### PR TITLE
feat(resolve): Python from-import alias resolution scope (#174)

### DIFF
--- a/crates/rag-rat-core/src/index/edges/extract.rs
+++ b/crates/rag-rat-core/src/index/edges/extract.rs
@@ -628,13 +628,42 @@ pub(crate) fn python_edges(
                     EdgeConfidence::NameOnly,
                 ));
             }
+            // Record an alias for the rebind ONLY when the from-import is BOTH module-bound AND
+            // RELATIVE (`from .compat import X as Y`). Two gates:
+            //  - module-bound: a `def`/`class`-nested import binds the alias only in that local
+            //    scope, so a whole-file alias scope would rebind unrelated same-name references; it
+            //    binds file-wide at top level and inside transparent `if`/`try`/`with`/`for`
+            //    blocks.
+            //  - relative: a relative import provably names an IN-CORPUS sibling module, so
+            //    rebinding its alias to the in-corpus target is safe. An ABSOLUTE import (`from
+            //    urllib3.util import Timeout as TimeoutSauce`) is usually EXTERNAL — rebinding
+            //    `TimeoutSauce` → bare `Timeout` would mis-bind to a same-named LOCAL class
+            //    (`requests.exceptions .Timeout`), a real precision regression measured on
+            //    psf/requests (#174 review). Distinguishing absolute-in-corpus from
+            //    absolute-external needs a Python package model we don't have; relative is the
+            //    correct-by-construction in-corpus subset.
+            // A non-recorded alias still emits its plain target Imports edge (dependency captured).
+            let record_alias =
+                is_python_module_bound(node) && python_from_import_is_relative(node, text);
+            let import_start = node.start_byte();
+            // The module root is needed to bound the alias's scope at the next module-scope
+            // rebinding of the alias name (#174 review) — see `python_import_target`.
+            let module_root = record_alias.then(|| python_module_root(node)).flatten();
             let module_id = module.map(|m| m.id());
             let mut cursor = node.walk();
             for child in node.named_children(&mut cursor) {
                 if Some(child.id()) == module_id {
                     continue;
                 }
-                python_import_target(child, text, path, out);
+                python_import_target(
+                    child,
+                    text,
+                    path,
+                    record_alias,
+                    import_start,
+                    module_root,
+                    out,
+                );
             }
         },
         // `import <module>` / `import <module> as alias` — Imports edge to the module, not the
@@ -642,7 +671,7 @@ pub(crate) fn python_edges(
         "import_statement" => {
             let mut cursor = node.walk();
             for child in node.named_children(&mut cursor) {
-                python_import_target(child, text, path, out);
+                python_import_target(child, text, path, false, node.start_byte(), None, out);
             }
         },
         // Function / method / constructor call. Mirror the C handler: the callee is the LAST
@@ -795,7 +824,7 @@ fn emit_python_type_refs(
                 emit_python_type_refs(child, symbols, text, out);
             }
         },
-        "identifier" | "attribute" | "dotted_name" => {
+        "identifier" =>
             if let Some(name) = last_identifier_text(node, text) {
                 out.push(symbol_edge(
                     symbols,
@@ -805,8 +834,35 @@ fn emit_python_type_refs(
                     EdgeConfidence::NameOnly,
                     last_identifier_node(node).map(final_segment_node).map(CalleeRange::of_node),
                 ));
-            }
-        },
+            },
+        // A QUALIFIED type reference (`pkg.Account`, `a.b.C`, `Account.Inner`): record the receiver
+        // AND a dotted qualified name. The receiver_hint marks it qualified (so a bare-leaf alias
+        // rebind skips it — `pkg.Account` is NOT the local alias `Account`) AND lets a
+        // RECEIVER-alias rebind rewrite the root: `Account.Inner` with `Account` an alias
+        // for `User` resolves `User::Inner`, not bare `Inner` (#174 review). Without the
+        // qualified name the rebind would have nothing to rewrite and resolution would fall
+        // back to the ambiguous bare tail.
+        "attribute" | "dotted_name" =>
+            if let Some(name) = last_identifier_text(node, text) {
+                let identifiers = identifiers_under(node, text);
+                let receiver = node
+                    .child_by_field_name("object")
+                    .map(|object| node_text(object, text))
+                    .or_else(|| identifiers.first().cloned());
+                out.push(symbol_edge_with_context(
+                    symbols,
+                    node,
+                    "",
+                    name,
+                    EdgeKind::ReferencesType,
+                    EdgeConfidence::NameOnly,
+                    EdgeContext {
+                        receiver_hint: receiver,
+                        target_qualified_name: dotted_qualified_name(&identifiers),
+                    },
+                    last_identifier_node(node).map(final_segment_node).map(CalleeRange::of_node),
+                ));
+            },
         _ => {},
     }
 }
