### PR TITLE
feat(index): dictionary-zstd chunk-text compression + drop chunks.text (#77 Phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -2487,6 +2489,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3190,6 +3202,7 @@ dependencies = [
  "tree-sitter-rust",
  "tree-sitter-typescript",
  "ureq 2.12.1",
+ "zstd",
 ]
 
 [[package]]
@@ -5136,3 +5149,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -35,9 +35,7 @@ pub(crate) fn index(config: &Config, args: &IndexArgs) -> anyhow::Result<()> {
     }
     // Serialize with the background watcher / other writers (busy_timeout backstops any heal on
     // the query path).
-    let _lock = rag_rat_core::locks::FileLock::acquire_blocking(
-        &rag_rat_core::locks::write_lock_path(&config.database),
-    )?;
+    let _lock = rag_rat_core::locks::WriteLock::acquire_blocking(&config.database)?;
     // `--worktree`: index a linked worktree's branch overlay on top of the existing base index
     // (#219). A distinct mode — the delta vs the base, not a base (re)build — so handle it before
     // the full/discover/changed branches.
@@ -260,9 +258,7 @@ pub(crate) fn with_oracle_write_lock<T>(
     config: &Config,
     body: impl FnOnce(&IndexDatabase) -> anyhow::Result<T>,
 ) -> anyhow::Result<T> {
-    let _lock = rag_rat_core::locks::FileLock::acquire_blocking(
-        &rag_rat_core::locks::write_lock_path(&config.database),
-    )?;
+    let _lock = rag_rat_core::locks::WriteLock::acquire_blocking(&config.database)?;
     let db = open_index(config)?;
     body(&db)
 }
@@ -1075,9 +1071,7 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
     // Serialize with the background watcher (and other writers). The hook backgrounds this command,
     // so blocking here never holds up the git operation; busy_timeout backstops the query-path
     // heal.
-    let _lock = rag_rat_core::locks::FileLock::acquire_blocking(
-        &rag_rat_core::locks::write_lock_path(&config.database),
-    )?;
+    let _lock = rag_rat_core::locks::WriteLock::acquire_blocking(&config.database)?;
 
     let mut db = IndexDatabase::index_discover_with_progress(config, render_index_progress)?;
     // ONE time budget for the whole pass — the per-overlay embedding reconciles AND the base

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -34,6 +34,9 @@ thiserror.workspace = true
 toml.workspace = true
 toon-format.workspace = true
 ureq.workspace = true
+# Dictionary-trained zstd compression of stored chunk text (#77 Phase 2). One shared dictionary
+# trained on a corpus sample (zdict_builder) + bulk one-shot compress/decompress per chunk blob.
+zstd = "0.13"
 tree-sitter.workspace = true
 tree-sitter-c.workspace = true
 tree-sitter-cpp.workspace = true

