### PR TITLE
Scope edge resolution to the active checkout (#89)

### DIFF
--- a/crates/rag-rat-core/src/index/edges/helpers.rs
+++ b/crates/rag-rat-core/src/index/edges/helpers.rs
@@ -203,6 +203,10 @@ pub(crate) fn symbols_for_file(
     let rows = stmt.query_map([file_id], symbol_row)?;
     collect_rows(rows)
 }
+/// Every symbol in the ACTIVE CHECKOUT, ordered by qualified name. The `files` join goes through
+/// the per-connection scoped TEMP VIEW (overlay wins, dead scopes excluded) — resolving against
+/// raw `symbols` duplicated every symbol whenever multiple scopes coexist and collapsed edge
+/// resolution (#89).
 pub(crate) fn all_symbols(conn: &Connection) -> anyhow::Result<Vec<IndexedSymbol>> {
     let mut stmt = conn.prepare(
         "
@@ -210,6 +214,7 @@ pub(crate) fn all_symbols(conn: &Connection) -> anyhow::Result<Vec<IndexedSymbol
          symbols.qualified_name, symbols.kind,
                symbols.start_byte, symbols.end_byte, symbols.start_line, symbols.end_line
         FROM symbols
+        JOIN files ON files.id = symbols.file_id
         ORDER BY symbols.qualified_name
         ",
     )?;

--- a/crates/rag-rat-core/src/index/edges/resolve.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve.rs
@@ -1,11 +1,29 @@
 use super::*;
 
+/// Re-resolve the ACTIVE CHECKOUT's edges against the ACTIVE CHECKOUT's symbols.
+///
+/// SCOPE (load-bearing, #89): both SELECTs join `files` — the per-connection scoped TEMP VIEW
+/// (`install_scope_view`: overlay rows win, shadowed committed rows and other commits/worktrees
+/// are excluded). The DB legitimately holds MULTIPLE scopes at once (a dead commit's rows linger
+/// until gc after every HEAD move; a sibling worktree's scope is live permanently; dirty files
+/// add overlay rows), and resolving against raw `symbols` made every symbol a duplicate: unique
+/// qualified-suffix/name matches demoted to `logical_variant` picking `matches[0]` — an ARBITRARY
+/// scope's symbol id, which the active-checkout reads (and the oracle's def-drift gate) then
+/// rightly refuse — and cross-scope mixtures went ambiguous → mass-NULLed targets. On a
+/// connection without the view (a raw test connection), `files` falls back to `main.files` and
+/// resolution is unscoped — production connections always have the view (`set_context` installs
+/// it at open/rebuild/incremental).
+///
+/// Dead scopes' edges are likewise NOT re-resolved (their source file is outside the view): each
+/// scope's edges stay self-consistent until gc prunes them or their own worktree's pass rewrites
+/// them.
 pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
     let symbols = all_symbols(conn)?;
     let index = SymbolIndex::build(&symbols);
     let mut stmt = conn.prepare(
-        "SELECT id, source_file_id, to_name, target_qualified_name, edge_kind, confidence, \
-         evidence, receiver_hint FROM edges ORDER BY id",
+        "SELECT edges.id, edges.source_file_id, edges.to_name, edges.target_qualified_name, \
+         edges.edge_kind, edges.confidence, edges.evidence, edges.receiver_hint FROM edges JOIN \
+         files ON files.id = edges.source_file_id ORDER BY edges.id",
     )?;
     let rows = stmt.query_map([], |row| {
         Ok((
@@ -432,4 +450,143 @@ pub(crate) fn preferred_matches<'a>(
         .copied()
         .filter(|symbol| preferred_kinds.contains(&symbol.kind.as_str()))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::{Connection, params};
+
+    use super::*;
+    use crate::index::schema;
+
+    const NEW: &str = "newcommitsha";
+    const OLD: &str = "oldcommitsha";
+
+    fn seeded_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        conn
+    }
+
+    fn add_file(conn: &Connection, path: &str, commit: &str) -> i64 {
+        conn.execute(
+            "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+             commit_sha, worktree_id) VALUES (?1, 'rust', 'source', ?2, 0, 0, ?3, '')",
+            params![path, format!("sha-{commit}-{path}"), commit],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn add_symbol(conn: &Connection, file_id: i64, name: &str, qualified: &str) -> i64 {
+        conn.execute(
+            "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte, \
+             end_byte, start_line, end_line) VALUES (?1, 'rust', ?2, ?3, 'function', 0, 10, 1, 1)",
+            params![file_id, name, qualified],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn add_edge(
+        conn: &Connection,
+        source_file_id: i64,
+        to_name: &str,
+        target_qualified_name: &str,
+    ) -> i64 {
+        conn.execute(
+            "INSERT INTO edges(source_file_id, to_name, target_qualified_name, edge_kind, \
+             confidence, resolution) VALUES (?1, ?2, ?3, 'calls_name', 'NameOnly', 'unresolved')",
+            params![source_file_id, to_name, target_qualified_name],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn edge_state(conn: &Connection, edge_id: i64) -> (Option<i64>, String, String) {
+        conn.query_row(
+            "SELECT to_symbol_id, confidence, resolution FROM edges WHERE id = ?1",
+            params![edge_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap()
+    }
+
+    /// The #89 regression: with a DEAD scope's rows still in the DB (post-HEAD-move before gc, or
+    /// a sibling worktree's live scope), resolution must behave exactly as in a single-scope DB —
+    /// unique qualified-suffix matches stay `qualified_suffix` (not demoted to `logical_variant`
+    /// picking an arbitrary scope's copy), and the target id belongs to the ACTIVE scope.
+    #[test]
+    fn resolution_is_scoped_to_the_active_checkout() {
+        let conn = seeded_conn();
+        // Active scope NEW + dead scope OLD, same corpus shape in both.
+        let caller_new = add_file(&conn, "a.rs", NEW);
+        let defs_new = add_file(&conn, "b.rs", NEW);
+        let caller_old = add_file(&conn, "a.rs", OLD);
+        let defs_old = add_file(&conn, "b.rs", OLD);
+        let target_new = add_symbol(&conn, defs_new, "target", "crate::b::target");
+        let target_old = add_symbol(&conn, defs_old, "target", "crate::b::target");
+        add_symbol(&conn, caller_new, "caller", "crate::a::caller");
+        add_symbol(&conn, caller_old, "caller", "crate::a::caller");
+
+        // The suffix-shaped qualified target exercises the by_qn_tail arm (the one duplicates
+        // demote): `b::target` matches `crate::b::target` by suffix.
+        let edge_new = add_edge(&conn, caller_new, "b::target", "b::target");
+        // The dead scope's own edge: pre-resolved to its own scope's symbol; must stay untouched.
+        let edge_old = add_edge(&conn, caller_old, "b::target", "b::target");
+        conn.execute(
+            "UPDATE edges SET to_symbol_id = ?2, confidence = 'Syntactic', resolution = \
+             'qualified_suffix' WHERE id = ?1",
+            params![edge_old, target_old],
+        )
+        .unwrap();
+
+        crate::index::install_scope_view(&conn, NEW, "").unwrap();
+        resolve_all_edges(&conn).unwrap();
+
+        let (to, confidence, resolution) = edge_state(&conn, edge_new);
+        assert_eq!(
+            to,
+            Some(target_new),
+            "the active edge must resolve to the ACTIVE scope's symbol, not an arbitrary copy"
+        );
+        assert_eq!(confidence, "Syntactic");
+        assert_eq!(
+            resolution, "qualified_suffix",
+            "a unique in-scope suffix match must not demote to logical_variant"
+        );
+
+        let (to, _, resolution) = edge_state(&conn, edge_old);
+        assert_eq!(to, Some(target_old), "the dead scope's edge is left untouched");
+        assert_eq!(resolution, "qualified_suffix");
+    }
+
+    /// A dirty-worktree overlay shadows the committed row: resolution must target the OVERLAY's
+    /// symbols (the active content), not the shadowed committed copy.
+    #[test]
+    fn resolution_prefers_overlay_over_shadowed_committed_rows() {
+        let conn = seeded_conn();
+        let caller = add_file(&conn, "a.rs", NEW);
+        let defs_committed = add_file(&conn, "b.rs", NEW);
+        // Overlay row for b.rs (dirty file): commit_sha empty, worktree id set.
+        conn.execute(
+            "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+             commit_sha, worktree_id) VALUES ('b.rs', 'rust', 'source', 'sha-overlay', 0, 0, '', \
+             '/wt')",
+            [],
+        )
+        .unwrap();
+        let defs_overlay = conn.last_insert_rowid();
+        add_symbol(&conn, defs_committed, "target", "crate::b::target");
+        let target_overlay = add_symbol(&conn, defs_overlay, "target", "crate::b::target");
+        add_symbol(&conn, caller, "caller", "crate::a::caller");
+        let edge = add_edge(&conn, caller, "b::target", "b::target");
+
+        crate::index::install_scope_view(&conn, NEW, "/wt").unwrap();
+        resolve_all_edges(&conn).unwrap();
+
+        let (to, _, resolution) = edge_state(&conn, edge);
+        assert_eq!(to, Some(target_overlay), "overlay symbols win over shadowed committed rows");
+        assert_eq!(resolution, "qualified_suffix");
+    }
 }


### PR DESCRIPTION
Fixes #89.

## Root cause

`resolve_all_edges` (the incremental/watcher re-resolution pass) read raw `symbols` and raw `edges` with no scope join, while the DB legitimately holds **multiple scopes at once**: a dead commit's rows linger until gc after every HEAD move, a sibling worktree's scope is live permanently, and dirty files add worktree-overlay rows alongside their shadowed committed rows.

With every symbol duplicated across scopes:
- unique qualified-suffix / by-name matches demoted to `logical_variant`, resolving to `matches[0]` — an **arbitrary scope's** symbol id, which the active-checkout query reads and the oracle's def-drift gate then rightly refuse to surface;
- cross-scope mixtures went ambiguous and **mass-NULLed** targets (`remove_file_in_scope` NULLs in-edges by design and relies on this resolver to re-point them).

Observed on the live self-index as the #89 collapse: 1,219 of 34k targeted edges (vs 8k+ after a full rebuild), oracle `upgraded` jumping 1.5k → 7.6k, and a "healed" state that was still degraded — zero `exact`/`qualified_suffix` resolutions, 14,580 `logical_variant`s pointing into arbitrary scopes.

## Fix

Both of the resolver's SELECTs now join `files` — the **per-connection scoped TEMP VIEW** (`install_scope_view`: overlay wins, shadowed committed rows and dead scopes excluded), the same pattern the orientation/graph queries already use. Resolution sees exactly the active checkout: full-rebuild-quality matches, targets always in the active scope, and dead scopes' edges are left self-consistent (their own worktree's pass rewrites them; gc prunes them) instead of being re-resolved against the wrong corpus.

## Verification

- TDD regression tests (failing before the fix): a dead-commit duplicate scope must not demote a unique suffix match to `logical_variant` or steal the target id; an overlay row must win over its shadowed committed row.
- Live self-index with **three** coexisting scopes (overlay + two commits): resolved targets back to the full-rebuild baseline (~8.3k over 35k active candidates); `logical_variant` down from 14,580 (scope-duplicate artifacts) to 296 (genuine cfg twins).
- `cargo test` (294 core + cli + mcp) green, clippy clean, nightly fmt.

The byte-identical full-rebuild path is untouched (it resolves via the in-memory single-scope graph, not this resolver).