### PR TITLE
fix(memory): validate path/dir bindings to non-indexed files against the filesystem (#98)

### DIFF
--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -3012,7 +3012,7 @@ fn memory_survives_file_move_via_moniker_relocation() {
     )])]);
     run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
 
-    let report = validate_memories(&h.conn).unwrap();
+    let report = validate_memories(&h.conn, None).unwrap();
     assert!(report.relocated >= 1, "expected a relocation, got {report:?}");
 
     let memory = memory_by_id(&h.conn, &memory_id).unwrap().unwrap();
@@ -3060,7 +3060,7 @@ fn cross_version_moniker_match_requires_kind_corroboration() {
         run_oracle(&h.conn, TOOL, "v-newer", COMMIT, WORKTREE, &bytes, h.root(), None, None)
             .unwrap();
 
-        validate_memories(&h.conn).unwrap();
+        validate_memories(&h.conn, None).unwrap();
         let memory = memory_by_id(&h.conn, &memory_id).unwrap().unwrap();
         let symbol_binding =
             memory.bindings.iter().find(|b| b.binding_kind == "symbol").expect("symbol binding");
@@ -3096,7 +3096,7 @@ fn path_binding_status_after_validate(h: &Harness, path: &str) -> String {
         bind: RepoMemoryBindTarget { path: Some(path.to_string()), ..Default::default() },
     })
     .unwrap();
-    validate_memories(&h.conn).unwrap();
+    validate_memories(&h.conn, None).unwrap();
     let memory = memory_by_id(&h.conn, &created.memory.memory_id).unwrap().unwrap();
     memory
         .bindings
@@ -3162,7 +3162,7 @@ fn spanned_path_binding_to_unindexed_file_is_unverified() {
         },
     })
     .unwrap();
-    validate_memories(&h.conn).unwrap();
+    validate_memories(&h.conn, None).unwrap();
     let memory = memory_by_id(&h.conn, &created.memory.memory_id).unwrap().unwrap();
     let pb = memory.bindings.iter().find(|b| b.binding_kind == "path").expect("path binding");
     assert_eq!(
@@ -3190,7 +3190,7 @@ fn dir_binding_to_unindexed_dir_present_on_disk_is_current() {
         bind: RepoMemoryBindTarget { dir: Some("scripts".to_string()), ..Default::default() },
     })
     .unwrap();
-    validate_memories(&h.conn).unwrap();
+    validate_memories(&h.conn, None).unwrap();
     let memory = memory_by_id(&h.conn, &created.memory.memory_id).unwrap().unwrap();
     let db = memory.bindings.iter().find(|b| b.binding_kind == "dir").expect("dir binding");
     assert_eq!(
@@ -3218,10 +3218,84 @@ fn dir_binding_to_missing_dir_is_gone() {
         },
     })
     .unwrap();
-    validate_memories(&h.conn).unwrap();
+    validate_memories(&h.conn, None).unwrap();
     let memory = memory_by_id(&h.conn, &created.memory.memory_id).unwrap().unwrap();
     let db = memory.bindings.iter().find(|b| b.binding_kind == "dir").expect("dir binding");
     assert_eq!(db.anchor_status, "gone", "a dir that exists nowhere is genuinely gone");
