### PR TITLE
fix(symbol): accept a sym_<hex> handle in the ref slot (#201)

### DIFF
--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -594,6 +594,10 @@ mod name_based_tests {
         assert!(!super::selector_is_name_based(&selector(None, Some("sym_zzzz"))));
         // A real qualified name in the same slot stays name-based (heal-eligible).
         assert!(super::selector_is_name_based(&selector(None, Some("crates/x/src/a.rs::foo"))));
+        // A qualified name that merely STARTS with `sym_` (path-qualified, or a `sym_…/` path) is a
+        // name, not a handle — it keeps the #152 heal (P3 review follow-up).
+        assert!(super::selector_is_name_based(&selector(None, Some("sym_helpers.rs::build"))));
+        assert!(super::selector_is_name_based(&selector(None, Some("sym_dir/mod.rs::build"))));
         // A bare name is name-based.
         assert!(super::selector_is_name_based(&selector(Some("foo"), None)));
     }

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -503,11 +503,14 @@ impl IndexDatabase {
 /// isn't a "just added" symbol, just a stale or wrong id, so re-indexing the change set wouldn't
 /// recover it and would put a `git status` on every such miss.
 fn selector_is_name_based(selector: &crate::query::symbol::SymbolSelector) -> bool {
-    // A `sym_<hex>` handle in the ref/symbol_path slot resolves as a logical id (#201), not a name,
-    // so use the EFFECTIVE id here: a stale/mistyped handle must fail cheaply like `id`, never be
-    // misread as a name/path miss that trips the #152 zero-hit heal + reindex on every bad handle.
+    // A `sym_<hex>` handle in the ref/symbol_path slot is id-based (#201), not a name — exclude
+    // both a handle that RESOLVES and one that's merely handle-SHAPED but malformed (typo/bad
+    // hex). Either way it must fail cheaply like `id`, never be misread as a name/path miss
+    // that trips the #152 zero-hit heal + reindex (which can't recover a handle anyway) on
+    // every bad handle.
     selector.symbol_id.is_none()
         && selector.effective_logical_symbol_id().is_none()
+        && !selector.ref_is_handle_shaped()
         && (selector.symbol.is_some() || selector.symbol_path.is_some())
 }
 
@@ -586,6 +589,9 @@ mod name_based_tests {
         // tripping the #152 zero-hit heal/reindex meant for genuinely-new name/path lookups.
         let token = crate::serde_big_id::format_sym_handle(0x688b_7144_3793_b726_u64 as i64);
         assert!(!super::selector_is_name_based(&selector(None, Some(&token))));
+        // A MALFORMED handle (typo/bad hex) is still handle-SHAPED → id-based, so it also cannot
+        // trip the heal even though it doesn't parse (#201 review follow-up).
+        assert!(!super::selector_is_name_based(&selector(None, Some("sym_zzzz"))));
         // A real qualified name in the same slot stays name-based (heal-eligible).
         assert!(super::selector_is_name_based(&selector(None, Some("crates/x/src/a.rs::foo"))));
         // A bare name is name-based.

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -503,8 +503,11 @@ impl IndexDatabase {
 /// isn't a "just added" symbol, just a stale or wrong id, so re-indexing the change set wouldn't
 /// recover it and would put a `git status` on every such miss.
 fn selector_is_name_based(selector: &crate::query::symbol::SymbolSelector) -> bool {
+    // A `sym_<hex>` handle in the ref/symbol_path slot resolves as a logical id (#201), not a name,
+    // so use the EFFECTIVE id here: a stale/mistyped handle must fail cheaply like `id`, never be
+    // misread as a name/path miss that trips the #152 zero-hit heal + reindex on every bad handle.
     selector.symbol_id.is_none()
-        && selector.logical_symbol_id.is_none()
+        && selector.effective_logical_symbol_id().is_none()
         && (selector.symbol.is_some() || selector.symbol_path.is_some())
 }
 
@@ -559,3 +562,33 @@ fn annotate_completeness_with_externals(
 
 #[cfg(test)]
 mod oracle_surfacing_tests;
+
+#[cfg(test)]
+mod name_based_tests {
+    use crate::query::symbol::SymbolSelector;
+
+    fn selector(symbol: Option<&str>, symbol_path: Option<&str>) -> SymbolSelector {
+        SymbolSelector {
+            logical_symbol_id: None,
+            symbol_id: None,
+            symbol_path: symbol_path.map(str::to_string),
+            symbol: symbol.map(str::to_string),
+            language: None,
+            allow_ambiguous: false,
+            limit: 10,
+        }
+    }
+
+    #[test]
+    fn ref_slot_handle_is_not_name_based() {
+        // #201 review (P2): a `sym_<hex>` handle in the ref/symbol_path slot resolves as a logical
+        // id, so it must be treated as id-based — a stale handle then fails cheaply instead of
+        // tripping the #152 zero-hit heal/reindex meant for genuinely-new name/path lookups.
+        let token = crate::serde_big_id::format_sym_handle(0x688b_7144_3793_b726_u64 as i64);
+        assert!(!super::selector_is_name_based(&selector(None, Some(&token))));
+        // A real qualified name in the same slot stays name-based (heal-eligible).
+        assert!(super::selector_is_name_based(&selector(None, Some("crates/x/src/a.rs::foo"))));
+        // A bare name is name-based.
+        assert!(super::selector_is_name_based(&selector(Some("foo"), None)));
+    }
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -2462,6 +2462,33 @@ pub fn caller() {
         "logical exact callers: {exact_logical:?}"
     );
 
+    // #201 review (P2): feeding the candidate's `sym_<hex>` handle back through the
+    // `ref`/symbol_path slot must resolve to the logical group's members WITHOUT reporting
+    // disambiguation — every member shares that one handle, so the client has no more specific
+    // token to give. (Before the fix, `disambiguation_required` was computed from the raw
+    // 2-candidate count → a dead end.)
+    let handle = crate::serde_big_id::format_sym_handle(logical_symbol_id);
+    let by_ref_handle = db
+        .symbol_candidates(&crate::query::symbol::SymbolSelector {
+            logical_symbol_id: None,
+            symbol_id: None,
+            symbol_path: Some(handle),
+            symbol: None,
+            language: None,
+            allow_ambiguous: false,
+            limit: 10,
+        })
+        .unwrap();
+    assert_eq!(by_ref_handle.candidates.len(), 2, "handle resolves the whole cfg group");
+    assert!(
+        by_ref_handle.candidates.iter().all(|c| c.logical_symbol_id == Some(logical_symbol_id)),
+        "every member shares the queried handle"
+    );
+    assert!(
+        !by_ref_handle.disambiguation_required,
+        "a handle in the ref slot is not ambiguous: {by_ref_handle:?}"
+    );
+
     fs::remove_dir_all(root).unwrap();
 }
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -2469,15 +2469,18 @@ pub fn caller() {
     // 2-candidate count → a dead end.)
     let handle = crate::serde_big_id::format_sym_handle(logical_symbol_id);
     let by_ref_handle = db
-        .symbol_candidates(&crate::query::symbol::SymbolSelector {
-            logical_symbol_id: None,
-            symbol_id: None,
-            symbol_path: Some(handle),
-            symbol: None,
-            language: None,
-            allow_ambiguous: false,
-            limit: 10,
-        })
+        .symbol_candidates(
+            &crate::query::symbol::SymbolSelector {
+                logical_symbol_id: None,
+                symbol_id: None,
+                symbol_path: Some(handle),
+                symbol: None,
+                language: None,
+                allow_ambiguous: false,
+                limit: 10,
+            },
+            false,
+        )
         .unwrap();
     assert_eq!(by_ref_handle.candidates.len(), 2, "handle resolves the whole cfg group");
     assert!(

--- a/crates/rag-rat-core/src/query/symbol.rs
+++ b/crates/rag-rat-core/src/query/symbol.rs
@@ -101,6 +101,19 @@ pub struct SymbolSelector {
     pub limit: u32,
 }
 
+impl SymbolSelector {
+    /// The logical-symbol handle to resolve by — `logical_symbol_id` if set, else a `sym_<hex>`
+    /// handle that arrived in the `ref`/`symbol_path` slot (#201). A `symbol_lookup` candidate is
+    /// emitted with its handle as `id`, so the obvious drill-down — feeding that token back as
+    /// `ref` — used to resolve `symbol_path = "sym_…"` against qualified names, match nothing, and
+    /// return null. Routing it here (a qualified name never looks like a `sym_` handle, so there's
+    /// no ambiguity) makes the handle work in EITHER slot across every symbol-shaped tool.
+    pub fn effective_logical_symbol_id(&self) -> Option<i64> {
+        self.logical_symbol_id
+            .or_else(|| self.symbol_path.as_deref().and_then(crate::serde_big_id::parse_sym_handle))
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct SymbolDisambiguation {
     pub candidates: Vec<SymbolHit>,
@@ -142,7 +155,7 @@ pub fn select_one(
     if candidates.is_empty() {
         return Ok(Ok(None));
     }
-    if selector.logical_symbol_id.is_some() {
+    if selector.effective_logical_symbol_id().is_some() {
         return Ok(Ok(Some(candidates.remove(0))));
     }
     if needs_disambiguation(&candidates, selector.allow_ambiguous) {
@@ -207,7 +220,10 @@ fn candidates_for_selector(
     selector: &SymbolSelector,
     include_generated: bool,
 ) -> anyhow::Result<Vec<SymbolHit>> {
-    if let Some(logical_symbol_id) = selector.logical_symbol_id {
+    // `logical_symbol_id`, OR a `sym_<hex>` handle that arrived in the `symbol_path`/`ref` slot
+    // (#201) — resolve both as the logical symbol so a drilled-down candidate handle works in
+    // either slot.
+    if let Some(logical_symbol_id) = selector.effective_logical_symbol_id() {
         return lookup_logical_members(conn, logical_symbol_id, selector.limit);
     }
     if let Some(symbol_id) = selector.symbol_id {
@@ -492,4 +508,37 @@ fn enrich_symbol_hit(conn: &Connection, hit: &mut SymbolHit) -> anyhow::Result<(
         hit.logical_group_reason = Some(logical.group_reason);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn selector(logical_symbol_id: Option<i64>, symbol_path: Option<&str>) -> SymbolSelector {
+        SymbolSelector {
+            logical_symbol_id,
+            symbol_id: None,
+            symbol_path: symbol_path.map(str::to_string),
+            symbol: None,
+            language: None,
+            allow_ambiguous: false,
+            limit: 10,
+        }
+    }
+
+    #[test]
+    fn effective_logical_symbol_id_accepts_a_handle_in_either_slot() {
+        let handle = 0x688b_7144_3793_b726_u64 as i64;
+        let token = crate::serde_big_id::format_sym_handle(handle);
+        // Explicit `id` wins.
+        assert_eq!(selector(Some(handle), None).effective_logical_symbol_id(), Some(handle));
+        // #201: a sym_<hex> handle fed into the `ref`/symbol_path slot resolves as the handle.
+        assert_eq!(selector(None, Some(&token)).effective_logical_symbol_id(), Some(handle));
+        // A real qualified name is NOT a handle → falls through to the symbol_path lookup.
+        assert_eq!(
+            selector(None, Some("crates/x/src/a.rs::foo")).effective_logical_symbol_id(),
+            None
+        );
+        assert_eq!(selector(None, None).effective_logical_symbol_id(), None);
+    }
 }

--- a/crates/rag-rat-core/src/query/symbol.rs
+++ b/crates/rag-rat-core/src/query/symbol.rs
@@ -138,11 +138,13 @@ pub fn lookup_candidates(
     include_generated: bool,
 ) -> anyhow::Result<SymbolLookup> {
     let candidates = candidates_for_selector(conn, selector, include_generated)?;
-    Ok(SymbolLookup {
-        disambiguation_required: needs_disambiguation(&candidates, selector.allow_ambiguous),
-        candidates,
-        stale_files: Vec::new(),
-    })
+    // A handle — `id`, or a `sym_<hex>` in the ref/symbol_path slot (#201) — resolves to one
+    // logical symbol's members; binding to any member is binding to the same thing, so a
+    // cfg-split/overload group must NOT report disambiguation (the client has no more specific
+    // token to give). Mirrors `select_one`'s handle short-circuit.
+    let disambiguation_required = selector.effective_logical_symbol_id().is_none()
+        && needs_disambiguation(&candidates, selector.allow_ambiguous);
+    Ok(SymbolLookup { disambiguation_required, candidates, stale_files: Vec::new() })
 }
 
 pub fn select_one(

--- a/crates/rag-rat-core/src/query/symbol.rs
+++ b/crates/rag-rat-core/src/query/symbol.rs
@@ -112,6 +112,16 @@ impl SymbolSelector {
         self.logical_symbol_id
             .or_else(|| self.symbol_path.as_deref().and_then(crate::serde_big_id::parse_sym_handle))
     }
+
+    /// Whether the `ref`/`symbol_path` slot holds a value SHAPED like a `sym_<hex>` handle — it
+    /// parses, OR it starts with `sym_` but is malformed (typo, bad hex, truncated copy). A
+    /// qualified name is `path::name` and never starts with `sym_`, so a `sym_`-prefixed value is
+    /// always a handle the client copied back, never a name. Callers treat it as id-based even when
+    /// it fails to parse, so a bad handle fails cheaply instead of tripping the #152 name-miss
+    /// heal/reindex (which can never recover a handle anyway) (#201 review).
+    pub fn ref_is_handle_shaped(&self) -> bool {
+        self.symbol_path.as_deref().is_some_and(|value| value.starts_with("sym_"))
+    }
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/rag-rat-core/src/query/symbol.rs
+++ b/crates/rag-rat-core/src/query/symbol.rs
@@ -114,13 +114,16 @@ impl SymbolSelector {
     }
 
     /// Whether the `ref`/`symbol_path` slot holds a value SHAPED like a `sym_<hex>` handle — it
-    /// parses, OR it starts with `sym_` but is malformed (typo, bad hex, truncated copy). A
-    /// qualified name is `path::name` and never starts with `sym_`, so a `sym_`-prefixed value is
-    /// always a handle the client copied back, never a name. Callers treat it as id-based even when
-    /// it fails to parse, so a bad handle fails cheaply instead of tripping the #152 name-miss
-    /// heal/reindex (which can never recover a handle anyway) (#201 review).
+    /// parses, OR it starts with `sym_` but is malformed (typo, bad hex, truncated copy). A real
+    /// handle is `sym_` + hex with no separators, so we additionally require NO `::` and NO `/`:
+    /// that keeps a genuine qualified name that merely *starts* with `sym_` (e.g. a path-qualified
+    /// `sym_helpers.rs::build`, or a `sym_dir/…` path) classified as a name, so it stays eligible
+    /// for the #152 zero-hit heal. A bad-but-bare handle (`sym_zzzz`) stays id-based and fails
+    /// cheaply instead of tripping a heal/reindex that can never recover a handle (#201 review).
     pub fn ref_is_handle_shaped(&self) -> bool {
-        self.symbol_path.as_deref().is_some_and(|value| value.starts_with("sym_"))
+        self.symbol_path.as_deref().is_some_and(|value| {
+            value.starts_with("sym_") && !value.contains("::") && !value.contains('/')
+        })
     }
 }
 


### PR DESCRIPTION
Fixes #201 — reported by a coding agent in the parent repo.

## Bug
`symbol_lookup` (and the other symbol tools) return candidates carrying their handle as `id: sym_<hex>`. The obvious drill-down — feeding that token back as **`ref`** — returned `null`: `ref` maps to `symbol_path`, which resolves against qualified names, so `symbol_path="sym_abc123"` matched nothing. The disambiguation→drill-down handoff silently dead-ended.

## Fix
`SymbolSelector::effective_logical_symbol_id()` = `logical_symbol_id` if set, else a `sym_<hex>` handle parsed out of `symbol_path` (via `parse_sym_handle`). Used by `candidates_for_selector` (routes to the logical-member lookup) and `select_one`'s unambiguous-pick. A real qualified name never parses as a `sym_` handle, so there's no ambiguity — the handle now works in **either** slot (`id` or `ref`) across every symbol-shaped tool (impact_surface, find_callers, trace_callees, docs_for_symbol, memory_for_symbol, …).

## Tests
Unit test covers: explicit `id` wins, a handle in `ref` resolves, a real qualified name falls through to the symbol_path lookup, empty → none. 550 core tests pass; clippy clean.

Closes #201.