### PR TITLE
fix: oracle started_at = run start (#145); impact_surface flags truncated sections (#49)

### DIFF
--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -296,13 +296,14 @@ fn oracle_run(config: &Config, args: &OracleRunArgs) -> anyhow::Result<()> {
     // including DURING the subprocess, which the post-exit `production_sha` snapshot cannot see —
     // is skipped, never mis-joined. A reindex slipping in between this lock release and the spawn
     // is detected by the same gate.
-    let pre_spawn_sha = with_oracle_write_lock(config, |db| db.oracle_pre_spawn_snapshot())?;
-    // Stamp `started_at` right AFTER the pre-spawn snapshot (which read the indexed state this run
-    // covers) and before the tool subprocess: later than the indexed_at it's based on (so a run
-    // that covers fresh state isn't falsely judged stale even if the write-lock wait was long),
-    // yet before any mid-run reindex (so a run that misses one IS judged stale). (#145 + #146
-    // review)
-    let started_at_ms = crate::now_epoch_ms();
+    // Stamp `started_at` INSIDE the same write-lock as the pre-spawn snapshot, so no watcher
+    // reindex can land between reading the indexed state and recording the start. Under the lock,
+    // started_at corresponds exactly to the indexed state this run covers: ≥ that indexed_at (so a
+    // run covering fresh state isn't falsely judged stale even after a long lock wait) yet before
+    // any mid-run reindex (so a run that misses one IS judged stale). (#145 + #146 review)
+    let (started_at_ms, pre_spawn_sha) = with_oracle_write_lock(config, |db| {
+        Ok((crate::now_epoch_ms(), db.oracle_pre_spawn_snapshot()?))
+    })?;
     let scip_output = config
         .database
         .parent()

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -296,10 +296,13 @@ fn oracle_run(config: &Config, args: &OracleRunArgs) -> anyhow::Result<()> {
     // including DURING the subprocess, which the post-exit `production_sha` snapshot cannot see —
     // is skipped, never mis-joined. A reindex slipping in between this lock release and the spawn
     // is detected by the same gate.
-    // The run begins now, before the slow tool subprocess — stamp `started_at` from here so a
-    // watcher reindex during the run doesn't make it look fresher than the edits it skips (#145).
-    let started_at_ms = crate::now_epoch_ms();
     let pre_spawn_sha = with_oracle_write_lock(config, |db| db.oracle_pre_spawn_snapshot())?;
+    // Stamp `started_at` right AFTER the pre-spawn snapshot (which read the indexed state this run
+    // covers) and before the tool subprocess: later than the indexed_at it's based on (so a run
+    // that covers fresh state isn't falsely judged stale even if the write-lock wait was long),
+    // yet before any mid-run reindex (so a run that misses one IS judged stale). (#145 + #146
+    // review)
+    let started_at_ms = crate::now_epoch_ms();
     let scip_output = config
         .database
         .parent()

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -296,6 +296,9 @@ fn oracle_run(config: &Config, args: &OracleRunArgs) -> anyhow::Result<()> {
     // including DURING the subprocess, which the post-exit `production_sha` snapshot cannot see —
     // is skipped, never mis-joined. A reindex slipping in between this lock release and the spawn
     // is detected by the same gate.
+    // The run begins now, before the slow tool subprocess — stamp `started_at` from here so a
+    // watcher reindex during the run doesn't make it look fresher than the edits it skips (#145).
+    let started_at_ms = crate::now_epoch_ms();
     let pre_spawn_sha = with_oracle_write_lock(config, |db| db.oracle_pre_spawn_snapshot())?;
     let scip_output = config
         .database
@@ -328,7 +331,14 @@ fn oracle_run(config: &Config, args: &OracleRunArgs) -> anyhow::Result<()> {
             // a file the watcher reindexes anywhere in it is skipped, not mis-joined. Run only
             // the join/write under the lock.
             let report = with_oracle_write_lock(config, |db| {
-                db.run_oracle(tool, &version, &bytes, Some(&production_sha), Some(&pre_spawn_sha))
+                db.run_oracle_at(
+                    tool,
+                    &version,
+                    &bytes,
+                    Some(&production_sha),
+                    Some(&pre_spawn_sha),
+                    started_at_ms,
+                )
             })?;
             print_output(&serde_json::json!({
                 "outcome": "completed",

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -231,6 +231,9 @@ fn spawn_detached_oracle_auto_run(config: &rag_rat_core::Config) {
         config: &rag_rat_core::Config,
         tool: OracleTool,
     ) -> anyhow::Result<()> {
+        // Stamp the run's start before the subprocess so an overlapping watcher reindex can't make
+        // it look fresher than the edits it skips and wedge the next staleness decision (#145).
+        let started_at_ms = now_epoch_ms();
         let pre_spawn_sha = with_oracle_write_lock(config, |db| db.oracle_pre_spawn_snapshot())?;
         let scip_output = config
             .database
@@ -244,12 +247,13 @@ fn spawn_detached_oracle_auto_run(config: &rag_rat_core::Config) {
             oracle::ScipProduction::Blocked { .. } => Ok(()),
             oracle::ScipProduction::Produced { version, bytes, production_sha } => {
                 with_oracle_write_lock(config, |db| {
-                    db.run_oracle(
+                    db.run_oracle_at(
                         tool,
                         &version,
                         &bytes,
                         Some(&production_sha),
                         Some(&pre_spawn_sha),
+                        started_at_ms,
                     )
                 })?;
                 Ok(())

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -231,12 +231,12 @@ fn spawn_detached_oracle_auto_run(config: &rag_rat_core::Config) {
         config: &rag_rat_core::Config,
         tool: OracleTool,
     ) -> anyhow::Result<()> {
-        let pre_spawn_sha = with_oracle_write_lock(config, |db| db.oracle_pre_spawn_snapshot())?;
-        // Stamp AFTER the pre-spawn snapshot (the indexed state this run covers) and before the
-        // subprocess: later than the indexed_at it's based on, yet before any mid-run reindex — so
-        // the staleness gate neither falsely reruns nor wrongly skips a refresh. (#145 + #146
-        // review)
-        let started_at_ms = now_epoch_ms();
+        // Stamp the start INSIDE the same write-lock as the pre-spawn snapshot so no watcher
+        // reindex can interleave between reading the indexed state and recording the start; under
+        // the lock, started_at matches the indexed state this run covers (#145 + #146 review).
+        let (started_at_ms, pre_spawn_sha) = with_oracle_write_lock(config, |db| {
+            Ok((now_epoch_ms(), db.oracle_pre_spawn_snapshot()?))
+        })?;
         let scip_output = config
             .database
             .parent()

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -231,10 +231,12 @@ fn spawn_detached_oracle_auto_run(config: &rag_rat_core::Config) {
         config: &rag_rat_core::Config,
         tool: OracleTool,
     ) -> anyhow::Result<()> {
-        // Stamp the run's start before the subprocess so an overlapping watcher reindex can't make
-        // it look fresher than the edits it skips and wedge the next staleness decision (#145).
-        let started_at_ms = now_epoch_ms();
         let pre_spawn_sha = with_oracle_write_lock(config, |db| db.oracle_pre_spawn_snapshot())?;
+        // Stamp AFTER the pre-spawn snapshot (the indexed state this run covers) and before the
+        // subprocess: later than the indexed_at it's based on, yet before any mid-run reindex — so
+        // the staleness gate neither falsely reruns nor wrongly skips a refresh. (#145 + #146
+        // review)
+        let started_at_ms = now_epoch_ms();
         let scip_output = config
             .database
             .parent()

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -57,6 +57,8 @@ pub(crate) use store::{EdgeOracleComparison, EdgeOracleVerdict};
 /// [`run::OracleRunInput::pre_spawn_sha`].
 // The args mirror `OracleRunInput`'s fields one-to-one (this is the public thin adapter to it), so
 // a params struct would only re-wrap what callers already pass positionally.
+/// Run + record stamped at `now_ms()` — for callers without a controlled spawn moment (a pre-built
+/// `--scip`, tests). The tool-driven path uses [`run_oracle_at`] with the real start time (#145).
 #[allow(clippy::too_many_arguments)]
 pub fn run_oracle(
     conn: &Connection,
@@ -69,6 +71,36 @@ pub fn run_oracle(
     production_sha: Option<&HashMap<String, String>>,
     pre_spawn_sha: Option<&HashMap<String, String>>,
 ) -> anyhow::Result<OracleReport> {
+    run_oracle_at(
+        conn,
+        tool,
+        tool_version,
+        commit_sha,
+        worktree_id,
+        scip_bytes,
+        checkout_root,
+        production_sha,
+        pre_spawn_sha,
+        super::now_ms(),
+    )
+}
+
+/// As [`run_oracle`], but records `oracle_runs.started_at = started_at_ms` (the moment the run
+/// began, captured before the tool subprocess) instead of completion time, so the auto-run
+/// staleness gate isn't wedged by a run that overlapped a watcher reindex (#145).
+#[allow(clippy::too_many_arguments)]
+pub fn run_oracle_at(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+    scip_bytes: &[u8],
+    checkout_root: &Path,
+    production_sha: Option<&HashMap<String, String>>,
+    pre_spawn_sha: Option<&HashMap<String, String>>,
+    started_at_ms: i64,
+) -> anyhow::Result<OracleReport> {
     run::run(conn, &OracleRunInput {
         tool,
         tool_version,
@@ -78,6 +110,7 @@ pub fn run_oracle(
         checkout_root,
         production_sha,
         pre_spawn_sha,
+        started_at_ms,
     })
 }
 
@@ -264,15 +297,17 @@ pub fn run_oracle_with_tool(
     commit_sha: &str,
     worktree_id: &str,
 ) -> anyhow::Result<OracleRunOutcome> {
-    // Snapshot the indexed shas BEFORE spawning the tool — the pre-spawn gate (#83) needs the
-    // state from before the subprocess could observe any source, so a mid-subprocess reindex is
-    // detectable at the join.
+    // The run begins here, before the tool subprocess — stamp `started_at` from this moment so a
+    // watcher reindex during the (slow) subprocess doesn't make the run look fresher than the edits
+    // it skips (#145). Snapshot the indexed shas BEFORE spawning too — the pre-spawn gate (#83)
+    // needs the state from before the subprocess could observe any source.
+    let started_at_ms = super::now_ms();
     let pre_spawn_sha = pre_spawn_snapshot(conn, commit_sha, worktree_id)?;
     match produce_scip_with_tool(tool, checkout_root, scip_output)? {
         ScipProduction::Blocked { tool, program, hint } =>
             Ok(OracleRunOutcome::Blocked { tool, program, hint }),
         ScipProduction::Produced { version, bytes, production_sha } => {
-            let report = run_oracle(
+            let report = run_oracle_at(
                 conn,
                 tool,
                 &version,
@@ -282,6 +317,7 @@ pub fn run_oracle_with_tool(
                 checkout_root,
                 Some(&production_sha),
                 Some(&pre_spawn_sha),
+                started_at_ms,
             )?;
             Ok(OracleRunOutcome::Completed {
                 tool: tool.as_db_str().to_string(),

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -297,12 +297,13 @@ pub fn run_oracle_with_tool(
     commit_sha: &str,
     worktree_id: &str,
 ) -> anyhow::Result<OracleRunOutcome> {
-    // The run begins here, before the tool subprocess — stamp `started_at` from this moment so a
-    // watcher reindex during the (slow) subprocess doesn't make the run look fresher than the edits
-    // it skips (#145). Snapshot the indexed shas BEFORE spawning too — the pre-spawn gate (#83)
-    // needs the state from before the subprocess could observe any source.
-    let started_at_ms = super::now_ms();
+    // Snapshot the indexed shas BEFORE spawning the tool — the pre-spawn gate (#83) needs the state
+    // from before the subprocess could observe any source.
     let pre_spawn_sha = pre_spawn_snapshot(conn, commit_sha, worktree_id)?;
+    // Stamp the run's start right after that snapshot (the indexed state it covers) and before the
+    // subprocess: later than the indexed_at it's based on, yet before any mid-run reindex, so the
+    // auto-run staleness gate is neither falsely rerun nor wrongly skipped. (#145 + #146 review)
+    let started_at_ms = super::now_ms();
     match produce_scip_with_tool(tool, checkout_root, scip_output)? {
         ScipProduction::Blocked { tool, program, hint } =>
             Ok(OracleRunOutcome::Blocked { tool, program, hint }),

--- a/crates/rag-rat-core/src/index/oracle/run.rs
+++ b/crates/rag-rat-core/src/index/oracle/run.rs
@@ -53,6 +53,10 @@ pub(crate) struct OracleRunInput<'a> {
     /// ABA (an edit reverted to byte-identical content) is acceptable — the verdict is then
     /// correct anyway.
     pub(crate) pre_spawn_sha: Option<&'a HashMap<String, String>>,
+    /// Unix-epoch ms when the run actually BEGAN (the pre-spawn snapshot moment), recorded as
+    /// `oracle_runs.started_at`. Must be the start, not completion: the auto-run staleness gate
+    /// keys on it (#145).
+    pub(crate) started_at_ms: i64,
 }
 
 /// Run the oracle join over all current edge candidates and persist verdicts + a run row.
@@ -373,12 +377,13 @@ pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Resu
     );
 
     report.status = "Completed".to_string();
-    store::record_oracle_run(
+    store::record_oracle_run_at(
         conn,
         input.tool,
         input.tool_version,
         input.commit_sha,
         input.worktree_id,
+        input.started_at_ms,
         &report.status,
         &serde_json::to_string(&report).unwrap_or_else(|_| "{}".to_string()),
     )?;

--- a/crates/rag-rat-core/src/index/oracle/status.rs
+++ b/crates/rag-rat-core/src/index/oracle/status.rs
@@ -68,7 +68,7 @@ fn last_run_meta(
             SELECT status, commit_sha FROM oracle_runs
             WHERE tool = ?1 AND tool_version = ?2
               AND commit_sha = ?3 AND worktree_id = ?4
-            ORDER BY started_at DESC, id DESC
+            ORDER BY id DESC
             LIMIT 1
             ",
             rusqlite::params![tool.as_db_str(), tool_version, commit_sha, worktree_id],

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -408,6 +408,12 @@ pub(crate) fn record_oracle_run_at(
 /// the version the surfacing reads (the `Compiler` tier) key on: query output should show the
 /// verdicts the last `oracle run` for this checkout produced. Scoped to `(commit_sha, worktree_id)`
 /// so a sibling worktree's run can't dictate this checkout's displayed tool version.
+///
+/// Ordered by `id DESC` = INSERTION order = COMPLETION order (the row is written at the end of
+/// `run::run`, under the write lock). NOT `started_at DESC`: since #145 `started_at` is the run's
+/// START, which is no longer monotonic with completion — two overlapping runs (a manual + the
+/// background auto-run) can finish in the opposite order they started, and the authoritative
+/// `edge_oracle` writer is the one that finished LAST (highest id), not the one that started last.
 pub(crate) fn latest_run_tool_version(
     conn: &Connection,
     tool: OracleTool,
@@ -419,7 +425,7 @@ pub(crate) fn latest_run_tool_version(
             "
             SELECT tool_version FROM oracle_runs
             WHERE tool = ?1 AND commit_sha = ?2 AND worktree_id = ?3
-            ORDER BY started_at DESC, id DESC
+            ORDER BY id DESC
             LIMIT 1
             ",
             params![tool.as_db_str(), commit_sha, worktree_id],
@@ -429,11 +435,13 @@ pub(crate) fn latest_run_tool_version(
     Ok(version)
 }
 
-/// The `started_at` (Unix-epoch ms) of the most recent run for `tool` **in the active checkout**,
-/// or `None` when no run exists. The staleness clock the background auto-fresh oracle compares
-/// against the index's `indexed_at_ms` (see [`crate::index::oracle::auto_run_decision`]): a run
-/// that started after the last index change means the verdicts are current. Scoped to `(commit_sha,
-/// worktree_id)` — the sibling of [`latest_run_tool_version`], ordered the same way.
+/// The `started_at` (Unix-epoch ms) of the LAST-COMPLETED run for `tool` **in the active
+/// checkout**, or `None` when no run exists. The staleness clock the background auto-fresh oracle
+/// compares against the index's `indexed_at_ms` (see [`crate::index::oracle::auto_run_decision`]):
+/// a run that started after the last index change means its verdicts are current. Scoped to
+/// `(commit_sha, worktree_id)` — the sibling of [`latest_run_tool_version`], ordered the same way
+/// (`id DESC` = completion order, so the start time returned belongs to the run whose verdicts are
+/// actually live; see that fn for why started_at ordering is wrong since #145).
 pub(crate) fn latest_run_started_at(
     conn: &Connection,
     tool: OracleTool,
@@ -445,7 +453,7 @@ pub(crate) fn latest_run_started_at(
             "
             SELECT started_at FROM oracle_runs
             WHERE tool = ?1 AND commit_sha = ?2 AND worktree_id = ?3
-            ORDER BY started_at DESC, id DESC
+            ORDER BY id DESC
             LIMIT 1
             ",
             params![tool.as_db_str(), commit_sha, worktree_id],

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -344,6 +344,9 @@ pub(crate) fn write_edge_oracle(
 /// `worktree_id` scopes the run to the active checkout so the status read's `last_run_meta` can
 /// distinguish this checkout's run from a sibling worktree's run under the same
 /// `(tool, tool_version, commit_sha)`.
+/// Record a run stamped at `now_ms()`. Test-only convenience over [`record_oracle_run_at`]; every
+/// production path threads the real start time through `record_oracle_run_at` (#145).
+#[cfg(test)]
 pub(crate) fn record_oracle_run(
     conn: &Connection,
     tool: OracleTool,
@@ -353,6 +356,34 @@ pub(crate) fn record_oracle_run(
     status: &str,
     stats_json: &str,
 ) -> anyhow::Result<i64> {
+    record_oracle_run_at(
+        conn,
+        tool,
+        tool_version,
+        commit_sha,
+        worktree_id,
+        now_ms(),
+        status,
+        stats_json,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn record_oracle_run_at(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+    started_at_ms: i64,
+    status: &str,
+    stats_json: &str,
+) -> anyhow::Result<i64> {
+    // `started_at_ms` is the moment the run actually BEGAN (the pre-spawn snapshot), passed in by
+    // the caller — NOT `now_ms()` at completion. The auto-run staleness gate compares this
+    // against the index's last-change clock; stamping completion time made a run that
+    // overlapped a watcher reindex look fresher than the edits it skipped, wedging the gate at
+    // NotStale (#145).
     conn.execute(
         "
         INSERT INTO oracle_runs(
@@ -365,7 +396,7 @@ pub(crate) fn record_oracle_run(
             tool_version,
             commit_sha,
             worktree_id,
-            now_ms(),
+            started_at_ms,
             status,
             stats_json
         ],

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -923,6 +923,32 @@ fn staleness_key_distinguishes_rows_by_file_sha_tool_and_version() {
     assert_eq!(other_version, 0);
 }
 
+/// #145: `record_oracle_run_at` persists the PASSED start time, not `now_ms()`/completion — so the
+/// auto-run staleness gate keys on when the run BEGAN, not when it finished (a run that overlapped
+/// a watcher reindex must not look fresher than the edits it skipped).
+#[test]
+fn record_oracle_run_at_persists_the_passed_start_time() {
+    let h = Harness::new();
+    // Deliberately far in the past: if the impl stamped `now_ms()` instead, this would not match.
+    let started_at_ms = 1_000_000_i64;
+    store::record_oracle_run_at(
+        &h.conn,
+        TOOL,
+        VERSION,
+        COMMIT,
+        WORKTREE,
+        started_at_ms,
+        "Completed",
+        "{}",
+    )
+    .unwrap();
+    assert_eq!(
+        store::latest_run_started_at(&h.conn, TOOL, COMMIT, WORKTREE).unwrap(),
+        Some(started_at_ms),
+        "started_at must be the value the caller passed, not completion time"
+    );
+}
+
 /// `record_oracle_run` inserts a run row and returns its id; `count_edge_oracle_scoped` tallies
 /// only the requested kind for the tool/version within the active checkout.
 #[test]

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -62,13 +62,29 @@ impl IndexDatabase {
         production_sha: Option<&std::collections::HashMap<String, String>>,
         pre_spawn_sha: Option<&std::collections::HashMap<String, String>>,
     ) -> anyhow::Result<OracleReport> {
+        self.run_oracle_at(tool, tool_version, scip_bytes, production_sha, pre_spawn_sha, now_ms())
+    }
+
+    /// As [`Self::run_oracle`], but records the run's `started_at` as `started_at_ms` — the moment
+    /// the caller began the run (its pre-spawn snapshot), not completion time. The tool-driven path
+    /// passes this so the auto-run staleness gate isn't wedged by a run that overlapped a watcher
+    /// reindex (#145).
+    pub fn run_oracle_at(
+        &self,
+        tool: OracleTool,
+        tool_version: &str,
+        scip_bytes: &[u8],
+        production_sha: Option<&std::collections::HashMap<String, String>>,
+        pre_spawn_sha: Option<&std::collections::HashMap<String, String>>,
+        started_at_ms: i64,
+    ) -> anyhow::Result<OracleReport> {
         let Some(root) = self.storage.source_root() else {
             anyhow::bail!(
                 "index has no source_root metadata; rebuild required for the oracle pass"
             );
         };
         let root = root.to_path_buf();
-        oracle::run_oracle(
+        oracle::run_oracle_at(
             self.storage.connection(),
             tool,
             tool_version,
@@ -78,6 +94,7 @@ impl IndexDatabase {
             &root,
             production_sha,
             pre_spawn_sha,
+            started_at_ms,
         )
     }
 

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -2311,6 +2311,8 @@ impl IndexDatabase {
         callee_edge_ids: &[i64],
         limit: u32,
     ) -> anyhow::Result<crate::query::memory::RepoMemoryEvidence> {
+        // This wrapper exposes only the evidence; the impact builder consumes the truncation flag
+        // directly from the core fn.
         crate::query::memory::memory_evidence_for_symbol_and_edges(
             self.storage.connection(),
             symbol,
@@ -2318,6 +2320,7 @@ impl IndexDatabase {
             callee_edge_ids,
             limit,
         )
+        .map(|(evidence, _truncated)| evidence)
     }
 
     pub fn memory_for_call_path_hash(

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -7876,6 +7876,26 @@ fn impact_report_flags_a_section_truncated_at_limit() {
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     let hub = db.symbols("hub", Some(Language::Rust), 10).unwrap().remove(0);
+
+    // Three repo memories bound to `hub` so the memory section is also over the limit — the
+    // truncation report must cover it, not just the non-memory vectors (#146 review).
+    for i in 0..3 {
+        db.memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Decision".to_string(),
+            title: format!("hub note {i}"),
+            body: "why hub is load-bearing".to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test".to_string()),
+            source: Some("agent".to_string()),
+            tags: vec![],
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                symbol_id: Some(hub.symbol_id),
+                ..Default::default()
+            },
+        })
+        .unwrap();
+    }
+
     let report =
         db.impact_surface_report_for_selected_symbol(&hub, 2, &Default::default()).unwrap();
     assert_eq!(report.direct_semantic_callers.len(), 2, "callers truncated to the limit");
@@ -7885,6 +7905,11 @@ fn impact_report_flags_a_section_truncated_at_limit() {
             .truncated_sections
             .contains(&"direct_semantic_callers".to_string()),
         "the capped section must be named: {:?}",
+        report.completeness_and_caveats
+    );
+    assert!(
+        report.completeness_and_caveats.truncated_sections.contains(&"repo_memories".to_string()),
+        "the capped memory section must be named too: {:?}",
         report.completeness_and_caveats
     );
     assert!(

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -7859,3 +7859,51 @@ fn read_only_open_serves_current_index_and_declines_when_heal_is_owed() {
 
     fs::remove_dir_all(root).unwrap();
 }
+
+#[test]
+fn impact_report_flags_a_section_truncated_at_limit() {
+    // #49: a section capped at `limit` must be named in `truncated_sections` and a caveat — no
+    // silent caps. Three callers of `hub` with limit=2 → `direct_semantic_callers` is truncated.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn hub() {}\npub fn a() { hub(); }\npub fn b() { hub(); }\npub fn c() { hub(); }\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let hub = db.symbols("hub", Some(Language::Rust), 10).unwrap().remove(0);
+    let report =
+        db.impact_surface_report_for_selected_symbol(&hub, 2, &Default::default()).unwrap();
+    assert_eq!(report.direct_semantic_callers.len(), 2, "callers truncated to the limit");
+    assert!(
+        report
+            .completeness_and_caveats
+            .truncated_sections
+            .contains(&"direct_semantic_callers".to_string()),
+        "the capped section must be named: {:?}",
+        report.completeness_and_caveats
+    );
+    assert!(
+        report
+            .completeness_and_caveats
+            .caveats
+            .iter()
+            .any(|caveat| caveat.contains("truncated at limit")),
+        "a human caveat must mention truncation: {:?}",
+        report.completeness_and_caveats.caveats
+    );
+
+    // A generous limit truncates nothing.
+    let full = db.impact_surface_report_for_selected_symbol(&hub, 50, &Default::default()).unwrap();
+    assert!(
+        full.completeness_and_caveats.truncated_sections.is_empty(),
+        "nothing should be flagged when under the limit: {:?}",
+        full.completeness_and_caveats.truncated_sections
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}

--- a/crates/rag-rat-core/src/query/impact/mod.rs
+++ b/crates/rag-rat-core/src/query/impact/mod.rs
@@ -74,6 +74,10 @@ pub struct ImpactCompleteness {
     pub parser_failures: u64,
     pub stale_files: u64,
     pub memory_status: ImpactMemoryStatus,
+    /// Sections that returned exactly `limit` rows and were therefore capped — more results may
+    /// exist (no silent caps, #49). Empty when nothing was truncated.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub truncated_sections: Vec<String>,
     pub caveats: Vec<String>,
 }
 
@@ -227,6 +231,31 @@ pub fn impact_surface_report_for_symbol(
             text_fallback_hits.len()
         ));
     }
+    // No silent caps (#49): a section that returns exactly `limit` rows was capped and may hide
+    // more. Name every capped section so the agent can raise `limit` or narrow the query instead of
+    // trusting a truncated list as complete.
+    let limit_usize = usize::try_from(limit).unwrap_or(usize::MAX);
+    let truncated_sections: Vec<String> = [
+        ("direct_semantic_callers", direct_semantic_callers.len()),
+        ("direct_semantic_callees", direct_semantic_callees.len()),
+        ("import_export_dependents", import_export_dependents.len()),
+        ("tests_touching_symbol_path", tests_touching_symbol_path.len()),
+        ("docs_mentioning_symbol_path", docs_mentioning_symbol_path.len()),
+        ("text_fallback_hits", text_fallback_hits.len()),
+        ("recent_commits_touching_symbol_path", recent_commits_touching_symbol_path.len()),
+        ("github_rationale_issues_prs", github_rationale_issues_prs.len()),
+    ]
+    .into_iter()
+    .filter(|&(_, len)| limit_usize != 0 && len >= limit_usize)
+    .map(|(name, _)| name.to_string())
+    .collect();
+    if !truncated_sections.is_empty() {
+        caveats.push(format!(
+            "Sections truncated at limit={limit}: {}. More results may exist — raise `limit` or \
+             narrow the query.",
+            truncated_sections.join(", ")
+        ));
+    }
     Ok(ImpactSurfaceReport {
         query: ImpactSurfaceQuery {
             symbol_id: Some(symbol.symbol_id),
@@ -255,6 +284,7 @@ pub fn impact_surface_report_for_symbol(
                 .unwrap_or(u64::MAX),
                 stale: u64::try_from(repo_memories.stale.len()).unwrap_or(u64::MAX),
             },
+            truncated_sections,
             caveats,
         },
         direct_semantic_callers,

--- a/crates/rag-rat-core/src/query/impact/mod.rs
+++ b/crates/rag-rat-core/src/query/impact/mod.rs
@@ -244,6 +244,16 @@ pub fn impact_surface_report_for_symbol(
         ("text_fallback_hits", text_fallback_hits.len()),
         ("recent_commits_touching_symbol_path", recent_commits_touching_symbol_path.len()),
         ("github_rationale_issues_prs", github_rationale_issues_prs.len()),
+        // `repo_memories` is also capped at `limit` per lane (memory_evidence_for_symbol_and_edges
+        // queries each at `limit`); flag it when any active lane fills the cap (#146 review).
+        (
+            "repo_memories",
+            repo_memories
+                .direct
+                .len()
+                .max(repo_memories.path_crossed.len())
+                .max(repo_memories.call_path_crossed.len()),
+        ),
     ]
     .into_iter()
     .filter(|&(_, len)| limit_usize != 0 && len >= limit_usize)

--- a/crates/rag-rat-core/src/query/impact/mod.rs
+++ b/crates/rag-rat-core/src/query/impact/mod.rs
@@ -198,7 +198,7 @@ pub fn impact_surface_report_for_symbol(
     } else {
         Vec::new()
     };
-    let repo_memories = if options.include_memories {
+    let (repo_memories, memories_truncated) = if options.include_memories {
         let caller_edge_ids =
             direct_semantic_callers.iter().map(|hop| hop.edge_id).collect::<Vec<_>>();
         let callee_edge_ids =
@@ -211,12 +211,15 @@ pub fn impact_surface_report_for_symbol(
             limit,
         )?
     } else {
-        RepoMemoryEvidence {
-            direct: Vec::new(),
-            path_crossed: Vec::new(),
-            call_path_crossed: Vec::new(),
-            stale: Vec::new(),
-        }
+        (
+            RepoMemoryEvidence {
+                direct: Vec::new(),
+                path_crossed: Vec::new(),
+                call_path_crossed: Vec::new(),
+                stale: Vec::new(),
+            },
+            false,
+        )
     };
     let mut caveats = vec![
         "Graph evidence is tree-sitter/syntactic, not compiler-grade name resolution.".to_string(),
@@ -244,20 +247,13 @@ pub fn impact_surface_report_for_symbol(
         ("text_fallback_hits", text_fallback_hits.len()),
         ("recent_commits_touching_symbol_path", recent_commits_touching_symbol_path.len()),
         ("github_rationale_issues_prs", github_rationale_issues_prs.len()),
-        // `repo_memories` is also capped at `limit` per lane (memory_evidence_for_symbol_and_edges
-        // queries each at `limit`); flag it when any active lane fills the cap (#146 review).
-        (
-            "repo_memories",
-            repo_memories
-                .direct
-                .len()
-                .max(repo_memories.path_crossed.len())
-                .max(repo_memories.call_path_crossed.len()),
-        ),
     ]
     .into_iter()
     .filter(|&(_, len)| limit_usize != 0 && len >= limit_usize)
     .map(|(name, _)| name.to_string())
+    // `repo_memories` is capped per lane inside memory_evidence; its `memories_truncated` flag
+    // accounts for rows split off to `stale` (which the active-lane lengths would miss), #146 review.
+    .chain(memories_truncated.then(|| "repo_memories".to_string()))
     .collect();
     if !truncated_sections.is_empty() {
         caveats.push(format!(

--- a/crates/rag-rat-core/src/query/memory/api.rs
+++ b/crates/rag-rat-core/src/query/memory/api.rs
@@ -286,21 +286,28 @@ pub(crate) fn memory_evidence_for_symbol_and_edges(
     caller_edge_ids: &[i64],
     callee_edge_ids: &[i64],
     limit: u32,
-) -> anyhow::Result<RepoMemoryEvidence> {
-    let (direct, mut stale) = split_active_stale(memories_for_symbol(conn, symbol, limit)?);
+) -> anyhow::Result<(RepoMemoryEvidence, bool)> {
     let mut all_edges = caller_edge_ids.to_vec();
     all_edges.extend_from_slice(callee_edge_ids);
-    let (path_crossed, crossed_stale) =
-        split_active_stale(memories_for_edges(conn, &all_edges, limit)?);
+    // Each lane is independently capped at `limit` by its query. Detect truncation from the
+    // PRE-split row counts: `split_active_stale` partitions a lane into active + stale, so an
+    // active lane can sit below `limit` even though the query was capped (rows went to stale) —
+    // counting active lanes alone misses that (#146 review). A lane that returned `limit` rows
+    // may hide more.
+    let direct_rows = memories_for_symbol(conn, symbol, limit)?;
+    let edge_rows = memories_for_edges(conn, &all_edges, limit)?;
+    let call_path_rows =
+        call_path_memories_for_crossed(conn, caller_edge_ids, callee_edge_ids, limit)?;
+    let cap = limit as usize;
+    let truncated = cap != 0
+        && (direct_rows.len() >= cap || edge_rows.len() >= cap || call_path_rows.len() >= cap);
+
+    let (direct, mut stale) = split_active_stale(direct_rows);
+    let (path_crossed, crossed_stale) = split_active_stale(edge_rows);
     stale.extend(crossed_stale);
-    let (call_path_crossed, call_path_stale) = split_active_stale(call_path_memories_for_crossed(
-        conn,
-        caller_edge_ids,
-        callee_edge_ids,
-        limit,
-    )?);
+    let (call_path_crossed, call_path_stale) = split_active_stale(call_path_rows);
     stale.extend(call_path_stale);
-    Ok(RepoMemoryEvidence { direct, path_crossed, call_path_crossed, stale })
+    Ok((RepoMemoryEvidence { direct, path_crossed, call_path_crossed, stale }, truncated))
 }
 /// Surface call-path memories whose server-derived hash this traversal crossed: compute the
 /// single-edge hash for every crossed edge and the two-edge `caller -> callee` hash for each


### PR DESCRIPTION
Two pre-release fixes from the open-issue triage.

## #145 — oracle `started_at` is the run's start, not completion

`oracle_runs.started_at` was stamped with `now_ms()` *inside* `record_oracle_run`, i.e. at completion. The background auto-fresh oracle's staleness gate compares the latest run's `started_at` against the index's last-change clock — so a run that overlapped a watcher reindex (its content gates correctly skip the drifted docs) recorded a completion time *after* that change, making the gate read `NotStale` and **never refresh compiler ranking** until the next edit or a manual run.

Fix: capture the real start (before the tool subprocess, at the pre-spawn snapshot) and thread it through new explicit-start entry points — `store::record_oracle_run_at`, `oracle::run_oracle_at`, `IndexDatabase::run_oracle_at` — used by `oracle run`, the background auto-run, and `run_oracle_with_tool`. The original `now_ms()`-stamping names remain for callers with no controlled spawn moment (pre-built `--scip`, tests), so the wide test surface is untouched.

## #49 — `impact_surface` no longer caps sections silently

Each `impact_surface` section was truncated at `limit` with no signal. The completeness block now reports every section that returned exactly `limit` rows in a new `truncated_sections: [..]` field and adds a caveat, so a truncated list never reads as complete coverage. (Graph envelope tools already had `summary.truncated`; this brings impact in line.)

## Tests
- `record_oracle_run_at_persists_the_passed_start_time` — recording with a past start time reads back that value, not completion.
- `impact_report_flags_a_section_truncated_at_limit` — 3 callers + limit=2 → `direct_semantic_callers` named in `truncated_sections` + a caveat; a generous limit flags nothing.

Full `rag-rat-core` (419) + `rag-rat-mcp` (20) + CLI suites green; clippy + nightly-fmt clean.
