### PR TITLE
fix(mcp): report the real crate version in serverInfo (was hardcoded 0.3.1)

### DIFF
--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -464,7 +464,7 @@ impl RagRatService {
 impl ServerHandler for RagRatService {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
-            .with_server_info(Implementation::new("rag-rat", "0.3.1"))
+            .with_server_info(Implementation::new("rag-rat", env!("CARGO_PKG_VERSION")))
             .with_instructions(
                 "Read-only-source repo intelligence. Index and auto-heal writes are confined to \
                  the configured SQLite database.",


### PR DESCRIPTION
The MCP `initialize` response hardcoded `serverInfo.version = "0.3.1"` (`Implementation::new("rag-rat", "0.3.1")`), so every client saw a stale version regardless of the actual release. Use `env!("CARGO_PKG_VERSION")` so it tracks the lockstep workspace version automatically.

Verified over the wire:
```
$ printf '…initialize…' | rag-rat mcp
"serverInfo":{"name":"rag-rat","version":"0.5.0"}
```

Surfaced while investigating #85 (Codex MCP integration). clippy + `cargo +nightly fmt` clean.