### PR TITLE
feat: PageRank symbol importance ranking (#108)

### DIFF
--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -54,6 +54,9 @@ pub(crate) enum Command {
     /// Ownership / co-change clusters.
     Clusters(ClustersArgs),
 
+    /// Rank the most load-bearing symbols by weighted PageRank over the edge graph.
+    ImportantSymbols(ImportantSymbolsArgs),
+
     /// Run the stdio MCP server.
     Mcp,
 
@@ -145,6 +148,13 @@ pub(crate) struct BriefArgs {
     /// Omit drive-by repo memories.
     #[arg(long)]
     pub no_memories: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ImportantSymbolsArgs {
+    /// Max load-bearing symbols to return.
+    #[arg(long)]
+    pub limit: Option<u32>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -155,6 +155,10 @@ pub(crate) struct ImportantSymbolsArgs {
     /// Max load-bearing symbols to return.
     #[arg(long)]
     pub limit: Option<u32>,
+    /// Symbol ids to bias importance toward (the symbols you're working on) — comma-separated or
+    /// repeated. Empty = global importance.
+    #[arg(long, value_delimiter = ',')]
+    pub personalize: Vec<i64>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -93,7 +93,7 @@ pub(crate) fn important_symbols(
     args: &ImportantSymbolsArgs,
 ) -> anyhow::Result<()> {
     let db = open_index(config)?;
-    print_output(&db.important_symbols(args.limit.unwrap_or(20) as usize, &[])?)
+    print_output(&db.important_symbols(args.limit.unwrap_or(20) as usize, &args.personalize)?)
 }
 pub(crate) fn dump_config(config: &Config) -> anyhow::Result<()> {
     let targets = config

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -4,9 +4,10 @@ use rag_rat_core::OutputFormat;
 
 use super::*;
 use crate::cli::{
-    BriefArgs, ClustersArgs, EvalArgs, GithubArgs, GithubCommand, HookAction, HooksArgs, IndexArgs,
-    MaintenanceArgs, MemoryArgs, MemoryCommand, ModelsArgs, ModelsCommand, OracleArgs,
-    OracleCommand, OracleRunArgs, OracleStatusArgs, QueryArgs, ReconcileArgs,
+    BriefArgs, ClustersArgs, EvalArgs, GithubArgs, GithubCommand, HookAction, HooksArgs,
+    ImportantSymbolsArgs, IndexArgs, MaintenanceArgs, MemoryArgs, MemoryCommand, ModelsArgs,
+    ModelsCommand, OracleArgs, OracleCommand, OracleRunArgs, OracleStatusArgs, QueryArgs,
+    ReconcileArgs,
 };
 
 /// Process-wide output format, set once from the global `--json` flag in `main` before any command
@@ -86,6 +87,13 @@ pub(crate) fn clusters(config: &Config, args: &ClustersArgs) -> anyhow::Result<(
         include_memories: !args.no_memories,
         min_cluster_size: args.min_cluster_size.unwrap_or(2),
     })?)
+}
+pub(crate) fn important_symbols(
+    config: &Config,
+    args: &ImportantSymbolsArgs,
+) -> anyhow::Result<()> {
+    let db = open_index(config)?;
+    print_output(&db.important_symbols(args.limit.unwrap_or(20) as usize, &[])?)
 }
 pub(crate) fn dump_config(config: &Config) -> anyhow::Result<()> {
     let targets = config

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -55,6 +55,7 @@ fn main() -> anyhow::Result<()> {
         Cmd::Query(args) => query(&config, &args)?,
         Cmd::Brief(args) => brief(&config, &args)?,
         Cmd::Clusters(args) => clusters(&config, &args)?,
+        Cmd::ImportantSymbols(args) => important_symbols(&config, &args)?,
         Cmd::Mcp => {
             // Refresh the crates.io version cache out of band (a detached thread on this long-lived
             // server) when stale + opted-in, so `index_status` and the next SessionStart digest

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -335,6 +335,30 @@ pub(crate) fn current_oracle_verdicts_for_edges(
     )
 }
 
+/// Fetch ALL current, in-scope oracle verdicts for `(tool, tool_version)` in this checkout, keyed
+/// by `edge_id` → `(kind, resolved_symbol_id)`. The whole-graph sibling of
+/// [`current_oracle_verdicts_for_edges`], for symbol-importance ranking which walks every edge (one
+/// scan, not a query per edge). Same scope + currency gate via the store helper.
+pub(crate) fn current_oracle_verdicts_all(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<std::collections::HashMap<i64, (OracleResolutionKind, Option<i64>)>> {
+    store::current_oracle_verdicts_all(conn, tool, tool_version, commit_sha, worktree_id)
+}
+
+/// Whether ANY oracle run exists in the active checkout (across all tools) — the cheap existence
+/// probe that short-circuits the per-tool [`latest_run_tool_version`] calls when nothing ever ran.
+pub(crate) fn any_run_in_scope(
+    conn: &Connection,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<bool> {
+    store::any_run_in_scope(conn, commit_sha, worktree_id)
+}
+
 /// Prune `oracle_runs` rows for dead `(commit_sha, worktree_id)` contexts — the gc companion to the
 /// `edge_oracle` FK cascade. See [`store::prune_oracle_runs_outside_scope`]. Returns rows deleted.
 pub fn prune_oracle_runs_outside_scope(

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -398,6 +398,25 @@ pub(crate) fn latest_run_tool_version(
     Ok(version)
 }
 
+/// Whether ANY oracle run exists in the active checkout, across all tools — one query to short out
+/// the per-tool [`latest_run_tool_version`] probes on the dominant "no oracle ever" path (where the
+/// table is empty, so this returns instantly). Scoped to `(commit_sha, worktree_id)`.
+pub(crate) fn any_run_in_scope(
+    conn: &Connection,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<bool> {
+    let exists = conn
+        .query_row(
+            "SELECT 1 FROM oracle_runs WHERE commit_sha = ?1 AND worktree_id = ?2 LIMIT 1",
+            params![commit_sha, worktree_id],
+            |_| Ok(()),
+        )
+        .ok()
+        .is_some();
+    Ok(exists)
+}
+
 /// The single canonical scope predicate every `edge_oracle` metric read joins through: restrict the
 /// counted verdicts to those whose edge belongs to the active `(commit_sha, worktree_id)` checkout,
 /// via `edge_oracle -> edges -> files`. This is the SAME join `edge_join_candidates` /
@@ -613,6 +632,46 @@ pub(crate) fn current_oracle_verdicts_for_edges(
                 tool_version: tool_version.to_string(),
             });
         }
+    }
+    Ok(out)
+}
+
+/// Fetch ALL current, in-scope oracle verdicts for `(tool, tool_version)` in this checkout, keyed
+/// by `edge_id` → `(kind, resolved_symbol_id)`. The single-scan sibling of
+/// [`current_oracle_verdicts_for_edges`] (which filters to a bounded id list): symbol-importance
+/// ranking ([`crate::query::pagerank`]) walks the WHOLE edge graph, so it needs the verdict set in
+/// one pass rather than a query per edge. Routes through the shared [`edge_oracle_scope_join`] +
+/// [`edge_oracle_current_predicate`] so the scope+currency gate can't be re-spelled — the only raw
+/// `FROM edge_oracle` lives here (#81). `resolved_symbol_id` is returned (not just its name)
+/// because the ranker needs the id to retarget an `Upgrade` edge.
+pub(crate) fn current_oracle_verdicts_all(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<std::collections::HashMap<i64, (OracleResolutionKind, Option<i64>)>> {
+    let sql = format!(
+        "SELECT edge_oracle.edge_id, edge_oracle.kind, \
+         edge_oracle.resolved_symbol_id{scope_join}{current}",
+        scope_join = edge_oracle_scope_join(),
+        current = edge_oracle_current_predicate(),
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows =
+        stmt.query_map(params![tool.as_db_str(), tool_version, commit_sha, worktree_id], |row| {
+            let edge_id: i64 = row.get(0)?;
+            let kind: String = row.get(1)?;
+            let resolved_symbol_id: Option<i64> = row.get(2)?;
+            Ok((edge_id, kind, resolved_symbol_id))
+        })?;
+    let mut out = std::collections::HashMap::new();
+    for row in rows {
+        let (edge_id, kind, resolved_symbol_id) = row?;
+        let Some(kind) = OracleResolutionKind::from_db_str(&kind) else {
+            continue;
+        };
+        out.insert(edge_id, (kind, resolved_symbol_id));
     }
     Ok(out)
 }

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -2632,6 +2632,28 @@ fn drifted_file_verdict_is_not_surfaced() {
     assert!(verdicts.is_empty(), "a drifted file's verdict must not surface as Compiler");
 }
 
+/// The whole-graph scan ([`store::current_oracle_verdicts_all`], used by symbol-importance ranking)
+/// returns the same current+in-scope verdicts as the per-edge read — `(kind, resolved_symbol_id)`
+/// keyed by edge id — and applies the same currency gate (a drifted callsite drops out).
+#[test]
+fn current_oracle_verdicts_all_returns_scoped_current() {
+    let (h, edge, _sha, resolved) =
+        seed_verdict_full(OracleResolutionKind::Upgrade, "scip x `target`().", true);
+    let all = store::current_oracle_verdicts_all(&h.conn, TOOL, VERSION, COMMIT, WORKTREE).unwrap();
+    assert_eq!(
+        all.get(&edge),
+        Some(&(OracleResolutionKind::Upgrade, resolved)),
+        "the whole-graph scan returns the current verdict with its resolved symbol id"
+    );
+
+    // Drift the callsite file: the currency gate must drop the verdict from the whole-graph scan
+    // too, exactly as it does for the per-edge read.
+    h.conn.execute("UPDATE files SET sha256 = 'drifted-sha' WHERE path = 'a.rs'", []).unwrap();
+    let after =
+        store::current_oracle_verdicts_all(&h.conn, TOOL, VERSION, COMMIT, WORKTREE).unwrap();
+    assert!(after.is_empty(), "a drifted file's verdict must not surface in the whole-graph scan");
+}
+
 /// Def-drift revert (#82 finding 3): an in-corpus verdict keeps its callsite file unchanged (so the
 /// `file_sha` gate still matches), but its resolved DEFINITION symbol is deleted/reinserted by
 /// incremental reindexing — the old `resolved_symbol_id` dangles. The surfacing read must drop the

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -1671,15 +1671,87 @@ impl IndexDatabase {
     /// Top load-bearing symbols by weighted PageRank over the active checkout's edge graph (#108).
     /// `personalize_to` biases importance toward those symbol ids (changed/query symbols); empty =
     /// global.
+    ///
+    /// When a SCIP oracle run exists for this checkout, ranking uses the compiler-verified graph
+    /// (contradicted edges dropped, upgrades retargeted, confirmed/upgraded edges weighted above
+    /// heuristic) — otherwise the heuristic graph with confidence weighting. The oracle lookup is
+    /// gated on a run existing, so absent oracle data it costs nothing (no scan).
     pub fn important_symbols(
         &self,
         limit: usize,
         personalize_to: &[i64],
     ) -> anyhow::Result<Vec<crate::query::pagerank::SymbolImportance>> {
+        let oracle_effects = self.symbol_importance_oracle_effects()?;
         crate::query::pagerank::important_symbols(
             self.storage.connection(),
-            crate::query::pagerank::ImportanceOptions { limit, personalize_to },
+            crate::query::pagerank::ImportanceOptions {
+                limit,
+                personalize_to,
+                oracle_effects: oracle_effects.as_ref(),
+            },
         )
+    }
+
+    /// Build the `edge_id -> EdgeOracleEffect` map that makes [`Self::important_symbols`]
+    /// SCIP-aware, merging current+in-scope verdicts across every oracle tool that has a run in
+    /// this checkout. Returns `None` when no run exists — the common case, where ranking pays zero
+    /// oracle cost (one existence probe short-circuits the per-tool version lookups + the
+    /// whole-graph verdict scan). Maps `OracleResolutionKind` to a ranking effect here so
+    /// `query::pagerank` stays free of oracle types:
+    /// - the compiler resolved an in-corpus target (`Upgrade` or `Contradict` with a resolved
+    ///   symbol) → **retarget** the edge there (the compiler's answer, whether it upgrades an
+    ///   unconfirmed edge or overrides a wrong heuristic one);
+    /// - `Confirm` → verify the heuristic target in place;
+    /// - `ResolvedExternal`, or a `Contradict` with no in-corpus target → **drop** the phantom edge
+    ///   (the real callee is out of corpus);
+    /// - an `Upgrade` with no resolved target → leave the edge heuristic (unconfirmed, not refuted
+    ///   — #82 finding 2).
+    fn symbol_importance_oracle_effects(
+        &self,
+    ) -> anyhow::Result<
+        Option<std::collections::HashMap<i64, crate::query::pagerank::EdgeOracleEffect>>,
+    > {
+        use crate::index::oracle::OracleResolutionKind as Kind;
+        use crate::query::pagerank::EdgeOracleEffect;
+        // CPU gate: one scoped existence query, so the dominant "no oracle ever" path skips the
+        // per-tool version lookups and the whole-graph verdict scan entirely.
+        if !oracle::any_run_in_scope(
+            self.storage.connection(),
+            &self.active_commit_sha,
+            &self.active_worktree_id,
+        )? {
+            return Ok(None);
+        }
+        let mut effects: Option<std::collections::HashMap<i64, EdgeOracleEffect>> = None;
+        for &tool in oracle::OracleTool::ALL {
+            let Some(version) = self.latest_oracle_run_version(tool)? else {
+                continue;
+            };
+            let verdicts = oracle::current_oracle_verdicts_all(
+                self.storage.connection(),
+                tool,
+                &version,
+                &self.active_commit_sha,
+                &self.active_worktree_id,
+            )?;
+            let map = effects.get_or_insert_with(std::collections::HashMap::new);
+            for (edge_id, (kind, resolved_symbol_id)) in verdicts {
+                let effect = match (kind, resolved_symbol_id) {
+                    // Out-of-corpus callee: the in-repo target is a phantom either way.
+                    (Kind::ResolvedExternal, _) | (Kind::Contradict, None) =>
+                        EdgeOracleEffect::Drop,
+                    (Kind::Confirm, _) => EdgeOracleEffect::Confirm,
+                    // Compiler resolved an in-corpus target — trust it over the heuristic.
+                    (Kind::Upgrade | Kind::Contradict, Some(id)) => EdgeOracleEffect::Retarget(id),
+                    // Upgrade we can't name a target for: leave the edge heuristic.
+                    (Kind::Upgrade, None) => continue,
+                };
+                // An edge belongs to one file → one language → at most one tool's verdict, so this
+                // never overwrites a different tool's effect for the same edge.
+                map.insert(edge_id, effect);
+            }
+        }
+        Ok(effects)
     }
 
     pub fn memory_create(
@@ -2268,6 +2340,88 @@ mod oracle_surfacing_tests {
         assert_eq!(
             c.resolved_external, None,
             "an in-corpus contradiction must not be labeled resolved-external"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// End-to-end #108 SCIP-aware ranking: an in-corpus Contradict RETARGETS importance to the
+    /// compiler's true callee. The heuristic resolves `caller -> target`; the compiler contradicts
+    /// it, resolving the callee to the in-corpus `other`. Before the run, `target` carries the
+    /// call's rank and `other` none; after, the rank flows to `other` (the compiler's answer),
+    /// not the heuristic guess. Proves the wrapper gates on a run existing, maps in-corpus
+    /// Contradict to a retarget, and applies it through to the ranker.
+    #[test]
+    fn important_symbols_retargets_an_in_corpus_contradiction() {
+        let root = temp_root();
+        fs::write(
+            root.join("src/lib.rs"),
+            "fn caller() { target(); } fn target() {} fn other() {}\n",
+        )
+        .unwrap();
+        let config = rust_config(root.clone());
+        let db = IndexDatabase::rebuild(&config).unwrap();
+        let conn = db.storage.connection();
+
+        let (edge_id, cs, ce, path) = call_edge(&db);
+        let name_of = |id: i64| -> String {
+            conn.query_row("SELECT qualified_name FROM symbols WHERE id = ?1", params![id], |r| {
+                r.get(0)
+            })
+            .unwrap()
+        };
+        let target_sym: i64 = conn
+            .query_row("SELECT id FROM symbols WHERE name = 'target' LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        let target_qn = name_of(target_sym);
+        // Force the heuristic edge to look exactly-resolved to `target`.
+        conn.execute(
+            "UPDATE edges SET confidence = 'Exact', resolution = 'exact', to_symbol_id = ?2 WHERE \
+             id = ?1",
+            params![edge_id, target_sym],
+        )
+        .unwrap();
+
+        let score_of = |out: &[crate::query::pagerank::SymbolImportance], qn: &str| {
+            out.iter().find(|s| s.qualified_name == qn).map_or(0.0, |s| s.score)
+        };
+
+        // The compiler contradicts the heuristic, resolving the callee to the other in-corpus def.
+        let (other_id, other_start, other_end): (i64, i64, i64) = conn
+            .query_row(
+                "SELECT id, start_byte, end_byte FROM symbols WHERE name = 'other' LIMIT 1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        let other_qn = name_of(other_id);
+
+        // Heuristic ranking (no oracle run yet): `target` carries the call's rank, `other` none.
+        let before = db.important_symbols(20, &[]).unwrap();
+        assert!(
+            score_of(&before, &target_qn) > 0.0,
+            "heuristically `target` carries rank: {before:?}"
+        );
+        assert_eq!(
+            score_of(&before, &other_qn),
+            0.0,
+            "`other` is uncalled heuristically: {before:?}"
+        );
+
+        let symbol = "scip-rust crate held-mini `other`().";
+        let scip = scip_with(&path, cs, ce, symbol, Some(&path), Some((other_start, other_end)));
+        db.run_oracle_from_scip(OracleTool::RustAnalyzer, "v-test", &scip).unwrap();
+
+        // SCIP-aware ranking: the edge is retargeted to the compiler's `other` — rank flows there,
+        // and the contradicted heuristic target `target` loses it.
+        let after = db.important_symbols(20, &[]).unwrap();
+        assert!(
+            score_of(&after, &other_qn) > score_of(&after, &target_qn),
+            "rank flows to the compiler's resolved callee, not the heuristic guess: {after:?}"
+        );
+        assert!(
+            score_of(&after, &other_qn) > score_of(&before, &other_qn),
+            "the retargeted callee gains rank it did not have heuristically: {after:?}"
         );
 
         let _ = fs::remove_dir_all(&root);

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -1668,6 +1668,20 @@ impl IndexDatabase {
         crate::query::clusters::repo_clusters(self.storage.connection(), options)
     }
 
+    /// Top load-bearing symbols by weighted PageRank over the active checkout's edge graph (#108).
+    /// `personalize_to` biases importance toward those symbol ids (changed/query symbols); empty =
+    /// global.
+    pub fn important_symbols(
+        &self,
+        limit: usize,
+        personalize_to: &[i64],
+    ) -> anyhow::Result<Vec<crate::query::pagerank::SymbolImportance>> {
+        crate::query::pagerank::important_symbols(
+            self.storage.connection(),
+            crate::query::pagerank::ImportanceOptions { limit, personalize_to },
+        )
+    }
+
     pub fn memory_create(
         &self,
         request: crate::query::memory::RepoMemoryCreate,

--- a/crates/rag-rat-core/src/query/mod.rs
+++ b/crates/rag-rat-core/src/query/mod.rs
@@ -5,6 +5,7 @@ pub mod grep_augment;
 pub mod impact;
 pub mod memory;
 pub mod orientation;
+pub mod pagerank;
 pub mod repo_brief;
 pub mod symbol;
 pub mod tree;

--- a/crates/rag-rat-core/src/query/pagerank.rs
+++ b/crates/rag-rat-core/src/query/pagerank.rs
@@ -19,6 +19,9 @@ const DAMPING: f64 = 0.85;
 const MAX_ITERS: usize = 100;
 /// L1-change convergence threshold: stop once the rank vector barely moves.
 const TOLERANCE: f64 = 1e-6;
+/// Hard cap on returned rows. Hydration is one point query per winner, so a hostile or careless
+/// `limit` (the MCP/CLI surface takes a `u32`) can't turn this into tens of thousands of lookups.
+const MAX_RESULTS: usize = 500;
 
 /// Per-edge-kind weight: structural dependencies (calls, impls) carry full importance; weaker
 /// associations (imports, containment) carry less. Unknown kinds default to `1.0`.
@@ -177,30 +180,38 @@ pub fn important_symbols(
 
     let scores = pagerank(symbol_ids.len(), &out_edges, personalize.as_deref());
 
-    // Top-`limit` indices by score.
+    // Top-`limit` indices by score. `sort_by` is stable, so equal scores keep insertion order →
+    // deterministic output for a fixed index. Clamp to `MAX_RESULTS` so the hydration loop below is
+    // bounded regardless of the caller's `limit`.
     let mut ranked: Vec<usize> = (0..symbol_ids.len()).collect();
     ranked.sort_by(|&a, &b| scores[b].partial_cmp(&scores[a]).unwrap_or(std::cmp::Ordering::Equal));
-    ranked.truncate(options.limit);
+    ranked.truncate(options.limit.min(MAX_RESULTS));
 
-    // Hydrate the winners with symbol metadata in one query.
+    // Hydrate the winners with symbol metadata. Joining `symbols` to the per-connection `files`
+    // scope view keeps hydration scope-consistent with the edge query: a winner whose file isn't in
+    // the active checkout drops out instead of emitting an empty path. Endpoints are active-scope
+    // by the edge re-resolution invariant, so this rarely fires — when it does, the result is
+    // shorter than `limit` rather than wrong.
     let mut out = Vec::with_capacity(ranked.len());
     for idx in ranked {
         let symbol_id = symbol_ids[idx];
-        let meta = conn
+        let row = conn
             .query_row(
-                "SELECT qualified_name, kind, file_id FROM symbols WHERE id = ?1",
+                "SELECT s.qualified_name, s.kind, f.path
+                 FROM symbols s
+                 JOIN files f ON f.id = s.file_id
+                 WHERE s.id = ?1",
                 [symbol_id],
                 |row| {
-                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, i64>(2)?))
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                    ))
                 },
             )
             .ok();
-        let Some((qualified_name, kind, file_id)) = meta else { continue };
-        let path = conn
-            .query_row("SELECT path FROM files WHERE id = ?1", [file_id], |row| {
-                row.get::<_, String>(0)
-            })
-            .unwrap_or_default();
+        let Some((qualified_name, kind, path)) = row else { continue };
         out.push(SymbolImportance { symbol_id, qualified_name, path, kind, score: scores[idx] });
     }
     Ok(out)
@@ -330,6 +341,69 @@ mod tests {
             important_symbols(&bare, ImportanceOptions { limit: 10, personalize_to: &[] })
                 .unwrap()
                 .is_empty()
+        );
+    }
+
+    /// Insert `n` symbols (`s1..sn`, ids `1..=n`) plus `edges` as `(from_id, to_id)` calls, all in
+    /// one file. Returns the connection ready for `important_symbols`.
+    fn graph_conn(n: usize, edges: &[(i64, i64)]) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
+             VALUES ('a.rs', 'rust', 'source', 'h', 0, 0)",
+            [],
+        )
+        .unwrap();
+        for i in 1..=n {
+            conn.execute(
+                "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte,
+                                     end_byte, signature, docs)
+                 VALUES (1, 'rust', ?1, ?2, 'function', 0, 10, NULL, NULL)",
+                params![format!("s{i}"), format!("a::s{i}")],
+            )
+            .unwrap();
+        }
+        for &(from, to) in edges {
+            conn.execute(
+                "INSERT INTO edges(source_file_id, from_symbol_id, to_symbol_id, to_name,
+                                   target_qualified_name, edge_kind, confidence)
+                 VALUES (1, ?1, ?2, 'x', 'a::x', 'calls_name', 'exact')",
+                params![from, to],
+            )
+            .unwrap();
+        }
+        conn
+    }
+
+    #[test]
+    fn limit_truncates_and_a_huge_limit_is_safe() {
+        let conn = graph_conn(3, &[(1, 3), (2, 3)]);
+        // `limit` truncates to fewer than the node count.
+        let one =
+            important_symbols(&conn, ImportanceOptions { limit: 1, personalize_to: &[] }).unwrap();
+        assert_eq!(one.len(), 1, "limit caps the result count");
+        // An absurd limit clamps to the node count via MAX_RESULTS — no panic, no overflow, no
+        // tens-of-thousands of point lookups.
+        let huge = important_symbols(&conn, ImportanceOptions {
+            limit: u32::MAX as usize,
+            personalize_to: &[],
+        })
+        .unwrap();
+        assert_eq!(huge.len(), 3, "bounded by the graph, never by the caller's limit");
+    }
+
+    #[test]
+    fn personalization_biases_the_db_ranking() {
+        // Two disjoint symmetric 2-cycles: {1↔2} and {3↔4}. Globally all four are balanced;
+        // personalizing toward symbol 1 must lift its cluster (1,2) above the other (3,4).
+        let conn = graph_conn(4, &[(1, 2), (2, 1), (3, 4), (4, 3)]);
+        let out =
+            important_symbols(&conn, ImportanceOptions { limit: 4, personalize_to: &[1] }).unwrap();
+        let top_two: Vec<&str> = out.iter().take(2).map(|s| s.qualified_name.as_str()).collect();
+        assert!(
+            top_two.iter().all(|q| *q == "a::s1" || *q == "a::s2"),
+            "personalized cluster ranks first: {out:?}"
         );
     }
 }

--- a/crates/rag-rat-core/src/query/pagerank.rs
+++ b/crates/rag-rat-core/src/query/pagerank.rs
@@ -36,6 +36,44 @@ fn edge_weight(kind: &str) -> f64 {
     }
 }
 
+/// Multiplier on [`edge_weight`] by the heuristic resolver's confidence in the edge
+/// (`EdgeConfidence` db strings). A name-only guess is a weak signal that a dependency exists, so
+/// it should flow less of the source's rank to that callee than a structurally-resolved call.
+/// Unknown values default to `1.0` (same defensive posture as [`edge_weight`]). A SCIP-verified
+/// edge bypasses this entirely and uses [`COMPILER_FACTOR`].
+fn confidence_factor(confidence: &str) -> f64 {
+    match confidence {
+        "Exact" => 1.0,
+        "Syntactic" => 0.85,
+        "NameOnly" => 0.4,
+        "Ambiguous" => 0.2,
+        _ => 1.0,
+    }
+}
+
+/// Confidence factor for an edge a SCIP oracle confirmed or resolved — above a heuristic `Exact`
+/// (`1.0`), so a compiler-verified dependency outranks a merely well-guessed one. Because PageRank
+/// normalizes each source node's out-weights, the bonus only changes the outcome at a *mixed*
+/// source (some edges compiler-verified, some heuristic), tilting that node's rank toward the
+/// verified callees; it is a no-op at a node whose edges are all the same tier.
+const COMPILER_FACTOR: f64 = 1.2;
+
+/// What a current, in-scope SCIP oracle verdict does to an edge during ranking, keyed by `edge_id`.
+/// Built by the query layer from `OracleResolutionKind` so this module stays free of oracle types.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum EdgeOracleEffect {
+    /// The real callee is out of corpus — a `resolved-external`, or a `contradict` the compiler
+    /// couldn't resolve to an in-corpus symbol. Drop the phantom in-repo edge from the graph.
+    Drop,
+    /// The compiler confirmed the heuristic target — keep it, but weight at [`COMPILER_FACTOR`].
+    Confirm,
+    /// The compiler resolved the edge to an in-corpus symbol id — retarget the edge there and
+    /// weight at [`COMPILER_FACTOR`]. Covers both an `upgrade` (of an unconfirmed edge) and an
+    /// in-corpus `contradict` (overriding a wrong heuristic target): in both cases the id is
+    /// the compiler's answer.
+    Retarget(i64),
+}
+
 /// One node's outgoing edges as `(target_index, weight)`. Index space is `0..n`.
 pub type Adjacency = Vec<Vec<(usize, f64)>>;
 
@@ -115,6 +153,10 @@ pub struct ImportanceOptions<'a> {
     /// Optional personalization seed — symbol ids to bias importance toward (the agent's changed /
     /// query symbols). Empty/none = global importance.
     pub personalize_to: &'a [i64],
+    /// Optional SCIP-oracle effects keyed by `edge_id` (current + in-scope verdicts). `None` = no
+    /// oracle run for this checkout → rank the heuristic graph with confidence weighting only. The
+    /// caller builds this so absent oracle data costs zero (no scan); see the query-layer wrapper.
+    pub oracle_effects: Option<&'a HashMap<i64, EdgeOracleEffect>>,
 }
 
 /// Compute weighted PageRank over the active checkout's resolved symbol→symbol edges and return the
@@ -126,17 +168,26 @@ pub fn important_symbols(
     options: ImportanceOptions<'_>,
 ) -> anyhow::Result<Vec<SymbolImportance>> {
     // Resolved symbol→symbol edges in the active checkout: both endpoints non-null, source file in
-    // the scope view. `edge_strings` resolves the edge-kind id to its name for weighting.
+    // the scope view. `edge_strings` resolves the edge-kind and confidence ids to their names — the
+    // kind sets the base weight, the confidence scales it (a name-only guess flows less rank than a
+    // structurally-resolved call). `d.id` keys the optional SCIP-oracle effect lookup.
     let mut stmt = conn.prepare(
-        "SELECT d.from_symbol_id, d.to_symbol_id, ek.value
+        "SELECT d.id, d.from_symbol_id, d.to_symbol_id, ek.value, cf.value
          FROM edges_data d
          JOIN files ON files.id = d.source_file_id
          JOIN edge_strings ek ON ek.id = d.edge_kind_id
+         JOIN edge_strings cf ON cf.id = d.confidence_id
          WHERE d.from_symbol_id IS NOT NULL AND d.to_symbol_id IS NOT NULL",
     )?;
     let rows = stmt
         .query_map([], |row| {
-            Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?, row.get::<_, String>(2)?))
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+            ))
         })?
         .collect::<Result<Vec<_>, _>>()?;
     if rows.is_empty() {
@@ -153,13 +204,23 @@ pub fn important_symbols(
         })
     };
     let mut out_edges: Adjacency = Vec::new();
