### PR TITLE
perf(impact): stop scanning chunks.text in impact_surface (#77 Phase 1)

### DIFF
--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -139,6 +139,10 @@ impl IndexDatabase {
             self.insert_parser_failure(&file.relative_path, file.language, message)?;
         }
         let path = path_string(&file.relative_path);
+        // Precompute the file-level test-code flag (#77): impact_surface's "tests touching this
+        // symbol" query reads this indexed flag instead of scanning `chunks.text` for the markers.
+        // Computed from the chunk text we already hold; same marker set as the V024 backfill.
+        let has_test_code = prepared.chunks.iter().any(|pc| text_has_test_marker(&pc.chunk.text));
         // prepare_cached so the per-file/-chunk/-symbol INSERTs compile once per connection and
         // are reused across the whole rebuild instead of re-parsing the SQL on every row (#57).
         let file_id = self
@@ -146,8 +150,8 @@ impl IndexDatabase {
             .connection()
             .prepare_cached(
                 "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, generated, \
-                 indexed_at_ms, indexed_revision, commit_sha, worktree_id)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+                 indexed_at_ms, indexed_revision, commit_sha, worktree_id, has_test_code)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
                  RETURNING id",
             )?
             .query_row(
@@ -162,6 +166,7 @@ impl IndexDatabase {
                     prepared.sha256,
                     file.commit_sha,
                     file.worktree_id,
+                    has_test_code,
                 ],
                 |row| row.get::<_, i64>(0),
             )?;

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -72,10 +72,21 @@ impl IndexDatabase {
             }
         }
         let sha256 = hex_sha256(text.as_bytes());
+        let chunks = if kind == TargetKind::Generated {
+            chunker::generated_chunks_for_file(path, text)
+        } else {
+            chunker::chunks_for_file(path, language, text)
+        };
+        let chunks = prepare_chunks(path, language.as_str(), kind.as_str(), chunks, text);
+        // has_test_code from the SAME chunk-text marker set as insert_prepared_file + the V024
+        // backfill, so a file healed through this path matches a fully-indexed one (#77). The heal
+        // path is a second files-insert site; chunks are prepared up here (they don't need file_id)
+        // so the flag can be set in the INSERT instead of left at the default 0.
+        let has_test_code = chunks.iter().any(|pc| text_has_test_marker(&pc.chunk.text));
         let file_id = self.storage.connection().query_row(
             "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, generated, \
-             indexed_at_ms, indexed_revision, commit_sha, worktree_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+             indexed_at_ms, indexed_revision, commit_sha, worktree_id, has_test_code)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
              RETURNING id",
             params![
                 path_string(path),
@@ -88,15 +99,10 @@ impl IndexDatabase {
                 sha256,
                 &scope.commit_sha,
                 &scope.worktree_id,
+                has_test_code,
             ],
             |row| row.get::<_, i64>(0),
         )?;
-        let chunks = if kind == TargetKind::Generated {
-            chunker::generated_chunks_for_file(path, text)
-        } else {
-            chunker::chunks_for_file(path, language, text)
-        };
-        let chunks = prepare_chunks(path, language.as_str(), kind.as_str(), chunks, text);
         let symbols =
             if kind == TargetKind::Generated || text.len() > chunker::MAX_STRUCTURAL_PARSE_BYTES {
                 Vec::new()

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -212,13 +212,13 @@ pub(crate) fn install_scope_view(
             DROP VIEW IF EXISTS temp.files;
             CREATE TEMP VIEW temp.files AS
             SELECT id, path, language, kind, sha256, modified_at_ms, generated, indexed_at_ms, \
-         indexed_revision, commit_sha, worktree_id
+         indexed_revision, commit_sha, worktree_id, has_test_code
             FROM main.files
             WHERE worktree_id = (SELECT value FROM temp.connection_context WHERE key = \
          'worktree_id') AND worktree_id != '' AND kind != 'deleted'
             UNION ALL
             SELECT id, path, language, kind, sha256, modified_at_ms, generated, indexed_at_ms, \
-         indexed_revision, commit_sha, worktree_id
+         indexed_revision, commit_sha, worktree_id, has_test_code
             FROM main.files
             WHERE commit_sha = (SELECT value FROM temp.connection_context WHERE key = 'commit_sha')
               AND commit_sha != ''

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -746,7 +746,7 @@ fn migration_creates_oracle_side_tables() {
         assert!(columns.contains(&expected.to_string()), "edge_oracle missing {expected}");
     }
 
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 23);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 24);
 }
 
 /// The V019 moniker migration: the `logical_symbol_monikers` table (STRICT, NO foreign key — see

--- a/crates/rag-rat-core/src/index/query_api/graph.rs
+++ b/crates/rag-rat-core/src/index/query_api/graph.rs
@@ -702,7 +702,14 @@ impl IndexDatabase {
         limit: u32,
         options: &crate::query::impact::ImpactSurfaceOptions,
     ) -> anyhow::Result<crate::query::impact::ImpactSurfaceReport> {
-        self.ensure_fts_fresh()?;
+        // Only the text sections (tests / docs / text-fallback) run `chunk_fts MATCH`; the report
+        // builder's neighbors come from the graph, not FTS. So skip the FTS refresh when the caller
+        // excludes every text section (e.g. MCP `include: ["git"]`) — no point rebuilding FTS for a
+        // report that won't read it. (The non-report wrappers always need it: the flat builder runs
+        // an ungated textual fallback.)
+        if options.include_tests || options.include_docs || options.include_text_fallback {
+            self.ensure_fts_fresh()?;
+        }
         // Surface the `Compiler` tier on impact's direct graph neighbors too (same read-side JOIN
         // as trace_callees/find_callers). The enrichment is now injected INTO the builder so it
         // runs over the OVERFETCHED candidate set before the re-rank + limit truncation (#82

--- a/crates/rag-rat-core/src/index/query_api/graph.rs
+++ b/crates/rag-rat-core/src/index/query_api/graph.rs
@@ -660,6 +660,9 @@ impl IndexDatabase {
         query: &str,
         limit: u32,
     ) -> anyhow::Result<Vec<crate::query::impact::ImpactItem>> {
+        // impact's chunk-mention evidence runs `chunk_fts MATCH` (#77 Phase 1), so the FTS index
+        // must be fresh first — same precondition search enforces before its MATCH queries.
+        self.ensure_fts_fresh()?;
         crate::query::impact::impact_surface(self.storage.connection(), query, limit)
     }
 
@@ -669,6 +672,7 @@ impl IndexDatabase {
         limit: u32,
         resolution_mode: crate::query::graph::GraphResolutionMode,
     ) -> anyhow::Result<Vec<crate::query::impact::ImpactItem>> {
+        self.ensure_fts_fresh()?;
         crate::query::impact::impact_surface_with_options(
             self.storage.connection(),
             query,
@@ -683,6 +687,7 @@ impl IndexDatabase {
         limit: u32,
         resolution_mode: crate::query::graph::GraphResolutionMode,
     ) -> anyhow::Result<Vec<crate::query::impact::ImpactItem>> {
+        self.ensure_fts_fresh()?;
         crate::query::impact::impact_surface_for_symbol(
             self.storage.connection(),
             symbol,
@@ -697,6 +702,7 @@ impl IndexDatabase {
         limit: u32,
         options: &crate::query::impact::ImpactSurfaceOptions,
     ) -> anyhow::Result<crate::query::impact::ImpactSurfaceReport> {
+        self.ensure_fts_fresh()?;
         // Surface the `Compiler` tier on impact's direct graph neighbors too (same read-side JOIN
         // as trace_callees/find_callers). The enrichment is now injected INTO the builder so it
         // runs over the OVERFETCHED candidate set before the re-rank + limit truncation (#82

--- a/crates/rag-rat-core/src/index/schema/baseline.rs
+++ b/crates/rag-rat-core/src/index/schema/baseline.rs
@@ -20,6 +20,11 @@ pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
             indexed_revision TEXT NOT NULL DEFAULT '',
             commit_sha TEXT NOT NULL DEFAULT '',
             worktree_id TEXT NOT NULL DEFAULT '',
+            -- 1 when the file text contains a test marker (cfg(test) / describe( / it( / test();
+            -- precomputed at index time so impact_surface test detection filters on an indexed \
+         flag
+            -- instead of a full chunks.text LIKE scan (#77).
+            has_test_code INTEGER NOT NULL DEFAULT 0,
             UNIQUE(path, commit_sha, worktree_id)
         );
 

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -663,6 +663,23 @@ pub(crate) fn apply_dispatch_edge_facts_view_exclusion(conn: &Connection) -> rus
     ensure_edges_view(conn)
 }
 
+/// V024 (#77): add `files.has_test_code` and backfill it from existing chunk text. Additive +
+/// idempotent — `add_column_if_missing` guards the ADD (a fresh DB already has the column from the
+/// baseline), and the backfill recomputes from the SAME markers `impact_surface` previously scanned
+/// for, so a forward-migrated index matches a freshly-indexed one immediately (no wait for
+/// reindex). Invariant: the marker set here MUST stay in sync with `index::text_has_test_marker`
+/// (the index-time compute) and `test_items`'s filter, or migrated vs reindexed rows would diverge.
+pub(crate) fn apply_files_has_test_code(conn: &Connection) -> rusqlite::Result<()> {
+    add_column_if_missing(conn, "files", "has_test_code", "INTEGER NOT NULL DEFAULT 0")?;
+    conn.execute_batch(
+        "UPDATE files SET has_test_code = 1 WHERE id IN (
+             SELECT DISTINCT file_id FROM chunks
+             WHERE text LIKE '%#[cfg(test)]%' OR text LIKE '%describe(%'
+                OR text LIKE '%it(%' OR text LIKE '%test(%'
+         );",
+    )
+}
+
 pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
     let legacy_table: Option<String> = conn
         .query_row(
@@ -990,6 +1007,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_021_ID => Some(21),
             MIGRATION_022_ID => Some(22),
             MIGRATION_023_ID => Some(23),
+            MIGRATION_024_ID => Some(24),
             _ => None,
         })
         .max()
@@ -1022,6 +1040,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_021_ID
             | MIGRATION_022_ID
             | MIGRATION_023_ID
+            | MIGRATION_024_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1051,6 +1070,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_021_ID => migration.checksum != MIGRATION_021_CHECKSUM,
         MIGRATION_022_ID => migration.checksum != MIGRATION_022_CHECKSUM,
         MIGRATION_023_ID => migration.checksum != MIGRATION_023_CHECKSUM,
+        MIGRATION_024_ID => migration.checksum != MIGRATION_024_CHECKSUM,
         _ => false,
     }
 }

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -669,13 +669,17 @@ pub(crate) fn apply_dispatch_edge_facts_view_exclusion(conn: &Connection) -> rus
 /// for, so a forward-migrated index matches a freshly-indexed one immediately (no wait for
 /// reindex). Invariant: the marker set here MUST stay in sync with `index::text_has_test_marker`
 /// (the index-time compute) and `test_items`'s filter, or migrated vs reindexed rows would diverge.
+/// Uses `instr` (case-sensitive, literal substring), NOT `LIKE` — SQLite `LIKE` is case-insensitive
+/// for ASCII, so it would match an uppercase `TEST(` that the case-sensitive `str::contains` at
+/// index time does not, diverging a forward-migrated row from a freshly-indexed one. (`instr` also
+/// needs no `%`-escaping of the `[`/`(` in the markers.)
 pub(crate) fn apply_files_has_test_code(conn: &Connection) -> rusqlite::Result<()> {
     add_column_if_missing(conn, "files", "has_test_code", "INTEGER NOT NULL DEFAULT 0")?;
     conn.execute_batch(
         "UPDATE files SET has_test_code = 1 WHERE id IN (
              SELECT DISTINCT file_id FROM chunks
-             WHERE text LIKE '%#[cfg(test)]%' OR text LIKE '%describe(%'
-                OR text LIKE '%it(%' OR text LIKE '%test(%'
+             WHERE instr(text, '#[cfg(test)]') > 0 OR instr(text, 'describe(') > 0
+                OR instr(text, 'it(') > 0 OR instr(text, 'test(') > 0
          );",
     )
 }

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use migrations::*;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 23;
+pub const LATEST_SCHEMA_VERSION: u32 = 24;
 const DIRTY_MIGRATION_ID: &str = "__dirty__";
 const MIGRATION_001_ID: &str = "001_sqlite_storage_baseline";
 const MIGRATION_001_CHECKSUM: &str = "sha256:rag-rat-sqlite-baseline-v1";
@@ -100,6 +100,11 @@ const MIGRATION_023_ID: &str = "023_dispatch_edge_facts_view_exclusion";
 const MIGRATION_023_CHECKSUM: &str = "sha256:rag-rat-dispatch-edge-facts-view-exclusion-v23";
 const MIGRATION_023_DESCRIPTION: &str = "Recreate the edges compatibility view to exclude \
                                          internal dispatch FACT rows from query-layer reads (#200)";
+const MIGRATION_024_ID: &str = "024_files_has_test_code";
+const MIGRATION_024_CHECKSUM: &str = "sha256:rag-rat-files-has-test-code-v24";
+const MIGRATION_024_DESCRIPTION: &str = "Add files.has_test_code flag (precomputed test-marker \
+                                         detection) so impact_surface avoids a chunks.text scan \
+                                         (#77)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -315,6 +320,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_023_CHECKSUM,
         description: MIGRATION_023_DESCRIPTION,
         apply: apply_dispatch_edge_facts_view_exclusion,
+    },
+    Migration {
+        id: MIGRATION_024_ID,
+        checksum: MIGRATION_024_CHECKSUM,
+        description: MIGRATION_024_DESCRIPTION,
+        apply: apply_files_has_test_code,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -8795,7 +8795,7 @@ fn v022_fresh_apply_creates_packages_and_dedicated_import_scope_columns() {
     schema::apply(&conn).unwrap();
 
     assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 23);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 24);
     assert!(conn_table_exists(&conn, "packages"), "packages table is created on a fresh apply");
 
     let package_cols = conn_table_columns(&conn, "packages");
@@ -8858,9 +8858,13 @@ fn v022_forward_migrate_adds_artifacts_to_an_older_index() {
         ALTER TABLE edges_data DROP COLUMN import_scope_end_byte;
         ALTER TABLE edges_data DROP COLUMN import_mod_id;
         DELETE FROM schema_version WHERE id = '022_per_package_import_scope';
-        -- Also drop V023 (recreates the view) so `known_version` reads the contiguous V21 below;
-        -- leaving it would make the applied-set max 23 and skip the migrate.
+        -- Also drop the later migration rows so `known_version` reads the contiguous V21 below;
+        -- leaving any would make the applied-set max > 21 and skip the migrate. (The artifacts
+        -- those later migrations added — the edges view (V023), files.has_test_code (V024) — can
+        -- stay: their apply fns are idempotent, so the forward-migrate below is a clean no-op for
+        -- the parts already present.)
         DELETE FROM schema_version WHERE id = '023_dispatch_edge_facts_view_exclusion';
+        DELETE FROM schema_version WHERE id = '024_files_has_test_code';
         ",
     )
     .unwrap();
@@ -8881,6 +8885,35 @@ fn v022_forward_migrate_adds_artifacts_to_an_older_index() {
     }
     // The view was rebuilt and surfaces the columns (a SELECT must not fail).
     conn.query_row("SELECT import_mod_id FROM edges LIMIT 1", [], |_| Ok(())).optional().unwrap();
+}
+
+#[test]
+fn files_has_test_code_flag_is_computed_at_index_time() {
+    // #77 V024: the precomputed files.has_test_code flag replaces impact_surface's chunks.text
+    // marker scan. Assert it's set at index time from the file's text (the same marker set the
+    // V024 backfill + test_items use), independent of the path.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    // A test-marker file whose PATH has no 'test'/'spec' — only the flag can classify it.
+    fs::write(root.join("src/markers.rs"), "#[cfg(test)]\nmod inner {\n    pub fn check() {}\n}\n")
+        .unwrap();
+    fs::write(root.join("src/plain.rs"), "pub fn plain_helper() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let flag = |path: &str| -> i64 {
+        db.storage
+            .connection()
+            .query_row("SELECT has_test_code FROM main.files WHERE path = ?1", [path], |row| {
+                row.get(0)
+            })
+            .unwrap()
+    };
+    assert_eq!(flag("src/markers.rs"), 1, "a #[cfg(test)] file gets has_test_code = 1");
+    assert_eq!(flag("src/plain.rs"), 0, "a plain file gets has_test_code = 0");
+
+    let _ = fs::remove_dir_all(&root);
 }
 
 /// End-to-end through the FULL-REBUILD driver (`resolve_and_insert_edges`): a real `rebuild` of a

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -8948,6 +8948,45 @@ fn files_has_test_code_flag_survives_the_heal_path() {
     let _ = fs::remove_dir_all(&root);
 }
 
+#[test]
+fn has_test_code_backfill_is_case_sensitive() {
+    // PR #223 review: the V024 backfill must use the SAME case rules as the index-time
+    // `str::contains` (case-sensitive). SQLite `LIKE` is case-insensitive for ASCII, so it would
+    // set the flag for an uppercase `TEST(` that a freshly-indexed file (whose
+    // `contains("test(")` is false) leaves at 0 — a migrated-vs-reindexed divergence. `instr`
+    // is case-sensitive, so they agree.
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    for (id, path) in [(1, "a.rs"), (2, "b.rs")] {
+        conn.execute(
+            "INSERT INTO files(id, path, language, kind, sha256, modified_at_ms, indexed_at_ms) \
+             VALUES (?1, ?2, 'rust', 'source', 'x', 0, 0)",
+            rusqlite::params![id, path],
+        )
+        .unwrap();
+    }
+    // File 1: a lowercase marker. File 2: only an UPPERCASE non-marker (no lowercase marker).
+    conn.execute(
+        "INSERT INTO chunks(file_id, chunk_kind, start_byte, end_byte, start_line, end_line, \
+         text, text_hash) VALUES (1, 'block', 0, 1, 1, 1, 'fn f() { test() }', 'h1')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO chunks(file_id, chunk_kind, start_byte, end_byte, start_line, end_line, \
+         text, text_hash) VALUES (2, 'block', 0, 1, 1, 1, 'fn g() { TEST() }', 'h2')",
+        [],
+    )
+    .unwrap();
+    conn.execute("UPDATE files SET has_test_code = 0", []).unwrap();
+    schema::apply_files_has_test_code(&conn).unwrap();
+    let flag = |id: i64| -> i64 {
+        conn.query_row("SELECT has_test_code FROM files WHERE id = ?1", [id], |r| r.get(0)).unwrap()
+    };
+    assert_eq!(flag(1), 1, "lowercase test( marks the file");
+    assert_eq!(flag(2), 0, "uppercase TEST( does NOT (case-sensitive, like str::contains)");
+}
+
 /// End-to-end through the FULL-REBUILD driver (`resolve_and_insert_edges`): a real `rebuild` of a
 /// tiny Cargo workspace must apply per-package + module-aware import scope. A bare reference to a
 /// name `use`d from an EXTERNAL crate stays unresolved; a same-named LOCAL workspace symbol still

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -8916,6 +8916,38 @@ fn files_has_test_code_flag_is_computed_at_index_time() {
     let _ = fs::remove_dir_all(&root);
 }
 
+#[test]
+fn files_has_test_code_flag_survives_the_heal_path() {
+    // #77 / PR #223 review: the lazy heal path (heal_file -> index_file) is a SECOND files-insert
+    // site. Without computing the flag there, a marker-only test file healed (e.g. on a lexical
+    // search miss) would drop to has_test_code = 0 and be misclassified as a non-test. Heal must
+    // recompute it from the same chunk markers as the full/incremental path.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    // PATH has no 'test'/'spec' — only the flag can classify it.
+    fs::write(root.join("src/markers.rs"), "#[cfg(test)]\nmod inner {\n    pub fn check() {}\n}\n")
+        .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let flag = || -> i64 {
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT has_test_code FROM main.files WHERE path = 'src/markers.rs'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap()
+    };
+    assert_eq!(flag(), 1, "full index sets has_test_code");
+    db.heal_file(std::path::Path::new("src/markers.rs")).unwrap();
+    assert_eq!(flag(), 1, "heal_file re-indexes through index_file and keeps has_test_code = 1");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
 /// End-to-end through the FULL-REBUILD driver (`resolve_and_insert_edges`): a real `rebuild` of a
 /// tiny Cargo workspace must apply per-package + module-aware import scope. A bare reference to a
 /// name `use`d from an EXTERNAL crate stays unresolved; a same-named LOCAL workspace symbol still

--- a/crates/rag-rat-core/src/index/util.rs
+++ b/crates/rag-rat-core/src/index/util.rs
@@ -15,6 +15,20 @@ pub(crate) fn table_row_count(conn: &rusqlite::Connection, table: &str) -> anyho
     Ok(u64::try_from(count).unwrap_or(0))
 }
 
+/// Whether `text` contains a test marker — the file-level `files.has_test_code` signal that lets
+/// `impact_surface`'s "tests touching this symbol" query filter on an indexed flag instead of a
+/// `chunks.text LIKE` scan (#77). INVARIANT: this marker set MUST match the V024 backfill SQL in
+/// `schema::migrations::apply_files_has_test_code` and `test_items`'s filter, or an incrementally
+/// reindexed file and a forward-migrated one would disagree. (The `it(` / `test(` substrings are
+/// intentionally broad — they reproduce the original `LIKE '%it(%'` / `'%test(%'` behavior exactly,
+/// noise included, so the precomputed flag is a faithful drop-in for the scan it replaces.)
+pub(crate) fn text_has_test_marker(text: &str) -> bool {
+    text.contains("#[cfg(test)]")
+        || text.contains("describe(")
+        || text.contains("it(")
+        || text.contains("test(")
+}
+
 pub(crate) fn file_metadata_ms(path: &Path) -> anyhow::Result<i64> {
     let modified = fs::metadata(path)?.modified()?;
     Ok(duration_ms(modified.duration_since(UNIX_EPOCH)?))

--- a/crates/rag-rat-core/src/query/impact/items.rs
+++ b/crates/rag-rat-core/src/query/impact/items.rs
@@ -131,6 +131,20 @@ pub(crate) fn section_like_items(
     limit: u32,
 ) -> anyhow::Result<Vec<ImpactItem>> {
     let like = format!("%{needle}%");
+    // Chunk-text "mentions" match goes through the `chunk_fts` index (MATCH), NOT a raw
+    // `chunks.text LIKE` full scan — tokenized + indexed, reads no raw text (#77). The FTS subquery
+    // yields chunk file_ids across all scopes; the outer `files` is the active-scope view, so
+    // `files.id IN (...)` keeps only in-scope files. `None` (needle has no token) → omit the
+    // clause. (`LEFT JOIN chunks` stays for now: `test_items`'s filter still references
+    // `chunks.text` for the test-marker detection — replaced by a precomputed
+    // `files.has_test_code` flag in the next step.)
+    let fts = fts_phrase_query(needle);
+    let chunk_clause = if fts.is_some() {
+        "OR files.id IN (SELECT chunks.file_id FROM chunks JOIN chunk_fts ON chunk_fts.rowid = \
+         chunks.id WHERE chunk_fts MATCH ?3)"
+    } else {
+        ""
+    };
     // Collapse to ONE row per file. The previous `LEFT JOIN symbols` without aggregation fanned a
     // file out into one row per symbol whenever the match was file-level (path or chunk text),
     // flooding the output and letting one big file starve the `LIMIT` (see issue #48). Grouping by
@@ -150,15 +164,20 @@ pub(crate) fn section_like_items(
               files.path LIKE ?1
               OR symbols.name LIKE ?1
               OR symbols.qualified_name LIKE ?1
-              OR chunks.text LIKE ?1
+              {chunk_clause}
           )
         GROUP BY files.path, files.language, files.kind
         ORDER BY files.kind, files.path
         LIMIT ?2
         "
     );
+    let limit_param = i64::from(limit);
+    let mut binds: Vec<&dyn rusqlite::ToSql> = vec![&like, &limit_param];
+    if let Some(fts) = &fts {
+        binds.push(fts);
+    }
     let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map(params![like, i64::from(limit)], |row| {
+    let rows = stmt.query_map(rusqlite::params_from_iter(binds), |row| {
         let matched_symbol: Option<String> = row.get(3)?;
         let path_match: i64 = row.get(4)?;
         // Precedence is path > symbol > chunk text. A path match is checked first because a

--- a/crates/rag-rat-core/src/query/impact/items.rs
+++ b/crates/rag-rat-core/src/query/impact/items.rs
@@ -48,15 +48,15 @@ pub(crate) fn test_items(
             &name,
             "Tests touching this symbol/path",
             "test_mentions_symbol_or_path",
+            // Test detection reads the precomputed `files.has_test_code` flag (#77) instead of
+            // scanning `chunks.text` for the markers — same marker set (see
+            // `index::text_has_test_marker`), now an indexed column, no raw-text scan.
             "
             files.kind = 'source'
             AND (
                 files.path LIKE '%test%'
                 OR files.path LIKE '%spec%'
-                OR chunks.text LIKE '%#[cfg(test)]%'
-                OR chunks.text LIKE '%describe(%'
-                OR chunks.text LIKE '%it(%'
-                OR chunks.text LIKE '%test(%'
+                OR files.has_test_code = 1
             )
             ",
             limit,
@@ -135,9 +135,7 @@ pub(crate) fn section_like_items(
     // `chunks.text LIKE` full scan — tokenized + indexed, reads no raw text (#77). The FTS subquery
     // yields chunk file_ids across all scopes; the outer `files` is the active-scope view, so
     // `files.id IN (...)` keeps only in-scope files. `None` (needle has no token) → omit the
-    // clause. (`LEFT JOIN chunks` stays for now: `test_items`'s filter still references
-    // `chunks.text` for the test-marker detection — replaced by a precomputed
-    // `files.has_test_code` flag in the next step.)
+    // clause.
     let fts = fts_phrase_query(needle);
     let chunk_clause = if fts.is_some() {
         "OR files.id IN (SELECT chunks.file_id FROM chunks JOIN chunk_fts ON chunk_fts.rowid = \
@@ -158,7 +156,6 @@ pub(crate) fn section_like_items(
                MAX(CASE WHEN files.path LIKE ?1 THEN 1 ELSE 0 END) AS path_match
         FROM files
         LEFT JOIN symbols ON symbols.file_id = files.id
-        LEFT JOIN chunks ON chunks.file_id = files.id
         WHERE ({filter})
           AND (
               files.path LIKE ?1

--- a/crates/rag-rat-core/src/query/impact/mod.rs
+++ b/crates/rag-rat-core/src/query/impact/mod.rs
@@ -15,6 +15,20 @@ use crate::query::graph::{self, GraphHop, GraphResolutionMode, GraphTraversalOpt
 use crate::query::memory::{self, CompactRepoMemoryEvidence, RepoMemoryEvidence};
 use crate::query::symbol::SymbolHit;
 
+/// An FTS5 phrase query for `needle` (a symbol name / qualified name / path), or `None` when it has
+/// no alphanumeric token. Used to find chunks that MENTION the needle through the `chunk_fts` index
+/// instead of a raw `chunks.text LIKE '%needle%'` full-table scan — same intent, but tokenized +
+/// indexed, and it never reads raw chunk text (so it stays fast and survives #77 text compression).
+/// Wrapped as a quoted FTS5 phrase (embedded `"` doubled) so `::`, `(`, `<`, etc. in a symbol name
+/// tokenize as separators rather than parse as FTS query syntax. Semantics shift substring→token —
+/// more precise for "mentions this symbol" than a substring match.
+pub(super) fn fts_phrase_query(needle: &str) -> Option<String> {
+    if !needle.chars().any(char::is_alphanumeric) {
+        return None;
+    }
+    Some(format!("\"{}\"", needle.replace('"', "\"\"")))
+}
+
 #[derive(Debug, Serialize)]
 pub struct ImpactItem {
     pub path: String,

--- a/crates/rag-rat-core/src/query/impact/neighbors.rs
+++ b/crates/rag-rat-core/src/query/impact/neighbors.rs
@@ -225,27 +225,44 @@ pub(crate) fn textual_fallback(
         return Ok(());
     }
     let like = format!("%{query}%");
-    let mut stmt = conn.prepare(
+    // Chunk-text fallback goes through the `chunk_fts` index (MATCH), not a raw `chunks.text LIKE`
+    // full scan — tokenized + indexed, reads no raw text (#77). The FTS subquery yields chunk
+    // file_ids across all scopes; the outer `files` is the active-scope view, so `files.id IN
+    // (...)` keeps only in-scope files. `None` (no token) → omit the clause. No `LEFT JOIN
+    // chunks` needed.
+    let fts = fts_phrase_query(query);
+    let chunk_clause = if fts.is_some() {
+        "OR files.id IN (SELECT chunks.file_id FROM chunks JOIN chunk_fts ON chunk_fts.rowid = \
+         chunks.id WHERE chunk_fts MATCH ?3)"
+    } else {
+        ""
+    };
+    let sql = format!(
         "
         SELECT DISTINCT files.path, files.language, files.kind, symbols.qualified_name,
                CASE
                    WHEN files.path LIKE ?1 THEN 'path LIKE fallback'
                    WHEN symbols.name LIKE ?1 OR symbols.qualified_name LIKE ?1 THEN 'symbol LIKE \
          fallback'
-                   ELSE 'chunk text LIKE fallback'
+                   ELSE 'chunk text match fallback'
                END
         FROM files
         LEFT JOIN symbols ON symbols.file_id = files.id
-        LEFT JOIN chunks ON chunks.file_id = files.id
         WHERE files.path LIKE ?1
            OR symbols.name LIKE ?1
            OR symbols.qualified_name LIKE ?1
-           OR chunks.text LIKE ?1
+           {chunk_clause}
         ORDER BY files.kind, files.path, symbols.qualified_name
         LIMIT ?2
-        ",
-    )?;
-    let rows = stmt.query_map(params![like, i64::try_from(limit).unwrap_or(i64::MAX)], |row| {
+        "
+    );
+    let limit_param = i64::try_from(limit).unwrap_or(i64::MAX);
+    let mut binds: Vec<&dyn rusqlite::ToSql> = vec![&like, &limit_param];
+    if let Some(fts) = &fts {
+        binds.push(fts);
+    }
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(rusqlite::params_from_iter(binds), |row| {
         Ok((
             FileSymbol {
                 path: row.get(0)?,


### PR DESCRIPTION
## Summary

`impact_surface` matched chunk mentions and detected test files with **global `chunks.text LIKE` scans** — full reads of the heaviest column on every call. This removes them: chunk mentions go through the `chunk_fts` index, and test detection reads a precomputed flag. `impact_surface` no longer scans raw `chunks.text` at all.

Part of #77 (Phase 1). It's an independent `impact_surface` speedup, and the prerequisite for #77's chunk-text compression: with raw `chunks.text` now only read-and-returned + FTS-external-content, the heavy column can be compressed (Phase 2, a `chunk_text` sister table) without forcing per-row decompression on a hot scan.

## Changes

- **Needle/mentions match → `chunk_fts MATCH`** (`section_like_items`, `neighbors::textual_fallback`). New shared `fts_phrase_query` helper builds a quoted FTS5 phrase; the subquery yields chunk file_ids across scopes and the outer (scope-view) `files.id IN (...)` keeps only in-scope files. Semantics shift substring→token for chunk mentions (more precise; path + symbol matches unchanged). `neighbors` drops its now-unused `LEFT JOIN chunks`.
- **Test detection → `files.has_test_code`** (precomputed flag). Migration **V024** adds the column (baseline + forward-migrate) with a one-time backfill from existing chunk text, so a migrated index matches a freshly-indexed one immediately. The flag is computed in `insert_prepared_file` from the chunk text already held; the marker set lives in `index::text_has_test_marker`, kept in sync with the V024 backfill SQL and `test_items`'s filter (invariant noted in code). `test_items` filters on the flag; the `chunks.text` marker LIKEs and the last `LEFT JOIN chunks` are gone. The scope view (`install_scope_view`) carries the new column.

## Tests

577 core tests pass; clippy clean; workspace builds. New: `files_has_test_code_flag_is_computed_at_index_time`; existing impact + schema migration tests (incl. the V024 forward-migrate convergence) updated and green.

## Not in this PR

Phase 2 (compress `chunks.text` via a `chunk_text(chunk_id, text_zstd)` sister table + dictionary zstd, benchmark-gated) is deferred — design captured on #77.
