### PR TITLE
feat(oracle): scip-typescript backend + ts-ky corpus

### DIFF
--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -58,11 +58,12 @@ concurrency:
 
 env:
   # Pinned SCIP toolchain for the small tier so a PR number isn't perturbed by an unrelated indexer
-  # release. scip-clang/scip-python are pinned to explicit versions; rust-analyzer is installed as a
+  # release. scip-clang/scip-python/scip-typescript are pinned to explicit versions; rust-analyzer is installed as a
   # rustup component (below), pinning it to the stable toolchain (a ~6-week cadence) instead of the
   # weekly `releases/latest` — so a fresh RA build can't change `rust-semver`'s numbers mid-PR.
   SCIP_CLANG_VERSION: v0.4.0
   SCIP_PYTHON_VERSION: 0.6.6
+  SCIP_TYPESCRIPT_VERSION: 0.4.0
 
 jobs:
   matrix:
@@ -129,6 +130,9 @@ jobs:
             scip-python)
               npm install -g "@sourcegraph/scip-python@${SCIP_PYTHON_VERSION}"
               scip-python --version ;;
+            scip-typescript)
+              npm install -g "@sourcegraph/scip-typescript@${SCIP_TYPESCRIPT_VERSION}"
+              scip-typescript --version ;;
             *)
               echo "unknown tool '$tool'" >&2; exit 1 ;;
           esac

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -304,6 +304,8 @@ pub(crate) enum OracleToolArg {
     ScipClang,
     #[value(name = "scip-python")]
     ScipPython,
+    #[value(name = "scip-typescript")]
+    ScipTypescript,
 }
 
 impl OracleToolArg {
@@ -312,6 +314,8 @@ impl OracleToolArg {
             OracleToolArg::RustAnalyzer => rag_rat_core::index::oracle::OracleTool::RustAnalyzer,
             OracleToolArg::ScipClang => rag_rat_core::index::oracle::OracleTool::ScipClang,
             OracleToolArg::ScipPython => rag_rat_core::index::oracle::OracleTool::ScipPython,
+            OracleToolArg::ScipTypescript =>
+                rag_rat_core::index::oracle::OracleTool::ScipTypescript,
         }
     }
 }

--- a/crates/rag-rat-core/src/index/oracle/corpus.rs
+++ b/crates/rag-rat-core/src/index/oracle/corpus.rs
@@ -169,8 +169,16 @@ health    = { expected_min_heuristic_edges = 50000, expected_min_oracle_examined
         };
         let corpora = load_corpora(&toml_str).unwrap();
         let ids: Vec<&str> = corpora.iter().map(|c| c.corpus_id.as_str()).collect();
-        assert_eq!(ids, ["rust-semver", "c-cjson", "py-requests", "rust-cargo", "linux-kernel"]);
+        assert_eq!(ids, [
+            "rust-semver",
+            "c-cjson",
+            "py-requests",
+            "ts-ky",
+            "rust-cargo",
+            "linux-kernel"
+        ]);
         assert_eq!(corpus_by_id(&corpora, "py-requests").unwrap().tool, "scip-python");
+        assert_eq!(corpus_by_id(&corpora, "ts-ky").unwrap().tool, "scip-typescript");
 
         // GOLDEN per-profile hashes: an edit to any corpus field changes its hash (and makes prior
         // reports incomparable) — recompute deliberately when intended.
@@ -180,6 +188,7 @@ health    = { expected_min_heuristic_edges = 50000, expected_min_oracle_examined
             ("rust-semver", GOLDEN_RUST_SEMVER.to_string()),
             ("c-cjson", GOLDEN_C_CJSON.to_string()),
             ("py-requests", GOLDEN_PY_REQUESTS.to_string()),
+            ("ts-ky", GOLDEN_TS_KY.to_string()),
             ("rust-cargo", GOLDEN_RUST_CARGO.to_string()),
             ("linux-kernel", GOLDEN_LINUX_KERNEL.to_string()),
         ]);
@@ -191,6 +200,7 @@ health    = { expected_min_heuristic_edges = 50000, expected_min_oracle_examined
     const GOLDEN_C_CJSON: &str = "685a33345247c2ef310b7671fb9e2a55a7cb7c577fcd29fecac436ff0634c9dc";
     const GOLDEN_PY_REQUESTS: &str =
         "76abdb4592d1e1997f133fb5cd185d85b57851e8a82e085268e45d4d16c2c832";
+    const GOLDEN_TS_KY: &str = "4565e3323659cc3de96eebfb033440a2a91622bcd14f7bec2b022d4e642f1bba";
     const GOLDEN_RUST_CARGO: &str =
         "60452736340151a253001bb5c33cc83efa2a4ceabba4d42a227d3188d7761d79";
     const GOLDEN_LINUX_KERNEL: &str =

--- a/crates/rag-rat-core/src/index/oracle/manifest.rs
+++ b/crates/rag-rat-core/src/index/oracle/manifest.rs
@@ -77,6 +77,15 @@ impl ToolManifest {
                                (e.g. into a virtualenv) so imports resolve, or pass a pre-built \
                                index with `--scip <path>`.",
             },
+            OracleTool::ScipTypescript => ToolManifest {
+                tool,
+                program: "scip-typescript",
+                languages: &["typescript"],
+                install_hint: "scip-typescript not found on PATH. Install it (e.g. `npm install \
+                               -g @sourcegraph/scip-typescript`) AND install the project's \
+                               dependencies (`npm install`) so cross-package references resolve, \
+                               or pass a pre-built index with `--scip <path>`.",
+            },
         }
     }
 
