### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.5.0...rag-rat-core-v0.6.0) - 2026-06-15
+
+### Added
+
+- *(mcp)* expose memory_doctor; raise memory body cap to 8000 + document caps ([#159](https://github.com/cq27-dev/rag-rat/pull/159))
+- opaque sym_<hex> symbol handle; drop ephemeral symbol_id from the wire ([#149](https://github.com/cq27-dev/rag-rat/pull/149)) ([#153](https://github.com/cq27-dev/rag-rat/pull/153))
+- lazy-heal symbol_lookup + flag dirty result files (#147, #148) ([#151](https://github.com/cq27-dev/rag-rat/pull/151))
+- confidence-aware + SCIP-aware symbol importance ranking ([#108](https://github.com/cq27-dev/rag-rat/pull/108)) ([#142](https://github.com/cq27-dev/rag-rat/pull/142))
+- crates.io version check surfaced to agents + operators (opt-out via rag-rat.toml) ([#136](https://github.com/cq27-dev/rag-rat/pull/136))
+
+### Fixed
+
+- *(impact)* signal truncation on the flat impact_surface shape ([#150](https://github.com/cq27-dev/rag-rat/pull/150)) ([#157](https://github.com/cq27-dev/rag-rat/pull/157))
+- *(index)* heal a just-added symbol on a zero-hit name lookup ([#152](https://github.com/cq27-dev/rag-rat/pull/152)) ([#158](https://github.com/cq27-dev/rag-rat/pull/158))
+- *(memory)* re-derive chunk for live logical-symbol bindings on validate ([#154](https://github.com/cq27-dev/rag-rat/pull/154)) ([#156](https://github.com/cq27-dev/rag-rat/pull/156))
+- oracle started_at = run start ([#145](https://github.com/cq27-dev/rag-rat/pull/145)); impact_surface flags truncated sections ([#49](https://github.com/cq27-dev/rag-rat/pull/49)) ([#146](https://github.com/cq27-dev/rag-rat/pull/146))
+- *(mcp)* read tools open read-only so a writer can't lock them out ([#143](https://github.com/cq27-dev/rag-rat/pull/143)) ([#144](https://github.com/cq27-dev/rag-rat/pull/144))
+- *(grep-augment)* skip pipe-incidental greps + dedup indexed hits (#138, #139) ([#140](https://github.com/cq27-dev/rag-rat/pull/140))
+
+### Other
+
+- de-spine the index + mcp crates — module splits, param structs, naming ([#155](https://github.com/cq27-dev/rag-rat/pull/155))
+- rewrite README, add oracle/grep-augmentation docs, fix MCP setup footgun
+- *(index)* regression for foreign leaked rows self-healing on full rebuild ([#59](https://github.com/cq27-dev/rag-rat/pull/59)) ([#133](https://github.com/cq27-dev/rag-rat/pull/133))
+
 ## [0.5.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.4.0...rag-rat-core-v0.5.0) - 2026-06-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3118,7 +3118,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rag-rat"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3167,7 +3167,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-mcp"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "3"
 # and the internal path deps below pin the same literal, so the three crates always publish in
 # lockstep. Bump this one line (and the two internal-dep `version`s under workspace.dependencies)
 # to release.
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kristaps Karlsons"]
 edition = "2024"
 rust-version = "1.89"
@@ -25,8 +25,8 @@ categories = ["command-line-utilities", "development-tools"]
 # Internal crates — declared once here so the version requirement is set in lockstep with
 # [workspace.package].version above. Members reference these via `{ workspace = true }` and add
 # their own feature toggles at the use site.
-rag-rat-core = { version = "0.5.0", path = "crates/rag-rat-core", default-features = false }
-rag-rat-mcp = { version = "0.5.0", path = "crates/rag-rat-mcp", default-features = false }
+rag-rat-core = { version = "0.6.0", path = "crates/rag-rat-core", default-features = false }
+rag-rat-mcp = { version = "0.6.0", path = "crates/rag-rat-mcp", default-features = false }
 anyhow = "1.0"
 fastembed = { version = "5.1.0", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
 gix = { version = "0.84.0", default-features = false, features = ["status", "parallel", "sha1"] }


### PR DESCRIPTION



## 🤖 New release

* `rag-rat-core`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `rag-rat-mcp`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `rag-rat`: 0.5.0 -> 0.6.0

### ⚠ `rag-rat-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field GraphHop.importance in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-core/src/query/graph/mod.rs:289
  field SymbolHit.importance in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-core/src/query/symbol.rs:44
  field ImpactCompleteness.truncated_sections in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-core/src/query/impact/mod.rs:79
  field Config.version_check in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-core/src/config.rs:18
  field Config.oracle in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-core/src/config.rs:19
  field Config.version_check in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-core/src/config.rs:18
  field Config.oracle in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-core/src/config.rs:19
  field SearchHit.importance in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-core/src/search/lexical.rs:44
  field SymbolLookup.stale_files in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-core/src/query/symbol.rs:55

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function rag_rat_core::serde_big_id::big_id_opt::deserialize, previously in file /tmp/.tmpceAVPL/rag-rat-core/src/serde_big_id.rs:104
  function rag_rat_core::serde_big_id::big_id::serialize, previously in file /tmp/.tmpceAVPL/rag-rat-core/src/serde_big_id.rs:86
  function rag_rat_core::serde_big_id::big_id_opt::serialize, previously in file /tmp/.tmpceAVPL/rag-rat-core/src/serde_big_id.rs:100
  function rag_rat_core::serde_big_id::big_id::deserialize, previously in file /tmp/.tmpceAVPL/rag-rat-core/src/serde_big_id.rs:90

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_parameter_count_changed.ron

Failed in:
  rag_rat_core::search::lexical::search_with_options now takes 2 parameters instead of 6, in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-core/src/search/lexical.rs:148

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  IndexDatabase::search_with_graph_meta_options, previously in file /tmp/.tmpceAVPL/rag-rat-core/src/index/query_api.rs:270
  IndexDatabase::search_explain_with_graph_meta, previously in file /tmp/.tmpceAVPL/rag-rat-core/src/index/query_api.rs:291
  IndexDatabase::search_explain_with_graph_meta_options, previously in file /tmp/.tmpceAVPL/rag-rat-core/src/index/query_api.rs:309
  IndexDatabase::gc, previously in file /tmp/.tmpceAVPL/rag-rat-core/src/index/query_api.rs:782
  IndexDatabase::search_with_graph_meta_options, previously in file /tmp/.tmpceAVPL/rag-rat-core/src/index/query_api.rs:270
  IndexDatabase::search_explain_with_graph_meta, previously in file /tmp/.tmpceAVPL/rag-rat-core/src/index/query_api.rs:291
  IndexDatabase::search_explain_with_graph_meta_options, previously in file /tmp/.tmpceAVPL/rag-rat-core/src/index/query_api.rs:309
  IndexDatabase::gc, previously in file /tmp/.tmpceAVPL/rag-rat-core/src/index/query_api.rs:782

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  rag_rat_core::index::IndexDatabase::run_oracle takes 5 parameters in /tmp/.tmpceAVPL/rag-rat-core/src/index/query_api.rs:17, but now takes 4 parameters in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-core/src/index/query_api/oracle_runs.rs:34
  rag_rat_core::index::IndexDatabase::search_with_graph_meta takes 5 parameters in /tmp/.tmpceAVPL/rag-rat-core/src/index/query_api.rs:252, but now takes 1 parameters in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-core/src/index/query_api/search.rs:65
  rag_rat_core::IndexDatabase::run_oracle takes 5 parameters in /tmp/.tmpceAVPL/rag-rat-core/src/index/query_api.rs:17, but now takes 4 parameters in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-core/src/index/query_api/oracle_runs.rs:34
  rag_rat_core::IndexDatabase::search_with_graph_meta takes 5 parameters in /tmp/.tmpceAVPL/rag-rat-core/src/index/query_api.rs:252, but now takes 1 parameters in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-core/src/index/query_api/search.rs:65

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod rag_rat_core::serde_big_id::big_id, previously in file /tmp/.tmpceAVPL/rag-rat-core/src/serde_big_id.rs:83
  mod rag_rat_core::serde_big_id::big_id_opt, previously in file /tmp/.tmpceAVPL/rag-rat-core/src/serde_big_id.rs:97

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field include_tests of struct CompareGraphTextQuery, previously in file /tmp/.tmpceAVPL/rag-rat-core/src/query/graph/mod.rs:186
  field include_tests of struct ImpactSurfaceQuery, previously in file /tmp/.tmpceAVPL/rag-rat-core/src/query/impact/mod.rs:61
  field include_docs of struct ImpactSurfaceQuery, previously in file /tmp/.tmpceAVPL/rag-rat-core/src/query/impact/mod.rs:62
  field include_git of struct ImpactSurfaceQuery, previously in file /tmp/.tmpceAVPL/rag-rat-core/src/query/impact/mod.rs:63
  field include_papertrail of struct ImpactSurfaceQuery, previously in file /tmp/.tmpceAVPL/rag-rat-core/src/query/impact/mod.rs:64
  field include_text_fallback of struct ImpactSurfaceQuery, previously in file /tmp/.tmpceAVPL/rag-rat-core/src/query/impact/mod.rs:65
  field include_memories of struct ImpactSurfaceQuery, previously in file /tmp/.tmpceAVPL/rag-rat-core/src/query/impact/mod.rs:66
```

### ⚠ `rag-rat-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CompareGraphTextArgs.include in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:368
  field ImpactArgs.include in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:397
  field RepoBriefArgs.include in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:261
  field RepoClustersArgs.include in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:270
  field PapertrailCommitArgs.include in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:666
  field SearchArgs.include in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:226
  field SymbolArgs.include in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:313
  field SymbolGraphArgs.include in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:339
  field ReadChunkArgs.include in /tmp/.tmpY6fl8t/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:415

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field symbol_id of struct CompareGraphTextArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:285
  field include_tests of struct CompareGraphTextArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:291
  field include_references of struct CompareGraphTextArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:295
  field include_unresolved of struct CompareGraphTextArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:297
  field include_macros of struct CompareGraphTextArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:299
  field include_common_methods of struct CompareGraphTextArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:301
  field symbol_id of struct ImpactArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:314
  field include_tests of struct ImpactArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:321
  field include_docs of struct ImpactArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:323
  field include_git of struct ImpactArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:325
  field include_papertrail of struct ImpactArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:327
  field include_text_fallback of struct ImpactArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:329
  field include_memories of struct ImpactArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:331
  field include_generated of struct RepoBriefArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:213
  field include_memories of struct RepoBriefArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:215
  field include_generated of struct RepoClustersArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:223
  field include_memories of struct RepoClustersArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:225
  field symbol_id of struct MemoryBindArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:452
  field include_fallback of struct PapertrailCommitArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:575
  field include_generated of struct SearchArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:171
  field include_git of struct SearchArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:175
  field include_papertrail of struct SearchArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:177
  field include_fallback of struct SearchArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:183
  field symbol_id of struct SymbolArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:238
  field include_memories of struct SymbolArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:245
  field symbol_id of struct SymbolGraphArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:255
  field include_references of struct SymbolGraphArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:263
  field include_unresolved of struct SymbolGraphArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:265
  field include_macros of struct SymbolGraphArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:267
  field include_common_methods of struct SymbolGraphArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:269
  field include_coverage of struct SymbolGraphArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:271
  field include_memories of struct SymbolGraphArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:273
  field include_memories of struct ReadChunkArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:348
  field symbol_id of struct MemoryForSymbolArgs, previously in file /tmp/.tmpceAVPL/rag-rat-mcp/src/tools/mod.rs:524
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rag-rat-core`

<blockquote>

## [0.6.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.5.0...rag-rat-core-v0.6.0) - 2026-06-15

### Added

- *(mcp)* expose memory_doctor; raise memory body cap to 8000 + document caps ([#159](https://github.com/cq27-dev/rag-rat/pull/159))
- opaque sym_<hex> symbol handle; drop ephemeral symbol_id from the wire ([#149](https://github.com/cq27-dev/rag-rat/pull/149)) ([#153](https://github.com/cq27-dev/rag-rat/pull/153))
- lazy-heal symbol_lookup + flag dirty result files (#147, #148) ([#151](https://github.com/cq27-dev/rag-rat/pull/151))
- confidence-aware + SCIP-aware symbol importance ranking ([#108](https://github.com/cq27-dev/rag-rat/pull/108)) ([#142](https://github.com/cq27-dev/rag-rat/pull/142))
- crates.io version check surfaced to agents + operators (opt-out via rag-rat.toml) ([#136](https://github.com/cq27-dev/rag-rat/pull/136))

### Fixed

- *(impact)* signal truncation on the flat impact_surface shape ([#150](https://github.com/cq27-dev/rag-rat/pull/150)) ([#157](https://github.com/cq27-dev/rag-rat/pull/157))
- *(index)* heal a just-added symbol on a zero-hit name lookup ([#152](https://github.com/cq27-dev/rag-rat/pull/152)) ([#158](https://github.com/cq27-dev/rag-rat/pull/158))
- *(memory)* re-derive chunk for live logical-symbol bindings on validate ([#154](https://github.com/cq27-dev/rag-rat/pull/154)) ([#156](https://github.com/cq27-dev/rag-rat/pull/156))
- oracle started_at = run start ([#145](https://github.com/cq27-dev/rag-rat/pull/145)); impact_surface flags truncated sections ([#49](https://github.com/cq27-dev/rag-rat/pull/49)) ([#146](https://github.com/cq27-dev/rag-rat/pull/146))
- *(mcp)* read tools open read-only so a writer can't lock them out ([#143](https://github.com/cq27-dev/rag-rat/pull/143)) ([#144](https://github.com/cq27-dev/rag-rat/pull/144))
- *(grep-augment)* skip pipe-incidental greps + dedup indexed hits (#138, #139) ([#140](https://github.com/cq27-dev/rag-rat/pull/140))

### Other

- de-spine the index + mcp crates — module splits, param structs, naming ([#155](https://github.com/cq27-dev/rag-rat/pull/155))
- rewrite README, add oracle/grep-augmentation docs, fix MCP setup footgun
- *(index)* regression for foreign leaked rows self-healing on full rebuild ([#59](https://github.com/cq27-dev/rag-rat/pull/59)) ([#133](https://github.com/cq27-dev/rag-rat/pull/133))
</blockquote>

## `rag-rat-mcp`

<blockquote>

## [0.6.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.5.0...rag-rat-core-v0.6.0) - 2026-06-15

### Added

- *(mcp)* expose memory_doctor; raise memory body cap to 8000 + document caps ([#159](https://github.com/cq27-dev/rag-rat/pull/159))
- opaque sym_<hex> symbol handle; drop ephemeral symbol_id from the wire ([#149](https://github.com/cq27-dev/rag-rat/pull/149)) ([#153](https://github.com/cq27-dev/rag-rat/pull/153))
- lazy-heal symbol_lookup + flag dirty result files (#147, #148) ([#151](https://github.com/cq27-dev/rag-rat/pull/151))
- confidence-aware + SCIP-aware symbol importance ranking ([#108](https://github.com/cq27-dev/rag-rat/pull/108)) ([#142](https://github.com/cq27-dev/rag-rat/pull/142))
- crates.io version check surfaced to agents + operators (opt-out via rag-rat.toml) ([#136](https://github.com/cq27-dev/rag-rat/pull/136))

### Fixed

- *(impact)* signal truncation on the flat impact_surface shape ([#150](https://github.com/cq27-dev/rag-rat/pull/150)) ([#157](https://github.com/cq27-dev/rag-rat/pull/157))
- *(index)* heal a just-added symbol on a zero-hit name lookup ([#152](https://github.com/cq27-dev/rag-rat/pull/152)) ([#158](https://github.com/cq27-dev/rag-rat/pull/158))
- *(memory)* re-derive chunk for live logical-symbol bindings on validate ([#154](https://github.com/cq27-dev/rag-rat/pull/154)) ([#156](https://github.com/cq27-dev/rag-rat/pull/156))
- oracle started_at = run start ([#145](https://github.com/cq27-dev/rag-rat/pull/145)); impact_surface flags truncated sections ([#49](https://github.com/cq27-dev/rag-rat/pull/49)) ([#146](https://github.com/cq27-dev/rag-rat/pull/146))
- *(mcp)* read tools open read-only so a writer can't lock them out ([#143](https://github.com/cq27-dev/rag-rat/pull/143)) ([#144](https://github.com/cq27-dev/rag-rat/pull/144))
- *(grep-augment)* skip pipe-incidental greps + dedup indexed hits (#138, #139) ([#140](https://github.com/cq27-dev/rag-rat/pull/140))

### Other

- de-spine the index + mcp crates — module splits, param structs, naming ([#155](https://github.com/cq27-dev/rag-rat/pull/155))
- rewrite README, add oracle/grep-augmentation docs, fix MCP setup footgun
- *(index)* regression for foreign leaked rows self-healing on full rebuild ([#59](https://github.com/cq27-dev/rag-rat/pull/59)) ([#133](https://github.com/cq27-dev/rag-rat/pull/133))
</blockquote>

## `rag-rat`

<blockquote>

## [0.6.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.5.0...rag-rat-core-v0.6.0) - 2026-06-15

### Added

- *(mcp)* expose memory_doctor; raise memory body cap to 8000 + document caps ([#159](https://github.com/cq27-dev/rag-rat/pull/159))
- opaque sym_<hex> symbol handle; drop ephemeral symbol_id from the wire ([#149](https://github.com/cq27-dev/rag-rat/pull/149)) ([#153](https://github.com/cq27-dev/rag-rat/pull/153))
- lazy-heal symbol_lookup + flag dirty result files (#147, #148) ([#151](https://github.com/cq27-dev/rag-rat/pull/151))
- confidence-aware + SCIP-aware symbol importance ranking ([#108](https://github.com/cq27-dev/rag-rat/pull/108)) ([#142](https://github.com/cq27-dev/rag-rat/pull/142))
- crates.io version check surfaced to agents + operators (opt-out via rag-rat.toml) ([#136](https://github.com/cq27-dev/rag-rat/pull/136))

### Fixed

- *(impact)* signal truncation on the flat impact_surface shape ([#150](https://github.com/cq27-dev/rag-rat/pull/150)) ([#157](https://github.com/cq27-dev/rag-rat/pull/157))
- *(index)* heal a just-added symbol on a zero-hit name lookup ([#152](https://github.com/cq27-dev/rag-rat/pull/152)) ([#158](https://github.com/cq27-dev/rag-rat/pull/158))
- *(memory)* re-derive chunk for live logical-symbol bindings on validate ([#154](https://github.com/cq27-dev/rag-rat/pull/154)) ([#156](https://github.com/cq27-dev/rag-rat/pull/156))
- oracle started_at = run start ([#145](https://github.com/cq27-dev/rag-rat/pull/145)); impact_surface flags truncated sections ([#49](https://github.com/cq27-dev/rag-rat/pull/49)) ([#146](https://github.com/cq27-dev/rag-rat/pull/146))
- *(mcp)* read tools open read-only so a writer can't lock them out ([#143](https://github.com/cq27-dev/rag-rat/pull/143)) ([#144](https://github.com/cq27-dev/rag-rat/pull/144))
- *(grep-augment)* skip pipe-incidental greps + dedup indexed hits (#138, #139) ([#140](https://github.com/cq27-dev/rag-rat/pull/140))

### Other

- de-spine the index + mcp crates — module splits, param structs, naming ([#155](https://github.com/cq27-dev/rag-rat/pull/155))
- rewrite README, add oracle/grep-augmentation docs, fix MCP setup footgun
- *(index)* regression for foreign leaked rows self-healing on full rebuild ([#59](https://github.com/cq27-dev/rag-rat/pull/59)) ([#133](https://github.com/cq27-dev/rag-rat/pull/133))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).