### PR TITLE
fix(graph): bind let-bound dispatch handlers under a wrapper tail (#207)

### DIFF
--- a/crates/rag-rat-core/src/index/edges/extract.rs
+++ b/crates/rag-rat-core/src/index/edges/extract.rs
@@ -1463,31 +1463,317 @@ fn alternative_constructor_key<'a>(
     enum_variant_key(path, text).map(|key| (key, path))
 }
 
-/// The DELEGATE call(s) a `match` arm routes to (#200): the tail call of the arm body, descending
-/// through control-flow shapes so a guard/scrutinee is never mistaken for the handler. A block →
-/// its tail expression; an `if` → both branch tails; a nested `match` → each arm's tail; `await`/
-/// `return`/`break`/parens/unsafe/try → their inner expression. A bare `call_expression` is the
-/// call itself. Anything else (a non-call tail, e.g. a literal) contributes nothing. Critically
-/// this does NOT descend into a call's arguments, so `handle(validate(x))` yields only `handle`,
-/// and `if ready() { a() } else { b() }` yields `a`/`b` — never `ready`.
-fn collect_tail_calls<'a>(node: Node<'a>, out: &mut Vec<Node<'a>>) {
+/// The DELEGATE handler call(s) a `match` arm routes to (#200/#207/#208). Traces the calls whose
+/// result becomes the arm's RESPONSE through a CLOSED set of value adapters (wrappers,
+/// constructors, containers, field/index/cast projections) and SIMPLE `let` bindings.
+///
+/// Deliberately CONSERVATIVE rather than a full dataflow analysis (#208 review, ~7 rounds): a
+/// precise answer needs Rust value-provenance + name-resolution + mutation tracking, which leaks at
+/// every un-modeled construct. Instead, anything not in the closed model emits NOTHING (a missed
+/// edge, never a false one):
+/// - if the arm REBINDS a local anywhere (`x = ..` / `(x, _) = ..`), bail entirely — a mutated
+///   binding's value can't be tracked path-sensitively, so no edge is synthesized for the arm;
+/// - only a plain `let x = value` maps `x` to its producer; any destructuring `let` invalidates its
+///   bindings (can't attribute which producer feeds which name);
+/// - `if`/`match` contribute only branch RESULTS (never a condition/scrutinee); a single match-arm
+///   payload binding inherits the scrutinee's producer; a side-effect statement / struct field
+///   LABEL / nested handler ARGUMENT is never a handler.
+fn collect_handler_calls<'a>(node: Node<'a>, text: &str, out: &mut Vec<Node<'a>>) {
+    if arm_rebinds_local(node) {
+        return;
+    }
+    result_handler_calls(node, text, &std::collections::HashMap::new(), out);
+}
+
+/// Whether the arm body MUTATES a local through any `=`/`op=` whose target subtree contains an
+/// identifier — anywhere under `node`. That covers an identifier (`resp = ..`), a destructuring
+/// tuple/array/struct/tuple-struct (`(resp,_) = ..`, `Out { resp } = ..`), a wrapped form
+/// (`(resp) = ..`, `*p = ..`), AND a field/index store on a local (`r.id = ..`, `buf[0] = ..` —
+/// which can stale a returned `r.id`/`buf[0]` projection, #208 review round 10). Any of these can
+/// make a `let` binding's stored producer stale in ways that need real control-flow / scope
+/// dataflow, so the whole arm BAILS rather than risk a stale/false handler edge. Conservative: a
+/// field store on a non-returned place (`self.metric = ..`) also bails — accepted recall.
+fn arm_rebinds_local(node: Node<'_>) -> bool {
+    if matches!(node.kind(), "assignment_expression" | "compound_assignment_expr")
+        && let Some(left) = node.child_by_field_name("left")
+        && subtree_has_identifier(left)
+    {
+        return true;
+    }
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor).any(arm_rebinds_local)
+}
+
+/// Whether `node`'s subtree contains an `identifier` — used to decide if an assignment target can
+/// rebind/stale a local (see [`arm_rebinds_local`]).
+fn subtree_has_identifier(node: Node<'_>) -> bool {
+    if node.kind() == "identifier" {
+        return true;
+    }
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor).any(subtree_has_identifier)
+}
+
+/// See [`collect_handler_calls`]. `scope` maps an in-scope binding name to the ALREADY-RESOLVED
+/// handler calls its current value contributes (built in declaration order; a later `let` or
+/// assignment of the same name replaces the entry). A binding read just contributes its stored
+/// handlers — there is no binding→binding recursion, hence no depth/cycle guard.
+fn result_handler_calls<'a>(
+    node: Node<'a>,
+    text: &str,
+    scope: &std::collections::HashMap<String, Vec<Node<'a>>>,
+    out: &mut Vec<Node<'a>>,
+) {
     match node.kind() {
-        "call_expression" => out.push(node),
+        "call_expression" => match classify_call(node, text) {
+            // The handler — recorded, args NOT descended. (A method call on a scoped binding —
+            // `v.into()`, `worker.run()` — is recorded too: a real handler-method like `worker.run`
+            // resolves and surfaces, while a pure adapter like `v.into`/`v.clone` is a std trait
+            // method that doesn't resolve to an in-corpus symbol, so it's dropped at resolution and
+            // creates no edge — #208 review round 11.)
+            CallRole::Delegate => out.push(node),
+            CallRole::Skip => {},
+            CallRole::Wrapper =>
+            // A transparent wrapper / variant constructor returns its SINGLE wrapped value, so the
+            // handler is whatever produced it. Descend only the lone payload arg — with MULTIPLE
+            // args we can't tell which is the response (`Resp::X(handler(), metric())`). Comments
+            // are NAMED children, so filter them before counting.
+                if let Some(args) = node.child_by_field_name("arguments") {
+                    let mut cursor = args.walk();
+                    let arguments: Vec<Node<'a>> = args
+                        .named_children(&mut cursor)
+                        .filter(|arg| !matches!(arg.kind(), "line_comment" | "block_comment"))
+                        .collect();
+                    if let [only] = arguments.as_slice() {
+                        result_handler_calls(*only, text, scope, out);
+                    }
+                },
+        },
+        "identifier" => {
+            // A value-position read of a binding contributes its already-resolved handlers.
+            if let Ok(name) = node.utf8_text(text.as_bytes())
+                && let Some(handlers) = scope.get(name)
+            {
+                out.extend(handlers.iter().copied());
+            }
+        },
         "block" => {
+            // Skip comments: tree-sitter exposes `line_comment`/`block_comment` as NAMED children,
+            // so a trailing comment would otherwise masquerade as the block's tail expression.
             let mut cursor = node.walk();
-            if let Some(tail) = node.named_children(&mut cursor).last() {
-                collect_tail_calls(tail, out);
+            let children: Vec<Node<'a>> = node
+                .named_children(&mut cursor)
+                .filter(|child| !matches!(child.kind(), "line_comment" | "block_comment"))
+                .collect();
+            let Some((tail, statements)) = children.split_last() else {
+                return;
+            };
+            // Resolve `let` bindings in declaration order. Only a PLAIN `let x = value` maps `x` to
+            // its producer; a destructuring `let` (`let (a, b) = ..`, `let Out { x } = ..`) can't
+            // attribute which producer feeds which binding, so it INVALIDATES its names. (The arm
+            // has already been checked free of reassignment by `arm_rebinds_local`, so
+            // a binding's mapped value is final.)
+            let mut local = scope.clone();
+            for statement in statements {
+                if statement.kind() != "let_declaration" {
+                    continue; // a bare side-effect statement is not a handler source
+                }
+                let Some(pattern) = statement.child_by_field_name("pattern") else {
+                    continue;
+                };
+                if let Some(name) = simple_binding_name(pattern, text) {
+                    let mut handlers = Vec::new();
+                    if let Some(value) = statement.child_by_field_name("value") {
+                        result_handler_calls(value, text, &local, &mut handlers);
+                    }
+                    local.insert(name, handlers);
+                } else {
+                    let mut names = Vec::new();
+                    pattern_binding_names(pattern, text, &mut names);
+                    for name in names {
+                        local.remove(&name);
+                    }
+                }
+            }
+            let before = out.len();
+            if tail.kind() != "let_declaration" {
+                result_handler_calls(*tail, text, &local, out);
+            }
+            // EFFECT-ONLY fallback (#208, held feedback): a command/ack handler does its work in a
+            // `?`-propagated side-effecting call and returns a FIXED value (`{ self.diarize(..)?;
+            // Ok(Resp::Done) }`), so the value-trace above found nothing. Record the LAST `?`-stmt
+            // whose payload is a DIRECT delegate call (`<call>.await?` / `<call>?`). Recording the
+            // call DIRECTLY — not via scope-traced `result_handler_calls` — avoids resolving a
+            // `let`-bound `?` (`task?`) against the final block scope, which a later shadowing
+            // `let` could redirect to the wrong producer (#208 review round 11). The
+            // `?` gate + direct-call requirement excludes fire-and-forget side effects
+            // (`metrics::inc();`).
+            if out.len() == before {
+                for statement in children.iter().rev() {
+                    if statement.kind() == "expression_statement"
+                        && let Some(try_expr) = statement.named_child(0)
+                        && try_expr.kind() == "try_expression"
+                        && let Some(call) = unwrap_to_call(try_expr)
+                        && matches!(classify_call(call, text), CallRole::Delegate)
+                    {
+                        out.push(call);
+                        break;
+                    }
+                }
             }
         },
         "if_expression" => {
+            // Branch RESULTS only — the `condition` field (a guard/scrutinee) is never a handler.
+            // EXCEPT an `if let Pat = value` condition: its payload bindings are projections of
+            // `value`, so the CONSEQUENCE inherits the value's handlers (like a match arm, #208).
+            let consequence_scope = match node.child_by_field_name("condition") {
+                Some(condition) if condition.kind() == "let_condition" => {
+                    let mut scrutinee_handlers = Vec::new();
+                    if let Some(value) = condition.child_by_field_name("value") {
+                        result_handler_calls(value, text, scope, &mut scrutinee_handlers);
+                    }
+                    let mut inner = scope.clone();
+                    if let Some(pattern) = condition.child_by_field_name("pattern") {
+                        let mut bound = Vec::new();
+                        pattern_binding_names(pattern, text, &mut bound);
+                        bound.sort();
+                        bound.dedup();
+                        match bound.as_slice() {
+                            [name] => {
+                                inner.insert(name.clone(), scrutinee_handlers);
+                            },
+                            _ =>
+                                for name in bound {
+                                    inner.remove(&name);
+                                },
+                        }
+                    }
+                    inner
+                },
+                _ => scope.clone(),
+            };
             if let Some(consequence) = node.child_by_field_name("consequence") {
-                collect_tail_calls(consequence, out);
+                result_handler_calls(consequence, text, &consequence_scope, out);
             }
             if let Some(alternative) = node.child_by_field_name("alternative") {
-                collect_tail_calls(alternative, out);
+                result_handler_calls(alternative, text, scope, out);
             }
         },
-        "else_clause"
+        "match_expression" => {
+            // Each arm's RESULT only — never the scrutinee directly. An arm's pattern bindings are
+            // projections of the SCRUTINEE, so they inherit the scrutinee's resolved handlers (a
+            // returned payload `match load()? { Some(v) => Ok(Wrap(v)) }` traces `v` back to
+            // `load`). This also overrides any outer `let` of the same name, so a
+            // payload `Some(value)` never resolves to an unrelated outer `let value`
+            // (#208 review).
+            let scrutinee_handlers = match node.child_by_field_name("value") {
+                Some(scrutinee) => {
+                    let mut handlers = Vec::new();
+                    result_handler_calls(scrutinee, text, scope, &mut handlers);
+                    handlers
+                },
+                None => Vec::new(),
+            };
+            if let Some(body) = node.child_by_field_name("body") {
+                let mut arm_cursor = body.walk();
+                for arm in body.named_children(&mut arm_cursor) {
+                    if arm.kind() == "match_arm"
+                        && let Some(value) = arm.child_by_field_name("value")
+                    {
+                        let mut arm_scope = scope.clone();
+                        if let Some(pattern) = arm.child_by_field_name("pattern") {
+                            let mut bound = Vec::new();
+                            pattern_binding_names(pattern, text, &mut bound);
+                            // An or-pattern repeats the same binding per alternative
+                            // (`Ok(v) | Err(v)`); dedup so it counts as the single projected
+                            // payload.
+                            bound.sort();
+                            bound.dedup();
+                            match bound.as_slice() {
+                                // A single payload binding IS the projected scrutinee value —
+                                // inherit its handlers. Multiple
+                                // bindings can't each be the whole scrutinee
+                                // (`(resp, _span)` would credit every binding with every producer),
+                                // so mask them (#208 review).
+                                [name] => {
+                                    arm_scope.insert(name.clone(), scrutinee_handlers.clone());
+                                },
+                                _ =>
+                                    for name in bound {
+                                        arm_scope.remove(&name);
+                                    },
+                            }
+                        }
+                        result_handler_calls(value, text, &arm_scope, out);
+                    }
+                }
+            }
+        },
+        "struct_expression" => {
+            // Trace field VALUES and shorthand reads (`Resp { vector }`), never field LABELS
+            // (`Resp { status: .. }` must not match a `status` local). ONLY when there is exactly
+            // one field value — a multi-field struct can't attribute which field is the
+            // returned response (`Resp { ok: handler(), metric: m() }`), so emit
+            // nothing (no false edge, #208 review).
+            let mut cursor = node.walk();
+            let Some(fields) =
+                node.named_children(&mut cursor).find(|c| c.kind() == "field_initializer_list")
+            else {
+                return;
+            };
+            let mut field_cursor = fields.walk();
+            let values: Vec<Node<'a>> = fields
+                .named_children(&mut field_cursor)
+                .filter(|f| {
+                    matches!(
+                        f.kind(),
+                        "field_initializer"
+                            | "shorthand_field_initializer"
+                            | "base_field_initializer"
+                    )
+                })
+                .collect();
+            if let [field] = values.as_slice() {
+                match field.kind() {
+                    "field_initializer" =>
+                        if let Some(value) = field.child_by_field_name("value") {
+                            result_handler_calls(value, text, scope, out);
+                        },
+                    _ => {
+                        let mut inner_cursor = field.walk();
+                        for inner in field.named_children(&mut inner_cursor) {
+                            result_handler_calls(inner, text, scope, out);
+                        }
+                    },
+                }
+            }
+        },
+        "index_expression" => {
+            // A projection `r[i]` of a result — trace ONLY the indexed receiver (`r`), never the
+            // index expression (`choose_index()` selects, it doesn't produce the response).
+            let mut cursor = node.walk();
+            if let Some(receiver) = node.named_children(&mut cursor).next() {
+                result_handler_calls(receiver, text, scope, out);
+            }
+        },
+        "tuple_expression" | "array_expression" => {
+            // A SINGLE-element container is a transparent wrapper (`(x,)`, `[x]`); a multi-element
+            // one can't attribute which element is the returned response (`(handler(), metric())`),
+            // so emit nothing rather than credit a discarded sibling (#208 review).
+            let mut cursor = node.walk();
+            let elements: Vec<Node<'a>> = node.named_children(&mut cursor).collect();
+            if let [only] = elements.as_slice() {
+                result_handler_calls(*only, text, scope, out);
+            }
+        },
+        // Single-value projections/wrappers of a result (`&x`, `r.id`, `r as u32`, `*r`; the
+        // `field_identifier`/type is not an `identifier`, so it contributes nothing), plus
+        // control-flow and postfix wrappers — trace their children.
+        "reference_expression"
+        | "field_expression"
+        | "type_cast_expression"
+        | "unary_expression"
+        | "else_clause"
         | "expression_statement"
         | "return_expression"
         | "break_expression"
@@ -1497,25 +1783,153 @@ fn collect_tail_calls<'a>(node: Node<'a>, out: &mut Vec<Node<'a>>) {
         | "await_expression" => {
             let mut cursor = node.walk();
             for child in node.named_children(&mut cursor) {
-                collect_tail_calls(child, out);
-            }
-        },
-        "match_expression" => {
-            let mut cursor = node.walk();
-            for descendant in node.named_children(&mut cursor) {
-                if descendant.kind() == "match_block" {
-                    let mut arm_cursor = descendant.walk();
-                    for arm in descendant.named_children(&mut arm_cursor) {
-                        if arm.kind() == "match_arm"
-                            && let Some(value) = arm.child_by_field_name("value")
-                        {
-                            collect_tail_calls(value, out);
-                        }
-                    }
-                }
+                result_handler_calls(child, text, scope, out);
             }
         },
         _ => {},
+    }
+}
+
+/// The single identifier a PLAIN `let` pattern binds (`let x` / `let mut x`), or `None` for a
+/// destructuring pattern (which is invalidated, not mapped — see [`collect_handler_calls`]).
+fn simple_binding_name(pattern: Node<'_>, text: &str) -> Option<String> {
+    let identifier = match pattern.kind() {
+        "identifier" => pattern,
+        // `let mut x`: the `mut_pattern`'s first named child is the `mutable_specifier`, so find
+        // the identifier child rather than taking `named_child(0)` (#208 review round 10).
+        "mut_pattern" => {
+            let mut cursor = pattern.walk();
+            pattern.named_children(&mut cursor).find(|node| node.kind() == "identifier")?
+        },
+        _ => return None,
+    };
+    identifier.utf8_text(text.as_bytes()).ok().map(str::to_string)
+}
+
+/// Unwrap `?` / `.await` / parentheses to the underlying `call_expression`, for the effect-only
+/// fallback (`<call>.await?` / `<call>?`). `None` if the payload isn't a direct call (e.g. `task?`
+/// awaits a bound value — not a call — and must NOT be resolved against the block scope, #208
+/// review round 11).
+fn unwrap_to_call(node: Node<'_>) -> Option<Node<'_>> {
+    match node.kind() {
+        "call_expression" => Some(node),
+        "try_expression" | "await_expression" | "parenthesized_expression" =>
+            node.named_child(0).and_then(unwrap_to_call),
+        _ => None,
+    }
+}
+
+/// The local variable names a `let` / `match`-arm pattern BINDS — snake_case `identifier` leaves
+/// and struct-pattern shorthands — excluding field labels (`field_identifier`), type/variant paths
+/// (PascalCase identifiers, scoped paths), and literals. Used to map destructuring bindings to
+/// their producer and to mask match-arm payloads so they don't resolve to an outer `let` (#208
+/// review).
+fn pattern_binding_names(pattern: Node<'_>, text: &str, out: &mut Vec<String>) {
+    match pattern.kind() {
+        "shorthand_field_identifier" =>
+            if let Ok(name) = pattern.utf8_text(text.as_bytes()) {
+                out.push(name.to_string());
+            },
+        "identifier" =>
+        // A binding is snake_case / `_`-led; a PascalCase identifier pattern is a unit variant or
+        // const, which binds nothing.
+        {
+            if let Ok(name) = pattern.utf8_text(text.as_bytes())
+                && name.chars().next().is_some_and(|c| c == '_' || c.is_lowercase())
+            {
+                out.push(name.to_string());
+            }
+        },
+        "match_pattern" => {
+            // A guarded arm's `pattern` is `match_pattern` = the pattern + an `if <guard>` whose
+            // `condition` holds READS, not bindings — recurse the pattern, skip the guard (#208).
+            let guard = pattern.child_by_field_name("condition");
+            let mut cursor = pattern.walk();
+            for child in pattern.named_children(&mut cursor) {
+                if Some(child) != guard {
+                    pattern_binding_names(child, text, out);
+                }
+            }
+        },
+        "tuple_struct_pattern" | "struct_pattern" => {
+            // Skip the `type` path qualifier (`status::Ready(v)` / `Out { .. }`) — a lowercase
+            // module segment there is NOT a binding and must not mask an outer `let` of
+            // that name (#208).
+            let type_field = pattern.child_by_field_name("type");
+            let mut cursor = pattern.walk();
+            for child in pattern.named_children(&mut cursor) {
+                if Some(child) != type_field {
+                    pattern_binding_names(child, text, out);
+                }
+            }
+        },
+        // A bare `scoped_identifier` pattern is a UNIT-VARIANT / const path (`status::Ready`,
+        // `Mod::CONST`); its segments are a qualifier + variant, never bindings (#208 review).
+        "scoped_identifier" => {},
+        _ => {
+            let mut cursor = pattern.walk();
+            for child in pattern.named_children(&mut cursor) {
+                pattern_binding_names(child, text, out);
+            }
+        },
+    }
+}
+
+/// How `result_handler_calls` treats a `call_expression` (#200/#208 — one classifier so the
+/// delegate/wrapper decision can't disagree with itself, as it did across review rounds):
+/// - `Delegate`: RECORD it as the handler (a free fn `run`, a method `self.embed`, a module-pathed
+///   fn `crate::ml::embed::embed_text`).
+/// - `Wrapper`: a TRANSPARENT wrapper / variant constructor whose single argument IS the response —
+///   `Ok`/`Some` and ANY PascalCase-tail ctor (`MlResp::Embedded`, `dto::Wrapped`, bare `Wrapped`).
+///   Trace its lone payload argument.
+/// - `Skip`: emit nothing — `Err`/`None` (error/absence payload), a snake-tail `Type::assoc`
+///   constructor (`Vec::with_capacity`, `Resp::empty` — its arg configures, isn't the response), or
+///   a UFCS associated call (`<Resp as Default>::default()`).
+///
+/// Classification is by the path TAIL (constructor names are PascalCase; fns/methods are
+/// snake_case), which is receiver-agnostic — so `dto::Wrapped` and `Resp::Embedded` are both
+/// wrappers. Accepted recall: a bare PascalCase FFI fn (`CreateFileW`) reads as a wrapper (traced
+/// through, not recorded) — there is no extraction-time signal vs a tuple-struct ctor, and
+/// recording it risks crediting a constructor as a handler (a false edge), which the contract
+/// forbids.
+enum CallRole {
+    Delegate,
+    Wrapper,
+    Skip,
+}
+
+fn classify_call(call: Node<'_>, text: &str) -> CallRole {
+    let Some(function) = call.child_by_field_name("function") else {
+        return CallRole::Delegate;
+    };
+    let Ok(raw) = function.utf8_text(text.as_bytes()) else {
+        return CallRole::Delegate;
+    };
+    let raw = raw.trim();
+    // A LEADING `<...>` is a UFCS qualifier (`<Resp as Default>::default()`), an
+    // associated/constructor call — never a handler, and its arg (if any) isn't the response.
+    if raw.starts_with('<') {
+        return CallRole::Skip;
+    }
+    let stripped = strip_generics(raw);
+    let segments: Vec<&str> =
+        stripped.split("::").map(str::trim).filter(|segment| !segment.is_empty()).collect();
+    let Some(tail) = segments.last() else {
+        return CallRole::Delegate;
+    };
+    if matches!(*tail, "Err" | "None") {
+        return CallRole::Skip;
+    }
+    if matches!(*tail, "Ok" | "Some") || is_pascal_case(tail) {
+        // A PascalCase tail is a variant / tuple-struct constructor (`Resp::Embedded`,
+        // `dto::Wrapped`, bare `Wrapped`) — a transparent wrapper of its payload.
+        return CallRole::Wrapper;
+    }
+    // snake_case tail: a `Type::assoc(..)` (PascalCase receiver) is a config-taking constructor;
+    // a bare fn / method / module-pathed fn is the handler.
+    match segments.as_slice() {
+        [.., receiver, _last] if is_pascal_case(receiver) => CallRole::Skip,
+        _ => CallRole::Delegate,
     }
 }
 
@@ -1590,9 +2004,9 @@ fn rust_dispatch_handle_facts(
     let Some(value) = node.child_by_field_name("value") else {
         return;
     };
-    let mut tail_calls = Vec::new();
-    collect_tail_calls(value, &mut tail_calls);
-    for call in &tail_calls {
+    let mut handler_calls = Vec::new();
+    collect_handler_calls(value, text, &mut handler_calls);
+    for call in &handler_calls {
         let Some(handler) = call_target_name(*call, text) else {
             continue;
         };

--- a/crates/rag-rat-core/src/index/edges/helpers.rs
+++ b/crates/rag-rat-core/src/index/edges/helpers.rs
@@ -1,8 +1,42 @@
 use super::*;
 
+/// Remove balanced `<...>` generic-argument regions from a call path — and the turbofish's leading
+/// `::` (`f::<a::B>` → `f`, `Vec::<u8>::new` → `Vec::new`) — so a generic argument's `::` /
+/// identifiers don't corrupt path-based call name / receiver / qualified-name extraction. `<`/`>`
+/// inside a `{...}` const-generic block (`Foo::<{ 1 << 2 }>`) are shift/comparison operators, not
+/// generic delimiters, so brace regions suppress angle counting.
+///
+/// A LEADING `<...>` is a UFCS qualifier (`<Resp as Default>::default`), NOT a generic argument —
+/// stripping it would drop the type/receiver and mangle the qualified name (#208 review round 10),
+/// so a path that starts with `<` is returned unchanged.
+pub(crate) fn strip_generics(path: &str) -> String {
+    if path.trim_start().starts_with('<') {
+        return path.to_string();
+    }
+    let mut out = String::new();
+    let mut angle: u32 = 0;
+    let mut brace: u32 = 0;
+    for ch in path.chars() {
+        match ch {
+            '{' => brace += 1,
+            '}' => brace = brace.saturating_sub(1),
+            '<' if brace == 0 => {
+                if angle == 0 && out.ends_with("::") {
+                    out.truncate(out.len() - 2);
+                }
+                angle += 1;
+            },
+            '>' if brace == 0 => angle = angle.saturating_sub(1),
+            _ if angle == 0 => out.push(ch),
+            _ => {},
+        }
+    }
+    out
+}
+
 pub(crate) fn target_qualified_name(node: Node<'_>, text: &str) -> Option<String> {
     let function = node.child_by_field_name("function").unwrap_or(node);
-    let value = node_text(function, text);
+    let value = strip_generics(&node_text(function, text));
     (value.contains("::") || value.contains('.')).then(|| value.replace('.', "::"))
 }
 pub(crate) fn dotted_qualified_name(identifiers: &[String]) -> Option<String> {
@@ -31,8 +65,19 @@ pub(crate) fn containing_symbol(symbols: &[IndexedSymbol], byte: usize) -> Optio
         Some(first)
     }
 }
+/// A trailing turbofish (`f::<T>`) wraps the callee path in a `generic_function`; unwrap it so the
+/// type arguments' identifiers / byte ranges aren't mistaken for the callee.
+fn unwrap_generic_function(function: Node<'_>) -> Node<'_> {
+    if function.kind() == "generic_function" {
+        function.child_by_field_name("function").unwrap_or(function)
+    } else {
+        function
+    }
+}
+
 pub(crate) fn call_target_name(node: Node<'_>, text: &str) -> Option<String> {
     node.child_by_field_name("function")
+        .map(unwrap_generic_function)
         .and_then(|child| last_identifier_text(child, text))
         .map(|name| short_name(&name).to_string())
         .or_else(|| first_identifier_text(node, text))
@@ -44,13 +89,14 @@ pub(crate) fn call_target_name(node: Node<'_>, text: &str) -> Option<String> {
 /// node is available — never guess a wrong range.
 pub(crate) fn call_target_node(node: Node<'_>) -> Option<Node<'_>> {
     node.child_by_field_name("function")
+        .map(unwrap_generic_function)
         .and_then(last_identifier_node)
         .or_else(|| first_identifier_node(node))
         .map(final_segment_node)
 }
 pub(crate) fn scoped_receiver_name(node: Node<'_>, text: &str) -> Option<String> {
     let function = node.child_by_field_name("function").unwrap_or(node);
-    let value = node_text(function, text);
+    let value = strip_generics(&node_text(function, text));
     let separator = if value.contains("::") {
         "::"
     } else if value.contains('.') {

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -200,7 +200,15 @@ const MAX_AUTO_HEAL_FILES_PER_CALL: usize = 4;
 // 8: #200 — the graph re-extract+resolve now emits the `dispatch_construct`/`dispatch_handle` FACT
 // rows and synthesizes `dispatches` edges; without the bump a migrated v7 index would carry NO
 // dispatch edges until a manual rebuild, since the re-resolve (which re-extracts edges) never runs.
-const GRAPH_INDEX_VERSION: &str = "8";
+// 9: #207/#208 — the dispatch HANDLER detection changed (conservative closed recognizer), so the
+// `dispatch_handle` facts an existing v8 index extracted are stale (old tail-only handlers); the
+// bump re-extracts them so the corrected `dispatches` edges reach deployed indexes.
+// 10: #208 review rounds 9/10 — effect-only handler fallback (`h()?; Ok(unit)`), wrapper/delegate
+// reclassification (PascalCase tails, UFCS, Err), if-let payloads, `let mut`, field-store bails;
+// re-extract so the corrected `dispatch_handle` set reaches deployed indexes.
+// 11: #208 review round 11 — effect-only fallback records the direct call (no shadowing
+// misresolve); method calls on scoped receivers (`worker.run()`) are recorded again; re-extract.
+const GRAPH_INDEX_VERSION: &str = "11";
 
 // Bumped when the DEFINITION of `files.generated` changes, so an existing index re-derives the flag
 // on next open. Incremental discovery only rewrites a file row when its sha/language/kind changes —

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -2375,6 +2375,1036 @@ pub fn deliver() {}
 }
 
 #[test]
+fn dispatch_binds_let_bound_handler_under_a_wrapper_tail() {
+    // #207: the real-world actor idiom delegates in a `let` binding and returns a wrapper —
+    // `MlReq::EmbedText { .. } => { let v = embed_text(..)?; Ok(Resp::Embedded(v)) }`. The handler
+    // is the let-bound `embed_text`, NOT the tail `Ok(..)` wrapper; the variant is constructed
+    // elsewhere (a generic `call` helper sends it). The dispatch edge must reach `embed_text`,
+    // not `Ok`.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub enum MlReq { EmbedText { text: String }, Other }
+pub enum Resp { Embedded(i32), Empty }
+
+pub fn enqueue(text: String) { call(MlReq::EmbedText { text }); }
+fn call(_req: MlReq) {}
+
+pub fn handle(req: MlReq) -> Result<Resp, ()> {
+    match req {
+        MlReq::EmbedText { text } => {
+            let vector = embed_text(text)?;
+            Ok(Resp::Embedded(vector))
+        }
+        MlReq::Other => Ok(Resp::Empty),
+    }
+}
+
+fn embed_text(_text: String) -> Result<i32, ()> { Ok(0) }
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let dispatch_senders = |symbol: &str| -> Vec<String> {
+        db.find_callers(symbol, 50)
+            .unwrap()
+            .into_iter()
+            .filter(|hop| hop.edge_kind == "dispatches")
+            .filter_map(|hop| hop.from_symbol)
+            .collect()
+    };
+
+    // The let-bound handler `embed_text` is reached from the sender via the dispatch edge.
+    let embed = dispatch_senders("embed_text");
+    assert!(
+        embed.iter().any(|s| s.ends_with("enqueue")),
+        "let-bound handler must get a dispatch caller: {embed:?}"
+    );
+    // The `Ok(..)` / `Resp::Embedded(..)` wrapper constructors are NOT dispatch handlers.
+    assert!(
+        dispatch_senders("Embedded").is_empty(),
+        "a wrapper constructor must not be a dispatch handler"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn dispatch_handler_selection_distinguishes_handlers_from_wrappers_and_setup() {
+    // #208 review: the arm handler is the call producing the result. Keep real calls (incl. FFI/
+    // codegen PascalCase fns); never bind a `Result`/`Option` wrapper, a response constructor under
+    // a wrapper, or a setup `let` whose binding the tail never references.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub enum Msg { Build { x: u8 }, Open { p: u8 }, Direct { y: u8 }, Empty, Setup { z: u8 } }
+pub enum Resp { Wrapped(u8), Blank }
+impl Resp { fn empty() -> Resp { Resp::Blank } }
+
+pub fn enqueue() {
+    send(Msg::Build { x: 1 });
+    send(Msg::Open { p: 2 });
+    send(Msg::Direct { y: 3 });
+    send(Msg::Empty);
+    send(Msg::Setup { z: 4 });
+}
+fn send(_m: Msg) {}
+
+pub fn handle(m: Msg) -> Result<Resp, ()> {
+    match m {
+        Msg::Build { x } => {
+            let result = build_it(x)?;          // let-bound handler under a wrapper tail (#207)
+            Ok(Resp::Wrapped(result))           // Resp::Wrapped is a constructor, not a handler
+        }
+        Msg::Open { p } => CreateFileW(p),      // PascalCase FFI fn — must stay a handler (#208)
+        Msg::Direct { y } => handle_direct(y),  // plain tail handler
+        Msg::Empty => Ok(Resp::empty()),        // response ctor under wrapper — NO handler (#208)
+        Msg::Setup { z } => {
+            let _guard = start_span(z);          // setup let not referenced by the tail (#208)
+            run_setup()
+        }
+    }
+}
+fn build_it(_x: u8) -> Result<u8, ()> { Ok(0) }
+fn CreateFileW(_p: u8) -> Result<Resp, ()> { Ok(Resp::Blank) }
+fn handle_direct(_y: u8) -> Result<Resp, ()> { Ok(Resp::Blank) }
+fn start_span(_z: u8) {}
+fn run_setup() -> Result<Resp, ()> { Ok(Resp::Blank) }
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let dispatches_from_enqueue = |symbol: &str| -> bool {
+        db.find_callers(symbol, 50)
+            .unwrap()
+            .into_iter()
+            .filter(|hop| hop.edge_kind == "dispatches")
+            .filter_map(|hop| hop.from_symbol)
+            .any(|from| from.ends_with("enqueue"))
+    };
+
+    // Handlers that MUST be reached: the let-bound one (through the `Resp::Wrapped` constructor),
+    // the plain tail, and the setup arm's actual tail.
+    for handler in ["build_it", "handle_direct", "run_setup"] {
+        assert!(dispatches_from_enqueue(handler), "{handler} must be a dispatch handler");
+    }
+    // Non-handlers: a response ctor under a wrapper, a setup `let` the tail never reads, and the
+    // bare PascalCase `CreateFileW` — indistinguishable from a tuple-struct ctor, so it reads as a
+    // wrapper (traced through, not recorded) rather than risk crediting a ctor (accepted recall,
+    // #208 review round 10).
+    for non_handler in ["empty", "start_span", "CreateFileW"] {
+        assert!(
+            !dispatches_from_enqueue(non_handler),
+            "{non_handler} must NOT be a dispatch handler"
+        );
+    }
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn dispatch_handler_tracing_follows_result_dataflow_not_textual_names() {
+    // #208 review round 2: the handler is the call whose result becomes the arm response, traced
+    // through wrappers/constructors and `let` bindings. Covers per-branch let-feeds, shadowing,
+    // condition-only lets, let-bound response constructors, and struct field-label collisions.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub enum Msg { Branch, Shadow, Cond, LetCtor, Field }
+pub enum Resp { A, B, Wrap(u8) }
+impl Resp { fn empty() -> Resp { Resp::A } }
+pub struct Out { status: u8 }
+
+pub fn enqueue() {
+    send(Msg::Branch);
+    send(Msg::Shadow);
+    send(Msg::Cond);
+    send(Msg::LetCtor);
+    send(Msg::Field);
+}
+fn send(_m: Msg) {}
+
+pub fn handle(m: Msg) {
+    match m {
+        // per-branch: slow_path feeds the else wrapper branch; fast_path is the if branch.
+        Msg::Branch => { let r = slow_path()?; if cond() { fast_path() } else { Ok(Resp::Wrap(r)) } }
+        // shadowing: only the last `r` (second_handler) feeds the tail.
+        Msg::Shadow => { let r = first_handler()?; let r = second_handler(r)?; Ok(Resp::Wrap(r)) }
+        // condition-only: check_ready feeds only the if condition, not the result.
+        Msg::Cond => { let ready = check_ready(); if ready { Ok(Resp::A) } else { Ok(Resp::B) } }
+        // let-bound response constructor: not a handler.
+        Msg::LetCtor => { let resp = Resp::empty(); Ok(resp) }
+        // struct field LABEL `status` collides with the setup binding name `status`.
+        Msg::Field => { let status = start_span(); Ok(Out { status: 0 }) }
+    }
+}
+fn slow_path() -> Result<u8, ()> { Ok(0) }
+fn fast_path() -> Result<Resp, ()> { Ok(Resp::A) }
+fn cond() -> bool { true }
+fn first_handler() -> Result<u8, ()> { Ok(0) }
+fn second_handler(_r: u8) -> Result<u8, ()> { Ok(0) }
+fn check_ready() -> bool { true }
+fn start_span() {}
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let dispatches_from_enqueue = |symbol: &str| -> bool {
+        db.find_callers(symbol, 50)
+            .unwrap()
+            .into_iter()
+            .filter(|hop| hop.edge_kind == "dispatches")
+            .filter_map(|hop| hop.from_symbol)
+            .any(|from| from.ends_with("enqueue"))
+    };
+
+    // Reached: both branches of a mixed tail, and the in-scope (shadowing) binding.
+    for handler in ["slow_path", "fast_path", "second_handler"] {
+        assert!(dispatches_from_enqueue(handler), "{handler} must be a dispatch handler");
+    }
+    // Not reached: a shadowed binding, a condition-only let, a let-bound response constructor, and
+    // a setup binding that only collides with a struct field label.
+    for non_handler in ["first_handler", "cond", "check_ready", "empty", "start_span"] {
+        assert!(
+            !dispatches_from_enqueue(non_handler),
+            "{non_handler} must NOT be a dispatch handler"
+        );
+    }
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn dispatch_handler_tracing_handles_scope_and_turbofish_edge_cases() {
+    // #208 review round 3: declaration-ordered binding resolution (shadowing, self-wrapping,
+    // reassignment), match-arm pattern masking, let-pattern field labels, turbofish stripping, and
+    // wrapper payload containers.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub enum Msg { Nested, SelfWrap, FieldLet, Turbo, TurboCtor, Tuple, Reassign }
+pub enum Resp { Wrap(u8), Empty }
+impl Resp { fn empty() -> Resp { Resp::Empty } }
+pub struct Out { status: u8 }
+
+pub fn enqueue() {
+    send(Msg::Nested);
+    send(Msg::SelfWrap);
+    send(Msg::FieldLet);
+    send(Msg::Turbo);
+    send(Msg::TurboCtor);
+    send(Msg::Tuple);
+    send(Msg::Reassign);
+}
+fn send(_m: Msg) {}
+
+pub fn handle(m: Msg) {
+    match m {
+        // nested match arm binding `value` (the Some payload) must not resolve to the outer let.
+        Msg::Nested => {
+            let value = start_span();
+            match maybe() { Some(value) => Ok(Resp::Wrap(value)), _ => Ok(Resp::Empty) }
+        }
+        // declaration-time scope: the inner `Ok(r)` reads the FIRST `r` (load).
+        Msg::SelfWrap => { let r = load()?; let r = Ok(r)?; Ok(Resp::Wrap(r)) }
+        // a destructuring field label `status` must not shadow the outer `status` binding.
+        Msg::FieldLet => {
+            let status = build_status()?;
+            let Out { status: other } = read_out()?;
+            Ok(Resp::Wrap(status))
+        }
+        // turbofish on a bare fn stays a handler.
+        Msg::Turbo => CreateThing::<u8>(),
+        // turbofish on a constructor stays a constructor (no handler).
+        Msg::TurboCtor => Ok(Resp::<u8>::empty()),
+        // a wrapper payload tuple passes the handler result through.
+        Msg::Tuple => { let v = produce()?; Ok((v, 0)) }
+        // reassignment: the returned value is the LATEST assignment.
+        Msg::Reassign => { let mut resp = start_response()?; resp = finish_response()?; Ok(resp) }
+    }
+}
+fn start_span() {}
+fn maybe() -> Option<u8> { None }
+fn load() -> Result<u8, ()> { Ok(0) }
+fn build_status() -> Result<u8, ()> { Ok(0) }
+fn read_out() -> Result<Out, ()> { Ok(Out { status: 0 }) }
+fn CreateThing() -> Result<Resp, ()> { Ok(Resp::Empty) }
+fn produce() -> Result<u8, ()> { Ok(0) }
+fn start_response() -> Result<u8, ()> { Ok(0) }
+fn finish_response() -> Result<u8, ()> { Ok(0) }
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let dispatches_from_enqueue = |symbol: &str| -> bool {
+        db.find_callers(symbol, 50)
+            .unwrap()
+            .into_iter()
+            .filter(|hop| hop.edge_kind == "dispatches")
+            .filter_map(|hop| hop.from_symbol)
+            .any(|from| from.ends_with("enqueue"))
+    };
+
+    // Reached: the prior shadowed binding (load), and the outer field-let binding (build_status).
+    for handler in ["load", "build_status"] {
+        assert!(dispatches_from_enqueue(handler), "{handler} must be a dispatch handler");
+    }
+    // Not reached: a setup masked by a match-arm payload, a destructured-away initializer, a
+    // turbofished constructor, a reassigning arm's BOTH producers (the arm bails), `produce` (its
+    // `Ok((v, 0))` is a MULTI-element tuple), and the bare PascalCase `CreateThing` (reads as a
+    // wrapper, not a handler — accepted recall, #208 review round 10).
+    for non_handler in [
+        "start_span",
+        "read_out",
+        "empty",
+        "start_response",
+        "finish_response",
+        "produce",
+        "CreateThing",
+    ] {
+        assert!(
+            !dispatches_from_enqueue(non_handler),
+            "{non_handler} must NOT be a dispatch handler"
+        );
+    }
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn dispatch_handler_tracing_handles_destructuring_masking_and_control_flow() {
+    // #208 review round 4: a destructuring `let` overwrites a stale binding; a struct-pattern field
+    // LABEL doesn't mask an outer binding; a turbofish with a path type-arg stays a handler; and a
+    // binding reassigned inside control flow is invalidated (no stale-setup edge).
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub enum Msg { Destructure, MatchLabel, TurboPath, CfgReassign }
+pub enum Resp { Wrap(u8), Empty }
+pub struct Out { status: u8 }
+
+pub fn enqueue() {
+    send(Msg::Destructure);
+    send(Msg::MatchLabel);
+    send(Msg::TurboPath);
+    send(Msg::CfgReassign);
+}
+fn send(_m: Msg) {}
+
+pub fn handle(m: Msg) {
+    match m {
+        // the destructuring let overwrites the stale `status`; the value comes from read_out.
+        Msg::Destructure => {
+            let status = start_span()?;
+            let Out { status } = read_out()?;
+            Ok(Resp::Wrap(status))
+        }
+        // a struct-pattern field LABEL `status` must not mask the outer `status` binding.
+        Msg::MatchLabel => {
+            let status = build_status()?;
+            match out() { Out { status: other } => Ok(Resp::Wrap(status)), _ => Ok(Resp::Empty) }
+        }
+        // a turbofish whose type argument is itself a `::` path stays a handler.
+        Msg::TurboPath => OpenThing::<some::Handle>(),
+        // a binding reassigned inside control flow is invalidated (no stale-setup edge).
+        Msg::CfgReassign => {
+            let mut resp = start_response()?;
+            if cond() { resp = finish_a()?; } else { resp = finish_b()?; }
+            Ok(resp)
+        }
+    }
+}
+fn start_span() -> Result<u8, ()> { Ok(0) }
+fn read_out() -> Result<Out, ()> { Ok(Out { status: 0 }) }
+fn build_status() -> Result<u8, ()> { Ok(0) }
+fn out() -> Out { Out { status: 0 } }
+fn OpenThing() -> Result<Resp, ()> { Ok(Resp::Empty) }
+fn cond() -> bool { true }
+fn start_response() -> Result<u8, ()> { Ok(0) }
+fn finish_a() -> Result<u8, ()> { Ok(0) }
+fn finish_b() -> Result<u8, ()> { Ok(0) }
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let dispatches_from_enqueue = |symbol: &str| -> bool {
+        db.find_callers(symbol, 50)
+            .unwrap()
+            .into_iter()
+            .filter(|hop| hop.edge_kind == "dispatches")
+            .filter_map(|hop| hop.from_symbol)
+            .any(|from| from.ends_with("enqueue"))
+    };
+
+    // Reached: the outer binding the match-arm label can't mask.
+    assert!(dispatches_from_enqueue("build_status"), "build_status must be a dispatch handler");
+    // Not reached: a setup overwritten by a destructuring let (and its producer `read_out`), a
+    // control-flow reassignment (its arm bails), and the bare PascalCase `OpenThing` (reads as a
+    // wrapper, not a handler — accepted recall, #208 review round 10).
+    for non_handler in ["start_span", "read_out", "start_response", "OpenThing"] {
+        assert!(
+            !dispatches_from_enqueue(non_handler),
+            "{non_handler} must NOT be a dispatch handler"
+        );
+    }
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn dispatch_handler_tracing_handles_guards_typed_wrappers_scrutinee_and_shadow() {
+    // #208 review round 5: guards excluded from masking; turbofished `Ok::<T,E>` recognized as a
+    // wrapper; match-payload bindings inherit the scrutinee producer; assignments hidden in a `let`
+    // initializer invalidate; inner-block shadowing doesn't invalidate the outer binding; a
+    // multi-binding destructure doesn't credit every producer; const-generic call names resolve.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub enum Msg { Guard, TypedOk, MatchPayload, LetInitAssign, InnerShadow, TupleDestr }
+pub enum Resp { Wrap(u8), Empty }
+pub struct Out { other: u8 }
+pub struct Grid;
+impl Grid { fn assemble<const N: usize>() -> u8 { 0 } }
+
+pub fn enqueue() {
+    send(Msg::Guard);
+    send(Msg::TypedOk);
+    send(Msg::MatchPayload);
+    send(Msg::LetInitAssign);
+    send(Msg::InnerShadow);
+    send(Msg::TupleDestr);
+}
+fn send(_m: Msg) {}
+pub fn const_caller() { Grid::<{ 2 << 1 }>::assemble::<3>(); }
+
+pub fn handle(m: Msg) {
+    match m {
+        // a guard's `status` read must not be masked as a binding; build_status survives.
+        Msg::Guard => {
+            let status = build_status()?;
+            match out() { Out { other } if status > 0 => Ok(Resp::Wrap(status)), _ => Ok(Resp::Empty) }
+        }
+        // a typed `Ok::<Resp, ()>` is a wrapper — traced through to the let-fed compute.
+        Msg::TypedOk => { let v = compute()?; Ok::<Resp, ()>(Resp::Wrap(v)) }
+        // a returned match payload inherits the scrutinee producer (load).
+        Msg::MatchPayload => {
+            let r = load()?;
+            match r { Some(v) => Ok(Resp::Wrap(v)), _ => Ok(Resp::Empty) }
+        }
+        // an assignment hidden in a `let` initializer invalidates resp (no stale `start`).
+        Msg::LetInitAssign => {
+            let mut resp = start()?;
+            let _ = { resp = finish()?; };
+            Ok(resp)
+        }
+        // an inner-block shadow reassignment must not invalidate the outer `built`.
+        Msg::InnerShadow => {
+            let built = build()?;
+            { let mut built = 0; built = 1; }
+            Ok(Resp::Wrap(built))
+        }
+        // a multi-binding destructure must not credit `start_span` to `resp`.
+        Msg::TupleDestr => {
+            let (resp, _span) = (build_resp()?, start_span());
+            Ok(Resp::Wrap(resp))
+        }
+    }
+}
+fn out() -> Out { Out { other: 0 } }
+fn build_status() -> Result<u8, ()> { Ok(0) }
+fn compute() -> Result<u8, ()> { Ok(0) }
+fn load() -> Result<Option<u8>, ()> { Ok(None) }
+fn start() -> Result<u8, ()> { Ok(0) }
+fn finish() -> Result<u8, ()> { Ok(0) }
+fn build() -> Result<u8, ()> { Ok(0) }
+fn build_resp() -> Result<u8, ()> { Ok(0) }
+fn start_span() -> u8 { 0 }
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let dispatch_from_enqueue = |symbol: &str| -> bool {
+        db.find_callers(symbol, 50)
+            .unwrap()
+            .into_iter()
+            .filter(|hop| hop.edge_kind == "dispatches")
+            .filter_map(|hop| hop.from_symbol)
+            .any(|from| from.ends_with("enqueue"))
+    };
+    let called_by = |symbol: &str, caller: &str| -> bool {
+        db.find_callers(symbol, 50)
+            .unwrap()
+            .into_iter()
+            .filter_map(|hop| hop.from_symbol)
+            .any(|from| from.ends_with(caller))
+    };
+
+    for handler in ["build_status", "compute", "load"] {
+        assert!(dispatch_from_enqueue(handler), "{handler} must be a dispatch handler");
+    }
+    // `build` (InnerShadow arm) now bails: the arm reassigns a local (`built = 1`), so the whole
+    // arm is conservatively dropped rather than tracking shadow-aware scopes (accepted recall,
+    // #208).
+    for non_handler in ["start", "start_span", "build"] {
+        assert!(
+            !dispatch_from_enqueue(non_handler),
+            "{non_handler} must NOT be a dispatch handler"
+        );
+    }
+    // Const-generic turbofish: the call names the function, not the type — `assemble` has a caller.
+    assert!(
+        called_by("assemble", "const_caller"),
+        "const-generic call must resolve to the callee name"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn dispatch_handler_tracing_handles_multibind_ufcs_field_and_path_qualifiers() {
+    // #208 review round 6: multi-binding match scrutinee doesn't credit every producer; a
+    // reassignment in an assignment RHS invalidates; UFCS is a constructor; pre-shadow assignments
+    // target the outer binding; field projections trace their receiver; a module-qualified
+    // pattern's qualifier doesn't mask an outer binding.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub enum Msg { MultiScrut, RhsReassign, Ufcs, ShadowOrder, FieldProj, PathQual }
+pub enum Resp { Wrap(u8), Empty }
+pub struct Thing { id: u8 }
+pub enum E { Ready(u8) }
+
+pub fn enqueue() {
+    send(Msg::MultiScrut);
+    send(Msg::RhsReassign);
+    send(Msg::Ufcs);
+    send(Msg::ShadowOrder);
+    send(Msg::FieldProj);
+    send(Msg::PathQual);
+}
+fn send(_m: Msg) {}
+
+pub fn handle(m: Msg) {
+    match m {
+        // a multi-binding match scrutinee must not credit start_span to resp.
+        Msg::MultiScrut => match (build_resp()?, start_span()) { (resp, _span) => Ok(Resp::Wrap(resp)) },
+        // a reassignment hidden in an assignment RHS invalidates resp (no stale start_a).
+        Msg::RhsReassign => { let mut resp = start_a()?; other = { resp = finish_a()?; 1 }; Ok(resp) }
+        // a UFCS associated call is a constructor, not a handler.
+        Msg::Ufcs => Ok(<Resp as Default>::default()),
+        // a pre-shadow assignment targets the outer resp → invalidate (no stale start_b).
+        Msg::ShadowOrder => { let mut resp = start_b()?; { resp = finish_b()?; let resp = 0; } Ok(resp) }
+        // a field projection of a result binding traces back to its producer.
+        Msg::FieldProj => { let r = build()?; Ok(Resp::Wrap(r.id)) }
+        // a module-qualified pattern's qualifier must not mask the outer binding.
+        Msg::PathQual => {
+            let status = build_status()?;
+            match e() { status::Ready(v) => Ok(Resp::Wrap(status)), _ => Ok(Resp::Empty) }
+        }
+    }
+}
+fn build_resp() -> Result<u8, ()> { Ok(0) }
+fn start_span() -> u8 { 0 }
+fn start_a() -> Result<u8, ()> { Ok(0) }
+fn finish_a() -> Result<u8, ()> { Ok(0) }
+fn start_b() -> Result<u8, ()> { Ok(0) }
+fn finish_b() -> Result<u8, ()> { Ok(0) }
+fn build() -> Result<Thing, ()> { Ok(Thing { id: 0 }) }
+fn build_status() -> Result<u8, ()> { Ok(0) }
+fn e() -> E { E::Ready(0) }
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let dispatch_from_enqueue = |symbol: &str| -> bool {
+        db.find_callers(symbol, 50)
+            .unwrap()
+            .into_iter()
+            .filter(|hop| hop.edge_kind == "dispatches")
+            .filter_map(|hop| hop.from_symbol)
+            .any(|from| from.ends_with("enqueue"))
+    };
+
+    for handler in ["build", "build_status"] {
+        assert!(dispatch_from_enqueue(handler), "{handler} must be a dispatch handler");
+    }
+    for non_handler in ["start_span", "start_a", "default", "start_b"] {
+        assert!(
+            !dispatch_from_enqueue(non_handler),
+            "{non_handler} must NOT be a dispatch handler"
+        );
+    }
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn dispatch_handler_tracing_index_cast_orpattern_and_rebind_bail() {
+    // #208 review round 7 (after the conservative restructure): index projections trace only the
+    // receiver; casts trace the operand; or-pattern payloads inherit the scrutinee; and any arm
+    // that rebinds a local (destructuring-assign, closure reassignment) or destructures a
+    // discarded producer bails / invalidates rather than emitting a stale or false edge.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub enum Msg { IndexProj, OrPat, CastProj, DestrIgnore, DestrAssign, ClosureReassign }
+pub enum Resp { Wrap(u8), Empty }
+pub enum Sig { A(u8), B(u8) }
+
+pub fn enqueue() {
+    send(Msg::IndexProj);
+    send(Msg::OrPat);
+    send(Msg::CastProj);
+    send(Msg::DestrIgnore);
+    send(Msg::DestrAssign);
+    send(Msg::ClosureReassign);
+}
+fn send(_m: Msg) {}
+
+pub fn handle(m: Msg) {
+    match m {
+        // an index projection traces only the receiver, not the index expression.
+        Msg::IndexProj => { let r = build_idx()?; Ok(Resp::Wrap(r[choose_index()])) }
+        // an or-pattern's repeated payload binding inherits the scrutinee producer.
+        Msg::OrPat => match get() { Sig::A(v) | Sig::B(v) => Ok(Resp::Wrap(v)), },
+        // a cast of a returned binding traces the operand.
+        Msg::CastProj => { let v = build_cast()?; Ok(Resp::Wrap(v as u32)) }
+        // a destructure that discards a producer doesn't credit it.
+        Msg::DestrIgnore => { let (resp, _) = (build_d()?, start_span()); Ok(Resp::Wrap(resp)) }
+        // a destructuring assignment rebinds a local → the arm bails.
+        Msg::DestrAssign => { let mut resp = start_da()?; (resp, _) = (finish_da()?, 0); Ok(resp) }
+        // a reassignment inside a closure rebinds a local → the arm bails.
+        Msg::ClosureReassign => {
+            let resp = build_c()?;
+            let _f = || { resp = finish_c()?; };
+            Ok(Resp::Wrap(resp))
+        }
+    }
+}
+fn build_idx() -> Result<u8, ()> { Ok(0) }
+fn choose_index() -> usize { 0 }
+fn get() -> Sig { Sig::A(0) }
+fn build_cast() -> Result<u8, ()> { Ok(0) }
+fn build_d() -> Result<u8, ()> { Ok(0) }
+fn start_span() -> u8 { 0 }
+fn start_da() -> Result<u8, ()> { Ok(0) }
+fn finish_da() -> Result<u8, ()> { Ok(0) }
+fn build_c() -> Result<u8, ()> { Ok(0) }
+fn finish_c() -> Result<u8, ()> { Ok(0) }
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let dispatch_from_enqueue = |symbol: &str| -> bool {
+        db.find_callers(symbol, 50)
+            .unwrap()
+            .into_iter()
+            .filter(|hop| hop.edge_kind == "dispatches")
+            .filter_map(|hop| hop.from_symbol)
+            .any(|from| from.ends_with("enqueue"))
+    };
+
+    // Reached: the indexed receiver, the or-pattern scrutinee, and the cast operand's producer.
+    for handler in ["build_idx", "get", "build_cast"] {
+        assert!(dispatch_from_enqueue(handler), "{handler} must be a dispatch handler");
+    }
+    // Not reached: an index selector, a discarded destructure producer, and producers in arms that
+    // rebind a local (destructuring-assign / closure reassignment — the arm bails).
+    for non_handler in ["choose_index", "start_span", "start_da", "finish_c"] {
+        assert!(
+            !dispatch_from_enqueue(non_handler),
+            "{non_handler} must NOT be a dispatch handler"
+        );
+    }
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn dispatch_handler_tracing_suppresses_multivalue_error_and_rebind_false_edges() {
+    // #208 review round 8: the contract is "a missed edge is OK, a FALSE edge is a bug."
+    // Multi-value containers (multi-arg ctor / multi-element tuple / multi-field struct), `Err`
+    // payloads, multi-producer scrutinees, and reassignments via wrapped/destructuring LHS must
+    // NOT synthesize a handler edge to a discarded/stale/error call. Unit-variant path
+    // qualifiers and unary projections are handled too.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub enum Msg { MultiCtor, MultiTuple, ErrArm, ParenRebind, DerefRebind, ArrayAssign, StructAssign, PartialScrut, UnitQual, DerefProj }
+pub enum Resp { Wrap(u8), Two(u8, u8), Empty }
+pub struct Out { resp: u8 }
+pub enum Sig { Ready }
+
+pub fn enqueue() {
+    send(Msg::MultiCtor);
+    send(Msg::MultiTuple);
+    send(Msg::ErrArm);
+    send(Msg::ParenRebind);
+    send(Msg::DerefRebind);
+    send(Msg::ArrayAssign);
+    send(Msg::StructAssign);
+    send(Msg::PartialScrut);
+    send(Msg::UnitQual);
+    send(Msg::DerefProj);
+}
+fn send(_m: Msg) {}
+
+pub fn handle(m: Msg) {
+    match m {
+        // multi-arg constructor: can't attribute the response → no edge (no false `record_metric`).
+        Msg::MultiCtor => Ok(Resp::Two(embed_text(), record_metric())),
+        // multi-element tuple → no edge (no false `side`).
+        Msg::MultiTuple => Ok((handler_a(), side())),
+        // an `Err` payload is an error value, not a response handler.
+        Msg::ErrArm => Err(build_error()),
+        // paren-wrapped reassignment rebinds a local → arm bails (no stale `first`).
+        Msg::ParenRebind => { let mut resp = first(); (resp) = second(); Ok(Resp::Wrap(resp)) }
+        // deref reassignment rebinds a local → arm bails (no stale `first_d`).
+        Msg::DerefRebind => { let mut v = first_d(); let p = &mut v; *p = second_d(); Ok(Resp::Wrap(v)) }
+        // array destructuring assignment → arm bails (no stale `first_arr`).
+        Msg::ArrayAssign => { let mut resp = first_arr(); [resp, _] = [second_arr(), 0]; Ok(Resp::Wrap(resp)) }
+        // struct destructuring assignment → arm bails (no stale `first_st`).
+        Msg::StructAssign => { let mut resp = first_st(); Out { resp } = make_out(); Ok(Resp::Wrap(resp)) }
+        // a single binding over a MULTI-producer scrutinee tuple → no scrutinee inheritance.
+        Msg::PartialScrut => match (build_p()?, start_span()) { (resp, 0) => Ok(Resp::Wrap(resp)), _ => Ok(Resp::Empty) },
+        // a unit-variant path qualifier must not mask the outer binding.
+        Msg::UnitQual => { let status = build_status()?; match sig() { Sig::Ready => Ok(Resp::Wrap(status)), _ => Ok(Resp::Empty) } }
+        // a unary deref projection of a returned binding traces the operand.
+        Msg::DerefProj => { let v = build_deref()?; Ok(Resp::Wrap(*v)) }
+    }
+}
+fn embed_text() -> u8 { 0 }
+fn record_metric() -> u8 { 0 }
+fn handler_a() -> u8 { 0 }
+fn side() -> u8 { 0 }
+fn build_error() -> () {}
+fn first() -> u8 { 0 }
+fn second() -> u8 { 0 }
+fn first_d() -> u8 { 0 }
+fn second_d() -> u8 { 0 }
+fn first_arr() -> u8 { 0 }
+fn second_arr() -> u8 { 0 }
+fn first_st() -> u8 { 0 }
+fn make_out() -> Out { Out { resp: 0 } }
+fn build_p() -> Result<u8, ()> { Ok(0) }
+fn start_span() -> u8 { 0 }
+fn build_status() -> Result<u8, ()> { Ok(0) }
+fn sig() -> Sig { Sig::Ready }
+fn build_deref() -> Result<u8, ()> { Ok(0) }
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let dispatch_from_enqueue = |symbol: &str| -> bool {
+        db.find_callers(symbol, 50)
+            .unwrap()
+            .into_iter()
+            .filter(|hop| hop.edge_kind == "dispatches")
+            .filter_map(|hop| hop.from_symbol)
+            .any(|from| from.ends_with("enqueue"))
+    };
+
+    // Reached: the unit-variant-qualifier arm's outer binding, and the unary-deref projection.
+    for handler in ["build_status", "build_deref"] {
+        assert!(dispatch_from_enqueue(handler), "{handler} must be a dispatch handler");
+    }
+    // FALSE edges that must NOT exist: discarded multi-value siblings, an `Err` payload builder,
+    // stale producers behind a wrapped/destructuring reassignment, and a multi-producer scrutinee's
+    // other producer.
+    for non_handler in [
+        "record_metric",
+        "side",
+        "build_error",
+        "first",
+        "first_d",
+        "first_arr",
+        "first_st",
+        "start_span",
+    ] {
+        assert!(
+            !dispatch_from_enqueue(non_handler),
+            "{non_handler} must NOT be a dispatch handler (false edge)"
+        );
+    }
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn dispatch_handler_tracing_field_store_scoped_err_config_ctor_and_comments() {
+    // #208 review round 9: a field/index store before the tail must NOT bail the arm; a scoped
+    // `Result::Err(..)` must be suppressed like bare `Err`; a snake-tail associated constructor
+    // (`Vec::with_capacity(config)`) must NOT be traced as a payload wrapper; and a comment in a
+    // wrapper's argument list must not hide the single payload.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub enum Msg { FieldStore, ScopedErr, ConfigCtor, Commented }
+pub enum Resp { Wrap(u8), Empty }
+pub struct S { count: u8 }
+
+pub fn enqueue() {
+    send(Msg::FieldStore);
+    send(Msg::ScopedErr);
+    send(Msg::ConfigCtor);
+    send(Msg::Commented);
+}
+fn send(_m: Msg) {}
+
+pub fn handle(state: &mut S, m: Msg) {
+    match m {
+        // a field store before the tail is a side effect, not a rebind — `run` is still the handler.
+        Msg::FieldStore => { state.count = now(); run() }
+        // a scoped `Result::Err(..)` is an error wrapper — its builder is not a handler.
+        Msg::ScopedErr => Result::Err(build_error()),
+        // `Vec::with_capacity(n)` is a snake-tail associated ctor; `n` configures, isn't the payload.
+        Msg::ConfigCtor => Ok(Vec::with_capacity(record_metric())),
+        // a comment in the wrapper arg list must not hide the single payload `v`.
+        Msg::Commented => { let v = handler_c()?; Ok(v /* note */) }
+    }
+}
+fn now() -> u8 { 0 }
+fn run() -> Result<Resp, ()> { Ok(Resp::Empty) }
+fn build_error() -> () {}
+fn record_metric() -> usize { 0 }
+fn handler_c() -> Result<u8, ()> { Ok(0) }
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let dispatch_from_enqueue = |symbol: &str| -> bool {
+        db.find_callers(symbol, 50)
+            .unwrap()
+            .into_iter()
+            .filter(|hop| hop.edge_kind == "dispatches")
+            .filter_map(|hop| hop.from_symbol)
+            .any(|from| from.ends_with("enqueue"))
+    };
+
+    // Reached: the let-bound payload behind a comment.
+    assert!(dispatch_from_enqueue("handler_c"), "handler_c must be a dispatch handler");
+    // FALSE edges that must NOT exist: a scoped-`Err` builder, and a config arg of an associated
+    // constructor. Plus `run`/`now` — a field store (`state.count = now()`) can stale a returned
+    // projection, so an arm containing ANY local-mutating assignment bails entirely (accepted
+    // recall, #208 review round 10).
+    for non_handler in ["now", "build_error", "record_metric", "run"] {
+        assert!(
+            !dispatch_from_enqueue(non_handler),
+            "{non_handler} must NOT be a dispatch handler"
+        );
+    }
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn dispatch_handler_tracing_effect_only_wrappers_iflet_mut_and_adapters() {
+    // #208 review round 10 + held feedback: the EFFECT-ONLY handler (`h()?; Ok(unit)`) is
+    // recovered; module-qualified/bare PascalCase ctors are transparent wrappers; `if let`
+    // payloads and `let mut` bindings resolve; a fire-and-forget side effect, a scoped-receiver
+    // method adapter, and a field store that can stale a returned projection produce no edge.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub enum Msg { Effect, Fire, ModCtor, BareCtor, MutBind, IfLet, MethodAdapter, FieldProj }
+pub enum MlResp { Diarized, Done }
+pub enum Resp { Wrap(u8), Empty }
+pub struct Bare(u8);
+pub struct Out { id: u8 }
+pub mod dto { pub struct Wrapped(pub u8); }
+
+pub fn enqueue() {
+    send(Msg::Effect);
+    send(Msg::Fire);
+    send(Msg::ModCtor);
+    send(Msg::BareCtor);
+    send(Msg::MutBind);
+    send(Msg::IfLet);
+    send(Msg::MethodAdapter);
+    send(Msg::FieldProj);
+}
+fn send(_m: Msg) {}
+
+pub fn handle(m: Msg) {
+    match m {
+        // effect-only: a `?`-propagated work call + a fixed ack → the fallback records do_work.
+        Msg::Effect => { do_work()?; Ok(MlResp::Diarized) }
+        // a fire-and-forget side effect (no `?`) must NOT be recorded.
+        Msg::Fire => { fire_and_forget(); Ok(MlResp::Done) }
+        // a module-qualified tuple ctor is a transparent wrapper → traces v → dto_build.
+        Msg::ModCtor => { let v = dto_build()?; Ok(dto::Wrapped(v)) }
+        // a bare tuple-struct ctor is a transparent wrapper → traces v → bare_build.
+        Msg::BareCtor => { let v = bare_build()?; Ok(Bare(v)) }
+        // a `let mut` binding maps to its producer.
+        Msg::MutBind => { let mut v = build_mut()?; Ok(Resp::Wrap(v)) }
+        // an if-let payload inherits the condition value's producer.
+        Msg::IfLet => if let Some(v) = load_il()? { Ok(Resp::Wrap(v)) } else { Ok(Resp::Empty) },
+        // a method adapter on a scoped binding is suppressed (no false `into` edge; build_into is
+        // conservatively dropped).
+        Msg::MethodAdapter => { let v = build_into()?; Ok(Resp::Wrap(v.into())) }
+        // a field store can stale a returned projection → the whole arm bails.
+        Msg::FieldProj => { let mut r = mk()?; r.id = finish_fp()?; Ok(Resp::Wrap(r.id)) }
+    }
+}
+fn do_work() -> Result<u8, ()> { Ok(0) }
+fn fire_and_forget() {}
+fn dto_build() -> Result<u8, ()> { Ok(0) }
+fn bare_build() -> Result<u8, ()> { Ok(0) }
+fn build_mut() -> Result<u8, ()> { Ok(0) }
+fn load_il() -> Result<Option<u8>, ()> { Ok(None) }
+fn build_into() -> Result<u8, ()> { Ok(0) }
+fn mk() -> Result<Out, ()> { Ok(Out { id: 0 }) }
+fn finish_fp() -> Result<u8, ()> { Ok(0) }
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let dispatch_from_enqueue = |symbol: &str| -> bool {
+        db.find_callers(symbol, 50)
+            .unwrap()
+            .into_iter()
+            .filter(|hop| hop.edge_kind == "dispatches")
+            .filter_map(|hop| hop.from_symbol)
+            .any(|from| from.ends_with("enqueue"))
+    };
+
+    // Reached: the effect-only work call, the module/bare wrapper payloads, the `let mut` binding,
+    // and the if-let payload.
+    for handler in ["do_work", "dto_build", "bare_build", "build_mut", "load_il"] {
+        assert!(dispatch_from_enqueue(handler), "{handler} must be a dispatch handler");
+    }
+    // Not reached: a fire-and-forget side effect, a scoped-receiver method adapter's producer
+    // (suppressed), and a field-store arm's producers (the arm bails).
+    for non_handler in ["fire_and_forget", "build_into", "mk", "finish_fp"] {
+        assert!(
+            !dispatch_from_enqueue(non_handler),
+            "{non_handler} must NOT be a dispatch handler"
+        );
+    }
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn dispatch_handler_tracing_effect_only_shadow_and_scoped_methods() {
+    // #208 review round 11: the effect-only fallback records the DIRECT call, not a `let`-bound `?`
+    // resolved against the final (shadowed) scope; and a method call on a scoped binding
+    // (`worker.run()`) IS recorded as the handler again (a real method resolves; a pure adapter
+    // `v.into()` is a std method that doesn't resolve, so it creates no edge).
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/lib.rs"),
+        r#"
+pub enum Msg { ShadowFallback, Worker }
+pub enum Resp { Done, Out(u8) }
+pub struct W;
+impl W { fn run(&self) -> Result<Resp, ()> { Ok(Resp::Done) } }
+
+pub fn enqueue() {
+    send(Msg::ShadowFallback);
+    send(Msg::Worker);
+}
+fn send(_m: Msg) {}
+
+pub fn handle(m: Msg) {
+    match m {
+        // the effect-only fallback must NOT resolve the bound `task?` against the SHADOWED final
+        // scope (which maps `task` to record_metric) — `task?` isn't a direct call, so it's skipped.
+        Msg::ShadowFallback => { let task = do_work(); task?; let task = record_metric(); Ok(Resp::Done) }
+        // a method call on a scoped binding IS the handler (worker.run), recorded again.
+        Msg::Worker => { let worker = make_worker(); worker.run() }
+    }
+}
+fn do_work() -> Result<(), ()> { Ok(()) }
+fn record_metric() -> Result<(), ()> { Ok(()) }
+fn make_worker() -> W { W }
+"#,
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let dispatch_from_enqueue = |symbol: &str| -> bool {
+        db.find_callers(symbol, 50)
+            .unwrap()
+            .into_iter()
+            .filter(|hop| hop.edge_kind == "dispatches")
+            .filter_map(|hop| hop.from_symbol)
+            .any(|from| from.ends_with("enqueue"))
+    };
+
+    // Reached: the method handler on a scoped binding.
+    assert!(dispatch_from_enqueue("run"), "run must be a dispatch handler");
+    // Not reached: a shadowing producer the effect-only fallback must not misresolve to, and the
+    // bound `task?`'s producer (a bound-`?` is not a direct call — accepted recall).
+    for non_handler in ["record_metric", "do_work"] {
+        assert!(
+            !dispatch_from_enqueue(non_handler),
+            "{non_handler} must NOT be a dispatch handler"
+        );
+    }
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn dispatch_ignores_nested_payload_variants() {
     // #200 review: an arm pattern `Outer::Wrapped(Inner::Start) => run()` handles `Outer::Wrapped`,
     // NOT the nested payload `Inner::Start`. A function that only constructs `Inner::Start` as data


### PR DESCRIPTION
## What

The synthesized `dispatches` edges (#200) missed the **most common Rust actor dispatch idiom** — a handler arm that delegates in a `let` binding and returns a wrapper:

```rust
MlReq::EmbedText { .. } => {
    let vector = embed_text(..).await?;
    Ok(MlResp::Embedded(vector))
}
```

`collect_tail_calls` looked only at the arm's **tail**, which here is `Ok(MlResp::Embedded(..))`. So the handle fact's "handler" became `Ok` (unresolvable) → the fact was dropped → **no dispatch edge**, even though the construct side was detected. The real handler (`embed_text`) lives in the `let` initializer. (The generic build-variant + `call(req)` send indirection is *not* the cause — the construct fact is attributed to the constructing fn regardless of where the send happens.)

## How

Collect handler calls from **`let` initializers + the tail**, and treat **wrapper constructors** (`Ok`/`Err`/`Some`/`None` and PascalCase variant/struct ctors) as non-handlers — descend into their args for the real inner call instead of binding the wrapper. This captures the let-bound handler while preserving the precision from prior rounds: non-tail side-effect statements (`metrics::inc();`), guard/scrutinee calls (`if ready()`), and nested argument calls (`handle(validate(x))`) are still excluded.

## Test

`dispatch_binds_let_bound_handler_under_a_wrapper_tail` — asserts the let-bound `embed_text` gets the dispatch caller and the `Ok`/`Resp::Embedded` wrappers do not. All existing dispatch tests unchanged. Core (562) + mcp (27) green, clippy clean.

## Scope

Addresses the **let-bound-handler** half of #207 (the real-world blocker hit on actor code). The remaining half — bare `use Enum::*` variant constructions/matches — is tracked in #207.