### PR TITLE
fix(init): Python root-entrypoint + env-only directory selection (#173)

### DIFF
--- a/crates/rag-rat-cli/src/init/mod.rs
+++ b/crates/rag-rat-cli/src/init/mod.rs
@@ -11,6 +11,7 @@ use rag_rat_core::config::EmbeddingBackend;
 use rag_rat_core::index::ai::{
     FASTEMBED_MODEL_ID, HASH_MODEL_ID, MODEL2VEC_MODEL_ID, ReconcileOptions,
 };
+use rag_rat_core::index::ignore_rules::{IgnoreMatcher, is_virtualenv_dir};
 use rag_rat_core::language::Language;
 use rag_rat_core::{Config, IndexDatabase};
 pub(crate) use render::*;
@@ -31,9 +32,10 @@ const SKIPPED_DIRS: &[&str] = &[
     ".venv",
     // Python virtualenv / dependency / cache trees — never project source. Skipping them at scan
     // time means their `.py` files never become dir candidates, so the "no default → promote the
-    // largest" fallback can't select a `site-packages` tree (#167 review).
+    // largest" fallback can't select a `site-packages` tree (#167 review). NB: `virtualenv` is NOT
+    // here — it's a real first-party package name; a virtualenv literally named `virtualenv/` is
+    // caught by content (`pyvenv.cfg`) in `scan_dir` instead (#181).
     "venv",
-    "virtualenv",
     "site-packages",
     "__pycache__",
     ".tox",
@@ -70,6 +72,14 @@ pub(crate) struct RepoScan {
     dir_counts: BTreeMap<Language, BTreeMap<PathBuf, usize>>,
     direct_dir_counts: BTreeMap<Language, BTreeMap<PathBuf, usize>>,
     total_source_bytes: u64,
+    /// The scan found a real Python virtualenv (a dir with a `pyvenv.cfg`) ANYWHERE the index
+    /// would walk — not gitignored, not floored. The indexer floor can't cover a venv under an
+    /// ambiguous name (`env`/`virtualenv`), so a `python = ["."]` walk WOULD index it; when
+    /// one is present we must not auto-bind `.`. Gitignored / conventionally-floored venvs
+    /// (`.venv`/`venv`) and first-party packages that merely share a venv-ish NAME (no
+    /// `pyvenv.cfg`) are NOT recorded here — content detection, not the name, decides (#181
+    /// review).
+    has_python_virtualenv: bool,
 }
 
 impl InitOptions {
@@ -284,6 +294,7 @@ mod tests {
             ]),
             direct_dir_counts: BTreeMap::new(),
             total_source_bytes: 0,
+            has_python_virtualenv: false,
         };
 
         let plan = default_plan(".".to_string(), &scan);
@@ -319,6 +330,7 @@ mod tests {
                 ]),
             )]),
             total_source_bytes: 0,
+            has_python_virtualenv: false,
         };
 
         let defaults = candidate_dirs(&scan, Language::C)

--- a/crates/rag-rat-cli/src/init/run.rs
+++ b/crates/rag-rat-cli/src/init/run.rs
@@ -11,6 +11,17 @@ pub(crate) fn run(args: &crate::cli::InitArgs, config_path: &str) -> anyhow::Res
     } else {
         prompt_plan(root, root_value, &scan)?
     };
