### PR TITLE
feat: lazy-heal symbol_lookup + flag dirty result files (#147, #148)

### DIFF
--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -416,8 +416,88 @@ impl IndexDatabase {
     ) -> anyhow::Result<crate::query::symbol::SymbolLookup> {
         let mut lookup =
             crate::query::symbol::lookup_candidates(self.storage.connection(), selector)?;
+        // #147: symbol rows aren't anchor-relocated like chunks, so a file edited since indexing
+        // returns stale line numbers. Heal the matched files inline (bounded, like
+        // search_with_heal) and re-resolve so positions/ids are current; #148: report any
+        // file still dirty after.
+        let paths: Vec<String> = lookup.candidates.iter().map(|c| c.path.clone()).collect();
+        let stale = self.stale_source_paths(&paths)?;
+        if !stale.is_empty() {
+            self.heal_stale_paths(&stale)?; // NeedsReindex beyond the cap
+            let healed =
+                crate::query::symbol::lookup_candidates(self.storage.connection(), selector)?;
+            if healed.candidates.is_empty() && !lookup.candidates.is_empty() {
+                // A `symbol_id` selector can't survive a reindex (ids are reassigned per #149), so
+                // the re-resolve finds nothing. Keep the pre-heal candidates rather than return
+                // empty, but flag the files as stale so the caller knows the positions are old.
+                lookup.stale_files = stale;
+            } else {
+                lookup = healed;
+                let healed_paths: Vec<String> =
+                    lookup.candidates.iter().map(|c| c.path.clone()).collect();
+                lookup.stale_files = self.stale_source_paths(&healed_paths)?;
+            }
+        }
         self.enrich_symbol_hits_with_load_bearing(&mut lookup.candidates)?;
         Ok(lookup)
+    }
+
+    /// The indexed `files.sha256` for `path` in the ACTIVE checkout (via the per-connection `files`
+    /// scope view), or `None` when the path isn't indexed in this scope.
+    fn indexed_sha_for_path(&self, path: &str) -> anyhow::Result<Option<String>> {
+        Ok(self
+            .storage
+            .connection()
+            .query_row("SELECT sha256 FROM files WHERE path = ?1 LIMIT 1", [path], |row| {
+                row.get::<_, String>(0)
+            })
+            .optional()?)
+    }
+
+    /// Of `paths`, those whose on-disk content differs from the indexed sha (or are unreadable) —
+    /// results drawn from them may be stale relative to the working tree. Deduped; paths not
+    /// indexed in scope are skipped (nothing to be stale against); no source root → empty
+    /// (bare/copied index). One file read + hash per distinct path — callers pass the small
+    /// result set, not the whole corpus.
+    fn stale_source_paths(&self, paths: &[String]) -> anyhow::Result<Vec<String>> {
+        let Some(root) = self.storage.source_root().map(Path::to_path_buf) else {
+            return Ok(Vec::new());
+        };
+        let mut stale = Vec::new();
+        let mut seen = std::collections::BTreeSet::new();
+        for path in paths {
+            if !seen.insert(path.as_str()) {
+                continue;
+            }
+            let Some(indexed) = self.indexed_sha_for_path(path)? else {
+                continue;
+            };
+            match fs::read(root.join(path)) {
+                Ok(bytes) if hex_sha256(&bytes) == indexed => {},
+                _ => stale.push(path.clone()),
+            }
+        }
+        Ok(stale)
+    }
+
+    /// Reindex stale files inline so the next read sees current positions (#147), mirroring
+    /// `search_with_heal`: bounded by `MAX_AUTO_HEAL_FILES_PER_CALL` (raises `NeedsReindex` beyond
+    /// it so a huge dirty set can't turn a read into an unbounded rebuild), then sync FTS.
+    fn heal_stale_paths(&self, stale: &[String]) -> anyhow::Result<()> {
+        if stale.is_empty() {
+            return Ok(());
+        }
+        if stale.len() > MAX_AUTO_HEAL_FILES_PER_CALL {
+            anyhow::bail!(IndexError::NeedsReindex {
+                stale_files: stale.len(),
+                cap: MAX_AUTO_HEAL_FILES_PER_CALL,
+            });
+        }
+        for path in stale {
+            self.heal_file(Path::new(path))?;
+        }
+        self.sync_fts()?;
+        Ok(())
     }
 
     pub fn select_symbol(
@@ -1737,6 +1817,32 @@ impl IndexDatabase {
             &mut report.direct_semantic_callers,
             &mut report.direct_semantic_callees,
         )?;
+        // #148: flag how many of the result's files are dirty relative to the index, so the impact
+        // surface isn't read as current when the working tree has moved under it. Flag-only here
+        // (not heal): impact spans an unbounded neighbor set, so an inline heal can't be bounded
+        // the way symbol_lookup's matched-file heal is — the agent re-runs symbol_lookup
+        // (which heals) for a specific symbol if it needs fresh positions. Covers the
+        // selected symbol's file, the direct caller/callee call-site files, and the
+        // current-source item sections.
+        let mut result_paths = vec![symbol.path.clone()];
+        for hop in
+            report.direct_semantic_callers.iter().chain(report.direct_semantic_callees.iter())
+        {
+            if let Some(callsite) = &hop.callsite {
+                result_paths.push(callsite.path.clone());
+            }
+        }
+        for item in report
+            .import_export_dependents
+            .iter()
+            .chain(report.tests_touching_symbol_path.iter())
+            .chain(report.docs_mentioning_symbol_path.iter())
+            .chain(report.text_fallback_hits.iter())
+        {
+            result_paths.push(item.path.clone());
+        }
+        report.completeness_and_caveats.stale_files =
+            u64::try_from(self.stale_source_paths(&result_paths)?.len()).unwrap_or(u64::MAX);
         Ok(report)
     }
 

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -426,10 +426,15 @@ impl IndexDatabase {
             self.heal_stale_paths(&stale)?; // NeedsReindex beyond the cap
             let healed =
                 crate::query::symbol::lookup_candidates(self.storage.connection(), selector)?;
-            if healed.candidates.is_empty() && !lookup.candidates.is_empty() {
-                // A `symbol_id` selector can't survive a reindex (ids are reassigned per #149), so
-                // the re-resolve finds nothing. Keep the pre-heal candidates rather than return
-                // empty, but flag the files as stale so the caller knows the positions are old.
+            // A `symbol_id` selector can't survive a reindex (ids are reassigned per #149), so a
+            // re-resolve by the OLD id finds nothing even though the symbol still exists — keep the
+            // pre-heal candidates, flagged stale. For a name/symbol_path/logical selector an empty
+            // re-resolve means the symbol was genuinely deleted/renamed by the edit, so we must NOT
+            // resurrect a ghost with dead ids and old offsets — return the (empty) healed result.
+            if healed.candidates.is_empty()
+                && !lookup.candidates.is_empty()
+                && selector.symbol_id.is_some()
+            {
                 lookup.stale_files = stale;
             } else {
                 lookup = healed;
@@ -440,6 +445,25 @@ impl IndexDatabase {
         }
         self.enrich_symbol_hits_with_load_bearing(&mut lookup.candidates)?;
         Ok(lookup)
+    }
+
+    /// The active-scope file path that defines `qualified_name` (lowest symbol id on a tie), or
+    /// `None` if unresolved — used to fold a direct callee's DEFINITION file into impact staleness.
+    /// Scoped through the per-connection `files` view, like `active_symbol_id_for_qualified_name`.
+    fn file_for_qualified_name(&self, qualified_name: &str) -> anyhow::Result<Option<String>> {
+        Ok(self
+            .storage
+            .connection()
+            .query_row(
+                "SELECT files.path FROM symbols
+                 JOIN files ON files.id = symbols.file_id
+                 WHERE symbols.qualified_name = ?1
+                 ORDER BY symbols.id
+                 LIMIT 1",
+                [qualified_name],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?)
     }
 
     /// The indexed `files.sha256` for `path` in the ACTIVE checkout (via the per-connection `files`
@@ -1830,6 +1854,16 @@ impl IndexDatabase {
         {
             if let Some(callsite) = &hop.callsite {
                 result_paths.push(callsite.path.clone());
+            }
+        }
+        // A direct callee resolves to a DEFINITION in another file; if THAT file changed, the
+        // resolution is stale even though the call-site file didn't — so add each returned callee's
+        // target definition file, not just its call site (#151 review).
+        for hop in report.direct_semantic_callees.iter() {
+            if let Some(name) = hop.to_symbol.as_deref().or(hop.target_qualified_name.as_deref())
+                && let Some(path) = self.file_for_qualified_name(name)?
+            {
+                result_paths.push(path);
             }
         }
         for item in report

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -8001,3 +8001,110 @@ fn impact_completeness_flags_dirty_result_files() {
 
     fs::remove_dir_all(root).unwrap();
 }
+
+#[test]
+fn symbol_lookup_does_not_resurrect_a_deleted_symbol_after_heal() {
+    // #151 review (P1): when an edit deletes/renames a symbol, healing the stale file and
+    // re-resolving by NAME returns nothing — symbol_candidates must NOT keep the pre-heal ghost
+    // (dead id, old offsets). The pre-heal fallback is only for symbol_id selectors.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn doomed() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let by_name = crate::query::symbol::SymbolSelector {
+        logical_symbol_id: None,
+        symbol_id: None,
+        symbol_path: None,
+        symbol: Some("doomed".to_string()),
+        language: None,
+        allow_ambiguous: true,
+        limit: 10,
+    };
+    assert!(!db.symbol_candidates(&by_name).unwrap().candidates.is_empty(), "found before delete");
+
+    // The edit removes `doomed` entirely.
+    fs::write(root.join("src/lib.rs"), "pub fn something_else() {}\n").unwrap();
+
+    let after = db.symbol_candidates(&by_name).unwrap();
+    assert!(
+        after.candidates.is_empty(),
+        "a deleted symbol must not be resurrected after heal: {:?}",
+        after.candidates
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn symbol_lookup_by_id_keeps_pre_heal_candidate_flagged_stale() {
+    // #151 review (P1): a symbol_id selector can't survive a reindex (ids reassigned), so the
+    // re-resolve is empty — keep the pre-heal candidate flagged stale rather than vanish.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn keep() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    // `symbols()` does not heal, so this id is from the clean index.
+    let id = db.symbols("keep", Some(Language::Rust), 10).unwrap().remove(0).symbol_id;
+    fs::write(root.join("src/lib.rs"), "// a\n// b\npub fn keep() {}\n").unwrap();
+
+    let by_id = crate::query::symbol::SymbolSelector {
+        logical_symbol_id: None,
+        symbol_id: Some(id),
+        symbol_path: None,
+        symbol: None,
+        language: None,
+        allow_ambiguous: true,
+        limit: 10,
+    };
+    let res = db.symbol_candidates(&by_id).unwrap();
+    assert!(!res.candidates.is_empty(), "symbol_id selector keeps the pre-heal candidate");
+    assert!(!res.stale_files.is_empty(), "and flags the file stale: {:?}", res.stale_files);
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn impact_completeness_flags_a_dirty_callee_definition_file() {
+    // #151 review (P2): a callee defined in another file that's edited makes the resolution stale;
+    // the callee's DEFINITION file must be counted, not just the call-site file.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub mod a;\npub mod b;\n").unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn caller() { crate::b::callee(); }\n").unwrap();
+    fs::write(root.join("src/b.rs"), "pub fn callee() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let caller = db.symbols("caller", Some(Language::Rust), 10).unwrap().remove(0);
+    let clean =
+        db.impact_surface_report_for_selected_symbol(&caller, 20, &Default::default()).unwrap();
+    let resolved_to_b = clean
+        .direct_semantic_callees
+        .iter()
+        .any(|hop| hop.to_symbol.as_deref().is_some_and(|s| s.contains("b.rs")));
+    assert!(
+        resolved_to_b,
+        "callee resolved cross-file to b.rs: {:?}",
+        clean.direct_semantic_callees
+    );
+    assert_eq!(clean.completeness_and_caveats.stale_files, 0, "nothing dirty yet");
+
+    // Edit ONLY the callee's definition file (b.rs), not the call-site file (a.rs).
+    fs::write(root.join("src/b.rs"), "// shifted\npub fn callee() {}\n").unwrap();
+    let dirty =
+        db.impact_surface_report_for_selected_symbol(&caller, 20, &Default::default()).unwrap();
+    assert!(
+        dirty.completeness_and_caveats.stale_files >= 1,
+        "the dirty callee definition file must be flagged: {:?}",
+        dirty.completeness_and_caveats
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -7932,3 +7932,72 @@ fn impact_report_flags_a_section_truncated_at_limit() {
 
     fs::remove_dir_all(root).unwrap();
 }
+
+#[test]
+fn symbol_lookup_heals_stale_line_numbers_after_an_edit() {
+    // #147: symbol rows aren't anchor-relocated like chunks, so an edit shifts their byte/line
+    // positions until reindex. symbol_candidates must lazily heal the matched file and return
+    // current positions (and report no residual stale files).
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn target() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let selector = crate::query::symbol::SymbolSelector {
+        logical_symbol_id: None,
+        symbol_id: None,
+        symbol_path: None,
+        symbol: Some("target".to_string()),
+        language: None,
+        allow_ambiguous: true,
+        limit: 10,
+    };
+    let before = db.symbol_candidates(&selector).unwrap();
+    let before_byte = before.candidates[0].start_byte;
+    assert!(before.stale_files.is_empty(), "clean index has no stale files");
+
+    // Shift `target` down on disk WITHOUT reindexing — the index is now stale for this file.
+    fs::write(root.join("src/lib.rs"), "// a\n// b\n// c\npub fn target() {}\n").unwrap();
+
+    let after = db.symbol_candidates(&selector).unwrap();
+    assert!(after.stale_files.is_empty(), "matched file was healed: {:?}", after.stale_files);
+    assert!(
+        after.candidates[0].start_byte > before_byte,
+        "healed lookup reflects the shifted position: {} !> {before_byte}",
+        after.candidates[0].start_byte
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn impact_completeness_flags_dirty_result_files() {
+    // #148: a result file dirty vs the index is counted in completeness.stale_files. Resolve via
+    // the non-healing `symbols()` so the edit isn't healed away before impact sees it.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn hub() {}\npub fn a() { hub(); }\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let hub = db.symbols("hub", Some(Language::Rust), 10).unwrap().remove(0);
+    let clean =
+        db.impact_surface_report_for_selected_symbol(&hub, 20, &Default::default()).unwrap();
+    assert_eq!(clean.completeness_and_caveats.stale_files, 0, "nothing dirty right after rebuild");
+
+    // Edit the symbol's file on disk without reindexing.
+    fs::write(root.join("src/lib.rs"), "// shifted\npub fn hub() {}\npub fn a() { hub(); }\n")
+        .unwrap();
+    let dirty =
+        db.impact_surface_report_for_selected_symbol(&hub, 20, &Default::default()).unwrap();
+    assert!(
+        dirty.completeness_and_caveats.stale_files >= 1,
+        "the dirty symbol file must be flagged: {:?}",
+        dirty.completeness_and_caveats
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}

--- a/crates/rag-rat-core/src/query/symbol.rs
+++ b/crates/rag-rat-core/src/query/symbol.rs
@@ -37,10 +37,15 @@ pub struct SymbolHit {
     pub importance: Option<crate::query::load_bearing::ImportanceEnrichment>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Default, Serialize)]
 pub struct SymbolLookup {
     pub candidates: Vec<SymbolHit>,
     pub disambiguation_required: bool,
+    /// Files among the candidates whose on-disk content differs from the index (dirty relative to
+    /// HEAD/overlay) and that the lazy heal did not bring current — so a candidate's line numbers
+    /// may be stale (#147/#148). Empty in the common case (heal succeeded or nothing was dirty).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub stale_files: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -101,6 +106,7 @@ pub fn lookup_candidates(
     Ok(SymbolLookup {
         disambiguation_required: needs_disambiguation(&candidates, selector.allow_ambiguous),
         candidates,
+        stale_files: Vec::new(),
     })
 }
 


### PR DESCRIPTION
Implements the freshness-after-write fixes surfaced from the agent dogfooding session.

## #147 — `symbol_lookup` lazy-heals stale positions
Symbol rows carry stored `start_byte`/`end_byte` with **no anchor relocation** (unlike `read_chunk`, which validates+relocates against current source). So after you edit a file, `symbol_lookup` returns pre-edit line numbers until the debounced watcher reindexes (~0.4–2.5 s) — exactly when you're iterating.

`symbol_candidates` now: detect matched files dirty vs the index (`disk sha != files.sha256`) → heal them inline (bounded by `MAX_AUTO_HEAL_FILES_PER_CALL`, `NeedsReindex` beyond it — same contract as `search_with_heal`) → re-resolve so positions/ids are current. A `symbol_id` selector that can't survive the reindex (ids are reassigned, see #149) keeps its pre-heal candidates flagged stale rather than returning empty.

## #148 — flag dirty result files
- `SymbolLookup` gains `stale_files` (residual after heal; empty in the common case).
- `impact_surface` populates `completeness.stale_files` over the selected symbol's file, the caller/callee call-site files, and the current-source item sections. **Flag-only** for impact (not heal): its neighbor set is unbounded, so an inline heal can't be bounded the way symbol_lookup's matched-file heal can — the agent re-runs `symbol_lookup` (which heals) for a specific symbol if it needs fresh positions.
- `semantic_search` already heals stale hits via `search_with_heal`, so it needs no separate flag.

Shared helpers on `IndexDatabase`: `stale_source_paths` (one read+hash per distinct result path), `heal_stale_paths` (bounded heal + FTS sync), `indexed_sha_for_path`.

## Tests
- `symbol_lookup_heals_stale_line_numbers_after_an_edit` — edit shifts a symbol; lookup by name returns the new position, `stale_files` empty.
- `impact_completeness_flags_dirty_result_files` — editing the symbol's file makes `completeness.stale_files >= 1`.

Full core (421) + mcp (20) + CLI green; clippy + nightly-fmt clean.

Closes #147
Closes #148