-    for (from, to, kind) in &rows {
+    for (edge_id, from, to, kind, confidence) in &rows {
+        // Apply the SCIP verdict, if any: drop a contradicted/external edge entirely, retarget an
+        // upgrade to the compiler's resolved symbol, and weight a confirmed/upgraded edge at the
+        // compiler tier. Absent a verdict, fall back to heuristic confidence weighting.
+        let (to_id, weight) = match options.oracle_effects.and_then(|m| m.get(edge_id)) {
+            Some(EdgeOracleEffect::Drop) => continue,
+            Some(EdgeOracleEffect::Retarget(resolved)) =>
+                (*resolved, edge_weight(kind) * COMPILER_FACTOR),
+            Some(EdgeOracleEffect::Confirm) => (*to, edge_weight(kind) * COMPILER_FACTOR),
+            None => (*to, edge_weight(kind) * confidence_factor(confidence)),
+        };
         let from_idx = intern(*from, &mut index_of, &mut symbol_ids);
-        let to_idx = intern(*to, &mut index_of, &mut symbol_ids);
+        let to_idx = intern(to_id, &mut index_of, &mut symbol_ids);
         if out_edges.len() < symbol_ids.len() {
             out_edges.resize_with(symbol_ids.len(), Vec::new);
         }
-        out_edges[from_idx].push((to_idx, edge_weight(kind)));
+        out_edges[from_idx].push((to_idx, weight));
     }
     out_edges.resize_with(symbol_ids.len(), Vec::new);
 
@@ -228,6 +289,17 @@ mod tests {
         let mut idx: Vec<usize> = (0..scores.len()).collect();
         idx.sort_by(|&a, &b| scores[b].partial_cmp(&scores[a]).unwrap());
         idx
+    }
+
+    /// `ImportanceOptions` with no SCIP effects — the heuristic + confidence ranking path.
+    fn opts(limit: usize, personalize_to: &[i64]) -> ImportanceOptions<'_> {
+        ImportanceOptions { limit, personalize_to, oracle_effects: None }
+    }
+
+    /// Score of the symbol with `qualified_name` in a result set, or `0.0` when absent (a dropped /
+    /// never-interned node).
+    fn score_of(out: &[SymbolImportance], qualified_name: &str) -> f64 {
+        out.iter().find(|s| s.qualified_name == qualified_name).map_or(0.0, |s| s.score)
     }
 
     #[test]
