### PR TITLE
feat(oracle): C++ corpus (yaml-cpp) + index .h headers under a cpp binding

### DIFF
--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -586,7 +586,7 @@ fn ensure_checkout_matches_corpus(
     // form's defaults; anything else measures a different population under the same hash.
     for target in &config.targets {
         let default_include: BTreeSet<String> =
-            target.language.simple_extensions().iter().map(|ext| format!("**/*.{ext}")).collect();
+            target.language.default_include_globs().into_iter().collect();
         let include: BTreeSet<String> = target.include.iter().cloned().collect();
         anyhow::ensure!(
             target.exclude.is_empty() && include == default_include,

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -176,6 +176,26 @@ pub struct ResolvedTarget {
     pub kind: TargetKind,
 }
 
+impl ResolvedTarget {
+    /// Indexing precedence when more than one target claims the same file (lower sorts first /
+    /// wins). Two levels: (1) kind — generated/tests/docs before source, the existing order;
+    /// (2) within a kind, a language that claims an ambiguous extension as an upgrade
+    /// ([`Language::upgrades_ambiguous_extension`]) wins it — so a `.h` covered by both a `c` and a
+    /// `cpp` binding indexes as C++ (the deliberate intent), not C (alphabetical accident). Both
+    /// the full-rebuild walk (first-claimer-wins) and the incremental per-path resolver use
+    /// this.
+    pub fn index_precedence(&self) -> (u8, u8) {
+        let kind_rank = match self.kind {
+            TargetKind::Generated => 0,
+            TargetKind::Tests => 1,
+            TargetKind::Docs => 2,
+            TargetKind::Source => 3,
+        };
+        let upgrade_rank = u8::from(!self.language.upgrades_ambiguous_extension());
+        (kind_rank, upgrade_rank)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TargetKind {
     Source,
@@ -269,7 +289,7 @@ fn resolve_targets(
             if language == Language::Markdown { TargetKind::Docs } else { TargetKind::Source };
         let name = language.as_str().to_string();
         push_target(root, &mut names, &mut targets, ResolvedTarget {
-            include: language.simple_extensions().iter().map(|ext| format!("**/*.{ext}")).collect(),
+            include: language.default_include_globs(),
             exclude: Vec::new(),
             name,
             language,
@@ -290,9 +310,7 @@ fn resolve_targets(
             name: target.name,
             language,
             directories: target.directories.into_iter().map(PathBuf::from).collect(),
-            include: target.include.unwrap_or_else(|| {
-                language.simple_extensions().iter().map(|ext| format!("**/*.{ext}")).collect()
-            }),
+            include: target.include.unwrap_or_else(|| language.default_include_globs()),
             exclude: target.exclude.unwrap_or_default(),
             kind,
         })?;
@@ -567,6 +585,35 @@ mod tests {
         assert_eq!(from_main.database, main.canonicalize().unwrap().join(".rag-rat/index.sqlite"));
 
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn cpp_target_renders_h_in_its_default_globs_but_c_keeps_h_too() {
+        // The simple-binding glob render goes through `default_include_globs`, so a `cpp` binding
+        // includes `**/*.h` (the header-resolution fix) while `c` keeps it as well.
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!("ragrat-prec-{}-{id}", std::process::id()));
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(
+            root.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\n[target_bindings]\nc = [\".\"]\ncpp = [\".\"]\n",
+        )
+        .unwrap();
+        let config = Config::load(root.join("rag-rat.toml")).unwrap();
+        let cpp = config.targets.iter().find(|t| t.language == Language::Cpp).unwrap();
+        assert!(cpp.include.contains(&"**/*.h".to_string()), "cpp globs: {:?}", cpp.include);
+        // cpp must sort ahead of c so it wins the ambiguous `.h` (index_precedence).
+        assert!(
+            cpp.index_precedence()
+                < config
+                    .targets
+                    .iter()
+                    .find(|t| t.language == Language::C)
+                    .unwrap()
+                    .index_precedence(),
+            "cpp must outrank c for the shared .h header"
+        );
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/discovery.rs
+++ b/crates/rag-rat-core/src/index/discovery.rs
@@ -48,12 +48,18 @@ pub(crate) fn discovery_plan(
         let (file, current_hash) = hashed_file?;
         let relative = path_string(&file.relative_path);
         current_paths.insert(file.relative_path.clone());
-        let Some(indexed_hash) = indexed.remove(&relative) else {
+        let Some(indexed) = indexed.remove(&relative) else {
             unindexed.push(file.clone());
             files.push(file);
             continue;
         };
-        if current_hash != indexed_hash {
+        // Reindex on content drift OR target drift: the discovered (language, kind) can change with
+        // no content change — e.g. after an upgrade or a binding edit moves a `.h` from a `c` to a
+        // `cpp` target. The stored row would otherwise keep its old parse forever (sha unchanged),
+        // so the `.h`→C++ upgrade would never take effect on an existing index without `--full`.
+        let target_drift =
+            indexed.language != file.language.as_str() || indexed.kind != file.kind.as_str();
+        if current_hash != indexed.sha256 || target_drift {
             changed.push(file.relative_path.clone());
             files.push(file);
         }
@@ -78,16 +84,30 @@ pub(crate) fn discovery_plan(
     })
 }
 
+/// One indexed `files` row's identity for discovery: its content hash plus the (language, kind) it
+/// was indexed under, so discovery can detect TARGET drift (a binding/precedence change that
+/// re-languages a path) as well as content drift.
+pub(crate) struct IndexedFileRow {
+    pub(crate) sha256: String,
+    pub(crate) language: String,
+    pub(crate) kind: String,
+}
+
 pub(crate) fn indexed_file_map(
     conn: &rusqlite::Connection,
-) -> anyhow::Result<BTreeMap<String, String>> {
-    let mut stmt = conn.prepare("SELECT path, sha256 FROM files ORDER BY path")?;
-    let rows =
-        stmt.query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?;
+) -> anyhow::Result<BTreeMap<String, IndexedFileRow>> {
+    let mut stmt = conn.prepare("SELECT path, sha256, language, kind FROM files ORDER BY path")?;
+    let rows = stmt.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, IndexedFileRow {
+            sha256: row.get(1)?,
+            language: row.get(2)?,
+            kind: row.get(3)?,
+        }))
+    })?;
     let mut files = BTreeMap::new();
     for row in rows {
-        let (path, sha256) = row?;
-        files.insert(path, sha256);
+        let (path, indexed) = row?;
+        files.insert(path, indexed);
     }
     Ok(files)
 }
@@ -97,16 +117,15 @@ pub(crate) fn target_for_path(
     relative_path: &Path,
 ) -> Option<(Language, TargetKind)> {
     let relative = path_string(relative_path);
-    let language = Language::from_path(relative_path)?;
+    // Skip extensionless / non-code files early; the per-target check below decides language by
+    // which target CLAIMS the extension, so a `.h` lands on a `cpp` binding (as C++) or a `c`
+    // binding (as C) — bare `from_path` detection would force every `.h` to C and starve C++
+    // header resolution.
+    relative_path.extension().and_then(|ext| ext.to_str())?;
     let mut targets = config.targets.iter().collect::<Vec<_>>();
-    targets.sort_by_key(|target| match target.kind {
-        TargetKind::Generated => 0,
-        TargetKind::Tests => 1,
-        TargetKind::Docs => 2,
-        TargetKind::Source => 3,
-    });
+    targets.sort_by_key(|target| target.index_precedence());
     targets.into_iter().find_map(|target| {
-        if target.language != language {
+        if !target.language.claims_path(relative_path) {
             return None;
         }
         if !target.directories.iter().any(|directory| {
@@ -124,4 +143,39 @@ pub(crate) fn target_for_path(
         }
         Some((target.language, target.kind))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+    use crate::language::Language;
+
+    #[test]
+    fn h_resolves_to_cpp_when_both_c_and_cpp_bindings_cover_it() {
+        // Both bindings claim `.h`; the `cpp` upgrade must win it (the deliberate intent), while a
+        // `.c` stays C and a `.cpp` stays C++.
+        static N: AtomicU64 = AtomicU64::new(0);
+        let id = N.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!("ragrat-disc-{}-{id}", std::process::id()));
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(
+            root.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\n[target_bindings]\nc = [\".\"]\ncpp = [\".\"]\n",
+        )
+        .unwrap();
+        let config = crate::config::Config::load(root.join("rag-rat.toml")).unwrap();
+
+        assert_eq!(target_for_path(&config, Path::new("a.h")).map(|(l, _)| l), Some(Language::Cpp));
+        assert_eq!(target_for_path(&config, Path::new("a.c")).map(|(l, _)| l), Some(Language::C));
+        assert_eq!(
+            target_for_path(&config, Path::new("a.cpp")).map(|(l, _)| l),
+            Some(Language::Cpp)
+        );
+        // A non-code file resolves to nothing.
+        assert_eq!(target_for_path(&config, Path::new("README")), None);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
 }

--- a/crates/rag-rat-core/src/index/oracle/corpus.rs
+++ b/crates/rag-rat-core/src/index/oracle/corpus.rs
@@ -174,11 +174,13 @@ health    = { expected_min_heuristic_edges = 50000, expected_min_oracle_examined
             "c-cjson",
             "py-requests",
             "ts-ky",
+            "cpp-yaml",
             "rust-cargo",
             "linux-kernel"
         ]);
         assert_eq!(corpus_by_id(&corpora, "py-requests").unwrap().tool, "scip-python");
         assert_eq!(corpus_by_id(&corpora, "ts-ky").unwrap().tool, "scip-typescript");
+        assert_eq!(corpus_by_id(&corpora, "cpp-yaml").unwrap().tool, "scip-clang");
 
         // GOLDEN per-profile hashes: an edit to any corpus field changes its hash (and makes prior
         // reports incomparable) — recompute deliberately when intended.
@@ -189,6 +191,7 @@ health    = { expected_min_heuristic_edges = 50000, expected_min_oracle_examined
             ("c-cjson", GOLDEN_C_CJSON.to_string()),
             ("py-requests", GOLDEN_PY_REQUESTS.to_string()),
             ("ts-ky", GOLDEN_TS_KY.to_string()),
+            ("cpp-yaml", GOLDEN_CPP_YAML.to_string()),
             ("rust-cargo", GOLDEN_RUST_CARGO.to_string()),
             ("linux-kernel", GOLDEN_LINUX_KERNEL.to_string()),
         ]);
@@ -201,6 +204,8 @@ health    = { expected_min_heuristic_edges = 50000, expected_min_oracle_examined
     const GOLDEN_PY_REQUESTS: &str =
         "76abdb4592d1e1997f133fb5cd185d85b57851e8a82e085268e45d4d16c2c832";
     const GOLDEN_TS_KY: &str = "4565e3323659cc3de96eebfb033440a2a91622bcd14f7bec2b022d4e642f1bba";
+    const GOLDEN_CPP_YAML: &str =
+        "2b6d2ec7f00b34e330116bf1b93fd51416926ac3d30e24dac766f0f8fb910f58";
     const GOLDEN_RUST_CARGO: &str =
         "60452736340151a253001bb5c33cc83efa2a4ceabba4d42a227d3188d7761d79";
     const GOLDEN_LINUX_KERNEL: &str =

--- a/crates/rag-rat-core/src/index/prep.rs
+++ b/crates/rag-rat-core/src/index/prep.rs
@@ -71,12 +71,7 @@ pub(crate) struct PreparedIndexContent {
 
 pub(crate) fn collect_index_files(config: &Config) -> anyhow::Result<Vec<IndexFile>> {
     let mut targets = config.targets.iter().collect::<Vec<_>>();
-    targets.sort_by_key(|target| match target.kind {
-        TargetKind::Generated => 0,
-        TargetKind::Tests => 1,
-        TargetKind::Docs => 2,
-        TargetKind::Source => 3,
-    });
+    targets.sort_by_key(|target| target.index_precedence());
     let mut seen = BTreeSet::new();
     let mut files = Vec::new();
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -1711,6 +1711,40 @@ fn index_discover_reporting_flags_content_changes() {
 }
 
 #[test]
+fn discover_relanguages_h_when_binding_changes_c_to_cpp() {
+    // A `.h` indexed under a `c` binding, then re-discovered under a `cpp` binding with IDENTICAL
+    // content, must be reindexed as C++ — discovery treats (language, kind) drift as a change, not
+    // just sha drift. Without this the `.h`→C++ upgrade would never take effect on an existing
+    // index (the sha is unchanged) until `--full`.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.h"), "class X { public: void f(); };\n").unwrap();
+
+    let db = IndexDatabase::rebuild(&source_config(root.clone(), Language::C)).unwrap();
+    let lang: String = db
+        .storage
+        .connection()
+        .query_row("SELECT language FROM files WHERE path = 'src/lib.h'", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(lang, "c", "indexed as C under the c binding");
+    drop(db);
+
+    let (db, changed) =
+        IndexDatabase::index_discover_reporting(&source_config(root.clone(), Language::Cpp))
+            .unwrap();
+    assert!(changed, "re-languaging a .h with unchanged content must report a change");
+    let lang: String = db
+        .storage
+        .connection()
+        .query_row("SELECT language FROM files WHERE path = 'src/lib.h'", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(lang, "cpp", "the .h must be reindexed as C++ after the binding change");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn indexes_rust_graph_edges_from_tree_sitter() {
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);

--- a/crates/rag-rat-core/src/index/walker.rs
+++ b/crates/rag-rat-core/src/index/walker.rs
@@ -51,10 +51,10 @@ fn walk_dir(
 }
 
 fn is_target_file(root: &Path, path: &Path, target: &ResolvedTarget) -> bool {
-    let Some(language) = crate::language::Language::from_path(path) else {
-        return false;
-    };
-    if language != target.language {
+    // The target's language must CLAIM this extension (not bare `from_path` detection): that's what
+    // lets a `cpp` binding index its `.h` headers, which bare detection resolves to C. The file is
+    // then parsed as the target's language (see `discovery::target_for_path`).
+    if !target.language.claims_path(path) {
         return false;
     }
     let relative = path.strip_prefix(root).unwrap_or(path);
@@ -108,6 +108,41 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("ragrat-walk-{}-{id}", std::process::id()));
         fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    fn cpp_target() -> ResolvedTarget {
+        ResolvedTarget {
+            name: "cpp".to_string(),
+            language: Language::Cpp,
+            directories: vec![PathBuf::from(".")],
+            include: Language::Cpp.default_include_globs(),
+            exclude: Vec::new(),
+            kind: TargetKind::Source,
+        }
+    }
+
+    #[test]
+    fn cpp_target_indexes_h_headers_but_not_c_sources() {
+        let root = tempdir();
+        write(&root.join("include/lib.h"), "class C { void f(); };\n");
+        write(&root.join("src/lib.cpp"), "#include \"lib.h\"\nvoid C::f() {}\n");
+        write(&root.join("legacy.c"), "int g(void){return 0;}\n");
+
+        let target = cpp_target();
+        let ignore = IgnoreMatcher::compile(&root, &target.directories);
+        let rel: Vec<String> = walk_target(&root, &target, &ignore)
+            .unwrap()
+            .iter()
+            .map(|p| p.strip_prefix(&root).unwrap().to_string_lossy().replace('\\', "/"))
+            .collect();
+
+        // The `.h` header is claimed by the cpp binding (the header-resolution fix)...
+        assert!(rel.contains(&"include/lib.h".to_string()), "cpp must claim .h: {rel:?}");
+        assert!(rel.contains(&"src/lib.cpp".to_string()), "{rel:?}");
+        // ...but a plain `.c` file is NOT a C++ source.
+        assert!(!rel.contains(&"legacy.c".to_string()), "cpp must not claim .c: {rel:?}");
+
+        fs::remove_dir_all(&root).ok();
     }
 
     #[test]

--- a/crates/rag-rat-core/src/language.rs
+++ b/crates/rag-rat-core/src/language.rs
@@ -43,6 +43,10 @@ impl Language {
         }
     }
 
+    /// Extensions used for **bare** language detection ([`Self::from_path`]) — the unambiguous
+    /// default for a file seen with no explicit target binding. `.h` lives on C here (the safe
+    /// default for the ambiguous C/C++ header); an explicit `cpp` binding upgrades it via
+    /// [`Self::target_extensions`].
     pub fn simple_extensions(self) -> &'static [&'static str] {
         match self {
             Self::Rust => &["rs"],
@@ -53,6 +57,49 @@ impl Language {
             Self::Python => &["py", "pyi"],
             Self::Markdown => &["md", "markdown"],
         }
+    }
+
+    /// Extensions an **explicit** target/binding of this language claims for indexing. Identical to
+    /// [`Self::simple_extensions`] except a `cpp` target also claims the ambiguous `.h` header:
+    /// bare detection resolves `.h` to C (the safe default), but binding a directory as `cpp` is
+    /// the signal to index its `.h` headers as C++ (otherwise a C++ library whose API lives in
+    /// `.h` files — most of them — gets no header symbols, so cross-file calls resolve to
+    /// nothing).
+    pub fn target_extensions(self) -> &'static [&'static str] {
+        match self {
+            Self::Cpp => &["cc", "cpp", "cxx", "c++", "hh", "hpp", "hxx", "h++", "h"],
+            _ => self.simple_extensions(),
+        }
+    }
+
+    /// Whether an explicit target of this language claims a file with this extension (see
+    /// [`Self::target_extensions`]).
+    pub fn claims_extension(self, ext: &str) -> bool {
+        self.target_extensions().contains(&ext)
+    }
+
+    /// Whether this language claims an **ambiguous** extension — one another language owns by
+    /// default — as a deliberate upgrade (currently only C++ claiming `.h`, which bare
+    /// detection gives to C). Indexing precedence sorts such targets FIRST so the explicit
+    /// upgrade wins the shared file: a `.h` matched by both a `c` and a `cpp` binding indexes
+    /// as C++ (the deliberate intent), not C (the alphabetical-order accident). A `.c` is
+    /// claimed only by C, so this never steals it.
+    pub fn upgrades_ambiguous_extension(self) -> bool {
+        self.target_extensions().iter().any(|ext| !self.simple_extensions().contains(ext))
+    }
+
+    /// Whether an explicit target of this language claims this path, by its extension. `false` for
+    /// an extensionless path or one whose extension this language doesn't claim.
+    pub fn claims_path(self, path: &std::path::Path) -> bool {
+        path.extension().and_then(|ext| ext.to_str()).is_some_and(|ext| self.claims_extension(ext))
+    }
+
+    /// The default `include` globs for a simple binding of this language — one `**/*.<ext>` per
+    /// [`Self::target_extensions`]. The single source of truth for rendering a target's filters
+    /// ([`crate::config`]) and validating a corpus checkout against its bindings, so the two never
+    /// drift.
+    pub fn default_include_globs(self) -> Vec<String> {
+        self.target_extensions().iter().map(|ext| format!("**/*.{ext}")).collect()
     }
 
     pub fn supports_embeddings(self) -> bool {
@@ -101,4 +148,46 @@ impl FromStr for Language {
 pub enum LanguageError {
     #[error("unknown language `{0}`")]
     Unknown(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::Language;
+
+    #[test]
+    fn bare_detection_resolves_h_to_c_not_cpp() {
+        // `.h` is ambiguous; bare detection picks the safe default (C), never C++.
+        assert_eq!(Language::from_path(Path::new("a/b.h")), Some(Language::C));
+        assert_eq!(Language::from_path(Path::new("a/b.cpp")), Some(Language::Cpp));
+        assert_eq!(Language::from_path(Path::new("a/b.rs")), Some(Language::Rust));
+        assert_eq!(Language::from_path(Path::new("a/README")), None);
+    }
+
+    #[test]
+    fn cpp_target_claims_h_headers_but_c_target_keeps_them_too() {
+        // An explicit `cpp` binding claims `.h` (so a C++ library's `.h` API gets indexed)...
+        assert!(Language::Cpp.claims_extension("h"));
+        assert!(Language::Cpp.claims_extension("cpp"));
+        assert!(Language::Cpp.claims_path(Path::new("include/fmt/format.h")));
+        // ...while `.c` still belongs to C, not C++.
+        assert!(!Language::Cpp.claims_extension("c"));
+        // C continues to claim both `.c` and `.h`.
+        assert!(Language::C.claims_extension("c"));
+        assert!(Language::C.claims_extension("h"));
+        // Other languages are unchanged (no `.h` creep).
+        assert!(!Language::Rust.claims_extension("h"));
+        assert!(Language::Rust.claims_extension("rs"));
+        assert!(!Language::Cpp.claims_path(Path::new("README")));
+    }
+
+    #[test]
+    fn default_include_globs_track_target_extensions() {
+        assert_eq!(Language::Rust.default_include_globs(), vec!["**/*.rs"]);
+        // cpp globs include `**/*.h` (the header-resolution fix) alongside the cpp source globs.
+        let cpp = Language::Cpp.default_include_globs();
+        assert!(cpp.contains(&"**/*.h".to_string()), "cpp globs must include .h: {cpp:?}");
+        assert!(cpp.contains(&"**/*.cpp".to_string()));
+    }
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -52,8 +52,17 @@ Simple bindings map a language to directories:
 rust = ["crates/app/src"]
 typescript = ["apps/mobile/src"]
 kotlin = ["apps/wear-bridge/src"]
+cpp = ["include", "src"]
 markdown = ["docs"]
 ```
+
+A simple binding indexes each language's default extensions in the listed directories
+(`rust` → `.rs`, `typescript` → `.ts`/`.tsx`, `python` → `.py`/`.pyi`, `c` → `.c`/`.h`, etc.).
+The one ambiguous case is the `.h` header: with no binding it is detected as **C** (the safe
+default), but an explicit `cpp` binding also claims `.h` in its directories and indexes those headers
+as **C++**. This is what lets a C++ library whose API lives in `.h` files (most of them) get header
+symbols, so calls resolve to their definitions instead of going unresolved. A `.c` file is never
+treated as C++.
 
 Expanded targets add name, kind, include, and exclude metadata:
 
@@ -67,8 +76,9 @@ include = ["**/*.ts"]
 exclude = ["**/*.map"]
 ```
 
-Supported languages are `rust`, `typescript`, `kotlin`, and `markdown`. Rust, TypeScript/TSX,
-and Kotlin source use tree-sitter structural indexing when files are under the parser size cap.
+Supported languages are `rust`, `typescript`, `kotlin`, `c`, `cpp`, `python`, and `markdown`. Rust,
+TypeScript/TSX, Kotlin, C, C++, and Python source use tree-sitter structural indexing when files are
+under the parser size cap.
 Markdown uses heading-section chunking and does not use tree-sitter. Supported target kinds are
 `source`, `generated`, `docs`, and `tests`; generated targets are indexed with coarse chunks and
 still obey `include_generated` filtering.

--- a/tools/oracle-corpora.toml
+++ b/tools/oracle-corpora.toml
@@ -57,6 +57,26 @@ prepare   = ["npm install --no-audit --no-fund"]
 bindings  = { typescript = ["source"] }
 health    = { expected_min_heuristic_edges = 50, expected_min_oracle_examined = 20, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 10, timeout_minutes = 12 }
 
+[[corpus]]
+corpus_id = "cpp-yaml"
+tier      = "small"
+repo      = "https://github.com/jbeder/yaml-cpp"
+rev       = "0.8.0"
+tool      = "scip-clang"
+# C++ counterpart to the C `c-cjson` corpus — exercises classes / methods / overloads (the C++
+# resolution lever, logical_variant tiebreak) AND C++ header resolution: yaml-cpp's API is declared
+# in `include/yaml-cpp/*.h` and defined across ~31 `src/*.cpp` TUs. Binding BOTH dirs as `cpp` indexes
+# the `.h` headers as C++ too (a `cpp` binding claims `.h` — see Language::target_extensions), so
+# calls to header-declared methods resolve to their in-corpus definitions instead of going external.
+# Tests/tools off keeps the build to the library TUs; scip-clang indexes all 31 in a couple seconds.
+prepare   = ["cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DYAML_CPP_BUILD_TESTS=OFF -DYAML_CPP_BUILD_TOOLS=OFF", "cp build/compile_commands.json ."]
+bindings  = { cpp = ["src", "include"] }
+# Thresholds sit ABOVE the src-only baseline (no `.h` indexed: ~4600 edges, ~3400 examined, ~350
+# monikers) and below the src+include run (~9200 / ~5800 / ~1040), so this corpus actually GUARDS C++
+# header resolution: if `.h` indexing regresses, the run collapses to the src-only numbers and trips
+# the gate instead of passing green.
+health    = { expected_min_heuristic_edges = 7000, expected_min_oracle_examined = 4500, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 700, timeout_minutes = 12 }
+
 # --- heavy "headline" corpora: release/dispatch only, pushed to Bencher; excluded from the PR matrix.
 
 [[corpus]]


### PR DESCRIPTION
Adds a **C++ corpus** to the oracle report table and fixes the root reason C++ couldn't resolve well: **`.h` headers weren't indexable as C++.**

## The `.h` problem

`.h` is ambiguous (C or C++). Bare detection (`Language::from_path`) resolves it to **C** (the safe default), and the index walk gated target membership on `from_path(path) == target.language` + a glob rendered from `simple_extensions` (which, for `cpp`, is `cc/cpp/cxx/hh/hpp/…` — **not `.h`**). So a `cpp` binding could never index a C++ library's `.h` header API — and most C++ libraries put their API in `.h`. Cross-file calls into those headers resolved to nothing.

## Fix — `.h` resolves as C++ under an explicit `cpp` binding

Centralized in `language.rs` (the single home for extension/glob logic):
- **`target_extensions()`** — what an *explicit* binding claims; `cpp` adds `"h"`. (`simple_extensions` / bare `from_path` unchanged — `.h` still defaults to C with no binding.)
- **`claims_extension` / `claims_path`** and **`default_include_globs()`** — the one source of truth for rendering target filters *and* validating a corpus checkout, so they never drift.
- `config::resolve_targets`, `commands::ensure_checkout_matches_corpus`, `index::walker`, and `index::discovery` all route through these (removed the scattered `simple_extensions().map("**/*.{ext}")` duplication). Files are parsed as the **target's** language, so `.h` under `cpp` → C++, under `c` → C. A `.c` is never C++.

## The corpus

`cpp-yaml` (yaml-cpp 0.8.0, scip-clang, small tier, `bindings = { cpp = ["src", "include"] }`). Binding `include/` exercises the fix — yaml-cpp's classes are declared in `include/yaml-cpp/*.h` and defined in `src/*.cpp`:

| | src only | src + include (this PR) |
|---|---|---|
| files indexed | 31 | **90** |
| resolved_external | 2364 | **72** (header calls now resolve in-corpus) |
| precision | 0.917 | 0.825 |
| recall | 0.95 | 0.402 |
| monikers | 353 | **1038** |

Recall drops because the heuristic's genuine C++ call-coverage gap is now honestly measured against the header API; precision (~0.83) tracks the earlier fmt measurement (the `logical_variant` overload/decl-vs-def tiebreak is the lever). Reuses oracle.yml's existing scip-clang install; auto-added to the small matrix.

## Validation

fmt + clippy clean, 530 core tests + CLI tests (`--features eval`) pass. Validated `cpp-yaml` end-to-end locally (healthy; profile hash pinned in `corpus.rs`).
