### PR TITLE
feat(oracle): `oracle report --corpus <id>` — run a corpus + emit its C2 resolution report (C2-CLI)

### DIFF
--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -259,6 +259,9 @@ pub(crate) enum OracleCommand {
     Run(OracleRunArgs),
     /// Report oracle verdict counts + whether the indexer tool is installed.
     Status(OracleStatusArgs),
+    /// Run the oracle for a declared corpus and emit its typed before/after resolution report
+    /// (C2). Applies the corpus health gate: exits non-zero if the run falls outside thresholds.
+    Report(OracleReportArgs),
 }
 
 #[derive(Debug, Args)]
@@ -277,6 +280,20 @@ pub(crate) struct OracleStatusArgs {
     /// Report on one oracle tool only (default: every known tool).
     #[arg(long, value_enum)]
     pub tool: Option<OracleToolArg>,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct OracleReportArgs {
+    /// The corpus id to report on (must match a `[[corpus]]` entry's `corpus_id`).
+    #[arg(long)]
+    pub corpus: String,
+    /// Path to the corpus profiles file. Defaults to `<root>/tools/oracle-corpora.toml`.
+    #[arg(long)]
+    pub corpora: Option<PathBuf>,
+    /// Consume a pre-built `.scip` instead of invoking the corpus's tool. Deterministic; the tool
+    /// need not be installed.
+    #[arg(long)]
+    pub scip: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -548,5 +565,34 @@ mod tests {
             cli.command,
             Command::Oracle(OracleArgs { command: OracleCommand::Status(_) })
         ));
+    }
+
+    #[test]
+    fn oracle_report_requires_corpus_and_takes_optional_paths() {
+        // `--corpus` is mandatory; a bare `oracle report` must not parse.
+        assert!(Cli::try_parse_from(["rag-rat", "oracle", "report"]).is_err());
+        let cli = Cli::try_parse_from([
+            "rag-rat",
+            "oracle",
+            "report",
+            "--corpus",
+            "py-requests",
+            "--corpora",
+            "/tmp/corpora.toml",
+            "--scip",
+            "/tmp/x.scip",
+        ])
+        .expect("parse");
+        match cli.command {
+            Command::Oracle(OracleArgs { command: OracleCommand::Report(args) }) => {
+                assert_eq!(args.corpus, "py-requests");
+                assert_eq!(
+                    args.corpora.as_deref(),
+                    Some(std::path::Path::new("/tmp/corpora.toml"))
+                );
+                assert_eq!(args.scip.as_deref(), Some(std::path::Path::new("/tmp/x.scip")));
+            },
+            other => panic!("expected oracle report, got {other:?}"),
+        }
     }
 }

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -424,13 +424,25 @@ fn oracle_report(config: &Config, args: &OracleReportArgs) -> anyhow::Result<()>
             profile.tool
         )
     })?;
+
+    // Fail closed if the active checkout's target bindings don't match the corpus profile (Codex on
+    // #175). The report stamps this profile's `corpus_profile_hash`, asserting "these numbers are
+    // that corpus"; if `rag-rat oracle report --corpus X` is pointed at a checkout indexing a
+    // different population (wrong repo/targets), the health gate could pass on the wrong numbers
+    // while the report stays *comparable* under the intended hash — a silently-wrong Δ. (Tag-vs-SHA
+    // resolution makes an in-command repo/rev check intractable; the runner guarantees those by
+    // cloning repo@rev, so we validate the bindings, which independently fix the measured
+    // population.)
+    ensure_checkout_matches_corpus(config, &profile)?;
+
     let rag_rat_commit = rag_rat_commit_provenance();
 
-    // Run the oracle, then assemble the typed report — both under the index write lock so a watcher
-    // reindex can't land between the join's verdict writes and the report's "before"/moniker reads.
-    // Producing the `.scip` with the tool happens OUTSIDE the lock (#82 P3): the slow subprocess
-    // must not starve the watcher.
-    let report = if let Some(scip_path) = &args.scip {
+    // Run the oracle, then assemble the typed report + apply the health gate — all under the index
+    // write lock so a watcher reindex can't land between the join's verdict writes and the report's
+    // "before"/moniker reads, AND so an unhealthy run is rolled back atomically (it must not
+    // survive as the authoritative latest verdicts). Producing the `.scip` with the tool
+    // happens OUTSIDE the lock (#82 P3): the slow subprocess must not starve the watcher.
+    let (report, violations) = if let Some(scip_path) = &args.scip {
         let scip_bytes = fs::read(scip_path).map_err(|err| {
             anyhow::anyhow!("failed to read SCIP index {}: {err}", scip_path.display())
         })?;
@@ -448,7 +460,7 @@ fn oracle_report(config: &Config, args: &OracleReportArgs) -> anyhow::Result<()>
                 worktree_id: db.active_worktree_id.clone(),
                 production_sha: production_sha.clone(),
             };
-            db.resolution_report(&profile, &provenance, tool, &run)
+            finalize_corpus_report(db, &profile, &provenance, tool, &run)
         })?
     } else {
         // No pre-built index: probe first so a missing tool fails before touching the index, then
@@ -491,19 +503,18 @@ fn oracle_report(config: &Config, args: &OracleReportArgs) -> anyhow::Result<()>
                         worktree_id: db.active_worktree_id.clone(),
                         production_sha: fingerprint.clone(),
                     };
-                    db.resolution_report(&profile, &provenance, tool, &run)
+                    finalize_corpus_report(db, &profile, &provenance, tool, &run)
                 })?
             },
         }
     };
 
-    // Emit the report unconditionally — the glue/Δ script consumes it even for a failing run.
+    // Emit the report unconditionally — the glue/Δ script consumes it even for a failing run (the
+    // run itself was already rolled back inside the lock when unhealthy).
     print_output(&report)?;
 
     // Health gate: a violated threshold means the run is untrustworthy, so exit non-zero even
