### PR TITLE
feat: crates.io version check surfaced to agents + operators (opt-out via rag-rat.toml)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3162,6 +3162,7 @@ dependencies = [
  "tree-sitter-kotlin-ng",
  "tree-sitter-rust",
  "tree-sitter-typescript",
+ "ureq 2.12.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ serde_json = "1.0"
 sha2 = "0.11"
 thiserror = "2.0"
 tokio = { version = "1.48", features = ["rt-multi-thread", "macros", "io-std"] }
+# Minimal blocking HTTP for the crates.io version check (and future GitHub/GitLab/Bitbucket REST).
+# rustls (no system OpenSSL); gzip off — the responses are tiny. The only HTTP at the core edge.
+ureq = { version = "2", default-features = false, features = ["tls"] }
 # TOON (Token-Oriented Object Notation): the default render for CLI + MCP output. ~34% fewer tokens
 # than compact JSON on uniform-row payloads, neutral on nested ones — see rag_rat_core::output.
 # default-features = false drops its `cli` feature (ratatui/crossterm/arboard/syntect/tiktoken-rs/…)

--- a/crates/rag-rat-cli/src/claude_hook.rs
+++ b/crates/rag-rat-cli/src/claude_hook.rs
@@ -286,8 +286,12 @@ fn version_line(status: &rag_rat_core::version_check::VersionStatus) -> Option<S
             "\n⚠ rag-rat update available: {} → {} — run `{}`\n",
             status.current_version, latest, status.update_command
         ))
-    } else {
+    } else if latest == status.current_version {
         Some(format!("\nrag-rat {} (latest on crates.io)\n", status.current_version))
+    } else {
+        // Local build ahead of the published latest (dev / pre-release after a version bump) —
+        // don't call it the crates.io latest.
+        Some(format!("\nrag-rat {} (ahead of crates.io latest {latest})\n", status.current_version))
     }
 }
 