@@ -327,8 +399,7 @@ mod tests {
             .unwrap();
         }
 
-        let out =
-            important_symbols(&conn, ImportanceOptions { limit: 10, personalize_to: &[] }).unwrap();
+        let out = important_symbols(&conn, opts(10, &[])).unwrap();
         assert!(!out.is_empty(), "graph has edges → results");
         assert_eq!(out[0].qualified_name, "a::hub", "the called hub ranks first: {out:?}");
         assert_eq!(out[0].path, "a.rs");
@@ -337,11 +408,7 @@ mod tests {
         // No resolved symbol→symbol edges → empty (not an error).
         let bare = Connection::open_in_memory().unwrap();
         schema::apply(&bare).unwrap();
-        assert!(
-            important_symbols(&bare, ImportanceOptions { limit: 10, personalize_to: &[] })
-                .unwrap()
-                .is_empty()
-        );
+        assert!(important_symbols(&bare, opts(10, &[])).unwrap().is_empty());
     }
 
     /// Insert `n` symbols (`s1..sn`, ids `1..=n`) plus `edges` as `(from_id, to_id)` calls, all in
@@ -380,16 +447,11 @@ mod tests {
     fn limit_truncates_and_a_huge_limit_is_safe() {
         let conn = graph_conn(3, &[(1, 3), (2, 3)]);
         // `limit` truncates to fewer than the node count.
-        let one =
-            important_symbols(&conn, ImportanceOptions { limit: 1, personalize_to: &[] }).unwrap();
+        let one = important_symbols(&conn, opts(1, &[])).unwrap();
         assert_eq!(one.len(), 1, "limit caps the result count");
         // An absurd limit clamps to the node count via MAX_RESULTS — no panic, no overflow, no
         // tens-of-thousands of point lookups.
-        let huge = important_symbols(&conn, ImportanceOptions {
-            limit: u32::MAX as usize,
-            personalize_to: &[],
-        })
-        .unwrap();
+        let huge = important_symbols(&conn, opts(u32::MAX as usize, &[])).unwrap();
         assert_eq!(huge.len(), 3, "bounded by the graph, never by the caller's limit");
     }
 
@@ -398,12 +460,141 @@ mod tests {
         // Two disjoint symmetric 2-cycles: {1↔2} and {3↔4}. Globally all four are balanced;
         // personalizing toward symbol 1 must lift its cluster (1,2) above the other (3,4).
         let conn = graph_conn(4, &[(1, 2), (2, 1), (3, 4), (4, 3)]);
-        let out =
-            important_symbols(&conn, ImportanceOptions { limit: 4, personalize_to: &[1] }).unwrap();
+        let out = important_symbols(&conn, opts(4, &[1])).unwrap();
         let top_two: Vec<&str> = out.iter().take(2).map(|s| s.qualified_name.as_str()).collect();
         assert!(
             top_two.iter().all(|q| *q == "a::s1" || *q == "a::s2"),
             "personalized cluster ranks first: {out:?}"
         );
+    }
+
+    /// Like [`graph_conn`] but each edge carries an explicit confidence (`EdgeConfidence::as_str`
+    /// casing, e.g. `"Exact"` / `"NameOnly"`); kind is always `calls_name`. Edge ids are `1..` in
+    /// insertion order, so a test can key an `oracle_effects` map by them.
+    fn conf_conn(n: usize, edges: &[(i64, i64, &str)]) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
+             VALUES ('a.rs', 'rust', 'source', 'h', 0, 0)",
+            [],
+        )
+        .unwrap();
+        for i in 1..=n {
+            conn.execute(
+                "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte,
+                                     end_byte, signature, docs)
+                 VALUES (1, 'rust', ?1, ?2, 'function', 0, 10, NULL, NULL)",
+                params![format!("s{i}"), format!("a::s{i}")],
+            )
+            .unwrap();
+        }
+        for &(from, to, confidence) in edges {
+            conn.execute(
+                "INSERT INTO edges(source_file_id, from_symbol_id, to_symbol_id, to_name,
+                                   target_qualified_name, edge_kind, confidence)
+                 VALUES (1, ?1, ?2, 'x', 'a::x', 'calls_name', ?3)",
+                params![from, to, confidence],
+            )
+            .unwrap();
+        }
+        conn
+    }
+
+    #[test]
+    fn confidence_factor_orders_by_certainty() {
+        assert!(confidence_factor("Exact") > confidence_factor("Syntactic"));
+        assert!(confidence_factor("Syntactic") > confidence_factor("NameOnly"));
+        assert!(confidence_factor("NameOnly") > confidence_factor("Ambiguous"));
+        assert_eq!(
+            confidence_factor("whatever"),
+            1.0,
+            "unknown confidence defaults to full weight"
+        );
+    }
+
+    #[test]
+    fn confidence_lifts_the_more_certain_dependency() {
+        // 1 calls 2 (Exact) and 3 (NameOnly), same kind → the exactly-resolved callee outranks the
+        // name-only guess purely on confidence.
+        let conn = conf_conn(3, &[(1, 2, "Exact"), (1, 3, "NameOnly")]);
+        let out = important_symbols(&conn, opts(10, &[])).unwrap();
+        assert!(
+            score_of(&out, "a::s2") > score_of(&out, "a::s3"),
+            "higher-confidence callee ranks higher: {out:?}"
+        );
+    }
+
+    #[test]
+    fn contradicted_edge_is_dropped_from_ranking() {
+        // 1 calls 2 (edge id 1) and 3 (edge id 2); the oracle contradicts 1→2. The phantom target
+        // gets no rank and falls out of the graph entirely; the real callee ranks first.
+        let conn = conf_conn(3, &[(1, 2, "Exact"), (1, 3, "Exact")]);
+        let effects = HashMap::from([(1_i64, EdgeOracleEffect::Drop)]);
+        let out = important_symbols(&conn, ImportanceOptions {
+            limit: 10,
+            personalize_to: &[],
+            oracle_effects: Some(&effects),
+        })
+        .unwrap();
+        assert_eq!(out[0].qualified_name, "a::s3", "the surviving callee ranks first: {out:?}");
+        assert!(
+            !out.iter().any(|s| s.qualified_name == "a::s2"),
+            "the contradicted-only target drops out of the graph: {out:?}"
+        );
+    }
+
+    #[test]
+    fn upgrade_retargets_rank_to_the_resolved_symbol() {
+        // 1 calls 2 heuristically (edge id 1), but the oracle upgrades the edge to resolve at 3.
+        // Rank flows to the compiler's target, not the heuristic guess.
+        let conn = conf_conn(3, &[(1, 2, "NameOnly")]);
+        let effects = HashMap::from([(1_i64, EdgeOracleEffect::Retarget(3))]);
+        let out = important_symbols(&conn, ImportanceOptions {
+            limit: 10,
+            personalize_to: &[],
+            oracle_effects: Some(&effects),
+        })
+        .unwrap();
+        assert_eq!(out[0].qualified_name, "a::s3", "rank flows to the retargeted symbol: {out:?}");
+        assert!(
+            !out.iter().any(|s| s.qualified_name == "a::s2"),
+            "the heuristic target gets no rank: {out:?}"
+        );
+    }
+
+    #[test]
+    fn confirm_overrides_low_heuristic_confidence() {
+        // 1 calls 2 (name_only, CONFIRMED, edge id 1) and 3 (name_only, no verdict, edge id 2).
+        // Confirm weights 1→2 at the compiler tier (above NameOnly), so 2 outranks 3.
+        let conn = conf_conn(3, &[(1, 2, "NameOnly"), (1, 3, "NameOnly")]);
+        let effects = HashMap::from([(1_i64, EdgeOracleEffect::Confirm)]);
+        let out = important_symbols(&conn, ImportanceOptions {
+            limit: 10,
+            personalize_to: &[],
+            oracle_effects: Some(&effects),
+        })
+        .unwrap();
+        assert!(
+            score_of(&out, "a::s2") > score_of(&out, "a::s3"),
+            "the confirmed edge outranks an equal-confidence unverified one: {out:?}"
+        );
+    }
+
+    #[test]
+    fn no_oracle_run_is_heuristic_confidence_only() {
+        // `None` effects and an empty effects map must rank identically — guards the CPU gate: an
+        // absent oracle introduces no behavioral dependency, it's just the confidence-weighted
+        // path.
+        let conn = conf_conn(3, &[(1, 2, "Exact"), (1, 3, "NameOnly")]);
+        let none = important_symbols(&conn, opts(10, &[])).unwrap();
+        let empty: HashMap<i64, EdgeOracleEffect> = HashMap::new();
+        let empty_map = important_symbols(&conn, ImportanceOptions {
+            limit: 10,
+            personalize_to: &[],
+            oracle_effects: Some(&empty),
+        })
+        .unwrap();
+        assert_eq!(none, empty_map, "None and an empty effects map rank identically");
     }
 }

