### PR TITLE
feat(impact): compact repo-memory view by default; full bodies on request (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ The highest-leverage ones (full catalog + JSON schemas in [`docs/mcp-tools.md`](
 - **`find_callers` / `trace_callees`** — reverse/forward graph traversal (low-signal std/macro noise
   filtered by default).
 - **`impact_surface`** — the coding preflight: callers, callees, tests, git history, GitHub
-  papertrail, and repo memories for a symbol in one call.
+  papertrail, and repo memories for a symbol in one call. `repo_memories` defaults to a compact,
+  scannable per-memory header (kind, title, confidence, anchor status, and where it's bound); pass
+  `full_memories: true` (or use `memory_for_symbol|path|call_path`) for the full bodies + bindings.
 - **`important_symbols`** — load-bearing symbols by (SCIP-aware) PageRank; see
   [`docs/oracle.md`](docs/oracle.md).
 - **`repo_brief` / `repo_clusters`** — orientation: spine / churn / god-modules / ownership clusters.

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -4134,9 +4134,183 @@ fn repo_memory_bound_to_logical_symbol_surfaces_in_symbol_chunk_and_impact() {
             &crate::query::impact::ImpactSurfaceOptions::default(),
         )
         .unwrap();
-    assert_eq!(impact.repo_memories.direct.len(), 1);
+    assert_eq!(impact.repo_memories.compact().unwrap().direct.len(), 1);
     assert_eq!(impact.completeness_and_caveats.memory_status.active, 1);
     assert_eq!(impact.completeness_and_caveats.memory_status.stale, 0);
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn compact_repo_memory_view_projects_primary_binding_then_full_mode_round_trips() {
+    // #37: the default `impact_surface` memory output is the scannable compact projection of each
+    // memory's primary binding; full bodies + bindings stay one explicit flag away.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn anchored() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let symbol = db
+        .select_symbol(&crate::query::symbol::SymbolSelector {
+            logical_symbol_id: None,
+            symbol_id: None,
+            symbol_path: None,
+            symbol: Some("anchored".to_string()),
+            language: Some(Language::Rust),
+            allow_ambiguous: false,
+            limit: 10,
+        })
+        .unwrap()
+        .unwrap()
+        .expect("selected symbol");
+    let logical_symbol_id = symbol.logical_symbol_id.expect("logical symbol id");
+    let full_body = "Runtime shutdown must be idempotent; second call is a no-op.".to_string();
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "Runtime shutdown must be idempotent".to_string(),
+            body: full_body.clone(),
+            confidence: "high".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: vec!["runtime".to_string()],
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                logical_symbol_id: Some(logical_symbol_id),
+                ..Default::default()
+            },
+        })
+        .unwrap();
+
+    // Default mode is compact: a scannable header projected from the primary binding.
+    let compact_report = db
+        .impact_surface_report_for_selected_symbol(
+            &symbol,
+            10,
+            &crate::query::impact::ImpactSurfaceOptions::default(),
+        )
+        .unwrap();
+    let compact = compact_report.repo_memories.compact().expect("compact by default");
+    assert!(compact_report.repo_memories.full().is_none(), "default must not be full");
+    assert_eq!(compact.direct.len(), 1);
+    let entry = &compact.direct[0];
+    assert_eq!(entry.memory_id, created.memory.memory_id);
+    assert_eq!(entry.kind, "Invariant");
+    assert_eq!(entry.title, "Runtime shutdown must be idempotent");
+    assert_eq!(entry.confidence, "high");
+    assert_eq!(entry.status, "active");
+    assert_eq!(entry.anchor_status.as_deref(), Some("current"));
+    assert_eq!(entry.binding_kind.as_deref(), Some("logical_symbol"));
+    assert_eq!(entry.path.as_deref(), Some("src/lib.rs"));
+    assert!(entry.span.is_some(), "logical-symbol binding carries a line span");
+    assert_eq!(entry.logical_symbol_id, Some(logical_symbol_id));
+    assert_eq!(entry.tags, vec!["runtime".to_string()]);
+
+    // Explicit full mode restores the body + full bindings for deep inspection.
+    let full_report = db
+        .impact_surface_report_for_selected_symbol(
+            &symbol,
+            10,
+            &crate::query::impact::ImpactSurfaceOptions {
+                compact_memories: false,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    let full = full_report.repo_memories.full().expect("full on request");
+    assert!(full_report.repo_memories.compact().is_none(), "full mode is not compact");
+    assert_eq!(full.direct.len(), 1);
+    assert_eq!(full.direct[0].body, full_body);
+    assert_eq!(full.direct[0].bindings[0].binding_kind, "logical_symbol");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn compact_repo_memory_view_separates_the_stale_lane() {
+    // #37: a memory whose anchor went stale lands in the compact `stale` lane (not `direct`), with
+    // its `anchor_status` carried through so an agent can see it needs re-anchoring.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn drifting() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let symbol = db
+        .select_symbol(&crate::query::symbol::SymbolSelector {
+            logical_symbol_id: None,
+            symbol_id: None,
+            symbol_path: None,
+            symbol: Some("drifting".to_string()),
+            language: Some(Language::Rust),
+            allow_ambiguous: false,
+            limit: 10,
+        })
+        .unwrap()
+        .unwrap()
+        .expect("selected symbol");
+    let chunk_id = db
+        .storage
+        .connection()
+        .query_row(
+            "
+                SELECT chunks.id
+                FROM chunks
+                JOIN files ON files.id = chunks.file_id
+                WHERE files.path = ?1 AND chunks.symbol_path = ?2
+                LIMIT 1
+                ",
+            params![symbol.path, symbol.qualified_name],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap();
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Risk".to_string(),
+            title: "Anchor drifts when the chunk hash changes".to_string(),
+            body: "Stale anchors belong in their own lane, away from current evidence.".to_string(),
+            confidence: "medium".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                chunk_id: Some(chunk_id),
+                ..Default::default()
+            },
+        })
+        .unwrap();
+
+    // Current anchor: the memory is in the active `direct` lane, stale lane empty.
+    let before = db
+        .impact_surface_report_for_selected_symbol(
+            &symbol,
+            10,
+            &crate::query::impact::ImpactSurfaceOptions::default(),
+        )
+        .unwrap();
+    let before = before.repo_memories.compact().unwrap();
+    assert_eq!(before.direct.len(), 1);
+    assert!(before.stale.is_empty());
+
+    // Drift the underlying chunk so validation marks the binding stale.
+    db.storage
+        .connection()
+        .execute("UPDATE chunks SET text_hash = 'changed' WHERE id = ?1", [chunk_id])
+        .unwrap();
+    assert_eq!(db.memory_validate().unwrap().stale, 1);
+
+    let after = db
+        .impact_surface_report_for_selected_symbol(
+            &symbol,
+            10,
+            &crate::query::impact::ImpactSurfaceOptions::default(),
+        )
+        .unwrap();
+    let after = after.repo_memories.compact().unwrap();
+    assert!(after.direct.is_empty(), "a stale memory leaves the direct lane");
+    assert_eq!(after.stale.len(), 1);
+    assert_eq!(after.stale[0].memory_id, created.memory.memory_id);
+    assert_eq!(after.stale[0].anchor_status.as_deref(), Some("stale"));
 
     fs::remove_dir_all(root).unwrap();
 }
@@ -4385,9 +4559,10 @@ fn repo_memory_bound_to_edge_surfaces_when_impact_crosses_call_path() {
             },
         )
         .unwrap();
-    assert!(impact.repo_memories.direct.is_empty());
-    assert_eq!(impact.repo_memories.path_crossed.len(), 1);
-    assert_eq!(impact.repo_memories.path_crossed[0].memory_id, edge_memory.memory.memory_id);
+    let compact = impact.repo_memories.compact().unwrap();
+    assert!(compact.direct.is_empty());
+    assert_eq!(compact.path_crossed.len(), 1);
+    assert_eq!(compact.path_crossed[0].memory_id, edge_memory.memory.memory_id);
     assert_eq!(impact.completeness_and_caveats.memory_status.active, 1);
 
     let call_path_memory = db
@@ -4626,14 +4801,14 @@ fn impact_surface_surfaces_call_path_memory_when_path_crossed() {
     )
     .unwrap();
 
+    let compact = report.repo_memories.compact().unwrap();
     assert!(
-        report
-            .repo_memories
+        compact
             .call_path_crossed
             .iter()
             .any(|memory| memory.title == "a -> b -> c is the hot path"),
         "call-path memory should surface in impact_surface(b); got call_path_crossed = {:?}",
-        report.repo_memories.call_path_crossed.iter().map(|m| &m.title).collect::<Vec<_>>()
+        compact.call_path_crossed.iter().map(|m| &m.title).collect::<Vec<_>>()
     );
 
     fs::remove_dir_all(root).unwrap();

--- a/crates/rag-rat-core/src/query/impact/mod.rs
+++ b/crates/rag-rat-core/src/query/impact/mod.rs
@@ -12,7 +12,7 @@ pub(crate) use select::*;
 use serde::Serialize;
 
 use crate::query::graph::{self, GraphHop, GraphResolutionMode, GraphTraversalOptions};
-use crate::query::memory::{self, RepoMemoryEvidence};
+use crate::query::memory::{self, CompactRepoMemoryEvidence, RepoMemoryEvidence};
 use crate::query::symbol::SymbolHit;
 
 #[derive(Debug, Serialize)]
@@ -36,6 +36,38 @@ pub struct ImpactSurfaceOptions {
     pub include_papertrail: bool,
     pub include_text_fallback: bool,
     pub include_memories: bool,
+    /// Emit `repo_memories` as the scannable compact view (default) rather than full bodies +
+    /// bindings + call paths (#37). The agent-facing MCP default is compact; full detail stays one
+    /// lookup away (`memory_for_symbol` / `memory_for_path` / `memory_for_call_path`).
+    pub compact_memories: bool,
+}
+
+/// `impact_surface`'s `repo_memories` payload — compact by default (#37), full on request. The two
+/// variants serialize with identical field names (`direct` / `path_crossed` / `call_path_crossed` /
+/// `stale`), so only the per-memory detail differs on the wire, not the lane shape.
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub enum RepoMemoryEvidenceView {
+    Compact(CompactRepoMemoryEvidence),
+    Full(RepoMemoryEvidence),
+}
+
+impl RepoMemoryEvidenceView {
+    /// Borrow the full evidence; `None` when this view is compact.
+    pub fn full(&self) -> Option<&RepoMemoryEvidence> {
+        match self {
+            Self::Full(evidence) => Some(evidence),
+            Self::Compact(_) => None,
+        }
+    }
+
+    /// Borrow the compact evidence; `None` when this view is full.
+    pub fn compact(&self) -> Option<&CompactRepoMemoryEvidence> {
+        match self {
+            Self::Compact(evidence) => Some(evidence),
+            Self::Full(_) => None,
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -49,7 +81,7 @@ pub struct ImpactSurfaceReport {
     pub text_fallback_hits: Vec<ImpactItem>,
     pub recent_commits_touching_symbol_path: Vec<ImpactItem>,
     pub github_rationale_issues_prs: Vec<ImpactItem>,
-    pub repo_memories: RepoMemoryEvidence,
+    pub repo_memories: RepoMemoryEvidenceView,
     pub completeness_and_caveats: ImpactCompleteness,
 }
 
@@ -96,6 +128,7 @@ impl Default for ImpactSurfaceOptions {
             include_papertrail: true,
             include_text_fallback: true,
             include_memories: true,
+            compact_memories: true,
         }
     }
 }
@@ -261,6 +294,20 @@ pub fn impact_surface_report_for_symbol(
             truncated_sections.join(", ")
         ));
     }