@@ -874,12 +930,214 @@ fn python_attribute_is_static(node: Node<'_>, text: &str) -> bool {
 /// imported name's dotted tail — NEVER the `as` alias (which is a local binding, not the import). A
 /// comma / parenthesized list (`from pkg import A, B`) nests its clauses under an `import_list`, so
 /// recurse into that.
-fn python_import_target(child: Node<'_>, text: &str, path: &Path, out: &mut Vec<EdgeCandidate>) {
+/// Whether a Python import statement binds its names in the MODULE namespace: true at the top level
+/// and inside top-level `if`/`try`/`with`/`for` blocks (so `try: from x import Y as Z except` still
+/// scopes `Z` file-wide), false inside a `def`/`class`/lambda body (those bind locally). Walks
+/// ancestors to the `module` root, treating block statements as transparent (#174 review).
+fn is_python_module_bound(node: Node<'_>) -> bool {
+    let mut current = node.parent();
+    while let Some(ancestor) = current {
+        match ancestor.kind() {
+            "module" => return true,
+            "function_definition" | "class_definition" | "lambda" => return false,
+            _ => current = ancestor.parent(),
+        }
+    }
+    false
+}
+
+/// Whether a `from … import …` statement is RELATIVE (`from . import x`, `from .compat import y`,
+/// `from ..pkg import z`) rather than absolute (`from urllib3.util import …`). A relative import
+/// names a sibling/parent module WITHIN the same Python package, so its alias is almost always
+/// in-corpus and safe to rebind; an absolute import may be external (#174 review). Detected by a
+/// `relative_import` module node, with a leading-dot text fallback for the `from . import x` shape.
+///
+/// LIMITATION (documented): when the index root/targets cover only a SUBpackage, a parent relative
+/// import (`from ..models import X`) can still point OUTSIDE the indexed targets, and the rebind
+/// would resolve the bare target against an unrelated in-corpus symbol. Closing this needs an
+/// in-corpus Python module/package model (resolve the relative module to an indexed file) — the
+/// same machinery the absolute-in-corpus case wants — which rag-rat does not have yet.
+fn python_from_import_is_relative(node: Node<'_>, text: &str) -> bool {
+    if node.child_by_field_name("module_name").is_some_and(|m| m.kind() == "relative_import") {
+        return true;
+    }
+    node_text(node, text)
+        .strip_prefix("from")
+        .map(|rest| rest.trim_start())
+        .is_some_and(|rest| rest.starts_with('.'))
+}
+
+/// The enclosing `module` node (Python file root), walking up from `node`. `None` only for a
+/// detached node with no module ancestor.
+fn python_module_root(node: Node<'_>) -> Option<Node<'_>> {
+    let mut current = Some(node);
+    while let Some(ancestor) = current {
+        if ancestor.kind() == "module" {
+            return Some(ancestor);
+        }
+        current = ancestor.parent();
+    }
+    None
+}
+
+/// The byte at which the next MODULE-SCOPE rebinding of `name` strictly after `after_byte` takes
+/// effect, or `None` (#174 review). Bounds a from-import alias's scope: Python is order-dependent,
+/// so a later `name = …` / `def name` / `class name` / `type name = …` / re-import reassigns the
+/// name and the alias must not rebind references past that point. Only UNCONDITIONAL top-level
+/// statements (DIRECT children of the `module`) count: a rebinding inside a `def`/`class` body is
+/// local, and one inside a conditional block (`if`/`try`/…) isn't guaranteed — the `try: import …
+/// except: import …` fallback is left ambiguous downstream instead of shadowed by byte order.
+/// Bindings BEFORE the import are excluded by `after_byte`.
+fn python_next_module_binding(
+    module: Node<'_>,
+    name: &str,
+    after_byte: usize,
+    text: &str,
+) -> Option<usize> {
+    let mut best: Option<usize> = None;
+    let mut cursor = module.walk();
+    for child in module.named_children(&mut cursor) {
+        if let Some(byte) = python_rebinding_effective_byte(child, name, text)
+            && byte > after_byte
+        {
+            best = Some(best.map_or(byte, |current: usize| current.min(byte)));
+        }
+    }
+    best
+}
+
+/// The byte at which a top-level statement's rebinding of `name` TAKES EFFECT (past which the alias
+/// is dead), or `None` if it doesn't rebind `name` (#174 review). For an ASSIGNMENT this is the
+/// statement END — the right-hand side still sees the old alias (`Account = Account()` resolves its
+/// RHS to the import) — for a `def`/`class`/`type`/import it is the START (the def's own body refs
+/// are a separate scope; the rare header-annotation case stays bound to the new name). A bare
+/// annotation without a value (`Account: T`) records `__annotations__` but does NOT bind `name`, so
+/// it is skipped. A plain `import a.b.c` binds the TOP-LEVEL `a`, never the dotted tail.
+fn python_rebinding_effective_byte(node: Node<'_>, name: &str, text: &str) -> Option<usize> {
+    match node.kind() {
+        "function_definition" | "class_definition" | "type_alias_statement" => node
+            .child_by_field_name("name")
+            .or_else(|| node.named_child(0))
+            .and_then(|name_node| last_identifier_text(name_node, text))
+            .filter(|defined| defined == name)
+            .map(|_| node.start_byte()),
+        "expression_statement" =>
+            node.named_child(0).and_then(|inner| python_rebinding_effective_byte(inner, name, text)),
+        "assignment"
+            if node.child_by_field_name("right").is_some()
+                && node
+                    .child_by_field_name("left")
+                    .is_some_and(|left| python_assignment_target_binds(left, name, text)) =>
+            Some(node.end_byte()),
+        "import_from_statement" | "import_statement" =>
+            python_import_binds_name(node, name, text).then(|| node.start_byte()),
+        // `del Account` at module scope removes the binding, so the alias is dead from there (#174
+        // review). `del Account.attr` / `del Account[i]` do NOT unbind `Account` itself —
+        // `python_assignment_target_binds` returns false for attribute/subscript targets.
+        "delete_statement" => {
+            let mut cursor = node.walk();
+            node.named_children(&mut cursor)
+                .any(|target| python_assignment_target_binds(target, name, text))
+                .then(|| node.start_byte())
+        },
+        _ => None,
+    }
+}
+
+/// Whether a target binds the bare name `name` — a plain `identifier`, a tuple/list-unpacking
+/// target containing it (`name, other = …`), a starred target (`*name, rest = …`), or a `del`
+/// expression list. An `attribute`/`subscript` target (`name.attr`, `name[i]`) does NOT rebind
+/// `name`.
+fn python_assignment_target_binds(target: Node<'_>, name: &str, text: &str) -> bool {
+    match target.kind() {
+        "identifier" => node_text(target, text) == name,
+        "pattern_list" | "tuple_pattern" | "list_pattern" | "splat_pattern"
+        | "list_splat_pattern" | "expression_list" => {
+            let mut cursor = target.walk();
+            target
+                .named_children(&mut cursor)
+                .any(|element| python_assignment_target_binds(element, name, text))
+        },
+        _ => false,
+    }
+}
+
+/// Whether an import statement binds `name`. The bound name depends on the import FORM (#174
+/// review): a `from m import T as name` / `from m import name` binds the imported LEAF, but a plain
+/// `import a.b.c` binds only the TOP-LEVEL `a` (Python doesn't bind the dotted tail) — `import
+/// a.b.c as name` binds the alias. So an `import other.Account` does NOT rebind `Account`.
+fn python_import_binds_name(node: Node<'_>, name: &str, text: &str) -> bool {
+    let from_import = node.kind() == "import_from_statement";
+    let module_id = node.child_by_field_name("module_name").map(|module| module.id());
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor).any(|child| {
+        if Some(child.id()) == module_id {
+            return false;
+        }
+        match child.kind() {
+            "aliased_import" => child
+                .child_by_field_name("alias")
+                .and_then(|alias| last_identifier_text(alias, text))
+                .is_some_and(|alias| alias == name),
+            // from-import: the imported leaf (`from m import Account`). plain import: the top-level
+            // segment of the dotted module path (`import other.Account` binds `other`).
+            "dotted_name" if from_import =>
+                last_identifier_text(child, text).is_some_and(|leaf| leaf == name),
+            "dotted_name" => first_identifier_text(child, text).is_some_and(|root| root == name),
+            "import_list" => python_import_binds_name(child, name, text),
+            _ => false,
+        }
+    })
+}
+
+fn python_import_target(
+    child: Node<'_>,
+    text: &str,
+    path: &Path,
+    record_alias: bool,
+    import_start: usize,
+    module_root: Option<Node<'_>>,
+    out: &mut Vec<EdgeCandidate>,
+) {
     if child.kind() == "import_list" {
         let mut cursor = child.walk();
         for clause in child.named_children(&mut cursor) {
-            python_import_target(clause, text, path, out);
+            python_import_target(clause, text, path, record_alias, import_start, module_root, out);
         }
+        return;
+    }
+    // `from <module> import <target> as <alias>` — a SYMBOL alias (#174). Emit the Imports edge to
+    // the target (so the in-corpus dependency is recorded) but carry the alias in `evidence` + an
+    // import scope, so resolution can rebind a later `alias` reference to `target`. Recorded only
+    // for a top-level import (`record_alias`, checked by the caller); `import x as m` (module
+    // alias) is a qualified-resolution problem, left out of scope.
+    if record_alias
+        && child.kind() == "aliased_import"
+        && let Some(target_node) = child.child_by_field_name("name")
+        && let Some(target) = last_identifier_text(target_node, text)
+        && let Some(alias_node) = child.child_by_field_name("alias")
+        && let Some(alias) = last_identifier_text(alias_node, text)
+    {
+        // The alias binding is valid from the import until the name is REBOUND at module scope —
+        // Python is order-dependent, so a later `alias = …` / `def alias` / `class alias` /
+        // re-import reassigns the name and the alias must not rebind references past that point
+        // (#174 review). `scope_end` is that next module-scope rebinding, else end of file. Only
+        // module-scope bindings count (a binding inside a def/class body is local), and the scan is
+        // ordered by byte, so a definition BEFORE the import does not shrink the scope.
+        let scope_end = module_root
+            .and_then(|root| python_next_module_binding(root, &alias, import_start, text))
+            .unwrap_or(text.len());
+        let scope =
+            ImportScopeRange { scope_start: import_start, scope_end, mod_id: MOD_FILE_ROOT };
+        out.push(file_edge_scoped(
+            path,
+            target_node,
+            target,
+            Some(alias),
+            EdgeKind::Imports,
+            EdgeConfidence::NameOnly,
+            Some(scope),
+        ));
         return;
     }
     let target = match child.kind() {
@@ -1355,5 +1613,273 @@ mod python_edge_tests {
             has(&e, EdgeKind::ReferencesType, "str"),
             "annotation ReferencesType missing: {e:?}"
         );
+    }
+
+    /// The Imports edge carrying a from-import alias (`from m import User as Account`): its
+    /// `to_name` is the imported target, `evidence` is the alias, and — unlike the plain dependency
+    /// edge (whose evidence defaults to its own name) — it carries an import scope so resolution
+    /// can rebind alias references (#174). The import scope is what marks it as an alias
+    /// binding.
+    fn aliased_import<'e>(edges: &'e [EdgeCandidate], target: &str) -> Option<&'e EdgeCandidate> {
+        edges.iter().find(|e| {
+            e.edge_kind == EdgeKind::Imports && e.to_name == target && e.import_scope.is_some()
+        })
+    }
+
+    #[test]
+    fn top_level_relative_from_import_alias_carries_scope_and_evidence() {
+        // A module-level RELATIVE `from .models import User as Account` binds `Account` file-wide
+        // and is safe to rebind (the module is provably in-corpus) (#174 review).
+        let e = edges("from .models import User as Account\n");
+        let imp = aliased_import(&e, "User").expect("aliased import edge for User");
+        assert_eq!(imp.evidence.as_deref(), Some("Account"), "alias must ride on evidence");
+        assert!(imp.import_scope.is_some(), "module-level alias must carry an import scope");
+    }
+
+    #[test]
+    fn absolute_external_from_import_alias_is_not_recorded() {
+        // `from urllib3.util import Timeout as TimeoutSauce` — an ABSOLUTE import, usually
+        // EXTERNAL. Rebinding `TimeoutSauce` → bare `Timeout` would mis-bind to a
+        // same-named LOCAL class (the measured psf/requests precision regression), so no
+        // alias scope is recorded — only the plain dependency edge to the target (#174
+        // review). The dotted module tail still imports.
+        let e = edges("from urllib3.util import Timeout as TimeoutSauce\n");
+        assert!(
+            has(&e, EdgeKind::Imports, "Timeout"),
+            "the dependency edge is still emitted: {e:?}"
+        );
+        assert!(
+            aliased_import(&e, "Timeout").is_none(),
+            "an absolute (external) alias must NOT carry a rebind scope: {e:?}"
+        );
+    }
+
+    #[test]
+    fn try_block_from_import_alias_is_module_bound() {
+        // The `try: import X as Y except ImportError:` fallback pattern binds in the MODULE
+        // namespace — a top-level `try` block is transparent (#174 review).
+        let e = edges(
+            "try:\n    from .fast import Engine as DB\nexcept ImportError:\n    from .slow import \
+             Engine as DB\n",
+        );
+        let imp = aliased_import(&e, "Engine").expect("aliased import edge for Engine");
+        assert_eq!(imp.evidence.as_deref(), Some("DB"));
+        assert!(imp.import_scope.is_some(), "try-block alias must still be module-scoped");
+    }
+
+    #[test]
+    fn function_nested_from_import_alias_is_not_recorded() {
+        // An import inside a `def` binds the alias LOCALLY, not file-wide — recording it whole-file
+        // would rebind unrelated same-name references, so no alias is carried (#174 review). The
+        // plain dependency edge to the target is still emitted.
+        let e =
+            edges("def load():\n    from .models import User as Account\n    return Account()\n");
+        assert!(
+            has(&e, EdgeKind::Imports, "User"),
+            "the dependency edge to the target is still emitted: {e:?}"
+        );
+        assert!(
+            aliased_import(&e, "User").is_none(),
+            "a function-nested alias must not be recorded file-wide: {e:?}"
+        );
+    }
+
+    #[test]
+    fn qualified_type_reference_carries_a_receiver_hint() {
+        // `x: pkg.Account` is a qualified type reference — the receiver hint marks it so the alias
+        // rebind skips it (`pkg.Account` is not the local alias `Account`) (#174 review).
+        let e = edges("def f(x: pkg.Account) -> None:\n    pass\n");
+        let ref_edge = e
+            .iter()
+            .find(|c| c.edge_kind == EdgeKind::ReferencesType && c.to_name == "Account")
+            .expect("qualified type reference edge");
+        assert_eq!(ref_edge.receiver_hint.as_deref(), Some("pkg"));
+    }
+
+    /// The alias edge's `scope_end` — where extraction decided the alias stops applying because the
+    /// name is rebound at module scope (#174 review).
+    fn alias_scope_end(edges: &[EdgeCandidate], target: &str) -> usize {
+        aliased_import(edges, target)
+            .and_then(|e| e.import_scope)
+            .expect("aliased import edge with a scope")
+            .scope_end
+    }
+
+    #[test]
+    fn alias_scope_runs_to_eof_with_no_redefinition() {
+        // No later rebinding of `Account`: the alias is in effect for the whole file.
+        let src = "from .models import User as Account\nAccount()\n";
+        let e = edges(src);
+        assert_eq!(alias_scope_end(&e, "User"), src.len(), "scope should run to EOF");
+    }
+
+    #[test]
+    fn alias_scope_ends_at_a_later_class_redefinition() {
+        // `class Account` after the import reassigns the name at module scope; the alias must stop
+        // there so a later `Account()` resolves to the local class, not the import.
+        let src = "from .models import User as Account\nclass Account:\n    pass\n";
+        let e = edges(src);
+        assert_eq!(alias_scope_end(&e, "User"), src.find("class Account").unwrap());
+    }
+
+    #[test]
+    fn alias_scope_ends_at_a_later_module_assignment() {
+        // A plain lowercase module assignment (`Account = ...`) is NOT indexed as a symbol, so only
+        // this extraction-time scan catches it — the round-2 `latest_def_before` could not. The
+        // scope ends at the assignment's END, not its start, so the RHS still sees the alias
+        // (`Account = Account()` resolves its RHS to the import, #174 review).
+        let src = "from .models import User as Account\nAccount = make_account()\n";
+        let e = edges(src);
+        let stmt = "Account = make_account()";
+        let expected = src.find(stmt).unwrap() + stmt.len();
+        assert_eq!(
+            alias_scope_end(&e, "User"),
+            expected,
+            "scope ends after the assignment, not before"
+        );
+    }
+
+    #[test]
+    fn alias_scope_ends_at_a_starred_unpacking_rebinding() {
+        // `*Account, rest = rows` rebinds `Account` at module scope through a starred target (#174
+        // review) — the scan must look inside `splat_pattern`/`list_splat_pattern`.
+        let src = "from .models import User as Account\n*Account, rest = rows\n";
+        let e = edges(src);
+        let stmt = "*Account, rest = rows";
+        let expected = src.find(stmt).unwrap() + stmt.len();
+        assert_eq!(alias_scope_end(&e, "User"), expected, "a starred unpack must end the scope");
+    }
+
+    #[test]
+    fn alias_scope_ends_at_a_module_level_del() {
+        // `del Account` removes the binding, so the alias is dead from there (#174 review).
+        let src = "from .models import User as Account\ndel Account\nAccount()\n";
+        let e = edges(src);
+        assert_eq!(alias_scope_end(&e, "User"), src.find("del Account").unwrap());
+    }
+
+    #[test]
+    fn alias_scope_ignores_a_del_of_an_attribute() {
+        // `del Account.cache` removes an attribute, NOT the `Account` binding — the alias survives.
+        let src = "from .models import User as Account\ndel Account.cache\nAccount()\n";
+        let e = edges(src);
+        assert_eq!(
+            alias_scope_end(&e, "User"),
+            src.len(),
+            "a `del` of an attribute must not end the scope"
+        );
+    }
+
+    #[test]
+    fn alias_scope_covers_the_rhs_of_its_own_rebinding() {
+        // `Account = Account()` — the RHS `Account()` evaluates BEFORE the new binding takes
+        // effect, so it must still be inside the alias scope (#174 review). The RHS call's
+        // byte is < scope_end.
+        let src = "from .models import User as Account\nAccount = Account()\n";
+        let e = edges(src);
+        let scope_end = alias_scope_end(&e, "User");
+        let rhs_call = src.rfind("Account()").unwrap();
+        assert!(rhs_call < scope_end, "the RHS reference must fall within the alias scope");
+    }
+
+    #[test]
+    fn alias_scope_ends_at_a_later_type_alias() {
+        // PEP 695 `type Account = int` rebinds the name at module scope (#174 review).
+        let src = "from .models import User as Account\ntype Account = int\n";
+        let e = edges(src);
+        assert_eq!(alias_scope_end(&e, "User"), src.find("type Account").unwrap());
+    }
+
+    #[test]
+    fn alias_scope_ignores_a_value_less_annotation() {
+        // `Account: type[User]` records `__annotations__` but does NOT bind `Account` (no value),
+        // so the alias is still in effect afterward (#174 review).
+        let src = "from .models import User as Account\nAccount: type[User]\nAccount()\n";
+        let e = edges(src);
+        assert_eq!(
+            alias_scope_end(&e, "User"),
+            src.len(),
+            "a value-less annotation must not shrink scope"
+        );
+    }
+
+    #[test]
+    fn alias_scope_ignores_a_plain_dotted_import() {
+        // `import other.Account` binds the top-level `other`, never the dotted tail `Account`, so
+        // it must not end an `Account` alias (#174 review).
+        let src = "from .models import User as Account\nimport other.Account\nAccount()\n";
+        let e = edges(src);
+        assert_eq!(
+            alias_scope_end(&e, "User"),
+            src.len(),
+            "a plain dotted import of the tail must not shrink scope"
+        );
+    }
+
+    #[test]
+    fn alias_scope_ignores_a_conditional_rebinding() {
+        // A rebinding inside a top-level `if`/`try` block isn't guaranteed to execute, so it must
+        // not shrink the alias scope by byte order (#174 review) — the ambiguity is left to
+        // the resolver.
+        let src =
+            "from .models import User as Account\nif flag:\n    Account = other()\nAccount()\n";
+        let e = edges(src);
+        assert_eq!(
+            alias_scope_end(&e, "User"),
+            src.len(),
+            "a conditional rebinding must not shrink scope"
+        );
+    }
+
+    #[test]
+    fn qualified_type_reference_carries_a_qualified_name() {
+        // `x: Account.Inner` — a qualified type ref carries BOTH the receiver hint and a dotted
+        // qualified name, so a receiver-alias rebind can rewrite the root to `User::Inner` (#174
+        // review).
+        let e = edges("def f(x: Account.Inner) -> None:\n    pass\n");
+        let ref_edge = e
+            .iter()
+            .find(|c| c.edge_kind == EdgeKind::ReferencesType && c.to_name == "Inner")
+            .expect("qualified type reference edge");
+        assert_eq!(ref_edge.receiver_hint.as_deref(), Some("Account"));
+        assert_eq!(ref_edge.target_qualified_name.as_deref(), Some("Account::Inner"));
+    }
+
+    #[test]
+    fn alias_scope_ignores_a_nested_redefinition() {
+        // A `class Account` INSIDE a function binds locally, not at module scope, so it must not
+        // shrink the alias scope (the round-2 whole-symbol scan wrongly counted nested defs).
+        let src =
+            "from .models import User as Account\ndef f():\n    class Account:\n        pass\n";
+        let e = edges(src);
+        assert_eq!(alias_scope_end(&e, "User"), src.len(), "a nested redef must not shrink scope");
+    }
+
+    #[test]
+    fn alias_scope_ignores_an_attribute_assignment() {
+        // `Account.config = x` mutates an attribute; it does NOT rebind `Account` itself, so the
+        // alias scope must not stop there.
+        let src = "from .models import User as Account\nAccount.config = 1\nAccount()\n";
+        let e = edges(src);
+        assert_eq!(
+            alias_scope_end(&e, "User"),
+            src.len(),
+            "an attribute set must not shrink scope"
+        );
+    }
+
+    #[test]
+    fn alias_scope_starts_after_a_definition_before_the_import() {
+        // A `class Account` BEFORE the import does not shadow it (the import is the later binding):
+        // scope_start is the import, scope_end runs to EOF.
+        let src = "class Account:\n    pass\n\n\nfrom .models import User as Account\nAccount()\n";
+        let e = edges(src);
+        let scope = aliased_import(&e, "User").and_then(|edge| edge.import_scope).expect("scope");
+        assert_eq!(
+            scope.scope_start,
+            src.find("from .models").unwrap(),
+            "scope starts at the import"
+        );
+        assert_eq!(scope.scope_end, src.len(), "a redef before the import does not shrink scope");
     }
 }