-    // though the oracle command itself succeeded. Violations go to stderr (the report owns
-    // stdout).
-    let violations = oracle::check_corpus_health(&profile, &report);
+    // though the oracle command itself succeeded. Violations go to stderr (the report owns stdout).
     if !violations.is_empty() {
         for violation in &violations {
             eprintln!("corpus health [{}]: {}", violation.check, violation.detail);
@@ -514,6 +525,65 @@ fn oracle_report(config: &Config, args: &OracleReportArgs) -> anyhow::Result<()>
             violations.len()
         );
     }
+    Ok(())
+}
+
+/// Assemble the typed report, apply the corpus health gate, and — when the run is unhealthy — ROLL
+/// IT BACK before returning, so a broken-environment run can't survive as the authoritative latest
+/// verdict set for later status/query surfaces (Codex on #175). Runs entirely under the caller's
+/// `with_oracle_write_lock`, so the rollback is atomic with the run that wrote the verdicts.
+/// Returns the report (for stdout) plus the violations (for the caller's exit-code decision).
+fn finalize_corpus_report(
+    db: &IndexDatabase,
+    profile: &rag_rat_core::index::oracle::CorpusProfile,
+    provenance: &rag_rat_core::index::oracle::RunProvenance,
+    tool: rag_rat_core::index::oracle::OracleTool,
+    run: &rag_rat_core::index::oracle::OracleReport,
+) -> anyhow::Result<(
+    rag_rat_core::index::oracle::OracleResolutionReport,
+    Vec<rag_rat_core::index::oracle::HealthViolation>,
+)> {
+    let report = db.resolution_report(profile, provenance, tool, run)?;
+    let violations = rag_rat_core::index::oracle::check_corpus_health(profile, &report);
+    if !violations.is_empty() {
+        db.rollback_oracle_run(tool, &provenance.tool_version)?;
+    }
+    Ok((report, violations))
+}
+
+/// Fail closed unless the active checkout's target bindings (language → directories) exactly match
+/// the corpus profile's `bindings`. The corpus runner generates the checkout's `rag-rat.toml` from
+/// these same bindings, so a match is the invariant; a mismatch means `oracle report --corpus X`
+/// was pointed at the wrong checkout, and its numbers would be stamped with X's
+/// `corpus_profile_hash` while measuring a different population. Compared as `language -> sorted
+/// dir set`, the same root-relative path strings both sides store.
+fn ensure_checkout_matches_corpus(
+    config: &Config,
+    profile: &rag_rat_core::index::oracle::CorpusProfile,
+) -> anyhow::Result<()> {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    let mut actual: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for target in &config.targets {
+        actual
+            .entry(target.language.as_str().to_string())
+            .or_default()
+            .extend(target.directories.iter().map(|dir| dir.to_string_lossy().into_owned()));
+    }
+    let expected: BTreeMap<String, BTreeSet<String>> = profile
+        .bindings
+        .iter()
+        .map(|(lang, dirs)| (lang.clone(), dirs.iter().cloned().collect()))
+        .collect();
+
+    anyhow::ensure!(
+        actual == expected,
+        "active checkout target bindings {actual:?} do not match corpus `{}` bindings \
+         {expected:?} — run `oracle report` against a checkout indexed with the corpus's bindings \
+         (the corpus runner does this) so the report measures the population its profile hash \
+         claims",
+        profile.corpus_id,
+    );
     Ok(())
 }
 
@@ -1042,6 +1112,58 @@ mod tests {
             oracle: Default::default(),
         };
         (root, config)
+    }
+
+    #[test]
+    fn checkout_bindings_must_match_corpus() {
+        use std::collections::BTreeMap;
+
+        use rag_rat_core::index::oracle::{CorpusHealth, CorpusProfile};
+
+        let config = Config {
+            root: PathBuf::from("/x"),
+            database: PathBuf::from("/x/db"),
+            targets: vec![ResolvedTarget {
+                name: "rust".to_string(),
+                language: Language::Rust,
+                directories: vec![PathBuf::from("src")],
+                include: Vec::new(),
+                exclude: Vec::new(),
+                kind: TargetKind::Source,
+            }],
+            local_ai: Default::default(),
+            watch: Default::default(),
+            version_check: Default::default(),
+            oracle: Default::default(),
+        };
+        let profile = |dirs: &[&str]| {
+            let mut bindings = BTreeMap::new();
+            bindings.insert("rust".to_string(), dirs.iter().map(|d| d.to_string()).collect());
+            CorpusProfile {
+                corpus_id: "rust-semver".to_string(),
+                tier: "small".to_string(),
+                repo: "r".to_string(),
+                rev: "v".to_string(),
+                tool: "rust-analyzer".to_string(),
+                prepare: Vec::new(),
+                bindings,
+                health: CorpusHealth {
+                    expected_min_heuristic_edges: 1,
+                    expected_min_oracle_examined: 1,
+                    expected_max_skipped_drifted: 0,
+                    expected_min_symbols_with_moniker: 1,
+                    timeout_minutes: 1,
+                },
+            }
+        };
+        // Exact language+dirs match → ok.
+        assert!(super::ensure_checkout_matches_corpus(&config, &profile(&["src"])).is_ok());
+        // Same language, different directory → fail closed (a different population).
+        assert!(super::ensure_checkout_matches_corpus(&config, &profile(&["lib"])).is_err());
+        // Extra binding the checkout doesn't have → fail closed.
+        let mut two_langs = profile(&["src"]);
+        two_langs.bindings.insert("python".to_string(), vec!["pkg".to_string()]);
+        assert!(super::ensure_checkout_matches_corpus(&config, &two_langs).is_err());
     }
 
     fn run_args() -> OracleArgs {

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -8,8 +8,8 @@ use crate::cli::EvalArgs;
 use crate::cli::{
     BriefArgs, ClustersArgs, GithubArgs, GithubCommand, HookAction, HooksArgs,
     ImportantSymbolsArgs, IndexArgs, MaintenanceArgs, MemoryArgs, MemoryCommand, ModelsArgs,
-    ModelsCommand, OracleArgs, OracleCommand, OracleRunArgs, OracleStatusArgs, QueryArgs,
-    ReconcileArgs,
+    ModelsCommand, OracleArgs, OracleCommand, OracleReportArgs, OracleRunArgs, OracleStatusArgs,
+    QueryArgs, ReconcileArgs,
 };
 
 /// Process-wide output format, set once from the global `--json` flag in `main` before any command
@@ -214,6 +214,7 @@ pub(crate) fn oracle(config: &Config, args: &OracleArgs) -> anyhow::Result<()> {
             let db = open_index(config)?;
             oracle_status(&db, status_args)
         },
+        OracleCommand::Report(report_args) => oracle_report(config, report_args),
     }
 }
 