@@ -565,6 +569,15 @@ mod tests {
     #[test]
     fn version_line_is_none_when_latest_unknown() {
         assert_eq!(version_line(&status(None, false)), None, "no cached check → no line");
+    }
+
+    #[test]
+    fn version_line_marks_a_local_build_ahead_of_crates_io() {
+        // Running 0.5.0 while crates.io latest is 0.4.0 (dev/pre-release): not an update, but not
+        // "the crates.io latest" either.
+        let line = version_line(&status(Some("0.4.0"), false)).expect("ahead status renders");
+        assert!(line.contains("ahead of crates.io latest 0.4.0"), "got: {line}");
+        assert!(!line.contains("(latest on crates.io)"), "must not claim it's the latest: {line}");
     }
 
     // ─── HookInput parsing ────────────────────────────────────────────────────

--- a/crates/rag-rat-cli/src/claude_hook.rs
+++ b/crates/rag-rat-cli/src/claude_hook.rs
@@ -271,9 +271,16 @@ fn session_start(input: &HookInput) -> anyhow::Result<()> {
 /// it out of band); `None` when version checking is disabled or no check has been cached yet, so a
 /// fresh repo or an opted-out user sees nothing.
 fn version_check_line(config: &Config) -> Option<String> {
-    use rag_rat_core::version_check;
-    let status = version_check::cached_status(config.version_check.enabled, &config.database)?;
-    let latest = status.latest_version?;
+    let status =
+        rag_rat_core::version_check::cached_status(config.version_check.enabled, &config.database)?;
+    version_line(&status)
+}
+
+/// Format the digest version line from a status (pure, so it's testable without a config/cache).
+/// `None` when the latest version is unknown (no successful check cached yet) — stay quiet rather
+/// than print a half-answer.
+fn version_line(status: &rag_rat_core::version_check::VersionStatus) -> Option<String> {
+    let latest = status.latest_version.as_deref()?;
     if status.update_available {
         Some(format!(
             "\n⚠ rag-rat update available: {} → {} — run `{}`\n",
@@ -523,6 +530,42 @@ mod tests {
     use rag_rat_core::query::tree::{DirTree, TreeNode};
 
     use super::*;
+
+    // ─── version line ─────────────────────────────────────────────────────────
+
+    fn status(latest: Option<&str>, update: bool) -> rag_rat_core::version_check::VersionStatus {
+        rag_rat_core::version_check::VersionStatus {
+            current_version: "0.5.0".to_string(),
+            latest_version: latest.map(str::to_string),
+            update_available: update,
+            update_command: "cargo install rag-rat --force".to_string(),
+            checked_at_ms: latest.map(|_| 1),
+        }
+    }
+
+    #[test]
+    fn version_line_nags_when_behind() {
+        let line = version_line(&status(Some("0.6.0"), true)).expect("a behind status renders");
+        assert!(line.contains("update available"), "got: {line}");
+        assert!(line.contains("0.5.0 → 0.6.0"), "states current → latest: {line}");
+        assert!(
+            line.contains("cargo install rag-rat --force"),
+            "states the update command: {line}"
+        );
+    }
+
+    #[test]
+    fn version_line_is_quiet_when_current() {
+        let line =
+            version_line(&status(Some("0.5.0"), false)).expect("an up-to-date status renders");
+        assert!(line.contains("0.5.0 (latest on crates.io)"), "got: {line}");
+        assert!(!line.contains("update available"), "no nag when current: {line}");
+    }
+
+    #[test]
+    fn version_line_is_none_when_latest_unknown() {
+        assert_eq!(version_line(&status(None, false)), None, "no cached check → no line");
+    }
 
     // ─── HookInput parsing ────────────────────────────────────────────────────
 

--- a/crates/rag-rat-cli/src/claude_hook.rs
+++ b/crates/rag-rat-cli/src/claude_hook.rs
@@ -260,7 +260,28 @@ fn session_start(input: &HookInput) -> anyhow::Result<()> {
     let o = rag_rat_core::query::orientation::orientation(conn.connection(), root)?;
     let (live, enabled) = watcher_state(&config);
     print!("{}", format_digest(&o, live, enabled));
+    if let Some(line) = version_check_line(&config) {
+        print!("{line}");
+    }
     Ok(())
+}
+
+/// One digest line stating the running version vs the latest published on crates.io, with the
+/// update command when behind. Reads the cached check only (no network — the MCP server refreshes
+/// it out of band); `None` when version checking is disabled or no check has been cached yet, so a
+/// fresh repo or an opted-out user sees nothing.
+fn version_check_line(config: &Config) -> Option<String> {
+    use rag_rat_core::version_check;
+    let status = version_check::cached_status(config.version_check.enabled, &config.database)?;
+    let latest = status.latest_version?;
+    if status.update_available {
+        Some(format!(
+            "\n⚠ rag-rat update available: {} → {} — run `{}`\n",
+            status.current_version, latest, status.update_command
+        ))
+    } else {
+        Some(format!("\nrag-rat {} (latest on crates.io)\n", status.current_version))
+    }
 }
 
 /// PreToolUse path (grep augmentation).

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -86,6 +86,10 @@ pub(crate) enum Command {
 
     /// Print the resolved configuration as JSON.
     DumpConfig,
+
+    /// Check crates.io for a newer published rag-rat, refresh the cache, and print current vs
+    /// latest.
+    VersionCheck,
 }
 
 #[derive(Debug, Args)]

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -130,11 +130,12 @@ pub(crate) fn version_check(config: &Config) -> anyhow::Result<()> {
             "note": "version checking is disabled ([version_check] enabled = false in rag-rat.toml)",
         }));
     }
-    let _ = version_check::refresh(&config.database);
-    print_output(&version_check::build_status(
-        version_check::current_version(),
-        version_check::read_cache(&config.database).as_ref(),
-    ))
+    // Prefer the just-fetched result; only fall back to the cache when the network fetch itself
+    // failed — so a successful check still reports even if the cache write didn't land (read-only
+    // checkout, full disk).
+    let cached = version_check::refresh(&config.database)
+        .or_else(|| version_check::read_cache(&config.database));
+    print_output(&version_check::build_status(version_check::current_version(), cached.as_ref()))
 }
 pub(crate) fn eval(config: &Config, args: &EvalArgs) -> anyhow::Result<()> {
     let options = rag_rat_core::eval::EvalOptions {

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -118,6 +118,24 @@ pub(crate) fn dump_config(config: &Config) -> anyhow::Result<()> {
         "targets": targets,
     }))
 }
+/// `version-check`: refresh the crates.io cache (network, synchronous — this is the explicit path)
+/// and print current vs latest plus how to update. Best-effort: an offline/refused check still
+/// prints the current version with a null latest. No network when disabled in config.
+pub(crate) fn version_check(config: &Config) -> anyhow::Result<()> {
+    use rag_rat_core::version_check;
+    if !config.version_check.enabled {
+        return print_output(&serde_json::json!({
+            "enabled": false,
+            "current_version": version_check::current_version(),
+            "note": "version checking is disabled ([version_check] enabled = false in rag-rat.toml)",
+        }));
+    }
+    let _ = version_check::refresh(&config.database);
+    print_output(&version_check::build_status(
+        version_check::current_version(),
+        version_check::read_cache(&config.database).as_ref(),
+    ))
+}
 pub(crate) fn eval(config: &Config, args: &EvalArgs) -> anyhow::Result<()> {
     let options = rag_rat_core::eval::EvalOptions {
         queries_path: args
@@ -829,6 +847,7 @@ mod tests {
             }],
             local_ai: Default::default(),
             watch: Default::default(),
+            version_check: Default::default(),
         };
         (root, config)
     }

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -56,6 +56,11 @@ fn main() -> anyhow::Result<()> {
         Cmd::Brief(args) => brief(&config, &args)?,
         Cmd::Clusters(args) => clusters(&config, &args)?,
         Cmd::Mcp => {
+            // Refresh the crates.io version cache out of band (a detached thread on this long-lived
+            // server) when stale + opted-in, so `index_status` and the next SessionStart digest
+            // read a fresh result without ever blocking startup or a request. Fail-open
+            // (#version-check).
+            spawn_detached_version_refresh(&config);
             // The MCP server is an stdio JSON-RPC loop (one client, mostly serial) plus a SIGUSR1
             // task; the file watcher runs on its own OS thread and CPU-heavy indexing is rayon, not
             // tokio. The default runtime's ~num_cpus workers are therefore idle overhead, so cap it
@@ -87,9 +92,34 @@ fn main() -> anyhow::Result<()> {
         Cmd::Eval(args) => eval(&config, &args)?,
         Cmd::Oracle(args) => oracle(&config, &args)?,
         Cmd::DumpConfig => dump_config(&config)?,
+        Cmd::VersionCheck => version_check(&config)?,
     }
 
     Ok(())
+}
+
+/// Spawn a detached best-effort crates.io refresh (no-op when disabled or still fresh). Detached so
+/// it never blocks the caller; the thread outlives the call on a long-lived server and is harmless
+/// on a short-lived one (it simply may not finish — the next invocation retries).
+fn spawn_detached_version_refresh(config: &rag_rat_core::Config) {
+    use rag_rat_core::version_check;
+    if !config.version_check.enabled {
+        return;
+    }
+    let database = config.database.clone();
+    std::thread::spawn(move || {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0);
+        if version_check::needs_refresh(
+            version_check::read_cache(&database).as_ref(),
+            now,
+            version_check::DEFAULT_TTL_MS,
+        ) {
+            let _ = version_check::refresh(&database);
+        }
+    });
 }
 
 /// Load the config, mapping a missing file to a friendly hint instead of a raw IO error.

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -98,26 +98,35 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Spawn a detached best-effort crates.io refresh (no-op when disabled or still fresh). Detached so
-/// it never blocks the caller; the thread outlives the call on a long-lived server and is harmless
-/// on a short-lived one (it simply may not finish — the next invocation retries).
+/// Background thread that keeps the crates.io version cache fresh for the long-lived MCP server:
+/// refresh-if-stale now, then poll on a sub-TTL cadence so a release that lands while the server
+/// stays up is picked up within `DEFAULT_TTL_MS` (not only at restart) — `index_status` and the
+/// SessionStart digest read that cache. Best-effort + non-blocking: the actual crates.io call runs
+/// at most once per TTL (gated by `needs_refresh`), fail-open; the thread dies with the process (a
+/// hot-upgrade re-exec re-spawns it). No-op when version checking is disabled.
 fn spawn_detached_version_refresh(config: &rag_rat_core::Config) {
     use rag_rat_core::version_check;
+    /// Poll cadence — well under the TTL so the once-per-day network refresh actually fires on a
+    /// server that outlives the TTL, while the cache read in between is trivially cheap.
+    const POLL: std::time::Duration = std::time::Duration::from_secs(6 * 60 * 60);
     if !config.version_check.enabled {
         return;
     }
     let database = config.database.clone();
     std::thread::spawn(move || {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_millis() as i64)
-            .unwrap_or(0);
-        if version_check::needs_refresh(
-            version_check::read_cache(&database).as_ref(),
-            now,
-            version_check::DEFAULT_TTL_MS,
-        ) {
-            let _ = version_check::refresh(&database);
+        loop {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as i64)
+                .unwrap_or(0);
+            if version_check::needs_refresh(
+                version_check::read_cache(&database).as_ref(),
+                now,
+                version_check::DEFAULT_TTL_MS,
+            ) {
+                let _ = version_check::refresh(&database);
+            }
+            std::thread::sleep(POLL);
         }
     });
 }

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -33,6 +33,7 @@ sha2.workspace = true
 thiserror.workspace = true
 toml.workspace = true
 toon-format.workspace = true
