### PR TITLE
fix(index): heal a just-added symbol on a zero-hit name lookup (#152)

### DIFF
--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -264,7 +264,7 @@ impl IndexDatabase {
         Ok((count, manifest_in_change_set))
     }
 
-    fn assign_file_scopes(
+    pub(super) fn assign_file_scopes(
         &self,
         files: Vec<IndexFile>,
         changes: &GitChangedPaths,
@@ -355,7 +355,7 @@ impl IndexDatabase {
         Ok(healed)
     }
 
-    fn apply_incremental_file_plan<F>(
+    pub(super) fn apply_incremental_file_plan<F>(
         &self,
         files: Vec<IndexFile>,
         deleted: BTreeSet<PathBuf>,

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -50,6 +50,7 @@ impl IndexDatabase {
             active_commit_sha: String::new(),
             active_worktree_id: String::new(),
             github: github::GitHubContext::default(),
+            config: None,
         };
         if check_graph {
             db.ensure_graph_index_current()?;
@@ -65,6 +66,7 @@ impl IndexDatabase {
         // Real usage: resolve the GitHub repo context from the local `gh` CLI here, at the
         // boundary. rebuild/open (used by tests and the bare index command) leave it offline.
         db.github = github::GitHubContext::from_gh();
+        db.config = Some(config.clone());
         db.ensure_graph_index_current()?;
         Ok(db)
     }
@@ -109,6 +111,7 @@ impl IndexDatabase {
             active_commit_sha: String::new(),
             active_worktree_id: String::new(),
             github: github::GitHubContext::from_gh(),
+            config: Some(config.clone()),
         };
         db.set_context(&commit_sha, &worktree_id)?;
         Ok(Some(db))
@@ -165,6 +168,7 @@ impl IndexDatabase {
             active_commit_sha: String::new(),
             active_worktree_id: String::new(),
             github: github::GitHubContext::default(),
+            config: None,
         })
     }
 

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -87,6 +87,12 @@ pub struct IndexDatabase {
     /// `rebuild`/`open` leave it offline, and tests set it explicitly — so the library never
     /// shells out to `gh` during tests (#60).
     github: github::GitHubContext,
+    /// The config this index was opened against — present only on the config-bearing opens
+    /// (`open_config` / `try_open_config_read_only`), `None` for `rebuild`/`open`/tests. Lets a
+    /// read tool classify a working-tree change set against the indexed targets — the lazy
+    /// zero-hit heal (`symbol_candidates`, #152) needs it to index a just-added file the watcher
+    /// hasn't caught yet. Without it that heal is a graceful no-op.
+    config: Option<Config>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -116,6 +116,15 @@ impl IndexDatabase {
     ) -> anyhow::Result<crate::query::symbol::SymbolLookup> {
         let mut lookup =
             crate::query::symbol::lookup_candidates(self.storage.connection(), selector)?;
+        // #152: a name/symbol_path lookup that found NOTHING may be a just-added symbol the watcher
+        // hasn't indexed yet. Index the working-tree change set (bounded) and re-resolve once.
+        // Name-based selectors only — a miss on a churning id isn't "newly added".
+        if lookup.candidates.is_empty()
+            && selector_is_name_based(selector)
+            && self.heal_changed_for_zero_hit()?
+        {
+            lookup = crate::query::symbol::lookup_candidates(self.storage.connection(), selector)?;
+        }
         // #147: symbol rows aren't anchor-relocated like chunks, so a file edited since indexing
         // returns stale line numbers. Heal the matched files inline (bounded, like
         // search_with_heal) and re-resolve so positions/ids are current; #148: report any
@@ -222,6 +231,62 @@ impl IndexDatabase {
         }
         self.sync_fts()?;
         Ok(())
+    }
+
+    /// #152: a name lookup that found NOTHING may be a symbol just added (or renamed into
+    /// existence) the watcher hasn't indexed yet. Index the working-tree change set — changed
+    /// source files that are dirty-vs-index OR not-yet-indexed — bounded by
+    /// `MAX_AUTO_HEAL_FILES_PER_CALL` (over the cap → do nothing; never raise `NeedsReindex`, since
+    /// the common zero-hit is a plain typo'd miss that must stay cheap), then re-derive logical
+    /// symbols + edges so the re-resolve sees the new symbol. Returns whether anything was indexed.
+    /// No-op without a stored `Config` (rebuild/open/tests) or a git root — a genuine miss on a
+    /// clean tree costs at most one `git status` and no write.
+    fn heal_changed_for_zero_hit(&self) -> anyhow::Result<bool> {
+        let Some(config) = self.config.as_ref() else {
+            return Ok(false);
+        };
+        let Ok(changes) = crate::index::git_changed_paths(&config.root) else {
+            return Ok(false);
+        };
+        if changes.changed.is_empty() {
+            return Ok(false);
+        }
+        // Classify changed paths against the indexed targets (include/exclude/language), keeping
+        // only those dirty-vs-index OR not-yet-indexed — a file already current adds nothing.
+        let mut healable = Vec::new();
+        for file in collect_changed_index_files(config, &changes)? {
+            let needs_index = match self.indexed_sha_for_path(&path_string(&file.relative_path))? {
+                None => true,
+                Some(indexed) => match fs::read(&file.full_path) {
+                    Ok(bytes) => hex_sha256(&bytes) != indexed,
+                    Err(_) => false,
+                },
+            };
+            if needs_index {
+                healable.push(file);
+            }
+            if healable.len() > MAX_AUTO_HEAL_FILES_PER_CALL {
+                // Too many newly-changed files to heal inline on a lookup miss — leave it to the
+                // watcher rather than turn a read into a large rebuild.
+                return Ok(false);
+            }
+        }
+        if healable.is_empty() {
+            return Ok(false);
+        }
+        let files = self.assign_file_scopes(healable, &changes);
+        let indexed = self.apply_incremental_file_plan(
+            files,
+            std::collections::BTreeSet::new(),
+            &mut |_| {},
+        )?;
+        if indexed == 0 {
+            return Ok(false);
+        }
+        // Re-derive so the new symbol carries a logical id and its edges resolve for enrichment.
+        self.rebuild_logical_symbols()?;
+        self.resolve_edges()?;
+        Ok(true)
     }
 
     pub fn select_symbol(
@@ -402,6 +467,16 @@ impl IndexDatabase {
     ) -> anyhow::Result<crate::query::clusters::RepoClustersReport> {
         crate::query::clusters::repo_clusters(self.storage.connection(), options)
     }
+}
+
+/// Whether a selector resolves by NAME (`symbol` / `symbol_path`) rather than by a reindex-churning
+/// id. Only name lookups get the #152 zero-hit heal: a miss on a `symbol_id`/`logical_symbol_id`
+/// isn't a "just added" symbol, just a stale or wrong id, so re-indexing the change set wouldn't
+/// recover it and would put a `git status` on every such miss.
+fn selector_is_name_based(selector: &crate::query::symbol::SymbolSelector) -> bool {
+    selector.symbol_id.is_none()
+        && selector.logical_symbol_id.is_none()
+        && (selector.symbol.is_some() || selector.symbol_path.is_some())
 }
 
 /// `resolved-external(<package>)` for a SCIP symbol that names a dependency outside the corpus, or

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -275,18 +275,36 @@ impl IndexDatabase {
             return Ok(false);
         }
         let files = self.assign_file_scopes(healable, &changes);
-        let indexed = self.apply_incremental_file_plan(
-            files,
-            std::collections::BTreeSet::new(),
-            &mut |_| {},
-        )?;
-        if indexed == 0 {
-            return Ok(false);
+        // Apply with the SAME write discipline as the incremental indexer
+        // (`index_incremental_with_progress`), not a corner-cut version (PR #158 review):
+        //  - one `BEGIN IMMEDIATE` txn so a concurrent reader never observes the index between the
+        //    logical-symbol DELETE-all and its rebuild (which would return empty logical handles);
+        //  - apply `changes.deleted` so a removed file's stale rows don't survive the re-resolve
+        //    and let the new file's edges bind to a deleted definition;
+        //  - `refresh_packages` BEFORE `resolve_edges`, since per-package import scope (#61) is
+        //    read at resolve time — a change set that adds/edits a Cargo.toml must resolve against
+        //    the fresh package map, not the stale one.
+        // On the read-only MCP connection the BEGIN trips SQLITE_READONLY and the dispatch retries
+        // read-write (like the #147 heal), so the txn always runs on a writable connection.
+        self.storage.execute_batch("BEGIN IMMEDIATE")?;
+        let result = (|| -> anyhow::Result<()> {
+            self.apply_incremental_file_plan(files, changes.deleted.clone(), &mut |_| {})?;
+            self.refresh_packages(&config.root)?;
+            self.rebuild_logical_symbols()?;
+            self.resolve_edges()?;
+            self.sync_fts()?;
+            Ok(())
+        })();
+        match result {
+            Ok(()) => {
+                self.storage.execute_batch("COMMIT")?;
+                Ok(true)
+            },
+            Err(error) => {
+                let _ = self.storage.execute_batch("ROLLBACK");
+                Err(error)
+            },
         }
-        // Re-derive so the new symbol carries a logical id and its edges resolve for enrichment.
-        self.rebuild_logical_symbols()?;
-        self.resolve_edges()?;
-        Ok(true)
     }
 
     pub fn select_symbol(

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -7973,6 +7973,56 @@ fn symbol_lookup_heals_stale_line_numbers_after_an_edit() {
 }
 
 #[test]
+fn symbol_lookup_heals_a_just_added_symbol_without_waiting_for_the_watcher() {
+    // #152: a name lookup for a symbol just added (here, in a brand-new not-yet-indexed file)
+    // returns it via the lazy zero-hit heal, instead of nothing until the watcher catches up. The
+    // heal needs a stored Config (open_config) and a git working tree to derive the change set.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn existing() {}\n").unwrap();
+    run_git(&root, &["init", "-q"]);
+    run_git(&root, &["add", "-A"]);
+    run_git(&root, &["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "init"]);
+
+    let config = source_config(root.clone(), Language::Rust);
+    IndexDatabase::rebuild(&config).unwrap();
+    // Reopen via open_config so the zero-hit heal has the Config to classify the change set.
+    let db = IndexDatabase::open_config(&config).unwrap();
+
+    // A brand-new file with a brand-new symbol — never indexed, not yet committed.
+    fs::write(root.join("src/added.rs"), "pub fn brand_new_symbol() {}\n").unwrap();
+
+    let selector = crate::query::symbol::SymbolSelector {
+        logical_symbol_id: None,
+        symbol_id: None,
+        symbol_path: None,
+        symbol: Some("brand_new_symbol".to_string()),
+        language: None,
+        allow_ambiguous: true,
+        limit: 10,
+    };
+    let found = db.symbol_candidates(&selector).unwrap();
+    assert!(
+        found.candidates.iter().any(|c| c.name == "brand_new_symbol"),
+        "a just-added symbol must be healed in without waiting for the watcher: {:?}",
+        found.candidates
+    );
+
+    // A genuine miss (a name that exists nowhere) returns empty — no heal resurrects it, no error.
+    let miss = crate::query::symbol::SymbolSelector {
+        symbol: Some("no_such_symbol_anywhere".to_string()),
+        ..selector.clone()
+    };
+    assert!(
+        db.symbol_candidates(&miss).unwrap().candidates.is_empty(),
+        "a genuine miss must stay empty"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn impact_completeness_flags_dirty_result_files() {
     // #148: a result file dirty vs the index is counted in completeness.stale_files. Resolve via
     // the non-healing `symbols()` so the edit isn't healed away before impact sees it.


### PR DESCRIPTION
Fixes #152.

## Problem
`symbol_lookup`'s lazy heal (#147) derived its heal set from the matched candidates' files. A lookup for a **just-added** symbol (or one renamed into existence) returns zero candidates → empty path set → no heal → keeps returning nothing until the watcher reindexes (~0.4–2.5 s). The symmetric case of #147 ("I just wrote `fn foo`, find it") still missed in the sub-debounce window.

## Fix
On a zero-hit for a **name / symbol_path** selector, index the working-tree change set (changed source files that are dirty-vs-index OR not-yet-indexed), re-derive logical symbols + edges, and re-resolve once. Bounded exactly as the issue's "bound it hard" section asks:
- **name/symbol_path selectors only** — a miss on a churning `symbol_id`/`logical_symbol_id` isn't "newly added", so those misses never pay a `git status`.
- **capped at `MAX_AUTO_HEAL_FILES_PER_CALL`** — over the cap does nothing; **never** raises `NeedsReindex` (a plain typo'd miss stays cheap).
- a genuine miss on a clean tree costs one `git status` and no write.

### Config retention
Indexing a brand-new (never-indexed) file needs the target config to classify language/kind (`collect_changed_index_files`). So `IndexDatabase` now retains the `Config` it was opened with, but **only on the config-bearing opens** (`open_config` / `try_open_config_read_only`) — `None` for `rebuild`/`open`/tests, where the heal is a graceful no-op. This mirrors the existing `github`-context "resolved only at the config boundary" pattern.

On the read-only MCP connection (#143) the heal's write trips `SQLITE_READONLY` and the dispatch retries read-write — the same path the #147 heal already uses. The heal reuses the incremental indexer's `collect_changed_index_files` / `assign_file_scopes` / `apply_incremental_file_plan` (widened to `pub(super)`).

## Test
`symbol_lookup_heals_a_just_added_symbol_without_waiting_for_the_watcher`: in a git repo, a brand-new file's symbol is found by name with no reindex; a genuine miss stays empty. Confirmed it fails (`[]`) without the heal.

`cargo build` / `clippy --all-targets` / `test` (435 core) / `+nightly fmt --check` all green.