@@ -386,6 +387,146 @@ fn oracle_status(db: &IndexDatabase, args: &OracleStatusArgs) -> anyhow::Result<
     }
     print_output(&entries)
 }
+
+/// `rag-rat oracle report --corpus <id>` — run the oracle for a declared corpus and emit its typed
+/// C2 [`OracleResolutionReport`] (before/after edge resolution + verdicts + metrics, schema- and
+/// profile-stamped) as JSON/TOON. The report is ALWAYS printed (so a Δ glue script can consume it
+/// even on a failing run); then the per-corpus health gate runs and, on any violation, the command
+/// exits non-zero — catching "scip emitted almost nothing" / "venv didn't resolve deps" / a broken
+/// parse even when the underlying oracle command itself succeeded.
+///
+/// Unlike `oracle run`, a missing/unrunnable tool is a hard ERROR here, not the exit-0 `Blocked`
+/// UX: this is a measurement runner over a corpus whose tool CI is expected to have installed, so a
+/// silent skip would let a broken environment pass green.
+fn oracle_report(config: &Config, args: &OracleReportArgs) -> anyhow::Result<()> {
+    use rag_rat_core::index::oracle;
+
+    // Load the corpus profile (defaults to the committed `tools/oracle-corpora.toml`).
+    let corpora_path = args
+        .corpora
+        .clone()
+        .unwrap_or_else(|| config.root.join("tools").join("oracle-corpora.toml"));
+    let toml_str = fs::read_to_string(&corpora_path).map_err(|err| {
+        anyhow::anyhow!("failed to read corpora file {}: {err}", corpora_path.display())
+    })?;
+    let corpora = oracle::load_corpora(&toml_str)?;
+    let profile = oracle::corpus_by_id(&corpora, &args.corpus)
+        .ok_or_else(|| {
+            anyhow::anyhow!("no corpus `{}` in {}", args.corpus, corpora_path.display())
+        })?
+        .clone();
+
+    // Map the corpus's declared tool id to an oracle backend.
+    let tool = oracle::OracleTool::from_db_str(&profile.tool).ok_or_else(|| {
+        anyhow::anyhow!(
+            "corpus `{}` names unknown oracle tool `{}`",
+            profile.corpus_id,
+            profile.tool
+        )
+    })?;
+    let rag_rat_commit = rag_rat_commit_provenance();
+
+    // Run the oracle, then assemble the typed report — both under the index write lock so a watcher
+    // reindex can't land between the join's verdict writes and the report's "before"/moniker reads.
+    // Producing the `.scip` with the tool happens OUTSIDE the lock (#82 P3): the slow subprocess
+    // must not starve the watcher.
+    let report = if let Some(scip_path) = &args.scip {
+        let scip_bytes = fs::read(scip_path).map_err(|err| {
+            anyhow::anyhow!("failed to read SCIP index {}: {err}", scip_path.display())
+        })?;
+        let tool_version = format!(
+            "scip-file:{}@{}",
+            scip_path.file_name().and_then(|n| n.to_str()).unwrap_or("index.scip"),
+            oracle::scip_content_fingerprint(&scip_bytes),
+        );
+        let production_sha = oracle::scip_content_fingerprint(&scip_bytes);
+        with_oracle_write_lock(config, |db| {
+            let run = db.run_oracle_from_scip(tool, &tool_version, &scip_bytes)?;
+            let provenance = oracle::RunProvenance {
+                tool_version: tool_version.clone(),
+                rag_rat_commit: rag_rat_commit.clone(),
+                worktree_id: db.active_worktree_id.clone(),
+                production_sha: production_sha.clone(),
+            };
+            db.resolution_report(&profile, &provenance, tool, &run)
+        })?
+    } else {
+        // No pre-built index: probe first so a missing tool fails before touching the index, then
+        // snapshot the pre-spawn shas (under the lock) and produce the `.scip` outside it
+        // (#82/#83).
+        if let oracle::ToolAvailability::Blocked { hint, .. } = oracle::probe_oracle_tool(tool) {
+            anyhow::bail!("oracle tool for corpus `{}` unavailable: {hint}", profile.corpus_id);
+        }
+        let (started_at_ms, pre_spawn_sha) = with_oracle_write_lock(config, |db| {
+            Ok((crate::now_epoch_ms(), db.oracle_pre_spawn_snapshot()?))
+        })?;
+        let scip_output = config
+            .database
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(std::env::temp_dir)
+            .join(format!("rag-rat-oracle-report-{}.scip", std::process::id()));
+        let production = oracle::produce_scip_with_tool(tool, &config.root, &scip_output);
+        let _ = fs::remove_file(&scip_output);
+        match production? {
+            oracle::ScipProduction::Blocked { hint, .. } => {
+                anyhow::bail!("oracle tool for corpus `{}` unavailable: {hint}", profile.corpus_id);
+            },
+            oracle::ScipProduction::Produced { version, bytes, production_sha } => {
+                let fingerprint = oracle::scip_content_fingerprint(&bytes);
+                with_oracle_write_lock(config, |db| {
+                    let run = db.run_oracle_at(
+                        tool,
+                        &version,
+                        &bytes,
+                        rag_rat_core::index::OracleShaSnapshots {
+                            production: Some(&production_sha),
+                            pre_spawn: Some(&pre_spawn_sha),
+                        },
+                        started_at_ms,
+                    )?;
+                    let provenance = oracle::RunProvenance {
+                        tool_version: version.clone(),
+                        rag_rat_commit: rag_rat_commit.clone(),
+                        worktree_id: db.active_worktree_id.clone(),
+                        production_sha: fingerprint.clone(),
+                    };
+                    db.resolution_report(&profile, &provenance, tool, &run)
+                })?
+            },
+        }
+    };
+
+    // Emit the report unconditionally — the glue/Δ script consumes it even for a failing run.
+    print_output(&report)?;
+
+    // Health gate: a violated threshold means the run is untrustworthy, so exit non-zero even
+    // though the oracle command itself succeeded. Violations go to stderr (the report owns
+    // stdout).
+    let violations = oracle::check_corpus_health(&profile, &report);
+    if !violations.is_empty() {
+        for violation in &violations {
+            eprintln!("corpus health [{}]: {}", violation.check, violation.detail);
+        }
+        anyhow::bail!(
+            "corpus `{}` failed {} health threshold(s)",
+            profile.corpus_id,
+            violations.len()
+        );
+    }
+    Ok(())
+}
+
+/// The `rag_rat_commit` provenance stamp for a resolution report: CI exports `RAG_RAT_COMMIT`
+/// (the building checkout's git SHA) so a number traces to an exact engine build; off CI it falls
+/// back to the crate version, which is enough to disambiguate published builds.
+fn rag_rat_commit_provenance() -> String {
+    std::env::var("RAG_RAT_COMMIT")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string())
+}
+
 pub(crate) fn models(config: &Config, args: &ModelsArgs) -> anyhow::Result<()> {
     let db = open_index(config)?;
     match &args.command {

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -437,11 +437,11 @@ fn oracle_report(config: &Config, args: &OracleReportArgs) -> anyhow::Result<()>
 
     let rag_rat_commit = rag_rat_commit_provenance();
 
-    // Run the oracle, then assemble the typed report + apply the health gate — all under the index
-    // write lock so a watcher reindex can't land between the join's verdict writes and the report's
-    // "before"/moniker reads, AND so an unhealthy run is rolled back atomically (it must not
-    // survive as the authoritative latest verdicts). Producing the `.scip` with the tool
-    // happens OUTSIDE the lock (#82 P3): the slow subprocess must not starve the watcher.
+    // Run the oracle + assemble the report + apply the health gate as ONE provisional transaction
+    // (`db.run_oracle_report` commits only if healthy, else rolls the whole run back), all under
+    // the index write lock so a watcher reindex can't interleave. Producing the `.scip` with
+    // the tool happens OUTSIDE the lock (#82 P3): the slow subprocess must not starve the
+    // watcher.
     let (report, violations) = if let Some(scip_path) = &args.scip {
         let scip_bytes = fs::read(scip_path).map_err(|err| {
             anyhow::anyhow!("failed to read SCIP index {}: {err}", scip_path.display())
@@ -451,16 +451,25 @@ fn oracle_report(config: &Config, args: &OracleReportArgs) -> anyhow::Result<()>
             scip_path.file_name().and_then(|n| n.to_str()).unwrap_or("index.scip"),
             oracle::scip_content_fingerprint(&scip_bytes),
         );
-        let production_sha = oracle::scip_content_fingerprint(&scip_bytes);
+        let provenance = oracle::RunProvenance {
+            tool_version,
+            rag_rat_commit: rag_rat_commit.clone(),
+            // worktree_id filled under the lock (it's the active checkout's, read from the db).
+            worktree_id: String::new(),
+            production_sha: oracle::scip_content_fingerprint(&scip_bytes),
+        };
         with_oracle_write_lock(config, |db| {
-            let run = db.run_oracle_from_scip(tool, &tool_version, &scip_bytes)?;
-            let provenance = oracle::RunProvenance {
-                tool_version: tool_version.clone(),
-                rag_rat_commit: rag_rat_commit.clone(),
-                worktree_id: db.active_worktree_id.clone(),
-                production_sha: production_sha.clone(),
-            };
-            finalize_corpus_report(db, &profile, &provenance, tool, &run)
+            let provenance =
+                oracle::RunProvenance { worktree_id: db.active_worktree_id.clone(), ..provenance };
+            // A pre-built `--scip` arms neither content-drift gate and has no spawn moment.
+            db.run_oracle_report(
+                &profile,
+                &provenance,
+                tool,
+                &scip_bytes,
+                rag_rat_core::index::OracleShaSnapshots::default(),
+                crate::now_epoch_ms(),
+            )
         })?
     } else {
         // No pre-built index: probe first so a missing tool fails before touching the index, then
@@ -485,32 +494,35 @@ fn oracle_report(config: &Config, args: &OracleReportArgs) -> anyhow::Result<()>
                 anyhow::bail!("oracle tool for corpus `{}` unavailable: {hint}", profile.corpus_id);
             },
             oracle::ScipProduction::Produced { version, bytes, production_sha } => {
-                let fingerprint = oracle::scip_content_fingerprint(&bytes);
+                let provenance = oracle::RunProvenance {
+                    tool_version: version,
+                    rag_rat_commit: rag_rat_commit.clone(),
+                    worktree_id: String::new(),
+                    production_sha: oracle::scip_content_fingerprint(&bytes),
+                };
                 with_oracle_write_lock(config, |db| {
-                    let run = db.run_oracle_at(
+                    let provenance = oracle::RunProvenance {
+                        worktree_id: db.active_worktree_id.clone(),
+                        ..provenance
+                    };
+                    db.run_oracle_report(
+                        &profile,
+                        &provenance,
                         tool,
-                        &version,
                         &bytes,
                         rag_rat_core::index::OracleShaSnapshots {
                             production: Some(&production_sha),
                             pre_spawn: Some(&pre_spawn_sha),
                         },
                         started_at_ms,
-                    )?;
-                    let provenance = oracle::RunProvenance {
-                        tool_version: version.clone(),
-                        rag_rat_commit: rag_rat_commit.clone(),
-                        worktree_id: db.active_worktree_id.clone(),
-                        production_sha: fingerprint.clone(),
-                    };
-                    finalize_corpus_report(db, &profile, &provenance, tool, &run)
+                    )
                 })?
             },
         }
     };
 
-    // Emit the report unconditionally — the glue/Δ script consumes it even for a failing run (the
-    // run itself was already rolled back inside the lock when unhealthy).
+    // Emit the report unconditionally — the glue/Δ script consumes it even for a failing run (an
+    // unhealthy run was already rolled back whole inside the transaction).
     print_output(&report)?;
 
     // Health gate: a violated threshold means the run is untrustworthy, so exit non-zero even
@@ -526,29 +538,6 @@ fn oracle_report(config: &Config, args: &OracleReportArgs) -> anyhow::Result<()>
         );
     }
     Ok(())
