### PR TITLE
fix(grep-augment): skip pipe-incidental greps + dedup indexed hits (#138, #139)

### DIFF
--- a/crates/rag-rat-cli/src/claude_hook.rs
+++ b/crates/rag-rat-cli/src/claude_hook.rs
@@ -102,7 +102,7 @@ pub fn parse_bash_search(command: &str) -> Option<(String, Option<String>)> {
         return None; // substitution: ambiguous
     }
     // Split into pipeline/sequence segments; examine each for a search command.
-    for segment in split_top_level(command) {
+    for (piped, segment) in split_top_level(command) {
         let tokens = shell_tokens(&segment)?;
         let mut tokens = tokens.as_slice();
         // Skip env-var prefixes (FOO=bar) before the command word.
@@ -115,6 +115,14 @@ pub fn parse_bash_search(command: &str) -> Option<(String, Option<String>)> {
             return None; // grep as an argument of these is ambiguous
         }
         if !SEARCH_COMMANDS.contains(&base) {
+            continue;
+        }
+        // A search command DOWNSTREAM of a pipe is filtering another tool's output
+        // (`cargo test | grep …`, `gh … | rg …`), not a code search — skip it so augmentation
+        // doesn't fire on incidental greps (#138). A grep that is the pipeline HEAD (`grep … |
+        // head`) or a sequenced command (`cd x && rg …`) is a real search and still
+        // matches.
+        if piped {
             continue;
         }
         let mut pattern: Option<String> = None;
@@ -143,14 +151,20 @@ pub fn parse_bash_search(command: &str) -> Option<(String, Option<String>)> {
 }
 
 /// Split on top-level `|`, `&&`, `||`, `;` (quote-aware); also drop a leading `cd …` segment.
+/// Each returned segment carries a `piped` flag: true when it was preceded by a single `|` (i.e. it
+/// consumes the previous command's output). `||`, `&&`, `;`, `&`, and the first segment are not
+/// piped — they're independent commands. This lets the caller tell a real grep (pipeline head or
+/// sequenced) from an incidental output filter (#138).
 ///
 /// Quote characters are preserved verbatim into the segment so that [`shell_tokens`] can
 /// strip them itself — a top-level separator inside quotes must not split, and a quoted
 /// pattern (`rg "quoted pattern" src`) must survive intact for re-tokenization.
-fn split_top_level(command: &str) -> Vec<String> {
+fn split_top_level(command: &str) -> Vec<(bool, String)> {
     let mut segments = Vec::new();
     let mut current = String::new();
     let mut quote: Option<char> = None;
+    // Whether the segment currently being accumulated was preceded by a single `|`.
+    let mut piped = false;
     let mut chars = command.chars().peekable();
     while let Some(ch) = chars.next() {
         match (quote, ch) {
@@ -165,26 +179,34 @@ fn split_top_level(command: &str) -> Vec<String> {
                 quote = Some(ch);
                 current.push(ch);
             },
-            (None, '|' | ';') => {
-                if chars.peek() == Some(&'|') {
+            (None, '|') => {
+                let double = chars.peek() == Some(&'|');
+                if double {
                     chars.next();
                 }
-                segments.push(std::mem::take(&mut current));
+                segments.push((piped, std::mem::take(&mut current)));
+                // A single `|` pipes into the next segment; `||` (logical or) does not.
+                piped = !double;
+            },
+            (None, ';') => {
+                segments.push((piped, std::mem::take(&mut current)));
+                piped = false;
             },
             (None, '&') => {
                 if chars.peek() == Some(&'&') {
                     chars.next();
                 }
-                segments.push(std::mem::take(&mut current));
+                segments.push((piped, std::mem::take(&mut current)));
+                piped = false;
             },
             (None, c) => current.push(c),
         }
     }
-    segments.push(current);
+    segments.push((piped, current));
     segments
         .into_iter()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty() && !s.starts_with("cd ") && *s != "cd")
+        .map(|(piped, s)| (piped, s.trim().to_string()))
+        .filter(|(_, s)| !s.is_empty() && !s.starts_with("cd ") && *s != "cd")
         .collect()
 }
 
@@ -619,7 +641,8 @@ mod tests {
             ("cd crates && rg spawn_listener", "spawn_listener", None),
             ("FOO=1 rg spawn_listener", "spawn_listener", None),
             ("rg -A 3 -B 2 needle haystack/", "needle", Some("haystack/")),
-            ("git log | rg fix", "fix", None),
+            // grep is the pipeline HEAD (a real search piped into a pager) → still matches.
+            ("rg foo | head", "foo", None),
             (r#"rg "quoted pattern" src"#, "quoted pattern", Some("src")),
         ];
         for (cmd, pattern, path) in positives {
@@ -635,6 +658,12 @@ mod tests {
             "echo `rg foo`",                             // backticks: ambiguous
             "xargs grep foo",                            // xargs: ambiguous
             "groups",                                    // not grep
+            // #138: grep DOWNSTREAM of a pipe is filtering another tool's output, not a code
+            // search — must not augment.
+            "git log | rg fix",
+            "cargo test | grep result",
+            "gh run view | grep -i error",
+            "cargo clippy | grep -E warning",
         ];
         for cmd in negatives {
             assert!(parse_bash_search(cmd).is_none(), "false positive for {cmd}");

--- a/crates/rag-rat-cli/src/claude_hook.rs
+++ b/crates/rag-rat-cli/src/claude_hook.rs
@@ -180,13 +180,22 @@ fn split_top_level(command: &str) -> Vec<(bool, String)> {
                 current.push(ch);
             },
             (None, '|') => {
-                let double = chars.peek() == Some(&'|');
-                if double {
-                    chars.next();
-                }
+                // `|` pipes into the next segment; `|&` (bash shorthand for `2>&1 |`) also pipes
+                // (stdout+stderr) so the next segment is still a downstream filter; `||` (logical
+                // or) does NOT pipe — it's an independent command.
+                let next_piped = match chars.peek() {
+                    Some('|') => {
+                        chars.next();
+                        false
+                    },
+                    Some('&') => {
+                        chars.next();
+                        true
+                    },
+                    _ => true,
+                };
                 segments.push((piped, std::mem::take(&mut current)));
-                // A single `|` pipes into the next segment; `||` (logical or) does not.
-                piped = !double;
+                piped = next_piped;
             },
             (None, ';') => {
                 segments.push((piped, std::mem::take(&mut current)));
@@ -664,6 +673,8 @@ mod tests {
             "cargo test | grep result",
             "gh run view | grep -i error",
             "cargo clippy | grep -E warning",
+            "cargo test |& grep result", // |& pipes stdout+stderr → still a downstream filter
+            "cargo clippy |& rg warning",
         ];
         for cmd in negatives {
             assert!(parse_bash_search(cmd).is_none(), "false positive for {cmd}");

--- a/crates/rag-rat-core/src/query/grep_augment.rs
+++ b/crates/rag-rat-core/src/query/grep_augment.rs
@@ -220,6 +220,11 @@ pub fn compose(
     // Seen set for memory dedup — preserves insertion order (symbol-bound first, then FTS,
     // then path-bound), unlike the old sort+dedup which ordered by creation-time ID.
     let mut seen_memory_ids: HashSet<String> = HashSet::new();
+    // Within-call dedup of symbol hits by (path, qualified_name): `symbol::lookup` can return the
+    // same logical symbol once per concrete row (overloads, multiple definitions, re-export rows),
+    // which otherwise renders as N identical "Known symbols" lines — same defect as the lexical
+    // lane (#139).
+    let mut seen_symbol_keys: HashSet<String> = HashSet::new();
 
     if let Some(ident) = extract_symbol_identifier(&normalized) {
         // Symbol lane. Bare name for qualified queries: `Watcher::spawn` → `spawn`.
@@ -227,7 +232,7 @@ pub fn compose(
         for hit in symbol::lookup(conn, bare, None, MAX_SYMBOLS)? {
             symbol_lane_had_hits = true;
             let key = format!("{}:{}", hit.path, hit.qualified_name);
-            if dedupe.symbol_keys.contains(&key) {
+            if dedupe.symbol_keys.contains(&key) || !seen_symbol_keys.insert(key.clone()) {
                 continue;
             }
             let (callers, callees) = edge_counts(conn, &hit)?;
@@ -529,6 +534,38 @@ mod tests {
         assert!(lines[0].contains("a.rs:1-9"), "first line is a.rs once: {lines:?}");
         assert!(lines[1].contains("b.rs:2-3"), "second is b.rs: {lines:?}");
         assert!(!lines.iter().any(|l| l.contains("c.rs")), "weak hit dropped: {lines:?}");
+    }
+
+    /// #139 (symbol lane): two symbol rows sharing (path, qualified_name) — overloads / cfg
+    /// variants / re-export rows — must render once, not once per row.
+    #[test]
+    fn symbol_lane_dedups_duplicate_rows() {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
+             VALUES ('src/a.rs', 'rust', 'source', 'h', 0, 0)",
+            [],
+        )
+        .unwrap();
+        for _ in 0..3 {
+            conn.execute(
+                "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte,
+                                     end_byte, signature, docs)
+                 VALUES (1, 'rust', 'foo', 'a::foo', 'function', 0, 10, 'fn foo()', NULL)",
+                [],
+            )
+            .unwrap();
+        }
+        let out = compose(&conn, "foo", None, &DedupeFilter::default())
+            .unwrap()
+            .expect("symbol lane augments");
+        assert_eq!(
+            out.context.matches("`a::foo`").count(),
+            1,
+            "duplicate symbol rows must render once:\n{}",
+            out.context
+        );
     }
 
     fn seeded_conn() -> Connection {

--- a/crates/rag-rat-core/src/query/grep_augment.rs
+++ b/crates/rag-rat-core/src/query/grep_augment.rs
@@ -276,15 +276,12 @@ pub fn compose(
     // gate: keep only hits within LEXICAL_RELATIVE_FLOOR of the best hit's score, so the weak tail
     // (e.g. an incidental match several ranks down) isn't injected as noise.
     let lexical_lines = if !symbol_lane_had_hits {
-        let hits = lexical::search_lexical_only(conn, &normalized, MAX_LEXICAL_HITS, false)?;
-        let best = hits.iter().map(|hit| hit.score).fold(0.0_f64, f64::max);
-        let floor = best * LEXICAL_RELATIVE_FLOOR;
-        hits.into_iter()
-            .filter(|hit| hit.score >= floor)
-            .map(|hit| {
-                format!("- {}:{}-{} — {}", hit.path, hit.start_line, hit.end_line, hit.summary)
-            })
-            .collect::<Vec<_>>()
+        lexical_lines_from_hits(lexical::search_lexical_only(
+            conn,
+            &normalized,
+            MAX_LEXICAL_HITS,
+            false,
+        )?)
     } else {
         Vec::new()
     };
@@ -293,6 +290,22 @@ pub fn compose(
         return Ok(None);
     }
     Ok(Some(render(memories, symbol_items, lexical_lines)))
+}
+
+/// Floor-filter, dedup, and render the lexical-lane hits. Extracted so the dedup is unit-testable:
+/// `search_lexical_only` can return the same chunk more than once (e.g. one row per matched FTS
+/// term), which — capped at `MAX_LEXICAL_HITS` — otherwise rendered as N identical "Indexed hits"
+/// lines (#139). Keeps the first occurrence of each `(path, start, end)`, preserving rank order,
+/// after the relevance floor.
+fn lexical_lines_from_hits(hits: Vec<lexical::SearchHit>) -> Vec<String> {
+    let best = hits.iter().map(|hit| hit.score).fold(0.0_f64, f64::max);
+    let floor = best * LEXICAL_RELATIVE_FLOOR;
+    let mut seen: HashSet<(String, i64, i64)> = HashSet::new();
+    hits.into_iter()
+        .filter(|hit| hit.score >= floor)
+        .filter(|hit| seen.insert((hit.path.clone(), hit.start_line, hit.end_line)))
+        .map(|hit| format!("- {}:{}-{} — {}", hit.path, hit.start_line, hit.end_line, hit.summary))
+        .collect()
 }
 
 /// A single rendered symbol line plus the key that identifies it in the dedupe set.
@@ -480,6 +493,43 @@ mod tests {
     use super::*;
     use crate::index::schema;
     use crate::query::memory::{self, RepoMemoryBindTarget, RepoMemoryCreate};
+    use crate::search::lexical::SearchHit;
+
+    fn lexical_hit(path: &str, start: i64, end: i64, score: f64) -> SearchHit {
+        SearchHit {
+            chunk_id: 0,
+            path: path.to_string(),
+            language: "rust".to_string(),
+            kind: "chunk".to_string(),
+            start_line: start,
+            end_line: end,
+            symbol_path: None,
+            score,
+            retrieval_mode: "lexical".to_string(),
+            summary: format!("{path} summary"),
+            graph: None,
+            score_components: None,
+        }
+    }
+
+    /// #139: the same chunk returned more than once (capped at MAX_LEXICAL_HITS) rendered as N
+    /// identical "Indexed hits" lines. The dedup keeps one line per (path, start, end); the
+    /// relevance floor still drops weak hits.
+    #[test]
+    fn lexical_lines_dedup_chunks_and_apply_floor() {
+        let hits = vec![
+            lexical_hit("a.rs", 1, 9, 1.0),
+            lexical_hit("a.rs", 1, 9, 1.0), // exact duplicate chunk
+            lexical_hit("a.rs", 1, 9, 1.0), // and again — would have filled all 3 slots
+            lexical_hit("b.rs", 2, 3, 0.9), // distinct, above floor (0.6 * 1.0)
+            lexical_hit("c.rs", 4, 5, 0.1), // below floor → dropped
+        ];
+        let lines = lexical_lines_from_hits(hits);
+        assert_eq!(lines.len(), 2, "a.rs deduped to one, c.rs floored out: {lines:?}");
+        assert!(lines[0].contains("a.rs:1-9"), "first line is a.rs once: {lines:?}");
+        assert!(lines[1].contains("b.rs:2-3"), "second is b.rs: {lines:?}");
+        assert!(!lines.iter().any(|l| l.contains("c.rs")), "weak hit dropped: {lines:?}");
+    }
 
     fn seeded_conn() -> Connection {
         let conn = Connection::open_in_memory().unwrap();


### PR DESCRIPTION
The two concrete augmentation-quality fixes from the session review.

### #138 — stop firing on incidental pipe-greps
The PreToolUse hook triggered whenever a Bash command *contained* `grep`/`rg`/`ag`, including when it merely filters another tool's output (`cargo test | grep "result"`, `gh run view | grep -i error`, `cargo clippy | grep -E warning`). It then matched the log-filter pattern against memories/symbols and injected near-random context — noise on the majority of Bash calls.

`split_top_level` now tags each segment with a **`piped`** flag (true iff preceded by a single `|`; `||`/`&&`/`;`/`&`/first-segment are not piped), and `parse_bash_search` **skips a search command that consumes a pipe**. A grep that is the pipeline *head* (`rg foo | head`) or a sequenced command (`cd x && rg …`) is a real search and still matches. Aligns with the existing "false negatives are fine, false positives are not" contract.

The prior test that asserted `git log | rg fix` → matches `fix` encoded exactly this bug — moved to the negatives.

### #139 — dedup "Indexed hits"
The lexical lane rendered the same chunk 2–3× when `search_lexical_only` returned it more than once (one row per matched FTS term), capped at `MAX_LEXICAL_HITS=3` → up to 3 identical lines. Extracted `lexical_lines_from_hits` and dedup by `(path, start, end)` after the relevance floor, preserving rank order.

## Tests
- `bash_parser_table`: + pipe-incidental negatives (`git log | rg fix`, `cargo test | grep result`, `gh run view | grep -i error`, `cargo clippy | grep -E warning`) and a pipeline-head positive (`rg foo | head`).
- `lexical_lines_dedup_chunks_and_apply_floor`: a chunk repeated 3× collapses to one line; a below-floor hit is dropped.
- Full `cargo test` (core query + cli claude_hook), clippy `--all-targets`, `cargo +nightly fmt` clean.

The deeper layers (symbol-resolution gate, SetFit-E5 intent tiebreaker, reranker) remain tracked in #138's design comment + #109/#112; this PR is Layer 1 + the dedup.

Fixes #138, #139