### PR TITLE
oracle run: close the residual mid-subprocess TOCTOU with a pre-spawn files.sha256 snapshot (#83)

### DIFF
--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -201,6 +201,12 @@ fn oracle_run(config: &Config, args: &OracleRunArgs) -> anyhow::Result<()> {
     // No pre-built index: produce the `.scip` with the tool BEFORE acquiring the write lock, so the
     // slow rust-analyzer subprocess doesn't hold the lock and starve the watcher (#82 P3). Only the
     // probe-recheck + join/write below run under the lock.
+    //
+    // Snapshot the indexed shas BEFORE spawning (#83): a cheap read-only query, taken without the
+    // write lock. The join requires every verdict's documents to still carry these shas, so a file
+    // the watcher reindexes ANYWHERE in the spawn → join window — including DURING the subprocess,
+    // which the post-exit `production_sha` snapshot cannot see — is skipped, never mis-joined.
+    let pre_spawn_sha = open_index(config)?.oracle_pre_spawn_snapshot()?;
     let scip_output = config
         .database
         .parent()
@@ -224,13 +230,15 @@ fn oracle_run(config: &Config, args: &OracleRunArgs) -> anyhow::Result<()> {
             bytes,
             production_sha,
         } => {
-            // The join's content gate revalidates against current disk bytes under the lock, and
-            // `production_sha` (the per-document disk hashes captured the instant the subprocess
-            // finished) pins the `.scip` to the content it was built against — so a file the
-            // watcher reindexes in this lock-free window is skipped, not mis-joined
-            // (#82 TOCTOU). Run only the join/write under the lock.
+            // The join's content gate revalidates against current disk bytes under the lock;
+            // `production_sha` (per-document disk hashes captured the instant the subprocess
+            // finished) pins the `.scip` to the content it was built against (#82 TOCTOU); and
+            // `pre_spawn_sha` (indexed shas captured before the spawn) extends that pin across
+            // the subprocess interior (#83) — together they cover the whole lock-free window, so
+            // a file the watcher reindexes anywhere in it is skipped, not mis-joined. Run only
+            // the join/write under the lock.
             let report = with_oracle_write_lock(config, |db| {
-                db.run_oracle(tool, &version, &bytes, Some(&production_sha))
+                db.run_oracle(tool, &version, &bytes, Some(&production_sha), Some(&pre_spawn_sha))
             })?;
             print_json(&serde_json::json!({
                 "outcome": "completed",

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -200,13 +200,32 @@ fn oracle_run(config: &Config, args: &OracleRunArgs) -> anyhow::Result<()> {
 
     // No pre-built index: produce the `.scip` with the tool BEFORE acquiring the write lock, so the
     // slow rust-analyzer subprocess doesn't hold the lock and starve the watcher (#82 P3). Only the
-    // probe-recheck + join/write below run under the lock.
+    // brief pre-spawn snapshot + the join/write run under the lock.
     //
-    // Snapshot the indexed shas BEFORE spawning (#83): a cheap read-only query, taken without the
-    // write lock. The join requires every verdict's documents to still carry these shas, so a file
-    // the watcher reindexes ANYWHERE in the spawn → join window — including DURING the subprocess,
-    // which the post-exit `production_sha` snapshot cannot see — is skipped, never mis-joined.
-    let pre_spawn_sha = open_index(config)?.oracle_pre_spawn_snapshot()?;
+    // Probe the tool FIRST so a missing/unrunnable tool yields the documented `Blocked` + exit-0
+    // UX before anything touches the index (#88 review): opening the index is not guaranteed
+    // side-effect free (a stale graph version triggers an edge reindex), and a Blocked probe
+    // must not be preempted by an index-open failure.
+    if let rag_rat_core::index::oracle::ToolAvailability::Blocked { tool, program, hint } =
+        rag_rat_core::index::oracle::probe_oracle_tool(tool)
+    {
+        eprintln!("oracle: {hint}");
+        return print_json(&rag_rat_core::index::oracle::OracleRunOutcome::Blocked {
+            tool,
+            program,
+            hint,
+        });
+    }
+
+    // Snapshot the indexed shas BEFORE spawning (#83). The query itself is a cheap read, but
+    // `open_index` may upgrade a stale graph index (a WRITE — `ensure_graph_index_current`
+    // rebuilds `edges`), so the snapshot takes the write lock briefly and releases it before the
+    // subprocess spawns (#88 review). The join later requires every verdict's documents to still
+    // carry these shas, so a file the watcher reindexes ANYWHERE in the spawn → join window —
+    // including DURING the subprocess, which the post-exit `production_sha` snapshot cannot see —
+    // is skipped, never mis-joined. A reindex slipping in between this lock release and the spawn
+    // is detected by the same gate.
+    let pre_spawn_sha = with_oracle_write_lock(config, |db| db.oracle_pre_spawn_snapshot())?;
     let scip_output = config
         .database
         .parent()

--- a/crates/rag-rat-core/src/eval.rs
+++ b/crates/rag-rat-core/src/eval.rs
@@ -254,7 +254,7 @@ fn run_oracle_eval(
     // Eval consumes a pre-built fixture `.scip` (no tool subprocess), so there is no production
     // snapshot — `None` leaves only the index-vs-disk content gate, as on the `--scip` CLI path.
     let report =
-        db.run_oracle(OracleTool::RustAnalyzer, EVAL_ORACLE_TOOL_VERSION, &scip_bytes, None)?;
+        db.run_oracle(OracleTool::RustAnalyzer, EVAL_ORACLE_TOOL_VERSION, &scip_bytes, None, None)?;
     // Both recall sides come from the run, occurrence-counted over the call population.
     let recall_calls =
         RecallCalls { covered: report.covered_calls, oracle_only: report.oracle_only_calls };

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -48,6 +48,11 @@ pub(crate) use store::{EdgeOracleComparison, EdgeOracleVerdict};
 /// `production_sha` is the per-document disk-hash snapshot captured when a TOOL produced this
 /// `.scip` (`None` for a pre-built `--scip`). When present it arms the scip-vs-disk content gate
 /// (#82 TOCTOU); see [`run::OracleRunInput::production_sha`].
+///
+/// `pre_spawn_sha` is the indexed `(path -> files.sha256)` snapshot taken BEFORE the tool
+/// subprocess was spawned (`None` for a pre-built `--scip`). It arms the pre-spawn gate (#83),
+/// which covers the subprocess INTERIOR the post-exit `production_sha` cannot; see
+/// [`run::OracleRunInput::pre_spawn_sha`].
 // The args mirror `OracleRunInput`'s fields one-to-one (this is the public thin adapter to it), so
 // a params struct would only re-wrap what callers already pass positionally.
 #[allow(clippy::too_many_arguments)]
@@ -60,6 +65,7 @@ pub fn run_oracle(
     scip_bytes: &[u8],
     checkout_root: &Path,
     production_sha: Option<&HashMap<String, String>>,
+    pre_spawn_sha: Option<&HashMap<String, String>>,
 ) -> anyhow::Result<OracleReport> {
     run::run(conn, &OracleRunInput {
         tool,
@@ -69,7 +75,19 @@ pub fn run_oracle(
         scip_bytes,
         checkout_root,
         production_sha,
+        pre_spawn_sha,
     })
+}
+
+/// The indexed `(path -> files.sha256)` map for the active checkout — the pre-spawn snapshot
+/// callers take BEFORE spawning the oracle tool (#83). Cheap (reads indexed shas; hashes
+/// nothing), and read-only, so the CLI takes it before acquiring the index write lock.
+pub fn pre_spawn_snapshot(
+    conn: &Connection,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<HashMap<String, String>> {
+    store::indexed_file_shas_in_scope(conn, commit_sha, worktree_id)
 }
 
 /// Heuristic-vs-oracle eval metrics for a tool/version, diffing `edge_oracle` against `edges`,
@@ -127,10 +145,12 @@ pub enum ScipProduction {
     /// tool version (content-addressed staleness key). `production_sha` is `relative_path -> hex
     /// sha256` of each document's disk bytes read the instant the subprocess finished — the
     /// scip-vs-disk content pin the join uses to reject a document the watcher reindexed in the
-    /// lock-free window before the join (#82 TOCTOU). It is a best-effort snapshot taken as close
-    /// to production as the API allows; a file unreadable at snapshot time is simply absent
-    /// (its candidate then fails the `Some(_) == disk` gate and is skipped, the safe
-    /// direction).
+    /// lock-free window AFTER production (#82 TOCTOU). A file unreadable at snapshot time is
+    /// simply absent (its candidate then fails the `Some(_) == disk` gate and is skipped, the
+    /// safe direction). The window INSIDE the subprocess — an edit between the tool reading a
+    /// source and this post-exit snapshot — is covered by the separate pre-spawn indexed-sha
+    /// snapshot the caller takes before spawning (#83); the two gates compose to span the whole
+    /// spawn → join window.
     Produced { version: String, bytes: Vec<u8>, production_sha: HashMap<String, String> },
     /// The tool isn't runnable / can't produce SCIP — the `oracle run` Blocked UX.
     Blocked { tool: String, program: String, hint: String },
@@ -217,6 +237,10 @@ pub fn run_oracle_with_tool(
     commit_sha: &str,
     worktree_id: &str,
 ) -> anyhow::Result<OracleRunOutcome> {
+    // Snapshot the indexed shas BEFORE spawning the tool — the pre-spawn gate (#83) needs the
+    // state from before the subprocess could observe any source, so a mid-subprocess reindex is
+    // detectable at the join.
+    let pre_spawn_sha = pre_spawn_snapshot(conn, commit_sha, worktree_id)?;
     match produce_scip_with_tool(tool, checkout_root, scip_output)? {
         ScipProduction::Blocked { tool, program, hint } =>
             Ok(OracleRunOutcome::Blocked { tool, program, hint }),
@@ -230,6 +254,7 @@ pub fn run_oracle_with_tool(
                 &bytes,
                 checkout_root,
                 Some(&production_sha),
+                Some(&pre_spawn_sha),
             )?;
             Ok(OracleRunOutcome::Completed {
                 tool: tool.as_db_str().to_string(),

--- a/crates/rag-rat-core/src/index/oracle/run.rs
+++ b/crates/rag-rat-core/src/index/oracle/run.rs
@@ -128,6 +128,11 @@ pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Resu
     // A non-call edge kind (`references_type` / `uses_macro` / …) marks `matched_occurrences` but
     // NOT this set, so its confirmation can't inflate recall.
     let mut covered_call_occurrences: HashSet<(String, usize, usize)> = HashSet::new();
+    // Documents a drift gate fired for (call-site OR definition side). The recall pass must
+    // exclude occurrences in (or resolving into) these: a skipped-as-drifted candidate's
+    // occurrence is not a heuristic miss — the oracle deliberately declined to judge it — so
+    // counting it as `oracle_only_calls` would falsely lower recall (#88 review).
+    let mut drifted_paths: HashSet<String> = HashSet::new();
 
     // Resolve a SCIP definition `(path, byte-range)` back to one of OUR symbols, scoped to the
     // active `(commit_sha, worktree_id)` checkout (via `symbol_spans_for_path`). Used both by the
@@ -164,6 +169,7 @@ pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Resu
         let disk = disk_sha.get(&candidate.source_path).map(String::as_str);
         if disk != Some(&candidate.file_sha) {
             report.skipped_drifted += 1;
+            drifted_paths.insert(candidate.source_path.clone());
             continue;
         }
 
@@ -179,6 +185,7 @@ pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Resu
             && production_sha.get(&candidate.source_path).map(String::as_str) != disk
         {
             report.skipped_drifted += 1;
+            drifted_paths.insert(candidate.source_path.clone());
             continue;
         }
 
@@ -193,6 +200,7 @@ pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Resu
                 != Some(candidate.file_sha.as_str())
         {
             report.skipped_drifted += 1;
+            drifted_paths.insert(candidate.source_path.clone());
             continue;
         }
 
@@ -227,6 +235,7 @@ pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Resu
                 != disk_sha.get(&def.path).map(String::as_str)
         {
             report.skipped_drifted += 1;
+            drifted_paths.insert(def.path.clone());
             continue;
         }
 
@@ -241,6 +250,7 @@ pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Resu
                 != indexed_shas.get(&def.path).map(String::as_str)
         {
             report.skipped_drifted += 1;
+            drifted_paths.insert(def.path.clone());
             continue;
         }
 
@@ -339,8 +349,13 @@ pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Resu
     // can cover a call from an unindexed source file, so those occurrences are out of scope,
     // not misses.
     let indexed_paths = store::indexed_paths_in_scope(conn, commit_sha, worktree_id)?;
-    report.oracle_only_calls =
-        count_uncovered_calls(&index, &matched_occurrences, &indexed_paths, &resolve_symbol);
+    report.oracle_only_calls = count_uncovered_calls(
+        &index,
+        &matched_occurrences,
+        &indexed_paths,
+        &drifted_paths,
+        &resolve_symbol,
+    );
 
     report.status = "Completed".to_string();
     store::record_oracle_run(
@@ -402,13 +417,17 @@ fn count_uncovered_calls(
     index: &ScipIndex,
     matched: &HashSet<(String, usize, usize)>,
     indexed_paths: &HashSet<String>,
+    drifted_paths: &HashSet<String>,
     resolve_definition: &dyn Fn(&str, usize, usize) -> Option<i64>,
 ) -> u64 {
     let mut count = 0u64;
     for (path, occurrences) in &index.occurrences_by_path {
         // The call site must live in a file rag-rat indexed in this checkout; a call from an
         // unindexed source is unreachable by any edge candidate, so it is not a recall gap.
-        if !indexed_paths.contains(path) {
+        // A DRIFTED call-site document is excluded too (#88 review): its candidates were
+        // deliberately skipped as untrusted, so its uncovered occurrences are abstentions, not
+        // heuristic misses.
+        if !indexed_paths.contains(path) || drifted_paths.contains(path) {
             continue;
         }
         for occ in occurrences {
@@ -422,6 +441,12 @@ fn count_uncovered_calls(
             let Some(def) = index.definitions.get(&occ.symbol) else {
                 continue;
             };
+            // A def in a DRIFTED document is excluded for the same reason as a drifted call
+            // site: the byte-converted def range can't be trusted, and the candidates that
+            // depended on it were skipped, not missed.
+            if drifted_paths.contains(&def.path) {
+                continue;
+            }
             if resolve_definition(&def.path, def.start_byte, def.end_byte).is_none() {
                 continue;
             }

--- a/crates/rag-rat-core/src/index/oracle/run.rs
+++ b/crates/rag-rat-core/src/index/oracle/run.rs
@@ -41,6 +41,18 @@ pub(crate) struct OracleRunInput<'a> {
     /// == file_sha` (both the new content) still passes the index-vs-disk gate. See
     /// [`super::ScipProduction::Produced`].
     pub(crate) production_sha: Option<&'a HashMap<String, String>>,
+    /// The indexed `(path -> files.sha256)` snapshot taken **before the tool subprocess was
+    /// spawned** (#83); `None` for a pre-built `--scip` (no spawn). The post-exit
+    /// `production_sha` gate cannot see INSIDE the subprocess: the tool reads each source near
+    /// the start of a run that can take tens of seconds, so a file edited mid-run and
+    /// reindexed before the join leaves `.scip` describing the OLD content while
+    /// `files.sha256`, the disk bytes, and `production_sha` are all the NEW content — every
+    /// post-exit gate passes and a stale verdict persists. Requiring the join-time indexed sha
+    /// to ALSO equal this pre-spawn snapshot asserts the watcher reindexed nothing across the
+    /// ENTIRE window (spawn → join), for both the call-site and definition documents. Residual
+    /// ABA (an edit reverted to byte-identical content) is acceptable — the verdict is then
+    /// correct anyway.
+    pub(crate) pre_spawn_sha: Option<&'a HashMap<String, String>>,
 }
 
 /// Run the oracle join over all current edge candidates and persist verdicts + a run row.
@@ -95,6 +107,12 @@ pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Resu
         .iter()
         .filter_map(|(path, bytes)| bytes.as_ref().map(|b| (path.clone(), hex_sha256(b))))
         .collect();
+
+    // The join-time indexed `(path -> files.sha256)` map for the active checkout. Used by the
+    // pre-spawn gate's DEFINITION-side check (#83) and the moniker pass below (the call-site side
+    // compares against `candidate.file_sha`, which already IS the join-time indexed sha).
+    let indexed_shas =
+        store::indexed_file_shas_in_scope(conn, input.commit_sha, input.worktree_id)?;
 
     // Cache symbol spans per source path (resolve_symbol is called per candidate). RefCell so the
     // resolver closure stays `Fn` (the join expects `&dyn Fn`) while lazily populating the cache.
@@ -164,6 +182,20 @@ pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Resu
             continue;
         }
 
+        // Pre-spawn gate, CALL-SITE side (#83): the two gates above only prove the edge, the
+        // disk, and the post-exit production snapshot agree — all three can be the NEW content
+        // when a file was edited DURING the subprocess and the watcher reindexed it before the
+        // join, while the `.scip` still describes the old bytes. Requiring the join-time indexed
+        // sha (`candidate.file_sha`) to equal the snapshot taken BEFORE the spawn asserts no
+        // reindex happened across the entire spawn → join window.
+        if let Some(pre_spawn) = input.pre_spawn_sha
+            && pre_spawn.get(&candidate.source_path).map(String::as_str)
+                != Some(candidate.file_sha.as_str())
+        {
+            report.skipped_drifted += 1;
+            continue;
+        }
+
         let verdict = join::classify_edge(&JoinInput {
             callee_start_byte: candidate.callee_start_byte,
             callee_end_byte: candidate.callee_end_byte,
@@ -193,6 +225,20 @@ pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Resu
             && let Some(def) = index.definitions.get(&verdict.scip_symbol)
             && production_sha.get(&def.path).map(String::as_str)
                 != disk_sha.get(&def.path).map(String::as_str)
+        {
+            report.skipped_drifted += 1;
+            continue;
+        }
+
+        // Pre-spawn gate, DEFINITION side (#83): the same mid-subprocess hole applies to the
+        // resolved symbol's defining document — a def file edited during the subprocess and
+        // reindexed before the join resolves the byte-converted def range against the wrong
+        // symbol while every post-exit gate passes. The join-time indexed sha of the def file
+        // must equal the pre-spawn snapshot.
+        if let Some(pre_spawn) = input.pre_spawn_sha
+            && let Some(def) = index.definitions.get(&verdict.scip_symbol)
+            && pre_spawn.get(&def.path).map(String::as_str)
+                != indexed_shas.get(&def.path).map(String::as_str)
         {
             report.skipped_drifted += 1;
             continue;
@@ -239,8 +285,6 @@ pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Resu
     // arbitrary winner changed between runs. Pick the best moniker per logical symbol instead:
     // shortest, then lexicographic. SCIP member monikers extend the parent's descriptor chain
     // (`…Struct#field.` vs `…Struct#`), so shortest selects the symbol's own moniker.
-    let indexed_shas =
-        store::indexed_file_shas_in_scope(conn, input.commit_sha, input.worktree_id)?;
     let mut best_monikers: HashMap<i64, &str> = HashMap::new();
     for (scip_symbol, def) in &index.definitions {
         let disk = disk_sha.get(&def.path).map(String::as_str);
@@ -249,6 +293,15 @@ pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Resu
         }
         if let Some(production_sha) = input.production_sha
             && production_sha.get(&def.path).map(String::as_str) != disk
+        {
+            continue;
+        }
+        // Pre-spawn gate (#83): same mid-subprocess discipline as the verdict join — a def file
+        // reindexed during the subprocess maps the moniker to the wrong symbol while every
+        // post-exit gate passes. (`disk` equals the join-time indexed sha here, per the first
+        // check above.)
+        if let Some(pre_spawn) = input.pre_spawn_sha
+            && pre_spawn.get(&def.path).map(String::as_str) != disk
         {
             continue;
         }

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -3321,6 +3321,7 @@ fn pre_spawn_gate_passes_when_nothing_reindexed() {
     });
     assert!(verdict.is_some(), "matching pre-spawn snapshot must not block the verdict");
     assert_eq!(report.skipped_drifted, 0);
+    assert_eq!(report.oracle_only_calls, 0, "the covered call is no recall gap");
 }
 
 /// CALL-SITE document edited during the subprocess: index/disk/production all carry the NEW
@@ -3338,6 +3339,9 @@ fn pre_spawn_gate_skips_call_site_reindexed_mid_subprocess() {
     assert!(verdict.is_none(), "mid-subprocess call-site reindex must skip the verdict");
     assert_eq!(report.skipped_drifted, 1);
     assert_eq!(report.rows_written, 0);
+    // A skipped-as-drifted candidate is an ABSTENTION, not a heuristic miss: its occurrence must
+    // not count as a recall gap (#88 review).
+    assert_eq!(report.oracle_only_calls, 0, "drifted call-site doc is excluded from recall");
 }
 
 /// DEFINITION document edited during the subprocess: the call-site gate passes, but the resolved
@@ -3355,4 +3359,7 @@ fn pre_spawn_gate_skips_definition_reindexed_mid_subprocess() {
     assert!(verdict.is_none(), "mid-subprocess def reindex must skip the verdict");
     assert_eq!(report.skipped_drifted, 1);
     assert_eq!(report.rows_written, 0);
+    // The call site is clean but its DEF document drifted: the occurrence resolving into it must
+    // not count as a recall gap either (#88 review).
+    assert_eq!(report.oracle_only_calls, 0, "drifted def doc is excluded from recall");
 }

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -354,7 +354,7 @@ fn def_inside_corpus_upgrades_unresolved_edge() {
     });
     let bytes = full.write_to_bytes().unwrap();
 
-    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
 
     let (kind, resolved, _scip) = h.verdict(edge).expect("verdict written");
     assert_eq!(kind, OracleResolutionKind::Upgrade.as_db_str());
@@ -376,7 +376,7 @@ fn def_outside_corpus_resolves_external() {
         occurrence(0, 14, 19, external, SymbolRole::UnspecifiedSymbolRole as i32),
     ]);
 
-    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
 
     let (kind, resolved, scip) = h.verdict(edge).expect("verdict written");
     assert_eq!(kind, OracleResolutionKind::ResolvedExternal.as_db_str());
@@ -450,7 +450,7 @@ fn non_ascii_identifier_resolves_under_both_encodings() {
         });
         let bytes = index.write_to_bytes().unwrap();
 
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
 
         let (kind, resolved, _) =
             h.verdict(edge).unwrap_or_else(|| panic!("verdict written for encoding {encoding:?}"));
@@ -475,7 +475,7 @@ fn local_symbols_are_skipped() {
         occurrence(0, 14, 20, "local 0", SymbolRole::UnspecifiedSymbolRole as i32),
     ]);
 
-    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
 
     assert!(h.verdict(edge).is_none(), "local symbol must not produce a verdict");
 }
@@ -520,7 +520,7 @@ fn exact_edge_contradiction_recorded_not_applied() {
     });
     let bytes = index.write_to_bytes().unwrap();
 
-    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
 
     let (kind, resolved, _) = h.verdict(edge).expect("verdict written");
     assert_eq!(kind, OracleResolutionKind::Contradict.as_db_str());
@@ -565,7 +565,7 @@ fn exact_edge_agreement_recorded_as_confirm() {
     let bytes = index.write_to_bytes().unwrap();
 
     let report =
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
 
     let (kind, resolved, _) = h.verdict(edge).expect("verdict written");
     assert_eq!(kind, OracleResolutionKind::Confirm.as_db_str());
@@ -969,7 +969,7 @@ fn run_with_empty_scip_completes_with_no_verdicts() {
 
     let empty = Index::default().write_to_bytes().unwrap();
     let report =
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &empty, h.root(), None).unwrap();
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &empty, h.root(), None, None).unwrap();
 
     assert_eq!(report.edges_examined, 1);
     assert_eq!(report.no_occurrence, 1, "no document → no occurrence bucket");
@@ -1002,7 +1002,7 @@ fn candidate_outside_any_occurrence_counts_no_occurrence() {
     ]);
 
     let report =
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
     assert_eq!(report.edges_examined, 1);
     assert_eq!(report.no_occurrence, 1);
     assert_eq!(report.rows_written, 0);
@@ -1045,7 +1045,7 @@ fn run_aggregates_counts_and_recall_gap() {
     let bytes = index.write_to_bytes().unwrap();
 
     let report =
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
     assert_eq!(report.edges_examined, 1);
     assert_eq!(report.upgraded, 1);
     assert_eq!(report.rows_written, 1);
@@ -1086,7 +1086,7 @@ fn rerun_clears_stale_verdict_for_dropped_edge() {
         ..Default::default()
     });
     let bytes = index.write_to_bytes().unwrap();
-    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
     assert_eq!(
         h.verdict(edge).map(|(k, _, _)| k).as_deref(),
         Some("upgrade"),
@@ -1105,7 +1105,7 @@ fn rerun_clears_stale_verdict_for_dropped_edge() {
                 SymbolRole::UnspecifiedSymbolRole as i32,
             ),
         ]);
-    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &empty_doc, h.root(), None).unwrap();
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &empty_doc, h.root(), None, None).unwrap();
 
     assert!(h.verdict(edge).is_none(), "the dropped edge's stale verdict was cleared on rerun");
     let total: i64 =
@@ -1154,7 +1154,7 @@ fn recall_gap_counts_only_call_like_occurrences() {
     };
     let bytes = index.write_to_bytes().unwrap();
     let report =
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
 
     // Only the one uncovered callable reference is the recall gap; the import + type ref are not.
     assert_eq!(report.oracle_only_calls, 1, "only the call-like uncovered reference counts");
@@ -1722,7 +1722,7 @@ fn recall_gap_excludes_definitions_in_unindexed_files() {
             ..Default::default()
         });
         let bytes = index.write_to_bytes().unwrap();
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None)
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None)
             .unwrap()
             .oracle_only_calls
     };
@@ -1781,7 +1781,7 @@ fn recall_gap_excludes_occurrences_in_unindexed_source_files() {
             ..Default::default()
         });
         let bytes = index.write_to_bytes().unwrap();
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None)
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None)
             .unwrap()
             .oracle_only_calls
     };
@@ -1888,7 +1888,7 @@ fn exact_in_corpus_edge_contradicted_by_external_scip_resolution() {
     ]);
 
     let report =
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
 
     let (kind, resolved, scip) = h.verdict(edge).expect("verdict written");
     assert_eq!(
@@ -1937,7 +1937,7 @@ fn name_only_edge_with_external_scip_stays_resolved_external() {
     ]);
 
     let report =
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
 
     let (kind, _, _) = h.verdict(edge).expect("verdict written");
     assert_eq!(kind, OracleResolutionKind::ResolvedExternal.as_db_str());
@@ -1986,7 +1986,7 @@ fn scip_definition_outside_indexed_corpus_resolves_external() {
     let bytes = index.write_to_bytes().unwrap();
 
     let report =
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
     let (kind, resolved, _) = h.verdict(edge).expect("verdict written");
     assert_eq!(kind, OracleResolutionKind::ResolvedExternal.as_db_str());
     assert_eq!(resolved, None, "def maps to no indexed symbol → external");
@@ -2010,7 +2010,7 @@ fn reference_without_definition_or_package_yields_no_verdict() {
     ]);
 
     let report =
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
     assert!(h.verdict(edge).is_none(), "no definition + no package → no verdict");
     assert_eq!(report.rows_written, 0);
     assert_eq!(report.no_occurrence, 1, "dropped into the no-actionable bucket");
@@ -2053,7 +2053,7 @@ fn recall_gap_excludes_field_const_term_reads() {
             ..Default::default()
         };
         let bytes = index.write_to_bytes().unwrap();
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None)
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None)
             .unwrap()
             .oracle_only_calls
     };
