### PR TITLE
fix(mcp): read tools open read-only so a writer can't lock them out (#143)

### DIFF
--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -1,6 +1,15 @@
 use super::*;
 
 pub(crate) fn ensure_model_manifest(conn: &Connection) -> anyhow::Result<()> {
+    // Read-first: skip the (write-locking) DML entirely when the manifest already matches what we
+    // would write. `ensure_model_manifest` runs on EVERY `IndexDatabase::open*`, so issuing
+    // unconditional INSERT/UPDATE/DELETE here made every open — including read-only MCP tools —
+    // take the SQLite write lock, serializing them against the watcher and other clients and
+    // surfacing "database is locked" under concurrency (#143). After the first open establishes
+    // the manifest, every later open is a handful of SELECTs and never touches the write lock.
+    if model_manifest_is_current(conn)? {
+        return Ok(());
+    }
     remove_legacy_models(conn)?;
     upsert_model(conn, HASH_MODEL_ID, "embedding", Some(HASH_EMBEDDING_DIM), "hash", false)?;
     upsert_model(
@@ -21,6 +30,47 @@ pub(crate) fn ensure_model_manifest(conn: &Connection) -> anyhow::Result<()> {
     )?;
     normalize_embedding_model_versions(conn)?;
     Ok(())
+}
+
+/// Read-only test of whether `ensure_model_manifest` would be a no-op — i.e. the manifest is
+/// already in its target state. Mirrors exactly the three writes in `ensure_model_manifest`:
+/// no legacy model rows linger, all three current models are present (`upsert_model` is
+/// `ON CONFLICT DO NOTHING`, so presence is the only condition), and no `chunk_embeddings` row
+/// still carries the pre-normalization `'v1'` model_version. Used both to short-circuit the open
+/// write path (#143) and to let the read-only MCP open refuse to serve when a manifest write is
+/// still owed (falling back to the read-write open, which heals once).
+pub(crate) fn model_manifest_is_current(conn: &Connection) -> anyhow::Result<bool> {
+    for model_id in LEGACY_MODEL_IDS {
+        let lingering: bool = conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM ai_models WHERE model_id = ?1)
+                 OR EXISTS(SELECT 1 FROM chunk_embeddings WHERE model_id = ?1)
+                 OR EXISTS(SELECT 1 FROM index_meta WHERE key = ?2 AND value = ?1)",
+            params![model_id, ACTIVE_EMBEDDING_MODEL_META],
+            |row| row.get(0),
+        )?;
+        if lingering {
+            return Ok(false);
+        }
+    }
+    for model_id in [HASH_MODEL_ID, FASTEMBED_MODEL_ID, MODEL2VEC_MODEL_ID] {
+        let present: bool = conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM ai_models WHERE model_id = ?1)",
+            params![model_id],
+            |row| row.get(0),
+        )?;
+        if !present {
+            return Ok(false);
+        }
+    }
+    let stale_version: bool = conn.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM chunk_embeddings
+             WHERE model_version = 'v1' AND model_id IN (?1, ?2)
+         )",
+        params![HASH_MODEL_ID, FASTEMBED_MODEL_ID],
+        |row| row.get(0),
+    )?;
+    Ok(!stale_version)
 }
 
 pub(crate) fn remove_legacy_models(conn: &Connection) -> anyhow::Result<()> {
@@ -771,5 +821,61 @@ pub(crate) fn install_model2vec_model(conn: &Connection, model_id: &str) -> anyh
             params![model_id, MODEL2VEC_MISSING_FEATURE_MESSAGE],
         )?;
         anyhow::bail!("{}", MODEL2VEC_MISSING_FEATURE_MESSAGE)
