### PR TITLE
feat(oracle): opt-in external-resolution health floor for npm-style corpora (#185 item 1)

### DIFF
--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -1171,6 +1171,7 @@ mod tests {
                     expected_min_oracle_examined: 1,
                     expected_max_skipped_drifted: 0,
                     expected_min_symbols_with_moniker: 1,
+                    expected_min_resolved_external: None,
                     timeout_minutes: 1,
                 },
             }

--- a/crates/rag-rat-core/src/index/oracle/corpus.rs
+++ b/crates/rag-rat-core/src/index/oracle/corpus.rs
@@ -99,6 +99,19 @@ pub fn check_corpus_health(
         });
     }
 
+    // Opt-in external-resolution floor (#185): for npm-style backends `symbols_with_moniker` stays
+    // high even with `node_modules` absent (local monikers come from package.json), so only
+    // `resolved_external` reveals a missing-dependency run. Gated only when the profile sets a
+    // floor.
+    if let Some(min_resolved_external) = health.expected_min_resolved_external
+        && report.resolved_external < min_resolved_external
+    {
+        violations.push(HealthViolation {
+            check: "min_resolved_external",
+            detail: format!("{} < {min_resolved_external}", report.resolved_external),
+        });
+    }
+
     violations
 }
 
@@ -202,7 +215,7 @@ health    = { expected_min_heuristic_edges = 50000, expected_min_oracle_examined
         "ba5a37328901f0b1964c51bc8cff3c729d07070a0ce0d61f9934ea7790ca6b64";
     const GOLDEN_C_LIBUV: &str = "b34ef742c7d4b5efc02bdb95a8457719be9a0dd5621485e11c7d42d2e534d965";
     const GOLDEN_PY_RICH: &str = "0a4a22be9817ff26b549119b098d23004e5a8b4d7817126e5084f9d730f1efda";
-    const GOLDEN_TS_RXJS: &str = "492436f3827cbf9afe206b5feb03227388521db68a5965c1c3e904f68f0e1109";
+    const GOLDEN_TS_RXJS: &str = "da31c85864cdad38b7a4553774e46d241a602e3c4e9d11229bdd52c2f7411ee1";
     const GOLDEN_CPP_YAML: &str =
         "2b6d2ec7f00b34e330116bf1b93fd51416926ac3d30e24dac766f0f8fb910f58";
     const GOLDEN_RUST_CARGO: &str =
@@ -260,5 +273,41 @@ health    = { expected_min_heuristic_edges = 50000, expected_min_oracle_examined
             "max_skipped_drifted",
             "min_symbols_with_moniker",
         ]);
+    }
+
+    #[test]
+    fn external_resolution_floor_gates_only_when_set() {
+        // #185: the dep-resolution floor is opt-in. Unset (the SAMPLE default) → never gated, so a
+        // backend where external resolution isn't the signal isn't spuriously failed.
+        let mut profile =
+            corpus_by_id(&load_corpora(SAMPLE).unwrap(), "rust-semver").unwrap().clone();
+        assert!(profile.health.expected_min_resolved_external.is_none());
+        let mut report = report_with(100, 30, 0, 15); // resolved_external defaults to 0
+        assert_eq!(report.resolved_external, 0);
+        assert!(
+            check_corpus_health(&profile, &report)
+                .iter()
+                .all(|v| v.check != "min_resolved_external"),
+            "no floor set → external resolution is not gated even at 0"
+        );
+
+        // With a floor, a run whose external resolution falls below it violates (the npm-style
+        // missing-node_modules failure mode that `symbols_with_moniker` would miss).
+        profile.health.expected_min_resolved_external = Some(50);
+        let checks: Vec<&str> =
+            check_corpus_health(&profile, &report).iter().map(|v| v.check).collect();
+        assert!(
+            checks.contains(&"min_resolved_external"),
+            "below-floor external resolution must violate; got {checks:?}"
+        );
+
+        // A run clearing the floor passes the external check.
+        report.resolved_external = 80;
+        assert!(
+            check_corpus_health(&profile, &report)
+                .iter()
+                .all(|v| v.check != "min_resolved_external"),
+            "external resolution >= floor passes"
+        );
     }
 }

--- a/crates/rag-rat-core/src/index/oracle/report.rs
+++ b/crates/rag-rat-core/src/index/oracle/report.rs
@@ -45,6 +45,17 @@ pub struct CorpusHealth {
     /// Minimum logical symbols that gained a moniker (catches "scip-python ran but resolved
     /// nothing", the venv-not-installed failure mode).
     pub expected_min_symbols_with_moniker: u64,
+    /// Minimum edges the oracle resolved to an EXTERNAL definition — an OPT-IN
+    /// dependency-resolution floor (#185). `symbols_with_moniker` is the canonical "did deps
+    /// resolve" signal for most backends, but it is unreliable for the npm-style ones:
+    /// scip-typescript mints local package monikers from `package.json` regardless of whether
+    /// `node_modules` is installed, so the moniker count stays high while only EXTERNAL
+    /// resolution collapses. Gating `resolved_external` directly catches a missing-dependency
+    /// run those backends would otherwise pass. `None` (omitted) = no gate — the default for
+    /// backends where external resolution isn't the dep signal (rust-analyzer/scip-clang) or
+    /// is already covered by the moniker floor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_min_resolved_external: Option<u64>,
     /// Wall-clock budget for the whole corpus run; the runner wraps the run in this timeout.
     pub timeout_minutes: u64,
 }