-}
-
-/// Assemble the typed report, apply the corpus health gate, and — when the run is unhealthy — ROLL
-/// IT BACK before returning, so a broken-environment run can't survive as the authoritative latest
-/// verdict set for later status/query surfaces (Codex on #175). Runs entirely under the caller's
-/// `with_oracle_write_lock`, so the rollback is atomic with the run that wrote the verdicts.
-/// Returns the report (for stdout) plus the violations (for the caller's exit-code decision).
-fn finalize_corpus_report(
-    db: &IndexDatabase,
-    profile: &rag_rat_core::index::oracle::CorpusProfile,
-    provenance: &rag_rat_core::index::oracle::RunProvenance,
-    tool: rag_rat_core::index::oracle::OracleTool,
-    run: &rag_rat_core::index::oracle::OracleReport,
-) -> anyhow::Result<(
-    rag_rat_core::index::oracle::OracleResolutionReport,
-    Vec<rag_rat_core::index::oracle::HealthViolation>,
-)> {
-    let report = db.resolution_report(profile, provenance, tool, run)?;
-    let violations = rag_rat_core::index::oracle::check_corpus_health(profile, &report);
-    if !violations.is_empty() {
-        db.rollback_oracle_run(tool, &provenance.tool_version)?;
-    }
-    Ok((report, violations))
 }
 
 /// Fail closed unless the active checkout's targets are EXACTLY the corpus profile's `bindings`

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -551,12 +551,19 @@ fn finalize_corpus_report(
     Ok((report, violations))
 }
 
