### PR TITLE
Harden crate-aware import scope: evidence truncation, path-dep aliases, bin-only packages (#97)

### DIFF
--- a/crates/rag-rat-core/src/index/edges/extract.rs
+++ b/crates/rag-rat-core/src/index/edges/extract.rs
@@ -141,13 +141,20 @@ pub(crate) fn rust_edges(
         "use_declaration" => {
             let names = identifiers_under(node, text);
             let is_reexport = node_text(node, text).trim_start().starts_with("pub use ");
+            // The crate-aware import scope rebuilds its per-file {leaf → root} map by re-parsing an
+            // Imports edge's `evidence` with `imports::parse_use` (#61). The default
+            // `edge_evidence` truncates to 240 chars, which drops the late leaves of a
+            // long braced `use foo::{…, X}` — those names then go un-suppressed (#97
+            // item 1). Carry the FULL normalized use text on Imports edges so every
+            // leaf survives the round trip.
+            let use_evidence = use_declaration_evidence(node, text);
             for name in names {
                 if !is_rust_path_keyword(&name) {
-                    out.push(file_edge(
+                    out.push(file_edge_with_evidence(
                         path,
                         node,
-                        text,
                         name,
+                        Some(use_evidence.clone()),
                         EdgeKind::Imports,
                         EdgeConfidence::NameOnly,
                     ));
@@ -583,12 +590,32 @@ pub(crate) fn file_edge(
     edge_kind: EdgeKind,
     confidence: EdgeConfidence,
 ) -> EdgeCandidate {
+    file_edge_with_evidence(
+        path,
+        node,
+        to_name,
+        Some(edge_evidence(node, text)),
+        edge_kind,
+        confidence,
+    )
+}
+/// Like [`file_edge`] but with caller-supplied evidence — used by the `use_declaration` arm to
+/// carry the UNTRUNCATED use text so the crate-aware import scope can re-parse every braced leaf
+/// (#97).
+pub(crate) fn file_edge_with_evidence(
+    path: &Path,
+    node: Node<'_>,
+    to_name: String,
+    evidence: Option<String>,
+    edge_kind: EdgeKind,
+    confidence: EdgeConfidence,
+) -> EdgeCandidate {
     EdgeCandidate {
         from_symbol_id: None,
         from_name: Some(path.to_string_lossy().replace('\\', "/")),
         to_name,
         target_qualified_name: None,
-        evidence: Some(edge_evidence(node, text)),
+        evidence,
         receiver_hint: None,
         source_span: span_for_node(node),
         // File-level edges (imports / exports / mod) have no callee identifier to anchor (#67).

--- a/crates/rag-rat-core/src/index/edges/extract.rs
+++ b/crates/rag-rat-core/src/index/edges/extract.rs
@@ -145,16 +145,22 @@ pub(crate) fn rust_edges(
             // Imports edge's `evidence` with `imports::parse_use` (#61). The default
             // `edge_evidence` truncates to 240 chars, which drops the late leaves of a
             // long braced `use foo::{…, X}` — those names then go un-suppressed (#97
-            // item 1). Carry the FULL normalized use text on Imports edges so every
-            // leaf survives the round trip.
-            let use_evidence = use_declaration_evidence(node, text);
+            // item 1). One edge carrying the FULL normalized use text is enough:
+            // `parse_use` returns EVERY leaf from it, so a single `add_use`
+            // populates the whole {leaf → root} map for this `use`. So attach the full text to only
+            // the FIRST emitted Imports edge and let the rest carry the standard truncated evidence
+            // — cloning the untruncated text into every leaf's edge would expand a few-hundred-KB
+            // `use` into GBs of transient `String`s before the interner dedupes them (#97 item 3).
+            let mut full_use_evidence = Some(use_declaration_evidence(node, text));
             for name in names {
                 if !is_rust_path_keyword(&name) {
+                    let evidence =
+                        full_use_evidence.take().unwrap_or_else(|| edge_evidence(node, text));
                     out.push(file_edge_with_evidence(
                         path,
                         node,
                         name,
-                        Some(use_evidence.clone()),
+                        Some(evidence),
                         EdgeKind::Imports,
                         EdgeConfidence::NameOnly,
                     ));

--- a/crates/rag-rat-core/src/index/edges/helpers.rs
+++ b/crates/rag-rat-core/src/index/edges/helpers.rs
@@ -183,6 +183,14 @@ pub(crate) fn edge_evidence(node: Node<'_>, text: &str) -> String {
         .take(240)
         .collect()
 }
+/// Whitespace-normalized but UNTRUNCATED node text, for a `use_declaration`'s evidence. The
+/// crate-aware import scope re-parses this with `imports::parse_use` (#61); the 240-char cap in
+/// [`edge_evidence`] would drop the late leaves of a long braced `use foo::{…, X}`, leaving those
+/// names un-suppressed (#97 item 1). A `use` statement is bounded and small, so storing it in full
+/// is cheap.
+pub(crate) fn use_declaration_evidence(node: Node<'_>, text: &str) -> String {
+    node_text(node, text).split_whitespace().collect::<Vec<_>>().join(" ")
+}
 pub(crate) fn short_name(name: &str) -> &str {
     name.rsplit([':', '.', '#', '/']).find(|part| !part.is_empty()).unwrap_or(name)
 }

--- a/crates/rag-rat-core/src/index/edges/imports.rs
+++ b/crates/rag-rat-core/src/index/edges/imports.rs
@@ -51,10 +51,13 @@ pub(crate) fn local_crate_roots(root: &Path) -> HashSet<String> {
         // Renamed / path-dependency aliases: `local_alias = { path = "…", package = "real" }` lets
         // the import KEY (`use local_alias::…`) differ from the package's canonical crate name, so
         // the key must itself count as a local root or the bare reference OVER-suppresses (a
-        // dropped LOCAL bind — the harmful direction, #97 item 2). The key is the crate
-        // root written in source, so it needs no `-`→`_` normalization (a `use` path can't
-        // contain `-`).
-        collect_path_dependency_aliases(&manifest, &mut roots);
+        // dropped LOCAL bind — the harmful direction, #97 item 2). The key is `-`→`_` normalized
+        // before insertion because a dependency KEY may contain `-` (`foo-bar = { path = … }`) yet
+        // Rust imports it as `use foo_bar::…` (RFC 940 / Cargo's crate-name rule), the same
+        // normalization `lib_crate_root_name` applies to package names.
+        if let Some(manifest_dir) = manifest_dir {
+            collect_path_dependency_aliases(&manifest, manifest_dir, root, &mut roots);
+        }
     }
     roots
 }
@@ -65,14 +68,24 @@ pub(crate) fn local_crate_roots(root: &Path) -> HashSet<String> {
 /// and no autodiscovered `src/lib.rs`): such a package is not importable, so contributing its name
 /// as a root would wrongly mark a same-named EXTERNAL dependency as local and skip suppression
 /// (#97 item 3). The `src/lib.rs` probe mirrors Cargo's lib autodiscovery and is resolved relative
-/// to the manifest directory.
+/// to the manifest directory; `[package] autolib = false` disables that autodiscovery, so a stray
+/// `src/lib.rs` in a bin-only package does NOT count as a lib target (#97 item 4). An EXPLICIT
+/// `[lib]` table still contributes regardless of `autolib` — that flag only governs autodiscovery.
 fn lib_crate_root_name(manifest: &toml::Value, manifest_dir: Option<&Path>) -> Option<String> {
     let lib = manifest.get("lib");
     if let Some(lib_name) = lib.and_then(|lib| lib.get("name")).and_then(|name| name.as_str()) {
         return Some(lib_name.replace('-', "_"));
     }
-    let has_lib_target =
-        lib.is_some() || manifest_dir.is_some_and(|dir| dir.join("src").join("lib.rs").is_file());
+    // `[package] autolib = false` turns off `src/lib.rs` autodiscovery; an explicit `[lib]` table
+    // is still honored above and below.
+    let autolib_enabled = manifest
+        .get("package")
+        .and_then(|package| package.get("autolib"))
+        .and_then(toml::Value::as_bool)
+        != Some(false);
+    let has_lib_target = lib.is_some()
+        || (autolib_enabled
+            && manifest_dir.is_some_and(|dir| dir.join("src").join("lib.rs").is_file()));
     if !has_lib_target {
         return None;
     }
@@ -80,22 +93,79 @@ fn lib_crate_root_name(manifest: &toml::Value, manifest_dir: Option<&Path>) -> O
     Some(package.replace('-', "_"))
 }
 
-/// Add every `[dependencies]` / `[workspace.dependencies]` KEY whose value carries a `path` key to
-/// `roots` — these are local path dependencies whose import name is the KEY (possibly renamed via
-/// the `package` key), so the bare-reference scope must treat the key as a local crate root (#97
-/// item 2). A string dependency (`serde = "1"`) or a non-`path` table dependency is external and
-/// contributes nothing.
-fn collect_path_dependency_aliases(manifest: &toml::Value, roots: &mut HashSet<String>) {
-    let deps_tables = [
-        manifest.get("dependencies"),
-        manifest.get("workspace").and_then(|workspace| workspace.get("dependencies")),
-    ];
-    for table in deps_tables.into_iter().flatten().filter_map(toml::Value::as_table) {
+/// Add every path-dependency KEY whose target resolves INSIDE `root` to `roots` — these are local
+/// path dependencies whose import name is the KEY (possibly renamed via the `package` key), so the
+/// bare-reference scope must treat the key as a local crate root (#97 item 2). A string dependency
+/// (`serde = "1"`) or a non-`path` table dependency is external and contributes nothing.
+///
+/// Scans the normal, dev, and build dependency tables, plus every `[target.*.dependencies/.dev-
+/// dependencies/.build-dependencies]` table and `[workspace.dependencies]`: path aliases declared
+/// for tests/examples/build scripts/cfg-specific modules feed indexed Rust files too, so a
+/// `use local_alias::…` from any of them must resolve local (#97 item 4).
+///
+/// The key is `-`→`_` normalized before insertion (#97 item 1 / P1): a dependency KEY may contain
+/// `-` yet Rust imports it as `use foo_bar::…`, so the raw key would never match a `use` root.
+///
+/// A `path` pointing OUTSIDE the indexed `root` is NOT added (#97 item 5): that crate has no
+/// symbols in this index, so localizing its alias would let a same-named in-corpus symbol wrongly
+/// bind. The target is resolved relative to `manifest_dir`; an unresolvable path (canonicalize
+/// fails — the sibling isn't checked out) is treated as outside the corpus and skipped.
+fn collect_path_dependency_aliases(
+    manifest: &toml::Value,
+    manifest_dir: &Path,
+    root: &Path,
+    roots: &mut HashSet<String>,
+) {
+    for table in dependency_tables(manifest) {
         for (key, spec) in table {
-            if spec.get("path").is_some() {
-                roots.insert(key.clone());
+            let Some(path) = spec.get("path").and_then(toml::Value::as_str) else { continue };
+            if path_dependency_is_in_corpus(manifest_dir, path, root) {
+                roots.insert(key.replace('-', "_"));
             }
         }
+    }
+}
+
+/// Every dependency table in a manifest that can carry a path alias bound into indexed Rust: the
+/// top-level `[dependencies]` / `[dev-dependencies]` / `[build-dependencies]`, `[workspace.
+/// dependencies]`, and each per-platform `[target.<cfg>.{dependencies,dev-dependencies,build-
+/// dependencies}]` table.
+fn dependency_tables(manifest: &toml::Value) -> Vec<&toml::value::Table> {
+    const KINDS: [&str; 3] = ["dependencies", "dev-dependencies", "build-dependencies"];
+    let mut tables = Vec::new();
+    for kind in KINDS {
+        tables.extend(manifest.get(kind).and_then(toml::Value::as_table));
+    }
+    tables.extend(
+        manifest
+            .get("workspace")
+            .and_then(|workspace| workspace.get("dependencies"))
+            .and_then(toml::Value::as_table),
+    );
+    // `[target.<cfg>.dependencies]` etc.: each `<cfg>` is its own sub-table holding the dependency
+    // kinds.
+    if let Some(targets) = manifest.get("target").and_then(toml::Value::as_table) {
+        for cfg in targets.values() {
+            for kind in KINDS {
+                tables.extend(cfg.get(kind).and_then(toml::Value::as_table));
+            }
+        }
+    }
+    tables
+}
+
+/// Whether a path dependency's target directory resolves to a location under the indexed `root`
+/// (#97 item 5). `manifest_dir` is the directory of the manifest declaring the dependency; `path`
+/// is the relative `path = "…"` value. Canonicalizes both so `../` traversal and symlinks compare
+/// honestly; if the target can't be canonicalized (it isn't present on disk), it can't hold indexed
+/// symbols, so it's treated as outside the corpus.
+fn path_dependency_is_in_corpus(manifest_dir: &Path, path: &str, root: &Path) -> bool {
+    let Ok(target) = manifest_dir.join(path).canonicalize() else { return false };
+    match root.canonicalize() {
+        Ok(canonical_root) => target.starts_with(&canonical_root),
+        // Root not canonicalizable (shouldn't happen — we just walked it) — fall back to the raw
+        // root so we don't drop every alias.
+        Err(_) => target.starts_with(root),
     }
 }
 
@@ -385,17 +455,26 @@ mod tests {
     /// imports under its KEY (`use local_alias::…`), which differs from the package's canonical
     /// crate name. The key must be a local root or a bare reference through it OVER-suppresses (a
     /// dropped LOCAL bind). String/non-path table deps are external and contribute nothing.
+    /// #97 item 1 (P1): a hyphenated alias KEY (`foo-bar = { path = … }`) imports as `use foo_bar`,
+    /// so the key is `-`→`_` normalized before insertion. All path targets here live INSIDE the
+    /// corpus, so #97 item 5 keeps them (the out-of-corpus exclusion has its own test).
     #[test]
     fn local_crate_roots_recognizes_path_dependency_aliases() {
         let dir = std::env::temp_dir().join(format!("rr-path-alias-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(dir.join("src")).unwrap();
         std::fs::write(dir.join("src/lib.rs"), "").unwrap();
+        // In-corpus path-dependency targets (must exist on disk so item-5 corpus containment keeps
+        // them). The alias is the KEY, independent of the target directory name.
+        for target in ["real-crate", "other", "hyph-target", "crates/ws"] {
+            std::fs::create_dir_all(dir.join(target)).unwrap();
+        }
         std::fs::write(
             dir.join("Cargo.toml"),
-            "[package]\nname=\"app\"\n[dependencies]\nlocal_alias = { path = \"../real-crate\", \
-             package = \"real-crate\" }\nplain_path = { path = \"../other\" }\nserde = \
-             \"1\"\n[workspace.dependencies]\nws_local = { path = \"crates/ws\" }\n",
+            "[package]\nname=\"app\"\n[dependencies]\nlocal_alias = { path = \"real-crate\", \
+             package = \"real-crate\" }\nplain_path = { path = \"other\" }\nhyphen-alias = { path \
+             = \"hyph-target\" }\nserde = \"1\"\n[workspace.dependencies]\nws_local = { path = \
+             \"crates/ws\" }\n",
         )
         .unwrap();
         let roots = local_crate_roots(&dir);
@@ -409,12 +488,89 @@ mod tests {
             "path dep without `package` still local; got {roots:?}"
         );
         assert!(
+            roots.contains("hyphen_alias"),
+            "hyphenated alias KEY is `-`→`_` normalized (item 1); got {roots:?}"
+        );
+        assert!(
+            !roots.contains("hyphen-alias"),
+            "the raw hyphenated key must NOT survive (it can never match a `use` root); got \
+             {roots:?}"
+        );
+        assert!(
             roots.contains("ws_local"),
             "[workspace.dependencies] path dep is local; got {roots:?}"
         );
         assert!(
             !roots.contains("serde"),
             "a string (external) dep is not a local root; got {roots:?}"
+        );
+    }
+
+    /// #97 item 4: path-dep aliases declared in `[dev-dependencies]`, `[build-dependencies]`, and
+    /// `[target.<cfg>.dependencies]` feed indexed Rust (tests/examples/build scripts/cfg modules),
+    /// so a `use alias::…` from any of those must resolve local too. All targets are in-corpus.
+    #[test]
+    fn local_crate_roots_scans_dev_build_target_dependency_tables() {
+        let dir = std::env::temp_dir().join(format!("rr-dep-tables-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+        std::fs::write(dir.join("src/lib.rs"), "").unwrap();
+        for target in ["dev-dep", "build-dep", "cfg-dep"] {
+            std::fs::create_dir_all(dir.join(target)).unwrap();
+        }
+        std::fs::write(
+            dir.join("Cargo.toml"),
+            "[package]\nname=\"app\"\n[dev-dependencies]\ndev_local = { path = \"dev-dep\" \
+             }\n[build-dependencies]\nbuild_local = { path = \"build-dep\" \
+             }\n[target.'cfg(unix)'.dependencies]\ncfg_local = { path = \"cfg-dep\" }\n",
+        )
+        .unwrap();
+        let roots = local_crate_roots(&dir);
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(roots.contains("dev_local"), "[dev-dependencies] path dep is local; got {roots:?}");
+        assert!(
+            roots.contains("build_local"),
+            "[build-dependencies] path dep is local; got {roots:?}"
+        );
+        assert!(
+            roots.contains("cfg_local"),
+            "[target.*.dependencies] path dep is local; got {roots:?}"
+        );
+    }
+
+    /// #97 item 5: a `path = "…"` dependency pointing OUTSIDE the indexed root has no symbols in this
+    /// index, so localizing its alias would let a same-named in-corpus symbol wrongly bind. Only
+    /// in-corpus path deps become local roots.
+    #[test]
+    fn local_crate_roots_excludes_out_of_corpus_path_deps() {
+        let base = std::env::temp_dir().join(format!("rr-corpus-scope-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        let root = base.join("indexed");
+        // A SIBLING crate outside the indexed root — present on disk, but not in the corpus.
+        std::fs::create_dir_all(base.join("sibling/src")).unwrap();
+        std::fs::write(base.join("sibling/src/lib.rs"), "").unwrap();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(root.join("inside")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), "").unwrap();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[package]\nname=\"app\"\n[dependencies]\noutside_alias = { path = \"../sibling\" \
+             }\ninside_alias = { path = \"inside\" }\nmissing_alias = { path = \"nope\" }\n",
+        )
+        .unwrap();
+        let roots = local_crate_roots(&root);
+        let _ = std::fs::remove_dir_all(&base);
+        assert!(
+            !roots.contains("outside_alias"),
+            "a path dep outside the indexed root is NOT a local root; got {roots:?}"
+        );
+        assert!(
+            roots.contains("inside_alias"),
+            "a path dep inside the indexed root IS a local root; got {roots:?}"
+        );
+        assert!(
+            !roots.contains("missing_alias"),
+            "a path dep whose target doesn't exist can't hold indexed symbols; got {roots:?}"
         );
     }
 
@@ -455,6 +611,40 @@ mod tests {
         assert!(
             roots.contains("explicit"),
             "an explicit [lib] table contributes its root; got {roots:?}"
+        );
+    }
+
+    /// #97 item 4 (autolib): `[package] autolib = false` disables `src/lib.rs` autodiscovery, so a
+    /// bin-only package that keeps a stray `src/lib.rs` is NOT importable and must not contribute a
+    /// root (otherwise a same-named external dep gets misclassified local). An EXPLICIT `[lib]`
+    /// table still contributes — `autolib` only governs autodiscovery.
+    #[test]
+    fn local_crate_roots_respects_autolib_false() {
+        let dir = std::env::temp_dir().join(format!("rr-autolib-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        // Stray src/lib.rs but autolib disabled → name colliding with external `clap` stays
+        // external.
+        std::fs::create_dir_all(dir.join("tool/src")).unwrap();
+        std::fs::write(dir.join("tool/Cargo.toml"), "[package]\nname=\"clap\"\nautolib=false\n")
+            .unwrap();
+        std::fs::write(dir.join("tool/src/lib.rs"), "").unwrap();
+        // autolib false but an EXPLICIT [lib] table still makes it importable.
+        std::fs::create_dir_all(dir.join("explicit/src")).unwrap();
+        std::fs::write(
+            dir.join("explicit/Cargo.toml"),
+            "[package]\nname=\"explicit\"\nautolib=false\n[lib]\npath=\"src/lib.rs\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir.join("explicit/src/lib.rs"), "").unwrap();
+        let roots = local_crate_roots(&dir);
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(
+            !roots.contains("clap"),
+            "autolib=false disables src/lib.rs autodiscovery; got {roots:?}"
+        );
+        assert!(
+            roots.contains("explicit"),
+            "an explicit [lib] table contributes regardless of autolib; got {roots:?}"
         );
     }
 

--- a/crates/rag-rat-core/src/index/edges/imports.rs
+++ b/crates/rag-rat-core/src/index/edges/imports.rs
@@ -40,24 +40,63 @@ pub(crate) fn local_crate_roots(root: &Path) -> HashSet<String> {
             continue;
         }
         let Ok(text) = std::fs::read_to_string(entry.path()) else { continue };
-        let Ok(value) = toml::from_str::<toml::Value>(&text) else { continue };
-        if let Some(name) = crate_root_name(&value) {
+        // Parse with the serde entry point (`toml::from_str`), NOT `text.parse::<toml::Value>()`:
+        // `toml::Value`'s `FromStr` compiles but does not parse a full Cargo.toml document — it
+        // returns Err on a valid manifest, silently emptying the local set.
+        let Ok(manifest) = toml::from_str::<toml::Value>(&text) else { continue };
+        let manifest_dir = entry.path().parent();
+        if let Some(name) = lib_crate_root_name(&manifest, manifest_dir) {
             roots.insert(name);
         }
+        // Renamed / path-dependency aliases: `local_alias = { path = "…", package = "real" }` lets
+        // the import KEY (`use local_alias::…`) differ from the package's canonical crate name, so
+        // the key must itself count as a local root or the bare reference OVER-suppresses (a
+        // dropped LOCAL bind — the harmful direction, #97 item 2). The key is the crate
+        // root written in source, so it needs no `-`→`_` normalization (a `use` path can't
+        // contain `-`).
+        collect_path_dependency_aliases(&manifest, &mut roots);
     }
     roots
 }
 
-/// The crate root identifier used in `use` paths: `[lib].name` if set, else the package name with
-/// `-` normalized to `_` (Cargo's crate-name rule: `cargo-credential` → `cargo_credential`).
-fn crate_root_name(manifest: &toml::Value) -> Option<String> {
-    if let Some(lib_name) =
-        manifest.get("lib").and_then(|lib| lib.get("name")).and_then(|name| name.as_str())
-    {
+/// The crate root identifier used in `use` paths when this manifest defines an importable LIBRARY:
+/// `[lib].name` if the table sets one, else the package name (`-`→`_`, Cargo's crate-name rule:
+/// `cargo-credential` → `cargo_credential`). Returns `None` for a BIN-ONLY member (no `[lib]` table
+/// and no autodiscovered `src/lib.rs`): such a package is not importable, so contributing its name
+/// as a root would wrongly mark a same-named EXTERNAL dependency as local and skip suppression
+/// (#97 item 3). The `src/lib.rs` probe mirrors Cargo's lib autodiscovery and is resolved relative
+/// to the manifest directory.
+fn lib_crate_root_name(manifest: &toml::Value, manifest_dir: Option<&Path>) -> Option<String> {
+    let lib = manifest.get("lib");
+    if let Some(lib_name) = lib.and_then(|lib| lib.get("name")).and_then(|name| name.as_str()) {
         return Some(lib_name.replace('-', "_"));
+    }
+    let has_lib_target =
+        lib.is_some() || manifest_dir.is_some_and(|dir| dir.join("src").join("lib.rs").is_file());
+    if !has_lib_target {
+        return None;
     }
     let package = manifest.get("package")?.get("name")?.as_str()?;
     Some(package.replace('-', "_"))
+}
+
+/// Add every `[dependencies]` / `[workspace.dependencies]` KEY whose value carries a `path` key to
+/// `roots` — these are local path dependencies whose import name is the KEY (possibly renamed via
+/// the `package` key), so the bare-reference scope must treat the key as a local crate root (#97
+/// item 2). A string dependency (`serde = "1"`) or a non-`path` table dependency is external and
+/// contributes nothing.
+fn collect_path_dependency_aliases(manifest: &toml::Value, roots: &mut HashSet<String>) {
+    let deps_tables = [
+        manifest.get("dependencies"),
+        manifest.get("workspace").and_then(|workspace| workspace.get("dependencies")),
+    ];
+    for table in deps_tables.into_iter().flatten().filter_map(toml::Value::as_table) {
+        for (key, spec) in table {
+            if spec.get("path").is_some() {
+                roots.insert(key.clone());
+            }
+        }
+    }
 }
 
 /// Parse a Rust `use` statement into its crate root and the leaf NAMES it actually binds into
@@ -323,18 +362,100 @@ mod tests {
     fn local_crate_roots_scans_workspace_manifests() {
         let dir = std::env::temp_dir().join(format!("rr-crate-roots-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
+        // Both members carry a `src/lib.rs` so each is an importable LIBRARY (autodiscovery) and
+        // contributes its package name as a root (#97 item 3 gates this on a lib target).
+        std::fs::create_dir_all(dir.join("src")).unwrap();
         std::fs::create_dir_all(dir.join("crates/foo-bar/src")).unwrap();
         std::fs::write(
             dir.join("Cargo.toml"),
             "[workspace]\nmembers=[\"crates/*\"]\n[package]\nname=\"cargo\"\n",
         )
         .unwrap();
+        std::fs::write(dir.join("src/lib.rs"), "").unwrap();
         std::fs::write(dir.join("crates/foo-bar/Cargo.toml"), "[package]\nname=\"foo-bar\"\n")
             .unwrap();
+        std::fs::write(dir.join("crates/foo-bar/src/lib.rs"), "").unwrap();
         let roots = local_crate_roots(&dir);
         let _ = std::fs::remove_dir_all(&dir);
         assert!(roots.contains("cargo"), "top package; got {roots:?}");
         assert!(roots.contains("foo_bar"), "hyphen→underscore normalized; got {roots:?}");
+    }
+
+    /// #97 item 2: a renamed / path dependency (`local_alias = { path = …, package = "real" }`)
+    /// imports under its KEY (`use local_alias::…`), which differs from the package's canonical
+    /// crate name. The key must be a local root or a bare reference through it OVER-suppresses (a
+    /// dropped LOCAL bind). String/non-path table deps are external and contribute nothing.
+    #[test]
+    fn local_crate_roots_recognizes_path_dependency_aliases() {
+        let dir = std::env::temp_dir().join(format!("rr-path-alias-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+        std::fs::write(dir.join("src/lib.rs"), "").unwrap();
+        std::fs::write(
+            dir.join("Cargo.toml"),
+            "[package]\nname=\"app\"\n[dependencies]\nlocal_alias = { path = \"../real-crate\", \
+             package = \"real-crate\" }\nplain_path = { path = \"../other\" }\nserde = \
+             \"1\"\n[workspace.dependencies]\nws_local = { path = \"crates/ws\" }\n",
+        )
+        .unwrap();
+        let roots = local_crate_roots(&dir);
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(
+            roots.contains("local_alias"),
+            "renamed path-dep KEY is a local root; got {roots:?}"
+        );
+        assert!(
+            roots.contains("plain_path"),
+            "path dep without `package` still local; got {roots:?}"
+        );
+        assert!(
+            roots.contains("ws_local"),
+            "[workspace.dependencies] path dep is local; got {roots:?}"
+        );
+        assert!(
+            !roots.contains("serde"),
+            "a string (external) dep is not a local root; got {roots:?}"
+        );
+    }
+
+    /// #97 item 3: a BIN-ONLY member (no `[lib]` table, no `src/lib.rs`) is not importable, so it
+    /// must NOT contribute its package name as a root — otherwise a same-named external dependency
+    /// (`use clap::…` where a local bin is also named `clap`) is wrongly treated as local and
+    /// suppression is skipped. A LIBRARY member still contributes its root.
+    #[test]
+    fn local_crate_roots_skips_bin_only_packages() {
+        let dir = std::env::temp_dir().join(format!("rr-bin-only-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        // A bin-only crate whose name collides with the external `clap` dependency.
+        std::fs::create_dir_all(dir.join("tool/src")).unwrap();
+        std::fs::write(dir.join("tool/Cargo.toml"), "[package]\nname=\"clap\"\n").unwrap();
+        std::fs::write(dir.join("tool/src/main.rs"), "fn main() {}").unwrap();
+        // A real library member (autodiscovered src/lib.rs) that DOES contribute its root.
+        std::fs::create_dir_all(dir.join("lib-crate/src")).unwrap();
+        std::fs::write(dir.join("lib-crate/Cargo.toml"), "[package]\nname=\"lib-crate\"\n")
+            .unwrap();
+        std::fs::write(dir.join("lib-crate/src/lib.rs"), "").unwrap();
+        // A member declaring an explicit [lib] table (no src/lib.rs needed).
+        std::fs::create_dir_all(dir.join("explicit/src")).unwrap();
+        std::fs::write(
+            dir.join("explicit/Cargo.toml"),
+            "[package]\nname=\"explicit\"\n[lib]\npath=\"src/thing.rs\"\n",
+        )
+        .unwrap();
+        let roots = local_crate_roots(&dir);
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(
+            !roots.contains("clap"),
+            "a bin-only package name is not a local root; got {roots:?}"
+        );
+        assert!(
+            roots.contains("lib_crate"),
+            "an autodiscovered lib contributes its root; got {roots:?}"
+        );
+        assert!(
+            roots.contains("explicit"),
+            "an explicit [lib] table contributes its root; got {roots:?}"
+        );
     }
 
     #[test]
@@ -342,5 +463,41 @@ mod tests {
         let mut scope = ImportScope::new(HashSet::new());
         scope.add_use(1, "use url::Url;");
         assert!(!scope.is_external_import(1, "Url"), "no manifests → suppress nothing");
+    }
+
+    /// #97 item 1: a braced `use` longer than the 240-char `edge_evidence` cap must still mark its
+    /// LATE leaf external. The Imports edges produced by extraction now carry the UNTRUNCATED use
+    /// text, so the per-file scope built from that evidence sees every leaf — including one pushed
+    /// past byte 240 by many earlier bindings.
+    #[test]
+    fn long_braced_use_marks_a_late_leaf_external() {
+        // Pad with enough early leaves that `LateLeaf` lands well past char 240; each is a real
+        // brace binding, so the source `use` is valid.
+        let early = (0..60).map(|i| format!("Early{i}")).collect::<Vec<_>>().join(", ");
+        let src = format!("use external_dep::{{{early}, LateLeaf}};");
+        assert!(src.len() > 240, "fixture must exceed the truncation cap; len {}", src.len());
+
+        // Extract real Imports edges (the path that used to truncate) and rebuild the scope from
+        // their evidence, exactly as the resolve drivers do.
+        let edges = crate::index::edges::syntactic_edges(
+            std::path::Path::new("a.rs"),
+            crate::language::Language::Rust,
+            &src,
+            &[],
+        )
+        .unwrap();
+        let mut scope = ImportScope::new(HashSet::from(["mycrate".to_string()]));
+        for edge in &edges {
+            if edge.edge_kind == crate::index::edges::EdgeKind::Imports
+                && let Some(evidence) = edge.evidence.as_deref()
+            {
+                scope.add_use(1, evidence);
+            }
+        }
+        assert!(
+            scope.is_external_import(1, "LateLeaf"),
+            "a leaf past the 240-char cap must still be marked external"
+        );
+        assert!(scope.is_external_import(1, "Early0"), "early leaves stay external too");
     }
 }


### PR DESCRIPTION
Closes three completeness gaps in crate-aware import suppression (#61 Project B). All three previously failed toward the pre-#61 behavior (a missed suppression → local binding) — except item 2, which could *over*-suppress (drop a valid local bind), the harmful direction.

## 1. Evidence truncation (`resolve.rs` / `helpers.rs` / `extract.rs`)
`ImportScope` rebuilds its per-file `{leaf → root}` map by re-parsing an Imports edge's `evidence` with `parse_use`. `edge_evidence` truncated that text to 240 chars, so the late leaves of a long braced `use foo::{…, PathBuf}` were lost and went un-suppressed.

**Fix:** Imports edges now carry the **untruncated** use text. New `helpers::use_declaration_evidence` (whitespace-normalized, no cap) + `extract::file_edge_with_evidence`; the `use_declaration` arm uses them, and `file_edge` delegates to the new helper with the capped `edge_evidence` for all other file edges.

**Why forward-full-text and not combine per-edge `to_name`:** a tree-sitter probe confirmed the braced edge stream emits `{Bar as Baz}` as *both* `Bar` (source, not bound) and `Baz` (bound), and drops `{self}` via the path-keyword filter. `parse_use` already resolves aliases/`self`/nesting/glob correctly; the per-`to_name` route would reintroduce those exact bugs. A `use` statement is bounded and small, so storing it whole is cheap.

## 2. Renamed / path dependency aliases — could OVER-suppress (highest priority) (`imports.rs`)
`local_crate_roots` recorded only each package's canonical crate name, so `local_alias = { path = "../real", package = "real" }` — imported as `use local_alias::Type` — was treated as external and `Type` was wrongly suppressed (a dropped *local* bind).

**Fix:** `collect_path_dependency_aliases` parses `[dependencies]` and `[workspace.dependencies]` (reusing `toml::from_str::<toml::Value>`, not `text.parse()`) and adds every key whose value table has a `path` key. The key is the source-level crate root, so no `-`→`_` normalization. String deps and non-path table deps contribute nothing.

## 3. Binary-only packages (`imports.rs`)
The `[package].name` fallback treated bin-only members (no lib target) as importable roots; if such a name collided with a real external dependency, `use name::Type` was taken as local and suppression skipped.

**Fix:** `lib_crate_root_name` (replacing `crate_root_name`) contributes `[package].name` only when the manifest has an importable lib target — an explicit `[lib]` table **or** an autodiscovered `src/lib.rs` (filesystem check relative to the manifest dir). Path-dep alias keys from item 2 are added independently.

## Tests
- `long_braced_use_marks_a_late_leaf_external` — a >240-char braced `use` whose late leaf is still marked external (end-to-end through real extraction + `ImportScope`).
- `local_crate_roots_recognizes_path_dependency_aliases` — renamed (`package`), bare-`path`, and `[workspace.dependencies]` path-dep keys are local roots; a string dep is not.
- `local_crate_roots_skips_bin_only_packages` — a bin-only package name colliding with an external dep stays external; autodiscovered-lib and explicit-`[lib]` members still contribute their roots.
- Updated `local_crate_roots_scans_workspace_manifests` to add `src/lib.rs` (members are now gated on a lib target).

`cargo test -p rag-rat-core` (318 pass), `cargo clippy -p rag-rat-core --all-targets` clean, `cargo +nightly fmt`.

Fixes #97