@@ -2108,7 +2108,7 @@ fn covered_side_ignores_references_type_confirmation() {
     let bytes = index.write_to_bytes().unwrap();
 
     let report =
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
     // BOTH edges got verdicts (both carry callee ranges and join)…
     assert!(h.verdict(call_edge).is_some(), "call edge verdicted");
     assert!(h.verdict(type_edge).is_some(), "type-ref edge verdicted");
@@ -2183,7 +2183,8 @@ fn drifted_file_sha_is_skipped_not_verdicted() {
         let _ = target_sym;
         let bytes = index.write_to_bytes().unwrap();
         let report =
-            run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+            run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None)
+                .unwrap();
         (h.verdict(edge), report.skipped_drifted, report.rows_written)
     };
 
@@ -2290,6 +2291,7 @@ fn stale_production_snapshot_is_skipped_not_verdicted() {
             &bytes,
             h.root(),
             Some(&production),
+            None,
         )
         .unwrap();
         (h.verdict(edge), report.skipped_drifted, report.rows_written)
@@ -2396,7 +2398,7 @@ fn deleted_file_occurrences_do_not_inflate_gap() {
             ..Default::default()
         });
         let bytes = index.write_to_bytes().unwrap();
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None)
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None)
             .unwrap()
             .oracle_only_calls
     };