--- a/crates/rag-rat-core/src/eval.rs
+++ b/crates/rag-rat-core/src/eval.rs
@@ -651,19 +651,17 @@ fn find_current_source_violations(
     db: &IndexDatabase,
     hits: &[crate::search::lexical::SearchHit],
 ) -> anyhow::Result<Vec<CurrentSourceViolation>> {
-    // One dict-bound decompressor for the whole hit set; `read_chunk_current_with` reuses it
-    // instead of reloading the ~112 KB dict per hit (#77 Phase 2). This also drops the graph +
-    // memory work the public `read_chunk` would do — the violation check only reads
-    // path/text/line span.
-    let dict = db.chunk_text_dict()?.unwrap_or_default();
-    let mut decompressor = crate::index::text_compression::ChunkDecompressor::new(&dict)?;
+    // `read_chunk_current` builds its own dict decoder per call; this eval pass is a cold CLI
+    // diagnostic (not the hot retrieval path), so the per-call dict load is fine. It also drops the
+    // graph + memory work the public `read_chunk` would do — the violation check only reads
+    // path/text/line span (#77 Phase 2).
     let mut violations = Vec::new();
     let mut checked = BTreeSet::new();
     for hit in hits {
         if !checked.insert(hit.chunk_id) {
             continue;
         }
-        match db.read_chunk_current_with(hit.chunk_id, &mut decompressor) {
+        match db.read_chunk_current(hit.chunk_id) {
             Ok(Some(chunk)) => {
                 let source_path = config.root.join(&chunk.path);
                 match fs::read_to_string(&source_path) {

--- a/crates/rag-rat-core/src/eval.rs
+++ b/crates/rag-rat-core/src/eval.rs
@@ -351,12 +351,12 @@ fn evaluate_query(
     let started = Instant::now();
     let mut hits = search(db, mode, &query.text)?;
     let mut latency_ms = started.elapsed().as_secs_f64() * 1000.0;
-    let mut current_source_violations = find_current_source_violations(config, db, &hits);
+    let mut current_source_violations = find_current_source_violations(config, db, &hits)?;
     if !current_source_violations.is_empty() {
         let retry_started = Instant::now();
         hits = search(db, mode, &query.text)?;
         latency_ms += retry_started.elapsed().as_secs_f64() * 1000.0;
-        current_source_violations = find_current_source_violations(config, db, &hits);
+        current_source_violations = find_current_source_violations(config, db, &hits)?;
     }
     let top_hits = top_hits(&hits);
 
@@ -650,14 +650,20 @@ fn find_current_source_violations(
     config: &Config,
     db: &IndexDatabase,
     hits: &[crate::search::lexical::SearchHit],
-) -> Vec<CurrentSourceViolation> {
+) -> anyhow::Result<Vec<CurrentSourceViolation>> {
+    // One dict-bound decompressor for the whole hit set; `read_chunk_current_with` reuses it
+    // instead of reloading the ~112 KB dict per hit (#77 Phase 2). This also drops the graph +
+    // memory work the public `read_chunk` would do — the violation check only reads
+    // path/text/line span.
+    let dict = db.chunk_text_dict()?.unwrap_or_default();
+    let mut decompressor = crate::index::text_compression::ChunkDecompressor::new(&dict)?;
     let mut violations = Vec::new();
     let mut checked = BTreeSet::new();
     for hit in hits {
         if !checked.insert(hit.chunk_id) {
             continue;
         }
-        match db.read_chunk(hit.chunk_id) {
+        match db.read_chunk_current_with(hit.chunk_id, &mut decompressor) {
             Ok(Some(chunk)) => {
                 let source_path = config.root.join(&chunk.path);
                 match fs::read_to_string(&source_path) {
@@ -691,7 +697,7 @@ fn find_current_source_violations(
             }),
         }
     }
-    violations
+    Ok(violations)
 }
 
 fn slice_lines(source: &str, start_line: i64, end_line: i64) -> Option<String> {

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -512,12 +512,11 @@ pub(crate) fn reconcile_with_options_progress(
         if options.force { "" } else { scan.model_id },
         options.changed_first,
     )?;
-    // One dict-bound decompressor for the whole run: each `select_reconcile_batch` loads text for
-    // its batch from the compressed `chunk_text` store (#77 Phase 2), and reusing this
-    // decompressor keeps the ~112 KB dict SELECT + dictionary prep to once per run rather than
-    // once per batch.
-    let dict = crate::query::chunk_text_dict(conn)?;
-    let mut decompressor = crate::index::text_compression::ChunkDecompressor::new(&dict)?;
+    // One dict decoder for the whole run: each `select_reconcile_batch` loads text for its batch
+    // from the compressed `chunk_text` store (#77 Phase 2), and reusing this decoder keeps the dict
+    // SELECT + dictionary prep to once per run rather than once per batch.
+    let dicts = crate::query::chunk_text_dicts(conn)?;
+    let mut decoder = crate::index::text_compression::ChunkTextDecoder::new(&dicts);
     let mut cursor = 0usize;
     let mut processed_ids: HashSet<i64> = HashSet::new();
     let mut remaining = options.limit.map(u64::from);
@@ -549,8 +548,7 @@ pub(crate) fn reconcile_with_options_progress(
         if batch_ids.is_empty() {
             break; // candidate list exhausted
         }
-        let selected =
-            select_reconcile_batch(conn, &scan, &batch_ids, &options, &mut decompressor)?;
+        let selected = select_reconcile_batch(conn, &scan, &batch_ids, &options, &mut decoder)?;
         if selected.jobs.is_empty() {
             // Every id in this batch was filtered (ineligible/already current); keep walking the
             // rest of the candidate list rather than stopping.
@@ -677,19 +675,18 @@ pub(crate) fn embedding_policy_skip_summary(
     // (and `reconcile_plan`), so it dominated `index --full` peak memory. The same
     // `embedding_policy_for_chunk` runs over the same chunks, so the counts are identical.
     //
-    // Chunk text comes from the compressed `chunk_text` store (#77 Phase 2); `chunks.text` is the
-    // LEFT-JOIN fallback for a chunk with no blob yet. One dict-bound decompressor for the whole
-    // stream (dict loaded once, reused per row). The old `WHERE chunks.text IS NOT NULL` was
-    // vacuous (text is NOT NULL in the schema), so it's dropped.
-    let dict = crate::query::chunk_text_dict(conn)?;
-    let mut decompressor = crate::index::text_compression::ChunkDecompressor::new(&dict)?;
+    // Chunk text comes from the compressed `chunk_text` store (#77 Phase 2); the `chunks.text`
+    // column is gone, so INNER JOIN `chunk_text` (every live chunk has one blob). One dict decoder
+    // for the whole stream (versions loaded once, reused per row).
+    let dicts = crate::query::chunk_text_dicts(conn)?;
+    let mut decoder = crate::index::text_compression::ChunkTextDecoder::new(&dicts);
     let mut stmt = conn.prepare(
         "
         SELECT files.path, files.language, files.kind, chunks.chunk_kind, chunks.symbol_path,
-               chunks.text, chunk_text.blob, chunk_text.raw_len
+               chunk_text.blob, chunk_text.raw_len, chunk_text.dict_version
         FROM chunks
         JOIN files ON files.id = chunks.file_id
-        LEFT JOIN chunk_text ON chunk_text.chunk_id = chunks.id
+        JOIN chunk_text ON chunk_text.chunk_id = chunks.id
         ",
     )?;
     let mut rows = stmt.query([])?;
@@ -700,11 +697,11 @@ pub(crate) fn embedding_policy_skip_summary(
         let chunk_kind = row.get::<_, String>(3)?;
         let symbol_path = row.get::<_, Option<String>>(4)?;
         let text = crate::index::text_compression::ChunkTextRow {
-            fallback: row.get(5)?,
-            blob: row.get(6)?,
-            raw_len: row.get(7)?,
+            blob: row.get(5)?,
+            raw_len: row.get(6)?,
+            dict_version: row.get(7)?,
         }
-        .resolve(&mut decompressor)?;
+        .resolve(&mut decoder)?;
         let decision = embedding_policy_for_chunk(
             std::path::Path::new(&path),
             &language,

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -512,6 +512,12 @@ pub(crate) fn reconcile_with_options_progress(
         if options.force { "" } else { scan.model_id },
         options.changed_first,
     )?;
+    // One dict-bound decompressor for the whole run: each `select_reconcile_batch` loads text for
+    // its batch from the compressed `chunk_text` store (#77 Phase 2), and reusing this
+    // decompressor keeps the ~112 KB dict SELECT + dictionary prep to once per run rather than
+    // once per batch.
+    let dict = crate::query::chunk_text_dict(conn)?;
+    let mut decompressor = crate::index::text_compression::ChunkDecompressor::new(&dict)?;
     let mut cursor = 0usize;
     let mut processed_ids: HashSet<i64> = HashSet::new();
     let mut remaining = options.limit.map(u64::from);
@@ -543,7 +549,8 @@ pub(crate) fn reconcile_with_options_progress(
         if batch_ids.is_empty() {
             break; // candidate list exhausted
         }
-        let selected = select_reconcile_batch(conn, &scan, &batch_ids, &options)?;
+        let selected =
+            select_reconcile_batch(conn, &scan, &batch_ids, &options, &mut decompressor)?;
         if selected.jobs.is_empty() {
             // Every id in this batch was filtered (ineligible/already current); keep walking the
             // rest of the candidate list rather than stopping.
@@ -667,16 +674,22 @@ pub(crate) fn embedding_policy_skip_summary(
     // The previous `current_chunks(conn, None)` loaded ALL chunk rows — including each chunk's full
     // `text` — into a `Vec` just to produce this count. On a kernel-sized index (~4.2M chunks) that
     // is ~4 GB resident for a summary that keeps nothing per row, and it runs on every reconcile
-    // (and `reconcile_plan`), so it dominated `index --full` peak memory. Same WHERE filter
-    // (`chunks.text IS NOT NULL`) and the same `embedding_policy_for_chunk`, so the counts are
-    // identical; only the column set is leaner (no `chunk_embeddings` join — policy ignores it).
+    // (and `reconcile_plan`), so it dominated `index --full` peak memory. The same
+    // `embedding_policy_for_chunk` runs over the same chunks, so the counts are identical.
+    //
+    // Chunk text comes from the compressed `chunk_text` store (#77 Phase 2); `chunks.text` is the
+    // LEFT-JOIN fallback for a chunk with no blob yet. One dict-bound decompressor for the whole
+    // stream (dict loaded once, reused per row). The old `WHERE chunks.text IS NOT NULL` was
+    // vacuous (text is NOT NULL in the schema), so it's dropped.
+    let dict = crate::query::chunk_text_dict(conn)?;
+    let mut decompressor = crate::index::text_compression::ChunkDecompressor::new(&dict)?;
     let mut stmt = conn.prepare(
         "
         SELECT files.path, files.language, files.kind, chunks.chunk_kind, chunks.symbol_path,
-               chunks.text
+               chunks.text, chunk_text.blob, chunk_text.raw_len
         FROM chunks
         JOIN files ON files.id = chunks.file_id
-        WHERE chunks.text IS NOT NULL
+        LEFT JOIN chunk_text ON chunk_text.chunk_id = chunks.id
         ",
     )?;
     let mut rows = stmt.query([])?;
@@ -686,7 +699,12 @@ pub(crate) fn embedding_policy_skip_summary(
         let file_kind = row.get::<_, String>(2)?;
         let chunk_kind = row.get::<_, String>(3)?;
         let symbol_path = row.get::<_, Option<String>>(4)?;
-        let text = row.get::<_, String>(5)?;
+        let text = crate::index::text_compression::ChunkTextRow {
+            fallback: row.get(5)?,
+            blob: row.get(6)?,
+            raw_len: row.get(7)?,
+        }
+        .resolve(&mut decompressor)?;
         let decision = embedding_policy_for_chunk(
             std::path::Path::new(&path),
             &language,

--- a/crates/rag-rat-core/src/index/ai/store.rs
+++ b/crates/rag-rat-core/src/index/ai/store.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::index::text_compression::{ChunkDecompressor, ChunkTextRow};
+use crate::index::text_compression::{ChunkTextDecoder, ChunkTextRow};
 
 pub(crate) fn current_chunks(
     conn: &Connection,
@@ -9,11 +9,11 @@ pub(crate) fn current_chunks(
 }
 
 /// Map one candidate row to its `CurrentChunk` (with a placeholder `text`) plus the
-/// [`ChunkTextRow`] carrying the chunk's stored text (compressed `chunk_text` blob + `raw_len`,
-/// with `chunks.text` as the mid-migration fallback). The real `text` is filled in a post-loop via
-/// [`ChunkTextRow::resolve`] — decompress returns `anyhow::Result`, which can't cross this rusqlite
-/// closure (#77 Phase 2). The SELECT order is: 0-5 identity, 6 chunks.text (fallback), 7-14
-/// embedding metadata, 15 blob, 16 raw_len.
+/// [`ChunkTextRow`] carrying the chunk's stored text (the compressed `chunk_text` blob + `raw_len`;
+/// the `chunks.text` column is gone, so the SELECT INNER JOINs `chunk_text`). The real `text` is
+/// filled in a post-loop via [`ChunkTextRow::resolve`] — decompress returns `anyhow::Result`, which
+/// can't cross this rusqlite closure (#77 Phase 2). The SELECT order is: 0-5 identity, 6-13
+/// embedding metadata, 14 blob, 15 raw_len, 16 dict_version.
 pub(crate) fn current_chunk_row(
     row: &rusqlite::Row<'_>,
 ) -> rusqlite::Result<(CurrentChunk, ChunkTextRow)> {
@@ -25,18 +25,18 @@ pub(crate) fn current_chunk_row(
         chunk_kind: row.get(4)?,
         symbol_path: row.get(5)?,
         text: String::new(),
-        text_hash: row.get(7)?,
-        embedding_status: row.get(8)?,
-        source_text_hash: row.get(9)?,
-        model_version: row.get(10)?,
-        embedding_dim: row.get(11)?,
-        input_hash: row.get(12)?,
-        embedding_text_version: row.get(13)?,
-        next_retry_after_ms: row.get(14)?,
+        text_hash: row.get(6)?,
+        embedding_status: row.get(7)?,
+        source_text_hash: row.get(8)?,
+        model_version: row.get(9)?,
+        embedding_dim: row.get(10)?,
+        input_hash: row.get(11)?,
+        embedding_text_version: row.get(12)?,
+        next_retry_after_ms: row.get(13)?,
         reason: ReconcileReason::Forced,
     };
     let text_row =
-        ChunkTextRow { fallback: row.get(6)?, blob: row.get(15)?, raw_len: row.get(16)? };
+        ChunkTextRow { blob: row.get(14)?, raw_len: row.get(15)?, dict_version: row.get(16)? };
     Ok((chunk, text_row))
 }
 
@@ -53,10 +53,9 @@ pub(crate) fn embedding_job_candidates(
     } else {
         "chunks.embedding_priority ASC,"
     };
-    // Chunk text comes from the compressed `chunk_text` store (#77 Phase 2); `chunks.text` stays in
-    // the SELECT as the LEFT-JOIN fallback for a chunk with no blob yet (mid-migration /
-    // incremental before a dict existed). The old `WHERE chunks.text IS NOT NULL` was vacuous
-    // (text is NOT NULL in the schema), so it's dropped.
+    // Chunk text comes from the compressed `chunk_text` store (#77 Phase 2); the `chunks.text`
+    // column is gone, so INNER JOIN `chunk_text` (every live chunk has exactly one blob). The old
+    // `WHERE chunks.text IS NOT NULL` was already dropped as vacuous.
     let sql = format!(
         "
         SELECT chunks.id,
@@ -65,7 +64,6 @@ pub(crate) fn embedding_job_candidates(
                files.kind,
                chunks.chunk_kind,
                chunks.symbol_path,
-               chunks.text,
                chunks.text_hash,
                chunk_embeddings.status,
                chunk_embeddings.source_text_hash,
@@ -75,13 +73,14 @@ pub(crate) fn embedding_job_candidates(
                chunk_embeddings.embedding_text_version,
                chunk_embeddings.next_retry_after_ms,
                chunk_text.blob,
-               chunk_text.raw_len
+               chunk_text.raw_len,
+               chunk_text.dict_version
         FROM chunks
         JOIN files ON files.id = chunks.file_id
         LEFT JOIN chunk_embeddings
           ON chunk_embeddings.chunk_id = chunks.id
          AND chunk_embeddings.model_id = ?1
-        LEFT JOIN chunk_text ON chunk_text.chunk_id = chunks.id
+        JOIN chunk_text ON chunk_text.chunk_id = chunks.id
         ORDER BY
           CASE
             WHEN chunk_embeddings.chunk_id IS NULL THEN 0
@@ -105,14 +104,14 @@ pub(crate) fn embedding_job_candidates(
         ],
         current_chunk_row,
     )?;
-    // Decompress in a post-loop with a single dict-bound decompressor (dict loaded once per call,
-    // not per row) — decompress's anyhow::Result can't cross the rusqlite closure above.
+    // Decompress in a post-loop with a single dict decoder (versions loaded once per call, not per
+    // row) — decompress's anyhow::Result can't cross the rusqlite closure above.
     let collected = collect_rows(rows)?;
-    let dict = crate::query::chunk_text_dict(conn)?;
-    let mut decompressor = ChunkDecompressor::new(&dict)?;
+    let dicts = crate::query::chunk_text_dicts(conn)?;
+    let mut decoder = ChunkTextDecoder::new(&dicts);
     let mut chunks = Vec::with_capacity(collected.len());
     for (mut chunk, text_row) in collected {
-        chunk.text = text_row.resolve(&mut decompressor)?;
+        chunk.text = text_row.resolve(&mut decoder)?;
         if !model_id.is_empty() {
             chunk.reason = ReconcileReason::Missing;
         }
@@ -168,31 +167,31 @@ pub(crate) fn current_chunks_by_ids(
     conn: &Connection,
     model_id: &str,
     ids: &[i64],
-    decompressor: &mut ChunkDecompressor,
+    decoder: &mut ChunkTextDecoder,
 ) -> anyhow::Result<Vec<CurrentChunk>> {
     if ids.is_empty() {
         return Ok(Vec::new());
     }
     let placeholders = vec!["?"; ids.len()].join(",");
-    // Chunk text comes from the compressed `chunk_text` store (#77 Phase 2); `chunks.text` is the
-    // LEFT-JOIN fallback for a chunk with no blob yet. The caller reuses one dict-bound
-    // `decompressor` across all batches of a run, so the dict is loaded once per run (not per
-    // batch).
+    // Chunk text comes from the compressed `chunk_text` store (#77 Phase 2); the `chunks.text`
+    // column is gone, so INNER JOIN `chunk_text` (every live chunk has one blob). The caller reuses
+    // one dict `decoder` across all batches of a run, so the dict versions are loaded once per run
+    // (not per batch).
     let sql = format!(
         "
         SELECT chunks.id, files.path, files.language, files.kind, chunks.chunk_kind,
-               chunks.symbol_path, chunks.text, chunks.text_hash,
+               chunks.symbol_path, chunks.text_hash,
                chunk_embeddings.status, chunk_embeddings.source_text_hash,
                chunk_embeddings.model_version, chunk_embeddings.embedding_dim,
                chunk_embeddings.input_hash, chunk_embeddings.embedding_text_version,
                chunk_embeddings.next_retry_after_ms,
-               chunk_text.blob, chunk_text.raw_len
+               chunk_text.blob, chunk_text.raw_len, chunk_text.dict_version
         FROM chunks
         JOIN files ON files.id = chunks.file_id
         LEFT JOIN chunk_embeddings
           ON chunk_embeddings.chunk_id = chunks.id
          AND chunk_embeddings.model_id = ?1
-        LEFT JOIN chunk_text ON chunk_text.chunk_id = chunks.id
+        JOIN chunk_text ON chunk_text.chunk_id = chunks.id
         WHERE chunks.id IN ({placeholders})
         "
     );
@@ -208,7 +207,7 @@ pub(crate) fn current_chunks_by_ids(
     let mut by_id: std::collections::HashMap<i64, CurrentChunk> =
         std::collections::HashMap::with_capacity(ids.len());
     for (mut chunk, text_row) in collect_rows(rows)? {
-        chunk.text = text_row.resolve(decompressor)?;
+        chunk.text = text_row.resolve(decoder)?;
         if !model_id.is_empty() {
             chunk.reason = ReconcileReason::Missing;
         }
@@ -259,12 +258,12 @@ pub(crate) fn select_reconcile_batch(
     scan: &EmbeddingScan<'_>,
     ids: &[i64],
     options: &ReconcileOptions,
-    decompressor: &mut ChunkDecompressor,
+    decoder: &mut ChunkTextDecoder,
 ) -> anyhow::Result<SelectedBatch> {
     // Under --force the candidate ordering does not reflect embedding state, so the empty model_id
     // (matching no chunk_embeddings) keeps every chunk's reason as Forced.
     let model_id = if options.force { "" } else { scan.model_id };
-    let candidates = current_chunks_by_ids(conn, model_id, ids, decompressor)?;
+    let candidates = current_chunks_by_ids(conn, model_id, ids, decoder)?;
     let mut jobs = Vec::new();
     for candidate in candidates {
         let policy = policy_for_job(&candidate, scan.max_embedding_chars);

--- a/crates/rag-rat-core/src/index/ai/store.rs
+++ b/crates/rag-rat-core/src/index/ai/store.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::index::text_compression::{ChunkDecompressor, ChunkTextRow};
 
 pub(crate) fn current_chunks(
     conn: &Connection,
@@ -7,15 +8,23 @@ pub(crate) fn current_chunks(
     embedding_job_candidates(conn, "", "", 0, limit, false)
 }
 
-pub(crate) fn current_chunk_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CurrentChunk> {
-    Ok(CurrentChunk {
+/// Map one candidate row to its `CurrentChunk` (with a placeholder `text`) plus the
+/// [`ChunkTextRow`] carrying the chunk's stored text (compressed `chunk_text` blob + `raw_len`,
+/// with `chunks.text` as the mid-migration fallback). The real `text` is filled in a post-loop via
+/// [`ChunkTextRow::resolve`] — decompress returns `anyhow::Result`, which can't cross this rusqlite
+/// closure (#77 Phase 2). The SELECT order is: 0-5 identity, 6 chunks.text (fallback), 7-14
+/// embedding metadata, 15 blob, 16 raw_len.
+pub(crate) fn current_chunk_row(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<(CurrentChunk, ChunkTextRow)> {
+    let chunk = CurrentChunk {
         id: row.get(0)?,
         path: row.get(1)?,
         language: row.get(2)?,
         file_kind: row.get(3)?,
         chunk_kind: row.get(4)?,
         symbol_path: row.get(5)?,
-        text: row.get(6)?,
+        text: String::new(),
         text_hash: row.get(7)?,
         embedding_status: row.get(8)?,
         source_text_hash: row.get(9)?,
@@ -25,7 +34,10 @@ pub(crate) fn current_chunk_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Cur
         embedding_text_version: row.get(13)?,
         next_retry_after_ms: row.get(14)?,
         reason: ReconcileReason::Forced,
-    })
+    };
+    let text_row =
+        ChunkTextRow { fallback: row.get(6)?, blob: row.get(15)?, raw_len: row.get(16)? };
+    Ok((chunk, text_row))
 }
 
 pub(crate) fn embedding_job_candidates(
@@ -41,6 +53,10 @@ pub(crate) fn embedding_job_candidates(
     } else {
         "chunks.embedding_priority ASC,"
     };
+    // Chunk text comes from the compressed `chunk_text` store (#77 Phase 2); `chunks.text` stays in
+    // the SELECT as the LEFT-JOIN fallback for a chunk with no blob yet (mid-migration /
+    // incremental before a dict existed). The old `WHERE chunks.text IS NOT NULL` was vacuous
+    // (text is NOT NULL in the schema), so it's dropped.
     let sql = format!(
         "
         SELECT chunks.id,
@@ -57,13 +73,15 @@ pub(crate) fn embedding_job_candidates(
                chunk_embeddings.embedding_dim,
                chunk_embeddings.input_hash,
                chunk_embeddings.embedding_text_version,
-               chunk_embeddings.next_retry_after_ms
+               chunk_embeddings.next_retry_after_ms,
+               chunk_text.blob,
+               chunk_text.raw_len
         FROM chunks
         JOIN files ON files.id = chunks.file_id
         LEFT JOIN chunk_embeddings
           ON chunk_embeddings.chunk_id = chunks.id
          AND chunk_embeddings.model_id = ?1
-        WHERE chunks.text IS NOT NULL
+        LEFT JOIN chunk_text ON chunk_text.chunk_id = chunks.id
         ORDER BY
           CASE
             WHEN chunk_embeddings.chunk_id IS NULL THEN 0
@@ -87,11 +105,18 @@ pub(crate) fn embedding_job_candidates(
         ],
         current_chunk_row,
     )?;
-    let mut chunks = collect_rows(rows)?;
-    if !model_id.is_empty() {
-        for chunk in &mut chunks {
+    // Decompress in a post-loop with a single dict-bound decompressor (dict loaded once per call,
+    // not per row) — decompress's anyhow::Result can't cross the rusqlite closure above.
+    let collected = collect_rows(rows)?;
+    let dict = crate::query::chunk_text_dict(conn)?;
+    let mut decompressor = ChunkDecompressor::new(&dict)?;
+    let mut chunks = Vec::with_capacity(collected.len());
+    for (mut chunk, text_row) in collected {
+        chunk.text = text_row.resolve(&mut decompressor)?;
+        if !model_id.is_empty() {
             chunk.reason = ReconcileReason::Missing;
         }
+        chunks.push(chunk);
     }
     Ok(chunks)
 }
@@ -119,7 +144,6 @@ pub(crate) fn embedding_candidate_ids(
         LEFT JOIN chunk_embeddings
           ON chunk_embeddings.chunk_id = chunks.id
          AND chunk_embeddings.model_id = ?1
-        WHERE chunks.text IS NOT NULL
         ORDER BY
           CASE
             WHEN chunk_embeddings.chunk_id IS NULL THEN 0
@@ -144,11 +168,16 @@ pub(crate) fn current_chunks_by_ids(
     conn: &Connection,
     model_id: &str,
     ids: &[i64],
+    decompressor: &mut ChunkDecompressor,
 ) -> anyhow::Result<Vec<CurrentChunk>> {
     if ids.is_empty() {
         return Ok(Vec::new());
     }
     let placeholders = vec!["?"; ids.len()].join(",");
+    // Chunk text comes from the compressed `chunk_text` store (#77 Phase 2); `chunks.text` is the
+    // LEFT-JOIN fallback for a chunk with no blob yet. The caller reuses one dict-bound
+    // `decompressor` across all batches of a run, so the dict is loaded once per run (not per
+    // batch).
     let sql = format!(
         "
         SELECT chunks.id, files.path, files.language, files.kind, chunks.chunk_kind,
@@ -156,12 +185,14 @@ pub(crate) fn current_chunks_by_ids(
                chunk_embeddings.status, chunk_embeddings.source_text_hash,
                chunk_embeddings.model_version, chunk_embeddings.embedding_dim,
                chunk_embeddings.input_hash, chunk_embeddings.embedding_text_version,
-               chunk_embeddings.next_retry_after_ms
+               chunk_embeddings.next_retry_after_ms,
+               chunk_text.blob, chunk_text.raw_len
         FROM chunks
         JOIN files ON files.id = chunks.file_id
         LEFT JOIN chunk_embeddings
           ON chunk_embeddings.chunk_id = chunks.id
          AND chunk_embeddings.model_id = ?1
+        LEFT JOIN chunk_text ON chunk_text.chunk_id = chunks.id
         WHERE chunks.id IN ({placeholders})
         "
     );
@@ -170,15 +201,18 @@ pub(crate) fn current_chunks_by_ids(
     bind.extend(ids.iter().map(|id| Value::Integer(*id)));
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(params_from_iter(bind), current_chunk_row)?;
-    let mut by_id: std::collections::HashMap<i64, CurrentChunk> =
-        collect_rows(rows)?.into_iter().map(|chunk| (chunk.id, chunk)).collect();
+    // Decompress in a post-loop — decompress's anyhow::Result can't cross the rusqlite closure.
     // Mirror embedding_job_candidates: a non-empty model_id means this is a real (non-force) run,
     // so the default reason is Missing (the precise reason is recomputed in
     // select_reconcile_batch).
-    if !model_id.is_empty() {
-        for chunk in by_id.values_mut() {
+    let mut by_id: std::collections::HashMap<i64, CurrentChunk> =
+        std::collections::HashMap::with_capacity(ids.len());
+    for (mut chunk, text_row) in collect_rows(rows)? {
+        chunk.text = text_row.resolve(decompressor)?;
+        if !model_id.is_empty() {
             chunk.reason = ReconcileReason::Missing;
         }
+        by_id.insert(chunk.id, chunk);
     }
     Ok(ids.iter().filter_map(|id| by_id.remove(id)).collect())
 }
@@ -225,11 +259,12 @@ pub(crate) fn select_reconcile_batch(
     scan: &EmbeddingScan<'_>,
     ids: &[i64],
     options: &ReconcileOptions,
+    decompressor: &mut ChunkDecompressor,
 ) -> anyhow::Result<SelectedBatch> {
     // Under --force the candidate ordering does not reflect embedding state, so the empty model_id
     // (matching no chunk_embeddings) keeps every chunk's reason as Forced.
     let model_id = if options.force { "" } else { scan.model_id };
-    let candidates = current_chunks_by_ids(conn, model_id, ids)?;
+    let candidates = current_chunks_by_ids(conn, model_id, ids, decompressor)?;
     let mut jobs = Vec::new();
     for candidate in candidates {
         let policy = policy_for_job(&candidate, scan.max_embedding_chars);

--- a/crates/rag-rat-core/src/index/chunk_text_store.rs
+++ b/crates/rag-rat-core/src/index/chunk_text_store.rs
@@ -2,71 +2,132 @@
 //! of chunk text and compress every chunk into `chunk_text`. During the transition the source of
 //! truth is still `chunks.text`; this derives the compressed store from it. Idempotent.
 
+use rusqlite::Connection;
+
 use super::*;
 
 /// Target chunk-text samples for dictionary training. zstd wants samples >> dict size; a few
 /// thousand covers the corpus and bounds the train cost.
 const DICT_SAMPLE_TARGET: i64 = 4096;
 
+/// The latest (highest-version) dict, or `None` when no dict exists yet. The dict is an immutable
+/// decode key, so writes compress against the CURRENT version and a future retrain adds a new one
+/// (see the `chunk_text_dict` schema comment); "latest" is what new blobs reference.
+pub(crate) fn latest_dict(conn: &Connection) -> anyhow::Result<Option<(i64, Vec<u8>)>> {
+    Ok(conn
+        .query_row(
+            "SELECT version, dict FROM chunk_text_dict ORDER BY version DESC LIMIT 1",
+            [],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?)),
+        )
+        .optional()?)
+}
+
+/// Build the compressed `chunk_text` store from a `(chunk_id, text)` `source` —
+/// `temp.rebuild_chunk_text` during a full rebuild, or `(SELECT id AS chunk_id, text FROM chunks)`
+/// in the V027 migration that retires the `chunks.text` column. `source` is an internal constant,
+/// never user input. If no dict exists yet, trains version 1 from a sample of the source; otherwise
+/// compresses against the existing latest version (the dict is immutable — never retrained in
+/// place, so other contexts' blobs stay decodable). Does NOT clear `chunk_text`/`chunk_text_dict`:
+/// the staged context's old rows were already cascade-deleted with its chunks; this inserts the
+/// staged chunks' blobs only. Runs INSIDE the caller's transaction so a freshly-trained dict and
+/// its blobs commit atomically.
+pub(crate) fn build_store(conn: &Connection, source: &str) -> anyhow::Result<()> {
+    let total: i64 =
+        conn.query_row(&format!("SELECT COUNT(*) FROM {source}"), [], |row| row.get(0))?;
+    if total == 0 {
+        return Ok(());
+    }
+    let (version, dict) = match latest_dict(conn)? {
+        Some(existing) => existing,
+        None => {
+            // First index: train version 1. Sample evenly across the id space (first-N would bias
+            // to one corner of the repo). Fall back to an EMPTY dict (no-dict plain zstd) when the
+            // corpus is too small to train on (`from_samples` hard-errors under ~7 samples).
+            let stride = (total / DICT_SAMPLE_TARGET).max(1);
+            let samples: Vec<Vec<u8>> = {
+                let mut stmt = conn.prepare(&format!(
+                    "SELECT text FROM {source} WHERE chunk_id % ?1 = 0 LIMIT ?2"
+                ))?;
+                let rows = stmt.query_map(params![stride, DICT_SAMPLE_TARGET], |row| {
+                    Ok(row.get::<_, String>(0)?.into_bytes())
+                })?;
+                rows.collect::<rusqlite::Result<_>>()?
+            };
+            let dict = text_compression::train_dict(&samples, text_compression::DEFAULT_DICT_SIZE)
+                .unwrap_or_default();
+            conn.execute("INSERT INTO chunk_text_dict(version, dict) VALUES (1, ?1)", params![
+                dict
+            ])?;
+            (1, dict)
+        },
+    };
+    // Compress every staged chunk against the chosen dict version, reusing one compressor.
+    let mut compressor = text_compression::ChunkCompressor::new(&dict)?;
+    let mut read = conn.prepare(&format!("SELECT chunk_id, text FROM {source}"))?;
+    let mut insert = conn.prepare(
+        "INSERT INTO chunk_text(chunk_id, blob, raw_len, dict_version) VALUES (?1, ?2, ?3, ?4)",
+    )?;
+    let mut rows = read.query([])?;
+    while let Some(row) = rows.next()? {
+        let id: i64 = row.get(0)?;
+        let text: String = row.get(1)?;
+        let blob = compressor.compress(text.as_bytes())?;
+        insert.execute(params![
+            id,
+            blob,
+            i64::try_from(text.len()).unwrap_or(i64::MAX),
+            version
+        ])?;
+    }
+    Ok(())
+}
+
 impl IndexDatabase {
-    /// Train the shared dictionary on a sample of chunk text and compress every chunk into
-    /// `chunk_text` (#77 Phase 2). Idempotent — clears + rebuilds the store + the single dict row.
-    /// Runs INSIDE the caller's transaction (the full rebuild's BEGIN..COMMIT); it does not open
-    /// its own, so the dict row and the blobs compressed against it commit atomically — never a
-    /// mixed-dict state where a stale blob can't be decompressed.
+    /// Full-rebuild entry: build the store from the rebuild's `temp.rebuild_chunk_text` staging
+    /// table (insert_chunks wrote the in-memory text there for the first index, when no dict
+    /// exists), then clear the staging. A no-op when a dict already exists (insert_chunks
+    /// compressed inline). See [`build_store`].
     pub(crate) fn build_chunk_text_store(&self) -> anyhow::Result<()> {
         let conn = self.storage.connection();
-        conn.execute("DELETE FROM chunk_text", [])?;
-        conn.execute("DELETE FROM chunk_text_dict", [])?;
-        let total: i64 = conn.query_row("SELECT COUNT(*) FROM chunks", [], |row| row.get(0))?;
-        if total == 0 {
-            return Ok(());
-        }
-        // Sample evenly across the id space (first-N would bias to one corner of the repo).
-        let stride = (total / DICT_SAMPLE_TARGET).max(1);
-        let samples: Vec<Vec<u8>> = {
-            let mut stmt = conn.prepare("SELECT text FROM chunks WHERE id % ?1 = 0 LIMIT ?2")?;
-            let rows = stmt.query_map(params![stride, DICT_SAMPLE_TARGET], |row| {
-                Ok(row.get::<_, String>(0)?.into_bytes())
-            })?;
-            rows.collect::<rusqlite::Result<_>>()?
-        };
-        // Train; fall back to an EMPTY dict (no-dict plain zstd) when the corpus is too small to
-        // train on (`from_samples` hard-errors under ~7 samples) — keeps tiny-repo indexing
-        // working.
-        let dict = text_compression::train_dict(&samples, text_compression::DEFAULT_DICT_SIZE)
-            .unwrap_or_default();
-        conn.execute(
-            "INSERT INTO chunk_text_dict(id, dict, dict_version) VALUES (1, ?1, 1)",
-            params![dict],
-        )?;
-        // Compress every chunk, reusing one dictionary-bound compressor across all rows.
-        let mut compressor = text_compression::ChunkCompressor::new(&dict)?;
-        let mut read = conn.prepare("SELECT id, text FROM chunks")?;
-        let mut insert =
-            conn.prepare("INSERT INTO chunk_text(chunk_id, blob, raw_len) VALUES (?1, ?2, ?3)")?;
-        let mut rows = read.query([])?;
-        while let Some(row) = rows.next()? {
-            let id: i64 = row.get(0)?;
-            let text: String = row.get(1)?;
-            let blob = compressor.compress(text.as_bytes())?;
-            insert.execute(params![id, blob, i64::try_from(text.len()).unwrap_or(i64::MAX)])?;
-        }
+        build_store(conn, "temp.rebuild_chunk_text")?;
+        conn.execute("DELETE FROM temp.rebuild_chunk_text", [])?;
         Ok(())
     }
 
-    /// The shared dictionary blob, or `None` when no store/dict exists yet (a fresh DB, or mid
-    /// full rebuild after the dict was cleared). An empty `Vec` is the no-dict sentinel (corpus too
-    /// small to train) — callers pass it straight to [`text_compression`], which treats empty as
-    /// plain zstd. Used by the incremental/heal write path to compress new chunks inline; absent →
-    /// the path skips `chunk_text` (the next full rebuild's bulk pass builds it).
-    pub(crate) fn chunk_text_dict(&self) -> anyhow::Result<Option<Vec<u8>>> {
-        Ok(self
-            .storage
-            .connection()
-            .query_row("SELECT dict FROM chunk_text_dict WHERE id = 1", [], |row| {
-                row.get::<_, Vec<u8>>(0)
-            })
-            .optional()?)
+    /// The latest dict version + its bytes, or `None` when no dict exists yet (a fresh DB mid first
+    /// rebuild before the dict is trained). The incremental/heal write path compresses new chunks
+    /// inline against this version and records it on the `chunk_text` row; absent → the path stages
+    /// the text instead (the first full rebuild's bulk pass trains the dict).
+    pub(crate) fn latest_chunk_text_dict(&self) -> anyhow::Result<Option<(i64, Vec<u8>)>> {
+        latest_dict(self.storage.connection())
     }
+}
+
+/// Test seeder: chunks now have no `text` column, so tests that insert a chunk row directly must
+/// also seed its compressed `chunk_text` blob (readers INNER JOIN `chunk_text`). Compresses against
+/// the EXISTING latest dict version if one exists (e.g. a prior rebuild trained version 1) so the
+/// blob is decodable; otherwise creates version 1 with the empty-dict (no-dict, plain zstd)
+/// sentinel. Tagging an empty-dict blob with a trained version would make it undecodable.
+#[cfg(test)]
+pub(crate) fn seed_chunk_text(
+    conn: &Connection,
+    chunk_id: i64,
+    text: &str,
+) -> rusqlite::Result<()> {
+    let (version, dict) = match latest_dict(conn).expect("read latest dict") {
+        Some(existing) => existing,
+        None => {
+            conn.execute("INSERT INTO chunk_text_dict(version, dict) VALUES (1, x'')", [])?;
+            (1, Vec::new())
+        },
+    };
+    let blob = text_compression::ChunkCompressor::new(&dict)
+        .and_then(|mut c| c.compress(text.as_bytes()))
+        .expect("compress is infallible for a valid dict");
+    conn.execute(
+        "INSERT INTO chunk_text(chunk_id, blob, raw_len, dict_version) VALUES (?1, ?2, ?3, ?4)",
+        params![chunk_id, blob, i64::try_from(text.len()).unwrap_or(i64::MAX), version],
+    )
+    .map(|_| ())
 }

--- a/crates/rag-rat-core/src/index/chunk_text_store.rs
+++ b/crates/rag-rat-core/src/index/chunk_text_store.rs
@@ -35,15 +35,19 @@ pub(crate) fn latest_dict(conn: &Connection) -> anyhow::Result<Option<(i64, Vec<
 pub(crate) fn build_store(conn: &Connection, source: &str) -> anyhow::Result<()> {
     let total: i64 =
         conn.query_row(&format!("SELECT COUNT(*) FROM {source}"), [], |row| row.get(0))?;
-    if total == 0 {
-        return Ok(());
-    }
+    // NB: do NOT early-return on total==0. A full rebuild that indexes files but produces ZERO
+    // chunks (e.g. a whitespace-only markdown file) must still establish version 1 — otherwise the
+    // index is left dict-less with files present, and the next incremental/heal hits insert_chunks'
+    // "no dict" branch, which stages into the rebuild-only `temp.rebuild_chunk_text` and either
+    // orphans the chunk (same connection) or errors "no such table" (fresh connection). An empty
+    // corpus trains an empty (no-dict) dict; later chunks compress against it inline.
     let (version, dict) = match latest_dict(conn)? {
         Some(existing) => existing,
         None => {
             // First index: train version 1. Sample evenly across the id space (first-N would bias
             // to one corner of the repo). Fall back to an EMPTY dict (no-dict plain zstd) when the
-            // corpus is too small to train on (`from_samples` hard-errors under ~7 samples).
+            // corpus is too small to train on (`from_samples` hard-errors under ~7 samples; an
+            // empty source yields zero samples → empty dict, which is the no-dict sentinel).
             let stride = (total / DICT_SAMPLE_TARGET).max(1);
             let samples: Vec<Vec<u8>> = {
                 let mut stmt = conn.prepare(&format!(

--- a/crates/rag-rat-core/src/index/chunk_text_store.rs
+++ b/crates/rag-rat-core/src/index/chunk_text_store.rs
@@ -1,0 +1,57 @@
+//! Build the compressed `chunk_text` store (#77 Phase 2): train the shared dictionary on a sample
+//! of chunk text and compress every chunk into `chunk_text`. During the transition the source of
+//! truth is still `chunks.text`; this derives the compressed store from it. Idempotent.
+
+use super::*;
+
+/// Target chunk-text samples for dictionary training. zstd wants samples >> dict size; a few
+/// thousand covers the corpus and bounds the train cost.
+const DICT_SAMPLE_TARGET: i64 = 4096;
+
+impl IndexDatabase {
+    /// Train the shared dictionary on a sample of chunk text and compress every chunk into
+    /// `chunk_text` (#77 Phase 2). Idempotent — clears + rebuilds the store + the single dict row.
+    /// Runs INSIDE the caller's transaction (the full rebuild's BEGIN..COMMIT); it does not open
+    /// its own, so the dict row and the blobs compressed against it commit atomically — never a
+    /// mixed-dict state where a stale blob can't be decompressed.
+    pub(crate) fn build_chunk_text_store(&self) -> anyhow::Result<()> {
+        let conn = self.storage.connection();
+        conn.execute("DELETE FROM chunk_text", [])?;
+        conn.execute("DELETE FROM chunk_text_dict", [])?;
+        let total: i64 = conn.query_row("SELECT COUNT(*) FROM chunks", [], |row| row.get(0))?;
+        if total == 0 {
+            return Ok(());
+        }
+        // Sample evenly across the id space (first-N would bias to one corner of the repo).
+        let stride = (total / DICT_SAMPLE_TARGET).max(1);
+        let samples: Vec<Vec<u8>> = {
+            let mut stmt = conn.prepare("SELECT text FROM chunks WHERE id % ?1 = 0 LIMIT ?2")?;
+            let rows = stmt.query_map(params![stride, DICT_SAMPLE_TARGET], |row| {
+                Ok(row.get::<_, String>(0)?.into_bytes())
+            })?;
+            rows.collect::<rusqlite::Result<_>>()?
+        };
+        // Train; fall back to an EMPTY dict (no-dict plain zstd) when the corpus is too small to
+        // train on (`from_samples` hard-errors under ~7 samples) — keeps tiny-repo indexing
+        // working.
+        let dict = text_compression::train_dict(&samples, text_compression::DEFAULT_DICT_SIZE)
+            .unwrap_or_default();
+        conn.execute(
+            "INSERT INTO chunk_text_dict(id, dict, dict_version) VALUES (1, ?1, 1)",
+            params![dict],
+        )?;
+        // Compress every chunk, reusing one dictionary-bound compressor across all rows.
+        let mut compressor = text_compression::ChunkCompressor::new(&dict)?;
+        let mut read = conn.prepare("SELECT id, text FROM chunks")?;
+        let mut insert =
+            conn.prepare("INSERT INTO chunk_text(chunk_id, blob, raw_len) VALUES (?1, ?2, ?3)")?;
+        let mut rows = read.query([])?;
+        while let Some(row) = rows.next()? {
+            let id: i64 = row.get(0)?;
+            let text: String = row.get(1)?;
+            let blob = compressor.compress(text.as_bytes())?;
+            insert.execute(params![id, blob, i64::try_from(text.len()).unwrap_or(i64::MAX)])?;
+        }
+        Ok(())
+    }
+}

--- a/crates/rag-rat-core/src/index/chunk_text_store.rs
+++ b/crates/rag-rat-core/src/index/chunk_text_store.rs
@@ -54,4 +54,19 @@ impl IndexDatabase {
         }
         Ok(())
     }
+
+    /// The shared dictionary blob, or `None` when no store/dict exists yet (a fresh DB, or mid
+    /// full rebuild after the dict was cleared). An empty `Vec` is the no-dict sentinel (corpus too
+    /// small to train) — callers pass it straight to [`text_compression`], which treats empty as
+    /// plain zstd. Used by the incremental/heal write path to compress new chunks inline; absent →
+    /// the path skips `chunk_text` (the next full rebuild's bulk pass builds it).
+    pub(super) fn chunk_text_dict(&self) -> anyhow::Result<Option<Vec<u8>>> {
+        Ok(self
+            .storage
+            .connection()
+            .query_row("SELECT dict FROM chunk_text_dict WHERE id = 1", [], |row| {
+                row.get::<_, Vec<u8>>(0)
+            })
+            .optional()?)
+    }
 }

--- a/crates/rag-rat-core/src/index/chunk_text_store.rs
+++ b/crates/rag-rat-core/src/index/chunk_text_store.rs
@@ -60,7 +60,7 @@ impl IndexDatabase {
     /// small to train) — callers pass it straight to [`text_compression`], which treats empty as
     /// plain zstd. Used by the incremental/heal write path to compress new chunks inline; absent →
     /// the path skips `chunk_text` (the next full rebuild's bulk pass builds it).
-    pub(super) fn chunk_text_dict(&self) -> anyhow::Result<Option<Vec<u8>>> {
+    pub(crate) fn chunk_text_dict(&self) -> anyhow::Result<Option<Vec<u8>>> {
         Ok(self
             .storage
             .connection()

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -117,7 +117,7 @@ impl IndexDatabase {
             };
         // Inline/heal path: keep chunk_fts in sync per row (partial file replace would otherwise
         // desync the external-content index until the next forced rebuild).
-        self.insert_chunks(ChunkInsertFile { file_id, source_revision: &sha256 }, &chunks, true)?;
+        self.insert_chunks(ChunkInsertFile { file_id, source_revision: &sha256 }, &chunks)?;
         self.insert_symbols(file_id, language, &symbols)?;
         if kind != TargetKind::Generated && text.len() <= edges::MAX_GRAPH_PARSE_BYTES {
             edges::index_file_edges(self.storage.connection(), file_id, path, language, text)?;
@@ -126,9 +126,6 @@ impl IndexDatabase {
         Ok(())
     }
 
-    /// `write_fts`: false on a full rebuild (the closing bulk `rebuild_fts` repopulates
-    /// `chunk_fts`), true on incremental discovery (per-file replace needs the external-content
-    /// index kept in sync in place). See `insert_chunks`.
     /// `graph`: on a full rebuild, `Some` accumulator — symbols (with their new DB ids) and
     /// remapped edge candidates are collected for one in-memory resolve-and-insert pass after
     /// the loop, and NO edges are inserted here. `None` (incremental) inserts edges unresolved
@@ -136,7 +133,6 @@ impl IndexDatabase {
     pub(super) fn insert_prepared_file(
         &self,
         prepared_file: &PreparedIndexFile,
-        write_fts: bool,
         graph: Option<&mut edges::FullRebuildGraph>,
     ) -> anyhow::Result<()> {
         let file = &prepared_file.file;
@@ -185,7 +181,6 @@ impl IndexDatabase {
         self.insert_chunks(
             ChunkInsertFile { file_id, source_revision: &prepared.sha256 },
             &prepared.chunks,
-            write_fts,
         )?;
         let symbol_db_ids = self.insert_symbols(file_id, file.language, &prepared.symbols)?;
         // Edge candidates were computed in the parallel prepare phase with LOCAL symbol indices;
@@ -219,17 +214,16 @@ impl IndexDatabase {
     /// embedding policy were all computed in the parallel prepare phase (see `prepare_chunks`), so
     /// nothing here hashes or parses.
     ///
-    /// `write_fts` controls the per-row `chunk_fts` insert. On a FULL REBUILD it's `false`: the
-    /// rebuild empties `chunk_fts` and the closing `rebuild_fts` repopulates it from the content
-    /// table in one bulk pass, so per-row writes are pure double work. Incremental / heal paths
-    /// pass `true`: they delete and re-insert individual files, which would leave `chunks` rows
-    /// without `chunk_fts` shadow entries (an external-content desync, #51) until a query
-    /// forces a rebuild — the per-row insert keeps the index consistent in place.
+    /// Writes the per-row `chunk_fts` token row inline on EVERY path. `chunk_fts` is contentless
+    /// (#77 Phase 2), so it cannot be bulk-rebuilt from a content column — the only way it stays in
+    /// sync is this inline write at index time (full rebuild, incremental, and heal all insert
+    /// here). The full rebuild's `finalize_full_rebuild_fts` only bulk-rebuilds the separate
+    /// external-content `commit_fts`; `chunk_fts` recovery lives in `rebuild_chunk_fts`
+    /// (decompresses the store).
     fn insert_chunks(
         &self,
         file: ChunkInsertFile<'_>,
         chunks: &[PreparedChunk],
-        write_fts: bool,
     ) -> anyhow::Result<()> {
         let ChunkInsertFile { file_id, source_revision } = file;
         // Maintain the compressed store inline when a dict exists (incremental + heal, and a full
@@ -281,11 +275,10 @@ impl IndexDatabase {
             ])?;
             let chunk_id = conn.last_insert_rowid();
             // chunk_fts is contentless (#77 Phase 2): tokens come from the in-memory text here, on
-            // every path (write_fts), never from a chunks.text column.
-            if write_fts {
-                conn.prepare_cached("INSERT INTO chunk_fts(rowid, text) VALUES (?1, ?2)")?
-                    .execute(params![chunk_id, chunk.text])?;
-            }
+            // EVERY indexing path, never from a chunks.text column (a contentless FTS can't be
+            // bulk-rebuilt from a content table, so the inline write is what keeps it in sync).
+            conn.prepare_cached("INSERT INTO chunk_fts(rowid, text) VALUES (?1, ?2)")?
+                .execute(params![chunk_id, chunk.text])?;
             match compressor.as_mut() {
                 // Dict present: compress inline against its version into the durable store.
                 Some(compressor) => {

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -232,26 +232,32 @@ impl IndexDatabase {
         write_fts: bool,
     ) -> anyhow::Result<()> {
         let ChunkInsertFile { file_id, source_revision } = file;
-        // Maintain the compressed store inline when a dict exists (incremental + heal paths). On a
-        // full rebuild the dict is cleared up front, so this is None and build_chunk_text_store
-        // does the bulk pass at the end (#77). Load the dict BEFORE taking `conn` to avoid
-        // a nested connection borrow. Empty dict = the no-dict (plain zstd) sentinel.
-        let dict = self.chunk_text_dict()?;
-        let mut compressor =
-            dict.as_deref().map(text_compression::ChunkCompressor::new).transpose()?;
+        // Maintain the compressed store inline when a dict exists (incremental + heal, and a full
+        // rebuild after the first one). Compress against the LATEST dict version and record it on
+        // the row — the dict is an immutable decode key (#77 Phase 2). When NO dict exists
+        // (the very first full rebuild), there is nothing to compress against yet, so the
+        // text is staged and build_chunk_text_store trains version 1 at the end. Load the
+        // dict BEFORE taking `conn` to avoid a nested connection borrow. Empty dict bytes =
+        // the no-dict (plain zstd) sentinel.
+        let latest_dict = self.latest_chunk_text_dict()?;
+        let mut compressor = latest_dict
+            .as_ref()
+            .map(|(_, dict)| text_compression::ChunkCompressor::new(dict))
+            .transpose()?;
+        let dict_version = latest_dict.as_ref().map(|(version, _)| *version);
         let conn = self.storage.connection();
         for prepared in chunks {
             let chunk = &prepared.chunk;
             let anchor = &prepared.anchor;
             conn.prepare_cached(
                 "INSERT INTO chunks(file_id, chunk_kind, symbol_path, start_byte, end_byte, \
-                 start_line, end_line, text, text_hash,
+                 start_line, end_line, text_hash,
                                     source_revision, anchor_version, normalized_hash, \
                  start_boundary_hash, end_boundary_hash,
                                     start_context_hash, end_context_hash, context_radius, \
                  embedding_policy, embedding_priority)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, \
-                 ?17, ?18, ?19)",
+                 ?17, ?18)",
             )?
             .execute(params![
                 file_id,
@@ -261,7 +267,6 @@ impl IndexDatabase {
                 i64::try_from(chunk.end_byte)?,
                 i64::try_from(chunk.start_line)?,
                 i64::try_from(chunk.end_line)?,
-                chunk.text,
                 prepared.text_hash,
                 source_revision,
                 anchor.version,
@@ -275,20 +280,37 @@ impl IndexDatabase {
                 prepared.embedding.priority,
             ])?;
             let chunk_id = conn.last_insert_rowid();
+            // chunk_fts is contentless (#77 Phase 2): tokens come from the in-memory text here, on
+            // every path (write_fts), never from a chunks.text column.
             if write_fts {
                 conn.prepare_cached("INSERT INTO chunk_fts(rowid, text) VALUES (?1, ?2)")?
                     .execute(params![chunk_id, chunk.text])?;
             }
-            if let Some(compressor) = compressor.as_mut() {
-                let blob = compressor.compress(chunk.text.as_bytes())?;
-                conn.prepare_cached(
-                    "INSERT INTO chunk_text(chunk_id, blob, raw_len) VALUES (?1, ?2, ?3)",
-                )?
-                .execute(params![
-                    chunk_id,
-                    blob,
-                    i64::try_from(chunk.text.len())?
-                ])?;
+            match compressor.as_mut() {
+                // Dict present: compress inline against its version into the durable store.
+                Some(compressor) => {
+                    let blob = compressor.compress(chunk.text.as_bytes())?;
+                    conn.prepare_cached(
+                        "INSERT INTO chunk_text(chunk_id, blob, raw_len, dict_version) VALUES \
+                         (?1, ?2, ?3, ?4)",
+                    )?
+                    .execute(params![
+                        chunk_id,
+                        blob,
+                        i64::try_from(chunk.text.len())?,
+                        dict_version.expect("dict_version is Some whenever the compressor is"),
+                    ])?;
+                },
+                // No dict yet (the FIRST full rebuild): stage the text in the rebuild temp table so
+                // `build_chunk_text_store` trains version 1 over a corpus sample and compresses
+                // every chunk at the end. There is no chunks.text column to read
+                // from.
+                None => {
+                    conn.prepare_cached(
+                        "INSERT INTO temp.rebuild_chunk_text(chunk_id, text) VALUES (?1, ?2)",
+                    )?
+                    .execute(params![chunk_id, chunk.text])?;
+                },
             }
         }
         Ok(())

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -232,6 +232,13 @@ impl IndexDatabase {
         write_fts: bool,
     ) -> anyhow::Result<()> {
         let ChunkInsertFile { file_id, source_revision } = file;
+        // Maintain the compressed store inline when a dict exists (incremental + heal paths). On a
+        // full rebuild the dict is cleared up front, so this is None and build_chunk_text_store
+        // does the bulk pass at the end (#77). Load the dict BEFORE taking `conn` to avoid
+        // a nested connection borrow. Empty dict = the no-dict (plain zstd) sentinel.
+        let dict = self.chunk_text_dict()?;
+        let mut compressor =
+            dict.as_deref().map(text_compression::ChunkCompressor::new).transpose()?;
         let conn = self.storage.connection();
         for prepared in chunks {
             let chunk = &prepared.chunk;
@@ -267,10 +274,21 @@ impl IndexDatabase {
                 prepared.embedding.policy,
                 prepared.embedding.priority,
             ])?;
+            let chunk_id = conn.last_insert_rowid();
             if write_fts {
-                let chunk_id = conn.last_insert_rowid();
                 conn.prepare_cached("INSERT INTO chunk_fts(rowid, text) VALUES (?1, ?2)")?
                     .execute(params![chunk_id, chunk.text])?;
+            }
+            if let Some(compressor) = compressor.as_mut() {
+                let blob = compressor.compress(chunk.text.as_bytes())?;
+                conn.prepare_cached(
+                    "INSERT INTO chunk_text(chunk_id, blob, raw_len) VALUES (?1, ?2, ?3)",
+                )?
+                .execute(params![
+                    chunk_id,
+                    blob,
+                    i64::try_from(chunk.text.len())?
+                ])?;
             }
         }
         Ok(())

--- a/crates/rag-rat-core/src/index/file_rows.rs
+++ b/crates/rag-rat-core/src/index/file_rows.rs
@@ -96,9 +96,11 @@ impl IndexDatabase {
             params![path, commit_sha, worktree_id],
         )?;
         // Deleting the chunks cascades (ON DELETE CASCADE, foreign_keys=ON) to git_chunk_blame,
-        // chunk_embeddings, and chunk_summaries — so the gate skipping the full git-history wipe
-        // does NOT leak blame. (`docs` has no FK and is not cleaned here — a pre-existing gap,
-        // tracked separately.)
+        // chunk_embeddings, chunk_summaries, and chunk_text — so the gate skipping the full
+        // git-history wipe does NOT leak blame, and compressed text (#77) doesn't orphan. (`docs`
+        // has no FK and is not cleaned here — a pre-existing gap, tracked separately.) The
+        // full-rebuild / GC path (delete_staged_files_cascade) enumerates these explicitly for the
+        // FK-off-during-migration case; this live path runs with foreign_keys = ON.
         self.storage.connection().execute(
             "DELETE FROM chunks
              WHERE file_id IN (

--- a/crates/rag-rat-core/src/index/fts.rs
+++ b/crates/rag-rat-core/src/index/fts.rs
@@ -28,29 +28,29 @@ impl IndexDatabase {
 
     /// Repopulate the contentless `chunk_fts` from scratch (#77 Phase 2): clear it, then
     /// re-tokenize every chunk's text. The text comes from the compressed `chunk_text` store
-    /// (decompressed with one reused decompressor), falling back to `chunks.text` for a chunk
-    /// not yet in the store. This is the recovery path only — the full-rebuild and incremental
-    /// paths write `chunk_fts` inline from the in-memory chunk text (`write_fts`), so this
-    /// never runs there.
+    /// (decompressed with one reused decompressor); the `chunks.text` column is gone, so this INNER
+    /// JOINs `chunk_text`. This is the recovery path only — the full-rebuild and incremental paths
+    /// write `chunk_fts` inline from the in-memory chunk text (`write_fts`), so this never runs
+    /// there.
     fn rebuild_chunk_fts(&self) -> anyhow::Result<()> {
         let conn = self.storage.connection();
         // 'delete-all' is the FTS5 command to clear a contentless index (a bare DELETE is
         // unsupported; on an external-content table it also corrupts a desynced index — #51).
         conn.execute("INSERT INTO chunk_fts(chunk_fts) VALUES('delete-all')", [])?;
-        let dict = crate::query::chunk_text_dict(conn)?;
-        let mut decompressor = crate::index::text_compression::ChunkDecompressor::new(&dict)?;
+        let dicts = crate::query::chunk_text_dicts(conn)?;
+        let mut decoder = crate::index::text_compression::ChunkTextDecoder::new(&dicts);
         // Collect (rowid, ChunkTextRow) first: decompress's anyhow::Result can't cross the rusqlite
         // closure, and the SELECT statement can't stay open while we INSERT into chunk_fts.
         let rows: Vec<(i64, crate::index::text_compression::ChunkTextRow)> = {
             let mut stmt = conn.prepare(
-                "SELECT chunks.id, chunks.text, chunk_text.blob, chunk_text.raw_len
-                 FROM chunks LEFT JOIN chunk_text ON chunk_text.chunk_id = chunks.id",
+                "SELECT chunks.id, chunk_text.blob, chunk_text.raw_len, chunk_text.dict_version
+                 FROM chunks JOIN chunk_text ON chunk_text.chunk_id = chunks.id",
             )?;
             let mapped = stmt.query_map([], |row| {
                 Ok((row.get::<_, i64>(0)?, crate::index::text_compression::ChunkTextRow {
-                    fallback: row.get(1)?,
-                    blob: row.get(2)?,
-                    raw_len: row.get(3)?,
+                    blob: row.get(1)?,
+                    raw_len: row.get(2)?,
+                    dict_version: row.get(3)?,
                 }))
             })?;
             let mut out = Vec::new();
@@ -61,7 +61,7 @@ impl IndexDatabase {
         };
         let mut insert = conn.prepare("INSERT INTO chunk_fts(rowid, text) VALUES (?1, ?2)")?;
         for (chunk_id, text_row) in rows {
-            let text = text_row.resolve(&mut decompressor)?;
+            let text = text_row.resolve(&mut decoder)?;
             insert.execute(rusqlite::params![chunk_id, text])?;
         }
         Ok(())

--- a/crates/rag-rat-core/src/index/fts.rs
+++ b/crates/rag-rat-core/src/index/fts.rs
@@ -3,11 +3,67 @@
 use super::*;
 
 impl IndexDatabase {
+    /// Recovery / freshness rebuild: repopulate the contentless `chunk_fts` from the durable text
+    /// store and rebuild the external-content `commit_fts`, then record freshness. The hot
+    /// full-rebuild path uses [`finalize_full_rebuild_fts`] instead (chunk_fts is written inline).
     pub fn rebuild_fts(&self) -> anyhow::Result<()> {
-        schema::rebuild_fts(self.storage.connection())?;
+        self.rebuild_chunk_fts()?;
+        schema::rebuild_commit_fts(self.storage.connection())?;
         self.record_content_revision()?;
         self.record_fts_current()?;
         self.set_meta("fts_dirty", "false")?;
+        Ok(())
+    }
+
+    /// Full-rebuild FTS finalize: `chunk_fts` was written inline (write_fts=true) during chunk
+    /// insert, so only the external-content `commit_fts` needs the bulk 'rebuild' here. Records
+    /// freshness like [`rebuild_fts`], without re-tokenizing every chunk.
+    pub(super) fn finalize_full_rebuild_fts(&self) -> anyhow::Result<()> {
+        schema::rebuild_commit_fts(self.storage.connection())?;
+        self.record_content_revision()?;
+        self.record_fts_current()?;
+        self.set_meta("fts_dirty", "false")?;
+        Ok(())
+    }
+
+    /// Repopulate the contentless `chunk_fts` from scratch (#77 Phase 2): clear it, then
+    /// re-tokenize every chunk's text. The text comes from the compressed `chunk_text` store
+    /// (decompressed with one reused decompressor), falling back to `chunks.text` for a chunk
+    /// not yet in the store. This is the recovery path only — the full-rebuild and incremental
+    /// paths write `chunk_fts` inline from the in-memory chunk text (`write_fts`), so this
+    /// never runs there.
+    fn rebuild_chunk_fts(&self) -> anyhow::Result<()> {
+        let conn = self.storage.connection();
+        // 'delete-all' is the FTS5 command to clear a contentless index (a bare DELETE is
+        // unsupported; on an external-content table it also corrupts a desynced index — #51).
+        conn.execute("INSERT INTO chunk_fts(chunk_fts) VALUES('delete-all')", [])?;
+        let dict = crate::query::chunk_text_dict(conn)?;
+        let mut decompressor = crate::index::text_compression::ChunkDecompressor::new(&dict)?;
+        // Collect (rowid, ChunkTextRow) first: decompress's anyhow::Result can't cross the rusqlite
+        // closure, and the SELECT statement can't stay open while we INSERT into chunk_fts.
+        let rows: Vec<(i64, crate::index::text_compression::ChunkTextRow)> = {
+            let mut stmt = conn.prepare(
+                "SELECT chunks.id, chunks.text, chunk_text.blob, chunk_text.raw_len
+                 FROM chunks LEFT JOIN chunk_text ON chunk_text.chunk_id = chunks.id",
+            )?;
+            let mapped = stmt.query_map([], |row| {
+                Ok((row.get::<_, i64>(0)?, crate::index::text_compression::ChunkTextRow {
+                    fallback: row.get(1)?,
+                    blob: row.get(2)?,
+                    raw_len: row.get(3)?,
+                }))
+            })?;
+            let mut out = Vec::new();
+            for row in mapped {
+                out.push(row?);
+            }
+            out
+        };
+        let mut insert = conn.prepare("INSERT INTO chunk_fts(rowid, text) VALUES (?1, ?2)")?;
+        for (chunk_id, text_row) in rows {
+            let text = text_row.resolve(&mut decompressor)?;
+            insert.execute(rusqlite::params![chunk_id, text])?;
+        }
         Ok(())
     }
 

--- a/crates/rag-rat-core/src/index/fts.rs
+++ b/crates/rag-rat-core/src/index/fts.rs
@@ -15,7 +15,7 @@ impl IndexDatabase {
         Ok(())
     }
 
-    /// Full-rebuild FTS finalize: `chunk_fts` was written inline (write_fts=true) during chunk
+    /// Full-rebuild FTS finalize: `chunk_fts` was written inline during chunk
     /// insert, so only the external-content `commit_fts` needs the bulk 'rebuild' here. Records
     /// freshness like [`rebuild_fts`], without re-tokenizing every chunk.
     pub(super) fn finalize_full_rebuild_fts(&self) -> anyhow::Result<()> {
@@ -30,8 +30,13 @@ impl IndexDatabase {
     /// re-tokenize every chunk's text. The text comes from the compressed `chunk_text` store
     /// (decompressed with one reused decompressor); the `chunks.text` column is gone, so this INNER
     /// JOINs `chunk_text`. This is the recovery path only — the full-rebuild and incremental paths
-    /// write `chunk_fts` inline from the in-memory chunk text (`write_fts`), so this never runs
-    /// there.
+    /// write `chunk_fts` inline from the in-memory chunk text, so this never runs there.
+    ///
+    /// COST: unlike the old external-content `'rebuild'` (which re-tokenized in-engine from the
+    /// content column), this decompresses the WHOLE store in Rust. It is gated by
+    /// `ensure_fts_fresh` (only fires when the FTS is genuinely dirty/stale — the same trigger
+    /// as before), so a steady-state query never pays it; but a stale-read heal is now a
+    /// heavier one-off.
     fn rebuild_chunk_fts(&self) -> anyhow::Result<()> {
         let conn = self.storage.connection();
         // 'delete-all' is the FTS5 command to clear a contentless index (a bare DELETE is

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -200,9 +200,11 @@ impl IndexDatabase {
                         kind: prepared_file.file.kind,
                     });
                 }
-                // Full rebuild: skip per-row chunk_fts writes; rebuild_fts repopulates it at the
-                // end.
-                self.insert_prepared_file(prepared_file, false, Some(&mut graph))?;
+                // Write chunk_fts inline from the in-memory chunk text (#77 Phase 2): chunk_fts is
+                // contentless now, so there is no content table for a closing 'rebuild' to re-read,
+                // and the in-memory text is available regardless of whether the chunks.text column
+                // still exists. `finalize_full_rebuild_fts` then only rebuilds commit_fts.
+                self.insert_prepared_file(prepared_file, true, Some(&mut graph))?;
             }
             // `prepared` (this wave's chunk texts / symbols / edge candidates) drops here.
         }

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -200,11 +200,11 @@ impl IndexDatabase {
                         kind: prepared_file.file.kind,
                     });
                 }
-                // Write chunk_fts inline from the in-memory chunk text (#77 Phase 2): chunk_fts is
+                // chunk_fts is written inline from the in-memory chunk text (#77 Phase 2): it's
                 // contentless now, so there is no content table for a closing 'rebuild' to re-read,
                 // and the in-memory text is available regardless of whether the chunks.text column
                 // still exists. `finalize_full_rebuild_fts` then only rebuilds commit_fts.
-                self.insert_prepared_file(prepared_file, true, Some(&mut graph))?;
+                self.insert_prepared_file(prepared_file, Some(&mut graph))?;
             }
             // `prepared` (this wave's chunk texts / symbols / edge candidates) drops here.
         }
@@ -390,10 +390,10 @@ impl IndexDatabase {
                 &prepared_file.file.commit_sha,
                 &prepared_file.file.worktree_id,
             )?;
-            // Incremental: per-file replace, so keep chunk_fts synced in place (no full
-            // rebuild_fts). No accumulator — edges are inserted unresolved here and
-            // resolved by resolve_edges.
-            self.insert_prepared_file(prepared_file, true, None)?;
+            // Incremental: per-file replace; chunk_fts is kept synced in place by the inline write
+            // in insert_chunks (no full rebuild_fts). No accumulator — edges are inserted
+            // unresolved here and resolved by resolve_edges.
+            self.insert_prepared_file(prepared_file, None)?;
         }
 
         Ok(files.len() + deleted_count)

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -23,20 +23,23 @@ impl IndexDatabase {
         // An `Older` schema is migrated UNDER THE INDEX WRITE LOCK: auto-migration now fires from
         // ordinary read/MCP opens, so a hot-restarted server and a concurrent `query` could both
         // observe `Older` and race `add_column_if_missing`'s check-then-ALTER into a
-        // duplicate-column DDL failure. Serializing on `write_lock_path` makes one opener
-        // migrate while the other waits, then re-checks under the lock (the waiter sees
-        // `Compatible` and does nothing). Compatible/Newer/Dirty/Missing need no lock —
-        // `ensure_compatible_or_migrate` returns or refuses without writing.
+        // duplicate-column DDL failure. Serializing on the write lock makes one opener migrate
+        // while the other waits, then re-checks under the lock (the waiter sees
+        // `Compatible` and does nothing). `WriteLock` (not the raw `FileLock`) is REENTRANT
+        // on the holding thread: a CLI write command / watcher pass already holds it and
+        // opens UNDER it, so a raw re-acquire here would self-deadlock (same process,
+        // second fd → flock blocks → 30s timeout, schema never migrates — #226). Reentrant
+        // acquire returns immediately when this thread already holds it; a non-holder
+        // (read/MCP/init open) still takes the real lock. Compatible/Newer/Dirty/Missing
+        // need no lock — `ensure_compatible_or_migrate` returns or refuses without writing.
         if schema::status(storage.connection())?.state == schema::SchemaState::Older {
-            let _lock = crate::locks::FileLock::acquire_timeout(
-                &crate::locks::write_lock_path(path),
-                SCHEMA_MIGRATE_LOCK_TIMEOUT,
-            )?
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "timed out waiting for the index write lock to auto-migrate the schema"
-                )
-            })?;
+            let _lock =
+                crate::locks::WriteLock::acquire_timeout(path, SCHEMA_MIGRATE_LOCK_TIMEOUT)?
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "timed out waiting for the index write lock to auto-migrate the schema"
+                        )
+                    })?;
             schema::ensure_compatible_or_migrate(storage.connection())?;
         } else {
             schema::ensure_compatible_or_migrate(storage.connection())?;

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -11,7 +11,7 @@ pub mod schema;
 pub mod symbols;
 pub mod walker;
 
-mod chunk_text_store;
+pub(crate) mod chunk_text_store;
 mod discovery;
 mod file_index;
 mod file_rows;

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -28,6 +28,10 @@ mod prep;
 mod query_api;
 mod rebuild;
 mod staleness;
+// Landed first as a tested, self-contained foundation; wired into the index (compress at index
+// time, decompress on the read paths) in the next #77 Phase 2 increment.
+#[allow(dead_code)]
+mod text_compression;
 mod util;
 mod worktree_overlay;
 pub use discovery::DiscoveryStatus;

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -29,10 +29,9 @@ mod prep;
 mod query_api;
 mod rebuild;
 mod staleness;
-// Landed first as a tested, self-contained foundation; wired into the index (compress at index
-// time, decompress on the read paths) in the next #77 Phase 2 increment.
-#[allow(dead_code)]
-mod text_compression;
+// #77 Phase 2 chunk-text compression. pub(crate) so the read layer (`crate::query`) can decompress
+// stored blobs, not just the index write path.
+pub(crate) mod text_compression;
 mod util;
 mod worktree_overlay;
 pub use discovery::DiscoveryStatus;

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -11,6 +11,7 @@ pub mod schema;
 pub mod symbols;
 pub mod walker;
 
+mod chunk_text_store;
 mod discovery;
 mod file_index;
 mod file_rows;

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -161,11 +161,14 @@ impl Harness {
         self.conn
             .execute(
                 "INSERT INTO chunks(file_id, chunk_kind, symbol_path, start_byte, end_byte, \
-                 start_line, end_line, text, text_hash) VALUES (?1, 'symbol', ?2, 0, ?3, 1, 1, \
-                 ?4, ?5)",
-                params![file_id, symbol_path, text.len() as i64, text, sha256_hex(text.as_bytes())],
+                 start_line, end_line, text_hash) VALUES (?1, 'symbol', ?2, 0, ?3, 1, 1, ?4)",
+                params![file_id, symbol_path, text.len() as i64, sha256_hex(text.as_bytes())],
             )
             .unwrap();
+        // chunks.text is gone (#77 Phase 2); seed the compressed chunk_text blob readers INNER
+        // JOIN.
+        let chunk_id = self.conn.last_insert_rowid();
+        crate::index::chunk_text_store::seed_chunk_text(&self.conn, chunk_id, text).unwrap();
     }
 
     /// The persisted moniker row for a logical symbol, if any.
@@ -746,7 +749,7 @@ fn migration_creates_oracle_side_tables() {
         assert!(columns.contains(&expected.to_string()), "edge_oracle missing {expected}");
     }
 
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 26);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 27);
 }
 
 /// The V019 moniker migration: the `logical_symbol_monikers` table (STRICT, NO foreign key — see

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -746,7 +746,7 @@ fn migration_creates_oracle_side_tables() {
         assert!(columns.contains(&expected.to_string()), "edge_oracle missing {expected}");
     }
 
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 24);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 25);
 }
 
 /// The V019 moniker migration: the `logical_symbol_monikers` table (STRICT, NO foreign key — see

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -746,7 +746,7 @@ fn migration_creates_oracle_side_tables() {
         assert!(columns.contains(&expected.to_string()), "edge_oracle missing {expected}");
     }
 
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 25);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 26);
 }
 
 /// The V019 moniker migration: the `logical_symbol_monikers` table (STRICT, NO foreign key — see

--- a/crates/rag-rat-core/src/index/query_api/graph.rs
+++ b/crates/rag-rat-core/src/index/query_api/graph.rs
@@ -616,10 +616,10 @@ impl IndexDatabase {
             "
             SELECT chunks.id, files.path, files.language, files.kind,
                    chunks.start_line, chunks.end_line, chunks.symbol_path,
-                   chunks.text, chunk_text.blob, chunk_text.raw_len
+                   chunk_text.blob, chunk_text.raw_len, chunk_text.dict_version
             FROM chunks
             JOIN files ON files.id = chunks.file_id
-            LEFT JOIN chunk_text ON chunk_text.chunk_id = chunks.id
+            JOIN chunk_text ON chunk_text.chunk_id = chunks.id
             WHERE files.path = ?1
               AND (
                 chunks.symbol_path = ?2
@@ -665,19 +665,19 @@ impl IndexDatabase {
                         importance: None,
                     },
                     crate::index::text_compression::ChunkTextRow {
-                        fallback: row.get(7)?,
-                        blob: row.get(8)?,
-                        raw_len: row.get(9)?,
+                        blob: row.get(7)?,
+                        raw_len: row.get(8)?,
+                        dict_version: row.get(9)?,
                     },
                 ))
             },
         )?;
         let collected = rows.collect::<rusqlite::Result<Vec<_>>>()?;
-        let dict = crate::query::chunk_text_dict(conn)?;
-        let mut decompressor = crate::index::text_compression::ChunkDecompressor::new(&dict)?;
+        let dicts = crate::query::chunk_text_dicts(conn)?;
+        let mut decoder = crate::index::text_compression::ChunkTextDecoder::new(&dicts);
         let mut hits = Vec::with_capacity(collected.len());
         for (mut hit, text_row) in collected {
-            hit.summary = bounded_summary(&text_row.resolve(&mut decompressor)?);
+            hit.summary = bounded_summary(&text_row.resolve(&mut decoder)?);
             hits.push(hit);
         }
         Ok(hits)

--- a/crates/rag-rat-core/src/index/query_api/graph.rs
+++ b/crates/rag-rat-core/src/index/query_api/graph.rs
@@ -599,17 +599,32 @@ impl IndexDatabase {
         symbol: &crate::query::symbol::SymbolHit,
         limit: u32,
     ) -> anyhow::Result<Vec<SearchHit>> {
-        let mut stmt = self.storage.connection().prepare(
+        // The text-mention fallback runs `chunk_fts MATCH` (#77) — you can't LIKE a compressed blob
+        // — so the FTS index must be fresh first (same precondition as search/impact). Omitted when
+        // the symbol name has no FTS token (then it's symbol_path matching only).
+        self.ensure_fts_fresh()?;
+        let conn = self.storage.connection();
+        let name_like = format!("%{}%", symbol.name);
+        let fts = crate::query::impact::fts_phrase_query(&symbol.name);
+        let text_clause = if fts.is_some() {
+            "OR chunks.id IN (SELECT c2.id FROM chunks AS c2 JOIN chunk_fts ON chunk_fts.rowid = \
+             c2.id WHERE chunk_fts MATCH ?4)"
+        } else {
+            ""
+        };
+        let sql = format!(
             "
             SELECT chunks.id, files.path, files.language, files.kind,
-                   chunks.start_line, chunks.end_line, chunks.symbol_path, chunks.text
+                   chunks.start_line, chunks.end_line, chunks.symbol_path,
+                   chunks.text, chunk_text.blob, chunk_text.raw_len
             FROM chunks
             JOIN files ON files.id = chunks.file_id
+            LEFT JOIN chunk_text ON chunk_text.chunk_id = chunks.id
             WHERE files.path = ?1
               AND (
                 chunks.symbol_path = ?2
                 OR chunks.symbol_path LIKE ?3
-                OR chunks.text LIKE ?4
+                {text_clause}
               )
             ORDER BY
               CASE
@@ -619,38 +634,51 @@ impl IndexDatabase {
               END,
               chunks.start_line
             LIMIT ?5
-            ",
-        )?;
+            "
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        // ?4 is bound unconditionally (unreferenced when `text_clause` is empty); decompress the
+        // snippet text in the post-loop (decompress can't cross the rusqlite closure).
         let rows = stmt.query_map(
             params![
                 symbol.path,
                 symbol.qualified_name,
-                format!("%{}%", symbol.name),
-                format!("%{}%", symbol.name),
+                name_like,
+                fts.unwrap_or_default(),
                 i64::from(limit.max(1)),
             ],
             |row| {
-                let text: String = row.get(7)?;
-                Ok(SearchHit {
-                    chunk_id: row.get(0)?,
-                    path: row.get(1)?,
-                    language: row.get(2)?,
-                    kind: row.get(3)?,
-                    start_line: row.get(4)?,
-                    end_line: row.get(5)?,
-                    symbol_path: row.get(6)?,
-                    score: 1.0,
-                    retrieval_mode: "lexical".to_string(),
-                    summary: bounded_summary(&text),
-                    graph: None,
-                    score_components: None,
-                    importance: None,
-                })
+                Ok((
+                    SearchHit {
+                        chunk_id: row.get(0)?,
+                        path: row.get(1)?,
+                        language: row.get(2)?,
+                        kind: row.get(3)?,
+                        start_line: row.get(4)?,
+                        end_line: row.get(5)?,
+                        symbol_path: row.get(6)?,
+                        score: 1.0,
+                        retrieval_mode: "lexical".to_string(),
+                        summary: String::new(),
+                        graph: None,
+                        score_components: None,
+                        importance: None,
+                    },
+                    crate::index::text_compression::ChunkTextRow {
+                        fallback: row.get(7)?,
+                        blob: row.get(8)?,
+                        raw_len: row.get(9)?,
+                    },
+                ))
             },
         )?;
-        let mut hits = Vec::new();
-        for row in rows {
-            hits.push(row?);
+        let collected = rows.collect::<rusqlite::Result<Vec<_>>>()?;
+        let dict = crate::query::chunk_text_dict(conn)?;
+        let mut decompressor = crate::index::text_compression::ChunkDecompressor::new(&dict)?;
+        let mut hits = Vec::with_capacity(collected.len());
+        for (mut hit, text_row) in collected {
+            hit.summary = bounded_summary(&text_row.resolve(&mut decompressor)?);
+            hits.push(hit);
         }
         Ok(hits)
     }

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -392,7 +392,21 @@ impl IndexDatabase {
     }
 
     fn read_chunk_current(&self, chunk_id: i64) -> anyhow::Result<Option<crate::query::ReadChunk>> {
-        let Some(mut chunk) = crate::query::read_chunk(self.storage.connection(), chunk_id)? else {
+        let dict = crate::query::chunk_text_dict(self.storage.connection())?;
+        let mut decompressor = crate::index::text_compression::ChunkDecompressor::new(&dict)?;
+        self.read_chunk_current_with(chunk_id, &mut decompressor)
+    }
+
+    /// Live-revalidating chunk read that resolves text through a caller-owned, dict-bound
+    /// decompressor (reused across a batch) rather than reloading the dict per call.
+    pub(crate) fn read_chunk_current_with(
+        &self,
+        chunk_id: i64,
+        decompressor: &mut crate::index::text_compression::ChunkDecompressor,
+    ) -> anyhow::Result<Option<crate::query::ReadChunk>> {
+        let Some(mut chunk) =
+            crate::query::read_chunk_with(self.storage.connection(), chunk_id, decompressor)?
+        else {
             return Ok(None);
         };
         // Under a LINKED-WORKTREE OVERLAY scope, `source_root` is the MAIN checkout — NOT the

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -391,21 +391,24 @@ impl IndexDatabase {
         Ok(Some(chunk))
     }
 
-    fn read_chunk_current(&self, chunk_id: i64) -> anyhow::Result<Option<crate::query::ReadChunk>> {
-        let dict = crate::query::chunk_text_dict(self.storage.connection())?;
-        let mut decompressor = crate::index::text_compression::ChunkDecompressor::new(&dict)?;
-        self.read_chunk_current_with(chunk_id, &mut decompressor)
+    pub(crate) fn read_chunk_current(
+        &self,
+        chunk_id: i64,
+    ) -> anyhow::Result<Option<crate::query::ReadChunk>> {
+        let dicts = crate::query::chunk_text_dicts(self.storage.connection())?;
+        let mut decoder = crate::index::text_compression::ChunkTextDecoder::new(&dicts);
+        self.read_chunk_current_with(chunk_id, &mut decoder)
     }
 
-    /// Live-revalidating chunk read that resolves text through a caller-owned, dict-bound
-    /// decompressor (reused across a batch) rather than reloading the dict per call.
+    /// Live-revalidating chunk read that resolves text through a caller-owned dict decoder (reused
+    /// across a batch) rather than reloading the dict versions per call.
     pub(crate) fn read_chunk_current_with(
         &self,
         chunk_id: i64,
-        decompressor: &mut crate::index::text_compression::ChunkDecompressor,
+        decoder: &mut crate::index::text_compression::ChunkTextDecoder,
     ) -> anyhow::Result<Option<crate::query::ReadChunk>> {
         let Some(mut chunk) =
-            crate::query::read_chunk_with(self.storage.connection(), chunk_id, decompressor)?
+            crate::query::read_chunk_with(self.storage.connection(), chunk_id, decoder)?
         else {
             return Ok(None);
         };

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -137,10 +137,21 @@ impl IndexDatabase {
             ",
         )?;
         self.delete_staged_files_cascade()?;
-        // The shared dictionary is global (one row, not per-file), so the staged cascade above does
-        // not touch it. Clear it here so insert_chunks sees no dict mid-rebuild and skips per-row
-        // compression; build_chunk_text_store retrains + bulk-compresses once at the end (#77).
-        self.storage.execute_batch("DELETE FROM chunk_text_dict;")?;
+        // Do NOT clear chunk_text_dict: dicts are IMMUTABLE decode keys (#77 Phase 2). Other
+        // worktree contexts' blobs reference existing versions, and deleting a version would orphan
+        // them. The staged cascade above already removed THIS context's chunk_text rows;
+        // insert_chunks recompresses them against the latest existing dict version (or, on
+        // the very first index when no dict exists yet, stages the text so
+        // build_chunk_text_store trains version 1). Per-connection staging table for that
+        // first-index path: insert_chunks writes the in-memory text here (there is no
+        // chunks.text column) and build_chunk_text_store reads + clears it.
+        self.storage.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS rebuild_chunk_text(
+                 chunk_id INTEGER PRIMARY KEY,
+                 text TEXT NOT NULL
+             );
+             DELETE FROM temp.rebuild_chunk_text;",
+        )?;
         self.storage.execute_batch("DELETE FROM temp.staged_file_ids;")?;
         Ok(())
     }

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -79,6 +79,10 @@ impl IndexDatabase {
             // flags version current and skip a redundant re-derive on next open (#202).
             db.mark_generated_flags_current()?;
             mem_trace("after mark_graph_index_current");
+            // Derive the compressed chunk_text store (#77 Phase 2) from chunks.text inside the same
+            // transaction, so the dict row + the blobs that use it are committed atomically.
+            db.build_chunk_text_store()?;
+            mem_trace("after build_chunk_text_store");
             progress(IndexProgress::RebuildingFts);
             db.rebuild_fts()?;
             mem_trace("after rebuild_fts");

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -84,8 +84,10 @@ impl IndexDatabase {
             db.build_chunk_text_store()?;
             mem_trace("after build_chunk_text_store");
             progress(IndexProgress::RebuildingFts);
-            db.rebuild_fts()?;
-            mem_trace("after rebuild_fts");
+            // chunk_fts was written inline during chunk insert (write_fts=true); only commit_fts
+            // needs the bulk 'rebuild' here (#77 Phase 2).
+            db.finalize_full_rebuild_fts()?;
+            mem_trace("after finalize_full_rebuild_fts");
             db.set_meta("indexed_at_ms", &now_ms().to_string())?;
             db.storage.execute_batch("COMMIT")?;
             mem_trace("after COMMIT");

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -135,6 +135,10 @@ impl IndexDatabase {
             ",
         )?;
         self.delete_staged_files_cascade()?;
+        // The shared dictionary is global (one row, not per-file), so the staged cascade above does
+        // not touch it. Clear it here so insert_chunks sees no dict mid-rebuild and skips per-row
+        // compression; build_chunk_text_store retrains + bulk-compresses once at the end (#77).
+        self.storage.execute_batch("DELETE FROM chunk_text_dict;")?;
         self.storage.execute_batch("DELETE FROM temp.staged_file_ids;")?;
         Ok(())
     }
@@ -207,6 +211,16 @@ impl IndexDatabase {
                 JOIN temp.staged_file_ids ON staged_file_ids.id = chunks.file_id
             );
             DELETE FROM main.docs
+            WHERE chunk_id IN (
+                SELECT chunks.id
+                FROM main.chunks
+                JOIN temp.staged_file_ids ON staged_file_ids.id = chunks.file_id
+            );
+            -- chunk_text cascades from chunks via FK, but enumerate it explicitly like the other
+            -- chunk-child tables (#77): the migration runner toggles foreign_keys = OFF, so a \
+             delete
+            -- that ran while FK was off would orphan compressed blobs.
+            DELETE FROM main.chunk_text
             WHERE chunk_id IN (
                 SELECT chunks.id
                 FROM main.chunks

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -84,7 +84,7 @@ impl IndexDatabase {
             db.build_chunk_text_store()?;
             mem_trace("after build_chunk_text_store");
             progress(IndexProgress::RebuildingFts);
-            // chunk_fts was written inline during chunk insert (write_fts=true); only commit_fts
+            // chunk_fts was written inline during chunk insert; only commit_fts
             // needs the bulk 'rebuild' here (#77 Phase 2).
             db.finalize_full_rebuild_fts()?;
             mem_trace("after finalize_full_rebuild_fts");

--- a/crates/rag-rat-core/src/index/schema/baseline.rs
+++ b/crates/rag-rat-core/src/index/schema/baseline.rs
@@ -53,7 +53,8 @@ pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
             end_byte INTEGER NOT NULL,
             start_line INTEGER NOT NULL,
             end_line INTEGER NOT NULL,
-            text TEXT NOT NULL,
+            -- Chunk text lives ONLY in the compressed chunk_text store (#77 Phase 2); there is no
+            -- inline text column. text_hash stays (it keys embedding/anchor freshness, not text).
             text_hash TEXT NOT NULL,
             source_revision TEXT NOT NULL DEFAULT '',
             anchor_version INTEGER NOT NULL DEFAULT 1,
@@ -78,21 +79,29 @@ pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
             -- raw_len is the decompress capacity; CHECK(>= 0) so a bad write can't become a huge
             -- usize at the read-side cast and blow up Vec::with_capacity.
             raw_len INTEGER NOT NULL CHECK(raw_len >= 0),
+            -- Which chunk_text_dict version compressed this blob: a zstd blob is only decodable
+            -- against the dict it was made with, so the dict is a per-blob decode key (#77 Phase \
+         2).
+            dict_version INTEGER NOT NULL,
             FOREIGN KEY(chunk_id) REFERENCES chunks(id) ON DELETE CASCADE
         ) STRICT;
 
-        -- The single shared zstd dictionary for chunk_text (#77). Stored IN the DB so a copied /
-        -- P2P-streamed index is self-contained: decompress anywhere with no extension. CHECK(id = \
-         1)
-        -- enforces the single-row invariant (two dict rows -> undefined which one wins -> every \
-         blob
-        -- fails to decompress); a dict_version bump retrains + recompresses ALL rows atomically \
-         (no
-        -- per-row version, so the recompress must be one transaction).
+        -- The zstd dictionaries for chunk_text (#77 Phase 2). A trained dict is an IMMUTABLE \
+         decode
+        -- KEY: blobs reference the version they were compressed against \
+         (chunk_text.dict_version), and
+        -- a dict is NEVER mutated/replaced in place (that would orphan every blob built against \
+         it —
+        -- the same footgun as gc nulling pool strings out from under live refs). The first index
+        -- trains version 1 and everything references it; a future retrain ADDS a new version and
+        -- compresses new blobs against it while old blobs keep pointing at theirs (both stay
+        -- resident, so decode is always possible). Stored IN the DB so a copied / P2P-streamed \
+         index
+        -- is self-contained. No FK from chunk_text into this table — gc sweeps versions with zero
+        -- referencing blobs (like the edge_strings pool).
         CREATE TABLE IF NOT EXISTS chunk_text_dict(
-            id INTEGER PRIMARY KEY CHECK(id = 1),
-            dict BLOB NOT NULL,
-            dict_version INTEGER NOT NULL DEFAULT 1
+            version INTEGER PRIMARY KEY,
+            dict BLOB NOT NULL
         ) STRICT;
 
         CREATE TABLE IF NOT EXISTS symbols(

--- a/crates/rag-rat-core/src/index/schema/baseline.rs
+++ b/crates/rag-rat-core/src/index/schema/baseline.rs
@@ -486,7 +486,7 @@ pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
         -- text, and does NOT point at `chunks` as a content table — so dropping `chunks.text` \
          can't
         -- break it. Tokens are written from the in-memory chunk text at index time (insert_chunks
-        -- with write_fts=true on every path). `contentless_delete=1` (SQLite >= 3.43) keeps
+        -- inline on every path). `contentless_delete=1` (SQLite >= 3.43) keeps
         -- delete-by-rowid working without a content row to read. Only MATCH + bm25() are used
         -- (snippets come from the compressed chunk_text store, not FTS), so contentless is \
          sufficient.
@@ -594,7 +594,7 @@ pub(crate) fn rebuild_commit_fts(conn: &Connection) -> anyhow::Result<()> {
     //
     // `chunk_fts` is NO LONGER rebuilt here: it is contentless (#77 Phase 2), so 'rebuild' (which
     // re-reads a content table) does not apply. Its tokens are written inline at index time
-    // (write_fts), and the recovery repopulate lives in `IndexDatabase::rebuild_chunk_fts` (it
+    // (insert_chunks), and the recovery repopulate lives in `IndexDatabase::rebuild_chunk_fts` (it
     // decompresses the chunk_text store, which a SQL-only rebuild here can't do).
     conn.execute_batch("INSERT INTO commit_fts(commit_fts) VALUES('rebuild');")?;
     Ok(())

--- a/crates/rag-rat-core/src/index/schema/baseline.rs
+++ b/crates/rag-rat-core/src/index/schema/baseline.rs
@@ -68,6 +68,26 @@ pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
             FOREIGN KEY(file_id) REFERENCES files(id) ON DELETE CASCADE
         );
 
+        -- Compressed chunk text (#77 Phase 2). The heavy chunks.text payload moves here as a
+        -- dictionary-trained zstd blob (one shared dict in chunk_text_dict), decompressed on read,
+        -- so the chunks row stays small. raw_len is the decompressed byte length = decompress
+        -- capacity. One blob per chunk preserves random-access reads.
+        CREATE TABLE IF NOT EXISTS chunk_text(
+            chunk_id INTEGER PRIMARY KEY,
+            blob BLOB NOT NULL,
+            raw_len INTEGER NOT NULL,
+            FOREIGN KEY(chunk_id) REFERENCES chunks(id) ON DELETE CASCADE
+        ) STRICT;
+
+        -- The single shared zstd dictionary for chunk_text (#77). Stored IN the DB so a copied /
+        -- P2P-streamed index is self-contained: decompress anywhere with no extension. Row id is
+        -- always 1; dict_version bumps force a retrain + recompress.
+        CREATE TABLE IF NOT EXISTS chunk_text_dict(
+            id INTEGER PRIMARY KEY,
+            dict BLOB NOT NULL,
+            dict_version INTEGER NOT NULL DEFAULT 1
+        ) STRICT;
+
         CREATE TABLE IF NOT EXISTS symbols(
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             file_id INTEGER NOT NULL,

--- a/crates/rag-rat-core/src/index/schema/baseline.rs
+++ b/crates/rag-rat-core/src/index/schema/baseline.rs
@@ -473,10 +473,18 @@ pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
             FOREIGN KEY(memory_id) REFERENCES repo_memories(id) ON DELETE CASCADE
         );
 
+        -- CONTENTLESS (#77 Phase 2): chunk_fts stores only the inverted index, NOT a copy of the
+        -- text, and does NOT point at `chunks` as a content table — so dropping `chunks.text` \
+         can't
+        -- break it. Tokens are written from the in-memory chunk text at index time (insert_chunks
+        -- with write_fts=true on every path). `contentless_delete=1` (SQLite >= 3.43) keeps
+        -- delete-by-rowid working without a content row to read. Only MATCH + bm25() are used
+        -- (snippets come from the compressed chunk_text store, not FTS), so contentless is \
+         sufficient.
         CREATE VIRTUAL TABLE IF NOT EXISTS chunk_fts USING fts5(
             text,
-            content='chunks',
-            content_rowid='id',
+            content='',
+            contentless_delete=1,
             tokenize='porter'
         );
 
@@ -568,19 +576,18 @@ pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
     Ok(())
 }
 
-pub(crate) fn rebuild_fts(conn: &Connection) -> anyhow::Result<()> {
-    // `chunk_fts` / `commit_fts` are external-content FTS5 tables (content='chunks' /
-    // content='git_commits'). The canonical way to rebuild an external-content index is the
-    // built-in 'rebuild' command, which re-reads the content table. An unqualified
-    // `DELETE FROM <table>` on an external-content FTS5 table corrupts the index when the FTS
-    // and content tables are out of sync (`database disk image is malformed`, SQLite 11/267) —
-    // see #51. 'rebuild' is desync-safe.
-    conn.execute_batch(
-        "
-        INSERT INTO chunk_fts(chunk_fts) VALUES('rebuild');
-        INSERT INTO commit_fts(commit_fts) VALUES('rebuild');
-        ",
-    )?;
+pub(crate) fn rebuild_commit_fts(conn: &Connection) -> anyhow::Result<()> {
+    // `commit_fts` is an external-content FTS5 table (content='git_commits'). The canonical way to
+    // rebuild an external-content index is the built-in 'rebuild' command, which re-reads the
+    // content table. An unqualified `DELETE FROM <table>` on an external-content FTS5 table
+    // corrupts the index when the FTS and content tables are out of sync (`database disk image
+    // is malformed`, SQLite 11/267) — see #51. 'rebuild' is desync-safe.
+    //
+    // `chunk_fts` is NO LONGER rebuilt here: it is contentless (#77 Phase 2), so 'rebuild' (which
+    // re-reads a content table) does not apply. Its tokens are written inline at index time
+    // (write_fts), and the recovery repopulate lives in `IndexDatabase::rebuild_chunk_fts` (it
+    // decompresses the chunk_text store, which a SQL-only rebuild here can't do).
+    conn.execute_batch("INSERT INTO commit_fts(commit_fts) VALUES('rebuild');")?;
     Ok(())
 }
 
@@ -588,35 +595,33 @@ pub(crate) fn rebuild_fts(conn: &Connection) -> anyhow::Result<()> {
 mod rebuild_fts_tests {
     use rusqlite::Connection;
 
-    // Reproduces #51: chunks present that were never inserted into the external-content
-    // `chunk_fts`. The old `DELETE FROM chunk_fts` rebuild corrupts the index on this desync;
-    // the 'rebuild' command recovers it and indexes the content.
+    // Reproduces #51 for the still-external-content `commit_fts`: a git_commits row present that
+    // was never inserted into commit_fts. The old `DELETE FROM <fts>` rebuild corrupts the
+    // index on this desync; the 'rebuild' command recovers it and indexes the content.
+    // (chunk_fts is now contentless — its recovery path is `IndexDatabase::rebuild_chunk_fts`,
+    // tested separately.)
     #[test]
-    fn rebuild_fts_recovers_a_desynced_external_content_index() {
+    fn rebuild_commit_fts_recovers_a_desynced_external_content_index() {
         let conn = Connection::open_in_memory().unwrap();
         super::super::apply(&conn).unwrap();
+        // Seed a commit WITHOUT a matching commit_fts row — the out-of-sync state from #51.
         conn.execute(
-            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
-             VALUES ('src/a.rs', 'rust', 'source', 'h', 0, 0)",
-            [],
-        )
-        .unwrap();
-        // Seed a chunk WITHOUT a matching chunk_fts row — the out-of-sync state from #51.
-        conn.execute(
-            "INSERT INTO chunks(file_id, chunk_kind, symbol_path, start_byte, end_byte,
-                                start_line, end_line, text, text_hash)
-             VALUES (1, 'symbol', 'alpha', 0, 10, 1, 5, 'fn alpha() { beta() }', 'th')",
+            "INSERT INTO git_commits(hash, author_name, author_email, authored_at_s,
+                                     committed_at_s, subject, body)
+             VALUES ('abc', 'A', 'a@e', 0, 0, 'fix the alpha regression', 'details about beta')",
             [],
         )
         .unwrap();
 
-        super::rebuild_fts(&conn).unwrap();
+        super::rebuild_commit_fts(&conn).unwrap();
 
         let hits: i64 = conn
-            .query_row("SELECT count(*) FROM chunk_fts WHERE chunk_fts MATCH 'alpha'", [], |row| {
-                row.get(0)
-            })
+            .query_row(
+                "SELECT count(*) FROM commit_fts WHERE commit_fts MATCH 'alpha'",
+                [],
+                |row| row.get(0),
+            )
             .unwrap();
-        assert_eq!(hits, 1, "rebuilt FTS index must be queryable and contain the chunk");
+        assert_eq!(hits, 1, "rebuilt commit_fts index must be queryable and contain the commit");
     }
 }

--- a/crates/rag-rat-core/src/index/schema/baseline.rs
+++ b/crates/rag-rat-core/src/index/schema/baseline.rs
@@ -75,15 +75,22 @@ pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
         CREATE TABLE IF NOT EXISTS chunk_text(
             chunk_id INTEGER PRIMARY KEY,
             blob BLOB NOT NULL,
-            raw_len INTEGER NOT NULL,
+            -- raw_len is the decompress capacity; CHECK(>= 0) so a bad write can't become a huge
+            -- usize at the read-side cast and blow up Vec::with_capacity.
+            raw_len INTEGER NOT NULL CHECK(raw_len >= 0),
             FOREIGN KEY(chunk_id) REFERENCES chunks(id) ON DELETE CASCADE
         ) STRICT;
 
         -- The single shared zstd dictionary for chunk_text (#77). Stored IN the DB so a copied /
-        -- P2P-streamed index is self-contained: decompress anywhere with no extension. Row id is
-        -- always 1; dict_version bumps force a retrain + recompress.
+        -- P2P-streamed index is self-contained: decompress anywhere with no extension. CHECK(id = \
+         1)
+        -- enforces the single-row invariant (two dict rows -> undefined which one wins -> every \
+         blob
+        -- fails to decompress); a dict_version bump retrains + recompresses ALL rows atomically \
+         (no
+        -- per-row version, so the recompress must be one transaction).
         CREATE TABLE IF NOT EXISTS chunk_text_dict(
-            id INTEGER PRIMARY KEY,
+            id INTEGER PRIMARY KEY CHECK(id = 1),
             dict BLOB NOT NULL,
             dict_version INTEGER NOT NULL DEFAULT 1
         ) STRICT;

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -695,11 +695,11 @@ pub(crate) fn apply_chunk_text_compression_tables(conn: &Connection) -> rusqlite
         CREATE TABLE IF NOT EXISTS chunk_text(
             chunk_id INTEGER PRIMARY KEY,
             blob BLOB NOT NULL,
-            raw_len INTEGER NOT NULL,
+            raw_len INTEGER NOT NULL CHECK(raw_len >= 0),
             FOREIGN KEY(chunk_id) REFERENCES chunks(id) ON DELETE CASCADE
         ) STRICT;
         CREATE TABLE IF NOT EXISTS chunk_text_dict(
-            id INTEGER PRIMARY KEY,
+            id INTEGER PRIMARY KEY CHECK(id = 1),
             dict BLOB NOT NULL,
             dict_version INTEGER NOT NULL DEFAULT 1
         ) STRICT;

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -707,6 +707,29 @@ pub(crate) fn apply_chunk_text_compression_tables(conn: &Connection) -> rusqlite
     )
 }
 
+/// V026 (#77 Phase 2): recreate `chunk_fts` as a CONTENTLESS FTS5 index (it was external-content,
+/// `content='chunks'`) and repopulate it from `chunks.text` — which still exists at migration time
+/// (the column drop is the later V027). Going contentless is the prerequisite for dropping
+/// `chunks.text`: an external-content index re-reads that column on every rebuild. After this,
+/// tokens are written inline at index time (`write_fts`), so the column drop can't break the index.
+/// DROP+CREATE (not idempotent `IF NOT EXISTS`) is intended: a pre-V026 DB has the external-content
+/// table and must be converted; a fresh DB already has the contentless table from the baseline and
+/// this rebuilds it empty (the SELECT over zero chunks is a no-op).
+pub(crate) fn apply_contentless_chunk_fts(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS chunk_fts;
+        CREATE VIRTUAL TABLE chunk_fts USING fts5(
+            text,
+            content='',
+            contentless_delete=1,
+            tokenize='porter'
+        );
+        INSERT INTO chunk_fts(rowid, text) SELECT id, text FROM chunks;
+        ",
+    )
+}
+
 pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
     let legacy_table: Option<String> = conn
         .query_row(
@@ -1036,6 +1059,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_023_ID => Some(23),
             MIGRATION_024_ID => Some(24),
             MIGRATION_025_ID => Some(25),
+            MIGRATION_026_ID => Some(26),
             _ => None,
         })
         .max()
@@ -1070,6 +1094,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_023_ID
             | MIGRATION_024_ID
             | MIGRATION_025_ID
+            | MIGRATION_026_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1101,6 +1126,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_023_ID => migration.checksum != MIGRATION_023_CHECKSUM,
         MIGRATION_024_ID => migration.checksum != MIGRATION_024_CHECKSUM,
         MIGRATION_025_ID => migration.checksum != MIGRATION_025_CHECKSUM,
+        MIGRATION_026_ID => migration.checksum != MIGRATION_026_CHECKSUM,
         _ => false,
     }
 }

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -675,6 +675,13 @@ pub(crate) fn apply_dispatch_edge_facts_view_exclusion(conn: &Connection) -> rus
 /// needs no `%`-escaping of the `[`/`(` in the markers.)
 pub(crate) fn apply_files_has_test_code(conn: &Connection) -> rusqlite::Result<()> {
     add_column_if_missing(conn, "files", "has_test_code", "INTEGER NOT NULL DEFAULT 0")?;
+    // The backfill reads chunks.text. On a fresh DB the baseline omits that column (V027 retired
+    // it), and there is nothing to backfill — chunks is empty and the index-time path sets
+    // has_test_code. Only a pre-V027 forward-migrate (column still present, chunks populated)
+    // needs the backfill.
+    if !column_exists(conn, "chunks", "text")? {
+        return Ok(());
+    }
     conn.execute_batch(
         "UPDATE files SET has_test_code = 1 WHERE id IN (
              SELECT DISTINCT file_id FROM chunks
@@ -696,12 +703,12 @@ pub(crate) fn apply_chunk_text_compression_tables(conn: &Connection) -> rusqlite
             chunk_id INTEGER PRIMARY KEY,
             blob BLOB NOT NULL,
             raw_len INTEGER NOT NULL CHECK(raw_len >= 0),
+            dict_version INTEGER NOT NULL,
             FOREIGN KEY(chunk_id) REFERENCES chunks(id) ON DELETE CASCADE
         ) STRICT;
         CREATE TABLE IF NOT EXISTS chunk_text_dict(
-            id INTEGER PRIMARY KEY CHECK(id = 1),
-            dict BLOB NOT NULL,
-            dict_version INTEGER NOT NULL DEFAULT 1
+            version INTEGER PRIMARY KEY,
+            dict BLOB NOT NULL
         ) STRICT;
         ",
     )
@@ -716,6 +723,22 @@ pub(crate) fn apply_chunk_text_compression_tables(conn: &Connection) -> rusqlite
 /// table and must be converted; a fresh DB already has the contentless table from the baseline and
 /// this rebuilds it empty (the SELECT over zero chunks is a no-op).
 pub(crate) fn apply_contentless_chunk_fts(conn: &Connection) -> rusqlite::Result<()> {
+    // IDEMPOTENT: this migration's DROP+CREATE is destructive (it discards the chunk_fts index),
+    // and `schema::apply` re-runs every additive migration on each call, so converting
+    // unconditionally would wipe the inline-written contentless index on every open/rebuild.
+    // Only convert when chunk_fts is still the OLD external-content table; if it is already
+    // contentless (or absent — the baseline creates it contentless), do nothing.
+    let already_contentless: bool = conn.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM sqlite_master
+             WHERE name = 'chunk_fts' AND sql NOT LIKE '%content=''chunks''%'
+         )",
+        [],
+        |row| row.get(0),
+    )?;
+    if already_contentless {
+        return Ok(());
+    }
     conn.execute_batch(
         "
         DROP TABLE IF EXISTS chunk_fts;
@@ -725,9 +748,16 @@ pub(crate) fn apply_contentless_chunk_fts(conn: &Connection) -> rusqlite::Result
             contentless_delete=1,
             tokenize='porter'
         );
-        INSERT INTO chunk_fts(rowid, text) SELECT id, text FROM chunks;
         ",
-    )
+    )?;
+    // Repopulate from chunks.text only on a pre-V027 forward-migrate, where the column still
+    // exists. On a fresh DB the baseline omits chunks.text (and chunks is empty), so there is
+    // nothing to repopulate — the inline write_fts path fills chunk_fts during the rebuild
+    // instead.
+    if column_exists(conn, "chunks", "text")? {
+        conn.execute("INSERT INTO chunk_fts(rowid, text) SELECT id, text FROM chunks", [])?;
+    }
+    Ok(())
 }
 
 pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
@@ -1060,6 +1090,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_024_ID => Some(24),
             MIGRATION_025_ID => Some(25),
             MIGRATION_026_ID => Some(26),
+            MIGRATION_027_ID => Some(27),
             _ => None,
         })
         .max()
@@ -1095,6 +1126,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_024_ID
             | MIGRATION_025_ID
             | MIGRATION_026_ID
+            | MIGRATION_027_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1127,6 +1159,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_024_ID => migration.checksum != MIGRATION_024_CHECKSUM,
         MIGRATION_025_ID => migration.checksum != MIGRATION_025_CHECKSUM,
         MIGRATION_026_ID => migration.checksum != MIGRATION_026_CHECKSUM,
+        MIGRATION_027_ID => migration.checksum != MIGRATION_027_CHECKSUM,
         _ => false,
     }
 }
@@ -1179,6 +1212,41 @@ pub(crate) fn add_column_if_missing(
     }
 
     conn.execute_batch(&format!("ALTER TABLE {table} ADD COLUMN {column} {definition}"))
+}
+
+pub(crate) fn column_exists(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+) -> rusqlite::Result<bool> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})"))?;
+    let rows = stmt.query_map([], |row| row.get::<_, String>(1))?;
+    for row in rows {
+        if row? == column {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// V027 (#77 Phase 2): retire the `chunks.text` column — the irreversible payoff step. A fresh DB's
+/// baseline already omits the column; a forward-migrated index still has it plus a (possibly empty)
+/// `chunk_text` store. Build the compressed store FROM `chunks.text` (its last read), guaranteeing
+/// every chunk has a blob, THEN drop the column. Guarded by `column_exists` so a fresh DB (no
+/// column) or a re-run is a clean no-op.
+pub(crate) fn apply_drop_chunks_text(conn: &Connection) -> rusqlite::Result<()> {
+    if !column_exists(conn, "chunks", "text")? {
+        return Ok(());
+    }
+    crate::index::chunk_text_store::build_store(conn, "(SELECT id AS chunk_id, text FROM chunks)")
+        .map_err(|err| {
+            rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_ERROR),
+                Some(format!("V027 chunk_text backfill failed before dropping chunks.text: {err}")),
+            )
+        })?;
+    conn.execute("ALTER TABLE chunks DROP COLUMN text", [])?;
+    Ok(())
 }
 
 pub(crate) fn apply_commit_addressable_worktrees(conn: &Connection) -> rusqlite::Result<()> {

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -684,6 +684,29 @@ pub(crate) fn apply_files_has_test_code(conn: &Connection) -> rusqlite::Result<(
     )
 }
 
+/// V025 (#77): create the chunk_text (zstd blob) + chunk_text_dict (shared dictionary) tables for
+/// compressed chunk text. Additive + idempotent (CREATE TABLE IF NOT EXISTS); a fresh DB already
+/// has them from the baseline. NO backfill here — populating chunk_text + retiring chunks.text is
+/// driven by the index pipeline (compress at write) once the read paths decompress from chunk_text,
+/// so the data move isn't an irreversible one-shot in the migration.
+pub(crate) fn apply_chunk_text_compression_tables(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS chunk_text(
+            chunk_id INTEGER PRIMARY KEY,
+            blob BLOB NOT NULL,
+            raw_len INTEGER NOT NULL,
+            FOREIGN KEY(chunk_id) REFERENCES chunks(id) ON DELETE CASCADE
+        ) STRICT;
+        CREATE TABLE IF NOT EXISTS chunk_text_dict(
+            id INTEGER PRIMARY KEY,
+            dict BLOB NOT NULL,
+            dict_version INTEGER NOT NULL DEFAULT 1
+        ) STRICT;
+        ",
+    )
+}
+
 pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
     let legacy_table: Option<String> = conn
         .query_row(
@@ -1012,6 +1035,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_022_ID => Some(22),
             MIGRATION_023_ID => Some(23),
             MIGRATION_024_ID => Some(24),
+            MIGRATION_025_ID => Some(25),
             _ => None,
         })
         .max()
@@ -1045,6 +1069,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_022_ID
             | MIGRATION_023_ID
             | MIGRATION_024_ID
+            | MIGRATION_025_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1075,6 +1100,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_022_ID => migration.checksum != MIGRATION_022_CHECKSUM,
         MIGRATION_023_ID => migration.checksum != MIGRATION_023_CHECKSUM,
         MIGRATION_024_ID => migration.checksum != MIGRATION_024_CHECKSUM,
+        MIGRATION_025_ID => migration.checksum != MIGRATION_025_CHECKSUM,
         _ => false,
     }
 }

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -718,7 +718,7 @@ pub(crate) fn apply_chunk_text_compression_tables(conn: &Connection) -> rusqlite
 /// `content='chunks'`) and repopulate it from `chunks.text` — which still exists at migration time
 /// (the column drop is the later V027). Going contentless is the prerequisite for dropping
 /// `chunks.text`: an external-content index re-reads that column on every rebuild. After this,
-/// tokens are written inline at index time (`write_fts`), so the column drop can't break the index.
+/// tokens are written inline at index time, so the column drop can't break the index.
 /// DROP+CREATE (not idempotent `IF NOT EXISTS`) is intended: a pre-V026 DB has the external-content
 /// table and must be converted; a fresh DB already has the contentless table from the baseline and
 /// this rebuilds it empty (the SELECT over zero chunks is a no-op).
@@ -752,7 +752,7 @@ pub(crate) fn apply_contentless_chunk_fts(conn: &Connection) -> rusqlite::Result
     )?;
     // Repopulate from chunks.text only on a pre-V027 forward-migrate, where the column still
     // exists. On a fresh DB the baseline omits chunks.text (and chunks is empty), so there is
-    // nothing to repopulate — the inline write_fts path fills chunk_fts during the rebuild
+    // nothing to repopulate — the inline write path fills chunk_fts during the rebuild
     // instead.
     if column_exists(conn, "chunks", "text")? {
         conn.execute("INSERT INTO chunk_fts(rowid, text) SELECT id, text FROM chunks", [])?;

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use migrations::*;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 26;
+pub const LATEST_SCHEMA_VERSION: u32 = 27;
 const DIRTY_MIGRATION_ID: &str = "__dirty__";
 const MIGRATION_001_ID: &str = "001_sqlite_storage_baseline";
 const MIGRATION_001_CHECKSUM: &str = "sha256:rag-rat-sqlite-baseline-v1";
@@ -114,6 +114,10 @@ const MIGRATION_026_CHECKSUM: &str = "sha256:rag-rat-contentless-chunk-fts-v26";
 const MIGRATION_026_DESCRIPTION: &str = "Recreate chunk_fts as a contentless FTS5 index and \
                                          repopulate it, so chunks.text can be dropped (#77 Phase \
                                          2)";
+const MIGRATION_027_ID: &str = "027_drop_chunks_text";
+const MIGRATION_027_CHECKSUM: &str = "sha256:rag-rat-drop-chunks-text-v27";
+const MIGRATION_027_DESCRIPTION: &str = "Build the compressed chunk_text store from chunks.text, \
+                                         then drop the chunks.text column (#77 Phase 2)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -347,6 +351,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_026_CHECKSUM,
         description: MIGRATION_026_DESCRIPTION,
         apply: apply_contentless_chunk_fts,
+    },
+    Migration {
+        id: MIGRATION_027_ID,
+        checksum: MIGRATION_027_CHECKSUM,
+        description: MIGRATION_027_DESCRIPTION,
+        apply: apply_drop_chunks_text,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use migrations::*;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 24;
+pub const LATEST_SCHEMA_VERSION: u32 = 25;
 const DIRTY_MIGRATION_ID: &str = "__dirty__";
 const MIGRATION_001_ID: &str = "001_sqlite_storage_baseline";
 const MIGRATION_001_CHECKSUM: &str = "sha256:rag-rat-sqlite-baseline-v1";
@@ -105,6 +105,10 @@ const MIGRATION_024_CHECKSUM: &str = "sha256:rag-rat-files-has-test-code-v24";
 const MIGRATION_024_DESCRIPTION: &str = "Add files.has_test_code flag (precomputed test-marker \
                                          detection) so impact_surface avoids a chunks.text scan \
                                          (#77)";
+const MIGRATION_025_ID: &str = "025_chunk_text_compression_tables";
+const MIGRATION_025_CHECKSUM: &str = "sha256:rag-rat-chunk-text-compression-tables-v25";
+const MIGRATION_025_DESCRIPTION: &str = "Add chunk_text (zstd blob) + chunk_text_dict (shared \
+                                         dictionary) tables for compressed chunk text (#77)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -326,6 +330,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_024_CHECKSUM,
         description: MIGRATION_024_DESCRIPTION,
         apply: apply_files_has_test_code,
+    },
+    Migration {
+        id: MIGRATION_025_ID,
+        checksum: MIGRATION_025_CHECKSUM,
+        description: MIGRATION_025_DESCRIPTION,
+        apply: apply_chunk_text_compression_tables,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use migrations::*;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 25;
+pub const LATEST_SCHEMA_VERSION: u32 = 26;
 const DIRTY_MIGRATION_ID: &str = "__dirty__";
 const MIGRATION_001_ID: &str = "001_sqlite_storage_baseline";
 const MIGRATION_001_CHECKSUM: &str = "sha256:rag-rat-sqlite-baseline-v1";
@@ -109,6 +109,11 @@ const MIGRATION_025_ID: &str = "025_chunk_text_compression_tables";
 const MIGRATION_025_CHECKSUM: &str = "sha256:rag-rat-chunk-text-compression-tables-v25";
 const MIGRATION_025_DESCRIPTION: &str = "Add chunk_text (zstd blob) + chunk_text_dict (shared \
                                          dictionary) tables for compressed chunk text (#77)";
+const MIGRATION_026_ID: &str = "026_contentless_chunk_fts";
+const MIGRATION_026_CHECKSUM: &str = "sha256:rag-rat-contentless-chunk-fts-v26";
+const MIGRATION_026_DESCRIPTION: &str = "Recreate chunk_fts as a contentless FTS5 index and \
+                                         repopulate it, so chunks.text can be dropped (#77 Phase \
+                                         2)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -336,6 +341,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_025_CHECKSUM,
         description: MIGRATION_025_DESCRIPTION,
         apply: apply_chunk_text_compression_tables,
+    },
+    Migration {
+        id: MIGRATION_026_ID,
+        checksum: MIGRATION_026_CHECKSUM,
+        description: MIGRATION_026_DESCRIPTION,
+        apply: apply_contentless_chunk_fts,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -10467,6 +10467,50 @@ fn rebuild_with_files_but_no_chunks_still_trains_a_dict_so_incrementals_dont_orp
 }
 
 #[test]
+fn open_under_a_held_write_lock_migrates_older_schema_without_deadlock() {
+    // #226 regression: a CLI write command (index/maintenance/oracle) and a watcher pass hold the
+    // per-DB write lock, then open the index — which may migrate an Older schema UNDER the same
+    // lock. With a raw file lock that self-deadlocks (same process, second fd → flock blocks → 30s
+    // timeout, schema never migrates). WriteLock is reentrant on the holding thread, so the
+    // open-time migrate re-enters instead of blocking.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn f() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db_path = config.database.clone();
+
+    // Build a current index, then make it look Older by removing the newest migration's ledger row
+    // (the DDL stays applied; only the version regresses, so the re-run is an idempotent no-op).
+    {
+        let db = IndexDatabase::rebuild(&config).unwrap();
+        db.storage
+            .connection()
+            .execute("DELETE FROM schema_version WHERE id = '027_drop_chunks_text'", [])
+            .unwrap();
+        assert_eq!(
+            schema::status(db.storage.connection()).unwrap().state,
+            schema::SchemaState::Older,
+            "removing the V027 ledger row makes the schema Older"
+        );
+    }
+
+    // Hold the write lock exactly as the CLI `index` command does, then open under it. Pre-#226
+    // this blocked 30s on the migrate lock and errored; now it migrates immediately.
+    let _lock = crate::locks::WriteLock::acquire_blocking(&db_path).unwrap();
+    let db =
+        IndexDatabase::open(&db_path).expect("open migrates the Older schema under the held lock");
+    assert_eq!(
+        schema::status(db.storage.connection()).unwrap().state,
+        schema::SchemaState::Compatible,
+        "open re-ran the migration under the held lock; the schema is current"
+    );
+
+    drop(_lock);
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
 fn v022_fresh_apply_creates_packages_and_dedicated_import_scope_columns() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -10164,12 +10164,37 @@ fn conn_table_exists(conn: &rusqlite::Connection, table: &str) -> bool {
 /// persisted pointer). The oracle's `callee_*` columns are untouched (the columns are dedicated,
 /// not a callee overload).
 #[test]
+fn v025_creates_chunk_text_compression_tables() {
+    // #77 Phase 2: the chunk_text (zstd blob) + chunk_text_dict (shared dictionary) tables exist
+    // after a fresh apply (baseline) AND a forward-migrate (V025).
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
+    for t in ["chunk_text", "chunk_text_dict"] {
+        assert!(conn_table_exists(&conn, t), "{t} created on fresh apply");
+    }
+    let cols = conn_table_columns(&conn, "chunk_text");
+    for expected in ["chunk_id", "blob", "raw_len"] {
+        assert!(cols.contains(&expected.to_string()), "chunk_text missing {expected}");
+    }
+    // Forward-migrate path: drop the tables + the V025 ledger row, re-apply → recreated.
+    conn.execute_batch(
+        "DROP TABLE chunk_text; DROP TABLE chunk_text_dict;
+         DELETE FROM schema_version WHERE id = '025_chunk_text_compression_tables';",
+    )
+    .unwrap();
+    schema::apply(&conn).unwrap();
+    assert!(conn_table_exists(&conn, "chunk_text"), "V025 recreates chunk_text on forward migrate");
+    assert!(conn_table_exists(&conn, "chunk_text_dict"));
+}
+
+#[test]
 fn v022_fresh_apply_creates_packages_and_dedicated_import_scope_columns() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
 
     assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 24);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 25);
     assert!(conn_table_exists(&conn, "packages"), "packages table is created on a fresh apply");
 
     let package_cols = conn_table_columns(&conn, "packages");
@@ -10239,6 +10264,7 @@ fn v022_forward_migrate_adds_artifacts_to_an_older_index() {
         -- the parts already present.)
         DELETE FROM schema_version WHERE id = '023_dispatch_edge_facts_view_exclusion';
         DELETE FROM schema_version WHERE id = '024_files_has_test_code';
+        DELETE FROM schema_version WHERE id = '025_chunk_text_compression_tables';
         ",
     )
     .unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -10186,6 +10186,23 @@ fn v025_creates_chunk_text_compression_tables() {
     schema::apply(&conn).unwrap();
     assert!(conn_table_exists(&conn, "chunk_text"), "V025 recreates chunk_text on forward migrate");
     assert!(conn_table_exists(&conn, "chunk_text_dict"));
+
+    // CHECK constraints (adversary-found). chunk_text_dict is single-row (id = 1); a second dict
+    // row would make "which dict wins" undefined → every blob throws Dictionary mismatch.
+    conn.execute("INSERT INTO chunk_text_dict(id, dict, dict_version) VALUES (1, x'00', 1)", [])
+        .unwrap();
+    assert!(
+        conn.execute("INSERT INTO chunk_text_dict(id, dict, dict_version) VALUES (2, x'00', 1)", [
+        ])
+        .is_err(),
+        "chunk_text_dict rejects id != 1"
+    );
+    // raw_len is the decompress capacity; a negative value would cast to a huge usize.
+    assert!(
+        conn.execute("INSERT INTO chunk_text(chunk_id, blob, raw_len) VALUES (1, x'00', -1)", [])
+            .is_err(),
+        "chunk_text rejects negative raw_len"
+    );
 }
 
 #[test]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -10250,6 +10250,54 @@ fn full_rebuild_populates_the_chunk_text_store() {
 }
 
 #[test]
+fn incremental_heal_maintains_the_chunk_text_store() {
+    // #77 Phase 2 (2b-2a): the incremental/heal path writes chunk_text inline with the existing
+    // dict, so a healed file's compressed blobs match its NEW text (the old rows cascade out with
+    // the chunks). Without this, chunk_text would go stale on every incremental update.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn original() -> u8 { 1 }\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    // Change the file on disk, then heal it (the incremental path: remove + re-index).
+    fs::write(root.join("src/a.rs"), "pub fn changed() -> u8 { 2 }\npub fn added() {}\n").unwrap();
+    db.heal_file(std::path::Path::new("src/a.rs")).unwrap();
+
+    let conn = db.storage.connection();
+    let chunks: i64 = conn.query_row("SELECT COUNT(*) FROM chunks", [], |r| r.get(0)).unwrap();
+    let stored: i64 = conn.query_row("SELECT COUNT(*) FROM chunk_text", [], |r| r.get(0)).unwrap();
+    assert_eq!(
+        stored, chunks,
+        "heal kept chunk_text one-to-one with chunks (no stale/orphan rows)"
+    );
+    let dict: Vec<u8> =
+        conn.query_row("SELECT dict FROM chunk_text_dict WHERE id = 1", [], |r| r.get(0)).unwrap();
+    let mut stmt = conn
+        .prepare(
+            "SELECT c.text, ct.blob, ct.raw_len FROM chunks c JOIN chunk_text ct ON ct.chunk_id = \
+             c.id",
+        )
+        .unwrap();
+    let rows = stmt
+        .query_map([], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, Vec<u8>>(1)?, r.get::<_, i64>(2)?))
+        })
+        .unwrap();
+    let mut saw_changed = false;
+    for row in rows {
+        let (text, blob, raw_len) = row.unwrap();
+        let back = super::text_compression::decompress(&blob, &dict, raw_len as usize).unwrap();
+        assert_eq!(back, text.as_bytes(), "blob round-trips to the chunk's CURRENT text");
+        saw_changed |= text.contains("changed");
+    }
+    assert!(saw_changed, "the healed file's NEW text is what's stored, not the rebuild-time text");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
 fn v022_fresh_apply_creates_packages_and_dedicated_import_scope_columns() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -10206,6 +10206,113 @@ fn v025_creates_chunk_text_compression_tables() {
 }
 
 #[test]
+fn v026_recreates_chunk_fts_contentless_and_repopulates() {
+    // #77 Phase 2: chunk_fts becomes a CONTENTLESS FTS5 index. Fresh apply yields a contentless
+    // table that supports delete-by-rowid (contentless_delete=1); the forward-migrate (V026)
+    // converts an existing external-content table and repopulates it from chunks.text.
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+
+    let fts_sql: String = conn
+        .query_row("SELECT sql FROM sqlite_master WHERE name = 'chunk_fts'", [], |r| r.get(0))
+        .unwrap();
+    assert!(fts_sql.contains("content=''"), "chunk_fts must be contentless: {fts_sql}");
+    assert!(
+        fts_sql.contains("contentless_delete=1"),
+        "chunk_fts needs contentless_delete: {fts_sql}"
+    );
+    // Contentless delete-by-rowid round-trip (the incremental delete path relies on this).
+    conn.execute("INSERT INTO chunk_fts(rowid, text) VALUES (1, 'alpha beta')", []).unwrap();
+    let before: i64 = conn
+        .query_row("SELECT count(*) FROM chunk_fts WHERE chunk_fts MATCH 'alpha'", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(before, 1);
+    conn.execute("DELETE FROM chunk_fts WHERE rowid = 1", []).unwrap();
+    let after: i64 = conn
+        .query_row("SELECT count(*) FROM chunk_fts WHERE chunk_fts MATCH 'alpha'", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(after, 0, "contentless_delete=1 removes the row by rowid");
+
+    // Forward-migrate: rebuild an OLD external-content chunk_fts with a seeded chunk, drop the V026
+    // ledger row, re-apply → V026 converts to contentless and repopulates from chunks.text.
+    conn.execute(
+        "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
+         VALUES ('src/a.rs', 'rust', 'source', 'h', 0, 0)",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO chunks(file_id, chunk_kind, symbol_path, start_byte, end_byte,
+                            start_line, end_line, text, text_hash)
+         VALUES (1, 'symbol', 'gamma', 0, 10, 1, 5, 'fn gamma() { delta() }', 'th')",
+        [],
+    )
+    .unwrap();
+    conn.execute_batch(
+        "DROP TABLE chunk_fts;
+         CREATE VIRTUAL TABLE chunk_fts USING fts5(text, content='chunks', content_rowid='id', \
+         tokenize='porter');
+         INSERT INTO chunk_fts(chunk_fts) VALUES('rebuild');
+         DELETE FROM schema_version WHERE id = '026_contentless_chunk_fts';",
+    )
+    .unwrap();
+    schema::apply(&conn).unwrap();
+
+    let migrated_sql: String = conn
+        .query_row("SELECT sql FROM sqlite_master WHERE name = 'chunk_fts'", [], |r| r.get(0))
+        .unwrap();
+    assert!(
+        migrated_sql.contains("content=''"),
+        "V026 makes chunk_fts contentless: {migrated_sql}"
+    );
+    let hits: i64 = conn
+        .query_row("SELECT count(*) FROM chunk_fts WHERE chunk_fts MATCH 'gamma'", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(hits, 1, "V026 repopulates chunk_fts from chunks.text");
+}
+
+#[test]
+fn rebuild_fts_repopulates_contentless_chunk_fts_from_the_store() {
+    // #77 Phase 2 recovery path: if the contentless chunk_fts is emptied/desynced,
+    // IndexDatabase::rebuild_fts repopulates it by decompressing the chunk_text store (it does not
+    // re-read chunks.text), and search works again.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn alpha_recovery() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let match_count = |db: &IndexDatabase| -> i64 {
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT count(*) FROM chunk_fts WHERE chunk_fts MATCH 'alpha_recovery'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap()
+    };
+
+    // The full rebuild writes chunk_fts inline (write_fts=true).
+    assert_eq!(match_count(&db), 1, "full rebuild writes chunk_fts inline");
+
+    // Simulate a desync: clear the contentless index, then recover.
+    db.storage
+        .connection()
+        .execute("INSERT INTO chunk_fts(chunk_fts) VALUES('delete-all')", [])
+        .unwrap();
+    assert_eq!(match_count(&db), 0);
+    db.rebuild_fts().unwrap();
+    assert_eq!(
+        match_count(&db),
+        1,
+        "rebuild_fts repopulates contentless chunk_fts from chunk_text"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn full_rebuild_populates_the_chunk_text_store() {
     // #77 Phase 2: a full rebuild compresses every chunk into chunk_text against the shared dict,
     // and every stored blob round-trips to its chunks.text.
@@ -10303,7 +10410,7 @@ fn v022_fresh_apply_creates_packages_and_dedicated_import_scope_columns() {
     schema::apply(&conn).unwrap();
 
     assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 25);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 26);
     assert!(conn_table_exists(&conn, "packages"), "packages table is created on a fresh apply");
 
     let package_cols = conn_table_columns(&conn, "packages");
@@ -10374,6 +10481,7 @@ fn v022_forward_migrate_adds_artifacts_to_an_older_index() {
         DELETE FROM schema_version WHERE id = '023_dispatch_edge_facts_view_exclusion';
         DELETE FROM schema_version WHERE id = '024_files_has_test_code';
         DELETE FROM schema_version WHERE id = '025_chunk_text_compression_tables';
+        DELETE FROM schema_version WHERE id = '026_contentless_chunk_fts';
         ",
     )
     .unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -10309,7 +10309,7 @@ fn rebuild_fts_repopulates_contentless_chunk_fts_from_the_store() {
             .unwrap()
     };
 
-    // The full rebuild writes chunk_fts inline (write_fts=true).
+    // The full rebuild writes chunk_fts inline.
     assert_eq!(match_count(&db), 1, "full rebuild writes chunk_fts inline");
 
     // Simulate a desync: clear the contentless index, then recover.
@@ -10412,6 +10412,56 @@ fn incremental_heal_maintains_the_chunk_text_store() {
         "the healed file's NEW text is what's stored"
     );
     assert!(!corpus.contains("original"), "stale pre-heal text is gone from the store");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn rebuild_with_files_but_no_chunks_still_trains_a_dict_so_incrementals_dont_orphan() {
+    // #77 Phase 2 regression (adversarial finding). A full rebuild that indexes a file producing
+    // ZERO chunks — a whitespace-only markdown file (markdown_chunks has no whole-file fallback) —
+    // must still establish dict version 1. Pre-fix, build_store early-returned on an empty corpus,
+    // leaving the index dict-less with files present; the next incremental/heal then hit
+    // insert_chunks' "no dict" branch, which stages into the rebuild-only `temp.rebuild_chunk_text`
+    // and either ORPHANED the new chunk (same connection: a live chunk with no chunk_text row,
+    // which every reader's INNER JOIN silently drops) or errored "no such table" (fresh
+    // connection).
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/empty.md"), "   \n\t\n  \n").unwrap();
+    let config = source_config(root.clone(), Language::Markdown);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    {
+        let conn = db.storage.connection();
+        let files: i64 = conn.query_row("SELECT COUNT(*) FROM files", [], |r| r.get(0)).unwrap();
+        let chunks: i64 = conn.query_row("SELECT COUNT(*) FROM chunks", [], |r| r.get(0)).unwrap();
+        let dicts: i64 =
+            conn.query_row("SELECT COUNT(*) FROM chunk_text_dict", [], |r| r.get(0)).unwrap();
+        assert!(files >= 1, "the whitespace-only markdown file was indexed");
+        assert_eq!(chunks, 0, "it produced zero chunks");
+        assert_eq!(dicts, 1, "version 1 is established even with zero chunks (the fix)");
+    }
+
+    // The (already-tracked) file gains real content; heal it on the SAME connection. Pre-fix this
+    // orphaned the resulting chunk; post-fix it compresses inline against the established v1 dict.
+    fs::write(root.join("src/empty.md"), "# Title\n\nReal content that yields a chunk.\n").unwrap();
+    db.heal_file(std::path::Path::new("src/empty.md")).unwrap();
+    let conn = db.storage.connection();
+    let chunks: i64 = conn.query_row("SELECT COUNT(*) FROM chunks", [], |r| r.get(0)).unwrap();
+    let stored: i64 = conn.query_row("SELECT COUNT(*) FROM chunk_text", [], |r| r.get(0)).unwrap();
+    assert!(chunks >= 1, "the real markdown file produced a chunk");
+    let orphans: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM chunks
+             LEFT JOIN chunk_text ON chunk_text.chunk_id = chunks.id
+             WHERE chunk_text.chunk_id IS NULL",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(orphans, 0, "no live chunk lacks a chunk_text blob (readers INNER JOIN it)");
+    assert_eq!(stored, chunks, "chunk_text is one-to-one with chunks");
 
     let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -506,11 +506,11 @@ fn full_rebuild_preserves_other_worktree_contexts() {
             "
                 INSERT INTO main.chunks(
                     file_id, chunk_kind, symbol_path, start_byte, end_byte, start_line, end_line,
-                    text, text_hash, source_revision, anchor_version, normalized_hash,
+                    text_hash, source_revision, anchor_version, normalized_hash,
                     start_boundary_hash, end_boundary_hash, start_context_hash, end_context_hash,
                     context_radius, embedding_policy, embedding_priority
                 )
-                VALUES (?1, 'symbol', 'other_context', 0, 12, 1, 1, 'other context', 'other-text',
+                VALUES (?1, 'symbol', 'other_context', 0, 12, 1, 1, 'other-text',
                     'other-sha', 1, '', '', '', '', '', 2, 'Embed', 1)
                 RETURNING id
                 ",
@@ -518,6 +518,14 @@ fn full_rebuild_preserves_other_worktree_contexts() {
             |row| row.get::<_, i64>(0),
         )
         .unwrap();
+    // chunks.text is gone (#77 Phase 2); seed the chunk_text blob readers INNER JOIN. (The
+    // chunk_fts row for this other-context chunk is seeded a few lines below.)
+    crate::index::chunk_text_store::seed_chunk_text(
+        db.storage.connection(),
+        other_chunk_id,
+        "other context",
+    )
+    .unwrap();
     db.storage
         .connection()
         .execute(
@@ -10174,7 +10182,7 @@ fn v025_creates_chunk_text_compression_tables() {
         assert!(conn_table_exists(&conn, t), "{t} created on fresh apply");
     }
     let cols = conn_table_columns(&conn, "chunk_text");
-    for expected in ["chunk_id", "blob", "raw_len"] {
+    for expected in ["chunk_id", "blob", "raw_len", "dict_version"] {
         assert!(cols.contains(&expected.to_string()), "chunk_text missing {expected}");
     }
     // Forward-migrate path: drop the tables + the V025 ledger row, re-apply → recreated.
@@ -10187,20 +10195,20 @@ fn v025_creates_chunk_text_compression_tables() {
     assert!(conn_table_exists(&conn, "chunk_text"), "V025 recreates chunk_text on forward migrate");
     assert!(conn_table_exists(&conn, "chunk_text_dict"));
 
-    // CHECK constraints (adversary-found). chunk_text_dict is single-row (id = 1); a second dict
-    // row would make "which dict wins" undefined → every blob throws Dictionary mismatch.
-    conn.execute("INSERT INTO chunk_text_dict(id, dict, dict_version) VALUES (1, x'00', 1)", [])
-        .unwrap();
-    assert!(
-        conn.execute("INSERT INTO chunk_text_dict(id, dict, dict_version) VALUES (2, x'00', 1)", [
-        ])
-        .is_err(),
-        "chunk_text_dict rejects id != 1"
-    );
+    // Dicts are immutable + versioned (#77 Phase 2): MULTIPLE versions coexist (the prior
+    // CHECK(id=1) single-row constraint is gone — that was the mutable-global-slot footgun a
+    // retrain would hit).
+    conn.execute("INSERT INTO chunk_text_dict(version, dict) VALUES (1, x'00')", []).unwrap();
+    conn.execute("INSERT INTO chunk_text_dict(version, dict) VALUES (2, x'00')", [])
+        .expect("multiple dict versions coexist");
     // raw_len is the decompress capacity; a negative value would cast to a huge usize.
     assert!(
-        conn.execute("INSERT INTO chunk_text(chunk_id, blob, raw_len) VALUES (1, x'00', -1)", [])
-            .is_err(),
+        conn.execute(
+            "INSERT INTO chunk_text(chunk_id, blob, raw_len, dict_version) VALUES (1, x'00', -1, \
+             1)",
+            [],
+        )
+        .is_err(),
         "chunk_text rejects negative raw_len"
     );
 }
@@ -10233,8 +10241,11 @@ fn v026_recreates_chunk_fts_contentless_and_repopulates() {
         .unwrap();
     assert_eq!(after, 0, "contentless_delete=1 removes the row by rowid");
 
-    // Forward-migrate: rebuild an OLD external-content chunk_fts with a seeded chunk, drop the V026
-    // ledger row, re-apply → V026 converts to contentless and repopulates from chunks.text.
+    // Forward-migrate from a pre-V026 index: re-add the old chunks.text column, seed a chunk + an
+    // external-content chunk_fts, and drop the V026 + V027 ledger rows. Re-applying runs V026
+    // (convert chunk_fts to contentless + repopulate from chunks.text) then V027 (build the
+    // chunk_text store from chunks.text + drop the column) — the full retirement path as a unit.
+    conn.execute("ALTER TABLE chunks ADD COLUMN text TEXT NOT NULL DEFAULT ''", []).unwrap();
     conn.execute(
         "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
          VALUES ('src/a.rs', 'rust', 'source', 'h', 0, 0)",
@@ -10243,8 +10254,8 @@ fn v026_recreates_chunk_fts_contentless_and_repopulates() {
     .unwrap();
     conn.execute(
         "INSERT INTO chunks(file_id, chunk_kind, symbol_path, start_byte, end_byte,
-                            start_line, end_line, text, text_hash)
-         VALUES (1, 'symbol', 'gamma', 0, 10, 1, 5, 'fn gamma() { delta() }', 'th')",
+                            start_line, end_line, text_hash, text)
+         VALUES (1, 'symbol', 'gamma', 0, 10, 1, 5, 'th', 'fn gamma() { delta() }')",
         [],
     )
     .unwrap();
@@ -10253,7 +10264,8 @@ fn v026_recreates_chunk_fts_contentless_and_repopulates() {
          CREATE VIRTUAL TABLE chunk_fts USING fts5(text, content='chunks', content_rowid='id', \
          tokenize='porter');
          INSERT INTO chunk_fts(chunk_fts) VALUES('rebuild');
-         DELETE FROM schema_version WHERE id = '026_contentless_chunk_fts';",
+         DELETE FROM schema_version WHERE id = '026_contentless_chunk_fts';
+         DELETE FROM schema_version WHERE id = '027_drop_chunks_text';",
     )
     .unwrap();
     schema::apply(&conn).unwrap();
@@ -10268,7 +10280,11 @@ fn v026_recreates_chunk_fts_contentless_and_repopulates() {
     let hits: i64 = conn
         .query_row("SELECT count(*) FROM chunk_fts WHERE chunk_fts MATCH 'gamma'", [], |r| r.get(0))
         .unwrap();
-    assert_eq!(hits, 1, "V026 repopulates chunk_fts from chunks.text");
+    assert_eq!(hits, 1, "V026 repopulates chunk_fts from chunks.text before V027 drops it");
+    // V027 retired the column and built the compressed store from it.
+    assert!(!schema::column_exists(&conn, "chunks", "text").unwrap(), "V027 drops chunks.text");
+    let blobs: i64 = conn.query_row("SELECT count(*) FROM chunk_text", [], |r| r.get(0)).unwrap();
+    assert_eq!(blobs, 1, "V027 builds the chunk_text store from chunks.text");
 }
 
 #[test]
@@ -10330,28 +10346,27 @@ fn full_rebuild_populates_the_chunk_text_store() {
     let stored: i64 = conn.query_row("SELECT COUNT(*) FROM chunk_text", [], |r| r.get(0)).unwrap();
     assert!(chunks > 0, "the rebuild indexed some chunks");
     assert_eq!(stored, chunks, "every chunk is compressed into chunk_text");
-    let dict: Vec<u8> =
-        conn.query_row("SELECT dict FROM chunk_text_dict WHERE id = 1", [], |r| r.get(0)).unwrap();
+    let dict: Vec<u8> = conn
+        .query_row("SELECT dict FROM chunk_text_dict WHERE version = 1", [], |r| r.get(0))
+        .unwrap();
 
-    let mut stmt = conn
-        .prepare(
-            "SELECT c.text, ct.blob, ct.raw_len FROM chunks c JOIN chunk_text ct ON ct.chunk_id = \
-             c.id",
-        )
-        .unwrap();
-    let rows = stmt
-        .query_map([], |r| {
-            Ok((r.get::<_, String>(0)?, r.get::<_, Vec<u8>>(1)?, r.get::<_, i64>(2)?))
-        })
-        .unwrap();
+    // The chunks.text column is gone (#77 Phase 2), so verify the store is self-consistent: every
+    // blob decompresses to valid UTF-8 and the decompressed corpus contains the indexed source.
+    let mut stmt = conn.prepare("SELECT ct.blob, ct.raw_len FROM chunk_text ct").unwrap();
+    let rows = stmt.query_map([], |r| Ok((r.get::<_, Vec<u8>>(0)?, r.get::<_, i64>(1)?))).unwrap();
+    let mut corpus = String::new();
     let mut checked = 0;
     for row in rows {
-        let (text, blob, raw_len) = row.unwrap();
+        let (blob, raw_len) = row.unwrap();
         let back = super::text_compression::decompress(&blob, &dict, raw_len as usize).unwrap();
-        assert_eq!(back, text.as_bytes(), "chunk_text blob round-trips to chunks.text");
+        corpus.push_str(std::str::from_utf8(&back).expect("chunk_text blob decompresses to UTF-8"));
         checked += 1;
     }
     assert_eq!(checked, chunks);
+    assert!(
+        corpus.contains("alpha") && corpus.contains("beta") && corpus.contains("gamma"),
+        "the decompressed store contains the indexed source"
+    );
 
     let _ = fs::remove_dir_all(&root);
 }
@@ -10379,27 +10394,24 @@ fn incremental_heal_maintains_the_chunk_text_store() {
         stored, chunks,
         "heal kept chunk_text one-to-one with chunks (no stale/orphan rows)"
     );
-    let dict: Vec<u8> =
-        conn.query_row("SELECT dict FROM chunk_text_dict WHERE id = 1", [], |r| r.get(0)).unwrap();
-    let mut stmt = conn
-        .prepare(
-            "SELECT c.text, ct.blob, ct.raw_len FROM chunks c JOIN chunk_text ct ON ct.chunk_id = \
-             c.id",
-        )
+    let dict: Vec<u8> = conn
+        .query_row("SELECT dict FROM chunk_text_dict WHERE version = 1", [], |r| r.get(0))
         .unwrap();
-    let rows = stmt
-        .query_map([], |r| {
-            Ok((r.get::<_, String>(0)?, r.get::<_, Vec<u8>>(1)?, r.get::<_, i64>(2)?))
-        })
-        .unwrap();
-    let mut saw_changed = false;
+    // chunks.text is gone (#77 Phase 2): decompress the store and assert it reflects the healed
+    // NEW text and not the stale pre-heal text.
+    let mut stmt = conn.prepare("SELECT ct.blob, ct.raw_len FROM chunk_text ct").unwrap();
+    let rows = stmt.query_map([], |r| Ok((r.get::<_, Vec<u8>>(0)?, r.get::<_, i64>(1)?))).unwrap();
+    let mut corpus = String::new();
     for row in rows {
-        let (text, blob, raw_len) = row.unwrap();
+        let (blob, raw_len) = row.unwrap();
         let back = super::text_compression::decompress(&blob, &dict, raw_len as usize).unwrap();
-        assert_eq!(back, text.as_bytes(), "blob round-trips to the chunk's CURRENT text");
-        saw_changed |= text.contains("changed");
+        corpus.push_str(std::str::from_utf8(&back).expect("chunk_text blob decompresses to UTF-8"));
     }
-    assert!(saw_changed, "the healed file's NEW text is what's stored, not the rebuild-time text");
+    assert!(
+        corpus.contains("changed") && corpus.contains("added"),
+        "the healed file's NEW text is what's stored"
+    );
+    assert!(!corpus.contains("original"), "stale pre-heal text is gone from the store");
 
     let _ = fs::remove_dir_all(&root);
 }
@@ -10410,7 +10422,7 @@ fn v022_fresh_apply_creates_packages_and_dedicated_import_scope_columns() {
     schema::apply(&conn).unwrap();
 
     assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 26);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 27);
     assert!(conn_table_exists(&conn, "packages"), "packages table is created on a fresh apply");
 
     let package_cols = conn_table_columns(&conn, "packages");
@@ -10482,6 +10494,7 @@ fn v022_forward_migrate_adds_artifacts_to_an_older_index() {
         DELETE FROM schema_version WHERE id = '024_files_has_test_code';
         DELETE FROM schema_version WHERE id = '025_chunk_text_compression_tables';
         DELETE FROM schema_version WHERE id = '026_contentless_chunk_fts';
+        DELETE FROM schema_version WHERE id = '027_drop_chunks_text';
         ",
     )
     .unwrap();
@@ -10574,6 +10587,9 @@ fn has_test_code_backfill_is_case_sensitive() {
     // is case-sensitive, so they agree.
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
+    // V024's backfill reads chunks.text, which V027 retired; this test exercises the backfill as a
+    // pre-V027 forward-migrate would, so re-add the column it reads.
+    conn.execute("ALTER TABLE chunks ADD COLUMN text TEXT NOT NULL DEFAULT ''", []).unwrap();
     for (id, path) in [(1, "a.rs"), (2, "b.rs")] {
         conn.execute(
             "INSERT INTO files(id, path, language, kind, sha256, modified_at_ms, indexed_at_ms) \

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -10206,6 +10206,50 @@ fn v025_creates_chunk_text_compression_tables() {
 }
 
 #[test]
+fn full_rebuild_populates_the_chunk_text_store() {
+    // #77 Phase 2: a full rebuild compresses every chunk into chunk_text against the shared dict,
+    // and every stored blob round-trips to its chunks.text.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn alpha() {}\npub fn beta(x: u8) -> u8 { x }\n")
+        .unwrap();
+    fs::write(root.join("src/b.rs"), "pub fn gamma() -> u8 { 3 }\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+
+    let chunks: i64 = conn.query_row("SELECT COUNT(*) FROM chunks", [], |r| r.get(0)).unwrap();
+    let stored: i64 = conn.query_row("SELECT COUNT(*) FROM chunk_text", [], |r| r.get(0)).unwrap();
+    assert!(chunks > 0, "the rebuild indexed some chunks");
+    assert_eq!(stored, chunks, "every chunk is compressed into chunk_text");
+    let dict: Vec<u8> =
+        conn.query_row("SELECT dict FROM chunk_text_dict WHERE id = 1", [], |r| r.get(0)).unwrap();
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT c.text, ct.blob, ct.raw_len FROM chunks c JOIN chunk_text ct ON ct.chunk_id = \
+             c.id",
+        )
+        .unwrap();
+    let rows = stmt
+        .query_map([], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, Vec<u8>>(1)?, r.get::<_, i64>(2)?))
+        })
+        .unwrap();
+    let mut checked = 0;
+    for row in rows {
+        let (text, blob, raw_len) = row.unwrap();
+        let back = super::text_compression::decompress(&blob, &dict, raw_len as usize).unwrap();
+        assert_eq!(back, text.as_bytes(), "chunk_text blob round-trips to chunks.text");
+        checked += 1;
+    }
+    assert_eq!(checked, chunks);
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
 fn v022_fresh_apply_creates_packages_and_dedicated_import_scope_columns() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();

--- a/crates/rag-rat-core/src/index/staleness.rs
+++ b/crates/rag-rat-core/src/index/staleness.rs
@@ -117,6 +117,11 @@ impl IndexDatabase {
         let Some(root) = self.storage.source_root() else {
             return Ok(Vec::new());
         };
+        // One dict-bound decompressor for the whole hit set: this loops `read_chunk` per hit, and
+        // the per-call dict SELECT + dictionary prep is ~20x the decompress itself, so reusing it
+        // across the batch keeps the healing-search check cheap (#77 Phase 2 read-path perf).
+        let dict = crate::query::chunk_text_dict(self.storage.connection())?;
+        let mut decompressor = crate::index::text_compression::ChunkDecompressor::new(&dict)?;
         let mut stale = Vec::new();
         let mut seen = BTreeSet::new();
         for hit in hits {
@@ -128,7 +133,11 @@ impl IndexDatabase {
                 stale.push(hit.path.clone());
                 continue;
             };
-            let chunk = crate::query::read_chunk(self.storage.connection(), hit.chunk_id)?;
+            let chunk = crate::query::read_chunk_with(
+                self.storage.connection(),
+                hit.chunk_id,
+                &mut decompressor,
+            )?;
             let Some(chunk) = chunk else {
                 stale.push(hit.path.clone());
                 continue;

--- a/crates/rag-rat-core/src/index/staleness.rs
+++ b/crates/rag-rat-core/src/index/staleness.rs
@@ -117,11 +117,11 @@ impl IndexDatabase {
         let Some(root) = self.storage.source_root() else {
             return Ok(Vec::new());
         };
-        // One dict-bound decompressor for the whole hit set: this loops `read_chunk` per hit, and
-        // the per-call dict SELECT + dictionary prep is ~20x the decompress itself, so reusing it
-        // across the batch keeps the healing-search check cheap (#77 Phase 2 read-path perf).
-        let dict = crate::query::chunk_text_dict(self.storage.connection())?;
-        let mut decompressor = crate::index::text_compression::ChunkDecompressor::new(&dict)?;
+        // One dict decoder for the whole hit set: this loops `read_chunk` per hit, and the per-call
+        // dict SELECT + dictionary prep is ~20x the decompress itself, so reusing it across the
+        // batch keeps the healing-search check cheap (#77 Phase 2 read-path perf).
+        let dicts = crate::query::chunk_text_dicts(self.storage.connection())?;
+        let mut decoder = crate::index::text_compression::ChunkTextDecoder::new(&dicts);
         let mut stale = Vec::new();
         let mut seen = BTreeSet::new();
         for hit in hits {
@@ -136,7 +136,7 @@ impl IndexDatabase {
             let chunk = crate::query::read_chunk_with(
                 self.storage.connection(),
                 hit.chunk_id,
-                &mut decompressor,
+                &mut decoder,
             )?;
             let Some(chunk) = chunk else {
                 stale.push(hit.path.clone());

--- a/crates/rag-rat-core/src/index/text_compression.rs
+++ b/crates/rag-rat-core/src/index/text_compression.rs
@@ -32,20 +32,11 @@ pub(crate) fn train_dict(samples: &[Vec<u8>], max_size: usize) -> Result<Vec<u8>
     Ok(zstd::dict::from_samples(&refs, max_size)?)
 }
 
-/// Compress one chunk's text. An EMPTY `dict` means "no dictionary" (plain zstd) — the fallback for
-/// corpora too small to train a dict on (`from_samples` hard-errors under ~7 samples); the read
-/// side recognizes the same empty-dict sentinel, so write and read stay consistent.
-pub(crate) fn compress(text: &[u8], dict: &[u8]) -> Result<Vec<u8>> {
-    if dict.is_empty() {
-        return Ok(zstd::bulk::compress(text, COMPRESSION_LEVEL)?);
-    }
-    let mut compressor = zstd::bulk::Compressor::with_dictionary(COMPRESSION_LEVEL, dict)?;
-    Ok(compressor.compress(text)?)
-}
-
-/// A compressor bound to the shared dictionary once, reused across many chunks. The per-call
-/// [`compress`] re-prepares the dictionary every invocation (~costly over a full corpus), so the
-/// index-time build path uses this instead. An empty dict means no-dictionary (plain zstd).
+/// A compressor bound to the shared dictionary once, reused across many chunks (writes go through
+/// this, not a per-call helper, which would re-prepare the dictionary every invocation — costly
+/// over a full corpus). An empty dict means no-dictionary (plain zstd) — the fallback for corpora
+/// too small to train on (`from_samples` hard-errors under ~7 samples); the read side recognizes
+/// the same empty-dict sentinel, so write and read stay consistent.
 pub(crate) struct ChunkCompressor<'a>(Option<zstd::bulk::Compressor<'a>>);
 
 impl<'a> ChunkCompressor<'a> {
@@ -93,12 +84,16 @@ mod tests {
             .collect()
     }
 
+    fn compress(text: &[u8], dict: &[u8]) -> Vec<u8> {
+        ChunkCompressor::new(dict).unwrap().compress(text).unwrap()
+    }
+
     #[test]
     fn round_trips_with_dict() {
         let dict = train_dict(&sample(), 16 * 1024).unwrap();
         let text =
             b"pub fn handler_x(req: Request, ctx: &Ctx) -> Result<Response, Error> { ok() }\n";
-        let blob = compress(text, &dict).unwrap();
+        let blob = compress(text, &dict);
         let back = decompress(&blob, &dict, text.len() + 64).unwrap();
         assert_eq!(back, text);
     }
@@ -108,7 +103,7 @@ mod tests {
         let samples = sample();
         let dict = train_dict(&samples, 16 * 1024).unwrap();
         let text = samples[0].as_slice();
-        let with_dict = compress(text, &dict).unwrap().len();
+        let with_dict = compress(text, &dict).len();
         let without_dict = zstd::bulk::compress(text, COMPRESSION_LEVEL).unwrap().len();
         assert!(
             with_dict < without_dict,
@@ -119,7 +114,7 @@ mod tests {
     #[test]
     fn empty_text_round_trips() {
         let dict = train_dict(&sample(), 16 * 1024).unwrap();
-        let blob = compress(b"", &dict).unwrap();
+        let blob = compress(b"", &dict);
         assert_eq!(decompress(&blob, &dict, 16).unwrap(), b"");
     }
 
@@ -128,7 +123,7 @@ mod tests {
         // A corpus too small to train on stores an empty dict; compress/decompress must round-trip
         // with no dictionary (plain zstd), so the tiny-repo fallback is transparent to callers.
         let text = b"fn tiny() -> u8 { 7 }\n";
-        let blob = compress(text, &[]).unwrap();
+        let blob = compress(text, &[]);
         assert_eq!(decompress(&blob, &[], text.len() + 16).unwrap(), text);
     }
 }

--- a/crates/rag-rat-core/src/index/text_compression.rs
+++ b/crates/rag-rat-core/src/index/text_compression.rs
@@ -67,6 +67,29 @@ pub(crate) fn decompress(blob: &[u8], dict: &[u8], capacity: usize) -> Result<Ve
     Ok(decompressor.decompress(blob, capacity)?)
 }
 
+/// A decompressor bound to the shared dictionary once, reused across many chunks — the batch read
+/// paths (lexical snippets, the embedding scan) decompress many blobs, and the per-call
+/// [`decompress`] re-prepares the dictionary every time (~7x slower). An empty dict means
+/// no-dictionary (plain zstd). `capacity` per call is the row's stored `raw_len`.
+pub(crate) struct ChunkDecompressor<'a>(Option<zstd::bulk::Decompressor<'a>>);
+
+impl<'a> ChunkDecompressor<'a> {
+    pub(crate) fn new(dict: &'a [u8]) -> Result<Self> {
+        Ok(Self(if dict.is_empty() {
+            None
+        } else {
+            Some(zstd::bulk::Decompressor::with_dictionary(dict)?)
+        }))
+    }
+
+    pub(crate) fn decompress(&mut self, blob: &[u8], capacity: usize) -> Result<Vec<u8>> {
+        match &mut self.0 {
+            Some(decompressor) => Ok(decompressor.decompress(blob, capacity)?),
+            None => Ok(zstd::bulk::decompress(blob, capacity)?),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rag-rat-core/src/index/text_compression.rs
+++ b/crates/rag-rat-core/src/index/text_compression.rs
@@ -32,15 +32,46 @@ pub(crate) fn train_dict(samples: &[Vec<u8>], max_size: usize) -> Result<Vec<u8>
     Ok(zstd::dict::from_samples(&refs, max_size)?)
 }
 
-/// Compress one chunk's text with the shared dictionary.
+/// Compress one chunk's text. An EMPTY `dict` means "no dictionary" (plain zstd) — the fallback for
+/// corpora too small to train a dict on (`from_samples` hard-errors under ~7 samples); the read
+/// side recognizes the same empty-dict sentinel, so write and read stay consistent.
 pub(crate) fn compress(text: &[u8], dict: &[u8]) -> Result<Vec<u8>> {
+    if dict.is_empty() {
+        return Ok(zstd::bulk::compress(text, COMPRESSION_LEVEL)?);
+    }
     let mut compressor = zstd::bulk::Compressor::with_dictionary(COMPRESSION_LEVEL, dict)?;
     Ok(compressor.compress(text)?)
 }
 
+/// A compressor bound to the shared dictionary once, reused across many chunks. The per-call
+/// [`compress`] re-prepares the dictionary every invocation (~costly over a full corpus), so the
+/// index-time build path uses this instead. An empty dict means no-dictionary (plain zstd).
+pub(crate) struct ChunkCompressor<'a>(Option<zstd::bulk::Compressor<'a>>);
+
+impl<'a> ChunkCompressor<'a> {
+    pub(crate) fn new(dict: &'a [u8]) -> Result<Self> {
+        Ok(Self(if dict.is_empty() {
+            None
+        } else {
+            Some(zstd::bulk::Compressor::with_dictionary(COMPRESSION_LEVEL, dict)?)
+        }))
+    }
+
+    pub(crate) fn compress(&mut self, text: &[u8]) -> Result<Vec<u8>> {
+        match &mut self.0 {
+            Some(compressor) => Ok(compressor.compress(text)?),
+            None => Ok(zstd::bulk::compress(text, COMPRESSION_LEVEL)?),
+        }
+    }
+}
+
 /// Decompress one chunk blob. `capacity` is an upper bound on the decompressed size — store the
-/// original byte length per row and pass it; a too-small value errors rather than truncating.
+/// original byte length per row and pass it; a too-small value errors rather than truncating. An
+/// empty `dict` means the blob was written without a dictionary (see [`compress`]).
 pub(crate) fn decompress(blob: &[u8], dict: &[u8], capacity: usize) -> Result<Vec<u8>> {
+    if dict.is_empty() {
+        return Ok(zstd::bulk::decompress(blob, capacity)?);
+    }
     let mut decompressor = zstd::bulk::Decompressor::with_dictionary(dict)?;
     Ok(decompressor.decompress(blob, capacity)?)
 }
@@ -90,5 +121,14 @@ mod tests {
         let dict = train_dict(&sample(), 16 * 1024).unwrap();
         let blob = compress(b"", &dict).unwrap();
         assert_eq!(decompress(&blob, &dict, 16).unwrap(), b"");
+    }
+
+    #[test]
+    fn empty_dict_is_the_no_dict_fallback() {
+        // A corpus too small to train on stores an empty dict; compress/decompress must round-trip
+        // with no dictionary (plain zstd), so the tiny-repo fallback is transparent to callers.
+        let text = b"fn tiny() -> u8 { 7 }\n";
+        let blob = compress(text, &[]).unwrap();
+        assert_eq!(decompress(&blob, &[], text.len() + 16).unwrap(), text);
     }
 }

--- a/crates/rag-rat-core/src/index/text_compression.rs
+++ b/crates/rag-rat-core/src/index/text_compression.rs
@@ -58,7 +58,12 @@ impl<'a> ChunkCompressor<'a> {
 
 /// Decompress one chunk blob. `capacity` is an upper bound on the decompressed size — store the
 /// original byte length per row and pass it; a too-small value errors rather than truncating. An
-/// empty `dict` means the blob was written without a dictionary (see [`compress`]).
+/// empty `dict` means the blob was written without a dictionary (see [`ChunkCompressor`]).
+///
+/// Single-shot convenience — production read paths all reuse a [`ChunkDecompressor`] across a batch
+/// (the per-call dictionary prep is the cost), so this now serves only round-trip tests (#77 Phase
+/// 2).
+#[cfg(test)]
 pub(crate) fn decompress(blob: &[u8], dict: &[u8], capacity: usize) -> Result<Vec<u8>> {
     if dict.is_empty() {
         return Ok(zstd::bulk::decompress(blob, capacity)?);

--- a/crates/rag-rat-core/src/index/text_compression.rs
+++ b/crates/rag-rat-core/src/index/text_compression.rs
@@ -95,24 +95,58 @@ impl<'a> ChunkDecompressor<'a> {
     }
 }
 
-/// A chunk's stored text as fetched for a read (#77): the compressed `chunk_text` blob + `raw_len`,
-/// with `chunks.text` as the fallback for a chunk not yet in the store (mid-migration / incremental
-/// before a dict existed). [`resolve`] decompresses the blob (or returns the fallback) — the shared
-/// shape every batch reader (lexical, graph local-context) collects per row before decompressing in
-/// a post-loop, since decompress's `anyhow::Result` can't cross a rusqlite closure.
+/// A chunk's stored text as fetched for a read (#77 Phase 2): the compressed `chunk_text` blob,
+/// `raw_len`, and the `dict_version` it was compressed against. Since `chunks.text` was dropped,
+/// every live chunk has exactly one `chunk_text` row, so readers INNER JOIN `chunk_text` and there
+/// is no fallback. [`resolve`] decompresses the blob against ITS dict version via a
+/// [`ChunkTextDecoder`] — the shared shape every batch reader (lexical, graph, embedding scan)
+/// collects per row before decompressing in a post-loop, since decompress's `anyhow::Result` can't
+/// cross a rusqlite closure.
 pub(crate) struct ChunkTextRow {
-    pub(crate) fallback: String,
-    pub(crate) blob: Option<Vec<u8>>,
-    pub(crate) raw_len: Option<i64>,
+    pub(crate) blob: Vec<u8>,
+    pub(crate) raw_len: i64,
+    pub(crate) dict_version: i64,
 }
 
 impl ChunkTextRow {
-    pub(crate) fn resolve(self, decompressor: &mut ChunkDecompressor) -> Result<String> {
-        match (self.blob, self.raw_len) {
-            (Some(blob), Some(raw_len)) =>
-                Ok(String::from_utf8(decompressor.decompress(&blob, raw_len.max(0) as usize)?)?),
-            _ => Ok(self.fallback),
+    pub(crate) fn resolve(self, decoder: &mut ChunkTextDecoder) -> Result<String> {
+        let bytes =
+            decoder.decompress(self.dict_version, &self.blob, self.raw_len.max(0) as usize)?;
+        Ok(String::from_utf8(bytes)?)
+    }
+}
+
+/// Decodes chunk_text blobs across dict versions, reusing one dict-bound [`ChunkDecompressor`] per
+/// version (#77 Phase 2). A zstd blob only decodes against the dict it was compressed with, and a
+/// retrain ADDS a version rather than replacing one, so a batch can mix versions; this caches a
+/// decompressor per version (built on first use) so the per-call dict prep is paid once per
+/// version, not per row. Borrows the resident dict bytes (load them once with `chunk_text_dicts`);
+/// an absent version falls back to the empty (no-dict) decompressor.
+pub(crate) struct ChunkTextDecoder<'a> {
+    dicts: &'a std::collections::HashMap<i64, Vec<u8>>,
+    cache: std::collections::HashMap<i64, ChunkDecompressor<'a>>,
+}
+
+impl<'a> ChunkTextDecoder<'a> {
+    pub(crate) fn new(dicts: &'a std::collections::HashMap<i64, Vec<u8>>) -> Self {
+        Self { dicts, cache: std::collections::HashMap::new() }
+    }
+
+    pub(crate) fn decompress(
+        &mut self,
+        dict_version: i64,
+        blob: &[u8],
+        capacity: usize,
+    ) -> Result<Vec<u8>> {
+        if !self.cache.contains_key(&dict_version) {
+            let dict = self.dicts.get(&dict_version).map(Vec::as_slice).unwrap_or(&[]);
+            self.cache.insert(dict_version, ChunkDecompressor::new(dict)?);
         }
+        // Present by construction (just inserted if missing).
+        self.cache
+            .get_mut(&dict_version)
+            .expect("decompressor cached above")
+            .decompress(blob, capacity)
     }
 }
 

--- a/crates/rag-rat-core/src/index/text_compression.rs
+++ b/crates/rag-rat-core/src/index/text_compression.rs
@@ -1,0 +1,91 @@
+//! Dictionary-trained zstd compression of stored chunk text (#77 Phase 2).
+//!
+//! One shared dictionary, trained once on a sample of the corpus and STORED IN THE DB, so the index
+//! is self-contained: a copied or P2P-streamed index decompresses anywhere with no SQLite extension
+//! and no per-connection setup. Per-chunk bulk one-shot compress/decompress keeps random-access
+//! reads (one blob per row) instead of a single big stream.
+//!
+//! Why hand-rolled (not sqlite-zstd): the dictionary lives in the DB (self-contained); no extension
+//! to load on every connection; works under ATTACH / streaming; full control. The #77 spike on real
+//! chunk text measured ~3.9x (rust) / ~2.9x (ts) at the per-row level WITH a shared dict, vs only
+//! ~2.3x / ~1.8x without — the dictionary is what makes small chunks (~730 B avg) compress, and one
+//! global dict was within ~3% of per-language, so we keep a single dict (no per-language keying).
+
+use anyhow::Result;
+
+/// zstd level for stored chunk blobs. 19 is near-max ratio; chunks are small and compressed ONCE at
+/// index time (amortized), while decompress on the read path stays ~GB/s.
+pub(crate) const COMPRESSION_LEVEL: i32 = 19;
+
+/// Default trained-dictionary size — zstd's own default; the #77 spike measured its ratios at this
+/// size. Stored once in the DB, so its cost is negligible against the per-row savings.
+pub(crate) const DEFAULT_DICT_SIZE: usize = 112 * 1024;
+
+/// Train a single shared zstd dictionary from a sample of chunk texts (`max_size` caps the dict;
+/// production passes [`DEFAULT_DICT_SIZE`]). The spike showed one global dict performs within ~3%
+/// of per-language dicts, so we train ONE — no per-language keying / `lang` column needed.
+pub(crate) fn train_dict(samples: &[Vec<u8>], max_size: usize) -> Result<Vec<u8>> {
+    let refs: Vec<&[u8]> = samples.iter().map(Vec::as_slice).collect();
+    Ok(zstd::dict::from_samples(&refs, max_size)?)
+}
+
+/// Compress one chunk's text with the shared dictionary.
+pub(crate) fn compress(text: &[u8], dict: &[u8]) -> Result<Vec<u8>> {
+    let mut compressor = zstd::bulk::Compressor::with_dictionary(COMPRESSION_LEVEL, dict)?;
+    Ok(compressor.compress(text)?)
+}
+
+/// Decompress one chunk blob. `capacity` is an upper bound on the decompressed size — store the
+/// original byte length per row and pass it; a too-small value errors rather than truncating.
+pub(crate) fn decompress(blob: &[u8], dict: &[u8], capacity: usize) -> Result<Vec<u8>> {
+    let mut decompressor = zstd::bulk::Decompressor::with_dictionary(dict)?;
+    Ok(decompressor.decompress(blob, capacity)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A varied sample large enough to train a small dict (zstd wants samples >> dict size).
+    fn sample() -> Vec<Vec<u8>> {
+        (0..2000)
+            .map(|i| {
+                format!(
+                    "pub fn handler_{i}(req: Request, ctx: &Ctx) -> Result<Response, Error> {{\n    \
+                     let value = ctx.lookup({i})?;\n    Ok(Response::ok(value))\n}}\n"
+                )
+                .into_bytes()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn round_trips_with_dict() {
+        let dict = train_dict(&sample(), 16 * 1024).unwrap();
+        let text =
+            b"pub fn handler_x(req: Request, ctx: &Ctx) -> Result<Response, Error> { ok() }\n";
+        let blob = compress(text, &dict).unwrap();
+        let back = decompress(&blob, &dict, text.len() + 64).unwrap();
+        assert_eq!(back, text);
+    }
+
+    #[test]
+    fn dict_beats_no_dict_on_a_small_chunk() {
+        let samples = sample();
+        let dict = train_dict(&samples, 16 * 1024).unwrap();
+        let text = samples[0].as_slice();
+        let with_dict = compress(text, &dict).unwrap().len();
+        let without_dict = zstd::bulk::compress(text, COMPRESSION_LEVEL).unwrap().len();
+        assert!(
+            with_dict < without_dict,
+            "dict ({with_dict}B) should beat no-dict ({without_dict}B) on a small chunk"
+        );
+    }
+
+    #[test]
+    fn empty_text_round_trips() {
+        let dict = train_dict(&sample(), 16 * 1024).unwrap();
+        let blob = compress(b"", &dict).unwrap();
+        assert_eq!(decompress(&blob, &dict, 16).unwrap(), b"");
+    }
+}

--- a/crates/rag-rat-core/src/index/text_compression.rs
+++ b/crates/rag-rat-core/src/index/text_compression.rs
@@ -6,16 +6,19 @@
 //! reads (one blob per row) instead of a single big stream.
 //!
 //! Why hand-rolled (not sqlite-zstd): the dictionary lives in the DB (self-contained); no extension
-//! to load on every connection; works under ATTACH / streaming; full control. The #77 spike on real
-//! chunk text measured ~3.9x (rust) / ~2.9x (ts) at the per-row level WITH a shared dict, vs only
-//! ~2.3x / ~1.8x without — the dictionary is what makes small chunks (~730 B avg) compress, and one
-//! global dict was within ~3% of per-language, so we keep a single dict (no per-language keying).
+//! to load on every connection; works under ATTACH / streaming; full control. The dictionary is
+//! essential — small chunks (~730 B avg) barely compress alone (~2x) but ~4x WITH a shared dict;
+//! one global dict measured within ~3% of per-language, so we keep a single dict (no per-language
+//! keying).
 
 use anyhow::Result;
 
-/// zstd level for stored chunk blobs. 19 is near-max ratio; chunks are small and compressed ONCE at
-/// index time (amortized), while decompress on the read path stays ~GB/s.
-pub(crate) const COMPRESSION_LEVEL: i32 = 19;
+/// zstd level for stored chunk blobs. Compression runs at INDEX time on the write path, so the
+/// level is chosen for write speed, NOT max ratio: measured on the real kernel corpus, level 3 =
+/// 212 MB/s (~4.2x) vs level 19 = 4.1 MB/s (~4.9x) — 52x faster for ~80% of the ratio (levels
+/// 15->22 buy almost nothing). Level 3 keeps a full reindex's added compression cost negligible
+/// (the hard no-indexing-delay constraint); decompression throughput is level-independent.
+pub(crate) const COMPRESSION_LEVEL: i32 = 3;
 
 /// Default trained-dictionary size — zstd's own default; the #77 spike measured its ratios at this
 /// size. Stored once in the DB, so its cost is negligible against the per-row savings.

--- a/crates/rag-rat-core/src/index/text_compression.rs
+++ b/crates/rag-rat-core/src/index/text_compression.rs
@@ -90,6 +90,27 @@ impl<'a> ChunkDecompressor<'a> {
     }
 }
 
+/// A chunk's stored text as fetched for a read (#77): the compressed `chunk_text` blob + `raw_len`,
+/// with `chunks.text` as the fallback for a chunk not yet in the store (mid-migration / incremental
+/// before a dict existed). [`resolve`] decompresses the blob (or returns the fallback) — the shared
+/// shape every batch reader (lexical, graph local-context) collects per row before decompressing in
+/// a post-loop, since decompress's `anyhow::Result` can't cross a rusqlite closure.
+pub(crate) struct ChunkTextRow {
+    pub(crate) fallback: String,
+    pub(crate) blob: Option<Vec<u8>>,
+    pub(crate) raw_len: Option<i64>,
+}
+
+impl ChunkTextRow {
+    pub(crate) fn resolve(self, decompressor: &mut ChunkDecompressor) -> Result<String> {
+        match (self.blob, self.raw_len) {
+            (Some(blob), Some(raw_len)) =>
+                Ok(String::from_utf8(decompressor.decompress(&blob, raw_len.max(0) as usize)?)?),
+            _ => Ok(self.fallback),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rag-rat-core/src/locks.rs
+++ b/crates/rag-rat-core/src/locks.rs
@@ -10,6 +10,8 @@
 //! Locks release when the file handle drops (the OS also releases on process death), so there is no
 //! stale-pidfile cleanup. Caveat: file locks are unreliable on NFS and WSL2 `drvfs`/`9p` mounts.
 
+use std::cell::RefCell;
+use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions, TryLockError};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
@@ -78,6 +80,97 @@ impl FileLock {
 /// shared DB, or `<root>/.rag-rat/` for a single worktree — both excluded from the watch tree).
 pub fn write_lock_path(database: &Path) -> PathBuf {
     database.parent().unwrap_or_else(|| Path::new(".")).join("rag-rat-write.lock")
+}
+
+thread_local! {
+    /// Reentrancy registry for the per-DB write lock: lock-file path → nesting depth on THIS thread.
+    /// Thread-local because the only legitimate nested acquire is an `open()`-time schema migrate
+    /// running synchronously inside a command / watcher pass that already holds the lock on the SAME
+    /// thread (#226). A different thread wanting the write lock is a genuine second writer and must
+    /// contend on the real OS flock, so it deliberately does not see this thread's hold.
+    static HELD_WRITE_LOCKS: RefCell<BTreeMap<PathBuf, usize>> = const { RefCell::new(BTreeMap::new()) };
+}
+
+fn write_lock_held_on_this_thread(lock_path: &Path) -> bool {
+    HELD_WRITE_LOCKS.with_borrow(|held| held.get(lock_path).is_some_and(|&depth| depth > 0))
+}
+
+fn register_write_lock(lock_path: &Path) {
+    HELD_WRITE_LOCKS.with_borrow_mut(|held| *held.entry(lock_path.to_path_buf()).or_insert(0) += 1);
+}
+
+fn release_write_lock(lock_path: &Path) {
+    HELD_WRITE_LOCKS.with_borrow_mut(|held| {
+        if let Some(depth) = held.get_mut(lock_path) {
+            *depth -= 1;
+            if *depth == 0 {
+                held.remove(lock_path);
+            }
+        }
+    });
+}
+
+/// The per-DB write-serialization lock, made REENTRANT within a thread (unlike the raw
+/// [`FileLock`]).
+///
+/// A CLI write command (`index` / `maintenance` / `oracle run`) and a watcher maintenance pass hold
+/// this lock for their whole duration, and the `open()` they run inside it may itself need to
+/// migrate an `Older` schema under the same lock. With a raw file lock that is a SELF-DEADLOCK: the
+/// same process re-`flock`s the file on a second fd, which blocks (flock is per-open-file-
+/// description), times out after 30s, and leaves the schema unmigrated (#226). `WriteLock` records
+/// the hold in a thread-local registry, so a nested acquire on the same thread is reentrant — it
+/// skips the OS lock and just bumps a depth count; only the outermost guard takes and releases the
+/// real `flock`. A second THREAD still contends on the OS lock, so cross-thread it behaves like a
+/// normal exclusive lock.
+#[derive(Debug)]
+pub struct WriteLock {
+    /// `None` for a reentrant inner acquire (this thread already held the lock, so no OS lock was
+    /// taken — dropping it must only decrement the depth, never unlock the file).
+    _inner: Option<FileLock>,
+    lock_path: PathBuf,
+}
+
+impl WriteLock {
+    /// Blocks until acquired (returns immediately if this thread already holds it). Use only for
+    /// non-interactive writers; interactive / hook callers use [`WriteLock::acquire_timeout`].
+    pub fn acquire_blocking(database: &Path) -> anyhow::Result<WriteLock> {
+        let lock_path = write_lock_path(database);
+        if write_lock_held_on_this_thread(&lock_path) {
+            register_write_lock(&lock_path);
+            return Ok(WriteLock { _inner: None, lock_path });
+        }
+        let inner = FileLock::acquire_blocking(&lock_path)?;
+        register_write_lock(&lock_path);
+        Ok(WriteLock { _inner: Some(inner), lock_path })
+    }
+
+    /// Polls until acquired or `timeout` elapses (returns immediately if this thread already holds
+    /// it); `Ok(None)` on timeout.
+    pub fn acquire_timeout(
+        database: &Path,
+        timeout: Duration,
+    ) -> anyhow::Result<Option<WriteLock>> {
+        let lock_path = write_lock_path(database);
+        if write_lock_held_on_this_thread(&lock_path) {
+            register_write_lock(&lock_path);
+            return Ok(Some(WriteLock { _inner: None, lock_path }));
+        }
+        match FileLock::acquire_timeout(&lock_path, timeout)? {
+            Some(inner) => {
+                register_write_lock(&lock_path);
+                Ok(Some(WriteLock { _inner: Some(inner), lock_path }))
+            },
+            None => Ok(None),
+        }
+    }
+}
+
+impl Drop for WriteLock {
+    fn drop(&mut self) {
+        // Decrement first; `_inner` then drops AFTER this body, unlocking the OS flock for the
+        // outermost guard. A reentrant guard has `_inner: None`, so its drop only decrements.
+        release_write_lock(&self.lock_path);
+    }
 }
 
 /// `sun_path` budget for Unix domain sockets (108 bytes on Linux, 104 on macOS) with headroom.
@@ -199,6 +292,42 @@ mod tests {
         drop(first);
         let reacquired = FileLock::try_acquire(&path).unwrap();
         assert!(reacquired.is_some(), "should acquire after the holder drops");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn write_lock_is_reentrant_within_a_thread_but_not_across_threads() {
+        // #226: a CLI/watcher write command holds the write lock and opens UNDER it (the open-time
+        // schema migrate re-acquires). Reentrant on the SAME thread → no self-deadlock; a different
+        // thread is a genuine second writer → must still contend on the real OS lock.
+        let dir = temp_dir();
+        let db = dir.join("index.sqlite");
+
+        let outer = WriteLock::acquire_blocking(&db).unwrap();
+        // Nested acquire on the same thread re-enters immediately (a raw lock would self-deadlock).
+        let inner = WriteLock::acquire_timeout(&db, Duration::from_millis(50)).unwrap();
+        assert!(inner.is_some(), "nested same-thread acquire must re-enter, not block");
+        drop(inner);
+
+        // While `outer` is still held, a DIFFERENT thread must not be able to acquire it.
+        let db_other = db.clone();
+        let got = std::thread::spawn(move || {
+            WriteLock::acquire_timeout(&db_other, Duration::from_millis(100)).unwrap().is_some()
+        })
+        .join()
+        .unwrap();
+        assert!(!got, "a second thread must contend on the real OS lock while the first holds it");
+
+        drop(outer);
+        // Fully released once the outermost guard drops: a fresh (cross-thread) acquire succeeds.
+        let db_after = db.clone();
+        let reacquired = std::thread::spawn(move || {
+            WriteLock::acquire_timeout(&db_after, Duration::from_millis(100)).unwrap().is_some()
+        })
+        .join()
+        .unwrap();
+        assert!(reacquired, "the lock is free after the outermost guard drops");
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/crates/rag-rat-core/src/query/grep_augment.rs
+++ b/crates/rag-rat-core/src/query/grep_augment.rs
@@ -586,15 +586,22 @@ mod tests {
             [],
         )
         .unwrap();
+        let chunk_text = "fn watcher_main() { /* election retry loop */ }";
         conn.execute(
             "INSERT INTO chunks(file_id, chunk_kind, symbol_path, start_byte, end_byte,
-                                start_line, end_line, text, text_hash)
-             VALUES (1, 'symbol', 'watch::watcher_main', 0, 100, 1, 20,
-                     'fn watcher_main() { /* election retry loop */ }', 'h1')",
+                                start_line, end_line, text_hash)
+             VALUES (1, 'symbol', 'watch::watcher_main', 0, 100, 1, 20, 'h1')",
             [],
         )
         .unwrap();
         let chunk_id = conn.last_insert_rowid();
+        // chunks.text is gone (#77 Phase 2): seed the compressed chunk_text blob (readers INNER
+        // JOIN it) and the contentless chunk_fts tokens.
+        crate::index::chunk_text_store::seed_chunk_text(&conn, chunk_id, chunk_text).unwrap();
+        conn.execute("INSERT INTO chunk_fts(rowid, text) VALUES (?1, ?2)", rusqlite::params![
+            chunk_id, chunk_text
+        ])
+        .unwrap();
         // One caller edge and one callee edge for the counts line.
         conn.execute(
             "INSERT INTO edges(source_file_id, from_symbol_id, to_symbol_id, to_name,

--- a/crates/rag-rat-core/src/query/impact/mod.rs
+++ b/crates/rag-rat-core/src/query/impact/mod.rs
@@ -22,7 +22,7 @@ use crate::query::symbol::SymbolHit;
 /// Wrapped as a quoted FTS5 phrase (embedded `"` doubled) so `::`, `(`, `<`, etc. in a symbol name
 /// tokenize as separators rather than parse as FTS query syntax. Semantics shift substring→token —
 /// more precise for "mentions this symbol" than a substring match.
-pub(super) fn fts_phrase_query(needle: &str) -> Option<String> {
+pub(crate) fn fts_phrase_query(needle: &str) -> Option<String> {
     if !needle.chars().any(char::is_alphanumeric) {
         return None;
     }

--- a/crates/rag-rat-core/src/query/mod.rs
+++ b/crates/rag-rat-core/src/query/mod.rs
@@ -40,8 +40,24 @@ pub struct ReadChunk {
 }
 
 pub fn read_chunk(conn: &Connection, chunk_id: i64) -> anyhow::Result<Option<ReadChunk>> {
-    // Text comes from the compressed store (#77 Phase 2); chunks.text is the LEFT-JOIN fallback for
-    // a chunk with no chunk_text row yet (mid-migration / incremental before a dict existed).
+    // One-shot read: load the dict and build a decompressor for this call. Batch readers that loop
+    // over many chunk ids (`stale_hit_paths`, eval) should build ONE decompressor and call
+    // [`read_chunk_with`] instead — the per-call dict SELECT + dictionary prep is ~20x the
+    // decompress itself, so reusing it across a batch is the win (#77 Phase 2 read-path perf).
+    let dict = chunk_text_dict(conn)?;
+    let mut decompressor = crate::index::text_compression::ChunkDecompressor::new(&dict)?;
+    read_chunk_with(conn, chunk_id, &mut decompressor)
+}
+
+/// Read one chunk, resolving its text through a caller-owned dict-bound decompressor (reused across
+/// a batch). Text comes from the compressed `chunk_text` store (#77 Phase 2); `chunks.text` is the
+/// LEFT-JOIN fallback for a chunk with no blob yet (mid-migration / incremental before a dict).
+pub(crate) fn read_chunk_with(
+    conn: &Connection,
+    chunk_id: i64,
+    decompressor: &mut crate::index::text_compression::ChunkDecompressor,
+) -> anyhow::Result<Option<ReadChunk>> {
+    use crate::index::text_compression::ChunkTextRow;
     let row = conn
         .query_row(
             "
@@ -64,25 +80,19 @@ pub fn read_chunk(conn: &Connection, chunk_id: i64) -> anyhow::Result<Option<Rea
                         start_line: row.get(4)?,
                         end_line: row.get(5)?,
                         symbol_path: row.get(6)?,
-                        text: row.get(7)?,
+                        text: String::new(),
                         graph: None,
                         memories: Vec::new(),
                     },
-                    row.get::<_, Option<Vec<u8>>>(8)?,
-                    row.get::<_, Option<i64>>(9)?,
+                    ChunkTextRow { fallback: row.get(7)?, blob: row.get(8)?, raw_len: row.get(9)? },
                 ))
             },
         )
         .optional()?;
-    let Some((mut chunk, blob, raw_len)) = row else {
+    let Some((mut chunk, text_row)) = row else {
         return Ok(None);
     };
-    if let (Some(blob), Some(raw_len)) = (blob, raw_len) {
-        let dict = chunk_text_dict(conn)?;
-        let bytes =
-            crate::index::text_compression::decompress(&blob, &dict, raw_len.max(0) as usize)?;
-        chunk.text = String::from_utf8(bytes)?;
-    }
+    chunk.text = text_row.resolve(decompressor)?;
     Ok(Some(chunk))
 }
 

--- a/crates/rag-rat-core/src/query/mod.rs
+++ b/crates/rag-rat-core/src/query/mod.rs
@@ -40,22 +40,23 @@ pub struct ReadChunk {
 }
 
 pub fn read_chunk(conn: &Connection, chunk_id: i64) -> anyhow::Result<Option<ReadChunk>> {
-    // One-shot read: load the dict and build a decompressor for this call. Batch readers that loop
-    // over many chunk ids (`stale_hit_paths`, eval) should build ONE decompressor and call
+    // One-shot read: load the dict versions and build a decoder for this call. Batch readers that
+    // loop over many chunk ids (`stale_hit_paths`, eval) should build ONE decoder and call
     // [`read_chunk_with`] instead — the per-call dict SELECT + dictionary prep is ~20x the
     // decompress itself, so reusing it across a batch is the win (#77 Phase 2 read-path perf).
-    let dict = chunk_text_dict(conn)?;
-    let mut decompressor = crate::index::text_compression::ChunkDecompressor::new(&dict)?;
-    read_chunk_with(conn, chunk_id, &mut decompressor)
+    let dicts = chunk_text_dicts(conn)?;
+    let mut decoder = crate::index::text_compression::ChunkTextDecoder::new(&dicts);
+    read_chunk_with(conn, chunk_id, &mut decoder)
 }
 
-/// Read one chunk, resolving its text through a caller-owned dict-bound decompressor (reused across
-/// a batch). Text comes from the compressed `chunk_text` store (#77 Phase 2); `chunks.text` is the
-/// LEFT-JOIN fallback for a chunk with no blob yet (mid-migration / incremental before a dict).
+/// Read one chunk, resolving its text through a caller-owned dict decoder (reused across a batch).
+/// Text comes from the compressed `chunk_text` store (#77 Phase 2) — the `chunks.text` column is
+/// gone, so this INNER JOINs `chunk_text` (every live chunk has exactly one blob), and each blob is
+/// decoded against its own `dict_version`.
 pub(crate) fn read_chunk_with(
     conn: &Connection,
     chunk_id: i64,
-    decompressor: &mut crate::index::text_compression::ChunkDecompressor,
+    decoder: &mut crate::index::text_compression::ChunkTextDecoder,
 ) -> anyhow::Result<Option<ReadChunk>> {
     use crate::index::text_compression::ChunkTextRow;
     let row = conn
@@ -63,10 +64,10 @@ pub(crate) fn read_chunk_with(
             "
             SELECT chunks.id, files.path, files.language, files.kind,
                    chunks.start_line, chunks.end_line, chunks.symbol_path,
-                   chunks.text, chunk_text.blob, chunk_text.raw_len
+                   chunk_text.blob, chunk_text.raw_len, chunk_text.dict_version
             FROM chunks
             JOIN files ON files.id = chunks.file_id
-            LEFT JOIN chunk_text ON chunk_text.chunk_id = chunks.id
+            JOIN chunk_text ON chunk_text.chunk_id = chunks.id
             WHERE chunks.id = ?1
             ",
             [chunk_id],
@@ -84,7 +85,11 @@ pub(crate) fn read_chunk_with(
                         graph: None,
                         memories: Vec::new(),
                     },
-                    ChunkTextRow { fallback: row.get(7)?, blob: row.get(8)?, raw_len: row.get(9)? },
+                    ChunkTextRow {
+                        blob: row.get(7)?,
+                        raw_len: row.get(8)?,
+                        dict_version: row.get(9)?,
+                    },
                 ))
             },
         )
@@ -92,17 +97,25 @@ pub(crate) fn read_chunk_with(
     let Some((mut chunk, text_row)) = row else {
         return Ok(None);
     };
-    chunk.text = text_row.resolve(decompressor)?;
+    chunk.text = text_row.resolve(decoder)?;
     Ok(Some(chunk))
 }
 
-/// The single shared chunk-text dictionary blob (empty = no-dict sentinel, or absent), read
-/// alongside a `chunk_text` blob to decompress it (#77 Phase 2).
-pub(crate) fn chunk_text_dict(conn: &Connection) -> anyhow::Result<Vec<u8>> {
-    Ok(conn
-        .query_row("SELECT dict FROM chunk_text_dict WHERE id = 1", [], |row| {
-            row.get::<_, Vec<u8>>(0)
-        })
-        .optional()?
-        .unwrap_or_default())
+/// All chunk-text dictionary versions (version → dict bytes), loaded once and reused across a batch
+/// via [`crate::index::text_compression::ChunkTextDecoder`]. Each `chunk_text` blob records the
+/// version it was compressed against (#77 Phase 2); a dict is an immutable decode key and a retrain
+/// adds a version rather than replacing one, so a read may span multiple resident versions. An
+/// empty map (fresh DB, no dicts yet) decodes nothing — every chunk has a blob only once a dict
+/// exists.
+pub(crate) fn chunk_text_dicts(
+    conn: &Connection,
+) -> anyhow::Result<std::collections::HashMap<i64, Vec<u8>>> {
+    let mut stmt = conn.prepare("SELECT version, dict FROM chunk_text_dict")?;
+    let rows = stmt.query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?)))?;
+    let mut dicts = std::collections::HashMap::new();
+    for row in rows {
+        let (version, dict) = row?;
+        dicts.insert(version, dict);
+    }
+    Ok(dicts)
 }

--- a/crates/rag-rat-core/src/query/mod.rs
+++ b/crates/rag-rat-core/src/query/mod.rs
@@ -40,30 +40,59 @@ pub struct ReadChunk {
 }
 
 pub fn read_chunk(conn: &Connection, chunk_id: i64) -> anyhow::Result<Option<ReadChunk>> {
-    Ok(conn
+    // Text comes from the compressed store (#77 Phase 2); chunks.text is the LEFT-JOIN fallback for
+    // a chunk with no chunk_text row yet (mid-migration / incremental before a dict existed).
+    let row = conn
         .query_row(
             "
             SELECT chunks.id, files.path, files.language, files.kind,
-                   chunks.start_line, chunks.end_line, chunks.symbol_path, chunks.text
+                   chunks.start_line, chunks.end_line, chunks.symbol_path,
+                   chunks.text, chunk_text.blob, chunk_text.raw_len
             FROM chunks
             JOIN files ON files.id = chunks.file_id
+            LEFT JOIN chunk_text ON chunk_text.chunk_id = chunks.id
             WHERE chunks.id = ?1
             ",
             [chunk_id],
             |row| {
-                Ok(ReadChunk {
-                    chunk_id: row.get(0)?,
-                    path: row.get(1)?,
-                    language: row.get(2)?,
-                    kind: row.get(3)?,
-                    start_line: row.get(4)?,
-                    end_line: row.get(5)?,
-                    symbol_path: row.get(6)?,
-                    text: row.get(7)?,
-                    graph: None,
-                    memories: Vec::new(),
-                })
+                Ok((
+                    ReadChunk {
+                        chunk_id: row.get(0)?,
+                        path: row.get(1)?,
+                        language: row.get(2)?,
+                        kind: row.get(3)?,
+                        start_line: row.get(4)?,
+                        end_line: row.get(5)?,
+                        symbol_path: row.get(6)?,
+                        text: row.get(7)?,
+                        graph: None,
+                        memories: Vec::new(),
+                    },
+                    row.get::<_, Option<Vec<u8>>>(8)?,
+                    row.get::<_, Option<i64>>(9)?,
+                ))
             },
         )
-        .optional()?)
+        .optional()?;
+    let Some((mut chunk, blob, raw_len)) = row else {
+        return Ok(None);
+    };
+    if let (Some(blob), Some(raw_len)) = (blob, raw_len) {
+        let dict = chunk_text_dict(conn)?;
+        let bytes =
+            crate::index::text_compression::decompress(&blob, &dict, raw_len.max(0) as usize)?;
+        chunk.text = String::from_utf8(bytes)?;
+    }
+    Ok(Some(chunk))
+}
+
+/// The single shared chunk-text dictionary blob (empty = no-dict sentinel, or absent), read
+/// alongside a `chunk_text` blob to decompress it (#77 Phase 2).
+pub(crate) fn chunk_text_dict(conn: &Connection) -> anyhow::Result<Vec<u8>> {
+    Ok(conn
+        .query_row("SELECT dict FROM chunk_text_dict WHERE id = 1", [], |row| {
+            row.get::<_, Vec<u8>>(0)
+        })
+        .optional()?
+        .unwrap_or_default())
 }

--- a/crates/rag-rat-core/src/search/lexical.rs
+++ b/crates/rag-rat-core/src/search/lexical.rs
@@ -174,17 +174,29 @@ fn search_with_query_embedding(
     let candidate_limit = i64::from(limit.max(10)).saturating_mul(8);
     let vector_available = query_embedding.is_some();
     let mut ranked = BTreeMap::<i64, RankedHit>::new();
+    // One dict-bound decompressor shared by both candidate passes (#77 Phase 2): bm25 and vector
+    // each decompress a batch of snippet text and run sequentially, so building it once here avoids
+    // the duplicate ~112 KB dict SELECT + dictionary prep the two passes used to do independently.
+    let dict = crate::query::chunk_text_dict(conn)?;
+    let mut decompressor = text_compression::ChunkDecompressor::new(&dict)?;
 
     for (rank, hit) in
-        bm25_candidates(conn, query, candidate_limit, include_generated)?.into_iter().enumerate()
+        bm25_candidates(conn, query, candidate_limit, include_generated, &mut decompressor)?
+            .into_iter()
+            .enumerate()
     {
         let entry = ranked.entry(hit.chunk_id).or_insert_with(|| RankedHit::new(hit));
         entry.components.bm25 = BM25_WEIGHT * lexical_rank_score(rank);
     }
 
-    for (hit, similarity) in
-        vector_candidates(conn, query, candidate_limit, include_generated, query_embedding)?
-    {
+    for (hit, similarity) in vector_candidates(
+        conn,
+        query,
+        candidate_limit,
+        include_generated,
+        query_embedding,
+        &mut decompressor,
+    )? {
         let entry = ranked.entry(hit.chunk_id).or_insert_with(|| RankedHit::new(hit));
         entry.components.vector = VECTOR_WEIGHT * f64::from(similarity).clamp(0.0, 1.0);
     }
@@ -256,6 +268,7 @@ fn bm25_candidates(
     query: &str,
     limit: i64,
     include_generated: bool,
+    decompressor: &mut text_compression::ChunkDecompressor,
 ) -> anyhow::Result<Vec<SearchHit>> {
     let fts_query = fts_query(query);
     if fts_query == "\"\"" {
@@ -304,11 +317,9 @@ fn bm25_candidates(
         ))
     })?;
     let collected = collect_rows(rows)?;
-    let dict = crate::query::chunk_text_dict(conn)?;
-    let mut decompressor = text_compression::ChunkDecompressor::new(&dict)?;
     let mut hits = Vec::with_capacity(collected.len());
     for (mut hit, text_row) in collected {
-        hit.summary = snippet(&text_row.resolve(&mut decompressor)?, query);
+        hit.summary = snippet(&text_row.resolve(decompressor)?, query);
         hits.push(hit);
     }
     Ok(hits)
@@ -320,6 +331,7 @@ fn vector_candidates(
     limit: i64,
     include_generated: bool,
     query_embedding: Option<ai::QueryEmbedding>,
+    decompressor: &mut text_compression::ChunkDecompressor,
 ) -> anyhow::Result<Vec<(SearchHit, f32)>> {
     let Some(query_embedding) = query_embedding else {
         return Ok(Vec::new());
@@ -385,22 +397,27 @@ fn vector_candidates(
             ))
         },
     )?;
-    let collected = collect_rows(rows)?;
-    let dict = crate::query::chunk_text_dict(conn)?;
-    let mut decompressor = text_compression::ChunkDecompressor::new(&dict)?;
-    let mut hits = Vec::new();
-    for (mut hit, vector_blob, text_row) in collected {
+    // Score first (decode + dot), then truncate, THEN decompress only the survivors' snippets. This
+    // is a brute-force flat scan, so many rows can clear `similarity > 0`, but only the top `limit`
+    // are kept — decompressing snippet text before the truncate would decompress (and discard) all
+    // the rest (#77 Phase 2 read-path perf).
+    let mut scored: Vec<(SearchHit, f32, ChunkTextRow)> = Vec::new();
+    for (hit, vector_blob, text_row) in collect_rows(rows)? {
         let Some(vector) = ai::decode_vector(&vector_blob, query_embedding.dim) else {
             continue;
         };
         let similarity = dot(&query_embedding.vector, &vector);
         if similarity > 0.0 {
-            hit.summary = snippet(&text_row.resolve(&mut decompressor)?, query);
-            hits.push((hit, similarity));
+            scored.push((hit, similarity, text_row));
         }
     }
-    hits.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-    hits.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
+    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    scored.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
+    let mut hits = Vec::with_capacity(scored.len());
+    for (mut hit, similarity, text_row) in scored {
+        hit.summary = snippet(&text_row.resolve(decompressor)?, query);
+        hits.push((hit, similarity));
+    }
     Ok(hits)
 }
 

--- a/crates/rag-rat-core/src/search/lexical.rs
+++ b/crates/rag-rat-core/src/search/lexical.rs
@@ -174,14 +174,14 @@ fn search_with_query_embedding(
     let candidate_limit = i64::from(limit.max(10)).saturating_mul(8);
     let vector_available = query_embedding.is_some();
     let mut ranked = BTreeMap::<i64, RankedHit>::new();
-    // One dict-bound decompressor shared by both candidate passes (#77 Phase 2): bm25 and vector
-    // each decompress a batch of snippet text and run sequentially, so building it once here avoids
-    // the duplicate ~112 KB dict SELECT + dictionary prep the two passes used to do independently.
-    let dict = crate::query::chunk_text_dict(conn)?;
-    let mut decompressor = text_compression::ChunkDecompressor::new(&dict)?;
+    // One dict decoder shared by both candidate passes (#77 Phase 2): bm25 and vector each
+    // decompress a batch of snippet text and run sequentially, so loading the dict versions once
+    // here avoids the duplicate SELECT + dictionary prep the two passes used to do independently.
+    let dicts = crate::query::chunk_text_dicts(conn)?;
+    let mut decoder = text_compression::ChunkTextDecoder::new(&dicts);
 
     for (rank, hit) in
-        bm25_candidates(conn, query, candidate_limit, include_generated, &mut decompressor)?
+        bm25_candidates(conn, query, candidate_limit, include_generated, &mut decoder)?
             .into_iter()
             .enumerate()
     {
@@ -195,7 +195,7 @@ fn search_with_query_embedding(
         candidate_limit,
         include_generated,
         query_embedding,
-        &mut decompressor,
+        &mut decoder,
     )? {
         let entry = ranked.entry(hit.chunk_id).or_insert_with(|| RankedHit::new(hit));
         entry.components.vector = VECTOR_WEIGHT * f64::from(similarity).clamp(0.0, 1.0);
@@ -268,7 +268,7 @@ fn bm25_candidates(
     query: &str,
     limit: i64,
     include_generated: bool,
-    decompressor: &mut text_compression::ChunkDecompressor,
+    decoder: &mut text_compression::ChunkTextDecoder,
 ) -> anyhow::Result<Vec<SearchHit>> {
     let fts_query = fts_query(query);
     if fts_query == "\"\"" {
@@ -280,11 +280,11 @@ fn bm25_candidates(
         SELECT chunks.id, files.path, files.language, files.kind,
                chunks.start_line, chunks.end_line, chunks.symbol_path,
                bm25(chunk_fts) AS score,
-               chunks.text, chunk_text.blob, chunk_text.raw_len
+               chunk_text.blob, chunk_text.raw_len, chunk_text.dict_version
         FROM chunk_fts
         JOIN chunks ON chunks.id = chunk_fts.rowid
         JOIN files ON files.id = chunks.file_id
-        LEFT JOIN chunk_text ON chunk_text.chunk_id = chunks.id
+        JOIN chunk_text ON chunk_text.chunk_id = chunks.id
         WHERE chunk_fts MATCH ?1
           AND {generated_filter}
         ORDER BY score
@@ -313,13 +313,13 @@ fn bm25_candidates(
                 score_components: None,
                 importance: None,
             },
-            ChunkTextRow { fallback: row.get(8)?, blob: row.get(9)?, raw_len: row.get(10)? },
+            ChunkTextRow { blob: row.get(8)?, raw_len: row.get(9)?, dict_version: row.get(10)? },
         ))
     })?;
     let collected = collect_rows(rows)?;
     let mut hits = Vec::with_capacity(collected.len());
     for (mut hit, text_row) in collected {
-        hit.summary = snippet(&text_row.resolve(decompressor)?, query);
+        hit.summary = snippet(&text_row.resolve(decoder)?, query);
         hits.push(hit);
     }
     Ok(hits)
@@ -331,7 +331,7 @@ fn vector_candidates(
     limit: i64,
     include_generated: bool,
     query_embedding: Option<ai::QueryEmbedding>,
-    decompressor: &mut text_compression::ChunkDecompressor,
+    decoder: &mut text_compression::ChunkTextDecoder,
 ) -> anyhow::Result<Vec<(SearchHit, f32)>> {
     let Some(query_embedding) = query_embedding else {
         return Ok(Vec::new());
@@ -342,12 +342,13 @@ fn vector_candidates(
         "
         SELECT chunks.id, files.path, files.language, files.kind,
                chunks.start_line, chunks.end_line, chunks.symbol_path,
-               chunks.text, chunk_embeddings.vector_blob, chunk_text.blob, chunk_text.raw_len
+               chunk_embeddings.vector_blob, chunk_text.blob, chunk_text.raw_len,
+               chunk_text.dict_version
         FROM chunk_embeddings
         JOIN ai_models ON ai_models.model_id = chunk_embeddings.model_id
         JOIN chunks ON chunks.id = chunk_embeddings.chunk_id
         JOIN files ON files.id = chunks.file_id
-        LEFT JOIN chunk_text ON chunk_text.chunk_id = chunks.id
+        JOIN chunk_text ON chunk_text.chunk_id = chunks.id
         WHERE chunk_embeddings.model_id = ?1
           AND ai_models.installed = 1
           AND ai_models.disabled = 0
@@ -371,7 +372,7 @@ fn vector_candidates(
             ai::EMBEDDING_TEXT_VERSION
         ],
         |row| {
-            let vector_blob: Vec<u8> = row.get(8)?;
+            let vector_blob: Vec<u8> = row.get(7)?;
             Ok((
                 SearchHit {
                     chunk_id: row.get(0)?,
@@ -393,7 +394,11 @@ fn vector_candidates(
                     importance: None,
                 },
                 vector_blob,
-                ChunkTextRow { fallback: row.get(7)?, blob: row.get(9)?, raw_len: row.get(10)? },
+                ChunkTextRow {
+                    blob: row.get(8)?,
+                    raw_len: row.get(9)?,
+                    dict_version: row.get(10)?,
+                },
             ))
         },
     )?;
@@ -415,7 +420,7 @@ fn vector_candidates(
     scored.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
     let mut hits = Vec::with_capacity(scored.len());
     for (mut hit, similarity, text_row) in scored {
-        hit.summary = snippet(&text_row.resolve(decompressor)?, query);
+        hit.summary = snippet(&text_row.resolve(decoder)?, query);
         hits.push((hit, similarity));
     }
     Ok(hits)
@@ -671,26 +676,23 @@ mod tests {
             [],
         )
         .unwrap();
+        let text = "fn watcher_main() { /* election retry loop */ }";
         let chunk_id: i64 = conn
             .query_row(
                 "INSERT INTO chunks(file_id, chunk_kind, symbol_path, start_byte, end_byte,
-                                    start_line, end_line, text, text_hash)
-                 VALUES (1, 'symbol', 'watcher_main', 0, 10, 1, 20,
-                         'fn watcher_main() { /* election retry loop */ }', 'h1')
+                                    start_line, end_line, text_hash)
+                 VALUES (1, 'symbol', 'watcher_main', 0, 10, 1, 20, 'h1')
                  RETURNING id",
                 [],
                 |row| row.get(0),
             )
             .unwrap();
-        // Populate the FTS index directly — external-content FTS5 tables need an explicit
-        // INSERT on the FTS virtual table to build shadow-table entries (or a 'rebuild', as
-        // schema::rebuild_fts now does). A direct INSERT keeps this seed self-contained.
-        conn.execute(
-            "INSERT INTO chunk_fts(rowid, text)
-             VALUES (?1, 'fn watcher_main() { /* election retry loop */ }')",
-            [chunk_id],
-        )
-        .unwrap();
+        // chunks.text is gone (#77 Phase 2): seed the compressed chunk_text blob (readers INNER
+        // JOIN it) and the contentless chunk_fts tokens directly, keeping this seed
+        // self-contained.
+        crate::index::chunk_text_store::seed_chunk_text(&conn, chunk_id, text).unwrap();
+        conn.execute("INSERT INTO chunk_fts(rowid, text) VALUES (?1, ?2)", params![chunk_id, text])
+            .unwrap();
         conn
     }
 

--- a/crates/rag-rat-core/src/search/lexical.rs
+++ b/crates/rag-rat-core/src/search/lexical.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use rusqlite::{Connection, params};
 use serde::Serialize;
 
-use crate::index::ai;
+use crate::index::{ai, text_compression};
 use crate::query::graph_meta::GraphEvidence;
 
 const BM25_WEIGHT: f64 = 0.45;
@@ -266,10 +266,11 @@ fn bm25_candidates(
         SELECT chunks.id, files.path, files.language, files.kind,
                chunks.start_line, chunks.end_line, chunks.symbol_path,
                bm25(chunk_fts) AS score,
-               chunks.text
+               chunks.text, chunk_text.blob, chunk_text.raw_len
         FROM chunk_fts
         JOIN chunks ON chunks.id = chunk_fts.rowid
         JOIN files ON files.id = chunks.file_id
+        LEFT JOIN chunk_text ON chunk_text.chunk_id = chunks.id
         WHERE chunk_fts MATCH ?1
           AND {generated_filter}
         ORDER BY score
@@ -277,27 +278,61 @@ fn bm25_candidates(
         "
     );
     let mut stmt = conn.prepare(&sql)?;
+    // Snippet text comes from the compressed store (#77); collect blob + raw_len here and
+    // decompress in the post-loop — decompress returns anyhow::Result, which can't cross the
+    // rusqlite closure.
     let rows = stmt.query_map(params![fts_query, limit], |row| {
-        let text: String = row.get(8)?;
-        Ok(SearchHit {
-            chunk_id: row.get(0)?,
-            path: row.get(1)?,
-            language: row.get(2)?,
-            kind: row.get(3)?,
-            start_line: row.get(4)?,
-            end_line: row.get(5)?,
-            symbol_path: row.get(6)?,
-            score: row.get(7)?,
-            // Placeholder — RankedHit::finish sets the real mode from the scored components.
-            retrieval_mode: String::new(),
-            summary: snippet(&text, query),
-            graph: None,
-            score_components: None,
-            importance: None,
-        })
+        Ok((
+            SearchHit {
+                chunk_id: row.get(0)?,
+                path: row.get(1)?,
+                language: row.get(2)?,
+                kind: row.get(3)?,
+                start_line: row.get(4)?,
+                end_line: row.get(5)?,
+                symbol_path: row.get(6)?,
+                score: row.get(7)?,
+                // Placeholder — RankedHit::finish sets the real mode from the scored components.
+                retrieval_mode: String::new(),
+                summary: String::new(),
+                graph: None,
+                score_components: None,
+                importance: None,
+            },
+            ChunkTextRow { fallback: row.get(8)?, blob: row.get(9)?, raw_len: row.get(10)? },
+        ))
     })?;
+    let collected = collect_rows(rows)?;
+    let dict = crate::query::chunk_text_dict(conn)?;
+    let mut decompressor = text_compression::ChunkDecompressor::new(&dict)?;
+    let mut hits = Vec::with_capacity(collected.len());
+    for (mut hit, text_row) in collected {
+        hit.summary = snippet(&text_row.resolve(&mut decompressor)?, query);
+        hits.push(hit);
+    }
+    Ok(hits)
+}
 
-    collect_rows(rows)
+/// A chunk's stored text as fetched for a search hit (#77): the compressed `chunk_text` blob +
+/// `raw_len`, with `chunks.text` as the fallback for a chunk not yet in the store. [`resolve`]
+/// decompresses the blob (or returns the fallback).
+struct ChunkTextRow {
+    fallback: String,
+    blob: Option<Vec<u8>>,
+    raw_len: Option<i64>,
+}
+
+impl ChunkTextRow {
+    fn resolve(
+        self,
+        decompressor: &mut text_compression::ChunkDecompressor,
+    ) -> anyhow::Result<String> {
+        match (self.blob, self.raw_len) {
+            (Some(blob), Some(raw_len)) =>
+                Ok(String::from_utf8(decompressor.decompress(&blob, raw_len.max(0) as usize)?)?),
+            _ => Ok(self.fallback),
+        }
+    }
 }
 
 fn vector_candidates(
@@ -316,11 +351,12 @@ fn vector_candidates(
         "
         SELECT chunks.id, files.path, files.language, files.kind,
                chunks.start_line, chunks.end_line, chunks.symbol_path,
-               chunks.text, chunk_embeddings.vector_blob
+               chunks.text, chunk_embeddings.vector_blob, chunk_text.blob, chunk_text.raw_len
         FROM chunk_embeddings
         JOIN ai_models ON ai_models.model_id = chunk_embeddings.model_id
         JOIN chunks ON chunks.id = chunk_embeddings.chunk_id
         JOIN files ON files.id = chunks.file_id
+        LEFT JOIN chunk_text ON chunk_text.chunk_id = chunks.id
         WHERE chunk_embeddings.model_id = ?1
           AND ai_models.installed = 1
           AND ai_models.disabled = 0
@@ -344,8 +380,7 @@ fn vector_candidates(
             ai::EMBEDDING_TEXT_VERSION
         ],
         |row| {
-            let text: String = row.get(7)?;
-            let blob: Vec<u8> = row.get(8)?;
+            let vector_blob: Vec<u8> = row.get(8)?;
             Ok((
                 SearchHit {
                     chunk_id: row.get(0)?,
@@ -359,23 +394,29 @@ fn vector_candidates(
                     // Placeholder — RankedHit::finish sets the real mode from the scored
                     // components.
                     retrieval_mode: String::new(),
-                    summary: snippet(&text, query),
+                    // Filled from the compressed store in the post-loop (decompress can't cross the
+                    // rusqlite closure).
+                    summary: String::new(),
                     graph: None,
                     score_components: None,
                     importance: None,
                 },
-                blob,
+                vector_blob,
+                ChunkTextRow { fallback: row.get(7)?, blob: row.get(9)?, raw_len: row.get(10)? },
             ))
         },
     )?;
+    let collected = collect_rows(rows)?;
+    let dict = crate::query::chunk_text_dict(conn)?;
+    let mut decompressor = text_compression::ChunkDecompressor::new(&dict)?;
     let mut hits = Vec::new();
-    for row in rows {
-        let (hit, blob) = row?;
-        let Some(vector) = ai::decode_vector(&blob, query_embedding.dim) else {
+    for (mut hit, vector_blob, text_row) in collected {
+        let Some(vector) = ai::decode_vector(&vector_blob, query_embedding.dim) else {
             continue;
         };
         let similarity = dot(&query_embedding.vector, &vector);
         if similarity > 0.0 {
+            hit.summary = snippet(&text_row.resolve(&mut decompressor)?, query);
             hits.push((hit, similarity));
         }
     }

--- a/crates/rag-rat-core/src/search/lexical.rs
+++ b/crates/rag-rat-core/src/search/lexical.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use rusqlite::{Connection, params};
 use serde::Serialize;
 
+use crate::index::text_compression::ChunkTextRow;
 use crate::index::{ai, text_compression};
 use crate::query::graph_meta::GraphEvidence;
 
@@ -311,28 +312,6 @@ fn bm25_candidates(
         hits.push(hit);
     }
     Ok(hits)
-}
-
-/// A chunk's stored text as fetched for a search hit (#77): the compressed `chunk_text` blob +
-/// `raw_len`, with `chunks.text` as the fallback for a chunk not yet in the store. [`resolve`]
-/// decompresses the blob (or returns the fallback).
-struct ChunkTextRow {
-    fallback: String,
-    blob: Option<Vec<u8>>,
-    raw_len: Option<i64>,
-}
-
-impl ChunkTextRow {
-    fn resolve(
-        self,
-        decompressor: &mut text_compression::ChunkDecompressor,
-    ) -> anyhow::Result<String> {
-        match (self.blob, self.raw_len) {
-            (Some(blob), Some(raw_len)) =>
-                Ok(String::from_utf8(decompressor.decompress(&blob, raw_len.max(0) as usize)?)?),
-            _ => Ok(self.fallback),
-        }
-    }
 }
 
 fn vector_candidates(

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -82,16 +82,14 @@ impl Debounce {
 
 /// Run one maintenance pass, blocking on the per-DB write lock (watcher-to-watcher serializes).
 pub fn maintenance_pass(config: &Config, run_gc: bool) -> anyhow::Result<()> {
-    let lock_path = locks::write_lock_path(&config.database);
-    let _lock = FileLock::acquire_blocking(&lock_path)?;
+    let _lock = locks::WriteLock::acquire_blocking(&config.database)?;
     run_pass(config, run_gc)
 }
 
 /// Run one maintenance pass only if the write lock is free within `SKIP_TIMEOUT`; returns whether
 /// it ran. Used by interactive / hook / shutdown callers so a held lock can't hang them.
 pub fn maintenance_pass_or_skip(config: &Config, run_gc: bool) -> anyhow::Result<bool> {
-    let lock_path = locks::write_lock_path(&config.database);
-    match FileLock::acquire_timeout(&lock_path, SKIP_TIMEOUT)? {
+    match locks::WriteLock::acquire_timeout(&config.database, SKIP_TIMEOUT)? {
         Some(_lock) => {
             run_pass(config, run_gc)?;
             Ok(true)
@@ -650,8 +648,7 @@ fn watcher_main(config: Config, fleet_bin: Option<PathBuf>, stop: &AtomicBool) {
 
 /// A bounded shutdown refresh: take the write lock only if free, run discover (no reconcile/embed).
 fn shutdown_discover(config: &Config) -> anyhow::Result<bool> {
-    let lock_path = locks::write_lock_path(&config.database);
-    match FileLock::acquire_timeout(&lock_path, SKIP_TIMEOUT)? {
+    match locks::WriteLock::acquire_timeout(&config.database, SKIP_TIMEOUT)? {
         Some(_lock) => {
             IndexDatabase::index_discover(config)?;
             Ok(true)


### PR DESCRIPTION
Implements #77: stored chunk text moves to a dictionary-trained zstd `chunk_text` store, and the inline `chunks.text` column is retired. Phase 1 (#223) removed the `impact_surface` text scan + added `files.has_test_code`; this is the compression itself.

## What changed

**Storage**
- New `chunk_text(chunk_id, blob, raw_len, dict_version)` holds each chunk's text as a dictionary-trained zstd blob; `chunks.text` is dropped (V027). The store is built from `chunks.text` during forward-migration, then the column goes.
- The dictionary is **immutable and versioned** (`chunk_text_dict(version, dict)` + per-blob `dict_version`), not a single mutable global slot. A zstd blob only decodes against the dict it was made with, so the dict is a per-blob decode key. The first index trains version 1; nothing ever replaces it. A future retrain would *add* a version (new blobs use it; old blobs keep theirs; both stay resident), so a rebuild of one worktree context can never orphan another context's blobs. One shared dict (measured within ~3% of per-language).

**FTS**
- `chunk_fts` becomes **contentless** (`content=''`, `contentless_delete=1`) — an external-content index re-reads the content column, which would block dropping it. Tokens are written inline from the in-memory chunk text on every path (full rebuild + incremental); only `MATCH`/`bm25()` are used (snippets come from `chunk_text`), so contentless loses nothing. Requires SQLite ≥ 3.43 (the codebase already required ≥ 3.37 for STRICT / 3.35 for DROP COLUMN).

**Reads**
- A version-aware `ChunkTextDecoder` decodes a batch across resident dict versions, reusing one decompressor per version. Every reader (`read_chunk`, lexical bm25/vector, graph local-context, embedding scan, policy skip-summary, FTS repopulate) decodes from `chunk_text`; the per-call dict load is hoisted to once-per-batch.

**Migrations**: V025 (chunk_text tables), V026 (contentless `chunk_fts`, idempotent), V027 (build store from `chunks.text` then drop it). Forward-migrating an existing index rebuilds the store from the column before dropping it; the column drop is irreversible.

## Benchmark (the gate)

Kernel subtree `mm/fs/kernel/lib` (128,875 chunks), pre-Phase-2 base vs this branch:

| Metric | Before | After |
|---|---|---|
| DB size | 396.0 MB | **329.5 MB** (−17%) |
| Full index time | 150.7 s | **110.6 s** (−27%, faster) |
| chunk_text compression | — | 2.65× (74.3 MB raw → 28.1 MB blobs) |
| Query latency | 1.13 s | 1.02 s |

Indexing got *faster* (contentless FTS skips the bulk external-content `'rebuild'` re-read), and retrieval is correct (snippets decode) and not slower — honoring the no-indexing-delay and no-retrieval-delay constraints.

## Result vs the issue's estimate

The issue estimated `~3.8 GB → <1 GB` assuming chunk text dominates the DB. Measured on the real kernel index, `chunks.text` is ~31% of the DB (not the dominant majority), so blob-level compression lands the full kernel around ~3.6 GB → ~2.8 GB. This PR delivers the compression #77 specifies; the remaining size budget (edge framing, indexes, symbols) is tracked in #224.

## Follow-ups (not in this PR)
- gc sweep of orphan dict versions + an explicit dict-retrain op — only relevant once a retrain creates a second version.

Closes #77.

https://claude.ai/code/session_01Qj5oCLLt7UcjBv2Ckr3gc8