### PR TITLE
feat(oracle): live before/after resolution report computation (C2 core)

### DIFF
--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -146,6 +146,39 @@ pub fn oracle_eval_metrics(
     run::eval_metrics(conn, tool, tool_version, commit_sha, worktree_id, recall_calls)
 }
 
+/// Assemble the typed before/after [`OracleResolutionReport`] (C2) for a just-completed run: read
+/// the heuristic "before" resolution counts + the moniker tally from the index, compute the diffed
+/// eval metrics, and map everything onto the C0 schema. `run` is the run's [`OracleReport`] (its
+/// run-only counts — `skipped_drifted`, the recall call pair — aren't reconstructable from the side
+/// tables). The SCIP `tool_version` is read from `provenance` (the single source for both the
+/// report envelope and the metric scope key). Pure data: Markdown rendering is a glue concern, not
+/// here.
+pub fn resolution_report(
+    conn: &Connection,
+    profile: &report::CorpusProfile,
+    provenance: &report::RunProvenance,
+    tool: OracleTool,
+    commit_sha: &str,
+    worktree_id: &str,
+    run: &OracleReport,
+) -> anyhow::Result<report::OracleResolutionReport> {
+    let (total_edges, resolved_in_corpus, unresolved) =
+        store::resolution_before_counts(conn, commit_sha, worktree_id)?;
+    let before = report::ResolutionBefore { total_edges, resolved_in_corpus, unresolved };
+    let symbols_with_moniker = store::count_symbols_with_moniker(conn, tool)?;
+    let recall = RecallCalls { covered: run.covered_calls, oracle_only: run.oracle_only_calls };
+    let metrics =
+        run::eval_metrics(conn, tool, &provenance.tool_version, commit_sha, worktree_id, recall)?;
+    Ok(report::OracleResolutionReport::assemble(
+        profile,
+        provenance,
+        run,
+        &metrics,
+        before,
+        symbols_with_moniker,
+    ))
+}
+
 /// Persisted oracle status for a tool/version, scoped to the active `(commit_sha, worktree_id)`
 /// checkout (the verdict counts must cover only this checkout, like the eval metrics).
 pub fn oracle_status(

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -165,7 +165,8 @@ pub fn resolution_report(
     let (total_edges, resolved_in_corpus, unresolved) =
         store::resolution_before_counts(conn, commit_sha, worktree_id)?;
     let before = report::ResolutionBefore { total_edges, resolved_in_corpus, unresolved };
-    let symbols_with_moniker = store::count_symbols_with_moniker(conn, tool)?;
+    let symbols_with_moniker =
+        store::count_symbols_with_moniker(conn, tool, &provenance.tool_version)?;
     let recall = RecallCalls { covered: run.covered_calls, oracle_only: run.oracle_only_calls };
     let metrics =
         run::eval_metrics(conn, tool, &provenance.tool_version, commit_sha, worktree_id, recall)?;

--- a/crates/rag-rat-core/src/index/oracle/report.rs
+++ b/crates/rag-rat-core/src/index/oracle/report.rs
@@ -23,7 +23,11 @@ use super::run::OracleEvalMetrics;
 /// Schema version for [`OracleResolutionReport`]. **Bump on any change to the report's shape or to
 /// the semantics of a field** (e.g. a denominator redefinition). A Δ consumer must refuse to diff
 /// two reports whose `report_schema_version` differ — the numbers are no longer comparable.
-pub const REPORT_SCHEMA_VERSION: u32 = 1;
+///
+/// v2: `resolved_before`/`resolved_after` are defined as the join's `heuristic_resolved_in_corpus`
+/// (Exact/Syntactic confidence with a resolved in-corpus symbol), correcting the v1 wording
+/// ("exact + same-file-name") to match the live computation. (#168 review.)
+pub const REPORT_SCHEMA_VERSION: u32 = 2;
 
 /// Per-corpus health thresholds. The runner fails a corpus whose oracle run falls outside these
 /// even when the underlying command exits 0 — catching "scip emitted almost nothing" / "venv didn't

--- a/crates/rag-rat-core/src/index/oracle/report.rs
+++ b/crates/rag-rat-core/src/index/oracle/report.rs
@@ -99,15 +99,16 @@ pub struct RunProvenance {
 }
 
 /// Heuristic "before" vs compiler "after" edge resolution. `resolved_before` is the heuristic's
-/// in-corpus resolutions (exact + same-file-name); `resolved_after` adds the oracle's recoveries
-/// (`upgraded` in-corpus + `resolved_external`). Denominator is `total_edges` (edge candidates
-/// carrying a callee range) for both rates — stated here so it is part of the contract, not an
-/// implementation detail.
+/// in-corpus resolutions — `Exact`/`Syntactic` confidence with a resolved in-corpus symbol, the
+/// same `heuristic_resolved_in_corpus` definition the join uses; `resolved_after` adds the oracle's
+/// recoveries (`upgraded` in-corpus + `resolved_external`). Denominator is `total_edges` (edge
+/// candidates carrying a callee range) for both rates — stated here so it is part of the contract,
+/// not an implementation detail.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 pub struct ResolutionDelta {
     /// Edge candidates with a callee range — the denominator for both resolved rates.
     pub total_edges: u64,
-    /// Heuristic in-corpus resolutions before the oracle (exact + same-file-name).
+    /// Heuristic in-corpus resolutions before the oracle (Exact/Syntactic + resolved in-corpus).
     pub resolved_before: u64,
     /// `resolved_before` + oracle upgrades (in-corpus) + resolved-external.
     pub resolved_after: u64,

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -32,6 +32,60 @@ pub(crate) fn active_checkout_file_predicate(sha_param: &str, wt_param: &str) ->
     )
 }
 
