### PR TITLE
Per-package + module-aware import-scope rework (#61)

### DIFF
--- a/crates/rag-rat-core/src/index/edges/extract.rs
+++ b/crates/rag-rat-core/src/index/edges/extract.rs
@@ -75,6 +75,7 @@ pub(crate) fn contains_edges(symbols: &[IndexedSymbol]) -> Vec<EdgeCandidate> {
                 receiver_hint: None,
                 source_span: child.span(),
                 callee_span: None,
+                import_scope: None,
                 edge_kind: EdgeKind::Contains,
                 confidence: EdgeConfidence::Exact,
             });
@@ -141,15 +142,32 @@ pub(crate) fn rust_edges(
         "use_declaration" => {
             let names = identifiers_under(node, text);
             let is_reexport = node_text(node, text).trim_start().starts_with("pub use ");
+            // Module-aware import scope (#61): a Rust `use` is scoped to its enclosing module body
+            // (or block, for a block-local `use`), not the whole file. Record that scope + the
+            // enclosing module's id on the dedicated import-scope columns so resolution suppresses
+            // a bare reference only inside the `use`'s scope (parent-`mod` `use`s don't
+            // reach a child `mod`). Top-level `use` → whole file, `MOD_FILE_ROOT`.
+            let scope = enclosing_use_scope(node, text);
+            // The crate-aware scope rebuilds its {leaf → root} map by re-parsing an Imports edge's
+            // `evidence` with `imports::parse_use`; `parse_use` returns EVERY leaf, so ONE edge
+            // carrying the FULL (untruncated) use text populates the whole map for this `use`.
+            // Attach the full text to only the FIRST emitted Imports edge — the default
+            // `edge_evidence` truncates at 240 chars and would drop late braced leaves (#97 item 1)
+            // — and let the rest carry standard evidence, so a multi-hundred-KB `use` isn't cloned
+            // into every leaf's edge (#97 item 3).
+            let mut full_use_evidence = Some(use_declaration_evidence(node, text));
             for name in names {
                 if !is_rust_path_keyword(&name) {
-                    out.push(file_edge(
+                    let evidence =
+                        full_use_evidence.take().unwrap_or_else(|| edge_evidence(node, text));
+                    out.push(file_edge_scoped(
                         path,
                         node,
-                        text,
                         name,
+                        Some(evidence),
                         EdgeKind::Imports,
                         EdgeConfidence::NameOnly,
+                        Some(scope),
                     ));
                 }
             }
@@ -170,13 +188,19 @@ pub(crate) fn rust_edges(
         },
         "mod_item" =>
             if let Some(name) = child_name_text(node, text) {
-                out.push(file_edge(
+                // An INLINE `mod foo { … }` carries its body range + its own id as the import scope
+                // so resolution can rebuild the per-file module interval set (the ref→mod-id
+                // lookup) from edges alone, WITHOUT the tree (#61) — including modules that contain
+                // no `use`. A non-inline `mod foo;` has no body and introduces no scope (NULL).
+                let scope = inline_mod_scope(node);
+                out.push(file_edge_scoped(
                     path,
                     node,
-                    text,
                     name,
+                    Some(edge_evidence(node, text)),
                     EdgeKind::Imports,
                     EdgeConfidence::NameOnly,
+                    scope,
                 ));
             },
         "call_expression" => {
@@ -275,6 +299,7 @@ pub(crate) fn rust_impl_edges(
             // The trait/type names here come from string-splitting the impl header, not from a
             // located identifier node, so there is no clean callee range to record (#67).
             callee_span: None,
+            import_scope: None,
             edge_kind: EdgeKind::Implements,
             confidence: EdgeConfidence::NameOnly,
         });
@@ -593,9 +618,86 @@ pub(crate) fn file_edge(
         source_span: span_for_node(node),
         // File-level edges (imports / exports / mod) have no callee identifier to anchor (#67).
         callee_span: None,
+        import_scope: None,
         edge_kind,
         confidence,
     }
+}
+/// `file_edge` with caller-supplied evidence and an optional module-aware import scope, for the
+/// `use_declaration` / inline `mod_item` arms (#61). The Imports edge carries the untruncated `use`
+/// text (so the crate-aware scope re-parses every braced leaf, #97) plus the enclosing scope range
+/// and module id in the DEDICATED `import_scope_*` / `import_mod_id` columns — never the `callee_*`
+/// columns, which stay NULL on file-level edges so the oracle join is unaffected.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn file_edge_scoped(
+    path: &Path,
+    node: Node<'_>,
+    to_name: String,
+    evidence: Option<String>,
+    edge_kind: EdgeKind,
+    confidence: EdgeConfidence,
+    import_scope: Option<ImportScopeRange>,
+) -> EdgeCandidate {
+    EdgeCandidate {
+        from_symbol_id: None,
+        from_name: Some(path.to_string_lossy().replace('\\', "/")),
+        to_name,
+        target_qualified_name: None,
+        evidence,
+        receiver_hint: None,
+        source_span: span_for_node(node),
+        callee_span: None,
+        import_scope,
+        edge_kind,
+        confidence,
+    }
+}
+/// The module-aware scope of a Rust `use_declaration` (#61): walk ancestors to the nearest body
+/// that resets import scope. A nested `mod m { … }`'s `declaration_list` is the scope AND its start
+/// byte is the enclosing-module id. A `block` (fn body / inner block) does NOT reset import scope
+/// (uses are inherited), but a block-local `use` is itself confined to the block — so a `block`
+/// hit narrows the SCOPE to the block range while the module id is taken from the block's own
+/// nearest-enclosing module. A top-level `use` has no such ancestor: it scopes the whole file with
+/// `MOD_FILE_ROOT`. Rust `use` items are order-independent within their scope, so the WHOLE body
+/// range (not "from the `use` onward") is correct.
+pub(crate) fn enclosing_use_scope(node: Node<'_>, text: &str) -> ImportScopeRange {
+    let mut parent = node.parent();
+    let mut block_scope: Option<(usize, usize)> = None;
+    while let Some(ancestor) = parent {
+        match ancestor.kind() {
+            // The nearest module body: it both bounds a module-level `use` and supplies the module
+            // id for a block-local one (the first block we passed through narrowed the scope).
+            "declaration_list" if ancestor.parent().is_some_and(|p| p.kind() == "mod_item") => {
+                let mod_start = i64::try_from(ancestor.start_byte()).unwrap_or(MOD_FILE_ROOT);
+                let (scope_start, scope_end) =
+                    block_scope.unwrap_or((ancestor.start_byte(), ancestor.end_byte()));
+                return ImportScopeRange { scope_start, scope_end, mod_id: mod_start };
+            },
+            // Record only the INNERMOST (first-seen) block as the confining scope; outer blocks
+            // don't widen it. Don't return yet — keep walking for the enclosing module id.
+            "block" if block_scope.is_none() => {
+                block_scope = Some((ancestor.start_byte(), ancestor.end_byte()));
+            },
+            _ => {},
+        }
+        parent = ancestor.parent();
+    }
+    // No enclosing module: top-level `use` (or block-local at file root). Scope is the block if we
+    // saw one, else the whole file; module id is the file root.
+    let (scope_start, scope_end) = block_scope.unwrap_or((0, text.len()));
+    ImportScopeRange { scope_start, scope_end, mod_id: MOD_FILE_ROOT }
+}
+/// The body range of an INLINE `mod foo { … }` as an import scope whose `mod_id` is its own body
+/// start — so resolution rebuilds the per-file module interval set from these edges (#61). `None`
+/// for a non-inline `mod foo;` (no body, introduces no scope).
+pub(crate) fn inline_mod_scope(node: Node<'_>) -> Option<ImportScopeRange> {
+    let body = node.child_by_field_name("body")?;
+    let scope_start = body.start_byte();
+    Some(ImportScopeRange {
+        scope_start,
+        scope_end: body.end_byte(),
+        mod_id: i64::try_from(scope_start).unwrap_or(MOD_FILE_ROOT),
+    })
 }
 pub(crate) fn symbol_edge(
     symbols: &[IndexedSymbol],
@@ -642,6 +744,7 @@ pub(crate) fn symbol_edge_with_context(
         receiver_hint: context.receiver_hint,
         source_span: span_for_node(node),
         callee_span,
+        import_scope: None,
         edge_kind,
         confidence,
     }

--- a/crates/rag-rat-core/src/index/edges/helpers.rs
+++ b/crates/rag-rat-core/src/index/edges/helpers.rs
@@ -183,6 +183,14 @@ pub(crate) fn edge_evidence(node: Node<'_>, text: &str) -> String {
         .take(240)
         .collect()
 }
+/// Whitespace-normalized but UNTRUNCATED node text, for a `use_declaration`'s evidence. The
+/// crate-aware import scope re-parses this with `imports::parse_use` (#61); the 240-char cap in
+/// [`edge_evidence`] would drop the late leaves of a long braced `use foo::{…, X}`, leaving those
+/// names un-suppressed (#97 item 1). A `use` statement is bounded and small, so storing it in full
+/// is cheap.
+pub(crate) fn use_declaration_evidence(node: Node<'_>, text: &str) -> String {
+    node_text(node, text).split_whitespace().collect::<Vec<_>>().join(" ")
+}
 pub(crate) fn short_name(name: &str) -> &str {
     name.rsplit([':', '.', '#', '/']).find(|part| !part.is_empty()).unwrap_or(name)
 }
@@ -321,6 +329,17 @@ pub(crate) fn insert_candidates(
             ),
             None => (None, None),
         };
+        // Module-aware import scope (#61): the dedicated columns, NULL on non-import edges so the
+        // oracle's `callee_start_byte IS NOT NULL` candidate filter never sees them.
+        let (import_scope_start_byte, import_scope_end_byte, import_mod_id) =
+            match candidate.import_scope {
+                Some(scope) => (
+                    Some(i64::try_from(scope.scope_start).unwrap_or(0)),
+                    Some(i64::try_from(scope.scope_end).unwrap_or(0)),
+                    Some(scope.mod_id),
+                ),
+                None => (None, None, None),
+            };
         // Direct interned write to edges_data (#79): the view's INSTEAD OF insert would work but
         // costs 8 dictionary probes per row in SQL, and `last_insert_rowid` does not survive an
         // INSTEAD OF trigger.
@@ -339,9 +358,11 @@ pub(crate) fn insert_candidates(
                 target_qualified_name_id, evidence, receiver_hint_id,
                 source_start_line, source_end_line, source_start_byte, source_end_byte,
                 callee_start_byte, callee_end_byte,
+                import_scope_start_byte, import_scope_end_byte, import_mod_id,
                 edge_kind_id, confidence_id, resolution_id
             )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, \
+             ?18, ?19)
             ",
         )?
         .execute(params![
@@ -358,6 +379,9 @@ pub(crate) fn insert_candidates(
             candidate.source_span.end_byte,
             callee_start_byte,
             callee_end_byte,
+            import_scope_start_byte,
+            import_scope_end_byte,
+            import_mod_id,
             edge_kind_id,
             confidence_id,
             resolution_id,

--- a/crates/rag-rat-core/src/index/edges/imports.rs
+++ b/crates/rag-rat-core/src/index/edges/imports.rs
@@ -75,13 +75,34 @@ pub(crate) fn scan_packages(root: &Path) -> (HashSet<String>, Vec<PackageRoots>)
             manifests.push((dir, manifest));
         }
     }
+    // The workspace root: the manifest declaring `[workspace]`. Its `[workspace.dependencies]`
+    // table holds the `path` for any member dep written `{ workspace = true }`, and that path
+    // is relative to the WORKSPACE ROOT dir (not the inheriting member's). Captured once so the
+    // per-package pass can resolve inherited path-dep aliases (#5).
+    let workspace_deps = manifests
+        .iter()
+        .find(|(_, manifest)| manifest.get("workspace").is_some())
+        .map(|(dir, manifest)| WorkspaceDeps {
+            root_dir: dir.clone(),
+            table: manifest
+                .get("workspace")
+                .and_then(|workspace| workspace.get("dependencies"))
+                .and_then(toml::Value::as_table)
+                .cloned(),
+        });
     // Second pass: per-package roots = the workspace union plus this manifest's in-corpus path-dep
     // alias keys (only that package treats those aliases as local — #1).
     let mut packages = Vec::with_capacity(manifests.len());
     let mut global_roots = workspace_roots.clone();
     for (manifest_dir, manifest) in &manifests {
         let mut local_roots = workspace_roots.clone();
-        collect_path_dependency_aliases(manifest, manifest_dir, root, &mut local_roots);
+        collect_path_dependency_aliases(
+            manifest,
+            manifest_dir,
+            root,
+            workspace_deps.as_ref(),
+            &mut local_roots,
+        );
         // The global fallback union also includes every alias key, so a file with no package row
         // still fails open the same way the pre-#61 single-set did.
         global_roots.extend(local_roots.iter().cloned());
@@ -127,6 +148,14 @@ fn lib_crate_root_name(manifest: &toml::Value, manifest_dir: Option<&Path>) -> O
     Some(package.replace('-', "_"))
 }
 
+/// The workspace root's `[workspace.dependencies]` table and the dir it lives in. A member dep
+/// written `local = { workspace = true }` inherits its real `path` from this table, and that path
+/// is relative to `root_dir` (the workspace root), not the inheriting member's dir (#5).
+struct WorkspaceDeps {
+    root_dir: std::path::PathBuf,
+    table: Option<toml::value::Table>,
+}
+
 /// Add every path-dependency KEY whose target resolves INSIDE `root` to `roots` — these are local
 /// path dependencies whose import name is the KEY (possibly renamed via the `package` key), so the
 /// bare-reference scope must treat the key as a local crate root (#97 item 2). A string dependency
@@ -139,16 +168,42 @@ fn lib_crate_root_name(manifest: &toml::Value, manifest_dir: Option<&Path>) -> O
 /// `use foo_bar::…`). A `path` pointing OUTSIDE the indexed `root` is NOT added (#97 item 5): that
 /// crate has no symbols in this index, so localizing its alias would let a same-named in-corpus
 /// symbol wrongly bind.
+///
+/// A member dep `local = { workspace = true }` carries no `path` of its own — its path lives in the
+/// workspace root's `[workspace.dependencies]` and is relative to the WORKSPACE ROOT dir. Such a
+/// dep is resolved against `workspace_deps` so the inherited path-dep alias is still treated as
+/// local in the member (#5); without it, `use local::Thing` in the member was misclassified
+/// external.
 fn collect_path_dependency_aliases(
     manifest: &toml::Value,
     manifest_dir: &Path,
     root: &Path,
+    workspace_deps: Option<&WorkspaceDeps>,
     roots: &mut HashSet<String>,
 ) {
     for table in dependency_tables(manifest) {
         for (key, spec) in table {
-            let Some(path) = spec.get("path").and_then(toml::Value::as_str) else { continue };
-            if path_dependency_is_in_corpus(manifest_dir, path, root) {
+            // A direct `path` on the dep: resolve relative to THIS manifest's dir.
+            if let Some(path) = spec.get("path").and_then(toml::Value::as_str) {
+                if path_dependency_is_in_corpus(manifest_dir, path, root) {
+                    roots.insert(key.replace('-', "_"));
+                }
+                continue;
+            }
+            // `{ workspace = true }`: inherit the `path` from `[workspace.dependencies]`, resolved
+            // relative to the WORKSPACE ROOT dir (#5).
+            let inherits_workspace =
+                spec.get("workspace").and_then(toml::Value::as_bool) == Some(true);
+            if inherits_workspace
+                && let Some(ws) = workspace_deps
+                && let Some(path) = ws
+                    .table
+                    .as_ref()
+                    .and_then(|table| table.get(key))
+                    .and_then(|inherited| inherited.get("path"))
+                    .and_then(toml::Value::as_str)
+                && path_dependency_is_in_corpus(&ws.root_dir, path, root)
+            {
                 roots.insert(key.replace('-', "_"));
             }
         }
@@ -353,11 +408,25 @@ pub(crate) struct ImportScope {
     file_package: HashMap<i64, i64>,
     package_roots: HashMap<i64, HashSet<String>>,
     global_roots: HashSet<String>,
+    /// Whether the indexed corpus is a Cargo project at all (at least one `Cargo.toml` found).
+    /// This is DISTINCT from an empty root set: a Cargo project of only BIN targets has no
+    /// importable library crate names and no path-dep aliases, so its root set is empty — yet
+    /// `use url::Url;` in it still names the EXTERNAL `url` crate and must suppress a local
+    /// `Url`. Only a genuinely non-Cargo corpus (no manifest at all) fails open. Set true by
+    /// [`Self::mark_has_manifests`] when any package row is loaded.
+    has_manifests: bool,
 }
 
 impl ImportScope {
     pub(crate) fn new(global_roots: HashSet<String>) -> Self {
         Self { global_roots, ..Self::default() }
+    }
+
+    /// Record that the corpus has at least one Cargo manifest — so an empty root set is read as
+    /// "Cargo project with no library crates" (still suppress external imports), not "non-Cargo
+    /// corpus" (fail open). See [`Self::has_manifests`].
+    pub(crate) fn mark_has_manifests(&mut self) {
+        self.has_manifests = true;
     }
 
     /// Map a file to its owning package (so its bindings consult that package's local-crate set).
@@ -484,7 +553,10 @@ impl ImportScope {
     /// is suppressed.
     pub(crate) fn is_external_import(&self, file_id: i64, name: &str, ref_byte: usize) -> bool {
         let local_roots = self.roots_for_file(file_id);
-        if local_roots.is_empty() {
+        // Fail open ONLY for a non-Cargo corpus (no manifest scanned). A Cargo project with no
+        // library crates (bin-only) has an empty root set but still suppresses external imports —
+        // `use url::Url;` names the external `url` crate there too (#97-followup item 4).
+        if local_roots.is_empty() && !self.has_manifests {
             return false;
         }
         let Some(root) = self.covering_root(file_id, name, ref_byte) else {
@@ -602,6 +674,22 @@ mod tests {
         scope.add_use(1, "use url::Url;", Some(scope_at_file_root(0, usize::MAX)));
         scope.finalize();
         assert!(!scope.is_external_import(1, "Url", 100), "no manifests → suppress nothing");
+    }
+
+    /// #4: a bin-only Cargo crate has an EMPTY local-root set (no importable lib name, no path-dep
+    /// aliases) yet IS a Cargo project — `use url::Url;` names the external `url` crate and must
+    /// still suppress a local `Url`. Only a genuinely non-Cargo corpus fails open. The
+    /// discriminator is `mark_has_manifests`, not the emptiness of the root set.
+    #[test]
+    fn bin_only_crate_still_suppresses_external_imports() {
+        let mut scope = ImportScope::new(HashSet::new());
+        scope.mark_has_manifests(); // a Cargo manifest exists, just no library crate roots
+        scope.add_use(1, "use url::Url;", Some(scope_at_file_root(0, usize::MAX)));
+        scope.finalize();
+        assert!(
+            scope.is_external_import(1, "Url", 100),
+            "a bin-only Cargo crate still suppresses an external import despite an empty root set"
+        );
     }
 
     /// #1 (per-package locality): a `path`-dep alias `local` is local for crate A (which declares
@@ -820,6 +908,50 @@ mod tests {
             !pkg_b.local_roots.contains("a_only"),
             "package b never declared the alias — must not be local for it; got {:?}",
             pkg_b.local_roots
+        );
+    }
+
+    /// #5: a member dep written `local = { workspace = true }` inherits its `path` from the root
+    /// `[workspace.dependencies]` table (path relative to the WORKSPACE ROOT dir). The member must
+    /// treat `local` as a local crate root so `use local::Thing` resolves local — without inherited
+    /// resolution it was dropped as external.
+    #[test]
+    fn scan_packages_resolves_inherited_workspace_path_dep() {
+        let root = std::env::temp_dir().join(format!("rr-ws-inherit-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        // Workspace root declares the path dep in [workspace.dependencies]; path is relative to the
+        // workspace root dir.
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), "").unwrap();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[workspace]\nmembers=[\"member\"]\n[package]\nname=\"ws_root\"\n[workspace.\
+             dependencies]\nlocal = { path = \"shared\" }\n",
+        )
+        .unwrap();
+        // The shared crate the alias points at.
+        std::fs::create_dir_all(root.join("shared/src")).unwrap();
+        std::fs::write(root.join("shared/Cargo.toml"), "[package]\nname=\"shared\"\n").unwrap();
+        std::fs::write(root.join("shared/src/lib.rs"), "").unwrap();
+        // The member inherits the dep with `{ workspace = true }` — no path of its own.
+        std::fs::create_dir_all(root.join("member/src")).unwrap();
+        std::fs::write(
+            root.join("member/Cargo.toml"),
+            "[package]\nname=\"member\"\n[dependencies]\nlocal = { workspace = true }\n",
+        )
+        .unwrap();
+        std::fs::write(root.join("member/src/lib.rs"), "").unwrap();
+        let (global, packages) = scan_packages(&root);
+        let _ = std::fs::remove_dir_all(&root);
+        assert!(
+            global.contains("local"),
+            "the inherited workspace path-dep alias is in the global union; got {global:?}"
+        );
+        let member = packages.iter().find(|p| p.manifest_dir == "member").expect("member package");
+        assert!(
+            member.local_roots.contains("local"),
+            "the member inherits the workspace path-dep alias as a LOCAL root; got {:?}",
+            member.local_roots
         );
     }
 }

--- a/crates/rag-rat-core/src/index/edges/imports.rs
+++ b/crates/rag-rat-core/src/index/edges/imports.rs
@@ -1,17 +1,28 @@
-//! Crate-aware import scope (#61, Project B). A reference to a name imported from an EXTERNAL
+//! Per-package + module-aware import scope (#61). A reference to a name imported from an EXTERNAL
 //! dependency crate must not bind to a local same-named symbol — the `use` says where the name
-//! comes from. We tell a LOCAL workspace crate root (keep binding — e.g. cross-crate references
-//! into the `cargo` crate, which the heuristic resolves correctly) from an external dependency root
-//! (`url`, `serde_core`, `std`, … — don't bind locally) by parsing the corpus's Cargo.toml
-//! manifests for the set of local crate names. Rust/Cargo-specific by construction: a corpus with
-//! no manifests yields an empty set and the scope suppresses nothing (fail open).
+//! comes from. Two refinements over the original per-file global-set model (the 5 Codex edge cases,
+//! see `docs/plans/2026-06-14-import-scope-rework.md`):
+//!
+//! - **Per-package locality** — a `path`-dependency alias (`local = { path = "…" }`) is
+//!   manifest-LOCAL: it must make `local` a local root only for the package that declares it, not
+//!   for every file in the corpus. The local-crate set is therefore per-package
+//!   (`package_roots[file_package[file]]`), with the workspace crate names as the global fallback.
+//! - **Module-aware scope** — a Rust `use` is scoped to its enclosing module body (or block, when
+//!   block-local), and child `mod`s do NOT inherit a parent module's `use`s. A binding suppresses a
+//!   reference only when the reference is lexically inside the `use`'s scope AND in the SAME module
+//!   (`mod_id` match), with the INNERMOST (smallest-span) covering binding winning a shadow.
+//!
+//! Rust/Cargo-specific by construction: a corpus with no manifests yields empty sets and the scope
+//! suppresses nothing (fail open) — a missed suppression is never a dropped local bind.
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use rusqlite::{Connection, OptionalExtension};
 
-/// Load the persisted local-crate-root set — newline-joined under `local_crate_roots` in
+use super::{ImportScopeRange, MOD_FILE_ROOT};
+
+/// Load the persisted GLOBAL local-crate-root set — newline-joined under `local_crate_roots` in
 /// `index_meta`, written at rebuild by [`local_crate_roots`]. Empty when absent (a non-Cargo corpus
 /// or a pre-V021 index), which makes [`ImportScope`] suppress nothing.
 pub(crate) fn load_local_roots(conn: &Connection) -> HashSet<String> {
@@ -25,39 +36,161 @@ pub(crate) fn load_local_roots(conn: &Connection) -> HashSet<String> {
     .unwrap_or_default()
 }
 
-/// The set of LOCAL crate roots in the corpus: the underscore-normalized crate name of every
-/// Cargo.toml package found under `root` (respecting .gitignore, so `target/` vendored manifests
-/// are skipped). A `use <root>::…` whose `<root>` is in this set — or is `crate`/`self`/`super` —
-/// names a local item; any other root names an external dependency.
-pub(crate) fn local_crate_roots(root: &Path) -> HashSet<String> {
-    let mut roots = HashSet::new();
-    // `parents(false)`: honor the indexed root's OWN .gitignore (skip its `target/` vendored
-    // manifests) but NOT ancestor gitignores above it — otherwise a root that happens to live under
-    // some ancestor's ignored path (e.g. the bench corpus under the repo's `target/`) is treated as
-    // wholly ignored and the walk yields nothing.
+/// One Cargo package discovered in the corpus: the directory of its manifest and the set of crate
+/// roots that resolve LOCAL from inside it — the workspace crate names (global union) PLUS this
+/// manifest's in-corpus path-dependency alias keys (#61 per-package locality).
+#[derive(Debug, Clone)]
+pub(crate) struct PackageRoots {
+    pub(crate) manifest_dir: String,
+    pub(crate) local_roots: HashSet<String>,
+}
+
+/// Scan the corpus's Cargo manifests once and return both the GLOBAL local-crate-root union (every
+/// importable workspace crate name + every in-corpus path-dep alias key, the fallback set) and the
+/// PER-PACKAGE roots (one [`PackageRoots`] per manifest, each = the global workspace crate names
+/// plus that manifest's own in-corpus path-dep alias keys). Built in one walk so
+/// rebuild/incremental pay the manifest I/O once.
+pub(crate) fn scan_packages(root: &Path) -> (HashSet<String>, Vec<PackageRoots>) {
+    // First pass: every importable LIBRARY crate root in the corpus — the workspace crate names
+    // shared by every package as local. `parents(false)`: honor the indexed root's OWN .gitignore
+    // (skip its `target/` vendored manifests) but NOT ancestor gitignores above it — otherwise a
+    // root nested under some ancestor's ignored path (e.g. a bench corpus under `target/`) is
+    // treated as wholly ignored and the walk yields nothing.
+    let mut workspace_roots = HashSet::new();
+    let mut manifests: Vec<(std::path::PathBuf, toml::Value)> = Vec::new();
     for entry in ignore::WalkBuilder::new(root).parents(false).build().flatten() {
         if entry.path().file_name().and_then(|name| name.to_str()) != Some("Cargo.toml") {
             continue;
         }
         let Ok(text) = std::fs::read_to_string(entry.path()) else { continue };
-        let Ok(value) = toml::from_str::<toml::Value>(&text) else { continue };
-        if let Some(name) = crate_root_name(&value) {
-            roots.insert(name);
+        // Parse with the serde entry point (`toml::from_str`), NOT `text.parse::<toml::Value>()`:
+        // `toml::Value`'s `FromStr` compiles but does not parse a full Cargo.toml document — it
+        // returns Err on a valid manifest, silently emptying the local set.
+        let Ok(manifest) = toml::from_str::<toml::Value>(&text) else { continue };
+        let manifest_dir = entry.path().parent().map(Path::to_path_buf);
+        if let Some(name) = lib_crate_root_name(&manifest, manifest_dir.as_deref()) {
+            workspace_roots.insert(name);
+        }
+        if let Some(dir) = manifest_dir {
+            manifests.push((dir, manifest));
         }
     }
-    roots
+    // Second pass: per-package roots = the workspace union plus this manifest's in-corpus path-dep
+    // alias keys (only that package treats those aliases as local — #1).
+    let mut packages = Vec::with_capacity(manifests.len());
+    let mut global_roots = workspace_roots.clone();
+    for (manifest_dir, manifest) in &manifests {
+        let mut local_roots = workspace_roots.clone();
+        collect_path_dependency_aliases(manifest, manifest_dir, root, &mut local_roots);
+        // The global fallback union also includes every alias key, so a file with no package row
+        // still fails open the same way the pre-#61 single-set did.
+        global_roots.extend(local_roots.iter().cloned());
+        // Store `manifest_dir` RELATIVE to the indexed root (`/`-normalized) so it prefix-matches a
+        // file's stored relative path when assigning `files.package_id`. The root manifest yields
+        // an empty string, which is a prefix of every path (the root crate owns top-level files).
+        let relative = manifest_dir
+            .strip_prefix(root)
+            .unwrap_or(manifest_dir)
+            .to_string_lossy()
+            .replace('\\', "/");
+        packages.push(PackageRoots { manifest_dir: relative, local_roots });
+    }
+    (global_roots, packages)
 }
 
-/// The crate root identifier used in `use` paths: `[lib].name` if set, else the package name with
-/// `-` normalized to `_` (Cargo's crate-name rule: `cargo-credential` → `cargo_credential`).
-fn crate_root_name(manifest: &toml::Value) -> Option<String> {
-    if let Some(lib_name) =
-        manifest.get("lib").and_then(|lib| lib.get("name")).and_then(|name| name.as_str())
-    {
+/// The crate root identifier used in `use` paths when this manifest defines an importable LIBRARY:
+/// `[lib].name` if the table sets one, else the package name (`-`→`_`, Cargo's crate-name rule:
+/// `cargo-credential` → `cargo_credential`). Returns `None` for a BIN-ONLY member (no `[lib]` table
+/// and no autodiscovered `src/lib.rs`): such a package is not importable, so contributing its name
+/// as a root would wrongly mark a same-named EXTERNAL dependency as local and skip suppression
+/// (#97 item 3). The `src/lib.rs` probe mirrors Cargo's lib autodiscovery, resolved relative to the
+/// manifest directory; `[package] autolib = false` disables that autodiscovery (#97 item 4). An
+/// EXPLICIT `[lib]` table still contributes regardless of `autolib` — that flag only governs
+/// autodiscovery.
+fn lib_crate_root_name(manifest: &toml::Value, manifest_dir: Option<&Path>) -> Option<String> {
+    let lib = manifest.get("lib");
+    if let Some(lib_name) = lib.and_then(|lib| lib.get("name")).and_then(|name| name.as_str()) {
         return Some(lib_name.replace('-', "_"));
+    }
+    let autolib_enabled = manifest
+        .get("package")
+        .and_then(|package| package.get("autolib"))
+        .and_then(toml::Value::as_bool)
+        != Some(false);
+    let has_lib_target = lib.is_some()
+        || (autolib_enabled
+            && manifest_dir.is_some_and(|dir| dir.join("src").join("lib.rs").is_file()));
+    if !has_lib_target {
+        return None;
     }
     let package = manifest.get("package")?.get("name")?.as_str()?;
     Some(package.replace('-', "_"))
+}
+
+/// Add every path-dependency KEY whose target resolves INSIDE `root` to `roots` — these are local
+/// path dependencies whose import name is the KEY (possibly renamed via the `package` key), so the
+/// bare-reference scope must treat the key as a local crate root (#97 item 2). A string dependency
+/// (`serde = "1"`) or a non-`path` table dependency is external and contributes nothing.
+///
+/// Scans the normal/dev/build dependency tables, every `[target.*.…]` table, and
+/// `[workspace.dependencies]`: aliases declared for tests/examples/build scripts/cfg-specific
+/// modules feed indexed Rust too, so a `use local_alias::…` from any of them must resolve local
+/// (#97 item 4). The key is `-`→`_` normalized (a dependency KEY may contain `-` yet imports as
+/// `use foo_bar::…`). A `path` pointing OUTSIDE the indexed `root` is NOT added (#97 item 5): that
+/// crate has no symbols in this index, so localizing its alias would let a same-named in-corpus
+/// symbol wrongly bind.
+fn collect_path_dependency_aliases(
+    manifest: &toml::Value,
+    manifest_dir: &Path,
+    root: &Path,
+    roots: &mut HashSet<String>,
+) {
+    for table in dependency_tables(manifest) {
+        for (key, spec) in table {
+            let Some(path) = spec.get("path").and_then(toml::Value::as_str) else { continue };
+            if path_dependency_is_in_corpus(manifest_dir, path, root) {
+                roots.insert(key.replace('-', "_"));
+            }
+        }
+    }
+}
+
+/// Every dependency table in a manifest that can carry a path alias bound into indexed Rust: the
+/// top-level `[dependencies]` / `[dev-dependencies]` / `[build-dependencies]`,
+/// `[workspace.dependencies]`, and each per-platform `[target.<cfg>.{dependencies,…}]` table.
+fn dependency_tables(manifest: &toml::Value) -> Vec<&toml::value::Table> {
+    const KINDS: [&str; 3] = ["dependencies", "dev-dependencies", "build-dependencies"];
+    let mut tables = Vec::new();
+    for kind in KINDS {
+        tables.extend(manifest.get(kind).and_then(toml::Value::as_table));
+    }
+    tables.extend(
+        manifest
+            .get("workspace")
+            .and_then(|workspace| workspace.get("dependencies"))
+            .and_then(toml::Value::as_table),
+    );
+    if let Some(targets) = manifest.get("target").and_then(toml::Value::as_table) {
+        for cfg in targets.values() {
+            for kind in KINDS {
+                tables.extend(cfg.get(kind).and_then(toml::Value::as_table));
+            }
+        }
+    }
+    tables
+}
+
+/// Whether a path dependency's target directory resolves under the indexed `root` (#97 item 5).
+/// `manifest_dir` is the directory of the manifest declaring the dependency; `path` is the relative
+/// `path = "…"` value. Canonicalizes both so `../` traversal and symlinks compare honestly; an
+/// unresolvable target (not present on disk) can't hold indexed symbols, so it's treated as
+/// outside.
+fn path_dependency_is_in_corpus(manifest_dir: &Path, path: &str, root: &Path) -> bool {
+    let Ok(target) = manifest_dir.join(path).canonicalize() else { return false };
+    match root.canonicalize() {
+        Ok(canonical_root) => target.starts_with(&canonical_root),
+        Err(_) => target.starts_with(root),
+    }
 }
 
 /// Parse a Rust `use` statement into its crate root and the leaf NAMES it actually binds into
@@ -94,8 +227,6 @@ pub(crate) fn parse_use(use_text: &str) -> Option<(String, Vec<String>)> {
 /// edge), so the caller records nothing.
 fn strip_use_visibility(s: &str) -> Option<&str> {
     let s = s.trim_start();
-    // `pub use …`, `pub(crate) use …`, `pub(in path) use …`. A bare `pub` must be followed by a
-    // boundary (whitespace or `(`) so we don't eat the `pub` prefix of an unrelated identifier.
     let s = match s.strip_prefix("pub") {
         Some(after) if after.starts_with('(') =>
             after.split_once(')').map(|(_, tail)| tail).unwrap_or(after).trim_start(),
@@ -184,65 +315,205 @@ fn split_top_level(inner: &str) -> Vec<&str> {
     parts
 }
 
-/// Per-file map of imported leaf name → the crate root it was imported from, plus the local-crate
-/// set, so resolution can tell an external-dependency import from a local one.
+/// One `use`-introduced binding of a leaf name: the crate root it came from and the module-aware
+/// scope it applies to (#61). A reference is suppressed by this binding only when it falls inside
+/// `[scope_start, scope_end)` AND its enclosing-module id equals `mod_id` — so `mod a { use
+/// url::Url }` does not suppress a local `Url` in a sibling/child `mod b`. On multiple covering
+/// bindings the INNERMOST (smallest span) wins (inner-local `use` shadows an outer-external one).
+#[derive(Clone, Debug)]
+struct ImportBinding {
+    root: String,
+    scope_start: usize,
+    scope_end: usize,
+    mod_id: i64,
+}
+
+impl ImportBinding {
+    fn span(&self) -> usize {
+        self.scope_end.saturating_sub(self.scope_start)
+    }
+
+    /// Whether a reference at `ref_byte` whose enclosing module is `ref_mod_id` is covered by this
+    /// binding: lexically inside the scope (half-open) AND in the same module body.
+    fn covers(&self, ref_byte: usize, ref_mod_id: i64) -> bool {
+        ref_byte >= self.scope_start && ref_byte < self.scope_end && ref_mod_id == self.mod_id
+    }
+}
+
+/// Per-file, module-aware map of imported leaf name → its `use` bindings, plus the per-package and
+/// global local-crate sets and the per-file module-range interval set, so resolution can tell an
+/// external-dependency import from a local one WITHOUT the tree.
 #[derive(Default)]
 pub(crate) struct ImportScope {
-    local_roots: HashSet<String>,
-    by_file: HashMap<i64, HashMap<String, String>>,
+    by_file: HashMap<i64, HashMap<String, Vec<ImportBinding>>>,
+    /// Per file, the inline-module body ranges as `(start, end, mod_id)`, sorted + de-duplicated
+    /// by [`Self::finalize`] — built ONCE per file on ingest so the ref→mod-id lookup stays
+    /// off the per-edge hot path.
+    module_ranges: HashMap<i64, Vec<(usize, usize, i64)>>,
+    file_package: HashMap<i64, i64>,
+    package_roots: HashMap<i64, HashSet<String>>,
+    global_roots: HashSet<String>,
 }
 
 impl ImportScope {
-    pub(crate) fn new(local_roots: HashSet<String>) -> Self {
-        Self { local_roots, by_file: HashMap::new() }
+    pub(crate) fn new(global_roots: HashSet<String>) -> Self {
+        Self { global_roots, ..Self::default() }
     }
 
-    /// Record a `use` statement's bindings for `file_id`: every leaf name it brings into scope →
-    /// the crate root it came from. Idempotent — the same evidence text arrives once per identifier
-    /// in the imports edge stream, and re-recording the same (leaf → root) is a no-op.
-    pub(crate) fn add_use(&mut self, file_id: i64, use_text: &str) {
+    /// Map a file to its owning package (so its bindings consult that package's local-crate set).
+    pub(crate) fn set_file_package(&mut self, file_id: i64, package_id: i64) {
+        self.file_package.insert(file_id, package_id);
+    }
+
+    /// Record a package's local-crate-root set (workspace crates + that manifest's in-corpus path-
+    /// dep alias keys).
+    pub(crate) fn set_package_roots(&mut self, package_id: i64, roots: HashSet<String>) {
+        self.package_roots.insert(package_id, roots);
+    }
+
+    /// Record one Imports edge for `file_id`. An inline-`mod` edge (scope present, but `use_text`
+    /// not a `use`) contributes only a module-range interval; a `use` edge records a binding per
+    /// leaf name with the edge's module-aware scope. Idempotent — the same evidence arrives once
+    /// per identifier in the imports edge stream, and the leaf map de-dups exact repeats;
+    /// module ranges are de-duplicated when [`Self::finalize`] runs.
+    pub(crate) fn add_use(
+        &mut self,
+        file_id: i64,
+        use_text: &str,
+        scope: Option<ImportScopeRange>,
+    ) {
+        if let Some(scope) = scope {
+            // An inline `mod foo { … }` edge carries its OWN body as the scope with
+            // `mod_id == scope_start` — these populate the module interval set (the ref→mod-id
+            // lookup), including modules with no `use`. A `use` edge's scope `mod_id` is its
+            // ENCLOSING module's start (≠ its own scope_start unless top-level), so only `mod`
+            // edges contribute a self-range; recording every edge's scope here is still correct,
+            // since a `use`'s `[scope_start, scope_end)` for a module-level use IS that module's
+            // body — `finalize` de-dups the overlap.
+            self.module_ranges.entry(file_id).or_default().push((
+                scope.scope_start,
+                scope.scope_end,
+                scope.mod_id,
+            ));
+        }
         let Some((root, leaves)) = parse_use(use_text) else { return };
+        let (scope_start, scope_end, mod_id) = match scope {
+            Some(scope) => (scope.scope_start, scope.scope_end, scope.mod_id),
+            // A pre-#61 import edge (or a test) with no scope columns: fall open to whole-file,
+            // file-root scope — reproduces the original per-file behavior.
+            None => (0, usize::MAX, MOD_FILE_ROOT),
+        };
         let file = self.by_file.entry(file_id).or_default();
         for leaf in leaves {
-            file.insert(leaf, root.clone());
+            let binding = ImportBinding { root: root.clone(), scope_start, scope_end, mod_id };
+            let bindings = file.entry(leaf).or_default();
+            // Dedup exact repeats (the same leaf re-emitted under the truncated-evidence edges of
+            // one `use`); a different scope/root is a distinct binding and is kept.
+            if !bindings.iter().any(|b| {
+                b.root == binding.root
+                    && b.scope_start == binding.scope_start
+                    && b.scope_end == binding.scope_end
+                    && b.mod_id == binding.mod_id
+            }) {
+                bindings.push(binding);
+            }
         }
     }
 
-    /// Whether `name` in `file_id` was imported from an EXTERNAL dependency crate — not a local
-    /// workspace crate, not `crate`/`self`/`super`. When true, the name denotes that dependency's
-    /// item and must NOT bind to a local same-named symbol. Fails OPEN: with no local-crate set
-    /// (non-Cargo corpus / manifest scan found nothing), nothing is ever suppressed.
-    pub(crate) fn is_external_import(&self, file_id: i64, name: &str) -> bool {
-        if self.local_roots.is_empty() {
+    /// Finalize the per-file module-range interval sets: sort each by `(start asc, end desc)` and
+    /// drop exact duplicates. Called ONCE after all edges are ingested, so the ref→mod-id lookup
+    /// stays cheap and off the per-edge hot path. Idempotent.
+    pub(crate) fn finalize(&mut self) {
+        for ranges in self.module_ranges.values_mut() {
+            ranges.sort_by(|a, b| a.0.cmp(&b.0).then(b.1.cmp(&a.1)));
+            ranges.dedup();
+        }
+    }
+
+    /// The id of the INNERMOST inline module whose body contains `ref_byte`, or [`MOD_FILE_ROOT`]
+    /// when the reference is at file root. "Innermost" = the smallest containing body. O(n) over a
+    /// file's module ranges (a handful), already sorted by [`Self::finalize`].
+    fn ref_mod_id(&self, file_id: i64, ref_byte: usize) -> i64 {
+        let Some(ranges) = self.module_ranges.get(&file_id) else {
+            return MOD_FILE_ROOT;
+        };
+        let mut best: Option<(usize, i64)> = None; // (span, mod_id)
+        for &(start, end, mod_id) in ranges {
+            // A `use` edge contributes ranges with `mod_id != start` (its enclosing module); only a
+            // real inline-`mod` self-range (mod_id == start) defines a module the ref can belong
+            // to.
+            if mod_id != start as i64 {
+                continue;
+            }
+            if ref_byte >= start && ref_byte < end {
+                let span = end - start;
+                if best.is_none_or(|(best_span, _)| span <= best_span) {
+                    best = Some((span, mod_id));
+                }
+            }
+        }
+        best.map(|(_, mod_id)| mod_id).unwrap_or(MOD_FILE_ROOT)
+    }
+
+    /// The local-crate-root set that applies to `file_id`: its package's set if known, else the
+    /// global union (a file with no package row falls open exactly like the pre-#61 single-set).
+    fn roots_for_file(&self, file_id: i64) -> &HashSet<String> {
+        self.file_package
+            .get(&file_id)
+            .and_then(|package_id| self.package_roots.get(package_id))
+            .unwrap_or(&self.global_roots)
+    }
+
+    /// The crate root that binds `name` at `ref_byte` in `file_id`, if any — the INNERMOST covering
+    /// `use` binding's root (smallest span wins, so an inner-local `use` shadows an outer one). The
+    /// module-aware covering test stops a parent-`mod` `use` from reaching a child-`mod` reference.
+    fn covering_root(&self, file_id: i64, name: &str, ref_byte: usize) -> Option<&str> {
+        let bindings = self.by_file.get(&file_id)?.get(name)?;
+        let ref_mod_id = self.ref_mod_id(file_id, ref_byte);
+        bindings
+            .iter()
+            .filter(|binding| binding.covers(ref_byte, ref_mod_id))
+            .min_by_key(|binding| binding.span())
+            .map(|binding| binding.root.as_str())
+    }
+
+    /// Whether `name` at `ref_byte` in `file_id` was imported from an EXTERNAL dependency crate —
+    /// not a local workspace/path-dep crate, not `crate`/`self`/`super`. When true, the name
+    /// denotes that dependency's item and must NOT bind to a local same-named symbol. Fails
+    /// OPEN: with no local-crate set (non-Cargo corpus / manifest scan found nothing), nothing
+    /// is suppressed.
+    pub(crate) fn is_external_import(&self, file_id: i64, name: &str, ref_byte: usize) -> bool {
+        let local_roots = self.roots_for_file(file_id);
+        if local_roots.is_empty() {
             return false;
         }
-        let Some(root) = self.by_file.get(&file_id).and_then(|names| names.get(name)) else {
+        let Some(root) = self.covering_root(file_id, name, ref_byte) else {
             return false;
         };
-        !self.local_roots.contains(root) && !matches!(root.as_str(), "crate" | "self" | "super")
+        !local_roots.contains(root) && !matches!(root, "crate" | "self" | "super")
     }
 
     /// Whether a path-qualified reference's RECEIVER/root names an external import — `Url::parse`
     /// (target_qualified_name `Url::parse`) where `Url` was `use`d from the external `url` crate.
     /// The leaf `parse` itself isn't imported, so [`is_external_import`] on the callee name misses
-    /// it; the new scope-path lookup would otherwise bind `Url::parse` to an in-repo `Url::parse`.
+    /// it; this checks the receiver root.
     ///
-    /// Gated on a TYPE-LIKE (uppercase) head. `target_qualified_name` rewrites `.`→`::`
-    /// (helpers::target_qualified_name), so a value-receiver method call `config.build()` arrives
-    /// here as `config::build` and is INDISTINGUISHABLE from a path call by punctuation alone.
-    /// Suppressing it would drop a valid local method call whenever the receiver's name happens to
-    /// match an imported leaf. The realistic mis-bind this guards against is a PascalCase type
-    /// collision (`Url::parse` → a same-named local `impl Url`); module/value heads are snake_case,
-    /// so the uppercase gate keeps the type case and leaves lowercase heads to fall through
-    /// (fail open — a missed suppression, never a dropped local bind).
+    /// Gated on a TYPE-LIKE (uppercase) head. `target_qualified_name` rewrites `.`→`::`, so a
+    /// value-receiver method call `config.build()` arrives as `config::build` and is
+    /// INDISTINGUISHABLE from a path call by punctuation alone; suppressing it would drop a valid
+    /// local method call. The uppercase gate keeps the PascalCase-type case (`Url::parse`) and lets
+    /// snake_case value/module heads fall through (fail open — a missed suppression, never a
+    /// dropped local bind).
     pub(crate) fn is_external_qualified_root(
         &self,
         file_id: i64,
         target_qualified_name: Option<&str>,
+        ref_byte: usize,
     ) -> bool {
         target_qualified_name.and_then(|qualified| qualified.split_once("::")).is_some_and(
             |(root, _)| {
-                root.starts_with(char::is_uppercase) && self.is_external_import(file_id, root)
+                root.starts_with(char::is_uppercase)
+                    && self.is_external_import(file_id, root, ref_byte)
             },
         )
     }
@@ -260,6 +531,20 @@ mod tests {
         })
     }
 
+    /// An inline-module body range as an [`ImportScopeRange`] (`mod_id == scope_start`).
+    fn mod_scope(start: usize, end: usize) -> ImportScopeRange {
+        ImportScopeRange { scope_start: start, scope_end: end, mod_id: start as i64 }
+    }
+
+    /// A `use` scope inside module `mod_id` (a body start), covering `[start, end)`.
+    fn use_in_mod(start: usize, end: usize, mod_id: i64) -> ImportScopeRange {
+        ImportScopeRange { scope_start: start, scope_end: end, mod_id }
+    }
+
+    fn scope_at_file_root(start: usize, end: usize) -> ImportScopeRange {
+        ImportScopeRange { scope_start: start, scope_end: end, mod_id: MOD_FILE_ROOT }
+    }
+
     #[test]
     fn parse_use_extracts_root_and_only_bound_leaves() {
         let s = |v: &[&str]| v.iter().map(|x| x.to_string()).collect::<Vec<_>>();
@@ -268,55 +553,143 @@ mod tests {
             parsed("use cargo::core::Workspace;"),
             Some(("cargo".into(), s(&["Workspace"])))
         );
-        // The braced form: the path PREFIX `path` is NOT a binding — only `Path`/`PathBuf` are.
         assert_eq!(
             parsed("use std::path::{Path, PathBuf};"),
             Some(("std".into(), s(&["Path", "PathBuf"])))
         );
-        // `use std::path;` DOES bind the module `path` (no braces, last segment is the binding).
         assert_eq!(parsed("use std::path;"), Some(("std".into(), s(&["path"]))));
-        // Restricted visibility must still parse (was dropped by the old `pub ` strip).
         assert_eq!(parsed("pub(crate) use url::Url;"), Some(("url".into(), s(&["Url"]))));
         assert_eq!(parsed("pub(super) use a::B;"), Some(("a".into(), s(&["B"]))));
         assert_eq!(parsed("pub(in crate::x) use a::B;"), Some(("a".into(), s(&["B"]))));
         assert_eq!(parsed("pub use crate::a::B;"), Some(("crate".into(), s(&["B"]))));
-        // `as` alias: the alias is the bound name.
         assert_eq!(parsed("use foo::Bar as Baz;"), Some(("foo".into(), s(&["Baz"]))));
-        // Brace-free ROOT alias: the root is the pre-`as` crate, the leaf is the alias.
         assert_eq!(parsed("use my_crate as local;"), Some(("my_crate".into(), s(&["local"]))));
         assert_eq!(parsed("use foo::{Bar as Baz, Qux};"), Some(("foo".into(), s(&["Baz", "Qux"]))));
-        // `self` in a group binds the parent segment.
         assert_eq!(parsed("use a::b::{self, C};"), Some(("a".into(), s(&["C", "b"]))));
-        // Nested groups.
         assert_eq!(parsed("use a::{b::{C, D}, E};"), Some(("a".into(), s(&["C", "D", "E"]))));
-        // Glob binds no specific name (fail open).
         assert_eq!(parse_use("use foo::*;"), Some(("foo".to_string(), Vec::new())));
-        // Leading `::` (absolute path): root is the real crate, not empty.
         assert_eq!(parsed("use ::external::X;"), Some(("external".into(), s(&["X"]))));
-        // Not a `use` statement.
         assert_eq!(parse_use("mod foo;"), None);
     }
 
     #[test]
     fn external_import_distinguishes_local_from_dependency() {
         let mut scope = ImportScope::new(HashSet::from(["cargo".to_string()]));
-        scope.add_use(1, "use url::Url;"); // external dep
-        scope.add_use(1, "use cargo::core::Workspace;"); // local workspace crate
-        scope.add_use(1, "use std::path::{Path, PathBuf};"); // std = external
-        scope.add_use(1, "use crate::a::Helper;"); // local (crate-relative)
-        assert!(scope.is_external_import(1, "Url"), "url is an external dep");
-        assert!(scope.is_external_import(1, "Path"), "std is external");
-        assert!(!scope.is_external_import(1, "Workspace"), "cargo is a local workspace crate");
-        assert!(!scope.is_external_import(1, "Helper"), "crate-rooted is local");
+        let s = Some(scope_at_file_root(0, usize::MAX));
+        scope.add_use(1, "use url::Url;", s); // external dep
+        scope.add_use(1, "use cargo::core::Workspace;", s); // local workspace crate
+        scope.add_use(1, "use std::path::{Path, PathBuf};", s); // std = external
+        scope.add_use(1, "use crate::a::Helper;", s); // local (crate-relative)
+        scope.finalize();
+        assert!(scope.is_external_import(1, "Url", 100), "url is an external dep");
+        assert!(scope.is_external_import(1, "Path", 100), "std is external");
+        assert!(!scope.is_external_import(1, "Workspace", 100), "cargo is a local workspace crate");
+        assert!(!scope.is_external_import(1, "Helper", 100), "crate-rooted is local");
         assert!(
-            !scope.is_external_import(1, "path"),
+            !scope.is_external_import(1, "path", 100),
             "the `std::path` PREFIX is not a binding — a local `path` must stay resolvable"
         );
         assert!(
-            !scope.is_external_import(1, "Unimported"),
+            !scope.is_external_import(1, "Unimported", 100),
             "an unimported name is never suppressed"
         );
-        assert!(!scope.is_external_import(2, "Url"), "scoped per file");
+        assert!(!scope.is_external_import(2, "Url", 100), "scoped per file");
+    }
+
+    #[test]
+    fn empty_local_set_fails_open() {
+        let mut scope = ImportScope::new(HashSet::new());
+        scope.add_use(1, "use url::Url;", Some(scope_at_file_root(0, usize::MAX)));
+        scope.finalize();
+        assert!(!scope.is_external_import(1, "Url", 100), "no manifests → suppress nothing");
+    }
+
+    /// #1 (per-package locality): a `path`-dep alias `local` is local for crate A (which declares
+    /// it) but EXTERNAL for crate B (with its own same-named import). One global set can't express
+    /// that; the per-package set must.
+    #[test]
+    fn per_package_alias_does_not_leak_across_packages() {
+        let mut scope = ImportScope::new(HashSet::from(["myws".to_string(), "local".to_string()]));
+        scope.set_package_roots(10, HashSet::from(["myws".to_string(), "local".to_string()]));
+        scope.set_package_roots(20, HashSet::from(["myws".to_string()]));
+        scope.set_file_package(1, 10); // file 1 → package A
+        scope.set_file_package(2, 20); // file 2 → package B
+        scope.add_use(1, "use local::Thing;", Some(scope_at_file_root(0, usize::MAX)));
+        scope.add_use(2, "use local::Thing;", Some(scope_at_file_root(0, usize::MAX)));
+        scope.finalize();
+        assert!(
+            !scope.is_external_import(1, "Thing", 100),
+            "in package A, `local` is its own path-dep alias — a LOCAL crate"
+        );
+        assert!(
+            scope.is_external_import(2, "Thing", 100),
+            "in package B, `local` is NOT a declared alias — it names an EXTERNAL crate"
+        );
+    }
+
+    /// #4 (parent-`mod` `use` does not suppress a child-`mod` local): the use in `mod a` must not
+    /// reach a `Url` reference inside the child `mod b` — child modules don't inherit a parent's
+    /// `use`s. A reference in `mod a` itself IS covered.
+    #[test]
+    fn parent_module_use_does_not_suppress_child_mod_local() {
+        let mut scope = ImportScope::new(HashSet::from(["myws".to_string()]));
+        scope.add_use(1, "mod a", Some(mod_scope(0, 200))); // mod a body [0,200)
+        scope.add_use(1, "mod b", Some(mod_scope(80, 160))); // nested mod b body [80,160)
+        scope.add_use(1, "use url::Url;", Some(use_in_mod(0, 200, 0))); // use lives in mod a
+        scope.finalize();
+        assert!(
+            !scope.is_external_import(1, "Url", 100),
+            "a's `use url::Url` must not reach a reference inside child mod b"
+        );
+        assert!(
+            scope.is_external_import(1, "Url", 40),
+            "a reference in mod a itself IS covered by a's `use url::Url`"
+        );
+    }
+
+    /// #5 (innermost shadowing): an inner-local `use crate::Url` and an outer-external `use url::Url`
+    /// both lexically cover a reference; the INNERMOST (smallest span, same module) wins → resolve
+    /// LOCAL.
+    #[test]
+    fn innermost_use_wins_over_outer() {
+        let mut scope = ImportScope::new(HashSet::from(["myws".to_string()]));
+        scope.add_use(1, "mod a", Some(mod_scope(0, 300)));
+        scope.add_use(1, "mod b", Some(mod_scope(100, 200)));
+        scope.add_use(1, "use url::Url;", Some(use_in_mod(0, 300, 0))); // outer external, mod a
+        scope.add_use(1, "use crate::Url;", Some(use_in_mod(100, 200, 100))); // inner local, mod b
+        scope.finalize();
+        assert!(
+            !scope.is_external_import(1, "Url", 150),
+            "the inner-local `use crate::Url` shadows the outer-external one"
+        );
+    }
+
+    /// The `use`'s scope is the MODULE body, not a `block` inside it that merely INHERITS the
+    /// module's uses; a block-local `use` is confined to its block (#61).
+    #[test]
+    fn use_scope_is_module_not_block() {
+        let mut scope = ImportScope::new(HashSet::from(["myws".to_string()]));
+        scope.add_use(1, "mod a", Some(mod_scope(0, 300)));
+        scope.add_use(1, "use url::Url;", Some(use_in_mod(0, 300, 0))); // module-level use
+        scope.finalize();
+        assert!(
+            scope.is_external_import(1, "Url", 80),
+            "a module-level `use` covers a reference in a nested block of the same module"
+        );
+
+        let mut block_scope = ImportScope::new(HashSet::from(["myws".to_string()]));
+        block_scope.add_use(1, "mod a", Some(mod_scope(0, 300)));
+        // Block-local use: scope is the block [50,120), mod_id still 0 (the enclosing module).
+        block_scope.add_use(1, "use url::Url;", Some(use_in_mod(50, 120, 0)));
+        block_scope.finalize();
+        assert!(
+            block_scope.is_external_import(1, "Url", 80),
+            "a block-local use covers a reference inside the block"
+        );
+        assert!(
+            !block_scope.is_external_import(1, "Url", 200),
+            "a block-local use does NOT reach a reference outside the block (same module)"
+        );
     }
 
     #[test]
@@ -329,18 +702,124 @@ mod tests {
             "[workspace]\nmembers=[\"crates/*\"]\n[package]\nname=\"cargo\"\n",
         )
         .unwrap();
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+        std::fs::write(dir.join("src/lib.rs"), "").unwrap();
         std::fs::write(dir.join("crates/foo-bar/Cargo.toml"), "[package]\nname=\"foo-bar\"\n")
             .unwrap();
-        let roots = local_crate_roots(&dir);
+        std::fs::write(dir.join("crates/foo-bar/src/lib.rs"), "").unwrap();
+        let roots = scan_packages(&dir).0;
         let _ = std::fs::remove_dir_all(&dir);
         assert!(roots.contains("cargo"), "top package; got {roots:?}");
         assert!(roots.contains("foo_bar"), "hyphen→underscore normalized; got {roots:?}");
     }
 
+    /// #97 item 3: a BIN-ONLY member (no `[lib]`, no `src/lib.rs`) is not importable, so it must NOT
+    /// contribute its package name as a root — else a same-named external dependency is wrongly
+    /// treated as local. A LIBRARY member (autodiscovered `src/lib.rs` or explicit `[lib]`) does.
     #[test]
-    fn empty_local_set_fails_open() {
-        let mut scope = ImportScope::new(HashSet::new());
-        scope.add_use(1, "use url::Url;");
-        assert!(!scope.is_external_import(1, "Url"), "no manifests → suppress nothing");
+    fn local_crate_roots_skips_bin_only_packages() {
+        let dir = std::env::temp_dir().join(format!("rr-bin-only-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("tool/src")).unwrap();
+        std::fs::write(dir.join("tool/Cargo.toml"), "[package]\nname=\"clap\"\n").unwrap();
+        std::fs::write(dir.join("tool/src/main.rs"), "fn main() {}").unwrap();
+        std::fs::create_dir_all(dir.join("lib-crate/src")).unwrap();
+        std::fs::write(dir.join("lib-crate/Cargo.toml"), "[package]\nname=\"lib-crate\"\n")
+            .unwrap();
+        std::fs::write(dir.join("lib-crate/src/lib.rs"), "").unwrap();
+        std::fs::create_dir_all(dir.join("explicit/src")).unwrap();
+        std::fs::write(
+            dir.join("explicit/Cargo.toml"),
+            "[package]\nname=\"explicit\"\n[lib]\npath=\"src/thing.rs\"\n",
+        )
+        .unwrap();
+        let roots = scan_packages(&dir).0;
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(
+            !roots.contains("clap"),
+            "a bin-only package name is not a local root; got {roots:?}"
+        );
+        assert!(
+            roots.contains("lib_crate"),
+            "an autodiscovered lib contributes its root; got {roots:?}"
+        );
+        assert!(
+            roots.contains("explicit"),
+            "an explicit [lib] table contributes its root; got {roots:?}"
+        );
+    }
+
+    /// #97 item 5: a `path = "…"` dependency pointing OUTSIDE the indexed root has no symbols in
+    /// this index, so localizing its alias would let a same-named in-corpus symbol wrongly bind.
+    #[test]
+    fn local_crate_roots_excludes_out_of_corpus_path_deps() {
+        let base = std::env::temp_dir().join(format!("rr-corpus-scope-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        let root = base.join("indexed");
+        std::fs::create_dir_all(base.join("sibling/src")).unwrap();
+        std::fs::write(base.join("sibling/src/lib.rs"), "").unwrap();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(root.join("inside")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), "").unwrap();
+        std::fs::write(
+            root.join("Cargo.toml"),
+            "[package]\nname=\"app\"\n[dependencies]\noutside_alias = { path = \"../sibling\" \
+             }\ninside_alias = { path = \"inside\" }\nmissing_alias = { path = \"nope\" }\n",
+        )
+        .unwrap();
+        let roots = scan_packages(&root).0;
+        let _ = std::fs::remove_dir_all(&base);
+        assert!(
+            !roots.contains("outside_alias"),
+            "a path dep outside the indexed root is NOT a local root; got {roots:?}"
+        );
+        assert!(
+            roots.contains("inside_alias"),
+            "a path dep inside the indexed root IS a local root; got {roots:?}"
+        );
+        assert!(
+            !roots.contains("missing_alias"),
+            "a path dep whose target doesn't exist can't hold indexed symbols; got {roots:?}"
+        );
+    }
+
+    /// `scan_packages` returns per-package roots: each manifest's set is the workspace union plus
+    /// only ITS OWN in-corpus path-dep alias keys (#1 — the cross-package leak guard at the
+    /// source).
+    #[test]
+    fn scan_packages_keeps_path_dep_aliases_package_local() {
+        let root = std::env::temp_dir().join(format!("rr-scan-pkg-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("shared/src")).unwrap();
+        std::fs::write(root.join("shared/Cargo.toml"), "[package]\nname=\"shared\"\n").unwrap();
+        std::fs::write(root.join("shared/src/lib.rs"), "").unwrap();
+        std::fs::create_dir_all(root.join("a/src")).unwrap();
+        std::fs::write(
+            root.join("a/Cargo.toml"),
+            "[package]\nname=\"a\"\n[dependencies]\na_only = { path = \"../shared\" }\n",
+        )
+        .unwrap();
+        std::fs::write(root.join("a/src/lib.rs"), "").unwrap();
+        std::fs::create_dir_all(root.join("b/src")).unwrap();
+        std::fs::write(root.join("b/Cargo.toml"), "[package]\nname=\"b\"\n").unwrap();
+        std::fs::write(root.join("b/src/lib.rs"), "").unwrap();
+        let (global, packages) = scan_packages(&root);
+        let _ = std::fs::remove_dir_all(&root);
+        assert!(
+            global.contains("a_only"),
+            "the global union includes every alias key; got {global:?}"
+        );
+        let pkg_a = packages.iter().find(|p| p.manifest_dir == "a").expect("package a");
+        let pkg_b = packages.iter().find(|p| p.manifest_dir == "b").expect("package b");
+        assert!(
+            pkg_a.local_roots.contains("a_only"),
+            "package a owns the alias; got {:?}",
+            pkg_a.local_roots
+        );
+        assert!(
+            !pkg_b.local_roots.contains("a_only"),
+            "package b never declared the alias — must not be local for it; got {:?}",
+            pkg_b.local_roots
+        );
     }
 }

--- a/crates/rag-rat-core/src/index/edges/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/mod.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 pub(crate) use extract::*;
 pub(crate) use helpers::*;
-pub(crate) use imports::local_crate_roots;
+pub(crate) use imports::scan_packages;
 use intern::{OptSym, StrArena, Sym};
 pub(crate) use resolve::*;
 use rusqlite::{Connection, params};
@@ -87,6 +87,25 @@ impl CalleeRange {
     }
 }
 
+/// Module-aware import scope of a Rust `use` (or the body range of an inline `mod`), stored on
+/// Imports edges in the DEDICATED `import_scope_*` / `import_mod_id` columns (#61 per-package +
+/// module-aware rework). For a `use`: `[scope_start, scope_end)` is the enclosing module body — or
+/// the enclosing block, for a block-local `use` — and `mod_id` is the enclosing module body's start
+/// byte (`MOD_FILE_ROOT` for a top-level `use`). For an inline `mod foo { … }`: the range is the
+/// module body and `mod_id` is its own start byte, so resolution can rebuild the per-file module
+/// interval set (the ref→mod-id lookup) from these edges WITHOUT the tree. Kept off the `callee_*`
+/// columns so the oracle's `callee_start_byte IS NOT NULL` candidate filter is untouched.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ImportScopeRange {
+    pub(crate) scope_start: usize,
+    pub(crate) scope_end: usize,
+    pub(crate) mod_id: i64,
+}
+
+/// Sentinel `import_mod_id` for a top-level `use` / a file-root reference: no enclosing module
+/// body. `-1` because a real `mod_id` is a module body's `start_byte` (≥ 0).
+pub(crate) const MOD_FILE_ROOT: i64 = -1;
+
 #[derive(Debug, Clone)]
 pub(crate) struct EdgeCandidate {
     from_symbol_id: Option<i64>,
@@ -99,6 +118,9 @@ pub(crate) struct EdgeCandidate {
     /// Byte range of the callee identifier token; see [`CalleeRange`]. `None` for non-symbol
     /// edges.
     callee_span: Option<CalleeRange>,
+    /// Module-aware import scope; see [`ImportScopeRange`]. `Some` only for Rust Imports edges (a
+    /// `use`'s enclosing scope, or an inline `mod`'s body range); `None` for every other edge.
+    import_scope: Option<ImportScopeRange>,
     edge_kind: EdgeKind,
     confidence: EdgeConfidence,
 }
@@ -243,6 +265,12 @@ struct CompactEdge {
     /// Callee identifier byte range; `u32::MAX` in `callee_start_byte` is the `None` sentinel.
     callee_start_byte: u32,
     callee_end_byte: u32,
+    /// Module-aware import scope (#61); `u32::MAX` in `import_scope_start_byte` is the `None`
+    /// sentinel (a non-import edge). `import_mod_id` is a real `i64` ([`MOD_FILE_ROOT`] = -1 for a
+    /// top-level `use`), so it cannot carry the niche — the start-byte sentinel gates it.
+    import_scope_start_byte: u32,
+    import_scope_end_byte: u32,
+    import_mod_id: i64,
     edge_kind: EdgeKind,
     confidence: EdgeConfidence,
 }
@@ -271,6 +299,48 @@ impl CompactEdge {
             (None, None)
         } else {
             (Some(i64::from(self.callee_start_byte)), Some(i64::from(self.callee_end_byte)))
+        }
+    }
+
+    /// Pack `Option<ImportScopeRange>` into the two `u32` scope-byte fields + the `i64` mod-id,
+    /// using `u32::MAX` in the start byte for `None` (mirrors `pack_callee`). The start sentinel —
+    /// not `mod_id` — gates presence, because `MOD_FILE_ROOT` (-1) is itself a valid stored mod id.
+    fn pack_import_scope(scope: Option<ImportScopeRange>) -> (u32, u32, i64) {
+        match scope {
+            Some(range) => {
+                let clamp = |value: usize| u32::try_from(value).unwrap_or(0);
+                (clamp(range.scope_start), clamp(range.scope_end), range.mod_id)
+            },
+            None => (Self::CALLEE_NONE, Self::CALLEE_NONE, MOD_FILE_ROOT),
+        }
+    }
+
+    /// The stored import scope as an [`ImportScopeRange`], or `None` for a non-import edge. Used by
+    /// the full-rebuild driver to feed `ImportScope::add_use` from the in-memory accumulator (the
+    /// twin of the DB driver reading the `import_scope_*` columns).
+    fn import_scope_range(&self) -> Option<ImportScopeRange> {
+        if self.import_scope_start_byte == Self::CALLEE_NONE {
+            None
+        } else {
+            Some(ImportScopeRange {
+                scope_start: self.import_scope_start_byte as usize,
+                scope_end: self.import_scope_end_byte as usize,
+                mod_id: self.import_mod_id,
+            })
+        }
+    }
+
+    /// The stored import-scope range as nullable `i64`s for the edge-row insert: `(NULL, NULL,
+    /// NULL)` for a non-import edge, otherwise `(scope_start, scope_end, mod_id)`.
+    fn import_scope_columns(&self) -> (Option<i64>, Option<i64>, Option<i64>) {
+        if self.import_scope_start_byte == Self::CALLEE_NONE {
+            (None, None, None)
+        } else {
+            (
+                Some(i64::from(self.import_scope_start_byte)),
+                Some(i64::from(self.import_scope_end_byte)),
+                Some(self.import_mod_id),
+            )
         }
     }
 }
@@ -318,6 +388,8 @@ impl FullRebuildGraph {
             usize::try_from(local).ok().and_then(|index| db_ids.get(index)).copied()
         });
         let (callee_start_byte, callee_end_byte) = CompactEdge::pack_callee(candidate.callee_span);
+        let (import_scope_start_byte, import_scope_end_byte, import_mod_id) =
+            CompactEdge::pack_import_scope(candidate.import_scope);
         let compact = CompactEdge {
             from_symbol_id,
             from_name: self.arena.intern_opt(candidate.from_name.as_deref()),
@@ -330,6 +402,9 @@ impl FullRebuildGraph {
             source_span: CompactSpan::from_span(candidate.source_span),
             callee_start_byte,
             callee_end_byte,
+            import_scope_start_byte,
+            import_scope_end_byte,
+            import_mod_id,
             edge_kind: candidate.edge_kind,
             confidence: candidate.confidence,
         };

--- a/crates/rag-rat-core/src/index/edges/resolve.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve.rs
@@ -45,7 +45,10 @@ fn load_package_roots_into_scope(
         }
     }
     // files → package_id, scoped to the active checkout via the `files` TEMP VIEW (overlay wins,
-    // dead scopes excluded), matching the symbol/edge resolution scope.
+    // dead scopes excluded), matching the symbol/edge resolution scope. Any non-null package_id in
+    // the active scope means the corpus is a Cargo project — so a bin-only crate (empty root set)
+    // still suppresses external imports rather than failing open (#4). This is scope-correct: it
+    // reads the active checkout's files, not the unscoped `packages` table above.
     {
         let mut stmt = conn.prepare(
             "SELECT files.id, files.package_id FROM files WHERE files.package_id IS NOT NULL",
@@ -54,6 +57,7 @@ fn load_package_roots_into_scope(
         for row in rows {
             let (file_id, package_id) = row?;
             scope.set_file_package(file_id, package_id);
+            scope.mark_has_manifests();
         }
     }
     Ok(())

--- a/crates/rag-rat-core/src/index/edges/resolve.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve.rs
@@ -18,49 +18,113 @@ fn import_scope_from_row(
     })
 }
 
-/// Load the per-package local-crate sets + the file→package mapping for the ACTIVE CHECKOUT into
-/// `scope` (#61 per-package locality). `packages.local_roots_json` is a JSON string array of crate
-/// roots. Both reads are scoped through the per-connection `files`/`packages` rows of the active
-/// commit/worktree — a missing/empty `packages` table (non-Cargo corpus, pre-V022 index) leaves the
-/// scope's per-package maps empty so every file falls open to the global set. Shared by BOTH
-/// drivers so the per-package model is identical (#61 both-driver parity).
+/// Load the per-package local-crate sets and COMPUTE each active file's owning package into `scope`
+/// (#61 per-package locality). `packages.local_roots_json` is a JSON string array of crate roots.
+///
+/// The file→package mapping is computed AT LOAD time — not read from a persisted `files.package_id`
+/// — by longest-`manifest_dir`-prefix over the active scope's `packages` rows. A persisted pointer
+/// was the #106 multi-worktree leak: a clean file is a SHARED commit-scope row read by every
+/// worktree at that commit, while a package row is worktree-scoped, so one worktree's refresh
+/// stamped its package ids onto the shared rows a sibling then followed (and the DELETE + reinsert
+/// churned those ids each pass). Computing here against the active scope's OWN `packages` rows
+/// means worktree B never sees worktree A's package map.
+///
+/// The `packages` read is scoped to the active `(commit_sha, worktree_id)` via the per-connection
+/// `temp.connection_context` (the same context `install_scope_view` reads to build the `files`
+/// view); the file list comes from the `files` TEMP VIEW (overlay wins, dead/sibling scopes
+/// excluded), matching the symbol/edge resolution scope. A missing/empty `packages` table
+/// (non-Cargo corpus, pre-V022 index) leaves the per-package maps empty so every file falls open to
+/// the global set. Shared by BOTH drivers so the per-package model is identical (#61 both-driver
+/// parity).
 fn load_package_roots_into_scope(
     conn: &Connection,
     scope: &mut imports::ImportScope,
 ) -> anyhow::Result<()> {
-    // packages: id → local_roots (JSON array). Unscoped read of the whole table is fine — a
-    // package id is unique across scopes (its own PK), and files only reference ids in their scope.
-    {
-        let mut stmt = match conn.prepare("SELECT id, local_roots_json FROM packages") {
+    // The active checkout's (commit_sha, worktree_id), so the `packages` read is scoped exactly
+    // like the `files` view (which reads the same context table). A raw test connection without
+    // the context falls back to empty strings — the same scope `add_package`/`refresh_packages`
+    // write under for non-git fixtures, so the test path stays consistent.
+    let active_commit_sha = scope_context_value(conn, "commit_sha");
+    let active_worktree_id = scope_context_value(conn, "worktree_id");
+
+    // The active scope's packages, longest `manifest_dir` first so the first matching prefix is the
+    // most specific package. A synthetic per-load index keys `scope.package_roots` — the persisted
+    // `packages.id` is deliberately NOT consulted (it churns on every `refresh_packages` DELETE +
+    // reinsert and is meaningless across scopes).
+    let packages: Vec<(String, HashSet<String>)> = {
+        let mut stmt = match conn.prepare(
+            "SELECT manifest_dir, local_roots_json FROM packages WHERE commit_sha = ?1 AND \
+             worktree_id = ?2",
+        ) {
             Ok(stmt) => stmt,
             // No `packages` table (pre-V022 / non-Cargo): nothing to load, fall open.
             Err(_) => return Ok(()),
         };
+        let rows = stmt.query_map(params![active_commit_sha, active_worktree_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
+        let mut packages: Vec<(String, HashSet<String>)> = rows
+            .map(|row| {
+                let (manifest_dir, roots_json) = row?;
+                let roots: HashSet<String> = serde_json::from_str(&roots_json).unwrap_or_default();
+                Ok::<_, anyhow::Error>((manifest_dir, roots))
+            })
+            .collect::<Result<_, _>>()?;
+        packages.sort_by_key(|(dir, _)| std::cmp::Reverse(dir.len()));
+        packages
+    };
+    // No package rows for this scope (non-Cargo corpus, or a scope that never ran
+    // refresh_packages): leave the per-package maps empty so every file falls open to the
+    // global union.
+    if packages.is_empty() {
+        return Ok(());
+    }
+    for (synthetic_id, (_, roots)) in packages.iter().enumerate() {
+        scope.set_package_roots(synthetic_id as i64, roots.clone());
+    }
+
+    // Assign each active file its package by longest manifest-dir prefix — the SAME prefix rule the
+    // persisted assignment used: the empty-dir root manifest is the catch-all, else the path must
+    // equal the dir or continue with `/` after it. Built once on ingest, so `is_external_import`'s
+    // per-file lookup stays O(1). The `files` view scopes to the active checkout (#89). Any package
+    // row in this scope means the corpus is a Cargo project, so even a file matching no package
+    // (left unmapped → global fallback) still marks the scope as having manifests — a bin-only
+    // crate suppresses external imports rather than failing open (#4).
+    {
+        let mut stmt = conn.prepare("SELECT id, path FROM files")?;
         let rows =
             stmt.query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)))?;
         for row in rows {
-            let (package_id, roots_json) = row?;
-            let roots: HashSet<String> = serde_json::from_str(&roots_json).unwrap_or_default();
-            scope.set_package_roots(package_id, roots);
-        }
-    }
-    // files → package_id, scoped to the active checkout via the `files` TEMP VIEW (overlay wins,
-    // dead scopes excluded), matching the symbol/edge resolution scope. Any non-null package_id in
-    // the active scope means the corpus is a Cargo project — so a bin-only crate (empty root set)
-    // still suppresses external imports rather than failing open (#4). This is scope-correct: it
-    // reads the active checkout's files, not the unscoped `packages` table above.
-    {
-        let mut stmt = conn.prepare(
-            "SELECT files.id, files.package_id FROM files WHERE files.package_id IS NOT NULL",
-        )?;
-        let rows = stmt.query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)))?;
-        for row in rows {
-            let (file_id, package_id) = row?;
-            scope.set_file_package(file_id, package_id);
+            let (file_id, path) = row?;
             scope.mark_has_manifests();
+            let package = packages.iter().enumerate().find_map(|(synthetic_id, (dir, _))| {
+                let in_package = dir.is_empty()
+                    || path == *dir
+                    || path.strip_prefix(dir).is_some_and(|rest| rest.starts_with('/'));
+                in_package.then_some(synthetic_id as i64)
+            });
+            if let Some(synthetic_id) = package {
+                scope.set_file_package(file_id, synthetic_id);
+            }
         }
     }
     Ok(())
+}
+
+/// Read a value from the per-connection `temp.connection_context` (the scope table
+/// `install_scope_view` populates). Empty string when absent — a raw test connection without the
+/// view, where `refresh_packages`/`add_package` also write the empty scope.
+fn scope_context_value(conn: &Connection, key: &str) -> String {
+    use rusqlite::OptionalExtension;
+    conn.query_row(
+        "SELECT value FROM temp.connection_context WHERE key = ?1",
+        params![key],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()
+    .ok()
+    .flatten()
+    .unwrap_or_default()
 }
 
 /// Re-resolve the ACTIVE CHECKOUT's edges against the ACTIVE CHECKOUT's symbols.
@@ -1133,32 +1197,48 @@ mod tests {
         assert_eq!(resolution, "unresolved");
     }
 
-    fn add_package(conn: &Connection, manifest_dir: &str, roots_json: &str) -> i64 {
+    /// Insert a `packages` row for the active test scope `(NEW, worktree_id)`.
+    fn add_package_in(conn: &Connection, manifest_dir: &str, worktree_id: &str, roots_json: &str) {
         conn.execute(
             "INSERT INTO packages(manifest_dir, commit_sha, worktree_id, local_roots_json) VALUES \
-             (?1, ?2, '', ?3)",
-            params![manifest_dir, NEW, roots_json],
+             (?1, ?2, ?3, ?4)",
+            params![manifest_dir, NEW, worktree_id, roots_json],
+        )
+        .unwrap();
+    }
+
+    fn add_package(conn: &Connection, manifest_dir: &str, roots_json: &str) {
+        add_package_in(conn, manifest_dir, "", roots_json);
+    }
+
+    /// Insert a file row in an explicit `(commit_sha, worktree_id)` scope (the default `add_file`
+    /// pins `worktree_id=''`). Used by the multi-worktree regression test, which needs two files
+    /// living in two different worktree scopes at the same commit.
+    fn add_file_in(conn: &Connection, path: &str, commit: &str, worktree_id: &str) -> i64 {
+        conn.execute(
+            "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+             commit_sha, worktree_id) VALUES (?1, 'rust', 'source', ?2, 0, 0, ?3, ?4)",
+            params![path, format!("sha-{commit}-{worktree_id}-{path}"), commit, worktree_id],
         )
         .unwrap();
         conn.last_insert_rowid()
     }
 
     /// #61 (#1 via the DB driver): a `path`-dep alias is local for the package that declares it and
-    /// EXTERNAL for a package that does not — `files.package_id` + `packages.local_roots_json` flow
-    /// through `resolve_all_edges`.
+    /// EXTERNAL for a package that does not. The file→package mapping is computed at LOAD time from
+    /// the `packages` rows (longest `manifest_dir` prefix) — there is no persisted
+    /// `files.package_id` — and `packages.local_roots_json` then flows through
+    /// `resolve_all_edges`.
     #[test]
     fn per_package_alias_suppression_through_db_driver() {
         let conn = seeded_conn();
         // Global fallback union has both crates; per-package sets differ.
         set_local_crate_roots(&conn, "myws\nlocal");
-        let pkg_a = add_package(&conn, "a", "[\"myws\",\"local\"]");
-        let pkg_b = add_package(&conn, "b", "[\"myws\"]");
+        add_package(&conn, "a", "[\"myws\",\"local\"]");
+        add_package(&conn, "b", "[\"myws\"]");
+        // Files live under their package dirs; the loader assigns each by longest-prefix match.
         let file_a = add_file(&conn, "a/src/lib.rs", NEW);
         let file_b = add_file(&conn, "b/src/lib.rs", NEW);
-        conn.execute("UPDATE main.files SET package_id = ?2 WHERE id = ?1", params![file_a, pkg_a])
-            .unwrap();
-        conn.execute("UPDATE main.files SET package_id = ?2 WHERE id = ?1", params![file_b, pkg_b])
-            .unwrap();
         // A local `Thing` definition both files' bare refs could bind to.
         let local = add_symbol(&conn, file_a, "Thing", "crate::a::Thing");
         add_import_edge_scoped(&conn, file_a, "Thing", "use local::Thing;", 0, 9999, MOD_FILE_ROOT);
@@ -1175,6 +1255,53 @@ mod tests {
         assert_eq!(
             to, None,
             "in package B, `local` is an EXTERNAL crate — the bare ref is suppressed"
+        );
+        assert_eq!(resolution, "unresolved");
+    }
+
+    /// #106 multi-worktree regression: two worktree scopes at the SAME commit whose `packages` carry
+    /// DIFFERENT path-dep aliases for the same key. Each scope must resolve `use alias::X` against
+    /// ITS OWN package roots — worktree B must NOT see worktree A's alias as local. This is the
+    /// leak the dropped persisted `files.package_id` caused: a clean file is a shared
+    /// commit-scope row, so stamping it with one worktree's package id let the sibling follow
+    /// the wrong map. Computing the mapping at load from the ACTIVE scope's own `packages` rows
+    /// makes the leak impossible.
+    #[test]
+    fn worktree_package_roots_do_not_leak_across_scopes() {
+        let conn = seeded_conn();
+        // Both worktrees share the commit `NEW`; their `packages` rows differ on whether `local` is
+        // a declared (local) alias. `wt_a` has it; `wt_b` does not.
+        let wt_a = "/wt-a";
+        let wt_b = "/wt-b";
+        set_local_crate_roots(&conn, "myws\nlocal");
+        add_package_in(&conn, "", wt_a, "[\"myws\",\"local\"]");
+        add_package_in(&conn, "", wt_b, "[\"myws\"]");
+        // Each worktree's own overlay row for the same file path (commit_sha empty, worktree set —
+        // the dirty-overlay shape `install_scope_view` selects on for the active worktree).
+        let file_a = add_file_in(&conn, "src/lib.rs", "", wt_a);
+        let file_b = add_file_in(&conn, "src/lib.rs", "", wt_b);
+        let local_a = add_symbol(&conn, file_a, "Thing", "crate::Thing");
+        // A same-named local symbol in B's scope, the temptation the suppression must resist.
+        let _local_b = add_symbol(&conn, file_b, "Thing", "crate::Thing");
+        add_import_edge_scoped(&conn, file_a, "Thing", "use local::Thing;", 0, 9999, MOD_FILE_ROOT);
+        add_import_edge_scoped(&conn, file_b, "Thing", "use local::Thing;", 0, 9999, MOD_FILE_ROOT);
+        let ref_a = add_edge_at_byte(&conn, file_a, "Thing", "", 100);
+        let ref_b = add_edge_at_byte(&conn, file_b, "Thing", "", 100);
+
+        // Resolve worktree A's scope: `local` is A's own alias → LOCAL, binds to A's `Thing`.
+        crate::index::install_scope_view(&conn, NEW, wt_a).unwrap();
+        resolve_all_edges(&conn).unwrap();
+        let (to, _, _) = edge_state(&conn, ref_a);
+        assert_eq!(to, Some(local_a), "worktree A declares `local` — its bare ref binds local");
+
+        // Resolve worktree B's scope: `local` is NOT B's alias → EXTERNAL, the bare ref is
+        // suppressed. If B were following A's package map (the #106 leak), this would bind local.
+        crate::index::install_scope_view(&conn, NEW, wt_b).unwrap();
+        resolve_all_edges(&conn).unwrap();
+        let (to, _, resolution) = edge_state(&conn, ref_b);
+        assert_eq!(
+            to, None,
+            "worktree B does NOT declare `local` — it must not see worktree A's alias as local"
         );
         assert_eq!(resolution, "unresolved");
     }

--- a/crates/rag-rat-core/src/index/edges/resolve.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve.rs
@@ -1,4 +1,63 @@
+use std::collections::HashSet;
+
 use super::*;
+
+/// Build an [`ImportScopeRange`] from the three dedicated edge columns, or `None` when the start
+/// byte is NULL (a non-import edge). The DB driver's twin of `CompactEdge::import_scope_range`
+/// (the full-rebuild path) — they must stay in lockstep (#61 both-driver parity).
+fn import_scope_from_row(
+    scope_start: Option<i64>,
+    scope_end: Option<i64>,
+    mod_id: Option<i64>,
+) -> Option<ImportScopeRange> {
+    let scope_start = scope_start?;
+    Some(ImportScopeRange {
+        scope_start: usize::try_from(scope_start).unwrap_or(0),
+        scope_end: usize::try_from(scope_end.unwrap_or(0)).unwrap_or(0),
+        mod_id: mod_id.unwrap_or(MOD_FILE_ROOT),
+    })
+}
+
+/// Load the per-package local-crate sets + the file→package mapping for the ACTIVE CHECKOUT into
+/// `scope` (#61 per-package locality). `packages.local_roots_json` is a JSON string array of crate
+/// roots. Both reads are scoped through the per-connection `files`/`packages` rows of the active
+/// commit/worktree — a missing/empty `packages` table (non-Cargo corpus, pre-V022 index) leaves the
+/// scope's per-package maps empty so every file falls open to the global set. Shared by BOTH
+/// drivers so the per-package model is identical (#61 both-driver parity).
+fn load_package_roots_into_scope(
+    conn: &Connection,
+    scope: &mut imports::ImportScope,
+) -> anyhow::Result<()> {
+    // packages: id → local_roots (JSON array). Unscoped read of the whole table is fine — a
+    // package id is unique across scopes (its own PK), and files only reference ids in their scope.
+    {
+        let mut stmt = match conn.prepare("SELECT id, local_roots_json FROM packages") {
+            Ok(stmt) => stmt,
+            // No `packages` table (pre-V022 / non-Cargo): nothing to load, fall open.
+            Err(_) => return Ok(()),
+        };
+        let rows =
+            stmt.query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)))?;
+        for row in rows {
+            let (package_id, roots_json) = row?;
+            let roots: HashSet<String> = serde_json::from_str(&roots_json).unwrap_or_default();
+            scope.set_package_roots(package_id, roots);
+        }
+    }
+    // files → package_id, scoped to the active checkout via the `files` TEMP VIEW (overlay wins,
+    // dead scopes excluded), matching the symbol/edge resolution scope.
+    {
+        let mut stmt = conn.prepare(
+            "SELECT files.id, files.package_id FROM files WHERE files.package_id IS NOT NULL",
+        )?;
+        let rows = stmt.query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)))?;
+        for row in rows {
+            let (file_id, package_id) = row?;
+            scope.set_file_package(file_id, package_id);
+        }
+    }
+    Ok(())
+}
 
 /// Re-resolve the ACTIVE CHECKOUT's edges against the ACTIVE CHECKOUT's symbols.
 ///
@@ -20,13 +79,19 @@ use super::*;
 pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
     let symbols = all_symbols(conn)?;
     let index = SymbolIndex::build(&symbols);
-    // Crate-aware import scope (#61 Project B): the active checkout's Imports edges → per-file
-    // {leaf name → crate root}, so resolution suppresses a local bind when the name is `use`d from
-    // an external dependency. Scoped via the `files` TEMP VIEW like the resolution query below.
+    // Per-package + module-aware import scope (#61): the active checkout's Imports edges → per-file
+    // module-scoped bindings, plus the per-package local-crate sets, so resolution suppresses a
+    // local bind only when the name is `use`d from an external dependency in that reference's
+    // module + package. Scoped via the `files` TEMP VIEW like the resolution query below.
     let mut import_scope = imports::ImportScope::new(imports::load_local_roots(conn));
+    load_package_roots_into_scope(conn, &mut import_scope)?;
     {
+        // The dedicated import-scope columns (NULL on non-import edges); the `use` text rides in
+        // `evidence`. Building the per-file module interval set here is once-per-pass, not
+        // per-edge.
         let mut stmt = conn.prepare(
-            "SELECT d.source_file_id, d.evidence FROM edges_data d JOIN files ON files.id = \
+            "SELECT d.source_file_id, d.evidence, d.import_scope_start_byte, \
+             d.import_scope_end_byte, d.import_mod_id FROM edges_data d JOIN files ON files.id = \
              d.source_file_id JOIN edge_strings ek ON ek.id = d.edge_kind_id WHERE ek.value = \
              'imports'",
         )?;
@@ -34,11 +99,13 @@ pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
         while let Some(row) = rows.next()? {
             let file_id: i64 = row.get(0)?;
             let evidence: Option<String> = row.get(1)?;
+            let scope = import_scope_from_row(row.get(2)?, row.get(3)?, row.get(4)?);
             if let Some(evidence) = evidence {
-                import_scope.add_use(file_id, &evidence);
+                import_scope.add_use(file_id, &evidence, scope);
             }
         }
     }
+    import_scope.finalize();
     // Read/write `edges_data` directly (#79): this loop is per-edge hot on every incremental
     // pass, so the strings it needs come from explicit dictionary joins and the verdict UPDATEs
     // write pre-interned ids instead of paying the view triggers' per-row probes. The `files`
@@ -46,11 +113,11 @@ pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
     let mut interner = EdgeStringInterner::default();
     let mut stmt = conn.prepare(
         "SELECT d.id, d.source_file_id, tn.value, tqn.value, ek.value, conf.value, d.evidence, \
-         rh.value FROM edges_data d JOIN files ON files.id = d.source_file_id LEFT JOIN \
-         edge_strings tn ON tn.id = d.to_name_id LEFT JOIN edge_strings tqn ON tqn.id = \
-         d.target_qualified_name_id LEFT JOIN edge_strings ek ON ek.id = d.edge_kind_id LEFT JOIN \
-         edge_strings conf ON conf.id = d.confidence_id LEFT JOIN edge_strings rh ON rh.id = \
-         d.receiver_hint_id ORDER BY d.id",
+         rh.value, d.source_start_byte FROM edges_data d JOIN files ON files.id = \
+         d.source_file_id LEFT JOIN edge_strings tn ON tn.id = d.to_name_id LEFT JOIN \
+         edge_strings tqn ON tqn.id = d.target_qualified_name_id LEFT JOIN edge_strings ek ON \
+         ek.id = d.edge_kind_id LEFT JOIN edge_strings conf ON conf.id = d.confidence_id LEFT \
+         JOIN edge_strings rh ON rh.id = d.receiver_hint_id ORDER BY d.id",
     )?;
     let rows = stmt.query_map([], |row| {
         Ok((
@@ -62,6 +129,7 @@ pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
             row.get::<_, String>(5)?,
             row.get::<_, Option<String>>(6)?,
             row.get::<_, Option<String>>(7)?,
+            row.get::<_, i64>(8)?,
         ))
     })?;
     let rows = rows.collect::<Result<Vec<_>, _>>()?;
@@ -74,8 +142,11 @@ pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
         current_confidence,
         evidence,
         receiver_hint,
+        source_start_byte,
     ) in rows
     {
+        // The reference's byte position drives the module-aware covering test (#61).
+        let ref_byte = usize::try_from(source_start_byte).unwrap_or(0);
         let resolution = resolve_symbol(
             ResolveSymbolRequest {
                 name: &to_name,
@@ -85,12 +156,15 @@ pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
                 receiver_hint: receiver_hint.as_deref(),
                 source_file_id,
                 source_language: index.file_language.get(&source_file_id).copied(),
-                imported_external: import_scope
-                    .is_external_import(source_file_id, short_name(&to_name))
-                    || import_scope.is_external_qualified_root(
-                        source_file_id,
-                        target_qualified_name.as_deref(),
-                    ),
+                imported_external: import_scope.is_external_import(
+                    source_file_id,
+                    short_name(&to_name),
+                    ref_byte,
+                ) || import_scope.is_external_qualified_root(
+                    source_file_id,
+                    target_qualified_name.as_deref(),
+                    ref_byte,
+                ),
             },
             &index,
         );
@@ -181,17 +255,22 @@ pub(crate) fn resolve_and_insert_edges(
     // dominant resolve-phase structure at kernel scale. Byte-identical: a `file_id` never recurs in
     // a later block, so per-file reset makes exactly the dedup decisions a global per-`file_id` set
     // would; `file_id` therefore drops out of the key (constant within each reset window).
-    // Crate-aware import scope (#61 Project B): map each file's `use`d leaf names to their crate
-    // root from the accumulated Imports edges, so resolution can suppress a bind to a local symbol
-    // when the name actually comes from an external dependency crate.
+    // Per-package + module-aware import scope (#61): from the accumulated Imports edges, build each
+    // file's module-scoped bindings + the per-file module interval set, plus the per-package local-
+    // crate sets — so resolution suppresses a bind to a local symbol only when the name comes from
+    // an external dependency in that reference's module + package. EXACT PARITY with the DB driver
+    // `resolve_all_edges`: identical `add_use(file, use_text, scope)` + `finalize()` +
+    // `is_external_*` calls, same fail-open; the only difference is the source (in-memory
+    // accumulator vs DB rows).
     let mut import_scope = imports::ImportScope::new(imports::load_local_roots(conn));
+    load_package_roots_into_scope(conn, &mut import_scope)?;
     for (file_id, candidate) in &edges {
-        if candidate.edge_kind == EdgeKind::Imports
-            && let Some(evidence) = arena.get_opt(candidate.evidence)
-        {
-            import_scope.add_use(*file_id, evidence);
+        if candidate.edge_kind == EdgeKind::Imports {
+            let evidence = arena.get_opt(candidate.evidence).unwrap_or("");
+            import_scope.add_use(*file_id, evidence, candidate.import_scope_range());
         }
     }
+    import_scope.finalize();
 
     let mut seen = BTreeSet::new();
     let mut seen_file_id: Option<i64> = None;
@@ -224,6 +303,9 @@ pub(crate) fn resolve_and_insert_edges(
         let target_qualified_name = arena.get_opt(candidate.target_qualified_name);
         let evidence = arena.get_opt(candidate.evidence);
         let receiver_hint = arena.get_opt(candidate.receiver_hint);
+        // The reference's byte position drives the module-aware covering test (#61) — same input
+        // the DB driver reads from `source_start_byte`.
+        let ref_byte = candidate.source_span.start_byte as usize;
         let resolution = resolve_symbol(
             ResolveSymbolRequest {
                 name: to_name,
@@ -233,8 +315,15 @@ pub(crate) fn resolve_and_insert_edges(
                 receiver_hint,
                 source_file_id: *file_id,
                 source_language: index.file_language.get(file_id).copied(),
-                imported_external: import_scope.is_external_import(*file_id, short_name(to_name))
-                    || import_scope.is_external_qualified_root(*file_id, target_qualified_name),
+                imported_external: import_scope.is_external_import(
+                    *file_id,
+                    short_name(to_name),
+                    ref_byte,
+                ) || import_scope.is_external_qualified_root(
+                    *file_id,
+                    target_qualified_name,
+                    ref_byte,
+                ),
             },
             &index,
         );
@@ -259,6 +348,9 @@ pub(crate) fn resolve_and_insert_edges(
         // NULL when the sentinel marks an absent callee range; see
         // `CompactEdge::callee_byte_columns`.
         let (callee_start_byte, callee_end_byte) = candidate.callee_byte_columns();
+        // NULL on non-import edges; the dedicated import-scope columns (#61).
+        let (import_scope_start_byte, import_scope_end_byte, import_mod_id) =
+            candidate.import_scope_columns();
         // Interned ids straight into edges_data (#79); the memo keeps repeated names to one map
         // probe, so the bulk path writes pure integers.
         let from_name_id = interner.get_opt(conn, from_name)?;
@@ -275,11 +367,12 @@ pub(crate) fn resolve_and_insert_edges(
                 target_qualified_name_id, evidence, receiver_hint_id,
                 source_start_line, source_end_line, source_start_byte, source_end_byte,
                 callee_start_byte, callee_end_byte,
+                import_scope_start_byte, import_scope_end_byte, import_mod_id,
                 edge_kind_id, confidence_id,
                 to_symbol_id, target_start_line, target_end_line, resolution_id
             )
             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, \
-             ?18, ?19)
+             ?18, ?19, ?20, ?21, ?22)
             ",
         )?
         .execute(params![
@@ -296,6 +389,9 @@ pub(crate) fn resolve_and_insert_edges(
             i64::from(candidate.source_span.end_byte),
             callee_start_byte,
             callee_end_byte,
+            import_scope_start_byte,
+            import_scope_end_byte,
+            import_mod_id,
             edge_kind_id,
             confidence_id,
             to_symbol_id,
@@ -951,6 +1047,174 @@ mod tests {
             to,
             Some(build),
             "`config.build()` (lowercase value receiver) must NOT be suppressed by the import"
+        );
+    }
+
+    /// Insert an Imports edge carrying the dedicated module-aware scope columns (the V022 shape):
+    /// `[scope_start, scope_end)` + `mod_id`. For an inline `mod`, pass `mod_id == scope_start`.
+    fn add_import_edge_scoped(
+        conn: &Connection,
+        source_file_id: i64,
+        to_name: &str,
+        evidence: &str,
+        scope_start: i64,
+        scope_end: i64,
+        mod_id: i64,
+    ) {
+        conn.execute(
+            "INSERT INTO edges(source_file_id, to_name, target_qualified_name, edge_kind, \
+             confidence, resolution, evidence, import_scope_start_byte, import_scope_end_byte, \
+             import_mod_id) VALUES (?1, ?2, '', 'imports', 'NameOnly', 'unresolved', ?3, ?4, ?5, \
+             ?6)",
+            params![source_file_id, to_name, evidence, scope_start, scope_end, mod_id],
+        )
+        .unwrap();
+    }
+
+    /// A `calls_name`/reference edge whose call site sits at `source_start_byte` (drives the
+    /// module-aware covering test).
+    fn add_edge_at_byte(
+        conn: &Connection,
+        source_file_id: i64,
+        to_name: &str,
+        target_qualified_name: &str,
+        source_start_byte: i64,
+    ) -> i64 {
+        conn.execute(
+            "INSERT INTO edges(source_file_id, to_name, target_qualified_name, edge_kind, \
+             confidence, resolution, source_start_byte) VALUES (?1, ?2, ?3, 'calls_name', \
+             'NameOnly', 'unresolved', ?4)",
+            params![source_file_id, to_name, target_qualified_name, source_start_byte],
+        )
+        .unwrap();
+        conn.query_row("SELECT MAX(id) FROM edges_data", [], |row| row.get(0)).unwrap()
+    }
+
+    /// #61 (#4 via the DB driver): a `use url::Url` in a parent module must NOT suppress a `Url`
+    /// reference inside a CHILD module — the module-aware scope columns + inline-`mod` ranges flow
+    /// through `resolve_all_edges`, not just the unit-level `ImportScope`. A reference in the
+    /// parent module IS suppressed.
+    #[test]
+    fn module_aware_suppression_through_db_driver() {
+        let conn = seeded_conn();
+        set_local_crate_roots(&conn, "mycrate");
+        let user = add_file(&conn, "a.rs", NEW);
+        let defs = add_file(&conn, "b.rs", NEW);
+        // A local `Url` definition the bare references could (wrongly) bind to.
+        let local = add_symbol(&conn, defs, "Url", "crate::b::Url");
+        add_symbol(&conn, user, "user_fn", "crate::a::user_fn");
+        // Inline modules: parent a body [0,200), child b body [80,160) nested inside.
+        add_import_edge_scoped(&conn, user, "a", "mod a", 0, 200, 0);
+        add_import_edge_scoped(&conn, user, "b", "mod b", 80, 160, 80);
+        // `use url::Url;` lives directly in mod a (enclosing mod_id 0).
+        add_import_edge_scoped(&conn, user, "Url", "use url::Url;", 0, 200, 0);
+        // A `Url` reference inside child mod b (byte 100) and one in mod a itself (byte 40).
+        let in_child = add_edge_at_byte(&conn, user, "Url", "", 100);
+        let in_parent = add_edge_at_byte(&conn, user, "Url", "", 40);
+
+        crate::index::install_scope_view(&conn, NEW, "").unwrap();
+        resolve_all_edges(&conn).unwrap();
+
+        let (to, _, _) = edge_state(&conn, in_child);
+        assert_eq!(
+            to,
+            Some(local),
+            "the parent module's `use url::Url` must not reach a reference in child mod b"
+        );
+        let (to, _, resolution) = edge_state(&conn, in_parent);
+        assert_eq!(
+            to, None,
+            "a `Url` reference in mod a itself IS suppressed by a's `use url::Url`"
+        );
+        assert_eq!(resolution, "unresolved");
+    }
+
+    fn add_package(conn: &Connection, manifest_dir: &str, roots_json: &str) -> i64 {
+        conn.execute(
+            "INSERT INTO packages(manifest_dir, commit_sha, worktree_id, local_roots_json) VALUES \
+             (?1, ?2, '', ?3)",
+            params![manifest_dir, NEW, roots_json],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    /// #61 (#1 via the DB driver): a `path`-dep alias is local for the package that declares it and
+    /// EXTERNAL for a package that does not — `files.package_id` + `packages.local_roots_json` flow
+    /// through `resolve_all_edges`.
+    #[test]
+    fn per_package_alias_suppression_through_db_driver() {
+        let conn = seeded_conn();
+        // Global fallback union has both crates; per-package sets differ.
+        set_local_crate_roots(&conn, "myws\nlocal");
+        let pkg_a = add_package(&conn, "a", "[\"myws\",\"local\"]");
+        let pkg_b = add_package(&conn, "b", "[\"myws\"]");
+        let file_a = add_file(&conn, "a/src/lib.rs", NEW);
+        let file_b = add_file(&conn, "b/src/lib.rs", NEW);
+        conn.execute("UPDATE main.files SET package_id = ?2 WHERE id = ?1", params![file_a, pkg_a])
+            .unwrap();
+        conn.execute("UPDATE main.files SET package_id = ?2 WHERE id = ?1", params![file_b, pkg_b])
+            .unwrap();
+        // A local `Thing` definition both files' bare refs could bind to.
+        let local = add_symbol(&conn, file_a, "Thing", "crate::a::Thing");
+        add_import_edge_scoped(&conn, file_a, "Thing", "use local::Thing;", 0, 9999, MOD_FILE_ROOT);
+        add_import_edge_scoped(&conn, file_b, "Thing", "use local::Thing;", 0, 9999, MOD_FILE_ROOT);
+        let ref_a = add_edge_at_byte(&conn, file_a, "Thing", "", 100);
+        let ref_b = add_edge_at_byte(&conn, file_b, "Thing", "", 100);
+
+        crate::index::install_scope_view(&conn, NEW, "").unwrap();
+        resolve_all_edges(&conn).unwrap();
+
+        let (to, _, _) = edge_state(&conn, ref_a);
+        assert_eq!(to, Some(local), "in package A, `local` is its own alias — a LOCAL crate");
+        let (to, _, resolution) = edge_state(&conn, ref_b);
+        assert_eq!(
+            to, None,
+            "in package B, `local` is an EXTERNAL crate — the bare ref is suppressed"
+        );
+        assert_eq!(resolution, "unresolved");
+    }
+
+    /// The dedicated import-scope columns must NOT perturb the SCIP-oracle candidate set: import
+    /// edges leave `callee_start_byte` NULL, so `edge_join_candidates` (whose filter is
+    /// `callee_start_byte IS NOT NULL`) never sees them — this is why the columns are DEDICATED and
+    /// the `ORACLE_JUDGED_EDGE_KINDS` band-aid (#100) is unnecessary.
+    #[test]
+    fn oracle_unaffected_by_import_scope_columns() {
+        let conn = seeded_conn();
+        let user = add_file(&conn, "a.rs", NEW);
+        // An import edge with scope columns set but callee_* NULL.
+        add_import_edge_scoped(&conn, user, "Url", "use url::Url;", 0, 200, 0);
+        // A call edge that DOES carry a callee range (the oracle's real candidate).
+        conn.execute(
+            "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, \
+             callee_start_byte, callee_end_byte) VALUES (?1, 'parse', 'calls_name', 'NameOnly', \
+             'unresolved', 10, 15)",
+            params![user],
+        )
+        .unwrap();
+
+        crate::index::install_scope_view(&conn, NEW, "").unwrap();
+        // The oracle's candidate filter is exactly `callee_start_byte IS NOT NULL` (store.rs
+        // `edge_join_candidates`). Mirror it here: only the call edge qualifies; the import edge —
+        // despite its populated import_scope_* columns — leaves callee_* NULL and is excluded.
+        let candidate_kinds: Vec<String> = {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT edge_kind FROM edges WHERE callee_start_byte IS NOT NULL AND \
+                     callee_end_byte IS NOT NULL ORDER BY edge_kind",
+                )
+                .unwrap();
+            stmt.query_map([], |row| row.get::<_, String>(0))
+                .unwrap()
+                .collect::<Result<_, _>>()
+                .unwrap()
+        };
+        assert_eq!(
+            candidate_kinds,
+            vec!["calls_name".to_string()],
+            "only the call edge (non-NULL callee range) is an oracle candidate; the import edge's \
+             scope columns must not pull it in"
         );
     }
 }

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -79,7 +79,7 @@ impl IndexDatabase {
                 db.set_meta_if_changed("source_root", &config.root.display().to_string())?;
             db.storage.set_source_root(config.root.clone());
             let git_meta_changed = db.write_git_meta(&config.root)?;
-            let indexed = match mode {
+            let (indexed, manifest_in_change_set) = match mode {
                 IndexMode::Changed => db.index_changed_files_with_progress(config, progress)?,
                 IndexMode::Discover => db.index_discovered_files_with_progress(config, progress)?,
                 IndexMode::Full => unreachable!("full mode is handled by rebuild_with_progress"),
@@ -100,9 +100,28 @@ impl IndexDatabase {
                 db.apply_prepared_git_history(&config.root, handle)?;
                 mutated = true;
             }
+            // Per-package import scope (#61, salvaging #95's ordering): rewrite `packages` +
+            // reassign `files.package_id` + refresh the global `local_crate_roots` union BEFORE the
+            // resolve pass, so the resolver sees the current package map. Run it when a file was
+            // (re)indexed (a new/edited .rs needs its package_id) OR a Cargo.toml is in the change
+            // set (the crate set may have changed) — OUTSIDE the `indexed>0 || healed>0` gate, so a
+            // manifest-only change (no Rust file touched, indexed==0) still refreshes (#95 bug:
+            // the refresh was nested inside that gate and was skipped, leaving the crate set stale
+            // until the next full rebuild). `refresh_packages` returns whether the global union
+            // changed, which forces a re-resolve even when no file was indexed.
+            let roots_changed = if indexed > 0 || healed > 0 || manifest_in_change_set {
+                db.refresh_packages(&config.root)?
+            } else {
+                false
+            };
+            if roots_changed {
+                mutated = true;
+            }
             // Healing can delete overlay symbols (NULLing their in-edges via
             // `remove_file_in_scope`), so it needs the same re-derive tail as real file changes.
-            if indexed > 0 || healed > 0 {
+            // Also re-resolve when the crate set changed but no file was indexed (a manifest-only
+            // change) so `use new_crate::X` resolves correctly (#95).
+            if indexed > 0 || healed > 0 || roots_changed {
                 progress(IndexProgress::RebuildingLogicalSymbols);
                 db.rebuild_logical_symbols()?;
                 progress(IndexProgress::ResolvingGraph);
@@ -185,39 +204,61 @@ impl IndexDatabase {
             }
             // `prepared` (this wave's chunk texts / symbols / edge candidates) drops here.
         }
+        // Per-package import scope (#61): write `packages` + `files.package_id` + the global
+        // `local_crate_roots` union now — files are inserted, but the resolve below has not run, so
+        // it reads the fresh package assignment. (`set_context` installs the `files` scope view at
+        // open, so the scoped reads in the resolve see these rows.)
+        self.refresh_packages(&config.root)?;
         edges::resolve_and_insert_edges(self.storage.connection(), graph)?;
 
         Ok(total)
     }
 
+    /// Returns `(file_count, manifest_in_change_set)`. The manifest flag is true when any changed
+    /// or deleted path is a `Cargo.toml`, signalling the workspace crate set may have changed
+    /// and the `packages` map should be refreshed before the resolve pass (#61, salvaging #95).
     fn index_changed_files_with_progress<F>(
         &self,
         config: &Config,
         progress: &mut F,
-    ) -> anyhow::Result<usize>
+    ) -> anyhow::Result<(usize, bool)>
     where
         F: FnMut(IndexProgress),
     {
         progress(IndexProgress::Discovering);
         let changes = git_changed_paths(&config.root)?;
+        let manifest_in_change_set =
+            paths_include_cargo_toml(changes.changed.iter().map(PathBuf::as_path))
+                || paths_include_cargo_toml(changes.deleted.iter().map(PathBuf::as_path));
         let files = collect_changed_index_files(config, &changes)?;
         let files = self.assign_file_scopes(files, &changes);
-        self.apply_incremental_file_plan(files, changes.deleted, progress)
+        let count = self.apply_incremental_file_plan(files, changes.deleted, progress)?;
+        Ok((count, manifest_in_change_set))
     }
 
+    /// Returns `(file_count, manifest_in_change_set)`. The manifest flag also consults the
+    /// discovery plan's file list, so a NEW (untracked, not-yet-committed) `Cargo.toml` is
+    /// caught even though git status would not list it as changed (#61, salvaging #95).
     fn index_discovered_files_with_progress<F>(
         &self,
         config: &Config,
         progress: &mut F,
-    ) -> anyhow::Result<usize>
+    ) -> anyhow::Result<(usize, bool)>
     where
         F: FnMut(IndexProgress),
     {
         progress(IndexProgress::Discovering);
         let plan = discovery_plan(self.storage.connection(), config)?;
         let changes = git_changed_paths(&config.root).unwrap_or_default();
+        let manifest_in_change_set =
+            paths_include_cargo_toml(changes.changed.iter().map(PathBuf::as_path))
+                || paths_include_cargo_toml(changes.deleted.iter().map(PathBuf::as_path))
+                || paths_include_cargo_toml(
+                    plan.files.iter().map(|file| file.relative_path.as_path()),
+                );
         let files = self.assign_file_scopes(plan.files, &changes);
-        self.apply_incremental_file_plan(files, plan.deleted, progress)
+        let count = self.apply_incremental_file_plan(files, plan.deleted, progress)?;
+        Ok((count, manifest_in_change_set))
     }
 
     fn assign_file_scopes(
@@ -352,4 +393,11 @@ impl IndexDatabase {
 
         Ok(files.len() + deleted_count)
     }
+}
+
+/// Whether any path in an iterator is a `Cargo.toml` — the gate for the per-package refresh on an
+/// incremental pass (#61, salvaging #95). Checked against both changed and deleted paths so a crate
+/// removal also triggers the refresh.
+fn paths_include_cargo_toml<'a>(mut paths: impl Iterator<Item = &'a Path>) -> bool {
+    paths.any(|path| path.file_name().and_then(|name| name.to_str()) == Some("Cargo.toml"))
 }

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -101,13 +101,15 @@ impl IndexDatabase {
                 mutated = true;
             }
             // Per-package import scope (#61, salvaging #95's ordering): rewrite `packages` +
-            // reassign `files.package_id` + refresh the global `local_crate_roots` union BEFORE the
-            // resolve pass, so the resolver sees the current package map. Run it when a file was
-            // (re)indexed (a new/edited .rs needs its package_id) OR a Cargo.toml is in the change
-            // set (the crate set may have changed) — OUTSIDE the `indexed>0 || healed>0` gate, so a
-            // manifest-only change (no Rust file touched, indexed==0) still refreshes (#95 bug:
-            // the refresh was nested inside that gate and was skipped, leaving the crate set stale
-            // until the next full rebuild). `refresh_packages` returns whether the global union
+            // refresh the global `local_crate_roots` union BEFORE the resolve pass, so
+            // the resolver sees the current package map (the file→package mapping is
+            // then computed at resolve LOAD time from those rows — there is no
+            // persisted `files.package_id` to reassign). Run it when a Cargo.toml is in
+            // the change set (the crate set may have changed) OR a file was (re)indexed
+            // — OUTSIDE the `indexed>0 || healed>0` gate, so a manifest-only change (no
+            // Rust file touched, indexed==0) still refreshes (#95 bug: the refresh was nested
+            // inside that gate and was skipped, leaving the crate set stale until the
+            // next full rebuild). `refresh_packages` returns whether the package map
             // changed, which forces a re-resolve even when no file was indexed.
             let roots_changed = if indexed > 0 || healed > 0 || manifest_in_change_set {
                 db.refresh_packages(&config.root)?
@@ -204,10 +206,11 @@ impl IndexDatabase {
             }
             // `prepared` (this wave's chunk texts / symbols / edge candidates) drops here.
         }
-        // Per-package import scope (#61): write `packages` + `files.package_id` + the global
+        // Per-package import scope (#61): write the active scope's `packages` rows + the global
         // `local_crate_roots` union now — files are inserted, but the resolve below has not run, so
-        // it reads the fresh package assignment. (`set_context` installs the `files` scope view at
-        // open, so the scoped reads in the resolve see these rows.)
+        // it computes each file's package from these fresh rows at load time. (`set_context`
+        // installs the `files` scope view at open, so the scoped reads in the resolve see
+        // these rows.)
         self.refresh_packages(&config.root)?;
         edges::resolve_and_insert_edges(self.storage.connection(), graph)?;
 

--- a/crates/rag-rat-core/src/index/internals.rs
+++ b/crates/rag-rat-core/src/index/internals.rs
@@ -697,6 +697,81 @@ impl IndexDatabase {
         self.set_meta("graph_index_version", GRAPH_INDEX_VERSION)
     }
 
+    /// Rewrite the `packages` rows for the ACTIVE scope from the corpus's Cargo manifests and
+    /// assign `files.package_id`, then persist the GLOBAL local-crate-root union to
+    /// `index_meta.local_crate_roots` (#61 per-package import scope). Returns whether the global
+    /// union changed (so an incremental pass can trigger a re-resolve only when it must).
+    ///
+    /// Scoped by `(active_commit_sha, active_worktree_id)` like `files`: each pass owns its scope's
+    /// rows (DELETE + reinsert), and a sibling worktree's package rows are untouched. A file is
+    /// assigned the package whose RELATIVE `manifest_dir` is the longest prefix of the file's
+    /// stored path (the root manifest's empty dir is the catch-all). Resolution falls open to
+    /// the global set for any file left with NULL `package_id` (no manifest matched / non-Cargo
+    /// corpus).
+    pub(super) fn refresh_packages(&self, root: &Path) -> anyhow::Result<bool> {
+        let (global_roots, packages) = super::edges::scan_packages(root);
+        let conn = self.storage.connection();
+        // Replace this scope's package rows. The id is reassigned each rebuild, which is fine — it
+        // is referenced only by this scope's freshly-written files.package_id below.
+        conn.execute("DELETE FROM packages WHERE commit_sha = ?1 AND worktree_id = ?2", params![
+            self.active_commit_sha,
+            self.active_worktree_id
+        ])?;
+        // (manifest_dir, package_id), kept for the longest-prefix file assignment. Sort longest dir
+        // first so the first matching prefix is the most specific package.
+        let mut package_ids: Vec<(String, i64)> = Vec::with_capacity(packages.len());
+        for package in &packages {
+            let roots_json = serde_json::to_string(
+                &package.local_roots.iter().collect::<std::collections::BTreeSet<_>>(),
+            )?;
+            conn.execute(
+                "INSERT OR REPLACE INTO packages(manifest_dir, commit_sha, worktree_id, \
+                 local_roots_json) VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    package.manifest_dir,
+                    self.active_commit_sha,
+                    self.active_worktree_id,
+                    roots_json
+                ],
+            )?;
+            package_ids.push((package.manifest_dir.clone(), conn.last_insert_rowid()));
+        }
+        package_ids.sort_by_key(|(dir, _)| std::cmp::Reverse(dir.len()));
+
+        // Assign package_id for every file in the active scope by longest manifest-dir prefix. A
+        // file at `crates/foo/src/x.rs` belongs to the package rooted at `crates/foo` (dir `crates/
+        // foo`), not the workspace root (dir ``) — so the path must continue with `/` after the
+        // prefix (or equal it), and the empty-dir root manifest matches anything as the fallback.
+        let files: Vec<(i64, String)> = {
+            let mut stmt = conn.prepare(
+                "SELECT id, path FROM main.files WHERE commit_sha = ?1 AND worktree_id = ?2",
+            )?;
+            let rows = stmt
+                .query_map(params![self.active_commit_sha, self.active_worktree_id], |row| {
+                    Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+                })?;
+            rows.collect::<Result<Vec<_>, _>>()?
+        };
+        for (file_id, path) in files {
+            let package_id = package_ids.iter().find_map(|(dir, id)| {
+                let in_package = dir.is_empty()
+                    || path == *dir
+                    || path.strip_prefix(dir).is_some_and(|rest| rest.starts_with('/'));
+                in_package.then_some(*id)
+            });
+            conn.execute("UPDATE main.files SET package_id = ?2 WHERE id = ?1", params![
+                file_id, package_id
+            ])?;
+        }
+
+        let serialized = {
+            let mut sorted: Vec<&str> = global_roots.iter().map(String::as_str).collect();
+            sorted.sort_unstable();
+            sorted.join("\n")
+        };
+        self.set_meta_if_changed("local_crate_roots", &serialized)
+    }
+
     pub(super) fn set_meta(&self, key: &str, value: &str) -> anyhow::Result<()> {
         self.storage.connection().execute(
             "INSERT INTO index_meta(key, value) VALUES (?1, ?2)

--- a/crates/rag-rat-core/src/index/internals.rs
+++ b/crates/rag-rat-core/src/index/internals.rs
@@ -663,12 +663,12 @@ impl IndexDatabase {
             self.storage.connection().execute("DELETE FROM edges_data", [])?;
             // Repopulate the per-package import scope BEFORE re-resolving (#61). A bare
             // version-bump re-resolve would re-derive `import_scope_*` on the new edges
-            // but read NULL `files.package_id` + an empty `packages` table (V022 only
-            // ADDED the columns; it did not backfill them), so every file would fall
-            // open to the global union and the new per-package behavior would never
-            // engage on a migrated index. `refresh_packages` writes `packages` +
-            // `files.package_id` + the global `local_crate_roots` union for the active
-            // scope so `resolve_edges` below sees the current package map.
+            // but read an empty `packages` table (V022 only ADDED the column; it did not
+            // backfill `packages`), so every file would fall open to the global union and
+            // the new per-package behavior would never engage on a migrated index.
+            // `refresh_packages` writes the active scope's `packages` rows + the global
+            // `local_crate_roots` union; `resolve_edges` below then computes each file's
+            // package at load time (`load_package_roots_into_scope`) from those rows.
             self.refresh_packages(&root)?;
             let files = self.graph_reindex_files()?;
             for file in files {
@@ -706,10 +706,10 @@ impl IndexDatabase {
         self.set_meta("graph_index_version", GRAPH_INDEX_VERSION)
     }
 
-    /// Rewrite the `packages` rows for the ACTIVE scope from the corpus's Cargo manifests and
-    /// assign `files.package_id`, then persist the GLOBAL local-crate-root union to
-    /// `index_meta.local_crate_roots` (#61 per-package import scope). Returns whether the package
-    /// map changed (so an incremental pass can trigger a re-resolve only when it must).
+    /// Rewrite the `packages` rows for the ACTIVE scope from the corpus's Cargo manifests, then
+    /// persist the GLOBAL local-crate-root union to `index_meta.local_crate_roots` (#61 per-package
+    /// import scope). Returns whether the package map changed (so an incremental pass can trigger a
+    /// re-resolve only when it must).
     ///
     /// "Changed" is reported when EITHER the global union changed OR any package's per-scope
     /// `(manifest_dir, local_roots_json)` set changed. Reporting only the global union missed a
@@ -719,11 +719,16 @@ impl IndexDatabase {
     /// results stale until an unrelated Rust edit or a full rebuild.
     ///
     /// Scoped by `(active_commit_sha, active_worktree_id)` like `files`: each pass owns its scope's
-    /// rows (DELETE + reinsert), and a sibling worktree's package rows are untouched. A file is
-    /// assigned the package whose RELATIVE `manifest_dir` is the longest prefix of the file's
-    /// stored path (the root manifest's empty dir is the catch-all). Resolution falls open to
-    /// the global set for any file left with NULL `package_id` (no manifest matched / non-Cargo
-    /// corpus).
+    /// rows (DELETE + reinsert), and a sibling worktree's package rows are untouched. The file→
+    /// package mapping is NOT persisted onto `files`: `load_package_roots_into_scope` (resolve.rs)
+    /// computes it at LOAD time by longest-`manifest_dir`-prefix over the active scope's `packages`
+    /// rows + the active files. Persisting a `files.package_id` pointer was the #106 multi-worktree
+    /// leak — a clean file is a SHARED commit-scope row (`commit_sha=HEAD, worktree_id=''`) read by
+    /// every worktree at that commit, while a package row is worktree-scoped, so one worktree's
+    /// refresh stamped its package ids onto the shared rows another worktree then followed (and the
+    /// DELETE-and-reinsert churns the AUTOINCREMENT ids each pass, invalidating any sibling's
+    /// pointer). Computing the mapping at load reads each scope's OWN `packages`, so no
+    /// cross-worktree pointer exists to leak.
     pub(super) fn refresh_packages(&self, root: &Path) -> anyhow::Result<bool> {
         let (global_roots, packages) = super::edges::scan_packages(root);
         let conn = self.storage.connection();
@@ -740,15 +745,13 @@ impl IndexDatabase {
                 })?;
             rows.collect::<Result<_, _>>()?
         };
-        // Replace this scope's package rows. The id is reassigned each rebuild, which is fine — it
-        // is referenced only by this scope's freshly-written files.package_id below.
+        // Replace this scope's package rows. The id is reassigned each rebuild, which is fine — the
+        // file→package mapping is computed at LOAD time from `manifest_dir`, not from a persisted
+        // id.
         conn.execute("DELETE FROM packages WHERE commit_sha = ?1 AND worktree_id = ?2", params![
             self.active_commit_sha,
             self.active_worktree_id
         ])?;
-        // (manifest_dir, package_id), kept for the longest-prefix file assignment. Sort longest dir
-        // first so the first matching prefix is the most specific package.
-        let mut package_ids: Vec<(String, i64)> = Vec::with_capacity(packages.len());
         // The freshly-written map, compared against `previous_package_map` below.
         let mut current_package_map: std::collections::BTreeMap<String, String> =
             std::collections::BTreeMap::new();
@@ -767,41 +770,8 @@ impl IndexDatabase {
                 ],
             )?;
             current_package_map.insert(package.manifest_dir.clone(), roots_json);
-            package_ids.push((package.manifest_dir.clone(), conn.last_insert_rowid()));
         }
         let package_map_changed = current_package_map != previous_package_map;
-        package_ids.sort_by_key(|(dir, _)| std::cmp::Reverse(dir.len()));
-
-        // Assign package_id for every file in the active scope by longest manifest-dir prefix. A
-        // file at `crates/foo/src/x.rs` belongs to the package rooted at `crates/foo` (dir `crates/
-        // foo`), not the workspace root (dir ``) — so the path must continue with `/` after the
-        // prefix (or equal it), and the empty-dir root manifest matches anything as the fallback.
-        //
-        // Read through the `files` TEMP VIEW (#89), NOT `main.files` with a both-columns-equal
-        // predicate. The scope view is the UNION encoded by `install_scope_view`: clean rows are
-        // `(commit_sha=HEAD, worktree_id='')`, dirty overlays are `(commit_sha='',
-        // worktree_id=active)`, and the overlay shadows its committed twin. A both-equal
-        // `main.files` filter matched NEITHER case in a real checkout (clean rows have an empty
-        // worktree_id, overlays an empty commit_sha), leaving every file's package_id NULL so the
-        // resolver fell open to the global union — the per-package alias leak this change fixes.
-        // The view's `id` is `main.files.id`, so the UPDATE below targets the real row by its key.
-        let files: Vec<(i64, String)> = {
-            let mut stmt = conn.prepare("SELECT id, path FROM files")?;
-            let rows =
-                stmt.query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)))?;
-            rows.collect::<Result<Vec<_>, _>>()?
-        };
-        for (file_id, path) in files {
-            let package_id = package_ids.iter().find_map(|(dir, id)| {
-                let in_package = dir.is_empty()
-                    || path == *dir
-                    || path.strip_prefix(dir).is_some_and(|rest| rest.starts_with('/'));
-                in_package.then_some(*id)
-            });
-            conn.execute("UPDATE main.files SET package_id = ?2 WHERE id = ?1", params![
-                file_id, package_id
-            ])?;
-        }
 
         let serialized = {
             let mut sorted: Vec<&str> = global_roots.iter().map(String::as_str).collect();

--- a/crates/rag-rat-core/src/index/internals.rs
+++ b/crates/rag-rat-core/src/index/internals.rs
@@ -661,6 +661,15 @@ impl IndexDatabase {
         self.storage.execute_batch("BEGIN IMMEDIATE TRANSACTION")?;
         let result = (|| -> anyhow::Result<()> {
             self.storage.connection().execute("DELETE FROM edges_data", [])?;
+            // Repopulate the per-package import scope BEFORE re-resolving (#61). A bare
+            // version-bump re-resolve would re-derive `import_scope_*` on the new edges
+            // but read NULL `files.package_id` + an empty `packages` table (V022 only
+            // ADDED the columns; it did not backfill them), so every file would fall
+            // open to the global union and the new per-package behavior would never
+            // engage on a migrated index. `refresh_packages` writes `packages` +
+            // `files.package_id` + the global `local_crate_roots` union for the active
+            // scope so `resolve_edges` below sees the current package map.
+            self.refresh_packages(&root)?;
             let files = self.graph_reindex_files()?;
             for file in files {
                 if file.kind == TargetKind::Generated || file.language == Language::Markdown {
@@ -699,8 +708,15 @@ impl IndexDatabase {
 
     /// Rewrite the `packages` rows for the ACTIVE scope from the corpus's Cargo manifests and
     /// assign `files.package_id`, then persist the GLOBAL local-crate-root union to
-    /// `index_meta.local_crate_roots` (#61 per-package import scope). Returns whether the global
-    /// union changed (so an incremental pass can trigger a re-resolve only when it must).
+    /// `index_meta.local_crate_roots` (#61 per-package import scope). Returns whether the package
+    /// map changed (so an incremental pass can trigger a re-resolve only when it must).
+    ///
+    /// "Changed" is reported when EITHER the global union changed OR any package's per-scope
+    /// `(manifest_dir, local_roots_json)` set changed. Reporting only the global union missed a
+    /// per-package alias move/add/remove that leaves the union identical (e.g. moving a path-dep
+    /// alias from member A to member B): the union is the same, but A and B now resolve `use
+    /// alias::…` differently, so the edges must be re-resolved. A union-only signal left those
+    /// results stale until an unrelated Rust edit or a full rebuild.
     ///
     /// Scoped by `(active_commit_sha, active_worktree_id)` like `files`: each pass owns its scope's
     /// rows (DELETE + reinsert), and a sibling worktree's package rows are untouched. A file is
@@ -711,6 +727,19 @@ impl IndexDatabase {
     pub(super) fn refresh_packages(&self, root: &Path) -> anyhow::Result<bool> {
         let (global_roots, packages) = super::edges::scan_packages(root);
         let conn = self.storage.connection();
+        // Snapshot this scope's existing package map BEFORE the DELETE so a per-package alias
+        // change (same global union) is still detected as a change → forces a re-resolve.
+        let previous_package_map: std::collections::BTreeMap<String, String> = {
+            let mut stmt = conn.prepare(
+                "SELECT manifest_dir, local_roots_json FROM packages WHERE commit_sha = ?1 AND \
+                 worktree_id = ?2",
+            )?;
+            let rows = stmt
+                .query_map(params![self.active_commit_sha, self.active_worktree_id], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })?;
+            rows.collect::<Result<_, _>>()?
+        };
         // Replace this scope's package rows. The id is reassigned each rebuild, which is fine — it
         // is referenced only by this scope's freshly-written files.package_id below.
         conn.execute("DELETE FROM packages WHERE commit_sha = ?1 AND worktree_id = ?2", params![
@@ -720,6 +749,9 @@ impl IndexDatabase {
         // (manifest_dir, package_id), kept for the longest-prefix file assignment. Sort longest dir
         // first so the first matching prefix is the most specific package.
         let mut package_ids: Vec<(String, i64)> = Vec::with_capacity(packages.len());
+        // The freshly-written map, compared against `previous_package_map` below.
+        let mut current_package_map: std::collections::BTreeMap<String, String> =
+            std::collections::BTreeMap::new();
         for package in &packages {
             let roots_json = serde_json::to_string(
                 &package.local_roots.iter().collect::<std::collections::BTreeSet<_>>(),
@@ -734,22 +766,29 @@ impl IndexDatabase {
                     roots_json
                 ],
             )?;
+            current_package_map.insert(package.manifest_dir.clone(), roots_json);
             package_ids.push((package.manifest_dir.clone(), conn.last_insert_rowid()));
         }
+        let package_map_changed = current_package_map != previous_package_map;
         package_ids.sort_by_key(|(dir, _)| std::cmp::Reverse(dir.len()));
 
         // Assign package_id for every file in the active scope by longest manifest-dir prefix. A
         // file at `crates/foo/src/x.rs` belongs to the package rooted at `crates/foo` (dir `crates/
         // foo`), not the workspace root (dir ``) — so the path must continue with `/` after the
         // prefix (or equal it), and the empty-dir root manifest matches anything as the fallback.
+        //
+        // Read through the `files` TEMP VIEW (#89), NOT `main.files` with a both-columns-equal
+        // predicate. The scope view is the UNION encoded by `install_scope_view`: clean rows are
+        // `(commit_sha=HEAD, worktree_id='')`, dirty overlays are `(commit_sha='',
+        // worktree_id=active)`, and the overlay shadows its committed twin. A both-equal
+        // `main.files` filter matched NEITHER case in a real checkout (clean rows have an empty
+        // worktree_id, overlays an empty commit_sha), leaving every file's package_id NULL so the
+        // resolver fell open to the global union — the per-package alias leak this change fixes.
+        // The view's `id` is `main.files.id`, so the UPDATE below targets the real row by its key.
         let files: Vec<(i64, String)> = {
-            let mut stmt = conn.prepare(
-                "SELECT id, path FROM main.files WHERE commit_sha = ?1 AND worktree_id = ?2",
-            )?;
-            let rows = stmt
-                .query_map(params![self.active_commit_sha, self.active_worktree_id], |row| {
-                    Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
-                })?;
+            let mut stmt = conn.prepare("SELECT id, path FROM files")?;
+            let rows =
+                stmt.query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)))?;
             rows.collect::<Result<Vec<_>, _>>()?
         };
         for (file_id, path) in files {
@@ -769,7 +808,8 @@ impl IndexDatabase {
             sorted.sort_unstable();
             sorted.join("\n")
         };
-        self.set_meta_if_changed("local_crate_roots", &serialized)
+        let union_changed = self.set_meta_if_changed("local_crate_roots", &serialized)?;
+        Ok(union_changed || package_map_changed)
     }
 
     pub(super) fn set_meta(&self, key: &str, value: &str) -> anyhow::Result<()> {

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -125,13 +125,13 @@ pub(crate) fn install_scope_view(
             DROP VIEW IF EXISTS temp.files;
             CREATE TEMP VIEW temp.files AS
             SELECT id, path, language, kind, sha256, modified_at_ms, generated, indexed_at_ms, \
-         indexed_revision, commit_sha, worktree_id
+         indexed_revision, commit_sha, worktree_id, package_id
             FROM main.files
             WHERE worktree_id = (SELECT value FROM temp.connection_context WHERE key = \
          'worktree_id') AND worktree_id != '' AND kind != 'deleted'
             UNION ALL
             SELECT id, path, language, kind, sha256, modified_at_ms, generated, indexed_at_ms, \
-         indexed_revision, commit_sha, worktree_id
+         indexed_revision, commit_sha, worktree_id, package_id
             FROM main.files
             WHERE commit_sha = (SELECT value FROM temp.connection_context WHERE key = 'commit_sha')
               AND commit_sha != ''

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -125,13 +125,13 @@ pub(crate) fn install_scope_view(
             DROP VIEW IF EXISTS temp.files;
             CREATE TEMP VIEW temp.files AS
             SELECT id, path, language, kind, sha256, modified_at_ms, generated, indexed_at_ms, \
-         indexed_revision, commit_sha, worktree_id, package_id
+         indexed_revision, commit_sha, worktree_id
             FROM main.files
             WHERE worktree_id = (SELECT value FROM temp.connection_context WHERE key = \
          'worktree_id') AND worktree_id != '' AND kind != 'deleted'
             UNION ALL
             SELECT id, path, language, kind, sha256, modified_at_ms, generated, indexed_at_ms, \
-         indexed_revision, commit_sha, worktree_id, package_id
+         indexed_revision, commit_sha, worktree_id
             FROM main.files
             WHERE commit_sha = (SELECT value FROM temp.connection_context WHERE key = 'commit_sha')
               AND commit_sha != ''

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -192,7 +192,13 @@ pub struct DiscoveryStatus {
 }
 
 const MAX_AUTO_HEAL_FILES_PER_CALL: usize = 4;
-const GRAPH_INDEX_VERSION: &str = "6";
+// Bumped whenever the resolved graph's SHAPE changes so an upgraded index re-resolves its edges on
+// next open (`ensure_graph_index_current`) instead of carrying forward stale resolutions. 7: the
+// per-package + module-aware import scope (#61) — re-resolve repopulates `packages` +
+// `files.package_id` and re-derives the dedicated `import_scope_*` edge columns, which the V022
+// migration only ADDED (never backfilled), so without the bump a migrated index keeps NULL scopes
+// and the global-fallback behavior forever.
+const GRAPH_INDEX_VERSION: &str = "7";
 
 #[derive(Debug, Error)]
 pub enum IndexError {

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -194,10 +194,11 @@ pub struct DiscoveryStatus {
 const MAX_AUTO_HEAL_FILES_PER_CALL: usize = 4;
 // Bumped whenever the resolved graph's SHAPE changes so an upgraded index re-resolves its edges on
 // next open (`ensure_graph_index_current`) instead of carrying forward stale resolutions. 7: the
-// per-package + module-aware import scope (#61) — re-resolve repopulates `packages` +
-// `files.package_id` and re-derives the dedicated `import_scope_*` edge columns, which the V022
-// migration only ADDED (never backfilled), so without the bump a migrated index keeps NULL scopes
-// and the global-fallback behavior forever.
+// per-package + module-aware import scope (#61) — re-resolve repopulates the `packages` rows and
+// re-derives the dedicated `import_scope_*` edge columns, which the V022 migration only ADDED
+// (never backfilled), so without the bump a migrated index keeps empty package scopes and the
+// global-fallback behavior forever. The file→package mapping itself is computed at LOAD time from
+// `packages` (no persisted `files.package_id`), so the re-resolve only needs the `packages` rows.
 const GRAPH_INDEX_VERSION: &str = "7";
 
 #[derive(Debug, Error)]

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -680,7 +680,7 @@ fn migration_creates_oracle_side_tables() {
         assert!(columns.contains(&expected.to_string()), "edge_oracle missing {expected}");
     }
 
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 21);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 22);
 }
 
 /// The V019 moniker migration: the `logical_symbol_monikers` table (STRICT, NO foreign key — see

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -53,10 +53,10 @@ impl IndexDatabase {
             mem_trace("after clear_full_rebuild_tables (purge)");
             db.set_meta("source_root", &config.root.display().to_string())?;
             db.storage.set_source_root(config.root.clone());
-            // Per-package import scope (#61): the `packages` rows + `files.package_id` + the global
-            // `local_crate_roots` union are written by `refresh_packages`, called inside
-            // `index_targets_with_progress` AFTER files are inserted but BEFORE the in-memory
-            // resolve pass — package assignment reads `main.files`, which does not exist yet here.
+            // Per-package import scope (#61): the `packages` rows + the global `local_crate_roots`
+            // union are written by `refresh_packages`, called inside `index_targets_with_progress`
+            // AFTER files are inserted but BEFORE the in-memory resolve pass (which computes each
+            // file's package from those rows at load time) — the files do not exist yet here.
             db.write_git_meta(&config.root)?;
             let indexed = db.index_targets_with_progress(config, &mut progress)?;
             mem_trace("after index_targets (edges resolved+inserted)");

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -53,13 +53,10 @@ impl IndexDatabase {
             mem_trace("after clear_full_rebuild_tables (purge)");
             db.set_meta("source_root", &config.root.display().to_string())?;
             db.storage.set_source_root(config.root.clone());
-            // Local crate roots (#61 Project B): the workspace's own crate names, for crate-aware
-            // import resolution. Written BEFORE index_targets so the resolve pass sees them.
-            let crate_roots = super::edges::local_crate_roots(&config.root);
-            db.set_meta(
-                "local_crate_roots",
-                &crate_roots.into_iter().collect::<Vec<_>>().join("\n"),
-            )?;
+            // Per-package import scope (#61): the `packages` rows + `files.package_id` + the global
+            // `local_crate_roots` union are written by `refresh_packages`, called inside
+            // `index_targets_with_progress` AFTER files are inserted but BEFORE the in-memory
+            // resolve pass — package assignment reads `main.files`, which does not exist yet here.
             db.write_git_meta(&config.root)?;
             let indexed = db.index_targets_with_progress(config, &mut progress)?;
             mem_trace("after index_targets (edges resolved+inserted)");

--- a/crates/rag-rat-core/src/index/schema/baseline.rs
+++ b/crates/rag-rat-core/src/index/schema/baseline.rs
@@ -20,9 +20,6 @@ pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
             indexed_revision TEXT NOT NULL DEFAULT '',
             commit_sha TEXT NOT NULL DEFAULT '',
             worktree_id TEXT NOT NULL DEFAULT '',
-            -- Owning Cargo package (#61, V022): the per-package local-crate-root set lives in
-            -- `packages`; NULL → fall open to the global `index_meta.local_crate_roots`.
-            package_id INTEGER,
             UNIQUE(path, commit_sha, worktree_id)
         );
 

--- a/crates/rag-rat-core/src/index/schema/baseline.rs
+++ b/crates/rag-rat-core/src/index/schema/baseline.rs
@@ -20,8 +20,27 @@ pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
             indexed_revision TEXT NOT NULL DEFAULT '',
             commit_sha TEXT NOT NULL DEFAULT '',
             worktree_id TEXT NOT NULL DEFAULT '',
+            -- Owning Cargo package (#61, V022): the per-package local-crate-root set lives in
+            -- `packages`; NULL → fall open to the global `index_meta.local_crate_roots`.
+            package_id INTEGER,
             UNIQUE(path, commit_sha, worktree_id)
         );
+
+        -- One row per Cargo manifest in the corpus, scoped by (commit_sha, worktree_id) like files
+        -- (#61, V022). `local_roots_json` holds this package's own importable crate roots — the
+        -- workspace crate names (global union) plus this manifest's in-corpus path-dependency \
+         alias
+        -- keys — so a `use alias::…` resolves local only for the package that declares the alias.
+        CREATE TABLE IF NOT EXISTS packages(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            manifest_dir TEXT NOT NULL,
+            commit_sha TEXT NOT NULL DEFAULT '',
+            worktree_id TEXT NOT NULL DEFAULT '',
+            local_roots_json TEXT NOT NULL DEFAULT '[]',
+            UNIQUE(manifest_dir, commit_sha, worktree_id)
+        ) STRICT;
+
+        CREATE INDEX IF NOT EXISTS idx_packages_scope ON packages(commit_sha, worktree_id);
 
         CREATE TABLE IF NOT EXISTS chunks(
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -129,6 +148,14 @@ pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
             resolution_id INTEGER NOT NULL,
             callee_start_byte INTEGER,
             callee_end_byte INTEGER,
+            -- Module-aware import scope (#61, V022): the enclosing module/block byte range a Rust
+            -- `use` (or inline `mod`) is scoped to, plus the enclosing module body's start byte as
+            -- `import_mod_id`. DEDICATED — not a callee_* overload — so the oracle's
+            -- `callee_start_byte IS NOT NULL` candidate filter is untouched. NULL on non-import \
+         edges.
+            import_scope_start_byte INTEGER,
+            import_scope_end_byte INTEGER,
+            import_mod_id INTEGER,
             edge_kind_id INTEGER NOT NULL,
             confidence_id INTEGER NOT NULL,
             FOREIGN KEY(source_file_id) REFERENCES files(id) ON DELETE CASCADE,

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -452,6 +452,46 @@ pub(crate) fn apply_symbol_scope_path(conn: &Connection) -> rusqlite::Result<()>
     Ok(())
 }
 
+/// V022 (#61 per-package + module-aware import-scope rework). Additive + idempotent, so it is
+/// byte-identical under both a fresh full `apply()` and a forward-only migrate from an older index.
+///
+/// `packages`: one row per Cargo manifest in the corpus, scoped by `(commit_sha, worktree_id)` like
+/// `files`. `local_roots_json` is this package's own importable crate roots — the workspace crate
+/// names (global union) PLUS this manifest's in-corpus path-dependency alias keys — so a
+/// `use alias::…` resolves local for the package that declares the alias and external everywhere
+/// else (#1: per-package locality). `files.package_id` points each file at its owning package
+/// (NULL → fall open to the global `index_meta.local_crate_roots` set).
+///
+/// Edge columns are DEDICATED (`import_scope_*`, `import_mod_id`), NOT a callee_* overload: the
+/// oracle's candidate filter is `callee_start_byte IS NOT NULL`, and overloading that column with a
+/// non-identifier scope range would drag import rows into the SCIP occurrence join (the #100
+/// collision). With dedicated NULL-on-non-import columns the oracle filter stays correct untouched.
+/// They are added to `edges_data` (the real table); the `edges` compatibility view is recreated by
+/// `ensure_edges_view` below so readers/tests can write them through the view.
+pub(crate) fn apply_per_package_import_scope(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS packages(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            manifest_dir TEXT NOT NULL,
+            commit_sha TEXT NOT NULL DEFAULT '',
+            worktree_id TEXT NOT NULL DEFAULT '',
+            local_roots_json TEXT NOT NULL DEFAULT '[]',
+            UNIQUE(manifest_dir, commit_sha, worktree_id)
+        ) STRICT;
+
+        CREATE INDEX IF NOT EXISTS idx_packages_scope ON packages(commit_sha, worktree_id);
+        ",
+    )?;
+    add_column_if_missing(conn, "files", "package_id", "INTEGER")?;
+    // The dedicated import-scope columns on the REAL edge table (the `edges` symbol is a view
+    // post-V020) are added + the compatibility view recreated by `ensure_edges_view`, which owns
+    // the view↔table column contract and is idempotent. (It already ran at V020; rerun so a
+    // forward-migrate from a pre-V022 index that somehow skipped the V020 rerun still converges.)
+    ensure_edges_view(conn)?;
+    Ok(())
+}
+
 pub(crate) fn apply_edge_callee_byte_range(conn: &Connection) -> rusqlite::Result<()> {
     // Byte range of the callee identifier token on symbol-referencing edges (the SCIP-oracle
     // prerequisite, #67). `source_start_byte`/`source_end_byte` cover the whole call_expression;
@@ -616,6 +656,14 @@ pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
     if legacy_table.is_some() {
         return Ok(());
     }
+    // The view body below references the dedicated import-scope columns (V022). This function runs
+    // at V020 too — BEFORE V022 in the linear apply — and on a forward-migrate from an older
+    // view-shaped DB whose `edges_data` predates them, so guarantee they exist here (idempotent)
+    // before the view is (re)defined against them. Without this the V020 CREATE VIEW resolves
+    // `d.import_scope_start_byte` against a table that lacks it and fails (#61).
+    add_column_if_missing(conn, "edges_data", "import_scope_start_byte", "INTEGER")?;
+    add_column_if_missing(conn, "edges_data", "import_scope_end_byte", "INTEGER")?;
+    add_column_if_missing(conn, "edges_data", "import_mod_id", "INTEGER")?;
     conn.execute_batch(
         "
         -- Recreate unconditionally: the view's definition evolves (e.g. the appended *_id
@@ -644,6 +692,16 @@ pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
                res.value AS resolution,
                d.callee_start_byte,
                d.callee_end_byte,
+               -- Import-scope columns (#61 per-package/per-module rework, V022): the enclosing
+               -- module/block byte range a Rust `use` is lexically scoped to, plus the enclosing
+               -- module body's id, so a bare reference is suppressed by this import only inside
+               -- that scope. DEDICATED columns (not the callee_* overload) so the oracle's
+               -- `callee_start_byte IS NOT NULL` candidate filter stays correct — import rows \
+         leave
+               -- callee_* NULL and never enter the SCIP occurrence join. NULL on non-import edges.
+               d.import_scope_start_byte,
+               d.import_scope_end_byte,
+               d.import_mod_id,
                ek.value AS edge_kind,
                conf.value AS confidence,
                -- The raw dictionary ids, appended after the legacy shape: hot predicates that the
@@ -683,6 +741,7 @@ pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
                 source_start_line, source_end_line, source_start_byte, source_end_byte,
                 target_start_line, target_end_line, target_qualified_name_id, evidence,
                 receiver_hint_id, resolution_id, callee_start_byte, callee_end_byte,
+                import_scope_start_byte, import_scope_end_byte, import_mod_id,
                 edge_kind_id, confidence_id
             )
             VALUES (
@@ -698,6 +757,7 @@ pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
                 (SELECT id FROM edge_strings
                  WHERE value = COALESCE(NEW.resolution, 'unresolved')),
                 NEW.callee_start_byte, NEW.callee_end_byte,
+                NEW.import_scope_start_byte, NEW.import_scope_end_byte, NEW.import_mod_id,
                 (SELECT id FROM edge_strings WHERE value = NEW.edge_kind),
                 (SELECT id FROM edge_strings WHERE value = NEW.confidence)
             );
@@ -730,6 +790,9 @@ pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
                 resolution_id = (SELECT id FROM edge_strings WHERE value = NEW.resolution),
                 callee_start_byte = NEW.callee_start_byte,
                 callee_end_byte = NEW.callee_end_byte,
+                import_scope_start_byte = NEW.import_scope_start_byte,
+                import_scope_end_byte = NEW.import_scope_end_byte,
+                import_mod_id = NEW.import_mod_id,
                 edge_kind_id = (SELECT id FROM edge_strings WHERE value = NEW.edge_kind),
                 confidence_id = (SELECT id FROM edge_strings WHERE value = NEW.confidence)
             WHERE id = OLD.id;
@@ -892,6 +955,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_019_ID => Some(19),
             MIGRATION_020_ID => Some(20),
             MIGRATION_021_ID => Some(21),
+            MIGRATION_022_ID => Some(22),
             _ => None,
         })
         .max()
@@ -922,6 +986,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_019_ID
             | MIGRATION_020_ID
             | MIGRATION_021_ID
+            | MIGRATION_022_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -949,6 +1014,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_019_ID => migration.checksum != MIGRATION_019_CHECKSUM,
         MIGRATION_020_ID => migration.checksum != MIGRATION_020_CHECKSUM,
         MIGRATION_021_ID => migration.checksum != MIGRATION_021_CHECKSUM,
+        MIGRATION_022_ID => migration.checksum != MIGRATION_022_CHECKSUM,
         _ => false,
     }
 }

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -459,8 +459,12 @@ pub(crate) fn apply_symbol_scope_path(conn: &Connection) -> rusqlite::Result<()>
 /// `files`. `local_roots_json` is this package's own importable crate roots — the workspace crate
 /// names (global union) PLUS this manifest's in-corpus path-dependency alias keys — so a
 /// `use alias::…` resolves local for the package that declares the alias and external everywhere
-/// else (#1: per-package locality). `files.package_id` points each file at its owning package
-/// (NULL → fall open to the global `index_meta.local_crate_roots` set).
+/// else (#1: per-package locality). The file→package mapping is NOT persisted on `files`: the
+/// resolver computes it at LOAD time (`load_package_roots_into_scope`) by longest-`manifest_dir`-
+/// prefix over the active scope's `packages` rows. A persisted `files.package_id` pointer was the
+/// #106 multi-worktree leak — a clean file is a SHARED commit-scope row read by every worktree, but a
+/// package row is worktree-scoped, so one worktree's refresh stamped its ids onto a sibling's
+/// shared rows. Computing at load reads each scope's OWN `packages`, so no pointer can leak.
 ///
 /// Edge columns are DEDICATED (`import_scope_*`, `import_mod_id`), NOT a callee_* overload: the
 /// oracle's candidate filter is `callee_start_byte IS NOT NULL`, and overloading that column with a
@@ -483,18 +487,19 @@ pub(crate) fn apply_per_package_import_scope(conn: &Connection) -> rusqlite::Res
         CREATE INDEX IF NOT EXISTS idx_packages_scope ON packages(commit_sha, worktree_id);
         ",
     )?;
-    add_column_if_missing(conn, "files", "package_id", "INTEGER")?;
     // The dedicated import-scope columns on the REAL edge table (the `edges` symbol is a view
     // post-V020) are added + the compatibility view recreated by `ensure_edges_view`, which owns
     // the view↔table column contract and is idempotent. (It already ran at V020; rerun so a
     // forward-migrate from a pre-V022 index that somehow skipped the V020 rerun still converges.)
     ensure_edges_view(conn)?;
-    // This migration only adds the package/scope COLUMNS — it does not backfill `packages` /
-    // `files.package_id` or re-derive the `import_scope_*` edge columns on existing rows. That
-    // backfill rides the `GRAPH_INDEX_VERSION` bump (→ 7) instead: an upgraded index has a stale
-    // `graph_index_version`, so `ensure_graph_index_current` re-resolves on next open and (per the
-    // `refresh_packages` call added to that path) repopulates the scope. Without the version bump
-    // the new per-package behavior would never engage post-migration.
+    // This migration only adds the package table + edge COLUMNS — it does not backfill `packages`
+    // or re-derive the `import_scope_*` edge columns on existing rows. That backfill rides the
+    // `GRAPH_INDEX_VERSION` bump (→ 7) instead: an upgraded index has a stale
+    // `graph_index_version`, so `ensure_graph_index_current` re-resolves on next open and (per
+    // the `refresh_packages` call added to that path) repopulates `packages`. Without the
+    // version bump the new per-package behavior would never engage post-migration. The
+    // file→package mapping is computed at LOAD time from `packages`, so there is no
+    // `files.package_id` column to add.
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -489,6 +489,12 @@ pub(crate) fn apply_per_package_import_scope(conn: &Connection) -> rusqlite::Res
     // the view↔table column contract and is idempotent. (It already ran at V020; rerun so a
     // forward-migrate from a pre-V022 index that somehow skipped the V020 rerun still converges.)
     ensure_edges_view(conn)?;
+    // This migration only adds the package/scope COLUMNS — it does not backfill `packages` /
+    // `files.package_id` or re-derive the `import_scope_*` edge columns on existing rows. That
+    // backfill rides the `GRAPH_INDEX_VERSION` bump (→ 7) instead: an upgraded index has a stale
+    // `graph_index_version`, so `ensure_graph_index_current` re-resolves on next open and (per the
+    // `refresh_packages` call added to that path) repopulates the scope. Without the version bump
+    // the new per-package behavior would never engage post-migration.
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use migrations::*;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 21;
+pub const LATEST_SCHEMA_VERSION: u32 = 22;
 const DIRTY_MIGRATION_ID: &str = "__dirty__";
 const MIGRATION_001_ID: &str = "001_sqlite_storage_baseline";
 const MIGRATION_001_CHECKSUM: &str = "sha256:rag-rat-sqlite-baseline-v1";
@@ -92,6 +92,11 @@ const MIGRATION_021_ID: &str = "021_symbol_scope_path";
 const MIGRATION_021_CHECKSUM: &str = "sha256:rag-rat-symbol-scope-path-v21";
 const MIGRATION_021_DESCRIPTION: &str =
     "Add symbols.scope_path (semantic enclosing-scope path) for scope-aware edge resolution (#61)";
+const MIGRATION_022_ID: &str = "022_per_package_import_scope";
+const MIGRATION_022_CHECKSUM: &str = "sha256:rag-rat-per-package-import-scope-v22";
+const MIGRATION_022_DESCRIPTION: &str = "Add packages + files.package_id + dedicated edge \
+                                         import-scope columns for per-package, module-aware \
+                                         import resolution (#61)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -186,6 +191,8 @@ pub fn apply(conn: &Connection) -> rusqlite::Result<()> {
     record_migration(conn, MIGRATION_020_ID, MIGRATION_020_CHECKSUM, MIGRATION_020_DESCRIPTION)?;
     apply_symbol_scope_path(conn)?;
     record_migration(conn, MIGRATION_021_ID, MIGRATION_021_CHECKSUM, MIGRATION_021_DESCRIPTION)?;
+    apply_per_package_import_scope(conn)?;
+    record_migration(conn, MIGRATION_022_ID, MIGRATION_022_CHECKSUM, MIGRATION_022_DESCRIPTION)?;
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -94,9 +94,8 @@ const MIGRATION_021_DESCRIPTION: &str =
     "Add symbols.scope_path (semantic enclosing-scope path) for scope-aware edge resolution (#61)";
 const MIGRATION_022_ID: &str = "022_per_package_import_scope";
 const MIGRATION_022_CHECKSUM: &str = "sha256:rag-rat-per-package-import-scope-v22";
-const MIGRATION_022_DESCRIPTION: &str = "Add packages + files.package_id + dedicated edge \
-                                         import-scope columns for per-package, module-aware \
-                                         import resolution (#61)";
+const MIGRATION_022_DESCRIPTION: &str = "Add packages table + dedicated edge import-scope columns \
+                                         for per-package, module-aware import resolution (#61)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -6727,9 +6727,11 @@ fn conn_table_exists(conn: &rusqlite::Connection, table: &str) -> bool {
 }
 
 /// V022 bootstrap (fresh-applies-all): a brand-new index applies every migration through V022 and
-/// ends with the `packages` table, `files.package_id`, and the three DEDICATED edge import-scope
-/// columns — and the `edges` compatibility view surfaces them. The oracle's `callee_*` columns are
-/// untouched (the columns are dedicated, not a callee overload).
+/// ends with the `packages` table and the three DEDICATED edge import-scope columns — and the
+/// `edges` compatibility view surfaces them. There is NO `files.package_id` column: the
+/// file→package mapping is computed at LOAD time from `packages` (the #106 fix dropped the
+/// persisted pointer). The oracle's `callee_*` columns are untouched (the columns are dedicated,
+/// not a callee overload).
 #[test]
 fn v022_fresh_apply_creates_packages_and_dedicated_import_scope_columns() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
@@ -6744,8 +6746,8 @@ fn v022_fresh_apply_creates_packages_and_dedicated_import_scope_columns() {
         assert!(package_cols.contains(&expected.to_string()), "packages missing {expected}");
     }
     assert!(
-        conn_table_columns(&conn, "files").contains(&"package_id".to_string()),
-        "files.package_id is added"
+        !conn_table_columns(&conn, "files").contains(&"package_id".to_string()),
+        "files.package_id is NOT added — the file→package mapping is computed at load (#106)"
     );
     // Dedicated columns on the real edge table — NOT a callee_* overload.
     let edges_data_cols = conn_table_columns(&conn, "edges_data");
@@ -6776,9 +6778,11 @@ fn v022_fresh_apply_creates_packages_and_dedicated_import_scope_columns() {
 }
 
 /// V022 forward-only migrate (older→latest): an index lacking the V022 artifacts (the `packages`
-/// table, `files.package_id`, the edge import-scope columns, and the V022 schema_version row) is
-/// re-`apply`ed and converges to V22 with all artifacts present — proving the migration is additive
-/// and idempotent on top of an older shape, the auto-migrate-forward path (#102).
+/// table, the edge import-scope columns, and the V022 schema_version row) is re-`apply`ed and
+/// converges to V22 with all artifacts present — proving the migration is additive and idempotent
+/// on top of an older shape, the auto-migrate-forward path (#102). V022 does NOT add a `files`
+/// column (the file→package mapping is computed at load, #106), so there is nothing to drop/re-add
+/// there.
 #[test]
 fn v022_forward_migrate_adds_artifacts_to_an_older_index() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
@@ -6793,7 +6797,6 @@ fn v022_forward_migrate_adds_artifacts_to_an_older_index() {
         DROP TRIGGER IF EXISTS edges_view_insert;
         DROP TRIGGER IF EXISTS edges_view_update;
         DROP TRIGGER IF EXISTS edges_view_delete;
-        ALTER TABLE files DROP COLUMN package_id;
         ALTER TABLE edges_data DROP COLUMN import_scope_start_byte;
         ALTER TABLE edges_data DROP COLUMN import_scope_end_byte;
         ALTER TABLE edges_data DROP COLUMN import_mod_id;
@@ -6808,7 +6811,10 @@ fn v022_forward_migrate_adds_artifacts_to_an_older_index() {
     schema::apply(&conn).unwrap();
     assert_eq!(schema::status(&conn).unwrap().current_version, 22);
     assert!(conn_table_exists(&conn, "packages"), "forward migrate creates packages");
-    assert!(conn_table_columns(&conn, "files").contains(&"package_id".to_string()));
+    assert!(
+        !conn_table_columns(&conn, "files").contains(&"package_id".to_string()),
+        "forward migrate does NOT add files.package_id (#106 computes the mapping at load)"
+    );
     let edges_data_cols = conn_table_columns(&conn, "edges_data");
     for expected in ["import_scope_start_byte", "import_scope_end_byte", "import_mod_id"] {
         assert!(edges_data_cols.contains(&expected.to_string()), "forward migrate adds {expected}");
@@ -6842,15 +6848,13 @@ fn full_rebuild_applies_per_package_import_scope() {
     let db = IndexDatabase::rebuild(&config).unwrap();
     let conn = db.storage.connection();
 
-    // The `packages` table was populated with myapp's root crate.
+    // The `packages` table was populated with myapp's root crate. The file→package mapping is NOT
+    // persisted (#106) — the resolver computes it at load from this row — so there is no
+    // `files.package_id` to assert; the behavioral assertions below prove the load-time computation
+    // engaged.
     let package_count: i64 =
         conn.query_row("SELECT COUNT(*) FROM packages", [], |row| row.get(0)).unwrap();
     assert!(package_count >= 1, "rebuild writes a packages row for the manifest");
-    // Every indexed file got a package_id (the single root package owns src/lib.rs).
-    let unassigned: i64 = conn
-        .query_row("SELECT COUNT(*) FROM files WHERE package_id IS NULL", [], |row| row.get(0))
-        .unwrap();
-    assert_eq!(unassigned, 0, "the file is assigned to its owning package");
 
     // The `Display` reference (use'd from external std) must NOT bind to the local `Display`
     // struct.
@@ -7290,25 +7294,46 @@ fn full_rebuild_survives_stale_overlay_rows() {
     fs::remove_dir_all(root).unwrap();
 }
 
-/// #1: in a REAL git checkout the active context is `(commit_sha=HEAD, worktree_id=<root path>)`
-/// while a clean file row is `(commit_sha=HEAD, worktree_id='')`. `refresh_packages` once SELECTed
-/// files with BOTH columns equal to the active values, which matches NEITHER a clean row (empty
-/// worktree_id) nor an overlay (empty commit_sha) — so `files.package_id` stayed NULL and the
-/// resolver fell open to the global union, leaking per-package aliases. Reading through the `files`
-/// scope VIEW assigns package_id correctly. Prior tests missed this: they used non-git fixtures
-/// where `active_worktree_id` is empty, so the both-equal predicate accidentally matched.
+/// #1 / #106: in a REAL git checkout the active context is `(commit_sha=HEAD, worktree_id=<root
+/// path>)` while a clean file row is `(commit_sha=HEAD, worktree_id='')`. The file→package mapping
+/// is computed at LOAD time (`load_package_roots_into_scope`) by longest-`manifest_dir`-prefix over
+/// the active scope's `packages` rows — there is no persisted `files.package_id` (#106 dropped it
+/// to stop a worktree from stamping its package ids onto shared clean rows). This proves the
+/// load-time computation correctly maps a clean-checkout file to ITS package on a real git
+/// checkout: a path-dep alias declared only by crate `foo` resolves LOCAL inside `foo` and EXTERNAL
+/// inside crate `bar`.
 #[test]
-fn clean_checkout_file_gets_package_id_assigned() {
+fn clean_checkout_file_resolves_against_its_own_package_roots() {
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join("crates/foo/src")).unwrap();
+    fs::create_dir_all(root.join("crates/bar/src")).unwrap();
+    fs::create_dir_all(root.join("crates/helper/src")).unwrap();
     run_git(&root, &["init"]);
     run_git(&root, &["config", "user.name", "Rag Rat"]);
     run_git(&root, &["config", "user.email", "rag@example.com"]);
-    // A two-crate Cargo workspace so the package map is non-trivial.
+    // A workspace where ONLY `foo` declares the RENAMED path-dep alias `shared` (pointing at the
+    // `helper` crate). The alias KEY `shared` is local ONLY to foo — it is not a workspace crate
+    // name (that is `helper`) and bar never declares it — so the same `use shared::Thing` is
+    // local in foo and external in bar. This is the per-package locality (#1) the load-time
+    // mapping must honor.
     fs::write(root.join("Cargo.toml"), "[workspace]\nmembers=[\"crates/*\"]\n").unwrap();
-    fs::write(root.join("crates/foo/Cargo.toml"), "[package]\nname=\"foo\"\n").unwrap();
-    fs::write(root.join("crates/foo/src/lib.rs"), "pub fn foo() -> i32 { 1 }\n").unwrap();
+    fs::write(
+        root.join("crates/foo/Cargo.toml"),
+        "[package]\nname=\"foo\"\n[dependencies]\nshared = { path = \"../helper\", package = \
+         \"helper\" }\n",
+    )
+    .unwrap();
+    // Both foo and bar reference a same-named `Thing` in TYPE position (a `references_type` edge —
+    // the bucket per-package suppression acts on).
+    fs::write(root.join("crates/foo/src/lib.rs"), "use shared::Thing;\npub fn foo(_t: Thing) {}\n")
+        .unwrap();
+    fs::write(root.join("crates/bar/Cargo.toml"), "[package]\nname=\"bar\"\n").unwrap();
+    fs::write(root.join("crates/bar/src/lib.rs"), "use shared::Thing;\npub fn bar(_t: Thing) {}\n")
+        .unwrap();
+    fs::write(root.join("crates/helper/Cargo.toml"), "[package]\nname=\"helper\"\n").unwrap();
+    // A local `Thing` symbol the bare references could bind to.
+    fs::write(root.join("crates/helper/src/lib.rs"), "pub struct Thing;\n").unwrap();
     run_git(&root, &["add", "."]);
     run_git(&root, &["commit", "-m", "init"]);
 
@@ -7330,20 +7355,39 @@ fn clean_checkout_file_gets_package_id_assigned() {
     let db = IndexDatabase::rebuild(&config).unwrap();
     assert!(!db.active_commit_sha.is_empty(), "fixture must be a real git checkout");
     assert!(!db.active_worktree_id.is_empty(), "a real checkout has a non-empty worktree id");
+    let conn = db.storage.connection();
 
-    let package_id: Option<i64> = db
-        .storage
-        .connection()
+    // In `foo`, `shared` is its declared path-dep alias → LOCAL → the bare `Thing` binds to the
+    // shared crate's `Thing`. In `bar`, `shared` is undeclared → EXTERNAL → the bare `Thing` is
+    // suppressed (stays unresolved). If the load-time mapping fell open to the global union (the
+    // #106 leak), bar's reference would wrongly bind too.
+    let foo_bound: i64 = conn
         .query_row(
-            "SELECT package_id FROM main.files WHERE path = 'crates/foo/src/lib.rs' AND kind != \
-             'deleted'",
+            "SELECT COUNT(*) FROM edges e JOIN files f ON f.id = e.source_file_id WHERE f.path = \
+             'crates/foo/src/lib.rs' AND e.to_name = 'Thing' AND e.edge_kind != 'imports' AND \
+             e.to_symbol_id IS NOT NULL",
             [],
             |row| row.get(0),
         )
         .unwrap();
     assert!(
-        package_id.is_some(),
-        "a normal clean-checkout file in a Cargo project must have package_id populated, not NULL"
+        foo_bound >= 1,
+        "in foo, `shared` is its own path-dep alias — the bare `Thing` resolves to the local \
+         symbol"
+    );
+    let bar_bound: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM edges e JOIN files f ON f.id = e.source_file_id WHERE f.path = \
+             'crates/bar/src/lib.rs' AND e.to_name = 'Thing' AND e.edge_kind != 'imports' AND \
+             e.to_symbol_id IS NOT NULL",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        bar_bound, 0,
+        "in bar, `shared` is an EXTERNAL crate — the bare `Thing` must NOT bind to the local \
+         symbol"
     );
 
     fs::remove_dir_all(root).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -7290,6 +7290,65 @@ fn full_rebuild_survives_stale_overlay_rows() {
     fs::remove_dir_all(root).unwrap();
 }
 
+/// #1: in a REAL git checkout the active context is `(commit_sha=HEAD, worktree_id=<root path>)`
+/// while a clean file row is `(commit_sha=HEAD, worktree_id='')`. `refresh_packages` once SELECTed
+/// files with BOTH columns equal to the active values, which matches NEITHER a clean row (empty
+/// worktree_id) nor an overlay (empty commit_sha) — so `files.package_id` stayed NULL and the
+/// resolver fell open to the global union, leaking per-package aliases. Reading through the `files`
+/// scope VIEW assigns package_id correctly. Prior tests missed this: they used non-git fixtures
+/// where `active_worktree_id` is empty, so the both-equal predicate accidentally matched.
+#[test]
+fn clean_checkout_file_gets_package_id_assigned() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("crates/foo/src")).unwrap();
+    run_git(&root, &["init"]);
+    run_git(&root, &["config", "user.name", "Rag Rat"]);
+    run_git(&root, &["config", "user.email", "rag@example.com"]);
+    // A two-crate Cargo workspace so the package map is non-trivial.
+    fs::write(root.join("Cargo.toml"), "[workspace]\nmembers=[\"crates/*\"]\n").unwrap();
+    fs::write(root.join("crates/foo/Cargo.toml"), "[package]\nname=\"foo\"\n").unwrap();
+    fs::write(root.join("crates/foo/src/lib.rs"), "pub fn foo() -> i32 { 1 }\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "init"]);
+
+    let config = Config {
+        root: root.clone(),
+        database: root.join(".rag-rat/index.sqlite"),
+        targets: vec![ResolvedTarget {
+            name: "rust".to_string(),
+            language: Language::Rust,
+            directories: vec![PathBuf::from("crates")],
+            include: vec!["**/*.rs".to_string()],
+            exclude: Vec::new(),
+            kind: TargetKind::Source,
+        }],
+        local_ai: Default::default(),
+        watch: Default::default(),
+    };
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    assert!(!db.active_commit_sha.is_empty(), "fixture must be a real git checkout");
+    assert!(!db.active_worktree_id.is_empty(), "a real checkout has a non-empty worktree id");
+
+    let package_id: Option<i64> = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT package_id FROM main.files WHERE path = 'crates/foo/src/lib.rs' AND kind != \
+             'deleted'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(
+        package_id.is_some(),
+        "a normal clean-checkout file in a Cargo project must have package_id populated, not NULL"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
 /// #87 (self-heal half): an incremental pass drops a stale overlay row whose path is clean.
 /// With a committed counterpart present the overlay is removed outright; without one, the row is
 /// RE-STAMPED to the commit scope in place (same row id — chunks/symbols/embeddings/memory

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -6710,6 +6710,166 @@ fn table_columns(db: &IndexDatabase, table: &str) -> Vec<String> {
     stmt.query_map([], |row| row.get::<_, String>(1)).unwrap().map(Result::unwrap).collect()
 }
 
+fn conn_table_columns(conn: &rusqlite::Connection, table: &str) -> Vec<String> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})")).unwrap();
+    stmt.query_map([], |row| row.get::<_, String>(1)).unwrap().map(Result::unwrap).collect()
+}
+
+fn conn_table_exists(conn: &rusqlite::Connection, table: &str) -> bool {
+    conn.query_row(
+        "SELECT 1 FROM sqlite_master WHERE type IN ('table','view') AND name = ?1",
+        [table],
+        |_| Ok(()),
+    )
+    .optional()
+    .unwrap()
+    .is_some()
+}
+
+/// V022 bootstrap (fresh-applies-all): a brand-new index applies every migration through V022 and
+/// ends with the `packages` table, `files.package_id`, and the three DEDICATED edge import-scope
+/// columns — and the `edges` compatibility view surfaces them. The oracle's `callee_*` columns are
+/// untouched (the columns are dedicated, not a callee overload).
+#[test]
+fn v022_fresh_apply_creates_packages_and_dedicated_import_scope_columns() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 22);
+    assert!(conn_table_exists(&conn, "packages"), "packages table is created on a fresh apply");
+
+    let package_cols = conn_table_columns(&conn, "packages");
+    for expected in ["id", "manifest_dir", "commit_sha", "worktree_id", "local_roots_json"] {
+        assert!(package_cols.contains(&expected.to_string()), "packages missing {expected}");
+    }
+    assert!(
+        conn_table_columns(&conn, "files").contains(&"package_id".to_string()),
+        "files.package_id is added"
+    );
+    // Dedicated columns on the real edge table — NOT a callee_* overload.
+    let edges_data_cols = conn_table_columns(&conn, "edges_data");
+    for expected in ["import_scope_start_byte", "import_scope_end_byte", "import_mod_id"] {
+        assert!(edges_data_cols.contains(&expected.to_string()), "edges_data missing {expected}");
+    }
+    assert!(
+        edges_data_cols.contains(&"callee_start_byte".to_string()),
+        "the oracle's callee_start_byte column is untouched"
+    );
+    // The compatibility view surfaces the new columns (so writers/tests can set them).
+    let edges_view_cols = conn_table_columns(&conn, "edges");
+    for expected in ["import_scope_start_byte", "import_scope_end_byte", "import_mod_id"] {
+        assert!(edges_view_cols.contains(&expected.to_string()), "edges view missing {expected}");
+    }
+    // The packages-scope index exists.
+    assert!(
+        conn.query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='index' AND name='idx_packages_scope'",
+            [],
+            |_| Ok(())
+        )
+        .optional()
+        .unwrap()
+        .is_some(),
+        "idx_packages_scope is created"
+    );
+}
+
+/// V022 forward-only migrate (older→latest): an index lacking the V022 artifacts (the `packages`
+/// table, `files.package_id`, the edge import-scope columns, and the V022 schema_version row) is
+/// re-`apply`ed and converges to V22 with all artifacts present — proving the migration is additive
+/// and idempotent on top of an older shape, the auto-migrate-forward path (#102).
+#[test]
+fn v022_forward_migrate_adds_artifacts_to_an_older_index() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    // Simulate a pre-V022 index: drop the V022 artifacts and its schema_version row. (SQLite ≥3.35
+    // supports DROP COLUMN; the bundled rusqlite is current.)
+    conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS packages;
+        DROP INDEX IF EXISTS idx_packages_scope;
+        DROP VIEW IF EXISTS edges;
+        DROP TRIGGER IF EXISTS edges_view_insert;
+        DROP TRIGGER IF EXISTS edges_view_update;
+        DROP TRIGGER IF EXISTS edges_view_delete;
+        ALTER TABLE files DROP COLUMN package_id;
+        ALTER TABLE edges_data DROP COLUMN import_scope_start_byte;
+        ALTER TABLE edges_data DROP COLUMN import_scope_end_byte;
+        ALTER TABLE edges_data DROP COLUMN import_mod_id;
+        DELETE FROM schema_version WHERE id = '022_per_package_import_scope';
+        ",
+    )
+    .unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, 21, "now looks like a V21 index");
+    assert!(!conn_table_exists(&conn, "packages"));
+
+    // Forward-migrate: re-running apply (the Older→apply path) converges to V22.
+    schema::apply(&conn).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, 22);
+    assert!(conn_table_exists(&conn, "packages"), "forward migrate creates packages");
+    assert!(conn_table_columns(&conn, "files").contains(&"package_id".to_string()));
+    let edges_data_cols = conn_table_columns(&conn, "edges_data");
+    for expected in ["import_scope_start_byte", "import_scope_end_byte", "import_mod_id"] {
+        assert!(edges_data_cols.contains(&expected.to_string()), "forward migrate adds {expected}");
+    }
+    // The view was rebuilt and surfaces the columns (a SELECT must not fail).
+    conn.query_row("SELECT import_mod_id FROM edges LIMIT 1", [], |_| Ok(())).optional().unwrap();
+}
+
+/// End-to-end through the FULL-REBUILD driver (`resolve_and_insert_edges`): a real `rebuild` of a
+/// tiny Cargo workspace must apply per-package + module-aware import scope. A bare reference to a
+/// name `use`d from an EXTERNAL crate stays unresolved; a same-named LOCAL workspace symbol still
+/// resolves from the package that owns it. This is the full-driver half of the both-driver parity
+/// (the DB driver is covered by `module_aware_suppression_through_db_driver`).
+#[test]
+fn full_rebuild_applies_per_package_import_scope() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    // A workspace crate `myapp` with a LOCAL `Helper` and an EXTERNAL `use std::fmt::Display`.
+    // `Helper` referenced via a local crate path resolves; a `Display` reference does not bind to a
+    // (hypothetical) local symbol because it is use'd from std.
+    fs::write(root.join("Cargo.toml"), "[package]\nname = \"myapp\"\n").unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        "use std::fmt::Display;\npub struct Helper;\npub struct Display;\npub fn run() {\n    let \
+         _ = Display;\n    let _ = Helper;\n}\n",
+    )
+    .unwrap();
+
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+
+    // The `packages` table was populated with myapp's root crate.
+    let package_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM packages", [], |row| row.get(0)).unwrap();
+    assert!(package_count >= 1, "rebuild writes a packages row for the manifest");
+    // Every indexed file got a package_id (the single root package owns src/lib.rs).
+    let unassigned: i64 = conn
+        .query_row("SELECT COUNT(*) FROM files WHERE package_id IS NULL", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(unassigned, 0, "the file is assigned to its owning package");
+
+    // The `Display` reference (use'd from external std) must NOT bind to the local `Display`
+    // struct.
+    let display_bound: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM edges WHERE to_name = 'Display' AND edge_kind = \
+             'references_type' AND to_symbol_id IS NOT NULL",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        display_bound, 0,
+        "a `Display` use'd from external std must not bind to the local `Display` struct"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
 fn indexed_revision_count(db: &IndexDatabase) -> i64 {
     db.storage
         .connection()


### PR DESCRIPTION
## Per-package + module-aware import-scope rework

Consolidated rework of crate-aware import suppression. A name `use`d from an EXTERNAL dependency crate must not bind to a local same-named symbol — this PR fixes the 5 edge cases the original per-file global-set model mishandled, with the full per-package `packages` table + module-aware scope model.

### Model

- **Per-package locality.** The local-crate set is per-package, not one global set. `ImportScope::roots_for_file` consults the file's package set (`packages.local_roots_json` via `files.package_id`), falling back to the global union (`index_meta.local_crate_roots`). A `path`-dependency alias `local = { path = "…" }` is local **only** for the package that declares it.
- **Module-aware scope.** A Rust `use` is scoped to its enclosing module body (or block, when block-local). A binding `{root, scope_start, scope_end, mod_id}` covers a reference iff the ref byte is in `[scope_start, scope_end)` **and** the ref's enclosing-module id equals the binding's `mod_id`. Child `mod`s do not inherit a parent's `use`s. On multiple covering bindings the innermost (smallest span) wins.
- **Dedicated edge columns, not the `callee_*` overload.** `import_scope_start_byte` / `import_scope_end_byte` / `import_mod_id` are NULL on non-import edges, so the SCIP oracle's `callee_start_byte IS NOT NULL` candidate filter stays correct and the `ORACLE_JUDGED_EDGE_KINDS` band-aid is unnecessary.
- The `ref→mod-id` lookup uses a per-file module interval set built **once on ingest** (`ImportScope::finalize`) from inline-`mod` edges — kept off the per-edge hot path.
- Both drivers (`resolve_all_edges` DB path + `resolve_and_insert_edges` full-rebuild interned path) stay in exact parity: same `add_use`/`finalize`/`is_external_*` calls, both thread the ref's `source_start_byte`, both share `load_package_roots_into_scope`.

### Codex edge cases → fix

| # | Case | Fix |
|---|------|-----|
| 1 | per-package alias must not leak across packages | `packages` table + `files.package_id`; `roots_for_file` is per-package with global fallback |
| 2 | `[lib].name` / autolib importable root | salvaged `lib_crate_root_name` (explicit `[lib]` or autodiscovered `src/lib.rs`, `autolib=false` honored) |
| 3 | bin-only / out-of-corpus path deps | `lib_crate_root_name` returns None for bin-only; `path_dependency_is_in_corpus` excludes out-of-corpus aliases |
| 4 | parent-`mod` `use` must not suppress a child-`mod` local | same-`mod_id` covering requirement |
| 5 | innermost shadowing | smallest-span covering binding wins |

### Migration V022 (`apply_per_package_import_scope`)

`packages` table (STRICT) + `files.package_id` + dedicated edge import-scope columns + `idx_packages_scope`. Additive and idempotent — lives in the post-squash baseline and is re-added via `add_column_if_missing` on a forward migrate; `ensure_edges_view` guarantees the columns exist before the view references them. `LATEST_SCHEMA_VERSION` → 22.

### Tests

5 Codex cases at the `ImportScope` unit level + through the DB driver; `oracle_unaffected_by_import_scope_columns`; full-rebuild end-to-end (the full-driver parity half); V022 bootstrap (fresh-applies-all + forward-older-to-latest); salvaged #97 bin-only + out-of-corpus tests. `cargo test -p rag-rat-core` green (328), clippy clean, nightly fmt applied.

### Supersedes

This **supersedes and replaces** #99 (fix/97), #100 (fix/96), and #101 (fix/95) — please close them as superseded by this PR. The keeper parts of each were salvaged (the #97 manifest parsing, the #96 enclosing-scope concept, the #95 incremental-refresh ordering); the callee-column overload and `ORACLE_JUDGED_EDGE_KINDS` band-aid are replaced by dedicated columns.
