### PR TITLE
feat(index): intern symbol qualified_name into the shared name_strings pool (#224)

### DIFF
--- a/crates/rag-rat-core/src/index/edges/helpers.rs
+++ b/crates/rag-rat-core/src/index/edges/helpers.rs
@@ -246,11 +246,11 @@ pub(crate) fn symbols_for_file(
 ) -> anyhow::Result<Vec<IndexedSymbol>> {
     let mut stmt = conn.prepare(
         "
-        SELECT symbols.id, symbols.file_id, symbols.language, symbols.name, \
-         symbols.qualified_name, symbols.kind,
+        SELECT symbols.id, symbols.file_id, symbols.language, symbols.name, qn.value, symbols.kind,
                symbols.start_byte, symbols.end_byte, symbols.start_line, symbols.end_line, \
          COALESCE(symbols.scope_path, '')
         FROM symbols
+        LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
         WHERE file_id = ?1
         ORDER BY symbols.start_byte, symbols.end_byte
         ",
@@ -265,13 +265,13 @@ pub(crate) fn symbols_for_file(
 pub(crate) fn all_symbols(conn: &Connection) -> anyhow::Result<Vec<IndexedSymbol>> {
     let mut stmt = conn.prepare(
         "
-        SELECT symbols.id, symbols.file_id, symbols.language, symbols.name, \
-         symbols.qualified_name, symbols.kind,
+        SELECT symbols.id, symbols.file_id, symbols.language, symbols.name, qn.value, symbols.kind,
                symbols.start_byte, symbols.end_byte, symbols.start_line, symbols.end_line, \
          COALESCE(symbols.scope_path, '')
         FROM symbols
         JOIN files ON files.id = symbols.file_id
-        ORDER BY symbols.qualified_name
+        LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
+        ORDER BY qn.value
         ",
     )?;
     let rows = stmt.query_map([], symbol_row)?;
@@ -294,13 +294,13 @@ pub(crate) fn symbol_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<IndexedSym
         scope_path: row.get(10)?,
     })
 }
-/// Intern one string into `edge_strings`, returning its id (#79). `INSERT OR IGNORE` + lookup —
+/// Intern one string into `name_strings`, returning its id (#79). `INSERT OR IGNORE` + lookup —
 /// two cached statements; callers on bulk paths wrap this in [`EdgeStringInterner`] so repeats
 /// hit a process-side map instead of the b-tree.
 pub(crate) fn intern_edge_string(conn: &Connection, value: &str) -> anyhow::Result<i64> {
-    conn.prepare_cached("INSERT OR IGNORE INTO edge_strings(value) VALUES (?1)")?
+    conn.prepare_cached("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)")?
         .execute([value])?;
-    conn.prepare_cached("SELECT id FROM edge_strings WHERE value = ?1")?
+    conn.prepare_cached("SELECT id FROM name_strings WHERE value = ?1")?
         .query_row([value], |row| row.get(0))
         .map_err(Into::into)
 }

--- a/crates/rag-rat-core/src/index/edges/resolve/dispatch.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/dispatch.rs
@@ -167,8 +167,8 @@ fn collect_constructors(
          d.source_end_line
          FROM edges_data d
          JOIN files ON files.id = d.source_file_id
-         JOIN edge_strings ek ON ek.id = d.edge_kind_id
-         JOIN edge_strings tn ON tn.id = d.to_name_id
+         JOIN name_strings ek ON ek.id = d.edge_kind_id
+         JOIN name_strings tn ON tn.id = d.to_name_id
          WHERE ek.value = 'dispatch_construct' AND d.from_symbol_id IS NOT NULL{}",
         write.files_write_predicate(),
     ))?;
@@ -194,11 +194,12 @@ fn collect_constructors(
 /// never guessed.
 fn collect_handlers(conn: &Connection) -> anyhow::Result<HashMap<String, HashMap<i64, Handler>>> {
     let mut stmt = conn.prepare(
-        "SELECT d.evidence, d.to_symbol_id, sym.qualified_name, sym.start_line, sym.end_line
+        "SELECT d.evidence, d.to_symbol_id, sym_qn.value, sym.start_line, sym.end_line
          FROM edges_data d
          JOIN files ON files.id = d.source_file_id
-         JOIN edge_strings ek ON ek.id = d.edge_kind_id
+         JOIN name_strings ek ON ek.id = d.edge_kind_id
          JOIN symbols sym ON sym.id = d.to_symbol_id
+         LEFT JOIN name_strings sym_qn ON sym_qn.id = sym.qualified_name_id
          WHERE ek.value = 'dispatch_handle' AND d.to_symbol_id IS NOT NULL AND d.evidence IS NOT \
          NULL",
     )?;

--- a/crates/rag-rat-core/src/index/edges/resolve/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/mod.rs
@@ -297,8 +297,8 @@ fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> any
         let mut stmt = conn.prepare(
             "SELECT d.source_file_id, files.language, tn.value, d.evidence, \
              d.import_scope_start_byte, d.import_scope_end_byte, d.import_mod_id FROM edges_data \
-             d JOIN files ON files.id = d.source_file_id JOIN edge_strings ek ON ek.id = \
-             d.edge_kind_id LEFT JOIN edge_strings tn ON tn.id = d.to_name_id WHERE ek.value = \
+             d JOIN files ON files.id = d.source_file_id JOIN name_strings ek ON ek.id = \
+             d.edge_kind_id LEFT JOIN name_strings tn ON tn.id = d.to_name_id WHERE ek.value = \
              'imports'",
         )?;
         let mut rows = stmt.query([])?;
@@ -333,10 +333,10 @@ fn resolve_edges_with_scope(conn: &Connection, write: EdgeWriteScope<'_>) -> any
     let mut stmt = conn.prepare(&format!(
         "SELECT d.id, d.source_file_id, tn.value, tqn.value, ek.value, conf.value, d.evidence, \
          rh.value, d.source_start_byte FROM edges_data d JOIN files ON files.id = \
-         d.source_file_id LEFT JOIN edge_strings tn ON tn.id = d.to_name_id LEFT JOIN \
-         edge_strings tqn ON tqn.id = d.target_qualified_name_id LEFT JOIN edge_strings ek ON \
-         ek.id = d.edge_kind_id LEFT JOIN edge_strings conf ON conf.id = d.confidence_id LEFT \
-         JOIN edge_strings rh ON rh.id = d.receiver_hint_id WHERE 1 = 1{} ORDER BY d.id",
+         d.source_file_id LEFT JOIN name_strings tn ON tn.id = d.to_name_id LEFT JOIN \
+         name_strings tqn ON tqn.id = d.target_qualified_name_id LEFT JOIN name_strings ek ON \
+         ek.id = d.edge_kind_id LEFT JOIN name_strings conf ON conf.id = d.confidence_id LEFT \
+         JOIN name_strings rh ON rh.id = d.receiver_hint_id WHERE 1 = 1{} ORDER BY d.id",
         write.files_write_predicate(),
     ))?;
     let rows = stmt.query_map([], |row| {

--- a/crates/rag-rat-core/src/index/edges/resolve/tests.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/tests.rs
@@ -23,9 +23,14 @@ fn add_file(conn: &Connection, path: &str, commit: &str) -> i64 {
 }
 
 fn add_symbol(conn: &Connection, file_id: i64, name: &str, qualified: &str) -> i64 {
+    // #224: qualified_name is interned into name_strings; intern then store the id.
+    conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)", params![qualified])
+        .unwrap();
     conn.execute(
-        "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte, end_byte, \
-         start_line, end_line) VALUES (?1, 'rust', ?2, ?3, 'function', 0, 10, 1, 1)",
+        "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, start_byte, \
+         end_byte, start_line, end_line)
+         VALUES (?1, 'rust', ?2, (SELECT id FROM name_strings WHERE value = ?3), 'function', 0, \
+         10, 1, 1)",
         params![file_id, name, qualified],
     )
     .unwrap();
@@ -142,9 +147,12 @@ fn add_symbol_kind(
     qualified: &str,
     kind: &str,
 ) -> i64 {
+    conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)", params![qualified])
+        .unwrap();
     conn.execute(
-        "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte, end_byte, \
-         start_line, end_line) VALUES (?1, 'rust', ?2, ?3, ?4, 0, 10, 1, 1)",
+        "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, start_byte, \
+         end_byte, start_line, end_line)
+         VALUES (?1, 'rust', ?2, (SELECT id FROM name_strings WHERE value = ?3), ?4, 0, 10, 1, 1)",
         params![file_id, name, qualified, kind],
     )
     .unwrap();
@@ -303,9 +311,12 @@ fn add_symbol_scope(
     qualified: &str,
     scope_path: &str,
 ) -> i64 {
+    conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)", params![qualified])
+        .unwrap();
     conn.execute(
-        "INSERT INTO symbols(file_id, language, name, qualified_name, scope_path, kind, \
-         start_byte, end_byte, start_line, end_line) VALUES (?1, 'rust', ?2, ?3, ?4, 'function', \
+        "INSERT INTO symbols(file_id, language, name, qualified_name_id, scope_path, kind, \
+         start_byte, end_byte, start_line, end_line)
+         VALUES (?1, 'rust', ?2, (SELECT id FROM name_strings WHERE value = ?3), ?4, 'function', \
          0, 10, 1, 1)",
         params![file_id, name, qualified, scope_path],
     )
@@ -767,9 +778,12 @@ fn py_source(conn: &Connection, path: &str) -> i64 {
 }
 
 fn py_sym(conn: &Connection, file_id: i64, name: &str, qualified: &str, kind: &str) -> i64 {
+    conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)", params![qualified])
+        .unwrap();
     conn.execute(
-        "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte, end_byte, \
-         start_line, end_line) VALUES (?1, 'python', ?2, ?3, ?4, 0, 10, 1, 1)",
+        "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, start_byte, \
+         end_byte, start_line, end_line)
+         VALUES (?1, 'python', ?2, (SELECT id FROM name_strings WHERE value = ?3), ?4, 0, 10, 1, 1)",
         params![file_id, name, qualified, kind],
     )
     .unwrap();
@@ -792,10 +806,12 @@ fn python_implements_ignores_a_foreign_language_class() {
     )
     .unwrap();
     let ts = conn.last_insert_rowid();
+    conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES ('w.ts::Base')", []).unwrap();
     conn.execute(
-        "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte, end_byte, \
-         start_line, end_line) VALUES (?1, 'typescript', 'Base', 'w.ts::Base', 'class', 0, 10, 1, \
-         1)",
+        "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, start_byte, \
+         end_byte, start_line, end_line)
+         VALUES (?1, 'typescript', 'Base', (SELECT id FROM name_strings WHERE value = \
+         'w.ts::Base'), 'class', 0, 10, 1, 1)",
         params![ts],
     )
     .unwrap();
@@ -1133,10 +1149,13 @@ fn add_py_symbol_scope(
     qualified: &str,
     scope_path: &str,
 ) -> i64 {
+    conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)", params![qualified])
+        .unwrap();
     conn.execute(
-        "INSERT INTO symbols(file_id, language, name, qualified_name, scope_path, kind, \
-         start_byte, end_byte, start_line, end_line) VALUES (?1, 'python', ?2, ?3, ?4, \
-         'function', 0, 10, 1, 1)",
+        "INSERT INTO symbols(file_id, language, name, qualified_name_id, scope_path, kind, \
+         start_byte, end_byte, start_line, end_line)
+         VALUES (?1, 'python', ?2, (SELECT id FROM name_strings WHERE value = ?3), ?4, 'function', \
+         0, 10, 1, 1)",
         params![file_id, name, qualified, scope_path],
     )
     .unwrap();
@@ -1167,9 +1186,13 @@ fn add_py_symbol_at(
     qualified: &str,
     start_byte: i64,
 ) -> i64 {
+    conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)", params![qualified])
+        .unwrap();
     conn.execute(
-        "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte, end_byte, \
-         start_line, end_line) VALUES (?1, 'python', ?2, ?3, 'class', ?4, ?4 + 10, 1, 1)",
+        "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, start_byte, \
+         end_byte, start_line, end_line)
+         VALUES (?1, 'python', ?2, (SELECT id FROM name_strings WHERE value = ?3), 'class', ?4, ?4 \
+         + 10, 1, 1)",
         params![file_id, name, qualified, start_byte],
     )
     .unwrap();

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -320,16 +320,21 @@ impl IndexDatabase {
         let conn = self.storage.connection();
         let mut symbol_ids = Vec::with_capacity(symbols.len());
         for symbol in symbols {
+            // Intern the qualified name into the shared `name_strings` pool and store its id (#224)
+            // — the qualified_name TEXT column was dropped in V028. The pool is shared with edge
+            // call-target names (~85% overlap), so most inserts hit an existing id.
+            let qualified_name_id =
+                crate::index::edges::intern_edge_string(conn, &symbol.qualified_name)?;
             conn.prepare_cached(
-                "INSERT INTO symbols(file_id, language, name, qualified_name, scope_path, kind, \
-                 start_byte, end_byte, start_line, end_line, signature, docs)
+                "INSERT INTO symbols(file_id, language, name, qualified_name_id, scope_path, \
+                 kind, start_byte, end_byte, start_line, end_line, signature, docs)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
             )?
             .execute(params![
                 file_id,
                 language.as_str(),
                 symbol.name,
-                symbol.qualified_name,
+                qualified_name_id,
                 symbol.scope_path,
                 symbol.kind,
                 i64::try_from(symbol.start_byte)?,
@@ -363,9 +368,12 @@ impl IndexDatabase {
     ) -> anyhow::Result<()> {
         let group_reason = if members.len() > 1 { "cfg_variant" } else { "single" };
         let logical_symbol_id = key.stable_id();
+        // Intern the qualified name into the shared `name_strings` pool (#224) — the
+        // qualified_name TEXT column was dropped in V028.
+        let qualified_name_id = crate::index::edges::intern_edge_string(conn, &key.qualified_name)?;
         conn.prepare_cached(
             "
-            INSERT INTO logical_symbols(id, language, path, logical_name, qualified_name, kind, \
+            INSERT INTO logical_symbols(id, language, path, logical_name, qualified_name_id, kind, \
              variant_count, group_reason)
             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
             ",
@@ -375,7 +383,7 @@ impl IndexDatabase {
             key.language,
             key.path,
             key.name,
-            key.qualified_name,
+            qualified_name_id,
             key.kind,
             i64::try_from(members.len()).unwrap_or(i64::MAX),
             group_reason,

--- a/crates/rag-rat-core/src/index/graph_index.rs
+++ b/crates/rag-rat-core/src/index/graph_index.rs
@@ -117,11 +117,12 @@ impl IndexDatabase {
         let mut stmt = conn.prepare(
             "
             SELECT symbols.id, main.files.path, symbols.language, symbols.name,
-                   symbols.qualified_name, symbols.kind, symbols.signature, symbols.start_line,
+                   qn.value, symbols.kind, symbols.signature, symbols.start_line,
                    symbols.end_line
             FROM main.symbols AS symbols
             JOIN main.files ON main.files.id = symbols.file_id
-            ORDER BY symbols.language, main.files.path, symbols.name, symbols.qualified_name,
+            LEFT JOIN main.name_strings qn ON qn.id = symbols.qualified_name_id
+            ORDER BY symbols.language, main.files.path, symbols.name, qn.value,
                      symbols.kind, symbols.signature, symbols.start_byte, symbols.end_byte
             ",
         )?;

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -717,9 +717,10 @@ pub(crate) fn current_oracle_verdicts_for_edges(
         // is left heuristic (#82 finding 2).
         let sql = format!(
             "SELECT edge_oracle.edge_id, edge_oracle.kind, edge_oracle.resolved_symbol_id, \
-             (SELECT qualified_name FROM symbols WHERE symbols.id = \
-             edge_oracle.resolved_symbol_id), edge_oracle.scip_symbol{scope_join}{current} AND \
-             edge_oracle.edge_id IN ({placeholders})",
+             (SELECT value FROM name_strings WHERE name_strings.id = (SELECT qualified_name_id \
+             FROM symbols WHERE symbols.id = edge_oracle.resolved_symbol_id)), \
+             edge_oracle.scip_symbol{scope_join}{current} AND edge_oracle.edge_id IN \
+             ({placeholders})",
             scope_join = edge_oracle_scope_join(),
             current = edge_oracle_current_predicate(),
         );
@@ -843,10 +844,10 @@ pub(crate) fn current_oracle_comparisons(
     // WHERE) stays the single source of the scope predicate — a JOIN can't legally follow a WHERE.
     let sql = format!(
         "SELECT edge_oracle.edge_id, edge_oracle.kind, edges.edge_kind, edges.confidence, (SELECT \
-         qualified_name FROM symbols WHERE symbols.id = edges.to_symbol_id), edges.to_name, \
-         edge_oracle.resolved_symbol_id, edge_oracle.scip_symbol, files.path, \
-         COALESCE(NULLIF(edges.source_start_line, 0), 1) {scope_join}{current} ORDER BY \
-         files.path, edges.source_start_line",
+         value FROM name_strings WHERE name_strings.id = (SELECT qualified_name_id FROM symbols \
+         WHERE symbols.id = edges.to_symbol_id)), edges.to_name, edge_oracle.resolved_symbol_id, \
+         edge_oracle.scip_symbol, files.path, COALESCE(NULLIF(edges.source_start_line, 0), 1) \
+         {scope_join}{current} ORDER BY files.path, edges.source_start_line",
         scope_join = edge_oracle_scope_join(),
         current = edge_oracle_current_predicate(),
     );

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -96,11 +96,16 @@ impl Harness {
 
     /// Insert a symbol with a byte span, returning its id.
     fn add_symbol(&self, file_id: i64, name: &str, start_byte: usize, end_byte: usize) -> i64 {
+        // #224: qualified_name interned into name_strings (here name == qualified_name).
+        self.conn
+            .execute("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)", params![name])
+            .unwrap();
         self.conn
             .execute(
-                "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte, \
-                 end_byte, start_line, end_line) VALUES (?1, 'rust', ?2, ?2, 'function', ?3, ?4, \
-                 1, 1)",
+                "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, \
+                 start_byte, end_byte, start_line, end_line)
+                 VALUES (?1, 'rust', ?2, (SELECT id FROM name_strings WHERE value = ?2), \
+                 'function', ?3, ?4, 1, 1)",
                 params![file_id, name, start_byte as i64, end_byte as i64],
             )
             .unwrap();
@@ -120,9 +125,16 @@ impl Harness {
         end_byte: usize,
     ) -> i64 {
         self.conn
+            .execute("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)", params![
+                qualified_name
+            ])
+            .unwrap();
+        self.conn
             .execute(
-                "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte, \
-                 end_byte, start_line, end_line) VALUES (?1, 'rust', ?2, ?3, ?4, ?5, ?6, 1, 1)",
+                "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, \
+                 start_byte, end_byte, start_line, end_line)
+                 VALUES (?1, 'rust', ?2, (SELECT id FROM name_strings WHERE value = ?3), ?4, ?5, \
+                 ?6, 1, 1)",
                 params![file_id, name, qualified_name, kind, start_byte as i64, end_byte as i64],
             )
             .unwrap();
@@ -139,10 +151,16 @@ impl Harness {
         symbol_id: i64,
     ) {
         self.conn
+            .execute("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)", params![
+                qualified_name
+            ])
+            .unwrap();
+        self.conn
             .execute(
-                "INSERT INTO logical_symbols(id, language, path, logical_name, qualified_name, \
-                 kind, variant_count, group_reason) VALUES (?1, 'rust', ?2, ?3, ?4, 'function', \
-                 1, 'single')",
+                "INSERT INTO logical_symbols(id, language, path, logical_name, qualified_name_id, \
+                 kind, variant_count, group_reason)
+                 VALUES (?1, 'rust', ?2, ?3, (SELECT id FROM name_strings WHERE value = ?4), \
+                 'function', 1, 'single')",
                 params![logical_symbol_id, path, name, qualified_name],
             )
             .unwrap();
@@ -749,7 +767,7 @@ fn migration_creates_oracle_side_tables() {
         assert!(columns.contains(&expected.to_string()), "edge_oracle missing {expected}");
     }
 
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 27);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 28);
 }
 
 /// The V019 moniker migration: the `logical_symbol_monikers` table (STRICT, NO foreign key — see
@@ -4075,7 +4093,7 @@ fn pre_spawn_gate_skips_definition_reindexed_mid_subprocess() {
 // Edge string interning (#79): compat view shape, round-trip writes, dedup, V020 conversion.
 // ---------------------------------------------------------------------------
 
-/// The V020 shape: `edges` is a VIEW over `edges_data` + the `edge_strings` dictionary, with
+/// The V020 shape: `edges` is a VIEW over `edges_data` + the `name_strings` dictionary, with
 /// INSTEAD OF triggers; both backing tables are STRICT; the int indexes replaced the TEXT ones.
 #[test]
 fn edges_is_a_compat_view_over_interned_tables() {
@@ -4088,7 +4106,7 @@ fn edges_is_a_compat_view_over_interned_tables() {
     };
     assert_eq!(object_type("edges"), "view");
     assert_eq!(object_type("edges_data"), "table");
-    assert_eq!(object_type("edge_strings"), "table");
+    assert_eq!(object_type("name_strings"), "table");
     for trigger in ["edges_view_insert", "edges_view_update", "edges_view_delete"] {
         assert_eq!(object_type(trigger), "trigger", "{trigger} must exist");
     }
@@ -4138,7 +4156,7 @@ fn view_writes_round_trip_and_dedup() {
     let shared: i64 = h
         .conn
         .query_row(
-            "SELECT COUNT(*) FROM edge_strings WHERE value IN ('a.rs::caller', 'calls_name', \
+            "SELECT COUNT(*) FROM name_strings WHERE value IN ('a.rs::caller', 'calls_name', \
              'NameOnly', 'unresolved')",
             [],
             |row| row.get(0),
@@ -4179,7 +4197,7 @@ fn v020_converts_a_legacy_edges_table() {
         DROP TRIGGER edges_view_delete;
         DROP VIEW edges;
         DELETE FROM edges_data;
-        DELETE FROM edge_strings;
+        DELETE FROM name_strings;
         CREATE TABLE edges(
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             source_file_id INTEGER,
@@ -4272,7 +4290,7 @@ fn or_branch_name_predicates_use_the_to_name_index() {
     let fixed = plan(
         "SELECT COUNT(*) FROM edges WHERE edge_kind IN ('calls_name','constructs','uses_macro') \
          AND (to_symbol_id = 5 OR (to_symbol_id IS NULL AND to_name_id = (SELECT id FROM \
-         edge_strings WHERE value = 'x')))",
+         name_strings WHERE value = 'x')))",
     );
     assert!(
         fixed.contains("idx_edges_to_name"),

--- a/crates/rag-rat-core/src/index/query_api/gc.rs
+++ b/crates/rag-rat-core/src/index/query_api/gc.rs
@@ -106,14 +106,19 @@ impl IndexDatabase {
         // rows would survive the file pruning. Prune them with the SAME live sets, so a run and the
         // edges it produced are dropped together.
         oracle::prune_oracle_runs_outside_scope(conn, live_commits, live_worktrees)?;
-        // Dictionary hygiene (#79): drop `edge_strings` values no edge references any more. The
-        // dictionary has NO FKs by design (see the schema comment), so orphans accumulate as
-        // edges are pruned; the vocabulary is small, but gc is the natural rate-limited home for
-        // the sweep. Every referencing column must appear here — a missed column would null its
-        // strings out from under live edges.
+        // Dictionary hygiene (#79, extended #224): drop `name_strings` values nothing references
+        // any more. The pool has NO FKs by design (see the schema comment), so orphans
+        // accumulate as edges/symbols are pruned; the vocabulary is small, but gc is the
+        // natural rate-limited home for the sweep. Every referencing column must appear
+        // here — a missed column would null its strings out from under live rows. #224
+        // added `symbols.qualified_name_id` and `logical_symbols.qualified_name_id`
+        // (interned symbol qnames live in this same pool now); omitting them would delete a
+        // pool entry a live symbol points at and null its qname out — the exact footgun
+        // this comment warns about (regression test:
+        // gc_preserves_a_name_strings_entry_referenced_only_by_a_symbol).
         conn.execute(
             "
-            DELETE FROM main.edge_strings
+            DELETE FROM main.name_strings
             WHERE id NOT IN (
                 SELECT from_name_id FROM main.edges_data WHERE from_name_id IS NOT NULL
                 UNION SELECT to_name_id FROM main.edges_data
@@ -124,6 +129,10 @@ impl IndexDatabase {
                 UNION SELECT resolution_id FROM main.edges_data
                 UNION SELECT edge_kind_id FROM main.edges_data
                 UNION SELECT confidence_id FROM main.edges_data
+                UNION SELECT qualified_name_id FROM main.symbols
+                    WHERE qualified_name_id IS NOT NULL
+                UNION SELECT qualified_name_id FROM main.logical_symbols
+                    WHERE qualified_name_id IS NOT NULL
             )
             ",
             [],

--- a/crates/rag-rat-core/src/index/query_api/importance.rs
+++ b/crates/rag-rat-core/src/index/query_api/importance.rs
@@ -465,7 +465,7 @@ impl IndexDatabase {
             .query_row(
                 "SELECT s.id FROM symbols s
                  JOIN files ON files.id = s.file_id
-                 WHERE s.qualified_name = ?1
+                 WHERE s.qualified_name_id = (SELECT id FROM name_strings WHERE value = ?1)
                  ORDER BY s.id
                  LIMIT 1",
                 [qualified_name],

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -177,7 +177,7 @@ impl IndexDatabase {
             .query_row(
                 "SELECT files.path FROM symbols
                  JOIN files ON files.id = symbols.file_id
-                 WHERE symbols.qualified_name = ?1
+                 WHERE symbols.qualified_name_id = (SELECT id FROM name_strings WHERE value = ?1)
                  ORDER BY symbols.id
                  LIMIT 1",
                 [qualified_name],

--- a/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
@@ -482,9 +482,13 @@ fn important_symbols_retargets_an_in_corpus_contradiction() {
 
     let (edge_id, cs, ce, path) = call_edge(&db);
     let name_of = |id: i64| -> String {
-        conn.query_row("SELECT qualified_name FROM symbols WHERE id = ?1", params![id], |r| {
-            r.get(0)
-        })
+        conn.query_row(
+            "SELECT qn.value FROM symbols
+             LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
+             WHERE symbols.id = ?1",
+            params![id],
+            |r| r.get(0),
+        )
         .unwrap()
     };
     let target_sym: i64 = conn
@@ -553,9 +557,13 @@ fn upgrade_hydrates_target_from_compiler_resolution() {
     let target_qualified: String = db
         .storage
         .connection()
-        .query_row("SELECT qualified_name FROM symbols WHERE name = 'target' LIMIT 1", [], |r| {
-            r.get(0)
-        })
+        .query_row(
+            "SELECT qn.value FROM symbols
+             LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
+             WHERE symbols.name = 'target' LIMIT 1",
+            [],
+            |r| r.get(0),
+        )
         .unwrap();
     let (target_start, target_end): (i64, i64) = db
         .storage

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -163,13 +163,13 @@ impl IndexDatabase {
     pub(super) fn delete_staged_files_cascade(&self) -> anyhow::Result<()> {
         self.storage.execute_batch(
             "
-            INSERT OR IGNORE INTO main.edge_strings(value) VALUES ('unresolved');
+            INSERT OR IGNORE INTO main.name_strings(value) VALUES ('unresolved');
             UPDATE main.edges_data
             SET to_symbol_id = NULL,
                 target_start_line = NULL,
                 target_end_line = NULL,
                 resolution_id =
-                    (SELECT id FROM main.edge_strings WHERE value = 'unresolved')
+                    (SELECT id FROM main.name_strings WHERE value = 'unresolved')
             WHERE to_symbol_id IN (
                 SELECT symbols.id
                 FROM main.symbols

--- a/crates/rag-rat-core/src/index/schema/baseline.rs
+++ b/crates/rag-rat-core/src/index/schema/baseline.rs
@@ -98,7 +98,7 @@ pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
         -- resident, so decode is always possible). Stored IN the DB so a copied / P2P-streamed \
          index
         -- is self-contained. No FK from chunk_text into this table — gc sweeps versions with zero
-        -- referencing blobs (like the edge_strings pool).
+        -- referencing blobs (like the name_strings pool).
         CREATE TABLE IF NOT EXISTS chunk_text_dict(
             version INTEGER PRIMARY KEY,
             dict BLOB NOT NULL
@@ -109,7 +109,18 @@ pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
             file_id INTEGER NOT NULL,
             language TEXT NOT NULL,
             name TEXT NOT NULL,
-            qualified_name TEXT NOT NULL,
+            -- The qualified name is INTERNED into the shared `name_strings` pool (#224): edge
+            -- call-target names already store ~85% of symbol qnames, so an integer id into the \
+         pool
+            -- replaces the inline TEXT column + its 49 MB string B-tree (idx on qualified_name_id \
+         is
+            -- ~13 MB of 3-byte ids). NULLABLE on purpose: a forward-migrated DB ADDs the column
+            -- (which can't be NOT NULL on a populated table) before backfilling, so a \
+         freshly-built
+            -- DB must match that shape. Readers reconstruct the text via a JOIN on name_strings;
+            -- gc MUST count this as a referencing column (query_api/gc.rs) or it nulls live \
+         qnames.
+            qualified_name_id INTEGER,
             kind TEXT NOT NULL,
             start_byte INTEGER NOT NULL,
             end_byte INTEGER NOT NULL,
@@ -123,7 +134,11 @@ pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
             language TEXT NOT NULL,
             path TEXT NOT NULL,
             logical_name TEXT NOT NULL,
-            qualified_name TEXT NOT NULL,
+            -- Interned into `name_strings` (#224), same as symbols.qualified_name_id above. \
+         NULLABLE
+            -- for the same forward-migrate-then-backfill reason; gc counts it as a referencing
+            -- column.
+            qualified_name_id INTEGER,
             kind TEXT NOT NULL,
             variant_count INTEGER NOT NULL,
             group_reason TEXT NOT NULL
@@ -154,7 +169,7 @@ pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
         -- here once and `edges_data` stores integer ids. Deliberately NO foreign keys from
         -- `edges_data` into this table — gc prunes orphaned values, and an FK would force
         -- dictionary-before-edges delete ordering for no integrity gain.
-        CREATE TABLE IF NOT EXISTS edge_strings(
+        CREATE TABLE IF NOT EXISTS name_strings(
             id INTEGER PRIMARY KEY,
             value TEXT NOT NULL UNIQUE
         ) STRICT;
@@ -530,12 +545,14 @@ pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
         CREATE INDEX IF NOT EXISTS idx_files_language ON files(language);
         CREATE INDEX IF NOT EXISTS idx_chunks_file ON chunks(file_id);
         CREATE INDEX IF NOT EXISTS idx_symbols_name ON symbols(name);
-        CREATE INDEX IF NOT EXISTS idx_symbols_qualified_name ON symbols(qualified_name);
+        -- The qualified_name_id indexes are created AFTER this batch \
+         (interned_qualified_name_indexes)
+        -- because on a forward-migrate the `symbols`/`logical_symbols` tables may PRE-EXIST in the
+        -- pre-V028 shape (inline `qualified_name`, no `qualified_name_id`) — `CREATE TABLE IF NOT
+        -- EXISTS` above is then a no-op and the id column does not exist yet (V028 adds it). #224.
         CREATE INDEX IF NOT EXISTS idx_symbols_file ON symbols(file_id);
         CREATE INDEX IF NOT EXISTS idx_symbol_facts_kind_value
             ON symbol_facts(fact_kind, fact_value);
-        CREATE INDEX IF NOT EXISTS idx_logical_symbols_qualified_name
-            ON logical_symbols(qualified_name);
         CREATE INDEX IF NOT EXISTS idx_logical_symbol_members_symbol
             ON logical_symbol_members(symbol_id);
         CREATE INDEX IF NOT EXISTS idx_git_file_changes_path ON git_file_changes(path);
@@ -582,6 +599,29 @@ pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
     apply_repo_memory_call_paths(conn)?;
     apply_repo_memory_call_path_edges(conn)?;
     apply_graph_file_lookup_indexes(conn)?;
+    interned_qualified_name_indexes(conn)?;
+    Ok(())
+}
+
+/// Create the interned qualified-name indexes (#224), but ONLY when the `qualified_name_id` column
+/// exists. On a fresh DB the baseline's `CREATE TABLE symbols/logical_symbols` makes the column, so
+/// this fires immediately. On a forward-migrate the tables PRE-EXIST in the pre-V028 shape (inline
+/// `qualified_name`, no id column) — the `CREATE TABLE IF NOT EXISTS` was a no-op and the column is
+/// absent until V028 adds + backfills it, which is where V028 creates these same indexes. Guarding
+/// here keeps `apply_baseline` from referencing a not-yet-added column on an older DB.
+fn interned_qualified_name_indexes(conn: &Connection) -> rusqlite::Result<()> {
+    if column_exists(conn, "symbols", "qualified_name_id")? {
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_symbols_qualified_name_id
+                ON symbols(qualified_name_id);",
+        )?;
+    }
+    if column_exists(conn, "logical_symbols", "qualified_name_id")? {
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_logical_symbols_qualified_name_id
+                ON logical_symbols(qualified_name_id);",
+        )?;
+    }
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -38,18 +38,32 @@ pub(crate) fn migrate_edges(conn: &Connection) -> rusqlite::Result<()> {
     add_column_if_missing(conn, "edges", "to_name", "TEXT NOT NULL DEFAULT ''")?;
     apply_edge_source_target_spans(conn)?;
     apply_edge_evidence_and_resolution(conn)?;
+    // This runs inside `apply_baseline`, BEFORE the ladder, so the `symbols` shape depends on the
+    // DB's age: a fresh post-V028 baseline has the interned `qualified_name_id` (and the dropped
+    // `qualified_name`), while a pre-V020 legacy DB still has the inline `qualified_name` TEXT
+    // column (V028 hasn't run yet). SQLite compiles the whole statement, so referencing a missing
+    // column is a hard error even when zero rows match — pick the backfill source by which column
+    // exists (#224). On a fresh DB this `edges` is the empty view; the UPDATE is a no-op either
+    // way.
+    let symbol_qname_expr = if column_exists(conn, "symbols", "qualified_name")? {
+        "(SELECT qualified_name FROM symbols WHERE symbols.id = edges.{side}_symbol_id)"
+    } else {
+        "(SELECT value FROM name_strings WHERE name_strings.id =
+              (SELECT qualified_name_id FROM symbols WHERE symbols.id = edges.{side}_symbol_id))"
+    };
+    let from_expr = symbol_qname_expr.replace("{side}", "from");
+    let to_expr = symbol_qname_expr.replace("{side}", "to");
     conn.execute(
-        "
+        &format!(
+            "
         UPDATE edges
-        SET from_name = COALESCE(from_name, (
-                SELECT qualified_name FROM symbols WHERE symbols.id = edges.from_symbol_id
-            )),
+        SET from_name = COALESCE(from_name, {from_expr}),
             to_name = CASE
                 WHEN to_name != '' THEN to_name
-                ELSE COALESCE((SELECT qualified_name FROM symbols WHERE symbols.id = \
-         edges.to_symbol_id), '')
+                ELSE COALESCE({to_expr}, '')
             END
-        ",
+        "
+        ),
         [],
     )?;
     conn.execute("DELETE FROM edges WHERE to_name = ''", [])?;
@@ -396,6 +410,13 @@ pub(crate) fn apply_graph_file_lookup_indexes(conn: &Connection) -> rusqlite::Re
 }
 
 pub(crate) fn apply_logical_symbol_groups(conn: &Connection) -> rusqlite::Result<()> {
+    // V007 created `logical_symbols` with an inline `qualified_name TEXT` and a string index. On a
+    // fresh post-V028 baseline the table ALREADY exists with the interned `qualified_name_id`
+    // shape, so the `CREATE TABLE IF NOT EXISTS` is a no-op — but the old `ON
+    // logical_symbols(qualified_name)` index would reference a column that no longer exists and
+    // fail. Create the qualified-name index on whichever column the table has (#224); a
+    // pre-V028 DB gets the string index (V028 later swaps it for the id index), a fresh DB gets
+    // the id index directly.
     conn.execute_batch(
         "
         CREATE TABLE IF NOT EXISTS logical_symbols(
@@ -421,12 +442,21 @@ pub(crate) fn apply_logical_symbol_groups(conn: &Connection) -> rusqlite::Result
             FOREIGN KEY(symbol_id) REFERENCES symbols(id) ON DELETE CASCADE
         );
 
-        CREATE INDEX IF NOT EXISTS idx_logical_symbols_qualified_name
-            ON logical_symbols(qualified_name);
         CREATE INDEX IF NOT EXISTS idx_logical_symbol_members_symbol
             ON logical_symbol_members(symbol_id);
         ",
     )?;
+    if column_exists(conn, "logical_symbols", "qualified_name")? {
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_logical_symbols_qualified_name
+                ON logical_symbols(qualified_name);",
+        )?;
+    } else {
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_logical_symbols_qualified_name_id
+                ON logical_symbols(qualified_name_id);",
+        )?;
+    }
     Ok(())
 }
 
@@ -648,7 +678,7 @@ pub(crate) fn ensure_edges_data_indexes(conn: &Connection) -> rusqlite::Result<(
 ///
 /// The view reconstructs the historical column shape, so the entire read surface — graph
 /// traversal, impact, memory fingerprints, oracle compare, dev-inspect SQL — keeps working
-/// unchanged. All dictionary joins are LEFT JOINs against the `edge_strings` PRIMARY KEY, so the
+/// unchanged. All dictionary joins are LEFT JOINs against the `name_strings` PRIMARY KEY, so the
 /// planner drops the joins a query doesn't reference.
 ///
 /// The triggers make ad-hoc writes through the view work (tests, migrations, maintenance UPDATEs)
@@ -822,7 +852,7 @@ pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
                -- The raw dictionary ids, appended after the legacy shape: hot predicates that the
                -- planner cannot transform through the value joins (an OR-branch string equality
                -- picks a non-selective index otherwise — the query_warm regression) compare these
-               -- against a constant `(SELECT id FROM edge_strings WHERE value = ?)` instead.
+               -- against a constant `(SELECT id FROM name_strings WHERE value = ?)` instead.
                d.from_name_id,
                d.to_name_id,
                d.target_qualified_name_id,
@@ -831,13 +861,13 @@ pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
                d.confidence_id,
                d.resolution_id
         FROM edges_data d
-        LEFT JOIN edge_strings fn ON fn.id = d.from_name_id
-        LEFT JOIN edge_strings tn ON tn.id = d.to_name_id
-        LEFT JOIN edge_strings tqn ON tqn.id = d.target_qualified_name_id
-        LEFT JOIN edge_strings rh ON rh.id = d.receiver_hint_id
-        LEFT JOIN edge_strings res ON res.id = d.resolution_id
-        LEFT JOIN edge_strings ek ON ek.id = d.edge_kind_id
-        LEFT JOIN edge_strings conf ON conf.id = d.confidence_id
+        LEFT JOIN name_strings fn ON fn.id = d.from_name_id
+        LEFT JOIN name_strings tn ON tn.id = d.to_name_id
+        LEFT JOIN name_strings tqn ON tqn.id = d.target_qualified_name_id
+        LEFT JOIN name_strings rh ON rh.id = d.receiver_hint_id
+        LEFT JOIN name_strings res ON res.id = d.resolution_id
+        LEFT JOIN name_strings ek ON ek.id = d.edge_kind_id
+        LEFT JOIN name_strings conf ON conf.id = d.confidence_id
         -- #200: the internal dispatch FACT rows (`dispatch_construct`/`dispatch_handle`) are \
          inputs
         -- to `synthesize_dispatch_edges`, NOT real edges — the handle fact duplicates the
@@ -851,21 +881,21 @@ pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
          so the
         -- planner keeps the indexed-id predicates, not a value-join string compare.
         WHERE d.edge_kind_id NOT IN (
-            SELECT id FROM edge_strings WHERE value IN ('dispatch_construct', 'dispatch_handle')
+            SELECT id FROM name_strings WHERE value IN ('dispatch_construct', 'dispatch_handle')
         );
 
         -- Interning per column: `INSERT OR IGNORE` + `value NOT NULL` means a NULL string is
         -- silently skipped and its id subselect yields NULL — exactly the legacy nullability.
         -- COALESCE mirrors the legacy table's column DEFAULTs for inserts that omit them.
         CREATE TRIGGER IF NOT EXISTS edges_view_insert INSTEAD OF INSERT ON edges BEGIN
-            INSERT OR IGNORE INTO edge_strings(value) VALUES (NEW.from_name);
-            INSERT OR IGNORE INTO edge_strings(value) VALUES (NEW.to_name);
-            INSERT OR IGNORE INTO edge_strings(value) VALUES (NEW.target_qualified_name);
-            INSERT OR IGNORE INTO edge_strings(value) VALUES (NEW.receiver_hint);
-            INSERT OR IGNORE INTO edge_strings(value)
+            INSERT OR IGNORE INTO name_strings(value) VALUES (NEW.from_name);
+            INSERT OR IGNORE INTO name_strings(value) VALUES (NEW.to_name);
+            INSERT OR IGNORE INTO name_strings(value) VALUES (NEW.target_qualified_name);
+            INSERT OR IGNORE INTO name_strings(value) VALUES (NEW.receiver_hint);
+            INSERT OR IGNORE INTO name_strings(value)
                 VALUES (COALESCE(NEW.resolution, 'unresolved'));
-            INSERT OR IGNORE INTO edge_strings(value) VALUES (NEW.edge_kind);
-            INSERT OR IGNORE INTO edge_strings(value) VALUES (NEW.confidence);
+            INSERT OR IGNORE INTO name_strings(value) VALUES (NEW.edge_kind);
+            INSERT OR IGNORE INTO name_strings(value) VALUES (NEW.confidence);
             INSERT INTO edges_data(
                 id, source_file_id, from_symbol_id, to_symbol_id, from_name_id, to_name_id,
                 source_start_line, source_end_line, source_start_byte, source_end_byte,
@@ -876,37 +906,37 @@ pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
             )
             VALUES (
                 NEW.id, NEW.source_file_id, NEW.from_symbol_id, NEW.to_symbol_id,
-                (SELECT id FROM edge_strings WHERE value = NEW.from_name),
-                (SELECT id FROM edge_strings WHERE value = NEW.to_name),
+                (SELECT id FROM name_strings WHERE value = NEW.from_name),
+                (SELECT id FROM name_strings WHERE value = NEW.to_name),
                 COALESCE(NEW.source_start_line, 0), COALESCE(NEW.source_end_line, 0),
                 COALESCE(NEW.source_start_byte, 0), COALESCE(NEW.source_end_byte, 0),
                 NEW.target_start_line, NEW.target_end_line,
-                (SELECT id FROM edge_strings WHERE value = NEW.target_qualified_name),
+                (SELECT id FROM name_strings WHERE value = NEW.target_qualified_name),
                 NEW.evidence,
-                (SELECT id FROM edge_strings WHERE value = NEW.receiver_hint),
-                (SELECT id FROM edge_strings
+                (SELECT id FROM name_strings WHERE value = NEW.receiver_hint),
+                (SELECT id FROM name_strings
                  WHERE value = COALESCE(NEW.resolution, 'unresolved')),
                 NEW.callee_start_byte, NEW.callee_end_byte,
                 NEW.import_scope_start_byte, NEW.import_scope_end_byte, NEW.import_mod_id,
-                (SELECT id FROM edge_strings WHERE value = NEW.edge_kind),
-                (SELECT id FROM edge_strings WHERE value = NEW.confidence)
+                (SELECT id FROM name_strings WHERE value = NEW.edge_kind),
+                (SELECT id FROM name_strings WHERE value = NEW.confidence)
             );
         END;
 
         CREATE TRIGGER IF NOT EXISTS edges_view_update INSTEAD OF UPDATE ON edges BEGIN
-            INSERT OR IGNORE INTO edge_strings(value) VALUES (NEW.from_name);
-            INSERT OR IGNORE INTO edge_strings(value) VALUES (NEW.to_name);
-            INSERT OR IGNORE INTO edge_strings(value) VALUES (NEW.target_qualified_name);
-            INSERT OR IGNORE INTO edge_strings(value) VALUES (NEW.receiver_hint);
-            INSERT OR IGNORE INTO edge_strings(value) VALUES (NEW.resolution);
-            INSERT OR IGNORE INTO edge_strings(value) VALUES (NEW.edge_kind);
-            INSERT OR IGNORE INTO edge_strings(value) VALUES (NEW.confidence);
+            INSERT OR IGNORE INTO name_strings(value) VALUES (NEW.from_name);
+            INSERT OR IGNORE INTO name_strings(value) VALUES (NEW.to_name);
+            INSERT OR IGNORE INTO name_strings(value) VALUES (NEW.target_qualified_name);
+            INSERT OR IGNORE INTO name_strings(value) VALUES (NEW.receiver_hint);
+            INSERT OR IGNORE INTO name_strings(value) VALUES (NEW.resolution);
+            INSERT OR IGNORE INTO name_strings(value) VALUES (NEW.edge_kind);
+            INSERT OR IGNORE INTO name_strings(value) VALUES (NEW.confidence);
             UPDATE edges_data SET
                 source_file_id = NEW.source_file_id,
                 from_symbol_id = NEW.from_symbol_id,
                 to_symbol_id = NEW.to_symbol_id,
-                from_name_id = (SELECT id FROM edge_strings WHERE value = NEW.from_name),
-                to_name_id = (SELECT id FROM edge_strings WHERE value = NEW.to_name),
+                from_name_id = (SELECT id FROM name_strings WHERE value = NEW.from_name),
+                to_name_id = (SELECT id FROM name_strings WHERE value = NEW.to_name),
                 source_start_line = NEW.source_start_line,
                 source_end_line = NEW.source_end_line,
                 source_start_byte = NEW.source_start_byte,
@@ -914,17 +944,17 @@ pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
                 target_start_line = NEW.target_start_line,
                 target_end_line = NEW.target_end_line,
                 target_qualified_name_id =
-                    (SELECT id FROM edge_strings WHERE value = NEW.target_qualified_name),
+                    (SELECT id FROM name_strings WHERE value = NEW.target_qualified_name),
                 evidence = NEW.evidence,
-                receiver_hint_id = (SELECT id FROM edge_strings WHERE value = NEW.receiver_hint),
-                resolution_id = (SELECT id FROM edge_strings WHERE value = NEW.resolution),
+                receiver_hint_id = (SELECT id FROM name_strings WHERE value = NEW.receiver_hint),
+                resolution_id = (SELECT id FROM name_strings WHERE value = NEW.resolution),
                 callee_start_byte = NEW.callee_start_byte,
                 callee_end_byte = NEW.callee_end_byte,
                 import_scope_start_byte = NEW.import_scope_start_byte,
                 import_scope_end_byte = NEW.import_scope_end_byte,
                 import_mod_id = NEW.import_mod_id,
-                edge_kind_id = (SELECT id FROM edge_strings WHERE value = NEW.edge_kind),
-                confidence_id = (SELECT id FROM edge_strings WHERE value = NEW.confidence)
+                edge_kind_id = (SELECT id FROM name_strings WHERE value = NEW.edge_kind),
+                confidence_id = (SELECT id FROM name_strings WHERE value = NEW.confidence)
             WHERE id = OLD.id;
         END;
 
@@ -936,7 +966,7 @@ pub(crate) fn ensure_edges_view(conn: &Connection) -> rusqlite::Result<()> {
     Ok(())
 }
 
-/// V020 (#79): convert a legacy `edges` TABLE into `edge_strings` + `edges_data` and re-point
+/// V020 (#79): convert a legacy `edges` TABLE into `name_strings` + `edges_data` and re-point
 /// `edge_oracle`'s FK at `edges_data`. Idempotent: a DB already on the view shape skips the
 /// conversion entirely. The copy runs in ONE transaction (legacy table intact on a crash);
 /// `PRAGMA foreign_keys` toggles outside it (it is a no-op inside one).
@@ -953,19 +983,19 @@ pub(crate) fn apply_edge_string_interning(conn: &Connection) -> rusqlite::Result
         let result = (|| -> rusqlite::Result<()> {
             conn.execute_batch(
                 "
-                INSERT OR IGNORE INTO edge_strings(value)
+                INSERT OR IGNORE INTO name_strings(value)
                     SELECT DISTINCT from_name FROM main.edges WHERE from_name IS NOT NULL;
-                INSERT OR IGNORE INTO edge_strings(value) SELECT DISTINCT to_name FROM main.edges;
-                INSERT OR IGNORE INTO edge_strings(value)
+                INSERT OR IGNORE INTO name_strings(value) SELECT DISTINCT to_name FROM main.edges;
+                INSERT OR IGNORE INTO name_strings(value)
                     SELECT DISTINCT target_qualified_name FROM main.edges
                     WHERE target_qualified_name IS NOT NULL;
-                INSERT OR IGNORE INTO edge_strings(value)
+                INSERT OR IGNORE INTO name_strings(value)
                     SELECT DISTINCT receiver_hint FROM main.edges WHERE receiver_hint IS NOT NULL;
-                INSERT OR IGNORE INTO edge_strings(value)
+                INSERT OR IGNORE INTO name_strings(value)
                     SELECT DISTINCT resolution FROM main.edges;
-                INSERT OR IGNORE INTO edge_strings(value)
+                INSERT OR IGNORE INTO name_strings(value)
                     SELECT DISTINCT edge_kind FROM main.edges;
-                INSERT OR IGNORE INTO edge_strings(value)
+                INSERT OR IGNORE INTO name_strings(value)
                     SELECT DISTINCT confidence FROM main.edges;
                 INSERT INTO main.edges_data(
                     id, source_file_id, from_symbol_id, to_symbol_id, from_name_id, to_name_id,
@@ -975,18 +1005,18 @@ pub(crate) fn apply_edge_string_interning(conn: &Connection) -> rusqlite::Result
                     edge_kind_id, confidence_id
                 )
                 SELECT e.id, e.source_file_id, e.from_symbol_id, e.to_symbol_id,
-                       (SELECT id FROM edge_strings WHERE value = e.from_name),
-                       (SELECT id FROM edge_strings WHERE value = e.to_name),
+                       (SELECT id FROM name_strings WHERE value = e.from_name),
+                       (SELECT id FROM name_strings WHERE value = e.to_name),
                        e.source_start_line, e.source_end_line,
                        e.source_start_byte, e.source_end_byte,
                        e.target_start_line, e.target_end_line,
-                       (SELECT id FROM edge_strings WHERE value = e.target_qualified_name),
+                       (SELECT id FROM name_strings WHERE value = e.target_qualified_name),
                        e.evidence,
-                       (SELECT id FROM edge_strings WHERE value = e.receiver_hint),
-                       (SELECT id FROM edge_strings WHERE value = e.resolution),
+                       (SELECT id FROM name_strings WHERE value = e.receiver_hint),
+                       (SELECT id FROM name_strings WHERE value = e.resolution),
                        e.callee_start_byte, e.callee_end_byte,
-                       (SELECT id FROM edge_strings WHERE value = e.edge_kind),
-                       (SELECT id FROM edge_strings WHERE value = e.confidence)
+                       (SELECT id FROM name_strings WHERE value = e.edge_kind),
+                       (SELECT id FROM name_strings WHERE value = e.confidence)
                 FROM main.edges e;
                 DROP TABLE main.edges;
                 ",
@@ -1091,6 +1121,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_025_ID => Some(25),
             MIGRATION_026_ID => Some(26),
             MIGRATION_027_ID => Some(27),
+            MIGRATION_028_ID => Some(28),
             _ => None,
         })
         .max()
@@ -1127,6 +1158,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_025_ID
             | MIGRATION_026_ID
             | MIGRATION_027_ID
+            | MIGRATION_028_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1160,6 +1192,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_025_ID => migration.checksum != MIGRATION_025_CHECKSUM,
         MIGRATION_026_ID => migration.checksum != MIGRATION_026_CHECKSUM,
         MIGRATION_027_ID => migration.checksum != MIGRATION_027_CHECKSUM,
+        MIGRATION_028_ID => migration.checksum != MIGRATION_028_CHECKSUM,
         _ => false,
     }
 }
@@ -1246,6 +1279,68 @@ pub(crate) fn apply_drop_chunks_text(conn: &Connection) -> rusqlite::Result<()> 
             )
         })?;
     conn.execute("ALTER TABLE chunks DROP COLUMN text", [])?;
+    Ok(())
+}
+
+/// V028 (#224): intern `symbols.qualified_name` + `logical_symbols.qualified_name` into the shared
+/// `name_strings` pool (the pool `edges_data` already references; the `edge_strings → name_strings`
+/// rename rides this version bump and is performed in `provision_baseline`, which runs BEFORE this
+/// replay — so `name_strings` is guaranteed present here). Backfill-before-drop, like the V027
+/// chunk-text precedent, so the column drop is the last step rather than an irreversible one-shot.
+///
+/// Idempotent + guarded so a fresh-baseline DB (already `qualified_name_id`, no `qualified_name`)
+/// is a clean no-op and a re-run after a half-apply is safe:
+/// 1. ADD `qualified_name_id INTEGER` to both tables (guarded — NULLABLE because an `ADD COLUMN …
+///    NOT NULL` fails on a populated table, so the fresh baseline matches).
+/// 2. Backfill ONLY while the old `qualified_name` column still exists: insert the not-yet-present
+///    qnames (`INSERT OR IGNORE` — the ~85% already stored as edge-target names are skipped; the
+///    new ~102K get fresh ids, and plain-PK reuse of prior gc gaps is safe because gc only deletes
+///    orphans), then set `qualified_name_id` from the pool.
+/// 3. Create the id-keyed indexes; drop the old string indexes.
+/// 4. Drop the `qualified_name` column (guarded by `column_exists`).
+pub(crate) fn apply_intern_symbol_qualified_names(conn: &Connection) -> rusqlite::Result<()> {
+    add_column_if_missing(conn, "symbols", "qualified_name_id", "INTEGER")?;
+    add_column_if_missing(conn, "logical_symbols", "qualified_name_id", "INTEGER")?;
+    // Backfill reads the OLD text column; on a fresh-baseline DB it is already gone (and the tables
+    // are empty), so guard each table independently — one may have migrated and the other not on a
+    // re-run after a partial apply.
+    if column_exists(conn, "symbols", "qualified_name")? {
+        conn.execute_batch(
+            "
+            INSERT OR IGNORE INTO name_strings(value) SELECT qualified_name FROM symbols;
+            UPDATE symbols
+               SET qualified_name_id =
+                   (SELECT id FROM name_strings WHERE name_strings.value = symbols.qualified_name);
+            ",
+        )?;
+    }
+    if column_exists(conn, "logical_symbols", "qualified_name")? {
+        conn.execute_batch(
+            "
+            INSERT OR IGNORE INTO name_strings(value) SELECT qualified_name FROM logical_symbols;
+            UPDATE logical_symbols
+               SET qualified_name_id =
+                   (SELECT id FROM name_strings
+                    WHERE name_strings.value = logical_symbols.qualified_name);
+            ",
+        )?;
+    }
+    conn.execute_batch(
+        "
+        CREATE INDEX IF NOT EXISTS idx_symbols_qualified_name_id
+            ON symbols(qualified_name_id);
+        CREATE INDEX IF NOT EXISTS idx_logical_symbols_qualified_name_id
+            ON logical_symbols(qualified_name_id);
+        DROP INDEX IF EXISTS idx_symbols_qualified_name;
+        DROP INDEX IF EXISTS idx_logical_symbols_qualified_name;
+        ",
+    )?;
+    if column_exists(conn, "symbols", "qualified_name")? {
+        conn.execute("ALTER TABLE symbols DROP COLUMN qualified_name", [])?;
+    }
+    if column_exists(conn, "logical_symbols", "qualified_name")? {
+        conn.execute("ALTER TABLE logical_symbols DROP COLUMN qualified_name", [])?;
+    }
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use migrations::*;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 27;
+pub const LATEST_SCHEMA_VERSION: u32 = 28;
 const DIRTY_MIGRATION_ID: &str = "__dirty__";
 const MIGRATION_001_ID: &str = "001_sqlite_storage_baseline";
 const MIGRATION_001_CHECKSUM: &str = "sha256:rag-rat-sqlite-baseline-v1";
@@ -86,7 +86,7 @@ const MIGRATION_019_DESCRIPTION: &str = "Add logical_symbol_monikers + moniker p
                                          relocation reason on repo memory bindings (#70)";
 const MIGRATION_020_ID: &str = "020_edge_string_interning";
 const MIGRATION_020_CHECKSUM: &str = "sha256:rag-rat-edge-string-interning-v20";
-const MIGRATION_020_DESCRIPTION: &str = "Normalize repeated edge strings into the edge_strings \
+const MIGRATION_020_DESCRIPTION: &str = "Normalize repeated edge strings into the name_strings \
                                          dictionary behind the edges compatibility view (#79)";
 const MIGRATION_021_ID: &str = "021_symbol_scope_path";
 const MIGRATION_021_CHECKSUM: &str = "sha256:rag-rat-symbol-scope-path-v21";
@@ -118,6 +118,10 @@ const MIGRATION_027_ID: &str = "027_drop_chunks_text";
 const MIGRATION_027_CHECKSUM: &str = "sha256:rag-rat-drop-chunks-text-v27";
 const MIGRATION_027_DESCRIPTION: &str = "Build the compressed chunk_text store from chunks.text, \
                                          then drop the chunks.text column (#77 Phase 2)";
+const MIGRATION_028_ID: &str = "028_intern_symbol_qualified_names";
+const MIGRATION_028_CHECKSUM: &str = "sha256:rag-rat-intern-symbol-qualified-names-v28";
+const MIGRATION_028_DESCRIPTION: &str = "Intern symbols/logical_symbols qualified_name into the \
+                                         shared name_strings pool, then drop the columns (#224)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -150,7 +154,7 @@ pub struct SchemaStatus {
 /// (all `CREATE … IF NOT EXISTS`) wrapped in the dirty marker so a crash mid-baseline is
 /// detectable, then record 001. Shared by [`apply`] (fresh DB) and [`migrate_forward`] (existing DB
 /// behind by N). LOAD-BEARING for forward-only: a pre-interning (≤v19) DB lacks shared tables like
-/// `edge_strings`/`edges_data` that later migrations INSERT into, so the baseline must run BEFORE
+/// `name_strings`/`edges_data` that later migrations INSERT into, so the baseline must run BEFORE
 /// any forward step replays — exactly what the old full `apply` did before the ladder.
 fn provision_baseline(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(
@@ -168,6 +172,28 @@ fn provision_baseline(conn: &Connection) -> rusqlite::Result<()> {
          VALUES (?1, ?2, ?3, ?4)",
         params![DIRTY_MIGRATION_ID, now_ms(), "", "partial migration in progress"],
     )?;
+    // The string pool was `edge_strings` before the name-pool merge (#224, the V028 bump); it now
+    // also holds symbol qualified-names, so the current schema names it `name_strings`. On a
+    // pre-merge DB the POPULATED table is still `edge_strings` — rename it into place HERE, before
+    // `apply_baseline`'s `CREATE TABLE IF NOT EXISTS name_strings` (and the `ensure_edges_view` it
+    // calls), so we adopt the real table instead of creating an empty one beside it (which would
+    // orphan every edge's interned names). Runs before any migration replay, so V023's
+    // `ensure_edges_view` then sees `name_strings`. Fresh / already-merged DBs have no
+    // `edge_strings` → no-op. A pre-merge DB is `Older` (< V028), so it reaches this migrate path;
+    // a `Compatible` open skips migration and is already `name_strings`.
+    let pre_merge_pool: i64 = conn.query_row(
+        "SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'edge_strings'",
+        [],
+        |row| row.get(0),
+    )?;
+    let merged_pool: i64 = conn.query_row(
+        "SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'name_strings'",
+        [],
+        |row| row.get(0),
+    )?;
+    if pre_merge_pool > 0 && merged_pool == 0 {
+        conn.execute_batch("ALTER TABLE edge_strings RENAME TO name_strings;")?;
+    }
     let result = apply_baseline(conn);
     if let Err(err) = result {
         let _ = conn.execute("UPDATE schema_version SET description = ?2 WHERE id = ?1", params![
@@ -358,11 +384,17 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         description: MIGRATION_027_DESCRIPTION,
         apply: apply_drop_chunks_text,
     },
+    Migration {
+        id: MIGRATION_028_ID,
+        checksum: MIGRATION_028_CHECKSUM,
+        description: MIGRATION_028_DESCRIPTION,
+        apply: apply_intern_symbol_qualified_names,
+    },
 ];
 
 /// Apply ONLY the additive migrations not already recorded, in order — the forward-only path for an
 /// existing index that lags this binary. It first provisions the baseline idempotently (so a
-/// ≤v19 DB that predates a shared table like `edge_strings`/`edges_data` has it before a later
+/// ≤v19 DB that predates a shared table like `name_strings`/`edges_data` has it before a later
 /// migration INSERTs into it), then replays just the unapplied steps. Unlike [`apply`], it never
 /// re-runs an already-applied migration, so a data backfill like 005's resolution rewrite (an
 /// unconditional UPDATE) cannot clobber current values on a routine open. The caller guarantees a

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -77,7 +77,7 @@ fn rebuild_bootstraps_sqlite_schema_for_empty_target_root() {
     assert!(edge_columns.contains(&"receiver_hint".to_string()));
     assert!(edge_columns.contains(&"resolution".to_string()));
     let logical_columns = table_columns(&db, "logical_symbols");
-    assert!(logical_columns.contains(&"qualified_name".to_string()));
+    assert!(logical_columns.contains(&"qualified_name_id".to_string()));
     assert!(logical_columns.contains(&"variant_count".to_string()));
     let member_columns = table_columns(&db, "logical_symbol_members");
     assert!(member_columns.contains(&"symbol_id".to_string()));
@@ -227,8 +227,8 @@ fn forward_migration_does_not_rerun_already_applied_migrations() {
 #[test]
 fn forward_migration_reprovisions_missing_baseline_tables() {
     // Forward-only must run the idempotent baseline BEFORE replaying steps (#103 review): a ≤v19
-    // index predates shared tables (e.g. edge_strings) that a later migration INSERTs into.
-    // Simulate by dropping the edges view + edge_strings and EVERY post-019 ledger row (so the
+    // index predates shared tables (e.g. name_strings) that a later migration INSERTs into.
+    // Simulate by dropping the edges view + name_strings and EVERY post-019 ledger row (so the
     // applied set stays contiguous at v19 — not a gap that `known_version` would read as current);
     // open must reprovision the table and reach Compatible rather than fail on a missing-table
     // INSERT.
@@ -240,7 +240,7 @@ fn forward_migration_reprovisions_missing_baseline_tables() {
     let conn = rusqlite::Connection::open(&database).unwrap();
     conn.execute_batch(
         "DROP VIEW IF EXISTS edges;
-         DROP TABLE IF EXISTS edge_strings;
+         DROP TABLE IF EXISTS name_strings;
          DELETE FROM schema_version WHERE id >= '020';",
     )
     .unwrap();
@@ -258,13 +258,13 @@ fn forward_migration_reprovisions_missing_baseline_tables() {
     let conn = rusqlite::Connection::open(&database).unwrap();
     let edge_strings_exists: i64 = conn
         .query_row(
-            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'edge_strings'",
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'name_strings'",
             [],
             |row| row.get(0),
         )
         .unwrap();
     drop(conn);
-    assert_eq!(edge_strings_exists, 1, "baseline did not reprovision edge_strings before replay");
+    assert_eq!(edge_strings_exists, 1, "baseline did not reprovision name_strings before replay");
 
     fs::remove_dir_all(root).unwrap();
 }
@@ -528,14 +528,19 @@ fn full_rebuild_preserves_other_worktree_contexts() {
     .unwrap();
     db.storage
         .connection()
+        .execute("INSERT OR IGNORE INTO main.name_strings(value) VALUES ('other_context')", [])
+        .unwrap();
+    db.storage
+        .connection()
         .execute(
             "
                 INSERT INTO main.symbols(
-                    file_id, language, name, qualified_name, kind, start_byte, end_byte, \
+                    file_id, language, name, qualified_name_id, kind, start_byte, end_byte, \
              signature, docs
                 )
-                VALUES (?1, 'rust', 'other_context', 'other_context', 'function', 0, 12, NULL, \
-             NULL)
+                VALUES (?1, 'rust', 'other_context',
+                    (SELECT id FROM main.name_strings WHERE value = 'other_context'),
+                    'function', 0, 12, NULL, NULL)
                 ",
             [other_file_id],
         )
@@ -2181,7 +2186,7 @@ pub fn upsert(_id: i64) {}
     };
     let data_count = |kind: &str| -> i64 {
         conn.query_row(
-            "SELECT COUNT(*) FROM edges_data d JOIN edge_strings ek ON ek.id = d.edge_kind_id
+            "SELECT COUNT(*) FROM edges_data d JOIN name_strings ek ON ek.id = d.edge_kind_id
              WHERE ek.value = ?1",
             [kind],
             |r| r.get(0),
@@ -7997,7 +8002,7 @@ fn calls_edge_target(db: &IndexDatabase, path: &str) -> Option<i64> {
         .query_row(
             "SELECT d.to_symbol_id FROM edges_data d
              JOIN files f ON f.id = d.source_file_id
-             JOIN edge_strings ek ON ek.id = d.edge_kind_id
+             JOIN name_strings ek ON ek.id = d.edge_kind_id
              WHERE f.path = ?1 AND ek.value = 'calls_name'",
             [path],
             |row| row.get::<_, Option<i64>>(0),
@@ -10486,12 +10491,13 @@ fn open_under_a_held_write_lock_migrates_older_schema_without_deadlock() {
         let db = IndexDatabase::rebuild(&config).unwrap();
         db.storage
             .connection()
-            .execute("DELETE FROM schema_version WHERE id = '027_drop_chunks_text'", [])
+            .execute("DELETE FROM schema_version WHERE id = '028_intern_symbol_qualified_names'", [
+            ])
             .unwrap();
         assert_eq!(
             schema::status(db.storage.connection()).unwrap().state,
             schema::SchemaState::Older,
-            "removing the V027 ledger row makes the schema Older"
+            "removing the V028 ledger row makes the schema Older"
         );
     }
 
@@ -10516,7 +10522,7 @@ fn v022_fresh_apply_creates_packages_and_dedicated_import_scope_columns() {
     schema::apply(&conn).unwrap();
 
     assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 27);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 28);
     assert!(conn_table_exists(&conn, "packages"), "packages table is created on a fresh apply");
 
     let package_cols = conn_table_columns(&conn, "packages");
@@ -10589,6 +10595,7 @@ fn v022_forward_migrate_adds_artifacts_to_an_older_index() {
         DELETE FROM schema_version WHERE id = '025_chunk_text_compression_tables';
         DELETE FROM schema_version WHERE id = '026_contentless_chunk_fts';
         DELETE FROM schema_version WHERE id = '027_drop_chunks_text';
+        DELETE FROM schema_version WHERE id = '028_intern_symbol_qualified_names';
         ",
     )
     .unwrap();
@@ -10609,6 +10616,292 @@ fn v022_forward_migrate_adds_artifacts_to_an_older_index() {
     }
     // The view was rebuilt and surfaces the columns (a SELECT must not fail).
     conn.query_row("SELECT import_mod_id FROM edges LIMIT 1", [], |_| Ok(())).optional().unwrap();
+}
+
+/// True when an INDEX of this name exists (sqlite_master, type='index').
+fn conn_index_exists(conn: &rusqlite::Connection, index: &str) -> bool {
+    conn.query_row(
+        "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?1",
+        [index],
+        |_| Ok(()),
+    )
+    .optional()
+    .unwrap()
+    .is_some()
+}
+
+/// V028 fresh apply (#224): a brand-new index stores qualified names as `qualified_name_id`
+/// (interned into `name_strings`), NOT inline `qualified_name`; the id indexes exist and the old
+/// string indexes do not.
+#[test]
+fn v028_fresh_apply_interns_symbol_qualified_names() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+
+    for table in ["symbols", "logical_symbols"] {
+        let cols = conn_table_columns(&conn, table);
+        assert!(
+            cols.contains(&"qualified_name_id".to_string()),
+            "{table} has the interned id column"
+        );
+        assert!(
+            !cols.contains(&"qualified_name".to_string()),
+            "{table} no longer has the inline text column"
+        );
+    }
+    assert!(conn_index_exists(&conn, "idx_symbols_qualified_name_id"));
+    assert!(conn_index_exists(&conn, "idx_logical_symbols_qualified_name_id"));
+    assert!(!conn_index_exists(&conn, "idx_symbols_qualified_name"));
+    assert!(!conn_index_exists(&conn, "idx_logical_symbols_qualified_name"));
+    // The pool is named `name_strings` (the #224 rename rode this version bump); `edge_strings` is
+    // gone.
+    assert!(conn_table_exists(&conn, "name_strings"));
+    assert!(!conn_table_exists(&conn, "edge_strings"));
+}
+
+/// V028 forward-migrate (#224): simulate a pre-V028 index — re-add the inline `qualified_name` TEXT
+/// column + the old string index, rename the pool back to `edge_strings`, and drop the V028 ledger
+/// row — then re-apply. The forward path must: rename `edge_strings → name_strings`, intern every
+/// symbol/logical qname into the pool, set `qualified_name_id`, drop the inline column, and leave a
+/// forward-migrated row reconstructable to the SAME qualified name as before.
+#[test]
+fn v028_forward_migrate_interns_and_drops_the_inline_column() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+
+    // Seed a file + a symbol + a logical symbol in the CURRENT (interned) shape.
+    conn.execute(
+        "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
+         VALUES ('a.rs', 'rust', 'source', 'h', 0, 0)",
+        [],
+    )
+    .unwrap();
+    let file_id = conn.last_insert_rowid();
+    let symbol_qn = "a.rs::do_thing";
+    let logical_qn = "a.rs::LogicalThing";
+    for qn in [symbol_qn, logical_qn] {
+        conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)", [qn]).unwrap();
+    }
+    conn.execute(
+        "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, start_byte, \
+         end_byte)
+         VALUES (?1, 'rust', 'do_thing', (SELECT id FROM name_strings WHERE value = ?2),
+                 'function', 0, 10)",
+        params![file_id, symbol_qn],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO logical_symbols(id, language, path, logical_name, qualified_name_id, kind,
+                                     variant_count, group_reason)
+         VALUES (7, 'rust', 'a.rs', 'LogicalThing',
+                 (SELECT id FROM name_strings WHERE value = ?1), 'struct', 1, 'single')",
+        params![logical_qn],
+    )
+    .unwrap();
+
+    // --- Regress the schema to the pre-V028 shape ---
+    // 1. Re-add the inline `qualified_name` TEXT column + restore its values from the pool, then
+    //    drop the interned id column + its index.
+    conn.execute_batch(
+        "
+        ALTER TABLE symbols ADD COLUMN qualified_name TEXT;
+        UPDATE symbols SET qualified_name =
+            (SELECT value FROM name_strings WHERE name_strings.id = symbols.qualified_name_id);
+        DROP INDEX IF EXISTS idx_symbols_qualified_name_id;
+        ALTER TABLE symbols DROP COLUMN qualified_name_id;
+        CREATE INDEX idx_symbols_qualified_name ON symbols(qualified_name);
+
+        ALTER TABLE logical_symbols ADD COLUMN qualified_name TEXT;
+        UPDATE logical_symbols SET qualified_name =
+            (SELECT value FROM name_strings WHERE name_strings.id =
+                logical_symbols.qualified_name_id);
+        DROP INDEX IF EXISTS idx_logical_symbols_qualified_name_id;
+        ALTER TABLE logical_symbols DROP COLUMN qualified_name_id;
+        CREATE INDEX idx_logical_symbols_qualified_name ON logical_symbols(qualified_name);
+        ",
+    )
+    .unwrap();
+    // 2. Rename the pool back to the pre-merge name `edge_strings` (the rename guard in
+    //    provision_baseline must adopt it). The view references name_strings, so drop it first; the
+    //    re-apply rebuilds it.
+    conn.execute_batch(
+        "
+        DROP VIEW IF EXISTS edges;
+        DROP TRIGGER IF EXISTS edges_view_insert;
+        DROP TRIGGER IF EXISTS edges_view_update;
+        DROP TRIGGER IF EXISTS edges_view_delete;
+        ALTER TABLE name_strings RENAME TO edge_strings;
+        ",
+    )
+    .unwrap();
+    // 3. Drop the V028 ledger row so the schema reads Older and the migration replays.
+    conn.execute("DELETE FROM schema_version WHERE id = '028_intern_symbol_qualified_names'", [])
+        .unwrap();
+    assert_eq!(
+        schema::status(&conn).unwrap().state,
+        schema::SchemaState::Older,
+        "removing the V028 ledger row makes the pre-V028 shape Older"
+    );
+
+    // --- Forward-migrate ---
+    schema::apply(&conn).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
+
+    // The rename happened and the inline columns are gone.
+    assert!(conn_table_exists(&conn, "name_strings"), "edge_strings was renamed to name_strings");
+    assert!(!conn_table_exists(&conn, "edge_strings"));
+    for table in ["symbols", "logical_symbols"] {
+        let cols = conn_table_columns(&conn, table);
+        assert!(cols.contains(&"qualified_name_id".to_string()), "{table} has qualified_name_id");
+        assert!(!cols.contains(&"qualified_name".to_string()), "{table} dropped the inline column");
+    }
+    assert!(conn_index_exists(&conn, "idx_symbols_qualified_name_id"));
+    assert!(conn_index_exists(&conn, "idx_logical_symbols_qualified_name_id"));
+    assert!(!conn_index_exists(&conn, "idx_symbols_qualified_name"));
+    assert!(!conn_index_exists(&conn, "idx_logical_symbols_qualified_name"));
+
+    // The ids backfilled correctly: each row reconstructs to its ORIGINAL qualified name via the
+    // join, and a round-trip lookup returns it.
+    let symbol_reconstructed: String = conn
+        .query_row(
+            "SELECT qn.value FROM symbols
+             LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
+             WHERE symbols.name = 'do_thing'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(symbol_reconstructed, symbol_qn, "symbol qname is preserved through the migration");
+    let logical_reconstructed: String = conn
+        .query_row(
+            "SELECT qn.value FROM logical_symbols
+             LEFT JOIN name_strings qn ON qn.id = logical_symbols.qualified_name_id
+             WHERE logical_symbols.id = 7",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(logical_reconstructed, logical_qn, "logical qname is preserved");
+
+    // Round-trip through the production read paths: exact lookup (lookup_symbol_path) + logical
+    // read.
+    let hit = crate::query::symbol::lookup_candidates(
+        &conn,
+        &crate::query::symbol::SymbolSelector {
+            logical_symbol_id: None,
+            symbol_id: None,
+            symbol_path: Some(symbol_qn.to_string()),
+            symbol: None,
+            language: None,
+            allow_ambiguous: true,
+            limit: 10,
+        },
+        false,
+    )
+    .unwrap();
+    assert_eq!(
+        hit.candidates.first().map(|c| c.qualified_name.as_str()),
+        Some(symbol_qn),
+        "lookup_symbol_path resolves the interned qualified name"
+    );
+    let logical = crate::query::symbol::lookup_logical_by_id(&conn, 7).unwrap().unwrap();
+    assert_eq!(logical.qualified_name, logical_qn, "logical read reconstructs the qname");
+}
+
+/// GC must-fix (#224, the highest-severity gate): the orphan-sweep prunes `name_strings` entries
+/// nothing references. After the merge, symbols/logical_symbols `qualified_name_id` are referencing
+/// columns too — so a pool entry referenced ONLY by a symbol (no edge) must SURVIVE gc, or gc nulls
+/// the symbol's qname out.
+#[test]
+fn gc_preserves_a_name_strings_entry_referenced_only_by_a_symbol() {
+    let (root, config) = markdown_config("# Note\nplaceholder\n");
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+    // `files`/`symbols` are per-connection scoped TEMP VIEWS after open/rebuild; write the base
+    // tables in `main`. Scope the file to the live commit so gc keeps it.
+    conn.execute(
+        "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms,
+                                commit_sha, worktree_id)
+         VALUES ('only.rs', 'rust', 'source', 'h', 0, 0, ?1, ?2)",
+        params![db.active_commit_sha, db.active_worktree_id],
+    )
+    .unwrap();
+    let file_id = conn.last_insert_rowid();
+    // A symbol whose qname is interned but referenced by NO edge.
+    let symbol_only_qn = "only.rs::orphan_if_gc_is_wrong";
+    conn.execute("INSERT OR IGNORE INTO main.name_strings(value) VALUES (?1)", [symbol_only_qn])
+        .unwrap();
+    conn.execute(
+        "INSERT INTO main.symbols(file_id, language, name, qualified_name_id, kind, start_byte,
+                                  end_byte)
+         VALUES (?1, 'rust', 'orphan_if_gc_is_wrong',
+                 (SELECT id FROM main.name_strings WHERE value = ?2), 'function', 0, 10)",
+        params![file_id, symbol_only_qn],
+    )
+    .unwrap();
+
+    // Run the pool-sweep through gc with the symbol's commit kept live.
+    db.prune_to_live(
+        std::slice::from_ref(&db.active_commit_sha),
+        std::slice::from_ref(&db.active_worktree_id),
+    )
+    .unwrap();
+
+    let conn = db.storage.connection();
+    let surviving: i64 = conn
+        .query_row("SELECT COUNT(*) FROM name_strings WHERE value = ?1", [symbol_only_qn], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(surviving, 1, "gc must NOT prune a pool entry a live symbol references");
+    // And the symbol's qname is still reconstructable (not nulled).
+    let reconstructed: Option<String> = conn
+        .query_row(
+            "SELECT qn.value FROM symbols
+             LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
+             WHERE symbols.name = 'orphan_if_gc_is_wrong'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(reconstructed.as_deref(), Some(symbol_only_qn));
+    drop(db);
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// Id-width guard (#224): the merged pool's `max(id)` must stay well under the 3→4-byte SQLite
+/// serial-type cliff (8,388,608) — a wider id would be a real edges-side regression (every edge
+/// carries two name-ids). A representative self-index of this repo is far below it; assert a large
+/// margin so a future blow-up surfaces here.
+#[test]
+fn name_strings_max_id_stays_in_the_three_byte_range() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    // Seed a representative spread of interned names across edges + symbols.
+    conn.execute(
+        "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
+         VALUES ('a.rs', 'rust', 'source', 'h', 0, 0)",
+        [],
+    )
+    .unwrap();
+    for i in 0..1000 {
+        let qn = format!("a.rs::sym_{i}");
+        conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)", [&qn]).unwrap();
+        conn.execute(
+            "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, start_byte,
+                                 end_byte)
+             VALUES (1, 'rust', ?1, (SELECT id FROM name_strings WHERE value = ?2), 'function', 0, \
+             1)",
+            params![format!("sym_{i}"), qn],
+        )
+        .unwrap();
+    }
+    let max_id: i64 =
+        conn.query_row("SELECT COALESCE(MAX(id), 0) FROM name_strings", [], |r| r.get(0)).unwrap();
+    assert!(
+        max_id < 8_388_608,
+        "name_strings max id {max_id} must stay under the 3→4-byte serial-type cliff"
+    );
 }
 
 #[test]

--- a/crates/rag-rat-core/src/query/graph/predicates.rs
+++ b/crates/rag-rat-core/src/query/graph/predicates.rs
@@ -1,5 +1,14 @@
 use super::*;
 
+// #224 ALIAS CONTRACT: symbol qualified-names are interned into `name_strings`, so these predicate
+// fragments reference the joined pool value `from_qn.value` / `to_qn.value` (NOT a
+// `from_symbols.qualified_name` column, which no longer exists). EVERY query that splices a
+// fragment from this module MUST also provide the matching `LEFT JOIN name_strings from_qn ON
+// from_qn.id = from_symbols.qualified_name_id` (and/or `to_qn`) for the alias it uses — `reverse_*`
+// use `to_qn`, `forward_*` use `from_qn`. The interned-id arms (`edges.to_name_id = (SELECT id FROM
+// name_strings WHERE value = ?3)`) are an edge-side pool lookup and are independent of these symbol
+// joins.
+
 pub(crate) fn validate_edge_kinds(edge_kinds: &[String]) -> anyhow::Result<()> {
     for edge_kind in edge_kinds {
         if !OPTIONAL_EDGE_KINDS.contains(&edge_kind.as_str()) {
@@ -60,31 +69,31 @@ pub(crate) fn reverse_predicate(mode: GraphResolutionMode, logical: bool) -> &'s
                     WHERE logical_symbol_id = ?8
                  )
                  OR to_symbols.name = ?3
-                 OR to_symbols.qualified_name = ?1
-                 OR to_symbols.qualified_name LIKE ?2
+                 OR to_qn.value = ?1
+                 OR to_qn.value LIKE ?2
                  OR edges.target_qualified_name = ?1
                  OR edges.target_qualified_name LIKE ?2
                  OR (?4 = 'true' AND edges.to_name_id =
-                        (SELECT id FROM edge_strings WHERE value = ?3))",
+                        (SELECT id FROM name_strings WHERE value = ?3))",
         };
     }
     match mode {
         GraphResolutionMode::Exact =>
             "edges.to_symbol_id IS NOT NULL
-             AND (edges.to_symbol_id = ?6 OR to_symbols.qualified_name = ?1)",
+             AND (edges.to_symbol_id = ?6 OR to_qn.value = ?1)",
         GraphResolutionMode::Syntactic =>
             "(edges.to_symbol_id = ?6
-              OR to_symbols.qualified_name = ?1
+              OR to_qn.value = ?1
               OR (?7 = 'true' AND to_symbols.name = ?3)
               OR edges.target_qualified_name = ?1)",
         GraphResolutionMode::Fuzzy =>
             "to_symbols.name = ?3
-             OR to_symbols.qualified_name = ?1
-             OR to_symbols.qualified_name LIKE ?2
+             OR to_qn.value = ?1
+             OR to_qn.value LIKE ?2
              OR edges.target_qualified_name = ?1
              OR edges.target_qualified_name LIKE ?2
              OR (?4 = 'true' AND edges.to_name_id =
-                    (SELECT id FROM edge_strings WHERE value = ?3))",
+                    (SELECT id FROM name_strings WHERE value = ?3))",
     }
 }
 pub(crate) fn reverse_tier(mode: GraphResolutionMode) -> &'static str {
@@ -101,7 +110,7 @@ pub(crate) fn reverse_tier(mode: GraphResolutionMode) -> &'static str {
                 WHEN edges.to_symbol_id IS NOT NULL THEN 0
                 WHEN edges.target_qualified_name = ?1 OR edges.target_qualified_name LIKE ?2 THEN 1
                 WHEN ?4 = 'true' AND edges.to_name_id =
-                    (SELECT id FROM edge_strings WHERE value = ?3) THEN 2
+                    (SELECT id FROM name_strings WHERE value = ?3) THEN 2
                 ELSE 4
              END",
     }
@@ -130,8 +139,8 @@ pub(crate) fn forward_source_predicate(mode: GraphResolutionMode, logical: bool)
                     WHERE logical_symbol_id = ?8
                  )
                  OR from_symbols.name = ?3
-                 OR from_symbols.qualified_name = ?1
-                 OR from_symbols.qualified_name LIKE ?2
+                 OR from_qn.value = ?1
+                 OR from_qn.value LIKE ?2
                  OR edges.from_name = ?1
                  OR edges.from_name LIKE ?2",
         };
@@ -139,16 +148,16 @@ pub(crate) fn forward_source_predicate(mode: GraphResolutionMode, logical: bool)
     match mode {
         GraphResolutionMode::Exact =>
             "from_symbols.id IS NOT NULL
-             AND (from_symbols.id = ?6 OR from_symbols.qualified_name = ?1)",
+             AND (from_symbols.id = ?6 OR from_qn.value = ?1)",
         GraphResolutionMode::Syntactic =>
             "from_symbols.id = ?6
-             OR from_symbols.qualified_name = ?1
+             OR from_qn.value = ?1
              OR (?7 = 'true' AND from_symbols.name = ?3)
              OR edges.from_name = ?1",
         GraphResolutionMode::Fuzzy =>
             "from_symbols.name = ?3
-             OR from_symbols.qualified_name = ?1
-             OR from_symbols.qualified_name LIKE ?2
+             OR from_qn.value = ?1
+             OR from_qn.value LIKE ?2
              OR edges.from_name = ?1
              OR edges.from_name LIKE ?2",
     }

--- a/crates/rag-rat-core/src/query/graph/traverse.rs
+++ b/crates/rag-rat-core/src/query/graph/traverse.rs
@@ -25,8 +25,8 @@ pub(crate) fn traverse_with_options(
         let tier = reverse_tier(mode);
         format!(
             "
-            SELECT COALESCE(from_symbols.qualified_name, edges.from_name) AS from_symbol,
-                   COALESCE(to_symbols.qualified_name, edges.to_name) AS to_symbol,
+            SELECT COALESCE(from_qn.value, edges.from_name) AS from_symbol,
+                   COALESCE(to_qn.value, edges.to_name) AS to_symbol,
                    edges.id AS edge_id,
                    edges.edge_kind AS edge_kind,
                    edges.confidence AS confidence,
@@ -45,6 +45,8 @@ pub(crate) fn traverse_with_options(
             JOIN files source_files ON source_files.id = edges.source_file_id
             LEFT JOIN symbols from_symbols ON from_symbols.id = edges.from_symbol_id
             LEFT JOIN symbols to_symbols ON to_symbols.id = edges.to_symbol_id
+            LEFT JOIN name_strings from_qn ON from_qn.id = from_symbols.qualified_name_id
+            LEFT JOIN name_strings to_qn ON to_qn.id = to_symbols.qualified_name_id
             WHERE edges.edge_kind IN ({quoted})
               AND ({predicate})
             ORDER BY match_tier,
@@ -65,8 +67,8 @@ pub(crate) fn traverse_with_options(
         let visibility_filter = forward_visibility_filter(options);
         format!(
             "
-            SELECT COALESCE(from_symbols.qualified_name, edges.from_name) AS from_symbol,
-                   COALESCE(to_symbols.qualified_name, edges.to_name) AS to_symbol,
+            SELECT COALESCE(from_qn.value, edges.from_name) AS from_symbol,
+                   COALESCE(to_qn.value, edges.to_name) AS to_symbol,
                    edges.id AS edge_id,
                    edges.edge_kind AS edge_kind,
                    edges.confidence AS confidence,
@@ -85,6 +87,8 @@ pub(crate) fn traverse_with_options(
             JOIN files source_files ON source_files.id = edges.source_file_id
             LEFT JOIN symbols from_symbols ON from_symbols.id = edges.from_symbol_id
             LEFT JOIN symbols to_symbols ON to_symbols.id = edges.to_symbol_id
+            LEFT JOIN name_strings from_qn ON from_qn.id = from_symbols.qualified_name_id
+            LEFT JOIN name_strings to_qn ON to_qn.id = to_symbols.qualified_name_id
             WHERE edges.edge_kind IN ({quoted})
               AND ({predicate})
               AND ({target_filter})
@@ -204,6 +208,7 @@ pub(crate) fn traversal_summary(
                 SUM(CASE WHEN edges.to_symbol_id IS NULL THEN 1 ELSE 0 END)
             FROM edges
             LEFT JOIN symbols to_symbols ON to_symbols.id = edges.to_symbol_id
+            LEFT JOIN name_strings to_qn ON to_qn.id = to_symbols.qualified_name_id
             WHERE edges.edge_kind IN ({quoted})
               AND ({predicate})
             "
@@ -223,6 +228,7 @@ pub(crate) fn traversal_summary(
                 SUM(CASE WHEN edges.to_symbol_id IS NULL THEN 1 ELSE 0 END)
             FROM edges
             LEFT JOIN symbols from_symbols ON from_symbols.id = edges.from_symbol_id
+            LEFT JOIN name_strings from_qn ON from_qn.id = from_symbols.qualified_name_id
             WHERE edges.edge_kind IN ({quoted})
               AND ({predicate})
               AND ({target_filter})
@@ -378,13 +384,14 @@ pub(crate) fn hidden_unresolved_candidate_count(
             SELECT COUNT(*)
             FROM edges
             LEFT JOIN symbols to_symbols ON to_symbols.id = edges.to_symbol_id
+            LEFT JOIN name_strings to_qn ON to_qn.id = to_symbols.qualified_name_id
             WHERE edges.edge_kind IN ({quoted})
               AND edges.to_symbol_id IS NULL
               AND NOT ({predicate})
               AND (
                 edges.target_qualified_name = ?1
                 OR edges.target_qualified_name LIKE ?2
-                OR edges.to_name_id = (SELECT id FROM edge_strings WHERE value = ?3)
+                OR edges.to_name_id = (SELECT id FROM name_strings WHERE value = ?3)
               )
             "
         )
@@ -397,6 +404,7 @@ pub(crate) fn hidden_unresolved_candidate_count(
             SELECT COUNT(*)
             FROM edges
             LEFT JOIN symbols from_symbols ON from_symbols.id = edges.from_symbol_id
+            LEFT JOIN name_strings from_qn ON from_qn.id = from_symbols.qualified_name_id
             WHERE edges.edge_kind IN ({quoted})
               AND ({source_predicate})
               AND edges.to_symbol_id IS NULL

--- a/crates/rag-rat-core/src/query/graph_meta.rs
+++ b/crates/rag-rat-core/src/query/graph_meta.rs
@@ -204,12 +204,13 @@ fn primary_symbol(conn: &Connection, chunk_id: i64) -> anyhow::Result<Option<Pri
     Ok(conn
         .query_row(
             "
-            SELECT symbols.id, symbols.name, symbols.qualified_name, symbols.kind, files.path
+            SELECT symbols.id, symbols.name, qn.value, symbols.kind, files.path
             FROM chunks
             JOIN symbols ON symbols.file_id = chunks.file_id
              AND symbols.start_byte < chunks.end_byte
              AND symbols.end_byte > chunks.start_byte
             JOIN files ON files.id = symbols.file_id
+            LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
             WHERE chunks.id = ?1
             ORDER BY
               CASE symbols.kind
@@ -253,7 +254,7 @@ fn count_callers(conn: &Connection, symbol: &PrimarySymbol) -> anyhow::Result<u6
         FROM edges
         WHERE edge_kind IN ('calls_name', 'constructs', 'uses_macro')
           AND (to_symbol_id = ?1 OR (to_symbol_id IS NULL AND to_name_id = (SELECT id FROM \
-             edge_strings WHERE value = ?2)))
+             name_strings WHERE value = ?2)))
         ",
         )?
         .query_row(params![symbol.id, symbol.name], |row| row.get::<_, i64>(0))?;
@@ -342,7 +343,7 @@ fn callers(
         "
         SELECT DISTINCT
                source_files.path,
-               COALESCE(source_symbols.qualified_name, edges.from_name, source_files.path),
+               COALESCE(source_qn.value, edges.from_name, source_files.path),
                COALESCE(NULLIF(edges.source_start_line, 0), source_chunks.start_line, 1),
                COALESCE(NULLIF(edges.source_end_line, 0), NULLIF(edges.source_start_line, 0), \
          source_chunks.start_line, 1),
@@ -351,12 +352,13 @@ fn callers(
         FROM edges
         JOIN files source_files ON source_files.id = edges.source_file_id
         LEFT JOIN symbols source_symbols ON source_symbols.id = edges.from_symbol_id
+        LEFT JOIN name_strings source_qn ON source_qn.id = source_symbols.qualified_name_id
         LEFT JOIN chunks source_chunks ON source_chunks.file_id = edges.source_file_id
           AND source_symbols.start_byte >= source_chunks.start_byte
           AND source_symbols.start_byte < source_chunks.end_byte
         WHERE edges.edge_kind IN ('calls_name', 'constructs', 'uses_macro')
           AND (edges.to_symbol_id = ?1 OR (edges.to_symbol_id IS NULL AND edges.to_name_id = \
-         (SELECT id FROM edge_strings WHERE value = ?2)))
+         (SELECT id FROM name_strings WHERE value = ?2)))
         ORDER BY
           CASE edges.confidence
             WHEN 'Exact' THEN 0
@@ -402,7 +404,7 @@ fn callees(conn: &Connection, symbol_id: i64, limit: u32) -> anyhow::Result<Vec<
         SELECT DISTINCT
                edges.to_name,
                target_files.path,
-               target_symbols.qualified_name,
+               target_qn.value,
                COALESCE(edges.target_start_line, target_chunks.start_line),
                source_files.path,
                COALESCE(NULLIF(edges.source_start_line, 0), source_chunks.start_line, 1),
@@ -413,6 +415,7 @@ fn callees(conn: &Connection, symbol_id: i64, limit: u32) -> anyhow::Result<Vec<
         FROM edges
         JOIN files source_files ON source_files.id = edges.source_file_id
         LEFT JOIN symbols target_symbols ON target_symbols.id = edges.to_symbol_id
+        LEFT JOIN name_strings target_qn ON target_qn.id = target_symbols.qualified_name_id
         LEFT JOIN files target_files ON target_files.id = target_symbols.file_id
         LEFT JOIN chunks target_chunks ON target_chunks.file_id = target_symbols.file_id
           AND target_symbols.start_byte >= target_chunks.start_byte

--- a/crates/rag-rat-core/src/query/grep_augment.rs
+++ b/crates/rag-rat-core/src/query/grep_augment.rs
@@ -549,11 +549,13 @@ mod tests {
             [],
         )
         .unwrap();
+        conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES ('a::foo')", []).unwrap();
         for _ in 0..3 {
             conn.execute(
-                "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte,
+                "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, start_byte,
                                      end_byte, signature, docs)
-                 VALUES (1, 'rust', 'foo', 'a::foo', 'function', 0, 10, 'fn foo()', NULL)",
+                 VALUES (1, 'rust', 'foo', (SELECT id FROM name_strings WHERE value = 'a::foo'),
+                         'function', 0, 10, 'fn foo()', NULL)",
                 [],
             )
             .unwrap();
@@ -578,11 +580,15 @@ mod tests {
             [],
         )
         .unwrap();
+        conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES ('watch::watcher_main')", [
+        ])
+        .unwrap();
         conn.execute(
-            "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte,
+            "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, start_byte,
                                  end_byte, signature, docs)
-             VALUES (1, 'rust', 'watcher_main', 'watch::watcher_main', 'function', 0, 100,
-                     'fn watcher_main(config: Config)', NULL)",
+             VALUES (1, 'rust', 'watcher_main',
+                     (SELECT id FROM name_strings WHERE value = 'watch::watcher_main'),
+                     'function', 0, 100, 'fn watcher_main(config: Config)', NULL)",
             [],
         )
         .unwrap();

--- a/crates/rag-rat-core/src/query/impact/items.rs
+++ b/crates/rag-rat-core/src/query/impact/items.rs
@@ -15,7 +15,7 @@ pub(crate) fn import_export_items(
         FROM edges
         JOIN files ON files.id = edges.source_file_id
         WHERE edges.edge_kind IN ('imports', 'exports')
-          AND (edges.to_symbol_id = ?1 OR edges.to_name_id = (SELECT id FROM edge_strings WHERE \
+          AND (edges.to_symbol_id = ?1 OR edges.to_name_id = (SELECT id FROM name_strings WHERE \
          value = ?2))
         ORDER BY files.kind, files.path, edges.edge_kind
         LIMIT ?3
@@ -151,16 +151,17 @@ pub(crate) fn section_like_items(
     let sql = format!(
         "
         SELECT files.path, files.language, files.kind,
-               MAX(CASE WHEN symbols.name LIKE ?1 OR symbols.qualified_name LIKE ?1
-                        THEN symbols.qualified_name END) AS matched_symbol,
+               MAX(CASE WHEN symbols.name LIKE ?1 OR qn.value LIKE ?1
+                        THEN qn.value END) AS matched_symbol,
                MAX(CASE WHEN files.path LIKE ?1 THEN 1 ELSE 0 END) AS path_match
         FROM files
         LEFT JOIN symbols ON symbols.file_id = files.id
+        LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
         WHERE ({filter})
           AND (
               files.path LIKE ?1
               OR symbols.name LIKE ?1
-              OR symbols.qualified_name LIKE ?1
+              OR qn.value LIKE ?1
               {chunk_clause}
           )
         GROUP BY files.path, files.language, files.kind

--- a/crates/rag-rat-core/src/query/impact/mod.rs
+++ b/crates/rag-rat-core/src/query/impact/mod.rs
@@ -473,13 +473,14 @@ pub fn ffi_surface(conn: &Connection, limit: u32) -> anyhow::Result<Vec<ImpactIt
                    files.path AS path,
                    files.language AS language,
                    files.kind AS kind,
-                   symbols.qualified_name AS symbol,
+                   qn.value AS symbol,
                    CASE
                        WHEN symbols.kind = 'impl' THEN 'rust_uniffi_exported_impl'
                        ELSE 'rust_uniffi_export'
                    END AS reason
             FROM symbols
             JOIN files ON files.id = symbols.file_id
+            LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
             JOIN symbol_facts
               ON symbol_facts.symbol_id = symbols.id
              AND symbol_facts.fact_kind = 'rust_attr'
@@ -492,7 +493,7 @@ pub fn ffi_surface(conn: &Connection, limit: u32) -> anyhow::Result<Vec<ImpactIt
                    files.path AS path,
                    files.language AS language,
                    files.kind AS kind,
-                   members.qualified_name AS symbol,
+                   members_qn.value AS symbol,
                    'rust_uniffi_impl_member' AS reason
             FROM symbols AS impls
             JOIN files ON files.id = impls.file_id
@@ -505,6 +506,7 @@ pub fn ffi_surface(conn: &Connection, limit: u32) -> anyhow::Result<Vec<ImpactIt
              AND members.start_byte > impls.start_byte
              AND members.end_byte < impls.end_byte
              AND members.kind IN ('function', 'method')
+            LEFT JOIN name_strings members_qn ON members_qn.id = members.qualified_name_id
             WHERE files.language = 'rust'
               AND impls.kind = 'impl'
         ),

--- a/crates/rag-rat-core/src/query/impact/neighbors.rs
+++ b/crates/rag-rat-core/src/query/impact/neighbors.rs
@@ -25,9 +25,9 @@ pub(crate) fn graph_neighbors(
         "COALESCE(to_files.kind, source_files.kind)"
     };
     let source_symbol_col = if reverse {
-        "COALESCE(from_symbols.qualified_name, edges.from_name)"
+        "COALESCE(from_qn.value, edges.from_name)"
     } else {
-        "COALESCE(to_symbols.qualified_name, edges.to_name)"
+        "COALESCE(to_qn.value, edges.to_name)"
     };
     let predicate = impact_graph_predicate(reverse, resolution_mode);
     let sql = format!(
@@ -39,6 +39,8 @@ pub(crate) fn graph_neighbors(
         LEFT JOIN files from_files ON from_files.id = from_symbols.file_id
         LEFT JOIN symbols to_symbols ON to_symbols.id = edges.to_symbol_id
         LEFT JOIN files to_files ON to_files.id = to_symbols.file_id
+        LEFT JOIN name_strings from_qn ON from_qn.id = from_symbols.qualified_name_id
+        LEFT JOIN name_strings to_qn ON to_qn.id = to_symbols.qualified_name_id
         LEFT JOIN files source_files ON source_files.id = edges.source_file_id
         WHERE edges.edge_kind IN ('calls_name', 'constructs', 'implements')
           AND ({predicate})
@@ -115,7 +117,7 @@ pub(crate) fn impact_graph_predicate(reverse: bool, mode: GraphResolutionMode) -
             "(edges.from_symbol_id = ?1 OR edges.from_name = ?2)
              AND (edges.to_symbol_id IS NOT NULL OR edges.target_qualified_name IS NOT NULL)",
         (true, GraphResolutionMode::Fuzzy) =>
-            "edges.to_symbol_id = ?1 OR edges.to_name_id = (SELECT id FROM edge_strings WHERE \
+            "edges.to_symbol_id = ?1 OR edges.to_name_id = (SELECT id FROM name_strings WHERE \
              value = ?2)",
         (false, GraphResolutionMode::Fuzzy) => "edges.from_symbol_id = ?1 OR edges.from_name = ?2",
     }
@@ -134,7 +136,7 @@ pub(crate) fn import_export_dependents(
         FROM edges
         JOIN files ON files.id = edges.source_file_id
         WHERE edges.edge_kind IN ('imports', 'exports')
-          AND (edges.to_symbol_id = ?1 OR edges.to_name_id = (SELECT id FROM edge_strings WHERE \
+          AND (edges.to_symbol_id = ?1 OR edges.to_name_id = (SELECT id FROM name_strings WHERE \
          value = ?2))
         ORDER BY files.kind, files.path, edges.edge_kind
         ",
@@ -186,9 +188,10 @@ pub(crate) fn same_file_siblings(
 ) -> anyhow::Result<()> {
     let mut stmt = conn.prepare(
         "
-        SELECT files.path, files.language, files.kind, symbols.qualified_name
+        SELECT files.path, files.language, files.kind, qn.value
         FROM symbols
         JOIN files ON files.id = symbols.file_id
+        LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
         WHERE symbols.file_id = ?1 AND symbols.id != ?2
         ORDER BY symbols.start_byte
         LIMIT 20
@@ -239,20 +242,20 @@ pub(crate) fn textual_fallback(
     };
     let sql = format!(
         "
-        SELECT DISTINCT files.path, files.language, files.kind, symbols.qualified_name,
+        SELECT DISTINCT files.path, files.language, files.kind, qn.value,
                CASE
                    WHEN files.path LIKE ?1 THEN 'path LIKE fallback'
-                   WHEN symbols.name LIKE ?1 OR symbols.qualified_name LIKE ?1 THEN 'symbol LIKE \
-         fallback'
+                   WHEN symbols.name LIKE ?1 OR qn.value LIKE ?1 THEN 'symbol LIKE fallback'
                    ELSE 'chunk text match fallback'
                END
         FROM files
         LEFT JOIN symbols ON symbols.file_id = files.id
+        LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
         WHERE files.path LIKE ?1
            OR symbols.name LIKE ?1
-           OR symbols.qualified_name LIKE ?1
+           OR qn.value LIKE ?1
            {chunk_clause}
-        ORDER BY files.kind, files.path, symbols.qualified_name
+        ORDER BY files.kind, files.path, qn.value
         LIMIT ?2
         "
     );

--- a/crates/rag-rat-core/src/query/impact/select.rs
+++ b/crates/rag-rat-core/src/query/impact/select.rs
@@ -31,10 +31,12 @@ pub(crate) fn exact_symbols(conn: &Connection, query: &str) -> anyhow::Result<Ve
     let mut stmt = conn.prepare(
         "
         SELECT symbols.id, symbols.file_id, files.path, files.language, files.kind,
-               symbols.name, symbols.qualified_name
+               symbols.name, qn.value
         FROM symbols
         JOIN files ON files.id = symbols.file_id
-        WHERE symbols.name = ?1 OR symbols.qualified_name = ?1
+        LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
+        WHERE symbols.name = ?1
+           OR symbols.qualified_name_id = (SELECT id FROM name_strings WHERE value = ?1)
         ORDER BY files.kind, files.path, symbols.start_byte
         ",
     )?;

--- a/crates/rag-rat-core/src/query/load_bearing.rs
+++ b/crates/rag-rat-core/src/query/load_bearing.rs
@@ -213,14 +213,14 @@ pub fn scoped_weighted_fan_in(
     // #89: in-edges are joined THROUGH the per-connection scoped `files` view
     // (`JOIN files ON files.id = edges_data.source_file_id`), NOT raw `main.edges`/`main.files`, so
     // the same symbol identity scores DIFFERENTLY per active scope and a foreign scope's edges
-    // never leak in. `edge_strings` resolves the kind/confidence ids to names for the weight
+    // never leak in. `name_strings` resolves the kind/confidence ids to names for the weight
     // tables; `d.id` keys the optional SCIP-oracle effect lookup.
     let mut stmt = conn.prepare(
         "SELECT d.id, ek.value, cf.value
          FROM edges_data d
          JOIN files ON files.id = d.source_file_id
-         JOIN edge_strings ek ON ek.id = d.edge_kind_id
-         JOIN edge_strings cf ON cf.id = d.confidence_id
+         JOIN name_strings ek ON ek.id = d.edge_kind_id
+         JOIN name_strings cf ON cf.id = d.confidence_id
          WHERE d.to_symbol_id = ?1
            -- Internal dispatch FACT rows (#200) are synthesis inputs, not real in-edges — the
            -- handle fact duplicates the dispatcher's existing calls_name, so counting it would
@@ -309,10 +309,14 @@ mod tests {
 
     /// Insert a symbol in `file_id`, returning its id.
     fn add_symbol(conn: &Connection, file_id: i64, name: &str, qualified: &str) -> i64 {
+        // #224: qualified_name interned into name_strings.
+        conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)", params![qualified])
+            .unwrap();
         conn.execute(
-            "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte,
+            "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, start_byte,
                                  end_byte, signature, docs)
-             VALUES (?1, 'rust', ?2, ?3, 'function', 0, 10, NULL, NULL)",
+             VALUES (?1, 'rust', ?2, (SELECT id FROM name_strings WHERE value = ?3),
+                     'function', 0, 10, NULL, NULL)",
             params![file_id, name, qualified],
         )
         .unwrap();
@@ -337,7 +341,7 @@ mod tests {
         )
         .unwrap();
         // `edges` is an INSTEAD OF INSERT view over `edges_data`; `last_insert_rowid()` after the
-        // trigger reflects an inner `edge_strings` insert, not the edge row — read the real
+        // trigger reflects an inner `name_strings` insert, not the edge row — read the real
         // `edges_data.id` so the oracle-effects map keys on the value `scoped_weighted_fan_in`'s
         // `d.id` query returns.
         conn.query_row("SELECT MAX(id) FROM edges_data", [], |row| row.get::<_, i64>(0)).unwrap()

--- a/crates/rag-rat-core/src/query/memory/api.rs
+++ b/crates/rag-rat-core/src/query/memory/api.rs
@@ -677,13 +677,14 @@ fn live_symbol_candidates(
     // we want all live symbols with this name, ranked by quality, not filtered by content.
     let mut stmt = match conn.prepare(
         "
-        SELECT symbols.qualified_name AS qualified_name,
+        SELECT qn.value             AS qualified_name,
                symbols.kind           AS kind,
                symbols.signature      AS signature
         FROM symbols
         JOIN files ON files.id = symbols.file_id
+        LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
         WHERE symbols.name = ?1
-        ORDER BY symbols.qualified_name
+        ORDER BY qn.value
         ",
     ) {
         Ok(s) => s,

--- a/crates/rag-rat-core/src/query/memory/moniker.rs
+++ b/crates/rag-rat-core/src/query/memory/moniker.rs
@@ -172,9 +172,13 @@ pub(crate) fn relocate_match_for_logical_symbol(
         },
     };
     let Some(qualified_name) = conn
-        .query_row("SELECT qualified_name FROM symbols WHERE id = ?1", [member_symbol_id], |row| {
-            row.get::<_, String>(0)
-        })
+        .query_row(
+            "SELECT qn.value FROM symbols
+             LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
+             WHERE symbols.id = ?1",
+            [member_symbol_id],
+            |row| row.get::<_, String>(0),
+        )
         .optional()?
     else {
         return Ok(None);

--- a/crates/rag-rat-core/src/query/memory/resolve.rs
+++ b/crates/rag-rat-core/src/query/memory/resolve.rs
@@ -383,10 +383,11 @@ pub(crate) fn chunk_for_symbol(
                symbols.id AS symbol_id
         FROM symbols
         JOIN files ON files.id = symbols.file_id
+        LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
         LEFT JOIN chunks ON chunks.file_id = files.id
-            AND (chunks.symbol_path = symbols.qualified_name OR chunks.symbol_path = ?2)
+            AND (chunks.symbol_path = qn.value OR chunks.symbol_path = ?2)
         WHERE symbols.id = ?1
-        ORDER BY CASE WHEN chunks.symbol_path = symbols.qualified_name THEN 0 ELSE 1 END,
+        ORDER BY CASE WHEN chunks.symbol_path = qn.value THEN 0 ELSE 1 END,
                  chunks.start_line
         LIMIT 1
         ",
@@ -412,8 +413,9 @@ pub(crate) fn chunk_for_logical_symbol(
         FROM logical_symbol_members
         JOIN symbols ON symbols.id = logical_symbol_members.symbol_id
         JOIN files ON files.id = symbols.file_id
+        LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
         LEFT JOIN chunks ON chunks.file_id = files.id
-            AND chunks.symbol_path = symbols.qualified_name
+            AND chunks.symbol_path = qn.value
         WHERE logical_symbol_members.logical_symbol_id = ?1
         ORDER BY logical_symbol_members.start_line, chunks.start_line
         LIMIT 1
@@ -455,7 +457,8 @@ pub(crate) fn symbol_id_for_chunk(
         SELECT symbols.id AS symbol_id
         FROM symbols
         JOIN files ON files.id = symbols.file_id
-        WHERE files.path = ?1 AND symbols.qualified_name = ?2
+        WHERE files.path = ?1
+          AND symbols.qualified_name_id = (SELECT id FROM name_strings WHERE value = ?2)
         LIMIT 1
         ",
         params![chunk.path, symbol_path],
@@ -859,10 +862,11 @@ pub(crate) fn relocate_symbol_by_name(
         // The join on `files` keeps this context-scoped, matching the qualified_name fallback
         // above.
         "
-        SELECT symbols.id AS symbol_id, symbols.qualified_name AS qualified_name,
+        SELECT symbols.id AS symbol_id, qn.value AS qualified_name,
                files.path AS path, symbols.kind AS kind, symbols.signature AS signature
         FROM symbols
         JOIN files ON files.id = symbols.file_id
+        LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
         WHERE symbols.name = ?1
         ",
     )?;

--- a/crates/rag-rat-core/src/query/memory/validate.rs
+++ b/crates/rag-rat-core/src/query/memory/validate.rs
@@ -74,7 +74,7 @@ pub(crate) fn validate_logical_symbol_binding(
             "
             SELECT id, path
             FROM logical_symbols
-            WHERE qualified_name = ?1
+            WHERE qualified_name_id = (SELECT id FROM name_strings WHERE value = ?1)
             LIMIT 1
             ",
             [&binding.binding_id],
@@ -129,7 +129,7 @@ pub(crate) fn validate_symbol_binding(
             SELECT symbols.id, files.path
             FROM symbols
             JOIN files ON files.id = symbols.file_id
-            WHERE symbols.qualified_name = ?1
+            WHERE symbols.qualified_name_id = (SELECT id FROM name_strings WHERE value = ?1)
             LIMIT 1
             ",
             [&binding.binding_id],

--- a/crates/rag-rat-core/src/query/pagerank.rs
+++ b/crates/rag-rat-core/src/query/pagerank.rs
@@ -315,7 +315,7 @@ pub fn important_symbols(
     options: ImportanceOptions<'_>,
 ) -> anyhow::Result<RankedImportance> {
     // Symbol→symbol edges in the active checkout whose SOURCE resolved, source file in the scope
-    // view. `edge_strings` resolves the edge-kind and confidence ids to their names — the kind sets
+    // view. `name_strings` resolves the edge-kind and confidence ids to their names — the kind sets
     // the base weight, the confidence scales it (a name-only guess flows less rank than a
     // structurally-resolved call). `d.id` keys the optional SCIP-oracle effect lookup.
     //
@@ -329,8 +329,8 @@ pub fn important_symbols(
         "SELECT d.id, d.from_symbol_id, d.to_symbol_id, ek.value, cf.value
          FROM edges_data d
          JOIN files ON files.id = d.source_file_id
-         JOIN edge_strings ek ON ek.id = d.edge_kind_id
-         JOIN edge_strings cf ON cf.id = d.confidence_id
+         JOIN name_strings ek ON ek.id = d.edge_kind_id
+         JOIN name_strings cf ON cf.id = d.confidence_id
          WHERE d.from_symbol_id IS NOT NULL
            -- Internal dispatch FACT rows (#200) are synthesis inputs, not real edges — they'd
            -- double-count (the handle fact duplicates the dispatcher's existing calls_name) and
@@ -429,9 +429,10 @@ pub fn important_symbols(
         let symbol_id = symbol_ids[idx];
         let row = conn
             .query_row(
-                "SELECT s.qualified_name, s.kind, f.path, lsm.logical_symbol_id
+                "SELECT qn.value, s.kind, f.path, lsm.logical_symbol_id
                  FROM symbols s
                  JOIN files f ON f.id = s.file_id
+                 LEFT JOIN name_strings qn ON qn.id = s.qualified_name_id
                  LEFT JOIN logical_symbol_members lsm ON lsm.symbol_id = s.id
                  WHERE s.id = ?1",
                 [symbol_id],
@@ -560,10 +561,13 @@ mod tests {
         for (name, qname) in
             [("caller_a", "a::caller_a"), ("caller_b", "a::caller_b"), ("hub", "a::hub")]
         {
+            conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)", params![qname])
+                .unwrap();
             conn.execute(
-                "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte,
+                "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, start_byte,
                                      end_byte, signature, docs)
-                 VALUES (1, 'rust', ?1, ?2, 'function', 0, 10, NULL, NULL)",
+                 VALUES (1, 'rust', ?1, (SELECT id FROM name_strings WHERE value = ?2),
+                         'function', 0, 10, NULL, NULL)",
                 params![name, qname],
             )
             .unwrap();
@@ -603,11 +607,15 @@ mod tests {
         )
         .unwrap();
         for i in 1..=n {
+            let qname = format!("a::s{i}");
+            conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)", params![qname])
+                .unwrap();
             conn.execute(
-                "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte,
+                "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, start_byte,
                                      end_byte, signature, docs)
-                 VALUES (1, 'rust', ?1, ?2, 'function', 0, 10, NULL, NULL)",
-                params![format!("s{i}"), format!("a::s{i}")],
+                 VALUES (1, 'rust', ?1, (SELECT id FROM name_strings WHERE value = ?2),
+                         'function', 0, 10, NULL, NULL)",
+                params![format!("s{i}"), qname],
             )
             .unwrap();
         }
@@ -663,11 +671,15 @@ mod tests {
         )
         .unwrap();
         for i in 1..=n {
+            let qname = format!("a::s{i}");
+            conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)", params![qname])
+                .unwrap();
             conn.execute(
-                "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte,
+                "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, start_byte,
                                      end_byte, signature, docs)
-                 VALUES (1, 'rust', ?1, ?2, 'function', 0, 10, NULL, NULL)",
-                params![format!("s{i}"), format!("a::s{i}")],
+                 VALUES (1, 'rust', ?1, (SELECT id FROM name_strings WHERE value = ?2),
+                         'function', 0, 10, NULL, NULL)",
+                params![format!("s{i}"), qname],
             )
             .unwrap();
         }
@@ -698,11 +710,15 @@ mod tests {
         )
         .unwrap();
         for i in 1..=2 {
+            let qname = format!("a::s{i}");
+            conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)", params![qname])
+                .unwrap();
             conn.execute(
-                "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte,
+                "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, start_byte,
                                      end_byte, signature, docs)
-                 VALUES (1, 'rust', ?1, ?2, 'function', 0, 10, NULL, NULL)",
-                params![format!("s{i}"), format!("a::s{i}")],
+                 VALUES (1, 'rust', ?1, (SELECT id FROM name_strings WHERE value = ?2),
+                         'function', 0, 10, NULL, NULL)",
+                params![format!("s{i}"), qname],
             )
             .unwrap();
         }

--- a/crates/rag-rat-core/src/query/symbol.rs
+++ b/crates/rag-rat-core/src/query/symbol.rs
@@ -214,10 +214,11 @@ pub fn lookup_by_id(conn: &Connection, symbol_id: i64) -> anyhow::Result<Option<
         .query_row(
             "
         SELECT symbols.id, files.id, files.path, files.kind, symbols.language, symbols.name, \
-             symbols.qualified_name,
+             qn.value,
                symbols.kind, symbols.start_byte, symbols.end_byte, symbols.signature, symbols.docs
         FROM symbols
         JOIN files ON files.id = symbols.file_id
+        LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
         WHERE symbols.id = ?1
         ",
             [symbol_id],
@@ -270,13 +271,20 @@ fn lookup_name(
     limit: u32,
     include_generated: bool,
 ) -> anyhow::Result<Vec<SymbolHit>> {
+    // Fuzzy qualified-name match is interned (#224): match against the shared `name_strings` pool
+    // (`qualified_name_id IN (SELECT id FROM name_strings WHERE value LIKE ?2)`) then scope back to
+    // `symbols` via the join. The `name = ?1` exact arm is unaffected and stays on
+    // `idx_symbols_name` — keep it first so a bare-name hit is indexed. The projection reads
+    // the value back through the `qn` join so the output `qualified_name` field is unchanged.
     let mut sql = "
         SELECT symbols.id, files.id, files.path, files.kind, symbols.language, symbols.name, \
-                   symbols.qualified_name,
+                   qn.value,
                symbols.kind, symbols.start_byte, symbols.end_byte, symbols.signature, symbols.docs
         FROM symbols
         JOIN files ON files.id = symbols.file_id
-        WHERE (symbols.name = ?1 OR symbols.qualified_name LIKE ?2)
+        LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
+        WHERE (symbols.name = ?1
+               OR symbols.qualified_name_id IN (SELECT id FROM name_strings WHERE value LIKE ?2))
     "
     .to_string();
     if !include_generated {
@@ -333,9 +341,12 @@ pub fn lookup_logical_by_id(
 ) -> anyhow::Result<Option<LogicalSymbolHit>> {
     conn.query_row(
         "
-        SELECT id, language, path, logical_name, qualified_name, kind, variant_count, group_reason
+        SELECT logical_symbols.id, logical_symbols.language, logical_symbols.path,
+               logical_symbols.logical_name, qn.value, logical_symbols.kind,
+               logical_symbols.variant_count, logical_symbols.group_reason
         FROM logical_symbols
-        WHERE id = ?1
+        LEFT JOIN name_strings qn ON qn.id = logical_symbols.qualified_name_id
+        WHERE logical_symbols.id = ?1
         ",
         [logical_symbol_id],
         logical_symbol_hit_row,
@@ -351,10 +362,11 @@ pub fn logical_for_symbol_id(
     conn.query_row(
         "
         SELECT logical_symbols.id, logical_symbols.language, logical_symbols.path,
-               logical_symbols.logical_name, logical_symbols.qualified_name, logical_symbols.kind,
+               logical_symbols.logical_name, qn.value, logical_symbols.kind,
                logical_symbols.variant_count, logical_symbols.group_reason
         FROM logical_symbol_members
         JOIN logical_symbols ON logical_symbols.id = logical_symbol_members.logical_symbol_id
+        LEFT JOIN name_strings qn ON qn.id = logical_symbols.qualified_name_id
         WHERE logical_symbol_members.symbol_id = ?1
         ",
         [symbol_id],
@@ -400,11 +412,12 @@ fn lookup_logical_members(
     let mut stmt = conn.prepare(
         "
         SELECT symbols.id, files.id, files.path, files.kind, symbols.language, symbols.name,
-               symbols.qualified_name, symbols.kind, symbols.start_byte, symbols.end_byte,
+               qn.value, symbols.kind, symbols.start_byte, symbols.end_byte,
                symbols.signature, symbols.docs
         FROM logical_symbol_members
         JOIN symbols ON symbols.id = logical_symbol_members.symbol_id
         JOIN files ON files.id = symbols.file_id
+        LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
         WHERE logical_symbol_members.logical_symbol_id = ?1
         ORDER BY symbols.start_byte, symbols.id
         LIMIT ?2
@@ -437,13 +450,16 @@ fn lookup_symbol_path(
     limit: u32,
     include_generated: bool,
 ) -> anyhow::Result<Vec<SymbolHit>> {
+    // Exact qualified-name match is interned (#224): resolve the name to its pool id once, then hit
+    // `idx_symbols_qualified_name_id`. The projection reads the value back through the `qn` join.
     let mut sql = "
         SELECT symbols.id, files.id, files.path, files.kind, symbols.language, symbols.name, \
-                   symbols.qualified_name,
+                   qn.value,
                symbols.kind, symbols.start_byte, symbols.end_byte, symbols.signature, symbols.docs
         FROM symbols
         JOIN files ON files.id = symbols.file_id
-        WHERE symbols.qualified_name = ?1
+        LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
+        WHERE symbols.qualified_name_id = (SELECT id FROM name_strings WHERE value = ?1)
     "
     .to_string();
     if !include_generated {

--- a/crates/rag-rat-core/src/search/lexical.rs
+++ b/crates/rag-rat-core/src/search/lexical.rs
@@ -484,12 +484,12 @@ fn graph_boost(conn: &Connection, hit: &SearchHit, terms: &[String]) -> anyhow::
         "
         SELECT ek.value, conf.value, fn.value, tn.value
         FROM edges_data d
-        JOIN edge_strings ek ON ek.id = d.edge_kind_id
-        JOIN edge_strings conf ON conf.id = d.confidence_id
-        LEFT JOIN edge_strings fn ON fn.id = d.from_name_id
-        JOIN edge_strings tn ON tn.id = d.to_name_id
-        WHERE d.from_name_id IN (SELECT id FROM edge_strings WHERE value IN (?1, ?2))
-           OR d.to_name_id IN (SELECT id FROM edge_strings WHERE value IN (?1, ?2))
+        JOIN name_strings ek ON ek.id = d.edge_kind_id
+        JOIN name_strings conf ON conf.id = d.confidence_id
+        LEFT JOIN name_strings fn ON fn.id = d.from_name_id
+        JOIN name_strings tn ON tn.id = d.to_name_id
+        WHERE d.from_name_id IN (SELECT id FROM name_strings WHERE value IN (?1, ?2))
+           OR d.to_name_id IN (SELECT id FROM name_strings WHERE value IN (?1, ?2))
         ORDER BY
             CASE conf.value
                 WHEN 'Exact' THEN 0
@@ -707,9 +707,9 @@ mod tests {
             .prepare(
                 "EXPLAIN QUERY PLAN
                  SELECT ek.value FROM edges_data d
-                 JOIN edge_strings ek ON ek.id = d.edge_kind_id
-                 WHERE d.from_name_id IN (SELECT id FROM edge_strings WHERE value IN ('a', 'b'))
-                    OR d.to_name_id IN (SELECT id FROM edge_strings WHERE value IN ('a', 'b'))",
+                 JOIN name_strings ek ON ek.id = d.edge_kind_id
+                 WHERE d.from_name_id IN (SELECT id FROM name_strings WHERE value IN ('a', 'b'))
+                    OR d.to_name_id IN (SELECT id FROM name_strings WHERE value IN ('a', 'b'))",
             )
             .unwrap()
             .query_map([], |row| row.get::<_, String>(3))

--- a/crates/rag-rat-mcp/src/claude_hook.rs
+++ b/crates/rag-rat-mcp/src/claude_hook.rs
@@ -245,11 +245,15 @@ mod listener_tests {
             )
             .unwrap();
         rw.connection()
+            .execute("INSERT OR IGNORE INTO name_strings(value) VALUES ('lib::frobnicate')", [])
+            .unwrap();
+        rw.connection()
             .execute(
-                "INSERT INTO symbols(file_id, language, name, qualified_name, kind, start_byte,
+                "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, start_byte,
                                      end_byte, signature, docs)
-                 VALUES (1, 'rust', 'frobnicate', 'lib::frobnicate', 'function', 0, 10,
-                         'fn frobnicate()', NULL)",
+                 VALUES (1, 'rust', 'frobnicate',
+                         (SELECT id FROM name_strings WHERE value = 'lib::frobnicate'),
+                         'function', 0, 10, 'fn frobnicate()', NULL)",
                 [],
             )
             .unwrap();


### PR DESCRIPTION
Implements #224 (the non-text index-size levers, #77 follow-up): the clean ~137 MB lever — interning symbol qualified-names into the shared string pool.

## What changed

`symbols.qualified_name` and `logical_symbols.qualified_name` are no longer inline TEXT with a string B-tree index; they're a `qualified_name_id INTEGER` into the shared pool that `edges_data` already references. 85% of symbol qnames are already edge-target names, so the merge adds only ~102K pool entries, rewrites **zero** edge rows (every existing `from/to_name_id` is byte-unchanged), and the pool stays 3-byte (max id ~1.22M vs the 8.4M serial-type cliff).

**Pool rename** `edge_strings` → `name_strings` (it holds symbol names too now — full rename, no transitional dual-naming in the live schema). The one-time forward-migrate `ALTER … RENAME` lives in `provision_baseline` (it runs before `apply_baseline`'s view rebuild and before any migration replay, so `ensure_edges_view` always sees the renamed table); it rides the V028 bump so a pre-merge DB is `Older` and reaches the migrate path.

**Migration V028** (additive, backfill-then-drop, idempotent + `column_exists`-guarded, matching the #77 V027 posture): add nullable `qualified_name_id`; backfill `INSERT OR IGNORE` into `name_strings` + `UPDATE` from the value-join; create the id indexes, drop the string indexes; drop the column. `LATEST_SCHEMA_VERSION` 27 → 28.

**GC must-fix**: the pool has no FKs, so its orphan-sweep is the only thing pruning it — `symbols.qualified_name_id` and `logical_symbols.qualified_name_id` are added to the `id NOT IN (…)` union, or gc would delete entries live symbols reference and null their qnames. Guarded by a test that gc preserves a symbol-only pool entry.

**Reads**: exact `qualified_name = ?` → `qualified_name_id = (SELECT id FROM name_strings WHERE value = ?)`; fuzzy `%name%` → `qualified_name_id IN (SELECT id FROM name_strings WHERE value LIKE ?)` (the leading-wildcard scan was never indexed, so no regression — it just moved to the smaller pool); projection → `LEFT JOIN name_strings qn … qn.value`. The output field `qualified_name: String` is unchanged — only storage moved. Writes intern via the existing edge-string helper.

## Verification

- Full suite green: `cargo nextest run` across all three crates (764 tests), `cargo clippy --all-targets -- -D warnings`, nightly `rustfmt`.
- Forward-migrate exercised from a synthetic pre-V020 DB (lossless) and the V028 fresh/forward-migrate round-trip (rename + backfill reconstructs the original qname).
- End-to-end on a real kernel `mm` index: schema correct, `query` / `important-symbols` / graph projections all return correctly reconstructed qualified names, the old string index is gone, names interned + shared in the pool, and `max(name_strings.id)` is well under the 3-byte cliff.
- Read semantics checked against the shared pool's over-match (an edge-only string never surfaces a symbol), exact-NULL (matches nothing, not everything), multi-symbol qnames, LEFT-JOIN no-drop, and scope (the `files` overlay join is intact, so no cross-context leak). EXPLAIN confirms exact-match is a double index seek, no scan.

Full-kernel ~137 MB reclaim per the issue's measured-byte estimate (column ~70 MB + string-index ~74 MB − ~6 MB pool growth). Deferred (a later PR, per the issue): edge CSR, signature/docs block compression, and a trigram index on `name_strings.value`.

Closes #224.

https://claude.ai/code/session_01Qj5oCLLt7UcjBv2Ckr3gc8