### PR TITLE
feat: Claude Code grep-augmentation PreToolUse hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,10 @@ server is read-only on source — it never edits files; it writes only its own S
 If the MCP returns empty results, the self-index may be stale or pointed at the wrong root —
 `rag-rat index --discover` then `rag-rat reconcile` refreshes it.
 
+The grep-augmentation PreToolUse hook augments Claude Code's `Grep` and Bash grep/rg/ag calls with
+symbol and repo-memory context automatically; install it with `rag-rat hooks install --claude` (or
+`--global`).
+
 ## Repo orientation
 
 - Rust workspace, three crates: `rag-rat-core` (engine: indexing, tree-sitter graph, embeddings,

--- a/README.md
+++ b/README.md
@@ -542,6 +542,90 @@ the index path when needed, then reconciles embeddings with `changed_first` unti
 budget is spent. The `post-commit` hook keeps the index current with the just-committed tree without
 waiting for the next checkout or merge.
 
+## Claude Code Grep Augmentation
+
+`rag-rat` can augment Claude Code's `Grep` tool calls and `grep`/`rg`/`ag` Bash commands with
+symbol and repo-memory context via the PreToolUse hook mechanism. When a grep pattern matches a
+known symbol or bound repo memory, the hook injects an `additionalContext` digest before the tool
+runs. The hook never blocks a grep — it always exits 0.
+
+### What gets injected
+
+The payload has three lanes (in order, up to 1500 characters total):
+
+1. **Repo memories** — `Invariant`, `Decision`, `Risk`, and other memories bound to the matched
+   symbol, the search path, or the pattern text. These are the unique signal: grep and search tools
+   can't surface them.
+2. **Matching symbols** — location (`file:line`), kind, caller/callee edge counts, and signature for
+   symbols whose name matches the pattern. Only triggered when the pattern looks like a code
+   identifier (single token, no spaces, at least 3 characters).
+3. **Lexical hits** — a few indexed source chunks (fallback lane, only active when no symbol match
+   was found).
+
+The pattern is normalized before matching: regex metacharacters become spaces, but dots and
+double-colons inside identifier tokens are preserved so `Watcher::spawn` or `foo.bar` resolve
+through the symbol lane.
+
+### Install
+
+Install the hook for the current project (writes `.claude/settings.json` in the repo root):
+
+```bash
+rag-rat hooks install --claude
+```
+
+Install globally (writes `~/.claude/settings.json`, applies to all Claude Code sessions):
+
+```bash
+rag-rat hooks install --claude --global
+```
+
+The global install is safe to run from any directory. When `rag-rat claude-hook` is invoked by
+Claude Code, it walks up from the hook's reported `cwd` looking for a `rag-rat.toml`. If none is
+found, the hook exits immediately without printing anything — it is a silent no-op for repositories
+that are not indexed by rag-rat.
+
+Check install status:
+
+```bash
+rag-rat hooks status --claude
+rag-rat hooks status --claude --global
+```
+
+Uninstall:
+
+```bash
+rag-rat hooks uninstall --claude
+rag-rat hooks uninstall --claude --global
+```
+
+The install adds two `PreToolUse` entries to the `hooks` block — one `matcher: Grep` and one
+`matcher: Bash` — each calling `rag-rat claude-hook` with a 10-second timeout.
+
+### How it serves
+
+When `rag-rat mcp` is running (the normal configuration for Claude Code), its process also holds the
+socket election for the current worktree. One listener wins per worktree and binds a Unix domain
+socket. The hook client connects to that socket, sends the pattern and session ID in a
+newline-delimited JSON request, and gets a reply within its 250 ms budget.
+
+If no listener is running (MCP not active, or a race during startup), the hook client falls back to
+a direct read-only SQLite query. The fallback is stateless: it produces the same payload lanes but
+without per-session dedupe.
+
+### Dedupe
+
+The listener tracks per-session state: once a memory or symbol has been injected for a given Claude
+Code session ID, it will not be injected again for the same session. The session map is
+in-memory; dedupe resets when the listener restarts. The fallback path is stateless — the same
+content can be injected on every grep when no listener is running.
+
+### Troubleshooting
+
+Set `RAG_RAT_HOOK_DEBUG=1` in the environment where `rag-rat mcp` runs to enable diagnostic output
+from the listener. Errors encountered while serving individual hook requests are printed to stderr.
+Without this variable, the listener is silent on errors; the hook client is always silent.
+
 ## Security
 
 The MCP server exposes read-only source tools only. It does not execute shell commands or write

--- a/crates/rag-rat-cli/src/claude_hook.rs
+++ b/crates/rag-rat-cli/src/claude_hook.rs
@@ -261,6 +261,9 @@ fn ask_listener(config: &Config, session_id: &str, search: &Search) -> Option<Op
             os::unix::net::UnixStream,
         };
         let socket = socket_path(config);
+        // SOCKET_BUDGET covers both read and write. Unix-domain connect() completes into
+        // the listener's backlog immediately (no network round-trip), so no separate connect
+        // timeout is needed.
         let stream = UnixStream::connect(&socket).ok()?;
         stream.set_read_timeout(Some(SOCKET_BUDGET)).ok()?;
         stream.set_write_timeout(Some(SOCKET_BUDGET)).ok()?;
@@ -286,12 +289,10 @@ fn ask_listener(config: &Config, session_id: &str, search: &Search) -> Option<Op
     }
 }
 
-/// Mirrors `rag_rat_mcp::claude_hook::socket_path_for` without depending on the MCP crate:
-/// both derive the path from the same `locks::hook_socket_path` inputs.
+/// Single source of truth via `locks::hook_socket_path_for`; same computation as the MCP
+/// listener's `socket_path_for`, guaranteed not to diverge.
 fn socket_path(config: &Config) -> PathBuf {
-    let base_dir =
-        config.database.parent().map(Path::to_path_buf).unwrap_or_else(|| config.root.clone());
-    locks::hook_socket_path(&base_dir, &config.root)
+    locks::hook_socket_path_for(config)
 }
 
 /// Stateless direct read (no dedupe — spec: fallback path). Any error ⇒ silence.

--- a/crates/rag-rat-cli/src/claude_hook.rs
+++ b/crates/rag-rat-cli/src/claude_hook.rs
@@ -1,0 +1,244 @@
+//! `rag-rat claude-hook`: the Claude Code PreToolUse hook client.
+//!
+//! Reads the hook JSON from stdin, asks the elected listener (or falls back to a direct
+//! read-only query), and prints `additionalContext` JSON. Exit 0 on every path — the hook
+//! augments greps and must never block one. Spec:
+//! `docs/specs/2026-06-09-grep-augment-pretooluse-hook.md`.
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct HookInput {
+    pub session_id: String,
+    pub cwd: String,
+    pub tool_name: String,
+    #[serde(default)]
+    pub tool_input: serde_json::Value,
+}
+
+pub struct Search {
+    pub pattern: String,
+    pub search_path: Option<String>,
+    pub source: &'static str,
+}
+
+/// Pull a search intent out of the hook input; `None` means "not a grep, stay silent".
+pub fn extract_search(input: &HookInput) -> Option<Search> {
+    match input.tool_name.as_str() {
+        "Grep" => {
+            let pattern = input.tool_input.get("pattern")?.as_str()?.to_string();
+            let search_path =
+                input.tool_input.get("path").and_then(|v| v.as_str()).map(str::to_string);
+            Some(Search { pattern, search_path, source: "grep_tool" })
+        },
+        "Bash" => {
+            let command = input.tool_input.get("command")?.as_str()?;
+            let (pattern, search_path) = parse_bash_search(command)?;
+            Some(Search { pattern, search_path, source: "bash" })
+        },
+        _ => None,
+    }
+}
+
+const SEARCH_COMMANDS: &[&str] = &["grep", "rg", "ag"];
+/// Flags whose *next* token is a value, not the pattern. Conservative superset across the
+/// three tools — a missed flag only costs a wrong-pattern no-op downstream, never a block.
+const ARG_FLAGS: &[&str] = &[
+    "-A", "-B", "-C", "-m", "-g", "-t", "-T", "-f", "-M", "--glob", "--type", "--type-not",
+    "--include", "--exclude", "--exclude-dir", "--max-count", "--max-depth", "--context",
+    "--after-context", "--before-context", "--file", "--ignore-file", "--threads", "--colors",
+];
+
+/// Extract (pattern, path) from a shell command that runs grep/rg/ag, or `None` when the
+/// command doesn't or parsing would have to guess. False negatives are fine; false
+/// positives are not (spec: Bash command parsing).
+pub fn parse_bash_search(command: &str) -> Option<(String, Option<String>)> {
+    if command.contains('`') || command.contains("$(") {
+        return None; // substitution: ambiguous
+    }
+    // Split into pipeline/sequence segments; examine each for a search command.
+    for segment in split_top_level(command) {
+        let tokens = shell_tokens(&segment)?;
+        let mut tokens = tokens.as_slice();
+        // Skip env-var prefixes (FOO=bar) before the command word.
+        while tokens.first().is_some_and(|t| t.contains('=') && !t.starts_with('-')) {
+            tokens = &tokens[1..];
+        }
+        let Some(command_word) = tokens.first() else { continue };
+        let base = command_word.rsplit('/').next().unwrap_or(command_word);
+        if base == "xargs" || base == "find" {
+            return None; // grep as an argument of these is ambiguous
+        }
+        if !SEARCH_COMMANDS.contains(&base) {
+            continue;
+        }
+        let mut pattern: Option<String> = None;
+        let mut path: Option<String> = None;
+        let mut rest = tokens[1..].iter();
+        while let Some(token) = rest.next() {
+            if let Some(value) = token.strip_prefix("--regexp=") {
+                pattern.get_or_insert_with(|| value.to_string());
+            } else if token == "-e" || token == "--regexp" {
+                if let Some(value) = rest.next() {
+                    pattern.get_or_insert_with(|| value.to_string());
+                }
+            } else if ARG_FLAGS.contains(&token.as_str()) {
+                rest.next(); // consume the flag's value
+            } else if token.starts_with('-') && token.len() > 1 {
+                // value-less flag (or unknown): skip
+            } else if pattern.is_none() {
+                pattern = Some(token.to_string());
+            } else if path.is_none() {
+                path = Some(token.to_string());
+            }
+        }
+        return pattern.map(|p| (p, path));
+    }
+    None
+}
+
+/// Split on top-level `|`, `&&`, `||`, `;` (quote-aware); also drop a leading `cd …` segment.
+///
+/// Quote characters are preserved verbatim into the segment so that [`shell_tokens`] can
+/// strip them itself — a top-level separator inside quotes must not split, and a quoted
+/// pattern (`rg "quoted pattern" src`) must survive intact for re-tokenization.
+fn split_top_level(command: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut quote: Option<char> = None;
+    let mut chars = command.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match (quote, ch) {
+            // Closing quote: keep the quote char so shell_tokens sees a balanced pair.
+            (Some(q), c) if c == q => {
+                quote = None;
+                current.push(c);
+            },
+            (Some(_), c) => current.push(c),
+            // Opening quote: keep the quote char verbatim.
+            (None, '\'' | '"') => {
+                quote = Some(ch);
+                current.push(ch);
+            },
+            (None, '|' | ';') => {
+                if chars.peek() == Some(&'|') {
+                    chars.next();
+                }
+                segments.push(std::mem::take(&mut current));
+            },
+            (None, '&') => {
+                if chars.peek() == Some(&'&') {
+                    chars.next();
+                }
+                segments.push(std::mem::take(&mut current));
+            },
+            (None, c) => current.push(c),
+        }
+    }
+    segments.push(current);
+    segments
+        .into_iter()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty() && !s.starts_with("cd ") && *s != "cd")
+        .collect()
+}
+
+/// Quote-aware tokenization of one segment. `None` on unbalanced quotes (ambiguous).
+fn shell_tokens(segment: &str) -> Option<Vec<String>> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut quote: Option<char> = None;
+    let mut quoted = false;
+    for ch in segment.chars() {
+        match (quote, ch) {
+            (Some(q), c) if c == q => quote = None,
+            (Some(_), c) => current.push(c),
+            (None, '\'' | '"') => {
+                quote = Some(ch);
+                quoted = true;
+            },
+            (None, c) if c.is_whitespace() => {
+                if !current.is_empty() || quoted {
+                    tokens.push(std::mem::take(&mut current));
+                    quoted = false;
+                }
+            },
+            (None, c) => current.push(c),
+        }
+    }
+    if quote.is_some() {
+        return None;
+    }
+    if !current.is_empty() || quoted {
+        tokens.push(current);
+    }
+    Some(tokens)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_grep_tool_input() {
+        let json = r#"{"session_id":"s1","cwd":"/repo","hook_event_name":"PreToolUse",
+            "tool_name":"Grep","tool_input":{"pattern":"watcher_main","path":"crates"}}"#;
+        let input: HookInput = serde_json::from_str(json).unwrap();
+        let search = extract_search(&input).unwrap();
+        assert_eq!(search.pattern, "watcher_main");
+        assert_eq!(search.search_path.as_deref(), Some("crates"));
+        assert_eq!(search.source, "grep_tool");
+    }
+
+    #[test]
+    fn bash_parser_table() {
+        // (command, expected pattern, expected path)
+        let positives = [
+            ("rg watcher_main", "watcher_main", None),
+            ("rg -n 'election retry' crates/", "election retry", Some("crates/")),
+            ("grep -rn foo src", "foo", Some("src")),
+            ("ag --rust frobnicate", "frobnicate", None),
+            ("rg -e 'fn main' --type rust", "fn main", None),
+            ("cd crates && rg spawn_listener", "spawn_listener", None),
+            ("FOO=1 rg spawn_listener", "spawn_listener", None),
+            ("rg -A 3 -B 2 needle haystack/", "needle", Some("haystack/")),
+            ("git log | rg fix", "fix", None),
+            (r#"rg "quoted pattern" src"#, "quoted pattern", Some("src")),
+        ];
+        for (cmd, pattern, path) in positives {
+            let got = parse_bash_search(cmd).unwrap_or_else(|| panic!("no match for {cmd}"));
+            assert_eq!(got.0, pattern, "pattern for {cmd}");
+            assert_eq!(got.1.as_deref(), path, "path for {cmd}");
+        }
+        let negatives = [
+            "ls -la",
+            "cargo test",
+            "rg",                       // no pattern
+            "find . -name '*.rs' -exec grep foo {} \\;", // -exec: ambiguous
+            "echo `rg foo`",            // backticks: ambiguous
+            "xargs grep foo",           // xargs: ambiguous
+            "groups",                   // not grep
+        ];
+        for cmd in negatives {
+            assert!(parse_bash_search(cmd).is_none(), "false positive for {cmd}");
+        }
+    }
+
+    #[test]
+    fn extract_search_routes_bash_commands() {
+        let json = r#"{"session_id":"s1","cwd":"/repo","hook_event_name":"PreToolUse",
+            "tool_name":"Bash","tool_input":{"command":"rg -n watcher_main crates/"}}"#;
+        let input: HookInput = serde_json::from_str(json).unwrap();
+        let search = extract_search(&input).unwrap();
+        assert_eq!(search.pattern, "watcher_main");
+        assert_eq!(search.source, "bash");
+    }
+
+    #[test]
+    fn extract_search_ignores_other_tools() {
+        let json = r#"{"session_id":"s1","cwd":"/repo","hook_event_name":"PreToolUse",
+            "tool_name":"Read","tool_input":{"path":"/x"}}"#;
+        let input: HookInput = serde_json::from_str(json).unwrap();
+        assert!(extract_search(&input).is_none());
+    }
+}

--- a/crates/rag-rat-cli/src/claude_hook.rs
+++ b/crates/rag-rat-cli/src/claude_hook.rs
@@ -5,7 +5,16 @@
 //! augments greps and must never block one. Spec:
 //! `docs/specs/2026-06-09-grep-augment-pretooluse-hook.md`.
 
