### PR TITLE
feat(mcp): expose memory_doctor; raise memory body cap to 8000

### DIFF
--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -3188,6 +3188,26 @@ fn logical_symbol_binding_survives_chunk_id_churn_on_reindex() {
     );
 }
 
+/// The memory body cap is 8000 chars (raised from 4000 so detailed Invariant/Decision/BugPattern
+/// memories aren't forced to drop content). Boundary: 8000 accepted, 8001 rejected.
+#[test]
+fn memory_body_cap_is_8000_chars() {
+    let h = Harness::new();
+    let make = |body: String| RepoMemoryCreate {
+        kind: "Invariant".to_string(),
+        title: "cap test".to_string(),
+        body,
+        confidence: "high".to_string(),
+        created_by: None,
+        source: None,
+        tags: Vec::new(),
+        bind: RepoMemoryBindTarget { path: Some("a.rs".to_string()), ..Default::default() },
+    };
+    assert!(create_memory(&h.conn, make("x".repeat(8000))).is_ok(), "8000 chars is accepted");
+    let err = create_memory(&h.conn, make("x".repeat(8001))).unwrap_err();
+    assert!(err.to_string().contains("body exceeds 8000"), "8001 rejected with the cap: {err}");
+}
+
 /// Point the index `source_root` meta at the harness checkout so the off-index filesystem
 /// existence fallback (#98) has a root to resolve a binding path against.
 fn set_source_root(h: &Harness) {

--- a/crates/rag-rat-core/src/query/memory/api.rs
+++ b/crates/rag-rat-core/src/query/memory/api.rs
@@ -1,13 +1,20 @@
 use super::*;
 
+/// Max chars for a memory title (a one-line summary) and body. The body cap is generous on purpose:
+/// Invariant / Decision / BugPattern memories are meant to carry the *why* + *how to apply* in
+/// detail, and 4 000 forced real content out (the MCP `memory_create`/`memory_update` schemas
+/// document these). Enforced in Rust, not the schema, so raising them needs no migration.
+pub(crate) const MAX_MEMORY_TITLE_LEN: usize = 160;
+pub(crate) const MAX_MEMORY_BODY_LEN: usize = 8000;
+
 pub(crate) fn create_memory(
     conn: &Connection,
     request: RepoMemoryCreate,
 ) -> anyhow::Result<RepoMemoryCreateResult> {
     validate_kind(&request.kind)?;
     validate_confidence(&request.confidence)?;
-    validate_len("title", &request.title, 160)?;
-    validate_len("body", &request.body, 4000)?;
+    validate_len("title", &request.title, MAX_MEMORY_TITLE_LEN)?;
+    validate_len("body", &request.body, MAX_MEMORY_BODY_LEN)?;
     let source = request.source.clone().unwrap_or_else(|| "agent".to_string());
     validate_source(&source)?;
     let binding = resolve_binding(conn, &request.bind)?;
@@ -67,10 +74,10 @@ pub(crate) fn update_memory(
         validate_status(status)?;
     }
     if let Some(title) = update.title.as_deref() {
-        validate_len("title", title, 160)?;
+        validate_len("title", title, MAX_MEMORY_TITLE_LEN)?;
     }
     if let Some(body) = update.body.as_deref() {
-        validate_len("body", body, 4000)?;
+        validate_len("body", body, MAX_MEMORY_BODY_LEN)?;
     }
     let now = now_ms();
     conn.execute(

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -461,6 +461,19 @@ impl RagRatService {
     }
 
     #[tool(
+        name = "memory_doctor",
+        description = "List repo memories with stale/gone anchors plus suggested re-anchor \
+                       targets — the actionable companion to memory_validate. Rebind them with \
+                       memory_rebind."
+    )]
+    fn memory_doctor(
+        &self,
+        Parameters(_args): Parameters<EmptyArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.call("memory_doctor", json!({}))
+    }
+
+    #[tool(
         name = "memory_mark_obsolete",
         description = "Mark a repo memory obsolete without deleting its audit trail."
     )]

--- a/crates/rag-rat-mcp/src/tools/catalog.rs
+++ b/crates/rag-rat-mcp/src/tools/catalog.rs
@@ -37,6 +37,7 @@ pub const TOOL_NAMES: &[&str] = &[
     "memory_for_path",
     "memory_for_call_path",
     "memory_validate",
+    "memory_doctor",
     "memory_mark_obsolete",
 ];
 
@@ -176,6 +177,11 @@ pub fn description(name: &str) -> &'static str {
         "memory_validate" =>
             "Re-anchor every repo memory against current source and mark each current / relocated \
              / stale / gone. Runs automatically after indexing.",
