### PR TITLE
Scope crate-aware import suppression to the enclosing module (#96)

### DIFF
--- a/crates/rag-rat-core/src/index/edges/extract.rs
+++ b/crates/rag-rat-core/src/index/edges/extract.rs
@@ -141,15 +141,21 @@ pub(crate) fn rust_edges(
         "use_declaration" => {
             let names = identifiers_under(node, text);
             let is_reexport = node_text(node, text).trim_start().starts_with("pub use ");
+            // Per-module import scope (#96): a Rust `use` is scoped to its enclosing module/block,
+            // not the whole file. Record that body's byte range on the Imports edge (carried in the
+            // otherwise-unused callee range for file-level edges) so resolution suppresses a bare
+            // reference only when it falls within the `use`'s scope. Top-level `use` → whole file.
+            let scope = enclosing_use_scope(node, text);
             for name in names {
                 if !is_rust_path_keyword(&name) {
-                    out.push(file_edge(
+                    out.push(file_edge_scoped(
                         path,
                         node,
                         text,
                         name,
                         EdgeKind::Imports,
                         EdgeConfidence::NameOnly,
+                        Some(scope),
                     ));
                 }
             }
@@ -575,6 +581,25 @@ pub(crate) fn c_like_edges(
         _ => {},
     }
 }
+/// The enclosing-scope byte range of a Rust `use_declaration`: the nearest ancestor body that
+/// introduces a lexical scope (`mod m { … }`'s `declaration_list`, or a `block` for a block-scoped
+/// `use`), so a bare reference is suppressed by this `use` only when it falls inside that body. A
+/// top-level `use` has no such ancestor and scopes the WHOLE file (`0..text.len()`) — matching the
+/// previous per-file behavior for the common case. Rust `use` items are order-independent within
+/// their module, so the full body range (not "from the `use` onward") is the correct scope (#96).
+pub(crate) fn enclosing_use_scope(node: Node<'_>, text: &str) -> CalleeRange {
+    let mut parent = node.parent();
+    while let Some(ancestor) = parent {
+        if matches!(ancestor.kind(), "declaration_list" | "block") {
+            return CalleeRange {
+                start_byte: ancestor.start_byte(),
+                end_byte: ancestor.end_byte(),
+            };
+        }
+        parent = ancestor.parent();
+    }
+    CalleeRange { start_byte: 0, end_byte: text.len() }
+}
 pub(crate) fn file_edge(
     path: &Path,
     node: Node<'_>,
@@ -582,6 +607,22 @@ pub(crate) fn file_edge(
     to_name: String,
     edge_kind: EdgeKind,
     confidence: EdgeConfidence,
+) -> EdgeCandidate {
+    file_edge_scoped(path, node, text, to_name, edge_kind, confidence, None)
+}
+/// `file_edge` plus an optional scope range carried in the callee-range slot. File-level edges have
+/// no callee identifier (#67), so the otherwise-unused `callee_start_byte`/`callee_end_byte`
+/// columns carry a Rust `use`'s enclosing-module byte range for per-module import suppression
+/// (#96).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn file_edge_scoped(
+    path: &Path,
+    node: Node<'_>,
+    text: &str,
+    to_name: String,
+    edge_kind: EdgeKind,
+    confidence: EdgeConfidence,
+    scope: Option<CalleeRange>,
 ) -> EdgeCandidate {
     EdgeCandidate {
         from_symbol_id: None,
@@ -591,8 +632,9 @@ pub(crate) fn file_edge(
         evidence: Some(edge_evidence(node, text)),
         receiver_hint: None,
         source_span: span_for_node(node),
-        // File-level edges (imports / exports / mod) have no callee identifier to anchor (#67).
-        callee_span: None,
+        // File-level edges (imports / exports / mod) have no callee identifier to anchor (#67); for
+        // a Rust `use` this slot instead carries the enclosing-module scope range (#96).
+        callee_span: scope,
         edge_kind,
         confidence,
     }
@@ -644,5 +686,78 @@ pub(crate) fn symbol_edge_with_context(
         callee_span,
         edge_kind,
         confidence,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    /// The (to_name, callee scope range) of every Imports edge a Rust source string produces. The
+    /// scope range is the enclosing-module/block byte range #96 records on the `use`'s edge,
+    /// carried in the otherwise-unused callee-byte slot.
+    fn import_scopes(src: &str) -> Vec<(String, Option<(usize, usize)>)> {
+        let candidates =
+            syntactic_edges(Path::new("a.rs"), Language::Rust, src, &[]).expect("parses");
+        candidates
+            .into_iter()
+            .filter(|candidate| candidate.edge_kind == EdgeKind::Imports)
+            .map(|candidate| {
+                (candidate.to_name, candidate.callee_span.map(|r| (r.start_byte, r.end_byte)))
+            })
+            .collect()
+    }
+
+    /// #96: a top-level `use` scopes the WHOLE file; a `use` inside `mod a { … }` scopes that
+    /// module's body (`declaration_list`) byte range, so resolution range-tests references against
+    /// the exact lexical scope rather than the whole file.
+    #[test]
+    fn enclosing_use_scope_is_the_module_body_not_the_file() {
+        let src = "use top::A;\nmod a { use url::Url; }\n";
+        let scopes = import_scopes(src);
+        // Imports edges carry the FULL `use` path as `to_name` (`top::A`, `url::Url`).
+        let top =
+            scopes.iter().find(|(name, _)| name == "top::A").expect("top-level import recorded");
+        assert_eq!(top.1, Some((0, src.len())), "a top-level `use` scopes the whole file");
+
+        // `mod a { use url::Url; }` — the body `declaration_list` is `{ use url::Url; }`.
+        let body_start = src.find("{ use").expect("mod body present");
+        let body_end = src.rfind('}').expect("mod body closes") + 1;
+        let url = scopes
+            .iter()
+            .find(|(name, _)| name == "url::Url")
+            .expect("module-scoped import recorded");
+        assert_eq!(
+            url.1,
+            Some((body_start, body_end)),
+            "a `use` inside `mod a` scopes only `mod a`'s body"
+        );
+    }
+
+    /// #96: a block-scoped `use` (inside a `fn` body) and a nested-module `use` both scope to their
+    /// nearest enclosing body, not the file.
+    #[test]
+    fn enclosing_use_scope_handles_block_and_nested_module() {
+        let block_src = "fn f() { use url::Url; let _x = Url; }\n";
+        let block_scopes = import_scopes(block_src);
+        let block_start = block_src.find("{ use").expect("fn body present");
+        let block_end = block_src.rfind('}').expect("fn body closes") + 1;
+        assert_eq!(
+            block_scopes.iter().find(|(name, _)| name == "url::Url").unwrap().1,
+            Some((block_start, block_end)),
+            "a block-scoped `use` scopes the enclosing block"
+        );
+
+        let nested_src = "mod a { mod inner { use url::Url; } }\n";
+        let nested_scopes = import_scopes(nested_src);
+        let inner_start = nested_src.find("{ use").expect("inner body present");
+        let inner_end = nested_src.find("; }").expect("inner body closes") + 3;
+        assert_eq!(
+            nested_scopes.iter().find(|(name, _)| name == "url::Url").unwrap().1,
+            Some((inner_start, inner_end)),
+            "a `use` in a nested module scopes the INNERMOST module body"
+        );
     }
 }

--- a/crates/rag-rat-core/src/index/edges/imports.rs
+++ b/crates/rag-rat-core/src/index/edges/imports.rs
@@ -184,12 +184,35 @@ fn split_top_level(inner: &str) -> Vec<&str> {
     parts
 }
 
-/// Per-file map of imported leaf name → the crate root it was imported from, plus the local-crate
-/// set, so resolution can tell an external-dependency import from a local one.
+/// One `use`-introduced binding of a leaf name: the crate root it came from and the BYTE RANGE of
+/// the enclosing module/block the `use` is scoped to (#96). A reference is suppressed by this
+/// binding only when its source byte falls inside `[scope_start, scope_end)` — so
+/// `mod a { use url::Url }` does not suppress a local `Url` in `mod b`. A top-level `use` records
+/// the whole-file range, reproducing the previous per-file behavior for the common case.
+#[derive(Clone)]
+struct ImportBinding {
+    root: String,
+    scope_start: usize,
+    scope_end: usize,
+}
+
+impl ImportBinding {
+    /// Whether a reference at `ref_byte` is lexically inside this `use`'s scope. Half-open range:
+    /// the enclosing body's `start_byte..end_byte` (Rust `use` items are order-independent within
+    /// their module, so the whole body, not "from the `use` onward", is the scope).
+    fn covers(&self, ref_byte: usize) -> bool {
+        ref_byte >= self.scope_start && ref_byte < self.scope_end
+    }
+}
+
+/// Per-file map of imported leaf name → the scoped bindings of that name, plus the local-crate set,
+/// so resolution can tell an external-dependency import from a local one AND confine the
+/// suppression to the lexical scope each `use` actually governs (#96). A name can be `use`d more
+/// than once in one file (different modules/blocks), so each name carries a LIST of bindings.
 #[derive(Default)]
 pub(crate) struct ImportScope {
     local_roots: HashSet<String>,
-    by_file: HashMap<i64, HashMap<String, String>>,
+    by_file: HashMap<i64, HashMap<String, Vec<ImportBinding>>>,
 }
 
 impl ImportScope {
@@ -197,35 +220,55 @@ impl ImportScope {
         Self { local_roots, by_file: HashMap::new() }
     }
 
-    /// Record a `use` statement's bindings for `file_id`: every leaf name it brings into scope →
-    /// the crate root it came from. Idempotent — the same evidence text arrives once per identifier
-    /// in the imports edge stream, and re-recording the same (leaf → root) is a no-op.
-    pub(crate) fn add_use(&mut self, file_id: i64, use_text: &str) {
+    /// Record a `use` statement's bindings for `file_id`, scoped to `[scope_start, scope_end)` (the
+    /// enclosing module/block byte range carried on the Imports edge, see `enclosing_use_scope`):
+    /// every leaf name it brings into scope → a binding to the crate root it came from. Idempotent
+    /// in effect — the same (leaf, root, scope) arrives once per identifier in the imports edge
+    /// stream, and a duplicate binding is dropped so a name's binding list stays the distinct set.
+    pub(crate) fn add_use(&mut self, file_id: i64, use_text: &str, scope: (usize, usize)) {
         let Some((root, leaves)) = parse_use(use_text) else { return };
+        let (scope_start, scope_end) = scope;
         let file = self.by_file.entry(file_id).or_default();
         for leaf in leaves {
-            file.insert(leaf, root.clone());
+            let bindings = file.entry(leaf).or_default();
+            let binding = ImportBinding { root: root.clone(), scope_start, scope_end };
+            if !bindings.iter().any(|existing| {
+                existing.root == binding.root
+                    && existing.scope_start == binding.scope_start
+                    && existing.scope_end == binding.scope_end
+            }) {
+                bindings.push(binding);
+            }
         }
     }
 
-    /// Whether `name` in `file_id` was imported from an EXTERNAL dependency crate — not a local
-    /// workspace crate, not `crate`/`self`/`super`. When true, the name denotes that dependency's
-    /// item and must NOT bind to a local same-named symbol. Fails OPEN: with no local-crate set
-    /// (non-Cargo corpus / manifest scan found nothing), nothing is ever suppressed.
-    pub(crate) fn is_external_import(&self, file_id: i64, name: &str) -> bool {
+    /// Whether `name`, referenced at `ref_byte` in `file_id`, was imported from an EXTERNAL
+    /// dependency crate by a `use` whose scope COVERS that reference — not a local workspace crate,
+    /// not `crate`/`self`/`super`. When true, the name denotes that dependency's item and must NOT
+    /// bind to a local same-named symbol. Fails OPEN: with no local-crate set (non-Cargo corpus /
+    /// manifest scan found nothing), nothing is ever suppressed. Per-module scoping (#96): a `use`
+    /// only suppresses references inside its enclosing module/block, so a same-named local item in
+    /// a sibling module stays resolvable.
+    pub(crate) fn is_external_import(&self, file_id: i64, name: &str, ref_byte: usize) -> bool {
         if self.local_roots.is_empty() {
             return false;
         }
-        let Some(root) = self.by_file.get(&file_id).and_then(|names| names.get(name)) else {
+        let Some(bindings) = self.by_file.get(&file_id).and_then(|names| names.get(name)) else {
             return false;
         };
-        !self.local_roots.contains(root) && !matches!(root.as_str(), "crate" | "self" | "super")
+        bindings.iter().any(|binding| {
+            binding.covers(ref_byte)
+                && !self.local_roots.contains(&binding.root)
+                && !matches!(binding.root.as_str(), "crate" | "self" | "super")
+        })
     }
 
     /// Whether a path-qualified reference's RECEIVER/root names an external import — `Url::parse`
     /// (target_qualified_name `Url::parse`) where `Url` was `use`d from the external `url` crate.
     /// The leaf `parse` itself isn't imported, so [`is_external_import`] on the callee name misses
     /// it; the new scope-path lookup would otherwise bind `Url::parse` to an in-repo `Url::parse`.
+    /// `ref_byte` confines the check to the receiver `use`'s lexical scope, like
+    /// [`is_external_import`].
     ///
     /// Gated on a TYPE-LIKE (uppercase) head. `target_qualified_name` rewrites `.`→`::`
     /// (helpers::target_qualified_name), so a value-receiver method call `config.build()` arrives
@@ -239,10 +282,12 @@ impl ImportScope {
         &self,
         file_id: i64,
         target_qualified_name: Option<&str>,
+        ref_byte: usize,
     ) -> bool {
         target_qualified_name.and_then(|qualified| qualified.split_once("::")).is_some_and(
             |(root, _)| {
-                root.starts_with(char::is_uppercase) && self.is_external_import(file_id, root)
+                root.starts_with(char::is_uppercase)
+                    && self.is_external_import(file_id, root, ref_byte)
             },
         )
     }
@@ -297,26 +342,56 @@ mod tests {
         assert_eq!(parse_use("mod foo;"), None);
     }
 
+    /// A whole-file scope, as a top-level `use` records (`enclosing_use_scope` → `0..text.len()`).
+    /// Lets the non-scoping assertions read `is_external_import` with a reference byte that always
+    /// falls inside scope.
+    const WHOLE_FILE: (usize, usize) = (0, usize::MAX);
+
     #[test]
     fn external_import_distinguishes_local_from_dependency() {
         let mut scope = ImportScope::new(HashSet::from(["cargo".to_string()]));
-        scope.add_use(1, "use url::Url;"); // external dep
-        scope.add_use(1, "use cargo::core::Workspace;"); // local workspace crate
-        scope.add_use(1, "use std::path::{Path, PathBuf};"); // std = external
-        scope.add_use(1, "use crate::a::Helper;"); // local (crate-relative)
-        assert!(scope.is_external_import(1, "Url"), "url is an external dep");
-        assert!(scope.is_external_import(1, "Path"), "std is external");
-        assert!(!scope.is_external_import(1, "Workspace"), "cargo is a local workspace crate");
-        assert!(!scope.is_external_import(1, "Helper"), "crate-rooted is local");
+        scope.add_use(1, "use url::Url;", WHOLE_FILE); // external dep
+        scope.add_use(1, "use cargo::core::Workspace;", WHOLE_FILE); // local workspace crate
+        scope.add_use(1, "use std::path::{Path, PathBuf};", WHOLE_FILE); // std = external
+        scope.add_use(1, "use crate::a::Helper;", WHOLE_FILE); // local (crate-relative)
+        assert!(scope.is_external_import(1, "Url", 0), "url is an external dep");
+        assert!(scope.is_external_import(1, "Path", 0), "std is external");
+        assert!(!scope.is_external_import(1, "Workspace", 0), "cargo is a local workspace crate");
+        assert!(!scope.is_external_import(1, "Helper", 0), "crate-rooted is local");
         assert!(
-            !scope.is_external_import(1, "path"),
+            !scope.is_external_import(1, "path", 0),
             "the `std::path` PREFIX is not a binding — a local `path` must stay resolvable"
         );
         assert!(
-            !scope.is_external_import(1, "Unimported"),
+            !scope.is_external_import(1, "Unimported", 0),
             "an unimported name is never suppressed"
         );
-        assert!(!scope.is_external_import(2, "Url"), "scoped per file");
+        assert!(!scope.is_external_import(2, "Url", 0), "scoped per file");
+    }
+
+    /// #96: two `use`s of the same leaf name in disjoint module scopes within one file. A reference
+    /// is suppressed only when its byte falls inside the `use`'s scope — so a bare `Url` in
+    /// `mod a` (where `use url::Url` lives) is external, while a `Url` in `mod b` (a local
+    /// definition, no external `use` in scope) is NOT suppressed.
+    #[test]
+    fn import_scope_is_confined_to_the_enclosing_module() {
+        let mut scope = ImportScope::new(HashSet::from(["mycrate".to_string()]));
+        // `mod a { use url::Url; }` spans bytes 10..40; `mod b { /* local Url */ }` spans 50..90.
+        scope.add_use(1, "use url::Url;", (10, 40));
+        // A reference inside `mod a`'s body is the external `url::Url`.
+        assert!(
+            scope.is_external_import(1, "Url", 25),
+            "a `Url` ref inside the importing module is the external dep"
+        );
+        // A reference inside `mod b` (outside the `use`'s scope) is the LOCAL `Url`, not
+        // suppressed.
+        assert!(
+            !scope.is_external_import(1, "Url", 60),
+            "a `Url` ref in a sibling module without the `use` in scope must stay resolvable (#96)"
+        );
+        // The boundary is half-open: a ref at the scope's end byte is outside it.
+        assert!(!scope.is_external_import(1, "Url", 40), "scope end is exclusive");
+        assert!(scope.is_external_import(1, "Url", 10), "scope start is inclusive");
     }
 
     #[test]
@@ -340,7 +415,7 @@ mod tests {
     #[test]
     fn empty_local_set_fails_open() {
         let mut scope = ImportScope::new(HashSet::new());
-        scope.add_use(1, "use url::Url;");
-        assert!(!scope.is_external_import(1, "Url"), "no manifests → suppress nothing");
+        scope.add_use(1, "use url::Url;", WHOLE_FILE);
+        assert!(!scope.is_external_import(1, "Url", 0), "no manifests → suppress nothing");
     }
 }

--- a/crates/rag-rat-core/src/index/edges/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/mod.rs
@@ -74,6 +74,11 @@ impl EdgeConfidence {
 /// join time from the checkout bytes, so only the byte range is stored. Set only for
 /// symbol-referencing edges (built via `symbol_edge`/`symbol_edge_with_context`); `None` for
 /// file-level / `contains` edges and for constructs where a clean identifier node isn't available.
+///
+/// OVERLOADED on Imports edges (#96): a Rust `use` has no callee identifier, so this slot instead
+/// carries the `use`'s enclosing-module/block byte range (see `enclosing_use_scope`), which
+/// per-module import suppression range-tests references against. The two uses never collide — an
+/// Imports edge is never SCIP-joined and a `calls_name` edge never carries a `use` scope.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct CalleeRange {
     start_byte: usize,

--- a/crates/rag-rat-core/src/index/edges/resolve.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve.rs
@@ -21,21 +21,27 @@ pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
     let symbols = all_symbols(conn)?;
     let index = SymbolIndex::build(&symbols);
     // Crate-aware import scope (#61 Project B): the active checkout's Imports edges → per-file
-    // {leaf name → crate root}, so resolution suppresses a local bind when the name is `use`d from
-    // an external dependency. Scoped via the `files` TEMP VIEW like the resolution query below.
+    // {leaf name → scoped crate-root bindings}, so resolution suppresses a local bind when the name
+    // is `use`d from an external dependency. Scoped via the `files` TEMP VIEW like the resolution
+    // query below. Per-module scope (#96): a Rust `use`'s enclosing-module/block byte range rides
+    // in the Imports edge's callee-byte columns (file-level edges have no callee identifier), so
+    // the suppression is confined to references inside that scope. Absent columns → whole-file
+    // scope.
     let mut import_scope = imports::ImportScope::new(imports::load_local_roots(conn));
     {
         let mut stmt = conn.prepare(
-            "SELECT d.source_file_id, d.evidence FROM edges_data d JOIN files ON files.id = \
-             d.source_file_id JOIN edge_strings ek ON ek.id = d.edge_kind_id WHERE ek.value = \
-             'imports'",
+            "SELECT d.source_file_id, d.evidence, d.callee_start_byte, d.callee_end_byte FROM \
+             edges_data d JOIN files ON files.id = d.source_file_id JOIN edge_strings ek ON ek.id \
+             = d.edge_kind_id WHERE ek.value = 'imports'",
         )?;
         let mut rows = stmt.query([])?;
         while let Some(row) = rows.next()? {
             let file_id: i64 = row.get(0)?;
             let evidence: Option<String> = row.get(1)?;
+            let scope_start: Option<i64> = row.get(2)?;
+            let scope_end: Option<i64> = row.get(3)?;
             if let Some(evidence) = evidence {
-                import_scope.add_use(file_id, &evidence);
+                import_scope.add_use(file_id, &evidence, use_scope(scope_start, scope_end));
             }
         }
     }
@@ -46,11 +52,11 @@ pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
     let mut interner = EdgeStringInterner::default();
     let mut stmt = conn.prepare(
         "SELECT d.id, d.source_file_id, tn.value, tqn.value, ek.value, conf.value, d.evidence, \
-         rh.value FROM edges_data d JOIN files ON files.id = d.source_file_id LEFT JOIN \
-         edge_strings tn ON tn.id = d.to_name_id LEFT JOIN edge_strings tqn ON tqn.id = \
-         d.target_qualified_name_id LEFT JOIN edge_strings ek ON ek.id = d.edge_kind_id LEFT JOIN \
-         edge_strings conf ON conf.id = d.confidence_id LEFT JOIN edge_strings rh ON rh.id = \
-         d.receiver_hint_id ORDER BY d.id",
+         rh.value, d.source_start_byte FROM edges_data d JOIN files ON files.id = \
+         d.source_file_id LEFT JOIN edge_strings tn ON tn.id = d.to_name_id LEFT JOIN \
+         edge_strings tqn ON tqn.id = d.target_qualified_name_id LEFT JOIN edge_strings ek ON \
+         ek.id = d.edge_kind_id LEFT JOIN edge_strings conf ON conf.id = d.confidence_id LEFT \
+         JOIN edge_strings rh ON rh.id = d.receiver_hint_id ORDER BY d.id",
     )?;
     let rows = stmt.query_map([], |row| {
         Ok((
@@ -62,6 +68,7 @@ pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
             row.get::<_, String>(5)?,
             row.get::<_, Option<String>>(6)?,
             row.get::<_, Option<String>>(7)?,
+            row.get::<_, i64>(8)?,
         ))
     })?;
     let rows = rows.collect::<Result<Vec<_>, _>>()?;
@@ -74,8 +81,11 @@ pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
         current_confidence,
         evidence,
         receiver_hint,
+        source_start_byte,
     ) in rows
     {
+        // The reference's source byte selects which in-scope `use` items can suppress it (#96).
+        let ref_byte = usize::try_from(source_start_byte).unwrap_or(0);
         let resolution = resolve_symbol(
             ResolveSymbolRequest {
                 name: &to_name,
@@ -85,12 +95,15 @@ pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
                 receiver_hint: receiver_hint.as_deref(),
                 source_file_id,
                 source_language: index.file_language.get(&source_file_id).copied(),
-                imported_external: import_scope
-                    .is_external_import(source_file_id, short_name(&to_name))
-                    || import_scope.is_external_qualified_root(
-                        source_file_id,
-                        target_qualified_name.as_deref(),
-                    ),
+                imported_external: import_scope.is_external_import(
+                    source_file_id,
+                    short_name(&to_name),
+                    ref_byte,
+                ) || import_scope.is_external_qualified_root(
+                    source_file_id,
+                    target_qualified_name.as_deref(),
+                    ref_byte,
+                ),
             },
             &index,
         );
@@ -183,13 +196,18 @@ pub(crate) fn resolve_and_insert_edges(
     // would; `file_id` therefore drops out of the key (constant within each reset window).
     // Crate-aware import scope (#61 Project B): map each file's `use`d leaf names to their crate
     // root from the accumulated Imports edges, so resolution can suppress a bind to a local symbol
-    // when the name actually comes from an external dependency crate.
+    // when the name actually comes from an external dependency crate. Per-module scope (#96): the
+    // `use`'s enclosing-module/block byte range rides in the candidate's callee-byte columns (a
+    // Rust `use` has no callee identifier), so suppression is confined to references inside it.
+    // This must stay in EXACT parity with the DB path in `resolve_all_edges` above — same scope
+    // source (callee bytes → `use_scope`), same `ref_byte` (the edge's source start byte).
     let mut import_scope = imports::ImportScope::new(imports::load_local_roots(conn));
     for (file_id, candidate) in &edges {
         if candidate.edge_kind == EdgeKind::Imports
             && let Some(evidence) = arena.get_opt(candidate.evidence)
         {
-            import_scope.add_use(*file_id, evidence);
+            let (scope_start, scope_end) = candidate.callee_byte_columns();
+            import_scope.add_use(*file_id, evidence, use_scope(scope_start, scope_end));
         }
     }
 
@@ -224,6 +242,9 @@ pub(crate) fn resolve_and_insert_edges(
         let target_qualified_name = arena.get_opt(candidate.target_qualified_name);
         let evidence = arena.get_opt(candidate.evidence);
         let receiver_hint = arena.get_opt(candidate.receiver_hint);
+        // The reference's source byte selects which in-scope `use` items suppress it (#96) — the DB
+        // path reads the same value from `d.source_start_byte`, keeping the two drivers in parity.
+        let ref_byte = usize::try_from(candidate.source_span.start_byte).unwrap_or(0);
         let resolution = resolve_symbol(
             ResolveSymbolRequest {
                 name: to_name,
@@ -233,8 +254,15 @@ pub(crate) fn resolve_and_insert_edges(
                 receiver_hint,
                 source_file_id: *file_id,
                 source_language: index.file_language.get(file_id).copied(),
-                imported_external: import_scope.is_external_import(*file_id, short_name(to_name))
-                    || import_scope.is_external_qualified_root(*file_id, target_qualified_name),
+                imported_external: import_scope.is_external_import(
+                    *file_id,
+                    short_name(to_name),
+                    ref_byte,
+                ) || import_scope.is_external_qualified_root(
+                    *file_id,
+                    target_qualified_name,
+                    ref_byte,
+                ),
             },
             &index,
         );
@@ -514,6 +542,19 @@ pub(crate) fn allow_unqualified_fallback(
         return false;
     }
     true
+}
+/// The byte range a Rust `use` is scoped to (#96), read from the Imports edge's callee-byte
+/// columns (which carry the enclosing-module/block range, not a callee identifier, for `use`s).
+/// NULL columns — a pre-#96 index, or a non-Rust import edge that never set them — fall back to the
+/// WHOLE-FILE range (`0..usize::MAX`), reproducing the previous per-file suppression so an older DB
+/// resolves exactly as before and only loses the per-module precision. Both resolve drivers call
+/// this with the same inputs so their suppression is identical.
+fn use_scope(scope_start: Option<i64>, scope_end: Option<i64>) -> (usize, usize) {
+    match (scope_start, scope_end) {
+        (Some(start), Some(end)) =>
+            (usize::try_from(start).unwrap_or(0), usize::try_from(end).unwrap_or(usize::MAX)),
+        _ => (0, usize::MAX),
+    }
 }
 /// Whether an edge's `target_qualified_name` is an explicitly LOCAL-rooted path (`crate::…`,
 /// `self::…`, `super::…`) — code disambiguating a local item with a qualifier. Such a reference is
@@ -858,6 +899,77 @@ mod tests {
             params![source_file_id, to_name, evidence],
         )
         .unwrap();
+    }
+
+    /// An Imports edge whose enclosing-`use`-scope byte range is recorded in the callee-byte
+    /// columns (#96), exactly as `enclosing_use_scope` does on a real `use_declaration`.
+    fn add_import_edge_scoped(
+        conn: &Connection,
+        source_file_id: i64,
+        to_name: &str,
+        evidence: &str,
+        scope: (i64, i64),
+    ) {
+        conn.execute(
+            "INSERT INTO edges(source_file_id, to_name, target_qualified_name, edge_kind, \
+             confidence, resolution, evidence, callee_start_byte, callee_end_byte) VALUES (?1, \
+             ?2, '', 'imports', 'NameOnly', 'unresolved', ?3, ?4, ?5)",
+            params![source_file_id, to_name, evidence, scope.0, scope.1],
+        )
+        .unwrap();
+    }
+
+    /// A reference edge positioned at `source_start_byte`, so per-module suppression (#96) can
+    /// range-test it against the `use`'s scope.
+    fn add_edge_at(
+        conn: &Connection,
+        source_file_id: i64,
+        to_name: &str,
+        target_qualified_name: &str,
+        source_start_byte: i64,
+    ) -> i64 {
+        conn.execute(
+            "INSERT INTO edges(source_file_id, to_name, target_qualified_name, edge_kind, \
+             confidence, resolution, source_start_byte) VALUES (?1, ?2, ?3, 'calls_name', \
+             'NameOnly', 'unresolved', ?4)",
+            params![source_file_id, to_name, target_qualified_name, source_start_byte],
+        )
+        .unwrap();
+        conn.query_row("SELECT MAX(id) FROM edges_data", [], |row| row.get(0)).unwrap()
+    }
+
+    /// #96: a single file with `mod a { use url::Url; }` and `mod b { struct Url; }`. The `use` is
+    /// scoped to `mod a`'s body, so a bare `Url` reference inside `mod a` is suppressed (external
+    /// `url::Url`), while a bare `Url` reference inside `mod b` binds to the LOCAL `Url` — the
+    /// per-file scope of #61 wrongly suppressed both.
+    #[test]
+    fn import_scope_is_per_module_not_per_file() {
+        let conn = seeded_conn();
+        set_local_crate_roots(&conn, "mycrate");
+        let user = add_file(&conn, "a.rs", NEW);
+        // `mod a { use url::Url; }` body spans bytes 10..40; `mod b { struct Url; … }` spans
+        // 50..90.
+        let local = add_symbol(&conn, user, "Url", "crate::a::b::Url");
+        add_import_edge_scoped(&conn, user, "Url", "use url::Url;", (10, 40));
+        // A `Url` reference inside `mod a` (byte 25) is the external import — suppressed.
+        let in_mod_a = add_edge_at(&conn, user, "Url", "", 25);
+        // A `Url` reference inside `mod b` (byte 60) is outside the `use`'s scope — binds local.
+        let in_mod_b = add_edge_at(&conn, user, "Url", "", 60);
+
+        crate::index::install_scope_view(&conn, NEW, "").unwrap();
+        resolve_all_edges(&conn).unwrap();
+
+        let (to, _, resolution) = edge_state(&conn, in_mod_a);
+        assert_eq!(to, None, "`Url` inside `mod a` is the external `url::Url` — suppressed");
+        assert_eq!(resolution, "unresolved");
+
+        let (to, _, _) = edge_state(&conn, in_mod_b);
+        assert_eq!(
+            to,
+            Some(local),
+            "`Url` inside `mod b` is outside the `use`'s scope — the local `Url` must resolve \
+             (#96)"
+        );
     }
 
     /// #61 Project B: a bare reference to a name `use`d from an EXTERNAL crate (`url::Url`) must not

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -57,6 +57,16 @@ pub(crate) struct EdgeJoinCandidate {
 /// *call* and must be excluded from the recall numerator (the population-mismatch finding, #81).
 pub(crate) const CALL_EDGE_KIND: &str = "calls_name";
 
+/// The edge kinds the oracle judges: symbol-referencing edges whose callee byte range is a callee
+/// *identifier token* SCIP occurrences key on. The NULL filter alone is NOT a sufficient candidate
+/// scope — since #96 a Rust `imports` edge overloads `callee_start_byte`/`callee_end_byte` with its
+/// enclosing-module *scope* range (a non-identifier span), so a NULL-only filter would feed import
+/// rows into occurrence classification and inflate `no_occurrence` (#100). File-level kinds
+/// (`imports` / `exports` / `contains`) are excluded here so only identifier-anchored edges reach
+/// the join. Keep this in step with the kinds `index::edges::extract` attaches a `CalleeRange` to.
+pub(crate) const ORACLE_JUDGED_EDGE_KINDS: &[&str] =
+    &["calls_name", "references_type", "uses_macro", "implements", "constructs"];
+
 /// One symbol's identity + byte span within a file, for mapping a SCIP definition range back to our
 /// symbol table by containment overlap.
 #[derive(Debug, Clone)]
@@ -67,14 +77,22 @@ pub(crate) struct SymbolSpan {
 }
 
 /// Load every edge candidate that carries a callee identifier byte range, joined to its source
-/// file's path + content sha. Only call-shaped edges set `callee_start_byte`, so the NULL filter
-/// scopes this to exactly the rows the SCIP occurrence join can act on. Scoped to the active
-/// commit/worktree via the `files` row the edge points at.
+/// file's path + content sha. Two filters jointly scope the candidate set to rows the SCIP
+/// occurrence join can act on: a non-NULL callee byte range AND an [`ORACLE_JUDGED_EDGE_KINDS`]
+/// membership check. The kind filter is load-bearing — since #96 a Rust `imports` edge stores its
+/// enclosing-module *scope* range (not a callee identifier) in the callee byte columns, so a
+/// NULL-only filter would drag import rows into occurrence classification and corrupt the metrics
+/// (#100). Scoped to the active commit/worktree via the `files` row the edge points at.
 pub(crate) fn edge_join_candidates(
     conn: &Connection,
     commit_sha: &str,
     worktree_id: &str,
 ) -> anyhow::Result<Vec<EdgeJoinCandidate>> {
+    let judged_kinds = ORACLE_JUDGED_EDGE_KINDS
+        .iter()
+        .map(|kind| format!("'{kind}'"))
+        .collect::<Vec<_>>()
+        .join(", ");
     let mut stmt = conn.prepare(&format!(
         "
         SELECT edges.id,
@@ -89,6 +107,7 @@ pub(crate) fn edge_join_candidates(
         JOIN files ON files.id = edges.source_file_id
         WHERE edges.callee_start_byte IS NOT NULL
           AND edges.callee_end_byte IS NOT NULL
+          AND edges.edge_kind IN ({judged_kinds})
           AND {scope}
         ORDER BY files.path, edges.callee_start_byte
         ",

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -802,6 +802,28 @@ fn edge_join_candidates_filters_null_range_and_scopes_by_worktree() {
     assert!(store::edge_join_candidates(&h.conn, "other-commit-sha", WORKTREE).unwrap().is_empty());
 }
 
+/// An `imports` edge whose callee byte columns carry a non-NULL range (since #96 a Rust `use`
+/// stores its enclosing-module SCOPE range there, not a callee identifier) must NOT become an
+/// oracle candidate — the NULL filter alone no longer scopes the population, so the edge-kind
+/// allowlist excludes it (#100). The judged sibling kinds on the same file still join.
+#[test]
+fn edge_join_candidates_excludes_imports_scope_range() {
+    let h = Harness::new();
+    let file = h.add_file("lib.rs", "use crate::foo;\nfn f() { bar(); }\n");
+    // The #96 import-scope edge: a non-NULL callee range that is a module SCOPE, not an identifier.
+    let import_edge = h.add_edge_with_kind(file, "crate::foo", 0, 34, "imports", "Exact", None);
+    // Judged kinds carrying a real callee identifier range stay candidates.
+    let call_edge = h.add_edge_with_kind(file, "bar", 25, 28, "calls_name", "NameOnly", None);
+    let type_edge = h.add_edge_with_kind(file, "Foo", 4, 14, "references_type", "Exact", None);
+
+    let candidates = store::edge_join_candidates(&h.conn, COMMIT, WORKTREE).unwrap();
+    let ids: Vec<i64> = candidates.iter().map(|c| c.edge_id).collect();
+    // The imports edge is filtered out despite its non-NULL callee range; the judged kinds remain
+    // (ordered by callee_start_byte: references_type at 4 before calls_name at 25).
+    assert!(!ids.contains(&import_edge), "imports edge must not be an oracle candidate");
+    assert_eq!(ids, vec![type_edge, call_edge]);
+}
+
 /// `symbol_spans_for_path` returns the file's symbols ordered by start byte, scoped to the path +
 /// commit/worktree, and empty for an unknown path.
 #[test]


### PR DESCRIPTION
Fixes #96.

## Problem

`ImportScope` (the #61 crate-aware import suppression) keyed imported bindings by **file**, but a Rust `use` item is scoped to its enclosing module/block. So a single file with

```rust
mod a { use url::Url; }   // external `url::Url`
mod b { struct Url; fn g() { let _: Url; } }   // local Url
```

made **every** `Url` edge in the file `imported_external`, so `resolve_symbol` returned `None` for `mod b`'s valid local `Url` references before normal matching.

## Scoping mechanism

Suppression is now confined to each `use`'s enclosing module/block, with **no schema migration** — it reuses columns already on the edge row.

- **Record the scope (extract.rs).** `enclosing_use_scope` walks `node.parent()` from the `use_declaration` to the nearest ancestor `declaration_list` (a `mod m { … }` body) or `block` (a block-scoped `use`) and takes that body's `start_byte..end_byte`. A top-level `use` has no such ancestor and scopes the **whole file** (`0..text.len()`), reproducing the old per-file behavior for the common case. Rust `use` items are order-independent within their module, so the whole body range is the correct lexical scope. The range rides in the Imports edge's otherwise-unused `callee_start_byte`/`callee_end_byte` columns (a `use` has no callee identifier), via the new `file_edge_scoped`.
- **Match references (imports.rs).** `ImportScope` stores per name a list of `{root, scope_start, scope_end}` bindings (a name can be `use`d in multiple scopes in one file). `is_external_import`/`is_external_qualified_root` take the reference's source byte and suppress only when a binding's half-open `[scope_start, scope_end)` covers it.
- **Carry the reference byte (resolve.rs).** Both resolve drivers pass the edge's `source_start_byte` as the reference position. The DB path (`resolve_all_edges`) reads it and the scope columns from SQL; the full-rebuild interned path (`resolve_and_insert_edges`) reads `candidate.source_span.start_byte` and `candidate.callee_byte_columns()`. Both funnel through one `use_scope(...)` helper, so they compute **identical** suppression.

## Fully handled vs deliberately limited

- **Fully handled:** top-level, `mod`-scoped, block-scoped, and nested-module `use`s; multiple `use`s of the same leaf name in disjoint scopes within one file; the `mod a { use url::Url } / mod b { local Url }` case from the issue.
- **Fail-soft / parity:** NULL callee columns (a pre-#96 index, or a non-Rust import edge) fall back to a whole-file scope, so an older DB resolves exactly as before and only loses per-module precision — never a regression.
- **Deliberately limited:** a `use` in a parent module is not *subtracted* when a child module shadows the same name from a different root (the parent scope still covers the child's bytes). This is the same conservative direction as #61 (toward suppression), vanishingly rare, and not worth the added complexity. Documented in the code and in a rag-rat memory.

Fail-open (empty local-crate set suppresses nothing) and the local-qualified (`crate::`/`self::`/`super::`) exemption are preserved.

## Tests

New:
- `extract::enclosing_use_scope_is_the_module_body_not_the_file`, `_handles_block_and_nested_module` — the scope source, via a real tree-sitter parse.
- `imports::import_scope_is_confined_to_the_enclosing_module` — unit, including the half-open boundary.
- `resolve::import_scope_is_per_module_not_per_file` — end-to-end DB path: a bare `Url` inside `mod a` stays suppressed while a `Url` inside `mod b` resolves to the local definition.

The existing #61 tests (`external_import_suppresses_bare_but_not_locally_qualified`, `use_path_prefix_does_not_suppress_a_local_name`, `qualified_call_through_an_external_receiver_is_suppressed`) are unchanged and still pass.

`cargo test -p rag-rat-core` (319 passed), `cargo clippy -p rag-rat-core --all-targets`, and `cargo +nightly fmt --check` are all clean.