@@ -272,6 +283,7 @@ mod tests {
                 expected_min_oracle_examined: 20,
                 expected_max_skipped_drifted: 0,
                 expected_min_symbols_with_moniker: 10,
+                expected_min_resolved_external: None,
                 timeout_minutes: 8,
             },
         }

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -4287,6 +4287,7 @@ fn resolution_report_assembles_before_after_from_index() {
             expected_min_oracle_examined: 1,
             expected_max_skipped_drifted: 0,
             expected_min_symbols_with_moniker: 1,
+            expected_min_resolved_external: None,
             timeout_minutes: 8,
         },
     };

--- a/tools/oracle-corpora.toml
+++ b/tools/oracle-corpora.toml
@@ -59,9 +59,17 @@ tool      = "scip-typescript"
 # of scip-python's venv); `npm install` makes them present. It requires a root `tsconfig.json` (rxjs
 # ships one) — the backend deliberately does NOT pass `--infer-tsconfig` (read-only-on-source). Bind
 # `src/internal` (the library implementation) rather than the whole `src` re-export surface.
+#
+# `expected_min_resolved_external` (#185) is the dependency-resolution floor for this npm-style
+# backend: scip-typescript mints local package monikers from package.json REGARDLESS of whether
+# node_modules is installed, so `symbols_with_moniker` (~626 measured) stays high even on a
+# missing-deps run — only EXTERNAL resolution collapses. Measured `resolved_external` ~2534 with
+# node_modules present; the 1000 floor catches a missing-`npm install` run (external resolution drops
+# toward zero) while sitting well below the healthy number. The non-npm backends leave it unset
+# (external resolution isn't their dep signal; rust/c use cargo fetch / the compdb).
 prepare   = ["npm install --no-audit --no-fund"]
 bindings  = { typescript = ["src/internal"] }
-health    = { expected_min_heuristic_edges = 5000, expected_min_oracle_examined = 3500, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 300, timeout_minutes = 15 }
+health    = { expected_min_heuristic_edges = 5000, expected_min_oracle_examined = 3500, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 300, expected_min_resolved_external = 1000, timeout_minutes = 15 }
 
 [[corpus]]
 corpus_id = "cpp-yaml"


### PR DESCRIPTION
## What

The oracle health gate's dependency-resolution signal is `symbols_with_moniker`, but that's unreliable for **scip-typescript**: it assigns local package monikers from `package.json` *regardless of whether `node_modules` is installed*, so the moniker count stays high even when external resolution collapses. A TS corpus with missing deps could pass the gate while silently under-counting `resolved_external` (Codex review on #184, item 1).

This adds an **opt-in** external-resolution floor:

- New `CorpusHealth.expected_min_resolved_external: Option<u64>` (`#[serde(default, skip_serializing_if = "Option::is_none")]`). `None` = no gate.
- `check_corpus_health` gates `report.resolved_external` against the floor when set (`min_resolved_external` violation).
- `resolved_external` was already computed and emitted in the report — this only adds the *gate*, so `REPORT_SCHEMA_VERSION` is unchanged (report output shape identical).

## Why opt-in

Because the field is `skip_serializing_if = None`, corpora that don't set it serialize byte-identically to before — so **only ts-rxjs's golden profile hash changes**, and the non-npm backends (rust-analyzer / scip-clang, where external resolution isn't the dep signal) are unaffected.

## The ts-rxjs floor

Measured locally (full `oracle-run.sh` with `npm install`): `resolved_external` ≈ **2534**, `symbols_with_moniker` ≈ 626, examined ≈ 7023. Floor set to **1000** — catches a missing-`npm install` run (external resolution drops toward zero while monikers stay high) while sitting comfortably below the healthy number, consistent with the other floors' ~40-50%-of-measured margin.

## Tests

- `external_resolution_floor_gates_only_when_set`: gate off when `None`; violates below floor; passes at/above.
- Re-pinned `GOLDEN_TS_RXJS`; `committed_corpora_file` confirms only ts-rxjs changed.
- `cargo +nightly fmt` + `clippy --all-targets` clean; 547 core tests pass.

## Scope

Addresses **item 1** of #185 (the health signal). Items 2-3 (pin the indexer's full dependency tree; lock corpus dependency installs via committed lockfiles / `npm ci`) are CI-reproducibility work and remain open on #185.