### PR TITLE
ci(oracle): pin indexer dep tree + lock corpus installs (#185 items 2-3)

### DIFF
--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -22,6 +22,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'tools/oracle-corpora.toml'
+      - 'tools/oracle-toolchain/**'
       - 'tools/oracle-corpus.py'
       - 'tools/oracle-run.sh'
       - 'tools/oracle-report-bmf.py'
@@ -34,6 +35,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'tools/oracle-corpora.toml'
+      - 'tools/oracle-toolchain/**'
       - 'tools/oracle-corpus.py'
       - 'tools/oracle-run.sh'
       - 'tools/oracle-report-bmf.py'
@@ -58,12 +60,14 @@ concurrency:
 
 env:
   # Pinned SCIP toolchain for the small tier so a PR number isn't perturbed by an unrelated indexer
-  # release. scip-clang/scip-python/scip-typescript are pinned to explicit versions; rust-analyzer is installed as a
-  # rustup component (below), pinning it to the stable toolchain (a ~6-week cadence) instead of the
-  # weekly `releases/latest` — so a fresh RA build can't change `rust-time`'s numbers mid-PR.
+  # release. scip-clang is pinned to an explicit prebuilt version (a single static binary, no
+  # transitive tree); rust-analyzer is installed as a rustup component (below), pinning it to the
+  # stable toolchain (a ~6-week cadence) instead of the weekly `releases/latest`. The npm-based
+  # indexers (scip-typescript, scip-python) are pinned by `tools/oracle-toolchain/package-lock.json`
+  # via `npm ci` — their FULL transitive tree (notably scip-typescript's bundled `typescript`
+  # compiler) is locked, so a transitive npm release can't shift a PR's numbers while the indexer's
+  # own `--version` is unchanged (#185 item 2).
   SCIP_CLANG_VERSION: v0.4.0
-  SCIP_PYTHON_VERSION: 0.6.6
-  SCIP_TYPESCRIPT_VERSION: 0.4.0
 
 jobs:
   matrix:
@@ -127,12 +131,13 @@ jobs:
                 -o /usr/local/bin/scip-clang
               chmod +x /usr/local/bin/scip-clang
               scip-clang --version ;;
-            scip-python)
-              npm install -g "@sourcegraph/scip-python@${SCIP_PYTHON_VERSION}"
-              scip-python --version ;;
-            scip-typescript)
-              npm install -g "@sourcegraph/scip-typescript@${SCIP_TYPESCRIPT_VERSION}"
-              scip-typescript --version ;;
+            scip-python|scip-typescript)
+              # Install the pinned npm toolchain from its committed lockfile (full transitive tree,
+              # incl. scip-typescript's bundled `typescript`) and put its bin dir on PATH for the
+              # oracle's probe. `npm ci` is reproducible; `npm install -g @pkg@ver` was not (#185 #2).
+              npm ci --no-audit --no-fund --prefix tools/oracle-toolchain
+              echo "$PWD/tools/oracle-toolchain/node_modules/.bin" >> "$GITHUB_PATH"
+              "$PWD/tools/oracle-toolchain/node_modules/.bin/$tool" --version ;;
             *)
               echo "unknown tool '$tool'" >&2; exit 1 ;;
           esac

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -137,6 +137,13 @@ jobs:
               # oracle's probe. `npm ci` is reproducible; `npm install -g @pkg@ver` was not (#185 #2).
               npm ci --no-audit --no-fund --prefix tools/oracle-toolchain
               echo "$PWD/tools/oracle-toolchain/node_modules/.bin" >> "$GITHUB_PATH"