@@ -120,7 +129,7 @@ impl ToolManifest {
             OracleTool::ScipClang => true,
             // scip-python emits via an `index` subcommand; `index --help` exiting 0 is the analog
             // of rust-analyzer's `scip --help` capability check.
-            OracleTool::ScipPython => Command::new(self.program)
+            OracleTool::ScipPython | OracleTool::ScipTypescript => Command::new(self.program)
                 .arg("index")
                 .arg("--help")
                 .output()
@@ -139,7 +148,12 @@ impl ToolManifest {
             // check (it's whatever the corpus `prepare` venv installs); a failed environment shows
             // up as a near-zero moniker count the report health gate catches, so there's nothing to
             // block on here.
-            OracleTool::RustAnalyzer | OracleTool::ScipPython => None,
+            // scip-typescript, like scip-python, has no single prerequisite sentinel: it indexes
+            // the project's own files even without `node_modules` (cross-package
+            // monikers just stay unresolved), and infers a `tsconfig.json` when missing
+            // (`--infer-tsconfig`). A failed environment surfaces as a low moniker
+            // count the report health gate catches.
+            OracleTool::RustAnalyzer | OracleTool::ScipPython | OracleTool::ScipTypescript => None,
             OracleTool::ScipClang => (!root.join("compile_commands.json").exists()).then(|| {
                 format!(
                     "scip-clang requires a compile_commands.json at {} — generate one (e.g. `bear \
@@ -194,6 +208,23 @@ impl ToolManifest {
                     .arg("_")
                     .arg("--cwd")
                     .arg(root)
+                    .arg("--output")
+                    .arg(output);
+                cmd
+            },
+            // scip-typescript indexes the working dir via its `index` subcommand (like
+            // scip-python). `--infer-tsconfig` synthesizes a `tsconfig.json` from
+            // `package.json` when the project doesn't ship one (a no-op when it does),
+            // so a corpus needn't hand-author one; package name/version come from
+            // `package.json`, NOT the git rev, so monikers are already stable
+            // across commits and need no `--project-version` pin (unlike scip-python). `--output`
+            // is absolute, unaffected by `--cwd`.
+            OracleTool::ScipTypescript => {
+                let mut cmd = Command::new(self.program);
+                cmd.arg("index")
+                    .arg("--cwd")
+                    .arg(root)
+                    .arg("--infer-tsconfig")
                     .arg("--output")
                     .arg(output);
                 cmd
@@ -337,6 +368,28 @@ mod tests {
             "_",
             "--cwd",
             "/work/requests",
+            "--output",
+            "/tmp/out.scip",
+        ]);
+        assert!(manifest.prerequisite_blocked(Path::new("/no/such/repo/xyzzy")).is_none());
+    }
+
+    #[test]
+    fn scip_typescript_indexes_a_cwd() {
+        // scip-typescript's invocation: `scip-typescript index --cwd <root> --infer-tsconfig
+        // --output <abs>`. No `--project-name` / `--project-version` (package.json supplies both,
+        // so monikers are already commit-stable) and no compile_commands.json prerequisite
+        // (the `npm install` is the corpus `prepare` step's job).
+        let manifest = ToolManifest::for_tool(OracleTool::ScipTypescript);
+        assert_eq!(manifest.program, "scip-typescript");
+        assert_eq!(manifest.languages, &["typescript"]);
+        let cmd = manifest.scip_command(Path::new("/work/ky"), Path::new("/tmp/out.scip"));
+        let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy().into_owned()).collect();
+        assert_eq!(args, vec![
+            "index",
+            "--cwd",
+            "/work/ky",
+            "--infer-tsconfig",
             "--output",
             "/tmp/out.scip",
         ]);

--- a/crates/rag-rat-core/src/index/oracle/manifest.rs
+++ b/crates/rag-rat-core/src/index/oracle/manifest.rs
@@ -148,12 +148,23 @@ impl ToolManifest {
             // check (it's whatever the corpus `prepare` venv installs); a failed environment shows
             // up as a near-zero moniker count the report health gate catches, so there's nothing to
             // block on here.
-            // scip-typescript, like scip-python, has no single prerequisite sentinel: it indexes
-            // the project's own files even without `node_modules` (cross-package
-            // monikers just stay unresolved), and infers a `tsconfig.json` when missing
-            // (`--infer-tsconfig`). A failed environment surfaces as a low moniker
-            // count the report health gate catches.
-            OracleTool::RustAnalyzer | OracleTool::ScipPython | OracleTool::ScipTypescript => None,
+            OracleTool::RustAnalyzer | OracleTool::ScipPython => None,
+            // scip-typescript needs a `tsconfig.json` at the root: with `--infer-tsconfig` it would
+            // otherwise WRITE one into the checkout (confirmed against v0.4.0), violating the
+            // read-only-on-source contract — so we don't pass that flag and instead require a real
+            // tsconfig (the TS analog of scip-clang's compile_commands.json). Cross-package deps
+            // (`node_modules`) are the corpus `prepare` step's job; a missing one is NOT reliably
+            // caught by the moniker-count gate (scip-typescript mints local monikers from
+            // package.json regardless of node_modules) — only external resolution drops. A
+            // dedicated external-resolution health signal is tracked in #185.
+            OracleTool::ScipTypescript => (!root.join("tsconfig.json").exists()).then(|| {
+                format!(
+                    "scip-typescript requires a tsconfig.json at {} — add one to the project \
+                     (most TypeScript projects ship one), or pass a pre-built index with `--scip \
+                     <path>`.",
+                    root.display()
+                )
+            }),
             OracleTool::ScipClang => (!root.join("compile_commands.json").exists()).then(|| {
                 format!(
                     "scip-clang requires a compile_commands.json at {} — generate one (e.g. `bear \
@@ -213,20 +224,16 @@ impl ToolManifest {
                 cmd
             },
             // scip-typescript indexes the working dir via its `index` subcommand (like
-            // scip-python). `--infer-tsconfig` synthesizes a `tsconfig.json` from
-            // `package.json` when the project doesn't ship one (a no-op when it does),
-            // so a corpus needn't hand-author one; package name/version come from
-            // `package.json`, NOT the git rev, so monikers are already stable
-            // across commits and need no `--project-version` pin (unlike scip-python). `--output`
-            // is absolute, unaffected by `--cwd`.
+            // scip-python), reading the project's `tsconfig.json` (prerequisite-checked — we
+            // deliberately do NOT pass `--infer-tsconfig`, which WRITES a tsconfig into the source
+            // tree, breaking read-only-on-source). No `--project-name` / `--project-version`:
+            // package name + version come from `package.json`. That version is embedded in every
+            // local moniker and has no CLI override, so it's normalized downstream at
+            // moniker-write time (`scip::stabilize_moniker_version`), not here. `--output` is
+            // absolute, unaffected by `--cwd`.
             OracleTool::ScipTypescript => {
                 let mut cmd = Command::new(self.program);
-                cmd.arg("index")
-                    .arg("--cwd")
-                    .arg(root)
-                    .arg("--infer-tsconfig")
-                    .arg("--output")
-                    .arg(output);
+                cmd.arg("index").arg("--cwd").arg(root).arg("--output").arg(output);
                 cmd
             },
         }
@@ -376,23 +383,29 @@ mod tests {
 
     #[test]
     fn scip_typescript_indexes_a_cwd() {
-        // scip-typescript's invocation: `scip-typescript index --cwd <root> --infer-tsconfig
-        // --output <abs>`. No `--project-name` / `--project-version` (package.json supplies both,
-        // so monikers are already commit-stable) and no compile_commands.json prerequisite
-        // (the `npm install` is the corpus `prepare` step's job).
+        // scip-typescript's invocation: `scip-typescript index --cwd <root> --output <abs>`. No
+        // `--project-name` / `--project-version` (package.json supplies both; the version is
+        // normalized downstream at moniker-write time). NO `--infer-tsconfig` — that flag writes a
+        // tsconfig into the source tree, so a missing tsconfig is a prerequisite Block instead.
         let manifest = ToolManifest::for_tool(OracleTool::ScipTypescript);
         assert_eq!(manifest.program, "scip-typescript");
         assert_eq!(manifest.languages, &["typescript"]);
         let cmd = manifest.scip_command(Path::new("/work/ky"), Path::new("/tmp/out.scip"));
         let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy().into_owned()).collect();
-        assert_eq!(args, vec![
-            "index",
-            "--cwd",
-            "/work/ky",
-            "--infer-tsconfig",
-            "--output",
-            "/tmp/out.scip",
-        ]);
-        assert!(manifest.prerequisite_blocked(Path::new("/no/such/repo/xyzzy")).is_none());
+        assert_eq!(args, vec!["index", "--cwd", "/work/ky", "--output", "/tmp/out.scip"]);
+        assert!(!args.iter().any(|a| a == "--infer-tsconfig"), "must not dirty the source tree");
+    }
+
+    #[test]
+    fn scip_typescript_requires_a_tsconfig() {
+        // A checkout without a tsconfig.json is Blocked (install-hint UX), not silently run with
+        // `--infer-tsconfig` writing one into the tree — the read-only-on-source contract.
+        let manifest = ToolManifest::for_tool(OracleTool::ScipTypescript);
+        assert!(manifest.prerequisite_blocked(Path::new("/no/such/repo/xyzzy")).is_some());
+        let dir = std::env::temp_dir().join("rag_rat_ts_prereq_test");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("tsconfig.json"), "{}").unwrap();
+        assert!(manifest.prerequisite_blocked(&dir).is_none());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -571,18 +571,24 @@ pub enum OracleTool {
     /// dependencies, so the corpus must install them (a venv) first; an unresolved environment
     /// shows up as a near-zero moniker count the report's health gate catches.
     ScipPython,
+    /// `scip-typescript index` — TypeScript / TSX (#71). Like scip-python, resolves cross-package
+    /// references against the project's installed `node_modules`, so the corpus must `npm install`
+    /// first; an unresolved environment shows up as a low moniker count the health gate catches.
+    ScipTypescript,
 }
 
 impl OracleTool {
     /// Every known oracle tool, for "report on all tools" surfaces (`oracle status` with no
     /// `--tool`). Later language backends (#72 Kotlin) extend this alongside the enum.
-    pub const ALL: &[OracleTool] = &[Self::RustAnalyzer, Self::ScipClang, Self::ScipPython];
+    pub const ALL: &[OracleTool] =
+        &[Self::RustAnalyzer, Self::ScipClang, Self::ScipPython, Self::ScipTypescript];
 
     pub fn as_db_str(self) -> &'static str {
         match self {
             Self::RustAnalyzer => "rust-analyzer",
             Self::ScipClang => "scip-clang",
             Self::ScipPython => "scip-python",
+            Self::ScipTypescript => "scip-typescript",
         }
     }
 
@@ -591,6 +597,7 @@ impl OracleTool {
             "rust-analyzer" => Some(Self::RustAnalyzer),
             "scip-clang" => Some(Self::ScipClang),
             "scip-python" => Some(Self::ScipPython),
+            "scip-typescript" => Some(Self::ScipTypescript),
             _ => None,
         }
     }

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -601,6 +601,21 @@ impl OracleTool {
             _ => None,
         }
     }
+
+    /// The position encoding to assume for SCIP documents this tool emits **without** an explicit
+    /// `position_encoding` (the protobuf default `Unspecified`). scip-typescript reports ranges in
+    /// UTF-16 code units (TypeScript's internal string offsets) but never sets the field, so
+    /// reading it as the generic UTF-32 fallback mis-converts columns after any astral
+    /// character. The other backends either set the field or are unaffected, so they keep the
+    /// conservative `Unspecified` (UTF-32-equivalent) default.
+    pub(crate) fn default_position_encoding(self) -> ::scip::types::PositionEncoding {
+        use ::scip::types::PositionEncoding;
+        match self {
+            Self::ScipTypescript => PositionEncoding::UTF16CodeUnitOffsetFromLineStart,
+            Self::RustAnalyzer | Self::ScipClang | Self::ScipPython =>
+                PositionEncoding::UnspecifiedPositionEncoding,
+        }
+    }
 }
 
 /// What the oracle concluded about one edge candidate. The names mirror the #61 design taxonomy.

--- a/crates/rag-rat-core/src/index/oracle/run.rs
+++ b/crates/rag-rat-core/src/index/oracle/run.rs
@@ -110,12 +110,16 @@ pub(crate) fn run_in_tx(
     // built against, the join is comparing incompatible coordinate spaces.
     let checkout_root = input.checkout_root.to_path_buf();
     let mut source_cache: HashMap<String, Option<Vec<u8>>> = HashMap::new();
-    let index = ScipIndex::parse(input.scip_bytes, |path| {
-        source_cache
-            .entry(path.to_string())
-            .or_insert_with(|| std::fs::read(checkout_root.join(path)).ok())
-            .clone()
-    })?;
+    let index = ScipIndex::parse_with_default(
+        input.scip_bytes,
+        input.tool.default_position_encoding(),
+        |path| {
+            source_cache
+                .entry(path.to_string())
+                .or_insert_with(|| std::fs::read(checkout_root.join(path)).ok())
+                .clone()
+        },
+    )?;
 
     // Per-document hash of the disk bytes actually read, for the content-integrity check. A
     // candidate whose `file_sha` (the `files.sha256` the edge was indexed against) differs from the
@@ -342,6 +346,13 @@ pub(crate) fn run_in_tx(
     // (`…Struct#field.` vs `…Struct#`), so shortest selects the symbol's own moniker.
     let mut best_monikers: HashMap<i64, &str> = HashMap::new();
     for (scip_symbol, def) in &index.definitions {
+        // A namespace/module/file symbol (ends in `/`) is never a code symbol's moniker. Skipping
+        // it here drops scip-typescript's synthetic zero-width (`0..0`) per-file
+        // definition, which would otherwise containment-map to the first real symbol and
+        // win shortest-moniker selection.
+        if scip::symbol_is_module(scip_symbol) {
+            continue;
+        }
         let disk = disk_sha.get(&def.path).map(String::as_str);
         if disk.is_none() || indexed_shas.get(&def.path).map(String::as_str) != disk {
             continue;

--- a/crates/rag-rat-core/src/index/oracle/run.rs
+++ b/crates/rag-rat-core/src/index/oracle/run.rs
@@ -376,12 +376,16 @@ pub(crate) fn run_in_tx(
             .or_insert(scip_symbol);
     }
     for (logical_symbol_id, moniker) in &best_monikers {
+        // Pin the version component to a constant so a release bump doesn't churn the moniker and
+        // orphan moniker-anchored memories (scip-typescript bakes package.json's version in and has
+        // no --project-version flag; a no-op for the already-stable tools).
+        let moniker = scip::stabilize_moniker_version(input.tool, moniker);
         store::write_logical_symbol_moniker(
             conn,
             input.tool,
             input.tool_version,
             *logical_symbol_id,
-            moniker,
+            &moniker,
         )?;
         report.monikers_written += 1;
     }

--- a/crates/rag-rat-core/src/index/oracle/scip.rs
+++ b/crates/rag-rat-core/src/index/oracle/scip.rs
@@ -176,6 +176,41 @@ fn is_local_symbol(symbol: &str) -> bool {
     ::scip::symbol::is_local_symbol(symbol)
 }
 
+/// The constant version component pinned into in-corpus monikers so they stay stable across commits
+/// (matches scip-python's `--project-version _`). See [`stabilize_moniker_version`].
+pub(crate) const STABLE_MONIKER_VERSION: &str = "_";
+
+/// Normalize the **version** component of an in-corpus moniker to a constant so a stored moniker is
+/// invariant across releases — the prerequisite for moniker-anchored memory relocation.
+///
+/// scip-typescript bakes the project's `package.json` `version` into the package component of every
+/// local moniker (`scip-typescript npm <name> <version> <descriptor>`) and exposes no
+/// `--project-version` flag to override it (unlike scip-python, which we pin to `_` at the CLI). A
+/// routine version bump would otherwise churn every TS moniker and orphan every memory bound to
+/// one. Rewriting the version to [`STABLE_MONIKER_VERSION`] yields the same stable form scip-python
+/// already produces. Tools whose monikers are already version-stable (rust-analyzer, scip-clang,
+/// scip-python) pass through untouched, as do unparsable / package-less / local symbols.
+pub(crate) fn stabilize_moniker_version(
+    tool: super::OracleTool,
+    symbol: &str,
+) -> std::borrow::Cow<'_, str> {
+    use std::borrow::Cow;
+    if tool != super::OracleTool::ScipTypescript {
+        return Cow::Borrowed(symbol);
+    }
+    let Ok(mut parsed) = ::scip::symbol::parse_symbol(symbol) else {
+        return Cow::Borrowed(symbol);
+    };
+    let Some(package) = parsed.package.as_mut() else {
+        return Cow::Borrowed(symbol);
+    };
+    if package.name.trim().is_empty() || package.version == STABLE_MONIKER_VERSION {
+        return Cow::Borrowed(symbol);
+    }
+    package.version = STABLE_MONIKER_VERSION.to_string();
+    Cow::Owned(::scip::symbol::format_symbol(parsed))
+}
+
 /// Converts a SCIP `Occurrence.range` (`[start_line, start_char, end_char]` for single-line, or
 /// `[start_line, start_char, end_line, end_char]` for multi-line) — whose char columns are in a
 /// document's `position_encoding` — into an absolute **byte** range within the file.

--- a/crates/rag-rat-core/src/index/oracle/scip.rs
+++ b/crates/rag-rat-core/src/index/oracle/scip.rs
@@ -65,13 +65,35 @@ impl ScipIndex {
     /// offsets can be converted in the document's encoding. A document whose source can't be read
     /// is skipped (its occurrences can't be byte-resolved); the join just finds no oracle data for
     /// those edges, which is the correct degradation.
+    ///
+    /// Test-only convenience for the unset-encoding default (`Unspecified`); the production path
+    /// calls [`Self::parse_with_default`] with the tool's known default.
+    #[cfg(test)]
     pub(crate) fn parse(
         bytes: &[u8],
+        read_document_source: impl FnMut(&str) -> Option<Vec<u8>>,
+    ) -> anyhow::Result<Self> {
+        Self::parse_with_default(
+            bytes,
+            PositionEncoding::UnspecifiedPositionEncoding,
+            read_document_source,
+        )
+    }
+
+    /// Like [`Self::parse`] but supplies the encoding to assume for documents that leave
+    /// `position_encoding` **unset** (the protobuf default `Unspecified`). Some indexers — notably
+    /// scip-typescript — emit ranges in UTF-16 code units but never set the field; reading those as
+    /// the historical UTF-32 fallback mis-converts any column past an astral character. The caller
+    /// passes the tool's known default (see `OracleTool::default_position_encoding`); a document
+    /// that DOES set the field always wins over this default.
+    pub(crate) fn parse_with_default(
+        bytes: &[u8],
+        default_encoding: PositionEncoding,
         mut read_document_source: impl FnMut(&str) -> Option<Vec<u8>>,
     ) -> anyhow::Result<Self> {
         let index = Index::parse_from_bytes(bytes)
             .map_err(|err| anyhow::anyhow!("failed to parse SCIP index: {err}"))?;
-        Self::from_index(&index, &mut read_document_source)
+        Self::from_index(&index, default_encoding, &mut read_document_source)
     }
 
     /// The relative paths of every document in a serialized `.scip`, WITHOUT reading any source or
@@ -90,6 +112,7 @@ impl ScipIndex {
     /// constructing an `Index` programmatically.
     pub(crate) fn from_index(
         index: &Index,
+        default_encoding: PositionEncoding,
         read_document_source: &mut impl FnMut(&str) -> Option<Vec<u8>>,
     ) -> anyhow::Result<Self> {
         let mut out = ScipIndex::default();
@@ -98,10 +121,17 @@ impl ScipIndex {
             let Some(source) = read_document_source(&path) else {
                 continue;
             };
-            let encoding = document
+            // A document that explicitly sets `position_encoding` wins; only fall back to the
+            // tool-supplied `default_encoding` when it's left unset (protobuf default
+            // `Unspecified`).
+            let encoding = match document
                 .position_encoding
                 .enum_value()
-                .unwrap_or(PositionEncoding::UnspecifiedPositionEncoding);
+                .unwrap_or(PositionEncoding::UnspecifiedPositionEncoding)
+            {
+                PositionEncoding::UnspecifiedPositionEncoding => default_encoding,
+                explicit => explicit,
+            };
             let mapper = LineColumnToByte::new(&source, encoding);
 
             let mut occurrences = Vec::with_capacity(document.occurrences.len());
@@ -166,8 +196,27 @@ fn has_import_role(symbol_roles: i32) -> bool {
 /// `…#`, a `Macro` `…!`, a `Meta` `…:`, a `Namespace`/`Package` `…/` — so they were already out. A
 /// symbol with no recognizable callable suffix is conservatively non-callable, so a malformed
 /// string can't inflate the recall denominator.
+///
+/// KNOWN SCOPE LIMIT (cross-language, most visible in TypeScript — tracked in #185): a
+/// **function-valued variable / arrow function** (`const f = () => …; f()`) is a `Term` (`…f.`),
+/// not a `Method`, so calls to it are excluded from BOTH sides of the recall ratio. SCIP carries no
+/// call role to tell a function-valued term from a plain value term, and admitting bare `.` would
+/// re-introduce the field/const over-count above — so TS recall measures method / function-
+/// declaration calls only (symmetric, but a narrower population than the heuristic emits). The
+/// verdict precision metrics are unaffected; only the recall denominator's scope is.
 pub(crate) fn symbol_is_callable(symbol: &str) -> bool {
     symbol.trim_end().ends_with(").")
+}
+
+/// Whether a SCIP symbol is a *namespace / module / package* descriptor — its final descriptor
+/// ends in `/` (the SCIP grammar's Namespace suffix, e.g. scip-typescript's per-file symbol
+/// `… src/`a.ts`/`). These are not code entities of their own in rag-rat's graph, so they must
+/// never become a logical symbol's moniker: scip-typescript emits a synthetic **zero-width** file
+/// definition at byte `0..0`, which the moniker pass's containment map would otherwise attach to
+/// the first real symbol — and being the shortest candidate, it would win selection and overwrite
+/// the symbol's own moniker, breaking moniker-based relocation.
+pub(crate) fn symbol_is_module(symbol: &str) -> bool {
+    symbol.trim_end().ends_with('/')
 }
 
 /// A SCIP `local …` symbol is function-local. SCIP's own `is_local_symbol` checks the `local`

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -1441,6 +1441,48 @@ fn parse_document_with_no_occurrences_registers_empty_entry() {
     assert!(idx.definitions.is_empty());
 }
 
+/// scip-typescript leaves `position_encoding` UNSET (Unspecified) but emits UTF-16 column offsets.
+/// `parse_with_default(UTF16, …)` must read those columns as UTF-16 so an identifier after an
+/// astral character lands on the right bytes; the historical Unspecified→UTF-32 fallback misaligns
+/// it.
+#[test]
+fn unspecified_encoding_uses_the_supplied_default() {
+    // "😀foo\n": the emoji is 4 UTF-8 bytes = 2 UTF-16 units = 1 UTF-32 unit; "foo" is bytes 4..7.
+    let source = "😀foo\n".as_bytes().to_vec();
+    // UTF-16 columns [2,5] (past the 2-unit emoji).
+    let occ =
+        occurrence(0, 2, 5, "scip-typescript npm p 1 `a.ts`/foo().", SymbolRole::Definition as i32);
+    // Document with NO position_encoding set (serialized as the protobuf default = Unspecified).
+    let bytes = scip_bytes("a.ts", PositionEncoding::UnspecifiedPositionEncoding, vec![occ]);
+
+    let s = source.clone();
+    let idx = ScipIndex::parse_with_default(
+        &bytes,
+        PositionEncoding::UTF16CodeUnitOffsetFromLineStart,
+        move |_| Some(s.clone()),
+    )
+    .unwrap();
+    let occ16 = &idx.occurrences_by_path.get("a.ts").unwrap()[0];
+    assert_eq!((occ16.start_byte, occ16.end_byte), (4, 7));
+    assert_eq!(&source[occ16.start_byte..occ16.end_byte], b"foo");
+
+    // The plain 2-arg parse (Unspecified → UTF-32 fallback) misaligns onto the wrong bytes.
+    let s = source.clone();
+    let idx32 = ScipIndex::parse(&bytes, move |_| Some(s.clone())).unwrap();
+    let occ32 = &idx32.occurrences_by_path.get("a.ts").unwrap()[0];
+    assert_ne!(&source[occ32.start_byte..occ32.end_byte], b"foo", "UTF-32 fallback misaligns");
+}
+
+/// `symbol_is_module` recognizes the SCIP namespace/module/package suffix (`/`) and nothing else.
+#[test]
+fn symbol_is_module_matches_only_namespace_suffix() {
+    use super::scip::symbol_is_module;
+    assert!(symbol_is_module("scip-typescript npm p 1 `a.ts`/"));
+    assert!(!symbol_is_module("scip-typescript npm p 1 `a.ts`/foo().")); // method
+    assert!(!symbol_is_module("scip-typescript npm p 1 `a.ts`/Bar#")); // type
+    assert!(!symbol_is_module("local 1"));
+}
+
 /// A multi-line occurrence range (`[start_line, start_char, end_line, end_char]`) parses to the
 /// byte span crossing the newline.
 #[test]
@@ -3667,6 +3709,33 @@ fn moniker_for_symbol_with_member_defs_is_the_symbols_own() {
     assert_eq!(report.monikers_written, 1, "one row per logical symbol, not per def");
     let (moniker, ..) = h.moniker(3003).expect("moniker row written");
     assert_eq!(moniker, struct_moniker, "the symbol's own (shortest) moniker wins");
+}
+
+/// A synthetic zero-width per-file definition (scip-typescript emits one ending in `/` at byte
+/// `0..0`) must NOT become a symbol's moniker: it containment-maps to the first symbol (whose span
+/// starts at 0) and, being shorter, would win shortest-moniker selection and clobber the real one.
+/// The namespace-suffix filter in the moniker pass drops it.
+#[test]
+fn synthetic_file_definition_does_not_overwrite_a_symbols_moniker() {
+    let h = Harness::new();
+    // `greet`'s span starts at byte 0, so a 0..0 file def would containment-map to it.
+    let defs = h.add_file("a.ts", "function greet() {}\n");
+    let sym = h.add_symbol_qualified(defs, "greet", "a.ts::greet", "function", 0, 19);
+    h.add_logical_symbol(4004, "a.ts", "greet", "a.ts::greet", sym);
+
+    let greet_moniker = "rust-analyzer cargo test_crate 0.1.0 greet().";
+    let file_moniker = "rust-analyzer cargo test_crate 0.1.0 `a.ts`/"; // shorter; ends in `/`
+    let bytes = scip_bytes_docs(vec![("a.ts", vec![
+        // File def first + at 0..0 so a naive containment+shortest winner would pick it.
+        occurrence(0, 0, 0, file_moniker, SymbolRole::Definition as i32),
+        occurrence(0, 9, 14, greet_moniker, SymbolRole::Definition as i32),
+    ])]);
+    let report =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
+
+    assert_eq!(report.monikers_written, 1, "the namespace symbol must not add a second row");
+    let (moniker, ..) = h.moniker(4004).expect("moniker row written");
+    assert_eq!(moniker, greet_moniker, "the symbol's own moniker wins, not the file's");
 }
 
 /// Moniker-STRING drift (Codex P2): rust-analyzer monikers embed the Cargo package version, so a

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -1633,8 +1633,10 @@ fn map_definition_to_symbol_requires_real_containment_not_just_start() {
 /// reject an unknown string — the `rust-modern-style` closed-enum contract.
 #[test]
 fn persisted_enums_round_trip_through_db_strings() {
-    assert_eq!(OracleTool::from_db_str(OracleTool::RustAnalyzer.as_db_str()), Some(TOOL));
-    assert_eq!(OracleTool::from_db_str("scip-typescript"), None);
+    for &tool in OracleTool::ALL {
+        assert_eq!(OracleTool::from_db_str(tool.as_db_str()), Some(tool));
+    }
+    assert_eq!(OracleTool::from_db_str("no-such-tool"), None);
 
     for kind in [
         OracleResolutionKind::Upgrade,

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -4265,3 +4265,30 @@ fn resolution_report_assembles_before_after_from_index() {
     assert_eq!(report.tool_version, VERSION);
     assert_eq!(report.tool, TOOL.as_db_str());
 }
+
+/// `scip::stabilize_moniker_version` pins a scip-typescript local moniker's version to `_` so a
+/// `package.json` version bump doesn't churn it (the basis for moniker-anchored memory relocation),
+/// while leaving every other tool's symbols — and unparsable / package-less / local ones —
+/// untouched.
+#[test]
+fn stabilize_moniker_version_pins_typescript_package_version() {
+    use super::scip::stabilize_moniker_version as norm;
+
+    // The version (3rd package field) is rewritten to `_`; name + descriptors are preserved.
+    let v1 = "scip-typescript npm tsmon 9.9.9 `src/a.ts`/greet().";
+    let v2 = "scip-typescript npm tsmon 9.9.10 `src/a.ts`/greet().";
+    let normed = norm(OracleTool::ScipTypescript, v1);
+    assert_eq!(normed, "scip-typescript npm tsmon _ `src/a.ts`/greet().");
+    // Two different package versions normalize to the SAME moniker — the relocation invariant.
+    assert_eq!(norm(OracleTool::ScipTypescript, v1), norm(OracleTool::ScipTypescript, v2));
+    // Already `_` is borrowed unchanged (idempotent).
+    let already = "scip-typescript npm tsmon _ `src/a.ts`/greet().";
+    assert!(matches!(norm(OracleTool::ScipTypescript, already), std::borrow::Cow::Borrowed(_)));
+
+    // Other tools pass through verbatim — scip-python already pins via `--project-version _`.
+    assert_eq!(norm(OracleTool::ScipPython, v1), v1);
+    assert_eq!(norm(OracleTool::RustAnalyzer, v1), v1);
+    // A local symbol (no package) is left alone.
+    let local = "local 42";
+    assert_eq!(norm(OracleTool::ScipTypescript, local), local);
+}

--- a/docs/oracle.md
+++ b/docs/oracle.md
@@ -3,8 +3,9 @@
 The code graph is tree-sitter-derived, so edges are heuristic and confidence-labeled
 (`Exact` / `Syntactic` / `NameOnly` / `Ambiguous`). The **oracle** is an opt-in pass that consumes a
 pre-built [SCIP](https://docs.sourcegraph.com/code_navigation/explanations/scip) index from a real
-language tool (`rust-analyzer scip` for Rust, `scip-clang` for C/C++, `scip-python` for Python) and
-uses it as a *resolution oracle* to upgrade those edges to a `Compiler` confidence tier.
+language tool (`rust-analyzer scip` for Rust, `scip-clang` for C/C++, `scip-python` for Python,
+`scip-typescript` for TypeScript/TSX) and uses it as a *resolution oracle* to upgrade those edges to
+a `Compiler` confidence tier.
 
 It is opt-in, batch, content-addressed, and network-free — indexing stays fast and dependency-free
 without it.
@@ -42,6 +43,7 @@ rag-rat oracle run                 # uses rust-analyzer by default
 rag-rat oracle run --tool rust-analyzer        # Rust
 rag-rat oracle run --tool scip-clang           # C/C++ (needs a compile_commands.json)
 rag-rat oracle run --tool scip-python          # Python (resolves against installed deps)
+rag-rat oracle run --tool scip-typescript      # TypeScript/TSX (resolves against node_modules)
 rag-rat oracle run --scip path/to/index.scip   # consume a pre-built SCIP index directly
 rag-rat oracle status
 ```
@@ -50,6 +52,12 @@ rag-rat oracle status
 deps must be importable (e.g. installed into a virtualenv) for cross-package edges to resolve. Its
 SCIP project version is pinned to a constant (not the git revision) so a symbol's moniker stays
 stable across commits — keeping moniker-anchored memory relocation working.
+
+`scip-typescript` resolves cross-package references against the project's **installed**
+`node_modules` (the analog of scip-python's venv), so `npm install` must have run; it reads the
+project's `tsconfig.json` and synthesizes one from `package.json` when absent (`--infer-tsconfig`).
+Package name/version come from `package.json`, not the git revision, so monikers are already
+commit-stable and need no project-version pin.
 
 A missing/unrunnable tool degrades to `Blocked` with an install hint and exit 0 — never an error.
 

--- a/docs/oracle.md
+++ b/docs/oracle.md
@@ -54,10 +54,13 @@ SCIP project version is pinned to a constant (not the git revision) so a symbol'
 stable across commits — keeping moniker-anchored memory relocation working.
 
 `scip-typescript` resolves cross-package references against the project's **installed**
-`node_modules` (the analog of scip-python's venv), so `npm install` must have run; it reads the
-project's `tsconfig.json` and synthesizes one from `package.json` when absent (`--infer-tsconfig`).
-Package name/version come from `package.json`, not the git revision, so monikers are already
-commit-stable and need no project-version pin.
+`node_modules` (the analog of scip-python's venv), so `npm install` must have run. It requires a
+`tsconfig.json` at the checkout root (a missing one is reported `Blocked` — we deliberately don't
+pass `--infer-tsconfig`, which would *write* a tsconfig into the source tree, breaking the
+read-only-on-source contract). It bakes the `package.json` **version** into every local symbol's
+moniker and offers no `--project-version` flag, so rag-rat normalizes that version to a constant at
+moniker-write time — keeping a symbol's moniker stable across releases, the same way scip-python's
+`--project-version _` pin does.
 
 A missing/unrunnable tool degrades to `Blocked` with an install hint and exit 0 — never an error.
 

--- a/tools/oracle-corpora.toml
+++ b/tools/oracle-corpora.toml
@@ -50,8 +50,9 @@ repo      = "https://github.com/sindresorhus/ky"
 rev       = "v1.7.2"
 tool      = "scip-typescript"
 # scip-typescript resolves cross-package references against the project's installed `node_modules`
-# (the analog of scip-python's venv); `npm install` makes them present. It reads the project's
-# `tsconfig.json` (ky ships one); the runner also passes `--infer-tsconfig` as a fallback.
+# (the analog of scip-python's venv); `npm install` makes them present. It requires a root
+# `tsconfig.json` (ky ships one) — the backend deliberately does NOT pass `--infer-tsconfig`, which
+# would write a tsconfig into the checkout (read-only-on-source).
 prepare   = ["npm install --no-audit --no-fund"]
 bindings  = { typescript = ["source"] }
 health    = { expected_min_heuristic_edges = 50, expected_min_oracle_examined = 20, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 10, timeout_minutes = 12 }

--- a/tools/oracle-corpora.toml
+++ b/tools/oracle-corpora.toml
@@ -43,6 +43,19 @@ prepare   = ["python -m venv .venv", ".venv/bin/pip install ."]
 bindings  = { python = ["src/requests"] }
 health    = { expected_min_heuristic_edges = 50, expected_min_oracle_examined = 20, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 10, timeout_minutes = 12 }
 
+[[corpus]]
+corpus_id = "ts-ky"
+tier      = "small"
+repo      = "https://github.com/sindresorhus/ky"
+rev       = "v1.7.2"
+tool      = "scip-typescript"
+# scip-typescript resolves cross-package references against the project's installed `node_modules`
+# (the analog of scip-python's venv); `npm install` makes them present. It reads the project's
+# `tsconfig.json` (ky ships one); the runner also passes `--infer-tsconfig` as a fallback.
+prepare   = ["npm install --no-audit --no-fund"]
+bindings  = { typescript = ["source"] }
+health    = { expected_min_heuristic_edges = 50, expected_min_oracle_examined = 20, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 10, timeout_minutes = 12 }
+
 # --- heavy "headline" corpora: release/dispatch only, pushed to Bencher; excluded from the PR matrix.
 
 [[corpus]]


### PR DESCRIPTION
Adds **scip-typescript** as a fourth SCIP oracle backend, so TypeScript/TSX
edges get upgraded to the `Compiler` confidence tier and TypeScript appears
as a row in the oracle resolution report table.

## What's in it

- **`OracleTool::ScipTypescript`** variant (`oracle/mod.rs`): `as_db_str`/`from_db_str` round trip + `ALL`.
- **Manifest entry** (`oracle/manifest.rs`): program `scip-typescript`, languages `[typescript]`, install hint. Invocation `scip-typescript index --cwd <root> --infer-tsconfig --output <abs>`.
  - **No `--project-name` / `--project-version` pin** (unlike scip-python): `package.json` supplies a commit-stable name + version, so monikers don't churn across commits.
  - `--infer-tsconfig` synthesizes a `tsconfig.json` from `package.json` when the project doesn't ship one.
  - Shares scip-python's `can_emit_scip` (`index --help`) and the no-prerequisite arm (cross-package refs resolve against installed `node_modules`; a non-installed env is caught by the moniker health gate).
- **CLI** `oracle run --tool scip-typescript` (`cli.rs`).
- **`ts-ky` corpus** (`tools/oracle-corpora.toml`): sindresorhus/ky v1.7.2, tier `small`, `npm install` prepare, `bindings = { typescript = ["source"] }`; golden profile hash pinned in `oracle/corpus.rs`.
- **Docs + CI**: `docs/oracle.md` tool list; `.github/workflows/oracle.yml` install case with `SCIP_TYPESCRIPT_VERSION` pinned to `0.4.0`.
- New manifest test + round-trip test now iterates `OracleTool::ALL`.

## Validation

E2E-validated against ky locally: **616 edges, 220 confirmed / 24 contradicted, 87 monikers**, scip-typescript v0.4.0. Full `cargo +nightly fmt --check`, `cargo clippy --all-targets`, and `cargo test` (core 521 + CLI) green.