--- a/crates/rag-rat-core/src/index/edges/imports.rs
+++ b/crates/rag-rat-core/src/index/edges/imports.rs
@@ -415,6 +415,27 @@ pub(crate) struct ImportScope {
     /// `Url`. Only a genuinely non-Cargo corpus (no manifest at all) fails open. Set true by
     /// [`Self::mark_has_manifests`] when any package row is loaded.
     has_manifests: bool,
+    /// Per-file Python import aliases: `alias name → its bindings` (#174). A `from m import T as
+    /// A` records `A → T` so a later reference to `A` resolves to the IMPORTED symbol `T`, not
+    /// an unrelated local `A`. Distinct from `by_file` (Rust external-import suppression):
+    /// this REBINDS an alias use to its in-corpus target name, rather than just flagging it
+    /// external.
+    python_aliases: HashMap<i64, HashMap<String, Vec<PythonAlias>>>,
+}
+
+/// One Python import alias binding: the imported target name the alias stands for, scoped to a byte
+/// range (whole-file today — Python imports are module-global). Mirrors [`ImportBinding`] but
+/// carries the TARGET name (for rebinding) rather than the crate root (for external detection).
+struct PythonAlias {
+    target: String,
+    scope_start: usize,
+    scope_end: usize,
+}
+
+impl PythonAlias {
+    fn covers(&self, ref_byte: usize) -> bool {
+        ref_byte >= self.scope_start && ref_byte < self.scope_end
+    }
 }
 
 impl ImportScope {
@@ -438,6 +459,56 @@ impl ImportScope {
     /// dep alias keys).
     pub(crate) fn set_package_roots(&mut self, package_id: i64, roots: HashSet<String>) {
         self.package_roots.insert(package_id, roots);
+    }
+
+    /// Record a Python `from <module> import <target> as <alias>` binding (#174): `alias → target`,
+    /// scoped to the import's byte range. The carrier is the aliased import's Imports edge — its
+    /// `to_name` is `target` and its `evidence` is `alias` (set by extraction's
+    /// `python_import_target`).
+    pub(crate) fn add_python_alias(
+        &mut self,
+        file_id: i64,
+        alias: String,
+        target: String,
+        scope: Option<ImportScopeRange>,
+    ) {
+        // A binding with no scope can't be range-tested; skip rather than bind file-wide blindly.
+        let Some(scope) = scope else { return };
+        self.python_aliases.entry(file_id).or_default().entry(alias).or_default().push(
+            PythonAlias { target, scope_start: scope.scope_start, scope_end: scope.scope_end },
+        );
+    }
+
+    /// The imported target name a Python alias `name` stands for at `ref_byte`, if any (#174). The
+    /// caller resolves the reference under this target name instead of the alias — so `Account()`
+    /// after `from models import User as Account` binds to `User`. `None` for non-Python files (the
+    /// map is empty) or a name that isn't an in-scope alias.
+    pub(crate) fn python_alias_target(
+        &self,
+        file_id: i64,
+        name: &str,
+        ref_byte: usize,
+    ) -> Option<&str> {
+        // The bindings covering `ref_byte` (#174 review). A sequential re-import
+        // (`from m1 import User as Account; from m2 import Customer as Account`) leaves exactly ONE
+        // covering binding at any byte — extraction's `python_next_module_binding` shrinks each
+        // earlier binding's `scope_end` to the next UNCONDITIONAL rebinding, so the ranges abut.
+        // The only way two cover the same byte is mutually-exclusive CONDITIONAL branches
+        // (`try: import … as A except: import … as A`), neither of which shrinks the other; when
+        // those name DIFFERENT targets the alias is genuinely AMBIGUOUS, so resolve nothing rather
+        // than pick one by byte order. All-same-target overlaps (try/except importing the same
+        // symbol from different modules) still resolve.
+        let mut covering = self
+            .python_aliases
+            .get(&file_id)?
+            .get(name)?
+            .iter()
+            .filter(|alias| alias.covers(ref_byte));
+        let first = covering.next()?;
+        if covering.any(|alias| alias.target != first.target) {
+            return None;
+        }
+        Some(first.target.as_str())
     }
 
     /// Record one Imports edge for `file_id`. An inline-`mod` edge (scope present, but `use_text`

--- a/crates/rag-rat-core/src/index/edges/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/mod.rs
@@ -479,6 +479,16 @@ impl<'a> SymbolIndex<'a> {
         }
         Self { by_qualified, by_scope_path, by_name, by_qn_tail, file_language }
     }
+
+    /// Whether `file_id` itself defines a symbol named `name`. The Python alias rebind uses this to
+    /// DEFER when the imported target's bare name is ALSO defined locally (#174 review): a bare
+    /// rewrite of `Account` → `User` could grab a same-file `User` instead of the import, so leave
+    /// it to normal resolution. (The alias-shadow ordering — a same-module `class Account` /
+    /// `Account = …` after the import reassigning the name — is handled at extraction by bounding
+    /// the alias's `scope_end` at the next module-scope rebinding, not here.)
+    pub(crate) fn file_defines(&self, file_id: i64, name: &str) -> bool {
+        self.by_name.get(name).is_some_and(|symbols| symbols.iter().any(|s| s.file_id == file_id))
+    }
 }
 
 pub(crate) struct ResolveSymbolRequest<'a> {

