### PR TITLE
fix(resolve): prefer a base CLASS for Python implements edges (#172)

### DIFF
--- a/crates/rag-rat-core/src/index/edges/extract.rs
+++ b/crates/rag-rat-core/src/index/edges/extract.rs
@@ -688,20 +688,40 @@ pub(crate) fn python_edges(
                     {
                         continue;
                     }
-                    // Implements points at the base HEAD only (`Generic`, not `T`); ReferencesType
-                    // covers the head AND every type argument (`Mapping[str, Api]` → `Mapping`,
-                    // `str`, `Api`).
-                    let head = python_type_head(base);
-                    if let Some(name) = last_identifier_text(head, text) {
+                    // Emit Implements ONLY for a STATIC head — a plain identifier, or an attribute
+                    // whose receiver chain is all identifiers and not `self`/`cls` (`pkg.Base`),
+                    // after unwrapping generic/subscript/paren wrappers (#172 review). A DYNAMIC
+                    // base has no compile-time class — `factory()`,
+                    // `factory().Base`, `self.Base`, `Base if flag else Other`,
+                    // a lambda, … — so claiming an Implements edge would
+                    // let the Python class preference mis-bind it to a same-named local class. An
+                    // allowlist (vs blocklisting each dynamic form) is robust to new expression
+                    // kinds.
+                    //
+                    // Implements targets the base HEAD's LEAF name (`Base` for
+                    // `pkg.Base`/`Generic[T]` → `Generic`); ReferencesType
+                    // (below) covers the head and every type argument. The edge
+                    // is bare-name (no qualified context): a module-qualified base `pkg.Base`
+                    // is resolved by the leaf `Base` exactly like a bare base, because a top-level
+                    // Python class's `scope_path` is the bare name, not `pkg::Base`. The cost is
+                    // that an EXTERNAL `pkg.Base`/bare imported base can still
+                    // bind a same-named local class — the general "Python has
+                    // no external-import suppression" gap (#172/#174
+                    // review), which needs an in-corpus Python module model to close, not a
+                    // per-base special case.
+                    if let Some(head) = python_static_base_head(base, text)
+                        && let Some(name) = last_identifier_text(head, text)
+                    {
+                        let callee = last_identifier_node(head)
+                            .map(final_segment_node)
+                            .map(CalleeRange::of_node);
                         out.push(symbol_edge(
                             symbols,
                             base,
                             name,
                             EdgeKind::Implements,
                             EdgeConfidence::NameOnly,
-                            last_identifier_node(head)
-                                .map(final_segment_node)
-                                .map(CalleeRange::of_node),
+                            callee,
                         ));
                     }
                     emit_python_type_refs(base, symbols, text, out);
@@ -801,21 +821,53 @@ fn python_is_type_alias_name(node: Node<'_>) -> bool {
     })
 }
 
-/// The "head" type node to anchor a Python type reference on, for a parameterized type. Unwraps the
-/// applicable wrappers to reach the base: a `type` wrapper, a `generic_type` (`Box[Item]` in an
-/// annotation → base `Box`), and a `subscript` (`Generic[T]` in a base-class list → value
-/// `Generic`). Plain identifiers/attributes pass through unchanged, so the type argument
-/// (`Item`/`T`) is never mistaken for the base. Bounded loop guards against a pathological tree.
-fn python_type_head(node: Node<'_>) -> Node<'_> {
-    let mut head = node;
+/// The STATIC head node of a Python base-class expression — a plain `identifier`, or an
+/// `attribute`/ `dotted_name` whose receiver chain is all identifiers (`pkg.Base`) — after
+/// unwrapping the wrappers `python_type_head` strips (`type`/`generic_type`/`subscript`) plus
+/// parentheses. `None` for a DYNAMIC base whose runtime class isn't a compile-time name: a `call`
+/// (`factory()`), an attribute off a call (`factory().Base`), a `conditional_expression` (`Base if
+/// flag else Other`), a lambda, a binary operator, etc. (#172 review). Only a static head should
+/// claim an `Implements` edge — an allowlist, so a NEW dynamic expression form is excluded by
+/// default rather than mis-bound by the Python class preference. Bounded loop guards a pathological
+/// tree.
+fn python_static_base_head<'a>(base: Node<'a>, text: &str) -> Option<Node<'a>> {
+    let mut node = base;
     for _ in 0..8 {
-        head = match head.kind() {
-            "type" | "generic_type" => head.named_child(0).unwrap_or(head),
-            "subscript" => head.child_by_field_name("value").unwrap_or(head),
-            _ => return head,
+        node = match node.kind() {
+            "type" | "generic_type" | "parenthesized_expression" => node.named_child(0)?,
+            "subscript" => node.child_by_field_name("value")?,
+            "identifier" => return Some(node),
+            "attribute" | "dotted_name" =>
+                return python_attribute_is_static(node, text).then_some(node),
+            // call / conditional_expression / lambda / binary_operator / … → no static class.
+            _ => return None,
         };
     }
-    head
+    None
+}
+
+/// Whether an `attribute`/`dotted_name` chain is purely static (`pkg.Base`, `a.b.C`) — every
+/// receiver is an identifier or another attribute, never a `call`/`subscript` (`factory().Base` is
+/// dynamic). A `self`/`cls`-rooted chain (`self.Base`) is DYNAMIC: the base comes off the runtime
+/// instance, not a compile-time class (#172 review). Bounded loop guards a pathological tree.
+fn python_attribute_is_static(node: Node<'_>, text: &str) -> bool {
+    let mut current = node;
+    for _ in 0..16 {
+        match current.kind() {
+            "identifier" => return !matches!(node_text(current, text).as_str(), "self" | "cls"),
+            "dotted_name" =>
+                return !matches!(
+                    first_identifier_text(current, text).as_deref(),
+                    Some("self" | "cls")
+                ),
+            "attribute" => match current.child_by_field_name("object") {
+                Some(object) => current = object,
+                None => return false,
+            },
+            _ => return false,
+        }
+    }
+    false
 }
 
 /// Emit an Imports edge for one import clause (`dotted_name` or `aliased_import`), targeting the
@@ -1071,6 +1123,127 @@ mod python_edge_tests {
         let e = edges("class Repo(Generic[T]):\n    pass\n");
         assert!(has(&e, EdgeKind::Implements, "Generic"), "base should be Generic: {e:?}");
         assert!(!has(&e, EdgeKind::Implements, "T"), "must not resolve to type arg T: {e:?}");
+    }
+
+    #[test]
+    fn call_shaped_base_emits_no_implements() {
+        // `class Sub(factory())` — a DYNAMIC base (the head is a callable, not the base class). No
+        // Implements edge (the resolver's class preference would mis-bind it), but the base call is
+        // still captured as a CallsName so the dependency on `factory` isn't lost (#172 review).
+        let e = edges("class Sub(factory()):\n    pass\n");
+        assert!(
+            !has(&e, EdgeKind::Implements, "factory"),
+            "a call-shaped base must NOT emit Implements: {e:?}"
+        );
+        assert!(
+            has(&e, EdgeKind::CallsName, "factory"),
+            "the base call is still captured as a CallsName: {e:?}"
+        );
+    }
+
+    #[test]
+    fn parenthesized_call_shaped_base_emits_no_implements() {
+        // `class Sub((factory()))` — tree-sitter nests the `call` under a
+        // `parenthesized_expression`, so the immediate-kind check missed it (#172 review round 2).
+        // Still a DYNAMIC base: no Implements, but the call dependency is captured.
+        let e = edges("class Sub((factory())):\n    pass\n");
+        assert!(
+            !has(&e, EdgeKind::Implements, "factory"),
+            "a parenthesized call-shaped base must NOT emit Implements: {e:?}"
+        );
+        assert!(
+            has(&e, EdgeKind::CallsName, "factory"),
+            "the base call is still captured as a CallsName: {e:?}"
+        );
+    }
+
+    #[test]
+    fn subscript_call_shaped_base_emits_no_implements() {
+        // `class Sub(factory()[T])` — tree-sitter exposes the base as a `subscript` whose value is
+        // the `call`; `python_type_head` unwraps the subscript to that call, so the dynamic-base
+        // check must unwrap it too (#172 review round 3). Still dynamic: no Implements.
+        let e = edges("class Sub(factory()[T]):\n    pass\n");
+        assert!(
+            !has(&e, EdgeKind::Implements, "factory"),
+            "a subscript-on-call base must NOT emit Implements: {e:?}"
+        );
+        assert!(
+            has(&e, EdgeKind::CallsName, "factory"),
+            "the base call is still captured as a CallsName: {e:?}"
+        );
+    }
+
+    #[test]
+    fn attribute_on_call_base_emits_no_implements() {
+        // `class Sub(factory().Base)` — the base is an `attribute` whose receiver is a `call`, so
+        // `Base` comes off the factory RESULT, not a static class (#172 review round 4). Dynamic:
+        // no Implements; subscripted `factory().Base[T]` is the same shape under a
+        // subscript.
+        let e = edges("class Sub(factory().Base):\n    pass\n");
+        assert!(
+            !has(&e, EdgeKind::Implements, "Base"),
+            "an attribute on a call result must NOT emit Implements: {e:?}"
+        );
+        let e = edges("class Sub(factory().Base[T]):\n    pass\n");
+        assert!(
+            !has(&e, EdgeKind::Implements, "Base"),
+            "a subscripted attribute on a call result must NOT emit Implements: {e:?}"
+        );
+    }
+
+    #[test]
+    fn static_attribute_base_emits_a_bare_implements() {
+        // `class Sub(pkg.Base)` — a static qualified base (receiver is a module, not a call) is a
+        // real superclass; the Implements edge targets the LEAF `Base` and is BARE (no qualified
+        // context) so it resolves like a bare base — a top-level Python class's `scope_path` is the
+        // bare name, not `pkg::Base` (#172 review).
+        let e = edges("class Sub(pkg.Base):\n    pass\n");
+        let imp = e
+            .iter()
+            .find(|c| c.edge_kind == EdgeKind::Implements && c.to_name == "Base")
+            .expect("qualified base Implements edge");
+        assert_eq!(imp.receiver_hint, None, "qualified base implements is bare-name");
+        assert_eq!(imp.target_qualified_name, None, "qualified base implements is bare-name");
+    }
+
+    #[test]
+    fn self_qualified_base_emits_no_implements() {
+        // `class Sub(self.Base)` (e.g. inside a method) — the base comes off the runtime instance,
+        // not a compile-time class, so it is DYNAMIC: no Implements (#172 review).
+        let e = edges(
+            "class Outer:\n    def make(self):\n        class Sub(self.Base):\n            pass\n",
+        );
+        assert!(
+            !has(&e, EdgeKind::Implements, "Base"),
+            "a `self.`-rooted base must NOT emit Implements: {e:?}"
+        );
+    }
+
+    #[test]
+    fn conditional_expression_base_emits_no_implements() {
+        // `class Sub(Base if flag else Other)` — the runtime base is expression-dependent, so it is
+        // NOT a static class; emitting an Implements to the last identifier (`Other`) would let the
+        // class preference mis-bind it (#172 review). The allowlist excludes the whole expression.
+        let e = edges("class Sub(Base if flag else Other):\n    pass\n");
+        assert!(
+            !has(&e, EdgeKind::Implements, "Other"),
+            "a conditional-expression base must NOT emit Implements: {e:?}"
+        );
+        assert!(
+            !has(&e, EdgeKind::Implements, "Base"),
+            "a conditional-expression base must NOT emit Implements: {e:?}"
+        );
+    }
+
+    #[test]
+    fn parenthesized_class_base_still_emits_implements() {
+        // `class Sub((Base))` — a parenthesized but STATIC base is a real superclass, so the
+        // Implements edge must survive the dynamic-base guard.
+        let e = edges("class Sub((Base)):\n    pass\n");
+        assert!(
+            has(&e, EdgeKind::Implements, "Base"),
+            "a parenthesized class base must still emit Implements: {e:?}"
+        );
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/edges/resolve/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/mod.rs
@@ -590,7 +590,7 @@ pub(crate) fn resolve_symbol<'a>(
         .copied()
         .filter(|symbol| kind_matches(symbol))
         .collect::<Vec<_>>();
-    let preferred = preferred_matches(request.edge_kind, &matches);
+    let preferred = preferred_matches(request.edge_kind, request.source_language, &matches);
     // In languages with separate type/value namespaces (Rust, C, C++), a `references_type`
     // reference must resolve to a type DEFINITION (struct/enum/trait/type/…). If none of the
     // same-named candidates is one, do NOT fall back to a non-type symbol (an `impl` block, a
@@ -602,6 +602,15 @@ pub(crate) fn resolve_symbol<'a>(
     if preferred.is_empty()
         && request.edge_kind == EdgeKind::ReferencesType.as_str()
         && matches!(request.source_language, Some("rust" | "c" | "cpp"))
+    {
+        return None;
+    }
+    // A Python `implements` (base class) that found no in-corpus PYTHON class must NOT fall back to
+    // the all-matches set: that would bind the base to a same-named non-class or a foreign-language
+    // class (#172 review). Leave it unresolved — the ReferencesType edge still records the base.
+    if preferred.is_empty()
+        && request.edge_kind == EdgeKind::Implements.as_str()
+        && request.source_language == Some(Language::Python.as_str())
     {
         return None;
     }
@@ -736,8 +745,25 @@ pub(crate) fn is_common_member_name(value: &str) -> bool {
 }
 pub(crate) fn preferred_matches<'a>(
     edge_kind: &str,
+    source_language: Option<&str>,
     matches: &[&'a IndexedSymbol],
 ) -> Vec<&'a IndexedSymbol> {
+    // Python base-class inheritance emits an `implements` edge to a CLASS — Python has no
+    // traits/interfaces — so prefer class-like kinds for Python (#172). This case ALSO filters by
+    // LANGUAGE: the name buckets are repo-wide, so without it a Python base would bind to a
+    // same-named TS/Kotlin/C++ class or Kotlin `object` in a mixed-language index (#172 review).
+    // Kept language-scoped so Kotlin/TS are otherwise UNCHANGED (`implements`/`: I` targets an
+    // interface, and a same-named class must not be preferred over it).
+    if edge_kind == "implements" && source_language == Some(Language::Python.as_str()) {
+        return matches
+            .iter()
+            .copied()
+            .filter(|symbol| {
+                matches!(symbol.kind.as_str(), "class" | "object")
+                    && symbol.language.as_str() == Language::Python.as_str()
+            })
+            .collect();
+    }
     let preferred_kinds: &[&str] = match edge_kind {
         "calls_name" => &["function", "method"],
         "constructs" => &["struct", "class", "object"],

--- a/crates/rag-rat-core/src/index/edges/resolve/tests.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/tests.rs
@@ -572,3 +572,96 @@ fn oracle_unaffected_by_import_scope_columns() {
          scope columns must not pull it in"
     );
 }
+
+/// #172: a Python `class Sub(Base)` emits an `implements` edge to `Base`, which is a CLASS (Python
+/// has no traits/interfaces). The resolver must prefer the base CLASS over a same-named non-class
+/// (e.g. a function) — language-scoped, so Kotlin/TS `implements` still prefers an interface.
+#[test]
+fn python_implements_prefers_a_base_class_over_a_non_class() {
+    let conn = seeded_conn();
+    let sub = py_source(&conn, "sub.py");
+    let base = py_source(&conn, "base.py");
+    let other = py_source(&conn, "other.py");
+    // A symbol in sub.py so the resolver knows the reference's source language is Python (a file's
+    // language is inferred from its symbols, and the language-scoped `implements` preference is
+    // what this exercises).
+    py_sym(&conn, sub, "Sub", "sub.py::Sub", "class");
+    // The real base class, and a DECOY same-named non-class (a module-level function `Base`).
+    let base_class = py_sym(&conn, base, "Base", "base.py::Base", "class");
+    let _decoy_fn = py_sym(&conn, other, "Base", "other.py::Base", "function");
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, \
+         source_start_byte) VALUES (?1, 'Base', 'implements', 'NameOnly', 'unresolved', 10)",
+        params![sub],
+    )
+    .unwrap();
+    let edge: i64 = conn.query_row("SELECT MAX(id) FROM edges_data", [], |r| r.get(0)).unwrap();
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    let (to, _confidence, _resolution) = edge_state(&conn, edge);
+    assert_eq!(
+        to,
+        Some(base_class),
+        "implements must prefer the base CLASS, not the decoy function"
+    );
+}
+
+fn py_source(conn: &Connection, path: &str) -> i64 {
+    conn.execute(
+        "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+         commit_sha, worktree_id) VALUES (?1, 'python', 'source', ?2, 0, 0, ?3, '')",
+        params![path, format!("sha-{path}"), NEW],
+    )
+    .unwrap();
+    conn.last_insert_rowid()
+}
+
+fn py_sym(conn: &Connection, file_id: i64, name: &str, qualified: &str, kind: &str) -> i64 {
+    conn.execute(
+        "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte, end_byte, \
+         start_line, end_line) VALUES (?1, 'python', ?2, ?3, ?4, 0, 10, 1, 1)",
+        params![file_id, name, qualified, kind],
+    )
+    .unwrap();
+    conn.last_insert_rowid()
+}
+
+/// #172 review: a Python `implements` (base class) must NOT bind to a same-named class in another
+/// language. With only a TypeScript `class Base` in the index (the Python base is external), the
+/// edge stays unresolved rather than wrongly binding cross-language.
+#[test]
+fn python_implements_ignores_a_foreign_language_class() {
+    let conn = seeded_conn();
+    let sub = py_source(&conn, "sub.py");
+    py_sym(&conn, sub, "Sub", "sub.py::Sub", "class");
+    // The only same-named `Base` is a TYPESCRIPT class.
+    conn.execute(
+        "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+         commit_sha, worktree_id) VALUES ('w.ts', 'typescript', 'source', 'sha-w', 0, 0, ?1, '')",
+        params![NEW],
+    )
+    .unwrap();
+    let ts = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte, end_byte, \
+         start_line, end_line) VALUES (?1, 'typescript', 'Base', 'w.ts::Base', 'class', 0, 10, 1, \
+         1)",
+        params![ts],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO edges(source_file_id, to_name, edge_kind, confidence, resolution, \
+         source_start_byte) VALUES (?1, 'Base', 'implements', 'NameOnly', 'unresolved', 10)",
+        params![sub],
+    )
+    .unwrap();
+    let edge: i64 = conn.query_row("SELECT MAX(id) FROM edges_data", [], |r| r.get(0)).unwrap();
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    let (to, _confidence, _resolution) = edge_state(&conn, edge);
+    assert_eq!(to, None, "a Python base must not bind to a foreign-language class");
+}


