### PR TITLE
feat(oracle): scip-java (Kotlin) backend

### DIFF
--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -306,6 +306,8 @@ pub(crate) enum OracleToolArg {
     ScipPython,
     #[value(name = "scip-typescript")]
     ScipTypescript,
+    #[value(name = "scip-java")]
+    ScipJava,
 }
 
 impl OracleToolArg {
@@ -316,6 +318,7 @@ impl OracleToolArg {
             OracleToolArg::ScipPython => rag_rat_core::index::oracle::OracleTool::ScipPython,
             OracleToolArg::ScipTypescript =>
                 rag_rat_core::index::oracle::OracleTool::ScipTypescript,
+            OracleToolArg::ScipJava => rag_rat_core::index::oracle::OracleTool::ScipJava,
         }
     }
 }

--- a/crates/rag-rat-core/src/index/oracle/manifest.rs
+++ b/crates/rag-rat-core/src/index/oracle/manifest.rs
@@ -266,15 +266,25 @@ impl ToolManifest {
                 cmd.arg("index").arg("--cwd").arg(root).arg("--output").arg(output);
                 cmd
             },
-            // scip-java auto-detects the build tool in the working dir and indexes through it
-            // (running the build with the semanticdb-kotlinc plugin), so cwd = root. No
-            // `--project-version` need (unlike scip-python): scip-java emits `.` placeholders for
-            // the local project's package/version regardless of the build's
-            // `group`/`version`, so monikers are already commit-stable. `--output` is
-            // absolute.
+            // scip-java indexes through the build (running it with the semanticdb-kotlinc plugin),
+            // so cwd = root. `--build-tool Gradle` is PINNED: the prerequisite only proved Gradle
+            // is present, but a checkout that ALSO carries a `pom.xml` (Maven→Gradle
+            // migration, parent Maven descriptor) makes scip-java's auto-detection see
+            // multiple build tools and abort with "Multiple build tools detected"
+            // instead of indexing. Forcing Gradle (this backend's only supported Kotlin
+            // path) skips that ambiguity (Codex on #193); the value is matched
+            // case-insensitively upstream. No `--project-version` need (unlike
+            // scip-python): scip-java emits `.` placeholders for the local project's
+            // package/version regardless of the build's `group`/`version`, so monikers
+            // are already commit-stable. `--output` is absolute.
             OracleTool::ScipJava => {
                 let mut cmd = Command::new(self.program);
-                cmd.current_dir(root).arg("index").arg("--output").arg(output);
+                cmd.current_dir(root)
+                    .arg("index")
+                    .arg("--build-tool")
+                    .arg("Gradle")
+                    .arg("--output")
+                    .arg(output);
                 cmd
             },
         }
@@ -460,17 +470,18 @@ mod tests {
     }
 
     #[test]
-    fn scip_java_indexes_through_the_build_in_cwd() {
-        // scip-java's invocation: `scip-java index --output <abs>`, run with cwd = root (it
-        // auto-detects the build tool there). No `--project-version` — scip-java emits `.`
-        // placeholders for the local project regardless of the build's group/version, so monikers
-        // are already commit-stable.
+    fn scip_java_indexes_through_the_gradle_build_in_cwd() {
+        // scip-java's invocation: `scip-java index --build-tool Gradle --output <abs>`, run with
+        // cwd = root. `--build-tool Gradle` is pinned so a checkout that also has a `pom.xml`
+        // doesn't trip scip-java's "Multiple build tools detected" abort. No `--project-version` —
+        // scip-java emits `.` placeholders for the local project regardless of the build's
+        // group/version, so monikers are already commit-stable.
         let manifest = ToolManifest::for_tool(OracleTool::ScipJava);
         assert_eq!(manifest.program, "scip-java");
         assert_eq!(manifest.languages, &["kotlin"]);
         let cmd = manifest.scip_command(Path::new("/work/app"), Path::new("/tmp/out.scip"));
         let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy().into_owned()).collect();
-        assert_eq!(args, vec!["index", "--output", "/tmp/out.scip"]);
+        assert_eq!(args, vec!["index", "--build-tool", "Gradle", "--output", "/tmp/out.scip"]);
         assert_eq!(cmd.get_current_dir(), Some(Path::new("/work/app")), "runs in the project root");
     }
 