--- a/crates/rag-rat-core/src/query/pagerank.rs
+++ b/crates/rag-rat-core/src/query/pagerank.rs
@@ -1,0 +1,335 @@
+//! Weighted PageRank over the symbol→symbol edge graph — "which symbols are load-bearing?" (#108).
+//!
+//! An edge `from_symbol → to_symbol` (a call, type reference, impl, …) flows importance to the
+//! callee, so a symbol many things depend on scores high. The pure [`pagerank`] core takes a
+//! weighted adjacency + an optional personalization vector (bias the random surfer toward the
+//! agent's changed/query symbols — the Aider repo-map trick) and is unit-tested without a DB;
+//! [`important_symbols`] builds the adjacency from the active checkout's resolved edges and returns
+//! the top-ranked symbols with metadata.
+
+use std::collections::HashMap;
+
+use rusqlite::Connection;
+use serde::Serialize;
+
+/// Standard random-restart probability — the surfer follows an edge with probability `DAMPING`,
+/// teleports with `1 - DAMPING`.
+const DAMPING: f64 = 0.85;
+/// Iteration cap; PageRank on these graphs converges well within this. Paired with `TOLERANCE`.
+const MAX_ITERS: usize = 100;
+/// L1-change convergence threshold: stop once the rank vector barely moves.
+const TOLERANCE: f64 = 1e-6;
+
+/// Per-edge-kind weight: structural dependencies (calls, impls) carry full importance; weaker
+/// associations (imports, containment) carry less. Unknown kinds default to `1.0`.
+fn edge_weight(kind: &str) -> f64 {
+    match kind {
+        "calls_name" | "implements" => 1.0,
+        "references_type" | "constructs" => 0.7,
+        "uses_macro" => 0.5,
+        "imports" | "exports" => 0.3,
+        "contains" => 0.2,
+        _ => 1.0,
+    }
+}
+
+/// One node's outgoing edges as `(target_index, weight)`. Index space is `0..n`.
+pub type Adjacency = Vec<Vec<(usize, f64)>>;
+
+/// Weighted PageRank. `out_edges[i]` is node `i`'s outgoing `(target, weight)` list. `personalize`,
+/// when `Some`, is the teleport distribution (need not be normalized; non-finite/negative entries
+/// are treated as 0, and an all-zero vector falls back to uniform); `None` = uniform teleport.
+/// Returns a score per node summing to ~1. Dangling nodes (no out-edges) redistribute their mass
+/// via the teleport vector each iteration, so rank is conserved.
+pub fn pagerank(n: usize, out_edges: &Adjacency, personalize: Option<&[f64]>) -> Vec<f64> {
+    if n == 0 {
+        return Vec::new();
+    }
+    // Teleport distribution: normalized personalization, or uniform.
+    let teleport: Vec<f64> = match personalize {
+        Some(p) if p.len() == n => {
+            let total: f64 = p.iter().filter(|x| x.is_finite() && **x > 0.0).sum();
+            if total > 0.0 {
+                p.iter().map(|x| if x.is_finite() && *x > 0.0 { x / total } else { 0.0 }).collect()
+            } else {
+                vec![1.0 / n as f64; n]
+            }
+        },
+        _ => vec![1.0 / n as f64; n],
+    };
+    // Pre-normalize each node's out-weights so they sum to 1 (a dangling node stays empty).
+    let normalized: Adjacency = out_edges
+        .iter()
+        .map(|edges| {
+            let total: f64 = edges.iter().map(|(_, w)| w.max(0.0)).sum();
+            if total > 0.0 {
+                edges.iter().map(|&(t, w)| (t, w.max(0.0) / total)).collect()
+            } else {
+                Vec::new()
+            }
+        })
+        .collect();
+
+    let mut rank = teleport.clone();
+    for _ in 0..MAX_ITERS {
+        // Mass stranded on dangling nodes this round, redistributed via teleport.
+        let dangling: f64 = (0..n).filter(|&i| normalized[i].is_empty()).map(|i| rank[i]).sum();
+        let mut next = vec![0.0_f64; n];
+        for (i, edges) in normalized.iter().enumerate() {
+            let share = DAMPING * rank[i];
+            for &(target, weight) in edges {
+                next[target] += share * weight;
+            }
+        }
+        let base = (1.0 - DAMPING) + DAMPING * dangling;
+        for i in 0..n {
+            next[i] += base * teleport[i];
+        }
+        let delta: f64 = (0..n).map(|i| (next[i] - rank[i]).abs()).sum();
+        rank = next;
+        if delta < TOLERANCE {
+            break;
+        }
+    }
+    rank
+}
+
+/// A ranked load-bearing symbol.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SymbolImportance {
+    pub symbol_id: i64,
+    pub qualified_name: String,
+    pub path: String,
+    pub kind: String,
+    /// PageRank score (higher = more depended-upon). Scores sum to ~1 across all graph nodes.
+    pub score: f64,
+}
+
+/// Options for [`important_symbols`].
+pub struct ImportanceOptions<'a> {
+    /// Max symbols to return.
+    pub limit: usize,
+    /// Optional personalization seed — symbol ids to bias importance toward (the agent's changed /
+    /// query symbols). Empty/none = global importance.
+    pub personalize_to: &'a [i64],
+}
+
+/// Compute weighted PageRank over the active checkout's resolved symbol→symbol edges and return the
+/// top-`limit` load-bearing symbols. Reads `edges_data` joined to the per-connection `files` scope
+/// view (active checkout only), using edges where both endpoints resolved to a symbol. Returns an
+/// empty list when the graph has no resolved symbol edges.
+pub fn important_symbols(
+    conn: &Connection,
+    options: ImportanceOptions<'_>,
+) -> anyhow::Result<Vec<SymbolImportance>> {
+    // Resolved symbol→symbol edges in the active checkout: both endpoints non-null, source file in
+    // the scope view. `edge_strings` resolves the edge-kind id to its name for weighting.
+    let mut stmt = conn.prepare(
+        "SELECT d.from_symbol_id, d.to_symbol_id, ek.value
+         FROM edges_data d
+         JOIN files ON files.id = d.source_file_id
+         JOIN edge_strings ek ON ek.id = d.edge_kind_id
+         WHERE d.from_symbol_id IS NOT NULL AND d.to_symbol_id IS NOT NULL",
+    )?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?, row.get::<_, String>(2)?))
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    if rows.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Map symbol ids to a dense 0..n index space.
+    let mut index_of: HashMap<i64, usize> = HashMap::new();
+    let mut symbol_ids: Vec<i64> = Vec::new();
+    let intern = |id: i64, index_of: &mut HashMap<i64, usize>, ids: &mut Vec<i64>| -> usize {
+        *index_of.entry(id).or_insert_with(|| {
+            ids.push(id);
+            ids.len() - 1
+        })
+    };
+    let mut out_edges: Adjacency = Vec::new();
+    for (from, to, kind) in &rows {
+        let from_idx = intern(*from, &mut index_of, &mut symbol_ids);
+        let to_idx = intern(*to, &mut index_of, &mut symbol_ids);
+        if out_edges.len() < symbol_ids.len() {
+            out_edges.resize_with(symbol_ids.len(), Vec::new);
+        }
+        out_edges[from_idx].push((to_idx, edge_weight(kind)));
+    }
+    out_edges.resize_with(symbol_ids.len(), Vec::new);
+
+    // Personalization: 1.0 on each seed symbol that is present in the graph, else uniform.
+    let personalize: Option<Vec<f64>> = if options.personalize_to.is_empty() {
+        None
+    } else {
+        let mut vector = vec![0.0_f64; symbol_ids.len()];
+        let mut any = false;
+        for id in options.personalize_to {
+            if let Some(&idx) = index_of.get(id) {
+                vector[idx] = 1.0;
+                any = true;
+            }
+        }
+        any.then_some(vector)
+    };
+
+    let scores = pagerank(symbol_ids.len(), &out_edges, personalize.as_deref());
+
+    // Top-`limit` indices by score.
+    let mut ranked: Vec<usize> = (0..symbol_ids.len()).collect();
+    ranked.sort_by(|&a, &b| scores[b].partial_cmp(&scores[a]).unwrap_or(std::cmp::Ordering::Equal));
+    ranked.truncate(options.limit);
+
+    // Hydrate the winners with symbol metadata in one query.
+    let mut out = Vec::with_capacity(ranked.len());
+    for idx in ranked {
+        let symbol_id = symbol_ids[idx];
+        let meta = conn
+            .query_row(
+                "SELECT qualified_name, kind, file_id FROM symbols WHERE id = ?1",
+                [symbol_id],
+                |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, i64>(2)?))
+                },
+            )
+            .ok();
+        let Some((qualified_name, kind, file_id)) = meta else { continue };
+        let path = conn
+            .query_row("SELECT path FROM files WHERE id = ?1", [file_id], |row| {
+                row.get::<_, String>(0)
+            })
+            .unwrap_or_default();
+        out.push(SymbolImportance { symbol_id, qualified_name, path, kind, score: scores[idx] });
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::params;
+
+    use super::*;
+    use crate::index::schema;
+
+    fn approx_desc(scores: &[f64]) -> Vec<usize> {
+        let mut idx: Vec<usize> = (0..scores.len()).collect();
+        idx.sort_by(|&a, &b| scores[b].partial_cmp(&scores[a]).unwrap());
+        idx
+    }
+
+    #[test]
+    fn ranks_a_hub_highest() {
+        // 0→2, 1→2, 3→2 : everyone depends on 2 → 2 is the most load-bearing.
+        let adj: Adjacency = vec![vec![(2, 1.0)], vec![(2, 1.0)], vec![], vec![(2, 1.0)]];
+        let scores = pagerank(4, &adj, None);
+        assert_eq!(
+            approx_desc(&scores)[0],
+            2,
+            "the hub everyone points at ranks first: {scores:?}"
+        );
+        let sum: f64 = scores.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-6, "rank is conserved (sums to 1): {sum}");
+    }
+
+    #[test]
+    fn weight_lifts_the_heavier_dependency() {
+        // 0 depends on both 1 and 2, but on 2 much more heavily → 2 outranks 1.
+        let adj: Adjacency = vec![vec![(1, 0.2), (2, 1.0)], vec![], vec![]];
+        let scores = pagerank(3, &adj, None);
+        assert!(scores[2] > scores[1], "heavier-weighted callee ranks higher: {scores:?}");
+    }
+
+    #[test]
+    fn dangling_node_conserves_rank() {
+        // 0→1, 1 dangling (no out-edges): mass must not leak — total stays ~1.
+        let adj: Adjacency = vec![vec![(1, 1.0)], vec![]];
+        let scores = pagerank(2, &adj, None);
+        let sum: f64 = scores.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-6, "dangling mass redistributed, not lost: {sum}");
+    }
+
+    #[test]
+    fn personalization_biases_toward_the_seed() {
+        // A symmetric two-node graph; personalizing toward node 0 must rank it above node 1.
+        let adj: Adjacency = vec![vec![(1, 1.0)], vec![(0, 1.0)]];
+        let global = pagerank(2, &adj, None);
+        assert!((global[0] - global[1]).abs() < 1e-6, "symmetric graph is balanced: {global:?}");
+        let biased = pagerank(2, &adj, Some(&[1.0, 0.0]));
+        assert!(biased[0] > biased[1], "personalization lifts the seed node: {biased:?}");
+    }
+
+    #[test]
+    fn empty_graph_is_empty() {
+        let empty: Adjacency = Vec::new();
+        assert!(pagerank(0, &empty, None).is_empty());
+    }
+
+    #[test]
+    fn invalid_personalization_falls_back_to_uniform() {
+        // Wrong length and all-zero personalization both degrade to uniform teleport (no panic).
+        let adj: Adjacency = vec![vec![(1, 1.0)], vec![(0, 1.0)]];
+        let wrong_len = pagerank(2, &adj, Some(&[1.0]));
+        let all_zero = pagerank(2, &adj, Some(&[0.0, 0.0]));
+        for scores in [wrong_len, all_zero] {
+            assert!((scores[0] - scores[1]).abs() < 1e-6, "uniform fallback: {scores:?}");
+        }
+    }
+
+    #[test]
+    fn edge_weight_downweights_weak_kinds() {
+        assert!(edge_weight("calls_name") > edge_weight("imports"));
+        assert!(edge_weight("implements") > edge_weight("contains"));
+        assert_eq!(edge_weight("something_new"), 1.0, "unknown kinds default to full weight");
+    }
+
+    #[test]
+    fn important_symbols_ranks_the_most_depended_on_first() {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
+             VALUES ('a.rs', 'rust', 'source', 'h', 0, 0)",
+            [],
+        )
+        .unwrap();
+        for (name, qname) in
+            [("caller_a", "a::caller_a"), ("caller_b", "a::caller_b"), ("hub", "a::hub")]
+        {
+            conn.execute(
+                "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte,
+                                     end_byte, signature, docs)
+                 VALUES (1, 'rust', ?1, ?2, 'function', 0, 10, NULL, NULL)",
+                params![name, qname],
+            )
+            .unwrap();
+        }
+        // symbol ids 1,2,3 in insertion order; both callers call the hub (id 3).
+        for from in [1_i64, 2] {
+            conn.execute(
+                "INSERT INTO edges(source_file_id, from_symbol_id, to_symbol_id, to_name,
+                                   target_qualified_name, edge_kind, confidence)
+                 VALUES (1, ?1, 3, 'hub', 'a::hub', 'calls_name', 'exact')",
+                params![from],
+            )
+            .unwrap();
+        }
+
+        let out =
+            important_symbols(&conn, ImportanceOptions { limit: 10, personalize_to: &[] }).unwrap();
+        assert!(!out.is_empty(), "graph has edges → results");
+        assert_eq!(out[0].qualified_name, "a::hub", "the called hub ranks first: {out:?}");
+        assert_eq!(out[0].path, "a.rs");
+        assert_eq!(out[0].kind, "function");
+
+        // No resolved symbol→symbol edges → empty (not an error).
+        let bare = Connection::open_in_memory().unwrap();
+        schema::apply(&bare).unwrap();
+        assert!(
+            important_symbols(&bare, ImportanceOptions { limit: 10, personalize_to: &[] })
+                .unwrap()
+                .is_empty()
+        );
+    }
+}

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -11,11 +11,11 @@ use rmcp::{ErrorData, RoleServer, ServerHandler, ServiceExt, tool, tool_handler,
 use serde_json::{Map, Value, json};
 
 use crate::tools::{
-    BlameChunkArgs, CompareGraphTextArgs, EmptyArgs, HealIndexArgs, ImpactArgs, LimitArgs,
-    MemoryCreateArgs, MemoryForCallPathArgs, MemoryForPathArgs, MemoryForSymbolArgs, MemoryIdArgs,
-    MemoryRebindArgs, MemorySearchArgs, MemoryUpdateArgs, PapertrailChunkArgs,
-    PapertrailCommitArgs, PathHistoryArgs, ReadChunkArgs, RepoBriefArgs, RepoClustersArgs,
-    SearchArgs, SymbolArgs, SymbolGraphArgs,
+    BlameChunkArgs, CompareGraphTextArgs, EmptyArgs, HealIndexArgs, ImpactArgs,
+    ImportantSymbolsArgs, LimitArgs, MemoryCreateArgs, MemoryForCallPathArgs, MemoryForPathArgs,
+    MemoryForSymbolArgs, MemoryIdArgs, MemoryRebindArgs, MemorySearchArgs, MemoryUpdateArgs,
+    PapertrailChunkArgs, PapertrailCommitArgs, PathHistoryArgs, ReadChunkArgs, RepoBriefArgs,
+    RepoClustersArgs, SearchArgs, SymbolArgs, SymbolGraphArgs,
 };
 
 #[derive(Clone)]
@@ -169,6 +169,18 @@ impl RagRatService {
         Parameters(args): Parameters<RepoClustersArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         self.call("repo_clusters", json!(args))
+    }
+
+    #[tool(
+        name = "important_symbols",
+        description = "Rank the most load-bearing symbols by weighted PageRank over the edge \
+                       graph — the spine to not reinvent or break. Run before editing."
+    )]
+    fn important_symbols(
+        &self,
+        Parameters(args): Parameters<ImportantSymbolsArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.call("important_symbols", json!(args))
     }
 
     #[tool(

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -78,7 +78,7 @@ pub(crate) fn call_tool_with_db(
         },
         "important_symbols" => {
             let args: ImportantSymbolsArgs = serde_json::from_value(arguments)?;
-            json!(db.important_symbols(args.limit as usize, &[])?)
+            json!(db.important_symbols(args.limit as usize, &args.personalize)?)
         },
         "ffi_surface" => {
             let args: LimitArgs = serde_json::from_value(arguments)?;

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -76,6 +76,10 @@ pub(crate) fn call_tool_with_db(
                 min_cluster_size: args.min_cluster_size,
             })?)
         },
