### PR TITLE
feat(oracle): SCIP phase 1 — reader, occurrence→edge join, heuristic precision/recall eval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,7 +1150,7 @@ dependencies = [
  "gix-worktree-stream",
  "nonempty",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1177,7 +1177,7 @@ dependencies = [
  "gix-trace",
  "kstring",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "unicode-bom",
 ]
 
@@ -1240,7 +1240,7 @@ dependencies = [
  "gix-ref",
  "gix-sec",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "unicode-bom",
 ]
 
@@ -1254,7 +1254,7 @@ dependencies = [
  "bstr",
  "gix-path",
  "libc",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1290,7 +1290,7 @@ dependencies = [
  "gix-trace",
  "gix-traverse",
  "gix-worktree",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1310,7 +1310,7 @@ dependencies = [
  "gix-trace",
  "gix-utils",
  "gix-worktree",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1325,7 +1325,7 @@ dependencies = [
  "gix-path",
  "gix-ref",
  "gix-sec",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1353,7 +1353,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "prodash",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "zlib-rs",
 ]
@@ -1376,7 +1376,7 @@ dependencies = [
  "gix-trace",
  "gix-utils",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1390,7 +1390,7 @@ dependencies = [
  "gix-features",
  "gix-path",
  "gix-utils",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1414,7 +1414,7 @@ dependencies = [
  "faster-hex",
  "gix-features",
  "sha1-checked",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1476,7 +1476,7 @@ dependencies = [
  "memmap2",
  "rustix",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1487,7 +1487,7 @@ checksum = "65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1506,7 +1506,7 @@ dependencies = [
  "gix-validate",
  "itoa",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1527,7 +1527,7 @@ dependencies = [
  "memmap2",
  "parking_lot",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1546,7 +1546,7 @@ dependencies = [
  "gix-path",
  "memmap2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1558,7 +1558,7 @@ dependencies = [
  "bstr",
  "faster-hex",
  "gix-trace",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1570,7 +1570,7 @@ dependencies = [
  "bstr",
  "gix-trace",
  "gix-validate",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1585,7 +1585,7 @@ dependencies = [
  "gix-config-value",
  "gix-glob",
  "gix-path",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1604,7 +1604,7 @@ dependencies = [
  "gix-utils",
  "maybe-async",
  "nonempty",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1635,7 +1635,7 @@ dependencies = [
  "gix-utils",
  "gix-validate",
  "memmap2",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1651,7 +1651,7 @@ dependencies = [
  "gix-revision",
  "gix-validate",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1683,7 +1683,7 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1708,7 +1708,7 @@ dependencies = [
  "gix-hash",
  "gix-lock",
  "nonempty",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1731,7 +1731,7 @@ dependencies = [
  "gix-pathspec",
  "gix-worktree",
  "portable-atomic",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1746,7 +1746,7 @@ dependencies = [
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1781,7 +1781,7 @@ dependencies = [
  "gix-quote",
  "gix-sec",
  "gix-url",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1798,7 +1798,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1810,7 +1810,7 @@ dependencies = [
  "bstr",
  "gix-path",
  "percent-encoding",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1986,7 +1986,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "ureq 2.12.1",
  "windows-sys 0.60.2",
 ]
@@ -2006,7 +2006,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "ureq 3.3.0",
  "windows-sys 0.61.2",
 ]
@@ -3021,6 +3021,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3034,7 +3054,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -3055,7 +3075,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3124,13 +3144,15 @@ dependencies = [
  "libc",
  "model2vec-rs",
  "notify",
+ "protobuf",
  "rayon",
  "regex",
  "rusqlite",
+ "scip",
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
+ "thiserror 2.0.18",
  "toml",
  "tree-sitter",
  "tree-sitter-c",
@@ -3237,7 +3259,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3360,7 +3382,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -3386,7 +3408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3534,6 +3556,15 @@ dependencies = [
  "quote",
  "serde_derive_internals",
  "syn",
+]
+
+[[package]]
+name = "scip"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46becf967b98a434bf7f19c8be30ca74bff57702ea7ef6af3628cbf52f57be0"
+dependencies = [
+ "protobuf",
 ]
 
 [[package]]
@@ -3817,11 +3848,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3929,7 +3980,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spm_precompiled",
- "thiserror",
+ "thiserror 2.0.18",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
@@ -3962,7 +4013,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spm_precompiled",
- "thiserror",
+ "thiserror 2.0.18",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -220,6 +220,10 @@ pub(crate) struct EvalArgs {
     /// Rewrite the baseline from this run's results.
     #[arg(long)]
     pub update_baseline: bool,
+    /// Optional pre-built `.scip` index to drive SCIP-oracle precision/recall metrics (#68).
+    /// Defaults to <root>/evals/oracle.scip when present; absent → oracle metrics skipped.
+    #[arg(long)]
+    pub scip: Option<PathBuf>,
     /// Emit JSON instead of the summary.
     #[arg(long)]
     pub json: bool,

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -108,6 +108,10 @@ pub(crate) fn eval(config: &Config, args: &EvalArgs) -> anyhow::Result<()> {
             .clone()
             .unwrap_or_else(|| default_eval_path(config, "expected_hits.toml")),
         update_baseline: args.update_baseline,
+        scip_path: args.scip.clone().or_else(|| {
+            let default = default_eval_path(config, "oracle.scip");
+            default.exists().then_some(default)
+        }),
     };
     let report = rag_rat_core::eval::run(config, &options)?;
     if args.json || options.update_baseline {

--- a/crates/rag-rat-cli/src/render.rs
+++ b/crates/rag-rat-cli/src/render.rs
@@ -31,6 +31,16 @@ pub(crate) fn print_eval_summary(report: &rag_rat_core::eval::EvalReport) {
     if let Some(precision) = report.metrics.papertrail_precision_sample {
         println!("eval: papertrail_precision_sample={precision:.3}");
     }
+    if let Some(oracle) = &report.oracle {
+        println!("{}", format_oracle_line(oracle));
+    }
+    if report.oracle_skipped_drifted > 0 {
+        println!(
+            "eval: WARNING oracle skipped {} candidate(s) on drifted source (file_sha mismatch); \
+             rebuild the index against the .scip checkout for complete oracle metrics",
+            report.oracle_skipped_drifted,
+        );
+    }
     println!(
         "eval: hash_vector_baseline model={} available={} current_artifacts={} mrr@10={:.3} \
          recall@10={:.3} delta_mrr@10={:+.3} delta_recall@10={:+.3}",
@@ -259,5 +269,61 @@ pub(crate) fn render_index_progress(progress: IndexProgress) {
         IndexProgress::Finished { files } => {
             eprintln!("index: complete ({files} files)");
         },
+    }
+}
+
+/// Format the one-line SCIP-oracle eval summary. Split out from `print_eval_summary` so the
+/// formatting is unit-testable without capturing stdout — the rates and raw counts must stay in the
+/// line so `eval` output is greppable.
+fn format_oracle_line(oracle: &rag_rat_core::index::oracle::OracleEvalMetrics) -> String {
+    format!(
+        "eval: oracle precision={:.3} recall={:.3} name_only_recovery={:.3} \
+         upgradeable_fraction={:.3} (confirm={} contradict={} upgrade={} external={} \
+         covered_calls={} oracle_only={})",
+        oracle.precision,
+        oracle.recall,
+        oracle.name_only_recovery_rate,
+        oracle.oracle_upgradeable_fraction,
+        oracle.confirmed,
+        oracle.contradicted,
+        oracle.upgraded,
+        oracle.resolved_external,
+        oracle.covered_calls,
+        oracle.oracle_only_calls,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use rag_rat_core::index::oracle::OracleEvalMetrics;
+
+    use super::format_oracle_line;
+
+    #[test]
+    fn oracle_line_carries_rates_and_raw_counts() {
+        let oracle = OracleEvalMetrics {
+            precision: 0.5,
+            recall: 0.75,
+            name_only_recovery_rate: 1.0,
+            oracle_upgradeable_fraction: 0.25,
+            confirmed: 3,
+            contradicted: 3,
+            upgraded: 2,
+            resolved_external: 1,
+            covered_calls: 12,
+            oracle_only_calls: 4,
+        };
+        let line = format_oracle_line(&oracle);
+        assert!(line.starts_with("eval: oracle "));
+        assert!(line.contains("precision=0.500"));
+        assert!(line.contains("recall=0.750"));
+        assert!(line.contains("upgradeable_fraction=0.250"));
+        // Raw counts present and greppable.
+        assert!(line.contains("confirm=3"));
+        assert!(line.contains("contradict=3"));
+        assert!(line.contains("upgrade=2"));
+        assert!(line.contains("external=1"));
+        assert!(line.contains("covered_calls=12"));
+        assert!(line.contains("oracle_only=4"));
     }
 }

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -21,6 +21,12 @@ notify = "8.2.0"
 rayon.workspace = true
 regex.workspace = true
 rusqlite.workspace = true
+# Sourcegraph SCIP protobuf types for the SCIP-oracle pass (#61/#68). Normal dependency — the
+# size budget is explicitly waived for SCIP; do NOT feature-gate or hand-copy the proto.
+# `protobuf` is scip's own transitive dep, pulled in directly so we can call `Message::parse_*`
+# on the generated SCIP types; pinned to the version scip 0.8 generates against.
+protobuf = "3.7"
+scip = "0.8.1"
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/rag-rat-core/src/eval.rs
+++ b/crates/rag-rat-core/src/eval.rs
@@ -6,9 +6,15 @@ use std::time::Instant;
 use serde::{Deserialize, Serialize};
 
 use crate::index::ai;
+use crate::index::oracle::{OracleEvalMetrics, OracleTool, RecallCalls};
 use crate::{Config, IndexDatabase};
 
 const TOP_K: usize = 10;
+
+/// Tool version recorded for the eval oracle pass. Eval consumes pre-built `.scip` fixtures, so the
+/// real indexer version isn't known here; a stable label keeps the `(file_sha, tool, tool_version)`
+/// staleness key deterministic across eval runs.
+const EVAL_ORACLE_TOOL_VERSION: &str = "eval-fixture";
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct EvalSuite {
@@ -74,6 +80,10 @@ pub struct EvalOptions {
     pub queries_path: PathBuf,
     pub expected_path: PathBuf,
     pub update_baseline: bool,
+    /// Optional pre-built `.scip` to drive the SCIP-oracle precision/recall metrics against the
+    /// eval corpus. `None` (or a missing path) skips the oracle pass — `EvalReport.oracle` is then
+    /// `None` and oracle metrics aren't gated.
+    pub scip_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Serialize)]
@@ -82,7 +92,21 @@ pub struct EvalReport {
     pub queries: usize,
     pub metrics: EvalMetrics,
     pub hash_vector_baseline: EvalBaselineReport,
+    /// SCIP-oracle precision/recall metrics (#68), present only when a `.scip` fixture was
+    /// supplied and the oracle pass ran.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oracle: Option<OracleEvalMetrics>,
+    /// Edge candidates the oracle pass skipped because their source file drifted between the index
+    /// build and the `.scip` (`file_sha` mismatch — content-integrity, #81 finding 2). Non-zero
+    /// means some documents were out of sync and their verdicts were correctly withheld; `eval`
+    /// surfaces it so the recall/precision numbers aren't silently computed over drifted content.
+    #[serde(skip_serializing_if = "is_zero")]
+    pub oracle_skipped_drifted: u64,
     pub results: Vec<EvalQueryReport>,
+}
+
+fn is_zero(value: &u64) -> bool {
+    *value == 0
 }
 
 #[derive(Debug, Serialize)]
@@ -192,14 +216,48 @@ pub fn run(config: &Config, options: &EvalOptions) -> anyhow::Result<EvalReport>
 
     let metrics = aggregate(&results);
     let baseline = hash_vector_baseline(config, &db, &suite.query, &expected, &metrics)?;
+    let oracle_eval = run_oracle_eval(&db, options)?;
+    let (oracle, oracle_skipped_drifted) = match oracle_eval {
+        Some((metrics, skipped_drifted)) => (Some(metrics), skipped_drifted),
+        None => (None, 0),
+    };
     let pass = metrics.stale_current_source_violations == 0 && results.iter().all(|r| r.passed);
     Ok(EvalReport {
         pass,
         queries: results.len(),
         metrics,
         hash_vector_baseline: baseline,
+        oracle,
+        oracle_skipped_drifted,
         results,
     })
+}
+
+/// Run the SCIP-oracle pass against the eval corpus from the supplied `.scip` fixture, returning
+/// its heuristic-vs-oracle metrics plus the count of candidates skipped for content drift. `None`
+/// when no fixture path is configured or the file is absent — the oracle is opt-in and never an
+/// error when unavailable (mirrors the missing-embedding degradation). The pass writes
+/// `edge_oracle` side rows; the heuristic `edges` rows are untouched.
+fn run_oracle_eval(
+    db: &IndexDatabase,
+    options: &EvalOptions,
+) -> anyhow::Result<Option<(OracleEvalMetrics, u64)>> {
+    let Some(scip_path) = options.scip_path.as_ref() else {
+        return Ok(None);
+    };
+    if !scip_path.exists() {
+        return Ok(None);
+    }
+    let scip_bytes = fs::read(scip_path).map_err(|err| {
+        anyhow::anyhow!("failed to read SCIP fixture {}: {err}", scip_path.display())
+    })?;
+    let report = db.run_oracle(OracleTool::RustAnalyzer, EVAL_ORACLE_TOOL_VERSION, &scip_bytes)?;
+    // Both recall sides come from the run, occurrence-counted over the call population.
+    let recall_calls =
+        RecallCalls { covered: report.covered_calls, oracle_only: report.oracle_only_calls };
+    let metrics =
+        db.oracle_eval_metrics(OracleTool::RustAnalyzer, EVAL_ORACLE_TOOL_VERSION, recall_calls)?;
+    Ok(Some((metrics, report.skipped_drifted)))
 }
 
 fn load_queries(path: &Path) -> anyhow::Result<EvalSuite> {
@@ -784,6 +842,7 @@ mod tests {
             queries_path: workspace_root().join("evals/queries.toml"),
             expected_path: workspace_root().join("evals/expected_hits.toml"),
             update_baseline: false,
+            scip_path: None,
         })
         .unwrap();
         assert_eq!(report.metrics.stale_current_source_violations, 0);
@@ -791,6 +850,91 @@ mod tests {
         assert!(report.metrics.recall_at_10 > 0.0);
 
         // Best-effort cleanup; do not fail the test on cleanup error.
+        let _ = std::fs::remove_dir_all(&db_dir);
+    }
+
+    /// When a `.scip` fixture is supplied, the eval suite runs the SCIP-oracle pass end-to-end
+    /// through the public `IndexDatabase` API (`run_oracle` + `oracle_eval_metrics`, both scoped to
+    /// the rebuilt fixture's active checkout) and attaches `OracleEvalMetrics` to the report. This
+    /// exercises `run_oracle_eval` and the `query_api` oracle wrappers — the integration seam the
+    /// unit tests can't reach (they call the `oracle::` functions directly on a synthetic conn).
+    #[test]
+    fn eval_suite_runs_oracle_when_scip_fixture_present() {
+        use ::protobuf::Message;
+        use ::scip::types::{
+            Document, Index as ScipIndexProto, Occurrence, PositionEncoding, SymbolRole,
+        };
+        use protobuf::EnumOrUnknown;
+
+        let root = fixture_root();
+        let mut config = Config::load(root.join("rag-rat.toml")).unwrap();
+        static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let mut db_dir = std::env::temp_dir();
+        db_dir.push(format!(
+            "rag-rat-eval-oracle-{}-{}",
+            std::process::id(),
+            COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&db_dir).unwrap();
+        config.database = db_dir.join("index.sqlite");
+
+        IndexDatabase::rebuild(&config).unwrap();
+
+        // A minimal but well-formed `.scip` over the fixture's `src/lib.rs`: a single reference to
+        // `open_database` plus its definition. The pass reads `src/lib.rs`'s real bytes for the
+        // position-encoding conversion, so the document path must match an indexed file.
+        let symbol = "scip-rust crate held-mini `open_database`().";
+        let index = ScipIndexProto {
+            documents: vec![Document {
+                relative_path: "src/lib.rs".to_string(),
+                occurrences: vec![
+                    // `open_database` is at line 2 (`pub fn open_database() {}`); its identifier
+                    // sits after "pub fn " (7 bytes) → chars 7..20 on line 2.
+                    Occurrence {
+                        range: vec![2, 7, 20],
+                        symbol: symbol.to_string(),
+                        symbol_roles: SymbolRole::Definition as i32,
+                        ..Default::default()
+                    },
+                ],
+                position_encoding: EnumOrUnknown::new(
+                    PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+                ),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let scip_path = db_dir.join("oracle.scip");
+        std::fs::write(&scip_path, index.write_to_bytes().unwrap()).unwrap();
+
+        let report = run(&config, &EvalOptions {
+            queries_path: workspace_root().join("evals/queries.toml"),
+            expected_path: workspace_root().join("evals/expected_hits.toml"),
+            update_baseline: false,
+            scip_path: Some(scip_path),
+        })
+        .unwrap();
+
+        // The oracle ran and produced metrics (rates are all in [0, 1]); the exact values depend on
+        // the fixture's edges, so we assert presence + bounds, not specific numbers.
+        let oracle = report.oracle.expect("oracle metrics attached when a .scip is supplied");
+        for rate in [
+            oracle.precision,
+            oracle.recall,
+            oracle.name_only_recovery_rate,
+            oracle.oracle_upgradeable_fraction,
+        ] {
+            assert!((0.0..=1.0).contains(&rate), "rate {rate} out of [0,1]");
+        }
+
+        // The run persisted an `oracle_runs` row + any verdicts; the status read (the other
+        // `query_api` oracle wrapper) reflects them for the same tool/version.
+        let db = IndexDatabase::open_config(&config).unwrap();
+        let status = db.oracle_status(OracleTool::RustAnalyzer, EVAL_ORACLE_TOOL_VERSION).unwrap();
+        assert_eq!(status.tool, "rust-analyzer");
+        assert_eq!(status.tool_version, EVAL_ORACLE_TOOL_VERSION);
+        assert_eq!(status.last_run_status.as_deref(), Some("Completed"));
+
         let _ = std::fs::remove_dir_all(&db_dir);
     }
 

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -5,6 +5,7 @@ pub mod edges;
 pub mod git_history;
 pub mod github;
 pub mod ignore_rules;
+pub mod oracle;
 pub mod parser;
 pub mod schema;
 pub mod symbols;

--- a/crates/rag-rat-core/src/index/oracle/join.rs
+++ b/crates/rag-rat-core/src/index/oracle/join.rs
@@ -1,0 +1,186 @@
+//! Occurrence → edge join. For each edge candidate carrying a callee identifier byte range, find
+//! the SCIP occurrence whose byte range **contains** that token (not line equality — identifiers
+//! share lines), resolve its symbol to a definition, and classify the result.
+//!
+//! Containment, not equality, is deliberate: tree-sitter's callee token range and SCIP's occurrence
+//! range need only overlap on the identifier, not match byte-for-byte (SCIP may bound the range
+//! slightly differently around generics/paths). We require the occurrence to *contain* the edge's
+//! token start, which is robust to those boundary differences while still being per-identifier.
+
+use super::scip::{ScipIndex, ScipOccurrence};
+use super::store::SymbolSpan;
+use super::{OracleReport, OracleResolutionKind};
+
+/// The classification for one edge candidate after the join — what to write to `edge_oracle`, or
+/// `None` when the oracle had nothing to say (no containing occurrence / unresolvable).
+#[derive(Debug, Clone)]
+pub(crate) struct EdgeVerdict {
+    pub(crate) resolved_symbol_id: Option<i64>,
+    pub(crate) scip_symbol: String,
+    pub(crate) kind: OracleResolutionKind,
+    /// The byte range of the occurrence that actually produced this verdict (the one
+    /// `find_containing_occurrence` selected — reference-preferred, full containment). The caller
+    /// marks EXACTLY this occurrence as covered, so the covered-marking and the verdict can never
+    /// disagree on overlapping occurrences (the weaker start-only/first-match `mark_covered`
+    /// could, #81 finding 4).
+    pub(crate) matched_occurrence: (usize, usize),
+}
+
+/// Inputs for classifying one edge against the oracle.
+pub(crate) struct JoinInput<'a> {
+    /// The edge's callee identifier byte range (`callee_start_byte..callee_end_byte`).
+    pub(crate) callee_start_byte: i64,
+    pub(crate) callee_end_byte: i64,
+    /// The heuristic confidence on the edge (`Exact` / `Syntactic` / `NameOnly` / `Ambiguous`).
+    pub(crate) confidence: &'a str,
+    /// The heuristic's resolved target symbol id, if any.
+    pub(crate) heuristic_symbol_id: Option<i64>,
+    /// Occurrences in the edge's source document (byte-keyed).
+    pub(crate) occurrences: &'a [ScipOccurrence],
+    /// The full parsed index, for definition lookup.
+    pub(crate) index: &'a ScipIndex,
+    /// Resolver from a definition `(path, byte-range)` to one of our symbol ids.
+    pub(crate) resolve_symbol: &'a dyn Fn(&str, usize, usize) -> Option<i64>,
+}
+
+/// Classify one edge candidate. Returns `None` when no occurrence contains the callee token (the
+/// `no_occurrence` bucket) or the reference occurrence has no resolvable definition.
+pub(crate) fn classify_edge(input: &JoinInput<'_>) -> Option<EdgeVerdict> {
+    let token_start = usize::try_from(input.callee_start_byte).ok()?;
+    let token_end = usize::try_from(input.callee_end_byte).ok()?;
+
+    // Find the reference occurrence containing the callee token. Prefer non-definition occurrences
+    // (a call site is a reference, not a definition); fall back to any containing occurrence.
+    let occurrence = find_containing_occurrence(input.occurrences, token_start, token_end)?;
+    let scip_symbol = occurrence.symbol.clone();
+    let matched_occurrence = (occurrence.start_byte, occurrence.end_byte);
+
+    // Where is this symbol defined?
+    let definition = input.index.definitions.get(&scip_symbol);
+    let resolved_symbol_id =
+        definition.and_then(|def| (input.resolve_symbol)(&def.path, def.start_byte, def.end_byte));
+
+    let kind = match (resolved_symbol_id, definition) {
+        // Definition inside the corpus → mapped to one of our symbols.
+        (Some(our_symbol), _) => classify_resolved(input, our_symbol),
+        // SCIP resolved the callee OUTSIDE the corpus (a definition the corpus doesn't index).
+        (None, Some(_)) => classify_external(input),
+        // SCIP referenced a symbol it has no definition for: treat package-bearing symbols as
+        // external (they name a dependency), drop the rest (no actionable oracle data).
+        (None, None) =>
+            if names_external_package(&scip_symbol) {
+                classify_external(input)
+            } else {
+                return None;
+            },
+    };
+
+    Some(EdgeVerdict { resolved_symbol_id, scip_symbol, kind, matched_occurrence })
+}
+
+/// For an in-corpus resolution, classify against the heuristic: confirm/contradict when the
+/// heuristic already resolved (Exact/Syntactic), upgrade otherwise (unresolved / NameOnly /
+/// Ambiguous).
+fn classify_resolved(input: &JoinInput<'_>, oracle_symbol_id: i64) -> OracleResolutionKind {
+    if heuristic_resolved_in_corpus(input) {
+        if input.heuristic_symbol_id == Some(oracle_symbol_id) {
+            OracleResolutionKind::Confirm
+        } else {
+            OracleResolutionKind::Contradict
+        }
+    } else {
+        OracleResolutionKind::Upgrade
+    }
+}
+
+/// Classify when SCIP resolves the callee to an EXTERNAL definition (outside the indexed corpus).
+///
+/// CRITICAL: `resolved-external` is NOT unconditional here. If the heuristic already resolved this
+/// edge to an IN-CORPUS symbol (`Exact`/`Syntactic` + `heuristic_symbol_id.is_some()`), SCIP's
+/// external resolution *disagrees* with that in-corpus target — the heuristic picked the wrong
+/// target (the real callee lives in a dependency) — so this is a **Contradict**, which counts in
+/// `confirm + contradict` and lowers precision honestly. `resolved-external` applies only when the
+/// heuristic did NOT resolve in-corpus (unresolved / `NameOnly` / `Ambiguous`): there is no
+/// in-corpus claim to contradict, just an external placement the heuristic missed.
+fn classify_external(input: &JoinInput<'_>) -> OracleResolutionKind {
+    if heuristic_resolved_in_corpus(input) {
+        OracleResolutionKind::Contradict
+    } else {
+        OracleResolutionKind::ResolvedExternal
+    }
+}
+
+/// Whether the heuristic already resolved this edge to an in-corpus symbol: an `Exact`/`Syntactic`
+/// confidence carrying a concrete `to_symbol_id`. This is the precondition for a confirm/contradict
+/// verdict (there is a heuristic claim to agree or disagree with).
+fn heuristic_resolved_in_corpus(input: &JoinInput<'_>) -> bool {
+    matches!(input.confidence, "Exact" | "Syntactic") && input.heuristic_symbol_id.is_some()
+}
+
+/// The occurrence whose byte range contains the callee token. Prefers a reference occurrence (the
+/// common case for a call site); a definition occurrence only matches a self-referential edge.
+fn find_containing_occurrence(
+    occurrences: &[ScipOccurrence],
+    token_start: usize,
+    token_end: usize,
+) -> Option<&ScipOccurrence> {
+    let contains = |occ: &ScipOccurrence| {
+        occ.start_byte <= token_start && token_end <= occ.end_byte && occ.start_byte < occ.end_byte
+    };
+    occurrences
+        .iter()
+        .find(|occ| !occ.is_definition && contains(occ))
+        .or_else(|| occurrences.iter().find(|occ| contains(occ)))
+}
+
+/// A SCIP symbol string names an external package when it parses to a symbol carrying a non-empty
+/// package component (manager/name/version). `local …` symbols are already filtered upstream.
+pub(crate) fn names_external_package(scip_symbol: &str) -> bool {
+    package_of(scip_symbol).is_some()
+}
+
+/// The package name component of a SCIP symbol (`scip::symbol::parse_symbol`), e.g. the crate name.
+/// `None` for local symbols or symbols without a package component.
+pub(crate) fn package_of(scip_symbol: &str) -> Option<String> {
+    let parsed = ::scip::symbol::parse_symbol(scip_symbol).ok()?;
+    let package = parsed.package.as_ref()?;
+    let name = package.name.trim();
+    if name.is_empty() { None } else { Some(name.to_string()) }
+}
+
+/// Map a SCIP definition byte-range to one of our symbols in `spans` by REAL containment: the
+/// symbol whose `[start_byte, end_byte]` actually contains the *whole* definition range
+/// (`span.start_byte <= def_start && def_end <= span.end_byte`), preferring the tightest (smallest)
+/// such span (so a method beats its enclosing impl). Returns the symbol id or `None`.
+///
+/// Containment is over the full def range — NOT just `def_start` — on purpose: a symbol whose span
+/// ends *before* the definition (a short helper preceding the real target) must NOT win. The
+/// earlier `def_start < span.end_byte.max(def_end)` predicate let exactly that happen — a large
+/// `def_end` pulled any span starting before `def_start` into the candidate set, so a preceding
+/// helper could be picked by `min_by_key`, recording the verdict against the WRONG symbol and
+/// corrupting precision/recall. Requiring `def_end <= span.end_byte` makes "contains" mean
+/// contains.
+pub(crate) fn map_definition_to_symbol(
+    spans: &[SymbolSpan],
+    def_start: usize,
+    def_end: usize,
+) -> Option<i64> {
+    let def_start = i64::try_from(def_start).ok()?;
+    let def_end = i64::try_from(def_end).ok()?;
+    spans
+        .iter()
+        .filter(|span| span.start_byte <= def_start && def_end <= span.end_byte)
+        .min_by_key(|span| span.end_byte - span.start_byte)
+        .map(|span| span.symbol_id)
+}
+
+/// Tally one verdict into the report's counters. Returns whether a row should be written
+/// (every verdict writes a row; the `None` no-op is handled by the caller).
+pub(crate) fn tally(report: &mut OracleReport, kind: OracleResolutionKind) {
+    match kind {
+        OracleResolutionKind::Upgrade => report.upgraded += 1,
+        OracleResolutionKind::ResolvedExternal => report.resolved_external += 1,
+        OracleResolutionKind::Confirm => report.confirmed += 1,
+        OracleResolutionKind::Contradict => report.contradicted += 1,
+    }
+}

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -1,0 +1,199 @@
+//! SCIP-oracle subsystem (#61 / #68 phase 1).
+//!
+//! Consumes a pre-built SCIP index (`rust-analyzer scip`, `scip-typescript`, …) and uses it as a
+//! *resolution oracle* for the tree-sitter graph: it confirms / contradicts heuristic edge
+//! resolutions and recovers low-confidence / unresolved ones with compiler-grade data. The pass is
+//! batch, diff-friendly, and opt-in — the same architectural slot as the embeddings `reconcile`.
+//!
+//! Phase 1 is **eval-only**: no CLI command, no MCP tool (those are #69). It reads a `.scip`,
+//! joins occurrences against edge candidates, writes `edge_oracle` side rows, and emits
+//! precision/recall metrics. The heuristic resolution on the `edges` row is **never** overwritten —
+//! both coexist so eval can diff them (see [`crate::index::schema::apply_oracle_tables`]).
+//!
+//! Layout mirrors `index/ai/`:
+//! - `scip.rs`  — `.scip` reader: per-document `position_encoding`-aware occurrence + definition
+//!   maps.
+//! - `join.rs`  — occurrence → edge join (identifier-token containment, not line equality).
+//! - `run.rs`   — the pass over edge candidates, producing an [`OracleReport`].
+//! - `status.rs`— status type surfaced like `local_ai_status`.
+//! - `store.rs` — `oracle_runs` / `edge_oracle` read + write helpers.
+
+mod join;
+mod run;
+mod scip;
+mod status;
+mod store;
+#[cfg(test)]
+mod tests;
+
+use std::path::Path;
+
+use run::OracleRunInput;
+pub use run::{OracleEvalMetrics, RecallCalls};
+use rusqlite::Connection;
+use serde::Serialize;
+pub use status::OracleStatus;
+
+/// Run one oracle pass over the current edge candidates from a pre-built `.scip` and return its
+/// [`OracleReport`]. Phase-1 public entry point (consumed by `eval`); no CLI/MCP surface yet (#69).
+///
+/// `checkout_root` is the source root whose bytes are read for per-document position-encoding
+/// conversion (the `.scip` document paths are relative to it).
+pub fn run_oracle(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+    scip_bytes: &[u8],
+    checkout_root: &Path,
+) -> anyhow::Result<OracleReport> {
+    run::run(conn, &OracleRunInput {
+        tool,
+        tool_version,
+        commit_sha,
+        worktree_id,
+        scip_bytes,
+        checkout_root,
+    })
+}
+
+/// Heuristic-vs-oracle eval metrics for a tool/version, diffing `edge_oracle` against `edges`,
+/// scoped to the active `(commit_sha, worktree_id)` checkout (the metric denominators must match
+/// the `edge_join_candidates` scope the run wrote through). [`RecallCalls`] carries the run's
+/// `(covered_calls, oracle_only_calls)` — BOTH occurrence-counted over the call population — so
+/// recall compares like with like; they come from the run's [`OracleReport`].
+pub fn oracle_eval_metrics(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+    recall_calls: RecallCalls,
+) -> anyhow::Result<OracleEvalMetrics> {
+    run::eval_metrics(conn, tool, tool_version, commit_sha, worktree_id, recall_calls)
+}
+
+/// Persisted oracle status for a tool/version, scoped to the active `(commit_sha, worktree_id)`
+/// checkout (the verdict counts must cover only this checkout, like the eval metrics).
+pub fn oracle_status(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<OracleStatus> {
+    status::status(conn, tool, tool_version, commit_sha, worktree_id)
+}
+
+/// The oracle tool that produced a SCIP index. Phase 1 ships only the Rust backend (consumed from a
+/// pre-built `.scip`); the enum is the registry seam phase 2 (#69) extends. Persisted enum →
+/// `as_db_str` / `from_db_str` per `rust-modern-style`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum OracleTool {
+    RustAnalyzer,
+}
+
+impl OracleTool {
+    pub fn as_db_str(self) -> &'static str {
+        match self {
+            Self::RustAnalyzer => "rust-analyzer",
+        }
+    }
+
+    pub fn from_db_str(value: &str) -> Option<Self> {
+        match value {
+            "rust-analyzer" => Some(Self::RustAnalyzer),
+            _ => None,
+        }
+    }
+}
+
+/// What the oracle concluded about one edge candidate. The names mirror the #61 design taxonomy.
+/// Persisted on `edge_oracle.kind`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum OracleResolutionKind {
+    /// An unresolved / `NameOnly` / `Ambiguous` edge whose callee the oracle resolved to a symbol
+    /// inside the corpus — a recovery the heuristic missed or under-resolved.
+    Upgrade,
+    /// The oracle resolved the callee to a definition **outside** the corpus (an external
+    /// dependency); `scip_symbol`'s package component names it. `resolved_symbol_id` is NULL.
+    ResolvedExternal,
+    /// An already-`Exact` / `Syntactic` edge whose oracle target agrees with the heuristic target.
+    /// The precision signal.
+    Confirm,
+    /// An already-`Exact` / `Syntactic` edge whose oracle target **disagrees** with the heuristic
+    /// target. Recorded for eval only — NEVER applied back to the heuristic `edges` row.
+    Contradict,
+}
+
+impl OracleResolutionKind {
+    pub fn as_db_str(self) -> &'static str {
+        match self {
+            Self::Upgrade => "upgrade",
+            Self::ResolvedExternal => "resolved-external",
+            Self::Confirm => "confirm",
+            Self::Contradict => "contradict",
+        }
+    }
+
+    pub fn from_db_str(value: &str) -> Option<Self> {
+        match value {
+            "upgrade" => Some(Self::Upgrade),
+            "resolved-external" => Some(Self::ResolvedExternal),
+            "confirm" => Some(Self::Confirm),
+            "contradict" => Some(Self::Contradict),
+            _ => None,
+        }
+    }
+}
+
+/// Outcome of an oracle pass, mirroring `ReconcileReport`'s shape (counts + a status string). One
+/// per `run()`; persisted opaquely as `oracle_runs.stats_json` and surfaced via [`OracleStatus`].
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct OracleReport {
+    /// Edge candidates examined (those carrying a callee byte range in the scoped source files).
+    pub edges_examined: u64,
+    /// Unresolved / low-confidence edges upgraded to an in-corpus symbol.
+    pub upgraded: u64,
+    /// Edges whose callee resolved to an external dependency.
+    pub resolved_external: u64,
+    /// Already-resolved edges the oracle confirmed.
+    pub confirmed: u64,
+    /// Already-resolved edges the oracle contradicted (recorded, never applied).
+    pub contradicted: u64,
+    /// Occurrences found by the oracle for which no matching edge candidate existed — the recall
+    /// gap (edges the heuristic never emitted at all). The DENOMINATOR's missed side. Counted over
+    /// the *call* population only (callable occurrences in indexed source whose def maps
+    /// in-corpus).
+    pub oracle_only_calls: u64,
+    /// Distinct *call* occurrences a `calls_name` edge DID cover — the covered side of recall,
+    /// counted over the SAME call-occurrence population as `oracle_only_calls` (both occurrence-
+    /// deduped, both call-only), so `recall = covered_calls / (covered_calls + oracle_only_calls)`
+    /// compares like with like. Non-call edge kinds (`references_type` / `uses_macro` / … ) carry
+    /// a callee byte range and produce verdicts, but never count here (#81 finding 1).
+    pub covered_calls: u64,
+    /// Candidates skipped because the disk bytes read for position conversion no longer match the
+    /// `file_sha` the edge candidate (and the `.scip`) were built against — the file drifted
+    /// between the indexer run and the `.scip` build. A verdict from drifted content joins
+    /// occurrence ranges (live disk bytes) against candidate ranges (indexed content) that no
+    /// longer correspond, so it is silently wrong; we skip it rather than persist a bogus
+    /// verdict (#81 finding 2). A non-zero count means `eval` should warn that some documents
+    /// were out of sync.
+    pub skipped_drifted: u64,
+    /// `local N` occurrences skipped (function-local, no cross-file meaning).
+    pub skipped_local: u64,
+    /// Candidates whose callee position fell outside any occurrence (no oracle data).
+    pub no_occurrence: u64,
+    /// `edge_oracle` rows written this pass.
+    pub rows_written: u64,
+    pub status: String,
+}
+
+/// An oracle backend: produces (or consumes) a SCIP index for a checkout. Phase 1 implements only
+/// the consume-existing-`.scip` path; the trait is the seam phase 2 (#69) fills with indexer
+/// invocation. Kept minimal on purpose.
+pub trait Oracle {
+    fn tool(&self) -> OracleTool;
+    fn tool_version(&self) -> &str;
+}

--- a/crates/rag-rat-core/src/index/oracle/run.rs
+++ b/crates/rag-rat-core/src/index/oracle/run.rs
@@ -1,0 +1,534 @@
+//! The oracle pass: consume a pre-built `.scip`, join its occurrences against edge candidates,
+//! write `edge_oracle` verdicts, and return an [`OracleReport`]. Phase 1 entry point — no indexer
+//! invocation, no CLI/MCP surface (#69).
+//!
+//! Resumable-friendly shape: candidates are loaded once and processed in document order, each
+//! verdict written independently, so a future incremental driver can scope `edge_join_candidates`
+//! to a changed-file set without touching this loop.
+
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use rusqlite::Connection;
+use sha2::{Digest, Sha256};
+
+use super::join::{self, JoinInput};
+use super::scip::{self, ScipIndex};
+use super::store::{self, CALL_EDGE_KIND, EdgeOracleRow};
+use super::{OracleReport, OracleResolutionKind, OracleTool};
+
+/// Inputs for one oracle pass.
+pub(crate) struct OracleRunInput<'a> {
+    pub(crate) tool: OracleTool,
+    pub(crate) tool_version: &'a str,
+    /// The commit/worktree the edges are scoped to (and which the `.scip` was built against).
+    pub(crate) commit_sha: &'a str,
+    pub(crate) worktree_id: &'a str,
+    /// Serialized `.scip` bytes.
+    pub(crate) scip_bytes: &'a [u8],
+    /// Checkout root: document paths in the `.scip` are joined against this to read current bytes
+    /// for position-encoding conversion.
+    pub(crate) checkout_root: &'a Path,
+}
+
+/// Run the oracle join over all current edge candidates and persist verdicts + a run row.
+///
+/// The run is **authoritative** for its `(tool, tool_version)`: it first clears that scope's prior
+/// `edge_oracle` rows, then writes the current `.scip`'s verdicts — all in one transaction. Without
+/// the clear, a rerun whose new `.scip` no longer yields a verdict for an edge would leave the
+/// prior (now stale) verdict in place (the per-edge upsert only overwrites edges the rerun
+/// revisits), so `status`/eval would keep counting a verdict the current oracle doesn't stand
+/// behind.
+pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Result<OracleReport> {
+    let mut report = OracleReport::default();
+
+    let candidates = store::edge_join_candidates(conn, input.commit_sha, input.worktree_id)?;
+
+    // Authoritative-rerun clear + the per-edge writes + the run row are one atomic unit, so the
+    // table is never observed mid-clear and a failed run rolls back to the prior verdicts. All
+    // inner reads/writes run on `conn` (the same underlying connection `tx` guards), so they
+    // are part of this transaction; `tx` exists only to BEGIN/COMMIT around them.
+    let tx = conn.unchecked_transaction()?;
+    store::clear_edge_oracle_for_tool(
+        conn,
+        input.tool,
+        input.tool_version,
+        input.commit_sha,
+        input.worktree_id,
+    )?;
+
+    // Parse the `.scip`, reading each document's current checkout bytes for encoding conversion.
+    // The bytes we read here are the SAME bytes whose hash we compare against each candidate's
+    // `file_sha` below (content-integrity, finding 2): occurrence byte ranges are derived from
+    // these live disk bytes, so if they drifted from what the edge candidate / `.scip` were
+    // built against, the join is comparing incompatible coordinate spaces.
+    let checkout_root = input.checkout_root.to_path_buf();
+    let mut source_cache: HashMap<String, Option<Vec<u8>>> = HashMap::new();
+    let index = ScipIndex::parse(input.scip_bytes, |path| {
+        source_cache
+            .entry(path.to_string())
+            .or_insert_with(|| std::fs::read(checkout_root.join(path)).ok())
+            .clone()
+    })?;
+
+    // Per-document hash of the disk bytes actually read, for the content-integrity check. A
+    // candidate whose `file_sha` (the `files.sha256` the edge was indexed against) differs from the
+    // disk bytes we just converted occurrences from is drifted — we skip its verdict rather than
+    // emit one from mismatched content (finding 2). `None`-valued cache entries (unreadable files,
+    // already skipped during parse) carry no hash.
+    let disk_sha: HashMap<String, String> = source_cache
+        .iter()
+        .filter_map(|(path, bytes)| bytes.as_ref().map(|b| (path.clone(), hex_sha256(b))))
+        .collect();
+
+    // Cache symbol spans per source path (resolve_symbol is called per candidate). RefCell so the
+    // resolver closure stays `Fn` (the join expects `&dyn Fn`) while lazily populating the cache.
+    let symbol_span_cache: RefCell<HashMap<String, Vec<store::SymbolSpan>>> =
+        RefCell::new(HashMap::new());
+
+    // Track which (path, occurrence) the edges covered, to compute the recall gap. EVERY verdict's
+    // occurrence goes here (so a covered occurrence — call or not — is never re-counted as a gap).
+    let mut matched_occurrences: HashSet<(String, usize, usize)> = HashSet::new();
+    // The covered side of recall: distinct (path, occurrence) covered specifically by a CALL
+    // (`calls_name`) edge. This is the numerator companion to `oracle_only_calls`, occurrence-
+    // deduped and call-only so both sides of recall range over the same population (finding 1).
+    // A non-call edge kind (`references_type` / `uses_macro` / …) marks `matched_occurrences` but
+    // NOT this set, so its confirmation can't inflate recall.
+    let mut covered_call_occurrences: HashSet<(String, usize, usize)> = HashSet::new();
+
+    // Resolve a SCIP definition `(path, byte-range)` back to one of OUR symbols, scoped to the
+    // active `(commit_sha, worktree_id)` checkout (via `symbol_spans_for_path`). Used both by the
+    // per-edge join below and by the recall-gap pass, so a `.scip` def in a file rag-rat didn't
+    // index (or in another checkout) maps to `None` and is excluded from both — they must agree on
+    // what "in the indexed corpus" means.
+    let commit_sha = input.commit_sha;
+    let worktree_id = input.worktree_id;
+    let resolve_symbol = |def_path: &str, def_start: usize, def_end: usize| -> Option<i64> {
+        if !symbol_span_cache.borrow().contains_key(def_path) {
+            let loaded = store::symbol_spans_for_path(conn, def_path, commit_sha, worktree_id)
+                .unwrap_or_default();
+            symbol_span_cache.borrow_mut().insert(def_path.to_string(), loaded);
+        }
+        let cache = symbol_span_cache.borrow();
+        let spans = cache.get(def_path)?;
+        join::map_definition_to_symbol(spans, def_start, def_end)
+    };
+
+    for candidate in &candidates {
+        report.edges_examined += 1;
+        let Some(occurrences) = index.occurrences_by_path.get(&candidate.source_path) else {
+            report.no_occurrence += 1;
+            continue;
+        };
+
+        // Content-integrity gate (finding 2): the occurrence byte ranges in `occurrences` were
+        // derived from the document's CURRENT disk bytes, but this candidate's callee byte range
+        // was recorded against `file_sha` (the indexed content). If those disagree, the file
+        // drifted between the index build and now — joining the two byte spaces yields a
+        // silently-wrong verdict. Skip the candidate and tally it as drifted so `eval` can
+        // warn. A file with no computed hash (unreadable) already produced no occurrences,
+        // so it never reaches here.
+        if disk_sha.get(&candidate.source_path).map(String::as_str) != Some(&candidate.file_sha) {
+            report.skipped_drifted += 1;
+            continue;
+        }
+
+        let verdict = join::classify_edge(&JoinInput {
+            callee_start_byte: candidate.callee_start_byte,
+            callee_end_byte: candidate.callee_end_byte,
+            confidence: &candidate.confidence,
+            heuristic_symbol_id: candidate.to_symbol_id,
+            occurrences,
+            index: &index,
+            resolve_symbol: &resolve_symbol,
+        });
+
+        let Some(verdict) = verdict else {
+            report.no_occurrence += 1;
+            continue;
+        };
+
+        // Mark EXACTLY the occurrence the verdict matched as covered (finding 4): use the range the
+        // join selected (reference-preferred, full containment), not a re-derived start-only match
+        // — on overlapping occurrences the two could pick different occurrences. Every
+        // verdict marks `matched_occurrences` (so it's never a recall gap); only a CALL
+        // (`calls_name`) edge also marks `covered_call_occurrences` (the recall numerator
+        // population — finding 1).
+        let (occ_start, occ_end) = verdict.matched_occurrence;
+        let key = (candidate.source_path.clone(), occ_start, occ_end);
+        matched_occurrences.insert(key.clone());
+        if candidate.edge_kind == CALL_EDGE_KIND {
+            covered_call_occurrences.insert(key);
+        }
+
+        join::tally(&mut report, verdict.kind);
+        store::write_edge_oracle(conn, input.tool, input.tool_version, &EdgeOracleRow {
+            edge_id: candidate.edge_id,
+            file_sha: &candidate.file_sha,
+            resolved_symbol_id: verdict.resolved_symbol_id,
+            scip_symbol: &verdict.scip_symbol,
+            kind: verdict.kind,
+        })?;
+        report.rows_written += 1;
+    }
+    report.covered_calls = covered_call_occurrences.len() as u64;
+
+    // Recall gap: in-corpus *reference* occurrences whose symbol resolves inside the corpus but
+    // that no edge candidate covered — calls the heuristic never emitted. Two scope filters, both
+    // required: (1) the resolver maps each SCIP *definition* back to a scoped DB symbol, so a
+    // `.scip` def in a file rag-rat didn't index is excluded; (2) `indexed_paths` restricts the
+    // *occurrence* (call site) to a file rag-rat indexed in THIS checkout — no edge candidate
+    // can cover a call from an unindexed source file, so those occurrences are out of scope,
+    // not misses.
+    let indexed_paths = store::indexed_paths_in_scope(conn, commit_sha, worktree_id)?;
+    report.oracle_only_calls =
+        count_uncovered_calls(&index, &matched_occurrences, &indexed_paths, &resolve_symbol);
+
+    report.status = "Completed".to_string();
+    store::record_oracle_run(
+        conn,
+        input.tool,
+        input.tool_version,
+        input.commit_sha,
+        input.worktree_id,
+        &report.status,
+        &serde_json::to_string(&report).unwrap_or_else(|_| "{}".to_string()),
+    )?;
+
+    tx.commit()?;
+    Ok(report)
+}
+
+/// Hex SHA-256 of a byte slice — matches `files.sha256` (computed as `hex_sha256(fs::read(file))`),
+/// so the content-integrity check compares the same hash space the indexer wrote.
+fn hex_sha256(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+/// Count *call-like* reference occurrences whose symbol is defined inside **rag-rat's indexed set**
+/// but that no edge covered — the heuristic's missed calls (the recall gap). Definitions and
+/// symbols defined outside the corpus don't count (the former aren't calls; the latter are
+/// external).
+///
+/// "Call-like" is necessarily a heuristic: SCIP roles don't mark "call", and the raw set of
+/// non-definition occurrences includes imports, type annotations, and field/member references the
+/// call graph was never meant to emit — counting those falsely lowers recall. We therefore restrict
+/// the denominator to occurrences that plausibly correspond to a CALL edge: (1) not an `Import`
+/// occurrence (`use foo::bar` is a reference, not a call), and (2) whose symbol is a *callable*
+/// (function / method / constructor) per `scip::symbol_is_callable` — a type/field/module reference
+/// is excluded. This is keyed on symbol-kind + role, the most defensible proxy available.
+///
+/// CRITICAL: "defined inside the index" means defined inside the set of files rag-rat actually
+/// indexed, NOT merely "the `.scip` has a definition for it". A `.scip` covers tests, examples,
+/// generated code, and dependency sources rag-rat skips; counting calls to those as a recall gap is
+/// a false miss (the heuristic was never asked to emit an edge there). So each candidate definition
+/// is resolved back to a scoped DB symbol via `resolve_definition` (the same
+/// `map_definition_to_symbol` against the active-checkout symbols the join uses); a def that maps
+/// to no indexed symbol is dropped, exactly as the join would record no in-corpus upgrade for it.
+///
+/// CRITICAL (occurrence side, the round-3 fix): the same skip-set logic applies to the file the
+/// *call site* lives in. An occurrence in a SOURCE document rag-rat didn't index (excluded
+/// test/example/generated source the `.scip` still covers) can NEVER be covered by an edge
+/// candidate — `edge_join_candidates` only emits candidates for indexed files — so counting it as
+/// an uncovered call is a false miss. `indexed_paths` is the set of files indexed in THIS checkout;
+/// an occurrence whose `path` is not in it is dropped before the def-resolution check.
+fn count_uncovered_calls(
+    index: &ScipIndex,
+    matched: &HashSet<(String, usize, usize)>,
+    indexed_paths: &HashSet<String>,
+    resolve_definition: &dyn Fn(&str, usize, usize) -> Option<i64>,
+) -> u64 {
+    let mut count = 0u64;
+    for (path, occurrences) in &index.occurrences_by_path {
+        // The call site must live in a file rag-rat indexed in this checkout; a call from an
+        // unindexed source is unreachable by any edge candidate, so it is not a recall gap.
+        if !indexed_paths.contains(path) {
+            continue;
+        }
+        for occ in occurrences {
+            if occ.is_definition || occ.is_import {
+                continue;
+            }
+            if !scip::symbol_is_callable(&occ.symbol) {
+                continue;
+            }
+            // The symbol must have a SCIP definition that resolves to one of OUR indexed symbols.
+            let Some(def) = index.definitions.get(&occ.symbol) else {
+                continue;
+            };
+            if resolve_definition(&def.path, def.start_byte, def.end_byte).is_none() {
+                continue;
+            }
+            if !matched.contains(&(path.clone(), occ.start_byte, occ.end_byte)) {
+                count += 1;
+            }
+        }
+    }
+    count
+}
+
+/// Build the per-kind verdict counts for status/eval, without re-running the join. SCOPED to the
+/// active `(commit_sha, worktree_id)` checkout: every count routes through
+/// `store::count_edge_oracle_scoped` (the shared `edge_oracle -> edges -> files` scope join), so a
+/// sibling worktree's verdicts for the same `(tool, tool_version)` never enter THIS checkout's
+/// totals. The total and the per-kind counts cover the same scope by construction — they share one
+/// helper — so precision/recall can't mix a cross-checkout numerator with a scoped denominator
+/// (the round-3 Codex finding: this was the last unscoped `edge_oracle` read).
+pub(crate) fn verdict_counts(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<VerdictCounts> {
+    let count = |kind| {
+        store::count_edge_oracle_scoped(conn, tool, tool_version, commit_sha, worktree_id, kind)
+    };
+    Ok(VerdictCounts {
+        total: count(None)?,
+        upgraded: count(Some(OracleResolutionKind::Upgrade))?,
+        resolved_external: count(Some(OracleResolutionKind::ResolvedExternal))?,
+        confirmed: count(Some(OracleResolutionKind::Confirm))?,
+        contradicted: count(Some(OracleResolutionKind::Contradict))?,
+    })
+}
+
+/// Per-kind `edge_oracle` counts for the status read.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct VerdictCounts {
+    pub(crate) total: u64,
+    pub(crate) upgraded: u64,
+    pub(crate) resolved_external: u64,
+    pub(crate) confirmed: u64,
+    pub(crate) contradicted: u64,
+}
+
+/// Heuristic-vs-oracle eval metrics, computed by diffing `edge_oracle` against `edges` for a
+/// tool/version. These are the #68 eval acceptance bar. All rates are
+/// in `[0, 1]`; denominators of 0 yield `1.0` (vacuously perfect — nothing to get wrong), matching
+/// the rest of `eval`'s hit-rate convention.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct OracleEvalMetrics {
+    /// Oracle-confirmed fraction of `Exact`/`Syntactic` edges the oracle had an opinion on:
+    /// `confirm / (confirm + contradict)`.
+    pub precision: f64,
+    /// CALL recall: of all in-corpus *calls* the oracle saw, the fraction a `calls_name` edge
+    /// covered — `covered_calls / (covered_calls + oracle_only_calls)`. BOTH sides are occurrence-
+    /// counted over the same call population (the covered side counts only `calls_name`-edge
+    /// occurrences, NOT confirmations on `references_type`/`uses_macro`/… ; the gap counts only
+    /// callable occurrences whose def maps in-corpus). The recall *gap* is `1 - recall`. (#81
+    /// finding 1: before this, the covered side counted ALL edge kinds while the gap admitted
+    /// field/const Term reads, so the two sides measured different populations and recall was
+    /// uninterpretable.)
+    pub recall: f64,
+    /// Fraction of `NameOnly`/`Ambiguous` edges the oracle upgraded to an in-corpus symbol.
+    pub name_only_recovery_rate: f64,
+    /// Fraction of low-confidence (`NameOnly`/`Ambiguous`) edges the oracle could resolve
+    /// (in-corpus upgrade OR resolved-external) — the "oracle-upgradeable fraction of
+    /// unresolved". Both numerator and denominator range over the low-confidence population,
+    /// so this is bounded by `1.0`.
+    pub oracle_upgradeable_fraction: f64,
+    /// Raw verdict counts behind the rates, for transparency in `eval --json`.
+    pub confirmed: u64,
+    pub contradicted: u64,
+    pub upgraded: u64,
+    pub resolved_external: u64,
+    /// The covered side of recall: distinct call occurrences a `calls_name` edge covered.
+    pub covered_calls: u64,
+    pub oracle_only_calls: u64,
+}
+
+/// The two occurrence-counted sides of CALL recall, carried in from the run's [`OracleReport`].
+/// Neither is reconstructable from `edge_oracle` alone (the gap is computed from `.scip`
+/// occurrences the heuristic never emitted; the covered side is occurrence-deduped and call-only,
+/// which the raw per-kind verdict counts can't reproduce). Keeping them paired in one struct
+/// prevents a caller from passing the gap without the matching covered count (the bug the old
+/// all-kinds SQL covered side hid).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RecallCalls {
+    /// Distinct call occurrences a `calls_name` edge covered ([`OracleReport::covered_calls`]).
+    pub covered: u64,
+    /// In-corpus call occurrences no edge covered ([`OracleReport::oracle_only_calls`]).
+    pub oracle_only: u64,
+}
+
+/// Compute [`OracleEvalMetrics`] from the persisted side tables for a tool/version. The recall
+/// call counts are carried in from the [`OracleReport`] of the run via [`RecallCalls`] (they aren't
+/// reconstructable from `edge_oracle` alone).
+pub(crate) fn eval_metrics(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+    recall_calls: RecallCalls,
+) -> anyhow::Result<OracleEvalMetrics> {
+    let counts = verdict_counts(conn, tool, tool_version, commit_sha, worktree_id)?;
+
+    // Precision: of Exact/Syntactic edges the oracle judged, how many it confirmed.
+    let judged = counts.confirmed + counts.contradicted;
+    let precision = ratio(counts.confirmed, judged);
+
+    // NameOnly/Ambiguous recovery: upgrades among low-confidence edges. The NUMERATOR must be
+    // counted over the SAME low-confidence population as the denominator — `upgrade` verdicts on
+    // `NameOnly`/`Ambiguous` edges — NOT the raw `counts.upgraded`. `classify_resolved` only emits
+    // `Upgrade` for non-Exact/Syntactic edges TODAY, but that is a property of the classifier, not
+    // of the table: an `Exact`-confidence edge carrying a NULL `to_symbol_id` (a future writer bug)
+    // would be `heuristic_resolved_in_corpus == false` and so get an `Upgrade`, and the raw count
+    // would then admit an upgrade NOT in the low-confidence denominator → recovery > 1.0. Scoping
+    // the numerator to the low-confidence join (exactly as `count_upgradeable_low_confidence` does)
+    // keeps it ⊆ the denominator structurally, mirroring the over-1.0 hardening on the upgradeable
+    // fraction (#81 finding 6b).
+    let low_conf_seen =
+        count_low_confidence_with_oracle(conn, tool, tool_version, commit_sha, worktree_id)?;
+    let low_conf_upgraded =
+        count_low_confidence_upgrades(conn, tool, tool_version, commit_sha, worktree_id)?;
+    let name_only_recovery_rate = ratio(low_conf_upgraded, low_conf_seen);
+
+    // Oracle-upgradeable fraction of unresolved: upgrade-OR-external verdicts on low-confidence
+    // (`NameOnly`/`Ambiguous`) edges, over all such candidates. BOTH numerator and denominator must
+    // range over the SAME population — low-confidence edges. The numerator must NOT use the raw
+    // `counts.{upgraded,resolved_external}`: those tally every `edge_oracle` row of that kind,
+    // including `resolved-external` verdicts on already-`Exact`/`Syntactic` edges, which are not in
+    // the denominator — counting them let the fraction exceed 1.0. Scoping the numerator to the
+    // low-confidence join keeps it ⊆ the denominator, so the fraction is bounded by 1.0 (at most
+    // one verdict per edge).
+    let unresolved_total = count_unresolved_candidates(conn, commit_sha, worktree_id)?;
+    let upgradeable_low_conf =
+        count_upgradeable_low_confidence(conn, tool, tool_version, commit_sha, worktree_id)?;
+    let oracle_upgradeable_fraction = ratio(upgradeable_low_conf, unresolved_total);
+
+    // CALL recall: covered call occurrences vs. all in-corpus call occurrences the oracle saw
+    // (covered + oracle-only). BOTH sides are occurrence-counted over the call population, carried
+    // in from the run (`covered` counts only `calls_name`-edge occurrences, deduped; `oracle_only`
+    // counts only callable occurrences whose def maps in-corpus). They measure the same population,
+    // so the ratio is a real recall — unlike the old `confirm+contradict+upgrade` covered side,
+    // which counted verdicts on every edge kind (type refs, macros, …) against a call-only gap.
+    let RecallCalls { covered: covered_calls, oracle_only: oracle_only_calls } = recall_calls;
+    let recall = ratio(covered_calls, covered_calls + oracle_only_calls);
+
+    Ok(OracleEvalMetrics {
+        precision,
+        recall,
+        name_only_recovery_rate,
+        oracle_upgradeable_fraction,
+        confirmed: counts.confirmed,
+        contradicted: counts.contradicted,
+        upgraded: counts.upgraded,
+        resolved_external: counts.resolved_external,
+        covered_calls,
+        oracle_only_calls,
+    })
+}
+
+fn ratio(numerator: u64, denominator: u64) -> f64 {
+    if denominator == 0 { 1.0 } else { numerator as f64 / denominator as f64 }
+}
+
+/// Count edges with a low-confidence heuristic resolution (`NameOnly`/`Ambiguous`) that the oracle
+/// produced a verdict for (i.e. have an `edge_oracle` row), scoped to the active checkout. Built on
+/// the shared `store::EDGE_ORACLE_SCOPE_JOIN` (the `?1..?4 = tool/version/commit_sha/worktree_id`
+/// scope) so the scope predicate is never re-spelled here — only the extra confidence filter is
+/// appended.
+fn count_low_confidence_with_oracle(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<u64> {
+    let count: i64 = conn.query_row(
+        &format!(
+            "SELECT COUNT(*){} AND edges.confidence IN ('NameOnly', 'Ambiguous')",
+            store::EDGE_ORACLE_SCOPE_JOIN
+        ),
+        rusqlite::params![tool.as_db_str(), tool_version, commit_sha, worktree_id],
+        |row| row.get(0),
+    )?;
+    Ok(u64::try_from(count).unwrap_or(0))
+}
+
+/// Count `upgrade` verdicts on low-confidence (`NameOnly`/`Ambiguous`) edges — the numerator of
+/// `name_only_recovery_rate`, scoped to the SAME low-confidence population as its denominator
+/// (`count_low_confidence_with_oracle`), so the rate can never exceed 1.0. The `edges.confidence`
+/// filter is what guards against an `Exact`-with-NULL-`to_symbol_id` writer bug recreating an
+/// over-1.0 rate (the raw per-kind `counts.upgraded` would admit such an upgrade; this won't).
+/// Built on the shared `store::EDGE_ORACLE_SCOPE_JOIN`, like the upgradeable-fraction numerator.
+fn count_low_confidence_upgrades(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<u64> {
+    let count: i64 = conn.query_row(
+        &format!(
+            "SELECT COUNT(*){} AND edge_oracle.kind = 'upgrade' AND edges.confidence IN \
+             ('NameOnly', 'Ambiguous')",
+            store::EDGE_ORACLE_SCOPE_JOIN
+        ),
+        rusqlite::params![tool.as_db_str(), tool_version, commit_sha, worktree_id],
+        |row| row.get(0),
+    )?;
+    Ok(u64::try_from(count).unwrap_or(0))
+}
+
+/// Count low-confidence (`NameOnly`/`Ambiguous`) edges the oracle could upgrade — an `upgrade` (an
+/// in-corpus recovery) OR a `resolved-external` (placed to a dependency) verdict. This is the
+/// numerator of the oracle-upgradeable fraction, scoped to the SAME low-confidence population the
+/// denominator (`count_unresolved_candidates`) counts, so the fraction can never exceed 1.0. There
+/// is at most one `edge_oracle` row per edge (PK `(edge_id, tool, tool_version)`), so this is a
+/// subset count, not a sum that could double-count. Built on the shared
+/// `store::EDGE_ORACLE_SCOPE_JOIN` so it stays ⊆ the scoped denominator by construction.
+fn count_upgradeable_low_confidence(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<u64> {
+    let count: i64 = conn.query_row(
+        &format!(
+            "SELECT COUNT(*){} AND edge_oracle.kind IN ('upgrade', 'resolved-external') AND \
+             edges.confidence IN ('NameOnly', 'Ambiguous')",
+            store::EDGE_ORACLE_SCOPE_JOIN
+        ),
+        rusqlite::params![tool.as_db_str(), tool_version, commit_sha, worktree_id],
+        |row| row.get(0),
+    )?;
+    Ok(u64::try_from(count).unwrap_or(0))
+}
+
+/// Count all unresolved/low-confidence edge candidates (carrying a callee range) — the denominator
+/// for the oracle-upgradeable fraction. These are the rows the oracle *could* have helped.
+///
+/// SCOPE (load-bearing): restricted to the active `(commit_sha, worktree_id)` checkout via the
+/// `edges -> files` join, mirroring `edge_join_candidates`. Without it a low-confidence edge in
+/// ANOTHER worktree would inflate this denominator and dilute the current run's fraction — the
+/// numerator (`count_upgradeable_low_confidence`) is already scoped, so the two must match.
+fn count_unresolved_candidates(
+    conn: &Connection,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<u64> {
+    let count: i64 = conn.query_row(
+        "
+        SELECT COUNT(*)
+        FROM edges
+        JOIN files ON files.id = edges.source_file_id
+        WHERE edges.callee_start_byte IS NOT NULL
+          AND edges.confidence IN ('NameOnly', 'Ambiguous')
+          AND files.commit_sha = ?1 AND files.worktree_id = ?2
+        ",
+        rusqlite::params![commit_sha, worktree_id],
+        |row| row.get(0),
+    )?;
+    Ok(u64::try_from(count).unwrap_or(0))
+}

--- a/crates/rag-rat-core/src/index/oracle/scip.rs
+++ b/crates/rag-rat-core/src/index/oracle/scip.rs
@@ -1,0 +1,267 @@
+//! SCIP `.scip` reader: turns a serialized SCIP index into the two lookup maps the join needs.
+//!
+//! 1. An **occurrence map** `path -> [Occurrence]`, each carrying its `(line, start_char,
+//!    end_char)` range in the **document's own position encoding** plus the SCIP symbol string.
+//! 2. A **definition map** `scip_symbol -> (path, def-range)` built from the `Definition`-role
+//!    occurrences, so a referenced symbol can be located back to its defining file + range.
+//!
+//! ## The position-encoding trap (read this before touching the conversion)
+//!
+//! SCIP occurrence ranges count columns in *code units of the document's `position_encoding`* —
+//! UTF-8 bytes, UTF-16 units, or UTF-32 (Unicode scalar) units — declared **per `Document`**, not
+//! globally. rag-rat's edge rows store the callee's **byte** range. To compare them we must convert
+//! one space to the other in the document's declared encoding. This only diverges on non-ASCII
+//! source (every encoding agrees on ASCII), so a UTF-8-assuming shortcut passes every ASCII test
+//! and then silently mis-joins the moment an identifier sits after a multibyte character (an
+//! accented name, a CJK comment earlier on the line). We therefore key occurrences by **byte**
+//! offsets computed from the encoding at read time, and the join works purely in byte space.
+//!
+//! `local N` symbols are dropped entirely here — they are function-local and carry no cross-file
+//! meaning, so they can never resolve a cross-file edge.
+
+use std::collections::HashMap;
+
+use ::protobuf::Message;
+use ::scip::types::{Index, PositionEncoding};
+
+/// A SCIP occurrence reduced to what the join needs: the **byte** range of the identifier token on
+/// its line and the SCIP symbol it refers to. Byte offsets are absolute within the file (not
+/// line-relative), so they compare directly against the edge's
+/// `callee_start_byte`/`callee_end_byte`.
+#[derive(Debug, Clone)]
+pub(crate) struct ScipOccurrence {
+    pub(crate) start_byte: usize,
+    pub(crate) end_byte: usize,
+    pub(crate) symbol: String,
+    /// True when this occurrence carries the `Definition` role bit.
+    pub(crate) is_definition: bool,
+    /// True when this occurrence carries the `Import` role bit. An import (`use foo::bar`) is a
+    /// reference, not a call site, so it must be excluded from the recall gap (see `run::run`).
+    pub(crate) is_import: bool,
+}
+
+/// Where a SCIP symbol is defined: the document path and the **byte** range of its definition
+/// occurrence. Used to decide in-corpus (maps to one of our symbols) vs. external.
+#[derive(Debug, Clone)]
+pub(crate) struct ScipDefinition {
+    pub(crate) path: String,
+    pub(crate) start_byte: usize,
+    pub(crate) end_byte: usize,
+}
+
+/// The parsed `.scip`, reduced to the join's two maps.
+#[derive(Debug, Default)]
+pub(crate) struct ScipIndex {
+    /// `relative_path -> occurrences` (definitions and references both), byte-keyed.
+    pub(crate) occurrences_by_path: HashMap<String, Vec<ScipOccurrence>>,
+    /// `scip_symbol -> definition site`. First definition wins (SCIP emits one per symbol).
+    pub(crate) definitions: HashMap<String, ScipDefinition>,
+}
+
+impl ScipIndex {
+    /// Parse a serialized SCIP index (`.scip` protobuf bytes) into the join maps.
+    ///
+    /// `read_document_source(path)` yields the **current checkout bytes** of a document so column
+    /// offsets can be converted in the document's encoding. A document whose source can't be read
+    /// is skipped (its occurrences can't be byte-resolved); the join just finds no oracle data for
+    /// those edges, which is the correct degradation.
+    pub(crate) fn parse(
+        bytes: &[u8],
+        mut read_document_source: impl FnMut(&str) -> Option<Vec<u8>>,
+    ) -> anyhow::Result<Self> {
+        let index = Index::parse_from_bytes(bytes)
+            .map_err(|err| anyhow::anyhow!("failed to parse SCIP index: {err}"))?;
+        Self::from_index(&index, &mut read_document_source)
+    }
+
+    /// Build the maps from an already-deserialized [`Index`] — the entry point tests use after
+    /// constructing an `Index` programmatically.
+    pub(crate) fn from_index(
+        index: &Index,
+        read_document_source: &mut impl FnMut(&str) -> Option<Vec<u8>>,
+    ) -> anyhow::Result<Self> {
+        let mut out = ScipIndex::default();
+        for document in &index.documents {
+            let path = document.relative_path.clone();
+            let Some(source) = read_document_source(&path) else {
+                continue;
+            };
+            let encoding = document
+                .position_encoding
+                .enum_value()
+                .unwrap_or(PositionEncoding::UnspecifiedPositionEncoding);
+            let mapper = LineColumnToByte::new(&source, encoding);
+
+            let mut occurrences = Vec::with_capacity(document.occurrences.len());
+            for occ in &document.occurrences {
+                // Skip function-local symbols entirely (no cross-file meaning).
+                if is_local_symbol(&occ.symbol) {
+                    continue;
+                }
+                let Some((start_byte, end_byte)) = mapper.byte_range(&occ.range) else {
+                    continue;
+                };
+                let is_definition = has_definition_role(occ.symbol_roles);
+                if is_definition {
+                    out.definitions.entry(occ.symbol.clone()).or_insert(ScipDefinition {
+                        path: path.clone(),
+                        start_byte,
+                        end_byte,
+                    });
+                }
+                occurrences.push(ScipOccurrence {
+                    start_byte,
+                    end_byte,
+                    symbol: occ.symbol.clone(),
+                    is_definition,
+                    is_import: has_import_role(occ.symbol_roles),
+                });
+            }
+            out.occurrences_by_path.insert(path, occurrences);
+        }
+        Ok(out)
+    }
+}
+
+/// `SymbolRole.Definition` is bit 1 (value `1`) of the `symbol_roles` bitset.
+fn has_definition_role(symbol_roles: i32) -> bool {
+    symbol_roles & (::scip::types::SymbolRole::Definition as i32) != 0
+}
+
+/// `SymbolRole.Import` is bit 2 (value `2`) of the `symbol_roles` bitset.
+fn has_import_role(symbol_roles: i32) -> bool {
+    symbol_roles & (::scip::types::SymbolRole::Import as i32) != 0
+}
+
+/// Whether a SCIP symbol names a *callable* (function / method), as opposed to a type, field,
+/// const, static, enum variant, module, or parameter. This is the kind a call-graph edge would
+/// target.
+///
+/// SCIP has no explicit "call" occurrence role, so call-likeness is necessarily a heuristic keyed
+/// on the symbol's descriptor *kind* — the LAST descriptor's `Suffix`. rust-analyzer (and SCIP
+/// generators generally) emit `Method` for both free functions and methods (the printed `().`
+/// suffix). We accept ONLY `Method` and reject everything else.
+///
+/// CRITICAL — why `).` and NOT a bare trailing `.`: SCIP prints BOTH a `Method` descriptor (`…).`)
+/// and a plain `Term` descriptor (`….`, no parens) with a trailing `.`. In rust-analyzer's SCIP
+/// output `Term` covers struct **fields, consts, statics, and enum variants** — NOT just callables.
+/// A bare-`.` test therefore admits an in-corpus field/const/static/variant *read* occurrence: it
+/// is not an `Import`, ends in `.`, and its def maps via containment to the enclosing struct/enum
+/// symbol — so every such read counted as an uncovered "call" and DEFLATED recall. SCIP's grammar
+/// distinguishes the two: a `Method` ends `).` (the printed `()` disambiguator before the `.`),
+/// whereas a plain `Term` ends `.` with no preceding `)`. Requiring the `).` suffix admits exactly
+/// the callable kind and excludes field/const/variant terms. Other kinds end differently — a `Type`
+/// `…#`, a `Macro` `…!`, a `Meta` `…:`, a `Namespace`/`Package` `…/` — so they were already out. A
+/// symbol with no recognizable callable suffix is conservatively non-callable, so a malformed
+/// string can't inflate the recall denominator.
+pub(crate) fn symbol_is_callable(symbol: &str) -> bool {
+    symbol.trim_end().ends_with(").")
+}
+
+/// A SCIP `local …` symbol is function-local. SCIP's own `is_local_symbol` checks the `local`
+/// scheme prefix; we mirror it so the dependency's exact rule applies.
+fn is_local_symbol(symbol: &str) -> bool {
+    ::scip::symbol::is_local_symbol(symbol)
+}
+
+/// Converts a SCIP `Occurrence.range` (`[start_line, start_char, end_char]` for single-line, or
+/// `[start_line, start_char, end_line, end_char]` for multi-line) — whose char columns are in a
+/// document's `position_encoding` — into an absolute **byte** range within the file.
+///
+/// Precomputes, per line, the byte offset of the line start, so a `(line, char)` lookup is a walk
+/// from the line start advancing one code unit at a time in the declared encoding. This is the
+/// single piece of code where the encoding actually matters; everything downstream is byte space.
+struct LineColumnToByte<'a> {
+    source: &'a [u8],
+    encoding: PositionEncoding,
+    /// Byte offset of the start of each line (`line_starts[i]` = first byte of 0-based line `i`).
+    line_starts: Vec<usize>,
+}
+
+impl<'a> LineColumnToByte<'a> {
+    fn new(source: &'a [u8], encoding: PositionEncoding) -> Self {
+        let mut line_starts = vec![0usize];
+        for (idx, byte) in source.iter().enumerate() {
+            if *byte == b'\n' {
+                line_starts.push(idx + 1);
+            }
+        }
+        Self { source, encoding, line_starts }
+    }
+
+    /// Byte range for a SCIP occurrence range vector. Returns `None` for malformed ranges or
+    /// positions past end-of-file.
+    fn byte_range(&self, range: &[i32]) -> Option<(usize, usize)> {
+        let (start_line, start_char, end_line, end_char) = match range {
+            [sl, sc, ec] => (*sl, *sc, *sl, *ec),
+            [sl, sc, el, ec] => (*sl, *sc, *el, *ec),
+            _ => return None,
+        };
+        let start = self.byte_at(start_line, start_char)?;
+        let end = self.byte_at(end_line, end_char)?;
+        if end < start {
+            return None;
+        }
+        Some((start, end))
+    }
+
+    /// Byte offset of a `(line, char)` position, where `char` counts code units in `self.encoding`.
+    fn byte_at(&self, line: i32, character: i32) -> Option<usize> {
+        let line = usize::try_from(line).ok()?;
+        let target_units = usize::try_from(character).ok()?;
+        let line_start = *self.line_starts.get(line)?;
+        // Bound the walk at the next line start (or EOF) so a column overrun can't spill onto the
+        // following line.
+        let line_end = self.line_starts.get(line + 1).copied().unwrap_or(self.source.len());
+        let mut byte = line_start;
+        let mut units = 0usize;
+        while units < target_units {
+            if byte >= line_end {
+                // Column points exactly at (or past) line end; clamp to line end. SCIP end columns
+                // commonly sit at the line's trailing position, which is valid.
+                return Some(line_end.min(self.source.len()));
+            }
+            let ch_len = utf8_char_len(self.source[byte]);
+            let ch_bytes = self.source.get(byte..byte + ch_len)?;
+            units += code_units_for(ch_bytes, self.encoding);
+            byte += ch_len;
+        }
+        Some(byte)
+    }
+}
+
+/// Length in bytes of the UTF-8 sequence whose lead byte is `lead`.
+fn utf8_char_len(lead: u8) -> usize {
+    if lead < 0x80 {
+        1
+    } else if lead >> 5 == 0b110 {
+        2
+    } else if lead >> 4 == 0b1110 {
+        3
+    } else if lead >> 3 == 0b11110 {
+        4
+    } else {
+        // Continuation or invalid lead byte: treat as a single byte so the walk always advances.
+        1
+    }
+}
+
+/// How many code units a single Unicode scalar (given as its UTF-8 bytes) occupies in `encoding`.
+///
+/// - UTF-8: the UTF-8 byte length.
+/// - UTF-16: 1 for BMP scalars, 2 for astral (surrogate pair) scalars (UTF-8 length 4).
+/// - UTF-32 / unspecified: 1 (one scalar = one unit). SCIP treats unspecified as UTF-32-ish; one
+///   unit per scalar is the safe default and matches the spec's fallback intent.
+fn code_units_for(utf8_bytes: &[u8], encoding: PositionEncoding) -> usize {
+    match encoding {
+        PositionEncoding::UTF8CodeUnitOffsetFromLineStart => utf8_bytes.len(),
+        PositionEncoding::UTF16CodeUnitOffsetFromLineStart =>
+            if utf8_bytes.len() == 4 {
+                2
+            } else {
+                1
+            },
+        PositionEncoding::UTF32CodeUnitOffsetFromLineStart
+        | PositionEncoding::UnspecifiedPositionEncoding => 1,
+    }
+}

--- a/crates/rag-rat-core/src/index/oracle/status.rs
+++ b/crates/rag-rat-core/src/index/oracle/status.rs
@@ -1,0 +1,79 @@
+//! Oracle status — the serializable summary surfaced like `local_ai_status` (phase 2 wires it into
+//! the MCP `local_ai_status`-style view; phase 1 just exposes the type + builder).
+
+use rusqlite::Connection;
+use serde::Serialize;
+
+use super::OracleTool;
+use super::run::{self, VerdictCounts};
+
+/// Snapshot of the persisted `edge_oracle` verdicts for one tool/version, plus the last run's
+/// status. Cheap to compute (count queries only); no join re-run.
+#[derive(Debug, Clone, Serialize)]
+pub struct OracleStatus {
+    pub tool: String,
+    pub tool_version: String,
+    pub total_verdicts: u64,
+    pub upgraded: u64,
+    pub resolved_external: u64,
+    pub confirmed: u64,
+    pub contradicted: u64,
+    pub last_run_status: Option<String>,
+    pub last_run_commit_sha: Option<String>,
+}
+
+/// Build the status for a tool/version from the persisted side tables, scoped to the active
+/// `(commit_sha, worktree_id)` checkout. The verdict counts go through the same scoped
+/// `verdict_counts` the eval metrics use, so a sibling worktree's verdicts for the same
+/// `(tool, tool_version)` never appear in this checkout's status (the same scope leak the round-3
+/// metric fix closed — status is a read-only sibling of the metric path).
+pub(crate) fn status(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<OracleStatus> {
+    let VerdictCounts { total, upgraded, resolved_external, confirmed, contradicted } =
+        run::verdict_counts(conn, tool, tool_version, commit_sha, worktree_id)?;
+    let last_run = last_run_meta(conn, tool, tool_version, commit_sha, worktree_id)?;
+    Ok(OracleStatus {
+        tool: tool.as_db_str().to_string(),
+        tool_version: tool_version.to_string(),
+        total_verdicts: total,
+        upgraded,
+        resolved_external,
+        confirmed,
+        contradicted,
+        last_run_status: last_run.as_ref().map(|run| run.0.clone()),
+        last_run_commit_sha: last_run.map(|run| run.1),
+    })
+}
+
+/// `(status, commit_sha)` of the most recent run for a tool/version **in the active checkout**, if
+/// any. SCOPE (load-bearing): filtered to `(commit_sha, worktree_id)` so a sibling worktree's run
+/// sharing the same `(tool, tool_version, commit_sha)` can't surface as THIS checkout's last run.
+/// The verdict counts in `status` are already worktree-scoped; this keeps the run meta consistent
+/// with them rather than describing a different checkout's pass.
+fn last_run_meta(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<Option<(String, String)>> {
+    let row = conn
+        .query_row(
+            "
+            SELECT status, commit_sha FROM oracle_runs
+            WHERE tool = ?1 AND tool_version = ?2
+              AND commit_sha = ?3 AND worktree_id = ?4
+            ORDER BY started_at DESC, id DESC
+            LIMIT 1
+            ",
+            rusqlite::params![tool.as_db_str(), tool_version, commit_sha, worktree_id],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        )
+        .ok();
+    Ok(row)
+}

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -1,0 +1,312 @@
+//! `oracle_runs` / `edge_oracle` persistence + the edge-candidate and symbol-mapping reads the
+//! join needs. SQL helpers named for the domain question, per repo style.
+//!
+//! INVARIANT (load-bearing): nothing here ever UPDATEs `edges.resolution` / `edges.to_symbol_id`.
+//! The heuristic resolution stays on the `edges` row untouched; the oracle's verdict lives only in
+//! `edge_oracle`. This is what lets eval diff heuristic-vs-oracle. See `apply_oracle_tables`.
+
+use rusqlite::{Connection, params};
+
+use super::{OracleResolutionKind, OracleTool};
+use crate::index::now_ms;
+
+/// An edge candidate to feed the oracle join: the callee identifier byte range (the SCIP key, #67)
+/// plus enough context to write a verdict and to recognise agreement/disagreement.
+#[derive(Debug, Clone)]
+pub(crate) struct EdgeJoinCandidate {
+    pub(crate) edge_id: i64,
+    pub(crate) source_path: String,
+    pub(crate) file_sha: String,
+    pub(crate) callee_start_byte: i64,
+    pub(crate) callee_end_byte: i64,
+    pub(crate) confidence: String,
+    /// The edge's kind (`calls_name`, `references_type`, `uses_macro`, …). Only `calls_name` edges
+    /// belong to the *call* population the recall metric measures; non-call kinds also carry a
+    /// callee byte range (so they join), but must NOT count toward the covered-call side of
+    /// recall.
+    pub(crate) edge_kind: String,
+    /// The heuristic's resolved target symbol id, if any (for confirm/contradict).
+    pub(crate) to_symbol_id: Option<i64>,
+}
+
+/// The edge kind that denotes a *call* — the only population the recall metric measures. Other
+/// kinds carrying a callee byte range (`references_type` / `uses_macro` / `implements` /
+/// `constructs`) join against SCIP occurrences too, but a confirmation on them is not a covered
+/// *call* and must be excluded from the recall numerator (the population-mismatch finding, #81).
+pub(crate) const CALL_EDGE_KIND: &str = "calls_name";
+
+/// One symbol's identity + byte span within a file, for mapping a SCIP definition range back to our
+/// symbol table by containment overlap.
+#[derive(Debug, Clone)]
+pub(crate) struct SymbolSpan {
+    pub(crate) symbol_id: i64,
+    pub(crate) start_byte: i64,
+    pub(crate) end_byte: i64,
+}
+
+/// Load every edge candidate that carries a callee identifier byte range, joined to its source
+/// file's path + content sha. Only call-shaped edges set `callee_start_byte`, so the NULL filter
+/// scopes this to exactly the rows the SCIP occurrence join can act on. Scoped to the active
+/// commit/worktree via the `files` row the edge points at.
+pub(crate) fn edge_join_candidates(
+    conn: &Connection,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<Vec<EdgeJoinCandidate>> {
+    let mut stmt = conn.prepare(
+        "
+        SELECT edges.id,
+               files.path,
+               files.sha256,
+               edges.callee_start_byte,
+               edges.callee_end_byte,
+               edges.confidence,
+               edges.edge_kind,
+               edges.to_symbol_id
+        FROM edges
+        JOIN files ON files.id = edges.source_file_id
+        WHERE edges.callee_start_byte IS NOT NULL
+          AND edges.callee_end_byte IS NOT NULL
+          AND files.commit_sha = ?1
+          AND files.worktree_id = ?2
+        ORDER BY files.path, edges.callee_start_byte
+        ",
+    )?;
+    let rows = stmt.query_map(params![commit_sha, worktree_id], |row| {
+        Ok(EdgeJoinCandidate {
+            edge_id: row.get(0)?,
+            source_path: row.get(1)?,
+            file_sha: row.get(2)?,
+            callee_start_byte: row.get(3)?,
+            callee_end_byte: row.get(4)?,
+            confidence: row.get(5)?,
+            edge_kind: row.get(6)?,
+            to_symbol_id: row.get(7)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+/// All symbols defined in a file (by path, scoped to commit/worktree), with their byte spans, so a
+/// SCIP definition range can be mapped to the enclosing symbol by overlap.
+pub(crate) fn symbol_spans_for_path(
+    conn: &Connection,
+    path: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<Vec<SymbolSpan>> {
+    let mut stmt = conn.prepare(
+        "
+        SELECT symbols.id, symbols.start_byte, symbols.end_byte
+        FROM symbols
+        JOIN files ON files.id = symbols.file_id
+        WHERE files.path = ?1
+          AND files.commit_sha = ?2
+          AND files.worktree_id = ?3
+        ORDER BY symbols.start_byte
+        ",
+    )?;
+    let rows = stmt.query_map(params![path, commit_sha, worktree_id], |row| {
+        Ok(SymbolSpan { symbol_id: row.get(0)?, start_byte: row.get(1)?, end_byte: row.get(2)? })
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+/// The set of file paths rag-rat indexed in the active `(commit_sha, worktree_id)` checkout. Used
+/// by the recall gap to drop occurrences originating in a SOURCE document outside the indexed
+/// corpus.
+///
+/// SCOPE (load-bearing): an occurrence's `path` is the document the *call site* lives in. The
+/// recall gap asks "did the heuristic miss a call the oracle saw?" — but no edge candidate can ever
+/// cover a call from a file rag-rat never indexed (an excluded test/example/generated/dependency
+/// source the `.scip` covers), so such an occurrence is not a miss, it is out of scope. Resolving
+/// the callee *definition* to an indexed symbol (the other recall-gap filter) is NOT enough: the
+/// def can be indexed while the occurrence's own source file is not. This set is the
+/// occurrence-side scope, the mirror of the definition-side `symbol_spans_for_path` check — both
+/// must hold for a recall gap.
+pub(crate) fn indexed_paths_in_scope(
+    conn: &Connection,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<std::collections::HashSet<String>> {
+    // EXCLUDE tombstones: `mark_file_deleted` leaves a `kind='deleted'` row in `files` for a path
+    // removed from the checkout (so incremental sync can detect the deletion). Its source is no
+    // longer indexed, so an occurrence whose call site is that path can never be covered by an edge
+    // candidate (`edge_join_candidates` won't emit one) — counting it would falsely inflate the
+    // recall gap. The deleted row must NOT count as "indexed in scope".
+    let mut stmt = conn.prepare(
+        "SELECT path FROM files WHERE commit_sha = ?1 AND worktree_id = ?2 AND kind != 'deleted'",
+    )?;
+    let rows = stmt.query_map(params![commit_sha, worktree_id], |row| row.get::<_, String>(0))?;
+    let mut out = std::collections::HashSet::new();
+    for row in rows {
+        out.insert(row?);
+    }
+    Ok(out)
+}
+
+/// Delete the `edge_oracle` verdicts for a `(tool, tool_version)` scope **within the active
+/// checkout**. Called at the start of a run so the pass is **authoritative** for its tool version:
+/// an edge the prior `.scip` covered but the current one no longer yields a verdict for must NOT
+/// keep its stale verdict (upsert alone only overwrites edges the current run revisits — it leaves
+/// dropped edges' rows intact). Run inside the same transaction that writes the current verdicts so
+/// the table is never observed mid-clear.
+///
+/// SCOPE (load-bearing): the DELETE is restricted to verdicts whose edge belongs to the run's
+/// `(commit_sha, worktree_id)` checkout — the SAME `edge_oracle -> edges -> files` scope join
+/// `edge_join_candidates` writes through. Without it, a run in one worktree would erase another
+/// worktree's valid verdicts for the same `(tool, tool_version)` in a multi-checkout DB. The
+/// authoritative-clear is per-checkout, not global.
+pub(crate) fn clear_edge_oracle_for_tool(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<()> {
+    conn.execute(
+        "
+        DELETE FROM edge_oracle
+        WHERE tool = ?1 AND tool_version = ?2
+          AND edge_id IN (
+            SELECT edges.id
+            FROM edges
+            JOIN files ON files.id = edges.source_file_id
+            WHERE files.commit_sha = ?3 AND files.worktree_id = ?4
+          )
+        ",
+        params![tool.as_db_str(), tool_version, commit_sha, worktree_id],
+    )?;
+    Ok(())
+}
+
+/// A verdict to persist for one edge.
+pub(crate) struct EdgeOracleRow<'a> {
+    pub(crate) edge_id: i64,
+    pub(crate) file_sha: &'a str,
+    pub(crate) resolved_symbol_id: Option<i64>,
+    pub(crate) scip_symbol: &'a str,
+    pub(crate) kind: OracleResolutionKind,
+}
+
+/// Upsert one `edge_oracle` row. Keyed by `(edge_id, tool, tool_version)`; re-running the same tool
+/// version overwrites the prior verdict (content addressed by `file_sha`). NEVER touches `edges`.
+pub(crate) fn write_edge_oracle(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    row: &EdgeOracleRow<'_>,
+) -> anyhow::Result<()> {
+    conn.execute(
+        "
+        INSERT INTO edge_oracle(
+            edge_id, file_sha, tool, tool_version,
+            resolved_symbol_id, scip_symbol, kind, computed_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+        ON CONFLICT(edge_id, tool, tool_version) DO UPDATE SET
+            file_sha = excluded.file_sha,
+            resolved_symbol_id = excluded.resolved_symbol_id,
+            scip_symbol = excluded.scip_symbol,
+            kind = excluded.kind,
+            computed_at = excluded.computed_at
+        ",
+        params![
+            row.edge_id,
+            row.file_sha,
+            tool.as_db_str(),
+            tool_version,
+            row.resolved_symbol_id,
+            row.scip_symbol,
+            row.kind.as_db_str(),
+            now_ms(),
+        ],
+    )?;
+    Ok(())
+}
+
+/// Record an oracle run, returning its row id. `stats_json` is an opaque `OracleReport` snapshot.
+/// `worktree_id` scopes the run to the active checkout so the status read's `last_run_meta` can
+/// distinguish this checkout's run from a sibling worktree's run under the same
+/// `(tool, tool_version, commit_sha)`.
+pub(crate) fn record_oracle_run(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+    status: &str,
+    stats_json: &str,
+) -> anyhow::Result<i64> {
+    conn.execute(
+        "
+        INSERT INTO oracle_runs(
+            tool, tool_version, commit_sha, worktree_id, started_at, status, stats_json
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+        ",
+        params![
+            tool.as_db_str(),
+            tool_version,
+            commit_sha,
+            worktree_id,
+            now_ms(),
+            status,
+            stats_json
+        ],
+    )?;
+    Ok(conn.last_insert_rowid())
+}
+
+/// The single canonical scope predicate every `edge_oracle` metric read joins through: restrict the
+/// counted verdicts to those whose edge belongs to the active `(commit_sha, worktree_id)` checkout,
+/// via `edge_oracle -> edges -> files`. This is the SAME join `edge_join_candidates` /
+/// `clear_edge_oracle_for_tool` write through, so every numerator and denominator covers the same
+/// checkout by construction.
+///
+/// SCOPE (load-bearing, DRY): do NOT re-spell this predicate per query. A new `edge_oracle` count
+/// must call [`count_edge_oracle_scoped`] (passing the kind filter, if any) so it cannot forget the
+/// scope — a global `WHERE tool = ? AND tool_version = ?` count mixes another worktree's verdicts
+/// into this checkout's precision/recall (the round-3 Codex finding on `verdict_counts`). The
+/// `?1..?4` bind slots are always `(tool, tool_version, commit_sha, worktree_id)`.
+pub(crate) const EDGE_ORACLE_SCOPE_JOIN: &str = "
+    FROM edge_oracle
+    JOIN edges ON edges.id = edge_oracle.edge_id
+    JOIN files ON files.id = edges.source_file_id
+    WHERE edge_oracle.tool = ?1 AND edge_oracle.tool_version = ?2
+      AND files.commit_sha = ?3 AND files.worktree_id = ?4";
+
+/// Count `edge_oracle` rows for `(tool, tool_version)` **within the active checkout**, optionally
+/// filtered to a single `kind`. The one scoped count helper behind both the total and the per-kind
+/// status/metric reads — every caller routes through [`EDGE_ORACLE_SCOPE_JOIN`], so the scope can
+/// never be re-spelled (and thus can't be forgotten) per query.
+pub(crate) fn count_edge_oracle_scoped(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+    kind: Option<OracleResolutionKind>,
+) -> anyhow::Result<u64> {
+    let count: i64 = match kind {
+        Some(kind) => conn.query_row(
+            &format!("SELECT COUNT(*){EDGE_ORACLE_SCOPE_JOIN} AND edge_oracle.kind = ?5"),
+            params![tool.as_db_str(), tool_version, commit_sha, worktree_id, kind.as_db_str()],
+            |row| row.get(0),
+        )?,
+        None => conn.query_row(
+            &format!("SELECT COUNT(*){EDGE_ORACLE_SCOPE_JOIN}"),
+            params![tool.as_db_str(), tool_version, commit_sha, worktree_id],
+            |row| row.get(0),
+        )?,
+    };
+    Ok(u64::try_from(count).unwrap_or(0))
+}

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -1,0 +1,2212 @@
+//! End-to-end tests for the SCIP-oracle join. SCIP `Index` objects are built **programmatically**
+//! via the `scip` crate's types (no rust-analyzer, no network) and serialized, then fed through the
+//! real `run_oracle` path against a DB seeded with synthetic files/symbols/edges. This keeps the
+//! join deterministic and exercises the exact code eval uses.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use ::protobuf::{EnumOrUnknown, Message};
+use ::scip::types::{Document, Index, Occurrence, PositionEncoding, SymbolRole};
+use rusqlite::{Connection, params};
+
+use super::{OracleResolutionKind, OracleTool, RecallCalls, run_oracle};
+use crate::index::schema;
+
+/// A unique temp directory under the system temp root (no external crate; matches the repo's
+/// `std::env::temp_dir` + atomic-counter convention). Cleaned up on `Drop`.
+struct TempRoot {
+    path: PathBuf,
+}
+
+impl TempRoot {
+    fn new() -> Self {
+        static N: AtomicU64 = AtomicU64::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "rag-rat-oracle-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        TempRoot { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempRoot {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+const TOOL: OracleTool = OracleTool::RustAnalyzer;
+const VERSION: &str = "test";
+const COMMIT: &str = "";
+const WORKTREE: &str = "";
+
+/// A test corpus written to a temp checkout + an index DB seeded to match.
+struct Harness {
+    conn: Connection,
+    root: TempRoot,
+}
+
+impl Harness {
+    fn new() -> Self {
+        let conn = Connection::open_in_memory().unwrap();
+        // Match production (storage.rs) so FK cascades fire — `edge_oracle.edge_id` cascades off
+        // `edges` (V018), and the oracle tests assert that cascade.
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        schema::apply(&conn).unwrap();
+        let root = TempRoot::new();
+        Harness { conn, root }
+    }
+
+    /// Write a source file to the checkout and insert its `files` row, returning the file id. The
+    /// `files.sha256` is the REAL hash of the written bytes (matching production), so the oracle's
+    /// content-integrity gate (finding 2) sees no drift — the run hashes the same disk bytes. Tests
+    /// that want to model drift override the row's `sha256` afterward (see `set_file_sha`).
+    fn add_file(&self, path: &str, contents: &str) -> i64 {
+        std::fs::write(self.root.path().join(path), contents).unwrap();
+        let sha = sha256_hex(contents.as_bytes());
+        self.conn
+            .execute(
+                "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+                 commit_sha, worktree_id) VALUES (?1, 'rust', 'source', ?2, 0, 0, ?3, ?4)",
+                params![path, sha, COMMIT, WORKTREE],
+            )
+            .unwrap();
+        self.conn.last_insert_rowid()
+    }
+
+    /// Force a file's recorded `sha256` to a value that does NOT match its disk bytes, modelling
+    /// content drift between the index build and the `.scip` — the candidate's `file_sha` then
+    /// disagrees with the disk-byte hash and the oracle skips it (finding 2).
+    fn set_file_sha(&self, file_id: i64, sha: &str) {
+        self.conn
+            .execute("UPDATE files SET sha256 = ?2 WHERE id = ?1", params![file_id, sha])
+            .unwrap();
+    }
+
+    /// Insert a symbol with a byte span, returning its id.
+    fn add_symbol(&self, file_id: i64, name: &str, start_byte: usize, end_byte: usize) -> i64 {
+        self.conn
+            .execute(
+                "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte, \
+                 end_byte, start_line, end_line) VALUES (?1, 'rust', ?2, ?2, 'function', ?3, ?4, \
+                 1, 1)",
+                params![file_id, name, start_byte as i64, end_byte as i64],
+            )
+            .unwrap();
+        self.conn.last_insert_rowid()
+    }
+
+    /// Insert a `calls_name` edge carrying a callee identifier byte range, returning its id.
+    #[allow(clippy::too_many_arguments)]
+    fn add_edge(
+        &self,
+        source_file_id: i64,
+        to_name: &str,
+        callee_start_byte: usize,
+        callee_end_byte: usize,
+        confidence: &str,
+        to_symbol_id: Option<i64>,
+    ) -> i64 {
+        self.add_edge_with_kind(
+            source_file_id,
+            to_name,
+            callee_start_byte,
+            callee_end_byte,
+            "calls_name",
+            confidence,
+            to_symbol_id,
+        )
+    }
+
+    /// Insert an edge of an explicit `edge_kind` (e.g. `references_type`) carrying a callee byte
+    /// range, returning its id. Non-call kinds still join against SCIP occurrences (they carry a
+    /// callee range) but must not count toward the covered side of recall.
+    #[allow(clippy::too_many_arguments)]
+    fn add_edge_with_kind(
+        &self,
+        source_file_id: i64,
+        to_name: &str,
+        callee_start_byte: usize,
+        callee_end_byte: usize,
+        edge_kind: &str,
+        confidence: &str,
+        to_symbol_id: Option<i64>,
+    ) -> i64 {
+        let resolution = if to_symbol_id.is_some() { "exact" } else { "unresolved" };
+        self.conn
+            .execute(
+                "INSERT INTO edges(source_file_id, to_name, callee_start_byte, callee_end_byte, \
+                 edge_kind, confidence, resolution, to_symbol_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, \
+                 ?7, ?8)",
+                params![
+                    source_file_id,
+                    to_name,
+                    callee_start_byte as i64,
+                    callee_end_byte as i64,
+                    edge_kind,
+                    confidence,
+                    resolution,
+                    to_symbol_id,
+                ],
+            )
+            .unwrap();
+        self.conn.last_insert_rowid()
+    }
+
+    fn root(&self) -> &Path {
+        self.root.path()
+    }
+
+    /// Insert a `files` row in an explicit `(commit_sha, worktree_id)` scope (no checkout write —
+    /// these rows model another checkout sharing the same DB). Returns the file id.
+    fn add_file_in_scope(&self, path: &str, commit: &str, worktree: &str) -> i64 {
+        let sha = format!("sha-{worktree}-{path}");
+        self.conn
+            .execute(
+                "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+                 commit_sha, worktree_id) VALUES (?1, 'rust', 'source', ?2, 0, 0, ?3, ?4)",
+                params![path, sha, commit, worktree],
+            )
+            .unwrap();
+        self.conn.last_insert_rowid()
+    }
+
+    /// The persisted oracle verdict for an edge, if any.
+    fn verdict(&self, edge_id: i64) -> Option<(String, Option<i64>, String)> {
+        self.conn
+            .query_row(
+                "SELECT kind, resolved_symbol_id, scip_symbol FROM edge_oracle WHERE edge_id = ?1",
+                params![edge_id],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, Option<i64>>(1)?,
+                        row.get::<_, String>(2)?,
+                    ))
+                },
+            )
+            .ok()
+    }
+
+    /// The heuristic resolution on the `edges` row (must never change).
+    fn heuristic_resolution(&self, edge_id: i64) -> (String, Option<i64>) {
+        self.conn
+            .query_row(
+                "SELECT resolution, to_symbol_id FROM edges WHERE id = ?1",
+                params![edge_id],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<i64>>(1)?)),
+            )
+            .unwrap()
+    }
+}
+
+/// A single-line occurrence: `range = [line, start_char, end_char]` in the document's encoding.
+fn occurrence(line: i32, start_char: i32, end_char: i32, symbol: &str, roles: i32) -> Occurrence {
+    Occurrence {
+        range: vec![line, start_char, end_char],
+        symbol: symbol.to_string(),
+        symbol_roles: roles,
+        ..Default::default()
+    }
+}
+
+/// Build a single-document SCIP index over `path` with the given occurrences + encoding,
+/// serialized.
+fn scip_bytes(path: &str, encoding: PositionEncoding, occurrences: Vec<Occurrence>) -> Vec<u8> {
+    let document = Document {
+        relative_path: path.to_string(),
+        occurrences,
+        position_encoding: EnumOrUnknown::new(encoding),
+        ..Default::default()
+    };
+    let index = Index { documents: vec![document], ..Default::default() };
+    index.write_to_bytes().unwrap()
+}
+
+/// Hex SHA-256 of bytes — the same hash `files.sha256` carries, so a test file's recorded sha
+/// matches the disk-byte hash the oracle's content-integrity gate computes (finding 2).
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+/// A def inside the corpus upgrades an unresolved edge; the `edge_oracle` row is written and the
+/// heuristic `edges` row is untouched.
+#[test]
+fn def_inside_corpus_upgrades_unresolved_edge() {
+    let h = Harness::new();
+    // `caller.rs` calls `target` defined in `defs.rs`.
+    let caller = h.add_file("caller.rs", "fn caller() { target(); }\n");
+    let defs = h.add_file("defs.rs", "fn target() {}\n");
+    // `target` definition spans bytes 3..9 ("target") in defs.rs.
+    let target_sym = h.add_symbol(defs, "target", 3, 9);
+    // The callee identifier `target` in caller.rs is at bytes 14..20.
+    let edge = h.add_edge(caller, "target", 14, 20, "NameOnly", None);
+
+    let same = "scip-rust crate v1 `target`().";
+    let bytes = scip_bytes("caller.rs", PositionEncoding::UTF8CodeUnitOffsetFromLineStart, vec![
+        // Reference occurrence at the call site: chars 14..20 on line 0 (ASCII → bytes).
+        occurrence(0, 14, 20, same, SymbolRole::UnspecifiedSymbolRole as i32),
+    ]);
+    // Definition occurrence lives in defs.rs.
+    let mut full = Index::parse_from_bytes(&bytes).unwrap();
+    full.documents.push(Document {
+        relative_path: "defs.rs".to_string(),
+        occurrences: vec![occurrence(0, 3, 9, same, SymbolRole::Definition as i32)],
+        position_encoding: EnumOrUnknown::new(PositionEncoding::UTF8CodeUnitOffsetFromLineStart),
+        ..Default::default()
+    });
+    let bytes = full.write_to_bytes().unwrap();
+
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+
+    let (kind, resolved, _scip) = h.verdict(edge).expect("verdict written");
+    assert_eq!(kind, OracleResolutionKind::Upgrade.as_db_str());
+    assert_eq!(resolved, Some(target_sym));
+    // Heuristic row untouched.
+    assert_eq!(h.heuristic_resolution(edge), ("unresolved".to_string(), None));
+}
+
+/// A def outside the corpus resolves to `resolved-external(<package>)`.
+#[test]
+fn def_outside_corpus_resolves_external() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.rs", "fn caller() { spawn(); }\n");
+    let edge = h.add_edge(caller, "spawn", 14, 19, "NameOnly", None);
+
+    // A SCIP symbol with a package component, no definition occurrence in the corpus → external.
+    let external = "scip-rust cargo tokio 1.0 `spawn`().";
+    let bytes = scip_bytes("caller.rs", PositionEncoding::UTF8CodeUnitOffsetFromLineStart, vec![
+        occurrence(0, 14, 19, external, SymbolRole::UnspecifiedSymbolRole as i32),
+    ]);
+
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+
+    let (kind, resolved, scip) = h.verdict(edge).expect("verdict written");
+    assert_eq!(kind, OracleResolutionKind::ResolvedExternal.as_db_str());
+    assert_eq!(resolved, None);
+    assert_eq!(scip, external);
+}
+
+/// The position-encoding correctness test: a non-ASCII identifier resolves correctly under BOTH
+/// UTF-8 and UTF-16 `position_encoding`. The multibyte prefix shifts the byte offset away from the
+/// char offset; only correct per-encoding conversion lands on the identifier.
+#[test]
+fn non_ascii_identifier_resolves_under_both_encodings() {
+    for encoding in [
+        PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+        PositionEncoding::UTF16CodeUnitOffsetFromLineStart,
+    ] {
+        let h = Harness::new();
+        // `café` is the receiver prefix: 'é' is 2 UTF-8 bytes (1 UTF-16 unit). The call is
+        // `café.naïve()`. We want the callee identifier `naïve`.
+        //   bytes:  c a f é(2) . n a ï(2) v e ( ) ;
+        //   "café." = c(1)a(1)f(1)é(2).(1) = 6 bytes → `naïve` starts at byte 6.
+        //   `naïve` = n a ï(2) v e = 6 bytes → ends at byte 12.
+        let src = "café.naïve();\n";
+        let caller = h.add_file("caller.rs", src);
+        let defs = h.add_file("defs.rs", "fn naïve() {}\n");
+        // `naïve` definition in defs.rs: "fn " = 3 bytes, then `naïve` (6 bytes) → 3..9.
+        let target_sym = h.add_symbol(defs, "naïve", 3, 9);
+        let edge = h.add_edge(caller, "naïve", 6, 12, "NameOnly", None);
+
+        // Char offsets of `naïve` on line 0 differ by encoding:
+        //   UTF-8 : "café." = c,a,f,é(2),. = 6 code units → start 6; `naïve` = 6 units → end 12.
+        //   UTF-16: "café." = c,a,f,é(1),. = 5 code units → start 5; `naïve` (ï=1) = 5 units → 10.
+        let (start_char, end_char) = match encoding {
+            PositionEncoding::UTF8CodeUnitOffsetFromLineStart => (6, 12),
+            PositionEncoding::UTF16CodeUnitOffsetFromLineStart => (5, 10),
+            _ => unreachable!(),
+        };
+        let (def_start, def_end) = match encoding {
+            PositionEncoding::UTF8CodeUnitOffsetFromLineStart => (3, 9),
+            PositionEncoding::UTF16CodeUnitOffsetFromLineStart => (3, 8),
+            _ => unreachable!(),
+        };
+
+        let symbol = "scip-rust crate v1 `naïve`().";
+        let mut index = Index {
+            documents: vec![Document {
+                relative_path: "caller.rs".to_string(),
+                occurrences: vec![occurrence(
+                    0,
+                    start_char,
+                    end_char,
+                    symbol,
+                    SymbolRole::UnspecifiedSymbolRole as i32,
+                )],
+                position_encoding: EnumOrUnknown::new(encoding),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        index.documents.push(Document {
+            relative_path: "defs.rs".to_string(),
+            occurrences: vec![occurrence(
+                0,
+                def_start,
+                def_end,
+                symbol,
+                SymbolRole::Definition as i32,
+            )],
+            position_encoding: EnumOrUnknown::new(encoding),
+            ..Default::default()
+        });
+        let bytes = index.write_to_bytes().unwrap();
+
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+
+        let (kind, resolved, _) =
+            h.verdict(edge).unwrap_or_else(|| panic!("verdict written for encoding {encoding:?}"));
+        assert_eq!(
+            kind,
+            OracleResolutionKind::Upgrade.as_db_str(),
+            "encoding {encoding:?}: expected in-corpus upgrade"
+        );
+        assert_eq!(resolved, Some(target_sym), "encoding {encoding:?}: wrong symbol");
+    }
+}
+
+/// `local N` symbols are skipped entirely — they never produce a verdict.
+#[test]
+fn local_symbols_are_skipped() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.rs", "fn caller() { helper(); }\n");
+    let edge = h.add_edge(caller, "helper", 14, 20, "NameOnly", None);
+
+    // A `local 0` occurrence covers the call site — must be ignored.
+    let bytes = scip_bytes("caller.rs", PositionEncoding::UTF8CodeUnitOffsetFromLineStart, vec![
+        occurrence(0, 14, 20, "local 0", SymbolRole::UnspecifiedSymbolRole as i32),
+    ]);
+
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+
+    assert!(h.verdict(edge).is_none(), "local symbol must not produce a verdict");
+}
+
+/// An Exact/Syntactic edge the oracle contradicts is recorded as a disagreement; the heuristic
+/// `edges` row is unchanged.
+#[test]
+fn exact_edge_contradiction_recorded_not_applied() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.rs", "fn caller() { target(); }\n");
+    let defs = h.add_file("defs.rs", "fn target() {}\nfn other() {}\n");
+    // Two candidate symbols: heuristic resolved to `wrong`, oracle says `right`.
+    let wrong_sym = h.add_symbol(defs, "other", 18, 23);
+    let right_sym = h.add_symbol(defs, "target", 3, 9);
+    // Heuristic edge is Exact → resolved to the WRONG symbol.
+    let edge = h.add_edge(caller, "target", 14, 20, "Exact", Some(wrong_sym));
+
+    let symbol = "scip-rust crate v1 `target`().";
+    let mut index = Index {
+        documents: vec![Document {
+            relative_path: "caller.rs".to_string(),
+            occurrences: vec![occurrence(
+                0,
+                14,
+                20,
+                symbol,
+                SymbolRole::UnspecifiedSymbolRole as i32,
+            )],
+            position_encoding: EnumOrUnknown::new(
+                PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+            ),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    index.documents.push(Document {
+        relative_path: "defs.rs".to_string(),
+        // Definition of `target` at bytes 3..9.
+        occurrences: vec![occurrence(0, 3, 9, symbol, SymbolRole::Definition as i32)],
+        position_encoding: EnumOrUnknown::new(PositionEncoding::UTF8CodeUnitOffsetFromLineStart),
+        ..Default::default()
+    });
+    let bytes = index.write_to_bytes().unwrap();
+
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+
+    let (kind, resolved, _) = h.verdict(edge).expect("verdict written");
+    assert_eq!(kind, OracleResolutionKind::Contradict.as_db_str());
+    assert_eq!(resolved, Some(right_sym), "oracle resolved to the correct symbol");
+    // Heuristic row STILL points at the wrong symbol — never auto-applied.
+    assert_eq!(h.heuristic_resolution(edge), ("exact".to_string(), Some(wrong_sym)));
+}
+
+/// An Exact edge the oracle agrees with is recorded as a confirmation (the precision signal).
+#[test]
+fn exact_edge_agreement_recorded_as_confirm() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.rs", "fn caller() { target(); }\n");
+    let defs = h.add_file("defs.rs", "fn target() {}\n");
+    let target_sym = h.add_symbol(defs, "target", 3, 9);
+    let edge = h.add_edge(caller, "target", 14, 20, "Exact", Some(target_sym));
+
+    let symbol = "scip-rust crate v1 `target`().";
+    let mut index = Index {
+        documents: vec![Document {
+            relative_path: "caller.rs".to_string(),
+            occurrences: vec![occurrence(
+                0,
+                14,
+                20,
+                symbol,
+                SymbolRole::UnspecifiedSymbolRole as i32,
+            )],
+            position_encoding: EnumOrUnknown::new(
+                PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+            ),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    index.documents.push(Document {
+        relative_path: "defs.rs".to_string(),
+        occurrences: vec![occurrence(0, 3, 9, symbol, SymbolRole::Definition as i32)],
+        position_encoding: EnumOrUnknown::new(PositionEncoding::UTF8CodeUnitOffsetFromLineStart),
+        ..Default::default()
+    });
+    let bytes = index.write_to_bytes().unwrap();
+
+    let report = run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+
+    let (kind, resolved, _) = h.verdict(edge).expect("verdict written");
+    assert_eq!(kind, OracleResolutionKind::Confirm.as_db_str());
+    assert_eq!(resolved, Some(target_sym));
+    assert_eq!(report.confirmed, 1);
+}
+
+/// The migration creates the side tables with the expected columns + STRICT mode.
+#[test]
+fn migration_creates_oracle_side_tables() {
+    let conn = Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+
+    for table in ["oracle_runs", "edge_oracle"] {
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name = ?1",
+                params![table],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "{table} table must exist");
+    }
+
+    // STRICT mode (repo convention for new tables).
+    let edge_oracle_sql: String = conn
+        .query_row("SELECT sql FROM sqlite_master WHERE name = 'edge_oracle'", [], |row| row.get(0))
+        .unwrap();
+    assert!(edge_oracle_sql.contains("STRICT"), "edge_oracle must be STRICT");
+
+    let columns = table_columns(&conn, "edge_oracle");
+    for expected in [
+        "edge_id",
+        "file_sha",
+        "tool",
+        "tool_version",
+        "resolved_symbol_id",
+        "scip_symbol",
+        "kind",
+        "computed_at",
+    ] {
+        assert!(columns.contains(&expected.to_string()), "edge_oracle missing {expected}");
+    }
+
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 18);
+}
+
+fn table_columns(conn: &Connection, table: &str) -> Vec<String> {
+    conn.prepare(&format!("PRAGMA table_info({table})"))
+        .unwrap()
+        .query_map([], |row| row.get::<_, String>(1))
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+}
+
+/// Deleting an `edges` row cascades to its `edge_oracle` verdict (FK `ON DELETE CASCADE`, V018), so
+/// no orphan verdict survives for `status`/eval to keep counting. The rebuild +
+/// `remove_file_in_scope` edge deletes reinsert edges with new ids and recompute the oracle, so
+/// cascading old verdicts away is correct.
+#[test]
+fn deleting_an_edge_cascades_away_its_oracle_verdict() {
+    let h = Harness::new();
+    let f = h.add_file("a.rs", "fn caller() { target(); }\n");
+    let edge = h.add_edge(f, "target", 14, 20, "NameOnly", None);
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &EdgeOracleRow {
+        edge_id: edge,
+        file_sha: "s",
+        resolved_symbol_id: None,
+        scip_symbol: "s",
+        kind: OracleResolutionKind::Upgrade,
+    })
+    .unwrap();
+    assert!(h.verdict(edge).is_some(), "verdict present before delete");
+
+    h.conn.execute("DELETE FROM edges WHERE id = ?1", params![edge]).unwrap();
+
+    assert!(h.verdict(edge).is_none(), "verdict cascaded away with its edge");
+    let remaining: i64 =
+        h.conn.query_row("SELECT COUNT(*) FROM edge_oracle", [], |r| r.get(0)).unwrap();
+    assert_eq!(remaining, 0, "no orphan edge_oracle rows survive the edge delete");
+}
+
+// ---------------------------------------------------------------------------
+// store.rs — side-table I/O round trips, candidate scoping, staleness key.
+// ---------------------------------------------------------------------------
+
+use super::join::{self, names_external_package, package_of};
+use super::scip::ScipIndex;
+use super::store::{self, EdgeOracleRow, SymbolSpan};
+
+/// `edge_join_candidates` returns only edges carrying a callee byte range, scoped to the active
+/// commit/worktree, ordered by `(path, callee_start_byte)`. Edges with a NULL callee range and
+/// edges in another worktree are excluded.
+#[test]
+fn edge_join_candidates_filters_null_range_and_scopes_by_worktree() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.rs", "fn caller() { a(); b(); }\n");
+    // Two call edges with callee ranges (out of source order so we can assert ORDER BY).
+    let edge_b = h.add_edge(caller, "b", 19, 20, "NameOnly", None);
+    let edge_a = h.add_edge(caller, "a", 14, 15, "NameOnly", None);
+    // A non-call edge with NULL callee range must be excluded.
+    h.conn
+        .execute(
+            "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution) VALUES \
+             (?1, 'mod', 'contains', 'Exact', 'exact')",
+            params![caller],
+        )
+        .unwrap();
+
+    let candidates = store::edge_join_candidates(&h.conn, COMMIT, WORKTREE).unwrap();
+    let ids: Vec<i64> = candidates.iter().map(|c| c.edge_id).collect();
+    // Only the two call edges, ordered by callee_start_byte (a at 14 before b at 19).
+    assert_eq!(ids, vec![edge_a, edge_b]);
+    // `file_sha` is the file's real content hash (what production records), so the candidate's
+    // `edge_kind` and `file_sha` round-trip from the `files`/`edges` rows.
+    assert_eq!(candidates[0].file_sha, sha256_hex("fn caller() { a(); b(); }\n".as_bytes()));
+    assert_eq!(candidates[0].edge_kind, "calls_name");
+    assert_eq!(candidates[0].source_path, "caller.rs");
+
+    // A candidate in a different worktree is out of scope.
+    assert!(store::edge_join_candidates(&h.conn, COMMIT, "other-worktree").unwrap().is_empty());
+}
+
+/// `symbol_spans_for_path` returns the file's symbols ordered by start byte, scoped to the path +
+/// commit/worktree, and empty for an unknown path.
+#[test]
+fn symbol_spans_for_path_returns_scoped_ordered_spans() {
+    let h = Harness::new();
+    let defs = h.add_file("defs.rs", "fn a() {}\nfn b() {}\n");
+    let a = h.add_symbol(defs, "a", 3, 4);
+    let b = h.add_symbol(defs, "b", 13, 14);
+
+    let spans = store::symbol_spans_for_path(&h.conn, "defs.rs", COMMIT, WORKTREE).unwrap();
+    assert_eq!(spans.iter().map(|s| s.symbol_id).collect::<Vec<_>>(), vec![a, b]);
+    assert_eq!(spans[0].start_byte, 3);
+    assert_eq!(spans[1].end_byte, 14);
+
+    assert!(
+        store::symbol_spans_for_path(&h.conn, "missing.rs", COMMIT, WORKTREE).unwrap().is_empty()
+    );
+}
+
+/// Writing an `edge_oracle` row and reading it back round-trips every field; re-writing the same
+/// `(edge_id, tool, tool_version)` upserts (new file_sha/kind) rather than inserting a duplicate.
+/// The matching `edges` row is never touched (side-table invariant).
+#[test]
+fn write_edge_oracle_round_trips_and_upserts_without_touching_edges() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.rs", "fn caller() { target(); }\n");
+    let defs = h.add_file("defs.rs", "fn target() {}\n");
+    let target_sym = h.add_symbol(defs, "target", 3, 9);
+    let edge = h.add_edge(caller, "target", 14, 20, "Exact", Some(target_sym));
+
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &EdgeOracleRow {
+        edge_id: edge,
+        file_sha: "sha-v1",
+        resolved_symbol_id: Some(7),
+        scip_symbol: "scip `target`().",
+        kind: OracleResolutionKind::Upgrade,
+    })
+    .unwrap();
+
+    let (kind, resolved, scip) = h.verdict(edge).expect("row written");
+    assert_eq!(kind, OracleResolutionKind::Upgrade.as_db_str());
+    assert_eq!(resolved, Some(7));
+    assert_eq!(scip, "scip `target`().");
+    assert_eq!(
+        store::count_edge_oracle_scoped(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, None).unwrap(),
+        1
+    );
+
+    // Re-write the same key with a new sha + verdict → upsert, still one row.
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &EdgeOracleRow {
+        edge_id: edge,
+        file_sha: "sha-v2",
+        resolved_symbol_id: None,
+        scip_symbol: "scip cargo tokio `target`().",
+        kind: OracleResolutionKind::ResolvedExternal,
+    })
+    .unwrap();
+    assert_eq!(
+        store::count_edge_oracle_scoped(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, None).unwrap(),
+        1
+    );
+    let (kind2, resolved2, _) = h.verdict(edge).expect("row still present");
+    assert_eq!(kind2, OracleResolutionKind::ResolvedExternal.as_db_str());
+    assert_eq!(resolved2, None);
+    let file_sha: String = h
+        .conn
+        .query_row("SELECT file_sha FROM edge_oracle WHERE edge_id = ?1", params![edge], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(file_sha, "sha-v2", "upsert refreshed the staleness sha");
+
+    // The heuristic edges row is untouched by either write.
+    assert_eq!(h.heuristic_resolution(edge), ("exact".to_string(), Some(target_sym)));
+}
+
+/// The `(file_sha, tool, tool_version)` staleness key is a real composite: rows written under one
+/// sha are findable by that sha, and a different sha (changed file bytes) does not match — the
+/// content-addressing property the staleness index guards.
+#[test]
+fn staleness_key_distinguishes_rows_by_file_sha_tool_and_version() {
+    let h = Harness::new();
+    let f = h.add_file("a.rs", "fn caller() {}\n");
+    let e1 = h.add_edge(f, "x", 1, 2, "NameOnly", None);
+    let e2 = h.add_edge(f, "y", 3, 4, "NameOnly", None);
+
+    let row = |edge: i64, sha: &'static str| EdgeOracleRow {
+        edge_id: edge,
+        file_sha: sha,
+        resolved_symbol_id: None,
+        scip_symbol: "s",
+        kind: OracleResolutionKind::Upgrade,
+    };
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &row(e1, "sha-fresh")).unwrap();
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &row(e2, "sha-old")).unwrap();
+
+    let count_for_sha = |sha: &str| -> i64 {
+        h.conn
+            .query_row(
+                "SELECT COUNT(*) FROM edge_oracle WHERE file_sha = ?1 AND tool = ?2 AND \
+                 tool_version = ?3",
+                params![sha, TOOL.as_db_str(), VERSION],
+                |r| r.get(0),
+            )
+            .unwrap()
+    };
+    assert_eq!(count_for_sha("sha-fresh"), 1, "row matches its own sha");
+    assert_eq!(count_for_sha("sha-old"), 1);
+    assert_eq!(count_for_sha("sha-changed"), 0, "a changed file's sha matches no rows (stale)");
+    // Wrong tool_version also fails the key.
+    let other_version: i64 = h
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM edge_oracle WHERE tool = ?1 AND tool_version = ?2",
+            params![TOOL.as_db_str(), "other-version"],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(other_version, 0);
+}
+
+/// `record_oracle_run` inserts a run row and returns its id; `count_edge_oracle_scoped` tallies
+/// only the requested kind for the tool/version within the active checkout.
+#[test]
+fn record_oracle_run_and_count_by_kind() {
+    let h = Harness::new();
+    let id1 = store::record_oracle_run(&h.conn, TOOL, VERSION, "abc", WORKTREE, "Completed", "{}")
+        .unwrap();
+    let id2 = store::record_oracle_run(&h.conn, TOOL, VERSION, "abc", WORKTREE, "Completed", "{}")
+        .unwrap();
+    assert!(id2 > id1, "row id increments");
+
+    let f = h.add_file("a.rs", "x\n");
+    let e_up = h.add_edge(f, "u", 0, 1, "NameOnly", None);
+    let e_conf = h.add_edge(f, "c", 1, 2, "Exact", None);
+    let mk = |edge, kind| EdgeOracleRow {
+        edge_id: edge,
+        file_sha: "s",
+        resolved_symbol_id: None,
+        scip_symbol: "s",
+        kind,
+    };
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(e_up, OracleResolutionKind::Upgrade))
+        .unwrap();
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(e_conf, OracleResolutionKind::Confirm))
+        .unwrap();
+
+    assert_eq!(
+        store::count_edge_oracle_scoped(
+            &h.conn,
+            TOOL,
+            VERSION,
+            COMMIT,
+            WORKTREE,
+            Some(OracleResolutionKind::Upgrade)
+        )
+        .unwrap(),
+        1
+    );
+    assert_eq!(
+        store::count_edge_oracle_scoped(
+            &h.conn,
+            TOOL,
+            VERSION,
+            COMMIT,
+            WORKTREE,
+            Some(OracleResolutionKind::Contradict)
+        )
+        .unwrap(),
+        0
+    );
+}
+
+// ---------------------------------------------------------------------------
+// status.rs — status construction + serialization, last-run metadata.
+// ---------------------------------------------------------------------------
+
+/// `oracle_status` reflects the persisted verdict counts and the most recent run's status/commit;
+/// it serializes to JSON with the documented field names.
+#[test]
+fn oracle_status_reports_counts_and_last_run() {
+    let h = Harness::new();
+    // No verdicts, no runs yet → zeros and `None` last run.
+    let empty = super::oracle_status(&h.conn, TOOL, VERSION, COMMIT, WORKTREE).unwrap();
+    assert_eq!(empty.total_verdicts, 0);
+    assert_eq!(empty.last_run_status, None);
+    assert_eq!(empty.last_run_commit_sha, None);
+
+    // Two runs in THIS checkout; the later one wins for "last run". Both recorded under the active
+    // `(COMMIT, WORKTREE)` so the worktree-scoped `last_run_meta` can see them (finding 3).
+    store::record_oracle_run(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, "Completed", "{}").unwrap();
+    store::record_oracle_run(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, "Blocked", "{}").unwrap();
+
+    let f = h.add_file("a.rs", "x\n");
+    let e1 = h.add_edge(f, "a", 0, 1, "NameOnly", None);
+    let e2 = h.add_edge(f, "b", 1, 2, "Exact", None);
+    let mk = |edge, kind| EdgeOracleRow {
+        edge_id: edge,
+        file_sha: "s",
+        resolved_symbol_id: None,
+        scip_symbol: "s",
+        kind,
+    };
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(e1, OracleResolutionKind::Upgrade))
+        .unwrap();
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(e2, OracleResolutionKind::Contradict))
+        .unwrap();
+
+    let status = super::oracle_status(&h.conn, TOOL, VERSION, COMMIT, WORKTREE).unwrap();
+    assert_eq!(status.tool, "rust-analyzer");
+    assert_eq!(status.tool_version, VERSION);
+    assert_eq!(status.total_verdicts, 2);
+    assert_eq!(status.upgraded, 1);
+    assert_eq!(status.contradicted, 1);
+    assert_eq!(status.confirmed, 0);
+    assert_eq!(status.last_run_status.as_deref(), Some("Blocked"));
+    assert_eq!(status.last_run_commit_sha.as_deref(), Some(COMMIT));
+
+    let json = serde_json::to_value(&status).unwrap();
+    assert_eq!(json["total_verdicts"], 2);
+    assert_eq!(json["last_run_commit_sha"], COMMIT);
+}
+
+// ---------------------------------------------------------------------------
+// run.rs — report aggregation, empty/no-scip path, eval metric ratios.
+// ---------------------------------------------------------------------------
+
+/// A run with no `.scip` documents (empty index) examines its candidates but writes no verdicts and
+/// returns cleanly with `status = "Completed"` — the no-data path is not an error.
+#[test]
+fn run_with_empty_scip_completes_with_no_verdicts() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.rs", "fn caller() { target(); }\n");
+    let edge = h.add_edge(caller, "target", 14, 20, "NameOnly", None);
+
+    let empty = Index::default().write_to_bytes().unwrap();
+    let report = run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &empty, h.root()).unwrap();
+
+    assert_eq!(report.edges_examined, 1);
+    assert_eq!(report.no_occurrence, 1, "no document → no occurrence bucket");
+    assert_eq!(report.rows_written, 0);
+    assert_eq!(report.oracle_only_calls, 0);
+    assert_eq!(report.status, "Completed");
+    assert!(h.verdict(edge).is_none());
+    // The run is still recorded.
+    let runs: i64 = h.conn.query_row("SELECT COUNT(*) FROM oracle_runs", [], |r| r.get(0)).unwrap();
+    assert_eq!(runs, 1);
+}
+
+/// A candidate whose callee byte range falls outside every occurrence lands in the `no_occurrence`
+/// bucket with no verdict written, even though the document has occurrences.
+#[test]
+fn candidate_outside_any_occurrence_counts_no_occurrence() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.rs", "fn caller() { target(); }\n");
+    // Callee range 14..20 in source, but the only occurrence covers bytes 0..5 (the `fn ca`
+    // prefix).
+    let edge = h.add_edge(caller, "target", 14, 20, "NameOnly", None);
+    let bytes = scip_bytes("caller.rs", PositionEncoding::UTF8CodeUnitOffsetFromLineStart, vec![
+        occurrence(
+            0,
+            0,
+            5,
+            "scip-rust crate v1 `other`().",
+            SymbolRole::UnspecifiedSymbolRole as i32,
+        ),
+    ]);
+
+    let report = run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+    assert_eq!(report.edges_examined, 1);
+    assert_eq!(report.no_occurrence, 1);
+    assert_eq!(report.rows_written, 0);
+    assert!(h.verdict(edge).is_none());
+}
+
+/// A run aggregates per-kind counts across multiple edges and computes the recall gap: an in-corpus
+/// reference occurrence no edge covered increments `oracle_only_calls`.
+#[test]
+fn run_aggregates_counts_and_recall_gap() {
+    let h = Harness::new();
+    // Two call sites of `target` in caller.rs; only one is emitted as an edge → recall gap of 1.
+    let caller = h.add_file("caller.rs", "fn caller() { target(); target(); }\n");
+    let defs = h.add_file("defs.rs", "fn target() {}\n");
+    let target_sym = h.add_symbol(defs, "target", 3, 9);
+    // Edge covers the FIRST call site (bytes 14..20). Second call site (24..30) has no edge.
+    let edge = h.add_edge(caller, "target", 14, 20, "NameOnly", None);
+
+    let sym = "scip-rust crate v1 `target`().";
+    let mut index = Index {
+        documents: vec![Document {
+            relative_path: "caller.rs".to_string(),
+            occurrences: vec![
+                occurrence(0, 14, 20, sym, SymbolRole::UnspecifiedSymbolRole as i32),
+                occurrence(0, 24, 30, sym, SymbolRole::UnspecifiedSymbolRole as i32),
+            ],
+            position_encoding: EnumOrUnknown::new(
+                PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+            ),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    index.documents.push(Document {
+        relative_path: "defs.rs".to_string(),
+        occurrences: vec![occurrence(0, 3, 9, sym, SymbolRole::Definition as i32)],
+        position_encoding: EnumOrUnknown::new(PositionEncoding::UTF8CodeUnitOffsetFromLineStart),
+        ..Default::default()
+    });
+    let bytes = index.write_to_bytes().unwrap();
+
+    let report = run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+    assert_eq!(report.edges_examined, 1);
+    assert_eq!(report.upgraded, 1);
+    assert_eq!(report.rows_written, 1);
+    assert_eq!(report.oracle_only_calls, 1, "the uncovered second call site is the recall gap");
+    let (kind, resolved, _) = h.verdict(edge).expect("verdict written");
+    assert_eq!(kind, OracleResolutionKind::Upgrade.as_db_str());
+    assert_eq!(resolved, Some(target_sym));
+}
+
+/// A rerun is AUTHORITATIVE for its `(tool, tool_version)`: when the new `.scip` no longer yields a
+/// verdict for an edge the prior run covered, that edge's stale verdict must be GONE after the
+/// rerun (not left behind by the per-edge upsert). The run clears the scope before writing.
+#[test]
+fn rerun_clears_stale_verdict_for_dropped_edge() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.rs", "fn caller() { target(); }\n");
+    let defs = h.add_file("defs.rs", "fn target() {}\n");
+    let target_sym = h.add_symbol(defs, "target", 3, 9);
+    let edge = h.add_edge(caller, "target", 14, 20, "NameOnly", None);
+
+    // First run: a `.scip` that covers the edge → an Upgrade verdict is written.
+    let sym = "scip-rust crate v1 `target`().";
+    let mut index = Index {
+        documents: vec![Document {
+            relative_path: "caller.rs".to_string(),
+            occurrences: vec![occurrence(0, 14, 20, sym, SymbolRole::UnspecifiedSymbolRole as i32)],
+            position_encoding: EnumOrUnknown::new(
+                PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+            ),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    index.documents.push(Document {
+        relative_path: "defs.rs".to_string(),
+        occurrences: vec![occurrence(0, 3, 9, sym, SymbolRole::Definition as i32)],
+        position_encoding: EnumOrUnknown::new(PositionEncoding::UTF8CodeUnitOffsetFromLineStart),
+        ..Default::default()
+    });
+    let bytes = index.write_to_bytes().unwrap();
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+    assert_eq!(
+        h.verdict(edge).map(|(k, _, _)| k).as_deref(),
+        Some("upgrade"),
+        "first run wrote it"
+    );
+    assert_eq!(target_sym, target_sym); // (binds target_sym so the def mapping is exercised)
+
+    // Rerun with a `.scip` that has NO occurrence for that edge (the document lost the call site).
+    let empty_doc =
+        scip_bytes("caller.rs", PositionEncoding::UTF8CodeUnitOffsetFromLineStart, vec![
+            occurrence(
+                0,
+                0,
+                5,
+                "scip-rust crate v1 `other`().",
+                SymbolRole::UnspecifiedSymbolRole as i32,
+            ),
+        ]);
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &empty_doc, h.root()).unwrap();
+
+    assert!(h.verdict(edge).is_none(), "the dropped edge's stale verdict was cleared on rerun");
+    let total: i64 =
+        h.conn.query_row("SELECT COUNT(*) FROM edge_oracle", [], |r| r.get(0)).unwrap();
+    assert_eq!(total, 0, "rerun left no stale rows for this (tool, version)");
+}
+
+/// The recall gap counts only CALL-LIKE occurrences: an `Import`-role reference and a non-callable
+/// (`Type`-descriptor) reference are excluded even though they have in-corpus definitions, while an
+/// uncovered callable reference IS counted. This keeps imports / type refs from falsely lowering
+/// recall (`oracle_only_calls`).
+#[test]
+fn recall_gap_counts_only_call_like_occurrences() {
+    let h = Harness::new();
+    // One source file with three uncovered references (no edges emitted for any of them):
+    //   - a callable (`Method` suffix) → counts toward the recall gap,
+    //   - an import of that same callable (Import role) → excluded,
+    //   - a type reference (`Type` suffix) → excluded.
+    let src = h.add_file("src.rs", "fn caller() {}\nstruct Thing;\n");
+    let _ = h.add_edge(src, "noop", 0, 1, "NameOnly", None); // unrelated edge, distinct occurrence
+    // The callable's SCIP definition (line 1, bytes 15..21) must map to one of OUR indexed symbols,
+    // otherwise it is (correctly) excluded as not-in-rag-rat's-set. Seed a symbol spanning it.
+    h.add_symbol(src, "target", 15, 21);
+
+    let callable = "scip-rust crate v1 `target`().";
+    let ty = "scip-rust crate v1 `Thing`#"; // `#` is the Type descriptor suffix in SCIP symbol text
+    let index = Index {
+        documents: vec![Document {
+            relative_path: "src.rs".to_string(),
+            occurrences: vec![
+                // Uncovered callable reference + its definition (in-corpus) → 1 recall-gap call.
+                occurrence(0, 5, 11, callable, SymbolRole::UnspecifiedSymbolRole as i32),
+                occurrence(1, 0, 6, callable, SymbolRole::Definition as i32),
+                // An IMPORT of the callable → excluded (Import role).
+                occurrence(0, 12, 13, callable, SymbolRole::Import as i32),
+                // A type reference + its definition → excluded (not callable).
+                occurrence(1, 7, 12, ty, SymbolRole::UnspecifiedSymbolRole as i32),
+                occurrence(1, 7, 12, ty, SymbolRole::Definition as i32),
+            ],
+            position_encoding: EnumOrUnknown::new(
+                PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+            ),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let bytes = index.write_to_bytes().unwrap();
+    let report = run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+
+    // Only the one uncovered callable reference is the recall gap; the import + type ref are not.
+    assert_eq!(report.oracle_only_calls, 1, "only the call-like uncovered reference counts");
+}
+
+/// `oracle_eval_metrics` derives precision / recall / recovery rates from the persisted verdicts.
+/// One confirm + one contradict → precision 0.5; one upgrade among the low-confidence edges →
+/// recovery 1.0.
+#[test]
+fn eval_metrics_derive_rates_from_persisted_verdicts() {
+    let h = Harness::new();
+    let f = h.add_file("a.rs", "fn caller() {}\n");
+    // Exact edges judged: one confirmed, one contradicted. (to_symbol_id NULL keeps the FK happy;
+    // precision is derived from the persisted edge_oracle rows, not the edges row.)
+    let e_conf = h.add_edge(f, "c", 0, 1, "Exact", None);
+    let e_contra = h.add_edge(f, "d", 1, 2, "Exact", None);
+    // A NameOnly edge the oracle upgraded.
+    let e_up = h.add_edge(f, "u", 2, 3, "NameOnly", None);
+
+    let mk = |edge, kind, resolved| EdgeOracleRow {
+        edge_id: edge,
+        file_sha: "s",
+        resolved_symbol_id: resolved,
+        scip_symbol: "s",
+        kind,
+    };
+    store::write_edge_oracle(
+        &h.conn,
+        TOOL,
+        VERSION,
+        &mk(e_conf, OracleResolutionKind::Confirm, Some(1)),
+    )
+    .unwrap();
+    store::write_edge_oracle(
+        &h.conn,
+        TOOL,
+        VERSION,
+        &mk(e_contra, OracleResolutionKind::Contradict, Some(3)),
+    )
+    .unwrap();
+    store::write_edge_oracle(
+        &h.conn,
+        TOOL,
+        VERSION,
+        &mk(e_up, OracleResolutionKind::Upgrade, Some(4)),
+    )
+    .unwrap();
+
+    // Recall sides come from the run, occurrence-counted over the call population: 3 covered call
+    // occurrences + 1 oracle-only gap. (Recall no longer derives from the per-kind verdict sum.)
+    let m = super::oracle_eval_metrics(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, RecallCalls {
+        covered: 3,
+        oracle_only: 1,
+    })
+    .unwrap();
+    assert_eq!(m.confirmed, 1);
+    assert_eq!(m.contradicted, 1);
+    assert_eq!(m.upgraded, 1);
+    assert_eq!(m.oracle_only_calls, 1);
+    assert_eq!(m.covered_calls, 3);
+    // precision = confirm / (confirm + contradict) = 1/2.
+    assert!((m.precision - 0.5).abs() < 1e-9);
+    // recovery = upgrades / low-confidence-edges-with-oracle = 1/1.
+    assert!((m.name_only_recovery_rate - 1.0).abs() < 1e-9);
+    // recall = covered_calls / (covered_calls + oracle_only) = 3/4.
+    assert!((m.recall - 0.75).abs() < 1e-9, "recall was {}", m.recall);
+    // oracle_upgradeable_fraction = (upgrade + external) / unresolved candidates.
+    // Only `e_up` is a NameOnly edge carrying a callee range → denominator 1, numerator 1.
+    assert!((m.oracle_upgradeable_fraction - 1.0).abs() < 1e-9);
+}
+
+/// `oracle_upgradeable_fraction` stays bounded by 1.0 even when the oracle resolved an
+/// already-Exact edge to an external dependency. Numerator and denominator must both range over the
+/// low-confidence (`NameOnly`/`Ambiguous`) population: a `resolved-external` verdict on an Exact
+/// edge is NOT in the denominator, so counting it in the numerator (the old bug) let the fraction
+/// exceed 1.0.
+#[test]
+fn oracle_upgradeable_fraction_is_bounded_by_one() {
+    let h = Harness::new();
+    let f = h.add_file("a.rs", "fn caller() {}\n");
+    // The only low-confidence candidate (denominator = 1): a NameOnly edge the oracle upgraded.
+    let e_low = h.add_edge(f, "u", 0, 1, "NameOnly", None);
+    // An already-Exact edge the oracle placed to an EXTERNAL dep — NOT in the low-conf denominator.
+    let e_exact = h.add_edge(f, "x", 1, 2, "Exact", None);
+
+    let mk = |edge, kind| EdgeOracleRow {
+        edge_id: edge,
+        file_sha: "s",
+        resolved_symbol_id: None,
+        scip_symbol: "s",
+        kind,
+    };
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(e_low, OracleResolutionKind::Upgrade))
+        .unwrap();
+    store::write_edge_oracle(
+        &h.conn,
+        TOOL,
+        VERSION,
+        &mk(e_exact, OracleResolutionKind::ResolvedExternal),
+    )
+    .unwrap();
+
+    let m = super::oracle_eval_metrics(
+        &h.conn,
+        TOOL,
+        VERSION,
+        COMMIT,
+        WORKTREE,
+        RecallCalls::default(),
+    )
+    .unwrap();
+    // Old numerator (upgraded 1 + resolved_external 1 = 2) over denominator 1 would be 2.0.
+    // Scoped numerator counts only the low-conf upgrade → 1/1 = 1.0.
+    assert!(
+        m.oracle_upgradeable_fraction <= 1.0,
+        "fraction {} exceeds 1.0",
+        m.oracle_upgradeable_fraction
+    );
+    assert!((m.oracle_upgradeable_fraction - 1.0).abs() < 1e-9);
+    // The raw counts still report both verdicts for transparency.
+    assert_eq!(m.upgraded, 1);
+    assert_eq!(m.resolved_external, 1);
+}
+
+/// Vacuous denominators yield 1.0 across the board (nothing to get wrong) — the documented
+/// hit-rate convention.
+#[test]
+fn eval_metrics_are_vacuously_perfect_with_no_verdicts() {
+    let h = Harness::new();
+    let m = super::oracle_eval_metrics(
+        &h.conn,
+        TOOL,
+        VERSION,
+        COMMIT,
+        WORKTREE,
+        RecallCalls::default(),
+    )
+    .unwrap();
+    assert_eq!(m.precision, 1.0);
+    assert_eq!(m.recall, 1.0);
+    assert_eq!(m.name_only_recovery_rate, 1.0);
+    assert_eq!(m.oracle_upgradeable_fraction, 1.0);
+}
+
+// ---------------------------------------------------------------------------
+// scip.rs — reader branches: empty/malformed bytes, multi-line, encoding fallback.
+// ---------------------------------------------------------------------------
+
+/// Malformed protobuf bytes return a clean parse error (not a panic), naming the SCIP index.
+#[test]
+fn parse_malformed_bytes_returns_clean_error() {
+    // A long run of 0xFF is not a valid protobuf wire stream.
+    let err = ScipIndex::parse(&[0xFF; 64], |_| Some(Vec::new())).unwrap_err();
+    assert!(err.to_string().contains("SCIP"), "error mentions SCIP: {err}");
+}
+
+/// Empty bytes parse to an empty index (zero documents) — not an error.
+#[test]
+fn parse_empty_bytes_yields_empty_maps() {
+    let idx = ScipIndex::parse(&[], |_| Some(Vec::new())).unwrap();
+    assert!(idx.occurrences_by_path.is_empty());
+    assert!(idx.definitions.is_empty());
+}
+
+/// A document whose source can't be read is skipped entirely — its occurrences never enter the
+/// maps (the correct degradation; the join just finds no oracle data for those edges).
+#[test]
+fn parse_skips_documents_with_unreadable_source() {
+    let bytes =
+        scip_bytes("gone.rs", PositionEncoding::UTF8CodeUnitOffsetFromLineStart, vec![occurrence(
+            0,
+            0,
+            3,
+            "scip-rust crate v1 `f`().",
+            SymbolRole::UnspecifiedSymbolRole as i32,
+        )]);
+    // read_document_source returns None → document dropped.
+    let idx = ScipIndex::parse(&bytes, |_| None).unwrap();
+    assert!(idx.occurrences_by_path.is_empty());
+}
+
+/// A document with no occurrences still registers an (empty) path entry; definitions stay empty.
+#[test]
+fn parse_document_with_no_occurrences_registers_empty_entry() {
+    let bytes = scip_bytes("a.rs", PositionEncoding::UTF8CodeUnitOffsetFromLineStart, vec![]);
+    let idx = ScipIndex::parse(&bytes, |_| Some(b"fn a() {}\n".to_vec())).unwrap();
+    assert_eq!(idx.occurrences_by_path.get("a.rs").map(Vec::len), Some(0));
+    assert!(idx.definitions.is_empty());
+}
+
+/// A multi-line occurrence range (`[start_line, start_char, end_line, end_char]`) parses to the
+/// byte span crossing the newline.
+#[test]
+fn parse_multi_line_occurrence_range() {
+    // Source: line 0 = "fn a(\n", line 1 = "   b) {}\n". A range from (0,3) to (1,4) spans
+    // bytes 3 .. (line1_start 6 + 4) = 3..10.
+    let source = b"fn a(\n   b) {}\n".to_vec();
+    let occ = Occurrence {
+        range: vec![0, 3, 1, 4],
+        symbol: "scip-rust crate v1 `span`().".to_string(),
+        symbol_roles: SymbolRole::UnspecifiedSymbolRole as i32,
+        ..Default::default()
+    };
+    let bytes = scip_bytes("a.rs", PositionEncoding::UTF8CodeUnitOffsetFromLineStart, vec![occ]);
+    let idx = ScipIndex::parse(&bytes, move |_| Some(source.clone())).unwrap();
+    let occs = idx.occurrences_by_path.get("a.rs").unwrap();
+    assert_eq!(occs.len(), 1);
+    assert_eq!((occs[0].start_byte, occs[0].end_byte), (3, 10));
+}
+
+/// An unspecified `position_encoding` falls back to one-byte-per-code-unit on ASCII (it behaves
+/// like UTF-32: one unit per scalar), so an ASCII identifier resolves to the same span a UTF-8
+/// document would.
+#[test]
+fn parse_unspecified_encoding_falls_back_for_ascii() {
+    let source = b"fn a() { foo(); }\n".to_vec();
+    // `foo` sits at chars/bytes 9..12 on line 0 (ASCII → all encodings agree).
+    let occ = occurrence(
+        0,
+        9,
+        12,
+        "scip-rust crate v1 `foo`().",
+        SymbolRole::UnspecifiedSymbolRole as i32,
+    );
+    let bytes = scip_bytes("a.rs", PositionEncoding::UnspecifiedPositionEncoding, vec![occ]);
+    let idx = ScipIndex::parse(&bytes, move |_| Some(source.clone())).unwrap();
+    let occs = idx.occurrences_by_path.get("a.rs").unwrap();
+    assert_eq!((occs[0].start_byte, occs[0].end_byte), (9, 12));
+}
+
+/// A malformed occurrence range (wrong arity) is dropped, not fatal — the rest of the document
+/// still parses.
+#[test]
+fn parse_drops_malformed_occurrence_range() {
+    let source = b"fn a() { foo(); }\n".to_vec();
+    let bad = Occurrence {
+        range: vec![0, 9], // arity 2 — neither single- nor multi-line shape.
+        symbol: "scip-rust crate v1 `foo`().".to_string(),
+        symbol_roles: SymbolRole::UnspecifiedSymbolRole as i32,
+        ..Default::default()
+    };
+    let good = occurrence(
+        0,
+        9,
+        12,
+        "scip-rust crate v1 `bar`().",
+        SymbolRole::UnspecifiedSymbolRole as i32,
+    );
+    let bytes =
+        scip_bytes("a.rs", PositionEncoding::UTF8CodeUnitOffsetFromLineStart, vec![bad, good]);
+    let idx = ScipIndex::parse(&bytes, move |_| Some(source.clone())).unwrap();
+    let occs = idx.occurrences_by_path.get("a.rs").unwrap();
+    // Only the well-formed range survives.
+    assert_eq!(occs.len(), 1);
+    assert_eq!(occs[0].symbol, "scip-rust crate v1 `bar`().");
+}
+
+/// A 3-byte UTF-8 scalar (a BMP CJK character) is one UTF-16 unit; an ASCII identifier after it
+/// lands at the right byte offset under UTF-16 — exercises the 3-byte `utf8_char_len` arm and the
+/// BMP (non-astral) UTF-16 branch.
+#[test]
+fn parse_utf16_three_byte_bmp_character_offsets_correctly() {
+    // Line 0: "中x foo()\n". '中' (U+4E2D) is 3 UTF-8 bytes / 1 UTF-16 unit.
+    //   bytes: 中(3 → 0..3) x(byte 3) ' '(byte 4) f o o → `foo` at bytes 5..8.
+    //   UTF-16 units before `foo`: 中=1, x=1, space=1 = 3 → `foo` is units 3..6.
+    let source = "中x foo()\n".as_bytes().to_vec();
+    assert_eq!(&source[5..8], b"foo", "byte offset sanity check");
+    let occ = occurrence(
+        0,
+        3,
+        6,
+        "scip-rust crate v1 `foo`().",
+        SymbolRole::UnspecifiedSymbolRole as i32,
+    );
+    let bytes = scip_bytes("a.rs", PositionEncoding::UTF16CodeUnitOffsetFromLineStart, vec![occ]);
+    let idx = ScipIndex::parse(&bytes, move |_| Some(source.clone())).unwrap();
+    let occs = idx.occurrences_by_path.get("a.rs").unwrap();
+    assert_eq!((occs[0].start_byte, occs[0].end_byte), (5, 8));
+}
+
+/// A range whose end column lands BEFORE its start column is malformed and dropped (the
+/// `end < start` guard in `byte_range`), not surfaced as an inverted span.
+#[test]
+fn parse_drops_range_with_end_before_start() {
+    let source = b"fn a() { foo(); }\n".to_vec();
+    // Single-line range [line 0, start_char 12, end_char 9] → end byte < start byte.
+    let occ = occurrence(
+        0,
+        12,
+        9,
+        "scip-rust crate v1 `foo`().",
+        SymbolRole::UnspecifiedSymbolRole as i32,
+    );
+    let bytes = scip_bytes("a.rs", PositionEncoding::UTF8CodeUnitOffsetFromLineStart, vec![occ]);
+    let idx = ScipIndex::parse(&bytes, move |_| Some(source.clone())).unwrap();
+    let occs = idx.occurrences_by_path.get("a.rs").unwrap();
+    assert_eq!(occs.len(), 0, "inverted range dropped");
+}
+
+/// A column that overruns the line is clamped to the line end (the `byte >= line_end` branch in
+/// `byte_at`), so an over-long end column resolves to the newline boundary instead of spilling.
+#[test]
+fn parse_clamps_column_overrun_to_line_end() {
+    // Line 0 = "ab\n": line_starts = [0, 3]. An end column of 9 overruns the line → the walk hits
+    // `byte >= line_end` and clamps to the line-end boundary (byte 3, the start of line 1).
+    let source = b"ab\ncd\n".to_vec();
+    let occ =
+        occurrence(0, 0, 9, "scip-rust crate v1 `ab`().", SymbolRole::UnspecifiedSymbolRole as i32);
+    let bytes = scip_bytes("a.rs", PositionEncoding::UTF8CodeUnitOffsetFromLineStart, vec![occ]);
+    let idx = ScipIndex::parse(&bytes, move |_| Some(source.clone())).unwrap();
+    let occs = idx.occurrences_by_path.get("a.rs").unwrap();
+    assert_eq!(occs[0].start_byte, 0);
+    assert_eq!(occs[0].end_byte, 3, "overrun clamped to the line-end boundary");
+}
+
+// ---------------------------------------------------------------------------
+// join.rs — package extraction, def-range → symbol overlap mapping.
+// ---------------------------------------------------------------------------
+
+/// `package_of` / `names_external_package` extract the crate/package name from a package-bearing
+/// SCIP symbol and return `None`/false for a local symbol.
+#[test]
+fn package_extraction_from_scip_symbol() {
+    let external = "scip-rust cargo tokio 1.0 `spawn`().";
+    assert_eq!(package_of(external).as_deref(), Some("tokio"));
+    assert!(names_external_package(external));
+
+    // A `local …` symbol has no package component.
+    assert_eq!(package_of("local 0"), None);
+    assert!(!names_external_package("local 0"));
+}
+
+/// `map_definition_to_symbol` picks the tightest span that REALLY contains the whole definition
+/// range (a method beats its enclosing impl) and returns `None` when no span contains it.
+#[test]
+fn map_definition_to_symbol_prefers_tightest_span() {
+    let spans = vec![
+        SymbolSpan { symbol_id: 1, start_byte: 0, end_byte: 100 }, // enclosing impl
+        SymbolSpan { symbol_id: 2, start_byte: 10, end_byte: 20 }, // tight method
+    ];
+    // Def 12..16 is contained by both → the tighter (id 2) wins.
+    assert_eq!(join::map_definition_to_symbol(&spans, 12, 16), Some(2));
+    // Def 50..50 is past the tight method's end (20) → only the enclosing impl contains it.
+    assert_eq!(join::map_definition_to_symbol(&spans, 50, 50), Some(1));
+    // Def 200..200 is past every span → no containment.
+    assert_eq!(join::map_definition_to_symbol(&spans, 200, 200), None);
+}
+
+/// REAL containment: a symbol span whose `end_byte` falls BEFORE the definition must NOT match,
+/// even though its `start_byte <= def_start`. This is the corrupting case the old
+/// `end_byte.max(def_end)` predicate got wrong — a short helper preceding the real target would win
+/// via `min_by_key` and record the verdict against the WRONG symbol. The fix requires `def_end <=
+/// span.end_byte`.
+#[test]
+fn map_definition_to_symbol_requires_real_containment_not_just_start() {
+    let spans = vec![
+        // A short helper that ENDS before the definition (10..20), but starts before def_start.
+        SymbolSpan { symbol_id: 1, start_byte: 10, end_byte: 20 },
+        // The real enclosing target that actually contains the def (0..100).
+        SymbolSpan { symbol_id: 2, start_byte: 0, end_byte: 100 },
+    ];
+    // Def 50..60 is contained ONLY by id 2; the preceding helper (ends at 20) must be rejected even
+    // though 10 <= 50. Under the old `max(def_end)` predicate the tighter helper (10..20) wrongly
+    // won. Now only id 2 contains it.
+    assert_eq!(join::map_definition_to_symbol(&spans, 50, 60), Some(2));
+
+    // A def whose END spills past the only candidate span (30..40, def 35..50) is NOT contained —
+    // partial overlap is not containment, so it returns None rather than a wrong match.
+    let one = vec![SymbolSpan { symbol_id: 5, start_byte: 30, end_byte: 40 }];
+    assert_eq!(join::map_definition_to_symbol(&one, 35, 50), None);
+    // The same span DOES contain a def that fits entirely inside it.
+    assert_eq!(join::map_definition_to_symbol(&one, 32, 38), Some(5));
+}
+
+// ---------------------------------------------------------------------------
+// mod.rs — persisted-enum round trips.
+// ---------------------------------------------------------------------------
+
+/// Both persisted enums round-trip through `as_db_str` / `from_db_str` for every variant, and
+/// reject an unknown string — the `rust-modern-style` closed-enum contract.
+#[test]
+fn persisted_enums_round_trip_through_db_strings() {
+    assert_eq!(OracleTool::from_db_str(OracleTool::RustAnalyzer.as_db_str()), Some(TOOL));
+    assert_eq!(OracleTool::from_db_str("scip-typescript"), None);
+
+    for kind in [
+        OracleResolutionKind::Upgrade,
+        OracleResolutionKind::ResolvedExternal,
+        OracleResolutionKind::Confirm,
+        OracleResolutionKind::Contradict,
+    ] {
+        assert_eq!(OracleResolutionKind::from_db_str(kind.as_db_str()), Some(kind));
+    }
+    assert_eq!(OracleResolutionKind::from_db_str("nonsense"), None);
+}
+
+/// A 4-byte UTF-8 scalar (an astral-plane character) counts as **2** UTF-16 code units; an ASCII
+/// identifier after it lands at the right byte offset only when the reader applies that surrogate
+/// width — the UTF-16 astral branch in `code_units_for` plus the 4-byte `utf8_char_len` arm.
+#[test]
+fn parse_utf16_astral_character_shifts_offset_by_surrogate_width() {
+    // Source line 0: "𝛂x foo()\n". '𝛂' (U+1D6C2) is 4 UTF-8 bytes / 2 UTF-16 units.
+    //   bytes:  𝛂(4 → 0..4) x(byte 4) ' '(byte 5) f o o → `foo` starts at byte 6, ends at 9.
+    //   UTF-16 units before `foo`: 𝛂=2, x=1, space=1 = 4 → `foo` is units 4..7.
+    let source = "𝛂x foo()\n".as_bytes().to_vec();
+    assert_eq!(&source[6..9], b"foo", "byte offset sanity check");
+    let occ = occurrence(
+        0,
+        4,
+        7,
+        "scip-rust crate v1 `foo`().",
+        SymbolRole::UnspecifiedSymbolRole as i32,
+    );
+    let bytes = scip_bytes("a.rs", PositionEncoding::UTF16CodeUnitOffsetFromLineStart, vec![occ]);
+    let idx = ScipIndex::parse(&bytes, move |_| Some(source.clone())).unwrap();
+    let occs = idx.occurrences_by_path.get("a.rs").unwrap();
+    // Correct surrogate accounting lands the byte range on `foo` (bytes 6..9).
+    assert_eq!((occs[0].start_byte, occs[0].end_byte), (6, 9));
+}
+
+// ---------------------------------------------------------------------------
+// Multi-checkout scoping — the four PR-#81 review findings (#68). Every
+// metric/clear/recall read must scope to the run's (commit_sha, worktree_id),
+// mirroring `edge_join_candidates`, so a sibling checkout in the same DB can't
+// leak into (or be erased by) the active run.
+// ---------------------------------------------------------------------------
+
+const OTHER_WORKTREE: &str = "other-wt";
+
+/// Finding 1: `clear_edge_oracle_for_tool` must delete ONLY the active checkout's verdicts. With
+/// two worktrees' verdicts for the same `(tool, tool_version)` in one DB, clearing one leaves the
+/// other's intact (the clear is scoped via `edge_oracle -> edges -> files`).
+#[test]
+fn clear_edge_oracle_is_scoped_to_active_checkout() {
+    let h = Harness::new();
+    // Active-checkout edge (commit_sha="" / worktree_id="") + a verdict.
+    let active_file = h.add_file("a.rs", "fn caller() { target(); }\n");
+    let active_edge = h.add_edge(active_file, "target", 14, 20, "NameOnly", None);
+    // Another worktree's edge (same DB) + a verdict for the SAME tool/version.
+    let other_file = h.add_file_in_scope("a.rs", COMMIT, OTHER_WORKTREE);
+    let other_edge = h.add_edge(other_file, "target", 14, 20, "NameOnly", None);
+
+    let mk = |edge| EdgeOracleRow {
+        edge_id: edge,
+        file_sha: "s",
+        resolved_symbol_id: None,
+        scip_symbol: "s",
+        kind: OracleResolutionKind::Upgrade,
+    };
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(active_edge)).unwrap();
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(other_edge)).unwrap();
+    // Whole-table count (both worktrees) — the production count helper is intentionally scoped to
+    // ONE checkout, so this test reads the raw total directly to prove the cross-checkout state.
+    let total_rows = || -> i64 {
+        h.conn.query_row("SELECT COUNT(*) FROM edge_oracle", [], |row| row.get(0)).unwrap()
+    };
+    assert_eq!(total_rows(), 2);
+    // The scoped count sees ONLY the active checkout's verdict.
+    assert_eq!(
+        store::count_edge_oracle_scoped(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, None).unwrap(),
+        1
+    );
+
+    // Clear the ACTIVE checkout's scope only.
+    store::clear_edge_oracle_for_tool(&h.conn, TOOL, VERSION, COMMIT, WORKTREE).unwrap();
+
+    assert!(h.verdict(active_edge).is_none(), "active checkout's verdict cleared");
+    assert!(h.verdict(other_edge).is_some(), "the other worktree's verdict is untouched");
+    assert_eq!(total_rows(), 1, "only the other worktree's verdict remains in the table");
+    assert_eq!(
+        store::count_edge_oracle_scoped(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, None).unwrap(),
+        0,
+        "active checkout's scoped count is now zero"
+    );
+}
+
+/// Finding 2: a low-confidence edge in ANOTHER worktree must not inflate the current run's
+/// `oracle_upgradeable_fraction` denominator. With one upgraded low-conf edge in-scope and an
+/// extra unresolved low-conf edge out-of-scope, the scoped fraction is 1/1 = 1.0 (not 1/2).
+#[test]
+fn upgradeable_fraction_denominator_is_scoped_to_active_checkout() {
+    let h = Harness::new();
+    // Active checkout: one NameOnly edge the oracle upgraded → numerator 1, denominator 1.
+    let active = h.add_file("a.rs", "fn caller() {}\n");
+    let e_low = h.add_edge(active, "u", 0, 1, "NameOnly", None);
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &EdgeOracleRow {
+        edge_id: e_low,
+        file_sha: "s",
+        resolved_symbol_id: Some(1),
+        scip_symbol: "s",
+        kind: OracleResolutionKind::Upgrade,
+    })
+    .unwrap();
+
+    // Another worktree: an unresolved NameOnly candidate carrying a callee range, NO verdict. If
+    // the denominator weren't scoped, it would count → fraction 1/2.
+    let other = h.add_file_in_scope("a.rs", COMMIT, OTHER_WORKTREE);
+    let _ = h.add_edge(other, "v", 0, 1, "NameOnly", None);
+
+    let m = super::oracle_eval_metrics(
+        &h.conn,
+        TOOL,
+        VERSION,
+        COMMIT,
+        WORKTREE,
+        RecallCalls::default(),
+    )
+    .unwrap();
+    assert!(
+        (m.oracle_upgradeable_fraction - 1.0).abs() < 1e-9,
+        "scoped fraction is 1/1, not diluted to 1/2 by the other worktree; got {}",
+        m.oracle_upgradeable_fraction
+    );
+}
+
+/// Finding 3: a `.scip` definition in a file rag-rat did NOT index (no matching DB symbol) is
+/// excluded from the recall gap — counting calls to un-indexed tests/examples/generated/dependency
+/// sources as misses is a false negative. The same callable, when its def maps to an indexed
+/// symbol, IS counted; without an indexed symbol it drops to zero.
+#[test]
+fn recall_gap_excludes_definitions_in_unindexed_files() {
+    // The `.scip` references `target`, defined in `gen.rs` — a file with occurrences but whose
+    // definition byte range maps to NO indexed symbol (rag-rat never indexed gen.rs's symbols).
+    let build = |seed_symbol: bool| -> u64 {
+        let h = Harness::new();
+        let caller = h.add_file("caller.rs", "fn caller() { target(); }\n");
+        let _ = h.add_edge(caller, "noop", 0, 1, "NameOnly", None); // unrelated, distinct occurrence
+        let gen_file = h.add_file("gen.rs", "fn target() {}\n");
+        if seed_symbol {
+            // Seed the def symbol so the callable resolves to OUR corpus → counted.
+            h.add_symbol(gen_file, "target", 3, 9);
+        }
+
+        let callable = "scip-rust crate v1 `target`().";
+        let mut index = Index {
+            documents: vec![Document {
+                relative_path: "caller.rs".to_string(),
+                // Uncovered callable reference (no edge covers it) at bytes 14..20.
+                occurrences: vec![occurrence(
+                    0,
+                    14,
+                    20,
+                    callable,
+                    SymbolRole::UnspecifiedSymbolRole as i32,
+                )],
+                position_encoding: EnumOrUnknown::new(
+                    PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+                ),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        index.documents.push(Document {
+            relative_path: "gen.rs".to_string(),
+            occurrences: vec![occurrence(0, 3, 9, callable, SymbolRole::Definition as i32)],
+            position_encoding: EnumOrUnknown::new(
+                PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+            ),
+            ..Default::default()
+        });
+        let bytes = index.write_to_bytes().unwrap();
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root())
+            .unwrap()
+            .oracle_only_calls
+    };
+
+    assert_eq!(build(false), 0, "a def in an un-indexed file is NOT a recall gap");
+    assert_eq!(build(true), 1, "the same callable IS a recall gap once its def maps to a symbol");
+}
+
+/// Round-3 finding (occurrence side of the recall gap): a `.scip` occurrence whose *call site*
+/// lives in a SOURCE document rag-rat did NOT index in this checkout is excluded from the recall
+/// gap, even when the callee *definition* resolves to an indexed symbol. No edge candidate can ever
+/// cover a call from an unindexed file (`edge_join_candidates` only emits candidates for indexed
+/// files), so counting it as an uncovered call is a false miss. The same callable, when its call
+/// site IS an indexed file, IS counted — proving the filter is the occurrence path, not the
+/// definition.
+#[test]
+fn recall_gap_excludes_occurrences_in_unindexed_source_files() {
+    // `target` is defined in an INDEXED file with a seeded symbol (so the def-side filter passes).
+    // The uncovered call occurrence lives in `caller.rs`; we vary whether rag-rat indexed it.
+    let build = |index_caller: bool| -> u64 {
+        let h = Harness::new();
+        // The def file is always indexed + its symbol seeded → the def-side filter never trips.
+        let defs = h.add_file("defs.rs", "fn target() {}\n");
+        h.add_symbol(defs, "target", 3, 9);
+        if index_caller {
+            // caller.rs IS an indexed file in this checkout → the call site is in scope.
+            h.add_file("caller.rs", "fn caller() { target(); }\n");
+        }
+        // else: caller.rs exists in the `.scip` but is NOT a `files` row → out-of-scope call site.
+
+        let callable = "scip-rust crate v1 `target`().";
+        let mut index = Index {
+            documents: vec![Document {
+                relative_path: "caller.rs".to_string(),
+                // Uncovered callable reference (no edge covers it) at bytes 14..20.
+                occurrences: vec![occurrence(
+                    0,
+                    14,
+                    20,
+                    callable,
+                    SymbolRole::UnspecifiedSymbolRole as i32,
+                )],
+                position_encoding: EnumOrUnknown::new(
+                    PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+                ),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        index.documents.push(Document {
+            relative_path: "defs.rs".to_string(),
+            occurrences: vec![occurrence(0, 3, 9, callable, SymbolRole::Definition as i32)],
+            position_encoding: EnumOrUnknown::new(
+                PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+            ),
+            ..Default::default()
+        });
+        let bytes = index.write_to_bytes().unwrap();
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root())
+            .unwrap()
+            .oracle_only_calls
+    };
+
+    assert_eq!(build(false), 0, "a call from an un-indexed source file is NOT a recall gap");
+    assert_eq!(build(true), 1, "the same call IS a recall gap once its source file is indexed");
+}
+
+/// Round-3 finding (the comprehensive audit): a sibling checkout's `edge_oracle` rows for the SAME
+/// `(tool, tool_version)` must not perturb the active checkout's `verdict_counts`-derived metrics
+/// (precision/recall) OR its status. Checkout A sees 1 confirm + 1 contradict (precision 0.5);
+/// checkout B has its own confirm/confirm/upgrade rows. Before the round-3 fix `verdict_counts` was
+/// a global `(tool, tool_version)` count, so B's confirms would inflate A's numerator and break
+/// both precision and recall. This pins the whole metric path to the active checkout.
+#[test]
+fn verdict_counts_and_metrics_ignore_sibling_checkout_rows() {
+    let h = Harness::new();
+    let mk = |edge, kind| EdgeOracleRow {
+        edge_id: edge,
+        file_sha: "s",
+        resolved_symbol_id: None,
+        scip_symbol: "s",
+        kind,
+    };
+
+    // Active checkout A: one confirmed + one contradicted Exact edge → precision 1/2.
+    let a_file = h.add_file("a.rs", "fn caller() {}\n");
+    let a_conf = h.add_edge(a_file, "c", 0, 1, "Exact", None);
+    let a_contra = h.add_edge(a_file, "d", 1, 2, "Exact", None);
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(a_conf, OracleResolutionKind::Confirm))
+        .unwrap();
+    store::write_edge_oracle(
+        &h.conn,
+        TOOL,
+        VERSION,
+        &mk(a_contra, OracleResolutionKind::Contradict),
+    )
+    .unwrap();
+
+    // Sibling checkout B (same DB, same tool/version): TWO confirms + an upgrade. If A's counts
+    // leaked B's rows, A's precision would jump to 3/4 and its recall would change.
+    let b_file = h.add_file_in_scope("a.rs", COMMIT, OTHER_WORKTREE);
+    let b_conf1 = h.add_edge(b_file, "e", 0, 1, "Exact", None);
+    let b_conf2 = h.add_edge(b_file, "f", 1, 2, "Exact", None);
+    let b_up = h.add_edge(b_file, "g", 2, 3, "NameOnly", None);
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(b_conf1, OracleResolutionKind::Confirm))
+        .unwrap();
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(b_conf2, OracleResolutionKind::Confirm))
+        .unwrap();
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(b_up, OracleResolutionKind::Upgrade))
+        .unwrap();
+
+    // A's metrics: precision = 1 confirm / (1 confirm + 1 contradict) = 0.5; recall over A's
+    // covered call set (2 covered call occurrences) and 0 oracle-only = 2/2 = 1.0. The recall
+    // counts come from the run; B's three verdict rows never enter A's precision either.
+    let m = super::oracle_eval_metrics(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, RecallCalls {
+        covered: 2,
+        oracle_only: 0,
+    })
+    .unwrap();
+    assert_eq!(m.confirmed, 1, "only A's confirm counts");
+    assert_eq!(m.contradicted, 1);
+    assert_eq!(m.upgraded, 0, "B's upgrade does not leak into A");
+    assert!(
+        (m.precision - 0.5).abs() < 1e-9,
+        "precision unperturbed by B's confirms; got {}",
+        m.precision
+    );
+    assert!((m.recall - 1.0).abs() < 1e-9, "recall is A's covered set only; got {}", m.recall);
+
+    // The status read shares the same scoped `verdict_counts`, so it is scoped identically.
+    let status = super::oracle_status(&h.conn, TOOL, VERSION, COMMIT, WORKTREE).unwrap();
+    assert_eq!(status.total_verdicts, 2, "status counts only A's two verdicts");
+    assert_eq!(status.confirmed, 1);
+    assert_eq!(status.contradicted, 1);
+    assert_eq!(status.upgraded, 0);
+
+    // Sanity: checkout B's own scoped status sees its three rows, proving the rows really exist.
+    let status_b = super::oracle_status(&h.conn, TOOL, VERSION, COMMIT, OTHER_WORKTREE).unwrap();
+    assert_eq!(status_b.total_verdicts, 3);
+    assert_eq!(status_b.confirmed, 2);
+    assert_eq!(status_b.upgraded, 1);
+}
+
+/// Finding 4: an already-resolved (`Exact`) edge pointing at an IN-CORPUS target, when SCIP
+/// resolves the same call to an EXTERNAL definition, is a CONTRADICTION (the heuristic picked the
+/// wrong target) — not `resolved-external`. It must count in `confirm + contradict` and lower
+/// precision.
+#[test]
+fn exact_in_corpus_edge_contradicted_by_external_scip_resolution() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.rs", "fn caller() { spawn(); }\n");
+    let defs = h.add_file("defs.rs", "fn spawn() {}\n");
+    // The heuristic resolved `spawn` to an IN-CORPUS symbol (Exact).
+    let in_corpus = h.add_symbol(defs, "spawn", 3, 8);
+    let edge = h.add_edge(caller, "spawn", 14, 19, "Exact", Some(in_corpus));
+
+    // SCIP says `spawn` is the external tokio::spawn — a package-bearing symbol with NO in-corpus
+    // definition.
+    let external = "scip-rust cargo tokio 1.0 `spawn`().";
+    let bytes = scip_bytes("caller.rs", PositionEncoding::UTF8CodeUnitOffsetFromLineStart, vec![
+        occurrence(0, 14, 19, external, SymbolRole::UnspecifiedSymbolRole as i32),
+    ]);
+
+    let report = run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+
+    let (kind, resolved, scip) = h.verdict(edge).expect("verdict written");
+    assert_eq!(
+        kind,
+        OracleResolutionKind::Contradict.as_db_str(),
+        "external-vs-in-corpus disagreement is a contradiction, not resolved-external"
+    );
+    assert_eq!(resolved, None, "no in-corpus symbol — the real target is external");
+    assert_eq!(scip, external);
+    assert_eq!(report.contradicted, 1);
+    assert_eq!(report.resolved_external, 0, "it is NOT counted as resolved-external");
+    // Heuristic row untouched.
+    assert_eq!(h.heuristic_resolution(edge), ("exact".to_string(), Some(in_corpus)));
+
+    // Precision counts it honestly: 0 confirmed / (0 + 1 contradicted) = 0.0.
+    let m = super::oracle_eval_metrics(
+        &h.conn,
+        TOOL,
+        VERSION,
+        COMMIT,
+        WORKTREE,
+        RecallCalls::default(),
+    )
+    .unwrap();
+    assert!(
+        (m.precision - 0.0).abs() < 1e-9,
+        "contradiction lowers precision; got {}",
+        m.precision
+    );
+    assert_eq!(m.contradicted, 1);
+}
+
+/// Finding 4 (counterpart): an UNRESOLVED / `NameOnly` edge SCIP places externally is still
+/// `resolved-external` — there is no in-corpus claim to contradict. This pins the boundary so the
+/// contradiction rule doesn't swallow the legitimate external-recovery case.
+#[test]
+fn name_only_edge_with_external_scip_stays_resolved_external() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.rs", "fn caller() { spawn(); }\n");
+    // NameOnly + unresolved (no heuristic symbol) → no in-corpus claim.
+    let edge = h.add_edge(caller, "spawn", 14, 19, "NameOnly", None);
+
+    let external = "scip-rust cargo tokio 1.0 `spawn`().";
+    let bytes = scip_bytes("caller.rs", PositionEncoding::UTF8CodeUnitOffsetFromLineStart, vec![
+        occurrence(0, 14, 19, external, SymbolRole::UnspecifiedSymbolRole as i32),
+    ]);
+
+    let report = run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+
+    let (kind, _, _) = h.verdict(edge).expect("verdict written");
+    assert_eq!(kind, OracleResolutionKind::ResolvedExternal.as_db_str());
+    assert_eq!(report.resolved_external, 1);
+    assert_eq!(report.contradicted, 0);
+}
+
+/// The `(None, Some(_))` join arm: SCIP HAS a definition document for the callee, but that
+/// definition's byte range maps to NO indexed symbol (the def lives in an un-indexed file) → the
+/// callee is external. A NameOnly edge there is `resolved-external`. Distinct from the package-only
+/// `(None, None)` path covered above — this exercises the in-`.scip`-but-out-of-corpus branch.
+#[test]
+fn scip_definition_outside_indexed_corpus_resolves_external() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.rs", "fn caller() { target(); }\n");
+    // `defs.rs` is indexed as a file but we seed NO symbol for `target`, so the def maps to
+    // nothing.
+    let _defs = h.add_file("defs.rs", "fn target() {}\n");
+    let edge = h.add_edge(caller, "target", 14, 20, "NameOnly", None);
+
+    // A package-bearing symbol WITH a definition occurrence in defs.rs → goes through (None, Some).
+    let symbol = "scip-rust crate v1 `target`().";
+    let mut index = Index {
+        documents: vec![Document {
+            relative_path: "caller.rs".to_string(),
+            occurrences: vec![occurrence(
+                0,
+                14,
+                20,
+                symbol,
+                SymbolRole::UnspecifiedSymbolRole as i32,
+            )],
+            position_encoding: EnumOrUnknown::new(
+                PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+            ),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    index.documents.push(Document {
+        relative_path: "defs.rs".to_string(),
+        occurrences: vec![occurrence(0, 3, 9, symbol, SymbolRole::Definition as i32)],
+        position_encoding: EnumOrUnknown::new(PositionEncoding::UTF8CodeUnitOffsetFromLineStart),
+        ..Default::default()
+    });
+    let bytes = index.write_to_bytes().unwrap();
+
+    let report = run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+    let (kind, resolved, _) = h.verdict(edge).expect("verdict written");
+    assert_eq!(kind, OracleResolutionKind::ResolvedExternal.as_db_str());
+    assert_eq!(resolved, None, "def maps to no indexed symbol → external");
+    assert_eq!(report.resolved_external, 1);
+}
+
+/// A reference occurrence whose symbol has NO SCIP definition and names NO package is the
+/// no-actionable-data `(None, None)` drop: the join returns `None`, no verdict is written. (A
+/// non-`local`, non-package, definition-less symbol — e.g. a malformed/synthetic one.)
+#[test]
+fn reference_without_definition_or_package_yields_no_verdict() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.rs", "fn caller() { mystery(); }\n");
+    let edge = h.add_edge(caller, "mystery", 14, 21, "NameOnly", None);
+
+    // A bare symbol with no `Definition` occurrence anywhere and no package component.
+    let bare = "scip-rust  `mystery`().";
+    assert!(!join::names_external_package(bare), "fixture must have no package");
+    let bytes = scip_bytes("caller.rs", PositionEncoding::UTF8CodeUnitOffsetFromLineStart, vec![
+        occurrence(0, 14, 21, bare, SymbolRole::UnspecifiedSymbolRole as i32),
+    ]);
+
+    let report = run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+    assert!(h.verdict(edge).is_none(), "no definition + no package → no verdict");
+    assert_eq!(report.rows_written, 0);
+    assert_eq!(report.no_occurrence, 1, "dropped into the no-actionable bucket");
+}
+
+// ---------------------------------------------------------------------------
+// #81 review fixes — recall population, content integrity, worktree scope, tombstones.
+// ---------------------------------------------------------------------------
+
+/// Finding 1 (gap side): an in-corpus FIELD/CONST read — a SCIP `Term` descriptor ending in a bare
+/// `.` (no `()`), with an in-corpus definition — is NOT a callable, so it must NOT count as a
+/// missed call in the recall gap. Before the `symbol_is_callable` tightening (`).` not bare `.`) it
+/// slipped through and deflated recall. The same occurrence as a genuine `Method` (`).`) IS
+/// counted, proving the suffix is what gates it.
+#[test]
+fn recall_gap_excludes_field_const_term_reads() {
+    let build = |callable: bool| -> u64 {
+        let h = Harness::new();
+        let src = h.add_file("src.rs", "fn caller() {}\n");
+        // Seed the def symbol so the def-side filter passes — the ONLY thing left deciding the gap
+        // is callability.
+        h.add_symbol(src, "VALUE", 3, 8);
+        // A `Term` (bare `.`) is a const/field read; a `Method` (`).`) is a call.
+        let symbol =
+            if callable { "scip-rust crate v1 `VALUE`()." } else { "scip-rust crate v1 `VALUE`." };
+        let index = Index {
+            documents: vec![Document {
+                relative_path: "src.rs".to_string(),
+                occurrences: vec![
+                    // Uncovered reference (no edge covers it) at bytes 5..10.
+                    occurrence(0, 5, 10, symbol, SymbolRole::UnspecifiedSymbolRole as i32),
+                    // Its in-corpus definition (line 0, bytes 3..8).
+                    occurrence(0, 3, 8, symbol, SymbolRole::Definition as i32),
+                ],
+                position_encoding: EnumOrUnknown::new(
+                    PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+                ),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let bytes = index.write_to_bytes().unwrap();
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root())
+            .unwrap()
+            .oracle_only_calls
+    };
+
+    assert_eq!(build(false), 0, "a bare-`.` Term (field/const read) is NOT a missed call");
+    assert_eq!(build(true), 1, "the same occurrence as a `).` Method IS a missed call");
+}
+
+/// Finding 1 (covered side): the covered side of recall counts ONLY `calls_name`-edge occurrences.
+/// A `references_type` edge that the oracle CONFIRMS carries a callee byte range (so it joins and
+/// gets a verdict), but it is not a *call* — it must NOT inflate `covered_calls`. A `calls_name`
+/// edge over a DIFFERENT occurrence does count. So with one confirmed type-ref edge and one covered
+/// call, `covered_calls == 1`, not 2.
+#[test]
+fn covered_side_ignores_references_type_confirmation() {
+    let h = Harness::new();
+    // `caller.rs`: a call to `target` at 14..20 and a type reference `Thing` at 24..29.
+    let caller = h.add_file("caller.rs", "fn caller() { target(); Thing::new(); }\n");
+    let defs = h.add_file("defs.rs", "fn target() {}\nstruct Thing;\n");
+    let target_sym = h.add_symbol(defs, "target", 3, 9);
+    let thing_sym = h.add_symbol(defs, "Thing", 22, 27);
+    // A CALL edge (covers the call occurrence) and a TYPE-REF edge (covers the type occurrence).
+    let call_edge = h.add_edge(caller, "target", 14, 20, "Exact", Some(target_sym));
+    let type_edge =
+        h.add_edge_with_kind(caller, "Thing", 24, 29, "references_type", "Exact", Some(thing_sym));
+
+    let call_sym = "scip-rust crate v1 `target`().";
+    let type_sym = "scip-rust crate v1 `Thing`#";
+    let mut index = Index {
+        documents: vec![Document {
+            relative_path: "caller.rs".to_string(),
+            occurrences: vec![
+                occurrence(0, 14, 20, call_sym, SymbolRole::UnspecifiedSymbolRole as i32),
+                occurrence(0, 24, 29, type_sym, SymbolRole::UnspecifiedSymbolRole as i32),
+            ],
+            position_encoding: EnumOrUnknown::new(
+                PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+            ),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    index.documents.push(Document {
+        relative_path: "defs.rs".to_string(),
+        occurrences: vec![
+            occurrence(0, 3, 9, call_sym, SymbolRole::Definition as i32),
+            occurrence(1, 7, 12, type_sym, SymbolRole::Definition as i32),
+        ],
+        position_encoding: EnumOrUnknown::new(PositionEncoding::UTF8CodeUnitOffsetFromLineStart),
+        ..Default::default()
+    });
+    let bytes = index.write_to_bytes().unwrap();
+
+    let report = run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+    // BOTH edges got verdicts (both carry callee ranges and join)…
+    assert!(h.verdict(call_edge).is_some(), "call edge verdicted");
+    assert!(h.verdict(type_edge).is_some(), "type-ref edge verdicted");
+    // …but only the CALL occurrence counts toward the covered side of recall.
+    assert_eq!(
+        report.covered_calls, 1,
+        "the references_type confirmation does NOT inflate covered"
+    );
+    assert_eq!(report.oracle_only_calls, 0, "both call-like occurrences were covered");
+
+    let m = super::oracle_eval_metrics(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, RecallCalls {
+        covered: report.covered_calls,
+        oracle_only: report.oracle_only_calls,
+    })
+    .unwrap();
+    assert!(
+        (m.recall - 1.0).abs() < 1e-9,
+        "recall over the call population only; got {}",
+        m.recall
+    );
+    assert_eq!(m.covered_calls, 1);
+}
+
+/// Finding 2: a candidate whose recorded `file_sha` no longer matches the disk bytes (content drift
+/// between the index build and the `.scip`) is SKIPPED — no verdict is emitted from mismatched
+/// content — and tallied in `skipped_drifted`. The same edge, with a matching `file_sha`, IS
+/// verdicted, proving the gate is the sha comparison.
+#[test]
+fn drifted_file_sha_is_skipped_not_verdicted() {
+    // (verdict row: kind, resolved_symbol_id, scip_symbol; skipped_drifted; examined)
+    type DriftProbe = (Option<(String, Option<i64>, String)>, u64, u64);
+    let build = |drift: bool| -> DriftProbe {
+        let h = Harness::new();
+        let caller = h.add_file("caller.rs", "fn caller() { target(); }\n");
+        let defs = h.add_file("defs.rs", "fn target() {}\n");
+        let target_sym = h.add_symbol(defs, "target", 3, 9);
+        let edge = h.add_edge(caller, "target", 14, 20, "NameOnly", None);
+        if drift {
+            // The edge was indexed against a DIFFERENT sha than the file on disk now.
+            h.set_file_sha(
+                caller,
+                "0000000000000000000000000000000000000000000000000000000000000000",
+            );
+        }
+
+        let sym = "scip-rust crate v1 `target`().";
+        let mut index = Index {
+            documents: vec![Document {
+                relative_path: "caller.rs".to_string(),
+                occurrences: vec![occurrence(
+                    0,
+                    14,
+                    20,
+                    sym,
+                    SymbolRole::UnspecifiedSymbolRole as i32,
+                )],
+                position_encoding: EnumOrUnknown::new(
+                    PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+                ),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        index.documents.push(Document {
+            relative_path: "defs.rs".to_string(),
+            occurrences: vec![occurrence(0, 3, 9, sym, SymbolRole::Definition as i32)],
+            position_encoding: EnumOrUnknown::new(
+                PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+            ),
+            ..Default::default()
+        });
+        let _ = target_sym;
+        let bytes = index.write_to_bytes().unwrap();
+        let report =
+            run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+        (h.verdict(edge), report.skipped_drifted, report.rows_written)
+    };
+
+    let (verdict, skipped, written) = build(true);
+    assert!(verdict.is_none(), "a drifted candidate must NOT be verdicted");
+    assert_eq!(skipped, 1, "the drifted candidate is tallied in skipped_drifted");
+    assert_eq!(written, 0, "nothing written from drifted content");
+
+    let (verdict, skipped, written) = build(false);
+    assert!(verdict.is_some(), "the same candidate with a matching file_sha IS verdicted");
+    assert_eq!(skipped, 0, "no drift when the sha matches");
+    assert_eq!(written, 1);
+}
+
+/// Finding 3: a run recorded for ANOTHER worktree (same tool/version/commit) does NOT surface as
+/// this checkout's last run. `oracle_runs` now carries `worktree_id` and `last_run_meta` filters on
+/// it, so the status read describes only the active checkout — consistent with its worktree-scoped
+/// verdict counts.
+#[test]
+fn last_run_meta_is_scoped_to_active_worktree() {
+    let h = Harness::new();
+    // A run in a SIBLING worktree (same tool/version/commit). It must not be THIS checkout's last.
+    store::record_oracle_run(&h.conn, TOOL, VERSION, COMMIT, OTHER_WORKTREE, "Completed", "{}")
+        .unwrap();
+
+    // This checkout has no run yet → no last run, despite the sibling's row existing.
+    let status = super::oracle_status(&h.conn, TOOL, VERSION, COMMIT, WORKTREE).unwrap();
+    assert_eq!(status.last_run_status, None, "the sibling worktree's run is not ours");
+    assert_eq!(status.last_run_commit_sha, None);
+
+    // Record a run in THIS checkout → now it's the last run.
+    store::record_oracle_run(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, "Blocked", "{}").unwrap();
+    let status = super::oracle_status(&h.conn, TOOL, VERSION, COMMIT, WORKTREE).unwrap();
+    assert_eq!(status.last_run_status.as_deref(), Some("Blocked"));
+}
+
+/// Finding 5: a file marked deleted (a `kind='deleted'` tombstone left by `mark_file_deleted`) but
+/// still present in the `.scip` must NOT have its occurrences inflate the recall gap. The tombstone
+/// is not "indexed in scope", so an uncovered call from it is out of scope, not a miss. A live file
+/// with the same occurrence IS counted.
+#[test]
+fn deleted_file_occurrences_do_not_inflate_gap() {
+    let build = |deleted: bool| -> u64 {
+        let h = Harness::new();
+        // `target` is defined in an indexed, live file (def-side filter passes).
+        let defs = h.add_file("defs.rs", "fn target() {}\n");
+        h.add_symbol(defs, "target", 3, 9);
+        // The call site lives in caller.rs.
+        let caller = h.add_file("caller.rs", "fn caller() { target(); }\n");
+        if deleted {
+            // Tombstone it: a `kind='deleted'` row, as `mark_file_deleted` leaves.
+            h.conn
+                .execute("UPDATE files SET kind = 'deleted' WHERE id = ?1", params![caller])
+                .unwrap();
+        }
+
+        let sym = "scip-rust crate v1 `target`().";
+        let mut index = Index {
+            documents: vec![Document {
+                relative_path: "caller.rs".to_string(),
+                occurrences: vec![occurrence(
+                    0,
+                    14,
+                    20,
+                    sym,
+                    SymbolRole::UnspecifiedSymbolRole as i32,
+                )],
+                position_encoding: EnumOrUnknown::new(
+                    PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+                ),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        index.documents.push(Document {
+            relative_path: "defs.rs".to_string(),
+            occurrences: vec![occurrence(0, 3, 9, sym, SymbolRole::Definition as i32)],
+            position_encoding: EnumOrUnknown::new(
+                PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+            ),
+            ..Default::default()
+        });
+        let bytes = index.write_to_bytes().unwrap();
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root())
+            .unwrap()
+            .oracle_only_calls
+    };
+
+    assert_eq!(build(true), 0, "a tombstoned source file's occurrence is NOT a recall gap");
+    assert_eq!(build(false), 1, "the same call from a live indexed file IS a recall gap");
+}
+
+/// Finding 6a: the oracle's checkout scope is leak-proof BY CONSTRUCTION — every raw `edge_oracle`
+/// query lives in `store.rs` (which owns the scoped helpers + the `EDGE_ORACLE_SCOPE_JOIN`
+/// predicate). This source-scan test fails CI if a future unscoped `FROM edge_oracle` query is
+/// added to any other oracle module (run.rs / status.rs / join.rs / scip.rs), forcing it back
+/// through the scoped helper.
+#[test]
+fn raw_edge_oracle_queries_live_only_in_store() {
+    let oracle_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/index/oracle");
+    for entry in std::fs::read_dir(&oracle_dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let name = path.file_name().unwrap().to_str().unwrap().to_string();
+        // store.rs owns the scoped helpers; tests.rs exercises them with direct assertions.
+        if name == "store.rs" || name == "tests.rs" {
+            continue;
+        }
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            !text.contains("FROM edge_oracle"),
+            "{name} contains a raw `FROM edge_oracle` query — route it through \
+             store::count_edge_oracle_scoped / EDGE_ORACLE_SCOPE_JOIN so it can't drop the \
+             checkout scope",
+        );
+    }
+}
+
+/// Finding 6b: `name_only_recovery_rate` cannot exceed 1.0 even if a writer bug stamps an `upgrade`
+/// verdict on an `Exact`-confidence edge (e.g. an Exact edge with a NULL `to_symbol_id` that
+/// `classify_resolved` would treat as unresolved). The numerator is now scoped to `upgrade`
+/// verdicts on `NameOnly`/`Ambiguous` edges only, so the stray Exact upgrade is excluded — the rate
+/// stays over the low-confidence population the denominator counts.
+#[test]
+fn name_only_recovery_rate_excludes_exact_upgrades() {
+    let h = Harness::new();
+    let f = h.add_file("a.rs", "fn caller() {}\n");
+    // The legitimate low-confidence population: one NameOnly edge the oracle upgraded (1/1 = 1.0).
+    let e_low = h.add_edge(f, "u", 0, 1, "NameOnly", None);
+    // A pathological Exact edge ALSO stamped `upgrade` (the writer-bug shape). It is NOT in the
+    // low-confidence denominator, so admitting it in the numerator (the old raw `counts.upgraded`)
+    // would push the rate to 2/1 = 2.0.
+    let e_exact = h.add_edge(f, "x", 1, 2, "Exact", None);
+
+    let mk = |edge, kind| EdgeOracleRow {
+        edge_id: edge,
+        file_sha: "s",
+        resolved_symbol_id: None,
+        scip_symbol: "s",
+        kind,
+    };
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(e_low, OracleResolutionKind::Upgrade))
+        .unwrap();
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(e_exact, OracleResolutionKind::Upgrade))
+        .unwrap();
+
+    let m = super::oracle_eval_metrics(
+        &h.conn,
+        TOOL,
+        VERSION,
+        COMMIT,
+        WORKTREE,
+        RecallCalls::default(),
+    )
+    .unwrap();
+    // Raw count still reports both upgrade rows for transparency…
+    assert_eq!(m.upgraded, 2);
+    // …but the rate is scoped to the low-confidence population: 1 low-conf upgrade / 1 low-conf
+    // edge-with-oracle = 1.0, never 2.0.
+    assert!(
+        m.name_only_recovery_rate <= 1.0,
+        "recovery rate {} exceeds 1.0",
+        m.name_only_recovery_rate
+    );
+    assert!((m.name_only_recovery_rate - 1.0).abs() < 1e-9);
+}

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -1,6 +1,72 @@
 use super::*;
+use crate::index::oracle::{
+    self, OracleEvalMetrics, OracleReport, OracleStatus, OracleTool, RecallCalls,
+};
 
 impl IndexDatabase {
+    /// Run a SCIP-oracle pass from a pre-built `.scip` over the current (active commit/worktree)
+    /// edge candidates, writing `edge_oracle` verdicts. The heuristic resolution on the `edges`
+    /// row is never touched. Phase 1 (#68): eval-only, no CLI/MCP surface. Requires a `source_root`
+    /// (the checkout whose bytes back the SCIP document position-encoding conversion).
+    pub fn run_oracle(
+        &self,
+        tool: OracleTool,
+        tool_version: &str,
+        scip_bytes: &[u8],
+    ) -> anyhow::Result<OracleReport> {
+        let Some(root) = self.storage.source_root() else {
+            anyhow::bail!(
+                "index has no source_root metadata; rebuild required for the oracle pass"
+            );
+        };
+        let root = root.to_path_buf();
+        oracle::run_oracle(
+            self.storage.connection(),
+            tool,
+            tool_version,
+            &self.active_commit_sha,
+            &self.active_worktree_id,
+            scip_bytes,
+            &root,
+        )
+    }
+
+    /// Heuristic-vs-oracle eval metrics (precision/recall/recovery) for a tool/version, diffing the
+    /// persisted `edge_oracle` rows against the `edges` heuristic. [`RecallCalls`] is the
+    /// `(covered_calls, oracle_only_calls)` pair reported by the most recent [`run_oracle`] — both
+    /// occurrence-counted over the call population, so recall compares like with like.
+    pub fn oracle_eval_metrics(
+        &self,
+        tool: OracleTool,
+        tool_version: &str,
+        recall_calls: RecallCalls,
+    ) -> anyhow::Result<OracleEvalMetrics> {
+        oracle::oracle_eval_metrics(
+            self.storage.connection(),
+            tool,
+            tool_version,
+            &self.active_commit_sha,
+            &self.active_worktree_id,
+            recall_calls,
+        )
+    }
+
+    /// Persisted oracle status (verdict counts + last run) for a tool/version, scoped to this
+    /// database's active `(commit_sha, worktree_id)` checkout.
+    pub fn oracle_status(
+        &self,
+        tool: OracleTool,
+        tool_version: &str,
+    ) -> anyhow::Result<OracleStatus> {
+        oracle::oracle_status(
+            self.storage.connection(),
+            tool,
+            tool_version,
+            &self.active_commit_sha,
+            &self.active_worktree_id,
+        )
+    }
+
     pub fn status(&self, database: &Path) -> anyhow::Result<IndexStatus> {
         let mut counts = BTreeMap::new();
         let mut stmt = self

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -454,6 +454,72 @@ pub(crate) fn apply_edge_callee_byte_range(conn: &Connection) -> rusqlite::Resul
     Ok(())
 }
 
+pub(crate) fn apply_oracle_tables(conn: &Connection) -> rusqlite::Result<()> {
+    // SCIP-oracle side tables (#68). Greenfield, STRICT per repo convention.
+    //
+    // `oracle_runs`: one row per oracle pass (a `.scip` consumed against a checkout). `stats_json`
+    // is an opaque per-run `OracleReport` snapshot, suffixed `_json` per the naming convention.
+    //
+    // `edge_oracle`: the compiler-grade resolution for an edge, kept **beside** the heuristic
+    // resolution that lives on the `edges` row — the heuristic row is NEVER overwritten, so eval
+    // can diff the two and `compare_graph_to_scip` (#69) has both. INVARIANT: writing an
+    // `edge_oracle` row must not UPDATE `edges.resolution` / `edges.to_symbol_id`.
+    //
+    // Staleness key is `(file_sha, tool, tool_version)` (content addressing, exactly like the
+    // embedding `input_hash`): a row is valid iff the file bytes it was computed against are
+    // unchanged. `file_sha` is the `files.sha256` of the edge's source file at compute time, so a
+    // changed file's oracle rows are detectably stale without an indexer re-run on unchanged files.
+    //
+    // `kind` is the oracle resolution outcome (upgrade / resolved-external / confirm / contradict);
+    // `resolved_symbol_id` is our `symbols.id` when the SCIP definition mapped inside the corpus,
+    // NULL for `resolved-external`. `scip_symbol` is the raw SCIP symbol string for provenance.
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS oracle_runs(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tool TEXT NOT NULL,
+            tool_version TEXT NOT NULL,
+            commit_sha TEXT NOT NULL,
+            -- The checkout the run was scoped to. A multi-worktree DB holds runs from sibling
+            -- checkouts under the same `(tool, tool_version, commit_sha)`; without this the status
+            -- read's `last_run_meta` could surface a SIBLING worktree's run as THIS checkout's \
+         last
+            -- run (the verdict counts are already worktree-scoped, so the two would disagree). \
+         Added
+            -- in V018 directly (this is the unshipped oracle migration) — no separate migration.
+            worktree_id TEXT NOT NULL DEFAULT '',
+            started_at INTEGER NOT NULL,
+            status TEXT NOT NULL,
+            stats_json TEXT NOT NULL DEFAULT '{}'
+        ) STRICT;
+
+        CREATE TABLE IF NOT EXISTS edge_oracle(
+            edge_id INTEGER NOT NULL,
+            file_sha TEXT NOT NULL,
+            tool TEXT NOT NULL,
+            tool_version TEXT NOT NULL,
+            resolved_symbol_id INTEGER,
+            scip_symbol TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            computed_at INTEGER NOT NULL,
+            PRIMARY KEY(edge_id, tool, tool_version),
+            -- A verdict is meaningless once its edge is gone. The full rebuild and
+            -- `remove_file_in_scope` delete + reinsert edges with new ids and recompute the \
+         oracle,
+            -- so cascading old verdicts away (rather than orphaning them, where status/eval would
+            -- keep counting them) is correct. `PRAGMA foreign_keys=ON` is set, so this fires.
+            FOREIGN KEY(edge_id) REFERENCES edges(id) ON DELETE CASCADE
+        ) STRICT;
+
+        CREATE INDEX IF NOT EXISTS idx_edge_oracle_staleness
+            ON edge_oracle(file_sha, tool, tool_version);
+        CREATE INDEX IF NOT EXISTS idx_edge_oracle_symbol
+            ON edge_oracle(resolved_symbol_id);
+        ",
+    )?;
+    Ok(())
+}
+
 pub(crate) fn applied_migrations(conn: &Connection) -> anyhow::Result<Vec<AppliedMigration>> {
     let mut stmt = conn.prepare(
         "
@@ -498,6 +564,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_015_ID => Some(15),
             MIGRATION_016_ID => Some(16),
             MIGRATION_017_ID => Some(17),
+            MIGRATION_018_ID => Some(18),
             _ => None,
         })
         .max()
@@ -524,6 +591,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_015_ID
             | MIGRATION_016_ID
             | MIGRATION_017_ID
+            | MIGRATION_018_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -547,6 +615,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_015_ID => migration.checksum != MIGRATION_015_CHECKSUM,
         MIGRATION_016_ID => migration.checksum != MIGRATION_016_CHECKSUM,
         MIGRATION_017_ID => migration.checksum != MIGRATION_017_CHECKSUM,
+        MIGRATION_018_ID => migration.checksum != MIGRATION_018_CHECKSUM,
         _ => false,
     }
 }

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use migrations::*;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 17;
+pub const LATEST_SCHEMA_VERSION: u32 = 18;
 const DIRTY_MIGRATION_ID: &str = "__dirty__";
 const MIGRATION_001_ID: &str = "001_sqlite_storage_baseline";
 const MIGRATION_001_CHECKSUM: &str = "sha256:rag-rat-sqlite-baseline-v1";
@@ -76,6 +76,10 @@ const MIGRATION_017_ID: &str = "017_edge_callee_byte_range";
 const MIGRATION_017_CHECKSUM: &str = "sha256:rag-rat-edge-callee-byte-range-v17";
 const MIGRATION_017_DESCRIPTION: &str =
     "Add callee identifier byte range to edges for the SCIP occurrence join (#61 prerequisite)";
+const MIGRATION_018_ID: &str = "018_scip_oracle_tables";
+const MIGRATION_018_CHECKSUM: &str = "sha256:rag-rat-scip-oracle-tables-v18";
+const MIGRATION_018_DESCRIPTION: &str =
+    "Add oracle_runs + edge_oracle side tables for SCIP compiler-grade edge resolution (#68)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -162,6 +166,8 @@ pub fn apply(conn: &Connection) -> rusqlite::Result<()> {
     record_migration(conn, MIGRATION_016_ID, MIGRATION_016_CHECKSUM, MIGRATION_016_DESCRIPTION)?;
     apply_edge_callee_byte_range(conn)?;
     record_migration(conn, MIGRATION_017_ID, MIGRATION_017_CHECKSUM, MIGRATION_017_DESCRIPTION)?;
+    apply_oracle_tables(conn)?;
+    record_migration(conn, MIGRATION_018_ID, MIGRATION_018_CHECKSUM, MIGRATION_018_DESCRIPTION)?;
     Ok(())
 }
 


### PR DESCRIPTION
Phase 1 of the SCIP oracle (#61): consume a compiler-produced SCIP index as a resolution oracle and turn it into a trustworthy heuristic-vs-compiler precision/recall signal. Greenfield except for the additive schema; no change to indexing behavior, query output, or the byte-identical rebuild.

## What it adds
- **`index/oracle/` subsystem** (mirrors `index/ai/`): `scip.rs` (protobuf reader), `join.rs` (occurrence→edge join), `run.rs` (the pass + metrics), `store.rs` (side-table I/O), `status.rs`, `mod.rs`. Consumes a **pre-built `.scip`** (Rust first); no indexer invocation — `oracle run` (CLI), the `Compiler` confidence tier, and the `compare_graph_to_scip` tool are #69.
- **Dependency:** the `scip` crate (Apache-2.0) + `protobuf` for message (de)serialization. No hand-copied proto.
- **Schema V018 (additive):** `oracle_runs` + `edge_oracle` side tables (STRICT). The heuristic `edges` row is **never overwritten** — the oracle verdict lives only in `edge_oracle`, so eval can diff the two; `edge_oracle` cascades off `edges` (`ON DELETE CASCADE`); staleness keyed by `(file_sha, tool, tool_version)`.
- **Eval metrics** in `eval --json` (emitted only when a `.scip` is supplied; baseline-gated): precision (oracle-confirmed fraction of Exact/Syntactic), call **recall**, NameOnly/Ambiguous recovery rate, and oracle-upgradeable fraction.

## Correctness properties (the point of phase 1 — the numbers must not lie)
- **Checkout-scoped by construction.** Every metric/status read of `edge_oracle` routes through one shared `EDGE_ORACLE_SCOPE_JOIN` predicate filtered to the run's `(commit_sha, worktree_id)`, matching the scoped candidate selection. A source-scan test fails CI if any query reads `edge_oracle` outside `store.rs`.
- **Numerator ⊆ denominator, bounded ≤ 1.0** for every rate, all over the same scoped population.
- **Call recall over the call population on both sides.** Covered and gap are both the `calls_name` occurrence set (occurrence-deduped): type-ref/macro confirmations don't inflate it, and `Term` field/const reads don't deflate it.
- **Contradiction vs. external.** An Exact/Syntactic edge with an in-corpus target that SCIP resolves externally is recorded as a **contradiction** (honestly lowers precision), not `resolved-external`.
- **Content-integrity gate.** Per document, disk bytes are SHA-checked against the candidate's `file_sha`; drifted candidates are skipped (no verdict) and surfaced as `skipped_drifted`, so eval warns instead of silently misreporting.
- **Real containment** for def→symbol mapping; per-document `position_encoding` handling (UTF-8/16/32, surrogate pairs, multi-line ranges, malformed-range rejection).
- **Authoritative reruns** — per `(tool, tool_version, checkout)`: clear the scope, then write, in one transaction.

## Tests / quality
~50 oracle tests, including the non-ASCII identifier under both UTF-8 and UTF-16, multi-worktree metric isolation, the content-drift skip, and the call-population recall cases. clippy `-D warnings` + fmt clean; full `rag-rat-core` suite green.

Fixes #68. Part of #61.