--- a/crates/rag-rat-core/src/index/oracle/manifest.rs
+++ b/crates/rag-rat-core/src/index/oracle/manifest.rs
@@ -86,6 +86,17 @@ impl ToolManifest {
                                dependencies (`npm install`) so cross-package references resolve, \
                                or pass a pre-built index with `--scip <path>`.",
             },
+            // scip-java is the SemanticDB-based JVM indexer; we drive it for KOTLIN (it indexes
+            // through the project's Gradle/Maven build via the semanticdb-kotlinc compiler plugin).
+            OracleTool::ScipJava => ToolManifest {
+                tool,
+                program: "scip-java",
+                languages: &["kotlin"],
+                install_hint: "scip-java not found on PATH. Install it (e.g. `cs install \
+                               --contrib scip-java`, needs a JVM) — it indexes through the \
+                               project's Gradle/Maven build, so the build must succeed; or pass a \
+                               pre-built index with `--scip <path>`.",
+            },
         }
     }
 
@@ -127,13 +138,14 @@ impl ToolManifest {
                 .output()
                 .is_ok_and(|output| output.status.success()),
             OracleTool::ScipClang => true,
-            // scip-python emits via an `index` subcommand; `index --help` exiting 0 is the analog
-            // of rust-analyzer's `scip --help` capability check.
-            OracleTool::ScipPython | OracleTool::ScipTypescript => Command::new(self.program)
-                .arg("index")
-                .arg("--help")
-                .output()
-                .is_ok_and(|output| output.status.success()),
+            // scip-python/typescript/java emit via an `index` subcommand; `index --help` exiting 0
+            // is the analog of rust-analyzer's `scip --help` capability check.
+            OracleTool::ScipPython | OracleTool::ScipTypescript | OracleTool::ScipJava =>
+                Command::new(self.program)
+                    .arg("index")
+                    .arg("--help")
+                    .output()
+                    .is_ok_and(|output| output.status.success()),
         }
     }
 