-/// Fail closed unless the active checkout's target bindings (language → directories) exactly match
-/// the corpus profile's `bindings`. The corpus runner generates the checkout's `rag-rat.toml` from
-/// these same bindings, so a match is the invariant; a mismatch means `oracle report --corpus X`
-/// was pointed at the wrong checkout, and its numbers would be stamped with X's
-/// `corpus_profile_hash` while measuring a different population. Compared as `language -> sorted
-/// dir set`, the same root-relative path strings both sides store.
+/// Fail closed unless the active checkout's targets are EXACTLY the corpus profile's `bindings`
+/// rendered through the plain `[target_bindings]` form — same languages, same directories, AND
+/// default include/exclude filters. The corpus runner generates the checkout's `rag-rat.toml` from
+/// these bindings (the simple form), so that's the invariant; any deviation means
+/// `oracle report --corpus X` would stamp X's `corpus_profile_hash` onto a different file
+/// population.
+///
+/// Two layers, both load-bearing:
+/// 1. language → directory set equality (catches a wrong repo / extra or missing bindings).
+/// 2. default filters per target: a `[[target]]` with the same language+dirs but custom
+///    `include`/`exclude` indexes a filtered subset/superset under the same hash (Codex on #175),
+///    so reject any target whose filters aren't the simple form's defaults (`include =
+///    ["**/*.<ext>", …]`, `exclude = []`).
 fn ensure_checkout_matches_corpus(
     config: &Config,
     profile: &rag_rat_core::index::oracle::CorpusProfile,
@@ -584,6 +591,26 @@ fn ensure_checkout_matches_corpus(
          claims",
         profile.corpus_id,
     );
+
+    // The dir set can match while a custom `include`/`exclude` quietly filters the indexed files.
+    // The corpus binding has no filter knobs, so a legitimate checkout carries exactly the simple
+    // form's defaults; anything else measures a different population under the same hash.
+    for target in &config.targets {
+        let default_include: BTreeSet<String> =
+            target.language.simple_extensions().iter().map(|ext| format!("**/*.{ext}")).collect();
+        let include: BTreeSet<String> = target.include.iter().cloned().collect();
+        anyhow::ensure!(
+            target.exclude.is_empty() && include == default_include,
+            "target `{}` ({}) has custom include/exclude filters (include {:?}, exclude {:?}) — \
+             `oracle report --corpus {}` requires the corpus's plain bindings (default filters) \
+             so the report's profile hash matches the file population it measured",
+            target.name,
+            target.language.as_str(),
+            target.include,
+            target.exclude,
+            profile.corpus_id,
+        );
+    }
     Ok(())
 }
 
