### PR TITLE
feat(graph): synthesize message-dispatch (actor-channel / enum) edges (#200)

### DIFF
--- a/crates/rag-rat-core/src/index/edges/extract.rs
+++ b/crates/rag-rat-core/src/index/edges/extract.rs
@@ -243,7 +243,62 @@ pub(crate) fn rust_edges(
                         .map(CalleeRange::of_node),
                 ));
             }
+            // #200 dispatch construct fact: a tuple enum-variant construction `Enum::Variant(..)`.
+            // Key off the FULL call path's last two PascalCase `::` segments, so
+            // `crate::m::Msg::Start(..)` still yields `Msg::Start` (the bare receiver would be
+            // `crate`). `Foo::new()` / `T::CONST` are excluded (tail not PascalCase).
+            if let Some(key) =
+                node.child_by_field_name("function").and_then(|f| enum_variant_key(f, text))
+            {
+                out.push(dispatch_fact(
+                    symbols,
+                    node,
+                    key,
+                    EdgeKind::DispatchConstruct,
+                    EdgeContext::default(),
+                    None,
+                ));
+            }
         },
+        "struct_expression" =>
+        // #200 dispatch construct fact: a struct enum-variant construction `Enum::Variant { .. }`.
+        {
+            if let Some(key) =
+                node.child_by_field_name("name").and_then(|n| enum_variant_key(n, text))
+            {
+                out.push(dispatch_fact(
+                    symbols,
+                    node,
+                    key,
+                    EdgeKind::DispatchConstruct,
+                    EdgeContext::default(),
+                    None,
+                ));
+            }
+        },
+        "scoped_identifier" =>
+        // #200 dispatch construct fact: a UNIT enum-variant `Enum::Stop` in a VALUE position — a
+        // call argument (`send(Msg::Stop)`), a `let` initializer (`let m = Msg::Stop;`), an
+        // assignment RHS, or a `return`/`break` value. Not a `call_expression`, so the arms above
+        // miss it. The value-position gate keeps an ordinary type/module/use path out;
+        // over-emitting for a non-enum `Foo::Bar` is harmless — synthesis only joins a
+        // variant whose head is a unique in-scope `enum`, so a non-enum head never yields a
+        // `dispatches` edge.
+        {
+            if scoped_identifier_in_value_position(node)
+                && let Some(key) = enum_variant_key(node, text)
+            {
+                out.push(dispatch_fact(
+                    symbols,
+                    node,
+                    key,
+                    EdgeKind::DispatchConstruct,
+                    EdgeContext::default(),
+                    None,
+                ));
+            }
+        },
+        "match_arm" => rust_dispatch_handle_facts(text, node, symbols, out),
         "macro_invocation" =>
             if let Some(name) = first_identifier_text(node, text) {
                 out.push(symbol_edge_with_context(
@@ -1299,6 +1354,266 @@ pub(crate) fn symbol_edge_with_context(
         import_scope: None,
         edge_kind,
         confidence,
+    }
+}
+
+/// PascalCase test for the enum/variant convention (#200): first char uppercase AND at least one
+/// lowercase — so `MlReq`/`Upsert` qualify but `new`, a SCREAMING `CONST`, and a bare `T` do not.
+fn is_pascal_case(name: &str) -> bool {
+    name.chars().next().is_some_and(char::is_uppercase) && name.chars().any(char::is_lowercase)
+}
+
+/// The `Enum::Variant` dispatch key from a scoped path node — its last two `::`-segments when BOTH
+/// are PascalCase, else `None`. Robust to longer paths (`crate::ml::MlReq::Upsert` →
+/// `MlReq::Upsert`) so a construction site and a handler arm produce the SAME key regardless of
+/// import depth (#200). Splits the node TEXT on `::` rather than counting identifier children —
+/// tree-sitter treats a `scoped_(type_)identifier` as a single identifier token, so
+/// `identifiers_under` returns the whole path as one element.
+///
+/// `Self::Variant` is rewritten to `<impl type>::Variant` using the enclosing `impl` block — `Self`
+/// is NOT a stable cross-file identity, so two unrelated enums each writing `Self::Ripe` would
+/// otherwise collapse to one key and cross-link (the actor pattern `impl MlReq { fn enqueue() {
+/// send(Self::Upsert) } }` is exactly this). With no enclosing impl type, a `Self`-headed key is
+/// dropped rather than admitted under the bare `Self` head.
+fn enum_variant_key(node: Node<'_>, text: &str) -> Option<String> {
+    let full = node.utf8_text(text.as_bytes()).ok()?;
+    let segments: Vec<&str> =
+        full.split("::").map(str::trim).filter(|segment| !segment.is_empty()).collect();
+    let n = segments.len();
+    if n < 2 || !is_pascal_case(segments[n - 1]) {
+        return None;
+    }
+    let variant = segments[n - 1];
+    let head = segments[n - 2];
+    let head = if head == "Self" {
+        enclosing_impl_type_name(node, text)?
+    } else if is_pascal_case(head) {
+        head.to_string()
+    } else {
+        return None;
+    };
+    Some(format!("{head}::{variant}"))
+}
+
+/// The base type name of the nearest enclosing `impl` block (`impl MlReq` / `impl Trait for MlReq`
+/// / `impl Foo<T>` → `MlReq` / `Foo`), or `None` when `node` is not inside an impl. Used to resolve
+/// a `Self`-headed dispatch key (#200 adversarial review). Strips generics and any module path.
+fn enclosing_impl_type_name(node: Node<'_>, text: &str) -> Option<String> {
+    let mut current = node.parent();
+    while let Some(ancestor) = current {
+        if ancestor.kind() == "impl_item" {
+            let type_node = ancestor.child_by_field_name("type")?;
+            let raw = type_node.utf8_text(text.as_bytes()).ok()?;
+            let base = raw.split('<').next().unwrap_or(raw).trim();
+            let last = base.rsplit("::").next().unwrap_or(base).trim();
+            return (!last.is_empty()).then(|| last.to_string());
+        }
+        current = ancestor.parent();
+    }
+    None
+}
+
+/// Every TOP-LEVEL `Enum::Variant` key carried by a `match` arm pattern (#200), paired with the
+/// scoped-path NODE it came from, deduped by key. Each OR-alternative contributes ONLY its outer
+/// constructor — `Msg::Start | Msg::Resume` yields both, but `Msg::Wrapped(Inner::Start)` yields
+/// only `Msg::Wrapped` (the nested payload `Inner::Start` is NOT a handled variant; including it
+/// would let an unrelated `Inner::Start` constructor be reported as a dispatch caller). The node is
+/// returned so each emitted handle fact anchors at its OWN variant span: the full-rebuild insert
+/// dedups on `(from, to_name, kind, span)` (NOT evidence), so two facts for the same delegate call
+/// would otherwise collapse to one. Empty for a non-enum pattern.
+fn pattern_enum_variant_keys<'a>(pattern: Node<'a>, text: &str) -> Vec<(String, Node<'a>)> {
+    // Unwrap `match_pattern` (which also wraps any `if`-guard) to the actual pattern / or_pattern.
+    let inner = if pattern.kind() == "match_pattern" {
+        let mut cursor = pattern.walk();
+        pattern.named_children(&mut cursor).next().unwrap_or(pattern)
+    } else {
+        pattern
+    };
+    let mut alternatives = Vec::new();
+    if inner.kind() == "or_pattern" {
+        let mut cursor = inner.walk();
+        alternatives.extend(inner.named_children(&mut cursor));
+    } else {
+        alternatives.push(inner);
+    }
+    let mut keys: Vec<(String, Node<'a>)> = Vec::new();
+    for alternative in alternatives {
+        if let Some((key, node)) = alternative_constructor_key(alternative, text)
+            && !keys.iter().any(|(existing, _)| existing == &key)
+        {
+            keys.push((key, node));
+        }
+    }
+    keys
+}
+
+/// The outer-constructor `Enum::Variant` key (+ its node) of ONE match-arm alternative — the type
+/// of a tuple/struct variant pattern, or a bare unit-variant path. `None` for a non-enum
+/// alternative (a wildcard, literal, or binding). Does NOT look inside the pattern, so a nested
+/// payload variant is not mistaken for the handled variant (#200 review).
+fn alternative_constructor_key<'a>(
+    alternative: Node<'a>,
+    text: &str,
+) -> Option<(String, Node<'a>)> {
+    let path = match alternative.kind() {
+        "tuple_struct_pattern" | "struct_pattern" => alternative.child_by_field_name("type")?,
+        "scoped_identifier" | "scoped_type_identifier" => alternative,
+        _ => return None,
+    };
+    enum_variant_key(path, text).map(|key| (key, path))
+}
+
+/// The DELEGATE call(s) a `match` arm routes to (#200): the tail call of the arm body, descending
+/// through control-flow shapes so a guard/scrutinee is never mistaken for the handler. A block →
+/// its tail expression; an `if` → both branch tails; a nested `match` → each arm's tail; `await`/
+/// `return`/`break`/parens/unsafe/try → their inner expression. A bare `call_expression` is the
+/// call itself. Anything else (a non-call tail, e.g. a literal) contributes nothing. Critically
+/// this does NOT descend into a call's arguments, so `handle(validate(x))` yields only `handle`,
+/// and `if ready() { a() } else { b() }` yields `a`/`b` — never `ready`.
+fn collect_tail_calls<'a>(node: Node<'a>, out: &mut Vec<Node<'a>>) {
+    match node.kind() {
+        "call_expression" => out.push(node),
+        "block" => {
+            let mut cursor = node.walk();
+            if let Some(tail) = node.named_children(&mut cursor).last() {
+                collect_tail_calls(tail, out);
+            }
+        },
+        "if_expression" => {
+            if let Some(consequence) = node.child_by_field_name("consequence") {
+                collect_tail_calls(consequence, out);
+            }
+            if let Some(alternative) = node.child_by_field_name("alternative") {
+                collect_tail_calls(alternative, out);
+            }
+        },
+        "else_clause"
+        | "expression_statement"
+        | "return_expression"
+        | "break_expression"
+        | "parenthesized_expression"
+        | "unsafe_block"
+        | "try_expression"
+        | "await_expression" => {
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                collect_tail_calls(child, out);
+            }
+        },
+        "match_expression" => {
+            let mut cursor = node.walk();
+            for descendant in node.named_children(&mut cursor) {
+                if descendant.kind() == "match_block" {
+                    let mut arm_cursor = descendant.walk();
+                    for arm in descendant.named_children(&mut arm_cursor) {
+                        if arm.kind() == "match_arm"
+                            && let Some(value) = arm.child_by_field_name("value")
+                        {
+                            collect_tail_calls(value, out);
+                        }
+                    }
+                }
+            }
+        },
+        _ => {},
+    }
+}
+
+/// Whether a `scoped_identifier` sits in an expression VALUE position where a unit enum-variant is
+/// being produced (#200): a call argument, a `let` initializer, an assignment RHS, or a
+/// `return`/`break` value. Excludes type/pattern/use/path positions (a `use` leaf, a `let Pat = …`
+/// pattern, a `T::Assoc` type). Field-checked where the node could be on either side (let pattern
+/// vs value, assignment left vs right).
+fn scoped_identifier_in_value_position(node: Node<'_>) -> bool {
+    let Some(parent) = node.parent() else {
+        return false;
+    };
+    match parent.kind() {
+        "arguments" | "return_expression" | "break_expression" => true,
+        "let_declaration" => parent.child_by_field_name("value") == Some(node),
+        "assignment_expression" => parent.child_by_field_name("right") == Some(node),
+        _ => false,
+    }
+}
+
+/// Build a dispatch FACT edge candidate (#200) whose `from_symbol` is the enclosing function. For a
+/// handle fact `evidence` carries the `Enum::Variant` key (safe: `resolve_symbol` never reads
+/// `evidence` for a non-import kind — only `synthesize_dispatch_edges` does), and `context` carries
+/// the same `target_qualified_name` / `receiver_hint` a normal call would, so the handler resolves
+/// identically to a `calls_name` (e.g. `self.handle(x)` / `Self::handle(x)` bind to the right
+/// method). `to_name` is the variant key (construct) or the handler name (handle). No callee range,
+/// so the SCIP oracle skips these rows.
+fn dispatch_fact(
+    symbols: &[IndexedSymbol],
+    node: Node<'_>,
+    to_name: String,
+    edge_kind: EdgeKind,
+    context: EdgeContext,
+    evidence: Option<String>,
+) -> EdgeCandidate {
+    let source = containing_symbol(symbols, node.start_byte());
+    EdgeCandidate {
+        from_symbol_id: source.map(|symbol| symbol.id),
+        from_name: source.map(|symbol| symbol.qualified_name.clone()),
+        to_name,
+        target_qualified_name: context.target_qualified_name,
+        evidence,
+        receiver_hint: context.receiver_hint,
+        source_span: span_for_node(node),
+        callee_span: None,
+        import_scope: None,
+        edge_kind,
+        confidence: EdgeConfidence::NameOnly,
+    }
+}
+
+/// Emit `DispatchHandle` facts for a `match_arm` whose pattern names one or more `Enum::Variant`s
+/// (#200): `evidence` = the variant key, `to_name` = the arm's DELEGATING call. Conservative on
+/// both ends — fires only when the pattern carries a 2-segment PascalCase enum path (an integer/`_`
+/// arm yields nothing), and binds only the tail/delegate call(s) (`collect_tail_calls`), so
+/// side-effect statements (`metrics::inc(); handle(x)`), nested argument calls
+/// (`handle(validate(x))`), and guard/scrutinee calls (`if ready() { a() }` → `a`, never `ready`)
+/// are not spurious targets. An OR-pattern arm (`A | B => handle()`) emits a fact for EACH variant.
+fn rust_dispatch_handle_facts(
+    text: &str,
+    node: Node<'_>,
+    symbols: &[IndexedSymbol],
+    out: &mut Vec<EdgeCandidate>,
+) {
+    let Some(pattern) = node.child_by_field_name("pattern") else {
+        return;
+    };
+    let keys = pattern_enum_variant_keys(pattern, text);
+    if keys.is_empty() {
+        return;
+    }
+    let Some(value) = node.child_by_field_name("value") else {
+        return;
+    };
+    let mut tail_calls = Vec::new();
+    collect_tail_calls(value, &mut tail_calls);
+    for call in &tail_calls {
+        let Some(handler) = call_target_name(*call, text) else {
+            continue;
+        };
+        let context = EdgeContext {
+            target_qualified_name: target_qualified_name(*call, text),
+            receiver_hint: scoped_receiver_name(*call, text),
+        };
+        for (key, variant_node) in &keys {
+            // Anchor each fact at its OWN variant-pattern node (not the shared delegate call), so
+            // distinct variants of an OR-pattern arm survive the span-keyed full-rebuild dedup. The
+            // handler name + call context still come from the delegate call; from_symbol resolves
+            // to the same dispatcher fn either way.
+            out.push(dispatch_fact(
+                symbols,
+                *variant_node,
+                handler.clone(),
+                EdgeKind::DispatchHandle,
+                context.clone(),
+                Some(key.clone()),
+            ));
+        }
     }
 }
 

