### PR TITLE
feat: confidence-aware + SCIP-aware symbol importance ranking (#108)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,14 @@ language = "markdown"
 directories = ["."]
 include = ["**/*.md"]
 exclude = [".git/**", ".rag-rat/**", "target/**", "node_modules/**"]
+
+# Optional: background refresh of compiler-grade (SCIP) importance ranking. Off by default.
+# Needs a language tool on PATH (e.g. rust-analyzer); the throttled pass runs only in the MCP
+# server. `rag-rat init` asks whether to enable this.
+[oracle]
+auto_run = false
+# auto_run_quiet_period_secs = 900    # wait this long after the last index change before a run
+# auto_run_min_interval_secs = 21600  # never re-run more often than this
 ```
 
 Then run the pieces directly:
@@ -602,6 +610,10 @@ name = "android-kotlin"
 language = "kotlin"
 directories = ["android/src/main/java"]
 include = ["**/*.kt"]
+
+# Opt-in background compiler-grade ranking refresh (off by default; needs e.g. rust-analyzer).
+[oracle]
+auto_run = false
 ```
 
 ## Git Hooks

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -54,6 +54,9 @@ pub(crate) enum Command {
     /// Ownership / co-change clusters.
     Clusters(ClustersArgs),
 
+    /// Rank the most load-bearing symbols by weighted PageRank over the edge graph.
+    ImportantSymbols(ImportantSymbolsArgs),
+
     /// Run the stdio MCP server.
     Mcp,
 
@@ -145,6 +148,13 @@ pub(crate) struct BriefArgs {
     /// Omit drive-by repo memories.
     #[arg(long)]
     pub no_memories: bool,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ImportantSymbolsArgs {
+    /// Max load-bearing symbols to return.
+    #[arg(long)]
+    pub limit: Option<u32>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -155,6 +155,10 @@ pub(crate) struct ImportantSymbolsArgs {
     /// Max load-bearing symbols to return.
     #[arg(long)]
     pub limit: Option<u32>,
+    /// Symbol ids to bias importance toward (the symbols you're working on) — comma-separated or
+    /// repeated. Empty = global importance.
+    #[arg(long, value_delimiter = ',')]
+    pub personalize: Vec<i64>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -155,10 +155,13 @@ pub(crate) struct ImportantSymbolsArgs {
     /// Max load-bearing symbols to return.
     #[arg(long)]
     pub limit: Option<u32>,
-    /// Symbol ids to bias importance toward (the symbols you're working on) — comma-separated or
-    /// repeated. Empty = global importance.
+    /// Symbols to bias importance toward (the symbols you're working on) — names, symbol paths, or
+    /// numeric ids, comma-separated or repeated. A numeric value is a raw symbol id; otherwise
+    /// it's resolved by symbol path then name (ambiguous/missing entries are skipped). Empty =
+    /// global importance (the CLI is global-by-default — it never auto-seeds from the git
+    /// diff).
     #[arg(long, value_delimiter = ',')]
-    pub personalize: Vec<i64>,
+    pub personalize: Vec<String>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -93,7 +93,13 @@ pub(crate) fn important_symbols(
     args: &ImportantSymbolsArgs,
 ) -> anyhow::Result<()> {
     let db = open_index(config)?;
-    print_output(&db.important_symbols(args.limit.unwrap_or(20) as usize, &args.personalize)?)
+    // CLI stays global-by-default: no auto-seed from the git diff (`auto_seed_from_diff: false`).
+    // Only an explicit `--personalize` seeds — the intentional divergence from the MCP default.
+    print_output(&db.important_symbols(rag_rat_core::index::ImportantSymbolsRequest {
+        limit: args.limit.unwrap_or(20) as usize,
+        personalize: args.personalize.clone(),
+        auto_seed_from_diff: false,
+    })?)
 }
 pub(crate) fn dump_config(config: &Config) -> anyhow::Result<()> {
     let targets = config

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -93,7 +93,7 @@ pub(crate) fn important_symbols(
     args: &ImportantSymbolsArgs,
 ) -> anyhow::Result<()> {
     let db = open_index(config)?;
-    print_output(&db.important_symbols(args.limit.unwrap_or(20) as usize, &[])?)
+    print_output(&db.important_symbols(args.limit.unwrap_or(20) as usize, &args.personalize)?)
 }
 pub(crate) fn dump_config(config: &Config) -> anyhow::Result<()> {
     let targets = config

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -4,9 +4,10 @@ use rag_rat_core::OutputFormat;
 
 use super::*;
 use crate::cli::{
-    BriefArgs, ClustersArgs, EvalArgs, GithubArgs, GithubCommand, HookAction, HooksArgs, IndexArgs,
-    MaintenanceArgs, MemoryArgs, MemoryCommand, ModelsArgs, ModelsCommand, OracleArgs,
-    OracleCommand, OracleRunArgs, OracleStatusArgs, QueryArgs, ReconcileArgs,
+    BriefArgs, ClustersArgs, EvalArgs, GithubArgs, GithubCommand, HookAction, HooksArgs,
+    ImportantSymbolsArgs, IndexArgs, MaintenanceArgs, MemoryArgs, MemoryCommand, ModelsArgs,
+    ModelsCommand, OracleArgs, OracleCommand, OracleRunArgs, OracleStatusArgs, QueryArgs,
+    ReconcileArgs,
 };
 
 /// Process-wide output format, set once from the global `--json` flag in `main` before any command
@@ -86,6 +87,13 @@ pub(crate) fn clusters(config: &Config, args: &ClustersArgs) -> anyhow::Result<(
         include_memories: !args.no_memories,
         min_cluster_size: args.min_cluster_size.unwrap_or(2),
     })?)
+}
+pub(crate) fn important_symbols(
+    config: &Config,
+    args: &ImportantSymbolsArgs,
+) -> anyhow::Result<()> {
+    let db = open_index(config)?;
+    print_output(&db.important_symbols(args.limit.unwrap_or(20) as usize, &[])?)
 }
 pub(crate) fn dump_config(config: &Config) -> anyhow::Result<()> {
     let targets = config

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -95,11 +95,26 @@ pub(crate) fn important_symbols(
     let db = open_index(config)?;
     // CLI stays global-by-default: no auto-seed from the git diff (`auto_seed_from_diff: false`).
     // Only an explicit `--personalize` seeds — the intentional divergence from the MCP default.
-    print_output(&db.important_symbols(rag_rat_core::index::ImportantSymbolsRequest {
+    let mut result = db.important_symbols(rag_rat_core::index::ImportantSymbolsRequest {
         limit: args.limit.unwrap_or(20) as usize,
         personalize: args.personalize.clone(),
         auto_seed_from_diff: false,
-    })?)
+    })?;
+    apply_auto_run_ranking_hint(&mut result, config);
+    print_output(&result)
+}
+
+/// Swap the heuristic-ranking nudge to the background-oracle wording when `[oracle] auto_run` is on
+/// (the core method, config-unaware, emits the manual `oracle run` variant). No-op when the hint is
+/// absent (a current oracle run exists) or auto_run is off.
+pub(crate) fn apply_auto_run_ranking_hint(
+    result: &mut rag_rat_core::query::pagerank::ImportantSymbolsResult,
+    config: &Config,
+) {
+    if config.oracle.auto_run && result.ranking_hint.is_some() {
+        result.ranking_hint =
+            Some(rag_rat_core::query::pagerank::RANKING_HINT_AUTO_RUN.to_string());
+    }
 }
 pub(crate) fn dump_config(config: &Config) -> anyhow::Result<()> {
     let targets = config
@@ -212,7 +227,7 @@ pub(crate) fn oracle(config: &Config, args: &OracleArgs) -> anyhow::Result<()> {
 /// snapshot is taken at exit, not when rust-analyzer read each file, so a mid-subprocess edit + a
 /// pre-join reindex remains best-effort — pinning the pre-spawn `files.sha256` would close that
 /// residual tail (follow-up).
-fn with_oracle_write_lock<T>(
+pub(crate) fn with_oracle_write_lock<T>(
     config: &Config,
     body: impl FnOnce(&IndexDatabase) -> anyhow::Result<T>,
 ) -> anyhow::Result<T> {
@@ -863,6 +878,7 @@ mod tests {
             local_ai: Default::default(),
             watch: Default::default(),
             version_check: Default::default(),
+            oracle: Default::default(),
         };
         (root, config)
     }

--- a/crates/rag-rat-cli/src/init/mod.rs
+++ b/crates/rag-rat-cli/src/init/mod.rs
@@ -49,6 +49,10 @@ pub(crate) struct InitPlan {
     languages: Vec<Language>,
     bindings: BTreeMap<Language, Vec<PathBuf>>,
     backend: EmbeddingBackend,
+    /// Whether to write `[oracle] auto_run = true` — the opt-in background refresh of
+    /// compiler-grade (SCIP) importance ranking. Default false (matches `OracleConfig`'s
+    /// default).
+    oracle_auto_run: bool,
 }
 
 #[derive(Debug, Default)]
@@ -221,6 +225,7 @@ mod tests {
                 (Language::TypeScript, vec![PathBuf::from("web/src"), PathBuf::from("app/src")]),
             ]),
             backend: EmbeddingBackend::Model2Vec,
+            oracle_auto_run: false,
         };
 
         let text = render_config(&plan);
@@ -231,6 +236,21 @@ mod tests {
         assert!(text.contains("typescript = [\"web/src\", \"app/src\"]"));
         assert!(text.contains("[local_ai.embedding]"));
         assert!(text.contains("model = \"model2vec\""));
+        // The oracle section is always rendered so the knob is discoverable; default is OFF.
+        assert!(text.contains("[oracle]"));
+        assert!(text.contains("auto_run = false"));
+    }
+
+    #[test]
+    fn render_config_enables_oracle_auto_run_when_opted_in() {
+        let plan = InitPlan {
+            root_value: ".".to_string(),
+            languages: vec![Language::Rust],
+            bindings: BTreeMap::from([(Language::Rust, vec![PathBuf::from("src")])]),
+            backend: EmbeddingBackend::FastEmbed,
+            oracle_auto_run: true,
+        };
+        assert!(render_config(&plan).contains("auto_run = true"));
     }
 
     #[test]

--- a/crates/rag-rat-cli/src/init/render.rs
+++ b/crates/rag-rat-cli/src/init/render.rs
@@ -18,6 +18,14 @@ pub(crate) fn render_config(plan: &InitPlan) -> String {
         let dirs = plan.bindings.get(language).cloned().unwrap_or_default();
         text.push_str(&format!("{} = [{}]\n", language.as_str(), quoted_paths(&dirs)));
     }
+    text.push('\n');
+    text.push_str("[oracle]\n");
+    text.push_str(
+        "# Background auto-refresh of compiler-grade (SCIP) importance ranking. Needs a \
+         language\n# tool on PATH (e.g. rust-analyzer); runs throttled in the MCP server only. \
+         Default off.\n",
+    );
+    text.push_str(&format!("auto_run = {}\n", plan.oracle_auto_run));
     text
 }
 pub(crate) fn quoted_paths(paths: &[PathBuf]) -> String {

--- a/crates/rag-rat-cli/src/init/run.rs
+++ b/crates/rag-rat-cli/src/init/run.rs
@@ -106,7 +106,27 @@ pub(crate) fn prompt_plan(
     }
 
     let backend = prompt_backend(scan)?;
-    Ok(InitPlan { root_value, languages, bindings, backend })
+    let oracle_auto_run = prompt_oracle_auto_run()?;
+    Ok(InitPlan { root_value, languages, bindings, backend, oracle_auto_run })
+}
+
+/// Offer the opt-in background oracle. Default NO: it needs a language tool (e.g. rust-analyzer) on
+/// PATH and spends CPU on a throttled SCIP pass, so it should be a deliberate choice. Writing
+/// `auto_run = false` either way keeps the knob visible in the generated config.
+pub(crate) fn prompt_oracle_auto_run() -> anyhow::Result<bool> {
+    println!();
+    println!(
+        "Compiler-grade ranking: a background pass can refresh SCIP-based importance ranking as \
+         the"
+    );
+    println!(
+        "repo changes (needs a language tool such as rust-analyzer on PATH; runs only in the MCP"
+    );
+    println!("server, heavily throttled). You can flip `[oracle] auto_run` later.");
+    Ok(Confirm::new()
+        .with_prompt("Enable background compiler-grade ranking refresh?")
+        .default(false)
+        .interact()?)
 }
 pub(crate) fn prompt_backend(scan: &RepoScan) -> anyhow::Result<EmbeddingBackend> {
     let estimate = estimated_chunks(scan.total_source_bytes);
@@ -154,7 +174,8 @@ pub(crate) fn default_plan(root_value: String, scan: &RepoScan) -> InitPlan {
         })
         .collect();
     let backend = recommend_backend(estimated_chunks(scan.total_source_bytes));
-    InitPlan { root_value, languages, bindings, backend }
+    // Non-interactive default mirrors `OracleConfig`'s default: off until explicitly enabled.
+    InitPlan { root_value, languages, bindings, backend, oracle_auto_run: false }
 }
 pub(crate) fn setup_index(config: &Config) -> anyhow::Result<IndexDatabase> {
     eprintln!("init: migrating SQLite schema");

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -55,6 +55,7 @@ fn main() -> anyhow::Result<()> {
         Cmd::Query(args) => query(&config, &args)?,
         Cmd::Brief(args) => brief(&config, &args)?,
         Cmd::Clusters(args) => clusters(&config, &args)?,
+        Cmd::ImportantSymbols(args) => important_symbols(&config, &args)?,
         Cmd::Mcp => {
             // Refresh the crates.io version cache out of band (a detached thread on this long-lived
             // server) when stale + opted-in, so `index_status` and the next SessionStart digest

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -62,6 +62,11 @@ fn main() -> anyhow::Result<()> {
             // read a fresh result without ever blocking startup or a request. Fail-open
             // (#version-check).
             spawn_detached_version_refresh(&config);
+            // Keep SCIP-grade ranking self-maintaining: a heavily-throttled detached thread runs
+            // the oracle when the active checkout's index is stale AND quiet (opt-in
+            // via `[oracle] auto_run`, default OFF). Mirrors the version-refresh thread
+            // — fail-open, dies with the process. No-op unless enabled.
+            spawn_detached_oracle_auto_run(&config);
             // The MCP server is an stdio JSON-RPC loop (one client, mostly serial) plus a SIGUSR1
             // task; the file watcher runs on its own OS thread and CPU-heavy indexing is rayon, not
             // tokio. The default runtime's ~num_cpus workers are therefore idle overhead, so cap it
@@ -130,6 +135,133 @@ fn spawn_detached_version_refresh(config: &rag_rat_core::Config) {
             std::thread::sleep(POLL);
         }
     });
+}
+
+/// Background thread that keeps SCIP-grade ranking fresh for the long-lived MCP server without a
+/// manual `oracle run`: poll on a sub-quiet-period cadence and, when the active checkout's index is
+/// stale AND has been quiet long enough AND the min-interval floor has elapsed, run the oracle for
+/// each known tool. Opt-in (`[oracle] auto_run`, default OFF) — returns immediately when disabled,
+/// so short-lived CLI/hook commands (which never reach `Cmd::Mcp`) never spawn it.
+///
+/// Mirrors [`spawn_detached_version_refresh`]: detached, best-effort, fail-open (`let _ = …`), dies
+/// with the process (a hot-upgrade re-exec re-spawns it). Each run uses the SAME lock-free
+/// production path as `oracle run` — `produce_scip_with_tool` OUTSIDE the write lock, only the
+/// pre-spawn snapshot + the join briefly serialized (#82/#83) — so the watcher is never starved
+/// through the minutes-long subprocess, and the #82/#83 TOCTOU gates stay armed. A `Blocked`
+/// outcome (tool not installed) is a no-op: the loop simply sleeps to the next tick rather than
+/// spinning on it.
+fn spawn_detached_oracle_auto_run(config: &rag_rat_core::Config) {
+    use rag_rat_core::index::oracle::{self, AutoRunDecision, AutoRunInputs, OracleTool};
+    if !config.oracle.auto_run {
+        return;
+    }
+    // Poll well under the quiet period so a checkout that goes quiet is picked up within roughly
+    // one quiet window, while the between-tick cost (a cheap meta + `oracle_runs` read, gated
+    // by the pure decision before any subprocess) stays negligible. Floor the cadence so a tiny
+    // configured quiet period can't busy-loop.
+    let quiet_secs = config.oracle.auto_run_quiet_period_secs;
+    let poll = std::time::Duration::from_secs((quiet_secs / 4).max(60));
+    let quiet_period_ms = saturating_secs_to_ms(quiet_secs);
+    let min_interval_ms = saturating_secs_to_ms(config.oracle.auto_run_min_interval_secs);
+    let config = config.clone();
+    std::thread::spawn(move || {
+        loop {
+            // Each tick re-opens the index so a fresh `(commit_sha, worktree_id)` checkout (the
+            // server outlives branch switches) and the latest `indexed_at_ms` are read anew. All
+            // fail-open: any error just waits for the next tick.
+            let _ = maybe_run_oracle_once(&config, quiet_period_ms, min_interval_ms);
+            std::thread::sleep(poll);
+        }
+    });
+
+    /// One throttled pass: read the staleness inputs for each tool, ask the pure gate, and on `Run`
+    /// take the lock-free production path. Returns `Ok(())` even when nothing ran — the caller only
+    /// uses it to swallow errors fail-open.
+    fn maybe_run_oracle_once(
+        config: &rag_rat_core::Config,
+        quiet_period_ms: i64,
+        min_interval_ms: i64,
+    ) -> anyhow::Result<()> {
+        let now_ms = now_epoch_ms();
+        // `indexed_at_ms` is the active checkout's last index-change clock; without it we can't
+        // judge staleness, so skip this tick.
+        let last_index_change_ms = {
+            let db = open_index(config)?;
+            match db.status(&config.database)?.indexed_at_ms {
+                Some(ms) => ms,
+                None => return Ok(()),
+            }
+        };
+        for &tool in OracleTool::ALL {
+            // Cheap probe before any decision: an uninstalled tool can never run, so don't even
+            // read its run history.
+            if matches!(oracle::probe_oracle_tool(tool), oracle::ToolAvailability::Blocked { .. }) {
+                continue;
+            }
+            let last_run_ms = {
+                let db = open_index(config)?;
+                db.latest_oracle_run_started_at(tool)?
+            };
+            let decision = oracle::auto_run_decision(AutoRunInputs {
+                enabled: true,
+                now_ms,
+                last_index_change_ms,
+                last_run_ms,
+                quiet_period_ms,
+                min_interval_ms,
+            });
+            if decision == AutoRunDecision::Run {
+                let _ = run_oracle_tool_background(config, tool);
+            }
+        }
+        Ok(())
+    }
+
+    /// The lock-free `oracle run` body for one tool, sans CLI output. Mirrors
+    /// `commands::oracle_run`: snapshot the pre-spawn shas under the write lock, produce the
+    /// `.scip` OUTSIDE the lock, then run only the join/write under the lock. A `Blocked`
+    /// production is a no-op (returns `Ok`).
+    fn run_oracle_tool_background(
+        config: &rag_rat_core::Config,
+        tool: OracleTool,
+    ) -> anyhow::Result<()> {
+        let pre_spawn_sha = with_oracle_write_lock(config, |db| db.oracle_pre_spawn_snapshot())?;
+        let scip_output = config
+            .database
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(std::env::temp_dir)
+            .join(format!("rag-rat-oracle-auto-{}.scip", std::process::id()));
+        let production = oracle::produce_scip_with_tool(tool, &config.root, &scip_output);
+        let _ = fs::remove_file(&scip_output);
+        match production? {
+            oracle::ScipProduction::Blocked { .. } => Ok(()),
+            oracle::ScipProduction::Produced { version, bytes, production_sha } => {
+                with_oracle_write_lock(config, |db| {
+                    db.run_oracle(
+                        tool,
+                        &version,
+                        &bytes,
+                        Some(&production_sha),
+                        Some(&pre_spawn_sha),
+                    )
+                })?;
+                Ok(())
+            },
+        }
+    }
+
+    /// Saturating seconds → ms for the throttle inputs (a wild config value can't overflow `i64`).
+    fn saturating_secs_to_ms(secs: u64) -> i64 {
+        i64::try_from(secs).unwrap_or(i64::MAX).saturating_mul(1000)
+    }
+}
+
+fn now_epoch_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
 }
 
 /// Load the config, mapping a missing file to a friendly hint instead of a raw IO error.

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -166,11 +166,17 @@ fn spawn_detached_oracle_auto_run(config: &rag_rat_core::Config) {
     let config = config.clone();
     std::thread::spawn(move || {
         loop {
+            // Sleep BEFORE the first decision. This thread is spawned just before `run_stdio`
+            // starts the file watcher, so an immediate first tick could run the oracle against the
+            // pre-watcher index — missing any unindexed working-tree changes, recording them as
+            // skipped/drifted documents, and then letting the min-interval gate block a corrected
+            // run for hours. One poll interval lets the watcher's initial maintenance pass index
+            // those changes first. (#142 review)
+            std::thread::sleep(poll);
             // Each tick re-opens the index so a fresh `(commit_sha, worktree_id)` checkout (the
             // server outlives branch switches) and the latest `indexed_at_ms` are read anew. All
             // fail-open: any error just waits for the next tick.
             let _ = maybe_run_oracle_once(&config, quiet_period_ms, min_interval_ms);
-            std::thread::sleep(poll);
         }
     });
 

--- a/crates/rag-rat-core/benches/shared/mod.rs
+++ b/crates/rag-rat-core/benches/shared/mod.rs
@@ -66,6 +66,7 @@ pub fn bench_config(subdir: &str) -> Config {
         local_ai: Default::default(),
         watch: Default::default(),
         version_check: Default::default(),
+        oracle: Default::default(),
     }
 }
 

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -16,6 +16,35 @@ pub struct Config {
     pub local_ai: LocalAiConfig,
     pub watch: WatchConfig,
     pub version_check: VersionCheckConfig,
+    pub oracle: OracleConfig,
+}
+
+/// Background auto-fresh oracle (`[oracle]`). Opt-in; default OFF. When `auto_run` is enabled, the
+/// long-lived `rag-rat mcp` server runs the SCIP oracle for the active checkout when the index is
+/// stale and quiet, heavily throttled by two gates (a long quiet-period debounce + a
+/// minimum-interval floor) — see [`crate::index::oracle::auto_run_decision`]. SCIP production takes
+/// minutes while edits arrive in seconds, so edge-collapsing alone would thrash; both gates are
+/// required. Fail-open and detached: it never blocks a request and dies with the server process.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OracleConfig {
+    /// Run the oracle in the background on the MCP server (default false — opt in explicitly).
+    pub auto_run: bool,
+    /// Run only after the index has been quiet (no change) for at least this long. The debounce
+    /// that keeps an active editing session from triggering a minutes-long SCIP pass on every
+    /// save.
+    pub auto_run_quiet_period_secs: u64,
+    /// And at most once this often, regardless of churn. The minimum-interval floor.
+    pub auto_run_min_interval_secs: u64,
+}
+
+impl Default for OracleConfig {
+    fn default() -> Self {
+        Self {
+            auto_run: false,
+            auto_run_quiet_period_secs: 900,
+            auto_run_min_interval_secs: 21_600,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -220,8 +249,9 @@ impl Config {
         let local_ai = LocalAiConfig::try_from(raw.local_ai)?;
         let watch = raw.watch.into();
         let version_check = raw.version_check.into();
+        let oracle = raw.oracle.into();
 
-        Ok(Self { root, database, targets, local_ai, watch, version_check })
+        Ok(Self { root, database, targets, local_ai, watch, version_check, oracle })
     }
 }
 
@@ -347,6 +377,8 @@ struct RawConfig {
     #[serde(default)]
     version_check: RawVersionCheck,
     #[serde(default)]
+    oracle: RawOracle,
+    #[serde(default)]
     target_bindings: BTreeMap<String, Vec<String>>,
     #[serde(default, rename = "target")]
     target: Vec<RawTarget>,
@@ -380,6 +412,28 @@ struct RawVersionCheck {
 impl From<RawVersionCheck> for VersionCheckConfig {
     fn from(raw: RawVersionCheck) -> Self {
         Self { enabled: raw.enabled.unwrap_or(VersionCheckConfig::default().enabled) }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawOracle {
+    auto_run: Option<bool>,
+    auto_run_quiet_period_secs: Option<u64>,
+    auto_run_min_interval_secs: Option<u64>,
+}
+
+impl From<RawOracle> for OracleConfig {
+    fn from(raw: RawOracle) -> Self {
+        let default = OracleConfig::default();
+        Self {
+            auto_run: raw.auto_run.unwrap_or(default.auto_run),
+            auto_run_quiet_period_secs: raw
+                .auto_run_quiet_period_secs
+                .unwrap_or(default.auto_run_quiet_period_secs),
+            auto_run_min_interval_secs: raw
+                .auto_run_min_interval_secs
+                .unwrap_or(default.auto_run_min_interval_secs),
+        }
     }
 }
 
@@ -646,6 +700,33 @@ mod tests {
             toml::from_str("[index]\nroot = \".\"\n\n[version_check]\nenabled = false\n").unwrap();
         let version_check: VersionCheckConfig = raw.version_check.into();
         assert!(!version_check.enabled, "[version_check] enabled = false opts out");
+    }
+
+    #[test]
+    fn oracle_defaults_off_and_parses_overrides() {
+        let default: OracleConfig = RawOracle::default().into();
+        assert!(!default.auto_run, "background oracle is OFF by default");
+        assert_eq!(default.auto_run_quiet_period_secs, 900);
+        assert_eq!(default.auto_run_min_interval_secs, 21_600);
+
+        let raw: RawConfig = toml::from_str(
+            r#"
+            [index]
+            root = "."
+
+            [oracle]
+            auto_run = true
+            auto_run_quiet_period_secs = 60
+            auto_run_min_interval_secs = 3600
+            "#,
+        )
+        .unwrap();
+        let oracle: OracleConfig = raw.oracle.into();
+        assert_eq!(oracle, OracleConfig {
+            auto_run: true,
+            auto_run_quiet_period_secs: 60,
+            auto_run_min_interval_secs: 3600,
+        });
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -18,6 +18,7 @@ mod query_api;
 mod rebuild;
 
 pub(crate) use lifecycle::install_scope_view;
+pub use query_api::ImportantSymbolsRequest;
 
 #[cfg(test)]
 mod anchor_tests;
@@ -426,7 +427,7 @@ fn is_likely_parser_gap_kind(kind: &str) -> bool {
     matches!(kind, "parser_call_extraction" | "parser_failure")
 }
 
-fn is_generated_path(path: &str) -> bool {
+pub(crate) fn is_generated_path(path: &str) -> bool {
     path.contains("/generated/")
         || path.contains("/generated-web/")
         || path.ends_with(".d.ts")
@@ -615,9 +616,9 @@ struct DiscoveryPlan {
 }
 
 #[derive(Debug, Default)]
-struct GitChangedPaths {
-    changed: BTreeSet<PathBuf>,
-    deleted: BTreeSet<PathBuf>,
+pub(crate) struct GitChangedPaths {
+    pub(crate) changed: BTreeSet<PathBuf>,
+    pub(crate) deleted: BTreeSet<PathBuf>,
 }
 
 fn collect_index_files(config: &Config) -> anyhow::Result<Vec<IndexFile>> {
@@ -1008,7 +1009,7 @@ pub(crate) fn target_for_path(
     })
 }
 
-fn git_changed_paths(root: &Path) -> anyhow::Result<GitChangedPaths> {
+pub(crate) fn git_changed_paths(root: &Path) -> anyhow::Result<GitChangedPaths> {
     let repo = gix::discover(root)?;
     let worktree_root = repo
         .workdir()
@@ -1145,6 +1146,12 @@ fn hex_sha256(bytes: &[u8]) -> String {
 
 fn path_string(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
+}
+
+/// `path_string` for the read path: the importance auto-seed normalizes a `git_changed_paths` entry
+/// to the same `/`-separated form the `files` table stores, so the scoped-view lookup matches.
+pub(crate) fn path_string_for_seed(path: &Path) -> String {
+    path_string(path)
 }
 
 #[cfg(test)]

--- a/crates/rag-rat-core/src/index/oracle/auto_run.rs
+++ b/crates/rag-rat-core/src/index/oracle/auto_run.rs
@@ -1,0 +1,151 @@
+//! The pure throttle gate for the background auto-fresh oracle (Phase 5, opt-in / default OFF).
+//!
+//! SCIP production takes minutes; index edits arrive in seconds. Edge-collapsing a reindex burst is
+//! NOT enough — the server would still kick off a minutes-long pass on the first edit of an active
+//! session. So the decision is a **two-gate throttle**: a long *quiet-period* debounce (run only
+//! after the index has been still for a while) AND a *minimum-interval* floor (run at most once
+//! every few hours). Both gates are evaluated against plain timestamps sourced by the caller — the
+//! index's last change time and the last successful oracle run's start time — so the decision
+//! itself is pure and fully unit-testable without a clock, a database, or rust-analyzer.
+//!
+//! Mirrors the shape of [`crate::version_check::needs_refresh`]: inputs are values, the decision is
+//! a closed enum, the clock lives outside.
+
+/// Plain-value inputs to [`auto_run_decision`] — sourced by the caller (config, index meta, the
+/// latest `oracle_runs` row) so the gate has no I/O of its own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AutoRunInputs {
+    /// `[oracle] auto_run`. When false the gate short-circuits to [`AutoRunDecision::Disabled`].
+    pub enabled: bool,
+    /// Now, Unix-epoch ms (injected).
+    pub now_ms: i64,
+    /// When the active checkout's index last changed, Unix-epoch ms (`indexed_at_ms` meta).
+    pub last_index_change_ms: i64,
+    /// When the most recent successful oracle run for the active checkout STARTED, or `None` when
+    /// no run exists yet (`oracle_runs.started_at`).
+    pub last_run_ms: Option<i64>,
+    /// `[oracle] auto_run_quiet_period_secs`, in ms.
+    pub quiet_period_ms: i64,
+    /// `[oracle] auto_run_min_interval_secs`, in ms.
+    pub min_interval_ms: i64,
+}
+
+/// The throttle verdict. Every non-`Run` arm names the gate that held it back so a caller (or a log
+/// line) can explain why a pass didn't fire. Closed enum — exhaustive matching keeps a future gate
+/// from being silently dropped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoRunDecision {
+    /// `auto_run = false` — the feature is opt-in and was not enabled.
+    Disabled,
+    /// The index has NOT changed since the last successful run — fresh verdicts already cover it.
+    NotStale,
+    /// The index changed too recently — still inside the quiet-period debounce (active editing).
+    NotQuiet,
+    /// A run started too recently — inside the minimum-interval floor.
+    TooSoon,
+    /// All gates clear: the index is stale, has been quiet long enough, and the floor has elapsed.
+    Run,
+}
+
+/// The two-gate throttle, pure. Order matters: a disabled feature never inspects timestamps; a
+/// not-stale index never schedules; the quiet-period debounce precedes the min-interval floor.
+///
+/// - `enabled == false` → [`AutoRunDecision::Disabled`].
+/// - index NOT stale (no change since the last successful run) → [`AutoRunDecision::NotStale`].
+/// - last index change within `quiet_period_ms` → [`AutoRunDecision::NotQuiet`] (still editing).
+/// - last run within `min_interval_ms` → [`AutoRunDecision::TooSoon`].
+/// - else → [`AutoRunDecision::Run`].
+///
+/// "Stale" means the index changed AFTER the last successful run started (or no run has ever
+/// happened). `saturating_sub` keeps a clock that went backwards from underflowing into a spurious
+/// `Run`.
+pub fn auto_run_decision(p: AutoRunInputs) -> AutoRunDecision {
+    if !p.enabled {
+        return AutoRunDecision::Disabled;
+    }
+    // Stale = the index moved since the last run began. No prior run ⇒ always stale.
+    let stale = match p.last_run_ms {
+        Some(last_run_ms) => p.last_index_change_ms > last_run_ms,
+        None => true,
+    };
+    if !stale {
+        return AutoRunDecision::NotStale;
+    }
+    // Quiet-period debounce: don't kick off a minutes-long pass while the working tree is churning.
+    if p.now_ms.saturating_sub(p.last_index_change_ms) < p.quiet_period_ms {
+        return AutoRunDecision::NotQuiet;
+    }
+    // Minimum-interval floor: cap how often the pass can run regardless of churn.
+    if let Some(last_run_ms) = p.last_run_ms
+        && p.now_ms.saturating_sub(last_run_ms) < p.min_interval_ms
+    {
+        return AutoRunDecision::TooSoon;
+    }
+    AutoRunDecision::Run
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A baseline that clears every gate (stale + quiet + past the floor), so each test perturbs
+    /// one dimension to isolate the gate it exercises.
+    fn runnable() -> AutoRunInputs {
+        AutoRunInputs {
+            enabled: true,
+            now_ms: 100_000,
+            last_index_change_ms: 50_000, // changed 50s ago
+            last_run_ms: Some(10_000),    // ran 90s ago, before the change
+            quiet_period_ms: 30_000,      // 30s quiet window
+            min_interval_ms: 60_000,      // 60s floor
+        }
+    }
+
+    #[test]
+    fn disabled_short_circuits() {
+        let p = AutoRunInputs { enabled: false, ..runnable() };
+        assert_eq!(auto_run_decision(p), AutoRunDecision::Disabled);
+    }
+
+    #[test]
+    fn not_stale_when_run_is_newer_than_last_change() {
+        // The last run started AFTER the last index change → verdicts already cover the index.
+        let p = AutoRunInputs { last_run_ms: Some(60_000), ..runnable() };
+        assert_eq!(auto_run_decision(p), AutoRunDecision::NotStale);
+    }
+
+    #[test]
+    fn stale_but_within_quiet_period_is_not_quiet() {
+        // Index changed 5s ago (now 100_000, change 95_000) — inside the 30s quiet window.
+        let p = AutoRunInputs { last_index_change_ms: 95_000, ..runnable() };
+        assert_eq!(auto_run_decision(p), AutoRunDecision::NotQuiet);
+    }
+
+    #[test]
+    fn stale_and_quiet_but_within_min_interval_is_too_soon() {
+        // Index changed 35s ago (65_000) — past the 30s quiet window, so quiet. The last run was
+        // 50s ago (50_000) — before the change (so still stale) but inside the 60s floor → TooSoon.
+        let p =
+            AutoRunInputs { last_index_change_ms: 65_000, last_run_ms: Some(50_000), ..runnable() };
+        assert_eq!(auto_run_decision(p), AutoRunDecision::TooSoon);
+    }
+
+    #[test]
+    fn stale_quiet_and_past_min_interval_runs() {
+        assert_eq!(auto_run_decision(runnable()), AutoRunDecision::Run);
+    }
+
+    #[test]
+    fn no_prior_run_stale_and_quiet_runs() {
+        // First-ever run: stale by definition; the min-interval floor doesn't apply without a prior
+        // run.
+        let p = AutoRunInputs { last_run_ms: None, ..runnable() };
+        assert_eq!(auto_run_decision(p), AutoRunDecision::Run);
+    }
+
+    #[test]
+    fn no_prior_run_but_not_quiet_is_debounced() {
+        let p = AutoRunInputs { last_run_ms: None, last_index_change_ms: 95_000, ..runnable() };
+        assert_eq!(auto_run_decision(p), AutoRunDecision::NotQuiet);
+    }
+}

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -335,6 +335,30 @@ pub(crate) fn current_oracle_verdicts_for_edges(
     )
 }
 
+/// Fetch ALL current, in-scope oracle verdicts for `(tool, tool_version)` in this checkout, keyed
+/// by `edge_id` → `(kind, resolved_symbol_id)`. The whole-graph sibling of
+/// [`current_oracle_verdicts_for_edges`], for symbol-importance ranking which walks every edge (one
+/// scan, not a query per edge). Same scope + currency gate via the store helper.
+pub(crate) fn current_oracle_verdicts_all(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<std::collections::HashMap<i64, (OracleResolutionKind, Option<i64>)>> {
+    store::current_oracle_verdicts_all(conn, tool, tool_version, commit_sha, worktree_id)
+}
+
+/// Whether ANY oracle run exists in the active checkout (across all tools) — the cheap existence
+/// probe that short-circuits the per-tool [`latest_run_tool_version`] calls when nothing ever ran.
+pub(crate) fn any_run_in_scope(
+    conn: &Connection,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<bool> {
+    store::any_run_in_scope(conn, commit_sha, worktree_id)
+}
+
 /// Prune `oracle_runs` rows for dead `(commit_sha, worktree_id)` contexts — the gc companion to the
 /// `edge_oracle` FK cascade. See [`store::prune_oracle_runs_outside_scope`]. Returns rows deleted.
 pub fn prune_oracle_runs_outside_scope(

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -18,6 +18,7 @@
 //! - `status.rs`— status type surfaced like `local_ai_status`.
 //! - `store.rs` — `oracle_runs` / `edge_oracle` read + write helpers.
 
+mod auto_run;
 mod join;
 mod manifest;
 mod run;
@@ -30,6 +31,7 @@ mod tests;
 use std::collections::HashMap;
 use std::path::Path;
 
+pub use auto_run::{AutoRunDecision, AutoRunInputs, auto_run_decision};
 pub(crate) use join::package_of;
 pub use manifest::{ToolAvailability, ToolManifest};
 use run::OracleRunInput;
@@ -379,6 +381,18 @@ pub fn latest_run_tool_version(
     worktree_id: &str,
 ) -> anyhow::Result<Option<String>> {
     store::latest_run_tool_version(conn, tool, commit_sha, worktree_id)
+}
+
+/// The `started_at` (Unix-epoch ms) of the most recent run for `tool` in the active checkout, or
+/// `None` when no run exists — the staleness clock the background auto-fresh oracle compares
+/// against the index's `indexed_at_ms`. See [`auto_run_decision`].
+pub fn latest_run_started_at(
+    conn: &Connection,
+    tool: OracleTool,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<Option<i64>> {
+    store::latest_run_started_at(conn, tool, commit_sha, worktree_id)
 }
 
 /// Load the CURRENT, in-scope `edge_oracle` verdicts joined to their heuristic edge resolution —

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -398,6 +398,25 @@ pub(crate) fn latest_run_tool_version(
     Ok(version)
 }
 
+/// Whether ANY oracle run exists in the active checkout, across all tools — one query to short out
+/// the per-tool [`latest_run_tool_version`] probes on the dominant "no oracle ever" path (where the
+/// table is empty, so this returns instantly). Scoped to `(commit_sha, worktree_id)`.
+pub(crate) fn any_run_in_scope(
+    conn: &Connection,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<bool> {
+    let exists = conn
+        .query_row(
+            "SELECT 1 FROM oracle_runs WHERE commit_sha = ?1 AND worktree_id = ?2 LIMIT 1",
+            params![commit_sha, worktree_id],
+            |_| Ok(()),
+        )
+        .ok()
+        .is_some();
+    Ok(exists)
+}
+
 /// The single canonical scope predicate every `edge_oracle` metric read joins through: restrict the
 /// counted verdicts to those whose edge belongs to the active `(commit_sha, worktree_id)` checkout,
 /// via `edge_oracle -> edges -> files`. This is the SAME join `edge_join_candidates` /
@@ -613,6 +632,46 @@ pub(crate) fn current_oracle_verdicts_for_edges(
                 tool_version: tool_version.to_string(),
             });
         }
+    }
+    Ok(out)
+}
+
+/// Fetch ALL current, in-scope oracle verdicts for `(tool, tool_version)` in this checkout, keyed
+/// by `edge_id` → `(kind, resolved_symbol_id)`. The single-scan sibling of
+/// [`current_oracle_verdicts_for_edges`] (which filters to a bounded id list): symbol-importance
+/// ranking ([`crate::query::pagerank`]) walks the WHOLE edge graph, so it needs the verdict set in
+/// one pass rather than a query per edge. Routes through the shared [`edge_oracle_scope_join`] +
+/// [`edge_oracle_current_predicate`] so the scope+currency gate can't be re-spelled — the only raw
+/// `FROM edge_oracle` lives here (#81). `resolved_symbol_id` is returned (not just its name)
+/// because the ranker needs the id to retarget an `Upgrade` edge.
+pub(crate) fn current_oracle_verdicts_all(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<std::collections::HashMap<i64, (OracleResolutionKind, Option<i64>)>> {
+    let sql = format!(
+        "SELECT edge_oracle.edge_id, edge_oracle.kind, \
+         edge_oracle.resolved_symbol_id{scope_join}{current}",
+        scope_join = edge_oracle_scope_join(),
+        current = edge_oracle_current_predicate(),
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows =
+        stmt.query_map(params![tool.as_db_str(), tool_version, commit_sha, worktree_id], |row| {
+            let edge_id: i64 = row.get(0)?;
+            let kind: String = row.get(1)?;
+            let resolved_symbol_id: Option<i64> = row.get(2)?;
+            Ok((edge_id, kind, resolved_symbol_id))
+        })?;
+    let mut out = std::collections::HashMap::new();
+    for row in rows {
+        let (edge_id, kind, resolved_symbol_id) = row?;
+        let Some(kind) = OracleResolutionKind::from_db_str(&kind) else {
+            continue;
+        };
+        out.insert(edge_id, (kind, resolved_symbol_id));
     }
     Ok(out)
 }

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -398,6 +398,32 @@ pub(crate) fn latest_run_tool_version(
     Ok(version)
 }
 
+/// The `started_at` (Unix-epoch ms) of the most recent run for `tool` **in the active checkout**,
+/// or `None` when no run exists. The staleness clock the background auto-fresh oracle compares
+/// against the index's `indexed_at_ms` (see [`crate::index::oracle::auto_run_decision`]): a run
+/// that started after the last index change means the verdicts are current. Scoped to `(commit_sha,
+/// worktree_id)` — the sibling of [`latest_run_tool_version`], ordered the same way.
+pub(crate) fn latest_run_started_at(
+    conn: &Connection,
+    tool: OracleTool,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<Option<i64>> {
+    let started_at = conn
+        .query_row(
+            "
+            SELECT started_at FROM oracle_runs
+            WHERE tool = ?1 AND commit_sha = ?2 AND worktree_id = ?3
+            ORDER BY started_at DESC, id DESC
+            LIMIT 1
+            ",
+            params![tool.as_db_str(), commit_sha, worktree_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .ok();
+    Ok(started_at)
+}
+
 /// Whether ANY oracle run exists in the active checkout, across all tools — one query to short out
 /// the per-tool [`latest_run_tool_version`] probes on the dominant "no oracle ever" path (where the
 /// table is empty, so this returns instantly). Scoped to `(commit_sha, worktree_id)`.

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -2632,6 +2632,28 @@ fn drifted_file_verdict_is_not_surfaced() {
     assert!(verdicts.is_empty(), "a drifted file's verdict must not surface as Compiler");
 }
 
+/// The whole-graph scan ([`store::current_oracle_verdicts_all`], used by symbol-importance ranking)
+/// returns the same current+in-scope verdicts as the per-edge read — `(kind, resolved_symbol_id)`
+/// keyed by edge id — and applies the same currency gate (a drifted callsite drops out).
+#[test]
+fn current_oracle_verdicts_all_returns_scoped_current() {
+    let (h, edge, _sha, resolved) =
+        seed_verdict_full(OracleResolutionKind::Upgrade, "scip x `target`().", true);
+    let all = store::current_oracle_verdicts_all(&h.conn, TOOL, VERSION, COMMIT, WORKTREE).unwrap();
+    assert_eq!(
+        all.get(&edge),
+        Some(&(OracleResolutionKind::Upgrade, resolved)),
+        "the whole-graph scan returns the current verdict with its resolved symbol id"
+    );
+
+    // Drift the callsite file: the currency gate must drop the verdict from the whole-graph scan
+    // too, exactly as it does for the per-edge read.
+    h.conn.execute("UPDATE files SET sha256 = 'drifted-sha' WHERE path = 'a.rs'", []).unwrap();
+    let after =
+        store::current_oracle_verdicts_all(&h.conn, TOOL, VERSION, COMMIT, WORKTREE).unwrap();
+    assert!(after.is_empty(), "a drifted file's verdict must not surface in the whole-graph scan");
+}
+
 /// Def-drift revert (#82 finding 3): an in-corpus verdict keeps its callsite file unchanged (so the
 /// `file_sha` gate still matches), but its resolved DEFINITION symbol is deleted/reinserted by
 /// incremental reindexing — the old `resolved_symbol_id` dangles. The surfacing read must drop the

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -1671,15 +1671,87 @@ impl IndexDatabase {
     /// Top load-bearing symbols by weighted PageRank over the active checkout's edge graph (#108).
     /// `personalize_to` biases importance toward those symbol ids (changed/query symbols); empty =
     /// global.
+    ///
+    /// When a SCIP oracle run exists for this checkout, ranking uses the compiler-verified graph
+    /// (contradicted edges dropped, upgrades retargeted, confirmed/upgraded edges weighted above
+    /// heuristic) — otherwise the heuristic graph with confidence weighting. The oracle lookup is
+    /// gated on a run existing, so absent oracle data it costs nothing (no scan).
     pub fn important_symbols(
         &self,
         limit: usize,
         personalize_to: &[i64],
     ) -> anyhow::Result<Vec<crate::query::pagerank::SymbolImportance>> {
+        let oracle_effects = self.symbol_importance_oracle_effects()?;
         crate::query::pagerank::important_symbols(
             self.storage.connection(),
-            crate::query::pagerank::ImportanceOptions { limit, personalize_to },
+            crate::query::pagerank::ImportanceOptions {
+                limit,
+                personalize_to,
+                oracle_effects: oracle_effects.as_ref(),
+            },
         )
+    }
+
+    /// Build the `edge_id -> EdgeOracleEffect` map that makes [`Self::important_symbols`]
+    /// SCIP-aware, merging current+in-scope verdicts across every oracle tool that has a run in
+    /// this checkout. Returns `None` when no run exists — the common case, where ranking pays zero
+    /// oracle cost (one existence probe short-circuits the per-tool version lookups + the
+    /// whole-graph verdict scan). Maps `OracleResolutionKind` to a ranking effect here so
+    /// `query::pagerank` stays free of oracle types:
+    /// - the compiler resolved an in-corpus target (`Upgrade` or `Contradict` with a resolved
+    ///   symbol) → **retarget** the edge there (the compiler's answer, whether it upgrades an
+    ///   unconfirmed edge or overrides a wrong heuristic one);
+    /// - `Confirm` → verify the heuristic target in place;
+    /// - `ResolvedExternal`, or a `Contradict` with no in-corpus target → **drop** the phantom edge
+    ///   (the real callee is out of corpus);
+    /// - an `Upgrade` with no resolved target → leave the edge heuristic (unconfirmed, not refuted
+    ///   — #82 finding 2).
+    fn symbol_importance_oracle_effects(
+        &self,
+    ) -> anyhow::Result<
+        Option<std::collections::HashMap<i64, crate::query::pagerank::EdgeOracleEffect>>,
+    > {
+        use crate::index::oracle::OracleResolutionKind as Kind;
+        use crate::query::pagerank::EdgeOracleEffect;
+        // CPU gate: one scoped existence query, so the dominant "no oracle ever" path skips the
+        // per-tool version lookups and the whole-graph verdict scan entirely.
+        if !oracle::any_run_in_scope(
+            self.storage.connection(),
+            &self.active_commit_sha,
+            &self.active_worktree_id,
+        )? {
+            return Ok(None);
+        }
+        let mut effects: Option<std::collections::HashMap<i64, EdgeOracleEffect>> = None;
+        for &tool in oracle::OracleTool::ALL {
+            let Some(version) = self.latest_oracle_run_version(tool)? else {
+                continue;
+            };
+            let verdicts = oracle::current_oracle_verdicts_all(
+                self.storage.connection(),
+                tool,
+                &version,
+                &self.active_commit_sha,
+                &self.active_worktree_id,
+            )?;
+            let map = effects.get_or_insert_with(std::collections::HashMap::new);
+            for (edge_id, (kind, resolved_symbol_id)) in verdicts {
+                let effect = match (kind, resolved_symbol_id) {
+                    // Out-of-corpus callee: the in-repo target is a phantom either way.
+                    (Kind::ResolvedExternal, _) | (Kind::Contradict, None) =>
+                        EdgeOracleEffect::Drop,
+                    (Kind::Confirm, _) => EdgeOracleEffect::Confirm,
+                    // Compiler resolved an in-corpus target — trust it over the heuristic.
+                    (Kind::Upgrade | Kind::Contradict, Some(id)) => EdgeOracleEffect::Retarget(id),
+                    // Upgrade we can't name a target for: leave the edge heuristic.
+                    (Kind::Upgrade, None) => continue,
+                };
+                // An edge belongs to one file → one language → at most one tool's verdict, so this
+                // never overwrites a different tool's effect for the same edge.
+                map.insert(edge_id, effect);
+            }
+        }
+        Ok(effects)
     }
 
     pub fn memory_create(
@@ -2268,6 +2340,88 @@ mod oracle_surfacing_tests {
         assert_eq!(
             c.resolved_external, None,
             "an in-corpus contradiction must not be labeled resolved-external"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// End-to-end #108 SCIP-aware ranking: an in-corpus Contradict RETARGETS importance to the
+    /// compiler's true callee. The heuristic resolves `caller -> target`; the compiler contradicts
+    /// it, resolving the callee to the in-corpus `other`. Before the run, `target` carries the
+    /// call's rank and `other` none; after, the rank flows to `other` (the compiler's answer),
+    /// not the heuristic guess. Proves the wrapper gates on a run existing, maps in-corpus
+    /// Contradict to a retarget, and applies it through to the ranker.
+    #[test]
+    fn important_symbols_retargets_an_in_corpus_contradiction() {
+        let root = temp_root();
+        fs::write(
+            root.join("src/lib.rs"),
+            "fn caller() { target(); } fn target() {} fn other() {}\n",
+        )
+        .unwrap();
+        let config = rust_config(root.clone());
+        let db = IndexDatabase::rebuild(&config).unwrap();
+        let conn = db.storage.connection();
+
+        let (edge_id, cs, ce, path) = call_edge(&db);
+        let name_of = |id: i64| -> String {
+            conn.query_row("SELECT qualified_name FROM symbols WHERE id = ?1", params![id], |r| {
+                r.get(0)
+            })
+            .unwrap()
+        };
+        let target_sym: i64 = conn
+            .query_row("SELECT id FROM symbols WHERE name = 'target' LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        let target_qn = name_of(target_sym);
+        // Force the heuristic edge to look exactly-resolved to `target`.
+        conn.execute(
+            "UPDATE edges SET confidence = 'Exact', resolution = 'exact', to_symbol_id = ?2 WHERE \
+             id = ?1",
+            params![edge_id, target_sym],
+        )
+        .unwrap();
+
+        let score_of = |out: &[crate::query::pagerank::SymbolImportance], qn: &str| {
+            out.iter().find(|s| s.qualified_name == qn).map_or(0.0, |s| s.score)
+        };
+
+        // The compiler contradicts the heuristic, resolving the callee to the other in-corpus def.
+        let (other_id, other_start, other_end): (i64, i64, i64) = conn
+            .query_row(
+                "SELECT id, start_byte, end_byte FROM symbols WHERE name = 'other' LIMIT 1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        let other_qn = name_of(other_id);
+
+        // Heuristic ranking (no oracle run yet): `target` carries the call's rank, `other` none.
+        let before = db.important_symbols(20, &[]).unwrap();
+        assert!(
+            score_of(&before, &target_qn) > 0.0,
+            "heuristically `target` carries rank: {before:?}"
+        );
+        assert_eq!(
+            score_of(&before, &other_qn),
+            0.0,
+            "`other` is uncalled heuristically: {before:?}"
+        );
+
+        let symbol = "scip-rust crate held-mini `other`().";
+        let scip = scip_with(&path, cs, ce, symbol, Some(&path), Some((other_start, other_end)));
+        db.run_oracle_from_scip(OracleTool::RustAnalyzer, "v-test", &scip).unwrap();
+
+        // SCIP-aware ranking: the edge is retargeted to the compiler's `other` — rank flows there,
+        // and the contradicted heuristic target `target` loses it.
+        let after = db.important_symbols(20, &[]).unwrap();
+        assert!(
+            score_of(&after, &other_qn) > score_of(&after, &target_qn),
+            "rank flows to the compiler's resolved callee, not the heuristic guess: {after:?}"
+        );
+        assert!(
+            score_of(&after, &other_qn) > score_of(&before, &other_qn),
+            "the retargeted callee gains rank it did not have heuristically: {after:?}"
         );
 
         let _ = fs::remove_dir_all(&root);

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -1949,7 +1949,12 @@ impl IndexDatabase {
                 limit: PER_NAME_SEED_CAP,
                 ..by_path
             };
-            let candidates = self.symbol_candidates(&by_name)?.candidates;
+            // Use the UNENRICHED lookup: seed resolution only needs `symbol_id`, and the enriched
+            // `symbol_candidates` would fetch the oracle effect map + run a fan-in query per hit —
+            // a whole-graph oracle scan per seed name, repeated, all discarded here (#142 review).
+            let candidates =
+                crate::query::symbol::lookup_candidates(self.storage.connection(), &by_name)?
+                    .candidates;
             if candidates.is_empty() {
                 unresolved += 1;
             } else {
@@ -2184,8 +2189,10 @@ impl IndexDatabase {
     /// oracle fetch for the whole batch.
     fn enrich_search_hits_with_load_bearing(&self, hits: &mut [SearchHit]) -> anyhow::Result<()> {
         use crate::query::load_bearing::{self, OracleContext};
-        // Nothing to enrich → don't pay the oracle lookup. (#142 review)
-        if hits.is_empty() {
+        // Nothing enrichable → don't pay the (whole-graph) oracle lookup. A result made entirely of
+        // file/doc chunks with no `symbol_path` (common for Markdown/config) would otherwise scan
+        // every oracle verdict and then skip every hit. (#142 review)
+        if hits.iter().all(|hit| hit.symbol_path.is_none()) {
             return Ok(());
         }
         let effects = self.load_bearing_oracle_effects()?;

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -1,7 +1,47 @@
+use rusqlite::OptionalExtension;
+
 use super::*;
 use crate::index::oracle::{
     self, OracleEvalMetrics, OracleReport, OracleStatus, OracleTool, RecallCalls,
 };
+use crate::query::pagerank::{ImportantSymbolsResult, SymbolImportance};
+
+/// Inputs to [`IndexDatabase::important_symbols`]. The seed (`personalize`) takes names, paths, or
+/// numeric ids; `auto_seed_from_diff` is the MCP-only default (seed from the current git diff when
+/// no explicit seed is given) — the CLI passes `false` so it stays global-by-default. The
+/// intentional MCP/CLI divergence is acceptance-invariant #1.
+pub struct ImportantSymbolsRequest {
+    pub limit: usize,
+    pub personalize: Vec<String>,
+    pub auto_seed_from_diff: bool,
+}
+
+/// Explicit seed selectors resolved to in-graph symbol ids, plus the count that resolved to nothing
+/// (ambiguous / missing — skipped, not fatal).
+struct ResolvedSeeds {
+    symbol_ids: Vec<i64>,
+    unresolved: u64,
+}
+
+/// The git-diff auto-seed, mapped through the scoped `files` view, with provenance counts.
+#[derive(Default)]
+struct DiffSeed {
+    symbol_ids: Vec<i64>,
+    changed_paths: u64,
+    indexed_paths: u64,
+    skipped: crate::query::pagerank::SkippedSeeds,
+}
+
+/// What one changed path contributed to the diff seed.
+enum ChangedPathSymbols {
+    /// The path is indexed (non-generated) in the active scope; its symbol ids (possibly empty for
+    /// a config/markdown file or a parser gap).
+    Symbols(Vec<i64>),
+    /// The path is indexed as a generated artifact — deliberately excluded from the seed.
+    Generated,
+    /// The path is not in the active scope's `files` view at all.
+    None,
+}
 
 impl IndexDatabase {
     /// Run a SCIP-oracle pass from a pre-built `.scip` over the current (active commit/worktree)
@@ -1676,20 +1716,243 @@ impl IndexDatabase {
     /// (contradicted edges dropped, upgrades retargeted, confirmed/upgraded edges weighted above
     /// heuristic) — otherwise the heuristic graph with confidence weighting. The oracle lookup is
     /// gated on a run existing, so absent oracle data it costs nothing (no scan).
+    /// Rank load-bearing symbols, returning the labeled [`ImportantSymbolsResult`] (mode + seed
+    /// provenance), per the spec's "three scales". Seed resolution happens HERE, at the query
+    /// boundary, because it needs both the symbol index (name/path → id) and git (the working-set
+    /// diff) — `query::pagerank` stays a pure ranking primitive over raw ids.
+    ///
+    /// Seed precedence:
+    /// - explicit `request.personalize` (names / paths / numeric ids) → `SeedKind::Explicit`;
+    /// - else, if `request.auto_seed_from_diff` (the MCP default), the current git diff →
+    ///   `SeedKind::GitDiff`;
+    /// - else (the CLI default, or an explicit empty/`global` selector) → global, un-seeded.
+    ///
+    /// A seed intent that resolves to NO in-graph symbol (bad names only, or a diff with no indexed
+    /// symbols) does NOT hard-error: it falls through to global ranking but REPORTS the
+    /// fall-through (`mode = global …` + `reason` + the diff counts), so the caller sees WHY it
+    /// was un-seeded.
     pub fn important_symbols(
         &self,
-        limit: usize,
-        personalize_to: &[i64],
-    ) -> anyhow::Result<Vec<crate::query::pagerank::SymbolImportance>> {
+        request: ImportantSymbolsRequest,
+    ) -> anyhow::Result<ImportantSymbolsResult> {
+        use crate::query::pagerank::{ImportanceMode, SeedKind, SeedSource, SkippedSeeds};
+
         let oracle_effects = self.symbol_importance_oracle_effects()?;
-        crate::query::pagerank::important_symbols(
-            self.storage.connection(),
-            crate::query::pagerank::ImportanceOptions {
-                limit,
-                personalize_to,
-                oracle_effects: oracle_effects.as_ref(),
-            },
-        )
+        let rank = |seed: &[i64]| -> anyhow::Result<Vec<SymbolImportance>> {
+            crate::query::pagerank::important_symbols(
+                self.storage.connection(),
+                crate::query::pagerank::ImportanceOptions {
+                    limit: request.limit,
+                    personalize_to: seed,
+                    oracle_effects: oracle_effects.as_ref(),
+                },
+            )
+        };
+
+        // Explicit names/paths/ids win over the auto-diff default.
+        if !request.personalize.is_empty() {
+            let resolved = self.resolve_seed_selectors(&request.personalize)?;
+            let symbols = rank(&resolved.symbol_ids)?;
+            let seed_source = SeedSource {
+                kind: SeedKind::Explicit,
+                // Explicit seeds are names, not paths — no path population to report.
+                changed_paths: 0,
+                indexed_paths: 0,
+                symbol_seed_count: resolved.symbol_ids.len() as u64,
+                skipped: SkippedSeeds { no_symbols: resolved.unresolved, ..Default::default() },
+            };
+            // Every explicit name missed → no graph seed → global ranking, but say so.
+            if resolved.symbol_ids.is_empty() {
+                return Ok(ImportantSymbolsResult {
+                    mode: ImportanceMode::Global,
+                    seed_source: Some(seed_source),
+                    reason: Some("no named symbols resolved to the active scope".to_string()),
+                    diff_paths_considered: None,
+                    diff_paths_with_symbols: None,
+                    symbols,
+                });
+            }
+            return Ok(ImportantSymbolsResult {
+                mode: ImportanceMode::PersonalizedToChanges,
+                seed_source: Some(seed_source),
+                reason: None,
+                diff_paths_considered: None,
+                diff_paths_with_symbols: None,
+                symbols,
+            });
+        }
+
+        // No explicit seed. CLI stays global-by-default; only the MCP default auto-seeds from diff.
+        if !request.auto_seed_from_diff {
+            return Ok(ImportantSymbolsResult {
+                mode: ImportanceMode::Global,
+                seed_source: None,
+                reason: None,
+                diff_paths_considered: None,
+                diff_paths_with_symbols: None,
+                symbols: rank(&[])?,
+            });
+        }
+
+        let diff = self.diff_seed()?;
+        let symbols = rank(&diff.symbol_ids)?;
+        // The diff had changes but none mapped to an indexed symbol (markdown/config/generated/
+        // deleted-only changes, or parser gaps): fall back to global, but report it with counts.
+        if diff.symbol_ids.is_empty() {
+            return Ok(ImportantSymbolsResult {
+                mode: ImportanceMode::Global,
+                seed_source: Some(SeedSource {
+                    kind: SeedKind::GitDiff,
+                    changed_paths: diff.changed_paths,
+                    indexed_paths: diff.indexed_paths,
+                    symbol_seed_count: 0,
+                    skipped: diff.skipped,
+                }),
+                reason: Some("no symbols found in current diff".to_string()),
+                diff_paths_considered: Some(diff.changed_paths),
+                diff_paths_with_symbols: Some(diff.indexed_paths),
+                symbols,
+            });
+        }
+        Ok(ImportantSymbolsResult {
+            mode: ImportanceMode::PersonalizedToChanges,
+            seed_source: Some(SeedSource {
+                kind: SeedKind::GitDiff,
+                changed_paths: diff.changed_paths,
+                indexed_paths: diff.indexed_paths,
+                symbol_seed_count: diff.symbol_ids.len() as u64,
+                skipped: diff.skipped,
+            }),
+            reason: None,
+            diff_paths_considered: None,
+            diff_paths_with_symbols: None,
+            symbols,
+        })
+    }
+
+    /// Resolve a mixed list of explicit seed selectors (numeric symbol ids, symbol paths, or bare
+    /// names) to in-index symbol ids at the query boundary. A numeric string is a raw symbol id; an
+    /// ambiguous or missing name is SKIPPED (counted in `unresolved`), never fatal — one bad name
+    /// must not sink the whole call. Resolution order per non-numeric entry: `symbol_path` exact,
+    /// then `symbol` (name), mirroring `SymbolSelector` precedence.
+    fn resolve_seed_selectors(&self, selectors: &[String]) -> anyhow::Result<ResolvedSeeds> {
+        use crate::query::symbol::SymbolSelector;
+
+        let mut symbol_ids = Vec::new();
+        let mut unresolved = 0_u64;
+        for raw in selectors {
+            let entry = raw.trim();
+            if entry.is_empty() {
+                continue;
+            }
+            if let Ok(id) = entry.parse::<i64>() {
+                symbol_ids.push(id);
+                continue;
+            }
+            // Try `symbol_path` (exact qualified name) FIRST, then fall back to a bare-name lookup
+            // — `SymbolSelector` short-circuits on the first set field, so the two must be SEPARATE
+            // selectors. `allow_ambiguous: false` makes a multi-candidate name resolve to
+            // `Err(disambiguation)` → we skip it (record the miss); a missing one is `Ok(None)`.
+            let by_path = SymbolSelector {
+                logical_symbol_id: None,
+                symbol_id: None,
+                symbol_path: Some(entry.to_string()),
+                symbol: None,
+                language: None,
+                allow_ambiguous: false,
+                // `limit >= 2` so an ambiguous name surfaces >1 candidate and resolves to
+                // `Err(disambiguation)` (skipped) — a `limit` of 1 would silently pick the first.
+                limit: 8,
+            };
+            let by_name = SymbolSelector {
+                symbol_path: None,
+                symbol: Some(entry.to_string()),
+                ..by_path.clone()
+            };
+            let resolved = match self.select_symbol(&by_path)? {
+                Ok(Some(hit)) => Some(hit),
+                // No exact qualified-name match → try the bare name.
+                Ok(None) | Err(_) => self.select_symbol(&by_name)?.ok().flatten(),
+            };
+            match resolved {
+                Some(hit) => symbol_ids.push(hit.symbol_id),
+                None => unresolved += 1,
+            }
+        }
+        symbol_ids.sort_unstable();
+        symbol_ids.dedup();
+        Ok(ResolvedSeeds { symbol_ids, unresolved })
+    }
+
+    /// Auto-seed from the current git diff (the MCP default). Maps the changed paths through the
+    /// per-connection scoped `files` view to in-scope symbol ids, bucketing the paths that
+    /// contribute no seed (deleted, generated, no-symbols) for provenance.
+    fn diff_seed(&self) -> anyhow::Result<DiffSeed> {
+        let Some(root) = self.storage.source_root() else {
+            // No source root → no working tree to diff (e.g. a bare/copied index). Treat as an
+            // empty diff, not an error: the caller falls through to global with a reason.
+            return Ok(DiffSeed::default());
+        };
+        let changed = crate::index::git_changed_paths(root)?;
+        let changed_paths = (changed.changed.len() + changed.deleted.len()) as u64;
+        let mut seed = DiffSeed { changed_paths, ..Default::default() };
+        // Deleted/renamed-away paths can never carry an in-scope symbol — count and skip them.
+        seed.skipped.deleted = changed.deleted.len() as u64;
+
+        let mut symbol_ids = Vec::new();
+        for path in &changed.changed {
+            let path = crate::index::path_string_for_seed(path);
+            match self.symbol_ids_for_changed_path(&path)? {
+                ChangedPathSymbols::Symbols(ids) if !ids.is_empty() => {
+                    seed.indexed_paths += 1;
+                    symbol_ids.extend(ids);
+                },
+                // Indexed as a generated artifact: real but deliberately excluded from the seed.
+                ChangedPathSymbols::Generated => seed.skipped.generated += 1,
+                // In the working set but contributes no in-scope symbol (config/markdown, parser
+                // gap, or not indexed at all).
+                ChangedPathSymbols::Symbols(_) | ChangedPathSymbols::None =>
+                    seed.skipped.no_symbols += 1,
+            }
+        }
+        symbol_ids.sort_unstable();
+        symbol_ids.dedup();
+        seed.symbol_ids = symbol_ids;
+        Ok(seed)
+    }
+
+    /// Map ONE changed path to its in-scope symbol ids, classifying via the per-connection scoped
+    /// `files` view. SCOPED-VIEW REQUIREMENT (#89): the JOIN goes through `files` (the TEMP VIEW
+    /// installed per connection — overlay rows win, other commits/worktrees excluded), NEVER raw
+    /// `main.symbols`/`main.files`. Querying raw tables here would seed PageRank from symbols
+    /// belonging to a non-active checkout (or shadowed committed rows), corrupting a per-scope
+    /// ranking with cross-scope identity — the exact failure the scope view exists to prevent.
+    fn symbol_ids_for_changed_path(&self, path: &str) -> anyhow::Result<ChangedPathSymbols> {
+        let conn = self.storage.connection();
+        // First: is the path indexed in the active scope at all, and is it generated? `files` is
+        // the scoped view, so a path outside the active checkout returns no row → `None`.
+        let generated: Option<bool> = conn
+            .query_row("SELECT generated FROM files WHERE path = ?1", [path], |row| {
+                row.get::<_, i64>(0).map(|flag| flag != 0)
+            })
+            .optional()?;
+        let Some(generated) = generated else {
+            return Ok(ChangedPathSymbols::None);
+        };
+        if generated {
+            return Ok(ChangedPathSymbols::Generated);
+        }
+        // SCOPED-VIEW REQUIREMENT (#89): join symbols to the `files` scope view, not raw tables, so
+        // only symbols of the ACTIVE version of this file become PageRank seeds.
+        let mut stmt = conn.prepare(
+            "SELECT symbols.id
+             FROM symbols
+             JOIN files ON files.id = symbols.file_id
+             WHERE files.path = ?1",
+        )?;
+        let ids =
+            stmt.query_map([path], |row| row.get::<_, i64>(0))?.collect::<Result<Vec<_>, _>>()?;
+        Ok(ChangedPathSymbols::Symbols(ids))
     }
 
     /// Build the `edge_id -> EdgeOracleEffect` map that makes [`Self::important_symbols`]
@@ -2397,7 +2660,7 @@ mod oracle_surfacing_tests {
         let other_qn = name_of(other_id);
 
         // Heuristic ranking (no oracle run yet): `target` carries the call's rank, `other` none.
-        let before = db.important_symbols(20, &[]).unwrap();
+        let before = global_ranking(&db);
         assert!(
             score_of(&before, &target_qn) > 0.0,
             "heuristically `target` carries rank: {before:?}"
@@ -2414,7 +2677,7 @@ mod oracle_surfacing_tests {
 
         // SCIP-aware ranking: the edge is retargeted to the compiler's `other` — rank flows there,
         // and the contradicted heuristic target `target` loses it.
-        let after = db.important_symbols(20, &[]).unwrap();
+        let after = global_ranking(&db);
         assert!(
             score_of(&after, &other_qn) > score_of(&after, &target_qn),
             "rank flows to the compiler's resolved callee, not the heuristic guess: {after:?}"
@@ -2742,6 +3005,277 @@ mod oracle_surfacing_tests {
             .status()
             .unwrap();
         assert!(status.success(), "git {args:?} failed");
+    }
+
+    /// Global (un-seeded) ranking — the common assertion shape: no explicit seed, no auto-diff.
+    fn global_ranking(db: &IndexDatabase) -> Vec<crate::query::pagerank::SymbolImportance> {
+        db.important_symbols(ImportantSymbolsRequest {
+            limit: 20,
+            personalize: Vec::new(),
+            auto_seed_from_diff: false,
+        })
+        .unwrap()
+        .symbols
+    }
+
+    /// A real committed git checkout where `caller` calls `target`, plus an UNCOMMITTED edit that
+    /// adds `fn touched()` to a second file — so `git_changed_paths` reports a non-empty diff with
+    /// an indexed symbol. Returns the db; `touched.rs` is the changed file.
+    fn checkout_with_dirty_indexed_symbol() -> (IndexDatabase, PathBuf) {
+        let root = temp_root();
+        fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
+        fs::write(root.join("src/touched.rs"), "pub fn placeholder() {}\n").unwrap();
+        git(&root, &["init", "-q"]);
+        git(&root, &["add", "-A"]);
+        git(&root, &["commit", "-q", "-m", "init"]);
+        // Edit a tracked file AFTER commit → an uncommitted working-tree change with a real symbol.
+        fs::write(root.join("src/touched.rs"), "pub fn placeholder() {} pub fn touched() {}\n")
+            .unwrap();
+        let config = rust_config(root.clone());
+        let db = IndexDatabase::rebuild(&config).unwrap();
+        (db, root)
+    }
+
+    /// Name/path/id seed resolution: a valid name resolves to a personalized ranking; a missing
+    /// name is skipped (counted, not fatal); an all-missing seed falls through to global WITH a
+    /// reason.
+    #[test]
+    fn explicit_seed_resolves_names_and_skips_misses() {
+        let root = temp_root();
+        fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
+        let config = rust_config(root.clone());
+        let db = IndexDatabase::rebuild(&config).unwrap();
+
+        // A real name + a bogus one: the bogus is skipped (no_symbols += 1), the real one seeds.
+        let result = db
+            .important_symbols(ImportantSymbolsRequest {
+                limit: 20,
+                personalize: vec!["target".to_string(), "does_not_exist_anywhere".to_string()],
+                auto_seed_from_diff: false,
+            })
+            .unwrap();
+        assert_eq!(result.mode.label(), "importance relative to your current changes");
+        let seed = result.seed_source.expect("explicit seed reports provenance");
+        assert_eq!(seed.kind, crate::query::pagerank::SeedKind::Explicit);
+        assert_eq!(seed.symbol_seed_count, 1, "only the real name seeded");
+        assert_eq!(seed.skipped.no_symbols, 1, "the bogus name is skipped, not fatal");
+        assert!(result.reason.is_none());
+
+        // A raw numeric id is accepted verbatim (the `target` symbol id).
+        let target_id: i64 = db
+            .storage
+            .connection()
+            .query_row("SELECT id FROM symbols WHERE name = 'target' LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        let by_id = db
+            .important_symbols(ImportantSymbolsRequest {
+                limit: 20,
+                personalize: vec![target_id.to_string()],
+                auto_seed_from_diff: false,
+            })
+            .unwrap();
+        assert_eq!(by_id.mode, crate::query::pagerank::ImportanceMode::PersonalizedToChanges);
+
+        // All-missing seed → global fall-through WITH a reason (never silent, never an error).
+        let all_missing = db
+            .important_symbols(ImportantSymbolsRequest {
+                limit: 20,
+                personalize: vec!["nope_a".to_string(), "nope_b".to_string()],
+                auto_seed_from_diff: false,
+            })
+            .unwrap();
+        assert_eq!(all_missing.mode, crate::query::pagerank::ImportanceMode::Global);
+        assert!(all_missing.reason.is_some(), "all-missing explicit seed reports why it's global");
+        assert_eq!(all_missing.seed_source.unwrap().skipped.no_symbols, 2);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// Ambiguous names are skipped (not fatal): two symbols share a name → the seed resolves to
+    /// neither, counts the miss, and falls through to global with a reason.
+    #[test]
+    fn ambiguous_name_seed_is_skipped() {
+        if std::process::Command::new("git").arg("--version").output().is_err() {
+            return;
+        }
+        let root = temp_root();
+        // `dup` defined twice across two files → name `dup` is ambiguous.
+        fs::write(root.join("src/lib.rs"), "pub fn dup() {}\n").unwrap();
+        fs::write(root.join("src/other.rs"), "pub fn dup() {}\n").unwrap();
+        let config = rust_config(root.clone());
+        let db = IndexDatabase::rebuild(&config).unwrap();
+
+        let result = db
+            .important_symbols(ImportantSymbolsRequest {
+                limit: 20,
+                personalize: vec!["dup".to_string()],
+                auto_seed_from_diff: false,
+            })
+            .unwrap();
+        assert_eq!(result.mode, crate::query::pagerank::ImportanceMode::Global);
+        assert_eq!(
+            result.seed_source.expect("reports provenance").skipped.no_symbols,
+            1,
+            "an ambiguous name is skipped, not fatal"
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// Auto-seed maps the git diff to symbols THROUGH the scoped `files` view: a dirty indexed file
+    /// yields a personalized result whose seed provenance is `git_diff`.
+    #[test]
+    fn auto_seed_from_diff_picks_changed_symbols() {
+        if std::process::Command::new("git").arg("--version").output().is_err() {
+            return;
+        }
+        let (db, root) = checkout_with_dirty_indexed_symbol();
+        let result = db
+            .important_symbols(ImportantSymbolsRequest {
+                limit: 20,
+                personalize: Vec::new(),
+                auto_seed_from_diff: true,
+            })
+            .unwrap();
+        assert_eq!(result.mode, crate::query::pagerank::ImportanceMode::PersonalizedToChanges);
+        let seed = result.seed_source.expect("auto-seed reports provenance");
+        assert_eq!(seed.kind, crate::query::pagerank::SeedKind::GitDiff);
+        assert!(seed.indexed_paths >= 1, "the dirty indexed file counted: {seed:?}");
+        assert!(seed.symbol_seed_count >= 1, "the changed file's symbol seeded: {seed:?}");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// Diff with NO indexed symbols (a changed markdown file only) → global mode, a reason, and the
+    /// diff counts, NOT a silent fall-through.
+    #[test]
+    fn diff_without_symbols_falls_back_to_global_with_reason() {
+        if std::process::Command::new("git").arg("--version").output().is_err() {
+            return;
+        }
+        let root = temp_root();
+        fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
+        git(&root, &["init", "-q"]);
+        git(&root, &["add", "-A"]);
+        git(&root, &["commit", "-q", "-m", "init"]);
+        // The only working-tree change is a markdown file — never indexed as a Rust symbol.
+        fs::write(root.join("NOTES.md"), "# notes\n").unwrap();
+        let config = rust_config(root.clone());
+        let db = IndexDatabase::rebuild(&config).unwrap();
+
+        let result = db
+            .important_symbols(ImportantSymbolsRequest {
+                limit: 20,
+                personalize: Vec::new(),
+                auto_seed_from_diff: true,
+            })
+            .unwrap();
+        assert_eq!(result.mode, crate::query::pagerank::ImportanceMode::Global);
+        assert_eq!(result.reason.as_deref(), Some("no symbols found in current diff"));
+        assert_eq!(result.diff_paths_with_symbols, Some(0));
+        let seed = result.seed_source.expect("a fall-through still reports the diff it tried");
+        assert!(seed.changed_paths >= 1, "the markdown change was considered: {seed:?}");
+        assert_eq!(seed.symbol_seed_count, 0);
+        assert!(!result.symbols.is_empty(), "global ranking still returns the spine");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// Deleted and generated changed paths are counted in `skipped`, not seeded.
+    #[test]
+    fn deleted_and_generated_paths_counted_in_skipped() {
+        if std::process::Command::new("git").arg("--version").output().is_err() {
+            return;
+        }
+        let root = temp_root();
+        fs::create_dir_all(root.join("gen")).unwrap();
+        fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
+        fs::write(root.join("src/doomed.rs"), "pub fn doomed() {}\n").unwrap();
+        fs::write(root.join("gen/out.rs"), "pub fn generated_fn() {}\n").unwrap();
+        // A config with a Generated target for `gen/` so `out.rs` indexes generated.
+        let config = Config {
+            root: root.clone(),
+            database: root.join(".rag-rat/index.sqlite"),
+            targets: vec![
+                ResolvedTarget {
+                    name: "rust".to_string(),
+                    language: Language::Rust,
+                    directories: vec![PathBuf::from("src")],
+                    include: vec!["src/".to_string()],
+                    exclude: Vec::new(),
+                    kind: TargetKind::Source,
+                },
+                ResolvedTarget {
+                    name: "gen".to_string(),
+                    language: Language::Rust,
+                    directories: vec![PathBuf::from("gen")],
+                    include: vec!["gen/".to_string()],
+                    exclude: Vec::new(),
+                    kind: TargetKind::Generated,
+                },
+            ],
+            local_ai: Default::default(),
+            watch: Default::default(),
+            version_check: Default::default(),
+        };
+        git(&root, &["init", "-q"]);
+        git(&root, &["add", "-A"]);
+        git(&root, &["commit", "-q", "-m", "init"]);
+        let db = IndexDatabase::rebuild(&config).unwrap();
+
+        // Working-tree changes: delete a tracked file, and edit the generated one.
+        fs::remove_file(root.join("src/doomed.rs")).unwrap();
+        fs::write(root.join("gen/out.rs"), "pub fn generated_fn() {} pub fn more() {}\n").unwrap();
+
+        let result = db
+            .important_symbols(ImportantSymbolsRequest {
+                limit: 20,
+                personalize: Vec::new(),
+                auto_seed_from_diff: true,
+            })
+            .unwrap();
+        let seed = result.seed_source.expect("reports provenance");
+        assert_eq!(seed.skipped.deleted, 1, "the removed file is counted deleted: {seed:?}");
+        assert_eq!(seed.skipped.generated, 1, "the generated file is counted generated: {seed:?}");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// Acceptance invariant #1: with a non-empty diff carrying an indexed symbol, MCP defaults
+    /// (auto-seed ON) ⇒ PERSONALIZED, while CLI defaults (auto-seed OFF) ⇒ GLOBAL. The intentional
+    /// divergence — easy to "clean up" into uniformity by accident, so it's pinned.
+    #[test]
+    fn mcp_auto_seeds_but_cli_stays_global_on_a_nonempty_diff() {
+        if std::process::Command::new("git").arg("--version").output().is_err() {
+            return;
+        }
+        let (db, root) = checkout_with_dirty_indexed_symbol();
+
+        // MCP default: auto_seed_from_diff = true → personalized.
+        let mcp = db
+            .important_symbols(ImportantSymbolsRequest {
+                limit: 20,
+                personalize: Vec::new(),
+                auto_seed_from_diff: true,
+            })
+            .unwrap();
+        assert_eq!(
+            mcp.mode,
+            crate::query::pagerank::ImportanceMode::PersonalizedToChanges,
+            "MCP no-personalize + non-empty diff ⇒ personalized"
+        );
+
+        // CLI default: auto_seed_from_diff = false → global even with the same non-empty diff.
+        let cli = db
+            .important_symbols(ImportantSymbolsRequest {
+                limit: 20,
+                personalize: Vec::new(),
+                auto_seed_from_diff: false,
+            })
+            .unwrap();
+        assert_eq!(
+            cli.mode,
+            crate::query::pagerank::ImportanceMode::Global,
+            "CLI no-personalize ⇒ global, even with a non-empty diff"
+        );
+        assert!(cli.seed_source.is_none(), "CLI global carries no seed provenance");
+        let _ = fs::remove_dir_all(&root);
     }
 
     /// #82 P2 regression: `find_callers` with NO oracle data must return the IDENTICAL membership

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::index::oracle::{
     self, OracleEvalMetrics, OracleReport, OracleStatus, OracleTool, RecallCalls,
 };
-use crate::query::pagerank::{ImportantSymbolsResult, SymbolImportance};
+use crate::query::pagerank::ImportantSymbolsResult;
 
 /// Inputs to [`IndexDatabase::important_symbols`]. The seed (`personalize`) takes names, paths, or
 /// numeric ids; `auto_seed_from_diff` is the MCP-only default (seed from the current git diff when
@@ -1773,7 +1773,7 @@ impl IndexDatabase {
         let ranking_hint: Option<String> = oracle_effects
             .is_none()
             .then(|| crate::query::pagerank::RANKING_HINT_RUN_ORACLE.to_string());
-        let rank = |seed: &[i64]| -> anyhow::Result<Vec<SymbolImportance>> {
+        let rank = |seed: &[i64]| -> anyhow::Result<crate::query::pagerank::RankedImportance> {
             crate::query::pagerank::important_symbols(
                 self.storage.connection(),
                 crate::query::pagerank::ImportanceOptions {
@@ -1787,25 +1787,33 @@ impl IndexDatabase {
         // Explicit names/paths/ids win over the auto-diff default.
         if !request.personalize.is_empty() {
             let resolved = self.resolve_seed_selectors(&request.personalize)?;
-            let symbols = rank(&resolved.symbol_ids)?;
+            let ranked = rank(&resolved.symbol_ids)?;
             let seed_source = SeedSource {
                 kind: SeedKind::Explicit,
                 // Explicit seeds are names, not paths — no path population to report.
                 changed_paths: 0,
                 indexed_paths: 0,
                 symbol_seed_count: resolved.symbol_ids.len() as u64,
+                effective_seed_count: ranked.effective_seed_count,
                 skipped: SkippedSeeds { no_symbols: resolved.unresolved, ..Default::default() },
             };
-            // Every explicit name missed → no graph seed → global ranking, but say so.
-            if resolved.symbol_ids.is_empty() {
+            // No seed reached the graph — either nothing resolved, or the resolved symbols are not
+            // endpoints of any edge — so the ranking is actually global. Label it Global and say
+            // why, rather than implying it is personalized to the named symbols. (#142 review)
+            if ranked.effective_seed_count == 0 {
+                let reason = if resolved.symbol_ids.is_empty() {
+                    "no named symbols resolved to the active scope"
+                } else {
+                    "named symbols are not connected in the graph"
+                };
                 return Ok(ImportantSymbolsResult {
                     mode: ImportanceMode::Global,
                     seed_source: Some(seed_source),
-                    reason: Some("no named symbols resolved to the active scope".to_string()),
+                    reason: Some(reason.to_string()),
                     diff_paths_considered: None,
                     diff_paths_with_symbols: None,
                     ranking_hint: ranking_hint.clone(),
-                    symbols,
+                    symbols: ranked.symbols,
                 });
             }
             return Ok(ImportantSymbolsResult {
@@ -1815,7 +1823,7 @@ impl IndexDatabase {
                 diff_paths_considered: None,
                 diff_paths_with_symbols: None,
                 ranking_hint,
-                symbols,
+                symbols: ranked.symbols,
             });
         }
 
@@ -1828,29 +1836,37 @@ impl IndexDatabase {
                 diff_paths_considered: None,
                 diff_paths_with_symbols: None,
                 ranking_hint: ranking_hint.clone(),
-                symbols: rank(&[])?,
+                symbols: rank(&[])?.symbols,
             });
         }
 
         let diff = self.diff_seed()?;
-        let symbols = rank(&diff.symbol_ids)?;
-        // The diff had changes but none mapped to an indexed symbol (markdown/config/generated/
-        // deleted-only changes, or parser gaps): fall back to global, but report it with counts.
-        if diff.symbol_ids.is_empty() {
+        let ranked = rank(&diff.symbol_ids)?;
+        // The diff produced no effective graph seed — either no changed path mapped to an indexed
+        // symbol (markdown/config/generated/deleted-only, parser gaps) OR the symbols it resolved
+        // are isolated in the graph — so the ranking is actually global. Report it with counts and
+        // the reason rather than mislabeling it personalized. (#142 review)
+        if ranked.effective_seed_count == 0 {
+            let reason = if diff.symbol_ids.is_empty() {
+                "no symbols found in current diff"
+            } else {
+                "diff symbols are not connected in the graph"
+            };
             return Ok(ImportantSymbolsResult {
                 mode: ImportanceMode::Global,
                 seed_source: Some(SeedSource {
                     kind: SeedKind::GitDiff,
                     changed_paths: diff.changed_paths,
                     indexed_paths: diff.indexed_paths,
-                    symbol_seed_count: 0,
+                    symbol_seed_count: diff.symbol_ids.len() as u64,
+                    effective_seed_count: 0,
                     skipped: diff.skipped,
                 }),
-                reason: Some("no symbols found in current diff".to_string()),
+                reason: Some(reason.to_string()),
                 diff_paths_considered: Some(diff.changed_paths),
                 diff_paths_with_symbols: Some(diff.indexed_paths),
                 ranking_hint: ranking_hint.clone(),
-                symbols,
+                symbols: ranked.symbols,
             });
         }
         Ok(ImportantSymbolsResult {
@@ -1860,13 +1876,14 @@ impl IndexDatabase {
                 changed_paths: diff.changed_paths,
                 indexed_paths: diff.indexed_paths,
                 symbol_seed_count: diff.symbol_ids.len() as u64,
+                effective_seed_count: ranked.effective_seed_count,
                 skipped: diff.skipped,
             }),
             reason: None,
             diff_paths_considered: None,
             diff_paths_with_symbols: None,
             ranking_hint,
-            symbols,
+            symbols: ranked.symbols,
         })
     }
 
@@ -1953,7 +1970,13 @@ impl IndexDatabase {
             // empty diff, not an error: the caller falls through to global with a reason.
             return Ok(DiffSeed::default());
         };
-        let changed = crate::index::git_changed_paths(root)?;
+        // A configured source root that is not a git worktree (or has no HEAD, or git is absent)
+        // must NOT fail the whole tool: auto-seed-from-diff is a best-effort default, so treat any
+        // git error as an empty diff and let the caller fall through to global — mirroring the
+        // other index paths that tolerate missing git with empty metadata. (#142 review)
+        let Ok(changed) = crate::index::git_changed_paths(root) else {
+            return Ok(DiffSeed::default());
+        };
         let changed_paths = (changed.changed.len() + changed.deleted.len()) as u64;
         let mut seed = DiffSeed { changed_paths, ..Default::default() };
         // Deleted/renamed-away paths can never carry an in-scope symbol — count and skip them.
@@ -2124,6 +2147,10 @@ impl IndexDatabase {
         callees: &mut [crate::query::graph::GraphHop],
     ) -> anyhow::Result<()> {
         use crate::query::load_bearing::{self, OracleContext};
+        // Nothing to enrich → don't pay the oracle lookup. (#142 review)
+        if callers.is_empty() && callees.is_empty() {
+            return Ok(());
+        }
         let effects = self.load_bearing_oracle_effects()?;
         let oracle = OracleContext { effects: effects.as_ref() };
         let enrich = |hop: &mut crate::query::graph::GraphHop,
@@ -2157,6 +2184,10 @@ impl IndexDatabase {
     /// oracle fetch for the whole batch.
     fn enrich_search_hits_with_load_bearing(&self, hits: &mut [SearchHit]) -> anyhow::Result<()> {
         use crate::query::load_bearing::{self, OracleContext};
+        // Nothing to enrich → don't pay the oracle lookup. (#142 review)
+        if hits.is_empty() {
+            return Ok(());
+        }
         let effects = self.load_bearing_oracle_effects()?;
         let oracle = OracleContext { effects: effects.as_ref() };
         for hit in hits.iter_mut() {
@@ -2180,6 +2211,10 @@ impl IndexDatabase {
         hits: &mut [crate::query::symbol::SymbolHit],
     ) -> anyhow::Result<()> {
         use crate::query::load_bearing::{self, OracleContext};
+        // Nothing to enrich → don't pay the oracle lookup. (#142 review)
+        if hits.is_empty() {
+            return Ok(());
+        }
         let effects = self.load_bearing_oracle_effects()?;
         let oracle = OracleContext { effects: effects.as_ref() };
         for hit in hits.iter_mut() {
@@ -3197,7 +3232,11 @@ mod oracle_surfacing_tests {
 
     /// A real committed git checkout where `caller` calls `target`, plus an UNCOMMITTED edit that
     /// adds `fn touched()` to a second file — so `git_changed_paths` reports a non-empty diff with
-    /// an indexed symbol. Returns the db; `touched.rs` is the changed file.
+    /// an indexed symbol. `touched` CALLS `placeholder` so it is an endpoint of a resolved edge,
+    /// i.e. an actual node in the PageRank graph — a seed must reach the graph to personalize the
+    /// ranking (an isolated changed symbol now correctly falls back to global; see
+    /// `seed_resolving_only_to_isolated_symbols_is_labeled_global`). Returns the db; `touched.rs`
+    /// is the changed file.
     fn checkout_with_dirty_indexed_symbol() -> (IndexDatabase, PathBuf) {
         let root = temp_root();
         fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
@@ -3205,9 +3244,13 @@ mod oracle_surfacing_tests {
         git(&root, &["init", "-q"]);
         git(&root, &["add", "-A"]);
         git(&root, &["commit", "-q", "-m", "init"]);
-        // Edit a tracked file AFTER commit → an uncommitted working-tree change with a real symbol.
-        fs::write(root.join("src/touched.rs"), "pub fn placeholder() {} pub fn touched() {}\n")
-            .unwrap();
+        // Edit a tracked file AFTER commit → an uncommitted working-tree change with a real symbol
+        // that participates in the graph (touched → placeholder).
+        fs::write(
+            root.join("src/touched.rs"),
+            "pub fn placeholder() {} pub fn touched() { placeholder(); }\n",
+        )
+        .unwrap();
         let config = rust_config(root.clone());
         let db = IndexDatabase::rebuild(&config).unwrap();
         (db, root)
@@ -3264,6 +3307,77 @@ mod oracle_surfacing_tests {
         assert_eq!(all_missing.mode, crate::query::pagerank::ImportanceMode::Global);
         assert!(all_missing.reason.is_some(), "all-missing explicit seed reports why it's global");
         assert_eq!(all_missing.seed_source.unwrap().skipped.no_symbols, 2);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// #142 review: a seed that RESOLVES to real symbols which are not endpoints of any resolved
+    /// edge has no effect on the ranking, so the result must be labeled `Global` (with a reason and
+    /// `effective_seed_count = 0`), NOT `PersonalizedToChanges` — otherwise the caller is told the
+    /// ranking is "relative to your changes" when it is actually global.
+    #[test]
+    fn seed_resolving_only_to_isolated_symbols_is_labeled_global() {
+        let root = temp_root();
+        // `caller -> target` is the only edge; `island` is a real symbol with no edges, so it never
+        // enters the PageRank graph.
+        fs::write(
+            root.join("src/lib.rs"),
+            "fn caller() { target(); } fn target() {} fn island() {}\n",
+        )
+        .unwrap();
+        let config = rust_config(root.clone());
+        let db = IndexDatabase::rebuild(&config).unwrap();
+
+        let result = db
+            .important_symbols(ImportantSymbolsRequest {
+                limit: 20,
+                personalize: vec!["island".to_string()],
+                auto_seed_from_diff: false,
+            })
+            .unwrap();
+        assert_eq!(
+            result.mode,
+            crate::query::pagerank::ImportanceMode::Global,
+            "an isolated seed yields a global ranking, not a personalized one"
+        );
+        let seed = result.seed_source.expect("seed provenance is still reported");
+        assert_eq!(seed.symbol_seed_count, 1, "the name resolved to exactly one symbol");
+        assert_eq!(seed.effective_seed_count, 0, "but that symbol is not a graph node");
+        assert_eq!(result.reason.as_deref(), Some("named symbols are not connected in the graph"));
+
+        // Contrast: a connected seed (`target`) genuinely personalizes.
+        let connected = db
+            .important_symbols(ImportantSymbolsRequest {
+                limit: 20,
+                personalize: vec!["target".to_string()],
+                auto_seed_from_diff: false,
+            })
+            .unwrap();
+        assert_eq!(connected.mode, crate::query::pagerank::ImportanceMode::PersonalizedToChanges);
+        assert_eq!(connected.seed_source.unwrap().effective_seed_count, 1);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// #142 review: auto-seed-from-diff in a source root that is NOT a git worktree must not fail
+    /// the tool — it is best-effort, so it falls through to a global ranking (with a reason)
+    /// instead of propagating the git error. (`temp_root()` is deliberately not `git init`-ed.)
+    #[test]
+    fn auto_seed_outside_a_git_worktree_falls_back_to_global() {
+        let root = temp_root();
+        fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
+        let config = rust_config(root.clone());
+        let db = IndexDatabase::rebuild(&config).unwrap();
+
+        let result = db
+            .important_symbols(ImportantSymbolsRequest {
+                limit: 20,
+                personalize: Vec::new(),
+                auto_seed_from_diff: true,
+            })
+            .unwrap();
+        assert_eq!(result.mode, crate::query::pagerank::ImportanceMode::Global);
+        assert!(!result.symbols.is_empty(), "the global ranking is still computed");
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -2145,7 +2145,7 @@ impl IndexDatabase {
             enrich(hop, neighbor.as_deref())?;
         }
         for hop in callees.iter_mut() {
-            let neighbor = hop.target_qualified_name.clone().or_else(|| hop.to_symbol.clone());
+            let neighbor = hop.to_symbol.clone().or_else(|| hop.target_qualified_name.clone());
             enrich(hop, neighbor.as_deref())?;
         }
         Ok(())

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -1871,12 +1871,27 @@ impl IndexDatabase {
     }
 
     /// Resolve a mixed list of explicit seed selectors (numeric symbol ids, symbol paths, or bare
-    /// names) to in-index symbol ids at the query boundary. A numeric string is a raw symbol id; an
-    /// ambiguous or missing name is SKIPPED (counted in `unresolved`), never fatal — one bad name
-    /// must not sink the whole call. Resolution order per non-numeric entry: `symbol_path` exact,
-    /// then `symbol` (name), mirroring `SymbolSelector` precedence.
+    /// names) to in-index symbol ids at the query boundary. A numeric string is a raw symbol id; a
+    /// name that resolves to nothing in the active scope is SKIPPED (counted in `unresolved`),
+    /// never fatal — one bad name must not sink the whole call. Resolution order per
+    /// non-numeric entry: `symbol_path` (EXACT qualified name) first; only if that resolves to
+    /// exactly one symbol do we use it — otherwise we fall through to a bare-NAME lookup.
+    ///
+    /// Personalization is a teleport SET, not a single-symbol picker: a bare name therefore seeds
+    /// ALL of its in-scope matches (the type PLUS its `impl` blocks/methods all carry the type's
+    /// name — that whole entity is exactly what we want to bias toward), rather than skipping on
+    /// ambiguity the way a `memory rebind`-style resolver would. Skipping on >1 match was the Phase
+    /// 4 UX bug: any type with impls (essentially every type) matched >1 symbol, so the
+    /// headline `--personalize <Type>` resolved to nothing and silently fell back to global
+    /// ranking.
     fn resolve_seed_selectors(&self, selectors: &[String]) -> anyhow::Result<ResolvedSeeds> {
         use crate::query::symbol::SymbolSelector;
+
+        // Cap per-name expansion so a very common name (matched by hundreds of symbols) can't flood
+        // the teleport set and wash out the signal. 25 comfortably covers a type plus its impls/
+        // methods (the intended entity) while bounding pathological names; the overall `symbol_ids`
+        // is sort+dedup'd below so a name and an explicit id that overlap don't double-count.
+        const PER_NAME_SEED_CAP: u32 = 25;
 
         let mut symbol_ids = Vec::new();
         let mut unresolved = 0_u64;
@@ -1889,10 +1904,10 @@ impl IndexDatabase {
                 symbol_ids.push(id);
                 continue;
             }
-            // Try `symbol_path` (exact qualified name) FIRST, then fall back to a bare-name lookup
-            // — `SymbolSelector` short-circuits on the first set field, so the two must be SEPARATE
-            // selectors. `allow_ambiguous: false` makes a multi-candidate name resolve to
-            // `Err(disambiguation)` → we skip it (record the miss); a missing one is `Ok(None)`.
+            // Try `symbol_path` (EXACT qualified name) FIRST: an unambiguous fully-qualified name
+            // resolves to exactly one symbol and we use it as-is. `allow_ambiguous: false` makes a
+            // multi-candidate qualified name resolve to `Err(disambiguation)` → fall through to the
+            // bare-name expansion below; a missing one is `Ok(None)` → also fall through.
             let by_path = SymbolSelector {
                 logical_symbol_id: None,
                 symbol_id: None,
@@ -1900,23 +1915,28 @@ impl IndexDatabase {
                 symbol: None,
                 language: None,
                 allow_ambiguous: false,
-                // `limit >= 2` so an ambiguous name surfaces >1 candidate and resolves to
-                // `Err(disambiguation)` (skipped) — a `limit` of 1 would silently pick the first.
                 limit: 8,
             };
+            if let Ok(Some(hit)) = self.select_symbol(&by_path)? {
+                symbol_ids.push(hit.symbol_id);
+                continue;
+            }
+            // Bare-NAME fallback: resolve to ALL in-scope matches (capped) and seed every one.
+            // `symbol_candidates` → `lookup_candidates` reads through the per-connection scoped
+            // `files` view (overlay rows win, non-active checkouts excluded), so these ids are
+            // already scope-correct — keep that path; do not query raw tables.
             let by_name = SymbolSelector {
                 symbol_path: None,
                 symbol: Some(entry.to_string()),
-                ..by_path.clone()
+                allow_ambiguous: true,
+                limit: PER_NAME_SEED_CAP,
+                ..by_path
             };
-            let resolved = match self.select_symbol(&by_path)? {
-                Ok(Some(hit)) => Some(hit),
-                // No exact qualified-name match → try the bare name.
-                Ok(None) | Err(_) => self.select_symbol(&by_name)?.ok().flatten(),
-            };
-            match resolved {
-                Some(hit) => symbol_ids.push(hit.symbol_id),
-                None => unresolved += 1,
+            let candidates = self.symbol_candidates(&by_name)?.candidates;
+            if candidates.is_empty() {
+                unresolved += 1;
+            } else {
+                symbol_ids.extend(candidates.into_iter().map(|hit| hit.symbol_id));
             }
         }
         symbol_ids.sort_unstable();
@@ -3248,33 +3268,49 @@ mod oracle_surfacing_tests {
         let _ = fs::remove_dir_all(&root);
     }
 
-    /// Ambiguous names are skipped (not fatal): two symbols share a name → the seed resolves to
-    /// neither, counts the miss, and falls through to global with a reason.
+    /// A name that matches MULTIPLE in-scope symbols seeds ALL of them — personalization is a
+    /// teleport SET, so `--personalize Thing` (where `Thing` is a struct plus its impls) biases
+    /// toward the whole entity, NOT skip-on-ambiguity. This is the Phase 4 UX-bug fix: any type
+    /// with impls used to resolve to nothing and fall back to global.
     #[test]
-    fn ambiguous_name_seed_is_skipped() {
-        if std::process::Command::new("git").arg("--version").output().is_err() {
-            return;
-        }
+    fn multi_match_name_seeds_all_in_scope_symbols() {
         let root = temp_root();
-        // `dup` defined twice across two files → name `dup` is ambiguous.
-        fs::write(root.join("src/lib.rs"), "pub fn dup() {}\n").unwrap();
-        fs::write(root.join("src/other.rs"), "pub fn dup() {}\n").unwrap();
+        // A struct `Thing` plus two `impl Thing` blocks → the bare name `Thing` matches the struct
+        // row AND the impl rows (impl blocks carry the type's name), i.e. ≥ 2 symbols share
+        // "Thing".
+        fs::write(
+            root.join("src/lib.rs"),
+            "pub struct Thing;\nimpl Thing { pub fn a(&self) {} }\nimpl Thing { pub fn b(&self) \
+             {} }\n",
+        )
+        .unwrap();
         let config = rust_config(root.clone());
         let db = IndexDatabase::rebuild(&config).unwrap();
+
+        // Sanity: the bare name really does match more than one symbol.
+        let match_count: i64 = db
+            .storage
+            .connection()
+            .query_row("SELECT COUNT(*) FROM symbols WHERE name = 'Thing'", [], |r| r.get(0))
+            .unwrap();
+        assert!(match_count >= 2, "the struct + its impls all carry the name: {match_count}");
 
         let result = db
             .important_symbols(ImportantSymbolsRequest {
                 limit: 20,
-                personalize: vec!["dup".to_string()],
+                personalize: vec!["Thing".to_string()],
                 auto_seed_from_diff: false,
             })
             .unwrap();
-        assert_eq!(result.mode, crate::query::pagerank::ImportanceMode::Global);
-        assert_eq!(
-            result.seed_source.expect("reports provenance").skipped.no_symbols,
-            1,
-            "an ambiguous name is skipped, not fatal"
+        // PERSONALIZED, not global: the multi-match name resolved to multiple seeds.
+        assert_eq!(result.mode, crate::query::pagerank::ImportanceMode::PersonalizedToChanges);
+        let seed = result.seed_source.expect("reports provenance");
+        assert_eq!(seed.kind, crate::query::pagerank::SeedKind::Explicit);
+        assert!(
+            seed.symbol_seed_count >= 2,
+            "all of the name's in-scope symbols are seeded: {seed:?}"
         );
+        assert_eq!(seed.skipped.no_symbols, 0, "a matched name is never counted as a miss");
         let _ = fs::remove_dir_all(&root);
     }
 

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -325,6 +325,7 @@ impl IndexDatabase {
             graph_mode,
             graph_limit,
         )?;
+        self.enrich_search_hits_with_load_bearing(&mut hits)?;
         Ok(hits)
     }
 
@@ -364,6 +365,7 @@ impl IndexDatabase {
             graph_mode,
             graph_limit,
         )?;
+        self.enrich_search_hits_with_load_bearing(&mut hits)?;
         Ok(hits)
     }
 
@@ -373,14 +375,20 @@ impl IndexDatabase {
         language: Option<Language>,
         limit: u32,
     ) -> anyhow::Result<Vec<crate::query::symbol::SymbolHit>> {
-        crate::query::symbol::lookup(self.storage.connection(), name, language, limit)
+        let mut hits =
+            crate::query::symbol::lookup(self.storage.connection(), name, language, limit)?;
+        self.enrich_symbol_hits_with_load_bearing(&mut hits)?;
+        Ok(hits)
     }
 
     pub fn symbol_candidates(
         &self,
         selector: &crate::query::symbol::SymbolSelector,
     ) -> anyhow::Result<crate::query::symbol::SymbolLookup> {
-        crate::query::symbol::lookup_candidates(self.storage.connection(), selector)
+        let mut lookup =
+            crate::query::symbol::lookup_candidates(self.storage.connection(), selector)?;
+        self.enrich_symbol_hits_with_load_bearing(&mut lookup.candidates)?;
+        Ok(lookup)
     }
 
     pub fn select_symbol(
@@ -1626,6 +1634,7 @@ impl IndexDatabase {
                     summary: bounded_summary(&text),
                     graph: None,
                     score_components: None,
+                    importance: None,
                 })
             },
         )?;
@@ -1684,12 +1693,20 @@ impl IndexDatabase {
         // finding
         // 4) and before the memory-evidence edge-id collection — so a compiler-upgraded neighbor
         // can't be dropped by the heuristic limit, and downstream counts see the final window.
-        let report = crate::query::impact::impact_surface_report_for_symbol(
+        let mut report = crate::query::impact::impact_surface_report_for_symbol(
             self.storage.connection(),
             symbol,
             limit,
             options,
             |hops| self.enrich_hops_with_oracle(hops),
+        )?;
+        // Attach the LOCAL structural-load signal (scoped weighted fan-in — the third importance
+        // scale, NOT PageRank) to the direct graph neighbors AFTER the oracle re-rank + truncate,
+        // so it scores exactly the neighbors the report returns. One gated oracle fetch is
+        // reused across all neighbors.
+        self.enrich_neighbors_with_load_bearing(
+            &mut report.direct_semantic_callers,
+            &mut report.direct_semantic_callees,
         )?;
         Ok(report)
     }
@@ -2015,6 +2032,121 @@ impl IndexDatabase {
             }
         }
         Ok(effects)
+    }
+
+    /// The active-scope symbol id for a qualified name, resolved THROUGH the per-connection `files`
+    /// scope view so a foreign scope's same-named symbol never matches (the same #89 discipline the
+    /// fan-in query uses). `None` when no in-scope symbol has that qualified name. When more than
+    /// one in-scope symbol shares the name (overloads / cfg twins) the lowest id is returned —
+    /// the fan-in is computed per concrete symbol id, and the load-bearing signal is a coarse
+    /// bucket, so picking a stable representative is acceptable for the enrichment.
+    fn active_symbol_id_for_qualified_name(
+        &self,
+        qualified_name: &str,
+    ) -> anyhow::Result<Option<i64>> {
+        Ok(self
+            .storage
+            .connection()
+            .query_row(
+                "SELECT s.id FROM symbols s
+                 JOIN files ON files.id = s.file_id
+                 WHERE s.qualified_name = ?1
+                 ORDER BY s.id
+                 LIMIT 1",
+                [qualified_name],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()?)
+    }
+
+    /// Build the load-bearing oracle context ONCE for an enrichment call: reuse the same gated
+    /// verdict map `important_symbols` uses (a single existence probe short-circuits the
+    /// no-oracle-ever path), and hold it for the whole pass so no symbol triggers its own verdict
+    /// scan. The returned owned map is borrowed into an [`OracleContext`] per symbol below.
+    fn load_bearing_oracle_effects(
+        &self,
+    ) -> anyhow::Result<
+        Option<std::collections::HashMap<i64, crate::query::pagerank::EdgeOracleEffect>>,
+    > {
+        self.symbol_importance_oracle_effects()
+    }
+
+    /// Attach the LOCAL structural-load enrichment (scoped weighted fan-in — the third importance
+    /// scale, NOT PageRank) to `impact_surface` neighbors. The neighbor whose load we score is the
+    /// edge's FAR end: for a CALLER hop that's `from_symbol`, for a CALLEE hop that's `to_symbol`.
+    /// The oracle effect map is fetched ONCE and reused across every hop.
+    fn enrich_neighbors_with_load_bearing(
+        &self,
+        callers: &mut [crate::query::graph::GraphHop],
+        callees: &mut [crate::query::graph::GraphHop],
+    ) -> anyhow::Result<()> {
+        use crate::query::load_bearing::{self, OracleContext};
+        let effects = self.load_bearing_oracle_effects()?;
+        let oracle = OracleContext { effects: effects.as_ref() };
+        let enrich = |hop: &mut crate::query::graph::GraphHop,
+                      neighbor: Option<&str>|
+         -> anyhow::Result<()> {
+            let Some(name) = neighbor else { return Ok(()) };
+            let Some(symbol_id) = self.active_symbol_id_for_qualified_name(name)? else {
+                return Ok(());
+            };
+            hop.importance = load_bearing::scoped_weighted_fan_in(
+                self.storage.connection(),
+                symbol_id,
+                &oracle,
+            )?;
+            Ok(())
+        };
+        for hop in callers.iter_mut() {
+            let neighbor = hop.from_symbol.clone();
+            enrich(hop, neighbor.as_deref())?;
+        }
+        for hop in callees.iter_mut() {
+            let neighbor = hop.target_qualified_name.clone().or_else(|| hop.to_symbol.clone());
+            enrich(hop, neighbor.as_deref())?;
+        }
+        Ok(())
+    }
+
+    /// Attach the load-bearing enrichment to search hits, scoring each hit's symbol (resolved from
+    /// `chunk.symbol_path`, which is the chunk's qualified name) through the active scope. Hits
+    /// with no symbol, or whose symbol has no in-scope in-edges, are left un-enriched. One
+    /// oracle fetch for the whole batch.
+    fn enrich_search_hits_with_load_bearing(&self, hits: &mut [SearchHit]) -> anyhow::Result<()> {
+        use crate::query::load_bearing::{self, OracleContext};
+        let effects = self.load_bearing_oracle_effects()?;
+        let oracle = OracleContext { effects: effects.as_ref() };
+        for hit in hits.iter_mut() {
+            let Some(symbol_path) = hit.symbol_path.clone() else { continue };
+            let Some(symbol_id) = self.active_symbol_id_for_qualified_name(&symbol_path)? else {
+                continue;
+            };
+            hit.importance = load_bearing::scoped_weighted_fan_in(
+                self.storage.connection(),
+                symbol_id,
+                &oracle,
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Attach the load-bearing enrichment to `symbol_lookup` hits (each carries its own
+    /// `symbol_id`). One oracle fetch for the whole batch.
+    fn enrich_symbol_hits_with_load_bearing(
+        &self,
+        hits: &mut [crate::query::symbol::SymbolHit],
+    ) -> anyhow::Result<()> {
+        use crate::query::load_bearing::{self, OracleContext};
+        let effects = self.load_bearing_oracle_effects()?;
+        let oracle = OracleContext { effects: effects.as_ref() };
+        for hit in hits.iter_mut() {
+            hit.importance = load_bearing::scoped_weighted_fan_in(
+                self.storage.connection(),
+                hit.symbol_id,
+                &oracle,
+            )?;
+        }
+        Ok(())
     }
 
     pub fn memory_create(
@@ -2943,6 +3075,7 @@ mod oracle_surfacing_tests {
             verified_target_symbol: false,
             shown_by_default: true,
             callsite: None,
+            importance: None,
         };
         let hops = vec![
             hop(Some("resolved-external(tokio)")),

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -1668,6 +1668,20 @@ impl IndexDatabase {
         crate::query::clusters::repo_clusters(self.storage.connection(), options)
     }
 
+    /// Top load-bearing symbols by weighted PageRank over the active checkout's edge graph (#108).
+    /// `personalize_to` biases importance toward those symbol ids (changed/query symbols); empty =
+    /// global.
+    pub fn important_symbols(
+        &self,
+        limit: usize,
+        personalize_to: &[i64],
+    ) -> anyhow::Result<Vec<crate::query::pagerank::SymbolImportance>> {
+        crate::query::pagerank::important_symbols(
+            self.storage.connection(),
+            crate::query::pagerank::ImportanceOptions { limit, personalize_to },
+        )
+    }
+
     pub fn memory_create(
         &self,
         request: crate::query::memory::RepoMemoryCreate,

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -188,6 +188,18 @@ impl IndexDatabase {
         )
     }
 
+    /// The `started_at` (Unix-epoch ms) of the most recent oracle run for `tool` in this checkout,
+    /// or `None` when none exists — the staleness clock the background auto-fresh oracle (Phase
+    /// 5) compares against the index's `indexed_at_ms` to decide whether verdicts are stale.
+    pub fn latest_oracle_run_started_at(&self, tool: OracleTool) -> anyhow::Result<Option<i64>> {
+        oracle::latest_run_started_at(
+            self.storage.connection(),
+            tool,
+            &self.active_commit_sha,
+            &self.active_worktree_id,
+        )
+    }
+
     pub fn status(&self, database: &Path) -> anyhow::Result<IndexStatus> {
         let mut counts = BTreeMap::new();
         let mut stmt = self
@@ -1755,6 +1767,12 @@ impl IndexDatabase {
         use crate::query::pagerank::{ImportanceMode, SeedKind, SeedSource, SkippedSeeds};
 
         let oracle_effects = self.symbol_importance_oracle_effects()?;
+        // Heuristic-only ranking (no oracle run for this checkout) earns a one-line nudge that
+        // compiler-grade ranking is available. The config-unaware wording lives here; CLI/MCP swap
+        // in the auto-run variant when `[oracle] auto_run` is on.
+        let ranking_hint: Option<String> = oracle_effects
+            .is_none()
+            .then(|| crate::query::pagerank::RANKING_HINT_RUN_ORACLE.to_string());
         let rank = |seed: &[i64]| -> anyhow::Result<Vec<SymbolImportance>> {
             crate::query::pagerank::important_symbols(
                 self.storage.connection(),
@@ -1786,6 +1804,7 @@ impl IndexDatabase {
                     reason: Some("no named symbols resolved to the active scope".to_string()),
                     diff_paths_considered: None,
                     diff_paths_with_symbols: None,
+                    ranking_hint: ranking_hint.clone(),
                     symbols,
                 });
             }
@@ -1795,6 +1814,7 @@ impl IndexDatabase {
                 reason: None,
                 diff_paths_considered: None,
                 diff_paths_with_symbols: None,
+                ranking_hint,
                 symbols,
             });
         }
@@ -1807,6 +1827,7 @@ impl IndexDatabase {
                 reason: None,
                 diff_paths_considered: None,
                 diff_paths_with_symbols: None,
+                ranking_hint: ranking_hint.clone(),
                 symbols: rank(&[])?,
             });
         }
@@ -1828,6 +1849,7 @@ impl IndexDatabase {
                 reason: Some("no symbols found in current diff".to_string()),
                 diff_paths_considered: Some(diff.changed_paths),
                 diff_paths_with_symbols: Some(diff.indexed_paths),
+                ranking_hint: ranking_hint.clone(),
                 symbols,
             });
         }
@@ -1843,6 +1865,7 @@ impl IndexDatabase {
             reason: None,
             diff_paths_considered: None,
             diff_paths_with_symbols: None,
+            ranking_hint,
             symbols,
         })
     }
@@ -2364,6 +2387,7 @@ mod oracle_surfacing_tests {
             local_ai: Default::default(),
             watch: Default::default(),
             version_check: Default::default(),
+            oracle: Default::default(),
         }
     }
 
@@ -3347,6 +3371,7 @@ mod oracle_surfacing_tests {
             local_ai: Default::default(),
             watch: Default::default(),
             version_check: Default::default(),
+            oracle: Default::default(),
         };
         git(&root, &["init", "-q"]);
         git(&root, &["add", "-A"]);

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -26,6 +26,7 @@ fn rebuild_bootstraps_sqlite_schema_for_empty_target_root() {
         local_ai: Default::default(),
         watch: Default::default(),
         version_check: Default::default(),
+        oracle: Default::default(),
     };
 
     let db = IndexDatabase::rebuild(&config).unwrap();
@@ -1406,6 +1407,7 @@ fn git_history_indexes_commits_paths_queries_and_blame() {
         local_ai: Default::default(),
         watch: Default::default(),
         version_check: Default::default(),
+        oracle: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let status = db.status(&config.database).unwrap();
@@ -1520,6 +1522,7 @@ fn rag_rat_config(root: &Path) -> Config {
         local_ai: Default::default(),
         watch: Default::default(),
         version_check: Default::default(),
+        oracle: Default::default(),
     }
 }
 
@@ -2464,6 +2467,7 @@ DEVICE_DT_INST_DEFINE(0, entropy_init, NULL, NULL, NULL,
         local_ai: Default::default(),
         watch: Default::default(),
         version_check: Default::default(),
+        oracle: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
 
@@ -3156,6 +3160,7 @@ where
         local_ai: Default::default(),
         watch: Default::default(),
         version_check: Default::default(),
+        oracle: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let symbol = db.symbols("spawn_blocking", Some(Language::Rust), 10).unwrap().remove(0);
@@ -3920,6 +3925,7 @@ fn parser_failures_report_paths() {
         local_ai: Default::default(),
         watch: Default::default(),
         version_check: Default::default(),
+        oracle: Default::default(),
     };
 
     let db = IndexDatabase::rebuild(&config).unwrap();
@@ -5804,6 +5810,7 @@ fn repo_brief_ranks_churn_and_god_module_candidates() {
         local_ai: Default::default(),
         watch: Default::default(),
         version_check: Default::default(),
+        oracle: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
 
@@ -5883,6 +5890,7 @@ fn repo_clusters_groups_cotouched_files() {
         local_ai: Default::default(),
         watch: Default::default(),
         version_check: Default::default(),
+        oracle: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
 
@@ -5972,6 +5980,7 @@ fn markdown_config_for_root(root: PathBuf) -> Config {
         local_ai: Default::default(),
         watch: Default::default(),
         version_check: Default::default(),
+        oracle: Default::default(),
     }
 }
 
@@ -5994,6 +6003,7 @@ fn source_config(root: PathBuf, language: Language) -> Config {
         local_ai: Default::default(),
         watch: Default::default(),
         version_check: Default::default(),
+        oracle: Default::default(),
     }
 }
 
@@ -6400,6 +6410,7 @@ fn dir_tree_label_depth_collapse_single_child_chain() {
         local_ai: Default::default(),
         watch: Default::default(),
         version_check: Default::default(),
+        oracle: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let conn = db.storage.connection();
@@ -6624,6 +6635,7 @@ fn dir_tree_truncates_at_max_nodes() {
         local_ai: Default::default(),
         watch: Default::default(),
         version_check: Default::default(),
+        oracle: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let conn = db.storage.connection();
@@ -6765,6 +6777,7 @@ fn dir_tree_children_of_collapsed_node_use_leaf_labels() {
         local_ai: Default::default(),
         watch: Default::default(),
         version_check: Default::default(),
+        oracle: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let conn = db.storage.connection();
@@ -7364,6 +7377,7 @@ fn git_fixture_for_overlay_tests() -> (PathBuf, Config) {
         local_ai: Default::default(),
         watch: Default::default(),
         version_check: Default::default(),
+        oracle: Default::default(),
     };
     (root, config)
 }
@@ -7524,6 +7538,7 @@ fn clean_checkout_file_resolves_against_its_own_package_roots() {
         local_ai: Default::default(),
         watch: Default::default(),
         version_check: Default::default(),
+        oracle: Default::default(),
     };
 
     let db = IndexDatabase::rebuild(&config).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -7631,3 +7631,93 @@ fn incremental_pass_heals_stale_overlay_rows() {
 
     fs::remove_dir_all(root).unwrap();
 }
+
+/// Phase 3: the LOCAL structural-load enrichment (`scoped weighted fan-in`) rides along on BOTH the
+/// `impact_surface` neighbors AND `symbol_lookup` / `search` hits — labeled, never as PageRank. A
+/// hub called by several functions outranks a leaf nothing depends on.
+#[test]
+fn load_bearing_enrichment_present_on_impact_neighbors_and_lookup_hits() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub fn load_bearing_hub() -> i32 { 1 }
+pub fn quiet_leaf() -> i32 { 2 }
+pub fn caller_one() -> i32 { load_bearing_hub() }
+pub fn caller_two() -> i32 { load_bearing_hub() }
+pub fn caller_three() -> i32 { load_bearing_hub() }
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    // impact_surface neighbors: running impact on a CALLER surfaces the hub as a callee neighbor,
+    // and the hub (three callers) carries the labeled load-bearing signal — the third importance
+    // scale, never PageRank.
+    let caller_selector = crate::query::symbol::SymbolSelector {
+        logical_symbol_id: None,
+        symbol_id: None,
+        symbol_path: None,
+        symbol: Some("caller_one".to_string()),
+        language: Some(Language::Rust),
+        allow_ambiguous: false,
+        limit: 10,
+    };
+    let caller = db.select_symbol(&caller_selector).unwrap().unwrap().expect("caller symbol");
+    let report = db
+        .impact_surface_report_for_selected_symbol(
+            &caller,
+            50,
+            &crate::query::impact::ImpactSurfaceOptions::default(),
+        )
+        .unwrap();
+    let enriched_hub = report
+        .direct_semantic_callees
+        .iter()
+        .find_map(|hop| hop.importance.as_ref())
+        .expect("the hub callee neighbor carries the load-bearing enrichment");
+    assert_eq!(enriched_hub.label, "local structural load", "labeled, not PageRank");
+    assert_eq!(enriched_hub.signal, "scoped weighted fan-in");
+    assert!(enriched_hub.score > 0.0, "the hub's three callers give it positive fan-in");
+
+    // symbol_lookup hits: the hub (3 callers) outscores the leaf (0). Both carry the label, but the
+    // leaf has no in-edges in scope so its enrichment is absent — the score reflects scoped fan-in.
+    let hub_hit = db
+        .symbols("load_bearing_hub", Some(Language::Rust), 10)
+        .unwrap()
+        .into_iter()
+        .find(|h| h.qualified_name.ends_with("load_bearing_hub"))
+        .expect("hub lookup hit");
+    let hub_importance =
+        hub_hit.importance.as_ref().expect("hub has callers → a load-bearing signal");
+    assert_eq!(hub_importance.label, "local structural load");
+    assert!(hub_importance.score > 0.0, "the hub's three callers give it positive fan-in");
+
+    let leaf_hit = db
+        .symbols("quiet_leaf", Some(Language::Rust), 10)
+        .unwrap()
+        .into_iter()
+        .find(|h| h.qualified_name.ends_with("quiet_leaf"))
+        .expect("leaf lookup hit");
+    assert!(
+        leaf_hit.importance.is_none(),
+        "a symbol nothing depends on has no in-scope fan-in: {:?}",
+        leaf_hit.importance
+    );
+
+    // search hits carry the same enrichment on the resolved symbol.
+    let search_hub =
+        db.search("load_bearing_hub", 20, true).unwrap().into_iter().find(|hit| {
+            hit.symbol_path.as_deref().is_some_and(|s| s.ends_with("load_bearing_hub"))
+        });
+    if let Some(hit) = search_hub
+        && let Some(importance) = hit.importance.as_ref()
+    {
+        assert_eq!(importance.label, "local structural load", "search hit labeled correctly");
+    }
+
+    fs::remove_dir_all(root).unwrap();
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -7736,3 +7736,83 @@ pub fn caller_three() -> i32 { load_bearing_hub() }
 
     fs::remove_dir_all(root).unwrap();
 }
+
+/// Phase 3 regression: a CALLEE neighbor whose call was written with a `::` path carries a
+/// source-level `target_qualified_name` (e.g. `crate::helper::deep_helper`) that does NOT match
+/// rag-rat's `path::name` `qualified_name`. The enrichment must resolve such callees by
+/// `to_symbol` (the verified rag-rat `path::name` target) FIRST — resolving by
+/// `target_qualified_name` first leaves every qualified-call callee un-enriched. The sibling test
+/// above misses this: its callees are bare calls, so `target_qualified_name` is `None` and the
+/// fallback to `to_symbol` masks the wrong-order bug.
+#[test]
+fn load_bearing_enrichment_present_on_qualified_callee_neighbor() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    // `deep_helper` is reached only via the `crate::helper::deep_helper()` path, so its callee
+    // edge carries a `target_qualified_name` of `crate::helper::deep_helper` — divergent from the
+    // rag-rat `path::name` `qualified_name`. Two callers give it fan-in ≥ 1 (so its scoped
+    // weighted fan-in is `Some`).
+    fs::write(
+        root.join("src/helper.rs"),
+        r#"
+pub fn deep_helper() -> i32 { 7 }
+"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub mod helper;
+pub fn qualified_caller_one() -> i32 { crate::helper::deep_helper() }
+pub fn qualified_caller_two() -> i32 { crate::helper::deep_helper() }
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let caller_selector = crate::query::symbol::SymbolSelector {
+        logical_symbol_id: None,
+        symbol_id: None,
+        symbol_path: None,
+        symbol: Some("qualified_caller_one".to_string()),
+        language: Some(Language::Rust),
+        allow_ambiguous: false,
+        limit: 10,
+    };
+    let caller =
+        db.select_symbol(&caller_selector).unwrap().unwrap().expect("qualified caller symbol");
+    let report = db
+        .impact_surface_report_for_selected_symbol(
+            &caller,
+            50,
+            &crate::query::impact::ImpactSurfaceOptions::default(),
+        )
+        .unwrap();
+
+    let callee_hop = report
+        .direct_semantic_callees
+        .iter()
+        .find(|hop| hop.to_symbol.as_deref().is_some_and(|s| s.ends_with("deep_helper")))
+        .expect("the qualified callee neighbor is surfaced");
+    // The callee carries the divergent source-level qualified name — the exact shape that
+    // un-enriched callees in the wild (`self::storage::connection`, etc.).
+    assert!(
+        callee_hop
+            .target_qualified_name
+            .as_deref()
+            .is_some_and(|q| q.contains("::") && !q.contains('/')),
+        "callee carries a source-level (non path::name) target_qualified_name: {:?}",
+        callee_hop.target_qualified_name
+    );
+    let importance = callee_hop
+        .importance
+        .as_ref()
+        .expect("the qualified callee neighbor carries the load-bearing enrichment");
+    assert_eq!(importance.label, "local structural load", "labeled, not PageRank");
+    assert_eq!(importance.signal, "scoped weighted fan-in");
+    assert!(importance.score > 0.0, "two callers give the callee positive fan-in");
+
+    fs::remove_dir_all(root).unwrap();
+}

--- a/crates/rag-rat-core/src/query/graph/mod.rs
+++ b/crates/rag-rat-core/src/query/graph/mod.rs
@@ -273,6 +273,12 @@ pub struct GraphHop {
     pub shown_by_default: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub callsite: Option<Callsite>,
+    /// LOCAL structural-load signal (scoped weighted fan-in) for this neighbor — the THIRD
+    /// importance scale, NOT PageRank. Attached by the `impact_surface` enrichment pass over the
+    /// neighbors a result already holds. `None` when the neighbor has no in-edges in the active
+    /// scope or wasn't enriched. See `crate::query::load_bearing`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub importance: Option<crate::query::load_bearing::ImportanceEnrichment>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/rag-rat-core/src/query/graph/traverse.rs
+++ b/crates/rag-rat-core/src/query/graph/traverse.rs
@@ -149,6 +149,9 @@ pub(crate) fn traverse_with_options(
                 line: callsite_start,
                 span: [callsite_start, callsite_end],
             }),
+            // Filled by the `impact_surface` load-bearing enrichment pass (`IndexDatabase`), which
+            // has the active scope + oracle context; heuristic traversal leaves it absent.
+            importance: None,
         })
     })?;
     let mut hops = Vec::new();

--- a/crates/rag-rat-core/src/query/grep_augment.rs
+++ b/crates/rag-rat-core/src/query/grep_augment.rs
@@ -514,6 +514,7 @@ mod tests {
             summary: format!("{path} summary"),
             graph: None,
             score_components: None,
+            importance: None,
         }
     }
 

--- a/crates/rag-rat-core/src/query/load_bearing.rs
+++ b/crates/rag-rat-core/src/query/load_bearing.rs
@@ -86,7 +86,11 @@ impl Serialize for LoadBearingBucket {
 /// Today the only non-heuristic tier is `compiler` (a confirmed/upgraded in-edge), so the enum has
 /// one variant — it exists so the field is a self-describing label (`oracle_tier: "compiler"`)
 /// rather than a bare bool, and so a later backend can add tiers without changing the field shape.
+// `rename_all = "snake_case"` so the serialized label matches `as_str()` and the documented
+// contract (`"compiler"`), not the variant's `"Compiler"` — MCP/CLI consumers key off the lower
+// form. (#142 review)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum OracleTier {
     /// At least one in-edge was confirmed/upgraded by a SCIP oracle — compiler-grade.
     Compiler,
@@ -256,6 +260,28 @@ mod tests {
 
     use super::*;
     use crate::index::{install_scope_view, schema};
+
+    /// #142 review: the wire label for the oracle tier must match `as_str()` and the documented
+    /// contract (`"compiler"`), not the variant name `"Compiler"` — MCP/CLI consumers key off the
+    /// lower form.
+    #[test]
+    fn oracle_tier_serializes_as_lowercase_compiler() {
+        assert_eq!(OracleTier::Compiler.as_str(), "compiler");
+        assert_eq!(
+            serde_json::to_value(OracleTier::Compiler).unwrap(),
+            serde_json::json!("compiler")
+        );
+        // …and through the enrichment that actually carries it on the wire.
+        let enrichment = ImportanceEnrichment {
+            label: "local structural load",
+            signal: "scoped weighted fan-in",
+            score: 1.0,
+            bucket: LoadBearingBucket::High,
+            oracle_tier: Some(OracleTier::Compiler),
+        };
+        let value = serde_json::to_value(&enrichment).unwrap();
+        assert_eq!(value["oracle_tier"], serde_json::json!("compiler"));
+    }
 
     /// A connection with the schema applied and a single active scope (committed `sha`, no
     /// worktree), ready for fan-in queries against the `files` view.

--- a/crates/rag-rat-core/src/query/load_bearing.rs
+++ b/crates/rag-rat-core/src/query/load_bearing.rs
@@ -1,0 +1,525 @@
+//! Scoped weighted fan-in — the THIRD, LOCAL importance scale (#108 / importance-ux-overhaul Phase
+//! 3). A cheap, per-result-symbol structural signal that rides along in tools agents already call
+//! (`impact_surface` neighbors, `semantic_search` / `symbol_lookup` hits) — NOT global PageRank.
+//!
+//! ```text
+//! scoped_weighted_fan_in(symbol) =
+//!     Σ  edge_weight(kind) × confidence_factor(confidence) × oracle_factor(verdict?)
+//!     over the symbol's IN-edges VISIBLE IN THE ACTIVE files SCOPE
+//! ```
+//!
+//! It reuses the `query::pagerank` weight tables ([`edge_weight`] / [`confidence_factor`] /
+//! [`COMPILER_FACTOR`]) verbatim — single source of truth — but is a *different metric on a
+//! different scope*: a local weighted in-degree, never the global/transitive PageRank flow. The
+//! result is LABELED ([`ImportanceEnrichment::label`] = `"local structural load"`) so an agent can
+//! never mistake it for a PageRank score (the spec's "three scales" anti-pattern). The PageRank
+//! scales live in `important_symbols`; this one rides along.
+//!
+//! Why no whole-graph pass: the in-degree is computed only for the symbols a result already holds,
+//! one bounded query each, so enrichment costs nothing on a result with no symbols and stays cheap
+//! on a handful. Oracle data is fetched ONCE per enrichment call and threaded through (no
+//! per-symbol verdict scan); when no oracle run exists for the active checkout the factor is `1.0`
+//! (pure heuristic) and costs nothing — the caller gates on a run existing.
+
+use std::collections::HashMap;
+
+use rusqlite::Connection;
+use serde::Serialize;
+
+use crate::query::pagerank::{COMPILER_FACTOR, EdgeOracleEffect, confidence_factor, edge_weight};
+
+/// The load-bearing bucket for a symbol's scoped weighted fan-in. Buckets travel where raw floats
+/// do not: the raw `score` drifts with graph density, language, parser coverage, and scope size, so
+/// it is kept only for sorting — the BUCKET is the stable, comparable signal an agent reads.
+///
+/// Thresholds (on the raw weighted in-degree) are HEURISTIC and TUNABLE. They are absolute (not a
+/// percentile — a percentile pass would mean ranking the whole graph per call, which defeats the
+/// point of a local enrichment). Calibration intuition: a `calls_name` edge at `Exact` confidence
+/// contributes `1.0 × 1.0 = 1.0`; a `NameOnly` guess `1.0 × 0.4 = 0.4`; an `imports` edge `0.3`.
+/// So `Low` ≈ a symbol nothing-much depends on, `Medium` ≈ a few real callers, `High` ≈ a
+/// genuinely depended-upon helper, `Critical` ≈ a hub many things call. See [`Self::THRESHOLDS`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LoadBearingBucket {
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+impl LoadBearingBucket {
+    /// `(lower_bound, bucket)` pairs, ascending. A score `>=` a row's bound and `<` the next row's
+    /// falls in that bucket; `Low` is the open floor. HEURISTIC + TUNABLE (see the type doc).
+    const THRESHOLDS: [(f64, LoadBearingBucket); 3] = [
+        (2.0, LoadBearingBucket::Medium),
+        (5.0, LoadBearingBucket::High),
+        (12.0, LoadBearingBucket::Critical),
+    ];
+
+    /// Bucket a raw scoped-weighted-fan-in score against [`Self::THRESHOLDS`].
+    pub fn from_score(score: f64) -> Self {
+        let mut bucket = LoadBearingBucket::Low;
+        for (lower, candidate) in Self::THRESHOLDS {
+            if score >= lower {
+                bucket = candidate;
+            }
+        }
+        bucket
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Critical => "critical",
+        }
+    }
+}
+
+impl Serialize for LoadBearingBucket {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+/// The best SCIP tier observed among a symbol's in-edges, when an oracle run covers any of them.
+/// Today the only non-heuristic tier is `compiler` (a confirmed/upgraded in-edge), so the enum has
+/// one variant — it exists so the field is a self-describing label (`oracle_tier: "compiler"`)
+/// rather than a bare bool, and so a later backend can add tiers without changing the field shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum OracleTier {
+    /// At least one in-edge was confirmed/upgraded by a SCIP oracle — compiler-grade.
+    Compiler,
+}
+
+impl OracleTier {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Compiler => "compiler",
+        }
+    }
+}
+
+/// The local structural-load signal attached to a result symbol. LABELED so it is never confused
+/// with PageRank: `label` / `signal` are fixed contract strings naming the scale.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ImportanceEnrichment {
+    /// EXACTLY `"local structural load"` — the agent-facing name of this (third) scale. Never
+    /// `"global importance"` or anything implying comparability with PageRank.
+    pub label: &'static str,
+    /// EXACTLY `"scoped weighted fan-in"` — how the score was computed.
+    pub signal: &'static str,
+    /// Raw weighted in-degree, for sorting. Drifts with scope/language/density — prefer `bucket`
+    /// for any comparison.
+    pub score: f64,
+    pub bucket: LoadBearingBucket,
+    /// The best SCIP tier among the in-edges, if an oracle run covered any of them; else `None`
+    /// (pure heuristic).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oracle_tier: Option<OracleTier>,
+}
+
+impl ImportanceEnrichment {
+    const LABEL: &'static str = "local structural load";
+    const SIGNAL: &'static str = "scoped weighted fan-in";
+}
+
+/// Pre-fetched oracle data for an enrichment call: the per-`edge_id` [`EdgeOracleEffect`] map,
+/// built ONCE by the caller (`IndexDatabase`) and reused across every symbol in the result — never
+/// a verdict scan per symbol. `None` = no oracle run for the active checkout, so the heuristic path
+/// runs with `oracle_factor = 1.0` and no oracle lookups happen at all (gated upstream).
+pub struct OracleContext<'a> {
+    pub effects: Option<&'a HashMap<i64, EdgeOracleEffect>>,
+}
+
+impl<'a> OracleContext<'a> {
+    /// A heuristic-only context (no oracle run) — the dominant path.
+    pub fn none() -> Self {
+        Self { effects: None }
+    }
+}
+
+/// One in-edge's contribution to the scoped weighted fan-in, after applying its oracle verdict (if
+/// any). A `None` means the edge was DROPPED (a contradicted / resolved-external phantom — it
+/// doesn't count toward load), matching how `important_symbols` drops the same verdicts.
+struct InEdgeContribution {
+    weight: f64,
+    /// Whether this edge counts at the compiler tier (confirm/upgrade) — used to set
+    /// `oracle_tier`.
+    compiler: bool,
+}
+
+/// Apply an in-edge's oracle verdict to its heuristic weight, mirroring
+/// `pagerank::important_symbols`'s per-edge logic so the two scales agree on what a verdict does.
+/// `to_symbol_id` is the symbol being scored (S) — the heuristic target the in-edge query selected
+/// on (`WHERE d.to_symbol_id = S`):
+/// - `Drop` (contradict / resolved-external) → the edge is a phantom, it contributes nothing;
+/// - `Confirm` → the compiler confirmed S as the target; the in-edge counts at the compiler tier;
+/// - `Retarget(t)` where `t == S` → the rare case where the oracle resolved the edge back onto S
+///   itself; counts at the compiler tier, same as `Confirm`;
+/// - `Retarget(t)` where `t != S` → **DROP** (`None`): the oracle resolved the edge to `t`, NOT S.
+///   The edge makes the caller depend on `t`, not S — the heuristic mis-attributed it to S, so it
+///   is not an in-edge of S and must not inflate S's fan-in (the global graph build MOVES such an
+///   edge to its resolved target, the behavior `important_symbols` produces);
+/// - no verdict → `edge_weight × confidence_factor` (pure heuristic).
+fn in_edge_contribution(
+    kind: &str,
+    confidence: &str,
+    edge_id: i64,
+    to_symbol_id: i64,
+    oracle: &OracleContext<'_>,
+) -> Option<InEdgeContribution> {
+    match oracle.effects.and_then(|m| m.get(&edge_id)) {
+        Some(EdgeOracleEffect::Drop) => None,
+        // A retarget onto a DIFFERENT symbol is not an in-edge of S — drop it (no false inflation).
+        Some(EdgeOracleEffect::Retarget(t)) if *t != to_symbol_id => None,
+        // `Confirm`, or a `Retarget` that lands back on S itself: confirmed in-edge of S.
+        Some(EdgeOracleEffect::Confirm) | Some(EdgeOracleEffect::Retarget(_)) =>
+            Some(InEdgeContribution { weight: edge_weight(kind) * COMPILER_FACTOR, compiler: true }),
+        None => Some(InEdgeContribution {
+            weight: edge_weight(kind) * confidence_factor(confidence),
+            compiler: false,
+        }),
+    }
+}
+
+/// Compute the scoped weighted fan-in for a single symbol: the sum of its in-edges' weights, where
+/// in-edges are read THROUGH the active per-connection `files` scope view (never `main.*`), so the
+/// score reflects only dependencies visible in the active checkout. Returns `None` when the symbol
+/// has no visible in-edge contribution at all (so the caller can leave `importance` absent rather
+/// than emit a meaningless `score: 0`).
+///
+/// ## Accepted oracle limitation (keyed on the HEURISTIC target)
+/// The in-edge query is keyed on the heuristic target (`WHERE d.to_symbol_id = S`). Oracle
+/// retargets are honored to EXCLUDE mis-attributed in-edges — an edge whose heuristic target is S
+/// but which the oracle `Retarget`s onto some OTHER symbol is dropped (see
+/// [`in_edge_contribution`]) so it never falsely inflates S's fan-in. They are NOT used to chase IN
+/// edges retargeted ONTO S: an edge whose heuristic target is some other symbol but which the
+/// oracle resolves to S is not selected by this query, so S's fan-in can slightly UNDERCOUNT
+/// oracle-retargeted-in dependencies. Picking those up would require scanning beyond the symbol's
+/// own in-edges (a reverse index), which we deliberately do NOT build — the signal is advisory and
+/// bucketed, and must stay a cheap per-symbol local query. Removing the false inflation is the
+/// correctness win; the residual undercount is bounded and acceptable for a bucketed advisory
+/// signal.
+pub fn scoped_weighted_fan_in(
+    conn: &Connection,
+    to_symbol_id: i64,
+    oracle: &OracleContext<'_>,
+) -> anyhow::Result<Option<ImportanceEnrichment>> {
+    // #89: in-edges are joined THROUGH the per-connection scoped `files` view
+    // (`JOIN files ON files.id = edges_data.source_file_id`), NOT raw `main.edges`/`main.files`, so
+    // the same symbol identity scores DIFFERENTLY per active scope and a foreign scope's edges
+    // never leak in. `edge_strings` resolves the kind/confidence ids to names for the weight
+    // tables; `d.id` keys the optional SCIP-oracle effect lookup.
+    let mut stmt = conn.prepare(
+        "SELECT d.id, ek.value, cf.value
+         FROM edges_data d
+         JOIN files ON files.id = d.source_file_id
+         JOIN edge_strings ek ON ek.id = d.edge_kind_id
+         JOIN edge_strings cf ON cf.id = d.confidence_id
+         WHERE d.to_symbol_id = ?1",
+    )?;
+    let rows = stmt
+        .query_map([to_symbol_id], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut score = 0.0_f64;
+    let mut counted = false;
+    let mut compiler = false;
+    for (edge_id, kind, confidence) in &rows {
+        let Some(contribution) =
+            in_edge_contribution(kind, confidence, *edge_id, to_symbol_id, oracle)
+        else {
+            continue;
+        };
+        score += contribution.weight;
+        counted = true;
+        compiler |= contribution.compiler;
+    }
+    if !counted {
+        return Ok(None);
+    }
+    Ok(Some(ImportanceEnrichment {
+        label: ImportanceEnrichment::LABEL,
+        signal: ImportanceEnrichment::SIGNAL,
+        score: crate::query::round_score(score),
+        bucket: LoadBearingBucket::from_score(score),
+        oracle_tier: compiler.then_some(OracleTier::Compiler),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::params;
+
+    use super::*;
+    use crate::index::{install_scope_view, schema};
+
+    /// A connection with the schema applied and a single active scope (committed `sha`, no
+    /// worktree), ready for fan-in queries against the `files` view.
+    fn scoped_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        conn
+    }
+
+    /// Insert a file row for `(commit_sha, worktree_id)` and return its id.
+    fn add_file(conn: &Connection, path: &str, commit: &str, worktree: &str) -> i64 {
+        conn.execute(
+            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms,
+                               commit_sha, worktree_id)
+             VALUES (?1, 'rust', 'source', 'h', 0, 0, ?2, ?3)",
+            params![path, commit, worktree],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    /// Insert a symbol in `file_id`, returning its id.
+    fn add_symbol(conn: &Connection, file_id: i64, name: &str, qualified: &str) -> i64 {
+        conn.execute(
+            "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte,
+                                 end_byte, signature, docs)
+             VALUES (?1, 'rust', ?2, ?3, 'function', 0, 10, NULL, NULL)",
+            params![file_id, name, qualified],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    /// Insert an in-edge `from → to` of `kind` at `confidence` in `source_file_id`, returning the
+    /// edge id (for keying an oracle-effects map).
+    fn add_edge(
+        conn: &Connection,
+        source_file_id: i64,
+        from: i64,
+        to: i64,
+        kind: &str,
+        confidence: &str,
+    ) -> i64 {
+        conn.execute(
+            "INSERT INTO edges(source_file_id, from_symbol_id, to_symbol_id, to_name,
+                               target_qualified_name, edge_kind, confidence)
+             VALUES (?1, ?2, ?3, 'x', 'a::x', ?4, ?5)",
+            params![source_file_id, from, to, kind, confidence],
+        )
+        .unwrap();
+        // `edges` is an INSTEAD OF INSERT view over `edges_data`; `last_insert_rowid()` after the
+        // trigger reflects an inner `edge_strings` insert, not the edge row — read the real
+        // `edges_data.id` so the oracle-effects map keys on the value `scoped_weighted_fan_in`'s
+        // `d.id` query returns.
+        conn.query_row("SELECT MAX(id) FROM edges_data", [], |row| row.get::<_, i64>(0)).unwrap()
+    }
+
+    fn fan_in(conn: &Connection, to_symbol_id: i64) -> Option<ImportanceEnrichment> {
+        scoped_weighted_fan_in(conn, to_symbol_id, &OracleContext::none()).unwrap()
+    }
+
+    #[test]
+    fn bucketing_thresholds() {
+        assert_eq!(LoadBearingBucket::from_score(0.0), LoadBearingBucket::Low);
+        assert_eq!(LoadBearingBucket::from_score(1.99), LoadBearingBucket::Low);
+        assert_eq!(LoadBearingBucket::from_score(2.0), LoadBearingBucket::Medium);
+        assert_eq!(LoadBearingBucket::from_score(4.99), LoadBearingBucket::Medium);
+        assert_eq!(LoadBearingBucket::from_score(5.0), LoadBearingBucket::High);
+        assert_eq!(LoadBearingBucket::from_score(11.99), LoadBearingBucket::High);
+        assert_eq!(LoadBearingBucket::from_score(12.0), LoadBearingBucket::Critical);
+        assert_eq!(LoadBearingBucket::from_score(1000.0), LoadBearingBucket::Critical);
+    }
+
+    #[test]
+    fn more_and_heavier_in_edges_score_higher() {
+        let conn = scoped_conn();
+        let f = add_file(&conn, "a.rs", "c", "");
+        let hub = add_symbol(&conn, f, "hub", "a::hub");
+        let weak = add_symbol(&conn, f, "weak", "a::weak");
+        let mut callers = Vec::new();
+        for i in 0..6 {
+            callers.push(add_symbol(&conn, f, &format!("c{i}"), &format!("a::c{i}")));
+        }
+        // hub: six exact `calls_name` in-edges (6 × 1.0 × 1.0 = 6.0).
+        for &c in &callers {
+            add_edge(&conn, f, c, hub, "calls_name", "Exact");
+        }
+        // weak: one name-only call in-edge (1 × 1.0 × 0.4 = 0.4).
+        add_edge(&conn, f, callers[0], weak, "calls_name", "NameOnly");
+        install_scope_view(&conn, "c", "").unwrap();
+
+        let hub_score = fan_in(&conn, hub).unwrap();
+        let weak_score = fan_in(&conn, weak).unwrap();
+        assert!(
+            hub_score.score > weak_score.score,
+            "more/heavier in-edges score higher: {hub_score:?} vs {weak_score:?}"
+        );
+        assert_eq!(hub_score.label, "local structural load");
+        assert_eq!(hub_score.signal, "scoped weighted fan-in");
+        assert_eq!(hub_score.bucket, LoadBearingBucket::High, "6.0 ⇒ High");
+        assert_eq!(weak_score.bucket, LoadBearingBucket::Low, "0.4 ⇒ Low");
+    }
+
+    #[test]
+    fn edge_kind_and_confidence_weighting_reflected() {
+        let conn = scoped_conn();
+        let f = add_file(&conn, "a.rs", "c", "");
+        let called = add_symbol(&conn, f, "called", "a::called");
+        let imported = add_symbol(&conn, f, "imported", "a::imported");
+        let caller = add_symbol(&conn, f, "caller", "a::caller");
+        // A `calls_name` in-edge (weight 1.0) vs an `imports` in-edge (weight 0.3), same
+        // confidence.
+        add_edge(&conn, f, caller, called, "calls_name", "Exact");
+        add_edge(&conn, f, caller, imported, "imports", "Exact");
+        install_scope_view(&conn, "c", "").unwrap();
+
+        let called = fan_in(&conn, called).unwrap();
+        let imported = fan_in(&conn, imported).unwrap();
+        assert!(
+            called.score > imported.score,
+            "the call in-edge outweighs the import in-edge: {called:?} vs {imported:?}"
+        );
+    }
+
+    #[test]
+    fn no_in_edges_is_none() {
+        let conn = scoped_conn();
+        let f = add_file(&conn, "a.rs", "c", "");
+        let leaf = add_symbol(&conn, f, "leaf", "a::leaf");
+        install_scope_view(&conn, "c", "").unwrap();
+        assert!(fan_in(&conn, leaf).is_none(), "a symbol nothing depends on has no fan-in");
+    }
+
+    #[test]
+    fn oracle_confirm_lifts_score_and_sets_tier() {
+        // One name-only in-edge: heuristic weight 1.0 × 0.4 = 0.4. With a Confirm verdict it counts
+        // at the compiler tier (1.0 × 1.2 = 1.2) AND sets oracle_tier = compiler.
+        let conn = scoped_conn();
+        let f = add_file(&conn, "a.rs", "c", "");
+        let target = add_symbol(&conn, f, "target", "a::target");
+        let caller = add_symbol(&conn, f, "caller", "a::caller");
+        let edge = add_edge(&conn, f, caller, target, "calls_name", "NameOnly");
+        install_scope_view(&conn, "c", "").unwrap();
+
+        let heuristic = fan_in(&conn, target).unwrap();
+        assert_eq!(heuristic.oracle_tier, None, "no oracle run ⇒ pure heuristic, no tier");
+
+        let effects = HashMap::from([(edge, EdgeOracleEffect::Confirm)]);
+        let lifted =
+            scoped_weighted_fan_in(&conn, target, &OracleContext { effects: Some(&effects) })
+                .unwrap()
+                .unwrap();
+        assert!(
+            lifted.score > heuristic.score,
+            "the confirmed in-edge lifts the score: {lifted:?} vs {heuristic:?}"
+        );
+        assert_eq!(lifted.oracle_tier, Some(OracleTier::Compiler));
+    }
+
+    #[test]
+    fn oracle_drop_removes_a_phantom_in_edge() {
+        // Two in-edges; the oracle contradicts one (Drop). The dropped edge contributes nothing, so
+        // the score reflects only the surviving in-edge.
+        let conn = scoped_conn();
+        let f = add_file(&conn, "a.rs", "c", "");
+        let target = add_symbol(&conn, f, "target", "a::target");
+        let real = add_symbol(&conn, f, "real", "a::real");
+        let phantom = add_symbol(&conn, f, "phantom", "a::phantom");
+        add_edge(&conn, f, real, target, "calls_name", "Exact");
+        let dropped = add_edge(&conn, f, phantom, target, "calls_name", "Exact");
+        install_scope_view(&conn, "c", "").unwrap();
+
+        let both = fan_in(&conn, target).unwrap();
+        let effects = HashMap::from([(dropped, EdgeOracleEffect::Drop)]);
+        let one = scoped_weighted_fan_in(&conn, target, &OracleContext { effects: Some(&effects) })
+            .unwrap()
+            .unwrap();
+        assert!(one.score < both.score, "dropping a phantom in-edge lowers the score: {one:?}");
+    }
+
+    #[test]
+    fn oracle_retarget_to_other_symbol_does_not_count_but_retarget_to_self_does() {
+        // The in-edge query selects on the HEURISTIC target S. An oracle `Retarget(other)` means
+        // the edge actually points at `other`, not S — the heuristic mis-attributed it — so
+        // it must NOT count toward S. A `Retarget(S)` (resolved back onto S itself) DOES
+        // count, at the compiler tier, like a `Confirm`.
+        let conn = scoped_conn();
+        let f = add_file(&conn, "a.rs", "c", "");
+        let target = add_symbol(&conn, f, "target", "a::target");
+        let other = add_symbol(&conn, f, "other", "a::other");
+        let caller = add_symbol(&conn, f, "caller", "a::caller");
+        // One in-edge whose heuristic target is S (`target`).
+        let edge = add_edge(&conn, f, caller, target, "calls_name", "Exact");
+        install_scope_view(&conn, "c", "").unwrap();
+
+        // Heuristic baseline: the single in-edge counts (1.0 × 1.0 = 1.0).
+        let heuristic = fan_in(&conn, target).unwrap();
+
+        // Oracle retargets the edge ONTO a DIFFERENT symbol: it is not an in-edge of S, so S's
+        // fan-in drops to nothing.
+        let to_other = HashMap::from([(edge, EdgeOracleEffect::Retarget(other))]);
+        assert!(
+            scoped_weighted_fan_in(&conn, target, &OracleContext { effects: Some(&to_other) })
+                .unwrap()
+                .is_none(),
+            "a retarget onto a DIFFERENT symbol must not count toward S's fan-in"
+        );
+
+        // Oracle retargets the edge back ONTO S itself: counts at the compiler tier, lifting the
+        // score above the heuristic and setting oracle_tier = compiler.
+        let to_self = HashMap::from([(edge, EdgeOracleEffect::Retarget(target))]);
+        let lifted =
+            scoped_weighted_fan_in(&conn, target, &OracleContext { effects: Some(&to_self) })
+                .unwrap()
+                .unwrap();
+        assert!(
+            lifted.score > heuristic.score,
+            "a retarget back onto S counts at the compiler tier: {lifted:?} vs {heuristic:?}"
+        );
+        assert_eq!(lifted.oracle_tier, Some(OracleTier::Compiler));
+    }
+
+    /// Acceptance invariant #2 (the critical cross-scope guard): the SAME symbol identity exists in
+    /// two scopes (two worktree overlays of the same file) with DIFFERENT incoming edges. The
+    /// enrichment must compute a DIFFERENT scoped-weighted-fan-in per active scope and must NOT
+    /// leak edges across scopes — it reads the active `files` view, nothing else. Modeled on
+    /// `worktree_package_roots_do_not_leak_across_scopes`.
+    #[test]
+    fn fan_in_does_not_leak_across_scopes() {
+        let conn = scoped_conn();
+        let wt_a = "/wt-a";
+        let wt_b = "/wt-b";
+        // Two worktree overlays of the same path (commit_sha empty, worktree set — the
+        // dirty-overlay shape `install_scope_view` selects on for the active worktree).
+        // Each carries its OWN copy of the same symbol identity `a::Thing`.
+        let file_a = add_file(&conn, "src/lib.rs", "", wt_a);
+        let file_b = add_file(&conn, "src/lib.rs", "", wt_b);
+        let thing_a = add_symbol(&conn, file_a, "Thing", "a::Thing");
+        let thing_b = add_symbol(&conn, file_b, "Thing", "a::Thing");
+        // Worktree A: THREE exact call in-edges into its Thing (3 × 1.0 = 3.0 ⇒ Medium).
+        for i in 0..3 {
+            let c = add_symbol(&conn, file_a, &format!("a{i}"), &format!("a::a{i}"));
+            add_edge(&conn, file_a, c, thing_a, "calls_name", "Exact");
+        }
+        // Worktree B: ONE exact call in-edge into its Thing (1 × 1.0 = 1.0 ⇒ Low).
+        let cb = add_symbol(&conn, file_b, "b0", "a::b0");
+        add_edge(&conn, file_b, cb, thing_b, "calls_name", "Exact");
+
+        // Active scope = worktree A: only A's edges are visible.
+        install_scope_view(&conn, "", wt_a).unwrap();
+        let a = fan_in(&conn, thing_a).unwrap();
+        assert_eq!(a.bucket, LoadBearingBucket::Medium, "A sees its 3 in-edges: {a:?}");
+        // B's symbol is OUT of scope here — its file isn't in A's `files` view, so its in-edges are
+        // invisible: querying B's symbol id under A's scope yields nothing.
+        assert!(fan_in(&conn, thing_b).is_none(), "B's symbol is invisible under A's scope");
+
+        // Switch active scope = worktree B: now only B's single edge is visible.
+        install_scope_view(&conn, "", wt_b).unwrap();
+        let b = fan_in(&conn, thing_b).unwrap();
+        assert_eq!(b.bucket, LoadBearingBucket::Low, "B sees its 1 in-edge: {b:?}");
+        assert!(
+            b.score < a.score,
+            "the same identity scores DIFFERENTLY per scope, no leak: A={a:?} B={b:?}"
+        );
+        assert!(fan_in(&conn, thing_a).is_none(), "A's symbol is invisible under B's scope");
+    }
+}

--- a/crates/rag-rat-core/src/query/mod.rs
+++ b/crates/rag-rat-core/src/query/mod.rs
@@ -5,6 +5,7 @@ pub mod grep_augment;
 pub mod impact;
 pub mod memory;
 pub mod orientation;
+pub mod pagerank;
 pub mod repo_brief;
 pub mod symbol;
 pub mod tree;

--- a/crates/rag-rat-core/src/query/mod.rs
+++ b/crates/rag-rat-core/src/query/mod.rs
@@ -3,6 +3,7 @@ pub mod graph;
 pub mod graph_meta;
 pub mod grep_augment;
 pub mod impact;
+pub mod load_bearing;
 pub mod memory;
 pub mod orientation;
 pub mod pagerank;

--- a/crates/rag-rat-core/src/query/pagerank.rs
+++ b/crates/rag-rat-core/src/query/pagerank.rs
@@ -19,6 +19,9 @@ const DAMPING: f64 = 0.85;
 const MAX_ITERS: usize = 100;
 /// L1-change convergence threshold: stop once the rank vector barely moves.
 const TOLERANCE: f64 = 1e-6;
+/// Hard cap on returned rows. Hydration is one point query per winner, so a hostile or careless
+/// `limit` (the MCP/CLI surface takes a `u32`) can't turn this into tens of thousands of lookups.
+const MAX_RESULTS: usize = 500;
 
 /// Per-edge-kind weight: structural dependencies (calls, impls) carry full importance; weaker
 /// associations (imports, containment) carry less. Unknown kinds default to `1.0`.
@@ -177,30 +180,38 @@ pub fn important_symbols(
 
     let scores = pagerank(symbol_ids.len(), &out_edges, personalize.as_deref());
 
-    // Top-`limit` indices by score.
+    // Top-`limit` indices by score. `sort_by` is stable, so equal scores keep insertion order →
+    // deterministic output for a fixed index. Clamp to `MAX_RESULTS` so the hydration loop below is
+    // bounded regardless of the caller's `limit`.
     let mut ranked: Vec<usize> = (0..symbol_ids.len()).collect();
     ranked.sort_by(|&a, &b| scores[b].partial_cmp(&scores[a]).unwrap_or(std::cmp::Ordering::Equal));
-    ranked.truncate(options.limit);
+    ranked.truncate(options.limit.min(MAX_RESULTS));
 
-    // Hydrate the winners with symbol metadata in one query.
+    // Hydrate the winners with symbol metadata. Joining `symbols` to the per-connection `files`
+    // scope view keeps hydration scope-consistent with the edge query: a winner whose file isn't in
+    // the active checkout drops out instead of emitting an empty path. Endpoints are active-scope
+    // by the edge re-resolution invariant, so this rarely fires — when it does, the result is
+    // shorter than `limit` rather than wrong.
     let mut out = Vec::with_capacity(ranked.len());
     for idx in ranked {
         let symbol_id = symbol_ids[idx];
-        let meta = conn
+        let row = conn
             .query_row(
-                "SELECT qualified_name, kind, file_id FROM symbols WHERE id = ?1",
+                "SELECT s.qualified_name, s.kind, f.path
+                 FROM symbols s
+                 JOIN files f ON f.id = s.file_id
+                 WHERE s.id = ?1",
                 [symbol_id],
                 |row| {
-                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, i64>(2)?))
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                    ))
                 },
             )
             .ok();
-        let Some((qualified_name, kind, file_id)) = meta else { continue };
-        let path = conn
-            .query_row("SELECT path FROM files WHERE id = ?1", [file_id], |row| {
-                row.get::<_, String>(0)
-            })
-            .unwrap_or_default();
+        let Some((qualified_name, kind, path)) = row else { continue };
         out.push(SymbolImportance { symbol_id, qualified_name, path, kind, score: scores[idx] });
     }
     Ok(out)
@@ -330,6 +341,69 @@ mod tests {
             important_symbols(&bare, ImportanceOptions { limit: 10, personalize_to: &[] })
                 .unwrap()
                 .is_empty()
+        );
+    }
+
+    /// Insert `n` symbols (`s1..sn`, ids `1..=n`) plus `edges` as `(from_id, to_id)` calls, all in
+    /// one file. Returns the connection ready for `important_symbols`.
+    fn graph_conn(n: usize, edges: &[(i64, i64)]) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
+             VALUES ('a.rs', 'rust', 'source', 'h', 0, 0)",
+            [],
+        )
+        .unwrap();
+        for i in 1..=n {
+            conn.execute(
+                "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte,
+                                     end_byte, signature, docs)
+                 VALUES (1, 'rust', ?1, ?2, 'function', 0, 10, NULL, NULL)",
+                params![format!("s{i}"), format!("a::s{i}")],
+            )
+            .unwrap();
+        }
+        for &(from, to) in edges {
+            conn.execute(
+                "INSERT INTO edges(source_file_id, from_symbol_id, to_symbol_id, to_name,
+                                   target_qualified_name, edge_kind, confidence)
+                 VALUES (1, ?1, ?2, 'x', 'a::x', 'calls_name', 'exact')",
+                params![from, to],
+            )
+            .unwrap();
+        }
+        conn
+    }
+
+    #[test]
+    fn limit_truncates_and_a_huge_limit_is_safe() {
+        let conn = graph_conn(3, &[(1, 3), (2, 3)]);
+        // `limit` truncates to fewer than the node count.
+        let one =
+            important_symbols(&conn, ImportanceOptions { limit: 1, personalize_to: &[] }).unwrap();
+        assert_eq!(one.len(), 1, "limit caps the result count");
+        // An absurd limit clamps to the node count via MAX_RESULTS — no panic, no overflow, no
+        // tens-of-thousands of point lookups.
+        let huge = important_symbols(&conn, ImportanceOptions {
+            limit: u32::MAX as usize,
+            personalize_to: &[],
+        })
+        .unwrap();
+        assert_eq!(huge.len(), 3, "bounded by the graph, never by the caller's limit");
+    }
+
+    #[test]
+    fn personalization_biases_the_db_ranking() {
+        // Two disjoint symmetric 2-cycles: {1↔2} and {3↔4}. Globally all four are balanced;
+        // personalizing toward symbol 1 must lift its cluster (1,2) above the other (3,4).
+        let conn = graph_conn(4, &[(1, 2), (2, 1), (3, 4), (4, 3)]);
+        let out =
+            important_symbols(&conn, ImportanceOptions { limit: 4, personalize_to: &[1] }).unwrap();
+        let top_two: Vec<&str> = out.iter().take(2).map(|s| s.qualified_name.as_str()).collect();
+        assert!(
+            top_two.iter().all(|q| *q == "a::s1" || *q == "a::s2"),
+            "personalized cluster ranks first: {out:?}"
         );
     }
 }

--- a/crates/rag-rat-core/src/query/pagerank.rs
+++ b/crates/rag-rat-core/src/query/pagerank.rs
@@ -36,6 +36,44 @@ fn edge_weight(kind: &str) -> f64 {
     }
 }
 
+/// Multiplier on [`edge_weight`] by the heuristic resolver's confidence in the edge
+/// (`EdgeConfidence` db strings). A name-only guess is a weak signal that a dependency exists, so
+/// it should flow less of the source's rank to that callee than a structurally-resolved call.
+/// Unknown values default to `1.0` (same defensive posture as [`edge_weight`]). A SCIP-verified
+/// edge bypasses this entirely and uses [`COMPILER_FACTOR`].
+fn confidence_factor(confidence: &str) -> f64 {
+    match confidence {
+        "Exact" => 1.0,
+        "Syntactic" => 0.85,
+        "NameOnly" => 0.4,
+        "Ambiguous" => 0.2,
+        _ => 1.0,
+    }
+}
+
+/// Confidence factor for an edge a SCIP oracle confirmed or resolved — above a heuristic `Exact`
+/// (`1.0`), so a compiler-verified dependency outranks a merely well-guessed one. Because PageRank
+/// normalizes each source node's out-weights, the bonus only changes the outcome at a *mixed*
+/// source (some edges compiler-verified, some heuristic), tilting that node's rank toward the
+/// verified callees; it is a no-op at a node whose edges are all the same tier.
+const COMPILER_FACTOR: f64 = 1.2;
+
+/// What a current, in-scope SCIP oracle verdict does to an edge during ranking, keyed by `edge_id`.
+/// Built by the query layer from `OracleResolutionKind` so this module stays free of oracle types.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum EdgeOracleEffect {
+    /// The real callee is out of corpus — a `resolved-external`, or a `contradict` the compiler
+    /// couldn't resolve to an in-corpus symbol. Drop the phantom in-repo edge from the graph.
+    Drop,
+    /// The compiler confirmed the heuristic target — keep it, but weight at [`COMPILER_FACTOR`].
+    Confirm,
+    /// The compiler resolved the edge to an in-corpus symbol id — retarget the edge there and
+    /// weight at [`COMPILER_FACTOR`]. Covers both an `upgrade` (of an unconfirmed edge) and an
+    /// in-corpus `contradict` (overriding a wrong heuristic target): in both cases the id is
+    /// the compiler's answer.
+    Retarget(i64),
+}
+
 /// One node's outgoing edges as `(target_index, weight)`. Index space is `0..n`.
 pub type Adjacency = Vec<Vec<(usize, f64)>>;
 
@@ -115,6 +153,10 @@ pub struct ImportanceOptions<'a> {
     /// Optional personalization seed — symbol ids to bias importance toward (the agent's changed /
     /// query symbols). Empty/none = global importance.
     pub personalize_to: &'a [i64],
+    /// Optional SCIP-oracle effects keyed by `edge_id` (current + in-scope verdicts). `None` = no
+    /// oracle run for this checkout → rank the heuristic graph with confidence weighting only. The
+    /// caller builds this so absent oracle data costs zero (no scan); see the query-layer wrapper.
+    pub oracle_effects: Option<&'a HashMap<i64, EdgeOracleEffect>>,
 }
 
 /// Compute weighted PageRank over the active checkout's resolved symbol→symbol edges and return the
@@ -126,17 +168,26 @@ pub fn important_symbols(
     options: ImportanceOptions<'_>,
 ) -> anyhow::Result<Vec<SymbolImportance>> {
     // Resolved symbol→symbol edges in the active checkout: both endpoints non-null, source file in
-    // the scope view. `edge_strings` resolves the edge-kind id to its name for weighting.
+    // the scope view. `edge_strings` resolves the edge-kind and confidence ids to their names — the
+    // kind sets the base weight, the confidence scales it (a name-only guess flows less rank than a
+    // structurally-resolved call). `d.id` keys the optional SCIP-oracle effect lookup.
     let mut stmt = conn.prepare(
-        "SELECT d.from_symbol_id, d.to_symbol_id, ek.value
+        "SELECT d.id, d.from_symbol_id, d.to_symbol_id, ek.value, cf.value
          FROM edges_data d
          JOIN files ON files.id = d.source_file_id
          JOIN edge_strings ek ON ek.id = d.edge_kind_id
+         JOIN edge_strings cf ON cf.id = d.confidence_id
          WHERE d.from_symbol_id IS NOT NULL AND d.to_symbol_id IS NOT NULL",
     )?;
     let rows = stmt
         .query_map([], |row| {
-            Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?, row.get::<_, String>(2)?))
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+            ))
         })?
         .collect::<Result<Vec<_>, _>>()?;
     if rows.is_empty() {
@@ -153,13 +204,23 @@ pub fn important_symbols(
         })
     };
     let mut out_edges: Adjacency = Vec::new();
-    for (from, to, kind) in &rows {
+    for (edge_id, from, to, kind, confidence) in &rows {
+        // Apply the SCIP verdict, if any: drop a contradicted/external edge entirely, retarget an
+        // upgrade to the compiler's resolved symbol, and weight a confirmed/upgraded edge at the
+        // compiler tier. Absent a verdict, fall back to heuristic confidence weighting.
+        let (to_id, weight) = match options.oracle_effects.and_then(|m| m.get(edge_id)) {
+            Some(EdgeOracleEffect::Drop) => continue,
+            Some(EdgeOracleEffect::Retarget(resolved)) =>
+                (*resolved, edge_weight(kind) * COMPILER_FACTOR),
+            Some(EdgeOracleEffect::Confirm) => (*to, edge_weight(kind) * COMPILER_FACTOR),
+            None => (*to, edge_weight(kind) * confidence_factor(confidence)),
+        };
         let from_idx = intern(*from, &mut index_of, &mut symbol_ids);
-        let to_idx = intern(*to, &mut index_of, &mut symbol_ids);
+        let to_idx = intern(to_id, &mut index_of, &mut symbol_ids);
         if out_edges.len() < symbol_ids.len() {
             out_edges.resize_with(symbol_ids.len(), Vec::new);
         }
-        out_edges[from_idx].push((to_idx, edge_weight(kind)));
+        out_edges[from_idx].push((to_idx, weight));
     }
     out_edges.resize_with(symbol_ids.len(), Vec::new);
 
@@ -228,6 +289,17 @@ mod tests {
         let mut idx: Vec<usize> = (0..scores.len()).collect();
         idx.sort_by(|&a, &b| scores[b].partial_cmp(&scores[a]).unwrap());
         idx
+    }
+
+    /// `ImportanceOptions` with no SCIP effects — the heuristic + confidence ranking path.
+    fn opts(limit: usize, personalize_to: &[i64]) -> ImportanceOptions<'_> {
+        ImportanceOptions { limit, personalize_to, oracle_effects: None }
+    }
+
+    /// Score of the symbol with `qualified_name` in a result set, or `0.0` when absent (a dropped /
+    /// never-interned node).
+    fn score_of(out: &[SymbolImportance], qualified_name: &str) -> f64 {
+        out.iter().find(|s| s.qualified_name == qualified_name).map_or(0.0, |s| s.score)
     }
 
     #[test]
@@ -327,8 +399,7 @@ mod tests {
             .unwrap();
         }
 
-        let out =
-            important_symbols(&conn, ImportanceOptions { limit: 10, personalize_to: &[] }).unwrap();
+        let out = important_symbols(&conn, opts(10, &[])).unwrap();
         assert!(!out.is_empty(), "graph has edges → results");
         assert_eq!(out[0].qualified_name, "a::hub", "the called hub ranks first: {out:?}");
         assert_eq!(out[0].path, "a.rs");
@@ -337,11 +408,7 @@ mod tests {
         // No resolved symbol→symbol edges → empty (not an error).
         let bare = Connection::open_in_memory().unwrap();
         schema::apply(&bare).unwrap();
-        assert!(
-            important_symbols(&bare, ImportanceOptions { limit: 10, personalize_to: &[] })
-                .unwrap()
-                .is_empty()
-        );
+        assert!(important_symbols(&bare, opts(10, &[])).unwrap().is_empty());
     }
 
     /// Insert `n` symbols (`s1..sn`, ids `1..=n`) plus `edges` as `(from_id, to_id)` calls, all in
@@ -380,16 +447,11 @@ mod tests {
     fn limit_truncates_and_a_huge_limit_is_safe() {
         let conn = graph_conn(3, &[(1, 3), (2, 3)]);
         // `limit` truncates to fewer than the node count.
-        let one =
-            important_symbols(&conn, ImportanceOptions { limit: 1, personalize_to: &[] }).unwrap();
+        let one = important_symbols(&conn, opts(1, &[])).unwrap();
         assert_eq!(one.len(), 1, "limit caps the result count");
         // An absurd limit clamps to the node count via MAX_RESULTS — no panic, no overflow, no
         // tens-of-thousands of point lookups.
-        let huge = important_symbols(&conn, ImportanceOptions {
-            limit: u32::MAX as usize,
-            personalize_to: &[],
-        })
-        .unwrap();
+        let huge = important_symbols(&conn, opts(u32::MAX as usize, &[])).unwrap();
         assert_eq!(huge.len(), 3, "bounded by the graph, never by the caller's limit");
     }
 
@@ -398,12 +460,141 @@ mod tests {
         // Two disjoint symmetric 2-cycles: {1↔2} and {3↔4}. Globally all four are balanced;
         // personalizing toward symbol 1 must lift its cluster (1,2) above the other (3,4).
         let conn = graph_conn(4, &[(1, 2), (2, 1), (3, 4), (4, 3)]);
-        let out =
-            important_symbols(&conn, ImportanceOptions { limit: 4, personalize_to: &[1] }).unwrap();
+        let out = important_symbols(&conn, opts(4, &[1])).unwrap();
         let top_two: Vec<&str> = out.iter().take(2).map(|s| s.qualified_name.as_str()).collect();
         assert!(
             top_two.iter().all(|q| *q == "a::s1" || *q == "a::s2"),
             "personalized cluster ranks first: {out:?}"
         );
+    }
+
+    /// Like [`graph_conn`] but each edge carries an explicit confidence (`EdgeConfidence::as_str`
+    /// casing, e.g. `"Exact"` / `"NameOnly"`); kind is always `calls_name`. Edge ids are `1..` in
+    /// insertion order, so a test can key an `oracle_effects` map by them.
+    fn conf_conn(n: usize, edges: &[(i64, i64, &str)]) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
+             VALUES ('a.rs', 'rust', 'source', 'h', 0, 0)",
+            [],
+        )
+        .unwrap();
+        for i in 1..=n {
+            conn.execute(
+                "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte,
+                                     end_byte, signature, docs)
+                 VALUES (1, 'rust', ?1, ?2, 'function', 0, 10, NULL, NULL)",
+                params![format!("s{i}"), format!("a::s{i}")],
+            )
+            .unwrap();
+        }
+        for &(from, to, confidence) in edges {
+            conn.execute(
+                "INSERT INTO edges(source_file_id, from_symbol_id, to_symbol_id, to_name,
+                                   target_qualified_name, edge_kind, confidence)
+                 VALUES (1, ?1, ?2, 'x', 'a::x', 'calls_name', ?3)",
+                params![from, to, confidence],
+            )
+            .unwrap();
+        }
+        conn
+    }
+
+    #[test]
+    fn confidence_factor_orders_by_certainty() {
+        assert!(confidence_factor("Exact") > confidence_factor("Syntactic"));
+        assert!(confidence_factor("Syntactic") > confidence_factor("NameOnly"));
+        assert!(confidence_factor("NameOnly") > confidence_factor("Ambiguous"));
+        assert_eq!(
+            confidence_factor("whatever"),
+            1.0,
+            "unknown confidence defaults to full weight"
+        );
+    }
+
+    #[test]
+    fn confidence_lifts_the_more_certain_dependency() {
+        // 1 calls 2 (Exact) and 3 (NameOnly), same kind → the exactly-resolved callee outranks the
+        // name-only guess purely on confidence.
+        let conn = conf_conn(3, &[(1, 2, "Exact"), (1, 3, "NameOnly")]);
+        let out = important_symbols(&conn, opts(10, &[])).unwrap();
+        assert!(
+            score_of(&out, "a::s2") > score_of(&out, "a::s3"),
+            "higher-confidence callee ranks higher: {out:?}"
+        );
+    }
+
+    #[test]
+    fn contradicted_edge_is_dropped_from_ranking() {
+        // 1 calls 2 (edge id 1) and 3 (edge id 2); the oracle contradicts 1→2. The phantom target
+        // gets no rank and falls out of the graph entirely; the real callee ranks first.
+        let conn = conf_conn(3, &[(1, 2, "Exact"), (1, 3, "Exact")]);
+        let effects = HashMap::from([(1_i64, EdgeOracleEffect::Drop)]);
+        let out = important_symbols(&conn, ImportanceOptions {
+            limit: 10,
+            personalize_to: &[],
+            oracle_effects: Some(&effects),
+        })
+        .unwrap();
+        assert_eq!(out[0].qualified_name, "a::s3", "the surviving callee ranks first: {out:?}");
+        assert!(
+            !out.iter().any(|s| s.qualified_name == "a::s2"),
+            "the contradicted-only target drops out of the graph: {out:?}"
+        );
+    }
+
+    #[test]
+    fn upgrade_retargets_rank_to_the_resolved_symbol() {
+        // 1 calls 2 heuristically (edge id 1), but the oracle upgrades the edge to resolve at 3.
+        // Rank flows to the compiler's target, not the heuristic guess.
+        let conn = conf_conn(3, &[(1, 2, "NameOnly")]);
+        let effects = HashMap::from([(1_i64, EdgeOracleEffect::Retarget(3))]);
+        let out = important_symbols(&conn, ImportanceOptions {
+            limit: 10,
+            personalize_to: &[],
+            oracle_effects: Some(&effects),
+        })
+        .unwrap();
+        assert_eq!(out[0].qualified_name, "a::s3", "rank flows to the retargeted symbol: {out:?}");
+        assert!(
+            !out.iter().any(|s| s.qualified_name == "a::s2"),
+            "the heuristic target gets no rank: {out:?}"
+        );
+    }
+
+    #[test]
+    fn confirm_overrides_low_heuristic_confidence() {
+        // 1 calls 2 (name_only, CONFIRMED, edge id 1) and 3 (name_only, no verdict, edge id 2).
+        // Confirm weights 1→2 at the compiler tier (above NameOnly), so 2 outranks 3.
+        let conn = conf_conn(3, &[(1, 2, "NameOnly"), (1, 3, "NameOnly")]);
+        let effects = HashMap::from([(1_i64, EdgeOracleEffect::Confirm)]);
+        let out = important_symbols(&conn, ImportanceOptions {
+            limit: 10,
+            personalize_to: &[],
+            oracle_effects: Some(&effects),
+        })
+        .unwrap();
+        assert!(
+            score_of(&out, "a::s2") > score_of(&out, "a::s3"),
+            "the confirmed edge outranks an equal-confidence unverified one: {out:?}"
+        );
+    }
+
+    #[test]
+    fn no_oracle_run_is_heuristic_confidence_only() {
+        // `None` effects and an empty effects map must rank identically — guards the CPU gate: an
+        // absent oracle introduces no behavioral dependency, it's just the confidence-weighted
+        // path.
+        let conn = conf_conn(3, &[(1, 2, "Exact"), (1, 3, "NameOnly")]);
+        let none = important_symbols(&conn, opts(10, &[])).unwrap();
+        let empty: HashMap<i64, EdgeOracleEffect> = HashMap::new();
+        let empty_map = important_symbols(&conn, ImportanceOptions {
+            limit: 10,
+            personalize_to: &[],
+            oracle_effects: Some(&empty),
+        })
+        .unwrap();
+        assert_eq!(none, empty_map, "None and an empty effects map rank identically");
     }
 }

--- a/crates/rag-rat-core/src/query/pagerank.rs
+++ b/crates/rag-rat-core/src/query/pagerank.rs
@@ -298,24 +298,31 @@ pub fn important_symbols(
     conn: &Connection,
     options: ImportanceOptions<'_>,
 ) -> anyhow::Result<RankedImportance> {
-    // Resolved symbol→symbol edges in the active checkout: both endpoints non-null, source file in
-    // the scope view. `edge_strings` resolves the edge-kind and confidence ids to their names — the
-    // kind sets the base weight, the confidence scales it (a name-only guess flows less rank than a
+    // Symbol→symbol edges in the active checkout whose SOURCE resolved, source file in the scope
+    // view. `edge_strings` resolves the edge-kind and confidence ids to their names — the kind sets
+    // the base weight, the confidence scales it (a name-only guess flows less rank than a
     // structurally-resolved call). `d.id` keys the optional SCIP-oracle effect lookup.
+    //
+    // We intentionally KEEP edges with a NULL target so a SCIP-oracle UPGRADE can still supply one:
+    // the compiler routinely resolves a `NameOnly`/unresolved heuristic edge (`to_symbol_id` NULL)
+    // to an in-corpus symbol, and that recovered call must contribute PageRank — filtering NULL
+    // targets here dropped exactly the upgrade cases the SCIP-aware ranking exists to capture (#142
+    // review P1). A NULL-target edge with no Retarget verdict carries no usable callee and is
+    // skipped in the loop below.
     let mut stmt = conn.prepare(
         "SELECT d.id, d.from_symbol_id, d.to_symbol_id, ek.value, cf.value
          FROM edges_data d
          JOIN files ON files.id = d.source_file_id
          JOIN edge_strings ek ON ek.id = d.edge_kind_id
          JOIN edge_strings cf ON cf.id = d.confidence_id
-         WHERE d.from_symbol_id IS NOT NULL AND d.to_symbol_id IS NOT NULL",
+         WHERE d.from_symbol_id IS NOT NULL",
     )?;
     let rows = stmt
         .query_map([], |row| {
             Ok((
                 row.get::<_, i64>(0)?,
                 row.get::<_, i64>(1)?,
-                row.get::<_, i64>(2)?,
+                row.get::<_, Option<i64>>(2)?,
                 row.get::<_, String>(3)?,
                 row.get::<_, String>(4)?,
             ))
@@ -338,13 +345,22 @@ pub fn important_symbols(
     for (edge_id, from, to, kind, confidence) in &rows {
         // Apply the SCIP verdict, if any: drop a contradicted/external edge entirely, retarget an
         // upgrade to the compiler's resolved symbol, and weight a confirmed/upgraded edge at the
-        // compiler tier. Absent a verdict, fall back to heuristic confidence weighting.
+        // compiler tier. Absent a verdict, fall back to heuristic confidence weighting. A Retarget
+        // supplies a target even when the heuristic edge had none (NULL `to`); Confirm and the
+        // heuristic path need an existing target, so a NULL-target edge without a Retarget is
+        // skipped (no usable callee).
         let (to_id, weight) = match options.oracle_effects.and_then(|m| m.get(edge_id)) {
             Some(EdgeOracleEffect::Drop) => continue,
             Some(EdgeOracleEffect::Retarget(resolved)) =>
                 (*resolved, edge_weight(kind) * COMPILER_FACTOR),
-            Some(EdgeOracleEffect::Confirm) => (*to, edge_weight(kind) * COMPILER_FACTOR),
-            None => (*to, edge_weight(kind) * confidence_factor(confidence)),
+            Some(EdgeOracleEffect::Confirm) => match to {
+                Some(to) => (*to, edge_weight(kind) * COMPILER_FACTOR),
+                None => continue,
+            },
+            None => match to {
+                Some(to) => (*to, edge_weight(kind) * confidence_factor(confidence)),
+                None => continue,
+            },
         };
         let from_idx = intern(*from, &mut index_of, &mut symbol_ids);
         let to_idx = intern(to_id, &mut index_of, &mut symbol_ids);
@@ -636,6 +652,56 @@ mod tests {
             .unwrap();
         }
         conn
+    }
+
+    #[test]
+    fn oracle_upgrade_ranks_a_recovered_null_target_edge() {
+        // #142 review P1: a NameOnly/unresolved heuristic edge has to_symbol_id NULL — only the
+        // SCIP verdict carries the resolved in-corpus target. The edge must still contribute
+        // PageRank via EdgeOracleEffect::Retarget, or compiler-recovered calls are dropped from the
+        // ranking (the very upgrade case SCIP-aware ranking exists to capture).
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
+             VALUES ('a.rs', 'rust', 'source', 'h', 0, 0)",
+            [],
+        )
+        .unwrap();
+        for i in 1..=2 {
+            conn.execute(
+                "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte,
+                                     end_byte, signature, docs)
+                 VALUES (1, 'rust', ?1, ?2, 'function', 0, 10, NULL, NULL)",
+                params![format!("s{i}"), format!("a::s{i}")],
+            )
+            .unwrap();
+        }
+        // A NameOnly edge from s1 the heuristic could NOT resolve (to_symbol_id NULL), edge id 1.
+        conn.execute(
+            "INSERT INTO edges(source_file_id, from_symbol_id, to_symbol_id, to_name,
+                               target_qualified_name, edge_kind, confidence)
+             VALUES (1, 1, NULL, 's2', 'a::s2', 'calls_name', 'NameOnly')",
+            [],
+        )
+        .unwrap();
+
+        // No verdict → the unresolved edge contributes no callee → empty graph (not an error).
+        assert!(important_symbols(&conn, opts(10, &[])).unwrap().symbols.is_empty());
+
+        // The compiler resolves the edge to s2 → s2 must now be ranked.
+        let effects = HashMap::from([(1_i64, EdgeOracleEffect::Retarget(2))]);
+        let out = important_symbols(&conn, ImportanceOptions {
+            limit: 10,
+            personalize_to: &[],
+            oracle_effects: Some(&effects),
+        })
+        .unwrap()
+        .symbols;
+        assert!(
+            out.iter().any(|s| s.qualified_name == "a::s2"),
+            "the oracle-recovered target must be ranked: {out:?}"
+        );
     }
 
     #[test]

--- a/crates/rag-rat-core/src/query/pagerank.rs
+++ b/crates/rag-rat-core/src/query/pagerank.rs
@@ -204,8 +204,13 @@ pub struct SeedSource {
     pub changed_paths: u64,
     /// Of `changed_paths`, how many were indexed in the active scope (git-diff only).
     pub indexed_paths: u64,
-    /// Symbol ids that became graph seeds.
+    /// Seeds that resolved to a symbol id in the active scope (before graph membership is
+    /// checked).
     pub symbol_seed_count: u64,
+    /// Of `symbol_seed_count`, how many actually became nodes in the ranked graph. When this is
+    /// `0` the seeds had no effect and the ranking is global despite the resolved seeds (#142
+    /// review).
+    pub effective_seed_count: u64,
     pub skipped: SkippedSeeds,
 }
 
@@ -250,6 +255,17 @@ pub const RANKING_HINT_RUN_ORACLE: &str =
 pub const RANKING_HINT_AUTO_RUN: &str =
     "heuristic ranking — compiler ranking refreshes in the background";
 
+/// The outcome of [`important_symbols`]: the ranked symbols plus how many of the requested seeds
+/// actually became nodes in the ranked graph. `effective_seed_count == 0` with a non-empty
+/// `personalize_to` means the seeds had NO effect (they resolved to symbols that are not endpoints
+/// of any resolved edge), so the ranking is really global — the caller must label it `Global`, not
+/// `PersonalizedToChanges`. Always `0` for an unseeded (global) query. (#142 review)
+#[derive(Debug, Clone, PartialEq)]
+pub struct RankedImportance {
+    pub symbols: Vec<SymbolImportance>,
+    pub effective_seed_count: u64,
+}
+
 /// A ranked load-bearing symbol.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct SymbolImportance {
@@ -281,7 +297,7 @@ pub struct ImportanceOptions<'a> {
 pub fn important_symbols(
     conn: &Connection,
     options: ImportanceOptions<'_>,
-) -> anyhow::Result<Vec<SymbolImportance>> {
+) -> anyhow::Result<RankedImportance> {
     // Resolved symbol→symbol edges in the active checkout: both endpoints non-null, source file in
     // the scope view. `edge_strings` resolves the edge-kind and confidence ids to their names — the
     // kind sets the base weight, the confidence scales it (a name-only guess flows less rank than a
@@ -306,7 +322,7 @@ pub fn important_symbols(
         })?
         .collect::<Result<Vec<_>, _>>()?;
     if rows.is_empty() {
-        return Ok(Vec::new());
+        return Ok(RankedImportance { symbols: Vec::new(), effective_seed_count: 0 });
     }
 
     // Map symbol ids to a dense 0..n index space.
@@ -340,18 +356,22 @@ pub fn important_symbols(
     out_edges.resize_with(symbol_ids.len(), Vec::new);
 
     // Personalization: 1.0 on each seed symbol that is present in the graph, else uniform.
+    // `effective_seed_count` is how many seeds actually landed as graph nodes — the caller uses it
+    // to avoid labeling a ranking "personalized" when no seed had any effect (#142 review).
+    let mut effective_seed_count: u64 = 0;
     let personalize: Option<Vec<f64>> = if options.personalize_to.is_empty() {
         None
     } else {
         let mut vector = vec![0.0_f64; symbol_ids.len()];
-        let mut any = false;
         for id in options.personalize_to {
-            if let Some(&idx) = index_of.get(id) {
+            if let Some(&idx) = index_of.get(id)
+                && vector[idx] == 0.0
+            {
                 vector[idx] = 1.0;
-                any = true;
+                effective_seed_count += 1;
             }
         }
-        any.then_some(vector)
+        (effective_seed_count > 0).then_some(vector)
     };
 
     let scores = pagerank(symbol_ids.len(), &out_edges, personalize.as_deref());
@@ -390,7 +410,7 @@ pub fn important_symbols(
         let Some((qualified_name, kind, path)) = row else { continue };
         out.push(SymbolImportance { symbol_id, qualified_name, path, kind, score: scores[idx] });
     }
-    Ok(out)
+    Ok(RankedImportance { symbols: out, effective_seed_count })
 }
 
 #[cfg(test)]
@@ -514,7 +534,7 @@ mod tests {
             .unwrap();
         }
 
-        let out = important_symbols(&conn, opts(10, &[])).unwrap();
+        let out = important_symbols(&conn, opts(10, &[])).unwrap().symbols;
         assert!(!out.is_empty(), "graph has edges → results");
         assert_eq!(out[0].qualified_name, "a::hub", "the called hub ranks first: {out:?}");
         assert_eq!(out[0].path, "a.rs");
@@ -523,7 +543,7 @@ mod tests {
         // No resolved symbol→symbol edges → empty (not an error).
         let bare = Connection::open_in_memory().unwrap();
         schema::apply(&bare).unwrap();
-        assert!(important_symbols(&bare, opts(10, &[])).unwrap().is_empty());
+        assert!(important_symbols(&bare, opts(10, &[])).unwrap().symbols.is_empty());
     }
 
     /// Insert `n` symbols (`s1..sn`, ids `1..=n`) plus `edges` as `(from_id, to_id)` calls, all in
@@ -562,11 +582,11 @@ mod tests {
     fn limit_truncates_and_a_huge_limit_is_safe() {
         let conn = graph_conn(3, &[(1, 3), (2, 3)]);
         // `limit` truncates to fewer than the node count.
-        let one = important_symbols(&conn, opts(1, &[])).unwrap();
+        let one = important_symbols(&conn, opts(1, &[])).unwrap().symbols;
         assert_eq!(one.len(), 1, "limit caps the result count");
         // An absurd limit clamps to the node count via MAX_RESULTS — no panic, no overflow, no
         // tens-of-thousands of point lookups.
-        let huge = important_symbols(&conn, opts(u32::MAX as usize, &[])).unwrap();
+        let huge = important_symbols(&conn, opts(u32::MAX as usize, &[])).unwrap().symbols;
         assert_eq!(huge.len(), 3, "bounded by the graph, never by the caller's limit");
     }
 
@@ -575,7 +595,9 @@ mod tests {
         // Two disjoint symmetric 2-cycles: {1↔2} and {3↔4}. Globally all four are balanced;
         // personalizing toward symbol 1 must lift its cluster (1,2) above the other (3,4).
         let conn = graph_conn(4, &[(1, 2), (2, 1), (3, 4), (4, 3)]);
-        let out = important_symbols(&conn, opts(4, &[1])).unwrap();
+        let ranked = important_symbols(&conn, opts(4, &[1])).unwrap();
+        assert_eq!(ranked.effective_seed_count, 1, "the seed (symbol 1) is a graph node");
+        let out = ranked.symbols;
         let top_two: Vec<&str> = out.iter().take(2).map(|s| s.qualified_name.as_str()).collect();
         assert!(
             top_two.iter().all(|q| *q == "a::s1" || *q == "a::s2"),
@@ -633,7 +655,7 @@ mod tests {
         // 1 calls 2 (Exact) and 3 (NameOnly), same kind → the exactly-resolved callee outranks the
         // name-only guess purely on confidence.
         let conn = conf_conn(3, &[(1, 2, "Exact"), (1, 3, "NameOnly")]);
-        let out = important_symbols(&conn, opts(10, &[])).unwrap();
+        let out = important_symbols(&conn, opts(10, &[])).unwrap().symbols;
         assert!(
             score_of(&out, "a::s2") > score_of(&out, "a::s3"),
             "higher-confidence callee ranks higher: {out:?}"
@@ -651,7 +673,8 @@ mod tests {
             personalize_to: &[],
             oracle_effects: Some(&effects),
         })
-        .unwrap();
+        .unwrap()
+        .symbols;
         assert_eq!(out[0].qualified_name, "a::s3", "the surviving callee ranks first: {out:?}");
         assert!(
             !out.iter().any(|s| s.qualified_name == "a::s2"),
@@ -670,7 +693,8 @@ mod tests {
             personalize_to: &[],
             oracle_effects: Some(&effects),
         })
-        .unwrap();
+        .unwrap()
+        .symbols;
         assert_eq!(out[0].qualified_name, "a::s3", "rank flows to the retargeted symbol: {out:?}");
         assert!(
             !out.iter().any(|s| s.qualified_name == "a::s2"),
@@ -689,7 +713,8 @@ mod tests {
             personalize_to: &[],
             oracle_effects: Some(&effects),
         })
-        .unwrap();
+        .unwrap()
+        .symbols;
         assert!(
             score_of(&out, "a::s2") > score_of(&out, "a::s3"),
             "the confirmed edge outranks an equal-confidence unverified one: {out:?}"
@@ -702,14 +727,15 @@ mod tests {
         // absent oracle introduces no behavioral dependency, it's just the confidence-weighted
         // path.
         let conn = conf_conn(3, &[(1, 2, "Exact"), (1, 3, "NameOnly")]);
-        let none = important_symbols(&conn, opts(10, &[])).unwrap();
+        let none = important_symbols(&conn, opts(10, &[])).unwrap().symbols;
         let empty: HashMap<i64, EdgeOracleEffect> = HashMap::new();
         let empty_map = important_symbols(&conn, ImportanceOptions {
             limit: 10,
             personalize_to: &[],
             oracle_effects: Some(&empty),
         })
-        .unwrap();
+        .unwrap()
+        .symbols;
         assert_eq!(none, empty_map, "None and an empty effects map rank identically");
     }
 }

--- a/crates/rag-rat-core/src/query/pagerank.rs
+++ b/crates/rag-rat-core/src/query/pagerank.rs
@@ -1,0 +1,335 @@
+//! Weighted PageRank over the symbol→symbol edge graph — "which symbols are load-bearing?" (#108).
+//!
+//! An edge `from_symbol → to_symbol` (a call, type reference, impl, …) flows importance to the
+//! callee, so a symbol many things depend on scores high. The pure [`pagerank`] core takes a
+//! weighted adjacency + an optional personalization vector (bias the random surfer toward the
+//! agent's changed/query symbols — the Aider repo-map trick) and is unit-tested without a DB;
+//! [`important_symbols`] builds the adjacency from the active checkout's resolved edges and returns
+//! the top-ranked symbols with metadata.
+
+use std::collections::HashMap;
+
+use rusqlite::Connection;
+use serde::Serialize;
+
+/// Standard random-restart probability — the surfer follows an edge with probability `DAMPING`,
+/// teleports with `1 - DAMPING`.
+const DAMPING: f64 = 0.85;
+/// Iteration cap; PageRank on these graphs converges well within this. Paired with `TOLERANCE`.
+const MAX_ITERS: usize = 100;
+/// L1-change convergence threshold: stop once the rank vector barely moves.
+const TOLERANCE: f64 = 1e-6;
+
+/// Per-edge-kind weight: structural dependencies (calls, impls) carry full importance; weaker
+/// associations (imports, containment) carry less. Unknown kinds default to `1.0`.
+fn edge_weight(kind: &str) -> f64 {
+    match kind {
+        "calls_name" | "implements" => 1.0,
+        "references_type" | "constructs" => 0.7,
+        "uses_macro" => 0.5,
+        "imports" | "exports" => 0.3,
+        "contains" => 0.2,
+        _ => 1.0,
+    }
+}
+
+/// One node's outgoing edges as `(target_index, weight)`. Index space is `0..n`.
+pub type Adjacency = Vec<Vec<(usize, f64)>>;
+
+/// Weighted PageRank. `out_edges[i]` is node `i`'s outgoing `(target, weight)` list. `personalize`,
+/// when `Some`, is the teleport distribution (need not be normalized; non-finite/negative entries
+/// are treated as 0, and an all-zero vector falls back to uniform); `None` = uniform teleport.
+/// Returns a score per node summing to ~1. Dangling nodes (no out-edges) redistribute their mass
+/// via the teleport vector each iteration, so rank is conserved.
+pub fn pagerank(n: usize, out_edges: &Adjacency, personalize: Option<&[f64]>) -> Vec<f64> {
+    if n == 0 {
+        return Vec::new();
+    }
+    // Teleport distribution: normalized personalization, or uniform.
+    let teleport: Vec<f64> = match personalize {
+        Some(p) if p.len() == n => {
+            let total: f64 = p.iter().filter(|x| x.is_finite() && **x > 0.0).sum();
+            if total > 0.0 {
+                p.iter().map(|x| if x.is_finite() && *x > 0.0 { x / total } else { 0.0 }).collect()
+            } else {
+                vec![1.0 / n as f64; n]
+            }
+        },
+        _ => vec![1.0 / n as f64; n],
+    };
+    // Pre-normalize each node's out-weights so they sum to 1 (a dangling node stays empty).
+    let normalized: Adjacency = out_edges
+        .iter()
+        .map(|edges| {
+            let total: f64 = edges.iter().map(|(_, w)| w.max(0.0)).sum();
+            if total > 0.0 {
+                edges.iter().map(|&(t, w)| (t, w.max(0.0) / total)).collect()
+            } else {
+                Vec::new()
+            }
+        })
+        .collect();
+
+    let mut rank = teleport.clone();
+    for _ in 0..MAX_ITERS {
+        // Mass stranded on dangling nodes this round, redistributed via teleport.
+        let dangling: f64 = (0..n).filter(|&i| normalized[i].is_empty()).map(|i| rank[i]).sum();
+        let mut next = vec![0.0_f64; n];
+        for (i, edges) in normalized.iter().enumerate() {
+            let share = DAMPING * rank[i];
+            for &(target, weight) in edges {
+                next[target] += share * weight;
+            }
+        }
+        let base = (1.0 - DAMPING) + DAMPING * dangling;
+        for i in 0..n {
+            next[i] += base * teleport[i];
+        }
+        let delta: f64 = (0..n).map(|i| (next[i] - rank[i]).abs()).sum();
+        rank = next;
+        if delta < TOLERANCE {
+            break;
+        }
+    }
+    rank
+}
+
+/// A ranked load-bearing symbol.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SymbolImportance {
+    pub symbol_id: i64,
+    pub qualified_name: String,
+    pub path: String,
+    pub kind: String,
+    /// PageRank score (higher = more depended-upon). Scores sum to ~1 across all graph nodes.
+    pub score: f64,
+}
+
+/// Options for [`important_symbols`].
+pub struct ImportanceOptions<'a> {
+    /// Max symbols to return.
+    pub limit: usize,
+    /// Optional personalization seed — symbol ids to bias importance toward (the agent's changed /
+    /// query symbols). Empty/none = global importance.
+    pub personalize_to: &'a [i64],
+}
+
+/// Compute weighted PageRank over the active checkout's resolved symbol→symbol edges and return the
+/// top-`limit` load-bearing symbols. Reads `edges_data` joined to the per-connection `files` scope
+/// view (active checkout only), using edges where both endpoints resolved to a symbol. Returns an
+/// empty list when the graph has no resolved symbol edges.
+pub fn important_symbols(
+    conn: &Connection,
+    options: ImportanceOptions<'_>,
+) -> anyhow::Result<Vec<SymbolImportance>> {
+    // Resolved symbol→symbol edges in the active checkout: both endpoints non-null, source file in
+    // the scope view. `edge_strings` resolves the edge-kind id to its name for weighting.
+    let mut stmt = conn.prepare(
+        "SELECT d.from_symbol_id, d.to_symbol_id, ek.value
+         FROM edges_data d
+         JOIN files ON files.id = d.source_file_id
+         JOIN edge_strings ek ON ek.id = d.edge_kind_id
+         WHERE d.from_symbol_id IS NOT NULL AND d.to_symbol_id IS NOT NULL",
+    )?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?, row.get::<_, String>(2)?))
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    if rows.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Map symbol ids to a dense 0..n index space.
+    let mut index_of: HashMap<i64, usize> = HashMap::new();
+    let mut symbol_ids: Vec<i64> = Vec::new();
+    let intern = |id: i64, index_of: &mut HashMap<i64, usize>, ids: &mut Vec<i64>| -> usize {
+        *index_of.entry(id).or_insert_with(|| {
+            ids.push(id);
+            ids.len() - 1
+        })
+    };
+    let mut out_edges: Adjacency = Vec::new();
+    for (from, to, kind) in &rows {
+        let from_idx = intern(*from, &mut index_of, &mut symbol_ids);
+        let to_idx = intern(*to, &mut index_of, &mut symbol_ids);
+        if out_edges.len() < symbol_ids.len() {
+            out_edges.resize_with(symbol_ids.len(), Vec::new);
+        }
+        out_edges[from_idx].push((to_idx, edge_weight(kind)));
+    }
+    out_edges.resize_with(symbol_ids.len(), Vec::new);
+
+    // Personalization: 1.0 on each seed symbol that is present in the graph, else uniform.
+    let personalize: Option<Vec<f64>> = if options.personalize_to.is_empty() {
+        None
+    } else {
+        let mut vector = vec![0.0_f64; symbol_ids.len()];
+        let mut any = false;
+        for id in options.personalize_to {
+            if let Some(&idx) = index_of.get(id) {
+                vector[idx] = 1.0;
+                any = true;
+            }
+        }
+        any.then_some(vector)
+    };
+
+    let scores = pagerank(symbol_ids.len(), &out_edges, personalize.as_deref());
+
+    // Top-`limit` indices by score.
+    let mut ranked: Vec<usize> = (0..symbol_ids.len()).collect();
+    ranked.sort_by(|&a, &b| scores[b].partial_cmp(&scores[a]).unwrap_or(std::cmp::Ordering::Equal));
+    ranked.truncate(options.limit);
+
+    // Hydrate the winners with symbol metadata in one query.
+    let mut out = Vec::with_capacity(ranked.len());
+    for idx in ranked {
+        let symbol_id = symbol_ids[idx];
+        let meta = conn
+            .query_row(
+                "SELECT qualified_name, kind, file_id FROM symbols WHERE id = ?1",
+                [symbol_id],
+                |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, i64>(2)?))
+                },
+            )
+            .ok();
+        let Some((qualified_name, kind, file_id)) = meta else { continue };
+        let path = conn
+            .query_row("SELECT path FROM files WHERE id = ?1", [file_id], |row| {
+                row.get::<_, String>(0)
+            })
+            .unwrap_or_default();
+        out.push(SymbolImportance { symbol_id, qualified_name, path, kind, score: scores[idx] });
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::params;
+
+    use super::*;
+    use crate::index::schema;
+
+    fn approx_desc(scores: &[f64]) -> Vec<usize> {
+        let mut idx: Vec<usize> = (0..scores.len()).collect();
+        idx.sort_by(|&a, &b| scores[b].partial_cmp(&scores[a]).unwrap());
+        idx
+    }
+
+    #[test]
+    fn ranks_a_hub_highest() {
+        // 0→2, 1→2, 3→2 : everyone depends on 2 → 2 is the most load-bearing.
+        let adj: Adjacency = vec![vec![(2, 1.0)], vec![(2, 1.0)], vec![], vec![(2, 1.0)]];
+        let scores = pagerank(4, &adj, None);
+        assert_eq!(
+            approx_desc(&scores)[0],
+            2,
+            "the hub everyone points at ranks first: {scores:?}"
+        );
+        let sum: f64 = scores.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-6, "rank is conserved (sums to 1): {sum}");
+    }
+
+    #[test]
+    fn weight_lifts_the_heavier_dependency() {
+        // 0 depends on both 1 and 2, but on 2 much more heavily → 2 outranks 1.
+        let adj: Adjacency = vec![vec![(1, 0.2), (2, 1.0)], vec![], vec![]];
+        let scores = pagerank(3, &adj, None);
+        assert!(scores[2] > scores[1], "heavier-weighted callee ranks higher: {scores:?}");
+    }
+
+    #[test]
+    fn dangling_node_conserves_rank() {
+        // 0→1, 1 dangling (no out-edges): mass must not leak — total stays ~1.
+        let adj: Adjacency = vec![vec![(1, 1.0)], vec![]];
+        let scores = pagerank(2, &adj, None);
+        let sum: f64 = scores.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-6, "dangling mass redistributed, not lost: {sum}");
+    }
+
+    #[test]
+    fn personalization_biases_toward_the_seed() {
+        // A symmetric two-node graph; personalizing toward node 0 must rank it above node 1.
+        let adj: Adjacency = vec![vec![(1, 1.0)], vec![(0, 1.0)]];
+        let global = pagerank(2, &adj, None);
+        assert!((global[0] - global[1]).abs() < 1e-6, "symmetric graph is balanced: {global:?}");
+        let biased = pagerank(2, &adj, Some(&[1.0, 0.0]));
+        assert!(biased[0] > biased[1], "personalization lifts the seed node: {biased:?}");
+    }
+
+    #[test]
+    fn empty_graph_is_empty() {
+        let empty: Adjacency = Vec::new();
+        assert!(pagerank(0, &empty, None).is_empty());
+    }
+
+    #[test]
+    fn invalid_personalization_falls_back_to_uniform() {
+        // Wrong length and all-zero personalization both degrade to uniform teleport (no panic).
+        let adj: Adjacency = vec![vec![(1, 1.0)], vec![(0, 1.0)]];
+        let wrong_len = pagerank(2, &adj, Some(&[1.0]));
+        let all_zero = pagerank(2, &adj, Some(&[0.0, 0.0]));
+        for scores in [wrong_len, all_zero] {
+            assert!((scores[0] - scores[1]).abs() < 1e-6, "uniform fallback: {scores:?}");
+        }
+    }
+
+    #[test]
+    fn edge_weight_downweights_weak_kinds() {
+        assert!(edge_weight("calls_name") > edge_weight("imports"));
+        assert!(edge_weight("implements") > edge_weight("contains"));
+        assert_eq!(edge_weight("something_new"), 1.0, "unknown kinds default to full weight");
+    }
+
+    #[test]
+    fn important_symbols_ranks_the_most_depended_on_first() {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
+             VALUES ('a.rs', 'rust', 'source', 'h', 0, 0)",
+            [],
+        )
+        .unwrap();
+        for (name, qname) in
+            [("caller_a", "a::caller_a"), ("caller_b", "a::caller_b"), ("hub", "a::hub")]
+        {
+            conn.execute(
+                "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte,
+                                     end_byte, signature, docs)
+                 VALUES (1, 'rust', ?1, ?2, 'function', 0, 10, NULL, NULL)",
+                params![name, qname],
+            )
+            .unwrap();
+        }
+        // symbol ids 1,2,3 in insertion order; both callers call the hub (id 3).
+        for from in [1_i64, 2] {
+            conn.execute(
+                "INSERT INTO edges(source_file_id, from_symbol_id, to_symbol_id, to_name,
+                                   target_qualified_name, edge_kind, confidence)
+                 VALUES (1, ?1, 3, 'hub', 'a::hub', 'calls_name', 'exact')",
+                params![from],
+            )
+            .unwrap();
+        }
+
+        let out =
+            important_symbols(&conn, ImportanceOptions { limit: 10, personalize_to: &[] }).unwrap();
+        assert!(!out.is_empty(), "graph has edges → results");
+        assert_eq!(out[0].qualified_name, "a::hub", "the called hub ranks first: {out:?}");
+        assert_eq!(out[0].path, "a.rs");
+        assert_eq!(out[0].kind, "function");
+
+        // No resolved symbol→symbol edges → empty (not an error).
+        let bare = Connection::open_in_memory().unwrap();
+        schema::apply(&bare).unwrap();
+        assert!(
+            important_symbols(&bare, ImportanceOptions { limit: 10, personalize_to: &[] })
+                .unwrap()
+                .is_empty()
+        );
+    }
+}

--- a/crates/rag-rat-core/src/query/pagerank.rs
+++ b/crates/rag-rat-core/src/query/pagerank.rs
@@ -135,6 +135,95 @@ pub fn pagerank(n: usize, out_edges: &Adjacency, personalize: Option<&[f64]>) ->
     rank
 }
 
+/// Which importance scale a result was computed on. The label string is the contract the spec's
+/// "three scales" table pins — agents read it to know whether they're looking at GLOBAL or
+/// PERSONALIZED PageRank, so they must NEVER be presented as comparable. (The third scale, "local
+/// structural load", is a different surface — `impact_surface`/search enrichment — not this tool.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportanceMode {
+    /// No (effective) seeds — live whole-graph PageRank.
+    Global,
+    /// Seeded (by name/id or auto-diff) — PageRank biased toward the working set.
+    PersonalizedToChanges,
+}
+
+impl ImportanceMode {
+    /// The agent-facing label. Matches the spec's three-scale table verbatim.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Global => "global PageRank importance",
+            Self::PersonalizedToChanges => "importance relative to your current changes",
+        }
+    }
+}
+
+impl Serialize for ImportanceMode {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.label())
+    }
+}
+
+/// How the personalization seed was produced. `git_diff` = auto-seeded from the working set (the
+/// MCP default); `explicit` = the caller named symbols (ids/names/paths).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SeedKind {
+    GitDiff,
+    Explicit,
+}
+
+/// Seeds that were considered but did not contribute a graph node, bucketed by why. Present only on
+/// an auto-diff seed (`git_diff`); an explicit seed reports its misses via `skipped.no_symbols` too
+/// but has no deleted/generated notion.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct SkippedSeeds {
+    /// Changed paths that no longer exist on disk (deleted/renamed-away) — git-diff only.
+    pub deleted: u64,
+    /// Changed paths classified as generated artifacts — git-diff only.
+    pub generated: u64,
+    /// Considered seeds (paths or names) that resolved to no symbol in the active scope.
+    pub no_symbols: u64,
+}
+
+/// Provenance of the personalization seed, present only when the result is seeded.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SeedSource {
+    pub kind: SeedKind,
+    /// Paths the seed considered (git-diff: changed paths; explicit: 0 — explicit seeds are names,
+    /// not paths).
+    pub changed_paths: u64,
+    /// Of `changed_paths`, how many were indexed in the active scope (git-diff only).
+    pub indexed_paths: u64,
+    /// Symbol ids that became graph seeds.
+    pub symbol_seed_count: u64,
+    pub skipped: SkippedSeeds,
+}
+
+/// The labeled result of an importance query: the mode + seed provenance carry more for an agent
+/// than the bare ranking does. This is the output contract for the CLI/MCP `important_symbols`
+/// surface (a labeled object, NOT a bare array).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ImportantSymbolsResult {
+    pub mode: ImportanceMode,
+    /// Present only when the result is seeded (mode = personalized OR a fall-through that still
+    /// computed a seed source). Absent for an un-seeded global query.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seed_source: Option<SeedSource>,
+    /// Present only on a fall-through to global from an intended seed (e.g. the diff had no
+    /// indexed symbols) — a short human-readable reason.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Diff paths considered, surfaced on a fall-through so the caller sees WHY the seed was
+    /// empty.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diff_paths_considered: Option<u64>,
+    /// Of the considered diff paths, how many yielded any indexed symbol — `0` on the no-symbols
+    /// fall-through.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diff_paths_with_symbols: Option<u64>,
+    pub symbols: Vec<SymbolImportance>,
+}
+
 /// A ranked load-bearing symbol.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct SymbolImportance {

--- a/crates/rag-rat-core/src/query/pagerank.rs
+++ b/crates/rag-rat-core/src/query/pagerank.rs
@@ -25,7 +25,11 @@ const MAX_RESULTS: usize = 500;
 
 /// Per-edge-kind weight: structural dependencies (calls, impls) carry full importance; weaker
 /// associations (imports, containment) carry less. Unknown kinds default to `1.0`.
-fn edge_weight(kind: &str) -> f64 {
+///
+/// `pub(crate)` so the scoped-weighted-fan-in enrichment (`query::load_bearing`, the third
+/// importance scale) reuses the SAME weight table — this is the single source of truth for
+/// edge-kind weighting; do not duplicate it.
+pub(crate) fn edge_weight(kind: &str) -> f64 {
     match kind {
         "calls_name" | "implements" => 1.0,
         "references_type" | "constructs" => 0.7,
@@ -41,7 +45,10 @@ fn edge_weight(kind: &str) -> f64 {
 /// it should flow less of the source's rank to that callee than a structurally-resolved call.
 /// Unknown values default to `1.0` (same defensive posture as [`edge_weight`]). A SCIP-verified
 /// edge bypasses this entirely and uses [`COMPILER_FACTOR`].
-fn confidence_factor(confidence: &str) -> f64 {
+///
+/// `pub(crate)` so `query::load_bearing` reuses the SAME confidence table for scoped-weighted
+/// fan-in — single source of truth; do not duplicate.
+pub(crate) fn confidence_factor(confidence: &str) -> f64 {
     match confidence {
         "Exact" => 1.0,
         "Syntactic" => 0.85,
@@ -56,7 +63,10 @@ fn confidence_factor(confidence: &str) -> f64 {
 /// normalizes each source node's out-weights, the bonus only changes the outcome at a *mixed*
 /// source (some edges compiler-verified, some heuristic), tilting that node's rank toward the
 /// verified callees; it is a no-op at a node whose edges are all the same tier.
-const COMPILER_FACTOR: f64 = 1.2;
+///
+/// `pub(crate)` so `query::load_bearing` weights an oracle-confirmed in-edge at the compiler tier
+/// in scoped-weighted fan-in — single source of truth; do not duplicate.
+pub(crate) const COMPILER_FACTOR: f64 = 1.2;
 
 /// What a current, in-scope SCIP oracle verdict does to an edge during ranking, keyed by `edge_id`.
 /// Built by the query layer from `OracleResolutionKind` so this module stays free of oracle types.

--- a/crates/rag-rat-core/src/query/pagerank.rs
+++ b/crates/rag-rat-core/src/query/pagerank.rs
@@ -231,8 +231,24 @@ pub struct ImportantSymbolsResult {
     /// fall-through.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diff_paths_with_symbols: Option<u64>,
+    /// One-line nudge surfaced ONLY when this ranking used heuristic data (no current SCIP-oracle
+    /// run for the checkout): compiler-grade ranking is available via `oracle run` (or, when
+    /// the background auto-fresh oracle is enabled, refreshing on its own). Absent once a run
+    /// exists.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ranking_hint: Option<String>,
     pub symbols: Vec<SymbolImportance>,
 }
+
+/// The heuristic-only nudge (no oracle run for the checkout). The static, config-unaware wording
+/// the core query emits; the CLI/MCP wrappers swap in [`RANKING_HINT_AUTO_RUN`] when `[oracle]
+/// auto_run` is on.
+pub const RANKING_HINT_RUN_ORACLE: &str =
+    "heuristic ranking — run `oracle run` for compiler-grade ranking";
+/// The heuristic-only nudge variant for when the background auto-fresh oracle is enabled: no manual
+/// action needed, compiler verdicts will arrive on the next throttled pass.
+pub const RANKING_HINT_AUTO_RUN: &str =
+    "heuristic ranking — compiler ranking refreshes in the background";
 
 /// A ranked load-bearing symbol.
 #[derive(Debug, Clone, PartialEq, Serialize)]

--- a/crates/rag-rat-core/src/query/symbol.rs
+++ b/crates/rag-rat-core/src/query/symbol.rs
@@ -29,6 +29,12 @@ pub struct SymbolHit {
     pub end_byte: i64,
     pub signature: Option<String>,
     pub docs: Option<String>,
+    /// LOCAL structural-load signal (scoped weighted fan-in) for this symbol — the THIRD
+    /// importance scale, NOT PageRank. Attached by the `symbol_lookup` enrichment pass. `None`
+    /// when the symbol has no in-edges in the active scope or wasn't enriched. See
+    /// `crate::query::load_bearing`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub importance: Option<crate::query::load_bearing::ImportanceEnrichment>,
 }
 
 #[derive(Debug, Serialize)]
@@ -397,6 +403,7 @@ fn symbol_hit_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SymbolHit> {
         end_byte: row.get(9)?,
         signature: row.get(10)?,
         docs: row.get(11)?,
+        importance: None,
     })
 }
 

--- a/crates/rag-rat-core/src/search/lexical.rs
+++ b/crates/rag-rat-core/src/search/lexical.rs
@@ -33,6 +33,13 @@ pub struct SearchHit {
     pub graph: Option<GraphEvidence>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub score_components: Option<ScoreComponents>,
+    /// LOCAL structural-load signal (scoped weighted fan-in) for the hit's symbol — the THIRD
+    /// importance scale, NOT PageRank. Attached by the search/`symbol_lookup` enrichment pass over
+    /// the symbol a hit resolves to (`chunks.symbol_path` → the active-scope symbol). `None` when
+    /// the hit has no symbol, the symbol has no in-edges in scope, or it wasn't enriched. See
+    /// `crate::query::load_bearing`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub importance: Option<crate::query::load_bearing::ImportanceEnrichment>,
 }
 
 #[derive(Debug, Clone, Default, Serialize)]
@@ -277,6 +284,7 @@ fn bm25_candidates(
             summary: snippet(&text, query),
             graph: None,
             score_components: None,
+            importance: None,
         })
     })?;
 
@@ -345,6 +353,7 @@ fn vector_candidates(
                     summary: snippet(&text, query),
                     graph: None,
                     score_components: None,
+                    importance: None,
                 },
                 blob,
             ))

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -454,6 +454,7 @@ mod tests {
             local_ai: LocalAiConfig { embedding: EmbeddingConfig::default() },
             watch: WatchConfig::default(),
             version_check: Default::default(),
+            oracle: Default::default(),
         };
         let ignore = IgnoreMatcher::compile(&root, &[]);
 
@@ -513,6 +514,7 @@ mod tests {
             local_ai: LocalAiConfig { embedding: EmbeddingConfig::default() },
             watch: WatchConfig::default(),
             version_check: Default::default(),
+            oracle: Default::default(),
         };
 
         let ignore = IgnoreMatcher::compile(&root, &[]);
@@ -583,6 +585,7 @@ mod tests {
             local_ai: LocalAiConfig { embedding: EmbeddingConfig::default() },
             watch: WatchConfig::default(),
             version_check: Default::default(),
+            oracle: Default::default(),
         };
 
         // Before: a source file under the subdir fires.

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -11,11 +11,11 @@ use rmcp::{ErrorData, RoleServer, ServerHandler, ServiceExt, tool, tool_handler,
 use serde_json::{Map, Value, json};
 
 use crate::tools::{
-    BlameChunkArgs, CompareGraphTextArgs, EmptyArgs, HealIndexArgs, ImpactArgs, LimitArgs,
-    MemoryCreateArgs, MemoryForCallPathArgs, MemoryForPathArgs, MemoryForSymbolArgs, MemoryIdArgs,
-    MemoryRebindArgs, MemorySearchArgs, MemoryUpdateArgs, PapertrailChunkArgs,
-    PapertrailCommitArgs, PathHistoryArgs, ReadChunkArgs, RepoBriefArgs, RepoClustersArgs,
-    SearchArgs, SymbolArgs, SymbolGraphArgs,
+    BlameChunkArgs, CompareGraphTextArgs, EmptyArgs, HealIndexArgs, ImpactArgs,
+    ImportantSymbolsArgs, LimitArgs, MemoryCreateArgs, MemoryForCallPathArgs, MemoryForPathArgs,
+    MemoryForSymbolArgs, MemoryIdArgs, MemoryRebindArgs, MemorySearchArgs, MemoryUpdateArgs,
+    PapertrailChunkArgs, PapertrailCommitArgs, PathHistoryArgs, ReadChunkArgs, RepoBriefArgs,
+    RepoClustersArgs, SearchArgs, SymbolArgs, SymbolGraphArgs,
 };
 
 #[derive(Clone)]
@@ -169,6 +169,18 @@ impl RagRatService {
         Parameters(args): Parameters<RepoClustersArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         self.call("repo_clusters", json!(args))
+    }
+
+    #[tool(
+        name = "important_symbols",
+        description = "Rank the most load-bearing symbols by weighted PageRank over the edge \
+                       graph — the spine to not reinvent or break. Run before editing."
+    )]
+    fn important_symbols(
+        &self,
+        Parameters(args): Parameters<ImportantSymbolsArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.call("important_symbols", json!(args))
     }
 
     #[tool(

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -78,7 +78,7 @@ pub(crate) fn call_tool_with_db(
         },
         "important_symbols" => {
             let args: ImportantSymbolsArgs = serde_json::from_value(arguments)?;
-            json!(db.important_symbols(args.limit as usize, &args.personalize)?)
+            json!(important_symbols_tool(db, args)?)
         },
         "ffi_surface" => {
             let args: LimitArgs = serde_json::from_value(arguments)?;
@@ -573,6 +573,32 @@ pub(crate) fn memory_for_symbol_tool(
         Ok(None) => Ok(Value::Null),
         Err(disambiguation) => Ok(json!(disambiguation)),
     }
+}
+
+/// `important_symbols` over MCP: auto-seeds from the current git diff when no `personalize` is
+/// given (the headline default). A single `"global"` selector (or an all-empty list) is the
+/// explicit override that forces whole-repo PageRank — distinct from "no arg", which auto-seeds.
+/// Returns the labeled [`ImportantSymbolsResult`] (mode + seed provenance), not a bare array.
+fn important_symbols_tool(
+    db: &IndexDatabase,
+    args: ImportantSymbolsArgs,
+) -> anyhow::Result<rag_rat_core::query::pagerank::ImportantSymbolsResult> {
+    let meaningful: Vec<String> =
+        args.personalize.into_iter().filter(|entry| !entry.trim().is_empty()).collect();
+    let force_global = meaningful.len() == 1 && meaningful[0].eq_ignore_ascii_case("global");
+    let (personalize, auto_seed_from_diff) = if force_global {
+        // Explicit global override: drop the selector, do NOT auto-seed.
+        (Vec::new(), false)
+    } else {
+        // No explicit seed → auto-seed from the diff (MCP default). With seeds → personalize.
+        let auto_seed = meaningful.is_empty();
+        (meaningful, auto_seed)
+    };
+    db.important_symbols(rag_rat_core::index::ImportantSymbolsRequest {
+        limit: args.limit as usize,
+        personalize,
+        auto_seed_from_diff,
+    })
 }
 
 pub(crate) fn symbol_selector(args: SymbolArgs) -> anyhow::Result<SymbolSelector> {

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -78,7 +78,7 @@ pub(crate) fn call_tool_with_db(
         },
         "important_symbols" => {
             let args: ImportantSymbolsArgs = serde_json::from_value(arguments)?;
-            json!(db.important_symbols(args.limit as usize, &[])?)
+            json!(db.important_symbols(args.limit as usize, &args.personalize)?)
         },
         "ffi_surface" => {
             let args: LimitArgs = serde_json::from_value(arguments)?;

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -76,6 +76,10 @@ pub(crate) fn call_tool_with_db(
                 min_cluster_size: args.min_cluster_size,
             })?)
         },
+        "important_symbols" => {
+            let args: ImportantSymbolsArgs = serde_json::from_value(arguments)?;
+            json!(db.important_symbols(args.limit as usize, &[])?)
+        },
         "ffi_surface" => {
             let args: LimitArgs = serde_json::from_value(arguments)?;
             json!(db.ffi_surface(args.limit)?)

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -233,11 +233,14 @@ pub struct ImportantSymbolsArgs {
     /// Max load-bearing symbols to return.
     #[serde(default = "default_repo_brief_limit")]
     pub limit: u32,
-    /// Symbol ids to bias importance toward (the symbols you're editing/querying) — the random
-    /// surfer teleports back to these, lifting the spine *they* depend on. Empty = global
-    /// importance.
+    /// Symbols to bias importance toward (the symbols you're editing/querying) — names, symbol
+    /// paths, or numeric ids; the random surfer teleports back to these, lifting the spine *they*
+    /// depend on. A numeric value is a raw symbol id; otherwise it's resolved by symbol path then
+    /// name (ambiguous/missing entries are skipped, never fatal). LEAVE EMPTY to auto-seed from
+    /// your current git diff (the default — "importance relative to your current changes").
+    /// Pass a single `"global"` to force whole-repo PageRank instead.
     #[serde(default)]
-    pub personalize: Vec<i64>,
+    pub personalize: Vec<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
@@ -736,8 +739,11 @@ pub fn description(name: &str) -> &'static str {
         "important_symbols" =>
             "Rank the most load-bearing symbols by weighted PageRank over the call/type/import \
              edge graph — what the rest of the code most depends on. Run before editing to see the \
-             spine you shouldn't reinvent or break. Pass `personalize` (symbol ids you're working \
-             on) to bias the ranking toward the spine those symbols depend on.",
+             spine you shouldn't reinvent or break. By DEFAULT (no `personalize`) it auto-seeds \
+             from your current git diff, returning importance relative to your current changes; \
+             pass `personalize` (names, symbol paths, or ids you're working on) to seed it \
+             explicitly, or a single `\"global\"` to force whole-repo PageRank. The result is a \
+             labeled object: `mode` (which scale), `seed_source` (seed provenance), and `symbols`.",
         "ffi_surface" =>
             "Find the FFI surface: #[uniffi::export] items, exported impl members, and generated \
              binding artifacts (detected by path). Empty in repos without FFI.",

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -233,6 +233,11 @@ pub struct ImportantSymbolsArgs {
     /// Max load-bearing symbols to return.
     #[serde(default = "default_repo_brief_limit")]
     pub limit: u32,
+    /// Symbol ids to bias importance toward (the symbols you're editing/querying) — the random
+    /// surfer teleports back to these, lifting the spine *they* depend on. Empty = global
+    /// importance.
+    #[serde(default)]
+    pub personalize: Vec<i64>,
 }
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
@@ -731,7 +736,8 @@ pub fn description(name: &str) -> &'static str {
         "important_symbols" =>
             "Rank the most load-bearing symbols by weighted PageRank over the call/type/import \
              edge graph — what the rest of the code most depends on. Run before editing to see the \
-             spine you shouldn't reinvent or break.",
+             spine you shouldn't reinvent or break. Pass `personalize` (symbol ids you're working \
+             on) to bias the ranking toward the spine those symbols depend on.",
         "ffi_surface" =>
             "Find the FFI surface: #[uniffi::export] items, exported impl members, and generated \
              binding artifacts (detected by path). Empty in repos without FFI.",

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -637,6 +637,20 @@ pub fn call_tool_for_config(
     {
         obj.insert("version".to_string(), serde_json::json!(version));
     }
+    // Mirror the CLI's `apply_auto_run_ranking_hint`: when the background auto-fresh oracle is on,
+    // rewrite `important_symbols`' heuristic nudge so it doesn't tell the agent to run `oracle run`
+    // by hand — compiler ranking refreshes on its own. The core query is config-unaware, so the
+    // rewrite happens here where the config is available. (#142 review)
+    if name == "important_symbols"
+        && config.oracle.auto_run
+        && let Some(obj) = result.as_object_mut()
+        && obj.get("ranking_hint").and_then(Value::as_str).is_some()
+    {
+        obj.insert(
+            "ranking_hint".to_string(),
+            serde_json::json!(rag_rat_core::query::pagerank::RANKING_HINT_AUTO_RUN),
+        );
+    }
     Ok(result)
 }
 

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -133,6 +133,7 @@ pub const TOOL_NAMES: &[&str] = &[
     "impact_surface",
     "repo_brief",
     "repo_clusters",
+    "important_symbols",
     "ffi_surface",
     "docs_for_symbol",
     "read_chunk",
@@ -225,6 +226,13 @@ pub struct RepoClustersArgs {
     pub include_memories: bool,
     #[serde(default = "default_min_cluster_size")]
     pub min_cluster_size: u32,
+}
+
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
+pub struct ImportantSymbolsArgs {
+    /// Max load-bearing symbols to return.
+    #[serde(default = "default_repo_brief_limit")]
+    pub limit: u32,
 }
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
@@ -720,6 +728,10 @@ pub fn description(name: &str) -> &'static str {
         "repo_clusters" =>
             "Map the repo into ownership clusters from path proximity, graph edges, and git \
              co-touch — a cheap overview of subsystems and their representative files.",
+        "important_symbols" =>
+            "Rank the most load-bearing symbols by weighted PageRank over the call/type/import \
+             edge graph — what the rest of the code most depends on. Run before editing to see the \
+             spine you shouldn't reinvent or break.",
         "ffi_surface" =>
             "Find the FFI surface: #[uniffi::export] items, exported impl members, and generated \
              binding artifacts (detected by path). Empty in repos without FFI.",
@@ -813,6 +825,7 @@ pub fn schema(name: &str) -> Value {
         "impact_surface" => schema_for::<ImpactArgs>(),
         "repo_brief" => schema_for::<RepoBriefArgs>(),
         "repo_clusters" => schema_for::<RepoClustersArgs>(),
+        "important_symbols" => schema_for::<ImportantSymbolsArgs>(),
         "ffi_surface" => schema_for::<LimitArgs>(),
         "read_chunk" => schema_for::<ReadChunkArgs>(),
         "git_history_for_path" | "github_refs_for_path" => schema_for::<PathHistoryArgs>(),

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -656,6 +656,34 @@ fn assert_symbol_selector_schema(tools: &[Value], name: &str) {
     }
 }
 
+#[test]
+fn mcp_rewrites_ranking_hint_when_auto_run_enabled() {
+    // #142 review: with `[oracle] auto_run` on and no oracle data yet, the important_symbols nudge
+    // must say compiler ranking refreshes in the background — not tell the agent to run `oracle
+    // run` by hand. The core query is config-unaware, so call_tool_for_config applies the
+    // rewrite.
+    let (root, mut config) = mixed_config();
+    IndexDatabase::rebuild(&config).unwrap();
+
+    config.oracle.auto_run = true;
+    let auto = call_tool_for_config(&config, "important_symbols", json!({"limit": 5})).unwrap();
+    assert_eq!(
+        auto["ranking_hint"].as_str(),
+        Some(rag_rat_core::query::pagerank::RANKING_HINT_AUTO_RUN),
+        "auto_run must rewrite the heuristic nudge: {auto:?}"
+    );
+
+    // With auto_run OFF the default manual-run nudge is preserved.
+    config.oracle.auto_run = false;
+    let manual = call_tool_for_config(&config, "important_symbols", json!({"limit": 5})).unwrap();
+    assert_eq!(
+        manual["ranking_hint"].as_str(),
+        Some(rag_rat_core::query::pagerank::RANKING_HINT_RUN_ORACLE),
+    );
+
+    std::fs::remove_dir_all(root).unwrap();
+}
+
 fn tool_schema<'a>(tools: &'a [Value], name: &str) -> &'a Value {
     tools
         .iter()

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -694,6 +694,7 @@ fn mixed_config() -> (PathBuf, Config) {
         local_ai: Default::default(),
         watch: Default::default(),
         version_check: Default::default(),
+        oracle: Default::default(),
     })
 }
 
@@ -715,6 +716,7 @@ fn markdown_config(text: &str) -> (PathBuf, Config) {
         local_ai: Default::default(),
         watch: Default::default(),
         version_check: Default::default(),
+        oracle: Default::default(),
     })
 }
 
@@ -733,6 +735,7 @@ fn rust_config(root: PathBuf) -> Config {
         local_ai: Default::default(),
         watch: Default::default(),
         version_check: Default::default(),
+        oracle: Default::default(),
     }
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -127,6 +127,28 @@ an error, and **never blocks** session start (reads only the cache; `rag-rat ver
 it synchronously on demand). The cache lives at `<index-dir>/version-check.json`. Set
 `enabled = false` to disable the feature entirely (no crates.io requests).
 
+`[oracle]` controls the background auto-fresh SCIP oracle — compiler-grade ranking that keeps itself
+current without a manual `rag-rat oracle run`. **Opt-in; off by default.** When enabled, the
+long-lived `rag-rat mcp` server runs the oracle for the active checkout when its index is *stale*
+(changed since the last run) and *quiet* (no recent edits), heavily throttled by two gates:
+
+```toml
+[oracle]
+auto_run = false                 # off by default — opt in explicitly
+auto_run_quiet_period_secs = 900   # run only after ~15 min with no index change (debounce)
+auto_run_min_interval_secs = 21600 # and at most once every 6 h (floor)
+```
+
+Both gates are required, not redundant: producing a `.scip` takes minutes while edits arrive in
+seconds, so debouncing a single burst is not enough — the quiet-period keeps a pass from firing
+mid-session, and the min-interval floor caps how often it can run regardless of churn. The pass runs
+on a **detached thread of the MCP server only** (never short-lived CLI/hook commands), uses the same
+lock-free production path as `oracle run` (the slow subprocess runs OUTSIDE the index write lock; only
+the brief join/write serializes), and is **fail-open** — any error, or a missing indexer tool, is a
+silent no-op, and the thread dies with the server process. While auto-fresh is on, `important-symbols`
+reports `heuristic ranking — compiler ranking refreshes in the background` instead of nudging you to
+run the oracle by hand.
+
 `rag-rat hooks install` writes generated `post-checkout`, `post-merge`, `post-rewrite`, and
 `post-commit` hooks to the current worktree's Git hooks directory. Those hooks call `rag-rat
 maintenance --max-seconds 30` in the background so branch switches, merges, rebases, and commits


### PR DESCRIPTION
## Summary

Implements confidence-aware, SCIP-aware **symbol importance ranking** (#108) and threads the resulting signal through the read surface so agents see "what's load-bearing here" inline.

### What's in it
- **PageRank importance** (`query/pagerank.rs`): confidence-weighted, SCIP-aware ranking over the call graph. Edge weights respect resolver confidence and oracle (compiler-tier) corroboration.
- **Load-bearing analysis** (`query/load_bearing.rs`): scoped weighted fan-in signal — the `importance: { label, signal, score, bucket }` block now attached to symbols/chunks in query output.
- **Enrichment on the read path**: `impact_surface` and `semantic_search` carry importance; `impact_surface` CALLEE neighbors are resolved via `to_symbol` first (correct enrichment).
- **`important_symbols`** MCP tool + CLI: clamped result count, scope-consistent hydration, personalization.
  - **Personalize by name**: a bare `--personalize <name>` seeds ALL in-scope symbols matching the name (teleport set), never skip-on-ambiguity.
  - **Auto-seed from git diff** (MCP): the MCP path seeds from the working-tree diff; CLI stays global — intentional divergence.
- **Opt-in background auto-fresh oracle** (`index/oracle/auto_run.rs`) + a ranking nudge for the #108 UX.

### Notes
- Importance shows as `label: "local structural load"`, `signal: "scoped weighted fan-in"`, with a `bucket` (critical/high/low).
- Config + docs updated (`docs/config.md`).

Closes #108.