+    // A plan with no bindings would render an empty `[target_bindings]` and index nothing — a
+    // useless config. `init -y` can reach this when every detected language drops to a dependency
+    // tree (e.g. Python whose only `.py` live under a virtualenv); the interactive path already
+    // bails, so guard the non-interactive path the same way rather than write an unusable file
+    // (#181 review).
+    if plan.bindings.is_empty() {
+        anyhow::bail!(
+            "init found no indexable source to bind — every detected language resolved to a \
+             dependency tree (e.g. a virtualenv). Nothing to configure."
+        );
+    }
     let config_text = render_config(&plan);
 
     if options.dry_run {
@@ -100,9 +111,22 @@ pub(crate) fn prompt_plan(
         let dirs: Vec<_> =
             selected.into_iter().map(|index| candidates[index].path.clone()).collect();
         if dirs.is_empty() {
-            anyhow::bail!("init needs at least one selected root for {}", language.as_str());
+            // No roots selected — drop the language (don't bind it), matching the non-interactive
+            // plan which omits a language with no safe default (e.g. env-only Python, whose
+            // candidates are all dependency trees and so default to none). Bailing here would make
+            // accepting the offered defaults fail for exactly that case (#181 review).
+            continue;
         }
         bindings.insert(*language, dirs);
+    }
+    // Keep `languages` consistent with the bindings actually chosen (a dropped language must not
+    // linger and make `render_config` emit an empty list).
+    let languages = languages
+        .into_iter()
+        .filter(|language| bindings.contains_key(language))
+        .collect::<Vec<_>>();
+    if bindings.is_empty() {
+        anyhow::bail!("init needs at least one selected root to index");
     }
 
     let backend = prompt_backend(scan)?;
@@ -161,18 +185,34 @@ pub(crate) fn default_plan(root_value: String, scan: &RepoScan) -> InitPlan {
         .filter(|language| scan.language_counts.get(language).copied().unwrap_or_default() > 0)
         .collect::<Vec<_>>();
     let languages = if languages.is_empty() { vec![Language::Rust] } else { languages };
-    let bindings = languages
+    let bindings: BTreeMap<Language, Vec<PathBuf>> = languages
         .iter()
-        .map(|language| {
-            let dirs = candidate_dirs(scan, *language)
-                .into_iter()
+        .filter_map(|language| {
+            let candidates = candidate_dirs(scan, *language);
+            let defaults = candidates
+                .iter()
                 .filter(|candidate| candidate.default)
-                .map(|candidate| candidate.path)
+                .map(|candidate| candidate.path.clone())
                 .collect::<Vec<_>>();
-            let dirs = if dirs.is_empty() { vec![PathBuf::from(".")] } else { dirs };
-            (*language, dirs)
+            if !defaults.is_empty() {
+                return Some((*language, defaults));
+            }
+            // No safe default. For Python this is an env-only repo (every `.py` under a dependency
+            // tree — `candidate_dirs` deliberately refuses to promote `.` over it, #173): OMIT the
+            // binding rather than fall back to `["."]`, which would index the installed deps (#181
+            // — the empty-default state must survive into the non-interactive plan, not
+            // get reconverted to `.` here). For other languages, `.` is the reasonable
+            // "index everything" default.
+            if *language == Language::Python && !candidates.is_empty() {
+                return None;
+            }
+            Some((*language, vec![PathBuf::from(".")]))
         })
         .collect();
+    // Keep `languages` consistent with the bindings actually emitted (a dropped env-only Python
+    // must not linger in the language list).
+    let languages =
+        languages.into_iter().filter(|language| bindings.contains_key(language)).collect();
     let backend = recommend_backend(estimated_chunks(scan.total_source_bytes));
     // Non-interactive default mirrors `OracleConfig`'s default: off until explicitly enabled.
     InitPlan { root_value, languages, bindings, backend, oracle_auto_run: false }
@@ -337,5 +377,90 @@ pub(crate) fn absolute_config_path(config: &Config, config_path: &Path) -> anyho
         Ok(config_path.to_path_buf())
     } else {
         Ok(config.root.join(config_path).canonicalize()?)
+    }
+}
+
+#[cfg(test)]
+mod default_plan_tests {
+    use std::path::Path;
+
+    use super::*;
+
+    /// #181: a repo whose only `.py` files live under a dependency tree must NOT get
+    /// `python = ["."]` — `default_plan` carries the no-safe-default state through by omitting the
+    /// Python binding entirely (rather than reconverting an empty default list to `.`).
+    #[test]
+    fn env_only_python_writes_no_binding_not_dot() {
+        let root = Path::new("/repo");
+        let mut scan = RepoScan::default();
+        for name in ["a.py", "b.py"] {
+            *scan.language_counts.entry(Language::Python).or_default() += 1;
+            add_file_to_dir_counts(
+                root,
+                &root.join("env/lib/site-packages/pkg").join(name),
+                Language::Python,
+                &mut scan,
+            )
+            .unwrap();
+        }
+        let plan = default_plan(".".to_string(), &scan);
+        assert!(
+            !plan.bindings.contains_key(&Language::Python),
+            "env-only Python must get NO binding, not `.`: {:?}",
+            plan.bindings
+        );
+        assert!(!plan.languages.contains(&Language::Python));
+    }
+
+    /// #173: a root entrypoint (`manage.py`) directly under the root binds `.` — preserved.
+    #[test]
+    fn root_entrypoint_binds_dot() {
+        let root = Path::new("/repo");
+        let mut scan = RepoScan::default();
+        *scan.language_counts.entry(Language::Python).or_default() += 1;
+        add_file_to_dir_counts(root, &root.join("manage.py"), Language::Python, &mut scan).unwrap();
+        let plan = default_plan(".".to_string(), &scan);
+        assert_eq!(plan.bindings.get(&Language::Python), Some(&vec![PathBuf::from(".")]));
+    }
+
+    /// #181 review: a root entrypoint ALONGSIDE a root UNFLOORED venv (`env`/`.env`/`virtualenv`) must
+    /// NOT bind `.` — the walk would ingest the venv (the indexer floor can't cover those names).
+    /// With only the root entrypoint and no package dir, Python is omitted rather than indexing
+    /// the venv. (A FLOORED venv like `.venv` does NOT set this flag, so it keeps binding `.` —
+    /// see `root_entrypoint_binds_dot` and
+    /// `only_unfloored_dependency_dirs_block_the_dot_default`.)
+    #[test]
+    fn root_entrypoint_with_root_venv_does_not_bind_dot() {
+        let root = Path::new("/repo");
+        let mut scan = RepoScan::default();
+        *scan.language_counts.entry(Language::Python).or_default() += 1;
+        add_file_to_dir_counts(root, &root.join("manage.py"), Language::Python, &mut scan).unwrap();
+        // An unfloored venv (`virtualenv`/`env`/`.env`) sits at the root — what `scan_dir` records.
+        scan.has_python_virtualenv = true;
+        let plan = default_plan(".".to_string(), &scan);
+        assert!(
+            !plan.bindings.contains_key(&Language::Python),
+            "a root venv must suppress the `.` default: {:?}",
+            plan.bindings
+        );
+    }
+
+    /// A normal Python package dir still binds (the env-only omission must not over-reach).
+    #[test]
+    fn python_package_dir_still_binds() {
+        let root = Path::new("/repo");
+        let mut scan = RepoScan::default();
+        for name in ["__init__.py", "views.py"] {
+            *scan.language_counts.entry(Language::Python).or_default() += 1;
+            add_file_to_dir_counts(
+                root,
+                &root.join("myapp").join(name),
+                Language::Python,
+                &mut scan,
+            )
+            .unwrap();
+        }
+        let plan = default_plan(".".to_string(), &scan);
+        assert_eq!(plan.bindings.get(&Language::Python), Some(&vec![PathBuf::from("myapp")]));
     }
 }

--- a/crates/rag-rat-cli/src/init/scan.rs
+++ b/crates/rag-rat-cli/src/init/scan.rs
@@ -26,29 +26,48 @@ pub(crate) fn backend_label(backend: EmbeddingBackend) -> &'static str {
 }
 pub(crate) fn scan_repo(root: &Path) -> anyhow::Result<RepoScan> {
     let mut scan = RepoScan::default();
-    scan_dir(root, root, 0, &mut scan)?;
+    // The scan honors the SAME ignore rules as the index walk (gitignore + the unconditional floor)
+    // so what it counts as candidate source matches what the index will actually contain (#181
+    // review). Empty target dirs → the matcher governs the whole root.
+    let ignore = IgnoreMatcher::compile(root, &[]);
+    scan_dir(root, root, &ignore, &mut scan)?;
     Ok(scan)
 }
 pub(crate) fn scan_dir(
     root: &Path,
     dir: &Path,
-    depth: usize,
+    ignore: &IgnoreMatcher,
     scan: &mut RepoScan,
 ) -> anyhow::Result<()> {
-    if depth > 10 {
-        return Ok(());
-    }
     let mut entries = fs::read_dir(dir)?.collect::<Result<Vec<_>, io::Error>>()?;
     entries.sort_by_key(|entry| entry.file_name());
     for entry in entries {
         let path = entry.path();
         let file_type = entry.file_type()?;
         if file_type.is_dir() {
-            if should_skip_dir(&entry.file_name().to_string_lossy()) {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            // A real Python VIRTUALENV (detected by content — a `pyvenv.cfg`, NOT by an ambiguous
+            // name) is never project source: skip it and DON'T count its files, so a nested
+            // `tools/env/` can't inflate `tools` into a candidate (#181 review). It also records
+            // that a venv exists the index WOULD walk, so
+            // `python_root_has_direct_source` refuses the `.` default — `python =
+            // ["."]` would ingest the venv (the floor can't cover `env`/ `virtualenv`
+            // names). Content detection keeps a same-named FIRST-PARTY package (the
+            // `virtualenv` PyPI package's `src/virtualenv/`, which has no `pyvenv.cfg`) a normal
+            // candidate. A gitignored venv is already `is_ignored` below (skipped + unindexed), so
+            // it doesn't reach here.
+            if !ignore.is_ignored(&path, true) && is_virtualenv_dir(&path) {
+                scan.has_python_virtualenv = true;
                 continue;
             }
-            scan_dir(root, &path, depth + 1, scan)?;
+            // Skip what the index won't walk: its hardcoded scan-skip names OR anything the shared
+            // ignore matcher (gitignore + floor) excludes — so scan counts == index contents.
+            if should_skip_dir(&name) || ignore.is_ignored(&path, true) {
+                continue;
+            }
+            scan_dir(root, &path, ignore, scan)?;
         } else if file_type.is_file()
+            && !ignore.is_ignored(&path, false)
             && let Some(language) = Language::from_path(&path)
         {
             *scan.language_counts.entry(language).or_default() += 1;
@@ -66,6 +85,11 @@ pub(crate) fn add_file_to_dir_counts(
 ) -> anyhow::Result<()> {
     let parent = path.parent().unwrap_or(root);
     let relative_parent = parent.strip_prefix(root).unwrap_or(parent);
+    // A root-level file (parent == root) strips to an empty path; key it under "." so `.` is
+    // recognized as DIRECTLY containing source (root entrypoints like manage.py), not merely as the
+    // aggregate bucket every file increments below (#173).
+    let relative_parent =
+        if relative_parent.as_os_str().is_empty() { Path::new(".") } else { relative_parent };
     *scan
         .direct_dir_counts
         .entry(language)
@@ -75,6 +99,11 @@ pub(crate) fn add_file_to_dir_counts(
     *scan.dir_counts.entry(language).or_default().entry(PathBuf::from(".")).or_default() += 1;
     let mut current = PathBuf::new();
     for component in relative_parent.components() {
+        // The "." aggregate is counted once above; skip the CurDir component so a root file doesn't
+        // double-count it.
+        if component.as_os_str() == "." {
+            continue;
+        }
         current.push(component.as_os_str());
         *scan.dir_counts.entry(language).or_default().entry(current.clone()).or_default() += 1;
     }
@@ -104,6 +133,16 @@ pub(crate) fn candidate_dirs(scan: &RepoScan, language: Language) -> Vec<DirCand
         && let Some(best) = candidates
             .iter_mut()
             .filter(|candidate| !fallback_excluded(language, &candidate.path))
+            // For Python, don't promote the aggregate `.` bucket when the root holds no real source
+            // directly: in an env-only repo every `.py` lives under a dependency tree (those dirs
+            // are `fallback_excluded`), so `.` would win on aggregate count alone and write
+            // `python = ["."]` over installed deps (#173). A root with genuine entrypoints has a
+            // non-zero direct count and is already a default above, so it never reaches here.
+            .filter(|candidate| {
+                language != Language::Python
+                    || candidate.path != Path::new(".")
+                    || python_root_has_direct_source(scan, &candidate.path)
+            })
             .max_by_key(|candidate| candidate.count)
     {
         best.default = true;
@@ -141,7 +180,8 @@ pub(crate) fn default_dir(scan: &RepoScan, language: Language, path: &Path) -> b
             !is_python_dependency_dir(&text)
                 && (text == "src"
                     || text.ends_with("/src")
-                    || directly_contains_source(scan, language, path)),
+                    || directly_contains_source(scan, language, path)
+                    || python_root_has_direct_source(scan, path)),
         Language::Markdown => text == "docs" || text == ".",
     }
 }
@@ -165,11 +205,35 @@ fn is_python_dependency_dir(text: &str) -> bool {
         )
     })
 }
+
 /// Whether the no-default fallback must NOT promote this candidate: a Python dependency/virtualenv
 /// tree (`env`/`.env`/`venv`/`site-packages`/…). `is_python_dependency_dir` covers the names
 /// `SKIPPED_DIRS` doesn't skip during the walk (e.g. `env`, which is too generic to skip globally).
 fn fallback_excluded(language: Language, path: &Path) -> bool {
     language == Language::Python && is_python_dependency_dir(&display_rel(path))
+}
+
+/// The repo root (`.`) directly contains non-dependency Python source — e.g. `manage.py` /
+/// `setup.py` / `main.py` at the top level (#173). `directly_contains_source` deliberately excludes
+/// `.` (it's the aggregate bucket every file increments), so root entrypoints would otherwise never
+/// make `.` a default — omitted entirely when a package dir is also present. Root-level files key
+/// under `.` in `direct_dir_counts` (see `add_file_to_dir_counts`), so a positive direct count
+/// means real source sits at the root (env-only repos have their `.py` under a dependency tree,
+/// never at the root, so their `.` direct count is 0).
+fn python_root_has_direct_source(scan: &RepoScan, path: &Path) -> bool {
+    path == Path::new(".")
+        // A real virtualenv (a `pyvenv.cfg` dir) the index would walk, found anywhere by the
+        // gitignore-honoring scan, makes `python = ["."]` unsafe — it would ingest the venv. Omit the
+        // `.` default; the user can bind `.` explicitly. A gitignored / floored venv doesn't set this
+        // flag, so a `manage.py`-plus-gitignored-venv repo still binds `.` (#181 review).
+        && !scan.has_python_virtualenv
+        && scan
+            .direct_dir_counts
+            .get(&Language::Python)
+            .and_then(|counts| counts.get(Path::new(".")))
+            .copied()
+            .unwrap_or_default()
+            > 0
 }
 
 pub(crate) fn directly_contains_source(scan: &RepoScan, language: Language, path: &Path) -> bool {
@@ -208,6 +272,24 @@ mod python_dir_tests {
     }
 
     #[test]
+    fn virtualenv_detected_by_content_not_name() {
+        let tmp = std::env::temp_dir().join(format!("rag-rat-venv-detect-{}", std::process::id()));
+        fs::remove_dir_all(&tmp).ok();
+        // A real venv (any name) has a `pyvenv.cfg` → detected.
+        fs::create_dir_all(tmp.join("env")).unwrap();
+        fs::write(tmp.join("env/pyvenv.cfg"), "home = /usr\n").unwrap();
+        assert!(is_virtualenv_dir(&tmp.join("env")), "a pyvenv.cfg dir is a venv");
+        // A first-party package that merely shares a venv-ish NAME (no pyvenv.cfg) is NOT a venv.
+        fs::create_dir_all(tmp.join("src/virtualenv")).unwrap();
+        fs::write(tmp.join("src/virtualenv/__init__.py"), "").unwrap();
+        assert!(
+            !is_virtualenv_dir(&tmp.join("src/virtualenv")),
+            "the virtualenv package dir has no pyvenv.cfg"
+        );
+        fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
     fn fallback_does_not_promote_a_venv_only_python_repo() {
         // A repo whose only discovered .py files live under an `env/` virtualenv: the no-default
         // fallback must NOT promote it (else `init -y` writes `python = ["env"]`).
@@ -220,6 +302,62 @@ mod python_dir_tests {
         assert!(
             candidates.iter().all(|candidate| !candidate.default),
             "a virtualenv dir must never be selected as the default Python target: {candidates:?}"
+        );
+    }
+
+    /// #173 case 2: a realistic env-only repo — `add_file_to_dir_counts` always increments the `.`
+    /// aggregate, so `.` carries the full count. The fallback must still NOT promote `.` (its only
+    /// `.py` live under the dependency tree), so `init -y` writes no Python binding rather than
+    /// `python = ["."]` over installed deps.
+    #[test]
+    fn fallback_does_not_promote_dot_when_python_lives_only_under_a_dependency_tree() {
+        let root = Path::new("/repo");
+        let mut scan = RepoScan::default();
+        // Two `.py` files under `env/lib/site-packages/pkg` — nothing at the root.
+        for name in ["a.py", "b.py"] {
+            add_file_to_dir_counts(
+                root,
+                &root.join("env/lib/site-packages/pkg").join(name),
+                Language::Python,
+                &mut scan,
+            )
+            .unwrap();
+        }
+        let candidates = candidate_dirs(&scan, Language::Python);
+        assert!(
+            candidates.iter().all(|candidate| !candidate.default),
+            "no binding for an env-only repo (not even `.`): {candidates:?}"
+        );
+    }
+
+    /// #173 case 1: root entrypoints (`manage.py`) alongside a package dir. Both `.` (root source)
+    /// and the package dir must be defaults, so `init -y` indexes the root entrypoints too — not
+    /// only the package.
+    #[test]
+    fn root_entrypoints_default_alongside_a_package_dir() {
+        let root = Path::new("/repo");
+        let mut scan = RepoScan::default();
+        // A root entrypoint + package-dir sources.
+        add_file_to_dir_counts(root, &root.join("manage.py"), Language::Python, &mut scan).unwrap();
+        for name in ["__init__.py", "views.py"] {
+            add_file_to_dir_counts(
+                root,
+                &root.join("myapp").join(name),
+                Language::Python,
+                &mut scan,
+            )
+            .unwrap();
+        }
+        let candidates = candidate_dirs(&scan, Language::Python);
+        let default_paths: Vec<String> =
+            candidates.iter().filter(|c| c.default).map(|c| display_rel(&c.path)).collect();
+        assert!(
+            default_paths.contains(&".".to_string()),
+            "root entrypoints make `.` a default: {candidates:?}"
+        );
+        assert!(
+            default_paths.contains(&"myapp".to_string()),
+            "the package dir is still a default: {candidates:?}"
         );
     }
 }

--- a/crates/rag-rat-cli/tests/init_dir_selection.rs
+++ b/crates/rag-rat-cli/tests/init_dir_selection.rs
@@ -1,0 +1,122 @@
+//! `rag-rat init` Python dir-selection (#181): the scan honors the same gitignore + floor rules as
+//! the index walk, so a GITIGNORED virtualenv at the root does not drop a real `manage.py`
+//! entrypoint, while a NON-gitignored env-only repo produces no usable config and fails instead of
+//! writing an empty `[target_bindings]`.
+//!
+//! These use `init -y --dry-run`, which renders the planned config to STDOUT and returns BEFORE
+//! writing the file, indexing, or installing MCP servers/hooks — so the test never touches the
+//! filesystem outside its temp repo, never mutates the developer's/CI's MCP config, and never
+//! shells out to `claude`/`codex` (the real `init` install flow does all of those).
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+static TEMP_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn unique_temp_root() -> PathBuf {
+    let id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!("rag-rat-init-dirsel-{}-{id}", std::process::id()))
+}
+
+fn write(root: &std::path::Path, rel: &str, contents: &str) {
+    let path = root.join(rel);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, contents).unwrap();
+}
+
+/// Run `init -y --dry-run` in `root`. Dry-run prints the rendered config and returns before any
+/// side effect, so this is pure planning — no config write, no index, no MCP/hook install.
+fn init_dry_run(root: &std::path::Path) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+        .args(["init", "-y", "--dry-run"])
+        .current_dir(root)
+        .output()
+        .expect("run rag-rat init --dry-run")
+}
+
+#[test]
+fn gitignored_root_venv_does_not_drop_the_root_entrypoint() {
+    let root = unique_temp_root();
+    fs::create_dir_all(&root).unwrap();
+    // A Django-style layout: a root `manage.py`, a real package, and a GITIGNORED virtualenv.
+    write(&root, "manage.py", "def main():\n    pass\n");
+    write(&root, "myapp/__init__.py", "");
+    write(&root, "myapp/models.py", "class A:\n    pass\n");
+    write(&root, "env/bin/activate_this.py", "x = 1\n");
+    write(&root, ".gitignore", "env/\n");
+
+    let output = init_dry_run(&root);
+    assert!(output.status.success(), "init --dry-run should succeed: {output:?}");
+    let rendered = String::from_utf8_lossy(&output.stdout);
+    // The gitignored `env/` is skipped by the scan (as the index would skip it), so `.` is still a
+    // safe default for the root entrypoint.
+    assert!(
+        rendered.contains("python = [\".\", \"myapp\"]"),
+        "expected `.` + package binding, got:\n{rendered}"
+    );
+    assert!(!root.join("rag-rat.toml").exists(), "dry-run must not write a config");
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn non_gitignored_env_only_repo_fails_instead_of_empty_config() {
+    let root = unique_temp_root();
+    fs::create_dir_all(&root).unwrap();
+    // The only Python lives under a NON-gitignored, unfloored `env/` virtualenv — there is no safe
+    // binding, so init must fail rather than emit an empty `[target_bindings]`.
+    write(&root, "env/bin/activate_this.py", "x = 1\n");
+
+    let output = init_dry_run(&root);
+    assert!(!output.status.success(), "init should fail with no indexable source: {output:?}");
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn first_party_virtualenv_package_is_bindable() {
+    let root = unique_temp_root();
+    fs::create_dir_all(&root).unwrap();
+    // The `virtualenv` PyPI package's own layout: `src/virtualenv/` is FIRST-PARTY source (no
+    // `pyvenv.cfg`). It must not be treated as a dependency tree — Python stays bound.
+    write(&root, "src/virtualenv/__init__.py", "class Session:\n    pass\n");
+    write(&root, "src/virtualenv/run.py", "def cli():\n    pass\n");
+
+    let output = init_dry_run(&root);
+    assert!(output.status.success(), "init should bind the first-party package: {output:?}");
+    let rendered = String::from_utf8_lossy(&output.stdout);
+    // Bound as ordinary source under the `src` layout — NOT dropped as a "virtualenv" dependency.
+    assert!(
+        rendered.contains("python = [\"src\"]"),
+        "the virtualenv package must remain a Python binding, got:\n{rendered}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn nested_real_venv_does_not_promote_its_ancestor() {
+    let root = unique_temp_root();
+    fs::create_dir_all(&root).unwrap();
+    // A real venv (has `pyvenv.cfg`) nested under `tools/`, plus a genuine package. The venv's
+    // files must not count, so `tools` is never promoted and `.` is blocked; only `myapp`
+    // binds.
+    write(&root, "myapp/__init__.py", "");
+    write(&root, "myapp/models.py", "class A:\n    pass\n");
+    write(&root, "manage.py", "def main():\n    pass\n");
+    write(&root, "tools/env/pyvenv.cfg", "home = /usr\n");
+    write(&root, "tools/env/bin/activate_this.py", "x = 1\n");
+    write(&root, "tools/env/lib/site.py", "y = 2\n");
+
+    let output = init_dry_run(&root);
+    assert!(output.status.success(), "init should succeed binding the real package: {output:?}");
+    let rendered = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        rendered.contains("python = [\"myapp\"]"),
+        "only the real package should bind (not `.` or `tools`), got:\n{rendered}"
+    );
+
+    fs::remove_dir_all(&root).ok();
+}

--- a/crates/rag-rat-core/src/index/ignore_rules.rs
+++ b/crates/rag-rat-core/src/index/ignore_rules.rs
@@ -68,9 +68,18 @@ const FLOOR_DIRS: &[&str] = &[
     // Python virtualenv / dependency / cache trees: never project source. `site-packages` is the
     // load-bearing one — installed deps live there regardless of the venv dir's name (`.venv`,
     // `venv`, `env`, …), so flooring it stops a `python = ["."]` config from ingesting the whole
-    // dependency set even when the venv dir itself isn't named conventionally.
+    // dependency set even when the venv dir itself isn't named conventionally. Only names that can
+    // NEVER be a first-party import package are floored: `.venv`/`.tox`/`.nox` start with a dot (a
+    // Python package dir can't), and `site-packages`/`__pycache__` are reserved. `venv` is the one
+    // bare name kept (overwhelmingly a virtualenv). `virtualenv`/`env`/`.env` are deliberately NOT
+    // floored — `virtualenv` is itself a real package (`src/virtualenv/…` is first-party source,
+    // #181 review), and `env`/`.env` are too generic; their installed deps are still caught by
+    // `site-packages`, and the init scanner refuses to auto-bind `.` when any of them sit at the
+    // root.
     ".venv",
     "venv",
+    ".tox",
+    ".nox",
     "site-packages",
     "__pycache__",
 ];
@@ -78,6 +87,17 @@ const FLOOR_DIRS: &[&str] = &[
 /// Whether a single path component matches a floor directory name (see [`FLOOR_DIRS`]).
 fn is_floor_dir(name: &str) -> bool {
     FLOOR_DIRS.contains(&name)
+}
+
+/// Whether `dir` is a Python virtualenv — detected by CONTENT, not name: every venv created by
+/// `python -m venv` / `virtualenv` (Python 3.3+) writes a `pyvenv.cfg` at its root. This is the
+/// name-independent test that distinguishes an ambiguously-named venv (`env/`, `virtualenv/`) from
+/// a first-party package of the same name (the `virtualenv` PyPI package's `src/virtualenv/` has no
+/// `pyvenv.cfg`). Used to keep a venv out of init's binding candidates without flooring real
+/// package names (#181). `FLOOR_DIRS` still covers the conventional names (`.venv`/`venv`) as a
+/// fast path and for legacy venvs lacking the marker.
+pub fn is_virtualenv_dir(dir: &Path) -> bool {
+    dir.join("pyvenv.cfg").is_file()
 }
 
 /// One `.gitignore`, compiled by [`GitignoreBuilder`] with its own directory as the matching root
@@ -363,6 +383,25 @@ mod tests {
         assert!(m.is_ignored(&tmp.join(".rag-rat"), true));
         assert!(m.is_ignored(&tmp.join("node_modules/pkg/index.ts"), false));
         assert!(!m.is_ignored(&tmp.join("src/lib.rs"), false));
+        fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn python_venv_floor_dirs_ignored_but_generic_env_indexed() {
+        let tmp = tempdir();
+        let m = compile(&tmp);
+        // Dotted tooling trees can never be first-party import packages, so they're floored even
+        // with no .gitignore (#181).
+        assert!(m.is_ignored(&tmp.join(".tox/py311/lib/foo.py"), false));
+        assert!(m.is_ignored(&tmp.join(".nox/session/foo.py"), false));
+        // site-packages stays floored regardless of the enclosing venv dir's name.
+        assert!(m.is_ignored(&tmp.join("env/lib/python3.11/site-packages/dep.py"), false));
+        // …but bare names that CAN be a real import package are NOT floored globally: `virtualenv`
+        // is itself a PyPI package (`src/virtualenv/…` is first-party, #181 review), and
+        // `env`/`.env` are too generic. Their own non-site-packages files stay indexable.
+        assert!(!m.is_ignored(&tmp.join("src/virtualenv/__init__.py"), false));
+        assert!(!m.is_ignored(&tmp.join("env/settings.py"), false));
+        assert!(!m.is_ignored(&tmp.join(".env/config.py"), false));
         fs::remove_dir_all(&tmp).ok();
     }
 


### PR DESCRIPTION
Fixes #173. Two init-scanner UX refinements for Python directory selection. The safety-critical part (the walker flooring `site-packages`/`.venv`/`venv`/`__pycache__`) already shipped in #167 — these are about what `init -y` *writes*.

## 1. Root entrypoints alongside a package dir

A repo with root `manage.py`/`main.py` **and** a package dir wrote only the package binding, omitting the root files: `.` (the aggregate bucket every file increments) was never recognized as *directly* containing source. Now root-level files key under `.` in `direct_dir_counts`, and a new `python_root_has_direct_source` makes `.` a default when the root holds genuine entrypoints — so both `.` and the package dir are offered.

## 2. env-only repos no longer promote `.`

When every `.py` lives under a dependency tree (`env/`, `.venv/…/site-packages`, …), the no-default fallback would pick `.` on aggregate count and write `python = ["."]` (over installed deps). The fallback now skips `.` for Python unless the root directly contains real source — so an env-only repo gets no Python binding rather than a wrong one.

## Tests

- `root_entrypoints_default_alongside_a_package_dir` — `manage.py` + `myapp/` → both `.` and `myapp` are defaults.
- `fallback_does_not_promote_dot_when_python_lives_only_under_a_dependency_tree` — realistic env-only repo (`.` carries the aggregate count) → no default.
- The existing `fallback_does_not_promote_a_venv_only_python_repo` stays green; full `rag-rat` suite + fmt + clippy clean. The count-keying change is Python-guarded in the selection logic, so other languages' dir selection is unaffected.

Last of the #167 Python follow-ups (with #172 / PR #180 and #174 / PR #179).