### PR TITLE
chore(ci): workflow_dispatch on bench.yml to reapply Bencher thresholds on demand

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,6 +9,10 @@ name: bench
 on:
   push:
     branches: [main]
+  # Manual trigger to REAPPLY the Bencher thresholds (this job runs `bencher run --thresholds-reset`
+  # on `main`). Use it when the baseline drifts or thresholds get into a bad state without waiting
+  # for the next push to main — PR runs clone `main`'s thresholds via `--start-point-clone-thresholds`.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -34,6 +34,10 @@ env:
 jobs:
   bench:
     runs-on: ubuntu-latest
+    # The publish steps below hardcode `--branch main --thresholds-reset`, so this job must only run
+    # against main — a manual dispatch from a feature ref would otherwise reset main's baseline with
+    # non-main results. The push trigger is already main-only; this guards the workflow_dispatch ref.
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
The bench job reapplies the Bencher thresholds (`bencher run --thresholds-reset` on `main`) **only on push to main**, so a drifted/bad threshold baseline (which makes PR bench checks fail spuriously — e.g. #167) can't be reapplied without a code push.

Add `workflow_dispatch` so thresholds can be reapplied on demand: **Actions → bench → Run workflow** (on `main`) re-establishes the baseline that PR runs clone via `--start-point-clone-thresholds`.

No behavior change to the push path.