### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.7.0...rag-rat-core-v0.8.0) - 2026-06-19
+
+### Added
+
+- *(index)* intern symbol qualified_name into the shared name_strings pool ([#224](https://github.com/cq27-dev/rag-rat/pull/224)) ([#227](https://github.com/cq27-dev/rag-rat/pull/227))
+- *(index)* dictionary-zstd chunk-text compression + drop chunks.text (#77 Phase 2) ([#225](https://github.com/cq27-dev/rag-rat/pull/225))
+- *(serve)* worktree-aware serving — linked git worktrees as branch overlays ([#219](https://github.com/cq27-dev/rag-rat/pull/219))
+- *(git)* move all runtime git operations to gix (gitoxide) ([#212](https://github.com/cq27-dev/rag-rat/pull/212)) ([#213](https://github.com/cq27-dev/rag-rat/pull/213))
+- *(graph)* synthesize message-dispatch (actor-channel / enum) edges ([#200](https://github.com/cq27-dev/rag-rat/pull/200)) ([#206](https://github.com/cq27-dev/rag-rat/pull/206))
+- *(graph)* zero-caller find_callers is never low completeness ([#200](https://github.com/cq27-dev/rag-rat/pull/200)) ([#205](https://github.com/cq27-dev/rag-rat/pull/205))
+- *(symbol)* exclude generated bindings from symbol search by default ([#202](https://github.com/cq27-dev/rag-rat/pull/202)) ([#204](https://github.com/cq27-dev/rag-rat/pull/204))
+- *(oracle)* add py-django corpus + tolerate diagnostic exit codes (#182 groundwork) ([#198](https://github.com/cq27-dev/rag-rat/pull/198))
+- *(oracle)* opt-in external-resolution health floor for npm-style corpora ([#185](https://github.com/cq27-dev/rag-rat/pull/185)) ([#196](https://github.com/cq27-dev/rag-rat/pull/196))
+- *(oracle)* scip-java (Kotlin) backend ([#193](https://github.com/cq27-dev/rag-rat/pull/193))
+- *(impact)* compact repo-memory view by default; full bodies on request ([#37](https://github.com/cq27-dev/rag-rat/pull/37)) ([#194](https://github.com/cq27-dev/rag-rat/pull/194))
+
+### Fixed
+
+- *(parser)* bound tree-sitter parse with a wall-clock budget ([#210](https://github.com/cq27-dev/rag-rat/pull/210)) ([#211](https://github.com/cq27-dev/rag-rat/pull/211))
+- *(graph)* synthesize message-dispatch (actor-channel / enum) edges ([#200](https://github.com/cq27-dev/rag-rat/pull/200)) ([#208](https://github.com/cq27-dev/rag-rat/pull/208))
+- *(symbol)* accept a sym_<hex> handle in the ref slot ([#201](https://github.com/cq27-dev/rag-rat/pull/201)) ([#203](https://github.com/cq27-dev/rag-rat/pull/203))
+
+### Other
+
+- *(impact)* stop scanning chunks.text in impact_surface (#77 Phase 1) ([#223](https://github.com/cq27-dev/rag-rat/pull/223))
+- *(oracle)* pin indexer dep tree + lock corpus installs (#185 items 2-3) ([#197](https://github.com/cq27-dev/rag-rat/pull/197))
+
 ## [0.7.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.6.0...rag-rat-core-v0.7.0) - 2026-06-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3155,7 +3155,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rag-rat"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-mcp"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "3"
 # and the internal path deps below pin the same literal, so the three crates always publish in
 # lockstep. Bump this one line (and the two internal-dep `version`s under workspace.dependencies)
 # to release.
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Kristaps Karlsons"]
 edition = "2024"
 rust-version = "1.89"
@@ -25,8 +25,8 @@ categories = ["command-line-utilities", "development-tools"]
 # Internal crates — declared once here so the version requirement is set in lockstep with
 # [workspace.package].version above. Members reference these via `{ workspace = true }` and add
 # their own feature toggles at the use site.
-rag-rat-core = { version = "0.7.0", path = "crates/rag-rat-core", default-features = false }
-rag-rat-mcp = { version = "0.7.0", path = "crates/rag-rat-mcp", default-features = false }
+rag-rat-core = { version = "0.8.0", path = "crates/rag-rat-core", default-features = false }
+rag-rat-mcp = { version = "0.8.0", path = "crates/rag-rat-mcp", default-features = false }
 anyhow = "1.0"
 fastembed = { version = "5.1.0", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
 gix = { version = "0.84.0", default-features = false, features = ["status", "parallel", "sha1", "sha256", "revision", "blob-diff", "blame"] }


### PR DESCRIPTION



## 🤖 New release

* `rag-rat-core`: 0.7.0 -> 0.8.0 (⚠ API breaking changes)
* `rag-rat-mcp`: 0.7.0 -> 0.8.0 (⚠ API breaking changes)
* `rag-rat`: 0.7.0 -> 0.8.0

### ⚠ `rag-rat-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ImpactSurfaceOptions.compact_memories in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-core/src/query/impact/mod.rs:56
  field CorpusHealth.expected_min_resolved_external in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-core/src/index/oracle/report.rs:58
  field GraphTraversalSummary.completeness_note in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-core/src/query/graph/mod.rs:105

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant EdgeKind:Dispatches in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-core/src/index/edges/mod.rs:38
  variant EdgeKind:DispatchConstruct in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-core/src/index/edges/mod.rs:42
  variant EdgeKind:DispatchHandle in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-core/src/index/edges/mod.rs:47
  variant OracleTool:ScipJava in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-core/src/index/oracle/mod.rs:651

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_parameter_count_changed.ron

Failed in:
  rag_rat_core::query::orientation::orientation now takes 3 parameters instead of 2, in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-core/src/query/orientation.rs:51
  rag_rat_core::query::symbol::lookup_candidates now takes 3 parameters instead of 2, in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-core/src/query/symbol.rs:148

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  rag_rat_core::index::IndexDatabase::symbol_candidates takes 1 parameters in /tmp/.tmpM8o6J2/rag-rat-core/src/index/query_api/mod.rs:113, but now takes 2 parameters in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-core/src/index/query_api/mod.rs:113
  rag_rat_core::IndexDatabase::symbol_candidates takes 1 parameters in /tmp/.tmpM8o6J2/rag-rat-core/src/index/query_api/mod.rs:113, but now takes 2 parameters in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-core/src/index/query_api/mod.rs:113
```

### ⚠ `rag-rat-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field HookRequest.cwd in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-mcp/src/claude_hook.rs:25
  field ReadChunkArgs.worktree in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:483
  field ImpactArgs.full_memories in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:455
  field ImpactArgs.worktree in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:460
  field SearchArgs.worktree in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:246
  field SymbolArgs.worktree in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:335
  field SymbolGraphArgs.worktree in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:394

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant McpGraphEdgeKind::UsesMacro 2 -> 3 in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:91
  variant McpGraphEdgeKind::ReferencesType 3 -> 4 in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:92
  variant McpGraphEdgeKind::Imports 4 -> 5 in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:93
  variant McpGraphEdgeKind::Exports 5 -> 6 in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:94
  variant McpGraphEdgeKind::Contains 6 -> 7 in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:95
  variant McpGraphEdgeKind::Implements 7 -> 8 in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:96

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant McpGraphEdgeKind:Dispatches in /tmp/.tmpDXS0H3/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:90
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rag-rat-core`

<blockquote>

## [0.8.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.7.0...rag-rat-core-v0.8.0) - 2026-06-19

### Added

- *(index)* intern symbol qualified_name into the shared name_strings pool ([#224](https://github.com/cq27-dev/rag-rat/pull/224)) ([#227](https://github.com/cq27-dev/rag-rat/pull/227))
- *(index)* dictionary-zstd chunk-text compression + drop chunks.text (#77 Phase 2) ([#225](https://github.com/cq27-dev/rag-rat/pull/225))
- *(serve)* worktree-aware serving — linked git worktrees as branch overlays ([#219](https://github.com/cq27-dev/rag-rat/pull/219))
- *(git)* move all runtime git operations to gix (gitoxide) ([#212](https://github.com/cq27-dev/rag-rat/pull/212)) ([#213](https://github.com/cq27-dev/rag-rat/pull/213))
- *(graph)* synthesize message-dispatch (actor-channel / enum) edges ([#200](https://github.com/cq27-dev/rag-rat/pull/200)) ([#206](https://github.com/cq27-dev/rag-rat/pull/206))
- *(graph)* zero-caller find_callers is never low completeness ([#200](https://github.com/cq27-dev/rag-rat/pull/200)) ([#205](https://github.com/cq27-dev/rag-rat/pull/205))
- *(symbol)* exclude generated bindings from symbol search by default ([#202](https://github.com/cq27-dev/rag-rat/pull/202)) ([#204](https://github.com/cq27-dev/rag-rat/pull/204))
- *(oracle)* add py-django corpus + tolerate diagnostic exit codes (#182 groundwork) ([#198](https://github.com/cq27-dev/rag-rat/pull/198))
- *(oracle)* opt-in external-resolution health floor for npm-style corpora ([#185](https://github.com/cq27-dev/rag-rat/pull/185)) ([#196](https://github.com/cq27-dev/rag-rat/pull/196))
- *(oracle)* scip-java (Kotlin) backend ([#193](https://github.com/cq27-dev/rag-rat/pull/193))
- *(impact)* compact repo-memory view by default; full bodies on request ([#37](https://github.com/cq27-dev/rag-rat/pull/37)) ([#194](https://github.com/cq27-dev/rag-rat/pull/194))

### Fixed

- *(parser)* bound tree-sitter parse with a wall-clock budget ([#210](https://github.com/cq27-dev/rag-rat/pull/210)) ([#211](https://github.com/cq27-dev/rag-rat/pull/211))
- *(graph)* synthesize message-dispatch (actor-channel / enum) edges ([#200](https://github.com/cq27-dev/rag-rat/pull/200)) ([#208](https://github.com/cq27-dev/rag-rat/pull/208))
- *(symbol)* accept a sym_<hex> handle in the ref slot ([#201](https://github.com/cq27-dev/rag-rat/pull/201)) ([#203](https://github.com/cq27-dev/rag-rat/pull/203))

### Other

- *(impact)* stop scanning chunks.text in impact_surface (#77 Phase 1) ([#223](https://github.com/cq27-dev/rag-rat/pull/223))
- *(oracle)* pin indexer dep tree + lock corpus installs (#185 items 2-3) ([#197](https://github.com/cq27-dev/rag-rat/pull/197))
</blockquote>

## `rag-rat-mcp`

<blockquote>

## [0.8.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.7.0...rag-rat-core-v0.8.0) - 2026-06-19

### Added

- *(index)* intern symbol qualified_name into the shared name_strings pool ([#224](https://github.com/cq27-dev/rag-rat/pull/224)) ([#227](https://github.com/cq27-dev/rag-rat/pull/227))
- *(index)* dictionary-zstd chunk-text compression + drop chunks.text (#77 Phase 2) ([#225](https://github.com/cq27-dev/rag-rat/pull/225))
- *(serve)* worktree-aware serving — linked git worktrees as branch overlays ([#219](https://github.com/cq27-dev/rag-rat/pull/219))
- *(git)* move all runtime git operations to gix (gitoxide) ([#212](https://github.com/cq27-dev/rag-rat/pull/212)) ([#213](https://github.com/cq27-dev/rag-rat/pull/213))
- *(graph)* synthesize message-dispatch (actor-channel / enum) edges ([#200](https://github.com/cq27-dev/rag-rat/pull/200)) ([#206](https://github.com/cq27-dev/rag-rat/pull/206))
- *(graph)* zero-caller find_callers is never low completeness ([#200](https://github.com/cq27-dev/rag-rat/pull/200)) ([#205](https://github.com/cq27-dev/rag-rat/pull/205))
- *(symbol)* exclude generated bindings from symbol search by default ([#202](https://github.com/cq27-dev/rag-rat/pull/202)) ([#204](https://github.com/cq27-dev/rag-rat/pull/204))
- *(oracle)* add py-django corpus + tolerate diagnostic exit codes (#182 groundwork) ([#198](https://github.com/cq27-dev/rag-rat/pull/198))
- *(oracle)* opt-in external-resolution health floor for npm-style corpora ([#185](https://github.com/cq27-dev/rag-rat/pull/185)) ([#196](https://github.com/cq27-dev/rag-rat/pull/196))
- *(oracle)* scip-java (Kotlin) backend ([#193](https://github.com/cq27-dev/rag-rat/pull/193))
- *(impact)* compact repo-memory view by default; full bodies on request ([#37](https://github.com/cq27-dev/rag-rat/pull/37)) ([#194](https://github.com/cq27-dev/rag-rat/pull/194))

### Fixed

- *(parser)* bound tree-sitter parse with a wall-clock budget ([#210](https://github.com/cq27-dev/rag-rat/pull/210)) ([#211](https://github.com/cq27-dev/rag-rat/pull/211))
- *(graph)* synthesize message-dispatch (actor-channel / enum) edges ([#200](https://github.com/cq27-dev/rag-rat/pull/200)) ([#208](https://github.com/cq27-dev/rag-rat/pull/208))
- *(symbol)* accept a sym_<hex> handle in the ref slot ([#201](https://github.com/cq27-dev/rag-rat/pull/201)) ([#203](https://github.com/cq27-dev/rag-rat/pull/203))

### Other

- *(impact)* stop scanning chunks.text in impact_surface (#77 Phase 1) ([#223](https://github.com/cq27-dev/rag-rat/pull/223))
- *(oracle)* pin indexer dep tree + lock corpus installs (#185 items 2-3) ([#197](https://github.com/cq27-dev/rag-rat/pull/197))
</blockquote>

## `rag-rat`

<blockquote>

## [0.8.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.7.0...rag-rat-core-v0.8.0) - 2026-06-19

### Added

- *(index)* intern symbol qualified_name into the shared name_strings pool ([#224](https://github.com/cq27-dev/rag-rat/pull/224)) ([#227](https://github.com/cq27-dev/rag-rat/pull/227))
- *(index)* dictionary-zstd chunk-text compression + drop chunks.text (#77 Phase 2) ([#225](https://github.com/cq27-dev/rag-rat/pull/225))
- *(serve)* worktree-aware serving — linked git worktrees as branch overlays ([#219](https://github.com/cq27-dev/rag-rat/pull/219))
- *(git)* move all runtime git operations to gix (gitoxide) ([#212](https://github.com/cq27-dev/rag-rat/pull/212)) ([#213](https://github.com/cq27-dev/rag-rat/pull/213))
- *(graph)* synthesize message-dispatch (actor-channel / enum) edges ([#200](https://github.com/cq27-dev/rag-rat/pull/200)) ([#206](https://github.com/cq27-dev/rag-rat/pull/206))
- *(graph)* zero-caller find_callers is never low completeness ([#200](https://github.com/cq27-dev/rag-rat/pull/200)) ([#205](https://github.com/cq27-dev/rag-rat/pull/205))
- *(symbol)* exclude generated bindings from symbol search by default ([#202](https://github.com/cq27-dev/rag-rat/pull/202)) ([#204](https://github.com/cq27-dev/rag-rat/pull/204))
- *(oracle)* add py-django corpus + tolerate diagnostic exit codes (#182 groundwork) ([#198](https://github.com/cq27-dev/rag-rat/pull/198))
- *(oracle)* opt-in external-resolution health floor for npm-style corpora ([#185](https://github.com/cq27-dev/rag-rat/pull/185)) ([#196](https://github.com/cq27-dev/rag-rat/pull/196))
- *(oracle)* scip-java (Kotlin) backend ([#193](https://github.com/cq27-dev/rag-rat/pull/193))
- *(impact)* compact repo-memory view by default; full bodies on request ([#37](https://github.com/cq27-dev/rag-rat/pull/37)) ([#194](https://github.com/cq27-dev/rag-rat/pull/194))

### Fixed

- *(parser)* bound tree-sitter parse with a wall-clock budget ([#210](https://github.com/cq27-dev/rag-rat/pull/210)) ([#211](https://github.com/cq27-dev/rag-rat/pull/211))
- *(graph)* synthesize message-dispatch (actor-channel / enum) edges ([#200](https://github.com/cq27-dev/rag-rat/pull/200)) ([#208](https://github.com/cq27-dev/rag-rat/pull/208))
- *(symbol)* accept a sym_<hex> handle in the ref slot ([#201](https://github.com/cq27-dev/rag-rat/pull/201)) ([#203](https://github.com/cq27-dev/rag-rat/pull/203))

### Other

- *(impact)* stop scanning chunks.text in impact_surface (#77 Phase 1) ([#223](https://github.com/cq27-dev/rag-rat/pull/223))
- *(oracle)* pin indexer dep tree + lock corpus installs (#185 items 2-3) ([#197](https://github.com/cq27-dev/rag-rat/pull/197))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).