### PR TITLE
Scope-aware + crate-aware edge resolution (#61)

### DIFF
--- a/crates/rag-rat-core/src/index/edges/helpers.rs
+++ b/crates/rag-rat-core/src/index/edges/helpers.rs
@@ -194,7 +194,8 @@ pub(crate) fn symbols_for_file(
         "
         SELECT symbols.id, symbols.file_id, symbols.language, symbols.name, \
          symbols.qualified_name, symbols.kind,
-               symbols.start_byte, symbols.end_byte, symbols.start_line, symbols.end_line
+               symbols.start_byte, symbols.end_byte, symbols.start_line, symbols.end_line, \
+         COALESCE(symbols.scope_path, '')
         FROM symbols
         WHERE file_id = ?1
         ORDER BY symbols.start_byte, symbols.end_byte
@@ -212,7 +213,8 @@ pub(crate) fn all_symbols(conn: &Connection) -> anyhow::Result<Vec<IndexedSymbol
         "
         SELECT symbols.id, symbols.file_id, symbols.language, symbols.name, \
          symbols.qualified_name, symbols.kind,
-               symbols.start_byte, symbols.end_byte, symbols.start_line, symbols.end_line
+               symbols.start_byte, symbols.end_byte, symbols.start_line, symbols.end_line, \
+         COALESCE(symbols.scope_path, '')
         FROM symbols
         JOIN files ON files.id = symbols.file_id
         ORDER BY symbols.qualified_name
@@ -235,6 +237,7 @@ pub(crate) fn symbol_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<IndexedSym
         end_byte,
         start_line: row.get(8)?,
         end_line: row.get(9)?,
+        scope_path: row.get(10)?,
     })
 }
 /// Intern one string into `edge_strings`, returning its id (#79). `INSERT OR IGNORE` + lookup —

--- a/crates/rag-rat-core/src/index/edges/imports.rs
+++ b/crates/rag-rat-core/src/index/edges/imports.rs
@@ -75,7 +75,13 @@ fn crate_root_name(manifest: &toml::Value) -> Option<String> {
 pub(crate) fn parse_use(use_text: &str) -> Option<(String, Vec<String>)> {
     let rest = strip_use_visibility(use_text.trim())?;
     let tree = rest.strip_suffix(';').unwrap_or(rest).trim();
-    let root = tree.split("::").next().map(str::trim).filter(|seg| !seg.is_empty())?;
+    // First `::`-segment, then its first whitespace token — strips a brace-free root alias
+    // (`use my_crate as alias;` → root `my_crate`, not `my_crate as alias`).
+    let root = tree
+        .split("::")
+        .next()
+        .and_then(|seg| seg.split_whitespace().next())
+        .filter(|seg| !seg.is_empty())?;
     let mut leaves = Vec::new();
     collect_use_leaves(tree, &mut leaves);
     Some((root.to_string(), leaves))
@@ -213,6 +219,22 @@ impl ImportScope {
         };
         !self.local_roots.contains(root) && !matches!(root.as_str(), "crate" | "self" | "super")
     }
+
+    /// Whether a path-qualified reference's RECEIVER/root names an external import — `Url::parse`
+    /// (target_qualified_name `Url::parse`) where `Url` was `use`d from the external `url` crate.
+    /// The leaf `parse` itself isn't imported, so [`is_external_import`] on the callee name misses
+    /// it; the new scope-path lookup would otherwise bind `Url::parse` to an in-repo `Url::parse`.
+    /// Keyed on `target_qualified_name`'s `::`-head only (not the value-receiver hint), so a method
+    /// call on a local value (`url.parse()`, no `::` path) is never suppressed.
+    pub(crate) fn is_external_qualified_root(
+        &self,
+        file_id: i64,
+        target_qualified_name: Option<&str>,
+    ) -> bool {
+        target_qualified_name
+            .and_then(|qualified| qualified.split_once("::"))
+            .is_some_and(|(root, _)| self.is_external_import(file_id, root))
+    }
 }
 
 #[cfg(test)]
@@ -249,6 +271,8 @@ mod tests {
         assert_eq!(parsed("pub use crate::a::B;"), Some(("crate".into(), s(&["B"]))));
         // `as` alias: the alias is the bound name.
         assert_eq!(parsed("use foo::Bar as Baz;"), Some(("foo".into(), s(&["Baz"]))));
+        // Brace-free ROOT alias: the root is the pre-`as` crate, the leaf is the alias.
+        assert_eq!(parsed("use my_crate as local;"), Some(("my_crate".into(), s(&["local"]))));
         assert_eq!(parsed("use foo::{Bar as Baz, Qux};"), Some(("foo".into(), s(&["Baz", "Qux"]))));
         // `self` in a group binds the parent segment.
         assert_eq!(parsed("use a::b::{self, C};"), Some(("a".into(), s(&["C", "b"]))));

--- a/crates/rag-rat-core/src/index/edges/imports.rs
+++ b/crates/rag-rat-core/src/index/edges/imports.rs
@@ -60,13 +60,120 @@ fn crate_root_name(manifest: &toml::Value) -> Option<String> {
     Some(package.replace('-', "_"))
 }
 
-/// The crate root of a `use` statement: its first path segment (`use cargo::core::…` → `cargo`,
-/// `pub use crate::x` → `crate`). `None` for a glob/unparseable form (we then suppress nothing).
-pub(crate) fn use_root(use_text: &str) -> Option<&str> {
-    let trimmed = use_text.trim_start();
-    let trimmed = trimmed.strip_prefix("pub ").map(str::trim_start).unwrap_or(trimmed);
-    let rest = trimmed.strip_prefix("use ")?.trim_start();
-    rest.split([':', ' ', '{', ';', '*']).next().filter(|segment| !segment.is_empty())
+/// Parse a Rust `use` statement into its crate root and the leaf NAMES it actually binds into
+/// scope — the only names a bare reference can resolve through. The imports edge stream enumerates
+/// every identifier under a `use` path (`use std::path::{Path, PathBuf}` emits `std::path`, `Path`,
+/// `PathBuf`), so building the scope from those over-records the path prefix `path` as a binding
+/// and then wrongly suppresses an unrelated local `path`. Parsing the statement records only the
+/// real bindings.
+///
+/// Handles restricted visibility (`pub(crate) use …`, `pub(in path) use …`), brace groups
+/// (including nesting), `as` aliases (the alias is the bound name), and `self` in a group (binds
+/// the parent segment). Returns `None` for a non-`use`/unparseable form; a glob (`*`) contributes
+/// no specific binding (the names it brings in are unknowable, so it fails open — suppresses
+/// nothing).
+pub(crate) fn parse_use(use_text: &str) -> Option<(String, Vec<String>)> {
+    let rest = strip_use_visibility(use_text.trim())?;
+    let tree = rest.strip_suffix(';').unwrap_or(rest).trim();
+    let root = tree.split("::").next().map(str::trim).filter(|seg| !seg.is_empty())?;
+    let mut leaves = Vec::new();
+    collect_use_leaves(tree, &mut leaves);
+    Some((root.to_string(), leaves))
+}
+
+/// Strip an optional leading visibility modifier and the `use ` keyword, returning the use TREE
+/// (everything after `use `). `None` when the statement isn't a `use` (e.g. a `mod foo;` Imports
+/// edge), so the caller records nothing.
+fn strip_use_visibility(s: &str) -> Option<&str> {
+    let s = s.trim_start();
+    // `pub use …`, `pub(crate) use …`, `pub(in path) use …`. A bare `pub` must be followed by a
+    // boundary (whitespace or `(`) so we don't eat the `pub` prefix of an unrelated identifier.
+    let s = match s.strip_prefix("pub") {
+        Some(after) if after.starts_with('(') =>
+            after.split_once(')').map(|(_, tail)| tail).unwrap_or(after).trim_start(),
+        Some(after) if after.starts_with(char::is_whitespace) => after.trim_start(),
+        _ => s,
+    };
+    s.strip_prefix("use ").map(str::trim_start)
+}
+
+/// The bound leaf names of a use (sub)tree, appended to `out`. A tree is either a single path
+/// (`a::b::C`, optionally `… as Alias`) or a path with a brace group (`a::b::{…}`); recurse into
+/// the group, which may itself nest.
+fn collect_use_leaves(tree: &str, out: &mut Vec<String>) {
+    let tree = tree.trim();
+    match tree.find('{') {
+        None =>
+            if let Some(leaf) = single_use_binding(tree) {
+                out.push(leaf);
+            },
+        Some(open) => {
+            let prefix = tree[..open].trim_end().trim_end_matches(':');
+            for entry in split_top_level(brace_inner(&tree[open..])) {
+                let entry = entry.trim();
+                if entry == "self" {
+                    // `a::b::{self}` binds the parent segment `b`.
+                    if let Some(parent) = prefix.rsplit("::").next().filter(|seg| !seg.is_empty()) {
+                        out.push(parent.to_string());
+                    }
+                } else if !entry.is_empty() {
+                    collect_use_leaves(entry, out);
+                }
+            }
+        },
+    }
+}
+
+/// The bound name of a single (brace-free) use path: the alias after `as`, else the last `::`
+/// segment. A glob (`*`) or a bare `self`/empty tail binds nothing here (the caller fails open).
+fn single_use_binding(path: &str) -> Option<String> {
+    if let Some((_, alias)) = path.split_once(" as ") {
+        let alias = alias.trim();
+        return (!alias.is_empty() && alias != "_").then(|| alias.to_string());
+    }
+    match path.rsplit("::").next().map(str::trim) {
+        Some("" | "*" | "self") | None => None,
+        Some(name) => Some(name.to_string()),
+    }
+}
+
+/// The content between the first `{` and its matching `}` (or to end-of-string if the evidence was
+/// truncated). `from_brace` must start at the `{`.
+fn brace_inner(from_brace: &str) -> &str {
+    let mut depth = 0u32;
+    for (i, b) in from_brace.bytes().enumerate() {
+        match b {
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return &from_brace[1..i];
+                }
+            },
+            _ => {},
+        }
+    }
+    &from_brace[1..]
+}
+
+/// Split a brace group's interior on top-level commas — commas inside a nested `{…}` don't split.
+fn split_top_level(inner: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut depth = 0u32;
+    let mut start = 0;
+    for (i, b) in inner.bytes().enumerate() {
+        match b {
+            b'{' => depth += 1,
+            b'}' => depth = depth.saturating_sub(1),
+            b',' if depth == 0 => {
+                parts.push(&inner[start..i]);
+                start = i + 1;
+            },
+            _ => {},
+        }
+    }
+    parts.push(&inner[start..]);
+    parts
 }
 
 /// Per-file map of imported leaf name → the crate root it was imported from, plus the local-crate