--- a/crates/rag-rat-core/src/index/edges/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/mod.rs
@@ -31,6 +31,20 @@ pub enum EdgeKind {
     ReferencesType,
     Implements,
     Contains,
+    /// Synthesized at resolve time (#200): a `dispatches` edge from a function that CONSTRUCTS a
+    /// message/command enum variant to the handler that the matching arm calls — the actor-channel
+    /// dispatch hop a static call graph otherwise misses. NOT extracted directly; produced by
+    /// `synthesize_dispatch_edges` from the two fact kinds below.
+    Dispatches,
+    /// Internal dispatch FACT (#200), never user-visible: function `F` constructs `Enum::Variant`.
+    /// `to_name` is the 2-segment `Enum::Variant` key. Consumed by dispatch synthesis; excluded
+    /// from every user-facing edge-kind set, from PageRank, and from the oracle.
+    DispatchConstruct,
+    /// Internal dispatch FACT (#200), never user-visible: a `match`/`when` arm for `Enum::Variant`
+    /// (carried in `evidence`) whose body calls handler `to_name`. Resolution binds `to_name` to
+    /// the handler symbol; synthesis then joins it to the constructor on the variant key. Same
+    /// exclusions as `DispatchConstruct`.
+    DispatchHandle,
 }
 
 impl EdgeKind {
@@ -44,6 +58,9 @@ impl EdgeKind {
             Self::ReferencesType => "references_type",
             Self::Implements => "implements",
             Self::Contains => "contains",
+            Self::Dispatches => "dispatches",
+            Self::DispatchConstruct => "dispatch_construct",
+            Self::DispatchHandle => "dispatch_handle",
         }
     }
 }