+}
+
+/// #98 review (Codex): a `path` binding names a FILE. If the file is deleted and a DIRECTORY now
+/// occupies that name, the file is genuinely `gone` — the off-index fallback must use `is_file`,
+/// not `exists`, so a directory at the path can't keep the file anchor alive.
+#[test]
+fn path_binding_to_a_dir_replacing_the_file_is_gone() {
+    let h = Harness::new();
+    set_source_root(&h);
+    // A directory sits where the bound file used to be.
+    std::fs::create_dir_all(h.root().join("tools/build.sh")).unwrap();
+    assert_eq!(
+        path_binding_status_after_validate(&h, "tools/build.sh"),
+        "gone",
+        "a directory occupying a file-bound path does not keep the file anchor alive"
+    );
+}
+
+/// #98 review (Codex): path bindings are repo-root-relative by contract. An absolute path or one
+/// with `..` could resolve OUTSIDE `source_root` (`root.join(abs)` replaces the root), letting an
+/// unrelated out-of-repo file mark the anchor alive. Such a binding must be treated as `gone`.
+#[test]
+fn path_binding_escaping_source_root_is_gone() {
+    let h = Harness::new();
+    set_source_root(&h);
+    // A real file OUTSIDE the source_root, reachable only by escaping it via `..`.
+    let outside = h.root().parent().unwrap().join(format!("escape-{}.sh", std::process::id()));
+    std::fs::write(&outside, "#!/bin/sh\n").unwrap();
+    let traversal = format!("../{}", outside.file_name().unwrap().to_string_lossy());
+    let status = path_binding_status_after_validate(&h, &traversal);
+    let _ = std::fs::remove_file(&outside);
+    assert_eq!(
+        status, "gone",
+        "a `..`-escaping path must not validate against an out-of-repo file"
+    );
+}
+
+/// #98 review (Codex): under a shared DB across git worktrees, `index_meta.source_root` holds
+/// whichever worktree last indexed. `validate_memories` must prefer the caller-supplied ACTIVE
+/// checkout root so a sibling worktree checks its OWN filesystem, not the last indexer's.
+#[test]
+fn validate_prefers_active_root_over_persisted_meta() {
+    let h = Harness::new();
+    // Persisted meta points at a bogus root (a stale/sibling worktree); the active checkout is
+    // h.root(), where the file actually lives.
+    h.conn
+        .execute(
+            "INSERT OR REPLACE INTO index_meta(key, value) VALUES ('source_root', ?1)",
+            params![h.root().join("nonexistent-worktree").to_string_lossy()],
+        )
+        .unwrap();
+    std::fs::create_dir_all(h.root().join("tools")).unwrap();
+    std::fs::write(h.root().join("tools/notes.Containerfile"), "FROM scratch\n").unwrap();
+    let created = create_memory(&h.conn, RepoMemoryCreate {
+        kind: "Decision".to_string(),
+        title: "worktree note".to_string(),
+        body: "still valid".to_string(),
+        confidence: "high".to_string(),
+        created_by: None,
+        source: None,
+        tags: Vec::new(),
+        bind: RepoMemoryBindTarget {
+            path: Some("tools/notes.Containerfile".to_string()),
+            ..Default::default()
+        },
+    })
+    .unwrap();
+    validate_memories(&h.conn, Some(h.root())).unwrap();
+    let memory = memory_by_id(&h.conn, &created.memory.memory_id).unwrap().unwrap();
+    let pb = memory.bindings.iter().find(|b| b.binding_kind == "path").expect("path binding");
+    assert_eq!(
+        pb.anchor_status, "current",
+        "the active checkout root must win over the stale persisted source_root"
+    );
 }
 
 /// `scip_moniker` binding statuses: `unverified` when the tool has no data at all, `gone` when
