### PR TITLE
feat(oracle): corpus profiles + health-gate loader (C1)

### DIFF
--- a/crates/rag-rat-core/src/index/oracle/corpus.rs
+++ b/crates/rag-rat-core/src/index/oracle/corpus.rs
@@ -17,9 +17,17 @@ struct CorpusFile {
     corpus: Vec<CorpusProfile>,
 }
 
-/// Parse the corpus profiles from an `oracle-corpora.toml` string.
+/// Parse the corpus profiles from an `oracle-corpora.toml` string. Fails closed on an empty result:
+/// a typo'd table name (`[[corpora]]` instead of `[[corpus]]`) deserializes to zero corpora, which
+/// would silently turn the CI matrix into a no-op and skip the health gate — so require at least
+/// one.
 pub fn load_corpora(toml_str: &str) -> anyhow::Result<Vec<CorpusProfile>> {
-    Ok(toml::from_str::<CorpusFile>(toml_str)?.corpus)
+    let corpora = toml::from_str::<CorpusFile>(toml_str)?.corpus;
+    anyhow::ensure!(
+        !corpora.is_empty(),
+        "oracle-corpora.toml has no [[corpus]] entries (wrong table name?)"
+    );
+    Ok(corpora)
 }
 
 /// The corpus with this id, if any.
@@ -101,44 +109,83 @@ mod tests {
         OracleEvalMetrics, OracleReport, ResolutionBefore, ResolutionDelta, RunProvenance,
     };
 
-    const CORPORA: &str = include_str!("../../../../../tools/oracle-corpora.toml");
+    // Inline sample for the deterministic logic/health tests — kept IN-CRATE so they're packaging-
+    // safe (no `include_str!` of a file outside the `rag-rat-core` package). The committed
+    // `tools/oracle-corpora.toml` is validated separately at runtime (`committed_corpora_file`).
+    const SAMPLE: &str = r#"
+[[corpus]]
+corpus_id = "rust-semver"
+tier      = "small"
+repo      = "https://github.com/dtolnay/semver"
+rev       = "1.0.26"
+tool      = "rust-analyzer"
+prepare   = ["cargo fetch"]
+bindings  = { rust = ["src"] }
+health    = { expected_min_heuristic_edges = 50, expected_min_oracle_examined = 20, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 10, timeout_minutes = 8 }
 
-    #[test]
-    fn committed_corpora_load_with_expected_ids_and_tiers() {
-        let corpora = load_corpora(CORPORA).unwrap();
-        let ids: Vec<&str> = corpora.iter().map(|c| c.corpus_id.as_str()).collect();
-        assert_eq!(ids, ["rust-semver", "c-cjson", "py-requests", "rust-cargo", "linux-kernel"]);
+[[corpus]]
+corpus_id = "linux-kernel"
+tier      = "heavy"
+repo      = "https://github.com/torvalds/linux"
+rev       = "v7.0"
+tool      = "scip-clang"
+prepare   = ["make defconfig"]
+bindings  = { c = ["."] }
+health    = { expected_min_heuristic_edges = 50000, expected_min_oracle_examined = 5000, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 1000, timeout_minutes = 120 }
+"#;
 
-        let small: Vec<&str> =
-            corpora_for_tier(&corpora, "small").iter().map(|c| c.corpus_id.as_str()).collect();
-        assert_eq!(small, ["rust-semver", "c-cjson", "py-requests"]);
-        let heavy: Vec<&str> =
-            corpora_for_tier(&corpora, "heavy").iter().map(|c| c.corpus_id.as_str()).collect();
-        assert_eq!(heavy, ["rust-cargo", "linux-kernel"]);
-
-        let requests = corpus_by_id(&corpora, "py-requests").unwrap();
-        assert_eq!(requests.tool, "scip-python");
-        assert_eq!(requests.bindings.get("python"), Some(&vec!["src/requests".to_string()]));
+    /// Path to the committed corpora file (repo `tools/`), relative to this crate's manifest.
+    fn committed_corpora_path() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tools/oracle-corpora.toml")
     }
 
     #[test]
