### PR TITLE
fix(mcp): harden hook listener — bind-retry, coverage-flaky test, cfg-gated tokio (#53, #84, #54)

### DIFF
--- a/crates/rag-rat-mcp/Cargo.toml
+++ b/crates/rag-rat-mcp/Cargo.toml
@@ -18,10 +18,13 @@ rmcp.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["signal", "sync", "io-util", "net", "time"] }
+tokio = { workspace = true, features = ["sync", "io-util"] }
 
+# `net` / `time` / `signal` are consumed only by the unix-gated hot-upgrade (`upgrade.rs`) and hook
+# listener (`claude_hook.rs::listener`) — dead on non-unix targets, so gate them there (#54).
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
+tokio = { workspace = true, features = ["net", "time", "signal"] }
 
 [features]
 default = ["fastembed", "model2vec"]

--- a/crates/rag-rat-mcp/src/claude_hook.rs
+++ b/crates/rag-rat-mcp/src/claude_hook.rs
@@ -73,21 +73,33 @@ mod listener {
     pub fn spawn_listener(config: Config) -> JoinHandle<()> {
         tokio::spawn(async move {
             let lock_path = socket_lock_path_for(&config);
-            // The lock must live inside this task: aborting the task drops it, so a
-            // surviving process's retry loop can take over (election, watcher-identical).
-            let _lock: FileLock = loop {
-                match FileLock::try_acquire(&lock_path) {
-                    Ok(Some(lock)) => break lock,
-                    _ => tokio::time::sleep(ELECTION_RETRY).await,
-                }
-            };
             let socket = socket_path_for(&config);
             if let Some(parent) = socket.parent() {
                 let _ = std::fs::create_dir_all(parent);
             }
-            // Only the lock holder ever unlinks: race-free stale-socket cleanup.
-            let _ = std::fs::remove_file(&socket);
-            let Ok(listener) = UnixListener::bind(&socket) else { return };
+            // Win the socket election, then bind. The lock must live inside this task: aborting the
+            // task drops it, so a surviving process's retry loop can take over (election,
+            // watcher-identical). A bind that fails AFTER winning the election (a transient
+            // FS/permissions hiccup) must not strand the worktree serving nothing while holding the
+            // lock (#53): drop the election so a sibling can try, back off, and re-elect — the same
+            // die→next-process-takes-over model, made resilient for the single-process case too.
+            let (_lock, listener): (FileLock, UnixListener) = loop {
+                let lock = loop {
+                    match FileLock::try_acquire(&lock_path) {
+                        Ok(Some(lock)) => break lock,
+                        _ => tokio::time::sleep(ELECTION_RETRY).await,
+                    }
+                };
+                // Only the lock holder ever unlinks: race-free stale-socket cleanup.
+                let _ = std::fs::remove_file(&socket);
+                match UnixListener::bind(&socket) {
+                    Ok(listener) => break (lock, listener),
+                    Err(_) => {
+                        drop(lock);
+                        tokio::time::sleep(ELECTION_RETRY).await;
+                    },
+                }
+            };
             let mut sessions: HashMap<String, SessionState> = HashMap::new();
             loop {
                 let Ok((stream, _addr)) = listener.accept().await else {
@@ -233,6 +245,26 @@ mod listener_tests {
         serde_json::from_str(&line).unwrap()
     }
 
+    /// Fallible `request`: `None` on any connect/write/read failure or an empty read. During a
+    /// listener takeover the connection can be reset or closed mid-handoff while the new owner is
+    /// still binding (the race widens under llvm-cov instrumentation — #84), which means "not
+    /// serving yet, retry," not a test failure. Callers must use a FRESH session per attempt so a
+    /// half-completed attempt can't dedupe the retry to a null context.
+    async fn try_request(
+        socket: &std::path::Path,
+        body: serde_json::Value,
+    ) -> Option<serde_json::Value> {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+        let stream = tokio::net::UnixStream::connect(socket).await.ok()?;
+        let (read, mut write) = stream.into_split();
+        write.write_all(format!("{body}\n").as_bytes()).await.ok()?;
+        let mut line = String::new();
+        if BufReader::new(read).read_line(&mut line).await.ok()? == 0 {
+            return None;
+        }
+        serde_json::from_str(&line).ok()
+    }
+
     #[tokio::test]
     async fn listener_serves_context_then_dedupes_per_session() {
         let config = test_config();
@@ -280,16 +312,21 @@ mod listener_tests {
         let _ = winner.await;
         // NOTE: in-process abort drops the FileLock (held by the task) but the dead socket
         // file remains — exactly the stale-socket case. The loser must unlink + re-bind.
-        let req = serde_json::json!({"v": 1, "kind": "grep_augment", "session_id": "takeover",
-                                     "pattern": "frobnicate", "search_path": null,
-                                     "source": "grep_tool"});
+        // Election retry is 5s; poll until the loser owns the socket and serves a real reply. The
+        // connection can be reset/closed mid-handoff while the loser is still binding, so use the
+        // fallible `try_request` with a FRESH session per attempt (so a half-completed attempt
+        // never dedupes the retry) rather than unwrap()-ing the first read (#84).
         let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        let mut attempt = 0u32;
         loop {
-            // Election retry is 5s; poll until the loser owns the socket and answers.
-            if let Ok(stream) = tokio::net::UnixStream::connect(&socket).await {
-                drop(stream);
-                let reply = request(&socket, req.clone()).await;
-                assert!(reply["context"].as_str().unwrap().contains("lib::frobnicate"));
+            attempt += 1;
+            let req = serde_json::json!({"v": 1, "kind": "grep_augment",
+                                         "session_id": format!("takeover-{attempt}"),
+                                         "pattern": "frobnicate", "search_path": null,
+                                         "source": "grep_tool"});
+            if let Some(reply) = try_request(&socket, req).await
+                && reply["context"].as_str().is_some_and(|c| c.contains("lib::frobnicate"))
+            {
                 break;
             }
             assert!(std::time::Instant::now() < deadline, "loser never took over the socket");


### PR DESCRIPTION
Three related rag-rat-mcp hook-listener fixes.

### #53 — bind failure after winning the election stranded the worktree
`spawn_listener` won the socket election, then `let Ok(listener) = UnixListener::bind(..) else { return }`. A bind failure *after* the election (transient FS/permissions) exited the task while holding the election lock — augmentation silently off, and no sibling `rag-rat mcp` could take the socket. Now election+bind is a loop: on bind failure, **drop the lock and re-elect after a backoff** (the watcher's die→next-process-takes-over model, now resilient in the single-process case too).

### #84 — flaky `second_listener_takes_over_when_winner_dies` under llvm-cov
The takeover test `read_line().unwrap()`-ed the first read; under coverage instrumentation the connection can be reset/closed mid-handoff while the new owner is still binding, panicking instead of yielding a line. Added a fallible `try_request` (returns `None` on connect/write/read failure or an empty read) and the takeover loop now polls it with a **fresh session per attempt** — so a half-completed attempt can't dedupe the retry to a null context — within the existing bounded deadline. No blanket sleep.

### #54 — gate unix-only tokio features
`net`/`time`/`signal` are consumed only by the `#[cfg(unix)]` hot-upgrade (`upgrade.rs`, wholly gated in lib.rs) and hook listener; moved them under `[target.'cfg(unix)'.dependencies]`, leaving `sync`/`io-util` unconditional.

## Verification
- `cargo test -p rag-rat-mcp -p rag-rat` green; `claude_hook` tests pass 3× under `--no-default-features` (the coverage-CI config where #84 surfaced).
- clippy + `cargo +nightly fmt` clean.
- Non-unix not cross-compiled (no suitable target/toolchain installed — Android is unix, wasm won't build rusqlite), but every `net`/`time`/`signal` consumer is in `#[cfg(unix)]` code by grep + the `#[cfg(unix)] mod upgrade` gate, so they're dead on non-unix by construction.

Fixes #53, #84, #54