@@ -2830,7 +2832,7 @@ fn oracle_run_writes_monikers_for_in_corpus_defs() {
         )]),
     ]);
     let report =
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
 
     assert_eq!(report.monikers_written, 1, "only the in-corpus def writes a moniker");
     let (moniker, tool, tool_version) = h.moniker(1001).expect("moniker row written");
@@ -2859,12 +2861,12 @@ fn oracle_rerun_clears_prior_monikers_for_tool() {
         TARGET_MONIKER,
         SymbolRole::Definition as i32,
     )])]);
-    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
     assert!(h.moniker(1001).is_some());
 
     // Second run: a `.scip` with no definitions at all.
     let empty = scip_bytes_docs(vec![("defs.rs", vec![])]);
-    run_oracle(&h.conn, TOOL, "v2", COMMIT, WORKTREE, &empty, h.root(), None).unwrap();
+    run_oracle(&h.conn, TOOL, "v2", COMMIT, WORKTREE, &empty, h.root(), None, None).unwrap();
     assert!(h.moniker(1001).is_none(), "authoritative clear removed the stale moniker");
 }
 
@@ -2925,7 +2927,7 @@ fn memory_survives_file_move_via_moniker_relocation() {
         TARGET_MONIKER,
         SymbolRole::Definition as i32,
     )])]);
