### PR TITLE
feat(lang): Python language support (symbols, graph edges, embeddings)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Reach for these first:
 
 - **`semantic_search`** — "where is this concept implemented?" Returns current source chunks with
   inline graph (callers/callees), git, and GitHub papertrail, all validated against current source.
-- **`symbol_lookup`** — exact/fuzzy symbol resolution (Rust/TS/Kotlin/C/C++), with any bound
+- **`symbol_lookup`** — exact/fuzzy symbol resolution (Rust/TS/Kotlin/C/C++/Python), with any bound
   memories attached.
 - **`impact_surface`** — the coding preflight before editing a symbol: graph callers/callees,
   tests, git history, papertrail, and **repo memories** crossing the call path. Run it before

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3160,6 +3160,7 @@ dependencies = [
  "tree-sitter-c",
  "tree-sitter-cpp",
  "tree-sitter-kotlin-ng",
+ "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
  "ureq 2.12.1",
@@ -4248,6 +4249,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,5 +55,6 @@ tree-sitter = "=0.26.9"
 tree-sitter-c = "=0.24.2"
 tree-sitter-cpp = "=0.23.4"
 tree-sitter-kotlin = { package = "tree-sitter-kotlin-ng", version = "1.1.0" }
+tree-sitter-python = "=0.25.0"
 tree-sitter-rust = "=0.24.2"
 tree-sitter-typescript = "=0.23.2"

--- a/crates/rag-rat-cli/src/init/mod.rs
+++ b/crates/rag-rat-cli/src/init/mod.rs
@@ -29,6 +29,15 @@ const SKIPPED_DIRS: &[&str] = &[
     ".next",
     ".turbo",
     ".venv",
+    // Python virtualenv / dependency / cache trees — never project source. Skipping them at scan
+    // time means their `.py` files never become dir candidates, so the "no default → promote the
+    // largest" fallback can't select a `site-packages` tree (#167 review).
+    "venv",
+    "virtualenv",
+    "site-packages",
+    "__pycache__",
+    ".tox",
+    ".nox",
     "build",
     "dist",
     "node_modules",

--- a/crates/rag-rat-cli/src/init/scan.rs
+++ b/crates/rag-rat-cli/src/init/scan.rs
@@ -96,8 +96,15 @@ pub(crate) fn candidate_dirs(scan: &RepoScan, language: Language) -> Vec<DirCand
             default: default_dir(scan, language, path),
         })
         .collect::<Vec<_>>();
+    // When nothing is a natural default, promote the largest candidate — but NEVER a Python
+    // dependency tree (`env/`, `site-packages`, …): in a repo whose only `.py` files live under a
+    // virtualenv, promoting it would write a binding into installed deps. If every candidate is a
+    // dependency dir, leave none defaulted (no binding beats the wrong binding).
     if !candidates.iter().any(|candidate| candidate.default)
-        && let Some(best) = candidates.iter_mut().max_by_key(|candidate| candidate.count)
+        && let Some(best) = candidates
+            .iter_mut()
+            .filter(|candidate| !fallback_excluded(language, &candidate.path))
+            .max_by_key(|candidate| candidate.count)
     {
         best.default = true;
     }
@@ -127,9 +134,44 @@ pub(crate) fn default_dir(scan: &RepoScan, language: Language, path: &Path) -> b
                 || text == "include"
                 || text.ends_with("/include")
                 || directly_contains_source(scan, language, path),
+        // Python packages typically sit at the repo root, under `src/`, or as a dir named after the
+        // package that directly contains `.py` files — but NEVER a virtualenv / dependency tree
+        // (`.venv/…/site-packages`), which would pollute the index with the whole dependency set.
+        Language::Python =>
+            !is_python_dependency_dir(&text)
+                && (text == "src"
+                    || text.ends_with("/src")
+                    || directly_contains_source(scan, language, path)),
         Language::Markdown => text == "docs" || text == ".",
     }
 }
+
+/// `true` for a path under a Python virtualenv / dependency tree — these hold installed third-party
+/// `.py` files (`site-packages`) that must never be indexed as project source.
+fn is_python_dependency_dir(text: &str) -> bool {
+    text.split('/').any(|component| {
+        matches!(
+            component,
+            ".venv"
+                | "venv"
+                | "env"
+                | ".env"
+                | "virtualenv"
+                | "site-packages"
+                | "__pycache__"
+                | ".tox"
+                | ".nox"
+                | "node_modules"
+        )
+    })
+}
+/// Whether the no-default fallback must NOT promote this candidate: a Python dependency/virtualenv
+/// tree (`env`/`.env`/`venv`/`site-packages`/…). `is_python_dependency_dir` covers the names
+/// `SKIPPED_DIRS` doesn't skip during the walk (e.g. `env`, which is too generic to skip globally).
+fn fallback_excluded(language: Language, path: &Path) -> bool {
+    language == Language::Python && is_python_dependency_dir(&display_rel(path))
+}
+
 pub(crate) fn directly_contains_source(scan: &RepoScan, language: Language, path: &Path) -> bool {
     path != Path::new(".")
         && scan
@@ -149,5 +191,35 @@ pub(crate) fn print_language_summary(scan: &RepoScan) {
         if count > 0 {
             println!("  {}: {count} files", language.as_str());
         }
+    }
+}
+
+#[cfg(test)]
+mod python_dir_tests {
+    use super::*;
+
+    #[test]
+    fn python_dependency_dir_detection() {
+        assert!(is_python_dependency_dir(".venv"));
+        assert!(is_python_dependency_dir("env"));
+        assert!(is_python_dependency_dir("project/.venv/lib/site-packages"));
+        assert!(!is_python_dependency_dir("src"));
+        assert!(!is_python_dependency_dir("app"));
+    }
+
+    #[test]
+    fn fallback_does_not_promote_a_venv_only_python_repo() {
+        // A repo whose only discovered .py files live under an `env/` virtualenv: the no-default
+        // fallback must NOT promote it (else `init -y` writes `python = ["env"]`).
+        let mut scan = RepoScan::default();
+        let dir = PathBuf::from("env");
+        scan.dir_counts.entry(Language::Python).or_default().insert(dir.clone(), 9);
+        scan.direct_dir_counts.entry(Language::Python).or_default().insert(dir, 9);
+
+        let candidates = candidate_dirs(&scan, Language::Python);
+        assert!(
+            candidates.iter().all(|candidate| !candidate.default),
+            "a virtualenv dir must never be selected as the default Python target: {candidates:?}"
+        );
     }
 }

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -38,6 +38,7 @@ tree-sitter.workspace = true
 tree-sitter-c.workspace = true
 tree-sitter-cpp.workspace = true
 tree-sitter-kotlin.workspace = true
