### PR TITLE
Persist callee-identifier byte range on graph edges (#67)

### DIFF
--- a/crates/rag-rat-core/src/index/edges/extract.rs
+++ b/crates/rag-rat-core/src/index/edges/extract.rs
@@ -74,6 +74,7 @@ pub(crate) fn contains_edges(symbols: &[IndexedSymbol]) -> Vec<EdgeCandidate> {
                 evidence: Some(child.qualified_name.clone()),
                 receiver_hint: None,
                 source_span: child.span(),
+                callee_span: None,
                 edge_kind: EdgeKind::Contains,
                 confidence: EdgeConfidence::Exact,
             });
@@ -191,6 +192,7 @@ pub(crate) fn rust_edges(
                         target_qualified_name: target_qualified_name(node, text),
                         receiver_hint: scoped_receiver_name(node, text),
                     },
+                    call_target_node(node).map(CalleeRange::of_node),
                 ));
             }
             // A scoped call receiver is a type reference only when it names a type. By Rust
@@ -207,6 +209,12 @@ pub(crate) fn rust_edges(
                     receiver,
                     EdgeKind::ReferencesType,
                     EdgeConfidence::NameOnly,
+                    // The type is the receiver — the LEADING `::` segment (`Foo` in `Foo::bar()`)
+                    // — so anchor the range on the function path's first
+                    // identifier, not its tail.
+                    node.child_by_field_name("function")
+                        .and_then(first_identifier_node)
+                        .map(CalleeRange::of_node),
                 ));
             }
         },
@@ -220,6 +228,7 @@ pub(crate) fn rust_edges(
                     EdgeKind::UsesMacro,
                     EdgeConfidence::NameOnly,
                     EdgeContext::default(),
+                    first_identifier_node(node).map(CalleeRange::of_node),
                 ));
             },
         "impl_item" => rust_impl_edges(text, node, symbols, out),
@@ -231,6 +240,7 @@ pub(crate) fn rust_edges(
                     name,
                     EdgeKind::ReferencesType,
                     EdgeConfidence::NameOnly,
+                    last_identifier_node(node).map(final_segment_node).map(CalleeRange::of_node),
                 ));
             }
         },
@@ -262,6 +272,9 @@ pub(crate) fn rust_impl_edges(
             evidence: Some(edge_evidence(node, text)),
             receiver_hint: None,
             source_span: span_for_node(node),
+            // The trait/type names here come from string-splitting the impl header, not from a
+            // located identifier node, so there is no clean callee range to record (#67).
+            callee_span: None,
             edge_kind: EdgeKind::Implements,
             confidence: EdgeConfidence::NameOnly,
         });
@@ -272,6 +285,9 @@ pub(crate) fn rust_impl_edges(
             type_name.clone(),
             EdgeKind::ReferencesType,
             EdgeConfidence::NameOnly,
+            // `type_name` is string-split from the impl header, not a located node — no range
+            // (#67).
+            None,
         ));
     }
 }
@@ -306,8 +322,11 @@ pub(crate) fn typescript_edges(
                 ));
             },
         "call_expression" | "new_expression" => {
-            let identifiers =
-                identifiers_under(node.child_by_field_name("function").unwrap_or(node), text);
+            let function = node.child_by_field_name("function").unwrap_or(node);
+            let identifiers = identifiers_under(function, text);
+            // Parallel to `identifiers` (same traversal order), so `.last()`/`.first()` pick the
+            // node for the same token the string Vec does (#67).
+            let identifier_nodes = identifier_nodes_under(function);
             if let Some(name) = identifiers.last().cloned().or_else(|| call_target_name(node, text))
             {
                 let edge_kind = if node.kind() == "new_expression" {
@@ -329,6 +348,8 @@ pub(crate) fn typescript_edges(
                             .filter(|_| identifiers.len() > 1)
                             .cloned(),
                     },
+                    // The callee is the final segment — `.last()`, matching `identifiers.last()`.
+                    identifier_nodes.last().copied().map(CalleeRange::of_node),
                 ));
             }
             if let Some(receiver) = identifiers.first().filter(|_| identifiers.len() > 1).cloned() {
@@ -338,6 +359,13 @@ pub(crate) fn typescript_edges(
                     receiver,
                     EdgeKind::ReferencesType,
                     EdgeConfidence::NameOnly,
+                    // The type is the receiver — the FIRST segment, matching
+                    // `identifiers.first()`.
+                    identifier_nodes
+                        .first()
+                        .filter(|_| identifier_nodes.len() > 1)
+                        .copied()
+                        .map(CalleeRange::of_node),
                 ));
             }
         },
