### PR TITLE
feat(oracle): add py-django corpus + tolerate diagnostic exit codes (#182 groundwork)

### DIFF
--- a/crates/rag-rat-core/src/index/oracle/corpus.rs
+++ b/crates/rag-rat-core/src/index/oracle/corpus.rs
@@ -188,12 +188,14 @@ health    = { expected_min_heuristic_edges = 50000, expected_min_oracle_examined
             "py-rich",
             "ts-rxjs",
             "cpp-yaml",
+            "py-django",
             "rust-cargo",
             "linux-kernel"
         ]);
         assert_eq!(corpus_by_id(&corpora, "py-rich").unwrap().tool, "scip-python");
         assert_eq!(corpus_by_id(&corpora, "ts-rxjs").unwrap().tool, "scip-typescript");
         assert_eq!(corpus_by_id(&corpora, "cpp-yaml").unwrap().tool, "scip-clang");
+        assert_eq!(corpus_by_id(&corpora, "py-django").unwrap().tool, "scip-python");
 
         // GOLDEN per-profile hashes: an edit to any corpus field changes its hash (and makes prior
         // reports incomparable) — recompute deliberately when intended.
@@ -205,6 +207,7 @@ health    = { expected_min_heuristic_edges = 50000, expected_min_oracle_examined
             ("py-rich", GOLDEN_PY_RICH.to_string()),
             ("ts-rxjs", GOLDEN_TS_RXJS.to_string()),
             ("cpp-yaml", GOLDEN_CPP_YAML.to_string()),
+            ("py-django", GOLDEN_PY_DJANGO.to_string()),
             ("rust-cargo", GOLDEN_RUST_CARGO.to_string()),
             ("linux-kernel", GOLDEN_LINUX_KERNEL.to_string()),
         ]);
