### PR TITLE
chore(ci): run the eval suite via nextest

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@nextest
       # Cache the MiniLM model download (immutable → static key) so the semantic pass doesn't
       # re-fetch ~90 MB from Hugging Face every run; first run / cache-miss warms it.
       - name: cache embedding model
@@ -53,9 +54,9 @@ jobs:
       # current-source-safety violations, and zero-retrieval regressions without a model download.
       # The FULL baseline (incl. the semantic-only expectations) is enforced by the hybrid pass below.
       - name: eval suite (lexical, deterministic smoke)
-        run: cargo test -p rag-rat-core --no-default-features --features eval --locked eval_suite
+        run: cargo nextest run -p rag-rat-core --no-default-features --features eval --locked -E 'test(eval_suite)'
       # Real gate: default features compile the MiniLM backend, so the eval suite installs the model
       # (cached above) + reconciles embeddings and asserts report.pass over the actual hybrid
       # (lexical + semantic) retrieval path the product ships — every must_include_* expectation.
       - name: eval suite (hybrid, full gate)
-        run: cargo test -p rag-rat-core --features eval --locked eval_suite
+        run: cargo nextest run -p rag-rat-core --features eval --locked -E 'test(eval_suite)'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ the domain question, with invariant comments and tests (migrations included).
 
 ```bash
 cargo build
-cargo test -p rag-rat-core
+cargo nextest run -p rag-rat-core   # CI runs nextest (`cargo nextest run --workspace`); see .config/nextest.toml
 cargo clippy --all-targets
 cargo +nightly fmt   # CI uses nightly rustfmt; stable fmt silently diverges and reddens CI
 ```


### PR DESCRIPTION
`ci.yml` already runs `cargo nextest run --workspace --profile ci` (with `.config/nextest.toml`), but `eval.yml` was the lone CI step still on `cargo test`. This switches its two steps — the lexical deterministic smoke and the hybrid full gate — to `cargo nextest run … -E 'test(eval_suite)'`, and adds the `taiki-e/install-action@nextest` step to match `ci.yml`. The `AGENTS.md` build/test snippet is updated to `cargo nextest run` for consistency.

Verified locally: `-E 'test(eval_suite)'` matches both eval tests (search-quality + oracle), equivalent to the old `eval_suite` substring filter. No other `cargo test` invocations remain in CI/scripts/docs.

https://claude.ai/code/session_01Qj5oCLLt7UcjBv2Ckr3gc8