+/// The heuristic "before" resolution counts over the active checkout's edge candidates (those with
+/// a callee range — the oracle's `edges_examined` population). `(total, resolved_in_corpus,
+/// unresolved)`:
+/// - `resolved_in_corpus` mirrors the join's [`super::join`] `heuristic_resolved_in_corpus`:
+///   confidence `Exact`/`Syntactic` AND a non-NULL `to_symbol_id`. Same definition both sides, so
+///   `resolved_after = resolved_before + upgraded + resolved_external` is consistent.
+/// - `unresolved` is the low-confidence (`NameOnly`/`Ambiguous`) population (the oracle's
+///   upgrade/recovery denominator).
+pub(crate) fn resolution_before_counts(
+    conn: &Connection,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<(u64, u64, u64)> {
+    let scope = active_checkout_file_predicate("?1", "?2");
+    let (total, resolved, unresolved): (i64, i64, i64) = conn.query_row(
+        &format!(
+            "
+        SELECT
+          COUNT(*),
+          COUNT(*) FILTER (
+            WHERE edges.confidence IN ('Exact', 'Syntactic') AND edges.to_symbol_id IS NOT NULL
+          ),
+          COUNT(*) FILTER (WHERE edges.confidence IN ('NameOnly', 'Ambiguous'))
+        FROM edges
+        JOIN files ON files.id = edges.source_file_id
+        WHERE edges.callee_start_byte IS NOT NULL
+          AND {scope}
+        ",
+        ),
+        params![commit_sha, worktree_id],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )?;
+    Ok((
+        u64::try_from(total).unwrap_or(0),
+        u64::try_from(resolved).unwrap_or(0),
+        u64::try_from(unresolved).unwrap_or(0),
+    ))
+}
+
+/// The number of logical symbols enriched with a SCIP moniker for `tool` — the "symbols enriched"
+/// signal (#70). `logical_symbol_monikers` is keyed `(logical_symbol_id, tool)` and is not
+/// checkout-scoped (logical symbols are repo-global), so this is a straight per-tool count.
+pub(crate) fn count_symbols_with_moniker(
+    conn: &Connection,
+    tool: OracleTool,
+) -> anyhow::Result<u64> {
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM logical_symbol_monikers WHERE tool = ?1",
+        params![tool.as_db_str()],
+        |row| row.get(0),
+    )?;
+    Ok(u64::try_from(count).unwrap_or(0))
+}
+
 /// An edge candidate to feed the oracle join: the callee identifier byte range (the SCIP key, #67)
 /// plus enough context to write a verdict and to recognise agreement/disagreement.
 #[derive(Debug, Clone)]

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -58,6 +58,7 @@ pub(crate) fn resolution_before_counts(
         FROM edges
         JOIN files ON files.id = edges.source_file_id
         WHERE edges.callee_start_byte IS NOT NULL
+          AND edges.callee_end_byte IS NOT NULL
           AND {scope}
         ",
         ),
@@ -71,16 +72,20 @@ pub(crate) fn resolution_before_counts(
     ))
 }
 
-/// The number of logical symbols enriched with a SCIP moniker for `tool` — the "symbols enriched"
-/// signal (#70). `logical_symbol_monikers` is keyed `(logical_symbol_id, tool)` and is not
-/// checkout-scoped (logical symbols are repo-global), so this is a straight per-tool count.
+/// The number of logical symbols enriched with a SCIP moniker for `(tool, tool_version)` — the
+/// "symbols enriched" signal (#70). Scoped to `tool_version` (not just `tool`) so the count
+/// describes the SAME run as the report's `edge_oracle`-derived metrics: a later same-tool run with
+/// a different `tool_version` must not bleed its monikers into this report.
+/// `logical_symbol_monikers` is keyed `(logical_symbol_id, tool)` (repo-global, not
+/// checkout-scoped).
 pub(crate) fn count_symbols_with_moniker(
     conn: &Connection,
     tool: OracleTool,
+    tool_version: &str,
 ) -> anyhow::Result<u64> {
     let count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM logical_symbol_monikers WHERE tool = ?1",
-        params![tool.as_db_str()],
+        "SELECT COUNT(*) FROM logical_symbol_monikers WHERE tool = ?1 AND tool_version = ?2",
+        params![tool.as_db_str(), tool_version],
         |row| row.get(0),
     )?;
     Ok(u64::try_from(count).unwrap_or(0))

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -4089,3 +4089,120 @@ fn or_branch_name_predicates_use_the_to_name_index() {
         "plain to_name equality must use the int index, got plan:\n{simple}"
     );
 }
