### PR TITLE
SCIP phase 3: moniker anchors for repo memories + logical symbols (#70)

### DIFF
--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -468,8 +468,9 @@ mod tests {
         ])
         .expect("parse");
         match cli.command {
-            Command::Memory(MemoryArgs { command: MemoryCommand::Rebind { symbol_path, .. } }) =>
-                assert_eq!(symbol_path.as_deref(), Some("src/a.rs::foo")),
+            Command::Memory(MemoryArgs { command: MemoryCommand::Rebind { symbol_path, .. } }) => {
+                assert_eq!(symbol_path.as_deref(), Some("src/a.rs::foo"))
+            },
             other => panic!("expected memory rebind, got {other:?}"),
         }
     }

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -315,6 +315,10 @@ pub(crate) enum MemoryCommand {
         path: Option<String>,
         #[arg(long)]
         chunk: Option<i64>,
+        /// Directory anchor relative to the repo root (`""` for the repo root) — the area-level
+        /// binding `dir`-bound memories use.
+        #[arg(long)]
+        dir: Option<String>,
     },
 }
 

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -259,9 +259,9 @@ pub(crate) struct OracleRunArgs {
 
 #[derive(Debug, Args)]
 pub(crate) struct OracleStatusArgs {
-    /// The oracle tool to report on (default: rust-analyzer).
-    #[arg(long, value_enum, default_value_t = OracleToolArg::RustAnalyzer)]
-    pub tool: OracleToolArg,
+    /// Report on one oracle tool only (default: every known tool).
+    #[arg(long, value_enum)]
+    pub tool: Option<OracleToolArg>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -243,21 +243,30 @@ fn oracle_run(config: &Config, args: &OracleRunArgs) -> anyhow::Result<()> {
 }
 
 /// `rag-rat oracle status` — verdict counts for the latest run in this checkout, plus whether the
-/// indexer tool is installed (its probe, a `Blocked` line when absent, never an error).
+/// indexer tool is installed (its probe, a `Blocked` line when absent, never an error). Always an
+/// ARRAY of per-tool objects: every known tool by default, one element under `--tool` — the shape
+/// stays stable as language backends (#71 TS, #72 Kotlin) join the registry.
 fn oracle_status(db: &IndexDatabase, args: &OracleStatusArgs) -> anyhow::Result<()> {
-    let tool = args.tool.core();
-    let availability = db.probe_oracle_tool(tool);
-    // Use the most recent run's version for the verdict counts; no run → no counts (status is a
-    // read-only sibling — nothing to report against).
-    let status = match db.latest_oracle_run_version(tool)? {
-        Some(version) => Some(db.oracle_status(tool, &version)?),
-        None => None,
+    let tools: Vec<rag_rat_core::index::oracle::OracleTool> = match args.tool {
+        Some(tool) => vec![tool.core()],
+        None => rag_rat_core::index::oracle::OracleTool::ALL.to_vec(),
     };
-    print_json(&serde_json::json!({
-        "tool": tool.as_db_str(),
-        "tool_available": availability,
-        "verdicts": status,
-    }))
+    let mut entries = Vec::with_capacity(tools.len());
+    for tool in tools {
+        let availability = db.probe_oracle_tool(tool);
+        // Use the most recent run's version for the verdict counts; no run → no counts (status is
+        // a read-only sibling — nothing to report against).
+        let status = match db.latest_oracle_run_version(tool)? {
+            Some(version) => Some(db.oracle_status(tool, &version)?),
+            None => None,
+        };
+        entries.push(serde_json::json!({
+            "tool": tool.as_db_str(),
+            "tool_available": availability,
+            "verdicts": status,
+        }));
+    }
+    print_json(&entries)
 }
 pub(crate) fn models(config: &Config, args: &ModelsArgs) -> anyhow::Result<()> {
     let db = open_index(config)?;

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -400,6 +400,10 @@ fn path_bind_target(path: String) -> rag_rat_core::query::memory::RepoMemoryBind
     rag_rat_core::query::memory::RepoMemoryBindTarget { path: Some(path), ..Default::default() }
 }
 
+fn dir_bind_target(dir: String) -> rag_rat_core::query::memory::RepoMemoryBindTarget {
+    rag_rat_core::query::memory::RepoMemoryBindTarget { dir: Some(dir), ..Default::default() }
+}
+
 fn chunk_bind_target(chunk_id: i64) -> rag_rat_core::query::memory::RepoMemoryBindTarget {
     rag_rat_core::query::memory::RepoMemoryBindTarget {
         chunk_id: Some(chunk_id),
@@ -455,7 +459,7 @@ pub(crate) fn memory(config: &Config, args: &MemoryArgs) -> anyhow::Result<()> {
             }
             Ok(())
         },
-        MemoryCommand::Rebind { memory_id, symbol, symbol_path, symbol_id, path, chunk } => {
+        MemoryCommand::Rebind { memory_id, symbol, symbol_path, symbol_id, path, chunk, dir } => {
             let db = open_index(config)?;
             let bind = if symbol.is_some() || symbol_path.is_some() || symbol_id.is_some() {
                 let selector = rag_rat_core::query::symbol::SymbolSelector {
@@ -492,10 +496,12 @@ pub(crate) fn memory(config: &Config, args: &MemoryArgs) -> anyhow::Result<()> {
                 path_bind_target(path.clone())
             } else if let Some(chunk_id) = chunk {
                 chunk_bind_target(*chunk_id)
+            } else if let Some(dir) = dir {
+                dir_bind_target(dir.clone())
             } else {
                 anyhow::bail!(
                     "memory rebind needs one of --symbol <name>, --symbol-path <path::name>, \
-                     --symbol-id <id>, --path <path>, or --chunk <id>"
+                     --symbol-id <id>, --path <path>, --chunk <id>, or --dir <dir>"
                 );
             };
             print_json(&db.memory_rebind(memory_id, bind)?)

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -149,8 +149,9 @@ pub fn produce_scip_with_tool(
     let manifest = ToolManifest::for_tool(tool);
     let version = match manifest.probe() {
         ToolAvailability::Available { version, .. } => version,
-        ToolAvailability::Blocked { tool, program, hint } =>
-            return Ok(ScipProduction::Blocked { tool, program, hint }),
+        ToolAvailability::Blocked { tool, program, hint } => {
+            return Ok(ScipProduction::Blocked { tool, program, hint });
+        },
     };
     let mut command = manifest.scip_command(checkout_root, scip_output);
     let status = command
@@ -420,6 +421,9 @@ pub struct OracleReport {
     pub no_occurrence: u64,
     /// `edge_oracle` rows written this pass.
     pub rows_written: u64,
+    /// `logical_symbol_monikers` rows written this pass — in-corpus SCIP definitions mapped to a
+    /// logical symbol (#70).
+    pub monikers_written: u64,
     pub status: String,
 }
 

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -329,6 +329,10 @@ pub enum OracleTool {
 }
 
 impl OracleTool {
+    /// Every known oracle tool, for "report on all tools" surfaces (`oracle status` with no
+    /// `--tool`). Later language backends (#71 TS, #72 Kotlin) extend this alongside the enum.
+    pub const ALL: &[OracleTool] = &[Self::RustAnalyzer];
+
     pub fn as_db_str(self) -> &'static str {
         match self {
             Self::RustAnalyzer => "rust-analyzer",
@@ -421,8 +425,10 @@ pub struct OracleReport {
     pub no_occurrence: u64,
     /// `edge_oracle` rows written this pass.
     pub rows_written: u64,
-    /// `logical_symbol_monikers` rows written this pass — in-corpus SCIP definitions mapped to a
-    /// logical symbol (#70).
+    /// `logical_symbol_monikers` rows written this pass — distinct logical symbols whose moniker
+    /// an in-corpus SCIP definition supplied (#70). Several defs can map to one logical symbol
+    /// (fields/variants map up to the enclosing symbol); only the deterministic best (shortest)
+    /// moniker is written, so this counts rows, not defs.
     pub monikers_written: u64,
     pub status: String,
 }

--- a/crates/rag-rat-core/src/index/oracle/run.rs
+++ b/crates/rag-rat-core/src/index/oracle/run.rs
@@ -230,8 +230,18 @@ pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Resu
     // a tool-driven run — the production snapshot must both still match those bytes, or the
     // mapping landed in the wrong coordinate space and would anchor the moniker to the wrong
     // symbol. `local N` symbols never reach here (dropped at parse).
+    //
+    // SEVERAL defs can containment-map to ONE logical symbol: a struct's fields / consts / enum
+    // variants have no symbol row of their own, so their def occurrences map up to the enclosing
+    // symbol alongside the symbol's own def. The stored moniker must be DETERMINISTIC — a binding
+    // records it at create time and relocation later re-matches it against a fresh run's rows, so
+    // a last-writer-wins over HashMap iteration order would silently break relocation whenever the
+    // arbitrary winner changed between runs. Pick the best moniker per logical symbol instead:
+    // shortest, then lexicographic. SCIP member monikers extend the parent's descriptor chain
+    // (`…Struct#field.` vs `…Struct#`), so shortest selects the symbol's own moniker.
     let indexed_shas =
         store::indexed_file_shas_in_scope(conn, input.commit_sha, input.worktree_id)?;
+    let mut best_monikers: HashMap<i64, &str> = HashMap::new();
     for (scip_symbol, def) in &index.definitions {
         let disk = disk_sha.get(&def.path).map(String::as_str);
         if disk.is_none() || indexed_shas.get(&def.path).map(String::as_str) != disk {
@@ -248,12 +258,22 @@ pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Resu
         let Some(logical_symbol_id) = store::logical_symbol_id_for_member(conn, symbol_id)? else {
             continue;
         };
+        best_monikers
+            .entry(logical_symbol_id)
+            .and_modify(|best| {
+                if (scip_symbol.len(), scip_symbol.as_str()) < (best.len(), *best) {
+                    *best = scip_symbol;
+                }
+            })
+            .or_insert(scip_symbol);
+    }
+    for (logical_symbol_id, moniker) in &best_monikers {
         store::write_logical_symbol_moniker(
             conn,
             input.tool,
             input.tool_version,
-            logical_symbol_id,
-            scip_symbol,
+            *logical_symbol_id,
+            moniker,
         )?;
         report.monikers_written += 1;
     }

--- a/crates/rag-rat-core/src/index/oracle/run.rs
+++ b/crates/rag-rat-core/src/index/oracle/run.rs
@@ -68,6 +68,9 @@ pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Resu
         input.commit_sha,
         input.worktree_id,
     )?;
+    // Monikers are authoritative per tool the same way verdicts are per (tool, tool_version):
+    // clear, then write the current `.scip`'s definitions, all in this transaction (#70).
+    store::clear_logical_symbol_monikers_for_tool(conn, input.tool)?;
 
     // Parse the `.scip`, reading each document's current checkout bytes for encoding conversion.
     // The bytes we read here are the SAME bytes whose hash we compare against each candidate's
@@ -219,6 +222,41 @@ pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Resu
         report.rows_written += 1;
     }
     report.covered_calls = covered_call_occurrences.len() as u64;
+
+    // Moniker pass (#70 phase 3): for every SCIP definition that maps to an in-corpus symbol,
+    // record the SCIP symbol string as that logical symbol's moniker. Same drift discipline as the
+    // edge join, applied to the DEFINITION document: the def occurrence's byte range was converted
+    // against live disk bytes, so the indexed content (the symbol spans we map against) and — for
+    // a tool-driven run — the production snapshot must both still match those bytes, or the
+    // mapping landed in the wrong coordinate space and would anchor the moniker to the wrong
+    // symbol. `local N` symbols never reach here (dropped at parse).
+    let indexed_shas =
+        store::indexed_file_shas_in_scope(conn, input.commit_sha, input.worktree_id)?;
+    for (scip_symbol, def) in &index.definitions {
+        let disk = disk_sha.get(&def.path).map(String::as_str);
+        if disk.is_none() || indexed_shas.get(&def.path).map(String::as_str) != disk {
+            continue;
+        }
+        if let Some(production_sha) = input.production_sha
+            && production_sha.get(&def.path).map(String::as_str) != disk
+        {
+            continue;
+        }
+        let Some(symbol_id) = resolve_symbol(&def.path, def.start_byte, def.end_byte) else {
+            continue;
+        };
+        let Some(logical_symbol_id) = store::logical_symbol_id_for_member(conn, symbol_id)? else {
+            continue;
+        };
+        store::write_logical_symbol_moniker(
+            conn,
+            input.tool,
+            input.tool_version,
+            logical_symbol_id,
+            scip_symbol,
+        )?;
+        report.monikers_written += 1;
+    }
 
     // Recall gap: in-corpus *reference* occurrences whose symbol resolves inside the corpus but
     // that no edge candidate covered — calls the heuristic never emitted. Two scope filters, both

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -176,6 +176,87 @@ pub(crate) fn indexed_paths_in_scope(
     Ok(out)
 }
 
+/// The `files.sha256` of every file indexed in the active `(commit_sha, worktree_id)` checkout,
+/// keyed by path. The moniker pass uses it as its index-vs-disk drift gate: a SCIP definition in a
+/// document whose disk bytes no longer match the indexed content was byte-converted against a
+/// coordinate space the symbol spans don't share, so its moniker must not be written. Tombstones
+/// are excluded for the same reason as [`indexed_paths_in_scope`].
+pub(crate) fn indexed_file_shas_in_scope(
+    conn: &Connection,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<std::collections::HashMap<String, String>> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT path, sha256 FROM files WHERE {scope} AND kind != 'deleted'",
+        scope = active_checkout_file_predicate("?1", "?2"),
+    ))?;
+    let rows = stmt.query_map(params![commit_sha, worktree_id], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })?;
+    let mut out = std::collections::HashMap::new();
+    for row in rows {
+        let (path, sha) = row?;
+        out.insert(path, sha);
+    }
+    Ok(out)
+}
+
+/// The logical symbol a member symbol belongs to, if grouped. Local copy of the
+/// `logical_symbol_members` read so the oracle layer doesn't reach into `query::memory`.
+pub(crate) fn logical_symbol_id_for_member(
+    conn: &Connection,
+    symbol_id: i64,
+) -> anyhow::Result<Option<i64>> {
+    use rusqlite::OptionalExtension as _;
+    conn.query_row(
+        "SELECT logical_symbol_id FROM logical_symbol_members WHERE symbol_id = ?1 LIMIT 1",
+        [symbol_id],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+/// Delete every `logical_symbol_monikers` row for `tool`. Called at the start of a run, inside the
+/// run's transaction, so the moniker set is **authoritative** for the latest run: a symbol the
+/// current `.scip` no longer defines must not keep a stale moniker, and dangling rows (whose
+/// content-derived logical id died in a rebuild) are swept on every run. The clear is global for
+/// the tool — `logical_symbols` itself is rebuilt unscoped from all symbols, so monikers follow
+/// the same (single-checkout-in-practice) lifecycle rather than inventing a per-checkout scope the
+/// parent table doesn't have.
+pub(crate) fn clear_logical_symbol_monikers_for_tool(
+    conn: &Connection,
+    tool: OracleTool,
+) -> anyhow::Result<()> {
+    conn.execute("DELETE FROM logical_symbol_monikers WHERE tool = ?1", [tool.as_db_str()])?;
+    Ok(())
+}
+
+/// Upsert one moniker row: this logical symbol's SCIP symbol string per `tool`, with the version
+/// that produced it. PK `(logical_symbol_id, tool)` — one moniker per logical symbol per tool;
+/// cfg-gated variants share the logical symbol, hence the moniker, by construction (#70).
+pub(crate) fn write_logical_symbol_moniker(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    logical_symbol_id: i64,
+    moniker: &str,
+) -> anyhow::Result<()> {
+    conn.execute(
+        "
+        INSERT INTO logical_symbol_monikers(logical_symbol_id, tool, tool_version, moniker, \
+         computed_at)
+        VALUES (?1, ?2, ?3, ?4, ?5)
+        ON CONFLICT(logical_symbol_id, tool) DO UPDATE SET
+            tool_version = excluded.tool_version,
+            moniker = excluded.moniker,
+            computed_at = excluded.computed_at
+        ",
+        params![logical_symbol_id, tool.as_db_str(), tool_version, moniker, now_ms()],
+    )?;
+    Ok(())
+}
+
 /// Delete the `edge_oracle` verdicts for a `(tool, tool_version)` scope **within the active
 /// checkout**. Called at the start of a run so the pass is **authoritative** for its tool version:
 /// an edge the prior `.scip` covered but the current one no longer yields a verdict for must NOT

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -3064,3 +3064,30 @@ fn moniker_binding_validation_statuses() {
     h.conn.execute("DELETE FROM logical_symbol_monikers", []).unwrap();
     assert_eq!(moniker_status(&h), "unverified");
 }
+
+/// Several defs containment-map to one logical symbol (a struct's fields have no symbol row, so
+/// they map up to the enclosing struct alongside its own def). The stored moniker must be the
+/// DETERMINISTIC best — shortest, then lexicographic — i.e. the symbol's own moniker, never an
+/// arbitrary member's (HashMap-order last-writer would silently break relocation between runs).
+#[test]
+fn moniker_for_symbol_with_member_defs_is_the_symbols_own() {
+    let h = Harness::new();
+    // `struct Config { db: u32 }` — one symbol row spanning the whole struct.
+    let defs = h.add_file("defs.rs", "struct Config { db: u32 }\n");
+    let sym = h.add_symbol_qualified(defs, "Config", "defs.rs::Config", "struct", 0, 25);
+    h.add_logical_symbol(3003, "defs.rs", "Config", "defs.rs::Config", sym);
+
+    let struct_moniker = "rust-analyzer cargo test_crate 0.1.0 Config#";
+    let field_moniker = "rust-analyzer cargo test_crate 0.1.0 Config#db.";
+    let bytes = scip_bytes_docs(vec![("defs.rs", vec![
+        // Field def first so a naive insertion-order winner would pick it.
+        occurrence(0, 16, 18, field_moniker, SymbolRole::Definition as i32),
+        occurrence(0, 7, 13, struct_moniker, SymbolRole::Definition as i32),
+    ])]);
+    let report =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+
+    assert_eq!(report.monikers_written, 1, "one row per logical symbol, not per def");
+    let (moniker, ..) = h.moniker(3003).expect("moniker row written");
+    assert_eq!(moniker, struct_moniker, "the symbol's own (shortest) moniker wins");
+}

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -107,6 +107,85 @@ impl Harness {
         self.conn.last_insert_rowid()
     }
 
+    /// Insert a symbol with an explicit qualified name + kind (the production shape is
+    /// path-qualified), returning its id. The moniker tests need the qualified name to CHANGE on a
+    /// file move so the qualified-name relocation arm can't fire.
+    fn add_symbol_qualified(
+        &self,
+        file_id: i64,
+        name: &str,
+        qualified_name: &str,
+        kind: &str,
+        start_byte: usize,
+        end_byte: usize,
+    ) -> i64 {
+        self.conn
+            .execute(
+                "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte, \
+                 end_byte, start_line, end_line) VALUES (?1, 'rust', ?2, ?3, ?4, ?5, ?6, 1, 1)",
+                params![file_id, name, qualified_name, kind, start_byte as i64, end_byte as i64],
+            )
+            .unwrap();
+        self.conn.last_insert_rowid()
+    }
+
+    /// Insert a logical symbol group (explicit content-derived-style id) with one member.
+    fn add_logical_symbol(
+        &self,
+        logical_symbol_id: i64,
+        path: &str,
+        name: &str,
+        qualified_name: &str,
+        symbol_id: i64,
+    ) {
+        self.conn
+            .execute(
+                "INSERT INTO logical_symbols(id, language, path, logical_name, qualified_name, \
+                 kind, variant_count, group_reason) VALUES (?1, 'rust', ?2, ?3, ?4, 'function', \
+                 1, 'single')",
+                params![logical_symbol_id, path, name, qualified_name],
+            )
+            .unwrap();
+        self.conn
+            .execute(
+                "INSERT INTO logical_symbol_members(logical_symbol_id, symbol_id, cfg_expr, \
+                 signature_hash, start_line, end_line) VALUES (?1, ?2, NULL, NULL, 1, 1)",
+                params![logical_symbol_id, symbol_id],
+            )
+            .unwrap();
+    }
+
+    /// Insert a chunk for a symbol (the memory bind/validate path reads the symbol's chunk for its
+    /// content hash and line span; a symbol row without one is not a shape the indexer produces).
+    fn add_chunk(&self, file_id: i64, symbol_path: &str, text: &str) {
+        self.conn
+            .execute(
+                "INSERT INTO chunks(file_id, chunk_kind, symbol_path, start_byte, end_byte, \
+                 start_line, end_line, text, text_hash) VALUES (?1, 'symbol', ?2, 0, ?3, 1, 1, \
+                 ?4, ?5)",
+                params![file_id, symbol_path, text.len() as i64, text, sha256_hex(text.as_bytes())],
+            )
+            .unwrap();
+    }
+
+    /// The persisted moniker row for a logical symbol, if any.
+    fn moniker(&self, logical_symbol_id: i64) -> Option<(String, String, String)> {
+        self.conn
+            .query_row(
+                "SELECT moniker, tool, tool_version FROM logical_symbol_monikers WHERE \
+                 logical_symbol_id = ?1",
+                params![logical_symbol_id],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                    ))
+                },
+            )
+            .ok()
+    }
+
     /// Insert a `calls_name` edge carrying a callee identifier byte range, returning its id.
     #[allow(clippy::too_many_arguments)]
     fn add_edge(
@@ -531,7 +610,47 @@ fn migration_creates_oracle_side_tables() {
         assert!(columns.contains(&expected.to_string()), "edge_oracle missing {expected}");
     }
 
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 18);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 19);
+}
+
+/// The V019 moniker migration: the `logical_symbol_monikers` table (STRICT, NO foreign key — see
+/// the migration's invariant comment: an FK would cascade-wipe monikers on every
+/// `rebuild_logical_symbols` DELETE-all pass) plus the moniker provenance + relocation-reason
+/// columns on `repo_memory_bindings`.
+#[test]
+fn migration_creates_moniker_table_and_binding_columns() {
+    let conn = Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+
+    let sql: String = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE name = 'logical_symbol_monikers'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(sql.contains("STRICT"), "logical_symbol_monikers must be STRICT");
+    assert!(
+        !sql.to_uppercase().contains("FOREIGN KEY"),
+        "logical_symbol_monikers must NOT carry an FK to logical_symbols — the DELETE-all \
+         logical-symbol rebuild would cascade-wipe monikers on every index pass"
+    );
+
+    let columns = table_columns(&conn, "logical_symbol_monikers");
+    for expected in ["logical_symbol_id", "tool", "tool_version", "moniker", "computed_at"] {
+        assert!(
+            columns.contains(&expected.to_string()),
+            "logical_symbol_monikers missing {expected}"
+        );
+    }
+
+    let binding_columns = table_columns(&conn, "repo_memory_bindings");
+    for expected in ["moniker_tool", "moniker_tool_version", "relocation_reason"] {
+        assert!(
+            binding_columns.contains(&expected.to_string()),
+            "repo_memory_bindings missing {expected}"
+        );
+    }
 }
 
 fn table_columns(conn: &Connection, table: &str) -> Vec<String> {
@@ -2657,4 +2776,291 @@ fn prune_oracle_runs_drops_dead_contexts_only() {
     let remaining: i64 =
         h.conn.query_row("SELECT COUNT(*) FROM oracle_runs", [], |r| r.get(0)).unwrap();
     assert_eq!(remaining, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Moniker anchors (#70, phase 3): oracle-run moniker pass + memory relocation.
+// ---------------------------------------------------------------------------
+
+use crate::query::memory::{
+    RepoMemoryBindTarget, RepoMemoryCreate, create_memory, memory_by_id, split_active_stale,
+    validate_memories,
+};
+
+/// Build a multi-document SCIP index, serialized.
+fn scip_bytes_docs(docs: Vec<(&str, Vec<Occurrence>)>) -> Vec<u8> {
+    let documents = docs
+        .into_iter()
+        .map(|(path, occurrences)| Document {
+            relative_path: path.to_string(),
+            occurrences,
+            position_encoding: EnumOrUnknown::new(
+                PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+            ),
+            ..Default::default()
+        })
+        .collect();
+    let index = Index { documents, ..Default::default() };
+    index.write_to_bytes().unwrap()
+}
+
+const TARGET_MONIKER: &str = "rust-analyzer cargo test_crate 0.1.0 target().";
+
+/// A definition that maps to an in-corpus symbol writes that logical symbol's moniker; a
+/// definition in a document rag-rat never indexed writes nothing.
+#[test]
+fn oracle_run_writes_monikers_for_in_corpus_defs() {
+    let h = Harness::new();
+    let defs = h.add_file("defs.rs", "fn target() {}\n");
+    let sym = h.add_symbol_qualified(defs, "target", "defs.rs::target", "function", 0, 14);
+    h.add_chunk(defs, "defs.rs::target", "fn target() {}\n");
+    h.add_logical_symbol(1001, "defs.rs", "target", "defs.rs::target", sym);
+    // A dependency source the `.scip` covers but rag-rat never indexed (on disk, no `files` row).
+    std::fs::write(h.root().join("dep.rs"), "fn external_fn() {}\n").unwrap();
+
+    let bytes = scip_bytes_docs(vec![
+        // `target` identifier at line 0, chars 3..9.
+        ("defs.rs", vec![occurrence(0, 3, 9, TARGET_MONIKER, SymbolRole::Definition as i32)]),
+        ("dep.rs", vec![occurrence(
+            0,
+            3,
+            14,
+            "rust-analyzer cargo dep 1.0.0 external_fn().",
+            SymbolRole::Definition as i32,
+        )]),
+    ]);
+    let report =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+
+    assert_eq!(report.monikers_written, 1, "only the in-corpus def writes a moniker");
+    let (moniker, tool, tool_version) = h.moniker(1001).expect("moniker row written");
+    assert_eq!(moniker, TARGET_MONIKER);
+    assert_eq!(tool, TOOL.as_db_str());
+    assert_eq!(tool_version, VERSION);
+    let total: i64 =
+        h.conn.query_row("SELECT COUNT(*) FROM logical_symbol_monikers", [], |r| r.get(0)).unwrap();
+    assert_eq!(total, 1, "the unindexed dep def must not write a row");
+}
+
+/// A re-run is authoritative for the tool: monikers the current `.scip` no longer defines are
+/// cleared, not left stale.
+#[test]
+fn oracle_rerun_clears_prior_monikers_for_tool() {
+    let h = Harness::new();
+    let defs = h.add_file("defs.rs", "fn target() {}\n");
+    let sym = h.add_symbol_qualified(defs, "target", "defs.rs::target", "function", 0, 14);
+    h.add_chunk(defs, "defs.rs::target", "fn target() {}\n");
+    h.add_logical_symbol(1001, "defs.rs", "target", "defs.rs::target", sym);
+
+    let bytes = scip_bytes_docs(vec![("defs.rs", vec![occurrence(
+        0,
+        3,
+        9,
+        TARGET_MONIKER,
+        SymbolRole::Definition as i32,
+    )])]);
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+    assert!(h.moniker(1001).is_some());
+
+    // Second run: a `.scip` with no definitions at all.
+    let empty = scip_bytes_docs(vec![("defs.rs", vec![])]);
+    run_oracle(&h.conn, TOOL, "v2", COMMIT, WORKTREE, &empty, h.root(), None).unwrap();
+    assert!(h.moniker(1001).is_none(), "authoritative clear removed the stale moniker");
+}
+
+/// Create a memory bound to the harness symbol, asserting the automatic `scip_moniker` binding.
+fn create_target_memory(h: &Harness, symbol_id: i64) -> String {
+    let created = create_memory(&h.conn, RepoMemoryCreate {
+        kind: "Invariant".to_string(),
+        title: "target invariant".to_string(),
+        body: "target must stay reentrant".to_string(),
+        confidence: "high".to_string(),
+        created_by: None,
+        source: None,
+        tags: Vec::new(),
+        bind: RepoMemoryBindTarget { symbol_id: Some(symbol_id), ..Default::default() },
+    })
+    .unwrap();
+    assert!(!created.duplicate);
+    let moniker_binding =
+        created.memory.bindings.iter().find(|b| b.binding_kind == "scip_moniker").expect(
+            "memory on a symbol with a known moniker gets the moniker binding automatically",
+        );
+    assert_eq!(moniker_binding.binding_id, TARGET_MONIKER);
+    assert_eq!(moniker_binding.moniker_tool.as_deref(), Some(TOOL.as_db_str()));
+    assert_eq!(moniker_binding.moniker_tool_version.as_deref(), Some(VERSION));
+    created.memory.memory_id
+}
+
+/// Simulate a file move WITH a content edit: the old file/symbol/logical rows die, the new home
+/// has a different path, qualified name, AND content — so neither the qualified-name arm nor the
+/// name+content-hash arm can relocate, only the moniker can. Returns the new symbol id.
+fn move_target_with_edit(h: &Harness, old_file: i64, new_kind: &str) -> i64 {
+    h.conn.execute("DELETE FROM logical_symbol_members", []).unwrap();
+    h.conn.execute("DELETE FROM logical_symbols", []).unwrap();
+    h.conn.execute("DELETE FROM symbols", []).unwrap();
+    h.conn.execute("DELETE FROM files WHERE id = ?1", params![old_file]).unwrap();
+    std::fs::remove_file(h.root().join("defs.rs")).unwrap();
+
+    let moved = h.add_file("moved.rs", "fn target(changed: u32) {}\n");
+    let sym = h.add_symbol_qualified(moved, "target", "moved.rs::target", new_kind, 0, 26);
+    h.add_chunk(moved, "moved.rs::target", "fn target(changed: u32) {}\n");
+    h.add_logical_symbol(2002, "moved.rs", "target", "moved.rs::target", sym);
+    sym
+}
+
+/// The #70 acceptance test: a memory bound to a symbol survives a file move (with a content edit
+/// the hash fallback can't survive) via moniker relocation — `relocated`, reason `moniker-match`.
+#[test]
+fn memory_survives_file_move_via_moniker_relocation() {
+    let h = Harness::new();
+    let defs = h.add_file("defs.rs", "fn target() {}\n");
+    let sym = h.add_symbol_qualified(defs, "target", "defs.rs::target", "function", 0, 14);
+    h.add_chunk(defs, "defs.rs::target", "fn target() {}\n");
+    h.add_logical_symbol(1001, "defs.rs", "target", "defs.rs::target", sym);
+    let bytes = scip_bytes_docs(vec![("defs.rs", vec![occurrence(
+        0,
+        3,
+        9,
+        TARGET_MONIKER,
+        SymbolRole::Definition as i32,
+    )])]);
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+
+    let memory_id = create_target_memory(&h, sym);
+
+    move_target_with_edit(&h, defs, "function");
+    // The next oracle run sees the same moniker defined at its new home.
+    let bytes = scip_bytes_docs(vec![("moved.rs", vec![occurrence(
+        0,
+        3,
+        9,
+        TARGET_MONIKER,
+        SymbolRole::Definition as i32,
+    )])]);
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+
+    let report = validate_memories(&h.conn).unwrap();
+    assert!(report.relocated >= 1, "expected a relocation, got {report:?}");
+
+    let memory = memory_by_id(&h.conn, &memory_id).unwrap().unwrap();
+    let symbol_binding =
+        memory.bindings.iter().find(|b| b.binding_kind == "symbol").expect("symbol binding");
+    assert_eq!(symbol_binding.anchor_status, "relocated");
+    assert_eq!(symbol_binding.binding_id, "moved.rs::target");
+    assert_eq!(symbol_binding.path.as_deref(), Some("moved.rs"));
+    assert_eq!(symbol_binding.relocation_reason.as_deref(), Some("moniker-match"));
+    let moniker_binding =
+        memory.bindings.iter().find(|b| b.binding_kind == "scip_moniker").expect("moniker binding");
+    assert_eq!(moniker_binding.anchor_status, "relocated");
+    assert_eq!(moniker_binding.logical_symbol_id, Some(2002));
+}
+
+/// A moniker match under a DIFFERENT current tool_version is lower confidence: it relocates only
+/// when the stored `symbol_kind` corroborates the candidate.
+#[test]
+fn cross_version_moniker_match_requires_kind_corroboration() {
+    for (new_kind, expect_status) in [("function", "relocated"), ("struct", "gone")] {
+        let h = Harness::new();
+        let defs = h.add_file("defs.rs", "fn target() {}\n");
+        let sym = h.add_symbol_qualified(defs, "target", "defs.rs::target", "function", 0, 14);
+        h.add_chunk(defs, "defs.rs::target", "fn target() {}\n");
+        h.add_logical_symbol(1001, "defs.rs", "target", "defs.rs::target", sym);
+        let bytes = scip_bytes_docs(vec![("defs.rs", vec![occurrence(
+            0,
+            3,
+            9,
+            TARGET_MONIKER,
+            SymbolRole::Definition as i32,
+        )])]);
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+        let memory_id = create_target_memory(&h, sym);
+
+        move_target_with_edit(&h, defs, new_kind);
+        // The re-run comes from an UPGRADED tool: same moniker, different tool_version.
+        let bytes = scip_bytes_docs(vec![("moved.rs", vec![occurrence(
+            0,
+            3,
+            9,
+            TARGET_MONIKER,
+            SymbolRole::Definition as i32,
+        )])]);
+        run_oracle(&h.conn, TOOL, "v-newer", COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+
+        validate_memories(&h.conn).unwrap();
+        let memory = memory_by_id(&h.conn, &memory_id).unwrap().unwrap();
+        let symbol_binding =
+            memory.bindings.iter().find(|b| b.binding_kind == "symbol").expect("symbol binding");
+        assert_eq!(
+            symbol_binding.anchor_status, expect_status,
+            "cross-version match with new_kind={new_kind}"
+        );
+    }
+}
+
+/// `scip_moniker` binding statuses: `unverified` when the tool has no data at all, `gone` when
+/// current data lacks the moniker, `stale` when the moniker's row dangles (its content-derived
+/// logical id died after the symbol changed).
+#[test]
+fn moniker_binding_validation_statuses() {
+    let h = Harness::new();
+    let defs = h.add_file("defs.rs", "fn target() {}\n");
+    let sym = h.add_symbol_qualified(defs, "target", "defs.rs::target", "function", 0, 14);
+    h.add_chunk(defs, "defs.rs::target", "fn target() {}\n");
+    h.add_logical_symbol(1001, "defs.rs", "target", "defs.rs::target", sym);
+    let bytes = scip_bytes_docs(vec![("defs.rs", vec![occurrence(
+        0,
+        3,
+        9,
+        TARGET_MONIKER,
+        SymbolRole::Definition as i32,
+    )])]);
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+    let memory_id = create_target_memory(&h, sym);
+
+    let moniker_status = |h: &Harness| -> String {
+        validate_memories(&h.conn).unwrap();
+        let memory = memory_by_id(&h.conn, &memory_id).unwrap().unwrap();
+        memory
+            .bindings
+            .iter()
+            .find(|b| b.binding_kind == "scip_moniker")
+            .expect("moniker binding")
+            .anchor_status
+            .clone()
+    };
+
+    assert_eq!(moniker_status(&h), "current");
+
+    // Dangling: the symbol changed — its content-derived logical id died, the row points nowhere.
+    h.conn.execute("DELETE FROM logical_symbols WHERE id = 1001", []).unwrap();
+    assert_eq!(moniker_status(&h), "stale");
+
+    // A lagging moniker anchor must NOT demote the memory's evidence — the symbol binding is
+    // intact, and the moniker self-heals on the next oracle run.
+    let memory = memory_by_id(&h.conn, &memory_id).unwrap().unwrap();
+    let symbol_status = memory
+        .bindings
+        .iter()
+        .find(|b| b.binding_kind == "symbol")
+        .map(|b| b.anchor_status.clone())
+        .unwrap();
+    assert_eq!(symbol_status, "current");
+    let (direct, stale) = split_active_stale(vec![memory]);
+    assert_eq!(direct.len(), 1, "stale moniker anchor must not demote the memory");
+    assert!(stale.is_empty());
+
+    // Gone: the tool has current data, but not this moniker.
+    h.conn
+        .execute(
+            "UPDATE logical_symbol_monikers SET moniker = 'rust-analyzer cargo test_crate 0.1.0 \
+             other().' WHERE logical_symbol_id = 1001",
+            [],
+        )
+        .unwrap();
+    assert_eq!(moniker_status(&h), "gone");
+
+    // Unverified: no oracle data for the tool at all.
+    h.conn.execute("DELETE FROM logical_symbol_monikers", []).unwrap();
+    assert_eq!(moniker_status(&h), "unverified");
 }

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -3050,6 +3050,11 @@ fn moniker_binding_validation_statuses() {
     assert_eq!(direct.len(), 1, "stale moniker anchor must not demote the memory");
     assert!(stale.is_empty());
 
+    // ...and must not count toward the anchor-health totals that drive the "run memory doctor"
+    // warnings — doctor hides moniker rows, so counting them would warn about nothing visible.
+    let health = crate::query::memory::anchor_health_counts(&h.conn).unwrap();
+    assert_eq!(health.stale, 0, "auxiliary moniker anchors are excluded from health counts");
+
     // Gone: the tool has current data, but not this moniker.
     h.conn
         .execute(
@@ -3090,4 +3095,110 @@ fn moniker_for_symbol_with_member_defs_is_the_symbols_own() {
     assert_eq!(report.monikers_written, 1, "one row per logical symbol, not per def");
     let (moniker, ..) = h.moniker(3003).expect("moniker row written");
     assert_eq!(moniker, struct_moniker, "the symbol's own (shortest) moniker wins");
+}
+
+/// Moniker-STRING drift (Codex P2): rust-analyzer monikers embed the Cargo package version, so a
+/// routine version bump rewrites every string while no symbol changes. The binding's stored
+/// content-derived logical id is still live, so validation re-anchors the binding to the new
+/// string (`relocated`, reason `moniker-refresh`) instead of marking it gone forever — and a
+/// LATER file move can still relocate via the refreshed moniker.
+#[test]
+fn moniker_string_drift_rebinds_via_live_logical_symbol_then_survives_move() {
+    let h = Harness::new();
+    let defs = h.add_file("defs.rs", "fn target() {}\n");
+    let sym = h.add_symbol_qualified(defs, "target", "defs.rs::target", "function", 0, 14);
+    h.add_chunk(defs, "defs.rs::target", "fn target() {}\n");
+    h.add_logical_symbol(1001, "defs.rs", "target", "defs.rs::target", sym);
+    let bytes = scip_bytes_docs(vec![("defs.rs", vec![occurrence(
+        0,
+        3,
+        9,
+        TARGET_MONIKER,
+        SymbolRole::Definition as i32,
+    )])]);
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+    let memory_id = create_target_memory(&h, sym);
+
+    // Crate version bump: same symbol, same location, NEW moniker string + tool version.
+    let bumped_moniker = "rust-analyzer cargo test_crate 0.2.0 target().";
+    let bytes = scip_bytes_docs(vec![("defs.rs", vec![occurrence(
+        0,
+        3,
+        9,
+        bumped_moniker,
+        SymbolRole::Definition as i32,
+    )])]);
+    run_oracle(&h.conn, TOOL, "v-bumped", COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+
+    validate_memories(&h.conn).unwrap();
+    let memory = memory_by_id(&h.conn, &memory_id).unwrap().unwrap();
+    let moniker_binding =
+        memory.bindings.iter().find(|b| b.binding_kind == "scip_moniker").expect("moniker binding");
+    assert_eq!(moniker_binding.anchor_status, "relocated");
+    assert_eq!(moniker_binding.binding_id, bumped_moniker, "rebound to the current string");
+    assert_eq!(moniker_binding.moniker_tool_version.as_deref(), Some("v-bumped"));
+    assert_eq!(moniker_binding.relocation_reason.as_deref(), Some("moniker-refresh"));
+
+    // The refreshed anchor still does its job: a later move + content edit relocates via it.
+    move_target_with_edit(&h, defs, "function");
+    let bytes = scip_bytes_docs(vec![("moved.rs", vec![occurrence(
+        0,
+        3,
+        9,
+        bumped_moniker,
+        SymbolRole::Definition as i32,
+    )])]);
+    run_oracle(&h.conn, TOOL, "v-bumped", COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+    validate_memories(&h.conn).unwrap();
+    let memory = memory_by_id(&h.conn, &memory_id).unwrap().unwrap();
+    let symbol_binding =
+        memory.bindings.iter().find(|b| b.binding_kind == "symbol").expect("symbol binding");
+    assert_eq!(symbol_binding.anchor_status, "relocated");
+    assert_eq!(symbol_binding.path.as_deref(), Some("moved.rs"));
+    assert_eq!(symbol_binding.relocation_reason.as_deref(), Some("moniker-match"));
+}
+
+/// The string-resolution path must NOT refresh the bind-time `moniker_tool_version` (Codex P1):
+/// the cross-version corroboration gate compares the CURRENT data's version against bind-time
+/// provenance, and a "last verified" refresh would silently downgrade a real cross-version match
+/// to same-version.
+#[test]
+fn string_resolution_preserves_bind_time_tool_version() {
+    let h = Harness::new();
+    let defs = h.add_file("defs.rs", "fn target() {}\n");
+    let sym = h.add_symbol_qualified(defs, "target", "defs.rs::target", "function", 0, 14);
+    h.add_chunk(defs, "defs.rs::target", "fn target() {}\n");
+    h.add_logical_symbol(1001, "defs.rs", "target", "defs.rs::target", sym);
+    let bytes = scip_bytes_docs(vec![("defs.rs", vec![occurrence(
+        0,
+        3,
+        9,
+        TARGET_MONIKER,
+        SymbolRole::Definition as i32,
+    )])]);
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+    let memory_id = create_target_memory(&h, sym);
+
+    // Move with the SAME moniker string but a NEWER tool version: the stored logical id is dead,
+    // so validation takes the string-resolution path.
+    move_target_with_edit(&h, defs, "function");
+    let bytes = scip_bytes_docs(vec![("moved.rs", vec![occurrence(
+        0,
+        3,
+        9,
+        TARGET_MONIKER,
+        SymbolRole::Definition as i32,
+    )])]);
+    run_oracle(&h.conn, TOOL, "v-newer", COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+    validate_memories(&h.conn).unwrap();
+
+    let memory = memory_by_id(&h.conn, &memory_id).unwrap().unwrap();
+    let moniker_binding =
+        memory.bindings.iter().find(|b| b.binding_kind == "scip_moniker").expect("moniker binding");
+    assert_eq!(moniker_binding.anchor_status, "relocated");
+    assert_eq!(
+        moniker_binding.moniker_tool_version.as_deref(),
+        Some(VERSION),
+        "bind-time provenance must survive a string-resolution relocate"
+    );
 }

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -3202,3 +3202,55 @@ fn string_resolution_preserves_bind_time_tool_version() {
         "bind-time provenance must survive a string-resolution relocate"
     );
 }
+
+/// Bare `path` bindings are AREA anchors (like `dir` bindings): a file edit must not stale them —
+/// before this, every commit permanently staled every area-level note bound to a touched file,
+/// burying real staleness signals. A SPANNED `path:start-end` binding claims specific content and
+/// keeps the content-hash staleness.
+#[test]
+fn bare_path_binding_survives_file_edit_spanned_goes_stale() {
+    let h = Harness::new();
+    let file = h.add_file("notes.rs", "fn a() {}\nfn b() {}\n");
+
+    let bind_path = |start: Option<i64>, end: Option<i64>, title: &str| {
+        create_memory(&h.conn, RepoMemoryCreate {
+            kind: "Decision".to_string(),
+            title: title.to_string(),
+            body: "area note".to_string(),
+            confidence: "high".to_string(),
+            created_by: None,
+            source: None,
+            tags: Vec::new(),
+            bind: RepoMemoryBindTarget {
+                path: Some("notes.rs".to_string()),
+                start_line: start,
+                end_line: end,
+                ..Default::default()
+            },
+        })
+        .unwrap()
+        .memory
+        .memory_id
+    };
+    let bare = bind_path(None, None, "bare path note");
+    let spanned = bind_path(Some(1), Some(1), "spanned path note");
+
+    // Edit the file: new content, new sha on the files row.
+    h.set_file_sha(file, "edited-sha");
+    validate_memories(&h.conn).unwrap();
+
+    let status =
+        |id: &str| memory_by_id(&h.conn, id).unwrap().unwrap().bindings[0].anchor_status.clone();
+    assert_eq!(
+        status(&bare),
+        "current",
+        "bare path binding is an area anchor — never content-stale"
+    );
+    assert_eq!(status(&spanned), "stale", "spanned path binding still claims content");
+
+    // Deleting the file row sends both to gone.
+    h.conn.execute("DELETE FROM files WHERE id = ?1", [file]).unwrap();
+    validate_memories(&h.conn).unwrap();
+    assert_eq!(status(&bare), "gone");
+    assert_eq!(status(&spanned), "gone");
+}

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -520,6 +520,51 @@ pub(crate) fn apply_oracle_tables(conn: &Connection) -> rusqlite::Result<()> {
     Ok(())
 }
 
+pub(crate) fn apply_scip_moniker_anchors(conn: &Connection) -> rusqlite::Result<()> {
+    // SCIP moniker anchors (#70, phase 3). Greenfield table STRICT per repo convention.
+    //
+    // `logical_symbol_monikers`: the SCIP symbol string ("moniker") for a logical symbol, written
+    // by `oracle run` from the `.scip` definition map. Keyed by `logical_symbols.id`, which is a
+    // CONTENT-DERIVED stable id (language/path/name/qualified_name/kind/signature — see
+    // `LogicalSymbolKey::stable_id`), NOT a rowid.
+    //
+    // INVARIANT (load-bearing): NO foreign key to `logical_symbols`, on purpose.
+    // `rebuild_logical_symbols` runs on EVERY index pass and rebuilds the table wholesale
+    // (DELETE-all + reinsert) — an FK cascade would wipe every moniker on every reindex, defeating
+    // the relocation fallback. Because the id is content-derived, an unchanged symbol's reinserted
+    // row keeps its id and its moniker row stays valid across rebuilds with no re-run. A CHANGED
+    // symbol mints a new id and its old moniker row dangles; every read joins live
+    // `logical_symbols`, so a dangling row never resolves, and the next `oracle run`'s
+    // authoritative per-tool clear removes it.
+    //
+    // PK `(logical_symbol_id, tool)`: one moniker per logical symbol per tool — cfg-gated Rust
+    // variants share the logical symbol, hence share the moniker by construction. `tool_version`
+    // rides along so a relocation match against a binding recorded under a different version can
+    // be treated as lower confidence (#70).
+    //
+    // `repo_memory_bindings` gains the moniker provenance pair (set on `scip_moniker`-kind binding
+    // rows) and `relocation_reason` (e.g. `moniker-match`), all nullable/additive.
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS logical_symbol_monikers(
+            logical_symbol_id INTEGER NOT NULL,
+            tool TEXT NOT NULL,
+            tool_version TEXT NOT NULL,
+            moniker TEXT NOT NULL,
+            computed_at INTEGER NOT NULL,
+            PRIMARY KEY(logical_symbol_id, tool)
+        ) STRICT;
+
+        CREATE INDEX IF NOT EXISTS idx_logical_symbol_monikers_moniker
+            ON logical_symbol_monikers(moniker, tool);
+        ",
+    )?;
+    add_column_if_missing(conn, "repo_memory_bindings", "moniker_tool", "TEXT")?;
+    add_column_if_missing(conn, "repo_memory_bindings", "moniker_tool_version", "TEXT")?;
+    add_column_if_missing(conn, "repo_memory_bindings", "relocation_reason", "TEXT")?;
+    Ok(())
+}
+
 pub(crate) fn applied_migrations(conn: &Connection) -> anyhow::Result<Vec<AppliedMigration>> {
     let mut stmt = conn.prepare(
         "
@@ -565,6 +610,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_016_ID => Some(16),
             MIGRATION_017_ID => Some(17),
             MIGRATION_018_ID => Some(18),
+            MIGRATION_019_ID => Some(19),
             _ => None,
         })
         .max()
@@ -592,6 +638,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_016_ID
             | MIGRATION_017_ID
             | MIGRATION_018_ID
+            | MIGRATION_019_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -616,6 +663,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_016_ID => migration.checksum != MIGRATION_016_CHECKSUM,
         MIGRATION_017_ID => migration.checksum != MIGRATION_017_CHECKSUM,
         MIGRATION_018_ID => migration.checksum != MIGRATION_018_CHECKSUM,
+        MIGRATION_019_ID => migration.checksum != MIGRATION_019_CHECKSUM,
         _ => false,
     }
 }

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use migrations::*;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 18;
+pub const LATEST_SCHEMA_VERSION: u32 = 19;
 const DIRTY_MIGRATION_ID: &str = "__dirty__";
 const MIGRATION_001_ID: &str = "001_sqlite_storage_baseline";
 const MIGRATION_001_CHECKSUM: &str = "sha256:rag-rat-sqlite-baseline-v1";
@@ -80,6 +80,10 @@ const MIGRATION_018_ID: &str = "018_scip_oracle_tables";
 const MIGRATION_018_CHECKSUM: &str = "sha256:rag-rat-scip-oracle-tables-v18";
 const MIGRATION_018_DESCRIPTION: &str =
     "Add oracle_runs + edge_oracle side tables for SCIP compiler-grade edge resolution (#68)";
+const MIGRATION_019_ID: &str = "019_scip_moniker_anchors";
+const MIGRATION_019_CHECKSUM: &str = "sha256:rag-rat-scip-moniker-anchors-v19";
+const MIGRATION_019_DESCRIPTION: &str = "Add logical_symbol_monikers + moniker provenance and \
+                                         relocation reason on repo memory bindings (#70)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -168,6 +172,8 @@ pub fn apply(conn: &Connection) -> rusqlite::Result<()> {
     record_migration(conn, MIGRATION_017_ID, MIGRATION_017_CHECKSUM, MIGRATION_017_DESCRIPTION)?;
     apply_oracle_tables(conn)?;
     record_migration(conn, MIGRATION_018_ID, MIGRATION_018_CHECKSUM, MIGRATION_018_DESCRIPTION)?;
+    apply_scip_moniker_anchors(conn)?;
+    record_migration(conn, MIGRATION_019_ID, MIGRATION_019_CHECKSUM, MIGRATION_019_DESCRIPTION)?;
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/query/memory/api.rs
+++ b/crates/rag-rat-core/src/query/memory/api.rs
@@ -704,6 +704,10 @@ pub(crate) fn anchor_health_counts(
         FROM repo_memory_bindings AS b
         JOIN repo_memories AS m ON m.id = b.memory_id
         WHERE m.status = 'active'
+          -- Auxiliary `scip_moniker` anchors are excluded exactly as in `doctor_report`: these
+          -- counts drive the 'run memory doctor' warnings, so counting rows doctor then hides
+          -- would yield an unresolvable warning (#70 review).
+          AND b.binding_kind != 'scip_moniker'
         GROUP BY b.anchor_status
         ",
     )?;

--- a/crates/rag-rat-core/src/query/memory/api.rs
+++ b/crates/rag-rat-core/src/query/memory/api.rs
@@ -42,6 +42,9 @@ pub(crate) fn create_memory(
         ],
     )?;
     insert_binding(conn, &id, &binding, now)?;
+    // A symbol-bound memory whose logical symbol has a known SCIP moniker gets the moniker anchor
+    // automatically (#70) — the relocation fallback the hash anchors can't provide.
+    insert_auto_moniker_binding(conn, &id, &binding, now)?;
     replace_tags(conn, &id, &request.tags)?;
     upsert_memory_fts(conn, &id)?;
     let memory = memory_by_id(conn, &id)?
@@ -453,6 +456,7 @@ pub(crate) fn rebind_memory(
     conn.execute("DELETE FROM repo_memory_call_paths WHERE memory_id = ?1", [memory_id])?;
     let now = now_ms();
     insert_binding(conn, memory_id, &binding, now)?;
+    insert_auto_moniker_binding(conn, memory_id, &binding, now)?;
     conn.execute(
         "UPDATE repo_memories SET source_text_hash = ?2, updated_at_ms = ?3 WHERE id = ?1",
         params![memory_id, binding.source_text_hash, now],
@@ -569,6 +573,10 @@ pub(crate) fn doctor_report(conn: &Connection) -> anyhow::Result<Vec<MemoryDocto
         JOIN repo_memories AS m ON m.id = b.memory_id
         WHERE m.status = 'active'
           AND b.anchor_status IN ('gone', 'stale')
+          -- `scip_moniker` bindings are excluded: a lagging moniker self-heals on the next
+          -- `oracle run` and is never rebind-actionable; a genuinely dead symbol surfaces via
+          -- its symbol/logical_symbol binding anyway (#70).
+          AND b.binding_kind != 'scip_moniker'
         ORDER BY b.memory_id, b.binding_kind, b.binding_id
         ",
     )?;
@@ -719,8 +727,8 @@ pub(crate) fn validate_memories(conn: &Connection) -> anyhow::Result<RepoMemoryV
         "
         SELECT memory_id, binding_kind, binding_id, path, start_line, end_line,
                logical_symbol_id, symbol_id, chunk_id, edge_id, commit_hash, github_owner,
-               github_repo, github_number, symbol_kind, signature_hash, anchor_status, \
-         created_at_ms
+               github_repo, github_number, symbol_kind, signature_hash, moniker_tool,
+               moniker_tool_version, relocation_reason, anchor_status, created_at_ms
         FROM repo_memory_bindings
         ",
     )?;
@@ -744,7 +752,8 @@ pub(crate) fn validate_memories(conn: &Connection) -> anyhow::Result<RepoMemoryV
             UPDATE OR IGNORE repo_memory_bindings
             SET anchor_status = ?3, logical_symbol_id = ?4, symbol_id = ?5, chunk_id = ?6,
                 edge_id = ?7, path = ?8, start_line = ?9, end_line = ?10,
-                binding_id = ?11, symbol_kind = ?12, signature_hash = ?13
+                binding_id = ?11, symbol_kind = ?12, signature_hash = ?13,
+                moniker_tool_version = ?15, relocation_reason = ?16
             WHERE memory_id = ?1 AND binding_kind = ?2 AND binding_id = ?14
             ",
             params![
@@ -761,7 +770,9 @@ pub(crate) fn validate_memories(conn: &Connection) -> anyhow::Result<RepoMemoryV
                 binding.binding_id,
                 binding.symbol_kind,
                 binding.signature_hash,
-                original_binding_id
+                original_binding_id,
+                binding.moniker_tool_version,
+                binding.relocation_reason
             ],
         )?;
         // UPDATE OR IGNORE: if a sibling binding already holds the new (memory_id, kind,

--- a/crates/rag-rat-core/src/query/memory/mod.rs
+++ b/crates/rag-rat-core/src/query/memory/mod.rs
@@ -1,10 +1,12 @@
 mod api;
+mod moniker;
 mod resolve;
 mod validate;
 use std::collections::BTreeSet;
 
 pub use api::memory_evidence_for_symbol;
 pub(crate) use api::*;
+pub(crate) use moniker::*;
 pub(crate) use resolve::*;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
@@ -67,6 +69,17 @@ pub struct RepoMemoryBinding {
     pub symbol_kind: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signature_hash: Option<String>,
+    /// SCIP moniker provenance, set on `scip_moniker`-kind bindings: the oracle tool + version
+    /// whose data supplied `binding_id` (the moniker) at bind time. A relocation match against a
+    /// different current `tool_version` is lower confidence (#70).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub moniker_tool: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub moniker_tool_version: Option<String>,
+    /// How the last validation relocated this binding (e.g. `moniker-match`), `None` when the
+    /// anchor never relocated or relocated via the default qualified-name/content paths.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relocation_reason: Option<String>,
     pub anchor_status: String,
     pub created_at_ms: i64,
 }

--- a/crates/rag-rat-core/src/query/memory/moniker.rs
+++ b/crates/rag-rat-core/src/query/memory/moniker.rs
@@ -1,0 +1,340 @@
+//! SCIP moniker anchors for repo memories (#70, SCIP phase 3).
+//!
+//! `oracle run` records each in-corpus SCIP definition's symbol string ("moniker") against the
+//! defining logical symbol in `logical_symbol_monikers` (see `index/oracle/run.rs`). This module
+//! is the memory-side consumer:
+//!
+//! - **Auto-binding:** a memory created (or rebound) on a symbol whose logical symbol has a known
+//!   moniker gets an additional `scip_moniker` binding row automatically — binding_id is the
+//!   moniker, with tool + tool_version provenance on the row.
+//! - **Validation:** a `scip_moniker` binding re-resolves its moniker against the current oracle
+//!   data and refreshes its location fields.
+//! - **Relocation fallback:** when a symbol/logical_symbol binding's other anchors are exhausted
+//!   (qualified name gone, no content-hash match), the sibling moniker binding is re-resolved; a
+//!   unique live match relocates the binding with `relocation_reason = "moniker-match"`. A match
+//!   under a different current `tool_version` is lower confidence and additionally requires
+//!   `symbol_kind` corroboration.
+
+use super::*;
+
+/// Why a moniker relocation succeeded — persisted on `repo_memory_bindings.relocation_reason` so
+/// `doctor`/MCP output can distinguish a semantic-identity relocate from the default
+/// qualified-name/content paths.
+pub(crate) const MONIKER_MATCH_REASON: &str = "moniker-match";
+
+/// The binding kind for a moniker anchor row.
+pub(crate) const SCIP_MONIKER_BINDING_KIND: &str = "scip_moniker";
+
+/// One `logical_symbol_monikers` row, as read for auto-binding.
+#[derive(Debug, Clone)]
+pub(crate) struct MonikerRow {
+    pub(crate) moniker: String,
+    pub(crate) tool: String,
+    pub(crate) tool_version: String,
+}
+
+/// The current moniker for a logical symbol, if the oracle has recorded one. At most one row per
+/// tool; with a single tool per language today the first row wins deterministically (ORDER BY
+/// tool so a future multi-tool index stays stable).
+pub(crate) fn moniker_for_logical_symbol(
+    conn: &Connection,
+    logical_symbol_id: i64,
+) -> anyhow::Result<Option<MonikerRow>> {
+    conn.query_row(
+        "
+        SELECT moniker, tool, tool_version
+        FROM logical_symbol_monikers
+        WHERE logical_symbol_id = ?1
+        ORDER BY tool
+        LIMIT 1
+        ",
+        [logical_symbol_id],
+        |row| Ok(MonikerRow { moniker: row.get(0)?, tool: row.get(1)?, tool_version: row.get(2)? }),
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+/// What re-resolving a moniker against the current oracle data concluded.
+#[derive(Debug)]
+pub(crate) enum MonikerResolution {
+    /// The tool has no moniker rows at all — the oracle never ran (or its data was cleared), so
+    /// nothing can be said either way.
+    NoData,
+    /// The tool has current data and no row carries this moniker: the latest oracle run did not
+    /// see this symbol.
+    Gone,
+    /// A row carries the moniker but its content-derived logical id no longer exists — the symbol
+    /// changed (or moved) after the last `oracle run`; the data is outdated, not authoritative.
+    Dangling,
+    /// More than one live logical symbol carries this moniker — ambiguous, never relocate.
+    Ambiguous,
+    /// Exactly one live logical symbol carries this moniker.
+    Unique { logical_symbol_id: i64, tool_version: String },
+}
+
+/// Re-resolve a moniker for `tool` against the current `logical_symbol_monikers` data, joining
+/// live `logical_symbols` (a dangling row — its content-derived id died in a rebuild — must not
+/// resolve).
+pub(crate) fn resolve_moniker(
+    conn: &Connection,
+    moniker: &str,
+    tool: &str,
+) -> anyhow::Result<MonikerResolution> {
+    let mut stmt = conn.prepare(
+        "
+        SELECT logical_symbol_monikers.logical_symbol_id, logical_symbol_monikers.tool_version,
+               logical_symbols.id IS NOT NULL AS live
+        FROM logical_symbol_monikers
+        LEFT JOIN logical_symbols ON logical_symbols.id = logical_symbol_monikers.logical_symbol_id
+        WHERE logical_symbol_monikers.moniker = ?1 AND logical_symbol_monikers.tool = ?2
+        ",
+    )?;
+    let rows = stmt
+        .query_map(params![moniker, tool], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?, row.get::<_, bool>(2)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    let mut live = rows.iter().filter(|(_, _, is_live)| *is_live);
+    let first = live.next();
+    let second = live.next();
+    match (rows.is_empty(), first, second) {
+        (true, ..) => {
+            let tool_has_rows: bool = conn.query_row(
+                "SELECT EXISTS(SELECT 1 FROM logical_symbol_monikers WHERE tool = ?1)",
+                [tool],
+                |row| row.get(0),
+            )?;
+            Ok(if tool_has_rows { MonikerResolution::Gone } else { MonikerResolution::NoData })
+        },
+        (false, None, _) => Ok(MonikerResolution::Dangling),
+        (false, Some(_), Some(_)) => Ok(MonikerResolution::Ambiguous),
+        (false, Some((logical_symbol_id, tool_version, _)), None) =>
+            Ok(MonikerResolution::Unique {
+                logical_symbol_id: *logical_symbol_id,
+                tool_version: tool_version.clone(),
+            }),
+    }
+}
+
+/// Build the relocation target for a live logical symbol: its representative member symbol
+/// (chunk-first, member-table fallback) with the same fields `relocate_symbol_by_name` recovers,
+/// so a moniker relocate rebinds identically to a name/content relocate.
+pub(crate) fn relocate_match_for_logical_symbol(
+    conn: &Connection,
+    logical_symbol_id: i64,
+) -> anyhow::Result<Option<RelocateMatch>> {
+    let chunk = chunk_for_logical_symbol(conn, logical_symbol_id)?;
+    let member_symbol_id = match chunk.as_ref().and_then(|c| c.symbol_id) {
+        Some(id) => id,
+        None => {
+            // No chunk-attached member (e.g. a chunking gap): fall back to the first member row.
+            let Some(id) = conn
+                .query_row(
+                    "SELECT symbol_id FROM logical_symbol_members
+                     WHERE logical_symbol_id = ?1 ORDER BY start_line LIMIT 1",
+                    [logical_symbol_id],
+                    |row| row.get::<_, i64>(0),
+                )
+                .optional()?
+            else {
+                return Ok(None);
+            };
+            id
+        },
+    };
+    let Some(qualified_name) = conn
+        .query_row("SELECT qualified_name FROM symbols WHERE id = ?1", [member_symbol_id], |row| {
+            row.get::<_, String>(0)
+        })
+        .optional()?
+    else {
+        return Ok(None);
+    };
+    let Some(path) = conn
+        .query_row(
+            "SELECT files.path FROM symbols JOIN files ON files.id = symbols.file_id
+             WHERE symbols.id = ?1",
+            [member_symbol_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+    else {
+        return Ok(None);
+    };
+    let (symbol_kind, signature_hash) = symbol_signal(conn, member_symbol_id)?;
+    Ok(Some(RelocateMatch {
+        binding_id: qualified_name,
+        symbol_id: member_symbol_id,
+        logical_symbol_id: Some(logical_symbol_id),
+        path,
+        chunk_id: chunk.as_ref().map(|c| c.chunk_id),
+        start_line: chunk.as_ref().map(|c| c.start_line),
+        end_line: chunk.as_ref().map(|c| c.end_line),
+        symbol_kind,
+        signature_hash,
+    }))
+}
+
+/// The moniker recorded for a memory at bind time: the `scip_moniker` sibling binding's
+/// `(moniker, tool, tool_version)`, if the memory has one.
+pub(crate) fn moniker_binding_for_memory(
+    conn: &Connection,
+    memory_id: &str,
+) -> anyhow::Result<Option<MonikerRow>> {
+    conn.query_row(
+        "
+        SELECT binding_id, moniker_tool, moniker_tool_version
+        FROM repo_memory_bindings
+        WHERE memory_id = ?1 AND binding_kind = ?2
+        LIMIT 1
+        ",
+        params![memory_id, SCIP_MONIKER_BINDING_KIND],
+        |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, Option<String>>(2)?,
+            ))
+        },
+    )
+    .optional()
+    .map(|row| {
+        row.and_then(|(moniker, tool, tool_version)| {
+            Some(MonikerRow { moniker, tool: tool?, tool_version: tool_version? })
+        })
+    })
+    .map_err(Into::into)
+}
+
+/// The moniker relocation fallback for a `symbol` / `logical_symbol` binding whose other anchors
+/// are exhausted (#70): re-resolve the memory's recorded moniker against current oracle data and
+/// return the unique live target, or `None`.
+///
+/// Confidence gate: a match whose current `tool_version` differs from the one recorded at bind
+/// time is lower confidence (the tool's moniker format may have changed between versions), so it
+/// additionally requires `symbol_kind` corroboration against the binding's stored kind — a
+/// same-version match relocates on moniker identity alone.
+pub(crate) fn relocate_binding_by_moniker(
+    conn: &Connection,
+    binding: &RepoMemoryBinding,
+) -> anyhow::Result<Option<RelocateMatch>> {
+    let Some(recorded) = moniker_binding_for_memory(conn, &binding.memory_id)? else {
+        return Ok(None);
+    };
+    let MonikerResolution::Unique { logical_symbol_id, tool_version } =
+        resolve_moniker(conn, &recorded.moniker, &recorded.tool)?
+    else {
+        return Ok(None);
+    };
+    let Some(matched) = relocate_match_for_logical_symbol(conn, logical_symbol_id)? else {
+        return Ok(None);
+    };
+    let cross_version = tool_version != recorded.tool_version;
+    if cross_version {
+        let corroborated = match (binding.symbol_kind.as_deref(), matched.symbol_kind.as_deref()) {
+            (Some(stored), Some(found)) => stored == found,
+            _ => false,
+        };
+        if !corroborated {
+            return Ok(None);
+        }
+    }
+    Ok(Some(matched))
+}
+
+/// Insert the automatic `scip_moniker` binding for a freshly bound memory, when the primary
+/// binding is a symbol/logical_symbol whose logical symbol has a known moniker. No-op otherwise.
+/// `INSERT OR IGNORE` keeps a re-create of the same memory id from tripping the binding PK.
+pub(crate) fn insert_auto_moniker_binding(
+    conn: &Connection,
+    memory_id: &str,
+    primary: &ResolvedBinding,
+    now: i64,
+) -> anyhow::Result<()> {
+    if !matches!(primary.binding_kind.as_str(), "symbol" | "logical_symbol") {
+        return Ok(());
+    }
+    let Some(logical_symbol_id) = primary.logical_symbol_id else {
+        return Ok(());
+    };
+    let Some(row) = moniker_for_logical_symbol(conn, logical_symbol_id)? else {
+        return Ok(());
+    };
+    conn.execute(
+        "
+        INSERT OR IGNORE INTO repo_memory_bindings(
+            memory_id, binding_kind, binding_id, path, start_line, end_line, logical_symbol_id,
+            symbol_id, chunk_id, edge_id, commit_hash, github_owner, github_repo, github_number,
+            symbol_kind, signature_hash, moniker_tool, moniker_tool_version, anchor_status,
+            created_at_ms
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, NULL, NULL, NULL, NULL, NULL, ?10, ?11, ?12, \
+         ?13, 'current', ?14)
+        ",
+        params![
+            memory_id,
+            SCIP_MONIKER_BINDING_KIND,
+            row.moniker,
+            primary.path,
+            primary.start_line,
+            primary.end_line,
+            logical_symbol_id,
+            primary.symbol_id,
+            primary.chunk_id,
+            primary.symbol_kind,
+            primary.signature_hash,
+            row.tool,
+            row.tool_version,
+            now
+        ],
+    )?;
+    Ok(())
+}
+
+/// Validate a `scip_moniker` binding: re-resolve the moniker against current oracle data and
+/// refresh the binding's location fields from the live logical symbol. Statuses:
+///
+/// - `unverified` — no oracle data for the tool at all (nothing can be said), or a malformed row
+///   missing its tool provenance.
+/// - `gone` — the tool has current data and the moniker is not in it.
+/// - `stale` — the data is outdated (the moniker's row dangles after the symbol changed) or
+///   ambiguous (two live logical symbols share it); awaiting the next `oracle run`.
+/// - `current` / `relocated` — unique live match; `relocated` when the resolved logical symbol
+///   differs from the stored one (the binding's fields are rewritten to the new home).
+pub(crate) fn validate_moniker_binding(
+    conn: &Connection,
+    binding: &mut RepoMemoryBinding,
+) -> anyhow::Result<String> {
+    let Some(tool) = binding.moniker_tool.clone() else {
+        return Ok("unverified".to_string());
+    };
+    match resolve_moniker(conn, &binding.binding_id, &tool)? {
+        MonikerResolution::NoData => Ok("unverified".to_string()),
+        MonikerResolution::Gone => Ok("gone".to_string()),
+        MonikerResolution::Dangling | MonikerResolution::Ambiguous => Ok("stale".to_string()),
+        MonikerResolution::Unique { logical_symbol_id, tool_version } => {
+            let moved = binding.logical_symbol_id != Some(logical_symbol_id);
+            let Some(matched) = relocate_match_for_logical_symbol(conn, logical_symbol_id)? else {
+                return Ok("stale".to_string());
+            };
+            binding.logical_symbol_id = matched.logical_symbol_id;
+            binding.symbol_id = Some(matched.symbol_id);
+            binding.path = Some(matched.path);
+            binding.chunk_id = matched.chunk_id;
+            binding.start_line = matched.start_line;
+            binding.end_line = matched.end_line;
+            binding.symbol_kind = matched.symbol_kind;
+            binding.signature_hash = matched.signature_hash;
+            // The binding is now verified against this version's data.
+            binding.moniker_tool_version = Some(tool_version);
+            if moved {
+                binding.relocation_reason = Some(MONIKER_MATCH_REASON.to_string());
+                Ok("relocated".to_string())
+            } else {
+                Ok("current".to_string())
+            }
+        },
+    }
+}

--- a/crates/rag-rat-core/src/query/memory/moniker.rs
+++ b/crates/rag-rat-core/src/query/memory/moniker.rs
@@ -22,6 +22,12 @@ use super::*;
 /// qualified-name/content paths.
 pub(crate) const MONIKER_MATCH_REASON: &str = "moniker-match";
 
+/// Why a `scip_moniker` binding's own anchor string was rewritten: its live logical symbol got a
+/// NEW moniker from the latest run (rust-analyzer monikers embed the Cargo package version, so a
+/// routine version bump changes every string without changing any symbol identity). The rebind is
+/// keyed off our own content-derived logical id, not fuzzy matching.
+pub(crate) const MONIKER_REFRESH_REASON: &str = "moniker-refresh";
+
 /// The binding kind for a moniker anchor row.
 pub(crate) const SCIP_MONIKER_BINDING_KIND: &str = "scip_moniker";
 
@@ -49,6 +55,27 @@ pub(crate) fn moniker_for_logical_symbol(
         LIMIT 1
         ",
         [logical_symbol_id],
+        |row| Ok(MonikerRow { moniker: row.get(0)?, tool: row.get(1)?, tool_version: row.get(2)? }),
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+/// The current moniker row for a logical symbol under a SPECIFIC tool — the read the validation
+/// re-derivation path uses (the binding records which tool supplied its anchor, so the refresh
+/// must not cross tools).
+pub(crate) fn moniker_for_logical_symbol_tool(
+    conn: &Connection,
+    logical_symbol_id: i64,
+    tool: &str,
+) -> anyhow::Result<Option<MonikerRow>> {
+    conn.query_row(
+        "
+        SELECT moniker, tool, tool_version
+        FROM logical_symbol_monikers
+        WHERE logical_symbol_id = ?1 AND tool = ?2
+        ",
+        params![logical_symbol_id, tool],
         |row| Ok(MonikerRow { moniker: row.get(0)?, tool: row.get(1)?, tool_version: row.get(2)? }),
     )
     .optional()
@@ -298,11 +325,25 @@ pub(crate) fn insert_auto_moniker_binding(
 ///
 /// - `unverified` — no oracle data for the tool at all (nothing can be said), or a malformed row
 ///   missing its tool provenance.
-/// - `gone` — the tool has current data and the moniker is not in it.
+/// - `gone` — the tool has current data and the moniker is not in it (and the stored logical symbol
+///   is dead too).
 /// - `stale` — the data is outdated (the moniker's row dangles after the symbol changed) or
 ///   ambiguous (two live logical symbols share it); awaiting the next `oracle run`.
-/// - `current` / `relocated` — unique live match; `relocated` when the resolved logical symbol
-///   differs from the stored one (the binding's fields are rewritten to the new home).
+/// - `current` / `relocated` — anchored to a live logical symbol; `relocated` when the resolved
+///   logical symbol — or the moniker string itself — changed (the binding is rewritten).
+///
+/// Resolution order is deliberate. (1) The binding's stored `logical_symbol_id` is a
+/// CONTENT-DERIVED stable id — when it is still live and carries a current moniker row, that is
+/// the strongest evidence and also heals MONIKER-STRING DRIFT: rust-analyzer monikers embed the
+/// Cargo package version, so a routine version bump rewrites every string while no symbol
+/// changes; matching by string alone would mark every anchor `gone` forever. The rebind takes the
+/// row's fresh `tool_version` as new provenance (it is a re-bind under current data, not a
+/// cross-version string trust). (2) Only when the stored id is dead (the file-move case) does the
+/// recorded STRING resolve against current rows — and there the bind-time
+/// `moniker_tool_version` is deliberately NOT refreshed, so the cross-version corroboration gate
+/// in [`relocate_binding_by_moniker`] always compares against bind-time provenance (Codex P1: a
+/// refreshed "last verified" version would silently downgrade a real cross-version match to
+/// same-version).
 pub(crate) fn validate_moniker_binding(
     conn: &Connection,
     binding: &mut RepoMemoryBinding,
@@ -310,25 +351,35 @@ pub(crate) fn validate_moniker_binding(
     let Some(tool) = binding.moniker_tool.clone() else {
         return Ok("unverified".to_string());
     };
+    // (1) The stored stable logical id is live and has a current moniker row → anchor there.
+    if let Some(stored_id) = binding.logical_symbol_id
+        && crate::query::symbol::lookup_logical_by_id(conn, stored_id)?.is_some()
+        && let Some(row) = moniker_for_logical_symbol_tool(conn, stored_id, &tool)?
+    {
+        let Some(matched) = relocate_match_for_logical_symbol(conn, stored_id)? else {
+            return Ok("stale".to_string());
+        };
+        let drifted = binding.binding_id != row.moniker;
+        apply_relocate_match(binding, &matched);
+        if drifted {
+            binding.binding_id = row.moniker;
+            binding.moniker_tool_version = Some(row.tool_version);
+            binding.relocation_reason = Some(MONIKER_REFRESH_REASON.to_string());
+            return Ok("relocated".to_string());
+        }
+        return Ok("current".to_string());
+    }
+    // (2) The stored id is dead (file move) or has no current row: resolve the recorded string.
     match resolve_moniker(conn, &binding.binding_id, &tool)? {
         MonikerResolution::NoData => Ok("unverified".to_string()),
         MonikerResolution::Gone => Ok("gone".to_string()),
         MonikerResolution::Dangling | MonikerResolution::Ambiguous => Ok("stale".to_string()),
-        MonikerResolution::Unique { logical_symbol_id, tool_version } => {
+        MonikerResolution::Unique { logical_symbol_id, tool_version: _ } => {
             let moved = binding.logical_symbol_id != Some(logical_symbol_id);
             let Some(matched) = relocate_match_for_logical_symbol(conn, logical_symbol_id)? else {
                 return Ok("stale".to_string());
             };
-            binding.logical_symbol_id = matched.logical_symbol_id;
-            binding.symbol_id = Some(matched.symbol_id);
-            binding.path = Some(matched.path);
-            binding.chunk_id = matched.chunk_id;
-            binding.start_line = matched.start_line;
-            binding.end_line = matched.end_line;
-            binding.symbol_kind = matched.symbol_kind;
-            binding.signature_hash = matched.signature_hash;
-            // The binding is now verified against this version's data.
-            binding.moniker_tool_version = Some(tool_version);
+            apply_relocate_match(binding, &matched);
             if moved {
                 binding.relocation_reason = Some(MONIKER_MATCH_REASON.to_string());
                 Ok("relocated".to_string())
@@ -337,4 +388,17 @@ pub(crate) fn validate_moniker_binding(
             }
         },
     }
+}
+
+/// Rewrite a binding's location fields from a relocate match (shared by the moniker validate arms;
+/// the symbol/logical fallback in validate.rs additionally rewrites `binding_id`).
+fn apply_relocate_match(binding: &mut RepoMemoryBinding, matched: &RelocateMatch) {
+    binding.logical_symbol_id = matched.logical_symbol_id;
+    binding.symbol_id = Some(matched.symbol_id);
+    binding.path = Some(matched.path.clone());
+    binding.chunk_id = matched.chunk_id;
+    binding.start_line = matched.start_line;
+    binding.end_line = matched.end_line;
+    binding.symbol_kind = matched.symbol_kind.clone();
+    binding.signature_hash = matched.signature_hash.clone();
 }

--- a/crates/rag-rat-core/src/query/memory/resolve.rs
+++ b/crates/rag-rat-core/src/query/memory/resolve.rs
@@ -1028,6 +1028,9 @@ pub(crate) fn binding_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RepoMemor
         github_number: row.get("github_number")?,
         symbol_kind: row.get("symbol_kind")?,
         signature_hash: row.get("signature_hash")?,
+        moniker_tool: row.get("moniker_tool")?,
+        moniker_tool_version: row.get("moniker_tool_version")?,
+        relocation_reason: row.get("relocation_reason")?,
         anchor_status: row.get("anchor_status")?,
         created_at_ms: row.get("created_at_ms")?,
     })
@@ -1040,7 +1043,8 @@ pub(crate) fn attach_memory_children(
         "
         SELECT memory_id, binding_kind, binding_id, path, start_line, end_line, logical_symbol_id,
                symbol_id, chunk_id, edge_id, commit_hash, github_owner, github_repo,
-               github_number, symbol_kind, signature_hash, anchor_status, created_at_ms
+               github_number, symbol_kind, signature_hash, moniker_tool, moniker_tool_version,
+               relocation_reason, anchor_status, created_at_ms
         FROM repo_memory_bindings
         WHERE memory_id = ?1
         ORDER BY binding_kind, binding_id
@@ -1095,9 +1099,14 @@ pub(crate) fn split_active_stale(memories: Vec<RepoMemory>) -> (Vec<RepoMemory>,
     let mut direct = Vec::new();
     let mut stale = Vec::new();
     for memory in memories {
+        // The auxiliary `scip_moniker` binding never demotes a memory: it is an identity anchor
+        // for relocation (#70), not a content anchor, and it naturally lags between (opt-in)
+        // oracle runs. A real problem with the anchored code shows on the primary
+        // symbol/logical_symbol binding, which still demotes.
         if memory.status == "stale"
             || memory.bindings.iter().any(|binding| {
-                matches!(binding.anchor_status.as_str(), "stale" | "gone" | "unverified")
+                binding.binding_kind != SCIP_MONIKER_BINDING_KIND
+                    && matches!(binding.anchor_status.as_str(), "stale" | "gone" | "unverified")
             })
         {
             stale.push(memory);

--- a/crates/rag-rat-core/src/query/memory/validate.rs
+++ b/crates/rag-rat-core/src/query/memory/validate.rs
@@ -10,6 +10,7 @@ pub(crate) fn validate_binding(
         "chunk" => validate_chunk_binding(conn, binding),
         "edge" => validate_edge_binding(conn, binding),
         "call_path" => validate_call_path_binding(conn, binding),
+        "scip_moniker" => validate_moniker_binding(conn, binding),
         "path" => validate_path_binding(conn, binding),
         "dir" => validate_dir_binding(conn, binding),
         "commit" | "github" => Ok("unverified".to_string()),
@@ -78,7 +79,7 @@ pub(crate) fn validate_logical_symbol_binding(
             return Ok("relocated".to_string());
         }
     }
-    Ok("gone".to_string())
+    relocate_via_moniker_or_gone(conn, binding)
 }
 pub(crate) fn validate_symbol_binding(
     conn: &Connection,
@@ -131,6 +132,31 @@ pub(crate) fn validate_symbol_binding(
             binding.signature_hash = m.signature_hash;
             return Ok("relocated".to_string());
         }
+    }
+    relocate_via_moniker_or_gone(conn, binding)
+}
+
+/// Last-resort relocation for a symbol/logical_symbol binding whose qualified-name and
+/// name+content-hash anchors are exhausted: re-resolve the memory's recorded SCIP moniker against
+/// current oracle data (#70). A unique live match — semantic identity, robust to content edits the
+/// hash fallback can't survive — relocates with `relocation_reason = "moniker-match"`; otherwise
+/// the binding is gone.
+fn relocate_via_moniker_or_gone(
+    conn: &Connection,
+    binding: &mut RepoMemoryBinding,
+) -> anyhow::Result<String> {
+    if let Some(m) = relocate_binding_by_moniker(conn, binding)? {
+        binding.binding_id = m.binding_id;
+        binding.symbol_id = Some(m.symbol_id);
+        binding.logical_symbol_id = m.logical_symbol_id;
+        binding.path = Some(m.path);
+        binding.chunk_id = m.chunk_id;
+        binding.start_line = m.start_line;
+        binding.end_line = m.end_line;
+        binding.symbol_kind = m.symbol_kind;
+        binding.signature_hash = m.signature_hash;
+        binding.relocation_reason = Some(MONIKER_MATCH_REASON.to_string());
+        return Ok("relocated".to_string());
     }
     Ok("gone".to_string())
 }

--- a/crates/rag-rat-core/src/query/memory/validate.rs
+++ b/crates/rag-rat-core/src/query/memory/validate.rs
@@ -345,6 +345,15 @@ pub(crate) fn validate_path_binding(
     let Some(current_hash) = current_hash else {
         return Ok("gone".to_string());
     };
+    // A BARE path binding (no line span) is an AREA anchor, like a `dir` binding: the claim is
+    // "this note is about this file", not "this file's bytes are X" — so it is current while the
+    // file is indexed, never content-stale. Hashing the whole file made every commit stale every
+    // area-level note bound to a touched file, permanently (nothing refreshes the hash), which
+    // buried the real staleness signals under noise. Only a SPANNED `path:start-end` binding
+    // claims specific content and keeps the content-hash check.
+    if binding.start_line.is_none() && binding.end_line.is_none() {
+        return Ok("current".to_string());
+    }
     match source_hash_for_memory(conn, &binding.memory_id)? {
         Some(expected) if expected != current_hash => Ok("stale".to_string()),
         _ => Ok("current".to_string()),


### PR DESCRIPTION
Implements phase 3 of the SCIP oracle epic (#61). Fixes #70.

## What

- **V019 migration**: `logical_symbol_monikers` side table (STRICT) + `moniker_tool` / `moniker_tool_version` / `relocation_reason` columns on `repo_memory_bindings` (all additive).
- **Moniker pass in `oracle run`** (same transaction as the edge join): every in-corpus SCIP definition is mapped back to its logical symbol (containment, same drift gates as edge verdicts — index-vs-disk on the def document, plus the production-sha pin for tool-driven runs) and its SCIP symbol string recorded as the moniker. Authoritative per-tool clear at run start. `OracleReport` gains `monikers_written`.
- **New `scip_moniker` binding kind**: a memory created (or rebound) on a symbol whose logical symbol has a known moniker gets the anchor automatically, with tool+version provenance on the binding row.
- **Relocation fallback**: when a `symbol` / `logical_symbol` binding's qualified-name and name+content-hash anchors are exhausted, the memory's recorded moniker is re-resolved against current oracle data; a **unique live** match relocates the binding with `relocation_reason = "moniker-match"`. A match under a different current `tool_version` is lower confidence and additionally requires `symbol_kind` corroboration (the #70 risk mitigation).
- The auxiliary moniker binding never demotes a memory in evidence splitting and is excluded from `memory doctor` — it self-heals on the next `oracle run` and is never rebind-actionable; a genuinely dead symbol still surfaces via its symbol binding.

## Design deviation from the issue text (deliberate)

The issue scoped `logical_symbols.scip_moniker` (nullable column). That shape is unworkable: `rebuild_logical_symbols` rebuilds the table **wholesale on every index pass** (DELETE-all + reinsert), so a column (or an FK-cascading side row) would be wiped seconds after every oracle run. Instead the side table is keyed by the **content-derived logical-symbol stable id** with **no FK**: an unchanged symbol's reinserted row keeps its id, so its moniker survives rebuilds with no re-run; a changed symbol's row dangles harmlessly (every read joins live `logical_symbols`) and is swept by the next run's authoritative clear. cfg-gated variants share the logical symbol, hence the moniker, by construction — as the issue intended.

## Acceptance criteria

- Integration test: a memory bound to a symbol survives a file move via moniker relocation — with a **content edit**, so the existing name+content-hash fallback provably cannot catch it; `relocated`, reason `moniker-match`.
- Cross-version match gating, validation statuses (`unverified` / `gone` / `stale` / `current`), authoritative re-run clear, V019 shape — all covered in `oracle/tests.rs`.
- Real run on this repo (`rag-rat oracle run --tool rust-analyzer` against a fresh clone + index): **4,484 monikers written** alongside 34,088 edge verdicts; spot-checked rows map `query/memory/moniker/validate_moniker_binding().` ↔ `crates/rag-rat-core/src/query/memory/moniker.rs::validate_moniker_binding`.
- Rebuild/index paths untouched — no change to indexing output or wall time.

`cargo test` (all crates) green, `cargo clippy --all-targets` clean, `cargo +nightly fmt` applied. (One pre-existing formatting hunk in `cli.rs` updated to match the current nightly rustfmt, which CI's fmt job tracks.)