-    fn committed_corpus_profile_hashes_are_pinned() {
-        // GOLDEN: pin each committed profile's hash. An edit to any corpus field changes its hash
-        // (and makes prior reports incomparable) — recompute deliberately when the change is
-        // intended. This is the review tripwire for an accidental corpus/threshold edit.
-        let corpora = load_corpora(CORPORA).unwrap();
-        let hashes: Vec<(String, String)> =
-            corpora.iter().map(|c| (c.corpus_id.clone(), c.hash())).collect();
+    fn load_rejects_empty_or_misnamed_corpus_array() {
+        // A typo'd table name parses to zero corpora — must fail closed, not yield a no-op matrix.
+        assert!(load_corpora("[[corpora]]\ncorpus_id = \"x\"\n").is_err());
+        assert!(load_corpora("").is_err());
+    }
+
+    #[test]
+    fn sample_loads_and_selects_by_id_and_tier() {
+        let corpora = load_corpora(SAMPLE).unwrap();
+        let small: Vec<&str> =
+            corpora_for_tier(&corpora, "small").iter().map(|c| c.corpus_id.as_str()).collect();
+        assert_eq!(small, ["rust-semver"]);
+        let heavy: Vec<&str> =
+            corpora_for_tier(&corpora, "heavy").iter().map(|c| c.corpus_id.as_str()).collect();
+        assert_eq!(heavy, ["linux-kernel"]);
+        assert!(corpus_by_id(&corpora, "nope").is_none());
+    }
+
+    /// Runtime-fs (not `include_str!`) so the crate stays packaging-safe: the committed file lives
+    /// in the repo `tools/`, outside the published crate. Skips when absent (e.g. a packaged
+    /// crate); when present it's the review tripwire — the committed corpora's ids/tiers +
+    /// golden hashes.
+    #[test]
+    fn committed_corpora_file() {
+        let Ok(toml_str) = std::fs::read_to_string(committed_corpora_path()) else {
+            return; // not in a repo checkout (packaged crate) — nothing to validate.
+        };
+        let corpora = load_corpora(&toml_str).unwrap();
+        let ids: Vec<&str> = corpora.iter().map(|c| c.corpus_id.as_str()).collect();
+        assert_eq!(ids, ["rust-semver", "c-cjson", "py-requests", "rust-cargo", "linux-kernel"]);
+        assert_eq!(corpus_by_id(&corpora, "py-requests").unwrap().tool, "scip-python");
+
+        // GOLDEN per-profile hashes: an edit to any corpus field changes its hash (and makes prior
+        // reports incomparable) — recompute deliberately when intended.
+        let hashes: Vec<(&str, String)> =
+            corpora.iter().map(|c| (c.corpus_id.as_str(), c.hash())).collect();
         assert_eq!(hashes, vec![
-            ("rust-semver".to_string(), GOLDEN_RUST_SEMVER.to_string()),
-            ("c-cjson".to_string(), GOLDEN_C_CJSON.to_string()),
-            ("py-requests".to_string(), GOLDEN_PY_REQUESTS.to_string()),
-            ("rust-cargo".to_string(), GOLDEN_RUST_CARGO.to_string()),
-            ("linux-kernel".to_string(), GOLDEN_LINUX_KERNEL.to_string()),
+            ("rust-semver", GOLDEN_RUST_SEMVER.to_string()),
+            ("c-cjson", GOLDEN_C_CJSON.to_string()),
+            ("py-requests", GOLDEN_PY_REQUESTS.to_string()),
+            ("rust-cargo", GOLDEN_RUST_CARGO.to_string()),
+            ("linux-kernel", GOLDEN_LINUX_KERNEL.to_string()),
         ]);
     }
 
-    // Filled in from the first test run (see `committed_corpus_profile_hashes_are_pinned`).
+    // Pinned from the committed `tools/oracle-corpora.toml` (see `committed_corpora_file`).
     const GOLDEN_RUST_SEMVER: &str =
         "7973c3d62bbea9fbbdf3d7a4380fb7d9ccdbf2659a3503c9267eb9f9f329bb97";
     const GOLDEN_C_CJSON: &str = "685a33345247c2ef310b7671fb9e2a55a7cb7c577fcd29fecac436ff0634c9dc";
@@ -147,7 +194,7 @@ mod tests {
     const GOLDEN_RUST_CARGO: &str =
         "60452736340151a253001bb5c33cc83efa2a4ceabba4d42a227d3188d7761d79";
     const GOLDEN_LINUX_KERNEL: &str =
-        "5c075d0a7847a063e7a6a0439e108e804700d154223ce9eedbf74d98448d0f15";
+        "abf87f3dca38d79ad6239348659c13ca484c70f2197fd36e3a7e1f97e27165ff";
 
     fn report_with(
         total_edges: u64,
@@ -155,7 +202,7 @@ mod tests {
         skipped_drifted: u64,
         monikers: u64,
     ) -> OracleResolutionReport {
-        let profile = corpus_by_id(&load_corpora(CORPORA).unwrap(), "rust-semver").unwrap().clone();
+        let profile = corpus_by_id(&load_corpora(SAMPLE).unwrap(), "rust-semver").unwrap().clone();
         // Split `verdicts` across the four kinds arbitrarily (the gate sums them).
         let run = OracleReport {
             confirmed: verdicts,
@@ -180,7 +227,7 @@ mod tests {
 
     #[test]
     fn healthy_report_has_no_violations() {
-        let profile = corpus_by_id(&load_corpora(CORPORA).unwrap(), "rust-semver").unwrap().clone();
+        let profile = corpus_by_id(&load_corpora(SAMPLE).unwrap(), "rust-semver").unwrap().clone();
         // edges 100>=50, verdicts 30>=20, drift 0<=0, monikers 15>=10.
         let report = report_with(100, 30, 0, 15);
         assert!(check_corpus_health(&profile, &report).is_empty());
@@ -188,7 +235,7 @@ mod tests {
 
     #[test]
     fn each_threshold_violation_is_reported() {
-        let profile = corpus_by_id(&load_corpora(CORPORA).unwrap(), "rust-semver").unwrap().clone();
+        let profile = corpus_by_id(&load_corpora(SAMPLE).unwrap(), "rust-semver").unwrap().clone();
         // All four below/over threshold.
         let report = report_with(10, 5, 3, 2);
         let checks: Vec<&str> =

--- a/crates/rag-rat-core/src/index/oracle/corpus.rs
+++ b/crates/rag-rat-core/src/index/oracle/corpus.rs
@@ -1,0 +1,203 @@
+//! Corpus profiles for the multi-language SCIP-oracle runner (#164, C1): load the declarative
+//! `tools/oracle-corpora.toml`, select corpora by id / tier, and evaluate one run's report against
+//! its corpus health thresholds — the **fail-on-nonsense gate** that catches "scip emitted almost
+//! nothing" / "venv didn't resolve deps" / a broken parse even when the underlying command exits 0.
+//!
+//! Pure data + logic: parsing a provided string and comparing numbers. The CLI / shell runner do
+//! the I/O (read the file, clone the repo, run the oracle) and act on the returned violations.
+
+use serde::Deserialize;
+
+use super::report::{CorpusProfile, OracleResolutionReport};
+
+/// The `[[corpus]]` array shape of `oracle-corpora.toml`.
+#[derive(Debug, Clone, Deserialize)]
+struct CorpusFile {
+    #[serde(default)]
+    corpus: Vec<CorpusProfile>,
+}
+
+/// Parse the corpus profiles from an `oracle-corpora.toml` string.
+pub fn load_corpora(toml_str: &str) -> anyhow::Result<Vec<CorpusProfile>> {
+    Ok(toml::from_str::<CorpusFile>(toml_str)?.corpus)
+}
+
+/// The corpus with this id, if any.
+pub fn corpus_by_id<'a>(corpora: &'a [CorpusProfile], id: &str) -> Option<&'a CorpusProfile> {
+    corpora.iter().find(|corpus| corpus.corpus_id == id)
+}
+
+/// The corpora in a tier (`"small"` for the per-PR matrix, `"heavy"` for release/Bencher).
+pub fn corpora_for_tier<'a>(corpora: &'a [CorpusProfile], tier: &str) -> Vec<&'a CorpusProfile> {
+    corpora.iter().filter(|corpus| corpus.tier == tier).collect()
+}
+
+/// One failed health threshold. A non-empty list means the run is untrustworthy and the runner must
+/// exit non-zero, even if the oracle command itself succeeded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HealthViolation {
+    /// The threshold name (stable, for machine/log use).
+    pub check: &'static str,
+    /// `actual vs expected` detail for the human-facing message.
+    pub detail: String,
+}
+
+/// Evaluate a run's [`OracleResolutionReport`] against the corpus's health thresholds. Empty result
+/// = healthy. `timeout_minutes` is enforced by the runner around the whole run (wall-clock), not
+/// here — this checks only what the report carries.
+pub fn check_corpus_health(
+    profile: &CorpusProfile,
+    report: &OracleResolutionReport,
+) -> Vec<HealthViolation> {
+    let health = &profile.health;
+    let mut violations = Vec::new();
+
+    // Edge candidates the heuristic produced — near-zero means a broken parse / empty index.
+    let edges = report.resolution.total_edges;
+    if edges < health.expected_min_heuristic_edges {
+        violations.push(HealthViolation {
+            check: "min_heuristic_edges",
+            detail: format!("{edges} < {}", health.expected_min_heuristic_edges),
+        });
+    }
+
+    // Verdicts the oracle produced (the edges it actually had an opinion on) — near-zero means the
+    // SCIP index resolved almost nothing (e.g. a tool failure or, for Python, an unresolved venv).
+    let examined =
+        report.confirmed + report.contradicted + report.upgraded + report.resolved_external;
+    if examined < health.expected_min_oracle_examined {
+        violations.push(HealthViolation {
+            check: "min_oracle_examined",
+            detail: format!("{examined} < {}", health.expected_min_oracle_examined),
+        });
+    }
+
+    // Drift means the SCIP and the index disagree on file content — the numbers are untrustworthy.
+    if report.skipped_drifted > health.expected_max_skipped_drifted {
+        violations.push(HealthViolation {
+            check: "max_skipped_drifted",
+            detail: format!("{} > {}", report.skipped_drifted, health.expected_max_skipped_drifted),
+        });
+    }
+
+    // Symbols the SCIP enriched with a moniker — the canonical "did the tool resolve deps" signal.
+    if report.symbols_with_moniker < health.expected_min_symbols_with_moniker {
+        violations.push(HealthViolation {
+            check: "min_symbols_with_moniker",
+            detail: format!(
+                "{} < {}",
+                report.symbols_with_moniker, health.expected_min_symbols_with_moniker
+            ),
+        });
+    }
+
+    violations
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::index::oracle::{
+        OracleEvalMetrics, OracleReport, ResolutionBefore, ResolutionDelta, RunProvenance,
+    };
+
+    const CORPORA: &str = include_str!("../../../../../tools/oracle-corpora.toml");
+
+    #[test]
+    fn committed_corpora_load_with_expected_ids_and_tiers() {
+        let corpora = load_corpora(CORPORA).unwrap();
+        let ids: Vec<&str> = corpora.iter().map(|c| c.corpus_id.as_str()).collect();
+        assert_eq!(ids, ["rust-semver", "c-cjson", "py-requests", "rust-cargo", "linux-kernel"]);
+
+        let small: Vec<&str> =
+            corpora_for_tier(&corpora, "small").iter().map(|c| c.corpus_id.as_str()).collect();
+        assert_eq!(small, ["rust-semver", "c-cjson", "py-requests"]);
+        let heavy: Vec<&str> =
+            corpora_for_tier(&corpora, "heavy").iter().map(|c| c.corpus_id.as_str()).collect();
+        assert_eq!(heavy, ["rust-cargo", "linux-kernel"]);
+
+        let requests = corpus_by_id(&corpora, "py-requests").unwrap();
+        assert_eq!(requests.tool, "scip-python");
+        assert_eq!(requests.bindings.get("python"), Some(&vec!["src/requests".to_string()]));
+    }
+
+    #[test]
+    fn committed_corpus_profile_hashes_are_pinned() {
+        // GOLDEN: pin each committed profile's hash. An edit to any corpus field changes its hash
+        // (and makes prior reports incomparable) — recompute deliberately when the change is
+        // intended. This is the review tripwire for an accidental corpus/threshold edit.
+        let corpora = load_corpora(CORPORA).unwrap();
+        let hashes: Vec<(String, String)> =
+            corpora.iter().map(|c| (c.corpus_id.clone(), c.hash())).collect();
+        assert_eq!(hashes, vec![
+            ("rust-semver".to_string(), GOLDEN_RUST_SEMVER.to_string()),
+            ("c-cjson".to_string(), GOLDEN_C_CJSON.to_string()),
+            ("py-requests".to_string(), GOLDEN_PY_REQUESTS.to_string()),
+            ("rust-cargo".to_string(), GOLDEN_RUST_CARGO.to_string()),
+            ("linux-kernel".to_string(), GOLDEN_LINUX_KERNEL.to_string()),
+        ]);
+    }
+
+    // Filled in from the first test run (see `committed_corpus_profile_hashes_are_pinned`).
+    const GOLDEN_RUST_SEMVER: &str =
+        "7973c3d62bbea9fbbdf3d7a4380fb7d9ccdbf2659a3503c9267eb9f9f329bb97";
+    const GOLDEN_C_CJSON: &str = "685a33345247c2ef310b7671fb9e2a55a7cb7c577fcd29fecac436ff0634c9dc";
+    const GOLDEN_PY_REQUESTS: &str =
+        "76abdb4592d1e1997f133fb5cd185d85b57851e8a82e085268e45d4d16c2c832";
+    const GOLDEN_RUST_CARGO: &str =
+        "60452736340151a253001bb5c33cc83efa2a4ceabba4d42a227d3188d7761d79";
+    const GOLDEN_LINUX_KERNEL: &str =
+        "5c075d0a7847a063e7a6a0439e108e804700d154223ce9eedbf74d98448d0f15";
+
+    fn report_with(
+        total_edges: u64,
+        verdicts: u64,
+        skipped_drifted: u64,
+        monikers: u64,
+    ) -> OracleResolutionReport {
+        let profile = corpus_by_id(&load_corpora(CORPORA).unwrap(), "rust-semver").unwrap().clone();
+        // Split `verdicts` across the four kinds arbitrarily (the gate sums them).
+        let run = OracleReport {
+            confirmed: verdicts,
+            skipped_drifted,
+            monikers_written: monikers,
+            ..Default::default()
+        };
+        let before =
+            ResolutionBefore { total_edges, resolved_in_corpus: 0, unresolved: total_edges };
+        let mut report = OracleResolutionReport::assemble(
+            &profile,
+            &RunProvenance::default(),
+            &run,
+            &OracleEvalMetrics::default(),
+            before,
+            monikers,
+        );
+        // `assemble` derives `resolution` from `before`; ensure total_edges is what we set.
+        report.resolution = ResolutionDelta { total_edges, ..report.resolution };
+        report
+    }
+
+    #[test]
+    fn healthy_report_has_no_violations() {
+        let profile = corpus_by_id(&load_corpora(CORPORA).unwrap(), "rust-semver").unwrap().clone();
+        // edges 100>=50, verdicts 30>=20, drift 0<=0, monikers 15>=10.
+        let report = report_with(100, 30, 0, 15);
+        assert!(check_corpus_health(&profile, &report).is_empty());
+    }
+
+    #[test]
+    fn each_threshold_violation_is_reported() {
+        let profile = corpus_by_id(&load_corpora(CORPORA).unwrap(), "rust-semver").unwrap().clone();
+        // All four below/over threshold.
+        let report = report_with(10, 5, 3, 2);
+        let checks: Vec<&str> =
+            check_corpus_health(&profile, &report).iter().map(|v| v.check).collect();
+        assert_eq!(checks, [
+            "min_heuristic_edges",
+            "min_oracle_examined",
+            "max_skipped_drifted",
+            "min_symbols_with_moniker",
+        ]);
+    }
+}

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -19,6 +19,7 @@
 //! - `store.rs` — `oracle_runs` / `edge_oracle` read + write helpers.
 
 mod auto_run;
+mod corpus;
 mod join;
 mod manifest;
 mod report;
@@ -33,6 +34,9 @@ use std::collections::HashMap;
 use std::path::Path;
 
 pub use auto_run::{AutoRunDecision, AutoRunInputs, auto_run_decision};
+pub use corpus::{
+    HealthViolation, check_corpus_health, corpora_for_tier, corpus_by_id, load_corpora,
+};
 pub(crate) use join::package_of;
 pub use manifest::{ToolAvailability, ToolManifest};
 pub use report::{

--- a/crates/rag-rat-core/src/index/oracle/report.rs
+++ b/crates/rag-rat-core/src/index/oracle/report.rs
@@ -14,7 +14,7 @@
 
 use std::collections::BTreeMap;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use super::OracleReport;
@@ -33,7 +33,7 @@ pub const REPORT_SCHEMA_VERSION: u32 = 2;
 /// even when the underlying command exits 0 — catching "scip emitted almost nothing" / "venv didn't
 /// resolve deps" / a silently-broken parse. Part of the profile, so it is covered by the profile
 /// hash (a threshold change is a profile change).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CorpusHealth {
     /// Minimum heuristic edges the index must carry (catches a broken parse / empty index).
     pub expected_min_heuristic_edges: u64,
@@ -53,7 +53,7 @@ pub struct CorpusHealth {
 /// when their [`CorpusProfile::hash`] match; the hash covers every field here, so a changed repo /
 /// rev / tool / prepare step / binding / threshold yields a different hash and an *incomparable*
 /// verdict rather than a silently-wrong Δ.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CorpusProfile {
     /// Stable corpus id (e.g. `"py-requests"`).
     pub corpus_id: String,

--- a/tools/oracle-corpora.toml
+++ b/tools/oracle-corpora.toml
@@ -1,0 +1,66 @@
+# SCIP-oracle corpus profiles (#164, C1). Declarative inputs for the resolution-quality runner:
+# each entry pins a real repo + revision + SCIP tool + per-language prepare steps + health gates.
+#
+# Two tiers:
+#   small — run per-PR (fast clone + build + index); the before/after delta comment gate.
+#   heavy — release/dispatch only; the Bencher headline resolution series. Never on PRs.
+#
+# Every field is part of the profile HASH (corpus_profile_hash), so changing a repo/rev/tool/prepare/
+# binding/threshold makes prior reports "incomparable" rather than silently mis-diffed. Pin `rev` to
+# an immutable ref; tags below are resolved to their commit at clone time by the runner.
+#
+# NOTE: `rev`s are release tags as a first cut — pin to the tag's commit SHA before trusting the
+# Bencher series (a moved tag would silently change the corpus). The golden hash test in
+# `oracle/corpus.rs` pins each profile's hash, so any edit here surfaces in review.
+
+[[corpus]]
+corpus_id = "rust-semver"
+tier      = "small"
+repo      = "https://github.com/dtolnay/semver"
+rev       = "1.0.26"
+tool      = "rust-analyzer"
+prepare   = ["cargo fetch"]
+bindings  = { rust = ["src"] }
+health    = { expected_min_heuristic_edges = 50, expected_min_oracle_examined = 20, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 10, timeout_minutes = 8 }
+
+[[corpus]]
+corpus_id = "c-cjson"
+tier      = "small"
+repo      = "https://github.com/DaveGamble/cJSON"
+rev       = "v1.7.18"
+tool      = "scip-clang"
+prepare   = ["cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON", "cp build/compile_commands.json ."]
+bindings  = { c = ["."] }
+health    = { expected_min_heuristic_edges = 50, expected_min_oracle_examined = 20, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 10, timeout_minutes = 8 }
+
+[[corpus]]
+corpus_id = "py-requests"
+tier      = "small"
+repo      = "https://github.com/psf/requests"
+rev       = "v2.32.3"
+tool      = "scip-python"
+prepare   = ["python -m venv .venv", ".venv/bin/pip install ."]
+bindings  = { python = ["src/requests"] }
+health    = { expected_min_heuristic_edges = 50, expected_min_oracle_examined = 20, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 10, timeout_minutes = 12 }
+
+# --- heavy "headline" corpora: release/dispatch only, pushed to Bencher; excluded from the PR matrix.
+
+[[corpus]]
+corpus_id = "rust-cargo"
+tier      = "heavy"
+repo      = "https://github.com/rust-lang/cargo"
+rev       = "0.97.1"
+tool      = "rust-analyzer"
+prepare   = ["cargo fetch"]
+bindings  = { rust = ["src", "crates"] }
+health    = { expected_min_heuristic_edges = 5000, expected_min_oracle_examined = 1000, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 200, timeout_minutes = 45 }
+
+[[corpus]]
+corpus_id = "linux-kernel"
+tier      = "heavy"
+repo      = "https://github.com/torvalds/linux"
+rev       = "v7.0"
+tool      = "scip-clang"
+prepare   = ["make defconfig", "make compile_commands.json"]
+bindings  = { c = ["."] }
+health    = { expected_min_heuristic_edges = 50000, expected_min_oracle_examined = 5000, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 1000, timeout_minutes = 120 }

--- a/tools/oracle-corpora.toml
+++ b/tools/oracle-corpora.toml
@@ -61,6 +61,9 @@ tier      = "heavy"
 repo      = "https://github.com/torvalds/linux"
 rev       = "v7.0"
 tool      = "scip-clang"
-prepare   = ["make defconfig", "make compile_commands.json"]
+# The compile_commands.json target reads per-object `.cmd` files, so the kernel must be BUILT first
+# (mirrors tools/kernel-c-oracle.sh). Without the build the compdb is empty and scip-clang sees
+# nothing.
+prepare   = ["make defconfig", "make -j", "make compile_commands.json"]
 bindings  = { c = ["."] }
 health    = { expected_min_heuristic_edges = 50000, expected_min_oracle_examined = 5000, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 1000, timeout_minutes = 120 }


### PR DESCRIPTION
C1 of #164 — the declarative corpus inputs + health gate the runner (C3) and `oracle report` CLI consume. Builds on the merged C0/C2 report contract.

## What
- **`tools/oracle-corpora.toml`** — 5 corpora: **small** tier (semver / cJSON / requests — per-PR) + **heavy** tier (cargo / kernel — release→Bencher), each pinning `repo`/`rev`/`tool`/`prepare`/`bindings`/`health`.
- **`oracle/corpus.rs`** — `load_corpora` (TOML), `corpus_by_id`, `corpora_for_tier`, and **`check_corpus_health`**: the fail-on-nonsense gate (min heuristic edges / min oracle verdicts / max `skipped_drifted` / min `symbols_with_moniker`) returning typed `HealthViolation`s, so the runner exits non-zero on a bogus run even when the oracle command exits 0.
- `CorpusProfile`/`CorpusHealth` gain `Deserialize` (TOML); report contract otherwise unchanged.

## Tests
Committed corpora load with the expected ids/tiers (+ `py-requests` → `scip-python` tool/binding); **golden per-profile hashes** (the review tripwire for an accidental corpus/threshold edit — an edit changes the hash and makes prior reports incomparable); health-gate healthy + each-threshold-violation cases.

## Notes
- `rev`s are release tags as a first cut; pin to the tag's commit SHA before trusting the Bencher series. The golden hash test surfaces any such edit.
- `py-requests` uses `tool = "scip-python"` as data; the backend lands in **B6** (gated on #167). The loader doesn't validate the tool against `OracleTool`, so C1 is independent of B6.

449 core tests green, clippy clean both shapes, nightly fmt clean.