### PR TITLE
feat: opaque sym_<hex> symbol handle; drop ephemeral symbol_id from the wire (#149)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .rag-rat/
 target/
+
+# Plans/specs are kept on disk for review, never committed (see dont-commit-plans).
+docs/plans/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,12 @@ Reach for these first:
 - **`important_symbols`** — load-bearing symbols by (SCIP-aware) PageRank; pass `personalize` to
   bias toward what you're editing. Compiler-grade once `rag-rat oracle run` has run.
 
-**Symbol handle:** symbol-returning tools emit `logical_symbol_id`, an opaque `sym_<hex>` token —
-the stable handle to cache and pass back into graph/impact/memory tools (copy verbatim; never parse
+**Symbol handle:** symbol-returning tools emit `id`, an opaque `sym_<hex>` token — the stable handle
+to cache and pass back into graph/impact/memory tools as the `id` param (copy verbatim; never parse
 it as a number). There is no numeric `symbol_id` on the wire (it's an internal rowid reassigned on
-every reindex). Use `symbol_path` for the human-readable identity.
+every reindex). Use `ref` (the `path::name` qualified name) for the human-readable identity. The
+symbol-tool params are `ref` / `id` / `lang` (formerly `symbol_path` / `logical_symbol_id` /
+`language`).
 
 Why this beats grep here:
 - Results carry **provenance**: confidence labels, coverage warnings, and raw evidence, so you can
@@ -59,7 +61,7 @@ Codex's own store) is invisible to the others. rag-rat is the **cross-agent memo
 anything another agent would benefit from here.
 
 How to do it well:
-- **Anchor to the tightest stable target.** Prefer a `logical_symbol_id` binding (the `sym_<hex>`
+- **Anchor to the tightest stable target.** Prefer an `id` binding (the `sym_<hex>` logical-symbol
   handle — self-heals across cross-file moves via the relocation engine); fall back to a `path`
   binding for file/area-level notes, or a commit/GitHub ref for historical rationale.
 - **Pick the right `kind`:** `Invariant` (must stay true), `Decision`/`RejectedAlternative` (why it's

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,11 @@ Reach for these first:
 - **`important_symbols`** — load-bearing symbols by (SCIP-aware) PageRank; pass `personalize` to
   bias toward what you're editing. Compiler-grade once `rag-rat oracle run` has run.
 
+**Symbol handle:** symbol-returning tools emit `logical_symbol_id`, an opaque `sym_<hex>` token —
+the stable handle to cache and pass back into graph/impact/memory tools (copy verbatim; never parse
+it as a number). There is no numeric `symbol_id` on the wire (it's an internal rowid reassigned on
+every reindex). Use `symbol_path` for the human-readable identity.
+
 Why this beats grep here:
 - Results carry **provenance**: confidence labels, coverage warnings, and raw evidence, so you can
   judge them rather than trust them blindly.
@@ -54,9 +59,9 @@ Codex's own store) is invisible to the others. rag-rat is the **cross-agent memo
 anything another agent would benefit from here.
 
 How to do it well:
-- **Anchor to the tightest stable target.** Prefer a `symbol_id`/`logical_symbol_id` binding (these
-  now self-heal across cross-file moves — see the relocation engine); fall back to a `path` binding
-  for file/area-level notes, or a commit/GitHub ref for historical rationale.
+- **Anchor to the tightest stable target.** Prefer a `logical_symbol_id` binding (the `sym_<hex>`
+  handle — self-heals across cross-file moves via the relocation engine); fall back to a `path`
+  binding for file/area-level notes, or a commit/GitHub ref for historical rationale.
 - **Pick the right `kind`:** `Invariant` (must stay true), `Decision`/`RejectedAlternative` (why it's
   this way / why not the other), `Risk` / `BugPattern` (footguns), `PerformanceNote`, `PlatformQuirk`,
   `FFIBoundary`. Write a concrete title, and a body with the *why* and *how to apply* — not just *what*.

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -155,11 +155,12 @@ pub(crate) struct ImportantSymbolsArgs {
     /// Max load-bearing symbols to return.
     #[arg(long)]
     pub limit: Option<u32>,
-    /// Symbols to bias importance toward (the symbols you're working on) — names, symbol paths, or
-    /// numeric ids, comma-separated or repeated. A numeric value is a raw symbol id; otherwise
-    /// it's resolved by symbol path then name (ambiguous/missing entries are skipped). Empty =
-    /// global importance (the CLI is global-by-default — it never auto-seeds from the git
-    /// diff).
+    /// Symbols to bias importance toward (the symbols you're working on) — names, refs
+    /// (path::name), or sym_<hex> handles, comma-separated or repeated. A sym_<hex> handle
+    /// resolves to its logical symbol's members; otherwise the entry is resolved by ref then
+    /// name (ambiguous/missing entries are skipped). Raw numeric symbol ids are NOT accepted —
+    /// they are reindex-churned rowids (#149). Empty = global importance (the CLI is
+    /// global-by-default — it never auto-seeds from the git diff).
     #[arg(long, value_delimiter = ',')]
     pub personalize: Vec<String>,
 }

--- a/crates/rag-rat-cli/tests/mcp_stdio.rs
+++ b/crates/rag-rat-cli/tests/mcp_stdio.rs
@@ -107,7 +107,7 @@ fn mcp_stdio_smoke_lists_and_calls_core_tools() {
             "method": "tools/call",
             "params": {
                 "name": "papertrail_for_symbol",
-                "arguments": {"symbol": "open_database", "language": "rust", "limit": 1}
+                "arguments": {"symbol": "open_database", "lang": "rust", "limit": 1}
             }
         }),
     );

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -1516,7 +1516,6 @@ impl IndexDatabase {
                 symbol_path: symbol.qualified_name.clone(),
                 pattern: pattern.to_string(),
                 resolution: options.resolution_mode.as_str().to_string(),
-                include_tests,
             },
             logical_symbol,
             variants,

--- a/crates/rag-rat-core/src/index/query_api.rs
+++ b/crates/rag-rat-core/src/index/query_api.rs
@@ -7,8 +7,8 @@ use crate::index::oracle::{
 use crate::query::pagerank::ImportantSymbolsResult;
 
 /// Inputs to [`IndexDatabase::important_symbols`]. The seed (`personalize`) takes names, paths, or
-/// numeric ids; `auto_seed_from_diff` is the MCP-only default (seed from the current git diff when
-/// no explicit seed is given) — the CLI passes `false` so it stays global-by-default. The
+/// `sym_<hex>` handles; `auto_seed_from_diff` is the MCP-only default (seed from the current git
+/// diff when no explicit seed is given) — the CLI passes `false` so it stays global-by-default. The
 /// intentional MCP/CLI divergence is acceptance-invariant #1.
 pub struct ImportantSymbolsRequest {
     pub limit: usize,
@@ -2074,8 +2074,33 @@ impl IndexDatabase {
             if entry.is_empty() {
                 continue;
             }
-            if let Ok(id) = entry.parse::<i64>() {
-                symbol_ids.push(id);
+            // An opaque `sym_<hex>` handle — what every symbol-returning tool now emits as the id
+            // to feed back here (#149). Resolve the logical symbol to its in-scope
+            // member rowids. A raw numeric id is deliberately NOT accepted: the wire
+            // dropped `symbol_id` (reindex-churned), so a bare number would be a stale
+            // rowid that silently seeds the wrong symbol.
+            if entry.starts_with("sym_") {
+                let Some(logical_symbol_id) = crate::serde_big_id::parse_sym_handle(entry) else {
+                    unresolved += 1;
+                    continue;
+                };
+                let by_handle = SymbolSelector {
+                    logical_symbol_id: Some(logical_symbol_id),
+                    symbol_id: None,
+                    symbol_path: None,
+                    symbol: None,
+                    language: None,
+                    allow_ambiguous: true,
+                    limit: PER_NAME_SEED_CAP,
+                };
+                let members =
+                    crate::query::symbol::lookup_candidates(self.storage.connection(), &by_handle)?
+                        .candidates;
+                if members.is_empty() {
+                    unresolved += 1;
+                } else {
+                    symbol_ids.extend(members.into_iter().map(|hit| hit.symbol_id));
+                }
                 continue;
             }
             // Try `symbol_path` (EXACT qualified name) FIRST: an unambiguous fully-qualified name
@@ -3448,20 +3473,27 @@ mod oracle_surfacing_tests {
         assert_eq!(seed.skipped.no_symbols, 1, "the bogus name is skipped, not fatal");
         assert!(result.reason.is_none());
 
-        // A raw numeric id is accepted verbatim (the `target` symbol id).
+        // A `sym_<hex>` handle — the id every symbol-returning tool now emits (#149) — resolves to
+        // its logical symbol's members and seeds them. A raw numeric rowid is deliberately NOT
+        // accepted: the wire dropped `symbol_id`, so a bare number is treated as a name/path.
         let target_id: i64 = db
             .storage
             .connection()
             .query_row("SELECT id FROM symbols WHERE name = 'target' LIMIT 1", [], |r| r.get(0))
             .unwrap();
-        let by_id = db
+        let handle =
+            crate::query::symbol::logical_for_symbol_id(db.storage.connection(), target_id)
+                .unwrap()
+                .map(|logical| crate::serde_big_id::format_sym_handle(logical.logical_symbol_id))
+                .expect("the `target` symbol has a logical handle");
+        let by_handle = db
             .important_symbols(ImportantSymbolsRequest {
                 limit: 20,
-                personalize: vec![target_id.to_string()],
+                personalize: vec![handle],
                 auto_seed_from_diff: false,
             })
             .unwrap();
-        assert_eq!(by_id.mode, crate::query::pagerank::ImportanceMode::PersonalizedToChanges);
+        assert_eq!(by_handle.mode, crate::query::pagerank::ImportanceMode::PersonalizedToChanges);
 
         // All-missing seed → global fall-through WITH a reason (never silent, never an error).
         let all_missing = db

--- a/crates/rag-rat-core/src/query/graph/mod.rs
+++ b/crates/rag-rat-core/src/query/graph/mod.rs
@@ -192,7 +192,6 @@ pub struct CompareGraphTextQuery {
     pub symbol_path: String,
     pub pattern: String,
     pub resolution: String,
-    pub include_tests: bool,
 }
 
 #[derive(Debug, Default, Serialize)]

--- a/crates/rag-rat-core/src/query/graph/mod.rs
+++ b/crates/rag-rat-core/src/query/graph/mod.rs
@@ -53,15 +53,16 @@ pub struct GraphTraversalQuery {
     #[serde(skip_serializing)]
     pub symbol_id: Option<i64>,
     // Opaque `sym_<hex>` symbol handle (stable, JSON-safe — #130/#149).
-    #[serde(serialize_with = "crate::serde_big_id::sym_handle_opt::serialize")]
+    #[serde(rename = "id", serialize_with = "crate::serde_big_id::sym_handle_opt::serialize")]
     pub logical_symbol_id: Option<i64>,
+    #[serde(rename = "ref")]
     pub symbol_path: String,
     pub resolution: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct LogicalSymbol {
-    #[serde(serialize_with = "crate::serde_big_id::sym_handle::serialize")]
+    #[serde(rename = "id", serialize_with = "crate::serde_big_id::sym_handle::serialize")]
     pub logical_symbol_id: i64,
     pub qualified_name: String,
     pub variant_count: u64,
@@ -105,6 +106,7 @@ pub struct GraphCoverage {
 #[derive(Debug, Serialize)]
 pub struct GraphPathCoverage {
     pub path: String,
+    #[serde(rename = "lang")]
     pub language: String,
     pub parser_status: String,
     pub graph_status: String,
@@ -184,8 +186,9 @@ pub struct CompareGraphTextQuery {
     #[serde(skip_serializing)]
     pub symbol_id: Option<i64>,
     // Opaque `sym_<hex>` symbol handle (stable, JSON-safe — #130/#149).
-    #[serde(serialize_with = "crate::serde_big_id::sym_handle_opt::serialize")]
+    #[serde(rename = "id", serialize_with = "crate::serde_big_id::sym_handle_opt::serialize")]
     pub logical_symbol_id: Option<i64>,
+    #[serde(rename = "ref")]
     pub symbol_path: String,
     pub pattern: String,
     pub resolution: String,

--- a/crates/rag-rat-core/src/query/graph/mod.rs
+++ b/crates/rag-rat-core/src/query/graph/mod.rs
@@ -49,9 +49,11 @@ pub struct GraphTraversalReport {
 #[derive(Debug, Serialize)]
 pub struct GraphTraversalQuery {
     pub tool: String,
+    // Internal rowid — never serialized (reindex-churned, #149); the handle is logical_symbol_id.
+    #[serde(skip_serializing)]
     pub symbol_id: Option<i64>,
-    // Content-derived 64-bit hash > 2^53 — emit as a string so JSON clients don't round it (#130).
-    #[serde(serialize_with = "crate::serde_big_id::big_id_opt::serialize")]
+    // Opaque `sym_<hex>` symbol handle (stable, JSON-safe — #130/#149).
+    #[serde(serialize_with = "crate::serde_big_id::sym_handle_opt::serialize")]
     pub logical_symbol_id: Option<i64>,
     pub symbol_path: String,
     pub resolution: String,
@@ -59,7 +61,7 @@ pub struct GraphTraversalQuery {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct LogicalSymbol {
-    #[serde(serialize_with = "crate::serde_big_id::big_id::serialize")]
+    #[serde(serialize_with = "crate::serde_big_id::sym_handle::serialize")]
     pub logical_symbol_id: i64,
     pub qualified_name: String,
     pub variant_count: u64,
@@ -68,6 +70,8 @@ pub struct LogicalSymbol {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct LogicalSymbolVariant {
+    // Internal rowid only — a variant is identified on the wire by cfg/signature/lines (#149).
+    #[serde(skip_serializing)]
     pub symbol_id: i64,
     pub cfg_expr: Option<String>,
     pub signature_hash: Option<String>,
@@ -176,9 +180,11 @@ pub struct CompareGraphTextReport {
 
 #[derive(Debug, Serialize)]
 pub struct CompareGraphTextQuery {
+    // Internal rowid — never serialized (reindex-churned, #149); the handle is logical_symbol_id.
+    #[serde(skip_serializing)]
     pub symbol_id: Option<i64>,
-    // Content-derived 64-bit hash > 2^53 — emit as a string so JSON clients don't round it (#130).
-    #[serde(serialize_with = "crate::serde_big_id::big_id_opt::serialize")]
+    // Opaque `sym_<hex>` symbol handle (stable, JSON-safe — #130/#149).
+    #[serde(serialize_with = "crate::serde_big_id::sym_handle_opt::serialize")]
     pub logical_symbol_id: Option<i64>,
     pub symbol_path: String,
     pub pattern: String,

--- a/crates/rag-rat-core/src/query/graph_meta.rs
+++ b/crates/rag-rat-core/src/query/graph_meta.rs
@@ -53,15 +53,21 @@ pub struct GraphEvidence {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct GraphSymbol {
+    // Internal rowid — never serialized (reindex-churned, #149); the wire identity is `ref` /
+    // qualified_name. (Was leaking onto the wire as `id` before the #149 sweep covered this
+    // struct.)
+    #[serde(skip_serializing)]
     pub id: i64,
     pub name: String,
     pub qualified_name: String,
     pub kind: String,
+    #[serde(rename = "ref")]
     pub symbol_path: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct CallerEvidence {
+    #[serde(rename = "ref")]
     pub symbol_path: String,
     pub path: String,
     pub line: i64,

--- a/crates/rag-rat-core/src/query/impact/mod.rs
+++ b/crates/rag-rat-core/src/query/impact/mod.rs
@@ -63,12 +63,6 @@ pub struct ImpactSurfaceQuery {
     pub symbol_path: Option<String>,
     pub query: Option<String>,
     pub resolution: String,
-    pub include_tests: bool,
-    pub include_docs: bool,
-    pub include_git: bool,
-    pub include_papertrail: bool,
-    pub include_text_fallback: bool,
-    pub include_memories: bool,
 }
 
 #[derive(Debug, Default, Serialize)]
@@ -273,12 +267,6 @@ pub fn impact_surface_report_for_symbol(
             symbol_path: Some(symbol.qualified_name.clone()),
             query: None,
             resolution: options.resolution_mode.as_str().to_string(),
-            include_tests: options.include_tests,
-            include_docs: options.include_docs,
-            include_git: options.include_git,
-            include_papertrail: options.include_papertrail,
-            include_text_fallback: options.include_text_fallback,
-            include_memories: options.include_memories,
         },
         completeness_and_caveats: ImpactCompleteness {
             exact_graph_callers: u64::try_from(direct_semantic_callers.len()).unwrap_or(u64::MAX),

--- a/crates/rag-rat-core/src/query/impact/mod.rs
+++ b/crates/rag-rat-core/src/query/impact/mod.rs
@@ -18,6 +18,7 @@ use crate::query::symbol::SymbolHit;
 #[derive(Debug, Serialize)]
 pub struct ImpactItem {
     pub path: String,
+    #[serde(rename = "lang")]
     pub language: String,
     pub kind: String,
     pub symbol: Option<String>,
@@ -58,6 +59,7 @@ pub struct ImpactSurfaceQuery {
     // query.
     #[serde(skip_serializing)]
     pub symbol_id: Option<i64>,
+    #[serde(rename = "ref")]
     pub symbol_path: Option<String>,
     pub query: Option<String>,
     pub resolution: String,

--- a/crates/rag-rat-core/src/query/impact/mod.rs
+++ b/crates/rag-rat-core/src/query/impact/mod.rs
@@ -54,6 +54,9 @@ pub struct ImpactSurfaceReport {
 
 #[derive(Debug, Serialize)]
 pub struct ImpactSurfaceQuery {
+    // Internal rowid — never serialized (reindex-churned, #149); `symbol_path` identifies the
+    // query.
+    #[serde(skip_serializing)]
     pub symbol_id: Option<i64>,
     pub symbol_path: Option<String>,
     pub query: Option<String>,

--- a/crates/rag-rat-core/src/query/memory/mod.rs
+++ b/crates/rag-rat-core/src/query/memory/mod.rs
@@ -51,6 +51,7 @@ pub struct RepoMemoryBinding {
     pub end_line: Option<i64>,
     // Opaque `sym_<hex>` symbol handle (stable, JSON-safe — #130/#149).
     #[serde(
+        rename = "id",
         skip_serializing_if = "Option::is_none",
         serialize_with = "crate::serde_big_id::sym_handle_opt::serialize"
     )]
@@ -94,11 +95,13 @@ pub struct RepoMemoryCallPath {
     pub memory_id: String,
     // Opaque `sym_<hex>` symbol handles (stable, JSON-safe — #130/#149).
     #[serde(
+        rename = "start_id",
         skip_serializing_if = "Option::is_none",
         serialize_with = "crate::serde_big_id::sym_handle_opt::serialize"
     )]
     pub start_logical_symbol_id: Option<i64>,
     #[serde(
+        rename = "end_id",
         skip_serializing_if = "Option::is_none",
         serialize_with = "crate::serde_big_id::sym_handle_opt::serialize"
     )]
@@ -131,7 +134,11 @@ pub struct RepoMemoryCreate {
 pub struct RepoMemoryBindTarget {
     // Accept the opaque `sym_<hex>` handle (#149); `default` keeps it optional under the custom
     // deserializer.
-    #[serde(default, deserialize_with = "crate::serde_big_id::sym_handle_opt::deserialize")]
+    #[serde(
+        rename = "id",
+        default,
+        deserialize_with = "crate::serde_big_id::sym_handle_opt::deserialize"
+    )]
     pub logical_symbol_id: Option<i64>,
     // Internal rowid — NOT accepted from the wire (reindex-churned, #149); bind by handle/path.
     // CLI sets it programmatically. `skip_deserializing` keeps it off the input schema.
@@ -146,9 +153,17 @@ pub struct RepoMemoryBindTarget {
     pub github_owner: Option<String>,
     pub github_repo: Option<String>,
     pub github_number: Option<i64>,
-    #[serde(default, deserialize_with = "crate::serde_big_id::sym_handle_opt::deserialize")]
+    #[serde(
+        rename = "start_id",
+        default,
+        deserialize_with = "crate::serde_big_id::sym_handle_opt::deserialize"
+    )]
     pub start_logical_symbol_id: Option<i64>,
-    #[serde(default, deserialize_with = "crate::serde_big_id::sym_handle_opt::deserialize")]
+    #[serde(
+        rename = "end_id",
+        default,
+        deserialize_with = "crate::serde_big_id::sym_handle_opt::deserialize"
+    )]
     pub end_logical_symbol_id: Option<i64>,
     pub edge_sequence_hash: Option<String>,
     pub path_summary: Option<String>,

--- a/crates/rag-rat-core/src/query/memory/mod.rs
+++ b/crates/rag-rat-core/src/query/memory/mod.rs
@@ -49,13 +49,14 @@ pub struct RepoMemoryBinding {
     pub start_line: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub end_line: Option<i64>,
-    // Content-derived 64-bit hash > 2^53 — emit as a string so JSON clients don't round it (#130).
+    // Opaque `sym_<hex>` symbol handle (stable, JSON-safe — #130/#149).
     #[serde(
         skip_serializing_if = "Option::is_none",
-        serialize_with = "crate::serde_big_id::big_id_opt::serialize"
+        serialize_with = "crate::serde_big_id::sym_handle_opt::serialize"
     )]
     pub logical_symbol_id: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    // Internal rowid — never serialized (reindex-churned, #149); the handle is logical_symbol_id.
+    #[serde(skip_serializing)]
     pub symbol_id: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub chunk_id: Option<i64>,
@@ -91,16 +92,15 @@ pub struct RepoMemoryBinding {
 #[derive(Debug, Clone, Serialize)]
 pub struct RepoMemoryCallPath {
     pub memory_id: String,
-    // Content-derived 64-bit hashes > 2^53 — emit as strings so JSON clients don't round them
-    // (#130).
+    // Opaque `sym_<hex>` symbol handles (stable, JSON-safe — #130/#149).
     #[serde(
         skip_serializing_if = "Option::is_none",
-        serialize_with = "crate::serde_big_id::big_id_opt::serialize"
+        serialize_with = "crate::serde_big_id::sym_handle_opt::serialize"
     )]
     pub start_logical_symbol_id: Option<i64>,
     #[serde(
         skip_serializing_if = "Option::is_none",
-        serialize_with = "crate::serde_big_id::big_id_opt::serialize"
+        serialize_with = "crate::serde_big_id::sym_handle_opt::serialize"
     )]
     pub end_logical_symbol_id: Option<i64>,
     pub edge_sequence_hash: String,
@@ -129,12 +129,13 @@ pub struct RepoMemoryCreate {
 
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct RepoMemoryBindTarget {
-    // Content-derived 64-bit hash > 2^53 — accept it as a string (or number) so a >2^53 id isn't
-    // rounded by a JSON client before it reaches us (#130). `default` keeps the field optional now
-    // that a custom deserializer is attached (a plain `Option` no longer auto-defaults on
-    // absence).
-    #[serde(default, deserialize_with = "crate::serde_big_id::big_id_opt::deserialize")]
+    // Accept the opaque `sym_<hex>` handle (#149); `default` keeps it optional under the custom
+    // deserializer.
+    #[serde(default, deserialize_with = "crate::serde_big_id::sym_handle_opt::deserialize")]
     pub logical_symbol_id: Option<i64>,
+    // Internal rowid — NOT accepted from the wire (reindex-churned, #149); bind by handle/path.
+    // CLI sets it programmatically. `skip_deserializing` keeps it off the input schema.
+    #[serde(skip_deserializing)]
     pub symbol_id: Option<i64>,
     pub chunk_id: Option<i64>,
     pub edge_id: Option<i64>,
@@ -145,9 +146,9 @@ pub struct RepoMemoryBindTarget {
     pub github_owner: Option<String>,
     pub github_repo: Option<String>,
     pub github_number: Option<i64>,
-    #[serde(default, deserialize_with = "crate::serde_big_id::big_id_opt::deserialize")]
+    #[serde(default, deserialize_with = "crate::serde_big_id::sym_handle_opt::deserialize")]
     pub start_logical_symbol_id: Option<i64>,
-    #[serde(default, deserialize_with = "crate::serde_big_id::big_id_opt::deserialize")]
+    #[serde(default, deserialize_with = "crate::serde_big_id::sym_handle_opt::deserialize")]
     pub end_logical_symbol_id: Option<i64>,
     pub edge_sequence_hash: Option<String>,
     pub path_summary: Option<String>,

--- a/crates/rag-rat-core/src/query/mod.rs
+++ b/crates/rag-rat-core/src/query/mod.rs
@@ -24,10 +24,12 @@ pub(crate) fn round_score(value: f64) -> f64 {
 pub struct ReadChunk {
     pub chunk_id: i64,
     pub path: String,
+    #[serde(rename = "lang")]
     pub language: String,
     pub kind: String,
     pub start_line: i64,
     pub end_line: i64,
+    #[serde(rename = "ref")]
     pub symbol_path: Option<String>,
     pub text: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/rag-rat-core/src/query/pagerank.rs
+++ b/crates/rag-rat-core/src/query/pagerank.rs
@@ -275,6 +275,7 @@ pub struct SymbolImportance {
     /// Opaque `sym_<hex>` handle for this symbol — the stable id to feed into symbol_lookup /
     /// impact / find_callers. `None` only if the winner has no logical-symbol member row.
     #[serde(
+        rename = "id",
         skip_serializing_if = "Option::is_none",
         serialize_with = "crate::serde_big_id::sym_handle_opt::serialize"
     )]

--- a/crates/rag-rat-core/src/query/pagerank.rs
+++ b/crates/rag-rat-core/src/query/pagerank.rs
@@ -269,7 +269,16 @@ pub struct RankedImportance {
 /// A ranked load-bearing symbol.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct SymbolImportance {
+    // Internal rowid — never serialized (reindex-churned, #149); the handle is logical_symbol_id.
+    #[serde(skip_serializing)]
     pub symbol_id: i64,
+    /// Opaque `sym_<hex>` handle for this symbol — the stable id to feed into symbol_lookup /
+    /// impact / find_callers. `None` only if the winner has no logical-symbol member row.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::serde_big_id::sym_handle_opt::serialize"
+    )]
+    pub logical_symbol_id: Option<i64>,
     pub qualified_name: String,
     pub path: String,
     pub kind: String,
@@ -409,9 +418,10 @@ pub fn important_symbols(
         let symbol_id = symbol_ids[idx];
         let row = conn
             .query_row(
-                "SELECT s.qualified_name, s.kind, f.path
+                "SELECT s.qualified_name, s.kind, f.path, lsm.logical_symbol_id
                  FROM symbols s
                  JOIN files f ON f.id = s.file_id
+                 LEFT JOIN logical_symbol_members lsm ON lsm.symbol_id = s.id
                  WHERE s.id = ?1",
                 [symbol_id],
                 |row| {
@@ -419,12 +429,20 @@ pub fn important_symbols(
                         row.get::<_, String>(0)?,
                         row.get::<_, String>(1)?,
                         row.get::<_, String>(2)?,
+                        row.get::<_, Option<i64>>(3)?,
                     ))
                 },
             )
             .ok();
-        let Some((qualified_name, kind, path)) = row else { continue };
-        out.push(SymbolImportance { symbol_id, qualified_name, path, kind, score: scores[idx] });
+        let Some((qualified_name, kind, path, logical_symbol_id)) = row else { continue };
+        out.push(SymbolImportance {
+            symbol_id,
+            logical_symbol_id,
+            qualified_name,
+            path,
+            kind,
+            score: scores[idx],
+        });
     }
     Ok(RankedImportance { symbols: out, effective_seed_count })
 }

--- a/crates/rag-rat-core/src/query/repo_brief.rs
+++ b/crates/rag-rat-core/src/query/repo_brief.rs
@@ -92,6 +92,7 @@ pub struct RepoBriefMemoryCounts {
 #[derive(Debug, Serialize)]
 pub struct RepoBriefCandidate {
     pub path: String,
+    #[serde(rename = "lang")]
     pub language: String,
     pub kind: String,
     pub category: String,

--- a/crates/rag-rat-core/src/query/symbol.rs
+++ b/crates/rag-rat-core/src/query/symbol.rs
@@ -356,6 +356,18 @@ fn lookup_logical_members(
     for row in rows {
         hits.push(row?);
     }
+    // Stamp the logical handle onto every member: callers selecting by `logical_symbol_id` (impact,
+    // graph, memory) build their graph options from `SymbolHit.logical_symbol_id`, and a `None`
+    // here silently narrows the exact caller/callee set to the first concrete row instead of
+    // the whole logical group (#149 review). We already know the id, so set it without a
+    // per-member query.
+    if let Some(logical) = lookup_logical_by_id(conn, logical_symbol_id)? {
+        for hit in &mut hits {
+            hit.logical_symbol_id = Some(logical.logical_symbol_id);
+            hit.logical_variant_count = Some(logical.variant_count);
+            hit.logical_group_reason = Some(logical.group_reason.clone());
+        }
+    }
     Ok(hits)
 }
 

--- a/crates/rag-rat-core/src/query/symbol.rs
+++ b/crates/rag-rat-core/src/query/symbol.rs
@@ -13,6 +13,7 @@ pub struct SymbolHit {
     // The stable symbol handle: a content-derived id emitted as an opaque `sym_<hex>` token so a
     // JSON client can't round it (>2^53) or mistake it for a number to compute on (#130/#149).
     #[serde(
+        rename = "id",
         skip_serializing_if = "Option::is_none",
         serialize_with = "crate::serde_big_id::sym_handle_opt::serialize"
     )]
@@ -24,9 +25,11 @@ pub struct SymbolHit {
     pub file_id: i64,
     pub path: String,
     pub file_kind: String,
+    #[serde(rename = "lang")]
     pub language: String,
     pub name: String,
     pub qualified_name: String,
+    #[serde(rename = "ref")]
     pub symbol_path: String,
     pub kind: String,
     pub start_byte: i64,
@@ -54,8 +57,9 @@ pub struct SymbolLookup {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct LogicalSymbolHit {
-    #[serde(serialize_with = "crate::serde_big_id::sym_handle::serialize")]
+    #[serde(rename = "id", serialize_with = "crate::serde_big_id::sym_handle::serialize")]
     pub logical_symbol_id: i64,
+    #[serde(rename = "lang")]
     pub language: String,
     pub path: String,
     pub logical_name: String,

--- a/crates/rag-rat-core/src/query/symbol.rs
+++ b/crates/rag-rat-core/src/query/symbol.rs
@@ -5,12 +5,16 @@ use crate::language::Language;
 
 #[derive(Debug, Serialize)]
 pub struct SymbolHit {
+    // The raw rowid is the internal handle + FK target, but it's reassigned on every reindex
+    // (#149), so it never crosses the wire — `logical_symbol_id` is the stable, opaque handle a
+    // consumer caches/passes back. Kept on the struct for in-process use; never serialized.
+    #[serde(skip_serializing)]
     pub symbol_id: i64,
-    // logical_symbol_id is a content-derived 64-bit hash > 2^53; emit as a string so JSON clients
-    // don't round it (#130). symbol_id/file_id are small rowids and stay numbers.
+    // The stable symbol handle: a content-derived id emitted as an opaque `sym_<hex>` token so a
+    // JSON client can't round it (>2^53) or mistake it for a number to compute on (#130/#149).
     #[serde(
         skip_serializing_if = "Option::is_none",
-        serialize_with = "crate::serde_big_id::big_id_opt::serialize"
+        serialize_with = "crate::serde_big_id::sym_handle_opt::serialize"
     )]
     pub logical_symbol_id: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -50,7 +54,7 @@ pub struct SymbolLookup {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct LogicalSymbolHit {
-    #[serde(serialize_with = "crate::serde_big_id::big_id::serialize")]
+    #[serde(serialize_with = "crate::serde_big_id::sym_handle::serialize")]
     pub logical_symbol_id: i64,
     pub language: String,
     pub path: String,
@@ -63,6 +67,9 @@ pub struct LogicalSymbolHit {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct LogicalSymbolMember {
+    // Internal rowid only — a member is identified on the wire by its cfg/signature/lines, never
+    // by the reindex-churned id (#149).
+    #[serde(skip_serializing)]
     pub symbol_id: i64,
     pub cfg_expr: Option<String>,
     pub signature_hash: Option<String>,

--- a/crates/rag-rat-core/src/search/lexical.rs
+++ b/crates/rag-rat-core/src/search/lexical.rs
@@ -17,10 +17,12 @@ const GITHUB_WEIGHT: f64 = 0.02;
 pub struct SearchHit {
     pub chunk_id: i64,
     pub path: String,
+    #[serde(rename = "lang")]
     pub language: String,
     pub kind: String,
     pub start_line: i64,
     pub end_line: i64,
+    #[serde(rename = "ref")]
     pub symbol_path: Option<String>,
     pub score: f64,
     /// Which retrieval modes found this hit: "lexical" (BM25 only), "vector" (embedding cosine

--- a/crates/rag-rat-core/src/serde_big_id.rs
+++ b/crates/rag-rat-core/src/serde_big_id.rs
@@ -27,9 +27,23 @@ struct SymHandle(i64);
 
 const SYM_HANDLE_PREFIX: &str = "sym_";
 
+/// Format an `i64` symbol handle as its opaque `sym_<hex>` token (hex over the raw u64 bits, so any
+/// `i64` round-trips). The single source of truth for the on-the-wire handle shape — serde and any
+/// non-serde caller (e.g. seed-selector parsing) go through this and [`parse_sym_handle`].
+pub fn format_sym_handle(value: i64) -> String {
+    format!("{SYM_HANDLE_PREFIX}{:x}", value as u64)
+}
+
+/// Parse an opaque `sym_<hex>` handle back to its `i64`. `None` if the `sym_` prefix is missing or
+/// the remainder isn't valid hex — callers decide whether that's an error or a fall-through.
+pub fn parse_sym_handle(token: &str) -> Option<i64> {
+    let hex = token.strip_prefix(SYM_HANDLE_PREFIX)?;
+    u64::from_str_radix(hex, 16).ok().map(|bits| bits as i64)
+}
+
 impl Serialize for SymHandle {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&format!("{SYM_HANDLE_PREFIX}{:x}", self.0 as u64))
+        serializer.serialize_str(&format_sym_handle(self.0))
     }
 }
 
@@ -131,6 +145,18 @@ mod tests {
             "needs prefix"
         );
         assert!(serde_json::from_str::<Handle>(r#"{"id":"sym_zzz"}"#).is_err(), "bad hex");
+    }
+
+    #[test]
+    fn parse_and_format_sym_handle_round_trip() {
+        for value in [BIG, 0_i64, -1, i64::MAX, i64::MIN] {
+            let token = super::format_sym_handle(value);
+            assert!(token.starts_with("sym_"), "token must carry the prefix: {token}");
+            assert_eq!(super::parse_sym_handle(&token), Some(value), "round-trip via helpers");
+        }
+        assert_eq!(super::parse_sym_handle("23bad57dfb79ad5f"), None, "missing prefix → None");
+        assert_eq!(super::parse_sym_handle("sym_zzz"), None, "bad hex → None");
+        assert_eq!(super::parse_sym_handle("12345"), None, "bare number → None");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/serde_big_id.rs
+++ b/crates/rag-rat-core/src/serde_big_id.rs
@@ -1,17 +1,18 @@
-//! Serde for `i64` ids that exceed JSON's 2^53 safe-integer range — content-derived
-//! `logical_symbol_id` hashes (~2.5e18, far above 2^53 = 9_007_199_254_740_992). A JSON *number*
-//! cannot carry such a value losslessly: a client that parses JSON numbers as f64 (every JS-based
-//! MCP client) silently rounds it (`2574604874062343519` → `2574604874062343700`), so the id is
-//! corrupted in transit before the server ever sees it (#130).
+//! Serde for the symbol handle (`logical_symbol_id` and its call-path `start_/end_` variants) — a
+//! content-derived `i64` far above JSON's 2^53 safe-integer range (~2.5e18 vs
+//! 9_007_199_254_740_992). A JSON *number* cannot carry such a value losslessly: a client that
+//! parses numbers as f64 (every JS-based MCP client) silently rounds it, corrupting the id in
+//! transit (#130).
 //!
-//! The fix: these ids cross EVERY serde boundary (CLI `--json`, MCP JSON, MCP TOON) as a STRING.
-//! - Serialize → always a string, so a reader copies an opaque string and round-trips it intact.
-//! - Deserialize → accept a string OR a number, so callers within the safe range (and older
-//!   clients) keep working; the string form is what makes a >2^53 id survive.
+//! The handle therefore crosses every serde boundary (CLI `--json`, MCP JSON, MCP TOON) as an
+//! opaque `sym_<hex>` token (#149). A decimal string would also be lossless, but it still *looks*
+//! like a number and tempts a client to `parseInt` it (and round); the `sym_` prefix + hex make it
+//! unmistakably a handle, never a number — copy it verbatim and round-trip it intact. Deserialize
+//! accepts ONLY the token, so a stale numeric rowid passed by habit fails loudly.
 //!
-//! Apply with `#[serde(with = "crate::serde_big_id::big_id")]` on an `i64` field or
-//! `#[serde(with = "crate::serde_big_id::big_id_opt")]` on an `Option<i64>` field. On an MCP arg
-//! struct that derives `JsonSchema`, also add `#[schemars(with = "String")]` (or
+//! Apply with `#[serde(with = "crate::serde_big_id::sym_handle")]` on an `i64` field or
+//! `#[serde(with = "crate::serde_big_id::sym_handle_opt")]` on an `Option<i64>` field. On an MCP
+//! arg struct that derives `JsonSchema`, also add `#[schemars(with = "String")]` (or
 //! `Option<String>`) so the advertised input schema asks clients for a string.
 
 use std::fmt;
@@ -19,92 +20,69 @@ use std::fmt;
 use serde::de::{self, Deserialize, Deserializer, Unexpected, Visitor};
 use serde::{Serialize, Serializer};
 
-/// JSON's largest exactly-representable integer, `2^53 - 1`. A number outside `±MAX_SAFE_INTEGER`
-/// can't survive a JSON-number parse that goes through an f64, so by the time such a value reaches
-/// us as a number it has almost certainly already been rounded — accepting it would silently look
-/// up the WRONG id. The numeric deserialize path is therefore bounded to the safe range; anything
-/// larger MUST arrive as a string (#130 review).
-const MAX_SAFE_INTEGER: i64 = 9_007_199_254_740_991;
+/// An `i64` symbol handle that crosses serde as an opaque `sym_<hex>` token. Hex is over the raw
+/// u64 bit pattern so any `i64` round-trips exactly. Private — the public surface is the
+/// `sym_handle` / `sym_handle_opt` serde modules.
+struct SymHandle(i64);
 
-/// An `i64` that serializes as a decimal string and deserializes from either a string or a number.
-/// Private — the public surface is the `big_id` / `big_id_opt` serde modules.
-struct BigId(i64);
+const SYM_HANDLE_PREFIX: &str = "sym_";
 
-impl Serialize for BigId {
+impl Serialize for SymHandle {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&self.0.to_string())
+        serializer.serialize_str(&format!("{SYM_HANDLE_PREFIX}{:x}", self.0 as u64))
     }
 }
 
-impl<'de> Deserialize<'de> for BigId {
+impl<'de> Deserialize<'de> for SymHandle {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        deserializer.deserialize_any(BigIdVisitor)
+        deserializer.deserialize_str(SymHandleVisitor)
     }
 }
 
-/// The error for a numeric id outside the JSON safe-integer range — such a value can't be trusted
-/// (it may already be f64-rounded), so we reject it and point the caller at the string form.
-fn unsafe_number_message(value: impl fmt::Display) -> String {
-    format!(
-        "id {value} is outside JSON's safe-integer range (±2^53-1) and may have been rounded; \
-         pass it as a string"
-    )
-}
+struct SymHandleVisitor;
 
-struct BigIdVisitor;
-
-impl Visitor<'_> for BigIdVisitor {
-    type Value = BigId;
+impl Visitor<'_> for SymHandleVisitor {
+    type Value = SymHandle;
 
     fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("an i64 as a decimal string, or a JSON number within ±(2^53-1)")
+        f.write_str("a symbol handle string of the form `sym_<hex>`")
     }
 
-    fn visit_i64<E: de::Error>(self, value: i64) -> Result<BigId, E> {
-        if !(-MAX_SAFE_INTEGER..=MAX_SAFE_INTEGER).contains(&value) {
-            return Err(E::custom(unsafe_number_message(value)));
-        }
-        Ok(BigId(value))
-    }
-
-    fn visit_u64<E: de::Error>(self, value: u64) -> Result<BigId, E> {
-        if value > MAX_SAFE_INTEGER as u64 {
-            return Err(E::custom(unsafe_number_message(value)));
-        }
-        Ok(BigId(value as i64))
-    }
-
-    fn visit_str<E: de::Error>(self, value: &str) -> Result<BigId, E> {
-        value.parse::<i64>().map(BigId).map_err(|_| E::invalid_value(Unexpected::Str(value), &self))
+    fn visit_str<E: de::Error>(self, value: &str) -> Result<SymHandle, E> {
+        let hex = value.strip_prefix(SYM_HANDLE_PREFIX).ok_or_else(|| {
+            E::custom(format!("symbol handle must start with `{SYM_HANDLE_PREFIX}`: `{value}`"))
+        })?;
+        u64::from_str_radix(hex, 16)
+            .map(|bits| SymHandle(bits as i64))
+            .map_err(|_| E::invalid_value(Unexpected::Str(value), &self))
     }
 }
 
-/// `#[serde(with = "...")]` module for a required `i64` big id (string out, string-or-number in).
-pub mod big_id {
-    use super::{BigId, Deserialize, Deserializer, Serialize, Serializer};
+/// `#[serde(with = "...")]` module for a required `i64` symbol handle (`sym_<hex>` out, token in).
+pub mod sym_handle {
+    use super::{Deserialize, Deserializer, Serialize, Serializer, SymHandle};
 
     pub fn serialize<S: Serializer>(value: &i64, serializer: S) -> Result<S::Ok, S::Error> {
-        BigId(*value).serialize(serializer)
+        SymHandle(*value).serialize(serializer)
     }
 
     pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<i64, D::Error> {
-        BigId::deserialize(deserializer).map(|big| big.0)
+        SymHandle::deserialize(deserializer).map(|handle| handle.0)
     }
 }
 
-/// `#[serde(with = "...")]` module for an `Option<i64>` big id — `null`/absent stays `None`, a
-/// present value serializes as a string and deserializes from a string or a number.
-pub mod big_id_opt {
-    use super::{BigId, Deserialize, Deserializer, Serialize, Serializer};
+/// `#[serde(with = "...")]` module for an `Option<i64>` symbol handle — `null`/absent stays `None`.
+pub mod sym_handle_opt {
+    use super::{Deserialize, Deserializer, Serialize, Serializer, SymHandle};
 
     pub fn serialize<S: Serializer>(value: &Option<i64>, serializer: S) -> Result<S::Ok, S::Error> {
-        value.map(BigId).serialize(serializer)
+        value.map(SymHandle).serialize(serializer)
     }
 
     pub fn deserialize<'de, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Option<i64>, D::Error> {
-        Ok(Option::<BigId>::deserialize(deserializer)?.map(|big| big.0))
+        Ok(Option::<SymHandle>::deserialize(deserializer)?.map(|handle| handle.0))
     }
 }
 
@@ -113,79 +91,56 @@ mod tests {
     use serde::{Deserialize, Serialize};
 
     /// A content-derived logical_symbol_id beyond JS's 2^53 safe-integer ceiling — the value that
-    /// rounded to `...343700` as a JSON number in the field report.
+    /// rounded to `...343700` as a JSON number in the original field report (#130).
     const BIG: i64 = 2_574_604_874_062_343_519;
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
-    struct Req {
-        #[serde(with = "super::big_id")]
+    struct Handle {
+        #[serde(with = "super::sym_handle")]
         id: i64,
     }
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
-    struct Opt {
-        #[serde(with = "super::big_id_opt")]
+    struct HandleOpt {
+        #[serde(with = "super::sym_handle_opt")]
         id: Option<i64>,
     }
 
     #[test]
-    fn required_big_id_serializes_as_a_string() {
-        let json = serde_json::to_string(&Req { id: BIG }).unwrap();
-        assert_eq!(json, r#"{"id":"2574604874062343519"}"#, "must emit a string, not a number");
+    fn sym_handle_serializes_as_an_opaque_token() {
+        let json = serde_json::to_string(&Handle { id: BIG }).unwrap();
+        assert_eq!(json, r#"{"id":"sym_23bad57dfb79ad5f"}"#, "must emit sym_<hex>, not a number");
     }
 
     #[test]
-    fn required_big_id_round_trips_losslessly_through_json() {
-        let json = serde_json::to_string(&Req { id: BIG }).unwrap();
-        let back: Req = serde_json::from_str(&json).unwrap();
-        assert_eq!(back.id, BIG);
+    fn sym_handle_round_trips_losslessly_including_negative_and_zero() {
+        for value in [BIG, 0_i64, 1, -1, i64::MAX, i64::MIN] {
+            let json = serde_json::to_string(&Handle { id: value }).unwrap();
+            let back: Handle = serde_json::from_str(&json).unwrap();
+            assert_eq!(back.id, value, "round-trip failed for {value}");
+        }
     }
 
     #[test]
-    fn required_big_id_deserializes_from_a_string() {
-        let back: Req = serde_json::from_str(r#"{"id":"2574604874062343519"}"#).unwrap();
-        assert_eq!(back.id, BIG);
-    }
-
-    #[test]
-    fn required_big_id_still_accepts_a_safe_number_for_back_compat() {
-        // A small in-safe-range value sent as a JSON number must still deserialize.
-        let back: Req = serde_json::from_str(r#"{"id":1001}"#).unwrap();
-        assert_eq!(back.id, 1001);
-        // The boundary value 2^53-1 is still accepted as a number.
-        let edge: Req = serde_json::from_str(r#"{"id":9007199254740991}"#).unwrap();
-        assert_eq!(edge.id, 9_007_199_254_740_991);
-    }
-
-    #[test]
-    fn unsafe_number_is_rejected_so_a_rounded_id_never_silently_binds() {
-        // A value above 2^53 sent as a JSON NUMBER may already be f64-rounded; reject it rather
-        // than look up the wrong id. The same value as a STRING is exact and accepted (#130
-        // review).
-        let as_number = serde_json::from_str::<Req>(r#"{"id":2574604874062343519}"#);
-        assert!(as_number.is_err(), "an unsafe numeric id must be rejected, not silently accepted");
-        let as_string: Req = serde_json::from_str(r#"{"id":"2574604874062343519"}"#).unwrap();
-        assert_eq!(as_string.id, BIG);
-        // The optional variant rejects an unsafe number too.
-        assert!(serde_json::from_str::<Opt>(r#"{"id":2574604874062343519}"#).is_err());
-    }
-
-    #[test]
-    fn optional_big_id_serializes_string_or_null() {
-        assert_eq!(
-            serde_json::to_string(&Opt { id: Some(BIG) }).unwrap(),
-            r#"{"id":"2574604874062343519"}"#
+    fn sym_handle_rejects_a_bare_number_and_a_missing_prefix() {
+        // Clean break (#149): a numeric id (the old form) is no longer accepted, so a stale id
+        // passed by habit fails loudly instead of resolving to nothing.
+        assert!(serde_json::from_str::<Handle>(r#"{"id":2574604874062343519}"#).is_err());
+        assert!(
+            serde_json::from_str::<Handle>(r#"{"id":"23bad57dfb79ad5f"}"#).is_err(),
+            "needs prefix"
         );
-        assert_eq!(serde_json::to_string(&Opt { id: None }).unwrap(), r#"{"id":null}"#);
+        assert!(serde_json::from_str::<Handle>(r#"{"id":"sym_zzz"}"#).is_err(), "bad hex");
     }
 
     #[test]
-    fn optional_big_id_deserializes_string_number_and_null() {
-        let s: Opt = serde_json::from_str(r#"{"id":"2574604874062343519"}"#).unwrap();
-        assert_eq!(s.id, Some(BIG));
-        let n: Opt = serde_json::from_str(r#"{"id":1001}"#).unwrap();
-        assert_eq!(n.id, Some(1001));
-        let z: Opt = serde_json::from_str(r#"{"id":null}"#).unwrap();
-        assert_eq!(z.id, None);
+    fn sym_handle_opt_serializes_token_or_null() {
+        assert_eq!(
+            serde_json::to_string(&HandleOpt { id: Some(BIG) }).unwrap(),
+            r#"{"id":"sym_23bad57dfb79ad5f"}"#
+        );
+        assert_eq!(serde_json::to_string(&HandleOpt { id: None }).unwrap(), r#"{"id":null}"#);
+        let back: HandleOpt = serde_json::from_str(r#"{"id":"sym_23bad57dfb79ad5f"}"#).unwrap();
+        assert_eq!(back.id, Some(BIG));
     }
 }

--- a/crates/rag-rat-mcp/src/tools/defaults.rs
+++ b/crates/rag-rat-mcp/src/tools/defaults.rs
@@ -32,10 +32,6 @@ pub(crate) fn default_search_limit() -> u32 {
     10
 }
 
-pub(crate) fn default_true() -> bool {
-    true
-}
-
 pub(crate) fn default_search_graph_mode() -> McpGraphMode {
     McpGraphMode::Compact
 }

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -9,15 +9,16 @@ pub(crate) fn call_tool_with_db(
         "semantic_search" => {
             let args: SearchArgs = serde_json::from_value(arguments)?;
             let graph_mode = GraphMetaMode::parse(args.include_graph.as_str())?;
+            let include_generated = included(&args.include, SearchInclude::Generated, false);
             let options = SearchOptions {
-                include_git: args.include_git,
-                include_papertrail: args.include_papertrail,
+                include_git: included(&args.include, SearchInclude::Git, true),
+                include_papertrail: included(&args.include, SearchInclude::Papertrail, true),
             };
             if args.explain {
                 json!(db.search_explain_with_graph_meta_options(
                     &args.query,
                     args.limit,
-                    args.include_generated,
+                    include_generated,
                     graph_mode,
                     args.graph_limit,
                     options
@@ -26,7 +27,7 @@ pub(crate) fn call_tool_with_db(
                 json!(db.search_with_graph_meta_options(
                     &args.query,
                     args.limit,
-                    args.include_generated,
+                    include_generated,
                     graph_mode,
                     args.graph_limit,
                     options
@@ -63,16 +64,16 @@ pub(crate) fn call_tool_with_db(
             json!(db.repo_brief(RepoBriefOptions {
                 mode: args.mode.core(),
                 limit: args.limit,
-                include_generated: args.include_generated,
-                include_memories: args.include_memories,
+                include_generated: included(&args.include, OrientationInclude::Generated, false),
+                include_memories: included(&args.include, OrientationInclude::Memories, true),
             })?)
         },
         "repo_clusters" => {
             let args: RepoClustersArgs = serde_json::from_value(arguments)?;
             json!(db.repo_clusters(RepoClustersOptions {
                 limit: args.limit,
-                include_generated: args.include_generated,
-                include_memories: args.include_memories,
+                include_generated: included(&args.include, OrientationInclude::Generated, false),
+                include_memories: included(&args.include, OrientationInclude::Memories, true),
                 min_cluster_size: args.min_cluster_size,
             })?)
         },
@@ -94,7 +95,7 @@ pub(crate) fn call_tool_with_db(
                 args.chunk_id,
                 GraphMetaMode::parse(args.include_graph.as_str())?,
                 args.graph_limit,
-                args.include_memories
+                included(&args.include, MemoriesInclude::Memories, true)
             )?)
         },
         "commit_search" => {
@@ -128,7 +129,7 @@ pub(crate) fn call_tool_with_db(
         "papertrail_for_commit" => {
             let args: PapertrailCommitArgs = serde_json::from_value(arguments)?;
             let mut value = json!(db.papertrail_for_commit(&args.commit_hash, args.limit)?);
-            if !args.include_fallback {
+            if !included(&args.include, PapertrailCommitInclude::Fallback, false) {
                 strip_fallback_github_evidence(&mut value);
             }
             value
@@ -144,7 +145,7 @@ pub(crate) fn call_tool_with_db(
         "rationale_search" => {
             let args: SearchArgs = serde_json::from_value(arguments)?;
             let mut value = json!(db.rationale_search(&args.query, args.limit)?);
-            if !args.include_fallback {
+            if !included(&args.include, SearchInclude::Fallback, false) {
                 keep_literal_github_refs_if_present(&mut value);
             }
             value
@@ -210,7 +211,7 @@ pub(crate) fn call_tool_with_db(
 }
 
 pub(crate) fn symbol_lookup_tool(db: &IndexDatabase, args: SymbolArgs) -> anyhow::Result<Value> {
-    let include_memories = args.include_memories;
+    let include_memories = included(&args.include, MemoriesInclude::Memories, true);
     let lookup = db.symbol_candidates(&symbol_selector(args)?)?;
     let mut value = json!(lookup);
     if !include_memories {
@@ -238,11 +239,12 @@ pub(crate) fn graph_tool(
     reverse: bool,
 ) -> anyhow::Result<Value> {
     let limit = args.limit;
-    let include_references = args.include_references;
-    let include_unresolved = args.include_unresolved;
-    let include_macros = args.include_macros;
-    let include_common_methods = args.include_common_methods;
-    let include_memories = args.include_memories;
+    let include_references = included(&args.include, GraphInclude::References, false);
+    let include_unresolved = included(&args.include, GraphInclude::Unresolved, false);
+    let include_macros = included(&args.include, GraphInclude::Macros, false);
+    let include_common_methods = included(&args.include, GraphInclude::CommonMethods, false);
+    let include_coverage = included(&args.include, GraphInclude::Coverage, false);
+    let include_memories = included(&args.include, GraphInclude::Memories, true);
     let edge_kinds = graph_edge_kinds(args.edge_kinds.as_deref());
     let allow_ambiguous = args.allow_ambiguous;
     let selector = graph_symbol_selector(&args)?;
@@ -266,7 +268,7 @@ pub(crate) fn graph_tool(
                 limit,
                 &options
             )?);
-            compact_graph_coverage(&mut value, args.include_coverage);
+            compact_graph_coverage(&mut value, include_coverage);
             if include_memories {
                 let edge_ids = value["results"]
                     .as_array()
@@ -348,10 +350,14 @@ pub(crate) fn compare_graph_to_text_tool(
     match db.select_symbol(&selector)? {
         Ok(Some(symbol)) => {
             let options = GraphTraversalOptions {
-                include_references: args.include_references,
-                include_unresolved: args.include_unresolved,
-                include_macros: args.include_macros,
-                include_common_methods: args.include_common_methods,
+                include_references: included(&args.include, CompareInclude::References, false),
+                include_unresolved: included(&args.include, CompareInclude::Unresolved, false),
+                include_macros: included(&args.include, CompareInclude::Macros, false),
+                include_common_methods: included(
+                    &args.include,
+                    CompareInclude::CommonMethods,
+                    false,
+                ),
                 edge_kinds: graph_edge_kinds(args.edge_kinds.as_deref()),
                 resolution_mode,
                 symbol_id: Some(symbol.symbol_id),
@@ -362,7 +368,7 @@ pub(crate) fn compare_graph_to_text_tool(
                 &args.pattern,
                 args.limit,
                 &options,
-                args.include_tests
+                included(&args.include, CompareInclude::Tests, true)
             )?))
         },
         Ok(None) => Ok(Value::Null),
@@ -500,12 +506,12 @@ pub(crate) fn impact_tool(
 ) -> anyhow::Result<Value> {
     let options = ImpactSurfaceOptions {
         resolution_mode,
-        include_tests: args.include_tests,
-        include_docs: args.include_docs,
-        include_git: args.include_git,
-        include_papertrail: args.include_papertrail,
-        include_text_fallback: args.include_text_fallback,
-        include_memories: args.include_memories,
+        include_tests: included(&args.include, ImpactInclude::Tests, true),
+        include_docs: included(&args.include, ImpactInclude::Docs, true),
+        include_git: included(&args.include, ImpactInclude::Git, true),
+        include_papertrail: included(&args.include, ImpactInclude::Papertrail, true),
+        include_text_fallback: included(&args.include, ImpactInclude::TextFallback, true),
+        include_memories: included(&args.include, ImpactInclude::Memories, true),
     };
     if args.logical_symbol_id.is_some() || args.symbol_path.is_some() || args.symbol.is_some() {
         let selector = SymbolSelector {

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -312,7 +312,7 @@ pub(crate) fn graph_tool(
                 include_common_methods,
                 edge_kinds,
                 resolution_mode,
-                symbol_id: args.symbol_id,
+                symbol_id: None,
                 logical_symbol_id: args.logical_symbol_id,
             };
             let hops = if reverse {
@@ -352,7 +352,7 @@ pub(crate) fn compare_graph_to_text_tool(
 ) -> anyhow::Result<Value> {
     let selector = SymbolSelector {
         logical_symbol_id: args.logical_symbol_id,
-        symbol_id: args.symbol_id,
+        symbol_id: None,
         symbol_path: args.symbol_path,
         symbol: args.symbol,
         language: None,
@@ -521,14 +521,10 @@ pub(crate) fn impact_tool(
         include_text_fallback: args.include_text_fallback,
         include_memories: args.include_memories,
     };
-    if args.logical_symbol_id.is_some()
-        || args.symbol_id.is_some()
-        || args.symbol_path.is_some()
-        || args.symbol.is_some()
-    {
+    if args.logical_symbol_id.is_some() || args.symbol_path.is_some() || args.symbol.is_some() {
         let selector = SymbolSelector {
             logical_symbol_id: args.logical_symbol_id,
-            symbol_id: args.symbol_id,
+            symbol_id: None,
             symbol_path: args.symbol_path,
             symbol: args.symbol,
             language: None,
@@ -561,7 +557,7 @@ pub(crate) fn memory_for_symbol_tool(
 ) -> anyhow::Result<Value> {
     let selector = SymbolSelector {
         logical_symbol_id: args.logical_symbol_id,
-        symbol_id: args.symbol_id,
+        symbol_id: None,
         symbol_path: args.symbol_path,
         symbol: args.symbol,
         language: None,
@@ -604,7 +600,7 @@ fn important_symbols_tool(
 pub(crate) fn symbol_selector(args: SymbolArgs) -> anyhow::Result<SymbolSelector> {
     Ok(SymbolSelector {
         logical_symbol_id: args.logical_symbol_id,
-        symbol_id: args.symbol_id,
+        symbol_id: None,
         symbol_path: args.symbol_path,
         symbol: args.symbol,
         language: optional_language(args.language)?,
@@ -626,7 +622,7 @@ pub(crate) fn graph_edge_kinds(edge_kinds: Option<&[McpGraphEdgeKind]>) -> Optio
 pub(crate) fn graph_symbol_selector(args: &SymbolGraphArgs) -> anyhow::Result<SymbolSelector> {
     Ok(SymbolSelector {
         logical_symbol_id: args.logical_symbol_id,
-        symbol_id: args.symbol_id,
+        symbol_id: None,
         symbol_path: args.symbol_path.clone(),
         symbol: args.symbol.clone(),
         language: None,

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -219,25 +219,11 @@ pub(crate) fn symbol_lookup_tool(db: &IndexDatabase, args: SymbolArgs) -> anyhow
     let Some(candidates) = value.get_mut("candidates").and_then(Value::as_array_mut) else {
         return Ok(value);
     };
-    let selector = SymbolSelector {
-        logical_symbol_id: None,
-        symbol_id: None,
-        symbol_path: None,
-        symbol: None,
-        language: None,
-        allow_ambiguous: true,
-        limit: 1,
-    };
-    for candidate in candidates {
-        let Some(symbol_id) = candidate.get("symbol_id").and_then(Value::as_i64) else {
-            continue;
-        };
-        let mut selector = selector.clone();
-        selector.symbol_id = Some(symbol_id);
-        let Ok(Ok(Some(symbol))) = db.select_symbol(&selector) else {
-            continue;
-        };
-        let memories = db.memory_for_symbol(&symbol, 10)?;
+    // Resolve memories from the in-memory hits, which still carry the internal `symbol_id`. The
+    // serialized candidates no longer expose it (#149), so the old read of `candidate["symbol_id"]`
+    // found nothing and dropped every memory — zip by position against the source hits instead.
+    for (candidate, hit) in candidates.iter_mut().zip(&lookup.candidates) {
+        let memories = db.memory_for_symbol(hit, 10)?;
         if !memories.is_empty() {
             candidate["memories"] = json!(memories);
         }

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -95,7 +95,7 @@ impl McpGraphResolutionMode {
     }
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum McpGraphEdgeKind {
     CallsName,
@@ -153,6 +153,17 @@ where
         Some(Value::String(raw)) => serde_json::from_str(&raw).map(Some).map_err(D::Error::custom),
         Some(other) => serde_json::from_value(other).map(Some).map_err(D::Error::custom),
     }
+}
+
+/// Non-`Option` sibling of [`de_seq_or_json_string`] for a plain `Vec<T>` field (e.g.
+/// `personalize`): same array-or-JSON-string tolerance, with `null`/absent collapsing to an empty
+/// `Vec`.
+fn de_vec_or_json_string<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::de::DeserializeOwned,
+{
+    Ok(de_seq_or_json_string(deserializer)?.unwrap_or_default())
 }
 
 /// `semantic_search` `include` flags. `git`/`papertrail` are on by default (omit `include` to keep
@@ -337,7 +348,7 @@ pub struct ImportantSymbolsArgs {
     /// never fatal). LEAVE EMPTY to auto-seed from
     /// your current git diff (the default — "importance relative to your current changes").
     /// Pass a single `"global"` to force whole-repo PageRank instead.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_vec_or_json_string")]
     pub personalize: Vec<String>,
 }
 
@@ -390,6 +401,7 @@ pub struct SymbolGraphArgs {
     /// is the exact on-set (so listing `macros` alone also drops the default `memories`).
     #[serde(default, deserialize_with = "de_seq_or_json_string")]
     pub include: Option<Vec<GraphInclude>>,
+    #[serde(default, deserialize_with = "de_seq_or_json_string")]
     pub edge_kinds: Option<Vec<McpGraphEdgeKind>>,
 }
 
@@ -418,6 +430,7 @@ pub struct CompareGraphTextArgs {
     /// on-set.
     #[serde(default, deserialize_with = "de_seq_or_json_string")]
     pub include: Option<Vec<CompareInclude>>,
+    #[serde(default, deserialize_with = "de_seq_or_json_string")]
     pub edge_kinds: Option<Vec<McpGraphEdgeKind>>,
 }
 

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -233,10 +233,11 @@ pub struct ImportantSymbolsArgs {
     /// Max load-bearing symbols to return.
     #[serde(default = "default_repo_brief_limit")]
     pub limit: u32,
-    /// Symbols to bias importance toward (the symbols you're editing/querying) — names, symbol
-    /// paths, or numeric ids; the random surfer teleports back to these, lifting the spine *they*
-    /// depend on. A numeric value is a raw symbol id; otherwise it's resolved by symbol path then
-    /// name (ambiguous/missing entries are skipped, never fatal). LEAVE EMPTY to auto-seed from
+    /// Symbols to bias importance toward (the symbols you're editing/querying) — names, refs
+    /// (`path::name`), or `sym_<hex>` handles; the random surfer teleports back to these, lifting
+    /// the spine *they* depend on. A `sym_<hex>` handle resolves to its logical symbol's members;
+    /// otherwise the entry is resolved by ref then name (ambiguous/missing entries are skipped,
+    /// never fatal). LEAVE EMPTY to auto-seed from
     /// your current git diff (the default — "importance relative to your current changes").
     /// Pass a single `"global"` to force whole-repo PageRank instead.
     #[serde(default)]
@@ -246,11 +247,17 @@ pub struct ImportantSymbolsArgs {
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
 pub struct SymbolArgs {
     pub symbol: Option<String>,
+    #[serde(rename = "ref")]
     pub symbol_path: Option<String>,
     // 64-bit content hash > 2^53: take it as a string so a JSON client doesn't round it (#130).
-    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize")]
+    #[serde(
+        rename = "id",
+        default,
+        deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize"
+    )]
     #[schemars(with = "Option<String>")]
     pub logical_symbol_id: Option<i64>,
+    #[serde(rename = "lang")]
     pub language: Option<String>,
     #[serde(default)]
     pub allow_ambiguous: bool,
@@ -264,9 +271,14 @@ pub struct SymbolArgs {
 pub struct SymbolGraphArgs {
     pub symbol: Option<String>,
     // 64-bit content hash > 2^53: take it as a string so a JSON client doesn't round it (#130).
-    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize")]
+    #[serde(
+        rename = "id",
+        default,
+        deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize"
+    )]
     #[schemars(with = "Option<String>")]
     pub logical_symbol_id: Option<i64>,
+    #[serde(rename = "ref")]
     pub symbol_path: Option<String>,
     pub resolution: Option<McpGraphResolutionMode>,
     #[serde(default = "default_graph_limit")]
@@ -293,9 +305,14 @@ pub struct CompareGraphTextArgs {
     pub pattern: String,
     pub symbol: Option<String>,
     // 64-bit content hash > 2^53: take it as a string so a JSON client doesn't round it (#130).
-    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize")]
+    #[serde(
+        rename = "id",
+        default,
+        deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize"
+    )]
     #[schemars(with = "Option<String>")]
     pub logical_symbol_id: Option<i64>,
+    #[serde(rename = "ref")]
     pub symbol_path: Option<String>,
     pub resolution: Option<McpGraphResolutionMode>,
     #[serde(default = "default_compare_limit")]
@@ -319,9 +336,14 @@ pub struct CompareGraphTextArgs {
 pub struct ImpactArgs {
     pub query: Option<String>,
     pub symbol: Option<String>,
+    #[serde(rename = "ref")]
     pub symbol_path: Option<String>,
     // 64-bit content hash > 2^53: take it as a string so a JSON client doesn't round it (#130).
-    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize")]
+    #[serde(
+        rename = "id",
+        default,
+        deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize"
+    )]
     #[schemars(with = "Option<String>")]
     pub logical_symbol_id: Option<i64>,
     pub resolution: Option<McpGraphResolutionMode>,
@@ -458,7 +480,11 @@ impl McpMemorySource {
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
 pub struct MemoryBindArgs {
     // 64-bit content hash > 2^53: take it as a string so a JSON client doesn't round it (#130).
-    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize")]
+    #[serde(
+        rename = "id",
+        default,
+        deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize"
+    )]
     #[schemars(with = "Option<String>")]
     pub logical_symbol_id: Option<i64>,
     pub chunk_id: Option<i64>,
@@ -470,10 +496,18 @@ pub struct MemoryBindArgs {
     pub github_owner: Option<String>,
     pub github_repo: Option<String>,
     pub github_number: Option<i64>,
-    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize")]
+    #[serde(
+        rename = "start_id",
+        default,
+        deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize"
+    )]
     #[schemars(with = "Option<String>")]
     pub start_logical_symbol_id: Option<i64>,
-    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize")]
+    #[serde(
+        rename = "end_id",
+        default,
+        deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize"
+    )]
     #[schemars(with = "Option<String>")]
     pub end_logical_symbol_id: Option<i64>,
     pub edge_sequence_hash: Option<String>,
@@ -527,9 +561,14 @@ pub struct MemorySearchArgs {
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
 pub struct MemoryForSymbolArgs {
     pub symbol: Option<String>,
+    #[serde(rename = "ref")]
     pub symbol_path: Option<String>,
     // 64-bit content hash > 2^53: take it as a string so a JSON client doesn't round it (#130).
-    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize")]
+    #[serde(
+        rename = "id",
+        default,
+        deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize"
+    )]
     #[schemars(with = "Option<String>")]
     pub logical_symbol_id: Option<i64>,
     #[serde(default)]
@@ -749,8 +788,8 @@ pub fn description(name: &str) -> &'static str {
              without explain. Hits are validated against current source. Falls back to BM25-only \
              (every hit 'lexical') when no embedding model is present.",
         "symbol_lookup" =>
-            "Resolve a symbol name (or symbol_path/id) to its definition(s) in Rust, TypeScript, \
-             Kotlin, C, or C++ — exact or fuzzy. Returns candidates with signatures, locations, \
+            "Resolve a symbol name (or ref/id) to its definition(s) in Rust, TypeScript, Kotlin, \
+             C, or C++ — exact or fuzzy. Returns candidates with signatures, locations, \
              logical-symbol grouping (cfg variants), and any bound repo memories. Use to \
              disambiguate before a graph or read call.",
         "find_callers" =>
@@ -787,7 +826,7 @@ pub fn description(name: &str) -> &'static str {
              edge graph — what the rest of the code most depends on. Run before editing to see the \
              spine you shouldn't reinvent or break. By DEFAULT (no `personalize`) it auto-seeds \
              from your current git diff, returning importance relative to your current changes; \
-             pass `personalize` (names, symbol paths, or ids you're working on) to seed it \
+             pass `personalize` (names, refs, or `sym_<hex>` handles you're working on) to seed it \
              explicitly, or a single `\"global\"` to force whole-repo PageRank. The result is a \
              labeled object: `mode` (which scale), `seed_source` (seed provenance), and `symbols`.",
         "ffi_surface" =>

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -329,6 +329,7 @@ pub struct SymbolArgs {
     #[serde(
         rename = "id",
         default,
+        serialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::serialize",
         deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize"
     )]
     #[schemars(with = "Option<String>")]
@@ -351,6 +352,7 @@ pub struct SymbolGraphArgs {
     #[serde(
         rename = "id",
         default,
+        serialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::serialize",
         deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize"
     )]
     #[schemars(with = "Option<String>")]
@@ -378,6 +380,7 @@ pub struct CompareGraphTextArgs {
     #[serde(
         rename = "id",
         default,
+        serialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::serialize",
         deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize"
     )]
     #[schemars(with = "Option<String>")]
@@ -407,6 +410,7 @@ pub struct ImpactArgs {
     #[serde(
         rename = "id",
         default,
+        serialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::serialize",
         deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize"
     )]
     #[schemars(with = "Option<String>")]
@@ -542,6 +546,7 @@ pub struct MemoryBindArgs {
     #[serde(
         rename = "id",
         default,
+        serialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::serialize",
         deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize"
     )]
     #[schemars(with = "Option<String>")]
@@ -558,6 +563,7 @@ pub struct MemoryBindArgs {
     #[serde(
         rename = "start_id",
         default,
+        serialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::serialize",
         deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize"
     )]
     #[schemars(with = "Option<String>")]
@@ -565,6 +571,7 @@ pub struct MemoryBindArgs {
     #[serde(
         rename = "end_id",
         default,
+        serialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::serialize",
         deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize"
     )]
     #[schemars(with = "Option<String>")]
@@ -626,6 +633,7 @@ pub struct MemoryForSymbolArgs {
     #[serde(
         rename = "id",
         default,
+        serialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::serialize",
         deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize"
     )]
     #[schemars(with = "Option<String>")]

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -248,10 +248,9 @@ pub struct SymbolArgs {
     pub symbol: Option<String>,
     pub symbol_path: Option<String>,
     // 64-bit content hash > 2^53: take it as a string so a JSON client doesn't round it (#130).
-    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::big_id_opt::deserialize")]
+    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize")]
     #[schemars(with = "Option<String>")]
     pub logical_symbol_id: Option<i64>,
-    pub symbol_id: Option<i64>,
     pub language: Option<String>,
     #[serde(default)]
     pub allow_ambiguous: bool,
@@ -265,10 +264,9 @@ pub struct SymbolArgs {
 pub struct SymbolGraphArgs {
     pub symbol: Option<String>,
     // 64-bit content hash > 2^53: take it as a string so a JSON client doesn't round it (#130).
-    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::big_id_opt::deserialize")]
+    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize")]
     #[schemars(with = "Option<String>")]
     pub logical_symbol_id: Option<i64>,
-    pub symbol_id: Option<i64>,
     pub symbol_path: Option<String>,
     pub resolution: Option<McpGraphResolutionMode>,
     #[serde(default = "default_graph_limit")]
@@ -295,10 +293,9 @@ pub struct CompareGraphTextArgs {
     pub pattern: String,
     pub symbol: Option<String>,
     // 64-bit content hash > 2^53: take it as a string so a JSON client doesn't round it (#130).
-    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::big_id_opt::deserialize")]
+    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize")]
     #[schemars(with = "Option<String>")]
     pub logical_symbol_id: Option<i64>,
-    pub symbol_id: Option<i64>,
     pub symbol_path: Option<String>,
     pub resolution: Option<McpGraphResolutionMode>,
     #[serde(default = "default_compare_limit")]
@@ -324,10 +321,9 @@ pub struct ImpactArgs {
     pub symbol: Option<String>,
     pub symbol_path: Option<String>,
     // 64-bit content hash > 2^53: take it as a string so a JSON client doesn't round it (#130).
-    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::big_id_opt::deserialize")]
+    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize")]
     #[schemars(with = "Option<String>")]
     pub logical_symbol_id: Option<i64>,
-    pub symbol_id: Option<i64>,
     pub resolution: Option<McpGraphResolutionMode>,
     #[serde(default)]
     pub allow_ambiguous: bool,
@@ -462,10 +458,9 @@ impl McpMemorySource {
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
 pub struct MemoryBindArgs {
     // 64-bit content hash > 2^53: take it as a string so a JSON client doesn't round it (#130).
-    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::big_id_opt::deserialize")]
+    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize")]
     #[schemars(with = "Option<String>")]
     pub logical_symbol_id: Option<i64>,
-    pub symbol_id: Option<i64>,
     pub chunk_id: Option<i64>,
     pub edge_id: Option<i64>,
     pub path: Option<String>,
@@ -475,10 +470,10 @@ pub struct MemoryBindArgs {
     pub github_owner: Option<String>,
     pub github_repo: Option<String>,
     pub github_number: Option<i64>,
-    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::big_id_opt::deserialize")]
+    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize")]
     #[schemars(with = "Option<String>")]
     pub start_logical_symbol_id: Option<i64>,
-    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::big_id_opt::deserialize")]
+    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize")]
     #[schemars(with = "Option<String>")]
     pub end_logical_symbol_id: Option<i64>,
     pub edge_sequence_hash: Option<String>,
@@ -534,10 +529,9 @@ pub struct MemoryForSymbolArgs {
     pub symbol: Option<String>,
     pub symbol_path: Option<String>,
     // 64-bit content hash > 2^53: take it as a string so a JSON client doesn't round it (#130).
-    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::big_id_opt::deserialize")]
+    #[serde(default, deserialize_with = "rag_rat_core::serde_big_id::sym_handle_opt::deserialize")]
     #[schemars(with = "Option<String>")]
     pub logical_symbol_id: Option<i64>,
-    pub symbol_id: Option<i64>,
     #[serde(default)]
     pub allow_ambiguous: bool,
     #[serde(default = "default_search_limit")]
@@ -725,7 +719,7 @@ impl From<MemoryBindArgs> for RepoMemoryBindTarget {
     fn from(args: MemoryBindArgs) -> Self {
         Self {
             logical_symbol_id: args.logical_symbol_id,
-            symbol_id: args.symbol_id,
+            symbol_id: None,
             chunk_id: args.chunk_id,
             edge_id: args.edge_id,
             path: args.path,

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -123,6 +123,88 @@ impl McpGraphEdgeKind {
     }
 }
 
+/// Resolve one optional include-flag against the array form. `None` (the `include` key omitted)
+/// keeps the tool's historical `default`; a present `include` list is the EXACT on-set, so a
+/// default-on flag (e.g. impact's `tests`/`git`) is disabled simply by leaving it out. Presence in
+/// the list = on. This is why the surface is an array, not per-key booleans (#149 follow-up).
+fn included<T: PartialEq>(include: &Option<Vec<T>>, flag: T, default: bool) -> bool {
+    match include {
+        None => default,
+        Some(flags) => flags.contains(&flag),
+    }
+}
+
+/// `semantic_search` `include` flags. `git`/`papertrail` are on by default (omit `include` to keep
+/// them); `generated`/`fallback` are off by default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SearchInclude {
+    Generated,
+    Git,
+    Papertrail,
+    Fallback,
+}
+
+/// `repo_brief` / `repo_clusters` `include` flags. `memories` on by default; `generated` off.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum OrientationInclude {
+    Generated,
+    Memories,
+}
+
+/// `symbol_lookup` / `read_chunk` `include` flags. `memories` on by default (pass `include: []` to
+/// suppress).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoriesInclude {
+    Memories,
+}
+
+/// `find_callers` / `trace_callees` `include` flags. `memories` on by default; the rest off (they
+/// add unresolved/macro/common-method/reference noise or the coverage block on demand).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum GraphInclude {
+    References,
+    Unresolved,
+    Macros,
+    CommonMethods,
+    Coverage,
+    Memories,
+}
+
+/// `compare_graph_to_text` `include` flags. `tests` on by default; the rest off.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CompareInclude {
+    Tests,
+    References,
+    Unresolved,
+    Macros,
+    CommonMethods,
+}
+
+/// `impact_surface` `include` flags — ALL on by default (impact's value is the bundled evidence).
+/// Pass an explicit `include` to narrow it, e.g. `["git"]` for git history only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ImpactInclude {
+    Tests,
+    Docs,
+    Git,
+    Papertrail,
+    TextFallback,
+    Memories,
+}
+
+/// `papertrail_for_commit` `include` flags. `fallback` off by default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PapertrailCommitInclude {
+    Fallback,
+}
+
 pub const TOOL_NAMES: &[&str] = &[
     "semantic_search",
     "symbol_lookup",
@@ -169,19 +251,15 @@ pub struct SearchArgs {
     #[serde(default = "default_search_limit")]
     pub limit: u32,
     #[serde(default)]
-    pub include_generated: bool,
-    #[serde(default)]
     pub explain: bool,
-    #[serde(default = "default_true")]
-    pub include_git: bool,
-    #[serde(default = "default_true")]
-    pub include_papertrail: bool,
+    /// What to include: `git`, `papertrail` (both on by default), `generated`, `fallback` (off by
+    /// default). Omit to keep defaults; an explicit list is the exact on-set.
+    #[serde(default)]
+    pub include: Option<Vec<SearchInclude>>,
     #[serde(default = "default_search_graph_mode")]
     pub include_graph: McpGraphMode,
     #[serde(default = "default_search_graph_limit")]
     pub graph_limit: u32,
-    #[serde(default)]
-    pub include_fallback: bool,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, schemars::JsonSchema)]
@@ -210,20 +288,18 @@ pub struct RepoBriefArgs {
     pub mode: McpRepoBriefMode,
     #[serde(default = "default_repo_brief_limit")]
     pub limit: u32,
+    /// What to include: `memories` (on by default), `generated` (off). Omit to keep defaults.
     #[serde(default)]
-    pub include_generated: bool,
-    #[serde(default = "default_true")]
-    pub include_memories: bool,
+    pub include: Option<Vec<OrientationInclude>>,
 }
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
 pub struct RepoClustersArgs {
     #[serde(default = "default_repo_brief_limit")]
     pub limit: u32,
+    /// What to include: `memories` (on by default), `generated` (off). Omit to keep defaults.
     #[serde(default)]
-    pub include_generated: bool,
-    #[serde(default = "default_true")]
-    pub include_memories: bool,
+    pub include: Option<Vec<OrientationInclude>>,
     #[serde(default = "default_min_cluster_size")]
     pub min_cluster_size: u32,
 }
@@ -263,8 +339,9 @@ pub struct SymbolArgs {
     pub allow_ambiguous: bool,
     #[serde(default = "default_symbol_limit")]
     pub limit: u32,
-    #[serde(default = "default_true")]
-    pub include_memories: bool,
+    /// What to include: `memories` (on by default). Pass `include: []` to suppress.
+    #[serde(default)]
+    pub include: Option<Vec<MemoriesInclude>>,
 }
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
@@ -285,18 +362,11 @@ pub struct SymbolGraphArgs {
     pub limit: u32,
     #[serde(default)]
     pub allow_ambiguous: bool,
+    /// What to include: `memories` (on by default); `references`, `unresolved`, `macros`,
+    /// `common_methods`, `coverage` (all off by default). Omit to keep defaults; an explicit list
+    /// is the exact on-set (so listing `macros` alone also drops the default `memories`).
     #[serde(default)]
-    pub include_references: bool,
-    #[serde(default)]
-    pub include_unresolved: bool,
-    #[serde(default)]
-    pub include_macros: bool,
-    #[serde(default)]
-    pub include_common_methods: bool,
-    #[serde(default)]
-    pub include_coverage: bool,
-    #[serde(default = "default_true")]
-    pub include_memories: bool,
+    pub include: Option<Vec<GraphInclude>>,
     pub edge_kinds: Option<Vec<McpGraphEdgeKind>>,
 }
 
@@ -317,18 +387,13 @@ pub struct CompareGraphTextArgs {
     pub resolution: Option<McpGraphResolutionMode>,
     #[serde(default = "default_compare_limit")]
     pub limit: u32,
-    #[serde(default = "default_true")]
-    pub include_tests: bool,
     #[serde(default)]
     pub allow_ambiguous: bool,
+    /// What to include: `tests` (on by default); `references`, `unresolved`, `macros`,
+    /// `common_methods` (off by default). Omit to keep defaults; an explicit list is the exact
+    /// on-set.
     #[serde(default)]
-    pub include_references: bool,
-    #[serde(default)]
-    pub include_unresolved: bool,
-    #[serde(default)]
-    pub include_macros: bool,
-    #[serde(default)]
-    pub include_common_methods: bool,
+    pub include: Option<Vec<CompareInclude>>,
     pub edge_kinds: Option<Vec<McpGraphEdgeKind>>,
 }
 
@@ -351,18 +416,11 @@ pub struct ImpactArgs {
     pub allow_ambiguous: bool,
     #[serde(default = "default_graph_limit")]
     pub limit: u32,
-    #[serde(default = "default_true")]
-    pub include_tests: bool,
-    #[serde(default = "default_true")]
-    pub include_docs: bool,
-    #[serde(default = "default_true")]
-    pub include_git: bool,
-    #[serde(default = "default_true")]
-    pub include_papertrail: bool,
-    #[serde(default = "default_true")]
-    pub include_text_fallback: bool,
-    #[serde(default = "default_true")]
-    pub include_memories: bool,
+    /// What to include — `tests`, `docs`, `git`, `papertrail`, `text_fallback`, `memories`, ALL on
+    /// by default (impact's value is the bundled evidence). Omit to keep them; pass an explicit
+    /// list to narrow, e.g. `["git"]` for git history only.
+    #[serde(default)]
+    pub include: Option<Vec<ImpactInclude>>,
 }
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
@@ -378,8 +436,9 @@ pub struct ReadChunkArgs {
     pub include_graph: McpGraphMode,
     #[serde(default = "default_read_chunk_graph_limit")]
     pub graph_limit: u32,
-    #[serde(default = "default_true")]
-    pub include_memories: bool,
+    /// What to include: `memories` (on by default). Pass `include: []` to suppress.
+    #[serde(default)]
+    pub include: Option<Vec<MemoriesInclude>>,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, schemars::JsonSchema)]
@@ -620,8 +679,9 @@ pub struct PapertrailCommitArgs {
     pub commit_hash: String,
     #[serde(default = "default_graph_limit")]
     pub limit: u32,
+    /// What to include: `fallback` (off by default).
     #[serde(default)]
-    pub include_fallback: bool,
+    pub include: Option<Vec<PapertrailCommitInclude>>,
 }
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
@@ -799,8 +859,8 @@ pub fn description(name: &str) -> &'static str {
              symbol with symbol_lookup first when a name is ambiguous.",
         "trace_callees" =>
             "Find what a symbol calls (forward call graph). Same evidence shape as find_callers; \
-             unresolved std/common-method noise is filtered out by default (toggle with \
-             include_common_methods / include_unresolved).",
+             unresolved std/common-method noise is filtered out by default (add `common_methods` / \
+             `unresolved` to the `include` array to keep it).",
         "compare_graph_to_text" =>
             "Cross-check a symbol's graph caller edges against a regex text search of indexed \
              source — surfaces call sites the tree-sitter graph missed and flags likely false \

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -134,6 +134,27 @@ fn included<T: PartialEq>(include: &Option<Vec<T>>, flag: T, default: bool) -> b
     }
 }
 
+/// Deserialize an optional `Vec<T>` that may arrive EITHER as a real JSON array (the schema form)
+/// OR as a JSON-string-encoded array (`"[\"git\"]"`). Some MCP clients serialize non-string args as
+/// strings — Claude Code does this for array/object params (anthropics/claude-code#24599) — so the
+/// array `include` surface is unusable from them unless the server also accepts the stringified
+/// form. We keep advertising a real array (schema unchanged) and rescue the stringified case here;
+/// `null`/absent -> `None`, `[]` -> `Some(vec![])` (the explicit empty on-set). Serialize stays the
+/// default (a real array), which round-trips back through this deserializer fine — so no
+/// `serialize_with` is needed (contrast the scalar `sym_handle` fields, which DO need symmetry).
+fn de_seq_or_json_string<'de, D, T>(deserializer: D) -> Result<Option<Vec<T>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::de::DeserializeOwned,
+{
+    use serde::de::Error as _;
+    match Option::<Value>::deserialize(deserializer)? {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(raw)) => serde_json::from_str(&raw).map(Some).map_err(D::Error::custom),
+        Some(other) => serde_json::from_value(other).map(Some).map_err(D::Error::custom),
+    }
+}
+
 /// `semantic_search` `include` flags. `git`/`papertrail` are on by default (omit `include` to keep
 /// them); `generated`/`fallback` are off by default.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, schemars::JsonSchema)]
@@ -254,7 +275,7 @@ pub struct SearchArgs {
     pub explain: bool,
     /// What to include: `git`, `papertrail` (both on by default), `generated`, `fallback` (off by
     /// default). Omit to keep defaults; an explicit list is the exact on-set.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_seq_or_json_string")]
     pub include: Option<Vec<SearchInclude>>,
     #[serde(default = "default_search_graph_mode")]
     pub include_graph: McpGraphMode,
@@ -289,7 +310,7 @@ pub struct RepoBriefArgs {
     #[serde(default = "default_repo_brief_limit")]
     pub limit: u32,
     /// What to include: `memories` (on by default), `generated` (off). Omit to keep defaults.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_seq_or_json_string")]
     pub include: Option<Vec<OrientationInclude>>,
 }
 
@@ -298,7 +319,7 @@ pub struct RepoClustersArgs {
     #[serde(default = "default_repo_brief_limit")]
     pub limit: u32,
     /// What to include: `memories` (on by default), `generated` (off). Omit to keep defaults.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_seq_or_json_string")]
     pub include: Option<Vec<OrientationInclude>>,
     #[serde(default = "default_min_cluster_size")]
     pub min_cluster_size: u32,
@@ -341,7 +362,7 @@ pub struct SymbolArgs {
     #[serde(default = "default_symbol_limit")]
     pub limit: u32,
     /// What to include: `memories` (on by default). Pass `include: []` to suppress.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_seq_or_json_string")]
     pub include: Option<Vec<MemoriesInclude>>,
 }
 
@@ -367,7 +388,7 @@ pub struct SymbolGraphArgs {
     /// What to include: `memories` (on by default); `references`, `unresolved`, `macros`,
     /// `common_methods`, `coverage` (all off by default). Omit to keep defaults; an explicit list
     /// is the exact on-set (so listing `macros` alone also drops the default `memories`).
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_seq_or_json_string")]
     pub include: Option<Vec<GraphInclude>>,
     pub edge_kinds: Option<Vec<McpGraphEdgeKind>>,
 }
@@ -395,7 +416,7 @@ pub struct CompareGraphTextArgs {
     /// What to include: `tests` (on by default); `references`, `unresolved`, `macros`,
     /// `common_methods` (off by default). Omit to keep defaults; an explicit list is the exact
     /// on-set.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_seq_or_json_string")]
     pub include: Option<Vec<CompareInclude>>,
     pub edge_kinds: Option<Vec<McpGraphEdgeKind>>,
 }
@@ -423,7 +444,7 @@ pub struct ImpactArgs {
     /// What to include — `tests`, `docs`, `git`, `papertrail`, `text_fallback`, `memories`, ALL on
     /// by default (impact's value is the bundled evidence). Omit to keep them; pass an explicit
     /// list to narrow, e.g. `["git"]` for git history only.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_seq_or_json_string")]
     pub include: Option<Vec<ImpactInclude>>,
 }
 
@@ -441,7 +462,7 @@ pub struct ReadChunkArgs {
     #[serde(default = "default_read_chunk_graph_limit")]
     pub graph_limit: u32,
     /// What to include: `memories` (on by default). Pass `include: []` to suppress.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_seq_or_json_string")]
     pub include: Option<Vec<MemoriesInclude>>,
 }
 
@@ -688,7 +709,7 @@ pub struct PapertrailCommitArgs {
     #[serde(default = "default_graph_limit")]
     pub limit: u32,
     /// What to include: `fallback` (off by default).
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_seq_or_json_string")]
     pub include: Option<Vec<PapertrailCommitInclude>>,
 }
 

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -39,6 +39,42 @@ fn degraded_coverage_escalates_low_completeness_risk() {
 }
 
 #[test]
+fn arg_struct_handles_survive_an_rmcp_style_serde_round_trip() {
+    // rmcp's `Parameters` extractor round-trips tool args through serialize -> deserialize, so any
+    // custom serde on an arg field MUST be symmetric. A `deserialize_with` (sym_handle) without a
+    // matching `serialize_with` re-emits a bare i64 on the round-trip, which the second deserialize
+    // then rejects ("invalid type: integer, expected a symbol handle string") — breaking handle
+    // input on the LIVE MCP server while unit tests that call `call_tool` directly (bypassing rmcp)
+    // pass. This guards every arg struct that carries a `sym_<hex>` handle (#153 review).
+    const HANDLE: &str = "sym_23bad57dfb79ad5f";
+
+    macro_rules! assert_handle_round_trips {
+        ($ty:ty, $field:literal, $value:expr) => {{
+            let first: $ty = serde_json::from_value($value).expect("initial deserialize");
+            let reserialized = serde_json::to_value(&first).expect("serialize");
+            assert_eq!(
+                reserialized[$field],
+                HANDLE,
+                "{} must re-serialize {} as the sym_<hex> token, not a bare integer",
+                stringify!($ty),
+                $field
+            );
+            // The round-trip (what rmcp does) must deserialize again without error.
+            serde_json::from_value::<$ty>(reserialized).expect("round-trip deserialize");
+        }};
+    }
+
+    assert_handle_round_trips!(SymbolArgs, "id", json!({ "id": HANDLE }));
+    assert_handle_round_trips!(SymbolGraphArgs, "id", json!({ "id": HANDLE }));
+    assert_handle_round_trips!(CompareGraphTextArgs, "id", json!({ "pattern": "x", "id": HANDLE }));
+    assert_handle_round_trips!(ImpactArgs, "id", json!({ "id": HANDLE }));
+    assert_handle_round_trips!(MemoryForSymbolArgs, "id", json!({ "id": HANDLE }));
+    assert_handle_round_trips!(MemoryBindArgs, "id", json!({ "id": HANDLE }));
+    assert_handle_round_trips!(MemoryBindArgs, "start_id", json!({ "start_id": HANDLE }));
+    assert_handle_round_trips!(MemoryBindArgs, "end_id", json!({ "end_id": HANDLE }));
+}
+
+#[test]
 fn list_tools_exposes_complete_typed_schemas() {
     let tools = list_tools();
     let tools = tools.as_array().expect("tools/list shape");

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -92,6 +92,26 @@ fn include_accepts_a_json_string_encoded_array_from_buggy_clients() {
         serde_json::from_value::<ImpactArgs>(json!({ "include": "[]" })).unwrap().include,
         Some(vec![])
     );
+
+    // The other array params get the same tolerance: edge_kinds (Option<Vec>) and personalize
+    // (Vec).
+    let edges_arr: SymbolGraphArgs =
+        serde_json::from_value(json!({ "edge_kinds": ["calls_name"] })).unwrap();
+    let edges_str: SymbolGraphArgs =
+        serde_json::from_value(json!({ "edge_kinds": "[\"calls_name\"]" })).unwrap();
+    assert_eq!(edges_str.edge_kinds, Some(vec![McpGraphEdgeKind::CallsName]));
+    assert_eq!(edges_arr.edge_kinds, edges_str.edge_kinds);
+
+    let seeds_arr: ImportantSymbolsArgs =
+        serde_json::from_value(json!({ "personalize": ["a", "b"] })).unwrap();
+    let seeds_str: ImportantSymbolsArgs =
+        serde_json::from_value(json!({ "personalize": "[\"a\",\"b\"]" })).unwrap();
+    assert_eq!(seeds_str.personalize, vec!["a".to_string(), "b".to_string()]);
+    assert_eq!(seeds_arr.personalize, seeds_str.personalize);
+    // personalize is non-Option: absent collapses to an empty Vec (global ranking).
+    assert!(
+        serde_json::from_value::<ImportantSymbolsArgs>(json!({})).unwrap().personalize.is_empty()
+    );
 }
 
 #[test]

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -75,6 +75,26 @@ fn arg_struct_handles_survive_an_rmcp_style_serde_round_trip() {
 }
 
 #[test]
+fn include_accepts_a_json_string_encoded_array_from_buggy_clients() {
+    // Some MCP clients serialize array args as JSON strings (Claude Code does this for array/object
+    // params — anthropics/claude-code#24599), so `include` arrives as `"[\"git\"]"` not `["git"]`.
+    // The server accepts both forms so the array surface stays usable; the schema still advertises
+    // a real array (#153 review).
+    let from_array: ImpactArgs = serde_json::from_value(json!({ "include": ["git"] })).unwrap();
+    let from_string: ImpactArgs =
+        serde_json::from_value(json!({ "include": "[\"git\"]" })).unwrap();
+    assert_eq!(from_string.include, Some(vec![ImpactInclude::Git]));
+    assert_eq!(from_array.include, from_string.include, "array and stringified array must agree");
+
+    // Omitted -> None (tool defaults apply); explicit empty (either form) -> Some(empty on-set).
+    assert_eq!(serde_json::from_value::<ImpactArgs>(json!({})).unwrap().include, None);
+    assert_eq!(
+        serde_json::from_value::<ImpactArgs>(json!({ "include": "[]" })).unwrap().include,
+        Some(vec![])
+    );
+}
+
+#[test]
 fn list_tools_exposes_complete_typed_schemas() {
     let tools = list_tools();
     let tools = tools.as_array().expect("tools/list shape");

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -397,7 +397,7 @@ fn mcp_read_chunk_and_heal_index_do_not_return_stale_text() {
 }
 
 #[test]
-fn mcp_symbol_id_selection_disambiguates_graph_tools() {
+fn mcp_handle_selection_disambiguates_graph_tools() {
     let root = unique_temp_root();
     fs::create_dir_all(root.join("src")).unwrap();
     fs::write(root.join("src/lib.rs"), "pub mod one;\npub mod two;\n").unwrap();
@@ -419,8 +419,12 @@ fn mcp_symbol_id_selection_disambiguates_graph_tools() {
     assert_eq!(lookup["disambiguation_required"], true);
     let candidates = lookup["candidates"].as_array().unwrap();
     assert_eq!(candidates.len(), 2);
+    // #149: candidates carry the opaque `sym_<hex>` handle (not the ephemeral numeric symbol_id),
+    // plus the human-readable symbol_path.
     assert!(candidates.iter().all(|candidate| {
-        candidate["symbol_id"].is_i64() && candidate["symbol_path"].as_str().is_some()
+        candidate.get("symbol_id").is_none()
+            && candidate["logical_symbol_id"].as_str().is_some_and(|h| h.starts_with("sym_"))
+            && candidate["symbol_path"].as_str().is_some()
     }));
 
     let ambiguous =
@@ -436,14 +440,14 @@ fn mcp_symbol_id_selection_disambiguates_graph_tools() {
         &config.database,
         "find_callers",
         json!({
-            "symbol_id": one["symbol_id"].as_i64().unwrap(),
+            "logical_symbol_id": one["logical_symbol_id"].as_str().unwrap(),
             "resolution": "exact",
             "edge_kinds": ["calls_name"]
         }),
     )
     .unwrap();
     assert_eq!(exact["query"]["tool"], "find_callers");
-    assert_eq!(exact["query"]["symbol_id"], one["symbol_id"]);
+    assert_eq!(exact["query"]["logical_symbol_id"], one["logical_symbol_id"]);
     assert_eq!(exact["query"]["resolution"], "exact");
     assert_eq!(exact["summary"]["returned_count"], 1);
     assert_eq!(exact["summary"]["total_matching_edges"], 1);
@@ -457,7 +461,7 @@ fn mcp_symbol_id_selection_disambiguates_graph_tools() {
         &config.database,
         "find_callers",
         json!({
-            "symbol_id": one["symbol_id"].as_i64().unwrap(),
+            "logical_symbol_id": one["logical_symbol_id"].as_str().unwrap(),
             "resolution": "exact",
             "edge_kinds": ["calls_name"],
             "include_coverage": true
@@ -479,14 +483,14 @@ fn mcp_symbol_id_selection_disambiguates_graph_tools() {
         &config.database,
         "compare_graph_to_text",
         json!({
-            "symbol_id": one["symbol_id"].as_i64().unwrap(),
+            "logical_symbol_id": one["logical_symbol_id"].as_str().unwrap(),
             "pattern": "    shared\\(",
             "resolution": "exact",
             "edge_kinds": ["calls_name"]
         }),
     )
     .unwrap();
-    assert_eq!(comparison["query"]["symbol_id"], one["symbol_id"]);
+    assert_eq!(comparison["query"]["logical_symbol_id"], one["logical_symbol_id"]);
     assert_eq!(comparison["summary"]["graph_edges"], 1);
     assert_eq!(comparison["summary"]["graph_hits"], 1);
     assert_eq!(comparison["summary"]["text_hits"], 3);
@@ -515,7 +519,7 @@ fn mcp_symbol_id_selection_disambiguates_graph_tools() {
         &config.database,
         "compare_graph_to_text",
         json!({
-            "symbol_id": one["symbol_id"].as_i64().unwrap(),
+            "logical_symbol_id": one["logical_symbol_id"].as_str().unwrap(),
             "pattern": "shared",
             "resolution": "exact",
             "edge_kinds": ["calls_name"]
@@ -533,7 +537,7 @@ fn mcp_symbol_id_selection_disambiguates_graph_tools() {
         &config.database,
         "impact_surface",
         json!({
-            "symbol_id": one["symbol_id"].as_i64().unwrap(),
+            "logical_symbol_id": one["logical_symbol_id"].as_str().unwrap(),
             "resolution": "exact",
             "include_tests": true,
             "include_docs": true,
@@ -559,7 +563,7 @@ fn mcp_symbol_id_selection_disambiguates_graph_tools() {
     let papertrail = call_tool(
         &config.database,
         "papertrail_for_symbol",
-        json!({"symbol_id": one["symbol_id"].as_i64().unwrap()}),
+        json!({"logical_symbol_id": one["logical_symbol_id"].as_str().unwrap()}),
     )
     .unwrap();
     assert!(papertrail["current_source"]["symbol"].as_str().unwrap().contains("shared"));
@@ -576,6 +580,11 @@ fn assert_schema_requires(tools: &[Value], name: &str, field: &str) {
 fn assert_schema_has_property(tools: &[Value], name: &str, field: &str) {
     let schema = tool_schema(tools, name);
     assert!(schema["properties"].get(field).is_some(), "{name} should define {field}");
+}
+
+fn assert_schema_lacks_property(tools: &[Value], name: &str, field: &str) {
+    let schema = tool_schema(tools, name);
+    assert!(schema["properties"].get(field).is_none(), "{name} must not define {field}");
 }
 
 fn assert_schema_nested_property(tools: &[Value], name: &str, parent: &str, field: &str) {
@@ -651,9 +660,12 @@ fn assert_enum_values(schema: &Value, expected: &[&str], label: &str) {
 }
 
 fn assert_symbol_selector_schema(tools: &[Value], name: &str) {
-    for field in ["symbol", "symbol_path", "symbol_id", "logical_symbol_id", "allow_ambiguous"] {
+    // #149: the wire selector is symbol/symbol_path/logical_symbol_id (the opaque handle); the
+    // ephemeral numeric symbol_id is no longer an accepted input.
+    for field in ["symbol", "symbol_path", "logical_symbol_id", "allow_ambiguous"] {
         assert_schema_has_property(tools, name, field);
     }
+    assert_schema_lacks_property(tools, name, "symbol_id");
 }
 
 #[test]

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -358,6 +358,20 @@ fn mcp_memory_tools_create_surface_validate_and_obsolete_symbol_memory() {
     assert_eq!(impact["repo_memories"]["direct"].as_array().unwrap()[0]["memory_id"], memory_id);
     assert_eq!(impact["completeness_and_caveats"]["memory_status"]["active"], 1);
 
+    // symbol_lookup must still attach bound memories to each candidate. The enrichment resolves
+    // them from the in-memory hit's internal symbol_id, which no longer crosses the wire (#149/#153
+    // review) — reading it back off the serialized candidate would find nothing and drop them all.
+    let enriched = call_tool(
+        &config.database,
+        "symbol_lookup",
+        json!({"symbol": "cfg_helper", "allow_ambiguous": true}),
+    )
+    .unwrap();
+    let candidate_memories = enriched["candidates"].as_array().unwrap()[0]["memories"]
+        .as_array()
+        .expect("symbol_lookup candidate should carry its bound memory");
+    assert_eq!(candidate_memories[0]["memory_id"], memory_id);
+
     let validation = call_tool(&config.database, "memory_validate", json!({})).unwrap();
     assert_eq!(validation["current"], 1);
     let obsolete =

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -119,7 +119,7 @@ fn list_tools_exposes_complete_typed_schemas() {
         "contains",
         "implements",
     ]);
-    assert_schema_has_property(tools, "find_callers", "logical_symbol_id");
+    assert_schema_has_property(tools, "find_callers", "id");
     assert_symbol_selector_schema(tools, "find_callers");
     assert_schema_has_property(tools, "trace_callees", "include_references");
     assert_schema_has_property(tools, "trace_callees", "include_unresolved");
@@ -129,7 +129,7 @@ fn list_tools_exposes_complete_typed_schemas() {
     assert_schema_has_property(tools, "trace_callees", "include_memories");
     assert_schema_has_property(tools, "trace_callees", "edge_kinds");
     assert_schema_has_property(tools, "trace_callees", "resolution");
-    assert_schema_has_property(tools, "trace_callees", "logical_symbol_id");
+    assert_schema_has_property(tools, "trace_callees", "id");
     assert_symbol_selector_schema(tools, "trace_callees");
     assert_schema_requires(tools, "compare_graph_to_text", "pattern");
     assert_schema_has_property(tools, "compare_graph_to_text", "include_unresolved");
@@ -138,7 +138,7 @@ fn list_tools_exposes_complete_typed_schemas() {
     assert_schema_has_property(tools, "compare_graph_to_text", "include_tests");
     assert_schema_has_property(tools, "compare_graph_to_text", "edge_kinds");
     assert_schema_has_property(tools, "compare_graph_to_text", "resolution");
-    assert_schema_has_property(tools, "compare_graph_to_text", "logical_symbol_id");
+    assert_schema_has_property(tools, "compare_graph_to_text", "id");
     assert_symbol_selector_schema(tools, "compare_graph_to_text");
     assert_schema_has_property(tools, "impact_surface", "resolution");
     assert_schema_has_property(tools, "impact_surface", "include_tests");
@@ -147,7 +147,7 @@ fn list_tools_exposes_complete_typed_schemas() {
     assert_schema_has_property(tools, "impact_surface", "include_papertrail");
     assert_schema_has_property(tools, "impact_surface", "include_text_fallback");
     assert_schema_has_property(tools, "impact_surface", "include_memories");
-    assert_schema_has_property(tools, "impact_surface", "logical_symbol_id");
+    assert_schema_has_property(tools, "impact_surface", "id");
     assert_symbol_selector_schema(tools, "impact_surface");
     assert_schema_has_property(tools, "repo_brief", "mode");
     assert_schema_property_enum(tools, "repo_brief", "mode", &[
@@ -181,7 +181,7 @@ fn list_tools_exposes_complete_typed_schemas() {
     assert_schema_nested_property(tools, "memory_create", "bind", "path_summary");
     assert_schema_requires(tools, "memory_update", "memory_id");
     assert_schema_requires(tools, "memory_search", "query");
-    assert_schema_has_property(tools, "memory_for_symbol", "logical_symbol_id");
+    assert_schema_has_property(tools, "memory_for_symbol", "id");
     assert_schema_requires(tools, "memory_for_path", "path");
     assert_schema_requires(tools, "memory_for_call_path", "edge_sequence_hash");
     assert_schema_requires(tools, "memory_mark_obsolete", "memory_id");
@@ -305,8 +305,7 @@ fn mcp_memory_tools_create_surface_validate_and_obsolete_symbol_memory() {
     // logical_symbol_id crosses the MCP boundary as a STRING (#130: a 64-bit hash > 2^53 can't be a
     // JSON number without rounding). Read it as a string and pass it straight back to the other
     // tools — the round-trip the fix guarantees.
-    let logical_symbol_id =
-        lookup["candidates"].as_array().unwrap()[0]["logical_symbol_id"].as_str().unwrap();
+    let logical_symbol_id = lookup["candidates"].as_array().unwrap()[0]["id"].as_str().unwrap();
     let memory = call_tool(
             &config.database,
             "memory_create",
@@ -317,19 +316,15 @@ fn mcp_memory_tools_create_surface_validate_and_obsolete_symbol_memory() {
                 "confidence": "high",
                 "created_by": "mcp-test",
                 "tags": ["cfg", "graph"],
-                "bind": {"logical_symbol_id": logical_symbol_id}
+                "bind": {"id": logical_symbol_id}
             }),
         )
         .unwrap();
     assert_eq!(memory["duplicate"], false);
     let memory_id = memory["memory"]["memory_id"].as_str().unwrap();
 
-    let for_symbol = call_tool(
-        &config.database,
-        "memory_for_symbol",
-        json!({"logical_symbol_id": logical_symbol_id}),
-    )
-    .unwrap();
+    let for_symbol =
+        call_tool(&config.database, "memory_for_symbol", json!({"id": logical_symbol_id})).unwrap();
     assert_eq!(for_symbol.as_array().unwrap()[0]["memory_id"], memory_id);
     let search =
         call_tool(&config.database, "memory_search", json!({"query": "logical helper"})).unwrap();
@@ -352,7 +347,7 @@ fn mcp_memory_tools_create_surface_validate_and_obsolete_symbol_memory() {
     let impact = call_tool(
         &config.database,
         "impact_surface",
-        json!({"logical_symbol_id": logical_symbol_id, "include_memories": true}),
+        json!({"id": logical_symbol_id, "include_memories": true}),
     )
     .unwrap();
     assert_eq!(impact["repo_memories"]["direct"].as_array().unwrap()[0]["memory_id"], memory_id);
@@ -434,11 +429,11 @@ fn mcp_handle_selection_disambiguates_graph_tools() {
     let candidates = lookup["candidates"].as_array().unwrap();
     assert_eq!(candidates.len(), 2);
     // #149: candidates carry the opaque `sym_<hex>` handle (not the ephemeral numeric symbol_id),
-    // plus the human-readable symbol_path.
+    // plus the human-readable ref (symbol_path).
     assert!(candidates.iter().all(|candidate| {
         candidate.get("symbol_id").is_none()
-            && candidate["logical_symbol_id"].as_str().is_some_and(|h| h.starts_with("sym_"))
-            && candidate["symbol_path"].as_str().is_some()
+            && candidate["id"].as_str().is_some_and(|h| h.starts_with("sym_"))
+            && candidate["ref"].as_str().is_some()
     }));
 
     let ambiguous =
@@ -448,20 +443,20 @@ fn mcp_handle_selection_disambiguates_graph_tools() {
 
     let one = candidates
         .iter()
-        .find(|candidate| candidate["symbol_path"].as_str().unwrap().contains("one.rs"))
+        .find(|candidate| candidate["ref"].as_str().unwrap().contains("one.rs"))
         .unwrap();
     let exact = call_tool(
         &config.database,
         "find_callers",
         json!({
-            "logical_symbol_id": one["logical_symbol_id"].as_str().unwrap(),
+            "id": one["id"].as_str().unwrap(),
             "resolution": "exact",
             "edge_kinds": ["calls_name"]
         }),
     )
     .unwrap();
     assert_eq!(exact["query"]["tool"], "find_callers");
-    assert_eq!(exact["query"]["logical_symbol_id"], one["logical_symbol_id"]);
+    assert_eq!(exact["query"]["id"], one["id"]);
     assert_eq!(exact["query"]["resolution"], "exact");
     assert_eq!(exact["summary"]["returned_count"], 1);
     assert_eq!(exact["summary"]["total_matching_edges"], 1);
@@ -475,7 +470,7 @@ fn mcp_handle_selection_disambiguates_graph_tools() {
         &config.database,
         "find_callers",
         json!({
-            "logical_symbol_id": one["logical_symbol_id"].as_str().unwrap(),
+            "id": one["id"].as_str().unwrap(),
             "resolution": "exact",
             "edge_kinds": ["calls_name"],
             "include_coverage": true
@@ -497,14 +492,14 @@ fn mcp_handle_selection_disambiguates_graph_tools() {
         &config.database,
         "compare_graph_to_text",
         json!({
-            "logical_symbol_id": one["logical_symbol_id"].as_str().unwrap(),
+            "id": one["id"].as_str().unwrap(),
             "pattern": "    shared\\(",
             "resolution": "exact",
             "edge_kinds": ["calls_name"]
         }),
     )
     .unwrap();
-    assert_eq!(comparison["query"]["logical_symbol_id"], one["logical_symbol_id"]);
+    assert_eq!(comparison["query"]["id"], one["id"]);
     assert_eq!(comparison["summary"]["graph_edges"], 1);
     assert_eq!(comparison["summary"]["graph_hits"], 1);
     assert_eq!(comparison["summary"]["text_hits"], 3);
@@ -533,7 +528,7 @@ fn mcp_handle_selection_disambiguates_graph_tools() {
         &config.database,
         "compare_graph_to_text",
         json!({
-            "logical_symbol_id": one["logical_symbol_id"].as_str().unwrap(),
+            "id": one["id"].as_str().unwrap(),
             "pattern": "shared",
             "resolution": "exact",
             "edge_kinds": ["calls_name"]
@@ -551,7 +546,7 @@ fn mcp_handle_selection_disambiguates_graph_tools() {
         &config.database,
         "impact_surface",
         json!({
-            "logical_symbol_id": one["logical_symbol_id"].as_str().unwrap(),
+            "id": one["id"].as_str().unwrap(),
             "resolution": "exact",
             "include_tests": true,
             "include_docs": true,
@@ -561,7 +556,7 @@ fn mcp_handle_selection_disambiguates_graph_tools() {
         }),
     )
     .unwrap();
-    assert_eq!(impact["query"]["symbol_id"], one["symbol_id"]);
+    assert_eq!(impact["query"]["ref"], one["ref"]);
     assert_eq!(impact["query"]["resolution"], "exact");
     assert!(impact["direct_semantic_callers"].as_array().unwrap().len() == 1);
     assert!(impact["direct_semantic_callees"].as_array().unwrap().is_empty());
@@ -577,7 +572,7 @@ fn mcp_handle_selection_disambiguates_graph_tools() {
     let papertrail = call_tool(
         &config.database,
         "papertrail_for_symbol",
-        json!({"logical_symbol_id": one["logical_symbol_id"].as_str().unwrap()}),
+        json!({"id": one["id"].as_str().unwrap()}),
     )
     .unwrap();
     assert!(papertrail["current_source"]["symbol"].as_str().unwrap().contains("shared"));
@@ -674,9 +669,9 @@ fn assert_enum_values(schema: &Value, expected: &[&str], label: &str) {
 }
 
 fn assert_symbol_selector_schema(tools: &[Value], name: &str) {
-    // #149: the wire selector is symbol/symbol_path/logical_symbol_id (the opaque handle); the
+    // #149: the wire selector is symbol/ref/id (the opaque handle); the
     // ephemeral numeric symbol_id is no longer an accepted input.
-    for field in ["symbol", "symbol_path", "logical_symbol_id", "allow_ambiguous"] {
+    for field in ["symbol", "ref", "id", "allow_ambiguous"] {
         assert_schema_has_property(tools, name, field);
     }
     assert_schema_lacks_property(tools, name, "symbol_id");

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -91,17 +91,23 @@ fn list_tools_exposes_complete_typed_schemas() {
         "none", "compact", "full",
     ]);
     assert_schema_has_property(tools, "semantic_search", "graph_limit");
-    assert_schema_has_property(tools, "semantic_search", "include_git");
-    assert_schema_has_property(tools, "semantic_search", "include_papertrail");
-    assert_schema_has_property(tools, "semantic_search", "include_fallback");
+    assert_schema_array_item_enum(tools, "semantic_search", "include", &[
+        "generated",
+        "git",
+        "papertrail",
+        "fallback",
+    ]);
     assert_schema_has_property(tools, "semantic_search", "explain");
     assert_symbol_selector_schema(tools, "symbol_lookup");
-    assert_schema_has_property(tools, "find_callers", "include_references");
-    assert_schema_has_property(tools, "find_callers", "include_unresolved");
-    assert_schema_has_property(tools, "find_callers", "include_macros");
-    assert_schema_has_property(tools, "find_callers", "include_common_methods");
-    assert_schema_has_property(tools, "find_callers", "include_coverage");
-    assert_schema_has_property(tools, "find_callers", "include_memories");
+    assert_schema_array_item_enum(tools, "symbol_lookup", "include", &["memories"]);
+    assert_schema_array_item_enum(tools, "find_callers", "include", &[
+        "references",
+        "unresolved",
+        "macros",
+        "common_methods",
+        "coverage",
+        "memories",
+    ]);
     assert_schema_has_property(tools, "find_callers", "edge_kinds");
     assert_schema_has_property(tools, "find_callers", "resolution");
     assert_schema_property_enum(tools, "find_callers", "resolution", &[
@@ -121,32 +127,39 @@ fn list_tools_exposes_complete_typed_schemas() {
     ]);
     assert_schema_has_property(tools, "find_callers", "id");
     assert_symbol_selector_schema(tools, "find_callers");
-    assert_schema_has_property(tools, "trace_callees", "include_references");
-    assert_schema_has_property(tools, "trace_callees", "include_unresolved");
-    assert_schema_has_property(tools, "trace_callees", "include_macros");
-    assert_schema_has_property(tools, "trace_callees", "include_common_methods");
-    assert_schema_has_property(tools, "trace_callees", "include_coverage");
-    assert_schema_has_property(tools, "trace_callees", "include_memories");
+    assert_schema_array_item_enum(tools, "trace_callees", "include", &[
+        "references",
+        "unresolved",
+        "macros",
+        "common_methods",
+        "coverage",
+        "memories",
+    ]);
     assert_schema_has_property(tools, "trace_callees", "edge_kinds");
     assert_schema_has_property(tools, "trace_callees", "resolution");
     assert_schema_has_property(tools, "trace_callees", "id");
     assert_symbol_selector_schema(tools, "trace_callees");
     assert_schema_requires(tools, "compare_graph_to_text", "pattern");
-    assert_schema_has_property(tools, "compare_graph_to_text", "include_unresolved");
-    assert_schema_has_property(tools, "compare_graph_to_text", "include_macros");
-    assert_schema_has_property(tools, "compare_graph_to_text", "include_common_methods");
-    assert_schema_has_property(tools, "compare_graph_to_text", "include_tests");
+    assert_schema_array_item_enum(tools, "compare_graph_to_text", "include", &[
+        "tests",
+        "references",
+        "unresolved",
+        "macros",
+        "common_methods",
+    ]);
     assert_schema_has_property(tools, "compare_graph_to_text", "edge_kinds");
     assert_schema_has_property(tools, "compare_graph_to_text", "resolution");
     assert_schema_has_property(tools, "compare_graph_to_text", "id");
     assert_symbol_selector_schema(tools, "compare_graph_to_text");
     assert_schema_has_property(tools, "impact_surface", "resolution");
-    assert_schema_has_property(tools, "impact_surface", "include_tests");
-    assert_schema_has_property(tools, "impact_surface", "include_docs");
-    assert_schema_has_property(tools, "impact_surface", "include_git");
-    assert_schema_has_property(tools, "impact_surface", "include_papertrail");
-    assert_schema_has_property(tools, "impact_surface", "include_text_fallback");
-    assert_schema_has_property(tools, "impact_surface", "include_memories");
+    assert_schema_array_item_enum(tools, "impact_surface", "include", &[
+        "tests",
+        "docs",
+        "git",
+        "papertrail",
+        "text_fallback",
+        "memories",
+    ]);
     assert_schema_has_property(tools, "impact_surface", "id");
     assert_symbol_selector_schema(tools, "impact_surface");
     assert_schema_has_property(tools, "repo_brief", "mode");
@@ -157,9 +170,9 @@ fn list_tools_exposes_complete_typed_schemas() {
         "refactor_candidates",
     ]);
     assert_schema_has_property(tools, "repo_brief", "limit");
-    assert_schema_has_property(tools, "repo_brief", "include_memories");
+    assert_schema_array_item_enum(tools, "repo_brief", "include", &["generated", "memories"]);
     assert_schema_has_property(tools, "repo_clusters", "limit");
-    assert_schema_has_property(tools, "repo_clusters", "include_memories");
+    assert_schema_array_item_enum(tools, "repo_clusters", "include", &["generated", "memories"]);
     assert_schema_has_property(tools, "repo_clusters", "min_cluster_size");
     assert_symbol_selector_schema(tools, "docs_for_symbol");
     assert_symbol_selector_schema(tools, "git_history_for_symbol");
@@ -168,10 +181,15 @@ fn list_tools_exposes_complete_typed_schemas() {
     assert_schema_has_property(tools, "read_chunk", "include_graph");
     assert_schema_property_enum(tools, "read_chunk", "include_graph", &["none", "compact", "full"]);
     assert_schema_has_property(tools, "read_chunk", "graph_limit");
-    assert_schema_has_property(tools, "read_chunk", "include_memories");
+    assert_schema_array_item_enum(tools, "read_chunk", "include", &["memories"]);
     assert_schema_requires(tools, "papertrail_for_commit", "commit_hash");
-    assert_schema_has_property(tools, "papertrail_for_commit", "include_fallback");
-    assert_schema_has_property(tools, "rationale_search", "include_fallback");
+    assert_schema_array_item_enum(tools, "papertrail_for_commit", "include", &["fallback"]);
+    assert_schema_array_item_enum(tools, "rationale_search", "include", &[
+        "generated",
+        "git",
+        "papertrail",
+        "fallback",
+    ]);
     assert_schema_has_property(tools, "heal_index", "limit");
     assert_schema_requires(tools, "memory_create", "kind");
     assert_schema_requires(tools, "memory_create", "bind");
@@ -339,7 +357,7 @@ fn mcp_memory_tools_create_surface_validate_and_obsolete_symbol_memory() {
     let chunk = call_tool(
         &config.database,
         "read_chunk",
-        json!({"chunk_id": chunk_id, "include_memories": true}),
+        json!({"chunk_id": chunk_id, "include": ["memories"]}),
     )
     .unwrap();
     assert_eq!(chunk["memories"].as_array().unwrap()[0]["memory_id"], memory_id);
@@ -347,7 +365,7 @@ fn mcp_memory_tools_create_surface_validate_and_obsolete_symbol_memory() {
     let impact = call_tool(
         &config.database,
         "impact_surface",
-        json!({"id": logical_symbol_id, "include_memories": true}),
+        json!({"id": logical_symbol_id, "include": ["memories"]}),
     )
     .unwrap();
     assert_eq!(impact["repo_memories"]["direct"].as_array().unwrap()[0]["memory_id"], memory_id);
@@ -473,7 +491,7 @@ fn mcp_handle_selection_disambiguates_graph_tools() {
             "id": one["id"].as_str().unwrap(),
             "resolution": "exact",
             "edge_kinds": ["calls_name"],
-            "include_coverage": true
+            "include": ["coverage"]
         }),
     )
     .unwrap();
@@ -548,11 +566,7 @@ fn mcp_handle_selection_disambiguates_graph_tools() {
         json!({
             "id": one["id"].as_str().unwrap(),
             "resolution": "exact",
-            "include_tests": true,
-            "include_docs": true,
-            "include_git": true,
-            "include_papertrail": true,
-            "include_text_fallback": true
+            "include": ["tests", "docs", "git", "papertrail", "text_fallback"]
         }),
     )
     .unwrap();

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -53,15 +53,15 @@ To run from a checkout without installing, use a project-scoped server whose com
 
 ## Tools
 
-- `semantic_search`: `{ "query": string, "limit"?: number, "include_generated"?: boolean, "include_graph"?: "none" | "compact" | "full", "graph_limit"?: number, "include_git"?: boolean, "include_papertrail"?: boolean, "explain"?: boolean }`
-- `symbol_lookup`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "lang"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
-- `find_callers`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include_unresolved"?: boolean, "include_macros"?: boolean, "include_common_methods"?: boolean, "include_references"?: boolean, "edge_kinds"?: string[] }`
-- `trace_callees`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include_unresolved"?: boolean, "include_macros"?: boolean, "include_common_methods"?: boolean, "include_references"?: boolean, "edge_kinds"?: string[] }`
-- `compare_graph_to_text`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "pattern": string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include_tests"?: boolean, "include_unresolved"?: boolean, "include_macros"?: boolean, "include_common_methods"?: boolean, "include_references"?: boolean, "edge_kinds"?: string[] }`
-- `impact_surface`: `{ "query"?: string, "symbol"?: string, "ref"?: string, "id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include_tests"?: boolean, "include_docs"?: boolean, "include_git"?: boolean, "include_papertrail"?: boolean, "include_text_fallback"?: boolean }`
+- `semantic_search`: `{ "query": string, "limit"?: number, "include_graph"?: "none" | "compact" | "full", "graph_limit"?: number, "include"?: ("generated" | "git" | "papertrail" | "fallback")[], "explain"?: boolean }`
+- `symbol_lookup`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "lang"?: string, "allow_ambiguous"?: boolean, "limit"?: number, "include"?: ("memories")[] }`
+- `find_callers`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include"?: ("references" | "unresolved" | "macros" | "common_methods" | "coverage" | "memories")[], "edge_kinds"?: string[] }`
+- `trace_callees`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include"?: ("references" | "unresolved" | "macros" | "common_methods" | "coverage" | "memories")[], "edge_kinds"?: string[] }`
+- `compare_graph_to_text`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "pattern": string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include"?: ("tests" | "references" | "unresolved" | "macros" | "common_methods")[], "edge_kinds"?: string[] }`
+- `impact_surface`: `{ "query"?: string, "symbol"?: string, "ref"?: string, "id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include"?: ("tests" | "docs" | "git" | "papertrail" | "text_fallback" | "memories")[] }`
 - `ffi_surface`: `{ "limit"?: number }`
 - `docs_for_symbol`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
-- `read_chunk`: `{ "chunk_id": number, "include_graph"?: "none" | "compact" | "full", "graph_limit"?: number }`
+- `read_chunk`: `{ "chunk_id": number, "include_graph"?: "none" | "compact" | "full", "graph_limit"?: number, "include"?: ("memories")[] }`
 - `commit_search`: `{ "query": string, "limit"?: number }`
 - `git_history_for_path`: `{ "path": string, "limit"?: number }`
 - `git_history_for_symbol`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "lang"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
@@ -69,14 +69,22 @@ To run from a checkout without installing, use a project-scoped server whose com
 - `git_blame_chunk`: `{ "chunk_id": number }`
 - `papertrail_for_chunk`: `{ "chunk_id": number, "limit"?: number }`
 - `papertrail_for_symbol`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "lang"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
-- `papertrail_for_commit`: `{ "commit_hash": string, "limit"?: number }`
+- `papertrail_for_commit`: `{ "commit_hash": string, "limit"?: number, "include"?: ("fallback")[] }`
 - `github_issue_search`: `{ "query": string, "limit"?: number }`
 - `github_refs_for_path`: `{ "path": string, "limit"?: number }`
-- `rationale_search`: `{ "query": string, "limit"?: number }`
+- `rationale_search`: `{ "query": string, "limit"?: number, "include"?: ("fallback")[] }`
 - `local_ai_status`: `{}`
 - `heal_index`: `{ "limit"?: number }`
 - `github_sync_status`: `{}`
 - `index_status`: `{}`
+
+**The `include` array** replaces the former `include_*` boolean params (#149 follow-up — shorter,
+token-cheaper). Presence in the list turns a section on. **Omit `include` entirely to keep each
+tool's defaults** (e.g. `impact_surface` returns tests/docs/git/papertrail/text_fallback/memories;
+graph tools return memories). A **present** list is the EXACT on-set — so it's also how you disable a
+default-on section: `impact_surface` with `"include": ["git"]` returns git history only, and any
+tool with `"include": []` returns the bare result. Each tool accepts only its own flags (see the
+signatures above).
 
 `tools/list` is served by `rmcp` and exposes typed JSON schemas derived from the same request structs
 used by the handlers. Existing tool names and response fields are kept stable for current MCP clients.
@@ -145,9 +153,9 @@ from an outdated FTS table.
 - `include_graph`: `none`, `compact`, or `full`. Default is `compact`.
 - `graph_limit`: maximum caller/callee/import/type evidence entries to attach. Default is `3` for
   search and `20` for `read_chunk`.
-- `include_git`: include git-history ranking boosts when available. Default is `true`.
-- `include_papertrail`: include cached GitHub papertrail ranking boosts when available. Default is
-  `true`.
+- `include`: array of `generated` (index generated files), `git` (git-history ranking boosts),
+  `papertrail` (cached GitHub papertrail boosts), `fallback`. `git` and `papertrail` are on by
+  default — omit `include` to keep them; pass an explicit list to override.
 - `explain`: include score components (`bm25`, `vector`, `symbol`, `graph`, `git`, `github`).
   Default is `false`.
 
@@ -226,12 +234,16 @@ verified/repo-local `constructs` edges. It hides unresolved calls, unresolved ma
 references, imports/exports, common method/combinator calls, and std/common constructors unless a
 caller asks for them explicitly:
 
-- `include_unresolved`: include unresolved qualified/name-only calls.
-- `include_macros`: include `uses_macro` edges such as `format!`, `json!`, and `vec!`.
-- `include_common_methods`: include common low-signal calls such as `clone`, `map`, `map_err`,
+Pass these in the `include` array (each off by default; `memories` is on by default):
+
+- `unresolved`: include unresolved qualified/name-only calls.
+- `macros`: include `uses_macro` edges such as `format!`, `json!`, and `vec!`.
+- `common_methods`: include common low-signal calls such as `clone`, `map`, `map_err`,
   `and_then`, `unwrap_or`, `unwrap_or_else`, `to_string`, `to_owned`, `as_ref`, `as_mut`, `get`,
   `insert`, and unresolved/common `new`.
-- `include_references`: include type references, imports, exports, `contains`, and `implements`.
+- `references`: include type references, imports, exports, `contains`, and `implements`.
+- `coverage` (graph tools): attach the parser/coverage block. `memories`: attach crossing repo
+  memories (on by default; pass `"include": []` to drop them).
 
 `find_callers` uses exact target resolution first, then qualified-name and target-name fallbacks;
 fallback hits are labeled with `resolution`, `verified_target_symbol`, raw `evidence`, and optional
@@ -249,8 +261,7 @@ currently indexed source files, then compares `(path, line)` sets:
     "id": "sym_a3f29c1b",
     "ref": "crates/app/src/runtime/task_spawn.rs::spawn_blocking",
     "pattern": "crate::runtime::task_spawn::spawn_blocking\\(",
-    "resolution": "syntactic",
-    "include_tests": true
+    "resolution": "syntactic"
   },
   "summary": {
     "text_hits": 38,
@@ -294,9 +305,10 @@ treating the counts as authoritative.
 
 Use the same disambiguation controls as graph tools. `resolution: "exact"` means direct graph
 callers/callees are verified against the selected symbol; `syntactic` allows qualified
-tree-sitter evidence; `fuzzy` is for navigation only. Optional section controls are `include_tests`,
-`include_docs`, `include_git`, `include_papertrail`, and `include_text_fallback`, all enabled by
-default. If exact graph callers are empty but text fallback finds symbol/path hits, the caveats
+tree-sitter evidence; `fuzzy` is for navigation only. The sections are controlled by the `include`
+array — `tests`, `docs`, `git`, `papertrail`, `text_fallback`, `memories`, all on by default (omit
+`include` to keep them; pass e.g. `["git"]` to narrow to git history only). If exact graph callers
+are empty but text fallback finds symbol/path hits, the caveats
 section explicitly says that graph extraction or resolution gaps are likely. Free-text `query`
 requests retain the older flat impact item shape for compatibility.
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -54,21 +54,21 @@ To run from a checkout without installing, use a project-scoped server whose com
 ## Tools
 
 - `semantic_search`: `{ "query": string, "limit"?: number, "include_generated"?: boolean, "include_graph"?: "none" | "compact" | "full", "graph_limit"?: number, "include_git"?: boolean, "include_papertrail"?: boolean, "explain"?: boolean }`
-- `symbol_lookup`: `{ "symbol"?: string, "symbol_path"?: string, "logical_symbol_id"?: string, "language"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
-- `find_callers`: `{ "symbol"?: string, "symbol_path"?: string, "logical_symbol_id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include_unresolved"?: boolean, "include_macros"?: boolean, "include_common_methods"?: boolean, "include_references"?: boolean, "edge_kinds"?: string[] }`
-- `trace_callees`: `{ "symbol"?: string, "symbol_path"?: string, "logical_symbol_id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include_unresolved"?: boolean, "include_macros"?: boolean, "include_common_methods"?: boolean, "include_references"?: boolean, "edge_kinds"?: string[] }`
-- `compare_graph_to_text`: `{ "symbol"?: string, "symbol_path"?: string, "logical_symbol_id"?: string, "pattern": string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include_tests"?: boolean, "include_unresolved"?: boolean, "include_macros"?: boolean, "include_common_methods"?: boolean, "include_references"?: boolean, "edge_kinds"?: string[] }`
-- `impact_surface`: `{ "query"?: string, "symbol"?: string, "symbol_path"?: string, "logical_symbol_id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include_tests"?: boolean, "include_docs"?: boolean, "include_git"?: boolean, "include_papertrail"?: boolean, "include_text_fallback"?: boolean }`
+- `symbol_lookup`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "lang"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
+- `find_callers`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include_unresolved"?: boolean, "include_macros"?: boolean, "include_common_methods"?: boolean, "include_references"?: boolean, "edge_kinds"?: string[] }`
+- `trace_callees`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include_unresolved"?: boolean, "include_macros"?: boolean, "include_common_methods"?: boolean, "include_references"?: boolean, "edge_kinds"?: string[] }`
+- `compare_graph_to_text`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "pattern": string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include_tests"?: boolean, "include_unresolved"?: boolean, "include_macros"?: boolean, "include_common_methods"?: boolean, "include_references"?: boolean, "edge_kinds"?: string[] }`
+- `impact_surface`: `{ "query"?: string, "symbol"?: string, "ref"?: string, "id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include_tests"?: boolean, "include_docs"?: boolean, "include_git"?: boolean, "include_papertrail"?: boolean, "include_text_fallback"?: boolean }`
 - `ffi_surface`: `{ "limit"?: number }`
-- `docs_for_symbol`: `{ "symbol"?: string, "symbol_path"?: string, "logical_symbol_id"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
+- `docs_for_symbol`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
 - `read_chunk`: `{ "chunk_id": number, "include_graph"?: "none" | "compact" | "full", "graph_limit"?: number }`
 - `commit_search`: `{ "query": string, "limit"?: number }`
 - `git_history_for_path`: `{ "path": string, "limit"?: number }`
-- `git_history_for_symbol`: `{ "symbol"?: string, "symbol_path"?: string, "logical_symbol_id"?: string, "language"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
+- `git_history_for_symbol`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "lang"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
 - `commits_touching_query`: `{ "query": string, "limit"?: number }`
 - `git_blame_chunk`: `{ "chunk_id": number }`
 - `papertrail_for_chunk`: `{ "chunk_id": number, "limit"?: number }`
-- `papertrail_for_symbol`: `{ "symbol"?: string, "symbol_path"?: string, "logical_symbol_id"?: string, "language"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
+- `papertrail_for_symbol`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "lang"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
 - `papertrail_for_commit`: `{ "commit_hash": string, "limit"?: number }`
 - `github_issue_search`: `{ "query": string, "limit"?: number }`
 - `github_refs_for_path`: `{ "path": string, "limit"?: number }`
@@ -98,10 +98,10 @@ TOON and takes a global `--json` flag for JSON output.)
 {
   "candidates": [
     {
-      "logical_symbol_id": "sym_a3f29c1b",
+      "id": "sym_a3f29c1b",
       "logical_variant_count": 2,
       "logical_group_reason": "cfg_variant",
-      "symbol_path": "crates/app/src/runtime/task_spawn.rs::spawn_blocking",
+      "ref": "crates/app/src/runtime/task_spawn.rs::spawn_blocking",
       "qualified_name": "crates/app/src/runtime/task_spawn.rs::spawn_blocking",
       "kind": "function",
       "signature": "pub(crate) async fn spawn_blocking<F, T>(...)"
@@ -111,8 +111,8 @@ TOON and takes a global `--json` flag for JSON output.)
 }
 ```
 
-Graph, docs, git-history, papertrail, and symbol-specific impact tools accept `logical_symbol_id`,
-`symbol_path`, or `symbol` and resolve them in that priority order. `logical_symbol_id` is the
+Graph, docs, git-history, papertrail, and symbol-specific impact tools accept `id`,
+`ref`, or `symbol` and resolve them in that priority order. `id` is the
 **opaque, stable handle** a `symbol_lookup` (or any symbol-returning tool) emits — a `sym_<hex>`
 token; copy it verbatim and pass it back, never parse it as a number. There is no numeric
 `symbol_id` on the wire: it's an internal rowid reassigned on every reindex, so it could not be
@@ -121,7 +121,7 @@ returns the same candidate object instead of guessing. Pass `allow_ambiguous: tr
 navigation/debugging when name fallback is acceptable.
 
 Logical symbols group multiple concrete symbol rows that represent one source-level API, such as
-Rust `#[cfg]` variants of the same function in the same file. Use `logical_symbol_id` with
+Rust `#[cfg]` variants of the same function in the same file. Use `id` with
 `resolution: "exact"` when callers target the logical API rather than one cfg body. Exact logical
 mode only returns edges whose verified `target_symbol_id` is a member of the group. Graph envelopes
 include the selected `logical_symbol` and its `variants`; `cfg_expr` may be `null` until cfg
@@ -167,7 +167,7 @@ entries include exact tree-sitter callsite spans: `callsite.path`, `callsite.lin
 Graph tools and `impact_surface` accept `resolution`:
 
 - `exact`: only verified target-symbol rows are returned. A row is allowed only when the edge's
-  verified target resolves to the selected symbol (its `logical_symbol_id`/`symbol_path`), or the
+  verified target resolves to the selected symbol (its `id`/`ref`), or the
   resolved fully-qualified symbol identity matches `symbol`. Every returned row has
   `verified_target_symbol: true`.
 - `syntactic`: default. Exact matches plus qualified syntactic evidence are returned. Unresolved
@@ -175,10 +175,10 @@ Graph tools and `impact_surface` accept `resolution`:
 - `fuzzy`: compatibility/navigation mode. Suffix and bare-name fallback are allowed, including
   ambiguous candidates. Treat these rows as possible evidence, not proof.
 
-Use `logical_symbol_id` (the `sym_<hex>` handle from a previous `symbol_lookup`) with
+Use `id` (the `sym_<hex>` handle from a previous `symbol_lookup`) with
 `resolution: "exact"` to target a resolved symbol — including the cfg/duplicate-variant case, where
 the handle addresses the whole logical group (all its members). Bare names in `exact` mode
-intentionally return little or nothing unless `logical_symbol_id` is provided.
+intentionally return little or nothing unless `id` is provided.
 
 `find_callers` and `trace_callees` return a graph envelope, not a bare row array:
 
@@ -186,8 +186,8 @@ intentionally return little or nothing unless `logical_symbol_id` is provided.
 {
   "query": {
     "tool": "find_callers",
-    "logical_symbol_id": "sym_a3f29c1b",
-    "symbol_path": "crates/app/src/runtime/task_spawn.rs::spawn_blocking",
+    "id": "sym_a3f29c1b",
+    "ref": "crates/app/src/runtime/task_spawn.rs::spawn_blocking",
     "resolution": "exact"
   },
   "summary": {
@@ -246,8 +246,8 @@ currently indexed source files, then compares `(path, line)` sets:
 ```json
 {
   "query": {
-    "logical_symbol_id": "sym_a3f29c1b",
-    "symbol_path": "crates/app/src/runtime/task_spawn.rs::spawn_blocking",
+    "id": "sym_a3f29c1b",
+    "ref": "crates/app/src/runtime/task_spawn.rs::spawn_blocking",
     "pattern": "crate::runtime::task_spawn::spawn_blocking\\(",
     "resolution": "syntactic",
     "include_tests": true
@@ -280,7 +280,7 @@ graph traversal envelopes so audit output can be checked for stale source and pa
 treating the counts as authoritative.
 
 `impact_surface` is the graph-backed rg replacement path for a selected symbol. For
-`logical_symbol_id`, `symbol_path`, or `symbol` requests it returns sections instead of a flat list:
+`id`, `ref`, or `symbol` requests it returns sections instead of a flat list:
 
 1. `direct_semantic_callers`
 2. `direct_semantic_callees`

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -54,21 +54,21 @@ To run from a checkout without installing, use a project-scoped server whose com
 ## Tools
 
 - `semantic_search`: `{ "query": string, "limit"?: number, "include_generated"?: boolean, "include_graph"?: "none" | "compact" | "full", "graph_limit"?: number, "include_git"?: boolean, "include_papertrail"?: boolean, "explain"?: boolean }`
-- `symbol_lookup`: `{ "symbol"?: string, "symbol_path"?: string, "symbol_id"?: number, "logical_symbol_id"?: number, "language"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
-- `find_callers`: `{ "symbol"?: string, "symbol_path"?: string, "symbol_id"?: number, "logical_symbol_id"?: number, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include_unresolved"?: boolean, "include_macros"?: boolean, "include_common_methods"?: boolean, "include_references"?: boolean, "edge_kinds"?: string[] }`
-- `trace_callees`: `{ "symbol"?: string, "symbol_path"?: string, "symbol_id"?: number, "logical_symbol_id"?: number, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include_unresolved"?: boolean, "include_macros"?: boolean, "include_common_methods"?: boolean, "include_references"?: boolean, "edge_kinds"?: string[] }`
-- `compare_graph_to_text`: `{ "symbol"?: string, "symbol_path"?: string, "symbol_id"?: number, "logical_symbol_id"?: number, "pattern": string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include_tests"?: boolean, "include_unresolved"?: boolean, "include_macros"?: boolean, "include_common_methods"?: boolean, "include_references"?: boolean, "edge_kinds"?: string[] }`
-- `impact_surface`: `{ "query"?: string, "symbol"?: string, "symbol_path"?: string, "symbol_id"?: number, "logical_symbol_id"?: number, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include_tests"?: boolean, "include_docs"?: boolean, "include_git"?: boolean, "include_papertrail"?: boolean, "include_text_fallback"?: boolean }`
+- `symbol_lookup`: `{ "symbol"?: string, "symbol_path"?: string, "logical_symbol_id"?: string, "language"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
+- `find_callers`: `{ "symbol"?: string, "symbol_path"?: string, "logical_symbol_id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include_unresolved"?: boolean, "include_macros"?: boolean, "include_common_methods"?: boolean, "include_references"?: boolean, "edge_kinds"?: string[] }`
+- `trace_callees`: `{ "symbol"?: string, "symbol_path"?: string, "logical_symbol_id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include_unresolved"?: boolean, "include_macros"?: boolean, "include_common_methods"?: boolean, "include_references"?: boolean, "edge_kinds"?: string[] }`
+- `compare_graph_to_text`: `{ "symbol"?: string, "symbol_path"?: string, "logical_symbol_id"?: string, "pattern": string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include_tests"?: boolean, "include_unresolved"?: boolean, "include_macros"?: boolean, "include_common_methods"?: boolean, "include_references"?: boolean, "edge_kinds"?: string[] }`
+- `impact_surface`: `{ "query"?: string, "symbol"?: string, "symbol_path"?: string, "logical_symbol_id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include_tests"?: boolean, "include_docs"?: boolean, "include_git"?: boolean, "include_papertrail"?: boolean, "include_text_fallback"?: boolean }`
 - `ffi_surface`: `{ "limit"?: number }`
-- `docs_for_symbol`: `{ "symbol"?: string, "symbol_path"?: string, "symbol_id"?: number, "allow_ambiguous"?: boolean, "limit"?: number }`
+- `docs_for_symbol`: `{ "symbol"?: string, "symbol_path"?: string, "logical_symbol_id"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
 - `read_chunk`: `{ "chunk_id": number, "include_graph"?: "none" | "compact" | "full", "graph_limit"?: number }`
 - `commit_search`: `{ "query": string, "limit"?: number }`
 - `git_history_for_path`: `{ "path": string, "limit"?: number }`
-- `git_history_for_symbol`: `{ "symbol"?: string, "symbol_path"?: string, "symbol_id"?: number, "language"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
+- `git_history_for_symbol`: `{ "symbol"?: string, "symbol_path"?: string, "logical_symbol_id"?: string, "language"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
 - `commits_touching_query`: `{ "query": string, "limit"?: number }`
 - `git_blame_chunk`: `{ "chunk_id": number }`
 - `papertrail_for_chunk`: `{ "chunk_id": number, "limit"?: number }`
-- `papertrail_for_symbol`: `{ "symbol"?: string, "symbol_path"?: string, "symbol_id"?: number, "language"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
+- `papertrail_for_symbol`: `{ "symbol"?: string, "symbol_path"?: string, "logical_symbol_id"?: string, "language"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
 - `papertrail_for_commit`: `{ "commit_hash": string, "limit"?: number }`
 - `github_issue_search`: `{ "query": string, "limit"?: number }`
 - `github_refs_for_path`: `{ "path": string, "limit"?: number }`
@@ -98,8 +98,7 @@ TOON and takes a global `--json` flag for JSON output.)
 {
   "candidates": [
     {
-      "symbol_id": 3150,
-      "logical_symbol_id": 98,
+      "logical_symbol_id": "sym_a3f29c1b",
       "logical_variant_count": 2,
       "logical_group_reason": "cfg_variant",
       "symbol_path": "crates/app/src/runtime/task_spawn.rs::spawn_blocking",
@@ -113,9 +112,13 @@ TOON and takes a global `--json` flag for JSON output.)
 ```
 
 Graph, docs, git-history, papertrail, and symbol-specific impact tools accept `logical_symbol_id`,
-`symbol_id`, `symbol_path`, or `symbol` and resolve them in that priority order. If a bare `symbol`
-maps to multiple candidates, the tool returns the same candidate object instead of guessing. Pass
-`allow_ambiguous: true` only for navigation/debugging when name fallback is acceptable.
+`symbol_path`, or `symbol` and resolve them in that priority order. `logical_symbol_id` is the
+**opaque, stable handle** a `symbol_lookup` (or any symbol-returning tool) emits — a `sym_<hex>`
+token; copy it verbatim and pass it back, never parse it as a number. There is no numeric
+`symbol_id` on the wire: it's an internal rowid reassigned on every reindex, so it could not be
+cached safely across an edit (#149). If a bare `symbol` maps to multiple candidates, the tool
+returns the same candidate object instead of guessing. Pass `allow_ambiguous: true` only for
+navigation/debugging when name fallback is acceptable.
 
 Logical symbols group multiple concrete symbol rows that represent one source-level API, such as
 Rust `#[cfg]` variants of the same function in the same file. Use `logical_symbol_id` with
@@ -163,18 +166,19 @@ entries include exact tree-sitter callsite spans: `callsite.path`, `callsite.lin
 
 Graph tools and `impact_surface` accept `resolution`:
 
-- `exact`: only verified target-symbol rows are returned. A row is allowed only when
-  `target_symbol_id` matches `symbol_id`, or the resolved fully-qualified symbol identity matches
-  `symbol`. Every returned row has `verified_target_symbol: true`.
+- `exact`: only verified target-symbol rows are returned. A row is allowed only when the edge's
+  verified target resolves to the selected symbol (its `logical_symbol_id`/`symbol_path`), or the
+  resolved fully-qualified symbol identity matches `symbol`. Every returned row has
+  `verified_target_symbol: true`.
 - `syntactic`: default. Exact matches plus qualified syntactic evidence are returned. Unresolved
   qualified call targets may be shown, but broad bare-name ambiguous fallback is excluded.
 - `fuzzy`: compatibility/navigation mode. Suffix and bare-name fallback are allowed, including
   ambiguous candidates. Treat these rows as possible evidence, not proof.
 
-Use `symbol_id` with `resolution: "exact"` when a previous `symbol_lookup` result selected one
-specific concrete symbol. Use `logical_symbol_id` with `resolution: "exact"` when the lookup result
-shows multiple cfg/duplicate variants of the same logical API. Bare names in `exact` mode
-intentionally return little or nothing unless `symbol_id` or `logical_symbol_id` is provided.
+Use `logical_symbol_id` (the `sym_<hex>` handle from a previous `symbol_lookup`) with
+`resolution: "exact"` to target a resolved symbol — including the cfg/duplicate-variant case, where
+the handle addresses the whole logical group (all its members). Bare names in `exact` mode
+intentionally return little or nothing unless `logical_symbol_id` is provided.
 
 `find_callers` and `trace_callees` return a graph envelope, not a bare row array:
 
@@ -182,7 +186,7 @@ intentionally return little or nothing unless `symbol_id` or `logical_symbol_id`
 {
   "query": {
     "tool": "find_callers",
-    "symbol_id": 3150,
+    "logical_symbol_id": "sym_a3f29c1b",
     "symbol_path": "crates/app/src/runtime/task_spawn.rs::spawn_blocking",
     "resolution": "exact"
   },
@@ -242,8 +246,7 @@ currently indexed source files, then compares `(path, line)` sets:
 ```json
 {
   "query": {
-    "symbol_id": 3150,
-    "logical_symbol_id": 123,
+    "logical_symbol_id": "sym_a3f29c1b",
     "symbol_path": "crates/app/src/runtime/task_spawn.rs::spawn_blocking",
     "pattern": "crate::runtime::task_spawn::spawn_blocking\\(",
     "resolution": "syntactic",
@@ -276,8 +279,8 @@ rows are also listed in `likely_false_positives`. The tool includes the same `co
 graph traversal envelopes so audit output can be checked for stale source and parser failures before
 treating the counts as authoritative.
 
-`impact_surface` is the graph-backed rg replacement path for a selected symbol. For `symbol_id`,
-`symbol_path`, or `symbol` requests it returns sections instead of a flat list:
+`impact_surface` is the graph-backed rg replacement path for a selected symbol. For
+`logical_symbol_id`, `symbol_path`, or `symbol` requests it returns sections instead of a flat list:
 
 1. `direct_semantic_callers`
 2. `direct_semantic_callees`
@@ -290,7 +293,7 @@ treating the counts as authoritative.
 9. `completeness_and_caveats`
 
 Use the same disambiguation controls as graph tools. `resolution: "exact"` means direct graph
-callers/callees are verified against the selected `symbol_id`; `syntactic` allows qualified
+callers/callees are verified against the selected symbol; `syntactic` allows qualified
 tree-sitter evidence; `fuzzy` is for navigation only. Optional section controls are `include_tests`,
 `include_docs`, `include_git`, `include_papertrail`, and `include_text_fallback`, all enabled by
 default. If exact graph callers are empty but text fallback finds symbol/path hits, the caveats

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -84,7 +84,9 @@ tool's defaults** (e.g. `impact_surface` returns tests/docs/git/papertrail/text_
 graph tools return memories). A **present** list is the EXACT on-set — so it's also how you disable a
 default-on section: `impact_surface` with `"include": ["git"]` returns git history only, and any
 tool with `"include": []` returns the bare result. Each tool accepts only its own flags (see the
-signatures above).
+signatures above). The server also accepts a JSON-string-encoded array (`"[\"git\"]"`) as well as a
+real array, so the surface works even from clients that serialize array params as strings
+([anthropics/claude-code#24599](https://github.com/anthropics/claude-code/issues/24599)).
 
 `tools/list` is served by `rmcp` and exposes typed JSON schemas derived from the same request structs
 used by the handlers. Existing tool names and response fields are kept stable for current MCP clients.


### PR DESCRIPTION
Implements the wire-contract change specced in #149.

## What changed

The MCP/CLI wire exposed two symbol ids, both footguns:
- **`symbol_id`** — autoincrement rowid, reassigned on every reindex (dogfooded: 875582→875938 after a one-line edit), so it could never be cached safely across an edit.
- **`logical_symbol_id`** — stable but a ~6×10¹⁸ number; decimal-string-serialized (#130) yet still *number-shaped*, inviting `parseInt` → silent 2⁵³ rounding.

Now: **one opaque, stable handle on the wire; the ephemeral rowid never leaves the engine.** Clean break, no transitional support.

- **`serde_big_id::sym_handle` / `sym_handle_opt`** — `logical_symbol_id` crosses serde as an opaque **`sym_<hex>`** token (hex of the u64 bits, lossless for any i64). Deserialize accepts **only** the token, so a stale numeric id passed by habit fails loudly. Replaces the now-dead `big_id` (deleted).
- **`symbol_id` is internal-only** — `#[serde(skip_serializing)]` on every output struct (`SymbolHit`, `LogicalSymbol{Hit,Member,Variant}`, `SymbolImportance`, graph query echoes, `ImpactSurfaceQuery`, memory binding), removed from the MCP arg structs, and `#[serde(skip_deserializing)]` on the memory bind input. It stays the rowid + FK target in-process.
- **`important_symbols`** now emits `logical_symbol_id` too (LEFT JOIN `logical_symbol_members`), so every symbol-returning result carries a usable handle.

## Granularity (as decided in #149)

The handle addresses the *logical* symbol; per-cfg-body wire addressing is gone (overloads/different-signature symbols still get distinct handles). `resolution: "exact"` on the handle returns the whole group's edges — the realistic query. `ffi_surface` is unaffected (it emits qualified-name strings, never an id).

## Docs + tests

- `docs/mcp-tools.md` + `AGENTS.md`: handle described; `symbol_id` documented as gone from the wire; examples use `sym_<hex>`.
- `serde_big_id` tests: token round-trip (incl. negative/`i64::MIN`/MAX), reject bare number / missing prefix.
- The MCP disambiguation test round-trips the handle through `find_callers` / `compare_graph_to_text` / `papertrail_for_symbol` and asserts candidates carry no `symbol_id` and a `sym_`-prefixed handle. Schema test asserts the selector schema lacks `symbol_id`.

Full core (421) + mcp (20) + CLI suites green; clippy + nightly-fmt clean.

Closes #149