-    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
 
     let memory_id = create_target_memory(&h, sym);
 
@@ -2938,7 +2940,7 @@ fn memory_survives_file_move_via_moniker_relocation() {
         TARGET_MONIKER,
         SymbolRole::Definition as i32,
     )])]);
-    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
 
     let report = validate_memories(&h.conn).unwrap();
     assert!(report.relocated >= 1, "expected a relocation, got {report:?}");
@@ -2973,7 +2975,7 @@ fn cross_version_moniker_match_requires_kind_corroboration() {
             TARGET_MONIKER,
             SymbolRole::Definition as i32,
         )])]);
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
         let memory_id = create_target_memory(&h, sym);
 
         move_target_with_edit(&h, defs, new_kind);
@@ -2985,7 +2987,8 @@ fn cross_version_moniker_match_requires_kind_corroboration() {
             TARGET_MONIKER,
             SymbolRole::Definition as i32,
         )])]);
-        run_oracle(&h.conn, TOOL, "v-newer", COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+        run_oracle(&h.conn, TOOL, "v-newer", COMMIT, WORKTREE, &bytes, h.root(), None, None)
+            .unwrap();
 
         validate_memories(&h.conn).unwrap();
         let memory = memory_by_id(&h.conn, &memory_id).unwrap().unwrap();
@@ -3015,7 +3018,7 @@ fn moniker_binding_validation_statuses() {
         TARGET_MONIKER,
         SymbolRole::Definition as i32,
     )])]);
