### PR TITLE
chore(ci): workflow hygiene — naming, least-privilege permissions, action bumps (A1)

### DIFF
--- a/.github/workflows/bench-pr-run.yml
+++ b/.github/workflows/bench-pr-run.yml
@@ -2,31 +2,35 @@ name: bench-pr-run
 
 # Fork-safe step 1 of 2: runs benchmarks on a PR (forks included) with NO secrets, then uploads the
 # raw results + PR event as an artifact. The upload to Bencher (which needs the token) happens in
-# bench_pr_track.yml, triggered by this workflow completing — so a fork PR can never read the token.
+# bench-pr-track.yml, triggered by this workflow completing — so a fork PR can never read the token.
 # Pattern mirrors Bencher's "Track Benchmarks with GitHub Actions" (fork PRs) docs.
 
 on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
 
+# Fork-safe by construction: no secrets are used here, and the token is read-only.
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install valgrind (iai-callgrind)
         run: sudo apt-get update && sudo apt-get install -y valgrind
       - name: Cache iai-callgrind-runner
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/iai-callgrind-runner
           key: iai-runner-0.16.1
       - name: Install iai-callgrind-runner
         run: command -v iai-callgrind-runner || cargo install --locked iai-callgrind-runner@0.16.1
       - name: Cache bench corpus (cargo 0.97.1)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target/bench-corpus
           key: bench-corpus-cargo-0.97.1

--- a/.github/workflows/bench-pr-track.yml
+++ b/.github/workflows/bench-pr-track.yml
@@ -12,6 +12,10 @@ on:
 
 permissions:
   contents: read
+  # `bencher run --github-actions` posts BOTH a GitHub Check and a PR comment, so the tracker needs
+  # checks:write (specifying a permissions map sets omitted scopes to none) — Bencher's fork-PR
+  # example grants both. Without it the Check publish/update fails after the artifact download.
+  checks: write
   pull-requests: write
 
 env:

--- a/.github/workflows/bench-pr-track.yml
+++ b/.github/workflows/bench-pr-track.yml
@@ -11,6 +11,7 @@ on:
     types: [completed]
 
 permissions:
+  contents: read
   pull-requests: write
 
 env:

--- a/.github/workflows/bench-release.yml
+++ b/.github/workflows/bench-release.yml
@@ -34,6 +34,7 @@ on:
         default: ''
 
 permissions:
+  contents: read
   checks: write
 
 env:
