### PR TITLE
chore: add 'scip' to crate keywords

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.89"
 license = "MIT"
 repository = "https://github.com/cq27-dev/rag-rat"
 readme = "README.md"
-keywords = ["rag", "mcp", "code-search", "tree-sitter", "embeddings"]
+keywords = ["rag", "mcp", "code-search", "tree-sitter", "scip"]
 categories = ["command-line-utilities", "development-tools"]
 
 [workspace.dependencies]


### PR DESCRIPTION
Adds `scip` to the workspace `keywords` so the SCIP compiler-grade oracle surfaces in crates.io discovery. crates.io caps keywords at **5** and there were already 5, so this drops the most generic one (`embeddings`):

`["rag", "mcp", "code-search", "tree-sitter", "embeddings"]` → `["rag", "mcp", "code-search", "tree-sitter", "scip"]`

Happy to swap a different keyword out instead if you'd prefer to keep `embeddings`.