### PR TITLE
chore(oracle): normalize small-tier corpora to a comparable ~8k-12k edge scale

### DIFF
--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -60,7 +60,7 @@ env:
   # Pinned SCIP toolchain for the small tier so a PR number isn't perturbed by an unrelated indexer
   # release. scip-clang/scip-python/scip-typescript are pinned to explicit versions; rust-analyzer is installed as a
   # rustup component (below), pinning it to the stable toolchain (a ~6-week cadence) instead of the
-  # weekly `releases/latest` — so a fresh RA build can't change `rust-semver`'s numbers mid-PR.
+  # weekly `releases/latest` — so a fresh RA build can't change `rust-time`'s numbers mid-PR.
   SCIP_CLANG_VERSION: v0.4.0
   SCIP_PYTHON_VERSION: 0.6.6
   SCIP_TYPESCRIPT_VERSION: 0.4.0
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         # rust-analyzer as a toolchain component pins the SCIP emitter to the stable release (not the
-        # weekly `releases/latest`), so the `rust-semver` leg's numbers don't shift under the PR.
+        # weekly `releases/latest`), so the `rust-time` leg's numbers don't shift under the PR.
         with:
           components: rust-analyzer
       - uses: Swatinem/rust-cache@v2

--- a/crates/rag-rat-core/src/index/oracle/corpus.rs
+++ b/crates/rag-rat-core/src/index/oracle/corpus.rs
@@ -170,16 +170,16 @@ health    = { expected_min_heuristic_edges = 50000, expected_min_oracle_examined
         let corpora = load_corpora(&toml_str).unwrap();
         let ids: Vec<&str> = corpora.iter().map(|c| c.corpus_id.as_str()).collect();
         assert_eq!(ids, [
-            "rust-semver",
-            "c-cjson",
-            "py-requests",
-            "ts-ky",
+            "rust-time",
+            "c-libuv",
+            "py-rich",
+            "ts-rxjs",
             "cpp-yaml",
             "rust-cargo",
             "linux-kernel"
         ]);
-        assert_eq!(corpus_by_id(&corpora, "py-requests").unwrap().tool, "scip-python");
-        assert_eq!(corpus_by_id(&corpora, "ts-ky").unwrap().tool, "scip-typescript");
+        assert_eq!(corpus_by_id(&corpora, "py-rich").unwrap().tool, "scip-python");
+        assert_eq!(corpus_by_id(&corpora, "ts-rxjs").unwrap().tool, "scip-typescript");
         assert_eq!(corpus_by_id(&corpora, "cpp-yaml").unwrap().tool, "scip-clang");
 
         // GOLDEN per-profile hashes: an edit to any corpus field changes its hash (and makes prior
@@ -187,10 +187,10 @@ health    = { expected_min_heuristic_edges = 50000, expected_min_oracle_examined
         let hashes: Vec<(&str, String)> =
             corpora.iter().map(|c| (c.corpus_id.as_str(), c.hash())).collect();
         assert_eq!(hashes, vec![
-            ("rust-semver", GOLDEN_RUST_SEMVER.to_string()),
-            ("c-cjson", GOLDEN_C_CJSON.to_string()),
-            ("py-requests", GOLDEN_PY_REQUESTS.to_string()),
-            ("ts-ky", GOLDEN_TS_KY.to_string()),
+            ("rust-time", GOLDEN_RUST_TIME.to_string()),
+            ("c-libuv", GOLDEN_C_LIBUV.to_string()),
+            ("py-rich", GOLDEN_PY_RICH.to_string()),
+            ("ts-rxjs", GOLDEN_TS_RXJS.to_string()),
             ("cpp-yaml", GOLDEN_CPP_YAML.to_string()),
             ("rust-cargo", GOLDEN_RUST_CARGO.to_string()),
             ("linux-kernel", GOLDEN_LINUX_KERNEL.to_string()),
@@ -198,12 +198,11 @@ health    = { expected_min_heuristic_edges = 50000, expected_min_oracle_examined
     }
 
     // Pinned from the committed `tools/oracle-corpora.toml` (see `committed_corpora_file`).
-    const GOLDEN_RUST_SEMVER: &str =
-        "7973c3d62bbea9fbbdf3d7a4380fb7d9ccdbf2659a3503c9267eb9f9f329bb97";
-    const GOLDEN_C_CJSON: &str = "685a33345247c2ef310b7671fb9e2a55a7cb7c577fcd29fecac436ff0634c9dc";
-    const GOLDEN_PY_REQUESTS: &str =
-        "76abdb4592d1e1997f133fb5cd185d85b57851e8a82e085268e45d4d16c2c832";
-    const GOLDEN_TS_KY: &str = "4565e3323659cc3de96eebfb033440a2a91622bcd14f7bec2b022d4e642f1bba";
+    const GOLDEN_RUST_TIME: &str =
+        "ba5a37328901f0b1964c51bc8cff3c729d07070a0ce0d61f9934ea7790ca6b64";
+    const GOLDEN_C_LIBUV: &str = "b34ef742c7d4b5efc02bdb95a8457719be9a0dd5621485e11c7d42d2e534d965";
+    const GOLDEN_PY_RICH: &str = "0a4a22be9817ff26b549119b098d23004e5a8b4d7817126e5084f9d730f1efda";
+    const GOLDEN_TS_RXJS: &str = "492436f3827cbf9afe206b5feb03227388521db68a5965c1c3e904f68f0e1109";
     const GOLDEN_CPP_YAML: &str =
         "2b6d2ec7f00b34e330116bf1b93fd51416926ac3d30e24dac766f0f8fb910f58";
     const GOLDEN_RUST_CARGO: &str =

--- a/tools/oracle-corpora.toml
+++ b/tools/oracle-corpora.toml
@@ -13,49 +13,55 @@
 # Bencher series (a moved tag would silently change the corpus). The golden hash test in
 # `oracle/corpus.rs` pins each profile's hash, so any edit here surfaces in review.
 
+# The small-tier corpora are sized to a comparable scale (~8k–12k heuristic edges each) so the
+# report table's per-language rows are roughly equal and substantial — measured `total_edges`:
+# rust-time ~11.1k, c-libuv ~12.3k, py-rich ~8.4k, ts-rxjs ~7.9k, cpp-yaml ~9.2k. Each corpus's
+# health floors sit well below its measured numbers (catch a broken parse / unresolved deps), not as
+# exact regression gates. (cpp-yaml is the exception — its floors guard `.h` header resolution.)
+
 [[corpus]]
-corpus_id = "rust-semver"
+corpus_id = "rust-time"
 tier      = "small"
-repo      = "https://github.com/dtolnay/semver"
-rev       = "1.0.26"
+repo      = "https://github.com/time-rs/time"
+rev       = "v0.3.36"
 tool      = "rust-analyzer"
 prepare   = ["cargo fetch"]
-bindings  = { rust = ["src"] }
-health    = { expected_min_heuristic_edges = 50, expected_min_oracle_examined = 20, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 10, timeout_minutes = 8 }
+bindings  = { rust = ["time/src"] }
+health    = { expected_min_heuristic_edges = 6000, expected_min_oracle_examined = 2000, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 250, timeout_minutes = 10 }
 
 [[corpus]]
-corpus_id = "c-cjson"
+corpus_id = "c-libuv"
 tier      = "small"
-repo      = "https://github.com/DaveGamble/cJSON"
-rev       = "v1.7.18"
+repo      = "https://github.com/libuv/libuv"
+rev       = "v1.48.0"
 tool      = "scip-clang"
 prepare   = ["cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON", "cp build/compile_commands.json ."]
-bindings  = { c = ["."] }
-health    = { expected_min_heuristic_edges = 50, expected_min_oracle_examined = 20, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 10, timeout_minutes = 8 }
+bindings  = { c = ["src"] }
+health    = { expected_min_heuristic_edges = 7000, expected_min_oracle_examined = 1500, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 300, timeout_minutes = 10 }
 
 [[corpus]]
-corpus_id = "py-requests"
+corpus_id = "py-rich"
 tier      = "small"
-repo      = "https://github.com/psf/requests"
-rev       = "v2.32.3"
+repo      = "https://github.com/Textualize/rich"
+rev       = "v13.8.1"
 tool      = "scip-python"
 prepare   = ["python -m venv .venv", ".venv/bin/pip install ."]
-bindings  = { python = ["src/requests"] }
-health    = { expected_min_heuristic_edges = 50, expected_min_oracle_examined = 20, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 10, timeout_minutes = 12 }
+bindings  = { python = ["rich"] }
+health    = { expected_min_heuristic_edges = 5000, expected_min_oracle_examined = 4000, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 500, timeout_minutes = 12 }
 
 [[corpus]]
-corpus_id = "ts-ky"
+corpus_id = "ts-rxjs"
 tier      = "small"
-repo      = "https://github.com/sindresorhus/ky"
-rev       = "v1.7.2"
+repo      = "https://github.com/ReactiveX/rxjs"
+rev       = "7.8.1"
 tool      = "scip-typescript"
-# scip-typescript resolves cross-package references against the project's installed `node_modules`
-# (the analog of scip-python's venv); `npm install` makes them present. It requires a root
-# `tsconfig.json` (ky ships one) — the backend deliberately does NOT pass `--infer-tsconfig`, which
-# would write a tsconfig into the checkout (read-only-on-source).
+# scip-typescript resolves cross-package references against the installed `node_modules` (the analog
+# of scip-python's venv); `npm install` makes them present. It requires a root `tsconfig.json` (rxjs
+# ships one) — the backend deliberately does NOT pass `--infer-tsconfig` (read-only-on-source). Bind
+# `src/internal` (the library implementation) rather than the whole `src` re-export surface.
 prepare   = ["npm install --no-audit --no-fund"]
-bindings  = { typescript = ["source"] }
-health    = { expected_min_heuristic_edges = 50, expected_min_oracle_examined = 20, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 10, timeout_minutes = 12 }
+bindings  = { typescript = ["src/internal"] }
+health    = { expected_min_heuristic_edges = 5000, expected_min_oracle_examined = 3500, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 300, timeout_minutes = 15 }
 
 [[corpus]]
 corpus_id = "cpp-yaml"

--- a/tools/oracle-corpus.py
+++ b/tools/oracle-corpus.py
@@ -11,9 +11,9 @@ Pure stdlib (tomllib, 3.11+). No third-party deps so it runs on a bare CI runner
 
 Usage:
   oracle-corpus.py --list-tier small                 # corpus ids in a tier, one per line
-  oracle-corpus.py --corpus py-requests --field repo # a scalar field
-  oracle-corpus.py --corpus py-requests --field prepare        # one prepare command per line
-  oracle-corpus.py --corpus py-requests --field bindings_toml  # rag-rat.toml [target_bindings] body
+  oracle-corpus.py --corpus py-rich --field repo # a scalar field
+  oracle-corpus.py --corpus py-rich --field prepare        # one prepare command per line
+  oracle-corpus.py --corpus py-rich --field bindings_toml  # rag-rat.toml [target_bindings] body
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Normalizes the oracle report table's small-tier corpora to a comparable, substantial scale (the first half of #187).

Before, the small-tier corpora ranged from **616 to 9223** heuristic edges (a 15× spread), so the per-language rows weren't comparable and some languages measured a tiny, unrepresentative population. Each undersized corpus is swapped for a substantial repo of comparable scale:

| language | before | after | measured `total_edges` |
|---|---|---|---|
| rust | semver (1056) | time-rs/time `time/src` | ~11.1k |
| c | cJSON (3941) | libuv/libuv `src` | ~12.3k |
| python | requests (1632) | Textualize/rich `rich` | ~8.4k |
| ts | ky (616) | ReactiveX/rxjs `src/internal` | ~7.9k |
| cpp | yaml-cpp (unchanged) | — | ~9.2k |

Now ~7.9k–12.3k (≈1.6× spread). Each was **validated end-to-end** locally (clone → prepare → index → oracle → health gate) and is healthy:

- rust-time: examined 4010, monikers 510, precision 0.625
- c-libuv: examined 2667, monikers 679, precision 0.893
- py-rich: examined 7676, monikers 1098, precision 0.938
- ts-rxjs: examined 7023, monikers 626, precision 0.871

Per-corpus health floors sit well below the measured numbers (catch a broken parse / unresolved deps, not exact regression gates); cpp-yaml keeps its tighter floors that guard `.h` header resolution. Golden profile hashes re-pinned; the golden corpus test passes; stale `rust-semver`/`py-requests` doc references refreshed.

**Deferred:** the Kotlin corpus (other half of #187) needs the Kotlin SCIP backend (#72), so #187 stays open for it.

Gate: nightly fmt + clippy clean, 533 core tests pass.
