### PR TITLE
ci(release-plz): use RELEASE_PLZ_TOKEN so PR creation isn't blocked by org policy

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -4,6 +4,14 @@ name: Release-plz
 #   - release-plz-pr opens/updates a "Release" PR with the lockstep version bump + changelog;
 #   - release-plz-release fires once that PR's version commit lands, tagging + publishing.
 # Config (lockstep version_group, single tag/release, combined CHANGELOG) lives in release-plz.toml.
+#
+# AUTH: both jobs use a `RELEASE_PLZ_TOKEN` repo secret, NOT the default GITHUB_TOKEN. The cq27-dev
+# org disables "Allow GitHub Actions to create and approve pull requests", which makes the default
+# token 403 when release-plz opens the release PR (the repo-level toggle is greyed out under that
+# org policy). A fine-grained PAT or GitHub App token (contents: write + pull-requests: write) sidesteps
+# it — and, per release-plz's own guidance, lets the release PR and the version tag trigger downstream
+# workflows (GITHUB_TOKEN-authored refs do not, which would skip CI on the release PR and the v*-tagged
+# ios.yml). Create the token, add it as the `RELEASE_PLZ_TOKEN` secret, then this workflow goes green.
 on:
   push:
     branches:
@@ -38,7 +46,7 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   # When the release PR merges (the version commit lands on main), tag, publish each crate to
@@ -64,5 +72,5 @@ jobs:
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Why

release-plz's first run on `main` (from #124) fails its **Release-plz PR** job:

\`\`\`
ERROR Failed to open PR
  HTTP 403 Forbidden for https://api.github.com/repos/cq27-dev/rag-rat/pulls
\`\`\`

The job already requests \`pull-requests: write\`, but the **\`cq27-dev\` org** disables *"Allow GitHub Actions to create and approve pull requests"*, which overrides the repo (the repo-level toggle is greyed out under that org policy). The default \`GITHUB_TOKEN\` therefore can't open the release PR.

## Change

Both release-plz jobs now use a **\`RELEASE_PLZ_TOKEN\`** secret instead of \`GITHUB_TOKEN\`. A fine-grained PAT or GitHub App token (contents: write + pull-requests: write) sidesteps the org policy, and — per release-plz's guidance — lets the release PR and the version tag trigger downstream workflows (GITHUB_TOKEN-authored refs don't, which would skip CI on the release PR and the \`v*\`-tagged \`ios.yml\`).

## Action required before/with merge

Create the token and add it as the repo secret **\`RELEASE_PLZ_TOKEN\`**:
- **Fine-grained PAT** (simplest): scoped to \`cq27-dev/rag-rat\`, Repository permissions → Contents: Read and write, Pull requests: Read and write. Add under Settings → Secrets and variables → Actions → \`RELEASE_PLZ_TOKEN\`.
- **Or a GitHub App** token (no user-tied PAT) with the same permissions.

Until the secret exists this workflow will still fail; once it's set, Release-plz goes green.

Not related to the merged #98 fix — pre-existing infra from #124.