+        "important_symbols" => {
+            let args: ImportantSymbolsArgs = serde_json::from_value(arguments)?;
+            json!(db.important_symbols(args.limit as usize, &[])?)
+        },
         "ffi_surface" => {
             let args: LimitArgs = serde_json::from_value(arguments)?;
             json!(db.ffi_surface(args.limit)?)

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -233,6 +233,11 @@ pub struct ImportantSymbolsArgs {
     /// Max load-bearing symbols to return.
     #[serde(default = "default_repo_brief_limit")]
     pub limit: u32,
+    /// Symbol ids to bias importance toward (the symbols you're editing/querying) — the random
+    /// surfer teleports back to these, lifting the spine *they* depend on. Empty = global
+    /// importance.
+    #[serde(default)]
+    pub personalize: Vec<i64>,
 }
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
@@ -731,7 +736,8 @@ pub fn description(name: &str) -> &'static str {
         "important_symbols" =>
             "Rank the most load-bearing symbols by weighted PageRank over the call/type/import \
              edge graph — what the rest of the code most depends on. Run before editing to see the \
-             spine you shouldn't reinvent or break.",
+             spine you shouldn't reinvent or break. Pass `personalize` (symbol ids you're working \
+             on) to bias the ranking toward the spine those symbols depend on.",
         "ffi_surface" =>
             "Find the FFI surface: #[uniffi::export] items, exported impl members, and generated \
              binding artifacts (detected by path). Empty in repos without FFI.",

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -133,6 +133,7 @@ pub const TOOL_NAMES: &[&str] = &[
     "impact_surface",
     "repo_brief",
     "repo_clusters",
+    "important_symbols",
     "ffi_surface",
     "docs_for_symbol",
     "read_chunk",
@@ -225,6 +226,13 @@ pub struct RepoClustersArgs {
     pub include_memories: bool,
     #[serde(default = "default_min_cluster_size")]
     pub min_cluster_size: u32,
+}
+
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
+pub struct ImportantSymbolsArgs {
+    /// Max load-bearing symbols to return.
+    #[serde(default = "default_repo_brief_limit")]
+    pub limit: u32,
 }
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
@@ -720,6 +728,10 @@ pub fn description(name: &str) -> &'static str {
         "repo_clusters" =>
             "Map the repo into ownership clusters from path proximity, graph edges, and git \
              co-touch — a cheap overview of subsystems and their representative files.",
+        "important_symbols" =>
+            "Rank the most load-bearing symbols by weighted PageRank over the call/type/import \
+             edge graph — what the rest of the code most depends on. Run before editing to see the \
+             spine you shouldn't reinvent or break.",
         "ffi_surface" =>
             "Find the FFI surface: #[uniffi::export] items, exported impl members, and generated \
              binding artifacts (detected by path). Empty in repos without FFI.",
@@ -813,6 +825,7 @@ pub fn schema(name: &str) -> Value {
         "impact_surface" => schema_for::<ImpactArgs>(),
         "repo_brief" => schema_for::<RepoBriefArgs>(),
         "repo_clusters" => schema_for::<RepoClustersArgs>(),
+        "important_symbols" => schema_for::<ImportantSymbolsArgs>(),
         "ffi_surface" => schema_for::<LimitArgs>(),
         "read_chunk" => schema_for::<ReadChunkArgs>(),
         "git_history_for_path" | "github_refs_for_path" => schema_for::<PathHistoryArgs>(),


### PR DESCRIPTION
Ranks load-bearing symbols by **weighted PageRank** over the active checkout's resolved symbol→symbol edge graph — "which symbols is everything depending on?".

## What

An edge `from_symbol → to_symbol` (call, type reference, impl, …) flows importance to the callee, so a symbol many things depend on scores high. Edge kinds are weighted: structural dependencies carry full importance, weaker associations less.

| edge kind | weight |
|---|---|
| `calls_name`, `implements` | 1.0 |
| `references_type`, `constructs` | 0.7 |
| `uses_macro` | 0.5 |
| `imports`, `exports` | 0.3 |
| `contains` | 0.2 |
| (unknown) | 1.0 |

## Design

- **Pure `pagerank(n, out_edges, personalize)` core** — DB-free, unit-tested in isolation. Damping 0.85, dangling-node mass redistributed via teleport each iteration (rank conserved, sums to ~1). Optional personalization vector biases the random surfer toward seed symbols (the agent's changed/query symbols — the Aider repo-map trick); an all-zero or wrong-length vector degrades to uniform teleport (no panic).
- **`important_symbols(conn, ImportanceOptions)`** builds the adjacency from `edges_data` joined to the per-connection `files` scope view (active checkout only, both endpoints resolved) and hydrates the top-N winners with symbol metadata. Empty graph → empty result (not an error).

## Surface

Three ways, all sharing the core:
- CLI: `rag-rat important-symbols --limit N`
- MCP: `important_symbols` tool (advertised + routable, guarded by `mcp_stdio_every_advertised_tool_is_routable`)
- `IndexDatabase::important_symbols(limit, personalize_to)`

## Tests

8 unit tests in `pagerank.rs` (hub ranking, weight ordering, dangling-mass conservation, personalization bias, empty/invalid-input fallbacks, edge-weight ordering, end-to-end `important_symbols` over an in-memory schema). MCP routability passes. Live run on this repo surfaces `Language`, `GitHubContext`, `IndexConnection` as the top load-bearing types.

Closes #108