--- a/crates/rag-rat-core/src/index/edges/resolve/dispatch.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/dispatch.rs
@@ -1,0 +1,224 @@
+//! Synthesized dispatch edges (#200).
+//!
+//! Message/actor dispatch hides a real call-graph hop: a function CONSTRUCTS an enum variant
+//! (`MlReq::Upsert { .. }`), sends it over a channel, and a `match` arm elsewhere handles it
+//! (`MlReq::Upsert { x } => self.upsert(x)`). tree-sitter sees `sender → constructs MlReq` and
+//! `handler → calls upsert`, but never `sender → upsert`, so `find_callers(upsert)` misses the
+//! sender. Extraction records two FACT edge kinds — `dispatch_construct` (fn → `Enum::Variant`
+//! key, in `to_name`) and `dispatch_handle` (`Enum::Variant` key in `evidence`, handler in
+//! `to_name`, resolved to its symbol). This pass joins them on the variant key and emits a real
+//! `dispatches` edge from each constructor to each handler.
+//!
+//! Runs AFTER resolution, over the active-checkout `files` scope view, for BOTH drivers
+//! (incremental `resolve_all_edges` and full-rebuild `resolve_and_insert_edges`). Idempotent: it
+//! drops the prior scope's `dispatches` rows first, so the incremental driver re-runs cleanly.
+
+use std::collections::HashMap;
+
+use rusqlite::{Connection, params};
+
+use crate::index::edges::{EdgeConfidence, EdgeKind, EdgeStringInterner};
+
+/// Cap on constructors × handlers materialized for one variant key. A catch-all message enum used
+/// in many sites would otherwise blow up quadratically into low-value edges; past this we skip the
+/// whole variant (counted in the returned `skipped_variants`). 64 comfortably covers real actor
+/// enums (a handful of senders, one handler arm each).
+const MAX_DISPATCH_PAIRS_PER_VARIANT: usize = 64;
+
+#[derive(Clone, Copy)]
+struct Constructor {
+    symbol_id: i64,
+    source_file_id: i64,
+    start_line: i64,
+    end_line: i64,
+}
+
+struct Handler {
+    symbol_id: i64,
+    qualified_name: String,
+    start_line: i64,
+    end_line: i64,
+}
+
+/// Outcome of a synthesis pass — how many `dispatches` edges were emitted and how many variants
+/// were skipped for exceeding the fan-out cap. Returned so the indexer can `log` the skips (silent
+/// truncation would read as "no dispatch beyond this", which isn't true).
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct DispatchSynthesis {
+    pub inserted: usize,
+    pub skipped_variants: usize,
+}
+
+pub(crate) fn synthesize_dispatch_edges(conn: &Connection) -> anyhow::Result<DispatchSynthesis> {
+    let mut interner = EdgeStringInterner::default();
+    let dispatches_kind_id = interner.get(conn, EdgeKind::Dispatches.as_str())?;
+
+    // Idempotent re-run: drop any prior synthesized dispatches in the ACTIVE scope before
+    // rebuilding them. `files` is the per-connection scope view (#89), so other checkouts are
+    // untouched.
+    conn.execute(
+        "DELETE FROM edges_data
+         WHERE edge_kind_id = ?1 AND source_file_id IN (SELECT id FROM files)",
+        params![dispatches_kind_id],
+    )?;
+
+    let constructors = collect_constructors(conn)?;
+    let handlers = collect_handlers(conn)?;
+    if constructors.is_empty() || handlers.is_empty() {
+        return Ok(DispatchSynthesis::default());
+    }
+    // Scope the join by the enum DEFINITION (#200 review): the 2-segment key (`Msg::Start`) is
+    // module-stripped, so two active enums both named `Msg` would otherwise merge — emitting
+    // dispatches from one enum's senders to the other's handlers. Skip a variant ONLY when its enum
+    // head names MULTIPLE in-scope Rust enums (genuinely ambiguous → cross-enum risk). A head with
+    // zero enum definitions is admitted: it's an alias/import (`use proto::Message as Msg`) or
+    // external type, and since both the sender and the handler write the SAME head they still refer
+    // to the same enum — gating it out would just lose the dispatch (a recall miss, not safety).
+    let ambiguous_enums = ambiguous_enum_names(conn)?;
+
+    let confidence_id = interner.get(conn, EdgeConfidence::Syntactic.as_str())?;
+    let resolution_id = interner.get(conn, "dispatch")?;
+    let mut result = DispatchSynthesis::default();
+
+    for (variant, ctors) in &constructors {
+        let Some(hands) = handlers.get(variant) else {
+            continue;
+        };
+        let enum_name = variant.split("::").next().unwrap_or("");
+        if ambiguous_enums.contains(enum_name) {
+            result.skipped_variants += 1;
+            continue;
+        }
+        if ctors.len().saturating_mul(hands.len()) > MAX_DISPATCH_PAIRS_PER_VARIANT {
+            result.skipped_variants += 1;
+            continue;
+        }
+        // Intern each handler's qualified_name once per variant (reused across constructors).
+        let mut to_name_cache: HashMap<i64, i64> = HashMap::new();
+        for ctor in ctors.values() {
+            for handler in hands.values() {
+                if ctor.symbol_id == handler.symbol_id {
+                    // A handler that constructs the same variant it handles is not a dispatch INTO
+                    // itself; skip the self-edge.
+                    continue;
+                }
+                let to_name_id = match to_name_cache.get(&handler.symbol_id) {
+                    Some(id) => *id,
+                    None => {
+                        let id = interner.get(conn, &handler.qualified_name)?;
+                        to_name_cache.insert(handler.symbol_id, id);
+                        id
+                    },
+                };
+                conn.prepare_cached(
+                    "INSERT INTO edges_data(
+                        source_file_id, from_symbol_id, to_name_id, evidence,
+                        source_start_line, source_end_line,
+                        edge_kind_id, confidence_id,
+                        to_symbol_id, target_start_line, target_end_line, resolution_id
+                     )
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                )?
+                .execute(params![
+                    ctor.source_file_id,
+                    ctor.symbol_id,
+                    to_name_id,
+                    variant, // evidence: the Enum::Variant the dispatch routes through
+                    ctor.start_line,
+                    ctor.end_line,
+                    dispatches_kind_id,
+                    confidence_id,
+                    handler.symbol_id,
+                    handler.start_line,
+                    handler.end_line,
+                    resolution_id,
+                ])?;
+                result.inserted += 1;
+            }
+        }
+    }
+    Ok(result)
+}
+
+/// `variant_key -> { constructor_symbol_id -> Constructor }`, deduped by symbol id (a fn that
+/// constructs the variant twice contributes one constructor). Active-scope only via the `files`
+/// view.
+fn collect_constructors(
+    conn: &Connection,
+) -> anyhow::Result<HashMap<String, HashMap<i64, Constructor>>> {
+    let mut stmt = conn.prepare(
+        "SELECT tn.value, d.from_symbol_id, d.source_file_id, d.source_start_line, \
+         d.source_end_line
+         FROM edges_data d
+         JOIN files ON files.id = d.source_file_id
+         JOIN edge_strings ek ON ek.id = d.edge_kind_id
+         JOIN edge_strings tn ON tn.id = d.to_name_id
+         WHERE ek.value = 'dispatch_construct' AND d.from_symbol_id IS NOT NULL",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, Constructor {
+            symbol_id: row.get(1)?,
+            source_file_id: row.get(2)?,
+            start_line: row.get(3)?,
+            end_line: row.get(4)?,
+        }))
+    })?;
+    let mut out: HashMap<String, HashMap<i64, Constructor>> = HashMap::new();
+    for row in rows {
+        let (variant, ctor) = row?;
+        out.entry(variant).or_default().entry(ctor.symbol_id).or_insert(ctor);
+    }
+    Ok(out)
+}
+
+/// `variant_key -> { handler_symbol_id -> Handler }`, deduped by handler symbol id. The handle
+/// fact's `to_name` was resolved to a symbol by the normal resolver, so we only keep arms whose
+/// handler bound to an in-corpus symbol (`to_symbol_id IS NOT NULL`) — an unresolved handler is
+/// never guessed.
+fn collect_handlers(conn: &Connection) -> anyhow::Result<HashMap<String, HashMap<i64, Handler>>> {
+    let mut stmt = conn.prepare(
+        "SELECT d.evidence, d.to_symbol_id, sym.qualified_name, sym.start_line, sym.end_line
+         FROM edges_data d
+         JOIN files ON files.id = d.source_file_id
+         JOIN edge_strings ek ON ek.id = d.edge_kind_id
+         JOIN symbols sym ON sym.id = d.to_symbol_id
+         WHERE ek.value = 'dispatch_handle' AND d.to_symbol_id IS NOT NULL AND d.evidence IS NOT \
+         NULL",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, Handler {
+            symbol_id: row.get(1)?,
+            qualified_name: row.get(2)?,
+            start_line: row.get(3)?,
+            end_line: row.get(4)?,
+        }))
+    })?;
+    let mut out: HashMap<String, HashMap<i64, Handler>> = HashMap::new();
+    for row in rows {
+        let (variant, handler) = row?;
+        out.entry(variant).or_default().entry(handler.symbol_id).or_insert(handler);
+    }
+    Ok(out)
+}
+
+/// Names of RUST `enum` symbols defined MORE THAN ONCE in the active scope (genuinely ambiguous).
+/// The dispatch join skips these so two same-named enums in different modules never merge (#200
+/// review). Scoped to `language = 'rust'` because the facts are emitted from Rust syntax and the
+/// parser also stores C/C++ `enum_specifier` definitions as `kind = 'enum'` — a C++ `enum Msg` must
+/// not make a Rust `Msg` actor enum look ambiguous. Active-scope only via the `files` view.
+fn ambiguous_enum_names(conn: &Connection) -> anyhow::Result<std::collections::HashSet<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT sym.name
+         FROM symbols sym
+         JOIN files ON files.id = sym.file_id
+         WHERE sym.kind = 'enum' AND sym.language = 'rust'
+         GROUP BY sym.name
+         HAVING COUNT(*) > 1",
+    )?;
+    let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+    let mut out = std::collections::HashSet::new();
+    for row in rows {
+        out.insert(row?);
+    }
+    Ok(out)
+}