@@ -171,6 +183,17 @@ impl ToolManifest {
                      -- make`, CMake `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`, or the kernel's \
                      scripts/clang-tools/gen_compile_commands.py), or pass a pre-built index with \
                      `--scip <path>`.",
+                    root.display()
+                )
+            }),
+            // scip-java indexes THROUGH the build, so it needs a recognizable build at the root
+            // (Gradle or Maven). Without one it can't run; report Blocked rather than a confusing
+            // subprocess error (the JVM analog of scip-clang's compile_commands.json prerequisite).
+            OracleTool::ScipJava => (!has_jvm_build_file(root)).then(|| {
+                format!(
+                    "scip-java requires a Gradle or Maven build at {} (build.gradle[.kts], \
+                     settings.gradle[.kts], or pom.xml) — it indexes through the build; or pass a \
+                     pre-built index with `--scip <path>`.",
                     root.display()
                 )
             }),
@@ -236,8 +259,26 @@ impl ToolManifest {
                 cmd.arg("index").arg("--cwd").arg(root).arg("--output").arg(output);
                 cmd
             },
+            // scip-java auto-detects the build tool in the working dir and indexes through it
+            // (running the build with the semanticdb-kotlinc plugin), so cwd = root. No
+            // `--project-version` need (unlike scip-python): scip-java emits `.` placeholders for
+            // the local project's package/version regardless of the build's
+            // `group`/`version`, so monikers are already commit-stable. `--output` is
+            // absolute.
+            OracleTool::ScipJava => {
+                let mut cmd = Command::new(self.program);
+                cmd.current_dir(root).arg("index").arg("--output").arg(output);
+                cmd
+            },
         }
     }
+}
+
+/// Whether `root` has a recognizable JVM build (Gradle or Maven) that scip-java can index through.
+fn has_jvm_build_file(root: &Path) -> bool {
+    ["build.gradle.kts", "build.gradle", "settings.gradle.kts", "settings.gradle", "pom.xml"]
+        .iter()
+        .any(|name| root.join(name).exists())
 }
 
 /// Run `<program> --version` and return the first non-empty trimmed stdout line, or `None` when the
@@ -406,6 +447,36 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("tsconfig.json"), "{}").unwrap();
         assert!(manifest.prerequisite_blocked(&dir).is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scip_java_indexes_through_the_build_in_cwd() {
+        // scip-java's invocation: `scip-java index --output <abs>`, run with cwd = root (it
+        // auto-detects the build tool there). No `--project-version` — scip-java emits `.`
+        // placeholders for the local project regardless of the build's group/version, so monikers
+        // are already commit-stable.
+        let manifest = ToolManifest::for_tool(OracleTool::ScipJava);
+        assert_eq!(manifest.program, "scip-java");
+        assert_eq!(manifest.languages, &["kotlin"]);
+        let cmd = manifest.scip_command(Path::new("/work/app"), Path::new("/tmp/out.scip"));
+        let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy().into_owned()).collect();
+        assert_eq!(args, vec!["index", "--output", "/tmp/out.scip"]);
+        assert_eq!(cmd.get_current_dir(), Some(Path::new("/work/app")), "runs in the project root");
+    }
+
+    #[test]
+    fn scip_java_requires_a_jvm_build_file() {
+        // scip-java indexes THROUGH the build; without a Gradle/Maven build at the root it's
+        // Blocked (the JVM analog of scip-clang's compile_commands.json prerequisite).
+        let manifest = ToolManifest::for_tool(OracleTool::ScipJava);
+        assert!(manifest.prerequisite_blocked(Path::new("/no/such/repo/xyzzy")).is_some());
+        let dir = std::env::temp_dir().join("rag_rat_java_prereq_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(manifest.prerequisite_blocked(&dir).is_some(), "empty dir has no build → Blocked");
+        std::fs::write(dir.join("build.gradle.kts"), "").unwrap();
+        assert!(manifest.prerequisite_blocked(&dir).is_none(), "a Gradle build satisfies it");
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/rag-rat-core/src/index/oracle/manifest.rs
+++ b/crates/rag-rat-core/src/index/oracle/manifest.rs
@@ -87,15 +87,16 @@ impl ToolManifest {
                                or pass a pre-built index with `--scip <path>`.",
             },
             // scip-java is the SemanticDB-based JVM indexer; we drive it for KOTLIN (it indexes
-            // through the project's Gradle/Maven build via the semanticdb-kotlinc compiler plugin).
+            // through the project's Gradle build via the semanticdb-kotlinc compiler plugin —
+            // scip-java's auto-indexer supports Kotlin for Gradle only, not Maven).
             OracleTool::ScipJava => ToolManifest {
                 tool,
                 program: "scip-java",
                 languages: &["kotlin"],
                 install_hint: "scip-java not found on PATH. Install it (e.g. `cs install \
-                               --contrib scip-java`, needs a JVM) — it indexes through the \
-                               project's Gradle/Maven build, so the build must succeed; or pass a \
-                               pre-built index with `--scip <path>`.",
+                               --contrib scip-java`, needs a JVM) — it indexes Kotlin through the \
+                               project's Gradle build (Maven Kotlin is unsupported), so the build \
+                               must succeed; or pass a pre-built index with `--scip <path>`.",
             },
         }
     }
@@ -186,14 +187,20 @@ impl ToolManifest {
                     root.display()
                 )
             }),