+ureq.workspace = true
 tree-sitter.workspace = true
 tree-sitter-c.workspace = true
 tree-sitter-cpp.workspace = true

--- a/crates/rag-rat-core/benches/shared/mod.rs
+++ b/crates/rag-rat-core/benches/shared/mod.rs
@@ -65,6 +65,7 @@ pub fn bench_config(subdir: &str) -> Config {
         }],
         local_ai: Default::default(),
         watch: Default::default(),
+        version_check: Default::default(),
     }
 }
 

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -15,6 +15,21 @@ pub struct Config {
     pub targets: Vec<ResolvedTarget>,
     pub local_ai: LocalAiConfig,
     pub watch: WatchConfig,
+    pub version_check: VersionCheckConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VersionCheckConfig {
+    /// Check crates.io for a newer published `rag-rat` and surface it to agents/operators (default
+    /// true). Opt out with `[version_check] enabled = false` in `rag-rat.toml`. The check is
+    /// best-effort, cached, and never blocks; disabling it makes no network calls at all.
+    pub enabled: bool,
+}
+
+impl Default for VersionCheckConfig {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -204,8 +219,9 @@ impl Config {
         let targets = resolve_targets(&root, raw.target_bindings, raw.target)?;
         let local_ai = LocalAiConfig::try_from(raw.local_ai)?;
         let watch = raw.watch.into();
+        let version_check = raw.version_check.into();
 
-        Ok(Self { root, database, targets, local_ai, watch })
+        Ok(Self { root, database, targets, local_ai, watch, version_check })
     }
 }
 
@@ -329,6 +345,8 @@ struct RawConfig {
     #[serde(default)]
     watch: RawWatch,
     #[serde(default)]
+    version_check: RawVersionCheck,
+    #[serde(default)]
     target_bindings: BTreeMap<String, Vec<String>>,
     #[serde(default, rename = "target")]
     target: Vec<RawTarget>,
@@ -351,6 +369,17 @@ impl From<RawWatch> for WatchConfig {
             max_latency_ms: raw.max_latency_ms.unwrap_or(default.max_latency_ms),
             periodic_sweep_secs: raw.periodic_sweep_secs.unwrap_or(default.periodic_sweep_secs),
         }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawVersionCheck {
+    enabled: Option<bool>,
+}
+
+impl From<RawVersionCheck> for VersionCheckConfig {
+    fn from(raw: RawVersionCheck) -> Self {
+        Self { enabled: raw.enabled.unwrap_or(VersionCheckConfig::default().enabled) }
     }
 }
 
@@ -606,6 +635,17 @@ mod tests {
             max_latency_ms: 4000,
             periodic_sweep_secs: 0,
         });
+    }
+
+    #[test]
+    fn version_check_defaults_on_and_parses_opt_out() {
+        let default: VersionCheckConfig = RawVersionCheck::default().into();
+        assert!(default.enabled, "version check is opted in by default");
+
+        let raw: RawConfig =
+            toml::from_str("[index]\nroot = \".\"\n\n[version_check]\nenabled = false\n").unwrap();
+        let version_check: VersionCheckConfig = raw.version_check.into();
+        assert!(!version_check.enabled, "[version_check] enabled = false opts out");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -1882,6 +1882,7 @@ mod oracle_surfacing_tests {
             }],
             local_ai: Default::default(),
             watch: Default::default(),