+        "memory_doctor" =>
+            "List repo memories whose anchor is stale or gone, each with suggested re-anchor \
+             targets (qualified names) — the actionable companion to memory_validate. Read-only; \
+             reports the last-validated status, so run memory_validate first for a fresh check. \
+             Rebind the listed memories with memory_rebind.",
         "memory_mark_obsolete" =>
             "Mark a repo memory obsolete — kept for audit, hidden from active recall.",
         _ => "Unknown tool.",
@@ -213,8 +219,8 @@ pub fn schema(name: &str) -> Value {
         "memory_for_path" => schema_for::<MemoryForPathArgs>(),
         "memory_for_call_path" => schema_for::<MemoryForCallPathArgs>(),
         "memory_mark_obsolete" => schema_for::<MemoryIdArgs>(),
-        "local_ai_status" | "github_sync_status" | "index_status" | "memory_validate" =>
-            schema_for::<EmptyArgs>(),
+        "local_ai_status" | "github_sync_status" | "index_status" | "memory_validate"
+        | "memory_doctor" => schema_for::<EmptyArgs>(),
         _ => json!({"type": "object"}),
     }
 }

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -188,6 +188,7 @@ pub(crate) fn call_tool_with_db(
             json!(db.memory_for_call_path_hash(&args.edge_sequence_hash, args.limit)?)
         },
         "memory_validate" => json!(db.memory_validate()?),
+        "memory_doctor" => json!(db.memory_doctor()?),
         "memory_mark_obsolete" => {
             let args: MemoryIdArgs = serde_json::from_value(arguments)?;
             json!(db.memory_mark_obsolete(&args.memory_id)?)

--- a/crates/rag-rat-mcp/src/tools/requests.rs
+++ b/crates/rag-rat-mcp/src/tools/requests.rs
@@ -560,7 +560,9 @@ pub struct MemoryBindArgs {
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
 pub struct MemoryCreateArgs {
     pub kind: McpMemoryKind,
+    /// One-line summary, max 160 characters.
     pub title: String,
+    /// The memory text (the *why* + *how to apply*), max 8000 characters.
     pub body: String,
     pub confidence: McpMemoryConfidence,
     pub created_by: Option<String>,
@@ -580,7 +582,9 @@ pub struct MemoryRebindArgs {
 pub struct MemoryUpdateArgs {
     pub memory_id: String,
     pub kind: Option<McpMemoryKind>,
+    /// One-line summary, max 160 characters.
     pub title: Option<String>,
+    /// The memory text (the *why* + *how to apply*), max 8000 characters.
     pub body: Option<String>,
     pub confidence: Option<McpMemoryConfidence>,
     pub status: Option<McpMemoryStatus>,


### PR DESCRIPTION
Two repo-DX fixes surfaced from heavy dogfooding of the rag-rat MCP this session.

## 1. `memory_doctor` MCP tool
The actionable "which anchors are stale/gone, with suggested re-anchor targets" report (`doctor_report`) was **CLI-only**. The MCP `memory_validate` returns counts but not the per-binding fix list — so every time anchors drifted I had to shell out to `rag-rat memory doctor`, against the prefer-MCP guidance.

Exposes it as a read-only, no-arg MCP tool wired through `catalog` (name + description + `EmptyArgs` schema), `server` (`#[tool]`), and `handlers` (dispatch). It's a writer-deny-list miss → classified read-only automatically. Reports the **last-validated** status (it reads persisted `anchor_status`, like the core method), so the flow is: `memory_validate` (refresh) → `memory_doctor` (list) → `memory_rebind` (fix).

## 2. Memory body cap 4000 → 8000 + documented caps
The 4000-char body cap forced real content out of detailed Invariant/Decision/BugPattern memories (hit it twice this session, compressing actual rationale). Raised to 8000 via named consts (`MAX_MEMORY_TITLE_LEN` / `MAX_MEMORY_BODY_LEN`); enforcement is Rust-side (`validate_len`), not a schema CHECK, so **no migration**. Both caps (title 160, body 8000) are now documented in the `memory_create` / `memory_update` MCP arg schemas so callers learn the limit up front rather than by hitting the error.

## Tests
- The MCP routability (`every advertised tool is routable`) + read/write classification guards cover the new tool.
- A core test pins the new boundary: 8000 chars accepted, 8001 rejected.

`cargo build` / `clippy --all-targets` / `test --workspace` / `+nightly fmt --check` all green.