### PR TITLE
Auto-migrate forward on open — no manual `rag-rat migrate` (#102)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ rag-rat init
 ```
 
 `rag-rat init` scans the repository, prompts for languages and path bindings, writes
-`rag-rat.toml`, migrates the SQLite schema, indexes the repo, and offers to install/reconcile the
+`rag-rat.toml`, indexes the repo, and offers to install/reconcile the
 local embedding model. At the end it can also register the MCP server for Claude Code or Codex and
 install the optional git maintenance hooks.
 
@@ -195,7 +195,6 @@ exclude = [".git/**", ".rag-rat/**", "target/**", "node_modules/**"]
 Then run the pieces directly:
 
 ```bash
-rag-rat migrate
 rag-rat index --discover
 rag-rat doctor
 ```
@@ -447,7 +446,6 @@ Supported MCP tools:
 
 Supported operational commands:
 
-- `migrate` / `migrate --check`
 - `doctor`
 - `index_status`
 - `heal_index`
@@ -521,8 +519,6 @@ rag-rat index --discover
 rag-rat index --full
 rag-rat init
 rag-rat doctor
-rag-rat migrate --check
-rag-rat migrate
 rag-rat github sync --from-refs
 rag-rat github sync --issue cq27-dev/rag-rat#42
 rag-rat github sync --from-refs --offline

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -38,9 +38,6 @@ pub(crate) enum Command {
     /// Report schema, storage, discovery, targets, and index health as JSON.
     Doctor,
 
-    /// Apply or check pending schema migrations.
-    Migrate(MigrateArgs),
-
     /// Search the index (lexical + semantic).
     Query(QueryArgs),
 
@@ -111,13 +108,6 @@ pub(crate) struct IndexArgs {
     /// Run the background file watcher in the foreground until interrupted.
     #[arg(long)]
     pub watch: bool,
-}
-
-#[derive(Debug, Args)]
-pub(crate) struct MigrateArgs {
-    /// Check migration state without applying (non-zero exit if incompatible).
-    #[arg(long)]
-    pub check: bool,
 }
 
 #[derive(Debug, Args)]

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::cli::{
     BriefArgs, ClustersArgs, EvalArgs, GithubArgs, GithubCommand, HookAction, HooksArgs, IndexArgs,
-    MaintenanceArgs, MemoryArgs, MemoryCommand, MigrateArgs, ModelsArgs, ModelsCommand, OracleArgs,
+    MaintenanceArgs, MemoryArgs, MemoryCommand, ModelsArgs, ModelsCommand, OracleArgs,
     OracleCommand, OracleRunArgs, OracleStatusArgs, QueryArgs, ReconcileArgs,
 };
 
@@ -364,18 +364,6 @@ pub(crate) fn set_env_if_absent(key: &str, value: Option<u32>) {
     unsafe {
         env::set_var(key, value.to_string());
     }
-}
-pub(crate) fn migrate(config: &Config, args: &MigrateArgs) -> anyhow::Result<()> {
-    let status = if args.check {
-        IndexDatabase::migration_check(&config.database)?
-    } else {
-        IndexDatabase::migrate(&config.database)?
-    };
-    print_json(&status)?;
-    if args.check && status.state != rag_rat_core::index::schema::SchemaState::Compatible {
-        anyhow::bail!("{}", status.message);
-    }
-    Ok(())
 }
 pub(crate) fn doctor(config: &Config) -> anyhow::Result<()> {
     let schema = IndexDatabase::migration_check(&config.database)?;

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -43,7 +43,6 @@ fn main() -> anyhow::Result<()> {
         Cmd::Init(_) | Cmd::ClaudeHook => unreachable!("handled before the config load above"),
         Cmd::Index(args) => index(&config, &args)?,
         Cmd::Doctor => doctor(&config)?,
-        Cmd::Migrate(args) => migrate(&config, &args)?,
         Cmd::Query(args) => query(&config, &args)?,
         Cmd::Brief(args) => brief(&config, &args)?,
         Cmd::Clusters(args) => clusters(&config, &args)?,

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -1,5 +1,11 @@
 use super::*;
 
+/// How long an `open` waits for the index write lock before giving up on auto-migrating a schema
+/// that lags this binary. Generous — a concurrent migrator (or a watcher maintenance pass holding
+/// the lock) finishes well within it; a timeout surfaces an explicit error, never a silent
+/// half-open.
+const SCHEMA_MIGRATE_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 impl IndexDatabase {
     pub fn open(path: &Path) -> anyhow::Result<Self> {
         Self::open_with_graph_check(path, true)
@@ -13,12 +19,29 @@ impl IndexDatabase {
         let mut storage = IndexConnection::open(path)?;
         // Forward schema migrations are automatic on open (the index is our own derived data — a
         // binary upgrade must not require a manual `migrate`). Only Newer/Dirty/Missing refuse.
-        schema::ensure_compatible_or_migrate(storage.connection())?;
+        //
+        // An `Older` schema is migrated UNDER THE INDEX WRITE LOCK: auto-migration now fires from
+        // ordinary read/MCP opens, so a hot-restarted server and a concurrent `query` could both
+        // observe `Older` and race `add_column_if_missing`'s check-then-ALTER into a
+        // duplicate-column DDL failure. Serializing on `write_lock_path` makes one opener
+        // migrate while the other waits, then re-checks under the lock (the waiter sees
+        // `Compatible` and does nothing). Compatible/Newer/Dirty/Missing need no lock —
+        // `ensure_compatible_or_migrate` returns or refuses without writing.
+        if schema::status(storage.connection())?.state == schema::SchemaState::Older {
+            let _lock = crate::locks::FileLock::acquire_timeout(
+                &crate::locks::write_lock_path(path),
+                SCHEMA_MIGRATE_LOCK_TIMEOUT,
+            )?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "timed out waiting for the index write lock to auto-migrate the schema"
+                )
+            })?;
+            schema::ensure_compatible_or_migrate(storage.connection())?;
+        } else {
+            schema::ensure_compatible_or_migrate(storage.connection())?;
+        }
         ai::ensure_model_manifest(storage.connection())?;
-        // Recover a previously-downloaded fastembed model into the manifest automatically (used to
-        // be the `migrate` command's job, which is gone — the binary owns its derived state, no
-        // manual step). No-op when the `fastembed` feature is off or no cached model is present.
-        ai::recover_cached_fastembed_model(storage.connection())?;
         if let Some(root) = meta_for(storage.connection(), "source_root")? {
             storage.set_source_root(PathBuf::from(root));
         }

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -11,7 +11,9 @@ impl IndexDatabase {
 
     fn open_with_graph_check(path: &Path, check_graph: bool) -> anyhow::Result<Self> {
         let mut storage = IndexConnection::open(path)?;
-        schema::check_compatible(storage.connection())?;
+        // Forward schema migrations are automatic on open (the index is our own derived data — a
+        // binary upgrade must not require a manual `migrate`). Only Newer/Dirty/Missing refuse.
+        schema::ensure_compatible_or_migrate(storage.connection())?;
         ai::ensure_model_manifest(storage.connection())?;
         if let Some(root) = meta_for(storage.connection(), "source_root")? {
             storage.set_source_root(PathBuf::from(root));

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -15,6 +15,10 @@ impl IndexDatabase {
         // binary upgrade must not require a manual `migrate`). Only Newer/Dirty/Missing refuse.
         schema::ensure_compatible_or_migrate(storage.connection())?;
         ai::ensure_model_manifest(storage.connection())?;
+        // Recover a previously-downloaded fastembed model into the manifest automatically (used to
+        // be the `migrate` command's job, which is gone — the binary owns its derived state, no
+        // manual step). No-op when the `fastembed` feature is off or no cached model is present.
+        ai::recover_cached_fastembed_model(storage.connection())?;
         if let Some(root) = meta_for(storage.connection(), "source_root")? {
             storage.set_source_root(PathBuf::from(root));
         }

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -268,19 +268,40 @@ pub fn status(conn: &Connection) -> anyhow::Result<SchemaStatus> {
     })
 }
 
-pub fn check_compatible(conn: &Connection) -> anyhow::Result<()> {
-    let status = status(conn)?;
-    match status.state {
+/// Make the open-able index schema current, migrating FORWARD automatically when it lags this
+/// binary. The index is rag-rat's own derived data, so upgrading the binary must never make a
+/// developer hand-run `migrate` (or play devops) to get queries/memory writes working again — an
+/// `Older` schema is applied in place here. Migrations are additive and idempotent (the same
+/// `apply` the `migrate` command runs on `Older`), so bringing a partly-migrated DB to latest is
+/// safe and a no-op for already-present tables/columns.
+///
+/// Only genuinely unrecoverable states still refuse:
+/// - `Newer`: created by a future rag-rat — this binary can't apply migrations it doesn't have, and
+///   downgrading derived data isn't safe.
+/// - `Dirty`: a partial/crashed migration or checksum mismatch — needs a clean `index --full`.
+/// - `Missing`: there is no index at this path yet — nothing to migrate; build one first.
+pub fn ensure_compatible_or_migrate(conn: &Connection) -> anyhow::Result<()> {
+    let current = status(conn)?;
+    match current.state {
         SchemaState::Compatible => Ok(()),
-        SchemaState::Missing => {
-            anyhow::bail!(
-                "{}",
-                "index schema is not initialized; run `rag-rat migrate`, `rag-rat index`, or \
-                 `rag-rat index --full`"
-            )
+        // Forward migration is automatic. Apply, then re-verify we actually reached Compatible so a
+        // silent half-migration can't slip through as "opened fine".
+        SchemaState::Older => {
+            apply(conn)?;
+            let after = status(conn)?;
+            if after.state == SchemaState::Compatible {
+                Ok(())
+            } else {
+                anyhow::bail!(
+                    "auto-migration left the schema {:?}, not compatible; rebuild the derived \
+                     index with `rag-rat index --full`",
+                    after.state
+                )
+            }
         },
-        SchemaState::Older => anyhow::bail!("{}", status.message),
-        SchemaState::Newer => anyhow::bail!("{}", status.message),
-        SchemaState::Dirty => anyhow::bail!("{}", status.message),
+        SchemaState::Missing => anyhow::bail!(
+            "no index at this path yet; build one with `rag-rat index` or `rag-rat index --full`"
+        ),
+        SchemaState::Newer | SchemaState::Dirty => anyhow::bail!("{}", current.message),
     }
 }

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -198,8 +198,8 @@ pub fn status(conn: &Connection) -> anyhow::Result<SchemaStatus> {
                 current_version: 0,
                 latest_version: LATEST_SCHEMA_VERSION,
                 migrations: Vec::new(),
-                message: "legacy index schema has no schema_version table; run `rag-rat migrate` \
-                          or rebuild the derived index with `rag-rat index --full`"
+                message: "legacy index schema has no schema_version table; it migrates forward \
+                          automatically on open (or rebuild with `rag-rat index --full`)"
                     .to_string(),
             }
         } else {
@@ -208,8 +208,8 @@ pub fn status(conn: &Connection) -> anyhow::Result<SchemaStatus> {
                 current_version: 0,
                 latest_version: LATEST_SCHEMA_VERSION,
                 migrations: Vec::new(),
-                message: "index schema is not initialized; run `rag-rat migrate` or build the \
-                          derived index with `rag-rat index --full`"
+                message: "index schema is not initialized; build the derived index with `rag-rat \
+                          index` or `rag-rat index --full`"
                     .to_string(),
             }
         });
@@ -254,8 +254,8 @@ pub fn status(conn: &Connection) -> anyhow::Result<SchemaStatus> {
             current_version,
             latest_version: LATEST_SCHEMA_VERSION,
             migrations,
-            message: "index schema is older than this rag-rat; run `rag-rat migrate` or rebuild \
-                      the derived index with `rag-rat index --full`"
+            message: "index schema is older than this rag-rat; it migrates forward automatically \
+                      on open (or rebuild with `rag-rat index --full`)"
                 .to_string(),
         });
     }

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -146,46 +146,162 @@ pub fn apply(conn: &Connection) -> rusqlite::Result<()> {
     }
     conn.execute("DELETE FROM schema_version WHERE id = ?1", [DIRTY_MIGRATION_ID])?;
     record_migration(conn, MIGRATION_001_ID, MIGRATION_001_CHECKSUM, MIGRATION_001_DESCRIPTION)?;
-    apply_embedding_vector_metadata(conn)?;
-    record_migration(conn, MIGRATION_002_ID, MIGRATION_002_CHECKSUM, MIGRATION_002_DESCRIPTION)?;
-    apply_derived_artifact_reconcile_metadata(conn)?;
-    record_migration(conn, MIGRATION_003_ID, MIGRATION_003_CHECKSUM, MIGRATION_003_DESCRIPTION)?;
-    apply_edge_source_target_spans(conn)?;
-    record_migration(conn, MIGRATION_004_ID, MIGRATION_004_CHECKSUM, MIGRATION_004_DESCRIPTION)?;
-    apply_edge_evidence_and_resolution(conn)?;
-    record_migration(conn, MIGRATION_005_ID, MIGRATION_005_CHECKSUM, MIGRATION_005_DESCRIPTION)?;
-    apply_embedding_policy_and_input_hash(conn)?;
-    record_migration(conn, MIGRATION_006_ID, MIGRATION_006_CHECKSUM, MIGRATION_006_DESCRIPTION)?;
-    apply_logical_symbol_groups(conn)?;
-    record_migration(conn, MIGRATION_007_ID, MIGRATION_007_CHECKSUM, MIGRATION_007_DESCRIPTION)?;
-    apply_commit_addressable_worktrees(conn)?;
-    record_migration(conn, MIGRATION_008_ID, MIGRATION_008_CHECKSUM, MIGRATION_008_DESCRIPTION)?;
-    apply_github_ref_sync(conn)?;
-    record_migration(conn, MIGRATION_009_ID, MIGRATION_009_CHECKSUM, MIGRATION_009_DESCRIPTION)?;
-    apply_symbol_facts(conn)?;
-    record_migration(conn, MIGRATION_010_ID, MIGRATION_010_CHECKSUM, MIGRATION_010_DESCRIPTION)?;
-    apply_repo_memories(conn)?;
-    record_migration(conn, MIGRATION_011_ID, MIGRATION_011_CHECKSUM, MIGRATION_011_DESCRIPTION)?;
-    apply_repo_memory_call_paths(conn)?;
-    record_migration(conn, MIGRATION_012_ID, MIGRATION_012_CHECKSUM, MIGRATION_012_DESCRIPTION)?;
-    apply_graph_file_lookup_indexes(conn)?;
-    record_migration(conn, MIGRATION_013_ID, MIGRATION_013_CHECKSUM, MIGRATION_013_DESCRIPTION)?;
-    apply_memory_binding_signals(conn)?;
-    record_migration(conn, MIGRATION_014_ID, MIGRATION_014_CHECKSUM, MIGRATION_014_DESCRIPTION)?;
-    apply_repo_memory_call_path_edges(conn)?;
-    record_migration(conn, MIGRATION_015_ID, MIGRATION_015_CHECKSUM, MIGRATION_015_DESCRIPTION)?;
-    apply_symbol_line_spans(conn)?;
-    record_migration(conn, MIGRATION_016_ID, MIGRATION_016_CHECKSUM, MIGRATION_016_DESCRIPTION)?;
-    apply_edge_callee_byte_range(conn)?;
-    record_migration(conn, MIGRATION_017_ID, MIGRATION_017_CHECKSUM, MIGRATION_017_DESCRIPTION)?;
-    apply_oracle_tables(conn)?;
-    record_migration(conn, MIGRATION_018_ID, MIGRATION_018_CHECKSUM, MIGRATION_018_DESCRIPTION)?;
-    apply_scip_moniker_anchors(conn)?;
-    record_migration(conn, MIGRATION_019_ID, MIGRATION_019_CHECKSUM, MIGRATION_019_DESCRIPTION)?;
-    apply_edge_string_interning(conn)?;
-    record_migration(conn, MIGRATION_020_ID, MIGRATION_020_CHECKSUM, MIGRATION_020_DESCRIPTION)?;
-    apply_symbol_scope_path(conn)?;
-    record_migration(conn, MIGRATION_021_ID, MIGRATION_021_CHECKSUM, MIGRATION_021_DESCRIPTION)?;
+    // The additive migrations on top of the baseline, in order. Same list `migrate_forward` walks,
+    // so a fresh DB (here) and an existing DB behind by N apply exactly the same steps.
+    for step in ADDITIVE_MIGRATIONS {
+        (step.apply)(conn)?;
+        record_migration(conn, step.id, step.checksum, step.description)?;
+    }
+    Ok(())
+}
+
+/// One additive migration layered on the baseline (001): its identity + the function that applies
+/// it. Single source of truth for both `apply` (fresh DB, runs all) and `migrate_forward` (existing
+/// DB, runs only the unapplied ones).
+struct Migration {
+    id: &'static str,
+    checksum: &'static str,
+    description: &'static str,
+    apply: fn(&Connection) -> rusqlite::Result<()>,
+}
+
+const ADDITIVE_MIGRATIONS: &[Migration] = &[
+    Migration {
+        id: MIGRATION_002_ID,
+        checksum: MIGRATION_002_CHECKSUM,
+        description: MIGRATION_002_DESCRIPTION,
+        apply: apply_embedding_vector_metadata,
+    },
+    Migration {
+        id: MIGRATION_003_ID,
+        checksum: MIGRATION_003_CHECKSUM,
+        description: MIGRATION_003_DESCRIPTION,
+        apply: apply_derived_artifact_reconcile_metadata,
+    },
+    Migration {
+        id: MIGRATION_004_ID,
+        checksum: MIGRATION_004_CHECKSUM,
+        description: MIGRATION_004_DESCRIPTION,
+        apply: apply_edge_source_target_spans,
+    },
+    Migration {
+        id: MIGRATION_005_ID,
+        checksum: MIGRATION_005_CHECKSUM,
+        description: MIGRATION_005_DESCRIPTION,
+        apply: apply_edge_evidence_and_resolution,
+    },
+    Migration {
+        id: MIGRATION_006_ID,
+        checksum: MIGRATION_006_CHECKSUM,
+        description: MIGRATION_006_DESCRIPTION,
+        apply: apply_embedding_policy_and_input_hash,
+    },
+    Migration {
+        id: MIGRATION_007_ID,
+        checksum: MIGRATION_007_CHECKSUM,
+        description: MIGRATION_007_DESCRIPTION,
+        apply: apply_logical_symbol_groups,
+    },
+    Migration {
+        id: MIGRATION_008_ID,
+        checksum: MIGRATION_008_CHECKSUM,
+        description: MIGRATION_008_DESCRIPTION,
+        apply: apply_commit_addressable_worktrees,
+    },
+    Migration {
+        id: MIGRATION_009_ID,
+        checksum: MIGRATION_009_CHECKSUM,
+        description: MIGRATION_009_DESCRIPTION,
+        apply: apply_github_ref_sync,
+    },
+    Migration {
+        id: MIGRATION_010_ID,
+        checksum: MIGRATION_010_CHECKSUM,
+        description: MIGRATION_010_DESCRIPTION,
+        apply: apply_symbol_facts,
+    },
+    Migration {
+        id: MIGRATION_011_ID,
+        checksum: MIGRATION_011_CHECKSUM,
+        description: MIGRATION_011_DESCRIPTION,
+        apply: apply_repo_memories,
+    },
+    Migration {
+        id: MIGRATION_012_ID,
+        checksum: MIGRATION_012_CHECKSUM,
+        description: MIGRATION_012_DESCRIPTION,
+        apply: apply_repo_memory_call_paths,
+    },
+    Migration {
+        id: MIGRATION_013_ID,
+        checksum: MIGRATION_013_CHECKSUM,
+        description: MIGRATION_013_DESCRIPTION,
+        apply: apply_graph_file_lookup_indexes,
+    },
+    Migration {
+        id: MIGRATION_014_ID,
+        checksum: MIGRATION_014_CHECKSUM,
+        description: MIGRATION_014_DESCRIPTION,
+        apply: apply_memory_binding_signals,
+    },
+    Migration {
+        id: MIGRATION_015_ID,
+        checksum: MIGRATION_015_CHECKSUM,
+        description: MIGRATION_015_DESCRIPTION,
+        apply: apply_repo_memory_call_path_edges,
+    },
+    Migration {
+        id: MIGRATION_016_ID,
+        checksum: MIGRATION_016_CHECKSUM,
+        description: MIGRATION_016_DESCRIPTION,
+        apply: apply_symbol_line_spans,
+    },
+    Migration {
+        id: MIGRATION_017_ID,
+        checksum: MIGRATION_017_CHECKSUM,
+        description: MIGRATION_017_DESCRIPTION,
+        apply: apply_edge_callee_byte_range,
+    },
+    Migration {
+        id: MIGRATION_018_ID,
+        checksum: MIGRATION_018_CHECKSUM,
+        description: MIGRATION_018_DESCRIPTION,
+        apply: apply_oracle_tables,
+    },
+    Migration {
+        id: MIGRATION_019_ID,
+        checksum: MIGRATION_019_CHECKSUM,
+        description: MIGRATION_019_DESCRIPTION,
+        apply: apply_scip_moniker_anchors,
+    },
+    Migration {
+        id: MIGRATION_020_ID,
+        checksum: MIGRATION_020_CHECKSUM,
+        description: MIGRATION_020_DESCRIPTION,
+        apply: apply_edge_string_interning,
+    },
+    Migration {
+        id: MIGRATION_021_ID,
+        checksum: MIGRATION_021_CHECKSUM,
+        description: MIGRATION_021_DESCRIPTION,
+        apply: apply_symbol_scope_path,
+    },
+];
+
+/// Apply ONLY the additive migrations not already recorded, in order — the forward-only path for an
+/// existing index that lags this binary. Unlike [`apply`], it never re-runs an already-applied
+/// migration, so a data backfill like 005's resolution rewrite (an unconditional UPDATE) cannot
+/// clobber current values on a routine open. The caller guarantees the baseline (001) is present (a
+/// versioned ledger exists); a ledger-less legacy DB is refused upstream, not force-migrated.
+pub fn migrate_forward(conn: &Connection) -> anyhow::Result<()> {
+    let applied: std::collections::HashSet<String> =
+        applied_migrations(conn)?.into_iter().map(|migration| migration.id).collect();
+    for step in ADDITIVE_MIGRATIONS {
+        if !applied.contains(step.id) {
+            (step.apply)(conn)?;
+            record_migration(conn, step.id, step.checksum, step.description)?;
+        }
+    }
     Ok(())
 }
 
@@ -198,8 +314,8 @@ pub fn status(conn: &Connection) -> anyhow::Result<SchemaStatus> {
                 current_version: 0,
                 latest_version: LATEST_SCHEMA_VERSION,
                 migrations: Vec::new(),
-                message: "legacy index schema has no schema_version table; it migrates forward \
-                          automatically on open (or rebuild with `rag-rat index --full`)"
+                message: "legacy index schema has no version ledger; rebuild the derived index \
+                          with `rag-rat index --full`"
                     .to_string(),
             }
         } else {
@@ -284,10 +400,21 @@ pub fn ensure_compatible_or_migrate(conn: &Connection) -> anyhow::Result<()> {
     let current = status(conn)?;
     match current.state {
         SchemaState::Compatible => Ok(()),
-        // Forward migration is automatic. Apply, then re-verify we actually reached Compatible so a
-        // silent half-migration can't slip through as "opened fine".
+        // Forward migration is automatic — but FORWARD-ONLY: apply just the unapplied migrations,
+        // never the whole ladder. Re-running an applied data migration (e.g. 005's unconditional
+        // `UPDATE edges SET resolution = …`) would clobber current resolver reasons on a routine
+        // open. Forward-only needs a real version ledger to know what's applied; a legacy DB with
+        // NO schema_version table (current_version 0) can't be safely advanced — we'd have to
+        // re-run those data migrations — so it's refused, not force-migrated. Re-verify Compatible
+        // so a half-migration can't slip through as "opened fine".
         SchemaState::Older => {
-            apply(conn)?;
+            if !table_exists(conn, "schema_version")? {
+                anyhow::bail!(
+                    "legacy index schema has no version ledger and can't be safely migrated \
+                     forward; rebuild with `rag-rat index --full`"
+                );
+            }
+            migrate_forward(conn)?;
             let after = status(conn)?;
             if after.state == SchemaState::Compatible {
                 Ok(())

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -120,7 +120,13 @@ pub struct SchemaStatus {
     pub message: String,
 }
 
-pub fn apply(conn: &Connection) -> rusqlite::Result<()> {
+/// Provision the baseline (001) idempotently: the schema_version ledger, then `apply_baseline`
+/// (all `CREATE … IF NOT EXISTS`) wrapped in the dirty marker so a crash mid-baseline is
+/// detectable, then record 001. Shared by [`apply`] (fresh DB) and [`migrate_forward`] (existing DB
+/// behind by N). LOAD-BEARING for forward-only: a pre-interning (≤v19) DB lacks shared tables like
+/// `edge_strings`/`edges_data` that later migrations INSERT into, so the baseline must run BEFORE
+/// any forward step replays — exactly what the old full `apply` did before the ladder.
+fn provision_baseline(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(
         "
         CREATE TABLE IF NOT EXISTS schema_version(
@@ -145,9 +151,13 @@ pub fn apply(conn: &Connection) -> rusqlite::Result<()> {
         return Err(err);
     }
     conn.execute("DELETE FROM schema_version WHERE id = ?1", [DIRTY_MIGRATION_ID])?;
-    record_migration(conn, MIGRATION_001_ID, MIGRATION_001_CHECKSUM, MIGRATION_001_DESCRIPTION)?;
-    // The additive migrations on top of the baseline, in order. Same list `migrate_forward` walks,
-    // so a fresh DB (here) and an existing DB behind by N apply exactly the same steps.
+    record_migration(conn, MIGRATION_001_ID, MIGRATION_001_CHECKSUM, MIGRATION_001_DESCRIPTION)
+}
+
+pub fn apply(conn: &Connection) -> rusqlite::Result<()> {
+    provision_baseline(conn)?;
+    // Every additive migration in order. A fresh DB runs them all; data backfills on empty tables
+    // are no-ops. (An EXISTING DB takes the forward-only path via `migrate_forward`, not this.)
     for step in ADDITIVE_MIGRATIONS {
         (step.apply)(conn)?;
         record_migration(conn, step.id, step.checksum, step.description)?;
@@ -289,11 +299,14 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
 ];
 
 /// Apply ONLY the additive migrations not already recorded, in order — the forward-only path for an
-/// existing index that lags this binary. Unlike [`apply`], it never re-runs an already-applied
-/// migration, so a data backfill like 005's resolution rewrite (an unconditional UPDATE) cannot
-/// clobber current values on a routine open. The caller guarantees the baseline (001) is present (a
-/// versioned ledger exists); a ledger-less legacy DB is refused upstream, not force-migrated.
+/// existing index that lags this binary. It first provisions the baseline idempotently (so a
+/// ≤v19 DB that predates a shared table like `edge_strings`/`edges_data` has it before a later
+/// migration INSERTs into it), then replays just the unapplied steps. Unlike [`apply`], it never
+/// re-runs an already-applied migration, so a data backfill like 005's resolution rewrite (an
+/// unconditional UPDATE) cannot clobber current values on a routine open. The caller guarantees a
+/// versioned ledger exists; a ledger-less legacy DB is refused upstream, not force-migrated.
 pub fn migrate_forward(conn: &Connection) -> anyhow::Result<()> {
+    provision_baseline(conn)?;
     let applied: std::collections::HashSet<String> =
         applied_migrations(conn)?.into_iter().map(|migration| migration.id).collect();
     for step in ADDITIVE_MIGRATIONS {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -158,7 +158,10 @@ fn file_progress_reports_first_final_and_decile_boundaries() {
 }
 
 #[test]
-fn compatible_open_requires_recorded_schema_version() {
+fn open_auto_migrates_a_legacy_schema_without_version_table() {
+    // A pre-schema_version index (real tables, no version ledger) reads as `Older`. Opening it must
+    // migrate it forward automatically — a developer never hand-runs `migrate` for our own derived
+    // data.
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join(".rag-rat")).unwrap();
@@ -168,14 +171,48 @@ fn compatible_open_requires_recorded_schema_version() {
     conn.execute_batch("DROP TABLE schema_version;").unwrap();
     drop(conn);
 
-    let status = IndexDatabase::migration_check(&database).unwrap();
-    assert_eq!(status.state, schema::SchemaState::Older);
-    let err = IndexDatabase::open(&database).unwrap_err().to_string();
-    assert!(err.contains("run `rag-rat migrate`"), "{err}");
-
-    let migrated = IndexDatabase::migrate(&database).unwrap();
-    assert_eq!(migrated.state, schema::SchemaState::Compatible);
+    assert_eq!(
+        IndexDatabase::migration_check(&database).unwrap().state,
+        schema::SchemaState::Older
+    );
+    // Open succeeds (no manual migrate), and the schema is current afterward.
     IndexDatabase::open(&database).unwrap();
+    assert_eq!(
+        IndexDatabase::migration_check(&database).unwrap().state,
+        schema::SchemaState::Compatible
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn open_auto_migrates_a_forward_older_schema_to_latest() {
+    // The binary-upgrade case: a fully-migrated index missing only the newest migration row reads
+    // as `Older` (current_version < latest). Opening it re-applies forward to latest in place.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join(".rag-rat")).unwrap();
+    let database = root.join(".rag-rat/index.sqlite");
+    IndexDatabase::migrate(&database).unwrap();
+    // Drop the newest applied migration so the stored version lags this binary by one.
+    let conn = rusqlite::Connection::open(&database).unwrap();
+    conn.execute(
+        "DELETE FROM schema_version WHERE id = (SELECT id FROM schema_version ORDER BY id DESC \
+         LIMIT 1)",
+        [],
+    )
+    .unwrap();
+    drop(conn);
+
+    let before = IndexDatabase::migration_check(&database).unwrap();
+    assert_eq!(before.state, schema::SchemaState::Older);
+    assert_eq!(before.current_version, before.latest_version - 1);
+
+    IndexDatabase::open(&database).unwrap();
+
+    let after = IndexDatabase::migration_check(&database).unwrap();
+    assert_eq!(after.state, schema::SchemaState::Compatible);
+    assert_eq!(after.current_version, after.latest_version);
 
     fs::remove_dir_all(root).unwrap();
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -222,6 +222,50 @@ fn forward_migration_does_not_rerun_already_applied_migrations() {
 }
 
 #[test]
+fn forward_migration_reprovisions_missing_baseline_tables() {
+    // Forward-only must run the idempotent baseline BEFORE replaying steps (#103 review): a ≤v19
+    // index predates shared tables (e.g. edge_strings) that a later migration INSERTs into.
+    // Simulate by dropping the edges view + edge_strings and the two newest ledger rows so the
+    // index reads as pre-interning; open must reprovision the table and reach Compatible rather
+    // than fail on a missing-table INSERT.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join(".rag-rat")).unwrap();
+    let database = root.join(".rag-rat/index.sqlite");
+    IndexDatabase::migrate(&database).unwrap();
+    let conn = rusqlite::Connection::open(&database).unwrap();
+    conn.execute_batch(
+        "DROP VIEW IF EXISTS edges;
+         DROP TABLE IF EXISTS edge_strings;
+         DELETE FROM schema_version WHERE id LIKE '021%' OR id LIKE '020%';",
+    )
+    .unwrap();
+    drop(conn);
+
+    assert_eq!(
+        IndexDatabase::migration_check(&database).unwrap().state,
+        schema::SchemaState::Older
+    );
+    IndexDatabase::open(&database).unwrap();
+    assert_eq!(
+        IndexDatabase::migration_check(&database).unwrap().state,
+        schema::SchemaState::Compatible
+    );
+    let conn = rusqlite::Connection::open(&database).unwrap();
+    let edge_strings_exists: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'edge_strings'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    drop(conn);
+    assert_eq!(edge_strings_exists, 1, "baseline did not reprovision edge_strings before replay");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn open_auto_migrates_a_forward_older_schema_to_latest() {
     // The binary-upgrade case: a fully-migrated index missing only the newest migration row reads
     // as `Older` (current_version < latest). Opening it applies only the missing migration forward.

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -158,10 +158,10 @@ fn file_progress_reports_first_final_and_decile_boundaries() {
 }
 
 #[test]
-fn open_auto_migrates_a_legacy_schema_without_version_table() {
-    // A pre-schema_version index (real tables, no version ledger) reads as `Older`. Opening it must
-    // migrate it forward automatically — a developer never hand-runs `migrate` for our own derived
-    // data.
+fn open_refuses_a_legacy_schema_without_version_table() {
+    // A pre-ledger index (real tables, no schema_version) reads as `Older`, but forward-only
+    // migration can't know what's already applied — re-running data migrations would clobber
+    // current values — so open REFUSES it and points at a rebuild rather than risk corruption.
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join(".rag-rat")).unwrap();
@@ -175,8 +175,44 @@ fn open_auto_migrates_a_legacy_schema_without_version_table() {
         IndexDatabase::migration_check(&database).unwrap().state,
         schema::SchemaState::Older
     );
-    // Open succeeds (no manual migrate), and the schema is current afterward.
+    let err = IndexDatabase::open(&database).unwrap_err().to_string();
+    assert!(err.contains("rebuild"), "{err}");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn forward_migration_does_not_rerun_already_applied_migrations() {
+    // The forward-only guarantee (#103 review): opening a v(latest-1) index must apply ONLY the
+    // missing migration, never re-run an applied one. Migration 005 does an unconditional
+    // `UPDATE edges SET resolution = …` that would downgrade modern resolver reasons on every
+    // upgrade open if the whole ladder re-ran. Witness: stamp 005's row with a sentinel
+    // applied_at_ms; if 005 re-ran, record_migration (INSERT OR REPLACE) overwrites it with now_ms.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join(".rag-rat")).unwrap();
+    let database = root.join(".rag-rat/index.sqlite");
+    IndexDatabase::migrate(&database).unwrap();
+    let conn = rusqlite::Connection::open(&database).unwrap();
+    conn.execute("UPDATE schema_version SET applied_at_ms = 1 WHERE id LIKE '005%'", []).unwrap();
+    conn.execute(
+        "DELETE FROM schema_version WHERE id = (SELECT id FROM schema_version ORDER BY id DESC \
+         LIMIT 1)",
+        [],
+    )
+    .unwrap();
+    drop(conn);
+
     IndexDatabase::open(&database).unwrap();
+
+    let conn = rusqlite::Connection::open(&database).unwrap();
+    let applied_005: i64 = conn
+        .query_row("SELECT applied_at_ms FROM schema_version WHERE id LIKE '005%'", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    drop(conn);
+    assert_eq!(applied_005, 1, "migration 005 was re-applied on open — forward-only is broken");
     assert_eq!(
         IndexDatabase::migration_check(&database).unwrap().state,
         schema::SchemaState::Compatible
@@ -188,7 +224,7 @@ fn open_auto_migrates_a_legacy_schema_without_version_table() {
 #[test]
 fn open_auto_migrates_a_forward_older_schema_to_latest() {
     // The binary-upgrade case: a fully-migrated index missing only the newest migration row reads
-    // as `Older` (current_version < latest). Opening it re-applies forward to latest in place.
+    // as `Older` (current_version < latest). Opening it applies only the missing migration forward.
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join(".rag-rat")).unwrap();

--- a/docs/config.md
+++ b/docs/config.md
@@ -39,9 +39,11 @@ index, so switching the backend in the config takes effect after re-running `rag
 backends have different vector dimensions, so switching re-embeds from scratch.
 
 The database stores explicit schema migrations in `schema_version` with migration id,
-`applied_at_ms`, checksum, and description. `rag-rat migrate --check` verifies compatibility without
-changing source files; `rag-rat migrate` applies the current SQLite index schema. Normal runtime
-opens refuse older, newer, dirty, or partial schemas instead of silently altering tables.
+`applied_at_ms`, checksum, and description. Opening the index **migrates an older schema forward
+automatically** — the migration ladder is additive and idempotent, so a binary upgrade needs no
+manual step. Only a *newer* schema (created by a future rag-rat — can't downgrade), a *dirty* or
+checksum-mismatched schema (rebuild with `rag-rat index --full`), or a *missing* index (build it
+first) is refused. `rag-rat doctor` reports the schema state without changing anything.
 
 Simple bindings map a language to directories:
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -12,7 +12,6 @@ Install the binary from a local checkout:
 
 ```bash
 cargo install --path tools/rag-rat --bin rag-rat --features fastembed
-rag-rat migrate --config /home/kk/src/held/rag-rat.toml
 rag-rat index --discover --config /home/kk/src/held/rag-rat.toml
 rag-rat models install fastembed-all-minilm-l6-v2 --config /home/kk/src/held/rag-rat.toml
 rag-rat reconcile --changed-first --limit 500 --batch-size 64 --config /home/kk/src/held/rag-rat.toml


### PR DESCRIPTION
Fixes #102.

The index is rag-rat's own derived data, so a binary upgrade must never require a developer to hand-run `migrate` (or be a devops) to restore queries/memory writes. This surfaced live this session: after `cargo install`, the hot-upgraded MCP server's next `memory_update` failed with "index schema is older than this rag-rat; run \`rag-rat migrate\`".

## Change
- `IndexDatabase::open` now calls `schema::ensure_compatible_or_migrate` (was `check_compatible`). On `SchemaState::Older` it applies forward migrations in place (the same idempotent `apply()` the `migrate` command runs on Older), then re-verifies it reached `Compatible`.
- `Newer` (future binary, can't downgrade), `Dirty` (partial/checksum mismatch → `index --full`), and `Missing` (no index yet → build first) still refuse, with guidance.

## Tests
- `open_auto_migrates_a_legacy_schema_without_version_table`
- `open_auto_migrates_a_forward_older_schema_to_latest` (drops the newest migration row → Older v(latest-1) → open → Compatible at latest)
- `compatible_open_refuses_dirty_and_newer_schema` unchanged (still refuses).

316 lib tests pass; clippy clean; `cargo +nightly fmt` applied. Independent of the import-scope PRs (#99/#100/#101) — touches schema/lifecycle only.