### PR TITLE
Authoritative full-rebuild clear + stale-overlay self-heal (#87)

### DIFF
--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -84,13 +84,25 @@ impl IndexDatabase {
                 IndexMode::Discover => db.index_discovered_files_with_progress(config, progress)?,
                 IndexMode::Full => unreachable!("full mode is handled by rebuild_with_progress"),
             };
-            let mut mutated = indexed > 0 || source_root_changed || git_meta_changed;
+            // Self-heal stale worktree-overlay rows (#87): a dirty-then-committed file's overlay
+            // row otherwise lingers forever, shadowing its (correct) committed row in every
+            // scoped read and colliding with a later full rebuild. Runs AFTER the indexing step
+            // so a freshly discovered committed row can take over. Read-only when there is
+            // nothing to heal, preserving the idle-pass no-write invariant (#63).
+            let healed = match git_changed_paths(&config.root) {
+                Ok(changes) => db.heal_stale_overlay_rows(&changes)?,
+                // Non-git roots have no commit scope; overlays are their canonical rows.
+                Err(_) => 0,
+            };
+            let mut mutated = indexed > 0 || healed > 0 || source_root_changed || git_meta_changed;
             // None when the gate above found git history already current — skip the reload.
             if let Some(handle) = git_history.take() {
                 db.apply_prepared_git_history(&config.root, handle)?;
                 mutated = true;
             }
-            if indexed > 0 {
+            // Healing can delete overlay symbols (NULLing their in-edges via
+            // `remove_file_in_scope`), so it needs the same re-derive tail as real file changes.
+            if indexed > 0 || healed > 0 {
                 progress(IndexProgress::RebuildingLogicalSymbols);
                 db.rebuild_logical_symbols()?;
                 progress(IndexProgress::ResolvingGraph);
@@ -108,9 +120,10 @@ impl IndexDatabase {
                 db.storage.execute_batch("ROLLBACK")?;
             }
             progress(IndexProgress::Finished { files: indexed });
-            // Report whether index *content* changed (files added / edited / removed), so the
-            // watch loop can skip the reconcile / memory-validate tail on an idle sweep.
-            Ok(indexed > 0)
+            // Report whether index *content* changed (files added / edited / removed, or stale
+            // overlays healed — symbols move scope), so the watch loop can skip the
+            // reconcile / memory-validate tail on an idle sweep.
+            Ok(indexed > 0 || healed > 0)
         })();
         if result.is_err() {
             if let Some(handle) = git_history.take() {
@@ -226,6 +239,76 @@ impl IndexDatabase {
                 file
             })
             .collect()
+    }
+
+    /// Drop or re-stamp stale worktree-overlay rows: overlay rows of the active worktree whose
+    /// path is NOT currently dirty (#87). They arise when a dirty file is committed (or its edit
+    /// reverted) and the cleanup pass never ran — e.g. a binary upgrade or schema migration cut
+    /// the old watcher off mid-session. Left alone they shadow the committed row in every scoped
+    /// read (queries see stale content) and collide with a later full rebuild's insert.
+    ///
+    /// Per stale overlay row:
+    /// - a row exists at `(path, active_commit, '')` → DELETE the overlay (cascade via
+    ///   `remove_file_in_scope`); the committed row takes over.
+    /// - no committed row, and the overlay's `sha256` matches the disk bytes (the path is clean, so
+    ///   disk == HEAD) → RE-STAMP the row to the commit scope in place. The row id — and every
+    ///   chunk/symbol/embedding/oracle row and memory binding hanging off it — survives.
+    /// - no committed row and the sha differs (checkout moved under a stale overlay) → leave it;
+    ///   the next discover pass reindexes the path at the commit scope (sha mismatch), and the pass
+    ///   after that takes the first branch.
+    ///
+    /// Returns the number of rows healed. Purely a read when nothing is stale, so an idle pass
+    /// stays write-free (#63). Non-git contexts (`active_commit_sha` empty) are untouched —
+    /// overlay rows ARE their canonical scope.
+    pub(super) fn heal_stale_overlay_rows(
+        &self,
+        changes: &GitChangedPaths,
+    ) -> anyhow::Result<usize> {
+        if self.active_commit_sha.is_empty() {
+            return Ok(0);
+        }
+        let overlays: Vec<(i64, String, String)> = {
+            let conn = self.storage.connection();
+            let mut stmt = conn.prepare(
+                "SELECT id, path, sha256 FROM main.files
+                 WHERE worktree_id = ?1 AND worktree_id != '' AND kind != 'deleted'",
+            )?;
+            let rows = stmt.query_map([&self.active_worktree_id], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+            })?;
+            rows.collect::<Result<Vec<_>, _>>()?
+        };
+        let mut healed = 0usize;
+        for (file_id, path, sha) in overlays {
+            if changes.changed.contains(Path::new(&path)) {
+                continue; // genuinely dirty — the overlay is the canonical row
+            }
+            let committed_exists: bool = self.storage.connection().query_row(
+                "SELECT EXISTS(SELECT 1 FROM main.files
+                 WHERE path = ?1 AND commit_sha = ?2 AND worktree_id = '')",
+                params![path, self.active_commit_sha],
+                |row| row.get(0),
+            )?;
+            if committed_exists {
+                self.remove_file_in_scope(Path::new(&path), "", &self.active_worktree_id)?;
+                healed += 1;
+                continue;
+            }
+            let disk_matches = self
+                .storage
+                .source_root()
+                .map(|root| root.join(&path))
+                .and_then(|full| std::fs::read(full).ok())
+                .is_some_and(|bytes| hex_sha256(&bytes) == sha);
+            if disk_matches {
+                self.storage.connection().execute(
+                    "UPDATE main.files SET commit_sha = ?2, worktree_id = '' WHERE id = ?1",
+                    params![file_id, self.active_commit_sha],
+                )?;
+                healed += 1;
+            }
+        }
+        Ok(healed)
     }
 
     fn apply_incremental_file_plan<F>(

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -96,6 +96,16 @@ impl IndexDatabase {
 
     fn clear_full_rebuild_tables(&self) -> anyhow::Result<()> {
         // Stage the active context's file ids, then cascade-delete them and their derived rows.
+        //
+        // AUTHORITATIVE (load-bearing, #87): a full rebuild owns the WHOLE checkout, so the
+        // commit-scope staging deliberately does NOT mirror the scope VIEW's shadowing rule.
+        // The view excludes a committed row whose path has a worktree-overlay row (overlay
+        // wins for reads) — but exempting it from the CLEAR left it behind to collide with the
+        // rebuild's fresh insert at the same `(path, commit_sha, '')` whenever a stale overlay
+        // lingered (a dirty-then-committed file whose cleanup never ran), failing the whole
+        // rebuild with a UNIQUE constraint error. Stage every row of the active commit AND
+        // every row of the active worktree, shadowed or not. A sibling worktree at the same
+        // commit self-heals on its next discover pass (its missing paths reindex).
         self.storage.execute_batch(
             "
             CREATE TEMP TABLE IF NOT EXISTS staged_file_ids(id INTEGER PRIMARY KEY);
@@ -110,13 +120,7 @@ impl IndexDatabase {
             SELECT id
             FROM main.files
             WHERE commit_sha = (SELECT value FROM temp.connection_context WHERE key = 'commit_sha')
-              AND commit_sha != ''
-              AND path NOT IN (
-                  SELECT path FROM main.files
-                  WHERE worktree_id = (SELECT value FROM temp.connection_context WHERE key = \
-             'worktree_id')
-                    AND worktree_id != ''
-              );
+              AND commit_sha != '';
             ",
         )?;
         self.delete_staged_files_cascade()?;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -7036,3 +7036,155 @@ fn orientation_composes_through_read_only_connection() {
 
     fs::remove_dir_all(root).unwrap();
 }
+
+/// A git fixture with one committed source file, configured like production (absolute DB path).
+fn git_fixture_for_overlay_tests() -> (PathBuf, Config) {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    run_git(&root, &["init"]);
+    run_git(&root, &["config", "user.name", "Rag Rat"]);
+    run_git(&root, &["config", "user.email", "rag@example.com"]);
+    fs::write(root.join("src/lib.rs"), "pub fn stable() -> i32 { 1 }\n").unwrap();
+    fs::write(root.join("src/extra.rs"), "pub fn extra() -> i32 { 2 }\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "init"]);
+    let config = Config {
+        root: root.clone(),
+        database: root.join(".rag-rat/index.sqlite"),
+        targets: vec![ResolvedTarget {
+            name: "rust".to_string(),
+            language: Language::Rust,
+            directories: vec![PathBuf::from("src")],
+            include: vec!["**/*.rs".to_string()],
+            exclude: Vec::new(),
+            kind: TargetKind::Source,
+        }],
+        local_ai: Default::default(),
+        watch: Default::default(),
+    };
+    (root, config)
+}
+
+/// Insert a worktree-overlay `files` row mirroring an existing committed row's content — the
+/// stale leftover a dirty-then-committed file leaves behind when its cleanup never ran (#87).
+fn insert_stale_overlay_row(db: &IndexDatabase, path: &str, worktree_id: &str) -> i64 {
+    let (sha, language, kind): (String, String, String) = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT sha256, language, kind FROM main.files WHERE path = ?1 AND commit_sha != ''",
+            [path],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+             commit_sha, worktree_id) VALUES (?1, ?2, ?3, ?4, 0, 0, '', ?5)",
+            rusqlite::params![path, language, kind, sha, worktree_id],
+        )
+        .unwrap();
+    db.storage.connection().last_insert_rowid()
+}
+
+/// #87: a full rebuild must be authoritative for the whole checkout. A stale overlay row shadows
+/// its committed counterpart, which exempted the committed row from the clear stage — the rebuild
+/// then collided on UNIQUE(path, commit_sha, worktree_id) and FAILED. With the fix, the rebuild
+/// succeeds and leaves exactly one row per path, at the commit scope.
+#[test]
+fn full_rebuild_survives_stale_overlay_rows() {
+    let (root, config) = git_fixture_for_overlay_tests();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let worktree_id = db.active_worktree_id.clone();
+    let commit = db.active_commit_sha.clone();
+    assert!(!commit.is_empty(), "fixture must be a real git checkout");
+    insert_stale_overlay_row(&db, "src/lib.rs", &worktree_id);
+    drop(db);
+
+    let db = IndexDatabase::rebuild(&config).expect("rebuild must survive stale overlay rows");
+
+    let rows: Vec<(String, String)> = {
+        let conn = db.storage.connection();
+        let mut stmt = conn
+            .prepare(
+                "SELECT commit_sha, worktree_id FROM main.files WHERE path = 'src/lib.rs' AND \
+                 kind != 'deleted'",
+            )
+            .unwrap();
+        stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    };
+    assert_eq!(rows.len(), 1, "exactly one row per path after an authoritative rebuild: {rows:?}");
+    assert_eq!(rows[0], (commit, String::new()), "the clean tree indexes at the commit scope");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+/// #87 (self-heal half): an incremental pass drops a stale overlay row whose path is clean.
+/// With a committed counterpart present the overlay is removed outright; without one, the row is
+/// RE-STAMPED to the commit scope in place (same row id — chunks/symbols/embeddings/memory
+/// bindings all survive).
+#[test]
+fn incremental_pass_heals_stale_overlay_rows() {
+    let (root, config) = git_fixture_for_overlay_tests();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let worktree_id = db.active_worktree_id.clone();
+    let commit = db.active_commit_sha.clone();
+
+    // Case A: stale overlay WITH a committed counterpart -> deleted, committed row takes over.
+    insert_stale_overlay_row(&db, "src/lib.rs", &worktree_id);
+    // Case B: stale overlay WITHOUT a committed counterpart (its content matches disk) ->
+    // re-stamped to the commit scope in place.
+    let restamp_id = insert_stale_overlay_row(&db, "src/extra.rs", &worktree_id);
+    db.storage
+        .connection()
+        .execute("DELETE FROM main.files WHERE path = 'src/extra.rs' AND commit_sha != ''", [])
+        .unwrap();
+    drop(db);
+
+    let db = IndexDatabase::index_discover_with_progress(&config, |_| {}).unwrap();
+
+    let overlays: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM main.files WHERE worktree_id != '' AND kind != 'deleted'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(overlays, 0, "a clean tree leaves no overlay rows behind");
+
+    let lib_rows: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM main.files WHERE path = 'src/lib.rs' AND kind != 'deleted'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(lib_rows, 1, "the committed row takes over from the deleted overlay");
+
+    let (extra_id, extra_commit): (i64, String) = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT id, commit_sha FROM main.files WHERE path = 'src/extra.rs' AND kind != \
+             'deleted'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(extra_commit, commit, "the orphan overlay is re-stamped to the commit scope");
+    assert_eq!(
+        extra_id, restamp_id,
+        "re-stamp is in place — the row id (and ids hanging off it) survive"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}


### PR DESCRIPTION
Fixes #87.

## The two halves

**1. Full rebuild is now authoritative for the whole checkout.** `clear_full_rebuild_tables` staged the active commit's rows using the scope *view's* shadowing rule — a committed row whose path had a worktree-overlay row was exempted. That is correct for reads (overlay wins) but wrong for the clear: with a stale overlay lingering, the shadowed committed row survived and collided with the rebuild's fresh insert at the same `(path, commit_sha, '')`, failing the entire rebuild with `UNIQUE constraint failed: files.path, files.commit_sha, files.worktree_id`. The clear now stages every active-commit row AND every active-worktree row, shadowed or not. (A sibling worktree at the same commit self-heals on its next discover pass.)

**2. Incremental passes self-heal stale overlays** (the producer side — issue comment's suggested hardening). After the indexing step, an overlay row of the active worktree whose path is *clean* is:
- **deleted** (cascade) when a committed counterpart exists — the committed row takes over;
- **re-stamped to the commit scope in place** when no counterpart exists and its content matches disk — the row id, and every chunk/symbol/embedding/oracle row/memory binding hanging off it, survives (this is the missing dirty→clean transition);
- **left** when its sha drifted (checkout moved underneath) — the next discover pass reindexes the path and the pass after that deletes the orphan; converges in two passes.

Healing counts as content change (drives the resolve/FTS tail and the watcher's memory-validate tail) but is purely a read when nothing is stale, preserving the idle-pass no-write invariant (#63). Non-git roots are untouched — overlay rows are their canonical scope.

## Why stale overlays existed at all

The observed producer: a mid-session binary upgrade/schema migration cut the old watcher's writes off after files were committed, so its dirty-era overlay rows froze. Until now nothing ever removed them — they shadowed correct committed rows in every scoped read and broke the next full rebuild.

## Tests (failing first)

- `full_rebuild_survives_stale_overlay_rows` — real git fixture; reproduces the live UNIQUE failure verbatim pre-fix; post-fix asserts exactly one row per path at the commit scope.
- `incremental_pass_heals_stale_overlay_rows` — pins both heal modes, including row-id preservation for the re-stamp.
- `dirty_git_files_are_indexed_as_worktree_overlay` (existing) still green — genuinely dirty files keep their overlays.

`cargo test` (296 core + cli + mcp) green, clippy clean, nightly fmt.