@@ -349,6 +377,7 @@ pub(crate) fn typescript_edges(
                     name,
                     EdgeKind::ReferencesType,
                     EdgeConfidence::NameOnly,
+                    first_identifier_node(node).map(CalleeRange::of_node),
                 ));
             }
         },
@@ -360,6 +389,9 @@ pub(crate) fn typescript_edges(
                     name,
                     EdgeKind::ReferencesType,
                     EdgeConfidence::NameOnly,
+                    // `node` is itself the `type_identifier` token — its range is the callee
+                    // range.
+                    Some(CalleeRange::of_node(node)),
                 ));
             }
         },
@@ -388,6 +420,9 @@ pub(crate) fn kotlin_edges(
         },
         "call_expression" => {
             let identifiers = identifiers_under(node, text);
+            // Parallel to `identifiers` (same node, same traversal order) so the callee `.last()`
+            // and receiver/constructor `.first()` nodes line up with the string picks (#67).
+            let identifier_nodes = identifier_nodes_under(node);
             if let Some(name) =
                 identifiers.last().cloned().or_else(|| first_identifier_text(node, text))
             {
@@ -405,6 +440,7 @@ pub(crate) fn kotlin_edges(
                             .filter(|_| identifiers.len() > 1)
                             .cloned(),
                     },
+                    identifier_nodes.last().copied().map(CalleeRange::of_node),
                 ));
             }
             if let Some(receiver) = identifiers.first().filter(|_| identifiers.len() > 1).cloned() {
@@ -414,17 +450,26 @@ pub(crate) fn kotlin_edges(
                     receiver,
                     EdgeKind::ReferencesType,
                     EdgeConfidence::NameOnly,
+                    identifier_nodes
+                        .first()
+                        .filter(|_| identifier_nodes.len() > 1)
+                        .copied()
+                        .map(CalleeRange::of_node),
                 ));
             }
             if let Some(constructor) =
                 identifiers.first().filter(|name| looks_like_type_name(name)).cloned()
             {
+                // Both the type reference and the construct point at the constructor — the FIRST
+                // identifier (matching `identifiers.first()`).
+                let constructor_range = identifier_nodes.first().copied().map(CalleeRange::of_node);
                 out.push(symbol_edge(
                     symbols,
                     node,
                     constructor.clone(),
                     EdgeKind::ReferencesType,
                     EdgeConfidence::NameOnly,
+                    constructor_range,
                 ));
                 out.push(symbol_edge_with_context(
                     symbols,
@@ -434,6 +479,7 @@ pub(crate) fn kotlin_edges(
                     EdgeKind::Constructs,
                     EdgeConfidence::NameOnly,
                     EdgeContext::default(),
+                    constructor_range,
                 ));
             }
         },
@@ -445,6 +491,7 @@ pub(crate) fn kotlin_edges(
                     name,
                     EdgeKind::ReferencesType,
                     EdgeConfidence::NameOnly,
+                    last_identifier_node(node).map(final_segment_node).map(CalleeRange::of_node),
                 ));
             },
         "delegation_specifier" | "supertype" | "super_type" => {
@@ -455,6 +502,7 @@ pub(crate) fn kotlin_edges(
                     name,
                     EdgeKind::Implements,
                     EdgeConfidence::NameOnly,
+                    last_identifier_node(node).map(final_segment_node).map(CalleeRange::of_node),
                 ));
             }
         },
@@ -488,8 +536,10 @@ pub(crate) fn c_like_edges(
             }
         },
         "call_expression" => {
-            let identifiers =
-                identifiers_under(node.child_by_field_name("function").unwrap_or(node), text);
+            let function = node.child_by_field_name("function").unwrap_or(node);
+            let identifiers = identifiers_under(function, text);
+            // Parallel to `identifiers` so the callee `.last()` node matches the string pick (#67).
+            let identifier_nodes = identifier_nodes_under(function);
             if let Some(name) = identifiers.last().cloned().or_else(|| call_target_name(node, text))
             {
                 out.push(symbol_edge_with_context(
@@ -506,6 +556,7 @@ pub(crate) fn c_like_edges(
                             .filter(|_| identifiers.len() > 1)
                             .cloned(),
                     },
+                    identifier_nodes.last().copied().map(CalleeRange::of_node),
                 ));
             }
         },
@@ -517,6 +568,7 @@ pub(crate) fn c_like_edges(
                     name,
                     EdgeKind::ReferencesType,
                     EdgeConfidence::NameOnly,
+                    last_identifier_node(node).map(final_segment_node).map(CalleeRange::of_node),
                 ));
             }
         },
@@ -539,6 +591,8 @@ pub(crate) fn file_edge(
         evidence: Some(edge_evidence(node, text)),
         receiver_hint: None,
         source_span: span_for_node(node),
+        // File-level edges (imports / exports / mod) have no callee identifier to anchor (#67).
+        callee_span: None,
         edge_kind,
         confidence,
     }