-            // scip-java indexes THROUGH the build, so it needs a recognizable build at the root
-            // (Gradle or Maven). Without one it can't run; report Blocked rather than a confusing
-            // subprocess error (the JVM analog of scip-clang's compile_commands.json prerequisite).
-            OracleTool::ScipJava => (!has_jvm_build_file(root)).then(|| {
+            // scip-java indexes THROUGH the build, so it needs a recognizable build at the root.
+            // This backend advertises Kotlin only, and scip-java's automatic indexer supports
+            // Kotlin for GRADLE only — Maven Kotlin (`kotlin-maven-plugin`) is unsupported upstream
+            // (https://sourcegraph.github.io/scip-java/docs/getting-started.html#supported-build-tools).
+            // So a Maven-only (`pom.xml`) Kotlin checkout must report Blocked, not run scip-java
+            // and fail — accepting `pom.xml` would turn a clean block into a failed run
+            // + background retries (Codex on #193). The JVM analog of scip-clang's
+            // compile_commands.json gate.
+            OracleTool::ScipJava => (!has_gradle_build(root)).then(|| {
                 format!(
-                    "scip-java requires a Gradle or Maven build at {} (build.gradle[.kts], \
-                     settings.gradle[.kts], or pom.xml) — it indexes through the build; or pass a \
-                     pre-built index with `--scip <path>`.",
+                    "scip-java requires a Gradle build at {} (build.gradle[.kts] or \
+                     settings.gradle[.kts]) — it indexes Kotlin through the Gradle build (Maven \
+                     Kotlin is unsupported by scip-java's auto-indexer); or pass a pre-built \
+                     index with `--scip <path>`.",
                     root.display()
                 )
             }),
@@ -274,9 +281,11 @@ impl ToolManifest {
     }
 }
 
-/// Whether `root` has a recognizable JVM build (Gradle or Maven) that scip-java can index through.
-fn has_jvm_build_file(root: &Path) -> bool {
-    ["build.gradle.kts", "build.gradle", "settings.gradle.kts", "settings.gradle", "pom.xml"]
+/// Whether `root` has a Gradle build that scip-java can index Kotlin through. Maven is deliberately
+/// excluded: scip-java's automatic indexer supports Kotlin only for Gradle, and this backend
+/// advertises Kotlin only — a Maven (`pom.xml`) Kotlin checkout should report Blocked, not run.
+fn has_gradle_build(root: &Path) -> bool {
+    ["build.gradle.kts", "build.gradle", "settings.gradle.kts", "settings.gradle"]
         .iter()
         .any(|name| root.join(name).exists())
 }
@@ -466,15 +475,22 @@ mod tests {
     }
 
     #[test]
-    fn scip_java_requires_a_jvm_build_file() {
-        // scip-java indexes THROUGH the build; without a Gradle/Maven build at the root it's
-        // Blocked (the JVM analog of scip-clang's compile_commands.json prerequisite).
+    fn scip_java_requires_a_gradle_build() {
+        // scip-java indexes Kotlin THROUGH the Gradle build; without one it's Blocked (the JVM
+        // analog of scip-clang's compile_commands.json prerequisite). A Maven-only checkout is also
+        // Blocked: scip-java's auto-indexer supports Kotlin for Gradle only, so running it on a
+        // `pom.xml` Kotlin project would fail rather than index (Codex on #193).
         let manifest = ToolManifest::for_tool(OracleTool::ScipJava);
         assert!(manifest.prerequisite_blocked(Path::new("/no/such/repo/xyzzy")).is_some());
         let dir = std::env::temp_dir().join("rag_rat_java_prereq_test");
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         assert!(manifest.prerequisite_blocked(&dir).is_some(), "empty dir has no build → Blocked");
+        std::fs::write(dir.join("pom.xml"), "").unwrap();
+        assert!(
+            manifest.prerequisite_blocked(&dir).is_some(),
+            "Maven-only Kotlin is unsupported by scip-java → Blocked"
+        );
         std::fs::write(dir.join("build.gradle.kts"), "").unwrap();
         assert!(manifest.prerequisite_blocked(&dir).is_none(), "a Gradle build satisfies it");
         let _ = std::fs::remove_dir_all(&dir);

--- a/crates/rag-rat-core/src/index/oracle/manifest.rs
+++ b/crates/rag-rat-core/src/index/oracle/manifest.rs
@@ -197,10 +197,10 @@ impl ToolManifest {
             // compile_commands.json gate.
             OracleTool::ScipJava => (!has_gradle_build(root)).then(|| {
                 format!(
-                    "scip-java requires a Gradle build at {} (build.gradle[.kts] or \
-                     settings.gradle[.kts]) — it indexes Kotlin through the Gradle build (Maven \
-                     Kotlin is unsupported by scip-java's auto-indexer); or pass a pre-built \
-                     index with `--scip <path>`.",
+                    "scip-java requires a Gradle build at {} (build.gradle, build.gradle.kts, \
+                     settings.gradle, or gradlew) — it indexes Kotlin through the Gradle build \
+                     (Maven Kotlin is unsupported by scip-java's auto-indexer); or pass a \
+                     pre-built index with `--scip <path>`.",
                     root.display()
                 )
             }),
@@ -291,11 +291,17 @@ impl ToolManifest {
     }
 }
 
-/// Whether `root` has a Gradle build that scip-java can index Kotlin through. Maven is deliberately
-/// excluded: scip-java's automatic indexer supports Kotlin only for Gradle, and this backend
-/// advertises Kotlin only — a Maven (`pom.xml`) Kotlin checkout should report Blocked, not run.
+/// Whether `root` has a Gradle build that scip-java can index Kotlin through. The sentinel set
+/// mirrors scip-java's own `GradleBuildTool.usedInCurrentDirectory` EXACTLY (v0.12.3:
+/// `settings.gradle`, `gradlew`, `build.gradle`, `build.gradle.kts`) so this gate agrees with what
+/// the tool will actually detect (Codex on #193): note scip-java does NOT recognize
+/// `settings.gradle.kts`, and DOES recognize the `gradlew` wrapper — accepting the former or
+/// omitting the latter would let a checkout pass the gate then fail with "no Gradle tool", or block
+/// a wrapper-only root scip-java could index. Maven is deliberately excluded: scip-java's automatic
+/// indexer supports Kotlin only for Gradle, and this backend advertises Kotlin only — a Maven
+/// (`pom.xml`) Kotlin checkout should report Blocked, not run.
 fn has_gradle_build(root: &Path) -> bool {
-    ["build.gradle.kts", "build.gradle", "settings.gradle.kts", "settings.gradle"]
+    ["settings.gradle", "gradlew", "build.gradle", "build.gradle.kts"]
         .iter()
         .any(|name| root.join(name).exists())
 }
@@ -502,8 +508,19 @@ mod tests {
             manifest.prerequisite_blocked(&dir).is_some(),
             "Maven-only Kotlin is unsupported by scip-java → Blocked"
         );
-        std::fs::write(dir.join("build.gradle.kts"), "").unwrap();
-        assert!(manifest.prerequisite_blocked(&dir).is_none(), "a Gradle build satisfies it");
+        // scip-java's GradleBuildTool does NOT recognize `settings.gradle.kts`, so neither do we —
+        // accepting it would pass the gate then fail with "no Gradle tool" (Codex on #193).
+        std::fs::write(dir.join("settings.gradle.kts"), "").unwrap();
+        assert!(
+            manifest.prerequisite_blocked(&dir).is_some(),
+            "settings.gradle.kts is not a scip-java Gradle sentinel → still Blocked"
+        );
+        // …but the `gradlew` wrapper IS one of scip-java's sentinels, so it satisfies the gate.
+        std::fs::write(dir.join("gradlew"), "").unwrap();
+        assert!(
+            manifest.prerequisite_blocked(&dir).is_none(),
+            "a gradlew wrapper is a scip-java Gradle sentinel → satisfied"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -575,13 +575,24 @@ pub enum OracleTool {
     /// references against the project's installed `node_modules`, so the corpus must `npm install`
     /// first; an unresolved environment shows up as a low moniker count the health gate catches.
     ScipTypescript,
+    /// `scip-java index` — Kotlin (#72). The SemanticDB-based JVM indexer; we drive it for Kotlin
+    /// (it indexes through the project's Gradle/Maven build via the semanticdb-kotlinc plugin), so
+    /// the build must succeed. Emits UTF-16 columns with `position_encoding` unset, like
+    /// scip-typescript; unlike scip-python/typescript it embeds no project version in local
+    /// monikers (always `.` placeholders), so monikers are already commit-stable.
+    ScipJava,
 }
 
 impl OracleTool {
     /// Every known oracle tool, for "report on all tools" surfaces (`oracle status` with no
-    /// `--tool`). Later language backends (#72 Kotlin) extend this alongside the enum.
-    pub const ALL: &[OracleTool] =
-        &[Self::RustAnalyzer, Self::ScipClang, Self::ScipPython, Self::ScipTypescript];
+    /// `--tool`). Later language backends extend this alongside the enum.
+    pub const ALL: &[OracleTool] = &[
+        Self::RustAnalyzer,
+        Self::ScipClang,
+        Self::ScipPython,
+        Self::ScipTypescript,
+        Self::ScipJava,
+    ];
 
     pub fn as_db_str(self) -> &'static str {
         match self {
@@ -589,6 +600,7 @@ impl OracleTool {
             Self::ScipClang => "scip-clang",
             Self::ScipPython => "scip-python",
             Self::ScipTypescript => "scip-typescript",
+            Self::ScipJava => "scip-java",
         }
     }
 
@@ -598,6 +610,7 @@ impl OracleTool {
             "scip-clang" => Some(Self::ScipClang),
             "scip-python" => Some(Self::ScipPython),
             "scip-typescript" => Some(Self::ScipTypescript),
+            "scip-java" => Some(Self::ScipJava),
             _ => None,
         }
     }
@@ -611,7 +624,11 @@ impl OracleTool {
     pub(crate) fn default_position_encoding(self) -> ::scip::types::PositionEncoding {
         use ::scip::types::PositionEncoding;
         match self {
-            Self::ScipTypescript => PositionEncoding::UTF16CodeUnitOffsetFromLineStart,
+            // scip-typescript and scip-java (JVM/semanticdb) both emit UTF-16 columns with the
+            // field unset — empirically confirmed (a token after an astral char lands at the
+            // UTF-16 count). Reading them as the UTF-32 fallback mis-converts past astral chars.
+            Self::ScipTypescript | Self::ScipJava =>
+                PositionEncoding::UTF16CodeUnitOffsetFromLineStart,
             Self::RustAnalyzer | Self::ScipClang | Self::ScipPython =>
                 PositionEncoding::UnspecifiedPositionEncoding,
         }

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -4361,3 +4361,18 @@ fn stabilize_moniker_version_pins_typescript_package_version() {
     let local = "local 42";
     assert_eq!(norm(OracleTool::ScipTypescript, local), local);
 }
+
+/// The per-tool default position encoding for SCIP documents that leave the field unset:
+/// scip-typescript and scip-java emit UTF-16 columns (confirmed empirically), the rest stay
+/// Unspecified.
+#[test]
+fn default_position_encoding_is_utf16_for_typescript_and_java() {
+    use ::scip::types::PositionEncoding::{
+        UTF16CodeUnitOffsetFromLineStart as U16, UnspecifiedPositionEncoding as UNSPEC,
+    };
+    assert_eq!(OracleTool::ScipTypescript.default_position_encoding(), U16);
+    assert_eq!(OracleTool::ScipJava.default_position_encoding(), U16);
+    assert_eq!(OracleTool::RustAnalyzer.default_position_encoding(), UNSPEC);
+    assert_eq!(OracleTool::ScipClang.default_position_encoding(), UNSPEC);
+    assert_eq!(OracleTool::ScipPython.default_position_encoding(), UNSPEC);
+}


### PR DESCRIPTION
Adds **`OracleTool::ScipJava`** — the Kotlin SCIP backend (#72), completing the language matrix. scip-java is the SemanticDB-based JVM indexer; we drive it for Kotlin (it indexes through the project's Gradle/Maven build via the semanticdb-kotlinc compiler plugin). The occurrence→edge join is language-agnostic, so this is purely the manifest seam + per-tool quirks.

## Per-tool behavior (all empirically established, scip-java 0.12.3)
- **Invocation** `scip-java index --output <abs>` with **cwd = root** (it auto-detects the build tool there), like scip-clang's `current_dir`.
- **Indexes through the build** → `prerequisite_blocked` requires a Gradle/Maven build at root (`build.gradle[.kts]`/`settings.gradle[.kts]`/`pom.xml`) — the JVM analog of scip-clang's `compile_commands.json`.
- **UTF-16, unset encoding** → `default_position_encoding = UTF-16` (confirmed: a token after `😀` lands at the UTF-16 col 25, not codepoint 24), same as scip-typescript.
- **No moniker version churn** → scip-java emits `.` placeholders for the local project's package/version regardless of the build's `group`/`version` (tested with `version = "9.9.9"` → still `.`), so no `stabilize_moniker_version` needed.

## Validated end-to-end
`rag-rat oracle run --tool scip-java` on a minimal Kotlin Gradle project (scip-java 0.12.3, Gradle 8.10.2, Kotlin 2.1.20): **12 edges examined, 5 confirmed / 0 contradicted, 4 monikers, status Completed.** Real call edges resolved (`run()`→`greet()`, `greet()`→`format()`).

## Scope
This is the **backend**. The Kotlin **report-table corpus** (a real Gradle build in CI) is the separate #187 — also in the v0.8.0 milestone.

Tests: `scip_java_indexes_through_the_build_in_cwd`, `scip_java_requires_a_jvm_build_file`, `default_position_encoding_is_utf16_for_typescript_and_java`. The `persisted_enums` round-trip iterates `OracleTool::ALL` so it auto-covers the new variant. fmt + clippy clean, 542 core tests pass.
