### PR TITLE
perf: cut idle MCP load (no-op write skip + sweep gating + runtime cap)

### DIFF
--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -48,7 +48,16 @@ fn main() -> anyhow::Result<()> {
         Cmd::Brief(args) => brief(&config, &args)?,
         Cmd::Clusters(args) => clusters(&config, &args)?,
         Cmd::Mcp => {
-            tokio::runtime::Runtime::new()?.block_on(rag_rat_mcp::server::run_stdio(config))?;
+            // The MCP server is an stdio JSON-RPC loop (one client, mostly serial) plus a SIGUSR1
+            // task; the file watcher runs on its own OS thread and CPU-heavy indexing is rayon, not
+            // tokio. The default runtime's ~num_cpus workers are therefore idle overhead, so cap it
+            // small (issue #63, facet 3). Stay multi_thread (not current_thread) so a blocking tool
+            // handler can't stall the serve loop or the upgrade-signal task.
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
+                .enable_all()
+                .build()?
+                .block_on(rag_rat_mcp::server::run_stdio(config))?;
         },
         Cmd::Memory(args) => memory(&config, &args)?,
         Cmd::Github(args) => github(&config, &args)?,

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -61,17 +61,25 @@ impl IndexDatabase {
             // BEGIN IMMEDIATE: acquire the write lock up front so a racing writer waits out
             // busy_timeout instead of failing the deferred read→write upgrade with SQLITE_BUSY.
             db.storage.execute_batch("BEGIN IMMEDIATE")?;
-            db.set_meta("source_root", &config.root.display().to_string())?;
+            // Write meta only when it actually changed, and track whether this pass mutated
+            // anything at all. A periodic sweep or a spurious event over an unchanged tree must
+            // NOT churn the WAL with a timestamp-only write + COMMIT (issue #63) — that idle write
+            // is also exactly the false signal the watcher-loop diagnostic keys on
+            // (indexed_at_ms advancing while content is unchanged).
+            let source_root_changed =
+                db.set_meta_if_changed("source_root", &config.root.display().to_string())?;
             db.storage.set_source_root(config.root.clone());
-            db.write_git_meta(&config.root)?;
+            let git_meta_changed = db.write_git_meta(&config.root)?;
             let indexed = match mode {
                 IndexMode::Changed => db.index_changed_files_with_progress(config, progress)?,
                 IndexMode::Discover => db.index_discovered_files_with_progress(config, progress)?,
                 IndexMode::Full => unreachable!("full mode is handled by rebuild_with_progress"),
             };
+            let mut mutated = indexed > 0 || source_root_changed || git_meta_changed;
             // None when the gate above found git history already current — skip the reload.
             if let Some(handle) = git_history.take() {
                 db.apply_prepared_git_history(&config.root, handle)?;
+                mutated = true;
             }
             if indexed > 0 {
                 progress(IndexProgress::RebuildingLogicalSymbols);
@@ -82,8 +90,14 @@ impl IndexDatabase {
                 progress(IndexProgress::SyncingFts);
                 db.sync_fts()?;
             }
-            db.set_meta("indexed_at_ms", &now_ms().to_string())?;
-            db.storage.execute_batch("COMMIT")?;
+            if mutated {
+                db.set_meta("indexed_at_ms", &now_ms().to_string())?;
+                db.storage.execute_batch("COMMIT")?;
+            } else {
+                // Nothing changed since the last pass — close the (empty) transaction without
+                // writing, so an idle server does not touch the DB.
+                db.storage.execute_batch("ROLLBACK")?;
+            }
             progress(IndexProgress::Finished { files: indexed });
             Ok(())
         })();

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -10,6 +10,7 @@ impl IndexDatabase {
         F: FnMut(IndexProgress),
     {
         Self::index_incremental_with_progress(config, IndexMode::Changed, &mut progress)
+            .map(|(db, _)| db)
     }
 
     pub fn index_discover(config: &Config) -> anyhow::Result<Self> {
@@ -21,28 +22,36 @@ impl IndexDatabase {
         F: FnMut(IndexProgress),
     {
         Self::index_incremental_with_progress(config, IndexMode::Discover, &mut progress)
+            .map(|(db, _)| db)
+    }
+
+    /// Like [`Self::index_discover`], but also reports whether the pass changed index *content*
+    /// (a file was added / edited / removed). The watch loop uses this to skip the
+    /// reconcile / memory-validate tail on an idle no-change sweep (issue #63).
+    pub fn index_discover_reporting(config: &Config) -> anyhow::Result<(Self, bool)> {
+        Self::index_incremental_with_progress(config, IndexMode::Discover, &mut |_| {})
     }
 
     fn index_incremental_with_progress<F>(
         config: &Config,
         mode: IndexMode,
         progress: &mut F,
-    ) -> anyhow::Result<Self>
+    ) -> anyhow::Result<(Self, bool)>
     where
         F: FnMut(IndexProgress),
     {
         if !config.database.exists() {
-            return Self::rebuild_with_progress(config, progress);
+            return Self::rebuild_with_progress(config, progress).map(|db| (db, true));
         }
         if Self::migration_check(&config.database)?.state == schema::SchemaState::Missing {
-            return Self::rebuild_with_progress(config, progress);
+            return Self::rebuild_with_progress(config, progress).map(|db| (db, true));
         }
 
         let mut db = Self::open(&config.database)?;
         let (commit_sha, worktree_id) = resolve_git_context(&config.root);
         db.set_context(&commit_sha, &worktree_id)?;
         if db.indexed_file_count()? == 0 {
-            return Self::rebuild_with_progress(config, progress);
+            return Self::rebuild_with_progress(config, progress).map(|db| (db, true));
         }
         progress(IndexProgress::Started { database: config.database.clone(), mode });
         // Gate the git-history reload: `apply_prepared` is a full `git log` re-read (O(total
@@ -57,7 +66,7 @@ impl IndexDatabase {
             progress(IndexProgress::IndexingGitHistory);
             Some(spawn_git_history_prepare(&config.root))
         };
-        let result = (|| -> anyhow::Result<()> {
+        let result = (|| -> anyhow::Result<bool> {
             // BEGIN IMMEDIATE: acquire the write lock up front so a racing writer waits out
             // busy_timeout instead of failing the deferred read→write upgrade with SQLITE_BUSY.
             db.storage.execute_batch("BEGIN IMMEDIATE")?;
@@ -99,7 +108,9 @@ impl IndexDatabase {
                 db.storage.execute_batch("ROLLBACK")?;
             }
             progress(IndexProgress::Finished { files: indexed });
-            Ok(())
+            // Report whether index *content* changed (files added / edited / removed), so the
+            // watch loop can skip the reconcile / memory-validate tail on an idle sweep.
+            Ok(indexed > 0)
         })();
         if result.is_err() {
             if let Some(handle) = git_history.take() {
@@ -107,8 +118,8 @@ impl IndexDatabase {
             }
             let _ = db.storage.execute_batch("ROLLBACK");
         }
-        result?;
-        Ok(db)
+        let content_changed = result?;
+        Ok((db, content_changed))
     }
 
     pub fn index_targets(&self, config: &Config) -> anyhow::Result<()> {

--- a/crates/rag-rat-core/src/index/internals.rs
+++ b/crates/rag-rat-core/src/index/internals.rs
@@ -325,11 +325,25 @@ impl IndexDatabase {
         Ok(symbol_ids)
     }
 
-    pub(super) fn write_git_meta(&self, root: &Path) -> anyhow::Result<()> {
-        self.set_meta("git_commit", &git_output(root, &["rev-parse", "HEAD"]).unwrap_or_default())?;
+    /// Write a meta key only if the stored value differs. Returns whether a write happened — so a
+    /// no-change incremental/sweep pass can avoid dirtying a WAL page (see issue #63).
+    pub(super) fn set_meta_if_changed(&self, key: &str, value: &str) -> anyhow::Result<bool> {
+        if self.meta(key)?.as_deref() == Some(value) {
+            return Ok(false);
+        }
+        self.set_meta(key, value)?;
+        Ok(true)
+    }
+
+    /// Refresh `git_commit` / `git_dirty` meta, writing only the keys that actually changed.
+    /// Returns whether either was written (so the caller can tell a no-op pass from a real one).
+    pub(super) fn write_git_meta(&self, root: &Path) -> anyhow::Result<bool> {
+        let commit = git_output(root, &["rev-parse", "HEAD"]).unwrap_or_default();
         let dirty = !git_output(root, &["status", "--porcelain"]).unwrap_or_default().is_empty();
-        self.set_meta("git_dirty", if dirty { "true" } else { "false" })?;
-        Ok(())
+        let commit_changed = self.set_meta_if_changed("git_commit", &commit)?;
+        let dirty_changed =
+            self.set_meta_if_changed("git_dirty", if dirty { "true" } else { "false" })?;
+        Ok(commit_changed || dirty_changed)
     }
 
     /// O(1) check of whether the indexed git history is still current for `root`'s HEAD, so the

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -1514,6 +1514,56 @@ fn git_history_reload_is_not_skipped_on_a_shallow_clone() {
     fs::remove_dir_all(shallow).unwrap();
 }
 
+fn read_meta(db: &IndexDatabase, key: &str) -> Option<String> {
+    db.storage
+        .connection()
+        .query_row("SELECT value FROM index_meta WHERE key = ?1", [key], |row| row.get(0))
+        .optional()
+        .unwrap()
+}
+
+#[test]
+fn idle_discover_sweep_does_not_rewrite_indexed_at_ms() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    // Stamp a non-numeric sentinel so any spurious timestamp write is unmistakable.
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO index_meta(key, value) VALUES('indexed_at_ms', 'SENTINEL')
+             ON CONFLICT(key) DO UPDATE SET value = 'SENTINEL'",
+            [],
+        )
+        .unwrap();
+    drop(db);
+
+    // A discover sweep over an unchanged tree must not mutate the DB — the sentinel survives
+    // (no timestamp-only write + COMMIT). See issue #63.
+    let db = IndexDatabase::index_discover(&config).unwrap();
+    assert_eq!(
+        read_meta(&db, "indexed_at_ms").as_deref(),
+        Some("SENTINEL"),
+        "an unchanged discover sweep must not rewrite indexed_at_ms"
+    );
+    drop(db);
+
+    // A real change must persist — the sweep writes a fresh timestamp, clearing the sentinel.
+    fs::write(root.join("docs/added.md"), "# Added\nfresh content\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "Add a doc"]);
+    let db = IndexDatabase::index_discover(&config).unwrap();
+    assert_ne!(
+        read_meta(&db, "indexed_at_ms").as_deref(),
+        Some("SENTINEL"),
+        "a sweep that indexes a new file must update indexed_at_ms"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
 #[test]
 fn indexes_rust_graph_edges_from_tree_sitter() {
     let root = unique_temp_root();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -1565,6 +1565,25 @@ fn idle_discover_sweep_does_not_rewrite_indexed_at_ms() {
 }
 
 #[test]
+fn index_discover_reporting_flags_content_changes() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+    IndexDatabase::rebuild(&config).unwrap();
+
+    // No change → reports false, so the watch loop skips the reconcile / memory-validate tail.
+    let (_db, changed) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    assert!(!changed, "an unchanged discover sweep must report no content change");
+
+    // A new file on disk → reports true.
+    fs::write(root.join("docs/extra.md"), "# Extra\nbody text\n").unwrap();
+    let (_db, changed) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    assert!(changed, "a discover sweep that indexes a new file must report a content change");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn indexes_rust_graph_edges_from_tree_sitter() {
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -100,7 +100,16 @@ pub fn maintenance_pass_or_skip(config: &Config, run_gc: bool) -> anyhow::Result
 }
 
 fn run_pass(config: &Config, run_gc: bool) -> anyhow::Result<()> {
-    let db = IndexDatabase::index_discover(config)?;
+    let (db, content_changed) = IndexDatabase::index_discover_reporting(config)?;
+    // Idle backstop (issue #63, facet 2): when the sweep changed no content, skip the reconcile /
+    // gc / memory-validate tail — an idle server should do no work past discovery. `run_gc` (every
+    // GC_EVERY_PASSES) still forces a full tail, so the cases that DON'T flip content_changed are
+    // still caught within that bound: a freshly-installed embedder, an embedding backlog left by a
+    // time-capped reconcile (PASS_RECONCILE_MAX_SECONDS), and drifted memory anchors. Any real
+    // content change runs the full tail immediately.
+    if !content_changed && !run_gc {
+        return Ok(());
+    }
     let runtime = &config.local_ai.embedding.runtime;
     let options = ReconcileOptions {
         batch_size: Some(runtime.batch_size),


### PR DESCRIPTION
Addresses all three facets of #63 (idle MCP baseline CPU / DB churn). Three focused commits:

### Facet 1 — no DB write on a no-change pass
The incremental path opened `BEGIN IMMEDIATE` and unconditionally wrote `source_root` + git meta + `indexed_at_ms` then `COMMIT`ted on **every** pass — a WAL page per watcher event / 300 s sweep even when nothing changed (also the exact false signal the watcher-loop diagnostic keys on). Now `source_root`/git meta use `set_meta_if_changed`, the pass tracks a `mutated` flag, and `indexed_at_ms` + `COMMIT` happen only when something mutated; otherwise the empty transaction is rolled back. `indexed_at_ms` advances only on real change.

### Facet 2 — skip the reconcile/gc/memory-validate tail on an idle sweep
`index_discover_reporting` reports whether the pass changed index content; `run_pass` skips the whole reconcile → gc → memory-validate tail when nothing changed. `run_gc` (every `GC_EVERY_PASSES`) still forces a full tail, which bounds the cases that don't flip `content_changed`: a freshly-installed embedder, an embedding backlog from a time-capped reconcile, and drifted memory anchors. The CLI git-hook `maintenance` path is untouched (it fires on real git events, so it always full-passes).

### Facet 3 — cap the MCP stdio runtime workers
`rag-rat mcp` built its tokio runtime with `Runtime::new()` (~num_cpus workers, 12 on a typical box). The server is a serial stdio JSON-RPC loop + one SIGUSR1 task; the watcher is its own OS thread and indexing is rayon (untouched). Capped to 2 worker threads, kept multi-thread so a blocking handler can't stall the serve loop / signal task.

### Tests
New tests: idle sweep does not rewrite `indexed_at_ms`; `index_discover_reporting` flags content change vs no-change; existing git-history gate + MCP stdio/hot-upgrade tests still pass. 174 core tests + integration green, clippy clean.

Fixes #63