+    }
+}
+
+#[cfg(test)]
+mod manifest_idempotence_tests {
+    use super::*;
+    use crate::storage::IndexConnection;
+
+    // #143: `ensure_model_manifest` runs on every `IndexDatabase::open*`. It must be a no-op (no
+    // write lock) once the manifest is current, or every read tool serializes on the SQLite writer.
+    #[test]
+    fn ensure_model_manifest_does_not_write_when_already_current() {
+        let dir = std::env::temp_dir().join(format!("ragrat-manifest-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let db = dir.join("index.db");
+
+        // First open establishes the manifest (a write); afterward the read-only check sees it.
+        {
+            let rw = IndexConnection::open(&db).unwrap();
+            crate::index::schema::apply(rw.connection()).unwrap();
+            assert!(
+                !model_manifest_is_current(rw.connection()).unwrap(),
+                "a freshly applied schema has no model rows yet"
+            );
+            ensure_model_manifest(rw.connection()).unwrap();
+            assert!(model_manifest_is_current(rw.connection()).unwrap());
+        }
+
+        // A current manifest means ensure_model_manifest issues NO DML — prove it by running it on
+        // a read-only connection, which would error if any INSERT/UPDATE/DELETE executed.
+        {
+            let ro = IndexConnection::open_read_only_blocking(&db).unwrap();
+            assert!(model_manifest_is_current(ro.connection()).unwrap());
+            ensure_model_manifest(ro.connection())
+                .expect("a current manifest must not write on a read-only connection");
+        }
+
+        // A lingering legacy model row flips the check back to "needs work".
+        {
+            let rw = IndexConnection::open(&db).unwrap();
+            rw.connection()
+                .execute(
+                    "INSERT INTO ai_models(model_id, capability, embedding_dim, runtime, \
+                     installed, disabled, status, installed_at_ms) VALUES (?1, 'embedding', 384, \
+                     'hash', 0, 0, 'MissingModel', NULL)",
+                    params![LEGACY_MODEL_IDS[0]],
+                )
+                .unwrap();
+            assert!(
+                !model_manifest_is_current(rw.connection()).unwrap(),
+                "a lingering legacy model must require a manifest write"
+            );
+        }
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -69,6 +69,51 @@ impl IndexDatabase {
         Ok(db)
     }
 
+    /// Open the index **read-only** for a pure-read tool, returning `None` when the index still
+    /// owes a write to be brought current. A `SQLITE_OPEN_READ_ONLY` connection can never acquire
+    /// the main write lock, so a read served through it is structurally immune to being locked out
+    /// by a concurrent writer (the watcher, a heal, another client) — the fix for the intermittent
+    /// "database is locked" under concurrent MCP clients (#143). Unlike `open_config` it performs
+    /// NO on-open heal writes (`ensure_model_manifest` / `ensure_graph_index_current`).
+    ///
+    /// Returns `Ok(None)` — caller falls back to the read-write `open_config`, which heals once and
+    /// after which reads are lock-free again — when any of these is true:
+    /// - the DB has never been opened for write (read-only open errors),
+    /// - the schema is not `Compatible` (a forward migrate is owed; that is a write),
+    /// - the graph index is stale (`ensure_graph_index_current` would rebuild — a write),
+    /// - the model manifest is not yet current (`ensure_model_manifest` would write).
+    ///
+    /// The temp-scope view (`set_context` → `install_scope_view`) is still installed: it writes
+    /// only the per-connection `temp.*` database, which is writable even on a read-only main DB.
+    pub fn try_open_config_read_only(config: &Config) -> anyhow::Result<Option<Self>> {
+        let mut storage = match IndexConnection::open_read_only_blocking(&config.database) {
+            Ok(storage) => storage,
+            // Never opened for write yet (no file / no WAL) — let the read-write path create it.
+            Err(_) => return Ok(None),
+        };
+        if schema::status(storage.connection())?.state != schema::SchemaState::Compatible {
+            return Ok(None);
+        }
+        if meta_for(storage.connection(), "graph_index_version")?.as_deref()
+            != Some(GRAPH_INDEX_VERSION)
+        {
+            return Ok(None);
+        }
+        if !ai::model_manifest_is_current(storage.connection())? {
+            return Ok(None);
+        }
+        storage.set_source_root(config.root.clone());
+        let (commit_sha, worktree_id) = resolve_git_context(&config.root);
+        let mut db = Self {
+            storage,
+            active_commit_sha: String::new(),
+            active_worktree_id: String::new(),
+            github: github::GitHubContext::from_gh(),
+        };
+        db.set_context(&commit_sha, &worktree_id)?;
+        Ok(Some(db))
+    }
+
     /// Set the GitHub repo context explicitly (tests / non-gh callers), so the library never
     /// shells out to `gh`.
     pub fn set_github_context(&mut self, default_repo: Option<&str>, gh_available: bool) {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -7631,3 +7631,46 @@ fn incremental_pass_heals_stale_overlay_rows() {
 
     fs::remove_dir_all(root).unwrap();
 }
+
+#[test]
+fn read_only_open_serves_current_index_and_declines_when_heal_is_owed() {
+    // #143: a pure-read MCP tool opens the index read-only, so a concurrent writer (watcher, heal,
+    // another client) can never lock it out. A current index is served read-only (Some) and its
+    // connection cannot write the main DB; when a heal write is still owed (here a stale
+    // graph_index_version), the read path declines (None) so the caller falls back to the
+    // read-write open that heals — after which reads are lock-free again.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn ro_anchor() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    IndexDatabase::rebuild(&config).unwrap();
+
+    let ro = IndexDatabase::try_open_config_read_only(&config)
+        .unwrap()
+        .expect("a current index must be served read-only");
+    assert!(
+        !ro.symbols("ro_anchor", Some(Language::Rust), 10).unwrap().is_empty(),
+        "the read-only connection must answer queries"
+    );
+    assert!(
+        ro.storage
+            .connection()
+            .execute("INSERT INTO index_meta(key, value) VALUES ('ro_probe', 'x')", [])
+            .is_err(),
+        "a read-only tool connection must not be able to write the main DB"
+    );
+    drop(ro);
+
+    // Mark the graph index stale (a heal write is now owed). open() already ran and left it
+    // current, so set it afterward; the read-only path does not heal, so it must decline.
+    let db = IndexDatabase::open(&config.database).unwrap();
+    db.set_meta("graph_index_version", "0").unwrap();
+    drop(db);
+    assert!(
+        IndexDatabase::try_open_config_read_only(&config).unwrap().is_none(),
+        "a stale graph index owes a heal write → the read-only path must decline"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}

--- a/crates/rag-rat-core/src/storage.rs
+++ b/crates/rag-rat-core/src/storage.rs
@@ -34,12 +34,29 @@ impl IndexConnection {
     /// the file. WAL databases serve concurrent read-only opens; a DB that has never been
     /// opened for write errors here, which callers treat as "no context".
     pub fn open_read_only(path: &Path) -> anyhow::Result<Self> {
+        Self::open_read_only_with_busy_timeout(path, std::time::Duration::from_millis(100))
+    }
+
+    /// Read-only open that waits out a concurrent writer (the watcher mid-pass, a lazy heal)
+    /// instead of failing fast. Used by the MCP read tools: a `SQLITE_OPEN_READ_ONLY` connection
+    /// can never acquire the main write lock, so a served read is structurally immune to being
+    /// locked out by a writer — and the longer busy_timeout only matters for the brief WAL
+    /// checkpoint window. See [#143]. The 100ms `open_read_only` stays fast for the latency-
+    /// critical grep-augment hook, which prefers "no context" over blocking.
+    pub fn open_read_only_blocking(path: &Path) -> anyhow::Result<Self> {
+        Self::open_read_only_with_busy_timeout(path, std::time::Duration::from_secs(5))
+    }
+
+    fn open_read_only_with_busy_timeout(
+        path: &Path,
+        busy_timeout: std::time::Duration,
+    ) -> anyhow::Result<Self> {
         use rusqlite::OpenFlags;
         let conn = Connection::open_with_flags(
             path,
             OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
         )?;
-        conn.busy_timeout(std::time::Duration::from_millis(100))?;
+        conn.busy_timeout(busy_timeout)?;
         Ok(Self { conn, database_path: path.to_path_buf(), source_root: None })
     }
 

--- a/crates/rag-rat-core/src/storage.rs
+++ b/crates/rag-rat-core/src/storage.rs
@@ -11,6 +11,22 @@ pub struct StorageStatus {
     pub fts5_available: bool,
 }
 
+/// True when `err`'s chain contains a SQLite read-only violation (`SQLITE_READONLY`). The MCP read
+/// path opens read tools on a read-only connection (#143), but a few "read" tools still WRITE on a
+/// cold path — `semantic_search` heals stale FTS, `read_chunk` heals a stale/deleted file,
+/// `git_blame_chunk` fills the blame cache on a miss. That surfaces as this error; the dispatcher
+/// uses it to retry the call on a read-write connection (which also performs the heal). Walks the
+/// full `anyhow` cause chain because the rusqlite error is wrapped by the time it reaches the
+/// caller.
+pub fn is_readonly_violation(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<rusqlite::Error>(),
+            Some(rusqlite::Error::SqliteFailure(e, _)) if e.code == rusqlite::ErrorCode::ReadOnly
+        )
+    })
+}
+
 #[derive(Debug)]
 pub struct IndexConnection {
     conn: Connection,
@@ -144,5 +160,34 @@ mod tests {
     fn open_read_only_fails_cleanly_when_database_missing() {
         let missing = std::env::temp_dir().join("ragrat-ro-missing/never-created.db");
         assert!(IndexConnection::open_read_only(&missing).is_err());
+    }
+
+    #[test]
+    fn is_readonly_violation_flags_only_sqlite_readonly_errors() {
+        let dir = std::env::temp_dir().join(format!("ragrat-roviol-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let db = dir.join("index.db");
+        {
+            let rw = IndexConnection::open(&db).unwrap();
+            crate::index::schema::apply(rw.connection()).unwrap();
+        }
+        let ro = IndexConnection::open_read_only(&db).unwrap();
+
+        // A write through a read-only connection → SQLITE_READONLY → flagged (the dispatcher's
+        // retry-on-read-write signal, #143 review).
+        let write_err: anyhow::Error = ro
+            .connection()
+            .execute("INSERT INTO index_meta(key, value) VALUES ('x', 'y')", [])
+            .unwrap_err()
+            .into();
+        assert!(is_readonly_violation(&write_err), "a write on a read-only conn must be flagged");
+
+        // A different failure (a syntax error) must NOT be mistaken for a read-only violation, or
+        // the dispatcher would mask real errors behind a needless read-write retry.
+        let syntax_err: anyhow::Error =
+            ro.connection().execute("THIS IS NOT SQL", []).unwrap_err().into();
+        assert!(!is_readonly_violation(&syntax_err), "a non-readonly error must not be flagged");
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -623,21 +623,33 @@ pub fn call_tool_for_config(
     name: &str,
     arguments: Value,
 ) -> anyhow::Result<Value> {
-    // Read tools open read-only (never take the write lock); fall back to the read-write open only
-    // when the index still owes a heal/migrate write. Write tools always open read-write.
-    let db = if is_read_only_tool(name) {
-        match IndexDatabase::try_open_config_read_only(config)? {
-            Some(db) => db,
-            None => IndexDatabase::open_config(config)?,
+    // Read tools run on a lock-free read-only connection (#143). Two fall-backs to the read-write
+    // open: (1) `try_open_config_read_only` returns `None` when the index still owes a heal/migrate
+    // write; (2) a handful of read tools lazily WRITE on a cold path (`semantic_search` heals stale
+    // FTS, `read_chunk` heals a stale/deleted file, `git_blame_chunk` fills the blame cache), which
+    // fails on the read-only connection with `SQLITE_READONLY` — we detect that and retry the whole
+    // call read-write (which performs the heal). The warm path never writes, so it stays lock-free.
+    if is_read_only_tool(name)
+        && let Some(db) = IndexDatabase::try_open_config_read_only(config)?
+    {
+        match call_tool_with_db(&db, name, arguments.clone()) {
+            Ok(result) => return finalize_tool_result(config, name, result),
+            Err(err) if rag_rat_core::storage::is_readonly_violation(&err) => {
+                // A lazy write hit the read-only connection — fall through to the read-write open.
+            },
+            Err(err) => return Err(err),
         }
-    } else {
-        IndexDatabase::open_config(config)?
-    };
-    let mut result = call_tool_with_db(&db, name, arguments)?;
-    // Surface the crates.io version status on `index_status` so an agent can see (and relay) when a
-    // newer rag-rat is published. Read-only: it reads the cached check (refreshed out of band),
-    // never the network, so the tool stays fast. Omitted entirely when version checking is
-    // disabled.
+    }
+    let db = IndexDatabase::open_config(config)?;
+    let result = call_tool_with_db(&db, name, arguments)?;
+    finalize_tool_result(config, name, result)
+}
+
+/// Post-process a tool result before returning it. Currently only `index_status`: surface the
+/// crates.io version status so an agent can see (and relay) when a newer rag-rat is published.
+/// Read-only — it reads the cached check (refreshed out of band), never the network, so the tool
+/// stays fast; omitted entirely when version checking is disabled.
+fn finalize_tool_result(config: &Config, name: &str, mut result: Value) -> anyhow::Result<Value> {
     if name == "index_status"
         && let Some(version) = rag_rat_core::version_check::cached_status(
             config.version_check.enabled,

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -601,12 +601,38 @@ pub fn call_tool(database: &Path, name: &str, arguments: Value) -> anyhow::Resul
     call_tool_with_db(&db, name, arguments)
 }
 
+/// Tools that only read the index. They open a read-only connection so a concurrent writer can
+/// never lock them out (#143). This is a writer DENY-list, not a reader allow-list, on purpose: a
+/// newly added read tool is read-only by default (worst case: it falls back to a read-write open).
+/// Every tool listed here mutates the index — keep it in sync with the write handlers in
+/// `handlers.rs` (`tool_classification_covers_every_tool` guards that no tool is missed).
+fn is_read_only_tool(name: &str) -> bool {
+    !matches!(
+        name,
+        "heal_index"
+            | "memory_create"
+            | "memory_rebind"
+            | "memory_update"
+            | "memory_mark_obsolete"
+            | "memory_validate"
+    )
+}
+
 pub fn call_tool_for_config(
     config: &Config,
     name: &str,
     arguments: Value,
 ) -> anyhow::Result<Value> {
-    let db = IndexDatabase::open_config(config)?;
+    // Read tools open read-only (never take the write lock); fall back to the read-write open only
+    // when the index still owes a heal/migrate write. Write tools always open read-write.
+    let db = if is_read_only_tool(name) {
+        match IndexDatabase::try_open_config_read_only(config)? {
+            Some(db) => db,
+            None => IndexDatabase::open_config(config)?,
+        }
+    } else {
+        IndexDatabase::open_config(config)?
+    };
     let mut result = call_tool_with_db(&db, name, arguments)?;
     // Surface the crates.io version status on `index_status` so an agent can see (and relay) when a
     // newer rag-rat is published. Read-only: it reads the cached check (refreshed out of band),

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -740,3 +740,30 @@ fn unique_temp_root() -> PathBuf {
     let id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     std::env::temp_dir().join(format!("rag-rat-mcp-test-{}-{id}", std::process::id()))
 }
+
+#[test]
+fn read_only_classification_covers_every_tool_and_denies_writers() {
+    // #143: the read-only fast path must classify EVERY tool, and exactly the mutating tools must
+    // be denied read-only access. Drift either lock-contends a read tool (slow) or hands a write
+    // tool a read-only connection (runtime failure).
+    const WRITERS: &[&str] = &[
+        "heal_index",
+        "memory_create",
+        "memory_rebind",
+        "memory_update",
+        "memory_mark_obsolete",
+        "memory_validate",
+    ];
+    for writer in WRITERS {
+        assert!(TOOL_NAMES.contains(writer), "writer {writer} is not a registered tool");
+        assert!(!is_read_only_tool(writer), "{writer} mutates the index — must not be read-only");
+    }
+    for name in TOOL_NAMES {
+        let expected_read_only = !WRITERS.contains(name);
+        assert_eq!(
+            is_read_only_tool(name),
+            expected_read_only,
+            "tool {name} is misclassified for the read-only open path"
+        );
+    }
+}

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -742,6 +742,35 @@ fn unique_temp_root() -> PathBuf {
 }
 
 #[test]
+fn read_tool_lazy_write_retries_read_write_not_readonly_error() {
+    // #143 review: read tools open read-only, but a few lazily WRITE on a cold path — here
+    // `read_chunk` calls `mark_file_deleted` when its source file is gone on disk. That write fails
+    // on the read-only connection with SQLITE_READONLY; the dispatcher must transparently retry the
+    // call on a read-write connection, so the caller gets the domain error (chunk gone), NEVER a
+    // raw read-only violation.
+    let (root, config) = mixed_config();
+    IndexDatabase::rebuild(&config).unwrap();
+
+    let search =
+        call_tool_for_config(&config, "semantic_search", json!({"query": "alpha"})).unwrap();
+    let hit = search.as_array().unwrap().first().expect("a semantic hit").clone();
+    let chunk_id = hit["chunk_id"].as_i64().unwrap();
+    let path = hit["path"].as_str().unwrap().to_string();
+
+    // Remove the source file → `read_chunk` takes the mark_file_deleted (write) branch.
+    std::fs::remove_file(root.join(&path)).unwrap();
+
+    let result = call_tool_for_config(&config, "read_chunk", json!({"chunk_id": chunk_id}));
+    let err = result.expect_err("a deleted-source chunk reports gone");
+    assert!(
+        !rag_rat_core::storage::is_readonly_violation(&err),
+        "the lazy write must be retried read-write, never surfaced as SQLITE_READONLY: {err:?}"
+    );
+
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn read_only_classification_covers_every_tool_and_denies_writers() {
     // #143: the read-only fast path must classify EVERY tool, and exactly the mutating tools must
     // be denied read-only access. Drift either lock-contends a read tool (slow) or hands a write


### PR DESCRIPTION
Fixes #143.

## Problem

A second concurrent MCP client (e.g. Codex while another agent's MCP server is also attached) intermittently gets **`database is locked`** from read-only tools on a large index (observed on the Linux-kernel index).

Every MCP tool call opened the DB read-write (`call_tool_for_config` → `IndexDatabase::open_config` → `IndexConnection::open`), and `open_with_graph_check` ran `ensure_model_manifest` on **every** open. That helper issues unconditional write DML (`remove_legacy_models` DELETEs, 3× `upsert_model` INSERT, `normalize_embedding_model_versions` UPDATE). In rusqlite every DML statement takes the SQLite **write lock** for its implicit transaction even when it changes zero rows — so **every read tool acquired the write lock on open**. With a live watcher and/or a second MCP instance, those per-open writes serialize; when one holder runs past the 5s `busy_timeout`, the next returns `SQLITE_BUSY`. Intermittent because it only fires on overlap.

(The RW path already had a 5s busy_timeout; the 100ms one is only the grep-augment fallback. `ensure_graph_index_current` is not a steady-state culprit — it early-returns when the graph version matches.)

## Fix (two independent layers)

**A — `ensure_model_manifest` is read-first.** A new `model_manifest_is_current` short-circuits the writes when the manifest already matches what they would produce, so a steady-state open performs **zero** writes. Protects all read-write callers (CLI, watcher, write tools), not just the MCP.

**B — pure-read MCP tools open read-only.** `try_open_config_read_only` opens a `SQLITE_OPEN_READ_ONLY` connection (5s busy_timeout) and skips the on-open heal writes. A read-only connection can never take the main write lock, so reads are structurally immune to any writer. It declines (`None` → read-write fallback that heals once) when a write is still owed: schema not `Compatible`, stale graph index, or a not-yet-current manifest. Tool classification is a writer **deny-list** (a new tool is read-only by default), guarded by a test.

## Tests
- `ensure_model_manifest_does_not_write_when_already_current` — proves the no-op by running it on a read-only connection.
- `read_only_open_serves_current_index_and_declines_when_heal_is_owed`.
- `read_only_classification_covers_every_tool_and_denies_writers`.

Full `rag-rat-core` + `rag-rat-mcp` suites pass; clippy clean.

## Not in this PR
#77 (zstd-compress stored chunk text) is complementary on a different axis — it shortens how long any writer holds the lock, but doesn't change who takes it. Tracked separately.