@@ -549,6 +603,7 @@ pub(crate) fn symbol_edge(
     to_name: String,
     edge_kind: EdgeKind,
     confidence: EdgeConfidence,
+    callee_span: Option<CalleeRange>,
 ) -> EdgeCandidate {
     symbol_edge_with_context(
         symbols,
@@ -558,8 +613,10 @@ pub(crate) fn symbol_edge(
         edge_kind,
         confidence,
         EdgeContext::default(),
+        callee_span,
     )
 }
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn symbol_edge_with_context(
     symbols: &[IndexedSymbol],
     node: Node<'_>,
@@ -568,6 +625,11 @@ pub(crate) fn symbol_edge_with_context(
     edge_kind: EdgeKind,
     confidence: EdgeConfidence,
     context: EdgeContext,
+    // Byte range of the callee identifier token (the final `::`/`.` segment), or `None` when no
+    // clean identifier node is available. `node` here is the whole call/reference expression, so
+    // it can't be used for this — the caller locates the identifier via the `*_node` helpers
+    // and passes its range. See [`CalleeRange`] and #67.
+    callee_span: Option<CalleeRange>,
 ) -> EdgeCandidate {
     let byte = node.start_byte();
     let source = containing_symbol(symbols, byte);
@@ -579,6 +641,7 @@ pub(crate) fn symbol_edge_with_context(
         evidence: (!text.is_empty()).then(|| edge_evidence(node, text)),
         receiver_hint: context.receiver_hint,
         source_span: span_for_node(node),
+        callee_span,
         edge_kind,
         confidence,
     }

--- a/crates/rag-rat-core/src/index/edges/helpers.rs
+++ b/crates/rag-rat-core/src/index/edges/helpers.rs
@@ -37,6 +37,17 @@ pub(crate) fn call_target_name(node: Node<'_>, text: &str) -> Option<String> {
         .map(|name| short_name(&name).to_string())
         .or_else(|| first_identifier_text(node, text))
 }
+/// The callee identifier node for a call expression — the same token [`call_target_name`] names,
+/// returned as a node so its byte range can be recorded (SCIP occurrences key on the identifier's
+/// position, #67). Points at the FINAL `::`/`.` segment (the callee name itself), matching how
+/// `call_target_name`'s `short_name` collapses a path to its tail. `None` when no clean identifier
+/// node is available — never guess a wrong range.
+pub(crate) fn call_target_node(node: Node<'_>) -> Option<Node<'_>> {
+    node.child_by_field_name("function")
+        .and_then(last_identifier_node)
+        .or_else(|| first_identifier_node(node))
+        .map(final_segment_node)
+}
 pub(crate) fn scoped_receiver_name(node: Node<'_>, text: &str) -> Option<String> {
     let function = node.child_by_field_name("function").unwrap_or(node);
     let value = node_text(function, text);
@@ -91,6 +102,53 @@ pub(crate) fn collect_identifiers(node: Node<'_>, text: &str, out: &mut Vec<Stri
     for child in node.named_children(&mut cursor) {
         collect_identifiers(child, text, out);
     }
+}
+/// Node-returning twin of [`first_identifier_text`]: the first identifier-kind node in document
+/// order, so its byte range can be recorded for the SCIP join (#67). Same traversal, so the node it
+/// returns is exactly the token whose text [`first_identifier_text`] would have produced.
+pub(crate) fn first_identifier_node(node: Node<'_>) -> Option<Node<'_>> {
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        if is_identifier_kind(child.kind()) {
+            return Some(child);
+        }
+        if let Some(found) = first_identifier_node(child) {
+            return Some(found);
+        }
+    }
+    None
+}
+/// Node-returning twin of [`last_identifier_text`]: the last identifier-kind node under `node`.
+pub(crate) fn last_identifier_node(node: Node<'_>) -> Option<Node<'_>> {
+    identifier_nodes_under(node).into_iter().last()
+}
+/// Node-returning twin of [`identifiers_under`]: every identifier-kind node under `node`, in the
+/// same document order, so the callee (`.last()`) and receiver (`.first()`) nodes line up 1:1 with
+/// the strings the TS/Kotlin/C extractors already pick out of [`identifiers_under`]. The byte range
+/// of the matching node is what the SCIP join keys on (#67).
+pub(crate) fn identifier_nodes_under<'tree>(node: Node<'tree>) -> Vec<Node<'tree>> {
+    let mut out = Vec::new();
+    collect_identifier_nodes(node, &mut out);
+    out
+}
+fn collect_identifier_nodes<'tree>(node: Node<'tree>, out: &mut Vec<Node<'tree>>) {
+    if is_identifier_kind(node.kind()) {
+        out.push(node);
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        collect_identifier_nodes(child, out);
+    }
+}
+/// Narrow a scoped/dotted identifier node (`scoped_identifier` / `scoped_type_identifier`, whose
+/// text is the full `a::b::c`) down to its final segment — the callee/type name `c`. The
+/// tree-sitter grammars expose the tail as the `name` field; without it (a plain `identifier`) the
+/// node is already the final segment, so return it unchanged. This makes the recorded byte range
+/// cover only the callee identifier, matching how `short_name` collapses the printed name and how
+/// SCIP keys the occurrence.
+pub(crate) fn final_segment_node(node: Node<'_>) -> Node<'_> {
+    node.child_by_field_name("name").unwrap_or(node)
 }
 pub(crate) fn is_identifier_kind(kind: &str) -> bool {
     matches!(
@@ -201,15 +259,25 @@ pub(crate) fn insert_candidates(
         }
         // prepare_cached: this INSERT runs once per edge. conn.execute
         // recompiles the SQL every call; the cached statement compiles once per connection.
+        // NULL when the candidate has no callee identifier range (non-call / file-level edges)
+        // (#67).
+        let (callee_start_byte, callee_end_byte) = match candidate.callee_span {
+            Some(range) => (
+                Some(i64::try_from(range.start_byte).unwrap_or(0)),
+                Some(i64::try_from(range.end_byte).unwrap_or(0)),
+            ),
+            None => (None, None),
+        };
         conn.prepare_cached(
             "
             INSERT INTO edges(
                 source_file_id, from_symbol_id, from_name, to_name,
                 target_qualified_name, evidence, receiver_hint,
                 source_start_line, source_end_line, source_start_byte, source_end_byte,
+                callee_start_byte, callee_end_byte,
                 edge_kind, confidence
             )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
             ",
         )?
         .execute(params![
@@ -224,6 +292,8 @@ pub(crate) fn insert_candidates(
             candidate.source_span.end_line,
             candidate.source_span.start_byte,
             candidate.source_span.end_byte,
+            callee_start_byte,
+            callee_end_byte,
             candidate.edge_kind.as_str(),
             candidate.confidence.as_str(),
         ])?;

--- a/crates/rag-rat-core/src/index/edges/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/mod.rs
@@ -64,6 +64,26 @@ impl EdgeConfidence {
     }
 }
 
+/// Byte range of the callee identifier token (the final `::`/`.` segment of the called name), as
+/// `text[start_byte..end_byte]`. Distinct from `EdgeCandidate.source_span`, which covers the whole
+/// `call_expression`. SCIP occurrences key on the identifier token's position, so the SCIP-oracle
+/// join (#61) needs this range; `(line, col)` in the document's position encoding is derived at
+/// join time from the checkout bytes, so only the byte range is stored. Set only for
+/// symbol-referencing edges (built via `symbol_edge`/`symbol_edge_with_context`); `None` for
+/// file-level / `contains` edges and for constructs where a clean identifier node isn't available.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CalleeRange {
+    start_byte: usize,
+    end_byte: usize,
+}
+
+impl CalleeRange {
+    /// The byte range of a tree-sitter node — the callee identifier token's `start_byte..end_byte`.
+    pub(crate) fn of_node(node: Node<'_>) -> Self {
+        CalleeRange { start_byte: node.start_byte(), end_byte: node.end_byte() }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct EdgeCandidate {
     from_symbol_id: Option<i64>,
@@ -73,6 +93,9 @@ pub(crate) struct EdgeCandidate {
     evidence: Option<String>,
     receiver_hint: Option<String>,
     source_span: EdgeSpan,
+    /// Byte range of the callee identifier token; see [`CalleeRange`]. `None` for non-symbol
+    /// edges.
+    callee_span: Option<CalleeRange>,
     edge_kind: EdgeKind,
     confidence: EdgeConfidence,
 }
@@ -194,6 +217,14 @@ impl CompactSpan {
 /// ids and the span shrinks to [`CompactSpan`], taking the per-edge footprint from ~184 bytes (with
 /// five owned `Option<String>`) to ~64 — the dominant lever on full-rebuild peak RSS, since the
 /// edge accumulator is held in full until resolution.
+///
+/// The callee identifier byte range is two bare `u32`s, NOT `Option<CalleeRange>`: `u32::MAX` is
+/// the none-sentinel (mirroring [`OptSym`]'s niche), so the optional range costs 8 bytes flat
+/// rather than the 24 an `Option<(usize, usize)>` would. Safe because graph-parsed files are
+/// bounded at `MAX_GRAPH_PARSE_BYTES` (512_000), so every real byte offset fits `u32` with
+/// `u32::MAX` free as the sentinel. Footprint delta: +8 bytes/edge (~64 → ~72) — at the kernel's
+/// ~11M candidates that is ~88 MB of additional accumulator, held only until the single
+/// resolve-and-insert pass.
 struct CompactEdge {
     from_symbol_id: Option<i64>,
     from_name: OptSym,
@@ -202,8 +233,39 @@ struct CompactEdge {
     evidence: OptSym,
     receiver_hint: OptSym,
     source_span: CompactSpan,
+    /// Callee identifier byte range; `u32::MAX` in `callee_start_byte` is the `None` sentinel.
+    callee_start_byte: u32,
+    callee_end_byte: u32,
     edge_kind: EdgeKind,
     confidence: EdgeConfidence,
+}
+
+impl CompactEdge {
+    /// `u32::MAX` sentinel marking an absent callee range (mirrors [`OptSym::NONE`]).
+    const CALLEE_NONE: u32 = u32::MAX;
+
+    /// Pack `Option<CalleeRange>` into the two `u32` fields, clamping like [`CompactSpan`] and
+    /// using `u32::MAX` for `None`. A real offset can never collide with the sentinel: it is
+    /// bounded by `MAX_GRAPH_PARSE_BYTES` ≪ `u32::MAX`.
+    fn pack_callee(span: Option<CalleeRange>) -> (u32, u32) {
+        match span {
+            Some(range) => {
+                let clamp = |value: usize| u32::try_from(value).unwrap_or(0);
+                (clamp(range.start_byte), clamp(range.end_byte))
+            },
+            None => (Self::CALLEE_NONE, Self::CALLEE_NONE),
+        }
+    }
+
+    /// The stored callee byte range as nullable `i64`s for the edge-row insert: `(NULL, NULL)` when
+    /// the sentinel marks an absent range, otherwise the two offsets.
+    fn callee_byte_columns(&self) -> (Option<i64>, Option<i64>) {
+        if self.callee_start_byte == Self::CALLEE_NONE {
+            (None, None)
+        } else {
+            (Some(i64::from(self.callee_start_byte)), Some(i64::from(self.callee_end_byte)))
+        }
+    }
 }
 
 /// Symbols (with real DB ids) and edge candidates (with their source file id) accumulated across
@@ -247,6 +309,7 @@ impl FullRebuildGraph {
         let from_symbol_id = candidate.from_symbol_id.and_then(|local| {
             usize::try_from(local).ok().and_then(|index| db_ids.get(index)).copied()
         });
+        let (callee_start_byte, callee_end_byte) = CompactEdge::pack_callee(candidate.callee_span);
         let compact = CompactEdge {
             from_symbol_id,
             from_name: self.arena.intern_opt(candidate.from_name.as_deref()),
@@ -257,6 +320,8 @@ impl FullRebuildGraph {
             evidence: self.arena.intern_opt(candidate.evidence.as_deref()),
             receiver_hint: self.arena.intern_opt(candidate.receiver_hint.as_deref()),
             source_span: CompactSpan::from_span(candidate.source_span),
+            callee_start_byte,
+            callee_end_byte,
             edge_kind: candidate.edge_kind,
             confidence: candidate.confidence,
         };

--- a/crates/rag-rat-core/src/index/edges/resolve.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve.rs
@@ -186,16 +186,21 @@ pub(crate) fn resolve_and_insert_edges(
                     (None, confidence, None, None, "unresolved")
                 },
             };
+        // NULL when the sentinel marks an absent callee range; see
+        // `CompactEdge::callee_byte_columns`.
+        let (callee_start_byte, callee_end_byte) = candidate.callee_byte_columns();
         conn.prepare_cached(
             "
             INSERT INTO edges(
                 source_file_id, from_symbol_id, from_name, to_name,
                 target_qualified_name, evidence, receiver_hint,
                 source_start_line, source_end_line, source_start_byte, source_end_byte,
+                callee_start_byte, callee_end_byte,
                 edge_kind, confidence,
                 to_symbol_id, target_start_line, target_end_line, resolution
             )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, \
+             ?18, ?19)
             ",
         )?
         .execute(params![
@@ -210,6 +215,8 @@ pub(crate) fn resolve_and_insert_edges(
             i64::from(candidate.source_span.end_line),
             i64::from(candidate.source_span.start_byte),
             i64::from(candidate.source_span.end_byte),
+            callee_start_byte,
+            callee_end_byte,
             candidate.edge_kind.as_str(),
             confidence.as_str(),
             to_symbol_id,

--- a/crates/rag-rat-core/src/index/schema/baseline.rs
+++ b/crates/rag-rat-core/src/index/schema/baseline.rs
@@ -109,6 +109,10 @@ pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
             evidence TEXT,
             receiver_hint TEXT,
             resolution TEXT NOT NULL DEFAULT 'unresolved',
+            -- Callee identifier byte range (the SCIP occurrence key, #67); NULL for non-call /
+            -- file-level edges. source_*_byte covers the whole call_expression, these the token.
+            callee_start_byte INTEGER,
+            callee_end_byte INTEGER,
             edge_kind TEXT NOT NULL,
             confidence TEXT NOT NULL,
             FOREIGN KEY(source_file_id) REFERENCES files(id) ON DELETE CASCADE,

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -441,6 +441,19 @@ pub(crate) fn apply_symbol_line_spans(conn: &Connection) -> rusqlite::Result<()>
     Ok(())
 }
 
+pub(crate) fn apply_edge_callee_byte_range(conn: &Connection) -> rusqlite::Result<()> {
+    // Byte range of the callee identifier token on symbol-referencing edges (the SCIP-oracle
+    // prerequisite, #67). `source_start_byte`/`source_end_byte` cover the whole call_expression;
+    // SCIP occurrences key on the identifier token, so these two columns carry its range instead.
+    // Additive + NULLABLE on purpose: existing rows and non-call edges (contains / imports /
+    // exports / file-level) keep NULL, so the change is byte-identical for prior data. `(line,
+    // col)` in the document's position encoding is derived at join time from checkout bytes —
+    // not stored.
+    add_column_if_missing(conn, "edges", "callee_start_byte", "INTEGER")?;
+    add_column_if_missing(conn, "edges", "callee_end_byte", "INTEGER")?;
+    Ok(())
+}
+
 pub(crate) fn applied_migrations(conn: &Connection) -> anyhow::Result<Vec<AppliedMigration>> {
     let mut stmt = conn.prepare(
         "
@@ -484,6 +497,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_014_ID => Some(14),
             MIGRATION_015_ID => Some(15),
             MIGRATION_016_ID => Some(16),
+            MIGRATION_017_ID => Some(17),
             _ => None,
         })
         .max()
@@ -509,6 +523,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_014_ID
             | MIGRATION_015_ID
             | MIGRATION_016_ID
+            | MIGRATION_017_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -531,6 +546,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_014_ID => migration.checksum != MIGRATION_014_CHECKSUM,
         MIGRATION_015_ID => migration.checksum != MIGRATION_015_CHECKSUM,
         MIGRATION_016_ID => migration.checksum != MIGRATION_016_CHECKSUM,
+        MIGRATION_017_ID => migration.checksum != MIGRATION_017_CHECKSUM,
         _ => false,
     }
 }

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use migrations::*;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 16;
+pub const LATEST_SCHEMA_VERSION: u32 = 17;
 const DIRTY_MIGRATION_ID: &str = "__dirty__";
 const MIGRATION_001_ID: &str = "001_sqlite_storage_baseline";
 const MIGRATION_001_CHECKSUM: &str = "sha256:rag-rat-sqlite-baseline-v1";
@@ -72,6 +72,10 @@ const MIGRATION_016_ID: &str = "016_symbol_line_spans";
 const MIGRATION_016_CHECKSUM: &str = "sha256:rag-rat-symbol-line-spans-v16";
 const MIGRATION_016_DESCRIPTION: &str = "Store start_line/end_line on symbols so readers skip the \
                                          per-symbol chunk-containment subqueries";
+const MIGRATION_017_ID: &str = "017_edge_callee_byte_range";
+const MIGRATION_017_CHECKSUM: &str = "sha256:rag-rat-edge-callee-byte-range-v17";
+const MIGRATION_017_DESCRIPTION: &str =
+    "Add callee identifier byte range to edges for the SCIP occurrence join (#61 prerequisite)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -156,6 +160,8 @@ pub fn apply(conn: &Connection) -> rusqlite::Result<()> {
     record_migration(conn, MIGRATION_015_ID, MIGRATION_015_CHECKSUM, MIGRATION_015_DESCRIPTION)?;
     apply_symbol_line_spans(conn)?;
     record_migration(conn, MIGRATION_016_ID, MIGRATION_016_CHECKSUM, MIGRATION_016_DESCRIPTION)?;
+    apply_edge_callee_byte_range(conn)?;
+    record_migration(conn, MIGRATION_017_ID, MIGRATION_017_CHECKSUM, MIGRATION_017_DESCRIPTION)?;
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -247,6 +247,9 @@ fn migrate_adds_edge_name_columns_before_indexing_them() {
     assert!(columns.contains(&"source_end_byte".to_string()));
     assert!(columns.contains(&"target_start_line".to_string()));
     assert!(columns.contains(&"target_end_line".to_string()));
+    // The SCIP-oracle prerequisite columns (#67) are added additively to a legacy edges table.
+    assert!(columns.contains(&"callee_start_byte".to_string()));
+    assert!(columns.contains(&"callee_end_byte".to_string()));
     assert_eq!(table_count(&db, "idx_edges_from_name"), 1);
     assert_eq!(table_count(&db, "idx_edges_to_name"), 1);
 
@@ -1629,6 +1632,155 @@ fn caller() {
         }),
         "helper callers: {callers:?}"
     );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+/// The callee identifier byte range (#67) stored on the single edge matching
+/// `from LIKE %from% AND to_name LIKE %to% AND edge_kind`, as `Option<(start, end)>`.
+/// `None` means the column is NULL (no callee range recorded).
+fn callee_byte_range(
+    db: &IndexDatabase,
+    from: &str,
+    to: &str,
+    edge_kind: &str,
+) -> Option<(i64, i64)> {
+    let (start, end) = db
+        .storage
+        .connection()
+        .query_row(
+            "
+                SELECT callee_start_byte, callee_end_byte
+                FROM edges
+                WHERE edge_kind = ?1
+                  AND COALESCE(from_name, '') LIKE ?2
+                  AND to_name LIKE ?3
+                ",
+            params![edge_kind, format!("%{from}%"), format!("%{to}%")],
+            |row| Ok((row.get::<_, Option<i64>>(0)?, row.get::<_, Option<i64>>(1)?)),
+        )
+        .unwrap();
+    match (start, end) {
+        (Some(start), Some(end)) => Some((start, end)),
+        _ => None,
+    }
+}
+
+#[test]
+fn calls_name_edge_stores_callee_identifier_byte_range_not_whole_call() {
+    // #67: SCIP occurrences key on the callee identifier token, but source_start_byte covers the
+    // whole call_expression. The new callee_*_byte columns must span exactly the identifier:
+    //   `foo`   in `foo(a, b)`     (plain call)
+    //   `method` in `obj.method(x)` (final segment of a method call)
+    //   `c`     in `a::b::c()`     (final segment of a path call)
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    let source = r#"
+fn foo(a: u32, b: u32) -> u32 {
+    a + b
+}
+
+mod nested {
+    pub mod inner {
+        pub fn c() {}
+    }
+}
+
+struct Obj;
+
+impl Obj {
+    fn method(&self, _x: u32) {}
+}
+
+fn driver() {
+    let obj = Obj;
+    foo(1, 2);
+    obj.method(3);
+    nested::inner::c();
+}
+"#;
+    fs::write(root.join("src/lib.rs"), source).unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let assert_callee = |to: &str, expected: &str| {
+        let (start, end) = callee_byte_range(&db, "driver", to, "calls_name")
+            .unwrap_or_else(|| panic!("no callee range for driver -> {to}"));
+        let (start, end) = (start as usize, end as usize);
+        assert_eq!(
+            &source[start..end],
+            expected,
+            "callee range for driver -> {to} should be exactly `{expected}`, got `{}`",
+            &source[start..end]
+        );
+        // It must NOT be the whole call expression (that would include the `(`).
+        assert!(
+            !source[start..end].contains('('),
+            "callee range for driver -> {to} must not span the whole call: `{}`",
+            &source[start..end]
+        );
+    };
+
+    assert_callee("foo", "foo");
+    assert_callee("method", "method");
+    assert_callee("c", "c");
+
+    // A `contains` edge (parent symbol -> child symbol) has no callee identifier → NULL.
+    let contains = callee_byte_range(&db, "Obj", "method", "contains");
+    assert_eq!(contains, None, "contains edges must have a NULL callee range");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn imports_edge_has_null_callee_byte_range() {
+    // #67: file-level edges (imports / exports) carry no callee identifier range.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "mod worker;\n\nfn touch() {\n    worker::run();\n}\n")
+        .unwrap();
+    fs::write(root.join("src/worker.rs"), "pub fn run() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let import = callee_byte_range(&db, "src/lib.rs", "worker", "imports");
+    assert_eq!(import, None, "imports edges must have a NULL callee range");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn c_calls_name_edge_stores_callee_identifier_byte_range() {
+    // #67: at least one non-Rust language. A C call `helper(runtime)` stores the range of `helper`,
+    // not the whole `helper(runtime)` call expression.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    let source = r#"
+typedef struct Runtime Runtime;
+
+struct Runtime {
+  int state;
+};
+
+int helper(Runtime *runtime) {
+  return runtime->state;
+}
+
+int runtime_open(Runtime *runtime) {
+  return helper(runtime);
+}
+"#;
+    fs::write(root.join("src/runtime.c"), source).unwrap();
+    let config = source_config(root.clone(), Language::C);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let (start, end) = callee_byte_range(&db, "runtime_open", "helper", "calls_name")
+        .expect("no callee range for runtime_open -> helper");
+    let (start, end) = (start as usize, end as usize);
+    assert_eq!(&source[start..end], "helper", "C callee range must span exactly `helper`");
 
     fs::remove_dir_all(root).unwrap();
 }


### PR DESCRIPTION
Fixes #67. Byte-identical-guarded prerequisite for the SCIP oracle epic (#61).

For a `calls_name` (and `references_type` / `constructs` / `uses_macro` / `implements`) edge the source span is `span_for_node(node)` over the whole `call_expression`, but SCIP occurrences key on the **callee identifier token's** position. This records that token's byte range on each symbol-referencing edge so the SCIP-oracle join can match on it. `(line, col)` in the document's `position_encoding` is derived at join time from checkout bytes, so only the byte range is stored.

## Design → change map

1. **`EdgeCandidate.callee_span: Option<CalleeRange { start_byte, end_byte }>`** (`edges/mod.rs`) — set ONLY for symbol-referencing edges built via `symbol_edge` / `symbol_edge_with_context` (new trailing `callee_span` param). `None` for `contains` / `imports` / `exports` / file-level (`file_edge`) edges and for the impl-header string-split `implements` / `references_type` in `rust_impl_edges` (no clean identifier node).

2. **Extractor threading** (`edges/extract.rs` + `edges/helpers.rs`) — added node-returning twins of the existing name helpers: `call_target_node`, `first_identifier_node`, `last_identifier_node`, `identifier_nodes_under`, and `final_segment_node`. Each call site passes `node.map(CalleeRange::of_node)`. Covers **all** edge-building languages: `rust_edges`, `typescript_edges`, `kotlin_edges`, `c_like_edges`, `rust_impl_edges`. Multi-segment paths point at the **final** identifier segment (`obj.method` → `method`, `a::b::c` → `c`) via `final_segment_node` narrowing a `scoped_identifier`/`scoped_type_identifier` to its `name` field — matching how SCIP keys the occurrence. The scoped-receiver `references_type` (`Foo::bar()`) points at the **first** segment (`Foo`), since that's the type referenced.

3. **`CompactEdge`** (`edges/mod.rs`) — stores the range as **two bare `u32` fields with `u32::MAX` as the none-sentinel** (`CALLEE_NONE`), NOT an `Option`, mirroring the `OptSym` niche. `pack_callee` clamps + sentinels on intern; `callee_byte_columns()` hydrates back to `(NULL, NULL)` for the insert. **Footprint delta: +8 bytes/edge (~64 → ~72)** — at the kernel's ~11M candidates, ~88 MB of additional accumulator held only until the single resolve-and-insert pass. Safe because graph-parsed files are bounded by `MAX_GRAPH_PARSE_BYTES` = 512_000, so offsets fit `u32` and `u32::MAX` is a free sentinel.

4. **Schema** — additive **nullable** `callee_start_byte` / `callee_end_byte` INTEGER columns via the `add_column_if_missing` pattern. New migration `apply_edge_callee_byte_range`, registered as **V017** in `mod.rs` (`LATEST_SCHEMA_VERSION` 16 → 17) + `known_version` / `known_migration` / `migration_checksum_mismatch`. `baseline.rs` carries the columns for fresh DBs. The pre-squash convention (additive migrations on top of baseline) is preserved — no baseline edited in place.

5. **Insert paths** — both the full-rebuild insert (`resolve.rs::resolve_and_insert_edges`, via `CompactEdge::callee_byte_columns()`) and the incremental insert (`helpers.rs::insert_candidates`, from `candidate.callee_span`) write the two columns, NULL when the range is absent. All `INSERT INTO edges` use explicit column lists, so the added columns are positionally safe.

## Byte-identical verification

The columns are additive + nullable, so existing edge fields and their content fingerprints do not move. Confirmed by the full `cargo test -p rag-rat-core` suite passing unchanged (194 tests), including `server_derived_call_path_hash_is_stable_and_validates_through_edge_churn` — the cp1 sorted edge-fingerprint hash over the existing fields. Non-call / file-level edges keep NULL.

## Tests added (`schema_bootstrap_tests.rs`)

- `calls_name_edge_stores_callee_identifier_byte_range_not_whole_call` — Rust `foo(a, b)` → `text[start..end] == "foo"` (and asserts it does NOT span the whole call); `obj.method(x)` → `method`; `a::b::c()` → `c`; a `contains` edge has NULL callee range.
- `imports_edge_has_null_callee_byte_range` — file-level `imports` edge has NULL.
- `c_calls_name_edge_stores_callee_identifier_byte_range` — non-Rust coverage: C `helper(runtime)` → `helper`.
- Extended `migrate_adds_edge_name_columns_before_indexing_them` to assert the two new columns are added to a legacy edges table.

`cargo +nightly fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo test -p rag-rat-core` all clean/green.