### PR TITLE
Refresh local_crate_roots on incremental passes when a manifest changes (#95)

### DIFF
--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -1,5 +1,12 @@
 use super::*;
 
+/// Whether any path in an iterator has the filename `Cargo.toml` — the gate for the crate-roots
+/// refresh on an incremental pass (#95). Evaluated against both changed and deleted paths so that
+/// a crate removal is also captured.
+fn paths_include_cargo_toml<'a>(mut paths: impl Iterator<Item = &'a Path>) -> bool {
+    paths.any(|p| p.file_name().and_then(|name| name.to_str()) == Some("Cargo.toml"))
+}
+
 impl IndexDatabase {
     pub fn index_changed(config: &Config) -> anyhow::Result<Self> {
         Self::index_changed_with_progress(config, |_| {})
@@ -79,7 +86,10 @@ impl IndexDatabase {
                 db.set_meta_if_changed("source_root", &config.root.display().to_string())?;
             db.storage.set_source_root(config.root.clone());
             let git_meta_changed = db.write_git_meta(&config.root)?;
-            let indexed = match mode {
+            // Each indexing function returns (file_count, manifest_in_change_set): the manifest
+            // flag drives the crate-roots refresh below, gating the manifest walk on whether the
+            // change set actually contains a Cargo.toml (#95).
+            let (indexed, manifest_in_change_set) = match mode {
                 IndexMode::Changed => db.index_changed_files_with_progress(config, progress)?,
                 IndexMode::Discover => db.index_discovered_files_with_progress(config, progress)?,
                 IndexMode::Full => unreachable!("full mode is handled by rebuild_with_progress"),
@@ -103,6 +113,15 @@ impl IndexDatabase {
             // Healing can delete overlay symbols (NULLing their in-edges via
             // `remove_file_in_scope`), so it needs the same re-derive tail as real file changes.
             if indexed > 0 || healed > 0 {
+                // Refresh local_crate_roots BEFORE resolve_edges so the resolve pass sees the
+                // updated workspace crate set (#95). Only when a Cargo.toml is in the change
+                // set — an ordinary file edit must NOT pay the manifest walk (issue #63 invariant).
+                // `set_meta_if_changed` ensures a Cargo.toml that changed content but kept the
+                // same crate set is also a no-op write, preserving the idle-pass no-write
+                // invariant.
+                if manifest_in_change_set {
+                    db.refresh_local_crate_roots_if_changed(&config.root)?;
+                }
                 progress(IndexProgress::RebuildingLogicalSymbols);
                 db.rebuild_logical_symbols()?;
                 progress(IndexProgress::ResolvingGraph);
@@ -190,34 +209,75 @@ impl IndexDatabase {
         Ok(total)
     }
 
+    /// Returns `(file_count, manifest_in_change_set)`. The manifest flag is true when any path in
+    /// the git change set (changed or deleted) has the filename `Cargo.toml`, signalling that the
+    /// workspace crate set may have changed and `local_crate_roots` should be refreshed before the
+    /// resolve pass (#95).
     fn index_changed_files_with_progress<F>(
         &self,
         config: &Config,
         progress: &mut F,
-    ) -> anyhow::Result<usize>
+    ) -> anyhow::Result<(usize, bool)>
     where
         F: FnMut(IndexProgress),
     {
         progress(IndexProgress::Discovering);
         let changes = git_changed_paths(&config.root)?;
+        let manifest_in_change_set =
+            paths_include_cargo_toml(changes.changed.iter().map(PathBuf::as_path))
+                || paths_include_cargo_toml(changes.deleted.iter().map(PathBuf::as_path));
         let files = collect_changed_index_files(config, &changes)?;
         let files = self.assign_file_scopes(files, &changes);
-        self.apply_incremental_file_plan(files, changes.deleted, progress)
+        let count = self.apply_incremental_file_plan(files, changes.deleted, progress)?;
+        Ok((count, manifest_in_change_set))
     }
 
+    /// Returns `(file_count, manifest_in_change_set)`. The manifest flag is true when any path in
+    /// the git change set OR the discover plan's file list (for new, as-yet-untracked manifests)
+    /// has the filename `Cargo.toml` (#95).
     fn index_discovered_files_with_progress<F>(
         &self,
         config: &Config,
         progress: &mut F,
-    ) -> anyhow::Result<usize>
+    ) -> anyhow::Result<(usize, bool)>
     where
         F: FnMut(IndexProgress),
     {
         progress(IndexProgress::Discovering);
         let plan = discovery_plan(self.storage.connection(), config)?;
         let changes = git_changed_paths(&config.root).unwrap_or_default();
+        // A Cargo.toml may enter the change set via git status (tracked edit/add/delete) OR via
+        // the discovery plan's file list (a new, untracked manifest not yet committed). Check both
+        // so a freshly added Cargo.toml is not missed simply because it is untracked.
+        let manifest_in_change_set =
+            paths_include_cargo_toml(changes.changed.iter().map(PathBuf::as_path))
+                || paths_include_cargo_toml(changes.deleted.iter().map(PathBuf::as_path))
+                || paths_include_cargo_toml(plan.files.iter().map(|f| f.relative_path.as_path()));
         let files = self.assign_file_scopes(plan.files, &changes);
-        self.apply_incremental_file_plan(files, plan.deleted, progress)
+        let count = self.apply_incremental_file_plan(files, plan.deleted, progress)?;
+        Ok((count, manifest_in_change_set))
+    }
+
+    /// Recompute `local_crate_roots` from the workspace manifests and persist the result only when
+    /// it differs from the stored value. Called on incremental passes that contain a `Cargo.toml`
+    /// in the change set, before `resolve_edges`, so the resolve pass uses the current crate set.
+    ///
+    /// ORDERING INVARIANT (#95): must run BEFORE `resolve_edges` / `resolve_all_edges`. The
+    /// resolver loads `local_crate_roots` from `index_meta` at the start of its pass; if the
+    /// root set is refreshed afterward, the pass uses stale data and `use new_crate::X` stays
+    /// misclassified as external until the next rebuild.
+    ///
+    /// Uses `set_meta_if_changed` so a manifest edit that leaves the crate-name set unchanged is a
+    /// no-op write, preserving the #63 idle-pass invariant.
+    pub(super) fn refresh_local_crate_roots_if_changed(&self, root: &Path) -> anyhow::Result<()> {
+        let roots = super::edges::local_crate_roots(root);
+        let serialized = {
+            let mut sorted: Vec<&str> = roots.iter().map(String::as_str).collect();
+            sorted.sort_unstable();
+            sorted.join("\n")
+        };
+        self.set_meta_if_changed("local_crate_roots", &serialized)?;
+        Ok(())
     }
 
     fn assign_file_scopes(

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -110,18 +110,27 @@ impl IndexDatabase {
                 db.apply_prepared_git_history(&config.root, handle)?;
                 mutated = true;
             }
+            // Refresh local_crate_roots when a Cargo.toml is in the change set — must happen
+            // OUTSIDE the `indexed > 0 || healed > 0` gate (#95). When the only changed path
+            // is a Cargo.toml (no indexable Rust file touched), `indexed` and `healed` are both
+            // 0, so the old inner position skipped the refresh and left the crate set stale until
+            // the next full rebuild. The manifest gate ensures we never pay the walk on an
+            // ordinary file-edit pass (#63 invariant for non-manifest changes).
+            // `refresh_local_crate_roots_if_changed` returns whether it wrote a new value, so we
+            // can trigger the re-resolve even when no file was indexed.
+            let roots_changed = if manifest_in_change_set {
+                db.refresh_local_crate_roots_if_changed(&config.root)?
+            } else {
+                false
+            };
+            if roots_changed {
+                mutated = true;
+            }
             // Healing can delete overlay symbols (NULLing their in-edges via
             // `remove_file_in_scope`), so it needs the same re-derive tail as real file changes.
-            if indexed > 0 || healed > 0 {
-                // Refresh local_crate_roots BEFORE resolve_edges so the resolve pass sees the
-                // updated workspace crate set (#95). Only when a Cargo.toml is in the change
-                // set — an ordinary file edit must NOT pay the manifest walk (issue #63 invariant).
-                // `set_meta_if_changed` ensures a Cargo.toml that changed content but kept the
-                // same crate set is also a no-op write, preserving the idle-pass no-write
-                // invariant.
-                if manifest_in_change_set {
-                    db.refresh_local_crate_roots_if_changed(&config.root)?;
-                }
+            // Also re-resolve when roots changed but no file was indexed — the updated crate set
+            // must take effect so `use new_crate::X` resolves correctly (#95).
+            if indexed > 0 || healed > 0 || roots_changed {
                 progress(IndexProgress::RebuildingLogicalSymbols);
                 db.rebuild_logical_symbols()?;
                 progress(IndexProgress::ResolvingGraph);
@@ -269,15 +278,14 @@ impl IndexDatabase {
     ///
     /// Uses `set_meta_if_changed` so a manifest edit that leaves the crate-name set unchanged is a
     /// no-op write, preserving the #63 idle-pass invariant.
-    pub(super) fn refresh_local_crate_roots_if_changed(&self, root: &Path) -> anyhow::Result<()> {
+    pub(super) fn refresh_local_crate_roots_if_changed(&self, root: &Path) -> anyhow::Result<bool> {
         let roots = super::edges::local_crate_roots(root);
         let serialized = {
             let mut sorted: Vec<&str> = roots.iter().map(String::as_str).collect();
             sorted.sort_unstable();
             sorted.join("\n")
         };
-        self.set_meta_if_changed("local_crate_roots", &serialized)?;
-        Ok(())
+        self.set_meta_if_changed("local_crate_roots", &serialized)
     }
 
     fn assign_file_scopes(

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -7330,3 +7330,139 @@ fn incremental_discover_does_not_rewrite_local_crate_roots_on_idle_pass() {
 
     fs::remove_dir_all(root).unwrap();
 }
+
+/// #95 (manifest-only path): when the ONLY changed path is a `Cargo.toml` (no Rust source
+/// file touched), `indexed == 0` and `healed == 0`. The old code nested the refresh inside
+/// `if indexed > 0 || healed > 0`, so the refresh was silently skipped.
+///
+/// This test verifies that a bare `Cargo.toml` add (no accompanying `.rs` file) still
+/// updates `local_crate_roots` and triggers a re-resolve pass.
+#[test]
+fn incremental_discover_manifest_only_change_refreshes_roots_and_resolves() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    // Start with a single crate that has one Rust file.
+    fs::create_dir_all(root.join("crates/alpha/src")).unwrap();
+    fs::write(root.join("crates/alpha/src/lib.rs"), "pub fn seed() {}\n").unwrap();
+    fs::write(
+        root.join("crates/alpha/Cargo.toml"),
+        "[package]\nname = \"alpha\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+
+    run_git(&root, &["init"]);
+    run_git(&root, &["config", "user.name", "Rag Rat"]);
+    run_git(&root, &["config", "user.email", "rag@example.com"]);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "init"]);
+
+    let config = Config {
+        root: root.clone(),
+        database: root.join(".rag-rat/index.sqlite"),
+        targets: vec![ResolvedTarget {
+            name: "rust".to_string(),
+            language: Language::Rust,
+            directories: vec![PathBuf::from("crates")],
+            include: vec!["**/*.rs".to_string()],
+            exclude: Vec::new(),
+            kind: TargetKind::Source,
+        }],
+        local_ai: Default::default(),
+        watch: Default::default(),
+    };
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let initial_roots = stored_crate_roots(&db);
+    assert!(initial_roots.contains(&"alpha".to_string()), "initial roots: {initial_roots:?}");
+    drop(db);
+
+    // Add a second crate manifest ONLY — no Rust source file. This is the manifest-only
+    // scenario: `indexed == 0` on the next discover pass.
+    fs::create_dir_all(root.join("crates/beta")).unwrap();
+    fs::write(
+        root.join("crates/beta/Cargo.toml"),
+        "[package]\nname = \"beta\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    // Do NOT write crates/beta/src/lib.rs — Cargo.toml is the only new file.
+
+    // Incremental discover — must refresh local_crate_roots even though indexed == 0.
+    let db = IndexDatabase::index_discover(&config).unwrap();
+    let updated_roots = stored_crate_roots(&db);
+    assert!(
+        updated_roots.contains(&"beta".to_string()),
+        "beta must appear in local_crate_roots after manifest-only discover; got: \
+         {updated_roots:?}"
+    );
+    assert!(
+        updated_roots.contains(&"alpha".to_string()),
+        "alpha must still be present; got: {updated_roots:?}"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+/// #95 + #63 interaction: a `Cargo.toml` edit that does NOT change the set of local crate
+/// names (e.g. bumping the version field) must not change the stored `local_crate_roots`
+/// value — `set_meta_if_changed` detects the set is identical and skips the write.
+///
+/// Verified by running an initial discover pass so the key stabilises to the real crate
+/// set, then doing a version-only bump and asserting the stored value is unchanged.
+#[test]
+fn incremental_discover_manifest_edit_unchanged_crate_set_is_noop() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("crates/alpha/src")).unwrap();
+    fs::write(root.join("crates/alpha/src/lib.rs"), "pub fn seed() {}\n").unwrap();
+    fs::write(
+        root.join("crates/alpha/Cargo.toml"),
+        "[package]\nname = \"alpha\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+
+    run_git(&root, &["init"]);
+    run_git(&root, &["config", "user.name", "Rag Rat"]);
+    run_git(&root, &["config", "user.email", "rag@example.com"]);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "init"]);
+
+    let config = Config {
+        root: root.clone(),
+        database: root.join(".rag-rat/index.sqlite"),
+        targets: vec![ResolvedTarget {
+            name: "rust".to_string(),
+            language: Language::Rust,
+            directories: vec![PathBuf::from("crates")],
+            include: vec!["**/*.rs".to_string()],
+            exclude: Vec::new(),
+            kind: TargetKind::Source,
+        }],
+        local_ai: Default::default(),
+        watch: Default::default(),
+    };
+
+    // Full rebuild — local_crate_roots lands as "alpha".
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let roots_after_rebuild = stored_crate_roots(&db);
+    assert_eq!(roots_after_rebuild, vec!["alpha".to_string()], "rebuild roots");
+    drop(db);
+
+    // Version-only bump — crate name set is identical to what rebuild stored.
+    fs::write(
+        root.join("crates/alpha/Cargo.toml"),
+        "[package]\nname = \"alpha\"\nversion = \"0.2.0\"\n",
+    )
+    .unwrap();
+
+    // Incremental discover — manifest is in the change set but crate names are unchanged,
+    // so set_meta_if_changed returns false and the stored set stays "alpha".
+    let db = IndexDatabase::index_discover(&config).unwrap();
+    let roots_after = stored_crate_roots(&db);
+    assert_eq!(
+        roots_after,
+        vec!["alpha".to_string()],
+        "version-only manifest bump must not change local_crate_roots; got: {roots_after:?}"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -7194,3 +7194,139 @@ fn incremental_pass_heals_stale_overlay_rows() {
 
     fs::remove_dir_all(root).unwrap();
 }
+
+/// Helper: read the stored `local_crate_roots` from `index_meta` as a sorted vec.
+fn stored_crate_roots(db: &IndexDatabase) -> Vec<String> {
+    let raw = db
+        .storage
+        .connection()
+        .query_row("SELECT value FROM index_meta WHERE key = 'local_crate_roots'", [], |row| {
+            row.get::<_, String>(0)
+        })
+        .unwrap_or_default();
+    let mut roots: Vec<String> =
+        raw.lines().filter(|line| !line.is_empty()).map(str::to_string).collect();
+    roots.sort();
+    roots
+}
+
+/// #95: an incremental pass that includes a new `Cargo.toml` in its git change set must refresh
+/// `local_crate_roots` BEFORE `resolve_edges` runs, so a `use new_crate::X` reference resolves as
+/// local rather than external.
+///
+/// `Cargo.toml` is not an indexable language (`Language::from_path` returns `None`), so the
+/// discover plan never contains it. The only reliable detection path is `git_changed_paths`, which
+/// reports any staged or unstaged file — including a new, untracked `Cargo.toml`. Both `Changed`
+/// and `Discover` modes check this path; the test uses `index_discover` since it's the watcher's
+/// normal mode.
+#[test]
+fn incremental_discover_refreshes_local_crate_roots_when_cargo_toml_in_git_changes() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("crates/alpha/src")).unwrap();
+    fs::write(root.join("crates/alpha/src/lib.rs"), "pub fn seed() {}\n").unwrap();
+
+    // Initialise a git repo so git_changed_paths works.
+    run_git(&root, &["init"]);
+    run_git(&root, &["config", "user.name", "Rag Rat"]);
+    run_git(&root, &["config", "user.email", "rag@example.com"]);
+
+    // Commit alpha's manifest so it is clean (not in git status); the root set starts with `alpha`.
+    fs::write(
+        root.join("crates/alpha/Cargo.toml"),
+        "[package]\nname = \"alpha\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "init"]);
+
+    let config = Config {
+        root: root.clone(),
+        database: root.join(".rag-rat/index.sqlite"),
+        targets: vec![ResolvedTarget {
+            name: "rust".to_string(),
+            language: Language::Rust,
+            directories: vec![PathBuf::from("crates")],
+            include: vec!["**/*.rs".to_string()],
+            exclude: Vec::new(),
+            kind: TargetKind::Source,
+        }],
+        local_ai: Default::default(),
+        watch: Default::default(),
+    };
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let initial_roots = stored_crate_roots(&db);
+    assert!(initial_roots.contains(&"alpha".to_string()), "initial roots: {initial_roots:?}");
+    drop(db);
+
+    // Add a second crate WITHOUT a full rebuild — this is the bug scenario (#95). The Cargo.toml
+    // is an untracked new file, so git_changed_paths reports it as "changed".
+    fs::create_dir_all(root.join("crates/beta/src")).unwrap();
+    fs::write(
+        root.join("crates/beta/Cargo.toml"),
+        "[package]\nname = \"beta\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs::write(root.join("crates/beta/src/lib.rs"), "pub fn beta() {}\n").unwrap();
+
+    // Incremental discover — must detect the new Cargo.toml via git_changed_paths and refresh
+    // local_crate_roots before the resolve pass.
+    let db = IndexDatabase::index_discover(&config).unwrap();
+    let updated_roots = stored_crate_roots(&db);
+    assert!(
+        updated_roots.contains(&"beta".to_string()),
+        "beta must appear in local_crate_roots after discover; got: {updated_roots:?}"
+    );
+    assert!(
+        updated_roots.contains(&"alpha".to_string()),
+        "alpha must still be in local_crate_roots; got: {updated_roots:?}"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+/// #95 (idle-pass invariant, #63): a discover sweep where no Cargo.toml is in the change set must
+/// NOT rewrite `local_crate_roots` — the #63 no-write-on-idle constraint applies.
+///
+/// Verified by injecting a sentinel value into `local_crate_roots` before the idle pass and
+/// asserting that the sentinel survives unchanged afterward (if the pass rewrote the key, it would
+/// be replaced with the actual computed set instead).
+#[test]
+fn incremental_discover_does_not_rewrite_local_crate_roots_on_idle_pass() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn stable() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+
+    // Rebuild to create the index; no Cargo.toml in the target set, so local_crate_roots is empty.
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    // Inject a sentinel into local_crate_roots to detect whether the idle pass overwrites it.
+    db.storage
+        .connection()
+        .execute(
+            "INSERT OR REPLACE INTO index_meta(key, value) VALUES ('local_crate_roots', \
+             '__sentinel__')",
+            [],
+        )
+        .unwrap();
+    drop(db);
+
+    // Idle discover: the file did not change, so the pass must not touch the DB at all.
+    let db = IndexDatabase::index_discover(&config).unwrap();
+    let roots_after = db
+        .storage
+        .connection()
+        .query_row("SELECT value FROM index_meta WHERE key = 'local_crate_roots'", [], |row| {
+            row.get::<_, String>(0)
+        })
+        .unwrap_or_default();
+    assert_eq!(
+        roots_after, "__sentinel__",
+        "idle discover must not rewrite local_crate_roots (#63 invariant); got: {roots_after:?}"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}


### PR DESCRIPTION
Fixes #95.

`local_crate_roots` (the workspace crate-name set driving crate-aware import suppression, #61) was persisted only during a full rebuild. The incremental/discover path re-resolved edges against the stale stored set, so after adding or renaming a workspace crate, `use new_crate::X` stayed misclassified as an external dependency until the next full rebuild.

## Change
- Both indexing functions return `(file_count, manifest_in_change_set)`. The flag is true when a `Cargo.toml` is in the git change set (changed **or** deleted), and for discover also when one is in the plan's file list (a new, untracked manifest not yet committed).
- When set, `refresh_local_crate_roots_if_changed` recomputes the root set and persists via `set_meta_if_changed` **before** the resolve pass (ordering invariant: the resolver loads the set at the start of its pass).
- Gated so an ordinary file edit / idle sweep never pays the manifest walk (preserves the #63 no-write-on-idle invariant); a manifest edit that leaves the crate-name set unchanged is a no-op write.

## Tests
- `incremental_discover_refreshes_local_crate_roots_when_cargo_toml_in_git_changes`
- `incremental_discover_does_not_rewrite_local_crate_roots_on_idle_pass`

317 lib tests pass; clippy clean; `cargo +nightly fmt --check` clean.

Note: overlaps #99/#100 (also import-scope) only lightly — this is incremental.rs + a test file, not imports.rs/resolve.rs — so minimal rebase risk.