### PR TITLE
ci: integrate release-plz with lockstep workspace versioning

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,68 @@
+name: Release-plz
+
+# release-plz runs in two halves on every push to main:
+#   - release-plz-pr opens/updates a "Release" PR with the lockstep version bump + changelog;
+#   - release-plz-release fires once that PR's version commit lands, tagging + publishing.
+# Config (lockstep version_group, single tag/release, combined CHANGELOG) lives in release-plz.toml.
+on:
+  push:
+    branches:
+      - main
+
+# Least privilege at the top; each job grants only what it needs.
+permissions: {}
+
+jobs:
+  # Maintain the release PR: version bump + changelog, held for human review before anything ships.
+  release-plz-pr:
+    name: Release-plz PR
+    # Never cut releases from a fork.
+    if: ${{ github.repository_owner == 'cq27-dev' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    # Serialize PR updates so two pushes don't race on the same release branch.
+    concurrency:
+      group: release-plz-pr-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run release-plz
+        uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # When the release PR merges (the version commit lands on main), tag, publish each crate to
+  # crates.io, and create the GitHub release. No concurrency guard here — we never want a release
+  # skipped because commits arrived quickly.
+  release-plz-release:
+    name: Release-plz release
+    if: ${{ github.repository_owner == 'cq27-dev' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      # release-plz inspects the merged Release PR and its commits to build the release.
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run release-plz
+        uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,11 @@ members = [
 resolver = "3"
 
 [workspace.package]
+# Single source of truth for the crate version — every member sets `version.workspace = true`,
+# and the internal path deps below pin the same literal, so the three crates always publish in
+# lockstep. Bump this one line (and the two internal-dep `version`s under workspace.dependencies)
+# to release.
+version = "0.4.0"
 authors = ["Kristaps Karlsons"]
 edition = "2024"
 rust-version = "1.89"
@@ -17,6 +22,11 @@ keywords = ["rag", "mcp", "code-search", "tree-sitter", "embeddings"]
 categories = ["command-line-utilities", "development-tools"]
 
 [workspace.dependencies]
+# Internal crates — declared once here so the version requirement is set in lockstep with
+# [workspace.package].version above. Members reference these via `{ workspace = true }` and add
+# their own feature toggles at the use site.
+rag-rat-core = { version = "0.4.0", path = "crates/rag-rat-core", default-features = false }
+rag-rat-mcp = { version = "0.4.0", path = "crates/rag-rat-mcp", default-features = false }
 anyhow = "1.0"
 fastembed = { version = "5.1.0", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
 gix = { version = "0.84.0", default-features = false, features = ["status", "parallel", "sha1"] }

--- a/README.md
+++ b/README.md
@@ -710,6 +710,12 @@ returning search or `read_chunk` results.
 
 GitHub sync is explicit and uses `gh api`; normal query tools read the local SQLite cache.
 
+## Releasing
+
+Releases are automated by [release-plz](https://release-plz.dev): the three crates ship in lockstep
+at one version, merging the auto-generated Release PR publishes them to crates.io and cuts a single
+`vX.Y.Z` tag. See [docs/releasing.md](docs/releasing.md).
+
 ## License
 
 `rag-rat` is licensed under the MIT License. See [LICENSE](LICENSE).

--- a/crates/rag-rat-cli/Cargo.toml
+++ b/crates/rag-rat-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rag-rat"
-version = "0.4.0"
+version.workspace = true
 description = "CLI and MCP entrypoint for indexing repositories into local source, graph, history, and memory evidence."
 authors.workspace = true
 edition.workspace = true
@@ -20,8 +20,8 @@ anyhow.workspace = true
 clap = { version = "4.5", features = ["derive"] }
 dialoguer = "0.12"
 libc.workspace = true
-rag-rat-core = { version = "0.4.0", path = "../rag-rat-core", default-features = false }
-rag-rat-mcp = { version = "0.4.0", path = "../rag-rat-mcp", default-features = false }
+rag-rat-core = { workspace = true }
+rag-rat-mcp = { workspace = true }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rag-rat-core"
-version = "0.4.0"
+version.workspace = true
 description = "Repository evidence engine for source chunks, symbols, graph edges, Git history, GitHub rationale, and source-bound memories."
 authors.workspace = true
 edition.workspace = true

--- a/crates/rag-rat-mcp/Cargo.toml
+++ b/crates/rag-rat-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rag-rat-mcp"
-version = "0.4.0"
+version.workspace = true
 description = "MCP server tools for rag-rat repository search, symbol graph traversal, rationale lookup, and source-bound memories."
 authors.workspace = true
 edition.workspace = true
@@ -13,7 +13,7 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-rag-rat-core = { version = "0.4.0", path = "../rag-rat-core", default-features = false }
+rag-rat-core = { workspace = true }
 rmcp.workspace = true
 schemars.workspace = true
 serde.workspace = true

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,72 @@
+# Releasing
+
+Releases are automated by [release-plz](https://release-plz.dev) and the three crates ship in
+**lockstep** — `rag-rat`, `rag-rat-core`, and `rag-rat-mcp` always carry the same version. That
+version has a single source of truth in `[workspace.package].version` (root `Cargo.toml`); every
+crate inherits it via `version.workspace = true`, and `release-plz.toml` puts all three in one
+`version_group` so the bump is shared.
+
+## Flow
+
+Configured in `.github/workflows/release-plz.yml`; runs on every push to `main`.
+
+1. **Release PR.** release-plz opens (and keeps updating) a "Release" PR that bumps the workspace
+   version and regenerates the combined `CHANGELOG.md` from [Conventional
+   Commits](https://www.conventionalcommits.org). Nothing ships until a human merges it — review the
+   bump and changelog there.
+2. **Publish + tag.** When that PR merges, release-plz publishes each crate to crates.io in
+   dependency order (`rag-rat-core` → `rag-rat-mcp` → `rag-rat`, waiting for the registry to
+   propagate each before the next), then creates a single `vX.Y.Z` git tag and GitHub release for
+   the whole workspace.
+
+So day-to-day there is no manual release step: write Conventional-Commit messages, merge the Release
+PR when you want to cut a version.
+
+## Choosing the bump
+
+release-plz derives the next version from the Conventional-Commit messages since the last release.
+**We are pre-1.0, where semver demotes every bump one level, and release-plz follows cargo's
+compatibility rules:**
+
+| Commit                                    | Post-1.0 | Pre-1.0 (us, at `0.x`) |
+| ----------------------------------------- | -------- | ---------------------- |
+| `fix:`                                    | patch    | patch (`0.4.0→0.4.1`)  |
+| `feat:`                                   | minor    | patch (`0.4.0→0.4.1`)  |
+| `feat!:` / `BREAKING CHANGE:` footer      | major    | **minor** (`0.4.0→0.5.0`) |
+
+The catch: at `0.x` a plain `feat:` only bumps the patch, so an ordinary feature commit will **not**
+produce a minor bump. To go `0.4.0 → 0.5.0` you have two options:
+
+1. **Signal a breaking change** — land a commit marked `feat!:` (or any commit with a
+   `BREAKING CHANGE:` footer). release-plz reads that as a minor bump at `0.x`, applied to all three
+   crates (they share a `version_group`).
+
+2. **Force the exact version** with the release-plz CLI — the documented escape hatch for when the
+   commit history doesn't compute the version you want:
+
+   ```bash
+   release-plz set-version [email protected] [email protected] [email protected]
+   ```
+
+   (The workspace form is `<pkg>@<ver>`; the bare `set-version 1.2.3` form is single-crate only.)
+   Commit the change and push to `main`; the Release PR then carries `0.5.0`.
+
+**Safety net:** nothing publishes until the Release PR merges, and that PR shows the computed version
+and changelog first. If release-plz proposes `0.4.1` when you wanted `0.5.0`, push a `set-version`
+commit (or just edit the version in the PR) before merging.
+
+## One-time setup
+
+Already wired except where noted:
+
+- **`CARGO_REGISTRY_TOKEN`** must exist as a repository secret — a crates.io API token with the
+  `publish-new` and `publish-update` scopes. Without it the publish step can tag but not publish.
+- The default `GITHUB_TOKEN` does **not** trigger `ci.yml` on the Release PR (GitHub blocks
+  workflow-created PRs from starting other workflows). To gate the Release PR on CI, swap the token
+  in `release-plz.yml` for a PAT or GitHub App token.
+
+## Manual bump (no release-plz CLI)
+
+If you don't have the release-plz CLI installed, you can force a version the same way by hand: edit
+`[workspace.package].version` and the two internal-dep `version`s under `[workspace.dependencies]` in
+the root `Cargo.toml` — keep all three in step. This is exactly what `set-version` above automates.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,37 @@
+# release-plz: automates version bumps, changelog, crates.io publish, and the GitHub release for
+# this three-crate workspace. https://release-plz.dev/docs/config
+#
+# Lockstep is the contract: all three crates share one version (see `[workspace.package].version`
+# in Cargo.toml). `version_group` below makes release-plz assign the SAME next version to every
+# member (the highest bump required across the group), so they never drift.
+
+[workspace]
+# One git tag + one GitHub release per bump, not one per crate. The libraries stay tag/release-
+# silent; the `rag-rat` binary below re-enables both and anchors the single workspace tag.
+git_tag_enable = false
+git_release_enable = false
+# Conventional-commit changelog. `changelog_path` can only be set per-package (below), so all three
+# members point at the same root CHANGELOG.md to produce one combined history.
+changelog_update = true
+
+# `rag-rat` is the user-facing binary and the natural anchor for the workspace tag/release. Because
+# every release shares one version (version_group), this crate bumps on every release, so it always
+# emits exactly one `vX.Y.Z` tag + release covering the whole workspace.
+[[package]]
+name = "rag-rat"
+version_group = "rag-rat"
+git_tag_enable = true
+git_release_enable = true
+git_tag_name = "v{{ version }}"
+git_release_name = "v{{ version }}"
+changelog_path = "./CHANGELOG.md"
+
+[[package]]
+name = "rag-rat-core"
+version_group = "rag-rat"
+changelog_path = "./CHANGELOG.md"
+
+[[package]]
+name = "rag-rat-mcp"
+version_group = "rag-rat"
+changelog_path = "./CHANGELOG.md"


### PR DESCRIPTION
## What

- **Lockstep versions.** One `[workspace.package].version` inherited by all three crates via `version.workspace = true`; internal path deps declared once in `[workspace.dependencies]` (`{ workspace = true }` at the use sites). `rag-rat` / `rag-rat-core` / `rag-rat-mcp` can no longer drift.
- **release-plz integration** (`release-plz.toml` + `.github/workflows/release-plz.yml`):
  - `version_group` keeps all three crates on one shared version.
  - tags/releases enabled only on the `rag-rat` binary → one `vX.Y.Z` per bump, not three.
  - three `changelog_path`s fold into one root `CHANGELOG.md`.
  - two-job workflow on push to `main`: a reviewable **Release PR**, then publish (in dependency order `core → mcp → binary`) + tag on merge. Fork-guarded to `cq27-dev`.
- **Docs:** `docs/releasing.md` (full flow, pre-1.0 bump rules, `set-version`), plus a short pointer in the README.

## Notes

- `CARGO_REGISTRY_TOKEN` secret is set; `v0.1.0`..`v0.4.0` tags already exist, so the changelog baseline is clean.
- The default `GITHUB_TOKEN` won't run `ci.yml` on the auto-generated Release PR (GitHub restriction); swap to a PAT/App token later if CI-gating that PR is wanted.
- The **first** Release PR creates `CHANGELOG.md` — worth eyeballing that the combined-changelog + single-tag output render as intended.