+              # Fold the toolchain lockfile hash into the oracle's tool_version (consumed by
+              # `oracle report` via RAG_RAT_ORACLE_TOOL_VERSION_SUFFIX). The npm indexers' --version
+              # alone doesn't move when only a transitive dep (e.g. the bundled `typescript`) bumps,
+              # so without this a lockfile-only change would stay "comparable" to main and the Δ
+              # would mis-attribute the toolchain-output change to rag-rat (#185/#197).
+              lock_sha="$(sha256sum tools/oracle-toolchain/package-lock.json | cut -c1-12)"
+              echo "RAG_RAT_ORACLE_TOOL_VERSION_SUFFIX=toolchain:$lock_sha" >> "$GITHUB_ENV"
               "$PWD/tools/oracle-toolchain/node_modules/.bin/$tool" --version ;;
             *)
               echo "unknown tool '$tool'" >&2; exit 1 ;;

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -495,7 +495,10 @@ fn oracle_report(config: &Config, args: &OracleReportArgs) -> anyhow::Result<()>
             },
             oracle::ScipProduction::Produced { version, bytes, production_sha } => {
                 let provenance = oracle::RunProvenance {
-                    tool_version: version,
+                    // Fold the pinned-toolchain fingerprint into the probed `--version` so a
+                    // lockfile bump that changes the indexer's output breaks Δ
+                    // comparability (#185/#197).
+                    tool_version: with_oracle_tool_version_suffix(version),
                     rag_rat_commit: rag_rat_commit.clone(),
                     worktree_id: String::new(),
                     production_sha: oracle::scip_content_fingerprint(&bytes),
@@ -611,6 +614,25 @@ fn rag_rat_commit_provenance() -> String {
         .ok()
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string())
+}
+
+/// Fold the oracle TOOL-ENVIRONMENT fingerprint into a probed `tool_version`. CI exports
+/// `RAG_RAT_ORACLE_TOOL_VERSION_SUFFIX` (the pinned npm toolchain lockfile hash) for the npm-based
+/// backends, whose `--version` alone is insufficient: scip-typescript's bundled `typescript`
+/// compiler can move under a lockfile bump while `scip-typescript --version` stays `0.4.0`. Folding
+/// the lockfile hash into `tool_version` makes that bump yield a DIFFERENT `tool_version`, so the
+/// Δ-vs-main report (which keys comparability on `tool_version`) refuses to compare rather than
+/// mis-attributing the toolchain-output change to rag-rat (#185 / Codex on #197). Unset (local
+/// runs, non-npm backends) leaves the version unchanged.
+fn with_oracle_tool_version_suffix(version: String) -> String {
+    join_tool_version_suffix(version, std::env::var("RAG_RAT_ORACLE_TOOL_VERSION_SUFFIX").ok())
+}
+
+fn join_tool_version_suffix(version: String, suffix: Option<String>) -> String {
+    match suffix.map(|value| value.trim().to_string()).filter(|value| !value.is_empty()) {
+        Some(suffix) => format!("{version}+{suffix}"),
+        None => version,
+    }
 }
 
 pub(crate) fn models(config: &Config, args: &ModelsArgs) -> anyhow::Result<()> {
@@ -1091,6 +1113,23 @@ mod tests {
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::mpsc;
     use std::time::Duration;
+
+    #[test]
+    fn tool_version_suffix_folds_in_the_toolchain_fingerprint() {
+        // No suffix (local run / non-npm backend) → version unchanged.
+        assert_eq!(super::join_tool_version_suffix("0.4.0".into(), None), "0.4.0");
+        assert_eq!(super::join_tool_version_suffix("0.4.0".into(), Some("  ".into())), "0.4.0");
+        // A toolchain fingerprint makes a lockfile bump a DIFFERENT tool_version (breaks Δ
+        // comparability instead of mis-attributing the change), #185/#197.
+        assert_eq!(
+            super::join_tool_version_suffix("0.4.0".into(), Some("toolchain:abc123".into())),
+            "0.4.0+toolchain:abc123"
+        );
+        assert_ne!(
+            super::join_tool_version_suffix("0.4.0".into(), Some("toolchain:aaa".into())),
+            super::join_tool_version_suffix("0.4.0".into(), Some("toolchain:bbb".into())),
+        );
+    }
 
     use rag_rat_core::config::{ResolvedTarget, TargetKind};
     use rag_rat_core::language::Language;

--- a/crates/rag-rat-core/src/index/oracle/corpus.rs
+++ b/crates/rag-rat-core/src/index/oracle/corpus.rs
@@ -214,8 +214,8 @@ health    = { expected_min_heuristic_edges = 50000, expected_min_oracle_examined
     const GOLDEN_RUST_TIME: &str =
         "ba5a37328901f0b1964c51bc8cff3c729d07070a0ce0d61f9934ea7790ca6b64";
     const GOLDEN_C_LIBUV: &str = "b34ef742c7d4b5efc02bdb95a8457719be9a0dd5621485e11c7d42d2e534d965";
-    const GOLDEN_PY_RICH: &str = "0a4a22be9817ff26b549119b098d23004e5a8b4d7817126e5084f9d730f1efda";
-    const GOLDEN_TS_RXJS: &str = "da31c85864cdad38b7a4553774e46d241a602e3c4e9d11229bdd52c2f7411ee1";
+    const GOLDEN_PY_RICH: &str = "8aaf6cd7453a3c2ada0a80bd02f570e7885104b029d664a6159c200b6dce25a0";
+    const GOLDEN_TS_RXJS: &str = "1cb0bed09d093533087c7c617afa9eb963bcf506d2c903e704cdc988b30493e7";
     const GOLDEN_CPP_YAML: &str =
         "2b6d2ec7f00b34e330116bf1b93fd51416926ac3d30e24dac766f0f8fb910f58";
     const GOLDEN_RUST_CARGO: &str =

--- a/tools/oracle-corpora.toml
+++ b/tools/oracle-corpora.toml
@@ -45,7 +45,12 @@ tier      = "small"
 repo      = "https://github.com/Textualize/rich"
 rev       = "v13.8.1"
 tool      = "scip-python"
-prepare   = ["python -m venv .venv", ".venv/bin/pip install ."]
+# `pip install .` resolved rich's deps through ranges (pygments `^2.13`, markdown-it-py `>=2.2`), so
+# an upstream release could shift what scip-python sees while the profile hash — which records only
+# the command string — stayed "comparable" (#185 item 3). Pin rich v13.8.1's full resolved runtime
+# tree inline (these versions are now part of the hashed prepare command, so a bump is a deliberate,
+# reviewable profile change). `npm ci`'s pip analog.
+prepare   = ["python -m venv .venv", ".venv/bin/pip install . \"markdown-it-py==4.2.0\" \"mdurl==0.1.2\" \"pygments==2.20.0\""]
 bindings  = { python = ["rich"] }
 health    = { expected_min_heuristic_edges = 5000, expected_min_oracle_examined = 4000, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 500, timeout_minutes = 12 }
 
@@ -67,7 +72,11 @@ tool      = "scip-typescript"
 # node_modules present; the 1000 floor catches a missing-`npm install` run (external resolution drops
 # toward zero) while sitting well below the healthy number. The non-npm backends leave it unset
 # (external resolution isn't their dep signal; rust/c use cargo fetch / the compdb).
-prepare   = ["npm install --no-audit --no-fund"]
+# `npm ci` (not `npm install`) installs from rxjs's COMMITTED package-lock.json — a deterministic
+# dependency tree — so a transitive npm release can't shift the types/compiler inputs scip-typescript
+# sees while the profile hash stays "comparable" (#185 item 3). rxjs 7.8.1 ships a package-lock.json,
+# which `npm ci` requires.
+prepare   = ["npm ci --no-audit --no-fund"]
 bindings  = { typescript = ["src/internal"] }
 health    = { expected_min_heuristic_edges = 5000, expected_min_oracle_examined = 3500, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 300, expected_min_resolved_external = 1000, timeout_minutes = 15 }
 

--- a/tools/oracle-toolchain/.gitignore
+++ b/tools/oracle-toolchain/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tools/oracle-toolchain/package-lock.json
+++ b/tools/oracle-toolchain/package-lock.json
@@ -1,0 +1,457 @@
+{
+  "name": "rag-rat-oracle-toolchain",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rag-rat-oracle-toolchain",
+      "version": "0.0.0",
+      "dependencies": {
+        "@sourcegraph/scip-python": "0.6.6",
+        "@sourcegraph/scip-typescript": "0.4.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "license": "ISC"
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@sourcegraph/scip-python": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@sourcegraph/scip-python/-/scip-python-0.6.6.tgz",
+      "integrity": "sha512-qoKL1Rggg0o5newAFbCFAKlS0AjWxG5MA+mC28BtgxOv0DhO4zdL8u7151FxEppDpXMVvm7+yXSjXotoVH9cMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@iarna/toml": "^2.2.5",
+        "command-exists": "^1.2.9",
+        "commander": "^9.2.0",
+        "diff": "^5.0.0",
+        "glob": "^7.2.0",
+        "google-protobuf": "^3.19.3",
+        "ts-node": "^10.5.0",
+        "vscode-languageserver": "^7.0.0"
+      },
+      "bin": {
+        "scip-python": "index.js"
+      }
+    },
+    "node_modules/@sourcegraph/scip-typescript": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@sourcegraph/scip-typescript/-/scip-typescript-0.4.0.tgz",
+      "integrity": "sha512-k+AtsrqmS41Sd5qjkZlHcmvoSQIvBOonRj4jpgp0KNFM6aqvMGpdSuPUqrUcg8ENTKjUbfaUVszgQwq3bCOvwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "commander": "^12.1.0",
+        "google-protobuf": "^3.21.4",
+        "progress": "^2.0.3",
+        "typescript": "^5.6.2"
+      },
+      "bin": {
+        "scip-typescript": "dist/src/main.js"
+      }
+    },
+    "node_modules/@sourcegraph/scip-typescript/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sourcegraph/scip-typescript/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/command-exists": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/google-protobuf": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
+      "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==",
+      "license": "(BSD-3-Clause AND Apache-2.0)"
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "license": "ISC"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0 || >=10.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
+      "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.16.0"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "6.0.0",
+        "vscode-languageserver-types": "3.16.0"
+      }
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==",
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/tools/oracle-toolchain/package.json
+++ b/tools/oracle-toolchain/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "rag-rat-oracle-toolchain",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Pinned SCIP indexer toolchain for the oracle corpus runner (#185 item 2). npm ci against the committed package-lock.json pins each indexer's FULL transitive tree (notably scip-typescript's bundled `typescript` compiler), so a PR's resolution numbers can't shift under an unrelated upstream release while the indexer's --version is unchanged.",
+  "dependencies": {
+    "@sourcegraph/scip-typescript": "0.4.0",
+    "@sourcegraph/scip-python": "0.6.6"
+  }
+}


### PR DESCRIPTION
Completes #185 (item 1 — the external-resolution health floor — shipped in #196). These two address reproducibility: the small-tier oracle reports could move for reasons unrelated to rag-rat, corrupting the PR Δ-vs-main comparison.

## Item 2 — pin the indexer's full dependency tree

scip-typescript / scip-python were installed with `npm install -g @pkg@ver`, which resolves transitive deps through semver ranges. So scip-typescript's **bundled `typescript` compiler** could change while `scip-typescript --version` stayed `0.4.0` — silently shifting a PR's resolution numbers.

- New `tools/oracle-toolchain/{package.json,package-lock.json}` pins both indexers' **full transitive tree** (verified: locks `typescript` to 5.9.3). `node_modules` is gitignored.
- `oracle.yml` installs them via `npm ci --prefix tools/oracle-toolchain` and puts the bin dir on ``. scip-clang (prebuilt static binary) and rust-analyzer (rustup component) were already pinned, so only the npm tools needed this.

## Item 3 — lock corpus dependency installs

The corpus `prepare` steps resolved ranged deps fresh each run, while the profile hash recorded only the command string.

- **ts-rxjs**: `npm install` → `npm ci` (rxjs 7.8.1 ships a committed `package-lock.json`).
- **py-rich**: `pip install .` → `pip install . "markdown-it-py==4.2.0" "mdurl==0.1.2" "pygments==2.20.0"` — rich's resolved runtime tree pinned inline, so the versions become part of the hashed `prepare` (a bump is now a deliberate, reviewable profile change).

Re-pinned `GOLDEN_TS_RXJS` + `GOLDEN_PY_RICH` (both `prepare`s changed).

## Validation

- `npm ci` reproducibility verified locally for both the toolchain and rxjs; py-rich pinned install resolves to exactly the pins; `npm ci --prefix` works from repo root.
- **End-to-end**: ran the full `oracle-run.sh` for ts-rxjs with the new `npm ci` prepare + pinned toolchain → **exit 0 (healthy)**, `total_edges` 7875, `resolved_external` 2534 (clears the #196 floor), monikers 626.
- `cargo +nightly fmt` + `clippy --all-targets` clean; 547 core tests pass.

## Scope

Heavy tier (rust-cargo, linux-kernel) runs only rust-analyzer/scip-clang, so it's unaffected; `tools/bench.Containerfile` is left as-is (it doesn't run npm-based corpora). Added `tools/oracle-toolchain/**` to the workflow path filters so a toolchain bump re-runs the gate.

Closes #185.