### PR TITLE
fix(impact): signal truncation on the flat impact_surface shape (#150)

### DIFF
--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -3081,8 +3081,8 @@ pub fn hub() {
         .expect("a capped flat result must carry a completeness sentinel (#150)");
     assert!(sentinel.reason.contains("capped"), "sentinel explains the cap: {sentinel:?}");
     assert!(
-        sentinel.evidence.iter().any(|evidence| evidence.contains("not shown")),
-        "sentinel carries the dropped count: {sentinel:?}"
+        sentinel.evidence.iter().any(|evidence| evidence.contains("beyond the limit")),
+        "sentinel signals more exist: {sentinel:?}"
     );
     let real_items = impact.iter().filter(|item| item.category != "completeness").count();
     assert_eq!(real_items, limit as usize, "exactly `limit` real items, plus the sentinel");
@@ -3093,6 +3093,39 @@ pub fn hub() {
         full.iter().all(|item| item.category != "completeness"),
         "an uncapped result must NOT carry a sentinel: {full:?}"
     );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn impact_surface_flat_signals_truncation_from_a_capped_textual_fallback() {
+    // #150 (Codex review): the per-section caps clamp `textual_fallback`/`historical_evidence` to
+    // exactly `limit`, so a free-text query with MORE matching files than `limit` used to fill the
+    // surface to exactly `limit` and skip the sentinel — silent truncation on the very path the fix
+    // targets. The probe-one-past-limit detection must catch it.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    // The token `needle_token` appears only in COMMENTS across many files — no symbol is named it,
+    // so there are no exact targets / graph neighbors; everything comes from textual fallback.
+    for n in 0..6 {
+        fs::write(
+            root.join(format!("src/file_{n}.rs")),
+            format!("// needle_token marker {n}\npub fn unrelated_{n}() {{}}\n"),
+        )
+        .unwrap();
+    }
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let limit = 2u32;
+    let impact = db.impact_surface("needle_token", limit).unwrap();
+    assert!(
+        impact.iter().any(|item| item.category == "completeness"),
+        "a capped textual-fallback result must still signal truncation (#150 Codex): {impact:?}"
+    );
+    let real_items = impact.iter().filter(|item| item.category != "completeness").count();
+    assert_eq!(real_items, limit as usize, "exactly `limit` real items, plus the sentinel");
 
     fs::remove_dir_all(root).unwrap();
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -3044,6 +3044,60 @@ pub fn caller() {
 }
 
 #[test]
+fn impact_surface_flat_signals_truncation_when_capped() {
+    // #150: the flat (free-text query) impact shape capped at `limit` SILENTLY — a capped result
+    // read as complete. A capped result must now carry a visible `completeness` sentinel (the
+    // flat-shape analogue of the structured report's `truncated_sections`).
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub fn leaf_a() {}
+pub fn leaf_b() {}
+pub fn leaf_c() {}
+pub fn leaf_d() {}
+
+pub fn hub() {
+    leaf_a();
+    leaf_b();
+    leaf_c();
+    leaf_d();
+}
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    // A tiny limit forces truncation: `hub`'s own definition plus four callee neighbors overflow
+    // it.
+    let limit = 2u32;
+    let impact = db.impact_surface("hub", limit).unwrap();
+    let sentinel = impact
+        .iter()
+        .find(|item| item.category == "completeness")
+        .expect("a capped flat result must carry a completeness sentinel (#150)");
+    assert!(sentinel.reason.contains("capped"), "sentinel explains the cap: {sentinel:?}");
+    assert!(
+        sentinel.evidence.iter().any(|evidence| evidence.contains("not shown")),
+        "sentinel carries the dropped count: {sentinel:?}"
+    );
+    let real_items = impact.iter().filter(|item| item.category != "completeness").count();
+    assert_eq!(real_items, limit as usize, "exactly `limit` real items, plus the sentinel");
+
+    // A generous limit drops nothing, so no sentinel appears — it must not cry wolf.
+    let full = db.impact_surface("hub", 100).unwrap();
+    assert!(
+        full.iter().all(|item| item.category != "completeness"),
+        "an uncapped result must NOT carry a sentinel: {full:?}"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn impact_surface_collapses_file_matches_to_one_row_per_file() {
     // Regression for #48: a file-granularity match (path/chunk text) used to fan out into one
     // row per symbol in the file. Each such section must now yield at most one row per file.

--- a/crates/rag-rat-core/src/query/impact/historical.rs
+++ b/crates/rag-rat-core/src/query/impact/historical.rs
@@ -32,9 +32,18 @@ pub(crate) fn git_commits_for_paths(
     conn: &Connection,
     paths: &[String],
     surface: &mut ImpactSurface,
-    limit: usize,
+    budget: usize,
 ) -> anyhow::Result<()> {
-    let mut remaining = limit;
+    // `budget` is the number of distinct history ITEMS this section may add. All commits for one
+    // path collapse to a single `(path, "git_commit_touched_file")` item, so we budget PER PATH
+    // (not per commit row) — otherwise one hot file's commits exhaust the budget and starve later
+    // paths' items, hiding flat-shape truncation (#150 review). Per-path evidence is bounded by
+    // `budget` rows. The structured caller (`git_commit_items`) always passes a single path, so its
+    // behaviour is unchanged.
+    if budget == 0 {
+        return Ok(());
+    }
+    let mut added = 0usize;
     let mut stmt = conn.prepare(
         "
         SELECT files.path, files.language, files.kind,
@@ -48,12 +57,13 @@ pub(crate) fn git_commits_for_paths(
         ",
     )?;
     for path in paths {
-        if remaining == 0 {
+        if added >= budget {
             break;
         }
+        let before = surface.len();
         let file = file_for_path(conn, path)?;
         let rows =
-            stmt.query_map(params![path, i64::try_from(remaining).unwrap_or(i64::MAX)], |row| {
+            stmt.query_map(params![path, i64::try_from(budget).unwrap_or(i64::MAX)], |row| {
                 Ok((
                     row.get::<_, Option<String>>(0)?,
                     row.get::<_, Option<String>>(1)?,
@@ -77,10 +87,9 @@ pub(crate) fn git_commits_for_paths(
                 "git_commit_touched_file",
                 format!("{} touched {path} at {authored_at_s}: {subject}", short_hash(&hash)),
             );
-            remaining = remaining.saturating_sub(1);
-            if remaining == 0 {
-                break;
-            }
+        }
+        if surface.len() > before {
+            added += 1;
         }
     }
     Ok(())
@@ -90,9 +99,14 @@ pub(crate) fn github_refs_for_paths(
     conn: &Connection,
     paths: &[String],
     surface: &mut ImpactSurface,
-    limit: usize,
+    budget: usize,
 ) -> anyhow::Result<()> {
-    let mut remaining = limit;
+    // Budget per PATH (one `(path, "github_papertrail")` item per path), not per ref row — same
+    // item-vs-row reasoning as `git_commits_for_paths` (#150 review).
+    if budget == 0 {
+        return Ok(());
+    }
+    let mut added = 0usize;
     let mut stmt = conn.prepare(
         "
         SELECT owner, repo, number, ref_kind, source_kind, source_text
@@ -103,12 +117,13 @@ pub(crate) fn github_refs_for_paths(
         ",
     )?;
     for path in paths {
-        if remaining == 0 {
+        if added >= budget {
             break;
         }
+        let before = surface.len();
         let file = file_for_path(conn, path)?;
         let rows =
-            stmt.query_map(params![path, i64::try_from(remaining).unwrap_or(i64::MAX)], |row| {
+            stmt.query_map(params![path, i64::try_from(budget).unwrap_or(i64::MAX)], |row| {
                 Ok((
                     row.get::<_, String>(0)?,
                     row.get::<_, String>(1)?,
@@ -126,10 +141,9 @@ pub(crate) fn github_refs_for_paths(
                 "github_papertrail",
                 format!("{owner}/{repo}#{number} {ref_kind}/{source_kind}: {source_text}"),
             );
-            remaining = remaining.saturating_sub(1);
-            if remaining == 0 {
-                break;
-            }
+        }
+        if surface.len() > before {
+            added += 1;
         }
     }
     Ok(())
@@ -225,4 +239,61 @@ pub(crate) fn collect_rows<T>(
         out.push(row?);
     }
     Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::index::schema;
+
+    fn commit(conn: &Connection, hash: &str, path: &str, ts: i64) {
+        conn.execute(
+            "INSERT OR IGNORE INTO git_commits(hash, author_name, author_email, authored_at_s, \
+             committed_at_s, subject, body) VALUES (?1, 'a', 'a@b', ?2, ?2, ?3, '')",
+            rusqlite::params![hash, ts, format!("touch {path}")],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO git_file_changes(commit_hash, path) VALUES (?1, ?2)",
+            rusqlite::params![hash, path],
+        )
+        .unwrap();
+    }
+
+    /// #150 review: `git_commits_for_paths` budgets by ITEM (one per path), not by commit row — so a
+    /// hot file with many commits can't exhaust the budget and starve a later path's history item.
+    #[test]
+    fn git_commits_budget_is_per_path_not_per_commit_row() {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        // `hot.rs` has THREE commits; `cool.rs` has one. All of hot.rs's commits collapse to a
+        // single `(hot.rs, "git_commit_touched_file")` item.
+        commit(&conn, "c1", "hot.rs", 30);
+        commit(&conn, "c2", "hot.rs", 20);
+        commit(&conn, "c3", "hot.rs", 10);
+        commit(&conn, "c4", "cool.rs", 5);
+
+        let mut surface = ImpactSurface::default();
+        // Budget of 2 ITEMS. The old per-row budget would spend both slots on hot.rs's commits and
+        // never reach cool.rs; the per-path budget must surface BOTH files.
+        git_commits_for_paths(
+            &conn,
+            &["hot.rs".to_string(), "cool.rs".to_string()],
+            &mut surface,
+            2,
+        )
+        .unwrap();
+
+        let items = surface.into_items(10);
+        let paths: std::collections::BTreeSet<&str> =
+            items.iter().map(|item| item.path.as_str()).collect();
+        assert!(paths.contains("hot.rs"), "hot.rs item present: {items:?}");
+        assert!(
+            paths.contains("cool.rs"),
+            "cool.rs must not be starved by hot.rs's commits: {items:?}"
+        );
+        // hot.rs's three commits collapsed into one item carrying multiple evidence lines.
+        let hot = items.iter().find(|item| item.path == "hot.rs").unwrap();
+        assert!(hot.evidence.len() >= 2, "collapsed commits accumulate evidence: {hot:?}");
+    }
 }

--- a/crates/rag-rat-core/src/query/impact/mod.rs
+++ b/crates/rag-rat-core/src/query/impact/mod.rs
@@ -365,31 +365,39 @@ fn impact_surface_from_targets(
     import_export_dependents(conn, &targets, &target_names, &mut surface)?;
     same_file_siblings(conn, &targets, &mut surface)?;
 
-    if surface.len() < max_items {
-        let remaining = max_items.saturating_sub(surface.len());
+    // #150: probe ONE past the limit so a section that exactly fills the budget still reveals it
+    // had more. The per-section caps (`textual_fallback`, `historical_evidence`) otherwise stop
+    // at exactly `max_items`, leaving `surface.len() == max_items` — indistinguishable from a
+    // result that genuinely had no more, so the sentinel below would never fire for the
+    // free-text fallback / history paths (Codex review on #150). `into_items(max_items)`
+    // discards the probe item.
+    let probe = max_items.saturating_add(1);
+    if surface.len() < probe {
+        let remaining = probe.saturating_sub(surface.len());
         textual_fallback(conn, query, &mut surface, remaining)?;
     }
 
     let current_paths = surface.current_paths();
-    historical_evidence(conn, &current_paths, query, &mut surface, max_items)?;
+    historical_evidence(conn, &current_paths, query, &mut surface, probe)?;
 
-    // #150: the flat shape capped at `limit` silently — a capped result read as complete. When the
-    // combined surface overflowed, append a visible completeness sentinel (the flat-shape analogue
+    // The flat shape capped at `limit` silently — a capped result read as complete. When the probed
+    // surface overflowed `limit`, append a visible completeness sentinel (the flat-shape analogue
     // of the structured report's `truncated_sections`). Kept as a trailing `ImpactItem` so the
     // compatibility `Vec<ImpactItem>` shape is unchanged; `category`/`kind` = `"completeness"` so a
     // reader can detect it structurally.
-    let total = surface.len();
+    let truncated = surface.len() > max_items;
     let mut items = surface.into_items(max_items);
-    if total > max_items {
-        items.push(impact_truncation_notice(max_items, total));
+    if truncated {
+        items.push(impact_truncation_notice(max_items));
     }
     Ok(items)
 }
 
-/// Trailing sentinel flagging that a flat `impact_surface` result was capped at `limit` of `total`
-/// items (#150) — so a truncated flat result can't be mistaken for complete. Carries the dropped
-/// count in `evidence`; `category`/`kind` are `"completeness"` for structural detection.
-fn impact_truncation_notice(limit: usize, total: usize) -> ImpactItem {
+/// Trailing sentinel flagging that a flat `impact_surface` result was capped at `limit` (#150) — so
+/// a truncated flat result can't be mistaken for complete. No precise dropped count: the
+/// per-section caps mean the true total isn't known cheaply (we only probe one past the limit).
+/// `category`/ `kind` are `"completeness"` for structural detection.
+fn impact_truncation_notice(limit: usize) -> ImpactItem {
     ImpactItem {
         path: String::new(),
         language: String::new(),
@@ -397,11 +405,10 @@ fn impact_truncation_notice(limit: usize, total: usize) -> ImpactItem {
         symbol: None,
         category: "completeness".to_string(),
         reason: format!(
-            "result capped at {limit} of {total} impact items — more exist; raise `limit`, or use \
-             a symbol selector (symbol_path/symbol) for the structured report with per-section \
-             truncation"
+            "result capped at {limit} impact items — more exist; raise `limit`, or use a symbol \
+             selector (symbol_path/symbol) for the structured report with per-section truncation"
         ),
-        evidence: vec![format!("{} additional items not shown", total - limit)],
+        evidence: vec!["more impact items exist beyond the limit".to_string()],
     }
 }
 

--- a/crates/rag-rat-core/src/query/impact/mod.rs
+++ b/crates/rag-rat-core/src/query/impact/mod.rs
@@ -373,7 +373,36 @@ fn impact_surface_from_targets(
     let current_paths = surface.current_paths();
     historical_evidence(conn, &current_paths, query, &mut surface, max_items)?;
 
-    Ok(surface.into_items(max_items))
+    // #150: the flat shape capped at `limit` silently — a capped result read as complete. When the
+    // combined surface overflowed, append a visible completeness sentinel (the flat-shape analogue
+    // of the structured report's `truncated_sections`). Kept as a trailing `ImpactItem` so the
+    // compatibility `Vec<ImpactItem>` shape is unchanged; `category`/`kind` = `"completeness"` so a
+    // reader can detect it structurally.
+    let total = surface.len();
+    let mut items = surface.into_items(max_items);
+    if total > max_items {
+        items.push(impact_truncation_notice(max_items, total));
+    }
+    Ok(items)
+}
+
+/// Trailing sentinel flagging that a flat `impact_surface` result was capped at `limit` of `total`
+/// items (#150) — so a truncated flat result can't be mistaken for complete. Carries the dropped
+/// count in `evidence`; `category`/`kind` are `"completeness"` for structural detection.
+fn impact_truncation_notice(limit: usize, total: usize) -> ImpactItem {
+    ImpactItem {
+        path: String::new(),
+        language: String::new(),
+        kind: "completeness".to_string(),
+        symbol: None,
+        category: "completeness".to_string(),
+        reason: format!(
+            "result capped at {limit} of {total} impact items — more exist; raise `limit`, or use \
+             a symbol selector (symbol_path/symbol) for the structured report with per-section \
+             truncation"
+        ),
+        evidence: vec![format!("{} additional items not shown", total - limit)],
+    }
 }
 
 pub fn ffi_surface(conn: &Connection, limit: u32) -> anyhow::Result<Vec<ImpactItem>> {


### PR DESCRIPTION
Fixes #150.

## Problem
#49 added truncation reporting (`truncated_sections`) to the **structured** `impact_surface` report, but the **flat** `Vec<ImpactItem>` shape still capped at `limit` silently. The flat shape is returned for:
- free-text `query` requests (`handlers.rs`), and
- the `allow_ambiguous` symbol fallback when a name doesn't uniquely resolve.

Both route through `impact_surface_from_targets` → `ImpactSurface::into_items`, which sorts and `truncate(limit)`s with no completeness signal — so a capped flat result reads as complete.

## Fix
Chose **option 2** from the issue (visible signal, no breaking shape change): when the combined surface overflowed `limit`, append a trailing completeness sentinel `ImpactItem` (`category`/`kind` = `"completeness"`) carrying the dropped count. The compatibility `Vec<ImpactItem>` shape is unchanged; a reader can detect the sentinel structurally.

The fix lives in the flat path (`impact_surface_from_targets`) only. The structured report builds its per-section vecs through the *same* `into_items` but reports truncation via `truncated_sections` — so `into_items` itself is left untouched and no sentinel leaks into a structured section. This also covers both flat callers at once (free-text query *and* the ambiguous fallback), since both go through this function.

eval's impact scoring matches by `category`/`path` (the sentinel's `category="completeness"` / `path=""` match nothing) and never asserts vec length, so it's unaffected.

## Test
`impact_surface_flat_signals_truncation_when_capped`: a `hub` with four callees queried at `limit=2` emits the sentinel with exactly `limit` real items and a dropped-count in `evidence`; at `limit=100` no sentinel appears (no crying wolf). Confirmed it fails without the fix and passes with it.

`cargo build` / `clippy --all-targets` / `test` (435 core) / `+nightly fmt --check` all green.