+
+/// C2 live before/after report: the heuristic "before" counts come from the `edges` index, the
+/// after-side verdict counts + run-only fields come from the run's `OracleReport`, the precision/
+/// recall come from diffing `edge_oracle`, and the moniker tally from `logical_symbol_monikers` —
+/// all stamped onto the C0 schema with the caller's profile + provenance.
+#[test]
+fn resolution_report_assembles_before_after_from_index() {
+    let h = Harness::new();
+    let f = h.add_file("a.rs", "fn caller() {}\n");
+
+    // Heuristic "before": four Exact edges resolved to an in-corpus symbol (resolved_before = 4),
+    // three NameOnly edges (unresolved_before = 3); total_edges = 7 (all carry a callee range).
+    let target = h.add_symbol(f, "target", 3, 9);
+    h.add_edge(f, "target", 14, 20, "Exact", Some(target));
+    h.add_edge(f, "other", 21, 26, "Exact", Some(target));
+    let up = h.add_edge(f, "up", 30, 32, "NameOnly", None);
+    let ext = h.add_edge(f, "ext", 33, 36, "NameOnly", None);
+    let _plain = h.add_edge(f, "plain", 37, 42, "NameOnly", None);
+    let conf_sym = h.add_symbol(f, "conf", 43, 47);
+    let conf = h.add_edge(f, "conf", 48, 52, "Exact", Some(conf_sym));
+    let contra_sym = h.add_symbol(f, "contra", 53, 59);
+    let contra = h.add_edge(f, "contra", 60, 66, "Exact", Some(contra_sym));
+
+    // Oracle verdicts: Upgrade + ResolvedExternal on the NameOnly edges; Confirm + Contradict on
+    // two Exact edges → precision = 1 / (1 + 1) = 0.5.
+    let file_sha: String = h
+        .conn
+        .query_row("SELECT sha256 FROM files WHERE id = ?1", params![f], |r| r.get(0))
+        .unwrap();
+    let write = |edge: i64, kind: OracleResolutionKind, resolved: Option<i64>| {
+        store::write_edge_oracle(&h.conn, TOOL, VERSION, &EdgeOracleRow {
+            edge_id: edge,
+            file_sha: &file_sha,
+            resolved_symbol_id: resolved,
+            scip_symbol: "scip x `t`().",
+            kind,
+        })
+        .unwrap();
+    };
+    write(up, OracleResolutionKind::Upgrade, Some(target));
+    write(ext, OracleResolutionKind::ResolvedExternal, None);
+    write(conf, OracleResolutionKind::Confirm, Some(conf_sym));
+    write(contra, OracleResolutionKind::Contradict, Some(contra_sym));
+
+    // Two logical symbols enriched with a moniker for this tool.
+    for id in [1_i64, 2] {
+        h.conn
+            .execute(
+                "INSERT INTO logical_symbol_monikers(logical_symbol_id, tool, tool_version, \
+                 moniker, computed_at) VALUES (?1, ?2, ?3, ?4, 0)",
+                params![id, TOOL.as_db_str(), VERSION, format!("m{id}")],
+            )
+            .unwrap();
+    }
+
+    let mut bindings = std::collections::BTreeMap::new();
+    bindings.insert("rust".to_string(), vec!["src".to_string()]);
+    let profile = super::CorpusProfile {
+        corpus_id: "rust-test".to_string(),
+        tier: "small".to_string(),
+        repo: "r".to_string(),
+        rev: "1".to_string(),
+        tool: TOOL.as_db_str().to_string(),
+        prepare: Vec::new(),
+        bindings,
+        health: super::CorpusHealth {
+            expected_min_heuristic_edges: 1,
+            expected_min_oracle_examined: 1,
+            expected_max_skipped_drifted: 0,
+            expected_min_symbols_with_moniker: 1,
+            timeout_minutes: 8,
+        },
+    };
+    // `tool_version` MUST match the VERSION the verdicts were written under — it's the metric scope
+    // key as well as the report envelope's provenance.
+    let provenance = super::RunProvenance {
+        tool_version: VERSION.to_string(),
+        rag_rat_commit: "commit".to_string(),
+        worktree_id: WORKTREE.to_string(),
+        production_sha: "prod".to_string(),
+    };
+    let run = super::OracleReport {
+        upgraded: 1,
+        resolved_external: 1,
+        confirmed: 1,
+        contradicted: 1,
+        covered_calls: 8,
+        oracle_only_calls: 2,
+        skipped_drifted: 2,
+        monikers_written: 2,
+        ..Default::default()
+    };
+
+    let report =
+        super::resolution_report(&h.conn, &profile, &provenance, TOOL, COMMIT, WORKTREE, &run)
+            .unwrap();
+
+    // Before/after resolution.
+    assert_eq!(report.resolution.total_edges, 7);
+    assert_eq!(report.resolution.resolved_before, 4);
+    assert_eq!(report.resolution.unresolved_before, 3);
+    assert_eq!(report.resolution.resolved_after, 4 + 1 + 1);
+    // Verdict transitions (from the run) + moniker tally (from the index) + run-only drift.
+    assert_eq!(report.upgraded, 1);
+    assert_eq!(report.resolved_external, 1);
+    assert_eq!(report.confirmed, 1);
+    assert_eq!(report.contradicted, 1);
+    assert_eq!(report.symbols_with_moniker, 2);
+    assert_eq!(report.skipped_drifted, 2);
+    // Diffed metrics: precision 1/(1+1), recall covered/(covered+oracle_only) = 8/10.
+    assert!((report.metrics.precision - 0.5).abs() < 1e-9, "precision: {report:?}");
+    assert!((report.metrics.recall - 0.8).abs() < 1e-9, "recall: {report:?}");
+    // Envelope.
+    assert_eq!(report.corpus_profile_hash, profile.hash());
+    assert_eq!(report.tool_version, VERSION);
+    assert_eq!(report.tool, TOOL.as_db_str());
+}