### PR DESCRIPTION
Fixes #172. Python base-class inheritance (`class Sub(Base)`) emits an `implements` edge to `Base`, which is a **class** — Python has no traits/interfaces. The resolver's `implements` preference was `["trait", "interface"]`, so a Python base never matched and the edge could mis-resolve to a same-named non-class or fall back ambiguously.

## Fix

`preferred_matches` is now **language-aware**: for Python, `implements` prefers `["class", "object"]`; Kotlin / TS / Rust are **unchanged** (`["trait", "interface"]`) — there `implements` / `: I` targets an interface, and a same-named class must not be preferred over it. The source language is already threaded into `resolve_symbol` (`request.source_language`), so this is a one-line branch in the existing preference table.

## Verification

- New resolve test `python_implements_prefers_a_base_class_over_a_non_class`: with a base `class Base` and a **decoy** same-named module-level `function Base`, the Python `implements` edge binds to the class.
- e2e on a temp project: `class Sub(Base)` resolves `implements → base.py::Base (class)` at Syntactic confidence (was unresolved/ambiguous before).
- Full `rag-rat-core` suite (482) green; fmt + clippy clean. Kotlin/TS `implements` tests unaffected (the branch is gated to Python).

Sibling of #174 (alias resolution, PR #179) — both Python resolver refinements deferred from #167. The remaining `import x as m` module-alias case is still out of scope (noted in #174).