@@ -218,6 +221,8 @@ health    = { expected_min_heuristic_edges = 50000, expected_min_oracle_examined
     const GOLDEN_TS_RXJS: &str = "1cb0bed09d093533087c7c617afa9eb963bcf506d2c903e704cdc988b30493e7";
     const GOLDEN_CPP_YAML: &str =
         "2b6d2ec7f00b34e330116bf1b93fd51416926ac3d30e24dac766f0f8fb910f58";
+    const GOLDEN_PY_DJANGO: &str =
+        "9d15317c4c5f8a767a539277ccf953cfa76eeade92dc323c7a35ac4e9081bf98";
     const GOLDEN_RUST_CARGO: &str =
         "60452736340151a253001bb5c33cc83efa2a4ceabba4d42a227d3188d7761d79";
     const GOLDEN_LINUX_KERNEL: &str =

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -327,16 +327,39 @@ pub fn produce_scip_with_tool(
         .wait()
         .map_err(|err| anyhow::anyhow!("failed waiting for {}: {err}", manifest.program))?;
     let _ = forwarder.join();
-    if !status.success() {
-        anyhow::bail!("{} scip exited with status {status}", manifest.program);
-    }
-    let bytes = std::fs::read(scip_output).map_err(|err| {
-        anyhow::anyhow!(
-            "{} produced no readable index at {}: {err}",
+    // A SCIP indexer's exit CODE often reflects source DIAGNOSTICS, not indexing failure:
+    // scip-python (pyright) exits 1 whenever the analyzed project has type errors — true of most
+    // real-world Python projects (e.g. Django) — while still emitting a complete, valid index.
+    // So the contract "present tool that FAILS to produce SCIP → error" is keyed on whether a
+    // USABLE index was produced (non-empty + parses to ≥1 document), not on the exit code. A
+    // degenerate/partial index still trips the per-corpus health gate (min edges/examined/monikers)
+    // downstream, so accepting a parseable index here doesn't let a broken run masquerade as
+    // healthy. A non-zero exit with NO usable index remains a hard error.
+    let bytes = std::fs::read(scip_output).unwrap_or_default();
+    let usable_documents =
+        scip::ScipIndex::document_relative_paths(&bytes).map(|paths| paths.len()).unwrap_or(0);
+    if bytes.is_empty() || usable_documents == 0 {
+        if !status.success() {
+            anyhow::bail!(
+                "{} scip exited with status {status} and produced no usable index at {}",
+                manifest.program,
+                scip_output.display()
+            );
+        }
+        anyhow::bail!(
+            "{} produced no readable/parseable index at {}",
             manifest.program,
             scip_output.display()
-        )
-    })?;
+        );
+    }
+    if !status.success() {
+        eprintln!(
+            "note: {} exited with status {status} but produced a parseable index \
+             ({usable_documents} documents) — proceeding (a SCIP indexer's exit code reflects \
+             source diagnostics, not indexing failure); the health gate still guards the numbers",
+            manifest.program
+        );
+    }
     // Snapshot each document's disk hash NOW, the instant the subprocess finished — this is the
     // content the `.scip` describes. The join later pins its occurrence offsets to these hashes so
     // a file the watcher reindexes in the lock-free window before the join is skipped instead

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -318,8 +318,17 @@ pub fn produce_scip_with_tool(
     // PID-named file in the db dir, or an API caller reused the path) that the new indexer exits
     // non-zero without overwriting would be read, parse fine, and — under the diagnostic-exit
     // tolerance below — get its production hash captured against the CURRENT checkout and joined as
-    // if it were this run's output (#198 review).
-    let _ = std::fs::remove_file(scip_output);
+    // if it were this run's output (#198 review). A removal failure other than "wasn't there" is
+    // fatal: proceeding would risk reading exactly that stale file (a locked/permission-denied
+    // unlink leaves it in place).
+    match std::fs::remove_file(scip_output) {
+        Ok(()) => {},
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {},
+        Err(err) => anyhow::bail!(
+            "failed to clear stale oracle output at {} before indexing: {err}",
+            scip_output.display()
+        ),
+    }
     let mut child = command
         .spawn()
         .map_err(|err| anyhow::anyhow!("failed to invoke {}: {err}", manifest.program))?;
@@ -335,9 +344,13 @@ pub fn produce_scip_with_tool(
         .map_err(|err| anyhow::anyhow!("failed waiting for {}: {err}", manifest.program))?;
     let _ = forwarder.join();
     let bytes = std::fs::read(scip_output).unwrap_or_default();
-    if let Some(note) =
-        accept_produced_index(status.success(), &bytes, manifest.program, scip_output)?
-    {
+    if let Some(note) = accept_produced_index(
+        status.success(),
+        tool.exit_code_reflects_diagnostics(),
+        &bytes,
+        manifest.program,
+        scip_output,
+    )? {
         eprintln!("{note}");
     }
     // Snapshot each document's disk hash NOW, the instant the subprocess finished — this is the
@@ -354,17 +367,21 @@ pub fn produce_scip_with_tool(
 /// (no usable index); `Ok(None)` → accept silently (clean exit); `Ok(Some(note))` → accept but the
 /// caller should print `note` (a non-zero exit that was TOLERATED).
 ///
-/// A SCIP indexer's exit CODE often reflects source DIAGNOSTICS, not indexing failure: scip-python
-/// (pyright) exits 1 whenever the analyzed project has type errors — true of most real-world Python
-/// (e.g. Django) — while still emitting a complete, valid index. So a non-zero exit is tolerated
-/// ONLY when the tool produced JOIN-USABLE data: a parseable index with ≥1 occurrence. That's
-/// stricter than "≥1 document" on purpose — an early-bailing indexer can leave an empty doc shell,
-/// and on the non-health-gated paths (`oracle run`, auto-run) that would otherwise be recorded as a
-/// completed run with no compiler data, suppressing the "no oracle run" hint (#198 review). A clean
-/// exit needs only non-empty bytes (downstream join + health gate validate the rest). Pulled out as
-/// a pure fn so the accept/bail branches are unit-testable without spawning a tool.
+/// `tolerate_diagnostic_exit` (= [`OracleTool::exit_code_reflects_diagnostics`]) gates the only
+/// relaxation: a non-zero exit is accepted ONLY for a backend whose exit code reflects source
+/// DIAGNOSTICS rather than indexing failure (scip-python/pyright exits 1 on type errors — true of
+/// most real-world Python — while still emitting a complete, valid index), AND only when the tool
+/// produced JOIN-USABLE data (a parseable index with ≥1 occurrence). Stricter than "≥1 document" on
+/// purpose — an early-bailing indexer can leave an empty doc shell, and on the non-health-gated
+/// paths (`oracle run`, auto-run) that would otherwise be recorded as a completed run with no
+/// compiler data, suppressing the "no oracle run" hint. For every other backend a non-zero exit is
+/// a genuine failure (a crashed/killed rust-analyzer/scip-clang that left a partial-but-parseable
+/// `.scip` must NOT be accepted) and bails. A clean exit needs only non-empty bytes (the downstream
+/// join and health gate validate the rest). Pure fn so the accept/bail branches are unit-testable
+/// without spawning a tool (#198 review).
 fn accept_produced_index(
     status_success: bool,
+    tolerate_diagnostic_exit: bool,
     bytes: &[u8],
     program: &str,
     output: &Path,
@@ -374,6 +391,13 @@ fn accept_produced_index(
             anyhow::bail!("{program} produced no readable index at {}", output.display());
         }
         return Ok(None);
+    }
+    if !tolerate_diagnostic_exit {
+        anyhow::bail!(
+            "{program} scip exited non-zero (its exit code signals a real failure, not source \
+             diagnostics) — no usable index at {}",
+            output.display()
+        );
     }
     let occurrences = scip::ScipIndex::total_occurrences(bytes).unwrap_or(0);
     if bytes.is_empty() || occurrences == 0 {
@@ -386,7 +410,7 @@ fn accept_produced_index(
     }
     Ok(Some(format!(
         "note: {program} exited non-zero but produced a usable index ({occurrences} occurrences) \
-         — proceeding (a SCIP indexer's exit code reflects source diagnostics, not indexing \
+         — proceeding (this backend's exit code reflects source diagnostics, not indexing \
          failure); the health gate still guards the numbers"
     )))
 }
@@ -657,6 +681,20 @@ impl OracleTool {
             "scip-java" => Some(Self::ScipJava),
             _ => None,
         }
+    }
+
+    /// Whether this backend's non-zero EXIT CODE reflects source DIAGNOSTICS rather than indexing
+    /// failure — i.e. it can exit non-zero while still emitting a complete, valid index. Only such
+    /// tools get the diagnostic-exit tolerance in [`produce_scip_with_tool`]; for every other
+    /// backend a non-zero exit is a genuine failure and bails, so a crashed/killed
+    /// rust-analyzer/scip-clang that leaves a partial-but-parseable `.scip` is NOT recorded as a
+    /// completed run on the non-health-gated paths (#198 review).
+    ///
+    /// `scip-python` (pyright) exits 1 whenever the analyzed project has type errors — true of most
+    /// real-world Python. Restricted to this one verified case; broaden (e.g. scip-typescript, also
+    /// a compiler frontend) only with evidence a real corpus needs it.
+    pub(crate) fn exit_code_reflects_diagnostics(self) -> bool {
+        matches!(self, Self::ScipPython)
     }
 
     /// The position encoding to assume for SCIP documents this tool emits **without** an explicit

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -313,6 +313,13 @@ pub fn produce_scip_with_tool(
     // `[N/M] Indexed …`) would otherwise corrupt that JSON. A piped child + a copy thread keeps
     // the progress live on stderr (where rust-analyzer's already goes) while stdout stays clean.
     command.stdout(std::process::Stdio::piped());
+    // Remove any pre-existing file at the output path BEFORE spawning, so the bytes we read after
+    // the run are provably THIS child's. Otherwise a stale `.scip` (a killed prior run left its
+    // PID-named file in the db dir, or an API caller reused the path) that the new indexer exits
+    // non-zero without overwriting would be read, parse fine, and — under the diagnostic-exit
+    // tolerance below — get its production hash captured against the CURRENT checkout and joined as
+    // if it were this run's output (#198 review).
+    let _ = std::fs::remove_file(scip_output);
     let mut child = command
         .spawn()
         .map_err(|err| anyhow::anyhow!("failed to invoke {}: {err}", manifest.program))?;
@@ -327,36 +334,42 @@ pub fn produce_scip_with_tool(
         .wait()
         .map_err(|err| anyhow::anyhow!("failed waiting for {}: {err}", manifest.program))?;
     let _ = forwarder.join();
-    // A SCIP indexer's exit CODE often reflects source DIAGNOSTICS, not indexing failure:
-    // scip-python (pyright) exits 1 whenever the analyzed project has type errors — true of most
-    // real-world Python projects (e.g. Django) — while still emitting a complete, valid index.
-    // So the contract "present tool that FAILS to produce SCIP → error" is keyed on whether a
-    // USABLE index was produced (non-empty + parses to ≥1 document), not on the exit code. A
-    // degenerate/partial index still trips the per-corpus health gate (min edges/examined/monikers)
-    // downstream, so accepting a parseable index here doesn't let a broken run masquerade as
-    // healthy. A non-zero exit with NO usable index remains a hard error.
     let bytes = std::fs::read(scip_output).unwrap_or_default();
-    let usable_documents =
-        scip::ScipIndex::document_relative_paths(&bytes).map(|paths| paths.len()).unwrap_or(0);
-    if bytes.is_empty() || usable_documents == 0 {
-        if !status.success() {
+    if status.success() {
+        // Successful exit: require a readable index; the prior behavior (parse-validity is checked
+        // by the join + health gate downstream).
+        if bytes.is_empty() {
             anyhow::bail!(
-                "{} scip exited with status {status} and produced no usable index at {}",
+                "{} produced no readable index at {}",
                 manifest.program,
                 scip_output.display()
             );
         }
-        anyhow::bail!(
-            "{} produced no readable/parseable index at {}",
-            manifest.program,
-            scip_output.display()
-        );
-    }
-    if !status.success() {
+    } else {
+        // A SCIP indexer's exit CODE often reflects source DIAGNOSTICS, not indexing failure:
+        // scip-python (pyright) exits 1 whenever the analyzed project has type errors — true of
+        // most real-world Python projects (e.g. Django) — while still emitting a complete,
+        // valid index. So a non-zero exit is tolerated ONLY when the tool actually produced
+        // JOIN-USABLE data: a parseable index with ≥1 occurrence. This is stricter than "≥1
+        // document" on purpose — an indexer that bailed early can leave an empty doc shell,
+        // and on the non-health-gated paths (`oracle run`, auto-run) that would otherwise
+        // be recorded as a completed run with no compiler data, suppressing the "no oracle
+        // run" hint (#198 review). An empty/unparseable index on a non-zero exit stays a
+        // hard error.
+        let occurrences = scip::ScipIndex::total_occurrences(&bytes).unwrap_or(0);
+        if bytes.is_empty() || occurrences == 0 {
+            anyhow::bail!(
+                "{} scip exited with status {status} and produced no usable index at {} ({} \
+                 bytes, {occurrences} occurrences)",
+                manifest.program,
+                scip_output.display(),
+                bytes.len()
+            );
+        }
         eprintln!(
-            "note: {} exited with status {status} but produced a parseable index \
-             ({usable_documents} documents) — proceeding (a SCIP indexer's exit code reflects \
-             source diagnostics, not indexing failure); the health gate still guards the numbers",
+            "note: {} exited with status {status} but produced a usable index ({occurrences} \
+             occurrences) — proceeding (a SCIP indexer's exit code reflects source diagnostics, \
+             not indexing failure); the health gate still guards the numbers",
             manifest.program
         );
     }

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -335,43 +335,10 @@ pub fn produce_scip_with_tool(
         .map_err(|err| anyhow::anyhow!("failed waiting for {}: {err}", manifest.program))?;
     let _ = forwarder.join();
     let bytes = std::fs::read(scip_output).unwrap_or_default();
-    if status.success() {
-        // Successful exit: require a readable index; the prior behavior (parse-validity is checked
-        // by the join + health gate downstream).
-        if bytes.is_empty() {
-            anyhow::bail!(
-                "{} produced no readable index at {}",
-                manifest.program,
-                scip_output.display()
-            );
-        }
-    } else {
-        // A SCIP indexer's exit CODE often reflects source DIAGNOSTICS, not indexing failure:
-        // scip-python (pyright) exits 1 whenever the analyzed project has type errors — true of
-        // most real-world Python projects (e.g. Django) — while still emitting a complete,
-        // valid index. So a non-zero exit is tolerated ONLY when the tool actually produced
-        // JOIN-USABLE data: a parseable index with ≥1 occurrence. This is stricter than "≥1
-        // document" on purpose — an indexer that bailed early can leave an empty doc shell,
-        // and on the non-health-gated paths (`oracle run`, auto-run) that would otherwise
-        // be recorded as a completed run with no compiler data, suppressing the "no oracle
-        // run" hint (#198 review). An empty/unparseable index on a non-zero exit stays a
-        // hard error.
-        let occurrences = scip::ScipIndex::total_occurrences(&bytes).unwrap_or(0);
-        if bytes.is_empty() || occurrences == 0 {
-            anyhow::bail!(
-                "{} scip exited with status {status} and produced no usable index at {} ({} \
-                 bytes, {occurrences} occurrences)",
-                manifest.program,
-                scip_output.display(),
-                bytes.len()
-            );
-        }
-        eprintln!(
-            "note: {} exited with status {status} but produced a usable index ({occurrences} \
-             occurrences) — proceeding (a SCIP indexer's exit code reflects source diagnostics, \
-             not indexing failure); the health gate still guards the numbers",
-            manifest.program
-        );
+    if let Some(note) =
+        accept_produced_index(status.success(), &bytes, manifest.program, scip_output)?
+    {
+        eprintln!("{note}");
     }
     // Snapshot each document's disk hash NOW, the instant the subprocess finished — this is the
     // content the `.scip` describes. The join later pins its occurrence offsets to these hashes so
@@ -381,6 +348,47 @@ pub fn produce_scip_with_tool(
     // omitted (its candidate then fails the gate and is skipped — the safe direction).
     let production_sha = snapshot_document_disk_hashes(&bytes, checkout_root);
     Ok(ScipProduction::Produced { version, bytes, production_sha })
+}
+
+/// Decide whether a finished tool run's output `bytes` is an acceptable SCIP index. `Err` → bail
+/// (no usable index); `Ok(None)` → accept silently (clean exit); `Ok(Some(note))` → accept but the
+/// caller should print `note` (a non-zero exit that was TOLERATED).
+///
+/// A SCIP indexer's exit CODE often reflects source DIAGNOSTICS, not indexing failure: scip-python
+/// (pyright) exits 1 whenever the analyzed project has type errors — true of most real-world Python
+/// (e.g. Django) — while still emitting a complete, valid index. So a non-zero exit is tolerated
+/// ONLY when the tool produced JOIN-USABLE data: a parseable index with ≥1 occurrence. That's
+/// stricter than "≥1 document" on purpose — an early-bailing indexer can leave an empty doc shell,
+/// and on the non-health-gated paths (`oracle run`, auto-run) that would otherwise be recorded as a
+/// completed run with no compiler data, suppressing the "no oracle run" hint (#198 review). A clean
+/// exit needs only non-empty bytes (downstream join + health gate validate the rest). Pulled out as
+/// a pure fn so the accept/bail branches are unit-testable without spawning a tool.
+fn accept_produced_index(
+    status_success: bool,
+    bytes: &[u8],
+    program: &str,
+    output: &Path,
+) -> anyhow::Result<Option<String>> {
+    if status_success {
+        if bytes.is_empty() {
+            anyhow::bail!("{program} produced no readable index at {}", output.display());
+        }
+        return Ok(None);
+    }
+    let occurrences = scip::ScipIndex::total_occurrences(bytes).unwrap_or(0);
+    if bytes.is_empty() || occurrences == 0 {
+        anyhow::bail!(
+            "{program} scip exited non-zero and produced no usable index at {} ({} bytes, \
+             {occurrences} occurrences)",
+            output.display(),
+            bytes.len()
+        );
+    }
+    Ok(Some(format!(
+        "note: {program} exited non-zero but produced a usable index ({occurrences} occurrences) \
+         — proceeding (a SCIP indexer's exit code reflects source diagnostics, not indexing \
+         failure); the health gate still guards the numbers"
+    )))
 }
 
 /// Hash each `.scip` document's CURRENT disk bytes under `checkout_root`, returning `relative_path

--- a/crates/rag-rat-core/src/index/oracle/scip.rs
+++ b/crates/rag-rat-core/src/index/oracle/scip.rs
@@ -108,6 +108,18 @@ impl ScipIndex {
         Ok(index.documents.iter().map(|document| document.relative_path.clone()).collect())
     }
 
+    /// Total raw occurrence count across all documents — a cheap "did the indexer actually emit
+    /// resolvable data?" signal (raw protobuf count, no per-document position conversion). A
+    /// parseable index with ZERO occurrences is an empty shell the join can't use; the diagnostic-
+    /// exit tolerance in `produce_scip_with_tool` requires this to be non-zero before accepting a
+    /// non-zero tool exit, so an indexer that bailed early (leaving only an empty doc list) isn't
+    /// recorded as a completed run on the non-health-gated paths (#198 review).
+    pub(crate) fn total_occurrences(bytes: &[u8]) -> anyhow::Result<usize> {
+        let index = Index::parse_from_bytes(bytes)
+            .map_err(|err| anyhow::anyhow!("failed to parse SCIP index: {err}"))?;
+        Ok(index.documents.iter().map(|document| document.occurrences.len()).sum())
+    }
+
     /// Build the maps from an already-deserialized [`Index`] — the entry point tests use after
     /// constructing an `Index` programmatically.
     pub(crate) fn from_index(

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -332,6 +332,44 @@ fn total_occurrences_counts_data_and_distinguishes_an_empty_shell() {
     assert!(ScipIndex::total_occurrences(b"not a scip index").is_err());
 }
 
+#[test]
+fn accept_produced_index_tolerates_diagnostic_exit_only_with_usable_data() {
+    use std::path::Path;
+
+    use super::accept_produced_index;
+    let p = Path::new("/tmp/out.scip");
+    let data =
+        scip_bytes("a.py", PositionEncoding::UTF8CodeUnitOffsetFromLineStart, vec![occurrence(
+            0,
+            0,
+            3,
+            "scip x `a`/foo().",
+            SymbolRole::Definition as i32,
+        )]);
+    let empty_shell = scip_bytes("a.py", PositionEncoding::UTF8CodeUnitOffsetFromLineStart, vec![]);
+
+    // Clean exit: needs only non-empty bytes (join + health gate validate the rest); an empty doc
+    // shell is fine here (a 0-occurrence run trips the health gate downstream, not this).
+    assert!(accept_produced_index(true, &data, "scip-python", p).unwrap().is_none());
+    assert!(accept_produced_index(true, &empty_shell, "scip-python", p).unwrap().is_none());
+    assert!(
+        accept_produced_index(true, b"", "scip-python", p).is_err(),
+        "clean exit, no bytes → bail"
+    );
+
+    // Non-zero (diagnostic) exit: tolerated ONLY with join-usable occurrences.
+    let note = accept_produced_index(false, &data, "scip-python", p).unwrap();
+    assert!(note.expect("tolerated note").contains("1 occurrences"));
+    assert!(
+        accept_produced_index(false, &empty_shell, "scip-python", p).is_err(),
+        "non-zero exit + empty doc shell (0 occurrences) → bail"
+    );
+    assert!(
+        accept_produced_index(false, b"", "scip-python", p).is_err(),
+        "non-zero exit + no index → bail"
+    );
+}
+
 /// Hex SHA-256 of bytes — the same hash `files.sha256` carries, so a test file's recorded sha
 /// matches the disk-byte hash the oracle's content-integrity gate computes (finding 2).
 fn sha256_hex(bytes: &[u8]) -> String {

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -314,6 +314,24 @@ fn scip_bytes(path: &str, encoding: PositionEncoding, occurrences: Vec<Occurrenc
     index.write_to_bytes().unwrap()
 }
 
+#[test]
+fn total_occurrences_counts_data_and_distinguishes_an_empty_shell() {
+    use super::scip::ScipIndex;
+    // A real index with occurrences → the raw count; gates the diagnostic-exit tolerance in
+    // produce_scip_with_tool (#198 review) so an empty shell from an early-bailing tool isn't
+    // accepted on a non-zero exit.
+    let with_data = scip_bytes("a.py", PositionEncoding::UTF8CodeUnitOffsetFromLineStart, vec![
+        occurrence(0, 0, 3, "scip x `a`/foo().", SymbolRole::Definition as i32),
+        occurrence(1, 4, 7, "scip x `a`/foo().", 0),
+    ]);
+    assert_eq!(ScipIndex::total_occurrences(&with_data).unwrap(), 2);
+    // A parseable index with documents but ZERO occurrences — the empty shell the gate must reject.
+    let empty_shell = scip_bytes("a.py", PositionEncoding::UTF8CodeUnitOffsetFromLineStart, vec![]);
+    assert_eq!(ScipIndex::total_occurrences(&empty_shell).unwrap(), 0);
+    // Non-SCIP bytes don't parse → Err (the caller treats that as 0 / unusable).
+    assert!(ScipIndex::total_occurrences(b"not a scip index").is_err());
+}
+
 /// Hex SHA-256 of bytes — the same hash `files.sha256` carries, so a test file's recorded sha
 /// matches the disk-byte hash the oracle's content-integrity gate computes (finding 2).
 fn sha256_hex(bytes: &[u8]) -> String {

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -349,24 +349,34 @@ fn accept_produced_index_tolerates_diagnostic_exit_only_with_usable_data() {
     let empty_shell = scip_bytes("a.py", PositionEncoding::UTF8CodeUnitOffsetFromLineStart, vec![]);
 
     // Clean exit: needs only non-empty bytes (join + health gate validate the rest); an empty doc
-    // shell is fine here (a 0-occurrence run trips the health gate downstream, not this).
-    assert!(accept_produced_index(true, &data, "scip-python", p).unwrap().is_none());
-    assert!(accept_produced_index(true, &empty_shell, "scip-python", p).unwrap().is_none());
+    // shell is fine here (a 0-occurrence run trips the health gate downstream, not this). The
+    // `tolerate_diagnostic_exit` flag is irrelevant on a clean exit.
+    assert!(accept_produced_index(true, true, &data, "scip-python", p).unwrap().is_none());
     assert!(
-        accept_produced_index(true, b"", "scip-python", p).is_err(),
+        accept_produced_index(true, false, &empty_shell, "rust-analyzer", p).unwrap().is_none()
+    );
+    assert!(
+        accept_produced_index(true, true, b"", "scip-python", p).is_err(),
         "clean exit, no bytes → bail"
     );
 
-    // Non-zero (diagnostic) exit: tolerated ONLY with join-usable occurrences.
-    let note = accept_produced_index(false, &data, "scip-python", p).unwrap();
+    // Non-zero exit, DIAGNOSTIC-exit tool (scip-python): tolerated ONLY with usable occurrences.
+    let note = accept_produced_index(false, true, &data, "scip-python", p).unwrap();
     assert!(note.expect("tolerated note").contains("1 occurrences"));
     assert!(
-        accept_produced_index(false, &empty_shell, "scip-python", p).is_err(),
+        accept_produced_index(false, true, &empty_shell, "scip-python", p).is_err(),
         "non-zero exit + empty doc shell (0 occurrences) → bail"
     );
     assert!(
-        accept_produced_index(false, b"", "scip-python", p).is_err(),
+        accept_produced_index(false, true, b"", "scip-python", p).is_err(),
         "non-zero exit + no index → bail"
+    );
+
+    // Non-zero exit, NON-diagnostic tool (rust-analyzer/scip-clang): a real failure — bail even
+    // with a parseable, occurrence-bearing index (it could be a crashed run's partial output).
+    assert!(
+        accept_produced_index(false, false, &data, "rust-analyzer", p).is_err(),
+        "non-diagnostic backend's non-zero exit is a real failure → bail regardless of index"
     );
 }
 

--- a/tools/oracle-corpora.toml
+++ b/tools/oracle-corpora.toml
@@ -100,6 +100,26 @@ bindings  = { cpp = ["src", "include"] }
 # the gate instead of passing green.
 health    = { expected_min_heuristic_edges = 7000, expected_min_oracle_examined = 4500, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 700, timeout_minutes = 12 }
 
+[[corpus]]
+corpus_id = "py-django"
+tier      = "small"
+repo      = "https://github.com/django/django"
+rev       = "5.1.2"
+tool      = "scip-python"
+# A heavier Python corpus than py-rich, chosen to exercise external-import / out-of-corpus resolution
+# (#182): binding the `django/db` SUB-package (deep ORM/field/backend class hierarchies) means many
+# refs target symbols OUTSIDE the bound set — `django.core`, `django.utils`, third-party deps — so it
+# stresses the "is this name local or external?" decision the per-module import model is about.
+# Measured: 12.9k heuristic edges, ~9.2k oracle-examined, ~4.4k resolved-external, ~3.0k monikers.
+# Deps pinned inline (asgiref/sqlparse) for reproducibility (#185 item 3); scip-python needs them
+# importable in the venv to resolve cross-module references.
+prepare   = ["python -m venv .venv", ".venv/bin/pip install . \"asgiref==3.11.1\" \"sqlparse==0.5.5\""]
+bindings  = { python = ["django/db"] }
+# Floors sit ~30% below the measured numbers (catch a broken parse / unresolved venv), not as exact
+# gates. `expected_min_resolved_external` (#185 item 1) is apt here: django/db is external-heavy, so a
+# dependency/venv failure shows up as collapsed external resolution, not just a low moniker count.
+health    = { expected_min_heuristic_edges = 9000, expected_min_oracle_examined = 6000, expected_max_skipped_drifted = 0, expected_min_symbols_with_moniker = 1800, expected_min_resolved_external = 2500, timeout_minutes = 20 }
+
 # --- heavy "headline" corpora: release/dispatch only, pushed to Bencher; excluded from the PR matrix.
 
 [[corpus]]


### PR DESCRIPTION
Per #182's plan — *add a heavier Python corpus first to quantify the external-import / out-of-corpus resolution gap* before deciding whether to build the in-corpus module model.

## The corpus

`py-django` — `django/db` sub-package (django 5.1.2), **12.9k heuristic edges**. Deep ORM/field/backend class hierarchies whose references frequently target symbols *outside* the bound set (`django.core`, `django.utils`, third-party deps), so it directly stresses the "is this name local or external?" decision the module model is about — including #182's "`from ..models import X` when `models` is outside the indexed targets" case.

## Quantified gap (the deliverable)

Ran the oracle (scip-python) on py-django: **224 contradictions** (precision 3330/(3330+224) = 93.7%). Breaking them down:

| resolution_path | calls_name | implements | references_type |
|---|--:|--:|--:|
| `same_file_name` | 127 | 5 | 5 |
| `target_name_fallback` | 77 | 5 | 5 |

And by oracle target: **93 of 224 (42%)** are `oracle-external/out-of-corpus` — the heuristic bound an external/out-of-bound name to a **local same-named symbol**. That's exactly #182's gap, and **materially larger than py-requests** (where it was negligible: +3 confirmed / 0 contradicted). → justifies building the module model.

## Required fix: tolerate diagnostic exit codes

`produce_scip_with_tool` bailed on *any* non-zero tool exit. But **scip-python (pyright) exits 1 whenever the analyzed project has type errors** — true of Django and most real-world Python — while still emitting a complete, valid index (2941 documents here). So the oracle couldn't index any real Python project with diagnostics.

Now a non-zero exit is a failure only when **no usable index** (non-empty + parses to ≥1 document) was produced; a parseable index proceeds (with a `note:`), and the per-corpus **health gate** still guards the numbers. rust-analyzer / scip-clang are unaffected — they don't exit on diagnostics.

## Reproducibility + validation

- Deps pinned inline (`asgiref==3.11.1`, `sqlparse==0.5.5`) per #185 item 3.
- Health floors ~30% under measured (edges 12.9k, examined 9.2k, monikers 3.0k, resolved_external 4.4k); `expected_min_resolved_external` is apt here (django/db is external-heavy).
- **e2e**: `oracle-run.sh py-django` → healthy (exit 0), the tolerance `note:` fires for scip-python's exit 1.
- Golden hash pinned; `cargo +nightly fmt` + clippy clean; 547 core tests pass. Matrix auto-includes py-django; scip-python install path already pinned (#185).

## Follow-up

The module model itself (in-corpus Python import resolution / external suppression) remains #182's main body — this PR is the groundwork + the now-quantified justification to build it.