### PR TITLE
feat(resolve): Python external-import suppression (#182, conservative)

### DIFF
--- a/crates/rag-rat-core/src/index/edges/extract.rs
+++ b/crates/rag-rat-core/src/index/edges/extract.rs
@@ -76,6 +76,7 @@ pub(crate) fn contains_edges(symbols: &[IndexedSymbol]) -> Vec<EdgeCandidate> {
                 source_span: child.span(),
                 callee_span: None,
                 import_scope: None,
+                import_source_module: None,
                 edge_kind: EdgeKind::Contains,
                 confidence: EdgeConfidence::Exact,
             });
@@ -302,6 +303,7 @@ pub(crate) fn rust_impl_edges(
             // located identifier node, so there is no clean callee range to record (#67).
             callee_span: None,
             import_scope: None,
+            import_source_module: None,
             edge_kind: EdgeKind::Implements,
             confidence: EdgeConfidence::NameOnly,
         });
@@ -650,6 +652,14 @@ pub(crate) fn python_edges(
             // rebinding of the alias name (#174 review) — see `python_import_target`.
             let module_root = record_alias.then(|| python_module_root(node)).flatten();
             let module_id = module.map(|m| m.id());
+            // The ABSOLUTE source module (`django.core`) for classifying imported names external
+            // (#182). A relative import (text starts with `.`) is in-corpus by construction →
+            // `None` (never suppressed, conservative). `None` too when there's no
+            // module node (`from . import x` parses the dots as the relative prefix).
+            let absolute_module = module
+                .and_then(|m| m.utf8_text(text.as_bytes()).ok())
+                .map(str::trim)
+                .filter(|m| !m.is_empty() && !m.starts_with('.'));
             let mut cursor = node.walk();
             for child in node.named_children(&mut cursor) {
                 if Some(child.id()) == module_id {
@@ -662,16 +672,18 @@ pub(crate) fn python_edges(
                     record_alias,
                     import_start,
                     module_root,
+                    absolute_module,
                     out,
                 );
             }
         },
         // `import <module>` / `import <module> as alias` — Imports edge to the module, not the
-        // alias.
+        // alias. `import x` binds the qualified name `x` (you write `x.y`), not a bare name, and is
+        // left out of external classification (conservative, #182): `module_path = None`.
         "import_statement" => {
             let mut cursor = node.walk();
             for child in node.named_children(&mut cursor) {
-                python_import_target(child, text, path, false, node.start_byte(), None, out);
+                python_import_target(child, text, path, false, node.start_byte(), None, None, out);
             }
         },
         // Function / method / constructor call. Mirror the C handler: the callee is the LAST
@@ -1090,6 +1102,7 @@ fn python_import_binds_name(node: Node<'_>, name: &str, text: &str) -> bool {
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn python_import_target(
     child: Node<'_>,
     text: &str,
@@ -1097,12 +1110,26 @@ fn python_import_target(
     record_alias: bool,
     import_start: usize,
     module_root: Option<Node<'_>>,
+    // The ABSOLUTE source module of a `from <module> import <name>` (`django.core`), or `None` for
+    // a relative import / `import x` / when the module is unknown. Set on the plain name edge
+    // so resolution can classify `name` external (#182). Relative imports are in-corpus by
+    // construction, so they pass `None` and are never suppressed (conservative).
+    module_path: Option<&str>,
     out: &mut Vec<EdgeCandidate>,
 ) {
     if child.kind() == "import_list" {
         let mut cursor = child.walk();
         for clause in child.named_children(&mut cursor) {
-            python_import_target(clause, text, path, record_alias, import_start, module_root, out);
+            python_import_target(
+                clause,
+                text,
+                path,
+                record_alias,
+                import_start,
+                module_root,
+                module_path,
+                out,
+            );
         }
         return;
     }
@@ -1148,7 +1175,17 @@ fn python_import_target(
     if let Some(target) = target
         && let Some(name) = last_identifier_text(target, text)
     {
-        out.push(file_edge(path, target, text, name, EdgeKind::Imports, EdgeConfidence::NameOnly));
+        let mut edge =
+            file_edge(path, target, text, name, EdgeKind::Imports, EdgeConfidence::NameOnly);
+        // Carry the absolute source module so resolution can classify this imported name external
+        // (#182) — ONLY for a NON-aliased `from M import name` (`dotted_name`). An aliased import
+        // (`from urllib3.util import Timeout as TimeoutSauce`) binds the ALIAS, not the target, in
+        // the file; marking the target external would risk suppressing an unrelated LOCAL symbol of
+        // the target's name (the #174 regression). Relative imports / `import x` pass `None`.
+        if child.kind() != "aliased_import" {
+            edge.import_source_module = module_path.map(str::to_string);
+        }
+        out.push(edge);
     }
 }
 
@@ -1171,6 +1208,7 @@ pub(crate) fn file_edge(
         // File-level edges (imports / exports / mod) have no callee identifier to anchor (#67).
         callee_span: None,
         import_scope: None,
+        import_source_module: None,
         edge_kind,
         confidence,
     }
@@ -1200,6 +1238,7 @@ pub(crate) fn file_edge_scoped(
         source_span: span_for_node(node),
         callee_span: None,
         import_scope,
+        import_source_module: None,
         edge_kind,
         confidence,
     }
@@ -1297,6 +1336,7 @@ pub(crate) fn symbol_edge_with_context(
         source_span: span_for_node(node),
         callee_span,
         import_scope: None,
+        import_source_module: None,
         edge_kind,
         confidence,
     }

--- a/crates/rag-rat-core/src/index/edges/imports.rs
+++ b/crates/rag-rat-core/src/index/edges/imports.rs
@@ -248,6 +248,37 @@ fn path_dependency_is_in_corpus(manifest_dir: &Path, path: &str, root: &Path) ->
     }
 }
 
+/// The set of in-corpus Python module dotted paths, from indexed `.py` file paths (#182). A regular
+/// file `a/b/c.py` → module `a.b.c`; a package init `a/b/__init__.py` → package `a.b`. Paths are
+/// repo-root-relative — the root from which ABSOLUTE imports resolve — so `from a.b import x` is
+/// in-corpus iff `a.b` (or `a.b.x` as a submodule) is in this set. ASSUMES root-layout (the import
+/// root is the indexed root); a `src/`-layout package would need package-root (`__init__.py`)
+/// detection — deferred (it would only ever cause MISSED suppression, never a wrong one).
+pub(crate) fn python_module_set<'a>(paths: impl IntoIterator<Item = &'a str>) -> HashSet<String> {
+    let mut set = HashSet::new();
+    for path in paths {
+        let normalized = path.replace('\\', "/");
+        let Some(stripped) = normalized.strip_suffix(".py") else { continue };
+        let module_path = stripped.strip_suffix("/__init__").unwrap_or(stripped);
+        if !module_path.is_empty() {
+            set.insert(module_path.replace('/', "."));
+        }
+    }
+    set
+}
+
+/// Whether a plain absolute `from <module> import <name>` resolves OUTSIDE the in-corpus module set
+/// (#182): external iff NEITHER `module` NOR `module.name` (the name as a submodule) is in
+/// `in_corpus`. An external name must not bind to a local same-named symbol. Fails toward in-corpus
+/// (no suppression) — the conservative direction.
+pub(crate) fn is_external_python_module(
+    module: &str,
+    name: &str,
+    in_corpus: &HashSet<String>,
+) -> bool {
+    !in_corpus.contains(module) && !in_corpus.contains(&format!("{module}.{name}"))
+}
+
 /// Parse a Rust `use` statement into its crate root and the leaf NAMES it actually binds into
 /// scope — the only names a bare reference can resolve through. The imports edge stream enumerates
 /// every identifier under a `use` path (`use std::path::{Path, PathBuf}` emits `std::path`, `Path`,
@@ -421,6 +452,13 @@ pub(crate) struct ImportScope {
     /// this REBINDS an alias use to its in-corpus target name, rather than just flagging it
     /// external.
     python_aliases: HashMap<i64, HashMap<String, Vec<PythonAlias>>>,
+    /// Per-file Python names imported from an EXTERNAL (out-of-corpus) module: `file_id → {name}`
+    /// (#182). Populated at resolve time by classifying each plain absolute `from M import name`
+    /// against the in-corpus module set ([`python_module_set`] / [`is_external_python_module`]). A
+    /// name here makes [`Self::is_external_import`] true, so a bare reference to it is NOT bound
+    /// to a local same-named symbol — the Python mirror of the Rust crate-root suppression in
+    /// `by_file`.
+    python_external: HashMap<i64, HashSet<String>>,
 }
 
 /// One Python import alias binding: the imported target name the alias stands for, scoped to a byte
@@ -622,7 +660,20 @@ impl ImportScope {
     /// denotes that dependency's item and must NOT bind to a local same-named symbol. Fails
     /// OPEN: with no local-crate set (non-Cargo corpus / manifest scan found nothing), nothing
     /// is suppressed.
+    /// Record that `name` was imported from an external module in `file_id` (#182) — set by the
+    /// resolve-time classifier for a plain absolute `from M import name` whose `M` is
+    /// out-of-corpus.
+    pub(crate) fn add_python_external_import(&mut self, file_id: i64, name: String) {
+        self.python_external.entry(file_id).or_default().insert(name);
+    }
+
     pub(crate) fn is_external_import(&self, file_id: i64, name: &str, ref_byte: usize) -> bool {
+        // Python (#182): a name imported from an out-of-corpus module is external regardless of the
+        // Rust crate-root machinery below (which is empty for Python files). Mirrors the Rust
+        // path's role for the existing `imported_external` suppression in `resolve_symbol`.
+        if self.python_external.get(&file_id).is_some_and(|names| names.contains(name)) {
+            return true;
+        }
         let local_roots = self.roots_for_file(file_id);
         // Fail open ONLY for a non-Cargo corpus (no manifest scanned). A Cargo project with no
         // library crates (bin-only) has an empty root set but still suppresses external imports —
@@ -665,6 +716,51 @@ impl ImportScope {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn python_module_set_maps_paths_to_dotted_modules() {
+        let set = python_module_set([
+            "django/db/models/query.py",
+            "django/db/models/__init__.py",
+            "django/db/__init__.py",
+            "notpython.txt",
+        ]);
+        assert!(set.contains("django.db.models.query"));
+        assert!(set.contains("django.db.models")); // __init__.py → the package
+        assert!(set.contains("django.db"));
+        assert!(!set.contains("notpython")); // non-.py ignored
+    }
+
+    #[test]
+    fn is_external_python_module_classifies_against_the_in_corpus_set() {
+        // Only `django/db/*` is indexed (a sub-package binding).
+        let in_corpus = python_module_set([
+            "django/db/__init__.py",
+            "django/db/models/__init__.py",
+            "django/db/utils.py",
+        ]);
+        // `from django.core.exceptions import X` → module out-of-corpus → external (the #182 gap).
+        assert!(is_external_python_module("django.core.exceptions", "ValidationError", &in_corpus));
+        // `from django.db import models` → `django.db` in corpus → NOT external.
+        assert!(!is_external_python_module("django.db", "models", &in_corpus));
+        // `from django.db import connection` → name-as-submodule not needed; `django.db` in corpus.
+        assert!(!is_external_python_module("django.db", "connection", &in_corpus));
+        // `from django.db.models import Q` → `django.db.models` in corpus → NOT external.
+        assert!(!is_external_python_module("django.db.models", "Q", &in_corpus));
+        // A third-party import is external.
+        assert!(is_external_python_module("urllib3.util", "Timeout", &in_corpus));
+    }
+
+    #[test]
+    fn python_external_import_makes_is_external_import_true() {
+        let mut scope = ImportScope::new(HashSet::new());
+        scope.add_python_external_import(7, "ValidationError".to_string());
+        // The name is external in file 7 (ref_byte unused for the Python set).
+        assert!(scope.is_external_import(7, "ValidationError", 0));
+        // A different name / file is not.
+        assert!(!scope.is_external_import(7, "models", 0));
+        assert!(!scope.is_external_import(9, "ValidationError", 0));
+    }
 
     /// Helper: `(root, sorted leaves)` so the assertions don't depend on traversal order.
     fn parsed(use_text: &str) -> Option<(String, Vec<String>)> {

--- a/crates/rag-rat-core/src/index/edges/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/mod.rs
@@ -121,6 +121,13 @@ pub(crate) struct EdgeCandidate {
     /// Module-aware import scope; see [`ImportScopeRange`]. `Some` only for Rust Imports edges (a
     /// `use`'s enclosing scope, or an inline `mod`'s body range); `None` for every other edge.
     import_scope: Option<ImportScopeRange>,
+    /// The ABSOLUTE source module of a Python `from <module> import <name>` (#182): set ONLY on
+    /// the per-NAME Imports edge of a plain (non-alias) absolute from-import — the dotted
+    /// module text (`django.core.exceptions`). `None` for everything else (relative imports,
+    /// module edges, aliases, non-Python). Resolution classifies `name` external when this
+    /// module resolves to no in-corpus module, so a bare `name` reference is not bound to a
+    /// local same-named symbol.
+    import_source_module: Option<String>,
     edge_kind: EdgeKind,
     confidence: EdgeConfidence,
 }
@@ -271,6 +278,11 @@ struct CompactEdge {
     import_scope_start_byte: u32,
     import_scope_end_byte: u32,
     import_mod_id: i64,
+    /// Interned absolute Python from-import module (#182); `OptSym::NONE` for every
+    /// non-classifiable edge. In-memory only — the full-rebuild driver reads it to classify
+    /// external imports; not yet persisted to `edges_data` (incremental persistence is a
+    /// follow-up).
+    import_source_module: OptSym,
     edge_kind: EdgeKind,
     confidence: EdgeConfidence,
 }
@@ -405,6 +417,7 @@ impl FullRebuildGraph {
             import_scope_start_byte,
             import_scope_end_byte,
             import_mod_id,
+            import_source_module: self.arena.intern_opt(candidate.import_source_module.as_deref()),
             edge_kind: candidate.edge_kind,
             confidence: candidate.confidence,
         };

--- a/crates/rag-rat-core/src/index/edges/resolve/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/mod.rs
@@ -462,6 +462,18 @@ pub(crate) fn resolve_and_insert_edges(
             stmt.query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)))?;
         rows.collect::<Result<_, _>>()?
     };
+    // In-corpus Python module set for external-import classification (#182): repo-root-relative
+    // `.py` paths → dotted modules, so a plain absolute `from M import name` whose module is absent
+    // is external. Built once per pass from the active checkout's Python files (scoped `files`
+    // view).
+    let python_modules = {
+        let mut stmt =
+            conn.prepare("SELECT path FROM files WHERE language = ?1 AND kind = 'source'")?;
+        let rows = stmt
+            .query_map([Language::Python.as_str()], |row| row.get::<_, String>(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+        imports::python_module_set(rows.iter().map(String::as_str))
+    };
     for (file_id, candidate) in &edges {
         if candidate.edge_kind == EdgeKind::Imports {
             let evidence = arena.get_opt(candidate.evidence).unwrap_or("");
@@ -477,6 +489,16 @@ pub(crate) fn resolve_and_insert_edges(
                         target.to_string(),
                         candidate.import_scope_range(),
                     );
+                }
+                // External-import classification (#182): a plain absolute `from M import name`
+                // carries its module in `import_source_module`; mark `name` external when `M` is
+                // out-of-corpus, so the existing `imported_external` path suppresses binding a bare
+                // `name` reference to a local same-named symbol.
+                if let Some(module) = arena.get_opt(candidate.import_source_module)
+                    && !target.is_empty()
+                    && imports::is_external_python_module(module, target, &python_modules)
+                {
+                    import_scope.add_python_external_import(*file_id, target.to_string());
                 }
             } else {
                 import_scope.add_use(*file_id, evidence, candidate.import_scope_range());


### PR DESCRIPTION
Gives Python the external-import suppression Rust already has (`is_external_import`): a bare reference to a name imported from an **out-of-corpus module** no longer binds to a local same-named symbol. The integration is clean — `resolve_symbol` already suppresses a local bind when `imported_external` is true; this just makes that true for Python.

## How (conservative)

- **Extractor** carries each plain absolute `from M import name`'s module on the per-name edge (`EdgeCandidate.import_source_module`, interned into `CompactEdge`). **Not** aliased imports (the file binds the alias, not the target — avoids the #174 `TimeoutSauce` regression), **not** relative / `import x` (fail-open).
- **`python_module_set`** builds the in-corpus dotted-module set from indexed `.py` paths (`a/b/c.py`→`a.b.c`, `a/b/__init__.py`→`a.b`; root-layout assumption, documented).
- **`is_external_python_module`** classifies external (neither `M` nor `M.name` in-corpus).
- The **full-rebuild resolve driver** populates `ImportScope.python_external`; the existing `imported_external` path suppresses the bind. No `resolve_symbol` change.

## Measured (no regression)

| corpus | contradictions | precision | recall |
|---|---|---|---|
| py-django | 224 → **216** | 93.7 → **93.9** | 84.1 (flat) |
| py-rich | 113 → **109** | 95.0 → **95.1** | 81.3 (flat, confirm identical) |

rust/c/ts corpora are untouched (Python-only). Both Python corpora improve slightly; neither regresses recall or confirm.

## Key finding (redirects the lever to #191)

The diagnostic on py-django shows the **dominant** remaining external contradictions are **not imports** — they're method/dunder over-binding: `get` (42), `update` (9), `filter` (7), `join` (7), `__new__`, `__init__`… bound via `target_name_fallback`/`same_file_name` when the receiver is external. That's **#191 (resolver overconfidence)**, not external-import suppression — so the import gap's real ceiling here is the ~8 cut. The big precision lever is #191 (starting next).

## Scope

This wires the **full-rebuild** path (what `index --full` + the oracle corpus run use). Incremental (DB-driver) persistence of `import_source_module` (a dedicated edge column) is a documented follow-up — fail-open until then (a freshness gap, not corruption). Unit tests cover the module set, classifier, and the `ImportScope` external flag; 552 core tests pass, clippy clean.

Refs #182 (the in-corpus module model is delivered for the full-rebuild path; closes the import-suppression portion).