### PR TITLE
fix(memory): logical-symbol bindings survive chunk_id churn on reindex (#154)

### DIFF
--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -3119,6 +3119,75 @@ fn cross_version_moniker_match_requires_kind_corroboration() {
     }
 }
 
+/// #154: a `logical_symbol` binding must stay `current` across a reindex that merely SHIFTS the
+/// symbol's lines (an edit elsewhere in the file). The logical symbol's id is content-derived and
+/// stable, but chunk ids are reassigned on every re-chunk — so the stored `chunk_id` goes stale.
+/// Before the fix the stable-id arm called `validate_bound_chunk`, which found the churned chunk_id
+/// missing and returned `gone`; it must instead re-derive the chunk from the live logical symbol.
+#[test]
+fn logical_symbol_binding_survives_chunk_id_churn_on_reindex() {
+    let h = Harness::new();
+    let file = h.add_file("a.rs", "fn target() {}\n");
+    let sym = h.add_symbol_qualified(file, "target", "a.rs::target", "function", 0, 14);
+    h.add_chunk(file, "a.rs::target", "fn target() {}\n");
+    h.add_logical_symbol(1001, "a.rs", "target", "a.rs::target", sym);
+
+    let created = create_memory(&h.conn, RepoMemoryCreate {
+        kind: "Invariant".to_string(),
+        title: "target invariant".to_string(),
+        body: "target stays reentrant".to_string(),
+        confidence: "high".to_string(),
+        created_by: None,
+        source: None,
+        tags: Vec::new(),
+        bind: RepoMemoryBindTarget { logical_symbol_id: Some(1001), ..Default::default() },
+    })
+    .unwrap();
+    let memory_id = created.memory.memory_id;
+    let original_chunk_id = created
+        .memory
+        .bindings
+        .iter()
+        .find(|b| b.binding_kind == "logical_symbol")
+        .expect("logical_symbol binding")
+        .chunk_id
+        .expect("chunk_id bound");
+
+    // Re-chunk the file: chunk + symbol rows get NEW rowids (as a reindex reassigns them), but the
+    // logical symbol keeps its content-derived id 1001 (the symbol is unchanged, just shifted). The
+    // content is byte-identical, so the only thing that moved is the chunk_id.
+    h.conn.execute("DELETE FROM logical_symbol_members", []).unwrap();
+    h.conn.execute("DELETE FROM chunks", []).unwrap();
+    h.conn.execute("DELETE FROM symbols", []).unwrap();
+    let new_sym = h.add_symbol_qualified(file, "target", "a.rs::target", "function", 0, 14);
+    h.add_chunk(file, "a.rs::target", "fn target() {}\n");
+    h.conn
+        .execute(
+            "INSERT INTO logical_symbol_members(logical_symbol_id, symbol_id, cfg_expr, \
+             signature_hash, start_line, end_line) VALUES (1001, ?1, NULL, NULL, 1, 1)",
+            params![new_sym],
+        )
+        .unwrap();
+
+    validate_memories(&h.conn, None).unwrap();
+
+    let memory = memory_by_id(&h.conn, &memory_id).unwrap().unwrap();
+    let binding = memory
+        .bindings
+        .iter()
+        .find(|b| b.binding_kind == "logical_symbol")
+        .expect("logical_symbol binding");
+    assert_eq!(
+        binding.anchor_status, "current",
+        "a logical_symbol binding must survive chunk_id churn on reindex (#154)"
+    );
+    assert_ne!(
+        binding.chunk_id,
+        Some(original_chunk_id),
+        "the binding's chunk_id should be refreshed to the re-chunked symbol's new chunk"
+    );
+}
+
 /// Point the index `source_root` meta at the harness checkout so the off-index filesystem
 /// existence fallback (#98) has a root to resolve a binding path against.
 fn set_source_root(h: &Harness) {

--- a/crates/rag-rat-core/src/query/memory/validate.rs
+++ b/crates/rag-rat-core/src/query/memory/validate.rs
@@ -47,6 +47,26 @@ pub(crate) fn validate_logical_symbol_binding(
     if let Some(id) = binding.logical_symbol_id
         && crate::query::symbol::lookup_logical_by_id(conn, id)?.is_some()
     {
+        // The logical symbol is live. Its id is content-derived and STABLE across reindex, but
+        // chunk ids are reassigned on every re-chunk — so the stored `chunk_id` is stale whenever
+        // the symbol shifted lines (an edit ELSEWHERE in the same file leaves the symbol's
+        // name/qualified_name/kind/signature, hence its stable id, unchanged while its chunk
+        // moves). Re-derive the chunk from the live logical symbol before
+        // content-validating; trusting the churned `chunk_id` made `validate_bound_chunk`
+        // report `gone` for an unchanged symbol (#154 — the gone-on-every-reindex symptom
+        // was really gone-on-any-line-shift). Falls through to the stored-chunk check only
+        // when the logical symbol resolves to no chunk.
+        if let Some(chunk) = chunk_for_logical_symbol(conn, id)? {
+            binding.symbol_id = chunk.symbol_id;
+            binding.chunk_id = Some(chunk.chunk_id);
+            binding.path = Some(chunk.path);
+            binding.start_line = Some(chunk.start_line);
+            binding.end_line = Some(chunk.end_line);
+            return Ok(match source_hash_for_memory(conn, &binding.memory_id)? {
+                Some(expected) if expected != chunk.text_hash => "stale".to_string(),
+                _ => "current".to_string(),
+            });
+        }
         return validate_bound_chunk(conn, binding);
     }
     let relocated = conn


### PR DESCRIPTION
Fixes #154.

## Diagnosis
The reported symptom — "logical_symbol bindings go `gone` after every reindex" — was a misframing. The real trigger is narrower and reproducible: a `logical_symbol` binding goes `gone` when the bound symbol's **lines shift** (an edit elsewhere in the same file), even though its content-derived `stable_id` is unchanged. Routine commits re-chunk touched files, which is why it looked like "every reindex."

Verified by controlled experiment:
- Edit an **unrelated** file → reindex → all logical bindings stay `current`.
- Insert one line atop the bound symbol's file → reindex → the bindings go `gone`, while the logical id itself survives and the stored `chunk_id` no longer exists.

## Root cause
`validate_logical_symbol_binding`'s first arm matches the live (stable) `logical_symbol_id` and delegates to `validate_bound_chunk`, which trusts the binding's stored `chunk_id`. But **chunk ids are reassigned on every re-chunk**, so the stored id is stale after any line shift; the lookup misses and returns `gone`. Symbol bindings avoid this because their `symbol_id` also churns, routing them through the relocate arm that re-derives the chunk.

So the *stability* of the logical id is exactly what funnels the binding into the buggy path — making the "most durable" anchor the least durable in practice.

## Fix
When the logical symbol is confirmed live, re-derive its chunk via `chunk_for_logical_symbol` (refreshing `chunk_id` / `path` / lines / `symbol_id`) and content-validate against the refreshed chunk's `text_hash`: `current` when content matches, `stale` when it changed, never `gone` for a churned id. Falls back to the stored-chunk check only when the logical symbol resolves to no chunk.

## Test
New regression test `logical_symbol_binding_survives_chunk_id_churn_on_reindex`: re-chunks a file (new chunk + symbol rowids, stable logical id, identical content) and asserts the binding stays `current` with a refreshed `chunk_id`. Confirmed it fails (`gone`) without the fix and passes with it.

`cargo build` / `clippy --all-targets` / `test` (434 core) / `+nightly fmt --check` all green.