--- a/crates/rag-rat-core/src/index/edges/resolve/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use super::*;
 
@@ -16,6 +16,92 @@ fn import_scope_from_row(
         scope_end: usize::try_from(scope_end.unwrap_or(0)).unwrap_or(0),
         mod_id: mod_id.unwrap_or(MOD_FILE_ROOT),
     })
+}
+
+/// How a Python from-import alias reference is rewritten before resolution (#174). Empty (all
+/// `None`) when nothing is an in-scope alias. The order/scope correctness lives in extraction:
+/// each alias binding's `scope_end` already stops at the next module-scope rebinding of the name,
+/// so `python_alias_target` only returns an alias that is genuinely in effect at `ref_byte`.
+#[derive(Default)]
+struct PythonAliasRebind {
+    /// Override the leaf name passed to `resolve_symbol` — a BARE alias reference (`Account()` →
+    /// resolve `User`).
+    name: Option<String>,
+    /// Override `target_qualified_name` — a QUALIFIED reference whose receiver root is an alias
+    /// (`Account.from_id` → `User.from_id`).
+    target_qualified_name: Option<String>,
+    /// Override `receiver_hint` — the rebound receiver (`Account` → `User`).
+    receiver_hint: Option<String>,
+}
+
+/// Resolve a Python from-import alias to its imported target name, or `None` (#174). Picks the
+/// alias in effect at `ref_byte` (extraction already bounded its scope at the next module-scope
+/// rebinding), then declines if the file ALSO defines the target's bare name locally — a bare
+/// rewrite could grab the local definition instead of the import, so leave it to normal resolution
+/// (no edge beats a wrong one).
+fn python_alias_target<'i>(
+    import_scope: &'i imports::ImportScope,
+    index: &SymbolIndex<'_>,
+    file_id: i64,
+    name: &str,
+    ref_byte: usize,
+) -> Option<&'i str> {
+    let target = import_scope.python_alias_target(file_id, name, ref_byte)?;
+    if index.file_defines(file_id, short_name(target)) {
+        return None;
+    }
+    Some(target)
+}
+
+/// Rewrite a Python from-import alias reference before resolution (#174). A BARE reference
+/// (`Account()`) rebinds the leaf; a QUALIFIED reference rebinds only the RECEIVER root
+/// (`Account.from_id()` → `User.from_id`), never the leaf — `pkg.Account` is `pkg`'s member, not
+/// the local alias `Account`, so the leaf of a qualified reference is never treated as an alias.
+///
+/// MODEL BOUNDARY: this is a MODULE-scope alias model (#174 review). The alias's scope is bounded
+/// at the next MODULE-scope rebinding of the name (extraction's `python_next_module_binding`). It
+/// does NOT model per-nested-scope lexical shadowing: a reference inside a `def`/`class` body that
+/// has its OWN local binding of the alias name is still rebound to the module import. That is rare
+/// (a nested local class/def reusing an imported alias's exact name) and resolving it would require
+/// full lexical-scope analysis at the reference site, beyond "module-scope binding statements".
+fn python_alias_rebind(
+    import_scope: &imports::ImportScope,
+    index: &SymbolIndex<'_>,
+    file_id: i64,
+    to_name: &str,
+    target_qualified_name: Option<&str>,
+    receiver_hint: Option<&str>,
+    ref_byte: usize,
+) -> PythonAliasRebind {
+    match receiver_hint {
+        Some(receiver) => {
+            let Some(target) =
+                python_alias_target(import_scope, index, file_id, receiver, ref_byte)
+            else {
+                return PythonAliasRebind::default();
+            };
+            PythonAliasRebind {
+                name: None,
+                target_qualified_name: target_qualified_name
+                    .map(|qualified| replace_qualified_root(qualified, target)),
+                receiver_hint: Some(target.to_string()),
+            }
+        },
+        None => {
+            let target =
+                python_alias_target(import_scope, index, file_id, short_name(to_name), ref_byte);
+            PythonAliasRebind { name: target.map(str::to_string), ..PythonAliasRebind::default() }
+        },
+    }
+}
+
+/// Replace the first `::`-separated segment (the receiver root) of a dotted qualified name with
+/// `root` — `replace_qualified_root("Account::from_id", "User") == "User::from_id"`.
+fn replace_qualified_root(qualified: &str, root: &str) -> String {
+    match qualified.split_once("::") {
+        Some((_, rest)) => format!("{root}::{rest}"),
+        None => root.to_string(),
+    }
 }
 
 /// Load the per-package local-crate sets and COMPUTE each active file's owning package into `scope`