-    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
     let memory_id = create_target_memory(&h, sym);
 
     let moniker_status = |h: &Harness| -> String {
@@ -3090,7 +3093,7 @@ fn moniker_for_symbol_with_member_defs_is_the_symbols_own() {
         occurrence(0, 7, 13, struct_moniker, SymbolRole::Definition as i32),
     ])]);
     let report =
-        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
 
     assert_eq!(report.monikers_written, 1, "one row per logical symbol, not per def");
     let (moniker, ..) = h.moniker(3003).expect("moniker row written");
@@ -3116,7 +3119,7 @@ fn moniker_string_drift_rebinds_via_live_logical_symbol_then_survives_move() {
         TARGET_MONIKER,
         SymbolRole::Definition as i32,
     )])]);
-    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
     let memory_id = create_target_memory(&h, sym);
 
     // Crate version bump: same symbol, same location, NEW moniker string + tool version.
@@ -3128,7 +3131,7 @@ fn moniker_string_drift_rebinds_via_live_logical_symbol_then_survives_move() {
         bumped_moniker,
         SymbolRole::Definition as i32,
     )])]);
-    run_oracle(&h.conn, TOOL, "v-bumped", COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+    run_oracle(&h.conn, TOOL, "v-bumped", COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
 
     validate_memories(&h.conn).unwrap();
     let memory = memory_by_id(&h.conn, &memory_id).unwrap().unwrap();
@@ -3148,7 +3151,7 @@ fn moniker_string_drift_rebinds_via_live_logical_symbol_then_survives_move() {
         bumped_moniker,
         SymbolRole::Definition as i32,
     )])]);
