### PR TITLE
feat(graph): zero-caller find_callers is never low completeness (#200)

### DIFF
--- a/crates/rag-rat-core/src/query/graph/mod.rs
+++ b/crates/rag-rat-core/src/query/graph/mod.rs
@@ -92,6 +92,12 @@ pub struct GraphTraversalSummary {
     pub unresolved: u64,
     pub false_positive_risk: String,
     pub completeness_risk: String,
+    /// Why completeness may be worse than the counts suggest — set for a `find_callers` that found
+    /// ZERO callers (#200): a static call graph can't see callers reached via message/enum
+    /// dispatch, dynamic dispatch, trait objects, FFI, or reflection, nor entry points, so "0
+    /// callers" is not proof of none. `None` in the common case.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completeness_note: Option<String>,
 }
 
 #[derive(Debug, Default, Serialize)]

--- a/crates/rag-rat-core/src/query/graph/traverse.rs
+++ b/crates/rag-rat-core/src/query/graph/traverse.rs
@@ -251,6 +251,7 @@ pub(crate) fn traversal_summary(
             unresolved: count_col(row, 5)?,
             false_positive_risk: String::new(),
             completeness_risk: String::new(),
+            completeness_note: None,
         })
     })?;
     let hidden_unresolved = hidden_unresolved_candidate_count(
@@ -266,6 +267,23 @@ pub(crate) fn traversal_summary(
     summary.truncated = summary.total_matching_edges > u64::from(limit);
     summary.false_positive_risk = false_positive_risk(&summary, mode).to_string();
     summary.completeness_risk = completeness_risk(&summary).to_string();
+    // #200: a `find_callers` (reverse) that found ZERO candidate edges must not read `low` — a
+    // static call graph cannot prove the ABSENCE of callers. Callers reached via message/enum
+    // dispatch (the actor-channel pattern), dynamic dispatch, trait objects, FFI, or reflection
+    // are invisible, as are external/entry-point callers. Escalate a `low` to `medium` and
+    // attach a note so "0 callers" isn't trusted as complete. (Forward `trace_callees` with 0
+    // callees is a genuine leaf — left alone.)
+    if reverse && summary.total_matching_edges == 0 {
+        if summary.completeness_risk == "low" {
+            summary.completeness_risk = "medium".to_string();
+        }
+        summary.completeness_note = Some(
+            "no static callers found; a static call graph can't see callers reached via \
+             message/enum dispatch, dynamic dispatch, trait objects, FFI, or reflection, nor \
+             external/entry-point callers — 0 may be incomplete"
+                .to_string(),
+        );
+    }
     Ok(summary)
 }
 pub(crate) fn count_col(row: &rusqlite::Row<'_>, index: usize) -> rusqlite::Result<u64> {

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -676,6 +676,42 @@ fn mcp_handle_selection_disambiguates_graph_tools() {
     fs::remove_dir_all(root).unwrap();
 }
 
+#[test]
+fn find_callers_zero_callers_is_not_low_completeness() {
+    // #200: a symbol with no static callers can't be reported `low` completeness — a static graph
+    // can't see callers reached via message/enum dispatch, dynamic dispatch, trait objects, FFI, or
+    // reflection. find_callers on a call-less fn must escalate to >= medium and attach a note.
+    let root = unique_temp_root();
+    fs::create_dir_all(root.join("src")).unwrap();
+    // `orphan` is never called; `caller` calls `callee` so the graph is otherwise healthy.
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn orphan() {}\npub fn callee() {}\npub fn caller() {\n    callee();\n}\n",
+    )
+    .unwrap();
+    let config = rust_config(root.clone());
+    IndexDatabase::rebuild(&config).unwrap();
+
+    let orphan = call_tool(&config.database, "find_callers", json!({"symbol": "orphan"})).unwrap();
+    assert_eq!(orphan["summary"]["returned_count"], 0);
+    assert_ne!(
+        orphan["summary"]["completeness_risk"], "low",
+        "0 callers must not read low: {orphan:?}"
+    );
+    assert!(
+        orphan["summary"]["completeness_note"].as_str().is_some_and(|n| n.contains("dispatch")),
+        "0 callers must carry a hidden-edge note: {orphan:?}"
+    );
+
+    // A symbol WITH a resolved caller keeps its honest low risk and no note.
+    let callee = call_tool(&config.database, "find_callers", json!({"symbol": "callee"})).unwrap();
+    assert_eq!(callee["summary"]["returned_count"], 1);
+    assert_eq!(callee["summary"]["completeness_risk"], "low");
+    assert!(callee["summary"]["completeness_note"].is_null());
+
+    fs::remove_dir_all(root).unwrap();
+}
+
 fn assert_schema_requires(tools: &[Value], name: &str, field: &str) {
     let schema = tool_schema(tools, name);
     let required = schema["required"].as_array().expect("required array");


### PR DESCRIPTION
## What

`find_callers` returning **0 callers** used to report `completeness_risk: low` — but a static call graph can't prove the *absence* of callers. Callers reached via message/enum dispatch (the actor-channel pattern in #200), dynamic dispatch, trait objects, FFI, or reflection are invisible, as are external/entry-point callers. So "0 callers, low" misleads an agent into trusting 0 as complete.

## How

In `traversal_summary` (which knows the traversal direction), a **reverse** traversal with **zero candidate edges** now:
- escalates `completeness_risk` from `low` → `medium` (never downgrades an already-higher risk), and
- attaches a `completeness_note` naming the hidden-edge classes.

Forward `trace_callees` with 0 callees is a genuine leaf and is left untouched.

## Scope

This is the issue's **"at minimum, raise completeness_risk"** half. The larger half — synthetic *construct-site → handler* dispatch edges for message/enum dispatch — is designed and will follow as a separate PR (it touches extraction + a resolve-time global join + a new edge kind, and warrants its own review).

## Test

`find_callers_zero_callers_is_not_low_completeness`: a call-less `orphan` fn reports `medium` + a dispatch-mentioning note, while a fn with a resolved caller keeps honest `low` and no note. Core (552) + mcp (27) green, clippy clean.

Part of #200 (does not close it).