@@ -158,17 +244,28 @@ pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
         // `evidence`. Building the per-file module interval set here is once-per-pass, not
         // per-edge.
         let mut stmt = conn.prepare(
-            "SELECT d.source_file_id, d.evidence, d.import_scope_start_byte, \
-             d.import_scope_end_byte, d.import_mod_id FROM edges_data d JOIN files ON files.id = \
-             d.source_file_id JOIN edge_strings ek ON ek.id = d.edge_kind_id WHERE ek.value = \
+            "SELECT d.source_file_id, files.language, tn.value, d.evidence, \
+             d.import_scope_start_byte, d.import_scope_end_byte, d.import_mod_id FROM edges_data \
+             d JOIN files ON files.id = d.source_file_id JOIN edge_strings ek ON ek.id = \
+             d.edge_kind_id LEFT JOIN edge_strings tn ON tn.id = d.to_name_id WHERE ek.value = \
              'imports'",
         )?;
         let mut rows = stmt.query([])?;
         while let Some(row) = rows.next()? {
             let file_id: i64 = row.get(0)?;
-            let evidence: Option<String> = row.get(1)?;
-            let scope = import_scope_from_row(row.get(2)?, row.get(3)?, row.get(4)?);
-            if let Some(evidence) = evidence {
+            let language: String = row.get(1)?;
+            let to_name: Option<String> = row.get(2)?;
+            let evidence: Option<String> = row.get(3)?;
+            let scope = import_scope_from_row(row.get(4)?, row.get(5)?, row.get(6)?);
+            if language == Language::Python.as_str() {
+                // A Python `from m import T as A` alias edge carries `evidence = A` (alias),
+                // `to_name = T` (target), and a whole-file scope (#174); non-aliased Python imports
+                // have no scope and `add_python_alias` skips them. Python imports never go through
+                // `add_use` (that parses Rust `use` text).
+                if let (Some(alias), Some(target)) = (evidence, to_name) {
+                    import_scope.add_python_alias(file_id, alias, target, scope);
+                }
+            } else if let Some(evidence) = evidence {
                 import_scope.add_use(file_id, &evidence, scope);
             }
         }
@@ -215,13 +312,34 @@ pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
     {
         // The reference's byte position drives the module-aware covering test (#61).
         let ref_byte = usize::try_from(source_start_byte).unwrap_or(0);
+        // Python from-import alias rebind (#174): resolve a reference written under an alias using
+        // its imported TARGET — `Account()` after `from m import User as Account` binds to `User`,
+        // and `Account.from_id()` to `User.from_id`. Only reference edges — the Imports edge itself
+        // already names the real target. Non-Python files have no alias entries (cheap miss).
+        let rebind = if edge_kind == EdgeKind::Imports.as_str() {
+            PythonAliasRebind::default()
+        } else {
+            python_alias_rebind(
+                &import_scope,
+                &index,
+                source_file_id,
+                &to_name,
+                target_qualified_name.as_deref(),
+                receiver_hint.as_deref(),
+                ref_byte,
+            )
+        };
+        let resolve_name = rebind.name.as_deref().unwrap_or(to_name.as_str());
+        let resolve_qualified =
+            rebind.target_qualified_name.as_deref().or(target_qualified_name.as_deref());
+        let resolve_receiver = rebind.receiver_hint.as_deref().or(receiver_hint.as_deref());
         let resolution = resolve_symbol(
             ResolveSymbolRequest {
-                name: &to_name,
-                target_qualified_name: target_qualified_name.as_deref(),
+                name: resolve_name,
+                target_qualified_name: resolve_qualified,
                 edge_kind: &edge_kind,
                 evidence: evidence.as_deref(),
-                receiver_hint: receiver_hint.as_deref(),
+                receiver_hint: resolve_receiver,
                 source_file_id,
                 source_language: index.file_language.get(&source_file_id).copied(),
                 imported_external: import_scope.is_external_import(
@@ -332,10 +450,37 @@ pub(crate) fn resolve_and_insert_edges(
     // accumulator vs DB rows).
     let mut import_scope = imports::ImportScope::new(imports::load_local_roots(conn));
     load_package_roots_into_scope(conn, &mut import_scope)?;
+    // File languages from the DB, NOT `index.file_language` (built only from files that contributed
+    // a symbol). A Python entrypoint that ONLY does `from m import X as A; A()` has no symbol row
+    // for its own file, so `index.file_language` would miss it and the alias carrier would feed
+    // neither `add_python_alias` nor `add_use` under `index --full` (#174 review); the DB row
+    // is authoritative. The incremental driver already joins `files.language`, so this keeps
+    // the two drivers in lockstep.
+    let file_language: HashMap<i64, String> = {
+        let mut stmt = conn.prepare("SELECT id, language FROM files")?;
+        let rows =
+            stmt.query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)))?;
+        rows.collect::<Result<_, _>>()?
+    };
     for (file_id, candidate) in &edges {
         if candidate.edge_kind == EdgeKind::Imports {
             let evidence = arena.get_opt(candidate.evidence).unwrap_or("");
-            import_scope.add_use(*file_id, evidence, candidate.import_scope_range());
+            if file_language.get(file_id).map(String::as_str) == Some(Language::Python.as_str()) {
+                // Python from-import alias carrier (#174): evidence = alias, to_name = target,
+                // whole-file scope. Non-aliased Python imports have no scope → `add_python_alias`
+                // skips them; Python imports never feed `add_use` (Rust `use`-text parsing).
+                let target = arena.get(candidate.to_name).trim();
+                if !evidence.is_empty() && !target.is_empty() {
+                    import_scope.add_python_alias(
+                        *file_id,
+                        evidence.to_string(),
+                        target.to_string(),
+                        candidate.import_scope_range(),
+                    );
+                }
+            } else {
+                import_scope.add_use(*file_id, evidence, candidate.import_scope_range());
+            }
         }
     }
     import_scope.finalize();
@@ -374,13 +519,33 @@ pub(crate) fn resolve_and_insert_edges(
         // The reference's byte position drives the module-aware covering test (#61) — same input
         // the DB driver reads from `source_start_byte`.
         let ref_byte = candidate.source_span.start_byte as usize;
+        // Python from-import alias rebind (#174): mirror the DB driver — resolve a reference under
+        // its imported TARGET, so `Account()` binds to `User` and `Account.from_id()` to
+        // `User.from_id`. Imports edges keep their own target name; non-Python files have no alias
+        // entries.
+        let rebind = if candidate.edge_kind == EdgeKind::Imports {
+            PythonAliasRebind::default()
+        } else {
+            python_alias_rebind(
+                &import_scope,
+                &index,
+                *file_id,
+                to_name,
+                target_qualified_name,
+                receiver_hint,
+                ref_byte,
+            )
+        };
+        let resolve_name = rebind.name.as_deref().unwrap_or(to_name);
+        let resolve_qualified = rebind.target_qualified_name.as_deref().or(target_qualified_name);
+        let resolve_receiver = rebind.receiver_hint.as_deref().or(receiver_hint);
         let resolution = resolve_symbol(
             ResolveSymbolRequest {
-                name: to_name,
-                target_qualified_name,
+                name: resolve_name,
+                target_qualified_name: resolve_qualified,
                 edge_kind: candidate.edge_kind.as_str(),
                 evidence,
-                receiver_hint,
+                receiver_hint: resolve_receiver,
                 source_file_id: *file_id,
                 source_language: index.file_language.get(file_id).copied(),
                 imported_external: import_scope.is_external_import(

--- a/crates/rag-rat-core/src/index/edges/resolve/tests.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/tests.rs
@@ -665,3 +665,365 @@ fn python_implements_ignores_a_foreign_language_class() {
     let (to, _confidence, _resolution) = edge_state(&conn, edge);
     assert_eq!(to, None, "a Python base must not bind to a foreign-language class");
 }
+/// #174: a Python `from <module> import <T> as <alias>` makes a later reference to `alias` resolve
+/// to the imported `T`, NOT an unrelated local symbol named `alias`. The aliased import's Imports
+/// edge carries `to_name = T` (target), `evidence = alias`, and a whole-file import scope; the
+/// resolver registers `alias → T` and rebinds the alias use before name resolution.
+#[test]
+fn python_from_import_alias_rebinds_to_the_imported_target() {
+    let conn = seeded_conn();
+    let app = add_py_file(&conn, "app.py");
+    let models = add_py_file(&conn, "models.py");
+    let other = add_py_file(&conn, "other.py");
+    // The import target, and a DECOY local symbol that shares the ALIAS name.
+    let user = add_py_symbol(&conn, models, "User", "models.py::User");
+    let decoy = add_py_symbol(&conn, other, "Account", "other.py::Account");
+    // `from models import User as Account` → alias carrier: target `User`, alias `Account`, whole-
+    // file scope [0, 200).
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, evidence, \
+         source_start_byte, import_scope_start_byte, import_scope_end_byte, import_mod_id) VALUES \
+         (?1, 'User', 'imports', 'NameOnly', 'unresolved', 'Account', 0, 0, 200, -1)",
+        params![app],
+    )
+    .unwrap();
+    // `Account()` at byte 50 (inside the import scope).
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, \
+         source_start_byte) VALUES (?1, 'Account', 'calls_name', 'NameOnly', 'unresolved', 50)",
+        params![app],
+    )
+    .unwrap();
+    let call: i64 = conn.query_row("SELECT MAX(id) FROM edges_data", [], |r| r.get(0)).unwrap();
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    let (to, confidence, _resolution) = edge_state(&conn, call);
+    assert_eq!(
+        to,
+        Some(user),
+        "alias `Account` must rebind to the imported `User`, not the local decoy {decoy}"
+    );
+    assert_ne!(confidence, "NameOnly", "the rebound alias reference resolves");
+}
+
+/// #174 review: the alias's `scope_end` bounds the rebind — a reference PAST it (where extraction
+/// found the name rebound at module scope) is not covered, so it falls through to normal resolution
+/// and binds the local `class Account`. The order/shadow computation itself lives in extraction
+/// (`python_next_module_binding`); here we check the resolver honors the resulting `scope_end`.
+#[test]
+fn python_alias_rebind_respects_the_scope_end_shadow() {
+    let conn = seeded_conn();
+    let app = add_py_file(&conn, "app.py");
+    let models = add_py_file(&conn, "models.py");
+    add_py_symbol(&conn, models, "User", "models.py::User");
+    // A LOCAL `class Account` at byte 30 — extraction would set the alias `scope_end` here.
+    let local_account = add_py_symbol_at(&conn, app, "Account", "app.py::Account", 30);
+    // Alias scope is [0, 30): the rebind applies before the redefinition, not after.
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, evidence, \
+         source_start_byte, import_scope_start_byte, import_scope_end_byte, import_mod_id) VALUES \
+         (?1, 'User', 'imports', 'NameOnly', 'unresolved', 'Account', 0, 0, 30, -1)",
+        params![app],
+    )
+    .unwrap();
+    // `Account()` at byte 50 — PAST the scope_end, so the alias no longer applies.
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, \
+         source_start_byte) VALUES (?1, 'Account', 'calls_name', 'NameOnly', 'unresolved', 50)",
+        params![app],
+    )
+    .unwrap();
+    let call: i64 = conn.query_row("SELECT MAX(id) FROM edges_data", [], |r| r.get(0)).unwrap();
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    let (to, _confidence, _resolution) = edge_state(&conn, call);
+    assert_eq!(
+        to,
+        Some(local_account),
+        "a reference past scope_end must fall through to the local `class Account`, not the import"
+    );
+}
+
+/// #174 review: a QUALIFIED reference whose RECEIVER root is an alias is rebound at the receiver —
+/// `from models import User as Account; Account.from_id()` resolves the method on the imported
+/// `User`, not left unresolved. The alias rewrite rewrites the receiver + the qualified-name root.
+#[test]
+fn python_alias_rebind_rebinds_a_qualified_receiver() {
+    let conn = seeded_conn();
+    let app = add_py_file(&conn, "app.py");
+    let models = add_py_file(&conn, "models.py");
+    // The imported class `User` and its method `from_id` (scope_path `User::from_id`).
+    add_py_symbol(&conn, models, "User", "models.py::User");
+    let from_id =
+        add_py_symbol_scope(&conn, models, "from_id", "models.py::from_id", "User::from_id");
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, evidence, \
+         source_start_byte, import_scope_start_byte, import_scope_end_byte, import_mod_id) VALUES \
+         (?1, 'User', 'imports', 'NameOnly', 'unresolved', 'Account', 0, 0, 200, -1)",
+        params![app],
+    )
+    .unwrap();
+    // `Account.from_id()` at byte 50: to_name=from_id, receiver=Account, qn=Account::from_id.
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, target_qualified_name, edge_kind, confidence, \
+         resolution, receiver_hint, source_start_byte) VALUES (?1, 'from_id', 'Account::from_id', \
+         'calls_name', 'NameOnly', 'unresolved', 'Account', 50)",
+        params![app],
+    )
+    .unwrap();
+    let call: i64 = conn.query_row("SELECT MAX(id) FROM edges_data", [], |r| r.get(0)).unwrap();
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    let (to, _confidence, _resolution) = edge_state(&conn, call);
+    assert_eq!(
+        to,
+        Some(from_id),
+        "a qualified receiver alias must rebind so `Account.from_id` resolves to `User.from_id`"
+    );
+}
+
+/// #174 review: a sequential re-import reassigns the alias; the later binding wins. Real extraction
+/// shrinks the first binding's `scope_end` to the second's start, so the scopes ABUT (non-
+/// overlapping): `Account -> User` is [0, 20), `Account -> Customer` is [20, 200). `Account()` at
+/// byte 50 falls in the second, resolving to `Customer`.
+#[test]
+fn python_alias_rebind_picks_the_latest_reimport() {
+    let conn = seeded_conn();
+    let app = add_py_file(&conn, "app.py");
+    let models = add_py_file(&conn, "models.py");
+    let _user = add_py_symbol(&conn, models, "User", "models.py::User");
+    let customer = add_py_symbol(&conn, models, "Customer", "models.py::Customer");
+    // First binding `Account -> User` — scope ends where the second import rebinds the name (byte
+    // 20).
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, evidence, \
+         source_start_byte, import_scope_start_byte, import_scope_end_byte, import_mod_id) VALUES \
+         (?1, 'User', 'imports', 'NameOnly', 'unresolved', 'Account', 0, 0, 20, -1)",
+        params![app],
+    )
+    .unwrap();
+    // Second binding `Account -> Customer` at byte 20 — reassigns the alias.
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, evidence, \
+         source_start_byte, import_scope_start_byte, import_scope_end_byte, import_mod_id) VALUES \
+         (?1, 'Customer', 'imports', 'NameOnly', 'unresolved', 'Account', 20, 20, 200, -1)",
+        params![app],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, \
+         source_start_byte) VALUES (?1, 'Account', 'calls_name', 'NameOnly', 'unresolved', 50)",
+        params![app],
+    )
+    .unwrap();
+    let call: i64 = conn.query_row("SELECT MAX(id) FROM edges_data", [], |r| r.get(0)).unwrap();
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    let (to, _confidence, _resolution) = edge_state(&conn, call);
+    assert_eq!(to, Some(customer), "the latest re-import of the alias must win");
+}
+
+/// #174 review: mutually-exclusive branch imports (`try: import … as DB except: import … as DB`)
+/// produce two OVERLAPPING alias bindings to DIFFERENT targets — neither shrinks the other's scope
+/// (extraction only shrinks at unconditional rebindings). The alias is genuinely ambiguous, so the
+/// reference must stay unresolved rather than picking one by byte order.
+#[test]
+fn python_alias_rebind_is_ambiguous_across_exclusive_branches() {
+    let conn = seeded_conn();
+    let app = add_py_file(&conn, "app.py");
+    let models = add_py_file(&conn, "models.py");
+    add_py_symbol(&conn, models, "Fast", "models.py::Fast");
+    add_py_symbol(&conn, models, "Slow", "models.py::Slow");
+    // Two covering bindings of `DB`, both spanning the file (the try/except branches don't shrink
+    // each other), to different targets.
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, evidence, \
+         source_start_byte, import_scope_start_byte, import_scope_end_byte, import_mod_id) VALUES \
+         (?1, 'Fast', 'imports', 'NameOnly', 'unresolved', 'DB', 0, 0, 200, -1)",
+        params![app],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, evidence, \
+         source_start_byte, import_scope_start_byte, import_scope_end_byte, import_mod_id) VALUES \
+         (?1, 'Slow', 'imports', 'NameOnly', 'unresolved', 'DB', 20, 0, 200, -1)",
+        params![app],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, \
+         source_start_byte) VALUES (?1, 'DB', 'calls_name', 'NameOnly', 'unresolved', 50)",
+        params![app],
+    )
+    .unwrap();
+    let call: i64 = conn.query_row("SELECT MAX(id) FROM edges_data", [], |r| r.get(0)).unwrap();
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    let (to, confidence, _resolution) = edge_state(&conn, call);
+    assert_eq!(to, None, "an alias bound to different targets in exclusive branches is ambiguous");
+    assert_eq!(confidence, "NameOnly");
+}
+
+/// #174 review: two branch imports of the SAME target (`try: from a import Engine as DB except: from
+/// a import Engine as DB`) overlap but agree, so the alias still resolves.
+#[test]
+fn python_alias_rebind_resolves_when_branches_agree() {
+    let conn = seeded_conn();
+    let app = add_py_file(&conn, "app.py");
+    let models = add_py_file(&conn, "models.py");
+    let engine = add_py_symbol(&conn, models, "Engine", "models.py::Engine");
+    for start in [0, 20] {
+        conn.execute(
+            "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, \
+             evidence, source_start_byte, import_scope_start_byte, import_scope_end_byte, \
+             import_mod_id) VALUES (?1, 'Engine', 'imports', 'NameOnly', 'unresolved', 'DB', ?2, \
+             0, 200, -1)",
+            params![app, start],
+        )
+        .unwrap();
+    }
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, \
+         source_start_byte) VALUES (?1, 'DB', 'calls_name', 'NameOnly', 'unresolved', 50)",
+        params![app],
+    )
+    .unwrap();
+    let call: i64 = conn.query_row("SELECT MAX(id) FROM edges_data", [], |r| r.get(0)).unwrap();
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    let (to, _confidence, _resolution) = edge_state(&conn, call);
+    assert_eq!(to, Some(engine), "agreeing branch imports still resolve");
+}
+
+/// #174 review: a QUALIFIED reference (`other.Account()`) is not the local alias `Account`, so it
+/// must NOT be rebound to the import. The receiver hint marks the reference qualified; the rebind
+/// bails on it. With no local `Account` symbol, a rebound reference would resolve to `User` — so a
+/// NameOnly (unresolved) outcome proves the rebind was correctly skipped.
+#[test]
+fn python_alias_rebind_skips_a_qualified_reference() {
+    let conn = seeded_conn();
+    let app = add_py_file(&conn, "app.py");
+    let models = add_py_file(&conn, "models.py");
+    add_py_symbol(&conn, models, "User", "models.py::User");
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, evidence, \
+         source_start_byte, import_scope_start_byte, import_scope_end_byte, import_mod_id) VALUES \
+         (?1, 'User', 'imports', 'NameOnly', 'unresolved', 'Account', 0, 0, 200, -1)",
+        params![app],
+    )
+    .unwrap();
+    // `other.Account()` at byte 50 — a member access on `other`, recorded with a receiver hint.
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, \
+         receiver_hint, source_start_byte) VALUES (?1, 'Account', 'calls_name', 'NameOnly', \
+         'unresolved', 'other', 50)",
+        params![app],
+    )
+    .unwrap();
+    let call: i64 = conn.query_row("SELECT MAX(id) FROM edges_data", [], |r| r.get(0)).unwrap();
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    let (to, confidence, _resolution) = edge_state(&conn, call);
+    assert_eq!(to, None, "a qualified `other.Account` must not rebind to the imported `User`");
+    assert_eq!(confidence, "NameOnly", "the qualified reference stays unresolved");
+}
+
+/// #174 review: a reference BEFORE the import is outside the alias's scope, so it is not rebound.
+/// `Account()` (byte 5); `from m import User as Account` (byte 20) — the call precedes the binding,
+/// so it must stay unresolved rather than rebinding to `User`.
+#[test]
+fn python_alias_rebind_skips_a_use_before_the_import() {
+    let conn = seeded_conn();
+    let app = add_py_file(&conn, "app.py");
+    let models = add_py_file(&conn, "models.py");
+    add_py_symbol(&conn, models, "User", "models.py::User");
+    // The aliased import's scope starts at byte 20.
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, evidence, \
+         source_start_byte, import_scope_start_byte, import_scope_end_byte, import_mod_id) VALUES \
+         (?1, 'User', 'imports', 'NameOnly', 'unresolved', 'Account', 20, 20, 200, -1)",
+        params![app],
+    )
+    .unwrap();
+    // `Account()` at byte 5 — BEFORE the import scope opens.
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, \
+         source_start_byte) VALUES (?1, 'Account', 'calls_name', 'NameOnly', 'unresolved', 5)",
+        params![app],
+    )
+    .unwrap();
+    let call: i64 = conn.query_row("SELECT MAX(id) FROM edges_data", [], |r| r.get(0)).unwrap();
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    let (to, confidence, _resolution) = edge_state(&conn, call);
+    assert_eq!(to, None, "a use before the import is out of scope and must not rebind");
+    assert_eq!(confidence, "NameOnly", "the pre-import reference stays unresolved");
+}
+
+/// A Python symbol carrying a semantic `scope_path` (e.g. a method `User::from_id`), so the
+/// resolver's scope-suffix matching can bind a qualified reference.
+fn add_py_symbol_scope(
+    conn: &Connection,
+    file_id: i64,
+    name: &str,
+    qualified: &str,
+    scope_path: &str,
+) -> i64 {
+    conn.execute(
+        "INSERT INTO symbols(file_id, language, name, qualified_name, scope_path, kind, \
+         start_byte, end_byte, start_line, end_line) VALUES (?1, 'python', ?2, ?3, ?4, \
+         'function', 0, 10, 1, 1)",
+        params![file_id, name, qualified, scope_path],
+    )
+    .unwrap();
+    conn.last_insert_rowid()
+}
+
+fn add_py_file(conn: &Connection, path: &str) -> i64 {
+    conn.execute(
+        "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+         commit_sha, worktree_id) VALUES (?1, 'python', 'source', ?2, 0, 0, ?3, '')",
+        params![path, format!("sha-{path}"), NEW],
+    )
+    .unwrap();
+    conn.last_insert_rowid()
+}
+
+fn add_py_symbol(conn: &Connection, file_id: i64, name: &str, qualified: &str) -> i64 {
+    add_py_symbol_at(conn, file_id, name, qualified, 0)
+}
+
+/// Like [`add_py_symbol`] but with an explicit `start_byte`, so a test can position a local
+/// definition before or after the alias import — the order-aware shadow check (#174 review) depends
+/// on which comes first.
+fn add_py_symbol_at(
+    conn: &Connection,
+    file_id: i64,
+    name: &str,
+    qualified: &str,
+    start_byte: i64,
+) -> i64 {
+    conn.execute(
+        "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte, end_byte, \
+         start_line, end_line) VALUES (?1, 'python', ?2, ?3, 'class', ?4, ?4 + 10, 1, 1)",
+        params![file_id, name, qualified, start_byte],
+    )
+    .unwrap();
+    conn.last_insert_rowid()
+}


