### PR TITLE
feat(oracle): Markdown resolution report — job summary + fork-safe PR comment (C5)

### DIFF
--- a/.github/workflows/oracle-pr-comment.yml
+++ b/.github/workflows/oracle-pr-comment.yml
@@ -1,0 +1,52 @@
+name: oracle-pr-comment
+
+# Fork-safe step 2 of the small-tier oracle report: post the rendered resolution table as a sticky
+# PR comment. Triggered by the `oracle` workflow completing; runs in BASE-repo context (so it has
+# `pull-requests: write`) but only ever consumes the Markdown artifact step 1 produced — never the
+# fork's code — so a fork PR can't reach the write token. Mirrors bench-pr-run / bench-pr-track.
+
+on:
+  workflow_run:
+    workflows: [oracle]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    # Only for PR-triggered oracle runs (skip push / release / dispatch). The artifact is uploaded
+    # only by the small tier's `report` job, so non-PR runs simply have nothing to post.
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download the rendered report (from the oracle run)
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          name: oracle-report-md
+          run_id: ${{ github.event.workflow_run.id }}
+          if_no_artifact_found: ignore
+
+      - name: Upsert the sticky PR comment
+        if: hashFiles('oracle-report.md') != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('oracle-report.md', 'utf8');
+            const event = JSON.parse(fs.readFileSync('event.json', 'utf8'));
+            const issue_number = event.number;
+            const { owner, repo } = context.repo;
+            // Find our previous comment by the stable marker oracle-report-md.py emits, and update
+            // it in place so a PR carries ONE rolling report rather than one per push.
+            const marker = '<!-- rag-rat-oracle-report -->';
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -148,6 +148,75 @@ jobs:
           path: ${{ runner.temp }}/${{ matrix.corpus }}-report.json
           if-no-files-found: warn
 