+tree-sitter-python.workspace = true
 tree-sitter-rust.workspace = true
 tree-sitter-typescript.workspace = true
 

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -732,7 +732,7 @@ mod tests {
     #[test]
     fn rejects_unknown_language() {
         let root = std::env::current_dir().unwrap();
-        let simple = BTreeMap::from([("python".to_string(), vec![".".to_string()])]);
+        let simple = BTreeMap::from([("cobol".to_string(), vec![".".to_string()])]);
 
         let err = resolve_targets(&root, simple, Vec::new()).unwrap_err();
 

--- a/crates/rag-rat-core/src/index/ai/policy.rs
+++ b/crates/rag-rat-core/src/index/ai/policy.rs
@@ -134,34 +134,133 @@ pub(crate) fn is_test_fixture_path(path: &str) -> bool {
         || path.ends_with(".snap")
 }
 
+/// Whether a chunk is "pure plumbing" with no semantic signal worth embedding — every top-level
+/// statement is an import/include, a comment, or a bare docstring. AST-driven (#170): the chunk is
+/// re-parsed and classified by tree-sitter **node kind**, not line prefixes — robust to multi-line
+/// imports (`from x import (\n a,\n b,\n)`), docstrings, `#`-vs-`#define`, and spacing the old
+/// string heuristic mishandled. A symbol chunk is a definition node, so it's never low-signal.
+///
+/// `chunk_kind` / `symbol_path` are unused now (the node kinds carry the signal) but kept on the
+/// signature for the call site. Re-parsing a small chunk is cheap relative to the embedding it
+/// gates; if it ever shows up hot, precompute the flag from the file's parse at index time.
 pub(crate) fn is_low_signal_chunk(
     language: &str,
-    chunk_kind: &str,
-    symbol_path: Option<&str>,
+    _chunk_kind: &str,
+    _symbol_path: Option<&str>,
     text: &str,
 ) -> bool {
-    if language == "markdown" {
+    let Ok(lang) = language.parse::<Language>() else {
+        return false;
+    };
+    if lang == Language::Markdown {
         return false;
     }
-    let lines = text
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty() && !line.starts_with("//") && !line.starts_with("/*"))
-        .collect::<Vec<_>>();
-    if lines.is_empty() {
+    let ext = lang.simple_extensions().first().copied().unwrap_or("txt");
+    let path = std::path::PathBuf::from(format!("chunk.{ext}"));
+    let Some(parsed) = crate::index::parser::parse_file(&path, lang, text) else {
+        // No grammar / hard parse failure — keep it; don't skip a chunk we can't classify.
+        return false;
+    };
+    let root = parsed.root();
+    // Low-signal iff EVERY top-level statement is plumbing (vacuously true for an empty/`}`-only
+    // chunk that parses to no statements). Any definition/expression/other node is signal.
+    let mut cursor = root.walk();
+    root.named_children(&mut cursor).all(|child| is_plumbing_node(lang, child))
+}
+
+/// A top-level node carrying no embed-worthy signal: a comment, or a per-language import/include /
+/// package / docstring / `pass`. NOT a definition-introducing form (a C `#define` macro, a Rust
+/// `mod`, a Python `def`/`class`) — those are symbols and must keep their embedding.
+fn is_plumbing_node(language: Language, node: tree_sitter::Node<'_>) -> bool {
+    let kind = node.kind();
+    if kind.contains("comment") {
         return true;
     }
-    if symbol_path.is_none() && chunk_kind == "code" && lines.len() <= 3 {
-        return true;
+    match language {
+        Language::Rust => kind == "use_declaration",
+        Language::TypeScript => kind == "import_statement",
+        Language::Kotlin => matches!(kind, "import_header" | "package_header"),
+        Language::C | Language::Cpp => kind == "preproc_include",
+        Language::Python =>
+            matches!(
+                kind,
+                "import_statement"
+                    | "import_from_statement"
+                    | "future_import_statement"
+                    | "pass_statement"
+            ) || is_python_docstring_statement(node),
+        Language::Markdown => true,
     }
-    lines.iter().all(|line| {
-        line.starts_with("use ")
-            || line.starts_with("pub use ")
-            || line.starts_with("import ")
-            || line.starts_with("export ")
-            || line.starts_with("mod ")
-            || line.starts_with("pub mod ")
-            || *line == "}"
-            || *line == "{"
-    })
+}
+
+/// A Python bare docstring: an `expression_statement` whose sole child is a string literal.
+fn is_python_docstring_statement(node: tree_sitter::Node<'_>) -> bool {
+    node.kind() == "expression_statement"
+        && node.named_child_count() == 1
+        && node.named_child(0).is_some_and(|child| child.kind() == "string")
+}
+
+#[cfg(test)]
+mod low_signal_tests {
+    use super::is_low_signal_chunk;
+
+    #[test]
+    fn c_macro_definition_is_not_low_signal() {
+        // Regression (Codex on #167): `#` is a C directive, not a comment, and `#define` is a macro
+        // SYMBOL — its chunk must keep its embedding, not be filtered as plumbing.
+        assert!(!is_low_signal_chunk("c", "code", Some("DEVICE_API"), "#define DEVICE_API(x) (x)"));
+    }
+
+    #[test]
+    fn c_include_only_chunk_is_low_signal() {
+        assert!(is_low_signal_chunk(
+            "c",
+            "code",
+            Some("s"),
+            "#include <stdio.h>\n#include \"a.h\""
+        ));
+    }
+
+    #[test]
+    fn python_comment_and_docstring_only_is_low_signal() {
+        assert!(is_low_signal_chunk("python", "code", Some("s"), "# a note\n\"\"\"doc\"\"\""));
+    }
+
+    #[test]
+    fn python_multiline_docstring_only_is_low_signal() {
+        // The AST sees one `string` statement; the old line-prefix heuristic let the interior
+        // prose lines through and embedded it (#170 motivation).
+        let chunk =
+            "\"\"\"\nA multi-line module docstring.\nSpanning several prose lines.\n\"\"\"\n";
+        assert!(is_low_signal_chunk("python", "code", None, chunk));
+    }
+
+    #[test]
+    fn python_multiline_import_is_low_signal() {
+        // Parenthesized multi-import is one `import_from_statement` node — robust where line
+        // prefixes weren't.
+        let chunk = "from pkg import (\n    A,\n    B,\n    C,\n)\n";
+        assert!(is_low_signal_chunk("python", "code", None, chunk));
+    }
+
+    #[test]
+    fn python_real_code_is_not_low_signal() {
+        assert!(!is_low_signal_chunk("python", "code", None, "x = compute()\nreturn x\n"));
+    }
+
+    #[test]
+    fn python_import_only_is_low_signal_but_a_def_is_not() {
+        assert!(is_low_signal_chunk("python", "code", Some("s"), "import os\nfrom a import b"));
+        assert!(!is_low_signal_chunk(
+            "python",
+            "code",
+            Some("Api"),
+            "def host(self):\n    return 1"
+        ));
+    }
+
+    #[test]
+    fn rust_use_only_is_low_signal() {
+        assert!(is_low_signal_chunk("rust", "code", Some("s"), "use a::b;\npub use c::d;"));
+    }
 }

--- a/crates/rag-rat-core/src/index/edges/extract.rs
+++ b/crates/rag-rat-core/src/index/edges/extract.rs
@@ -96,6 +96,7 @@ pub(crate) fn syntactic_edges(
         ParserKind::Kotlin => tree_sitter_kotlin::LANGUAGE.into(),
         ParserKind::C => tree_sitter_c::LANGUAGE.into(),
         ParserKind::Cpp => tree_sitter_cpp::LANGUAGE.into(),
+        ParserKind::Python => tree_sitter_python::LANGUAGE.into(),
         ParserKind::Markdown => return Ok(Vec::new()),
     };
     let mut parser = tree_sitter::Parser::new();
@@ -123,6 +124,7 @@ pub(crate) fn collect_edges(
         Language::TypeScript => typescript_edges(text, node, symbols, path, out),
         Language::Kotlin => kotlin_edges(text, node, symbols, path, out),
         Language::C | Language::Cpp => c_like_edges(text, node, symbols, path, out),
+        Language::Python => python_edges(text, node, symbols, path, out),
         Language::Markdown => {},
     }
 
@@ -600,6 +602,246 @@ pub(crate) fn c_like_edges(
         _ => {},
     }
 }
+pub(crate) fn python_edges(
+    text: &str,
+    node: Node<'_>,
+    symbols: &[IndexedSymbol],
+    path: &Path,
+    out: &mut Vec<EdgeCandidate>,
+) {
+    match node.kind() {
+        // `from <module> import <name|name as alias>, ...` — emit Imports edges to the MODULE and
+        // to each imported NAME, never the local alias. A relative import (`.sessions`)
+        // normalizes to its dotted tail (the leading dots aren't identifiers), so the
+        // module name is recorded separately from any `as` alias.
+        "import_from_statement" => {
+            let module = node.child_by_field_name("module_name");
+            if let Some(module) = module
+                && let Some(name) = last_identifier_text(module, text)
+            {
+                out.push(file_edge(
+                    path,
+                    module,
+                    text,
+                    name,
+                    EdgeKind::Imports,
+                    EdgeConfidence::NameOnly,
+                ));
+            }
+            let module_id = module.map(|m| m.id());
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                if Some(child.id()) == module_id {
+                    continue;
+                }
+                python_import_target(child, text, path, out);
+            }
+        },
+        // `import <module>` / `import <module> as alias` — Imports edge to the module, not the
+        // alias.
+        "import_statement" => {
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                python_import_target(child, text, path, out);
+            }
+        },
+        // Function / method / constructor call. Mirror the C handler: the callee is the LAST
+        // identifier under the `function` child (`f()` → `f`, `obj.method()` → `method`), the
+        // receiver is the first (recorded only as a NameOnly hint — never claimed as exact;
+        // resolving it is the oracle's job, not the heuristic's).
+        "call" => {
+            let function = node.child_by_field_name("function").unwrap_or(node);
+            let identifiers = identifiers_under(function, text);
+            let identifier_nodes = identifier_nodes_under(function);
+            // `handlers[key]()` — the callee is the subscript RESULT, not the index variable
+            // `last()` would pick. There's no clean callee identifier, so emit nothing (a wrong
+            // `calls_name key` is worse than a missing edge).
+            if function.kind() == "subscript" {
+                // fall through to recursion without emitting a call edge
+            } else if let Some(name) = identifiers.last().cloned() {
+                out.push(symbol_edge_with_context(
+                    symbols,
+                    node,
+                    text,
+                    name,
+                    EdgeKind::CallsName,
+                    EdgeConfidence::NameOnly,
+                    EdgeContext {
+                        target_qualified_name: dotted_qualified_name(&identifiers),
+                        receiver_hint: identifiers
+                            .first()
+                            .filter(|_| identifiers.len() > 1)
+                            .cloned(),
+                    },
+                    identifier_nodes.last().copied().map(CalleeRange::of_node),
+                ));
+            }
+        },
+        // `class Foo(Base, Generic[T], metaclass=Meta)` — each POSITIONAL base is an Implements +
+        // ReferencesType edge. Keyword (`metaclass=`) and splat (`*bases`/`**kw`) arguments are not
+        // superclasses, and a parameterized base resolves to its head (`Generic`, not `T`).
+        "class_definition" =>
+            if let Some(supers) = node.child_by_field_name("superclasses") {
+                let mut cursor = supers.walk();
+                for base in supers.named_children(&mut cursor) {
+                    if matches!(base.kind(), "keyword_argument" | "list_splat" | "dictionary_splat")
+                    {
+                        continue;
+                    }
+                    // Implements points at the base HEAD only (`Generic`, not `T`); ReferencesType
+                    // covers the head AND every type argument (`Mapping[str, Api]` → `Mapping`,
+                    // `str`, `Api`).
+                    let head = python_type_head(base);
+                    if let Some(name) = last_identifier_text(head, text) {
+                        out.push(symbol_edge(
+                            symbols,
+                            base,
+                            name,
+                            EdgeKind::Implements,
+                            EdgeConfidence::NameOnly,
+                            last_identifier_node(head)
+                                .map(final_segment_node)
+                                .map(CalleeRange::of_node),
+                        ));
+                    }
+                    emit_python_type_refs(base, symbols, text, out);
+                }
+            },
+        // Type annotations (`x: T`, `-> T`) wrap their type in a `type` node.
+        // `emit_python_type_refs` walks the whole type expression — generics (`Box[Item]`),
+        // qualified generics (`typing.Optional[Api]`), unions (`A | B`), nested
+        // (`Optional[list[Api]]`), `Callable` param lists — emitting a ReferencesType per
+        // referenced type. The alias NAME in a `type X = …` is skipped (it's a definition,
+        // not a reference). String forward refs (`-> "Api"`) carry no identifier → no edge.
+        "type" if !python_is_type_alias_name(node) => {
+            emit_python_type_refs(node, symbols, text, out);
+        },
+        // A bare decorator (`@requires_auth`, `@pytest.fixture`) is an identifier/attribute, not a
+        // `call` — applying it is a call-like dependency, so emit a NameOnly call edge. A
+        // parenthesized decorator (`@foo(...)`) is a `call` child, already handled by the call arm
+        // via recursion.
+        "decorator" => {
+            if let Some(inner) = node.named_child(0)
+                && matches!(inner.kind(), "identifier" | "attribute")
+                && let Some(name) = last_identifier_text(inner, text)
+            {
+                // Preserve the qualifier so a qualified decorator (`@pytest.fixture`) carries its
+                // `pytest` receiver + dotted path — same context the call arm records — so the
+                // resolver doesn't fall back to a bare local `fixture` of the same name.
+                let identifiers = identifiers_under(inner, text);
+                out.push(symbol_edge_with_context(
+                    symbols,
+                    node,
+                    text,
+                    name,
+                    EdgeKind::CallsName,
+                    EdgeConfidence::NameOnly,
+                    EdgeContext {
+                        target_qualified_name: dotted_qualified_name(&identifiers),
+                        receiver_hint: identifiers
+                            .first()
+                            .filter(|_| identifiers.len() > 1)
+                            .cloned(),
+                    },
+                    last_identifier_node(inner).map(final_segment_node).map(CalleeRange::of_node),
+                ));
+            }
+        },
+        _ => {},
+    }
+}
+
+/// Emit `ReferencesType` edges for a subscript-form generic's type arguments, RECURSIVELY so nested
+/// generics (`typing.Optional[list[Api]]` → both `list` and `Api`) are all referenced. Each arg's
+/// head is emitted, then its own subscript args are walked; non-subscript args terminate.
+/// Emit a `ReferencesType` edge for every type referenced in a Python type expression, walking the
+/// whole shape: `type`/`generic_type`/`subscript`/`binary_operator` (PEP 604 `A |
+/// B`)/`list`/`tuple` (`Callable[[int, A], B]`)/`type_parameter` recurse into their children;
+/// `identifier`/`attribute`/ `dotted_name` are leaf references (the dotted tail is the referenced
+/// type). Anything else (string forward refs, `None`, literals) terminates with no edge. This
+/// single walker handles plain, generic, qualified, union, nested, and callable annotations
+/// uniformly.
+fn emit_python_type_refs(
+    node: Node<'_>,
+    symbols: &[IndexedSymbol],
+    text: &str,
+    out: &mut Vec<EdgeCandidate>,
+) {
+    match node.kind() {
+        "type" | "generic_type" | "subscript" | "binary_operator" | "list" | "tuple"
+        | "type_parameter" => {
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                emit_python_type_refs(child, symbols, text, out);
+            }
+        },
+        "identifier" | "attribute" | "dotted_name" => {
+            if let Some(name) = last_identifier_text(node, text) {
+                out.push(symbol_edge(
+                    symbols,
+                    node,
+                    name,
+                    EdgeKind::ReferencesType,
+                    EdgeConfidence::NameOnly,
+                    last_identifier_node(node).map(final_segment_node).map(CalleeRange::of_node),
+                ));
+            }
+        },
+        _ => {},
+    }
+}
+
+/// Whether `node` is the alias NAME being DEFINED in `type X = …` (the first child of a
+/// `type_alias_statement`) — a definition, not a reference, so it must not emit a `ReferencesType`
+/// self-edge. The value side (the second `type`) is referenced normally.
+fn python_is_type_alias_name(node: Node<'_>) -> bool {
+    node.parent().is_some_and(|parent| {
+        parent.kind() == "type_alias_statement"
+            && parent.named_child(0).map(|first| first.id()) == Some(node.id())
+    })
+}
+
+/// The "head" type node to anchor a Python type reference on, for a parameterized type. Unwraps the
+/// applicable wrappers to reach the base: a `type` wrapper, a `generic_type` (`Box[Item]` in an
+/// annotation → base `Box`), and a `subscript` (`Generic[T]` in a base-class list → value
+/// `Generic`). Plain identifiers/attributes pass through unchanged, so the type argument
+/// (`Item`/`T`) is never mistaken for the base. Bounded loop guards against a pathological tree.
+fn python_type_head(node: Node<'_>) -> Node<'_> {
+    let mut head = node;
+    for _ in 0..8 {
+        head = match head.kind() {
+            "type" | "generic_type" => head.named_child(0).unwrap_or(head),
+            "subscript" => head.child_by_field_name("value").unwrap_or(head),
+            _ => return head,
+        };
+    }
+    head
+}
+
+/// Emit an Imports edge for one import clause (`dotted_name` or `aliased_import`), targeting the
+/// imported name's dotted tail — NEVER the `as` alias (which is a local binding, not the import). A
+/// comma / parenthesized list (`from pkg import A, B`) nests its clauses under an `import_list`, so
+/// recurse into that.
+fn python_import_target(child: Node<'_>, text: &str, path: &Path, out: &mut Vec<EdgeCandidate>) {
+    if child.kind() == "import_list" {
+        let mut cursor = child.walk();
+        for clause in child.named_children(&mut cursor) {
+            python_import_target(clause, text, path, out);
+        }
+        return;
+    }
+    let target = match child.kind() {
+        "aliased_import" => child.child_by_field_name("name"),
+        "dotted_name" => Some(child),
+        _ => None,
+    };
+    if let Some(target) = target
+        && let Some(name) = last_identifier_text(target, text)
+    {
+        out.push(file_edge(path, target, text, name, EdgeKind::Imports, EdgeConfidence::NameOnly));
+    }
+}
+
 pub(crate) fn file_edge(
     path: &Path,
     node: Node<'_>,
@@ -747,5 +989,198 @@ pub(crate) fn symbol_edge_with_context(
         import_scope: None,
         edge_kind,
         confidence,
+    }
+}
+
+#[cfg(test)]
+mod python_edge_tests {
+    use std::path::Path;
+
+    use super::*;
+    use crate::language::Language;
+
+    fn edges(src: &str) -> Vec<EdgeCandidate> {
+        // No symbol table needed: the syntactic pass emits NameOnly candidates regardless of
+        // resolution, which is exactly the signal these assertions check.
+        syntactic_edges(Path::new("src/Main.py"), Language::Python, src, &[]).unwrap()
+    }
+
+    fn has(edges: &[EdgeCandidate], kind: EdgeKind, name: &str) -> bool {
+        edges.iter().any(|e| e.edge_kind == kind && e.to_name == name)
+    }
+
+    #[test]
+    fn relative_import_normalized_and_alias_not_treated_as_import() {
+        let e = edges("from .sessions import Session as ClientSession\n");
+        // The relative module `.sessions` normalizes to its dotted tail; the imported symbol is
+        // recorded separately.
+        assert!(has(&e, EdgeKind::Imports, "sessions"), "module import missing: {e:?}");
+        assert!(has(&e, EdgeKind::Imports, "Session"), "imported name missing: {e:?}");
+        // The local `as` alias is NOT an import target.
+        assert!(!has(&e, EdgeKind::Imports, "ClientSession"), "alias wrongly imported: {e:?}");
+    }
+
+    #[test]
+    fn plain_and_dotted_imports_use_module_not_alias() {
+        let e = edges("from requests.adapters import HTTPAdapter\nimport urllib3 as http\n");
+        assert!(has(&e, EdgeKind::Imports, "adapters"), "dotted module tail missing: {e:?}");
+        assert!(has(&e, EdgeKind::Imports, "HTTPAdapter"));
+        assert!(has(&e, EdgeKind::Imports, "urllib3"), "import module missing: {e:?}");
+        assert!(!has(&e, EdgeKind::Imports, "http"), "import alias wrongly recorded: {e:?}");
+    }
+
+    #[test]
+    fn method_call_records_receiver_hint_at_name_only_not_exact() {
+        let e = edges("def f():\n    http.disable_warnings()\n");
+        let call = e
+            .iter()
+            .find(|c| c.edge_kind == EdgeKind::CallsName && c.to_name == "disable_warnings")
+            .expect("method call edge");
+        assert_eq!(call.receiver_hint.as_deref(), Some("http"));
+        // The heuristic must NOT claim exact resolution for a member call — that's the oracle's
+        // job.
+        assert_eq!(call.confidence, EdgeConfidence::NameOnly);
+    }
+
+    #[test]
+    fn alias_call_emits_name_only_call_edge() {
+        // A call through an imported alias is a NameOnly call to the alias name (resolving the
+        // alias to its imported symbol is the resolver/oracle's job, not the syntactic
+        // pass).
+        let e = edges("def make():\n    return ClientSession()\n");
+        let call = e
+            .iter()
+            .find(|c| c.edge_kind == EdgeKind::CallsName && c.to_name == "ClientSession")
+            .expect("alias call edge");
+        assert_eq!(call.confidence, EdgeConfidence::NameOnly);
+    }
+
+    #[test]
+    fn base_class_emits_implements_and_references_type() {
+        let e = edges("class Api(Session):\n    pass\n");
+        assert!(has(&e, EdgeKind::Implements, "Session"), "base class Implements missing: {e:?}");
+        assert!(
+            has(&e, EdgeKind::ReferencesType, "Session"),
+            "base class ReferencesType missing: {e:?}"
+        );
+    }
+
+    #[test]
+    fn generic_base_resolves_to_base_not_type_arg() {
+        // `class Repo(Generic[T])` — the base is `Generic`, NOT the type argument `T`.
+        let e = edges("class Repo(Generic[T]):\n    pass\n");
+        assert!(has(&e, EdgeKind::Implements, "Generic"), "base should be Generic: {e:?}");
+        assert!(!has(&e, EdgeKind::Implements, "T"), "must not resolve to type arg T: {e:?}");
+    }
+
+    #[test]
+    fn metaclass_keyword_argument_is_not_a_base_class() {
+        // `class Model(Base, metaclass=Meta)` — `Base` is a base; `metaclass=Meta` is not.
+        let e = edges("class Model(Base, metaclass=Meta):\n    pass\n");
+        assert!(has(&e, EdgeKind::Implements, "Base"), "Base should be a base: {e:?}");
+        assert!(
+            !has(&e, EdgeKind::Implements, "Meta"),
+            "metaclass kwarg must not be a base: {e:?}"
+        );
+    }
+
+    #[test]
+    fn generic_annotation_anchors_the_head_type() {
+        // `x: Box[Item]` references `Box` (the head), which would otherwise be invisible.
+        let e = edges("def f(x: Box[Item]) -> None:\n    pass\n");
+        assert!(has(&e, EdgeKind::ReferencesType, "Box"), "annotation head Box missing: {e:?}");
+    }
+
+    #[test]
+    fn qualified_generic_annotation_emits_head_and_arg() {
+        // `x: typing.Optional[Api]` is a `subscript` — emit BOTH the head (`Optional`) and the type
+        // argument (`Api`); the latter is a plain expression the recursion otherwise misses.
+        let e = edges("def f(x: typing.Optional[Api]) -> None:\n    pass\n");
+        assert!(has(&e, EdgeKind::ReferencesType, "Optional"), "head Optional missing: {e:?}");
+        assert!(has(&e, EdgeKind::ReferencesType, "Api"), "type arg Api missing: {e:?}");
+    }
+
+    #[test]
+    fn union_annotation_emits_both_operands() {
+        // PEP 604 `A | B` — both operands are referenced types (was: only the last).
+        let e = edges("def f(x: A | B) -> None:\n    pass\n");
+        assert!(has(&e, EdgeKind::ReferencesType, "A"), "union operand A missing: {e:?}");
+        assert!(has(&e, EdgeKind::ReferencesType, "B"), "union operand B missing: {e:?}");
+    }
+
+    #[test]
+    fn subscript_callee_does_not_record_the_index() {
+        // `handlers[key]()` — `key` is the index, not the callee; emit no bogus call edge.
+        let e = edges("def f():\n    handlers[key]()\n");
+        assert!(
+            !has(&e, EdgeKind::CallsName, "key"),
+            "index var wrongly recorded as callee: {e:?}"
+        );
+    }
+
+    #[test]
+    fn generic_base_class_emits_type_args() {
+        // `class C(Mapping[str, Api])` — Implements the head `Mapping`, ReferencesType the arg
+        // `Api`.
+        let e = edges("class C(Mapping[str, Api]):\n    pass\n");
+        assert!(has(&e, EdgeKind::Implements, "Mapping"), "base head Implements missing: {e:?}");
+        assert!(has(&e, EdgeKind::ReferencesType, "Api"), "base type arg Api missing: {e:?}");
+        assert!(!has(&e, EdgeKind::Implements, "Api"), "type arg must not be Implements: {e:?}");
+    }
+
+    #[test]
+    fn type_alias_does_not_self_reference() {
+        // `type UserId = int` references `int`, NOT the alias name `UserId` being defined.
+        let e = edges("type UserId = int\n");
+        assert!(has(&e, EdgeKind::ReferencesType, "int"), "alias value int missing: {e:?}");
+        assert!(!has(&e, EdgeKind::ReferencesType, "UserId"), "alias name self-referenced: {e:?}");
+    }
+
+    #[test]
+    fn nested_qualified_generic_annotation_emits_all_heads() {
+        // `typing.Optional[list[Api]]` → Optional + list + the nested project type Api.
+        let e = edges("def f(x: typing.Optional[list[Api]]) -> None:\n    pass\n");
+        assert!(has(&e, EdgeKind::ReferencesType, "Optional"), "Optional missing: {e:?}");
+        assert!(has(&e, EdgeKind::ReferencesType, "list"), "list missing: {e:?}");
+        assert!(has(&e, EdgeKind::ReferencesType, "Api"), "nested Api missing: {e:?}");
+    }
+
+    #[test]
+    fn bare_decorator_emits_a_call_edge() {
+        // `@requires_auth` (no parens) is a dependency of the decorated symbol.
+        let e = edges("@requires_auth\ndef handler():\n    pass\n");
+        assert!(
+            has(&e, EdgeKind::CallsName, "requires_auth"),
+            "bare decorator edge missing: {e:?}"
+        );
+    }
+
+    #[test]
+    fn qualified_bare_decorator_keeps_its_receiver() {
+        // `@pytest.fixture` records the `pytest` receiver so it can't fall back to a local
+        // `fixture`.
+        let e = edges("@pytest.fixture\ndef t():\n    pass\n");
+        let edge = e
+            .iter()
+            .find(|c| c.edge_kind == EdgeKind::CallsName && c.to_name == "fixture")
+            .expect("qualified decorator edge");
+        assert_eq!(edge.receiver_hint.as_deref(), Some("pytest"));
+    }
+
+    #[test]
+    fn multi_import_emits_each_imported_name() {
+        // `from pkg import A, B` nests the names under an `import_list`.
+        let e = edges("from pkg import A, B\n");
+        assert!(has(&e, EdgeKind::Imports, "A"), "import A missing: {e:?}");
+        assert!(has(&e, EdgeKind::Imports, "B"), "import B missing: {e:?}");
+    }
+
+    #[test]
+    fn annotation_emits_references_type() {
+        let e = edges("def f(url: str) -> None:\n    pass\n");
+        assert!(
+            has(&e, EdgeKind::ReferencesType, "str"),
+            "annotation ReferencesType missing: {e:?}"
+        );
     }
 }

--- a/crates/rag-rat-core/src/index/ignore_rules.rs
+++ b/crates/rag-rat-core/src/index/ignore_rules.rs
@@ -55,8 +55,25 @@ use crate::index::git_history;
 /// never source; the rest are conventional build/dependency/output dirs that a non-git tree (no
 /// `.gitignore` to compile) still must not index. In a git tree these usually also appear in
 /// `.gitignore`, but the floor guarantees them even when they don't.
-const FLOOR_DIRS: &[&str] =
-    &[".git", ".rag-rat", ".omx", ".omc", "node_modules", "target", "dist", "build", "coverage"];
+const FLOOR_DIRS: &[&str] = &[
+    ".git",
+    ".rag-rat",
+    ".omx",
+    ".omc",
+    "node_modules",
+    "target",
+    "dist",
+    "build",
+    "coverage",
+    // Python virtualenv / dependency / cache trees: never project source. `site-packages` is the
+    // load-bearing one — installed deps live there regardless of the venv dir's name (`.venv`,
+    // `venv`, `env`, …), so flooring it stops a `python = ["."]` config from ingesting the whole
+    // dependency set even when the venv dir itself isn't named conventionally.
+    ".venv",
+    "venv",
+    "site-packages",
+    "__pycache__",
+];
 
 /// Whether a single path component matches a floor directory name (see [`FLOOR_DIRS`]).
 fn is_floor_dir(name: &str) -> bool {

--- a/crates/rag-rat-core/src/index/parser.rs
+++ b/crates/rag-rat-core/src/index/parser.rs
@@ -49,6 +49,7 @@ pub enum ParserKind {
     Kotlin,
     C,
     Cpp,
+    Python,
     Markdown,
 }
 
@@ -64,6 +65,7 @@ pub fn parser_kind(path: &Path, language: Language) -> ParserKind {
         Language::Kotlin => ParserKind::Kotlin,
         Language::C => ParserKind::C,
         Language::Cpp => ParserKind::Cpp,
+        Language::Python => ParserKind::Python,
         Language::Markdown => ParserKind::Markdown,
     }
 }
@@ -79,6 +81,7 @@ fn grammar_for(kind: ParserKind) -> Option<tree_sitter::Language> {
         ParserKind::Kotlin => tree_sitter_kotlin::LANGUAGE.into(),
         ParserKind::C => tree_sitter_c::LANGUAGE.into(),
         ParserKind::Cpp => tree_sitter_cpp::LANGUAGE.into(),
+        ParserKind::Python => tree_sitter_python::LANGUAGE.into(),
         ParserKind::Markdown => return None,
     })
 }
