### PR TITLE
feat(mcp): nudge the agent to re-anchor stale memories via tool-result content

### DIFF
--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -2903,8 +2903,8 @@ fn prune_oracle_runs_drops_dead_contexts_only() {
 // ---------------------------------------------------------------------------
 
 use crate::query::memory::{
-    RepoMemoryBindTarget, RepoMemoryCreate, create_memory, memory_by_id, split_active_stale,
-    validate_memories,
+    RepoMemoryBindTarget, RepoMemoryCreate, create_memory, doctor_attention_count, memory_by_id,
+    split_active_stale, validate_memories,
 };
 
 /// Build a multi-document SCIP index, serialized.
@@ -3206,6 +3206,82 @@ fn memory_body_cap_is_8000_chars() {
     assert!(create_memory(&h.conn, make("x".repeat(8000))).is_ok(), "8000 chars is accepted");
     let err = create_memory(&h.conn, make("x".repeat(8001))).unwrap_err();
     assert!(err.to_string().contains("body exceeds 8000"), "8001 rejected with the cap: {err}");
+}
+
+/// `doctor_attention_count` (behind the MCP staleness nudge) counts active bindings whose anchor is
+/// gone/stale, excludes obsolete memories, and matches the population `memory_doctor` lists.
+#[test]
+fn doctor_attention_count_counts_active_gone_and_stale_bindings() {
+    let h = Harness::new();
+    let created = create_memory(&h.conn, RepoMemoryCreate {
+        kind: "Invariant".to_string(),
+        title: "drift test".to_string(),
+        body: "x".to_string(),
+        confidence: "high".to_string(),
+        created_by: None,
+        source: None,
+        tags: Vec::new(),
+        bind: RepoMemoryBindTarget { path: Some("a.rs".to_string()), ..Default::default() },
+    })
+    .unwrap();
+    let id = created.memory.memory_id;
+    let set_status = |status: &str| {
+        h.conn
+            .execute(
+                "UPDATE repo_memory_bindings SET anchor_status = ?2 WHERE memory_id = ?1",
+                params![id, status],
+            )
+            .unwrap();
+    };
+
+    set_status("current");
+    assert_eq!(doctor_attention_count(&h.conn).unwrap(), 0, "current is not counted");
+    set_status("gone");
+    assert_eq!(doctor_attention_count(&h.conn).unwrap(), 1, "gone is counted");
+    set_status("stale");
+    assert_eq!(doctor_attention_count(&h.conn).unwrap(), 1, "stale is counted");
+    // An obsolete memory drops out even with a gone binding.
+    h.conn.execute("UPDATE repo_memories SET status = 'obsolete' WHERE id = ?1", [&id]).unwrap();
+    assert_eq!(doctor_attention_count(&h.conn).unwrap(), 0, "obsolete is excluded");
+}
+
+/// The public `memory_attention_count` (the MCP staleness nudge's source) reads from a file DB via
+/// a bare read-only open and fails open to 0 on a missing DB — it must never block a tool call.
+#[test]
+fn memory_attention_count_reads_file_db_and_fails_open() {
+    let dir = std::env::temp_dir().join(format!("ragrat-attn-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let db_path = dir.join("index.sqlite");
+
+    // Missing DB → 0 (fail-open).
+    assert_eq!(crate::memory_attention_count(&db_path), 0, "missing DB is 0, never an error");
+
+    // A real file DB with one gone binding → 1.
+    {
+        let rw = crate::storage::IndexConnection::open(&db_path).unwrap();
+        crate::index::schema::apply(rw.connection()).unwrap();
+        let created = create_memory(rw.connection(), RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "drift".to_string(),
+            body: "x".to_string(),
+            confidence: "high".to_string(),
+            created_by: None,
+            source: None,
+            tags: Vec::new(),
+            bind: RepoMemoryBindTarget { path: Some("a.rs".to_string()), ..Default::default() },
+        })
+        .unwrap();
+        rw.connection()
+            .execute(
+                "UPDATE repo_memory_bindings SET anchor_status = 'gone' WHERE memory_id = ?1",
+                [&created.memory.memory_id],
+            )
+            .unwrap();
+    }
+    assert_eq!(crate::memory_attention_count(&db_path), 1, "counts the gone binding from disk");
+
+    let _ = std::fs::remove_dir_all(&dir);
 }
 
 /// Point the index `source_root` meta at the harness checkout so the off-index filesystem

--- a/crates/rag-rat-core/src/lib.rs
+++ b/crates/rag-rat-core/src/lib.rs
@@ -15,3 +15,15 @@ pub mod watch;
 pub use config::{Config, ResolvedTarget, TargetKind, WatchConfig};
 pub use index::{IndexDatabase, IndexStatus};
 pub use output::{OutputFormat, render};
+
+/// Lightweight, lock-free count of active repo memories whose anchor is `gone`/`stale` — the same
+/// population `memory_doctor` lists. Opens a BARE read-only connection (no git resolution, scope
+/// view, or schema migration), so it is cheap enough to call on every MCP tool result to nudge the
+/// agent to re-anchor drifted memories. Returns 0 on any error (missing / locked / older DB) so the
+/// nudge simply doesn't show — never blocks or fails a tool call.
+pub fn memory_attention_count(database: &std::path::Path) -> u64 {
+    storage::IndexConnection::open_read_only(database)
+        .ok()
+        .and_then(|conn| query::memory::doctor_attention_count(conn.connection()).ok())
+        .unwrap_or(0)
+}

--- a/crates/rag-rat-core/src/query/memory/api.rs
+++ b/crates/rag-rat-core/src/query/memory/api.rs
@@ -575,6 +575,26 @@ pub struct MemoryDoctorEntry {
 /// Read-only report: active memories with `gone | stale` bindings plus live rebind candidates.
 ///
 /// Invariant: this function is purely READ — it never writes to the database.
+/// Count of active memories whose anchor is `gone`/`stale` — the EXACT population `doctor_report`
+/// lists (same WHERE), so a "N need re-anchoring" nudge matches what `memory_doctor` then shows.
+/// `scip_moniker` bindings are excluded (self-heal on the next oracle run, never
+/// rebind-actionable).
+pub(crate) fn doctor_attention_count(conn: &Connection) -> anyhow::Result<u64> {
+    let count: i64 = conn.query_row(
+        "
+        SELECT COUNT(*)
+        FROM repo_memory_bindings AS b
+        JOIN repo_memories AS m ON m.id = b.memory_id
+        WHERE m.status = 'active'
+          AND b.anchor_status IN ('gone', 'stale')
+          AND b.binding_kind != 'scip_moniker'
+        ",
+        [],
+        |row| row.get(0),
+    )?;
+    Ok(u64::try_from(count).unwrap_or(0))
+}
+
 pub(crate) fn doctor_report(conn: &Connection) -> anyhow::Result<Vec<MemoryDoctorEntry>> {
     // Query bindings whose anchor_status is non-current, restricted to active memories.
     // Mirrors the column list used by validate_memories / binding_row.

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -60,7 +60,29 @@ impl RagRatService {
         // a tool result is never lost. JSON is reachable by launching `rag-rat mcp --json`
         // (the format is chosen once at launch; MCP has no per-call flag).
         let text = rag_rat_core::render(&value, self.output_format);
-        Ok(CallToolResult::success(vec![Content::text(text)]))
+        let mut content = vec![Content::text(text)];
+        if let Some(nudge) = self.stale_memory_nudge() {
+            content.push(Content::text(nudge));
+        }
+        Ok(CallToolResult::success(content))
+    }
+
+    /// Surface drifted repo-memory anchors to the AGENT as a second tool-result content block.
+    /// Claude Code's agent is pull-based — MCP server notifications (`notifications/message`) reach
+    /// the UI/logs but NOT the model's context (anthropics/claude-code#3174) — so a tool result is
+    /// the one MCP-native channel that puts an actionable signal in front of the model. The nudge
+    /// self-limits: once the agent runs `memory_rebind`, the count drops to 0 and it stops showing.
+    /// Best-effort + lock-free (a bare read-only count), so it never slows or fails a tool call.
+    fn stale_memory_nudge(&self) -> Option<String> {
+        let n = rag_rat_core::memory_attention_count(&self.config.database);
+        (n > 0).then(|| {
+            let noun = if n == 1 { "memory" } else { "memories" };
+            format!(
+                "rag-rat: {n} active repo {noun} have stale/gone anchors. Call `memory_doctor` to \
+                 list them with suggested re-anchor targets, then `memory_rebind` to fix — so \
+                 source-anchored memory stays trustworthy for the next agent."
+            )
+        })
     }
 }
 

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -73,7 +73,14 @@ impl RagRatService {
     /// the one MCP-native channel that puts an actionable signal in front of the model. The nudge
     /// self-limits: once the agent runs `memory_rebind`, the count drops to 0 and it stops showing.
     /// Best-effort + lock-free (a bare read-only count), so it never slows or fails a tool call.
+    ///
+    /// Suppressed in `--json` mode: that mode exists for clients that parse the tool text AS JSON
+    /// (or concatenate all text blocks), and a prose block would break them. The nudge is
+    /// agent-directed prose, meaningful only in the default TOON (LLM-facing) mode.
     fn stale_memory_nudge(&self) -> Option<String> {
+        if self.output_format == rag_rat_core::OutputFormat::Json {
+            return None;
+        }
         let n = rag_rat_core::memory_attention_count(&self.config.database);
         (n > 0).then(|| {
             let noun = if n == 1 { "memory" } else { "memories" };
@@ -666,7 +673,7 @@ mod tests {
 
     static N: AtomicU64 = AtomicU64::new(0);
 
-    fn service_over_temp_repo() -> (PathBuf, RagRatService) {
+    fn config_over_temp_repo() -> (PathBuf, Config) {
         let root = std::env::temp_dir().join(format!(
             "rag-rat-server-test-{}-{}",
             std::process::id(),
@@ -691,7 +698,45 @@ mod tests {
             oracle: Default::default(),
         };
         IndexDatabase::rebuild(&config).unwrap();
+        (root, config)
+    }
+
+    fn service_over_temp_repo() -> (PathBuf, RagRatService) {
+        let (root, config) = config_over_temp_repo();
         (root, RagRatService::new(config, OutputFormat::Toon))
+    }
+
+    /// The staleness nudge (#160) rides a TOON tool result as a second content block, but is
+    /// SUPPRESSED in `--json` mode so JSON-parsing clients aren't broken (Codex #160 review).
+    #[test]
+    fn stale_memory_nudge_rides_toon_but_not_json() {
+        let (root, config) = config_over_temp_repo();
+        // A memory bound to an unindexed/absent path resolves `gone` → drift the nudge reports.
+        let toon = RagRatService::new(config.clone(), OutputFormat::Toon);
+        toon.call(
+            "memory_create",
+            json!({
+                "kind": "Invariant",
+                "title": "drift",
+                "body": "b",
+                "confidence": "high",
+                "bind": {"path": "does/not/exist.rs"}
+            }),
+        )
+        .unwrap();
+        // A path binding is created `current`; validation flips the absent path to `gone`.
+        toon.call("memory_validate", json!({})).unwrap();
+
+        // TOON (default, LLM-facing): nudge present as a second block.
+        let toon_result = toon.call("index_status", json!({})).unwrap();
+        assert_eq!(toon_result.content.len(), 2, "TOON result carries the nudge block");
+
+        // JSON mode: suppressed (single parseable block).
+        let json_svc = RagRatService::new(config, OutputFormat::Json);
+        let json_result = json_svc.call("index_status", json!({})).unwrap();
+        assert_eq!(json_result.content.len(), 1, "JSON result omits the prose nudge");
+
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]


### PR DESCRIPTION
Make the **agent** (not the user) eagerly notice and fix drifted repo-memory anchors.

## Why this mechanism
I checked the Claude Code / MCP docs (via the claude-code-guide agent). Key finding: **Claude Code's agent is pull-based.** Server-initiated MCP notifications (`notifications/message`, progress, resource-updated) reach the **UI/logs but not the model's context** — confirmed by [anthropics/claude-code#3174](https://github.com/anthropics/claude-code/issues/3174). The mechanisms that *do* reach the model are: tool-result content (multiple content blocks are shown to the model), and hooks' `additionalContext`. Of those, the only **MCP-server-native** one is tool-result content.

## What this does
Every rag-rat tool already funnels through one `call()` chokepoint in the server. When active memories have gone/stale anchors, `call()` appends a **second content block**:

> rag-rat: N active repo memories have stale/gone anchors. Call `memory_doctor` to list them with suggested re-anchor targets, then `memory_rebind` to fix …

The primary structured (TOON/JSON) block is untouched, so parsers are unaffected. It **self-limits** — once the agent runs `memory_rebind` the count drops to 0 and the block stops appearing, so it nags exactly while there's something to fix.

## Cost / safety
The count is `rag_rat_core::memory_attention_count(database)`: a **bare** read-only sqlite open + one indexed `COUNT` — no git resolution, scope view, or migration (so no `git rev-parse` subprocess per call). It mirrors `doctor_report`'s exact WHERE (active, `anchor_status IN ('gone','stale')`, excluding `scip_moniker`) so the nudge count matches what `memory_doctor` then lists. **Fail-open to 0** on any error — never blocks or fails a tool call.

## Tests
- `doctor_attention_count_counts_active_gone_and_stale_bindings` — counts active gone/stale, excludes obsolete.
- `memory_attention_count_reads_file_db_and_fails_open` — reads a file DB; missing DB → 0.

`cargo build` / `clippy --all-targets` / `test --workspace` (441 core, 25 mcp) / `+nightly fmt --check` all green.

Builds on #159 (the `memory_doctor` tool it points the agent to), now in main / v0.6.0.