@@ -1120,15 +1147,17 @@ mod tests {
 
         use rag_rat_core::index::oracle::{CorpusHealth, CorpusProfile};
 
-        let config = Config {
+        // A target carrying the SAME default filters the simple `[target_bindings]` form renders
+        // (`include = ["**/*.rs"]`, no exclude), so the bindings-match check accepts it.
+        let config_with = |include: Vec<String>, exclude: Vec<String>| Config {
             root: PathBuf::from("/x"),
             database: PathBuf::from("/x/db"),
             targets: vec![ResolvedTarget {
                 name: "rust".to_string(),
                 language: Language::Rust,
                 directories: vec![PathBuf::from("src")],
-                include: Vec::new(),
-                exclude: Vec::new(),
+                include,
+                exclude,
                 kind: TargetKind::Source,
             }],
             local_ai: Default::default(),
@@ -1136,6 +1165,7 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
         };
+        let config = config_with(vec!["**/*.rs".to_string()], Vec::new());
         let profile = |dirs: &[&str]| {
             let mut bindings = BTreeMap::new();
             bindings.insert("rust".to_string(), dirs.iter().map(|d| d.to_string()).collect());
@@ -1156,7 +1186,7 @@ mod tests {
                 },
             }
         };
-        // Exact language+dirs match → ok.
+        // Exact language+dirs match with default filters → ok.
         assert!(super::ensure_checkout_matches_corpus(&config, &profile(&["src"])).is_ok());
         // Same language, different directory → fail closed (a different population).
         assert!(super::ensure_checkout_matches_corpus(&config, &profile(&["lib"])).is_err());
@@ -1164,6 +1194,13 @@ mod tests {
         let mut two_langs = profile(&["src"]);
         two_langs.bindings.insert("python".to_string(), vec!["pkg".to_string()]);
         assert!(super::ensure_checkout_matches_corpus(&config, &two_langs).is_err());
+        // Same dirs but a custom `exclude` filters the population → fail closed (Codex #175).
+        let excluded =
+            config_with(vec!["**/*.rs".to_string()], vec!["**/generated/**".to_string()]);
+        assert!(super::ensure_checkout_matches_corpus(&excluded, &profile(&["src"])).is_err());
+        // Same dirs but a narrowed `include` → fail closed.
+        let narrowed = config_with(vec!["src/lib.rs".to_string()], Vec::new());
+        assert!(super::ensure_checkout_matches_corpus(&narrowed, &profile(&["src"])).is_err());
     }
 
     fn run_args() -> OracleArgs {

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -123,6 +123,29 @@ pub fn run_oracle_at(
     })
 }
 
+/// Roll back a just-completed oracle run for `(tool, tool_version)` in the active checkout: delete
+/// its `edge_oracle` verdicts, its `logical_symbol_monikers`, and its `oracle_runs` row, all in one
+/// transaction. Used when a corpus run FAILS its health gate (`oracle report`): the run's verdicts
+/// were already committed by [`run_oracle_at`], so without this it would become the authoritative
+/// latest run ([`store::latest_run_tool_version`]) and surface untrustworthy `Compiler`-tier
+/// verdicts in later status/query output — exactly the broken-environment case the gate exists to
+/// reject. Clearing the monikers is whole-tool (their PK is `(logical_symbol_id, tool)`, so the run
+/// already overwrote any prior version's at its start — there is nothing older to preserve).
+pub fn rollback_run(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<()> {
+    let tx = conn.unchecked_transaction()?;
+    store::clear_edge_oracle_for_tool(conn, tool, tool_version, commit_sha, worktree_id)?;
+    store::clear_logical_symbol_monikers_for_tool(conn, tool)?;
+    store::delete_oracle_run(conn, tool, tool_version, commit_sha, worktree_id)?;
+    tx.commit()?;
+    Ok(())
+}
+
 /// The indexed `(path -> files.sha256)` map for the active checkout — the pre-spawn snapshot
 /// callers take BEFORE spawning the oracle tool (#83). Cheap (reads indexed shas; hashes
 /// nothing), and read-only, so the CLI takes it before acquiring the index write lock.

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -123,27 +123,51 @@ pub fn run_oracle_at(
     })
 }
 
