### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.8.0...rag-rat-core-v0.9.0) - 2026-06-24
+
+### Added
+
+- *(clones)* name why a resolved symbol is clone-ineligible (#274 item 3a) ([#300](https://github.com/cq27-dev/rag-rat/pull/300))
+- *(clones)* exclude tests from the write-time clone check + raise its precision ([#292](https://github.com/cq27-dev/rag-rat/pull/292)) ([#293](https://github.com/cq27-dev/rag-rat/pull/293))
+- *(doctor)* flag stale clone fingerprints + stop listing migrations twice ([#291](https://github.com/cq27-dev/rag-rat/pull/291))
+- *(clones)* write-time clone check — warn agents when they're duplicating existing code ([#287](https://github.com/cq27-dev/rag-rat/pull/287)) ([#289](https://github.com/cq27-dev/rag-rat/pull/289))
+- *(clones)* precompute the clone-edge graph in the background so find_clones scales ([#286](https://github.com/cq27-dev/rag-rat/pull/286)) ([#288](https://github.com/cq27-dev/rag-rat/pull/288))
+- *(clones)* global cross-class refine cell budget ([#272](https://github.com/cq27-dev/rag-rat/pull/272)) ([#281](https://github.com/cq27-dev/rag-rat/pull/281))
+- *(clones)* clone measurement infrastructure — perf microbench + recall signature ([#279](https://github.com/cq27-dev/rag-rat/pull/279)) ([#280](https://github.com/cq27-dev/rag-rat/pull/280))
+- *(dream)* deterministic memory-maintenance worklist v1 ([#122](https://github.com/cq27-dev/rag-rat/pull/122)) ([#260](https://github.com/cq27-dev/rag-rat/pull/260))
+- *(clones)* multi-language correctness — comments, literals, TS function-valued declarators, generated-skip ([#232](https://github.com/cq27-dev/rag-rat/pull/232)) ([#252](https://github.com/cq27-dev/rag-rat/pull/252))
+- *(clones)* anti-unification refine engine — template + variation points + signature + clones --explain (#215 Plan 4b) ([#243](https://github.com/cq27-dev/rag-rat/pull/243))
+- cross-platform support — macOS + Windows ([#244](https://github.com/cq27-dev/rag-rat/pull/244))
+- clone refine 4a — coherence split + LCS confidence + refactorability ROI + cache (#215 Plan 4a) ([#236](https://github.com/cq27-dev/rag-rat/pull/236))
+- clone-detection query surface — find_clones + clones_for_symbol (#215 Plan 2) ([#234](https://github.com/cq27-dev/rag-rat/pull/234))
+- *(index)* clone-detection fingerprint substrate — SourcererCC inverted index ([#215](https://github.com/cq27-dev/rag-rat/pull/215)) ([#229](https://github.com/cq27-dev/rag-rat/pull/229))
+
+### Fixed
+
+- *(clones)* drop stale theta arg from coherence_split's #259 budget test — unbreak main ([#301](https://github.com/cq27-dev/rag-rat/pull/301))
+- *(clones)* dampen un-refined member_count factor so refine-failed classes can't masquerade as high-ROI ([#259](https://github.com/cq27-dev/rag-rat/pull/259)) ([#299](https://github.com/cq27-dev/rag-rat/pull/299))
+- *(clones)* covering-subset for coherence_split's budget-tripped tail ([#282](https://github.com/cq27-dev/rag-rat/pull/282)) ([#283](https://github.com/cq27-dev/rag-rat/pull/283))
+- *(clones)* close Kotlin boolean/null + C/C++ char-value normalize recall gaps ([#253](https://github.com/cq27-dev/rag-rat/pull/253)) ([#278](https://github.com/cq27-dev/rag-rat/pull/278))
+- *(clones)* Typedness::Structural for pure-closure signatures (#274 item 10) ([#277](https://github.com/cq27-dev/rag-rat/pull/277))
+- *(clones)* widen string-hole template cosmetics (#254, #274 item 16) ([#276](https://github.com/cq27-dev/rag-rat/pull/276))
+- *(clones)* close two #235 follow-ups — discriminator test + scoped callee reopen ([#273](https://github.com/cq27-dev/rag-rat/pull/273))
+- *(clones)* #256 follow-ups — de-flake dense-clique test + seed split by similarity (R-A) ([#265](https://github.com/cq27-dev/rag-rat/pull/265))
+- *(clones)* split giant over-merged components + coverage-gated ROI ([#256](https://github.com/cq27-dev/rag-rat/pull/256)) ([#257](https://github.com/cq27-dev/rag-rat/pull/257))
+- *(oracle)* edge_oracle survives reindex (content-anchored verdicts) + enforcing regression guards ([#248](https://github.com/cq27-dev/rag-rat/pull/248)) ([#249](https://github.com/cq27-dev/rag-rat/pull/249))
+
+### Other
+
+- *(clones)* coherence_split GROW checks pre-verified edge adjacency, not recomputed similarity ([#258](https://github.com/cq27-dev/rag-rat/pull/258)) ([#298](https://github.com/cq27-dev/rag-rat/pull/298))
+- *(clones)* cap non-discriminating hot-token postings in candidate generation ([#271](https://github.com/cq27-dev/rag-rat/pull/271)) ([#297](https://github.com/cq27-dev/rag-rat/pull/297))
+- *(clones)* consolidate the three test-path detectors into one canonical helper ([#294](https://github.com/cq27-dev/rag-rat/pull/294)) ([#295](https://github.com/cq27-dev/rag-rat/pull/295))
+- *(status)* db.status no longer runs the per-chunk embedding reconcile plan (~200s → ms) ([#285](https://github.com/cq27-dev/rag-rat/pull/285))
+- *(clones)* parallelize candidate-gen (sub_block 3.8×) + uncapped --recall-symbols (#282 follow-ups) ([#284](https://github.com/cq27-dev/rag-rat/pull/284))
+- code sweep — clone/god-module cleanup + ship #251/#220/#267/#222 ([#268](https://github.com/cq27-dev/rag-rat/pull/268))
+- *(clones)* total_cmp seed sort + document greedy cover seed-order dependence (#256 adversary polish) ([#266](https://github.com/cq27-dev/rag-rat/pull/266))
+- *(clones)* BLOB-pack the token bag — drop per-token symbol_token_postings ([#231](https://github.com/cq27-dev/rag-rat/pull/231)) ([#250](https://github.com/cq27-dev/rag-rat/pull/250))
+
 ## [0.8.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.7.0...rag-rat-core-v0.8.0) - 2026-06-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3151,7 +3151,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rag-rat"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3168,7 +3168,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-mcp"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "3"
 # and the internal path deps below pin the same literal, so the three crates always publish in
 # lockstep. Bump this one line (and the two internal-dep `version`s under workspace.dependencies)
 # to release.
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Kristaps Karlsons"]
 edition = "2024"
 # Bundled SQLite (rusqlite `bundled` -> libsqlite3-sys 0.38.1) compiles a build script that uses the
@@ -28,8 +28,8 @@ categories = ["command-line-utilities", "development-tools"]
 # Internal crates — declared once here so the version requirement is set in lockstep with
 # [workspace.package].version above. Members reference these via `{ workspace = true }` and add
 # their own feature toggles at the use site.
-rag-rat-core = { version = "0.8.0", path = "crates/rag-rat-core", default-features = false }
-rag-rat-mcp = { version = "0.8.0", path = "crates/rag-rat-mcp", default-features = false }
+rag-rat-core = { version = "0.9.0", path = "crates/rag-rat-core", default-features = false }
+rag-rat-mcp = { version = "0.9.0", path = "crates/rag-rat-mcp", default-features = false }
 anyhow = "1.0"
 fastembed = { version = "5.17.2", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
 gix = { version = "0.84.0", default-features = false, features = ["status", "parallel", "sha1", "sha256", "revision", "blob-diff", "blame"] }


### PR DESCRIPTION



## 🤖 New release

* `rag-rat-core`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)
* `rag-rat-mcp`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)
* `rag-rat`: 0.8.0 -> 0.9.0

### ⚠ `rag-rat-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Symbol.is_test in /tmp/.tmpkyl9M7/rag-rat/crates/rag-rat-core/src/index/symbols.rs:28
  field ParsedSymbol.is_test in /tmp/.tmpkyl9M7/rag-rat/crates/rag-rat-core/src/index/parser.rs:187
```

### ⚠ `rag-rat-mcp` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  RagRatService::semantic_search_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:98
  RagRatService::symbol_lookup_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:110
  RagRatService::find_callers_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:121
  RagRatService::trace_callees_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:132
  RagRatService::compare_graph_to_text_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:143
  RagRatService::compare_graph_to_scip_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:155
  RagRatService::impact_surface_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:167
  RagRatService::repo_brief_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:179
  RagRatService::repo_clusters_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:191
  RagRatService::important_symbols_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:203
  RagRatService::ffi_surface_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:215
  RagRatService::docs_for_symbol_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:226
  RagRatService::read_chunk_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:234
  RagRatService::commit_search_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:245
  RagRatService::git_history_for_path_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:256
  RagRatService::git_history_for_symbol_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:267
  RagRatService::commits_touching_query_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:278
  RagRatService::git_blame_chunk_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:289
  RagRatService::papertrail_for_chunk_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:300
  RagRatService::papertrail_for_symbol_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:311
  RagRatService::papertrail_for_commit_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:322
  RagRatService::github_issue_search_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:333
  RagRatService::github_refs_for_path_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:341
  RagRatService::rationale_search_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:352
  RagRatService::local_ai_status_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:360
  RagRatService::heal_index_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:371
  RagRatService::github_sync_status_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:382
  RagRatService::index_status_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:393
  RagRatService::memory_create_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:405
  RagRatService::memory_rebind_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:417
  RagRatService::memory_update_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:429
  RagRatService::memory_search_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:440
  RagRatService::memory_for_symbol_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:451
  RagRatService::memory_for_path_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:462
  RagRatService::memory_for_call_path_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:470
  RagRatService::memory_validate_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:481
  RagRatService::memory_doctor_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:492
  RagRatService::memory_mark_obsolete_tool_attr, previously in file /tmp/.tmpcfwc6e/rag-rat-mcp/src/server.rs:505
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rag-rat-core`

<blockquote>

## [0.9.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.8.0...rag-rat-core-v0.9.0) - 2026-06-24

### Added

- *(clones)* name why a resolved symbol is clone-ineligible (#274 item 3a) ([#300](https://github.com/cq27-dev/rag-rat/pull/300))
- *(clones)* exclude tests from the write-time clone check + raise its precision ([#292](https://github.com/cq27-dev/rag-rat/pull/292)) ([#293](https://github.com/cq27-dev/rag-rat/pull/293))
- *(doctor)* flag stale clone fingerprints + stop listing migrations twice ([#291](https://github.com/cq27-dev/rag-rat/pull/291))
- *(clones)* write-time clone check — warn agents when they're duplicating existing code ([#287](https://github.com/cq27-dev/rag-rat/pull/287)) ([#289](https://github.com/cq27-dev/rag-rat/pull/289))
- *(clones)* precompute the clone-edge graph in the background so find_clones scales ([#286](https://github.com/cq27-dev/rag-rat/pull/286)) ([#288](https://github.com/cq27-dev/rag-rat/pull/288))
- *(clones)* global cross-class refine cell budget ([#272](https://github.com/cq27-dev/rag-rat/pull/272)) ([#281](https://github.com/cq27-dev/rag-rat/pull/281))
- *(clones)* clone measurement infrastructure — perf microbench + recall signature ([#279](https://github.com/cq27-dev/rag-rat/pull/279)) ([#280](https://github.com/cq27-dev/rag-rat/pull/280))
- *(dream)* deterministic memory-maintenance worklist v1 ([#122](https://github.com/cq27-dev/rag-rat/pull/122)) ([#260](https://github.com/cq27-dev/rag-rat/pull/260))
- *(clones)* multi-language correctness — comments, literals, TS function-valued declarators, generated-skip ([#232](https://github.com/cq27-dev/rag-rat/pull/232)) ([#252](https://github.com/cq27-dev/rag-rat/pull/252))
- *(clones)* anti-unification refine engine — template + variation points + signature + clones --explain (#215 Plan 4b) ([#243](https://github.com/cq27-dev/rag-rat/pull/243))
- cross-platform support — macOS + Windows ([#244](https://github.com/cq27-dev/rag-rat/pull/244))
- clone refine 4a — coherence split + LCS confidence + refactorability ROI + cache (#215 Plan 4a) ([#236](https://github.com/cq27-dev/rag-rat/pull/236))
- clone-detection query surface — find_clones + clones_for_symbol (#215 Plan 2) ([#234](https://github.com/cq27-dev/rag-rat/pull/234))
- *(index)* clone-detection fingerprint substrate — SourcererCC inverted index ([#215](https://github.com/cq27-dev/rag-rat/pull/215)) ([#229](https://github.com/cq27-dev/rag-rat/pull/229))

### Fixed

- *(clones)* drop stale theta arg from coherence_split's #259 budget test — unbreak main ([#301](https://github.com/cq27-dev/rag-rat/pull/301))
- *(clones)* dampen un-refined member_count factor so refine-failed classes can't masquerade as high-ROI ([#259](https://github.com/cq27-dev/rag-rat/pull/259)) ([#299](https://github.com/cq27-dev/rag-rat/pull/299))
- *(clones)* covering-subset for coherence_split's budget-tripped tail ([#282](https://github.com/cq27-dev/rag-rat/pull/282)) ([#283](https://github.com/cq27-dev/rag-rat/pull/283))
- *(clones)* close Kotlin boolean/null + C/C++ char-value normalize recall gaps ([#253](https://github.com/cq27-dev/rag-rat/pull/253)) ([#278](https://github.com/cq27-dev/rag-rat/pull/278))
- *(clones)* Typedness::Structural for pure-closure signatures (#274 item 10) ([#277](https://github.com/cq27-dev/rag-rat/pull/277))
- *(clones)* widen string-hole template cosmetics (#254, #274 item 16) ([#276](https://github.com/cq27-dev/rag-rat/pull/276))
- *(clones)* close two #235 follow-ups — discriminator test + scoped callee reopen ([#273](https://github.com/cq27-dev/rag-rat/pull/273))
- *(clones)* #256 follow-ups — de-flake dense-clique test + seed split by similarity (R-A) ([#265](https://github.com/cq27-dev/rag-rat/pull/265))
- *(clones)* split giant over-merged components + coverage-gated ROI ([#256](https://github.com/cq27-dev/rag-rat/pull/256)) ([#257](https://github.com/cq27-dev/rag-rat/pull/257))
- *(oracle)* edge_oracle survives reindex (content-anchored verdicts) + enforcing regression guards ([#248](https://github.com/cq27-dev/rag-rat/pull/248)) ([#249](https://github.com/cq27-dev/rag-rat/pull/249))

### Other

- *(clones)* coherence_split GROW checks pre-verified edge adjacency, not recomputed similarity ([#258](https://github.com/cq27-dev/rag-rat/pull/258)) ([#298](https://github.com/cq27-dev/rag-rat/pull/298))
- *(clones)* cap non-discriminating hot-token postings in candidate generation ([#271](https://github.com/cq27-dev/rag-rat/pull/271)) ([#297](https://github.com/cq27-dev/rag-rat/pull/297))
- *(clones)* consolidate the three test-path detectors into one canonical helper ([#294](https://github.com/cq27-dev/rag-rat/pull/294)) ([#295](https://github.com/cq27-dev/rag-rat/pull/295))
- *(status)* db.status no longer runs the per-chunk embedding reconcile plan (~200s → ms) ([#285](https://github.com/cq27-dev/rag-rat/pull/285))
- *(clones)* parallelize candidate-gen (sub_block 3.8×) + uncapped --recall-symbols (#282 follow-ups) ([#284](https://github.com/cq27-dev/rag-rat/pull/284))
- code sweep — clone/god-module cleanup + ship #251/#220/#267/#222 ([#268](https://github.com/cq27-dev/rag-rat/pull/268))
- *(clones)* total_cmp seed sort + document greedy cover seed-order dependence (#256 adversary polish) ([#266](https://github.com/cq27-dev/rag-rat/pull/266))
- *(clones)* BLOB-pack the token bag — drop per-token symbol_token_postings ([#231](https://github.com/cq27-dev/rag-rat/pull/231)) ([#250](https://github.com/cq27-dev/rag-rat/pull/250))
</blockquote>

## `rag-rat-mcp`

<blockquote>

## [0.9.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.8.0...rag-rat-core-v0.9.0) - 2026-06-24

### Added

- *(clones)* name why a resolved symbol is clone-ineligible (#274 item 3a) ([#300](https://github.com/cq27-dev/rag-rat/pull/300))
- *(clones)* exclude tests from the write-time clone check + raise its precision ([#292](https://github.com/cq27-dev/rag-rat/pull/292)) ([#293](https://github.com/cq27-dev/rag-rat/pull/293))
- *(doctor)* flag stale clone fingerprints + stop listing migrations twice ([#291](https://github.com/cq27-dev/rag-rat/pull/291))
- *(clones)* write-time clone check — warn agents when they're duplicating existing code ([#287](https://github.com/cq27-dev/rag-rat/pull/287)) ([#289](https://github.com/cq27-dev/rag-rat/pull/289))
- *(clones)* precompute the clone-edge graph in the background so find_clones scales ([#286](https://github.com/cq27-dev/rag-rat/pull/286)) ([#288](https://github.com/cq27-dev/rag-rat/pull/288))
- *(clones)* global cross-class refine cell budget ([#272](https://github.com/cq27-dev/rag-rat/pull/272)) ([#281](https://github.com/cq27-dev/rag-rat/pull/281))
- *(clones)* clone measurement infrastructure — perf microbench + recall signature ([#279](https://github.com/cq27-dev/rag-rat/pull/279)) ([#280](https://github.com/cq27-dev/rag-rat/pull/280))
- *(dream)* deterministic memory-maintenance worklist v1 ([#122](https://github.com/cq27-dev/rag-rat/pull/122)) ([#260](https://github.com/cq27-dev/rag-rat/pull/260))
- *(clones)* multi-language correctness — comments, literals, TS function-valued declarators, generated-skip ([#232](https://github.com/cq27-dev/rag-rat/pull/232)) ([#252](https://github.com/cq27-dev/rag-rat/pull/252))
- *(clones)* anti-unification refine engine — template + variation points + signature + clones --explain (#215 Plan 4b) ([#243](https://github.com/cq27-dev/rag-rat/pull/243))
- cross-platform support — macOS + Windows ([#244](https://github.com/cq27-dev/rag-rat/pull/244))
- clone refine 4a — coherence split + LCS confidence + refactorability ROI + cache (#215 Plan 4a) ([#236](https://github.com/cq27-dev/rag-rat/pull/236))
- clone-detection query surface — find_clones + clones_for_symbol (#215 Plan 2) ([#234](https://github.com/cq27-dev/rag-rat/pull/234))
- *(index)* clone-detection fingerprint substrate — SourcererCC inverted index ([#215](https://github.com/cq27-dev/rag-rat/pull/215)) ([#229](https://github.com/cq27-dev/rag-rat/pull/229))

### Fixed

- *(clones)* drop stale theta arg from coherence_split's #259 budget test — unbreak main ([#301](https://github.com/cq27-dev/rag-rat/pull/301))
- *(clones)* dampen un-refined member_count factor so refine-failed classes can't masquerade as high-ROI ([#259](https://github.com/cq27-dev/rag-rat/pull/259)) ([#299](https://github.com/cq27-dev/rag-rat/pull/299))
- *(clones)* covering-subset for coherence_split's budget-tripped tail ([#282](https://github.com/cq27-dev/rag-rat/pull/282)) ([#283](https://github.com/cq27-dev/rag-rat/pull/283))
- *(clones)* close Kotlin boolean/null + C/C++ char-value normalize recall gaps ([#253](https://github.com/cq27-dev/rag-rat/pull/253)) ([#278](https://github.com/cq27-dev/rag-rat/pull/278))
- *(clones)* Typedness::Structural for pure-closure signatures (#274 item 10) ([#277](https://github.com/cq27-dev/rag-rat/pull/277))
- *(clones)* widen string-hole template cosmetics (#254, #274 item 16) ([#276](https://github.com/cq27-dev/rag-rat/pull/276))
- *(clones)* close two #235 follow-ups — discriminator test + scoped callee reopen ([#273](https://github.com/cq27-dev/rag-rat/pull/273))
- *(clones)* #256 follow-ups — de-flake dense-clique test + seed split by similarity (R-A) ([#265](https://github.com/cq27-dev/rag-rat/pull/265))
- *(clones)* split giant over-merged components + coverage-gated ROI ([#256](https://github.com/cq27-dev/rag-rat/pull/256)) ([#257](https://github.com/cq27-dev/rag-rat/pull/257))
- *(oracle)* edge_oracle survives reindex (content-anchored verdicts) + enforcing regression guards ([#248](https://github.com/cq27-dev/rag-rat/pull/248)) ([#249](https://github.com/cq27-dev/rag-rat/pull/249))

### Other

- *(clones)* coherence_split GROW checks pre-verified edge adjacency, not recomputed similarity ([#258](https://github.com/cq27-dev/rag-rat/pull/258)) ([#298](https://github.com/cq27-dev/rag-rat/pull/298))
- *(clones)* cap non-discriminating hot-token postings in candidate generation ([#271](https://github.com/cq27-dev/rag-rat/pull/271)) ([#297](https://github.com/cq27-dev/rag-rat/pull/297))
- *(clones)* consolidate the three test-path detectors into one canonical helper ([#294](https://github.com/cq27-dev/rag-rat/pull/294)) ([#295](https://github.com/cq27-dev/rag-rat/pull/295))
- *(status)* db.status no longer runs the per-chunk embedding reconcile plan (~200s → ms) ([#285](https://github.com/cq27-dev/rag-rat/pull/285))
- *(clones)* parallelize candidate-gen (sub_block 3.8×) + uncapped --recall-symbols (#282 follow-ups) ([#284](https://github.com/cq27-dev/rag-rat/pull/284))
- code sweep — clone/god-module cleanup + ship #251/#220/#267/#222 ([#268](https://github.com/cq27-dev/rag-rat/pull/268))
- *(clones)* total_cmp seed sort + document greedy cover seed-order dependence (#256 adversary polish) ([#266](https://github.com/cq27-dev/rag-rat/pull/266))
- *(clones)* BLOB-pack the token bag — drop per-token symbol_token_postings ([#231](https://github.com/cq27-dev/rag-rat/pull/231)) ([#250](https://github.com/cq27-dev/rag-rat/pull/250))
</blockquote>

## `rag-rat`

<blockquote>

## [0.9.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.8.0...rag-rat-core-v0.9.0) - 2026-06-24

### Added

- *(clones)* name why a resolved symbol is clone-ineligible (#274 item 3a) ([#300](https://github.com/cq27-dev/rag-rat/pull/300))
- *(clones)* exclude tests from the write-time clone check + raise its precision ([#292](https://github.com/cq27-dev/rag-rat/pull/292)) ([#293](https://github.com/cq27-dev/rag-rat/pull/293))
- *(doctor)* flag stale clone fingerprints + stop listing migrations twice ([#291](https://github.com/cq27-dev/rag-rat/pull/291))
- *(clones)* write-time clone check — warn agents when they're duplicating existing code ([#287](https://github.com/cq27-dev/rag-rat/pull/287)) ([#289](https://github.com/cq27-dev/rag-rat/pull/289))
- *(clones)* precompute the clone-edge graph in the background so find_clones scales ([#286](https://github.com/cq27-dev/rag-rat/pull/286)) ([#288](https://github.com/cq27-dev/rag-rat/pull/288))
- *(clones)* global cross-class refine cell budget ([#272](https://github.com/cq27-dev/rag-rat/pull/272)) ([#281](https://github.com/cq27-dev/rag-rat/pull/281))
- *(clones)* clone measurement infrastructure — perf microbench + recall signature ([#279](https://github.com/cq27-dev/rag-rat/pull/279)) ([#280](https://github.com/cq27-dev/rag-rat/pull/280))
- *(dream)* deterministic memory-maintenance worklist v1 ([#122](https://github.com/cq27-dev/rag-rat/pull/122)) ([#260](https://github.com/cq27-dev/rag-rat/pull/260))
- *(clones)* multi-language correctness — comments, literals, TS function-valued declarators, generated-skip ([#232](https://github.com/cq27-dev/rag-rat/pull/232)) ([#252](https://github.com/cq27-dev/rag-rat/pull/252))
- *(clones)* anti-unification refine engine — template + variation points + signature + clones --explain (#215 Plan 4b) ([#243](https://github.com/cq27-dev/rag-rat/pull/243))
- cross-platform support — macOS + Windows ([#244](https://github.com/cq27-dev/rag-rat/pull/244))
- clone refine 4a — coherence split + LCS confidence + refactorability ROI + cache (#215 Plan 4a) ([#236](https://github.com/cq27-dev/rag-rat/pull/236))
- clone-detection query surface — find_clones + clones_for_symbol (#215 Plan 2) ([#234](https://github.com/cq27-dev/rag-rat/pull/234))
- *(index)* clone-detection fingerprint substrate — SourcererCC inverted index ([#215](https://github.com/cq27-dev/rag-rat/pull/215)) ([#229](https://github.com/cq27-dev/rag-rat/pull/229))

### Fixed

- *(clones)* drop stale theta arg from coherence_split's #259 budget test — unbreak main ([#301](https://github.com/cq27-dev/rag-rat/pull/301))
- *(clones)* dampen un-refined member_count factor so refine-failed classes can't masquerade as high-ROI ([#259](https://github.com/cq27-dev/rag-rat/pull/259)) ([#299](https://github.com/cq27-dev/rag-rat/pull/299))
- *(clones)* covering-subset for coherence_split's budget-tripped tail ([#282](https://github.com/cq27-dev/rag-rat/pull/282)) ([#283](https://github.com/cq27-dev/rag-rat/pull/283))
- *(clones)* close Kotlin boolean/null + C/C++ char-value normalize recall gaps ([#253](https://github.com/cq27-dev/rag-rat/pull/253)) ([#278](https://github.com/cq27-dev/rag-rat/pull/278))
- *(clones)* Typedness::Structural for pure-closure signatures (#274 item 10) ([#277](https://github.com/cq27-dev/rag-rat/pull/277))
- *(clones)* widen string-hole template cosmetics (#254, #274 item 16) ([#276](https://github.com/cq27-dev/rag-rat/pull/276))
- *(clones)* close two #235 follow-ups — discriminator test + scoped callee reopen ([#273](https://github.com/cq27-dev/rag-rat/pull/273))
- *(clones)* #256 follow-ups — de-flake dense-clique test + seed split by similarity (R-A) ([#265](https://github.com/cq27-dev/rag-rat/pull/265))
- *(clones)* split giant over-merged components + coverage-gated ROI ([#256](https://github.com/cq27-dev/rag-rat/pull/256)) ([#257](https://github.com/cq27-dev/rag-rat/pull/257))
- *(oracle)* edge_oracle survives reindex (content-anchored verdicts) + enforcing regression guards ([#248](https://github.com/cq27-dev/rag-rat/pull/248)) ([#249](https://github.com/cq27-dev/rag-rat/pull/249))

### Other

- *(clones)* coherence_split GROW checks pre-verified edge adjacency, not recomputed similarity ([#258](https://github.com/cq27-dev/rag-rat/pull/258)) ([#298](https://github.com/cq27-dev/rag-rat/pull/298))
- *(clones)* cap non-discriminating hot-token postings in candidate generation ([#271](https://github.com/cq27-dev/rag-rat/pull/271)) ([#297](https://github.com/cq27-dev/rag-rat/pull/297))
- *(clones)* consolidate the three test-path detectors into one canonical helper ([#294](https://github.com/cq27-dev/rag-rat/pull/294)) ([#295](https://github.com/cq27-dev/rag-rat/pull/295))
- *(status)* db.status no longer runs the per-chunk embedding reconcile plan (~200s → ms) ([#285](https://github.com/cq27-dev/rag-rat/pull/285))
- *(clones)* parallelize candidate-gen (sub_block 3.8×) + uncapped --recall-symbols (#282 follow-ups) ([#284](https://github.com/cq27-dev/rag-rat/pull/284))
- code sweep — clone/god-module cleanup + ship #251/#220/#267/#222 ([#268](https://github.com/cq27-dev/rag-rat/pull/268))
- *(clones)* total_cmp seed sort + document greedy cover seed-order dependence (#256 adversary polish) ([#266](https://github.com/cq27-dev/rag-rat/pull/266))
- *(clones)* BLOB-pack the token bag — drop per-token symbol_token_postings ([#231](https://github.com/cq27-dev/rag-rat/pull/231)) ([#250](https://github.com/cq27-dev/rag-rat/pull/250))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).