+    // Completeness counts read the FULL evidence lanes, so compute them before the compact
+    // projection moves `repo_memories` into the view (#37).
+    let memory_active = u64::try_from(
+        repo_memories.direct.len()
+            + repo_memories.path_crossed.len()
+            + repo_memories.call_path_crossed.len(),
+    )
+    .unwrap_or(u64::MAX);
+    let memory_stale = u64::try_from(repo_memories.stale.len()).unwrap_or(u64::MAX);
+    let repo_memories = if options.compact_memories {
+        RepoMemoryEvidenceView::Compact(repo_memories.compact())
+    } else {
+        RepoMemoryEvidenceView::Full(repo_memories)
+    };
     Ok(ImpactSurfaceReport {
         query: ImpactSurfaceQuery {
             symbol_id: Some(symbol.symbol_id),
@@ -274,15 +321,7 @@ pub fn impact_surface_report_for_symbol(
             text_fallback_hits: u64::try_from(text_fallback_hits.len()).unwrap_or(u64::MAX),
             parser_failures: parser_failure_count(conn)?,
             stale_files: 0,
-            memory_status: ImpactMemoryStatus {
-                active: u64::try_from(
-                    repo_memories.direct.len()
-                        + repo_memories.path_crossed.len()
-                        + repo_memories.call_path_crossed.len(),
-                )
-                .unwrap_or(u64::MAX),
-                stale: u64::try_from(repo_memories.stale.len()).unwrap_or(u64::MAX),
-            },
+            memory_status: ImpactMemoryStatus { active: memory_active, stale: memory_stale },
             truncated_sections,
             caveats,
         },

--- a/crates/rag-rat-core/src/query/memory/mod.rs
+++ b/crates/rag-rat-core/src/query/memory/mod.rs
@@ -210,6 +210,95 @@ pub struct RepoMemoryEvidence {
     pub stale: Vec<RepoMemory>,
 }
 
+impl RepoMemoryEvidence {
+    /// Project to the scannable compact view (#37): drops bodies, extra bindings, and call paths,
+    /// keeping the per-lane header an agent skims during preflight. Field names match the full
+    /// evidence so the wire shape is identical apart from per-memory detail.
+    pub fn compact(&self) -> CompactRepoMemoryEvidence {
+        let project =
+            |memories: &[RepoMemory]| memories.iter().map(CompactRepoMemory::from).collect();
+        CompactRepoMemoryEvidence {
+            direct: project(&self.direct),
+            path_crossed: project(&self.path_crossed),
+            call_path_crossed: project(&self.call_path_crossed),
+            stale: project(&self.stale),
+        }
+    }
+}
+
+/// Compact (default) view of `RepoMemoryEvidence` for `impact_surface` (#37) — same lane layout,
+/// each memory summarized to its high-signal header by [`CompactRepoMemory`].
+#[derive(Debug, Clone, Serialize)]
+pub struct CompactRepoMemoryEvidence {
+    pub direct: Vec<CompactRepoMemory>,
+    pub path_crossed: Vec<CompactRepoMemory>,
+    #[serde(default)]
+    pub call_path_crossed: Vec<CompactRepoMemory>,
+    pub stale: Vec<CompactRepoMemory>,
+}
+
+/// A one-line-scannable projection of a [`RepoMemory`] for `impact_surface`'s default output (#37):
+/// what the memory says (kind/title/confidence/status) and where its *primary* binding
+/// (`bindings.first()`) is anchored — without the full body, the remaining bindings, or call paths.
+/// Full detail stays available via `memory_for_symbol` / `memory_for_path` /
+/// `memory_for_call_path`, or `impact_surface` full mode (`include` unaffected; `full_memories:
+/// true`).
+///
+/// Future direction: this header could carry a short LLM-generated `summary` of the full body,
+/// produced by an out-of-process local model (Ollama) rather than truncating the title — see the
+/// local-AI memory-maintenance spike (#122), which already commits to keeping Ollama out of the
+/// binary. Until that lands, the projection stays purely mechanical (no model dependency here).
+#[derive(Debug, Clone, Serialize)]
+pub struct CompactRepoMemory {
+    pub memory_id: String,
+    pub kind: String,
+    pub title: String,
+    pub confidence: String,
+    pub status: String,
+    /// Anchor status of the primary binding (`current` / `stale` / …); `None` when unbound.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub anchor_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub binding_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// `[start_line, end_line]` of the primary binding when both are known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span: Option<[i64; 2]>,
+    // Opaque `sym_<hex>` handle of the primary binding when it's a symbol binding — the actionable
+    // key for a follow-up `memory_for_symbol` / `impact_surface` full lookup (#149).
+    #[serde(
+        rename = "id",
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::serde_big_id::sym_handle_opt::serialize"
+    )]
+    pub logical_symbol_id: Option<i64>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+}
+
+impl From<&RepoMemory> for CompactRepoMemory {
+    fn from(memory: &RepoMemory) -> Self {
+        let primary = memory.bindings.first();
+        Self {
+            memory_id: memory.memory_id.clone(),
+            kind: memory.kind.clone(),
+            title: memory.title.clone(),
+            confidence: memory.confidence.clone(),
+            status: memory.status.clone(),
+            anchor_status: primary.map(|binding| binding.anchor_status.clone()),
+            binding_kind: primary.map(|binding| binding.binding_kind.clone()),
+            path: primary.and_then(|binding| binding.path.clone()),
+            span: primary.and_then(|binding| match (binding.start_line, binding.end_line) {
+                (Some(start), Some(end)) => Some([start, end]),
+                _ => None,
+            }),
+            logical_symbol_id: primary.and_then(|binding| binding.logical_symbol_id),
+            tags: memory.tags.clone(),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct ResolvedBinding {
     binding_kind: String,

--- a/crates/rag-rat-core/src/query/memory/mod.rs
+++ b/crates/rag-rat-core/src/query/memory/mod.rs
@@ -279,7 +279,19 @@ pub struct CompactRepoMemory {
 
 impl From<&RepoMemory> for CompactRepoMemory {
     fn from(memory: &RepoMemory) -> Self {
-        let primary = memory.bindings.first();
+        // Pick the first NON-moniker binding for the header. The auxiliary `scip_moniker` binding
+        // is an identity anchor that lags between (opt-in) oracle runs and is NOT the
+        // memory's real content anchor — `split_active_stale` excludes it from staleness
+        // for exactly this reason. But `attach_memory_children` orders bindings by
+        // `binding_kind`, and `"scip_moniker"` sorts before `"symbol"`, so a naive
+        // `bindings.first()` could surface a lagging `unverified`/`gone` moniker and make
+        // an ACTIVE memory read as stale in the compact view (Codex on #194). Fall back to
+        // the first binding only if every binding is a moniker.
+        let primary = memory
+            .bindings
+            .iter()
+            .find(|binding| binding.binding_kind != SCIP_MONIKER_BINDING_KIND)
+            .or_else(|| memory.bindings.first());
         Self {
             memory_id: memory.memory_id.clone(),
             kind: memory.kind.clone(),
@@ -374,4 +386,84 @@ pub(crate) struct EdgeFingerprintParts<'a> {
     edge_kind: &'a str,
     target_qualified_name: Option<&'a str>,
     receiver_hint: Option<&'a str>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn binding(kind: &str, anchor_status: &str, path: Option<&str>) -> RepoMemoryBinding {
+        RepoMemoryBinding {
+            memory_id: "mem_x".to_string(),
+            binding_kind: kind.to_string(),
+            binding_id: format!("{kind}-id"),
+            path: path.map(str::to_string),
+            start_line: path.map(|_| 10),
+            end_line: path.map(|_| 20),
+            logical_symbol_id: Some(42),
+            symbol_id: None,
+            chunk_id: None,
+            edge_id: None,
+            commit_hash: None,
+            github_owner: None,
+            github_repo: None,
+            github_number: None,
+            symbol_kind: None,
+            signature_hash: None,
+            moniker_tool: None,
+            moniker_tool_version: None,
+            relocation_reason: None,
+            anchor_status: anchor_status.to_string(),
+            created_at_ms: 0,
+        }
+    }
+
+    fn memory(bindings: Vec<RepoMemoryBinding>) -> RepoMemory {
+        RepoMemory {
+            memory_id: "mem_x".to_string(),
+            kind: "Invariant".to_string(),
+            title: "t".to_string(),
+            body: "b".to_string(),
+            confidence: "high".to_string(),
+            status: "active".to_string(),
+            created_by: None,
+            created_at_ms: 0,
+            updated_at_ms: 0,
+            source: "agent".to_string(),
+            source_text_hash: None,
+            input_hash: None,
+            memory_version: String::new(),
+            bindings,
+            call_paths: Vec::new(),
+            tags: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn compact_header_skips_a_lagging_moniker_binding_for_the_real_anchor() {
+        // `attach_memory_children` orders bindings by `binding_kind`, so a `scip_moniker` companion
+        // (which can be `unverified`/`gone` between oracle runs, and which `split_active_stale`
+        // deliberately ignores) sorts BEFORE the real `symbol` anchor. The compact header must skip
+        // it, or an ACTIVE memory reads as stale (Codex on #194).
+        let compact = CompactRepoMemory::from(&memory(vec![
+            binding(SCIP_MONIKER_BINDING_KIND, "unverified", None),
+            binding("symbol", "current", Some("src/lib.rs")),
+        ]));
+        assert_eq!(compact.binding_kind.as_deref(), Some("symbol"));
+        assert_eq!(compact.anchor_status.as_deref(), Some("current"));
+        assert_eq!(compact.path.as_deref(), Some("src/lib.rs"));
+        assert_eq!(compact.span, Some([10, 20]));
+    }
+
+    #[test]
+    fn compact_header_falls_back_to_a_moniker_only_binding_set() {
+        // A memory anchored ONLY by a moniker still gets a header (no non-moniker binding to
+        // prefer).
+        let compact = CompactRepoMemory::from(&memory(vec![binding(
+            SCIP_MONIKER_BINDING_KIND,
+            "current",
+            None,
+        )]));
+        assert_eq!(compact.binding_kind.as_deref(), Some(SCIP_MONIKER_BINDING_KIND));
+    }
 }

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -500,6 +500,7 @@ pub(crate) fn impact_tool(
         include_papertrail: included(&args.include, ImpactInclude::Papertrail, true),
         include_text_fallback: included(&args.include, ImpactInclude::TextFallback, true),
         include_memories: included(&args.include, ImpactInclude::Memories, true),
+        compact_memories: !args.full_memories,
     };
     if args.logical_symbol_id.is_some() || args.symbol_path.is_some() || args.symbol.is_some() {
         let selector = SymbolSelector {

--- a/crates/rag-rat-mcp/src/tools/requests.rs
+++ b/crates/rag-rat-mcp/src/tools/requests.rs
@@ -395,6 +395,11 @@ pub struct ImpactArgs {
     /// list to narrow, e.g. `["git"]` for git history only.
     #[serde(default, deserialize_with = "de_seq_or_json_string")]
     pub include: Option<Vec<ImpactInclude>>,
+    /// Return full memory bodies + every binding + call paths instead of the default compact,
+    /// scannable per-memory headers (#37). Full detail is also reachable via `memory_for_symbol` /
+    /// `memory_for_path` / `memory_for_call_path`.
+    #[serde(default)]
+    pub full_memories: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -58,7 +58,7 @@ To run from a checkout without installing, use a project-scoped server whose com
 - `find_callers`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include"?: ("references" | "unresolved" | "macros" | "common_methods" | "coverage" | "memories")[], "edge_kinds"?: string[] }`
 - `trace_callees`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include"?: ("references" | "unresolved" | "macros" | "common_methods" | "coverage" | "memories")[], "edge_kinds"?: string[] }`
 - `compare_graph_to_text`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "pattern": string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include"?: ("tests" | "references" | "unresolved" | "macros" | "common_methods")[], "edge_kinds"?: string[] }`
-- `impact_surface`: `{ "query"?: string, "symbol"?: string, "ref"?: string, "id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include"?: ("tests" | "docs" | "git" | "papertrail" | "text_fallback" | "memories")[] }`
+- `impact_surface`: `{ "query"?: string, "symbol"?: string, "ref"?: string, "id"?: string, "resolution"?: "exact" | "syntactic" | "fuzzy", "allow_ambiguous"?: boolean, "limit"?: number, "include"?: ("tests" | "docs" | "git" | "papertrail" | "text_fallback" | "memories")[], "full_memories"?: boolean }`
 - `ffi_surface`: `{ "limit"?: number }`
 - `docs_for_symbol`: `{ "symbol"?: string, "ref"?: string, "id"?: string, "allow_ambiguous"?: boolean, "limit"?: number }`
 - `read_chunk`: `{ "chunk_id": number, "include_graph"?: "none" | "compact" | "full", "graph_limit"?: number, "include"?: ("memories")[] }`
@@ -87,6 +87,15 @@ tool with `"include": []` returns the bare result. Each tool accepts only its ow
 signatures above). The server also accepts a JSON-string-encoded array (`"[\"git\"]"`) as well as a
 real array, so the surface works even from clients that serialize array params as strings
 ([anthropics/claude-code#24599](https://github.com/anthropics/claude-code/issues/24599)).
+
+**Compact vs full memories.** `impact_surface`'s `repo_memories` payload is **compact by default**
+(#37): each memory is summarized to a scannable header — `memory_id`, `kind`, `title`, `confidence`,
+`status`, and its primary binding's `anchor_status` / `binding_kind` / `path` / `span` / `id` — so an
+agent skims the high-signal facts without scrolling full bodies. The lane shape is unchanged
+(`direct` / `path_crossed` / `call_path_crossed` / `stale`). Pass `"full_memories": true` for the
+full bodies + every binding + call paths, or fetch full detail per-anchor via
+`memory_for_symbol` / `memory_for_path` / `memory_for_call_path`. (`full_memories` is orthogonal to
+`include`: drop `"memories"` from `include` to omit the lane entirely.)
 
 `tools/list` is served by `rmcp` and exposes typed JSON schemas derived from the same request structs
 used by the handlers. Existing tool names and response fields are kept stable for current MCP clients.


### PR DESCRIPTION
## What

`impact_surface` returned full `RepoMemory` objects in `repo_memories` — bodies, every binding, and call paths. That's machine-complete but noisy for an agent's preflight scan, which mostly wants *what the memory says* and *where it's anchored*.

This adds a **compact** projection and makes it the default:

- `CompactRepoMemory` — a scannable header per memory: `memory_id`, `kind`, `title`, `confidence`, `status`, and the **primary binding**'s `anchor_status` / `binding_kind` / `path` / `span` / `id` (sym handle).
- `repo_memories` is now an `#[serde(untagged)]` `Compact | Full` enum (`RepoMemoryEvidenceView`). The lane layout (`direct` / `path_crossed` / `call_path_crossed` / `stale`) and field names are **identical** on the wire — only per-memory detail changes.
- Compact is the default (`ImpactSurfaceOptions::compact_memories`, and the MCP default). Pass `full_memories: true` for the full objects, or fetch per-anchor detail via `memory_for_symbol` / `memory_for_path` / `memory_for_call_path`.
- Completeness counts (`memory_status.active` / `.stale`) are computed from the full lanes **before** the projection moves the evidence into the view, so they're unaffected.

## Tests

- Compact projection of the primary binding header + full-mode round-trip (body + bindings restored).
- Stale lane separated from `direct` in compact mode, `anchor_status` carried through.
- Existing path-crossed / call-path / direct impact tests updated to the `.compact()` accessor.
- Full `rag-rat-core` (541) + `rag-rat-mcp` suites green; `cargo +nightly fmt` + `clippy --all-targets` clean.

## Docs

README and `docs/mcp-tools.md` document the compact default and the `full_memories` escape hatch.

## Follow-up

A code comment on `CompactRepoMemory` + a note on #122 flag it as the future home for an out-of-process (Ollama) LLM-generated `summary`, once the local-AI substrate lands.

Closes #37.