### PR TITLE
feat(graph): worktree-aware serving — linked worktrees as branch overlays (#219)

### DIFF
--- a/crates/rag-rat-cli/src/claude_hook/mod.rs
+++ b/crates/rag-rat-cli/src/claude_hook/mod.rs
@@ -287,8 +287,16 @@ fn session_start(input: &HookInput) -> anyhow::Result<()> {
     // (`let _ = run_inner()`) — so the hook stays silent and never blocks session start. Do NOT
     // add error prints here: this branch's stdout is injected as model context.
     let conn = IndexConnection::open_read_only(&config.database)?;
-    let root = Path::new(&input.cwd);
-    let o = rag_rat_core::query::orientation::orientation(conn.connection(), root)?;
+    // Scope orientation to the session's worktree: `config.root` (anchored to the main worktree) is
+    // the base index, `input.cwd` is where the session is — a linked worktree gets its branch
+    // overlay (#219). find_config already anchored config.root to the main worktree, so the two
+    // together resolve the right overlay even when the session is launched from a linked
+    // checkout.
+    let o = rag_rat_core::query::orientation::orientation(
+        conn.connection(),
+        &config.root,
+        Path::new(&input.cwd),
+    )?;
     let (live, enabled) = watcher_state(&config);
     print!("{}", format_digest(&o, live, enabled));
     if let Some(line) = version_check_line(&config) {
@@ -331,8 +339,11 @@ fn pretooluse(input: &HookInput) -> anyhow::Result<()> {
     let Some(search) = extract_search(input) else { return Ok(()) };
     let Some(config) = find_config(Path::new(&input.cwd)) else { return Ok(()) };
 
-    let context = ask_listener(&config, &input.session_id, &search)
-        .unwrap_or_else(|| fallback_compose(&config, &search));
+    // Pass the session cwd through both paths so the grep-augmentation is scoped to the worktree
+    // the session is in (a linked worktree gets its branch overlay), not just the base index
+    // (#219).
+    let context = ask_listener(&config, &input.session_id, &input.cwd, &search)
+        .unwrap_or_else(|| fallback_compose(&config, &input.cwd, &search));
     if let Some(context) = context {
         // PreToolUse contract: allow + additionalContext; plain stdout is debug-only.
         println!(
@@ -504,7 +515,12 @@ fn find_config(start: &Path) -> Option<Config> {
 
 /// Outer Option: did the listener answer at all (None ⇒ fall back). Inner Option: did it
 /// have anything new to say.
-fn ask_listener(config: &Config, session_id: &str, search: &Search) -> Option<Option<String>> {
+fn ask_listener(
+    config: &Config,
+    session_id: &str,
+    cwd: &str,
+    search: &Search,
+) -> Option<Option<String>> {
     #[cfg(unix)]
     {
         use std::io::{BufRead, BufReader, Write as _};
@@ -516,8 +532,11 @@ fn ask_listener(config: &Config, session_id: &str, search: &Search) -> Option<Op
         let stream = UnixStream::connect(&socket).ok()?;
         stream.set_read_timeout(Some(SOCKET_BUDGET)).ok()?;
         stream.set_write_timeout(Some(SOCKET_BUDGET)).ok()?;
+        // `cwd` lets the listener scope the augmentation to the session's worktree overlay (#219);
+        // an older listener without the field just ignores it (lenient deserialize) → base scope.
         let request = serde_json::json!({
             "v": 1, "kind": "grep_augment", "session_id": session_id,
+            "cwd": cwd,
             "pattern": search.pattern, "search_path": search.search_path,
             "source": search.source,
         });
@@ -533,7 +552,7 @@ fn ask_listener(config: &Config, session_id: &str, search: &Search) -> Option<Op
     }
     #[cfg(not(unix))]
     {
-        let _ = (config, session_id, search);
+        let _ = (config, session_id, cwd, search);
         None
     }
 }
@@ -545,8 +564,17 @@ fn socket_path(config: &Config) -> PathBuf {
 }
 
 /// Stateless direct read (no dedupe — spec: fallback path). Any error ⇒ silence.
-fn fallback_compose(config: &Config, search: &Search) -> Option<String> {
+fn fallback_compose(config: &Config, cwd: &str, search: &Search) -> Option<String> {
     let conn = IndexConnection::open_read_only(&config.database).ok()?;
+    // Scope to the session's worktree overlay before composing — `compose` queries the `files`
+    // view, so without this it would read raw (unscoped) rows. config.root is the anchored main
+    // worktree; cwd is the session dir (a linked worktree → its overlay, else base) (#219).
+    rag_rat_core::index::install_worktree_scope_view(
+        conn.connection(),
+        &config.root,
+        Path::new(cwd),
+    )
+    .ok()?;
     grep_augment::compose(
         conn.connection(),
         &search.pattern,

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -120,6 +120,11 @@ pub(crate) struct IndexArgs {
     /// Index only changed files (the default).
     #[arg(long)]
     pub changed: bool,
+    /// Index a LINKED git worktree's branch overlay on top of the existing base index, so queries
+    /// scoped to it (`--worktree` / the MCP `worktree` arg) see that branch's changes. Indexes
+    /// only the delta vs the base; does not rebuild the base.
+    #[arg(long, value_name = "PATH")]
+    pub worktree: Option<std::path::PathBuf>,
     /// Run the background file watcher in the foreground until interrupted.
     #[arg(long)]
     pub watch: bool,

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -38,6 +38,26 @@ pub(crate) fn index(config: &Config, args: &IndexArgs) -> anyhow::Result<()> {
     let _lock = rag_rat_core::locks::FileLock::acquire_blocking(
         &rag_rat_core::locks::write_lock_path(&config.database),
     )?;
+    // `--worktree`: index a linked worktree's branch overlay on top of the existing base index
+    // (#219). A distinct mode — the delta vs the base, not a base (re)build — so handle it before
+    // the full/discover/changed branches.
+    if let Some(worktree) = &args.worktree {
+        let mut db = open_index(config)?;
+        let mut progress = render_index_progress;
+        let report = db.index_worktree_overlay(config, worktree, &mut progress)?;
+        if report.worktree_id.is_empty() {
+            anyhow::bail!(
+                "{} is not a linked worktree of {} — nothing indexed",
+                worktree.display(),
+                config.root.display()
+            );
+        }
+        eprintln!(
+            "worktree overlay [{}]: {} indexed, {} tombstoned, {} pruned",
+            report.worktree_id, report.indexed, report.tombstoned, report.pruned
+        );
+        return Ok(());
+    }
     let db = if args.full {
         IndexDatabase::rebuild_with_progress(config, render_index_progress)?
     } else if args.discover {

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -1076,16 +1076,12 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
     )?;
 
     let mut db = IndexDatabase::index_discover_with_progress(config, render_index_progress)?;
-    // Keep every live linked worktree's branch overlay fresh (#219). The git hooks run THIS command
-    // (not the foreground watcher), so without this a commit/checkout/merge in a linked worktree
-    // would index the base `config.root` but leave that worktree's overlay stale until a watcher
-    // pass or a manual `index --worktree`. Delta-only + idle-safe, like the watcher's pass; it
-    // restores the base scope afterward so reconcile/gc/memory-validate below run unscoped.
-    rag_rat_core::watch::refresh_worktree_overlays(&mut db, config);
     let elapsed = started.elapsed().as_secs();
     let remaining_seconds = max_seconds.saturating_sub(elapsed);
-    let reconcile_report = if remaining_seconds > 0 {
-        let options = rag_rat_core::index::ai::ReconcileOptions {
+    // Reconcile options shared by the overlay pass and the base reconcile below. `None` (no time
+    // budget left) skips both, so neither the overlay nor the base embeds when out of time.
+    let reconcile_options =
+        (remaining_seconds > 0).then(|| rag_rat_core::index::ai::ReconcileOptions {
             limit: None,
             batch_size: Some(config.local_ai.embedding.runtime.batch_size),
             force: false,
@@ -1094,10 +1090,19 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
             max_seconds: Some(remaining_seconds),
             max_embedding_chars: config.local_ai.embedding.runtime.max_embedding_chars,
             intra_threads: config.local_ai.embedding.runtime.ort_threads.map(|n| n as usize),
-        };
-        Some(db.reconcile_with_options_progress(options, render_reconcile_progress)?)
-    } else {
-        None
+        });
+    // Keep every live linked worktree's branch overlay fresh (#219). The git hooks run THIS command
+    // (not the foreground watcher), so without this a commit/checkout/merge in a linked worktree
+    // would index the base `config.root` but leave that worktree's overlay stale until a watcher
+    // pass or a manual `index --worktree`. Delta-only + idle-safe, like the watcher's pass; a
+    // CHANGED overlay's embeddings are reconciled INLINE (while scoped to it) so worktree queries
+    // aren't BM25-only for branch content. It restores the base scope afterward so the base
+    // reconcile/gc/memory-validate below run unscoped.
+    rag_rat_core::watch::refresh_worktree_overlays(&mut db, config, reconcile_options.as_ref());
+    let reconcile_report = match reconcile_options {
+        Some(options) =>
+            Some(db.reconcile_with_options_progress(options, render_reconcile_progress)?),
+        None => None,
     };
     // Prune index rows for git contexts that are no longer live (worktree-safe; keeps every
     // live worktree's HEAD). Cheap and bounded, so it runs every maintenance pass.

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -1076,21 +1076,26 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
     )?;
 
     let mut db = IndexDatabase::index_discover_with_progress(config, render_index_progress)?;
-    let elapsed = started.elapsed().as_secs();
-    let remaining_seconds = max_seconds.saturating_sub(elapsed);
-    // Reconcile options shared by the overlay pass and the base reconcile below. `None` (no time
-    // budget left) skips both, so neither the overlay nor the base embeds when out of time.
-    let reconcile_options =
-        (remaining_seconds > 0).then(|| rag_rat_core::index::ai::ReconcileOptions {
-            limit: None,
-            batch_size: Some(config.local_ai.embedding.runtime.batch_size),
-            force: false,
-            until_clean: false,
-            changed_first: true,
-            max_seconds: Some(remaining_seconds),
-            max_embedding_chars: config.local_ai.embedding.runtime.max_embedding_chars,
-            intra_threads: config.local_ai.embedding.runtime.ort_threads.map(|n| n as usize),
-        });
+    // ONE time budget for the whole pass — the per-overlay embedding reconciles AND the base
+    // reconcile below — measured from `started` so discovery already counts against it. Without a
+    // shared budget each overlay (each call starts its own `max_seconds` timer) plus the base could
+    // spend the full `--max-seconds`, holding the write lock (N+1)× past the advertised limit (#219
+    // review). A `0` cap means the caller asked to skip embedding work entirely.
+    let budget = (max_seconds > 0).then(|| {
+        rag_rat_core::watch::ReconcileBudget::new(
+            rag_rat_core::index::ai::ReconcileOptions {
+                limit: None,
+                batch_size: Some(config.local_ai.embedding.runtime.batch_size),
+                force: false,
+                until_clean: false,
+                changed_first: true,
+                max_seconds: Some(max_seconds),
+                max_embedding_chars: config.local_ai.embedding.runtime.max_embedding_chars,
+                intra_threads: config.local_ai.embedding.runtime.ort_threads.map(|n| n as usize),
+            },
+            started,
+        )
+    });
     // Keep every live linked worktree's branch overlay fresh (#219). The git hooks run THIS command
     // (not the foreground watcher), so without this a commit/checkout/merge in a linked worktree
     // would index the base `config.root` but leave that worktree's overlay stale until a watcher
@@ -1098,12 +1103,15 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
     // CHANGED overlay's embeddings are reconciled INLINE (while scoped to it) so worktree queries
     // aren't BM25-only for branch content. It restores the base scope afterward so the base
     // reconcile/gc/memory-validate below run unscoped.
-    rag_rat_core::watch::refresh_worktree_overlays(&mut db, config, reconcile_options.as_ref());
-    let reconcile_report = match reconcile_options {
-        Some(options) =>
-            Some(db.reconcile_with_options_progress(options, render_reconcile_progress)?),
-        None => None,
-    };
+    rag_rat_core::watch::refresh_worktree_overlays(&mut db, config, budget.as_ref());
+    // The base reconcile gets whatever budget the overlays left; `None` → exhausted (or no cap left
+    // at all), so skip it rather than start a fresh full-budget reconcile.
+    let reconcile_report =
+        match budget.as_ref().and_then(rag_rat_core::watch::ReconcileBudget::next_options) {
+            Some(options) =>
+                Some(db.reconcile_with_options_progress(options, render_reconcile_progress)?),
+            None => None,
+        };
     // Prune index rows for git contexts that are no longer live (worktree-safe; keeps every
     // live worktree's HEAD). Cheap and bounded, so it runs every maintenance pass.
     let gc_report = db.garbage_collect().ok();

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -1075,7 +1075,13 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
         &rag_rat_core::locks::write_lock_path(&config.database),
     )?;
 
-    let db = IndexDatabase::index_discover_with_progress(config, render_index_progress)?;
+    let mut db = IndexDatabase::index_discover_with_progress(config, render_index_progress)?;
+    // Keep every live linked worktree's branch overlay fresh (#219). The git hooks run THIS command
+    // (not the foreground watcher), so without this a commit/checkout/merge in a linked worktree
+    // would index the base `config.root` but leave that worktree's overlay stale until a watcher
+    // pass or a manual `index --worktree`. Delta-only + idle-safe, like the watcher's pass; it
+    // restores the base scope afterward so reconcile/gc/memory-validate below run unscoped.
+    rag_rat_core::watch::refresh_worktree_overlays(&mut db, config);
     let elapsed = started.elapsed().as_secs();
     let remaining_seconds = max_seconds.saturating_sub(elapsed);
     let reconcile_report = if remaining_seconds > 0 {
@@ -1187,6 +1193,77 @@ mod tests {
             oracle: Default::default(),
         };
         (root, config)
+    }
+
+    #[test]
+    fn maintenance_command_refreshes_a_linked_worktree_overlay() {
+        // #219 review: the git hooks invoke `rag-rat maintenance` (NOT the foreground watcher), so
+        // this command — not just `watch::maintenance_pass` — must refresh every live linked
+        // worktree's branch overlay. Without it, a commit/checkout/merge in a linked worktree
+        // indexes the base `config.root` but leaves the worktree overlay stale.
+        let git = |dir: &std::path::Path, args: &[&str]| {
+            std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
+        };
+        let root = std::env::temp_dir().join(format!(
+            "rag-rat-cli-maint-overlay-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        let main = root.join("main");
+        std::fs::create_dir_all(main.join("src")).unwrap();
+        std::fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+        git(&main, &["init", "-q", "-b", "main"]);
+        git(&main, &["config", "user.email", "t@example.com"]);
+        git(&main, &["config", "user.name", "t"]);
+        git(&main, &["add", "-A"]);
+        git(&main, &["commit", "-qm", "base"]);
+        let config = Config {
+            root: main.clone(),
+            database: main.join(".rag-rat/index.sqlite"),
+            targets: vec![ResolvedTarget {
+                name: "rust".to_string(),
+                language: Language::Rust,
+                directories: vec![PathBuf::from("src")],
+                include: vec!["src/".to_string()],
+                exclude: Vec::new(),
+                kind: TargetKind::Source,
+            }],
+            local_ai: Default::default(),
+            watch: Default::default(),
+            version_check: Default::default(),
+            oracle: Default::default(),
+        };
+        IndexDatabase::rebuild(&config).unwrap();
+
+        let linked = root.join("wt");
+        git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+        std::fs::write(linked.join("src/a.rs"), "pub fn linked_fn() {}\n").unwrap();
+        git(&linked, &["add", "-A"]);
+        git(&linked, &["commit", "-qm", "branch"]);
+
+        // Run the actual CLI maintenance command (the hook entry point).
+        let args = super::MaintenanceArgs {
+            trigger: Some("post-merge".to_string()),
+            max_seconds: Some(0), // skip the embedding reconcile; we only assert the overlay
+            branch_checkout: None,
+            old_head: None,
+            new_head: None,
+        };
+        super::maintenance(&config, &args).unwrap();
+
+        // The worktree-scoped query now sees the branch version, populated by the maintenance pass.
+        let mut db = IndexDatabase::open_config(&config).unwrap();
+        db.use_worktree_scope(&config.root, Some(&linked)).unwrap();
+        let names: Vec<String> =
+            db.symbols("linked_fn", None, 10).unwrap().into_iter().map(|h| h.name).collect();
+        assert!(
+            names.contains(&"linked_fn".to_string()),
+            "the maintenance command must populate the worktree overlay: {names:?}",
+        );
+
+        drop(db);
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -44,7 +44,11 @@ pub(crate) fn index(config: &Config, args: &IndexArgs) -> anyhow::Result<()> {
     if let Some(worktree) = &args.worktree {
         let mut db = open_index(config)?;
         let mut progress = render_index_progress;
-        let report = db.index_worktree_overlay(config, worktree, &mut progress)?;
+        // Index the overlay with the LINKED worktree's OWN target set (its branch `rag-rat.toml`),
+        // not the launching process's base targets — a branch that adds/narrows targets must be
+        // indexed by its own config or its overlay rows are filtered/pruned (#219 review).
+        let overlay_config = config.for_linked_worktree_overlay(worktree);
+        let report = db.index_worktree_overlay(&overlay_config, worktree, &mut progress)?;
         if report.worktree_id.is_empty() {
             anyhow::bail!(
                 "{} is not a linked worktree of {} — nothing indexed",

--- a/crates/rag-rat-cli/src/hooks_support.rs
+++ b/crates/rag-rat-cli/src/hooks_support.rs
@@ -54,16 +54,18 @@ pub(crate) fn hook_script(hook: &str) -> String {
     --new-head "$2" \
     --branch-checkout "$3" \
     --max-seconds 30"#,
+        // No positional args: git passes post-merge a squash flag (0/1) and post-rewrite the
+        // command (amend/rebase); `rag-rat maintenance` takes no positionals, so forwarding
+        // them ("$@") made the hook abort with `unexpected argument`. The trigger flag is
+        // all maintenance needs — it re-discovers either way.
         "post-merge" =>
             r#"rag-rat maintenance \
     --trigger post-merge \
-    --max-seconds 30 \
-    "$@""#,
+    --max-seconds 30"#,
         "post-rewrite" =>
             r#"rag-rat maintenance \
     --trigger post-rewrite \
-    --max-seconds 30 \
-    "$@""#,
+    --max-seconds 30"#,
         // git passes no positional args to post-commit; HEAD has already advanced, so the
         // maintenance discover-index re-keys the just-committed files under the new commit.
         "post-commit" =>
@@ -82,6 +84,15 @@ fi
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
 cd "$repo_root" || exit 0
+
+# Run rag-rat in a CLEAN git environment. Git exports GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE / ...
+# to every hook, pointing at the worktree the operation ran in. rag-rat must resolve the repo from
+# its OWN config root (anchored to the main worktree), not the launching git env — otherwise a hook
+# fired in a linked worktree mis-scopes the one shared index (the base + every overlay resolve to
+# that worktree, collapsing deltas and pruning rows). Belt-and-suspenders with discover_repo's
+# path-first resolution; also drops the transient GIT_INDEX_FILE the in-progress git op set.
+unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE GIT_PREFIX GIT_NAMESPACE \
+  GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES
 
 RAG_RAT_HOOK_DISABLE=1 \
   {command} >"${{TMPDIR:-/tmp}}/rag-rat-{hook}.log" 2>&1 &
@@ -102,4 +113,29 @@ pub(crate) fn make_executable(path: &Path) -> anyhow::Result<()> {
 #[cfg(not(unix))]
 pub(crate) fn make_executable(_path: &Path) -> anyhow::Result<()> {
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_hooks_clear_git_env_and_forward_no_positionals() {
+        for hook in ["post-checkout", "post-commit", "post-merge", "post-rewrite"] {
+            let script = hook_script(hook);
+            assert!(script.contains(HOOK_MARKER), "{hook}: missing marker");
+            // git passes post-merge a squash flag (0/1) and post-rewrite a command (amend/rebase);
+            // `rag-rat maintenance` takes no positionals, so forwarding "$@" aborted the hook.
+            assert!(
+                !script.contains("\"$@\""),
+                "{hook}: forwards git's positional args to maintenance"
+            );
+            // The hook must clear git's inherited env BEFORE invoking rag-rat, so a hook fired in a
+            // linked worktree can't hijack the shared index's repo resolution via GIT_DIR/etc.
+            let unset = script.find("unset GIT_DIR").expect("hook clears GIT_DIR");
+            assert!(script.contains("GIT_WORK_TREE") && script.contains("GIT_INDEX_FILE"));
+            let invoke = script.find("rag-rat maintenance").expect("hook invokes maintenance");
+            assert!(unset < invoke, "{hook}: clears git env AFTER invoking rag-rat");
+        }
+    }
 }

--- a/crates/rag-rat-cli/tests/worktree_git_env.rs
+++ b/crates/rag-rat-cli/tests/worktree_git_env.rs
@@ -1,0 +1,97 @@
+//! Regression (#219): an inherited `GIT_DIR` / `GIT_WORK_TREE` (e.g. a tool operating in a linked
+//! worktree — Claude Code, an IDE) must NOT hijack the index's git resolution.
+//!
+//! With the env honored unconditionally, `index --worktree` resolved BOTH the base repo and the
+//! linked repo to the single env-specified worktree (ignoring their path arguments), so the
+//! base↔linked overlay delta collapsed to empty and the real overlay rows were pruned/tombstoned —
+//! the file-reported worktree flip-flop. `discover_repo` now resolves from the configured path
+//! first, falling back to env overrides only when no repo is found upward. This test runs the CLI
+//! in a subprocess (env-isolated) with the hijacking env set and asserts the overlay survives.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use rag_rat_core::language::Language;
+use rag_rat_core::{Config, IndexDatabase};
+
+static TEMP: AtomicU64 = AtomicU64::new(0);
+
+fn git(dir: &Path, args: &[&str]) {
+    let out = Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
+    assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+}
+
+#[test]
+fn worktree_overlay_ignores_inherited_git_dir_env() {
+    let base = std::env::temp_dir().join(format!(
+        "rag-rat-wtenv-{}-{}",
+        std::process::id(),
+        TEMP.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = fs::remove_dir_all(&base);
+    let main = base.join("main");
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/keep.rs"), "pub fn keep_fn() {}\n").unwrap();
+    fs::write(main.join("src/reinf.rs"), "pub fn classify_seg() {}\n").unwrap();
+    // Nest the worktree under config.root and gitignore it (the perverse-but-real held layout).
+    fs::write(main.join(".gitignore"), "/wt/\n").unwrap();
+    fs::write(
+        main.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\ndatabase = \".rag-rat/index.sqlite\"\n\n[target_bindings]\nrust = \
+         [\"src\"]\n",
+    )
+    .unwrap();
+    git(&main, &["init", "-q"]);
+    git(&main, &["config", "user.email", "t@e.com"]);
+    git(&main, &["config", "user.name", "t"]);
+    git(&main, &["add", "."]);
+    git(&main, &["commit", "-q", "-m", "C1 has reinf"]);
+
+    // Linked worktree forked at C1 (HAS reinf.rs), nested + gitignored.
+    let wt = main.join("wt");
+    git(&main, &["worktree", "add", "-q", "-b", "feat", wt.to_str().unwrap()]);
+
+    // Main REMOVES reinf.rs at C2; the branch keeps it — so reinf.rs lives ONLY in the overlay.
+    fs::remove_file(main.join("src/reinf.rs")).unwrap();
+    git(&main, &["add", "."]);
+    git(&main, &["commit", "-q", "-m", "C2 removed reinf"]);
+
+    let config_path = main.join("rag-rat.toml");
+    let config = Config::load(&config_path).unwrap();
+    IndexDatabase::rebuild(&config).unwrap();
+
+    // Run `index --worktree` with the WORKTREE's GIT_DIR/GIT_WORK_TREE in the env — the exact shape
+    // a worktree shell exports, which used to hijack resolution and prune the overlay.
+    let git_dir = main.join(".git/worktrees/feat");
+    let binary = env!("CARGO_BIN_EXE_rag-rat");
+    let out = Command::new(binary)
+        .arg("--config")
+        .arg(&config_path)
+        .args(["index", "--worktree"])
+        .arg(&wt)
+        .env("RAG_RAT_NO_WATCH", "1")
+        .env("GIT_DIR", &git_dir)
+        .env("GIT_WORK_TREE", &wt)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "index --worktree failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // The overlay must serve reinf.rs READABLE in the worktree scope — the inherited GIT_DIR must
+    // not have collapsed the delta and pruned/tombstoned the row.
+    let mut db = IndexDatabase::open(&config.database).unwrap();
+    db.use_worktree_scope(&main, Some(&wt)).unwrap();
+    let hits = db.symbols("classify_seg", Some(Language::Rust), 10).unwrap();
+    assert!(
+        !hits.is_empty(),
+        "an inherited worktree GIT_DIR hijacked resolution and pruned the overlay (reinf.rs \
+         missing)"
+    );
+
+    let _ = fs::remove_dir_all(&base);
+}

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -263,12 +263,16 @@ impl Config {
         // write CONFLICTING overlay rows to the shared DB — a file present on one branch
         // races between readable and tombstone (#218/#219). The main worktree (and non-git
         // dirs) resolve to themselves, so single-worktree users see no change.
-        let root = main_worktree_or_self(&root);
-        // One database per repo: a relative path resolves against `root` (now the main worktree),
-        // so all linked worktrees share one index. An absolute path is honored as-is.
+        let root = anchor_root_to_main_worktree(&root);
+        // One database per repo, shared across worktrees: a relative path resolves against the MAIN
+        // worktree TOP — NOT `root`, which may be a subdirectory — so every worktree of a repo AND
+        // any `root="<subdir>"` config land on the SAME index. An absolute path is honored as-is.
         let database = match raw.index.database {
             Some(db) if Path::new(&db).is_absolute() => PathBuf::from(db),
-            other => root.join(other.unwrap_or_else(|| ".rag-rat/index.sqlite".to_string())),
+            other => {
+                let relative = other.unwrap_or_else(|| ".rag-rat/index.sqlite".to_string());
+                main_worktree_root(&root).unwrap_or_else(|| root.clone()).join(relative)
+            },
         };
         let targets = resolve_targets(&root, raw.target_bindings, raw.target)?;
         let local_ai = LocalAiConfig::try_from(raw.local_ai)?;
@@ -343,13 +347,30 @@ fn push_target(
     Ok(())
 }
 
-/// The **main** worktree root for a **linked** git worktree (so every worktree of a repo resolves
-/// to one `root` + one shared index DB); for the main worktree or a non-git dir, `root` unchanged —
-/// single-worktree setups are unaffected.
-fn main_worktree_or_self(root: &Path) -> PathBuf {
-    match main_worktree_root(root) {
-        Some(main_root) if main_root != root => main_root,
-        _ => root.to_path_buf(),
+/// Re-anchor a **linked** worktree's `root` to the equivalent path under the **main** worktree, so
+/// every worktree of a repo resolves to one root + one shared index — while PRESERVING any
+/// subdirectory the config root points at (a `root="<subdir>"` rebases to `<main>/<subdir>`, not
+/// the repo top). The main worktree (and non-git dirs) resolve to themselves. Collapsing a subdir
+/// root to the repo top changed the indexed file set and could fail config load when a target dir
+/// exists only under the subdir (#219 review).
+fn anchor_root_to_main_worktree(root: &Path) -> PathBuf {
+    let Ok(repo) = crate::index::discover_repo(root) else {
+        return root.to_path_buf();
+    };
+    let (Some(workdir), Some(main_root)) = (repo.workdir(), main_worktree_root(root)) else {
+        return root.to_path_buf();
+    };
+    let workdir = workdir.canonicalize().unwrap_or_else(|_| workdir.to_path_buf());
+    if main_root == workdir {
+        return root.to_path_buf(); // already the main worktree — keep the configured (sub)root
+    }
+    // Linked worktree: rebase root's in-worktree subpath under the main worktree top. `root` is
+    // canonicalized by `normalize_existing_dir`, so it strips cleanly against the canonical
+    // workdir; `root == workdir` (a `root="."` config) yields an empty suffix → the main
+    // worktree top.
+    match root.strip_prefix(&workdir) {
+        Ok(rel) => main_root.join(rel),
+        Err(_) => main_root,
     }
 }
 
@@ -620,14 +641,14 @@ mod tests {
     }
 
     #[test]
-    fn main_worktree_or_self_shares_one_db_across_worktrees() {
+    fn anchor_root_preserves_subdir_and_redirects_linked_to_main() {
         let git = |dir: &Path, args: &[&str]| {
             std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
         };
         let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
         let tmp = std::env::temp_dir().join(format!("ragrat-cfg-{}-{id}", std::process::id()));
         let main = tmp.join("main");
-        std::fs::create_dir_all(&main).unwrap();
+        std::fs::create_dir_all(main.join("src")).unwrap();
         git(&main, &["init", "-q"]);
         git(&main, &["config", "user.email", "t@example.com"]);
         git(&main, &["config", "user.name", "t"]);
@@ -636,20 +657,26 @@ mod tests {
         git(&main, &["commit", "-qm", "seed"]);
         let linked = tmp.join("wt");
         git(&main, &["worktree", "add", "--detach", "-q", linked.to_str().unwrap()]);
+        std::fs::create_dir_all(linked.join("src")).unwrap();
 
         let main_c = main.canonicalize().unwrap();
         let linked_c = linked.canonicalize().unwrap();
 
-        // Main worktree resolves to itself (no redirect → existing DB location preserved).
-        assert_eq!(main_worktree_or_self(&main_c), main_c);
-        // Linked worktree redirects to the main worktree → one shared DB.
-        assert_eq!(main_worktree_or_self(&linked_c), main_c);
+        // Main worktree (any root) resolves to itself.
+        assert_eq!(anchor_root_to_main_worktree(&main_c), main_c);
+        // A SUBDIR root on the main worktree is PRESERVED (not collapsed to the repo top) — the
+        // #219-review regression: collapsing changed the indexed file set + failed config load.
+        assert_eq!(anchor_root_to_main_worktree(&main_c.join("src")), main_c.join("src"));
+        // Linked worktree, root=".", redirects to the main worktree → one shared base.
+        assert_eq!(anchor_root_to_main_worktree(&linked_c), main_c);
+        // Linked worktree SUBDIR root rebases under the main worktree, subdir preserved.
+        assert_eq!(anchor_root_to_main_worktree(&linked_c.join("src")), main_c.join("src"));
 
         // A non-git directory falls back to itself.
         let plain = tmp.join("plain");
         std::fs::create_dir_all(&plain).unwrap();
         let plain_c = plain.canonicalize().unwrap();
-        assert_eq!(main_worktree_or_self(&plain_c), plain_c);
+        assert_eq!(anchor_root_to_main_worktree(&plain_c), plain_c);
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -253,7 +253,11 @@ impl Config {
         let raw: RawConfig = toml::from_str(&text)?;
         let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
         let root = config_dir.join(raw.index.root.unwrap_or_else(|| ".".to_string()));
-        let root = normalize_existing_dir(&root)?;
+        // The root of the checkout the config was actually READ from (a linked worktree has its own
+        // checked-out `rag-rat.toml`). Targets are validated against THIS, not the anchored main
+        // root below: a linked branch can add a target dir that exists only in that branch, and the
+        // launch must not fail with `MissingDirectory` against the main checkout (#219 review).
+        let local_root = normalize_existing_dir(&root)?;
         // Anchor `root` to the MAIN worktree root, so EVERY invocation resolves to the same root
         // and thus the same base commit for the one shared index — whether launched from
         // the main checkout, a linked worktree, or any cwd (`root="."` resolves against the
@@ -263,7 +267,7 @@ impl Config {
         // write CONFLICTING overlay rows to the shared DB — a file present on one branch
         // races between readable and tombstone (#218/#219). The main worktree (and non-git
         // dirs) resolve to themselves, so single-worktree users see no change.
-        let root = anchor_root_to_main_worktree(&root);
+        let root = anchor_root_to_main_worktree(&local_root);
         // One database per repo, shared across worktrees: a relative path resolves against the MAIN
         // worktree TOP — NOT `root`, which may be a subdirectory — so every worktree of a repo AND
         // any `root="<subdir>"` config land on the SAME index. An absolute path is honored as-is.
@@ -274,7 +278,12 @@ impl Config {
                 main_worktree_root(&root).unwrap_or_else(|| root.clone()).join(relative)
             },
         };
-        let targets = resolve_targets(&root, raw.target_bindings, raw.target)?;
+        // Validate directories against the local checkout (`local_root`), where the config — and
+        // any branch-only target dir — actually lives; the stored `Config.root` stays
+        // anchored to main so every worktree shares one base index.
+        // `ResolvedTarget.directories` are root-relative, so the stored targets are
+        // identical either way (#219 review).
+        let targets = resolve_targets(&local_root, raw.target_bindings, raw.target)?;
         let local_ai = LocalAiConfig::try_from(raw.local_ai)?;
         let watch = raw.watch.into();
         let version_check = raw.version_check.into();
@@ -606,6 +615,67 @@ mod tests {
             from_linked.root,
             main.canonicalize().unwrap(),
             "a linked worktree's config root anchors to the main worktree",
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn config_load_in_a_linked_worktree_validates_branch_only_target_dirs() {
+        // #219 review: a linked branch can point `rag-rat.toml` at a target dir that exists ONLY in
+        // that branch. `Config::load` anchors `root` to the main worktree for the shared base
+        // index, but it must VALIDATE the targets against the LINKED checkout (where the
+        // config + that dir live) — not the main checkout — or launching the index/MCP in
+        // the linked worktree fails with `MissingDirectory` against main.
+        let git = |dir: &Path, args: &[&str]| {
+            std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
+        };
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let tmp =
+            std::env::temp_dir().join(format!("ragrat-cfgbranch-{}-{id}", std::process::id()));
+        let main = tmp.join("main");
+        std::fs::create_dir_all(main.join("src")).unwrap();
+        std::fs::write(main.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        // Main's config indexes only `src`.
+        std::fs::write(
+            main.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n",
+        )
+        .unwrap();
+        git(&main, &["init", "-q"]);
+        git(&main, &["config", "user.email", "t@example.com"]);
+        git(&main, &["config", "user.name", "t"]);
+        git(&main, &["add", "-A"]);
+        git(&main, &["commit", "-qm", "seed"]);
+
+        // A branch adds a NEW target dir `extra` and a config that indexes it — committed only on
+        // the branch, checked out in the linked worktree.
+        let linked = tmp.join("wt");
+        git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+        std::fs::create_dir_all(linked.join("extra")).unwrap();
+        std::fs::write(linked.join("extra/more.rs"), "pub fn b() {}\n").unwrap();
+        std::fs::write(
+            linked.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\", \"extra\"]\n",
+        )
+        .unwrap();
+        git(&linked, &["add", "-A"]);
+        git(&linked, &["commit", "-qm", "branch adds extra"]);
+
+        // `extra` does not exist in the main checkout, so validating against main would fail.
+        assert!(!main.join("extra").exists(), "the branch-only dir must be absent from main");
+        let from_linked = Config::load(linked.join("rag-rat.toml"))
+            .expect("loading the branch config in the linked worktree must validate against it");
+        // root still anchors to main (one shared base index), targets validated against the branch.
+        assert_eq!(
+            from_linked.root,
+            main.canonicalize().unwrap(),
+            "root anchors to the main worktree for the shared base index",
+        );
+        let dirs = from_linked.target_directories();
+        assert!(
+            dirs.contains(&PathBuf::from("extra")),
+            "the branch-only target dir survives validation: {dirs:?}",
         );
 
         let _ = std::fs::remove_dir_all(&tmp);

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -247,6 +247,43 @@ impl Config {
         dirs
     }
 
+    /// A copy of this (BASE) config whose `targets` are re-resolved from a LINKED worktree's own
+    /// `rag-rat.toml` (at `<linked_worktree_root>/rag-rat.toml`), so an overlay refresh indexes
+    /// that branch with its OWN target set — not the sweeping process's. The shared `root`
+    /// (anchored to main), `database`, and the rest are kept: the overlay still resolves
+    /// against the one base index, but the delta + ignore filtering see the branch's targets.
+    /// Returns the config unchanged when the linked worktree has no readable/valid
+    /// `rag-rat.toml`, or when its targets don't validate against the linked checkout — so a
+    /// malformed branch config degrades to base targets rather than dropping the worktree. The
+    /// branch targets are root-relative, so they apply to the shared `root` directly (#219
+    /// review).
+    ///
+    /// Used by `refresh_worktree_overlays`: the main watcher/maintenance process refreshes every
+    /// linked worktree, but a worktree whose branch ADDS a target (e.g. `extra/`) would otherwise
+    /// be filtered against the sweeper's targets — pruning overlay rows a branch-launched hook
+    /// indexed.
+    pub fn for_linked_worktree_overlay(&self, linked_path: &Path) -> Self {
+        let linked_targets = (|| {
+            // `linked_path` may be the checkout root, a subdir of it, or the git dir (a hook); the
+            // branch `rag-rat.toml` lives at the WORKDIR top, so resolve the workdir first.
+            let workdir = crate::index::discover_repo(linked_path)
+                .ok()
+                .and_then(|repo| repo.workdir().map(Path::to_path_buf))
+                .unwrap_or_else(|| linked_path.to_path_buf());
+            let text = fs::read_to_string(workdir.join("rag-rat.toml")).ok()?;
+            let raw: RawConfig = toml::from_str(&text).ok()?;
+            // Targets are relative to the config's `[index].root` (a subdir layout puts the toml at
+            // the worktree top with `root = "<subdir>"`); resolve + validate them there so the
+            // stored, root-relative directories match the base config's spelling exactly.
+            let target_root = workdir.join(raw.index.root.as_deref().unwrap_or("."));
+            resolve_targets(&target_root, raw.target_bindings, raw.target).ok()
+        })();
+        match linked_targets {
+            Some(targets) => Self { targets, ..self.clone() },
+            None => self.clone(),
+        }
+    }
+
     pub fn load(path: impl AsRef<Path>) -> Result<Self, ConfigError> {
         let path = path.as_ref();
         let text = fs::read_to_string(path)?;
@@ -283,7 +320,18 @@ impl Config {
         // anchored to main so every worktree shares one base index.
         // `ResolvedTarget.directories` are root-relative, so the stored targets are
         // identical either way (#219 review).
-        let targets = resolve_targets(&local_root, raw.target_bindings, raw.target)?;
+        let local_targets = resolve_targets(&local_root, raw.target_bindings, raw.target)?;
+        // The stored `Config.targets` are the BASE targets — they drive discovery over the anchored
+        // `root` (= main). When this config was read from a LINKED worktree, its branch
+        // `rag-rat.toml` may NARROW or DROP a target that still exists on main; using the
+        // branch targets for base discovery would classify the now-undiscovered main files
+        // as deleted and tombstone them in the BASE scope, hiding committed files from main
+        // queries. So when anchoring to a different (main) root, re-resolve the base
+        // targets from MAIN's own `rag-rat.toml`. The branch's targets are NOT lost: the
+        // overlay refresh reloads each linked worktree's own config
+        // (`refresh_worktree_overlays`) and indexes the branch with its own target set (#219
+        // review).
+        let targets = main_base_targets(&root, &local_root).unwrap_or(local_targets);
         let local_ai = LocalAiConfig::try_from(raw.local_ai)?;
         let watch = raw.watch.into();
         let version_check = raw.version_check.into();
@@ -387,6 +435,27 @@ fn anchor_root_to_main_worktree(root: &Path) -> PathBuf {
     // calls that read `Config.root`. Keep the linked checkout's (validated, existing) root in that
     // case — the overlay still serves the branch; the base just can't anchor there (#219 review).
     if anchored.is_dir() { anchored } else { root.to_path_buf() }
+}
+
+/// The BASE targets for a config that was read from a LINKED worktree: the MAIN checkout's
+/// `rag-rat.toml` targets, resolved against the anchored (main) `root`. `None` — so the caller
+/// keeps the local (branch) targets — when this config is NOT anchored away from its own checkout
+/// (`root == local_root`: the main checkout or a non-git dir), when main has no readable
+/// `rag-rat.toml`, or when main's targets don't validate against `root` (e.g. a main target dir
+/// that only the subdir layout reaches). Reading main's config keeps base DISCOVERY faithful to
+/// main, so a branch that narrows/drops a target can't tombstone main's committed files in the base
+/// scope (#219 review). The branch's own targets still drive its overlay via
+/// `refresh_worktree_overlays`.
+fn main_base_targets(root: &Path, local_root: &Path) -> Option<Vec<ResolvedTarget>> {
+    if root == local_root {
+        return None; // not anchored away — the local config IS the base config
+    }
+    let main_config_path = main_worktree_root(root)?.join("rag-rat.toml");
+    let text = fs::read_to_string(&main_config_path).ok()?;
+    let raw: RawConfig = toml::from_str(&text).ok()?;
+    // Main's targets are root-relative; validate (and store) them against the anchored `root`,
+    // which is the equivalent path under the main worktree the base index is discovered from.
+    resolve_targets(root, raw.target_bindings, raw.target).ok()
 }
 
 /// The main worktree root, derived from the git common dir (`<main>/.git`). Returns `None` outside
@@ -627,12 +696,15 @@ mod tests {
     }
 
     #[test]
-    fn config_load_in_a_linked_worktree_validates_branch_only_target_dirs() {
+    fn config_load_in_a_linked_worktree_uses_main_base_targets_not_the_branch() {
         // #219 review: a linked branch can point `rag-rat.toml` at a target dir that exists ONLY in
         // that branch. `Config::load` anchors `root` to the main worktree for the shared base
-        // index, but it must VALIDATE the targets against the LINKED checkout (where the
-        // config + that dir live) — not the main checkout — or launching the index/MCP in
-        // the linked worktree fails with `MissingDirectory` against main.
+        // index. Two things must hold: (1) loading the branch config must NOT fail with
+        // `MissingDirectory` (the branch-only dir is validated against the linked checkout where it
+        // lives); (2) the stored BASE `targets` must come from MAIN's `rag-rat.toml`, not the
+        // branch's — otherwise base discovery walks main with the branch target set and tombstones
+        // any main file outside it. The branch's extra target is served via the overlay, not the
+        // base config.
         let git = |dir: &Path, args: &[&str]| {
             std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
         };
@@ -668,20 +740,81 @@ mod tests {
         git(&linked, &["add", "-A"]);
         git(&linked, &["commit", "-qm", "branch adds extra"]);
 
-        // `extra` does not exist in the main checkout, so validating against main would fail.
+        // `extra` does not exist in the main checkout, so validating against main would fail —
+        // loading still succeeds because the branch-only dir is validated against the linked
+        // checkout where it lives.
         assert!(!main.join("extra").exists(), "the branch-only dir must be absent from main");
         let from_linked = Config::load(linked.join("rag-rat.toml"))
-            .expect("loading the branch config in the linked worktree must validate against it");
-        // root still anchors to main (one shared base index), targets validated against the branch.
+            .expect("loading the branch config in the linked worktree must not fail (req 1)");
+        // root still anchors to main (one shared base index).
         assert_eq!(
             from_linked.root,
             main.canonicalize().unwrap(),
             "root anchors to the main worktree for the shared base index",
         );
+        // The stored BASE targets come from MAIN's config (`src` only), NOT the branch's
+        // (`src` + `extra`): base discovery must not walk main with the branch's target set (req
+        // 2).
         let dirs = from_linked.target_directories();
+        assert!(dirs.contains(&PathBuf::from("src")), "main's `src` target is the base: {dirs:?}");
+        assert!(
+            !dirs.contains(&PathBuf::from("extra")),
+            "the branch-only target must NOT be a base target (it can't tombstone main): {dirs:?}",
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn config_load_in_a_linked_worktree_keeps_main_targets_when_the_branch_narrows_them() {
+        // #219 review (3440746682): a linked branch's `rag-rat.toml` that NARROWS the target set
+        // (drops a dir that still exists on main) must NOT carry that narrowed set into the BASE
+        // config. The base config drives discovery over the anchored (main) root; with the branch's
+        // narrowed targets, main-only files would be classified `deleted` and tombstoned in the
+        // base scope — hiding committed files from main queries. The stored base targets
+        // must be MAIN's.
+        let git = |dir: &Path, args: &[&str]| {
+            std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
+        };
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let tmp =
+            std::env::temp_dir().join(format!("ragrat-cfgnarrow-{}-{id}", std::process::id()));
+        let main = tmp.join("main");
+        std::fs::create_dir_all(main.join("src")).unwrap();
+        std::fs::create_dir_all(main.join("extra")).unwrap();
+        std::fs::write(main.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        std::fs::write(main.join("extra/more.rs"), "pub fn b() {}\n").unwrap();
+        // Main indexes BOTH `src` and `extra`.
+        std::fs::write(
+            main.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\", \"extra\"]\n",
+        )
+        .unwrap();
+        git(&main, &["init", "-q"]);
+        git(&main, &["config", "user.email", "t@example.com"]);
+        git(&main, &["config", "user.name", "t"]);
+        git(&main, &["add", "-A"]);
+        git(&main, &["commit", "-qm", "seed"]);
+
+        // The branch NARROWS to `src` only (drops `extra`), committed on the branch.
+        let linked = tmp.join("wt");
+        git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+        std::fs::write(
+            linked.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n",
+        )
+        .unwrap();
+        git(&linked, &["add", "-A"]);
+        git(&linked, &["commit", "-qm", "branch narrows to src"]);
+
+        let from_linked = Config::load(linked.join("rag-rat.toml")).unwrap();
+        let dirs = from_linked.target_directories();
+        // Both of main's targets survive in the base config, so base discovery still walks `extra`
+        // on main and never tombstones `extra/more.rs`.
+        assert!(dirs.contains(&PathBuf::from("src")), "base keeps main's `src`: {dirs:?}");
         assert!(
             dirs.contains(&PathBuf::from("extra")),
-            "the branch-only target dir survives validation: {dirs:?}",
+            "base keeps main's `extra` even though the branch dropped it: {dirs:?}",
         );
 
         let _ = std::fs::remove_dir_all(&tmp);

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -377,10 +377,16 @@ fn anchor_root_to_main_worktree(root: &Path) -> PathBuf {
     // canonicalized by `normalize_existing_dir`, so it strips cleanly against the canonical
     // workdir; `root == workdir` (a `root="."` config) yields an empty suffix → the main
     // worktree top.
-    match root.strip_prefix(&workdir) {
+    let anchored = match root.strip_prefix(&workdir) {
         Ok(rel) => main_root.join(rel),
         Err(_) => main_root,
-    }
+    };
+    // The anchored path must EXIST in the main checkout. When the linked branch sets `[index].root`
+    // to a directory that lives only on the branch (not in main), `main_root.join(rel)` points at a
+    // missing path, which would break the later `discover_repo` / database-base / base-indexing
+    // calls that read `Config.root`. Keep the linked checkout's (validated, existing) root in that
+    // case — the overlay still serves the branch; the base just can't anchor there (#219 review).
+    if anchored.is_dir() { anchored } else { root.to_path_buf() }
 }
 
 /// The main worktree root, derived from the git common dir (`<main>/.git`). Returns `None` outside
@@ -747,6 +753,20 @@ mod tests {
         std::fs::create_dir_all(&plain).unwrap();
         let plain_c = plain.canonicalize().unwrap();
         assert_eq!(anchor_root_to_main_worktree(&plain_c), plain_c);
+
+        // A linked-worktree subdir root that does NOT exist in main must NOT anchor to a missing
+        // `main/<rel>` path (#219 review): the branch created `branch_only/`, which main never had.
+        // The anchored `main/branch_only` doesn't exist, so resolution keeps the linked checkout's
+        // (existing) root — otherwise `Config.root` would point outside any discoverable repo path.
+        let branch_only = linked.join("branch_only");
+        std::fs::create_dir_all(&branch_only).unwrap();
+        let branch_only_c = branch_only.canonicalize().unwrap();
+        assert!(!main_c.join("branch_only").exists(), "main never had this dir");
+        assert_eq!(
+            anchor_root_to_main_worktree(&branch_only_c),
+            branch_only_c,
+            "a branch-only root that's missing in main keeps the linked checkout's root",
+        );
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -254,16 +254,21 @@ impl Config {
         let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
         let root = config_dir.join(raw.index.root.unwrap_or_else(|| ".".to_string()));
         let root = normalize_existing_dir(&root)?;
-        // One database per repo: resolve a relative database path against the *main* worktree so
-        // all linked worktrees of a repo share one index (the commit/worktree overlay is built for
-        // exactly this). An absolute path is honored as-is. The main worktree resolves against its
-        // own root (unchanged), so single-worktree users see no change.
+        // Anchor `root` to the MAIN worktree root, so EVERY invocation resolves to the same root
+        // and thus the same base commit for the one shared index — whether launched from
+        // the main checkout, a linked worktree, or any cwd (`root="."` resolves against the
+        // launch dir, and a linked worktree has its OWN checked-out config). Per-worktree
+        // results come from the `worktree` QUERY scope, never a per-worktree config root:
+        // otherwise two processes rooted at different worktrees (different base commits)
+        // write CONFLICTING overlay rows to the shared DB — a file present on one branch
+        // races between readable and tombstone (#218/#219). The main worktree (and non-git
+        // dirs) resolve to themselves, so single-worktree users see no change.
+        let root = main_worktree_or_self(&root);
+        // One database per repo: a relative path resolves against `root` (now the main worktree),
+        // so all linked worktrees share one index. An absolute path is honored as-is.
         let database = match raw.index.database {
             Some(db) if Path::new(&db).is_absolute() => PathBuf::from(db),
-            other => {
-                let relative = other.unwrap_or_else(|| ".rag-rat/index.sqlite".to_string());
-                shared_db_base(&root).join(relative)
-            },
+            other => root.join(other.unwrap_or_else(|| ".rag-rat/index.sqlite".to_string())),
         };
         let targets = resolve_targets(&root, raw.target_bindings, raw.target)?;
         let local_ai = LocalAiConfig::try_from(raw.local_ai)?;
@@ -338,10 +343,10 @@ fn push_target(
     Ok(())
 }
 
-/// Base directory a relative `database` path resolves against. For a **linked** git worktree this
-/// is the **main** worktree root (so all worktrees share one index DB); for the main worktree or a
-/// non-git dir it is `root` unchanged — single-worktree setups keep their existing DB location.
-fn shared_db_base(root: &Path) -> PathBuf {
+/// The **main** worktree root for a **linked** git worktree (so every worktree of a repo resolves
+/// to one `root` + one shared index DB); for the main worktree or a non-git dir, `root` unchanged —
+/// single-worktree setups are unaffected.
+fn main_worktree_or_self(root: &Path) -> PathBuf {
     match main_worktree_root(root) {
         Some(main_root) if main_root != root => main_root,
         _ => root.to_path_buf(),
@@ -571,6 +576,16 @@ mod tests {
             "main and linked worktrees must share one index database",
         );
         assert_eq!(from_main.database, main.canonicalize().unwrap().join(".rag-rat/index.sqlite"));
+        // AND the `root` anchors to the main worktree from either launch point — so every process
+        // uses the same base commit for the shared index, instead of a worktree-launched one
+        // rooting at the worktree (a different base → conflicting overlay writes /
+        // readable-vs-tombstone races) (#218/#219).
+        assert_eq!(from_main.root, from_linked.root, "main and linked configs resolve to one root");
+        assert_eq!(
+            from_linked.root,
+            main.canonicalize().unwrap(),
+            "a linked worktree's config root anchors to the main worktree",
+        );
 
         let _ = std::fs::remove_dir_all(&tmp);
     }
@@ -605,7 +620,7 @@ mod tests {
     }
 
     #[test]
-    fn shared_db_base_shares_one_db_across_worktrees() {
+    fn main_worktree_or_self_shares_one_db_across_worktrees() {
         let git = |dir: &Path, args: &[&str]| {
             std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
         };
@@ -626,15 +641,15 @@ mod tests {
         let linked_c = linked.canonicalize().unwrap();
 
         // Main worktree resolves to itself (no redirect → existing DB location preserved).
-        assert_eq!(shared_db_base(&main_c), main_c);
+        assert_eq!(main_worktree_or_self(&main_c), main_c);
         // Linked worktree redirects to the main worktree → one shared DB.
-        assert_eq!(shared_db_base(&linked_c), main_c);
+        assert_eq!(main_worktree_or_self(&linked_c), main_c);
 
         // A non-git directory falls back to itself.
         let plain = tmp.join("plain");
         std::fs::create_dir_all(&plain).unwrap();
         let plain_c = plain.canonicalize().unwrap();
-        assert_eq!(shared_db_base(&plain_c), plain_c);
+        assert_eq!(main_worktree_or_self(&plain_c), plain_c);
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -252,6 +252,32 @@ pub(crate) fn status(conn: &Connection) -> anyhow::Result<LocalAiStatus> {
     })
 }
 
+/// How many chunks in the ACTIVE scope still need embedding (missing / stale / model- or
+/// dim-changed / retryable-failed), using the SAME candidate sizing the reconcile loop uses. The
+/// watcher gates a per-overlay reconcile on `this_changed`; a reconcile that returned `Partial`
+/// (the shared budget ran out mid-pass) leaves a backlog the next pass would skip because the
+/// overlay rows themselves did not change — so the watcher also reconciles an overlay whose `> 0`
+/// pending count means embeddings were left behind (#219 review). Returns 0 when no embedding model
+/// is ready (nothing to retry) rather than erroring — the watcher must not abort a pass over a
+/// missing embedder.
+pub(crate) fn pending_embedding_jobs(conn: &Connection) -> anyhow::Result<u64> {
+    ensure_model_manifest(conn)?;
+    let model_id = active_embedding_model_id(conn)?;
+    let model = model(conn, &model_id)?;
+    if validate_ready_model(&model).is_err() {
+        return Ok(0);
+    }
+    let model_version = active_embedding_model_version(conn, &model_id)?;
+    let dim = usize::try_from(model.embedding_dim.unwrap_or_default()).unwrap_or(0);
+    let scan = EmbeddingScan {
+        model_id: &model_id,
+        model_version: &model_version,
+        dim,
+        max_embedding_chars: DEFAULT_MAX_EMBEDDING_CHARS,
+    };
+    estimated_reconcile_jobs(conn, &scan, &ReconcileOptions::default())
+}
+
 pub(crate) fn reconcile_plan(conn: &Connection) -> anyhow::Result<ReconcilePlan> {
     ensure_model_manifest(conn)?;
     let model_id = active_embedding_model_id(conn)?;

--- a/crates/rag-rat-core/src/index/edges/resolve/dispatch.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/dispatch.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 
 use rusqlite::{Connection, params};
 
+use super::EdgeWriteScope;
 use crate::index::edges::{EdgeConfidence, EdgeKind, EdgeStringInterner};
 
 /// Cap on constructors × handlers materialized for one variant key. A catch-all message enum used
@@ -49,20 +50,30 @@ pub(crate) struct DispatchSynthesis {
     pub skipped_variants: usize,
 }
 
-pub(crate) fn synthesize_dispatch_edges(conn: &Connection) -> anyhow::Result<DispatchSynthesis> {
+pub(crate) fn synthesize_dispatch_edges(
+    conn: &Connection,
+    write: EdgeWriteScope<'_>,
+) -> anyhow::Result<DispatchSynthesis> {
     let mut interner = EdgeStringInterner::default();
     let dispatches_kind_id = interner.get(conn, EdgeKind::Dispatches.as_str())?;
 
-    // Idempotent re-run: drop any prior synthesized dispatches in the ACTIVE scope before
-    // rebuilding them. `files` is the per-connection scope view (#89), so other checkouts are
-    // untouched.
+    // Idempotent re-run: drop any prior synthesized dispatches in the WRITE scope before rebuilding
+    // them. `files` is the per-connection scope view (#89), so other checkouts are untouched; the
+    // extra write predicate keeps a LINKED-OVERLAY pass from deleting a SHARED committed (base)
+    // sender's `dispatches` row (#219 P1) — a base row visible in the overlay view but not owned by
+    // it.
     conn.execute(
-        "DELETE FROM edges_data
-         WHERE edge_kind_id = ?1 AND source_file_id IN (SELECT id FROM files)",
+        &format!(
+            "DELETE FROM edges_data
+             WHERE edge_kind_id = ?1 AND source_file_id IN (
+                 SELECT files.id FROM files WHERE 1 = 1{}
+             )",
+            write.files_write_predicate(),
+        ),
         params![dispatches_kind_id],
     )?;
 
-    let constructors = collect_constructors(conn)?;
+    let constructors = collect_constructors(conn, write)?;
     let handlers = collect_handlers(conn)?;
     if constructors.is_empty() || handlers.is_empty() {
         return Ok(DispatchSynthesis::default());
@@ -145,16 +156,22 @@ pub(crate) fn synthesize_dispatch_edges(conn: &Connection) -> anyhow::Result<Dis
 /// view.
 fn collect_constructors(
     conn: &Connection,
+    write: EdgeWriteScope<'_>,
 ) -> anyhow::Result<HashMap<String, HashMap<i64, Constructor>>> {
-    let mut stmt = conn.prepare(
+    // Constructors are the SOURCE rows we emit `dispatches` for, so restrict them to the write
+    // scope (#219 P1): a linked-overlay pass must not synthesize dispatches OUT of a shared
+    // committed sender. Handlers (the resolve TARGETS, below) stay full-scope so an overlay
+    // sender into a base handler still binds.
+    let mut stmt = conn.prepare(&format!(
         "SELECT tn.value, d.from_symbol_id, d.source_file_id, d.source_start_line, \
          d.source_end_line
          FROM edges_data d
          JOIN files ON files.id = d.source_file_id
          JOIN edge_strings ek ON ek.id = d.edge_kind_id
          JOIN edge_strings tn ON tn.id = d.to_name_id
-         WHERE ek.value = 'dispatch_construct' AND d.from_symbol_id IS NOT NULL",
-    )?;
+         WHERE ek.value = 'dispatch_construct' AND d.from_symbol_id IS NOT NULL{}",
+        write.files_write_predicate(),
+    ))?;
     let rows = stmt.query_map([], |row| {
         Ok((row.get::<_, String>(0)?, Constructor {
             symbol_id: row.get(1)?,

--- a/crates/rag-rat-core/src/index/edges/resolve/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/mod.rs
@@ -216,6 +216,39 @@ fn scope_context_value(conn: &Connection, key: &str) -> String {
     .unwrap_or_default()
 }
 
+/// Which edges a resolve pass may WRITE (re-resolve / re-synthesize).
+///
+/// READS always span the full active-checkout `files` scope view (so a target in a shadowed/base
+/// file still resolves); this only narrows the SET of source files whose `edges_data` rows the pass
+/// mutates. A LINKED-WORKTREE OVERLAY pass must NOT rewrite a SHARED committed (base-scoped) caller
+/// file's edges: the base row's `files.id` is the same row the base scope reads, so re-resolving it
+/// against the overlay's (shadowed) symbol set would corrupt base `find_callers`/impact until a
+/// base pass resolved it back — graph results flipping by whichever worktree refreshed last (#219
+/// P1).
+#[derive(Clone, Copy)]
+pub(crate) enum EdgeWriteScope<'a> {
+    /// Every in-view source file (the base/incremental/full-rebuild path: the active scope OWNS its
+    /// committed rows, so rewriting them is correct).
+    ActiveScope,
+    /// Only the linked worktree's OVERLAY rows (`files.worktree_id = id`). Shared committed rows in
+    /// the view are read for resolution targets but never written.
+    OverlayOnly(&'a str),
+}
+
+impl EdgeWriteScope<'_> {
+    /// `AND`-able predicate (with a leading space) restricting `files` to the writable source rows,
+    /// or empty for `ActiveScope`. Inlined (not bound) because it is appended to several different
+    /// SELECTs; the embedded value is a git-derived worktree id, single-quote-escaped defensively.
+    fn files_write_predicate(&self) -> String {
+        match self {
+            EdgeWriteScope::ActiveScope => String::new(),
+            EdgeWriteScope::OverlayOnly(worktree_id) => {
+                format!(" AND files.worktree_id = '{}'", worktree_id.replace('\'', "''"))
+            },
+        }
+    }
+}
+
 /// Re-resolve the ACTIVE CHECKOUT's edges against the ACTIVE CHECKOUT's symbols.
 ///
 /// SCOPE (load-bearing, #89): both SELECTs join `files` — the per-connection scoped TEMP VIEW
@@ -234,6 +267,21 @@ fn scope_context_value(conn: &Connection, key: &str) -> String {
 /// scope's edges stay self-consistent until gc prunes them or their own worktree's pass rewrites
 /// them.
 pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
+    resolve_edges_with_scope(conn, EdgeWriteScope::ActiveScope)
+}
+
+/// Re-resolve ONLY a linked worktree's OVERLAY edges (#219 P1). Resolution targets still span the
+/// full active scope (so an overlay edge into a base symbol resolves), but the WRITE set is the
+/// worktree's own overlay rows — a SHARED committed caller's `edges_data` is never rewritten by an
+/// overlay pass, so the base scope's graph is left intact. Accepted recall trade-off: a BASE
+/// caller's edge into an OVERLAY-modified symbol is not re-pointed in the overlay scope (the base
+/// row is read-only here); the overlay still serves its own files' edges, and the base resolves its
+/// own on its next pass.
+pub(crate) fn resolve_overlay_edges(conn: &Connection, worktree_id: &str) -> anyhow::Result<()> {
+    resolve_edges_with_scope(conn, EdgeWriteScope::OverlayOnly(worktree_id))
+}
+
+fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> anyhow::Result<()> {
     let symbols = all_symbols(conn)?;
     let index = SymbolIndex::build(&symbols);
     // Per-package + module-aware import scope (#61): the active checkout's Imports edges → per-file
@@ -279,14 +327,18 @@ pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
     // write pre-interned ids instead of paying the view triggers' per-row probes. The `files`
     // join is the active-checkout scope (#89) and is unaffected by the interning.
     let mut interner = EdgeStringInterner::default();
-    let mut stmt = conn.prepare(
+    // The WRITE filter (#219 P1): in an overlay pass this restricts the re-resolved (UPDATEd) rows
+    // to the worktree's OVERLAY source files, so a shared committed caller's edges are never
+    // rewritten; empty for the base/incremental/full-rebuild path.
+    let mut stmt = conn.prepare(&format!(
         "SELECT d.id, d.source_file_id, tn.value, tqn.value, ek.value, conf.value, d.evidence, \
          rh.value, d.source_start_byte FROM edges_data d JOIN files ON files.id = \
          d.source_file_id LEFT JOIN edge_strings tn ON tn.id = d.to_name_id LEFT JOIN \
          edge_strings tqn ON tqn.id = d.target_qualified_name_id LEFT JOIN edge_strings ek ON \
          ek.id = d.edge_kind_id LEFT JOIN edge_strings conf ON conf.id = d.confidence_id LEFT \
-         JOIN edge_strings rh ON rh.id = d.receiver_hint_id ORDER BY d.id",
-    )?;
+         JOIN edge_strings rh ON rh.id = d.receiver_hint_id WHERE 1 = 1{} ORDER BY d.id",
+        write.files_write_predicate(),
+    ))?;
     let rows = stmt.query_map([], |row| {
         Ok((
             row.get::<_, i64>(0)?,
@@ -417,8 +469,9 @@ pub(crate) fn resolve_all_edges(conn: &Connection) -> anyhow::Result<()> {
         ])?;
     }
     // #200: now that the dispatch FACT rows are resolved (handlers bound to symbols), synthesize
-    // the construct→handler `dispatches` edges. Idempotent over the active scope.
-    synthesize_dispatch_edges(conn)?;
+    // the construct→handler `dispatches` edges. Idempotent over the write scope (#219 P1: an
+    // overlay pass synthesizes/clears dispatches ONLY for its own overlay source files).
+    synthesize_dispatch_edges(conn, write)?;
     Ok(())
 }
 /// Full-rebuild fast path: resolve every accumulated edge candidate against an in-memory symbol
@@ -673,7 +726,8 @@ pub(crate) fn resolve_and_insert_edges(
     crate::index::mem_trace("edges: after index rebuild");
     // #200: synthesize construct→handler `dispatches` edges from the resolved fact rows. Runs after
     // the index rebuild — the few extra inserts maintain the (now rebuilt) indexes incrementally.
-    synthesize_dispatch_edges(conn)?;
+    // A full rebuild owns its whole scope, so it synthesizes over the active scope.
+    synthesize_dispatch_edges(conn, EdgeWriteScope::ActiveScope)?;
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -13,6 +13,12 @@ struct ChunkInsertFile<'a> {
 
 impl IndexDatabase {
     pub fn heal_file(&self, path: &Path) -> anyhow::Result<()> {
+        // A heal reads bytes from `source_root` (the MAIN checkout). Under a linked-worktree
+        // overlay scope that would shadow the branch's row with MAIN's content, so skip it
+        // — the overlay is maintained only by `index_worktree_overlay` (#219 review).
+        if self.active_scope_is_linked_overlay() {
+            return Ok(());
+        }
         let Some(root) = self.storage.source_root() else {
             anyhow::bail!("index has no source_root metadata; rebuild required");
         };

--- a/crates/rag-rat-core/src/index/file_rows.rs
+++ b/crates/rag-rat-core/src/index/file_rows.rs
@@ -5,8 +5,22 @@ use super::*;
 
 impl IndexDatabase {
     pub(super) fn mark_file_deleted(&self, path: &Path) -> anyhow::Result<()> {
+        self.write_tombstone_in_scope(path, &self.active_worktree_id)
+    }
+
+    /// Write a `kind='deleted'` overlay tombstone for `path` in an EXPLICIT `worktree_id` scope
+    /// (not necessarily the active one). The scope view excludes such a row from the overlay
+    /// branch AND (because the committed branch's `path NOT IN (overlay paths)` subquery still
+    /// counts it) suppresses the base committed row — so the path is HIDDEN rather than falling
+    /// through to the base. That is exactly what a linked worktree's branch-deleted file needs
+    /// (#219); `mark_file_deleted` is the active-scope special case.
+    pub(super) fn write_tombstone_in_scope(
+        &self,
+        path: &Path,
+        worktree_id: &str,
+    ) -> anyhow::Result<()> {
         let path = path_string(path);
-        self.remove_file_in_scope(Path::new(&path), "", &self.active_worktree_id)?;
+        self.remove_file_in_scope(Path::new(&path), "", worktree_id)?;
         self.storage.connection().execute(
             "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, generated, \
              indexed_at_ms, indexed_revision, commit_sha, worktree_id)
@@ -16,7 +30,7 @@ impl IndexDatabase {
                 sha256 = '',
                 modified_at_ms = 0,
                 indexed_at_ms = excluded.indexed_at_ms",
-            params![path, now_ms(), self.active_worktree_id],
+            params![path, now_ms(), worktree_id],
         )?;
         self.mark_fts_dirty()?;
         Ok(())

--- a/crates/rag-rat-core/src/index/file_rows.rs
+++ b/crates/rag-rat-core/src/index/file_rows.rs
@@ -75,9 +75,15 @@ impl IndexDatabase {
                 )",
             params![path, commit_sha, worktree_id],
         )?;
-        self.storage
-            .connection()
-            .execute("DELETE FROM parser_failures WHERE path = ?1", [&path])?;
+        // `parser_failures` is keyed by `path` only (no scope). A LINKED-WORKTREE OVERLAY pass must
+        // NOT delete by bare path: that would clear a REAL parse failure recorded for the same path
+        // by the base (or a sibling) scope. The overlay never WRITES this table either (see
+        // `insert_parser_failure`), so it has nothing of its own to remove (#219 review).
+        if !self.active_scope_is_linked_overlay() {
+            self.storage
+                .connection()
+                .execute("DELETE FROM parser_failures WHERE path = ?1", [&path])?;
+        }
         self.storage.connection().execute(
             "DELETE FROM chunk_fts
              WHERE rowid IN (

--- a/crates/rag-rat-core/src/index/git_context.rs
+++ b/crates/rag-rat-core/src/index/git_context.rs
@@ -139,8 +139,57 @@ pub(crate) fn path_is_dirty(repo: &gix::Repository, relative: &Path) -> bool {
 /// `open_config` path, integration tests) can install the same active-checkout scope `search` uses.
 pub fn resolve_git_context(root: &Path) -> (String, String) {
     let commit_sha = head_sha(root);
-    let worktree_id = root.to_string_lossy().trim_end_matches('/').to_string();
-    (commit_sha, worktree_id)
+    (commit_sha, worktree_id_of(root))
+}
+
+/// Format a worktree checkout path into the `worktree_id` string scope rows are keyed by (trailing
+/// slash trimmed) — shared by `resolve_git_context`, `resolve_worktree_scope`, and (for liveness)
+/// `live_worktree_contexts`, so the overlay key, the active scope, and the GC live set can't drift.
+pub(crate) fn worktree_id_of(path: &Path) -> String {
+    path.to_string_lossy().trim_end_matches('/').to_string()
+}
+
+/// Resolve the active scope `(commit_sha, worktree_id)` for a query, honoring an optional caller
+/// `worktree` (a linked-worktree checkout the caller is working in). The scope's BASE commit is
+/// always `root`'s indexed HEAD (the shared base index) — a linked worktree is served as an OVERLAY
+/// on that base, never as a separate index, and config/db stay anchored to `root` (#219). When
+/// `worktree` names a valid linked sibling of `root`'s repo, the `worktree_id` selects that
+/// worktree's overlay; otherwise (absent / main / foreign / unreadable) it falls back to `root`'s
+/// own scope — never the wrong repo.
+// Wired into the query open path (`open_config` / `set_context`) in #219 stage 3 (scope routing);
+// unused until then.
+#[allow(dead_code)]
+pub(crate) fn resolve_worktree_scope(root: &Path, worktree: Option<&Path>) -> (String, String) {
+    let (base_sha, base_id) = resolve_git_context(root);
+    match worktree.and_then(|candidate| validated_sibling_worktree(root, candidate)) {
+        Some(linked) => (base_sha, worktree_id_of(&linked)),
+        None => (base_sha, base_id),
+    }
+}
+
+/// If `candidate` is a LINKED worktree (`git_dir != common_dir`) sharing `root`'s repository (same
+/// common dir), return its checkout dir; otherwise `None`. Server-side validation of an UNTRUSTED
+/// caller-supplied path (e.g. a cwd that on macOS can be `/`): a main-worktree, foreign-repo, or
+/// unreadable path returns `None` so the caller falls back to the base scope rather than serving
+/// the wrong repo (#219). The comparison canonicalizes git/common dirs; the returned checkout path
+/// is gix's raw `workdir()` so its `worktree_id` matches the GC live set from
+/// `live_worktree_contexts`.
+#[allow(dead_code)] // Reached only via resolve_worktree_scope (wired in #219 stage 3).
+fn validated_sibling_worktree(root: &Path, candidate: &Path) -> Option<PathBuf> {
+    let repo = discover_repo(candidate).ok()?;
+    let git_dir = repo.git_dir().canonicalize().ok()?;
+    let common_dir = repo.common_dir().canonicalize().ok()?;
+    // The main worktree's per-worktree git dir IS the common dir; a linked worktree's differs. Main
+    // → None → base scope (which already serves the main checkout).
+    if git_dir == common_dir {
+        return None;
+    }
+    // Same repository as `root` iff they share a common dir — rejects an unrelated repo's worktree.
+    let root_common = discover_repo(root).ok()?.common_dir().canonicalize().ok()?;
+    if common_dir != root_common {
+        return None;
+    }
+    repo.workdir().map(Path::to_path_buf)
 }
 
 /// The live (commit_sha, worktree_id) keys across every worktree that shares this repo (the gix
@@ -195,4 +244,99 @@ pub(crate) fn live_worktree_contexts(root: &Path) -> (Vec<String>, Vec<String>) 
     commits.sort();
     commits.dedup();
     (commits, worktrees)
+}
+
+#[cfg(test)]
+mod worktree_scope_tests {
+    use std::process::Command;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@e")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@e")
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+    }
+
+    fn temp_dir(tag: &str) -> PathBuf {
+        static N: AtomicU64 = AtomicU64::new(0);
+        let n = N.fetch_add(1, Ordering::Relaxed);
+        let dir =
+            std::env::temp_dir().join(format!("ragrat-wtscope-{}-{tag}-{n}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        dir
+    }
+
+    fn init_repo(tag: &str) -> PathBuf {
+        let dir = temp_dir(tag);
+        std::fs::create_dir_all(&dir).unwrap();
+        git(&dir, &["init", "-q"]);
+        std::fs::write(dir.join("a.txt"), "hello").unwrap();
+        git(&dir, &["add", "."]);
+        git(&dir, &["commit", "-q", "-m", "init"]);
+        dir.canonicalize().unwrap()
+    }
+
+    #[test]
+    fn none_is_the_base_scope() {
+        let main = init_repo("none");
+        assert_eq!(resolve_worktree_scope(&main, None), resolve_git_context(&main));
+    }
+
+    #[test]
+    fn linked_worktree_selects_its_overlay_on_the_base_commit() {
+        let main = init_repo("linked-main");
+        let linked = temp_dir("linked-wt");
+        git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+        // A commit on the branch so the linked HEAD diverges from the base.
+        std::fs::write(linked.join("b.txt"), "branch").unwrap();
+        git(&linked, &["add", "."]);
+        git(&linked, &["commit", "-q", "-m", "branch"]);
+
+        let (base_sha, base_id) = resolve_git_context(&main);
+        let (sha, wt) = resolve_worktree_scope(&main, Some(&linked));
+        // Overlay-on-base: the base commit stays the rooted checkout's HEAD; only the worktree_id
+        // changes, selecting the linked worktree's overlay.
+        assert_eq!(sha, base_sha, "base commit must remain the rooted checkout's HEAD");
+        assert_ne!(wt, base_id, "worktree_id must select the linked worktree");
+        assert_eq!(PathBuf::from(&wt).canonicalize().unwrap(), linked.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn main_worktree_path_falls_back_to_base() {
+        let main = init_repo("main-fallback");
+        // Passing the MAIN checkout (git_dir == common_dir) is not a linked worktree → base scope.
+        assert_eq!(resolve_worktree_scope(&main, Some(&main)), resolve_git_context(&main));
+    }
+
+    #[test]
+    fn foreign_repo_worktree_falls_back_to_base() {
+        let main = init_repo("foreign-main");
+        let other = init_repo("foreign-other");
+        let other_linked = temp_dir("foreign-linked");
+        git(&other, &["worktree", "add", "-q", other_linked.to_str().unwrap()]);
+        // A genuine linked worktree, but of a DIFFERENT repo (common dir differs) → base scope,
+        // never the foreign repo.
+        assert_eq!(resolve_worktree_scope(&main, Some(&other_linked)), resolve_git_context(&main));
+    }
+
+    #[test]
+    fn unreadable_path_falls_back_to_base() {
+        let main = init_repo("unreadable");
+        // The macOS bogus cwd `/` and a nonexistent path both resolve to base — no panic, no wrong
+        // repo (untrusted-input guard).
+        assert_eq!(resolve_worktree_scope(&main, Some(Path::new("/"))), resolve_git_context(&main));
+        assert_eq!(
+            resolve_worktree_scope(&main, Some(&main.join("nope"))),
+            resolve_git_context(&main)
+        );
+    }
 }

--- a/crates/rag-rat-core/src/index/git_context.rs
+++ b/crates/rag-rat-core/src/index/git_context.rs
@@ -156,9 +156,6 @@ pub(crate) fn worktree_id_of(path: &Path) -> String {
 /// `worktree` names a valid linked sibling of `root`'s repo, the `worktree_id` selects that
 /// worktree's overlay; otherwise (absent / main / foreign / unreadable) it falls back to `root`'s
 /// own scope — never the wrong repo.
-// Wired into the query open path (`open_config` / `set_context`) in #219 stage 3 (scope routing);
-// unused until then.
-#[allow(dead_code)]
 pub(crate) fn resolve_worktree_scope(root: &Path, worktree: Option<&Path>) -> (String, String) {
     let (base_sha, base_id) = resolve_git_context(root);
     match worktree.and_then(|candidate| validated_sibling_worktree(root, candidate)) {
@@ -174,7 +171,6 @@ pub(crate) fn resolve_worktree_scope(root: &Path, worktree: Option<&Path>) -> (S
 /// the wrong repo (#219). The comparison canonicalizes git/common dirs; the returned checkout path
 /// is gix's raw `workdir()` so its `worktree_id` matches the GC live set from
 /// `live_worktree_contexts`.
-#[allow(dead_code)] // Reached only via resolve_worktree_scope (wired in #219 stage 3).
 fn validated_sibling_worktree(root: &Path, candidate: &Path) -> Option<PathBuf> {
     let repo = discover_repo(candidate).ok()?;
     let git_dir = repo.git_dir().canonicalize().ok()?;

--- a/crates/rag-rat-core/src/index/git_context.rs
+++ b/crates/rag-rat-core/src/index/git_context.rs
@@ -22,6 +22,14 @@ pub(crate) struct GitChangedPaths {
 /// configured purely through `GIT_DIR`/`GIT_WORK_TREE`, e.g. CI — #213) do we fall back to the
 /// environment-override discovery, so that legitimate env-configured layout still resolves instead
 /// of leaving git history "unavailable".
+///
+/// LIMITATION (accepted, #219 review): the env fallback fires only when plain discovery ERRORS. If
+/// `config.root` has no `.git` of its own but sits INSIDE an enclosing repo (a monorepo above, a
+/// `$HOME` dotfiles repo), plain discovery succeeds on that enclosing repo and the `GIT_DIR`-
+/// configured external worktree is silently ignored. We do NOT re-prefer `GIT_DIR` here: that is
+/// exactly the env-hijack this fix removed (a worktree shell / git hook exports `GIT_DIR` and would
+/// re-capture resolution). The contract is: the index's repo is the one discoverable from
+/// `config.root` — don't nest a `GIT_DIR`-only external worktree inside another repo.
 pub(crate) fn discover_repo(root: &Path) -> Result<gix::Repository, Box<gix::discover::Error>> {
     // Box the error: gix's `discover::Error` is a large enum, and an unboxed large `Err` bloats
     // every `Result` this returns (clippy::result_large_err). Callers use `.ok()` or `?`
@@ -146,11 +154,20 @@ pub fn resolve_git_context(root: &Path) -> (String, String) {
     (commit_sha, worktree_id_of(root))
 }
 
-/// Format a worktree checkout path into the `worktree_id` string scope rows are keyed by (trailing
-/// slash trimmed) — shared by `resolve_git_context`, `resolve_worktree_scope`, and (for liveness)
-/// `live_worktree_contexts`, so the overlay key, the active scope, and the GC live set can't drift.
+/// Format a worktree checkout path into the `worktree_id` string scope rows are keyed by — shared
+/// by `resolve_git_context`, `resolve_worktree_scope`, and (for liveness) `live_worktree_contexts`,
+/// so the overlay WRITE key, the query scope, and the GC live set can't drift.
+///
+/// CANONICALIZES the path so the SAME physical worktree yields the SAME id no matter how it's
+/// spelled — a symlinked or relative reference, or a trailing slash. Without this, indexing via one
+/// spelling (CLI `--worktree`, the watcher's `proxy.base()`) and querying via another (the MCP
+/// `worktree` param / cwd fallback) produced DIFFERENT ids: the query silently missed the overlay,
+/// and GC — whose live set is canonical — pruned the live overlay as dead on every maintenance pass
+/// (#219 review). Falls back to the literal path when it can't be resolved (a removed
+/// worktree mid-GC), trailing slash trimmed either way.
 pub(crate) fn worktree_id_of(path: &Path) -> String {
-    path.to_string_lossy().trim_end_matches('/').to_string()
+    let resolved = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    resolved.to_string_lossy().trim_end_matches('/').to_string()
 }
 
 /// Resolve the active scope `(commit_sha, worktree_id)` for a query, honoring an optional caller
@@ -204,7 +221,7 @@ pub(crate) fn live_worktree_contexts(root: &Path) -> (Vec<String>, Vec<String>) 
     let add_repo =
         |worktrees: &mut Vec<String>, commits: &mut Vec<String>, repo: &gix::Repository| {
             if let Some(workdir) = repo.workdir() {
-                worktrees.push(workdir.to_string_lossy().trim_end_matches('/').to_string());
+                worktrees.push(worktree_id_of(workdir));
             }
             if let Ok(id) = repo.head_id() {
                 commits.push(id.to_hex().to_string());
@@ -228,7 +245,7 @@ pub(crate) fn live_worktree_contexts(root: &Path) -> (Vec<String>, Vec<String>) 
     if let Ok(proxies) = repo.worktrees() {
         for proxy in proxies {
             if let Ok(base) = proxy.base() {
-                worktrees.push(base.to_string_lossy().trim_end_matches('/').to_string());
+                worktrees.push(worktree_id_of(&base));
             }
             if let Ok(linked) = proxy.into_repo_with_possibly_inaccessible_worktree()
                 && let Ok(id) = linked.head_id()

--- a/crates/rag-rat-core/src/index/git_context.rs
+++ b/crates/rag-rat-core/src/index/git_context.rs
@@ -9,23 +9,27 @@ pub(crate) struct GitChangedPaths {
     pub(crate) deleted: BTreeSet<PathBuf>,
 }
 
-/// Open the git repository for `root` via gix, honoring `GIT_DIR` / `GIT_WORK_TREE` — a bare git
-/// dir plus an external worktree (e.g. in CI) is configured purely through those env vars, and
-/// plain `gix::discover` only searches upward from `root`, so it would miss such a repo and leave
-/// git history "unavailable" (clearing the historical tables). All gix discovery goes through here
-/// (#213 review).
+/// Open the git repository for `root` via gix. Resolves from `root` (the configured PATH) FIRST,
+/// searching upward for a `.git`, and IGNORING `GIT_DIR` / `GIT_WORK_TREE` on that path. The
+/// index's git context is defined by `config.root`, so an inherited `GIT_DIR`/`GIT_WORK_TREE` from
+/// the launching shell (e.g. a tool operating in a linked worktree — Claude Code, an IDE) must NOT
+/// hijack resolution. With the env honored unconditionally, `discover_repo(config.root)` and
+/// `discover_repo(linked_path)` BOTH returned the single env-specified repo, regardless of their
+/// path argument — collapsing the base↔linked overlay delta to empty and PRUNING/tombstoning every
+/// overlay row (the field-reported worktree flip-flop, #219). All gix discovery goes through here.
 ///
-/// Known limitation (#218): gix resolves a RELATIVE `GIT_DIR`/`GIT_WORK_TREE` against the process
-/// cwd, not against `root` (the old `git -C root` resolved them against `root`). Absolute env
-/// values, and relative ones when cwd == `root`, work; relative values from a foreign cwd don't.
-/// gix exposes no way to open with an explicit (git-dir, worktree) pair from outside the crate, so
-/// re-rooting cleanly isn't possible without process-global cwd/env mutation (racy under the
-/// parallel indexer).
+/// Only when no repository is found upward from `root` (a bare git dir + external worktree
+/// configured purely through `GIT_DIR`/`GIT_WORK_TREE`, e.g. CI — #213) do we fall back to the
+/// environment-override discovery, so that legitimate env-configured layout still resolves instead
+/// of leaving git history "unavailable".
 pub(crate) fn discover_repo(root: &Path) -> Result<gix::Repository, Box<gix::discover::Error>> {
     // Box the error: gix's `discover::Error` is a large enum, and an unboxed large `Err` bloats
     // every `Result` this returns (clippy::result_large_err). Callers use `.ok()` or `?`
     // (anyhow), both of which handle the box transparently.
-    gix::discover_with_environment_overrides(root).map_err(Box::new)
+    match gix::discover(root) {
+        Ok(repo) => Ok(repo),
+        Err(_) => gix::discover_with_environment_overrides(root).map_err(Box::new),
+    }
 }
 
 pub(crate) fn git_changed_paths(root: &Path) -> anyhow::Result<GitChangedPaths> {

--- a/crates/rag-rat-core/src/index/graph_index.rs
+++ b/crates/rag-rat-core/src/index/graph_index.rs
@@ -94,14 +94,25 @@ impl IndexDatabase {
         // current group's members (kilobytes). Byte-identical: same grouping, same
         // `logical_symbols` insert order (ids are content-derived via `stable_id`, not rowids), and
         // the same member order, verified against the golden index.
+        // Read RAW `main.files` (all scopes), NOT the per-connection `files` scope VIEW.
+        // logical_symbols is a GLOBAL table; building it must not depend on whichever scope happens
+        // to be active. When this runs in a worktree-overlay context (a scope view IS installed),
+        // an unqualified `files` resolves to the scoped temp view, so the wholesale DELETE
+        // + repopulate would WIPE every other scope's grouping (base + sibling worktrees)
+        // and restore only the active scope's — persistently breaking `sym_<hex>`-handle
+        // graph nav for base symbols (the #219 review finding). Reading `main.files`
+        // groups every symbol in every live scope; the content-derived `stable_id`
+        // collapses cross-scope duplicates into one logical symbol with per-scope members,
+        // and downstream reads stay scope-filtered via the `files` view.
         let conn = self.storage.connection();
         let mut stmt = conn.prepare(
             "
-            SELECT symbols.id, files.path, symbols.language, symbols.name, symbols.qualified_name,
-                   symbols.kind, symbols.signature, symbols.start_line, symbols.end_line
-            FROM symbols
-            JOIN files ON files.id = symbols.file_id
-            ORDER BY symbols.language, files.path, symbols.name, symbols.qualified_name,
+            SELECT symbols.id, main.files.path, symbols.language, symbols.name,
+                   symbols.qualified_name, symbols.kind, symbols.signature, symbols.start_line,
+                   symbols.end_line
+            FROM main.symbols AS symbols
+            JOIN main.files ON main.files.id = symbols.file_id
+            ORDER BY symbols.language, main.files.path, symbols.name, symbols.qualified_name,
                      symbols.kind, symbols.signature, symbols.start_byte, symbols.end_byte
             ",
         )?;

--- a/crates/rag-rat-core/src/index/graph_index.rs
+++ b/crates/rag-rat-core/src/index/graph_index.rs
@@ -69,6 +69,15 @@ impl IndexDatabase {
         edges::resolve_all_edges(self.storage.connection())
     }
 
+    /// Resolve edges for a LINKED-WORKTREE OVERLAY pass (#219 P1): re-resolve / re-synthesize ONLY
+    /// the worktree's own overlay source files, never the SHARED committed (base) rows that are
+    /// merely visible in the overlay scope view. Resolution targets still span the full overlay
+    /// view, so an overlay edge into a base symbol resolves correctly. The plain `resolve_edges`
+    /// (base/incremental/full-rebuild) owns its scope and rewrites everything in view.
+    pub(super) fn resolve_overlay_edges(&self, worktree_id: &str) -> anyhow::Result<()> {
+        edges::resolve_overlay_edges(self.storage.connection(), worktree_id)
+    }
+
     pub(super) fn rebuild_logical_symbols(&self) -> anyhow::Result<()> {
         // The insert below re-derives the COMPLETE logical-symbol table from all current symbols,
         // so clear it entirely first. A member-join "rebuild set" misses logical_symbols whose

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -206,6 +206,24 @@ impl IndexDatabase {
     }
 }
 
+/// Install the per-connection scope view for a worktree-aware query on a RAW connection — the
+/// Claude Code hooks (SessionStart orientation, PreToolUse grep-augmentation) and the MCP hook
+/// listener open an `IndexConnection` directly, not `IndexDatabase`, so they can't use
+/// `use_worktree_scope`. Resolves the OVERLAY scope from `config_root` (the main worktree, where
+/// the base index lives) and `cwd` (the session's working dir): when `cwd` is a linked worktree of
+/// `config_root`'s repo, the view serves that branch's overlay on the base; otherwise (main /
+/// foreign / unreadable) it is the base scope. `pub` so the CLI hook + the MCP listener (other
+/// crates) can scope their context to the worktree the session is actually in (#219).
+pub fn install_worktree_scope_view(
+    conn: &rusqlite::Connection,
+    config_root: &Path,
+    cwd: &Path,
+) -> anyhow::Result<()> {
+    let (commit_sha, worktree_id) = resolve_worktree_scope(config_root, Some(cwd));
+    install_scope_view(conn, &commit_sha, &worktree_id)?;
+    Ok(())
+}
+
 /// Installs the per-connection commit/worktree scoping view; callers query `files` afterward and
 /// see only the active context.
 pub(crate) fn install_scope_view(

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -188,6 +188,22 @@ impl IndexDatabase {
         Ok(())
     }
 
+    /// Whether this connection is scoped to a LINKED-worktree overlay (a non-empty
+    /// `active_worktree_id` that differs from the base checkout's own id, derived from
+    /// `source_root`). The lazy heal paths (`heal_file`, `heal_index`) read file bytes from
+    /// `source_root` (the MAIN checkout), so writing under a linked overlay scope would shadow the
+    /// branch's rows with MAIN's content; they SKIP the write in that case and leave the overlay to
+    /// `index_worktree_overlay`, the one writer allowed to maintain it (#219 review).
+    pub(crate) fn active_scope_is_linked_overlay(&self) -> bool {
+        if self.active_worktree_id.is_empty() {
+            return false;
+        }
+        match self.storage.source_root() {
+            Some(root) => self.active_worktree_id != worktree_id_of(root),
+            None => false,
+        }
+    }
+
     /// Re-scope this connection to a caller's `worktree` (a linked-worktree checkout), serving its
     /// overlay over the base. The base commit stays `root`'s indexed HEAD; only the `worktree_id`
     /// selects the overlay. A `None`, main, foreign, or unreadable `worktree` resolves to `root`'s

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -187,6 +187,23 @@ impl IndexDatabase {
         install_scope_view(self.storage.connection(), commit_sha, worktree_id)?;
         Ok(())
     }
+
+    /// Re-scope this connection to a caller's `worktree` (a linked-worktree checkout), serving its
+    /// overlay over the base. The base commit stays `root`'s indexed HEAD; only the `worktree_id`
+    /// selects the overlay. A `None`, main, foreign, or unreadable `worktree` resolves to `root`'s
+    /// own scope — never the wrong repo (the validation lives in `resolve_worktree_scope`). The
+    /// query open path calls this after opening so a `worktree`-scoped request serves the
+    /// overlay (#219 stage 3); the overlay rows themselves are maintained by
+    /// `index_worktree_overlay` (#219 stages 2/5). `root` is passed explicitly (not read from
+    /// `self.config`) so it works on every open.
+    pub fn use_worktree_scope(
+        &mut self,
+        root: &Path,
+        worktree: Option<&Path>,
+    ) -> anyhow::Result<()> {
+        let (commit_sha, worktree_id) = resolve_worktree_scope(root, worktree);
+        self.set_context(&commit_sha, &worktree_id)
+    }
 }
 
 /// Installs the per-connection commit/worktree scoping view; callers query `files` afterward and

--- a/crates/rag-rat-core/src/index/meta.rs
+++ b/crates/rag-rat-core/src/index/meta.rs
@@ -32,9 +32,20 @@ impl IndexDatabase {
         read_meta(self.storage.connection(), key)
     }
 
+    /// The content digest over EVERY indexed file row — read from the GLOBAL `main.files`, NOT the
+    /// scoped `temp.files` view. The FTS mirror (`chunk_fts`), the `content_revision` meta, and the
+    /// `fts_dirty` flag are all GLOBAL (one FTS5 index over the whole `chunks` table), so their
+    /// freshness must track global content. Reading the scoped view here made `fts_source_revision`
+    /// ALTERNATE: `sync_fts` under a linked-overlay scope recorded the overlay-view digest, then a
+    /// base read recomputed the base-view digest, saw a mismatch, and rebuilt FTS — and the next
+    /// overlay read rebuilt it back, so interleaved base/overlay reads rebuilt the global FTS every
+    /// time even though the per-row FTS entries were already in sync (#219 review). The global
+    /// digest is scope-invariant, so the freshness check is stable regardless of the active
+    /// connection scope.
     pub(super) fn content_revision(&self) -> anyhow::Result<String> {
         let value = self.storage.connection().query_row(
-            "SELECT COALESCE(string_agg(path || ':' || sha256, ',' ORDER BY path), '') FROM files",
+            "SELECT COALESCE(string_agg(path || ':' || sha256, ',' ORDER BY path), '') FROM \
+             main.files WHERE kind != 'deleted'",
             [],
             |row| row.get::<_, String>(0),
         )?;

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -34,7 +34,12 @@ pub use discovery::DiscoveryStatus;
 pub(crate) use discovery::*;
 pub use git_context::resolve_git_context;
 pub(crate) use git_context::*;
+// Only tests reach `install_scope_view` directly now (non-test code goes through
+// `install_worktree_scope_view`, which calls it within `lifecycle`); gate the re-export so the
+// non-test build doesn't warn it unused.
+#[cfg(test)]
 pub(crate) use lifecycle::install_scope_view;
+pub use lifecycle::install_worktree_scope_view;
 pub(crate) use mem_diag::{maybe_set_sqlite_soft_heap_limit, mem_trace};
 pub use parser_failures::ParserFailure;
 pub(crate) use prep::*;

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -29,6 +29,7 @@ mod query_api;
 mod rebuild;
 mod staleness;
 mod util;
+mod worktree_overlay;
 pub use discovery::DiscoveryStatus;
 pub(crate) use discovery::*;
 pub use git_context::resolve_git_context;

--- a/crates/rag-rat-core/src/index/parser_failures.rs
+++ b/crates/rag-rat-core/src/index/parser_failures.rs
@@ -16,6 +16,17 @@ impl IndexDatabase {
         language: Language,
         message: &str,
     ) -> anyhow::Result<()> {
+        // `parser_failures` is keyed by `path` ONLY (no scope) and every reader counts it globally
+        // (coverage, repo_brief, the orientation digest). A LINKED-WORKTREE OVERLAY pass routes its
+        // files through this same write path, so a branch-only syntax error would be reported in
+        // the BASE and sibling scopes — and `remove_file_in_scope`'s bare-path delete would
+        // clear a real failure from another scope. The overlay is not the table's owner;
+        // skip the write under an overlay scope and leave the global table to the base pass
+        // (accepted recall: a branch-only parse failure is not surfaced in that branch's
+        // coverage) (#219 review).
+        if self.active_scope_is_linked_overlay() {
+            return Ok(());
+        }
         self.storage.connection().execute(
             "INSERT INTO parser_failures(path, language, message) VALUES (?1, ?2, ?3)",
             params![path_string(path), language.as_str(), message],

--- a/crates/rag-rat-core/src/index/query_api/ai_lifecycle.rs
+++ b/crates/rag-rat-core/src/index/query_api/ai_lifecycle.rs
@@ -50,4 +50,11 @@ impl IndexDatabase {
     pub fn current_embedding_count(&self, model_id: &str) -> anyhow::Result<u64> {
         ai::current_embedding_count(self.storage.connection(), model_id)
     }
+
+    /// Chunks in the ACTIVE scope still awaiting embedding — the watcher uses this to retry an
+    /// overlay whose inline reconcile was cut short by the shared time budget (returned `Partial`),
+    /// even on a later pass where the overlay rows themselves did not change (#219 review).
+    pub fn pending_embedding_jobs(&self) -> anyhow::Result<u64> {
+        ai::pending_embedding_jobs(self.storage.connection())
+    }
 }

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -378,6 +378,17 @@ impl IndexDatabase {
         let Some(mut chunk) = crate::query::read_chunk(self.storage.connection(), chunk_id)? else {
             return Ok(None);
         };
+        // Under a LINKED-WORKTREE OVERLAY scope, `source_root` is the MAIN checkout — NOT the
+        // branch the chunk came from. Live-revalidating against main would slice the chunk
+        // text out of main's copy of the file (returning BASE text for a branch chunk
+        // whenever the anchor still matches), or call the overlay-guarded `heal_file`
+        // no-op. The overlay rows are maintained by `index_worktree_overlay` (read from the
+        // linked checkout), so the STORED text is already the branch's — return it as-is
+        // and skip live revalidation (#219 review). The base/main scope keeps full live
+        // revalidation below.
+        if self.active_scope_is_linked_overlay() {
+            return Ok(Some(chunk));
+        }
         let Some(root) = self.storage.source_root() else {
             return Ok(Some(chunk));
         };

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -429,6 +429,22 @@ impl IndexDatabase {
     }
 
     pub fn heal_index(&self, limit: Option<u32>) -> anyhow::Result<HealIndexReport> {
+        // `heal_index` reads file bytes from `source_root` (the MAIN checkout) and would write into
+        // the active scope. Under a linked-worktree overlay scope that reindexes the overlay with
+        // MAIN's contents or tombstones branch-only files, so refuse — the overlay is owned by
+        // `index_worktree_overlay`. Callers scope writes to the base (#219 review).
+        if self.active_scope_is_linked_overlay() {
+            return Ok(HealIndexReport {
+                checked_files: 0,
+                healed_files: 0,
+                removed_files: 0,
+                skipped_files: 0,
+                fts_fresh: !self.fts_dirty()?,
+                message: Some(
+                    "skipped: heal does not run under a linked-worktree overlay scope".to_string(),
+                ),
+            });
+        }
         let Some(root) = self.storage.source_root() else {
             anyhow::bail!("heal_index requires source_root metadata; run `rag-rat index` first");
         };

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -204,6 +204,16 @@ impl IndexDatabase {
     /// (bare/copied index). One file read + hash per distinct path — callers pass the small
     /// result set, not the whole corpus.
     fn stale_source_paths(&self, paths: &[String]) -> anyhow::Result<Vec<String>> {
+        // Under a LINKED-WORKTREE OVERLAY scope, `source_root` is the MAIN checkout — NOT the
+        // branch these rows came from. Hashing the overlay rows against main's copy reports every
+        // branch-changed file as stale even though the overlay is current, which makes
+        // symbol_lookup's matched-file heal trip `NeedsReindex` (and `heal_file` no-ops under the
+        // overlay anyway) and impact's `stale_files` caveat lie. The overlay rows are authoritative
+        // (maintained by `index_worktree_overlay`), so report nothing stale — same rationale as the
+        // read_chunk overlay skip (#219 review).
+        if self.active_scope_is_linked_overlay() {
+            return Ok(Vec::new());
+        }
         let Some(root) = self.storage.source_root().map(Path::to_path_buf) else {
             return Ok(Vec::new());
         };
@@ -253,6 +263,13 @@ impl IndexDatabase {
     /// No-op without a stored `Config` (rebuild/open/tests) or a git root — a genuine miss on a
     /// clean tree costs at most one `git status` and no write.
     fn heal_changed_for_zero_hit(&self) -> anyhow::Result<bool> {
+        // Under a LINKED-WORKTREE OVERLAY scope this would scan `config.root` (the MAIN checkout)
+        // for working-tree changes and index them into the overlay scope — main's edits, not the
+        // branch's. The overlay is maintained by `index_worktree_overlay`; leave the heal to it
+        // (#219 review).
+        if self.active_scope_is_linked_overlay() {
+            return Ok(false);
+        }
         let Some(config) = self.config.as_ref() else {
             return Ok(false);
         };

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -8204,8 +8204,9 @@ fn refresh_worktree_overlays_reconciles_overlay_scope_embeddings() {
     run_git(&linked, &["commit", "-q", "-m", "add branch file"]);
 
     let options = ai::ReconcileOptions { batch_size: Some(8), ..Default::default() };
+    let budget = crate::watch::ReconcileBudget::new(options, std::time::Instant::now());
     // The pass refreshes the overlay AND reconciles its embeddings inline.
-    let changed = crate::watch::refresh_worktree_overlays(&mut db, &config, Some(&options));
+    let changed = crate::watch::refresh_worktree_overlays(&mut db, &config, Some(&budget));
     assert!(changed, "the overlay changed (a new branch file was indexed)");
 
     // In the overlay scope, the new branch file's chunk must carry a Current embedding — not be
@@ -8261,6 +8262,118 @@ fn worktree_overlay_branch_deleted_file_is_hidden_by_tombstone() {
 
     set_base_scope(&mut db, &main);
     assert!(path_in_scope(&db, "src/gone.rs"), "the base scope still has the file");
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn worktree_overlay_tombstones_an_ignored_replacement_of_a_base_file() {
+    // #219 review: when a branch drops a base file from its tracked/indexable view but an IGNORED
+    // file still sits at that path on disk, the candidate must be TOMBSTONED, not skipped. Before
+    // the fix the on-disk-but-ignored path hit `continue`, so the overlay scope fell through to the
+    // base row and queries returned a file the branch no longer presents.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/data.rs"), "pub fn base_data() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+    assert!(path_in_scope(&db, "src/data.rs"));
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // The branch git-rm's the tracked file (→ a deletion candidate in the tree-diff) AND ignores
+    // the path, then drops a NEW untracked file at the same path: on disk it exists but is
+    // gitignored, so it is NOT indexable — exactly the shadow-a-base-file-with-an-ignored-file
+    // case.
+    fs::remove_file(linked.join("src/data.rs")).unwrap();
+    fs::write(linked.join(".gitignore"), "/src/data.rs\n").unwrap();
+    run_git(&linked, &["add", "-A"]);
+    run_git(&linked, &["commit", "-q", "-m", "drop + ignore data"]);
+    fs::write(linked.join("src/data.rs"), "pub fn ignored_replacement() {}\n").unwrap();
+
+    let report = db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert!(report.tombstoned >= 1, "the ignored replacement of a base file is tombstoned");
+    assert!(
+        !path_in_scope(&db, "src/data.rs"),
+        "the overlay hides the base file behind a tombstone (the branch's view dropped it)"
+    );
+
+    set_base_scope(&mut db, &main);
+    assert!(path_in_scope(&db, "src/data.rs"), "the base scope still has the file");
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn worktree_overlay_reads_do_not_heal_against_main() {
+    // #219 review: read tools (symbol_lookup / impact / search) revalidated overlay rows against
+    // `source_root` (the MAIN checkout). A branch that changes more than
+    // MAX_AUTO_HEAL_FILES_PER_CALL files looks entirely stale vs main, so `symbol_candidates`'
+    // matched-file heal tripped `NeedsReindex` (and `heal_file` no-ops under an overlay
+    // anyway). The overlay is authoritative, so the staleness check must be skipped under a
+    // linked-overlay scope.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    // More than the heal cap (4) so an unguarded check would treat every branch file as stale.
+    for i in 0..6 {
+        fs::write(main.join(format!("src/f{i}.rs")), format!("pub fn shared_{i}() {{}}\n"))
+            .unwrap();
+    }
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // Every file differs from main on the branch, and one carries a NEW symbol to look up.
+    for i in 0..6 {
+        fs::write(
+            linked.join(format!("src/f{i}.rs")),
+            format!("pub fn shared_{i}() {{}}\npub fn branch_only_{i}() {{}}\n"),
+        )
+        .unwrap();
+    }
+    run_git(&linked, &["add", "-A"]);
+    run_git(&linked, &["commit", "-q", "-m", "branch changes every file"]);
+
+    // Leaves the connection in the overlay scope.
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+
+    let selector = crate::query::symbol::SymbolSelector {
+        logical_symbol_id: None,
+        symbol_id: None,
+        symbol_path: None,
+        symbol: Some("branch_only_0".to_string()),
+        language: Some(Language::Rust),
+        allow_ambiguous: true,
+        limit: 10,
+    };
+    // Unguarded, this raised NeedsReindex (6 > cap 4 stale-vs-main files); guarded, it resolves the
+    // branch symbol cleanly and flags nothing stale.
+    let lookup = db.symbol_candidates(&selector, false).unwrap();
+    assert!(
+        lookup.candidates.iter().any(|c| c.name == "branch_only_0"),
+        "the overlay symbol resolves without a main-root stale heal: {:?}",
+        lookup.candidates.iter().map(|c| &c.name).collect::<Vec<_>>()
+    );
+    assert!(
+        lookup.stale_files.is_empty(),
+        "no overlay file is flagged stale against main: {:?}",
+        lookup.stale_files
+    );
+    // Search must also not raise NeedsReindex under the overlay scope.
+    db.search("shared_0", 10, false).expect("search succeeds under the overlay scope");
 
     let _ = fs::remove_dir_all(&main);
     let _ = fs::remove_dir_all(&linked);

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -8222,6 +8222,74 @@ fn worktree_overlay_rename_is_delete_old_plus_add_new() {
     let _ = fs::remove_dir_all(&linked);
 }
 
+#[test]
+fn maintenance_pass_refreshes_a_linked_worktree_overlay() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/a.rs"), "pub fn linked_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch"]);
+
+    // A watcher maintenance pass auto-refreshes the overlay — no manual `index --worktree`.
+    crate::watch::maintenance_pass(&config, false).unwrap();
+
+    let mut db = IndexDatabase::open(&config.database).unwrap();
+    db.use_worktree_scope(&main, Some(&linked)).unwrap();
+    assert_eq!(
+        names_in_scope(&db, "src/a.rs"),
+        vec!["linked_fn".to_string()],
+        "the maintenance pass populated the worktree overlay"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn worktree_overlay_reindex_is_idle_safe() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/a.rs"), "pub fn linked_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch"]);
+
+    let first = db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert!(first.indexed >= 1, "the first overlay pass indexes the delta");
+    // A re-run on an UNCHANGED worktree must be a no-op (sha-skip + tombstone-exists + gated
+    // edge-resolve), so the watcher can refresh every pass without churn (#63 idle backstop).
+    let second = db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert_eq!(
+        (second.indexed, second.tombstoned, second.pruned),
+        (0, 0, 0),
+        "an unchanged worktree re-index writes nothing"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
 fn source_config(root: PathBuf, language: Language) -> Config {
     Config {
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -8072,6 +8072,45 @@ fn worktree_overlay_reads_uncommitted_linked_edit_not_head() {
     let _ = fs::remove_dir_all(&linked);
 }
 
+#[test]
+fn worktree_overlay_query_routing_selects_scope() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/a.rs"), "pub fn linked_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch"]);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+
+    // The routing entry the MCP/query path uses: None -> base, a valid linked sibling -> its
+    // overlay, an unreadable/foreign path -> base (never the wrong repo).
+    db.use_worktree_scope(&main, None).unwrap();
+    assert_eq!(names_in_scope(&db, "src/a.rs"), vec!["base_fn".to_string()]);
+
+    db.use_worktree_scope(&main, Some(&linked)).unwrap();
+    assert_eq!(names_in_scope(&db, "src/a.rs"), vec!["linked_fn".to_string()]);
+
+    db.use_worktree_scope(&main, Some(Path::new("/"))).unwrap();
+    assert_eq!(
+        names_in_scope(&db, "src/a.rs"),
+        vec!["base_fn".to_string()],
+        "an unreadable worktree path falls back to the base scope"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
 fn source_config(root: PathBuf, language: Language) -> Config {
     Config {
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -8429,6 +8429,49 @@ fn worktree_overlay_serves_worktree_version_when_main_moved_ahead() {
     let _ = fs::remove_dir_all(&linked);
 }
 
+#[test]
+fn worktree_overlay_stable_when_main_removed_a_file_a_nested_branch_keeps() {
+    // Field repro of the perverse held layout: a linked worktree NESTED inside config.root and
+    // gitignored there; MAIN removed a file the branch still HAS; the index retains the dead old
+    // commit scope that had the file. Across repeated WATCHER maintenance passes the overlay must
+    // serve that file READABLE in the worktree scope — never flip-flop to a tombstone.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/keep.rs"), "pub fn keep_fn() {}\n").unwrap();
+    fs::write(main.join("src/reinf.rs"), "pub fn classify_seg() {}\n").unwrap();
+    fs::write(main.join(".gitignore"), "/wt/\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "C1 has reinf"]);
+    let config = source_config(main.clone(), Language::Rust);
+
+    // Index at C1 → leaves a committed scope that HAS reinf.rs (the lingering dead scope).
+    IndexDatabase::rebuild(&config).unwrap();
+
+    // Linked worktree forked at C1, NESTED under main at the gitignored path.
+    let linked = main.join("wt");
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+
+    // Main REMOVES reinf.rs at C2; the branch keeps it on disk + in its HEAD.
+    fs::remove_file(main.join("src/reinf.rs")).unwrap();
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "C2 removed reinf"]);
+
+    for pass in 0..3 {
+        crate::watch::maintenance_pass(&config, pass == 2).unwrap(); // gc on the last pass
+        let mut db = IndexDatabase::open(&config.database).unwrap();
+        db.use_worktree_scope(&main, Some(&linked)).unwrap();
+        assert_eq!(
+            names_in_scope(&db, "src/reinf.rs"),
+            vec!["classify_seg".to_string()],
+            "pass {pass}: worktree overlay serves the branch file (readable, not tombstoned)"
+        );
+    }
+
+    let _ = fs::remove_dir_all(&main);
+}
+
 fn source_config(root: PathBuf, language: Language) -> Config {
     Config {
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -8384,6 +8384,51 @@ fn worktree_overlay_committed_added_file_symbol_resolves_cross_connection() {
     let _ = fs::remove_dir_all(&linked);
 }
 
+#[test]
+fn worktree_overlay_serves_worktree_version_when_main_moved_ahead() {
+    // Symmetry: when MAIN advances a file the worktree branch didn't touch, the worktree scope must
+    // still serve the WORKTREE's (older) version — the overlay is the worktree's view, not "newest
+    // wins" (the base/worktree direction is irrelevant).
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/shared.rs"), "pub fn v1() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "v1"]);
+    let config = source_config(main.clone(), Language::Rust);
+
+    // Worktree branches at v1 (it does NOT touch shared.rs afterward).
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+
+    // Main moves AHEAD: shared.rs -> v2.
+    fs::write(main.join("src/shared.rs"), "pub fn v2() {}\n").unwrap();
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "v2"]);
+
+    let mut db = IndexDatabase::rebuild(&config).unwrap(); // base = main @ v2
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+
+    // Worktree scope: the worktree's v1 (overlay shadows main's newer v2).
+    assert!(!db.symbols("v1", Some(Language::Rust), 10).unwrap().is_empty(), "worktree serves v1");
+    assert!(
+        db.symbols("v2", Some(Language::Rust), 10).unwrap().is_empty(),
+        "worktree scope does not show main's newer v2"
+    );
+    // Base scope: main's v2.
+    set_base_scope(&mut db, &main);
+    assert!(!db.symbols("v2", Some(Language::Rust), 10).unwrap().is_empty(), "base serves v2");
+    assert!(
+        db.symbols("v1", Some(Language::Rust), 10).unwrap().is_empty(),
+        "base does not show v1"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
 fn source_config(root: PathBuf, language: Language) -> Config {
     Config {
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -8699,6 +8699,235 @@ fn worktree_overlay_honors_gitignore_and_refreshes_on_change() {
 }
 
 #[test]
+fn worktree_overlay_pending_embeddings_are_detectable_for_retry() {
+    // #219 review (3440746687): a per-overlay embedding reconcile that returns `Partial` (the
+    // shared time budget ran out mid-pass) leaves the overlay's remaining chunks un-embedded.
+    // The next pass sees the overlay rows as unchanged and would skip the embed forever. The
+    // watcher retries on a positive `pending_embedding_jobs` count IN THE OVERLAY SCOPE — this
+    // asserts that count is non-zero for an overlay whose chunks haven't been embedded, and
+    // zero once they have.
+    // Function bodies long enough to clear the embedding eligibility floor (MIN_EMBEDDING_CHARS).
+    let base_src = r#"pub fn base_fn(input: u32) -> u32 {
+    let doubled = input.wrapping_mul(2);
+    let offset = doubled.wrapping_add(7);
+    offset.wrapping_sub(input)
+}
+"#;
+    let branch_src = r#"pub fn linked_fn(input: u32) -> u32 {
+    let tripled = input.wrapping_mul(3);
+    let offset = tripled.wrapping_add(11);
+    offset.wrapping_sub(input)
+}
+"#;
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), base_src).unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+    db.install_model(ai::HASH_MODEL_ID).unwrap();
+    // The base has at least one embeddable chunk before reconcile (so the test isn't vacuous)...
+    set_base_scope(&mut db, &main);
+    assert!(db.pending_embedding_jobs().unwrap() > 0, "base has an embeddable chunk to begin with");
+    // ...and embedding the base clears its backlog.
+    db.reconcile_with_options_progress(ai::ReconcileOptions::default(), |_| {}).unwrap();
+    set_base_scope(&mut db, &main);
+    assert_eq!(db.pending_embedding_jobs().unwrap(), 0, "base scope is fully embedded");
+
+    // A linked worktree modifies the file → the overlay carries a NEW, un-embedded chunk.
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/a.rs"), branch_src).unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch"]);
+    // index_worktree_overlay leaves the connection scoped to the overlay (and does NOT embed).
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert!(
+        db.pending_embedding_jobs().unwrap() > 0,
+        "the overlay's un-embedded chunk is detectable as pending in the overlay scope (retry \
+         gate)",
+    );
+
+    // After reconciling in the overlay scope, the backlog is cleared — a later pass won't re-run.
+    db.reconcile_with_options_progress(ai::ReconcileOptions::default(), |_| {}).unwrap();
+    assert_eq!(
+        db.pending_embedding_jobs().unwrap(),
+        0,
+        "once embedded, the overlay reports no pending jobs (idle-safe, no perpetual retry)",
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn worktree_overlay_fts_freshness_revision_is_scope_invariant() {
+    // #219 review (3440746692): `content_revision` (the FTS freshness digest) read the SCOPED
+    // `files` view, so the global `fts_source_revision` `sync_fts` recorded under a linked-overlay
+    // scope differed from the base-scope digest. Interleaved base/overlay reads then each saw the
+    // global revision as stale and rebuilt the global FTS, alternating forever. The digest must be
+    // GLOBAL (over `main.files`) so it is identical across scopes.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/a.rs"), "pub fn linked_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch"]);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+
+    // The digest computed under the OVERLAY scope (left active by index_worktree_overlay)...
+    let overlay_revision = db.content_revision().unwrap();
+    // ...must equal the digest under the BASE scope: it's a GLOBAL digest, not a per-scope one.
+    set_base_scope(&mut db, &main);
+    let base_revision = db.content_revision().unwrap();
+    assert_eq!(
+        overlay_revision, base_revision,
+        "the FTS freshness digest is global, so it can't alternate as scopes interleave",
+    );
+
+    // And it matches the stored `fts_source_revision` `sync_fts` wrote during the overlay refresh,
+    // so a base read sees FTS as fresh (no rebuild) rather than perpetually stale.
+    assert_eq!(
+        db.meta("fts_source_revision").unwrap().as_deref(),
+        Some(base_revision.as_str()),
+        "fts_source_revision recorded during the overlay pass matches the global digest",
+    );
+    assert!(!db.fts_dirty().unwrap(), "the overlay refresh left FTS clean, not dirty");
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn worktree_overlay_tombstones_a_base_file_a_gitignore_only_change_now_ignores() {
+    // #219 review (3440746674): when the branch's ONLY change is a `.gitignore` rule, the
+    // tree-diff/status candidates contain just `.gitignore` — an UNCHANGED base file the rule now
+    // ignores is never visited, so its (now stale) base row keeps showing in the worktree scope.
+    // The ignore-flip expansion must add that base file as a candidate so it is tombstoned.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    fs::write(main.join("src/keep.rs"), "pub fn keep_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    // The branch's ONLY change is a `.gitignore` rule that ignores the (unchanged) `src/a.rs`.
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join(".gitignore"), "/src/a.rs\n").unwrap();
+    run_git(&linked, &["add", ".gitignore"]);
+    run_git(&linked, &["commit", "-q", "-m", "ignore a.rs"]);
+
+    let report = db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert!(report.tombstoned >= 1, "the ignore-only change tombstones the now-ignored base file");
+    assert!(
+        !path_in_scope(&db, "src/a.rs"),
+        "a base file the branch's `.gitignore` now ignores is hidden in the worktree scope, not \
+         served from its stale base row",
+    );
+    // The sibling the rule does NOT touch is untouched (still served from its shared base row).
+    assert_eq!(
+        names_in_scope(&db, "src/keep.rs"),
+        vec!["keep_fn".to_string()],
+        "an unaffected base file is still served (no over-tombstoning)",
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn worktree_overlay_refreshed_with_the_branch_config_keeps_a_branch_only_target() {
+    // #219 review (3440746699): the main watcher/maintenance process sweeps every linked worktree
+    // with ITS OWN config. A branch whose `rag-rat.toml` ADDS a target (`extra/`) must be refreshed
+    // with the branch's targets (`Config::for_linked_worktree_overlay`), or the overlay rows a
+    // branch-launched hook indexed for `extra/` are filtered out of the delta and PRUNED by the
+    // sweep. This asserts the overlay row survives a sweep that uses the branch config.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    // Main indexes only `src`.
+    fs::write(
+        main.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n",
+    )
+    .unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    // The sweeping process's config is main's: `src` only.
+    let sweep_config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&sweep_config).unwrap();
+
+    // A branch adds an `extra/` target and a file in it, with its own `rag-rat.toml`.
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::create_dir_all(linked.join("extra")).unwrap();
+    fs::write(linked.join("extra/more.rs"), "pub fn extra_fn() {}\n").unwrap();
+    fs::write(
+        linked.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\", \"extra\"]\n",
+    )
+    .unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch adds extra"]);
+
+    // A branch-launched hook indexes the overlay WITH the branch config — `extra/more.rs` is
+    // overlaid.
+    let branch_config = sweep_config.for_linked_worktree_overlay(&linked);
+    db.index_worktree_overlay(&branch_config, &linked, &mut |_| {}).unwrap();
+    assert_eq!(
+        names_in_scope(&db, "extra/more.rs"),
+        vec!["extra_fn".to_string()],
+        "the branch-only target file is overlaid by the branch-config pass",
+    );
+
+    // The MAIN sweep refreshes the same worktree. Done with the SWEEP config (`src` only) it would
+    // PRUNE `extra/more.rs`; routed through `for_linked_worktree_overlay` it keeps the branch
+    // target.
+    let refreshed = sweep_config.for_linked_worktree_overlay(&linked);
+    db.index_worktree_overlay(&refreshed, &linked, &mut |_| {}).unwrap();
+    assert_eq!(
+        names_in_scope(&db, "extra/more.rs"),
+        vec!["extra_fn".to_string()],
+        "the main-process sweep refreshed with the branch config keeps the branch-only overlay row",
+    );
+
+    // Control: the sweep config alone (no `for_linked_worktree_overlay`) would prune it — proving
+    // the bug is real and the helper is what prevents it.
+    db.index_worktree_overlay(&sweep_config, &linked, &mut |_| {}).unwrap();
+    assert!(
+        !path_in_scope(&db, "extra/more.rs"),
+        "the raw sweep config (src-only) prunes the branch-only overlay row — the bug the helper \
+         fixes",
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
 fn worktree_overlay_committed_added_file_symbol_resolves_cross_connection() {
     let main = unique_temp_root();
     let _ = fs::remove_dir_all(&main);

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -8605,6 +8605,83 @@ fn orientation_in_a_linked_worktree_reflects_the_overlay_on_base() {
     let _ = fs::remove_dir_all(&linked);
 }
 
+/// #219 review: when `config.root` is a SUBDIR of the repo, the tree-diff / status candidates are
+/// repo-relative (`crate/src/lib.rs`) but the overlay keys + `target_for_path` are config-root-
+/// relative (`src/lib.rs`). The old code filtered every subdir edit out, so the overlay was empty
+/// and a worktree query kept serving the stale base. The fix rebases candidates to config-relative
+/// and reads bytes from the linked checkout's equivalent of `config.root`.
+#[test]
+fn worktree_overlay_serves_a_subdir_rooted_config() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("crate/src")).unwrap();
+    fs::write(main.join("crate/src/lib.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    // Config rooted at the SUBDIR `crate`, indexing `crate/src`.
+    let config = source_config(main.join("crate"), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // Branch edits a file UNDER the config subdir.
+    fs::write(linked.join("crate/src/lib.rs"), "pub fn linked_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch"]);
+    // The caller passes the linked worktree root; `compute_linked_worktree_delta` derives the
+    // `crate` subdir and reads bytes from `<linked>/crate`.
+    let report = db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert_eq!(report.indexed, 1, "the subdir edit must produce one overlay row");
+
+    db.use_worktree_scope(&config.root, Some(&linked)).unwrap();
+    assert_eq!(
+        names_in_scope(&db, "src/lib.rs"),
+        vec!["linked_fn".to_string()],
+        "the worktree query serves the branch version, keyed config-root-relative"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+/// #219 review: a caller can pass a path INSIDE the linked checkout (e.g. `--worktree .` run from
+/// `<linked>/src`) rather than its root. The overlay must still read the readable candidates from
+/// the resolved workdir, not from the raw `linked_path` (which would double the `src/` prefix and
+/// fail every read).
+#[test]
+fn worktree_overlay_accepts_a_path_inside_the_linked_checkout() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/a.rs"), "pub fn linked_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch"]);
+
+    // Pass a SUBDIR of the linked checkout, not its root. `gix` discovery resolves the workdir, so
+    // the readable file is read from `<linked>/src/a.rs`, not `<linked>/src/src/a.rs`.
+    let inside = linked.join("src");
+    let report = db.index_worktree_overlay(&config, &inside, &mut |_| {}).unwrap();
+    assert_eq!(report.indexed, 1, "the readable candidate must be read from the resolved workdir");
+
+    db.use_worktree_scope(&config.root, Some(&linked)).unwrap();
+    assert_eq!(names_in_scope(&db, "src/a.rs"), vec!["linked_fn".to_string()]);
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
 fn source_config(root: PathBuf, language: Language) -> Config {
     Config {
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -8290,6 +8290,50 @@ fn worktree_overlay_reindex_is_idle_safe() {
     let _ = fs::remove_dir_all(&linked);
 }
 
+#[test]
+fn worktree_overlay_honors_gitignore_and_refreshes_on_change() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // A tracked-but-gitignored file on the branch (force-added past the ignore rule), so it appears
+    // in the committed tree-diff yet must be excluded by the worktree's `.gitignore` — parity with
+    // the base walker, which the gix status path alone wouldn't enforce for a tracked file.
+    fs::write(linked.join(".gitignore"), "/src/ignored.rs\n").unwrap();
+    fs::write(linked.join("src/ignored.rs"), "pub fn ignored_fn() {}\n").unwrap();
+    run_git(&linked, &["add", ".gitignore"]);
+    run_git(&linked, &["add", "-f", "src/ignored.rs"]);
+    run_git(&linked, &["commit", "-q", "-m", "branch"]);
+
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert!(
+        !path_in_scope(&db, "src/ignored.rs"),
+        "a gitignored worktree file is not overlaid (parity with the base walker)"
+    );
+
+    // Remove the ignore rule on disk and re-index → the overlay now picks it up (a `.gitignore`
+    // change is honored because the matcher is recompiled each pass).
+    fs::write(linked.join(".gitignore"), "").unwrap();
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert_eq!(
+        names_in_scope(&db, "src/ignored.rs"),
+        vec!["ignored_fn".to_string()],
+        "removing the ignore rule refreshes the overlay to include the file"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
 fn source_config(root: PathBuf, language: Language) -> Config {
     Config {
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -8472,6 +8472,96 @@ fn worktree_overlay_stable_when_main_removed_a_file_a_nested_branch_keeps() {
     let _ = fs::remove_dir_all(&main);
 }
 
+#[test]
+fn worktree_overlay_keeps_base_scope_logical_grouping() {
+    // #219 regression: the overlay pass's rebuild_logical_symbols must NOT de-group the
+    // base (shadowed) scope. A linked worktree that MODIFIES a base file shadows the base committed
+    // row; that base symbol must keep its logical handle (sym_<hex>), or graph-nav-by-id silently
+    // breaks for base symbols. Before the fix the overlay rebuild ran against the worktree scope
+    // view and wiped every other scope's grouping.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/shared.rs"), "pub fn shared_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // Modify the base file in the worktree → the overlay shadows the base committed row.
+    fs::write(linked.join("src/shared.rs"), "pub fn shared_fn() {\n    let _x = 1;\n}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch"]);
+
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+
+    // The BASE committed shared_fn symbol (commit_sha != '', worktree_id = '') must still be
+    // grouped.
+    let base_grouped: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            // Query RAW main.files, not the `files` scope view: after the overlay pass the
+            // connection is worktree-scoped, which SHADOWS the base committed shared.rs row.
+            "SELECT COUNT(*) FROM logical_symbol_members m
+             JOIN main.symbols s ON s.id = m.symbol_id
+             JOIN main.files f ON f.id = s.file_id
+             WHERE s.name = 'shared_fn' AND f.commit_sha != '' AND f.worktree_id = ''",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(base_grouped >= 1, "overlay pass de-grouped the base scope (graph-nav-by-id breaks)");
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[cfg(unix)]
+#[test]
+fn worktree_overlay_resolves_through_a_symlinked_path() {
+    // #219 regression: a worktree referenced via a SYMLINK must resolve to the same
+    // worktree_id as the canonical path (worktree_id_of canonicalizes), so indexing via one
+    // spelling and querying via another agree. Before the fix the keys diverged → silent
+    // overlay miss + GC pruning the live overlay.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/lib.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/added.rs"), "pub fn added_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch"]);
+
+    // Index via the CANONICAL path; query via a SYMLINK to the same checkout.
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    let symlinked = unique_temp_root();
+    let _ = fs::remove_dir_all(&symlinked);
+    std::os::unix::fs::symlink(&linked, &symlinked).unwrap();
+
+    db.use_worktree_scope(&main, Some(&symlinked)).unwrap();
+    assert!(
+        !db.symbols("added_fn", Some(Language::Rust), 10).unwrap().is_empty(),
+        "a symlinked worktree path must resolve to the same overlay as the canonical path"
+    );
+
+    let _ = fs::remove_file(&symlinked);
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
 fn source_config(root: PathBuf, language: Language) -> Config {
     Config {
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -7979,6 +7979,257 @@ fn worktree_overlay_committed_modification_shadows_base() {
     let _ = fs::remove_dir_all(&linked);
 }
 
+/// The resolved target symbol id of the single `calls_name` edge whose source file is `path` — or
+/// `None` when it is unresolved. Reads `edges_data` directly (the edge rows are shared across
+/// scopes; `source_file_id` keys them by the scope's file row), so it can prove a shared committed
+/// caller's edge is left intact by an overlay pass (#219 P1).
+fn calls_edge_target(db: &IndexDatabase, path: &str) -> Option<i64> {
+    db.storage
+        .connection()
+        .query_row(
+            "SELECT d.to_symbol_id FROM edges_data d
+             JOIN files f ON f.id = d.source_file_id
+             JOIN edge_strings ek ON ek.id = d.edge_kind_id
+             WHERE f.path = ?1 AND ek.value = 'calls_name'",
+            [path],
+            |row| row.get::<_, Option<i64>>(0),
+        )
+        .unwrap()
+}
+
+#[test]
+fn worktree_overlay_resolution_does_not_corrupt_base_edges() {
+    // #219 P1: an UNCHANGED committed caller's edge into a symbol the overlay renames must NOT be
+    // rewritten by the overlay pass — the caller file's row is SHARED with the base scope, so an
+    // overlay-scoped re-resolve against the (shadowed) overlay symbol set would corrupt the base
+    // graph. The fix re-resolves ONLY the worktree's own overlay source rows.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    // `caller.rs` calls `target_fn` (defined in `target.rs`). The caller is never touched on the
+    // branch, so its committed row is shared between base and overlay scopes.
+    fs::write(main.join("src/caller.rs"), "pub fn use_it() { target_fn(); }\n").unwrap();
+    fs::write(main.join("src/target.rs"), "pub fn target_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    // The base edge resolves to a concrete target symbol; capture it.
+    let base_target = calls_edge_target(&db, "src/caller.rs");
+    assert!(base_target.is_some(), "base caller edge resolves to target_fn");
+
+    // The branch RENAMES target_fn → renamed_fn (so target_fn no longer exists in the overlay's
+    // symbol set), but leaves caller.rs untouched.
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/target.rs"), "pub fn renamed_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "rename target"]);
+
+    let report = db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert!(report.indexed >= 1, "target.rs indexed as an overlay row");
+
+    // Back in the base scope: the unchanged caller's edge must still resolve to the SAME base
+    // target. Before the fix the overlay pass re-resolved the shared caller row against its own
+    // symbol set (where target_fn is gone) and NULLed/retargeted it, corrupting the base graph.
+    set_base_scope(&mut db, &main);
+    assert_eq!(
+        calls_edge_target(&db, "src/caller.rs"),
+        base_target,
+        "the overlay pass must not rewrite the shared base caller's resolved edge"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+/// Global `parser_failures` row count (the table is unscoped — keyed by `path` only).
+fn parser_failure_total(db: &IndexDatabase) -> i64 {
+    db.storage
+        .connection()
+        .query_row("SELECT COUNT(*) FROM parser_failures", [], |row| row.get(0))
+        .unwrap()
+}
+
+#[test]
+fn worktree_overlay_does_not_pollute_or_clear_global_parser_failures() {
+    // #219 review: `parser_failures` is keyed by `path` only and every reader counts it globally.
+    // An overlay pass routes its files through the same write path, so (1) a BRANCH-ONLY syntax
+    // error must not be recorded into the global table (it would show in base/sibling coverage),
+    // and (2) an overlay pass over a path that is BROKEN in the base must not DELETE the base's
+    // failure by bare path.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/clean.rs"), "pub fn clean_fn() {}\n").unwrap();
+    fs::write(main.join("src/base_broken.rs"), "pub fn base_broken(").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    // The base has exactly one failure (base_broken.rs).
+    assert_eq!(parser_failure_total(&db), 1, "base records its one parse failure");
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // The branch BREAKS the previously-clean file AND fixes the base-broken one.
+    fs::write(linked.join("src/clean.rs"), "pub fn clean_fn(").unwrap();
+    fs::write(linked.join("src/base_broken.rs"), "pub fn now_ok() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch edits"]);
+
+    let mut db = db;
+    let report = db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert!(report.indexed >= 1, "the branch's two changed files are indexed as overlay rows");
+
+    // The global table is UNCHANGED by the overlay pass: the branch-only `clean.rs` failure was not
+    // recorded, and the base `base_broken.rs` failure was not cleared by the overlay's same-path
+    // re-index.
+    assert_eq!(
+        parser_failure_total(&db),
+        1,
+        "overlay neither pollutes nor clears the global parser_failures table"
+    );
+    set_base_scope(&mut db, &main);
+    let base_failures = db.parser_failure_paths().unwrap();
+    assert_eq!(base_failures.len(), 1);
+    assert_eq!(
+        base_failures[0].path, "src/base_broken.rs",
+        "the base scope still reports its own parse failure, untouched by the overlay"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+/// The lowest chunk id whose file row has `path` in the active scope (overlay row wins).
+fn scoped_chunk_id(db: &IndexDatabase, path: &str) -> i64 {
+    db.storage
+        .connection()
+        .query_row(
+            "SELECT c.id FROM chunks c JOIN files f ON f.id = c.file_id
+             WHERE f.path = ?1 ORDER BY c.id LIMIT 1",
+            [path],
+            |row| row.get(0),
+        )
+        .unwrap()
+}
+
+#[test]
+fn worktree_overlay_read_chunk_returns_branch_text_not_main() {
+    // #219 review: `read_chunk_current` revalidates a scoped chunk against `source_root` (the MAIN
+    // checkout). When a branch differs from main but the chunk's anchor still validates against
+    // main, the EXACT path re-sliced the chunk text out of MAIN's file — returning base text for a
+    // branch chunk. The anchor hash is whitespace-NORMALIZED (lines trimmed, blanks dropped), so a
+    // branch that differs from main ONLY in indentation anchors EXACT against main, then slices
+    // main's de-indented bytes. The fix skips live revalidation under an overlay scope, returning
+    // the stored branch-indexed text verbatim.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    // Main: no indentation.
+    let main_src = "pub fn marker() -> i32 {\nlet branch_witness = 1;\nbranch_witness\n}\n";
+    fs::write(main.join("src/a.rs"), main_src).unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // Branch: SAME normalized content (so the anchor matches EXACT against main), but distinctively
+    // indented — the indentation is what proves whether the stored branch text or main's bytes win.
+    let branch_src =
+        "pub fn marker() -> i32 {\n        let branch_witness = 1;\n        branch_witness\n}\n";
+    fs::write(linked.join("src/a.rs"), branch_src).unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch"]);
+
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    // index_worktree_overlay leaves the connection in the overlay scope.
+    let overlay_chunk_id = scoped_chunk_id(&db, "src/a.rs");
+    let chunk = db.read_chunk(overlay_chunk_id).unwrap().expect("overlay chunk readable");
+    assert!(
+        chunk.text.contains("        let branch_witness"),
+        "read_chunk returns the BRANCH's indented text in the overlay scope (not main's \
+         de-indented bytes via an EXACT anchor match), got: {:?}",
+        chunk.text
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn refresh_worktree_overlays_reconciles_overlay_scope_embeddings() {
+    // #219 review: `refresh_worktree_overlays` restored the base scope BEFORE the pass's reconcile,
+    // so a NEW/CHANGED overlay chunk never got an embedding (worktree `semantic_search` stayed
+    // BM25-only for branch content). The fix reconciles each CHANGED overlay inline, while scoped
+    // to it. Uses the deterministic in-process HASH model (no download).
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(
+        main.join("src/a.rs"),
+        "pub fn base_entry() {\n    // base content with enough detail to satisfy the embedding \
+         policy minimum\n}\n",
+    )
+    .unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+    db.install_model(ai::HASH_MODEL_ID).unwrap();
+    db.reconcile(None, Some(8)).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // A NEW branch-only file with enough text to be embedding-eligible.
+    fs::write(
+        linked.join("src/branch_new.rs"),
+        "pub fn branch_entry() {\n    // branch-only content with enough detail to satisfy the \
+         embedding policy minimum\n}\n",
+    )
+    .unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "add branch file"]);
+
+    let options = ai::ReconcileOptions { batch_size: Some(8), ..Default::default() };
+    // The pass refreshes the overlay AND reconciles its embeddings inline.
+    let changed = crate::watch::refresh_worktree_overlays(&mut db, &config, Some(&options));
+    assert!(changed, "the overlay changed (a new branch file was indexed)");
+
+    // In the overlay scope, the new branch file's chunk must carry a Current embedding — not be
+    // left BM25-only. `refresh_worktree_overlays` restored the base scope, so re-enter the
+    // overlay.
+    db.use_worktree_scope(&main, Some(&linked)).unwrap();
+    let embedded: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM chunk_embeddings ce
+             JOIN chunks c ON c.id = ce.chunk_id
+             JOIN files f ON f.id = c.file_id
+             WHERE f.path = 'src/branch_new.rs' AND ce.status = 'Current'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(embedded >= 1, "the overlay's new chunk was reconciled into an embedding");
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
 #[test]
 fn worktree_overlay_branch_deleted_file_is_hidden_by_tombstone() {
     let main = unique_temp_root();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -8111,6 +8111,117 @@ fn worktree_overlay_query_routing_selects_scope() {
     let _ = fs::remove_dir_all(&linked);
 }
 
+/// Raw count of overlay file rows (`worktree_id != ''`), bypassing the scope view — to assert GC
+/// keeps/prunes overlay rows directly.
+fn overlay_row_count(db: &IndexDatabase) -> i64 {
+    db.storage
+        .connection()
+        .query_row("SELECT COUNT(*) FROM main.files WHERE worktree_id != ''", [], |row| row.get(0))
+        .unwrap()
+}
+
+#[test]
+fn worktree_overlay_gc_keeps_a_live_worktrees_overlay() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/a.rs"), "pub fn linked_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch"]);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+
+    // Reset to the BASE scope so the overlay is kept only via `live_worktree_contexts` (the active-
+    // context fallback in garbage_collect would otherwise mask a worktree_id mismatch).
+    set_base_scope(&mut db, &main);
+    let before = overlay_row_count(&db);
+    assert!(before > 0, "overlay rows exist before GC");
+
+    db.garbage_collect().unwrap();
+    assert_eq!(
+        overlay_row_count(&db),
+        before,
+        "GC keeps a live worktree's overlay (the overlay worktree_id matches the GC live set)"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn worktree_overlay_gc_prunes_a_removed_worktrees_overlay() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/a.rs"), "pub fn linked_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch"]);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+
+    set_base_scope(&mut db, &main);
+    assert!(overlay_row_count(&db) > 0);
+
+    // Remove the worktree → it leaves the `live_worktree_contexts` set → GC prunes its overlay.
+    run_git(&main, &["worktree", "remove", "--force", linked.to_str().unwrap()]);
+    db.garbage_collect().unwrap();
+    assert_eq!(overlay_row_count(&db), 0, "GC prunes a removed worktree's overlay");
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn worktree_overlay_rename_is_delete_old_plus_add_new() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/old.rs"), "pub fn moved_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    run_git(&linked, &["mv", "src/old.rs", "src/new.rs"]);
+    run_git(&linked, &["commit", "-q", "-m", "rename"]);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+
+    // Linked scope: the old path is tombstoned (hidden), the new path carries the moved symbol.
+    assert!(!path_in_scope(&db, "src/old.rs"), "renamed-from path is hidden in the worktree scope");
+    assert!(path_in_scope(&db, "src/new.rs"));
+    assert_eq!(names_in_scope(&db, "src/new.rs"), vec!["moved_fn".to_string()]);
+
+    // Base scope is unchanged: old exists, new does not.
+    set_base_scope(&mut db, &main);
+    assert!(path_in_scope(&db, "src/old.rs"));
+    assert!(!path_in_scope(&db, "src/new.rs"));
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
 fn source_config(root: PathBuf, language: Language) -> Config {
     Config {
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -8334,6 +8334,56 @@ fn worktree_overlay_honors_gitignore_and_refreshes_on_change() {
     let _ = fs::remove_dir_all(&linked);
 }
 
+#[test]
+fn worktree_overlay_committed_added_file_symbol_resolves_cross_connection() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    {
+        // The CLI `index --worktree` writer: build the base, then overlay-index a worktree that
+        // COMMITTED a brand-new file, then drop the connection.
+        let mut db = IndexDatabase::rebuild(&config).unwrap();
+        run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+        fs::write(linked.join("src/added.rs"), "pub fn added_fn() {}\n").unwrap();
+        run_git(&linked, &["add", "."]);
+        run_git(&linked, &["commit", "-q", "-m", "add file"]);
+        let report = db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+        assert!(report.indexed >= 1, "the added file is indexed into the overlay");
+    }
+
+    // A FRESH connection (the MCP server querying after the CLI wrote the overlay).
+    let mut db = IndexDatabase::open(&config.database).unwrap();
+    db.use_worktree_scope(&main, Some(&linked)).unwrap();
+    assert!(
+        !db.symbols("added_fn", Some(Language::Rust), 10).unwrap().is_empty(),
+        "a committed added file's symbol resolves via symbol lookup in the worktree scope \
+         (cross-connection)"
+    );
+    // ...and is grouped into logical_symbols, so GRAPH NAV (find_callers/trace_callees resolve
+    // through logical_symbols) sees it too — the overlay pass must run rebuild_logical_symbols.
+    let grouped: bool = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM logical_symbols WHERE logical_name = 'added_fn')",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(grouped, "the overlay's added symbol is grouped into logical_symbols (graph nav)");
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
 fn source_config(root: PathBuf, language: Language) -> Config {
     Config {
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -8562,6 +8562,49 @@ fn worktree_overlay_resolves_through_a_symlinked_path() {
     let _ = fs::remove_dir_all(&linked);
 }
 
+#[test]
+fn orientation_in_a_linked_worktree_reflects_the_overlay_on_base() {
+    // #219: SessionStart orientation must scope to the session's WORKTREE (the overlay on the
+    // base), not the worktree's own HEAD — the index has no committed scope at a linked
+    // worktree's HEAD, so the old resolve_git_context(cwd) saw only the bare overlay delta,
+    // missing the base files.
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/base.rs"), "pub fn base_fn() {}\n").unwrap();
+    fs::write(main.join("src/keep.rs"), "pub fn keep_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+    let db_path = db.database_path().to_path_buf();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/added.rs"), "pub fn added_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch"]);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    drop(db);
+
+    let conn = IndexConnection::open_read_only(&db_path).unwrap();
+    // Worktree cwd: overlay ON base = base.rs + keep.rs + the overlay's added.rs = 3.
+    let o_wt = crate::query::orientation::orientation(conn.connection(), &main, &linked).unwrap();
+    assert_eq!(
+        o_wt.total_files, 3,
+        "worktree orientation must show base files + the overlay's added file"
+    );
+
+    // Main cwd: base scope only = 2.
+    let o_main = crate::query::orientation::orientation(conn.connection(), &main, &main).unwrap();
+    assert_eq!(o_main.total_files, 2, "main orientation shows the base scope");
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
 fn source_config(root: PathBuf, language: Language) -> Config {
     Config {
         root: root.clone(),
@@ -9829,7 +9872,7 @@ fn orientation_composes_read_only() {
 
     // orientation installs its own scope view — pass the raw connection.
     let conn = db.storage.connection();
-    let o1 = crate::query::orientation::orientation(conn, &root).unwrap();
+    let o1 = crate::query::orientation::orientation(conn, &root, &root).unwrap();
 
     // tree: root memory must be set; nodes must be non-empty.
     assert_eq!(
@@ -9878,7 +9921,7 @@ fn orientation_composes_read_only() {
     let _ = o1.parser_failures;
 
     // Idempotency: run orientation a second time — must succeed with same key results.
-    let o2 = crate::query::orientation::orientation(conn, &root).unwrap();
+    let o2 = crate::query::orientation::orientation(conn, &root, &root).unwrap();
     assert_eq!(
         o2.tree.root_memory_title.as_deref(),
         Some("root purpose"),
@@ -9918,7 +9961,7 @@ fn orientation_composes_through_read_only_connection() {
 
     // Open the SAME on-disk DB read-only, exactly as session_start does.
     let conn = IndexConnection::open_read_only(&db_path).unwrap();
-    let o = crate::query::orientation::orientation(conn.connection(), &root)
+    let o = crate::query::orientation::orientation(conn.connection(), &root, &root)
         .expect("orientation must compose through a read-only main-DB connection");
 
     // The scope view (TEMP table/view) was created and queried — non-empty tree + 6 files.

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -7901,6 +7901,177 @@ fn markdown_config_for_root(root: PathBuf) -> Config {
 fn test_gh_ctx() -> github::GitHubContext {
     github::GitHubContext::new(Some("cq27-dev/rag-rat"), false)
 }
+// ---- #219 stage 2: linked-worktree overlay indexing ----
+
+fn init_git_repo(root: &Path) {
+    run_git(root, &["init", "-q", "-b", "main"]);
+    run_git(root, &["config", "user.email", "t@e"]);
+    run_git(root, &["config", "user.name", "t"]);
+}
+
+/// Symbol names visible in the ACTIVE scope for `path` — queried through the `temp.files` scope
+/// view (set by `set_context`), so overlay shadowing and tombstones are reflected exactly as a real
+/// query would see them.
+fn names_in_scope(db: &IndexDatabase, path: &str) -> Vec<String> {
+    let conn = db.storage.connection();
+    let mut stmt = conn
+        .prepare(
+            "SELECT s.name FROM symbols s JOIN files f ON f.id = s.file_id WHERE f.path = ?1 \
+             ORDER BY s.name",
+        )
+        .unwrap();
+    let names = stmt.query_map([path], |row| row.get::<_, String>(0)).unwrap();
+    names.filter_map(Result::ok).collect()
+}
+
+/// Whether `path` is visible at all in the active scope view (a tombstone makes this false even
+/// when the base committed row exists).
+fn path_in_scope(db: &IndexDatabase, path: &str) -> bool {
+    db.storage
+        .connection()
+        .query_row("SELECT EXISTS(SELECT 1 FROM files WHERE path = ?1)", [path], |row| row.get(0))
+        .unwrap()
+}
+
+fn set_base_scope(db: &mut IndexDatabase, root: &Path) {
+    let (sha, _) = resolve_git_context(root);
+    db.set_context(&sha, &worktree_id_of(root)).unwrap();
+}
+
+#[test]
+fn worktree_overlay_committed_modification_shadows_base() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+    assert_eq!(names_in_scope(&db, "src/a.rs"), vec!["base_fn".to_string()]);
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/a.rs"), "pub fn linked_fn() {}\n").unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "branch"]);
+
+    let report = db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert!(!report.worktree_id.is_empty(), "linked worktree recognized");
+    assert!(report.indexed >= 1, "a.rs indexed as an overlay row");
+
+    // index_worktree_overlay leaves the connection in the linked overlay scope.
+    assert_eq!(
+        names_in_scope(&db, "src/a.rs"),
+        vec!["linked_fn".to_string()],
+        "linked scope sees the branch content, and the overlay shadows the base"
+    );
+    set_base_scope(&mut db, &main);
+    assert_eq!(
+        names_in_scope(&db, "src/a.rs"),
+        vec!["base_fn".to_string()],
+        "the base scope is unchanged by the overlay"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn worktree_overlay_branch_deleted_file_is_hidden_by_tombstone() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/keep.rs"), "pub fn keep_fn() {}\n").unwrap();
+    fs::write(main.join("src/gone.rs"), "pub fn gone_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+    assert!(path_in_scope(&db, "src/gone.rs"));
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::remove_file(linked.join("src/gone.rs")).unwrap();
+    run_git(&linked, &["add", "-A"]);
+    run_git(&linked, &["commit", "-q", "-m", "drop gone"]);
+
+    let report = db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert!(report.tombstoned >= 1, "gone.rs written as a tombstone");
+
+    // Tombstone hides the branch-deleted file; the untouched file falls through to the base.
+    assert!(!path_in_scope(&db, "src/gone.rs"), "linked scope hides the branch-deleted file");
+    assert!(path_in_scope(&db, "src/keep.rs"), "non-delta file falls through to the base");
+    assert_eq!(names_in_scope(&db, "src/keep.rs"), vec!["keep_fn".to_string()]);
+
+    set_base_scope(&mut db, &main);
+    assert!(path_in_scope(&db, "src/gone.rs"), "the base scope still has the file");
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn worktree_overlay_untracked_linked_file_appears() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", linked.to_str().unwrap()]);
+    // Untracked new file in the linked checkout (no branch commit).
+    fs::write(linked.join("src/new.rs"), "pub fn new_fn() {}\n").unwrap();
+
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert_eq!(names_in_scope(&db, "src/new.rs"), vec!["new_fn".to_string()]);
+
+    set_base_scope(&mut db, &main);
+    assert!(!path_in_scope(&db, "src/new.rs"), "the untracked file is not in the base scope");
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn worktree_overlay_reads_uncommitted_linked_edit_not_head() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", linked.to_str().unwrap()]);
+    // Linked HEAD == base; only a DIRTY (uncommitted) edit in the linked working tree.
+    fs::write(linked.join("src/a.rs"), "pub fn dirty_fn() {}\n").unwrap();
+
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert_eq!(
+        names_in_scope(&db, "src/a.rs"),
+        vec!["dirty_fn".to_string()],
+        "overlay reads the linked WORKING tree, not the linked HEAD tree"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}
+
 fn source_config(root: PathBuf, language: Language) -> Config {
     Config {
         root: root.clone(),

--- a/crates/rag-rat-core/src/index/staleness.rs
+++ b/crates/rag-rat-core/src/index/staleness.rs
@@ -105,6 +105,15 @@ impl IndexDatabase {
     }
 
     fn stale_hit_paths(&self, hits: &[SearchHit]) -> anyhow::Result<Vec<String>> {
+        // Under a LINKED-WORKTREE OVERLAY scope, `source_root` is the MAIN checkout — NOT the
+        // branch these hits came from. Revalidating overlay chunks against main's copy of the file
+        // marks every branch-changed file stale; `search_with_heal` then either raises
+        // `NeedsReindex` past the cap or calls the overlay-guarded `heal_file` no-op. The overlay
+        // rows are authoritative (maintained by `index_worktree_overlay`), so report nothing stale
+        // — same rationale as the read_chunk overlay skip (#219 review).
+        if self.active_scope_is_linked_overlay() {
+            return Ok(Vec::new());
+        }
         let Some(root) = self.storage.source_root() else {
             return Ok(Vec::new());
         };

--- a/crates/rag-rat-core/src/index/walker.rs
+++ b/crates/rag-rat-core/src/index/walker.rs
@@ -15,7 +15,18 @@ pub fn walk_target(
 ) -> anyhow::Result<Vec<PathBuf>> {
     let mut files = BTreeSet::new();
     for directory in &target.directories {
-        walk_dir(root, &root.join(directory), target, ignore, &mut files)?;
+        let dir = root.join(directory);
+        // A configured target directory may be ABSENT under `root` — most importantly when the
+        // config came from a linked worktree that added a BRANCH-ONLY target dir, but `Config.root`
+        // is anchored to the MAIN checkout (so the shared index has one base commit) (#219 review).
+        // Base discovery over main must SKIP the missing dir, not hard-error: there is nothing to
+        // index there on main, and the linked worktree's overlay pass picks up the branch-only
+        // files separately. Without this, a hook/maintenance launched from such a branch
+        // aborted before `refresh_worktree_overlays` could run.
+        if !dir.is_dir() {
+            continue;
+        }
+        walk_dir(root, &dir, target, ignore, &mut files)?;
     }
     Ok(files.into_iter().collect())
 }
@@ -173,6 +184,33 @@ mod tests {
         assert!(!rel.contains(&"crates/app/skip.rs".to_string()), "nested gitignore: {rel:?}");
         assert!(!rel.contains(&"generated/out.rs".to_string()), "root gitignore: {rel:?}");
         assert!(!rel.iter().any(|p| p.starts_with("target/")), "floor dir: {rel:?}");
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn walk_skips_a_missing_target_directory() {
+        // #219 review: a config carrying a BRANCH-ONLY target dir is anchored to the MAIN root, so
+        // base discovery over main must SKIP the absent dir, not hard-error on `read_dir` — else a
+        // hook/maintenance launched from such a branch aborts before the overlay pass can run.
+        let root = tempdir();
+        write(&root.join("present/lib.rs"), "fn a() {}\n");
+        let target = ResolvedTarget {
+            name: "rust".to_string(),
+            language: Language::Rust,
+            directories: vec![PathBuf::from("present"), PathBuf::from("branch_only")],
+            include: vec!["**/*.rs".to_string()],
+            exclude: Vec::new(),
+            kind: TargetKind::Source,
+        };
+        let ignore = IgnoreMatcher::compile(&root, &target.directories);
+
+        let found = walk_target(&root, &target, &ignore).expect("missing dir must not error");
+        let rel: Vec<String> = found
+            .iter()
+            .map(|p| p.strip_prefix(&root).unwrap().to_string_lossy().replace('\\', "/"))
+            .collect();
+        assert_eq!(rel, vec!["present/lib.rs".to_string()], "present dir indexed, missing skipped");
 
         fs::remove_dir_all(&root).ok();
     }

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -169,17 +169,24 @@ pub(crate) fn compute_linked_worktree_delta(
         if target_for_path(config, &rel).is_none() {
             continue;
         }
+        // Whether the base HEAD tree carries this path — i.e. there's a base row the overlay must
+        // shadow when the branch's indexable view no longer contains the file.
+        let shadows_base_file = || {
+            base_tree
+                .as_ref()
+                .and_then(|t| t.lookup_entry_by_path(&repo_rel).ok().flatten())
+                .is_some()
+        };
         let absolute = linked_config_root.join(&rel);
-        if absolute.is_file() {
-            if ignore.is_ignored(&absolute, false) {
-                continue; // gitignored in the worktree — the base walker wouldn't index it either
-            }
+        let indexable_in_worktree = absolute.is_file() && !ignore.is_ignored(&absolute, false);
+        if indexable_in_worktree {
             delta.readable.push(rel);
-        } else if base_tree
-            .as_ref()
-            .and_then(|t| t.lookup_entry_by_path(&repo_rel).ok().flatten())
-            .is_some()
-        {
+        } else if shadows_base_file() {
+            // The branch no longer presents an indexable file here (deleted, OR an IGNORED file now
+            // sits at the path — the base walker wouldn't index either), but a base row exists.
+            // Write a tombstone so the overlay shadows the base file; without it the
+            // scope falls through to the base row and queries return a file the
+            // branch's view dropped (#219 review).
             delta.tombstones.push(rel);
         }
     }
@@ -253,73 +260,102 @@ impl IndexDatabase {
         let (_, source_root) =
             linked_config_subdir_and_root(config, &base_repo, &linked_repo, linked_path);
         let scope = FileScope::worktree(worktree_id.clone());
-        let indexed = self.index_explicit_paths_from_root(
-            config,
-            &source_root,
-            &delta.readable,
-            &scope,
-            progress,
-        )?;
-        // Write a tombstone only when one isn't already present, so a re-run on a static worktree
-        // writes nothing (idle-safety, like the readable sha-skip).
-        let mut tombstoned = 0;
-        for path in &delta.tombstones {
-            let exists: bool = self.storage.connection().query_row(
-                "SELECT EXISTS(SELECT 1 FROM main.files WHERE path = ?1 AND commit_sha = '' AND \
-                 worktree_id = ?2 AND kind = 'deleted')",
-                params![path_string(path), worktree_id],
-                |row| row.get(0),
+        // ONE transaction around the whole overlay update — incremental file replacement, tombstone
+        // writes, the prune, AND the global logical-symbol/package/edge/FTS refresh — mirroring the
+        // incremental pass (`index_incremental_with_progress`). Without it a concurrent reader can
+        // observe partially replaced overlay rows or the globally cleared `logical_symbols` table
+        // mid-rebuild, and an error midway leaves the overlay half-applied. BEGIN IMMEDIATE
+        // acquires the write lock up front so a racing writer waits out busy_timeout
+        // instead of failing the deferred read→write upgrade with SQLITE_BUSY; ROLLBACK on
+        // any error (#219 review).
+        self.storage.execute_batch("BEGIN IMMEDIATE")?;
+        let result = (|| -> anyhow::Result<(usize, usize, usize)> {
+            let indexed = self.index_explicit_paths_from_root(
+                config,
+                &source_root,
+                &delta.readable,
+                &scope,
+                progress,
             )?;
-            if !exists {
-                self.write_tombstone_in_scope(path, &worktree_id)?;
-                tombstoned += 1;
+            // Write a tombstone only when one isn't already present, so a re-run on a static
+            // worktree writes nothing (idle-safety, like the readable sha-skip).
+            let mut tombstoned = 0;
+            for path in &delta.tombstones {
+                let exists: bool = self.storage.connection().query_row(
+                    "SELECT EXISTS(SELECT 1 FROM main.files WHERE path = ?1 AND commit_sha = '' \
+                     AND worktree_id = ?2 AND kind = 'deleted')",
+                    params![path_string(path), worktree_id],
+                    |row| row.get(0),
+                )?;
+                if !exists {
+                    self.write_tombstone_in_scope(path, &worktree_id)?;
+                    tombstoned += 1;
+                }
             }
-        }
-        // Prune overlay rows that no longer differ from the base — but ONLY when the delta is
-        // complete. A partial delta (the working-tree status read failed → `status_complete` false)
-        // is missing untracked / working-tree-deleted paths, so pruning against its
-        // `shadowing_paths` would delete valid overlay rows; skip the prune and let the
-        // next complete pass reconcile (mirrors gc's empty-live-set guard) (#219 review).
-        let pruned = if delta.status_complete {
-            self.prune_overlay_rows_not_in_delta(&worktree_id, &delta.shadowing_paths())?
-        } else {
-            0
+            // Prune overlay rows that no longer differ from the base — but ONLY when the delta is
+            // complete. A partial delta (the working-tree status read failed → `status_complete`
+            // false) is missing untracked / working-tree-deleted paths, so pruning against its
+            // `shadowing_paths` would delete valid overlay rows; skip the prune and let the
+            // next complete pass reconcile (mirrors gc's empty-live-set guard) (#219 review).
+            let pruned = if delta.status_complete {
+                self.prune_overlay_rows_not_in_delta(&worktree_id, &delta.shadowing_paths())?
+            } else {
+                0
+            };
+            self.finalize_overlay_refresh(&source_root, &worktree_id, indexed, tombstoned, pruned)?;
+            Ok((indexed, tombstoned, pruned))
+        })();
+        let (indexed, tombstoned, pruned) = match result {
+            Ok(counts) => {
+                self.storage.execute_batch("COMMIT")?;
+                counts
+            },
+            Err(err) => {
+                let _ = self.storage.execute_batch("ROLLBACK");
+                return Err(err);
+            },
         };
-        // Finalize like the incremental pass does — ONLY when something changed, so an unchanged
-        // worktree refresh is a true no-op (the watcher refreshes overlays every pass; this keeps
-        // idle passes write-free and clear of the self-sustaining re-index loop):
-        // - rebuild_logical_symbols: symbol_lookup / graph nav resolve through `logical_symbols`,
-        //   so a NEWLY-ADDED overlay file's symbols are invisible until regrouped (a modified
-        //   file's unchanged symbols resolve via the base's logical rows — which is why only added
-        //   files were missing). This is the field-reported bug.
-        // - resolve_overlay_edges: the overlay inserted edges unresolved. Uses the OVERLAY-SCOPED
-        //   resolver (NOT the base `resolve_edges`): resolution targets span the full overlay view,
-        //   but only the worktree's OWN overlay source rows are re-resolved — a shared committed
-        //   (base) caller's `edges_data`, visible in the overlay view but owned by the base scope,
-        //   must not be rewritten or base `find_callers`/impact would corrupt until a base pass
-        //   resolved it back, flipping by whichever worktree refreshed last (#219 P1).
-        // - refresh_packages: write the overlay scope's `packages` rows from the LINKED checkout's
-        //   manifests BEFORE resolving, so the per-package import scope (#61) is correct for the
-        //   branch. The resolver's `load_package_roots_into_scope` reads `packages` at the active
-        //   `(base_sha, linked_worktree_id)` scope — the base rows live at `(base_sha, '')` and are
-        //   invisible to it — so without this the overlay resolves imports against an empty package
-        //   map (every file falls open to the global union → external-dep suppression downgraded /
-        //   wrong for a branch with a new or changed Cargo.toml or path-dep alias) (#219 review).
-        // - resolve_overlay_edges: the overlay inserted edges unresolved. Uses the OVERLAY-SCOPED
-        //   resolver (NOT the base `resolve_edges`): resolution targets span the full overlay view,
-        //   but only the worktree's OWN overlay source rows are re-resolved — a shared committed
-        //   (base) caller's `edges_data`, visible in the overlay view but owned by the base scope,
-        //   must not be rewritten or base `find_callers`/impact would corrupt until a base pass
-        //   resolved it back, flipping by whichever worktree refreshed last (#219 P1).
-        // - sync_fts: so semantic_search (BM25) sees the overlay's chunks.
-        if indexed > 0 || tombstoned > 0 || pruned > 0 {
-            self.rebuild_logical_symbols()?;
-            self.refresh_packages(&source_root)?;
-            self.resolve_overlay_edges(&worktree_id)?;
-            self.sync_fts()?;
-        }
 
         Ok(WorktreeOverlayReport { worktree_id, indexed, tombstoned, pruned })
+    }
+
+    /// The post-write finalize tail of `index_worktree_overlay`, run INSIDE its transaction — ONLY
+    /// when something changed, so an unchanged worktree refresh is a true no-op (the watcher
+    /// refreshes overlays every pass; this keeps idle passes write-free and clear of the
+    /// self-sustaining re-index loop):
+    /// - rebuild_logical_symbols: symbol_lookup / graph nav resolve through `logical_symbols`, so a
+    ///   NEWLY-ADDED overlay file's symbols are invisible until regrouped (a modified file's
+    ///   unchanged symbols resolve via the base's logical rows — which is why only added files were
+    ///   missing). This is the field-reported bug.
+    /// - refresh_packages: write the overlay scope's `packages` rows from the LINKED checkout's
+    ///   manifests BEFORE resolving, so the per-package import scope (#61) is correct for the
+    ///   branch. The resolver's `load_package_roots_into_scope` reads `packages` at the active
+    ///   `(base_sha, linked_worktree_id)` scope — the base rows live at `(base_sha, '')` and are
+    ///   invisible to it — so without this the overlay resolves imports against an empty package
+    ///   map (every file falls open to the global union → external-dep suppression downgraded /
+    ///   wrong for a branch with a new or changed Cargo.toml or path-dep alias) (#219 review).
+    /// - resolve_overlay_edges: the overlay inserted edges unresolved. Uses the OVERLAY-SCOPED
+    ///   resolver (NOT the base `resolve_edges`): resolution targets span the full overlay view,
+    ///   but only the worktree's OWN overlay source rows are re-resolved — a shared committed
+    ///   (base) caller's `edges_data`, visible in the overlay view but owned by the base scope,
+    ///   must not be rewritten or base `find_callers`/impact would corrupt until a base pass
+    ///   resolved it back, flipping by whichever worktree refreshed last (#219 P1).
+    /// - sync_fts: so semantic_search (BM25) sees the overlay's chunks.
+    fn finalize_overlay_refresh(
+        &self,
+        source_root: &Path,
+        worktree_id: &str,
+        indexed: usize,
+        tombstoned: usize,
+        pruned: usize,
+    ) -> anyhow::Result<()> {
+        if indexed > 0 || tombstoned > 0 || pruned > 0 {
+            self.rebuild_logical_symbols()?;
+            self.refresh_packages(source_root)?;
+            self.resolve_overlay_edges(worktree_id)?;
+            self.sync_fts()?;
+        }
+        Ok(())
     }
 
     /// Index an EXPLICIT set of repo-relative `paths`, reading bytes from `source_root` (which may

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -1,0 +1,237 @@
+//! Linked-worktree overlay indexing (#219 stage 2).
+//!
+//! A linked worktree (a sibling working tree over the same `.git`, usually on a feature branch) has
+//! files that differ from the base scope (the rooted checkout's HEAD). This pass indexes ONLY those
+//! differences as worktree-scoped OVERLAY rows that shadow the base — and writes tombstones for
+//! files the branch removed, so the scope view HIDES them instead of falling through to the base
+//! row.
+//!
+//! Control flow is a dedicated, named pass (`index_worktree_overlay`); the actual read/parse/chunk/
+//! symbol/edge work reuses the existing per-file pipeline through the lower-level
+//! `index_explicit_paths_from_root` primitive (which knows nothing about worktree deltas — just
+//! "index these paths from this root into this scope"). Delta selection is NOT normal discovery
+//! ("what changed under config.root?") — it answers "what differs between the base scope and this
+//! sibling checkout?" — so it lives here, not in the incremental discovery path.
+
+use std::collections::BTreeSet;
+
+use super::*;
+
+/// Repo-relative paths whose linked-worktree state differs from the base scope, split into files to
+/// index from the linked checkout (`readable`) and files to shadow with a tombstone (`tombstones` —
+/// present in the base, absent from the linked working tree: branch/working-tree deletes and the
+/// old side of a rename).
+#[derive(Debug, Default)]
+pub(crate) struct WorktreeOverlayDelta {
+    pub(crate) readable: Vec<PathBuf>,
+    pub(crate) tombstones: Vec<PathBuf>,
+}
+
+impl WorktreeOverlayDelta {
+    /// Every path the overlay is authoritative for (readable + tombstone); anything else falls
+    /// through to the base scope. Used to prune overlay rows that no longer differ from the base.
+    pub(crate) fn shadowing_paths(&self) -> BTreeSet<PathBuf> {
+        self.readable.iter().chain(&self.tombstones).cloned().collect()
+    }
+}
+
+// Fields are read by the #219 stage-2 acceptance tests and by callers wired in stages 3-5; the lib
+// build has no non-test reader yet.
+#[allow(dead_code)]
+#[derive(Debug, Default)]
+pub(crate) struct WorktreeOverlayReport {
+    /// The overlay scope's `worktree_id`; empty when `linked_path` was not a valid linked sibling
+    /// (the pass was skipped).
+    pub(crate) worktree_id: String,
+    pub(crate) indexed: usize,
+    pub(crate) tombstoned: usize,
+    pub(crate) pruned: usize,
+}
+
+/// Compute the overlay delta of `linked_path` (a linked worktree of `config.root`'s repo) against
+/// the base scope. Candidate paths = the committed branch diff (base HEAD tree ↔ linked HEAD tree)
+/// UNION the linked worktree's working-tree status (dirty + untracked + deleted). Each candidate's
+/// FINAL category is decided by its on-disk state in the LINKED checkout — present → read it
+/// (readable); absent but present in the base tree → tombstone — which correctly merges committed
+/// and working-tree changes (and maps a rename to delete-old + add-new). Only target-matching paths
+/// are kept: the base wouldn't index the rest, so there is nothing to shadow.
+pub(crate) fn compute_linked_worktree_delta(
+    config: &Config,
+    linked_path: &Path,
+) -> anyhow::Result<WorktreeOverlayDelta> {
+    let base_repo = git_context::discover_repo(&config.root)?;
+    let linked_repo = git_context::discover_repo(linked_path)?;
+
+    // Resolve BOTH trees through `base_repo` so the cross-tree diff shares one object store — the
+    // worktrees share the same `.git`, so the linked HEAD's tree is reachable from base_repo by
+    // oid.
+    let base_tree = base_repo.head_id()?.object()?.peel_to_tree()?;
+    let linked_head = linked_repo.head_id()?.detach();
+    let linked_tree = base_repo.find_object(linked_head)?.peel_to_tree()?;
+
+    let mut candidates: BTreeSet<PathBuf> = BTreeSet::new();
+
+    // Committed branch diff. Rename detection OFF: a rename becomes delete(old)+add(new), which the
+    // on-disk categorization below resolves to tombstone(old) + readable(new).
+    base_tree
+        .changes()?
+        .options(|opts| {
+            opts.track_path().track_rewrites(None);
+        })
+        .for_each_to_obtain_tree(&linked_tree, |change| {
+            candidates.insert(change_location_path(&change));
+            Ok::<_, std::convert::Infallible>(gix::object::tree::diff::Action::Continue(()))
+        })?;
+
+    // Linked working-tree status (vs the linked HEAD): dirty edits, untracked files, deletes.
+    if let Ok(platform) = linked_repo.status(gix::progress::Discard)
+        && let Ok(items) =
+            platform.untracked_files(UntrackedFiles::Files).into_iter(None::<gix::bstr::BString>)
+    {
+        for item in items.flatten() {
+            candidates.insert(PathBuf::from(item.location().to_str_lossy().as_ref()));
+        }
+    }
+
+    let mut delta = WorktreeOverlayDelta::default();
+    for rel in candidates {
+        // Only paths the base scope would index can be shadowed/overlaid.
+        if target_for_path(config, &rel).is_none() {
+            continue;
+        }
+        if linked_path.join(&rel).is_file() {
+            delta.readable.push(rel);
+        } else if base_tree.lookup_entry_by_path(&rel).ok().flatten().is_some() {
+            delta.tombstones.push(rel);
+        }
+    }
+    Ok(delta)
+}
+
+fn change_location_path(change: &gix::object::tree::diff::Change<'_, '_, '_>) -> PathBuf {
+    use gix::object::tree::diff::Change;
+    let location = match change {
+        Change::Addition { location, .. }
+        | Change::Deletion { location, .. }
+        | Change::Modification { location, .. }
+        | Change::Rewrite { location, .. } => *location,
+    };
+    PathBuf::from(location.to_str_lossy().as_ref())
+}
+
+impl IndexDatabase {
+    /// Index a linked worktree's branch/working-tree delta as overlay rows that shadow the base
+    /// scope, and tombstone the files it removed (#219 stage 2). No-op (empty `worktree_id` in the
+    /// report) when `linked_path` is not a valid linked sibling of `config.root`'s repo. Leaves the
+    /// connection scope set to the overlay; callers re-`set_context` if they need another scope.
+    #[allow(dead_code)] // Wired into the query/watcher paths in #219 stages 3-5.
+    pub(crate) fn index_worktree_overlay<F>(
+        &mut self,
+        config: &Config,
+        linked_path: &Path,
+        progress: &mut F,
+    ) -> anyhow::Result<WorktreeOverlayReport>
+    where
+        F: FnMut(IndexProgress),
+    {
+        let (base_sha, worktree_id) =
+            git_context::resolve_worktree_scope(&config.root, Some(linked_path));
+        // Fell back to base → not a valid linked sibling; nothing to overlay.
+        if worktree_id == git_context::worktree_id_of(&config.root) {
+            return Ok(WorktreeOverlayReport::default());
+        }
+        // Scope the connection to the overlay (base commit + linked worktree id) so context-
+        // dependent steps (tombstones, FTS, edge resolution) operate in the linked scope.
+        self.set_context(&base_sha, &worktree_id)?;
+
+        let delta = compute_linked_worktree_delta(config, linked_path)?;
+        let scope = FileScope::worktree(worktree_id.clone());
+        let indexed = self.index_explicit_paths_from_root(
+            config,
+            linked_path,
+            &delta.readable,
+            &scope,
+            progress,
+        )?;
+        for path in &delta.tombstones {
+            self.write_tombstone_in_scope(path, &worktree_id)?;
+        }
+        let pruned =
+            self.prune_overlay_rows_not_in_delta(&worktree_id, &delta.shadowing_paths())?;
+        // The overlay inserted edges unresolved (apply_incremental_file_plan); resolve them in the
+        // now-active overlay scope so the linked symbols are graph-connected.
+        self.resolve_edges()?;
+
+        Ok(WorktreeOverlayReport {
+            worktree_id,
+            indexed,
+            tombstoned: delta.tombstones.len(),
+            pruned,
+        })
+    }
+
+    /// Index an EXPLICIT set of repo-relative `paths`, reading bytes from `source_root` (which may
+    /// differ from `config.root` — e.g. a sibling linked worktree) but keying every row by the
+    /// repo-relative logical path, with `scope`. The reusable primitive under
+    /// `index_worktree_overlay` — it knows nothing about worktree deltas, just "index these
+    /// paths from this root into this scope", applying the same target include/exclude policy
+    /// as discovery and reusing the per-file prepare/insert pipeline
+    /// (`apply_incremental_file_plan`).
+    #[allow(dead_code)] // Reached via index_worktree_overlay (wired in #219 stages 3-5).
+    pub(super) fn index_explicit_paths_from_root<F>(
+        &self,
+        config: &Config,
+        source_root: &Path,
+        paths: &[PathBuf],
+        scope: &FileScope,
+        progress: &mut F,
+    ) -> anyhow::Result<usize>
+    where
+        F: FnMut(IndexProgress),
+    {
+        let mut files = Vec::new();
+        for rel in paths {
+            let full_path = source_root.join(rel);
+            if !full_path.is_file() {
+                continue;
+            }
+            let Some((language, kind)) = target_for_path(config, rel) else {
+                continue;
+            };
+            files.push(IndexFile {
+                full_path,
+                relative_path: rel.clone(),
+                language,
+                kind,
+                commit_sha: scope.commit_sha.clone(),
+                worktree_id: scope.worktree_id.clone(),
+            });
+        }
+        self.apply_incremental_file_plan(files, BTreeSet::new(), progress)
+    }
+
+    /// Remove overlay rows of `worktree_id` whose path is no longer in the delta (the file matches
+    /// the base again), so the scope view falls back to the base row for them. Returns the count.
+    fn prune_overlay_rows_not_in_delta(
+        &self,
+        worktree_id: &str,
+        shadowing: &BTreeSet<PathBuf>,
+    ) -> anyhow::Result<usize> {
+        let existing: Vec<String> = {
+            let conn = self.storage.connection();
+            let mut stmt = conn.prepare(
+                "SELECT path FROM main.files WHERE worktree_id = ?1 AND worktree_id != ''",
+            )?;
+            let rows = stmt.query_map([worktree_id], |row| row.get::<_, String>(0))?;
+            rows.collect::<Result<Vec<_>, _>>()?
+        };
+        let mut pruned = 0usize;
+        for path in existing {
+            if !shadowing.contains(Path::new(&path)) {
+                self.remove_file_in_scope(Path::new(&path), "", worktree_id)?;
+                pruned += 1;
+            }
+        }
+        Ok(pruned)
+    }
+}

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -156,6 +156,27 @@ pub(crate) fn compute_linked_worktree_delta(
     // regardless of ignore rules.
     let ignore =
         ignore_rules::IgnoreMatcher::compile(&linked_config_root, &config.target_directories());
+
+    // Ignore-ONLY change expansion. When the branch's only change under a directory is a
+    // `.gitignore` edit, the tree-diff/status candidates contain just `.gitignore` itself — the
+    // UNCHANGED target files whose indexability the new rule FLIPS are never visited, so a base
+    // file the rule now ignores keeps falling through to its (stale-visible) base row. For each
+    // changed `.gitignore`, enumerate the BASE tree's target files under its directory and add
+    // those now NON-indexable in the linked checkout as candidates — the loop below tombstones
+    // them. Still- indexable base files are NOT added (they'd duplicate the shared base row as
+    // overlay rows; the overlay only carries DIFFERENCES). The unignore direction (a
+    // now-readable file) is already covered: an unignored untracked file reappears in the
+    // status read on this same pass, and an unignored tracked file is in the committed diff or
+    // status when its content differs (#219 review).
+    expand_candidates_for_ignore_only_flips(
+        &mut candidates,
+        base_tree.as_ref(),
+        &config_subdir,
+        &linked_config_root,
+        &ignore,
+        config,
+    );
+
     let mut delta = WorktreeOverlayDelta { status_complete, ..Default::default() };
     for repo_rel in candidates {
         // Candidates are repo-relative; the overlay keys rows config-root-relative (matching the
@@ -191,6 +212,76 @@ pub(crate) fn compute_linked_worktree_delta(
         }
     }
     Ok(delta)
+}
+
+/// Add the base-tree target files whose indexability an ignore-ONLY change flipped to NON-indexable
+/// (so they need a tombstone) to `candidates`. Bounded to the directory subtree of each changed
+/// `.gitignore` already in `candidates` — a `.gitignore` rule only affects its own directory and
+/// below. No-op when no `.gitignore` is among the candidates, or there is no base tree (orphan
+/// linked HEAD has no base files to shadow). Adds REPO-relative paths, matching the candidate set.
+fn expand_candidates_for_ignore_only_flips(
+    candidates: &mut BTreeSet<PathBuf>,
+    base_tree: Option<&gix::Tree<'_>>,
+    config_subdir: &Path,
+    linked_config_root: &Path,
+    ignore: &ignore_rules::IgnoreMatcher,
+    config: &Config,
+) {
+    let Some(base_tree) = base_tree else {
+        return;
+    };
+    // The directory subtrees affected by an ignore change: the parent dir of each changed
+    // `.gitignore`, REPO-relative. A repo-root `.gitignore` (no parent) affects the whole tree.
+    let ignore_dirs: Vec<PathBuf> = candidates
+        .iter()
+        .filter(|p| p.file_name().is_some_and(|name| name == ".gitignore"))
+        .map(|p| p.parent().map(Path::to_path_buf).unwrap_or_default())
+        .collect();
+    if ignore_dirs.is_empty() {
+        return;
+    }
+    // Enumerate every base-tree file once, keep those under an affected subtree that the linked
+    // checkout no longer indexes, and add them so the delta loop tombstones them.
+    for repo_rel in base_tree_files(base_tree) {
+        if !ignore_dirs.iter().any(|dir| repo_rel.starts_with(dir)) {
+            continue;
+        }
+        let Ok(rel) = repo_rel.strip_prefix(config_subdir) else {
+            continue; // outside the config subdir — no base row to shadow
+        };
+        if target_for_path(config, rel).is_none() {
+            continue;
+        }
+        let absolute = linked_config_root.join(rel);
+        let indexable = absolute.is_file() && !ignore.is_ignored(&absolute, false);
+        if !indexable {
+            // Newly ignored (or absent) under the changed rule — shadow the base row. The
+            // categorization loop re-confirms `shadows_base_file()` before tombstoning.
+            candidates.insert(repo_rel);
+        }
+    }
+}
+
+/// Every file path in `tree`, REPO-relative, via a diff against the empty tree (all entries appear
+/// as additions) — reusing the same change-walk machinery as the base↔linked diff rather than a
+/// separate recursion. Errors collapse to an empty set: the ignore-flip expansion is best-effort
+/// recall, never a hard failure of the overlay pass.
+fn base_tree_files(tree: &gix::Tree<'_>) -> BTreeSet<PathBuf> {
+    let mut files = BTreeSet::new();
+    let empty = tree.repo.empty_tree();
+    let walked = (|| -> anyhow::Result<()> {
+        empty
+            .changes()?
+            .options(|opts| {
+                opts.track_path().track_rewrites(None);
+            })
+            .for_each_to_obtain_tree(tree, |change| {
+                files.insert(change_location_path(&change));
+                Ok::<_, std::convert::Infallible>(gix::object::tree::diff::Action::Continue(()))
+            })?;
+        Ok(())
+    })();
+    if walked.is_ok() { files } else { BTreeSet::new() }
 }
 
 /// Fold a worktree-status iterator of `Result<Item, E>` into `candidates`, returning whether the

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -90,13 +90,25 @@ pub(crate) fn compute_linked_worktree_delta(
         }
     }
 
+    // Honor the worktree's `.gitignore` for files PRESENT in the worktree, so the overlay indexes
+    // the same set the base walker would. Reuse the base's IgnoreMatcher (the `ignore` crate)
+    // compiled for the linked checkout — using THIS, not a separate gitignore engine,
+    // guarantees the overlay and base classify a path identically (no drift). Recompiled each
+    // call, so a worktree `.gitignore` edit (which fires a pass) takes effect immediately.
+    // Tombstones are NOT ignore-filtered: a branch-deleted file must shadow its base row
+    // regardless of ignore rules.
+    let ignore = ignore_rules::IgnoreMatcher::compile(linked_path, &config.target_directories());
     let mut delta = WorktreeOverlayDelta::default();
     for rel in candidates {
         // Only paths the base scope would index can be shadowed/overlaid.
         if target_for_path(config, &rel).is_none() {
             continue;
         }
-        if linked_path.join(&rel).is_file() {
+        let absolute = linked_path.join(&rel);
+        if absolute.is_file() {
+            if ignore.is_ignored(&absolute, false) {
+                continue; // gitignored in the worktree — the base walker wouldn't index it either
+            }
             delta.readable.push(rel);
         } else if base_tree.lookup_entry_by_path(&rel).ok().flatten().is_some() {
             delta.tombstones.push(rel);

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -292,11 +292,30 @@ impl IndexDatabase {
         //   so a NEWLY-ADDED overlay file's symbols are invisible until regrouped (a modified
         //   file's unchanged symbols resolve via the base's logical rows — which is why only added
         //   files were missing). This is the field-reported bug.
-        // - resolve_edges: the overlay inserted edges unresolved.
+        // - resolve_overlay_edges: the overlay inserted edges unresolved. Uses the OVERLAY-SCOPED
+        //   resolver (NOT the base `resolve_edges`): resolution targets span the full overlay view,
+        //   but only the worktree's OWN overlay source rows are re-resolved — a shared committed
+        //   (base) caller's `edges_data`, visible in the overlay view but owned by the base scope,
+        //   must not be rewritten or base `find_callers`/impact would corrupt until a base pass
+        //   resolved it back, flipping by whichever worktree refreshed last (#219 P1).
+        // - refresh_packages: write the overlay scope's `packages` rows from the LINKED checkout's
+        //   manifests BEFORE resolving, so the per-package import scope (#61) is correct for the
+        //   branch. The resolver's `load_package_roots_into_scope` reads `packages` at the active
+        //   `(base_sha, linked_worktree_id)` scope — the base rows live at `(base_sha, '')` and are
+        //   invisible to it — so without this the overlay resolves imports against an empty package
+        //   map (every file falls open to the global union → external-dep suppression downgraded /
+        //   wrong for a branch with a new or changed Cargo.toml or path-dep alias) (#219 review).
+        // - resolve_overlay_edges: the overlay inserted edges unresolved. Uses the OVERLAY-SCOPED
+        //   resolver (NOT the base `resolve_edges`): resolution targets span the full overlay view,
+        //   but only the worktree's OWN overlay source rows are re-resolved — a shared committed
+        //   (base) caller's `edges_data`, visible in the overlay view but owned by the base scope,
+        //   must not be rewritten or base `find_callers`/impact would corrupt until a base pass
+        //   resolved it back, flipping by whichever worktree refreshed last (#219 P1).
         // - sync_fts: so semantic_search (BM25) sees the overlay's chunks.
         if indexed > 0 || tombstoned > 0 || pruned > 0 {
             self.rebuild_logical_symbols()?;
-            self.resolve_edges()?;
+            self.refresh_packages(&source_root)?;
+            self.resolve_overlay_edges(&worktree_id)?;
             self.sync_fts()?;
         }
 

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -25,6 +25,11 @@ use super::*;
 pub(crate) struct WorktreeOverlayDelta {
     pub(crate) readable: Vec<PathBuf>,
     pub(crate) tombstones: Vec<PathBuf>,
+    /// Whether the linked working-tree status was read in full. When `false` (a status read error
+    /// silently dropped the working-tree portion), the delta is PARTIAL and the caller must NOT
+    /// prune — pruning against a partial `shadowing_paths` would delete valid overlay rows (#219
+    /// review). The committed-diff portion is always complete (it errors hard).
+    pub(crate) status_complete: bool,
 }
 
 impl WorktreeOverlayDelta {
@@ -58,29 +63,48 @@ pub(crate) fn compute_linked_worktree_delta(
 ) -> anyhow::Result<WorktreeOverlayDelta> {
     let base_repo = git_context::discover_repo(&config.root)?;
     let linked_repo = git_context::discover_repo(linked_path)?;
-
-    // Resolve BOTH trees through `base_repo` so the cross-tree diff shares one object store — the
-    // worktrees share the same `.git`, so the linked HEAD's tree is reachable from base_repo by
-    // oid.
-    let base_tree = base_repo.head_id()?.object()?.peel_to_tree()?;
-    let linked_head = linked_repo.head_id()?.detach();
-    let linked_tree = base_repo.find_object(linked_head)?.peel_to_tree()?;
+    // Read files from the linked repo's actual WORKDIR, not the raw `linked_path` (which may be the
+    // git dir or a subdir, e.g. from a hook). Falls back to `linked_path` for a missing workdir.
+    let linked_workdir =
+        linked_repo.workdir().map(Path::to_path_buf).unwrap_or_else(|| linked_path.to_path_buf());
 
     let mut candidates: BTreeSet<PathBuf> = BTreeSet::new();
 
-    // Committed branch diff. Rename detection OFF: a rename becomes delete(old)+add(new), which the
-    // on-disk categorization below resolves to tombstone(old) + readable(new).
-    base_tree
-        .changes()?
-        .options(|opts| {
-            opts.track_path().track_rewrites(None);
-        })
-        .for_each_to_obtain_tree(&linked_tree, |change| {
-            candidates.insert(change_location_path(&change));
-            Ok::<_, std::convert::Infallible>(gix::object::tree::diff::Action::Continue(()))
-        })?;
+    // Resolve BOTH trees through `base_repo` so the cross-tree diff shares one object store (the
+    // worktrees share the same `.git`). Each is OPTIONAL: an unborn HEAD (a fresh `git worktree add
+    // --orphan`, zero commits) has no tree. Without tolerating that, `head_id()?` errored the whole
+    // pass, so the watcher logged a failure for an orphan worktree every pass (#219 review). The
+    // committed branch diff is computed only when both trees exist; the working-tree status below
+    // still captures an orphan worktree's files.
+    let base_tree = base_repo
+        .head_id()
+        .ok()
+        .and_then(|id| id.object().ok())
+        .and_then(|o| o.peel_to_tree().ok());
+    let linked_tree = linked_repo
+        .head_id()
+        .ok()
+        .and_then(|id| base_repo.find_object(id.detach()).ok())
+        .and_then(|o| o.peel_to_tree().ok());
+    if let (Some(base_tree), Some(linked_tree)) = (base_tree.as_ref(), linked_tree.as_ref()) {
+        // Rename detection OFF: a rename becomes delete(old)+add(new), which the on-disk
+        // categorization below resolves to tombstone(old) + readable(new).
+        base_tree
+            .changes()?
+            .options(|opts| {
+                opts.track_path().track_rewrites(None);
+            })
+            .for_each_to_obtain_tree(linked_tree, |change| {
+                candidates.insert(change_location_path(&change));
+                Ok::<_, std::convert::Infallible>(gix::object::tree::diff::Action::Continue(()))
+            })?;
+    }
 
-    // Linked working-tree status (vs the linked HEAD): dirty edits, untracked files, deletes.
+    // Linked working-tree status (vs the linked HEAD): dirty edits, untracked files, deletes. Track
+    // whether it was read in FULL — a silently-dropped status read yields a PARTIAL delta (missing
+    // untracked / working-tree-deleted paths), and the caller must skip the prune on a partial
+    // delta or it would delete valid overlay rows (#219 review).
+    let mut status_complete = false;
     if let Ok(platform) = linked_repo.status(gix::progress::Discard)
         && let Ok(items) =
             platform.untracked_files(UntrackedFiles::Files).into_iter(None::<gix::bstr::BString>)
@@ -88,6 +112,7 @@ pub(crate) fn compute_linked_worktree_delta(
         for item in items.flatten() {
             candidates.insert(PathBuf::from(item.location().to_str_lossy().as_ref()));
         }
+        status_complete = true;
     }
 
     // Honor the worktree's `.gitignore` for files PRESENT in the worktree, so the overlay indexes
@@ -97,20 +122,25 @@ pub(crate) fn compute_linked_worktree_delta(
     // call, so a worktree `.gitignore` edit (which fires a pass) takes effect immediately.
     // Tombstones are NOT ignore-filtered: a branch-deleted file must shadow its base row
     // regardless of ignore rules.
-    let ignore = ignore_rules::IgnoreMatcher::compile(linked_path, &config.target_directories());
-    let mut delta = WorktreeOverlayDelta::default();
+    let ignore =
+        ignore_rules::IgnoreMatcher::compile(&linked_workdir, &config.target_directories());
+    let mut delta = WorktreeOverlayDelta { status_complete, ..Default::default() };
     for rel in candidates {
         // Only paths the base scope would index can be shadowed/overlaid.
         if target_for_path(config, &rel).is_none() {
             continue;
         }
-        let absolute = linked_path.join(&rel);
+        let absolute = linked_workdir.join(&rel);
         if absolute.is_file() {
             if ignore.is_ignored(&absolute, false) {
                 continue; // gitignored in the worktree — the base walker wouldn't index it either
             }
             delta.readable.push(rel);
-        } else if base_tree.lookup_entry_by_path(&rel).ok().flatten().is_some() {
+        } else if base_tree
+            .as_ref()
+            .and_then(|t| t.lookup_entry_by_path(&rel).ok().flatten())
+            .is_some()
+        {
             delta.tombstones.push(rel);
         }
     }
@@ -176,8 +206,16 @@ impl IndexDatabase {
                 tombstoned += 1;
             }
         }
-        let pruned =
-            self.prune_overlay_rows_not_in_delta(&worktree_id, &delta.shadowing_paths())?;
+        // Prune overlay rows that no longer differ from the base — but ONLY when the delta is
+        // complete. A partial delta (the working-tree status read failed → `status_complete` false)
+        // is missing untracked / working-tree-deleted paths, so pruning against its
+        // `shadowing_paths` would delete valid overlay rows; skip the prune and let the
+        // next complete pass reconcile (mirrors gc's empty-live-set guard) (#219 review).
+        let pruned = if delta.status_complete {
+            self.prune_overlay_rows_not_in_delta(&worktree_id, &delta.shadowing_paths())?
+        } else {
+            0
+        };
         // Finalize like the incremental pass does — ONLY when something changed, so an unchanged
         // worktree refresh is a true no-op (the watcher refreshes overlays every pass; this keeps
         // idle passes write-free and clear of the self-sustaining re-index loop):

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -35,17 +35,14 @@ impl WorktreeOverlayDelta {
     }
 }
 
-// Fields are read by the #219 acceptance tests and by callers wired in stage 5 (CLI / watcher); the
-// lib build has no non-test reader yet.
-#[allow(dead_code)]
 #[derive(Debug, Default)]
 pub struct WorktreeOverlayReport {
     /// The overlay scope's `worktree_id`; empty when `linked_path` was not a valid linked sibling
     /// (the pass was skipped).
-    pub(crate) worktree_id: String,
-    pub(crate) indexed: usize,
-    pub(crate) tombstoned: usize,
-    pub(crate) pruned: usize,
+    pub worktree_id: String,
+    pub indexed: usize,
+    pub tombstoned: usize,
+    pub pruned: usize,
 }
 
 /// Compute the overlay delta of `linked_path` (a linked worktree of `config.root`'s repo) against

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -13,7 +13,7 @@
 //! ("what changed under config.root?") — it answers "what differs between the base scope and this
 //! sibling checkout?" — so it lives here, not in the incremental discovery path.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 
 use super::*;
 
@@ -149,21 +149,32 @@ impl IndexDatabase {
             &scope,
             progress,
         )?;
+        // Write a tombstone only when one isn't already present, so a re-run on a static worktree
+        // writes nothing (idle-safety, like the readable sha-skip).
+        let mut tombstoned = 0;
         for path in &delta.tombstones {
-            self.write_tombstone_in_scope(path, &worktree_id)?;
+            let exists: bool = self.storage.connection().query_row(
+                "SELECT EXISTS(SELECT 1 FROM main.files WHERE path = ?1 AND commit_sha = '' AND \
+                 worktree_id = ?2 AND kind = 'deleted')",
+                params![path_string(path), worktree_id],
+                |row| row.get(0),
+            )?;
+            if !exists {
+                self.write_tombstone_in_scope(path, &worktree_id)?;
+                tombstoned += 1;
+            }
         }
         let pruned =
             self.prune_overlay_rows_not_in_delta(&worktree_id, &delta.shadowing_paths())?;
-        // The overlay inserted edges unresolved (apply_incremental_file_plan); resolve them in the
-        // now-active overlay scope so the linked symbols are graph-connected.
-        self.resolve_edges()?;
+        // Resolve the overlay's edges (inserted unresolved by apply_incremental_file_plan) in the
+        // now-active overlay scope — ONLY when something changed, so an unchanged worktree refresh
+        // is a true no-op (the watcher refreshes overlays every pass; this keeps idle
+        // passes write-free and clear of the self-sustaining re-index loop).
+        if indexed > 0 || tombstoned > 0 || pruned > 0 {
+            self.resolve_edges()?;
+        }
 
-        Ok(WorktreeOverlayReport {
-            worktree_id,
-            indexed,
-            tombstoned: delta.tombstones.len(),
-            pruned,
-        })
+        Ok(WorktreeOverlayReport { worktree_id, indexed, tombstoned, pruned })
     }
 
     /// Index an EXPLICIT set of repo-relative `paths`, reading bytes from `source_root` (which may
@@ -173,7 +184,6 @@ impl IndexDatabase {
     /// paths from this root into this scope", applying the same target include/exclude policy
     /// as discovery and reusing the per-file prepare/insert pipeline
     /// (`apply_incremental_file_plan`).
-    #[allow(dead_code)] // Reached via index_worktree_overlay (wired in #219 stages 3-5).
     pub(super) fn index_explicit_paths_from_root<F>(
         &self,
         config: &Config,
@@ -185,11 +195,19 @@ impl IndexDatabase {
     where
         F: FnMut(IndexProgress),
     {
+        // Existing rows in this scope (path → sha) so an UNCHANGED file is skipped: re-running the
+        // overlay on a static worktree then writes nothing, so the watcher can refresh overlays
+        // every maintenance pass without churn — preserving the idle backstop (#63) and not
+        // tripping the self-sustaining re-index loop.
+        let existing = self.scope_file_shas(&scope.commit_sha, &scope.worktree_id)?;
         let mut files = Vec::new();
         for rel in paths {
             let full_path = source_root.join(rel);
-            if !full_path.is_file() {
-                continue;
+            let Ok(bytes) = std::fs::read(&full_path) else {
+                continue; // not a readable regular file
+            };
+            if existing.get(path_string(rel).as_str()) == Some(&hex_sha256(&bytes)) {
+                continue; // unchanged since the last overlay index
             }
             let Some((language, kind)) = target_for_path(config, rel) else {
                 continue;
@@ -204,6 +222,22 @@ impl IndexDatabase {
             });
         }
         self.apply_incremental_file_plan(files, BTreeSet::new(), progress)
+    }
+
+    /// Existing file rows in a scope as `path → sha256` — for the idle-safe skip above.
+    fn scope_file_shas(
+        &self,
+        commit_sha: &str,
+        worktree_id: &str,
+    ) -> anyhow::Result<HashMap<String, String>> {
+        let conn = self.storage.connection();
+        let mut stmt = conn.prepare(
+            "SELECT path, sha256 FROM main.files WHERE commit_sha = ?1 AND worktree_id = ?2",
+        )?;
+        let rows = stmt.query_map(params![commit_sha, worktree_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
+        rows.collect::<Result<HashMap<_, _>, _>>().map_err(Into::into)
     }
 
     /// Remove overlay rows of `worktree_id` whose path is no longer in the delta (the file matches

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -50,6 +50,36 @@ pub struct WorktreeOverlayReport {
     pub pruned: usize,
 }
 
+/// The `config.root` subdir prefix (relative to the repo's workdir) and the LINKED checkout's
+/// equivalent of `config.root`. The subdir is derived from the BASE workdir (both worktrees share
+/// the same layout); the linked root is the linked WORKDIR joined with that subdir — NOT the raw
+/// `linked_path`, which may be a subdir of the checkout (e.g. `--worktree .` from `/wt/src`) or the
+/// git dir (a hook). Falls back to the linked workdir / `linked_path` when the subdir can't be
+/// derived. Shared by the delta computation (path rebasing) and the read step (source root) so the
+/// two can't drift (#219 review).
+fn linked_config_subdir_and_root(
+    config: &Config,
+    base_repo: &gix::Repository,
+    linked_repo: &gix::Repository,
+    linked_path: &Path,
+) -> (PathBuf, PathBuf) {
+    let linked_workdir =
+        linked_repo.workdir().map(Path::to_path_buf).unwrap_or_else(|| linked_path.to_path_buf());
+    // `config.root` is canonicalized (by `Config::load`'s `normalize_existing_dir`), but gix's
+    // `workdir()` may not be; canonicalize the base workdir so the subdir prefix strips cleanly.
+    let config_subdir = base_repo
+        .workdir()
+        .map(|base_workdir| {
+            base_workdir.canonicalize().unwrap_or_else(|_| base_workdir.to_path_buf())
+        })
+        .and_then(|base_workdir| {
+            config.root.strip_prefix(&base_workdir).ok().map(Path::to_path_buf)
+        })
+        .unwrap_or_default();
+    let linked_config_root = linked_workdir.join(&config_subdir);
+    (config_subdir, linked_config_root)
+}
+
 /// Compute the overlay delta of `linked_path` (a linked worktree of `config.root`'s repo) against
 /// the base scope. Candidate paths = the committed branch diff (base HEAD tree ↔ linked HEAD tree)
 /// UNION the linked worktree's working-tree status (dirty + untracked + deleted). Each candidate's
@@ -63,10 +93,13 @@ pub(crate) fn compute_linked_worktree_delta(
 ) -> anyhow::Result<WorktreeOverlayDelta> {
     let base_repo = git_context::discover_repo(&config.root)?;
     let linked_repo = git_context::discover_repo(linked_path)?;
-    // Read files from the linked repo's actual WORKDIR, not the raw `linked_path` (which may be the
-    // git dir or a subdir, e.g. from a hook). Falls back to `linked_path` for a missing workdir.
-    let linked_workdir =
-        linked_repo.workdir().map(Path::to_path_buf).unwrap_or_else(|| linked_path.to_path_buf());
+    // `config.root` may be a SUBDIR of the repo. Tree-diff and status entries are repo-relative
+    // (e.g. `crate/src/lib.rs`), but `target_for_path` / the overlay path keys are config-root-
+    // relative (e.g. `src/lib.rs`), and the readable files are read from the LINKED checkout's
+    // equivalent of `config.root`. `config_subdir` is the prefix to strip; `linked_config_root` is
+    // the source root overlay bytes are read from (#219 review).
+    let (config_subdir, linked_config_root) =
+        linked_config_subdir_and_root(config, &base_repo, &linked_repo, linked_path);
 
     let mut candidates: BTreeSet<PathBuf> = BTreeSet::new();
 
@@ -109,10 +142,9 @@ pub(crate) fn compute_linked_worktree_delta(
         && let Ok(items) =
             platform.untracked_files(UntrackedFiles::Files).into_iter(None::<gix::bstr::BString>)
     {
-        for item in items.flatten() {
-            candidates.insert(PathBuf::from(item.location().to_str_lossy().as_ref()));
-        }
-        status_complete = true;
+        status_complete = fold_status_candidates(&mut candidates, items, |item| {
+            PathBuf::from(item.location().to_str_lossy().as_ref())
+        });
     }
 
     // Honor the worktree's `.gitignore` for files PRESENT in the worktree, so the overlay indexes
@@ -123,14 +155,21 @@ pub(crate) fn compute_linked_worktree_delta(
     // Tombstones are NOT ignore-filtered: a branch-deleted file must shadow its base row
     // regardless of ignore rules.
     let ignore =
-        ignore_rules::IgnoreMatcher::compile(&linked_workdir, &config.target_directories());
+        ignore_rules::IgnoreMatcher::compile(&linked_config_root, &config.target_directories());
     let mut delta = WorktreeOverlayDelta { status_complete, ..Default::default() };
-    for rel in candidates {
+    for repo_rel in candidates {
+        // Candidates are repo-relative; the overlay keys rows config-root-relative (matching the
+        // base rows + `target_for_path`). A candidate OUTSIDE the config subdir has no base row to
+        // shadow, so it can't strip the prefix → skip it.
+        let Ok(rel) = repo_rel.strip_prefix(&config_subdir) else {
+            continue;
+        };
+        let rel = rel.to_path_buf();
         // Only paths the base scope would index can be shadowed/overlaid.
         if target_for_path(config, &rel).is_none() {
             continue;
         }
-        let absolute = linked_workdir.join(&rel);
+        let absolute = linked_config_root.join(&rel);
         if absolute.is_file() {
             if ignore.is_ignored(&absolute, false) {
                 continue; // gitignored in the worktree — the base walker wouldn't index it either
@@ -138,13 +177,35 @@ pub(crate) fn compute_linked_worktree_delta(
             delta.readable.push(rel);
         } else if base_tree
             .as_ref()
-            .and_then(|t| t.lookup_entry_by_path(&rel).ok().flatten())
+            .and_then(|t| t.lookup_entry_by_path(&repo_rel).ok().flatten())
             .is_some()
         {
             delta.tombstones.push(rel);
         }
     }
     Ok(delta)
+}
+
+/// Fold a worktree-status iterator of `Result<Item, E>` into `candidates`, returning whether the
+/// read COMPLETED. A per-item error must NOT be flattened away: dropping a path while reporting
+/// "complete" yields a partial candidate set the prune then treats as authoritative, deleting valid
+/// overlay rows for the skipped paths. The first error stops the fold and returns `false`
+/// (incomplete) so the caller skips the prune; an empty stream is complete (#219 review). Generic +
+/// pure so the completeness decision is unit-testable without provoking a real gix status error.
+fn fold_status_candidates<T, E>(
+    candidates: &mut BTreeSet<PathBuf>,
+    items: impl IntoIterator<Item = Result<T, E>>,
+    locate: impl Fn(&T) -> PathBuf,
+) -> bool {
+    for item in items {
+        match item {
+            Ok(item) => {
+                candidates.insert(locate(&item));
+            },
+            Err(_) => return false,
+        }
+    }
+    true
 }
 
 fn change_location_path(change: &gix::object::tree::diff::Change<'_, '_, '_>) -> PathBuf {
@@ -183,10 +244,18 @@ impl IndexDatabase {
         self.set_context(&base_sha, &worktree_id)?;
 
         let delta = compute_linked_worktree_delta(config, linked_path)?;
+        // `delta.readable` is config-root-relative, so the bytes are read from the LINKED
+        // checkout's equivalent of `config.root` — not the raw `linked_path` (which may be
+        // a subdir of the checkout, e.g. `--worktree .` from `/wt/src`, or the git dir from
+        // a hook) (#219 review).
+        let base_repo = git_context::discover_repo(&config.root)?;
+        let linked_repo = git_context::discover_repo(linked_path)?;
+        let (_, source_root) =
+            linked_config_subdir_and_root(config, &base_repo, &linked_repo, linked_path);
         let scope = FileScope::worktree(worktree_id.clone());
         let indexed = self.index_explicit_paths_from_root(
             config,
-            linked_path,
+            &source_root,
             &delta.readable,
             &scope,
             progress,
@@ -320,5 +389,47 @@ impl IndexDatabase {
             }
         }
         Ok(pruned)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fold_status_candidates_marks_complete_on_a_clean_read() {
+        let mut candidates = BTreeSet::new();
+        let items: Vec<Result<&str, ()>> = vec![Ok("src/a.rs"), Ok("src/b.rs")];
+        let complete = fold_status_candidates(&mut candidates, items, |s| PathBuf::from(s));
+        assert!(complete, "a clean status read is complete");
+        assert_eq!(
+            candidates,
+            BTreeSet::from([PathBuf::from("src/a.rs"), PathBuf::from("src/b.rs")]),
+        );
+    }
+
+    #[test]
+    fn fold_status_candidates_marks_incomplete_on_a_per_item_error() {
+        // The bug the #219 review caught: `flatten()` dropped the erroring item but left the read
+        // looking complete, so the prune treated a partial candidate set as authoritative and could
+        // delete valid overlay rows. A per-item error must mark the delta INCOMPLETE.
+        let mut candidates = BTreeSet::new();
+        let items: Vec<Result<&str, ()>> = vec![Ok("src/a.rs"), Err(()), Ok("src/c.rs")];
+        let complete = fold_status_candidates(&mut candidates, items, |s| PathBuf::from(s));
+        assert!(
+            !complete,
+            "a per-item status error makes the delta incomplete → caller skips prune"
+        );
+        // Stops at the error (the trailing path after it is not authoritative either way).
+        assert!(candidates.contains(Path::new("src/a.rs")));
+        assert!(!candidates.contains(Path::new("src/c.rs")));
+    }
+
+    #[test]
+    fn fold_status_candidates_empty_stream_is_complete() {
+        let mut candidates = BTreeSet::new();
+        let items: Vec<Result<&str, ()>> = vec![];
+        assert!(fold_status_candidates(&mut candidates, items, |s| PathBuf::from(s)));
+        assert!(candidates.is_empty());
     }
 }

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -178,12 +178,19 @@ impl IndexDatabase {
         }
         let pruned =
             self.prune_overlay_rows_not_in_delta(&worktree_id, &delta.shadowing_paths())?;
-        // Resolve the overlay's edges (inserted unresolved by apply_incremental_file_plan) in the
-        // now-active overlay scope — ONLY when something changed, so an unchanged worktree refresh
-        // is a true no-op (the watcher refreshes overlays every pass; this keeps idle
-        // passes write-free and clear of the self-sustaining re-index loop).
+        // Finalize like the incremental pass does — ONLY when something changed, so an unchanged
+        // worktree refresh is a true no-op (the watcher refreshes overlays every pass; this keeps
+        // idle passes write-free and clear of the self-sustaining re-index loop):
+        // - rebuild_logical_symbols: symbol_lookup / graph nav resolve through `logical_symbols`,
+        //   so a NEWLY-ADDED overlay file's symbols are invisible until regrouped (a modified
+        //   file's unchanged symbols resolve via the base's logical rows — which is why only added
+        //   files were missing). This is the field-reported bug.
+        // - resolve_edges: the overlay inserted edges unresolved.
+        // - sync_fts: so semantic_search (BM25) sees the overlay's chunks.
         if indexed > 0 || tombstoned > 0 || pruned > 0 {
+            self.rebuild_logical_symbols()?;
             self.resolve_edges()?;
+            self.sync_fts()?;
         }
 
         Ok(WorktreeOverlayReport { worktree_id, indexed, tombstoned, pruned })

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -35,11 +35,11 @@ impl WorktreeOverlayDelta {
     }
 }
 
-// Fields are read by the #219 stage-2 acceptance tests and by callers wired in stages 3-5; the lib
-// build has no non-test reader yet.
+// Fields are read by the #219 acceptance tests and by callers wired in stage 5 (CLI / watcher); the
+// lib build has no non-test reader yet.
 #[allow(dead_code)]
 #[derive(Debug, Default)]
-pub(crate) struct WorktreeOverlayReport {
+pub struct WorktreeOverlayReport {
     /// The overlay scope's `worktree_id`; empty when `linked_path` was not a valid linked sibling
     /// (the pass was skipped).
     pub(crate) worktree_id: String,
@@ -124,8 +124,7 @@ impl IndexDatabase {
     /// scope, and tombstone the files it removed (#219 stage 2). No-op (empty `worktree_id` in the
     /// report) when `linked_path` is not a valid linked sibling of `config.root`'s repo. Leaves the
     /// connection scope set to the overlay; callers re-`set_context` if they need another scope.
-    #[allow(dead_code)] // Wired into the query/watcher paths in #219 stages 3-5.
-    pub(crate) fn index_worktree_overlay<F>(
+    pub fn index_worktree_overlay<F>(
         &mut self,
         config: &Config,
         linked_path: &Path,

--- a/crates/rag-rat-core/src/query/orientation.rs
+++ b/crates/rag-rat-core/src/query/orientation.rs
@@ -48,10 +48,18 @@ pub struct Orientation {
 ///
 /// Invariant: purely READ — all writes go to TEMP objects (the scope view) which are
 /// discarded when the connection closes.
-pub fn orientation(conn: &Connection, root: &std::path::Path) -> anyhow::Result<Orientation> {
-    // Step 1: install the scoping view for this connection.
-    let (commit_sha, worktree_id) = crate::index::resolve_git_context(root);
-    crate::index::install_scope_view(conn, &commit_sha, &worktree_id)?;
+pub fn orientation(
+    conn: &Connection,
+    config_root: &std::path::Path,
+    cwd: &std::path::Path,
+) -> anyhow::Result<Orientation> {
+    // Step 1: install the WORKTREE-AWARE scoping view. `config_root` (the main worktree, where the
+    // shared base index lives) anchors the base commit; `cwd` is the session's working dir — when
+    // it is a linked worktree, orientation reflects that branch's overlay on the base,
+    // otherwise the base scope (#219). Using the worktree's own HEAD as the base (the old
+    // `resolve_git_context(cwd)`) was wrong: the index has no committed scope at a linked
+    // worktree's HEAD, so orientation saw only the bare overlay delta.
+    crate::index::install_worktree_scope_view(conn, config_root, cwd)?;
 
     // Step 2: directory tree (reads scoped `files` view).
     let tree = crate::query::tree::dir_tree(conn, &Default::default())?;
@@ -69,7 +77,9 @@ pub fn orientation(conn: &Connection, root: &std::path::Path) -> anyhow::Result<
     let active_memory_total = active_non_dir_memory_count(conn)?;
 
     // Step 6: git-history index status (live HEAD + indexed HEAD).
-    let git_status = crate::index::git_history::status(conn, root)?;
+    // The git working-tree status reflects the SESSION's checkout (the worktree's own dirty state),
+    // so read it from `cwd`, not the base `config_root`.
+    let git_status = crate::index::git_history::status(conn, cwd)?;
     let head = git_status.head.unwrap_or_default();
     let indexed_head = git_status.indexed_head.unwrap_or_default();
 

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -179,18 +179,35 @@ pub fn refresh_worktree_overlays(
         if worktree == base_id {
             continue; // the rooted checkout is the base scope, not an overlay
         }
-        match db.index_worktree_overlay(config, Path::new(&worktree), &mut |_| {}) {
+        // Refresh the overlay with the LINKED worktree's OWN config targets, not the sweeping
+        // process's. A branch whose `rag-rat.toml` ADDS a target (e.g. `extra/`) would otherwise be
+        // filtered against the sweeper's targets, and a complete-status pass would PRUNE the
+        // overlay rows a branch-launched hook indexed for it. `for_linked_worktree_overlay`
+        // keeps the shared base `root`/`database` but swaps in the branch's target set
+        // (#219 review).
+        let overlay_config = config.for_linked_worktree_overlay(Path::new(&worktree));
+        match db.index_worktree_overlay(&overlay_config, Path::new(&worktree), &mut |_| {}) {
             Ok(report) => {
                 let this_changed = report.indexed > 0 || report.tombstoned > 0 || report.pruned > 0;
                 changed |= this_changed;
-                // Embed the overlay's new/changed chunks NOW, while the connection is still scoped
-                // to this overlay (index_worktree_overlay left it there) — the trailing base
-                // reconcile won't see them (#219 review). Idle-safe: skipped when the overlay was
-                // unchanged, so a static worktree adds no embedding work. `budget.next_options()`
-                // recomputes `max_seconds` from the time left in the SHARED budget, so two changed
-                // overlays plus the base reconcile can't each spend the full `--max-seconds` (#219
-                // review). `None` → the budget is exhausted (or absent); skip the embed.
-                if this_changed
+                // Embed the overlay's chunks NOW, while the connection is still scoped to this
+                // overlay (index_worktree_overlay left it there) — the trailing base reconcile
+                // won't see them (#219 review). Run when the overlay CHANGED, OR
+                // when it has a BACKLOG of un-embedded chunks: an earlier pass's
+                // inline reconcile may have returned `Partial` (the shared time
+                // budget ran out mid-pass), leaving overlay chunks un-embedded. The
+                // next pass sees the overlay rows as unchanged and would skip the embed forever, so
+                // a worktree-scoped `semantic_search` would stay BM25-only for that
+                // branch content until an unrelated file change.
+                // `pending_embedding_jobs` (active overlay scope) retries that
+                // backlog (#219 review). `budget.next_options()` recomputes `max_seconds`
+                // from the time left in the SHARED budget so overlays + base can't each spend the
+                // full `--max-seconds`; `None` → budget exhausted, skip and let the NEXT pass
+                // retry.
+                let needs_embed = this_changed
+                    || reconcile.is_some()
+                        && db.pending_embedding_jobs().is_ok_and(|pending| pending > 0);
+                if needs_embed
                     && let Some(budget) = reconcile
                     && let Some(options) = budget.next_options()
                     && let Err(err) = db.reconcile_with_options_progress(options, |_| {})

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -140,7 +140,12 @@ fn run_pass(config: &Config, run_gc: bool) -> anyhow::Result<()> {
 /// worktree writes nothing), and the connection is restored to the base scope afterward so the rest
 /// of the pass (reconcile / gc / memory-validate) runs unscoped as before. Best-effort per worktree
 /// — a failure on one worktree is logged and doesn't abort the pass.
-fn refresh_worktree_overlays(db: &mut IndexDatabase, config: &Config) -> bool {
+///
+/// `pub` so the hook-driven CLI `maintenance` command shares this exact path: the git hooks invoke
+/// `rag-rat maintenance` (not the foreground watcher), so without calling this a commit/checkout/
+/// merge in a linked worktree would index the base `config.root` but leave that worktree's overlay
+/// stale until a watcher pass or a manual `index --worktree` (#219 review).
+pub fn refresh_worktree_overlays(db: &mut IndexDatabase, config: &Config) -> bool {
     let (_, worktrees) = crate::index::live_worktree_contexts(&config.root);
     let base_id = crate::index::worktree_id_of(&config.root);
     let mut changed = false;

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -102,21 +102,6 @@ pub fn maintenance_pass_or_skip(config: &Config, run_gc: bool) -> anyhow::Result
 
 fn run_pass(config: &Config, run_gc: bool) -> anyhow::Result<()> {
     let (mut db, content_changed) = IndexDatabase::index_discover_reporting(config)?;
-    // Keep every live linked worktree's branch overlay fresh (#219), so a `worktree`-scoped query
-    // sees that branch's changes without a manual `index --worktree`. Delta-only and idle-safe (the
-    // overlay pass writes nothing when a worktree is unchanged), so it can run every pass; a
-    // worktree change counts toward running the tail below even when config.root itself didn't
-    // change.
-    let overlays_changed = refresh_worktree_overlays(&mut db, config);
-    // Idle backstop (issue #63, facet 2): when the sweep changed no content, skip the reconcile /
-    // gc / memory-validate tail — an idle server should do no work past discovery. `run_gc` (every
-    // GC_EVERY_PASSES) still forces a full tail, so the cases that DON'T flip content_changed are
-    // still caught within that bound: a freshly-installed embedder, an embedding backlog left by a
-    // time-capped reconcile (PASS_RECONCILE_MAX_SECONDS), and drifted memory anchors. Any real
-    // content change runs the full tail immediately.
-    if !content_changed && !overlays_changed && !run_gc {
-        return Ok(());
-    }
     let runtime = &config.local_ai.embedding.runtime;
     let options = ReconcileOptions {
         batch_size: Some(runtime.batch_size),
@@ -126,6 +111,22 @@ fn run_pass(config: &Config, run_gc: bool) -> anyhow::Result<()> {
         intra_threads: runtime.ort_threads.map(|n| n as usize),
         ..ReconcileOptions::default()
     };
+    // Keep every live linked worktree's branch overlay fresh (#219), so a `worktree`-scoped query
+    // sees that branch's changes without a manual `index --worktree`. Delta-only and idle-safe (the
+    // overlay pass writes nothing when a worktree is unchanged), so it can run every pass; a
+    // worktree change counts toward running the tail below even when config.root itself didn't
+    // change. Reconcile a CHANGED overlay's embeddings INLINE (while scoped to it) so a worktree
+    // query isn't BM25-only for branch content — the base reconcile below can't see overlay chunks.
+    let overlays_changed = refresh_worktree_overlays(&mut db, config, Some(&options));
+    // Idle backstop (issue #63, facet 2): when the sweep changed no content, skip the reconcile /
+    // gc / memory-validate tail — an idle server should do no work past discovery. `run_gc` (every
+    // GC_EVERY_PASSES) still forces a full tail, so the cases that DON'T flip content_changed are
+    // still caught within that bound: a freshly-installed embedder, an embedding backlog left by a
+    // time-capped reconcile (PASS_RECONCILE_MAX_SECONDS), and drifted memory anchors. Any real
+    // content change runs the full tail immediately.
+    if !content_changed && !overlays_changed && !run_gc {
+        return Ok(());
+    }
     db.reconcile_with_options_progress(options, |_| {})?;
     if run_gc {
         let _ = db.garbage_collect();
@@ -141,11 +142,24 @@ fn run_pass(config: &Config, run_gc: bool) -> anyhow::Result<()> {
 /// of the pass (reconcile / gc / memory-validate) runs unscoped as before. Best-effort per worktree
 /// — a failure on one worktree is logged and doesn't abort the pass.
 ///
+/// `reconcile` (when `Some`): after a CHANGED overlay is indexed — while the connection is STILL
+/// scoped to that overlay — reconcile its embeddings, so worktree-scoped `semantic_search` is not
+/// BM25-only for branch content. The pass's trailing reconcile runs AFTER this returns, when the
+/// connection is back on the base scope (the `files` view = base rows), so it never sees overlay
+/// chunks; reconciling here is the only point the overlay scope is active (#219 review). Embeddings
+/// for a NEW/MODIFIED overlay chunk are written keyed by chunk id (shared `chunk_embeddings`
+/// table), which the overlay scope reads through its own `files` view. `None` skips overlay
+/// reconcile (the caller has no embedder/options).
+///
 /// `pub` so the hook-driven CLI `maintenance` command shares this exact path: the git hooks invoke
 /// `rag-rat maintenance` (not the foreground watcher), so without calling this a commit/checkout/
 /// merge in a linked worktree would index the base `config.root` but leave that worktree's overlay
 /// stale until a watcher pass or a manual `index --worktree` (#219 review).
-pub fn refresh_worktree_overlays(db: &mut IndexDatabase, config: &Config) -> bool {
+pub fn refresh_worktree_overlays(
+    db: &mut IndexDatabase,
+    config: &Config,
+    reconcile: Option<&ReconcileOptions>,
+) -> bool {
     let (_, worktrees) = crate::index::live_worktree_contexts(&config.root);
     let base_id = crate::index::worktree_id_of(&config.root);
     let mut changed = false;
@@ -155,7 +169,18 @@ pub fn refresh_worktree_overlays(db: &mut IndexDatabase, config: &Config) -> boo
         }
         match db.index_worktree_overlay(config, Path::new(&worktree), &mut |_| {}) {
             Ok(report) => {
-                changed |= report.indexed > 0 || report.tombstoned > 0 || report.pruned > 0;
+                let this_changed = report.indexed > 0 || report.tombstoned > 0 || report.pruned > 0;
+                changed |= this_changed;
+                // Embed the overlay's new/changed chunks NOW, while the connection is still scoped
+                // to this overlay (index_worktree_overlay left it there) — the trailing base
+                // reconcile won't see them (#219 review). Idle-safe: skipped when the overlay was
+                // unchanged, so a static worktree adds no embedding work.
+                if this_changed
+                    && let Some(options) = reconcile
+                    && let Err(err) = db.reconcile_with_options_progress(options.clone(), |_| {})
+                {
+                    eprintln!("watch: worktree overlay reconcile failed for {worktree}: {err}");
+                }
             },
             Err(err) => eprintln!("watch: worktree overlay refresh failed for {worktree}: {err}"),
         }
@@ -267,14 +292,40 @@ fn event_touches_worktree(
     if !kind_is_mutation(&event.kind) {
         return false;
     }
+    // `config.root` may be a SUBDIR of the repo. A linked checkout mirrors that layout, so its
+    // event paths are `<checkout_root>/<config_subdir>/<target>/…`. After stripping the
+    // checkout root the remainder is still `<config_subdir>/<target>/…`, but `target_for_path`
+    // expects a CONFIG-ROOT- relative path (`<target>/…`) — so a subdir-rooted config would
+    // reject every linked edit and never debounce an overlay refresh. Strip the config subdir
+    // too (#219 review).
+    let config_subdir = config_subdir_prefix(config);
     event.paths.iter().any(|path| {
         if registry.is_some_and(|reg| path.starts_with(reg)) {
             return true;
         }
+        // A `.gitignore` edit in the linked checkout changes its ignored/unignored set, so the
+        // overlay must refresh — mirror the base classifier's `.gitignore` handling (#219 review).
+        // Bound it to the watched checkout roots so an unrelated repo's `.gitignore` is ignored.
+        if is_gitignore_path(path) && worktree_roots.iter().any(|root| path.starts_with(root)) {
+            return true;
+        }
         worktree_roots.iter().any(|root| {
-            path.strip_prefix(root).ok().is_some_and(|rel| target_for_path(config, rel).is_some())
+            let Ok(rel) = path.strip_prefix(root) else {
+                return false;
+            };
+            let rel = rel.strip_prefix(&config_subdir).unwrap_or(rel);
+            target_for_path(config, rel).is_some()
         })
     })
+}
+
+/// `config.root` relative to its own checkout's worktree root — the SUBDIR prefix to strip off a
+/// linked checkout's event paths before applying `target_for_path` (config-root-relative). Empty
+/// when `config.root` IS the worktree root (the common case) or in a non-git tree.
+fn config_subdir_prefix(config: &Config) -> PathBuf {
+    crate::index::git_history::worktree_root(&config.root)
+        .and_then(|wt| config.root.strip_prefix(&wt).ok().map(Path::to_path_buf))
+        .unwrap_or_default()
 }
 
 /// Live linked-worktree checkout roots (excluding the base `config.root`) plus the worktree
@@ -577,6 +628,21 @@ mod tests {
             &roots,
             Some(&registry),
         ));
+        // A `.gitignore` edit in the linked checkout fires (it changes the overlay's ignored set),
+        // mirroring the base classifier (#219 review).
+        assert!(event_touches_worktree(
+            &config,
+            &mutation_event(worktree.join(".gitignore")),
+            &roots,
+            Some(&registry),
+        ));
+        // A `.gitignore` OUTSIDE any watched checkout does not.
+        assert!(!event_touches_worktree(
+            &config,
+            &mutation_event(PathBuf::from("/elsewhere/.gitignore")),
+            &roots,
+            Some(&registry),
+        ));
         // A read event never fires (anti-feedback, same as the base watcher).
         let read = Event::new(EventKind::Access(AccessKind::Open(AccessMode::Read)))
             .add_path(worktree.join("src/a.rs"));
@@ -588,6 +654,65 @@ mod tests {
             &[],
             None,
         ));
+    }
+
+    #[test]
+    fn event_touches_worktree_rebases_subdir_rooted_config() {
+        // #219 review: when `config.root` is a repo SUBDIR (`<repo>/crate`), a linked checkout's
+        // edit arrives as `<checkout>/crate/src/a.rs`. Stripping only the checkout root leaves
+        // `crate/src/a.rs`, which `target_for_path` (config-root-relative, expecting `src/a.rs`)
+        // rejects — so the subdir prefix must be stripped too.
+        use std::process::Command;
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let id = N.fetch_add(1, Ordering::Relaxed);
+        let repo =
+            std::env::temp_dir().join(format!("ragrat-wt-subdir-{}-{id}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&repo);
+        std::fs::create_dir_all(repo.join("crate/src")).unwrap();
+        std::fs::write(repo.join("crate/src/a.rs"), "fn a() {}\n").unwrap();
+        for args in [
+            vec!["init", "-q", "-b", "main"],
+            vec!["config", "user.email", "t@e"],
+            vec!["config", "user.name", "t"],
+            vec!["add", "."],
+            vec!["commit", "-q", "-m", "base"],
+        ] {
+            Command::new("git").args(&args).current_dir(&repo).output().unwrap();
+        }
+        // `config.root` is the `crate` SUBDIR of the repo.
+        let config_root = repo.join("crate").canonicalize().unwrap();
+        let config = Config {
+            root: config_root,
+            database: repo.join("crate/.rag-rat/index.sqlite"),
+            targets: vec![ResolvedTarget {
+                name: "rust".to_string(),
+                language: Language::Rust,
+                directories: vec![PathBuf::from("src")],
+                include: vec!["**/*.rs".to_string()],
+                exclude: Vec::new(),
+                kind: TargetKind::Source,
+            }],
+            local_ai: LocalAiConfig { embedding: EmbeddingConfig::default() },
+            watch: WatchConfig::default(),
+            version_check: Default::default(),
+            oracle: Default::default(),
+        };
+        // A linked checkout mirrors the layout: `<checkout>/crate/src/a.rs`.
+        let checkout =
+            std::env::temp_dir().join(format!("ragrat-wt-subdir-co-{}-{id}", std::process::id()));
+        let roots = [checkout.clone()];
+        assert!(
+            event_touches_worktree(
+                &config,
+                &mutation_event(checkout.join("crate/src/a.rs")),
+                &roots,
+                None,
+            ),
+            "a subdir-rooted config must fire on a linked edit under <checkout>/<subdir>/<target>"
+        );
+
+        let _ = std::fs::remove_dir_all(&repo);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -101,6 +101,7 @@ pub fn maintenance_pass_or_skip(config: &Config, run_gc: bool) -> anyhow::Result
 }
 
 fn run_pass(config: &Config, run_gc: bool) -> anyhow::Result<()> {
+    let started = Instant::now();
     let (mut db, content_changed) = IndexDatabase::index_discover_reporting(config)?;
     let runtime = &config.local_ai.embedding.runtime;
     let options = ReconcileOptions {
@@ -111,13 +112,17 @@ fn run_pass(config: &Config, run_gc: bool) -> anyhow::Result<()> {
         intra_threads: runtime.ort_threads.map(|n| n as usize),
         ..ReconcileOptions::default()
     };
+    // One time budget shared by the per-overlay reconciles AND the base reconcile below, so a pass
+    // with several changed overlays can't blow past `PASS_RECONCILE_MAX_SECONDS` (N+1)× over (#219
+    // review). Measured from `started` so discovery time already counts against it.
+    let budget = ReconcileBudget::new(options, started);
     // Keep every live linked worktree's branch overlay fresh (#219), so a `worktree`-scoped query
     // sees that branch's changes without a manual `index --worktree`. Delta-only and idle-safe (the
     // overlay pass writes nothing when a worktree is unchanged), so it can run every pass; a
     // worktree change counts toward running the tail below even when config.root itself didn't
     // change. Reconcile a CHANGED overlay's embeddings INLINE (while scoped to it) so a worktree
     // query isn't BM25-only for branch content — the base reconcile below can't see overlay chunks.
-    let overlays_changed = refresh_worktree_overlays(&mut db, config, Some(&options));
+    let overlays_changed = refresh_worktree_overlays(&mut db, config, Some(&budget));
     // Idle backstop (issue #63, facet 2): when the sweep changed no content, skip the reconcile /
     // gc / memory-validate tail — an idle server should do no work past discovery. `run_gc` (every
     // GC_EVERY_PASSES) still forces a full tail, so the cases that DON'T flip content_changed are
@@ -127,7 +132,11 @@ fn run_pass(config: &Config, run_gc: bool) -> anyhow::Result<()> {
     if !content_changed && !overlays_changed && !run_gc {
         return Ok(());
     }
-    db.reconcile_with_options_progress(options, |_| {})?;
+    // The base reconcile gets only the budget the overlays left behind; `None` → already exhausted,
+    // so skip it (the embedding backlog rides the next pass) rather than spend a fresh full budget.
+    if let Some(options) = budget.next_options() {
+        db.reconcile_with_options_progress(options, |_| {})?;
+    }
     if run_gc {
         let _ = db.garbage_collect();
     }
@@ -158,10 +167,13 @@ fn run_pass(config: &Config, run_gc: bool) -> anyhow::Result<()> {
 pub fn refresh_worktree_overlays(
     db: &mut IndexDatabase,
     config: &Config,
-    reconcile: Option<&ReconcileOptions>,
+    reconcile: Option<&ReconcileBudget>,
 ) -> bool {
     let (_, worktrees) = crate::index::live_worktree_contexts(&config.root);
-    let base_id = crate::index::worktree_id_of(&config.root);
+    // The base id is the ENCLOSING worktree root, not `config.root` itself — see
+    // `enclosing_worktree_id` (a repo-SUBDIR `config.root` would otherwise mis-classify the main
+    // checkout as a linked overlay and re-index it as one) (#219 review).
+    let base_id = enclosing_worktree_id(&config.root);
     let mut changed = false;
     for worktree in worktrees {
         if worktree == base_id {
@@ -174,10 +186,14 @@ pub fn refresh_worktree_overlays(
                 // Embed the overlay's new/changed chunks NOW, while the connection is still scoped
                 // to this overlay (index_worktree_overlay left it there) — the trailing base
                 // reconcile won't see them (#219 review). Idle-safe: skipped when the overlay was
-                // unchanged, so a static worktree adds no embedding work.
+                // unchanged, so a static worktree adds no embedding work. `budget.next_options()`
+                // recomputes `max_seconds` from the time left in the SHARED budget, so two changed
+                // overlays plus the base reconcile can't each spend the full `--max-seconds` (#219
+                // review). `None` → the budget is exhausted (or absent); skip the embed.
                 if this_changed
-                    && let Some(options) = reconcile
-                    && let Err(err) = db.reconcile_with_options_progress(options.clone(), |_| {})
+                    && let Some(budget) = reconcile
+                    && let Some(options) = budget.next_options()
+                    && let Err(err) = db.reconcile_with_options_progress(options, |_| {})
                 {
                     eprintln!("watch: worktree overlay reconcile failed for {worktree}: {err}");
                 }
@@ -189,6 +205,46 @@ pub fn refresh_worktree_overlays(
     // scoped to the last worktree it touched).
     let _ = db.use_worktree_scope(&config.root, None);
     changed
+}
+
+/// A time budget shared across the per-overlay embedding reconciles AND the trailing base reconcile
+/// of one maintenance/watcher pass. Each reconcile call starts its own `Instant` timer against its
+/// `max_seconds`, so handing every overlay (and the base) the same `ReconcileOptions` would let
+/// each spend the FULL advertised budget — N overlays + base = (N+1)×`max_seconds` of held write
+/// lock. `next_options` recomputes `max_seconds` from the time remaining since `start`, so the
+/// whole pass stays within a single budget (#219 review). A budget with no `max_seconds` cap
+/// (`None`) is unbounded and every `next_options` returns the base options unchanged.
+pub struct ReconcileBudget {
+    options: ReconcileOptions,
+    start: Instant,
+    total_seconds: Option<u64>,
+}
+
+impl ReconcileBudget {
+    /// Build a shared budget. `start` is the pass's clock origin — pass the SAME instant the
+    /// surrounding command measured its own setup against (so discovery time already spent counts
+    /// toward the budget); the per-call `max_seconds` is `options.max_seconds` minus elapsed.
+    pub fn new(options: ReconcileOptions, start: Instant) -> Self {
+        let total_seconds = options.max_seconds;
+        Self { options, start, total_seconds }
+    }
+
+    /// The options for the NEXT reconcile in this pass, with `max_seconds` reduced to the time left
+    /// in the shared budget. `None` when the budget is exhausted (so the caller skips the reconcile
+    /// entirely rather than running it with a zero budget). An uncapped budget always yields the
+    /// base options.
+    pub fn next_options(&self) -> Option<ReconcileOptions> {
+        let Some(total) = self.total_seconds else {
+            return Some(self.options.clone());
+        };
+        let remaining = total.saturating_sub(self.start.elapsed().as_secs());
+        if remaining == 0 {
+            return None;
+        }
+        let mut options = self.options.clone();
+        options.max_seconds = Some(remaining);
+        Some(options)
+    }
 }
 
 /// Whether an event KIND should ever fire a pass. Only content mutations do — `Create`, `Remove`,
@@ -328,12 +384,28 @@ fn config_subdir_prefix(config: &Config) -> PathBuf {
         .unwrap_or_default()
 }
 
+/// The `worktree_id` of the worktree that ENCLOSES `root`, canonicalized to match the ids
+/// `live_worktree_contexts` reports. When `root` is a repo SUBDIR (`<repo>/crate`), the enclosing
+/// worktree root is `<repo>` — which is the spelling the main checkout contributes to
+/// `live_worktree_contexts`. Filtering live worktrees by `worktree_id_of(root)` (the subdir path)
+/// instead would never match that entry, so the main checkout would be misread as a LINKED overlay.
+/// Falls back to `root`'s own id outside a git worktree (#219 review).
+fn enclosing_worktree_id(root: &Path) -> String {
+    crate::index::git_history::worktree_root(root)
+        .map_or_else(|| crate::index::worktree_id_of(root), |wt| crate::index::worktree_id_of(&wt))
+}
+
 /// Live linked-worktree checkout roots (excluding the base `config.root`) plus the worktree
 /// registry dir (`<common_dir>/worktrees`), for the watcher to subscribe to — branch checkouts for
 /// edits, the registry for add/remove.
 fn worktree_watch_targets(config: &Config) -> (Vec<PathBuf>, Option<PathBuf>) {
     let (_, worktrees) = crate::index::live_worktree_contexts(&config.root);
-    let base = crate::index::worktree_id_of(&config.root);
+    // The base id is the ENCLOSING worktree root, not `config.root` itself. When `config.root` is a
+    // repo SUBDIR (`<repo>/crate`), `live_worktree_contexts` reports the main checkout as `<repo>`
+    // (its workdir), but `worktree_id_of(config.root)` is `<repo>/crate` — they wouldn't match, so
+    // the main checkout would be treated as a linked worktree and the watcher would recursively
+    // subscribe to the whole repo root outside the configured target (#219 review).
+    let base = enclosing_worktree_id(&config.root);
     let roots = worktrees.into_iter().filter(|w| *w != base).map(PathBuf::from).collect();
     let registry = crate::index::discover_repo(&config.root)
         .ok()
@@ -944,6 +1016,85 @@ mod tests {
         let d = Debounce::new(Duration::from_millis(400), Duration::from_millis(2500));
         assert!(d.due_in(Instant::now()).is_none());
         assert!(!d.should_fire(Instant::now()));
+    }
+
+    #[test]
+    fn reconcile_budget_is_shared_across_overlays_and_base() {
+        // #219 review: each overlay reconcile (and the base) starts its OWN `max_seconds` timer, so
+        // handing every one the same options lets the pass spend (N+1)× the advertised budget.
+        // `next_options` recomputes `max_seconds` from the time remaining in the shared budget.
+        let options = ReconcileOptions { max_seconds: Some(30), ..ReconcileOptions::default() };
+        // A budget whose clock STARTED 30s ago is already exhausted → skip the reconcile.
+        let spent = ReconcileBudget::new(
+            options.clone(),
+            Instant::now() - std::time::Duration::from_secs(30),
+        );
+        assert!(spent.next_options().is_none(), "an exhausted budget yields no reconcile");
+
+        // A fresh budget yields options whose `max_seconds` is at most the total (the remaining
+        // time), never a fresh full budget per call.
+        let fresh = ReconcileBudget::new(options, Instant::now());
+        let next = fresh.next_options().expect("a fresh budget has time left");
+        assert!(
+            next.max_seconds.is_some_and(|s| s <= 30),
+            "the per-call budget is bounded by the time remaining, not a fresh full budget: {:?}",
+            next.max_seconds,
+        );
+
+        // An uncapped budget (`max_seconds: None`) always yields the base options.
+        let uncapped = ReconcileBudget::new(ReconcileOptions::default(), Instant::now());
+        assert_eq!(uncapped.next_options().and_then(|o| o.max_seconds), None);
+    }
+
+    #[test]
+    fn worktree_watch_targets_excludes_the_main_checkout_for_a_subdir_config_root() {
+        // #219 review: when `config.root` is a repo SUBDIR (`<repo>/crate`),
+        // `live_worktree_contexts` reports the main checkout as `<repo>` (its workdir), but
+        // filtering by `worktree_id_of(config.root)` (`<repo>/crate`) wouldn't match — so
+        // the main checkout would be misread as a LINKED worktree and the watcher would
+        // recursively subscribe to the whole repo root. The base id must be the ENCLOSING
+        // worktree root.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let id = N.fetch_add(1, Ordering::Relaxed);
+        let main = std::env::temp_dir().join(format!("ragrat-wwt-{}-{id}", std::process::id()));
+        std::fs::create_dir_all(main.join("crate/src")).unwrap();
+        let git = |dir: &Path, args: &[&str]| {
+            std::process::Command::new("git").arg("-C").arg(dir).args(args).status().unwrap()
+        };
+        git(&main, &["init", "-q"]);
+        git(&main, &["config", "user.email", "t@e"]);
+        git(&main, &["config", "user.name", "t"]);
+        std::fs::write(main.join("crate/src/lib.rs"), "pub fn f() {}\n").unwrap();
+        git(&main, &["add", "-A"]);
+        git(&main, &["commit", "-qm", "seed"]);
+
+        let sub = main.join("crate").canonicalize().unwrap(); // config.root is the subdir.
+        let config = Config {
+            root: sub.clone(),
+            database: sub.join(".rag-rat/index.sqlite"),
+            targets: vec![ResolvedTarget {
+                name: "rust".to_string(),
+                language: Language::Rust,
+                directories: vec![PathBuf::from("src")],
+                include: vec!["**/*.rs".to_string()],
+                exclude: Vec::new(),
+                kind: TargetKind::Source,
+            }],
+            local_ai: LocalAiConfig { embedding: EmbeddingConfig::default() },
+            watch: WatchConfig::default(),
+            version_check: Default::default(),
+            oracle: Default::default(),
+        };
+
+        let (roots, _registry) = worktree_watch_targets(&config);
+        let main_id = crate::index::worktree_id_of(&main.canonicalize().unwrap());
+        assert!(
+            !roots.iter().any(|r| crate::index::worktree_id_of(r) == main_id),
+            "the main checkout must NOT be watched as a linked worktree: {roots:?}",
+        );
+
+        std::fs::remove_dir_all(&main).ok();
     }
 
     #[test]

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -101,14 +101,20 @@ pub fn maintenance_pass_or_skip(config: &Config, run_gc: bool) -> anyhow::Result
 }
 
 fn run_pass(config: &Config, run_gc: bool) -> anyhow::Result<()> {
-    let (db, content_changed) = IndexDatabase::index_discover_reporting(config)?;
+    let (mut db, content_changed) = IndexDatabase::index_discover_reporting(config)?;
+    // Keep every live linked worktree's branch overlay fresh (#219), so a `worktree`-scoped query
+    // sees that branch's changes without a manual `index --worktree`. Delta-only and idle-safe (the
+    // overlay pass writes nothing when a worktree is unchanged), so it can run every pass; a
+    // worktree change counts toward running the tail below even when config.root itself didn't
+    // change.
+    let overlays_changed = refresh_worktree_overlays(&mut db, config);
     // Idle backstop (issue #63, facet 2): when the sweep changed no content, skip the reconcile /
     // gc / memory-validate tail — an idle server should do no work past discovery. `run_gc` (every
     // GC_EVERY_PASSES) still forces a full tail, so the cases that DON'T flip content_changed are
     // still caught within that bound: a freshly-installed embedder, an embedding backlog left by a
     // time-capped reconcile (PASS_RECONCILE_MAX_SECONDS), and drifted memory anchors. Any real
     // content change runs the full tail immediately.
-    if !content_changed && !run_gc {
+    if !content_changed && !overlays_changed && !run_gc {
         return Ok(());
     }
     let runtime = &config.local_ai.embedding.runtime;
@@ -126,6 +132,33 @@ fn run_pass(config: &Config, run_gc: bool) -> anyhow::Result<()> {
     }
     let _ = db.memory_validate();
     Ok(())
+}
+
+/// Refresh the branch overlay of every live LINKED worktree of `config.root`'s repo (#219), so a
+/// `worktree`-scoped query stays current without a manual `index --worktree`. Returns whether any
+/// overlay actually changed. `index_worktree_overlay` is delta-only and idle-safe (a static
+/// worktree writes nothing), and the connection is restored to the base scope afterward so the rest
+/// of the pass (reconcile / gc / memory-validate) runs unscoped as before. Best-effort per worktree
+/// — a failure on one worktree is logged and doesn't abort the pass.
+fn refresh_worktree_overlays(db: &mut IndexDatabase, config: &Config) -> bool {
+    let (_, worktrees) = crate::index::live_worktree_contexts(&config.root);
+    let base_id = crate::index::worktree_id_of(&config.root);
+    let mut changed = false;
+    for worktree in worktrees {
+        if worktree == base_id {
+            continue; // the rooted checkout is the base scope, not an overlay
+        }
+        match db.index_worktree_overlay(config, Path::new(&worktree), &mut |_| {}) {
+            Ok(report) => {
+                changed |= report.indexed > 0 || report.tombstoned > 0 || report.pruned > 0;
+            },
+            Err(err) => eprintln!("watch: worktree overlay refresh failed for {worktree}: {err}"),
+        }
+    }
+    // Restore the base scope for the rest of the pass (index_worktree_overlay leaves the connection
+    // scoped to the last worktree it touched).
+    let _ = db.use_worktree_scope(&config.root, None);
+    changed
 }
 
 /// Whether an event KIND should ever fire a pass. Only content mutations do — `Create`, `Remove`,

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -247,6 +247,44 @@ fn event_is_relevant(config: &Config, ignore: &IgnoreMatcher, event: &Event) -> 
     })
 }
 
+/// Whether `event` should fire a pass for the LINKED-worktree layer (#219): a content mutation to a
+/// configured target inside a linked worktree checkout (its overlay needs refreshing), or any
+/// change in the worktree registry (`<common_dir>/worktrees`, i.e. a worktree add/remove). Separate
+/// from [`event_is_relevant`] so the base-tree classification — and its tests — stay untouched. The
+/// `config.root` ignore matcher doesn't govern paths outside `config.root`, so a worktree path is
+/// matched by the target globs alone (the overlay pass does its own delta + target filtering).
+fn event_touches_worktree(
+    config: &Config,
+    event: &Event,
+    worktree_roots: &[PathBuf],
+    registry: Option<&Path>,
+) -> bool {
+    if !kind_is_mutation(&event.kind) {
+        return false;
+    }
+    event.paths.iter().any(|path| {
+        if registry.is_some_and(|reg| path.starts_with(reg)) {
+            return true;
+        }
+        worktree_roots.iter().any(|root| {
+            path.strip_prefix(root).ok().is_some_and(|rel| target_for_path(config, rel).is_some())
+        })
+    })
+}
+
+/// Live linked-worktree checkout roots (excluding the base `config.root`) plus the worktree
+/// registry dir (`<common_dir>/worktrees`), for the watcher to subscribe to — branch checkouts for
+/// edits, the registry for add/remove.
+fn worktree_watch_targets(config: &Config) -> (Vec<PathBuf>, Option<PathBuf>) {
+    let (_, worktrees) = crate::index::live_worktree_contexts(&config.root);
+    let base = crate::index::worktree_id_of(&config.root);
+    let roots = worktrees.into_iter().filter(|w| *w != base).map(PathBuf::from).collect();
+    let registry = crate::index::discover_repo(&config.root)
+        .ok()
+        .map(|repo| repo.common_dir().join("worktrees"));
+    (roots, registry)
+}
+
 /// Whether `event` touches the installed binary path — the fleet hot-upgrade trigger. Matches by
 /// full path (`cargo install` renames its temp file to exactly this path) so unrelated churn in
 /// the same directory is ignored.
@@ -368,6 +406,16 @@ fn watcher_main(config: Config, fleet_bin: Option<PathBuf>, stop: &AtomicBool) {
     if let Some(dir) = fleet_dir {
         let _ = notify_watcher.watch(dir, RecursiveMode::NonRecursive);
     }
+    // Linked worktrees (#219): watch each branch checkout recursively so its edits refresh the
+    // overlay, and the worktree registry non-recursively so a `git worktree add`/`remove` fires a
+    // pass. `linked_worktrees` is reconciled after each pass to pick up newly-added worktrees.
+    let (mut linked_worktrees, worktree_registry) = worktree_watch_targets(&config);
+    for worktree in &linked_worktrees {
+        let _ = notify_watcher.watch(worktree, RecursiveMode::Recursive);
+    }
+    if let Some(registry) = &worktree_registry {
+        let _ = notify_watcher.watch(registry, RecursiveMode::NonRecursive);
+    }
 
     let mut debounce = Debounce::new(
         Duration::from_millis(config.watch.debounce_ms),
@@ -393,7 +441,14 @@ fn watcher_main(config: Config, fleet_bin: Option<PathBuf>, stop: &AtomicBool) {
         match rx.recv_timeout(wait) {
             Ok(Ok(event)) => {
                 let now = Instant::now();
-                if event_is_relevant(&config, &ignore, &event) {
+                if event_is_relevant(&config, &ignore, &event)
+                    || event_touches_worktree(
+                        &config,
+                        &event,
+                        &linked_worktrees,
+                        worktree_registry.as_deref(),
+                    )
+                {
                     debounce.on_event(now);
                     // A `.gitignore` mutation changed the rules — recompile so subsequent events
                     // are classified against current rules, not the matcher
@@ -420,6 +475,16 @@ fn watcher_main(config: Config, fleet_bin: Option<PathBuf>, stop: &AtomicBool) {
             let _ = maintenance_pass(&config, passes.is_multiple_of(GC_EVERY_PASSES));
             debounce.reset();
             last_pass = Instant::now();
+            // Pick up newly-added worktrees (a registry event fired this pass): watch any live
+            // linked checkout we aren't watching yet. Removed ones keep a now-stale watch
+            // (harmless; their overlay is GC-pruned) — avoids unwatch bookkeeping.
+            let (current, _) = worktree_watch_targets(&config);
+            for worktree in current {
+                if !linked_worktrees.contains(&worktree) {
+                    let _ = notify_watcher.watch(&worktree, RecursiveMode::Recursive);
+                    linked_worktrees.push(worktree);
+                }
+            }
         }
         if fleet_debounce.should_fire(now)
             && let Some(bin) = fleet_bin.as_deref()
@@ -462,6 +527,62 @@ mod tests {
 
     fn mutation_event(path: PathBuf) -> Event {
         Event::new(EventKind::Modify(ModifyKind::Any)).add_path(path)
+    }
+
+    #[test]
+    fn event_touches_worktree_matches_checkout_targets_and_registry() {
+        let config = Config {
+            root: PathBuf::from("/main"),
+            database: PathBuf::from("/main/.rag-rat/index.sqlite"),
+            targets: vec![ResolvedTarget {
+                name: "rust".to_string(),
+                language: Language::Rust,
+                directories: vec![PathBuf::from("src")],
+                include: vec!["**/*.rs".to_string()],
+                exclude: Vec::new(),
+                kind: TargetKind::Source,
+            }],
+            local_ai: LocalAiConfig { embedding: EmbeddingConfig::default() },
+            watch: WatchConfig::default(),
+            version_check: Default::default(),
+            oracle: Default::default(),
+        };
+        let worktree = PathBuf::from("/wt/feat");
+        let registry = PathBuf::from("/main/.git/worktrees");
+        let roots = [worktree.clone()];
+
+        // A target file in a linked worktree fires (its overlay needs refreshing).
+        assert!(event_touches_worktree(
+            &config,
+            &mutation_event(worktree.join("src/a.rs")),
+            &roots,
+            Some(&registry),
+        ));
+        // A non-target file in the worktree does not.
+        assert!(!event_touches_worktree(
+            &config,
+            &mutation_event(worktree.join("README.md")),
+            &roots,
+            Some(&registry),
+        ));
+        // A change in the worktree registry (a `git worktree add`/`remove`) fires.
+        assert!(event_touches_worktree(
+            &config,
+            &mutation_event(registry.join("feat/HEAD")),
+            &roots,
+            Some(&registry),
+        ));
+        // A read event never fires (anti-feedback, same as the base watcher).
+        let read = Event::new(EventKind::Access(AccessKind::Open(AccessMode::Read)))
+            .add_path(worktree.join("src/a.rs"));
+        assert!(!event_touches_worktree(&config, &read, &roots, Some(&registry)));
+        // No worktrees and no registry → nothing fires.
+        assert!(!event_touches_worktree(
+            &config,
+            &mutation_event(worktree.join("src/a.rs")),
+            &[],
+            None,
+        ));
     }
 
     #[test]

--- a/crates/rag-rat-mcp/src/claude_hook.rs
+++ b/crates/rag-rat-mcp/src/claude_hook.rs
@@ -19,6 +19,10 @@ pub struct HookRequest {
     pub search_path: Option<String>,
     #[serde(default)]
     pub source: String,
+    /// The session's working directory, so the listener scopes the augmentation to that worktree's
+    /// branch overlay (#219). Absent (older client) → base scope.
+    #[serde(default)]
+    pub cwd: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -151,11 +155,22 @@ mod listener {
                     state.filter.clone()
                 };
                 let database = config.database.clone();
+                let config_root = config.root.clone();
+                // Scope to the session's worktree overlay (#219). Absent cwd (older client) → the
+                // config root, which resolves to the base scope. This also fixes the listener's
+                // prior lack of ANY scope install: compose queries the `files` view, so without
+                // this it read raw, unscoped rows.
+                let cwd = req.cwd.clone().map(PathBuf::from).unwrap_or_else(|| config_root.clone());
                 let pattern = req.pattern.clone();
                 let search_path = req.search_path.clone();
                 // rusqlite is sync; one short read off the runtime threads.
                 let composed = tokio::task::spawn_blocking(move || {
                     let conn = IndexConnection::open_read_only(&database)?;
+                    rag_rat_core::index::install_worktree_scope_view(
+                        conn.connection(),
+                        &config_root,
+                        &cwd,
+                    )?;
                     grep_augment::compose(
                         conn.connection(),
                         &pattern,
@@ -214,10 +229,18 @@ mod listener_tests {
 
         let rw = IndexConnection::open(&config.database).unwrap();
         schema::apply(rw.connection()).unwrap();
+        // Seed at the scope a NON-git index uses (commit_sha '', worktree_id = the root), so the
+        // listener's worktree-scoped read (#219) surfaces the file — the listener now installs the
+        // scope view (resolve_worktree_scope → an absent request cwd resolves to config.root → base
+        // scope), where the overlay branch keys on `worktree_id`.
         rw.connection()
             .execute(
-                "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
-                 VALUES ('src/lib.rs', 'rust', 'source', 'abc', 0, 0)",
+                &format!(
+                    "INSERT INTO files(path, language, kind, sha256, modified_at_ms, \
+                     indexed_at_ms, worktree_id)
+                     VALUES ('src/lib.rs', 'rust', 'source', 'abc', 0, 0, '{}')",
+                    config.root.to_string_lossy()
+                ),
                 [],
             )
             .unwrap();

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -56,6 +56,18 @@ fn is_read_only_tool(name: &str) -> bool {
     )
 }
 
+/// Read tools that compare indexed graph/symbol data against LIVE on-disk source text, read through
+/// the stored `source_root` (the MAIN checkout). Under a linked-worktree overlay scope these tools'
+/// GRAPH side would come from the branch overlay while their TEXT side still read the main
+/// checkout, so matched / text-only / graph-only would be computed against mismatched sides. They
+/// are kept in the BASE scope even when a `worktree` is passed — the diagnostic stays
+/// self-consistent (graph and text both from main) rather than producing wrong overlay-vs-main
+/// results. Accepted recall: the diagnostic doesn't reflect branch-only changes when invoked with
+/// `worktree` (#219 review).
+fn tool_compares_against_live_source(name: &str) -> bool {
+    matches!(name, "compare_graph_to_text")
+}
+
 pub fn call_tool_for_config(
     config: &Config,
     name: &str,
@@ -68,6 +80,9 @@ pub fn call_tool_for_config(
     // / main / foreign / unreadable path — and only writes the per-connection `temp.*` scope
     // view, so it is safe even on the read-only connection.
     let worktree = worktree_arg(&arguments);
+    // A tool that compares the graph against LIVE main-checkout text stays BASE-scoped even with a
+    // `worktree` arg, so its graph and text sides come from the same checkout (#219 review).
+    let scope_worktree = if tool_compares_against_live_source(name) { None } else { worktree };
     // Read tools run on a lock-free read-only connection (#143). Two fall-backs to the read-write
     // open: (1) `try_open_config_read_only` returns `None` when the index still owes a heal/migrate
     // write; (2) a handful of read tools lazily WRITE on a cold path (`semantic_search` heals stale
@@ -77,7 +92,7 @@ pub fn call_tool_for_config(
     if is_read_only_tool(name)
         && let Some(mut db) = IndexDatabase::try_open_config_read_only(config)?
     {
-        db.use_worktree_scope(&config.root, worktree.as_deref())?;
+        db.use_worktree_scope(&config.root, scope_worktree.as_deref())?;
         match call_tool_with_db(&db, name, arguments.clone()) {
             Ok(result) => return finalize_tool_result(config, name, result),
             Err(err) if rag_rat_core::storage::is_readonly_violation(&err) => {
@@ -97,7 +112,7 @@ pub fn call_tool_for_config(
     // overlay scope (`IndexDatabase::active_scope_is_linked_overlay`) (#219 review).
     let mut db = IndexDatabase::open_config(config)?;
     if is_read_only_tool(name) {
-        db.use_worktree_scope(&config.root, worktree.as_deref())?;
+        db.use_worktree_scope(&config.root, scope_worktree.as_deref())?;
     }
     let result = call_tool_with_db(&db, name, arguments)?;
     finalize_tool_result(config, name, result)

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -92,15 +92,30 @@ pub fn call_tool_for_config(
     finalize_tool_result(config, name, result)
 }
 
-/// Extract the optional `worktree` request field (a linked-worktree checkout path) — common to
-/// every tool, read here rather than declared on each arg struct. Trimmed; empty/absent → `None`.
+/// The caller `worktree` (a linked-worktree checkout path): the explicit `worktree` request field,
+/// else the MCP server's own working directory. `resolve_worktree_scope` downstream VALIDATES it
+/// (non-worktree / foreign-repo / unreadable → base scope), so the cwd fallback is safe
+/// best-effort: an agent working IN a linked worktree gets that branch's overlay without passing
+/// the param, while a server rooted at and launched in the main checkout still resolves to base.
+/// The explicit param stays the reliable path (the server's cwd is launch-dependent — see #219).
+/// Common to every tool, read here rather than declared on each arg struct.
 fn worktree_arg(arguments: &Value) -> Option<std::path::PathBuf> {
+    worktree_arg_or_cwd(arguments, std::env::current_dir().ok())
+}
+
+/// Testable core of [`worktree_arg`]: explicit request field (trimmed; blank → ignored), else
+/// `cwd`.
+fn worktree_arg_or_cwd(
+    arguments: &Value,
+    cwd: Option<std::path::PathBuf>,
+) -> Option<std::path::PathBuf> {
     arguments
         .get("worktree")
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(std::path::PathBuf::from)
+        .or(cwd)
 }
 
 /// Post-process a tool result before returning it. Currently only `index_status`: surface the

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -86,8 +86,19 @@ pub fn call_tool_for_config(
             Err(err) => return Err(err),
         }
     }
+    // The read-WRITE open, reached by (a) a genuine write tool, or (b) a read tool whose lazy write
+    // tripped `SQLITE_READONLY` (or whose RO open was unavailable). A WRITE tool stays in the BASE
+    // scope: `heal_index` / the `memory_*` tools read file bytes from the stored `source_root` (the
+    // MAIN checkout) but would write into whatever scope the connection carries, so scoping the
+    // connection to a linked worktree would reindex the overlay with MAIN's contents or tombstone
+    // branch-only files — corrupting the overlay that only `index_worktree_overlay` may maintain. A
+    // READ tool keeps the worktree scope so its query still serves the overlay on this fallback;
+    // its lazy heal can't corrupt the overlay because the heal paths skip writes under a linked
+    // overlay scope (`IndexDatabase::active_scope_is_linked_overlay`) (#219 review).
     let mut db = IndexDatabase::open_config(config)?;
-    db.use_worktree_scope(&config.root, worktree.as_deref())?;
+    if is_read_only_tool(name) {
+        db.use_worktree_scope(&config.root, worktree.as_deref())?;
+    }
     let result = call_tool_with_db(&db, name, arguments)?;
     finalize_tool_result(config, name, result)
 }

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -61,6 +61,13 @@ pub fn call_tool_for_config(
     name: &str,
     arguments: Value,
 ) -> anyhow::Result<Value> {
+    // Optional caller `worktree`: scope the query to a linked worktree's branch overlay instead of
+    // the indexed checkout (#219). Extracted as a COMMON field from the request (serde ignores it
+    // per-tool — no `deny_unknown_fields`), so every tool routes without per-arg-struct plumbing.
+    // `use_worktree_scope` validates it server-side and falls back to the base scope for an absent
+    // / main / foreign / unreadable path — and only writes the per-connection `temp.*` scope
+    // view, so it is safe even on the read-only connection.
+    let worktree = worktree_arg(&arguments);
     // Read tools run on a lock-free read-only connection (#143). Two fall-backs to the read-write
     // open: (1) `try_open_config_read_only` returns `None` when the index still owes a heal/migrate
     // write; (2) a handful of read tools lazily WRITE on a cold path (`semantic_search` heals stale
@@ -68,8 +75,9 @@ pub fn call_tool_for_config(
     // fails on the read-only connection with `SQLITE_READONLY` — we detect that and retry the whole
     // call read-write (which performs the heal). The warm path never writes, so it stays lock-free.
     if is_read_only_tool(name)
-        && let Some(db) = IndexDatabase::try_open_config_read_only(config)?
+        && let Some(mut db) = IndexDatabase::try_open_config_read_only(config)?
     {
+        db.use_worktree_scope(&config.root, worktree.as_deref())?;
         match call_tool_with_db(&db, name, arguments.clone()) {
             Ok(result) => return finalize_tool_result(config, name, result),
             Err(err) if rag_rat_core::storage::is_readonly_violation(&err) => {
@@ -78,9 +86,21 @@ pub fn call_tool_for_config(
             Err(err) => return Err(err),
         }
     }
-    let db = IndexDatabase::open_config(config)?;
+    let mut db = IndexDatabase::open_config(config)?;
+    db.use_worktree_scope(&config.root, worktree.as_deref())?;
     let result = call_tool_with_db(&db, name, arguments)?;
     finalize_tool_result(config, name, result)
+}
+
+/// Extract the optional `worktree` request field (a linked-worktree checkout path) — common to
+/// every tool, read here rather than declared on each arg struct. Trimmed; empty/absent → `None`.
+fn worktree_arg(arguments: &Value) -> Option<std::path::PathBuf> {
+    arguments
+        .get("worktree")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(std::path::PathBuf::from)
 }
 
 /// Post-process a tool result before returning it. Currently only `index_status`: surface the

--- a/crates/rag-rat-mcp/src/tools/requests.rs
+++ b/crates/rag-rat-mcp/src/tools/requests.rs
@@ -239,6 +239,11 @@ pub struct SearchArgs {
     pub include_graph: McpGraphMode,
     #[serde(default = "default_search_graph_limit")]
     pub graph_limit: u32,
+    /// Absolute path to a linked git worktree you're working in. When set, results are served from
+    /// that worktree's branch overlay (its committed + uncommitted changes) on top of the indexed
+    /// checkout; omit to query the indexed checkout. An unrelated/invalid path falls back to it.
+    #[serde(default)]
+    pub worktree: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, schemars::JsonSchema)]
@@ -323,6 +328,11 @@ pub struct SymbolArgs {
     /// generated bindings back into the results). Pass `include: []` to suppress memories.
     #[serde(default, deserialize_with = "de_seq_or_json_string")]
     pub include: Option<Vec<SymbolInclude>>,
+    /// Absolute path to a linked git worktree you're working in; serves that worktree's branch
+    /// overlay over the indexed checkout. Omit (or pass an unrelated path) for the indexed
+    /// checkout.
+    #[serde(default)]
+    pub worktree: Option<String>,
 }
 
 /// Pure symbol-selector args (symbol/ref/id/lang) with no `include` — for tools that resolve ONE
@@ -377,6 +387,11 @@ pub struct SymbolGraphArgs {
     pub include: Option<Vec<GraphInclude>>,
     #[serde(default, deserialize_with = "de_seq_or_json_string")]
     pub edge_kinds: Option<Vec<McpGraphEdgeKind>>,
+    /// Absolute path to a linked git worktree you're working in; serves that worktree's branch
+    /// overlay over the indexed checkout. Omit (or pass an unrelated path) for the indexed
+    /// checkout.
+    #[serde(default)]
+    pub worktree: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
@@ -438,6 +453,11 @@ pub struct ImpactArgs {
     /// `memory_for_path` / `memory_for_call_path`.
     #[serde(default)]
     pub full_memories: bool,
+    /// Absolute path to a linked git worktree you're working in; serves that worktree's branch
+    /// overlay over the indexed checkout. Omit (or pass an unrelated path) for the indexed
+    /// checkout.
+    #[serde(default)]
+    pub worktree: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
@@ -456,6 +476,11 @@ pub struct ReadChunkArgs {
     /// What to include: `memories` (on by default). Pass `include: []` to suppress.
     #[serde(default, deserialize_with = "de_seq_or_json_string")]
     pub include: Option<Vec<MemoriesInclude>>,
+    /// Absolute path to a linked git worktree you're working in; serves that worktree's branch
+    /// overlay over the indexed checkout. Omit (or pass an unrelated path) for the indexed
+    /// checkout.
+    #[serde(default)]
+    pub worktree: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, schemars::JsonSchema)]

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use rag_rat_core::language::Language;
@@ -924,6 +924,78 @@ fn rust_config(root: PathBuf) -> Config {
 fn unique_temp_root() -> PathBuf {
     let id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     std::env::temp_dir().join(format!("rag-rat-mcp-test-{}-{id}", std::process::id()))
+}
+
+fn git(root: &Path, args: &[&str]) {
+    let out = std::process::Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@e")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@e")
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+}
+
+fn candidate_count(value: &Value) -> usize {
+    value.get("candidates").and_then(Value::as_array).map_or(0, Vec::len)
+}
+
+#[test]
+fn worktree_param_routes_query_to_branch_overlay() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    git(&root, &["init", "-q", "-b", "main"]);
+    git(&root, &["config", "user.email", "t@e"]);
+    git(&root, &["config", "user.name", "t"]);
+    git(&root, &["add", "."]);
+    git(&root, &["commit", "-q", "-m", "base"]);
+    let config = rust_config(root.clone());
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    git(&root, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/a.rs"), "pub fn linked_fn() {}\n").unwrap();
+    git(&linked, &["add", "."]);
+    git(&linked, &["commit", "-q", "-m", "branch"]);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    drop(db);
+
+    let linked_str = linked.to_str().unwrap();
+    // With the `worktree` param the query resolves against that worktree's branch overlay.
+    let hit = call_tool_for_config(
+        &config,
+        "symbol_lookup",
+        json!({"symbol": "linked_fn", "worktree": linked_str}),
+    )
+    .unwrap();
+    assert!(candidate_count(&hit) > 0, "worktree-scoped lookup finds the branch symbol");
+
+    // Without it the base scope is queried — the branch symbol isn't there.
+    let base =
+        call_tool_for_config(&config, "symbol_lookup", json!({"symbol": "linked_fn"})).unwrap();
+    assert_eq!(candidate_count(&base), 0, "base scope does not see the branch symbol");
+
+    // And within the worktree scope the overlay shadows the base symbol.
+    let shadowed = call_tool_for_config(
+        &config,
+        "symbol_lookup",
+        json!({"symbol": "base_fn", "worktree": linked_str}),
+    )
+    .unwrap();
+    assert_eq!(
+        candidate_count(&shadowed),
+        0,
+        "the overlay shadows the base symbol in the worktree scope"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_dir_all(&linked);
 }
 
 #[test]

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -944,6 +944,21 @@ fn candidate_count(value: &Value) -> usize {
 }
 
 #[test]
+fn worktree_arg_prefers_request_then_falls_back_to_cwd() {
+    let cwd = Some(PathBuf::from("/server/cwd"));
+    // Explicit request field wins.
+    assert_eq!(
+        worktree_arg_or_cwd(&json!({"worktree": "/explicit"}), cwd.clone()),
+        Some(PathBuf::from("/explicit"))
+    );
+    // Absent / blank request field → fall back to the server cwd (validated downstream).
+    assert_eq!(worktree_arg_or_cwd(&json!({}), cwd.clone()), Some(PathBuf::from("/server/cwd")));
+    assert_eq!(worktree_arg_or_cwd(&json!({"worktree": "  "}), cwd.clone()), cwd);
+    // No request field and no cwd → None (base scope).
+    assert_eq!(worktree_arg_or_cwd(&json!({}), None), None);
+}
+
+#[test]
 fn worktree_param_routes_query_to_branch_overlay() {
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -1014,6 +1014,72 @@ fn worktree_param_routes_query_to_branch_overlay() {
 }
 
 #[test]
+fn heal_index_from_a_linked_worktree_does_not_corrupt_the_overlay() {
+    // #219 review: `heal_index` (a WRITE tool) reads file bytes from the stored `source_root` (the
+    // MAIN checkout). If the read-write connection were scoped to the linked worktree, the heal
+    // would reindex the overlay with MAIN's contents or — for a BRANCH-ONLY file, absent from main
+    // — tombstone it in the overlay scope. The fix keeps write tools in the BASE scope and
+    // makes the heal paths refuse to write under a linked overlay scope, so the overlay
+    // survives a `heal_index` invoked from the worktree cwd.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn base_fn() {}\n").unwrap();
+    git(&root, &["init", "-q", "-b", "main"]);
+    git(&root, &["config", "user.email", "t@e"]);
+    git(&root, &["config", "user.name", "t"]);
+    git(&root, &["add", "."]);
+    git(&root, &["commit", "-q", "-m", "base"]);
+    let config = rust_config(root.clone());
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    git(&root, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    // Branch modifies one file AND adds a branch-only file (the file absent from main is the strong
+    // corruption vector: a worktree-scoped heal can't read it from `source_root`, so it
+    // tombstones).
+    fs::write(linked.join("src/a.rs"), "pub fn linked_fn() {}\n").unwrap();
+    fs::write(linked.join("src/only.rs"), "pub fn branch_only_fn() {}\n").unwrap();
+    git(&linked, &["add", "."]);
+    git(&linked, &["commit", "-q", "-m", "branch"]);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    drop(db);
+
+    let linked_str = linked.to_str().unwrap();
+    // Run `heal_index` from the worktree cwd (the `worktree` param the dispatcher would honor).
+    call_tool_for_config(&config, "heal_index", json!({"worktree": linked_str})).unwrap();
+
+    // The overlay is intact: the worktree scope still serves the modified BRANCH version, not
+    // main's.
+    let modified = call_tool_for_config(
+        &config,
+        "symbol_lookup",
+        json!({"symbol": "linked_fn", "worktree": linked_str}),
+    )
+    .unwrap();
+    assert!(
+        candidate_count(&modified) > 0,
+        "heal_index from the worktree must NOT overwrite the modified branch overlay",
+    );
+    // The branch-only file is still served — NOT tombstoned by a heal that couldn't read it in
+    // main.
+    let only = call_tool_for_config(
+        &config,
+        "symbol_lookup",
+        json!({"symbol": "branch_only_fn", "worktree": linked_str}),
+    )
+    .unwrap();
+    assert!(
+        candidate_count(&only) > 0,
+        "heal_index must NOT tombstone the branch-only overlay file",
+    );
+
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
 fn read_tool_lazy_write_retries_read_write_not_readonly_error() {
     // #143 review: read tools open read-only, but a few lazily WRITE on a cold path — here
     // `read_chunk` calls `mark_file_deleted` when its source file is gone on disk. That write fails

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -1014,6 +1014,71 @@ fn worktree_param_routes_query_to_branch_overlay() {
 }
 
 #[test]
+fn compare_graph_to_text_stays_base_scoped_under_a_worktree_param() {
+    // #219 review (3440746678): `compare_graph_to_text` reads LIVE source text through
+    // `source_root` (the MAIN checkout). Under an overlay scope its GRAPH side would be the branch
+    // overlay while its TEXT side stayed main — mismatched. It must stay BASE-scoped even with a
+    // `worktree` arg, so a `worktree`-passed call matches the base call exactly.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    // Base: `caller` calls `target`.
+    fs::write(root.join("src/a.rs"), "pub fn target() {}\npub fn caller() {\n    target();\n}\n")
+        .unwrap();
+    git(&root, &["init", "-q", "-b", "main"]);
+    git(&root, &["config", "user.email", "t@e"]);
+    git(&root, &["config", "user.name", "t"]);
+    git(&root, &["add", "."]);
+    git(&root, &["commit", "-q", "-m", "base"]);
+    let config = rust_config(root.clone());
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    // Branch: `caller` no longer calls `target` (the callsite is gone on the branch). An
+    // overlay-scoped compare would see 0 graph edges; the base sees 1.
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    git(&root, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/a.rs"), "pub fn target() {}\npub fn caller() {\n}\n").unwrap();
+    git(&linked, &["add", "."]);
+    git(&linked, &["commit", "-q", "-m", "branch drops call"]);
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    drop(db);
+
+    let lookup =
+        call_tool_for_config(&config, "symbol_lookup", json!({"symbol": "target"})).unwrap();
+    let id = lookup["candidates"][0]["id"].as_str().unwrap().to_string();
+    let args = |worktree: Option<&str>| {
+        let mut a = json!({"id": id, "pattern": "target\\(", "resolution": "exact",
+            "edge_kinds": ["calls_name"]});
+        if let Some(w) = worktree {
+            a["worktree"] = json!(w);
+        }
+        a
+    };
+
+    let base = call_tool_for_config(&config, "compare_graph_to_text", args(None)).unwrap();
+    let with_worktree = call_tool_for_config(
+        &config,
+        "compare_graph_to_text",
+        args(Some(linked.to_str().unwrap())),
+    )
+    .unwrap();
+    // The `worktree` call is identical to the base call: graph + text both from main, never the
+    // overlay (which would have dropped the graph edge).
+    assert_eq!(
+        base["summary"], with_worktree["summary"],
+        "compare_graph_to_text must stay base-scoped regardless of the worktree param",
+    );
+    assert!(
+        base["summary"]["graph_edges"].as_u64().unwrap() >= 1,
+        "the base call sees the committed callsite edge: {base:?}",
+    );
+
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
 fn heal_index_from_a_linked_worktree_does_not_corrupt_the_overlay() {
     // #219 review: `heal_index` (a WRITE tool) reads file bytes from the stored `source_root` (the
     // MAIN checkout). If the read-write connection were scoped to the linked worktree, the heal


### PR DESCRIPTION
## Summary

Serve linked git worktrees as branch **overlays** on the shared base index, so an agent working in a linked worktree (a feature branch) gets that branch's view from every rag-rat surface — MCP tools, the SessionStart orientation brief, and the PreToolUse grep-augmentation — instead of the rooted checkout's. Previously the index served ONLY the rooted checkout's scope: a linked worktree on another branch was invisible (its files unindexed, queries returning the base version as if current).

Closes #219.

## How it works

- **Scope model.** A linked worktree's branch delta (files differing from the base = the rooted checkout's HEAD) is indexed as worktree-scoped OVERLAY rows (`commit_sha=''`, `worktree_id=<checkout path>`) that shadow the base; branch-deleted files get `kind='deleted'` tombstones that hide the path. Unchanged files stay shared (one base row read by every worktree). `install_scope_view` UNIONs overlay-over-committed.
- **Populate.** `rag-rat index --worktree <path>` (manual) or the watcher (auto): it watches each linked checkout + the `<common_dir>/worktrees` registry and refreshes overlays every pass — delta-only and idle-safe, so it is write-free when a worktree is unchanged.
- **Query.** Pass `worktree=<checkout path>` to the MCP tools (semantic_search / symbol_lookup / find_callers / trace_callees / impact_surface / read_chunk), with a fallback to the server's cwd. Resolved server-side via `resolve_worktree_scope` (validated: a real linked sibling of the configured repo; absent / main / foreign / unreadable → base scope, never the wrong repo).
- **Config + DB anchored to the main worktree**: `root` and the database resolve to the main worktree regardless of launch cwd, so every process shares one base. A subdirectory `root` is preserved (rebased under the main worktree, not collapsed to the repo top).
- **Git resolution is path-defined.** `discover_repo` resolves from the configured path, IGNORING inherited `GIT_DIR`/`GIT_WORK_TREE` — a tool or git hook operating in a worktree must not hijack the shared index's repo identity (that collapsed the base↔overlay delta and pruned/tombstoned real rows). Env-override discovery is a fallback only when no repo is found upward (bare-dir / CI). Worktree keys are canonicalized so a symlinked or relative path can't drift from the GC live set.
- **Hooks.** The git maintenance hooks clear git's inherited env before invoking rag-rat and no longer forward positional args (post-merge / post-rewrite were aborting on git's hook args). The SessionStart + PreToolUse Claude Code hooks detect the session's worktree and scope their orientation / grep-augmentation to it.

## Tests

Acceptance + regression coverage for: committed / uncommitted overlays, branch-delete tombstones, rename, gitignore parity, GC keep/prune, maintenance-pass refresh, idle-safety, cross-connection symbol resolution, base-scope logical grouping preserved across overlay passes, symlinked-path resolution, subdir-root anchoring, unborn worktrees, git-env isolation, and worktree-aware orientation. Full suite green, clippy clean.
