### PR TITLE
fix(mcp): serialize logical_symbol_id as a string across serde boundaries (#130)

### DIFF
--- a/crates/rag-rat-core/src/lib.rs
+++ b/crates/rag-rat-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod locks;
 pub mod output;
 pub mod query;
 pub mod search;
+pub mod serde_big_id;
 pub mod storage;
 pub mod watch;
 

--- a/crates/rag-rat-core/src/query/graph/mod.rs
+++ b/crates/rag-rat-core/src/query/graph/mod.rs
@@ -50,6 +50,8 @@ pub struct GraphTraversalReport {
 pub struct GraphTraversalQuery {
     pub tool: String,
     pub symbol_id: Option<i64>,
+    // Content-derived 64-bit hash > 2^53 — emit as a string so JSON clients don't round it (#130).
+    #[serde(serialize_with = "crate::serde_big_id::big_id_opt::serialize")]
     pub logical_symbol_id: Option<i64>,
     pub symbol_path: String,
     pub resolution: String,
@@ -57,6 +59,7 @@ pub struct GraphTraversalQuery {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct LogicalSymbol {
+    #[serde(serialize_with = "crate::serde_big_id::big_id::serialize")]
     pub logical_symbol_id: i64,
     pub qualified_name: String,
     pub variant_count: u64,
@@ -174,6 +177,8 @@ pub struct CompareGraphTextReport {
 #[derive(Debug, Serialize)]
 pub struct CompareGraphTextQuery {
     pub symbol_id: Option<i64>,
+    // Content-derived 64-bit hash > 2^53 — emit as a string so JSON clients don't round it (#130).
+    #[serde(serialize_with = "crate::serde_big_id::big_id_opt::serialize")]
     pub logical_symbol_id: Option<i64>,
     pub symbol_path: String,
     pub pattern: String,

--- a/crates/rag-rat-core/src/query/memory/mod.rs
+++ b/crates/rag-rat-core/src/query/memory/mod.rs
@@ -49,7 +49,11 @@ pub struct RepoMemoryBinding {
     pub start_line: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub end_line: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    // Content-derived 64-bit hash > 2^53 — emit as a string so JSON clients don't round it (#130).
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::serde_big_id::big_id_opt::serialize"
+    )]
     pub logical_symbol_id: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol_id: Option<i64>,
@@ -87,9 +91,17 @@ pub struct RepoMemoryBinding {
 #[derive(Debug, Clone, Serialize)]
 pub struct RepoMemoryCallPath {
     pub memory_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    // Content-derived 64-bit hashes > 2^53 — emit as strings so JSON clients don't round them
+    // (#130).
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::serde_big_id::big_id_opt::serialize"
+    )]
     pub start_logical_symbol_id: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::serde_big_id::big_id_opt::serialize"
+    )]
     pub end_logical_symbol_id: Option<i64>,
     pub edge_sequence_hash: String,
     pub path_summary: String,
@@ -117,6 +129,11 @@ pub struct RepoMemoryCreate {
 
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct RepoMemoryBindTarget {
+    // Content-derived 64-bit hash > 2^53 — accept it as a string (or number) so a >2^53 id isn't
+    // rounded by a JSON client before it reaches us (#130). `default` keeps the field optional now
+    // that a custom deserializer is attached (a plain `Option` no longer auto-defaults on
+    // absence).
+    #[serde(default, deserialize_with = "crate::serde_big_id::big_id_opt::deserialize")]
     pub logical_symbol_id: Option<i64>,
     pub symbol_id: Option<i64>,
     pub chunk_id: Option<i64>,
@@ -128,7 +145,9 @@ pub struct RepoMemoryBindTarget {
     pub github_owner: Option<String>,
     pub github_repo: Option<String>,
     pub github_number: Option<i64>,
+    #[serde(default, deserialize_with = "crate::serde_big_id::big_id_opt::deserialize")]
     pub start_logical_symbol_id: Option<i64>,
+    #[serde(default, deserialize_with = "crate::serde_big_id::big_id_opt::deserialize")]
     pub end_logical_symbol_id: Option<i64>,
     pub edge_sequence_hash: Option<String>,
     pub path_summary: Option<String>,

--- a/crates/rag-rat-core/src/query/symbol.rs
+++ b/crates/rag-rat-core/src/query/symbol.rs
@@ -6,7 +6,12 @@ use crate::language::Language;
 #[derive(Debug, Serialize)]
 pub struct SymbolHit {
     pub symbol_id: i64,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    // logical_symbol_id is a content-derived 64-bit hash > 2^53; emit as a string so JSON clients
+    // don't round it (#130). symbol_id/file_id are small rowids and stay numbers.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::serde_big_id::big_id_opt::serialize"
+    )]
     pub logical_symbol_id: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub logical_variant_count: Option<u64>,
@@ -34,6 +39,7 @@ pub struct SymbolLookup {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct LogicalSymbolHit {
+    #[serde(serialize_with = "crate::serde_big_id::big_id::serialize")]
     pub logical_symbol_id: i64,
     pub language: String,
     pub path: String,

--- a/crates/rag-rat-core/src/serde_big_id.rs
+++ b/crates/rag-rat-core/src/serde_big_id.rs
@@ -1,0 +1,155 @@
+//! Serde for `i64` ids that exceed JSON's 2^53 safe-integer range — content-derived
+//! `logical_symbol_id` hashes (~2.5e18, far above 2^53 = 9_007_199_254_740_992). A JSON *number*
+//! cannot carry such a value losslessly: a client that parses JSON numbers as f64 (every JS-based
+//! MCP client) silently rounds it (`2574604874062343519` → `2574604874062343700`), so the id is
+//! corrupted in transit before the server ever sees it (#130).
+//!
+//! The fix: these ids cross EVERY serde boundary (CLI `--json`, MCP JSON, MCP TOON) as a STRING.
+//! - Serialize → always a string, so a reader copies an opaque string and round-trips it intact.
+//! - Deserialize → accept a string OR a number, so callers within the safe range (and older
+//!   clients) keep working; the string form is what makes a >2^53 id survive.
+//!
+//! Apply with `#[serde(with = "crate::serde_big_id::big_id")]` on an `i64` field or
+//! `#[serde(with = "crate::serde_big_id::big_id_opt")]` on an `Option<i64>` field. On an MCP arg
+//! struct that derives `JsonSchema`, also add `#[schemars(with = "String")]` (or
+//! `Option<String>`) so the advertised input schema asks clients for a string.
+
+use std::fmt;
+
+use serde::de::{self, Deserialize, Deserializer, Unexpected, Visitor};
+use serde::{Serialize, Serializer};
+
+/// An `i64` that serializes as a decimal string and deserializes from either a string or a number.
+/// Private — the public surface is the `big_id` / `big_id_opt` serde modules.
+struct BigId(i64);
+
+impl Serialize for BigId {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.0.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for BigId {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_any(BigIdVisitor)
+    }
+}
+
+struct BigIdVisitor;
+
+impl Visitor<'_> for BigIdVisitor {
+    type Value = BigId;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("an i64 as a decimal string or a JSON number")
+    }
+
+    fn visit_i64<E: de::Error>(self, value: i64) -> Result<BigId, E> {
+        Ok(BigId(value))
+    }
+
+    fn visit_u64<E: de::Error>(self, value: u64) -> Result<BigId, E> {
+        i64::try_from(value)
+            .map(BigId)
+            .map_err(|_| E::invalid_value(Unexpected::Unsigned(value), &self))
+    }
+
+    fn visit_str<E: de::Error>(self, value: &str) -> Result<BigId, E> {
+        value.parse::<i64>().map(BigId).map_err(|_| E::invalid_value(Unexpected::Str(value), &self))
+    }
+}
+
+/// `#[serde(with = "...")]` module for a required `i64` big id (string out, string-or-number in).
+pub mod big_id {
+    use super::{BigId, Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(value: &i64, serializer: S) -> Result<S::Ok, S::Error> {
+        BigId(*value).serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<i64, D::Error> {
+        BigId::deserialize(deserializer).map(|big| big.0)
+    }
+}
+
+/// `#[serde(with = "...")]` module for an `Option<i64>` big id — `null`/absent stays `None`, a
+/// present value serializes as a string and deserializes from a string or a number.
+pub mod big_id_opt {
+    use super::{BigId, Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(value: &Option<i64>, serializer: S) -> Result<S::Ok, S::Error> {
+        value.map(BigId).serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Option<i64>, D::Error> {
+        Ok(Option::<BigId>::deserialize(deserializer)?.map(|big| big.0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+
+    /// A content-derived logical_symbol_id beyond JS's 2^53 safe-integer ceiling — the value that
+    /// rounded to `...343700` as a JSON number in the field report.
+    const BIG: i64 = 2_574_604_874_062_343_519;
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Req {
+        #[serde(with = "super::big_id")]
+        id: i64,
+    }
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Opt {
+        #[serde(with = "super::big_id_opt")]
+        id: Option<i64>,
+    }
+
+    #[test]
+    fn required_big_id_serializes_as_a_string() {
+        let json = serde_json::to_string(&Req { id: BIG }).unwrap();
+        assert_eq!(json, r#"{"id":"2574604874062343519"}"#, "must emit a string, not a number");
+    }
+
+    #[test]
+    fn required_big_id_round_trips_losslessly_through_json() {
+        let json = serde_json::to_string(&Req { id: BIG }).unwrap();
+        let back: Req = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.id, BIG);
+    }
+
+    #[test]
+    fn required_big_id_deserializes_from_a_string() {
+        let back: Req = serde_json::from_str(r#"{"id":"2574604874062343519"}"#).unwrap();
+        assert_eq!(back.id, BIG);
+    }
+
+    #[test]
+    fn required_big_id_still_accepts_a_number_for_back_compat() {
+        // A small in-safe-range value sent as a JSON number must still deserialize.
+        let back: Req = serde_json::from_str(r#"{"id":1001}"#).unwrap();
+        assert_eq!(back.id, 1001);
+    }
+
+    #[test]
+    fn optional_big_id_serializes_string_or_null() {
+        assert_eq!(
+            serde_json::to_string(&Opt { id: Some(BIG) }).unwrap(),
+            r#"{"id":"2574604874062343519"}"#
+        );
+        assert_eq!(serde_json::to_string(&Opt { id: None }).unwrap(), r#"{"id":null}"#);
+    }
+
+    #[test]
+    fn optional_big_id_deserializes_string_number_and_null() {
+        let s: Opt = serde_json::from_str(r#"{"id":"2574604874062343519"}"#).unwrap();
+        assert_eq!(s.id, Some(BIG));
+        let n: Opt = serde_json::from_str(r#"{"id":1001}"#).unwrap();
+        assert_eq!(n.id, Some(1001));
+        let z: Opt = serde_json::from_str(r#"{"id":null}"#).unwrap();
+        assert_eq!(z.id, None);
+    }
+}

--- a/crates/rag-rat-core/src/serde_big_id.rs
+++ b/crates/rag-rat-core/src/serde_big_id.rs
@@ -19,6 +19,13 @@ use std::fmt;
 use serde::de::{self, Deserialize, Deserializer, Unexpected, Visitor};
 use serde::{Serialize, Serializer};
 
+/// JSON's largest exactly-representable integer, `2^53 - 1`. A number outside `±MAX_SAFE_INTEGER`
+/// can't survive a JSON-number parse that goes through an f64, so by the time such a value reaches
+/// us as a number it has almost certainly already been rounded — accepting it would silently look
+/// up the WRONG id. The numeric deserialize path is therefore bounded to the safe range; anything
+/// larger MUST arrive as a string (#130 review).
+const MAX_SAFE_INTEGER: i64 = 9_007_199_254_740_991;
+
 /// An `i64` that serializes as a decimal string and deserializes from either a string or a number.
 /// Private — the public surface is the `big_id` / `big_id_opt` serde modules.
 struct BigId(i64);
@@ -35,23 +42,36 @@ impl<'de> Deserialize<'de> for BigId {
     }
 }
 
+/// The error for a numeric id outside the JSON safe-integer range — such a value can't be trusted
+/// (it may already be f64-rounded), so we reject it and point the caller at the string form.
+fn unsafe_number_message(value: impl fmt::Display) -> String {
+    format!(
+        "id {value} is outside JSON's safe-integer range (±2^53-1) and may have been rounded; \
+         pass it as a string"
+    )
+}
+
 struct BigIdVisitor;
 
 impl Visitor<'_> for BigIdVisitor {
     type Value = BigId;
 
     fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("an i64 as a decimal string or a JSON number")
+        f.write_str("an i64 as a decimal string, or a JSON number within ±(2^53-1)")
     }
 
     fn visit_i64<E: de::Error>(self, value: i64) -> Result<BigId, E> {
+        if !(-MAX_SAFE_INTEGER..=MAX_SAFE_INTEGER).contains(&value) {
+            return Err(E::custom(unsafe_number_message(value)));
+        }
         Ok(BigId(value))
     }
 
     fn visit_u64<E: de::Error>(self, value: u64) -> Result<BigId, E> {
-        i64::try_from(value)
-            .map(BigId)
-            .map_err(|_| E::invalid_value(Unexpected::Unsigned(value), &self))
+        if value > MAX_SAFE_INTEGER as u64 {
+            return Err(E::custom(unsafe_number_message(value)));
+        }
+        Ok(BigId(value as i64))
     }
 
     fn visit_str<E: de::Error>(self, value: &str) -> Result<BigId, E> {
@@ -128,10 +148,26 @@ mod tests {
     }
 
     #[test]
-    fn required_big_id_still_accepts_a_number_for_back_compat() {
+    fn required_big_id_still_accepts_a_safe_number_for_back_compat() {
         // A small in-safe-range value sent as a JSON number must still deserialize.
         let back: Req = serde_json::from_str(r#"{"id":1001}"#).unwrap();
         assert_eq!(back.id, 1001);
+        // The boundary value 2^53-1 is still accepted as a number.
+        let edge: Req = serde_json::from_str(r#"{"id":9007199254740991}"#).unwrap();
+        assert_eq!(edge.id, 9_007_199_254_740_991);
+    }
+
+    #[test]
+    fn unsafe_number_is_rejected_so_a_rounded_id_never_silently_binds() {
+        // A value above 2^53 sent as a JSON NUMBER may already be f64-rounded; reject it rather
+        // than look up the wrong id. The same value as a STRING is exact and accepted (#130
+        // review).
+        let as_number = serde_json::from_str::<Req>(r#"{"id":2574604874062343519}"#);
+        assert!(as_number.is_err(), "an unsafe numeric id must be rejected, not silently accepted");
+        let as_string: Req = serde_json::from_str(r#"{"id":"2574604874062343519"}"#).unwrap();
+        assert_eq!(as_string.id, BIG);
+        // The optional variant rejects an unsafe number too.
+        assert!(serde_json::from_str::<Opt>(r#"{"id":2574604874062343519}"#).is_err());
     }
 
     #[test]

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -231,6 +231,9 @@ pub struct RepoClustersArgs {
 pub struct SymbolArgs {
     pub symbol: Option<String>,
     pub symbol_path: Option<String>,
+    // 64-bit content hash > 2^53: take it as a string so a JSON client doesn't round it (#130).
+    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::big_id_opt::deserialize")]
+    #[schemars(with = "Option<String>")]
     pub logical_symbol_id: Option<i64>,
     pub symbol_id: Option<i64>,
     pub language: Option<String>,
@@ -245,6 +248,9 @@ pub struct SymbolArgs {
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
 pub struct SymbolGraphArgs {
     pub symbol: Option<String>,
+    // 64-bit content hash > 2^53: take it as a string so a JSON client doesn't round it (#130).
+    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::big_id_opt::deserialize")]
+    #[schemars(with = "Option<String>")]
     pub logical_symbol_id: Option<i64>,
     pub symbol_id: Option<i64>,
     pub symbol_path: Option<String>,
@@ -272,6 +278,9 @@ pub struct SymbolGraphArgs {
 pub struct CompareGraphTextArgs {
     pub pattern: String,
     pub symbol: Option<String>,
+    // 64-bit content hash > 2^53: take it as a string so a JSON client doesn't round it (#130).
+    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::big_id_opt::deserialize")]
+    #[schemars(with = "Option<String>")]
     pub logical_symbol_id: Option<i64>,
     pub symbol_id: Option<i64>,
     pub symbol_path: Option<String>,
@@ -298,6 +307,9 @@ pub struct ImpactArgs {
     pub query: Option<String>,
     pub symbol: Option<String>,
     pub symbol_path: Option<String>,
+    // 64-bit content hash > 2^53: take it as a string so a JSON client doesn't round it (#130).
+    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::big_id_opt::deserialize")]
+    #[schemars(with = "Option<String>")]
     pub logical_symbol_id: Option<i64>,
     pub symbol_id: Option<i64>,
     pub resolution: Option<McpGraphResolutionMode>,
@@ -433,6 +445,9 @@ impl McpMemorySource {
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
 pub struct MemoryBindArgs {
+    // 64-bit content hash > 2^53: take it as a string so a JSON client doesn't round it (#130).
+    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::big_id_opt::deserialize")]
+    #[schemars(with = "Option<String>")]
     pub logical_symbol_id: Option<i64>,
     pub symbol_id: Option<i64>,
     pub chunk_id: Option<i64>,
@@ -444,7 +459,11 @@ pub struct MemoryBindArgs {
     pub github_owner: Option<String>,
     pub github_repo: Option<String>,
     pub github_number: Option<i64>,
+    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::big_id_opt::deserialize")]
+    #[schemars(with = "Option<String>")]
     pub start_logical_symbol_id: Option<i64>,
+    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::big_id_opt::deserialize")]
+    #[schemars(with = "Option<String>")]
     pub end_logical_symbol_id: Option<i64>,
     pub edge_sequence_hash: Option<String>,
     pub path_summary: Option<String>,
@@ -498,6 +517,9 @@ pub struct MemorySearchArgs {
 pub struct MemoryForSymbolArgs {
     pub symbol: Option<String>,
     pub symbol_path: Option<String>,
+    // 64-bit content hash > 2^53: take it as a string so a JSON client doesn't round it (#130).
+    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::big_id_opt::deserialize")]
+    #[schemars(with = "Option<String>")]
     pub logical_symbol_id: Option<i64>,
     pub symbol_id: Option<i64>,
     #[serde(default)]

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -283,8 +283,11 @@ fn mcp_memory_tools_create_surface_validate_and_obsolete_symbol_memory() {
         json!({"symbol": "cfg_helper", "allow_ambiguous": true}),
     )
     .unwrap();
+    // logical_symbol_id crosses the MCP boundary as a STRING (#130: a 64-bit hash > 2^53 can't be a
+    // JSON number without rounding). Read it as a string and pass it straight back to the other
+    // tools — the round-trip the fix guarantees.
     let logical_symbol_id =
-        lookup["candidates"].as_array().unwrap()[0]["logical_symbol_id"].as_i64().unwrap();
+        lookup["candidates"].as_array().unwrap()[0]["logical_symbol_id"].as_str().unwrap();
     let memory = call_tool(
             &config.database,
             "memory_create",


### PR DESCRIPTION
## Problem

`logical_symbol_id` is a content-derived 64-bit hash (~2.5e18), far above JSON's 2^53 safe-integer range. As a JSON **number** it can't round-trip: a client that parses numbers as f64 (every JS-based MCP client) silently rounds it — `2574604874062343519` → `2574604874062343700` — so the id is corrupted before the server ever sees it. Every MCP tool taking `logical_symbol_id` (`memory_rebind`, `memory_for_symbol`, `symbol_lookup`, …) was effectively unusable; only the CLI (string arg) worked.

## Fix

These ids now cross **every** serde boundary (CLI `--json`, MCP JSON, MCP TOON) as a **string**.

New `crate::serde_big_id` helper:
- `big_id` (i64) / `big_id_opt` (Option<i64>) — serialize → string; deserialize → accept **string or number** (back-compat for in-range values and older clients).

Applied to:
- **Output** (serialize → string): `SymbolHit`, `LogicalSymbolHit`, `GraphTraversalQuery`, `LogicalSymbol`, `CompareGraphTextQuery`, `RepoMemoryBinding`, `RepoMemoryCallPath`.
- **Input** (deserialize string-or-number): `RepoMemoryBindTarget` + the MCP arg structs, with `#[schemars(with = "Option<String>")]` so the advertised input schema asks clients for a string. `#[serde(default)]` keeps the fields optional now that a custom deserializer is attached.

Small rowids (`symbol_id`/`chunk_id`/`edge_id`) stay numbers — they're within JSON's safe range.

## Tests
- `serde_big_id` unit tests: serialize-as-string, >2^53 lossless round-trip, deserialize from string/number/null.
- The in-process MCP memory test now reads `logical_symbol_id` from `symbol_lookup` output **as a string** and passes it back through the arg structs into `memory_create`/`memory_for_symbol`/`impact_surface` — proving the end-to-end round-trip (the fixture's id is a content-hash > 2^53). It would have failed (`as_i64` → None) before the fix.

Full workspace tests, clippy, and `cargo +nightly fmt` clean.

## Compatibility note
CLI `--json` and MCP output now emit these ids as JSON strings instead of numbers. Pre-1.0; correct per JSON's integer limits. Deserialize still accepts numbers, so existing in-range callers keep working.

Fixes #130