--- a/crates/rag-rat-core/src/index/edges/resolve/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/mod.rs
@@ -2,6 +2,9 @@ use std::collections::{HashMap, HashSet};
 
 use super::*;
 
+mod dispatch;
+pub(crate) use dispatch::synthesize_dispatch_edges;
+
 /// Build an [`ImportScopeRange`] from the three dedicated edge columns, or `None` when the start
 /// byte is NULL (a non-import edge). The DB driver's twin of `CompactEdge::import_scope_range`
 /// (the full-rebuild path) — they must stay in lockstep (#61 both-driver parity).
@@ -310,6 +313,23 @@ pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
         source_start_byte,
     ) in rows
     {
+        // #200: a `dispatch_construct` fact's `to_name` is a synthetic `Enum::Variant` key, NOT a
+        // real call target — resolving it would bind a bogus `to_symbol_id` to any same-named
+        // symbol, and synthesis reads only the fact's `from_symbol_id`. Leave it
+        // unresolved. (`dispatch_handle` DOES resolve — synthesis reads its handler
+        // `to_symbol_id`.)
+        if edge_kind == EdgeKind::DispatchConstruct.as_str() {
+            let confidence_id = interner.get(conn, EdgeConfidence::NameOnly.as_str())?;
+            let resolution_id = interner.get(conn, "unresolved")?;
+            conn.prepare_cached(
+                "UPDATE edges_data
+                 SET to_symbol_id = NULL, target_start_line = NULL, target_end_line = NULL,
+                     confidence_id = ?2, resolution_id = ?3
+                 WHERE id = ?1",
+            )?
+            .execute(params![edge_id, confidence_id, resolution_id])?;
+            continue;
+        }
         // The reference's byte position drives the module-aware covering test (#61).
         let ref_byte = usize::try_from(source_start_byte).unwrap_or(0);
         // Python from-import alias rebind (#174): resolve a reference written under an alias using
@@ -396,6 +416,9 @@ pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
             resolution_id,
         ])?;
     }
+    // #200: now that the dispatch FACT rows are resolved (handlers bound to symbols), synthesize
+    // the construct→handler `dispatches` edges. Idempotent over the active scope.
+    synthesize_dispatch_edges(conn)?;
     Ok(())
 }
 /// Full-rebuild fast path: resolve every accumulated edge candidate against an in-memory symbol