+            version_check: Default::default(),
         }
     }
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -25,6 +25,7 @@ fn rebuild_bootstraps_sqlite_schema_for_empty_target_root() {
         }],
         local_ai: Default::default(),
         watch: Default::default(),
+        version_check: Default::default(),
     };
 
     let db = IndexDatabase::rebuild(&config).unwrap();
@@ -1404,6 +1405,7 @@ fn git_history_indexes_commits_paths_queries_and_blame() {
         ],
         local_ai: Default::default(),
         watch: Default::default(),
+        version_check: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let status = db.status(&config.database).unwrap();
@@ -1517,6 +1519,7 @@ fn rag_rat_config(root: &Path) -> Config {
         targets: git_history_targets(),
         local_ai: Default::default(),
         watch: Default::default(),
+        version_check: Default::default(),
     }
 }
 
@@ -2460,6 +2463,7 @@ DEVICE_DT_INST_DEFINE(0, entropy_init, NULL, NULL, NULL,
         }],
         local_ai: Default::default(),
         watch: Default::default(),
+        version_check: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
 
@@ -3151,6 +3155,7 @@ where
         ],
         local_ai: Default::default(),
         watch: Default::default(),
+        version_check: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let symbol = db.symbols("spawn_blocking", Some(Language::Rust), 10).unwrap().remove(0);
@@ -3914,6 +3919,7 @@ fn parser_failures_report_paths() {
         }],
         local_ai: Default::default(),
         watch: Default::default(),
+        version_check: Default::default(),
     };
 
     let db = IndexDatabase::rebuild(&config).unwrap();
@@ -5797,6 +5803,7 @@ fn repo_brief_ranks_churn_and_god_module_candidates() {
         }],
         local_ai: Default::default(),
         watch: Default::default(),
+        version_check: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
 
@@ -5875,6 +5882,7 @@ fn repo_clusters_groups_cotouched_files() {
         }],
         local_ai: Default::default(),
         watch: Default::default(),
+        version_check: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
 
@@ -5963,6 +5971,7 @@ fn markdown_config_for_root(root: PathBuf) -> Config {
         }],
         local_ai: Default::default(),
         watch: Default::default(),
+        version_check: Default::default(),
     }
 }
 
@@ -5984,6 +5993,7 @@ fn source_config(root: PathBuf, language: Language) -> Config {
         }],
         local_ai: Default::default(),
         watch: Default::default(),
+        version_check: Default::default(),
     }
 }
 
@@ -6389,6 +6399,7 @@ fn dir_tree_label_depth_collapse_single_child_chain() {
         }],
         local_ai: Default::default(),
         watch: Default::default(),
+        version_check: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let conn = db.storage.connection();
@@ -6612,6 +6623,7 @@ fn dir_tree_truncates_at_max_nodes() {
         }],
         local_ai: Default::default(),
         watch: Default::default(),
+        version_check: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let conn = db.storage.connection();
@@ -6752,6 +6764,7 @@ fn dir_tree_children_of_collapsed_node_use_leaf_labels() {
         }],
         local_ai: Default::default(),
         watch: Default::default(),
+        version_check: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let conn = db.storage.connection();
@@ -7350,6 +7363,7 @@ fn git_fixture_for_overlay_tests() -> (PathBuf, Config) {
         }],
         local_ai: Default::default(),
         watch: Default::default(),
+        version_check: Default::default(),
     };
     (root, config)
 }
@@ -7509,6 +7523,7 @@ fn clean_checkout_file_resolves_against_its_own_package_roots() {
         }],
         local_ai: Default::default(),
         watch: Default::default(),
+        version_check: Default::default(),
     };
 
     let db = IndexDatabase::rebuild(&config).unwrap();

--- a/crates/rag-rat-core/src/lib.rs
+++ b/crates/rag-rat-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod query;
 pub mod search;
 pub mod serde_big_id;
 pub mod storage;
+pub mod version_check;
 pub mod watch;
 
 pub use config::{Config, ResolvedTarget, TargetKind, WatchConfig};

--- a/crates/rag-rat-core/src/version_check.rs
+++ b/crates/rag-rat-core/src/version_check.rs
@@ -117,7 +117,14 @@ pub fn fetch_latest() -> Option<String> {
         .ok()?
         .into_string()
         .ok()?;
-    let json: serde_json::Value = serde_json::from_str(&body).ok()?;
+    parse_latest_response(&body)
+}
+
+/// Extract `crate.max_version` from a crates.io `/api/v1/crates/<name>` JSON body. `None` on
+/// malformed JSON or a missing/non-string field — the fail-open parse half of [`fetch_latest`],
+/// split out so it's testable without the network.
+fn parse_latest_response(body: &str) -> Option<String> {
+    let json: serde_json::Value = serde_json::from_str(body).ok()?;
     json.get("crate")?.get("max_version")?.as_str().map(str::to_string)
 }
 