@@ -56,7 +57,7 @@ jobs:
     # A whole-kernel index is long but bounded; cap it so a pathological run can't hang for hours.
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Pinned bench environment (#71): the Rust toolchain + deps live in the image, so the kernel
       # index runs against a reproducible toolchain rather than the drifting host. Layer-cached.

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -11,6 +11,7 @@ on:
     branches: [main]
 
 permissions:
+  contents: read
   checks: write
 
 concurrency:
@@ -30,20 +31,20 @@ jobs:
   bench:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install valgrind (iai-callgrind)
         run: sudo apt-get update && sudo apt-get install -y valgrind
       - name: Cache iai-callgrind-runner
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/iai-callgrind-runner
           key: iai-runner-${{ env.IAI_RUNNER_VERSION }}
       - name: Install iai-callgrind-runner
         run: command -v iai-callgrind-runner || cargo install --locked iai-callgrind-runner@${{ env.IAI_RUNNER_VERSION }}
       - name: Cache bench corpus (cargo 0.97.1)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: target/bench-corpus
           key: bench-corpus-cargo-0.97.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+# Least privilege: CI only reads the repo (codecov uploads use its own token, not GITHUB_TOKEN).
+permissions:
+  contents: read
+
 # Newer pushes to the same branch/PR cancel older in-flight runs.
 concurrency:
   group: ci-${{ github.ref }}
@@ -19,7 +23,7 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # rustfmt.toml uses nightly-only options (struct_lit_style, imports_granularity, …),
       # so the format check must run on nightly.
       - uses: dtolnay/rust-toolchain@nightly
@@ -31,7 +35,7 @@ jobs:
     name: clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -44,7 +48,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
@@ -65,7 +69,7 @@ jobs:
     name: build (fastembed + model2vec)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       # Compile the default feature set (downloads the ONNX runtime once, then cached) so the
@@ -76,7 +80,7 @@ jobs:
     name: coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -29,7 +29,7 @@ jobs:
     name: eval (search-quality)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -37,7 +37,7 @@ jobs:
       # Cache the MiniLM model download (immutable → static key) so the semantic pass doesn't
       # re-fetch ~90 MB from Hugging Face every run; first run / cache-miss warms it.
       - name: cache embedding model
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/.rag-rat-models
           key: rag-rat-models-minilm-v1

--- a/.github/workflows/oracle-kernel.yml
+++ b/.github/workflows/oracle-kernel.yml
@@ -14,6 +14,7 @@ on:
         default: 'defconfig'
 
 permissions:
+  contents: read
   checks: write
 
 env:
@@ -30,7 +31,7 @@ jobs:
     runs-on: [self-hosted, bigmem]
     timeout-minutes: 360
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Pinned bench environment (#71): scip-clang, rust-analyzer, the kernel-build deps (bc/…),
       # and the Rust toolchain all live in the image, so a missing host package (the `bc` failure)

--- a/.github/workflows/oracle-rust.yml
+++ b/.github/workflows/oracle-rust.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   checks: write
 
 env:
@@ -26,7 +27,7 @@ jobs:
     runs-on: [self-hosted, bigmem]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Pinned bench environment (#71): rust-analyzer + the Rust toolchain live in the image, so the
       # SCIP indexer version is reproducible (it's the content-addressed `tool_version` baked into

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -35,7 +35,7 @@ jobs:
       group: release-plz-pr-${{ github.ref }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -61,7 +61,7 @@ jobs:
       # release-plz inspects the merged Release PR and its commits to build the release.
       pull-requests: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/docs/bencher.md
+++ b/docs/bencher.md
@@ -73,9 +73,9 @@ Four workflows under `.github/workflows/`:
 | Workflow | Trigger | Has the token? | Role |
 |---|---|---|---|
 | `bench.yml` | push to `main` | yes | Records both lightweight signals against the `main` branch; sets/refreshes the thresholds new PRs are compared against. |
-| `bench_pr_run.yml` | `pull_request` (incl. forks) | **no** | Runs the benches, uploads raw output + the PR event as an artifact. Never sees secrets, so a fork PR can't exfiltrate the token. |
-| `bench_pr_track.yml` | `workflow_run` of bench_pr_run | yes | Runs in the base-repo context: downloads the artifact, uploads results to Bencher, comments the comparison on the PR. |
-| `bench_release.yml` | `release: published` + manual `workflow_dispatch` | yes | The heavyweight Linux-kernel headline bench (below). Not a gate — tracks latency/throughput/memory over releases. |
+| `bench-pr-run.yml` | `pull_request` (incl. forks) | **no** | Runs the benches, uploads raw output + the PR event as an artifact. Never sees secrets, so a fork PR can't exfiltrate the token. |
+| `bench-pr-track.yml` | `workflow_run` of bench-pr-run | yes | Runs in the base-repo context: downloads the artifact, uploads results to Bencher, comments the comparison on the PR. |
+| `bench-release.yml` | `release: published` + manual `workflow_dispatch` | yes | The heavyweight Linux-kernel headline bench (below). Not a gate — tracks latency/throughput/memory over releases. |
 
 The `pull_request` → `workflow_run` split is Bencher's documented fork-safe pattern: untrusted fork
 code runs without secrets, and only the trusted base-repo workflow (which never executes fork code)
@@ -84,7 +84,7 @@ holds the API token. PR runs use `--start-point main --start-point-clone-thresho
 
 ## Release headline: indexing the Linux kernel
 
-`tools/bench-kernel.sh` (run by `bench_release.yml`) is the "indexes the Linux kernel in X seconds"
+`tools/bench-kernel.sh` (run by `bench-release.yml`) is the "indexes the Linux kernel in X seconds"
 benchmark. It shallow-clones a pinned kernel tag (`KERNEL_TAG`, default `v7.0`), indexes its C/H
 sources **once** with the release `rag-rat` binary (`index --full`, `--no-default-features` =
 hash embedder, no model download), and writes a Bencher Metric Format JSON file with eight measures:


### PR DESCRIPTION
First step of #164 (A1 — independent workflow reorg).

## What
- **Hyphenate the bench workflow filenames** (`bench_pr_run` → `bench-pr-run`, etc.) so the whole `.github/workflows/` set is consistent. The `workflow_run` link resolves by workflow *name* (unchanged), so the rename is safe; `docs/bencher.md` updated to match.
- **Least-privilege `permissions:` on every workflow** — top-level `contents: read`, widened per-workflow only where needed (`checks: write` for the Bencher uploaders, `pull-requests: write` for the PR-comment tracker, `release-plz` keeps its `{}` + per-job scopes). Clears the CodeQL "workflow does not contain permissions" findings on `ci.yml` and `bench-pr-run`.
- **Bump the Node 20-deprecated actions** named in the runner warning: `actions/checkout` v4→v5 and `actions/cache` v4→v5 (both Node 24). Other actions left at their current majors to avoid unrelated breaking-change risk.

## Not in scope
The oracle consolidation, Python support, and the small-corpus runner are later items in #164 — this PR is just the independent hygiene pass.

All nine workflows parse; permissions verified least-privilege.