### PR TITLE
feat(index): clone-detection fingerprint substrate — SourcererCC inverted index (#215)

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,3 +202,10 @@ and uses `gh api`; normal query tools read only the local cache.
 
 Releases are automated by [release-plz](https://release-plz.dev) (the three crates ship in lockstep;
 see [`docs/releasing.md`](docs/releasing.md)). `rag-rat` is MIT-licensed — see [LICENSE](LICENSE).
+
+## Prior art
+
+rag-rat's clone-detection design is inspired by SourcererCC's scalable token-bag candidate
+generation, NiCad's normalized near-miss clone-detection framing, GumTree's move-aware AST
+differencing, and anti-unification / least-general generalization for template extraction. Planned
+fragment-level mining and copy-paste bug heuristics are inspired by CP-Miner.

--- a/crates/rag-rat-core/src/index/clones/mod.rs
+++ b/crates/rag-rat-core/src/index/clones/mod.rs
@@ -64,6 +64,32 @@ pub(crate) fn fingerprint_symbol(node: Node<'_>, text: &str) -> Option<SymbolFin
     })
 }
 
+/// Baseline fingerprints for a file's function symbols, walking the SHARED parse tree (no re-parse,
+/// no DB). Returns `(local_symbol_index, fingerprint)` pairs keyed by index into `symbols`, so the
+/// caller maps each to the right DB id when it writes. Non-function symbols, symbols that can't be
+/// located in the tree, and bodies that normalize below `MIN_TOKENS` are skipped. The full-rebuild
+/// prepare phase calls this from the parse it already did for symbols/edges; the incremental path
+/// re-parses and calls it from `store_symbol_fingerprints`.
+pub(crate) fn fingerprint_symbols(
+    root: Node<'_>,
+    text: &str,
+    symbols: &[crate::index::symbols::Symbol],
+) -> Vec<(usize, SymbolFingerprint)> {
+    let mut out = Vec::new();
+    for (i, symbol) in symbols.iter().enumerate() {
+        if symbol.kind != "function" {
+            continue;
+        }
+        let Some(node) = root.descendant_for_byte_range(symbol.start_byte, symbol.end_byte) else {
+            continue;
+        };
+        if let Some(fp) = fingerprint_symbol(node, text) {
+            out.push((i, fp));
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/crates/rag-rat-core/src/index/clones/mod.rs
+++ b/crates/rag-rat-core/src/index/clones/mod.rs
@@ -1,0 +1,97 @@
+//! Clone-detection fingerprint substrate (#215 Phase 1): a scope-independent structural
+//! fingerprint per function symbol, computed during indexing.
+
+// `NormalizerKind::Scip` + `from_db_str` are the Plan-3 SCIP token-space surface (a separate
+// `normalizer_kind='scip'` postings space, used only at refine/ranking when every member has it).
+// They are dead until Plan 3 lands; the rest of the module is live (R4's candidate read uses it).
+#![allow(dead_code)]
+
+mod normalize;
+mod tokens;
+
+use tree_sitter::Node;
+
+/// Bumped when normalization changes; invalidates fingerprints (and the later refine cache) without
+/// a schema migration.
+pub(crate) const NORM_VERSION: i64 = 1;
+/// Smallest normalized-token count a symbol must reach to be fingerprinted (skip trivial getters).
+pub(crate) const MIN_TOKENS: usize = 20;
+
+/// Which token space a fingerprint was computed in. Baseline is always present and is the only
+/// input to candidate recall; Scip is an optional precision signal (Plan 3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NormalizerKind {
+    Baseline,
+    Scip,
+}
+
+impl NormalizerKind {
+    pub(crate) fn as_db_str(self) -> &'static str {
+        match self {
+            NormalizerKind::Baseline => "baseline",
+            NormalizerKind::Scip => "scip",
+        }
+    }
+
+    pub(crate) fn from_db_str(value: &str) -> Option<Self> {
+        match value {
+            "baseline" => Some(NormalizerKind::Baseline),
+            "scip" => Some(NormalizerKind::Scip),
+            _ => None,
+        }
+    }
+}
+
+/// One symbol's baseline fingerprint, ready to persist.
+#[derive(Debug, Clone)]
+pub(crate) struct SymbolFingerprint {
+    pub struct_hash: String,
+    pub token_len: i64,
+    /// `(token_hash, freq)` multiset sorted by `token_hash`. Stored in `symbol_token_postings`.
+    pub token_bag: Vec<(i64, i64)>,
+}
+
+/// Baseline fingerprint for a symbol's AST node, or `None` if it normalizes below `MIN_TOKENS`.
+pub(crate) fn fingerprint_symbol(node: Node<'_>, text: &str) -> Option<SymbolFingerprint> {
+    let tokens = normalize::normalize_baseline(node, text);
+    if tokens.len() < MIN_TOKENS {
+        return None;
+    }
+    Some(SymbolFingerprint {
+        struct_hash: tokens::struct_hash(&tokens),
+        token_len: tokens.len() as i64,
+        token_bag: tokens::token_bag(&tokens),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+    use crate::index::parser;
+    use crate::language::Language;
+
+    fn fp(src: &str) -> Option<SymbolFingerprint> {
+        let parsed = parser::parse_file(Path::new("t.rs"), Language::Rust, src).expect("parse");
+        let func = parsed.symbols.iter().find(|s| s.kind == "function").expect("function");
+        let node =
+            parsed.root().descendant_for_byte_range(func.start_byte, func.end_byte).expect("node");
+        fingerprint_symbol(node, src)
+    }
+
+    #[test]
+    fn renamed_clones_get_the_same_struct_hash_and_token_bag() {
+        let a = "fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }";
+        let b = "fn load_order(store: Db) -> i32 { let o = store.get(20); validate(o); o + 1 }";
+        let fa = fp(a).expect("a fingerprinted");
+        let fb = fp(b).expect("b fingerprinted");
+        assert_eq!(fa.struct_hash, fb.struct_hash);
+        assert_eq!(fa.token_bag, fb.token_bag);
+    }
+
+    #[test]
+    fn trivial_bodies_below_min_tokens_are_not_fingerprinted() {
+        assert!(fp("fn x() -> i32 { 0 }").is_none());
+    }
+}

--- a/crates/rag-rat-core/src/index/clones/normalize.rs
+++ b/crates/rag-rat-core/src/index/clones/normalize.rs
@@ -1,0 +1,87 @@
+use std::collections::HashMap;
+
+use tree_sitter::Node;
+
+/// A leaf tree-sitter kind that names a binding/reference identifier (kept language-agnostic by
+/// matching the `*identifier` suffix tree-sitter grammars use).
+fn is_identifier_kind(kind: &str) -> bool {
+    kind.ends_with("identifier")
+}
+
+/// A leaf kind that is a literal whose *value* must not drive matching.
+fn is_literal_kind(kind: &str) -> bool {
+    kind.ends_with("literal")
+        || matches!(kind, "string_content" | "integer" | "float" | "number" | "char")
+}
+
+/// Baseline normalization (#215 §4): pre-order walk of the symbol subtree emitting one token per
+/// node — structural node kinds for internal nodes; for leaves, an alpha-renamed `ID<n>` for
+/// identifiers (numbered by first occurrence), a `LIT_<KIND>` bucket for literals, and the verbatim
+/// text for operators/keywords/punctuation. Scope-independent: depends only on this node's subtree.
+pub(crate) fn normalize_baseline(node: Node<'_>, text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut idents: HashMap<String, usize> = HashMap::new();
+    walk(node, text.as_bytes(), &mut idents, &mut out);
+    out
+}
+
+fn walk(node: Node<'_>, src: &[u8], idents: &mut HashMap<String, usize>, out: &mut Vec<String>) {
+    let kind = node.kind();
+    if node.child_count() == 0 {
+        let leaf = node.utf8_text(src).unwrap_or("");
+        if is_identifier_kind(kind) {
+            let next = idents.len();
+            let id = *idents.entry(leaf.to_string()).or_insert(next);
+            out.push(format!("ID{id}"));
+        } else if is_literal_kind(kind) {
+            out.push(format!("LIT_{}", kind.to_ascii_uppercase()));
+        } else {
+            // keyword / operator / punctuation — structural, kept verbatim
+            out.push(leaf.to_string());
+        }
+        return;
+    }
+    out.push(kind.to_string());
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk(child, src, idents, out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+    use crate::index::parser;
+    use crate::language::Language;
+
+    fn norm(src: &str) -> Vec<String> {
+        let parsed = parser::parse_file(Path::new("t.rs"), Language::Rust, src).expect("parse");
+        let func = parsed.symbols.iter().find(|s| s.kind == "function").expect("a function symbol");
+        let node =
+            parsed.root().descendant_for_byte_range(func.start_byte, func.end_byte).expect("node");
+        normalize_baseline(node, src)
+    }
+
+    #[test]
+    fn renamed_identical_bodies_normalize_equal() {
+        let a = "fn load_user(db: Db) -> i32 { let u = db.get(10); u + 1 }";
+        let b = "fn load_order(store: Db) -> i32 { let o = store.get(10); o + 1 }";
+        assert_eq!(norm(a), norm(b));
+    }
+
+    #[test]
+    fn structurally_different_bodies_differ() {
+        let a = "fn f(db: Db) -> i32 { let u = db.get(10); u + 1 }";
+        let b = "fn g(db: Db) -> i32 { while true { } 0 }";
+        assert_ne!(norm(a), norm(b));
+    }
+
+    #[test]
+    fn literals_are_bucketed_not_compared_by_value() {
+        let a = "fn f() -> i32 { let x = 10; x }";
+        let b = "fn g() -> i32 { let y = 99999; y }";
+        assert_eq!(norm(a), norm(b));
+    }
+}

--- a/crates/rag-rat-core/src/index/clones/tokens.rs
+++ b/crates/rag-rat-core/src/index/clones/tokens.rs
@@ -1,0 +1,84 @@
+//! Token-level helpers for clone-detection fingerprints: FNV-1a hashing, struct hash, and token
+//! bag (multiset) construction. All hashing is deterministic and stable across machines and runs.
+
+use std::collections::HashMap;
+
+const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+pub(crate) fn fnv1a(bytes: &[u8]) -> u64 {
+    let mut hash = FNV_OFFSET;
+    for &byte in bytes {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
+/// Content hash of the exact normalized token sequence — the exact-after-normalization fast path.
+pub(crate) fn struct_hash(tokens: &[String]) -> String {
+    crate::index::hex_sha256(tokens.join("\u{1}").as_bytes())
+}
+
+/// Build a `(token_hash, freq)` multiset from a token sequence. `token_hash` is
+/// `fnv1a(token.as_bytes()) as i64` (reinterpreted as signed for SQLite INTEGER compatibility).
+/// The result is sorted by `token_hash` for deterministic storage and lookup.
+pub(crate) fn token_bag(tokens: &[String]) -> Vec<(i64, i64)> {
+    let mut counts: HashMap<i64, i64> = HashMap::new();
+    for token in tokens {
+        let hash = fnv1a(token.as_bytes()) as i64;
+        *counts.entry(hash).or_insert(0) += 1;
+    }
+    let mut bag: Vec<(i64, i64)> = counts.into_iter().collect();
+    bag.sort_unstable_by_key(|&(hash, _)| hash);
+    bag
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn toks(words: &[&str]) -> Vec<String> {
+        words.iter().map(|w| w.to_string()).collect()
+    }
+
+    #[test]
+    fn identical_token_streams_have_equal_token_bag() {
+        let a = toks(&["if", "x", "(", "y", ")", "x", "y", "x", "y"]);
+        let b = a.clone();
+        assert_eq!(token_bag(&a), token_bag(&b));
+    }
+
+    #[test]
+    fn repeated_token_has_freq_greater_than_one() {
+        let tokens = toks(&["a", "b", "a", "c", "a"]);
+        let bag = token_bag(&tokens);
+        let a_hash = fnv1a(b"a") as i64;
+        let entry = bag.iter().find(|&&(h, _)| h == a_hash).expect("a in bag");
+        assert_eq!(entry.1, 3, "token 'a' appears 3 times");
+    }
+
+    #[test]
+    fn distinct_token_streams_produce_different_bags() {
+        let a = toks(&["foo", "bar", "baz"]);
+        let b = toks(&["qux", "quux", "corge"]);
+        assert_ne!(token_bag(&a), token_bag(&b));
+    }
+
+    #[test]
+    fn token_bag_is_sorted_by_token_hash() {
+        let tokens = toks(&["z", "a", "m", "b", "z", "a"]);
+        let bag = token_bag(&tokens);
+        let hashes: Vec<i64> = bag.iter().map(|&(h, _)| h).collect();
+        let mut sorted = hashes.clone();
+        sorted.sort();
+        assert_eq!(hashes, sorted, "bag must be sorted by token_hash");
+    }
+
+    #[test]
+    fn identical_token_streams_have_equal_struct_hash() {
+        let a = toks(&["if", "ID0", "(", "ID1", ")", "ID0", "ID1", "ID0", "ID1"]);
+        let b = a.clone();
+        assert_eq!(struct_hash(&a), struct_hash(&b));
+    }
+}

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -11,6 +11,12 @@ struct ChunkInsertFile<'a> {
     source_revision: &'a str,
 }
 
+/// Whether `write_symbol_fingerprints` should bump `clone_token_df` per token (#215). Named so the
+/// call site reads its intent: `BumpDf(false)` on the full-rebuild path (df is recomputed
+/// authoritatively at finalize, so the per-token bump is wasted work), `BumpDf(true)` on the
+/// incremental/heal path (no finalize runs there, so the bump keeps df current).
+struct BumpDf(bool);
+
 impl IndexDatabase {
     pub fn heal_file(&self, path: &Path) -> anyhow::Result<()> {
         // A heal reads bytes from `source_root` (the MAIN checkout). Under a linked-worktree
@@ -186,7 +192,16 @@ impl IndexDatabase {
         let symbol_db_ids = self.insert_symbols(file_id, file.language, &prepared.symbols)?;
         // Clone fingerprints were computed in the parallel prepare phase from the same parse used
         // for symbols/edges (#230) — no second read, no second parse here, just the DB write.
-        self.write_symbol_fingerprints(&symbol_db_ids, &prepared.symbol_fingerprints)?;
+        // bump_df = graph.is_none(): the full-rebuild path (graph: Some) recomputes clone_token_df
+        // authoritatively from the postings via one GROUP BY in refresh_clone_token_df at finalize
+        // (rebuild.rs), so the per-token df upserts here would be recomputed-and-discarded — pure
+        // waste + hot-row contention on common tokens. The incremental path (graph: None) runs no
+        // such finalize, so it must keep the df current with the drift-tolerated per-token bump.
+        self.write_symbol_fingerprints(
+            &symbol_db_ids,
+            &prepared.symbol_fingerprints,
+            BumpDf(graph.is_none()),
+        )?;
         // Edge candidates were computed in the parallel prepare phase with LOCAL symbol indices;
         // remap them to the real DB ids just assigned.
         match graph {
@@ -238,7 +253,9 @@ impl IndexDatabase {
             return Ok(());
         };
         let fingerprints = clones::fingerprint_symbols(parsed.root(), text, symbols);
-        self.write_symbol_fingerprints(symbol_ids, &fingerprints)
+        // Heal/inline path runs no full-rebuild finalize, so the df must be kept current here via
+        // the per-token bump (drift-tolerated; see write_symbol_fingerprints).
+        self.write_symbol_fingerprints(symbol_ids, &fingerprints, BumpDf(true))
     }
 
     /// Write precomputed baseline clone fingerprints (#215). `fingerprints` carries
@@ -246,10 +263,19 @@ impl IndexDatabase {
     /// selects the matching DB id in `symbol_db_ids`. This is the DB-write half shared by the
     /// full-rebuild prepare phase (#230) and the incremental `store_symbol_fingerprints` wrapper,
     /// so the per-row insert discipline lives in exactly one place.
+    ///
+    /// `bump_df` gates the per-token `clone_token_df` upsert. On the full-rebuild path it is
+    /// `BumpDf(false)`: `refresh_clone_token_df` (rebuild.rs) recomputes df exactly from the
+    /// postings at finalize, so bumping it per token here is recomputed-and-discarded work plus
+    /// hot-row B-tree contention on common tokens. On the incremental/heal paths it is
+    /// `BumpDf(true)` — no finalize runs there, so the drift-tolerated bump is how df stays current
+    /// (df is a selectivity hint only; the candidate read LEFT-JOINs + COALESCEs it, so drift never
+    /// changes a result — see query_api/clones.rs).
     fn write_symbol_fingerprints(
         &self,
         symbol_db_ids: &[i64],
         fingerprints: &[(usize, clones::SymbolFingerprint)],
+        bump_df: BumpDf,
     ) -> anyhow::Result<()> {
         let conn = self.storage.connection();
         let normalizer_kind = clones::NormalizerKind::Baseline.as_db_str();
@@ -268,11 +294,12 @@ impl IndexDatabase {
                 fp.token_len,
                 now_ms(),
             ])?;
-            // Write the inverted index: one posting row per distinct token, and bump the global
-            // document frequency for that token (#215). df is a selectivity hint only (the
-            // candidate read LEFT-JOINs + COALESCEs it), so the incremental/heal bump
-            // here is drift-tolerated; a full rebuild recomputes df authoritatively
-            // from postings (see rebuild.rs).
+            // Write the inverted index: one posting row per distinct token (#215). The global
+            // document frequency for the token is bumped here ONLY when `bump_df`
+            // (incremental/heal): df is a selectivity hint only (the candidate read
+            // LEFT-JOINs + COALESCEs it), so the bump is drift-tolerated. A full
+            // rebuild skips the bump and instead recomputes df authoritatively from the
+            // postings at finalize (refresh_clone_token_df, rebuild.rs).
             for &(token_hash, freq) in &fp.token_bag {
                 conn.prepare_cached(
                     "INSERT INTO symbol_token_postings(symbol_id, normalizer_kind, token_hash, \
@@ -280,12 +307,14 @@ impl IndexDatabase {
                      VALUES (?1, ?2, ?3, ?4)",
                 )?
                 .execute(params![symbol_id, normalizer_kind, token_hash, freq])?;
-                conn.prepare_cached(
-                    "INSERT INTO clone_token_df(normalizer_kind, token_hash, df)
-                     VALUES (?1, ?2, 1)
-                     ON CONFLICT(normalizer_kind, token_hash) DO UPDATE SET df = df + 1",
-                )?
-                .execute(params![normalizer_kind, token_hash])?;
+                if bump_df.0 {
+                    conn.prepare_cached(
+                        "INSERT INTO clone_token_df(normalizer_kind, token_hash, df)
+                         VALUES (?1, ?2, 1)
+                         ON CONFLICT(normalizer_kind, token_hash) DO UPDATE SET df = df + 1",
+                    )?
+                    .execute(params![normalizer_kind, token_hash])?;
+                }
             }
         }
         Ok(())

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -228,6 +228,12 @@ impl IndexDatabase {
         symbols: &[Symbol],
         symbol_ids: &[i64],
     ) -> anyhow::Result<()> {
+        // Only `kind == "function"` symbols are fingerprinted (#215). Bail before re-parsing the
+        // file when none qualify — the parse is the expensive part of this incremental/heal
+        // wrapper.
+        if symbols.iter().all(|s| s.kind != "function") {
+            return Ok(());
+        }
         let Some(parsed) = parser::parse_file(path, language, text) else {
             return Ok(());
         };

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -118,7 +118,8 @@ impl IndexDatabase {
         // Inline/heal path: keep chunk_fts in sync per row (partial file replace would otherwise
         // desync the external-content index until the next forced rebuild).
         self.insert_chunks(ChunkInsertFile { file_id, source_revision: &sha256 }, &chunks)?;
-        self.insert_symbols(file_id, language, &symbols)?;
+        let symbol_ids = self.insert_symbols(file_id, language, &symbols)?;
+        self.store_symbol_fingerprints(language, path, text, &symbols, &symbol_ids)?;
         if kind != TargetKind::Generated && text.len() <= edges::MAX_GRAPH_PARSE_BYTES {
             edges::index_file_edges(self.storage.connection(), file_id, path, language, text)?;
         }
@@ -183,6 +184,17 @@ impl IndexDatabase {
             &prepared.chunks,
         )?;
         let symbol_db_ids = self.insert_symbols(file_id, file.language, &prepared.symbols)?;
+        if let Some(root_dir) = self.storage.source_root()
+            && let Ok(text) = std::fs::read_to_string(root_dir.join(&file.relative_path))
+        {
+            self.store_symbol_fingerprints(
+                file.language,
+                &file.relative_path,
+                &text,
+                &prepared.symbols,
+                &symbol_db_ids,
+            )?;
+        }
         // Edge candidates were computed in the parallel prepare phase with LOCAL symbol indices;
         // remap them to the real DB ids just assigned.
         match graph {
@@ -207,6 +219,72 @@ impl IndexDatabase {
                 },
         }
         self.mark_fts_dirty()?;
+        Ok(())
+    }
+
+    /// Compute + persist baseline clone fingerprints for the file's function symbols (#215). A
+    /// fingerprint is a pure function of the symbol body, so it is scope-independent and keyed by
+    /// symbol_id; the FK cascade discards it when the symbol is removed on reindex. Re-parses the
+    /// file once to walk the AST (Plan 1 keeps this simple; if the kernel perf gate regresses, move
+    /// this into the parallel prepare phase).
+    fn store_symbol_fingerprints(
+        &self,
+        language: Language,
+        path: &Path,
+        text: &str,
+        symbols: &[Symbol],
+        symbol_ids: &[i64],
+    ) -> anyhow::Result<()> {
+        let Some(parsed) = parser::parse_file(path, language, text) else {
+            return Ok(());
+        };
+        let root = parsed.root();
+        let conn = self.storage.connection();
+        for (symbol, &symbol_id) in symbols.iter().zip(symbol_ids) {
+            if symbol.kind != "function" {
+                continue;
+            }
+            let Some(node) = root.descendant_for_byte_range(symbol.start_byte, symbol.end_byte)
+            else {
+                continue;
+            };
+            let Some(fp) = clones::fingerprint_symbol(node, text) else {
+                continue;
+            };
+            conn.prepare_cached(
+                "INSERT INTO symbol_fingerprints(symbol_id, normalizer_kind, normalizer_version, \
+                 oracle_run_id, struct_hash, token_len, created_at_ms)
+                 VALUES (?1, ?2, ?3, NULL, ?4, ?5, ?6)",
+            )?
+            .execute(params![
+                symbol_id,
+                clones::NormalizerKind::Baseline.as_db_str(),
+                clones::NORM_VERSION,
+                fp.struct_hash,
+                fp.token_len,
+                now_ms(),
+            ])?;
+            // Write the inverted index: one posting row per distinct token, and bump the global
+            // document frequency for that token (#215). df is a selectivity hint only (the
+            // candidate read LEFT-JOINs + COALESCEs it), so the incremental/heal bump
+            // here is drift-tolerated; a full rebuild recomputes df authoritatively
+            // from postings (see rebuild.rs).
+            let normalizer_kind = clones::NormalizerKind::Baseline.as_db_str();
+            for &(token_hash, freq) in &fp.token_bag {
+                conn.prepare_cached(
+                    "INSERT INTO symbol_token_postings(symbol_id, normalizer_kind, token_hash, \
+                     freq)
+                     VALUES (?1, ?2, ?3, ?4)",
+                )?
+                .execute(params![symbol_id, normalizer_kind, token_hash, freq])?;
+                conn.prepare_cached(
+                    "INSERT INTO clone_token_df(normalizer_kind, token_hash, df)
+                     VALUES (?1, ?2, 1)
+                     ON CONFLICT(normalizer_kind, token_hash) DO UPDATE SET df = df + 1",
+                )?
+                .execute(params![normalizer_kind, token_hash])?;
+            }
+        }
         Ok(())
     }
 

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -184,17 +184,9 @@ impl IndexDatabase {
             &prepared.chunks,
         )?;
         let symbol_db_ids = self.insert_symbols(file_id, file.language, &prepared.symbols)?;
-        if let Some(root_dir) = self.storage.source_root()
-            && let Ok(text) = std::fs::read_to_string(root_dir.join(&file.relative_path))
-        {
-            self.store_symbol_fingerprints(
-                file.language,
-                &file.relative_path,
-                &text,
-                &prepared.symbols,
-                &symbol_db_ids,
-            )?;
-        }
+        // Clone fingerprints were computed in the parallel prepare phase from the same parse used
+        // for symbols/edges (#230) — no second read, no second parse here, just the DB write.
+        self.write_symbol_fingerprints(&symbol_db_ids, &prepared.symbol_fingerprints)?;
         // Edge candidates were computed in the parallel prepare phase with LOCAL symbol indices;
         // remap them to the real DB ids just assigned.
         match graph {
@@ -225,8 +217,9 @@ impl IndexDatabase {
     /// Compute + persist baseline clone fingerprints for the file's function symbols (#215). A
     /// fingerprint is a pure function of the symbol body, so it is scope-independent and keyed by
     /// symbol_id; the FK cascade discards it when the symbol is removed on reindex. Re-parses the
-    /// file once to walk the AST (Plan 1 keeps this simple; if the kernel perf gate regresses, move
-    /// this into the parallel prepare phase).
+    /// file to walk the AST — the incremental/heal path that calls this already re-reads the file,
+    /// so the extra parse is local to that path. The full-rebuild path computes fingerprints in the
+    /// parallel prepare phase (#230) and calls `write_symbol_fingerprints` directly instead.
     fn store_symbol_fingerprints(
         &self,
         language: Language,
@@ -238,19 +231,24 @@ impl IndexDatabase {
         let Some(parsed) = parser::parse_file(path, language, text) else {
             return Ok(());
         };
-        let root = parsed.root();
+        let fingerprints = clones::fingerprint_symbols(parsed.root(), text, symbols);
+        self.write_symbol_fingerprints(symbol_ids, &fingerprints)
+    }
+
+    /// Write precomputed baseline clone fingerprints (#215). `fingerprints` carries
+    /// `(local_symbol_index, fingerprint)` pairs from `clones::fingerprint_symbols`; each index
+    /// selects the matching DB id in `symbol_db_ids`. This is the DB-write half shared by the
+    /// full-rebuild prepare phase (#230) and the incremental `store_symbol_fingerprints` wrapper,
+    /// so the per-row insert discipline lives in exactly one place.
+    fn write_symbol_fingerprints(
+        &self,
+        symbol_db_ids: &[i64],
+        fingerprints: &[(usize, clones::SymbolFingerprint)],
+    ) -> anyhow::Result<()> {
         let conn = self.storage.connection();
-        for (symbol, &symbol_id) in symbols.iter().zip(symbol_ids) {
-            if symbol.kind != "function" {
-                continue;
-            }
-            let Some(node) = root.descendant_for_byte_range(symbol.start_byte, symbol.end_byte)
-            else {
-                continue;
-            };
-            let Some(fp) = clones::fingerprint_symbol(node, text) else {
-                continue;
-            };
+        let normalizer_kind = clones::NormalizerKind::Baseline.as_db_str();
+        for (local_index, fp) in fingerprints {
+            let symbol_id = symbol_db_ids[*local_index];
             conn.prepare_cached(
                 "INSERT INTO symbol_fingerprints(symbol_id, normalizer_kind, normalizer_version, \
                  oracle_run_id, struct_hash, token_len, created_at_ms)
@@ -258,7 +256,7 @@ impl IndexDatabase {
             )?
             .execute(params![
                 symbol_id,
-                clones::NormalizerKind::Baseline.as_db_str(),
+                normalizer_kind,
                 clones::NORM_VERSION,
                 fp.struct_hash,
                 fp.token_len,
@@ -269,7 +267,6 @@ impl IndexDatabase {
             // candidate read LEFT-JOINs + COALESCEs it), so the incremental/heal bump
             // here is drift-tolerated; a full rebuild recomputes df authoritatively
             // from postings (see rebuild.rs).
-            let normalizer_kind = clones::NormalizerKind::Baseline.as_db_str();
             for &(token_hash, freq) in &fp.token_bag {
                 conn.prepare_cached(
                     "INSERT INTO symbol_token_postings(symbol_id, normalizer_kind, token_hash, \

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -12,6 +12,7 @@ pub mod symbols;
 pub mod walker;
 
 pub(crate) mod chunk_text_store;
+pub(crate) mod clones;
 mod discovery;
 mod file_index;
 mod file_rows;

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -767,7 +767,7 @@ fn migration_creates_oracle_side_tables() {
         assert!(columns.contains(&expected.to_string()), "edge_oracle missing {expected}");
     }
 
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 28);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 29);
 }
 
 /// The V019 moniker migration: the `logical_symbol_monikers` table (STRICT, NO foreign key — see

--- a/crates/rag-rat-core/src/index/prep.rs
+++ b/crates/rag-rat-core/src/index/prep.rs
@@ -66,6 +66,11 @@ pub(crate) struct PreparedIndexContent {
     // generated / oversized / markdown files. Moving this off the serial insert loop kills the
     // duplicate parse.
     pub(crate) edge_candidates: Vec<edges::EdgeCandidate>,
+    // Baseline clone fingerprints (#215), computed here from the SAME shared parse instead of the
+    // serial insert stage re-reading + re-parsing the file. Keyed by LOCAL index into `symbols`,
+    // remapped to the real DB id in insert_prepared_file. Empty for generated / oversized /
+    // markdown files (no structural parse).
+    pub(crate) symbol_fingerprints: Vec<(usize, clones::SymbolFingerprint)>,
     pub(crate) parser_failure: Option<String>,
 }
 
@@ -283,12 +288,21 @@ pub(crate) fn prepare_index_content(file: &IndexFile) -> anyhow::Result<Prepared
         None => Vec::new(),
     };
 
+    // Baseline clone fingerprints walk the SAME shared tree (no re-parse, no DB). Keyed by local
+    // symbol index; insert_prepared_file maps each to its DB id and writes. This is what lets the
+    // full-rebuild insert stage skip the second read + second parse the fingerprints used to need.
+    let symbol_fingerprints = parsed
+        .as_ref()
+        .map(|p| clones::fingerprint_symbols(p.root(), &text, &symbols))
+        .unwrap_or_default();
+
     Ok(PreparedIndexContent {
         modified_at_ms,
         sha256,
         chunks,
         symbols,
         edge_candidates,
+        symbol_fingerprints,
         parser_failure,
     })
 }

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -1,0 +1,303 @@
+//! Read layer for clone detection (#215). Plan 1 ships only the candidate-component read that
+//! proves the fingerprint substrate; the `find_clones` / `clones_for_symbol` surface is Plan 2.
+//!
+//! The candidate read is the SourcererCC algorithm (design rev 4 §3b): a `struct_hash` exact fast
+//! path, a deterministic-total-order sub-block filter over scoped baseline postings, and an EXACT
+//! max-denominator overlap verify. df is a *selectivity hint only* — admissibility comes from the
+//! shared total order plus the exact verify, so a missing/stale df never drops a true clone.
+
+use std::collections::BTreeMap;
+
+use rusqlite::Connection;
+
+use crate::index::IndexDatabase;
+
+/// Similarity threshold θ: a candidate pair is kept iff `overlap / max_len >= THETA`. The MAX
+/// denominator is deliberate (design rev-4 §3b) — it bounds the member length ratio to ≈1/θ, the
+/// whole-symbol bias, so a tiny helper contained in a giant function (overlap/min ≈ 1.0) is NOT a
+/// clone. Tunable later via the query surface.
+const THETA: f64 = 0.7;
+
+/// Sentinel df for tokens with no `clone_token_df` row (LEFT JOIN miss). i64::MAX sorts them LAST
+/// in `(coalesced_df ASC, token_hash ASC)` order — they are treated as maximally common (least
+/// selective), which is the conservative choice: it can only widen the sub-block, never shrink it,
+/// so no candidate is dropped. df is selectivity-only; correctness depends on the shared total
+/// order + exact verify, never on df accuracy (design rev-4 §2).
+const DF_FALLBACK: i64 = i64::MAX;
+
+/// One scoped baseline symbol's fingerprint, loaded for the candidate read.
+struct SymbolBag {
+    symbol_id: i64,
+    struct_hash: String,
+    token_len: i64,
+    /// `(token_hash, freq, coalesced_df)` for every distinct token in the symbol's bag.
+    tokens: Vec<TokenPosting>,
+}
+
+struct TokenPosting {
+    token_hash: i64,
+    freq: i64,
+    coalesced_df: i64,
+}
+
+impl IndexDatabase {
+    /// Candidate clone components over the ACTIVE scope, via the SourcererCC algorithm (design rev
+    /// 4 §3b): a `struct_hash` exact fast path plus sub-block-filtered candidate pairs verified
+    /// by EXACT max-denominator overlap, union-found into connected components. Both endpoints
+    /// are filtered to the scoped `files` view BEFORE pairing, so a component never mixes
+    /// out-of-scope symbols. Baseline postings only (recall is oracle-independent).
+    /// Over-generated on purpose — Plan 2's refine stage splits each component into coherent
+    /// clone classes.
+    pub fn candidate_clone_components(&self) -> anyhow::Result<Vec<Vec<i64>>> {
+        let conn = self.storage.connection();
+        let pairs = candidate_pairs(conn)?;
+        Ok(components_from_pairs(&pairs))
+    }
+}
+
+/// `(symbol_id, symbol_id)` candidate pairs (a < b), both within the scoped `files` view.
+///
+/// Combines the `struct_hash` exact fast path with the sub-block + exact-verify candidate read
+/// (design rev 4 §3b). Returns deduplicated `(a, b)` pairs with `a < b` for the union-find.
+fn candidate_pairs(conn: &Connection) -> anyhow::Result<Vec<(i64, i64)>> {
+    let bags = load_scoped_baseline_bags(conn)?;
+
+    let mut pairs: std::collections::BTreeSet<(i64, i64)> = std::collections::BTreeSet::new();
+
+    // 1. Exact fast path: every same-struct_hash set contributes all its pairwise pairs.
+    add_struct_hash_pairs(&bags, &mut pairs);
+
+    // 2. Sub-block candidate pairs via the inverted index over sub-block tokens only.
+    let candidate = sub_block_candidate_pairs(&bags);
+
+    // 3. Size prune + EXACT max-denominator verify over the FULL bags.
+    let by_id: BTreeMap<i64, &SymbolBag> = bags.iter().map(|b| (b.symbol_id, b)).collect();
+    for (a, b) in candidate {
+        let (ba, bb) = (by_id[&a], by_id[&b]);
+        if verified_clone(ba, bb) {
+            pairs.insert((a, b));
+        }
+    }
+
+    Ok(pairs.into_iter().collect())
+}
+
+/// Load every scoped baseline symbol's fingerprint + full token bag with LEFT-JOINed df. Both the
+/// fingerprint and its postings are filtered to the scoped `files` view through `symbols.file_id`,
+/// so only the ACTIVE version of each file participates (SCOPED-VIEW REQUIREMENT #89). df is read
+/// via LEFT JOIN + COALESCE so a missing-df token is never dropped (design rev-4 §2).
+fn load_scoped_baseline_bags(conn: &Connection) -> anyhow::Result<Vec<SymbolBag>> {
+    // Scoped baseline fingerprints: struct_hash + token_len per in-scope symbol.
+    let mut fp_stmt = conn.prepare(
+        "SELECT sf.symbol_id, sf.struct_hash, sf.token_len
+         FROM symbol_fingerprints sf
+         JOIN symbols ON symbols.id = sf.symbol_id
+         JOIN files ON files.id = symbols.file_id
+         WHERE sf.normalizer_kind = 'baseline'",
+    )?;
+    let mut bags: BTreeMap<i64, SymbolBag> = fp_stmt
+        .query_map([], |row| {
+            let symbol_id: i64 = row.get(0)?;
+            Ok((symbol_id, SymbolBag {
+                symbol_id,
+                struct_hash: row.get(1)?,
+                token_len: row.get(2)?,
+                tokens: Vec::new(),
+            }))
+        })?
+        .collect::<Result<_, _>>()?;
+
+    // Full token bag per scoped baseline symbol, with each token's df LEFT-JOINed + COALESCEd to
+    // the fallback sentinel (missing-df tokens must NOT be dropped — rev-4 §2).
+    let mut tok_stmt = conn.prepare(
+        "SELECT stp.symbol_id, stp.token_hash, stp.freq, COALESCE(df.df, ?1)
+         FROM symbol_token_postings stp
+         JOIN symbols ON symbols.id = stp.symbol_id
+         JOIN files ON files.id = symbols.file_id
+         LEFT JOIN clone_token_df df
+           ON df.normalizer_kind = stp.normalizer_kind AND df.token_hash = stp.token_hash
+         WHERE stp.normalizer_kind = 'baseline'",
+    )?;
+    let rows = tok_stmt.query_map([DF_FALLBACK], |row| {
+        Ok((row.get::<_, i64>(0)?, TokenPosting {
+            token_hash: row.get(1)?,
+            freq: row.get(2)?,
+            coalesced_df: row.get(3)?,
+        }))
+    })?;
+    for row in rows {
+        let (symbol_id, posting) = row?;
+        if let Some(bag) = bags.get_mut(&symbol_id) {
+            bag.tokens.push(posting);
+        }
+    }
+
+    Ok(bags.into_values().collect())
+}
+
+/// Exact fast path: every group of symbols sharing a `struct_hash` is
+/// identical-after-normalization, so it contributes all its pairwise pairs (no overlap math).
+fn add_struct_hash_pairs(bags: &[SymbolBag], pairs: &mut std::collections::BTreeSet<(i64, i64)>) {
+    let mut by_hash: BTreeMap<&str, Vec<i64>> = BTreeMap::new();
+    for bag in bags {
+        by_hash.entry(bag.struct_hash.as_str()).or_default().push(bag.symbol_id);
+    }
+    for ids in by_hash.values() {
+        for (i, &a) in ids.iter().enumerate() {
+            for &b in &ids[i + 1..] {
+                pairs.insert((a.min(b), a.max(b)));
+            }
+        }
+    }
+}
+
+/// Build the inverted index over sub-block tokens only and emit candidate pairs `(a < b)` for every
+/// pair of symbols sharing a sub-block token. Admissibility (design rev-4 §3b): two symbols can
+/// reach similarity ≥ θ only if their sub-blocks share a token hash, so this yields every true
+/// candidate pair regardless of df accuracy (given the shared total order).
+fn sub_block_candidate_pairs(bags: &[SymbolBag]) -> std::collections::BTreeSet<(i64, i64)> {
+    let mut inverted: BTreeMap<i64, Vec<i64>> = BTreeMap::new();
+    for bag in bags {
+        for token_hash in sub_block_tokens(bag) {
+            inverted.entry(token_hash).or_default().push(bag.symbol_id);
+        }
+    }
+
+    let mut candidate: std::collections::BTreeSet<(i64, i64)> = std::collections::BTreeSet::new();
+    for ids in inverted.values() {
+        for (i, &a) in ids.iter().enumerate() {
+            for &b in &ids[i + 1..] {
+                candidate.insert((a.min(b), a.max(b)));
+            }
+        }
+    }
+    candidate
+}
+
+/// A symbol's sub-block: the distinct token hashes whose occurrences reach into the first `p`
+/// occurrences under the deterministic total order `(coalesced_df ASC, token_hash ASC)`.
+///
+/// `p = token_len - ceil(THETA * token_len) + 1` is the sub-block OCCURRENCE length (clamped to ≥
+/// 0; if `p >= token_len` the whole bag is the sub-block). The sub-block is defined over EXPANDED
+/// token occurrences (Σ freq), not distinct posting rows, so it matches the multiset `Σ min(freq)`
+/// verifier (design rev-4 §3): walking distinct tokens in order accumulating `freq`, a token is
+/// included if the running occurrence-count BEFORE it is `< p` (i.e. any of its occurrences falls
+/// in the prefix).
+fn sub_block_tokens(bag: &SymbolBag) -> Vec<i64> {
+    let p = sub_block_len(bag.token_len);
+    if p <= 0 {
+        return Vec::new();
+    }
+
+    let mut ordered: Vec<&TokenPosting> = bag.tokens.iter().collect();
+    ordered.sort_by_key(|t| (t.coalesced_df, t.token_hash));
+
+    let mut sub_block = Vec::new();
+    let mut occurrences_before: i64 = 0;
+    for token in ordered {
+        // Include this token if any of its occurrences falls within the first `p` occurrences, i.e.
+        // the running count BEFORE it is still inside the prefix.
+        if occurrences_before < p {
+            sub_block.push(token.token_hash);
+        } else {
+            break; // every later token starts past the prefix too (occurrences only grow).
+        }
+        occurrences_before += token.freq;
+    }
+    sub_block
+}
+
+/// Sub-block occurrence length `p = token_len - ceil(THETA * token_len) + 1`, clamped to ≥ 0.
+fn sub_block_len(token_len: i64) -> i64 {
+    let threshold = (THETA * token_len as f64).ceil() as i64;
+    (token_len - threshold + 1).max(0)
+}
+
+/// Size prune + EXACT max-denominator verify (design rev-4 §3b). With `min_len`/`max_len` = the two
+/// token_lens: cheap size prune `min_len >= ceil(THETA * max_len)`; then `overlap = Σ min(freq_a,
+/// freq_b)` over the FULL bags, kept iff `overlap >= ceil(THETA * max_len)`. The GATE is
+/// `similarity = overlap / max_len`; containment = `overlap / min_len` is NOT gated here.
+fn verified_clone(a: &SymbolBag, b: &SymbolBag) -> bool {
+    let min_len = a.token_len.min(b.token_len);
+    let max_len = a.token_len.max(b.token_len);
+    let threshold = (THETA * max_len as f64).ceil() as i64;
+
+    // Size prune: a smaller block can't reach θ against a larger one.
+    if min_len < threshold {
+        return false;
+    }
+
+    overlap(a, b) >= threshold
+}
+
+/// Exact multiset overlap `Σ min(freq_a, freq_b)` over the two FULL token bags.
+fn overlap(a: &SymbolBag, b: &SymbolBag) -> i64 {
+    let freq_a: BTreeMap<i64, i64> = a.tokens.iter().map(|t| (t.token_hash, t.freq)).collect();
+    let mut total = 0;
+    for token in &b.tokens {
+        if let Some(&fa) = freq_a.get(&token.token_hash) {
+            total += fa.min(token.freq);
+        }
+    }
+    total
+}
+
+/// Union-find the pairs into components of size >= 2 (sorted for determinism).
+fn components_from_pairs(pairs: &[(i64, i64)]) -> Vec<Vec<i64>> {
+    use std::collections::BTreeMap;
+
+    fn find(parent: &mut BTreeMap<i64, i64>, x: i64) -> i64 {
+        let mut root = x;
+        while let Some(&p) = parent.get(&root) {
+            if p == root {
+                break;
+            }
+            root = p;
+        }
+        let mut cur = x;
+        while let Some(&p) = parent.get(&cur) {
+            if p == root {
+                break;
+            }
+            parent.insert(cur, root);
+            cur = p; // p captured before the insert, so advancing to the pre-compression parent is safe
+        }
+        root
+    }
+
+    let mut parent: BTreeMap<i64, i64> = BTreeMap::new();
+    for &(a, b) in pairs {
+        parent.entry(a).or_insert(a);
+        parent.entry(b).or_insert(b);
+        let (ra, rb) = (find(&mut parent, a), find(&mut parent, b));
+        if ra != rb {
+            parent.insert(ra.max(rb), ra.min(rb));
+        }
+    }
+    let mut groups: BTreeMap<i64, Vec<i64>> = BTreeMap::new();
+    let members: Vec<i64> = parent.keys().copied().collect(); // collect keys first: find() needs &mut parent
+    for member in members {
+        let root = find(&mut parent, member);
+        groups.entry(root).or_default().push(member);
+    }
+    groups
+        .into_values()
+        .filter(|g| g.len() >= 2)
+        .map(|mut g| {
+            g.sort_unstable();
+            g
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::components_from_pairs;
+
+    #[test]
+    fn union_find_groups_transitively_and_drops_singletons() {
+        // 1-2, 2-3 => {1,2,3}; 5-6 => {5,6}; 9 alone => dropped.
+        let comps = components_from_pairs(&[(1, 2), (2, 3), (5, 6)]);
+        assert_eq!(comps, vec![vec![1, 2, 3], vec![5, 6]]);
+    }
+}

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -88,12 +88,15 @@ fn candidate_pairs(conn: &Connection) -> anyhow::Result<Vec<(i64, i64)>> {
 /// via LEFT JOIN + COALESCE so a missing-df token is never dropped (design rev-4 §2).
 fn load_scoped_baseline_bags(conn: &Connection) -> anyhow::Result<Vec<SymbolBag>> {
     // Scoped baseline fingerprints: struct_hash + token_len per in-scope symbol.
+    // `files.generated = 0` excludes generated files (e.g. `src/generated/…`, `.d.ts`) from the
+    // candidate read — they are fingerprinted on write but must not enter clone components.
     let mut fp_stmt = conn.prepare(
         "SELECT sf.symbol_id, sf.struct_hash, sf.token_len
          FROM symbol_fingerprints sf
          JOIN symbols ON symbols.id = sf.symbol_id
          JOIN files ON files.id = symbols.file_id
-         WHERE sf.normalizer_kind = 'baseline'",
+         WHERE sf.normalizer_kind = 'baseline'
+           AND files.generated = 0",
     )?;
     let mut bags: BTreeMap<i64, SymbolBag> = fp_stmt
         .query_map([], |row| {
@@ -109,6 +112,8 @@ fn load_scoped_baseline_bags(conn: &Connection) -> anyhow::Result<Vec<SymbolBag>
 
     // Full token bag per scoped baseline symbol, with each token's df LEFT-JOINed + COALESCEd to
     // the fallback sentinel (missing-df tokens must NOT be dropped — rev-4 §2).
+    // `files.generated = 0` mirrors the fingerprint load: only non-generated symbols get postings
+    // loaded, so their bags never enter the inverted index or the exact verify.
     let mut tok_stmt = conn.prepare(
         "SELECT stp.symbol_id, stp.token_hash, stp.freq, COALESCE(df.df, ?1)
          FROM symbol_token_postings stp
@@ -116,7 +121,8 @@ fn load_scoped_baseline_bags(conn: &Connection) -> anyhow::Result<Vec<SymbolBag>
          JOIN files ON files.id = symbols.file_id
          LEFT JOIN clone_token_df df
            ON df.normalizer_kind = stp.normalizer_kind AND df.token_hash = stp.token_hash
-         WHERE stp.normalizer_kind = 'baseline'",
+         WHERE stp.normalizer_kind = 'baseline'
+           AND files.generated = 0",
     )?;
     let rows = tok_stmt.query_map([DF_FALLBACK], |row| {
         Ok((row.get::<_, i64>(0)?, TokenPosting {

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -7,6 +7,7 @@ use crate::query::text_compare::*;
 use crate::search::lexical::SearchOptions;
 
 mod ai_lifecycle;
+mod clones;
 mod gc;
 mod graph;
 mod history;

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -88,6 +88,14 @@ impl IndexDatabase {
             // needs the bulk 'rebuild' here (#77 Phase 2).
             db.finalize_full_rebuild_fts()?;
             mem_trace("after finalize_full_rebuild_fts");
+            // Recompute clone token document-frequency authoritatively from the postings just
+            // written (#215). The per-symbol incremental bump in store_symbol_fingerprints drifts
+            // over edits; a full rebuild owns the whole checkout, so derive df exactly here. df is
+            // a selectivity hint only (candidate read LEFT-JOINs + COALESCEs it), never
+            // a correctness input — but keeping it exact maximizes the rare-first
+            // sub-block prune.
+            db.refresh_clone_token_df()?;
+            mem_trace("after refresh_clone_token_df");
             db.set_meta("indexed_at_ms", &now_ms().to_string())?;
             db.storage.execute_batch("COMMIT")?;
             mem_trace("after COMMIT");
@@ -105,6 +113,21 @@ impl IndexDatabase {
         let _ = db.storage.execute_batch("PRAGMA synchronous = NORMAL;");
         result?;
         Ok(db)
+    }
+
+    /// Recompute `clone_token_df` exactly from `symbol_token_postings` (#215). One GROUP BY over
+    /// the postings replaces the drift-prone incremental bumps with the authoritative document
+    /// frequency (count of distinct symbols containing each token per normalizer). Runs inside
+    /// the rebuild transaction so the df and the postings it summarizes commit atomically.
+    fn refresh_clone_token_df(&self) -> anyhow::Result<()> {
+        self.storage.execute_batch(
+            "DELETE FROM clone_token_df;
+             INSERT INTO clone_token_df(normalizer_kind, token_hash, df)
+               SELECT normalizer_kind, token_hash, COUNT(DISTINCT symbol_id)
+               FROM symbol_token_postings
+               GROUP BY normalizer_kind, token_hash;",
+        )?;
+        Ok(())
     }
 
     fn clear_full_rebuild_tables(&self) -> anyhow::Result<()> {

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -268,6 +268,18 @@ impl IndexDatabase {
                 FROM main.files
                 JOIN temp.staged_file_ids ON staged_file_ids.id = files.id
             );
+            DELETE FROM main.symbol_fingerprints
+            WHERE symbol_id IN (
+                SELECT symbols.id
+                FROM main.symbols
+                JOIN temp.staged_file_ids ON staged_file_ids.id = symbols.file_id
+            );
+            DELETE FROM main.symbol_token_postings
+            WHERE symbol_id IN (
+                SELECT symbols.id
+                FROM main.symbols
+                JOIN temp.staged_file_ids ON staged_file_ids.id = symbols.file_id
+            );
             DELETE FROM main.symbols
             WHERE file_id IN (SELECT id FROM temp.staged_file_ids);
             DELETE FROM main.chunks

--- a/crates/rag-rat-core/src/index/schema/baseline.rs
+++ b/crates/rag-rat-core/src/index/schema/baseline.rs
@@ -600,6 +600,7 @@ pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
     apply_repo_memory_call_path_edges(conn)?;
     apply_graph_file_lookup_indexes(conn)?;
     interned_qualified_name_indexes(conn)?;
+    apply_clone_fingerprint_tables(conn)?;
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1122,6 +1122,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_026_ID => Some(26),
             MIGRATION_027_ID => Some(27),
             MIGRATION_028_ID => Some(28),
+            MIGRATION_029_ID => Some(29),
             _ => None,
         })
         .max()
@@ -1159,6 +1160,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_026_ID
             | MIGRATION_027_ID
             | MIGRATION_028_ID
+            | MIGRATION_029_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1193,6 +1195,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_026_ID => migration.checksum != MIGRATION_026_CHECKSUM,
         MIGRATION_027_ID => migration.checksum != MIGRATION_027_CHECKSUM,
         MIGRATION_028_ID => migration.checksum != MIGRATION_028_CHECKSUM,
+        MIGRATION_029_ID => migration.checksum != MIGRATION_029_CHECKSUM,
         _ => false,
     }
 }
@@ -1280,6 +1283,62 @@ pub(crate) fn apply_drop_chunks_text(conn: &Connection) -> rusqlite::Result<()> 
         })?;
     conn.execute("ALTER TABLE chunks DROP COLUMN text", [])?;
     Ok(())
+}
+
+/// V029 (#215, rework R1): clone-detection fingerprint substrate. All tables are scope-INDEPENDENT
+/// — symbol_fingerprints/symbol_token_postings key by symbol_id (FK CASCADE discards them on
+/// reindex); clone_token_df is a derived selectivity cache; clone_refinements keys by content
+/// (class_key). NEVER add scope columns here (see mem_19ec7384a9b).
+///
+/// R1 replaces the MinHash/LSH fingerprint_bands table with a SourcererCC-style inverted-index
+/// pair: symbol_token_postings (per-symbol token bag) + clone_token_df (document-frequency cache).
+pub(crate) const CLONE_FINGERPRINT_DDL: &str = "
+    CREATE TABLE IF NOT EXISTS symbol_fingerprints(
+        symbol_id          INTEGER NOT NULL REFERENCES symbols(id) ON DELETE CASCADE,
+        normalizer_kind    TEXT    NOT NULL,            -- baseline | scip
+        normalizer_version INTEGER NOT NULL,
+        oracle_run_id      INTEGER,                     -- NULL for baseline rows
+        struct_hash        TEXT    NOT NULL,
+        token_len          INTEGER NOT NULL,
+        created_at_ms      INTEGER NOT NULL,
+        PRIMARY KEY (symbol_id, normalizer_kind)
+    ) STRICT;
+    CREATE INDEX IF NOT EXISTS idx_symbol_fingerprints_struct
+        ON symbol_fingerprints(normalizer_kind, struct_hash);
+    CREATE TABLE IF NOT EXISTS symbol_token_postings(
+        symbol_id       INTEGER NOT NULL REFERENCES symbols(id) ON DELETE CASCADE,
+        normalizer_kind TEXT    NOT NULL,
+        token_hash      INTEGER NOT NULL,              -- FNV-1a(token) as signed i64
+        freq            INTEGER NOT NULL,
+        PRIMARY KEY (symbol_id, normalizer_kind, token_hash)
+    ) STRICT;
+    CREATE INDEX IF NOT EXISTS idx_symbol_token_postings_inv
+        ON symbol_token_postings(normalizer_kind, token_hash);
+    CREATE TABLE IF NOT EXISTS clone_token_df(
+        normalizer_kind TEXT    NOT NULL,
+        token_hash      INTEGER NOT NULL,
+        df              INTEGER NOT NULL,
+        PRIMARY KEY (normalizer_kind, token_hash)
+    ) STRICT;
+    CREATE TABLE IF NOT EXISTS clone_refinements(
+        class_key               TEXT    PRIMARY KEY,
+        language                TEXT    NOT NULL,
+        refine_mode             TEXT    NOT NULL,        -- baseline | scip
+        template                TEXT    NOT NULL,
+        variation_points_json   TEXT    NOT NULL CHECK (json_valid(variation_points_json)),
+        proposed_signature_json TEXT    NOT NULL CHECK (json_valid(proposed_signature_json)),
+        confidence              TEXT    NOT NULL,
+        anti_unify_coverage     REAL    NOT NULL,
+        lcs_ratio               REAL    NOT NULL,
+        refactorability         REAL    NOT NULL,
+        norm_version            INTEGER NOT NULL,
+        alignment_version       INTEGER NOT NULL,
+        created_at_ms           INTEGER NOT NULL
+    ) STRICT;
+";
+
+pub(crate) fn apply_clone_fingerprint_tables(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(CLONE_FINGERPRINT_DDL)
 }
 
 /// V028 (#224): intern `symbols.qualified_name` + `logical_symbols.qualified_name` into the shared

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1337,6 +1337,14 @@ pub(crate) const CLONE_FINGERPRINT_DDL: &str = "
     ) STRICT;
 ";
 
+/// Migrated-index population gap (#215): V029 only CREATEs the clone tables. Their rows
+/// (`symbol_fingerprints` / `symbol_token_postings` / `clone_token_df`) populate as files are
+/// (re)indexed — there is no backfill here. An existing index migrated forward therefore has
+/// EMPTY clone tables until a `rag-rat index --full`. Incremental discovery only reindexes the
+/// changed files, so `candidate_clone_components` stays empty until a full rebuild fingerprints
+/// the whole corpus. Backfilling at migration time is intentionally NOT done: it would require
+/// parsing the entire repo inside a migration, which migrations must not do. Plan 2's `find_clones`
+/// surface should detect empty clone tables and prompt the user to run a full rebuild.
 pub(crate) fn apply_clone_fingerprint_tables(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(CLONE_FINGERPRINT_DDL)
 }

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1312,8 +1312,9 @@ pub(crate) const CLONE_FINGERPRINT_DDL: &str = "
         freq            INTEGER NOT NULL,
         PRIMARY KEY (symbol_id, normalizer_kind, token_hash)
     ) STRICT;
-    CREATE INDEX IF NOT EXISTS idx_symbol_token_postings_inv
-        ON symbol_token_postings(normalizer_kind, token_hash);
+    -- Plan-1 candidate read loads postings by symbol_id (the PK prefix) and builds the inverted
+    -- index in Rust; a token_hash secondary index is unused. Plan 2 re-adds one if
+    -- clones_for_symbol moves the reverse lookup to SQL.
     CREATE TABLE IF NOT EXISTS clone_token_df(
         normalizer_kind TEXT    NOT NULL,
         token_hash      INTEGER NOT NULL,

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use migrations::*;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 28;
+pub const LATEST_SCHEMA_VERSION: u32 = 29;
 const DIRTY_MIGRATION_ID: &str = "__dirty__";
 const MIGRATION_001_ID: &str = "001_sqlite_storage_baseline";
 const MIGRATION_001_CHECKSUM: &str = "sha256:rag-rat-sqlite-baseline-v1";
@@ -122,6 +122,11 @@ const MIGRATION_028_ID: &str = "028_intern_symbol_qualified_names";
 const MIGRATION_028_CHECKSUM: &str = "sha256:rag-rat-intern-symbol-qualified-names-v28";
 const MIGRATION_028_DESCRIPTION: &str = "Intern symbols/logical_symbols qualified_name into the \
                                          shared name_strings pool, then drop the columns (#224)";
+const MIGRATION_029_ID: &str = "029_clone_fingerprint_tables";
+const MIGRATION_029_CHECKSUM: &str = "sha256:rag-rat-clone-fingerprint-tables-v29";
+const MIGRATION_029_DESCRIPTION: &str = "Add symbol_fingerprints + symbol_token_postings + \
+                                         clone_token_df + clone_refinements for clone detection \
+                                         (#215)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -389,6 +394,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_028_CHECKSUM,
         description: MIGRATION_028_DESCRIPTION,
         apply: apply_intern_symbol_qualified_names,
+    },
+    Migration {
+        id: MIGRATION_029_ID,
+        checksum: MIGRATION_029_CHECKSUM,
+        description: MIGRATION_029_DESCRIPTION,
+        apply: apply_clone_fingerprint_tables,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -10491,13 +10491,12 @@ fn open_under_a_held_write_lock_migrates_older_schema_without_deadlock() {
         let db = IndexDatabase::rebuild(&config).unwrap();
         db.storage
             .connection()
-            .execute("DELETE FROM schema_version WHERE id = '028_intern_symbol_qualified_names'", [
-            ])
+            .execute("DELETE FROM schema_version WHERE id = '029_clone_fingerprint_tables'", [])
             .unwrap();
         assert_eq!(
             schema::status(db.storage.connection()).unwrap().state,
             schema::SchemaState::Older,
-            "removing the V028 ledger row makes the schema Older"
+            "removing the V029 ledger row makes the schema Older"
         );
     }
 
@@ -10522,7 +10521,7 @@ fn v022_fresh_apply_creates_packages_and_dedicated_import_scope_columns() {
     schema::apply(&conn).unwrap();
 
     assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 28);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 29);
     assert!(conn_table_exists(&conn, "packages"), "packages table is created on a fresh apply");
 
     let package_cols = conn_table_columns(&conn, "packages");
@@ -10596,6 +10595,7 @@ fn v022_forward_migrate_adds_artifacts_to_an_older_index() {
         DELETE FROM schema_version WHERE id = '026_contentless_chunk_fts';
         DELETE FROM schema_version WHERE id = '027_drop_chunks_text';
         DELETE FROM schema_version WHERE id = '028_intern_symbol_qualified_names';
+        DELETE FROM schema_version WHERE id = '029_clone_fingerprint_tables';
         ",
     )
     .unwrap();
@@ -10734,13 +10734,16 @@ fn v028_forward_migrate_interns_and_drops_the_inline_column() {
         ",
     )
     .unwrap();
-    // 3. Drop the V028 ledger row so the schema reads Older and the migration replays.
-    conn.execute("DELETE FROM schema_version WHERE id = '028_intern_symbol_qualified_names'", [])
-        .unwrap();
+    // 3. Drop the V028 and V029 ledger rows so the schema reads Older and the migration replays.
+    conn.execute_batch(
+        "DELETE FROM schema_version WHERE id = '028_intern_symbol_qualified_names';
+         DELETE FROM schema_version WHERE id = '029_clone_fingerprint_tables';",
+    )
+    .unwrap();
     assert_eq!(
         schema::status(&conn).unwrap().state,
         schema::SchemaState::Older,
-        "removing the V028 ledger row makes the pre-V028 shape Older"
+        "removing the V028+V029 ledger rows makes the pre-V028 shape Older"
     );
 
     // --- Forward-migrate ---
@@ -12197,6 +12200,259 @@ fn impact_completeness_flags_a_dirty_callee_definition_file() {
         dirty.completeness_and_caveats.stale_files >= 1,
         "the dirty callee definition file must be flagged: {:?}",
         dirty.completeness_and_caveats
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn v029_creates_clone_fingerprint_tables_on_fresh_and_migrated_dbs() {
+    // Fresh DB: apply() must create the SourcererCC postings tables + refinements, and report
+    // Compatible at the latest version. fingerprint_bands must NOT exist (dropped in R1 rework).
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    crate::index::schema::apply(&conn).expect("apply");
+    for table in
+        ["symbol_fingerprints", "symbol_token_postings", "clone_token_df", "clone_refinements"]
+    {
+        let n: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?1",
+                [table],
+                |r| r.get(0),
+            )
+            .expect("query");
+        assert_eq!(n, 1, "{table} should exist after apply()");
+    }
+    // fingerprint_bands was replaced by symbol_token_postings + clone_token_df in R1.
+    let bands: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='fingerprint_bands'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("query bands");
+    assert_eq!(bands, 0, "fingerprint_bands must not exist after R1 rework");
+
+    let status = crate::index::schema::status(&conn).expect("status");
+    assert_eq!(status.current_version, crate::index::schema::LATEST_SCHEMA_VERSION);
+    assert!(matches!(status.state, crate::index::schema::SchemaState::Compatible));
+
+    // Migrated DB: a DB at the prior baseline that runs migrate_forward gains the new tables too.
+    let conn2 = rusqlite::Connection::open_in_memory().expect("open2");
+    crate::index::schema::apply(&conn2).expect("apply2"); // already-latest is a no-op forward
+    crate::index::schema::migrate_forward(&conn2).expect("migrate_forward");
+    let postings: i64 = conn2
+        .query_row(
+            "SELECT count(*) FROM sqlite_master WHERE type='table' AND \
+             name='symbol_token_postings'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("query2");
+    assert_eq!(postings, 1, "symbol_token_postings must exist after migrate_forward");
+    let df: i64 = conn2
+        .query_row(
+            "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='clone_token_df'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("query3");
+    assert_eq!(df, 1, "clone_token_df must exist after migrate_forward");
+}
+
+#[test]
+fn indexing_writes_baseline_fingerprints_for_functions() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    // Two near-identical functions (renamed) + one trivial one that must be skipped.
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\npub fn \
+         load_order(store: Db) -> i32 { let o = store.get(20); validate(o); o + 1 }\npub fn \
+         tiny() -> i32 { 0 }\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let conn = db.storage.connection();
+    let fps: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM symbol_fingerprints WHERE normalizer_kind='baseline'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(fps, 2, "the two functions are fingerprinted; tiny() is below MIN_TOKENS");
+
+    // The inverted index carries postings for exactly the two fingerprinted symbols (R3).
+    let posting_symbols: i64 = conn
+        .query_row(
+            "SELECT count(DISTINCT symbol_id) FROM symbol_token_postings WHERE \
+             normalizer_kind='baseline'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        posting_symbols, 2,
+        "both fingerprinted functions get postings rows; tiny() does not"
+    );
+
+    // df is populated from the postings.
+    let df_rows: i64 =
+        conn.query_row("SELECT count(*) FROM clone_token_df", [], |r| r.get(0)).unwrap();
+    assert!(df_rows > 0, "clone_token_df is populated during indexing");
+
+    // The two functions are renamed clones, so they share tokens — at least one token's df >= 2.
+    let max_df: i64 = conn
+        .query_row(
+            "SELECT COALESCE(MAX(df), 0) FROM clone_token_df WHERE normalizer_kind='baseline'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(max_df >= 2, "a token shared by both clones has df >= 2, got {max_df}");
+
+    // Cascade: deleting a symbol drops its fingerprint AND postings rows (FK + reindex freshness).
+    conn.execute("DELETE FROM symbols", []).unwrap();
+    let after_fps: i64 =
+        conn.query_row("SELECT count(*) FROM symbol_fingerprints", [], |r| r.get(0)).unwrap();
+    assert_eq!(after_fps, 0, "fingerprints cascade on symbol delete");
+    let after_postings: i64 =
+        conn.query_row("SELECT count(*) FROM symbol_token_postings", [], |r| r.get(0)).unwrap();
+    assert_eq!(after_postings, 0, "postings cascade on symbol delete");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn candidate_components_group_renamed_clones_and_exclude_unrelated() {
+    let root = unique_temp_root();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(
+        root.join("src/a.rs"),
+        "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("src/b.rs"),
+        "pub fn load_order(store: Db) -> i32 { let o = store.get(20); validate(o); o + 1 }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("src/c.rs"),
+        "pub fn parse_config(raw: String) -> Vec<u8> { let mut v = Vec::new(); for b in \
+         raw.bytes() { v.push(b ^ 7); } v }\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let components = db.candidate_clone_components().expect("components");
+    // Exactly one component: the two renamed clones (a.rs + b.rs). parse_config in c.rs is
+    // structurally unrelated and must not join the component.
+    assert_eq!(components.len(), 1, "exactly one clone component: {components:?}");
+    assert_eq!(components[0].len(), 2, "the component is the two renamed clones: {components:?}");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+/// Adversarial containment (design rev-4 §8): a small function A whose entire token bag is
+/// contained inside a much larger function B (A's body pasted into B amid other statements).
+/// containment = overlap/min ≈ 1.0, but similarity = overlap/max ≈ 0.1 < THETA, so A and B are NOT
+/// a whole-symbol clone — they must not land in a common component. (The size prune `min_len >=
+/// ceil(THETA*max_len)` already excludes this pair before the exact verify.)
+#[test]
+fn candidate_components_reject_small_function_contained_in_large_one() {
+    let root = unique_temp_root();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    // A: a ~20-token real Rust function.
+    let a_body = "let mut acc = 0; let p = compute(seed); acc += p; for q in items.iter() { acc \
+                  += transform(q); } acc";
+    std::fs::write(
+        root.join("src/a.rs"),
+        format!("pub fn small(seed: i32, items: Vec<i32>) -> i32 {{ {a_body} }}\n"),
+    )
+    .unwrap();
+    // B: a ~200-token function that CONTAINS all of A's tokens (A's body pasted in) amid ~10x more
+    // distinct statements, so B's token_len is roughly 10x A's. overlap/min(A) ≈ 1.0 but
+    // overlap/max(B) ≈ 0.1.
+    let mut filler = String::new();
+    for i in 0..40 {
+        filler.push_str(&format!(
+            "let v{i} = step{i}(base{i}, factor{i}) + delta{i}; total += v{i} * weight{i} - \
+             offset{i};\n"
+        ));
+    }
+    std::fs::write(
+        root.join("src/b.rs"),
+        format!(
+            "pub fn big(seed: i32, items: Vec<i32>, base: i32) -> i32 {{ let mut total = base; \
+             {filler} {a_body}; total += acc; total }}\n"
+        ),
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    // Sanity: both functions cleared MIN_TOKENS (so both are fingerprinted) and B is ~10x A.
+    let conn = db.storage.connection();
+    let lens: Vec<i64> = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT token_len FROM symbol_fingerprints WHERE normalizer_kind='baseline' ORDER \
+                 BY token_len",
+            )
+            .unwrap();
+        stmt.query_map([], |r| r.get(0)).unwrap().collect::<Result<_, _>>().unwrap()
+    };
+    assert_eq!(lens.len(), 2, "both functions are fingerprinted: {lens:?}");
+    assert!(
+        lens[1] >= 5 * lens[0],
+        "B is much larger than A so overlap/max stays below THETA: {lens:?}"
+    );
+
+    let components = db.candidate_clone_components().expect("components");
+    assert!(
+        components.is_empty(),
+        "a small function contained in a large one is NOT a whole-symbol clone: {components:?}"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+/// df is a selectivity hint only (design rev-4 §2, §8): emptying `clone_token_df` must NOT change
+/// the components found. The deterministic token order falls back to `token_hash` via LEFT JOIN +
+/// COALESCE, so no candidate is dropped — only the prefix prune loosens. Uses the
+/// two-renamed-clones fixture.
+#[test]
+fn candidate_components_unchanged_when_clone_token_df_is_empty() {
+    let root = unique_temp_root();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(
+        root.join("src/a.rs"),
+        "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("src/b.rs"),
+        "pub fn load_order(store: Db) -> i32 { let o = store.get(20); validate(o); o + 1 }\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let before = db.candidate_clone_components().expect("components before df delete");
+    assert_eq!(before.len(), 1, "baseline: one clone component: {before:?}");
+
+    db.storage.connection().execute("DELETE FROM clone_token_df", []).unwrap();
+
+    let after = db.candidate_clone_components().expect("components after df delete");
+    assert_eq!(
+        before, after,
+        "df is selectivity-only: emptying clone_token_df must not change components"
     );
 
     fs::remove_dir_all(root).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -12457,3 +12457,68 @@ fn candidate_components_unchanged_when_clone_token_df_is_empty() {
 
     fs::remove_dir_all(root).unwrap();
 }
+
+/// The `files.generated = 0` predicate is a READ-SIDE filter: generated files are still
+/// fingerprinted on write but their symbols must not appear in clone components. This test proves
+/// the filter is doing the exclusion (not a missing fingerprint row).
+#[test]
+fn candidate_components_exclude_generated_files_via_read_filter() {
+    let root = unique_temp_root();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    // Two renamed clones — same fixture as
+    // candidate_components_group_renamed_clones_and_exclude_unrelated.
+    std::fs::write(
+        root.join("src/a.rs"),
+        "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("src/b.rs"),
+        "pub fn load_order(store: Db) -> i32 { let o = store.get(20); validate(o); o + 1 }\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    // Baseline: both files non-generated — one clone component of 2.
+    let before = db.candidate_clone_components().expect("components before marking generated");
+    assert_eq!(before.len(), 1, "baseline: one clone component: {before:?}");
+    assert_eq!(before[0].len(), 2, "baseline component has 2 members: {before:?}");
+
+    // Mark b.rs as generated in the REAL base table (`temp.files` is a view; can't UPDATE it).
+    // This tests that the `files.generated = 0` predicate in the read query does the exclusion;
+    // the write rows (fingerprints/postings) are left intact to prove it's a read-side filter.
+    let conn = db.storage.connection();
+    let updated = conn
+        .execute("UPDATE main.files SET generated = 1 WHERE path LIKE '%b.rs'", [])
+        .unwrap();
+    assert_eq!(updated, 1, "exactly one file row marked generated");
+
+    // b.rs's symbols MUST still have fingerprint rows (proves it's the read filter, not a missing
+    // row).
+    let fp_count: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM symbol_fingerprints sf
+             JOIN symbols ON symbols.id = sf.symbol_id
+             JOIN main.files ON main.files.id = symbols.file_id
+             WHERE main.files.path LIKE '%b.rs' AND sf.normalizer_kind = 'baseline'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(fp_count > 0, "b.rs still has fingerprint rows after marking generated: {fp_count}");
+
+    // After marking b.rs generated the read filter must drop it — no component pairs a with b.
+    let after = db.candidate_clone_components().expect("components after marking generated");
+    let has_b_pair = after.iter().any(|component| {
+        // Any component that contained b.rs's symbol alongside a.rs's symbol would be size >= 2.
+        // Since b.rs is the only partner for a.rs, if a.rs has no partner the component is gone.
+        component.len() >= 2
+    });
+    assert!(
+        !has_b_pair,
+        "generated b.rs must be excluded from clone components by the read filter: {after:?}"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -12489,9 +12489,8 @@ fn candidate_components_exclude_generated_files_via_read_filter() {
     // This tests that the `files.generated = 0` predicate in the read query does the exclusion;
     // the write rows (fingerprints/postings) are left intact to prove it's a read-side filter.
     let conn = db.storage.connection();
-    let updated = conn
-        .execute("UPDATE main.files SET generated = 1 WHERE path LIKE '%b.rs'", [])
-        .unwrap();
+    let updated =
+        conn.execute("UPDATE main.files SET generated = 1 WHERE path LIKE '%b.rs'", []).unwrap();
     assert_eq!(updated, 1, "exactly one file row marked generated");
 
     // b.rs's symbols MUST still have fingerprint rows (proves it's the read filter, not a missing


### PR DESCRIPTION
Plan 1 of #215 — the **clone-detection fingerprint substrate**, using a SourcererCC-style normalized-token inverted index. Foundation only; the query surface, SCIP secondary fingerprint, and anti-unification refinement are Plans 2–4.

## What this adds (`index/clones/`)
- **`normalize_baseline`** — per-symbol AST walk → normalized token sequence (identifiers alpha-renamed by first occurrence, literals bucketed by category, structure kept verbatim) so renamed/Type-2 clones collapse to one shape.
- **`tokens`** — FNV-1a **token bag** (`token_hash → freq` multiset) + **`struct_hash`** (the exact Type-1/2 fast path); both deterministic and machine-stable.
- **`store_symbol_fingerprints`** — writes `symbol_fingerprints` + the `symbol_token_postings` inverted index + bumps `clone_token_df`, on both the incremental/heal and full-rebuild paths (the full rebuild refreshes df authoritatively).
- **`candidate_clone_components`** — the SourcererCC candidate read: `struct_hash` fast path, a rarest-token **sub-block filter** over a deterministic `(df, token_hash)` order, and an **exact max-denominator overlap verify** (`overlap / max_len ≥ θ`), then union-find — all over the scoped `files` view.

**Schema** (V029, additive, STRICT): `symbol_fingerprints`, `symbol_token_postings`, `clone_token_df`, `clone_refinements`.

## Invariants
- **Scope-independence** — fingerprints/postings key by `symbol_id` (FK `ON DELETE CASCADE`), no scope columns; clustering is the only scope-dependent step (query-time over the scoped `files` view). Avoids the per-scope cache leak the importance cache had to work around.
- **Baseline-only recall** — only baseline-normalizer postings drive candidate recall, so it never depends on oracle/SCIP coverage; SCIP is a later secondary signal.
- **df is selectivity-only** — admissibility comes from the shared deterministic token order + exact verify, never df accuracy; a missing/stale df can only slow candidate generation, never miss a clone.
- **Max-denominator gate** — `overlap/max` (not `overlap/min`, which is containment) keeps a small helper contained in a large function from being a false whole-symbol clone.

## Tests
655/655 (`cargo nextest run -p rag-rat-core`). Coverage: renamed-clone matching, literal bucketing, deterministic token bags, FK-cascade reindex freshness, scope-correct components, the containment-rejection adversarial case (20-token body inside a 200-token one is **not** a clone), and df-empty recall parity.

## Design lineage
Inspired by SourcererCC (token-bag candidate generation), NiCad (normalized near-miss framing), GumTree (move-aware AST diff, for the Plan-4 refinement), anti-unification / least-general generalization (template extraction), and CP-Miner (planned fragment-level mining + copy-paste-bug heuristics). See the README "Prior art" section.

## Follow-up (non-blocking)
#230 — the full-rebuild path re-reads + re-parses the file to fingerprint; move it into the prepare phase (drops the redundant work + a narrow TOCTOU).