@@ -150,10 +153,14 @@ fn collect_symbols(
     if node.is_error() || node.is_missing() {
         return;
     }
-    if let Some((kind, name_node)) = symbol_node(language, node) {
+    if let Some((kind, name_node)) = symbol_node(language, node, text) {
         let name = node_text(name_node, text).unwrap_or_default();
         if !name.is_empty() {
-            out.push(make_symbol(path, language, text, node, kind, name));
+            // The span (chunk/embedding) is the matched `node`; the SIGNATURE is read from the
+            // declaration node, which differs for a decorated Python def (the span starts at the
+            // decorator, but the signature must be the `def`/`class` line).
+            let signature_node = signature_source_node(language, node);
+            out.push(make_symbol(path, language, text, node, signature_node, kind, name));
         }
     }
     let mut cursor = node.walk();
@@ -162,7 +169,11 @@ fn collect_symbols(
     }
 }
 
-fn symbol_node(language: Language, node: Node<'_>) -> Option<(&'static str, Node<'_>)> {
+fn symbol_node<'a>(
+    language: Language,
+    node: Node<'a>,
+    text: &str,
+) -> Option<(&'static str, Node<'a>)> {
     let kind = node.kind();
     match language {
         Language::Rust => match kind {
@@ -224,8 +235,71 @@ fn symbol_node(language: Language, node: Node<'_>) -> Option<(&'static str, Node
             "preproc_function_def" => Some(("macro", child_name(node)?)),
             _ => None,
         },
+        Language::Python => match kind {
+            // A decorated def OWNS the symbol span (so `@app.get(...)` / `@dataclass` / `@property`
+            // decorator lines — which often define the API surface — are inside the chunk), using
+            // the inner def's name + kind. The inner `function_definition`/`class_definition` arms
+            // below are guarded so they don't ALSO emit a duplicate with the bare (decorator-less)
+            // span.
+            "decorated_definition" => {
+                let inner = node.child_by_field_name("definition")?;
+                let kind = match inner.kind() {
+                    "function_definition" => "function",
+                    "class_definition" => "class",
+                    _ => return None,
+                };
+                Some((kind, child_name(inner)?))
+            },
+            "function_definition" if !python_parent_is_decorated(node) =>
+                Some(("function", child_name(node)?)),
+            "class_definition" if !python_parent_is_decorated(node) =>
+                Some(("class", child_name(node)?)),
+            // PEP 695 type alias (`type UserId = int`) — index the alias like Rust/TS/C++ type
+            // aliases. `child_name` finds the first identifier (the alias name `UserId`).
+            "type_alias_statement" => Some(("type", child_name(node)?)),
+            // Constants are MODULE- or CLASS-level SCREAMING_SNAKE_CASE assignments only. Gating on
+            // scope keeps function-local uppercase temporaries (`TIMEOUT = compute()`) out of the
+            // symbol table, and the screaming-snake check keeps ordinary lowercase
+            // locals/attributes out.
+            "assignment" if python_assignment_is_const_scope(node) => {
+                let target = node.child_by_field_name("left")?;
+                let name = node_text(target, text)?;
+                (target.kind() == "identifier" && is_screaming_snake_case(&name))
+                    .then_some(("const", target))
+            },
+            _ => None,
+        },
         Language::Markdown => None,
     }
+}
+
+/// `true` for a Python constant name (SCREAMING_SNAKE_CASE): at least one ASCII uppercase letter
+/// and only uppercase / digits / underscore. Keeps `DEFAULT_NAME` but rejects `bridge_name` /
+/// `Api`.
+fn is_screaming_snake_case(name: &str) -> bool {
+    name.chars().any(|c| c.is_ascii_uppercase())
+        && name.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+}
+
+/// Whether a Python def node's parent is a `decorated_definition` (so the parent arm owns its
+/// symbol span and the inner arm must not emit a duplicate).
+fn python_parent_is_decorated(node: Node<'_>) -> bool {
+    node.parent().is_some_and(|parent| parent.kind() == "decorated_definition")
+}
+
+/// Whether a Python `assignment` is at module or class scope (a constant), vs a function-local
+/// temporary. Walks ancestors to the first scope boundary: a `function_definition`/`lambda` means
+/// local (not a constant); a `class_definition`/`module` means module/class level (a constant).
+fn python_assignment_is_const_scope(node: Node<'_>) -> bool {
+    let mut ancestor = node.parent();
+    while let Some(current) = ancestor {
+        match current.kind() {
+            "function_definition" | "lambda" => return false,
+            "class_definition" | "module" => return true,
+            _ => ancestor = current.parent(),
+        }
+    }
+    false
 }
 
 fn child_name(node: Node<'_>) -> Option<Node<'_>> {
@@ -294,6 +368,8 @@ fn scope_segment(language: Language, node: Node<'_>, text: &str) -> Option<Strin
         (Language::TypeScript, "internal_module" | "module" | "namespace_declaration") =>
             child_name(node)?,
         (Language::Kotlin, "class_declaration" | "object_declaration") => child_name(node)?,
+        // Python nests methods in classes and closures in functions — both bound `scope_path`.
+        (Language::Python, "class_definition" | "function_definition") => child_name(node)?,
         (Language::Cpp, "namespace_definition") => child_name(node)?,
         (
             Language::C | Language::Cpp,
@@ -372,6 +448,10 @@ fn make_symbol(
     language: Language,
     text: &str,
     node: Node<'_>,
+    // The declaration node the SIGNATURE is read from. Equals `node` except for a decorated Python
+    // def, where `node` is the `decorated_definition` (so the chunk span includes the decorators)
+    // but the signature must come from the inner `def`/`class` line.
+    signature_node: Node<'_>,
     kind: &str,
     name: String,
 ) -> ParsedSymbol {
@@ -391,10 +471,23 @@ fn make_symbol(
         end_byte,
         start_line,
         end_line,
-        signature: signature_for(text, start_byte, end_byte),
+        signature: signature_for(text, signature_node.start_byte(), signature_node.end_byte()),
         docs: docs_before(text, start_byte),
         facts: symbol_facts(language, text, node),
     }
+}
+
+/// The node a symbol's signature is read from. For a decorated Python def this is the inner
+/// `def`/`class` (so the signature is the declaration, not the `@decorator` line the span starts
+/// at); for everything else it's the matched node itself.
+fn signature_source_node<'a>(language: Language, node: Node<'a>) -> Node<'a> {
+    if language == Language::Python
+        && node.kind() == "decorated_definition"
+        && let Some(inner) = node.child_by_field_name("definition")
+    {
+        return inner;
+    }
+    node
 }
 
 fn symbol_facts(language: Language, text: &str, node: Node<'_>) -> Vec<ParsedSymbolFact> {

--- a/crates/rag-rat-core/src/index/parser_tests.rs
+++ b/crates/rag-rat-core/src/index/parser_tests.rs
@@ -90,6 +90,52 @@ fn extracts_kotlin_symbols() {
 }
 
 #[test]
+fn extracts_python_symbols() {
+    let text = include_str!("../../../../tests/fixtures/held-mini/src/Main.py");
+    let symbols = parser::parse_symbols(Path::new("src/Main.py"), Language::Python, text).unwrap();
+    assert_eq!(parser::parser_kind(Path::new("src/Main.py"), Language::Python), ParserKind::Python);
+    assert_symbol(&symbols, "class", "Api");
+    // A decorator (`@classmethod` / `@property`) must NOT hide the inner method symbol.
+    assert_symbol(&symbols, "function", "from_url");
+    assert_symbol(&symbols, "function", "host");
+    assert_symbol(&symbols, "function", "make");
+    // SCREAMING_SNAKE_CASE module assignment is a constant…
+    assert_symbol(&symbols, "const", "DEFAULT_TIMEOUT");
+    // …but a lowercase assignment is NOT — we don't flood the symbol table with every local.
+    assert_no_symbol(&symbols, "const", "default_retries");
+    // `adapter` (a lowercase local inside `from_url`) is likewise not a symbol.
+    assert_no_symbol(&symbols, "const", "adapter");
+    // And `LOCAL_MAX` — SCREAMING_SNAKE but a FUNCTION-local — is not a constant either: the const
+    // rule is gated to module/class scope.
+    assert_no_symbol(&symbols, "const", "LOCAL_MAX");
+
+    // A decorated def's symbol span includes its decorator line (so `@classmethod` etc. — often the
+    // API surface — is in the chunk), not just the bare `def`.
+    let from_url = symbols.iter().find(|s| s.name == "from_url").unwrap();
+    let decorator_line = text.lines().position(|l| l.trim() == "@classmethod").unwrap() + 1;
+    assert_eq!(
+        from_url.start_line, decorator_line,
+        "decorated symbol span should start at the @classmethod line"
+    );
+    // …but the SIGNATURE is the `def` declaration, not the `@classmethod` decorator (it feeds
+    // logical-symbol member hashing + memory anchoring, which must key on the declaration).
+    assert_eq!(
+        from_url.signature.as_deref(),
+        Some("def from_url(cls, url: str) -> \"Api\":"),
+        "decorated signature must be the def line, not the decorator"
+    );
+}
+
+#[test]
+fn extracts_python_type_alias() {
+    // PEP 695 `type X = …` is indexed as a type symbol (like Rust/TS/C++ aliases).
+    let symbols =
+        parser::parse_symbols(Path::new("src/a.py"), Language::Python, "type UserId = int\n")
+            .unwrap();
+    assert_symbol(&symbols, "type", "UserId");
+}
+
+#[test]
 fn extracts_kotlin_kdoc_without_closing_delimiter_residue() {
     let text = r#"
 /**

--- a/crates/rag-rat-core/src/language.rs
+++ b/crates/rag-rat-core/src/language.rs
@@ -12,12 +12,20 @@ pub enum Language {
     Kotlin,
     C,
     Cpp,
+    Python,
     Markdown,
 }
 
 impl Language {
-    pub const ALL: [Self; 6] =
-        [Self::Rust, Self::TypeScript, Self::Kotlin, Self::C, Self::Cpp, Self::Markdown];
+    pub const ALL: [Self; 7] = [
+        Self::Rust,
+        Self::TypeScript,
+        Self::Kotlin,
+        Self::C,
+        Self::Cpp,
+        Self::Python,
+        Self::Markdown,
+    ];
 
     pub fn all() -> &'static [Self] {
         &Self::ALL
@@ -30,6 +38,7 @@ impl Language {
             Self::Kotlin => "kotlin",
             Self::C => "c",
             Self::Cpp => "cpp",
+            Self::Python => "python",
             Self::Markdown => "markdown",
         }
     }
@@ -41,6 +50,7 @@ impl Language {
             Self::Kotlin => &["kt", "kts"],
             Self::C => &["c", "h"],
             Self::Cpp => &["cc", "cpp", "cxx", "c++", "hh", "hpp", "hxx", "h++"],
+            Self::Python => &["py", "pyi"],
             Self::Markdown => &["md", "markdown"],
         }
     }
@@ -48,7 +58,13 @@ impl Language {
     pub fn supports_embeddings(self) -> bool {
         matches!(
             self,
-            Self::Rust | Self::TypeScript | Self::Kotlin | Self::C | Self::Cpp | Self::Markdown
+            Self::Rust
+                | Self::TypeScript
+                | Self::Kotlin
+                | Self::C
+                | Self::Cpp
+                | Self::Python
+                | Self::Markdown
         )
     }
 
@@ -74,6 +90,7 @@ impl FromStr for Language {
             "kotlin" | "kt" => Ok(Self::Kotlin),
             "c" => Ok(Self::C),
             "cpp" | "c++" | "cc" | "cxx" => Ok(Self::Cpp),
+            "python" | "py" => Ok(Self::Python),
             "markdown" | "md" => Ok(Self::Markdown),
             other => Err(LanguageError::Unknown(other.to_string())),
         }

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -109,7 +109,7 @@ impl RagRatService {
 
     #[tool(
         name = "symbol_lookup",
-        description = "Find exact or fuzzy Rust, TypeScript, Kotlin, C, or C++ symbols."
+        description = "Find exact or fuzzy Rust, TypeScript, Kotlin, C, C++, or Python symbols."
     )]
     fn symbol_lookup(
         &self,

--- a/crates/rag-rat-mcp/src/tools/catalog.rs
+++ b/crates/rag-rat-mcp/src/tools/catalog.rs
@@ -65,7 +65,7 @@ pub fn description(name: &str) -> &'static str {
              (every hit 'lexical') when no embedding model is present.",
         "symbol_lookup" =>
             "Resolve a symbol name (or ref/id) to its definition(s) in Rust, TypeScript, Kotlin, \
-             C, or C++ — exact or fuzzy. Returns candidates with signatures, locations, \
+             C, C++, or Python — exact or fuzzy. Returns candidates with signatures, locations, \
              logical-symbol grouping (cfg variants), and any bound repo memories. Use to \
              disambiguate before a graph or read call.",
         "find_callers" =>

--- a/tests/fixtures/held-mini/rag-rat.toml
+++ b/tests/fixtures/held-mini/rag-rat.toml
@@ -6,4 +6,5 @@ database = ".rag-rat/index.sqlite"
 rust = ["src"]
 typescript = ["src"]
 kotlin = ["src"]
+python = ["src"]
 markdown = ["docs"]

--- a/tests/fixtures/held-mini/src/Main.py
+++ b/tests/fixtures/held-mini/src/Main.py
@@ -1,0 +1,28 @@
+"""Python fixture mirroring Main.kt — exercises the import/alias/decorator/base-class cases that a
+naive Python edge extractor gets wrong."""
+
+from .sessions import Session as ClientSession
+from requests.adapters import HTTPAdapter
+import urllib3 as http
+
+DEFAULT_TIMEOUT = 30
+default_retries = 3
+
+
+class Api(Session):
+    """A small client built on the imported Session base class."""
+
+    @classmethod
+    def from_url(cls, url: str) -> "Api":
+        LOCAL_MAX = 5
+        adapter = HTTPAdapter()
+        http.disable_warnings()
+        return cls()
+
+    @property
+    def host(self) -> str:
+        return "example.com"
+
+
+def make():
+    return ClientSession()


### PR DESCRIPTION
Adds **Python** as a fully indexed language (tree-sitter-python) and replaces the string-prefix low-signal-chunk heuristic with **AST node-kind classification** (the brittleness the Python policy work surfaced — closes #170).

## Language + parsing
- `Language::Python` (`.py`/`.pyi`) wired through every match arm + the grammar.
- Symbols: functions, classes, **decorated defs** (the `decorated_definition` owns the chunk span so decorators are embedded, while the signature is read from the inner `def`/`class`), module/class-level **SCREAMING_SNAKE constants** (scope-gated — no lowercase-local spam), and **PEP 695 `type` aliases**.

## Graph edges
- **Calls** — `obj.method()` records a NameOnly receiver hint (never faked exact); `handlers[key]()` is not mis-recorded as the index var.
- **Imports** — module + each imported name (incl. comma/parenthesized `import_list`), never the `as` alias; relative imports normalize to their tail.
- **Inheritance** — base classes emit Implements + ReferencesType, resolving a parameterized base (`Generic[T]`) to its head and skipping `metaclass=`/splat kwargs.
- **Type references** — one recursive walker covers plain, generic (`Box[Item]`), qualified (`typing.Optional[Api]`), PEP 604 unions (`A | B`), nested (`Optional[list[Api]]`), and `Callable` param lists.
- **Decorators** — bare (`@requires_auth`) and qualified (`@pytest.fixture`, keeping the receiver) emit a call edge; parenthesized go through the call path.

## Embeddings / indexing safety
- **`is_low_signal_chunk` is AST-driven** (#170): classifies by node kind, not line prefixes — low-signal iff every top-level statement is plumbing (comment / import-include-package / bare docstring / `pass`). Robust to multi-line imports, multi-line docstrings, `#`-vs-`#define`, spacing; a symbol chunk is a definition, so never low-signal.
- The index walker **`FLOOR_DIRS` floors `.venv`/`venv`/`site-packages`/`__pycache__`**, so a `python = ["."]` config never ingests installed deps.
- `init` skips Python virtualenv/dependency trees and won't promote one as the default target.

## Surface + tests
- `symbol_lookup` MCP description + `AGENTS.md` list Python.
- held-mini `src/Main.py` fixture (bound) + ~27 Python/policy tests, including the adversarial-review finds (unions, subscript callee, nested generics, alias-not-import, metaclass filtering, decorator signature/span split). Hybrid eval (embeds held-mini) verified — no baseline regression.

## Deferred to follow-ups (resolver/init subsystems, not extraction)
#172 (Implements resolution preference), #173 (init dir-selection cosmetics), #174 (import-alias scope).

Unblocks **B6** (scip-python oracle backend).