@@ -207,6 +214,47 @@ mod tests {
     #[test]
     fn cached_status_is_none_when_disabled() {
         assert_eq!(cached_status(false, Path::new("/x/.rag-rat/index.sqlite")), None);
+    }
+
+    #[test]
+    fn cached_status_enabled_reflects_the_cache() {
+        let dir = std::env::temp_dir().join(format!("rr-vcheck-status-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join(".rag-rat")).unwrap();
+        let database = dir.join(".rag-rat").join("index.sqlite");
+
+        // No cache yet: enabled → Some, but latest unknown and no update claimed.
+        let s = cached_status(true, &database).expect("enabled → Some");
+        assert_eq!(s.current_version, current_version());
+        assert_eq!(s.latest_version, None);
+        assert!(!s.update_available);
+
+        // A clearly-newer cached version flips update_available against the running version.
+        write_cache(&database, &CachedVersion {
+            latest_version: "99.0.0".into(),
+            checked_at_ms: 1,
+        });
+        let s = cached_status(true, &database).expect("enabled → Some");
+        assert_eq!(s.latest_version.as_deref(), Some("99.0.0"));
+        assert!(s.update_available, "99.0.0 is newer than the running {}", current_version());
+        assert_eq!(s.update_command, "cargo install rag-rat --force");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn parse_latest_response_extracts_max_version_fail_open() {
+        assert_eq!(
+            parse_latest_response(r#"{"crate":{"name":"rag-rat","max_version":"0.6.0"}}"#),
+            Some("0.6.0".to_string())
+        );
+        assert_eq!(parse_latest_response("definitely not json"), None);
+        assert_eq!(parse_latest_response(r#"{"crate":{}}"#), None, "missing max_version");
+        assert_eq!(parse_latest_response("{}"), None, "missing crate");
+        assert_eq!(
+            parse_latest_response(r#"{"crate":{"max_version":123}}"#),
+            None,
+            "non-string max_version is ignored, not coerced"
+        );
     }
 
     #[test]

--- a/crates/rag-rat-core/src/version_check.rs
+++ b/crates/rag-rat-core/src/version_check.rs
@@ -1,0 +1,239 @@
+//! Best-effort "is a newer rag-rat published on crates.io?" check, surfaced to agents and operators
+//! (the SessionStart digest and the `index_status` MCP tool). This is the one HTTP call in core; it
+//! is **fail-open** — offline, a 403, a parse miss, or a disabled config all yield "no info," never
+//! an error — and **cached** to a small JSON file next to the index so reads are instant and
+//! session start never blocks (the network refresh runs out of band; see `refresh`).
+//!
+//! Versions are reported as opaque strings; comparison is a lenient numeric semver (`major.minor.
+//! patch`, pre-release/build stripped) — if either side won't parse, no update is claimed.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+/// The published crate this binary is built from (the lockstep workspace crate name).
+pub const CRATE_NAME: &str = "rag-rat";
+/// How the operator updates — printed verbatim in the digest and the structured status.
+pub const UPDATE_COMMAND: &str = "cargo install rag-rat --force";
+/// Default staleness window: re-check crates.io at most once a day. Reads always use the cache.
+pub const DEFAULT_TTL_MS: i64 = 24 * 60 * 60 * 1000;
+/// Hard cap on the crates.io request so a slow network can never wedge a refresh.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(4);
+
+/// The running binary's version (lockstep across the three workspace crates, so core's
+/// `CARGO_PKG_VERSION` equals the `rag-rat` binary's).
+pub fn current_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+/// Agent/operator-facing version status. `latest_version`/`checked_at_ms` are `None` until a
+/// successful crates.io check has been cached; `update_available` is only ever true on a confirmed
+/// newer published version.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct VersionStatus {
+    pub current_version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latest_version: Option<String>,
+    pub update_available: bool,
+    pub update_command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checked_at_ms: Option<i64>,
+}
+
+/// The cached result of the last crates.io check (the JSON file's shape).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CachedVersion {
+    pub latest_version: String,
+    pub checked_at_ms: i64,
+}
+
+/// Where the version-check cache lives: next to the index DB (under the gitignored, floor-skipped
+/// `.rag-rat/`), so it's per-project and never indexed.
+pub fn cache_path(database: &Path) -> PathBuf {
+    database.parent().unwrap_or_else(|| Path::new(".")).join("version-check.json")
+}
+
+/// Read the cached crates.io result, or `None` when absent/unreadable/corrupt (all fail-open).
+pub fn read_cache(database: &Path) -> Option<CachedVersion> {
+    let text = std::fs::read_to_string(cache_path(database)).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+/// Persist a fresh crates.io result. Best-effort: a write error is swallowed (the next refresh
+/// retries), never surfaced.
+fn write_cache(database: &Path, cached: &CachedVersion) {
+    let path = cache_path(database);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(json) = serde_json::to_string(cached) {
+        let _ = std::fs::write(path, json);
+    }
+}
+
+/// Build the agent/operator-facing status from the current version and the last cached check.
+pub fn build_status(current: &str, cached: Option<&CachedVersion>) -> VersionStatus {
+    let latest_version = cached.map(|c| c.latest_version.clone());
+    let update_available =
+        latest_version.as_deref().is_some_and(|latest| is_newer(latest, current));
+    VersionStatus {
+        current_version: current.to_string(),
+        latest_version,
+        update_available,
+        update_command: UPDATE_COMMAND.to_string(),
+        checked_at_ms: cached.map(|c| c.checked_at_ms),
+    }
+}
+
+/// The cached status for this index, or `None` when version checking is disabled in config. No
+/// network — reads the cache only, so callers (digest, `index_status`) never block.
+pub fn cached_status(enabled: bool, database: &Path) -> Option<VersionStatus> {
+    if !enabled {
+        return None;
+    }
+    Some(build_status(current_version(), read_cache(database).as_ref()))
+}
+
+/// Whether the cache is missing or older than `ttl_ms` — i.e. a refresh should run.
+/// `now_ms`/`ttl_ms` are injected so the decision is pure and testable.
+pub fn needs_refresh(cached: Option<&CachedVersion>, now_ms: i64, ttl_ms: i64) -> bool {
+    match cached {
+        None => true,
+        Some(c) => now_ms.saturating_sub(c.checked_at_ms) >= ttl_ms,
+    }
+}
+
+/// Fetch the latest published version from crates.io. `None` on any failure (offline, non-200,
+/// timeout, unexpected JSON) — the check is best-effort and never an error. A `User-Agent` is
+/// mandatory: crates.io 403s a request without one.
+pub fn fetch_latest() -> Option<String> {
+    let url = format!("https://crates.io/api/v1/crates/{CRATE_NAME}");
+    let agent = ureq::AgentBuilder::new().timeout(FETCH_TIMEOUT).build();
+    let body = agent
+        .get(&url)
+        .set("User-Agent", concat!("rag-rat/", env!("CARGO_PKG_VERSION"), " (version-check)"))
+        .call()
+        .ok()?
+        .into_string()
+        .ok()?;
+    let json: serde_json::Value = serde_json::from_str(&body).ok()?;
+    json.get("crate")?.get("max_version")?.as_str().map(str::to_string)
+}
+
+/// Fetch crates.io and write the cache (network). Returns the latest version on success, `None`
+/// fail-open. Run out of band (a long-lived server's background, an explicit `version-check`
+/// command) — never on the session-start read path.
+pub fn refresh(database: &Path) -> Option<String> {
+    let latest = fetch_latest()?;
+    write_cache(database, &CachedVersion {
+        latest_version: latest.clone(),
+        checked_at_ms: now_ms(),
+    });
+    Some(latest)
+}
+
+fn now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_millis() as i64).unwrap_or(0)
+}
+
+/// `(major, minor, patch)`, pre-release/build metadata stripped. `None` if it doesn't parse.
+fn parse_semver(version: &str) -> Option<(u64, u64, u64)> {
+    let core = version.split(['-', '+']).next().unwrap_or(version);
+    let mut parts = core.split('.');
+    let major = parts.next()?.trim().parse().ok()?;
+    let minor = parts.next().unwrap_or("0").trim().parse().ok()?;
+    let patch = parts.next().unwrap_or("0").trim().parse().ok()?;
+    Some((major, minor, patch))
+}
+
+/// Whether `latest` is a strictly newer published version than `current`. Conservative: if either
+/// side won't parse as `major.minor.patch`, returns false (never nag on a version we can't
+/// compare).
+pub fn is_newer(latest: &str, current: &str) -> bool {
+    match (parse_semver(latest), parse_semver(current)) {
+        (Some(latest), Some(current)) => latest > current,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_newer_compares_numeric_semver() {
+        assert!(is_newer("0.6.0", "0.5.0"));
+        assert!(is_newer("0.5.1", "0.5.0"));
+        assert!(is_newer("1.0.0", "0.9.9"));
+        assert!(is_newer("0.5.10", "0.5.9"), "numeric, not lexical");
+        assert!(!is_newer("0.5.0", "0.5.0"), "equal is not newer");
+        assert!(!is_newer("0.4.0", "0.5.0"), "older is not newer");
+        assert!(is_newer("0.6.0-rc.1", "0.5.0"), "pre-release suffix stripped for the compare");
+        assert!(!is_newer("not-a-version", "0.5.0"), "unparseable latest → no update claimed");
+        assert!(!is_newer("0.6.0", "garbage"), "unparseable current → no update claimed");
+    }
+
+    #[test]
+    fn build_status_flags_an_available_update() {
+        let cached = CachedVersion { latest_version: "0.6.0".into(), checked_at_ms: 123 };
+        let s = build_status("0.5.0", Some(&cached));
+        assert_eq!(s.current_version, "0.5.0");
+        assert_eq!(s.latest_version.as_deref(), Some("0.6.0"));
+        assert!(s.update_available);
+        assert_eq!(s.update_command, "cargo install rag-rat --force");
+        assert_eq!(s.checked_at_ms, Some(123));
+    }
+
+    #[test]
+    fn build_status_up_to_date_has_no_update() {
+        let cached = CachedVersion { latest_version: "0.5.0".into(), checked_at_ms: 1 };
+        let s = build_status("0.5.0", Some(&cached));
+        assert!(!s.update_available);
+        assert_eq!(s.latest_version.as_deref(), Some("0.5.0"));
+    }
+
+    #[test]
+    fn build_status_without_cache_reports_unknown_latest() {
+        let s = build_status("0.5.0", None);
+        assert_eq!(s.latest_version, None);
+        assert!(!s.update_available);
+        assert_eq!(s.checked_at_ms, None);
+        // The update command is always present so an agent can relay it once a latest is known.
+        assert_eq!(s.update_command, "cargo install rag-rat --force");
+    }
+
+    #[test]
+    fn cached_status_is_none_when_disabled() {
+        assert_eq!(cached_status(false, Path::new("/x/.rag-rat/index.sqlite")), None);
+    }
+
+    #[test]
+    fn needs_refresh_on_missing_or_stale_only() {
+        let fresh = CachedVersion { latest_version: "0.5.0".into(), checked_at_ms: 1_000 };
+        assert!(needs_refresh(None, 0, DEFAULT_TTL_MS), "no cache → refresh");
+        assert!(!needs_refresh(Some(&fresh), 1_000 + DEFAULT_TTL_MS - 1, DEFAULT_TTL_MS), "fresh");
+        assert!(needs_refresh(Some(&fresh), 1_000 + DEFAULT_TTL_MS, DEFAULT_TTL_MS), "exactly TTL");
+        assert!(needs_refresh(Some(&fresh), 1_000 + DEFAULT_TTL_MS * 2, DEFAULT_TTL_MS), "stale");
+    }
+
+    #[test]
+    fn cache_round_trips_through_disk() {
+        let dir = std::env::temp_dir().join(format!("rr-vcheck-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join(".rag-rat")).unwrap();
+        let database = dir.join(".rag-rat").join("index.sqlite");
+        assert_eq!(read_cache(&database), None, "absent cache reads None");
+        write_cache(&database, &CachedVersion {
+            latest_version: "0.7.1".into(),
+            checked_at_ms: 42,
+        });
+        assert_eq!(
+            read_cache(&database),
+            Some(CachedVersion { latest_version: "0.7.1".into(), checked_at_ms: 42 })
+        );
+        assert_eq!(cache_path(&database), dir.join(".rag-rat").join("version-check.json"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/rag-rat-core/src/version_check.rs
+++ b/crates/rag-rat-core/src/version_check.rs
@@ -27,17 +27,16 @@ pub fn current_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
 
-/// Agent/operator-facing version status. `latest_version`/`checked_at_ms` are `None` until a
-/// successful crates.io check has been cached; `update_available` is only ever true on a confirmed
-/// newer published version.
+/// Agent/operator-facing version status. `latest_version`/`checked_at_ms` are `null` until a
+/// successful crates.io check has been cached (serialized explicitly, not omitted, so the object
+/// shape is stable for consumers that test `latest_version == null`); `update_available` is only
+/// ever true on a confirmed newer published version.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct VersionStatus {
     pub current_version: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub latest_version: Option<String>,
     pub update_available: bool,
     pub update_command: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub checked_at_ms: Option<i64>,
 }
 
@@ -128,16 +127,15 @@ fn parse_latest_response(body: &str) -> Option<String> {
     json.get("crate")?.get("max_version")?.as_str().map(str::to_string)
 }
 
-/// Fetch crates.io and write the cache (network). Returns the latest version on success, `None`
-/// fail-open. Run out of band (a long-lived server's background, an explicit `version-check`
-/// command) — never on the session-start read path.
-pub fn refresh(database: &Path) -> Option<String> {
-    let latest = fetch_latest()?;
-    write_cache(database, &CachedVersion {
-        latest_version: latest.clone(),
-        checked_at_ms: now_ms(),
-    });
-    Some(latest)
+/// Fetch crates.io and write the cache (network). Returns the fresh [`CachedVersion`] on success,
+/// `None` fail-open. The caller gets the result directly so it can report the just-fetched latest
+/// even if the cache write fails (read-only checkout, full disk). Run out of band (a long-lived
+/// server's background, an explicit `version-check` command) — never on the session-start read
+/// path.
+pub fn refresh(database: &Path) -> Option<CachedVersion> {
+    let cached = CachedVersion { latest_version: fetch_latest()?, checked_at_ms: now_ms() };
+    write_cache(database, &cached);
+    Some(cached)
 }
 
 fn now_ms() -> i64 {
@@ -209,6 +207,18 @@ mod tests {
         assert_eq!(s.checked_at_ms, None);
         // The update command is always present so an agent can relay it once a latest is known.
         assert_eq!(s.update_command, "cargo install rag-rat --force");
+    }
+
+    #[test]
+    fn unknown_status_serializes_null_fields_not_omitted() {
+        // Stable object shape: latest_version/checked_at_ms are present as null when unknown, so
+        // consumers can test `latest_version == null` rather than a missing key.
+        let json = serde_json::to_value(build_status("0.5.0", None)).unwrap();
+        let obj = json.as_object().unwrap();
+        assert!(obj.contains_key("latest_version") && obj["latest_version"].is_null());
+        assert!(obj.contains_key("checked_at_ms") && obj["checked_at_ms"].is_null());
+        assert_eq!(obj["current_version"], "0.5.0");
+        assert_eq!(obj["update_available"], false);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -453,6 +453,7 @@ mod tests {
             }],
             local_ai: LocalAiConfig { embedding: EmbeddingConfig::default() },
             watch: WatchConfig::default(),
+            version_check: Default::default(),
         };
         let ignore = IgnoreMatcher::compile(&root, &[]);
 
@@ -511,6 +512,7 @@ mod tests {
             }],
             local_ai: LocalAiConfig { embedding: EmbeddingConfig::default() },
             watch: WatchConfig::default(),
+            version_check: Default::default(),
         };
 
         let ignore = IgnoreMatcher::compile(&root, &[]);
@@ -580,6 +582,7 @@ mod tests {
             }],
             local_ai: LocalAiConfig { embedding: EmbeddingConfig::default() },
             watch: WatchConfig::default(),
+            version_check: Default::default(),
         };
 
         // Before: a source file under the subdir fires.

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -607,7 +607,21 @@ pub fn call_tool_for_config(
     arguments: Value,
 ) -> anyhow::Result<Value> {
     let db = IndexDatabase::open_config(config)?;
-    call_tool_with_db(&db, name, arguments)
+    let mut result = call_tool_with_db(&db, name, arguments)?;
+    // Surface the crates.io version status on `index_status` so an agent can see (and relay) when a
+    // newer rag-rat is published. Read-only: it reads the cached check (refreshed out of band),
+    // never the network, so the tool stays fast. Omitted entirely when version checking is
+    // disabled.
+    if name == "index_status"
+        && let Some(version) = rag_rat_core::version_check::cached_status(
+            config.version_check.enabled,
+            &config.database,
+        )
+        && let Some(obj) = result.as_object_mut()
+    {
+        obj.insert("version".to_string(), serde_json::json!(version));
+    }
+    Ok(result)
 }
 
 impl MemoryCreateArgs {

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -217,6 +217,25 @@ fn enum_like_tool_args_reject_unknown_values_during_decoding() {
 }
 
 #[test]
+fn index_status_surfaces_version_when_cached_and_enabled() {
+    let (root, config) = mixed_config();
+    IndexDatabase::rebuild(&config).unwrap();
+    // Seed a clearly-newer cached crates.io result next to the index (cache_path is public; the
+    // network refresh that normally writes this is out of band).
+    let cache = rag_rat_core::version_check::cache_path(&config.database);
+    std::fs::write(&cache, r#"{"latest_version":"99.0.0","checked_at_ms":1}"#).unwrap();
+
+    let status = call_tool_for_config(&config, "index_status", json!({})).unwrap();
+    let version = status.get("version").expect("index_status surfaces a version field");
+    assert_eq!(version["current_version"], rag_rat_core::version_check::current_version());
+    assert_eq!(version["latest_version"], "99.0.0");
+    assert_eq!(version["update_available"], true);
+    assert_eq!(version["update_command"], "cargo install rag-rat --force");
+
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn mcp_tool_calls_preserve_compatibility_shapes() {
     let (root, config) = mixed_config();
     let db = IndexDatabase::rebuild(&config).unwrap();

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -674,6 +674,7 @@ fn mixed_config() -> (PathBuf, Config) {
         ],
         local_ai: Default::default(),
         watch: Default::default(),
+        version_check: Default::default(),
     })
 }
 
@@ -694,6 +695,7 @@ fn markdown_config(text: &str) -> (PathBuf, Config) {
         }],
         local_ai: Default::default(),
         watch: Default::default(),
+        version_check: Default::default(),
     })
 }
 
@@ -711,6 +713,7 @@ fn rust_config(root: PathBuf) -> Config {
         }],
         local_ai: Default::default(),
         watch: Default::default(),
+        version_check: Default::default(),
     }
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -112,6 +112,21 @@ index are enforced with file locks under the index directory; the index DB is sh
 worktrees (a relative `database` resolves against the main worktree). File locks are unreliable on
 NFS and WSL2 `drvfs`/`9p` (`/mnt/...`) mounts — keep the repo on a native filesystem.
 
+`[version_check]` controls the best-effort check for a newer published `rag-rat` on crates.io,
+surfaced to agents/operators in the SessionStart digest and the `index_status` MCP tool's `version`
+field (current vs latest + the `cargo install rag-rat --force` update command):
+
+```toml
+[version_check]
+enabled = true   # opted in by default; false makes zero network calls
+```
+
+The check is **cached** (refreshed at most once a day, out of band by the long-lived `rag-rat mcp`
+server) and **fail-open** — offline, a non-200, or a parse miss simply yields no version info, never
+an error, and **never blocks** session start (reads only the cache; `rag-rat version-check` refreshes
+it synchronously on demand). The cache lives at `<index-dir>/version-check.json`. Set
+`enabled = false` to disable the feature entirely (no crates.io requests).
+
 `rag-rat hooks install` writes generated `post-checkout`, `post-merge`, `post-rewrite`, and
 `post-commit` hooks to the current worktree's Git hooks directory. Those hooks call `rag-rat
 maintenance --max-seconds 30` in the background so branch switches, merges, rebases, and commits


### PR DESCRIPTION
Surfaces "a newer rag-rat is published" to the agent — and through it the operator — with the exact update command, so a stale install gets noticed instead of silently lagging.

## What it does
- **`core::version_check`** — the one HTTP call in core (`ureq`, rustls, 4s timeout, mandatory `User-Agent` since crates.io 403s without one). **Fail-open**: offline / non-200 / parse miss → no version info, never an error. Result is **cached** to `<index-dir>/version-check.json`.
- **Surfaces**:
  - SessionStart digest line: `rag-rat 0.5.0 (latest on crates.io)`, or when behind `⚠ rag-rat update available: 0.5.0 → 0.6.0 — run \`cargo install rag-rat --force\``.
  - `index_status` MCP tool gains a structured `version` field: `{ current_version, latest_version, update_available, update_command, checked_at_ms }`.
- **Never blocks**: the digest and `index_status` only *read* the cache. The network refresh runs **out of band** — a detached thread on the long-lived `rag-rat mcp` server (once/day TTL), or synchronously via the new **`rag-rat version-check`** command.
- **Opt-out**: `[version_check] enabled = false` in `rag-rat.toml` (default opted in) → zero network calls. Documented in `docs/config.md`.

## Design notes
- HTTP (`ureq`) added at the **core edge** deliberately — per the request, it's reused by future GitHub/GitLab/Bitbucket REST integration. rustls (no system OpenSSL); gzip off (responses are tiny).
- Version compare is lenient numeric semver (`major.minor.patch`, pre-release/build stripped); if either side won't parse, no update is claimed.

## Verification
- Unit tests: version compare, status builder (update/up-to-date/unknown), `needs_refresh` TTL, cache round-trip, config opt-out parse.
- Live: `rag-rat version-check --json` fetched crates.io (`latest 0.5.0`); MCP `index_status` shows the `version` field; SessionStart digest renders the line.
- Full `cargo test` (core 363 + mcp/cli), `cargo clippy --all-targets`, `cargo +nightly fmt` clean.

The many one-line diffs in tests/`watch.rs`/`query_api.rs`/bench harness are just the new `version_check: Default::default()` field on `Config` literals.