### PR DESCRIPTION
Fixes #174. `from models import User as Account` then `Account()` now resolves the alias use to the imported `User`, instead of staying unresolved or binding to an unrelated local `Account`.

## Approach

Mirrors the Rust per-module `use`-scope machinery (#61), but where Rust's `is_external_import` only *suppresses* a local same-named symbol, Python needs to *rebind* the alias to its in-corpus target. Three layers:

1. **Extraction** (`python_import_target`, gated to `from`-imports): an `aliased_import` emits its Imports edge to the **target** (`to_name = User` — keeps the in-corpus dependency) via `file_edge_scoped`, carrying the **alias** in `evidence` and a whole-file `ImportScopeRange` (Python imports are module/file-global). The edge is the alias carrier. Module aliases (`import x as m`) are left alone — they're a qualified-resolution problem, out of scope.
2. **Scope build** (`ImportScope`): a new `python_aliases` map (`alias → target`, byte-scoped) with `add_python_alias` / `python_alias_target`. The import-edge load branches on `files.language`, so Python imports register aliases instead of feeding `add_use` (which parses Rust `use` text).
3. **Rebind** (`resolve_symbol` callers): before resolution, a non-import reference whose name is an in-scope alias resolves under the **target** name. The stored `to_name` stays the surface alias; only `to_symbol_id` becomes the target's.

Applied in **both** resolution drivers (incremental `resolve_all_edges` and the full-rebuild `CompactEdge` loop) per the #61 both-driver-parity rule — `index --full` uses the full-rebuild path.

## Verification

- New unit test `python_from_import_alias_rebinds_to_the_imported_target` (resolve/tests.rs): with a target `models.User` and a **decoy** local `other.Account`, the `Account()` edge binds to `User`.
- Manual e2e on a temp project confirmed the same (resolved to `models.py::User`, not the decoy).
- Full `rag-rat-core` suite green; `cargo +nightly fmt --check` + clippy clean. The import target itself was already captured, so existing import/resolution tests are unaffected.

## Scope

Symbol aliases via `from x import T as A` only; whole-file scope (a safe over-approximation). Module aliases (`import x as m; m.f()`) remain a follow-up — sibling of the already-closed #172.