### PR TITLE
fix(resolve): stop asserting high confidence on guessed Rust type references

### DIFF
--- a/crates/rag-rat-core/src/index/edges/resolve/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/mod.rs
@@ -808,12 +808,14 @@ pub(crate) fn resolve_symbol<'a>(
     let matches = if preferred.is_empty() { matches.as_slice() } else { preferred.as_slice() };
     match matches {
         [symbol] => Some((*symbol, EdgeConfidence::Syntactic, "target_name_fallback")),
-        // Multiple same-name candidates. For a `references_type` this is the associated-type case —
-        // don't guess (see `multi_pick_ok`); leave it unresolved (NameOnly) for the oracle to
-        // upgrade.
-        [_, ..] if !multi_pick_ok => None,
         [_, ..] => {
-            if same_logical_symbol(matches) {
+            // `logical_variant` (an arbitrary pick among same-`scope_path` candidates) is gated by
+            // `multi_pick_ok`: for a Rust `references_type` the same-scope group is distinct
+            // associated types (serde's many `impl Trait { type Value }` share a trait scope), so
+            // picking one is a wrong guess. `same_file_name` is KEPT even for `references_type` — a
+            // type defined AND used in its own file resolves reliably to the local definition even
+            // when the name recurs in other files.
+            if multi_pick_ok && same_logical_symbol(matches) {
                 return Some((matches[0], EdgeConfidence::Syntactic, "logical_variant"));
             }
             let same_file = matches
@@ -823,7 +825,7 @@ pub(crate) fn resolve_symbol<'a>(
                 .collect::<Vec<_>>();
             match same_file.as_slice() {
                 [symbol] => Some((*symbol, EdgeConfidence::Syntactic, "same_file_name")),
-                [_, ..] if same_logical_symbol(&same_file) =>
+                [_, ..] if multi_pick_ok && same_logical_symbol(&same_file) =>
                     Some((same_file[0], EdgeConfidence::Syntactic, "logical_variant")),
                 _ => None,
             }

--- a/crates/rag-rat-core/src/index/edges/resolve/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/mod.rs
@@ -678,6 +678,18 @@ pub(crate) fn resolve_symbol<'a>(
     {
         return None;
     }
+    // Whether to accept a pick among MULTIPLE same-name candidates (the `logical_variant` /
+    // `same_file_name` arms). A RUST `references_type` with several same-named definitions is
+    // almost always an associated type the reference can't disambiguate by name (serde defines
+    // `type Value` in dozens of trait impls, which share a trait-scoped `scope_path`); guessing
+    // one and asserting `Syntactic` is a ~0.3-precision coin flip the SCIP oracle counts as a
+    // contradiction. A UNIQUE type match still binds (the high-precision single-match arms).
+    // Restricted to Rust: in C/C++ a same-named type across files is often the SAME type
+    // (header decl + use) and the same-file pick is usually right, so gating there only loses
+    // confirms. Calls / imports / implements keep multi-candidate resolution (genuine decl/def
+    // + cfg variants) in every language.
+    let multi_pick_ok = !(request.edge_kind == EdgeKind::ReferencesType.as_str()
+        && request.source_language == Some(Language::Rust.as_str()));
     if let Some(qualified) = request.target_qualified_name.filter(|value| !value.is_empty()) {
         // Semantic SCOPE-PATH match first (#61). An edge's `target_qualified_name` is a source-code
         // path (`Workspace::new`), which aligns with a symbol's `scope_path`
@@ -702,7 +714,7 @@ pub(crate) fn resolve_symbol<'a>(
             .collect::<Vec<_>>();
         match scope_exact.as_slice() {
             [symbol] => return Some((*symbol, EdgeConfidence::Exact, "scope_exact")),
-            [_, ..] if same_logical_symbol(&scope_exact) =>
+            [_, ..] if multi_pick_ok && same_logical_symbol(&scope_exact) =>
                 return Some((scope_exact[0], EdgeConfidence::Syntactic, "logical_variant")),
             _ => {},
         }
@@ -717,7 +729,7 @@ pub(crate) fn resolve_symbol<'a>(
             .collect::<Vec<_>>();
         match scope_matches.as_slice() {
             [symbol] => return Some((*symbol, EdgeConfidence::Syntactic, "scope_suffix")),
-            [_, ..] if same_logical_symbol(&scope_matches) =>
+            [_, ..] if multi_pick_ok && same_logical_symbol(&scope_matches) =>
                 return Some((scope_matches[0], EdgeConfidence::Syntactic, "logical_variant")),
             _ => {},
         }
@@ -743,7 +755,7 @@ pub(crate) fn resolve_symbol<'a>(
             .collect::<Vec<_>>();
         match matches.as_slice() {
             [symbol] => return Some((*symbol, EdgeConfidence::Syntactic, "qualified_suffix")),
-            [_, ..] if same_logical_symbol(&matches) => {
+            [_, ..] if multi_pick_ok && same_logical_symbol(&matches) => {
                 return Some((matches[0], EdgeConfidence::Syntactic, "logical_variant"));
             },
             [_, ..] => return None,
@@ -796,6 +808,10 @@ pub(crate) fn resolve_symbol<'a>(
     let matches = if preferred.is_empty() { matches.as_slice() } else { preferred.as_slice() };
     match matches {
         [symbol] => Some((*symbol, EdgeConfidence::Syntactic, "target_name_fallback")),
+        // Multiple same-name candidates. For a `references_type` this is the associated-type case —
+        // don't guess (see `multi_pick_ok`); leave it unresolved (NameOnly) for the oracle to
+        // upgrade.
+        [_, ..] if !multi_pick_ok => None,
         [_, ..] => {
             if same_logical_symbol(matches) {
                 return Some((matches[0], EdgeConfidence::Syntactic, "logical_variant"));

--- a/crates/rag-rat-core/src/index/edges/resolve/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/mod.rs
@@ -664,6 +664,20 @@ pub(crate) fn resolve_symbol<'a>(
     if request.imported_external && !targets_local_qualified_path(request.target_qualified_name) {
         return None;
     }
+    // A Rust `references_type` to a GENERIC PARAMETER (`T`, `V`, `T1`) or an associated-type
+    // PROJECTION (`Self::Value`, `T::Output`, `V::Value`) has no in-corpus definition to point at —
+    // its concrete type is only known after type inference. Name-based resolution would bind it to
+    // whatever same-named concrete type happens to exist (serde has a `T` type and 50 `Value`s),
+    // asserting `Syntactic`; the SCIP oracle then counts that as a contradiction. Leave it
+    // unresolved (the edge is still recorded) instead of guessing. A real module-qualified type
+    // (`de::Deserializer`) has a lowercase path root and is NOT caught. Rust-only: TS/Kotlin/Python
+    // type parameters don't share this single-uppercase convention.
+    if request.source_language == Some(Language::Rust.as_str())
+        && request.edge_kind == EdgeKind::ReferencesType.as_str()
+        && rust_type_ref_is_unresolvable(request.name)
+    {
+        return None;
+    }
     if let Some(qualified) = request.target_qualified_name.filter(|value| !value.is_empty()) {
         // Semantic SCOPE-PATH match first (#61). An edge's `target_qualified_name` is a source-code
         // path (`Workspace::new`), which aligns with a symbol's `scope_path`
@@ -826,6 +840,27 @@ pub(crate) fn same_logical_symbol(symbols: &[&IndexedSymbol]) -> bool {
             && symbol.scope_path == first.scope_path
     })
 }
+/// Whether a Rust `references_type` target is a generic parameter or an associated-type projection
+/// — a reference name-based resolution can't (and shouldn't) bind to a concrete in-corpus type.
+/// True for a BARE generic-parameter name (`T`, `V`, `T1` — Rust's short-uppercase convention) or
+/// any PROJECTION whose root segment is `Self` or such a parameter (`Self::Value`, `T::Output`,
+/// `V::Value`). A module-qualified type (`de::Deserializer`, lowercase root) is NOT a projection.
+fn rust_type_ref_is_unresolvable(name: &str) -> bool {
+    match name.split_once("::") {
+        Some((root, _)) => root == "Self" || looks_like_type_parameter(root),
+        None => looks_like_type_parameter(name),
+    }
+}
+
+/// Rust generic-parameter NAME shape: one uppercase ASCII letter, then only digits (`T`, `K`, `V`,
+/// `T1`, `T2`). Deliberately narrow — a real two-letter type (`Id`, `IO`, `Ok`) or any longer name
+/// is NOT a parameter, so only the unambiguous single-letter convention is suppressed.
+fn looks_like_type_parameter(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars.next().is_some_and(|first| first.is_ascii_uppercase())
+        && chars.all(|rest| rest.is_ascii_digit())
+}
+
 pub(crate) fn allow_unqualified_fallback(
     edge_kind: &str,
     qualified: &str,

--- a/crates/rag-rat-core/src/index/edges/resolve/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/mod.rs
@@ -801,6 +801,20 @@ pub(crate) fn resolve_symbol<'a>(
         [] => None,
     }
 }
+/// Whether a set of same-name candidate symbols are all the SAME logical symbol — so the resolver
+/// may pick `matches[0]` and label it `Syntactic` (`logical_variant`) instead of bailing on
+/// ambiguity. This must hold ONLY for genuine variants of one item (e.g. a forward declaration +
+/// its definition, or `#[cfg]`-gated copies that share a scope), never for distinct items that
+/// merely share a name.
+///
+/// `qualified_name` is `{file_path}::{name}` — NOT unique within a file: one file can declare many
+/// distinct same-named items (e.g. serde's `impl Visitor for A { type Value }` /
+/// `impl Visitor for B { type Value }`, 31 `Value` rows in one file across 10 impls). Grouping
+/// those by `qualified_name` alone made the resolver assert one arbitrary pick at `Syntactic`,
+/// which the SCIP oracle then counted as a `Contradict` ~93% of the time — tanking Rust precision
+/// on trait/generic-heavy crates. Requiring an equal `scope_path` (which carries the enclosing
+/// impl/trait/module chain, e.g. `Visitor<'de>::Value`) splits those distinct items apart while
+/// keeping true variants — which share a scope — grouped.
 pub(crate) fn same_logical_symbol(symbols: &[&IndexedSymbol]) -> bool {
     let Some(first) = symbols.first() else {
         return false;
@@ -809,6 +823,7 @@ pub(crate) fn same_logical_symbol(symbols: &[&IndexedSymbol]) -> bool {
         symbol.qualified_name == first.qualified_name
             && symbol.name == first.name
             && symbol.kind == first.kind
+            && symbol.scope_path == first.scope_path
     })
 }
 pub(crate) fn allow_unqualified_fallback(

--- a/crates/rag-rat-core/src/index/edges/resolve/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/mod.rs
@@ -678,18 +678,6 @@ pub(crate) fn resolve_symbol<'a>(
     {
         return None;
     }
-    // Whether to accept a pick among MULTIPLE same-name candidates (the `logical_variant` /
-    // `same_file_name` arms). A RUST `references_type` with several same-named definitions is
-    // almost always an associated type the reference can't disambiguate by name (serde defines
-    // `type Value` in dozens of trait impls, which share a trait-scoped `scope_path`); guessing
-    // one and asserting `Syntactic` is a ~0.3-precision coin flip the SCIP oracle counts as a
-    // contradiction. A UNIQUE type match still binds (the high-precision single-match arms).
-    // Restricted to Rust: in C/C++ a same-named type across files is often the SAME type
-    // (header decl + use) and the same-file pick is usually right, so gating there only loses
-    // confirms. Calls / imports / implements keep multi-candidate resolution (genuine decl/def
-    // + cfg variants) in every language.
-    let multi_pick_ok = !(request.edge_kind == EdgeKind::ReferencesType.as_str()
-        && request.source_language == Some(Language::Rust.as_str()));
     if let Some(qualified) = request.target_qualified_name.filter(|value| !value.is_empty()) {
         // Semantic SCOPE-PATH match first (#61). An edge's `target_qualified_name` is a source-code
         // path (`Workspace::new`), which aligns with a symbol's `scope_path`
@@ -714,7 +702,7 @@ pub(crate) fn resolve_symbol<'a>(
             .collect::<Vec<_>>();
         match scope_exact.as_slice() {
             [symbol] => return Some((*symbol, EdgeConfidence::Exact, "scope_exact")),
-            [_, ..] if multi_pick_ok && same_logical_symbol(&scope_exact) =>
+            [_, ..] if same_logical_symbol(&scope_exact) =>
                 return Some((scope_exact[0], EdgeConfidence::Syntactic, "logical_variant")),
             _ => {},
         }
@@ -729,7 +717,7 @@ pub(crate) fn resolve_symbol<'a>(
             .collect::<Vec<_>>();
         match scope_matches.as_slice() {
             [symbol] => return Some((*symbol, EdgeConfidence::Syntactic, "scope_suffix")),
-            [_, ..] if multi_pick_ok && same_logical_symbol(&scope_matches) =>
+            [_, ..] if same_logical_symbol(&scope_matches) =>
                 return Some((scope_matches[0], EdgeConfidence::Syntactic, "logical_variant")),
             _ => {},
         }
@@ -755,7 +743,7 @@ pub(crate) fn resolve_symbol<'a>(
             .collect::<Vec<_>>();
         match matches.as_slice() {
             [symbol] => return Some((*symbol, EdgeConfidence::Syntactic, "qualified_suffix")),
-            [_, ..] if multi_pick_ok && same_logical_symbol(&matches) => {
+            [_, ..] if same_logical_symbol(&matches) => {
                 return Some((matches[0], EdgeConfidence::Syntactic, "logical_variant"));
             },
             [_, ..] => return None,
@@ -809,13 +797,7 @@ pub(crate) fn resolve_symbol<'a>(
     match matches {
         [symbol] => Some((*symbol, EdgeConfidence::Syntactic, "target_name_fallback")),
         [_, ..] => {
-            // `logical_variant` (an arbitrary pick among same-`scope_path` candidates) is gated by
-            // `multi_pick_ok`: for a Rust `references_type` the same-scope group is distinct
-            // associated types (serde's many `impl Trait { type Value }` share a trait scope), so
-            // picking one is a wrong guess. `same_file_name` is KEPT even for `references_type` — a
-            // type defined AND used in its own file resolves reliably to the local definition even
-            // when the name recurs in other files.
-            if multi_pick_ok && same_logical_symbol(matches) {
+            if same_logical_symbol(matches) {
                 return Some((matches[0], EdgeConfidence::Syntactic, "logical_variant"));
             }
             let same_file = matches
@@ -825,7 +807,7 @@ pub(crate) fn resolve_symbol<'a>(
                 .collect::<Vec<_>>();
             match same_file.as_slice() {
                 [symbol] => Some((*symbol, EdgeConfidence::Syntactic, "same_file_name")),
-                [_, ..] if multi_pick_ok && same_logical_symbol(&same_file) =>
+                [_, ..] if same_logical_symbol(&same_file) =>
                     Some((same_file[0], EdgeConfidence::Syntactic, "logical_variant")),
                 _ => None,
             }

--- a/crates/rag-rat-core/src/index/edges/resolve/tests.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/tests.rs
@@ -223,6 +223,38 @@ fn references_type_does_not_bind_generic_params_or_projections() {
     assert_eq!(to, Some(gadget), "a genuine type reference still resolves");
 }
 
+/// The PRODUCTION projection path: the Rust extractor emits `Self::Value` / `T::Output` as a
+/// `references_type` to the bare LAST segment (`Value` / `Output`), no `::`. When several
+/// same-named type definitions exist (serde declares `type Value` in dozens of trait impls),
+/// name-based resolution can't pick the right one — it must NOT guess one at `Syntactic` (the SCIP
+/// oracle counts that as a contradiction). A UNIQUE same-named type still resolves.
+#[test]
+fn references_type_multi_candidate_does_not_guess_in_rust() {
+    let conn = seeded_conn();
+    let user = add_file(&conn, "a.rs", NEW);
+    let f1 = add_file(&conn, "b.rs", NEW);
+    let f2 = add_file(&conn, "c.rs", NEW);
+    add_symbol(&conn, user, "user_fn", "crate::a::user_fn");
+    // Two distinct `Value` associated types (different impls) — a bare `Value` ref can't
+    // disambiguate.
+    add_symbol_kind(&conn, f1, "Value", "b.rs::Value", "type");
+    add_symbol_kind(&conn, f2, "Value", "c.rs::Value", "type");
+    // A uniquely-named type (positive control).
+    let only = add_symbol_kind(&conn, f1, "Config", "b.rs::Config", "struct");
+
+    let ambiguous = add_type_ref_edge(&conn, user, "Value"); // bare — the production projection shape
+    let unique = add_type_ref_edge(&conn, user, "Config");
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    let (to, _, resolution) = edge_state(&conn, ambiguous);
+    assert_eq!(to, None, "a bare multi-candidate type ref must not guess");
+    assert_eq!(resolution, "unresolved");
+    let (to, _, _) = edge_state(&conn, unique);
+    assert_eq!(to, Some(only), "a uniquely-named type still resolves");
+}
+
 fn add_symbol_scope(
     conn: &Connection,
     file_id: i64,

--- a/crates/rag-rat-core/src/index/edges/resolve/tests.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/tests.rs
@@ -255,6 +255,26 @@ fn references_type_multi_candidate_does_not_guess_in_rust() {
     assert_eq!(to, Some(only), "a uniquely-named type still resolves");
 }
 
+/// The multi-candidate `references_type` suppression must NOT drop a type defined AND used in its
+/// OWN file just because the name recurs elsewhere — `same_file_name` still resolves it locally.
+#[test]
+fn references_type_resolves_same_file_definition_despite_name_collision() {
+    let conn = seeded_conn();
+    let home = add_file(&conn, "a.rs", NEW);
+    let other = add_file(&conn, "b.rs", NEW);
+    // `Error` defined in BOTH files; a reference inside a.rs should bind to a.rs's own `Error`.
+    let local = add_symbol_kind(&conn, home, "Error", "a.rs::Error", "struct");
+    add_symbol_kind(&conn, other, "Error", "b.rs::Error", "struct");
+    let edge = add_type_ref_edge(&conn, home, "Error");
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    let (to, _, resolution) = edge_state(&conn, edge);
+    assert_eq!(to, Some(local), "a same-file type definition still resolves locally");
+    assert_eq!(resolution, "same_file_name");
+}
+
 fn add_symbol_scope(
     conn: &Connection,
     file_id: i64,

--- a/crates/rag-rat-core/src/index/edges/resolve/tests.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/tests.rs
@@ -246,6 +246,49 @@ fn scope_exact_binds_a_unique_scope_path() {
     assert_eq!(resolution, "scope_exact");
 }
 
+/// Distinct same-(file, name, kind) items that differ only by `scope_path` (e.g. two `impl` blocks
+/// each defining `build`, or serde's many `impl Visitor { type Value }`) are NOT one logical
+/// symbol. `same_logical_symbol` must split them so the resolver falls through to unresolved
+/// instead of picking one arbitrarily at `Syntactic` (`logical_variant`) — that overconfidence made
+/// the SCIP oracle count the wrong pick as a contradiction, tanking Rust precision on trait-heavy
+/// crates.
+#[test]
+fn same_file_distinct_scopes_do_not_collapse_to_logical_variant() {
+    let conn = seeded_conn();
+    let defs = add_file(&conn, "a.rs", NEW);
+    let caller = add_file(&conn, "c.rs", NEW);
+    // Two distinct `build`s in ONE file (so same qualified_name a.rs::build), different impls.
+    add_symbol_scope(&conn, defs, "build", "a.rs::build", "A::build");
+    add_symbol_scope(&conn, defs, "build", "a.rs::build", "B::build");
+    let edge = add_edge(&conn, caller, "build", ""); // bare name — nothing disambiguates
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    let (to, _, resolution) = edge_state(&conn, edge);
+    assert_eq!(to, None, "distinct same-file scopes must not collapse to an arbitrary pick");
+    assert_eq!(resolution, "unresolved");
+}
+
+/// Positive control: GENUINE variants — same file, name, kind AND scope_path (e.g. `#[cfg]`-gated
+/// copies) — still group, so the resolver binds the first at `Syntactic` via `logical_variant`.
+#[test]
+fn same_file_same_scope_variants_still_bind_via_logical_variant() {
+    let conn = seeded_conn();
+    let defs = add_file(&conn, "a.rs", NEW);
+    let caller = add_file(&conn, "c.rs", NEW);
+    let first = add_symbol_scope(&conn, defs, "build", "a.rs::build", "A::build");
+    add_symbol_scope(&conn, defs, "build", "a.rs::build", "A::build");
+    let edge = add_edge(&conn, caller, "build", "");
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    let (to, _, resolution) = edge_state(&conn, edge);
+    assert_eq!(to, Some(first), "true variants (shared scope_path) still bind the first");
+    assert_eq!(resolution, "logical_variant");
+}
+
 fn set_local_crate_roots(conn: &Connection, roots: &str) {
     conn.execute(
         "INSERT OR REPLACE INTO index_meta(key, value) VALUES ('local_crate_roots', ?1)",

--- a/crates/rag-rat-core/src/index/edges/resolve/tests.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/tests.rs
@@ -191,6 +191,38 @@ fn references_type_does_not_resolve_to_a_non_type_symbol() {
     assert_eq!(to, Some(gadget), "a type reference still resolves to a struct definition");
 }
 
+/// A Rust `references_type` to a generic parameter (`T`) or an associated-type projection
+/// (`Self::Value`, `V::Value`) must NOT bind to a same-named concrete type — name-based resolution
+/// can't know the concrete type, and an arbitrary confident bind is a pure oracle contradiction. A
+/// real type reference (`Gadget`) and a module-qualified path (lowercase root) still resolve.
+#[test]
+fn references_type_does_not_bind_generic_params_or_projections() {
+    let conn = seeded_conn();
+    let user = add_file(&conn, "a.rs", NEW);
+    let defs = add_file(&conn, "b.rs", NEW);
+    add_symbol(&conn, user, "user_fn", "crate::a::user_fn");
+    // Same-named concrete types exist in-corpus — the pre-fix resolver would bind to these.
+    add_symbol_kind(&conn, defs, "T", "crate::b::T", "struct");
+    add_symbol_kind(&conn, defs, "Value", "crate::b::Value", "struct");
+    let gadget = add_symbol_kind(&conn, defs, "Gadget", "crate::b::Gadget", "struct");
+
+    let generic = add_type_ref_edge(&conn, user, "T"); // generic parameter
+    let projection = add_type_ref_edge(&conn, user, "Self::Value"); // associated-type projection
+    let v_projection = add_type_ref_edge(&conn, user, "V::Value"); // type-param projection
+    let real = add_type_ref_edge(&conn, user, "Gadget"); // genuine type reference
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    for (edge, what) in [(generic, "T"), (projection, "Self::Value"), (v_projection, "V::Value")] {
+        let (to, _, resolution) = edge_state(&conn, edge);
+        assert_eq!(to, None, "{what} must stay unresolved, not bind a same-named concrete type");
+        assert_eq!(resolution, "unresolved", "{what}");
+    }
+    let (to, _, _) = edge_state(&conn, real);
+    assert_eq!(to, Some(gadget), "a genuine type reference still resolves");
+}
+
 fn add_symbol_scope(
     conn: &Connection,
     file_id: i64,

--- a/crates/rag-rat-core/src/index/edges/resolve/tests.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/tests.rs
@@ -225,34 +225,55 @@ fn references_type_does_not_bind_generic_params_or_projections() {
 
 /// The PRODUCTION projection path: the Rust extractor emits `Self::Value` / `T::Output` as a
 /// `references_type` to the bare LAST segment (`Value` / `Output`), no `::`. When several
-/// same-named type definitions exist (serde declares `type Value` in dozens of trait impls),
-/// name-based resolution can't pick the right one — it must NOT guess one at `Syntactic` (the SCIP
-/// oracle counts that as a contradiction). A UNIQUE same-named type still resolves.
+/// distinct same-named type definitions exist in DIFFERENT files (different `qualified_name` and
+/// `scope_path`), they're not one logical symbol, so a bare reference from a third file stays
+/// unresolved rather than guessing. A UNIQUE same-named type still resolves.
 #[test]
-fn references_type_multi_candidate_does_not_guess_in_rust() {
+fn references_type_multi_candidate_across_files_does_not_guess() {
     let conn = seeded_conn();
     let user = add_file(&conn, "a.rs", NEW);
     let f1 = add_file(&conn, "b.rs", NEW);
     let f2 = add_file(&conn, "c.rs", NEW);
     add_symbol(&conn, user, "user_fn", "crate::a::user_fn");
-    // Two distinct `Value` associated types (different impls) — a bare `Value` ref can't
-    // disambiguate.
+    // Two distinct `Value` types in different files — a bare `Value` ref can't disambiguate.
     add_symbol_kind(&conn, f1, "Value", "b.rs::Value", "type");
     add_symbol_kind(&conn, f2, "Value", "c.rs::Value", "type");
     // A uniquely-named type (positive control).
     let only = add_symbol_kind(&conn, f1, "Config", "b.rs::Config", "struct");
 
-    let ambiguous = add_type_ref_edge(&conn, user, "Value"); // bare — the production projection shape
+    let ambiguous = add_type_ref_edge(&conn, user, "Value");
     let unique = add_type_ref_edge(&conn, user, "Config");
 
     crate::index::install_scope_view(&conn, NEW, "").unwrap();
     resolve_all_edges(&conn).unwrap();
 
-    let (to, _, resolution) = edge_state(&conn, ambiguous);
-    assert_eq!(to, None, "a bare multi-candidate type ref must not guess");
-    assert_eq!(resolution, "unresolved");
-    let (to, _, _) = edge_state(&conn, unique);
-    assert_eq!(to, Some(only), "a uniquely-named type still resolves");
+    assert_eq!(
+        edge_state(&conn, ambiguous).0,
+        None,
+        "ambiguous cross-file type ref stays unresolved"
+    );
+    assert_eq!(edge_state(&conn, unique).0, Some(only), "a uniquely-named type still resolves");
+}
+
+/// `#[cfg]`-split twin types (`#[cfg(unix)] struct Thing` / `#[cfg(windows)] struct Thing`) share
+/// `qualified_name` AND `scope_path` — they ARE one logical symbol. A `references_type` to `Thing`
+/// must still resolve via `logical_variant` (multi-candidate suppression must not block true
+/// logical variants).
+#[test]
+fn references_type_resolves_cfg_split_twin_types() {
+    let conn = seeded_conn();
+    let home = add_file(&conn, "a.rs", NEW);
+    // Two cfg-gated `Thing` structs in one file: same qualified_name, same (empty) scope_path.
+    let first = add_symbol_kind(&conn, home, "Thing", "a.rs::Thing", "struct");
+    add_symbol_kind(&conn, home, "Thing", "a.rs::Thing", "struct");
+    let edge = add_type_ref_edge(&conn, home, "Thing");
+
+    crate::index::install_scope_view(&conn, NEW, "").unwrap();
+    resolve_all_edges(&conn).unwrap();
+
+    let (to, _, resolution) = edge_state(&conn, edge);
+    assert_eq!(to, Some(first), "cfg-twin type variants resolve via logical_variant");
+    assert_eq!(resolution, "logical_variant");
 }
 
 /// The multi-candidate `references_type` suppression must NOT drop a type defined AND used in its


### PR DESCRIPTION
Fixes two **resolver overconfidence** bugs that made the heuristic assert `Exact`/`Syntactic` on references it was actually guessing — which the SCIP oracle counts as contradictions (and which ship wrong high-confidence edges to `find_callers`/`impact_surface`). Surfaced while normalizing the Rust oracle corpus, where precision was anomalously low (serde 0.36, far below semver's 0.80).

### 1. `same_logical_symbol` ignored `scope_path`
It grouped same-name candidates by `qualified_name` (`{file}::{name}`) + name + kind — not unique within a file. serde's `de/impls.rs` has 31 `Value` rows across 10 `impl Visitor` blocks; they collapsed to "one logical symbol", so `logical_variant` confidently picked one (93% wrong). Now also requires equal `scope_path` (`Visitor::Value` ≠ `IgnoredAny::Value`); genuine variants (decl/def, `#[cfg]` copies) share a scope and stay grouped.

### 2. Rust generic params / associated-type projections
`references_type` to `T` (a generic parameter) or `Self::Value` / `V::Value` (associated-type projections) was bound to a same-named concrete type. These have no in-corpus definition — only type inference knows the target. On serde this was ~640 contradictions (`T` alone: 494). Now suppressed (bare single-uppercase-letter+digits, or a `Self`/param-rooted projection); a module-qualified path like `de::Deserializer` (lowercase root) still resolves.

### Measured precision (oracle, language-agnostic — no regressions)

| corpus | before | after |
|---|---|---|
| rust-serde | 0.356 | **0.763** |
| rust-semver | 0.796 | **0.831** |
| rust-time | 0.625 | 0.687 |
| cpp-yaml | 0.825 | 0.836 |
| py-rich | 0.938 | 0.950 |
| ts-rxjs | 0.871 | 0.873 |

rust-time's residual is corpus-specific (a local `type Result` shadowing `std` + macro-heavy code), not a resolver bug.

### Follow-up
The remaining overconfidence sources (multi-candidate type refs, external/prelude/alias shadowing, `calls_name` trait-method ambiguity) are tracked for a systematic audit in #191.

Both drivers (incremental + full-rebuild) share `resolve_symbol`, so both get the fixes. Tests added for each; fmt + clippy clean, 537 core tests pass.