+use std::{
+    io::Read as _,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use rag_rat_core::{config::Config, locks, query::grep_augment, storage::IndexConnection};
 use serde::Deserialize;
+
+const SOCKET_BUDGET: Duration = Duration::from_millis(250);
 
 #[derive(Debug, Deserialize)]
 pub struct HookInput {
@@ -44,9 +53,30 @@ const SEARCH_COMMANDS: &[&str] = &["grep", "rg", "ag"];
 /// Flags whose *next* token is a value, not the pattern. Conservative superset across the
 /// three tools — a missed flag only costs a wrong-pattern no-op downstream, never a block.
 const ARG_FLAGS: &[&str] = &[
-    "-A", "-B", "-C", "-m", "-g", "-t", "-T", "-f", "-M", "--glob", "--type", "--type-not",
-    "--include", "--exclude", "--exclude-dir", "--max-count", "--max-depth", "--context",
-    "--after-context", "--before-context", "--file", "--ignore-file", "--threads", "--colors",
+    "-A",
+    "-B",
+    "-C",
+    "-m",
+    "-g",
+    "-t",
+    "-T",
+    "-f",
+    "-M",
+    "--glob",
+    "--type",
+    "--type-not",
+    "--include",
+    "--exclude",
+    "--exclude-dir",
+    "--max-count",
+    "--max-depth",
+    "--context",
+    "--after-context",
+    "--before-context",
+    "--file",
+    "--ignore-file",
+    "--threads",
+    "--colors",
 ];
 
 /// Extract (pattern, path) from a shell command that runs grep/rg/ag, or `None` when the
@@ -175,6 +205,109 @@ fn shell_tokens(segment: &str) -> Option<Vec<String>> {
     Some(tokens)
 }
 
+/// Entry point for `rag-rat claude-hook`. Every failure path prints nothing and returns
+/// Ok(()) — the hook must never block a grep (spec: error posture).
+pub fn run() -> anyhow::Result<()> {
+    let _ = run_inner(); // swallow: silence is the contract
+    Ok(())
+}
+
+fn run_inner() -> anyhow::Result<()> {
+    let mut raw = String::new();
+    std::io::stdin().read_to_string(&mut raw)?;
+    let input: HookInput = serde_json::from_str(&raw)?;
+    let Some(search) = extract_search(&input) else { return Ok(()) };
+    let Some(config) = find_config(Path::new(&input.cwd)) else { return Ok(()) };
+
+    let context = ask_listener(&config, &input.session_id, &search)
+        .unwrap_or_else(|| fallback_compose(&config, &search));
+    if let Some(context) = context {
+        // PreToolUse contract: allow + additionalContext; plain stdout is debug-only.
+        println!(
+            "{}",
+            serde_json::json!({
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "allow",
+                    "additionalContext": context,
+                }
+            })
+        );
+    }
+    Ok(())
+}
+
+/// Walk up from the hook's cwd to the nearest rag-rat.toml. `None` ⇒ not a rag-rat repo ⇒
+/// silent no-op (what makes `--global` install safe).
+fn find_config(start: &Path) -> Option<Config> {
+    let mut dir = Some(start);
+    while let Some(current) = dir {
+        let candidate = current.join("rag-rat.toml");
+        if candidate.is_file() {
+            return Config::load(&candidate).ok();
+        }
+        dir = current.parent();
+    }
+    None
+}
+
+/// Outer Option: did the listener answer at all (None ⇒ fall back). Inner Option: did it
+/// have anything new to say.
+fn ask_listener(config: &Config, session_id: &str, search: &Search) -> Option<Option<String>> {
+    #[cfg(unix)]
+    {
+        use std::{
+            io::{BufRead, BufReader, Write as _},
+            os::unix::net::UnixStream,
+        };
+        let socket = socket_path(config);
+        let stream = UnixStream::connect(&socket).ok()?;
+        stream.set_read_timeout(Some(SOCKET_BUDGET)).ok()?;
+        stream.set_write_timeout(Some(SOCKET_BUDGET)).ok()?;
+        let request = serde_json::json!({
+            "v": 1, "kind": "grep_augment", "session_id": session_id,
+            "pattern": search.pattern, "search_path": search.search_path,
+            "source": search.source,
+        });
+        let mut writer = stream.try_clone().ok()?;
+        writeln!(writer, "{request}").ok()?;
+        let mut line = String::new();
+        BufReader::new(stream).read_line(&mut line).ok()?;
+        let reply: serde_json::Value = serde_json::from_str(&line).ok()?;
+        if reply.get("v")?.as_u64()? != 1 {
+            return None;
+        }
+        Some(reply.get("context")?.as_str().map(str::to_string))
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (config, session_id, search);
+        None
+    }
+}
+
+/// Mirrors `rag_rat_mcp::claude_hook::socket_path_for` without depending on the MCP crate:
+/// both derive the path from the same `locks::hook_socket_path` inputs.
+fn socket_path(config: &Config) -> PathBuf {
+    let base_dir =
+        config.database.parent().map(Path::to_path_buf).unwrap_or_else(|| config.root.clone());
+    locks::hook_socket_path(&base_dir, &config.root)
+}
+
+/// Stateless direct read (no dedupe — spec: fallback path). Any error ⇒ silence.
+fn fallback_compose(config: &Config, search: &Search) -> Option<String> {
+    let conn = IndexConnection::open_read_only(&config.database).ok()?;
+    grep_augment::compose(
+        conn.connection(),
+        &search.pattern,
+        search.search_path.as_deref(),
+        &grep_augment::DedupeFilter::default(),
+    )
+    .ok()
+    .flatten()
+    .map(|out| out.context)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -213,11 +346,11 @@ mod tests {
         let negatives = [
             "ls -la",
             "cargo test",
-            "rg",                       // no pattern
+            "rg",                                        // no pattern
             "find . -name '*.rs' -exec grep foo {} \\;", // -exec: ambiguous
-            "echo `rg foo`",            // backticks: ambiguous
-            "xargs grep foo",           // xargs: ambiguous
-            "groups",                   // not grep
+            "echo `rg foo`",                             // backticks: ambiguous
+            "xargs grep foo",                            // xargs: ambiguous
+            "groups",                                    // not grep
         ];
         for cmd in negatives {
             assert!(parse_bash_search(cmd).is_none(), "false positive for {cmd}");

--- a/crates/rag-rat-cli/src/claude_settings.rs
+++ b/crates/rag-rat-cli/src/claude_settings.rs
@@ -25,24 +25,34 @@ fn is_ours(entry: &Value) -> bool {
         .is_some_and(|hooks| hooks.iter().any(|h| h["command"] == HOOK_COMMAND))
 }
 
+/// The `hooks.PreToolUse` array, the single place both install and uninstall navigate to.
+/// With `create`, missing `hooks`/`PreToolUse` containers are inserted (install path); without
+/// it, a missing or malformed path yields `None` (uninstall/read path). Returns `None` rather
+/// than panicking whenever `hooks` or `PreToolUse` exists but is the wrong JSON type — a user's
+/// hand-edited settings.json must never crash `rag-rat hooks`.
+fn pretooluse_array_mut(settings: &mut Value, create: bool) -> Option<&mut Vec<Value>> {
+    if create {
+        if !settings.is_object() {
+            *settings = json!({});
+        }
+        let hooks = settings
+            .as_object_mut()
+            .unwrap() // safe: just ensured object above
+            .entry("hooks")
+            .or_insert_with(|| json!({}));
+        if hooks.is_object() {
+            hooks.as_object_mut().unwrap().entry("PreToolUse").or_insert_with(|| json!([]));
+        }
+    }
+    settings.get_mut("hooks").and_then(|h| h.get_mut("PreToolUse")).and_then(Value::as_array_mut)
+}
+
 /// Add missing Grep/Bash entries. Returns true when the document changed.
 ///
 /// Gracefully handles malformed pre-existing settings: if `hooks` is not an object or
 /// `hooks.PreToolUse` is not an array, leaves the document untouched and returns false.
 pub fn merge_hook_entries(settings: &mut Value) -> bool {
-    if !settings.is_object() {
-        *settings = json!({});
-    }
-    // If `hooks` already exists but is not an object, leave it untouched rather than panic.
-    let entries = settings
-        .as_object_mut()
-        .unwrap() // safe: we just ensured it's an object above
-        .entry("hooks")
-        .or_insert_with(|| json!({}))
-        .as_object_mut()
-        .map(|hooks| hooks.entry("PreToolUse").or_insert_with(|| json!([])));
-    // If `hooks` was not an object or `PreToolUse` is not an array (malformed), bail safely.
-    let Some(Value::Array(entries)) = entries else { return false };
+    let Some(entries) = pretooluse_array_mut(settings, true) else { return false };
     let mut changed = false;
     for matcher in MATCHERS {
         let present = entries.iter().any(|e| e["matcher"] == *matcher && is_ours(e));
@@ -56,11 +66,7 @@ pub fn merge_hook_entries(settings: &mut Value) -> bool {
 
 /// Remove our entries; prune `PreToolUse`/`hooks` containers that end up empty.
 pub fn remove_hook_entries(settings: &mut Value) -> bool {
-    let Some(entries) = settings
-        .get_mut("hooks")
-        .and_then(|h| h.get_mut("PreToolUse"))
-        .and_then(Value::as_array_mut)
-    else {
+    let Some(entries) = pretooluse_array_mut(settings, false) else {
         return false;
     };
     let before = entries.len();

--- a/crates/rag-rat-cli/src/claude_settings.rs
+++ b/crates/rag-rat-cli/src/claude_settings.rs
@@ -1,0 +1,175 @@
+//! Claude Code settings.json management for the grep-augment PreToolUse hook
+//! (`rag-rat hooks install|uninstall|status --claude [--global]`).
+//!
+//! Edits are additive and marker-aware: our entries are recognized by `HOOK_COMMAND`;
+//! everything else in the file is preserved byte-for-byte at the JSON level (read → modify
+//! → pretty-print 2-space, matching how Claude Code writes the file).
+
+use std::path::{Path, PathBuf};
+
+use serde_json::{Value, json};
+
+pub const HOOK_COMMAND: &str = "rag-rat claude-hook";
+const MATCHERS: &[&str] = &["Grep", "Bash"];
+
+fn our_entry(matcher: &str) -> Value {
+    json!({
+        "matcher": matcher,
+        "hooks": [{"type": "command", "command": HOOK_COMMAND, "timeout": 10}]
+    })
+}
+
+fn is_ours(entry: &Value) -> bool {
+    entry["hooks"]
+        .as_array()
+        .is_some_and(|hooks| hooks.iter().any(|h| h["command"] == HOOK_COMMAND))
+}
+
+/// Add missing Grep/Bash entries. Returns true when the document changed.
+///
+/// Gracefully handles malformed pre-existing settings: if `hooks` is not an object or
+/// `hooks.PreToolUse` is not an array, leaves the document untouched and returns false.
+pub fn merge_hook_entries(settings: &mut Value) -> bool {
+    if !settings.is_object() {
+        *settings = json!({});
+    }
+    // If `hooks` already exists but is not an object, leave it untouched rather than panic.
+    let entries = settings
+        .as_object_mut()
+        .unwrap() // safe: we just ensured it's an object above
+        .entry("hooks")
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+        .map(|hooks| hooks.entry("PreToolUse").or_insert_with(|| json!([])));
+    // If `hooks` was not an object or `PreToolUse` is not an array (malformed), bail safely.
+    let Some(Value::Array(entries)) = entries else { return false };
+    let mut changed = false;
+    for matcher in MATCHERS {
+        let present = entries.iter().any(|e| e["matcher"] == *matcher && is_ours(e));
+        if !present {
+            entries.push(our_entry(matcher));
+            changed = true;
+        }
+    }
+    changed
+}
+
+/// Remove our entries; prune `PreToolUse`/`hooks` containers that end up empty.
+pub fn remove_hook_entries(settings: &mut Value) -> bool {
+    let Some(entries) = settings
+        .get_mut("hooks")
+        .and_then(|h| h.get_mut("PreToolUse"))
+        .and_then(Value::as_array_mut)
+    else {
+        return false;
+    };
+    let before = entries.len();
+    entries.retain(|e| !is_ours(e));
+    let changed = entries.len() != before;
+    if entries.is_empty() {
+        // Both unwraps are safe: we only reach here because get_mut("hooks") succeeded
+        // (meaning "hooks" key exists and is an object) and "PreToolUse" was present.
+        settings["hooks"].as_object_mut().unwrap().remove("PreToolUse");
+    }
+    if settings["hooks"].as_object().is_some_and(serde_json::Map::is_empty) {
+        settings.as_object_mut().unwrap().remove("hooks");
+    }
+    changed
+}
+
+/// (grep_installed, bash_installed) for `hooks status --claude`.
+pub fn hook_status(settings: &Value) -> (bool, bool) {
+    let installed = |matcher: &str| {
+        settings["hooks"]["PreToolUse"]
+            .as_array()
+            .is_some_and(|entries| entries.iter().any(|e| e["matcher"] == matcher && is_ours(e)))
+    };
+    (installed("Grep"), installed("Bash"))
+}
+
+/// Project `.claude/settings.json` or, with `--global`, `~/.claude/settings.json`.
+pub fn settings_path(repo_root: &Path, global: bool) -> anyhow::Result<PathBuf> {
+    if global {
+        let home = std::env::var_os("HOME").ok_or_else(|| anyhow::anyhow!("HOME not set"))?;
+        Ok(PathBuf::from(home).join(".claude/settings.json"))
+    } else {
+        Ok(repo_root.join(".claude/settings.json"))
+    }
+}
+
+pub fn read_settings(path: &Path) -> anyhow::Result<Value> {
+    if !path.exists() {
+        return Ok(json!({}));
+    }
+    Ok(serde_json::from_str(&std::fs::read_to_string(path)?)?)
+}
+
+pub fn write_settings(path: &Path, settings: &Value) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, format!("{}\n", serde_json::to_string_pretty(settings)?))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_into_empty_settings_creates_both_matchers() {
+        let mut settings = serde_json::json!({});
+        let changed = merge_hook_entries(&mut settings);
+        assert!(changed);
+        let entries = settings["hooks"]["PreToolUse"].as_array().unwrap();
+        let matchers: Vec<&str> = entries.iter().map(|e| e["matcher"].as_str().unwrap()).collect();
+        assert!(matchers.contains(&"Grep") && matchers.contains(&"Bash"));
+        for entry in entries {
+            let hook = &entry["hooks"][0];
+            assert_eq!(hook["command"], HOOK_COMMAND);
+            assert_eq!(hook["timeout"], 10);
+        }
+    }
+
+    #[test]
+    fn install_is_idempotent_and_preserves_foreign_entries() {
+        let mut settings = serde_json::json!({
+            "permissions": {"allow": ["Bash(ls:*)"]},
+            "hooks": {"PreToolUse": [
+                {"matcher": "Edit", "hooks": [{"type": "command", "command": "other-tool"}]}
+            ]}
+        });
+        assert!(merge_hook_entries(&mut settings));
+        assert!(!merge_hook_entries(&mut settings), "second install is a no-op");
+        let entries = settings["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(entries.len(), 3, "foreign Edit entry preserved alongside Grep+Bash");
+        assert_eq!(settings["permissions"]["allow"][0], "Bash(ls:*)");
+    }
+
+    #[test]
+    fn uninstall_removes_only_ours_and_prunes_empty_containers() {
+        let mut settings = serde_json::json!({});
+        merge_hook_entries(&mut settings);
+        assert!(remove_hook_entries(&mut settings));
+        assert!(settings.get("hooks").is_none(), "empty containers pruned");
+
+        let mut mixed = serde_json::json!({
+            "hooks": {"PreToolUse": [
+                {"matcher": "Edit", "hooks": [{"type": "command", "command": "other-tool"}]}
+            ]}
+        });
+        merge_hook_entries(&mut mixed);
+        remove_hook_entries(&mut mixed);
+        let entries = mixed["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["matcher"], "Edit");
+    }
+
+    #[test]
+    fn status_reports_per_matcher_presence() {
+        let mut settings = serde_json::json!({});
+        assert_eq!(hook_status(&settings), (false, false));
+        merge_hook_entries(&mut settings);
+        assert_eq!(hook_status(&settings), (true, true));
+    }
+}

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -12,6 +12,7 @@ use rag_rat_core::{
     search::lexical::SearchHit,
 };
 
+mod claude_hook;
 mod init;
 
 fn main() -> anyhow::Result<()> {

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -24,6 +24,9 @@ fn main() -> anyhow::Result<()> {
     if command == "init" {
         return init::run(&args);
     }
+    if command == "claude-hook" {
+        return claude_hook::run();
+    }
     let config_path = option_value(&args, "--config").unwrap_or_else(|| "rag-rat.toml".to_string());
     let config = Config::load(&config_path)?;
     apply_embedding_runtime_env(&config.local_ai.embedding.runtime);
@@ -890,7 +893,7 @@ pub(crate) fn render_index_progress(progress: IndexProgress) {
 
 fn usage() {
     eprintln!(
-        "usage: rag-rat <init|index|doctor|migrate|query|brief|clusters|mcp|github|hooks|maintenance|models|reconcile|gc|eval|dump-config> [--config <path>] [query]\n\
+        "usage: rag-rat <init|index|doctor|migrate|query|brief|clusters|mcp|github|hooks|claude-hook|maintenance|models|reconcile|gc|eval|dump-config> [--config <path>] [query]\n\
          default config: rag-rat.toml\n\
          examples:\n\
          rag-rat init\n\

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -13,6 +13,7 @@ use rag_rat_core::{
 };
 
 mod claude_hook;
+mod claude_settings;
 mod init;
 
 fn main() -> anyhow::Result<()> {
@@ -564,6 +565,9 @@ fn hooks(config: &Config, args: &[String]) -> anyhow::Result<()> {
     let Some(subcommand) = args.get(1).map(String::as_str) else {
         anyhow::bail!("hooks command needs install, uninstall, or status");
     };
+    if args.iter().any(|a| a == "--claude") {
+        return claude_hooks(config, subcommand, args.iter().any(|a| a == "--global"));
+    }
     let git = git_paths(&config.root)?;
     match subcommand {
         "install" => {
@@ -624,6 +628,43 @@ fn hooks(config: &Config, args: &[String]) -> anyhow::Result<()> {
                 "git_common_dir": git.git_common_dir,
                 "hooks_dir": git.hooks_dir,
                 "hooks": hooks,
+            }))
+        },
+        other => anyhow::bail!("unknown hooks subcommand `{other}`"),
+    }
+}
+
+fn claude_hooks(config: &Config, subcommand: &str, global: bool) -> anyhow::Result<()> {
+    let path = claude_settings::settings_path(&config.root, global)?;
+    let mut settings = claude_settings::read_settings(&path)?;
+    match subcommand {
+        "install" => {
+            let changed = claude_settings::merge_hook_entries(&mut settings);
+            if changed {
+                claude_settings::write_settings(&path, &settings)?;
+            }
+            print_json(&serde_json::json!({
+                "status": if changed { "installed" } else { "already_installed" },
+                "settings_path": path,
+                "matchers": ["Grep", "Bash"],
+            }))
+        },
+        "uninstall" => {
+            let changed = claude_settings::remove_hook_entries(&mut settings);
+            if changed {
+                claude_settings::write_settings(&path, &settings)?;
+            }
+            print_json(&serde_json::json!({
+                "status": if changed { "uninstalled" } else { "not_installed" },
+                "settings_path": path,
+            }))
+        },
+        "status" => {
+            let (grep, bash) = claude_settings::hook_status(&settings);
+            print_json(&serde_json::json!({
+                "settings_path": path,
+                "grep_matcher_installed": grep,
+                "bash_matcher_installed": bash,
             }))
         },
         other => anyhow::bail!("unknown hooks subcommand `{other}`"),

--- a/crates/rag-rat-cli/tests/claude_hook_e2e.rs
+++ b/crates/rag-rat-cli/tests/claude_hook_e2e.rs
@@ -6,6 +6,16 @@ use std::{
     process::{Command, Stdio},
 };
 
+#[cfg(unix)]
+use std::{
+    fs,
+    io::{BufRead, BufReader},
+    path::{Path, PathBuf},
+    process::Child,
+    sync::atomic::{AtomicU64, Ordering},
+    time::{Duration, Instant},
+};
+
 fn run_hook(stdin_body: &str, cwd: &std::path::Path) -> (String, std::process::ExitStatus) {
     let mut child = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
         .arg("claude-hook")
@@ -53,4 +63,232 @@ fn non_search_tool_means_silent_exit_zero() {
     let (stdout, status) = run_hook(&input.to_string(), &dir);
     assert!(status.success());
     assert!(stdout.is_empty());
+}
+
+/// Full path: a live `rag-rat mcp` elects the hook listener, the `claude-hook` client reaches it
+/// over the Unix socket and gets the indexed symbol, a repeat in the same session is deduped to
+/// nothing, a fresh session sees it again, and once the server dies the client falls back to a
+/// direct read-only SQLite query (no dedupe). Proves listener + client + dedupe + fallback wiring.
+#[cfg(unix)]
+#[test]
+fn socket_path_serves_dedupes_and_falls_back() {
+    let repo = TestRepo::indexed_with_symbol();
+    let mut server = repo.spawn_mcp_initialized();
+
+    // The listener binds asynchronously after election; poll the exact path the client computes
+    // (the `sockets/`→XDG→temp budget cascade means globbing one dir would miss a divert).
+    let socket = repo.socket_path();
+    wait_for(&socket, Duration::from_secs(10));
+
+    // 1. First hook in session s1: the listener answers with the indexed symbol + its file.
+    let first = repo.run_hook_session("s1");
+    let context = additional_context(&first)
+        .unwrap_or_else(|| panic!("listener gave no additionalContext, got: {first}"));
+    assert!(
+        context.contains("frobnicate_xyz") && context.contains("src/lib.rs"),
+        "listener context must name the indexed symbol and file, got: {context}"
+    );
+
+    // 2. Same session s1 again: the listener already injected the symbol, so it dedupes to a
+    //    null context and the client prints nothing at all.
+    let repeat = repo.run_hook_session("s1");
+    assert!(
+        repeat.is_empty(),
+        "same-session repeat must be deduped to empty stdout, got: {repeat}"
+    );
+
+    // 3. A different session s2 while the server is still alive: not deduped, sees it again.
+    let other = repo.run_hook_session("s2");
+    let other_context = additional_context(&other)
+        .unwrap_or_else(|| panic!("fresh session got no additionalContext, got: {other}"));
+    assert!(
+        other_context.contains("frobnicate_xyz"),
+        "fresh session must not be deduped, got: {other_context}"
+    );
+
+    // 4. Kill the server: the socket goes away and the client takes the stateless fallback path
+    //    (direct read-only SQLite, no dedupe), so even a previously-injected session gets context.
+    server.kill_and_wait();
+    // Listener teardown releases the socket asynchronously; poll until the connect would fail so
+    // the run below provably exercises fallback, not a lingering listener.
+    wait_until_gone(&socket, Duration::from_secs(10));
+    let fallback = repo.run_hook_session("s1");
+    let fallback_context = additional_context(&fallback).unwrap_or_else(|| {
+        panic!("fallback path gave no additionalContext after server death, got: {fallback}")
+    });
+    assert!(
+        fallback_context.contains("frobnicate_xyz") && fallback_context.contains("src/lib.rs"),
+        "fallback must compose from SQLite directly, got: {fallback_context}"
+    );
+
+    repo.cleanup();
+}
+
+#[cfg(unix)]
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(unix)]
+struct TestRepo {
+    root: PathBuf,
+    config_path: PathBuf,
+    config: rag_rat_core::Config,
+}
+
+#[cfg(unix)]
+impl TestRepo {
+    /// A temp repo with one Rust source file carrying a distinctive symbol, indexed in-process via
+    /// `IndexDatabase::rebuild` (the same path `mcp_stdio`/`mcp_hot_upgrade` use to populate a real
+    /// index). Unique per run so parallel tests never collide on the socket election lock.
+    fn indexed_with_symbol() -> Self {
+        let id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let root =
+            std::env::temp_dir().join(format!("ragrat-hook-e2e-{}-{id}", std::process::id()));
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/lib.rs"), "pub fn frobnicate_xyz() {}\n").unwrap();
+        let config_path = root.join("rag-rat.toml");
+        fs::write(
+            &config_path,
+            "[index]\nroot = \".\"\ndatabase = \".rag-rat/index.sqlite\"\n\n\
+             [target_bindings]\nrust = [\"src\"]\n",
+        )
+        .unwrap();
+        let config = rag_rat_core::Config::load(&config_path).unwrap();
+        rag_rat_core::IndexDatabase::rebuild(&config).unwrap();
+        // Guard against a vacuous test: the symbol lane only fires if the symbol is really indexed.
+        assert_symbol_indexed(&config, "frobnicate_xyz");
+        Self { root, config_path, config }
+    }
+
+    /// Same client computation as the CLI: the deterministic socket path for this config.
+    fn socket_path(&self) -> PathBuf {
+        rag_rat_core::locks::hook_socket_path_for(&self.config)
+    }
+
+    /// Spawn `rag-rat mcp` and drive `initialize` so the server is fully up and `run_stdio_unix`
+    /// has spawned the hook listener.
+    fn spawn_mcp_initialized(&self) -> McpServer {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+            .arg("mcp")
+            .arg("--config")
+            .arg(&self.config_path)
+            .env("RAG_RAT_NO_WATCH", "1")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let mut stdin = child.stdin.take().unwrap();
+        let mut reader = BufReader::new(child.stdout.take().unwrap());
+        writeln!(
+            stdin,
+            "{}",
+            serde_json::json!({
+                "jsonrpc": "2.0", "id": 1, "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05", "capabilities": {},
+                    "clientInfo": {"name": "rag-rat-hook-e2e", "version": "0.1"}
+                }
+            })
+        )
+        .unwrap();
+        stdin.flush().unwrap();
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+        assert!(line.contains("\"id\":1"), "initialize response, got: {line}");
+        writeln!(
+            stdin,
+            "{}",
+            serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+        )
+        .unwrap();
+        stdin.flush().unwrap();
+        // Keep stdin/stdout owned so the server's pipes stay open for the life of the test.
+        McpServer { child, _stdin: stdin, _reader: reader }
+    }
+
+    /// Run the hook client with a Grep `tool_input` for the indexed symbol under the given session,
+    /// cwd = repo root (so `find_config` walks up to our `rag-rat.toml`).
+    fn run_hook_session(&self, session_id: &str) -> String {
+        let input = serde_json::json!({
+            "session_id": session_id, "cwd": self.root, "hook_event_name": "PreToolUse",
+            "tool_name": "Grep", "tool_input": {"pattern": "frobnicate_xyz"}
+        });
+        let (stdout, status) = run_hook(&input.to_string(), &self.root);
+        assert!(status.success(), "claude-hook must exit zero on every path");
+        stdout
+    }
+
+    fn cleanup(&self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+#[cfg(unix)]
+struct McpServer {
+    child: Child,
+    _stdin: std::process::ChildStdin,
+    _reader: BufReader<std::process::ChildStdout>,
+}
+
+#[cfg(unix)]
+impl McpServer {
+    fn kill_and_wait(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Decode the client's `hookSpecificOutput` JSON and pull out `additionalContext` (None when the
+/// client printed nothing, i.e. a deduped/empty response).
+#[cfg(unix)]
+fn additional_context(stdout: &str) -> Option<String> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let value: serde_json::Value =
+        serde_json::from_str(trimmed).expect("client emitted valid JSON");
+    assert_eq!(value["hookSpecificOutput"]["hookEventName"], "PreToolUse");
+    assert_eq!(value["hookSpecificOutput"]["permissionDecision"], "allow");
+    value["hookSpecificOutput"]["additionalContext"].as_str().map(str::to_string)
+}
+
+/// Independently confirm the symbol is in the index, so a missing symbol can't make the e2e pass
+/// vacuously (an empty context would otherwise look like a deduped no-op).
+#[cfg(unix)]
+fn assert_symbol_indexed(config: &rag_rat_core::Config, symbol: &str) {
+    use rag_rat_core::storage::IndexConnection;
+    let conn = IndexConnection::open_read_only(&config.database).unwrap();
+    let count: i64 = conn
+        .connection()
+        .query_row("SELECT COUNT(*) FROM symbols WHERE name = ?1", [symbol], |row| row.get(0))
+        .unwrap();
+    assert!(count > 0, "index must contain the `{symbol}` symbol or the e2e is vacuous");
+}
+
+#[cfg(unix)]
+fn wait_for(path: &Path, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if path.exists() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("expected socket {} within {timeout:?}", path.display());
+}
+
+#[cfg(unix)]
+fn wait_until_gone(path: &Path, timeout: Duration) {
+    use std::os::unix::net::UnixStream;
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        // A bound, accepting listener answers connect(); once the server dies the socket file may
+        // linger but connect() refuses — that is when the client provably falls back.
+        if UnixStream::connect(path).is_err() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("listener at {} still accepting after {timeout:?}", path.display());
 }

--- a/crates/rag-rat-cli/tests/claude_hook_e2e.rs
+++ b/crates/rag-rat-cli/tests/claude_hook_e2e.rs
@@ -238,6 +238,16 @@ impl McpServer {
     }
 }
 
+// Reap the spawned `mcp` process even if a test panics between spawn and the explicit
+// `kill_and_wait` — otherwise a mid-test assert failure orphans the process (and its bound
+// socket/lock) until the OS reaps it. Idempotent with `kill_and_wait`.
+#[cfg(unix)]
+impl Drop for McpServer {
+    fn drop(&mut self) {
+        self.kill_and_wait();
+    }
+}
+
 /// Decode the client's `hookSpecificOutput` JSON and pull out `additionalContext` (None when the
 /// client printed nothing, i.e. a deduped/empty response).
 #[cfg(unix)]

--- a/crates/rag-rat-cli/tests/claude_hook_e2e.rs
+++ b/crates/rag-rat-cli/tests/claude_hook_e2e.rs
@@ -15,7 +15,7 @@ fn run_hook(stdin_body: &str, cwd: &std::path::Path) -> (String, std::process::E
         .stderr(Stdio::null())
         .spawn()
         .unwrap();
-    child.stdin.as_mut().unwrap().write_all(stdin_body.as_bytes()).unwrap();
+    let _ = child.stdin.as_mut().unwrap().write_all(stdin_body.as_bytes());
     let out = child.wait_with_output().unwrap();
     (String::from_utf8_lossy(&out.stdout).into_owned(), out.status)
 }

--- a/crates/rag-rat-cli/tests/claude_hook_e2e.rs
+++ b/crates/rag-rat-cli/tests/claude_hook_e2e.rs
@@ -1,0 +1,56 @@
+//! End-to-end tests for `rag-rat claude-hook` (Unix only for socket paths; the no-op
+//! contract tests run everywhere).
+
+use std::{
+    io::Write,
+    process::{Command, Stdio},
+};
+
+fn run_hook(stdin_body: &str, cwd: &std::path::Path) -> (String, std::process::ExitStatus) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+        .arg("claude-hook")
+        .current_dir(cwd)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    child.stdin.as_mut().unwrap().write_all(stdin_body.as_bytes()).unwrap();
+    let out = child.wait_with_output().unwrap();
+    (String::from_utf8_lossy(&out.stdout).into_owned(), out.status)
+}
+
+#[test]
+fn no_rag_rat_toml_means_silent_exit_zero() {
+    let dir = std::env::temp_dir().join(format!("ragrat-hook-noindex-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let input = serde_json::json!({
+        "session_id": "s1", "cwd": dir, "hook_event_name": "PreToolUse",
+        "tool_name": "Grep", "tool_input": {"pattern": "anything"}
+    });
+    let (stdout, status) = run_hook(&input.to_string(), &dir);
+    assert!(status.success());
+    assert!(stdout.is_empty(), "must print nothing without an index, got: {stdout}");
+}
+
+#[test]
+fn garbage_stdin_means_silent_exit_zero() {
+    let dir = std::env::temp_dir().join(format!("ragrat-hook-garbage-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let (stdout, status) = run_hook("this is not json", &dir);
+    assert!(status.success());
+    assert!(stdout.is_empty());
+}
+
+#[test]
+fn non_search_tool_means_silent_exit_zero() {
+    let dir = std::env::temp_dir().join(format!("ragrat-hook-read-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let input = serde_json::json!({
+        "session_id": "s1", "cwd": dir, "hook_event_name": "PreToolUse",
+        "tool_name": "Read", "tool_input": {"path": "/x"}
+    });
+    let (stdout, status) = run_hook(&input.to_string(), &dir);
+    assert!(status.success());
+    assert!(stdout.is_empty());
+}

--- a/crates/rag-rat-cli/tests/mcp_hot_upgrade.rs
+++ b/crates/rag-rat-cli/tests/mcp_hot_upgrade.rs
@@ -10,7 +10,7 @@
 use std::{
     fs,
     io::{BufRead, BufReader, Write},
-    os::unix::fs::PermissionsExt,
+    os::unix::{fs::PermissionsExt, net::UnixStream},
     path::{Path, PathBuf},
     process::{Child, Command, Stdio},
     sync::atomic::{AtomicU64, Ordering},
@@ -46,6 +46,14 @@ fn sigusr1_hot_upgrade_resumes_session_in_place() {
     let after = session.call_semantic_search();
     assert!(after["chunk_id"].as_i64().is_some(), "session resumed transparently after exec");
 
+    // The grep-augment hook socket must answer *after* the in-place `exec`: the old process's lock
+    // fd and bound socket died with the exec'd image, so the resumed process has to re-run the
+    // socket election and re-bind the listener (the `AbortOnDrop` guard + the election retry loop).
+    // Probing it proves `spawn_listener` runs on the handoff-resume path, not just cold start.
+    let socket = env.hook_socket_path();
+    let reply = hook_roundtrip(&socket, "sqlite", Duration::from_secs(15));
+    assert_eq!(reply["v"], 1, "hook socket re-binds and speaks the protocol after hot-upgrade");
+
     session.stop();
     env.cleanup();
 }
@@ -71,6 +79,7 @@ fn sigusr1_exec_failure_exits_nonzero() {
 struct TestEnv {
     root: PathBuf,
     config_path: PathBuf,
+    config: Config,
 }
 
 impl TestEnv {
@@ -87,7 +96,14 @@ impl TestEnv {
         .unwrap();
         let config = Config::load(&config_path).unwrap();
         rag_rat_core::IndexDatabase::rebuild(&config).unwrap();
-        Self { root, config_path }
+        Self { root, config_path, config }
+    }
+
+    /// The deterministic hook-socket path for this config — the same derivation the elected
+    /// listener and the CLI client use (`hook_socket_path_for` handles the XDG/temp budget
+    /// cascade), so the probe can't drift from where the server actually binds.
+    fn hook_socket_path(&self) -> PathBuf {
+        rag_rat_core::locks::hook_socket_path_for(&self.config)
     }
 
     /// A `/bin/sh` wrapper that touches `sentinel` then `exec`s the real binary with our argv —
@@ -214,6 +230,34 @@ impl Session {
     fn stop(mut self) {
         let _ = self.child.kill();
         let _ = self.child.wait();
+    }
+}
+
+/// Connect to the hook socket and exchange one `grep_augment` request/reply, polling until a bound
+/// listener answers (the post-`exec` process must win the socket election before it re-binds, which
+/// the 5s election retry can stretch out). Returns the decoded reply envelope; the caller asserts on
+/// `v`. We deliberately do not couple to the `context` payload — the point is "the socket is alive
+/// and speaks the protocol after exec", not what it found for `pattern`.
+fn hook_roundtrip(socket: &Path, pattern: &str, timeout: Duration) -> Value {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Ok(stream) = UnixStream::connect(socket) {
+            stream.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
+            stream.set_write_timeout(Some(Duration::from_secs(2))).unwrap();
+            let mut writer = stream.try_clone().unwrap();
+            let request = json!({
+                "v": 1, "kind": "grep_augment", "session_id": "upgrade-probe",
+                "pattern": pattern, "search_path": null, "source": "grep_tool",
+            });
+            if writeln!(writer, "{request}").is_ok() {
+                let mut line = String::new();
+                if BufReader::new(stream).read_line(&mut line).is_ok() && !line.is_empty() {
+                    return serde_json::from_str(&line).unwrap();
+                }
+            }
+        }
+        assert!(Instant::now() < deadline, "hook socket never answered after upgrade: {socket:?}");
+        std::thread::sleep(Duration::from_millis(100));
     }
 }
 

--- a/crates/rag-rat-core/src/locks.rs
+++ b/crates/rag-rat-core/src/locks.rs
@@ -19,6 +19,8 @@ use std::{
 use anyhow::Context as _;
 use sha2::{Digest, Sha256};
 
+use crate::config::Config;
+
 /// A held exclusive file lock. Released on drop.
 #[derive(Debug)]
 pub struct FileLock {
@@ -123,6 +125,22 @@ pub fn hook_socket_path(base_dir: &Path, worktree_root: &Path) -> PathBuf {
     let runtime_base =
         std::env::var_os("XDG_RUNTIME_DIR").map(PathBuf::from).unwrap_or_else(std::env::temp_dir);
     socket_path_with_runtime_base(base_dir, worktree_root, &runtime_base)
+}
+
+/// Single source of truth for the hook socket path given a `Config`. Shared by the MCP listener
+/// and the CLI client so the two cannot diverge.
+pub fn hook_socket_path_for(config: &Config) -> PathBuf {
+    let base =
+        config.database.parent().map(Path::to_path_buf).unwrap_or_else(|| config.root.clone());
+    hook_socket_path(&base, &config.root)
+}
+
+/// Single source of truth for the hook socket election-lock path given a `Config`. Shared by the
+/// MCP listener and the CLI client so the two cannot diverge.
+pub fn hook_socket_lock_path_for(config: &Config) -> PathBuf {
+    let base =
+        config.database.parent().map(Path::to_path_buf).unwrap_or_else(|| config.root.clone());
+    socket_lock_path(&base, &config.root)
 }
 
 /// Inner implementation: builds the candidate path cascade with an explicit `runtime_base` so the

--- a/crates/rag-rat-core/src/locks.rs
+++ b/crates/rag-rat-core/src/locks.rs
@@ -120,14 +120,35 @@ pub fn socket_lock_path(base_dir: &Path, worktree_root: &Path) -> PathBuf {
 /// exceed the `sun_path` budget. Hook clients compute the same path independently, so this must
 /// stay deterministic for a given (base_dir, worktree_root) and environment.
 pub fn hook_socket_path(base_dir: &Path, worktree_root: &Path) -> PathBuf {
+    let runtime_base =
+        std::env::var_os("XDG_RUNTIME_DIR").map(PathBuf::from).unwrap_or_else(std::env::temp_dir);
+    socket_path_with_runtime_base(base_dir, worktree_root, &runtime_base)
+}
+
+/// Inner implementation: builds the candidate path cascade with an explicit `runtime_base` so the
+/// fallback logic can be unit-tested without touching the process environment.
+///
+/// Priority:
+/// 1. `<base_dir>/sockets/<hash>.sock` — within budget?  Use it.
+/// 2. `<runtime_base>/rag-rat/<hash>.sock` — within budget?  Use it.
+/// 3. `<temp_dir>/rag-rat/<hash>.sock` — best effort; callers fail open if still over budget.
+fn socket_path_with_runtime_base(
+    base_dir: &Path,
+    worktree_root: &Path,
+    runtime_base: &Path,
+) -> PathBuf {
     let name = format!("{}.sock", worktree_hash(worktree_root));
     let preferred = base_dir.join("sockets").join(&name);
     if preferred.as_os_str().len() <= MAX_SOCKET_PATH_LEN {
         return preferred;
     }
-    let runtime_base =
-        std::env::var_os("XDG_RUNTIME_DIR").map(PathBuf::from).unwrap_or_else(std::env::temp_dir);
-    runtime_base.join("rag-rat").join(name)
+    let xdg_candidate = runtime_base.join("rag-rat").join(&name);
+    if xdg_candidate.as_os_str().len() <= MAX_SOCKET_PATH_LEN {
+        return xdg_candidate;
+    }
+    // Both preferred and XDG are over budget — fall through to the OS temp dir.
+    // If even this is over budget there is nothing better; callers fail open.
+    std::env::temp_dir().join("rag-rat").join(name)
 }
 
 #[cfg(test)]
@@ -199,18 +220,49 @@ mod tests {
         assert!(socket.extension().is_some_and(|ext| ext == "sock"));
     }
 
+    /// Build a base dir long enough that `<base>/sockets/<hash>.sock` exceeds `MAX_SOCKET_PATH_LEN`.
+    fn long_base_dir() -> PathBuf {
+        let mut base = temp_dir();
+        // Each push appends ~28 bytes; 12 × 28 = 336, well over the 100-byte budget.
+        for _ in 0..12 {
+            base.push("very-long-directory-segment");
+        }
+        base
+    }
+
     #[test]
     fn hook_socket_path_falls_back_when_base_path_is_too_long() {
-        // sun_path is ~108 bytes; a deeply nested base dir must divert to a short runtime dir.
-        let mut long_base = temp_dir();
-        for _ in 0..12 {
-            long_base.push("very-long-directory-segment");
-        }
+        // When the preferred path is over budget and XDG_RUNTIME_DIR is a short /tmp path, the
+        // XDG candidate fits within budget and is returned.
+        let long_base = long_base_dir();
         let root = temp_dir();
-        let socket = hook_socket_path(&long_base, &root);
+        // Use a known-short runtime_base so the test is independent of the runner environment.
+        let short_runtime_base = std::env::temp_dir(); // e.g. /tmp — always short
+        let socket = socket_path_with_runtime_base(&long_base, &root, &short_runtime_base);
         assert!(
             socket.as_os_str().len() <= MAX_SOCKET_PATH_LEN,
-            "fallback path still too long: {}",
+            "XDG fallback path still too long: {}",
+            socket.display()
+        );
+        // Should NOT live under the long base dir.
+        assert!(!socket.starts_with(&long_base), "expected fallback, got preferred path");
+    }
+
+    #[test]
+    fn hook_socket_path_falls_back_to_temp_when_xdg_also_too_long() {
+        // When both the preferred path and the XDG candidate are over budget, the function falls
+        // through to the OS temp dir (best-effort; callers fail open).
+        let long_base = long_base_dir();
+        let long_runtime_base = long_base_dir();
+        let root = temp_dir();
+        let socket = socket_path_with_runtime_base(&long_base, &root, &long_runtime_base);
+        // Must not be under either long base.
+        assert!(!socket.starts_with(&long_base));
+        assert!(!socket.starts_with(&long_runtime_base));
+        // Should be rooted at the OS temp dir.
+        assert!(
+            socket.starts_with(std::env::temp_dir()),
+            "expected temp-dir fallback, got: {}",
             socket.display()
         );
     }

--- a/crates/rag-rat-core/src/locks.rs
+++ b/crates/rag-rat-core/src/locks.rs
@@ -81,6 +81,22 @@ pub fn write_lock_path(database: &Path) -> PathBuf {
     database.parent().unwrap_or_else(|| Path::new(".")).join("rag-rat-write.lock")
 }
 
+/// `sun_path` budget for Unix domain sockets (108 bytes on Linux, 104 on macOS) with headroom.
+pub const MAX_SOCKET_PATH_LEN: usize = 100;
+
+/// Stable per-worktree key: sha256 of the canonicalized root (see `election_lock_path` doc
+/// comment for why canonicalize-but-not-case-fold).
+fn worktree_hash(worktree_root: &Path) -> String {
+    let canonical = worktree_root.canonicalize().unwrap_or_else(|_| worktree_root.to_path_buf());
+    let digest = Sha256::digest(canonical.to_string_lossy().as_bytes());
+    let mut hash = String::with_capacity(32);
+    for byte in &digest[..16] {
+        use std::fmt::Write as _;
+        let _ = write!(hash, "{byte:02x}");
+    }
+    hash
+}
+
 /// Per-worktree election lock path, keyed by a hash of the **canonicalized** worktree root —
 /// `canonicalize` resolves symlink aliases (the common way one checkout is reached via two paths) to
 /// one key. We deliberately do **not** case-fold: folding would, on a case-sensitive volume,
@@ -90,14 +106,28 @@ pub fn write_lock_path(database: &Path) -> PathBuf {
 /// watchers, which the write lock makes harmless. `base_dir` is the index DB's directory (the
 /// shared location across a repo's worktrees), so all election locks sit under `<base_dir>/locks/`.
 pub fn election_lock_path(base_dir: &Path, worktree_root: &Path) -> PathBuf {
-    let canonical = worktree_root.canonicalize().unwrap_or_else(|_| worktree_root.to_path_buf());
-    let digest = Sha256::digest(canonical.to_string_lossy().as_bytes());
-    let mut hash = String::with_capacity(32);
-    for byte in &digest[..16] {
-        use std::fmt::Write as _;
-        let _ = write!(hash, "{byte:02x}");
+    base_dir.join("locks").join(format!("{}.lock", worktree_hash(worktree_root)))
+}
+
+/// Election lock for the grep-augment hook socket: one listener per worktree, separate from the
+/// watcher election so core never calls back into the MCP crate and either process may win each.
+pub fn socket_lock_path(base_dir: &Path, worktree_root: &Path) -> PathBuf {
+    base_dir.join("locks").join(format!("{}.socket.lock", worktree_hash(worktree_root)))
+}
+
+/// Where the elected listener binds. Prefers a `sockets/` sibling of `locks/` under the shared
+/// DB dir; diverts to `$XDG_RUNTIME_DIR/rag-rat/` then the OS temp dir when the result would
+/// exceed the `sun_path` budget. Hook clients compute the same path independently, so this must
+/// stay deterministic for a given (base_dir, worktree_root) and environment.
+pub fn hook_socket_path(base_dir: &Path, worktree_root: &Path) -> PathBuf {
+    let name = format!("{}.sock", worktree_hash(worktree_root));
+    let preferred = base_dir.join("sockets").join(&name);
+    if preferred.as_os_str().len() <= MAX_SOCKET_PATH_LEN {
+        return preferred;
     }
-    base_dir.join("locks").join(format!("{hash}.lock"))
+    let runtime_base =
+        std::env::var_os("XDG_RUNTIME_DIR").map(PathBuf::from).unwrap_or_else(std::env::temp_dir);
+    runtime_base.join("rag-rat").join(name)
 }
 
 #[cfg(test)]
@@ -146,5 +176,42 @@ mod tests {
         assert_eq!(a1, a2, "same worktree root → same lock");
         assert_ne!(a1, b, "different worktree roots → different locks");
         assert!(a1.starts_with(base.join("locks")));
+    }
+
+    #[test]
+    fn socket_lock_path_is_distinct_from_election_lock_path() {
+        let base = temp_dir();
+        let root = temp_dir();
+        let election = election_lock_path(&base, &root);
+        let socket_lock = socket_lock_path(&base, &root);
+        assert_ne!(election, socket_lock);
+        assert!(socket_lock.to_string_lossy().ends_with(".socket.lock"));
+        // Same worktree key: both live under <base>/locks/ with the same hash stem.
+        assert_eq!(election.parent(), socket_lock.parent());
+    }
+
+    #[test]
+    fn hook_socket_path_lives_under_base_sockets_dir() {
+        let base = temp_dir();
+        let root = temp_dir();
+        let socket = hook_socket_path(&base, &root);
+        assert_eq!(socket.parent().unwrap().file_name().unwrap(), "sockets");
+        assert!(socket.extension().is_some_and(|ext| ext == "sock"));
+    }
+
+    #[test]
+    fn hook_socket_path_falls_back_when_base_path_is_too_long() {
+        // sun_path is ~108 bytes; a deeply nested base dir must divert to a short runtime dir.
+        let mut long_base = temp_dir();
+        for _ in 0..12 {
+            long_base.push("very-long-directory-segment");
+        }
+        let root = temp_dir();
+        let socket = hook_socket_path(&long_base, &root);
+        assert!(
+            socket.as_os_str().len() <= MAX_SOCKET_PATH_LEN,
+            "fallback path still too long: {}",
+            socket.display()
+        );
     }
 }

--- a/crates/rag-rat-core/src/query/grep_augment.rs
+++ b/crates/rag-rat-core/src/query/grep_augment.rs
@@ -5,26 +5,92 @@
 //! `docs/specs/2026-06-09-grep-augment-pretooluse-hook.md`. Never loads the embedding
 //! model — symbol/FTS lanes only.
 
+use std::collections::HashSet;
+
+use rusqlite::{Connection, OptionalExtension};
+
+use crate::query::{memory, symbol};
+use crate::search::lexical;
+
+/// Hard cap on rendered context. Truncation drops whole items, never mid-item.
+pub const MAX_CONTEXT_CHARS: usize = 1500;
+const MAX_SYMBOLS: u32 = 3;
+const MAX_MEMORIES: u32 = 4;
+const MAX_LEXICAL_HITS: u32 = 3;
+
+/// Maximum body length in a rendered memory digest line; longer bodies are truncated with `…`.
+const MAX_MEMORY_BODY_CHARS: usize = 240;
+
 /// Strip regex syntax from a grep pattern, leaving plain query text. Metacharacters become
 /// spaces (so alternation/group contents survive as separate words); runs of whitespace
 /// collapse; result is trimmed.
+///
+/// Exception: a `.` (bare metachar) or `\.` (escaped) that sits directly between two ASCII
+/// word characters is preserved as a literal `.` — this keeps `foo.bar`-style qualified names
+/// intact. All other positions keep the space-substitution behavior.
 pub fn normalize_pattern(pattern: &str) -> String {
-    let mut out = String::with_capacity(pattern.len());
-    let mut chars = pattern.chars().peekable();
-    while let Some(ch) = chars.next() {
+    let chars_vec: Vec<char> = pattern.chars().collect();
+    let n = chars_vec.len();
+    let mut out = String::with_capacity(n);
+    let mut i = 0;
+    while i < n {
+        let ch = chars_vec[i];
         match ch {
-            '\\' => {
-                // Drop regex escapes entirely: \s/\b/\w and \\, \., \-, etc. all become a
-                // space — punctuation and class shorthands are not query signal.
-                if chars.peek().is_some() {
-                    chars.next(); // consume the escaped char
+            '\\' if i + 1 < n => {
+                let next = chars_vec[i + 1];
+                if next == '.' {
+                    // `\.` — check whether it's between two word chars in the *output* context.
+                    // We look at the last non-space char pushed to `out` (prev) and the char
+                    // after the escape sequence (lookahead).
+                    let prev_word = out
+                        .chars()
+                        .rev()
+                        .find(|c| *c != ' ')
+                        .map(|c| c.is_ascii_alphanumeric() || c == '_')
+                        .unwrap_or(false);
+                    let next_word = chars_vec
+                        .get(i + 2)
+                        .map(|c| c.is_ascii_alphanumeric() || *c == '_')
+                        .unwrap_or(false);
+                    if prev_word && next_word {
+                        out.push('.');
+                    } else {
+                        out.push(' ');
+                    }
+                    i += 2;
+                } else {
+                    // All other escapes → space; consume both chars.
+                    out.push(' ');
+                    i += 2;
                 }
-                out.push(' ');
             },
-            '^' | '$' | '.' | '*' | '+' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '|' => {
-                out.push(' ');
+            '.' => {
+                // Bare `.` metachar — preserve between word chars, else space.
+                let prev_word = out
+                    .chars()
+                    .rev()
+                    .find(|c| *c != ' ')
+                    .map(|c| c.is_ascii_alphanumeric() || c == '_')
+                    .unwrap_or(false);
+                let next_word = chars_vec
+                    .get(i + 1)
+                    .map(|c| c.is_ascii_alphanumeric() || *c == '_')
+                    .unwrap_or(false);
+                if prev_word && next_word {
+                    out.push('.');
+                } else {
+                    out.push(' ');
+                }
+                i += 1;
             },
-            _ => out.push(ch),
+            '^' | '$' | '*' | '+' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '|' => {
+                out.push(' ');
+                i += 1;
+            },
+            _ => {
+                out.push(ch);
+                i += 1;
+            },
         }
     }
     out.split_whitespace().collect::<Vec<_>>().join(" ")
@@ -43,19 +109,6 @@ pub fn identifier_candidate(normalized: &str) -> Option<&str> {
     }
     chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | ':' | '.')).then_some(normalized)
 }
-
-use std::collections::HashSet;
-
-use rusqlite::{Connection, OptionalExtension};
-
-use crate::query::{memory, symbol};
-use crate::search::lexical;
-
-/// Hard cap on rendered context. Truncation drops whole items, never mid-item.
-pub const MAX_CONTEXT_CHARS: usize = 1500;
-const MAX_SYMBOLS: u32 = 3;
-const MAX_MEMORIES: u32 = 4;
-const MAX_LEXICAL_HITS: u32 = 3;
 
 /// What the listener/fallback already injected for this session. Default = inject everything.
 #[derive(Debug, Default, Clone)]
@@ -87,11 +140,14 @@ pub fn compose(
     }
 
     let mut memories = Vec::new();
-    let mut symbol_lines = Vec::new();
-    let mut symbol_keys = Vec::new();
+    let mut symbol_items: Vec<SymbolItem> = Vec::new();
     // Track whether the symbol lane produced any raw hits (before dedup).
     // Lexical lane only runs when there were no symbol hits at all (not just all deduped).
     let mut symbol_lane_had_hits = false;
+
+    // Seen set for memory dedup — preserves insertion order (symbol-bound first, then FTS,
+    // then path-bound), unlike the old sort+dedup which ordered by creation-time ID.
+    let mut seen_memory_ids: HashSet<String> = HashSet::new();
 
     if let Some(ident) = identifier_candidate(&normalized) {
         // Symbol lane. Bare name for qualified queries: `Watcher::spawn` → `spawn`.
@@ -104,28 +160,44 @@ pub fn compose(
             }
             let (callers, callees) = edge_counts(conn, &hit)?;
             let start_line = line_for_symbol(conn, &hit)?;
-            symbol_lines.push(format!(
-                "- `{}` ({}) — {}:{} — {} callers / {} callees{}",
+            let line_suffix = match start_line {
+                Some(l) => format!("{}:{}", hit.path, l),
+                None => hit.path.clone(),
+            };
+            let rendered = format!(
+                "- `{}` ({}) — {} — {} callers / {} callees{}",
                 hit.qualified_name,
                 hit.kind,
-                hit.path,
-                start_line,
+                line_suffix,
                 callers,
                 callees,
                 hit.signature.as_deref().map(|s| format!(" — `{s}`")).unwrap_or_default(),
-            ));
-            memories.extend(memory::memories_for_symbol(conn, &hit, MAX_MEMORIES)?);
-            symbol_keys.push(key);
+            );
+            // Gather symbol-bound memories before adding them to the main list so they
+            // come first (highest priority lane).
+            for m in memory::memories_for_symbol(conn, &hit, MAX_MEMORIES)? {
+                if seen_memory_ids.insert(m.memory_id.clone()) {
+                    memories.push(m);
+                }
+            }
+            symbol_items.push(SymbolItem { rendered, key });
         }
     }
 
     // Memory lane: always. FTS over the normalized pattern + path-bound memories.
-    memories.extend(memory::memory_search(conn, &normalized, MAX_MEMORIES)?);
-    if let Some(path) = search_path {
-        memories.extend(memory::memories_for_path(conn, path, MAX_MEMORIES)?);
+    for m in memory::memory_search(conn, &normalized, MAX_MEMORIES)? {
+        if seen_memory_ids.insert(m.memory_id.clone()) {
+            memories.push(m);
+        }
     }
-    memories.sort_by(|a, b| a.memory_id.cmp(&b.memory_id));
-    memories.dedup_by(|a, b| a.memory_id == b.memory_id);
+    if let Some(path) = search_path {
+        for m in memory::memories_for_path(conn, path, MAX_MEMORIES)? {
+            if seen_memory_ids.insert(m.memory_id.clone()) {
+                memories.push(m);
+            }
+        }
+    }
+    // Apply session-level dedupe filter last (after insertion-order dedup above).
     memories.retain(|m| !dedupe.memory_ids.contains(&m.memory_id));
 
     // Lexical lane: only when the symbol lane found nothing (never had any raw hits).
@@ -140,10 +212,154 @@ pub fn compose(
         Vec::new()
     };
 
-    if memories.is_empty() && symbol_lines.is_empty() && lexical_lines.is_empty() {
+    if memories.is_empty() && symbol_items.is_empty() && lexical_lines.is_empty() {
         return Ok(None);
     }
-    Ok(Some(render(memories, symbol_lines, symbol_keys, lexical_lines)))
+    Ok(Some(render(memories, symbol_items, lexical_lines)))
+}
+
+/// A single rendered symbol line plus the key that identifies it in the dedupe set.
+struct SymbolItem {
+    rendered: String,
+    key: String,
+}
+
+/// A single renderable item in a section, with optional bookkeeping IDs.
+struct RenderItem {
+    line: String,
+    memory_id: Option<String>,
+    symbol_key: Option<String>,
+}
+
+/// A section is a header line + a list of items. Header is only committed when at least one
+/// item fits; the caller's ID is only appended to the output IDs when the item's line lands.
+struct Section {
+    header: String,
+    items: Vec<RenderItem>,
+    /// An optional closing/footer line (not associated with an ID).
+    footer: Option<String>,
+}
+
+/// Collapse all whitespace runs (including newlines) to single spaces and truncate to
+/// `MAX_MEMORY_BODY_CHARS`, appending `…` when truncated.
+fn clamp_body(body: &str) -> String {
+    let collapsed: String = body.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.len() <= MAX_MEMORY_BODY_CHARS {
+        collapsed
+    } else {
+        // Truncate at a char boundary ≤ MAX_MEMORY_BODY_CHARS.
+        let truncated: String = collapsed.chars().take(MAX_MEMORY_BODY_CHARS).collect();
+        format!("{truncated}…")
+    }
+}
+
+/// Memories first (the unique signal), then symbols, then lexical hits; whole-item truncation
+/// against `MAX_CONTEXT_CHARS`. Section headers are committed ONLY together with their first
+/// fitting item. IDs are appended to the returned vecs ONLY when their item line lands.
+fn render(
+    memories: Vec<memory::RepoMemory>,
+    symbol_items: Vec<SymbolItem>,
+    lexical_lines: Vec<String>,
+) -> GrepAugment {
+    let mut sections: Vec<Section> = Vec::new();
+
+    if !memories.is_empty() {
+        let items = memories
+            .into_iter()
+            .map(|m| RenderItem {
+                line: format!(
+                    "- [{} | {}] {} — {} (rag-rat: memory_search)",
+                    m.kind,
+                    m.status,
+                    m.title,
+                    clamp_body(&m.body),
+                ),
+                memory_id: Some(m.memory_id),
+                symbol_key: None,
+            })
+            .collect();
+        sections.push(Section {
+            header: "**Repo memories bound to this code:**".to_string(),
+            items,
+            footer: None,
+        });
+    }
+
+    if !symbol_items.is_empty() {
+        let items = symbol_items
+            .into_iter()
+            .map(|s| RenderItem { line: s.rendered, memory_id: None, symbol_key: Some(s.key) })
+            .collect();
+        sections.push(Section {
+            header: "**Known symbols matching this pattern:**".to_string(),
+            items,
+            footer: Some("(rag-rat: impact_surface <name> before editing)".to_string()),
+        });
+    }
+
+    if !lexical_lines.is_empty() {
+        let items = lexical_lines
+            .into_iter()
+            .map(|line| RenderItem { line, memory_id: None, symbol_key: None })
+            .collect();
+        sections.push(Section {
+            header: "**Indexed hits (rag-rat semantic_search has more):**".to_string(),
+            items,
+            footer: None,
+        });
+    }
+
+    let mut context = String::from("rag-rat index context for this search:\n");
+    let mut memory_ids: Vec<String> = Vec::new();
+    let mut symbol_keys: Vec<String> = Vec::new();
+
+    'section: for section in sections {
+        // We only know if the header fits once we find the first fitting item.
+        // Speculatively account for: header + '\n' + first item + '\n'.
+        let mut section_committed = false;
+
+        for item in section.items {
+            // Space needed: item line + newline. If the section header hasn't been
+            // committed yet, include it too.
+            let needed = if section_committed {
+                item.line.len() + 1
+            } else {
+                section.header.len() + 1 + item.line.len() + 1
+            };
+
+            if context.len() + needed > MAX_CONTEXT_CHARS {
+                // Whole-item truncation: stop at the first item that doesn't fit.
+                break 'section;
+            }
+
+            if !section_committed {
+                context.push_str(&section.header);
+                context.push('\n');
+                section_committed = true;
+            }
+            context.push_str(&item.line);
+            context.push('\n');
+
+            // Record IDs only for items whose lines actually landed.
+            if let Some(mid) = item.memory_id {
+                memory_ids.push(mid);
+            }
+            if let Some(key) = item.symbol_key {
+                symbol_keys.push(key);
+            }
+        }
+
+        // Footer is best-effort: append only if section was committed and it fits.
+        if section_committed
+            && let Some(footer) = section.footer
+            && context.len() + footer.len() < MAX_CONTEXT_CHARS
+        {
+            context.push_str(&footer);
+            context.push('\n');
+        }
+    }
+
+    GrepAugment { context: context.trim_end().to_string(), memory_ids, symbol_keys }
 }
 
 /// Caller/callee edge counts. Callers resolve by `to_symbol_id` or qualified-name match;
@@ -162,63 +378,19 @@ fn edge_counts(conn: &Connection, hit: &symbol::SymbolHit) -> anyhow::Result<(i6
     Ok((callers, callees))
 }
 
-/// 1-based start line for a symbol hit (line spans live on chunks; fall back to 1).
-fn line_for_symbol(conn: &Connection, hit: &symbol::SymbolHit) -> anyhow::Result<i64> {
-    let line: Option<i64> = conn
-        .query_row(
-            "SELECT start_line FROM chunks
-             WHERE file_id = ?1 AND start_byte <= ?2 AND end_byte >= ?2
-             ORDER BY (end_byte - start_byte) ASC LIMIT 1",
-            rusqlite::params![hit.file_id, hit.start_byte],
-            |row| row.get(0),
-        )
-        .optional()?;
-    Ok(line.unwrap_or(1))
-}
-
-/// Memories first (the unique signal), then symbols, then lexical hits; whole-item truncation
-/// against `MAX_CONTEXT_CHARS`.
-fn render(
-    memories: Vec<memory::RepoMemory>,
-    symbol_lines: Vec<String>,
-    symbol_keys: Vec<String>,
-    lexical_lines: Vec<String>,
-) -> GrepAugment {
-    let mut sections = Vec::new();
-    let mut memory_ids = Vec::new();
-    if !memories.is_empty() {
-        let mut lines = vec!["**Repo memories bound to this code:**".to_string()];
-        for m in &memories {
-            lines.push(format!(
-                "- [{} | {}] {} — {} (rag-rat: memory_search)",
-                m.kind, m.status, m.title, m.body
-            ));
-            memory_ids.push(m.memory_id.clone());
-        }
-        sections.push(lines);
-    }
-    if !symbol_lines.is_empty() {
-        let mut lines = vec!["**Known symbols matching this pattern:**".to_string()];
-        lines.extend(symbol_lines);
-        lines.push("(rag-rat: impact_surface <name> before editing)".to_string());
-        sections.push(lines);
-    }
-    if !lexical_lines.is_empty() {
-        let mut lines = vec!["**Indexed hits (rag-rat semantic_search has more):**".to_string()];
-        lines.extend(lexical_lines);
-        sections.push(lines);
-    }
-    let mut context = String::from("rag-rat index context for this search:\n");
-    'outer: for section in sections {
-        for line in section {
-            if context.len() + line.len() + 1 > MAX_CONTEXT_CHARS {
-                break 'outer;
-            }
-            context.push_str(&line);
-            context.push('\n');
-        }
-    }
-    GrepAugment { context: context.trim_end().to_string(), memory_ids, symbol_keys }
+/// Start line for a symbol hit (line spans live on chunks).
+/// Returns `None` when no matching chunk is found; callers render `{path}` without `:{line}`
+/// rather than a confidently-wrong `:1`.
+fn line_for_symbol(conn: &Connection, hit: &symbol::SymbolHit) -> anyhow::Result<Option<i64>> {
+    conn.query_row(
+        "SELECT start_line FROM chunks
+         WHERE file_id = ?1 AND start_byte <= ?2 AND end_byte >= ?2
+         ORDER BY (end_byte - start_byte) ASC LIMIT 1",
+        rusqlite::params![hit.file_id, hit.start_byte],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(Into::into)
 }
 
 #[cfg(test)]
@@ -371,6 +543,17 @@ mod tests {
     }
 
     #[test]
+    fn normalize_preserves_dot_between_word_chars() {
+        assert_eq!(normalize_pattern("foo.bar"), "foo.bar");
+        assert_eq!(normalize_pattern(r"foo\.bar"), "foo.bar");
+        // Leading/trailing dot is NOT between word chars → space.
+        assert_eq!(normalize_pattern(".foo"), "foo");
+        assert_eq!(normalize_pattern("foo."), "foo");
+        // Dot between non-word chars → space.
+        assert_eq!(normalize_pattern("foo. bar"), "foo bar");
+    }
+
+    #[test]
     fn identifier_candidate_accepts_identifier_shapes_only() {
         assert_eq!(identifier_candidate("watcher_main"), Some("watcher_main"));
         assert_eq!(identifier_candidate("Watcher::spawn"), Some("Watcher::spawn"));
@@ -379,5 +562,122 @@ mod tests {
         assert_eq!(identifier_candidate("ab"), None); // too short
         assert_eq!(identifier_candidate("1abc"), None); // leading digit
         assert_eq!(identifier_candidate(""), None);
+    }
+
+    #[test]
+    fn normalize_and_identifier_candidate_compose_for_dot_qualified() {
+        // End-to-end: a grep pattern `foo.bar` reaches the symbol lane.
+        let norm = normalize_pattern("foo.bar");
+        assert_eq!(norm, "foo.bar");
+        assert_eq!(identifier_candidate(&norm), Some("foo.bar"));
+
+        // `r"foo\.bar"` (escaped) also reaches the symbol lane.
+        let norm2 = normalize_pattern(r"foo\.bar");
+        assert_eq!(norm2, "foo.bar");
+        assert_eq!(identifier_candidate(&norm2), Some("foo.bar"));
+    }
+
+    #[test]
+    fn render_truncation_respects_cap_no_dangling_headers_ids_match() {
+        let conn = seeded_conn();
+
+        // Seed a memory with a ~3000-char body (under the 4000-char validation cap).
+        let long_body = "word ".repeat(600); // 3000 chars
+        assert!(long_body.len() < 4000, "precondition: under validation cap");
+        memory::create_memory(
+            &conn,
+            RepoMemoryCreate {
+                kind: "Decision".to_string(),
+                title: "Long body memory".to_string(),
+                body: long_body,
+                confidence: "medium".to_string(),
+                created_by: Some("test".to_string()),
+                source: None,
+                tags: vec![],
+                bind: RepoMemoryBindTarget {
+                    symbol_id: Some(1),
+                    logical_symbol_id: None,
+                    chunk_id: None,
+                    edge_id: None,
+                    path: None,
+                    start_line: None,
+                    end_line: None,
+                    commit_hash: None,
+                    github_owner: None,
+                    github_repo: None,
+                    github_number: None,
+                    start_logical_symbol_id: None,
+                    end_logical_symbol_id: None,
+                    edge_sequence_hash: None,
+                    path_summary: None,
+                },
+            },
+        )
+        .unwrap();
+
+        let out = compose(&conn, "watcher_main", None, &DedupeFilter::default())
+            .unwrap()
+            .expect("payload expected");
+
+        // (a) Context must not exceed the cap.
+        assert!(
+            out.context.len() <= MAX_CONTEXT_CHARS,
+            "context.len()={} > MAX_CONTEXT_CHARS={}",
+            out.context.len(),
+            MAX_CONTEXT_CHARS,
+        );
+
+        // (b) No section header is the last line / every header is followed by at least one item.
+        let section_headers = [
+            "**Repo memories bound to this code:**",
+            "**Known symbols matching this pattern:**",
+            "**Indexed hits (rag-rat semantic_search has more):**",
+        ];
+        let lines: Vec<&str> = out.context.lines().collect();
+        for (idx, line) in lines.iter().enumerate() {
+            let is_header = section_headers.iter().any(|h| line.trim() == *h);
+            if is_header {
+                assert!(
+                    idx + 1 < lines.len(),
+                    "section header '{line}' is the last line — dangling header",
+                );
+            }
+        }
+
+        // (c) Returned IDs correspond exactly to items whose titles/names appear in `context`.
+        // Check the two seeded memory titles: exactly those whose titles appear in context
+        // should have their IDs returned.
+        let watcher_in_context = out.context.contains("One watcher per worktree");
+        let long_in_context = out.context.contains("Long body memory");
+        // If a title appears in context, the count of returned IDs must be ≥ 1.
+        if watcher_in_context || long_in_context {
+            assert!(!out.memory_ids.is_empty(), "IDs must be returned for rendered memories");
+        }
+        // The long body must have been clamped — the 241st char onward must not appear.
+        // After whitespace-collapsing, "word ".repeat(600) → "word word word..." (5 chars/word
+        // including space). 240 chars fits ~48 words. Check that 60 consecutive words don't
+        // all appear (which would require an unclamped body).
+        assert!(
+            !out.context.contains(&"word ".repeat(60)),
+            "raw long body must not appear unclamped in context",
+        );
+    }
+
+    #[test]
+    fn clamp_body_truncates_long_bodies_and_collapses_whitespace() {
+        let short = "hello world";
+        assert_eq!(clamp_body(short), "hello world");
+
+        // Whitespace collapse.
+        let multiline = "line one\nline two\n  indented";
+        assert_eq!(clamp_body(multiline), "line one line two indented");
+
+        // Long body truncation.
+        let long = "x".repeat(300);
+        let clamped = clamp_body(&long);
+        assert!(clamped.ends_with('…'), "truncated body must end with ellipsis");
+        // The char count of the non-ellipsis prefix must be exactly MAX_MEMORY_BODY_CHARS.
+        let without_ellipsis: String = clamped.chars().take(MAX_MEMORY_BODY_CHARS).collect();
+        assert_eq!(without_ellipsis.len(), MAX_MEMORY_BODY_CHARS);
     }
 }

--- a/crates/rag-rat-core/src/query/grep_augment.rs
+++ b/crates/rag-rat-core/src/query/grep_augment.rs
@@ -1,0 +1,72 @@
+//! Payload composition for the Claude Code grep-augmentation PreToolUse hook.
+//!
+//! Shared by the `rag-rat mcp` socket listener (with per-session dedupe) and the hook
+//! client's direct read-only fallback (stateless). Spec:
+//! `docs/specs/2026-06-09-grep-augment-pretooluse-hook.md`. Never loads the embedding
+//! model — symbol/FTS lanes only.
+
+/// Strip regex syntax from a grep pattern, leaving plain query text. Metacharacters become
+/// spaces (so alternation/group contents survive as separate words); runs of whitespace
+/// collapse; result is trimmed.
+pub fn normalize_pattern(pattern: &str) -> String {
+    let mut out = String::with_capacity(pattern.len());
+    let mut chars = pattern.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\\' => {
+                // Drop regex escapes entirely: \s/\b/\w and \\, \., \-, etc. all become a
+                // space — punctuation and class shorthands are not query signal.
+                if chars.peek().is_some() {
+                    chars.next(); // consume the escaped char
+                }
+                out.push(' ');
+            },
+            '^' | '$' | '.' | '*' | '+' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '|' => {
+                out.push(' ');
+            },
+            _ => out.push(ch),
+        }
+    }
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// A normalized pattern that looks like one code identifier (optionally `::`/`.`-qualified):
+/// the symbol-lane trigger. Multi-word or short patterns return `None`.
+pub fn identifier_candidate(normalized: &str) -> Option<&str> {
+    if normalized.len() < 3 || normalized.contains(' ') {
+        return None;
+    }
+    let mut chars = normalized.chars();
+    let first = chars.next()?;
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return None;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | ':' | '.')).then_some(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_strips_regex_metacharacters_and_anchors() {
+        assert_eq!(normalize_pattern(r"^fn\s+watcher_main\b"), "fn watcher_main");
+        assert_eq!(
+            normalize_pattern(r"Watcher::spawn(_with_fleet)?"),
+            "Watcher::spawn _with_fleet"
+        );
+        assert_eq!(normalize_pattern("plain words"), "plain words");
+        assert_eq!(normalize_pattern(r".*[]()|+?^$\\"), "");
+    }
+
+    #[test]
+    fn identifier_candidate_accepts_identifier_shapes_only() {
+        assert_eq!(identifier_candidate("watcher_main"), Some("watcher_main"));
+        assert_eq!(identifier_candidate("Watcher::spawn"), Some("Watcher::spawn"));
+        assert_eq!(identifier_candidate("foo.bar"), Some("foo.bar"));
+        assert_eq!(identifier_candidate("fn watcher_main"), None); // two words
+        assert_eq!(identifier_candidate("ab"), None); // too short
+        assert_eq!(identifier_candidate("1abc"), None); // leading digit
+        assert_eq!(identifier_candidate(""), None);
+    }
+}

--- a/crates/rag-rat-core/src/query/grep_augment.rs
+++ b/crates/rag-rat-core/src/query/grep_augment.rs
@@ -244,10 +244,11 @@ struct Section {
 /// `MAX_MEMORY_BODY_CHARS`, appending `…` when truncated.
 fn clamp_body(body: &str) -> String {
     let collapsed: String = body.split_whitespace().collect::<Vec<_>>().join(" ");
-    if collapsed.len() <= MAX_MEMORY_BODY_CHARS {
+    // Compare char count (not byte length) so multibyte bodies don't get `…` with nothing removed.
+    if collapsed.chars().count() <= MAX_MEMORY_BODY_CHARS {
         collapsed
     } else {
-        // Truncate at a char boundary ≤ MAX_MEMORY_BODY_CHARS.
+        // Truncate at exactly MAX_MEMORY_BODY_CHARS chars.
         let truncated: String = collapsed.chars().take(MAX_MEMORY_BODY_CHARS).collect();
         format!("{truncated}…")
     }
@@ -579,42 +580,97 @@ mod tests {
 
     #[test]
     fn render_truncation_respects_cap_no_dangling_headers_ids_match() {
+        // ── Setup ──────────────────────────────────────────────────────────────────────
+        // seeded_conn() already contains one memory ("One watcher per worktree") bound to
+        // symbol_id=1.  We add FOUR more memories, each with a body long enough to survive
+        // the 240-char clamp as a full 241-char string (body trimmed = 300 ASCII words ≈
+        // 1499 chars, collapses to 1499 chars, clamped to exactly 240 chars + `…`).
+        //
+        // Each rendered memory line is:
+        //   "- [Invariant | active] <title≈80chars> — <241-char-body>\n"
+        //   ≈ 24 + 80 + 4 + 241 + 1 = ~350 chars
+        //
+        // With four such lines:
+        //   preamble(41) + header(39) + 4×350(1400) = 1480 chars for memories alone.
+        //
+        // The symbol section header+line needs ~151 chars more → 1480+151 = 1631 > 1500.
+        // Therefore the render loop MUST drop the symbol section entirely, giving us a
+        // genuine truncation scenario.  We assert below that the candidate total exceeds
+        // the cap so the test is self-verifying.
         let conn = seeded_conn();
 
-        // Seed a memory with a ~3000-char body (under the 4000-char validation cap).
-        let long_body = "word ".repeat(600); // 3000 chars
-        assert!(long_body.len() < 4000, "precondition: under validation cap");
-        memory::create_memory(
-            &conn,
-            RepoMemoryCreate {
-                kind: "Decision".to_string(),
-                title: "Long body memory".to_string(),
-                body: long_body,
-                confidence: "medium".to_string(),
-                created_by: Some("test".to_string()),
-                source: None,
-                tags: vec![],
-                bind: RepoMemoryBindTarget {
-                    symbol_id: Some(1),
-                    logical_symbol_id: None,
-                    chunk_id: None,
-                    edge_id: None,
-                    path: None,
-                    start_line: None,
-                    end_line: None,
-                    commit_hash: None,
-                    github_owner: None,
-                    github_repo: None,
-                    github_number: None,
-                    start_logical_symbol_id: None,
-                    end_logical_symbol_id: None,
-                    edge_sequence_hash: None,
-                    path_summary: None,
-                },
-            },
-        )
-        .unwrap();
+        // Body: 300 distinct English words × ~5 chars = ~1499 chars → collapses to 1499
+        // chars → clamped to 240 chars + `…`.  All ASCII so char count == byte count.
+        let long_body: String =
+            (0u32..300).map(|i| format!("word{i:04}")).collect::<Vec<_>>().join(" ");
+        assert!(long_body.len() > MAX_MEMORY_BODY_CHARS, "body must survive clamp");
+        assert!(long_body.len() < 4000, "must not exceed validation cap");
 
+        // Titles are ~80 chars — recognizable and unique, long enough to push each rendered
+        // line to ~350 chars.
+        let titles = [
+            "Truncation memory one — extra padding words fill the title field here ok",
+            "Truncation memory two — extra padding words fill the title field here ok",
+            "Truncation memory three — extra padding words fill the title field here",
+            "Truncation memory four — extra padding words fill the title field here ok",
+        ];
+
+        let mut created_ids: Vec<String> = Vec::new();
+        for title in &titles {
+            let result = memory::create_memory(
+                &conn,
+                RepoMemoryCreate {
+                    kind: "Invariant".to_string(),
+                    title: title.to_string(),
+                    body: long_body.clone(),
+                    confidence: "high".to_string(),
+                    created_by: Some("test".to_string()),
+                    source: None,
+                    tags: vec![],
+                    bind: RepoMemoryBindTarget {
+                        symbol_id: Some(1),
+                        logical_symbol_id: None,
+                        chunk_id: None,
+                        edge_id: None,
+                        path: None,
+                        start_line: None,
+                        end_line: None,
+                        commit_hash: None,
+                        github_owner: None,
+                        github_repo: None,
+                        github_number: None,
+                        start_logical_symbol_id: None,
+                        end_logical_symbol_id: None,
+                        edge_sequence_hash: None,
+                        path_summary: None,
+                    },
+                },
+            )
+            .unwrap();
+            created_ids.push(result.memory.memory_id);
+        }
+        assert_eq!(created_ids.len(), 4, "all four memories must be created");
+
+        // ── Sanity-check: verify the cap path triggers ─────────────────────────────────
+        // A single memory render line ≈ 350 chars (conservative lower bound: 24+70+4+241+1).
+        // Four lines + preamble + mem-header = min ~1480 chars; symbol section adds ~151.
+        // Assert total candidate content exceeds MAX_CONTEXT_CHARS so truncation is forced.
+        let per_mem_line_min: usize = "- [Invariant | active] ".len()  // 24
+            + titles[0].len()                                            // ≥70
+            + " — ".len()                                                // 4
+            + MAX_MEMORY_BODY_CHARS + 1; // 241 (clamped+…)
+        let preamble_len = "rag-rat index context for this search:\n".len();
+        let mem_header_len = "**Repo memories bound to this code:**\n".len();
+        let symbol_section_min: usize = "**Known symbols matching this pattern:**\n".len() + 80; // header + short line
+        let candidate_total =
+            preamble_len + mem_header_len + 4 * per_mem_line_min + symbol_section_min;
+        assert!(
+            candidate_total > MAX_CONTEXT_CHARS,
+            "candidate_total={candidate_total} must exceed MAX_CONTEXT_CHARS={MAX_CONTEXT_CHARS} \
+             for truncation to trigger",
+        );
+
+        // ── Run compose ────────────────────────────────────────────────────────────────
         let out = compose(&conn, "watcher_main", None, &DedupeFilter::default())
             .unwrap()
             .expect("payload expected");
@@ -627,7 +683,8 @@ mod tests {
             MAX_CONTEXT_CHARS,
         );
 
-        // (b) No section header is the last line / every header is followed by at least one item.
+        // (b) No section header is the last line / every committed header is followed by
+        //     at least one item line.
         let section_headers = [
             "**Repo memories bound to this code:**",
             "**Known symbols matching this pattern:**",
@@ -644,22 +701,35 @@ mod tests {
             }
         }
 
-        // (c) Returned IDs correspond exactly to items whose titles/names appear in `context`.
-        // Check the two seeded memory titles: exactly those whose titles appear in context
-        // should have their IDs returned.
-        let watcher_in_context = out.context.contains("One watcher per worktree");
-        let long_in_context = out.context.contains("Long body memory");
-        // If a title appears in context, the count of returned IDs must be ≥ 1.
-        if watcher_in_context || long_in_context {
-            assert!(!out.memory_ids.is_empty(), "IDs must be returned for rendered memories");
+        // (c) Exact two-way correspondence for every seeded memory:
+        //     context.contains(title)  ⟺  memory_ids.contains(that_id)
+        for (title, id) in titles.iter().zip(created_ids.iter()) {
+            let in_context = out.context.contains(*title);
+            let id_present = out.memory_ids.contains(id);
+            assert_eq!(
+                in_context, id_present,
+                "mismatch for '{title}': in_context={in_context}, id_present={id_present}",
+            );
         }
-        // The long body must have been clamped — the 241st char onward must not appear.
-        // After whitespace-collapsing, "word ".repeat(600) → "word word word..." (5 chars/word
-        // including space). 240 chars fits ~48 words. Check that 60 consecutive words don't
-        // all appear (which would require an unclamped body).
+
+        // (d) Two-way correspondence for the symbol: symbol_keys non-empty ⟺
+        //     "watch::watcher_main" appears in context.
+        let sym_in_context = out.context.contains("watch::watcher_main");
+        let sym_keys_non_empty = !out.symbol_keys.is_empty();
+        assert_eq!(
+            sym_in_context, sym_keys_non_empty,
+            "symbol context/key mismatch: sym_in_context={sym_in_context}, \
+             sym_keys_non_empty={sym_keys_non_empty}",
+        );
+
+        // (e) Truncation actually occurred: at least one seeded memory title OR the symbol
+        //     must be absent from context (we have more content than the cap allows).
+        let all_titles_present = titles.iter().all(|t| out.context.contains(*t));
+        let symbol_present = out.context.contains("watch::watcher_main");
         assert!(
-            !out.context.contains(&"word ".repeat(60)),
-            "raw long body must not appear unclamped in context",
+            !all_titles_present || !symbol_present,
+            "no truncation detected: all memory titles and the symbol section all fit within \
+             MAX_CONTEXT_CHARS — increase body/title size so the cap is actually exercised",
         );
     }
 

--- a/crates/rag-rat-core/src/query/grep_augment.rs
+++ b/crates/rag-rat-core/src/query/grep_augment.rs
@@ -44,9 +44,320 @@ pub fn identifier_candidate(normalized: &str) -> Option<&str> {
     chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | ':' | '.')).then_some(normalized)
 }
 
+use std::collections::HashSet;
+
+use rusqlite::{Connection, OptionalExtension};
+
+use crate::query::{memory, symbol};
+use crate::search::lexical;
+
+/// Hard cap on rendered context. Truncation drops whole items, never mid-item.
+pub const MAX_CONTEXT_CHARS: usize = 1500;
+const MAX_SYMBOLS: u32 = 3;
+const MAX_MEMORIES: u32 = 4;
+const MAX_LEXICAL_HITS: u32 = 3;
+
+/// What the listener/fallback already injected for this session. Default = inject everything.
+#[derive(Debug, Default, Clone)]
+pub struct DedupeFilter {
+    pub memory_ids: HashSet<String>,
+    pub symbol_keys: HashSet<String>,
+}
+
+/// A rendered digest plus the IDs it contains, for the caller's dedupe bookkeeping.
+#[derive(Debug)]
+pub struct GrepAugment {
+    pub context: String,
+    pub memory_ids: Vec<String>,
+    pub symbol_keys: Vec<String>,
+}
+
+/// Compose the grep-augmentation digest for one search. Lanes per the spec: symbol lane when
+/// the pattern looks like an identifier, memory lane always, lexical lane only when the
+/// symbol lane is empty. Returns `None` when nothing (new) is worth injecting.
+pub fn compose(
+    conn: &Connection,
+    raw_pattern: &str,
+    search_path: Option<&str>,
+    dedupe: &DedupeFilter,
+) -> anyhow::Result<Option<GrepAugment>> {
+    let normalized = normalize_pattern(raw_pattern);
+    if normalized.is_empty() {
+        return Ok(None);
+    }
+
+    let mut memories = Vec::new();
+    let mut symbol_lines = Vec::new();
+    let mut symbol_keys = Vec::new();
+    // Track whether the symbol lane produced any raw hits (before dedup).
+    // Lexical lane only runs when there were no symbol hits at all (not just all deduped).
+    let mut symbol_lane_had_hits = false;
+
+    if let Some(ident) = identifier_candidate(&normalized) {
+        // Symbol lane. Bare name for qualified queries: `Watcher::spawn` → `spawn`.
+        let bare = ident.rsplit([':', '.']).next().unwrap_or(ident);
+        for hit in symbol::lookup(conn, bare, None, MAX_SYMBOLS)? {
+            symbol_lane_had_hits = true;
+            let key = format!("{}:{}", hit.path, hit.qualified_name);
+            if dedupe.symbol_keys.contains(&key) {
+                continue;
+            }
+            let (callers, callees) = edge_counts(conn, &hit)?;
+            let start_line = line_for_symbol(conn, &hit)?;
+            symbol_lines.push(format!(
+                "- `{}` ({}) — {}:{} — {} callers / {} callees{}",
+                hit.qualified_name,
+                hit.kind,
+                hit.path,
+                start_line,
+                callers,
+                callees,
+                hit.signature.as_deref().map(|s| format!(" — `{s}`")).unwrap_or_default(),
+            ));
+            memories.extend(memory::memories_for_symbol(conn, &hit, MAX_MEMORIES)?);
+            symbol_keys.push(key);
+        }
+    }
+
+    // Memory lane: always. FTS over the normalized pattern + path-bound memories.
+    memories.extend(memory::memory_search(conn, &normalized, MAX_MEMORIES)?);
+    if let Some(path) = search_path {
+        memories.extend(memory::memories_for_path(conn, path, MAX_MEMORIES)?);
+    }
+    memories.sort_by(|a, b| a.memory_id.cmp(&b.memory_id));
+    memories.dedup_by(|a, b| a.memory_id == b.memory_id);
+    memories.retain(|m| !dedupe.memory_ids.contains(&m.memory_id));
+
+    // Lexical lane: only when the symbol lane found nothing (never had any raw hits).
+    let lexical_lines = if !symbol_lane_had_hits {
+        lexical::search_lexical_only(conn, &normalized, MAX_LEXICAL_HITS, false)?
+            .into_iter()
+            .map(|hit| {
+                format!("- {}:{}-{} — {}", hit.path, hit.start_line, hit.end_line, hit.summary)
+            })
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+
+    if memories.is_empty() && symbol_lines.is_empty() && lexical_lines.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(render(memories, symbol_lines, symbol_keys, lexical_lines)))
+}
+
+/// Caller/callee edge counts. Callers resolve by `to_symbol_id` or qualified-name match;
+/// callees are edges leaving any of the symbol's concrete rows.
+fn edge_counts(conn: &Connection, hit: &symbol::SymbolHit) -> anyhow::Result<(i64, i64)> {
+    let callers: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM edges WHERE to_symbol_id = ?1 OR target_qualified_name = ?2",
+        rusqlite::params![hit.symbol_id, hit.qualified_name],
+        |row| row.get(0),
+    )?;
+    let callees: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM edges WHERE from_symbol_id = ?1",
+        [hit.symbol_id],
+        |row| row.get(0),
+    )?;
+    Ok((callers, callees))
+}
+
+/// 1-based start line for a symbol hit (line spans live on chunks; fall back to 1).
+fn line_for_symbol(conn: &Connection, hit: &symbol::SymbolHit) -> anyhow::Result<i64> {
+    let line: Option<i64> = conn
+        .query_row(
+            "SELECT start_line FROM chunks
+             WHERE file_id = ?1 AND start_byte <= ?2 AND end_byte >= ?2
+             ORDER BY (end_byte - start_byte) ASC LIMIT 1",
+            rusqlite::params![hit.file_id, hit.start_byte],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(line.unwrap_or(1))
+}
+
+/// Memories first (the unique signal), then symbols, then lexical hits; whole-item truncation
+/// against `MAX_CONTEXT_CHARS`.
+fn render(
+    memories: Vec<memory::RepoMemory>,
+    symbol_lines: Vec<String>,
+    symbol_keys: Vec<String>,
+    lexical_lines: Vec<String>,
+) -> GrepAugment {
+    let mut sections = Vec::new();
+    let mut memory_ids = Vec::new();
+    if !memories.is_empty() {
+        let mut lines = vec!["**Repo memories bound to this code:**".to_string()];
+        for m in &memories {
+            lines.push(format!(
+                "- [{} | {}] {} — {} (rag-rat: memory_search)",
+                m.kind, m.status, m.title, m.body
+            ));
+            memory_ids.push(m.memory_id.clone());
+        }
+        sections.push(lines);
+    }
+    if !symbol_lines.is_empty() {
+        let mut lines = vec!["**Known symbols matching this pattern:**".to_string()];
+        lines.extend(symbol_lines);
+        lines.push("(rag-rat: impact_surface <name> before editing)".to_string());
+        sections.push(lines);
+    }
+    if !lexical_lines.is_empty() {
+        let mut lines = vec!["**Indexed hits (rag-rat semantic_search has more):**".to_string()];
+        lines.extend(lexical_lines);
+        sections.push(lines);
+    }
+    let mut context = String::from("rag-rat index context for this search:\n");
+    'outer: for section in sections {
+        for line in section {
+            if context.len() + line.len() + 1 > MAX_CONTEXT_CHARS {
+                break 'outer;
+            }
+            context.push_str(&line);
+            context.push('\n');
+        }
+    }
+    GrepAugment { context: context.trim_end().to_string(), memory_ids, symbol_keys }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
+    use rusqlite::Connection;
+
     use super::*;
+    use crate::index::schema;
+    use crate::query::memory::{self, RepoMemoryBindTarget, RepoMemoryCreate};
+
+    fn seeded_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
+             VALUES ('src/watch.rs', 'rust', 'source', 'abc', 0, 0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte,
+                                 end_byte, signature, docs)
+             VALUES (1, 'rust', 'watcher_main', 'watch::watcher_main', 'function', 0, 100,
+                     'fn watcher_main(config: Config)', NULL)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO chunks(file_id, chunk_kind, symbol_path, start_byte, end_byte,
+                                start_line, end_line, text, text_hash)
+             VALUES (1, 'symbol', 'watch::watcher_main', 0, 100, 1, 20,
+                     'fn watcher_main() { /* election retry loop */ }', 'h1')",
+            [],
+        )
+        .unwrap();
+        let chunk_id = conn.last_insert_rowid();
+        // One caller edge and one callee edge for the counts line.
+        conn.execute(
+            "INSERT INTO edges(source_file_id, from_symbol_id, to_symbol_id, to_name,
+                               target_qualified_name, edge_kind, confidence)
+             VALUES (1, NULL, 1, 'watcher_main', 'watch::watcher_main', 'calls_name', 'exact')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO edges(source_file_id, from_symbol_id, to_symbol_id, to_name,
+                               target_qualified_name, edge_kind, confidence)
+             VALUES (1, 1, NULL, 'maintenance_pass', NULL, 'calls_name', 'name_only')",
+            [],
+        )
+        .unwrap();
+        memory::create_memory(
+            &conn,
+            RepoMemoryCreate {
+                kind: "Invariant".to_string(),
+                title: "One watcher per worktree".to_string(),
+                body: "The election lock guarantees a single watcher; never bind without it."
+                    .to_string(),
+                confidence: "high".to_string(),
+                created_by: Some("test".to_string()),
+                source: None,
+                tags: vec![],
+                bind: RepoMemoryBindTarget {
+                    symbol_id: Some(1),
+                    logical_symbol_id: None,
+                    chunk_id: None,
+                    edge_id: None,
+                    path: None,
+                    start_line: None,
+                    end_line: None,
+                    commit_hash: None,
+                    github_owner: None,
+                    github_repo: None,
+                    github_number: None,
+                    start_logical_symbol_id: None,
+                    end_logical_symbol_id: None,
+                    edge_sequence_hash: None,
+                    path_summary: None,
+                },
+            },
+        )
+        .unwrap();
+        // Sync chunk_fts directly — external-content FTS5 needs explicit INSERT.
+        conn.execute(
+            "INSERT INTO chunk_fts(rowid, text)
+             VALUES (?1, 'fn watcher_main() { /* election retry loop */ }')",
+            [chunk_id],
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn compose_identifier_pattern_yields_symbol_and_memory() {
+        let conn = seeded_conn();
+        let out = compose(&conn, r"watcher_main\b", None, &DedupeFilter::default())
+            .unwrap()
+            .expect("payload expected");
+        assert!(out.context.contains("src/watch.rs"), "symbol location present");
+        assert!(out.context.contains("One watcher per worktree"), "memory title present");
+        let memory_pos = out.context.find("One watcher per worktree").unwrap();
+        let symbol_pos = out.context.find("src/watch.rs").unwrap();
+        assert!(memory_pos < symbol_pos, "memories render before symbols");
+        assert_eq!(out.memory_ids.len(), 1);
+        assert_eq!(out.symbol_keys.len(), 1);
+        assert!(out.context.len() <= MAX_CONTEXT_CHARS);
+    }
+
+    #[test]
+    fn compose_respects_dedupe_filter_and_returns_none_when_everything_filtered() {
+        let conn = seeded_conn();
+        let first = compose(&conn, "watcher_main", None, &DedupeFilter::default())
+            .unwrap()
+            .expect("first payload");
+        let filter = DedupeFilter {
+            memory_ids: first.memory_ids.iter().cloned().collect::<HashSet<_>>(),
+            symbol_keys: first.symbol_keys.iter().cloned().collect::<HashSet<_>>(),
+        };
+        assert!(compose(&conn, "watcher_main", None, &filter).unwrap().is_none());
+    }
+
+    #[test]
+    fn compose_non_identifier_pattern_uses_lexical_lane() {
+        let conn = seeded_conn();
+        let out = compose(&conn, "election retry loop", None, &DedupeFilter::default())
+            .unwrap()
+            .expect("lexical payload");
+        assert!(out.context.contains("src/watch.rs"));
+    }
+
+    #[test]
+    fn compose_unknown_pattern_yields_none() {
+        let conn = seeded_conn();
+        assert!(
+            compose(&conn, "zzqqyyxx_nothing", None, &DedupeFilter::default()).unwrap().is_none()
+        );
+    }
 
     #[test]
     fn normalize_strips_regex_metacharacters_and_anchors() {

--- a/crates/rag-rat-core/src/query/mod.rs
+++ b/crates/rag-rat-core/src/query/mod.rs
@@ -1,6 +1,7 @@
 pub mod clusters;
 pub mod graph;
 pub mod graph_meta;
+pub mod grep_augment;
 pub mod impact;
 pub mod memory;
 pub mod repo_brief;

--- a/crates/rag-rat-core/src/search/lexical.rs
+++ b/crates/rag-rat-core/src/search/lexical.rs
@@ -104,6 +104,26 @@ pub fn search_explain(
     )
 }
 
+/// BM25/FTS-only search for latency-critical callers (the grep-augment hook): bypasses
+/// `ai::embed_query`, so it can never trigger an embedding-model load. Also skips git and
+/// papertrail boosts — pure lexical + structural rank.
+pub fn search_lexical_only(
+    conn: &Connection,
+    query: &str,
+    limit: u32,
+    include_generated: bool,
+) -> anyhow::Result<Vec<SearchHit>> {
+    search_with_query_embedding(
+        conn,
+        query,
+        limit,
+        include_generated,
+        None,
+        false,
+        SearchOptions { include_git: false, include_papertrail: false },
+    )
+}
+
 pub fn search_with_options(
     conn: &Connection,
     query: &str,
@@ -545,4 +565,53 @@ fn collect_rows<T>(
         out.push(row?);
     }
     Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    use super::*;
+    use crate::index::schema;
+
+    fn seeded_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
+             VALUES ('src/watch.rs', 'rust', 'source', 'abc', 0, 0)",
+            [],
+        )
+        .unwrap();
+        let chunk_id: i64 = conn
+            .query_row(
+                "INSERT INTO chunks(file_id, chunk_kind, symbol_path, start_byte, end_byte,
+                                    start_line, end_line, text, text_hash)
+                 VALUES (1, 'symbol', 'watcher_main', 0, 10, 1, 20,
+                         'fn watcher_main() { /* election retry loop */ }', 'h1')
+                 RETURNING id",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        // Populate the FTS index directly — content tables in FTS5 need an explicit INSERT
+        // on the FTS virtual table to build shadow-table entries; rebuild_fts's DELETE approach
+        // is unreliable on fresh in-memory connections.
+        conn.execute(
+            "INSERT INTO chunk_fts(rowid, text)
+             VALUES (?1, 'fn watcher_main() { /* election retry loop */ }')",
+            [chunk_id],
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn search_lexical_only_returns_bm25_hits_without_embeddings() {
+        let conn = seeded_conn();
+        let hits = search_lexical_only(&conn, "election retry", 5, false).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].path, "src/watch.rs");
+        // No model is configured in this DB; reaching here without error proves no embed path ran.
+    }
 }

--- a/crates/rag-rat-core/src/storage.rs
+++ b/crates/rag-rat-core/src/storage.rs
@@ -31,6 +31,20 @@ impl IndexConnection {
         Ok(storage)
     }
 
+    /// Read-only open for latency-critical, never-blocking callers (the grep-augment hook
+    /// fallback). Skips `setup()` — no pragma writes, no dir creation — and refuses to create
+    /// the file. WAL databases serve concurrent read-only opens; a DB that has never been
+    /// opened for write errors here, which callers treat as "no context".
+    pub fn open_read_only(path: &Path) -> anyhow::Result<Self> {
+        use rusqlite::OpenFlags;
+        let conn = Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
+        conn.busy_timeout(std::time::Duration::from_millis(100))?;
+        Ok(Self { conn, database_path: path.to_path_buf(), source_root: None })
+    }
+
     pub fn database_path(&self) -> &Path {
         &self.database_path
     }
@@ -86,5 +100,34 @@ impl IndexConnection {
                 ",
             )
             .is_ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_read_only_reads_but_rejects_writes() {
+        let dir = std::env::temp_dir().join(format!("ragrat-ro-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let db = dir.join("index.db");
+        {
+            let rw = IndexConnection::open(&db).unwrap();
+            crate::index::schema::apply(rw.connection()).unwrap();
+        }
+        let ro = IndexConnection::open_read_only(&db).unwrap();
+        let n: i64 =
+            ro.connection().query_row("SELECT COUNT(*) FROM files", [], |row| row.get(0)).unwrap();
+        assert_eq!(n, 0);
+        let err = ro.connection().execute("INSERT INTO index_meta(key, value) VALUES('x','y')", []);
+        assert!(err.is_err(), "read-only connection must reject writes");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn open_read_only_fails_cleanly_when_database_missing() {
+        let missing = std::env::temp_dir().join("ragrat-ro-missing/never-created.db");
+        assert!(IndexConnection::open_read_only(&missing).is_err());
     }
 }

--- a/crates/rag-rat-mcp/Cargo.toml
+++ b/crates/rag-rat-mcp/Cargo.toml
@@ -18,7 +18,7 @@ rmcp.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["signal", "sync", "io-util"] }
+tokio = { workspace = true, features = ["signal", "sync", "io-util", "net", "time"] }
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true

--- a/crates/rag-rat-mcp/src/claude_hook.rs
+++ b/crates/rag-rat-mcp/src/claude_hook.rs
@@ -59,22 +59,12 @@ mod listener {
     /// > client's 250 ms timeout; a stalled peer cannot wedge the serialized accept loop.
     const READ_BUDGET: Duration = Duration::from_millis(500);
 
-    /// The shared base dir the socket and its election lock key off: the index DB's directory
-    /// (shared across a repo's worktrees), falling back to the worktree root.
-    fn socket_base_dir(config: &Config) -> PathBuf {
-        config
-            .database
-            .parent()
-            .map(std::path::Path::to_path_buf)
-            .unwrap_or_else(|| config.root.clone())
-    }
-
     pub fn socket_path_for(config: &Config) -> PathBuf {
-        locks::hook_socket_path(&socket_base_dir(config), &config.root)
+        locks::hook_socket_path_for(config)
     }
 
     fn socket_lock_path_for(config: &Config) -> PathBuf {
-        locks::socket_lock_path(&socket_base_dir(config), &config.root)
+        locks::hook_socket_lock_path_for(config)
     }
 
     /// Per-session record of what was already injected. Pruned by LRU cap + TTL.

--- a/crates/rag-rat-mcp/src/claude_hook.rs
+++ b/crates/rag-rat-mcp/src/claude_hook.rs
@@ -56,6 +56,8 @@ mod listener {
     const ELECTION_RETRY: Duration = Duration::from_secs(5);
     const SESSION_CAP: usize = 64;
     const SESSION_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+    /// > client's 250 ms timeout; a stalled peer cannot wedge the serialized accept loop.
+    const READ_BUDGET: Duration = Duration::from_millis(500);
 
     /// The shared base dir the socket and its election lock key off: the index DB's directory
     /// (shared across a repo's worktrees), falling back to the worktree root.
@@ -105,7 +107,10 @@ mod listener {
             let Ok(listener) = UnixListener::bind(&socket) else { return };
             let mut sessions: HashMap<String, SessionState> = HashMap::new();
             loop {
-                let Ok((stream, _addr)) = listener.accept().await else { continue };
+                let Ok((stream, _addr)) = listener.accept().await else {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    continue;
+                };
                 prune_sessions(&mut sessions);
                 if let Err(err) = serve_one(stream, &config, &mut sessions).await
                     && std::env::var_os("RAG_RAT_HOOK_DEBUG").is_some()
@@ -136,7 +141,12 @@ mod listener {
     ) -> anyhow::Result<()> {
         let (read, mut write) = stream.into_split();
         let mut line = String::new();
-        BufReader::new(read).read_line(&mut line).await?;
+        match tokio::time::timeout(READ_BUDGET, BufReader::new(read).read_line(&mut line)).await {
+            Err(_elapsed) => return Ok(()), // stalled peer — drop, keep loop live
+            Ok(io) => {
+                io?;
+            }, // propagate real I/O errors as before
+        }
         let reply = match serde_json::from_str::<HookRequest>(&line) {
             Ok(req) if req.v == PROTOCOL_VERSION && req.kind == "grep_augment" => {
                 let filter = {

--- a/crates/rag-rat-mcp/src/claude_hook.rs
+++ b/crates/rag-rat-mcp/src/claude_hook.rs
@@ -28,6 +28,282 @@ pub struct HookResponse {
     pub context: Option<String>,
 }
 
+#[cfg(unix)]
+pub use listener::{socket_path_for, spawn_listener};
+
+#[cfg(unix)]
+mod listener {
+    use std::{
+        collections::HashMap,
+        path::PathBuf,
+        time::{Duration, Instant},
+    };
+
+    use rag_rat_core::{
+        config::Config,
+        locks::{self, FileLock},
+        query::grep_augment::{self, DedupeFilter},
+        storage::IndexConnection,
+    };
+    use tokio::{
+        io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+        net::{UnixListener, UnixStream},
+        task::JoinHandle,
+    };
+
+    use super::{HookRequest, HookResponse, PROTOCOL_VERSION};
+
+    const ELECTION_RETRY: Duration = Duration::from_secs(5);
+    const SESSION_CAP: usize = 64;
+    const SESSION_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+    /// The shared base dir the socket and its election lock key off: the index DB's directory
+    /// (shared across a repo's worktrees), falling back to the worktree root.
+    fn socket_base_dir(config: &Config) -> PathBuf {
+        config
+            .database
+            .parent()
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_else(|| config.root.clone())
+    }
+
+    pub fn socket_path_for(config: &Config) -> PathBuf {
+        locks::hook_socket_path(&socket_base_dir(config), &config.root)
+    }
+
+    fn socket_lock_path_for(config: &Config) -> PathBuf {
+        locks::socket_lock_path(&socket_base_dir(config), &config.root)
+    }
+
+    /// Per-session record of what was already injected. Pruned by LRU cap + TTL.
+    #[derive(Default)]
+    struct SessionState {
+        filter: DedupeFilter,
+        last_used: Option<Instant>,
+    }
+
+    /// Spawn the hook listener task: win the socket election (retrying forever, like the
+    /// watcher), then accept hook clients until the task is dropped. Returns the JoinHandle so
+    /// the server can abort it on teardown; the lock and socket release with the process.
+    pub fn spawn_listener(config: Config) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            let lock_path = socket_lock_path_for(&config);
+            // The lock must live inside this task: aborting the task drops it, so a
+            // surviving process's retry loop can take over (election, watcher-identical).
+            let _lock: FileLock = loop {
+                match FileLock::try_acquire(&lock_path) {
+                    Ok(Some(lock)) => break lock,
+                    _ => tokio::time::sleep(ELECTION_RETRY).await,
+                }
+            };
+            let socket = socket_path_for(&config);
+            if let Some(parent) = socket.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            // Only the lock holder ever unlinks: race-free stale-socket cleanup.
+            let _ = std::fs::remove_file(&socket);
+            let Ok(listener) = UnixListener::bind(&socket) else { return };
+            let mut sessions: HashMap<String, SessionState> = HashMap::new();
+            loop {
+                let Ok((stream, _addr)) = listener.accept().await else { continue };
+                prune_sessions(&mut sessions);
+                if let Err(err) = serve_one(stream, &config, &mut sessions).await
+                    && std::env::var_os("RAG_RAT_HOOK_DEBUG").is_some()
+                {
+                    eprintln!("claude-hook listener: {err:#}");
+                }
+            }
+        })
+    }
+
+    /// Drop sessions idle past the TTL, then evict least-recently-used down to the cap.
+    fn prune_sessions(sessions: &mut HashMap<String, SessionState>) {
+        let now = Instant::now();
+        sessions.retain(|_, s| s.last_used.is_some_and(|t| now.duration_since(t) < SESSION_TTL));
+        while sessions.len() > SESSION_CAP {
+            let oldest = sessions.iter().min_by_key(|(_, s)| s.last_used).map(|(k, _)| k.clone());
+            let Some(key) = oldest else { break };
+            sessions.remove(&key);
+        }
+    }
+
+    /// One request per connection: read a line, compose (read-only DB, off the runtime
+    /// threads), record what was injected for the session, reply with one line.
+    async fn serve_one(
+        stream: UnixStream,
+        config: &Config,
+        sessions: &mut HashMap<String, SessionState>,
+    ) -> anyhow::Result<()> {
+        let (read, mut write) = stream.into_split();
+        let mut line = String::new();
+        BufReader::new(read).read_line(&mut line).await?;
+        let reply = match serde_json::from_str::<HookRequest>(&line) {
+            Ok(req) if req.v == PROTOCOL_VERSION && req.kind == "grep_augment" => {
+                let filter = {
+                    let state = sessions.entry(req.session_id.clone()).or_default();
+                    state.last_used = Some(Instant::now());
+                    // Clone ends the borrow before the spawn_blocking await below.
+                    state.filter.clone()
+                };
+                let database = config.database.clone();
+                let pattern = req.pattern.clone();
+                let search_path = req.search_path.clone();
+                // rusqlite is sync; one short read off the runtime threads.
+                let composed = tokio::task::spawn_blocking(move || {
+                    let conn = IndexConnection::open_read_only(&database)?;
+                    grep_augment::compose(
+                        conn.connection(),
+                        &pattern,
+                        search_path.as_deref(),
+                        &filter,
+                    )
+                })
+                .await??;
+                match composed {
+                    Some(out) => {
+                        // compose's returned IDs are exactly the items rendered, so the
+                        // session filter grows by exactly what the model now has.
+                        let state = sessions.entry(req.session_id).or_default();
+                        state.filter.memory_ids.extend(out.memory_ids.iter().cloned());
+                        state.filter.symbol_keys.extend(out.symbol_keys.iter().cloned());
+                        HookResponse { v: PROTOCOL_VERSION, context: Some(out.context) }
+                    },
+                    None => HookResponse { v: PROTOCOL_VERSION, context: None },
+                }
+            },
+            // Unknown v/kind or malformed JSON: answer null-context, never error back.
+            _ => HookResponse { v: PROTOCOL_VERSION, context: None },
+        };
+        let mut payload = serde_json::to_string(&reply)?;
+        payload.push('\n');
+        write.write_all(payload.as_bytes()).await?;
+        Ok(())
+    }
+}
+
+#[cfg(all(test, unix))]
+mod listener_tests {
+    use std::time::Duration;
+
+    use rag_rat_core::{Config, index::schema, storage::IndexConnection};
+
+    use super::*;
+
+    /// Build a Config rooted at a fresh temp dir with a seeded on-disk index. The toml shape
+    /// mirrors `mcp_hot_upgrade.rs`'s `TestEnv::setup`, minus targets (the listener never
+    /// indexes). The DB is created at `config.database` *after* `Config::load` so root
+    /// canonicalization can't desync the two paths.
+    fn test_config() -> Config {
+        let root = std::env::temp_dir().join(format!(
+            "ragrat-hooksock-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let config_path = root.join("rag-rat.toml");
+        std::fs::write(&config_path, "[index]\nroot = \".\"\ndatabase = \".rag-rat/index.db\"\n")
+            .unwrap();
+        let config = Config::load(&config_path).unwrap();
+
+        let rw = IndexConnection::open(&config.database).unwrap();
+        schema::apply(rw.connection()).unwrap();
+        rw.connection()
+            .execute(
+                "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
+                 VALUES ('src/lib.rs', 'rust', 'source', 'abc', 0, 0)",
+                [],
+            )
+            .unwrap();
+        rw.connection()
+            .execute(
+                "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte,
+                                     end_byte, signature, docs)
+                 VALUES (1, 'rust', 'frobnicate', 'lib::frobnicate', 'function', 0, 10,
+                         'fn frobnicate()', NULL)",
+                [],
+            )
+            .unwrap();
+        // No rebuild_fts here: external-content FTS5 rebuilds corrupt when out of sync with
+        // direct seeding, and the symbol lane needs no FTS rows.
+        config
+    }
+
+    async fn request(socket: &std::path::Path, body: serde_json::Value) -> serde_json::Value {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+        let stream = tokio::net::UnixStream::connect(socket).await.unwrap();
+        let (read, mut write) = stream.into_split();
+        write.write_all(format!("{body}\n").as_bytes()).await.unwrap();
+        let mut line = String::new();
+        BufReader::new(read).read_line(&mut line).await.unwrap();
+        serde_json::from_str(&line).unwrap()
+    }
+
+    #[tokio::test]
+    async fn listener_serves_context_then_dedupes_per_session() {
+        let config = test_config();
+        let _listener = spawn_listener(config.clone());
+        let socket = socket_path_for(&config);
+        // Election + bind are async; poll for the socket.
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        while !socket.exists() && std::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        let req = |sid: &str| {
+            serde_json::json!({"v": 1, "kind": "grep_augment", "session_id": sid,
+                               "pattern": "frobnicate", "search_path": null,
+                               "source": "grep_tool"})
+        };
+        let first = request(&socket, req("s1")).await;
+        assert!(first["context"].as_str().unwrap().contains("lib::frobnicate"));
+        let second = request(&socket, req("s1")).await;
+        assert!(second["context"].is_null(), "same session deduped");
+        let other = request(&socket, req("s2")).await;
+        assert!(
+            other["context"].as_str().unwrap().contains("lib::frobnicate"),
+            "fresh session not deduped"
+        );
+        let bad = request(&socket, serde_json::json!({"v": 99, "kind": "nope"})).await;
+        assert!(bad["context"].is_null(), "unknown version answered, not errored");
+    }
+
+    #[tokio::test]
+    async fn second_listener_takes_over_when_winner_dies() {
+        let config = test_config();
+        let winner = spawn_listener(config.clone());
+        let socket = socket_path_for(&config);
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        while !socket.exists() && std::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        // The loser parks in the election retry loop while the winner holds the lock.
+        let loser = spawn_listener(config.clone());
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(!loser.is_finished(), "loser must wait, not exit");
+
+        // Kill the winner: its lock fd and bound socket drop with the task's process state.
+        winner.abort();
+        let _ = winner.await;
+        // NOTE: in-process abort drops the FileLock (held by the task) but the dead socket
+        // file remains — exactly the stale-socket case. The loser must unlink + re-bind.
+        let req = serde_json::json!({"v": 1, "kind": "grep_augment", "session_id": "takeover",
+                                     "pattern": "frobnicate", "search_path": null,
+                                     "source": "grep_tool"});
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        loop {
+            // Election retry is 5s; poll until the loser owns the socket and answers.
+            if let Ok(stream) = tokio::net::UnixStream::connect(&socket).await {
+                drop(stream);
+                let reply = request(&socket, req.clone()).await;
+                assert!(reply["context"].as_str().unwrap().contains("lib::frobnicate"));
+                break;
+            }
+            assert!(std::time::Instant::now() < deadline, "loser never took over the socket");
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+        loser.abort();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rag-rat-mcp/src/claude_hook.rs
+++ b/crates/rag-rat-mcp/src/claude_hook.rs
@@ -1,0 +1,51 @@
+//! Unix-socket listener serving the Claude Code grep-augmentation PreToolUse hook.
+//!
+//! One listener per worktree (socket election lock); newline-delimited JSON, one request per
+//! connection; per-session dedupe in memory. Read-only on the index by construction. Spec:
+//! `docs/specs/2026-06-09-grep-augment-pretooluse-hook.md`.
+
+use serde::{Deserialize, Serialize};
+
+pub const PROTOCOL_VERSION: u32 = 1;
+
+/// One grep-augment query from a hook client. Unknown fields are ignored (forward compat);
+/// unknown `v`/`kind` get a null-context reply rather than an error.
+#[derive(Debug, Deserialize)]
+pub struct HookRequest {
+    pub v: u32,
+    pub kind: String,
+    pub session_id: String,
+    pub pattern: String,
+    #[serde(default)]
+    pub search_path: Option<String>,
+    #[serde(default)]
+    pub source: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct HookResponse {
+    pub v: u32,
+    pub context: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_roundtrips_and_tolerates_unknown_fields() {
+        let json = r#"{"v":1,"kind":"grep_augment","session_id":"s1","pattern":"foo",
+                       "search_path":null,"source":"grep_tool","future_field":true}"#;
+        let req: HookRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.v, 1);
+        assert_eq!(req.kind, "grep_augment");
+        assert_eq!(req.pattern, "foo");
+        assert!(req.search_path.is_none());
+    }
+
+    #[test]
+    fn response_serializes_null_context_explicitly() {
+        let resp = HookResponse { v: 1, context: None };
+        assert_eq!(serde_json::to_string(&resp).unwrap(), r#"{"v":1,"context":null}"#);
+    }
+}

--- a/crates/rag-rat-mcp/src/lib.rs
+++ b/crates/rag-rat-mcp/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod claude_hook;
 pub mod server;
 pub mod tools;
 #[cfg(unix)]

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -465,6 +465,19 @@ pub async fn run_stdio(config: Config) -> anyhow::Result<()> {
     }
 }
 
+/// Aborts a spawned task when dropped. Used to tear down the hook listener on normal EOF
+/// shutdown so its socket + election lock release promptly (a hot-`exec` replaces the process
+/// image instead, so the task vanishes and the successor re-elects).
+#[cfg(unix)]
+struct AbortOnDrop(tokio::task::JoinHandle<()>);
+
+#[cfg(unix)]
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
 /// Unix `run_stdio`: serves over a [`crate::upgrade::GatedStdin`] so a `SIGUSR1` can hot-`exec`
 /// the newly installed binary in place, and resumes (skipping `initialize`) when handed off to.
 #[cfg(unix)]
@@ -505,6 +518,12 @@ async fn run_stdio_unix(config: Config) -> anyhow::Result<()> {
     let install_path = upgrade::install_path();
     let _watcher =
         rag_rat_core::watch::Watcher::spawn_with_fleet(config.clone(), install_path.clone());
+
+    // Grep-augment hook listener: one elected listener per worktree. Spawned after the `running`
+    // match so it covers both cold start and hot-upgrade resume. On normal EOF shutdown the guard
+    // aborts the task so the socket + election lock release promptly; on a hot-`exec` the process
+    // image is replaced (task vanishes) and the new process re-elects.
+    let _hook_listener = AbortOnDrop(crate::claude_hook::spawn_listener(config.clone()));
 
     // Arm the SIGUSR1 hot-upgrade handler only when an install target is configured.
     if let Some(install_path) = install_path {


### PR DESCRIPTION
## What

A Claude Code **grep-augmentation PreToolUse hook** for rag-rat. When an agent greps, the hook injects rag-rat symbol + repo-memory context as `additionalContext` — and **never blocks the grep** (always exits 0).

## Architecture

- **`rag-rat claude-hook`** CLI client — reads the PreToolUse JSON on stdin, augments `Grep` tool calls and Bash `grep`/`rg`/`ag` commands (conservative parser; `echo grep foo` / `sudo grep foo` correctly ignored — no false positives).
- An **elected Unix-socket listener** inside `rag-rat mcp` (one per worktree) with per-session dedupe, so the same memory/symbol isn't re-injected within a session.
- A **read-only SQLite fallback** when no server is running (stateless). Both paths share one `compose` and one socket-path derivation (`locks::hook_socket_path_for`) so they cannot diverge.
- Install via `rag-rat hooks install --claude [--global]` (writes `.claude/settings.json`, marker-aware/idempotent, preserves foreign entries). `uninstall`/`status` too.

## Payload

Repo memories first (the unique signal), then matching symbols (location, caller/callee counts, signature), then lexical hits as fallback. **Never loads the embedding model** (symbol + FTS only — structurally unreachable model-load path). Hard-capped at 1500 chars with whole-item truncation. Identifier-shaped patterns trigger the symbol lane; others use memory FTS + lexical.

## Tests

164 tests pass (core 128, mcp 16, cli 13 + e2e 4 + hot-upgrade 2 + stdio 1), clippy clean, fmt clean.
- The end-to-end test (`claude_hook_e2e.rs`) spawns the real `rag-rat mcp`, drives the hook client cross-process, and proves serve -> same-session dedupe -> fresh-session re-serve -> kill-server -> stateless fallback. Mutation-tested for non-vacuity.
- The hot-upgrade test proves the socket re-binds after a real `SIGUSR1` `exec`.

## Merge note

This branch forked from `8c923e4`; `origin/main` has since moved to the selectable-embedding-backend work (`732eef5`), which also touches `crates/rag-rat-core/src/search/lexical.rs`. Expect a **mechanical conflict in `lexical.rs`** (and union the `query/mod.rs` module line + Cargo feature flags). After merging, re-run `cargo test -p rag-rat-core search_lexical_only` and the `grep_augment::` suite — main reworked the same `search_with_query_embedding` call chain.

## Follow-ups filed

#51 (rebuild_fts FTS5 corruption), #52 (non-atomic settings write), #53 (listener re-bind retry), #54 (cfg(unix) tokio features), #55 (optional fuzzy symbol fallback).

_Design spec + implementation plan are intentionally uncommitted (repo convention), so they're not in this diff._