@@ -539,27 +562,35 @@ pub(crate) fn resolve_and_insert_edges(
         let resolve_name = rebind.name.as_deref().unwrap_or(to_name);
         let resolve_qualified = rebind.target_qualified_name.as_deref().or(target_qualified_name);
         let resolve_receiver = rebind.receiver_hint.as_deref().or(receiver_hint);
-        let resolution = resolve_symbol(
-            ResolveSymbolRequest {
-                name: resolve_name,
-                target_qualified_name: resolve_qualified,
-                edge_kind: candidate.edge_kind.as_str(),
-                evidence,
-                receiver_hint: resolve_receiver,
-                source_file_id: *file_id,
-                source_language: index.file_language.get(file_id).copied(),
-                imported_external: import_scope.is_external_import(
-                    *file_id,
-                    short_name(to_name),
-                    ref_byte,
-                ) || import_scope.is_external_qualified_root(
-                    *file_id,
-                    target_qualified_name,
-                    ref_byte,
-                ),
-            },
-            &index,
-        );
+        // #200: a `dispatch_construct` fact's `to_name` is a synthetic `Enum::Variant` key, not a
+        // real target — never resolve it (synthesis reads only its `from_symbol_id`). Mirrors the
+        // incremental driver's skip; `dispatch_handle` DOES resolve (synthesis needs its handler
+        // id).
+        let resolution = if candidate.edge_kind == EdgeKind::DispatchConstruct {
+            None
+        } else {
+            resolve_symbol(
+                ResolveSymbolRequest {
+                    name: resolve_name,
+                    target_qualified_name: resolve_qualified,
+                    edge_kind: candidate.edge_kind.as_str(),
+                    evidence,
+                    receiver_hint: resolve_receiver,
+                    source_file_id: *file_id,
+                    source_language: index.file_language.get(file_id).copied(),
+                    imported_external: import_scope.is_external_import(
+                        *file_id,
+                        short_name(to_name),
+                        ref_byte,
+                    ) || import_scope.is_external_qualified_root(
+                        *file_id,
+                        target_qualified_name,
+                        ref_byte,
+                    ),
+                },
+                &index,
+            )
+        };
         let (to_symbol_id, confidence, target_start_line, target_end_line, reason) =
             match resolution {
                 Some((symbol, confidence, reason)) => (
@@ -640,6 +671,9 @@ pub(crate) fn resolve_and_insert_edges(
         conn.execute_batch(sql)?;
     }
     crate::index::mem_trace("edges: after index rebuild");
+    // #200: synthesize construct→handler `dispatches` edges from the resolved fact rows. Runs after
+    // the index rebuild — the few extra inserts maintain the (now rebuilt) indexes incrementally.
+    synthesize_dispatch_edges(conn)?;
     Ok(())
 }
 
@@ -980,7 +1014,10 @@ pub(crate) fn preferred_matches<'a>(
             .collect();
     }
     let preferred_kinds: &[&str] = match edge_kind {
-        "calls_name" => &["function", "method"],
+        // `dispatch_handle` (#200) is a call to the handler the match arm delegates to — resolve it
+        // with the SAME callable preference as a direct call, so a same-named type/const never wins
+        // over the handler function/method.
+        "calls_name" | "dispatch_handle" => &["function", "method"],
         "constructs" => &["struct", "class", "object"],
         "uses_macro" => &["macro"],
         "implements" => &["trait", "interface"],

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -197,7 +197,10 @@ const MAX_AUTO_HEAL_FILES_PER_CALL: usize = 4;
 // (never backfilled), so without the bump a migrated index keeps empty package scopes and the
 // global-fallback behavior forever. The file→package mapping itself is computed at LOAD time from
 // `packages` (no persisted `files.package_id`), so the re-resolve only needs the `packages` rows.
-const GRAPH_INDEX_VERSION: &str = "7";
+// 8: #200 — the graph re-extract+resolve now emits the `dispatch_construct`/`dispatch_handle` FACT
+// rows and synthesizes `dispatches` edges; without the bump a migrated v7 index would carry NO
+// dispatch edges until a manual rebuild, since the re-resolve (which re-extracts edges) never runs.
+const GRAPH_INDEX_VERSION: &str = "8";
 
 // Bumped when the DEFINITION of `files.generated` changes, so an existing index re-derives the flag
 // on next open. Incremental discovery only rewrites a file row when its sha/language/kind changes —

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -746,7 +746,7 @@ fn migration_creates_oracle_side_tables() {
         assert!(columns.contains(&expected.to_string()), "edge_oracle missing {expected}");
     }
 
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 22);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 23);
 }
 
 /// The V019 moniker migration: the `logical_symbol_monikers` table (STRICT, NO foreign key — see

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -656,6 +656,13 @@ pub(crate) fn ensure_edges_data_indexes(conn: &Connection) -> rusqlite::Result<(
 /// `last_insert_rowid()` REVERTS after an INSTEAD OF trigger ends — an insert through the view
 /// cannot read back the new edge id that way. The production insert paths write `edges_data`
 /// directly with interned ids for this reason (and for bulk speed).
+/// V023 (#200): recreate the `edges` compatibility view so its definition excludes the internal
+/// dispatch FACT rows. `ensure_edges_view` is idempotent (DROP + CREATE), so this simply rebuilds
+/// the view with the new body on an existing index; the underlying `edges_data` rows are untouched.
+pub(crate) fn apply_dispatch_edge_facts_view_exclusion(conn: &Connection) -> rusqlite::Result<()> {
+    ensure_edges_view(conn)
+}
+
 pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
     let legacy_table: Option<String> = conn
         .query_row(
@@ -733,7 +740,22 @@ pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
         LEFT JOIN edge_strings rh ON rh.id = d.receiver_hint_id
         LEFT JOIN edge_strings res ON res.id = d.resolution_id
         LEFT JOIN edge_strings ek ON ek.id = d.edge_kind_id
-        LEFT JOIN edge_strings conf ON conf.id = d.confidence_id;
+        LEFT JOIN edge_strings conf ON conf.id = d.confidence_id
+        -- #200: the internal dispatch FACT rows (`dispatch_construct`/`dispatch_handle`) are \
+         inputs
+        -- to `synthesize_dispatch_edges`, NOT real edges — the handle fact duplicates the
+        -- dispatcher's existing `calls_name`. Hide them at the compatibility view so EVERY \
+         query-layer
+        -- reader (graph traversal, repo_brief, clusters, grep-augment, orientation, …) is
+        -- structurally safe without each remembering an exclusion; the synthesized `dispatches` \
+         edge
+        -- (a real edge) stays visible. Resolution + synthesis read `edges_data` directly, so they
+        -- still see the facts. Filter on the raw `edge_kind_id` (a one-time constant subselect) \
+         so the
+        -- planner keeps the indexed-id predicates, not a value-join string compare.
+        WHERE d.edge_kind_id NOT IN (
+            SELECT id FROM edge_strings WHERE value IN ('dispatch_construct', 'dispatch_handle')
+        );
 
         -- Interning per column: `INSERT OR IGNORE` + `value NOT NULL` means a NULL string is
         -- silently skipped and its id subselect yields NULL — exactly the legacy nullability.
@@ -967,6 +989,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_020_ID => Some(20),
             MIGRATION_021_ID => Some(21),
             MIGRATION_022_ID => Some(22),
+            MIGRATION_023_ID => Some(23),
             _ => None,
         })
         .max()
@@ -998,6 +1021,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_020_ID
             | MIGRATION_021_ID
             | MIGRATION_022_ID
+            | MIGRATION_023_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1026,6 +1050,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_020_ID => migration.checksum != MIGRATION_020_CHECKSUM,
         MIGRATION_021_ID => migration.checksum != MIGRATION_021_CHECKSUM,
         MIGRATION_022_ID => migration.checksum != MIGRATION_022_CHECKSUM,
+        MIGRATION_023_ID => migration.checksum != MIGRATION_023_CHECKSUM,
         _ => false,
     }
 }

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use migrations::*;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 22;
+pub const LATEST_SCHEMA_VERSION: u32 = 23;
 const DIRTY_MIGRATION_ID: &str = "__dirty__";
 const MIGRATION_001_ID: &str = "001_sqlite_storage_baseline";
 const MIGRATION_001_CHECKSUM: &str = "sha256:rag-rat-sqlite-baseline-v1";
@@ -96,6 +96,10 @@ const MIGRATION_022_ID: &str = "022_per_package_import_scope";
 const MIGRATION_022_CHECKSUM: &str = "sha256:rag-rat-per-package-import-scope-v22";
 const MIGRATION_022_DESCRIPTION: &str = "Add packages table + dedicated edge import-scope columns \
                                          for per-package, module-aware import resolution (#61)";
+const MIGRATION_023_ID: &str = "023_dispatch_edge_facts_view_exclusion";
+const MIGRATION_023_CHECKSUM: &str = "sha256:rag-rat-dispatch-edge-facts-view-exclusion-v23";
+const MIGRATION_023_DESCRIPTION: &str = "Recreate the edges compatibility view to exclude \
+                                         internal dispatch FACT rows from query-layer reads (#200)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -305,6 +309,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_022_CHECKSUM,
         description: MIGRATION_022_DESCRIPTION,
         apply: apply_per_package_import_scope,
