### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.6.0...rag-rat-core-v0.7.0) - 2026-06-16
+
+### Added
+
+- *(oracle)* C++ corpus (yaml-cpp) + resolve .h headers as C++ under a cpp binding ([#186](https://github.com/cq27-dev/rag-rat/pull/186))
+- *(oracle)* scip-typescript backend + ts-ky corpus ([#184](https://github.com/cq27-dev/rag-rat/pull/184))
+- *(python)* from-import alias resolution ([#174](https://github.com/cq27-dev/rag-rat/pull/174)) ([#179](https://github.com/cq27-dev/rag-rat/pull/179))
+- *(init)* Python root-entrypoint binding + content-aware dir selection ([#173](https://github.com/cq27-dev/rag-rat/pull/173)) ([#181](https://github.com/cq27-dev/rag-rat/pull/181))
+- *(python)* prefer a base class when resolving `implements` edges ([#172](https://github.com/cq27-dev/rag-rat/pull/172)) ([#180](https://github.com/cq27-dev/rag-rat/pull/180))
+- *(oracle)* unified tier-driven corpus runner + oracle.yml (C3) ([#177](https://github.com/cq27-dev/rag-rat/pull/177))
+- *(oracle)* scip-python backend — Python compiler-grade resolution (B6) ([#176](https://github.com/cq27-dev/rag-rat/pull/176))
+- *(oracle)* `oracle report --corpus <id>` — run a corpus + emit its C2 resolution report (C2-CLI) ([#175](https://github.com/cq27-dev/rag-rat/pull/175))
+- *(lang)* Python language support (symbols, graph edges, embeddings) + AST low-signal ([#167](https://github.com/cq27-dev/rag-rat/pull/167))
+- *(oracle)* corpus profiles + health-gate loader (C1) ([#171](https://github.com/cq27-dev/rag-rat/pull/171))
+- *(oracle)* live before/after resolution report computation (C2 core) ([#168](https://github.com/cq27-dev/rag-rat/pull/168))
+- *(oracle)* resolution-report + corpus-profile schema contract (C0) ([#166](https://github.com/cq27-dev/rag-rat/pull/166))
+- *(eval)* gate eval behind a non-default feature + add CI eval job ([#162](https://github.com/cq27-dev/rag-rat/pull/162))
+- *(mcp)* nudge the agent to re-anchor stale memories via tool-result content ([#160](https://github.com/cq27-dev/rag-rat/pull/160))
+
+### Fixed
+
+- *(resolve)* stop asserting high confidence on guessed Rust type references ([#192](https://github.com/cq27-dev/rag-rat/pull/192))
+
+### Other
+
+- *(oracle)* normalize small-tier corpora to a comparable ~8k-12k edge scale ([#190](https://github.com/cq27-dev/rag-rat/pull/190))
+- list Python in the README's code-graph languages ([#183](https://github.com/cq27-dev/rag-rat/pull/183))
+
 ## [0.6.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.5.0...rag-rat-core-v0.6.0) - 2026-06-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3118,7 +3118,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rag-rat"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3168,7 +3168,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-mcp"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "3"
 # and the internal path deps below pin the same literal, so the three crates always publish in
 # lockstep. Bump this one line (and the two internal-dep `version`s under workspace.dependencies)
 # to release.
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Kristaps Karlsons"]
 edition = "2024"
 rust-version = "1.89"
@@ -25,8 +25,8 @@ categories = ["command-line-utilities", "development-tools"]
 # Internal crates — declared once here so the version requirement is set in lockstep with
 # [workspace.package].version above. Members reference these via `{ workspace = true }` and add
 # their own feature toggles at the use site.
-rag-rat-core = { version = "0.6.0", path = "crates/rag-rat-core", default-features = false }
-rag-rat-mcp = { version = "0.6.0", path = "crates/rag-rat-mcp", default-features = false }
+rag-rat-core = { version = "0.7.0", path = "crates/rag-rat-core", default-features = false }
+rag-rat-mcp = { version = "0.7.0", path = "crates/rag-rat-mcp", default-features = false }
 anyhow = "1.0"
 fastembed = { version = "5.1.0", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
 gix = { version = "0.84.0", default-features = false, features = ["status", "parallel", "sha1"] }


### PR DESCRIPTION



## 🤖 New release

* `rag-rat-core`: 0.6.0 -> 0.7.0 (⚠ API breaking changes)
* `rag-rat-mcp`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `rag-rat`: 0.6.0 -> 0.7.0

### ⚠ `rag-rat-core` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant ParserKind::Markdown 6 -> 7 in /tmp/.tmpeg9hps/rag-rat/crates/rag-rat-core/src/index/parser.rs:53
  variant Language::Markdown 5 -> 6 in /tmp/.tmpeg9hps/rag-rat/crates/rag-rat-core/src/language.rs:16

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant ParserKind:Python in /tmp/.tmpeg9hps/rag-rat/crates/rag-rat-core/src/index/parser.rs:52
  variant OracleTool:ScipPython in /tmp/.tmpeg9hps/rag-rat/crates/rag-rat-core/src/index/oracle/mod.rs:573
  variant OracleTool:ScipTypescript in /tmp/.tmpeg9hps/rag-rat/crates/rag-rat-core/src/index/oracle/mod.rs:577
  variant Language:Python in /tmp/.tmpeg9hps/rag-rat/crates/rag-rat-core/src/language.rs:15

--- warning partial_ord_enum_variants_reordered: enum variants reordered in #[derive(PartialOrd)] enum ---

Description:
A public enum that derives PartialOrd had its variants reordered. #[derive(PartialOrd)] uses the enum variant order to set the enum's ordering behavior, so this change may break downstream code that relies on the previous order.
        ref: https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html#derivable
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/partial_ord_enum_variants_reordered.ron

Failed in:
  Language::Markdown moved from position 6 to 7, in /tmp/.tmpeg9hps/rag-rat/crates/rag-rat-core/src/language.rs:16
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rag-rat-core`

<blockquote>

## [0.7.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.6.0...rag-rat-core-v0.7.0) - 2026-06-16

### Added

- *(oracle)* C++ corpus (yaml-cpp) + resolve .h headers as C++ under a cpp binding ([#186](https://github.com/cq27-dev/rag-rat/pull/186))
- *(oracle)* scip-typescript backend + ts-ky corpus ([#184](https://github.com/cq27-dev/rag-rat/pull/184))
- *(python)* from-import alias resolution ([#174](https://github.com/cq27-dev/rag-rat/pull/174)) ([#179](https://github.com/cq27-dev/rag-rat/pull/179))
- *(init)* Python root-entrypoint binding + content-aware dir selection ([#173](https://github.com/cq27-dev/rag-rat/pull/173)) ([#181](https://github.com/cq27-dev/rag-rat/pull/181))
- *(python)* prefer a base class when resolving `implements` edges ([#172](https://github.com/cq27-dev/rag-rat/pull/172)) ([#180](https://github.com/cq27-dev/rag-rat/pull/180))
- *(oracle)* unified tier-driven corpus runner + oracle.yml (C3) ([#177](https://github.com/cq27-dev/rag-rat/pull/177))
- *(oracle)* scip-python backend — Python compiler-grade resolution (B6) ([#176](https://github.com/cq27-dev/rag-rat/pull/176))
- *(oracle)* `oracle report --corpus <id>` — run a corpus + emit its C2 resolution report (C2-CLI) ([#175](https://github.com/cq27-dev/rag-rat/pull/175))
- *(lang)* Python language support (symbols, graph edges, embeddings) + AST low-signal ([#167](https://github.com/cq27-dev/rag-rat/pull/167))
- *(oracle)* corpus profiles + health-gate loader (C1) ([#171](https://github.com/cq27-dev/rag-rat/pull/171))
- *(oracle)* live before/after resolution report computation (C2 core) ([#168](https://github.com/cq27-dev/rag-rat/pull/168))
- *(oracle)* resolution-report + corpus-profile schema contract (C0) ([#166](https://github.com/cq27-dev/rag-rat/pull/166))
- *(eval)* gate eval behind a non-default feature + add CI eval job ([#162](https://github.com/cq27-dev/rag-rat/pull/162))
- *(mcp)* nudge the agent to re-anchor stale memories via tool-result content ([#160](https://github.com/cq27-dev/rag-rat/pull/160))

### Fixed

- *(resolve)* stop asserting high confidence on guessed Rust type references ([#192](https://github.com/cq27-dev/rag-rat/pull/192))

### Other

- *(oracle)* normalize small-tier corpora to a comparable ~8k-12k edge scale ([#190](https://github.com/cq27-dev/rag-rat/pull/190))
- list Python in the README's code-graph languages ([#183](https://github.com/cq27-dev/rag-rat/pull/183))
</blockquote>

## `rag-rat-mcp`

<blockquote>

## [0.7.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.6.0...rag-rat-core-v0.7.0) - 2026-06-16

### Added

- *(oracle)* C++ corpus (yaml-cpp) + resolve .h headers as C++ under a cpp binding ([#186](https://github.com/cq27-dev/rag-rat/pull/186))
- *(oracle)* scip-typescript backend + ts-ky corpus ([#184](https://github.com/cq27-dev/rag-rat/pull/184))
- *(python)* from-import alias resolution ([#174](https://github.com/cq27-dev/rag-rat/pull/174)) ([#179](https://github.com/cq27-dev/rag-rat/pull/179))
- *(init)* Python root-entrypoint binding + content-aware dir selection ([#173](https://github.com/cq27-dev/rag-rat/pull/173)) ([#181](https://github.com/cq27-dev/rag-rat/pull/181))
- *(python)* prefer a base class when resolving `implements` edges ([#172](https://github.com/cq27-dev/rag-rat/pull/172)) ([#180](https://github.com/cq27-dev/rag-rat/pull/180))
- *(oracle)* unified tier-driven corpus runner + oracle.yml (C3) ([#177](https://github.com/cq27-dev/rag-rat/pull/177))
- *(oracle)* scip-python backend — Python compiler-grade resolution (B6) ([#176](https://github.com/cq27-dev/rag-rat/pull/176))
- *(oracle)* `oracle report --corpus <id>` — run a corpus + emit its C2 resolution report (C2-CLI) ([#175](https://github.com/cq27-dev/rag-rat/pull/175))
- *(lang)* Python language support (symbols, graph edges, embeddings) + AST low-signal ([#167](https://github.com/cq27-dev/rag-rat/pull/167))
- *(oracle)* corpus profiles + health-gate loader (C1) ([#171](https://github.com/cq27-dev/rag-rat/pull/171))
- *(oracle)* live before/after resolution report computation (C2 core) ([#168](https://github.com/cq27-dev/rag-rat/pull/168))
- *(oracle)* resolution-report + corpus-profile schema contract (C0) ([#166](https://github.com/cq27-dev/rag-rat/pull/166))
- *(eval)* gate eval behind a non-default feature + add CI eval job ([#162](https://github.com/cq27-dev/rag-rat/pull/162))
- *(mcp)* nudge the agent to re-anchor stale memories via tool-result content ([#160](https://github.com/cq27-dev/rag-rat/pull/160))

### Fixed

- *(resolve)* stop asserting high confidence on guessed Rust type references ([#192](https://github.com/cq27-dev/rag-rat/pull/192))

### Other

- *(oracle)* normalize small-tier corpora to a comparable ~8k-12k edge scale ([#190](https://github.com/cq27-dev/rag-rat/pull/190))
- list Python in the README's code-graph languages ([#183](https://github.com/cq27-dev/rag-rat/pull/183))
</blockquote>

## `rag-rat`

<blockquote>

## [0.7.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.6.0...rag-rat-core-v0.7.0) - 2026-06-16

### Added

- *(oracle)* C++ corpus (yaml-cpp) + resolve .h headers as C++ under a cpp binding ([#186](https://github.com/cq27-dev/rag-rat/pull/186))
- *(oracle)* scip-typescript backend + ts-ky corpus ([#184](https://github.com/cq27-dev/rag-rat/pull/184))
- *(python)* from-import alias resolution ([#174](https://github.com/cq27-dev/rag-rat/pull/174)) ([#179](https://github.com/cq27-dev/rag-rat/pull/179))
- *(init)* Python root-entrypoint binding + content-aware dir selection ([#173](https://github.com/cq27-dev/rag-rat/pull/173)) ([#181](https://github.com/cq27-dev/rag-rat/pull/181))
- *(python)* prefer a base class when resolving `implements` edges ([#172](https://github.com/cq27-dev/rag-rat/pull/172)) ([#180](https://github.com/cq27-dev/rag-rat/pull/180))
- *(oracle)* unified tier-driven corpus runner + oracle.yml (C3) ([#177](https://github.com/cq27-dev/rag-rat/pull/177))
- *(oracle)* scip-python backend — Python compiler-grade resolution (B6) ([#176](https://github.com/cq27-dev/rag-rat/pull/176))
- *(oracle)* `oracle report --corpus <id>` — run a corpus + emit its C2 resolution report (C2-CLI) ([#175](https://github.com/cq27-dev/rag-rat/pull/175))
- *(lang)* Python language support (symbols, graph edges, embeddings) + AST low-signal ([#167](https://github.com/cq27-dev/rag-rat/pull/167))
- *(oracle)* corpus profiles + health-gate loader (C1) ([#171](https://github.com/cq27-dev/rag-rat/pull/171))
- *(oracle)* live before/after resolution report computation (C2 core) ([#168](https://github.com/cq27-dev/rag-rat/pull/168))
- *(oracle)* resolution-report + corpus-profile schema contract (C0) ([#166](https://github.com/cq27-dev/rag-rat/pull/166))
- *(eval)* gate eval behind a non-default feature + add CI eval job ([#162](https://github.com/cq27-dev/rag-rat/pull/162))
- *(mcp)* nudge the agent to re-anchor stale memories via tool-result content ([#160](https://github.com/cq27-dev/rag-rat/pull/160))

### Fixed

- *(resolve)* stop asserting high confidence on guessed Rust type references ([#192](https://github.com/cq27-dev/rag-rat/pull/192))

### Other

- *(oracle)* normalize small-tier corpora to a comparable ~8k-12k edge scale ([#190](https://github.com/cq27-dev/rag-rat/pull/190))
- list Python in the README's code-graph languages ([#183](https://github.com/cq27-dev/rag-rat/pull/183))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).