### PR TITLE
feat: default to TOON output for CLI + MCP, --json opt-out (#104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,26 +109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arboard"
-version = "3.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
-dependencies = [
- "clipboard-win",
- "image",
- "log",
- "objc2",
- "objc2-app-kit",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-foundation",
- "parking_lot",
- "percent-encoding",
- "windows-sys 0.60.2",
- "x11rb",
-]
-
-[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,27 +163,12 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
-]
-
-[[package]]
-name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -253,34 +218,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "byteorder-lite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cast"
@@ -326,10 +273,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -401,15 +346,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "clipboard-win"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
-dependencies = [
- "error-code",
-]
-
-[[package]]
 name = "clru"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,31 +359,6 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "comfy-table"
-version = "7.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
-dependencies = [
- "crossterm 0.29.0",
- "unicode-segmentation",
- "unicode-width 0.2.0",
-]
-
-[[package]]
-name = "compact_str"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "static_assertions",
-]
 
 [[package]]
 name = "compact_str"
@@ -473,7 +384,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.0",
+ "unicode-width",
  "windows-sys 0.59.0",
 ]
 
@@ -485,7 +396,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width 0.2.0",
+ "unicode-width",
  "windows-sys 0.61.2",
 ]
 
@@ -624,45 +535,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "mio",
- "parking_lot",
- "rustix 0.38.44",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "document-features",
- "parking_lot",
- "rustix 1.1.4",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "crunchy"
@@ -897,16 +769,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dispatch2"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
-dependencies = [
- "bitflags",
- "objc2",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,12 +838,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-code"
-version = "3.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
-
-[[package]]
 name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,22 +860,11 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
-dependencies = [
- "bit-set 0.5.3",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "fancy-regex"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
 dependencies = [
- "bit-set 0.8.0",
+ "bit-set",
  "regex-automata",
  "regex-syntax",
 ]
@@ -1055,21 +900,6 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "fax"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
-
-[[package]]
-name = "fdeflate"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
-dependencies = [
- "simd-adler32",
-]
 
 [[package]]
 name = "filetime"
@@ -1229,16 +1059,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "gethostname"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
-dependencies = [
- "rustix 1.1.4",
- "windows-link",
 ]
 
 [[package]]
@@ -1654,7 +1474,7 @@ dependencies = [
  "itoa",
  "libc",
  "memmap2",
- "rustix 1.1.4",
+ "rustix",
  "smallvec",
  "thiserror 2.0.18",
 ]
@@ -2094,8 +1914,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2498,20 +2316,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "image"
-version = "0.25.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
-dependencies = [
- "bytemuck",
- "byteorder-lite",
- "moxcms",
- "num-traits",
- "png",
- "tiff",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2532,7 +2336,7 @@ dependencies = [
  "console 0.15.11",
  "number_prefix",
  "portable-atomic",
- "unicode-width 0.2.0",
+ "unicode-width",
  "web-time",
 ]
 
@@ -2544,18 +2348,9 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console 0.16.3",
  "portable-atomic",
- "unicode-width 0.2.0",
+ "unicode-width",
  "unit-prefix",
  "web-time",
-]
-
-[[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
 ]
 
 [[package]]
@@ -2576,19 +2371,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "instability"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
-dependencies = [
- "darling 0.23.0",
- "indoc",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2619,15 +2401,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2730,12 +2503,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2765,18 +2532,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2810,15 +2565,6 @@ name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
-
-[[package]]
-name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
-]
 
 [[package]]
 name = "lru-slab"
@@ -2953,16 +2699,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "moxcms"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
-dependencies = [
- "num-traits",
- "pxfm",
-]
-
-[[package]]
 name = "ndarray"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3071,79 +2807,6 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
-name = "objc2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
-dependencies = [
- "objc2-encode",
-]
-
-[[package]]
-name = "objc2-app-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
-dependencies = [
- "bitflags",
- "objc2",
- "objc2-core-graphics",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags",
- "dispatch2",
- "objc2",
-]
-
-[[package]]
-name = "objc2-core-graphics"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
-dependencies = [
- "bitflags",
- "dispatch2",
- "objc2",
- "objc2-core-foundation",
- "objc2-io-surface",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
-name = "objc2-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
-dependencies = [
- "bitflags",
- "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-io-surface"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
-dependencies = [
- "bitflags",
- "objc2",
- "objc2-core-foundation",
-]
 
 [[package]]
 name = "once_cell"
@@ -3269,32 +2932,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
-name = "plist"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
-dependencies = [
- "base64 0.22.1",
- "indexmap",
- "quick-xml",
- "serde",
- "time",
-]
-
-[[package]]
-name = "png"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
-dependencies = [
- "bitflags",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3404,27 +3041,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pxfm"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
-name = "quick-xml"
-version = "0.39.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3435,7 +3051,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -3455,7 +3071,7 @@ dependencies = [
  "lru-slab",
  "rand",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -3589,27 +3205,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "ratatui"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
-dependencies = [
- "bitflags",
- "cassowary",
- "compact_str 0.8.2",
- "crossterm 0.28.1",
- "indoc",
- "instability",
- "itertools 0.13.0",
- "lru",
- "paste",
- "strum",
- "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -3835,12 +3430,6 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
@@ -3856,19 +3445,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3876,7 +3452,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -4126,27 +3702,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
-name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
-dependencies = [
- "libc",
- "mio",
- "signal-hook",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4244,28 +3799,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4303,27 +3836,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syntect"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
-dependencies = [
- "bincode",
- "flate2",
- "fnv",
- "once_cell",
- "onig",
- "plist",
- "regex-syntax",
- "serde",
- "serde_derive",
- "serde_json",
- "thiserror 2.0.18",
- "walkdir",
- "yaml-rust",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4332,7 +3844,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -4374,35 +3886,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tiff"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
-dependencies = [
- "fax",
- "flate2",
- "half",
- "quick-error",
- "weezl",
- "zune-jpeg",
-]
-
-[[package]]
-name = "tiktoken-rs"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a19830747d9034cd9da43a60eaa8e552dfda7712424aebf187b7a60126bae0d"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "bstr",
- "fancy-regex 0.13.0",
- "lazy_static",
- "regex",
- "rustc-hash 1.1.0",
 ]
 
 [[package]]
@@ -4479,11 +3962,11 @@ checksum = "a620b996116a59e184c2fa2dfd8251ea34a36d0a514758c6f966386bd2e03476"
 dependencies = [
  "ahash",
  "aho-corasick",
- "compact_str 0.9.1",
+ "compact_str",
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
- "fancy-regex 0.14.0",
+ "fancy-regex",
  "getrandom 0.3.4",
  "indicatif 0.17.11",
  "itertools 0.14.0",
@@ -4513,7 +3996,7 @@ checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
 dependencies = [
  "ahash",
  "aho-corasick",
- "compact_str 0.9.1",
+ "compact_str",
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
@@ -4633,21 +4116,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f89570c1a68d73941f728cca32a4345b2ffca36667ad921af336c60309a3e7e"
 dependencies = [
- "anyhow",
- "arboard",
- "chrono",
- "clap",
- "comfy-table",
- "crossterm 0.28.1",
  "indexmap",
- "ratatui",
  "serde",
  "serde_json",
- "syntect",
  "thiserror 2.0.18",
- "tiktoken-rs",
- "tui-textarea",
- "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -4803,17 +4275,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tui-textarea"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae"
-dependencies = [
- "crossterm 0.28.1",
- "ratatui",
- "unicode-width 0.2.0",
-]
-
-[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4854,23 +4315,6 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
-
-[[package]]
-name = "unicode-truncate"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
-dependencies = [
- "itertools 0.13.0",
- "unicode-segmentation",
- "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -5178,12 +4622,6 @@ checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
-
-[[package]]
-name = "weezl"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -5547,32 +4985,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
-name = "x11rb"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
-dependencies = [
- "gethostname",
- "rustix 1.1.4",
- "x11rb-protocol",
-]
-
-[[package]]
-name = "x11rb-protocol"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]
-
-[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5686,18 +5098,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zune-core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
-
-[[package]]
-name = "zune-jpeg"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
-dependencies = [
- "zune-core",
-]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,12 +183,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -218,16 +253,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cast"
@@ -273,8 +326,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -346,6 +401,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "clru"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,6 +423,31 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "crossterm 0.29.0",
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "compact_str"
@@ -384,7 +473,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
 
@@ -396,7 +485,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.61.2",
 ]
 
@@ -535,6 +624,45 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix 1.1.4",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -769,6 +897,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +976,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,11 +1004,22 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
 ]
@@ -900,6 +1055,21 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "filetime"
@@ -1059,6 +1229,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link",
 ]
 
 [[package]]
@@ -1474,7 +1654,7 @@ dependencies = [
  "itoa",
  "libc",
  "memmap2",
- "rustix",
+ "rustix 1.1.4",
  "smallvec",
  "thiserror 2.0.18",
 ]
@@ -1914,6 +2094,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2316,6 +2498,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "tiff",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2336,7 +2532,7 @@ dependencies = [
  "console 0.15.11",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
  "web-time",
 ]
 
@@ -2348,9 +2544,18 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console 0.16.3",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
  "unit-prefix",
  "web-time",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -2371,6 +2576,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2401,6 +2619,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2503,6 +2730,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2532,6 +2765,18 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2565,6 +2810,15 @@ name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -2699,6 +2953,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "ndarray"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2807,6 +3071,79 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
 
 [[package]]
 name = "once_cell"
@@ -2932,6 +3269,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plist"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3041,6 +3404,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3051,7 +3435,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -3071,7 +3455,7 @@ dependencies = [
  "lru-slab",
  "rand",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -3129,6 +3513,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "toon-format",
 ]
 
 [[package]]
@@ -3154,6 +3539,7 @@ dependencies = [
  "sha2",
  "thiserror 2.0.18",
  "toml",
+ "toon-format",
  "tree-sitter",
  "tree-sitter-c",
  "tree-sitter-cpp",
@@ -3203,6 +3589,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str 0.8.2",
+ "crossterm 0.28.1",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -3428,6 +3835,12 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
@@ -3443,6 +3856,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3450,7 +3876,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3700,6 +4126,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3797,6 +4244,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3834,6 +4303,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "onig",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 2.0.18",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3842,7 +4332,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3884,6 +4374,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "tiktoken-rs"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a19830747d9034cd9da43a60eaa8e552dfda7712424aebf187b7a60126bae0d"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bstr",
+ "fancy-regex 0.13.0",
+ "lazy_static",
+ "regex",
+ "rustc-hash 1.1.0",
 ]
 
 [[package]]
@@ -3960,11 +4479,11 @@ checksum = "a620b996116a59e184c2fa2dfd8251ea34a36d0a514758c6f966386bd2e03476"
 dependencies = [
  "ahash",
  "aho-corasick",
- "compact_str",
+ "compact_str 0.9.1",
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
- "fancy-regex",
+ "fancy-regex 0.14.0",
  "getrandom 0.3.4",
  "indicatif 0.17.11",
  "itertools 0.14.0",
@@ -3994,7 +4513,7 @@ checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
 dependencies = [
  "ahash",
  "aho-corasick",
- "compact_str",
+ "compact_str 0.9.1",
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
@@ -4107,6 +4626,29 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "toon-format"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f89570c1a68d73941f728cca32a4345b2ffca36667ad921af336c60309a3e7e"
+dependencies = [
+ "anyhow",
+ "arboard",
+ "chrono",
+ "clap",
+ "comfy-table",
+ "crossterm 0.28.1",
+ "indexmap",
+ "ratatui",
+ "serde",
+ "serde_json",
+ "syntect",
+ "thiserror 2.0.18",
+ "tiktoken-rs",
+ "tui-textarea",
+ "unicode-width 0.2.0",
+]
 
 [[package]]
 name = "tower"
@@ -4261,6 +4803,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tui-textarea"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae"
+dependencies = [
+ "crossterm 0.28.1",
+ "ratatui",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4303,10 +4856,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-truncate"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -4608,6 +5178,12 @@ checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -4971,6 +5547,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix 1.1.4",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5084,3 +5686,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ serde_json = "1.0"
 sha2 = "0.11"
 thiserror = "2.0"
 tokio = { version = "1.48", features = ["rt-multi-thread", "macros", "io-std"] }
+# TOON (Token-Oriented Object Notation): the default render for CLI + MCP output. ~34% fewer tokens
+# than compact JSON on uniform-row payloads, neutral on nested ones — see rag_rat_core::output.
+toon-format = "0.5.0"
 toml = "1.1"
 # Grammar crates are exact-pinned so parser node coverage changes deliberately.
 tree-sitter = "=0.26.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,9 @@ thiserror = "2.0"
 tokio = { version = "1.48", features = ["rt-multi-thread", "macros", "io-std"] }
 # TOON (Token-Oriented Object Notation): the default render for CLI + MCP output. ~34% fewer tokens
 # than compact JSON on uniform-row payloads, neutral on nested ones — see rag_rat_core::output.
-toon-format = "0.5.0"
+# default-features = false drops its `cli` feature (ratatui/crossterm/arboard/syntect/tiktoken-rs/…)
+# — we only need the library encode/decode surface.
+toon-format = { version = "0.5.0", default-features = false }
 toml = "1.1"
 # Grammar crates are exact-pinned so parser node coverage changes deliberately.
 tree-sitter = "=0.26.9"

--- a/README.md
+++ b/README.md
@@ -512,6 +512,27 @@ See [`docs/bencher.md`](docs/bencher.md) for how the signals are wired.
 Commands read `rag-rat.toml` by default. Use `--config <path>` when running from another directory
 or with another repository profile.
 
+### Output format
+
+By default the CLI emits **TOON** (Token-Oriented Object Notation) — a token-efficient text
+encoding that renders uniform result rows (`query`, `clusters`, symbol/caller lists) as a dense
+`[N]{cols}:` table. On those payloads TOON is ~30% smaller than compact JSON (and well under half
+the size of pretty JSON); on nested payloads it ties compact JSON, so it never costs more in
+practice. Pass the global `--json` flag (before or after the subcommand) when a JSON parser must
+read the output:
+
+```bash
+rag-rat query "semantic recall"           # TOON (default)
+rag-rat --json query "semantic recall"    # JSON
+rag-rat query "semantic recall" --json    # JSON (global flag, either position)
+```
+
+For commands that print a human summary by default (`reconcile --plan`, `eval`, `memory doctor`),
+`--json` selects their structured JSON output instead of the summary.
+
+The MCP server's tool results default to TOON as well — they are text content read by an LLM, so the
+denser encoding is both valid and cheaper. There is no per-call flag; MCP output is always TOON.
+
 ```bash
 rag-rat index
 rag-rat index --changed

--- a/README.md
+++ b/README.md
@@ -531,7 +531,9 @@ For commands that print a human summary by default (`reconcile --plan`, `eval`, 
 `--json` selects their structured JSON output instead of the summary.
 
 The MCP server's tool results default to TOON as well — they are text content read by an LLM, so the
-denser encoding is both valid and cheaper. There is no per-call flag; MCP output is always TOON.
+denser encoding is both valid and cheaper. MCP has no per-call flag, so the format is chosen once at
+launch: start the server as `rag-rat mcp --json` (in your MCP client config's `args`) to get JSON
+tool results instead — the escape hatch for a client that still parses tool text as JSON.
 
 ```bash
 rag-rat index

--- a/crates/rag-rat-cli/Cargo.toml
+++ b/crates/rag-rat-cli/Cargo.toml
@@ -26,6 +26,10 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 
+[dev-dependencies]
+# MCP tool results render as TOON; integration tests decode them back to JSON Values to assert.
+toon-format.workspace = true
+
 [features]
 default = ["fastembed", "model2vec"]
 fastembed = ["rag-rat-core/fastembed", "rag-rat-mcp/fastembed"]

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -19,6 +19,13 @@ pub(crate) struct Cli {
     #[arg(long, global = true, default_value = "rag-rat.toml")]
     pub config: String,
 
+    /// Emit JSON instead of the default TOON (Token-Oriented Object Notation). TOON is denser for
+    /// LLM consumers; pass --json when a JSON parser must read the output. For commands that print
+    /// a human summary by default (`reconcile --plan`, `eval`, `memory doctor`), --json also
+    /// selects their structured output.
+    #[arg(long, global = true)]
+    pub json: bool,
+
     #[command(subcommand)]
     pub command: Command,
 }
@@ -176,9 +183,6 @@ pub(crate) struct ReconcileArgs {
     /// Report the reconcile plan without computing embeddings.
     #[arg(long)]
     pub plan: bool,
-    /// Emit JSON (implied for --plan when set together).
-    #[arg(long)]
-    pub json: bool,
     /// Cap on chunks to embed this pass.
     #[arg(long)]
     pub limit: Option<u32>,
@@ -217,9 +221,6 @@ pub(crate) struct EvalArgs {
     /// Defaults to <root>/evals/oracle.scip when present; absent → oracle metrics skipped.
     #[arg(long)]
     pub scip: Option<PathBuf>,
-    /// Emit JSON instead of the summary.
-    #[arg(long)]
-    pub json: bool,
 }
 
 #[derive(Debug, Args)]
@@ -287,10 +288,7 @@ pub(crate) enum MemoryCommand {
     /// Show one memory by id.
     Show { memory_id: String },
     /// Report non-current anchors with rebind suggestions.
-    Doctor {
-        #[arg(long)]
-        json: bool,
-    },
+    Doctor,
     /// Re-anchor a memory to a symbol, path, or chunk.
     Rebind {
         memory_id: String,
@@ -410,6 +408,16 @@ mod tests {
     fn config_defaults_to_rag_rat_toml() {
         let cli = Cli::try_parse_from(["rag-rat", "gc"]).expect("parse");
         assert_eq!(cli.config, "rag-rat.toml");
+    }
+
+    #[test]
+    fn json_flag_defaults_off_and_is_global() {
+        // Absent → TOON (false). Present after the subcommand (global) → JSON (true).
+        let default = Cli::try_parse_from(["rag-rat", "gc"]).expect("parse");
+        assert!(!default.json, "--json must default off (TOON is the default render)");
+
+        let flagged = Cli::try_parse_from(["rag-rat", "query", "foo", "--json"]).expect("parse");
+        assert!(flagged.json, "--json must be accepted globally, after the subcommand");
     }
 
     #[test]

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -1,9 +1,30 @@
+use std::sync::OnceLock;
+
+use rag_rat_core::OutputFormat;
+
 use super::*;
 use crate::cli::{
     BriefArgs, ClustersArgs, EvalArgs, GithubArgs, GithubCommand, HookAction, HooksArgs, IndexArgs,
     MaintenanceArgs, MemoryArgs, MemoryCommand, ModelsArgs, ModelsCommand, OracleArgs,
     OracleCommand, OracleRunArgs, OracleStatusArgs, QueryArgs, ReconcileArgs,
 };
+
+/// Process-wide output format, set once from the global `--json` flag in `main` before any command
+/// runs. A `OnceLock` keeps `print_output` (~30 call sites) from threading an `OutputFormat`
+/// through every command signature; it defaults to TOON if `main` never sets it (e.g. a unit test
+/// calling a command helper directly).
+static OUTPUT_FORMAT: OnceLock<OutputFormat> = OnceLock::new();
+
+/// Set the global output format. Called once from `main` from the parsed `--json` flag; a second
+/// call is a no-op (`OnceLock::set` returns `Err`), so tests can't accidentally clobber it.
+pub(crate) fn set_output_format(format: OutputFormat) {
+    let _ = OUTPUT_FORMAT.set(format);
+}
+
+/// The format `print_output` renders in — TOON unless `main` set JSON from `--json`.
+pub(crate) fn output_format() -> OutputFormat {
+    OUTPUT_FORMAT.get().copied().unwrap_or_default()
+}
 
 pub(crate) fn index(config: &Config, args: &IndexArgs) -> anyhow::Result<()> {
     if args.watch {
@@ -33,7 +54,7 @@ pub(crate) fn index(config: &Config, args: &IndexArgs) -> anyhow::Result<()> {
     if doctor_count > 0 {
         eprintln!("⚠ {doctor_count} repo memories need re-anchoring — run 'rag-rat memory doctor'");
     }
-    print_json(&db.status(&config.database)?)
+    print_output(&db.status(&config.database)?)
 }
 pub(crate) fn query(config: &Config, args: &QueryArgs) -> anyhow::Result<()> {
     let query = args.query.join(" ");
@@ -45,12 +66,12 @@ pub(crate) fn query(config: &Config, args: &QueryArgs) -> anyhow::Result<()> {
         print_query_explain(&db.search_explain(&query, 10, false)?);
         return Ok(());
     }
-    print_json(&db.search(&query, 10, false)?)
+    print_output(&db.search(&query, 10, false)?)
 }
 pub(crate) fn brief(config: &Config, args: &BriefArgs) -> anyhow::Result<()> {
     let db = open_index(config)?;
     let mode = rag_rat_core::query::repo_brief::RepoBriefMode::parse(args.mode.as_deref())?;
-    print_json(&db.repo_brief(rag_rat_core::query::repo_brief::RepoBriefOptions {
+    print_output(&db.repo_brief(rag_rat_core::query::repo_brief::RepoBriefOptions {
         mode,
         limit: args.limit.unwrap_or(10),
         include_generated: args.include_generated,
@@ -59,7 +80,7 @@ pub(crate) fn brief(config: &Config, args: &BriefArgs) -> anyhow::Result<()> {
 }
 pub(crate) fn clusters(config: &Config, args: &ClustersArgs) -> anyhow::Result<()> {
     let db = open_index(config)?;
-    print_json(&db.repo_clusters(rag_rat_core::query::clusters::RepoClustersOptions {
+    print_output(&db.repo_clusters(rag_rat_core::query::clusters::RepoClustersOptions {
         limit: args.limit.unwrap_or(10),
         include_generated: args.include_generated,
         include_memories: !args.no_memories,
@@ -81,7 +102,7 @@ pub(crate) fn dump_config(config: &Config) -> anyhow::Result<()> {
             })
         })
         .collect::<Vec<_>>();
-    print_json(&serde_json::json!({
+    print_output(&serde_json::json!({
         "root": config.root,
         "database": config.database,
         "local_ai": {
@@ -114,8 +135,10 @@ pub(crate) fn eval(config: &Config, args: &EvalArgs) -> anyhow::Result<()> {
         }),
     };
     let report = rag_rat_core::eval::run(config, &options)?;
-    if args.json || options.update_baseline {
-        print_json(&report)?;
+    // `eval` prints a greppable human summary by default; the global `--json` (or a baseline
+    // rewrite, which needs the machine record) switches to the structured report.
+    if output_format() == OutputFormat::Json || options.update_baseline {
+        print_output(&report)?;
     } else {
         print_eval_summary(&report);
     }
@@ -190,7 +213,7 @@ fn oracle_run(config: &Config, args: &OracleRunArgs) -> anyhow::Result<()> {
         let report = with_oracle_write_lock(config, |db| {
             db.run_oracle_from_scip(tool, &tool_version, &scip_bytes)
         })?;
-        return print_json(&serde_json::json!({
+        return print_output(&serde_json::json!({
             "outcome": "completed",
             "tool": tool.as_db_str(),
             "tool_version": tool_version,
@@ -210,7 +233,7 @@ fn oracle_run(config: &Config, args: &OracleRunArgs) -> anyhow::Result<()> {
         rag_rat_core::index::oracle::probe_oracle_tool(tool)
     {
         eprintln!("oracle: {hint}");
-        return print_json(&rag_rat_core::index::oracle::OracleRunOutcome::Blocked {
+        return print_output(&rag_rat_core::index::oracle::OracleRunOutcome::Blocked {
             tool,
             program,
             hint,
@@ -238,7 +261,7 @@ fn oracle_run(config: &Config, args: &OracleRunArgs) -> anyhow::Result<()> {
     match production? {
         rag_rat_core::index::oracle::ScipProduction::Blocked { tool, program, hint } => {
             eprintln!("oracle: {hint}");
-            print_json(&rag_rat_core::index::oracle::OracleRunOutcome::Blocked {
+            print_output(&rag_rat_core::index::oracle::OracleRunOutcome::Blocked {
                 tool,
                 program,
                 hint,
@@ -259,7 +282,7 @@ fn oracle_run(config: &Config, args: &OracleRunArgs) -> anyhow::Result<()> {
             let report = with_oracle_write_lock(config, |db| {
                 db.run_oracle(tool, &version, &bytes, Some(&production_sha), Some(&pre_spawn_sha))
             })?;
-            print_json(&serde_json::json!({
+            print_output(&serde_json::json!({
                 "outcome": "completed",
                 "tool": tool.as_db_str(),
                 "tool_version": version,
@@ -293,21 +316,23 @@ fn oracle_status(db: &IndexDatabase, args: &OracleStatusArgs) -> anyhow::Result<
             "verdicts": status,
         }));
     }
-    print_json(&entries)
+    print_output(&entries)
 }
 pub(crate) fn models(config: &Config, args: &ModelsArgs) -> anyhow::Result<()> {
     let db = open_index(config)?;
     match &args.command {
-        None | Some(ModelsCommand::List) => print_json(&db.list_models()?),
-        Some(ModelsCommand::Install { model_id }) => print_json(&db.install_model(model_id)?),
+        None | Some(ModelsCommand::List) => print_output(&db.list_models()?),
+        Some(ModelsCommand::Install { model_id }) => print_output(&db.install_model(model_id)?),
     }
 }
 pub(crate) fn reconcile(config: &Config, args: &ReconcileArgs) -> anyhow::Result<()> {
     let db = open_index(config)?;
     if args.plan {
         let plan = db.reconcile_plan()?;
-        if args.json {
-            print_json(&plan)?;
+        // `--plan` prints a human summary by default; the global `--json` switches to the
+        // structured plan.
+        if output_format() == OutputFormat::Json {
+            print_output(&plan)?;
         } else {
             print_reconcile_plan(&plan);
         }
@@ -332,7 +357,7 @@ pub(crate) fn reconcile(config: &Config, args: &ReconcileArgs) -> anyhow::Result
     if non_current > 0 {
         eprintln!("⚠ {non_current} repo memories need re-anchoring — run 'rag-rat memory doctor'");
     }
-    print_json(&report)
+    print_output(&report)
 }
 pub(crate) fn run_watch(config: Config) -> anyhow::Result<()> {
     let Some(_watcher) = rag_rat_core::watch::Watcher::spawn(config.clone()) else {
@@ -378,7 +403,7 @@ pub(crate) fn doctor(config: &Config) -> anyhow::Result<()> {
         } else {
             (None, None, None)
         };
-    print_json(&serde_json::json!({
+    print_output(&serde_json::json!({
         "config_root": config.root,
         "database": config.database,
         "schema": schema,
@@ -428,11 +453,13 @@ fn chunk_bind_target(chunk_id: i64) -> rag_rat_core::query::memory::RepoMemoryBi
 
 pub(crate) fn memory(config: &Config, args: &MemoryArgs) -> anyhow::Result<()> {
     match &args.command {
-        MemoryCommand::Doctor { json } => {
+        MemoryCommand::Doctor => {
             let db = open_index(config)?;
             let entries = db.memory_doctor()?;
-            if *json {
-                print_json(&entries)?;
+            // Human-readable rebind suggestions by default; the global `--json` emits the
+            // structured doctor entries instead.
+            if output_format() == OutputFormat::Json {
+                print_output(&entries)?;
                 let any_gone = entries.iter().any(|e| e.anchor_status == "gone");
                 if any_gone {
                     anyhow::bail!("one or more memories have gone anchors");
@@ -519,7 +546,7 @@ pub(crate) fn memory(config: &Config, args: &MemoryArgs) -> anyhow::Result<()> {
                      --symbol-id <id>, --path <path>, --chunk <id>, or --dir <dir>"
                 );
             };
-            print_json(&db.memory_rebind(memory_id, bind)?)
+            print_output(&db.memory_rebind(memory_id, bind)?)
         },
         MemoryCommand::List { kind } => {
             let db = open_index(config)?;
@@ -567,7 +594,7 @@ pub(crate) fn github(config: &Config, args: &GithubArgs) -> anyhow::Result<()> {
             } else {
                 anyhow::bail!("github sync needs --from-refs or --issue <owner/repo#number>");
             };
-            print_json(&report)
+            print_output(&report)
         },
     }
 }
@@ -584,7 +611,7 @@ pub(crate) fn hooks(config: &Config, args: &HooksArgs) -> anyhow::Result<()> {
                 install_hook(&git.hooks_dir, hook)?;
                 installed.push(*hook);
             }
-            print_json(&serde_json::json!({
+            print_output(&serde_json::json!({
                 "status": "installed",
                 "repo_root": git.worktree_root,
                 "git_dir": git.git_dir,
@@ -608,7 +635,7 @@ pub(crate) fn hooks(config: &Config, args: &HooksArgs) -> anyhow::Result<()> {
                     kept.push(*hook);
                 }
             }
-            print_json(&serde_json::json!({
+            print_output(&serde_json::json!({
                 "status": "uninstalled",
                 "hooks_dir": git.hooks_dir,
                 "removed": removed,
@@ -629,7 +656,7 @@ pub(crate) fn hooks(config: &Config, args: &HooksArgs) -> anyhow::Result<()> {
                     })
                 })
                 .collect::<Vec<_>>();
-            print_json(&serde_json::json!({
+            print_output(&serde_json::json!({
                 "repo_root": git.worktree_root,
                 "git_dir": git.git_dir,
                 "git_common_dir": git.git_common_dir,
@@ -648,7 +675,7 @@ pub(crate) fn claude_hooks(config: &Config, subcommand: &str, global: bool) -> a
             if changed {
                 claude_settings::write_settings(&path, &settings)?;
             }
-            print_json(&serde_json::json!({
+            print_output(&serde_json::json!({
                 "status": if changed { "installed" } else { "already_installed" },
                 "settings_path": path,
                 "matchers": ["Grep", "Bash"],
@@ -659,14 +686,14 @@ pub(crate) fn claude_hooks(config: &Config, subcommand: &str, global: bool) -> a
             if changed {
                 claude_settings::write_settings(&path, &settings)?;
             }
-            print_json(&serde_json::json!({
+            print_output(&serde_json::json!({
                 "status": if changed { "uninstalled" } else { "not_installed" },
                 "settings_path": path,
             }))
         },
         "status" => {
             let status = claude_settings::hook_status(&settings);
-            print_json(&serde_json::json!({
+            print_output(&serde_json::json!({
                 "settings_path": path,
                 "pretooluse_installed": status.pretooluse,
                 "session_start_installed": status.session_start,
@@ -684,7 +711,7 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
     let started = Instant::now();
 
     if trigger == "post-checkout" && branch_checkout.as_deref() == Some("0") {
-        print_json(&serde_json::json!({
+        print_output(&serde_json::json!({
             "trigger": trigger,
             "status": "skipped",
             "reason": "file checkout",
@@ -728,7 +755,7 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
     // leaving stale anchors until a manual memory_validate.
     let memory_validation = db.memory_validate().ok();
     let plan = db.reconcile_plan()?;
-    print_json(&serde_json::json!({
+    print_output(&serde_json::json!({
         "trigger": trigger,
         "status": "complete",
         "old_head": old_head,

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -551,6 +551,11 @@ pub(crate) fn memory(config: &Config, args: &MemoryArgs) -> anyhow::Result<()> {
         MemoryCommand::List { kind } => {
             let db = open_index(config)?;
             let summaries = db.memory_list(kind.as_deref())?;
+            // The global `--json` emits the structured list (a caller parsing stdout gets JSON, not
+            // the human lines below).
+            if output_format() == OutputFormat::Json {
+                return print_output(&summaries);
+            }
             if summaries.is_empty() {
                 eprintln!("No memories found.");
                 return Ok(());
@@ -568,6 +573,10 @@ pub(crate) fn memory(config: &Config, args: &MemoryArgs) -> anyhow::Result<()> {
             let Some(memory) = db.memory_get(memory_id)? else {
                 anyhow::bail!("memory `{memory_id}` not found");
             };
+            // The global `--json` emits the structured memory instead of the human view below.
+            if output_format() == OutputFormat::Json {
+                return print_output(&memory);
+            }
             println!("Title:      {}", memory.title);
             println!("Kind:       {} / {} / {}", memory.kind, memory.status, memory.confidence);
             println!();

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -28,6 +28,15 @@ mod init;
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
+    // Pin the process-wide output format from the global flag before any command runs, so
+    // `print_output` renders TOON by default and JSON under `--json` without threading the format
+    // through every command signature.
+    set_output_format(if cli.json {
+        rag_rat_core::OutputFormat::Json
+    } else {
+        rag_rat_core::OutputFormat::Toon
+    });
+
     // These commands must work without a config file present — `init` creates one, and the
     // Claude Code hook entrypoint reads its event from stdin. Everything else needs a config.
     match &cli.command {
@@ -66,7 +75,7 @@ fn main() -> anyhow::Result<()> {
         Cmd::Reconcile(args) => reconcile(&config, &args)?,
         Cmd::Gc => {
             let db = open_index(&config)?;
-            print_json(&db.gc()?)?;
+            print_output(&db.gc()?)?;
         },
         Cmd::Eval(args) => eval(&config, &args)?,
         Cmd::Oracle(args) => oracle(&config, &args)?,

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -65,7 +65,14 @@ fn main() -> anyhow::Result<()> {
                 .worker_threads(2)
                 .enable_all()
                 .build()?
-                .block_on(rag_rat_mcp::server::run_stdio(config))?;
+                .block_on(rag_rat_mcp::server::run_stdio(
+                    config,
+                    if cli.json {
+                        rag_rat_core::OutputFormat::Json
+                    } else {
+                        rag_rat_core::OutputFormat::Toon
+                    },
+                ))?;
         },
         Cmd::Memory(args) => memory(&config, &args)?,
         Cmd::Github(args) => github(&config, &args)?,

--- a/crates/rag-rat-cli/src/render.rs
+++ b/crates/rag-rat-cli/src/render.rs
@@ -212,8 +212,11 @@ pub(crate) fn render_github_sync_progress(
         },
     }
 }
-pub(crate) fn print_json(value: &impl serde::Serialize) -> anyhow::Result<()> {
-    println!("{}", serde_json::to_string_pretty(value)?);
+/// Print a serializable result in the process-wide output format (TOON by default, JSON under
+/// `--json`). Renamed from `print_json` because it is no longer always JSON — the format is the
+/// global flag's choice, read from `output_format()`.
+pub(crate) fn print_output(value: &impl serde::Serialize) -> anyhow::Result<()> {
+    println!("{}", rag_rat_core::render(value, output_format()));
     Ok(())
 }
 pub(crate) fn render_index_progress(progress: IndexProgress) {

--- a/crates/rag-rat-cli/tests/mcp_hot_upgrade.rs
+++ b/crates/rag-rat-cli/tests/mcp_hot_upgrade.rs
@@ -35,7 +35,7 @@ fn sigusr1_hot_upgrade_resumes_session_in_place() {
     session.initialize();
 
     let before = session.call_semantic_search();
-    assert!(before["chunk_id"].as_i64().is_some(), "tool call works before upgrade");
+    assert!(before.contains("chunk_id"), "tool call works before upgrade: {before}");
 
     session.send_sigusr1();
     wait_for(&sentinel, Duration::from_secs(20)); // the wrapper ran ⇒ we `exec`'d the new binary.
@@ -43,7 +43,7 @@ fn sigusr1_hot_upgrade_resumes_session_in_place() {
     // No re-`initialize`: a cold server would reject this. A successful result proves the resumed
     // process skipped the handshake via `serve_directly`.
     let after = session.call_semantic_search();
-    assert!(after["chunk_id"].as_i64().is_some(), "session resumed transparently after exec");
+    assert!(after.contains("chunk_id"), "session resumed transparently after exec: {after}");
 
     // The grep-augment hook socket must answer *after* the in-place `exec`: the old process's lock
     // fd and bound socket died with the exec'd image, so the resumed process has to re-run the
@@ -172,8 +172,9 @@ impl Session {
         self.send(json!({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}));
     }
 
-    /// Issue a `semantic_search` tool call and return its decoded first hit (or the raw payload).
-    fn call_semantic_search(&mut self) -> Value {
+    /// Issue a `semantic_search` tool call and return its raw text result. MCP results are rendered
+    /// as TOON (not JSON), so callers assert on the text rather than parsing it as JSON.
+    fn call_semantic_search(&mut self) -> String {
         let id = self.take_id();
         self.send(json!({
             "jsonrpc": "2.0",
@@ -182,11 +183,10 @@ impl Session {
             "params": {"name": "semantic_search", "arguments": {"query": "search", "limit": 1}}
         }));
         let response = self.recv();
-        let text = response["result"]["content"][0]["text"]
+        response["result"]["content"][0]["text"]
             .as_str()
-            .unwrap_or_else(|| panic!("tool call had no text result: {response}"));
-        let hits: Value = serde_json::from_str(text).unwrap();
-        hits.as_array().and_then(|array| array.first().cloned()).unwrap_or(hits)
+            .unwrap_or_else(|| panic!("tool call had no text result: {response}"))
+            .to_string()
     }
 
     fn send_sigusr1(&self) {

--- a/crates/rag-rat-cli/tests/mcp_stdio.rs
+++ b/crates/rag-rat-cli/tests/mcp_stdio.rs
@@ -119,6 +119,70 @@ fn mcp_stdio_smoke_lists_and_calls_core_tools() {
     fs::remove_dir_all(root).unwrap();
 }
 
+#[test]
+fn mcp_stdio_json_flag_emits_json_not_toon() {
+    // `rag-rat mcp --json` is the MCP-side escape hatch: MCP has no per-call flag, so the output
+    // format is chosen once at launch. With it, tool results are JSON (parseable directly), not the
+    // default TOON (which `serde_json::from_str` would reject).
+    let root = unique_temp_root();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn open_database() {}\n").unwrap();
+    fs::write(
+        root.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\ndatabase = \".rag-rat/index.sqlite\"\n\n[target_bindings]\nrust = \
+         [\"src\"]\n",
+    )
+    .unwrap();
+    let config_path = root.join("rag-rat.toml");
+    let config = Config::load(&config_path).unwrap();
+    rag_rat_core::IndexDatabase::rebuild(&config).unwrap();
+
+    let binary = env!("CARGO_BIN_EXE_rag-rat");
+    let mut child = Command::new(binary)
+        .arg("mcp")
+        .arg("--json")
+        .arg("--config")
+        .arg(&config_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    let stdout = child.stdout.take().unwrap();
+    let mut reader = BufReader::new(stdout);
+
+    send(
+        &mut stdin,
+        json!({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {"protocolVersion": "2024-11-05", "capabilities": {},
+                       "clientInfo": {"name": "rag-rat-test", "version": "0.1"}}
+        }),
+    );
+    let _ = recv(&mut reader);
+    send(
+        &mut stdin,
+        json!({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}),
+    );
+    send(
+        &mut stdin,
+        json!({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": {"name": "semantic_search", "arguments": {"query": "database", "limit": 1}}
+        }),
+    );
+    let response = recv(&mut reader);
+    let text = response["result"]["content"][0]["text"].as_str().unwrap();
+    // The escape hatch: this parses as JSON directly (a TOON `[N]{cols}:` payload would not).
+    let parsed: Value = serde_json::from_str(text)
+        .unwrap_or_else(|err| panic!("MCP result under --json is not valid JSON ({err}):\n{text}"));
+    assert!(parsed.is_array() || parsed.is_object(), "expected a JSON array/object, got: {text}");
+
+    stop(child);
+    fs::remove_dir_all(root).unwrap();
+}
+
 fn send(stdin: &mut impl Write, value: Value) {
     writeln!(stdin, "{}", serde_json::to_string(&value).unwrap()).unwrap();
     stdin.flush().unwrap();

--- a/crates/rag-rat-cli/tests/mcp_stdio.rs
+++ b/crates/rag-rat-cli/tests/mcp_stdio.rs
@@ -131,9 +131,12 @@ fn recv(reader: &mut impl BufRead) -> Value {
     serde_json::from_str(&line).unwrap()
 }
 
+/// Decode an MCP tool result into a JSON `Value`. Tool results are rendered as TOON (the server
+/// default), so the text is TOON, not JSON — decode it back through `toon_format` to assert on it.
 fn response_text_json(response: Value) -> Value {
     let text = response["result"]["content"][0]["text"].as_str().unwrap();
-    serde_json::from_str(text).unwrap()
+    toon_format::decode(text, &toon_format::DecodeOptions::default())
+        .unwrap_or_else(|err| panic!("MCP result is not valid TOON ({err}):\n{text}"))
 }
 
 fn stop(mut child: Child) {

--- a/crates/rag-rat-cli/tests/output_format.rs
+++ b/crates/rag-rat-cli/tests/output_format.rs
@@ -1,0 +1,76 @@
+//! End-to-end check that the CLI defaults to TOON and `--json` flips it to JSON.
+//!
+//! `query` emits a uniform-row payload (the hit list), so the default render must produce TOON's
+//! dense form, while `--json` must produce parseable JSON. Both run against a tiny throwaway index.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use rag_rat_core::Config;
+
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_temp_root() -> PathBuf {
+    let root = std::env::temp_dir().join(format!(
+        "rag-rat-cli-output-{}-{}",
+        std::process::id(),
+        TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = fs::remove_dir_all(&root);
+    root
+}
+
+/// Build a throwaway index over one Rust file and return the config path the CLI should use.
+fn build_index() -> (PathBuf, PathBuf) {
+    let root = unique_temp_root();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn open_database() {}\npub fn close_database() {}\n")
+        .unwrap();
+    fs::write(
+        root.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\ndatabase = \".rag-rat/index.sqlite\"\n\n[target_bindings]\nrust = \
+         [\"src\"]\n",
+    )
+    .unwrap();
+    let config_path = root.join("rag-rat.toml");
+    let config = Config::load(&config_path).unwrap();
+    rag_rat_core::IndexDatabase::rebuild(&config).unwrap();
+    (root, config_path)
+}
+
+fn run_query(config_path: &PathBuf, json: bool) -> String {
+    let binary = env!("CARGO_BIN_EXE_rag-rat");
+    let mut cmd = Command::new(binary);
+    cmd.arg("--config").arg(config_path);
+    if json {
+        cmd.arg("--json");
+    }
+    cmd.arg("query").arg("database");
+    let out = cmd.output().unwrap();
+    assert!(out.status.success(), "query failed: {}", String::from_utf8_lossy(&out.stderr));
+    String::from_utf8(out.stdout).unwrap()
+}
+
+#[test]
+fn cli_defaults_to_toon_and_json_flag_flips_to_json() {
+    let (root, config_path) = build_index();
+
+    // Default: TOON. The hit list renders as a TOON object — and is NOT parseable as JSON (TOON's
+    // bare-key / tabular form is not a JSON document), which is the strongest single signal that
+    // the default is not JSON.
+    let toon = run_query(&config_path, false);
+    assert!(
+        serde_json::from_str::<serde_json::Value>(&toon).is_err(),
+        "default output parsed as JSON — TOON is supposed to be the default:\n{toon}"
+    );
+
+    // `--json`: valid, parseable JSON.
+    let json = run_query(&config_path, true);
+    let parsed: serde_json::Value = serde_json::from_str(&json)
+        .unwrap_or_else(|err| panic!("--json output is not valid JSON ({err}):\n{json}"));
+    assert!(parsed.is_object() || parsed.is_array(), "unexpected JSON shape:\n{json}");
+
+    let _ = fs::remove_dir_all(&root);
+}

--- a/crates/rag-rat-cli/tests/output_format.rs
+++ b/crates/rag-rat-cli/tests/output_format.rs
@@ -40,16 +40,21 @@ fn build_index() -> (PathBuf, PathBuf) {
     (root, config_path)
 }
 
-fn run_query(config_path: &PathBuf, json: bool) -> String {
+/// Run `rag-rat [--json] <args…>` against the index and return stdout (asserting success).
+fn run(config_path: &PathBuf, json: bool, args: &[&str]) -> String {
     let binary = env!("CARGO_BIN_EXE_rag-rat");
     let mut cmd = Command::new(binary);
     cmd.arg("--config").arg(config_path);
     if json {
         cmd.arg("--json");
     }
-    cmd.arg("query").arg("database");
+    cmd.args(args);
     let out = cmd.output().unwrap();
-    assert!(out.status.success(), "query failed: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        out.status.success(),
+        "`{args:?}` failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
     String::from_utf8(out.stdout).unwrap()
 }
 
@@ -60,17 +65,48 @@ fn cli_defaults_to_toon_and_json_flag_flips_to_json() {
     // Default: TOON. The hit list renders as a TOON object — and is NOT parseable as JSON (TOON's
     // bare-key / tabular form is not a JSON document), which is the strongest single signal that
     // the default is not JSON.
-    let toon = run_query(&config_path, false);
+    let toon = run(&config_path, false, &["query", "database"]);
     assert!(
         serde_json::from_str::<serde_json::Value>(&toon).is_err(),
         "default output parsed as JSON — TOON is supposed to be the default:\n{toon}"
     );
 
     // `--json`: valid, parseable JSON.
-    let json = run_query(&config_path, true);
+    let json = run(&config_path, true, &["query", "database"]);
     let parsed: serde_json::Value = serde_json::from_str(&json)
         .unwrap_or_else(|err| panic!("--json output is not valid JSON ({err}):\n{json}"));
     assert!(parsed.is_object() || parsed.is_array(), "unexpected JSON shape:\n{json}");
 
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// Every read command that prints structured output through `print_output` must honor the global
+/// format: TOON object by default (not JSON-parseable), valid JSON under `--json`. Covers the
+/// per-handler output branches (`doctor`/`brief`/`clusters`) the format flag threads through.
+#[test]
+fn read_commands_honor_global_format() {
+    let (root, config_path) = build_index();
+    for args in [&["doctor"][..], &["brief"][..], &["clusters"][..]] {
+        let toon = run(&config_path, false, args);
+        assert!(
+            serde_json::from_str::<serde_json::Value>(&toon).is_err(),
+            "`{args:?}` default output parsed as JSON — should be TOON:\n{toon}"
+        );
+        let json = run(&config_path, true, args);
+        serde_json::from_str::<serde_json::Value>(&json)
+            .unwrap_or_else(|err| panic!("`{args:?} --json` is not valid JSON ({err}):\n{json}"));
+    }
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// `memory list` println'd human text and ignored `--json` before this change; under `--json` it
+/// must emit the structured list (here an empty index → a JSON array).
+#[test]
+fn memory_list_json_flag_emits_json() {
+    let (root, config_path) = build_index();
+    let json = run(&config_path, true, &["memory", "list"]);
+    let parsed: serde_json::Value = serde_json::from_str(&json)
+        .unwrap_or_else(|err| panic!("`memory list --json` is not valid JSON ({err}):\n{json}"));
+    assert!(parsed.is_array(), "expected a JSON array of memory summaries, got:\n{json}");
     let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-cli/tests/output_format.rs
+++ b/crates/rag-rat-cli/tests/output_format.rs
@@ -50,11 +50,7 @@ fn run(config_path: &PathBuf, json: bool, args: &[&str]) -> String {
     }
     cmd.args(args);
     let out = cmd.output().unwrap();
-    assert!(
-        out.status.success(),
-        "`{args:?}` failed: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
+    assert!(out.status.success(), "`{args:?}` failed: {}", String::from_utf8_lossy(&out.stderr));
     String::from_utf8(out.stdout).unwrap()
 }
 

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -32,6 +32,7 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 toml.workspace = true
+toon-format.workspace = true
 tree-sitter.workspace = true
 tree-sitter-c.workspace = true
 tree-sitter-cpp.workspace = true

--- a/crates/rag-rat-core/src/lib.rs
+++ b/crates/rag-rat-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod fleet;
 pub mod index;
 pub mod language;
 pub mod locks;
+pub mod output;
 pub mod query;
 pub mod search;
 pub mod storage;
@@ -11,3 +12,4 @@ pub mod watch;
 
 pub use config::{Config, ResolvedTarget, TargetKind, WatchConfig};
 pub use index::{IndexDatabase, IndexStatus};
+pub use output::{OutputFormat, render};

--- a/crates/rag-rat-core/src/output.rs
+++ b/crates/rag-rat-core/src/output.rs
@@ -1,0 +1,125 @@
+//! One source of truth for rendering rag-rat's structured results to text.
+//!
+//! Both surfaces — the `rag-rat` CLI and the MCP server — emit the SAME typed values; only the
+//! wire encoding differs. TOON (Token-Oriented Object Notation) is the default because it is
+//! materially denser than JSON on the uniform-row payloads that dominate rag-rat's output
+//! (`find_callers`, `symbol_lookup`, `repo_clusters`, …), where it renders the tabular
+//! `[N]{cols}:` form and drops ~34% of the tokens of compact JSON; on nested payloads it ties
+//! compact JSON, so it never loses. JSON stays available as an opt-out (`--json` on the CLI) for
+//! tooling that needs to parse the output with a JSON parser.
+
+use serde::Serialize;
+
+/// Wire encoding for a rendered result. Plain enum — the format is a per-invocation choice (a CLI
+/// flag / the MCP default), never persisted, so it carries no `as_db_str` round-trip surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OutputFormat {
+    /// Token-Oriented Object Notation — the default; dense tabular form for uniform rows.
+    #[default]
+    Toon,
+    /// Pretty-printed JSON — the opt-out for JSON-parsing consumers.
+    Json,
+}
+
+/// Render a serializable value to text in the requested format.
+///
+/// TOON: encode via `toon_format`. A TOON encode error never aborts the command — it falls back to
+/// compact JSON so the caller always gets parseable output (capability loss is surfaced as the
+/// less-dense-but-honest format, not a panic or an empty string). JSON: pretty-printed, falling
+/// back to compact only if pretty-printing somehow fails.
+pub fn render<T: Serialize>(value: &T, format: OutputFormat) -> String {
+    match format {
+        OutputFormat::Toon => toon_format::encode(value, &toon_format::EncodeOptions::default())
+            .unwrap_or_else(|_| render_compact_json(value)),
+        OutputFormat::Json =>
+            serde_json::to_string_pretty(value).unwrap_or_else(|_| render_compact_json(value)),
+    }
+}
+
+/// Compact-JSON last resort. Used when the chosen encoder fails; itself falls back to an empty
+/// JSON object string rather than panicking, so `render` is total.
+fn render_compact_json<T: Serialize>(value: &T) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "{}".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Serialize;
+    use serde_json::Value;
+
+    use super::{OutputFormat, render};
+
+    /// A uniform-row payload mirrors the shape of `find_callers` / `symbol_lookup` results: a
+    /// homogeneous array of flat objects carrying provenance fields. TOON must render this as the
+    /// dense tabular `[N]{cols}:` form.
+    #[derive(Serialize)]
+    struct Caller {
+        symbol: String,
+        path: String,
+        confidence: String,
+        completeness_risk: bool,
+    }
+
+    #[derive(Serialize)]
+    struct Callers {
+        callers: Vec<Caller>,
+    }
+
+    fn sample() -> Callers {
+        Callers {
+            callers: vec![
+                Caller {
+                    symbol: "alpha".to_string(),
+                    path: "src/a.rs".to_string(),
+                    confidence: "high".to_string(),
+                    completeness_risk: false,
+                },
+                Caller {
+                    symbol: "beta".to_string(),
+                    path: "src/b.rs".to_string(),
+                    confidence: "low".to_string(),
+                    completeness_risk: true,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn toon_uniform_rows_render_tabular() {
+        let out = render(&sample(), OutputFormat::Toon);
+        // TOON's hallmark dense form for a uniform array: a length-tagged header listing the
+        // shared columns, e.g. `callers[2]{symbol,path,confidence,completeness_risk}:`.
+        assert!(out.contains("callers[2]{"), "expected tabular [N]{{cols}} header, got:\n{out}");
+        // The column header carries every field name once (not repeated per row).
+        assert!(out.contains("confidence"), "missing column header, got:\n{out}");
+        assert!(out.contains("completeness_risk"), "missing column header, got:\n{out}");
+        // Provenance values survive the encoding.
+        assert!(out.contains("high"), "provenance value lost, got:\n{out}");
+    }
+
+    #[test]
+    fn json_round_trips_via_serde() {
+        let out = render(&sample(), OutputFormat::Json);
+        let parsed: Value = serde_json::from_str(&out).expect("--json output must be valid JSON");
+        let callers = parsed.get("callers").and_then(Value::as_array).expect("callers array");
+        assert_eq!(callers.len(), 2);
+        // Provenance fields survive into the JSON path too.
+        assert_eq!(callers[0]["confidence"], "high");
+        assert_eq!(callers[1]["completeness_risk"], true);
+    }
+
+    #[test]
+    fn toon_preserves_all_provenance_fields() {
+        // Both a confidence label and a completeness_risk flag must round-trip through TOON,
+        // since downstream agents key on these provenance signals.
+        let out = render(&sample(), OutputFormat::Toon);
+        for needle in ["confidence", "completeness_risk", "high", "low"] {
+            assert!(out.contains(needle), "TOON dropped `{needle}`, got:\n{out}");
+        }
+    }
+
+    #[test]
+    fn default_format_is_toon() {
+        assert_eq!(OutputFormat::default(), OutputFormat::Toon);
+    }
+}

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -20,6 +20,10 @@ use crate::tools::{
 #[derive(Clone)]
 pub struct RagRatService {
     config: Config,
+    /// Output format for tool results. Defaults to TOON (denser for the LLM that reads them); set
+    /// to JSON when the server was launched as `rag-rat mcp --json` — MCP has no per-call flag, so
+    /// the choice is made once at launch (the CLI `--json` flag flows in via `run_stdio`).
+    output_format: rag_rat_core::OutputFormat,
     /// In-flight tool-call counter, observed by the hot-upgrade teardown so it drains at a request
     /// boundary before `exec`. Present only on Unix, where hot-upgrade is supported.
     #[cfg(unix)]
@@ -27,9 +31,10 @@ pub struct RagRatService {
 }
 
 impl RagRatService {
-    pub fn new(config: Config) -> Self {
+    pub fn new(config: Config, output_format: rag_rat_core::OutputFormat) -> Self {
         Self {
             config,
+            output_format,
             #[cfg(unix)]
             inflight: crate::upgrade::Inflight::new(),
         }
@@ -51,8 +56,9 @@ impl RagRatService {
         // MCP tool results are text content read by an LLM, so render TOON by default — it is
         // materially denser than JSON on the uniform-row payloads that dominate these tools, and
         // ties JSON on nested ones. `render` falls back to compact JSON on a TOON encode error, so
-        // a tool result is never lost. No per-call flag: MCP default is TOON.
-        let text = rag_rat_core::render(&value, rag_rat_core::OutputFormat::Toon);
+        // a tool result is never lost. JSON is reachable by launching `rag-rat mcp --json`
+        // (the format is chosen once at launch; MCP has no per-call flag).
+        let text = rag_rat_core::render(&value, self.output_format);
         Ok(CallToolResult::success(vec![Content::text(text)]))
     }
 }
@@ -471,17 +477,20 @@ impl ServerHandler for RagRatService {
     }
 }
 
-pub async fn run_stdio(config: Config) -> anyhow::Result<()> {
+pub async fn run_stdio(
+    config: Config,
+    output_format: rag_rat_core::OutputFormat,
+) -> anyhow::Result<()> {
     #[cfg(unix)]
     {
-        run_stdio_unix(config).await
+        run_stdio_unix(config, output_format).await
     }
     #[cfg(not(unix))]
     {
         // Keep the index fresh while a session is connected; dropping the watcher on shutdown
         // runs a final timeout-skip pass. (Hot-upgrade is Unix-only.)
         let _watcher = rag_rat_core::watch::Watcher::spawn(config.clone());
-        let service = RagRatService::new(config).serve(stdio()).await?;
+        let service = RagRatService::new(config, output_format).serve(stdio()).await?;
         service.waiting().await?;
         Ok(())
     }
@@ -503,7 +512,10 @@ impl Drop for AbortOnDrop {
 /// Unix `run_stdio`: serves over a [`crate::upgrade::GatedStdin`] so a `SIGUSR1` can hot-`exec`
 /// the newly installed binary in place, and resumes (skipping `initialize`) when handed off to.
 #[cfg(unix)]
-async fn run_stdio_unix(config: Config) -> anyhow::Result<()> {
+async fn run_stdio_unix(
+    config: Config,
+    output_format: rag_rat_core::OutputFormat,
+) -> anyhow::Result<()> {
     use std::sync::Arc;
 
     use rmcp::service::serve_directly;
@@ -512,7 +524,7 @@ async fn run_stdio_unix(config: Config) -> anyhow::Result<()> {
     use crate::upgrade::{self, GatedStdin, Upgrade, UpgradeGate};
 
     let gate = UpgradeGate::new();
-    let service = RagRatService::new(config.clone());
+    let service = RagRatService::new(config.clone(), output_format);
     let inflight = service.inflight();
 
     let transport = (GatedStdin::new(tokio::io::stdin(), Arc::clone(&gate)), tokio::io::stdout());

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -48,8 +48,11 @@ impl RagRatService {
         let _inflight = self.inflight.guard();
         let value = crate::tools::call_tool_for_config(&self.config, name, value)
             .map_err(|err| ErrorData::internal_error(err.to_string(), None))?;
-        let text = serde_json::to_string_pretty(&value)
-            .map_err(|err| ErrorData::internal_error(err.to_string(), None))?;
+        // MCP tool results are text content read by an LLM, so render TOON by default — it is
+        // materially denser than JSON on the uniform-row payloads that dominate these tools, and
+        // ties JSON on nested ones. `render` falls back to compact JSON on a TOON encode error, so
+        // a tool result is never lost. No per-call flag: MCP default is TOON.
+        let text = rag_rat_core::render(&value, rag_rat_core::OutputFormat::Toon);
         Ok(CallToolResult::success(vec![Content::text(text)]))
     }
 }

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -94,6 +94,17 @@ Development config without installing:
 `tools/list` is served by `rmcp` and exposes typed JSON schemas derived from the same request structs
 used by the handlers. Existing tool names and response fields are kept stable for current MCP clients.
 
+### Response encoding (TOON)
+
+Tool **results** are returned as **TOON** (Token-Oriented Object Notation), not JSON. TOON is a
+token-efficient text encoding that renders uniform result rows (caller lists, symbol candidates,
+clusters) as a dense `[N]{cols}:` table — measured ~30% smaller than compact JSON on those payloads,
+and never larger in practice (it ties compact JSON on nested shapes). Because MCP results are text
+content consumed by an LLM, the denser encoding is both valid and cheaper. There is no per-call flag;
+MCP output is always TOON. The JSON snippets below describe the **logical shape** of each response —
+the same fields, just shown in JSON for readability. (The `rag-rat` CLI mirrors this: it defaults to
+TOON and takes a global `--json` flag for JSON output.)
+
 `symbol_lookup` is the candidate-selection step for symbol-shaped tools. It returns:
 
 ```json

--- a/tools/kernel-c-oracle.sh
+++ b/tools/kernel-c-oracle.sh
@@ -70,7 +70,7 @@ echo "kernel-c-oracle: rag-rat index --full" >&2
 
 # The scip-clang oracle pass over the compiled subset (stdout = clean JSON report).
 echo "kernel-c-oracle: oracle run --tool scip-clang" >&2
-( cd "$KDIR" && "$RAG_RAT_BIN" oracle run --tool scip-clang ) > "$WORK/oracle-report.json"
+( cd "$KDIR" && "$RAG_RAT_BIN" oracle run --tool scip-clang --json ) > "$WORK/oracle-report.json"
 
 python3 - "$DB" "$WORK/oracle-report.json" "$TUS" "$BMF_OUT" "$KERNEL_TAG" <<'PY'
 import json, sqlite3, sys

--- a/tools/rust-scip-oracle.sh
+++ b/tools/rust-scip-oracle.sh
@@ -63,7 +63,7 @@ echo "rust-scip-oracle: rag-rat index --full" >&2
 
 # The rust-analyzer oracle pass over the whole workspace (stdout = clean JSON report).
 echo "rust-scip-oracle: oracle run --tool rust-analyzer" >&2
-( cd "$RDIR" && "$RAG_RAT_BIN" oracle run --tool rust-analyzer ) > "$WORK/oracle-report.json"
+( cd "$RDIR" && "$RAG_RAT_BIN" oracle run --tool rust-analyzer --json ) > "$WORK/oracle-report.json"
 
 python3 - "$DB" "$WORK/oracle-report.json" "$BMF_OUT" "$CARGO_TAG" <<'PY'
 import json, sqlite3, sys


### PR DESCRIPTION
Fixes #104.

Make **TOON** (Token-Oriented Object Notation) the default output for the `rag-rat` CLI and the MCP server, with JSON available via a global `--json` flag on the CLI. MCP tool results are now always TOON.

## What changed

- **Shared render helper (one source of truth).** New `rag_rat_core::output` exposes `OutputFormat { Toon, Json }` and `render<T: Serialize>(value, format) -> String`, re-exported from the crate root. TOON via `toon-format = "0.5.0"`; on a TOON encode error it falls back to compact JSON, so `render` never panics.
- **CLI: TOON default, global `--json` opt-out.** A global `--json` bool on the top-level `Cli`; `main` pins the process-wide format once into a `OnceLock<OutputFormat>` before dispatch. `print_json` → `print_output` (reads the global format).
- **MCP: TOON by default.** Tool results render TOON in `server.rs`. No per-call flag (matches the denser-is-better posture for LLM-read text content). Reversible behavior change for MCP consumers.
- **Docs.** README + `docs/mcp-tools.md` note TOON is the default and `--json` returns JSON.

## Reconciling the existing per-command `--json` flags

The pre-existing `--json` on `reconcile --plan`, `eval`, and `memory doctor` were **not** TOON-vs-JSON toggles — they switched between a human summary and structured output. A global `--json` plus a duplicate per-subcommand `--json` would clap-conflict, so the per-command fields were **removed**. Those summary-defaulting commands now emit structured **JSON** under the global `--json` and the human summary otherwise (preserving today's `--json` behavior exactly), so `--json` does double duty there: structured output + JSON encoding.

## Measured deltas (bytes; ~chars/4 ≈ tokens)

Identical decoded values re-encoded three ways:

| Payload | pretty JSON | compact JSON | TOON | TOON vs compact |
|---|---|---|---|---|
| `find_callers` (uniform rows) | 1115 | 827 | 562 | **−32%** |
| `symbol_lookup` (uniform rows) | 1152 | 864 | 599 | **−30%** |
| `impact_surface` (uniform rows) | 1115 | 827 | 562 | **−32%** |
| `semantic_search` (nested) | 3448 | 2025 | 2604 | +28% |

**TOON wins decisively on tabular/uniform-row output** (the dense `[N]{cols}:` form) and is roughly neutral on nested payloads — and since the previous default was *pretty* JSON, TOON is smaller than the old default in **every** case (e.g. nested `semantic_search`: 2604 vs 3448).

## Tests

- `rag_rat_core::output` unit tests: uniform rows encode to the `[N]{cols}:` tabular form; `--json` round-trips via `serde_json`; provenance fields (`confidence`, `completeness_risk`) survive TOON.
- CLI end-to-end test: default output is TOON (not JSON-parseable), `--json` flips to valid JSON.
- clap parse test for the global `--json` flag.
- MCP stdio + hot-upgrade integration tests updated to decode TOON results.
- `cargo test` (workspace), `cargo clippy --all-targets`, `cargo +nightly fmt --check` all clean.

Note: MCP output now defaults to TOON — a reversible behavior change for MCP consumers; the CLI's `--json` covers JSON-parsing callers.