-    run_oracle(&h.conn, TOOL, "v-bumped", COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+    run_oracle(&h.conn, TOOL, "v-bumped", COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
     validate_memories(&h.conn).unwrap();
     let memory = memory_by_id(&h.conn, &memory_id).unwrap().unwrap();
     let symbol_binding =
@@ -3176,7 +3179,7 @@ fn string_resolution_preserves_bind_time_tool_version() {
         TARGET_MONIKER,
         SymbolRole::Definition as i32,
     )])]);
-    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+    run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
     let memory_id = create_target_memory(&h, sym);
 
     // Move with the SAME moniker string but a NEWER tool version: the stored logical id is dead,
@@ -3189,7 +3192,7 @@ fn string_resolution_preserves_bind_time_tool_version() {
         TARGET_MONIKER,
         SymbolRole::Definition as i32,
     )])]);
-    run_oracle(&h.conn, TOOL, "v-newer", COMMIT, WORKTREE, &bytes, h.root(), None).unwrap();
+    run_oracle(&h.conn, TOOL, "v-newer", COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
     validate_memories(&h.conn).unwrap();
 
     let memory = memory_by_id(&h.conn, &memory_id).unwrap().unwrap();
@@ -3253,4 +3256,103 @@ fn bare_path_binding_survives_file_edit_spanned_goes_stale() {
     validate_memories(&h.conn).unwrap();
     assert_eq!(status(&bare), "gone");
     assert_eq!(status(&spanned), "gone");
+}
+
+// ---------------------------------------------------------------------------
+// Pre-spawn gate (#83): the mid-subprocess TOCTOU the post-exit snapshot can't see.
+// ---------------------------------------------------------------------------
+
+/// Build the standard caller/defs corpus + scip, then run the oracle with explicit
+/// production/pre-spawn maps. Returns (verdict for the edge, report, defs logical id).
+fn run_with_pins(
+    pre_spawn: impl Fn(&str, &str) -> std::collections::HashMap<String, String>,
+) -> (Option<(String, Option<i64>, String)>, super::OracleReport) {
+    let h = Harness::new();
+    let caller_text = "fn caller() { target(); }\n";
+    let defs_text = "fn target() {}\n";
+    let caller = h.add_file("caller.rs", caller_text);
+    let defs = h.add_file("defs.rs", defs_text);
+    let sym = h.add_symbol_qualified(defs, "target", "defs.rs::target", "function", 0, 14);
+    h.add_logical_symbol(1001, "defs.rs", "target", "defs.rs::target", sym);
+    let edge = h.add_edge(caller, "target", 14, 20, "NameOnly", None);
+
+    let bytes = scip_bytes_docs(vec![
+        ("caller.rs", vec![occurrence(0, 14, 20, TARGET_MONIKER, 0)]),
+        ("defs.rs", vec![occurrence(0, 3, 9, TARGET_MONIKER, SymbolRole::Definition as i32)]),
+    ]);
+    // The post-exit production snapshot agrees with disk (and disk agrees with the index): every
+    // #82 gate passes. Only the PRE-SPAWN snapshot distinguishes the mid-subprocess scenarios.
+    let caller_sha = sha256_hex(caller_text.as_bytes());
+    let defs_sha = sha256_hex(defs_text.as_bytes());
+    let production: std::collections::HashMap<String, String> =
+        [("caller.rs".to_string(), caller_sha.clone()), ("defs.rs".to_string(), defs_sha.clone())]
+            .into();
+    let pre = pre_spawn(&caller_sha, &defs_sha);
+    let report = run_oracle(
+        &h.conn,
+        TOOL,
+        VERSION,
+        COMMIT,
+        WORKTREE,
+        &bytes,
+        h.root(),
+        Some(&production),
+        Some(&pre),
+    )
+    .unwrap();
+    let moniker_written = h.moniker(1001).is_some();
+    assert_eq!(
+        moniker_written,
+        pre.get("defs.rs").map(String::as_str) == Some(defs_sha.as_str()),
+        "moniker write must follow the def document's pre-spawn gate"
+    );
+    (h.verdict(edge), report)
+}
+
+/// Control: a pre-spawn snapshot matching the indexed shas changes nothing — the verdict lands.
+#[test]
+fn pre_spawn_gate_passes_when_nothing_reindexed() {
+    let (verdict, report) = run_with_pins(|caller_sha, defs_sha| {
+        [
+            ("caller.rs".to_string(), caller_sha.to_string()),
+            ("defs.rs".to_string(), defs_sha.to_string()),
+        ]
+        .into()
+    });
+    assert!(verdict.is_some(), "matching pre-spawn snapshot must not block the verdict");
+    assert_eq!(report.skipped_drifted, 0);
+}
+
+/// CALL-SITE document edited during the subprocess: index/disk/production all carry the NEW
+/// content (every #82 gate passes), but the pre-spawn snapshot still has the OLD sha — the
+/// `.scip` was built from bytes nobody can verify, so the candidate is skipped, never verdicted.
+#[test]
+fn pre_spawn_gate_skips_call_site_reindexed_mid_subprocess() {
+    let (verdict, report) = run_with_pins(|_caller_sha, defs_sha| {
+        [
+            ("caller.rs".to_string(), "pre-spawn-old-sha".to_string()),
+            ("defs.rs".to_string(), defs_sha.to_string()),
+        ]
+        .into()
+    });
+    assert!(verdict.is_none(), "mid-subprocess call-site reindex must skip the verdict");
+    assert_eq!(report.skipped_drifted, 1);
+    assert_eq!(report.rows_written, 0);
+}
+
+/// DEFINITION document edited during the subprocess: the call-site gate passes, but the resolved
+/// symbol came from converting the def occurrence against bytes the pre-spawn snapshot can't
+/// confirm — the verdict (and the moniker, asserted in the helper) is skipped.
+#[test]
+fn pre_spawn_gate_skips_definition_reindexed_mid_subprocess() {
+    let (verdict, report) = run_with_pins(|caller_sha, _defs_sha| {
+        [
+            ("caller.rs".to_string(), caller_sha.to_string()),
+            ("defs.rs".to_string(), "pre-spawn-old-sha".to_string()),
+        ]
+        .into()
+    });
+    assert!(verdict.is_none(), "mid-subprocess def reindex must skip the verdict");
+    assert_eq!(report.skipped_drifted, 1);
+    assert_eq!(report.rows_written, 0);
 }

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -11,12 +11,16 @@ impl IndexDatabase {
     /// `production_sha` is the per-document disk-hash snapshot a tool-driven run captured the
     /// instant its `.scip` was produced (`Some`), arming the scip-vs-disk content gate (#82
     /// TOCTOU); a pre-built `--scip` has no production moment and passes `None`.
+    /// `pre_spawn_sha` is the indexed-sha snapshot taken before the tool subprocess was spawned
+    /// (see [`Self::oracle_pre_spawn_snapshot`]), arming the pre-spawn gate that covers the
+    /// subprocess interior (#83); a pre-built `--scip` has no spawn and passes `None`.
     pub fn run_oracle(
         &self,
         tool: OracleTool,
         tool_version: &str,
         scip_bytes: &[u8],
         production_sha: Option<&std::collections::HashMap<String, String>>,
+        pre_spawn_sha: Option<&std::collections::HashMap<String, String>>,
     ) -> anyhow::Result<OracleReport> {
         let Some(root) = self.storage.source_root() else {
             anyhow::bail!(
@@ -33,6 +37,21 @@ impl IndexDatabase {
             scip_bytes,
             &root,
             production_sha,
+            pre_spawn_sha,
+        )
+    }
+
+    /// The active checkout's indexed `(path -> files.sha256)` map — the pre-spawn snapshot the
+    /// CLI takes BEFORE spawning the oracle tool (and before acquiring the index write lock; this
+    /// is a cheap read-only query), so the join can reject any document the watcher reindexed
+    /// across the entire spawn → join window (#83).
+    pub fn oracle_pre_spawn_snapshot(
+        &self,
+    ) -> anyhow::Result<std::collections::HashMap<String, String>> {
+        oracle::pre_spawn_snapshot(
+            self.storage.connection(),
+            &self.active_commit_sha,
+            &self.active_worktree_id,
         )
     }
 
@@ -107,9 +126,9 @@ impl IndexDatabase {
         tool_version: &str,
         scip_bytes: &[u8],
     ) -> anyhow::Result<oracle::OracleReport> {
-        // A pre-built `--scip` carries no production moment we control, so there is no per-document
-        // snapshot to pin — the scip-vs-disk gate is off and only the index-vs-disk gate applies.
-        self.run_oracle(tool, tool_version, scip_bytes, None)
+        // A pre-built `--scip` carries no production moment or spawn we control, so neither the
+        // scip-vs-disk nor the pre-spawn gate can arm — only the index-vs-disk gate applies.
+        self.run_oracle(tool, tool_version, scip_bytes, None, None)
     }
 
     /// Probe whether an oracle tool is installed, for `oracle status`. A `Blocked` probe is
@@ -2349,6 +2368,7 @@ mod oracle_surfacing_tests {
             &db.active_worktree_id,
             &Index::default().write_to_bytes().unwrap(),
             &root,
+            None,
             None,
         )
         .unwrap();

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -1985,6 +1985,47 @@ mod oracle_surfacing_tests {
         let _ = fs::remove_dir_all(&root);
     }
 
+    /// `oracle_pre_spawn_snapshot` returns the active checkout's indexed `(path -> sha256)` map;
+    /// a run pinned to a MATCHING snapshot verdicts normally, while a snapshot disagreeing with
+    /// the join-time indexed sha (the mid-subprocess reindex, #83) skips the candidate.
+    #[test]
+    fn pre_spawn_snapshot_round_trips_through_run_oracle() {
+        let root = temp_root();
+        fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
+        let config = rust_config(root.clone());
+        let db = IndexDatabase::rebuild(&config).unwrap();
+
+        let (_edge_id, cs, ce, path) = call_edge(&db);
+        let snapshot = db.oracle_pre_spawn_snapshot().unwrap();
+        let indexed_sha: String = db
+            .storage
+            .connection()
+            .query_row("SELECT sha256 FROM files WHERE path = ?1", params![path], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            snapshot.get(&path).map(String::as_str),
+            Some(indexed_sha.as_str()),
+            "snapshot must carry the indexed sha for every active-checkout file"
+        );
+
+        let symbol = "scip-rust crate held-mini `target`().";
+        let scip = scip_with(&path, cs, ce, symbol, Some(&path), Some((29, 35)));
+        let report = db
+            .run_oracle(OracleTool::RustAnalyzer, "v-test", &scip, None, Some(&snapshot))
+            .unwrap();
+        assert!(report.confirmed >= 1 || report.upgraded >= 1, "matching pin verdicts normally");
+        assert_eq!(report.skipped_drifted, 0);
+
+        let mut stale = snapshot.clone();
+        stale.insert(path.clone(), "pre-spawn-old".to_string());
+        let report =
+            db.run_oracle(OracleTool::RustAnalyzer, "v-test2", &scip, None, Some(&stale)).unwrap();
+        assert_eq!(report.rows_written, 0, "a mid-subprocess reindex must skip the candidate");
+        assert!(report.skipped_drifted >= 1);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
     /// Staleness revert: after a current run surfaces `compiler`, drifting the source file (so its
     /// `files.sha256` no longer matches the verdict's `file_sha`) reverts the edge to heuristic
     /// display — never `compiler`.


### PR DESCRIPTION
Fixes #83 (follow-up from #82/#69), exactly along the issue's fix direction.

## What

- **Pre-spawn snapshot**: the CLI `oracle run` (tool-driven path) reads the active checkout's indexed `(path → files.sha256)` map **before spawning** the tool — a cheap read-only query taken without the index write lock (`IndexDatabase::oracle_pre_spawn_snapshot`). `run_oracle_with_tool` does the same internally for the coupled production+join path.
- **Three join gates**: the run skips any candidate whose join-time indexed sha no longer equals the pre-spawn snapshot — for the **call-site** document, the resolved **definition** document, and the **moniker pass**'s definition documents. This asserts the watcher reindexed nothing across the *entire* spawn → join window; the existing post-exit `production_sha` gate stays (the two compose).
- Residual ABA (edit reverted to byte-identical content) is accepted per the issue — the verdict is then correct anyway.
- Pre-built `--scip` runs arm neither gate (no spawn or production moment we control), unchanged.
- The honest "best-effort / mid-subprocess remains uncovered" comments at `commands.rs` and `ScipProduction::Produced` are updated as the issue requested.

## Tests

`run_with_pins` harness builds the corpus where index, disk, and the post-exit production snapshot all agree (every #82 gate passes) and only the pre-spawn snapshot distinguishes the scenarios:
- matching snapshot → verdict lands, `skipped_drifted == 0` (gate doesn't over-fire);
- call-site doc reindexed mid-subprocess → skipped, no verdict;
- definition doc reindexed mid-subprocess → skipped, no verdict, no moniker row.

`cargo test` (291 core + cli + mcp) green, clippy clean, nightly fmt applied.