### PR TITLE
SCIP phase 2: oracle run, Compiler tier, resolved-external, compare_graph_to_scip (#69)

### DIFF
--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -77,6 +77,9 @@ pub(crate) enum Command {
     /// Run the search-quality eval suite.
     Eval(EvalArgs),
 
+    /// SCIP-oracle pass: compiler-grade edge resolution from a language indexer.
+    Oracle(OracleArgs),
+
     /// Print the resolved configuration as JSON.
     DumpConfig,
 }
@@ -227,6 +230,52 @@ pub(crate) struct EvalArgs {
     /// Emit JSON instead of the summary.
     #[arg(long)]
     pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct OracleArgs {
+    #[command(subcommand)]
+    pub command: OracleCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum OracleCommand {
+    /// Run an oracle pass: invoke the indexer (or consume a pre-built `.scip`) and write verdicts.
+    Run(OracleRunArgs),
+    /// Report oracle verdict counts + whether the indexer tool is installed.
+    Status(OracleStatusArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct OracleRunArgs {
+    /// The oracle tool to use (default: rust-analyzer).
+    #[arg(long, value_enum, default_value_t = OracleToolArg::RustAnalyzer)]
+    pub tool: OracleToolArg,
+    /// Consume a pre-built `.scip` index instead of invoking the tool. Deterministic; the tool
+    /// need not be installed.
+    #[arg(long)]
+    pub scip: Option<PathBuf>,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct OracleStatusArgs {
+    /// The oracle tool to report on (default: rust-analyzer).
+    #[arg(long, value_enum, default_value_t = OracleToolArg::RustAnalyzer)]
+    pub tool: OracleToolArg,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum OracleToolArg {
+    #[value(name = "rust-analyzer")]
+    RustAnalyzer,
+}
+
+impl OracleToolArg {
+    pub(crate) fn core(self) -> rag_rat_core::index::oracle::OracleTool {
+        match self {
+            OracleToolArg::RustAnalyzer => rag_rat_core::index::oracle::OracleTool::RustAnalyzer,
+        }
+    }
 }
 
 #[derive(Debug, Args)]
@@ -436,5 +485,38 @@ mod tests {
             },
             other => panic!("expected hooks, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn oracle_run_defaults_to_rust_analyzer() {
+        let cli = Cli::try_parse_from(["rag-rat", "oracle", "run"]).expect("parse");
+        match cli.command {
+            Command::Oracle(OracleArgs { command: OracleCommand::Run(args) }) => {
+                assert_eq!(args.tool, OracleToolArg::RustAnalyzer);
+                assert!(args.scip.is_none());
+            },
+            other => panic!("expected oracle run, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn oracle_run_accepts_scip_path() {
+        let cli = Cli::try_parse_from(["rag-rat", "oracle", "run", "--scip", "/tmp/x.scip"])
+            .expect("parse");
+        match cli.command {
+            Command::Oracle(OracleArgs { command: OracleCommand::Run(args) }) => {
+                assert_eq!(args.scip.as_deref(), Some(std::path::Path::new("/tmp/x.scip")));
+            },
+            other => panic!("expected oracle run, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn oracle_status_parses() {
+        let cli = Cli::try_parse_from(["rag-rat", "oracle", "status"]).expect("parse");
+        assert!(matches!(
+            cli.command,
+            Command::Oracle(OracleArgs { command: OracleCommand::Status(_) })
+        ));
     }
 }

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -133,10 +133,24 @@ pub(crate) fn default_eval_path(config: &Config, file_name: &str) -> PathBuf {
 }
 
 pub(crate) fn oracle(config: &Config, args: &OracleArgs) -> anyhow::Result<()> {
-    let db = open_index(config)?;
     match &args.command {
-        OracleCommand::Run(run_args) => oracle_run(config, &db, run_args),
-        OracleCommand::Status(status_args) => oracle_status(&db, status_args),
+        OracleCommand::Run(run_args) => {
+            // `oracle run` WRITES `edge_oracle` / `oracle_runs`, so it must serialize with the
+            // background watcher / `index` exactly like `maintenance` does. A concurrent indexer
+            // can delete+reinsert `edges` (cascading `edge_oracle`) between the pass loading edge
+            // ids and writing verdicts — FK failures / verdicts against a moving graph. Hold the
+            // write lock for the whole run, acquired BEFORE opening the DB so the indexer can't
+            // slip in between open and the pass. `status` is read-only — no lock.
+            let _lock = rag_rat_core::locks::FileLock::acquire_blocking(
+                &rag_rat_core::locks::write_lock_path(&config.database),
+            )?;
+            let db = open_index(config)?;
+            oracle_run(config, &db, run_args)
+        },
+        OracleCommand::Status(status_args) => {
+            let db = open_index(config)?;
+            oracle_status(&db, status_args)
+        },
     }
 }
 
@@ -660,4 +674,123 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
             "skipped_by_policy": plan.embeddings.skipped_by_policy,
         }
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    use rag_rat_core::config::{ResolvedTarget, TargetKind};
+    use rag_rat_core::language::Language;
+    use rag_rat_core::locks::{FileLock, write_lock_path};
+    use rag_rat_core::{Config, IndexDatabase};
+
+    use crate::cli::{OracleArgs, OracleCommand, OracleRunArgs, OracleToolArg};
+
+    static N: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_config() -> (PathBuf, Config) {
+        let root = std::env::temp_dir().join(format!(
+            "rag-rat-cli-oracle-lock-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n")
+            .unwrap();
+        let config = Config {
+            root: root.clone(),
+            database: root.join(".rag-rat/index.sqlite"),
+            targets: vec![ResolvedTarget {
+                name: "rust".to_string(),
+                language: Language::Rust,
+                directories: vec![PathBuf::from("src")],
+                include: vec!["src/".to_string()],
+                exclude: Vec::new(),
+                kind: TargetKind::Source,
+            }],
+            local_ai: Default::default(),
+            watch: Default::default(),
+        };
+        (root, config)
+    }
+
+    fn run_args() -> OracleArgs {
+        // The `--scip` path is deterministic (no rust-analyzer); an empty (zero-byte) `.scip` is a
+        // valid empty SCIP index → the pass completes writing no verdicts. We only assert the LOCK
+        // discipline here, not the verdict content.
+        OracleArgs {
+            command: OracleCommand::Run(OracleRunArgs {
+                tool: OracleToolArg::RustAnalyzer,
+                scip: None, // set per-test to a written empty `.scip`
+            }),
+        }
+    }
+
+    /// #82 finding 5: `oracle run` acquires the repo write lock for the duration, so it can't race a
+    /// concurrent indexer. We hold the write lock, kick off `oracle run` on a thread, and assert it
+    /// does NOT complete while the lock is held; releasing the lock lets it finish.
+    #[test]
+    fn oracle_run_blocks_on_write_lock() {
+        let (root, config) = temp_config();
+        IndexDatabase::rebuild(&config).unwrap();
+        // A valid empty SCIP index (zero-byte protobuf message) for the deterministic `--scip`
+        // path.
+        let scip_path = root.join("empty.scip");
+        std::fs::write(&scip_path, []).unwrap();
+        let mut args = run_args();
+        if let OracleCommand::Run(run) = &mut args.command {
+            run.scip = Some(scip_path);
+        }
+
+        // Hold the write lock the run must contend for.
+        let lock = FileLock::acquire_blocking(&write_lock_path(&config.database)).unwrap();
+
+        let (tx, rx) = mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            let result = super::oracle(&config, &args);
+            let _ = tx.send(result.is_ok());
+        });
+
+        // While we hold the lock, the run must be blocked acquiring it — nothing arrives.
+        assert!(
+            rx.recv_timeout(Duration::from_millis(300)).is_err(),
+            "oracle run completed while the write lock was held — it must block on the lock"
+        );
+
+        // Release the lock; the run proceeds and completes.
+        drop(lock);
+        let ok =
+            rx.recv_timeout(Duration::from_secs(20)).expect("oracle run completes after unlock");
+        assert!(ok, "oracle run should succeed once the lock is free");
+        handle.join().unwrap();
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The lock is RELEASED after `oracle run` returns — a subsequent acquire succeeds immediately,
+    /// proving the run doesn't leak the lock (which would wedge the watcher/index).
+    #[test]
+    fn oracle_run_releases_write_lock_after_completion() {
+        let (root, config) = temp_config();
+        IndexDatabase::rebuild(&config).unwrap();
+        let scip_path = root.join("empty.scip");
+        std::fs::write(&scip_path, []).unwrap();
+        let mut args = run_args();
+        if let OracleCommand::Run(run) = &mut args.command {
+            run.scip = Some(scip_path);
+        }
+
+        super::oracle(&config, &args).unwrap();
+
+        // The lock is free now — a non-blocking acquire must succeed.
+        let lock = FileLock::try_acquire(&write_lock_path(&config.database)).unwrap();
+        assert!(lock.is_some(), "oracle run must release the write lock when it returns");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
 }

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -149,8 +149,13 @@ pub(crate) fn oracle(config: &Config, args: &OracleArgs) -> anyhow::Result<()> {
 /// indexer can't slip in between open and the pass.
 ///
 /// Scoped to JUST the join/write: the slow `rust-analyzer scip` subprocess runs OUTSIDE this (#82
-/// P3), so the watcher isn't starved through the whole subprocess. The content-integrity gate in
-/// the join already tolerates disk drift between `.scip` production and the join.
+/// P3), so the watcher isn't starved through the whole subprocess. The lock-free window that opens
+/// between `.scip` production and the join is narrowed by the scip-vs-disk content gate: production
+/// snapshots each document's disk hash at subprocess exit, and the join skips (never mis-joins) any
+/// candidate whose call-site OR definition document drifted from that snapshot (#82 TOCTOU). The
+/// snapshot is taken at exit, not when rust-analyzer read each file, so a mid-subprocess edit + a
+/// pre-join reindex remains best-effort — pinning the pre-spawn `files.sha256` would close that
+/// residual tail (follow-up).
 fn with_oracle_write_lock<T>(
     config: &Config,
     body: impl FnOnce(&IndexDatabase) -> anyhow::Result<T>,
@@ -214,11 +219,19 @@ fn oracle_run(config: &Config, args: &OracleRunArgs) -> anyhow::Result<()> {
                 hint,
             })
         },
-        rag_rat_core::index::oracle::ScipProduction::Produced { version, bytes } => {
-            // Re-probe under the lock is implicit: the content-integrity gate revalidates against
-            // current disk bytes during the join. Run only the join/write under the lock.
-            let report =
-                with_oracle_write_lock(config, |db| db.run_oracle(tool, &version, &bytes))?;
+        rag_rat_core::index::oracle::ScipProduction::Produced {
+            version,
+            bytes,
+            production_sha,
+        } => {
+            // The join's content gate revalidates against current disk bytes under the lock, and
+            // `production_sha` (the per-document disk hashes captured the instant the subprocess
+            // finished) pins the `.scip` to the content it was built against — so a file the
+            // watcher reindexes in this lock-free window is skipped, not mis-joined
+            // (#82 TOCTOU). Run only the join/write under the lock.
+            let report = with_oracle_write_lock(config, |db| {
+                db.run_oracle(tool, &version, &bytes, Some(&production_sha))
+            })?;
             print_json(&serde_json::json!({
                 "outcome": "completed",
                 "tool": tool.as_db_str(),

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::cli::{
     BriefArgs, ClustersArgs, EvalArgs, GithubArgs, GithubCommand, HookAction, HooksArgs, IndexArgs,
-    MaintenanceArgs, MemoryArgs, MemoryCommand, MigrateArgs, ModelsArgs, ModelsCommand, QueryArgs,
-    ReconcileArgs,
+    MaintenanceArgs, MemoryArgs, MemoryCommand, MigrateArgs, ModelsArgs, ModelsCommand, OracleArgs,
+    OracleCommand, OracleRunArgs, OracleStatusArgs, QueryArgs, ReconcileArgs,
 };
 
 pub(crate) fn index(config: &Config, args: &IndexArgs) -> anyhow::Result<()> {
@@ -130,6 +130,72 @@ pub(crate) fn eval(config: &Config, args: &EvalArgs) -> anyhow::Result<()> {
 }
 pub(crate) fn default_eval_path(config: &Config, file_name: &str) -> PathBuf {
     config.root.join("evals").join(file_name)
+}
+
+pub(crate) fn oracle(config: &Config, args: &OracleArgs) -> anyhow::Result<()> {
+    let db = open_index(config)?;
+    match &args.command {
+        OracleCommand::Run(run_args) => oracle_run(config, &db, run_args),
+        OracleCommand::Status(status_args) => oracle_status(&db, status_args),
+    }
+}
+
+/// `rag-rat oracle run` — either consume a pre-built `--scip` (deterministic; no tool needed) or
+/// invoke the indexer to produce a `.scip` into a temp file and run the join over it. A missing /
+/// unrunnable tool prints the install hint and exits 0 (the missing-embedding-model UX) — never an
+/// error. Prints the `OracleReport` (or the `Blocked` outcome) as JSON.
+fn oracle_run(config: &Config, db: &IndexDatabase, args: &OracleRunArgs) -> anyhow::Result<()> {
+    let tool = args.tool.core();
+    if let Some(scip_path) = &args.scip {
+        let scip_bytes = fs::read(scip_path).map_err(|err| {
+            anyhow::anyhow!("failed to read SCIP index {}: {err}", scip_path.display())
+        })?;
+        // A pre-built index carries no detectable tool version; label the run by the source path's
+        // file name so re-running the same fixture is content-addressed stably.
+        let tool_version = format!(
+            "scip-file:{}",
+            scip_path.file_name().and_then(|n| n.to_str()).unwrap_or("index.scip")
+        );
+        let report = db.run_oracle_from_scip(tool, &tool_version, &scip_bytes)?;
+        return print_json(&serde_json::json!({
+            "outcome": "completed",
+            "tool": tool.as_db_str(),
+            "tool_version": tool_version,
+            "report": report,
+        }));
+    }
+    // No pre-built index: invoke the tool, writing the `.scip` to a temp file the join consumes.
+    let scip_output = config
+        .database
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(std::env::temp_dir)
+        .join(format!("rag-rat-oracle-{}.scip", std::process::id()));
+    let outcome = db.run_oracle_with_tool(tool, &scip_output);
+    let _ = fs::remove_file(&scip_output);
+    let outcome = outcome?;
+    if let rag_rat_core::index::oracle::OracleRunOutcome::Blocked { hint, .. } = &outcome {
+        eprintln!("oracle: {hint}");
+    }
+    print_json(&outcome)
+}
+
+/// `rag-rat oracle status` — verdict counts for the latest run in this checkout, plus whether the
+/// indexer tool is installed (its probe, a `Blocked` line when absent, never an error).
+fn oracle_status(db: &IndexDatabase, args: &OracleStatusArgs) -> anyhow::Result<()> {
+    let tool = args.tool.core();
+    let availability = db.probe_oracle_tool(tool);
+    // Use the most recent run's version for the verdict counts; no run → no counts (status is a
+    // read-only sibling — nothing to report against).
+    let status = match db.latest_oracle_run_version(tool)? {
+        Some(version) => Some(db.oracle_status(tool, &version)?),
+        None => None,
+    };
+    print_json(&serde_json::json!({
+        "tool": tool.as_db_str(),
+        "tool_available": availability,
+        "verdicts": status,
+    }))
 }
 pub(crate) fn models(config: &Config, args: &ModelsArgs) -> anyhow::Result<()> {
     let db = open_index(config)?;

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -134,19 +134,7 @@ pub(crate) fn default_eval_path(config: &Config, file_name: &str) -> PathBuf {
 
 pub(crate) fn oracle(config: &Config, args: &OracleArgs) -> anyhow::Result<()> {
     match &args.command {
-        OracleCommand::Run(run_args) => {
-            // `oracle run` WRITES `edge_oracle` / `oracle_runs`, so it must serialize with the
-            // background watcher / `index` exactly like `maintenance` does. A concurrent indexer
-            // can delete+reinsert `edges` (cascading `edge_oracle`) between the pass loading edge
-            // ids and writing verdicts — FK failures / verdicts against a moving graph. Hold the
-            // write lock for the whole run, acquired BEFORE opening the DB so the indexer can't
-            // slip in between open and the pass. `status` is read-only — no lock.
-            let _lock = rag_rat_core::locks::FileLock::acquire_blocking(
-                &rag_rat_core::locks::write_lock_path(&config.database),
-            )?;
-            let db = open_index(config)?;
-            oracle_run(config, &db, run_args)
-        },
+        OracleCommand::Run(run_args) => oracle_run(config, run_args),
         OracleCommand::Status(status_args) => {
             let db = open_index(config)?;
             oracle_status(&db, status_args)
@@ -154,23 +142,49 @@ pub(crate) fn oracle(config: &Config, args: &OracleArgs) -> anyhow::Result<()> {
     }
 }
 
+/// Acquire the index write lock, open the DB, and run a CLOSURE under it. `oracle run` WRITES
+/// `edge_oracle` / `oracle_runs`, so the join/write must serialize with the background watcher /
+/// `index` — a concurrent indexer can delete+reinsert `edges` (cascading `edge_oracle`) between the
+/// pass loading edge ids and writing verdicts. The lock is acquired BEFORE opening the DB so the
+/// indexer can't slip in between open and the pass.
+///
+/// Scoped to JUST the join/write: the slow `rust-analyzer scip` subprocess runs OUTSIDE this (#82
+/// P3), so the watcher isn't starved through the whole subprocess. The content-integrity gate in
+/// the join already tolerates disk drift between `.scip` production and the join.
+fn with_oracle_write_lock<T>(
+    config: &Config,
+    body: impl FnOnce(&IndexDatabase) -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    let _lock = rag_rat_core::locks::FileLock::acquire_blocking(
+        &rag_rat_core::locks::write_lock_path(&config.database),
+    )?;
+    let db = open_index(config)?;
+    body(&db)
+}
+
 /// `rag-rat oracle run` — either consume a pre-built `--scip` (deterministic; no tool needed) or
 /// invoke the indexer to produce a `.scip` into a temp file and run the join over it. A missing /
 /// unrunnable tool prints the install hint and exits 0 (the missing-embedding-model UX) — never an
 /// error. Prints the `OracleReport` (or the `Blocked` outcome) as JSON.
-fn oracle_run(config: &Config, db: &IndexDatabase, args: &OracleRunArgs) -> anyhow::Result<()> {
+fn oracle_run(config: &Config, args: &OracleRunArgs) -> anyhow::Result<()> {
     let tool = args.tool.core();
     if let Some(scip_path) = &args.scip {
+        // Pre-built index: reading a file is fast, so this whole path runs under the lock.
         let scip_bytes = fs::read(scip_path).map_err(|err| {
             anyhow::anyhow!("failed to read SCIP index {}: {err}", scip_path.display())
         })?;
         // A pre-built index carries no detectable tool version; label the run by the source path's
-        // file name so re-running the same fixture is content-addressed stably.
+        // file name AND a content fingerprint so re-running the same fixture is content-addressed
+        // stably, while two DIFFERENT indexes that share a basename (`index.scip` from two trees)
+        // get distinct run-ids instead of colliding onto one `tool_version` (#82 P3).
         let tool_version = format!(
-            "scip-file:{}",
-            scip_path.file_name().and_then(|n| n.to_str()).unwrap_or("index.scip")
+            "scip-file:{}@{}",
+            scip_path.file_name().and_then(|n| n.to_str()).unwrap_or("index.scip"),
+            rag_rat_core::index::oracle::scip_content_fingerprint(&scip_bytes),
         );
-        let report = db.run_oracle_from_scip(tool, &tool_version, &scip_bytes)?;
+        let report = with_oracle_write_lock(config, |db| {
+            db.run_oracle_from_scip(tool, &tool_version, &scip_bytes)
+        })?;
         return print_json(&serde_json::json!({
             "outcome": "completed",
             "tool": tool.as_db_str(),
@@ -178,20 +192,41 @@ fn oracle_run(config: &Config, db: &IndexDatabase, args: &OracleRunArgs) -> anyh
             "report": report,
         }));
     }
-    // No pre-built index: invoke the tool, writing the `.scip` to a temp file the join consumes.
+
+    // No pre-built index: produce the `.scip` with the tool BEFORE acquiring the write lock, so the
+    // slow rust-analyzer subprocess doesn't hold the lock and starve the watcher (#82 P3). Only the
+    // probe-recheck + join/write below run under the lock.
     let scip_output = config
         .database
         .parent()
         .map(Path::to_path_buf)
         .unwrap_or_else(std::env::temp_dir)
         .join(format!("rag-rat-oracle-{}.scip", std::process::id()));
-    let outcome = db.run_oracle_with_tool(tool, &scip_output);
+    let production =
+        rag_rat_core::index::oracle::produce_scip_with_tool(tool, &config.root, &scip_output);
     let _ = fs::remove_file(&scip_output);
-    let outcome = outcome?;
-    if let rag_rat_core::index::oracle::OracleRunOutcome::Blocked { hint, .. } = &outcome {
-        eprintln!("oracle: {hint}");
+    match production? {
+        rag_rat_core::index::oracle::ScipProduction::Blocked { tool, program, hint } => {
+            eprintln!("oracle: {hint}");
+            print_json(&rag_rat_core::index::oracle::OracleRunOutcome::Blocked {
+                tool,
+                program,
+                hint,
+            })
+        },
+        rag_rat_core::index::oracle::ScipProduction::Produced { version, bytes } => {
+            // Re-probe under the lock is implicit: the content-integrity gate revalidates against
+            // current disk bytes during the join. Run only the join/write under the lock.
+            let report =
+                with_oracle_write_lock(config, |db| db.run_oracle(tool, &version, &bytes))?;
+            print_json(&serde_json::json!({
+                "outcome": "completed",
+                "tool": tool.as_db_str(),
+                "tool_version": version,
+                "report": report,
+            }))
+        },
     }
-    print_json(&outcome)
 }
 
 /// `rag-rat oracle status` — verdict counts for the latest run in this checkout, plus whether the

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -70,6 +70,7 @@ fn main() -> anyhow::Result<()> {
             print_json(&db.gc()?)?;
         },
         Cmd::Eval(args) => eval(&config, &args)?,
+        Cmd::Oracle(args) => oracle(&config, &args)?,
         Cmd::DumpConfig => dump_config(&config)?,
     }
 

--- a/crates/rag-rat-core/src/eval.rs
+++ b/crates/rag-rat-core/src/eval.rs
@@ -251,7 +251,10 @@ fn run_oracle_eval(
     let scip_bytes = fs::read(scip_path).map_err(|err| {
         anyhow::anyhow!("failed to read SCIP fixture {}: {err}", scip_path.display())
     })?;
-    let report = db.run_oracle(OracleTool::RustAnalyzer, EVAL_ORACLE_TOOL_VERSION, &scip_bytes)?;
+    // Eval consumes a pre-built fixture `.scip` (no tool subprocess), so there is no production
+    // snapshot — `None` leaves only the index-vs-disk content gate, as on the `--scip` CLI path.
+    let report =
+        db.run_oracle(OracleTool::RustAnalyzer, EVAL_ORACLE_TOOL_VERSION, &scip_bytes, None)?;
     // Both recall sides come from the run, occurrence-counted over the call population.
     let recall_calls =
         RecallCalls { covered: report.covered_calls, oracle_only: report.oracle_only_calls };

--- a/crates/rag-rat-core/src/index/oracle/manifest.rs
+++ b/crates/rag-rat-core/src/index/oracle/manifest.rs
@@ -1,0 +1,165 @@
+//! The oracle tool registry: per-tool id, version detection, invocation command, prerequisites,
+//! and languages. Phase 2 (#69) ships only the `rust-analyzer scip` backend; the registry is the
+//! seam later language backends (#71 TS, #72 Kotlin, #74 live LSP) extend with one entry each
+//! rather than new protocol code.
+//!
+//! A missing or unrunnable tool is NOT an error: [`ToolManifest::probe`] returns
+//! [`ToolAvailability::Blocked`] with an install hint, the same UX as a missing embedding model.
+//! The `oracle run` command turns a `Blocked` probe into a printed hint + exit 0, never a non-zero
+//! exit.
+
+use std::path::Path;
+use std::process::Command;
+
+use serde::Serialize;
+
+use super::OracleTool;
+
+/// The static registry entry for one oracle backend.
+#[derive(Debug, Clone, Copy)]
+pub struct ToolManifest {
+    /// The persisted tool id (`OracleTool::as_db_str`).
+    pub tool: OracleTool,
+    /// The executable to invoke (looked up on `PATH`).
+    pub program: &'static str,
+    /// Languages this backend resolves, for status/diagnostics.
+    pub languages: &'static [&'static str],
+    /// A one-line install hint surfaced when the tool is absent (the `Blocked` UX).
+    pub install_hint: &'static str,
+}
+
+/// Whether a registered tool can run, with the data needed to either invoke it or explain why not.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum ToolAvailability {
+    /// The tool is on `PATH` and reported a version; `oracle run` can invoke it.
+    Available { tool: String, program: String, version: String },
+    /// The tool is missing or unrunnable. `oracle run` prints `hint` and exits 0 (no error),
+    /// mirroring the missing-embedding-model degradation.
+    Blocked { tool: String, program: String, hint: String },
+}
+
+impl ToolAvailability {
+    pub fn is_available(&self) -> bool {
+        matches!(self, Self::Available { .. })
+    }
+}
+
+impl ToolManifest {
+    /// The manifest entry for a tool. Every [`OracleTool`] variant has exactly one.
+    pub fn for_tool(tool: OracleTool) -> ToolManifest {
+        match tool {
+            OracleTool::RustAnalyzer => ToolManifest {
+                tool,
+                program: "rust-analyzer",
+                languages: &["rust"],
+                install_hint: "rust-analyzer not found on PATH. Install it (e.g. `rustup \
+                               component add rust-analyzer`) or pass a pre-built index with \
+                               `--scip <path>`.",
+            },
+        }
+    }
+
+    /// Probe whether the tool can run by detecting its version. Never errors: an absent or
+    /// unrunnable program yields [`ToolAvailability::Blocked`] with the install hint, so the
+    /// `oracle run` / `oracle status` UX can degrade gracefully (exit 0) instead of failing.
+    pub fn probe(&self) -> ToolAvailability {
+        match detect_version(self.program) {
+            Some(version) => ToolAvailability::Available {
+                tool: self.tool.as_db_str().to_string(),
+                program: self.program.to_string(),
+                version,
+            },
+            None => ToolAvailability::Blocked {
+                tool: self.tool.as_db_str().to_string(),
+                program: self.program.to_string(),
+                hint: self.install_hint.to_string(),
+            },
+        }
+    }
+
+    /// Build the command that produces a `.scip` index at `output` for the checkout rooted at
+    /// `root`. `rust-analyzer scip <root> --output <path>` writes the SCIP index to a deterministic
+    /// path so the caller (a temp file) can consume it.
+    pub fn scip_command(&self, root: &Path, output: &Path) -> Command {
+        match self.tool {
+            OracleTool::RustAnalyzer => {
+                let mut cmd = Command::new(self.program);
+                cmd.arg("scip").arg(root).arg("--output").arg(output);
+                cmd
+            },
+        }
+    }
+}
+
+/// Run `<program> --version` and return the first non-empty trimmed stdout line, or `None` when the
+/// program is absent / not executable / exits non-zero. The version string is opaque (recorded as
+/// `tool_version` for content-addressed staleness — a different version invalidates prior
+/// verdicts).
+fn detect_version(program: &str) -> Option<String> {
+    let output = Command::new(program).arg("--version").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let line = stdout.lines().map(str::trim).find(|line| !line.is_empty())?;
+    Some(line.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_tool_has_a_manifest_entry() {
+        // Exhaustive over the OracleTool registry: each variant must resolve to a manifest with a
+        // non-empty program + hint, so `oracle run`/`status` can always describe it. (One variant
+        // today; the `match` is the exhaustiveness guard a new variant trips.)
+        let all_tools: &[OracleTool] = &[OracleTool::RustAnalyzer];
+        for &tool in all_tools {
+            let manifest = ToolManifest::for_tool(tool);
+            assert_eq!(manifest.tool, tool);
+            assert!(!manifest.program.is_empty());
+            assert!(!manifest.install_hint.is_empty());
+            assert!(!manifest.languages.is_empty());
+        }
+    }
+
+    #[test]
+    fn absent_program_probes_blocked_with_hint() {
+        // A program that cannot exist on PATH yields Blocked (never an error), carrying the hint —
+        // the missing-tool UX the `oracle run` command turns into exit 0.
+        let manifest = ToolManifest {
+            tool: OracleTool::RustAnalyzer,
+            program: "rag-rat-no-such-tool-xyzzy",
+            languages: &["rust"],
+            install_hint: "install hint here",
+        };
+        let availability = manifest.probe();
+        assert!(!availability.is_available());
+        match availability {
+            ToolAvailability::Blocked { hint, program, .. } => {
+                assert_eq!(program, "rag-rat-no-such-tool-xyzzy");
+                assert_eq!(hint, "install hint here");
+            },
+            other => panic!("expected Blocked, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detect_version_reads_a_known_program() {
+        // `cargo --version` is reliably present in the test environment (we're building with it).
+        // Proves the version-detection path returns a non-empty line for a real program.
+        let version = detect_version("cargo");
+        assert!(version.is_some_and(|v| v.starts_with("cargo")));
+    }
+
+    #[test]
+    fn scip_command_targets_output_path() {
+        let manifest = ToolManifest::for_tool(OracleTool::RustAnalyzer);
+        let cmd = manifest.scip_command(Path::new("/repo"), Path::new("/tmp/out.scip"));
+        let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy().into_owned()).collect();
+        assert_eq!(cmd.get_program().to_string_lossy(), "rust-analyzer");
+        assert_eq!(args, vec!["scip", "/repo", "--output", "/tmp/out.scip"]);
+    }
+}

--- a/crates/rag-rat-core/src/index/oracle/manifest.rs
+++ b/crates/rag-rat-core/src/index/oracle/manifest.rs
@@ -60,22 +60,40 @@ impl ToolManifest {
         }
     }
 
-    /// Probe whether the tool can run by detecting its version. Never errors: an absent or
-    /// unrunnable program yields [`ToolAvailability::Blocked`] with the install hint, so the
-    /// `oracle run` / `oracle status` UX can degrade gracefully (exit 0) instead of failing.
+    /// Probe whether the tool can run by detecting its version AND confirming it can actually
+    /// produce SCIP (it exposes the `scip` subcommand). Never errors: an absent program, an
+    /// unrunnable one, OR a binary on `PATH` that lacks the `scip` subcommand all yield
+    /// [`ToolAvailability::Blocked`] with the install hint, so the `oracle run` / `oracle status`
+    /// UX degrades gracefully (exit 0) instead of failing — or worse, invoking a `scip`-less
+    /// binary and reporting a confusing subprocess error.
+    ///
+    /// Checking only `--version` (#82 P3) would mark a stripped/wrong `rust-analyzer` build with no
+    /// `scip` subcommand as `Available`, then fail the actual run. `Blocked` must mean "can't
+    /// produce SCIP," so we exercise `<program> scip --help` too.
     pub fn probe(&self) -> ToolAvailability {
         match detect_version(self.program) {
-            Some(version) => ToolAvailability::Available {
+            Some(version) if self.supports_scip_subcommand() => ToolAvailability::Available {
                 tool: self.tool.as_db_str().to_string(),
                 program: self.program.to_string(),
                 version,
             },
-            None => ToolAvailability::Blocked {
+            _ => ToolAvailability::Blocked {
                 tool: self.tool.as_db_str().to_string(),
                 program: self.program.to_string(),
                 hint: self.install_hint.to_string(),
             },
         }
+    }
+
+    /// Whether `<program> scip --help` runs successfully — the cheap capability check that the
+    /// binary can actually emit a SCIP index (not just report a version). A non-zero exit or a
+    /// spawn failure means no `scip` subcommand, so the tool is `Blocked` for oracle purposes.
+    fn supports_scip_subcommand(&self) -> bool {
+        Command::new(self.program)
+            .arg("scip")
+            .arg("--help")
+            .output()
+            .is_ok_and(|output| output.status.success())
     }
 
     /// Build the command that produces a `.scip` index at `output` for the checkout rooted at
@@ -152,6 +170,26 @@ mod tests {
         // Proves the version-detection path returns a non-empty line for a real program.
         let version = detect_version("cargo");
         assert!(version.is_some_and(|v| v.starts_with("cargo")));
+    }
+
+    #[test]
+    fn probe_requires_the_scip_subcommand_not_just_a_version() {
+        // `cargo` is on PATH and reports a `--version`, but has no `scip` subcommand — so the
+        // capability check fails and the tool is Blocked, not Available (#82 P3: `Blocked` must
+        // mean "can't produce SCIP," not merely "absent"). We borrow `cargo` as a stand-in
+        // for a binary that exists + versions but can't emit SCIP.
+        let manifest = ToolManifest {
+            tool: OracleTool::RustAnalyzer,
+            program: "cargo",
+            languages: &["rust"],
+            install_hint: "hint",
+        };
+        assert!(detect_version("cargo").is_some(), "cargo reports a version");
+        assert!(!manifest.supports_scip_subcommand(), "cargo has no `scip` subcommand");
+        assert!(
+            !manifest.probe().is_available(),
+            "a versioned binary lacking `scip` must probe Blocked, not Available"
+        );
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -103,24 +103,35 @@ pub enum OracleRunOutcome {
     Blocked { tool: String, program: String, hint: String },
 }
 
-/// Invoke an oracle tool to produce a `.scip` for `checkout_root`, then run the phase-1 join over
-/// it — OR, when the tool is absent, return [`OracleRunOutcome::Blocked`] with the install hint
-/// (never an error exit). The produced index is written to `scip_output` (a caller-owned temp path)
-/// and consumed in place. `tool_version` is the probed version string (content-addressed staleness
-/// key), so a tool upgrade invalidates prior verdicts.
-pub fn run_oracle_with_tool(
-    conn: &Connection,
+/// The result of the LOCK-FREE half of a tool-driven oracle run: either the tool produced a `.scip`
+/// (carrying its probed version + the serialized bytes), or it was [`OracleRunOutcome::Blocked`].
+/// Splitting this from the join lets the CLI run the slow `rust-analyzer scip` subprocess WITHOUT
+/// the index write lock held — only the subsequent probe-recheck + join/write need to serialize
+/// against the watcher/indexer (#82 P3). The content-integrity gate in [`run_oracle`] already
+/// tolerates disk drift between this production and the join.
+pub enum ScipProduction {
+    /// The tool ran and wrote a readable `.scip`; `bytes` is its content, `version` the probed
+    /// tool version (content-addressed staleness key).
+    Produced { version: String, bytes: Vec<u8> },
+    /// The tool isn't runnable / can't produce SCIP — the `oracle run` Blocked UX.
+    Blocked { tool: String, program: String, hint: String },
+}
+
+/// Probe the tool and, if runnable, invoke `<tool> scip` to produce a `.scip` at `scip_output`,
+/// returning its bytes — the LOCK-FREE half of a tool-driven run. Takes NO DB connection, so the
+/// caller can run this before acquiring the index write lock (the rust-analyzer subprocess is the
+/// slow part and must not starve the watcher). A missing/unrunnable tool yields
+/// [`ScipProduction::Blocked`] — never an error.
+pub fn produce_scip_with_tool(
     tool: OracleTool,
     checkout_root: &Path,
     scip_output: &Path,
-    commit_sha: &str,
-    worktree_id: &str,
-) -> anyhow::Result<OracleRunOutcome> {
+) -> anyhow::Result<ScipProduction> {
     let manifest = ToolManifest::for_tool(tool);
     let version = match manifest.probe() {
         ToolAvailability::Available { version, .. } => version,
         ToolAvailability::Blocked { tool, program, hint } =>
-            return Ok(OracleRunOutcome::Blocked { tool, program, hint }),
+            return Ok(ScipProduction::Blocked { tool, program, hint }),
     };
     let mut command = manifest.scip_command(checkout_root, scip_output);
     let status = command
@@ -129,26 +140,69 @@ pub fn run_oracle_with_tool(
     if !status.success() {
         anyhow::bail!("{} scip exited with status {status}", manifest.program);
     }
-    let scip_bytes = std::fs::read(scip_output).map_err(|err| {
+    let bytes = std::fs::read(scip_output).map_err(|err| {
         anyhow::anyhow!(
             "{} produced no readable index at {}: {err}",
             manifest.program,
             scip_output.display()
         )
     })?;
-    let report =
-        run_oracle(conn, tool, &version, commit_sha, worktree_id, &scip_bytes, checkout_root)?;
-    Ok(OracleRunOutcome::Completed {
-        tool: tool.as_db_str().to_string(),
-        tool_version: version,
-        report,
-    })
+    Ok(ScipProduction::Produced { version, bytes })
+}
+
+/// Invoke an oracle tool to produce a `.scip` for `checkout_root`, then run the phase-1 join over
+/// it — OR, when the tool is absent, return [`OracleRunOutcome::Blocked`] with the install hint
+/// (never an error exit). The produced index is written to `scip_output` (a caller-owned temp path)
+/// and consumed in place. `tool_version` is the probed version string (content-addressed staleness
+/// key), so a tool upgrade invalidates prior verdicts.
+///
+/// This couples production + join under one connection (used by the public DB API + tests). The CLI
+/// `oracle run` path deliberately does NOT use this: it calls [`produce_scip_with_tool`] BEFORE the
+/// write lock, then [`run_oracle`] under the lock, so the subprocess doesn't hold the lock (#82
+/// P3).
+pub fn run_oracle_with_tool(
+    conn: &Connection,
+    tool: OracleTool,
+    checkout_root: &Path,
+    scip_output: &Path,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<OracleRunOutcome> {
+    match produce_scip_with_tool(tool, checkout_root, scip_output)? {
+        ScipProduction::Blocked { tool, program, hint } =>
+            Ok(OracleRunOutcome::Blocked { tool, program, hint }),
+        ScipProduction::Produced { version, bytes } => {
+            let report =
+                run_oracle(conn, tool, &version, commit_sha, worktree_id, &bytes, checkout_root)?;
+            Ok(OracleRunOutcome::Completed {
+                tool: tool.as_db_str().to_string(),
+                tool_version: version,
+                report,
+            })
+        },
+    }
 }
 
 /// Probe a tool's availability without running it — backs `oracle status`'s "is the tool
 /// installed?" line. A `Blocked` probe is informational, not an error.
 pub fn probe_oracle_tool(tool: OracleTool) -> ToolAvailability {
     ToolManifest::for_tool(tool).probe()
+}
+
+/// A short content fingerprint (first 12 hex chars of the SHA-256) of a pre-built `.scip`'s bytes.
+/// The `--scip` run-id keys on `scip-file:{basename}@{fingerprint}` so two DIFFERENT indexes that
+/// happen to share a basename (`index.scip` from two trees) don't collide onto one
+/// content-addressed `tool_version` — which would let a stale run's verdicts masquerade as the new
+/// fixture's (#82 P3). 12 hex chars (48 bits) is ample for a human-run fixture namespace.
+pub fn scip_content_fingerprint(scip_bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(scip_bytes);
+    let mut out = String::with_capacity(12);
+    for byte in digest.iter().take(6) {
+        use std::fmt::Write as _;
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
 }
 
 /// Fetch the CURRENT, in-scope oracle verdicts for a set of edge ids — the read-side join that

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -19,6 +19,7 @@
 //! - `store.rs` — `oracle_runs` / `edge_oracle` read + write helpers.
 
 mod join;
+mod manifest;
 mod run;
 mod scip;
 mod status;
@@ -28,11 +29,14 @@ mod tests;
 
 use std::path::Path;
 
+pub(crate) use join::package_of;
+pub use manifest::{ToolAvailability, ToolManifest};
 use run::OracleRunInput;
 pub use run::{OracleEvalMetrics, RecallCalls};
 use rusqlite::Connection;
 use serde::Serialize;
 pub use status::OracleStatus;
+pub(crate) use store::{EdgeOracleComparison, EdgeOracleVerdict};
 
 /// Run one oracle pass over the current edge candidates from a pre-built `.scip` and return its
 /// [`OracleReport`]. Phase-1 public entry point (consumed by `eval`); no CLI/MCP surface yet (#69).
@@ -84,6 +88,125 @@ pub fn oracle_status(
     worktree_id: &str,
 ) -> anyhow::Result<OracleStatus> {
     status::status(conn, tool, tool_version, commit_sha, worktree_id)
+}
+
+/// The outcome of `oracle run`: either a completed pass with its report, or a `Blocked` probe
+/// because the tool isn't installed. `Blocked` is a successful, no-op result — the CLI prints the
+/// hint and exits 0 (the missing-embedding-model UX), never an error.
+#[derive(Debug, Serialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum OracleRunOutcome {
+    /// The pass ran (consuming a pre-built `.scip` or one the tool produced) and persisted
+    /// verdicts.
+    Completed { tool: String, tool_version: String, report: OracleReport },
+    /// The requested tool isn't runnable. Carries the install hint; no verdicts were written.
+    Blocked { tool: String, program: String, hint: String },
+}
+
+/// Invoke an oracle tool to produce a `.scip` for `checkout_root`, then run the phase-1 join over
+/// it — OR, when the tool is absent, return [`OracleRunOutcome::Blocked`] with the install hint
+/// (never an error exit). The produced index is written to `scip_output` (a caller-owned temp path)
+/// and consumed in place. `tool_version` is the probed version string (content-addressed staleness
+/// key), so a tool upgrade invalidates prior verdicts.
+pub fn run_oracle_with_tool(
+    conn: &Connection,
+    tool: OracleTool,
+    checkout_root: &Path,
+    scip_output: &Path,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<OracleRunOutcome> {
+    let manifest = ToolManifest::for_tool(tool);
+    let version = match manifest.probe() {
+        ToolAvailability::Available { version, .. } => version,
+        ToolAvailability::Blocked { tool, program, hint } =>
+            return Ok(OracleRunOutcome::Blocked { tool, program, hint }),
+    };
+    let mut command = manifest.scip_command(checkout_root, scip_output);
+    let status = command
+        .status()
+        .map_err(|err| anyhow::anyhow!("failed to invoke {}: {err}", manifest.program))?;
+    if !status.success() {
+        anyhow::bail!("{} scip exited with status {status}", manifest.program);
+    }
+    let scip_bytes = std::fs::read(scip_output).map_err(|err| {
+        anyhow::anyhow!(
+            "{} produced no readable index at {}: {err}",
+            manifest.program,
+            scip_output.display()
+        )
+    })?;
+    let report =
+        run_oracle(conn, tool, &version, commit_sha, worktree_id, &scip_bytes, checkout_root)?;
+    Ok(OracleRunOutcome::Completed {
+        tool: tool.as_db_str().to_string(),
+        tool_version: version,
+        report,
+    })
+}
+
+/// Probe a tool's availability without running it — backs `oracle status`'s "is the tool
+/// installed?" line. A `Blocked` probe is informational, not an error.
+pub fn probe_oracle_tool(tool: OracleTool) -> ToolAvailability {
+    ToolManifest::for_tool(tool).probe()
+}
+
+/// Fetch the CURRENT, in-scope oracle verdicts for a set of edge ids — the read-side join that
+/// surfaces the `Compiler` tier in graph/impact output. Routes through the scoped + current store
+/// helper (`edge_oracle.file_sha == files.sha256`), so a drifted file's edge never surfaces
+/// `Compiler` (it reverts to heuristic display). `edge_ids` come from the heuristic traversal, so
+/// the result is a subset.
+pub(crate) fn current_oracle_verdicts_for_edges(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+    edge_ids: &[i64],
+) -> anyhow::Result<std::collections::HashMap<i64, EdgeOracleVerdict>> {
+    store::current_oracle_verdicts_for_edges(
+        conn,
+        tool,
+        tool_version,
+        commit_sha,
+        worktree_id,
+        edge_ids,
+    )
+}
+
+/// Prune `oracle_runs` rows for dead `(commit_sha, worktree_id)` contexts — the gc companion to the
+/// `edge_oracle` FK cascade. See [`store::prune_oracle_runs_outside_scope`]. Returns rows deleted.
+pub fn prune_oracle_runs_outside_scope(
+    conn: &Connection,
+    live_commits: &[String],
+    live_worktrees: &[String],
+) -> anyhow::Result<u64> {
+    store::prune_oracle_runs_outside_scope(conn, live_commits, live_worktrees)
+}
+
+/// The `tool_version` the surfacing reads (the `Compiler` tier) should key on for `tool` in the
+/// active checkout: the most recent run's version, or `None` when no run exists. Surfacing query
+/// output keys on the last run's verdicts.
+pub fn latest_run_tool_version(
+    conn: &Connection,
+    tool: OracleTool,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<Option<String>> {
+    store::latest_run_tool_version(conn, tool, commit_sha, worktree_id)
+}
+
+/// Load the CURRENT, in-scope `edge_oracle` verdicts joined to their heuristic edge resolution —
+/// the data `compare_graph_to_scip` diffs (it keeps `Contradict` rows). Scoped + current via the
+/// store helper, so drifted/dirty rows never appear as disagreements.
+pub(crate) fn current_oracle_comparisons(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<Vec<EdgeOracleComparison>> {
+    store::current_oracle_comparisons(conn, tool, tool_version, commit_sha, worktree_id)
 }
 
 /// The oracle tool that produced a SCIP index. Phase 1 ships only the Rust backend (consumed from a

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -27,6 +27,7 @@ mod store;
 #[cfg(test)]
 mod tests;
 
+use std::collections::HashMap;
 use std::path::Path;
 
 pub(crate) use join::package_of;
@@ -43,6 +44,13 @@ pub(crate) use store::{EdgeOracleComparison, EdgeOracleVerdict};
 ///
 /// `checkout_root` is the source root whose bytes are read for per-document position-encoding
 /// conversion (the `.scip` document paths are relative to it).
+///
+/// `production_sha` is the per-document disk-hash snapshot captured when a TOOL produced this
+/// `.scip` (`None` for a pre-built `--scip`). When present it arms the scip-vs-disk content gate
+/// (#82 TOCTOU); see [`run::OracleRunInput::production_sha`].
+// The args mirror `OracleRunInput`'s fields one-to-one (this is the public thin adapter to it), so
+// a params struct would only re-wrap what callers already pass positionally.
+#[allow(clippy::too_many_arguments)]
 pub fn run_oracle(
     conn: &Connection,
     tool: OracleTool,
@@ -51,6 +59,7 @@ pub fn run_oracle(
     worktree_id: &str,
     scip_bytes: &[u8],
     checkout_root: &Path,
+    production_sha: Option<&HashMap<String, String>>,
 ) -> anyhow::Result<OracleReport> {
     run::run(conn, &OracleRunInput {
         tool,
@@ -59,6 +68,7 @@ pub fn run_oracle(
         worktree_id,
         scip_bytes,
         checkout_root,
+        production_sha,
     })
 }
 
@@ -107,12 +117,21 @@ pub enum OracleRunOutcome {
 /// (carrying its probed version + the serialized bytes), or it was [`OracleRunOutcome::Blocked`].
 /// Splitting this from the join lets the CLI run the slow `rust-analyzer scip` subprocess WITHOUT
 /// the index write lock held — only the subsequent probe-recheck + join/write need to serialize
-/// against the watcher/indexer (#82 P3). The content-integrity gate in [`run_oracle`] already
-/// tolerates disk drift between this production and the join.
+/// against the watcher/indexer (#82 P3). The `production_sha` snapshot carried on `Produced` lets
+/// the join narrow the resulting lock-free window: a document the watcher reindexes between this
+/// production and the join is skipped (scip-vs-disk gate, #82 TOCTOU), never mis-joined. The
+/// snapshot is best-effort (taken at subprocess exit, not at rust-analyzer's own reads), so a
+/// mid-subprocess edit remains uncovered — see the `production_sha` field on `Produced` below.
 pub enum ScipProduction {
     /// The tool ran and wrote a readable `.scip`; `bytes` is its content, `version` the probed
-    /// tool version (content-addressed staleness key).
-    Produced { version: String, bytes: Vec<u8> },
+    /// tool version (content-addressed staleness key). `production_sha` is `relative_path -> hex
+    /// sha256` of each document's disk bytes read the instant the subprocess finished — the
+    /// scip-vs-disk content pin the join uses to reject a document the watcher reindexed in the
+    /// lock-free window before the join (#82 TOCTOU). It is a best-effort snapshot taken as close
+    /// to production as the API allows; a file unreadable at snapshot time is simply absent
+    /// (its candidate then fails the `Some(_) == disk` gate and is skipped, the safe
+    /// direction).
+    Produced { version: String, bytes: Vec<u8>, production_sha: HashMap<String, String> },
     /// The tool isn't runnable / can't produce SCIP — the `oracle run` Blocked UX.
     Blocked { tool: String, program: String, hint: String },
 }
@@ -147,7 +166,36 @@ pub fn produce_scip_with_tool(
             scip_output.display()
         )
     })?;
-    Ok(ScipProduction::Produced { version, bytes })
+    // Snapshot each document's disk hash NOW, the instant the subprocess finished — this is the
+    // content the `.scip` describes. The join later pins its occurrence offsets to these hashes so
+    // a file the watcher reindexes in the lock-free window before the join is skipped instead
+    // of mis-joined (#82 TOCTOU). Reading the doc list from the `.scip` (not the whole tree)
+    // keeps the snapshot to exactly the files the oracle can speak to. An unreadable file is
+    // omitted (its candidate then fails the gate and is skipped — the safe direction).
+    let production_sha = snapshot_document_disk_hashes(&bytes, checkout_root);
+    Ok(ScipProduction::Produced { version, bytes, production_sha })
+}
+
+/// Hash each `.scip` document's CURRENT disk bytes under `checkout_root`, returning `relative_path
+/// -> hex sha256`. Backs the scip-vs-disk content gate (#82 TOCTOU): the caller captures this right
+/// after the tool exits so the join can verify a document hasn't drifted since production. Hashes
+/// in the same space as `files.sha256` / the join's `disk_sha` (via [`run::hex_sha256`]) so the
+/// three compare directly. Unreadable documents (and an unparseable `.scip`, which can't have
+/// produced usable verdicts anyway) are simply absent from the map.
+fn snapshot_document_disk_hashes(
+    scip_bytes: &[u8],
+    checkout_root: &Path,
+) -> HashMap<String, String> {
+    let Ok(paths) = scip::ScipIndex::document_relative_paths(scip_bytes) else {
+        return HashMap::new();
+    };
+    let mut out = HashMap::with_capacity(paths.len());
+    for path in paths {
+        if let Ok(bytes) = std::fs::read(checkout_root.join(&path)) {
+            out.insert(path, run::hex_sha256(&bytes));
+        }
+    }
+    out
 }
 
 /// Invoke an oracle tool to produce a `.scip` for `checkout_root`, then run the phase-1 join over
@@ -171,9 +219,17 @@ pub fn run_oracle_with_tool(
     match produce_scip_with_tool(tool, checkout_root, scip_output)? {
         ScipProduction::Blocked { tool, program, hint } =>
             Ok(OracleRunOutcome::Blocked { tool, program, hint }),
-        ScipProduction::Produced { version, bytes } => {
-            let report =
-                run_oracle(conn, tool, &version, commit_sha, worktree_id, &bytes, checkout_root)?;
+        ScipProduction::Produced { version, bytes, production_sha } => {
+            let report = run_oracle(
+                conn,
+                tool,
+                &version,
+                commit_sha,
+                worktree_id,
+                &bytes,
+                checkout_root,
+                Some(&production_sha),
+            )?;
             Ok(OracleRunOutcome::Completed {
                 tool: tool.as_db_str().to_string(),
                 tool_version: version,

--- a/crates/rag-rat-core/src/index/oracle/run.rs
+++ b/crates/rag-rat-core/src/index/oracle/run.rs
@@ -434,7 +434,7 @@ fn ratio(numerator: u64, denominator: u64) -> f64 {
 
 /// Count edges with a low-confidence heuristic resolution (`NameOnly`/`Ambiguous`) that the oracle
 /// produced a verdict for (i.e. have an `edge_oracle` row), scoped to the active checkout. Built on
-/// the shared `store::EDGE_ORACLE_SCOPE_JOIN` (the `?1..?4 = tool/version/commit_sha/worktree_id`
+/// the shared `store::edge_oracle_scope_join()` (the `?1..?4 = tool/version/commit_sha/worktree_id`
 /// scope) so the scope predicate is never re-spelled here — only the extra confidence filter is
 /// appended.
 fn count_low_confidence_with_oracle(
@@ -447,7 +447,7 @@ fn count_low_confidence_with_oracle(
     let count: i64 = conn.query_row(
         &format!(
             "SELECT COUNT(*){} AND edges.confidence IN ('NameOnly', 'Ambiguous')",
-            store::EDGE_ORACLE_SCOPE_JOIN
+            store::edge_oracle_scope_join()
         ),
         rusqlite::params![tool.as_db_str(), tool_version, commit_sha, worktree_id],
         |row| row.get(0),
@@ -460,7 +460,7 @@ fn count_low_confidence_with_oracle(
 /// (`count_low_confidence_with_oracle`), so the rate can never exceed 1.0. The `edges.confidence`
 /// filter is what guards against an `Exact`-with-NULL-`to_symbol_id` writer bug recreating an
 /// over-1.0 rate (the raw per-kind `counts.upgraded` would admit such an upgrade; this won't).
-/// Built on the shared `store::EDGE_ORACLE_SCOPE_JOIN`, like the upgradeable-fraction numerator.
+/// Built on the shared `store::edge_oracle_scope_join()`, like the upgradeable-fraction numerator.
 fn count_low_confidence_upgrades(
     conn: &Connection,
     tool: OracleTool,
@@ -472,7 +472,7 @@ fn count_low_confidence_upgrades(
         &format!(
             "SELECT COUNT(*){} AND edge_oracle.kind = 'upgrade' AND edges.confidence IN \
              ('NameOnly', 'Ambiguous')",
-            store::EDGE_ORACLE_SCOPE_JOIN
+            store::edge_oracle_scope_join()
         ),
         rusqlite::params![tool.as_db_str(), tool_version, commit_sha, worktree_id],
         |row| row.get(0),
@@ -486,7 +486,7 @@ fn count_low_confidence_upgrades(
 /// denominator (`count_unresolved_candidates`) counts, so the fraction can never exceed 1.0. There
 /// is at most one `edge_oracle` row per edge (PK `(edge_id, tool, tool_version)`), so this is a
 /// subset count, not a sum that could double-count. Built on the shared
-/// `store::EDGE_ORACLE_SCOPE_JOIN` so it stays ⊆ the scoped denominator by construction.
+/// `store::edge_oracle_scope_join()` so it stays ⊆ the scoped denominator by construction.
 fn count_upgradeable_low_confidence(
     conn: &Connection,
     tool: OracleTool,
@@ -498,7 +498,7 @@ fn count_upgradeable_low_confidence(
         &format!(
             "SELECT COUNT(*){} AND edge_oracle.kind IN ('upgrade', 'resolved-external') AND \
              edges.confidence IN ('NameOnly', 'Ambiguous')",
-            store::EDGE_ORACLE_SCOPE_JOIN
+            store::edge_oracle_scope_join()
         ),
         rusqlite::params![tool.as_db_str(), tool_version, commit_sha, worktree_id],
         |row| row.get(0),
@@ -519,14 +519,17 @@ fn count_unresolved_candidates(
     worktree_id: &str,
 ) -> anyhow::Result<u64> {
     let count: i64 = conn.query_row(
-        "
+        &format!(
+            "
         SELECT COUNT(*)
         FROM edges
         JOIN files ON files.id = edges.source_file_id
         WHERE edges.callee_start_byte IS NOT NULL
           AND edges.confidence IN ('NameOnly', 'Ambiguous')
-          AND files.commit_sha = ?1 AND files.worktree_id = ?2
+          AND {scope}
         ",
+            scope = store::active_checkout_file_predicate("?1", "?2"),
+        ),
         rusqlite::params![commit_sha, worktree_id],
         |row| row.get(0),
     )?;

--- a/crates/rag-rat-core/src/index/oracle/run.rs
+++ b/crates/rag-rat-core/src/index/oracle/run.rs
@@ -30,6 +30,17 @@ pub(crate) struct OracleRunInput<'a> {
     /// Checkout root: document paths in the `.scip` are joined against this to read current bytes
     /// for position-encoding conversion.
     pub(crate) checkout_root: &'a Path,
+    /// `relative_path -> hex sha256` of the disk bytes captured the instant the tool finished
+    /// producing the `.scip`, for a tool-driven run; `None` for a pre-built `--scip` (no
+    /// production moment we control). When present it adds the scip-vs-disk leg of the content
+    /// gate (#82 TOCTOU): the `.scip`'s occurrence offsets describe the bytes the subprocess saw,
+    /// so the join only trusts them for a document whose disk content is STILL that snapshot. Both
+    /// documents a verdict depends on are pinned against it — the call-site document
+    /// (pre-classify) AND the resolved symbol's definition document (post-classify) — since
+    /// the watcher reindexing EITHER in the lock-free window corrupts the join while `disk_sha
+    /// == file_sha` (both the new content) still passes the index-vs-disk gate. See
+    /// [`super::ScipProduction::Produced`].
+    pub(crate) production_sha: Option<&'a HashMap<String, String>>,
 }
 
 /// Run the oracle join over all current edge candidates and persist verdicts + a run row.
@@ -129,7 +140,23 @@ pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Resu
         // silently-wrong verdict. Skip the candidate and tally it as drifted so `eval` can
         // warn. A file with no computed hash (unreadable) already produced no occurrences,
         // so it never reaches here.
-        if disk_sha.get(&candidate.source_path).map(String::as_str) != Some(&candidate.file_sha) {
+        let disk = disk_sha.get(&candidate.source_path).map(String::as_str);
+        if disk != Some(&candidate.file_sha) {
+            report.skipped_drifted += 1;
+            continue;
+        }
+
+        // scip-vs-disk gate (#82 TOCTOU): the index-vs-disk check above only proves the EDGE and
+        // the disk agree — both could be the NEW content the watcher reindexed in the
+        // lock-free window after the tool built the `.scip` against the OLD content. For a
+        // tool-driven run we also hold the disk hash captured at production time; require
+        // it to still match disk, so the `.scip`'s occurrence offsets describe the very
+        // bytes the join reads. A drifted document is skipped (tallied as drifted), exactly
+        // like index-vs-disk drift. A pre-built `--scip` (`production_sha == None`) has no
+        // production moment to pin, so it keeps the index-vs-disk gate only.
+        if let Some(production_sha) = input.production_sha
+            && production_sha.get(&candidate.source_path).map(String::as_str) != disk
+        {
             report.skipped_drifted += 1;
             continue;
         }
@@ -148,6 +175,25 @@ pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Resu
             report.no_occurrence += 1;
             continue;
         };
+
+        // scip-vs-disk gate, DEFINITION side (#82 TOCTOU, def-document variant). The call-site gate
+        // above only pins the document the occurrence lives in. But an in-corpus verdict also
+        // depends on the DEFINITION document: the resolved symbol comes from converting the `.scip`
+        // def occurrence's offsets against the def file's join-time disk bytes, then mapping that
+        // byte range to a current indexed symbol. If the watcher reindexed the DEF file in the
+        // lock-free window, that conversion lands on the wrong bytes and resolves the wrong symbol
+        // (a mis-targeted `Upgrade`/`Contradict`, or a false external when it maps to
+        // nothing). Pin the def document the same way — its hash is already in the
+        // production snapshot. An external symbol with no in-corpus definition entry has no
+        // def document to pin, so it's unaffected.
+        if let Some(production_sha) = input.production_sha
+            && let Some(def) = index.definitions.get(&verdict.scip_symbol)
+            && production_sha.get(&def.path).map(String::as_str)
+                != disk_sha.get(&def.path).map(String::as_str)
+        {
+            report.skipped_drifted += 1;
+            continue;
+        }
 
         // Mark EXACTLY the occurrence the verdict matched as covered (finding 4): use the range the
         // join selected (reference-preferred, full containment), not a re-derived start-only match
@@ -201,8 +247,10 @@ pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Resu
 }
 
 /// Hex SHA-256 of a byte slice — matches `files.sha256` (computed as `hex_sha256(fs::read(file))`),
-/// so the content-integrity check compares the same hash space the indexer wrote.
-fn hex_sha256(bytes: &[u8]) -> String {
+/// so the content-integrity check compares the same hash space the indexer wrote. `pub(crate)` so
+/// the production-time snapshot in `produce_scip_with_tool` hashes disk bytes in the SAME space the
+/// join's `disk_sha` / the candidate's `file_sha` live in (the scip-vs-disk gate, #82 TOCTOU).
+pub(crate) fn hex_sha256(bytes: &[u8]) -> String {
     let digest = Sha256::digest(bytes);
     let mut out = String::with_capacity(digest.len() * 2);
     for byte in digest {

--- a/crates/rag-rat-core/src/index/oracle/scip.rs
+++ b/crates/rag-rat-core/src/index/oracle/scip.rs
@@ -74,6 +74,18 @@ impl ScipIndex {
         Self::from_index(&index, &mut read_document_source)
     }
 
+    /// The relative paths of every document in a serialized `.scip`, WITHOUT reading any source or
+    /// converting offsets. Used by `produce_scip_with_tool` to snapshot the disk content the tool
+    /// just built against (the scip-vs-disk content gate, #82 TOCTOU) — that snapshot only needs
+    /// the document list, so it skips the full [`ScipIndex::parse`]. Returns paths in document
+    /// order; a duplicate document path (SCIP shouldn't emit one) is harmless to the caller's
+    /// set/hash use.
+    pub(crate) fn document_relative_paths(bytes: &[u8]) -> anyhow::Result<Vec<String>> {
+        let index = Index::parse_from_bytes(bytes)
+            .map_err(|err| anyhow::anyhow!("failed to parse SCIP index: {err}"))?;
+        Ok(index.documents.iter().map(|document| document.relative_path.clone()).collect())
+    }
+
     /// Build the maps from an already-deserialized [`Index`] — the entry point tests use after
     /// constructing an `Index` programmatically.
     pub(crate) fn from_index(

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -337,17 +337,30 @@ pub(crate) fn count_edge_oracle_scoped(
 }
 
 /// The CURRENT-content predicate appended to [`EDGE_ORACLE_SCOPE_JOIN`] for any READ that surfaces
-/// a verdict in query output (the `Compiler` tier). A verdict is valid for display ONLY when the
-/// file it was computed against is unchanged — `edge_oracle.file_sha == files.sha256` for the
-/// edge's current source file. A drifted/changed file's `file_sha` differs, so the verdict is
-/// filtered out here and the edge reverts to heuristic display (`oracle-stale`), never `Compiler`.
+/// a verdict in query output (the `Compiler` tier). A verdict is valid for display ONLY when BOTH:
+///
+/// 1. **The callsite file is unchanged** — `edge_oracle.file_sha == files.sha256` for the edge's
+///    current source file. A drifted/changed callsite's `file_sha` differs, so the verdict is
+///    filtered out and the edge reverts to heuristic display (`oracle-stale`), never `Compiler`.
+/// 2. **The resolved definition is unchanged** (in-corpus verdicts only) — the resolved symbol
+///    `edge_oracle.resolved_symbol_id` STILL EXISTS in the active scope. The callsite gate (1)
+///    alone misses *definition* drift: an `Upgrade`/`Confirm` keeps surfacing after the resolved
+///    *def* file changed or its symbol was deleted/reinserted, because the callsite file is
+///    untouched so its sha still matches (#82 finding 3). Since `symbols.id` is AUTOINCREMENT,
+///    reindexing the def file mints NEW ids and the old `resolved_symbol_id` dangles — so an
+///    `EXISTS` against `symbols.id` reverts the verdict to heuristic the moment the def file is
+///    reindexed. `resolved-external` verdicts (`resolved_symbol_id IS NULL`) skip this clause —
+///    there is no in-corpus def to drift.
+///
 /// This is the read-side mirror of the run-time content-integrity gate (run.rs) and the staleness
 /// key `(file_sha, tool, tool_version)`.
 ///
 /// (The eval/status COUNTS in [`count_edge_oracle_scoped`] deliberately do NOT apply this — they
 /// describe the persisted verdict population for precision/recall, which is content-addressed by
 /// the run, not the live display. Only the surfacing reads gate on currency.)
-pub(crate) const EDGE_ORACLE_CURRENT_PREDICATE: &str = " AND edge_oracle.file_sha = files.sha256";
+pub(crate) const EDGE_ORACLE_CURRENT_PREDICATE: &str =
+    " AND edge_oracle.file_sha = files.sha256 AND (edge_oracle.resolved_symbol_id IS NULL OR \
+     EXISTS (SELECT 1 FROM symbols WHERE symbols.id = edge_oracle.resolved_symbol_id))";
 
 /// One current, in-scope oracle verdict for an edge, surfaced in graph/impact query output as the
 /// `Compiler` tier. `package` is the external dependency name for `resolved-external` verdicts
@@ -355,6 +368,15 @@ pub(crate) const EDGE_ORACLE_CURRENT_PREDICATE: &str = " AND edge_oracle.file_sh
 #[derive(Debug, Clone)]
 pub(crate) struct EdgeOracleVerdict {
     pub(crate) kind: OracleResolutionKind,
+    /// The qualified name of the verdict's in-corpus `resolved_symbol_id` (joined at read time),
+    /// `None` when the verdict is external (`resolved_symbol_id IS NULL`) or the resolved symbol
+    /// no longer exists. An `Upgrade`'s target is hydrated from THIS name — never the
+    /// heuristic edge's stale/heuristic target — and an `Upgrade` whose resolved symbol can't
+    /// be surfaced (`None`) is NOT promoted to `compiler`: we won't attach the tier to a
+    /// target we can't name (#82 finding 2). The def-drift gate in
+    /// `EDGE_ORACLE_CURRENT_PREDICATE` already filters a deleted/reinserted resolved symbol,
+    /// so in practice this is `None` only for externals.
+    pub(crate) resolved_qualified_name: Option<String>,
     pub(crate) scip_symbol: String,
     pub(crate) tool: OracleTool,
     pub(crate) tool_version: String,
@@ -408,8 +430,15 @@ pub(crate) fn current_oracle_verdicts_for_edges(
     for chunk in edge_ids.chunks(900) {
         let placeholders =
             (0..chunk.len()).map(|i| format!("?{}", i + 5)).collect::<Vec<_>>().join(", ");
+        // The resolved symbol's qualified name is pulled via a correlated subquery (not a trailing
+        // JOIN) so the shared `EDGE_ORACLE_SCOPE_JOIN`/`..._CURRENT_PREDICATE` strings — which end
+        // in a WHERE — stay the single source of the scope+current predicate. A deleted/reinserted
+        // resolved symbol yields NULL here, so the `Upgrade` target can't be surfaced and the hop
+        // is left heuristic (#82 finding 2).
         let sql = format!(
             "SELECT edge_oracle.edge_id, edge_oracle.kind, edge_oracle.resolved_symbol_id, \
+             (SELECT qualified_name FROM symbols WHERE symbols.id = \
+             edge_oracle.resolved_symbol_id), \
              edge_oracle.scip_symbol{EDGE_ORACLE_SCOPE_JOIN}{EDGE_ORACLE_CURRENT_PREDICATE} AND \
              edge_oracle.edge_id IN ({placeholders})"
         );
@@ -426,17 +455,21 @@ pub(crate) fn current_oracle_verdicts_for_edges(
         let rows = stmt.query_map(rusqlite::params_from_iter(params.iter()), |row| {
             let edge_id: i64 = row.get(0)?;
             let kind: String = row.get(1)?;
-            let resolved_symbol_id: Option<i64> = row.get(2)?;
-            let scip_symbol: String = row.get(3)?;
-            Ok((edge_id, kind, resolved_symbol_id, scip_symbol))
+            // Column 2 (`resolved_symbol_id`) is selected so the def-drift EXISTS clause in the
+            // CURRENT predicate can reference it, but the verdict carries the joined NAME, not the
+            // raw id.
+            let resolved_qualified_name: Option<String> = row.get(3)?;
+            let scip_symbol: String = row.get(4)?;
+            Ok((edge_id, kind, resolved_qualified_name, scip_symbol))
         })?;
         for row in rows {
-            let (edge_id, kind, _resolved_symbol_id, scip_symbol) = row?;
+            let (edge_id, kind, resolved_qualified_name, scip_symbol) = row?;
             let Some(kind) = OracleResolutionKind::from_db_str(&kind) else {
                 continue;
             };
             out.insert(edge_id, EdgeOracleVerdict {
                 kind,
+                resolved_qualified_name,
                 scip_symbol,
                 tool,
                 tool_version: tool_version.to_string(),
@@ -458,6 +491,14 @@ pub(crate) struct EdgeOracleComparison {
     pub(crate) heuristic_confidence: String,
     pub(crate) heuristic_target: Option<String>,
     pub(crate) callee_name: Option<String>,
+    /// Our `symbols.id` when the compiler resolved this callee to an IN-CORPUS symbol (an
+    /// in-corpus `Contradict`: the compiler picked a different in-corpus target), `None` when
+    /// it placed the callee in a dependency. `compare_graph_to_scip` labels
+    /// `resolved_external` ONLY when this is `None` — a Rust SCIP symbol carries a
+    /// crate/package component even for the LOCAL crate, so deriving `resolved-external` from
+    /// `scip_symbol` alone would mislabel an in-corpus contradiction as
+    /// `resolved-external(<local-crate>)` (#82 finding 1).
+    pub(crate) resolved_symbol_id: Option<i64>,
     pub(crate) scip_symbol: String,
     pub(crate) callsite_path: String,
     pub(crate) callsite_line: i64,
@@ -482,7 +523,8 @@ pub(crate) fn current_oracle_comparisons(
     let sql = format!(
         "SELECT edge_oracle.edge_id, edge_oracle.kind, edges.edge_kind, edges.confidence, (SELECT \
          qualified_name FROM symbols WHERE symbols.id = edges.to_symbol_id), edges.to_name, \
-         edge_oracle.scip_symbol, files.path, COALESCE(NULLIF(edges.source_start_line, 0), 1) \
+         edge_oracle.resolved_symbol_id, edge_oracle.scip_symbol, files.path, \
+         COALESCE(NULLIF(edges.source_start_line, 0), 1) \
          {EDGE_ORACLE_SCOPE_JOIN}{EDGE_ORACLE_CURRENT_PREDICATE} ORDER BY files.path, \
          edges.source_start_line"
     );
@@ -497,9 +539,10 @@ pub(crate) fn current_oracle_comparisons(
                 row.get::<_, String>(3)?,
                 row.get::<_, Option<String>>(4)?,
                 row.get::<_, Option<String>>(5)?,
-                row.get::<_, String>(6)?,
+                row.get::<_, Option<i64>>(6)?,
                 row.get::<_, String>(7)?,
-                row.get::<_, i64>(8)?,
+                row.get::<_, String>(8)?,
+                row.get::<_, i64>(9)?,
             ))
         })?;
     let mut out = Vec::new();
@@ -511,6 +554,7 @@ pub(crate) fn current_oracle_comparisons(
             heuristic_confidence,
             heuristic_target,
             callee_name,
+            resolved_symbol_id,
             scip_symbol,
             callsite_path,
             callsite_line,
@@ -525,6 +569,7 @@ pub(crate) fn current_oracle_comparisons(
             heuristic_confidence,
             heuristic_target,
             callee_name,
+            resolved_symbol_id,
             scip_symbol,
             callsite_path,
             callsite_line,

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -348,7 +348,7 @@ pub(crate) fn edge_oracle_scope_join() -> String {
 
 /// Count `edge_oracle` rows for `(tool, tool_version)` **within the active checkout**, optionally
 /// filtered to a single `kind`. The one scoped count helper behind both the total and the per-kind
-/// status/metric reads — every caller routes through [`EDGE_ORACLE_SCOPE_JOIN`], so the scope can
+/// status/metric reads — every caller routes through [`edge_oracle_scope_join`], so the scope can
 /// never be re-spelled (and thus can't be forgotten) per query.
 pub(crate) fn count_edge_oracle_scoped(
     conn: &Connection,
@@ -374,7 +374,7 @@ pub(crate) fn count_edge_oracle_scoped(
     Ok(u64::try_from(count).unwrap_or(0))
 }
 
-/// The CURRENT-content predicate appended to [`EDGE_ORACLE_SCOPE_JOIN`] for any READ that surfaces
+/// The CURRENT-content predicate appended to [`edge_oracle_scope_join`] for any READ that surfaces
 /// a verdict in query output (the `Compiler` tier). A verdict is valid for display ONLY when BOTH:
 ///
 /// 1. **The callsite file is unchanged** — `edge_oracle.file_sha == files.sha256` for the edge's
@@ -429,7 +429,7 @@ pub(crate) struct EdgeOracleVerdict {
     /// heuristic edge's stale/heuristic target — and an `Upgrade` whose resolved symbol can't
     /// be surfaced (`None`) is NOT promoted to `compiler`: we won't attach the tier to a
     /// target we can't name (#82 finding 2). The def-drift gate in
-    /// `EDGE_ORACLE_CURRENT_PREDICATE` already filters a deleted/reinserted resolved symbol,
+    /// [`edge_oracle_current_predicate`] already filters a deleted/reinserted resolved symbol,
     /// so in practice this is `None` only for externals.
     pub(crate) resolved_qualified_name: Option<String>,
     pub(crate) scip_symbol: String,
@@ -459,8 +459,8 @@ impl EdgeOracleVerdict {
 
 /// Fetch the CURRENT, in-scope oracle verdicts for a set of edge ids (the read-side join that
 /// surfaces the `Compiler` tier in `trace_callees` / `find_callers` / `impact_surface`). Scoped to
-/// the active `(commit_sha, worktree_id)` via [`EDGE_ORACLE_SCOPE_JOIN`] AND gated to current
-/// content via [`EDGE_ORACLE_CURRENT_PREDICATE`], so a drifted file's verdict is never returned
+/// the active `(commit_sha, worktree_id)` via [`edge_oracle_scope_join`] AND gated to current
+/// content via [`edge_oracle_current_predicate`], so a drifted file's verdict is never returned
 /// (its edge reverts to heuristic display). Returns at most one row per edge id (PK
 /// `(edge_id, tool, tool_version)` and the single-tool scope).
 ///
@@ -486,8 +486,9 @@ pub(crate) fn current_oracle_verdicts_for_edges(
         let placeholders =
             (0..chunk.len()).map(|i| format!("?{}", i + 5)).collect::<Vec<_>>().join(", ");
         // The resolved symbol's qualified name is pulled via a correlated subquery (not a trailing
-        // JOIN) so the shared `EDGE_ORACLE_SCOPE_JOIN`/`..._CURRENT_PREDICATE` strings — which end
-        // in a WHERE — stay the single source of the scope+current predicate. A deleted/reinserted
+        // JOIN) so the shared `edge_oracle_scope_join()`/`edge_oracle_current_predicate()` strings
+        // — which end in a WHERE — stay the single source of the scope+current predicate. A
+        // deleted/reinserted
         // resolved symbol yields NULL here, so the `Upgrade` target can't be surfaced and the hop
         // is left heuristic (#82 finding 2).
         let sql = format!(
@@ -562,8 +563,8 @@ pub(crate) struct EdgeOracleComparison {
 
 /// Load every CURRENT, in-scope `edge_oracle` verdict joined to its edge's heuristic resolution —
 /// the data `compare_graph_to_scip` diffs (it keeps the `Contradict` rows). Scoped to the active
-/// `(commit_sha, worktree_id)` via [`EDGE_ORACLE_SCOPE_JOIN`] AND gated to current content via
-/// [`EDGE_ORACLE_CURRENT_PREDICATE`], so a drifted/dirty file's verdict is never reported as a
+/// `(commit_sha, worktree_id)` via [`edge_oracle_scope_join`] AND gated to current content via
+/// [`edge_oracle_current_predicate`], so a drifted/dirty file's verdict is never reported as a
 /// disagreement (it reverted to heuristic display). The heuristic target's qualified name comes
 /// from the `to_symbols` join (the `edges.to_symbol_id` the heuristic picked).
 pub(crate) fn current_oracle_comparisons(
@@ -574,7 +575,7 @@ pub(crate) fn current_oracle_comparisons(
     worktree_id: &str,
 ) -> anyhow::Result<Vec<EdgeOracleComparison>> {
     // The heuristic target's qualified name is fetched via a correlated subquery rather than a
-    // trailing LEFT JOIN, so the shared `EDGE_ORACLE_SCOPE_JOIN` string (which already ends in a
+    // trailing LEFT JOIN, so the shared `edge_oracle_scope_join` string (which already ends in a
     // WHERE) stays the single source of the scope predicate — a JOIN can't legally follow a WHERE.
     let sql = format!(
         "SELECT edge_oracle.edge_id, edge_oracle.kind, edges.edge_kind, edges.confidence, (SELECT \

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -266,6 +266,31 @@ pub(crate) fn record_oracle_run(
     Ok(conn.last_insert_rowid())
 }
 
+/// The `tool_version` of the most recent run for `tool` **in the active checkout**, if any. This is
+/// the version the surfacing reads (the `Compiler` tier) key on: query output should show the
+/// verdicts the last `oracle run` for this checkout produced. Scoped to `(commit_sha, worktree_id)`
+/// so a sibling worktree's run can't dictate this checkout's displayed tool version.
+pub(crate) fn latest_run_tool_version(
+    conn: &Connection,
+    tool: OracleTool,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<Option<String>> {
+    let version = conn
+        .query_row(
+            "
+            SELECT tool_version FROM oracle_runs
+            WHERE tool = ?1 AND commit_sha = ?2 AND worktree_id = ?3
+            ORDER BY started_at DESC, id DESC
+            LIMIT 1
+            ",
+            params![tool.as_db_str(), commit_sha, worktree_id],
+            |row| row.get::<_, String>(0),
+        )
+        .ok();
+    Ok(version)
+}
+
 /// The single canonical scope predicate every `edge_oracle` metric read joins through: restrict the
 /// counted verdicts to those whose edge belongs to the active `(commit_sha, worktree_id)` checkout,
 /// via `edge_oracle -> edges -> files`. This is the SAME join `edge_join_candidates` /
@@ -309,4 +334,247 @@ pub(crate) fn count_edge_oracle_scoped(
         )?,
     };
     Ok(u64::try_from(count).unwrap_or(0))
+}
+
+/// The CURRENT-content predicate appended to [`EDGE_ORACLE_SCOPE_JOIN`] for any READ that surfaces
+/// a verdict in query output (the `Compiler` tier). A verdict is valid for display ONLY when the
+/// file it was computed against is unchanged — `edge_oracle.file_sha == files.sha256` for the
+/// edge's current source file. A drifted/changed file's `file_sha` differs, so the verdict is
+/// filtered out here and the edge reverts to heuristic display (`oracle-stale`), never `Compiler`.
+/// This is the read-side mirror of the run-time content-integrity gate (run.rs) and the staleness
+/// key `(file_sha, tool, tool_version)`.
+///
+/// (The eval/status COUNTS in [`count_edge_oracle_scoped`] deliberately do NOT apply this — they
+/// describe the persisted verdict population for precision/recall, which is content-addressed by
+/// the run, not the live display. Only the surfacing reads gate on currency.)
+pub(crate) const EDGE_ORACLE_CURRENT_PREDICATE: &str = " AND edge_oracle.file_sha = files.sha256";
+
+/// One current, in-scope oracle verdict for an edge, surfaced in graph/impact query output as the
+/// `Compiler` tier. `package` is the external dependency name for `resolved-external` verdicts
+/// (`scip_symbol`'s package component), `None` for in-corpus resolutions.
+#[derive(Debug, Clone)]
+pub(crate) struct EdgeOracleVerdict {
+    pub(crate) kind: OracleResolutionKind,
+    pub(crate) scip_symbol: String,
+    pub(crate) tool: OracleTool,
+    pub(crate) tool_version: String,
+}
+
+impl EdgeOracleVerdict {
+    /// The provenance string surfaced as `resolution_reason` when this verdict upgrades an edge to
+    /// the `Compiler` tier: `scip:<tool>@<version>` (the #61 design's reason format).
+    pub(crate) fn resolution_reason(&self) -> String {
+        format!("scip:{}@{}", self.tool.as_db_str(), self.tool_version)
+    }
+
+    /// `resolved-external(<package>)` when the oracle placed this callee in a dependency outside
+    /// the corpus, deriving `<package>` from the SCIP symbol's package component; `None` for
+    /// in-corpus verdicts. The display string surfaced in query output for
+    /// unresolved-but-externally-resolved edges.
+    pub(crate) fn resolved_external_label(&self) -> Option<String> {
+        if self.kind != OracleResolutionKind::ResolvedExternal {
+            return None;
+        }
+        let package = super::join::package_of(&self.scip_symbol)?;
+        Some(format!("resolved-external({package})"))
+    }
+}
+
+/// Fetch the CURRENT, in-scope oracle verdicts for a set of edge ids (the read-side join that
+/// surfaces the `Compiler` tier in `trace_callees` / `find_callers` / `impact_surface`). Scoped to
+/// the active `(commit_sha, worktree_id)` via [`EDGE_ORACLE_SCOPE_JOIN`] AND gated to current
+/// content via [`EDGE_ORACLE_CURRENT_PREDICATE`], so a drifted file's verdict is never returned
+/// (its edge reverts to heuristic display). Returns at most one row per edge id (PK
+/// `(edge_id, tool, tool_version)` and the single-tool scope).
+///
+/// SCOPE (load-bearing): this is the ONLY place a surfacing read of `edge_oracle` lives — it routes
+/// through the shared scope predicate so the checkout scope can't be dropped, exactly like the
+/// metric reads. Callers pass `edge_ids` already produced by the heuristic traversal (themselves
+/// scoped), so the returned verdicts are a subset, never an expansion.
+pub(crate) fn current_oracle_verdicts_for_edges(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+    edge_ids: &[i64],
+) -> anyhow::Result<std::collections::HashMap<i64, EdgeOracleVerdict>> {
+    let mut out = std::collections::HashMap::new();
+    if edge_ids.is_empty() {
+        return Ok(out);
+    }
+    // Bind the variable-length id list after the fixed ?1..?4 scope slots. Chunk to stay under
+    // SQLite's bound-variable limit on large traversals.
+    for chunk in edge_ids.chunks(900) {
+        let placeholders =
+            (0..chunk.len()).map(|i| format!("?{}", i + 5)).collect::<Vec<_>>().join(", ");
+        let sql = format!(
+            "SELECT edge_oracle.edge_id, edge_oracle.kind, edge_oracle.resolved_symbol_id, \
+             edge_oracle.scip_symbol{EDGE_ORACLE_SCOPE_JOIN}{EDGE_ORACLE_CURRENT_PREDICATE} AND \
+             edge_oracle.edge_id IN ({placeholders})"
+        );
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = vec![
+            Box::new(tool.as_db_str().to_string()),
+            Box::new(tool_version.to_string()),
+            Box::new(commit_sha.to_string()),
+            Box::new(worktree_id.to_string()),
+        ];
+        for id in chunk {
+            params.push(Box::new(*id));
+        }
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(rusqlite::params_from_iter(params.iter()), |row| {
+            let edge_id: i64 = row.get(0)?;
+            let kind: String = row.get(1)?;
+            let resolved_symbol_id: Option<i64> = row.get(2)?;
+            let scip_symbol: String = row.get(3)?;
+            Ok((edge_id, kind, resolved_symbol_id, scip_symbol))
+        })?;
+        for row in rows {
+            let (edge_id, kind, _resolved_symbol_id, scip_symbol) = row?;
+            let Some(kind) = OracleResolutionKind::from_db_str(&kind) else {
+                continue;
+            };
+            out.insert(edge_id, EdgeOracleVerdict {
+                kind,
+                scip_symbol,
+                tool,
+                tool_version: tool_version.to_string(),
+            });
+        }
+    }
+    Ok(out)
+}
+
+/// One row of the `compare_graph_to_scip` diagnostic: an edge and the SCIP verdict that
+/// contradicts / agrees with its heuristic resolution, with enough edge context to render the
+/// disagreement. The compare tool filters to `Contradict` kinds; the total it scans is every
+/// current verdict in scope.
+#[derive(Debug, Clone)]
+pub(crate) struct EdgeOracleComparison {
+    pub(crate) edge_id: i64,
+    pub(crate) kind: OracleResolutionKind,
+    pub(crate) edge_kind: String,
+    pub(crate) heuristic_confidence: String,
+    pub(crate) heuristic_target: Option<String>,
+    pub(crate) callee_name: Option<String>,
+    pub(crate) scip_symbol: String,
+    pub(crate) callsite_path: String,
+    pub(crate) callsite_line: i64,
+}
+
+/// Load every CURRENT, in-scope `edge_oracle` verdict joined to its edge's heuristic resolution —
+/// the data `compare_graph_to_scip` diffs (it keeps the `Contradict` rows). Scoped to the active
+/// `(commit_sha, worktree_id)` via [`EDGE_ORACLE_SCOPE_JOIN`] AND gated to current content via
+/// [`EDGE_ORACLE_CURRENT_PREDICATE`], so a drifted/dirty file's verdict is never reported as a
+/// disagreement (it reverted to heuristic display). The heuristic target's qualified name comes
+/// from the `to_symbols` join (the `edges.to_symbol_id` the heuristic picked).
+pub(crate) fn current_oracle_comparisons(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<Vec<EdgeOracleComparison>> {
+    // The heuristic target's qualified name is fetched via a correlated subquery rather than a
+    // trailing LEFT JOIN, so the shared `EDGE_ORACLE_SCOPE_JOIN` string (which already ends in a
+    // WHERE) stays the single source of the scope predicate — a JOIN can't legally follow a WHERE.
+    let sql = format!(
+        "SELECT edge_oracle.edge_id, edge_oracle.kind, edges.edge_kind, edges.confidence, (SELECT \
+         qualified_name FROM symbols WHERE symbols.id = edges.to_symbol_id), edges.to_name, \
+         edge_oracle.scip_symbol, files.path, COALESCE(NULLIF(edges.source_start_line, 0), 1) \
+         {EDGE_ORACLE_SCOPE_JOIN}{EDGE_ORACLE_CURRENT_PREDICATE} ORDER BY files.path, \
+         edges.source_start_line"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows =
+        stmt.query_map(params![tool.as_db_str(), tool_version, commit_sha, worktree_id], |row| {
+            let kind: String = row.get(1)?;
+            Ok((
+                row.get::<_, i64>(0)?,
+                kind,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, Option<String>>(5)?,
+                row.get::<_, String>(6)?,
+                row.get::<_, String>(7)?,
+                row.get::<_, i64>(8)?,
+            ))
+        })?;
+    let mut out = Vec::new();
+    for row in rows {
+        let (
+            edge_id,
+            kind,
+            edge_kind,
+            heuristic_confidence,
+            heuristic_target,
+            callee_name,
+            scip_symbol,
+            callsite_path,
+            callsite_line,
+        ) = row?;
+        let Some(kind) = OracleResolutionKind::from_db_str(&kind) else {
+            continue;
+        };
+        out.push(EdgeOracleComparison {
+            edge_id,
+            kind,
+            edge_kind,
+            heuristic_confidence,
+            heuristic_target,
+            callee_name,
+            scip_symbol,
+            callsite_path,
+            callsite_line,
+        });
+    }
+    Ok(out)
+}
+
+/// Prune `oracle_runs` rows whose `(commit_sha, worktree_id)` is NOT live — the gc companion to the
+/// `edge_oracle` FK cascade (which already drops verdict rows when their edges are deleted). Unlike
+/// `edge_oracle`, `oracle_runs` is keyed by `(commit_sha, worktree_id)` directly, not by an edge,
+/// so nothing cascades it; a dead checkout's run rows would otherwise linger after gc drops its
+/// edges/files. Refuses to prune when both live sets are empty (mirrors `prune_to_live`), so a
+/// missing live set never wipes all run history. Returns the number of rows deleted.
+///
+/// A run survives iff its commit is live OR its worktree overlay is live — the SAME survival rule
+/// `prune_to_live` applies to `files`, so a run and the edges it produced are pruned together.
+pub(crate) fn prune_oracle_runs_outside_scope(
+    conn: &Connection,
+    live_commits: &[String],
+    live_worktrees: &[String],
+) -> anyhow::Result<u64> {
+    if live_commits.is_empty() && live_worktrees.is_empty() {
+        return Ok(0);
+    }
+    let commit_list = sql_quoted_list(live_commits);
+    let worktree_list = sql_quoted_list(live_worktrees);
+    let deleted = conn.execute(
+        &format!(
+            "DELETE FROM oracle_runs
+             WHERE commit_sha NOT IN ({commit_list})
+               AND worktree_id NOT IN ({worktree_list})"
+        ),
+        [],
+    )?;
+    Ok(u64::try_from(deleted).unwrap_or(0))
+}
+
+/// Render a slice of strings as a SQL `IN (...)` value list with single-quote escaping. Inputs are
+/// commit shas / worktree ids (hex / path-derived), never user free-text, but we escape `'` anyway
+/// so the list can't break the statement. An empty slice yields `''` (a value nothing matches),
+/// which is correct: `prune_oracle_runs_outside_scope` only reaches here when at least one of the
+/// two lists is non-empty, and a row survives if EITHER its commit or its worktree is live.
+fn sql_quoted_list(values: &[String]) -> String {
+    if values.is_empty() {
+        return "''".to_string();
+    }
+    values
+        .iter()
+        .map(|value| format!("'{}'", value.replace('\'', "''")))
+        .collect::<Vec<_>>()
+        .join(", ")
 }

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -10,6 +10,28 @@ use rusqlite::{Connection, params};
 use super::{OracleResolutionKind, OracleTool};
 use crate::index::now_ms;
 
+/// Render the **active-checkout** `files` predicate for an oracle scope read/write, binding the
+/// commit-sha at SQL param `sha_param` and the worktree-id at `wt_param`. This is the SINGLE source
+/// of the index's real checkout semantics for the oracle — the same rule
+/// `rebuild.rs::clear_full_rebuild_tables` stages file ids by, expressed inline so any
+/// `files`-anchored oracle query can `AND` it in.
+///
+/// SCOPE (load-bearing, #82 P0): a production `files` row carries EITHER `(commit_sha, '')` (clean,
+/// `FileScope::commit`) OR `('', worktree_id)` (dirty overlay, `FileScope::worktree`) — NEVER both
+/// (see `index/mod.rs::FileScope`, `incremental.rs::assign_file_scopes`). The old predicate
+/// `files.commit_sha = ?sha AND files.worktree_id = ?wt` with BOTH non-empty therefore matched ZERO
+/// rows on any real git checkout, silently writing 0 verdicts. A row is in the active checkout iff
+/// the dirty overlay claims it (`worktree_id = wt`, overlay wins) OR the committed row does
+/// (`commit_sha = sha`) AND no dirty overlay shadows that path. Both halves guard against the empty
+/// sentinel so a non-git index (`commit_sha = ''`) doesn't degenerate into "every row matches".
+pub(crate) fn active_checkout_file_predicate(sha_param: &str, wt_param: &str) -> String {
+    format!(
+        "((files.worktree_id = {wt_param} AND files.worktree_id != '') OR (files.commit_sha = \
+         {sha_param} AND files.commit_sha != '' AND files.path NOT IN (SELECT path FROM files \
+         WHERE worktree_id = {wt_param} AND worktree_id != '')))"
+    )
+}
+
 /// An edge candidate to feed the oracle join: the callee identifier byte range (the SCIP key, #67)
 /// plus enough context to write a verdict and to recognise agreement/disagreement.
 #[derive(Debug, Clone)]
@@ -53,7 +75,7 @@ pub(crate) fn edge_join_candidates(
     commit_sha: &str,
     worktree_id: &str,
 ) -> anyhow::Result<Vec<EdgeJoinCandidate>> {
-    let mut stmt = conn.prepare(
+    let mut stmt = conn.prepare(&format!(
         "
         SELECT edges.id,
                files.path,
@@ -67,11 +89,11 @@ pub(crate) fn edge_join_candidates(
         JOIN files ON files.id = edges.source_file_id
         WHERE edges.callee_start_byte IS NOT NULL
           AND edges.callee_end_byte IS NOT NULL
-          AND files.commit_sha = ?1
-          AND files.worktree_id = ?2
+          AND {scope}
         ORDER BY files.path, edges.callee_start_byte
         ",
-    )?;
+        scope = active_checkout_file_predicate("?1", "?2"),
+    ))?;
     let rows = stmt.query_map(params![commit_sha, worktree_id], |row| {
         Ok(EdgeJoinCandidate {
             edge_id: row.get(0)?,
@@ -99,17 +121,17 @@ pub(crate) fn symbol_spans_for_path(
     commit_sha: &str,
     worktree_id: &str,
 ) -> anyhow::Result<Vec<SymbolSpan>> {
-    let mut stmt = conn.prepare(
+    let mut stmt = conn.prepare(&format!(
         "
         SELECT symbols.id, symbols.start_byte, symbols.end_byte
         FROM symbols
         JOIN files ON files.id = symbols.file_id
         WHERE files.path = ?1
-          AND files.commit_sha = ?2
-          AND files.worktree_id = ?3
+          AND {scope}
         ORDER BY symbols.start_byte
         ",
-    )?;
+        scope = active_checkout_file_predicate("?2", "?3"),
+    ))?;
     let rows = stmt.query_map(params![path, commit_sha, worktree_id], |row| {
         Ok(SymbolSpan { symbol_id: row.get(0)?, start_byte: row.get(1)?, end_byte: row.get(2)? })
     })?;
@@ -142,9 +164,10 @@ pub(crate) fn indexed_paths_in_scope(
     // longer indexed, so an occurrence whose call site is that path can never be covered by an edge
     // candidate (`edge_join_candidates` won't emit one) — counting it would falsely inflate the
     // recall gap. The deleted row must NOT count as "indexed in scope".
-    let mut stmt = conn.prepare(
-        "SELECT path FROM files WHERE commit_sha = ?1 AND worktree_id = ?2 AND kind != 'deleted'",
-    )?;
+    let mut stmt = conn.prepare(&format!(
+        "SELECT path FROM files WHERE {scope} AND kind != 'deleted'",
+        scope = active_checkout_file_predicate("?1", "?2"),
+    ))?;
     let rows = stmt.query_map(params![commit_sha, worktree_id], |row| row.get::<_, String>(0))?;
     let mut out = std::collections::HashSet::new();
     for row in rows {
@@ -173,16 +196,19 @@ pub(crate) fn clear_edge_oracle_for_tool(
     worktree_id: &str,
 ) -> anyhow::Result<()> {
     conn.execute(
-        "
+        &format!(
+            "
         DELETE FROM edge_oracle
         WHERE tool = ?1 AND tool_version = ?2
           AND edge_id IN (
             SELECT edges.id
             FROM edges
             JOIN files ON files.id = edges.source_file_id
-            WHERE files.commit_sha = ?3 AND files.worktree_id = ?4
+            WHERE {scope}
           )
         ",
+            scope = active_checkout_file_predicate("?3", "?4"),
+        ),
         params![tool.as_db_str(), tool_version, commit_sha, worktree_id],
     )?;
     Ok(())
@@ -302,12 +328,23 @@ pub(crate) fn latest_run_tool_version(
 /// scope — a global `WHERE tool = ? AND tool_version = ?` count mixes another worktree's verdicts
 /// into this checkout's precision/recall (the round-3 Codex finding on `verdict_counts`). The
 /// `?1..?4` bind slots are always `(tool, tool_version, commit_sha, worktree_id)`.
-pub(crate) const EDGE_ORACLE_SCOPE_JOIN: &str = "
+///
+/// Returns a `String` (not a `const`) because the active-checkout file predicate
+/// ([`active_checkout_file_predicate`]) is an OR-of-overlay-vs-committed expression, not a fixed
+/// `AND` — #82 P0. Slots `?3`/`?4` (commit_sha / worktree_id) flow into it; `?1`/`?2`
+/// (tool / version) gate the side table. Callers append ` AND <extra>` exactly as before — the
+/// statement still ends in a trailing `WHERE`, so a JOIN can't legally follow.
+pub(crate) fn edge_oracle_scope_join() -> String {
+    format!(
+        "
     FROM edge_oracle
     JOIN edges ON edges.id = edge_oracle.edge_id
     JOIN files ON files.id = edges.source_file_id
     WHERE edge_oracle.tool = ?1 AND edge_oracle.tool_version = ?2
-      AND files.commit_sha = ?3 AND files.worktree_id = ?4";
+      AND {scope}",
+        scope = active_checkout_file_predicate("?3", "?4"),
+    )
+}
 
 /// Count `edge_oracle` rows for `(tool, tool_version)` **within the active checkout**, optionally
 /// filtered to a single `kind`. The one scoped count helper behind both the total and the per-kind
@@ -321,14 +358,15 @@ pub(crate) fn count_edge_oracle_scoped(
     worktree_id: &str,
     kind: Option<OracleResolutionKind>,
 ) -> anyhow::Result<u64> {
+    let scope_join = edge_oracle_scope_join();
     let count: i64 = match kind {
         Some(kind) => conn.query_row(
-            &format!("SELECT COUNT(*){EDGE_ORACLE_SCOPE_JOIN} AND edge_oracle.kind = ?5"),
+            &format!("SELECT COUNT(*){scope_join} AND edge_oracle.kind = ?5"),
             params![tool.as_db_str(), tool_version, commit_sha, worktree_id, kind.as_db_str()],
             |row| row.get(0),
         )?,
         None => conn.query_row(
-            &format!("SELECT COUNT(*){EDGE_ORACLE_SCOPE_JOIN}"),
+            &format!("SELECT COUNT(*){scope_join}"),
             params![tool.as_db_str(), tool_version, commit_sha, worktree_id],
             |row| row.get(0),
         )?,
@@ -343,14 +381,22 @@ pub(crate) fn count_edge_oracle_scoped(
 ///    current source file. A drifted/changed callsite's `file_sha` differs, so the verdict is
 ///    filtered out and the edge reverts to heuristic display (`oracle-stale`), never `Compiler`.
 /// 2. **The resolved definition is unchanged** (in-corpus verdicts only) — the resolved symbol
-///    `edge_oracle.resolved_symbol_id` STILL EXISTS in the active scope. The callsite gate (1)
-///    alone misses *definition* drift: an `Upgrade`/`Confirm` keeps surfacing after the resolved
-///    *def* file changed or its symbol was deleted/reinserted, because the callsite file is
-///    untouched so its sha still matches (#82 finding 3). Since `symbols.id` is AUTOINCREMENT,
+///    `edge_oracle.resolved_symbol_id` STILL EXISTS **in the active checkout scope**. The callsite
+///    gate (1) alone misses *definition* drift: an `Upgrade`/`Confirm` keeps surfacing after the
+///    resolved *def* file changed or its symbol was deleted/reinserted, because the callsite file
+///    is untouched so its sha still matches (#82 finding 3). Since `symbols.id` is AUTOINCREMENT,
 ///    reindexing the def file mints NEW ids and the old `resolved_symbol_id` dangles — so an
 ///    `EXISTS` against `symbols.id` reverts the verdict to heuristic the moment the def file is
 ///    reindexed. `resolved-external` verdicts (`resolved_symbol_id IS NULL`) skip this clause —
 ///    there is no in-corpus def to drift.
+///
+///    SCOPE (load-bearing, #82 P2): the EXISTS must join `symbols -> files` and apply the
+///    active-checkout predicate, NOT check the RAW `symbols` table. A dirty def file makes the
+///    indexer insert a worktree-scoped symbol row while leaving the old commit-scoped symbols
+///    shadowed-but-present — so a raw `EXISTS (symbols.id = resolved_symbol_id)` still finds the
+///    stale id and keeps surfacing a `Compiler` verdict pointing at the pre-edit target (the
+///    callsite sha is unchanged). Scoping the EXISTS to the active checkout means a shadowed
+///    commit-scoped def no longer counts, so the verdict reverts to heuristic.
 ///
 /// This is the read-side mirror of the run-time content-integrity gate (run.rs) and the staleness
 /// key `(file_sha, tool, tool_version)`.
@@ -358,9 +404,18 @@ pub(crate) fn count_edge_oracle_scoped(
 /// (The eval/status COUNTS in [`count_edge_oracle_scoped`] deliberately do NOT apply this — they
 /// describe the persisted verdict population for precision/recall, which is content-addressed by
 /// the run, not the live display. Only the surfacing reads gate on currency.)
-pub(crate) const EDGE_ORACLE_CURRENT_PREDICATE: &str =
-    " AND edge_oracle.file_sha = files.sha256 AND (edge_oracle.resolved_symbol_id IS NULL OR \
-     EXISTS (SELECT 1 FROM symbols WHERE symbols.id = edge_oracle.resolved_symbol_id))";
+///
+/// Returns a `String` (not a `const`) because the scope-aware EXISTS embeds
+/// [`active_checkout_file_predicate`] (`?3`/`?4`). The leading space + `AND` are kept so it appends
+/// cleanly after [`edge_oracle_scope_join`]'s trailing `WHERE`.
+pub(crate) fn edge_oracle_current_predicate() -> String {
+    format!(
+        " AND edge_oracle.file_sha = files.sha256 AND (edge_oracle.resolved_symbol_id IS NULL OR \
+         EXISTS (SELECT 1 FROM symbols JOIN files ON files.id = symbols.file_id WHERE symbols.id \
+         = edge_oracle.resolved_symbol_id AND {scope}))",
+        scope = active_checkout_file_predicate("?3", "?4"),
+    )
+}
 
 /// One current, in-scope oracle verdict for an edge, surfaced in graph/impact query output as the
 /// `Compiler` tier. `package` is the external dependency name for `resolved-external` verdicts
@@ -438,9 +493,10 @@ pub(crate) fn current_oracle_verdicts_for_edges(
         let sql = format!(
             "SELECT edge_oracle.edge_id, edge_oracle.kind, edge_oracle.resolved_symbol_id, \
              (SELECT qualified_name FROM symbols WHERE symbols.id = \
-             edge_oracle.resolved_symbol_id), \
-             edge_oracle.scip_symbol{EDGE_ORACLE_SCOPE_JOIN}{EDGE_ORACLE_CURRENT_PREDICATE} AND \
-             edge_oracle.edge_id IN ({placeholders})"
+             edge_oracle.resolved_symbol_id), edge_oracle.scip_symbol{scope_join}{current} AND \
+             edge_oracle.edge_id IN ({placeholders})",
+            scope_join = edge_oracle_scope_join(),
+            current = edge_oracle_current_predicate(),
         );
         let mut params: Vec<Box<dyn rusqlite::ToSql>> = vec![
             Box::new(tool.as_db_str().to_string()),
@@ -524,9 +580,10 @@ pub(crate) fn current_oracle_comparisons(
         "SELECT edge_oracle.edge_id, edge_oracle.kind, edges.edge_kind, edges.confidence, (SELECT \
          qualified_name FROM symbols WHERE symbols.id = edges.to_symbol_id), edges.to_name, \
          edge_oracle.resolved_symbol_id, edge_oracle.scip_symbol, files.path, \
-         COALESCE(NULLIF(edges.source_start_line, 0), 1) \
-         {EDGE_ORACLE_SCOPE_JOIN}{EDGE_ORACLE_CURRENT_PREDICATE} ORDER BY files.path, \
-         edges.source_start_line"
+         COALESCE(NULLIF(edges.source_start_line, 0), 1) {scope_join}{current} ORDER BY \
+         files.path, edges.source_start_line",
+        scope_join = edge_oracle_scope_join(),
+        current = edge_oracle_current_predicate(),
     );
     let mut stmt = conn.prepare(&sql)?;
     let rows =

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -2220,18 +2220,36 @@ fn name_only_recovery_rate_excludes_exact_upgrades() {
 
 /// Seed one edge with a written verdict and return `(harness, edge_id, file_sha)`. The verdict's
 /// `file_sha` matches the file's recorded sha (current), so it surfaces; tests that want staleness
-/// drift the edge's file sha afterward.
+/// drift the edge's file sha afterward. When `in_corpus` is set, a real `target` symbol is inserted
+/// and the verdict resolves to its id — so the def-drift gate (`resolved_symbol_id` must still
+/// EXIST in `symbols`) is satisfied for current verdicts. `None` (external) verdicts skip that
+/// gate.
 fn seed_verdict(
     kind: OracleResolutionKind,
     scip_symbol: &str,
-    resolved_symbol_id: Option<i64>,
+    in_corpus: bool,
 ) -> (Harness, i64, String) {
+    let (h, edge, file_sha, _resolved) = seed_verdict_full(kind, scip_symbol, in_corpus);
+    (h, edge, file_sha)
+}
+
+/// Like [`seed_verdict`] but also returns the in-corpus `resolved_symbol_id` (when any), so a test
+/// can delete/reindex that definition symbol and assert the verdict stops surfacing (#82 finding
+/// 3).
+fn seed_verdict_full(
+    kind: OracleResolutionKind,
+    scip_symbol: &str,
+    in_corpus: bool,
+) -> (Harness, i64, String, Option<i64>) {
     let h = Harness::new();
     let f = h.add_file("a.rs", "fn caller() { target(); }\n");
     let file_sha: String = h
         .conn
         .query_row("SELECT sha256 FROM files WHERE id = ?1", params![f], |r| r.get(0))
         .unwrap();
+    // An in-corpus resolution must point at a symbol that EXISTS — the def-drift gate in
+    // `EDGE_ORACLE_CURRENT_PREDICATE` filters a dangling `resolved_symbol_id`.
+    let resolved_symbol_id = in_corpus.then(|| h.add_symbol(f, "target", 3, 9));
     let edge = h.add_edge(f, "target", 14, 20, "NameOnly", None);
     store::write_edge_oracle(&h.conn, TOOL, VERSION, &EdgeOracleRow {
         edge_id: edge,
@@ -2241,15 +2259,14 @@ fn seed_verdict(
         kind,
     })
     .unwrap();
-    (h, edge, file_sha)
+    (h, edge, file_sha, resolved_symbol_id)
 }
 
 /// A CURRENT verdict (its `file_sha` matches `files.sha256`) is returned by the surfacing read —
 /// the `Compiler` tier data.
 #[test]
 fn current_verdict_is_surfaced_for_edge() {
-    let (h, edge, _sha) =
-        seed_verdict(OracleResolutionKind::Upgrade, "scip x `target`().", Some(1));
+    let (h, edge, _sha) = seed_verdict(OracleResolutionKind::Upgrade, "scip x `target`().", true);
     let verdicts =
         store::current_oracle_verdicts_for_edges(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &[edge])
             .unwrap();
@@ -2262,8 +2279,7 @@ fn current_verdict_is_surfaced_for_edge() {
 /// The surfacing read excludes it — the edge reverts to heuristic display, never `Compiler`.
 #[test]
 fn drifted_file_verdict_is_not_surfaced() {
-    let (h, edge, _sha) =
-        seed_verdict(OracleResolutionKind::Upgrade, "scip x `target`().", Some(1));
+    let (h, edge, _sha) = seed_verdict(OracleResolutionKind::Upgrade, "scip x `target`().", true);
     // The file's content changed since the verdict was computed: its sha now differs from
     // `edge_oracle.file_sha`, so the current-content predicate filters the verdict out.
     h.conn.execute("UPDATE files SET sha256 = 'drifted-sha' WHERE path = 'a.rs'", []).unwrap();
@@ -2273,13 +2289,36 @@ fn drifted_file_verdict_is_not_surfaced() {
     assert!(verdicts.is_empty(), "a drifted file's verdict must not surface as Compiler");
 }
 
+/// Def-drift revert (#82 finding 3): an in-corpus verdict keeps its callsite file unchanged (so the
+/// `file_sha` gate still matches), but its resolved DEFINITION symbol is deleted/reinserted by
+/// incremental reindexing — the old `resolved_symbol_id` dangles. The surfacing read must drop the
+/// verdict (the def the compiler resolved to no longer exists), reverting to heuristic display.
+#[test]
+fn resolved_def_drift_verdict_is_not_surfaced() {
+    let (h, edge, _sha, resolved) =
+        seed_verdict_full(OracleResolutionKind::Upgrade, "scip x `target`().", true);
+    let resolved = resolved.expect("in-corpus verdict has a resolved symbol id");
+    // Sanity: while the resolved def symbol exists, the verdict surfaces.
+    let before =
+        store::current_oracle_verdicts_for_edges(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &[edge])
+            .unwrap();
+    assert!(before.contains_key(&edge), "current in-corpus verdict surfaces before def drift");
+    // The def file was reindexed: AUTOINCREMENT mints new ids, so the old resolved symbol id is
+    // gone. Model that by deleting the resolved symbol row.
+    h.conn.execute("DELETE FROM symbols WHERE id = ?1", params![resolved]).unwrap();
+    let after =
+        store::current_oracle_verdicts_for_edges(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &[edge])
+            .unwrap();
+    assert!(after.is_empty(), "a verdict whose resolved definition drifted must not surface");
+}
+
 /// Dirty/overlay (uncommitted) edges never surface `Compiler`: an edge whose file lives in a
 /// different `(commit_sha, worktree_id)` scope than the active checkout is out of the scope join,
 /// so its verdict is never returned for the active checkout. (Models the overlay edge — the
 /// compiler hasn't seen the uncommitted edit; the oracle row binds to commit-scoped rows only.)
 #[test]
 fn out_of_scope_verdict_is_not_surfaced() {
-    let (h, edge, sha) = seed_verdict(OracleResolutionKind::Upgrade, "scip x `target`().", Some(1));
+    let (h, edge, sha) = seed_verdict(OracleResolutionKind::Upgrade, "scip x `target`().", true);
     // Query the SAME edge under a sibling worktree scope: the scope join excludes it.
     let verdicts = store::current_oracle_verdicts_for_edges(
         &h.conn,
@@ -2301,7 +2340,7 @@ fn resolved_external_label_surfaces_package() {
     let (h, edge, _sha) = seed_verdict(
         OracleResolutionKind::ResolvedExternal,
         "scip-rust cargo tokio 1.0 `spawn`().",
-        None,
+        false,
     );
     let verdicts =
         store::current_oracle_verdicts_for_edges(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &[edge])

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -2210,3 +2210,190 @@ fn name_only_recovery_rate_excludes_exact_upgrades() {
     );
     assert!((m.name_only_recovery_rate - 1.0).abs() < 1e-9);
 }
+
+// ---------------------------------------------------------------------------
+// Phase 2 (#69): read-side surfacing helpers — `Compiler` tier, staleness/dirty
+// revert, `resolved-external`, `compare_graph_to_scip` data, and gc pruning of
+// `oracle_runs`. All deterministic against the synthetic harness conn (no
+// rust-analyzer, no `.scip` subprocess).
+// ---------------------------------------------------------------------------
+
+/// Seed one edge with a written verdict and return `(harness, edge_id, file_sha)`. The verdict's
+/// `file_sha` matches the file's recorded sha (current), so it surfaces; tests that want staleness
+/// drift the edge's file sha afterward.
+fn seed_verdict(
+    kind: OracleResolutionKind,
+    scip_symbol: &str,
+    resolved_symbol_id: Option<i64>,
+) -> (Harness, i64, String) {
+    let h = Harness::new();
+    let f = h.add_file("a.rs", "fn caller() { target(); }\n");
+    let file_sha: String = h
+        .conn
+        .query_row("SELECT sha256 FROM files WHERE id = ?1", params![f], |r| r.get(0))
+        .unwrap();
+    let edge = h.add_edge(f, "target", 14, 20, "NameOnly", None);
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &EdgeOracleRow {
+        edge_id: edge,
+        file_sha: &file_sha,
+        resolved_symbol_id,
+        scip_symbol,
+        kind,
+    })
+    .unwrap();
+    (h, edge, file_sha)
+}
+
+/// A CURRENT verdict (its `file_sha` matches `files.sha256`) is returned by the surfacing read —
+/// the `Compiler` tier data.
+#[test]
+fn current_verdict_is_surfaced_for_edge() {
+    let (h, edge, _sha) =
+        seed_verdict(OracleResolutionKind::Upgrade, "scip x `target`().", Some(1));
+    let verdicts =
+        store::current_oracle_verdicts_for_edges(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &[edge])
+            .unwrap();
+    let verdict = verdicts.get(&edge).expect("current verdict surfaced");
+    assert_eq!(verdict.kind, OracleResolutionKind::Upgrade);
+    assert_eq!(verdict.resolution_reason(), format!("scip:{}@{VERSION}", TOOL.as_db_str()));
+}
+
+/// Staleness revert: drift the edge's file sha so it no longer matches the verdict's `file_sha`.
+/// The surfacing read excludes it — the edge reverts to heuristic display, never `Compiler`.
+#[test]
+fn drifted_file_verdict_is_not_surfaced() {
+    let (h, edge, _sha) =
+        seed_verdict(OracleResolutionKind::Upgrade, "scip x `target`().", Some(1));
+    // The file's content changed since the verdict was computed: its sha now differs from
+    // `edge_oracle.file_sha`, so the current-content predicate filters the verdict out.
+    h.conn.execute("UPDATE files SET sha256 = 'drifted-sha' WHERE path = 'a.rs'", []).unwrap();
+    let verdicts =
+        store::current_oracle_verdicts_for_edges(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &[edge])
+            .unwrap();
+    assert!(verdicts.is_empty(), "a drifted file's verdict must not surface as Compiler");
+}
+
+/// Dirty/overlay (uncommitted) edges never surface `Compiler`: an edge whose file lives in a
+/// different `(commit_sha, worktree_id)` scope than the active checkout is out of the scope join,
+/// so its verdict is never returned for the active checkout. (Models the overlay edge — the
+/// compiler hasn't seen the uncommitted edit; the oracle row binds to commit-scoped rows only.)
+#[test]
+fn out_of_scope_verdict_is_not_surfaced() {
+    let (h, edge, sha) = seed_verdict(OracleResolutionKind::Upgrade, "scip x `target`().", Some(1));
+    // Query the SAME edge under a sibling worktree scope: the scope join excludes it.
+    let verdicts = store::current_oracle_verdicts_for_edges(
+        &h.conn,
+        TOOL,
+        VERSION,
+        COMMIT,
+        "other-worktree",
+        &[edge],
+    )
+    .unwrap();
+    assert!(verdicts.is_empty(), "a verdict outside the active checkout must not surface");
+    let _ = sha;
+}
+
+/// A `resolved-external` verdict surfaces a `resolved-external(<package>)` label derived from the
+/// SCIP symbol's package component.
+#[test]
+fn resolved_external_label_surfaces_package() {
+    let (h, edge, _sha) = seed_verdict(
+        OracleResolutionKind::ResolvedExternal,
+        "scip-rust cargo tokio 1.0 `spawn`().",
+        None,
+    );
+    let verdicts =
+        store::current_oracle_verdicts_for_edges(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &[edge])
+            .unwrap();
+    let verdict = verdicts.get(&edge).expect("verdict surfaced");
+    assert_eq!(verdict.resolved_external_label().as_deref(), Some("resolved-external(tokio)"));
+}
+
+/// `current_oracle_comparisons` returns CURRENT, in-scope verdicts joined to the heuristic edge —
+/// the `compare_graph_to_scip` data. A `Contradict` verdict appears with its scip symbol; a drifted
+/// row does not.
+#[test]
+fn comparisons_return_current_contradictions_only() {
+    let h = Harness::new();
+    let f = h.add_file("a.rs", "fn caller() { target(); }\n");
+    let sha: String = h
+        .conn
+        .query_row("SELECT sha256 FROM files WHERE id = ?1", params![f], |r| r.get(0))
+        .unwrap();
+    let target = h.add_symbol(f, "target", 3, 9);
+    // An Exact edge the heuristic resolved to `target`; the oracle CONTRADICTS it (points
+    // elsewhere).
+    let edge = h.add_edge(f, "target", 14, 20, "Exact", Some(target));
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &EdgeOracleRow {
+        edge_id: edge,
+        file_sha: &sha,
+        resolved_symbol_id: None,
+        scip_symbol: "scip-rust cargo other 1.0 `target`().",
+        kind: OracleResolutionKind::Contradict,
+    })
+    .unwrap();
+
+    let comparisons =
+        store::current_oracle_comparisons(&h.conn, TOOL, VERSION, COMMIT, WORKTREE).unwrap();
+    assert_eq!(comparisons.len(), 1);
+    let c = &comparisons[0];
+    assert_eq!(c.kind, OracleResolutionKind::Contradict);
+    assert_eq!(c.edge_id, edge);
+    assert_eq!(c.heuristic_confidence, "Exact");
+    assert_eq!(c.scip_symbol, "scip-rust cargo other 1.0 `target`().");
+
+    // Drift the file → the comparison drops out (no stale contradiction surfaced).
+    h.conn.execute("UPDATE files SET sha256 = 'drift' WHERE id = ?1", params![f]).unwrap();
+    let after =
+        store::current_oracle_comparisons(&h.conn, TOOL, VERSION, COMMIT, WORKTREE).unwrap();
+    assert!(after.is_empty(), "a drifted file's contradiction must not surface");
+}
+
+/// `latest_run_tool_version` returns the most recent run's version for the active checkout, and
+/// `None` when there is no run.
+#[test]
+fn latest_run_tool_version_tracks_active_checkout() {
+    let h = Harness::new();
+    assert_eq!(store::latest_run_tool_version(&h.conn, TOOL, COMMIT, WORKTREE).unwrap(), None);
+    store::record_oracle_run(&h.conn, TOOL, "v1", COMMIT, WORKTREE, "Completed", "{}").unwrap();
+    store::record_oracle_run(&h.conn, TOOL, "v2", COMMIT, WORKTREE, "Completed", "{}").unwrap();
+    assert_eq!(
+        store::latest_run_tool_version(&h.conn, TOOL, COMMIT, WORKTREE).unwrap().as_deref(),
+        Some("v2")
+    );
+    // A sibling worktree's run does not leak in.
+    store::record_oracle_run(&h.conn, TOOL, "v3", COMMIT, "other", "Completed", "{}").unwrap();
+    assert_eq!(
+        store::latest_run_tool_version(&h.conn, TOOL, COMMIT, WORKTREE).unwrap().as_deref(),
+        Some("v2")
+    );
+}
+
+/// gc: `prune_oracle_runs_outside_scope` drops runs whose `(commit, worktree)` is dead, keeps live
+/// ones, and refuses to prune when both live sets are empty (so a missing live set never wipes all
+/// run history).
+#[test]
+fn prune_oracle_runs_drops_dead_contexts_only() {
+    let h = Harness::new();
+    store::record_oracle_run(&h.conn, TOOL, "v1", "live-commit", "live-wt", "Completed", "{}")
+        .unwrap();
+    store::record_oracle_run(&h.conn, TOOL, "v1", "dead-commit", "dead-wt", "Completed", "{}")
+        .unwrap();
+    // A run whose commit is dead but whose worktree overlay is live survives (OR rule).
+    store::record_oracle_run(&h.conn, TOOL, "v1", "dead-commit", "live-wt", "Completed", "{}")
+        .unwrap();
+
+    let live_commits = vec!["live-commit".to_string()];
+    let live_worktrees = vec!["live-wt".to_string()];
+
+    // Empty live sets are a no-op (never wipe everything).
+    assert_eq!(store::prune_oracle_runs_outside_scope(&h.conn, &[], &[]).unwrap(), 0);
+
+    let deleted =
+        store::prune_oracle_runs_outside_scope(&h.conn, &live_commits, &live_worktrees).unwrap();
+    assert_eq!(deleted, 1, "only the (dead-commit, dead-wt) run is pruned");
+    let remaining: i64 =
+        h.conn.query_row("SELECT COUNT(*) FROM oracle_runs", [], |r| r.get(0)).unwrap();
+    assert_eq!(remaining, 2);
+}

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -275,7 +275,7 @@ fn def_inside_corpus_upgrades_unresolved_edge() {
     });
     let bytes = full.write_to_bytes().unwrap();
 
-    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
 
     let (kind, resolved, _scip) = h.verdict(edge).expect("verdict written");
     assert_eq!(kind, OracleResolutionKind::Upgrade.as_db_str());
@@ -297,7 +297,7 @@ fn def_outside_corpus_resolves_external() {
         occurrence(0, 14, 19, external, SymbolRole::UnspecifiedSymbolRole as i32),
     ]);
 
-    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
 
     let (kind, resolved, scip) = h.verdict(edge).expect("verdict written");
     assert_eq!(kind, OracleResolutionKind::ResolvedExternal.as_db_str());
@@ -371,7 +371,7 @@ fn non_ascii_identifier_resolves_under_both_encodings() {
         });
         let bytes = index.write_to_bytes().unwrap();
 
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
 
         let (kind, resolved, _) =
             h.verdict(edge).unwrap_or_else(|| panic!("verdict written for encoding {encoding:?}"));
@@ -396,7 +396,7 @@ fn local_symbols_are_skipped() {
         occurrence(0, 14, 20, "local 0", SymbolRole::UnspecifiedSymbolRole as i32),
     ]);
 
-    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
 
     assert!(h.verdict(edge).is_none(), "local symbol must not produce a verdict");
 }
@@ -441,7 +441,7 @@ fn exact_edge_contradiction_recorded_not_applied() {
     });
     let bytes = index.write_to_bytes().unwrap();
 
-    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
 
     let (kind, resolved, _) = h.verdict(edge).expect("verdict written");
     assert_eq!(kind, OracleResolutionKind::Contradict.as_db_str());
@@ -485,7 +485,8 @@ fn exact_edge_agreement_recorded_as_confirm() {
     });
     let bytes = index.write_to_bytes().unwrap();
 
-    let report = run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+    let report =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
 
     let (kind, resolved, _) = h.verdict(edge).expect("verdict written");
     assert_eq!(kind, OracleResolutionKind::Confirm.as_db_str());
@@ -848,7 +849,8 @@ fn run_with_empty_scip_completes_with_no_verdicts() {
     let edge = h.add_edge(caller, "target", 14, 20, "NameOnly", None);
 
     let empty = Index::default().write_to_bytes().unwrap();
-    let report = run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &empty, h.root()).unwrap();
+    let report =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &empty, h.root(), None).unwrap();
 
     assert_eq!(report.edges_examined, 1);
     assert_eq!(report.no_occurrence, 1, "no document → no occurrence bucket");
@@ -880,7 +882,8 @@ fn candidate_outside_any_occurrence_counts_no_occurrence() {
         ),
     ]);
 
-    let report = run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+    let report =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
     assert_eq!(report.edges_examined, 1);
     assert_eq!(report.no_occurrence, 1);
     assert_eq!(report.rows_written, 0);
@@ -922,7 +925,8 @@ fn run_aggregates_counts_and_recall_gap() {
     });
     let bytes = index.write_to_bytes().unwrap();
 
-    let report = run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+    let report =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
     assert_eq!(report.edges_examined, 1);
     assert_eq!(report.upgraded, 1);
     assert_eq!(report.rows_written, 1);
@@ -963,7 +967,7 @@ fn rerun_clears_stale_verdict_for_dropped_edge() {
         ..Default::default()
     });
     let bytes = index.write_to_bytes().unwrap();
-    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
     assert_eq!(
         h.verdict(edge).map(|(k, _, _)| k).as_deref(),
         Some("upgrade"),
@@ -982,7 +986,7 @@ fn rerun_clears_stale_verdict_for_dropped_edge() {
                 SymbolRole::UnspecifiedSymbolRole as i32,
             ),
         ]);
-    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &empty_doc, h.root()).unwrap();
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &empty_doc, h.root(), None).unwrap();
 
     assert!(h.verdict(edge).is_none(), "the dropped edge's stale verdict was cleared on rerun");
     let total: i64 =
@@ -1030,7 +1034,8 @@ fn recall_gap_counts_only_call_like_occurrences() {
         ..Default::default()
     };
     let bytes = index.write_to_bytes().unwrap();
-    let report = run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+    let report =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
 
     // Only the one uncovered callable reference is the recall gap; the import + type ref are not.
     assert_eq!(report.oracle_only_calls, 1, "only the call-like uncovered reference counts");
@@ -1598,7 +1603,7 @@ fn recall_gap_excludes_definitions_in_unindexed_files() {
             ..Default::default()
         });
         let bytes = index.write_to_bytes().unwrap();
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root())
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None)
             .unwrap()
             .oracle_only_calls
     };
@@ -1657,7 +1662,7 @@ fn recall_gap_excludes_occurrences_in_unindexed_source_files() {
             ..Default::default()
         });
         let bytes = index.write_to_bytes().unwrap();
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root())
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None)
             .unwrap()
             .oracle_only_calls
     };
@@ -1763,7 +1768,8 @@ fn exact_in_corpus_edge_contradicted_by_external_scip_resolution() {
         occurrence(0, 14, 19, external, SymbolRole::UnspecifiedSymbolRole as i32),
     ]);
 
-    let report = run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+    let report =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
 
     let (kind, resolved, scip) = h.verdict(edge).expect("verdict written");
     assert_eq!(
@@ -1811,7 +1817,8 @@ fn name_only_edge_with_external_scip_stays_resolved_external() {
         occurrence(0, 14, 19, external, SymbolRole::UnspecifiedSymbolRole as i32),
     ]);
 
-    let report = run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+    let report =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
 
     let (kind, _, _) = h.verdict(edge).expect("verdict written");
     assert_eq!(kind, OracleResolutionKind::ResolvedExternal.as_db_str());
@@ -1859,7 +1866,8 @@ fn scip_definition_outside_indexed_corpus_resolves_external() {
     });
     let bytes = index.write_to_bytes().unwrap();
 
-    let report = run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+    let report =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
     let (kind, resolved, _) = h.verdict(edge).expect("verdict written");
     assert_eq!(kind, OracleResolutionKind::ResolvedExternal.as_db_str());
     assert_eq!(resolved, None, "def maps to no indexed symbol → external");
@@ -1882,7 +1890,8 @@ fn reference_without_definition_or_package_yields_no_verdict() {
         occurrence(0, 14, 21, bare, SymbolRole::UnspecifiedSymbolRole as i32),
     ]);
 
-    let report = run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+    let report =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
     assert!(h.verdict(edge).is_none(), "no definition + no package → no verdict");
     assert_eq!(report.rows_written, 0);
     assert_eq!(report.no_occurrence, 1, "dropped into the no-actionable bucket");
@@ -1925,7 +1934,7 @@ fn recall_gap_excludes_field_const_term_reads() {
             ..Default::default()
         };
         let bytes = index.write_to_bytes().unwrap();
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root())
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None)
             .unwrap()
             .oracle_only_calls
     };
@@ -1979,7 +1988,8 @@ fn covered_side_ignores_references_type_confirmation() {
     });
     let bytes = index.write_to_bytes().unwrap();
 
-    let report = run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+    let report =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
     // BOTH edges got verdicts (both carry callee ranges and join)…
     assert!(h.verdict(call_edge).is_some(), "call edge verdicted");
     assert!(h.verdict(type_edge).is_some(), "type-ref edge verdicted");
@@ -2054,7 +2064,7 @@ fn drifted_file_sha_is_skipped_not_verdicted() {
         let _ = target_sym;
         let bytes = index.write_to_bytes().unwrap();
         let report =
-            run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root()).unwrap();
+            run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
         (h.verdict(edge), report.skipped_drifted, report.rows_written)
     };
 
@@ -2067,6 +2077,132 @@ fn drifted_file_sha_is_skipped_not_verdicted() {
     assert!(verdict.is_some(), "the same candidate with a matching file_sha IS verdicted");
     assert_eq!(skipped, 0, "no drift when the sha matches");
     assert_eq!(written, 1);
+}
+
+/// #82 TOCTOU: the scip-vs-disk gate. A tool-driven run carries a per-document `production_sha`
+/// snapshot — the disk hashes captured the instant the subprocess finished. The join verdicts a
+/// candidate only when that snapshot STILL equals the disk bytes it reads; if the snapshot no
+/// longer matches (the watcher reindexed the call-site file in the lock-free window after the
+/// `.scip` was built, so index-vs-disk agrees on the NEW content while the `.scip` describes the
+/// OLD), the candidate is skipped as drifted instead of writing a spurious Compiler verdict. A
+/// document absent from the snapshot (unreadable at production) also fails the gate. The pre-built
+/// `--scip` path (`None`) keeps only the index-vs-disk gate — proven by
+/// `drifted_file_sha_is_skipped_not_verdicted`.
+#[test]
+fn stale_production_snapshot_is_skipped_not_verdicted() {
+    // What the production snapshot says about the documents a verdict depends on: the call-site
+    // file `caller.rs` and the definition file `defs.rs`.
+    enum Snapshot {
+        MatchesDisk,
+        StaleCaller,
+        MissingCaller,
+        StaleDefs,
+    }
+    // (verdict row; skipped_drifted; rows_written)
+    type Probe = (Option<(String, Option<i64>, String)>, u64, u64);
+    let build = |snapshot: Snapshot| -> Probe {
+        let h = Harness::new();
+        let caller = h.add_file("caller.rs", "fn caller() { target(); }\n");
+        let defs = h.add_file("defs.rs", "fn target() {}\n");
+        let _target_sym = h.add_symbol(defs, "target", 3, 9);
+        let edge = h.add_edge(caller, "target", 14, 20, "NameOnly", None);
+
+        let sym = "scip-rust crate v1 `target`().";
+        let mut index = Index {
+            documents: vec![Document {
+                relative_path: "caller.rs".to_string(),
+                occurrences: vec![occurrence(
+                    0,
+                    14,
+                    20,
+                    sym,
+                    SymbolRole::UnspecifiedSymbolRole as i32,
+                )],
+                position_encoding: EnumOrUnknown::new(
+                    PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+                ),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        index.documents.push(Document {
+            relative_path: "defs.rs".to_string(),
+            occurrences: vec![occurrence(0, 3, 9, sym, SymbolRole::Definition as i32)],
+            position_encoding: EnumOrUnknown::new(
+                PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+            ),
+            ..Default::default()
+        });
+        let bytes = index.write_to_bytes().unwrap();
+
+        // Hash the disk bytes the way the join does, so MatchesDisk pins the actual current
+        // content.
+        let disk_hash =
+            |rel: &str| super::run::hex_sha256(&std::fs::read(h.root().join(rel)).unwrap());
+        let stale = "0000000000000000000000000000000000000000000000000000000000000000".to_string();
+        let mut production: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        // Default: both documents match disk. Each arm then drifts exactly one (or omits it).
+        production.insert("caller.rs".to_string(), disk_hash("caller.rs"));
+        production.insert("defs.rs".to_string(), disk_hash("defs.rs"));
+        match snapshot {
+            Snapshot::MatchesDisk => {},
+            // The subprocess saw older CALL-SITE content than what's on disk at join time.
+            Snapshot::StaleCaller => {
+                production.insert("caller.rs".to_string(), stale);
+            },
+            Snapshot::MissingCaller => {
+                production.remove("caller.rs"); // unreadable at production → absent from the snapshot
+            },
+            // The call site is pristine, but the watcher reindexed the DEFINITION file in the
+            // window: the resolved-symbol byte range is converted against drifted bytes, so the
+            // verdict must be skipped even though `caller.rs` passes the call-site gate.
+            Snapshot::StaleDefs => {
+                production.insert("defs.rs".to_string(), stale);
+            },
+        }
+
+        let report = run_oracle(
+            &h.conn,
+            TOOL,
+            VERSION,
+            COMMIT,
+            WORKTREE,
+            &bytes,
+            h.root(),
+            Some(&production),
+        )
+        .unwrap();
+        (h.verdict(edge), report.skipped_drifted, report.rows_written)
+    };
+
+    let (verdict, skipped, written) = build(Snapshot::MatchesDisk);
+    assert!(verdict.is_some(), "a snapshot matching disk IS verdicted");
+    assert_eq!(skipped, 0);
+    assert_eq!(written, 1);
+
+    let (verdict, skipped, written) = build(Snapshot::StaleCaller);
+    assert!(verdict.is_none(), "a stale production snapshot must NOT be verdicted (TOCTOU)");
+    assert_eq!(skipped, 1, "the stale-snapshot candidate is tallied in skipped_drifted");
+    assert_eq!(written, 0, "nothing written from a `.scip` describing superseded content");
+
+    let (verdict, skipped, written) = build(Snapshot::MissingCaller);
+    assert!(
+        verdict.is_none(),
+        "a candidate absent from the production snapshot must NOT be verdicted"
+    );
+    assert_eq!(skipped, 1);
+    assert_eq!(written, 0);
+
+    // The def-document leg of the gate: call site pristine, definition file drifted from the
+    // snapshot → the resolved-target conversion is untrustworthy, so the verdict is skipped too.
+    let (verdict, skipped, written) = build(Snapshot::StaleDefs);
+    assert!(
+        verdict.is_none(),
+        "a verdict whose DEFINITION document drifted must NOT be verdicted (def-doc TOCTOU)"
+    );
+    assert_eq!(skipped, 1, "the stale-def candidate is tallied in skipped_drifted");
+    assert_eq!(written, 0);
 }
 
 /// Finding 3: a run recorded for ANOTHER worktree (same tool/version/commit) does NOT surface as
@@ -2141,7 +2277,7 @@ fn deleted_file_occurrences_do_not_inflate_gap() {
             ..Default::default()
         });
         let bytes = index.write_to_bytes().unwrap();
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root())
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None)
             .unwrap()
             .oracle_only_calls
     };
@@ -2151,7 +2287,7 @@ fn deleted_file_occurrences_do_not_inflate_gap() {
 }
 
 /// Finding 6a: the oracle's checkout scope is leak-proof BY CONSTRUCTION — every raw `edge_oracle`
-/// query lives in `store.rs` (which owns the scoped helpers + the `EDGE_ORACLE_SCOPE_JOIN`
+/// query lives in `store.rs` (which owns the scoped helpers + the `edge_oracle_scope_join`
 /// predicate). This source-scan test fails CI if a future unscoped `FROM edge_oracle` query is
 /// added to any other oracle module (run.rs / status.rs / join.rs / scip.rs), forcing it back
 /// through the scoped helper.
@@ -2172,7 +2308,7 @@ fn raw_edge_oracle_queries_live_only_in_store() {
         assert!(
             !text.contains("FROM edge_oracle"),
             "{name} contains a raw `FROM edge_oracle` query — route it through \
-             store::count_edge_oracle_scoped / EDGE_ORACLE_SCOPE_JOIN so it can't drop the \
+             store::count_edge_oracle_scoped / edge_oracle_scope_join so it can't drop the \
              checkout scope",
         );
     }
@@ -2264,7 +2400,7 @@ fn seed_verdict_full(
         .query_row("SELECT sha256 FROM files WHERE id = ?1", params![f], |r| r.get(0))
         .unwrap();
     // An in-corpus resolution must point at a symbol that EXISTS — the def-drift gate in
-    // `EDGE_ORACLE_CURRENT_PREDICATE` filters a dangling `resolved_symbol_id`.
+    // `edge_oracle_current_predicate` filters a dangling `resolved_symbol_id`.
     let resolved_symbol_id = in_corpus.then(|| h.add_symbol(f, "target", 3, 9));
     let edge = h.add_edge(f, "target", 14, 20, "NameOnly", None);
     store::write_edge_oracle(&h.conn, TOOL, VERSION, &EdgeOracleRow {

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -44,7 +44,11 @@ impl Drop for TempRoot {
 
 const TOOL: OracleTool = OracleTool::RustAnalyzer;
 const VERSION: &str = "test";
-const COMMIT: &str = "";
+// Model a REAL clean git checkout: a non-empty `commit_sha`, empty `worktree_id` (the
+// `FileScope::commit` case — the dominant production shape). The earlier `"" / ""` pair only
+// occurs in a non-git temp dir, where the active-checkout predicate degenerates and silently
+// masked the #82 P0 (the AND-of-both-non-empty predicate matched zero rows on every real repo).
+const COMMIT: &str = "deadbeefcafef00d";
 const WORKTREE: &str = "";
 
 /// A test corpus written to a temp checkout + an index DB seeded to match.
@@ -602,8 +606,10 @@ fn edge_join_candidates_filters_null_range_and_scopes_by_worktree() {
     assert_eq!(candidates[0].edge_kind, "calls_name");
     assert_eq!(candidates[0].source_path, "caller.rs");
 
-    // A candidate in a different worktree is out of scope.
-    assert!(store::edge_join_candidates(&h.conn, COMMIT, "other-worktree").unwrap().is_empty());
+    // A candidate scoped to a DIFFERENT commit is out of scope. (Under clean-checkout semantics a
+    // commit-scoped file is visible from any worktree-overlay query as long as the commit matches,
+    // so the isolation that actually matters is the commit, not the overlay id.)
+    assert!(store::edge_join_candidates(&h.conn, "other-commit-sha", WORKTREE).unwrap().is_empty());
 }
 
 /// `symbol_spans_for_path` returns the file's symbols ordered by start byte, scoped to the path +
@@ -1452,7 +1458,13 @@ fn parse_utf16_astral_character_shifts_offset_by_surrogate_width() {
 // leak into (or be erased by) the active run.
 // ---------------------------------------------------------------------------
 
-const OTHER_WORKTREE: &str = "other-wt";
+// A sibling checkout sharing the same DB: a DIFFERENT commit, clean (empty worktree). Modelling the
+// sibling as a distinct commit (rather than the same commit + a second worktree id) matches the
+// real shape — two checkouts at the same HEAD is unusual, and under the active-checkout predicate a
+// same-commit worktree overlay would (correctly) *shadow* the clean row by path, which is not the
+// cross-checkout-isolation property these tests mean to assert. Commit isolation is.
+const OTHER_COMMIT: &str = "5ad1f1ce5ad1f1ce";
+const OTHER_WORKTREE: &str = "";
 
 /// Finding 1: `clear_edge_oracle_for_tool` must delete ONLY the active checkout's verdicts. With
 /// two worktrees' verdicts for the same `(tool, tool_version)` in one DB, clearing one leaves the
@@ -1464,7 +1476,7 @@ fn clear_edge_oracle_is_scoped_to_active_checkout() {
     let active_file = h.add_file("a.rs", "fn caller() { target(); }\n");
     let active_edge = h.add_edge(active_file, "target", 14, 20, "NameOnly", None);
     // Another worktree's edge (same DB) + a verdict for the SAME tool/version.
-    let other_file = h.add_file_in_scope("a.rs", COMMIT, OTHER_WORKTREE);
+    let other_file = h.add_file_in_scope("a.rs", OTHER_COMMIT, OTHER_WORKTREE);
     let other_edge = h.add_edge(other_file, "target", 14, 20, "NameOnly", None);
 
     let mk = |edge| EdgeOracleRow {
@@ -1521,7 +1533,7 @@ fn upgradeable_fraction_denominator_is_scoped_to_active_checkout() {
 
     // Another worktree: an unresolved NameOnly candidate carrying a callee range, NO verdict. If
     // the denominator weren't scoped, it would count → fraction 1/2.
-    let other = h.add_file_in_scope("a.rs", COMMIT, OTHER_WORKTREE);
+    let other = h.add_file_in_scope("a.rs", OTHER_COMMIT, OTHER_WORKTREE);
     let _ = h.add_edge(other, "v", 0, 1, "NameOnly", None);
 
     let m = super::oracle_eval_metrics(
@@ -1687,7 +1699,7 @@ fn verdict_counts_and_metrics_ignore_sibling_checkout_rows() {
 
     // Sibling checkout B (same DB, same tool/version): TWO confirms + an upgrade. If A's counts
     // leaked B's rows, A's precision would jump to 3/4 and its recall would change.
-    let b_file = h.add_file_in_scope("a.rs", COMMIT, OTHER_WORKTREE);
+    let b_file = h.add_file_in_scope("a.rs", OTHER_COMMIT, OTHER_WORKTREE);
     let b_conf1 = h.add_edge(b_file, "e", 0, 1, "Exact", None);
     let b_conf2 = h.add_edge(b_file, "f", 1, 2, "Exact", None);
     let b_up = h.add_edge(b_file, "g", 2, 3, "NameOnly", None);
@@ -1724,7 +1736,8 @@ fn verdict_counts_and_metrics_ignore_sibling_checkout_rows() {
     assert_eq!(status.upgraded, 0);
 
     // Sanity: checkout B's own scoped status sees its three rows, proving the rows really exist.
-    let status_b = super::oracle_status(&h.conn, TOOL, VERSION, COMMIT, OTHER_WORKTREE).unwrap();
+    let status_b =
+        super::oracle_status(&h.conn, TOOL, VERSION, OTHER_COMMIT, OTHER_WORKTREE).unwrap();
     assert_eq!(status_b.total_verdicts, 3);
     assert_eq!(status_b.confirmed, 2);
     assert_eq!(status_b.upgraded, 1);
@@ -2063,8 +2076,11 @@ fn drifted_file_sha_is_skipped_not_verdicted() {
 #[test]
 fn last_run_meta_is_scoped_to_active_worktree() {
     let h = Harness::new();
-    // A run in a SIBLING worktree (same tool/version/commit). It must not be THIS checkout's last.
-    store::record_oracle_run(&h.conn, TOOL, VERSION, COMMIT, OTHER_WORKTREE, "Completed", "{}")
+    // A run in a SIBLING worktree (same tool/version/commit, distinct worktree id). It must not be
+    // THIS checkout's last. `oracle_runs.worktree_id` scoping is orthogonal to the file-predicate
+    // fix, so this uses a non-empty sibling worktree id directly rather than the file-level
+    // `OTHER_*` constants.
+    store::record_oracle_run(&h.conn, TOOL, VERSION, COMMIT, "sibling-wt", "Completed", "{}")
         .unwrap();
 
     // This checkout has no run yet → no last run, despite the sibling's row existing.
@@ -2312,25 +2328,95 @@ fn resolved_def_drift_verdict_is_not_surfaced() {
     assert!(after.is_empty(), "a verdict whose resolved definition drifted must not surface");
 }
 
-/// Dirty/overlay (uncommitted) edges never surface `Compiler`: an edge whose file lives in a
-/// different `(commit_sha, worktree_id)` scope than the active checkout is out of the scope join,
-/// so its verdict is never returned for the active checkout. (Models the overlay edge — the
-/// compiler hasn't seen the uncommitted edit; the oracle row binds to commit-scoped rows only.)
+/// Overlay def-drift (#82 P2): when the *def* file goes dirty, the indexer inserts a
+/// worktree-scoped overlay row and leaves the old commit-scoped symbols shadowed-but-PRESENT (not
+/// deleted). A raw `EXISTS (symbols.id = resolved_symbol_id)` would still find the stale id and
+/// keep surfacing a `Compiler` verdict pointing at the pre-edit target (the CALLSITE file is
+/// untouched, so its sha still matches). The scope-aware def-drift EXISTS — which joins `symbols ->
+/// files` and applies the active-checkout predicate — must treat the shadowed commit-scoped def as
+/// out of scope, reverting the verdict to heuristic. Callsite and def are in SEPARATE files so only
+/// the def's scope changes.
+#[test]
+fn overlay_shadowed_def_verdict_is_not_surfaced() {
+    let h = Harness::new();
+    // Callsite in `caller.rs` (stays committed); def in `defs.rs` (will get an overlay).
+    // The active context for a dirty checkout carries a real worktree id (the root path) alongside
+    // the HEAD commit — `resolve_git_context` always returns the root as `worktree_id`. Both the
+    // committed (clean) caller row and the dirty overlay use that id.
+    let active_wt = "/some/checkout/root";
+    let caller = h.add_file_in_scope("caller.rs", COMMIT, "");
+    h.conn
+        .execute("UPDATE files SET sha256 = 'caller-sha' WHERE id = ?1", params![caller])
+        .unwrap();
+    let defs = h.add_file_in_scope("defs.rs", COMMIT, "");
+    let resolved = h.add_symbol(defs, "target", 3, 9);
+    let edge = h.add_edge(caller, "target", 14, 20, "NameOnly", None);
+    store::write_edge_oracle(&h.conn, TOOL, VERSION, &EdgeOracleRow {
+        edge_id: edge,
+        file_sha: "caller-sha",
+        resolved_symbol_id: Some(resolved),
+        scip_symbol: "scip x `target`().",
+        kind: OracleResolutionKind::Upgrade,
+    })
+    .unwrap();
+
+    // Sanity: with no overlay, the committed def is in scope → the verdict surfaces.
+    let before =
+        store::current_oracle_verdicts_for_edges(&h.conn, TOOL, VERSION, COMMIT, active_wt, &[
+            edge,
+        ])
+        .unwrap();
+    assert!(before.contains_key(&edge), "verdict surfaces before the def file goes dirty");
+
+    // The def file goes dirty: a worktree-scoped overlay row for `defs.rs` is inserted; the
+    // committed `defs.rs` row (and its `target` symbol) stay shadowed-but-present. The active
+    // worktree id matches the overlay, so the committed def is now shadowed out of scope.
+    h.add_file_in_scope("defs.rs", "", active_wt);
+
+    let after =
+        store::current_oracle_verdicts_for_edges(&h.conn, TOOL, VERSION, COMMIT, active_wt, &[
+            edge,
+        ])
+        .unwrap();
+    assert!(
+        after.is_empty(),
+        "a verdict whose resolved def is shadowed by a dirty overlay must not keep surfacing"
+    );
+}
+
+/// A verdict whose edge lives in a different checkout never surfaces for the active one: querying
+/// the seeded (clean-checkout) edge under a DIFFERENT commit is out of the active-checkout scope
+/// join, so the verdict is excluded. (Commit, not worktree id, is the isolation boundary for a
+/// commit-scoped row — a clean file is visible from any worktree-overlay query at the same commit,
+/// so a sibling-worktree query at the SAME commit would correctly still see it; the genuine
+/// out-of-scope case is a different commit.)
 #[test]
 fn out_of_scope_verdict_is_not_surfaced() {
     let (h, edge, sha) = seed_verdict(OracleResolutionKind::Upgrade, "scip x `target`().", true);
-    // Query the SAME edge under a sibling worktree scope: the scope join excludes it.
+    // Query the SAME edge under a different commit's scope: the scope join excludes it.
     let verdicts = store::current_oracle_verdicts_for_edges(
         &h.conn,
         TOOL,
         VERSION,
-        COMMIT,
-        "other-worktree",
+        "a-different-commit-sha",
+        WORKTREE,
         &[edge],
     )
     .unwrap();
     assert!(verdicts.is_empty(), "a verdict outside the active checkout must not surface");
     let _ = sha;
+}
+
+/// #82 P3: the `--scip` run-id fingerprint is a stable 12-hex-char content hash, distinct for
+/// distinct bytes — so two indexes sharing a basename don't collide onto one `tool_version`.
+#[test]
+fn scip_content_fingerprint_is_stable_and_content_distinct() {
+    let a = super::scip_content_fingerprint(b"index-A-bytes");
+    let b = super::scip_content_fingerprint(b"index-B-bytes");
+    assert_eq!(a.len(), 12, "12 hex chars");
+    assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+    assert_eq!(a, super::scip_content_fingerprint(b"index-A-bytes"), "stable for identical bytes");
+    assert_ne!(a, b, "distinct bytes → distinct fingerprint (no basename collision)");
 }
 
 /// A `resolved-external` verdict surfaces a `resolved-external(<package>)` label derived from the

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -950,12 +950,20 @@ impl IndexDatabase {
     /// Dirty/overlay (uncommitted) edges never carry oracle verdicts (oracle rows bind to
     /// commit-scoped index rows only), so they always show heuristic — this falls out of the
     /// `(commit_sha, worktree_id)` scope with no special-casing.
+    /// Returns whether any hop was PROMOTED to the `compiler` tier — i.e. whether enrichment
+    /// changed a hop's `effective_confidence_rank`. Only an `Upgrade`/`Confirm` that became
+    /// `compiler` changes ranking; a `ResolvedExternal` sets a label but leaves the confidence
+    /// heuristic, so it does NOT count. The caller uses this to decide whether the
+    /// overfetch+re-sort is needed: with no promotion the heuristic order + the caller's
+    /// original `limit` are already correct and must be left untouched (#82 P2 — the
+    /// unconditional re-sort changed truncation membership on EVERY query, including repos with
+    /// no oracle run).
     fn enrich_hops_with_oracle(
         &self,
         hops: &mut [crate::query::graph::GraphHop],
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<bool> {
         if hops.is_empty() {
-            return Ok(());
+            return Ok(false);
         }
         let tool = oracle::OracleTool::RustAnalyzer;
         let Some(tool_version) = oracle::latest_run_tool_version(
@@ -966,7 +974,7 @@ impl IndexDatabase {
         )?
         else {
             // No oracle run for this checkout — nothing to surface, all hops stay heuristic.
-            return Ok(());
+            return Ok(false);
         };
         let edge_ids = hops.iter().map(|hop| hop.edge_id).collect::<Vec<_>>();
         let verdicts = oracle::current_oracle_verdicts_for_edges(
@@ -978,8 +986,9 @@ impl IndexDatabase {
             &edge_ids,
         )?;
         if verdicts.is_empty() {
-            return Ok(());
+            return Ok(false);
         }
+        let mut promoted_any = false;
         for hop in hops.iter_mut() {
             let Some(verdict) = verdicts.get(&hop.edge_id) else {
                 continue;
@@ -1002,6 +1011,7 @@ impl IndexDatabase {
                     hop.verified_target_symbol = true;
                     hop.confidence = "compiler".to_string();
                     hop.resolution_reason = Some(verdict.resolution_reason());
+                    promoted_any = true;
                 },
                 oracle::OracleResolutionKind::ResolvedExternal => {
                     hop.resolved_external = verdict.resolved_external_label();
@@ -1011,7 +1021,7 @@ impl IndexDatabase {
                 oracle::OracleResolutionKind::Contradict => {},
             }
         }
-        Ok(())
+        Ok(promoted_any)
     }
 
     /// Traverse, surface the `Compiler` tier, then rank-and-truncate so a compiler-upgraded edge is
@@ -1042,11 +1052,19 @@ impl IndexDatabase {
             overfetch,
             options,
         )?;
-        self.enrich_hops_with_oracle(&mut hops)?;
-        // Stable sort by effective (post-enrichment) confidence so a `compiler` upgrade rises above
-        // the heuristic `exact`/`syntactic` edges that out-ranked it in the SQL ORDER BY. Stable
-        // keeps the heuristic order within a tier.
-        hops.sort_by_key(|hop| crate::query::graph::effective_confidence_rank(&hop.confidence));
+        let promoted = self.enrich_hops_with_oracle(&mut hops)?;
+        // Only re-rank when a hop was actually PROMOTED to `compiler` (#82 P2). With no promotion
+        // the heuristic SQL order already ranks the candidates correctly, so re-sorting would only
+        // perturb truncation membership for free (it demotes `match_tier` to a within-confidence
+        // tiebreak) — including on every query in a repo with no oracle run. When nothing was
+        // promoted, keep the heuristic order and the caller's original `limit`: the overfetched set
+        // is in heuristic order, so its first `limit` rows ARE the original top-`limit`.
+        if promoted {
+            // Stable sort by effective (post-enrichment) confidence so a `compiler` upgrade rises
+            // above the heuristic `exact`/`syntactic` edges that out-ranked it in the SQL ORDER BY.
+            // Stable keeps the heuristic order (the `match_tier` primary key) within a tier.
+            hops.sort_by_key(|hop| crate::query::graph::effective_confidence_rank(&hop.confidence));
+        }
         hops.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
         Ok(hops)
     }
@@ -1346,6 +1364,19 @@ impl IndexDatabase {
             &self.active_worktree_id,
         )?;
         summary.verdicts_examined = u64::try_from(comparisons.len()).unwrap_or(u64::MAX);
+        // A run exists for this checkout but produced ZERO in-scope verdicts to compare. This is
+        // NOT "the compiler agrees with the graph" — it is "the run found nothing in this
+        // checkout's scope," which is exactly the silent-no-op symptom the #82 P0 scope bug
+        // produced (the active-checkout predicate matched no file rows). Surface it so a
+        // run-but-empty result is distinguishable from a genuine all-agree.
+        if summary.verdicts_examined == 0 {
+            summary.warnings.push(
+                "oracle run exists for this checkout but examined 0 in-scope verdicts — nothing \
+                 to compare (this is run-but-empty, not compiler-agrees); re-run `rag-rat oracle \
+                 run` if you expected verdicts"
+                    .to_string(),
+            );
+        }
         for comparison in comparisons {
             if comparison.kind != oracle::OracleResolutionKind::Contradict {
                 continue;
@@ -1709,13 +1740,18 @@ fn resolved_external_label(scip_symbol: &str) -> Option<String> {
     oracle::package_of(scip_symbol).map(|package| format!("resolved-external({package})"))
 }
 
-/// Append a quantitative clause to `summary.completeness_risk` describing how much of the
-/// unresolved gap the oracle placed in an external dependency, e.g. " (2 of 7 unresolved are
+/// Append a quantitative clause to `summary.completeness_risk` describing how many of the SHOWN
+/// neighbors the oracle placed in an external dependency, e.g. " (2 shown neighbors are
 /// resolved-external: libc, tokio)". Quantitative completeness is the #69 ask: turn the qualitative
 /// risk into a count when the oracle has data. No-op when no hop carries a `resolved-external`
-/// verdict (then the risk string stays purely qualitative). The denominator is `summary.unresolved
-/// + summary.name_only + summary.ambiguous` — every low-confidence/unresolved neighbor the
-/// heuristic couldn't pin down, the population a `resolved-external` placement informs.
+/// verdict (then the risk string stays purely qualitative).
+///
+/// COUNTING SCOPE (#82 P3): `external_count` is counted over the TRUNCATED `hops` window (the
+/// neighbors actually returned), so the clause speaks of "shown neighbors" — it does NOT divide by
+/// the population-wide `summary.unresolved + name_only + ambiguous`. Mixing a shown-window
+/// numerator with a population-wide denominator produced a misleading ratio (`5 of 7` where 5
+/// counts only the displayed window and 7 the whole graph). The honest statement is the count over
+/// what was shown.
 fn annotate_completeness_with_externals(
     summary: &mut crate::query::graph::GraphTraversalSummary,
     hops: &[crate::query::graph::GraphHop],
@@ -1736,16 +1772,12 @@ fn annotate_completeness_with_externals(
     if external_count == 0 {
         return;
     }
-    let gap =
-        summary.unresolved.saturating_add(summary.name_only).saturating_add(summary.ambiguous);
-    let denominator = gap.max(external_count);
+    let neighbor_word = if external_count == 1 { "neighbor is" } else { "neighbors are" };
     let package_list = packages.into_iter().collect::<Vec<_>>().join(", ");
     let clause = if package_list.is_empty() {
-        format!(" ({external_count} of {denominator} unresolved are resolved-external)")
+        format!(" ({external_count} shown {neighbor_word} resolved-external)")
     } else {
-        format!(
-            " ({external_count} of {denominator} unresolved are resolved-external: {package_list})"
-        )
+        format!(" ({external_count} shown {neighbor_word} resolved-external: {package_list})")
     };
     summary.completeness_risk.push_str(&clause);
 }
@@ -2032,6 +2064,40 @@ mod oracle_surfacing_tests {
         assert_eq!(c.heuristic_confidence, "exact");
         assert_eq!(c.resolved_external.as_deref(), Some("resolved-external(other)"));
 
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// #82 P0: when a run EXISTS but examined 0 in-scope verdicts, `compare_graph_to_scip` must WARN
+    /// — that is "run-but-empty" (the silent symptom of the scope bug), not "compiler agrees". Here
+    /// a run writes a verdict, then the callsite file drifts so the current-content gate
+    /// filters every verdict out → `verdicts_examined == 0` despite the run row existing.
+    #[test]
+    fn compare_warns_when_run_exists_but_no_verdicts_in_scope() {
+        let root = temp_root();
+        fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
+        let config = rust_config(root.clone());
+        let db = IndexDatabase::rebuild(&config).unwrap();
+
+        let (_edge_id, cs, ce, path) = call_edge(&db);
+        let symbol = "scip-rust crate held-mini `target`().";
+        let scip = scip_with(&path, cs, ce, symbol, Some(&path), Some((29, 35)));
+        db.run_oracle_from_scip(OracleTool::RustAnalyzer, "v-test", &scip).unwrap();
+
+        // Drift the callsite file so every verdict's `file_sha` gate fails → 0 in-scope verdicts,
+        // even though the `oracle_runs` row still exists.
+        db.storage
+            .connection()
+            .execute("UPDATE main.files SET sha256 = 'drifted' WHERE path = ?1", params![path])
+            .unwrap();
+
+        let compare = db.compare_graph_to_scip().unwrap();
+        assert!(!compare.summary.no_oracle_data, "a run DOES exist for this checkout");
+        assert_eq!(compare.summary.verdicts_examined, 0, "all verdicts filtered by the drift gate");
+        assert!(
+            compare.summary.warnings.iter().any(|w| w.contains("0 in-scope verdicts")),
+            "run-but-empty must warn, not silently read as compiler-agrees: {:?}",
+            compare.summary.warnings
+        );
         let _ = fs::remove_dir_all(&root);
     }
 
@@ -2354,9 +2420,11 @@ mod oracle_surfacing_tests {
             hop(None),
         ];
         annotate_completeness_with_externals(&mut summary, &hops);
+        // The count is over the SHOWN window (2 of the passed hops), not divided by the
+        // population-wide unresolved gap (#82 P3) — the clause speaks of "shown neighbors".
         assert_eq!(
             summary.completeness_risk,
-            "medium (2 of 5 unresolved are resolved-external: libc, tokio)"
+            "medium (2 shown neighbors are resolved-external: libc, tokio)"
         );
 
         // No externals → the qualitative string is left untouched.
@@ -2388,6 +2456,138 @@ mod oracle_surfacing_tests {
         let outcome =
             db.run_oracle_with_tool(OracleTool::RustAnalyzer, &root.join("o.scip")).unwrap();
         assert!(matches!(outcome, crate::index::oracle::OracleRunOutcome::Blocked { .. }));
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// Run a git command in `root`, panicking on failure — used to make a real committed checkout
+    /// so `resolve_git_context` returns a non-empty `commit_sha` AND `worktree_id` (the active
+    /// context every other e2e test misses by running in a non-git temp dir).
+    fn git(root: &std::path::Path, args: &[&str]) {
+        let status = std::process::Command::new("git")
+            .args(args)
+            .current_dir(root)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .unwrap();
+        assert!(status.success(), "git {args:?} failed");
+    }
+
+    /// #82 P2 regression: `find_callers` with NO oracle data must return the IDENTICAL membership
+    /// and order as the plain heuristic traversal. The unconditional re-sort in
+    /// `traverse_with_oracle` demoted `match_tier` to a within-confidence tiebreak and changed
+    /// truncation membership on EVERY query — including repos with no oracle run, where
+    /// enrichment is a no-op. The fix only re-sorts when a hop was actually promoted, so with
+    /// no oracle data the overfetched heuristic order + the caller's `limit` are returned
+    /// untouched.
+    #[test]
+    fn find_callers_without_oracle_matches_heuristic_order() {
+        let root = temp_root();
+        // Several callers of `target` with differing heuristic confidence, more than `limit` so
+        // truncation membership is observable.
+        let mut src = String::new();
+        for i in 0..8 {
+            src.push_str(&format!("fn caller{i}() {{ target(); }} "));
+        }
+        src.push_str("fn target() {}\n");
+        fs::write(root.join("src/lib.rs"), src).unwrap();
+        let config = rust_config(root.clone());
+        let db = IndexDatabase::rebuild(&config).unwrap();
+
+        // No oracle run at all: enrichment early-returns false, so no re-sort fires.
+        let opts = crate::query::graph::GraphTraversalOptions {
+            include_unresolved: true,
+            ..Default::default()
+        };
+        let limit = 3;
+        let via_oracle_path = db.find_callers_with_options("target", limit, &opts).unwrap();
+
+        // The pre-oracle path: plain heuristic traversal at the SAME limit (what the oracle-aware
+        // entry point must collapse to when there's nothing to enrich).
+        let grouped = db.graph_options_with_logical_group(&opts).unwrap();
+        let heuristic = crate::query::graph::traverse_with_options(
+            db.storage.connection(),
+            "target",
+            true,
+            limit,
+            &grouped,
+        )
+        .unwrap();
+
+        let ids = |hops: &[crate::query::graph::GraphHop]| {
+            hops.iter().map(|h| h.edge_id).collect::<Vec<_>>()
+        };
+        assert_eq!(
+            ids(&via_oracle_path),
+            ids(&heuristic),
+            "with no oracle data, find_callers must match the plain heuristic membership + order"
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// #82 P0 regression: on a REAL committed git checkout the active context is
+    /// `(commit_sha = HEAD, worktree_id = root)` — BOTH non-empty — and the indexed files are
+    /// `FileScope::commit` rows `(HEAD, '')`. The old oracle scope predicate
+    /// `files.commit_sha = ?sha AND files.worktree_id = ?wt` matched ZERO such rows, so `oracle
+    /// run` silently wrote 0 verdicts and the `Compiler` tier never surfaced. This test commits
+    /// the checkout, runs the oracle, and asserts verdicts are written AND `trace_callees`
+    /// surfaces `compiler` — the exact case the unit harness (`commit=''`) and the non-git e2e
+    /// tests both degenerate past.
+    #[test]
+    fn oracle_surfaces_compiler_tier_on_a_real_git_checkout() {
+        if std::process::Command::new("git").arg("--version").output().is_err() {
+            return; // no git on PATH — skip rather than fail.
+        }
+        let root = temp_root();
+        fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
+        // A real committed checkout: clean tree → files index as `FileScope::commit` (HEAD, '').
+        git(&root, &["init", "-q"]);
+        git(&root, &["add", "-A"]);
+        git(&root, &["commit", "-q", "-m", "init"]);
+
+        let config = rust_config(root.clone());
+        let db = IndexDatabase::rebuild(&config).unwrap();
+
+        // Sanity: the active context carries BOTH a real commit_sha and a worktree_id, and the file
+        // rows are committed-scoped (commit set, worktree empty) — the shape that broke the AND.
+        let (active_commit, active_worktree) = crate::index::resolve_git_context(&root);
+        assert!(!active_commit.is_empty(), "real checkout has a HEAD commit");
+        assert!(!active_worktree.is_empty(), "worktree id is the root path");
+        let (file_commit, file_worktree): (String, String) = db
+            .storage
+            .connection()
+            .query_row(
+                "SELECT commit_sha, worktree_id FROM files WHERE path = 'src/lib.rs'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert!(!file_commit.is_empty() && file_worktree.is_empty(), "committed-scoped file row");
+
+        let (edge_id, callee_start, callee_end, path) = call_edge(&db);
+        let symbol = "scip-rust crate held-mini `target`().";
+        let scip = scip_with(&path, callee_start, callee_end, symbol, Some(&path), Some((29, 35)));
+
+        let report = db.run_oracle_from_scip(OracleTool::RustAnalyzer, "v-test", &scip).unwrap();
+        assert!(
+            report.rows_written >= 1,
+            "verdicts must be written on a real git checkout (the #82 P0 wrote 0); got {report:?}"
+        );
+
+        let callees = db
+            .trace_callees_with_options("caller", 50, &crate::query::graph::GraphTraversalOptions {
+                include_unresolved: true,
+                ..Default::default()
+            })
+            .unwrap();
+        let hop = callees.iter().find(|h| h.edge_id == edge_id).expect("call edge present");
+        assert_eq!(hop.confidence, "compiler", "Compiler tier must surface on a real git checkout");
+        assert_eq!(hop.resolution_reason.as_deref(), Some("scip:rust-analyzer@v-test"));
+
         let _ = fs::remove_dir_all(&root);
     }
 }

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -67,6 +67,61 @@ impl IndexDatabase {
         )
     }
 
+    /// `rag-rat oracle run [--tool <id>]` without a pre-built `--scip`: invoke the indexer to
+    /// produce a `.scip` (to a caller-owned temp path), then run the phase-1 join over it. A
+    /// missing or unrunnable tool returns [`oracle::OracleRunOutcome::Blocked`] with an install
+    /// hint (the CLI prints it and exits 0) — never an error. Records an `oracle_runs` row on
+    /// success.
+    pub fn run_oracle_with_tool(
+        &self,
+        tool: OracleTool,
+        scip_output: &Path,
+    ) -> anyhow::Result<oracle::OracleRunOutcome> {
+        let Some(root) = self.storage.source_root() else {
+            anyhow::bail!(
+                "index has no source_root metadata; rebuild required for the oracle pass"
+            );
+        };
+        let root = root.to_path_buf();
+        oracle::run_oracle_with_tool(
+            self.storage.connection(),
+            tool,
+            &root,
+            scip_output,
+            &self.active_commit_sha,
+            &self.active_worktree_id,
+        )
+    }
+
+    /// Run the oracle pass over a PRE-BUILT `.scip` for a tool, recording an `oracle_runs` row. The
+    /// `--scip <path>` consumption path of `oracle run`; deterministic (no subprocess), so it's the
+    /// tested end-to-end seam. `tool_version` labels the run (content-addressed staleness key).
+    pub fn run_oracle_from_scip(
+        &self,
+        tool: OracleTool,
+        tool_version: &str,
+        scip_bytes: &[u8],
+    ) -> anyhow::Result<oracle::OracleReport> {
+        self.run_oracle(tool, tool_version, scip_bytes)
+    }
+
+    /// Probe whether an oracle tool is installed, for `oracle status`. A `Blocked` probe is
+    /// informational (the tool isn't installed), never an error.
+    pub fn probe_oracle_tool(&self, tool: OracleTool) -> oracle::ToolAvailability {
+        oracle::probe_oracle_tool(tool)
+    }
+
+    /// The `tool_version` of the most recent oracle run for `tool` in this checkout, or `None` when
+    /// no run exists. The version `oracle status` reports verdict counts against.
+    pub fn latest_oracle_run_version(&self, tool: OracleTool) -> anyhow::Result<Option<String>> {
+        oracle::latest_run_tool_version(
+            self.storage.connection(),
+            tool,
+            &self.active_commit_sha,
+            &self.active_worktree_id,
+        )
+    }
+
     pub fn status(&self, database: &Path) -> anyhow::Result<IndexStatus> {
         let mut counts = BTreeMap::new();
         let mut stmt = self
@@ -778,6 +833,12 @@ impl IndexDatabase {
         )?;
         self.delete_staged_files_cascade()?;
         conn.execute_batch("DELETE FROM temp.staged_file_ids;")?;
+        // `edge_oracle` verdicts cascade away with their edges via the FK ON DELETE CASCADE (fired
+        // by the cascade above, with `PRAGMA foreign_keys=ON`). `oracle_runs`, however, is keyed by
+        // `(commit_sha, worktree_id)` directly — nothing cascades it — so a dead checkout's run
+        // rows would survive the file pruning. Prune them with the SAME live sets, so a run and the
+        // edges it produced are dropped together.
+        oracle::prune_oracle_runs_outside_scope(conn, live_commits, live_worktrees)?;
         let files_remaining = table_row_count(conn, "files")?;
         let chunks_remaining = table_row_count(conn, "chunks")?;
         Ok(GcReport {
@@ -867,13 +928,84 @@ impl IndexDatabase {
         options: &crate::query::graph::GraphTraversalOptions,
     ) -> anyhow::Result<Vec<crate::query::graph::GraphHop>> {
         let options = self.graph_options_with_logical_group(options)?;
-        crate::query::graph::traverse_with_options(
+        let mut hops = crate::query::graph::traverse_with_options(
             self.storage.connection(),
             symbol,
             true,
             limit,
             &options,
-        )
+        )?;
+        self.enrich_hops_with_oracle(&mut hops)?;
+        Ok(hops)
+    }
+
+    /// Upgrade graph hops to the `Compiler` confidence tier where a CURRENT, in-scope `edge_oracle`
+    /// verdict covers the edge — the read-side surfacing for `trace_callees` / `find_callers` /
+    /// `impact_surface`. The heuristic `edges` row is NEVER mutated (side-table invariant); this
+    /// JOINs `edge_oracle` (scoped to the active checkout AND filtered to current content via
+    /// `file_sha == files.sha256`) at read time and rewrites only the in-memory hop's display
+    /// fields:
+    /// - `Upgrade`/`Confirm` (in-corpus compiler resolution) → `confidence = "compiler"` with
+    ///   `resolution_reason = "scip:<tool>@<version>"`. A drifted file's verdict is excluded by the
+    ///   current-content filter, so the hop reverts to heuristic display (never `compiler`).
+    /// - `ResolvedExternal` → `resolved_external = "resolved-external(<package>)"` + the reason;
+    ///   the confidence stays heuristic (the callee is outside the corpus, not an in-corpus
+    ///   upgrade).
+    /// - `Contradict` is NOT surfaced as `compiler`: the oracle disagrees with the heuristic
+    ///   target, so promoting it would assert a resolution we don't stand behind — it stays
+    ///   heuristic (`compare_graph_to_scip` is where contradictions surface).
+    ///
+    /// Dirty/overlay (uncommitted) edges never carry oracle verdicts (oracle rows bind to
+    /// commit-scoped index rows only), so they always show heuristic — this falls out of the
+    /// `(commit_sha, worktree_id)` scope with no special-casing.
+    fn enrich_hops_with_oracle(
+        &self,
+        hops: &mut [crate::query::graph::GraphHop],
+    ) -> anyhow::Result<()> {
+        if hops.is_empty() {
+            return Ok(());
+        }
+        let tool = oracle::OracleTool::RustAnalyzer;
+        let Some(tool_version) = oracle::latest_run_tool_version(
+            self.storage.connection(),
+            tool,
+            &self.active_commit_sha,
+            &self.active_worktree_id,
+        )?
+        else {
+            // No oracle run for this checkout — nothing to surface, all hops stay heuristic.
+            return Ok(());
+        };
+        let edge_ids = hops.iter().map(|hop| hop.edge_id).collect::<Vec<_>>();
+        let verdicts = oracle::current_oracle_verdicts_for_edges(
+            self.storage.connection(),
+            tool,
+            &tool_version,
+            &self.active_commit_sha,
+            &self.active_worktree_id,
+            &edge_ids,
+        )?;
+        if verdicts.is_empty() {
+            return Ok(());
+        }
+        for hop in hops.iter_mut() {
+            let Some(verdict) = verdicts.get(&hop.edge_id) else {
+                continue;
+            };
+            match verdict.kind {
+                oracle::OracleResolutionKind::Upgrade | oracle::OracleResolutionKind::Confirm => {
+                    hop.confidence = "compiler".to_string();
+                    hop.resolution_reason = Some(verdict.resolution_reason());
+                },
+                oracle::OracleResolutionKind::ResolvedExternal => {
+                    hop.resolved_external = verdict.resolved_external_label();
+                    hop.resolution_reason = Some(verdict.resolution_reason());
+                },
+                // The oracle disagrees with the heuristic target — do not promote to `compiler`.
+                oracle::OracleResolutionKind::Contradict => {},
+            }
+        }
+        Ok(())
     }
 
     pub fn trace_callees(
@@ -891,13 +1023,15 @@ impl IndexDatabase {
         options: &crate::query::graph::GraphTraversalOptions,
     ) -> anyhow::Result<Vec<crate::query::graph::GraphHop>> {
         let options = self.graph_options_with_logical_group(options)?;
-        crate::query::graph::traverse_with_options(
+        let mut hops = crate::query::graph::traverse_with_options(
             self.storage.connection(),
             symbol,
             false,
             limit,
             &options,
-        )
+        )?;
+        self.enrich_hops_with_oracle(&mut hops)?;
+        Ok(hops)
     }
 
     pub fn graph_traversal_report(
@@ -909,14 +1043,15 @@ impl IndexDatabase {
         options: &crate::query::graph::GraphTraversalOptions,
     ) -> anyhow::Result<crate::query::graph::GraphTraversalReport> {
         let options = self.graph_options_with_logical_group(options)?;
-        let results = crate::query::graph::traverse_with_options(
+        let mut results = crate::query::graph::traverse_with_options(
             self.storage.connection(),
             &symbol.qualified_name,
             reverse,
             limit,
             &options,
         )?;
-        let summary = crate::query::graph::traversal_summary(
+        self.enrich_hops_with_oracle(&mut results)?;
+        let mut summary = crate::query::graph::traversal_summary(
             self.storage.connection(),
             &symbol.qualified_name,
             reverse,
@@ -924,6 +1059,12 @@ impl IndexDatabase {
             &options,
             results.len(),
         )?;
+        // Make `completeness_risk` quantitative where the oracle covers the unresolved neighbors:
+        // append a clause like "2 of 7 unresolved are resolved-external: libc, tokio". This is a
+        // read-time annotation derived from the surfaced `resolved-external` verdicts — the risk
+        // *level* string is unchanged; the clause just tells the caller how much of the gap is a
+        // known external dependency rather than a resolver miss.
+        annotate_completeness_with_externals(&mut summary, &results);
         let (logical_symbol, variants) = self.graph_logical_symbol(options.logical_symbol_id)?;
         let mut paths = BTreeSet::new();
         paths.insert(symbol.path.clone());
@@ -1122,6 +1263,91 @@ impl IndexDatabase {
         })
     }
 
+    /// `compare_graph_to_scip` — report where tree-sitter and the compiler (SCIP) DISAGREE on edge
+    /// resolution: the `Contradict` verdicts in `edge_oracle` (the heuristic resolved an edge to an
+    /// in-corpus target the compiler says is wrong, OR resolved in-corpus while the compiler placed
+    /// the callee in a dependency). A user diagnostic + our own resolver-debugging instrument,
+    /// sibling of `compare_graph_to_text`.
+    ///
+    /// Scoped + current ONLY: reads through the store's scope+current join, so a sibling worktree's
+    /// or a drifted/dirty file's verdict is never reported. When no oracle run has populated this
+    /// checkout, `no_oracle_data` is set and the contradiction list is empty (the graph isn't
+    /// "verified to agree" — there's just nothing to compare). The heuristic `edges` row is never
+    /// mutated; this is pure read-time diffing.
+    pub fn compare_graph_to_scip(
+        &self,
+    ) -> anyhow::Result<crate::query::graph::CompareGraphScipReport> {
+        let tool = oracle::OracleTool::RustAnalyzer;
+        let conn = self.storage.connection();
+        let tool_version = oracle::latest_run_tool_version(
+            conn,
+            tool,
+            &self.active_commit_sha,
+            &self.active_worktree_id,
+        )?;
+        let mut summary = crate::query::graph::CompareGraphScipSummary::default();
+        let mut contradictions = Vec::new();
+        let Some(version) = tool_version.clone() else {
+            summary.no_oracle_data = true;
+            summary.warnings.push(
+                "no oracle run for this checkout; run `rag-rat oracle run` to populate compiler \
+                 verdicts before comparing"
+                    .to_string(),
+            );
+            return Ok(crate::query::graph::CompareGraphScipReport {
+                query: crate::query::graph::CompareGraphScipQuery {
+                    tool: tool.as_db_str().to_string(),
+                    tool_version: None,
+                    commit_sha: self.active_commit_sha.clone(),
+                    worktree_id: self.active_worktree_id.clone(),
+                },
+                summary,
+                contradictions,
+            });
+        };
+        let comparisons = oracle::current_oracle_comparisons(
+            conn,
+            tool,
+            &version,
+            &self.active_commit_sha,
+            &self.active_worktree_id,
+        )?;
+        summary.verdicts_examined = u64::try_from(comparisons.len()).unwrap_or(u64::MAX);
+        for comparison in comparisons {
+            if comparison.kind != oracle::OracleResolutionKind::Contradict {
+                continue;
+            }
+            contradictions.push(crate::query::graph::GraphScipContradiction {
+                edge_id: comparison.edge_id,
+                edge_kind: comparison.edge_kind,
+                heuristic_confidence: crate::query::graph::normalize_confidence(
+                    &comparison.heuristic_confidence,
+                )
+                .to_string(),
+                heuristic_target: comparison.heuristic_target,
+                callee_name: comparison.callee_name,
+                resolved_external: resolved_external_label(&comparison.scip_symbol),
+                scip_symbol: comparison.scip_symbol,
+                callsite: Some(crate::query::graph::Callsite {
+                    path: comparison.callsite_path,
+                    line: comparison.callsite_line,
+                    span: [comparison.callsite_line, comparison.callsite_line],
+                }),
+            });
+        }
+        summary.contradictions = u64::try_from(contradictions.len()).unwrap_or(u64::MAX);
+        Ok(crate::query::graph::CompareGraphScipReport {
+            query: crate::query::graph::CompareGraphScipQuery {
+                tool: tool.as_db_str().to_string(),
+                tool_version,
+                commit_sha: self.active_commit_sha.clone(),
+                worktree_id: self.active_worktree_id.clone(),
+            },
+            summary,
+            contradictions,
+        })
+    }
+
     fn graph_logical_symbol(
         &self,
         logical_symbol_id: Option<i64>,
@@ -1285,12 +1511,17 @@ impl IndexDatabase {
         limit: u32,
         options: &crate::query::impact::ImpactSurfaceOptions,
     ) -> anyhow::Result<crate::query::impact::ImpactSurfaceReport> {
-        crate::query::impact::impact_surface_report_for_symbol(
+        let mut report = crate::query::impact::impact_surface_report_for_symbol(
             self.storage.connection(),
             symbol,
             limit,
             options,
-        )
+        )?;
+        // Surface the `Compiler` tier on impact's direct graph neighbors too (same read-side JOIN
+        // as trace_callees/find_callers), so the coding preflight shows compiler-grade resolutions.
+        self.enrich_hops_with_oracle(&mut report.direct_semantic_callers)?;
+        self.enrich_hops_with_oracle(&mut report.direct_semantic_callees)?;
+        Ok(report)
     }
 
     pub fn repo_brief(
@@ -1421,5 +1652,476 @@ impl IndexDatabase {
         memory_id: &str,
     ) -> anyhow::Result<Option<crate::query::memory::RepoMemory>> {
         crate::query::memory::memory_by_id(self.storage.connection(), memory_id)
+    }
+}
+
+/// `resolved-external(<package>)` for a SCIP symbol that names a dependency outside the corpus, or
+/// `None` when it has no package component. Shared by `compare_graph_to_scip` to label a
+/// contradiction whose compiler resolution is external.
+fn resolved_external_label(scip_symbol: &str) -> Option<String> {
+    oracle::package_of(scip_symbol).map(|package| format!("resolved-external({package})"))
+}
+
+/// Append a quantitative clause to `summary.completeness_risk` describing how much of the
+/// unresolved gap the oracle placed in an external dependency, e.g. " (2 of 7 unresolved are
+/// resolved-external: libc, tokio)". Quantitative completeness is the #69 ask: turn the qualitative
+/// risk into a count when the oracle has data. No-op when no hop carries a `resolved-external`
+/// verdict (then the risk string stays purely qualitative). The denominator is `summary.unresolved
+/// + summary.name_only + summary.ambiguous` — every low-confidence/unresolved neighbor the
+/// heuristic couldn't pin down, the population a `resolved-external` placement informs.
+fn annotate_completeness_with_externals(
+    summary: &mut crate::query::graph::GraphTraversalSummary,
+    hops: &[crate::query::graph::GraphHop],
+) {
+    let mut packages: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    let mut external_count = 0u64;
+    for hop in hops {
+        if let Some(label) = &hop.resolved_external {
+            external_count += 1;
+            // `resolved-external(<package>)` → `<package>` for the readable list.
+            if let Some(package) =
+                label.strip_prefix("resolved-external(").and_then(|rest| rest.strip_suffix(')'))
+            {
+                packages.insert(package.to_string());
+            }
+        }
+    }
+    if external_count == 0 {
+        return;
+    }
+    let gap =
+        summary.unresolved.saturating_add(summary.name_only).saturating_add(summary.ambiguous);
+    let denominator = gap.max(external_count);
+    let package_list = packages.into_iter().collect::<Vec<_>>().join(", ");
+    let clause = if package_list.is_empty() {
+        format!(" ({external_count} of {denominator} unresolved are resolved-external)")
+    } else {
+        format!(
+            " ({external_count} of {denominator} unresolved are resolved-external: {package_list})"
+        )
+    };
+    summary.completeness_risk.push_str(&clause);
+}
+
+#[cfg(test)]
+mod oracle_surfacing_tests {
+    //! End-to-end integration tests for the phase-2 (#69) read-side surfacing through the public
+    //! `IndexDatabase` API: build a real temp Rust checkout with an intra-file call, rebuild, run
+    //! the oracle over a programmatically-built `.scip` (the deterministic `--scip` consumption
+    //! path — no rust-analyzer), and assert the `Compiler` tier / `resolved-external` /
+    //! `compare_graph_to_scip` / gc behaviours. Models `eval::tests::eval_suite_runs_oracle_*`.
+
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use ::protobuf::{EnumOrUnknown, Message};
+    use ::scip::types::{Document, Index, Occurrence, PositionEncoding, SymbolRole};
+
+    use super::*;
+    use crate::config::ResolvedTarget;
+    use crate::index::oracle::OracleTool;
+
+    static N: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_root() -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "rag-rat-q-oracle-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(root.join("src")).unwrap();
+        root
+    }
+
+    fn rust_config(root: PathBuf) -> Config {
+        Config {
+            root: root.clone(),
+            database: root.join(".rag-rat/index.sqlite"),
+            targets: vec![ResolvedTarget {
+                name: "rust".to_string(),
+                language: Language::Rust,
+                directories: vec![PathBuf::from("src")],
+                include: vec!["src/".to_string()],
+                exclude: Vec::new(),
+                kind: TargetKind::Source,
+            }],
+            local_ai: Default::default(),
+            watch: Default::default(),
+        }
+    }
+
+    /// The callee identifier byte range of the (single) `calls_name` edge, read back from the DB so
+    /// the `.scip` occurrence aligns exactly with what the indexer recorded.
+    fn call_edge(db: &IndexDatabase) -> (i64, i64, i64, String) {
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT edges.id, edges.callee_start_byte, edges.callee_end_byte, files.path
+                 FROM edges JOIN files ON files.id = edges.source_file_id
+                 WHERE edges.edge_kind = 'calls_name' AND edges.callee_start_byte IS NOT NULL
+                 LIMIT 1",
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, String>(3)?,
+                    ))
+                },
+            )
+            .unwrap()
+    }
+
+    /// Build a `.scip` over a single-line source file: a reference occurrence at the callee byte
+    /// range (single-line → char == byte for ASCII) plus a definition occurrence for the same
+    /// symbol at `def_range`. `def_path` is where the definition lives (in-corpus → Upgrade;
+    /// elsewhere/external symbol → resolved-external).
+    fn scip_with(
+        path: &str,
+        callee_start: i64,
+        callee_end: i64,
+        symbol: &str,
+        def_path: Option<&str>,
+        def_range: Option<(i64, i64)>,
+    ) -> Vec<u8> {
+        let occ = |start: i64, end: i64, role: SymbolRole| Occurrence {
+            range: vec![0, start as i32, end as i32],
+            symbol: symbol.to_string(),
+            symbol_roles: role as i32,
+            ..Default::default()
+        };
+        let mut documents = vec![Document {
+            relative_path: path.to_string(),
+            occurrences: vec![occ(callee_start, callee_end, SymbolRole::UnspecifiedSymbolRole)],
+            position_encoding: EnumOrUnknown::new(
+                PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+            ),
+            ..Default::default()
+        }];
+        if let (Some(def_path), Some((ds, de))) = (def_path, def_range) {
+            // A def in the SAME file must be appended to that document's occurrence list, not
+            // pushed as a SECOND document with the same `relative_path` —
+            // `ScipIndex::from_index` keys `occurrences_by_path` by path, so a
+            // duplicate-path document overwrites the ref.
+            if def_path == path {
+                documents[0].occurrences.push(occ(ds, de, SymbolRole::Definition));
+            } else {
+                documents.push(Document {
+                    relative_path: def_path.to_string(),
+                    occurrences: vec![occ(ds, de, SymbolRole::Definition)],
+                    position_encoding: EnumOrUnknown::new(
+                        PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+                    ),
+                    ..Default::default()
+                });
+            }
+        }
+        Index { documents, ..Default::default() }.write_to_bytes().unwrap()
+    }
+
+    /// The full path: rebuild a checkout where `caller` calls `target`, run the oracle from a
+    /// pre-built `.scip` that resolves the call in-corpus, and assert `find_callers` /
+    /// `trace_callees` surface the `compiler` tier with the `scip:<tool>@<version>` reason — while
+    /// the heuristic `edges` row is untouched. Also asserts `compare_graph_to_scip` reports no
+    /// contradiction (an Upgrade is agreement-shaped, not a disagreement).
+    #[test]
+    fn oracle_run_from_scip_surfaces_compiler_tier() {
+        let root = temp_root();
+        // Single line so byte offsets == char offsets (ASCII): `target` is the callee.
+        fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
+        let config = rust_config(root.clone());
+        let db = IndexDatabase::rebuild(&config).unwrap();
+
+        let (edge_id, callee_start, callee_end, path) = call_edge(&db);
+        // `target` definition: `fn target() {}` → identifier `target` at bytes 29..35.
+        let symbol = "scip-rust crate held-mini `target`().";
+        let scip = scip_with(&path, callee_start, callee_end, symbol, Some(&path), Some((29, 35)));
+
+        let report = db.run_oracle_from_scip(OracleTool::RustAnalyzer, "v-test", &scip).unwrap();
+        // `target` is defined in-corpus, so the heuristic resolves it; the oracle CONFIRMS it. Both
+        // Confirm and Upgrade surface the `compiler` tier.
+        assert!(
+            report.confirmed >= 1 || report.upgraded >= 1,
+            "expected in-corpus confirm/upgrade, got {report:?}"
+        );
+
+        // find_callers (reverse) surfaces the compiler tier on the matching edge.
+        let callers = db
+            .find_callers_with_options("target", 50, &crate::query::graph::GraphTraversalOptions {
+                include_unresolved: true,
+                ..Default::default()
+            })
+            .unwrap();
+        let hop = callers.iter().find(|h| h.edge_id == edge_id).expect("call edge present");
+        assert_eq!(hop.confidence, "compiler", "expected Compiler tier surfaced");
+        assert_eq!(hop.resolution_reason.as_deref(), Some("scip:rust-analyzer@v-test"));
+        // The heuristic edge confidence is preserved (not overwritten).
+        assert_ne!(hop.edge_confidence, "compiler");
+
+        // The heuristic `edges` row was never mutated by the oracle pass.
+        let edge_confidence: String = db
+            .storage
+            .connection()
+            .query_row("SELECT confidence FROM edges WHERE id = ?1", params![edge_id], |r| r.get(0))
+            .unwrap();
+        assert_ne!(edge_confidence, "compiler");
+
+        // An Upgrade is agreement-shaped → compare_graph_to_scip reports no contradiction.
+        let compare = db.compare_graph_to_scip().unwrap();
+        assert!(!compare.summary.no_oracle_data);
+        assert_eq!(compare.summary.contradictions, 0);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// Staleness revert: after a current run surfaces `compiler`, drifting the source file (so its
+    /// `files.sha256` no longer matches the verdict's `file_sha`) reverts the edge to heuristic
+    /// display — never `compiler`.
+    #[test]
+    fn drifted_file_reverts_to_heuristic_display() {
+        let root = temp_root();
+        fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
+        let config = rust_config(root.clone());
+        let db = IndexDatabase::rebuild(&config).unwrap();
+
+        let (edge_id, cs, ce, path) = call_edge(&db);
+        let symbol = "scip-rust crate held-mini `target`().";
+        let scip = scip_with(&path, cs, ce, symbol, Some(&path), Some((29, 35)));
+        db.run_oracle_from_scip(OracleTool::RustAnalyzer, "v-test", &scip).unwrap();
+
+        // Drift the recorded sha so the verdict's file_sha no longer matches (file changed). The
+        // active connection exposes `files` as a scoped TEMP VIEW (read-only), so the UPDATE must
+        // target the underlying `main.files` table.
+        db.storage
+            .connection()
+            .execute("UPDATE main.files SET sha256 = 'drifted' WHERE path = ?1", params![path])
+            .unwrap();
+
+        let callers = db
+            .find_callers_with_options("target", 50, &crate::query::graph::GraphTraversalOptions {
+                include_unresolved: true,
+                ..Default::default()
+            })
+            .unwrap();
+        let hop = callers.iter().find(|h| h.edge_id == edge_id).expect("call edge present");
+        assert_ne!(hop.confidence, "compiler", "drifted file must revert to heuristic display");
+        assert!(hop.resolution_reason.is_none());
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// `resolved-external`: a `.scip` resolving the callee to a packaged dependency symbol with no
+    /// in-corpus definition surfaces `resolved_external = resolved-external(<package>)` on the hop,
+    /// and feeds the quantitative completeness clause in the graph report.
+    #[test]
+    fn external_resolution_surfaces_resolved_external_label() {
+        let root = temp_root();
+        // `external_fn` is NOT defined in-corpus → the heuristic can't resolve it (NameOnly /
+        // unresolved), so SCIP's external resolution is a clean `resolved-external`, not a
+        // contradiction of an in-corpus claim.
+        fs::write(root.join("src/lib.rs"), "fn caller() { external_fn(); }\n").unwrap();
+        let config = rust_config(root.clone());
+        let db = IndexDatabase::rebuild(&config).unwrap();
+
+        let (edge_id, cs, ce, path) = call_edge(&db);
+        // A packaged SCIP symbol with NO in-corpus definition occurrence →
+        // resolved-external(tokio).
+        let symbol = "scip-rust cargo tokio 1.0 `external_fn`().";
+        let scip = scip_with(&path, cs, ce, symbol, None, None);
+        let report = db.run_oracle_from_scip(OracleTool::RustAnalyzer, "v-test", &scip).unwrap();
+        assert!(report.resolved_external >= 1, "expected resolved-external, got {report:?}");
+
+        let callees = db
+            .trace_callees_with_options("caller", 50, &crate::query::graph::GraphTraversalOptions {
+                include_unresolved: true,
+                ..Default::default()
+            })
+            .unwrap();
+        let hop = callees.iter().find(|h| h.edge_id == edge_id).expect("call edge present");
+        assert_eq!(hop.resolved_external.as_deref(), Some("resolved-external(tokio)"));
+        // External placement is not an in-corpus upgrade → confidence stays heuristic.
+        assert_ne!(hop.confidence, "compiler");
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// `compare_graph_to_scip` reports a contradiction when the heuristic resolved an edge
+    /// in-corpus but the compiler resolves the callee to a DIFFERENT (external) target.
+    #[test]
+    fn compare_graph_to_scip_reports_contradiction() {
+        let root = temp_root();
+        fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
+        let config = rust_config(root.clone());
+        let db = IndexDatabase::rebuild(&config).unwrap();
+
+        let (edge_id, cs, ce, path) = call_edge(&db);
+        // Force the heuristic edge to look in-corpus-resolved (Exact + to_symbol_id), so the
+        // compiler's external resolution is a contradiction, not a plain resolved-external.
+        let target_sym: i64 = db
+            .storage
+            .connection()
+            .query_row("SELECT id FROM symbols WHERE name = 'target' LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        db.storage
+            .connection()
+            .execute(
+                "UPDATE edges SET confidence = 'Exact', resolution = 'exact', to_symbol_id = ?2 \
+                 WHERE id = ?1",
+                params![edge_id, target_sym],
+            )
+            .unwrap();
+
+        // The compiler says the callee is actually `other::target` in a dependency → contradiction.
+        let symbol = "scip-rust cargo other 1.0 `target`().";
+        let scip = scip_with(&path, cs, ce, symbol, None, None);
+        db.run_oracle_from_scip(OracleTool::RustAnalyzer, "v-test", &scip).unwrap();
+
+        let compare = db.compare_graph_to_scip().unwrap();
+        assert_eq!(compare.summary.contradictions, 1, "{compare:?}");
+        let c = &compare.contradictions[0];
+        assert_eq!(c.edge_id, edge_id);
+        assert_eq!(c.heuristic_confidence, "exact");
+        assert_eq!(c.resolved_external.as_deref(), Some("resolved-external(other)"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// gc prunes `oracle_runs` for dead checkout contexts: an oracle run recorded under a sibling
+    /// `(commit, worktree)` is dropped by `prune_to_live` when that context is not live.
+    #[test]
+    fn gc_prunes_oracle_runs_for_dead_contexts() {
+        let root = temp_root();
+        fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
+        let config = rust_config(root.clone());
+        let db = IndexDatabase::rebuild(&config).unwrap();
+
+        // Record a run for THIS (active) checkout + a run for a dead sibling context.
+        crate::index::oracle::run_oracle(
+            db.storage.connection(),
+            OracleTool::RustAnalyzer,
+            "v-test",
+            &db.active_commit_sha,
+            &db.active_worktree_id,
+            &Index::default().write_to_bytes().unwrap(),
+            &root,
+        )
+        .unwrap();
+        db.storage
+            .connection()
+            .execute(
+                "INSERT INTO oracle_runs(tool, tool_version, commit_sha, worktree_id, started_at, \
+                 status, stats_json) VALUES ('rust-analyzer', 'v-test', 'dead-commit', \
+                 'dead-worktree', 0, 'Completed', '{}')",
+                [],
+            )
+            .unwrap();
+        let before: i64 = db
+            .storage
+            .connection()
+            .query_row("SELECT COUNT(*) FROM oracle_runs", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(before, 2);
+
+        // gc keeps the active context and prunes the dead one.
+        db.prune_to_live(
+            std::slice::from_ref(&db.active_commit_sha),
+            std::slice::from_ref(&db.active_worktree_id),
+        )
+        .unwrap();
+
+        let remaining: Vec<String> = {
+            let conn = db.storage.connection();
+            let mut stmt = conn.prepare("SELECT commit_sha FROM oracle_runs").unwrap();
+            stmt.query_map([], |r| r.get::<_, String>(0))
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+        };
+        assert!(
+            !remaining.iter().any(|c| c == "dead-commit"),
+            "dead-context oracle_runs row must be pruned: {remaining:?}"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn resolved_external_label_extracts_package() {
+        assert_eq!(
+            resolved_external_label("scip-rust cargo tokio 1.0 `spawn`()."),
+            Some("resolved-external(tokio)".to_string())
+        );
+        // A symbol with no package component yields no label.
+        assert_eq!(resolved_external_label("local 0"), None);
+    }
+
+    #[test]
+    fn completeness_annotation_counts_externals_and_lists_packages() {
+        let mut summary = crate::query::graph::GraphTraversalSummary {
+            unresolved: 5,
+            completeness_risk: "medium".to_string(),
+            ..Default::default()
+        };
+        let hop = |external: Option<&str>| crate::query::graph::GraphHop {
+            edge_id: 0,
+            from_symbol: None,
+            to_symbol: None,
+            edge_kind: "calls_name".to_string(),
+            confidence: "name_only".to_string(),
+            edge_confidence: "name_only".to_string(),
+            target: None,
+            target_qualified_name: None,
+            evidence: None,
+            receiver_hint: None,
+            resolution: "unresolved".to_string(),
+            resolution_reason: None,
+            resolved_external: external.map(str::to_string),
+            verified_target_symbol: false,
+            shown_by_default: true,
+            callsite: None,
+        };
+        let hops = vec![
+            hop(Some("resolved-external(tokio)")),
+            hop(Some("resolved-external(libc)")),
+            hop(None),
+        ];
+        annotate_completeness_with_externals(&mut summary, &hops);
+        assert_eq!(
+            summary.completeness_risk,
+            "medium (2 of 5 unresolved are resolved-external: libc, tokio)"
+        );
+
+        // No externals → the qualitative string is left untouched.
+        let mut bare = crate::query::graph::GraphTraversalSummary {
+            unresolved: 3,
+            completeness_risk: "high".to_string(),
+            ..Default::default()
+        };
+        annotate_completeness_with_externals(&mut bare, &[hop(None)]);
+        assert_eq!(bare.completeness_risk, "high");
+    }
+
+    /// `run_oracle_with_tool` degrades to `Blocked` (never an error) when the indexer isn't
+    /// installed — the missing-embedding-model UX. Skipped when rust-analyzer happens to be on PATH
+    /// (then the subprocess path runs, which this test doesn't assert).
+    #[test]
+    fn oracle_run_without_tool_is_blocked_not_error() {
+        if std::process::Command::new("rust-analyzer")
+            .arg("--version")
+            .output()
+            .is_ok_and(|o| o.status.success())
+        {
+            return; // rust-analyzer present; the Blocked path isn't exercised here.
+        }
+        let root = temp_root();
+        fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+        let config = rust_config(root.clone());
+        let db = IndexDatabase::rebuild(&config).unwrap();
+        let outcome =
+            db.run_oracle_with_tool(OracleTool::RustAnalyzer, &root.join("o.scip")).unwrap();
+        assert!(matches!(outcome, crate::index::oracle::OracleRunOutcome::Blocked { .. }));
+        let _ = fs::remove_dir_all(&root);
     }
 }

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -8,11 +8,15 @@ impl IndexDatabase {
     /// edge candidates, writing `edge_oracle` verdicts. The heuristic resolution on the `edges`
     /// row is never touched. Phase 1 (#68): eval-only, no CLI/MCP surface. Requires a `source_root`
     /// (the checkout whose bytes back the SCIP document position-encoding conversion).
+    /// `production_sha` is the per-document disk-hash snapshot a tool-driven run captured the
+    /// instant its `.scip` was produced (`Some`), arming the scip-vs-disk content gate (#82
+    /// TOCTOU); a pre-built `--scip` has no production moment and passes `None`.
     pub fn run_oracle(
         &self,
         tool: OracleTool,
         tool_version: &str,
         scip_bytes: &[u8],
+        production_sha: Option<&std::collections::HashMap<String, String>>,
     ) -> anyhow::Result<OracleReport> {
         let Some(root) = self.storage.source_root() else {
             anyhow::bail!(
@@ -28,6 +32,7 @@ impl IndexDatabase {
             &self.active_worktree_id,
             scip_bytes,
             &root,
+            production_sha,
         )
     }
 
@@ -102,7 +107,9 @@ impl IndexDatabase {
         tool_version: &str,
         scip_bytes: &[u8],
     ) -> anyhow::Result<oracle::OracleReport> {
-        self.run_oracle(tool, tool_version, scip_bytes)
+        // A pre-built `--scip` carries no production moment we control, so there is no per-document
+        // snapshot to pin — the scip-vs-disk gate is off and only the index-vs-disk gate applies.
+        self.run_oracle(tool, tool_version, scip_bytes, None)
     }
 
     /// Probe whether an oracle tool is installed, for `oracle status`. A `Blocked` probe is
@@ -947,9 +954,13 @@ impl IndexDatabase {
     ///   target, so promoting it would assert a resolution we don't stand behind — it stays
     ///   heuristic (`compare_graph_to_scip` is where contradictions surface).
     ///
-    /// Dirty/overlay (uncommitted) edges never carry oracle verdicts (oracle rows bind to
-    /// commit-scoped index rows only), so they always show heuristic — this falls out of the
-    /// `(commit_sha, worktree_id)` scope with no special-casing.
+    /// Verdicts bind to whichever files are the ACTIVE version of the checkout, not to
+    /// commit-scoped rows specifically: on a clean tree that's the committed `(sha,'')` rows;
+    /// on a dirty tree the worktree-dirty `('',wt)` overlay rows shadow them. The shared
+    /// active-checkout predicate (the #82 P0 fix) selects exactly one version per file, so a
+    /// verdict surfaces only for the version in play — a verdict written against a file that
+    /// has since been overlaid (or that belongs to a non-active checkout) drops out of scope
+    /// and the hop reverts to heuristic, with no special-casing.
     /// Returns whether any hop was PROMOTED to the `compiler` tier — i.e. whether enrichment
     /// changed a hop's `effective_confidence_rank`. Only an `Upgrade`/`Confirm` that became
     /// `compiler` changes ranking; a `ResolvedExternal` sets a label but leaves the confidence
@@ -1001,7 +1012,7 @@ impl IndexDatabase {
                     // moving the target would attach the compiler tier to a heuristic/absent
                     // target (#82 finding 2). If the resolved symbol can't be surfaced (it was
                     // deleted/reinserted, so its qualified name is gone — though the def-drift gate
-                    // in `EDGE_ORACLE_CURRENT_PREDICATE` already filters that case), do NOT
+                    // in `edge_oracle_current_predicate` already filters that case), do NOT
                     // promote.
                     let Some(resolved_name) = verdict.resolved_qualified_name.clone() else {
                         continue;
@@ -2338,6 +2349,7 @@ mod oracle_surfacing_tests {
             &db.active_worktree_id,
             &Index::default().write_to_bytes().unwrap(),
             &root,
+            None,
         )
         .unwrap();
         db.storage

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -928,15 +928,7 @@ impl IndexDatabase {
         options: &crate::query::graph::GraphTraversalOptions,
     ) -> anyhow::Result<Vec<crate::query::graph::GraphHop>> {
         let options = self.graph_options_with_logical_group(options)?;
-        let mut hops = crate::query::graph::traverse_with_options(
-            self.storage.connection(),
-            symbol,
-            true,
-            limit,
-            &options,
-        )?;
-        self.enrich_hops_with_oracle(&mut hops)?;
-        Ok(hops)
+        self.traverse_with_oracle(symbol, true, limit, &options)
     }
 
     /// Upgrade graph hops to the `Compiler` confidence tier where a CURRENT, in-scope `edge_oracle`
@@ -994,6 +986,20 @@ impl IndexDatabase {
             };
             match verdict.kind {
                 oracle::OracleResolutionKind::Upgrade | oracle::OracleResolutionKind::Confirm => {
+                    // Hydrate the hop's target from the compiler's `resolved_symbol_id` BEFORE
+                    // promoting to `compiler` — for an `Upgrade` on a `NameOnly`/`Ambiguous` edge
+                    // the heuristic target is missing or wrong, so promoting confidence without
+                    // moving the target would attach the compiler tier to a heuristic/absent
+                    // target (#82 finding 2). If the resolved symbol can't be surfaced (it was
+                    // deleted/reinserted, so its qualified name is gone — though the def-drift gate
+                    // in `EDGE_ORACLE_CURRENT_PREDICATE` already filters that case), do NOT
+                    // promote.
+                    let Some(resolved_name) = verdict.resolved_qualified_name.clone() else {
+                        continue;
+                    };
+                    hop.to_symbol = Some(resolved_name.clone());
+                    hop.target_qualified_name = Some(resolved_name);
+                    hop.verified_target_symbol = true;
                     hop.confidence = "compiler".to_string();
                     hop.resolution_reason = Some(verdict.resolution_reason());
                 },
@@ -1006,6 +1012,43 @@ impl IndexDatabase {
             }
         }
         Ok(())
+    }
+
+    /// Traverse, surface the `Compiler` tier, then rank-and-truncate so a compiler-upgraded edge is
+    /// never dropped by the heuristic limit (#82 finding 4).
+    ///
+    /// The heuristic `traverse_with_options` orders by heuristic confidence and applies `LIMIT`
+    /// BEFORE oracle enrichment runs — so a low-confidence edge the compiler would upgrade to
+    /// `compiler` (the tier ABOVE `exact`) can fall below the cutoff and never be fetched, even
+    /// though it should outrank the `exact`/`syntactic` neighbors that displaced it. To fix the
+    /// ordering we OVERFETCH (traverse with an inflated cap), enrich the larger candidate set,
+    /// RE-SORT by EFFECTIVE confidence (`compiler` > `exact` > `syntactic` > `name_only` >
+    /// `ambiguous`) with a stable tiebreak on the heuristic order, and only THEN truncate to
+    /// `limit`. The overfetch cap is bounded so a huge `limit` can't blow up the candidate set; an
+    /// edge upgraded beyond the overfetch window is the residual we accept (the heuristic already
+    /// ranked it far down, and the window is generous).
+    fn traverse_with_oracle(
+        &self,
+        symbol: &str,
+        reverse: bool,
+        limit: u32,
+        options: &crate::query::graph::GraphTraversalOptions,
+    ) -> anyhow::Result<Vec<crate::query::graph::GraphHop>> {
+        let overfetch = crate::query::graph::oracle_overfetch_limit(limit);
+        let mut hops = crate::query::graph::traverse_with_options(
+            self.storage.connection(),
+            symbol,
+            reverse,
+            overfetch,
+            options,
+        )?;
+        self.enrich_hops_with_oracle(&mut hops)?;
+        // Stable sort by effective (post-enrichment) confidence so a `compiler` upgrade rises above
+        // the heuristic `exact`/`syntactic` edges that out-ranked it in the SQL ORDER BY. Stable
+        // keeps the heuristic order within a tier.
+        hops.sort_by_key(|hop| crate::query::graph::effective_confidence_rank(&hop.confidence));
+        hops.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
+        Ok(hops)
     }
 
     pub fn trace_callees(
@@ -1023,15 +1066,7 @@ impl IndexDatabase {
         options: &crate::query::graph::GraphTraversalOptions,
     ) -> anyhow::Result<Vec<crate::query::graph::GraphHop>> {
         let options = self.graph_options_with_logical_group(options)?;
-        let mut hops = crate::query::graph::traverse_with_options(
-            self.storage.connection(),
-            symbol,
-            false,
-            limit,
-            &options,
-        )?;
-        self.enrich_hops_with_oracle(&mut hops)?;
-        Ok(hops)
+        self.traverse_with_oracle(symbol, false, limit, &options)
     }
 
     pub fn graph_traversal_report(
@@ -1043,14 +1078,12 @@ impl IndexDatabase {
         options: &crate::query::graph::GraphTraversalOptions,
     ) -> anyhow::Result<crate::query::graph::GraphTraversalReport> {
         let options = self.graph_options_with_logical_group(options)?;
-        let mut results = crate::query::graph::traverse_with_options(
-            self.storage.connection(),
-            &symbol.qualified_name,
-            reverse,
-            limit,
-            &options,
-        )?;
-        self.enrich_hops_with_oracle(&mut results)?;
+        // Overfetch + enrich + re-rank + truncate so a compiler-upgraded edge survives the limit
+        // (#82 finding 4). `traversal_summary` below still describes the FULL matching population
+        // (its own COUNT query, independent of the returned window), so passing the truncated
+        // `results.len()` as the returned count stays correct.
+        let results =
+            self.traverse_with_oracle(&symbol.qualified_name, reverse, limit, &options)?;
         let mut summary = crate::query::graph::traversal_summary(
             self.storage.connection(),
             &symbol.qualified_name,
@@ -1326,7 +1359,18 @@ impl IndexDatabase {
                 .to_string(),
                 heuristic_target: comparison.heuristic_target,
                 callee_name: comparison.callee_name,
-                resolved_external: resolved_external_label(&comparison.scip_symbol),
+                // Label `resolved-external` ONLY for a contradiction the compiler resolved OUTSIDE
+                // the corpus (`resolved_symbol_id IS NULL`). A Rust SCIP symbol carries a
+                // crate/package component even for the LOCAL crate (`scip-rust crate held-mini …`),
+                // so deriving the label from `scip_symbol` alone would mislabel an IN-CORPUS
+                // contradiction (the compiler resolved to a *different* in-corpus symbol) as
+                // `resolved-external(<local-crate>)` (#82 finding 1). An in-corpus contradiction is
+                // a same-corpus disagreement, not an external placement.
+                resolved_external: comparison
+                    .resolved_symbol_id
+                    .is_none()
+                    .then(|| resolved_external_label(&comparison.scip_symbol))
+                    .flatten(),
                 scip_symbol: comparison.scip_symbol,
                 callsite: Some(crate::query::graph::Callsite {
                     path: comparison.callsite_path,
@@ -1511,16 +1555,19 @@ impl IndexDatabase {
         limit: u32,
         options: &crate::query::impact::ImpactSurfaceOptions,
     ) -> anyhow::Result<crate::query::impact::ImpactSurfaceReport> {
-        let mut report = crate::query::impact::impact_surface_report_for_symbol(
+        // Surface the `Compiler` tier on impact's direct graph neighbors too (same read-side JOIN
+        // as trace_callees/find_callers). The enrichment is now injected INTO the builder so it
+        // runs over the OVERFETCHED candidate set before the re-rank + limit truncation (#82
+        // finding
+        // 4) and before the memory-evidence edge-id collection — so a compiler-upgraded neighbor
+        // can't be dropped by the heuristic limit, and downstream counts see the final window.
+        let report = crate::query::impact::impact_surface_report_for_symbol(
             self.storage.connection(),
             symbol,
             limit,
             options,
+            |hops| self.enrich_hops_with_oracle(hops),
         )?;
-        // Surface the `Compiler` tier on impact's direct graph neighbors too (same read-side JOIN
-        // as trace_callees/find_callers), so the coding preflight shows compiler-grade resolutions.
-        self.enrich_hops_with_oracle(&mut report.direct_semantic_callers)?;
-        self.enrich_hops_with_oracle(&mut report.direct_semantic_callees)?;
         Ok(report)
     }
 
@@ -1984,6 +2031,225 @@ mod oracle_surfacing_tests {
         assert_eq!(c.edge_id, edge_id);
         assert_eq!(c.heuristic_confidence, "exact");
         assert_eq!(c.resolved_external.as_deref(), Some("resolved-external(other)"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// #82 finding 1: an IN-CORPUS contradiction (the compiler resolved the callee to a DIFFERENT
+    /// in-corpus symbol than the heuristic) must NOT be labeled `resolved-external`. A Rust SCIP
+    /// symbol carries a crate/package component even for the LOCAL crate, so deriving the label
+    /// from `scip_symbol` alone would mislabel it as `resolved-external(held-mini)`.
+    #[test]
+    fn in_corpus_contradiction_is_not_labeled_resolved_external() {
+        let root = temp_root();
+        // Two in-corpus defs. The heuristic resolves `target()` to `target`; the compiler resolves
+        // the same callsite to the OTHER in-corpus def `other` → in-corpus Contradict.
+        fs::write(
+            root.join("src/lib.rs"),
+            "fn caller() { target(); } fn target() {} fn other() {}\n",
+        )
+        .unwrap();
+        let config = rust_config(root.clone());
+        let db = IndexDatabase::rebuild(&config).unwrap();
+
+        let (edge_id, cs, ce, path) = call_edge(&db);
+        // Force the heuristic edge to look in-corpus-resolved to `target` (Exact + to_symbol_id).
+        let target_sym: i64 = db
+            .storage
+            .connection()
+            .query_row("SELECT id FROM symbols WHERE name = 'target' LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        db.storage
+            .connection()
+            .execute(
+                "UPDATE edges SET confidence = 'Exact', resolution = 'exact', to_symbol_id = ?2 \
+                 WHERE id = ?1",
+                params![edge_id, target_sym],
+            )
+            .unwrap();
+        // The compiler resolves the callee to the in-corpus def `other` (a LOCAL-crate SCIP
+        // symbol), whose definition occurrence sits at `other`'s recorded byte span.
+        let (other_start, other_end): (i64, i64) = db
+            .storage
+            .connection()
+            .query_row(
+                "SELECT start_byte, end_byte FROM symbols WHERE name = 'other' LIMIT 1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        let symbol = "scip-rust crate held-mini `other`().";
+        let scip = scip_with(&path, cs, ce, symbol, Some(&path), Some((other_start, other_end)));
+        db.run_oracle_from_scip(OracleTool::RustAnalyzer, "v-test", &scip).unwrap();
+
+        let compare = db.compare_graph_to_scip().unwrap();
+        assert_eq!(compare.summary.contradictions, 1, "{compare:?}");
+        let c = &compare.contradictions[0];
+        assert_eq!(c.edge_id, edge_id);
+        // The disagreement is in-corpus → no external label, even though the SCIP symbol names the
+        // local crate.
+        assert_eq!(
+            c.resolved_external, None,
+            "an in-corpus contradiction must not be labeled resolved-external"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// #82 finding 2: an `Upgrade` on a heuristic-unresolved edge must surface the SCIP-RESOLVED
+    /// symbol as the hop's target, not the heuristic's missing/heuristic one. We strip the
+    /// heuristic resolution (NameOnly, no `to_symbol_id`) and let the compiler resolve in-corpus,
+    /// then read FORWARD from `caller` (robust for an unresolved edge) and assert the hop's target
+    /// moved to the compiler-resolved symbol.
+    #[test]
+    fn upgrade_hydrates_target_from_compiler_resolution() {
+        let root = temp_root();
+        fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
+        let config = rust_config(root.clone());
+        let db = IndexDatabase::rebuild(&config).unwrap();
+
+        let (edge_id, cs, ce, path) = call_edge(&db);
+        let target_qualified: String = db
+            .storage
+            .connection()
+            .query_row(
+                "SELECT qualified_name FROM symbols WHERE name = 'target' LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let (target_start, target_end): (i64, i64) = db
+            .storage
+            .connection()
+            .query_row(
+                "SELECT start_byte, end_byte FROM symbols WHERE name = 'target' LIMIT 1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        // Demote the heuristic edge to a genuine miss: NameOnly, no resolved target / qualified
+        // name. A promotion that didn't MOVE the target would surface this absent one.
+        db.storage
+            .connection()
+            .execute(
+                "UPDATE edges SET confidence = 'NameOnly', resolution = 'name_only', to_symbol_id \
+                 = NULL, target_qualified_name = NULL WHERE id = ?1",
+                params![edge_id],
+            )
+            .unwrap();
+        let symbol = "scip-rust crate held-mini `target`().";
+        let scip = scip_with(&path, cs, ce, symbol, Some(&path), Some((target_start, target_end)));
+        let report = db.run_oracle_from_scip(OracleTool::RustAnalyzer, "v-test", &scip).unwrap();
+        assert!(report.upgraded >= 1, "expected an Upgrade, got {report:?}");
+
+        let callees = db
+            .trace_callees_with_options("caller", 50, &crate::query::graph::GraphTraversalOptions {
+                include_unresolved: true,
+                ..Default::default()
+            })
+            .unwrap();
+        let hop = callees.iter().find(|h| h.edge_id == edge_id).expect("call edge present");
+        assert_eq!(hop.confidence, "compiler", "an Upgrade surfaces the compiler tier");
+        // The target moved to the SCIP-resolved symbol, not the heuristic's absent target.
+        assert_eq!(hop.to_symbol.as_deref(), Some(target_qualified.as_str()));
+        assert_eq!(hop.target_qualified_name.as_deref(), Some(target_qualified.as_str()));
+        assert!(hop.verified_target_symbol, "the compiler-resolved target is verified");
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// #82 finding 4: a compiler-`Upgrade`d low-confidence neighbor must appear within `limit` even
+    /// when more `Exact` neighbors than `limit` outrank it heuristically. Oracle enrichment runs
+    /// AFTER the heuristic-ordered limit, so without overfetch+re-rank the upgraded edge is
+    /// dropped.
+    #[test]
+    fn compiler_upgrade_survives_heuristic_limit() {
+        let root = temp_root();
+        // Single line so byte offsets == char offsets (ASCII) for the `.scip` occurrence. `pull` is
+        // the upgrade target; two of its three callers are Exact (high heuristic rank), the third
+        // is a name-only miss the compiler upgrades.
+        fs::write(
+            root.join("src/lib.rs"),
+            "fn pull() {} fn a() { pull(); } fn b() { pull(); } fn c() { pull(); }\n",
+        )
+        .unwrap();
+        let config = rust_config(root.clone());
+        let db = IndexDatabase::rebuild(&config).unwrap();
+
+        // Find the three call edges to `pull`. Make two of them Exact (high heuristic rank) and the
+        // third a NameOnly miss the compiler will upgrade.
+        let edges: Vec<(i64, i64, i64, String)> = {
+            let conn = db.storage.connection();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT edges.id, edges.callee_start_byte, edges.callee_end_byte, files.path \
+                     FROM edges JOIN files ON files.id = edges.source_file_id WHERE \
+                     edges.edge_kind = 'calls_name' AND edges.callee_start_byte IS NOT NULL ORDER \
+                     BY edges.id",
+                )
+                .unwrap();
+            let rows = stmt
+                .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get::<_, String>(3)?)))
+                .unwrap();
+            rows.map(Result::unwrap).collect()
+        };
+        assert_eq!(edges.len(), 3, "three calls to pull");
+        let pull_sym: i64 = db
+            .storage
+            .connection()
+            .query_row("SELECT id FROM symbols WHERE name = 'pull' LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        let (pull_start, pull_end): (i64, i64) = db
+            .storage
+            .connection()
+            .query_row(
+                "SELECT start_byte, end_byte FROM symbols WHERE name = 'pull' LIMIT 1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        // Edges 0,1: Exact resolved to `pull`. Edge 2: NameOnly miss (the upgrade candidate).
+        let conn = db.storage.connection();
+        for (edge_id, ..) in &edges[..2] {
+            conn.execute(
+                "UPDATE edges SET confidence = 'Exact', resolution = 'exact', to_symbol_id = ?2 \
+                 WHERE id = ?1",
+                params![edge_id, pull_sym],
+            )
+            .unwrap();
+        }
+        let (upgrade_edge, ucs, uce, path) = edges[2].clone();
+        // NameOnly (heuristically low rank, below the Exact callers) but still target-resolved to
+        // `pull` so the reverse traversal includes it as a candidate. The oracle still classifies
+        // it an Upgrade (the heuristic didn't resolve it Exact/Syntactic-in-corpus), and
+        // the re-rank must lift it above the Exact callers within the limit.
+        conn.execute(
+            "UPDATE edges SET confidence = 'NameOnly', resolution = 'name_only', to_symbol_id = \
+             ?2 WHERE id = ?1",
+            params![upgrade_edge, pull_sym],
+        )
+        .unwrap();
+
+        // The compiler upgrades ONLY the name-only edge to the in-corpus `pull` def.
+        let symbol = "scip-rust crate held-mini `pull`().";
+        let scip = scip_with(&path, ucs, uce, symbol, Some(&path), Some((pull_start, pull_end)));
+        let report = db.run_oracle_from_scip(OracleTool::RustAnalyzer, "v-test", &scip).unwrap();
+        assert!(report.upgraded >= 1, "expected an Upgrade, got {report:?}");
+
+        // limit = 1: heuristically the two Exact callers outrank the name-only one, so without the
+        // overfetch+re-rank the compiler upgrade is dropped. With it, the compiler tier wins.
+        let callers = db
+            .find_callers_with_options("pull", 1, &crate::query::graph::GraphTraversalOptions {
+                include_unresolved: true,
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(callers.len(), 1, "limit honored");
+        assert_eq!(
+            callers[0].edge_id, upgrade_edge,
+            "the compiler-upgraded neighbor must rank into the limit ahead of Exact neighbors"
+        );
+        assert_eq!(callers[0].confidence, "compiler");
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -4365,6 +4365,7 @@ fn impact_surface_surfaces_call_path_memory_when_path_crossed() {
         &symbol_b,
         10,
         &crate::query::impact::ImpactSurfaceOptions::default(),
+        |_hops| Ok(()),
     )
     .unwrap();
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -4365,7 +4365,7 @@ fn impact_surface_surfaces_call_path_memory_when_path_crossed() {
         &symbol_b,
         10,
         &crate::query::impact::ImpactSurfaceOptions::default(),
-        |_hops| Ok(()),
+        |_hops| Ok(false),
     )
     .unwrap();
 

--- a/crates/rag-rat-core/src/query/graph/mod.rs
+++ b/crates/rag-rat-core/src/query/graph/mod.rs
@@ -238,7 +238,13 @@ pub struct GraphHop {
     pub from_symbol: Option<String>,
     pub to_symbol: Option<String>,
     pub edge_kind: String,
+    /// The DISPLAYED confidence tier. Normally the heuristic tier (`exact`/`syntactic`/…);
+    /// upgraded to `compiler` when a current, in-scope `edge_oracle` verdict covers this edge
+    /// (the new tier ABOVE `exact`). `edge_confidence` always keeps the underlying heuristic
+    /// tier so the upgrade is legible.
     pub confidence: String,
+    /// The heuristic edge confidence as stored on the `edges` row, regardless of any oracle
+    /// upgrade — so a `compiler`-tier hop still shows what tree-sitter alone concluded.
     pub edge_confidence: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target: Option<String>,
@@ -249,6 +255,15 @@ pub struct GraphHop {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub receiver_hint: Option<String>,
     pub resolution: String,
+    /// `scip:<tool>@<version>` when this hop carries a current oracle verdict — the provenance of
+    /// the `compiler` tier (and the `resolved-external` placement). `None` for heuristic-only
+    /// hops.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolution_reason: Option<String>,
+    /// `resolved-external(<package>)` when the oracle resolved this callee to a dependency outside
+    /// the corpus. Present only on `resolved-external` verdicts; `None` otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved_external: Option<String>,
     pub verified_target_symbol: bool,
     pub shown_by_default: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -260,4 +275,60 @@ pub struct Callsite {
     pub path: String,
     pub line: i64,
     pub span: [i64; 2],
+}
+
+/// Report for `compare_graph_to_scip`: where tree-sitter and the compiler (SCIP) DISAGREE on an
+/// edge's resolution. Sibling of [`CompareGraphTextReport`]; a user diagnostic + a resolver-
+/// debugging instrument. Built from the `Contradict` verdicts in `edge_oracle` (the heuristic
+/// resolved an edge to an in-corpus target the compiler says is wrong), scoped to the active
+/// checkout and gated to current content — never from drifted/dirty rows.
+#[derive(Debug, Serialize)]
+pub struct CompareGraphScipReport {
+    pub query: CompareGraphScipQuery,
+    pub summary: CompareGraphScipSummary,
+    /// Edges the compiler contradicts: tree-sitter resolved them one way, SCIP another.
+    pub contradictions: Vec<GraphScipContradiction>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CompareGraphScipQuery {
+    pub tool: String,
+    pub tool_version: Option<String>,
+    pub commit_sha: String,
+    pub worktree_id: String,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct CompareGraphScipSummary {
+    /// `edge_oracle` rows examined in scope (current content only).
+    pub verdicts_examined: u64,
+    /// How many were `Contradict` (the heuristic and compiler disagree).
+    pub contradictions: u64,
+    /// True when no oracle run has populated this checkout — `contradictions` is then trivially 0
+    /// because there's nothing to compare, not because the graph agrees with the compiler.
+    pub no_oracle_data: bool,
+    pub warnings: Vec<String>,
+}
+
+/// One edge where the heuristic and the compiler disagree on the callee's resolution.
+#[derive(Debug, Serialize)]
+pub struct GraphScipContradiction {
+    pub edge_id: i64,
+    pub edge_kind: String,
+    /// The heuristic's confidence (`exact`/`syntactic`/…) — what tree-sitter concluded.
+    pub heuristic_confidence: String,
+    /// The heuristic's resolved target symbol (qualified name), if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heuristic_target: Option<String>,
+    /// The callee name the edge points at.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub callee_name: Option<String>,
+    /// The raw SCIP symbol the compiler resolved the callee to — the disagreement's other side.
+    pub scip_symbol: String,
+    /// `resolved-external(<package>)` when the compiler placed the callee in a dependency; `None`
+    /// when it resolved to a different in-corpus symbol.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved_external: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub callsite: Option<Callsite>,
 }

--- a/crates/rag-rat-core/src/query/graph/traverse.rs
+++ b/crates/rag-rat-core/src/query/graph/traverse.rs
@@ -281,6 +281,34 @@ pub(crate) fn normalize_confidence(value: &str) -> &'static str {
         _ => "name_only",
     }
 }
+/// Effective confidence ordering AFTER oracle enrichment, lowest rank = highest priority (so a
+/// stable ascending sort puts the strongest tier first). `compiler` (the SCIP oracle tier) ranks
+/// ABOVE `exact` — that is the whole point of the tier — then the heuristic ladder. Unknown strings
+/// rank last so a future tier can't silently jump the queue. Used to re-sort the overfetched
+/// candidate set before truncating to the caller's limit, so a compiler-upgraded low-confidence
+/// edge isn't dropped by the heuristic `LIMIT` (#82 finding 4).
+pub(crate) fn effective_confidence_rank(confidence: &str) -> u8 {
+    match confidence {
+        "compiler" => 0,
+        "exact" => 1,
+        "syntactic" => 2,
+        "name_only" => 3,
+        "ambiguous" => 4,
+        _ => 5,
+    }
+}
+/// The overfetch cap for an oracle-aware traversal: traverse this many heuristic candidates so a
+/// compiler-upgraded low-confidence edge — which the heuristic ranks below the `limit` cutoff — is
+/// still in the candidate set when enrichment + re-sort run, before truncating back to `limit`.
+/// `4x` with a floor of 200 gives generous headroom for the common small `limit`; the `5000`
+/// ceiling caps the extra headroom so a pathological `limit` can't materialize the whole graph, but
+/// the result is never below `limit` itself (we must still fetch what the caller asked for). An
+/// edge upgraded beyond this window is the accepted residual (the heuristic already ranked it very
+/// far down) (#82 finding 4).
+pub(crate) fn oracle_overfetch_limit(limit: u32) -> u32 {
+    let headroom = limit.saturating_mul(4).clamp(200, 5000);
+    limit.max(headroom)
+}
 pub(crate) fn false_positive_risk(
     summary: &GraphTraversalSummary,
     mode: GraphResolutionMode,

--- a/crates/rag-rat-core/src/query/graph/traverse.rs
+++ b/crates/rag-rat-core/src/query/graph/traverse.rs
@@ -138,6 +138,10 @@ pub(crate) fn traverse_with_options(
             evidence: row.get("evidence")?,
             receiver_hint: row.get("receiver_hint")?,
             resolution,
+            // Heuristic traversal sets no oracle fields; the `IndexDatabase` enrichment pass
+            // (`enrich_hops_with_oracle`) fills these from a current, in-scope `edge_oracle` join.
+            resolution_reason: None,
+            resolved_external: None,
             verified_target_symbol,
             shown_by_default: CALL_EDGE_KINDS.contains(&edge_kind.as_str()),
             callsite: Some(Callsite {

--- a/crates/rag-rat-core/src/query/impact/mod.rs
+++ b/crates/rag-rat-core/src/query/impact/mod.rs
@@ -105,23 +105,31 @@ pub fn impact_surface(
     impact_surface_with_options(conn, query, limit, GraphResolutionMode::Syntactic)
 }
 
-/// Traverse one direction, oracle-enrich, re-rank by effective confidence, and truncate to `limit`
-/// — the impact-side mirror of `IndexDatabase::traverse_with_oracle` so a compiler-upgraded
-/// neighbor survives the limit here too (#82 finding 4). Overfetches via
-/// `graph::oracle_overfetch_limit`, runs `enrich` over the larger candidate set, stable-sorts by
-/// `graph::effective_confidence_rank` (so `compiler` outranks `exact`), then truncates.
+/// Traverse one direction, oracle-enrich, re-rank by effective confidence ONLY when a hop was
+/// promoted, and truncate to `limit` — the impact-side mirror of
+/// `IndexDatabase::traverse_with_oracle` so a compiler-upgraded neighbor survives the limit here
+/// too (#82 finding 4). Overfetches via `graph::oracle_overfetch_limit`, runs `enrich` over the
+/// larger candidate set, and — when `enrich` reports a promotion — stable-sorts by
+/// `graph::effective_confidence_rank` (so `compiler` outranks `exact`) before truncating.
+///
+/// `enrich` returns whether any hop was PROMOTED to `compiler`. With no promotion (no oracle run,
+/// or no in-scope verdict on these hops) the heuristic order + the caller's `limit` are already
+/// correct — re-sorting would change truncation membership on EVERY query, including repos with no
+/// oracle run (#82 P2). The overfetched set is in heuristic order, so its first `limit` rows are
+/// the original top-`limit`, identical to pre-oracle behavior.
 fn oracle_ranked_neighbors(
     conn: &Connection,
     symbol: &str,
     reverse: bool,
     limit: u32,
     graph_options: &GraphTraversalOptions,
-    enrich: &impl Fn(&mut Vec<GraphHop>) -> anyhow::Result<()>,
+    enrich: &impl Fn(&mut Vec<GraphHop>) -> anyhow::Result<bool>,
 ) -> anyhow::Result<Vec<GraphHop>> {
     let overfetch = graph::oracle_overfetch_limit(limit);
     let mut hops = graph::traverse_with_options(conn, symbol, reverse, overfetch, graph_options)?;
-    enrich(&mut hops)?;
-    hops.sort_by_key(|hop| graph::effective_confidence_rank(&hop.confidence));
+    if enrich(&mut hops)? {
+        hops.sort_by_key(|hop| graph::effective_confidence_rank(&hop.confidence));
+    }
     hops.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
     Ok(hops)
 }
@@ -131,7 +139,7 @@ pub fn impact_surface_report_for_symbol(
     symbol: &SymbolHit,
     limit: u32,
     options: &ImpactSurfaceOptions,
-    enrich: impl Fn(&mut Vec<GraphHop>) -> anyhow::Result<()>,
+    enrich: impl Fn(&mut Vec<GraphHop>) -> anyhow::Result<bool>,
 ) -> anyhow::Result<ImpactSurfaceReport> {
     let graph_options = GraphTraversalOptions {
         resolution_mode: options.resolution_mode,

--- a/crates/rag-rat-core/src/query/impact/mod.rs
+++ b/crates/rag-rat-core/src/query/impact/mod.rs
@@ -105,11 +105,33 @@ pub fn impact_surface(
     impact_surface_with_options(conn, query, limit, GraphResolutionMode::Syntactic)
 }
 
+/// Traverse one direction, oracle-enrich, re-rank by effective confidence, and truncate to `limit`
+/// — the impact-side mirror of `IndexDatabase::traverse_with_oracle` so a compiler-upgraded
+/// neighbor survives the limit here too (#82 finding 4). Overfetches via
+/// `graph::oracle_overfetch_limit`, runs `enrich` over the larger candidate set, stable-sorts by
+/// `graph::effective_confidence_rank` (so `compiler` outranks `exact`), then truncates.
+fn oracle_ranked_neighbors(
+    conn: &Connection,
+    symbol: &str,
+    reverse: bool,
+    limit: u32,
+    graph_options: &GraphTraversalOptions,
+    enrich: &impl Fn(&mut Vec<GraphHop>) -> anyhow::Result<()>,
+) -> anyhow::Result<Vec<GraphHop>> {
+    let overfetch = graph::oracle_overfetch_limit(limit);
+    let mut hops = graph::traverse_with_options(conn, symbol, reverse, overfetch, graph_options)?;
+    enrich(&mut hops)?;
+    hops.sort_by_key(|hop| graph::effective_confidence_rank(&hop.confidence));
+    hops.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
+    Ok(hops)
+}
+
 pub fn impact_surface_report_for_symbol(
     conn: &Connection,
     symbol: &SymbolHit,
     limit: u32,
     options: &ImpactSurfaceOptions,
+    enrich: impl Fn(&mut Vec<GraphHop>) -> anyhow::Result<()>,
 ) -> anyhow::Result<ImpactSurfaceReport> {
     let graph_options = GraphTraversalOptions {
         resolution_mode: options.resolution_mode,
@@ -117,10 +139,28 @@ pub fn impact_surface_report_for_symbol(
         logical_symbol_id: symbol.logical_symbol_id,
         ..Default::default()
     };
-    let direct_semantic_callers =
-        graph::traverse_with_options(conn, &symbol.qualified_name, true, limit, &graph_options)?;
-    let direct_semantic_callees =
-        graph::traverse_with_options(conn, &symbol.qualified_name, false, limit, &graph_options)?;
+    // Overfetch → oracle-enrich → re-rank by effective confidence → truncate, so a
+    // compiler-upgraded low-confidence neighbor isn't dropped by the heuristic `LIMIT` before
+    // enrichment runs (#82 finding 4). Everything downstream (memory evidence edge ids,
+    // completeness counts) sees the SAME truncated, re-ranked window the report returns.
+    // `enrich` is a no-op for callers without an oracle pass (e.g. tests), so the lists
+    // collapse back to the plain heuristic top-`limit`.
+    let direct_semantic_callers = oracle_ranked_neighbors(
+        conn,
+        &symbol.qualified_name,
+        true,
+        limit,
+        &graph_options,
+        &enrich,
+    )?;
+    let direct_semantic_callees = oracle_ranked_neighbors(
+        conn,
+        &symbol.qualified_name,
+        false,
+        limit,
+        &graph_options,
+        &enrich,
+    )?;
     let names = vec![symbol.name.clone(), symbol.qualified_name.clone()];
     let import_export_dependents =
         import_export_items(conn, symbol.symbol_id, &symbol.qualified_name, &names, limit)?;

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -114,6 +114,18 @@ impl RagRatService {
     }
 
     #[tool(
+        name = "compare_graph_to_scip",
+        description = "Report edges where the tree-sitter graph and the SCIP compiler oracle \
+                       disagree on resolution (contradictions). Requires `rag-rat oracle run`."
+    )]
+    fn compare_graph_to_scip(
+        &self,
+        Parameters(_args): Parameters<EmptyArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.call("compare_graph_to_scip", json!({}))
+    }
+
+    #[tool(
         name = "impact_surface",
         description = "Graph-backed coding preflight with structural, textual fallback, and \
                        papertrail evidence."

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -52,6 +52,7 @@ pub(crate) fn call_tool_with_db(
             let resolution_mode = resolution_mode(args.resolution);
             compare_graph_to_text_tool(db, args, resolution_mode)?
         },
+        "compare_graph_to_scip" => json!(db.compare_graph_to_scip()?),
         "impact_surface" => {
             let args: ImpactArgs = serde_json::from_value(arguments)?;
             let resolution_mode = resolution_mode(args.resolution);

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -129,6 +129,7 @@ pub const TOOL_NAMES: &[&str] = &[
     "find_callers",
     "trace_callees",
     "compare_graph_to_text",
+    "compare_graph_to_scip",
     "impact_surface",
     "repo_brief",
     "repo_clusters",
@@ -667,6 +668,11 @@ pub fn description(name: &str) -> &'static str {
             "Cross-check a symbol's graph caller edges against a regex text search of indexed \
              source — surfaces call sites the tree-sitter graph missed and flags likely false \
              edges. Use when you suspect graph coverage gaps.",
+        "compare_graph_to_scip" =>
+            "Cross-check the tree-sitter graph against the SCIP compiler oracle — report the edges \
+             where they DISAGREE on a callee's resolution (the compiler contradicts tree-sitter). \
+             A resolver-debugging diagnostic; requires `rag-rat oracle run` first to populate \
+             compiler verdicts. Reports nothing when no oracle data exists for this checkout.",
         "impact_surface" =>
             "Pre-edit blast radius for a symbol or path: graph callers/callees, tests, docs, git \
              history, GitHub papertrail, and the repo memories crossing it, with a completeness / \
@@ -767,6 +773,7 @@ pub fn schema(name: &str) -> Value {
             schema_for::<SymbolArgs>(),
         "find_callers" | "trace_callees" | "docs_for_symbol" => schema_for::<SymbolGraphArgs>(),
         "compare_graph_to_text" => schema_for::<CompareGraphTextArgs>(),
+        "compare_graph_to_scip" => schema_for::<EmptyArgs>(),
         "impact_surface" => schema_for::<ImpactArgs>(),
         "repo_brief" => schema_for::<RepoBriefArgs>(),
         "repo_clusters" => schema_for::<RepoClustersArgs>(),

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -51,6 +51,7 @@ fn list_tools_exposes_complete_typed_schemas() {
         "find_callers",
         "trace_callees",
         "compare_graph_to_text",
+        "compare_graph_to_scip",
         "impact_surface",
         "repo_brief",
         "repo_clusters",


### PR DESCRIPTION
Fixes #69 (part of the #61 SCIP-oracle epic). Builds on #68 (the `index/oracle/` reader + join + eval + V018 `oracle_runs`/`edge_oracle` tables, merged on `main`). All of this is **read-side**: the heuristic `edges` row is never overwritten (the #68 side-table invariant holds), and every new `edge_oracle` read routes through `store.rs` (the #81 source-scan invariant stays green).

## Design point → change

**1. `oracle/manifest.rs` — the tool registry.** Per-tool `program` / `languages` / `install_hint`, `scip_command(root, output)`, and `probe()` (runs `<program> --version`). Registers `rust-analyzer scip`. A missing/unrunnable tool → `ToolAvailability::Blocked` with an install hint — **never an error** (same UX as a missing embedding model). The seam later language backends (#71/#72/#74) extend with one entry each.

**2. CLI `rag-rat oracle run [--tool <id>] [--scip <path>]` + `rag-rat oracle status`.** (clap derive in `cli.rs`; dispatch in `main.rs`; bodies in `commands.rs`.) Either invoke the indexer to produce a `.scip` (temp file) then run the phase-1 join, or consume a pre-built `--scip`. Records an `oracle_runs` row; prints the `OracleReport`. Missing tool → `Blocked` + hint, **exit 0**. A present tool that fails to produce SCIP → real error (exit 1) — verified on-device.

**3. `Compiler` confidence tier.** `IndexDatabase::enrich_hops_with_oracle` runs after `traverse_with_options`, batch-fetches verdicts for the returned `edge_id`s, and rewrites only the in-memory `GraphHop` display fields. Wired into `find_callers` / `trace_callees` / `impact_surface`. `confidence → "compiler"` with `resolution_reason = "scip:<tool>@<version>"` for `Upgrade`/`Confirm`; `edge_confidence` keeps the heuristic tier; `Contradict` is never promoted. The JOIN is **scoped + current**: `store::EDGE_ORACLE_SCOPE_JOIN` (active `(commit_sha, worktree_id)`) **+** `EDGE_ORACLE_CURRENT_PREDICATE` (`edge_oracle.file_sha = files.sha256`). A drifted/changed file's verdict is filtered out → the edge reverts to heuristic display, never `Compiler`. Dirty/overlay edges are out of the commit scope, so they never surface `Compiler` either. `completeness_risk` becomes quantitative (e.g. `… (2 of 7 unresolved are resolved-external: libc, tokio)`).

**4. `resolved-external(<package>)`** surfaced on `GraphHop.resolved_external` for edges the oracle placed outside the corpus (package from the SCIP symbol component).

**5. `compare_graph_to_scip` MCP tool** (sibling of `compare_graph_to_text`): reports the `Contradict` verdicts — where tree-sitter and the compiler disagree. Scoped + current rows only. Registered in `server.rs` `#[tool]`, `TOOL_NAMES`, `description()`, `schema()`, `handlers.rs`.

**6. gc.** `edge_oracle` cascades off `edges` (FK `ON DELETE CASCADE`, fired by the existing per-commit edge GC). `oracle_runs` is keyed by `(commit_sha, worktree_id)` directly, so it's now pruned in `prune_to_live` via `store::prune_oracle_runs_outside_scope` (refuses to prune when both live sets are empty).

## Tested vs gated-on-rust-analyzer

- **Deterministic `--scip` path — tested end-to-end** (`query_api.rs::oracle_surfacing_tests`): rebuild a temp Rust checkout, run `run_oracle_from_scip` over a programmatically-built `.scip`, assert `Compiler` surfacing, staleness revert (drift `files.sha256` → heuristic), dirty/out-of-scope rule, `resolved-external`, `compare_graph_to_scip` contradiction, and gc pruning of `oracle_runs`.
- **Store-level** deterministic tests in `oracle/tests.rs` for the current/stale/out-of-scope verdict reads, comparisons, `latest_run_tool_version`, and `prune_oracle_runs_outside_scope`.
- **Manifest**: `probe` Blocked + hint when absent, version detection on a known program.
- **rust-analyzer subprocess path**: gated — `oracle_run_without_tool_is_blocked_not_error` skips when rust-analyzer is on PATH; CI never depends on rust-analyzer.

## Quality

`cargo +nightly fmt --all --check` clean; `cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings` clean; `cargo test --workspace --no-default-features --locked` green. Coverage on the new testable code: `manifest.rs` ~91% lines, `store.rs` ~95% lines (the uncovered remainder is the rust-analyzer subprocess invocation, intentionally un-runnable in CI). New invariants recorded as rag-rat memories (the Compiler-tier-only-when-current rule; the manifest/Blocked contract).