+  report:
+    # Aggregate the small-tier corpus reports into one Markdown table: a job summary always, plus —
+    # on a PR — an artifact the fork-safe oracle-pr-comment.yml posts as a sticky comment. The Δ
+    # column diffs each corpus against `main`'s last reports, cached here (saved on a main push,
+    # restored on a PR). rag-rat emits JSON only; the Markdown is `tools/oracle-report-md.py` glue.
+    needs: [matrix, small]
+    # Run whenever the matrix ran, even if a corpus leg failed its health gate — a failing report is
+    # exactly what we want surfaced in the summary/comment.
+    if: always() && needs.matrix.outputs.tier == 'small' && needs.small.result != 'skipped'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download all corpus reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: oracle-report-*
+          path: reports
+          merge-multiple: true
+
+      # main's last reports, for the Δ column. restore-keys prefix-matches the most recent main save;
+      # absent on the first run / a brand-new corpus → the script degrades to absolute-only.
+      - name: Restore the main baseline reports
+        uses: actions/cache/restore@v4
+        with:
+          path: baselines
+          key: oracle-baseline-${{ github.run_id }}
+          restore-keys: oracle-baseline-
+
+      - name: Render the Markdown report → job summary
+        # Report/baseline paths are space-free (kebab corpus ids under runner.temp), so unquoted
+        # word-splitting is safe and keeps this free of bash-version builtins.
+        run: |
+          set -euo pipefail
+          reports="$(find reports -name '*-report.json' | sort)"
+          [ -n "$reports" ] || { echo "no corpus reports found" >&2; exit 1; }
+          baselines=""
+          [ -d baselines ] && baselines="$(find baselines -name '*-report.json' | sort)" || true
+          # shellcheck disable=SC2086
+          python3 tools/oracle-report-md.py --reports $reports ${baselines:+--baselines $baselines} \
+            > oracle-report.md
+          cat oracle-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Save the PR event (for the fork-safe comment step)
+        if: github.event_name == 'pull_request'
+        run: cp "$GITHUB_EVENT_PATH" event.json
+
+      - name: Upload the rendered report (consumed by oracle-pr-comment.yml)
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: oracle-report-md
+          path: |
+            oracle-report.md
+            event.json
+
+      # On a main push these reports become the new baseline future PRs diff against. Immutable
+      # per-run key; the PR restore-keys prefix picks the most recent.
+      - name: Publish the new main baseline
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          rm -rf baselines && mkdir baselines && cp reports/*-report.json baselines/
+      - name: Save the main baseline cache
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v4
+        with:
+          path: baselines
+          key: oracle-baseline-${{ github.run_id }}
+
   heavy:
     needs: matrix
     if: needs.matrix.outputs.tier == 'heavy'

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -25,6 +25,7 @@ on:
       - 'tools/oracle-corpus.py'
       - 'tools/oracle-run.sh'
       - 'tools/oracle-report-bmf.py'
+      - 'tools/oracle-report-md.py'
       - '.github/workflows/oracle.yml'
   push:
     branches: [main]
@@ -36,6 +37,7 @@ on:
       - 'tools/oracle-corpus.py'
       - 'tools/oracle-run.sh'
       - 'tools/oracle-report-bmf.py'
+      - 'tools/oracle-report-md.py'
       - '.github/workflows/oracle.yml'
   release:
     types: [published]

--- a/docs/oracle.md
+++ b/docs/oracle.md
@@ -69,3 +69,19 @@ auto_run_min_interval_secs = 21600   # and at most once every 6 h
 It needs a SCIP tool (e.g. `rust-analyzer`) on `PATH`, runs only inside the MCP server, and produces
 the `.scip` outside the index write lock so the file watcher is never starved. See
 [`config.md`](config.md) for all knobs.
+
+## Resolution-quality CI (the corpus runner)
+
+`tools/oracle-corpora.toml` declares real-repo corpora (a small per-PR tier + a heavy
+release/Bencher tier); `tools/oracle-run.sh` runs one corpus end to end (clone @ rev → prepare →
+index → `rag-rat oracle report`, gated by per-corpus health thresholds). The `oracle.yml` workflow
+drives it:
+
+- **small tier** (PRs + `main`): a matrix over the small corpora. Each leg's report is rendered into
+  a Markdown table — `tools/oracle-report-md.py` (JSON in, Markdown out; the resolution rate,
+  precision/recall, and a **Δ-vs-`main`** column gated on `corpus_profile_hash` + `tool_version`
+  comparability) — and posted both as a job summary and a sticky PR comment (fork-safe two-workflow
+  split: `oracle.yml` → `oracle-pr-comment.yml`, mirroring the Bencher PR pattern). A failed health
+  gate fails the PR.
+- **heavy tier** (release / dispatch): the big corpora on the self-hosted box, converted to BMF
+  (`tools/oracle-report-bmf.py`) and pushed to Bencher as the headline resolution series.

--- a/tools/oracle-report-md.py
+++ b/tools/oracle-report-md.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Render C2 oracle resolution reports (JSON) into a Markdown table for a CI job summary / PR comment.
+
+rag-rat emits the typed `OracleResolutionReport` as JSON only; turning it into Markdown is a glue
+concern (see the output-rendering decision) — this is that glue for the per-PR small tier. Each
+report becomes a row: the per-run before→after resolution (heuristic vs compiler) plus precision /
+recall / monikers. When a comparable BASELINE report (main's last run for the same corpus) is given,
+a Δ-vs-baseline column shows the regression signal.
+
+Comparability mirrors `OracleResolutionReport::comparable_to`: a baseline is only diffed when its
+`report_schema_version`, `corpus_profile_hash`, AND `tool_version` all match — otherwise the numbers
+describe different corpora/indexers, so the Δ is omitted (shown as `— (baseline incomparable)`)
+rather than silently subtracting apples from oranges. A missing baseline degrades to absolute-only.
+
+Usage:
+  oracle-report-md.py --reports a.json b.json [--baselines x.json y.json] > comment.md
+
+Reports/baselines are matched by `corpus_id`. Prints a stable marker comment so a PR sticky-comment
+updater can find and replace its own previous comment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+# A stable HTML-comment marker so the PR sticky-comment step can find + update its prior comment.
+MARKER = "<!-- rag-rat-oracle-report -->"
+
+
+def load(paths: list[str]) -> dict[str, dict]:
+    """Load reports keyed by corpus_id (last wins on a dup id)."""
+    out: dict[str, dict] = {}
+    for path in paths or []:
+        with open(path) as fh:
+            report = json.load(fh)
+        out[report["corpus_id"]] = report
+    return out
+
+
+def rate(numerator: int, denominator: int) -> float:
+    # Mirror the engine's vacuous-100% convention for an empty denominator.
+    return 100.0 if denominator == 0 else 100.0 * numerator / denominator
+
+
+def comparable(report: dict, baseline: dict | None) -> bool:
+    """The `comparable_to` rule: same schema version, profile hash, AND tool version."""
+    return baseline is not None and all(
+        report.get(key) == baseline.get(key)
+        for key in ("report_schema_version", "corpus_profile_hash", "tool_version")
+    )
+
+
+def resolved_after_pct(report: dict) -> float:
+    res = report["resolution"]
+    return rate(res["resolved_after"], res["total_edges"])
+
+
+def row(report: dict, baseline: dict | None) -> str:
+    res = report["resolution"]
+    before = rate(res["resolved_before"], res["total_edges"])
+    after = resolved_after_pct(report)
+    metrics = report.get("metrics", {})
+    precision = 100.0 * metrics.get("precision", 0.0)
+    recall = 100.0 * metrics.get("recall", 0.0)
+
+    if comparable(report, baseline):
+        delta = after - resolved_after_pct(baseline)
+        # Signed pp delta vs main; a regression (negative) reads at a glance.
+        delta_cell = f"{delta:+.1f}pp"
+    elif baseline is None:
+        delta_cell = "— (no baseline)"
+    else:
+        delta_cell = "— (baseline incomparable)"
+
+    return (
+        f"| `{report['corpus_id']}` | {report['tool']} | {res['total_edges']} "
+        f"| {before:.1f}% → {after:.1f}% | {precision:.1f}% | {recall:.1f}% "
+        f"| {report.get('symbols_with_moniker', 0)} | {delta_cell} |"
+    )
+
+
+def render(reports: dict[str, dict], baselines: dict[str, dict]) -> str:
+    lines = [
+        MARKER,
+        "## SCIP oracle — resolution report",
+        "",
+        "Heuristic→compiler edge resolution per corpus. **Δ** compares *resolved-after* to the "
+        "`main` baseline (only when the corpus profile + tool version match).",
+        "",
+        "| corpus | tool | edges | resolved (heuristic → compiler) | precision | recall "
+        "| monikers | Δ vs main |",
+        "|---|---|--:|---|--:|--:|--:|--:|",
+    ]
+    for corpus_id in sorted(reports):
+        lines.append(row(reports[corpus_id], baselines.get(corpus_id)))
+    lines.append("")
+    lines.append(
+        "<sub>resolved = `Exact`/`Syntactic` + compiler upgrades + resolved-external, over edge "
+        "candidates with a callee range. precision/recall are the oracle eval metrics.</sub>"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--reports", nargs="+", required=True)
+    parser.add_argument("--baselines", nargs="*", default=[])
+    args = parser.parse_args()
+
+    reports = load(args.reports)
+    if not reports:
+        sys.exit("oracle-report-md: no reports given")
+    baselines = load(args.baselines)
+    sys.stdout.write(render(reports, baselines))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/oracle-report-md.py
+++ b/tools/oracle-report-md.py
@@ -82,15 +82,21 @@ def row(report: dict, baseline: dict | None) -> str:
 
 
 def render(reports: dict[str, dict], baselines: dict[str, dict]) -> str:
+    # Explicit `+` joins on the multi-line literals (not adjacent-literal implicit concatenation,
+    # which CodeQL flags in a list as a likely missing comma).
     lines = [
         MARKER,
         "## SCIP oracle — resolution report",
         "",
-        "Heuristic→compiler edge resolution per corpus. **Δ** compares *resolved-after* to the "
-        "`main` baseline (only when the corpus profile + tool version match).",
+        (
+            "Heuristic→compiler edge resolution per corpus. **Δ** compares *resolved-after* to the "
+            + "`main` baseline (only when the corpus profile + tool version match)."
+        ),
         "",
-        "| corpus | tool | edges | resolved (heuristic → compiler) | precision | recall "
-        "| monikers | Δ vs main |",
+        (
+            "| corpus | tool | edges | resolved (heuristic → compiler) | precision | recall "
+            + "| monikers | Δ vs main |"
+        ),
         "|---|---|--:|---|--:|--:|--:|--:|",
     ]
     for corpus_id in sorted(reports):
@@ -98,7 +104,7 @@ def render(reports: dict[str, dict], baselines: dict[str, dict]) -> str:
     lines.append("")
     lines.append(
         "<sub>resolved = `Exact`/`Syntactic` + compiler upgrades + resolved-external, over edge "
-        "candidates with a callee range. precision/recall are the oracle eval metrics.</sub>"
+        + "candidates with a callee range. precision/recall are the oracle eval metrics.</sub>"
     )
     return "\n".join(lines) + "\n"
 


### PR DESCRIPTION
The final piece of the multi-language SCIP-oracle runner epic (#164). Turns the small-tier corpus reports into a human-facing Markdown table in CI — a job summary plus a sticky PR comment with a Δ-vs-`main` column.

## What

- **`tools/oracle-report-md.py`** — report JSON (+ optional baseline JSON) → Markdown. One row per corpus: resolution rate (heuristic → compiler), precision/recall, monikers, and a **Δ-vs-`main`** column. rag-rat emits JSON only; Markdown is glue (the TOON+JSON-only output rule). Δ comparability **mirrors `OracleResolutionReport::comparable_to`** — only diffs a baseline when `report_schema_version` + `corpus_profile_hash` + `tool_version` all match; otherwise `— (baseline incomparable)`, and a missing baseline → `— (no baseline)`. Never subtracts incomparable numbers. Emits a stable marker for sticky-comment upsert.
- **`oracle.yml` — new `report` job** (`needs: small`, `if: always()` so a failed health gate is still surfaced): aggregates the per-corpus reports, renders the table to the **job summary**, restores `main`'s reports as the Δ baseline from an Actions cache (and **saves** the new baseline on a `main` push), and on PRs uploads the rendered Markdown for the comment step.
- **`oracle-pr-comment.yml`** — fork-safe step 2 (`workflow_run` on `oracle`, PR events only): downloads the rendered Markdown and upserts a sticky PR comment from base-repo context. The `pull-requests: write` token never touches fork code (mirrors `bench-pr-run` / `bench-pr-track`).

## Example output

| corpus | tool | edges | resolved (heuristic → compiler) | precision | recall | monikers | Δ vs main |
|---|---|--:|---|--:|--:|--:|--:|
| `py-requests` | scip-python | 1060 | 32.5% → 71.7% | 89.9% | 81.0% | 292 | +1.9pp |
| `rust-semver` | rust-analyzer | 1056 | 39.0% → 88.6% | 79.0% | 83.0% | 78 | — (no baseline) |

## Verification

- `oracle-report-md.py` renders the comparable (`+Npp`), incomparable, and no-baseline cases correctly.
- The workflow render snippet (find → word-split → script) verified in real bash; both YAML files parse; `py_compile` clean.

## Epic complete

With this, #164's build-out is done: A1 (CI hygiene), C0 (contract), C1 (profiles), C2 (report core + CLI), B (Python lang + scip-python), C3 (unified runner), and C5 (this). The small tier gates PRs on resolution health and shows the Δ; the heavy tier feeds Bencher.