@@ -82,9 +189,15 @@ impl ImportScope {
         Self { local_roots, by_file: HashMap::new() }
     }
 
-    /// Record one `use <root>::…` binding for a file: the bound leaf name → its crate root.
-    pub(crate) fn add_import(&mut self, file_id: i64, leaf: &str, root: &str) {
-        self.by_file.entry(file_id).or_default().insert(leaf.to_string(), root.to_string());
+    /// Record a `use` statement's bindings for `file_id`: every leaf name it brings into scope →
+    /// the crate root it came from. Idempotent — the same evidence text arrives once per identifier
+    /// in the imports edge stream, and re-recording the same (leaf → root) is a no-op.
+    pub(crate) fn add_use(&mut self, file_id: i64, use_text: &str) {
+        let Some((root, leaves)) = parse_use(use_text) else { return };
+        let file = self.by_file.entry(file_id).or_default();
+        for leaf in leaves {
+            file.insert(leaf, root.clone());
+        }
     }
 
     /// Whether `name` in `file_id` was imported from an EXTERNAL dependency crate — not a local
@@ -106,26 +219,62 @@ impl ImportScope {
 mod tests {
     use super::*;
 
+    /// Helper: `(root, sorted leaves)` so the assertions don't depend on traversal order.
+    fn parsed(use_text: &str) -> Option<(String, Vec<String>)> {
+        parse_use(use_text).map(|(root, mut leaves)| {
+            leaves.sort();
+            (root, leaves)
+        })
+    }
+
     #[test]
-    fn use_root_extracts_first_segment() {
-        assert_eq!(use_root("use url::Url;"), Some("url"));
-        assert_eq!(use_root("use cargo::core::Workspace;"), Some("cargo"));
-        assert_eq!(use_root("pub use crate::a::B;"), Some("crate"));
-        assert_eq!(use_root("use std::path::{Path, PathBuf};"), Some("std"));
-        assert_eq!(use_root("use self::inner::X;"), Some("self"));
+    fn parse_use_extracts_root_and_only_bound_leaves() {
+        let s = |v: &[&str]| v.iter().map(|x| x.to_string()).collect::<Vec<_>>();
+        assert_eq!(parsed("use url::Url;"), Some(("url".into(), s(&["Url"]))));
+        assert_eq!(
+            parsed("use cargo::core::Workspace;"),
+            Some(("cargo".into(), s(&["Workspace"])))
+        );
+        // The braced form: the path PREFIX `path` is NOT a binding — only `Path`/`PathBuf` are.
+        assert_eq!(
+            parsed("use std::path::{Path, PathBuf};"),
+            Some(("std".into(), s(&["Path", "PathBuf"])))
+        );
+        // `use std::path;` DOES bind the module `path` (no braces, last segment is the binding).
+        assert_eq!(parsed("use std::path;"), Some(("std".into(), s(&["path"]))));
+        // Restricted visibility must still parse (was dropped by the old `pub ` strip).
+        assert_eq!(parsed("pub(crate) use url::Url;"), Some(("url".into(), s(&["Url"]))));
+        assert_eq!(parsed("pub(super) use a::B;"), Some(("a".into(), s(&["B"]))));
+        assert_eq!(parsed("pub(in crate::x) use a::B;"), Some(("a".into(), s(&["B"]))));
+        assert_eq!(parsed("pub use crate::a::B;"), Some(("crate".into(), s(&["B"]))));
+        // `as` alias: the alias is the bound name.
+        assert_eq!(parsed("use foo::Bar as Baz;"), Some(("foo".into(), s(&["Baz"]))));
+        assert_eq!(parsed("use foo::{Bar as Baz, Qux};"), Some(("foo".into(), s(&["Baz", "Qux"]))));
+        // `self` in a group binds the parent segment.
+        assert_eq!(parsed("use a::b::{self, C};"), Some(("a".into(), s(&["C", "b"]))));
+        // Nested groups.
+        assert_eq!(parsed("use a::{b::{C, D}, E};"), Some(("a".into(), s(&["C", "D", "E"]))));
+        // Glob binds no specific name (fail open).
+        assert_eq!(parse_use("use foo::*;"), Some(("foo".to_string(), Vec::new())));
+        // Not a `use` statement.
+        assert_eq!(parse_use("mod foo;"), None);
     }
 
     #[test]
     fn external_import_distinguishes_local_from_dependency() {
         let mut scope = ImportScope::new(HashSet::from(["cargo".to_string()]));
-        scope.add_import(1, "Url", "url"); // external dep
-        scope.add_import(1, "Workspace", "cargo"); // local workspace crate
-        scope.add_import(1, "Write", "std"); // std = external
-        scope.add_import(1, "Helper", "crate"); // local (crate-relative)
+        scope.add_use(1, "use url::Url;"); // external dep
+        scope.add_use(1, "use cargo::core::Workspace;"); // local workspace crate
+        scope.add_use(1, "use std::path::{Path, PathBuf};"); // std = external
+        scope.add_use(1, "use crate::a::Helper;"); // local (crate-relative)
         assert!(scope.is_external_import(1, "Url"), "url is an external dep");
-        assert!(scope.is_external_import(1, "Write"), "std is external");
+        assert!(scope.is_external_import(1, "Path"), "std is external");
         assert!(!scope.is_external_import(1, "Workspace"), "cargo is a local workspace crate");
         assert!(!scope.is_external_import(1, "Helper"), "crate-rooted is local");
+        assert!(
+            !scope.is_external_import(1, "path"),
+            "the `std::path` PREFIX is not a binding — a local `path` must stay resolvable"
+        );
         assert!(
             !scope.is_external_import(1, "Unimported"),
             "an unimported name is never suppressed"
@@ -154,7 +303,7 @@ mod tests {
     #[test]
     fn empty_local_set_fails_open() {
         let mut scope = ImportScope::new(HashSet::new());
-        scope.add_import(1, "Url", "url");
+        scope.add_use(1, "use url::Url;");
         assert!(!scope.is_external_import(1, "Url"), "no manifests → suppress nothing");
     }
 }

--- a/crates/rag-rat-core/src/index/edges/imports.rs
+++ b/crates/rag-rat-core/src/index/edges/imports.rs
@@ -1,0 +1,160 @@
+//! Crate-aware import scope (#61, Project B). A reference to a name imported from an EXTERNAL
+//! dependency crate must not bind to a local same-named symbol — the `use` says where the name
+//! comes from. We tell a LOCAL workspace crate root (keep binding — e.g. cross-crate references
+//! into the `cargo` crate, which the heuristic resolves correctly) from an external dependency root
+//! (`url`, `serde_core`, `std`, … — don't bind locally) by parsing the corpus's Cargo.toml
+//! manifests for the set of local crate names. Rust/Cargo-specific by construction: a corpus with
+//! no manifests yields an empty set and the scope suppresses nothing (fail open).
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use rusqlite::{Connection, OptionalExtension};
+
+/// Load the persisted local-crate-root set — newline-joined under `local_crate_roots` in
+/// `index_meta`, written at rebuild by [`local_crate_roots`]. Empty when absent (a non-Cargo corpus
+/// or a pre-V021 index), which makes [`ImportScope`] suppress nothing.
+pub(crate) fn load_local_roots(conn: &Connection) -> HashSet<String> {
+    conn.query_row("SELECT value FROM index_meta WHERE key = 'local_crate_roots'", [], |row| {
+        row.get::<_, String>(0)
+    })
+    .optional()
+    .ok()
+    .flatten()
+    .map(|value| value.lines().filter(|line| !line.is_empty()).map(str::to_string).collect())
+    .unwrap_or_default()
+}
+
+/// The set of LOCAL crate roots in the corpus: the underscore-normalized crate name of every
+/// Cargo.toml package found under `root` (respecting .gitignore, so `target/` vendored manifests
+/// are skipped). A `use <root>::…` whose `<root>` is in this set — or is `crate`/`self`/`super` —
+/// names a local item; any other root names an external dependency.
+pub(crate) fn local_crate_roots(root: &Path) -> HashSet<String> {
+    let mut roots = HashSet::new();
+    // `parents(false)`: honor the indexed root's OWN .gitignore (skip its `target/` vendored
+    // manifests) but NOT ancestor gitignores above it — otherwise a root that happens to live under
+    // some ancestor's ignored path (e.g. the bench corpus under the repo's `target/`) is treated as
+    // wholly ignored and the walk yields nothing.
+    for entry in ignore::WalkBuilder::new(root).parents(false).build().flatten() {
+        if entry.path().file_name().and_then(|name| name.to_str()) != Some("Cargo.toml") {
+            continue;
+        }
+        let Ok(text) = std::fs::read_to_string(entry.path()) else { continue };
+        let Ok(value) = toml::from_str::<toml::Value>(&text) else { continue };
+        if let Some(name) = crate_root_name(&value) {
+            roots.insert(name);
+        }
+    }
+    roots
+}
+
+/// The crate root identifier used in `use` paths: `[lib].name` if set, else the package name with
+/// `-` normalized to `_` (Cargo's crate-name rule: `cargo-credential` → `cargo_credential`).
+fn crate_root_name(manifest: &toml::Value) -> Option<String> {
+    if let Some(lib_name) =
+        manifest.get("lib").and_then(|lib| lib.get("name")).and_then(|name| name.as_str())
+    {
+        return Some(lib_name.replace('-', "_"));
+    }
+    let package = manifest.get("package")?.get("name")?.as_str()?;
+    Some(package.replace('-', "_"))
+}
+
+/// The crate root of a `use` statement: its first path segment (`use cargo::core::…` → `cargo`,
+/// `pub use crate::x` → `crate`). `None` for a glob/unparseable form (we then suppress nothing).
+pub(crate) fn use_root(use_text: &str) -> Option<&str> {
+    let trimmed = use_text.trim_start();
+    let trimmed = trimmed.strip_prefix("pub ").map(str::trim_start).unwrap_or(trimmed);
+    let rest = trimmed.strip_prefix("use ")?.trim_start();
+    rest.split([':', ' ', '{', ';', '*']).next().filter(|segment| !segment.is_empty())
+}
+
+/// Per-file map of imported leaf name → the crate root it was imported from, plus the local-crate
+/// set, so resolution can tell an external-dependency import from a local one.
+#[derive(Default)]
+pub(crate) struct ImportScope {
+    local_roots: HashSet<String>,
+    by_file: HashMap<i64, HashMap<String, String>>,
+}
+
+impl ImportScope {
+    pub(crate) fn new(local_roots: HashSet<String>) -> Self {
+        Self { local_roots, by_file: HashMap::new() }
+    }
+
+    /// Record one `use <root>::…` binding for a file: the bound leaf name → its crate root.
+    pub(crate) fn add_import(&mut self, file_id: i64, leaf: &str, root: &str) {
+        self.by_file.entry(file_id).or_default().insert(leaf.to_string(), root.to_string());
+    }
+
+    /// Whether `name` in `file_id` was imported from an EXTERNAL dependency crate — not a local
+    /// workspace crate, not `crate`/`self`/`super`. When true, the name denotes that dependency's
+    /// item and must NOT bind to a local same-named symbol. Fails OPEN: with no local-crate set
+    /// (non-Cargo corpus / manifest scan found nothing), nothing is ever suppressed.
+    pub(crate) fn is_external_import(&self, file_id: i64, name: &str) -> bool {
+        if self.local_roots.is_empty() {
+            return false;
+        }
+        let Some(root) = self.by_file.get(&file_id).and_then(|names| names.get(name)) else {
+            return false;
+        };
+        !self.local_roots.contains(root) && !matches!(root.as_str(), "crate" | "self" | "super")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn use_root_extracts_first_segment() {
+        assert_eq!(use_root("use url::Url;"), Some("url"));
+        assert_eq!(use_root("use cargo::core::Workspace;"), Some("cargo"));
+        assert_eq!(use_root("pub use crate::a::B;"), Some("crate"));
+        assert_eq!(use_root("use std::path::{Path, PathBuf};"), Some("std"));
+        assert_eq!(use_root("use self::inner::X;"), Some("self"));
+    }
+
+    #[test]
+    fn external_import_distinguishes_local_from_dependency() {
+        let mut scope = ImportScope::new(HashSet::from(["cargo".to_string()]));
+        scope.add_import(1, "Url", "url"); // external dep
+        scope.add_import(1, "Workspace", "cargo"); // local workspace crate
+        scope.add_import(1, "Write", "std"); // std = external
+        scope.add_import(1, "Helper", "crate"); // local (crate-relative)
+        assert!(scope.is_external_import(1, "Url"), "url is an external dep");
+        assert!(scope.is_external_import(1, "Write"), "std is external");
+        assert!(!scope.is_external_import(1, "Workspace"), "cargo is a local workspace crate");
+        assert!(!scope.is_external_import(1, "Helper"), "crate-rooted is local");
+        assert!(
+            !scope.is_external_import(1, "Unimported"),
+            "an unimported name is never suppressed"
+        );
+        assert!(!scope.is_external_import(2, "Url"), "scoped per file");
+    }
+
+    #[test]
+    fn local_crate_roots_scans_workspace_manifests() {
+        let dir = std::env::temp_dir().join(format!("rr-crate-roots-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("crates/foo-bar/src")).unwrap();
+        std::fs::write(
+            dir.join("Cargo.toml"),
+            "[workspace]\nmembers=[\"crates/*\"]\n[package]\nname=\"cargo\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir.join("crates/foo-bar/Cargo.toml"), "[package]\nname=\"foo-bar\"\n")
+            .unwrap();
+        let roots = local_crate_roots(&dir);
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(roots.contains("cargo"), "top package; got {roots:?}");
+        assert!(roots.contains("foo_bar"), "hyphen→underscore normalized; got {roots:?}");
+    }
+
+    #[test]
+    fn empty_local_set_fails_open() {
+        let mut scope = ImportScope::new(HashSet::new());
+        scope.add_import(1, "Url", "url");
+        assert!(!scope.is_external_import(1, "Url"), "no manifests → suppress nothing");
+    }
+}

--- a/crates/rag-rat-core/src/index/edges/imports.rs
+++ b/crates/rag-rat-core/src/index/edges/imports.rs
@@ -75,6 +75,8 @@ fn crate_root_name(manifest: &toml::Value) -> Option<String> {
 pub(crate) fn parse_use(use_text: &str) -> Option<(String, Vec<String>)> {
     let rest = strip_use_visibility(use_text.trim())?;
     let tree = rest.strip_suffix(';').unwrap_or(rest).trim();
+    // Drop a leading path separator (`use ::external::X;`) so the root is `external`, not empty.
+    let tree = tree.strip_prefix("::").unwrap_or(tree);
     // First `::`-segment, then its first whitespace token — strips a brace-free root alias
     // (`use my_crate as alias;` → root `my_crate`, not `my_crate as alias`).
     let root = tree
@@ -224,16 +226,25 @@ impl ImportScope {
     /// (target_qualified_name `Url::parse`) where `Url` was `use`d from the external `url` crate.
     /// The leaf `parse` itself isn't imported, so [`is_external_import`] on the callee name misses
     /// it; the new scope-path lookup would otherwise bind `Url::parse` to an in-repo `Url::parse`.
-    /// Keyed on `target_qualified_name`'s `::`-head only (not the value-receiver hint), so a method
-    /// call on a local value (`url.parse()`, no `::` path) is never suppressed.
+    ///
+    /// Gated on a TYPE-LIKE (uppercase) head. `target_qualified_name` rewrites `.`→`::`
+    /// (helpers::target_qualified_name), so a value-receiver method call `config.build()` arrives
+    /// here as `config::build` and is INDISTINGUISHABLE from a path call by punctuation alone.
+    /// Suppressing it would drop a valid local method call whenever the receiver's name happens to
+    /// match an imported leaf. The realistic mis-bind this guards against is a PascalCase type
+    /// collision (`Url::parse` → a same-named local `impl Url`); module/value heads are snake_case,
+    /// so the uppercase gate keeps the type case and leaves lowercase heads to fall through
+    /// (fail open — a missed suppression, never a dropped local bind).
     pub(crate) fn is_external_qualified_root(
         &self,
         file_id: i64,
         target_qualified_name: Option<&str>,
     ) -> bool {
-        target_qualified_name
-            .and_then(|qualified| qualified.split_once("::"))
-            .is_some_and(|(root, _)| self.is_external_import(file_id, root))
+        target_qualified_name.and_then(|qualified| qualified.split_once("::")).is_some_and(
+            |(root, _)| {
+                root.starts_with(char::is_uppercase) && self.is_external_import(file_id, root)
+            },
+        )
     }
 }
 
@@ -280,6 +291,8 @@ mod tests {
         assert_eq!(parsed("use a::{b::{C, D}, E};"), Some(("a".into(), s(&["C", "D", "E"]))));
         // Glob binds no specific name (fail open).
         assert_eq!(parse_use("use foo::*;"), Some(("foo".to_string(), Vec::new())));
+        // Leading `::` (absolute path): root is the real crate, not empty.
+        assert_eq!(parsed("use ::external::X;"), Some(("external".into(), s(&["X"]))));
         // Not a `use` statement.
         assert_eq!(parse_use("mod foo;"), None);
     }

--- a/crates/rag-rat-core/src/index/edges/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/mod.rs
@@ -1,12 +1,15 @@
 mod extract;
 mod helpers;
+mod imports;
 mod intern;
 mod resolve;
+
 use std::collections::{BTreeSet, HashMap};
 use std::path::Path;
 
 pub(crate) use extract::*;
 pub(crate) use helpers::*;
+pub(crate) use imports::local_crate_roots;
 use intern::{OptSym, StrArena, Sym};
 pub(crate) use resolve::*;
 use rusqlite::{Connection, params};
@@ -411,4 +414,8 @@ pub(crate) struct ResolveSymbolRequest<'a> {
     receiver_hint: Option<&'a str>,
     source_file_id: i64,
     source_language: Option<&'a str>,
+    /// `name` is brought into this file by a `use` from an EXTERNAL dependency crate (#61 Project
+    /// B). When set, the name denotes that dependency's item, so resolution must NOT bind it to a
+    /// local same-named symbol — it stays unresolved (the oracle bins it `resolved-external`).
+    imported_external: bool,
 }

--- a/crates/rag-rat-core/src/index/edges/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/mod.rs
@@ -107,6 +107,7 @@ pub(crate) struct IndexedSymbol {
     language: String,
     name: String,
     qualified_name: String,
+    scope_path: String,
     kind: String,
     start_byte: usize,
     end_byte: usize,
@@ -133,6 +134,7 @@ impl IndexedSymbol {
                 language: language.as_str().to_string(),
                 name: symbol.name.clone(),
                 qualified_name: symbol.qualified_name.clone(),
+                scope_path: symbol.scope_path.clone(),
                 kind: symbol.kind.clone(),
                 start_byte: symbol.start_byte,
                 end_byte: symbol.end_byte,
@@ -167,6 +169,7 @@ struct CompactSymbol {
     language: Sym,
     name: Sym,
     qualified_name: Sym,
+    scope_path: Sym,
     kind: Sym,
     start_byte: usize,
     end_byte: usize,
@@ -182,6 +185,7 @@ impl CompactSymbol {
             language: arena.get(self.language).to_string(),
             name: arena.get(self.name).to_string(),
             qualified_name: arena.get(self.qualified_name).to_string(),
+            scope_path: arena.get(self.scope_path).to_string(),
             kind: arena.get(self.kind).to_string(),
             start_byte: self.start_byte,
             end_byte: self.end_byte,
@@ -294,6 +298,7 @@ impl FullRebuildGraph {
             language: self.arena.intern(language.as_str()),
             name: self.arena.intern(&symbol.name),
             qualified_name: self.arena.intern(&symbol.qualified_name),
+            scope_path: self.arena.intern(&symbol.scope_path),
             kind: self.arena.intern(&symbol.kind),
             start_byte: symbol.start_byte,
             end_byte: symbol.end_byte,
@@ -365,6 +370,11 @@ impl IndexedSymbol {
 pub(crate) struct SymbolIndex<'a> {
     /// Exact `qualified_name` match.
     by_qualified: HashMap<&'a str, Vec<&'a IndexedSymbol>>,
+    /// Exact `scope_path` match (semantic scope, e.g. `Workspace::new`). Tried before bare-name
+    /// fallback: it aligns with an edge's source-derived `target_qualified_name`, so the strong
+    /// qualified path fires for methods/nested items instead of collapsing to bare-name
+    /// collisions.
+    by_scope_path: HashMap<&'a str, Vec<&'a IndexedSymbol>>,
     /// Short-name fallback (`symbol.name`).
     by_name: HashMap<&'a str, Vec<&'a IndexedSymbol>>,
     /// Candidates for the `qualified_name.ends_with("::{q}")` suffix match, keyed by the last
@@ -378,16 +388,18 @@ pub(crate) struct SymbolIndex<'a> {
 impl<'a> SymbolIndex<'a> {
     fn build(symbols: &'a [IndexedSymbol]) -> Self {
         let mut by_qualified: HashMap<&str, Vec<&IndexedSymbol>> = HashMap::new();
+        let mut by_scope_path: HashMap<&str, Vec<&IndexedSymbol>> = HashMap::new();
         let mut by_name: HashMap<&str, Vec<&IndexedSymbol>> = HashMap::new();
         let mut by_qn_tail: HashMap<&str, Vec<&IndexedSymbol>> = HashMap::new();
         let mut file_language: HashMap<i64, &str> = HashMap::new();
         for symbol in symbols {
             by_qualified.entry(symbol.qualified_name.as_str()).or_default().push(symbol);
+            by_scope_path.entry(symbol.scope_path.as_str()).or_default().push(symbol);
             by_name.entry(symbol.name.as_str()).or_default().push(symbol);
             by_qn_tail.entry(qn_tail(&symbol.qualified_name)).or_default().push(symbol);
             file_language.entry(symbol.file_id).or_insert(symbol.language.as_str());
         }
-        Self { by_qualified, by_name, by_qn_tail, file_language }
+        Self { by_qualified, by_scope_path, by_name, by_qn_tail, file_language }
     }
 }
 

--- a/crates/rag-rat-core/src/index/edges/resolve.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve.rs
@@ -283,6 +283,38 @@ pub(crate) fn resolve_symbol<'a>(
         request.edge_kind != EdgeKind::UsesMacro.as_str() || symbol.kind == "macro"
     };
     if let Some(qualified) = request.target_qualified_name.filter(|value| !value.is_empty()) {
+        // Semantic SCOPE-PATH match first (#61). An edge's `target_qualified_name` is a source-code
+        // path (`Workspace::new`), which aligns with a symbol's `scope_path`
+        // (`core::Workspace::new`) — NOT with the file-path `qualified_name` below, which a
+        // source path never equals. Exact hit → `Exact`; a unique enclosing-scope suffix
+        // match → `Syntactic`. This is what lets the strong qualified path fire for
+        // methods/nested items instead of collapsing to bare-name matching. On ambiguity,
+        // fall through rather than guess.
+        if let Some(symbol) = index
+            .by_scope_path
+            .get(qualified)
+            .into_iter()
+            .flatten()
+            .copied()
+            .find(|symbol| kind_matches(symbol))
+        {
+            return Some((symbol, EdgeConfidence::Exact, "scope_exact"));
+        }
+        let scope_suffix = format!("::{qualified}");
+        let scope_matches = index
+            .by_name
+            .get(qn_tail(qualified))
+            .into_iter()
+            .flatten()
+            .copied()
+            .filter(|symbol| kind_matches(symbol) && symbol.scope_path.ends_with(&scope_suffix))
+            .collect::<Vec<_>>();
+        match scope_matches.as_slice() {
+            [symbol] => return Some((*symbol, EdgeConfidence::Syntactic, "scope_suffix")),
+            [_, ..] if same_logical_symbol(&scope_matches) =>
+                return Some((scope_matches[0], EdgeConfidence::Syntactic, "logical_variant")),
+            _ => {},
+        }
         // Exact qualified-name match (bucket entries already share `qualified_name == qualified`).
         if let Some(symbol) = index
             .by_qualified

--- a/crates/rag-rat-core/src/index/edges/resolve.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve.rs
@@ -515,9 +515,9 @@ pub(crate) fn allow_unqualified_fallback(
 /// exempt from crate-aware import suppression (#61 Project B) even when the file also imports a
 /// same-named external item.
 fn targets_local_qualified_path(target_qualified_name: Option<&str>) -> bool {
-    target_qualified_name.is_some_and(|path| {
-        path.starts_with("crate::") || path.starts_with("self::") || path.starts_with("super::")
-    })
+    target_qualified_name
+        .and_then(|path| path.split_once("::"))
+        .is_some_and(|(root, _)| matches!(root, "crate" | "self" | "super"))
 }
 pub(crate) fn is_external_rust_root(value: &str) -> bool {
     matches!(

--- a/crates/rag-rat-core/src/index/edges/resolve.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve.rs
@@ -86,7 +86,11 @@ pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
                 source_file_id,
                 source_language: index.file_language.get(&source_file_id).copied(),
                 imported_external: import_scope
-                    .is_external_import(source_file_id, short_name(&to_name)),
+                    .is_external_import(source_file_id, short_name(&to_name))
+                    || import_scope.is_external_qualified_root(
+                        source_file_id,
+                        target_qualified_name.as_deref(),
+                    ),
             },
             &index,
         );
@@ -229,7 +233,8 @@ pub(crate) fn resolve_and_insert_edges(
                 receiver_hint,
                 source_file_id: *file_id,
                 source_language: index.file_language.get(file_id).copied(),
-                imported_external: import_scope.is_external_import(*file_id, short_name(to_name)),
+                imported_external: import_scope.is_external_import(*file_id, short_name(to_name))
+                    || import_scope.is_external_qualified_root(*file_id, target_qualified_name),
             },
             &index,
         );
@@ -907,5 +912,32 @@ mod tests {
             Some(local),
             "`path` is the use PREFIX, not a binding — local `path` resolves"
         );
+    }
+
+    /// #61 Project B (Codex review resolve.rs:89): a path-qualified call whose RECEIVER is an
+    /// external import (`Url::parse`, with `use url::Url`) must not bind to an in-repo `Url::parse`
+    /// via the scope-path lookup — the leaf `parse` isn't itself imported, so the receiver root has
+    /// to be checked. A call through a LOCAL receiver (`Widget::parse`) still resolves.
+    #[test]
+    fn qualified_call_through_an_external_receiver_is_suppressed() {
+        let conn = seeded_conn();
+        set_local_crate_roots(&conn, "mycrate");
+        let user = add_file(&conn, "a.rs", NEW);
+        let defs = add_file(&conn, "b.rs", NEW);
+        add_import_edge(&conn, user, "Url", "use url::Url;");
+        add_symbol_scope(&conn, defs, "parse", "b.rs::parse_url", "Url::parse");
+        let widget = add_symbol_scope(&conn, defs, "parse", "b.rs::parse_widget", "Widget::parse");
+        let external = add_edge(&conn, user, "parse", "Url::parse");
+        let local = add_edge(&conn, user, "parse", "Widget::parse");
+
+        crate::index::install_scope_view(&conn, NEW, "").unwrap();
+        resolve_all_edges(&conn).unwrap();
+
+        let (to, _, resolution) = edge_state(&conn, external);
+        assert_eq!(to, None, "`Url::parse` (external receiver) must not bind a local `Url::parse`");
+        assert_eq!(resolution, "unresolved");
+
+        let (to, _, _) = edge_state(&conn, local);
+        assert_eq!(to, Some(widget), "`Widget::parse` (local receiver) resolves normally");
     }
 }

--- a/crates/rag-rat-core/src/index/edges/resolve.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve.rs
@@ -20,6 +20,28 @@ use super::*;
 pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
     let symbols = all_symbols(conn)?;
     let index = SymbolIndex::build(&symbols);
+    // Crate-aware import scope (#61 Project B): the active checkout's Imports edges → per-file
+    // {leaf name → crate root}, so resolution suppresses a local bind when the name is `use`d from
+    // an external dependency. Scoped via the `files` TEMP VIEW like the resolution query below.
+    let mut import_scope = imports::ImportScope::new(imports::load_local_roots(conn));
+    {
+        let mut stmt = conn.prepare(
+            "SELECT d.source_file_id, tn.value, d.evidence FROM edges_data d JOIN files ON \
+             files.id = d.source_file_id JOIN edge_strings ek ON ek.id = d.edge_kind_id LEFT JOIN \
+             edge_strings tn ON tn.id = d.to_name_id WHERE ek.value = 'imports'",
+        )?;
+        let mut rows = stmt.query([])?;
+        while let Some(row) = rows.next()? {
+            let file_id: i64 = row.get(0)?;
+            let to_name: Option<String> = row.get(1)?;
+            let evidence: Option<String> = row.get(2)?;
+            if let (Some(to_name), Some(evidence)) = (to_name, evidence)
+                && let Some(root) = imports::use_root(&evidence)
+            {
+                import_scope.add_import(file_id, short_name(to_name.trim()), root);
+            }
+        }
+    }
     // Read/write `edges_data` directly (#79): this loop is per-edge hot on every incremental
     // pass, so the strings it needs come from explicit dictionary joins and the verdict UPDATEs
     // write pre-interned ids instead of paying the view triggers' per-row probes. The `files`
@@ -66,6 +88,8 @@ pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
                 receiver_hint: receiver_hint.as_deref(),
                 source_file_id,
                 source_language: index.file_language.get(&source_file_id).copied(),
+                imported_external: import_scope
+                    .is_external_import(source_file_id, short_name(&to_name)),
             },
             &index,
         );
@@ -156,6 +180,23 @@ pub(crate) fn resolve_and_insert_edges(
     // dominant resolve-phase structure at kernel scale. Byte-identical: a `file_id` never recurs in
     // a later block, so per-file reset makes exactly the dedup decisions a global per-`file_id` set
     // would; `file_id` therefore drops out of the key (constant within each reset window).
+    // Crate-aware import scope (#61 Project B): map each file's `use`d leaf names to their crate
+    // root from the accumulated Imports edges, so resolution can suppress a bind to a local symbol
+    // when the name actually comes from an external dependency crate.
+    let mut import_scope = imports::ImportScope::new(imports::load_local_roots(conn));
+    for (file_id, candidate) in &edges {
+        if candidate.edge_kind == EdgeKind::Imports
+            && let Some(evidence) = arena.get_opt(candidate.evidence)
+            && let Some(root) = imports::use_root(evidence)
+        {
+            import_scope.add_import(
+                *file_id,
+                short_name(arena.get(candidate.to_name).trim()),
+                root,
+            );
+        }
+    }
+
     let mut seen = BTreeSet::new();
     let mut seen_file_id: Option<i64> = None;
     let mut interner = EdgeStringInterner::default();
@@ -196,6 +237,7 @@ pub(crate) fn resolve_and_insert_edges(
                 receiver_hint,
                 source_file_id: *file_id,
                 source_language: index.file_language.get(file_id).copied(),
+                imported_external: import_scope.is_external_import(*file_id, short_name(to_name)),
             },
             &index,
         );
@@ -282,6 +324,15 @@ pub(crate) fn resolve_symbol<'a>(
     let kind_matches = |symbol: &IndexedSymbol| {
         request.edge_kind != EdgeKind::UsesMacro.as_str() || symbol.kind == "macro"
     };
+    // Crate-aware import suppression (#61 Project B): the name is `use`d from an external
+    // dependency crate, so it denotes that dependency's item — never a local same-named symbol.
+    // Leave it unresolved (the SCIP oracle bins it `resolved-external`). This kills the
+    // external-dep collisions (`Url` → local instead of the `url` crate) WITHOUT touching
+    // correct cross-crate binds into local workspace crates (those roots are in the local-crate
+    // set, so not external).
+    if request.imported_external {
+        return None;
+    }
     if let Some(qualified) = request.target_qualified_name.filter(|value| !value.is_empty()) {
         // Semantic SCOPE-PATH match first (#61). An edge's `target_qualified_name` is a source-code
         // path (`Workspace::new`), which aligns with a symbol's `scope_path`

--- a/crates/rag-rat-core/src/index/edges/resolve.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve.rs
@@ -26,19 +26,16 @@ pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
     let mut import_scope = imports::ImportScope::new(imports::load_local_roots(conn));
     {
         let mut stmt = conn.prepare(
-            "SELECT d.source_file_id, tn.value, d.evidence FROM edges_data d JOIN files ON \
-             files.id = d.source_file_id JOIN edge_strings ek ON ek.id = d.edge_kind_id LEFT JOIN \
-             edge_strings tn ON tn.id = d.to_name_id WHERE ek.value = 'imports'",
+            "SELECT d.source_file_id, d.evidence FROM edges_data d JOIN files ON files.id = \
+             d.source_file_id JOIN edge_strings ek ON ek.id = d.edge_kind_id WHERE ek.value = \
+             'imports'",
         )?;
         let mut rows = stmt.query([])?;
         while let Some(row) = rows.next()? {
             let file_id: i64 = row.get(0)?;
-            let to_name: Option<String> = row.get(1)?;
-            let evidence: Option<String> = row.get(2)?;
-            if let (Some(to_name), Some(evidence)) = (to_name, evidence)
-                && let Some(root) = imports::use_root(&evidence)
-            {
-                import_scope.add_import(file_id, short_name(to_name.trim()), root);
+            let evidence: Option<String> = row.get(1)?;
+            if let Some(evidence) = evidence {
+                import_scope.add_use(file_id, &evidence);
             }
         }
     }
@@ -187,13 +184,8 @@ pub(crate) fn resolve_and_insert_edges(
     for (file_id, candidate) in &edges {
         if candidate.edge_kind == EdgeKind::Imports
             && let Some(evidence) = arena.get_opt(candidate.evidence)
-            && let Some(root) = imports::use_root(evidence)
         {
-            import_scope.add_import(
-                *file_id,
-                short_name(arena.get(candidate.to_name).trim()),
-                root,
-            );
+            import_scope.add_use(*file_id, evidence);
         }
     }
 
@@ -330,7 +322,12 @@ pub(crate) fn resolve_symbol<'a>(
     // external-dep collisions (`Url` → local instead of the `url` crate) WITHOUT touching
     // correct cross-crate binds into local workspace crates (those roots are in the local-crate
     // set, so not external).
-    if request.imported_external {
+    //
+    // EXCEPTION: an explicitly LOCAL-qualified reference (`crate::Url`, `self::Url`, `super::Url`)
+    // names a local item by construction — the qualifier overrides the bare-leaf import. Don't
+    // suppress it just because the file also imports a same-named external item; fall through so
+    // the qualified path can bind.
+    if request.imported_external && !targets_local_qualified_path(request.target_qualified_name) {
         return None;
     }
     if let Some(qualified) = request.target_qualified_name.filter(|value| !value.is_empty()) {
@@ -341,15 +338,25 @@ pub(crate) fn resolve_symbol<'a>(
         // match → `Syntactic`. This is what lets the strong qualified path fire for
         // methods/nested items instead of collapsing to bare-name matching. On ambiguity,
         // fall through rather than guess.
-        if let Some(symbol) = index
+        //
+        // `scope_path` is NOT file-unique (a workspace with two crates each declaring
+        // `mod core { impl Workspace { fn new } }` has two symbols with scope_path
+        // `core::Workspace::new`), so an exact hit may be ambiguous — DON'T stamp the first one
+        // `Exact`. Bind only a unique hit (or one logical symbol's variants); otherwise fall
+        // through to the file-path/bare-name logic, which is itself ambiguity-aware.
+        let scope_exact = index
             .by_scope_path
             .get(qualified)
             .into_iter()
             .flatten()
             .copied()
-            .find(|symbol| kind_matches(symbol))
-        {
-            return Some((symbol, EdgeConfidence::Exact, "scope_exact"));
+            .filter(|symbol| kind_matches(symbol))
+            .collect::<Vec<_>>();
+        match scope_exact.as_slice() {
+            [symbol] => return Some((*symbol, EdgeConfidence::Exact, "scope_exact")),
+            [_, ..] if same_logical_symbol(&scope_exact) =>
+                return Some((scope_exact[0], EdgeConfidence::Syntactic, "logical_variant")),
+            _ => {},
         }
         let scope_suffix = format!("::{qualified}");
         let scope_matches = index
@@ -502,6 +509,15 @@ pub(crate) fn allow_unqualified_fallback(
         return false;
     }
     true
+}
+/// Whether an edge's `target_qualified_name` is an explicitly LOCAL-rooted path (`crate::…`,
+/// `self::…`, `super::…`) — code disambiguating a local item with a qualifier. Such a reference is
+/// exempt from crate-aware import suppression (#61 Project B) even when the file also imports a
+/// same-named external item.
+fn targets_local_qualified_path(target_qualified_name: Option<&str>) -> bool {
+    target_qualified_name.is_some_and(|path| {
+        path.starts_with("crate::") || path.starts_with("self::") || path.starts_with("super::")
+    })
 }
 pub(crate) fn is_external_rust_root(value: &str) -> bool {
     matches!(
@@ -764,5 +780,132 @@ mod tests {
 
         let (to, _, _) = edge_state(&conn, ref_struct);
         assert_eq!(to, Some(gadget), "a type reference still resolves to a struct definition");
+    }
+
+    fn add_symbol_scope(
+        conn: &Connection,
+        file_id: i64,
+        name: &str,
+        qualified: &str,
+        scope_path: &str,
+    ) -> i64 {
+        conn.execute(
+            "INSERT INTO symbols(file_id, language, name, qualified_name, scope_path, kind, \
+             start_byte, end_byte, start_line, end_line) VALUES (?1, 'rust', ?2, ?3, ?4, \
+             'function', 0, 10, 1, 1)",
+            params![file_id, name, qualified, scope_path],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    /// #61: `scope_path` is NOT file-unique. When two symbols in different files share a scope_path,
+    /// an exact scope match is AMBIGUOUS and must NOT bind one as `Exact` — it falls through.
+    #[test]
+    fn scope_exact_does_not_bind_an_ambiguous_scope_path() {
+        let conn = seeded_conn();
+        let f1 = add_file(&conn, "a.rs", NEW);
+        let f2 = add_file(&conn, "b.rs", NEW);
+        let caller = add_file(&conn, "c.rs", NEW);
+        // Two distinct symbols sharing the SAME scope_path (a multi-crate same-name collision).
+        add_symbol_scope(&conn, f1, "build", "a.rs::build", "core::Builder::build");
+        add_symbol_scope(&conn, f2, "build", "b.rs::build", "core::Builder::build");
+        let edge = add_edge(&conn, caller, "build", "core::Builder::build");
+
+        crate::index::install_scope_view(&conn, NEW, "").unwrap();
+        resolve_all_edges(&conn).unwrap();
+
+        let (to, _, resolution) = edge_state(&conn, edge);
+        assert_eq!(to, None, "an ambiguous scope_path must not silently bind one at Exact");
+        assert_eq!(resolution, "unresolved");
+    }
+
+    /// The positive control: a UNIQUE scope_path binds `Exact` via `scope_exact`.
+    #[test]
+    fn scope_exact_binds_a_unique_scope_path() {
+        let conn = seeded_conn();
+        let defs = add_file(&conn, "b.rs", NEW);
+        let caller = add_file(&conn, "c.rs", NEW);
+        let target = add_symbol_scope(&conn, defs, "build", "b.rs::build", "core::Builder::build");
+        let edge = add_edge(&conn, caller, "build", "core::Builder::build");
+
+        crate::index::install_scope_view(&conn, NEW, "").unwrap();
+        resolve_all_edges(&conn).unwrap();
+
+        let (to, _, resolution) = edge_state(&conn, edge);
+        assert_eq!(to, Some(target));
+        assert_eq!(resolution, "scope_exact");
+    }
+
+    fn set_local_crate_roots(conn: &Connection, roots: &str) {
+        conn.execute(
+            "INSERT OR REPLACE INTO index_meta(key, value) VALUES ('local_crate_roots', ?1)",
+            params![roots],
+        )
+        .unwrap();
+    }
+
+    fn add_import_edge(conn: &Connection, source_file_id: i64, to_name: &str, evidence: &str) {
+        conn.execute(
+            "INSERT INTO edges(source_file_id, to_name, target_qualified_name, edge_kind, \
+             confidence, resolution, evidence) VALUES (?1, ?2, '', 'imports', 'NameOnly', \
+             'unresolved', ?3)",
+            params![source_file_id, to_name, evidence],
+        )
+        .unwrap();
+    }
+
+    /// #61 Project B: a bare reference to a name `use`d from an EXTERNAL crate (`url::Url`) must not
+    /// bind to a local same-named symbol — but an explicitly LOCAL-qualified `crate::Url` reference
+    /// in the same file still must (the qualifier overrides the import; Codex review
+    /// resolve.rs:334).
+    #[test]
+    fn external_import_suppresses_bare_but_not_locally_qualified() {
+        let conn = seeded_conn();
+        set_local_crate_roots(&conn, "mycrate");
+        let user = add_file(&conn, "a.rs", NEW);
+        let defs = add_file(&conn, "b.rs", NEW);
+        let local = add_symbol(&conn, defs, "Url", "crate::b::Url");
+        add_import_edge(&conn, user, "Url", "use url::Url;");
+        let bare = add_edge(&conn, user, "Url", "");
+        let qualified = add_edge(&conn, user, "Url", "crate::Url");
+
+        crate::index::install_scope_view(&conn, NEW, "").unwrap();
+        resolve_all_edges(&conn).unwrap();
+
+        let (to, _, resolution) = edge_state(&conn, bare);
+        assert_eq!(to, None, "a bare `Url` from the external `url` crate must not bind locally");
+        assert_eq!(resolution, "unresolved");
+
+        let (to, _, _) = edge_state(&conn, qualified);
+        assert_eq!(
+            to,
+            Some(local),
+            "explicit `crate::Url` names the local item despite the import"
+        );
+    }
+
+    /// #61 Project B (Codex review imports.rs:87 / resolve.rs:41): the imports edge stream emits the
+    /// path PREFIX of a braced `use` (`std::path`) as well as the real bindings, so the scope must
+    /// be built from parsed bindings — a local `path` must stay resolvable next to `use
+    /// std::path::{…}`.
+    #[test]
+    fn use_path_prefix_does_not_suppress_a_local_name() {
+        let conn = seeded_conn();
+        set_local_crate_roots(&conn, "mycrate");
+        let user = add_file(&conn, "a.rs", NEW);
+        let local = add_symbol(&conn, user, "path", "crate::a::path");
+        add_import_edge(&conn, user, "Path", "use std::path::{Path, PathBuf};");
+        let call = add_edge(&conn, user, "path", "");
+
+        crate::index::install_scope_view(&conn, NEW, "").unwrap();
+        resolve_all_edges(&conn).unwrap();
+
+        let (to, _, _) = edge_state(&conn, call);
+        assert_eq!(
+            to,
+            Some(local),
+            "`path` is the use PREFIX, not a binding — local `path` resolves"
+        );
     }
 }

--- a/crates/rag-rat-core/src/index/edges/resolve.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve.rs
@@ -925,10 +925,16 @@ mod tests {
         let user = add_file(&conn, "a.rs", NEW);
         let defs = add_file(&conn, "b.rs", NEW);
         add_import_edge(&conn, user, "Url", "use url::Url;");
+        // A lowercase external import — a value-receiver method call must NOT be suppressed.
+        add_import_edge(&conn, user, "config", "use external_dep::config;");
         add_symbol_scope(&conn, defs, "parse", "b.rs::parse_url", "Url::parse");
         let widget = add_symbol_scope(&conn, defs, "parse", "b.rs::parse_widget", "Widget::parse");
+        // `config.build()` extracts as tqn `config::build` (helpers rewrites `.`→`::`); the head is
+        // a local value receiver, not an external type path.
+        let build = add_symbol_scope(&conn, defs, "build", "b.rs::cfg_build", "config::build");
         let external = add_edge(&conn, user, "parse", "Url::parse");
         let local = add_edge(&conn, user, "parse", "Widget::parse");
+        let value_recv = add_edge(&conn, user, "build", "config::build");
 
         crate::index::install_scope_view(&conn, NEW, "").unwrap();
         resolve_all_edges(&conn).unwrap();
@@ -939,5 +945,12 @@ mod tests {
 
         let (to, _, _) = edge_state(&conn, local);
         assert_eq!(to, Some(widget), "`Widget::parse` (local receiver) resolves normally");
+
+        let (to, _, _) = edge_state(&conn, value_recv);
+        assert_eq!(
+            to,
+            Some(build),
+            "`config.build()` (lowercase value receiver) must NOT be suppressed by the import"
+        );
     }
 }

--- a/crates/rag-rat-core/src/index/internals.rs
+++ b/crates/rag-rat-core/src/index/internals.rs
@@ -295,15 +295,16 @@ impl IndexDatabase {
         let mut symbol_ids = Vec::with_capacity(symbols.len());
         for symbol in symbols {
             conn.prepare_cached(
-                "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte, \
-                 end_byte, start_line, end_line, signature, docs)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                "INSERT INTO symbols(file_id, language, name, qualified_name, scope_path, kind, \
+                 start_byte, end_byte, start_line, end_line, signature, docs)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
             )?
             .execute(params![
                 file_id,
                 language.as_str(),
                 symbol.name,
                 symbol.qualified_name,
+                symbol.scope_path,
                 symbol.kind,
                 i64::try_from(symbol.start_byte)?,
                 i64::try_from(symbol.end_byte)?,

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -680,7 +680,7 @@ fn migration_creates_oracle_side_tables() {
         assert!(columns.contains(&expected.to_string()), "edge_oracle missing {expected}");
     }
 
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 20);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 21);
 }
 
 /// The V019 moniker migration: the `logical_symbol_monikers` table (STRICT, NO foreign key — see

--- a/crates/rag-rat-core/src/index/parser.rs
+++ b/crates/rag-rat-core/src/index/parser.rs
@@ -8,6 +8,14 @@ use crate::language::Language;
 pub struct ParsedSymbol {
     pub name: String,
     pub qualified_name: String,
+    /// The SEMANTIC scope path: the symbol's enclosing type/module/namespace names joined with
+    /// `::`, ending in its own name (a method `new` in `impl Workspace` in `mod core` →
+    /// `core::Workspace::new`; a free function → just its name). Distinct from
+    /// `qualified_name` (file-path form, the stable identity for logical-symbol grouping +
+    /// memory anchoring). `scope_path` ALIGNS with an edge's source-derived
+    /// `target_qualified_name` (`Workspace::new`), so the resolver's strong qualified-match
+    /// path fires instead of collapsing to collision-prone bare-name matching (#61).
+    pub scope_path: String,
     pub kind: String,
     pub start_byte: usize,
     pub end_byte: usize,
@@ -258,6 +266,44 @@ fn has_body(node: Node<'_>) -> bool {
     node.child_by_field_name("body").is_some()
 }
 
+/// The semantic scope path for a symbol node: enclosing type/module/namespace/trait names
+/// (outermost first) joined with `::`, ending in the symbol's own `name`. A top-level free function
+/// or type yields just its name. See [`ParsedSymbol::scope_path`].
+fn scope_path(language: Language, node: Node<'_>, text: &str, name: &str) -> String {
+    let mut segments = Vec::new();
+    let mut current = node.parent();
+    while let Some(parent) = current {
+        if let Some(segment) = scope_segment(language, parent, text) {
+            segments.push(segment);
+        }
+        current = parent.parent();
+    }
+    segments.reverse();
+    segments.push(name.to_string());
+    segments.join("::")
+}
+
+/// The scope-name contributed by an ENCLOSING node, if it introduces a named scope (a module, the
+/// type an `impl` is for, a class/trait/namespace). Returns `None` for nodes that don't nest a
+/// scope, so the walk skips blocks/expressions and only collects real path segments.
+fn scope_segment(language: Language, node: Node<'_>, text: &str) -> Option<String> {
+    let name_node = match (language, node.kind()) {
+        (Language::Rust, "mod_item" | "trait_item") => child_name(node)?,
+        (Language::Rust, "impl_item") => impl_name(node)?,
+        (Language::TypeScript, "class_declaration" | "interface_declaration") => child_name(node)?,
+        (Language::TypeScript, "internal_module" | "module" | "namespace_declaration") =>
+            child_name(node)?,
+        (Language::Kotlin, "class_declaration" | "object_declaration") => child_name(node)?,
+        (Language::Cpp, "namespace_definition") => child_name(node)?,
+        (
+            Language::C | Language::Cpp,
+            "struct_specifier" | "union_specifier" | "class_specifier",
+        ) if has_body(node) => child_name(node)?,
+        _ => return None,
+    };
+    node_text(name_node, text)
+}
+
 fn companion_name(node: Node<'_>) -> Option<Node<'_>> {
     for index in 0..node.child_count() {
         let Some(index) = u32::try_from(index).ok() else {
@@ -335,8 +381,10 @@ fn make_symbol(
     // node (O(1) struct field) instead of rescanning the file text for newlines. `row` is 0-based.
     let start_line = node.start_position().row + 1;
     let end_line = node.end_position().row + 1;
+    let scope_path = scope_path(language, node, text, &name);
     ParsedSymbol {
         qualified_name: format!("{}::{name}", path.to_string_lossy().replace('\\', "/")),
+        scope_path,
         name,
         kind: kind.to_string(),
         start_byte,

--- a/crates/rag-rat-core/src/index/parser_tests.rs
+++ b/crates/rag-rat-core/src/index/parser_tests.rs
@@ -219,6 +219,37 @@ fn assert_symbol(symbols: &[parser::ParsedSymbol], kind: &str, name: &str) {
     );
 }
 
+/// #61: `scope_path` encodes the enclosing semantic scope (module + impl type), ending in the
+/// symbol's own name — the resolution key that aligns with an edge's source-derived
+/// `target_qualified_name`. A top-level item's scope_path is just its name.
+#[test]
+fn scope_path_encodes_enclosing_module_and_impl_type() {
+    let text = "\
+mod core {
+    pub struct Client;
+    impl Client {
+        pub fn new() -> Self { Self }
+    }
+}
+pub fn entry() {}
+";
+    let symbols = parser::parse_symbols(Path::new("src/lib.rs"), Language::Rust, text).unwrap();
+    let scope_of = |name: &str, kind: &str| {
+        symbols
+            .iter()
+            .find(|s| s.name == name && s.kind == kind)
+            .map(|s| s.scope_path.as_str())
+            .unwrap_or("<missing>")
+    };
+    assert_eq!(
+        scope_of("new", "function"),
+        "core::Client::new",
+        "method carries module + impl type"
+    );
+    assert_eq!(scope_of("Client", "struct"), "core::Client", "type carries its module");
+    assert_eq!(scope_of("entry", "function"), "entry", "a top-level item is just its name");
+}
+
 fn assert_no_symbol(symbols: &[parser::ParsedSymbol], kind: &str, name: &str) {
     assert!(
         !symbols.iter().any(|symbol| symbol.kind == kind && symbol.name == name),

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -53,6 +53,13 @@ impl IndexDatabase {
             mem_trace("after clear_full_rebuild_tables (purge)");
             db.set_meta("source_root", &config.root.display().to_string())?;
             db.storage.set_source_root(config.root.clone());
+            // Local crate roots (#61 Project B): the workspace's own crate names, for crate-aware
+            // import resolution. Written BEFORE index_targets so the resolve pass sees them.
+            let crate_roots = super::edges::local_crate_roots(&config.root);
+            db.set_meta(
+                "local_crate_roots",
+                &crate_roots.into_iter().collect::<Vec<_>>().join("\n"),
+            )?;
             db.write_git_meta(&config.root)?;
             let indexed = db.index_targets_with_progress(config, &mut progress)?;
             mem_trace("after index_targets (edges resolved+inserted)");

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -441,6 +441,17 @@ pub(crate) fn apply_symbol_line_spans(conn: &Connection) -> rusqlite::Result<()>
     Ok(())
 }
 
+pub(crate) fn apply_symbol_scope_path(conn: &Connection) -> rusqlite::Result<()> {
+    // The symbol's SEMANTIC scope path (enclosing type/module/namespace names + own name, e.g.
+    // `Workspace::new`) — the resolver's qualified-match key, aligned with edges' source-derived
+    // `target_qualified_name`. Distinct from `qualified_name` (file-path form, kept as the stable
+    // identity for logical-symbol grouping + memory anchoring, untouched here). NULLABLE: existing
+    // rows read as `COALESCE(scope_path,'')` until a full reindex repopulates real values; the
+    // resolver simply skips the scope path until then (#61).
+    add_column_if_missing(conn, "symbols", "scope_path", "TEXT")?;
+    Ok(())
+}
+
 pub(crate) fn apply_edge_callee_byte_range(conn: &Connection) -> rusqlite::Result<()> {
     // Byte range of the callee identifier token on symbol-referencing edges (the SCIP-oracle
     // prerequisite, #67). `source_start_byte`/`source_end_byte` cover the whole call_expression;
@@ -880,6 +891,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_018_ID => Some(18),
             MIGRATION_019_ID => Some(19),
             MIGRATION_020_ID => Some(20),
+            MIGRATION_021_ID => Some(21),
             _ => None,
         })
         .max()
@@ -909,6 +921,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_018_ID
             | MIGRATION_019_ID
             | MIGRATION_020_ID
+            | MIGRATION_021_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -935,6 +948,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_018_ID => migration.checksum != MIGRATION_018_CHECKSUM,
         MIGRATION_019_ID => migration.checksum != MIGRATION_019_CHECKSUM,
         MIGRATION_020_ID => migration.checksum != MIGRATION_020_CHECKSUM,
+        MIGRATION_021_ID => migration.checksum != MIGRATION_021_CHECKSUM,
         _ => false,
     }
 }

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use migrations::*;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 20;
+pub const LATEST_SCHEMA_VERSION: u32 = 21;
 const DIRTY_MIGRATION_ID: &str = "__dirty__";
 const MIGRATION_001_ID: &str = "001_sqlite_storage_baseline";
 const MIGRATION_001_CHECKSUM: &str = "sha256:rag-rat-sqlite-baseline-v1";
@@ -88,6 +88,10 @@ const MIGRATION_020_ID: &str = "020_edge_string_interning";
 const MIGRATION_020_CHECKSUM: &str = "sha256:rag-rat-edge-string-interning-v20";
 const MIGRATION_020_DESCRIPTION: &str = "Normalize repeated edge strings into the edge_strings \
                                          dictionary behind the edges compatibility view (#79)";
+const MIGRATION_021_ID: &str = "021_symbol_scope_path";
+const MIGRATION_021_CHECKSUM: &str = "sha256:rag-rat-symbol-scope-path-v21";
+const MIGRATION_021_DESCRIPTION: &str =
+    "Add symbols.scope_path (semantic enclosing-scope path) for scope-aware edge resolution (#61)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -180,6 +184,8 @@ pub fn apply(conn: &Connection) -> rusqlite::Result<()> {
     record_migration(conn, MIGRATION_019_ID, MIGRATION_019_CHECKSUM, MIGRATION_019_DESCRIPTION)?;
     apply_edge_string_interning(conn)?;
     record_migration(conn, MIGRATION_020_ID, MIGRATION_020_CHECKSUM, MIGRATION_020_DESCRIPTION)?;
+    apply_symbol_scope_path(conn)?;
+    record_migration(conn, MIGRATION_021_ID, MIGRATION_021_CHECKSUM, MIGRATION_021_DESCRIPTION)?;
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -2196,7 +2196,10 @@ fn indexes_real_world_rust_graph_patterns() {
 
     assert_edge(&db, "src/lib.rs", "worker", "imports", "Syntactic");
     assert_edge(&db, "src/lib.rs", "Worker", "exports", "Syntactic");
-    assert_edge(&db, "entry", "new", "calls_name", "NameOnly");
+    // `Worker::new()` / `Client::new()` now resolve via the semantic scope path (`Worker::new` /
+    // `Client::new`) → Exact, where bare-name matching previously left two same-named `new` methods
+    // ambiguous (NameOnly) (#61 scope-path resolution).
+    assert_edge(&db, "entry", "new", "calls_name", "Exact");
     assert_edge(&db, "entry", "Client", "references_type", "Syntactic");
     assert_edge(&db, "drive", "serve", "calls_name", "NameOnly");
     assert_edge(&db, "drive", "GenericRunner", "references_type", "Syntactic");
@@ -3329,9 +3332,12 @@ fn indexes_real_world_kotlin_graph_patterns() {
     assert_edge(&db, "src/Main.kt", "ExternalFactory", "imports", "NameOnly");
     assert_edge(&db, "Worker", "companion", "contains", "Exact");
     assert_edge(&db, "companion", "create", "contains", "Exact");
-    assert_edge(&db, "syncOnce", "create", "calls_name", "Syntactic");
+    // `Worker.create()` / `SingletonRunner.run()` now resolve via the semantic scope path
+    // (`Worker::create` / `SingletonRunner::run`) → Exact, where they were a weaker suffix match
+    // before (#61 scope-path resolution).
+    assert_edge(&db, "syncOnce", "create", "calls_name", "Exact");
     assert_edge(&db, "syncOnce", "Worker", "references_type", "Syntactic");
-    assert_edge(&db, "syncOnce", "run", "calls_name", "Syntactic");
+    assert_edge(&db, "syncOnce", "run", "calls_name", "Exact");
     assert_edge(&db, "syncOnce", "SingletonRunner", "references_type", "Syntactic");
     assert_edge(&db, "syncOnce", "ExternalFactory", "calls_name", "NameOnly");
     assert_edge(&db, "syncOnce", "ExternalFactory", "references_type", "NameOnly");

--- a/crates/rag-rat-core/src/index/symbols.rs
+++ b/crates/rag-rat-core/src/index/symbols.rs
@@ -13,6 +13,9 @@ pub struct SymbolFact {
 pub struct Symbol {
     pub name: String,
     pub qualified_name: String,
+    /// Semantic scope path (see [`parser::ParsedSymbol::scope_path`]) — the resolution key that
+    /// aligns with edges' source-derived `target_qualified_name`.
+    pub scope_path: String,
     pub kind: String,
     pub start_byte: usize,
     pub end_byte: usize,
@@ -35,6 +38,7 @@ pub fn from_parsed(parsed: &[parser::ParsedSymbol]) -> Vec<Symbol> {
         .map(|symbol| Symbol {
             name: symbol.name.clone(),
             qualified_name: symbol.qualified_name.clone(),
+            scope_path: symbol.scope_path.clone(),
             kind: symbol.kind.clone(),
             start_byte: symbol.start_byte,
             end_byte: symbol.end_byte,

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -109,29 +109,36 @@ indexed `.rs` file (no subset caveat).
 |---|---|---|
 | Rust files indexed | 1,349 | the cargo workspace |
 | Heuristic `calls_name` resolved (in-corpus) | 14.6% | most calls in cargo target std/deps, which a single-repo name resolver can't bind in-corpus |
-| **Compiler precision (blended)** | **79.8%** | confirmed / (confirmed + contradicted), over every judged edge kind |
-| — `calls_name` | **87.5%** | function-call resolution (13,469 / 1,918) |
-| — `references_type` | **72.5%** | type references (12,189 / 4,623) — after the type-only resolution fix below |
+| **Compiler precision (blended)** | **81.4%** | confirmed / (confirmed + contradicted), over every judged edge kind |
+| — `calls_name` | **88.6%** | function-call resolution (15,907 / 2,045) |
+| — `references_type` | **73.4%** | type references (12,012 / 4,356) — after the resolution fixes below |
 | **Call recall** | **95.4%** | covered / (covered + oracle-only) — the graph had a `calls_name` edge for ~all calls the compiler saw |
-| Confirmed | 26,146 | heuristic target matched the compiler's |
-| Contradicted | 7,198 | heuristic bound a different target than the compiler |
-| Upgraded | 58,994 | edges promoted to `Compiler`-tier confidence |
-| Resolved-external | 67,589 | calls the compiler bound to std / a dependency crate (the bulk of cargo's calls) |
+| Confirmed | 28,216 | heuristic target matched the compiler's |
+| Contradicted | 6,437 | heuristic bound a different target than the compiler |
+| Upgraded | 56,916 | edges promoted to `Compiler`-tier confidence |
+| Resolved-external | 68,358 | calls/refs the compiler bound to std / a dependency crate (the bulk of cargo's) |
 
-Read the two side by side: **call resolution `calls_name` — C 91.8% vs Rust 87.5%**; blended C 91.5%
-vs Rust 79.8%. Rust's lower blend is its `references_type` at 72.5% — a softer version of the same
-type-resolution challenge. Two things keep it there: (1) **cross-crate workspace references** — a
-type defined in the `cargo` crate but referenced from a sibling member (`benchsuite`, tests) is
-emitted by rust-analyzer as an external moniker with no local definition, so the oracle can't credit
-rag-rat's (often correct) in-corpus binding — a measurement floor, not a real error; (2) **external-
-dependency name collisions** — a bare `Url`/`Write` bound to a local same-named type when the real
-target is the `url` crate or `std::io::Write`, which needs `use`-aware resolution to fix. The
-type-only resolution fix (a `references_type` reference no longer binds to a non-type symbol — an
-`impl` block, module, etc. — in Rust/C/C++) removed 621 such mis-binds and lifted `references_type`
-70.2% → 72.5%. Recall: C 44.3% (oracle sees only the compiled `defconfig` subset) vs Rust 95.4%
-(rust-analyzer sees the whole workspace). The low 14.6% in-corpus call rate is not a weakness: cargo
-calls overwhelmingly into `std`/dependency crates, and the oracle correctly bins **67.6k** of those
-as `resolved-external` rather than forcing a wrong in-corpus target.
+Read the two side by side: **call resolution `calls_name` — C 91.8% vs Rust 88.6%**; blended C 91.5%
+vs Rust 81.4%. Rust's lower blend is its `references_type` at 73.4%. Three resolution fixes lifted the
+Rust numbers from a 78.4% blend:
+- **type-only resolution** (a `references_type` reference no longer binds to a non-type symbol — an
+  `impl` block, module, etc. — in Rust/C/C++): removed 621 mis-binds, `references_type` 70.2% → 72.5%.
+- **semantic scope paths** (symbols carry a `scope_path` like `Workspace::new` that aligns with an
+  edge's source path, so the strong qualified match fires for methods instead of bare-name guessing):
+  `calls_name` 87.5% → 88.6%, blended → 80.9%.
+- **crate-aware import scope** (a name `use`d from an external dependency crate isn't bound to a local
+  same-named symbol — local workspace crates are told apart from deps by scanning the corpus's
+  Cargo.toml manifests): `references_type` 72.5% → 73.4%, blended → 81.4%.
+
+What keeps `references_type` at ~73% rather than higher is mostly **not a resolver bug**: a large
+share is **cross-crate workspace references** — a type defined in the `cargo` crate but referenced
+from a sibling member is emitted by rust-analyzer as an external moniker with no local definition, so
+the oracle can't credit rag-rat's *correct* in-corpus binding. That's a measurement floor; real
+`references_type` precision is meaningfully above the reported number. Recall: C 44.3% (oracle sees
+only the compiled `defconfig` subset) vs Rust 95.4% (rust-analyzer sees the whole workspace). The low
+14.6% in-corpus call rate is not a weakness: cargo calls overwhelmingly into `std`/dependency crates,
+and the oracle correctly bins **68k** of those as `resolved-external` rather than forcing a wrong
+in-corpus target.
 
 Run them yourself: `oracle-kernel.yml` / `tools/kernel-c-oracle.sh` (C) and `oracle-rust.yml` /
 `tools/rust-scip-oracle.sh` (Rust). Both pin the SCIP indexer via `tools/bench.Containerfile`, so the


### PR DESCRIPTION
Pushes heuristic edge resolution closer to compiler-grade on Rust, validated by the SCIP oracle (rust-analyzer over rust-lang/cargo). Two additive resolver improvements; one explored-and-rejected.

## Project A — semantic scope paths
Symbols carry a new `scope_path` (migration **V021**, additive) = enclosing module/impl/class/namespace names + own name (e.g. `core::Workspace::new`), computed by walking enclosing scope nodes. It *aligns* with an edge's source-derived `target_qualified_name`, so the resolver's strong qualified match fires for methods/nested items instead of collapsing to bare-name matching. `qualified_name` (file-path form — the stable identity for logical-symbol grouping + memory anchoring) is **untouched**, so there's no blast radius there.

- `calls_name` **87.5% → 88.6%**; ~3,159 edges now resolve via `scope_exact` (compiler-accurate); the graph points at the *right* same-named method.

## Project B — crate-aware import scope (suppression)
A name `use`d from an **external dependency** crate no longer binds to a local same-named symbol (the import says where it comes from). Local workspace crates are told apart from dependencies by scanning the corpus's `Cargo.toml` manifests (`toml` + `ignore`, no `cargo` invocation), stored as `index_meta.local_crate_roots`. Fail-open: no manifests → suppress nothing, so C/TS/Kotlin and non-Cargo corpora are unaffected.

- `references_type` **72.5% → 73.4%**, blended **80.9% → 81.4%**.

## Net (Rust, rust-analyzer oracle on cargo)
Blended **78.4% → 81.4%**, `calls_name` **87.5% → 88.6%**, `references_type` **70.2% → 73.4%**.

## Explored and rejected (not in this PR)
Positive import resolution (disambiguate a bare name via its `use`-path module) **regressed** precision (`references_type` 73.4% → 69.3%) — file-path module matching is too loose vs Rust's public/re-export module paths. Reverted; recorded as a rejected alternative. A correct version needs real module/re-export modeling.

## Notes
- The residual `references_type` gap is dominated by an **oracle-measurement floor** (cross-crate workspace refs the heuristic resolves correctly but rust-analyzer emits as external monikers with no local def) — not a resolver bug. A follow-up will credit those.
- 310 core tests pass (new `imports.rs`, `scope_path`, parser, and resolver tests); fmt + clippy clean.

Refs #61.