### PR TITLE
feat(git): move all runtime git operations to gix (gitoxide) (#212)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,13 +1660,16 @@ version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b47c88884dd3c1a19a39da19d10211fcdea2809aadc86869b6e824a1774340f"
 dependencies = [
+ "bitflags",
  "bstr",
  "gix-commitgraph",
  "gix-date",
  "gix-error",
  "gix-hash",
+ "gix-hashtable",
  "gix-object",
  "gix-revwalk",
+ "gix-trace",
  "nonempty",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3147,6 +3147,7 @@ dependencies = [
  "anyhow",
  "clap",
  "dialoguer",
+ "gix",
  "libc",
  "rag-rat-core",
  "rag-rat-mcp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,6 +1435,7 @@ dependencies = [
  "faster-hex",
  "gix-features",
  "sha1-checked",
+ "sha2",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,6 +1109,7 @@ checksum = "ae54ae0ebd1a5a3c3f8d95dd3b5ca6e63f4fed9bfd585e13801a97d7bde8f9ce"
 dependencies = [
  "gix-actor",
  "gix-attributes",
+ "gix-blame",
  "gix-command",
  "gix-commitgraph",
  "gix-config",
@@ -1188,6 +1189,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ebef0c26ad305747649e727bbcd56a7b7910754eb7cea88f6dff6f93c51283"
 dependencies = [
  "gix-error",
+]
+
+[[package]]
+name = "gix-blame"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d39a0c14af94c2edaa5eefe06d5ef2cdea55316ae9a9321314288e3f55fa4c0"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-diff",
+ "gix-error",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "smallvec",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rag-rat-core = { version = "0.7.0", path = "crates/rag-rat-core", default-featur
 rag-rat-mcp = { version = "0.7.0", path = "crates/rag-rat-mcp", default-features = false }
 anyhow = "1.0"
 fastembed = { version = "5.1.0", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
-gix = { version = "0.84.0", default-features = false, features = ["status", "parallel", "sha1"] }
+gix = { version = "0.84.0", default-features = false, features = ["status", "parallel", "sha1", "revision", "blob-diff"] }
 libc = "0.2"
 rmcp = { version = "1.7.0", features = ["transport-io"] }
 rusqlite = "0.40"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rag-rat-core = { version = "0.7.0", path = "crates/rag-rat-core", default-featur
 rag-rat-mcp = { version = "0.7.0", path = "crates/rag-rat-mcp", default-features = false }
 anyhow = "1.0"
 fastembed = { version = "5.1.0", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
-gix = { version = "0.84.0", default-features = false, features = ["status", "parallel", "sha1", "revision", "blob-diff"] }
+gix = { version = "0.84.0", default-features = false, features = ["status", "parallel", "sha1", "revision", "blob-diff", "blame"] }
 libc = "0.2"
 rmcp = { version = "1.7.0", features = ["transport-io"] }
 rusqlite = "0.40"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rag-rat-core = { version = "0.7.0", path = "crates/rag-rat-core", default-featur
 rag-rat-mcp = { version = "0.7.0", path = "crates/rag-rat-mcp", default-features = false }
 anyhow = "1.0"
 fastembed = { version = "5.1.0", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
-gix = { version = "0.84.0", default-features = false, features = ["status", "parallel", "sha1", "revision", "blob-diff", "blame"] }
+gix = { version = "0.84.0", default-features = false, features = ["status", "parallel", "sha1", "sha256", "revision", "blob-diff", "blame"] }
 libc = "0.2"
 rmcp = { version = "1.7.0", features = ["transport-io"] }
 rusqlite = "0.40"

--- a/crates/rag-rat-cli/Cargo.toml
+++ b/crates/rag-rat-cli/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 anyhow.workspace = true
 clap = { version = "4.5", features = ["derive"] }
 dialoguer = "0.12"
+gix.workspace = true
 libc.workspace = true
 rag-rat-core = { workspace = true }
 rag-rat-mcp = { workspace = true }

--- a/crates/rag-rat-cli/src/hooks_support.rs
+++ b/crates/rag-rat-cli/src/hooks_support.rs
@@ -1,7 +1,10 @@
 use super::*;
 
 pub(crate) fn git_paths(root: &Path) -> anyhow::Result<GitPaths> {
-    let repo = gix::discover(root)?;
+    // Env-aware discovery (honors GIT_DIR / GIT_WORK_TREE) so `hooks install/status/uninstall`
+    // works in a bare-dir + external-worktree checkout, matching the old `git -C root
+    // rev-parse` (#213 review).
+    let repo = gix::discover_with_environment_overrides(root)?;
     let worktree_root =
         repo.workdir().ok_or_else(|| anyhow::anyhow!("not inside a git worktree"))?.to_path_buf();
     // gix may report the git dir relative to the discovery root; mirror the old `rev-parse`

--- a/crates/rag-rat-cli/src/hooks_support.rs
+++ b/crates/rag-rat-cli/src/hooks_support.rs
@@ -1,28 +1,25 @@
 use super::*;
 
 pub(crate) fn git_paths(root: &Path) -> anyhow::Result<GitPaths> {
-    let worktree_root = git_rev_parse(root, "--show-toplevel")?;
-    let git_dir = git_rev_parse(root, "--git-dir")?;
-    let git_common_dir = git_rev_parse(root, "--git-common-dir")?;
-    let hooks_dir = git_rev_parse(root, "--git-path hooks")?;
+    let repo = gix::discover(root)?;
+    let worktree_root =
+        repo.workdir().ok_or_else(|| anyhow::anyhow!("not inside a git worktree"))?.to_path_buf();
+    // gix may report the git dir relative to the discovery root; mirror the old `rev-parse`
+    // absolutize (relative -> `root.join`).
+    let absolutize = |path: &Path| {
+        if path.is_absolute() { path.to_path_buf() } else { root.join(path) }
+    };
+    let git_dir = absolutize(repo.git_dir());
+    let git_common_dir = absolutize(repo.common_dir());
+    // `core.hooksPath` overrides the default `<git-dir>/hooks` (git resolves a relative value
+    // against the worktree); fall back to the standard location otherwise.
+    let hooks_dir = repo
+        .config_snapshot()
+        .trusted_path("core.hooksPath")
+        .and_then(Result::ok)
+        .map(|path| if path.is_absolute() { path.into_owned() } else { worktree_root.join(path) })
+        .unwrap_or_else(|| git_dir.join("hooks"));
     Ok(GitPaths { worktree_root, git_dir, git_common_dir, hooks_dir })
-}
-pub(crate) fn git_rev_parse(root: &Path, arg: &str) -> anyhow::Result<PathBuf> {
-    let mut command = Command::new("git");
-    command.arg("-C").arg(root).arg("rev-parse");
-    for part in arg.split_whitespace() {
-        command.arg(part);
-    }
-    let output = command.output()?;
-    if !output.status.success() {
-        anyhow::bail!(
-            "git rev-parse {arg} failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-    }
-    let value = String::from_utf8(output.stdout)?.trim().to_string();
-    let path = PathBuf::from(value);
-    Ok(if path.is_absolute() { path } else { root.join(path) })
 }
 pub(crate) fn install_hook(hooks_dir: &Path, hook: &str) -> anyhow::Result<()> {
     let path = hooks_dir.join(hook);

--- a/crates/rag-rat-cli/src/hooks_support.rs
+++ b/crates/rag-rat-cli/src/hooks_support.rs
@@ -11,14 +11,17 @@ pub(crate) fn git_paths(root: &Path) -> anyhow::Result<GitPaths> {
     };
     let git_dir = absolutize(repo.git_dir());
     let git_common_dir = absolutize(repo.common_dir());
-    // `core.hooksPath` overrides the default `<git-dir>/hooks` (git resolves a relative value
-    // against the worktree); fall back to the standard location otherwise.
+    // `core.hooksPath` overrides the default (git resolves a relative value against the worktree);
+    // otherwise the default is the COMMON hooks dir — a linked worktree shares `<main>/.git/hooks`,
+    // NOT its private `<git-dir>/worktrees/<name>/hooks`, so installing there would write hooks git
+    // never runs (#213 review). For the main worktree git_dir == common_dir, so this is correct
+    // there too.
     let hooks_dir = repo
         .config_snapshot()
         .trusted_path("core.hooksPath")
         .and_then(Result::ok)
         .map(|path| if path.is_absolute() { path.into_owned() } else { worktree_root.join(path) })
-        .unwrap_or_else(|| git_dir.join("hooks"));
+        .unwrap_or_else(|| git_common_dir.join("hooks"));
     Ok(GitPaths { worktree_root, git_dir, git_common_dir, hooks_dir })
 }
 pub(crate) fn install_hook(hooks_dir: &Path, hook: &str) -> anyhow::Result<()> {

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -4,7 +4,6 @@ mod fs_atomic;
 mod hooks_support;
 mod render;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::time::Instant;
 use std::{env, fs};
 

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -352,20 +352,8 @@ fn shared_db_base(root: &Path) -> PathBuf {
 /// a standard git repo (bare repo, custom `GIT_DIR`, git unavailable) so resolution falls back to
 /// `root` — never guess.
 fn main_worktree_root(root: &Path) -> Option<PathBuf> {
-    let output = std::process::Command::new("git")
-        .arg("-C")
-        .arg(root)
-        .args(["rev-parse", "--git-common-dir"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let common_dir = String::from_utf8(output.stdout).ok()?.trim().to_string();
-    if common_dir.is_empty() {
-        return None;
-    }
-    let common_dir = root.join(common_dir).canonicalize().ok()?;
+    let repo = gix::discover(root).ok()?;
+    let common_dir = repo.common_dir().canonicalize().ok()?;
     // Only the standard `<main>/.git` layout maps cleanly to a main worktree root.
     if common_dir.file_name()?.to_str()? != ".git" {
         return None;

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -352,7 +352,7 @@ fn shared_db_base(root: &Path) -> PathBuf {
 /// a standard git repo (bare repo, custom `GIT_DIR`, git unavailable) so resolution falls back to
 /// `root` — never guess.
 fn main_worktree_root(root: &Path) -> Option<PathBuf> {
-    let repo = gix::discover(root).ok()?;
+    let repo = crate::index::discover_repo(root).ok()?;
     let common_dir = repo.common_dir().canonicalize().ok()?;
     // Only the standard `<main>/.git` layout maps cleanly to a main worktree root.
     if common_dir.file_name()?.to_str()? != ".git" {

--- a/crates/rag-rat-core/src/index/git_context.rs
+++ b/crates/rag-rat-core/src/index/git_context.rs
@@ -71,14 +71,6 @@ pub(crate) fn matches_simple_pattern(path: &str, pattern: &str) -> bool {
     path == pattern || path.contains(pattern.trim_matches('*'))
 }
 
-pub(crate) fn git_output(root: &Path, args: &[&str]) -> Option<String> {
-    let output = Command::new("git").args(args).current_dir(root).output().ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
-}
-
 /// HEAD commit sha for `root` via gix, or empty if unborn / not a repo (matching the old
 /// `rev-parse HEAD` failure behavior).
 pub(crate) fn head_sha(root: &Path) -> String {
@@ -121,14 +113,30 @@ pub fn resolve_git_context(root: &Path) -> (String, String) {
 pub(crate) fn live_worktree_contexts(root: &Path) -> (Vec<String>, Vec<String>) {
     let mut commits = Vec::new();
     let mut worktrees = Vec::new();
-    let Some(output) = git_output(root, &["worktree", "list", "--porcelain"]) else {
+    let Ok(repo) = gix::discover(root) else {
         return (commits, worktrees);
     };
-    for line in output.lines() {
-        if let Some(path) = line.strip_prefix("worktree ") {
-            worktrees.push(path.trim().trim_end_matches('/').to_string());
-        } else if let Some(sha) = line.strip_prefix("HEAD ") {
-            commits.push(sha.trim().to_string());
+    let push_path = |worktrees: &mut Vec<String>, path: &Path| {
+        worktrees.push(path.to_string_lossy().trim_end_matches('/').to_string());
+    };
+    // The main worktree (gix `worktrees()` lists only the LINKED ones).
+    if let Some(workdir) = repo.workdir() {
+        push_path(&mut worktrees, workdir);
+    }
+    if let Ok(id) = repo.head_id() {
+        commits.push(id.to_hex().to_string());
+    }
+    // Linked worktrees: path from the proxy, HEAD from opening each one.
+    if let Ok(proxies) = repo.worktrees() {
+        for proxy in proxies {
+            if let Ok(base) = proxy.base() {
+                push_path(&mut worktrees, &base);
+            }
+            if let Ok(linked) = proxy.into_repo()
+                && let Ok(id) = linked.head_id()
+            {
+                commits.push(id.to_hex().to_string());
+            }
         }
     }
     (commits, worktrees)

--- a/crates/rag-rat-core/src/index/git_context.rs
+++ b/crates/rag-rat-core/src/index/git_context.rs
@@ -107,30 +107,40 @@ pub fn resolve_git_context(root: &Path) -> (String, String) {
     (commit_sha, worktree_id)
 }
 
-/// The live (commit_sha, worktree_id) keys across every worktree that shares this repo, from
-/// `git worktree list --porcelain`. Each worktree contributes its HEAD commit (for clean rows)
-/// and its path (for dirty/overlay rows). Returns empty vecs outside a git worktree.
+/// The live (commit_sha, worktree_id) keys across every worktree that shares this repo (the gix
+/// equivalent of `git worktree list --porcelain`). Each worktree contributes its HEAD commit (for
+/// clean rows) and its path (for dirty/overlay rows). Returns empty vecs outside a git worktree.
 pub(crate) fn live_worktree_contexts(root: &Path) -> (Vec<String>, Vec<String>) {
     let mut commits = Vec::new();
     let mut worktrees = Vec::new();
     let Ok(repo) = gix::discover(root) else {
         return (commits, worktrees);
     };
-    let push_path = |worktrees: &mut Vec<String>, path: &Path| {
-        worktrees.push(path.to_string_lossy().trim_end_matches('/').to_string());
-    };
-    // The main worktree (gix `worktrees()` lists only the LINKED ones).
-    if let Some(workdir) = repo.workdir() {
-        push_path(&mut worktrees, workdir);
+    let add_repo =
+        |worktrees: &mut Vec<String>, commits: &mut Vec<String>, repo: &gix::Repository| {
+            if let Some(workdir) = repo.workdir() {
+                worktrees.push(workdir.to_string_lossy().trim_end_matches('/').to_string());
+            }
+            if let Ok(id) = repo.head_id() {
+                commits.push(id.to_hex().to_string());
+            }
+        };
+    // The current worktree (may itself be the main one or a linked one).
+    add_repo(&mut worktrees, &mut commits, &repo);
+    // The MAIN worktree, ALWAYS — `worktrees()` enumerates only LINKED worktrees and
+    // `repo.workdir()` is whichever checkout we were launched from, so when that's a linked
+    // worktree the main one would otherwise be missing. A GC reading this set must keep the
+    // main worktree's path/HEAD live or it could prune the main checkout's indexed rows (#213
+    // review). The common dir IS the main repo's git dir.
+    if let Ok(main) = gix::open(repo.common_dir()) {
+        add_repo(&mut worktrees, &mut commits, &main);
     }
-    if let Ok(id) = repo.head_id() {
-        commits.push(id.to_hex().to_string());
-    }
-    // Linked worktrees: path from the proxy, HEAD from opening each one.
+    // Linked worktrees: path from the proxy (robust even if the checkout is gone), HEAD from
+    // opening.
     if let Ok(proxies) = repo.worktrees() {
         for proxy in proxies {
             if let Ok(base) = proxy.base() {
-                push_path(&mut worktrees, &base);
+                worktrees.push(base.to_string_lossy().trim_end_matches('/').to_string());
             }
             if let Ok(linked) = proxy.into_repo()
                 && let Ok(id) = linked.head_id()
@@ -139,5 +149,11 @@ pub(crate) fn live_worktree_contexts(root: &Path) -> (Vec<String>, Vec<String>) 
             }
         }
     }
+    // The current/main/linked sets overlap (e.g. launched from the main worktree); dedup so each
+    // live worktree path + HEAD appears once.
+    worktrees.sort();
+    worktrees.dedup();
+    commits.sort();
+    commits.dedup();
     (commits, worktrees)
 }

--- a/crates/rag-rat-core/src/index/git_context.rs
+++ b/crates/rag-rat-core/src/index/git_context.rs
@@ -98,6 +98,23 @@ pub(crate) fn is_worktree_dirty(root: &Path) -> bool {
     changes.next().is_some()
 }
 
+/// Whether `relative` (a worktree-root-relative path) is modified in the worktree — the per-path,
+/// filter-aware analog of [`is_worktree_dirty`]. gix status respects `.gitattributes` / autocrlf /
+/// LFS normalization, so a clean-but-normalized file is NOT flagged (unlike a raw byte compare).
+/// Conservative: a status error reports "not dirty" so callers (blame) don't lose results on a
+/// transient status hiccup.
+pub(crate) fn path_is_dirty(repo: &gix::Repository, relative: &Path) -> bool {
+    let Ok(platform) = repo.status(gix::progress::Discard) else {
+        return false;
+    };
+    let pathspec = gix::path::into_bstr(relative).into_owned();
+    let Ok(mut changes) = platform.untracked_files(UntrackedFiles::Files).into_iter([pathspec])
+    else {
+        return false;
+    };
+    changes.next().is_some()
+}
+
 /// The active-checkout `(commit_sha, worktree_id)` keys for `root`, as `open_config` derives them.
 /// `pub` so out-of-crate callers that open an index by path (benches mirroring the production
 /// `open_config` path, integration tests) can install the same active-checkout scope `search` uses.

--- a/crates/rag-rat-core/src/index/git_context.rs
+++ b/crates/rag-rat-core/src/index/git_context.rs
@@ -14,10 +14,17 @@ pub(crate) struct GitChangedPaths {
 /// plain `gix::discover` only searches upward from `root`, so it would miss such a repo and leave
 /// git history "unavailable" (clearing the historical tables). All gix discovery goes through here
 /// (#213 review).
+///
+/// Known limitation (#218): gix resolves a RELATIVE `GIT_DIR`/`GIT_WORK_TREE` against the process
+/// cwd, not against `root` (the old `git -C root` resolved them against `root`). Absolute env
+/// values, and relative ones when cwd == `root`, work; relative values from a foreign cwd don't.
+/// gix exposes no way to open with an explicit (git-dir, worktree) pair from outside the crate, so
+/// re-rooting cleanly isn't possible without process-global cwd/env mutation (racy under the
+/// parallel indexer).
 pub(crate) fn discover_repo(root: &Path) -> Result<gix::Repository, Box<gix::discover::Error>> {
-    // Box the error: gix's `discover::Error` is a large enum, and an unboxed large `Err` bloats every
-    // `Result` this returns (clippy::result_large_err). Callers use `.ok()` or `?` (anyhow), both of
-    // which handle the box transparently.
+    // Box the error: gix's `discover::Error` is a large enum, and an unboxed large `Err` bloats
+    // every `Result` this returns (clippy::result_large_err). Callers use `.ok()` or `?`
+    // (anyhow), both of which handle the box transparently.
     gix::discover_with_environment_overrides(root).map_err(Box::new)
 }
 

--- a/crates/rag-rat-core/src/index/git_context.rs
+++ b/crates/rag-rat-core/src/index/git_context.rs
@@ -9,8 +9,20 @@ pub(crate) struct GitChangedPaths {
     pub(crate) deleted: BTreeSet<PathBuf>,
 }
 
+/// Open the git repository for `root` via gix, honoring `GIT_DIR` / `GIT_WORK_TREE` — a bare git
+/// dir plus an external worktree (e.g. in CI) is configured purely through those env vars, and
+/// plain `gix::discover` only searches upward from `root`, so it would miss such a repo and leave
+/// git history "unavailable" (clearing the historical tables). All gix discovery goes through here
+/// (#213 review).
+pub(crate) fn discover_repo(root: &Path) -> Result<gix::Repository, Box<gix::discover::Error>> {
+    // Box the error: gix's `discover::Error` is a large enum, and an unboxed large `Err` bloats every
+    // `Result` this returns (clippy::result_large_err). Callers use `.ok()` or `?` (anyhow), both of
+    // which handle the box transparently.
+    gix::discover_with_environment_overrides(root).map_err(Box::new)
+}
+
 pub(crate) fn git_changed_paths(root: &Path) -> anyhow::Result<GitChangedPaths> {
-    let repo = gix::discover(root)?;
+    let repo = discover_repo(root)?;
     let worktree_root = repo
         .workdir()
         .ok_or_else(|| anyhow::anyhow!("git repository has no worktree"))?
@@ -74,7 +86,7 @@ pub(crate) fn matches_simple_pattern(path: &str, pattern: &str) -> bool {
 /// HEAD commit sha for `root` via gix, or empty if unborn / not a repo (matching the old
 /// `rev-parse HEAD` failure behavior).
 pub(crate) fn head_sha(root: &Path) -> String {
-    gix::discover(root)
+    discover_repo(root)
         .ok()
         .and_then(|repo| repo.head_id().ok().map(|id| id.to_hex().to_string()))
         .unwrap_or_default()
@@ -83,7 +95,7 @@ pub(crate) fn head_sha(root: &Path) -> String {
 /// Whether the worktree has any uncommitted change (tracked modifications + untracked files), the
 /// gix equivalent of a non-empty `git status --porcelain`. Lazy: stops at the first change.
 pub(crate) fn is_worktree_dirty(root: &Path) -> bool {
-    let Ok(repo) = gix::discover(root) else {
+    let Ok(repo) = discover_repo(root) else {
         return false;
     };
     let Ok(platform) = repo.status(gix::progress::Discard) else {
@@ -130,7 +142,7 @@ pub fn resolve_git_context(root: &Path) -> (String, String) {
 pub(crate) fn live_worktree_contexts(root: &Path) -> (Vec<String>, Vec<String>) {
     let mut commits = Vec::new();
     let mut worktrees = Vec::new();
-    let Ok(repo) = gix::discover(root) else {
+    let Ok(repo) = discover_repo(root) else {
         return (commits, worktrees);
     };
     let add_repo =
@@ -153,13 +165,16 @@ pub(crate) fn live_worktree_contexts(root: &Path) -> (Vec<String>, Vec<String>) 
         add_repo(&mut worktrees, &mut commits, &main);
     }
     // Linked worktrees: path from the proxy (robust even if the checkout is gone), HEAD from
-    // opening.
+    // opening the worktree's git dir. Use the inaccessible-tolerant open so a
+    // temporarily-missing checkout STILL contributes its registered HEAD — otherwise a clean
+    // row keyed by that commit could be GC-pruned even though the worktree is still registered
+    // and may return (#213 review).
     if let Ok(proxies) = repo.worktrees() {
         for proxy in proxies {
             if let Ok(base) = proxy.base() {
                 worktrees.push(base.to_string_lossy().trim_end_matches('/').to_string());
             }
-            if let Ok(linked) = proxy.into_repo()
+            if let Ok(linked) = proxy.into_repo_with_possibly_inaccessible_worktree()
                 && let Ok(id) = linked.head_id()
             {
                 commits.push(id.to_hex().to_string());

--- a/crates/rag-rat-core/src/index/git_context.rs
+++ b/crates/rag-rat-core/src/index/git_context.rs
@@ -79,12 +79,38 @@ pub(crate) fn git_output(root: &Path, args: &[&str]) -> Option<String> {
     Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
+/// HEAD commit sha for `root` via gix, or empty if unborn / not a repo (matching the old
+/// `rev-parse HEAD` failure behavior).
+pub(crate) fn head_sha(root: &Path) -> String {
+    gix::discover(root)
+        .ok()
+        .and_then(|repo| repo.head_id().ok().map(|id| id.to_hex().to_string()))
+        .unwrap_or_default()
+}
+
+/// Whether the worktree has any uncommitted change (tracked modifications + untracked files), the
+/// gix equivalent of a non-empty `git status --porcelain`. Lazy: stops at the first change.
+pub(crate) fn is_worktree_dirty(root: &Path) -> bool {
+    let Ok(repo) = gix::discover(root) else {
+        return false;
+    };
+    let Ok(platform) = repo.status(gix::progress::Discard) else {
+        return false;
+    };
+    // No pathspec → the whole worktree; lazy, so `.next()` stops at the first change.
+    let Ok(mut changes) =
+        platform.untracked_files(UntrackedFiles::Files).into_iter(None::<gix::bstr::BString>)
+    else {
+        return false;
+    };
+    changes.next().is_some()
+}
+
 /// The active-checkout `(commit_sha, worktree_id)` keys for `root`, as `open_config` derives them.
 /// `pub` so out-of-crate callers that open an index by path (benches mirroring the production
 /// `open_config` path, integration tests) can install the same active-checkout scope `search` uses.
 pub fn resolve_git_context(root: &Path) -> (String, String) {
-    let commit_sha =
-        git_output(root, &["rev-parse", "HEAD"]).map(|s| s.trim().to_string()).unwrap_or_default();
+    let commit_sha = head_sha(root);
     let worktree_id = root.to_string_lossy().trim_end_matches('/').to_string();
     (commit_sha, worktree_id)
 }

--- a/crates/rag-rat-core/src/index/git_history.rs
+++ b/crates/rag-rat-core/src/index/git_history.rs
@@ -558,26 +558,25 @@ fn read_history_inner(
         };
         let hash = record.hash.clone();
         let parent_ids: Vec<_> = commit.parent_ids().collect();
-        // MERGE commit: `git log --numstat -- .` does NOT pass `--diff-merges`, so a merge shows no
-        // per-file diff. Diffing it against its first parent would wrongly attribute the merged
-        // branch's paths to the merge and inflate `changed_file_count` (#213 review). Record the
-        // commit (it's part of history / FTS) with no file changes.
-        if parent_ids.len() > 1 {
-            commits.push(record);
-            continue;
-        }
         let new_tree = commit.tree()?;
-        // A shallow clone's boundary commit lists a parent whose object is ABSENT; treat it like a
-        // root commit (diff against the empty tree) instead of aborting, so its changed paths are
-        // still recorded — matching `git log --numstat` on a shallow clone (#213 review).
-        let parent_tree = match parent_ids.first() {
-            Some(parent) => repo
-                .find_commit(parent.detach())
-                .ok()
-                .and_then(|parent| parent.tree().ok())
-                .unwrap_or_else(|| repo.empty_tree()),
-            None => repo.empty_tree(),
+        // First parent's tree + whether its object is PRESENT. A missing object (shallow-clone
+        // boundary) → empty tree, treated as a ROOT: it records the full diff vs the empty tree
+        // (matching `git log --numstat` on a shallow clone), so even a shallow MERGE tip records
+        // its files instead of looking like a zero-change merge (#213 review).
+        let (parent_tree, parent_present) = match parent_ids.first() {
+            Some(parent) =>
+                match repo.find_commit(parent.detach()).ok().and_then(|p| p.tree().ok()) {
+                    Some(tree) => (tree, true),
+                    None => (repo.empty_tree(), false),
+                },
+            None => (repo.empty_tree(), false),
         };
+        // A real MERGE (>1 parent, first parent present) records NO per-file changes — `git log
+        // --numstat` has no `--diff-merges` — but its first-parent diff still decides whether the
+        // commit is IN SCOPE (a merge that didn't touch `root` is omitted, like `git log -- .` /
+        // `-- <subtree>`). A shallow boundary (parent absent) is a root, so it DOES record its
+        // diff.
+        let is_merge_with_parent = parent_ids.len() > 1 && parent_present;
         diff_cache.clear_resource_cache();
         let mut commit_changes = Vec::new();
         parent_tree
@@ -592,16 +591,21 @@ fn read_history_inner(
                 push_file_change(&change, &hash, scope.as_deref(), &mut diff_cache, &mut commit_changes);
                 Ok::<_, std::convert::Infallible>(Action::Continue(()))
             })?;
-        // A commit with no file changes in scope is not part of this index's history: the old
-        // `git log <head> -- .` pathspec applied history simplification and listed NEITHER empty
-        // commits (even at the repo root) NOR subtree-scoped commits that didn't touch `root` (#213
-        // review). (A root/shallow-boundary commit diffs against the empty tree, so it has changes
-        // and is kept; a mode-only change also counts.)
+        // No in-scope changes vs the first parent → not part of this index's history: `git log --
+        // .` / `-- <subtree>` history simplification lists NEITHER empty commits (even at
+        // the repo root) NOR merges/commits that didn't touch the scope (#213 review). (A
+        // root/shallow-boundary commit diffs against the empty tree, so it has changes and
+        // is kept; a mode-only change also counts.)
         if commit_changes.is_empty() {
             continue;
         }
         commits.push(record);
-        changes.append(&mut commit_changes);
+        // A real merge's first-parent diff was used ONLY for the scope decision above — do NOT
+        // record it (numstat has no merge diff). Non-merges and shallow-boundary roots
+        // record their changes.
+        if !is_merge_with_parent {
+            changes.append(&mut commit_changes);
+        }
     }
     Ok(())
 }
@@ -621,39 +625,50 @@ fn push_file_change(
     // alongside their leaves). A rename/copy is recorded once at the DESTINATION (the old
     // numstat parser normalized `old => new` to the destination), with counts from the
     // rewrite's content diff (`None` for a pure 100%-similar rename) (#213 review).
-    let (change_kind, location, additions, deletions) = match change {
+    // Each arm yields (change_kind, ROOT-RELATIVE path, counts) or returns. `scope_relative` maps a
+    // worktree-root-relative location to the index-root-relative path (or `None` = outside `root`).
+    let (change_kind, path, additions, deletions) = match change {
         Change::Addition { location, entry_mode, .. } if !entry_mode.is_tree() => {
+            let Some(path) = scope_relative(scope, &location.to_string()) else { return };
             let (additions, deletions) = blob_line_counts(change, diff_cache);
-            ("added", location.to_string(), additions, deletions)
+            ("added", path, additions, deletions)
         },
         Change::Deletion { location, entry_mode, .. } if !entry_mode.is_tree() => {
+            let Some(path) = scope_relative(scope, &location.to_string()) else { return };
             let (additions, deletions) = blob_line_counts(change, diff_cache);
-            ("deleted", location.to_string(), additions, deletions)
+            ("deleted", path, additions, deletions)
         },
         Change::Modification { location, entry_mode, .. } if !entry_mode.is_tree() => {
+            let Some(path) = scope_relative(scope, &location.to_string()) else { return };
             let (additions, deletions) = blob_line_counts(change, diff_cache);
-            ("modified", location.to_string(), additions, deletions)
+            ("modified", path, additions, deletions)
         },
-        Change::Rewrite { location, entry_mode, diff, copy, .. } if !entry_mode.is_tree() => {
+        Change::Rewrite { location, source_location, entry_mode, diff, copy, .. }
+            if !entry_mode.is_tree() =>
+        {
+            // A rename/copy can cross the index-root boundary in a subtree index, so filter EACH
+            // side by scope: both inside → one entry at the destination (a rename
+            // within the subtree); source-only inside → the file LEFT the subtree,
+            // recorded as a deletion; dest-only inside → it ENTERED the subtree,
+            // recorded as an addition. Matches what `git log --numstat -- <subtree>`
+            // reported for a boundary-crossing move (#213 review).
+            let source = scope_relative(scope, &source_location.to_string());
+            let destination = scope_relative(scope, &location.to_string());
             let (additions, deletions) = diff.as_ref().map_or((None, None), |stats| {
                 (Some(i64::from(stats.insertions)), Some(i64::from(stats.removals)))
             });
-            (if *copy { "copied" } else { "renamed" }, location.to_string(), additions, deletions)
+            match (source, destination) {
+                (Some(_), Some(path)) =>
+                    (if *copy { "copied" } else { "renamed" }, path, additions, deletions),
+                // Crossing the boundary: counts are unknown (the rewrite diff is the content delta,
+                // not the full add/delete) — the path + kind are what path history needs.
+                (None, Some(path)) => ("added", path, None, None),
+                (Some(path), None) => ("deleted", path, None, None),
+                (None, None) => return,
+            }
         },
         // A tree entry, or any future variant: not a leaf path change.
         _ => return,
-    };
-    // `location` is worktree-root-relative. At the worktree root keep it as-is; under a subtree
-    // index keep ONLY paths inside the subtree and make them root-relative — paths outside
-    // `root` are dropped so a subdirectory index doesn't record the wider worktree's changes
-    // (#213 review).
-    let path = match scope {
-        None => location,
-        Some(prefix) => match location.strip_prefix(prefix).and_then(|rest| rest.strip_prefix('/'))
-        {
-            Some(under_root) => under_root.to_string(),
-            None => return,
-        },
     };
     out.push(FileChange {
         commit_hash: hash.to_string(),
@@ -662,6 +677,19 @@ fn push_file_change(
         deletions,
         change_kind: change_kind.to_string(),
     });
+}
+
+/// Map a worktree-root-relative `location` to the index-root-relative path, or `None` if it falls
+/// outside the index `root`. At the worktree root (`scope` is `None`) it's the location unchanged;
+/// under a subtree index the location must start with the subtree prefix (#213 review).
+fn scope_relative(scope: Option<&str>, location: &str) -> Option<String> {
+    match scope {
+        None => Some(location.to_string()),
+        Some(prefix) => location
+            .strip_prefix(prefix)
+            .and_then(|rest| rest.strip_prefix('/'))
+            .map(str::to_string),
+    }
 }
 
 /// Line counts for a blob/symlink change via gix's blob diff. `(None, None)` for a

--- a/crates/rag-rat-core/src/index/git_history.rs
+++ b/crates/rag-rat-core/src/index/git_history.rs
@@ -658,17 +658,18 @@ fn count_table(conn: &Connection, table: &str) -> anyhow::Result<u64> {
 /// git call (the ignore matcher anchors its `.gitignore` ancestor stack here — issue #62 finding 3:
 /// a `config.root` that is a subdirectory of a larger worktree must honor the worktree-root rules).
 pub(crate) fn worktree_root(root: &Path) -> Option<PathBuf> {
-    git_output(root, &["rev-parse", "--show-toplevel"]).map(PathBuf::from)
+    gix::discover(root).ok()?.workdir().map(Path::to_path_buf)
 }
 
 fn git_repo(root: &Path) -> Option<GitRepo> {
-    let worktree_root = git_output(root, &["rev-parse", "--show-toplevel"])?;
-    let head = git_output(root, &["rev-parse", "HEAD"])?;
-    // `--is-shallow-repository` prints "true"/"false" (git 2.15+). Treat a probe failure as
-    // not-shallow: the worst case is one redundant full reload, never a skipped one.
-    let shallow =
-        git_output(root, &["rev-parse", "--is-shallow-repository"]).as_deref() == Some("true");
-    Some(GitRepo { worktree_root: PathBuf::from(worktree_root), head, shallow })
+    let repo = gix::discover(root).ok()?;
+    // `workdir()` is `None` for a bare repo — there is no worktree to index, so treat it as
+    // "no git" (the previous `--show-toplevel` failed there too).
+    let worktree_root = repo.workdir()?.to_path_buf();
+    // `head_id()` fails on an unborn HEAD (empty repo) — same as the old `rev-parse HEAD`.
+    let head = repo.head_id().ok()?.to_hex().to_string();
+    let shallow = repo.is_shallow();
+    Some(GitRepo { worktree_root, head, shallow })
 }
 
 /// Canonical serialization of the indexed root for the reload gate. The git-history row set is

--- a/crates/rag-rat-core/src/index/git_history.rs
+++ b/crates/rag-rat-core/src/index/git_history.rs
@@ -447,6 +447,10 @@ fn blame_lines_via_gix(
     let end = u32::try_from(end_line.max(start_line)).unwrap_or(start);
     let options = gix::repository::blame_file::Options {
         ranges: gix::blame::BlameRanges::from_one_based_inclusive_range(start..=end)?,
+        // Follow whole-file renames, like `git blame` does by default — otherwise every unchanged
+        // line in a renamed file is attributed to the rename commit instead of its original author,
+        // skewing the chunk's dominant/newest/oldest commit (#213 review).
+        rewrites: Some(gix::diff::Rewrites::default()),
         ..Default::default()
     };
     let outcome = repo.blame_file(file_path.as_ref(), head, options)?;
@@ -592,10 +596,11 @@ fn read_history_inner(
     Ok(())
 }
 
-/// Record one tree-diff change as a `FileChange` — files only (regular blobs AND symlinks; trees
-/// and submodule gitlinks are skipped) — with exact additions/deletions from a blob line-diff. A
-/// binary/uncountable diff yields `None` counts (the numstat `-` case). Symlinks are included
-/// because `git log --numstat` records them as changed paths (#213 review).
+/// Record one tree-diff change as a `FileChange` — any leaf path change (regular blob, symlink, OR
+/// submodule gitlink), skipping only directory (tree) entries — with additions/deletions from a
+/// blob line-diff. A binary/uncountable diff (and gitlinks, whose "content" is a commit id) yields
+/// `None` counts (the numstat `-` case). Symlinks and gitlinks are included because `git log
+/// --numstat` records them as changed paths (#213 review).
 fn push_file_change(
     change: &Change<'_, '_, '_>,
     hash: &str,
@@ -603,17 +608,20 @@ fn push_file_change(
     diff_cache: &mut gix::diff::blob::Platform,
     out: &mut Vec<FileChange>,
 ) {
-    let (change_kind, location, is_file) = match change {
+    // Keep blob / symlink / gitlink changes; drop only TREE entries (directory nodes the diff may
+    // emit alongside their leaf changes) — matching `git log --numstat`, which lists submodule
+    // pointer changes too (#213 review).
+    let (change_kind, location, is_path_change) = match change {
         Change::Addition { location, entry_mode, .. } =>
-            ("added", *location, entry_mode.is_blob_or_symlink()),
+            ("added", *location, !entry_mode.is_tree()),
         Change::Deletion { location, entry_mode, .. } =>
-            ("deleted", *location, entry_mode.is_blob_or_symlink()),
+            ("deleted", *location, !entry_mode.is_tree()),
         Change::Modification { location, entry_mode, .. } =>
-            ("modified", *location, entry_mode.is_blob_or_symlink()),
+            ("modified", *location, !entry_mode.is_tree()),
         // Rewrites are disabled above; ignore defensively if config ever forces them on.
         Change::Rewrite { .. } => return,
     };
-    if !is_file {
+    if !is_path_change {
         return;
     }
     // `location` is worktree-root-relative. At the worktree root keep it as-is; under a subtree

--- a/crates/rag-rat-core/src/index/git_history.rs
+++ b/crates/rag-rat-core/src/index/git_history.rs
@@ -428,6 +428,27 @@ fn blame_lines_via_gix(
     let worktree_root = repo.workdir().unwrap_or(root);
     let absolute = root.join(path);
     let relative = absolute.strip_prefix(worktree_root).unwrap_or_else(|_| Path::new(path));
+
+    // Blame attributes lines in HEAD's version of the file. If the working tree differs from HEAD
+    // (a dirty file, or one not in HEAD at all), its line numbers don't align with HEAD, so a HEAD
+    // blame would shift/mis-attribute the chunk's lines — and `git_blame_chunk` would cache that
+    // wrong result under the dirty content hash (#213 review). Only blame a file that is byte-for-
+    // byte identical to HEAD; otherwise return no attribution. (`git blame` with no revision blamed
+    // the worktree directly, marking uncommitted lines `0000000`; gix blames committed objects
+    // only, so a clean-file guard is the faithful, safe equivalent.)
+    let head_blob = repo
+        .find_commit(head)
+        .ok()
+        .and_then(|commit| commit.tree().ok())
+        .and_then(|tree| tree.lookup_entry_by_path(relative).ok().flatten())
+        .and_then(|entry| entry.object().ok())
+        .map(|object| object.data.clone());
+    match (head_blob, std::fs::read(&absolute)) {
+        (Some(head_bytes), Ok(worktree_bytes)) if head_bytes == worktree_bytes => {},
+        // Dirty / new / unreadable: skip rather than cache misaligned attribution.
+        _ => return Ok(Vec::new()),
+    }
+
     let file_path = gix::path::into_bstr(relative);
     let start = u32::try_from(start_line.max(1)).unwrap_or(1);
     let end = u32::try_from(end_line.max(start_line)).unwrap_or(start);

--- a/crates/rag-rat-core/src/index/git_history.rs
+++ b/crates/rag-rat-core/src/index/git_history.rs
@@ -421,7 +421,7 @@ fn blame_lines_via_gix(
     start_line: i64,
     end_line: i64,
 ) -> anyhow::Result<Vec<BlameLine>> {
-    let repo = gix::discover(root)?;
+    let repo = crate::index::git_context::discover_repo(root)?;
     let head = repo.head_id()?.detach();
     // gix blames a path relative to the WORKTREE root; the caller's path is relative to the index
     // root, which may be a subdirectory of the worktree.
@@ -517,7 +517,7 @@ fn read_history_inner(
     commits: &mut Vec<CommitRecord>,
     changes: &mut Vec<FileChange>,
 ) -> anyhow::Result<()> {
-    let mut repo = gix::discover(root)?;
+    let mut repo = crate::index::git_context::discover_repo(root)?;
     // The by-commit-time walk + per-commit tree diffs look up each commit/tree more than once; an
     // object cache avoids repeated zlib inflation (gitoxide's own recommendation for these passes).
     repo.object_cache_size_if_unset(16 * 1024 * 1024);
@@ -578,9 +578,12 @@ fn read_history_inner(
                 push_file_change(&change, &hash, scope.as_deref(), &mut diff_cache, &mut commit_changes);
                 Ok::<_, std::convert::Infallible>(Action::Continue(()))
             })?;
-        // A subtree-scoped commit that didn't touch `root` is not part of this index's history (the
-        // old `git log -- <subtree>` would not have listed it).
-        if scope.is_some() && commit_changes.is_empty() {
+        // A commit with no file changes in scope is not part of this index's history: the old
+        // `git log <head> -- .` pathspec applied history simplification and listed NEITHER empty
+        // commits (even at the repo root) NOR subtree-scoped commits that didn't touch `root` (#213
+        // review). (A root/shallow-boundary commit diffs against the empty tree, so it has changes
+        // and is kept; a mode-only change also counts.)
+        if commit_changes.is_empty() {
             continue;
         }
         commits.push(record);
@@ -589,9 +592,10 @@ fn read_history_inner(
     Ok(())
 }
 
-/// Record one tree-diff change as a `FileChange` — file blobs only (trees/submodules are skipped) —
-/// with exact additions/deletions from a blob line-diff. A binary/uncountable diff yields `None`
-/// counts (the numstat `-` case).
+/// Record one tree-diff change as a `FileChange` — files only (regular blobs AND symlinks; trees
+/// and submodule gitlinks are skipped) — with exact additions/deletions from a blob line-diff. A
+/// binary/uncountable diff yields `None` counts (the numstat `-` case). Symlinks are included
+/// because `git log --numstat` records them as changed paths (#213 review).
 fn push_file_change(
     change: &Change<'_, '_, '_>,
     hash: &str,
@@ -599,16 +603,17 @@ fn push_file_change(
     diff_cache: &mut gix::diff::blob::Platform,
     out: &mut Vec<FileChange>,
 ) {
-    let (change_kind, location, is_blob) = match change {
-        Change::Addition { location, entry_mode, .. } => ("added", *location, entry_mode.is_blob()),
+    let (change_kind, location, is_file) = match change {
+        Change::Addition { location, entry_mode, .. } =>
+            ("added", *location, entry_mode.is_blob_or_symlink()),
         Change::Deletion { location, entry_mode, .. } =>
-            ("deleted", *location, entry_mode.is_blob()),
+            ("deleted", *location, entry_mode.is_blob_or_symlink()),
         Change::Modification { location, entry_mode, .. } =>
-            ("modified", *location, entry_mode.is_blob()),
+            ("modified", *location, entry_mode.is_blob_or_symlink()),
         // Rewrites are disabled above; ignore defensively if config ever forces them on.
         Change::Rewrite { .. } => return,
     };
-    if !is_blob {
+    if !is_file {
         return;
     }
     // `location` is worktree-root-relative. At the worktree root keep it as-is; under a subtree
@@ -709,11 +714,11 @@ fn count_table(conn: &Connection, table: &str) -> anyhow::Result<u64> {
 /// git call (the ignore matcher anchors its `.gitignore` ancestor stack here — issue #62 finding 3:
 /// a `config.root` that is a subdirectory of a larger worktree must honor the worktree-root rules).
 pub(crate) fn worktree_root(root: &Path) -> Option<PathBuf> {
-    gix::discover(root).ok()?.workdir().map(Path::to_path_buf)
+    crate::index::git_context::discover_repo(root).ok()?.workdir().map(Path::to_path_buf)
 }
 
 fn git_repo(root: &Path) -> Option<GitRepo> {
-    let repo = gix::discover(root).ok()?;
+    let repo = crate::index::git_context::discover_repo(root).ok()?;
     // `workdir()` is `None` for a bare repo — there is no worktree to index, so treat it as
     // "no git" (the previous `--show-toplevel` failed there too).
     let worktree_root = repo.workdir()?.to_path_buf();

--- a/crates/rag-rat-core/src/index/git_history.rs
+++ b/crates/rag-rat-core/src/index/git_history.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use gix::object::tree::diff::{Action, Change};
 use gix::revision::walk::Sorting;
@@ -411,12 +410,49 @@ pub fn store_blame(conn: &Connection, summary: &ChunkBlameSummary) -> anyhow::Re
 }
 
 pub fn blame_lines(root: &Path, path: &str, start_line: i64, end_line: i64) -> Vec<BlameLine> {
-    let range = format!("{start_line},{end_line}");
-    let Some(output) = git_output(root, &["blame", "--line-porcelain", "-L", &range, "--", path])
-    else {
-        return Vec::new();
+    blame_lines_via_gix(root, path, start_line, end_line).unwrap_or_default()
+}
+
+/// Blame `start_line..=end_line` (1-based) of `path` via gix, one `BlameLine` per source line in
+/// order, attributing each to the commit gix's blame found and that commit's author time (#212).
+fn blame_lines_via_gix(
+    root: &Path,
+    path: &str,
+    start_line: i64,
+    end_line: i64,
+) -> anyhow::Result<Vec<BlameLine>> {
+    let repo = gix::discover(root)?;
+    let head = repo.head_id()?.detach();
+    // gix blames a path relative to the WORKTREE root; the caller's path is relative to the index
+    // root, which may be a subdirectory of the worktree.
+    let worktree_root = repo.workdir().unwrap_or(root);
+    let absolute = root.join(path);
+    let relative = absolute.strip_prefix(worktree_root).unwrap_or_else(|_| Path::new(path));
+    let file_path = gix::path::into_bstr(relative);
+    let start = u32::try_from(start_line.max(1)).unwrap_or(1);
+    let end = u32::try_from(end_line.max(start_line)).unwrap_or(start);
+    let options = gix::repository::blame_file::Options {
+        ranges: gix::blame::BlameRanges::from_one_based_inclusive_range(start..=end)?,
+        ..Default::default()
     };
-    parse_blame(&output)
+    let outcome = repo.blame_file(file_path.as_ref(), head, options)?;
+    let mut entries = outcome.entries;
+    entries.sort_by_key(|entry| entry.start_in_blamed_file);
+    let mut author_time: std::collections::HashMap<gix::ObjectId, Option<i64>> =
+        std::collections::HashMap::new();
+    let mut lines = Vec::new();
+    for entry in entries {
+        let commit = entry.commit_id.to_hex().to_string();
+        let time = *author_time.entry(entry.commit_id).or_insert_with(|| {
+            repo.find_commit(entry.commit_id)
+                .ok()
+                .and_then(|c| c.author().ok().map(|a| a.seconds()))
+        });
+        for _ in 0..entry.len.get() {
+            lines.push(BlameLine { commit: commit.clone(), author_time_s: time });
+        }
+    }
+    Ok(lines)
 }
 
 #[derive(Debug, Clone)]
@@ -575,32 +611,6 @@ fn normalize_git_path(root: &Path, worktree_root: &Path, path: &str) -> Option<S
     None
 }
 
-fn parse_blame(output: &str) -> Vec<BlameLine> {
-    let mut lines = Vec::new();
-    let mut current_commit = None::<String>;
-    let mut current_time = None::<i64>;
-    for line in output.lines() {
-        if let Some((hash, _rest)) = line.split_once(' ')
-            && hash.len() == 40
-            && hash.chars().all(|c| c.is_ascii_hexdigit())
-        {
-            current_commit = Some(hash.to_string());
-            current_time = None;
-            continue;
-        }
-        if let Some(value) = line.strip_prefix("author-time ") {
-            current_time = value.parse().ok();
-            continue;
-        }
-        if line.starts_with('\t')
-            && let Some(commit) = current_commit.clone()
-        {
-            lines.push(BlameLine { commit, author_time_s: current_time });
-        }
-    }
-    lines
-}
-
 fn path_history_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<PathHistoryItem> {
     Ok(PathHistoryItem {
         hash: row.get(0)?,
@@ -709,14 +719,6 @@ pub(crate) fn is_history_current(conn: &Connection, root: &Path) -> bool {
         Ok(head_matches && root_matches && prior_was_full && has_rows)
     };
     probe().unwrap_or(false)
-}
-
-fn git_output(root: &Path, args: &[&str]) -> Option<String> {
-    let output = Command::new("git").args(args).current_dir(root).output().ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 fn fts_query(query: &str) -> String {

--- a/crates/rag-rat-core/src/index/git_history.rs
+++ b/crates/rag-rat-core/src/index/git_history.rs
@@ -557,11 +557,20 @@ fn read_history_inner(
             body: body.trim().to_string(),
         };
         let hash = record.hash.clone();
+        let parent_ids: Vec<_> = commit.parent_ids().collect();
+        // MERGE commit: `git log --numstat -- .` does NOT pass `--diff-merges`, so a merge shows no
+        // per-file diff. Diffing it against its first parent would wrongly attribute the merged
+        // branch's paths to the merge and inflate `changed_file_count` (#213 review). Record the
+        // commit (it's part of history / FTS) with no file changes.
+        if parent_ids.len() > 1 {
+            commits.push(record);
+            continue;
+        }
         let new_tree = commit.tree()?;
         // A shallow clone's boundary commit lists a parent whose object is ABSENT; treat it like a
         // root commit (diff against the empty tree) instead of aborting, so its changed paths are
         // still recorded — matching `git log --numstat` on a shallow clone (#213 review).
-        let parent_tree = match commit.parent_ids().next() {
+        let parent_tree = match parent_ids.first() {
             Some(parent) => repo
                 .find_commit(parent.detach())
                 .ok()
@@ -573,10 +582,11 @@ fn read_history_inner(
         let mut commit_changes = Vec::new();
         parent_tree
             .changes()?
-            // Full paths for each change; NO rename detection — a rename shows as a deletion +
-            // addition, matching `git log --numstat` without `-M` (and avoiding the Rewrite variant).
+            // Full paths, AND rename detection ON (gix default is off; `git log --numstat` has it ON
+            // unless `--no-renames`): a `git mv` becomes a single Rewrite at the destination rather
+            // than a spurious delete+add that corrupts per-path churn (#213 review).
             .options(|opts| {
-                opts.track_path().track_rewrites(None);
+                opts.track_path().track_rewrites(Some(gix::diff::Rewrites::default()));
             })
             .for_each_to_obtain_tree(&new_tree, |change| {
                 push_file_change(&change, &hash, scope.as_deref(), &mut diff_cache, &mut commit_changes);
@@ -596,11 +606,10 @@ fn read_history_inner(
     Ok(())
 }
 
-/// Record one tree-diff change as a `FileChange` — any leaf path change (regular blob, symlink, OR
-/// submodule gitlink), skipping only directory (tree) entries — with additions/deletions from a
-/// blob line-diff. A binary/uncountable diff (and gitlinks, whose "content" is a commit id) yields
-/// `None` counts (the numstat `-` case). Symlinks and gitlinks are included because `git log
-/// --numstat` records them as changed paths (#213 review).
+/// Record one tree-diff change as a `FileChange` — any leaf path change (regular blob, symlink,
+/// submodule gitlink, OR a rename/copy), skipping only directory (tree) entries. Symlinks and
+/// gitlinks are included because `git log --numstat` records them as changed paths, and renames are
+/// recorded once at the destination (rename detection is on) (#213 review).
 fn push_file_change(
     change: &Change<'_, '_, '_>,
     hash: &str,
@@ -608,27 +617,36 @@ fn push_file_change(
     diff_cache: &mut gix::diff::blob::Platform,
     out: &mut Vec<FileChange>,
 ) {
-    // Keep blob / symlink / gitlink changes; drop only TREE entries (directory nodes the diff may
-    // emit alongside their leaf changes) — matching `git log --numstat`, which lists submodule
-    // pointer changes too (#213 review).
-    let (change_kind, location, is_path_change) = match change {
-        Change::Addition { location, entry_mode, .. } =>
-            ("added", *location, !entry_mode.is_tree()),
-        Change::Deletion { location, entry_mode, .. } =>
-            ("deleted", *location, !entry_mode.is_tree()),
-        Change::Modification { location, entry_mode, .. } =>
-            ("modified", *location, !entry_mode.is_tree()),
-        // Rewrites are disabled above; ignore defensively if config ever forces them on.
-        Change::Rewrite { .. } => return,
+    // Keep any leaf path change; drop only TREE entries (directory nodes the diff may emit
+    // alongside their leaves). A rename/copy is recorded once at the DESTINATION (the old
+    // numstat parser normalized `old => new` to the destination), with counts from the
+    // rewrite's content diff (`None` for a pure 100%-similar rename) (#213 review).
+    let (change_kind, location, additions, deletions) = match change {
+        Change::Addition { location, entry_mode, .. } if !entry_mode.is_tree() => {
+            let (additions, deletions) = blob_line_counts(change, diff_cache);
+            ("added", location.to_string(), additions, deletions)
+        },
+        Change::Deletion { location, entry_mode, .. } if !entry_mode.is_tree() => {
+            let (additions, deletions) = blob_line_counts(change, diff_cache);
+            ("deleted", location.to_string(), additions, deletions)
+        },
+        Change::Modification { location, entry_mode, .. } if !entry_mode.is_tree() => {
+            let (additions, deletions) = blob_line_counts(change, diff_cache);
+            ("modified", location.to_string(), additions, deletions)
+        },
+        Change::Rewrite { location, entry_mode, diff, copy, .. } if !entry_mode.is_tree() => {
+            let (additions, deletions) = diff.as_ref().map_or((None, None), |stats| {
+                (Some(i64::from(stats.insertions)), Some(i64::from(stats.removals)))
+            });
+            (if *copy { "copied" } else { "renamed" }, location.to_string(), additions, deletions)
+        },
+        // A tree entry, or any future variant: not a leaf path change.
+        _ => return,
     };
-    if !is_path_change {
-        return;
-    }
     // `location` is worktree-root-relative. At the worktree root keep it as-is; under a subtree
     // index keep ONLY paths inside the subtree and make them root-relative — paths outside
     // `root` are dropped so a subdirectory index doesn't record the wider worktree's changes
     // (#213 review).
-    let location = location.to_string();
     let path = match scope {
         None => location,
         Some(prefix) => match location.strip_prefix(prefix).and_then(|rest| rest.strip_prefix('/'))
@@ -637,13 +655,6 @@ fn push_file_change(
             None => return,
         },
     };
-    let (additions, deletions) = change
-        .diff(diff_cache)
-        .ok()
-        .and_then(|mut platform| platform.line_counts().ok().flatten())
-        .map_or((None, None), |stats| {
-            (Some(i64::from(stats.insertions)), Some(i64::from(stats.removals)))
-        });
     out.push(FileChange {
         commit_hash: hash.to_string(),
         path,
@@ -651,6 +662,24 @@ fn push_file_change(
         deletions,
         change_kind: change_kind.to_string(),
     });
+}
+
+/// Line counts for a blob/symlink change via gix's blob diff. `(None, None)` for a
+/// binary/uncountable diff — AND for submodule gitlinks (`EntryKind::Commit`, a commit id with no
+/// text content): gix's blob diff accepts only blobs/symlinks. The old `git log --numstat`
+/// synthesized `1/0`,`1/1`,`0/1` for submodule pointer changes; we record the path with unknown
+/// counts rather than fall back to a raw `git` invocation. Tracked in #218.
+fn blob_line_counts(
+    change: &Change<'_, '_, '_>,
+    diff_cache: &mut gix::diff::blob::Platform,
+) -> (Option<i64>, Option<i64>) {
+    change
+        .diff(diff_cache)
+        .ok()
+        .and_then(|mut platform| platform.line_counts().ok().flatten())
+        .map_or((None, None), |stats| {
+            (Some(i64::from(stats.insertions)), Some(i64::from(stats.removals)))
+        })
 }
 
 /// The index `root`'s path WITHIN the worktree (e.g. `Some("tools/rag-rat")`), or `None` when

--- a/crates/rag-rat-core/src/index/git_history.rs
+++ b/crates/rag-rat-core/src/index/git_history.rs
@@ -429,24 +429,17 @@ fn blame_lines_via_gix(
     let absolute = root.join(path);
     let relative = absolute.strip_prefix(worktree_root).unwrap_or_else(|_| Path::new(path));
 
-    // Blame attributes lines in HEAD's version of the file. If the working tree differs from HEAD
-    // (a dirty file, or one not in HEAD at all), its line numbers don't align with HEAD, so a HEAD
-    // blame would shift/mis-attribute the chunk's lines — and `git_blame_chunk` would cache that
-    // wrong result under the dirty content hash (#213 review). Only blame a file that is byte-for-
-    // byte identical to HEAD; otherwise return no attribution. (`git blame` with no revision blamed
-    // the worktree directly, marking uncommitted lines `0000000`; gix blames committed objects
-    // only, so a clean-file guard is the faithful, safe equivalent.)
-    let head_blob = repo
-        .find_commit(head)
-        .ok()
-        .and_then(|commit| commit.tree().ok())
-        .and_then(|tree| tree.lookup_entry_by_path(relative).ok().flatten())
-        .and_then(|entry| entry.object().ok())
-        .map(|object| object.data.clone());
-    match (head_blob, std::fs::read(&absolute)) {
-        (Some(head_bytes), Ok(worktree_bytes)) if head_bytes == worktree_bytes => {},
-        // Dirty / new / unreadable: skip rather than cache misaligned attribution.
-        _ => return Ok(Vec::new()),
+    // Blame attributes lines in HEAD's version of the file. If the file is modified in the
+    // worktree, its line numbers don't align with HEAD, so a HEAD blame would
+    // shift/mis-attribute the chunk's lines — and `git_blame_chunk` would cache that wrong
+    // result under the dirty content hash (#213 review). Skip blame for a modified file. Use
+    // gix status (filter-aware: a clean file that merely differs from its blob via
+    // .gitattributes / autocrlf / LFS normalization is NOT flagged) rather than a raw byte
+    // compare, which would wrongly treat such clean files as dirty (#213 review). (`git blame`
+    // with no revision blamed the worktree directly, marking uncommitted lines `0000000`; gix
+    // blames committed objects only, so a clean-file guard is the faithful, safe equivalent.)
+    if crate::index::git_context::path_is_dirty(&repo, relative) {
+        return Ok(Vec::new());
     }
 
     let file_path = gix::path::into_bstr(relative);
@@ -532,19 +525,25 @@ fn read_history_inner(
     // A blob-diff resource cache for per-file line counts (`change.diff`), reused across commits
     // and cleared each commit to bound its growth.
     let mut diff_cache = repo.diff_resource_cache_for_tree_diff()?;
+    // When `root` is a SUBDIRECTORY of the worktree, scope history to commits/paths under that
+    // subtree — what the old `git log <head> -- .` (run from `root`) covered. `None` at the
+    // worktree root keeps everything (#213 review).
+    let scope = scope_prefix(root, worktree_root);
     let walk = repo
         .rev_walk([head_id])
         // Newest-first, matching `git log`'s default reverse-chronological order.
         .sorting(Sorting::ByCommitTime(gix::traverse::commit::simple::CommitTimeOrder::NewestFirst))
         .all()?;
     for info in walk {
-        let id = info?.id;
-        let commit = repo.find_commit(id)?;
+        // A walk error (e.g. traversing past a shallow clone's boundary into absent objects) ends
+        // the walk with what we have, rather than discarding the whole history (#213 review).
+        let Ok(info) = info else { break };
+        let Ok(commit) = repo.find_commit(info.id) else { break };
         let author = commit.author()?;
         let committer = commit.committer()?;
         let body = commit.message_raw_sloppy().to_string();
-        commits.push(CommitRecord {
-            hash: id.to_hex().to_string(),
+        let record = CommitRecord {
+            hash: info.id.to_hex().to_string(),
             author_name: author.name.to_string(),
             author_email: author.email.to_string(),
             authored_at_s: author.seconds(),
@@ -552,15 +551,22 @@ fn read_history_inner(
             subject: commit.message()?.summary().to_string(),
             // The full raw message (git `%B`), so commit FTS covers the body, not just the subject.
             body: body.trim().to_string(),
-        });
-
-        let hash = id.to_hex().to_string();
+        };
+        let hash = record.hash.clone();
         let new_tree = commit.tree()?;
+        // A shallow clone's boundary commit lists a parent whose object is ABSENT; treat it like a
+        // root commit (diff against the empty tree) instead of aborting, so its changed paths are
+        // still recorded — matching `git log --numstat` on a shallow clone (#213 review).
         let parent_tree = match commit.parent_ids().next() {
-            Some(parent) => repo.find_commit(parent.detach())?.tree()?,
+            Some(parent) => repo
+                .find_commit(parent.detach())
+                .ok()
+                .and_then(|parent| parent.tree().ok())
+                .unwrap_or_else(|| repo.empty_tree()),
             None => repo.empty_tree(),
         };
         diff_cache.clear_resource_cache();
+        let mut commit_changes = Vec::new();
         parent_tree
             .changes()?
             // Full paths for each change; NO rename detection — a rename shows as a deletion +
@@ -569,9 +575,16 @@ fn read_history_inner(
                 opts.track_path().track_rewrites(None);
             })
             .for_each_to_obtain_tree(&new_tree, |change| {
-                push_file_change(&change, &hash, root, worktree_root, &mut diff_cache, changes);
+                push_file_change(&change, &hash, scope.as_deref(), &mut diff_cache, &mut commit_changes);
                 Ok::<_, std::convert::Infallible>(Action::Continue(()))
             })?;
+        // A subtree-scoped commit that didn't touch `root` is not part of this index's history (the
+        // old `git log -- <subtree>` would not have listed it).
+        if scope.is_some() && commit_changes.is_empty() {
+            continue;
+        }
+        commits.push(record);
+        changes.append(&mut commit_changes);
     }
     Ok(())
 }
@@ -582,8 +595,7 @@ fn read_history_inner(
 fn push_file_change(
     change: &Change<'_, '_, '_>,
     hash: &str,
-    root: &Path,
-    worktree_root: &Path,
+    scope: Option<&str>,
     diff_cache: &mut gix::diff::blob::Platform,
     out: &mut Vec<FileChange>,
 ) {
@@ -599,8 +611,18 @@ fn push_file_change(
     if !is_blob {
         return;
     }
-    let Some(path) = normalize_git_path(root, worktree_root, &location.to_string()) else {
-        return;
+    // `location` is worktree-root-relative. At the worktree root keep it as-is; under a subtree
+    // index keep ONLY paths inside the subtree and make them root-relative — paths outside
+    // `root` are dropped so a subdirectory index doesn't record the wider worktree's changes
+    // (#213 review).
+    let location = location.to_string();
+    let path = match scope {
+        None => location,
+        Some(prefix) => match location.strip_prefix(prefix).and_then(|rest| rest.strip_prefix('/'))
+        {
+            Some(under_root) => under_root.to_string(),
+            None => return,
+        },
     };
     let (additions, deletions) = change
         .diff(diff_cache)
@@ -618,18 +640,16 @@ fn push_file_change(
     });
 }
 
-/// Map a gix change `location` (repo-root-relative) to the index-root-relative path the rest of the
-/// index uses. Handles the subdirectory-repo case where the index `root` is a child of the git
-/// worktree root.
-fn normalize_git_path(root: &Path, worktree_root: &Path, path: &str) -> Option<String> {
-    let path = Path::new(path);
-    if let Ok(relative) = worktree_root.join(path).strip_prefix(root) {
-        return Some(path_string(relative));
-    }
-    if root.join(path).exists() || !path.is_absolute() {
-        return Some(path_string(path));
-    }
-    None
+/// The index `root`'s path WITHIN the worktree (e.g. `Some("tools/rag-rat")`), or `None` when
+/// `root` IS the worktree root (or the two can't be related). Used to scope history to the subtree
+/// the old `git log -- .` (run from `root`) covered. Canonicalizes both sides so a symlink / path-
+/// representation mismatch doesn't spuriously scope (or fail to scope).
+fn scope_prefix(root: &Path, worktree_root: &Path) -> Option<String> {
+    let root = root.canonicalize().ok()?;
+    let worktree_root = worktree_root.canonicalize().ok()?;
+    let relative = root.strip_prefix(&worktree_root).ok()?;
+    let prefix = path_string(relative);
+    (!prefix.is_empty()).then_some(prefix)
 }
 
 fn path_history_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<PathHistoryItem> {

--- a/crates/rag-rat-core/src/index/git_history.rs
+++ b/crates/rag-rat-core/src/index/git_history.rs
@@ -2,7 +2,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use rayon::prelude::*;
+use gix::object::tree::diff::{Action, Change};
+use gix::revision::walk::Sorting;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -127,12 +128,12 @@ pub(crate) fn prepare(root: &Path) -> anyhow::Result<PreparedGitHistory> {
     let Some(repo) = git_repo(root) else {
         return Ok(PreparedGitHistory { repo: None, commits: Vec::new(), changes: Vec::new() });
     };
-    // Pin both logs to the sha captured above, not the implicit HEAD: HEAD can move between
-    // `git_repo` and these two separate `git log` invocations, which would record the meta head
-    // while the tables hold a newer commit's history. Pinning makes `prepare` atomic w.r.t. a
-    // concurrent commit and keeps the stored `git_history_indexed_head` honest for the gate.
-    let commits = read_commits(root, &repo.head)?;
-    let changes = read_file_changes(root, &repo.worktree_root, &repo.head)?;
+    // One streaming gix revwalk pinned to the captured HEAD produces both the commit records and
+    // their file changes — no `git log` subprocess and no full-history stdout buffer, so memory
+    // stays bounded on deep-history repos (#212). Pinning to the captured sha (not implicit HEAD)
+    // keeps `prepare` atomic w.r.t. a concurrent commit, so the stored `git_history_indexed_head`
+    // stays honest for the reload gate.
+    let (commits, changes) = read_history(root, &repo.worktree_root, &repo.head);
     Ok(PreparedGitHistory { repo: Some(repo), commits, changes })
 }
 
@@ -443,93 +444,127 @@ fn clear(conn: &Connection) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn read_commits(root: &Path, head: &str) -> anyhow::Result<Vec<CommitRecord>> {
-    let Some(output) = git_output(root, &[
-        "log",
-        head,
-        "--format=format:%H%x1f%an%x1f%ae%x1f%at%x1f%ct%x1f%s%x1f%B%x1e",
-        "--",
-        ".",
-    ]) else {
-        return Ok(Vec::new());
-    };
-    Ok(output
-        .split('\x1e')
-        .collect::<Vec<_>>()
-        .into_par_iter()
-        .filter_map(parse_commit_record)
-        .collect())
-}
-
-fn read_file_changes(
+/// Walk the commit history reachable from `head` with gix (gitoxide), producing the commit records
+/// and their per-file changes in a SINGLE streaming pass — no `git log` subprocess and no
+/// full-history stdout buffer, so memory stays bounded on deep-history repos (#212). Best-effort: a
+/// repo gix can't open, or a commit it can't read, yields fewer rows rather than failing the whole
+/// index (matching the previous subprocess path's graceful degradation).
+fn read_history(
     root: &Path,
     worktree_root: &Path,
     head: &str,
-) -> anyhow::Result<Vec<FileChange>> {
-    let Some(output) =
-        git_output(root, &["log", head, "--numstat", "--format=format:%x1e%H", "--", "."])
-    else {
-        return Ok(Vec::new());
-    };
-    Ok(output
-        .split('\x1e')
-        .collect::<Vec<_>>()
-        .into_par_iter()
-        .flat_map(|record| parse_file_change_record(root, worktree_root, record))
-        .collect())
-}
-
-fn parse_commit_record(record: &str) -> Option<CommitRecord> {
-    let record = record.trim();
-    if record.is_empty() {
-        return None;
-    }
-    let mut parts = record.splitn(7, '\x1f');
-    let hash = parts.next()?;
-    let author_name = parts.next()?;
-    let author_email = parts.next()?;
-    let authored_at_s = parts.next()?;
-    let committed_at_s = parts.next()?;
-    let subject = parts.next()?;
-    let body = parts.next().unwrap_or_default().trim().to_string();
-    Some(CommitRecord {
-        hash: hash.to_string(),
-        author_name: author_name.to_string(),
-        author_email: author_email.to_string(),
-        authored_at_s: authored_at_s.parse().unwrap_or(0),
-        committed_at_s: committed_at_s.parse().unwrap_or(0),
-        subject: subject.to_string(),
-        body,
-    })
-}
-
-fn parse_file_change_record(root: &Path, worktree_root: &Path, record: &str) -> Vec<FileChange> {
-    let mut lines = record.lines().filter(|line| !line.trim().is_empty());
-    let Some(hash) = lines.next().map(str::trim).filter(|line| !line.is_empty()) else {
-        return Vec::new();
-    };
+) -> (Vec<CommitRecord>, Vec<FileChange>) {
+    let mut commits = Vec::new();
     let mut changes = Vec::new();
-    for line in lines {
-        let fields = line.split('\t').collect::<Vec<_>>();
-        if fields.len() < 3 {
-            continue;
-        }
-        let Some(path) = normalize_git_path(root, worktree_root, fields[2]) else {
-            continue;
-        };
-        changes.push(FileChange {
-            commit_hash: hash.to_string(),
-            path,
-            additions: parse_numstat_count(fields[0]),
-            deletions: parse_numstat_count(fields[1]),
-            change_kind: "modified".to_string(),
-        });
-    }
-    changes
+    let _ = read_history_inner(root, worktree_root, head, &mut commits, &mut changes);
+    (commits, changes)
 }
 
+fn read_history_inner(
+    root: &Path,
+    worktree_root: &Path,
+    head: &str,
+    commits: &mut Vec<CommitRecord>,
+    changes: &mut Vec<FileChange>,
+) -> anyhow::Result<()> {
+    let mut repo = gix::discover(root)?;
+    // The by-commit-time walk + per-commit tree diffs look up each commit/tree more than once; an
+    // object cache avoids repeated zlib inflation (gitoxide's own recommendation for these passes).
+    repo.object_cache_size_if_unset(16 * 1024 * 1024);
+    let head_id = gix::ObjectId::from_hex(head.as_bytes())?;
+    // A blob-diff resource cache for per-file line counts (`change.diff`), reused across commits
+    // and cleared each commit to bound its growth.
+    let mut diff_cache = repo.diff_resource_cache_for_tree_diff()?;
+    let walk = repo
+        .rev_walk([head_id])
+        // Newest-first, matching `git log`'s default reverse-chronological order.
+        .sorting(Sorting::ByCommitTime(gix::traverse::commit::simple::CommitTimeOrder::NewestFirst))
+        .all()?;
+    for info in walk {
+        let id = info?.id;
+        let commit = repo.find_commit(id)?;
+        let author = commit.author()?;
+        let committer = commit.committer()?;
+        let body = commit.message_raw_sloppy().to_string();
+        commits.push(CommitRecord {
+            hash: id.to_hex().to_string(),
+            author_name: author.name.to_string(),
+            author_email: author.email.to_string(),
+            authored_at_s: author.seconds(),
+            committed_at_s: committer.seconds(),
+            subject: commit.message()?.summary().to_string(),
+            // The full raw message (git `%B`), so commit FTS covers the body, not just the subject.
+            body: body.trim().to_string(),
+        });
+
+        let hash = id.to_hex().to_string();
+        let new_tree = commit.tree()?;
+        let parent_tree = match commit.parent_ids().next() {
+            Some(parent) => repo.find_commit(parent.detach())?.tree()?,
+            None => repo.empty_tree(),
+        };
+        diff_cache.clear_resource_cache();
+        parent_tree
+            .changes()?
+            // Full paths for each change; NO rename detection — a rename shows as a deletion +
+            // addition, matching `git log --numstat` without `-M` (and avoiding the Rewrite variant).
+            .options(|opts| {
+                opts.track_path().track_rewrites(None);
+            })
+            .for_each_to_obtain_tree(&new_tree, |change| {
+                push_file_change(&change, &hash, root, worktree_root, &mut diff_cache, changes);
+                Ok::<_, std::convert::Infallible>(Action::Continue(()))
+            })?;
+    }
+    Ok(())
+}
+
+/// Record one tree-diff change as a `FileChange` — file blobs only (trees/submodules are skipped) —
+/// with exact additions/deletions from a blob line-diff. A binary/uncountable diff yields `None`
+/// counts (the numstat `-` case).
+fn push_file_change(
+    change: &Change<'_, '_, '_>,
+    hash: &str,
+    root: &Path,
+    worktree_root: &Path,
+    diff_cache: &mut gix::diff::blob::Platform,
+    out: &mut Vec<FileChange>,
+) {
+    let (change_kind, location, is_blob) = match change {
+        Change::Addition { location, entry_mode, .. } => ("added", *location, entry_mode.is_blob()),
+        Change::Deletion { location, entry_mode, .. } =>
+            ("deleted", *location, entry_mode.is_blob()),
+        Change::Modification { location, entry_mode, .. } =>
+            ("modified", *location, entry_mode.is_blob()),
+        // Rewrites are disabled above; ignore defensively if config ever forces them on.
+        Change::Rewrite { .. } => return,
+    };
+    if !is_blob {
+        return;
+    }
+    let Some(path) = normalize_git_path(root, worktree_root, &location.to_string()) else {
+        return;
+    };
+    let (additions, deletions) = change
+        .diff(diff_cache)
+        .ok()
+        .and_then(|mut platform| platform.line_counts().ok().flatten())
+        .map_or((None, None), |stats| {
+            (Some(i64::from(stats.insertions)), Some(i64::from(stats.removals)))
+        });
+    out.push(FileChange {
+        commit_hash: hash.to_string(),
+        path,
+        additions,
+        deletions,
+        change_kind: change_kind.to_string(),
+    });
+}
+
+/// Map a gix change `location` (repo-root-relative) to the index-root-relative path the rest of the
+/// index uses. Handles the subdirectory-repo case where the index `root` is a child of the git
+/// worktree root.
 fn normalize_git_path(root: &Path, worktree_root: &Path, path: &str) -> Option<String> {
-    let path = normalize_rename_path(path);
     let path = Path::new(path);
     if let Ok(relative) = worktree_root.join(path).strip_prefix(root) {
         return Some(path_string(relative));
@@ -538,14 +573,6 @@ fn normalize_git_path(root: &Path, worktree_root: &Path, path: &str) -> Option<S
         return Some(path_string(path));
     }
     None
-}
-
-fn normalize_rename_path(path: &str) -> &str {
-    path.rsplit(" => ").next().unwrap_or(path).trim_matches('{').trim_matches('}')
-}
-
-fn parse_numstat_count(value: &str) -> Option<i64> {
-    (value != "-").then(|| value.parse::<i64>().ok()).flatten()
 }
 
 fn parse_blame(output: &str) -> Vec<BlameLine> {

--- a/crates/rag-rat-core/src/index/git_meta.rs
+++ b/crates/rag-rat-core/src/index/git_meta.rs
@@ -6,8 +6,8 @@ impl IndexDatabase {
     /// Refresh `git_commit` / `git_dirty` meta, writing only the keys that actually changed.
     /// Returns whether either was written (so the caller can tell a no-op pass from a real one).
     pub(super) fn write_git_meta(&self, root: &Path) -> anyhow::Result<bool> {
-        let commit = git_output(root, &["rev-parse", "HEAD"]).unwrap_or_default();
-        let dirty = !git_output(root, &["status", "--porcelain"]).unwrap_or_default().is_empty();
+        let commit = head_sha(root);
+        let dirty = is_worktree_dirty(root);
         let commit_changed = self.set_meta_if_changed("git_commit", &commit)?;
         let dirty_changed =
             self.set_meta_if_changed("git_dirty", if dirty { "true" } else { "false" })?;

--- a/crates/rag-rat-core/src/index/github/parse.rs
+++ b/crates/rag-rat-core/src/index/github/parse.rs
@@ -216,10 +216,6 @@ pub(crate) fn default_repo() -> Option<String> {
 pub(crate) fn gh_available() -> bool {
     Command::new("gh").arg("--version").output().is_ok_and(|output| output.status.success())
 }
-pub(crate) fn git_output(root: &Path, args: &[&str]) -> Option<String> {
-    let output = Command::new("git").args(args).current_dir(root).output().ok()?;
-    output.status.success().then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
-}
 pub(crate) fn string_value(value: &Value, key: &str) -> String {
     value[key].as_str().unwrap_or_default().to_string()
 }

--- a/crates/rag-rat-core/src/index/github/sync.rs
+++ b/crates/rag-rat-core/src/index/github/sync.rs
@@ -9,7 +9,7 @@ pub(crate) fn discover_and_store_refs(
     let mut refs = Vec::new();
     discover_commit_refs(conn, default_repo.as_deref(), &mut refs)?;
     discover_file_refs(conn, root, default_repo.as_deref(), &mut refs)?;
-    let branch = gix::discover(root)
+    let branch = crate::index::git_context::discover_repo(root)
         .ok()
         .and_then(|repo| repo.head_name().ok().flatten())
         .map(|name| name.shorten().to_string())

--- a/crates/rag-rat-core/src/index/github/sync.rs
+++ b/crates/rag-rat-core/src/index/github/sync.rs
@@ -9,7 +9,11 @@ pub(crate) fn discover_and_store_refs(
     let mut refs = Vec::new();
     discover_commit_refs(conn, default_repo.as_deref(), &mut refs)?;
     discover_file_refs(conn, root, default_repo.as_deref(), &mut refs)?;
-    let branch = git_output(root, &["branch", "--show-current"]).unwrap_or_default();
+    let branch = gix::discover(root)
+        .ok()
+        .and_then(|repo| repo.head_name().ok().flatten())
+        .map(|name| name.shorten().to_string())
+        .unwrap_or_default();
     for parsed in parse_refs(&branch, default_repo.as_deref()) {
         refs.push(GitHubRef {
             owner: parsed.owner,

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -47,7 +47,6 @@ mod parser_tests;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc;
 use std::thread::JoinHandle;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -1,3 +1,4 @@
+use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::*;


### PR DESCRIPTION
Closes #212.

## Why
The git-history indexer shelled out to `git log <head>` over the **entire** history and buffered all of stdout before parsing — O(full history) in memory, time, and DB rows (a 100k-commit repo buffers tens of MiB; deep repos risk OOM). More broadly, rag-rat's runtime git plumbing was a scatter of `git` subprocess calls. This moves **all runtime git operations to gix (gitoxide)** — already a dependency — for native, streaming, fork/exec-free access (and no hard `git` binary dependency at runtime).

## What changed (per commit)
1. **History walk** — `read_commits` + `read_file_changes` → a single streaming `rev_walk` (newest-first), commit metadata via gix accessors, file changes from a parent→commit tree diff with `line_counts()` for exact additions/deletions (+ real added/deleted/modified change kinds). No full-history buffer; no depth cap.
2. **rev-parse/status/branch** — `git_repo`/`worktree_root` (`--show-toplevel`→`workdir()`, `HEAD`→`head_id()`, `--is-shallow-repository`→`is_shallow()`), `git_meta` (HEAD + `status --porcelain` dirty → lazy gix status), `config` (`--git-common-dir`→`common_dir()`), github branch (`branch --show-current`→`head_name()`), `resolve_git_context` HEAD.
3. **worktree listing** — `git worktree list --porcelain` → gix (main `workdir()`/`head_id()` + linked `worktrees()` proxies).
4. **blame** — `git blame --line-porcelain` → `repo.blame_file()` with a one-based `BlameRanges`; per-line attribution + author time.
5. **cli hooks paths** — `git rev-parse` (`--git-dir`/`--git-common-dir`/`--git-path hooks`) → gix + `core.hooksPath`.

Enables gix features `revision`, `blob-diff`, `blame`. Removes all the `git_output` subprocess wrappers + `Command` imports.

## Verification
- gix history matches `git` on the rag-rat repo: 282 commits (= `git rev-list`), HEAD line counts identical to `git show --numstat` (445/31, 48/2, 9/1, 1030/0). Total file-changes within +4 (renames as add+delete with rename-detection off, and merge commits diffed against first-parent — both expected/more-complete than `git log --numstat`).
- Core 573 + cli + mcp 27 tests green (incl. `git_history_indexes_commits_paths_queries_and_blame`); clippy + fmt clean.

## Out of scope
Test fixtures that build throwaway repos (`git init`/`git commit` under `#[cfg(test)]`) keep using the git CLI — they create repos, they're not runtime git operations.