+    },
+    Migration {
+        id: MIGRATION_023_ID,
+        checksum: MIGRATION_023_CHECKSUM,
+        description: MIGRATION_023_DESCRIPTION,
+        apply: apply_dispatch_edge_facts_view_exclusion,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -2054,6 +2054,431 @@ fn find_callers_sees_calls_in_let_bindings() {
 }
 
 #[test]
+fn find_callers_sees_message_dispatch_via_synthetic_edge() {
+    // #200: a handler reached only through an enum-message dispatch (construct a variant in one fn,
+    // handle it in a `match` arm in another) has no static caller edge to the leaf. The synthesized
+    // `dispatches` edge connects the constructing fn to the handler the matching arm calls, so
+    // find_callers on the leaf surfaces the sender.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub enum MlReq {
+    UpsertJournalEmbedding { id: i64 },
+    Other,
+}
+
+pub fn enqueue() {
+    send(MlReq::UpsertJournalEmbedding { id: 1 });
+}
+
+fn send(_req: MlReq) {}
+
+pub fn handle(req: MlReq) {
+    match req {
+        MlReq::UpsertJournalEmbedding { id } => {
+            log_it();
+            upsert_journal_embedding(id)
+        },
+        MlReq::Other => {},
+    }
+}
+
+pub fn log_it() {}
+
+pub fn upsert_journal_embedding(_id: i64) {}
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let callers = db.find_callers("upsert_journal_embedding", 50).unwrap();
+    // The direct (calls_name) caller is the dispatcher `handle`.
+    assert!(
+        callers.iter().any(|hop| {
+            hop.edge_kind == "calls_name"
+                && hop.from_symbol.as_deref().is_some_and(|s| s.ends_with("handle"))
+        }),
+        "missing direct handler caller: {callers:?}"
+    );
+    // The synthesized dispatch caller is the constructing fn `enqueue`, via the MlReq variant.
+    let dispatch = callers
+        .iter()
+        .find(|hop| hop.edge_kind == "dispatches")
+        .expect("missing synthetic dispatch edge");
+    assert!(
+        dispatch.from_symbol.as_deref().is_some_and(|s| s.ends_with("enqueue")),
+        "dispatch edge should come from the sender: {dispatch:?}"
+    );
+    assert_eq!(
+        dispatch.evidence.as_deref(),
+        Some("MlReq::UpsertJournalEmbedding"),
+        "dispatch edge should record the routing variant as evidence"
+    );
+
+    // A symbol not reached by any dispatch arm gets no synthetic edge.
+    let send_callers = db.find_callers("send", 50).unwrap();
+    assert!(
+        send_callers.iter().all(|hop| hop.edge_kind != "dispatches"),
+        "no dispatch edge expected for a non-handler: {send_callers:?}"
+    );
+
+    // #200 review (P2 #4): a side-effect call earlier in the arm body (`log_it()`) is NOT the
+    // routed handler — only the arm's tail delegate is. `log_it` must get no dispatch caller.
+    let log_callers = db.find_callers("log_it", 50).unwrap();
+    assert!(
+        log_callers.iter().all(|hop| hop.edge_kind != "dispatches"),
+        "an arm side-effect call must not become a dispatch target: {log_callers:?}"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn dispatch_fact_rows_are_hidden_from_the_edges_view() {
+    // #200 adversarial review: the internal `dispatch_construct`/`dispatch_handle` FACT rows live
+    // in `edges_data` (needed by `synthesize_dispatch_edges`) but are EXCLUDED from the `edges`
+    // compatibility view, so every query-layer reader (repo_brief, clusters, grep-augment,
+    // orientation, traversal, …) is structurally safe without each remembering an exclusion. The
+    // synthesized `dispatches` edge IS a real edge and stays visible.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub enum MlReq { Upsert { id: i64 } }
+pub fn enqueue() { send(MlReq::Upsert { id: 1 }); }
+fn send(_r: MlReq) {}
+pub fn handle(r: MlReq) {
+    match r {
+        MlReq::Upsert { id } => upsert(id),
+    }
+}
+pub fn upsert(_id: i64) {}
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+
+    let view_count = |kind: &str| -> i64 {
+        conn.query_row("SELECT COUNT(*) FROM edges WHERE edge_kind = ?1", [kind], |r| r.get(0))
+            .unwrap()
+    };
+    let data_count = |kind: &str| -> i64 {
+        conn.query_row(
+            "SELECT COUNT(*) FROM edges_data d JOIN edge_strings ek ON ek.id = d.edge_kind_id
+             WHERE ek.value = ?1",
+            [kind],
+            |r| r.get(0),
+        )
+        .unwrap()
+    };
+
+    // The FACT rows exist in the base table but are invisible through the view.
+    assert!(data_count("dispatch_construct") > 0, "construct fact persisted in edges_data");
+    assert!(data_count("dispatch_handle") > 0, "handle fact persisted in edges_data");
+    assert_eq!(view_count("dispatch_construct"), 0, "construct fact must be hidden from the view");
+    assert_eq!(view_count("dispatch_handle"), 0, "handle fact must be hidden from the view");
+    // The synthesized real edge is visible through the view.
+    assert!(view_count("dispatches") > 0, "the synthesized dispatches edge must stay visible");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn dispatch_handles_or_patterns_guards_and_let_constructs() {
+    // #200 review: or-pattern arms emit a handle per variant; the delegate is the branch tail (a
+    // guard/scrutinee call is never a handler); a unit variant in a `let` value position is a
+    // construct.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub enum Cmd { Start, Resume, Stop }
+
+pub fn enqueue_start() { send(Cmd::Start); }
+pub fn enqueue_resume() { send(Cmd::Resume); }
+pub fn enqueue_stop() {
+    let c = Cmd::Stop;
+    send(c);
+}
+fn send(_c: Cmd) {}
+
+pub fn handle(c: Cmd) {
+    match c {
+        Cmd::Start | Cmd::Resume => run_active(),
+        Cmd::Stop => if should_stop() { run_stop() } else { run_active() },
+    }
+}
+
+pub fn should_stop() -> bool { true }
+pub fn run_active() {}
+pub fn run_stop() {}
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let dispatch_senders = |symbol: &str| -> Vec<String> {
+        db.find_callers(symbol, 50)
+            .unwrap()
+            .into_iter()
+            .filter(|hop| hop.edge_kind == "dispatches")
+            .filter_map(|hop| hop.from_symbol)
+            .collect()
+    };
+    let ends_with = |names: &[String], suffix: &str| names.iter().any(|n| n.ends_with(suffix));
+
+    // Or-pattern: both `Cmd::Start` and `Cmd::Resume` senders dispatch to `run_active`. The
+    // `Cmd::Stop` else-branch also lands on `run_active` (`enqueue_stop` constructs via a `let`).
+    let active = dispatch_senders("run_active");
+    assert!(ends_with(&active, "enqueue_start"), "or-pattern Start sender missing: {active:?}");
+    assert!(ends_with(&active, "enqueue_resume"), "or-pattern Resume sender missing: {active:?}");
+    assert!(ends_with(&active, "enqueue_stop"), "guard else-branch sender missing: {active:?}");
+
+    // Guard if-branch: `Cmd::Stop` sender dispatches to `run_stop`.
+    let stop = dispatch_senders("run_stop");
+    assert!(ends_with(&stop, "enqueue_stop"), "guard if-branch sender missing: {stop:?}");
+
+    // The guard/scrutinee call `should_stop()` is NOT a dispatch handler.
+    assert!(
+        dispatch_senders("should_stop").is_empty(),
+        "a guard/predicate call must not become a dispatch handler"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn dispatch_resolves_self_keyed_variants_per_impl() {
+    // #200 adversarial review (P1): `Self::Variant` is rewritten to the enclosing impl type, so two
+    // unrelated enums each writing `Self::Ripe` in construct + handle do NOT cross-link (the old
+    // bare `Self::Ripe` key collapsed them). A single impl's `Self::`-keyed dispatch still
+    // resolves.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub enum Apple { Ripe }
+pub enum Banana { Ripe }
+
+fn sink<T>(_t: T) {}
+
+impl Apple {
+    pub fn enqueue_apple() { sink(Self::Ripe); }
+    pub fn run_apple(self) { match self { Self::Ripe => apple_handler() } }
+}
+
+impl Banana {
+    pub fn enqueue_banana() { sink(Self::Ripe); }
+    pub fn run_banana(self) { match self { Self::Ripe => banana_handler() } }
+}
+
+pub fn apple_handler() {}
+pub fn banana_handler() {}
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let dispatch_senders = |symbol: &str| -> Vec<String> {
+        db.find_callers(symbol, 50)
+            .unwrap()
+            .into_iter()
+            .filter(|hop| hop.edge_kind == "dispatches")
+            .filter_map(|hop| hop.from_symbol)
+            .collect()
+    };
+
+    // `Self::Ripe` in `impl Apple` keys as `Apple::Ripe` (recall preserved) and does NOT reach the
+    // Banana handler (no cross-enum collapse).
+    let apple = dispatch_senders("apple_handler");
+    assert!(
+        apple.iter().any(|s| s.ends_with("enqueue_apple")),
+        "self-keyed dispatch lost: {apple:?}"
+    );
+    let banana = dispatch_senders("banana_handler");
+    assert!(
+        banana.iter().any(|s| s.ends_with("enqueue_banana")),
+        "self-keyed dispatch lost: {banana:?}"
+    );
+    assert!(
+        apple.iter().all(|s| !s.ends_with("enqueue_banana"))
+            && banana.iter().all(|s| !s.ends_with("enqueue_apple")),
+        "Self::Variant must not cross-link distinct enums: apple={apple:?} banana={banana:?}"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn dispatch_handles_await_tails_and_external_enum_heads() {
+    // #200 review: an `.await` tail still resolves the handler; and an enum head with no LOCAL
+    // definition (an imported/aliased enum) is admitted, not skipped, since both sender and handler
+    // write the same head.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub enum Job { Run }
+
+pub async fn enqueue() { dispatch(Job::Run); }
+async fn dispatch(_j: Job) {}
+pub async fn handle(j: Job) {
+    match j {
+        Job::Run => run_job().await,
+    }
+}
+pub async fn run_job() {}
+
+pub fn emit() { ship(Status::Ready); }
+fn ship(_s: Status) {}
+pub fn route(s: Status) {
+    match s {
+        Status::Ready => deliver(),
+    }
+}
+pub fn deliver() {}
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let dispatch_from = |symbol: &str, sender: &str| {
+        db.find_callers(symbol, 50).unwrap().iter().any(|hop| {
+            hop.edge_kind == "dispatches"
+                && hop.from_symbol.as_deref().is_some_and(|s| s.ends_with(sender))
+        })
+    };
+
+    // `.await` tail: `Job::Run => run_job().await` still binds `run_job`.
+    assert!(dispatch_from("run_job", "enqueue"), "await tail handler missing a dispatch caller");
+    // External/aliased head (`Status` has no local enum definition) is admitted.
+    assert!(dispatch_from("deliver", "emit"), "external enum-head dispatch missing");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn dispatch_ignores_nested_payload_variants() {
+    // #200 review: an arm pattern `Outer::Wrapped(Inner::Start) => run()` handles `Outer::Wrapped`,
+    // NOT the nested payload `Inner::Start`. A function that only constructs `Inner::Start` as data
+    // must not be reported as a dispatch caller of `run`.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub enum Outer { Wrapped(Inner) }
+pub enum Inner { Start }
+
+pub fn enqueue_outer() { send(Outer::Wrapped(Inner::Start)); }
+pub fn enqueue_inner_only() { take(Inner::Start); }
+fn send(_o: Outer) {}
+fn take(_i: Inner) {}
+
+pub fn handle(o: Outer) {
+    match o {
+        Outer::Wrapped(Inner::Start) => run(),
+    }
+}
+pub fn run() {}
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let senders: Vec<String> = db
+        .find_callers("run", 50)
+        .unwrap()
+        .into_iter()
+        .filter(|hop| hop.edge_kind == "dispatches")
+        .filter_map(|hop| hop.from_symbol)
+        .collect();
+    assert!(
+        senders.iter().any(|s| s.ends_with("enqueue_outer")),
+        "the outer-variant sender should dispatch: {senders:?}"
+    );
+    assert!(
+        senders.iter().all(|s| !s.ends_with("enqueue_inner_only")),
+        "a nested-payload variant must not be treated as the handled variant: {senders:?}"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn dispatch_join_is_scoped_to_a_unique_enum_definition() {
+    // #200 review (P2 #1): the variant key is module-stripped (`Msg::Start`), so two distinct enums
+    // both named `Msg` must NOT merge — a sender of one enum's variant must not appear as a caller
+    // of the other's handler. With the enum name ambiguous, the join is skipped entirely.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub mod a {
+    pub enum Msg { Start }
+    pub fn enqueue_a() { send_a(Msg::Start); }
+    fn send_a(_m: Msg) {}
+    pub fn handle_a(m: Msg) {
+        match m {
+            Msg::Start => run_a(),
+        }
+    }
+    pub fn run_a() {}
+}
+
+pub mod b {
+    pub enum Msg { Start }
+    pub fn enqueue_b() { send_b(Msg::Start); }
+    fn send_b(_m: Msg) {}
+    pub fn handle_b(m: Msg) {
+        match m {
+            Msg::Start => run_b(),
+        }
+    }
+    pub fn run_b() {}
+}
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    // `Msg` is ambiguous (two enums), so no dispatch edges are synthesized — crucially, NO
+    // cross-enum edge from `enqueue_a` to `run_b` (or vice versa).
+    for handler in ["run_a", "run_b"] {
+        let callers = db.find_callers(handler, 50).unwrap();
+        assert!(
+            callers.iter().all(|hop| hop.edge_kind != "dispatches"),
+            "ambiguous enum must not synthesize a (possibly cross-enum) dispatch into {handler}: \
+             {callers:?}"
+        );
+    }
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn symbol_search_excludes_generated_bindings_unless_opted_in() {
     // #202: a name/symbol_path search drowns in generated bindings (ubrn FFI output, codegen) that
     // shadow the hand-written source symbol. The real-world case is codegen living UNDER a source
@@ -7339,7 +7764,7 @@ fn v022_fresh_apply_creates_packages_and_dedicated_import_scope_columns() {
     schema::apply(&conn).unwrap();
 
     assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 22);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 23);
     assert!(conn_table_exists(&conn, "packages"), "packages table is created on a fresh apply");
 
     let package_cols = conn_table_columns(&conn, "packages");
@@ -7402,15 +7827,18 @@ fn v022_forward_migrate_adds_artifacts_to_an_older_index() {
         ALTER TABLE edges_data DROP COLUMN import_scope_end_byte;
         ALTER TABLE edges_data DROP COLUMN import_mod_id;
         DELETE FROM schema_version WHERE id = '022_per_package_import_scope';
+        -- Also drop V023 (recreates the view) so `known_version` reads the contiguous V21 below;
+        -- leaving it would make the applied-set max 23 and skip the migrate.
+        DELETE FROM schema_version WHERE id = '023_dispatch_edge_facts_view_exclusion';
         ",
     )
     .unwrap();
     assert_eq!(schema::status(&conn).unwrap().current_version, 21, "now looks like a V21 index");
     assert!(!conn_table_exists(&conn, "packages"));
 
-    // Forward-migrate: re-running apply (the Older→apply path) converges to V22.
+    // Forward-migrate: re-running apply (the Older→apply path) converges to the latest version.
     schema::apply(&conn).unwrap();
-    assert_eq!(schema::status(&conn).unwrap().current_version, 22);
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
     assert!(conn_table_exists(&conn, "packages"), "forward migrate creates packages");
     assert!(
         !conn_table_columns(&conn, "files").contains(&"package_id".to_string()),

--- a/crates/rag-rat-core/src/query/graph/mod.rs
+++ b/crates/rag-rat-core/src/query/graph/mod.rs
@@ -7,13 +7,18 @@ use rusqlite::{Connection, params_from_iter};
 use serde::Serialize;
 pub(crate) use traverse::*;
 
-const CALL_EDGE_KINDS: &[&str] = &["calls_name", "constructs"];
+// `dispatches` (#200) rides with the call kinds so find_callers/trace_callees surface the
+// construct→handler dispatch hop by default — it is exactly the missing call-graph signal. The
+// internal `dispatch_construct`/`dispatch_handle` FACT kinds are deliberately absent from every
+// set.
+const CALL_EDGE_KINDS: &[&str] = &["calls_name", "constructs", "dispatches"];
 const MACRO_EDGE_KINDS: &[&str] = &["uses_macro"];
 const REFERENCE_EDGE_KINDS: &[&str] =
     &["references_type", "imports", "exports", "contains", "implements"];
 const OPTIONAL_EDGE_KINDS: &[&str] = &[
     "calls_name",
     "constructs",
+    "dispatches",
     "uses_macro",
     "references_type",
     "imports",

--- a/crates/rag-rat-core/src/query/load_bearing.rs
+++ b/crates/rag-rat-core/src/query/load_bearing.rs
@@ -221,7 +221,11 @@ pub fn scoped_weighted_fan_in(
          JOIN files ON files.id = d.source_file_id
          JOIN edge_strings ek ON ek.id = d.edge_kind_id
          JOIN edge_strings cf ON cf.id = d.confidence_id
-         WHERE d.to_symbol_id = ?1",
+         WHERE d.to_symbol_id = ?1
+           -- Internal dispatch FACT rows (#200) are synthesis inputs, not real in-edges — the
+           -- handle fact duplicates the dispatcher's existing calls_name, so counting it would
+           -- double-weight the handler. The synthesized `dispatches` edge IS counted.
+           AND ek.value NOT IN ('dispatch_construct', 'dispatch_handle')",
     )?;
     let rows = stmt
         .query_map([to_symbol_id], |row| {

--- a/crates/rag-rat-core/src/query/pagerank.rs
+++ b/crates/rag-rat-core/src/query/pagerank.rs
@@ -32,6 +32,12 @@ const MAX_RESULTS: usize = 500;
 pub(crate) fn edge_weight(kind: &str) -> f64 {
     match kind {
         "calls_name" | "implements" => 1.0,
+        // A synthesized dispatch hop (#200) is a real control-flow dependency, weighted just below
+        // a direct call (it is a level removed: construct → handler via the message enum).
+        "dispatches" => 0.8,
+        // Internal dispatch FACT kinds (#200) are synthesis inputs, never real edges — zero weight
+        // so they contribute nothing even if a query forgets to exclude them (defense in depth).
+        "dispatch_construct" | "dispatch_handle" => 0.0,
         "references_type" | "constructs" => 0.7,
         "uses_macro" => 0.5,
         "imports" | "exports" => 0.3,
@@ -325,7 +331,11 @@ pub fn important_symbols(
          JOIN files ON files.id = d.source_file_id
          JOIN edge_strings ek ON ek.id = d.edge_kind_id
          JOIN edge_strings cf ON cf.id = d.confidence_id
-         WHERE d.from_symbol_id IS NOT NULL",
+         WHERE d.from_symbol_id IS NOT NULL
+           -- Internal dispatch FACT rows (#200) are synthesis inputs, not real edges — they'd
+           -- double-count (the handle fact duplicates the dispatcher's existing calls_name) and
+           -- inflate rank. The synthesized `dispatches` edge IS counted (it's a real dependency).
+           AND ek.value NOT IN ('dispatch_construct', 'dispatch_handle')",
     )?;
     let rows = stmt
         .query_map([], |row| {

--- a/crates/rag-rat-mcp/src/tools/catalog.rs
+++ b/crates/rag-rat-mcp/src/tools/catalog.rs
@@ -72,8 +72,10 @@ pub fn description(name: &str) -> &'static str {
         "find_callers" =>
             "Find what calls a symbol (reverse call graph), instead of grepping for call sites. \
              Returns call sites with confidence + target verification, a completeness / \
-             false-positive risk summary, and repo memories crossing the call path. Resolve the \
-             symbol with symbol_lookup first when a name is ambiguous.",
+             false-positive risk summary, and repo memories crossing the call path. Includes \
+             synthesized `dispatches` edges for message/enum (actor-channel) dispatch — the sender \
+             that constructs the variant a handler's match arm handles. Resolve the symbol with \
+             symbol_lookup first when a name is ambiguous.",
         "trace_callees" =>
             "Find what a symbol calls (forward call graph). Same evidence shape as find_callers; \
              unresolved std/common-method noise is filtered out by default (add `common_methods` / \

--- a/crates/rag-rat-mcp/src/tools/requests.rs
+++ b/crates/rag-rat-mcp/src/tools/requests.rs
@@ -87,6 +87,7 @@ impl McpGraphResolutionMode {
 pub enum McpGraphEdgeKind {
     CallsName,
     Constructs,
+    Dispatches,
     UsesMacro,
     ReferencesType,
     Imports,
@@ -100,6 +101,7 @@ impl McpGraphEdgeKind {
         match self {
             Self::CallsName => "calls_name",
             Self::Constructs => "constructs",
+            Self::Dispatches => "dispatches",
             Self::UsesMacro => "uses_macro",
             Self::ReferencesType => "references_type",
             Self::Imports => "imports",

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -200,6 +200,7 @@ fn list_tools_exposes_complete_typed_schemas() {
     assert_schema_array_item_enum(tools, "find_callers", "edge_kinds", &[
         "calls_name",
         "constructs",
+        "dispatches",
         "uses_macro",
         "references_type",
         "imports",


### PR DESCRIPTION
## What

Closes the second half of #200. A handler reached only through enum-message dispatch — construct a variant in one function, handle it in a `match` arm elsewhere (the actor-channel pattern) — had no static caller edge to the leaf, so `find_callers` returned 0. tree-sitter sees `sender → constructs Enum` and `handler → calls leaf`, but never `sender → leaf`.

(The first half — `find_callers` 0-callers no longer reads `low` completeness — shipped in #205.)

## How

A synthesized **`dispatches`** edge, formed at resolve time via a global variant-key join:

1. **Extraction (Rust)** records two internal FACT edge kinds:
   - `dispatch_construct` — fn → `Enum::Variant` key, for a tuple `Enum::Variant(..)` or struct `Enum::Variant { .. }` construction.
   - `dispatch_handle` — `Enum::Variant` key (in `evidence`) + handler (in `to_name`), for a `match` arm whose pattern names a variant and whose body calls a handler.
   - Conservative: both path segments must be PascalCase (excludes `Foo::new()`, `T::CONST`); a plain integer/`_` arm yields nothing.
2. **`synthesize_dispatch_edges`** (post-resolve, both drivers) joins constructors to handlers on the variant key and emits a `dispatches` edge from each sender to each resolved handler. Idempotent (drops the active scope's prior `dispatches` first, so incremental re-runs cleanly); fan-out capped per variant to bound a catch-all enum.

## Why it's safe

- The handler name is resolved by the **normal resolver** (the fact's `evidence` is never read by `resolve_symbol` — verified — only by synthesis), so an unresolved handler is never guessed.
- FACT rows carry **no callee range**, so the SCIP oracle (which gates on `callee_start_byte IS NOT NULL`) skips them — oracle metrics unaffected.
- FACT kinds are **excluded from PageRank** (they'd double-count the dispatcher's existing `calls_name`); the synthesized `dispatches` edge IS counted (weight 0.8, just below a direct call).
- It is purely **additive** — a new edge kind, never rewriting `calls_name`; `Syntactic` confidence, double-gated (constructed AND handled).

## Surfacing

`dispatches` rides the call edge-kind set, so `find_callers`/`trace_callees` show it by default; new `McpGraphEdgeKind::Dispatches` on the wire.

## Test

`find_callers_sees_message_dispatch_via_synthetic_edge`: an enum + sender (`enqueue` constructs `MlReq::UpsertJournalEmbedding`) + dispatcher (`handle` matches it → `upsert_journal_embedding`). `find_callers(upsert_journal_embedding)` returns both the direct `handle` (calls_name) and the synthesized `enqueue` (dispatches, evidence = the variant); a non-handler gets no dispatch edge. Core (555) + mcp (27) + cli green, clippy clean, fmt.

## Follow-up

Cross-language (TS discriminated-union reducers, Kotlin sealed-class `when`) reuses the shared synthesis — per-language fact extraction, each gated by corpus measurement. Design: `docs/plans/2026-06-17-200-dispatch-edges.md`.