--- a/crates/rag-rat-core/src/index/query_api/oracle_runs.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_runs.rs
@@ -107,6 +107,29 @@ impl IndexDatabase {
         )
     }
 
+    /// Assemble the typed before/after [`oracle::OracleResolutionReport`] (C2) for a just-completed
+    /// run over this checkout: the heuristic "before" resolution counts + moniker tally are read
+    /// from the index, the eval metrics are diffed from `edge_oracle`, and everything is stamped
+    /// onto the C0 schema with the caller's `profile` + `provenance`. `run` is the just-produced
+    /// [`OracleReport`] (its run-only counts can't be reconstructed from the side tables).
+    pub fn resolution_report(
+        &self,
+        profile: &oracle::CorpusProfile,
+        provenance: &oracle::RunProvenance,
+        tool: OracleTool,
+        run: &OracleReport,
+    ) -> anyhow::Result<oracle::OracleResolutionReport> {
+        oracle::resolution_report(
+            self.storage.connection(),
+            profile,
+            provenance,
+            tool,
+            &self.active_commit_sha,
+            &self.active_worktree_id,
+            run,
+        )
+    }
+
     /// Persisted oracle status (verdict counts + last run) for a tool/version, scoped to this
     /// database's active `(commit_sha, worktree_id)` checkout.
     pub fn oracle_status(


### PR DESCRIPTION
C2 of #164 — the live computation behind the C0 contract (#166, merged). Builds on the locked `OracleResolutionReport` schema.

## What
- **`store::resolution_before_counts`** — the heuristic 'before' counts over the active checkout's edge candidates: total (callee range present), `resolved_in_corpus` (Exact/Syntactic + `to_symbol_id`, matching the join's `heuristic_resolved_in_corpus` so before/after are consistent), unresolved (NameOnly/Ambiguous). One scoped query.
- **`store::count_symbols_with_moniker`** — per-tool `logical_symbol_monikers` tally (the 'symbols enriched' signal; re-run-safe, unlike `monikers_written`).
- **`oracle::resolution_report` + `IndexDatabase::resolution_report`** — read the before counts + moniker tally, diff the eval metrics from `edge_oracle`, and assemble the report. `tool_version` is sourced once from `provenance` and used for both the envelope and the metric scope key.
- **Fixture-DB test** over a synthetic edges + edge_oracle + monikers DB asserting the full path: before/after counts, every verdict transition, moniker tally, `skipped_drifted`, and precision/recall.
- Tightened the C0 `ResolutionDelta` doc to the actual definition (Exact/Syntactic + in-corpus, not 'same-file-name').

## Not in scope (remaining C2 slice)
The `rag-rat oracle report` **CLI surface** + **BMF derivation** — gated on **C1**'s corpus-profile file, since the report needs a `CorpusProfile` to stamp. `IndexDatabase::resolution_report` is the API the CLI/runner will call; the corpus file feeds the profile.

445 core tests green, clippy clean in both feature shapes, nightly fmt clean.