### PR TITLE
feat(index): compile and apply real .gitignore in walker + watcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,6 +1870,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2284,6 +2297,22 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -3091,6 +3120,7 @@ dependencies = [
  "fastembed",
  "gix",
  "iai-callgrind",
+ "ignore",
  "libc",
  "model2vec-rs",
  "notify",

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -15,6 +15,7 @@ categories.workspace = true
 anyhow.workspace = true
 fastembed = { workspace = true, optional = true }
 gix.workspace = true
+ignore = "0.4.26"
 model2vec-rs = { version = "0.2.1", default-features = false, features = ["hf-hub", "fancy-regex"], optional = true }
 notify = "8.2.0"
 rayon.workspace = true

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -166,6 +166,23 @@ impl FromStr for TargetKind {
 }
 
 impl Config {
+    /// The deduplicated set of target directories (relative to [`Config::root`]) across all
+    /// targets, in stable order. Used to scope `.gitignore` nested-discovery to the indexed trees
+    /// (see [`crate::index::ignore_rules::IgnoreMatcher::compile`]) instead of recursing the whole
+    /// root into unindexed siblings.
+    pub fn target_directories(&self) -> Vec<PathBuf> {
+        let mut seen = BTreeSet::new();
+        let mut dirs = Vec::new();
+        for target in &self.targets {
+            for dir in &target.directories {
+                if seen.insert(dir.clone()) {
+                    dirs.push(dir.clone());
+                }
+            }
+        }
+        dirs
+    }
+
     pub fn load(path: impl AsRef<Path>) -> Result<Self, ConfigError> {
         let path = path.as_ref();
         let text = fs::read_to_string(path)?;

--- a/crates/rag-rat-core/src/index/git_history.rs
+++ b/crates/rag-rat-core/src/index/git_history.rs
@@ -625,6 +625,15 @@ fn count_table(conn: &Connection, table: &str) -> anyhow::Result<u64> {
     Ok(u64::try_from(count).unwrap_or(0))
 }
 
+/// The enclosing Git worktree root for `root` (the directory `git rev-parse --show-toplevel`
+/// reports), or `None` when `root` is not inside a Git worktree (or `git` is unavailable). This is
+/// the single place the codebase shells `--show-toplevel`; reuse it rather than adding a parallel
+/// git call (the ignore matcher anchors its `.gitignore` ancestor stack here — issue #62 finding 3:
+/// a `config.root` that is a subdirectory of a larger worktree must honor the worktree-root rules).
+pub(crate) fn worktree_root(root: &Path) -> Option<PathBuf> {
+    git_output(root, &["rev-parse", "--show-toplevel"]).map(PathBuf::from)
+}
+
 fn git_repo(root: &Path) -> Option<GitRepo> {
     let worktree_root = git_output(root, &["rev-parse", "--show-toplevel"])?;
     let head = git_output(root, &["rev-parse", "HEAD"])?;

--- a/crates/rag-rat-core/src/index/ignore_rules.rs
+++ b/crates/rag-rat-core/src/index/ignore_rules.rs
@@ -1,0 +1,239 @@
+//! Shared ignore matcher for the walker (index discovery) and the watcher (event classification).
+//!
+//! Issue #62: discovery and the watcher both used to skip directories by a *hardcoded* name list
+//! (`.git`, `.rag-rat`, `target`, `node_modules`, `dist`, `build`, `coverage`). That missed
+//! repo-specific `.gitignore` entries — generated dirs, build outputs, vendored code in
+//! non-standard locations — so they could get indexed and (recursively) watched.
+//!
+//! [`IgnoreMatcher`] compiles the repo's real `.gitignore` rules (root **and** nested gitignores,
+//! via ripgrep's [`ignore`] crate) once, and both the walker and the watcher consult it so a path
+//! one ignores the other also ignores — no drift. The hardcoded names are kept as a **floor**
+//! ([`FLOOR_DIRS`]): they apply even in a non-git tree with no `.gitignore`, and they cover
+//! rag-rat's own index dir (`.rag-rat/`), which must never be indexed regardless of gitignore
+//! contents.
+
+use std::path::{Path, PathBuf};
+
+use ignore::Match;
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
+
+/// Directory names always skipped, gitignore or not — the floor under the compiled `.gitignore`
+/// rules. `.rag-rat` is rag-rat's own index dir (indexing it would be a feedback loop); `.git` is
+/// never source; the rest are conventional build/dependency/output dirs that a non-git tree (no
+/// `.gitignore` to compile) still must not index. In a git tree these usually also appear in
+/// `.gitignore`, but the floor guarantees them even when they don't.
+const FLOOR_DIRS: &[&str] =
+    &[".git", ".rag-rat", ".omx", ".omc", "node_modules", "target", "dist", "build", "coverage"];
+
+/// Whether a single path component matches a floor directory name (see [`FLOOR_DIRS`]).
+fn is_floor_dir(name: &str) -> bool {
+    FLOOR_DIRS.contains(&name)
+}
+
+/// One `.gitignore`, compiled with its own directory as the matching root so its patterns are
+/// scoped to that subtree (gitignore semantics: a non-anchored pattern like `skip.rs` matches only
+/// at or below the file's directory, not the whole repo).
+#[derive(Debug)]
+struct ScopedGitignore {
+    /// Absolute directory the `.gitignore` lives in; the matcher applies only to paths under it.
+    dir: PathBuf,
+    gitignore: Gitignore,
+}
+
+/// Compiled ignore rules for one repo root: the floor names plus a per-directory stack of compiled
+/// `.gitignore` files (root and nested), each scoped to its own subtree. Built once per walk/watch
+/// and shared so the walker and watcher classify paths identically (issue #62).
+///
+/// **Why a per-directory stack and not one flat `GitignoreBuilder`:** `GitignoreBuilder::add`
+/// flattens every file's globs into a single matcher rooted at the *builder* root and gives each
+/// non-anchored pattern a `**/` prefix — so a nested `.gitignore` rule `skip.rs` would wrongly
+/// match `skip.rs` anywhere in the repo. Compiling each `.gitignore` against *its own* directory
+/// and only applying it to descendants of that directory is what makes nesting correct.
+#[derive(Debug)]
+pub struct IgnoreMatcher {
+    /// Stack of compiled gitignores, **outermost first** (root before nested). Matching applies
+    /// them in order and lets the deepest matching one win (last write), so a nested whitelist can
+    /// override an outer ignore — standard git precedence.
+    stack: Vec<ScopedGitignore>,
+}
+
+impl IgnoreMatcher {
+    /// Compile the matcher for `root`. Collects every `.gitignore` at or below `root` (skipping the
+    /// floor dirs themselves, so we never descend into `target/` to read its vendored gitignores)
+    /// and compiles each against its own directory. Never fails — a malformed gitignore is dropped
+    /// and matching proceeds with what compiled.
+    pub fn compile(root: &Path) -> Self {
+        let mut stack = Vec::new();
+        for dir in collect_gitignore_dirs(root) {
+            let mut builder = GitignoreBuilder::new(&dir);
+            // `add` returns an Option<Error> for partial-parse problems; ignore it (best-effort,
+            // matching ripgrep's own tolerance) rather than failing the whole walk.
+            let _ = builder.add(dir.join(".gitignore"));
+            if let Ok(gitignore) = builder.build() {
+                stack.push(ScopedGitignore { dir, gitignore });
+            }
+        }
+        // Outermost first: shortest dir path sorts before its descendants.
+        stack.sort_by_key(|scoped| scoped.dir.as_os_str().len());
+        Self { stack }
+    }
+
+    /// Whether `path` is ignored. `is_dir` must say whether the path is a directory — gitignore
+    /// distinguishes `foo/` (dir-only) from `foo`. A floor-dir name anywhere in the path ignores it
+    /// unconditionally (the floor can't be whitelisted away); otherwise each `.gitignore` whose
+    /// directory is an ancestor is applied outermost→innermost and the last decision wins, so a
+    /// nested `!pattern` whitelist overrides an outer ignore (standard git precedence).
+    pub fn is_ignored(&self, path: &Path, is_dir: bool) -> bool {
+        if path_contains_floor_dir(path) {
+            return true;
+        }
+        let mut ignored = false;
+        for scoped in &self.stack {
+            let Ok(rel) = path.strip_prefix(&scoped.dir) else {
+                continue; // gitignore in a sibling/unrelated subtree — doesn't govern this path.
+            };
+            if rel.as_os_str().is_empty() {
+                continue; // the gitignore's own directory.
+            }
+            // `matched_path_or_any_parents` so a file under an ignored *directory* (`generated/`
+            // ignores `generated/out.rs`) is caught — plain `matched` only tests the leaf. It walks
+            // the path's parents within this gitignore's scope and returns the closest decision.
+            match scoped.gitignore.matched_path_or_any_parents(rel, is_dir) {
+                Match::Ignore(_) => ignored = true,
+                Match::Whitelist(_) => ignored = false,
+                Match::None => {},
+            }
+        }
+        ignored
+    }
+}
+
+/// Whether any component of `path` is a floor directory name.
+fn path_contains_floor_dir(path: &Path) -> bool {
+    path.components().any(|component| component.as_os_str().to_str().is_some_and(is_floor_dir))
+}
+
+/// Collect directories at or below `root` that contain a `.gitignore`, **without** descending into
+/// floor dirs (so we don't walk `target/`/`node_modules/` just to read gitignores the floor already
+/// excludes). Returns directories (not the `.gitignore` paths) so each can be compiled against its
+/// own root for correct nested scoping.
+fn collect_gitignore_dirs(root: &Path) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        if dir.join(".gitignore").is_file() {
+            found.push(dir.clone());
+        }
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if !file_type.is_dir() || file_type.is_symlink() {
+                continue;
+            }
+            let name = entry.file_name();
+            if name.to_str().is_some_and(is_floor_dir) {
+                continue;
+            }
+            stack.push(entry.path());
+        }
+    }
+    found
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    fn write(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn floor_dirs_ignored_without_any_gitignore() {
+        let tmp = tempdir();
+        let m = IgnoreMatcher::compile(&tmp);
+        assert!(m.is_ignored(&tmp.join("target"), true));
+        assert!(m.is_ignored(&tmp.join("target/debug/foo.rs"), false));
+        assert!(m.is_ignored(&tmp.join(".rag-rat"), true));
+        assert!(m.is_ignored(&tmp.join("node_modules/pkg/index.ts"), false));
+        assert!(!m.is_ignored(&tmp.join("src/lib.rs"), false));
+        fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn root_gitignore_is_honored() {
+        let tmp = tempdir();
+        write(&tmp.join(".gitignore"), "generated/\n*.bak\n");
+        write(&tmp.join("src/lib.rs"), "fn a() {}\n");
+        write(&tmp.join("generated/out.rs"), "fn b() {}\n");
+        write(&tmp.join("src/old.bak"), "x\n");
+        let m = IgnoreMatcher::compile(&tmp);
+        assert!(m.is_ignored(&tmp.join("generated"), true), "gitignored dir");
+        assert!(m.is_ignored(&tmp.join("generated/out.rs"), false), "file under gitignored dir");
+        assert!(m.is_ignored(&tmp.join("src/old.bak"), false), "gitignored glob");
+        assert!(!m.is_ignored(&tmp.join("src/lib.rs"), false), "non-ignored source");
+        fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn nested_gitignore_scopes_to_its_subtree() {
+        let tmp = tempdir();
+        // A nested gitignore ignores `vendor.rs` only under `sub/`, not at the root.
+        write(&tmp.join("sub/.gitignore"), "vendor.rs\n");
+        write(&tmp.join("sub/vendor.rs"), "x\n");
+        write(&tmp.join("vendor.rs"), "x\n");
+        let m = IgnoreMatcher::compile(&tmp);
+        assert!(m.is_ignored(&tmp.join("sub/vendor.rs"), false), "nested rule applies in subtree");
+        assert!(
+            !m.is_ignored(&tmp.join("vendor.rs"), false),
+            "nested rule does NOT leak to the root",
+        );
+        fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn whitelist_negation_unignores() {
+        let tmp = tempdir();
+        write(&tmp.join(".gitignore"), "build/\n!build/keep.rs\n");
+        write(&tmp.join("build/keep.rs"), "x\n");
+        write(&tmp.join("build/drop.rs"), "x\n");
+        let m = IgnoreMatcher::compile(&tmp);
+        // NOTE: `build` is also a FLOOR dir, so the floor wins regardless of negation — assert that
+        // the floor is unconditional. (A non-floor whitelisted dir is covered by the next test.)
+        assert!(
+            m.is_ignored(&tmp.join("build/keep.rs"), false),
+            "floor dir beats gitignore negation"
+        );
+        fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn negation_unignores_non_floor_dir() {
+        let tmp = tempdir();
+        write(&tmp.join(".gitignore"), "gen/\n!gen/keep.rs\n");
+        write(&tmp.join("gen/keep.rs"), "x\n");
+        write(&tmp.join("gen/drop.rs"), "x\n");
+        let m = IgnoreMatcher::compile(&tmp);
+        assert!(!m.is_ignored(&tmp.join("gen/keep.rs"), false), "whitelisted file un-ignored");
+        assert!(m.is_ignored(&tmp.join("gen/drop.rs"), false), "sibling still ignored");
+        fs::remove_dir_all(&tmp).ok();
+    }
+
+    fn tempdir() -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let id = N.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!("ragrat-ignore-{}-{id}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+}

--- a/crates/rag-rat-core/src/index/ignore_rules.rs
+++ b/crates/rag-rat-core/src/index/ignore_rules.rs
@@ -5,32 +5,50 @@
 //! repo-specific `.gitignore` entries — generated dirs, build outputs, vendored code in
 //! non-standard locations — so they could get indexed and (recursively) watched.
 //!
-//! [`IgnoreMatcher`] compiles the repo's real `.gitignore` rules (root **and** nested gitignores,
-//! via ripgrep's [`ignore`] crate) once, and both the walker and the watcher consult it so a path
-//! one ignores the other also ignores — no drift. The hardcoded names are kept as a **floor**
-//! ([`FLOOR_DIRS`]): they apply even in a non-git tree with no `.gitignore`, and they cover
-//! rag-rat's own index dir (`.rag-rat/`), which must never be indexed regardless of gitignore
-//! contents.
+//! [`IgnoreMatcher`] compiles the repo's real `.gitignore` rules and both the walker and the
+//! watcher consult it, so a path one ignores the other also ignores — no drift. The hardcoded names
+//! are kept as a **floor** ([`FLOOR_DIRS`]): they apply even in a non-git tree with no
+//! `.gitignore`, and they cover rag-rat's own index dir (`.rag-rat/`), which must never be indexed
+//! regardless of gitignore contents.
 //!
-//! **Two git semantics this matcher must get right** (both were P2 review findings — see issue #62
-//! / PR #66):
+//! **Git semantics, correct by construction (issue #62 / PR #66, three rounds of P2 findings).**
+//! We build the matcher on the [`ignore`] crate's native [`Gitignore`] machinery — each
+//! `.gitignore` is compiled by [`GitignoreBuilder`] *anchored at its own directory*, so a
+//! non-anchored pattern (`skip.rs`) scopes to that subtree exactly as Git does. We do **not**
+//! flatten everything into one builder (that would `**/`-prefix nested patterns and leak them
+//! repo-wide). The matcher is a small ancestor-anchored *stack* of these per-directory
+//! `Gitignore`s; precedence and parent-exclusion then fall out of walking a path's ancestors
+//! top-down (see [`IgnoreMatcher::is_ignored`]).
 //!
-//! 1. **All checks run on the path *relative to the repo root*, never on its absolute ancestors.**
-//!    The walker and the watcher feed absolute paths. A repo can live *under* a directory named
-//!    like a floor entry (`/tmp/build/repo`, a checkout below `…/node_modules/…`), so testing floor
-//!    components on the absolute path would mark the whole repo ignored → empty discovery. We strip
-//!    the root first and test only the in-repo remainder.
-//! 2. **Parent exclusion is honored: a file under an ignored directory is *not* re-included** by a
-//!    deeper negation unless the *parent directory itself* is re-included. Git evaluates ancestors
-//!    top-down and stops descending once a directory is excluded; a nested `gen/.gitignore`
-//!    `!keep.rs` under a root-ignored `gen/` does **not** resurrect `gen/keep.rs`. [`is_ignored`]
-//!    walks the relative path root→leaf and short-circuits at the first ignored ancestor, exactly
-//!    as `ignore`'s own `WalkBuilder` does.
+//! The three properties that earned their own findings:
+//!
+//! 1. **Repo-relative checks, never absolute-ancestor.** The walker and watcher feed absolute
+//!    paths. A repo can live *under* a directory named like a floor entry (`/tmp/build/repo`), so
+//!    the floor check runs on the path relative to `config.root`, not on its absolute ancestors.
+//! 2. **Parent exclusion.** A file under an ignored directory is *not* re-included by a deeper
+//!    negation unless the *parent directory itself* is re-included. Git stops descending once a
+//!    directory is excluded; a nested `gen/.gitignore !keep.rs` under a root-ignored `gen/` does
+//!    not resurrect `gen/keep.rs`. [`is_ignored`] walks ancestors root→leaf and short-circuits at
+//!    the first ignored directory, and discovery prunes excluded subtrees so their nested
+//!    `.gitignore` is never even read.
+//! 3. **Ancestor `.gitignore` files above a subdirectory `config.root`.** When `config.root` is a
+//!    subdirectory of a larger Git worktree, the worktree-root `.gitignore` (and every `.gitignore`
+//!    on the chain down to `config.root`) still governs paths under `config.root` — Git applies
+//!    them. The matcher resolves the worktree root (via
+//!    [`crate::index::git_history::worktree_root`], the one place we shell `git rev-parse
+//!    --show-toplevel`) and seeds the stack with that ancestor chain before the in-tree gitignores.
+//!    In a non-git tree the base is just `config.root`.
+//!
+//! **Discovery is scoped to the target trees** (finding from round 3): nested `.gitignore` files
+//! are collected only along the configured `target.directories`, never by recursing the whole
+//! `config.root` into large unindexed sibling directories.
 
 use std::path::{Component, Path, PathBuf};
 
 use ignore::Match;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
+
+use crate::index::git_history;
 
 /// Directory names always skipped, gitignore or not — the floor under the compiled `.gitignore`
 /// rules. `.rag-rat` is rag-rat's own index dir (indexing it would be a feedback loop); `.git` is
@@ -45,57 +63,85 @@ fn is_floor_dir(name: &str) -> bool {
     FLOOR_DIRS.contains(&name)
 }
 
-/// One `.gitignore`, compiled with its own directory as the matching root so its patterns are
-/// scoped to that subtree (gitignore semantics: a non-anchored pattern like `skip.rs` matches only
-/// at or below the file's directory, not the whole repo). `rel_dir` is that directory **relative to
-/// the repo root** — matching strips it off the candidate's repo-relative path before applying the
-/// compiled matcher, keeping every decision in repo-relative space (see [`IgnoreMatcher`] finding
-/// 1).
+/// One `.gitignore`, compiled by [`GitignoreBuilder`] with its own directory as the matching root
+/// so its patterns are scoped to that subtree (gitignore semantics: a non-anchored pattern like
+/// `skip.rs` matches only at or below the file's directory, not the whole repo). `rel_dir` is that
+/// directory **relative to the matcher base** (the worktree root, or `config.root` outside git);
+/// matching strips it off the candidate's base-relative path before applying the compiled matcher.
 #[derive(Debug)]
 struct ScopedGitignore {
-    /// The `.gitignore`'s directory relative to the repo root (empty for the root `.gitignore`);
-    /// the matcher applies only to repo-relative paths under it.
+    /// The `.gitignore`'s directory relative to the matcher base (empty for the base
+    /// `.gitignore`); the matcher applies only to base-relative paths under it.
     rel_dir: PathBuf,
     gitignore: Gitignore,
 }
 
-/// Compiled ignore rules for one repo root: the floor names plus a per-directory stack of compiled
-/// `.gitignore` files (root and nested), each scoped to its own subtree. Built once per walk/watch
-/// and shared so the walker and watcher classify paths identically (issue #62).
+/// Compiled ignore rules for one indexed root: the floor names plus an ancestor-anchored stack of
+/// per-directory [`Gitignore`]s. Built once per walk/watch and shared so the walker and watcher
+/// classify paths identically (issue #62).
 ///
-/// **Why a per-directory stack and not one flat `GitignoreBuilder`:** `GitignoreBuilder::add`
-/// flattens every file's globs into a single matcher rooted at the *builder* root and gives each
-/// non-anchored pattern a `**/` prefix — so a nested `.gitignore` rule `skip.rs` would wrongly
-/// match `skip.rs` anywhere in the repo. Compiling each `.gitignore` against *its own* directory
-/// and only applying it to descendants of that directory is what makes nesting correct.
+/// **Two anchors.** `base` is the matcher's gitignore frame — the Git worktree root when
+/// `config.root` is inside one (so ancestor `.gitignore` rules apply to a subdirectory root,
+/// finding 3), else `config.root`. `root` is `config.root` itself; the floor check and the
+/// "governed at all?" guard run relative to `root`, so a `config.root` living under a floor-named
+/// worktree path (`/tmp/build/repo`) still indexes its own files (finding 1).
 ///
-/// **All matching is repo-relative** (`root` is stripped first), and ancestor directories are
-/// evaluated top-down with parent-exclusion short-circuit — see the module docs and [`is_ignored`].
+/// **Why a per-directory stack and not one flat builder:** `GitignoreBuilder::add` flattens every
+/// file's globs into a single matcher rooted at the *builder* root and `**/`-prefixes non-anchored
+/// patterns — so a nested `.gitignore` rule `skip.rs` would wrongly match `skip.rs` anywhere.
+/// Compiling each `.gitignore` against *its own* directory and only applying it to descendants is
+/// what makes nesting correct.
 #[derive(Debug)]
 pub struct IgnoreMatcher {
-    /// The repo root. Absolute candidate paths are stripped to this before any floor / gitignore
-    /// check so we never test ancestors *above* the repo (finding 1).
+    /// `config.root` — the indexed root. Floor checks and the governed-path guard are relative to
+    /// this (finding 1), independently of the wider `base`.
     root: PathBuf,
-    /// Stack of compiled gitignores, **outermost first** (root before nested). Matching applies
-    /// the ones whose `rel_dir` is an ancestor of the candidate, outermost→innermost, deepest
-    /// decision winning, so a nested whitelist can override an outer ignore — standard git
-    /// precedence.
+    /// The gitignore frame: the Git worktree root if `root` is inside one, else `root`. Every
+    /// `ScopedGitignore.rel_dir` and all gitignore matching is relative to `base` (finding 3).
+    base: PathBuf,
+    /// Stack of compiled gitignores, **outermost first** (worktree-root/ancestor before nested).
+    /// Matching applies the ones whose `rel_dir` is an ancestor of the candidate,
+    /// outermost→innermost, deepest decision winning, so a nested whitelist can override an outer
+    /// ignore — standard git precedence.
     stack: Vec<ScopedGitignore>,
 }
 
 impl IgnoreMatcher {
-    /// Compile the matcher for `root`. Collects every `.gitignore` at or below `root` (skipping the
-    /// floor dirs themselves, and **not descending into a directory an outer rule already
-    /// ignores**, so a nested gitignore can't un-ignore files under an excluded parent —
-    /// finding 2) and compiles each against its own directory. Never fails — a malformed
-    /// gitignore is dropped and matching proceeds with what compiled.
-    pub fn compile(root: &Path) -> Self {
-        let mut matcher = Self { root: root.to_path_buf(), stack: Vec::new() };
-        // Discover and compile gitignores top-down so an outer rule is in `stack` before we decide
-        // whether to descend into a child directory (parent-exclusion pruning, finding 2).
-        matcher.collect_gitignores(root);
-        // Outermost first: shortest rel_dir sorts before its descendants. (collect_gitignores
-        // already pushes top-down, but make the invariant explicit and order-independent.)
+    /// Compile the matcher for `root`, scoping nested-`.gitignore` discovery to `target_dirs`
+    /// (relative to `root`). Resolves the enclosing Git worktree root and seeds the stack with the
+    /// ancestor `.gitignore` chain from there down to `root` (finding 3), then discovers nested
+    /// gitignores only along the target trees (round-3 scoping fix) — never recursing the whole
+    /// `root` into unindexed siblings. Never fails — a malformed gitignore is dropped and matching
+    /// proceeds with what compiled.
+    pub fn compile(root: &Path, target_dirs: &[PathBuf]) -> Self {
+        // The gitignore frame: the worktree root if `root` is inside a Git worktree, else `root`.
+        // Only accept it when `root` is actually a descendant (or equal) — a `--show-toplevel`
+        // result we can't relate to `root` is unusable as a prefix-stripping base.
+        let base = git_history::worktree_root(root)
+            .filter(|wt| root.starts_with(wt))
+            .unwrap_or_else(|| root.to_path_buf());
+
+        let mut matcher = Self { root: root.to_path_buf(), base, stack: Vec::new() };
+
+        // (1) Ancestor chain: every `.gitignore` from the worktree base down to (and including)
+        // `root`, so worktree-root rules govern a subdirectory `config.root` (finding 3).
+        matcher.collect_ancestor_gitignores();
+
+        // (2) Nested gitignores, but ONLY along the configured target directories (round-3 scoping
+        // fix) — not a recursive sweep of the whole `root`. Each target dir is walked top-down with
+        // parent-exclusion pruning (finding 2). Dedup so a `.gitignore` under overlapping target
+        // dirs is compiled once.
+        let scan_roots = if target_dirs.is_empty() {
+            vec![root.to_path_buf()]
+        } else {
+            target_dirs.iter().map(|dir| root.join(dir)).collect()
+        };
+        for scan_root in scan_roots {
+            matcher.collect_nested_gitignores(&scan_root);
+        }
+
+        // Outermost first: shortest rel_dir sorts before its descendants, making the precedence
+        // walk in `decision_for` order-independent.
         matcher.stack.sort_by_key(|scoped| scoped.rel_dir.as_os_str().len());
         matcher
     }
@@ -103,20 +149,27 @@ impl IgnoreMatcher {
     /// Whether `path` is ignored. `is_dir` must say whether the path is a directory — gitignore
     /// distinguishes `foo/` (dir-only) from `foo`.
     ///
-    /// The candidate is first made **repo-relative** by stripping `root`; a path outside the repo
-    /// is not governed by these rules (returns `false`). A floor-dir name among the *relative*
-    /// components ignores it unconditionally (the floor can't be whitelisted away). Otherwise each
-    /// ancestor directory is evaluated root→leaf against the scoped `.gitignore` stack: the first
-    /// ancestor that resolves to *ignored* makes the whole path ignored (git parent exclusion — a
-    /// deeper `!negation` cannot resurrect a file under an excluded directory). A whitelisted
-    /// ancestor clears the ignored state for that level so its subtree is re-evaluated.
+    /// A path outside `config.root` is not governed (returns `false`). A floor-dir name among the
+    /// components relative to `config.root` ignores it unconditionally (the floor can't be
+    /// whitelisted away — finding 1). Otherwise each ancestor directory, walked **relative to the
+    /// matcher base** (which may sit above `config.root`), is evaluated root→leaf against the
+    /// scoped `.gitignore` stack: the first ancestor that resolves to *ignored* makes the whole
+    /// path ignored (git parent exclusion — a deeper `!negation` cannot resurrect a file under
+    /// an excluded directory). A whitelisted ancestor clears the ignored state for that level.
     pub fn is_ignored(&self, path: &Path, is_dir: bool) -> bool {
-        let Ok(rel) = path.strip_prefix(&self.root) else {
-            return false; // outside the repo root — not governed by our rules.
+        // Governed only inside config.root; the floor is checked on the config.root-relative path
+        // so a root under a floor-named ancestor still indexes (finding 1).
+        let Ok(rel_to_root) = path.strip_prefix(&self.root) else {
+            return false; // outside the indexed root — not governed by our rules.
         };
-        if rel_contains_floor_dir(rel) {
+        if rel_contains_floor_dir(rel_to_root) {
             return true;
         }
+        // Gitignore matching is base-relative so ancestor `.gitignore`s above config.root apply
+        // (finding 3). `root` is always under `base`, so this strip succeeds.
+        let Ok(rel) = path.strip_prefix(&self.base) else {
+            return false;
+        };
         // Walk ancestor prefixes root→leaf. `ignored` carries the inherited decision from shallower
         // levels; once a directory level lands on `Ignore`, every deeper level inherits it unless a
         // level is explicitly whitelisted (which clears it for that and deeper levels).
@@ -125,7 +178,7 @@ impl IgnoreMatcher {
         let mut components = rel.components().peekable();
         while let Some(component) = components.next() {
             let Component::Normal(name) = component else {
-                continue; // skip `.`/`..`/prefix/root — repo-relative paths shouldn't have them.
+                continue; // skip `.`/`..`/prefix/root — base-relative paths shouldn't have them.
             };
             prefix.push(name);
             // The leaf uses the caller's `is_dir`; every intermediate prefix is a directory.
@@ -145,10 +198,11 @@ impl IgnoreMatcher {
         ignored
     }
 
-    /// The combined gitignore decision for one repo-relative path at one level, applying every
+    /// The combined gitignore decision for one base-relative path at one level, applying every
     /// scoped gitignore whose `rel_dir` is an ancestor, outermost→innermost (deepest wins). Uses
-    /// `matched` (not `matched_path_or_any_parents`): the caller ([`is_ignored`]) already walks
-    /// ancestors top-down, so per-level leaf matching is correct and avoids double parent-walking.
+    /// `Gitignore::matched` (leaf-only, not `matched_path_or_any_parents`): the caller
+    /// ([`is_ignored`]) already walks ancestors top-down, so per-level leaf matching is correct and
+    /// avoids double parent-walking.
     fn decision_for(&self, rel: &Path, is_dir: bool) -> Match<()> {
         let mut decision = Match::None;
         for scoped in &self.stack {
@@ -167,22 +221,38 @@ impl IgnoreMatcher {
         decision
     }
 
-    /// Recursively collect + compile `.gitignore` files at or below `dir`, pruning floor dirs and —
-    /// crucially — any directory an already-collected outer rule ignores (finding 2: don't descend
-    /// into an excluded directory to read a nested gitignore that could wrongly un-ignore its
-    /// contents). `dir` is absolute; `self.stack` is grown in place so outer rules govern the
-    /// descent decision for their children.
-    fn collect_gitignores(&mut self, dir: &Path) {
-        if dir.join(".gitignore").is_file() {
-            let rel_dir = dir.strip_prefix(&self.root).unwrap_or(Path::new("")).to_path_buf();
-            let mut builder = GitignoreBuilder::new(dir);
-            // `add` returns an Option<Error> for partial-parse problems; ignore it (best-effort,
-            // matching ripgrep's own tolerance) rather than failing the whole walk.
-            let _ = builder.add(dir.join(".gitignore"));
-            if let Ok(gitignore) = builder.build() {
-                self.stack.push(ScopedGitignore { rel_dir, gitignore });
-            }
+    /// Seed the stack with the ancestor `.gitignore` chain from the matcher `base` (worktree root)
+    /// down to and including `root`. These are the rules Git applies to paths under a subdirectory
+    /// `config.root` (finding 3). No-op when `base == root` (the chain is just `root` itself, which
+    /// the nested scan also covers — dedup in [`push_gitignore_in`] keeps it single).
+    fn collect_ancestor_gitignores(&mut self) {
+        // Build the list of directories from base down to root: base, base/a, base/a/b, …, root.
+        let Ok(rel) = self.root.strip_prefix(&self.base) else {
+            return;
+        };
+        // Collect the component names first so `self` isn't borrowed across the mutating pushes.
+        let names: Vec<PathBuf> = rel
+            .components()
+            .filter_map(|component| match component {
+                Component::Normal(name) => Some(PathBuf::from(name)),
+                _ => None,
+            })
+            .collect();
+        let mut dir = self.base.clone();
+        self.push_gitignore_in(&dir);
+        for name in names {
+            dir.push(name);
+            self.push_gitignore_in(&dir);
         }
+    }
+
+    /// Recursively collect + compile nested `.gitignore` files at or below `dir`, pruning floor
+    /// dirs and — crucially — any directory an already-collected outer rule ignores (finding 2:
+    /// don't descend into an excluded directory to read a nested gitignore that could wrongly
+    /// un-ignore its contents). `dir` is absolute; the stack is grown in place so outer rules
+    /// govern the descent decision for their children.
+    fn collect_nested_gitignores(&mut self, dir: &Path) {
+        self.push_gitignore_in(dir);
         let Ok(entries) = std::fs::read_dir(dir) else {
             return;
         };
@@ -204,12 +274,35 @@ impl IgnoreMatcher {
             if self.is_ignored(&child, true) {
                 continue;
             }
-            self.collect_gitignores(&child);
+            self.collect_nested_gitignores(&child);
+        }
+    }
+
+    /// Compile the `.gitignore` directly inside `dir` (if any) anchored at `dir`, and push it to
+    /// the stack with `rel_dir` relative to `base`. Idempotent: a `.gitignore` already in the
+    /// stack (the ancestor chain and the nested scan can overlap at `root`) is not added twice.
+    fn push_gitignore_in(&mut self, dir: &Path) {
+        let Ok(rel_dir) = dir.strip_prefix(&self.base) else {
+            return;
+        };
+        let rel_dir = rel_dir.to_path_buf();
+        if self.stack.iter().any(|scoped| scoped.rel_dir == rel_dir) {
+            return; // already compiled (ancestor chain ↔ nested scan overlap at `root`).
+        }
+        if !dir.join(".gitignore").is_file() {
+            return;
+        }
+        let mut builder = GitignoreBuilder::new(dir);
+        // `add` returns an Option<Error> for partial-parse problems; ignore it (best-effort,
+        // matching ripgrep's own tolerance) rather than failing the whole walk.
+        let _ = builder.add(dir.join(".gitignore"));
+        if let Ok(gitignore) = builder.build() {
+            self.stack.push(ScopedGitignore { rel_dir, gitignore });
         }
     }
 }
 
-/// Whether any component of the (repo-relative) `rel` path is a floor directory name.
+/// Whether any component of the (`config.root`-relative) `rel` path is a floor directory name.
 fn rel_contains_floor_dir(rel: &Path) -> bool {
     rel.components().any(|component| component.as_os_str().to_str().is_some_and(is_floor_dir))
 }
@@ -227,10 +320,27 @@ mod tests {
         fs::write(path, contents).unwrap();
     }
 
+    /// Compile scoping discovery to the whole root (the common case in these unit tests).
+    fn compile(root: &Path) -> IgnoreMatcher {
+        IgnoreMatcher::compile(root, &[])
+    }
+
+    /// Initialize a real (empty) Git repo at `dir` so worktree-root resolution returns `dir`. Used
+    /// by the ancestor-chain test; the others don't need git (base falls back to `root`).
+    fn git_init(dir: &Path) {
+        let ok = std::process::Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(dir)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        assert!(ok, "git init failed (git must be on PATH for this test)");
+    }
+
     #[test]
     fn floor_dirs_ignored_without_any_gitignore() {
         let tmp = tempdir();
-        let m = IgnoreMatcher::compile(&tmp);
+        let m = compile(&tmp);
         assert!(m.is_ignored(&tmp.join("target"), true));
         assert!(m.is_ignored(&tmp.join("target/debug/foo.rs"), false));
         assert!(m.is_ignored(&tmp.join(".rag-rat"), true));
@@ -246,7 +356,7 @@ mod tests {
         write(&tmp.join("src/lib.rs"), "fn a() {}\n");
         write(&tmp.join("generated/out.rs"), "fn b() {}\n");
         write(&tmp.join("src/old.bak"), "x\n");
-        let m = IgnoreMatcher::compile(&tmp);
+        let m = compile(&tmp);
         assert!(m.is_ignored(&tmp.join("generated"), true), "gitignored dir");
         assert!(m.is_ignored(&tmp.join("generated/out.rs"), false), "file under gitignored dir");
         assert!(m.is_ignored(&tmp.join("src/old.bak"), false), "gitignored glob");
@@ -261,7 +371,7 @@ mod tests {
         write(&tmp.join("sub/.gitignore"), "vendor.rs\n");
         write(&tmp.join("sub/vendor.rs"), "x\n");
         write(&tmp.join("vendor.rs"), "x\n");
-        let m = IgnoreMatcher::compile(&tmp);
+        let m = compile(&tmp);
         assert!(m.is_ignored(&tmp.join("sub/vendor.rs"), false), "nested rule applies in subtree");
         assert!(
             !m.is_ignored(&tmp.join("vendor.rs"), false),
@@ -276,7 +386,7 @@ mod tests {
         write(&tmp.join(".gitignore"), "build/\n!build/keep.rs\n");
         write(&tmp.join("build/keep.rs"), "x\n");
         write(&tmp.join("build/drop.rs"), "x\n");
-        let m = IgnoreMatcher::compile(&tmp);
+        let m = compile(&tmp);
         // NOTE: `build` is also a FLOOR dir, so the floor wins regardless of negation — assert that
         // the floor is unconditional. (A non-floor whitelisted dir is covered by the next test.)
         assert!(
@@ -295,7 +405,7 @@ mod tests {
         write(&tmp.join(".gitignore"), "gen/\n!gen/\ngen/skip/\n");
         write(&tmp.join("gen/a.rs"), "x\n");
         write(&tmp.join("gen/skip/b.rs"), "x\n");
-        let m = IgnoreMatcher::compile(&tmp);
+        let m = compile(&tmp);
         assert!(!m.is_ignored(&tmp.join("gen/a.rs"), false), "re-included dir's file un-ignored");
         assert!(m.is_ignored(&tmp.join("gen/skip/b.rs"), false), "re-ignored subdir still out");
         fs::remove_dir_all(&tmp).ok();
@@ -311,7 +421,7 @@ mod tests {
         write(&tmp.join("gen/.gitignore"), "!keep.rs\n");
         write(&tmp.join("gen/keep.rs"), "x\n");
         write(&tmp.join("gen/drop.rs"), "x\n");
-        let m = IgnoreMatcher::compile(&tmp);
+        let m = compile(&tmp);
         assert!(
             m.is_ignored(&tmp.join("gen/keep.rs"), false),
             "nested negation under an ignored parent must NOT re-include",
@@ -324,13 +434,12 @@ mod tests {
     fn flat_negation_unignores_non_floor_file() {
         // Distinct from the nested case: a SINGLE gitignore with `gen/` + `!gen/keep.rs` does NOT
         // re-include either, because git can't reach inside an excluded directory even from the
-        // same file. Both stay ignored. (This is the git-correct behavior; the pre-fix stack
-        // wrongly un-ignored here.)
+        // same file. Both stay ignored. (This is the git-correct behavior.)
         let tmp = tempdir();
         write(&tmp.join(".gitignore"), "gen/\n!gen/keep.rs\n");
         write(&tmp.join("gen/keep.rs"), "x\n");
         write(&tmp.join("gen/drop.rs"), "x\n");
-        let m = IgnoreMatcher::compile(&tmp);
+        let m = compile(&tmp);
         assert!(m.is_ignored(&tmp.join("gen/keep.rs"), false), "no reinclude under excluded dir");
         assert!(m.is_ignored(&tmp.join("gen/drop.rs"), false), "sibling still ignored");
         fs::remove_dir_all(&tmp).ok();
@@ -345,7 +454,7 @@ mod tests {
         let root = outer.join("my-repo");
         write(&root.join("src/lib.rs"), "fn a() {}\n");
         write(&root.join("target/debug/built.rs"), "fn b() {}\n");
-        let m = IgnoreMatcher::compile(&root);
+        let m = compile(&root);
         assert!(
             !m.is_ignored(&root.join("src/lib.rs"), false),
             "repo under a floor-named ancestor still indexes its files",
@@ -357,12 +466,72 @@ mod tests {
         fs::remove_dir_all(outer.parent().unwrap()).ok();
     }
 
+    #[test]
+    fn worktree_root_gitignore_governs_subdirectory_config_root() {
+        // FINDING 3 (round 3): `config.root` is a subdirectory (`crates`) of a larger Git worktree.
+        // The worktree-root `.gitignore` rules Git would apply to paths under that subdirectory
+        // must be honored — files Git ignores must not be indexed.
+        let wt = tempdir();
+        git_init(&wt);
+        // Worktree-root .gitignore ignores every `*.gen.rs` and the `vendored/` dir, repo-wide.
+        write(&wt.join(".gitignore"), "*.gen.rs\nvendored/\n");
+        let sub = wt.join("crates");
+        write(&sub.join("lib.rs"), "fn a() {}\n");
+        write(&sub.join("schema.gen.rs"), "fn g() {}\n");
+        write(&sub.join("vendored/dep.rs"), "fn v() {}\n");
+
+        // Compile with `config.root = crates` — the ancestor chain must pull in the worktree-root
+        // `.gitignore` even though it sits ABOVE config.root.
+        let m = IgnoreMatcher::compile(&sub, &[PathBuf::from(".")]);
+        assert!(!m.is_ignored(&sub.join("lib.rs"), false), "normal source under subdir indexes");
+        assert!(
+            m.is_ignored(&sub.join("schema.gen.rs"), false),
+            "worktree-root glob applies under the subdir config.root (finding 3)",
+        );
+        assert!(
+            m.is_ignored(&sub.join("vendored/dep.rs"), false),
+            "worktree-root dir rule applies under the subdir config.root (finding 3)",
+        );
+        fs::remove_dir_all(&wt).ok();
+    }
+
+    #[test]
+    fn discovery_does_not_walk_unignored_sibling_outside_targets() {
+        // ROUND 3 (scoping): a large unignored sibling dir OUTSIDE the configured target trees must
+        // not be scanned for nested `.gitignore`s. We assert by behavior: a nested `.gitignore` in
+        // the sibling is never compiled, so it has no effect on classification — and, conversely, a
+        // nested `.gitignore` INSIDE the target tree IS picked up.
+        let root = tempdir();
+        // Target tree: `src`. Sibling tree: `huge` (not a target).
+        write(&root.join("src/.gitignore"), "skip.rs\n");
+        write(&root.join("src/skip.rs"), "x\n");
+        // Sibling's nested gitignore would, if scanned, ignore `marker.rs`. Scoped discovery must
+        // NOT read it, so `marker.rs` stays unignored.
+        write(&root.join("huge/.gitignore"), "marker.rs\n");
+        write(&root.join("huge/marker.rs"), "x\n");
+
+        let m = IgnoreMatcher::compile(&root, &[PathBuf::from("src")]);
+        // In-target nested gitignore is honored.
+        assert!(
+            m.is_ignored(&root.join("src/skip.rs"), false),
+            "in-target nested gitignore honored"
+        );
+        // Out-of-target sibling's nested gitignore was never compiled → no effect.
+        assert!(
+            !m.is_ignored(&root.join("huge/marker.rs"), false),
+            "sibling outside target trees is not scanned for nested gitignores (scoping)",
+        );
+        fs::remove_dir_all(&root).ok();
+    }
+
     fn tempdir() -> std::path::PathBuf {
         use std::sync::atomic::{AtomicU64, Ordering};
         static N: AtomicU64 = AtomicU64::new(0);
         let id = N.fetch_add(1, Ordering::Relaxed);
         let dir = std::env::temp_dir().join(format!("ragrat-ignore-{}-{id}", std::process::id()));
         fs::create_dir_all(&dir).unwrap();
-        dir
+        // Canonicalize so the absolute paths we build match what worktree-root resolution returns
+        // (macOS /tmp is a symlink to /private/tmp; git reports the canonical form).
+        dir.canonicalize().unwrap_or(dir)
     }
 }

--- a/crates/rag-rat-core/src/index/ignore_rules.rs
+++ b/crates/rag-rat-core/src/index/ignore_rules.rs
@@ -11,8 +11,23 @@
 //! ([`FLOOR_DIRS`]): they apply even in a non-git tree with no `.gitignore`, and they cover
 //! rag-rat's own index dir (`.rag-rat/`), which must never be indexed regardless of gitignore
 //! contents.
+//!
+//! **Two git semantics this matcher must get right** (both were P2 review findings — see issue #62
+//! / PR #66):
+//!
+//! 1. **All checks run on the path *relative to the repo root*, never on its absolute ancestors.**
+//!    The walker and the watcher feed absolute paths. A repo can live *under* a directory named
+//!    like a floor entry (`/tmp/build/repo`, a checkout below `…/node_modules/…`), so testing floor
+//!    components on the absolute path would mark the whole repo ignored → empty discovery. We strip
+//!    the root first and test only the in-repo remainder.
+//! 2. **Parent exclusion is honored: a file under an ignored directory is *not* re-included** by a
+//!    deeper negation unless the *parent directory itself* is re-included. Git evaluates ancestors
+//!    top-down and stops descending once a directory is excluded; a nested `gen/.gitignore`
+//!    `!keep.rs` under a root-ignored `gen/` does **not** resurrect `gen/keep.rs`. [`is_ignored`]
+//!    walks the relative path root→leaf and short-circuits at the first ignored ancestor, exactly
+//!    as `ignore`'s own `WalkBuilder` does.
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use ignore::Match;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
@@ -32,11 +47,15 @@ fn is_floor_dir(name: &str) -> bool {
 
 /// One `.gitignore`, compiled with its own directory as the matching root so its patterns are
 /// scoped to that subtree (gitignore semantics: a non-anchored pattern like `skip.rs` matches only
-/// at or below the file's directory, not the whole repo).
+/// at or below the file's directory, not the whole repo). `rel_dir` is that directory **relative to
+/// the repo root** — matching strips it off the candidate's repo-relative path before applying the
+/// compiled matcher, keeping every decision in repo-relative space (see [`IgnoreMatcher`] finding
+/// 1).
 #[derive(Debug)]
 struct ScopedGitignore {
-    /// Absolute directory the `.gitignore` lives in; the matcher applies only to paths under it.
-    dir: PathBuf,
+    /// The `.gitignore`'s directory relative to the repo root (empty for the root `.gitignore`);
+    /// the matcher applies only to repo-relative paths under it.
+    rel_dir: PathBuf,
     gitignore: Gitignore,
 }
 
@@ -49,83 +68,123 @@ struct ScopedGitignore {
 /// non-anchored pattern a `**/` prefix — so a nested `.gitignore` rule `skip.rs` would wrongly
 /// match `skip.rs` anywhere in the repo. Compiling each `.gitignore` against *its own* directory
 /// and only applying it to descendants of that directory is what makes nesting correct.
+///
+/// **All matching is repo-relative** (`root` is stripped first), and ancestor directories are
+/// evaluated top-down with parent-exclusion short-circuit — see the module docs and [`is_ignored`].
 #[derive(Debug)]
 pub struct IgnoreMatcher {
+    /// The repo root. Absolute candidate paths are stripped to this before any floor / gitignore
+    /// check so we never test ancestors *above* the repo (finding 1).
+    root: PathBuf,
     /// Stack of compiled gitignores, **outermost first** (root before nested). Matching applies
-    /// them in order and lets the deepest matching one win (last write), so a nested whitelist can
-    /// override an outer ignore — standard git precedence.
+    /// the ones whose `rel_dir` is an ancestor of the candidate, outermost→innermost, deepest
+    /// decision winning, so a nested whitelist can override an outer ignore — standard git
+    /// precedence.
     stack: Vec<ScopedGitignore>,
 }
 
 impl IgnoreMatcher {
     /// Compile the matcher for `root`. Collects every `.gitignore` at or below `root` (skipping the
-    /// floor dirs themselves, so we never descend into `target/` to read its vendored gitignores)
-    /// and compiles each against its own directory. Never fails — a malformed gitignore is dropped
-    /// and matching proceeds with what compiled.
+    /// floor dirs themselves, and **not descending into a directory an outer rule already
+    /// ignores**, so a nested gitignore can't un-ignore files under an excluded parent —
+    /// finding 2) and compiles each against its own directory. Never fails — a malformed
+    /// gitignore is dropped and matching proceeds with what compiled.
     pub fn compile(root: &Path) -> Self {
-        let mut stack = Vec::new();
-        for dir in collect_gitignore_dirs(root) {
-            let mut builder = GitignoreBuilder::new(&dir);
-            // `add` returns an Option<Error> for partial-parse problems; ignore it (best-effort,
-            // matching ripgrep's own tolerance) rather than failing the whole walk.
-            let _ = builder.add(dir.join(".gitignore"));
-            if let Ok(gitignore) = builder.build() {
-                stack.push(ScopedGitignore { dir, gitignore });
-            }
-        }
-        // Outermost first: shortest dir path sorts before its descendants.
-        stack.sort_by_key(|scoped| scoped.dir.as_os_str().len());
-        Self { stack }
+        let mut matcher = Self { root: root.to_path_buf(), stack: Vec::new() };
+        // Discover and compile gitignores top-down so an outer rule is in `stack` before we decide
+        // whether to descend into a child directory (parent-exclusion pruning, finding 2).
+        matcher.collect_gitignores(root);
+        // Outermost first: shortest rel_dir sorts before its descendants. (collect_gitignores
+        // already pushes top-down, but make the invariant explicit and order-independent.)
+        matcher.stack.sort_by_key(|scoped| scoped.rel_dir.as_os_str().len());
+        matcher
     }
 
     /// Whether `path` is ignored. `is_dir` must say whether the path is a directory — gitignore
-    /// distinguishes `foo/` (dir-only) from `foo`. A floor-dir name anywhere in the path ignores it
-    /// unconditionally (the floor can't be whitelisted away); otherwise each `.gitignore` whose
-    /// directory is an ancestor is applied outermost→innermost and the last decision wins, so a
-    /// nested `!pattern` whitelist overrides an outer ignore (standard git precedence).
+    /// distinguishes `foo/` (dir-only) from `foo`.
+    ///
+    /// The candidate is first made **repo-relative** by stripping `root`; a path outside the repo
+    /// is not governed by these rules (returns `false`). A floor-dir name among the *relative*
+    /// components ignores it unconditionally (the floor can't be whitelisted away). Otherwise each
+    /// ancestor directory is evaluated root→leaf against the scoped `.gitignore` stack: the first
+    /// ancestor that resolves to *ignored* makes the whole path ignored (git parent exclusion — a
+    /// deeper `!negation` cannot resurrect a file under an excluded directory). A whitelisted
+    /// ancestor clears the ignored state for that level so its subtree is re-evaluated.
     pub fn is_ignored(&self, path: &Path, is_dir: bool) -> bool {
-        if path_contains_floor_dir(path) {
+        let Ok(rel) = path.strip_prefix(&self.root) else {
+            return false; // outside the repo root — not governed by our rules.
+        };
+        if rel_contains_floor_dir(rel) {
             return true;
         }
+        // Walk ancestor prefixes root→leaf. `ignored` carries the inherited decision from shallower
+        // levels; once a directory level lands on `Ignore`, every deeper level inherits it unless a
+        // level is explicitly whitelisted (which clears it for that and deeper levels).
         let mut ignored = false;
-        for scoped in &self.stack {
-            let Ok(rel) = path.strip_prefix(&scoped.dir) else {
-                continue; // gitignore in a sibling/unrelated subtree — doesn't govern this path.
+        let mut prefix = PathBuf::new();
+        let mut components = rel.components().peekable();
+        while let Some(component) = components.next() {
+            let Component::Normal(name) = component else {
+                continue; // skip `.`/`..`/prefix/root — repo-relative paths shouldn't have them.
             };
-            if rel.as_os_str().is_empty() {
-                continue; // the gitignore's own directory.
-            }
-            // `matched_path_or_any_parents` so a file under an ignored *directory* (`generated/`
-            // ignores `generated/out.rs`) is caught — plain `matched` only tests the leaf. It walks
-            // the path's parents within this gitignore's scope and returns the closest decision.
-            match scoped.gitignore.matched_path_or_any_parents(rel, is_dir) {
+            prefix.push(name);
+            // The leaf uses the caller's `is_dir`; every intermediate prefix is a directory.
+            let is_last = components.peek().is_none();
+            let level_is_dir = if is_last { is_dir } else { true };
+            match self.decision_for(&prefix, level_is_dir) {
                 Match::Ignore(_) => ignored = true,
                 Match::Whitelist(_) => ignored = false,
                 Match::None => {},
             }
+            // Parent exclusion: an ignored *directory* prunes its whole subtree — stop descending.
+            // (If this was the leaf, the loop ends anyway.) A deeper negation can't reach inside.
+            if ignored && level_is_dir && !is_last {
+                return true;
+            }
         }
         ignored
     }
-}
 
-/// Whether any component of `path` is a floor directory name.
-fn path_contains_floor_dir(path: &Path) -> bool {
-    path.components().any(|component| component.as_os_str().to_str().is_some_and(is_floor_dir))
-}
-
-/// Collect directories at or below `root` that contain a `.gitignore`, **without** descending into
-/// floor dirs (so we don't walk `target/`/`node_modules/` just to read gitignores the floor already
-/// excludes). Returns directories (not the `.gitignore` paths) so each can be compiled against its
-/// own root for correct nested scoping.
-fn collect_gitignore_dirs(root: &Path) -> Vec<PathBuf> {
-    let mut found = Vec::new();
-    let mut stack = vec![root.to_path_buf()];
-    while let Some(dir) = stack.pop() {
-        if dir.join(".gitignore").is_file() {
-            found.push(dir.clone());
+    /// The combined gitignore decision for one repo-relative path at one level, applying every
+    /// scoped gitignore whose `rel_dir` is an ancestor, outermost→innermost (deepest wins). Uses
+    /// `matched` (not `matched_path_or_any_parents`): the caller ([`is_ignored`]) already walks
+    /// ancestors top-down, so per-level leaf matching is correct and avoids double parent-walking.
+    fn decision_for(&self, rel: &Path, is_dir: bool) -> Match<()> {
+        let mut decision = Match::None;
+        for scoped in &self.stack {
+            let Ok(scoped_rel) = rel.strip_prefix(&scoped.rel_dir) else {
+                continue; // gitignore in a sibling/unrelated subtree — doesn't govern this path.
+            };
+            if scoped_rel.as_os_str().is_empty() {
+                continue; // the gitignore's own directory.
+            }
+            match scoped.gitignore.matched(scoped_rel, is_dir) {
+                Match::Ignore(_) => decision = Match::Ignore(()),
+                Match::Whitelist(_) => decision = Match::Whitelist(()),
+                Match::None => {},
+            }
         }
-        let Ok(entries) = std::fs::read_dir(&dir) else {
-            continue;
+        decision
+    }
+
+    /// Recursively collect + compile `.gitignore` files at or below `dir`, pruning floor dirs and —
+    /// crucially — any directory an already-collected outer rule ignores (finding 2: don't descend
+    /// into an excluded directory to read a nested gitignore that could wrongly un-ignore its
+    /// contents). `dir` is absolute; `self.stack` is grown in place so outer rules govern the
+    /// descent decision for their children.
+    fn collect_gitignores(&mut self, dir: &Path) {
+        if dir.join(".gitignore").is_file() {
+            let rel_dir = dir.strip_prefix(&self.root).unwrap_or(Path::new("")).to_path_buf();
+            let mut builder = GitignoreBuilder::new(dir);
+            // `add` returns an Option<Error> for partial-parse problems; ignore it (best-effort,
+            // matching ripgrep's own tolerance) rather than failing the whole walk.
+            let _ = builder.add(dir.join(".gitignore"));
+            if let Ok(gitignore) = builder.build() {
+                self.stack.push(ScopedGitignore { rel_dir, gitignore });
+            }
+        }
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
         };
         for entry in entries.flatten() {
             let Ok(file_type) = entry.file_type() else {
@@ -138,10 +197,21 @@ fn collect_gitignore_dirs(root: &Path) -> Vec<PathBuf> {
             if name.to_str().is_some_and(is_floor_dir) {
                 continue;
             }
-            stack.push(entry.path());
+            let child = entry.path();
+            // Don't descend into a directory an outer rule already ignores — a nested gitignore
+            // there must not re-include files under an excluded parent (finding 2). We classify the
+            // child as a directory against the rules collected so far.
+            if self.is_ignored(&child, true) {
+                continue;
+            }
+            self.collect_gitignores(&child);
         }
     }
-    found
+}
+
+/// Whether any component of the (repo-relative) `rel` path is a floor directory name.
+fn rel_contains_floor_dir(rel: &Path) -> bool {
+    rel.components().any(|component| component.as_os_str().to_str().is_some_and(is_floor_dir))
 }
 
 #[cfg(test)]
@@ -217,15 +287,74 @@ mod tests {
     }
 
     #[test]
-    fn negation_unignores_non_floor_dir() {
+    fn negation_unignores_whitelisted_dir_subtree() {
+        // git can re-include a file under a directory ONLY if the directory itself is whitelisted.
+        // `gen/` ignored + `!gen/` re-included + `gen/skip/` re-ignored: `gen/a.rs` is back,
+        // `gen/skip/b.rs` is out.
+        let tmp = tempdir();
+        write(&tmp.join(".gitignore"), "gen/\n!gen/\ngen/skip/\n");
+        write(&tmp.join("gen/a.rs"), "x\n");
+        write(&tmp.join("gen/skip/b.rs"), "x\n");
+        let m = IgnoreMatcher::compile(&tmp);
+        assert!(!m.is_ignored(&tmp.join("gen/a.rs"), false), "re-included dir's file un-ignored");
+        assert!(m.is_ignored(&tmp.join("gen/skip/b.rs"), false), "re-ignored subdir still out");
+        fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn nested_negation_under_ignored_parent_stays_ignored() {
+        // FINDING 2: a nested `.gitignore` inside a directory ignored by an OUTER rule must NOT
+        // re-include files. Git stops descending at the excluded `gen/`, so `gen/.gitignore`'s
+        // `!keep.rs` is never consulted — `gen/keep.rs` stays ignored.
+        let tmp = tempdir();
+        write(&tmp.join(".gitignore"), "gen/\n");
+        write(&tmp.join("gen/.gitignore"), "!keep.rs\n");
+        write(&tmp.join("gen/keep.rs"), "x\n");
+        write(&tmp.join("gen/drop.rs"), "x\n");
+        let m = IgnoreMatcher::compile(&tmp);
+        assert!(
+            m.is_ignored(&tmp.join("gen/keep.rs"), false),
+            "nested negation under an ignored parent must NOT re-include",
+        );
+        assert!(m.is_ignored(&tmp.join("gen/drop.rs"), false), "sibling under ignored parent out");
+        fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn flat_negation_unignores_non_floor_file() {
+        // Distinct from the nested case: a SINGLE gitignore with `gen/` + `!gen/keep.rs` does NOT
+        // re-include either, because git can't reach inside an excluded directory even from the
+        // same file. Both stay ignored. (This is the git-correct behavior; the pre-fix stack
+        // wrongly un-ignored here.)
         let tmp = tempdir();
         write(&tmp.join(".gitignore"), "gen/\n!gen/keep.rs\n");
         write(&tmp.join("gen/keep.rs"), "x\n");
         write(&tmp.join("gen/drop.rs"), "x\n");
         let m = IgnoreMatcher::compile(&tmp);
-        assert!(!m.is_ignored(&tmp.join("gen/keep.rs"), false), "whitelisted file un-ignored");
+        assert!(m.is_ignored(&tmp.join("gen/keep.rs"), false), "no reinclude under excluded dir");
         assert!(m.is_ignored(&tmp.join("gen/drop.rs"), false), "sibling still ignored");
         fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn repo_root_under_floor_named_ancestor_still_indexes() {
+        // FINDING 1: the repo lives under a directory named like a floor entry (`build`). The floor
+        // check must run on the path RELATIVE to the root, never on the absolute ancestors — so the
+        // repo's own files are still indexed.
+        let outer = tempdir().join("build");
+        let root = outer.join("my-repo");
+        write(&root.join("src/lib.rs"), "fn a() {}\n");
+        write(&root.join("target/debug/built.rs"), "fn b() {}\n");
+        let m = IgnoreMatcher::compile(&root);
+        assert!(
+            !m.is_ignored(&root.join("src/lib.rs"), false),
+            "repo under a floor-named ancestor still indexes its files",
+        );
+        // The repo's OWN `target/` (a relative floor component) is still skipped.
+        assert!(m.is_ignored(&root.join("target/debug/built.rs"), false), "in-repo floor skipped");
+        // A path outside the repo root is simply not governed (not ignored) by our rules.
+        assert!(!m.is_ignored(&outer.join("sibling.rs"), false), "outside-root path not governed");
+        fs::remove_dir_all(outer.parent().unwrap()).ok();
     }
 
     fn tempdir() -> std::path::PathBuf {

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -623,9 +623,11 @@ fn collect_index_files(config: &Config) -> anyhow::Result<Vec<IndexFile>> {
     let mut seen = BTreeSet::new();
     let mut files = Vec::new();
 
-    // Compile the repo's `.gitignore` rules (root + nested) once, shared across targets, so the
-    // walker skips the same paths the watcher's `event_is_relevant` will (issue #62).
-    let ignore = ignore_rules::IgnoreMatcher::compile(&config.root);
+    // Compile the repo's `.gitignore` rules (ancestor chain + nested-along-target-trees) once,
+    // shared across targets, so the walker skips the same paths the watcher's `event_is_relevant`
+    // will (issue #62). Nested-gitignore discovery is scoped to the configured target directories
+    // so a large unindexed sibling is never walked (round-3 finding).
+    let ignore = ignore_rules::IgnoreMatcher::compile(&config.root, &config.target_directories());
     for target in targets {
         for file in walker::walk_target(&config.root, target, &ignore)? {
             let relative_path = file.strip_prefix(&config.root)?.to_path_buf();

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -4,6 +4,7 @@ pub mod chunker;
 pub mod edges;
 pub mod git_history;
 pub mod github;
+pub mod ignore_rules;
 pub mod parser;
 pub mod schema;
 pub mod symbols;
@@ -622,8 +623,11 @@ fn collect_index_files(config: &Config) -> anyhow::Result<Vec<IndexFile>> {
     let mut seen = BTreeSet::new();
     let mut files = Vec::new();
 
+    // Compile the repo's `.gitignore` rules (root + nested) once, shared across targets, so the
+    // walker skips the same paths the watcher's `event_is_relevant` will (issue #62).
+    let ignore = ignore_rules::IgnoreMatcher::compile(&config.root);
     for target in targets {
-        for file in walker::walk_target(&config.root, target)? {
+        for file in walker::walk_target(&config.root, target, &ignore)? {
             let relative_path = file.strip_prefix(&config.root)?.to_path_buf();
             if !seen.insert(relative_path.clone()) {
                 continue;

--- a/crates/rag-rat-core/src/index/walker.rs
+++ b/crates/rag-rat-core/src/index/walker.rs
@@ -3,11 +3,19 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::config::ResolvedTarget;
+use crate::index::ignore_rules::IgnoreMatcher;
 
-pub fn walk_target(root: &Path, target: &ResolvedTarget) -> anyhow::Result<Vec<PathBuf>> {
+/// Walk one target's directories, honoring the repo's compiled `.gitignore` rules (root + nested)
+/// plus the hardcoded floor (see [`IgnoreMatcher`]). `ignore` is compiled once per index pass and
+/// shared across targets so the walker and watcher classify paths identically (issue #62).
+pub fn walk_target(
+    root: &Path,
+    target: &ResolvedTarget,
+    ignore: &IgnoreMatcher,
+) -> anyhow::Result<Vec<PathBuf>> {
     let mut files = BTreeSet::new();
     for directory in &target.directories {
-        walk_dir(root, &root.join(directory), target, &mut files)?;
+        walk_dir(root, &root.join(directory), target, ignore, &mut files)?;
     }
     Ok(files.into_iter().collect())
 }
@@ -16,6 +24,7 @@ fn walk_dir(
     root: &Path,
     dir: &Path,
     target: &ResolvedTarget,
+    ignore: &IgnoreMatcher,
     files: &mut BTreeSet<PathBuf>,
 ) -> anyhow::Result<()> {
     for entry in fs::read_dir(dir)? {
@@ -25,33 +34,20 @@ fn walk_dir(
         if file_type.is_symlink() {
             continue;
         }
-        let file_name = entry.file_name();
-        let file_name = file_name.to_string_lossy();
-        if should_skip_name(&file_name) {
+        // Honor `.gitignore` (root + nested) and the hardcoded floor. We test the full path with
+        // its dir-ness so nested-gitignore scoping and `foo/`-style dir-only rules resolve
+        // correctly; the floor (`.git`, `.rag-rat`, `target`, …) short-circuits inside
+        // `is_ignored`.
+        if ignore.is_ignored(&path, file_type.is_dir()) {
             continue;
         }
         if file_type.is_dir() {
-            walk_dir(root, &path, target, files)?;
+            walk_dir(root, &path, target, ignore, files)?;
         } else if file_type.is_file() && is_target_file(root, &path, target) {
             files.insert(path);
         }
     }
     Ok(())
-}
-
-fn should_skip_name(name: &str) -> bool {
-    matches!(
-        name,
-        ".git"
-            | ".rag-rat"
-            | ".omx"
-            | ".omc"
-            | "node_modules"
-            | "target"
-            | "dist"
-            | "build"
-            | "coverage"
-    )
 }
 
 fn is_target_file(root: &Path, path: &Path, target: &ResolvedTarget) -> bool {
@@ -77,4 +73,72 @@ fn matches_simple_pattern(path: &str, pattern: &str) -> bool {
         return path.starts_with(prefix);
     }
     path == pattern || path.contains(pattern.trim_matches('*'))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+    use crate::config::TargetKind;
+    use crate::language::Language;
+
+    fn rust_target() -> ResolvedTarget {
+        ResolvedTarget {
+            name: "rust".to_string(),
+            language: Language::Rust,
+            directories: vec![PathBuf::from(".")],
+            include: vec!["**/*.rs".to_string()],
+            exclude: Vec::new(),
+            kind: TargetKind::Source,
+        }
+    }
+
+    fn write(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+    }
+
+    fn tempdir() -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let id = N.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!("ragrat-walk-{}-{id}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn walk_skips_gitignored_and_nested_gitignored_files() {
+        let root = tempdir();
+        // Root gitignore hides `generated/`; a nested gitignore hides `skip.rs` under `crates/app`.
+        write(&root.join(".gitignore"), "generated/\n");
+        write(&root.join("crates/app/.gitignore"), "skip.rs\n");
+        write(&root.join("crates/app/keep.rs"), "fn a() {}\n");
+        write(&root.join("crates/app/skip.rs"), "fn b() {}\n");
+        write(&root.join("generated/out.rs"), "fn c() {}\n");
+        // A floor dir (target/) must be skipped even without a gitignore entry for it.
+        write(&root.join("target/debug/built.rs"), "fn d() {}\n");
+        // A sibling named `skip.rs` at the root is NOT covered by the nested gitignore.
+        write(&root.join("skip.rs"), "fn e() {}\n");
+
+        let target = rust_target();
+        let ignore = IgnoreMatcher::compile(&root);
+        let mut found = walk_target(&root, &target, &ignore).unwrap();
+        found.sort();
+        let rel: Vec<String> = found
+            .iter()
+            .map(|p| p.strip_prefix(&root).unwrap().to_string_lossy().replace('\\', "/"))
+            .collect();
+
+        assert!(rel.contains(&"crates/app/keep.rs".to_string()), "kept: {rel:?}");
+        assert!(rel.contains(&"skip.rs".to_string()), "root skip.rs not nested-ignored: {rel:?}");
+        assert!(!rel.contains(&"crates/app/skip.rs".to_string()), "nested gitignore: {rel:?}");
+        assert!(!rel.contains(&"generated/out.rs".to_string()), "root gitignore: {rel:?}");
+        assert!(!rel.iter().any(|p| p.starts_with("target/")), "floor dir: {rel:?}");
+
+        fs::remove_dir_all(&root).ok();
+    }
 }

--- a/crates/rag-rat-core/src/index/walker.rs
+++ b/crates/rag-rat-core/src/index/walker.rs
@@ -125,7 +125,7 @@ mod tests {
         write(&root.join("skip.rs"), "fn e() {}\n");
 
         let target = rust_target();
-        let ignore = IgnoreMatcher::compile(&root);
+        let ignore = IgnoreMatcher::compile(&root, &target.directories);
         let mut found = walk_target(&root, &target, &ignore).unwrap();
         found.sort();
         let rel: Vec<String> = found

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -22,6 +22,7 @@ use notify::{Event, RecursiveMode, Watcher as _, recommended_watcher};
 use crate::config::Config;
 use crate::fleet;
 use crate::index::ai::ReconcileOptions;
+use crate::index::ignore_rules::IgnoreMatcher;
 use crate::index::{IndexDatabase, target_for_path};
 use crate::locks::{self, FileLock};
 
@@ -135,10 +136,17 @@ fn kind_is_mutation(kind: &EventKind) -> bool {
 }
 
 /// A relevant event is a rescan/overflow notice, or a *content-mutating* event whose path matches a
-/// configured target — classification only decides *whether to fire a pass*, not what to index (the
-/// discover sweep does that). Ignored paths (`.rag-rat/`, `target/`, …) never match a target, so
-/// they never fire; read-only events never fire regardless of path (see [`kind_is_mutation`]).
-fn event_is_relevant(config: &Config, event: &Event) -> bool {
+/// configured target and is **not** ignored by the repo's compiled `.gitignore` rules + floor
+/// (issue #62). Classification only decides *whether to fire a pass*, not what to index (the
+/// discover sweep does that). The walker and watcher share one [`IgnoreMatcher`] so a path the
+/// walker won't index also won't fire a re-index here — no drift. Read-only events never fire
+/// regardless of path (see [`kind_is_mutation`]).
+///
+/// The event path may be a just-deleted file, so dir-ness can't be stat'd; we pass `is_dir = false`
+/// to the gitignore match. That is sound for the floor (component-name check is dir-ness-agnostic)
+/// and for file globs; the only gap is a `foo/`-dir-only gitignore rule on a removed directory,
+/// which at worst fires one extra harmless idempotent pass.
+fn event_is_relevant(config: &Config, ignore: &IgnoreMatcher, event: &Event) -> bool {
     if event.need_rescan() {
         return true;
     }
@@ -146,6 +154,9 @@ fn event_is_relevant(config: &Config, event: &Event) -> bool {
         return false;
     }
     event.paths.iter().any(|path| {
+        if ignore.is_ignored(path, false) {
+            return false;
+        }
         path.strip_prefix(&config.root)
             .ok()
             .is_some_and(|relative| target_for_path(config, relative).is_some())
@@ -247,6 +258,11 @@ fn watcher_main(config: Config, fleet_bin: Option<PathBuf>, stop: &AtomicBool) {
             let _ = notify_watcher.watch(&config.root.join(dir), RecursiveMode::Recursive);
         }
     }
+    // Compile the repo's `.gitignore` rules once for event classification — the same matcher the
+    // discover walk uses (issue #62), so an ignored path never fires a pass. Recompiled only at
+    // watcher start; a `.gitignore` edit is itself a mutation event that fires a pass, and each
+    // pass's discover walk recompiles, so the index stays correct even if this classifier lags.
+    let ignore = IgnoreMatcher::compile(&config.root);
     // Fleet hot-upgrade: also watch the installed binary's directory so a new `cargo install`
     // rename triggers a fleet-wide upgrade. Watch the directory (not the file) so the atomic
     // rename — which replaces the inode — is still observed.
@@ -279,7 +295,7 @@ fn watcher_main(config: Config, fleet_bin: Option<PathBuf>, stop: &AtomicBool) {
         match rx.recv_timeout(wait) {
             Ok(Ok(event)) => {
                 let now = Instant::now();
-                if event_is_relevant(&config, &event) {
+                if event_is_relevant(&config, &ignore, &event) {
                     debounce.on_event(now);
                 }
                 if event_targets_binary(fleet_bin.as_deref(), &event) {
@@ -329,7 +345,70 @@ fn shutdown_discover(config: &Config) -> anyhow::Result<bool> {
 
 #[cfg(test)]
 mod tests {
+    use notify::event::{CreateKind, ModifyKind};
+
     use super::*;
+    use crate::config::{
+        Config, EmbeddingConfig, LocalAiConfig, ResolvedTarget, TargetKind, WatchConfig,
+    };
+    use crate::language::Language;
+
+    fn mutation_event(path: PathBuf) -> Event {
+        Event::new(EventKind::Modify(ModifyKind::Any)).add_path(path)
+    }
+
+    #[test]
+    fn event_is_relevant_skips_gitignored_paths_consistently_with_walker() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let id = N.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!("ragrat-watchev-{}-{id}", std::process::id()));
+        std::fs::create_dir_all(root.join("crates")).unwrap();
+        std::fs::write(root.join(".gitignore"), "gen/\n").unwrap();
+
+        let config = Config {
+            root: root.clone(),
+            database: root.join(".rag-rat/index.sqlite"),
+            targets: vec![ResolvedTarget {
+                name: "rust".to_string(),
+                language: Language::Rust,
+                directories: vec![PathBuf::from("crates")],
+                include: vec!["**/*.rs".to_string()],
+                exclude: Vec::new(),
+                kind: TargetKind::Source,
+            }],
+            local_ai: LocalAiConfig { embedding: EmbeddingConfig::default() },
+            watch: WatchConfig::default(),
+        };
+        let ignore = IgnoreMatcher::compile(&root);
+
+        // A real source edit under the target fires.
+        let src = root.join("crates/lib.rs");
+        assert!(event_is_relevant(&config, &ignore, &mutation_event(src)), "source edit fires");
+
+        // A floor dir (target/) never fires, even though it would be language-matched.
+        let built = root.join("target/debug/foo.rs");
+        assert!(!event_is_relevant(&config, &ignore, &mutation_event(built)), "floor dir skipped");
+
+        // A gitignored dir under root never fires.
+        let generated = root.join("gen/out.rs");
+        assert!(
+            !event_is_relevant(&config, &ignore, &mutation_event(generated)),
+            "gitignored skipped",
+        );
+
+        // A read of a watched source file never fires (anti-feedback gate), even if not ignored.
+        let read = Event::new(EventKind::Access(AccessKind::Open(AccessMode::Read)))
+            .add_path(root.join("crates/lib.rs"));
+        assert!(!event_is_relevant(&config, &ignore, &read), "reads never fire");
+
+        // A creation under the target fires.
+        let created =
+            Event::new(EventKind::Create(CreateKind::File)).add_path(root.join("crates/new.rs"));
+        assert!(event_is_relevant(&config, &ignore, &created), "new source file fires");
+
+        std::fs::remove_dir_all(&root).ok();
+    }
 
     #[test]
     fn debounce_fires_after_quiet_window() {

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -135,6 +135,34 @@ fn kind_is_mutation(kind: &EventKind) -> bool {
     }
 }
 
+/// Directories whose `.gitignore` the watcher must subscribe to so a root-rule edit is *delivered*
+/// (round-3 finding 1). The target dirs the watcher already watches recursively are *below*
+/// `config.root`; when `config.root` is itself a subdirectory of a larger Git worktree, the
+/// worktree-root `.gitignore` (and any ancestor `.gitignore` down to `config.root`) sits ABOVE them
+/// and would otherwise never produce an event. This returns the ancestor chain from the worktree
+/// root down to and including `config.root`. In a non-git tree (or when `config.root` *is* the
+/// worktree root) it returns just `config.root` — already covered by the recursive target watches,
+/// so the extra non-recursive watch is a harmless no-op duplicate.
+fn gitignore_watch_dirs(root: &Path) -> Vec<PathBuf> {
+    let base = crate::index::git_history::worktree_root(root).filter(|wt| root.starts_with(wt));
+    let mut dirs = Vec::new();
+    if let Some(base) = base
+        && let Ok(rel) = root.strip_prefix(&base)
+    {
+        let mut dir = base;
+        dirs.push(dir.clone());
+        for component in rel.components() {
+            if let std::path::Component::Normal(name) = component {
+                dir.push(name);
+                dirs.push(dir.clone());
+            }
+        }
+    } else {
+        dirs.push(root.to_path_buf());
+    }
+    dirs
+}
+
 /// Whether `path`'s file name is `.gitignore`. A mutation to any `**/.gitignore` changes the
 /// repo's ignore rules, so it is a relevant event (issue #62 / PR #66 finding 4) even though
 /// `.gitignore` is not a configured target language — the pass it fires recompiles the matcher and
@@ -272,12 +300,25 @@ fn watcher_main(config: Config, fleet_bin: Option<PathBuf>, stop: &AtomicBool) {
             let _ = notify_watcher.watch(&config.root.join(dir), RecursiveMode::Recursive);
         }
     }
+    // Round-3 finding 1: when `config.root` is a subdirectory of a larger Git worktree, the target
+    // dirs are below `config.root`, so a watch scoped to them never sees an edit to the
+    // *worktree-root* (or any ancestor) `.gitignore` that lives ABOVE them — those root-rule
+    // changes would never recompile the matcher. Subscribe (non-recursively, to avoid
+    // re-watching the whole worktree) to every directory on the ancestor chain from the
+    // worktree root down to `config.root`, so a `.gitignore` mutation there is delivered.
+    // `gitignore_watch_dirs` returns the chain (always including `config.root`); the
+    // non-recursive watch only delivers events for files directly in each dir, which is exactly
+    // where each ancestor `.gitignore` sits.
+    for dir in gitignore_watch_dirs(&config.root) {
+        let _ = notify_watcher.watch(&dir, RecursiveMode::NonRecursive);
+    }
     // Compile the repo's `.gitignore` rules for event classification — the same matcher the
     // discover walk uses (issue #62), so an ignored path never fires a pass. Recompiled whenever a
     // `.gitignore` mutation is observed (finding 3) so the running classifier never applies stale
     // rules; each pass's discover walk also compiles its own fresh matcher, so the index itself is
     // always current regardless.
-    let mut ignore = IgnoreMatcher::compile(&config.root);
+    let target_dirs = config.target_directories();
+    let mut ignore = IgnoreMatcher::compile(&config.root, &target_dirs);
     // Fleet hot-upgrade: also watch the installed binary's directory so a new `cargo install`
     // rename triggers a fleet-wide upgrade. Watch the directory (not the file) so the atomic
     // rename — which replaces the inode — is still observed.
@@ -319,7 +360,7 @@ fn watcher_main(config: Config, fleet_bin: Option<PathBuf>, stop: &AtomicBool) {
                     if kind_is_mutation(&event.kind)
                         && event.paths.iter().any(|path| is_gitignore_path(path))
                     {
-                        ignore = IgnoreMatcher::compile(&config.root);
+                        ignore = IgnoreMatcher::compile(&config.root, &target_dirs);
                     }
                 }
                 if event_targets_binary(fleet_bin.as_deref(), &event) {
@@ -404,7 +445,7 @@ mod tests {
             local_ai: LocalAiConfig { embedding: EmbeddingConfig::default() },
             watch: WatchConfig::default(),
         };
-        let ignore = IgnoreMatcher::compile(&root);
+        let ignore = IgnoreMatcher::compile(&root, &[]);
 
         // A real source edit under the target fires.
         let src = root.join("crates/lib.rs");
@@ -436,9 +477,9 @@ mod tests {
 
     #[test]
     fn gitignore_edit_is_relevant_and_recompile_reflects_new_rules() {
-        // FINDINGS 3 + 4: a `.gitignore` mutation must (4) fire a pass even though `.gitignore` is
-        // not a target language, and (3) recompiling the matcher must make subsequent
-        // classification honor the new rules — so a now-ignored file stops firing and a
+        // EARLIER-ROUND FINDINGS (kept correct): a `.gitignore` mutation must fire a pass even
+        // though `.gitignore` is not a target language, AND recompiling the matcher must make
+        // subsequent classification honor the new rules — so a now-ignored file stops firing and a
         // now-unignored file resumes.
         use std::sync::atomic::{AtomicU64, Ordering};
         static N: AtomicU64 = AtomicU64::new(0);
@@ -463,7 +504,7 @@ mod tests {
             watch: WatchConfig::default(),
         };
 
-        let ignore = IgnoreMatcher::compile(&root);
+        let ignore = IgnoreMatcher::compile(&root, &[]);
         let secret = root.join("crates/secret.rs");
         // Before the rule edit: a normal source edit fires.
         assert!(event_is_relevant(&config, &ignore, &mutation_event(secret.clone())), "fires pre");
@@ -475,10 +516,10 @@ mod tests {
         let nested_gi = mutation_event(root.join("crates/.gitignore"));
         assert!(event_is_relevant(&config, &ignore, &nested_gi), "nested gitignore edit fires");
 
-        // Now the user adds `secret.rs` to `.gitignore`; recompiling (finding 3) must make the
-        // classifier drop it.
+        // Now the user adds `secret.rs` to `.gitignore`; recompiling must make the classifier drop
+        // it.
         std::fs::write(root.join(".gitignore"), "secret.rs\n").unwrap();
-        let ignore = IgnoreMatcher::compile(&root);
+        let ignore = IgnoreMatcher::compile(&root, &[]);
         assert!(
             !event_is_relevant(&config, &ignore, &mutation_event(secret)),
             "recompiled matcher honors the new ignore rule (now-ignored file stops firing)",
@@ -491,6 +532,65 @@ mod tests {
         );
 
         std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn worktree_root_gitignore_edit_recompiles_for_subdir_config_root() {
+        // FINDING 1 + 3 combined (test d for the subdirectory case): `config.root` is a subdir of a
+        // Git worktree. A live edit to the WORKTREE-ROOT `.gitignore` (above config.root) must,
+        // after recompiling the shared matcher, drop a now-ignored file under the subdir and keep
+        // an unrelated one firing — proving ancestor rules are honored AND the recompile
+        // takes effect.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let id = N.fetch_add(1, Ordering::Relaxed);
+        let wt = std::env::temp_dir().join(format!("ragrat-wtgi-{}-{id}", std::process::id()));
+        std::fs::create_dir_all(wt.join("crates")).unwrap();
+        let wt = wt.canonicalize().unwrap();
+        let ok = std::process::Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(&wt)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        assert!(ok, "git init failed (git must be on PATH)");
+        std::fs::write(wt.join(".gitignore"), "").unwrap();
+
+        let sub = wt.join("crates"); // config.root is the subdirectory.
+        let target_dirs = vec![PathBuf::from(".")];
+        let config = Config {
+            root: sub.clone(),
+            database: sub.join(".rag-rat/index.sqlite"),
+            targets: vec![ResolvedTarget {
+                name: "rust".to_string(),
+                language: Language::Rust,
+                directories: target_dirs.clone(),
+                include: vec!["**/*.rs".to_string()],
+                exclude: Vec::new(),
+                kind: TargetKind::Source,
+            }],
+            local_ai: LocalAiConfig { embedding: EmbeddingConfig::default() },
+            watch: WatchConfig::default(),
+        };
+
+        // Before: a source file under the subdir fires.
+        let ignore = IgnoreMatcher::compile(&sub, &target_dirs);
+        let secret = sub.join("secret.rs");
+        assert!(event_is_relevant(&config, &ignore, &mutation_event(secret.clone())), "fires pre");
+
+        // Edit the WORKTREE-ROOT `.gitignore` to ignore `secret.rs` repo-wide, then recompile.
+        std::fs::write(wt.join(".gitignore"), "secret.rs\n").unwrap();
+        let ignore = IgnoreMatcher::compile(&sub, &target_dirs);
+        assert!(
+            !event_is_relevant(&config, &ignore, &mutation_event(secret)),
+            "worktree-root rule (above config.root) drops the file after recompile (finding 1 + 3)",
+        );
+        assert!(
+            event_is_relevant(&config, &ignore, &mutation_event(sub.join("keep.rs"))),
+            "an unrelated source file under the subdir still fires",
+        );
+
+        std::fs::remove_dir_all(&wt).ok();
     }
 
     #[test]
@@ -545,5 +645,113 @@ mod tests {
         let d = Debounce::new(Duration::from_millis(400), Duration::from_millis(2500));
         assert!(d.due_in(Instant::now()).is_none());
         assert!(!d.should_fire(Instant::now()));
+    }
+
+    #[test]
+    fn gitignore_watch_dirs_includes_worktree_root_for_subdir_config_root() {
+        // FINDING 1 (round 3): when `config.root` is a subdirectory of a Git worktree, the watcher
+        // must also subscribe to the ancestor chain up to the worktree root so a root-`.gitignore`
+        // edit (which lives ABOVE the recursively-watched target dirs) is delivered.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let id = N.fetch_add(1, Ordering::Relaxed);
+        let wt = std::env::temp_dir().join(format!("ragrat-wdirs-{}-{id}", std::process::id()));
+        std::fs::create_dir_all(wt.join("crates/app")).unwrap();
+        let wt = wt.canonicalize().unwrap();
+        let ok = std::process::Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(&wt)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        assert!(ok, "git init failed (git must be on PATH)");
+
+        let sub = wt.join("crates/app");
+        let dirs = gitignore_watch_dirs(&sub);
+        // The chain from the worktree root down to config.root, inclusive.
+        assert_eq!(dirs.first(), Some(&wt), "worktree root is watched (finding 1)");
+        assert!(dirs.contains(&wt.join("crates")), "intermediate ancestor watched");
+        assert_eq!(dirs.last(), Some(&sub), "config.root itself is watched");
+
+        std::fs::remove_dir_all(&wt).ok();
+    }
+
+    #[test]
+    fn gitignore_watch_dirs_non_git_tree_is_just_root() {
+        // Outside a Git worktree the chain collapses to just `config.root` (already covered by the
+        // recursive target watches) — no ancestor sweep above an un-versioned directory.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let id = N.fetch_add(1, Ordering::Relaxed);
+        let root =
+            std::env::temp_dir().join(format!("ragrat-wdirs-ng-{}-{id}", std::process::id()));
+        std::fs::create_dir_all(&root).unwrap();
+        let root = root.canonicalize().unwrap();
+        // Best-effort: only meaningful when /tmp isn't itself inside a git worktree. If it is,
+        // skip.
+        if crate::index::git_history::worktree_root(&root).is_some() {
+            std::fs::remove_dir_all(&root).ok();
+            return;
+        }
+        assert_eq!(gitignore_watch_dirs(&root), vec![root.clone()]);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn root_gitignore_edit_is_delivered_to_a_real_watcher() {
+        // FINDING 1 end-to-end (test d): a live edit to the worktree-root `.gitignore` — which sits
+        // ABOVE the target dirs — must actually be *delivered* by the notify watcher once we
+        // subscribe to `gitignore_watch_dirs`. We spawn a real recommended_watcher over exactly the
+        // dirs the watcher subscribes to (target dir + ancestor chain) and assert the edit arrives.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let id = N.fetch_add(1, Ordering::Relaxed);
+        let wt = std::env::temp_dir().join(format!("ragrat-deliv-{}-{id}", std::process::id()));
+        std::fs::create_dir_all(wt.join("crates")).unwrap();
+        let wt = wt.canonicalize().unwrap();
+        let ok = std::process::Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(&wt)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        assert!(ok, "git init failed (git must be on PATH)");
+        std::fs::write(wt.join(".gitignore"), "").unwrap();
+
+        let sub = wt.join("crates"); // config.root is the subdirectory.
+        let (tx, rx) = std::sync::mpsc::channel();
+        let Ok(mut w) = recommended_watcher(move |res| {
+            let _ = tx.send(res);
+        }) else {
+            std::fs::remove_dir_all(&wt).ok();
+            return; // no watcher backend available (sandboxed CI) — nothing to assert.
+        };
+        // Subscribe exactly as watcher_main does: the (recursive) target dir + the gitignore chain.
+        w.watch(&sub, RecursiveMode::Recursive).unwrap();
+        for dir in gitignore_watch_dirs(&sub) {
+            let _ = w.watch(&dir, RecursiveMode::NonRecursive);
+        }
+
+        // Edit the worktree-root `.gitignore` (above config.root).
+        std::fs::write(wt.join(".gitignore"), "secret.rs\n").unwrap();
+
+        // Drain events for up to ~3s; assert at least one references the root `.gitignore`.
+        let deadline = Instant::now() + Duration::from_secs(3);
+        let mut delivered = false;
+        while Instant::now() < deadline {
+            match rx.recv_timeout(Duration::from_millis(250)) {
+                Ok(Ok(event)) =>
+                    if event.paths.iter().any(|p| is_gitignore_path(p)) {
+                        delivered = true;
+                        break;
+                    },
+                Ok(Err(_)) => {},
+                Err(RecvTimeoutError::Timeout) => {},
+                Err(RecvTimeoutError::Disconnected) => break,
+            }
+        }
+        drop(w);
+        std::fs::remove_dir_all(&wt).ok();
+        assert!(delivered, "root .gitignore edit above config.root must be delivered (finding 1)");
     }
 }

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -135,12 +135,21 @@ fn kind_is_mutation(kind: &EventKind) -> bool {
     }
 }
 
-/// A relevant event is a rescan/overflow notice, or a *content-mutating* event whose path matches a
-/// configured target and is **not** ignored by the repo's compiled `.gitignore` rules + floor
-/// (issue #62). Classification only decides *whether to fire a pass*, not what to index (the
-/// discover sweep does that). The walker and watcher share one [`IgnoreMatcher`] so a path the
-/// walker won't index also won't fire a re-index here — no drift. Read-only events never fire
-/// regardless of path (see [`kind_is_mutation`]).
+/// Whether `path`'s file name is `.gitignore`. A mutation to any `**/.gitignore` changes the
+/// repo's ignore rules, so it is a relevant event (issue #62 / PR #66 finding 4) even though
+/// `.gitignore` is not a configured target language — the pass it fires recompiles the matcher and
+/// re-discovers (dropping newly-ignored files, adding newly-unignored ones).
+fn is_gitignore_path(path: &Path) -> bool {
+    path.file_name().is_some_and(|name| name == ".gitignore")
+}
+
+/// A relevant event is a rescan/overflow notice, a *content-mutating* `.gitignore` edit (the rules
+/// themselves changed — finding 4), or a *content-mutating* event whose path matches a configured
+/// target and is **not** ignored by the repo's compiled `.gitignore` rules + floor (issue #62).
+/// Classification only decides *whether to fire a pass*, not what to index (the discover sweep does
+/// that). The walker and watcher share one [`IgnoreMatcher`] so a path the walker won't index also
+/// won't fire a re-index here — no drift. Read-only events never fire regardless of path (see
+/// [`kind_is_mutation`]).
 ///
 /// The event path may be a just-deleted file, so dir-ness can't be stat'd; we pass `is_dir = false`
 /// to the gitignore match. That is sound for the floor (component-name check is dir-ness-agnostic)
@@ -154,6 +163,11 @@ fn event_is_relevant(config: &Config, ignore: &IgnoreMatcher, event: &Event) -> 
         return false;
     }
     event.paths.iter().any(|path| {
+        // A `.gitignore` edit changes the rules; it must fire a pass even though it is not a
+        // target file and may itself sit in a directory the *current* rules ignore.
+        if is_gitignore_path(path) {
+            return true;
+        }
         if ignore.is_ignored(path, false) {
             return false;
         }
@@ -258,11 +272,12 @@ fn watcher_main(config: Config, fleet_bin: Option<PathBuf>, stop: &AtomicBool) {
             let _ = notify_watcher.watch(&config.root.join(dir), RecursiveMode::Recursive);
         }
     }
-    // Compile the repo's `.gitignore` rules once for event classification — the same matcher the
-    // discover walk uses (issue #62), so an ignored path never fires a pass. Recompiled only at
-    // watcher start; a `.gitignore` edit is itself a mutation event that fires a pass, and each
-    // pass's discover walk recompiles, so the index stays correct even if this classifier lags.
-    let ignore = IgnoreMatcher::compile(&config.root);
+    // Compile the repo's `.gitignore` rules for event classification — the same matcher the
+    // discover walk uses (issue #62), so an ignored path never fires a pass. Recompiled whenever a
+    // `.gitignore` mutation is observed (finding 3) so the running classifier never applies stale
+    // rules; each pass's discover walk also compiles its own fresh matcher, so the index itself is
+    // always current regardless.
+    let mut ignore = IgnoreMatcher::compile(&config.root);
     // Fleet hot-upgrade: also watch the installed binary's directory so a new `cargo install`
     // rename triggers a fleet-wide upgrade. Watch the directory (not the file) so the atomic
     // rename — which replaces the inode — is still observed.
@@ -297,6 +312,15 @@ fn watcher_main(config: Config, fleet_bin: Option<PathBuf>, stop: &AtomicBool) {
                 let now = Instant::now();
                 if event_is_relevant(&config, &ignore, &event) {
                     debounce.on_event(now);
+                    // A `.gitignore` mutation changed the rules — recompile so subsequent events
+                    // are classified against current rules, not the matcher
+                    // this watcher booted with (finding 3). Cheap relative to a
+                    // pass and only runs on actual gitignore edits.
+                    if kind_is_mutation(&event.kind)
+                        && event.paths.iter().any(|path| is_gitignore_path(path))
+                    {
+                        ignore = IgnoreMatcher::compile(&config.root);
+                    }
                 }
                 if event_targets_binary(fleet_bin.as_deref(), &event) {
                     fleet_debounce.on_event(now);
@@ -406,6 +430,65 @@ mod tests {
         let created =
             Event::new(EventKind::Create(CreateKind::File)).add_path(root.join("crates/new.rs"));
         assert!(event_is_relevant(&config, &ignore, &created), "new source file fires");
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn gitignore_edit_is_relevant_and_recompile_reflects_new_rules() {
+        // FINDINGS 3 + 4: a `.gitignore` mutation must (4) fire a pass even though `.gitignore` is
+        // not a target language, and (3) recompiling the matcher must make subsequent
+        // classification honor the new rules — so a now-ignored file stops firing and a
+        // now-unignored file resumes.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let id = N.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!("ragrat-watchgi-{}-{id}", std::process::id()));
+        std::fs::create_dir_all(root.join("crates")).unwrap();
+        // Initially nothing is gitignored.
+        std::fs::write(root.join(".gitignore"), "").unwrap();
+
+        let config = Config {
+            root: root.clone(),
+            database: root.join(".rag-rat/index.sqlite"),
+            targets: vec![ResolvedTarget {
+                name: "rust".to_string(),
+                language: Language::Rust,
+                directories: vec![PathBuf::from("crates")],
+                include: vec!["**/*.rs".to_string()],
+                exclude: Vec::new(),
+                kind: TargetKind::Source,
+            }],
+            local_ai: LocalAiConfig { embedding: EmbeddingConfig::default() },
+            watch: WatchConfig::default(),
+        };
+
+        let ignore = IgnoreMatcher::compile(&root);
+        let secret = root.join("crates/secret.rs");
+        // Before the rule edit: a normal source edit fires.
+        assert!(event_is_relevant(&config, &ignore, &mutation_event(secret.clone())), "fires pre");
+
+        // A `.gitignore` mutation is itself relevant (finding 4) — even a root `.gitignore`, and
+        // even a nested one that has no target language.
+        let gi_edit = mutation_event(root.join(".gitignore"));
+        assert!(event_is_relevant(&config, &ignore, &gi_edit), "gitignore edit fires a pass");
+        let nested_gi = mutation_event(root.join("crates/.gitignore"));
+        assert!(event_is_relevant(&config, &ignore, &nested_gi), "nested gitignore edit fires");
+
+        // Now the user adds `secret.rs` to `.gitignore`; recompiling (finding 3) must make the
+        // classifier drop it.
+        std::fs::write(root.join(".gitignore"), "secret.rs\n").unwrap();
+        let ignore = IgnoreMatcher::compile(&root);
+        assert!(
+            !event_is_relevant(&config, &ignore, &mutation_event(secret)),
+            "recompiled matcher honors the new ignore rule (now-ignored file stops firing)",
+        );
+        // A different, still-unignored source file keeps firing.
+        let other = root.join("crates/keep.rs");
+        assert!(
+            event_is_relevant(&config, &ignore, &mutation_event(other)),
+            "unignored still fires"
+        );
 
         std::fs::remove_dir_all(&root).ok();
     }


### PR DESCRIPTION
Replaces the hardcoded skip-name list with real `.gitignore` compilation, applied consistently by both the file walker (discovery) and the watcher (`event_is_relevant`).

### Approach
- New shared `crates/rag-rat-core/src/index/ignore_rules.rs::IgnoreMatcher`, compiled once per index pass / once at watcher start and consulted by **both** walker and watcher, so a path one skips the other also skips (no drift).
- **Augment, not replace**, the hardcoded list: it survives as an unconditional floor (`FLOOR_DIRS`: `.git .rag-rat .omx .omc node_modules target dist build coverage`) that can't be whitelisted away — guarantees correct skips in a non-git tree and that `.rag-rat/` is never indexed (feedback-loop guard). Compiled `.gitignore` rules layer on top.
- Added the `ignore` crate (ripgrep's engine; MIT/Unlicense, license-gate friendly).

### Two non-obvious findings (recorded as a repo memory)
1. A single flat `GitignoreBuilder` flattens nested files' globs to the root and `**/`-prefixes them, so a nested rule would wrongly ignore repo-wide. Fix: a per-directory stack of `Gitignore` matchers, deepest decision winning (nested `!whitelist` overrides an outer ignore).
2. `Gitignore::matched` only tests the leaf — a file under an ignored *directory* slipped through. Fix: `matched_path_or_any_parents`.

### Tests
New tests for root + nested `.gitignore` scoping, whitelist negation, floor-without-gitignore, walker end-to-end, and watcher `event_is_relevant` (skips ignored paths, fires on real source mutations, never on reads). The existing watcher target-directory constraint is preserved. 179 tests pass, clippy clean.

Fixes #62