@@ -3245,7 +3319,7 @@ fn moniker_binding_validation_statuses() {
     let memory_id = create_target_memory(&h, sym);
 
     let moniker_status = |h: &Harness| -> String {
-        validate_memories(&h.conn).unwrap();
+        validate_memories(&h.conn, None).unwrap();
         let memory = memory_by_id(&h.conn, &memory_id).unwrap().unwrap();
         memory
             .bindings
@@ -3356,7 +3430,7 @@ fn moniker_string_drift_rebinds_via_live_logical_symbol_then_survives_move() {
     )])]);
     run_oracle(&h.conn, TOOL, "v-bumped", COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
 
-    validate_memories(&h.conn).unwrap();
+    validate_memories(&h.conn, None).unwrap();
     let memory = memory_by_id(&h.conn, &memory_id).unwrap().unwrap();
     let moniker_binding =
         memory.bindings.iter().find(|b| b.binding_kind == "scip_moniker").expect("moniker binding");
@@ -3375,7 +3449,7 @@ fn moniker_string_drift_rebinds_via_live_logical_symbol_then_survives_move() {
         SymbolRole::Definition as i32,
     )])]);
     run_oracle(&h.conn, TOOL, "v-bumped", COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
-    validate_memories(&h.conn).unwrap();
+    validate_memories(&h.conn, None).unwrap();
     let memory = memory_by_id(&h.conn, &memory_id).unwrap().unwrap();
     let symbol_binding =
         memory.bindings.iter().find(|b| b.binding_kind == "symbol").expect("symbol binding");
@@ -3416,7 +3490,7 @@ fn string_resolution_preserves_bind_time_tool_version() {
         SymbolRole::Definition as i32,
     )])]);
     run_oracle(&h.conn, TOOL, "v-newer", COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
-    validate_memories(&h.conn).unwrap();
+    validate_memories(&h.conn, None).unwrap();
 
     let memory = memory_by_id(&h.conn, &memory_id).unwrap().unwrap();
     let moniker_binding =
@@ -3463,7 +3537,7 @@ fn bare_path_binding_survives_file_edit_spanned_goes_stale() {
 
     // Edit the file: new content, new sha on the files row.
     h.set_file_sha(file, "edited-sha");
-    validate_memories(&h.conn).unwrap();
+    validate_memories(&h.conn, None).unwrap();
 
     let status =
         |id: &str| memory_by_id(&h.conn, id).unwrap().unwrap().bindings[0].anchor_status.clone();
@@ -3476,7 +3550,7 @@ fn bare_path_binding_survives_file_edit_spanned_goes_stale() {
 
     // Deleting the file row sends both to gone.
     h.conn.execute("DELETE FROM files WHERE id = ?1", [file]).unwrap();
-    validate_memories(&h.conn).unwrap();
+    validate_memories(&h.conn, None).unwrap();
     assert_eq!(status(&bare), "gone");
     assert_eq!(status(&spanned), "gone");
 }

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -3071,6 +3071,159 @@ fn cross_version_moniker_match_requires_kind_corroboration() {
     }
 }
 
+/// Point the index `source_root` meta at the harness checkout so the off-index filesystem
+/// existence fallback (#98) has a root to resolve a binding path against.
+fn set_source_root(h: &Harness) {
+    h.conn
+        .execute(
+            "INSERT OR REPLACE INTO index_meta(key, value) VALUES ('source_root', ?1)",
+            params![h.root().to_string_lossy()],
+        )
+        .unwrap();
+}
+
+/// Create a bare path-bound memory and return its id + the validated anchor status of the `path`
+/// binding.
+fn path_binding_status_after_validate(h: &Harness, path: &str) -> String {
+    let created = create_memory(&h.conn, RepoMemoryCreate {
+        kind: "Decision".to_string(),
+        title: format!("note about {path}"),
+        body: "this guidance is still valid".to_string(),
+        confidence: "high".to_string(),
+        created_by: None,
+        source: None,
+        tags: Vec::new(),
+        bind: RepoMemoryBindTarget { path: Some(path.to_string()), ..Default::default() },
+    })
+    .unwrap();
+    validate_memories(&h.conn).unwrap();
+    let memory = memory_by_id(&h.conn, &created.memory.memory_id).unwrap().unwrap();
+    memory
+        .bindings
+        .iter()
+        .find(|b| b.binding_kind == "path")
+        .expect("path binding")
+        .anchor_status
+        .clone()
+}
+
+/// #98: a memory bound to a NON-INDEXED file that exists on disk (a Containerfile, shell script,
+/// `.yml`, `.toml` — anything outside the indexed language set, so it has no `files` row by
+/// construction) must validate `current`, not `gone`. Acting on a false `gone` would delete valid
+/// guidance.
+#[test]
+fn path_binding_to_unindexed_file_present_on_disk_is_current() {
+    let h = Harness::new();
+    set_source_root(&h);
+    std::fs::create_dir_all(h.root().join("tools")).unwrap();
+    std::fs::write(h.root().join("tools/bench.Containerfile"), "FROM scratch\n").unwrap();
+    // Deliberately NO `files` row — this file type is outside the indexed set.
+    assert_eq!(
+        path_binding_status_after_validate(&h, "tools/bench.Containerfile"),
+        "current",
+        "a path bound to a real-but-unindexed file is an area anchor, not gone"
+    );
+}
+
+/// #98: a path binding whose target is absent from BOTH the index and the filesystem is genuinely
+/// `gone`.
+#[test]
+fn path_binding_to_missing_file_is_gone() {
+    let h = Harness::new();
+    set_source_root(&h);
+    assert_eq!(
+        path_binding_status_after_validate(&h, "tools/deleted.Containerfile"),
+        "gone",
+        "a path that exists nowhere is genuinely gone"
+    );
+}
+
+/// #98: a SPANNED path binding (`path:start-end`) to a non-indexed file has no chunk to hash, so it
+/// is `unverified` rather than `gone` — it can't be content-validated but its target is alive.
+#[test]
+fn spanned_path_binding_to_unindexed_file_is_unverified() {
+    let h = Harness::new();
+    set_source_root(&h);
+    std::fs::create_dir_all(h.root().join("tools")).unwrap();
+    std::fs::write(h.root().join("tools/build.sh"), "#!/bin/sh\necho hi\n").unwrap();
+    let created = create_memory(&h.conn, RepoMemoryCreate {
+        kind: "Decision".to_string(),
+        title: "spanned note".to_string(),
+        body: "lines 1-2 matter".to_string(),
+        confidence: "high".to_string(),
+        created_by: None,
+        source: None,
+        tags: Vec::new(),
+        bind: RepoMemoryBindTarget {
+            path: Some("tools/build.sh".to_string()),
+            start_line: Some(1),
+            end_line: Some(2),
+            ..Default::default()
+        },
+    })
+    .unwrap();
+    validate_memories(&h.conn).unwrap();
+    let memory = memory_by_id(&h.conn, &created.memory.memory_id).unwrap().unwrap();
+    let pb = memory.bindings.iter().find(|b| b.binding_kind == "path").expect("path binding");
+    assert_eq!(
+        pb.anchor_status, "unverified",
+        "a spanned binding to a non-indexed file can't be hashed but isn't gone"
+    );
+}
+
+/// #98 (dir analogue): a `dir` binding to a directory that exists on disk but holds only
+/// non-indexed files (so `dir_has_files` finds nothing) must validate `current`, not `gone`.
+#[test]
+fn dir_binding_to_unindexed_dir_present_on_disk_is_current() {
+    let h = Harness::new();
+    set_source_root(&h);
+    std::fs::create_dir_all(h.root().join("scripts")).unwrap();
+    std::fs::write(h.root().join("scripts/deploy.sh"), "#!/bin/sh\n").unwrap();
+    let created = create_memory(&h.conn, RepoMemoryCreate {
+        kind: "Decision".to_string(),
+        title: "scripts dir note".to_string(),
+        body: "deploy scripts live here".to_string(),
+        confidence: "high".to_string(),
+        created_by: None,
+        source: None,
+        tags: Vec::new(),
+        bind: RepoMemoryBindTarget { dir: Some("scripts".to_string()), ..Default::default() },
+    })
+    .unwrap();
+    validate_memories(&h.conn).unwrap();
+    let memory = memory_by_id(&h.conn, &created.memory.memory_id).unwrap().unwrap();
+    let db = memory.bindings.iter().find(|b| b.binding_kind == "dir").expect("dir binding");
+    assert_eq!(
+        db.anchor_status, "current",
+        "a dir present on disk with only non-indexed files is current, not gone"
+    );
+}
+
+/// #98 (dir analogue): a `dir` binding to a directory absent from index and filesystem is `gone`.
+#[test]
+fn dir_binding_to_missing_dir_is_gone() {
+    let h = Harness::new();
+    set_source_root(&h);
+    let created = create_memory(&h.conn, RepoMemoryCreate {
+        kind: "Decision".to_string(),
+        title: "ghost dir note".to_string(),
+        body: "nothing here".to_string(),
+        confidence: "high".to_string(),
+        created_by: None,
+        source: None,
+        tags: Vec::new(),
+        bind: RepoMemoryBindTarget {
+            dir: Some("does/not/exist".to_string()),
+            ..Default::default()
+        },
+    })
+    .unwrap();
+    validate_memories(&h.conn).unwrap();
+    let memory = memory_by_id(&h.conn, &created.memory.memory_id).unwrap().unwrap();
+    let db = memory.bindings.iter().find(|b| b.binding_kind == "dir").expect("dir binding");
+    assert_eq!(db.anchor_status, "gone", "a dir that exists nowhere is genuinely gone");
+}
+
 /// `scip_moniker` binding statuses: `unverified` when the tool has no data at all, `gone` when
 /// current data lacks the moniker, `stale` when the moniker's row dangles (its content-derived
 /// logical id died after the symbol changed).

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -1760,7 +1760,10 @@ impl IndexDatabase {
     pub fn memory_validate(
         &self,
     ) -> anyhow::Result<crate::query::memory::RepoMemoryValidationReport> {
-        crate::query::memory::validate_memories(self.storage.connection())
+        crate::query::memory::validate_memories(
+            self.storage.connection(),
+            self.storage.source_root(),
+        )
     }
 
     pub fn memory_doctor(&self) -> anyhow::Result<Vec<crate::query::memory::MemoryDoctorEntry>> {

--- a/crates/rag-rat-core/src/query/memory/api.rs
+++ b/crates/rag-rat-core/src/query/memory/api.rs
@@ -726,7 +726,14 @@ pub(crate) fn anchor_health_counts(
     Ok(health)
 }
 
-pub(crate) fn validate_memories(conn: &Connection) -> anyhow::Result<RepoMemoryValidationReport> {
+pub(crate) fn validate_memories(
+    conn: &Connection,
+    active_root: Option<&std::path::Path>,
+) -> anyhow::Result<RepoMemoryValidationReport> {
+    // The off-index filesystem fallback (#98) resolves binding paths against the active checkout
+    // root when known (correct under a multi-worktree shared DB), else the persisted source_root.
+    let fs_root = effective_fs_root(conn, active_root);
+    let fs_root = fs_root.as_deref();
     let mut stmt = conn.prepare(
         "
         SELECT memory_id, binding_kind, binding_id, path, start_line, end_line,
@@ -750,7 +757,7 @@ pub(crate) fn validate_memories(conn: &Connection) -> anyhow::Result<RepoMemoryV
         let mut binding = row?;
         let original_binding_id = binding.binding_id.clone();
         report.checked += 1;
-        let status = validate_binding(conn, &mut binding)?;
+        let status = validate_binding(conn, &mut binding, fs_root)?;
         let updated = conn.execute(
             "
             UPDATE OR IGNORE repo_memory_bindings

--- a/crates/rag-rat-core/src/query/memory/validate.rs
+++ b/crates/rag-rat-core/src/query/memory/validate.rs
@@ -1,8 +1,11 @@
+use std::path::{Component, Path, PathBuf};
+
 use super::*;
 
 pub(crate) fn validate_binding(
     conn: &Connection,
     binding: &mut RepoMemoryBinding,
+    fs_root: Option<&Path>,
 ) -> anyhow::Result<String> {
     match binding.binding_kind.as_str() {
         "logical_symbol" => validate_logical_symbol_binding(conn, binding),
@@ -11,8 +14,8 @@ pub(crate) fn validate_binding(
         "edge" => validate_edge_binding(conn, binding),
         "call_path" => validate_call_path_binding(conn, binding),
         "scip_moniker" => validate_moniker_binding(conn, binding),
-        "path" => validate_path_binding(conn, binding),
-        "dir" => validate_dir_binding(conn, binding),
+        "path" => validate_path_binding(conn, binding, fs_root),
+        "dir" => validate_dir_binding(conn, binding, fs_root),
         "commit" | "github" => Ok("unverified".to_string()),
         _ => Ok("unverified".to_string()),
     }
@@ -24,16 +27,18 @@ pub(crate) fn validate_binding(
 /// A dir holding ONLY non-indexed file types (shell scripts, `.yml` workflows, Containerfiles)
 /// has no `files` rows by construction, so [`dir_has_files`] sees it as empty even though the
 /// directory is alive in the repo. Before declaring `gone`, fall back to a filesystem existence
-/// check against the index `source_root` (#98) so an area anchor to such a directory stays current.
+/// check against `fs_root` (the active checkout root; #98) so an area anchor to such a directory
+/// stays current.
 pub(crate) fn validate_dir_binding(
     conn: &Connection,
     binding: &mut RepoMemoryBinding,
+    fs_root: Option<&Path>,
 ) -> anyhow::Result<String> {
     let dir = binding.path.clone().unwrap_or_else(|| binding.binding_id.clone());
     if dir_has_files(conn, &dir)? {
         return Ok("current".to_string());
     }
-    Ok(if dir_exists_on_disk(conn, &dir) { "current" } else { "gone" }.to_string())
+    Ok(if dir_exists_on_disk(fs_root, &dir) { "current" } else { "gone" }.to_string())
 }
 pub(crate) fn validate_logical_symbol_binding(
     conn: &Connection,
@@ -339,6 +344,7 @@ pub(crate) fn validate_bound_chunk(
 pub(crate) fn validate_path_binding(
     conn: &Connection,
     binding: &mut RepoMemoryBinding,
+    fs_root: Option<&Path>,
 ) -> anyhow::Result<String> {
     let Some(path) = binding.path.as_deref() else {
         return Ok("unverified".to_string());
@@ -354,12 +360,14 @@ pub(crate) fn validate_path_binding(
         // No `files` row — but `files` holds only files in the configured indexed language set, so
         // a binding to a path OUTSIDE that set (a Containerfile, shell script, `.yml` workflow,
         // `.toml` config) has no row by construction and is indistinguishable from a deleted file
-        // by the index alone. Fall back to a filesystem existence check against the index
-        // `source_root` before declaring `gone` — acting on a false `gone` would delete valid
-        // guidance (#98). A BARE path is an area anchor → `current` while the file is present; a
-        // SPANNED `path:start-end` binding has no chunk to hash → `unverified` (alive but
-        // un-content-verifiable), never `gone`.
-        let status = match path_exists_on_disk(conn, path) {
+        // by the index alone. Fall back to a filesystem existence check against `fs_root` (the
+        // active checkout root) before declaring `gone` — acting on a false `gone` would delete
+        // valid guidance (#98). A BARE path is an area anchor → `current` while the file is
+        // present; a SPANNED `path:start-end` binding has no chunk to hash → `unverified`
+        // (alive but un-content-verifiable), never `gone`. The target must be a FILE: a
+        // path binding names a file, so a directory now occupying that name leaves the file
+        // genuinely `gone`.
+        let status = match path_is_file_on_disk(fs_root, path) {
             true if binding.start_line.is_none() && binding.end_line.is_none() => "current",
             true => "unverified",
             false => "gone",
@@ -380,30 +388,52 @@ pub(crate) fn validate_path_binding(
         _ => Ok("current".to_string()),
     }
 }
-/// The indexed checkout's `source_root` (the on-disk repo root), persisted in `index_meta` at
-/// open/rebuild/incremental. `None` on a raw connection that never recorded it (some test fixtures)
-/// — callers then skip the filesystem fallback and behave as if the target is absent.
-fn source_root(conn: &Connection) -> Option<std::path::PathBuf> {
+/// The persisted `source_root` (the on-disk repo root recorded in `index_meta` at
+/// open/rebuild/incremental). `None` on a raw connection that never recorded it (some test
+/// fixtures). This is a SINGLE shared value — under a shared DB across git worktrees it reflects
+/// whichever worktree last indexed, which is why [`validate_memories`] prefers the caller-supplied
+/// active checkout root and only falls back to this (#98 review).
+fn persisted_source_root(conn: &Connection) -> Option<PathBuf> {
     conn.query_row("SELECT value FROM index_meta WHERE key = 'source_root'", [], |row| {
         row.get::<_, String>(0)
     })
     .optional()
     .ok()
     .flatten()
-    .map(std::path::PathBuf::from)
+    .map(PathBuf::from)
 }
 
-/// Whether `path` (repo-root-relative) resolves to an existing file under the index `source_root`
-/// — the off-index existence check for non-indexed file types (#98). `false` when `source_root` is
-/// unknown, so a connection without it falls back to the pre-#98 `gone` behavior.
-fn path_exists_on_disk(conn: &Connection, path: &str) -> bool {
-    source_root(conn).is_some_and(|root| root.join(path).exists())
+/// The filesystem root the off-index existence checks resolve against: the caller-supplied ACTIVE
+/// checkout root (`storage.source_root`, correct under a multi-worktree shared DB) when known, else
+/// the single persisted `index_meta.source_root` (#98 review).
+pub(crate) fn effective_fs_root(conn: &Connection, active_root: Option<&Path>) -> Option<PathBuf> {
+    active_root.map(Path::to_path_buf).or_else(|| persisted_source_root(conn))
 }
 
-/// Whether `dir` (repo-root-relative, `""` = repo root) resolves to an existing directory under the
-/// index `source_root` — the off-index dir existence check (#98).
-fn dir_exists_on_disk(conn: &Connection, dir: &str) -> bool {
-    source_root(conn).is_some_and(|root| root.join(dir).is_dir())
+/// Whether a binding's stored `path`/`dir` honors the repo-root-relative contract: not absolute and
+/// free of any `..` / root-prefix component that could escape `source_root` (#98 review). A binding
+/// violating it is treated as not-on-disk, so a stray absolute/`..` path can't keep an out-of-repo
+/// file's anchor alive. A leading `./` (`CurDir`) and an empty string (the repo root) are fine.
+fn is_repo_relative(path: &str) -> bool {
+    let path = Path::new(path);
+    !path.is_absolute()
+        && path
+            .components()
+            .all(|component| matches!(component, Component::Normal(_) | Component::CurDir))
+}
+
+/// Whether `path` (repo-root-relative) resolves to an existing FILE under `root` — the off-index
+/// existence check for non-indexed file types (#98). `false` when `root` is unknown (so a
+/// connection without a source_root falls back to the pre-#98 `gone` behavior) or the path is not
+/// repo-relative.
+fn path_is_file_on_disk(root: Option<&Path>, path: &str) -> bool {
+    root.is_some_and(|root| is_repo_relative(path) && root.join(path).is_file())
+}
+
+/// Whether `dir` (repo-root-relative, `""` = repo root) resolves to an existing directory under
+/// `root` — the off-index dir existence check (#98).
+fn dir_exists_on_disk(root: Option<&Path>, dir: &str) -> bool {
+    root.is_some_and(|root| is_repo_relative(dir) && root.join(dir).is_dir())
 }
 
 pub(crate) fn source_hash_for_memory(

--- a/crates/rag-rat-core/src/query/memory/validate.rs
+++ b/crates/rag-rat-core/src/query/memory/validate.rs
@@ -20,12 +20,20 @@ pub(crate) fn validate_binding(
 /// Validate a `dir` binding: current while at least one indexed file lives at or under the
 /// directory, gone otherwise. Dir bindings are descriptive anchors with no `source_text_hash`
 /// — they never go stale, only current or gone.
+///
+/// A dir holding ONLY non-indexed file types (shell scripts, `.yml` workflows, Containerfiles)
+/// has no `files` rows by construction, so [`dir_has_files`] sees it as empty even though the
+/// directory is alive in the repo. Before declaring `gone`, fall back to a filesystem existence
+/// check against the index `source_root` (#98) so an area anchor to such a directory stays current.
 pub(crate) fn validate_dir_binding(
     conn: &Connection,
     binding: &mut RepoMemoryBinding,
 ) -> anyhow::Result<String> {
     let dir = binding.path.clone().unwrap_or_else(|| binding.binding_id.clone());
-    Ok(if dir_has_files(conn, &dir)? { "current" } else { "gone" }.to_string())
+    if dir_has_files(conn, &dir)? {
+        return Ok("current".to_string());
+    }
+    Ok(if dir_exists_on_disk(conn, &dir) { "current" } else { "gone" }.to_string())
 }
 pub(crate) fn validate_logical_symbol_binding(
     conn: &Connection,
@@ -343,7 +351,20 @@ pub(crate) fn validate_path_binding(
         )
         .optional()?;
     let Some(current_hash) = current_hash else {
-        return Ok("gone".to_string());
+        // No `files` row — but `files` holds only files in the configured indexed language set, so
+        // a binding to a path OUTSIDE that set (a Containerfile, shell script, `.yml` workflow,
+        // `.toml` config) has no row by construction and is indistinguishable from a deleted file
+        // by the index alone. Fall back to a filesystem existence check against the index
+        // `source_root` before declaring `gone` — acting on a false `gone` would delete valid
+        // guidance (#98). A BARE path is an area anchor → `current` while the file is present; a
+        // SPANNED `path:start-end` binding has no chunk to hash → `unverified` (alive but
+        // un-content-verifiable), never `gone`.
+        let status = match path_exists_on_disk(conn, path) {
+            true if binding.start_line.is_none() && binding.end_line.is_none() => "current",
+            true => "unverified",
+            false => "gone",
+        };
+        return Ok(status.to_string());
     };
     // A BARE path binding (no line span) is an AREA anchor, like a `dir` binding: the claim is
     // "this note is about this file", not "this file's bytes are X" — so it is current while the
@@ -359,6 +380,32 @@ pub(crate) fn validate_path_binding(
         _ => Ok("current".to_string()),
     }
 }
+/// The indexed checkout's `source_root` (the on-disk repo root), persisted in `index_meta` at
+/// open/rebuild/incremental. `None` on a raw connection that never recorded it (some test fixtures)
+/// — callers then skip the filesystem fallback and behave as if the target is absent.
+fn source_root(conn: &Connection) -> Option<std::path::PathBuf> {
+    conn.query_row("SELECT value FROM index_meta WHERE key = 'source_root'", [], |row| {
+        row.get::<_, String>(0)
+    })
+    .optional()
+    .ok()
+    .flatten()
+    .map(std::path::PathBuf::from)
+}
+
+/// Whether `path` (repo-root-relative) resolves to an existing file under the index `source_root`
+/// — the off-index existence check for non-indexed file types (#98). `false` when `source_root` is
+/// unknown, so a connection without it falls back to the pre-#98 `gone` behavior.
+fn path_exists_on_disk(conn: &Connection, path: &str) -> bool {
+    source_root(conn).is_some_and(|root| root.join(path).exists())
+}
+
+/// Whether `dir` (repo-root-relative, `""` = repo root) resolves to an existing directory under the
+/// index `source_root` — the off-index dir existence check (#98).
+fn dir_exists_on_disk(conn: &Connection, dir: &str) -> bool {
+    source_root(conn).is_some_and(|root| root.join(dir).is_dir())
+}
+
 pub(crate) fn source_hash_for_memory(
     conn: &Connection,
     memory_id: &str,


### PR DESCRIPTION
## Problem

`memory doctor` false-flags path/dir-bound memories as `gone` when the target is a **non-indexed file type** (Containerfile, shell script, `.yml` workflow, `.toml` config) — even though the file is present in the repo.

Root cause: `validate_path_binding` / `validate_dir_binding` resolve the target only against the indexed `files` table, which by construction holds only files in the configured indexed language set. A path outside that set has **no `files` row**, so it was indistinguishable from a deleted file. Acting on the resulting mark-obsolete recommendation would **delete valid guidance**, and these anchors formed a standing doctor noise floor that never cleared.

## Fix

Before declaring `gone`, fall back to a filesystem existence check against the index `source_root` (read from `index_meta`):

- **path binding**, no `files` row:
  - present on disk + bare (no line span) → `current` (area anchor to a real-but-unindexed file)
  - present on disk + spanned (`path:start-end`) → `unverified` (no chunk to hash, but alive — never `gone`)
  - absent → `gone`
- **dir binding**: no indexed files but the directory exists on disk → `current`; else `gone`

A connection without `source_root` meta skips the fallback (pre-fix `gone` behavior), so behavior is unchanged for raw/test connections that don't record it.

Note: `memory doctor` reads the **persisted** `anchor_status` and does not re-validate (deliberate read-only design), so a false `gone` clears on the next validate pass (watcher / incremental gc tail / open paths).

## Tests (TDD)

Added to `index/oracle/tests.rs`, written failing-first:

- `path_binding_to_unindexed_file_present_on_disk_is_current`
- `path_binding_to_missing_file_is_gone`
- `spanned_path_binding_to_unindexed_file_is_unverified`
- `dir_binding_to_unindexed_dir_present_on_disk_is_current`
- `dir_binding_to_missing_dir_is_gone`

`cargo test -p rag-rat-core` (344 passed), `cargo +nightly fmt`, and `cargo clippy --all-targets` all clean.

Fixes #98