-/// Roll back a just-completed oracle run for `(tool, tool_version)` in the active checkout: delete
-/// its `edge_oracle` verdicts, its `logical_symbol_monikers`, and its `oracle_runs` row, all in one
-/// transaction. Used when a corpus run FAILS its health gate (`oracle report`): the run's verdicts
-/// were already committed by [`run_oracle_at`], so without this it would become the authoritative
-/// latest run ([`store::latest_run_tool_version`]) and surface untrustworthy `Compiler`-tier
-/// verdicts in later status/query output — exactly the broken-environment case the gate exists to
-/// reject. Clearing the monikers is whole-tool (their PK is `(logical_symbol_id, tool)`, so the run
-/// already overwrote any prior version's at its start — there is nothing older to preserve).
-pub fn rollback_run(
+/// Run the oracle for a corpus report PROVISIONALLY: execute the pass, assemble the typed report,
+/// apply the corpus health gate, and COMMIT only if healthy. When the gate fails, the whole
+/// transaction — INCLUDING the authoritative clear of the prior `(tool, tool_version)` verdicts and
+/// the tool's monikers — is rolled back, so a rejected run leaves the previous healthy run's
+/// verdicts / monikers / `oracle_runs` row completely intact (Codex on #175). This is why the
+/// report path must NOT reuse the committing [`run_oracle_at`] + a post-hoc delete: the
+/// authoritative clear at the run's start already destroys the prior state, so only
+/// never-committing can preserve it.
+///
+/// `provenance.tool_version` is the run's content-addressed version — the single source for the run
+/// row, the metric scope, and the report envelope. Returns the report (always, for stdout) and the
+/// health violations (empty = committed; non-empty = rolled back).
+#[allow(clippy::too_many_arguments)]
+pub fn run_oracle_report(
     conn: &Connection,
+    profile: &report::CorpusProfile,
+    provenance: &report::RunProvenance,
     tool: OracleTool,
-    tool_version: &str,
     commit_sha: &str,
     worktree_id: &str,
-) -> anyhow::Result<()> {
+    scip_bytes: &[u8],
+    checkout_root: &Path,
+    production_sha: Option<&HashMap<String, String>>,
+    pre_spawn_sha: Option<&HashMap<String, String>>,
+    started_at_ms: i64,
+) -> anyhow::Result<(report::OracleResolutionReport, Vec<HealthViolation>)> {
     let tx = conn.unchecked_transaction()?;
-    store::clear_edge_oracle_for_tool(conn, tool, tool_version, commit_sha, worktree_id)?;
-    store::clear_logical_symbol_monikers_for_tool(conn, tool)?;
-    store::delete_oracle_run(conn, tool, tool_version, commit_sha, worktree_id)?;
-    tx.commit()?;
-    Ok(())
+    let run = run::run_in_tx(conn, &OracleRunInput {
+        tool,
+        tool_version: &provenance.tool_version,
+        commit_sha,
+        worktree_id,
+        scip_bytes,
+        checkout_root,
+        production_sha,
+        pre_spawn_sha,
+        started_at_ms,
+    })?;
+    let report = resolution_report(conn, profile, provenance, tool, commit_sha, worktree_id, &run)?;
+    let violations = check_corpus_health(profile, &report);
+    if violations.is_empty() {
+        tx.commit()?;
+    }
+    // Unhealthy → `tx` drops uncommitted → the whole run (clear + writes + run row) rolls back.
+    Ok((report, violations))
 }
 
 /// The indexed `(path -> files.sha256)` map for the active checkout — the pre-spawn snapshot

--- a/crates/rag-rat-core/src/index/oracle/run.rs
+++ b/crates/rag-rat-core/src/index/oracle/run.rs
@@ -68,15 +68,30 @@ pub(crate) struct OracleRunInput<'a> {
 /// revisits), so `status`/eval would keep counting a verdict the current oracle doesn't stand
 /// behind.
 pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Result<OracleReport> {
+    // Authoritative-rerun clear + the per-edge writes + the run row are one atomic unit, so the
+    // table is never observed mid-clear and a failed run rolls back to the prior verdicts. The body
+    // ([`run_in_tx`]) does all the writes on `conn`; `tx` exists only to BEGIN/COMMIT around them.
+    // `oracle report` (C2) calls `run_in_tx` directly inside ITS OWN transaction so it can roll the
+    // whole run back when the corpus health gate fails — keeping a rejected run from destroying the
+    // prior healthy verdicts/monikers (the authoritative clear is part of the rolled-back unit).
+    let tx = conn.unchecked_transaction()?;
+    let report = run_in_tx(conn, input)?;
+    tx.commit()?;
+    Ok(report)
+}
+
+/// The oracle pass body — every read/write, no transaction management. Runs inside the caller's
+/// transaction: [`run`] wraps it in a commit-on-success transaction; the report path wraps it in
+/// one it rolls back on an unhealthy gate. NEVER call this outside a transaction (the authoritative
+/// clear would not be atomic with the writes).
+pub(crate) fn run_in_tx(
+    conn: &Connection,
+    input: &OracleRunInput<'_>,
+) -> anyhow::Result<OracleReport> {
     let mut report = OracleReport::default();
 
     let candidates = store::edge_join_candidates(conn, input.commit_sha, input.worktree_id)?;
 
-    // Authoritative-rerun clear + the per-edge writes + the run row are one atomic unit, so the
-    // table is never observed mid-clear and a failed run rolls back to the prior verdicts. All
-    // inner reads/writes run on `conn` (the same underlying connection `tx` guards), so they
-    // are part of this transaction; `tx` exists only to BEGIN/COMMIT around them.
-    let tx = conn.unchecked_transaction()?;
     store::clear_edge_oracle_for_tool(
         conn,
         input.tool,
@@ -388,7 +403,6 @@ pub(crate) fn run(conn: &Connection, input: &OracleRunInput<'_>) -> anyhow::Resu
         &serde_json::to_string(&report).unwrap_or_else(|_| "{}".to_string()),
     )?;
 
-    tx.commit()?;
     Ok(report)
 }
 

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -463,26 +463,6 @@ pub(crate) fn record_oracle_run_at(
     Ok(conn.last_insert_rowid())
 }
 
-/// Delete the `oracle_runs` row for one `(tool, tool_version)` in the active checkout — the
-/// `oracle_runs` half of rolling back a run (the `edge_oracle` verdicts are cleared separately by
-/// [`clear_edge_oracle_for_tool`]; see [`super::rollback_run`]). Used when a corpus run fails its
-/// health gate: without removing the row, [`latest_run_tool_version`] would keep selecting the
-/// untrustworthy run, surfacing its verdicts in later status/query output despite the gate failure.
-pub(crate) fn delete_oracle_run(
-    conn: &Connection,
-    tool: OracleTool,
-    tool_version: &str,
-    commit_sha: &str,
-    worktree_id: &str,
-) -> anyhow::Result<()> {
-    conn.execute(
-        "DELETE FROM oracle_runs
-         WHERE tool = ?1 AND tool_version = ?2 AND commit_sha = ?3 AND worktree_id = ?4",
-        params![tool.as_db_str(), tool_version, commit_sha, worktree_id],
-    )?;
-    Ok(())
-}
-
 /// The `tool_version` of the most recent run for `tool` **in the active checkout**, if any. This is
 /// the version the surfacing reads (the `Compiler` tier) key on: query output should show the
 /// verdicts the last `oracle run` for this checkout produced. Scoped to `(commit_sha, worktree_id)`

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -463,6 +463,26 @@ pub(crate) fn record_oracle_run_at(
     Ok(conn.last_insert_rowid())
 }
 
+/// Delete the `oracle_runs` row for one `(tool, tool_version)` in the active checkout — the
+/// `oracle_runs` half of rolling back a run (the `edge_oracle` verdicts are cleared separately by
+/// [`clear_edge_oracle_for_tool`]; see [`super::rollback_run`]). Used when a corpus run fails its
+/// health gate: without removing the row, [`latest_run_tool_version`] would keep selecting the
+/// untrustworthy run, surfacing its verdicts in later status/query output despite the gate failure.
+pub(crate) fn delete_oracle_run(
+    conn: &Connection,
+    tool: OracleTool,
+    tool_version: &str,
+    commit_sha: &str,
+    worktree_id: &str,
+) -> anyhow::Result<()> {
+    conn.execute(
+        "DELETE FROM oracle_runs
+         WHERE tool = ?1 AND tool_version = ?2 AND commit_sha = ?3 AND worktree_id = ?4",
+        params![tool.as_db_str(), tool_version, commit_sha, worktree_id],
+    )?;
+    Ok(())
+}
+
 /// The `tool_version` of the most recent run for `tool` **in the active checkout**, if any. This is
 /// the version the surfacing reads (the `Compiler` tier) key on: query output should show the
 /// verdicts the last `oracle run` for this checkout produced. Scoped to `(commit_sha, worktree_id)`

--- a/crates/rag-rat-core/src/index/query_api/oracle_runs.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_runs.rs
@@ -130,18 +130,39 @@ impl IndexDatabase {
         )
     }
 
-    /// Roll back a just-completed run for `(tool, tool_version)` in this checkout — delete its
-    /// `edge_oracle` verdicts, monikers, and `oracle_runs` row. `oracle report` calls this when a
-    /// corpus FAILS its health gate, so a broken-environment run (the gate's whole purpose to
-    /// catch) can't linger as the authoritative latest verdict set for later status/query
-    /// surfaces.
-    pub fn rollback_oracle_run(&self, tool: OracleTool, tool_version: &str) -> anyhow::Result<()> {
-        oracle::rollback_run(
+    /// Run the oracle for a corpus report PROVISIONALLY and apply its health gate atomically: the
+    /// pass + report assembly + gate run in ONE transaction that commits only if healthy, so a
+    /// gate-failing run is rolled back whole — leaving the prior healthy verdicts/monikers/run row
+    /// intact (Codex on #175). `provenance.tool_version` is the run's content-addressed version.
+    /// Returns the report (always, for stdout) + the violations (empty = committed). The `shas` arm
+    /// the content-drift gates exactly as [`Self::run_oracle_at`].
+    pub fn run_oracle_report(
+        &self,
+        profile: &oracle::CorpusProfile,
+        provenance: &oracle::RunProvenance,
+        tool: OracleTool,
+        scip_bytes: &[u8],
+        shas: OracleShaSnapshots<'_>,
+        started_at_ms: i64,
+    ) -> anyhow::Result<(oracle::OracleResolutionReport, Vec<oracle::HealthViolation>)> {
+        let Some(root) = self.storage.source_root() else {
+            anyhow::bail!(
+                "index has no source_root metadata; rebuild required for the oracle pass"
+            );
+        };
+        let root = root.to_path_buf();
+        oracle::run_oracle_report(
             self.storage.connection(),
+            profile,
+            provenance,
             tool,
-            tool_version,
             &self.active_commit_sha,
             &self.active_worktree_id,
+            scip_bytes,
+            &root,
+            shas.production,
+            shas.pre_spawn,
+            started_at_ms,
         )
     }
 

--- a/crates/rag-rat-core/src/index/query_api/oracle_runs.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_runs.rs
@@ -130,6 +130,21 @@ impl IndexDatabase {
         )
     }
 
+    /// Roll back a just-completed run for `(tool, tool_version)` in this checkout — delete its
+    /// `edge_oracle` verdicts, monikers, and `oracle_runs` row. `oracle report` calls this when a
+    /// corpus FAILS its health gate, so a broken-environment run (the gate's whole purpose to
+    /// catch) can't linger as the authoritative latest verdict set for later status/query
+    /// surfaces.
+    pub fn rollback_oracle_run(&self, tool: OracleTool, tool_version: &str) -> anyhow::Result<()> {
+        oracle::rollback_run(
+            self.storage.connection(),
+            tool,
+            tool_version,
+            &self.active_commit_sha,
+            &self.active_worktree_id,
+        )
+    }
+
     /// Persisted oracle status (verdict counts + last run) for a tool/version, scoped to this
     /// database's active `(commit_sha, worktree_id)` checkout.
     pub fn oracle_status(


### PR DESCRIPTION
Part of the multi-language SCIP-oracle runner epic (#164). Adds the **C2-CLI** surface over the C0/C2 report contract that landed in #166/#168 and the corpus profiles/health-gate from #171.

## What

`rag-rat oracle report --corpus <id> [--corpora <path>] [--scip <path>]`:

1. Loads the corpus profile from `tools/oracle-corpora.toml` (override with `--corpora`).
2. Maps the corpus's declared `tool` to an oracle backend.
3. Runs the oracle — produces a `.scip` with the corpus's tool, or consumes a pre-built `--scip` (deterministic; no tool needed).
4. Assembles the typed `OracleResolutionReport` (before/after edge resolution, verdict transitions, metrics, schema- + profile-stamped) and emits it as JSON/TOON.
5. Applies the per-corpus **health gate**: a violated threshold exits non-zero even when the oracle command itself succeeded — catching "scip emitted almost nothing" / "venv didn't resolve deps" / a broken parse.

## Decisions

- **Report printed unconditionally, before the gate.** A Δ/glue script consumes the JSON even for a failing run; violations go to stderr, then the command exits non-zero.
- **Missing tool is a hard error here** — deliberately the opposite of `oracle run`'s Blocked+exit-0 UX. This is a measurement runner over a corpus whose tool CI is expected to have installed; a silent skip would pass green on a broken environment.
- **run + `resolution_report` under one write lock**; `.scip` production stays outside it (the #82 P3 lock-free-production posture).
- **`rag_rat_commit` provenance** reads `$RAG_RAT_COMMIT` (CI's git SHA), falling back to the crate version off CI.

## Tests / verification

- New parse test `oracle_report_requires_corpus_and_takes_optional_paths` (mandatory `--corpus`, optional `--corpora`/`--scip`).
- Existing `corpus.rs` health-gate unit tests cover the threshold logic.
- Manually verified end-to-end against this repo's own index with rust-analyzer: a real report (42k edges, resolved 9767→41365 after the oracle), the failing-gate path (exit 1, violation on stderr, report still on stdout), the passing-gate path (exit 0), and the `--scip` prebuilt path.
- `cargo +nightly fmt --check`, `cargo clippy --all-targets`, and the full cli + core-oracle suites are green.

## Follow-up

`oracle report --corpus py-requests` errors with "unknown oracle tool" until **B6** (the scip-python backend) lands — `OracleTool::from_db_str` doesn't yet know `scip-python`.