### PR TITLE
feat: clone refine 4a — coherence split + LCS confidence + refactorability ROI + cache (#215 Plan 4a)

### DIFF
--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -179,13 +179,16 @@ pub(crate) struct ImportantSymbolsArgs {
 
 #[derive(Debug, Args)]
 pub(crate) struct ClonesArgs {
-    /// Minimum pairwise overlap/max_len similarity (default: 0.7 θ threshold).
+    /// Minimum pairwise overlap/max_len similarity. Valid range [0.5, 1.0] (default: 0.7, the θ
+    /// threshold); out-of-range values are rejected.
     #[arg(long)]
     pub min_similarity: Option<f64>,
     /// Minimum number of copies for a class to be returned (default: 2).
     #[arg(long)]
     pub min_copies: Option<usize>,
-    /// Maximum number of clone classes to return, sorted by ROI descending.
+    /// Maximum number of clone classes to return, sorted by ROI descending. A supplied limit is
+    /// capped at the refine budget (currently 50): --limit N returns at most 50 classes, all
+    /// refined. Omit the flag to retrieve all classes (only the top 50 refined).
     #[arg(long)]
     pub limit: Option<usize>,
 }

--- a/crates/rag-rat-core/src/index/clones/mod.rs
+++ b/crates/rag-rat-core/src/index/clones/mod.rs
@@ -7,6 +7,7 @@
 #![allow(dead_code)]
 
 mod normalize;
+pub(crate) mod refine;
 mod tokens;
 
 use tree_sitter::Node;

--- a/crates/rag-rat-core/src/index/clones/mod.rs
+++ b/crates/rag-rat-core/src/index/clones/mod.rs
@@ -15,6 +15,11 @@ use tree_sitter::Node;
 /// Bumped when normalization changes; invalidates fingerprints (and the later refine cache) without
 /// a schema migration.
 pub(crate) const NORM_VERSION: i64 = 1;
+/// Bumped when the LCS alignment / refinement algorithm changes; participates in the content-
+/// addressed `refinement_key` and in the `clone_refinements` cache freshness predicate, so a bump
+/// invalidates every cached refinement without a schema migration (the same discipline as
+/// [`NORM_VERSION`]).
+pub(crate) const ALIGNMENT_VERSION: i64 = 1;
 /// Smallest normalized-token count a symbol must reach to be fingerprinted (skip trivial getters).
 pub(crate) const MIN_TOKENS: usize = 20;
 

--- a/crates/rag-rat-core/src/index/clones/mod.rs
+++ b/crates/rag-rat-core/src/index/clones/mod.rs
@@ -6,9 +6,9 @@
 // They are dead until Plan 3 lands; the rest of the module is live (R4's candidate read uses it).
 #![allow(dead_code)]
 
-mod normalize;
+pub(crate) mod normalize;
 pub(crate) mod refine;
-mod tokens;
+pub(crate) mod tokens;
 
 use tree_sitter::Node;
 

--- a/crates/rag-rat-core/src/index/clones/refine/align.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/align.rs
@@ -85,26 +85,89 @@ pub(crate) fn lcs_align(a: &[String], b: &[String]) -> Alignment {
     Alignment { lcs_len, ops }
 }
 
+/// Cap on the number of members used in the LCS all-pairs loop. With n members, pairs = n*(n-1)/2;
+/// at 64 members that is 2016 pairs, which is a manageable upper bound. When the seqs slice has
+/// more than LCS_MEMBER_SAMPLE members, only the first LCS_MEMBER_SAMPLE are used (the slice is
+/// already in canonical sorted order, so the sample is deterministic). The caller sees
+/// `lcs_sampled = true` when this cap engages.
+const LCS_MEMBER_SAMPLE: usize = 64;
+
+/// Cap on the per-pair DP table dimension. When max(|a|, |b|) exceeds this, the pair's LCS
+/// ratio is replaced by a token-multiset Dice coefficient (2·|a∩b| / (|a|+|b|)) — a cheap
+/// O(n) proxy that avoids allocating the (n+1)*(m+1) usize DP table. The Dice proxy is a
+/// reasonable approximation: it equals the exact LCS ratio when sequences are identical or
+/// disjoint, and is within the same order of magnitude otherwise. The caller sees
+/// `lcs_sampled = true` when this cap engages.
+const LCS_MAX_SEQ_TOKENS: usize = 2000;
+
+/// Token-multiset Dice coefficient: `2·|a∩b| / (|a|+|b|)`. Used as a proxy for the LCS ratio
+/// when either sequence exceeds [`LCS_MAX_SEQ_TOKENS`] tokens — avoids the O(n·m) DP table
+/// for very long sequences at the cost of exactness. O(n+m) via sorted-merge.
+///
+/// Returns `1.0` when both are empty, `0.0` when one is empty and the other is not.
+fn multiset_dice(a: &[String], b: &[String]) -> f64 {
+    let denom = (a.len() + b.len()) as f64;
+    if denom == 0.0 {
+        return 1.0;
+    }
+    // Build sorted vecs (clone to sort — inputs are short due to the cap guard).
+    let mut sa = a.to_vec();
+    let mut sb = b.to_vec();
+    sa.sort_unstable();
+    sb.sort_unstable();
+    // Two-pointer multiset intersection count.
+    let (mut ia, mut ib, mut intersection) = (0usize, 0usize, 0usize);
+    while ia < sa.len() && ib < sb.len() {
+        match sa[ia].cmp(&sb[ib]) {
+            std::cmp::Ordering::Less => ia += 1,
+            std::cmp::Ordering::Greater => ib += 1,
+            std::cmp::Ordering::Equal => {
+                intersection += 1;
+                ia += 1;
+                ib += 1;
+            },
+        }
+    }
+    2.0 * intersection as f64 / denom
+}
+
 /// NiCad-style class fidelity: the **minimum** over all unordered member pairs of
 /// `2 * LCS(a, b) / (|a| + |b|)`.
 ///
-/// Returns `1.0` for a slice with fewer than 2 members (degenerate case) and for any pair of
-/// identical sequences. Returns `0.0` when one sequence is empty and the other is not (edge case:
-/// `2*0 / (0 + m) == 0`). Guards `|a| + |b| == 0` (both empty) → `1.0`.
-pub(crate) fn class_lcs_ratio(seqs: &[Vec<String>]) -> f64 {
+/// Returns `(1.0, false)` for a slice with fewer than 2 members (degenerate case) and for any pair
+/// of identical sequences. Returns `0.0` when one sequence is empty and the other is not (edge
+/// case: `2*0 / (0 + m) == 0`). Guards `|a| + |b| == 0` (both empty) → `1.0`.
+///
+/// The returned `bool` is `lcs_sampled` — `true` when either cost cap engaged: the member-count cap
+/// ([`LCS_MEMBER_SAMPLE`], only the first N members entered the all-pairs loop) or the per-pair
+/// length cap ([`LCS_MAX_SEQ_TOKENS`], a pair fell back to the [`multiset_dice`] proxy instead of
+/// the exact O(n·m) DP). The caller folds this into the class's `metrics_sampled` flag so a
+/// cost-bounded fidelity is distinguishable from an exact one.
+pub(crate) fn class_lcs_ratio(seqs: &[Vec<String>]) -> (f64, bool) {
     if seqs.len() < 2 {
-        return 1.0;
+        return (1.0, false);
     }
 
-    let mut min_ratio = f64::INFINITY;
+    // Member-count cap: use at most LCS_MEMBER_SAMPLE members. The slice is already in canonical
+    // sorted order (by struct_hash then symbol_id), so the first LCS_MEMBER_SAMPLE is a
+    // deterministic, reproducible sample.
+    let sampled_members = seqs.len() > LCS_MEMBER_SAMPLE;
+    let effective = if sampled_members { &seqs[..LCS_MEMBER_SAMPLE] } else { seqs };
 
-    for i in 0..seqs.len() {
-        for j in (i + 1)..seqs.len() {
-            let a = &seqs[i];
-            let b = &seqs[j];
+    let mut min_ratio = f64::INFINITY;
+    let mut sampled_seq = false;
+
+    for i in 0..effective.len() {
+        for j in (i + 1)..effective.len() {
+            let a = &effective[i];
+            let b = &effective[j];
             let denom = (a.len() + b.len()) as f64;
             let ratio = if denom == 0.0 {
                 1.0
+            } else if a.len().max(b.len()) > LCS_MAX_SEQ_TOKENS {
+                // Per-pair length cap: use the Dice proxy instead of the O(n·m) DP.
+                sampled_seq = true;
+                multiset_dice(a, b)
             } else {
                 let lcs = lcs_align(a, b).lcs_len;
                 2.0 * lcs as f64 / denom
@@ -115,7 +178,8 @@ pub(crate) fn class_lcs_ratio(seqs: &[Vec<String>]) -> f64 {
         }
     }
 
-    min_ratio
+    let lcs_sampled = sampled_members || sampled_seq;
+    (if min_ratio == f64::INFINITY { 1.0 } else { min_ratio }, lcs_sampled)
 }
 
 #[cfg(test)]
@@ -139,8 +203,9 @@ mod tests {
             assert_eq!(*op, AlignOp::Match(k, k), "op at position {k} was not Match");
         }
 
-        let ratio = class_lcs_ratio(&[a, b]);
+        let (ratio, sampled) = class_lcs_ratio(&[a, b]);
         assert!((ratio - 1.0).abs() < 1e-12, "expected ratio 1.0 for identical seqs, got {ratio}");
+        assert!(!sampled, "small identical seqs must not engage any cost cap");
     }
 
     /// b = a with a contiguous run of K extra tokens inserted in the middle.
@@ -192,7 +257,7 @@ mod tests {
 
         // Exact ratio check.
         let expected = 2.0 * n as f64 / (n + n + k) as f64;
-        let ratio = class_lcs_ratio(&[base, b]);
+        let (ratio, _sampled) = class_lcs_ratio(&[base, b]);
         assert!((ratio - expected).abs() < 1e-12, "ratio: expected {expected}, got {ratio}");
     }
 
@@ -215,7 +280,7 @@ mod tests {
         assert_eq!(del_count, 1, "expected 1 DelA, got {del_count}");
         assert_eq!(ins_count, 1, "expected 1 InsB, got {ins_count}");
 
-        let ratio = class_lcs_ratio(&[a, b]);
+        let (ratio, _sampled) = class_lcs_ratio(&[a, b]);
         assert!(ratio < 1.0, "ratio should be < 1.0 for a renamed token, got {ratio}");
         // exact: 2*(n-1)/(n+n) = (n-1)/n
         let expected = (n - 1) as f64 / n as f64;
@@ -239,7 +304,7 @@ mod tests {
         // ratio_ac should be < 0.5; ensure it's noticeably less than the average of (1.0 + 1.0 +
         // ratio_ac)/3.
 
-        let class_ratio = class_lcs_ratio(&[a, b, c]);
+        let (class_ratio, _sampled) = class_lcs_ratio(&[a, b, c]);
         assert!(
             (class_ratio - ratio_ac).abs() < 1e-12,
             "class_lcs_ratio ({class_ratio}) should equal the minimum pairwise ratio ({ratio_ac})"
@@ -289,11 +354,11 @@ mod tests {
         let nonempty = strs(&["fn", "foo"]);
 
         // Both empty → 1.0.
-        let ratio_both = class_lcs_ratio(&[empty.clone(), empty.clone()]);
+        let (ratio_both, _) = class_lcs_ratio(&[empty.clone(), empty.clone()]);
         assert!((ratio_both - 1.0).abs() < 1e-12, "both empty: expected 1.0, got {ratio_both}");
 
         // One empty → 0.0.
-        let ratio_one = class_lcs_ratio(&[empty.clone(), nonempty.clone()]);
+        let (ratio_one, _) = class_lcs_ratio(&[empty.clone(), nonempty.clone()]);
         assert!(ratio_one.abs() < 1e-12, "one empty: expected 0.0, got {ratio_one}");
 
         // Verify lcs_align itself doesn't panic.
@@ -305,5 +370,51 @@ mod tests {
         assert_eq!(aln_one.lcs_len, 0);
         let aln_one_rev = lcs_align(&nonempty, &empty);
         assert_eq!(aln_one_rev.lcs_len, 0);
+    }
+
+    /// Fix 1 (#215 Plan 4a): the member-count cap. A class with more than [`LCS_MEMBER_SAMPLE`]
+    /// members uses only the first `LCS_MEMBER_SAMPLE` in the all-pairs loop and reports
+    /// `lcs_sampled = true`. The ratio is still computed over the (identical) sample, so it stays
+    /// `1.0`.
+    #[test]
+    fn class_lcs_ratio_caps_member_count_and_sets_sampled() {
+        // Build LCS_MEMBER_SAMPLE + 1 identical sequences → member-count cap kicks in.
+        let seq: Vec<String> = (0..10).map(|i| format!("tok{i}")).collect();
+        let seqs: Vec<Vec<String>> = (0..=LCS_MEMBER_SAMPLE).map(|_| seq.clone()).collect();
+        assert!(seqs.len() > LCS_MEMBER_SAMPLE);
+        let (ratio, sampled) = class_lcs_ratio(&seqs);
+        assert!((ratio - 1.0).abs() < 1e-12, "identical seqs → ratio 1.0, got {ratio}");
+        assert!(sampled, "member-count cap must set lcs_sampled=true");
+    }
+
+    /// Fix 1 (#215 Plan 4a): the per-pair length cap. A pair whose longer sequence exceeds
+    /// [`LCS_MAX_SEQ_TOKENS`] tokens skips the O(n·m) DP and uses the [`multiset_dice`] proxy,
+    /// reporting `lcs_sampled = true`. For two identical long sequences the Dice proxy is exactly
+    /// `1.0`.
+    #[test]
+    fn class_lcs_ratio_caps_long_seq_and_uses_dice_proxy() {
+        // Two sequences each LCS_MAX_SEQ_TOKENS + 1 tokens long → per-pair length cap kicks in.
+        let long_seq: Vec<String> = (0..=LCS_MAX_SEQ_TOKENS).map(|i| format!("t{i}")).collect();
+        let seqs = vec![long_seq.clone(), long_seq.clone()];
+        let (ratio, sampled) = class_lcs_ratio(&seqs);
+        // Identical long sequences → Dice proxy = 2*n/(2*n) = 1.0.
+        assert!((ratio - 1.0).abs() < 1e-12, "identical long seqs → Dice proxy 1.0, got {ratio}");
+        assert!(sampled, "per-pair length cap must set lcs_sampled=true");
+    }
+
+    /// Fix 1 (#215 Plan 4a): the [`multiset_dice`] proxy itself. Identical → 1.0, disjoint → 0.0,
+    /// half-overlap → `2·|a∩b| / (|a|+|b|)`.
+    #[test]
+    fn multiset_dice_basic() {
+        // Identical → 1.0.
+        let a: Vec<String> = vec!["a".into(), "b".into(), "c".into()];
+        assert!((multiset_dice(&a, &a) - 1.0).abs() < 1e-12);
+        // Disjoint → 0.0.
+        let b: Vec<String> = vec!["x".into(), "y".into()];
+        assert!(multiset_dice(&a, &b).abs() < 1e-12);
+        // Half overlap: a=[a,b,c], b=[b,c,d] → intersection=2, denom=6 → 4/6 ≈ 0.667.
+        let c: Vec<String> = vec!["b".into(), "c".into(), "d".into()];
+        let expected = 4.0 / 6.0;
+        assert!((multiset_dice(&a, &c) - expected).abs() < 1e-9, "got {}", multiset_dice(&a, &c));
     }
 }

--- a/crates/rag-rat-core/src/index/clones/refine/align.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/align.rs
@@ -193,7 +193,11 @@ pub(crate) fn class_lcs_ratio(seqs: &[Vec<String>]) -> (f64, bool) {
     }
 
     let lcs_sampled = sampled_members || sampled_seq;
-    (if min_ratio == f64::INFINITY { 1.0 } else { min_ratio }, lcs_sampled)
+    // SAFETY: the `seqs.len() < 2` early return guarantees `effective.len() >= 2`, so the inner
+    // loop body (i=0, j=1) executes at least once and `min_ratio` is updated from `f64::INFINITY`.
+    // The `f64::INFINITY` fallback is therefore unreachable — assert it in debug, return min_ratio.
+    debug_assert!(min_ratio.is_finite(), "min_ratio must be set: effective.len() >= 2");
+    (min_ratio, lcs_sampled)
 }
 
 #[cfg(test)]

--- a/crates/rag-rat-core/src/index/clones/refine/align.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/align.rs
@@ -1,0 +1,312 @@
+//! LCS alignment of normalized token sequences (#215 Plan 4a Task 3).
+//!
+//! # Tie-break rule (documented)
+//!
+//! The DP backtrace breaks ties deterministically: when `dp[i-1][j] == dp[i][j-1]`, we prefer
+//! **`DelA` (decrement `i`)** over `InsB` (decrement `j`). This means, in a tie, we attribute the
+//! LCS "progress" to advancing through `b` and declare the `a`-token as deleted rather than the
+//! `b`-token as inserted. The rule is arbitrary but fixed — it must not change without bumping
+//! `alignment_version`.
+//!
+//! # NiCad-style `lcs_ratio`
+//!
+//! `2 * LCS(a, b) / (|a| + |b|)` — a Dice coefficient over token sequences, identical to the
+//! similarity measure NiCad uses as `1 - dissimilarity`. `class_lcs_ratio` aggregates per-class as
+//! the **minimum** over all unordered pairs: a single loose member drags the class ratio down,
+//! mirroring Plan-2's min-not-average discipline.
+
+/// One step in an LCS alignment of two token sequences.
+#[allow(dead_code)] // wired by Plan-4a Task 4 / Plan-4b
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AlignOp {
+    /// `a[i] == b[j]` — matched token, kept in both.
+    Match(usize, usize),
+    /// `a[i]` only — deletion from `a` (or equivalently, absent from `b`).
+    DelA(usize),
+    /// `b[j]` only — insertion in `b` (or equivalently, absent from `a`).
+    InsB(usize),
+}
+
+/// The result of aligning two token sequences via LCS.
+#[allow(dead_code)] // wired by Plan-4b (anti-unify consumes ops)
+pub(crate) struct Alignment {
+    /// Length of the longest common subsequence.
+    pub(crate) lcs_len: usize,
+    /// Edit operations in ascending position order (Match/DelA/InsB interleaved).
+    pub(crate) ops: Vec<AlignOp>,
+}
+
+/// Classic LCS dynamic program with a deterministic backtrace.
+///
+/// Tie-break: when `dp[i-1][j] == dp[i][j-1]`, prefer `DelA` (decrement `i`). See module doc.
+#[allow(dead_code)] // wired by Plan-4b
+pub(crate) fn lcs_align(a: &[String], b: &[String]) -> Alignment {
+    let n = a.len();
+    let m = b.len();
+
+    // Build the DP table: dp[i][j] = LCS length of a[..i] and b[..j].
+    // Use a flat Vec<usize> of (n+1)*(m+1) for cache-friendliness.
+    let cols = m + 1;
+    let mut dp = vec![0usize; (n + 1) * cols];
+
+    for i in 1..=n {
+        for j in 1..=m {
+            dp[i * cols + j] = if a[i - 1] == b[j - 1] {
+                dp[(i - 1) * cols + (j - 1)] + 1
+            } else {
+                dp[(i - 1) * cols + j].max(dp[i * cols + (j - 1)])
+            };
+        }
+    }
+
+    let lcs_len = dp[n * cols + m];
+
+    // Backtrace from (n, m) → emit ops in reverse, then reverse at end.
+    let mut ops: Vec<AlignOp> = Vec::with_capacity(n + m);
+    let mut i = n;
+    let mut j = m;
+
+    while i > 0 || j > 0 {
+        if i > 0 && j > 0 && a[i - 1] == b[j - 1] {
+            // Match.
+            ops.push(AlignOp::Match(i - 1, j - 1));
+            i -= 1;
+            j -= 1;
+        } else if j == 0 || (i > 0 && dp[(i - 1) * cols + j] >= dp[i * cols + (j - 1)]) {
+            // Tie-break: prefer DelA (decrement i) when dp[i-1][j] >= dp[i][j-1].
+            // Also taken when j==0 (must consume remaining a tokens as DelA).
+            ops.push(AlignOp::DelA(i - 1));
+            i -= 1;
+        } else {
+            // InsB.
+            ops.push(AlignOp::InsB(j - 1));
+            j -= 1;
+        }
+    }
+
+    ops.reverse();
+    Alignment { lcs_len, ops }
+}
+
+/// NiCad-style class fidelity: the **minimum** over all unordered member pairs of
+/// `2 * LCS(a, b) / (|a| + |b|)`.
+///
+/// Returns `1.0` for a slice with fewer than 2 members (degenerate case) and for any pair of
+/// identical sequences. Returns `0.0` when one sequence is empty and the other is not (edge case:
+/// `2*0 / (0 + m) == 0`). Guards `|a| + |b| == 0` (both empty) → `1.0`.
+pub(crate) fn class_lcs_ratio(seqs: &[Vec<String>]) -> f64 {
+    if seqs.len() < 2 {
+        return 1.0;
+    }
+
+    let mut min_ratio = f64::INFINITY;
+
+    for i in 0..seqs.len() {
+        for j in (i + 1)..seqs.len() {
+            let a = &seqs[i];
+            let b = &seqs[j];
+            let denom = (a.len() + b.len()) as f64;
+            let ratio = if denom == 0.0 {
+                1.0
+            } else {
+                let lcs = lcs_align(a, b).lcs_len;
+                2.0 * lcs as f64 / denom
+            };
+            if ratio < min_ratio {
+                min_ratio = ratio;
+            }
+        }
+    }
+
+    min_ratio
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strs(tokens: &[&str]) -> Vec<String> {
+        tokens.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// Two identical sequences → all Match ops, lcs_len == len, class_lcs_ratio == 1.0.
+    #[test]
+    fn lcs_align_identical_is_all_match() {
+        let a = strs(&["fn", "foo", "(", ")", "{", "x", "}"]);
+        let b = a.clone();
+        let aln = lcs_align(&a, &b);
+
+        assert_eq!(aln.lcs_len, a.len());
+        assert_eq!(aln.ops.len(), a.len());
+        for (k, op) in aln.ops.iter().enumerate() {
+            assert_eq!(*op, AlignOp::Match(k, k), "op at position {k} was not Match");
+        }
+
+        let ratio = class_lcs_ratio(&[a, b]);
+        assert!((ratio - 1.0).abs() < 1e-12, "expected ratio 1.0 for identical seqs, got {ratio}");
+    }
+
+    /// b = a with a contiguous run of K extra tokens inserted in the middle.
+    /// Expected: the ops contain exactly K contiguous InsB ops; the rest are all Match;
+    /// lcs_len == a.len(); ratio == 2*|a| / (|a| + |a|+K).
+    #[test]
+    fn lcs_align_inserted_token_run() {
+        let base = strs(&["fn", "foo", "(", ")", "{", "x", "}"]);
+        let insert = strs(&["let", "y", "=", "1"]);
+        let k = insert.len(); // 4
+        let n = base.len(); // 7
+
+        // Insert the run after index 4 (after "{").
+        let mut b = base[..5].to_vec();
+        b.extend_from_slice(&insert);
+        b.extend_from_slice(&base[5..]);
+
+        let aln = lcs_align(&base, &b);
+
+        assert_eq!(aln.lcs_len, n, "lcs_len should equal |a| == {n}");
+
+        // Count InsB ops — should be exactly K.
+        let ins_b_count = aln.ops.iter().filter(|op| matches!(op, AlignOp::InsB(_))).count();
+        assert_eq!(ins_b_count, k, "expected {k} InsB ops, got {ins_b_count}");
+
+        // All non-InsB ops should be Match.
+        let non_match = aln
+            .ops
+            .iter()
+            .filter(|op| !matches!(op, AlignOp::InsB(_) | AlignOp::Match(_, _)))
+            .count();
+        assert_eq!(non_match, 0, "unexpected non-Match non-InsB ops");
+
+        // Verify the InsB ops are contiguous in the output.
+        let ins_positions: Vec<usize> = aln
+            .ops
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, op)| if matches!(op, AlignOp::InsB(_)) { Some(idx) } else { None })
+            .collect();
+        let first = ins_positions[0];
+        let last = ins_positions[ins_positions.len() - 1];
+        assert_eq!(
+            last - first + 1,
+            k,
+            "InsB ops are not contiguous: positions {:?}",
+            ins_positions
+        );
+
+        // Exact ratio check.
+        let expected = 2.0 * n as f64 / (n + n + k) as f64;
+        let ratio = class_lcs_ratio(&[base, b]);
+        assert!((ratio - expected).abs() < 1e-12, "ratio: expected {expected}, got {ratio}");
+    }
+
+    /// a and b differ at exactly one position (one token renamed).
+    /// Expected: lcs_len == len-1; ratio < 1.0; the differing position appears as a DelA+InsB pair.
+    #[test]
+    fn lcs_align_renamed_tokens_differ() {
+        let a = strs(&["fn", "foo", "(", "x", ")"]);
+        // rename "foo" → "bar"
+        let b = strs(&["fn", "bar", "(", "x", ")"]);
+        let n = a.len();
+
+        let aln = lcs_align(&a, &b);
+
+        assert_eq!(aln.lcs_len, n - 1, "lcs_len should be {} (one token differs)", n - 1);
+
+        // There must be exactly one DelA and one InsB.
+        let del_count = aln.ops.iter().filter(|op| matches!(op, AlignOp::DelA(_))).count();
+        let ins_count = aln.ops.iter().filter(|op| matches!(op, AlignOp::InsB(_))).count();
+        assert_eq!(del_count, 1, "expected 1 DelA, got {del_count}");
+        assert_eq!(ins_count, 1, "expected 1 InsB, got {ins_count}");
+
+        let ratio = class_lcs_ratio(&[a, b]);
+        assert!(ratio < 1.0, "ratio should be < 1.0 for a renamed token, got {ratio}");
+        // exact: 2*(n-1)/(n+n) = (n-1)/n
+        let expected = (n - 1) as f64 / n as f64;
+        assert!((ratio - expected).abs() < 1e-12, "ratio: expected {expected}, got {ratio}");
+    }
+
+    /// 3 seqs: two identical (pair ratio 1.0) + one distant (ratio ~0.5).
+    /// class_lcs_ratio must return the MIN (~0.5), not the average.
+    #[test]
+    fn class_lcs_ratio_is_minimum_not_average() {
+        // a and b are identical (ratio 1.0 between them).
+        let a = strs(&["fn", "foo", "(", ")", "{"]);
+        let b = a.clone();
+
+        // c shares only one token with a/b → ratio near 2*1/(5+5) = 0.2 or 2*k/(5+len_c).
+        // Use a 5-token sequence that shares exactly 1 token with a.
+        let c = strs(&["let", "x", "=", "y", "{"]);
+        // only "{" is in common with a → lcs(a,c)=1, ratio = 2*1/(5+5) = 0.2
+        let aln_ac = lcs_align(&a, &c);
+        let ratio_ac = 2.0 * aln_ac.lcs_len as f64 / (a.len() + c.len()) as f64;
+        // ratio_ac should be < 0.5; ensure it's noticeably less than the average of (1.0 + 1.0 +
+        // ratio_ac)/3.
+
+        let class_ratio = class_lcs_ratio(&[a, b, c]);
+        assert!(
+            (class_ratio - ratio_ac).abs() < 1e-12,
+            "class_lcs_ratio ({class_ratio}) should equal the minimum pairwise ratio ({ratio_ac})"
+        );
+        // Confirm it is indeed the minimum, not the average.
+        let average = (1.0 + ratio_ac + ratio_ac) / 3.0;
+        assert!(
+            class_ratio < average,
+            "class_lcs_ratio ({class_ratio}) should be less than average ({average})"
+        );
+    }
+
+    /// Tie-break pin: a="x y", b="y x". The DP has a classic tie; assert the exact ops produced
+    /// by the documented rule (prefer DelA when dp[i-1][j] >= dp[i][j-1]).
+    #[test]
+    fn lcs_align_deterministic_tiebreak() {
+        // a = ["x", "y"], b = ["y", "x"]
+        // LCS = 1 (either "x" or "y" can be the LCS — the tie-break picks one).
+        // DP table (0-indexed rows=a, cols=b):
+        //       ""  "y"  "x"
+        //   ""   0    0    0
+        //  "x"   0    0    1
+        //  "y"   0    1    1
+        // Backtrace from (2,2): dp[2][2]=1
+        //   a[1]="y" == b[1]="x"? No.
+        //   dp[1][2]=1, dp[2][1]=1 → tie → prefer DelA (i=2→1): emit DelA(1), i=1,j=2.
+        //   a[0]="x" == b[1]="x"? Yes → Match(0,1), i=0,j=1.
+        //   j=1>0, i=0: must InsB. emit InsB(0), j=0.
+        //   Reversed: [InsB(0), Match(0,1), DelA(1)]
+        let a = strs(&["x", "y"]);
+        let b = strs(&["y", "x"]);
+        let aln = lcs_align(&a, &b);
+
+        assert_eq!(aln.lcs_len, 1);
+        assert_eq!(
+            aln.ops,
+            vec![AlignOp::InsB(0), AlignOp::Match(0, 1), AlignOp::DelA(1)],
+            "deterministic tie-break produced unexpected ops: {:?}",
+            aln.ops
+        );
+    }
+
+    /// Both sequences empty → ratio 1.0, no panic. One empty → ratio 0.0.
+    #[test]
+    fn lcs_empty_sequences() {
+        let empty: Vec<String> = vec![];
+        let nonempty = strs(&["fn", "foo"]);
+
+        // Both empty → 1.0.
+        let ratio_both = class_lcs_ratio(&[empty.clone(), empty.clone()]);
+        assert!((ratio_both - 1.0).abs() < 1e-12, "both empty: expected 1.0, got {ratio_both}");
+
+        // One empty → 0.0.
+        let ratio_one = class_lcs_ratio(&[empty.clone(), nonempty.clone()]);
+        assert!(ratio_one.abs() < 1e-12, "one empty: expected 0.0, got {ratio_one}");
+
+        // Verify lcs_align itself doesn't panic.
+        let aln_both = lcs_align(&empty, &empty);
+        assert_eq!(aln_both.lcs_len, 0);
+        assert!(aln_both.ops.is_empty());
+
+        let aln_one = lcs_align(&empty, &nonempty);
+        assert_eq!(aln_one.lcs_len, 0);
+        let aln_one_rev = lcs_align(&nonempty, &empty);
+        assert_eq!(aln_one_rev.lcs_len, 0);
+    }
+}

--- a/crates/rag-rat-core/src/index/clones/refine/align.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/align.rs
@@ -16,7 +16,6 @@
 //! mirroring Plan-2's min-not-average discipline.
 
 /// One step in an LCS alignment of two token sequences.
-#[allow(dead_code)] // wired by Plan-4a Task 4 / Plan-4b
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AlignOp {
     /// `a[i] == b[j]` — matched token, kept in both.
@@ -28,7 +27,6 @@ pub(crate) enum AlignOp {
 }
 
 /// The result of aligning two token sequences via LCS.
-#[allow(dead_code)] // wired by Plan-4b (anti-unify consumes ops)
 pub(crate) struct Alignment {
     /// Length of the longest common subsequence.
     pub(crate) lcs_len: usize,
@@ -39,7 +37,6 @@ pub(crate) struct Alignment {
 /// Classic LCS dynamic program with a deterministic backtrace.
 ///
 /// Tie-break: when `dp[i-1][j] == dp[i][j-1]`, prefer `DelA` (decrement `i`). See module doc.
-#[allow(dead_code)] // wired by Plan-4b
 pub(crate) fn lcs_align(a: &[String], b: &[String]) -> Alignment {
     let n = a.len();
     let m = b.len();

--- a/crates/rag-rat-core/src/index/clones/refine/align.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/align.rs
@@ -90,7 +90,7 @@ pub(crate) fn lcs_align(a: &[String], b: &[String]) -> Alignment {
 /// more than LCS_MEMBER_SAMPLE members, only the first LCS_MEMBER_SAMPLE are used (the slice is
 /// already in canonical sorted order, so the sample is deterministic). The caller sees
 /// `lcs_sampled = true` when this cap engages.
-const LCS_MEMBER_SAMPLE: usize = 64;
+pub(crate) const LCS_MEMBER_SAMPLE: usize = 64;
 
 /// Cap on the per-pair DP table dimension. When max(|a|, |b|) exceeds this, the pair's LCS
 /// ratio is replaced by a token-multiset Dice coefficient (2·|a∩b| / (|a|+|b|)) — a cheap
@@ -110,7 +110,8 @@ fn multiset_dice(a: &[String], b: &[String]) -> f64 {
     if denom == 0.0 {
         return 1.0;
     }
-    // Build sorted vecs (clone to sort — inputs are short due to the cap guard).
+    // Build sorted vecs (clone to sort — inputs are bounded by LCS_MAX_SEQ_TOKENS≈2000, so the O(n
+    // log n) sort is cheap).
     let mut sa = a.to_vec();
     let mut sb = b.to_vec();
     sa.sort_unstable();

--- a/crates/rag-rat-core/src/index/clones/refine/align.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/align.rs
@@ -98,7 +98,17 @@ pub(crate) const LCS_MEMBER_SAMPLE: usize = 64;
 /// reasonable approximation: it equals the exact LCS ratio when sequences are identical or
 /// disjoint, and is within the same order of magnitude otherwise. The caller sees
 /// `lcs_sampled = true` when this cap engages.
-const LCS_MAX_SEQ_TOKENS: usize = 2000;
+pub(crate) const LCS_MAX_SEQ_TOKENS: usize = 2000;
+
+/// Order-blind upper bound, conservatively clamped. The [`multiset_dice`] proxy used past
+/// [`LCS_MAX_SEQ_TOKENS`] is a token-BAG overlap: it ignores token ORDER, so two long functions
+/// with the same normalized token multiset but very different ordering score ~1.0 even though their
+/// true (order-sensitive) LCS ratio is far lower. Dice is therefore an UPPER BOUND on the LCS
+/// ratio, never a lower one. We clamp a proxied pair's ratio to this ceiling — set just BELOW the
+/// `confidence_v1` High threshold of 0.9 — so a class whose fidelity rests on the order-blind proxy
+/// can reach at most Medium confidence and never full refactorability on the strength of a metric
+/// that can't see ordering.
+const DICE_PROXY_CEILING: f64 = 0.85;
 
 /// Token-multiset Dice coefficient: `2·|a∩b| / (|a|+|b|)`. Used as a proxy for the LCS ratio
 /// when either sequence exceeds [`LCS_MAX_SEQ_TOKENS`] tokens — avoids the O(n·m) DP table
@@ -166,9 +176,12 @@ pub(crate) fn class_lcs_ratio(seqs: &[Vec<String>]) -> (f64, bool) {
             let ratio = if denom == 0.0 {
                 1.0
             } else if a.len().max(b.len()) > LCS_MAX_SEQ_TOKENS {
-                // Per-pair length cap: use the Dice proxy instead of the O(n·m) DP.
+                // Per-pair length cap: use the Dice proxy instead of the O(n·m) DP. Dice ignores
+                // token order so it is an UPPER BOUND on the true LCS ratio — clamp to
+                // [`DICE_PROXY_CEILING`] (< the High-confidence threshold) so an order-blind
+                // proxy can't earn a class High confidence / full refactorability.
                 sampled_seq = true;
-                multiset_dice(a, b)
+                multiset_dice(a, b).min(DICE_PROXY_CEILING)
             } else {
                 let lcs = lcs_align(a, b).lcs_len;
                 2.0 * lcs as f64 / denom
@@ -390,17 +403,58 @@ mod tests {
 
     /// Fix 1 (#215 Plan 4a): the per-pair length cap. A pair whose longer sequence exceeds
     /// [`LCS_MAX_SEQ_TOKENS`] tokens skips the O(n·m) DP and uses the [`multiset_dice`] proxy,
-    /// reporting `lcs_sampled = true`. For two identical long sequences the Dice proxy is exactly
-    /// `1.0`.
+    /// reporting `lcs_sampled = true`. Even for two IDENTICAL long sequences (Dice = 1.0) the ratio
+    /// is clamped to [`DICE_PROXY_CEILING`] — the proxy is order-blind, so it can never certify a
+    /// full ratio.
     #[test]
     fn class_lcs_ratio_caps_long_seq_and_uses_dice_proxy() {
         // Two sequences each LCS_MAX_SEQ_TOKENS + 1 tokens long → per-pair length cap kicks in.
         let long_seq: Vec<String> = (0..=LCS_MAX_SEQ_TOKENS).map(|i| format!("t{i}")).collect();
         let seqs = vec![long_seq.clone(), long_seq.clone()];
         let (ratio, sampled) = class_lcs_ratio(&seqs);
-        // Identical long sequences → Dice proxy = 2*n/(2*n) = 1.0.
-        assert!((ratio - 1.0).abs() < 1e-12, "identical long seqs → Dice proxy 1.0, got {ratio}");
+        // Identical long sequences → raw Dice proxy = 1.0, but clamped to the sub-perfect ceiling.
+        assert!(
+            (ratio - DICE_PROXY_CEILING).abs() < 1e-12,
+            "identical long seqs → Dice proxy clamped to {DICE_PROXY_CEILING}, got {ratio}"
+        );
         assert!(sampled, "per-pair length cap must set lcs_sampled=true");
+    }
+
+    /// Fix 1 round-2 (#215 Plan 4a): the order-blind Dice proxy must NOT certify a perfect ratio.
+    /// Two long sequences with the SAME token multiset but REVERSED order have a true LCS ratio far
+    /// below 1.0, yet token-bag Dice scores them ~1.0. `class_lcs_ratio` clamps the proxied pair to
+    /// [`DICE_PROXY_CEILING`], reports `lcs_sampled = true`, and the resulting ratio bands at most
+    /// Medium confidence — never High.
+    #[test]
+    fn class_lcs_ratio_clamps_reversed_order_long_seqs_below_high() {
+        // Build seqs > LCS_MAX_SEQ_TOKENS by repeating a small alphabet, so the multiset is
+        // identical but the order is reversed.
+        let alphabet = ["a", "b", "c", "d", "e"];
+        let forward: Vec<String> =
+            (0..=LCS_MAX_SEQ_TOKENS).map(|i| alphabet[i % alphabet.len()].to_string()).collect();
+        assert!(forward.len() > LCS_MAX_SEQ_TOKENS, "must exceed the per-pair length cap");
+        let reversed: Vec<String> = forward.iter().rev().cloned().collect();
+        // Same multiset (a reversal preserves the bag), different order.
+        {
+            let mut fa = forward.clone();
+            let mut rb = reversed.clone();
+            fa.sort_unstable();
+            rb.sort_unstable();
+            assert_eq!(fa, rb, "reversed seq must have the SAME token multiset");
+        }
+
+        let (ratio, sampled) = class_lcs_ratio(&[forward, reversed]);
+        assert!(sampled, "per-pair length cap must set lcs_sampled=true");
+        assert!(
+            ratio <= DICE_PROXY_CEILING,
+            "order-blind proxy must clamp to ≤ {DICE_PROXY_CEILING}, not ~1.0; got {ratio}"
+        );
+        // Even with a perfect pairwise-similarity floor the clamped ratio cannot reach High.
+        assert_ne!(
+            super::super::score::confidence_v1(ratio, 1.0),
+            super::super::score::Confidence::High,
+            "a Dice-proxied ratio must not band High confidence (ratio {ratio})"
+        );
     }
 
     /// Fix 1 (#215 Plan 4a): the [`multiset_dice`] proxy itself. Identical → 1.0, disjoint → 0.0,

--- a/crates/rag-rat-core/src/index/clones/refine/cache.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/cache.rs
@@ -4,8 +4,15 @@
 //! refine mode, the version pins, and the member `struct_hash` multiset) — NOT from the read-side
 //! `class_key` (which is location-derived: `ref@path:start-end`). Two clone classes with the same
 //! structural content therefore share a refinement even when they live at different locations, and
-//! the key survives a reindex that reassigns rowids. [`refine_class`] is a read-through cache over
-//! the `clone_refinements` table keyed by this content address: compute on miss, persist, return.
+//! the key survives a reindex that reassigns rowids.
+//!
+//! The cache is split into a pure read ([`refine_lookup`], a SELECT — RO-connection-safe) and a
+//! compute-then-write ([`refine_compute_and_store`], the expensive LCS work + INSERT). Keeping them
+//! separate lets the caller probe the cache on a read-only connection WITHOUT triggering the
+//! expensive compute, then surface an `SQLITE_READONLY` error so the MCP dispatcher retries
+//! read-write — the compute runs exactly once, on the writable retry. [`refine_class`] is the
+//! convenience read-through (lookup → compute-and-store) for callers that already hold a writable
+//! connection.
 
 use rusqlite::{Connection, OptionalExtension};
 
@@ -20,7 +27,7 @@ const REFINE_MODE: &str = "baseline";
 /// A computed (or cache-hit) refinement for one clone class. The 4a surface carries only the
 /// scoring outputs; the template / variation-points / proposed-signature are persisted minimally
 /// (4b fills them) and not returned.
-pub(crate) struct Refinement {
+pub(crate) struct CachedRefinement {
     pub(crate) lcs_ratio: f64,
     pub(crate) confidence: Confidence,
     pub(crate) refactorability: f64,
@@ -54,23 +61,15 @@ pub(crate) fn refinement_key(language: &str, struct_hashes: &[String]) -> String
     crate::index::hex_sha256(material.as_bytes())
 }
 
-/// Read-through refinement: return the cached `clone_refinements` row for `refinement_key`
-/// (filtered to the current `NORM_VERSION` / `ALIGNMENT_VERSION` so a stale-version row never
-/// serves), else compute the 4a scores from the member token sequences, persist a minimal row, and
-/// return.
-///
-/// `similarity_min` is the Plan-2 pairwise floor for the class — it feeds the confidence band only,
-/// not the cache key (the key is purely structural). The persisted `template` is a crude LCS
-/// skeleton (4b fills the full anti-unification template + variation points); `anti_unify_coverage`
-/// is the `lcs_ratio` as a 4a proxy.
-pub(crate) fn refine_class(
+/// PURE READ: return the cached `clone_refinements` row for `refinement_key` (filtered to the
+/// current `NORM_VERSION` / `ALIGNMENT_VERSION` so a stale-version row never serves), or `None` on
+/// a cache miss. This is a SELECT only — NO compute, NO write — so it is safe to call on a
+/// read-only connection. Callers that want compute-on-miss decide separately whether the connection
+/// is writable before reaching for [`refine_compute_and_store`].
+pub(crate) fn refine_lookup(
     conn: &Connection,
     refinement_key: &str,
-    language: &str,
-    members: &[RefineMember],
-    similarity_min: f64,
-) -> anyhow::Result<Refinement> {
-    // Cache HIT: a row keyed by this content address at the current version pins.
+) -> anyhow::Result<Option<CachedRefinement>> {
     let hit: Option<(f64, String, f64)> = conn
         .query_row(
             "SELECT lcs_ratio, confidence, refactorability
@@ -80,16 +79,33 @@ pub(crate) fn refine_class(
             |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         )
         .optional()?;
-    if let Some((lcs_ratio, confidence, refactorability)) = hit {
-        return Ok(Refinement {
-            lcs_ratio,
-            confidence: Confidence::from_db_str(&confidence),
-            refactorability,
-            refine_mode: REFINE_MODE,
-        });
-    }
+    Ok(hit.map(|(lcs_ratio, confidence, refactorability)| CachedRefinement {
+        lcs_ratio,
+        confidence: Confidence::from_db_str(&confidence),
+        refactorability,
+        refine_mode: REFINE_MODE,
+    }))
+}
 
-    // Cache MISS: compute the 4a scores from the member token sequences.
+/// COMPUTE + WRITE: compute the 4a scores from the member token sequences, persist a minimal
+/// `clone_refinements` row keyed by `refinement_key`, and return the computed refinement. This is
+/// the expensive half (`class_lcs_ratio` + `lcs_skeleton` + the INSERT) and REQUIRES a writable
+/// connection — call it only after [`refine_lookup`] missed AND the caller confirmed the connection
+/// is read-write (otherwise the INSERT errors with `SQLITE_READONLY`, which is the deliberate
+/// signal the read path uses to retry read-write — see `refine_class_in_place`).
+///
+/// `similarity_min` is the Plan-2 pairwise floor for the class — it feeds the confidence band only,
+/// not the cache key (the key is purely structural). The persisted `template` is a crude LCS
+/// skeleton (4b fills the full anti-unification template + variation points); `anti_unify_coverage`
+/// is the `lcs_ratio` as a 4a proxy.
+pub(crate) fn refine_compute_and_store(
+    conn: &Connection,
+    refinement_key: &str,
+    language: &str,
+    members: &[RefineMember],
+    similarity_min: f64,
+) -> anyhow::Result<CachedRefinement> {
+    // Compute the 4a scores from the member token sequences.
     let seqs: Vec<Vec<String>> = members.iter().map(|m| m.seq.clone()).collect();
     let lcs_ratio = class_lcs_ratio(&seqs);
     let refactorability = refactorability_v1(lcs_ratio);
@@ -123,7 +139,24 @@ pub(crate) fn refine_class(
         ],
     )?;
 
-    Ok(Refinement { lcs_ratio, confidence, refactorability, refine_mode: REFINE_MODE })
+    Ok(CachedRefinement { lcs_ratio, confidence, refactorability, refine_mode: REFINE_MODE })
+}
+
+/// Read-through refinement (writable-connection convenience): [`refine_lookup`] on hit, else
+/// [`refine_compute_and_store`]. Requires a writable connection on a cache miss. The RO-aware read
+/// path (`refine_class_in_place`) calls the two halves directly so it can probe the cache on a
+/// read-only connection and surface `SQLITE_READONLY` BEFORE any expensive compute.
+pub(crate) fn refine_class(
+    conn: &Connection,
+    refinement_key: &str,
+    language: &str,
+    members: &[RefineMember],
+    similarity_min: f64,
+) -> anyhow::Result<CachedRefinement> {
+    if let Some(cached) = refine_lookup(conn, refinement_key)? {
+        return Ok(cached);
+    }
+    refine_compute_and_store(conn, refinement_key, language, members, similarity_min)
 }
 
 /// Crude 4a LCS skeleton: the LCS-common token run of the first member pair (exact for a 2-member
@@ -175,5 +208,77 @@ mod tests {
             ["fn", "f", "(", ")", "{", "}"].iter().map(|s| s.to_string()).collect();
         let seqs = vec![a.clone(), a.clone()];
         assert_eq!(lcs_skeleton(&seqs), a.join(" "));
+    }
+
+    /// [`refine_lookup`] is a PURE READ: a miss returns `None` and writes NOTHING — no
+    /// `clone_refinements` row appears. This is the property that makes the read path safe to run
+    /// on a read-only MCP connection: the cache probe never touches the write lock, so the
+    /// expensive `refine_compute_and_store` (and its INSERT) only runs after the caller has
+    /// confirmed a writable connection.
+    ///
+    /// The read-only-connection RETRY mechanism itself (probe → `BEGIN IMMEDIATE; ROLLBACK;`
+    /// triggering `SQLITE_READONLY` → dispatcher retries read-write → compute runs once) is
+    /// exercised end-to-end by the `refine_cache_is_read_through` integration test in
+    /// `schema_bootstrap_tests.rs`, which drives a real `IndexDatabase`. The unit-level invariant
+    /// here is the load-bearing half: the lookup must not write.
+    #[test]
+    fn refine_lookup_returns_none_on_miss_without_writing() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        crate::index::schema::apply(&conn).unwrap();
+
+        let count_rows = |conn: &rusqlite::Connection| -> i64 {
+            conn.query_row("SELECT COUNT(*) FROM clone_refinements", [], |r| r.get(0)).unwrap()
+        };
+        assert_eq!(count_rows(&conn), 0, "table starts empty");
+
+        let key = refinement_key("rust", &["h1".into(), "h2".into()]);
+        let hit = refine_lookup(&conn, &key).unwrap();
+
+        assert!(hit.is_none(), "a miss must return None");
+        assert_eq!(count_rows(&conn), 0, "refine_lookup must NOT write a row on a miss");
+    }
+
+    /// The writable-connection read-through [`refine_class`]: a miss computes + persists exactly
+    /// one row; a second call over the same key is a cache HIT that serves the persisted row
+    /// WITHOUT growing the count. (The RO-aware split path is `refine_class_in_place`; this
+    /// covers the convenience wrapper directly on a writable in-memory connection.)
+    #[test]
+    fn refine_class_read_through_computes_once_then_serves_cache() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        crate::index::schema::apply(&conn).unwrap();
+
+        let count_rows = |conn: &rusqlite::Connection| -> i64 {
+            conn.query_row("SELECT COUNT(*) FROM clone_refinements", [], |r| r.get(0)).unwrap()
+        };
+
+        // Two identical ordered token sequences ⇒ a clean, near-perfect class.
+        let seq: Vec<String> = ["fn", "f", "(", ")", "{", "g", "(", ")", ";", "}"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let mk = |id: i64| RefineMember {
+            symbol_id: id,
+            lang: crate::language::Language::Rust,
+            path: format!("src/m{id}.rs"),
+            start_byte: 0,
+            end_byte: seq.len(),
+            struct_hash: format!("h{id}"),
+            seq: seq.clone(),
+        };
+        let members = vec![mk(1), mk(2)];
+        let key = refinement_key("rust", &["h1".into(), "h2".into()]);
+
+        // Miss: compute + persist one row.
+        let first = refine_class(&conn, &key, "rust", &members, 1.0).unwrap();
+        assert_eq!(count_rows(&conn), 1, "the miss persists exactly one row");
+        assert!(first.lcs_ratio > 0.99, "identical sequences ⇒ near-perfect lcs_ratio");
+
+        // Hit: same key serves the cache, no new row.
+        let second = refine_class(&conn, &key, "rust", &members, 1.0).unwrap();
+        assert_eq!(count_rows(&conn), 1, "the hit must NOT grow the row count");
+        assert_eq!(
+            first.confidence, second.confidence,
+            "the cache-served refinement matches the computed one"
+        );
     }
 }

--- a/crates/rag-rat-core/src/index/clones/refine/cache.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/cache.rs
@@ -16,7 +16,7 @@
 
 use rusqlite::{Connection, OptionalExtension};
 
-use super::align::{class_lcs_ratio, lcs_align};
+use super::align::{LCS_MAX_SEQ_TOKENS, class_lcs_ratio, lcs_align};
 use super::score::{Confidence, confidence_v1, refactorability_v1};
 use crate::index::clones::refine::RefineMember;
 use crate::index::clones::{ALIGNMENT_VERSION, NORM_VERSION};
@@ -32,11 +32,11 @@ pub(crate) struct CachedRefinement {
     pub(crate) confidence: Confidence,
     pub(crate) refactorability: f64,
     pub(crate) refine_mode: &'static str,
-    /// `true` when the LCS fidelity for THIS compute engaged a cost cap (member-count or per-pair
-    /// length — see `class_lcs_ratio`). Computed on a cache MISS only; on a cache HIT it is
-    /// conservatively `false` (the persisted row carries no sampling marker — `lcs_sampled` is an
-    /// implementation artifact of the compute, not content, so it is deliberately NOT persisted in
-    /// `clone_refinements`). The caller folds it into the class's `metrics_sampled` flag.
+    /// `true` when the LCS fidelity for this refinement engaged a cost cap (member-count sample or
+    /// the per-pair length proxy — see `class_lcs_ratio`). PERSISTED in `clone_refinements`
+    /// (Fix 3, #215 Plan 4a round-2): a cache HIT reads the stored bit back, so the long-sequence
+    /// sampling dimension survives a warm hit instead of degrading to `false`. The caller folds it
+    /// into the class's `metrics_sampled` flag.
     pub(crate) lcs_sampled: bool,
 }
 
@@ -76,22 +76,23 @@ pub(crate) fn refine_lookup(
     conn: &Connection,
     refinement_key: &str,
 ) -> anyhow::Result<Option<CachedRefinement>> {
-    let hit: Option<(f64, String, f64)> = conn
+    let hit: Option<(f64, String, f64, i64)> = conn
         .query_row(
-            "SELECT lcs_ratio, confidence, refactorability
+            "SELECT lcs_ratio, confidence, refactorability, lcs_sampled
              FROM clone_refinements
              WHERE class_key = ?1 AND norm_version = ?2 AND alignment_version = ?3",
             rusqlite::params![refinement_key, NORM_VERSION, ALIGNMENT_VERSION],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
         )
         .optional()?;
-    Ok(hit.map(|(lcs_ratio, confidence, refactorability)| CachedRefinement {
+    Ok(hit.map(|(lcs_ratio, confidence, refactorability, lcs_sampled)| CachedRefinement {
         lcs_ratio,
         confidence: Confidence::from_db_str(&confidence),
         refactorability,
         refine_mode: REFINE_MODE,
-        // Cache hit: `lcs_sampled` is not persisted (see the field doc) — conservatively `false`.
-        lcs_sampled: false,
+        // Cache hit: read the persisted sampling bit back (Fix 3) so the long-sequence dimension
+        // survives a warm hit.
+        lcs_sampled: lcs_sampled != 0,
     }))
 }
 
@@ -128,8 +129,8 @@ pub(crate) fn refine_compute_and_store(
              class_key, language, refine_mode, template,
              variation_points_json, proposed_signature_json, confidence,
              anti_unify_coverage, lcs_ratio, refactorability,
-             norm_version, alignment_version, created_at_ms
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+             norm_version, alignment_version, created_at_ms, lcs_sampled
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
         rusqlite::params![
             refinement_key,
             language,
@@ -144,6 +145,7 @@ pub(crate) fn refine_compute_and_store(
             NORM_VERSION,
             ALIGNMENT_VERSION,
             crate::index::now_ms(),
+            lcs_sampled as i64, // Fix 3: persist the sampling bit so warm hits keep it.
         ],
     )?;
 
@@ -176,10 +178,30 @@ pub(crate) fn refine_class(
 /// Crude 4a LCS skeleton: the LCS-common token run of the first member pair (exact for a 2-member
 /// class; a heuristic skeleton for larger classes), space-joined. 4b replaces this with the full
 /// N-way anti-unification template; for 4a it is a legible, deterministic placeholder.
+///
+/// LENGTH GUARD (Fix 2, #215 Plan 4a round-2): the exact `lcs_align` allocates a `(|a|+1)·(|b|+1)`
+/// `usize` DP table, so a pair of multi-thousand-token members would burn hundreds of MB on the
+/// cold `find_clones` / `clones_for_symbol` path — even though `class_lcs_ratio` already fell back
+/// to the cheap proxy for those same long pairs. Mirror that cap here: when `max(|a|, |b|)` exceeds
+/// [`LCS_MAX_SEQ_TOKENS`], DON'T run the DP — emit a cheap common-prefix placeholder (the leading
+/// run of positionally-equal tokens, itself capped at [`LCS_MAX_SEQ_TOKENS`]) so the skeleton stays
+/// legible and bounded with no unbounded allocation.
 fn lcs_skeleton(seqs: &[Vec<String>]) -> String {
     match seqs {
         [] | [_] => seqs.first().map(|s| s.join(" ")).unwrap_or_default(),
         [a, b, ..] => {
+            if a.len().max(b.len()) > LCS_MAX_SEQ_TOKENS {
+                // Length-capped: skip the O(|a|·|b|) DP. Cheap common-prefix placeholder — the
+                // leading positionally-equal token run, bounded by the same cap.
+                let prefix: Vec<&str> = a
+                    .iter()
+                    .zip(b.iter())
+                    .take(LCS_MAX_SEQ_TOKENS)
+                    .take_while(|(ta, tb)| ta == tb)
+                    .map(|(ta, _)| ta.as_str())
+                    .collect();
+                return prefix.join(" ");
+            }
             let aln = lcs_align(a, b);
             let matched: Vec<&str> = aln
                 .ops
@@ -222,6 +244,107 @@ mod tests {
             ["fn", "f", "(", ")", "{", "}"].iter().map(|s| s.to_string()).collect();
         let seqs = vec![a.clone(), a.clone()];
         assert_eq!(lcs_skeleton(&seqs), a.join(" "));
+    }
+
+    /// Fix 2 (#215 Plan 4a round-2): the skeleton length guard. A pair whose longer member exceeds
+    /// [`LCS_MAX_SEQ_TOKENS`] tokens must NOT allocate the `(|a|+1)·(|b|+1)` DP table — it returns
+    /// a cheap common-prefix placeholder instead. This runs quickly (no quadratic allocation)
+    /// and the placeholder is the leading positionally-equal token run, bounded by the cap.
+    #[test]
+    fn lcs_skeleton_length_guard_returns_cheap_placeholder() {
+        // Two sequences longer than the cap with a short shared prefix then a divergence. If the
+        // DP ran on these (~2000²·8 bytes ≈ 32 MB+ for the table, and far more for the genuinely
+        // huge inputs the guard targets) this test would be slow / memory-hungry; the guard makes
+        // it cheap.
+        let prefix = ["fn", "f", "(", ")"];
+        let mut a: Vec<String> = prefix.iter().map(|s| s.to_string()).collect();
+        let mut b = a.clone();
+        // Diverge past the prefix and push both well over the cap with DIFFERENT fillers so the
+        // common-prefix walk stops at the prefix.
+        for i in 0..=LCS_MAX_SEQ_TOKENS {
+            a.push(format!("a{i}"));
+            b.push(format!("b{i}"));
+        }
+        assert!(a.len().max(b.len()) > LCS_MAX_SEQ_TOKENS, "must exceed the length cap");
+
+        let skeleton = lcs_skeleton(&[a, b]);
+        // The placeholder is exactly the shared leading run — the prefix, nothing past the
+        // divergence.
+        assert_eq!(skeleton, prefix.join(" "), "guarded skeleton must be the common-prefix run");
+    }
+
+    /// Fix 2 (#215 Plan 4a round-2): the compute path itself is cheap on long members. A 2-member
+    /// class whose sequences exceed [`LCS_MAX_SEQ_TOKENS`] flows through `refine_compute_and_store`
+    /// without the skeleton DP — it returns promptly, persists one row, and marks `lcs_sampled`
+    /// (the ratio fell back to the clamped Dice proxy).
+    #[test]
+    fn refine_compute_on_long_members_is_cheap_and_sampled() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        crate::index::schema::apply(&conn).unwrap();
+
+        let long_seq: Vec<String> = (0..=LCS_MAX_SEQ_TOKENS).map(|i| format!("t{i}")).collect();
+        let mk = |id: i64| RefineMember {
+            symbol_id: id,
+            lang: crate::language::Language::Rust,
+            path: format!("src/m{id}.rs"),
+            start_byte: 0,
+            end_byte: long_seq.len(),
+            struct_hash: format!("h{id}"),
+            seq: long_seq.clone(),
+        };
+        let members = vec![mk(1), mk(2)];
+        let key = refinement_key("rust", &["h1".into(), "h2".into()]);
+
+        let refinement = refine_compute_and_store(&conn, &key, "rust", &members, 1.0).unwrap();
+        assert!(refinement.lcs_sampled, "long-member compute must set lcs_sampled (proxy path)");
+        let rows: i64 =
+            conn.query_row("SELECT COUNT(*) FROM clone_refinements", [], |r| r.get(0)).unwrap();
+        assert_eq!(rows, 1, "compute persists exactly one row");
+    }
+
+    /// Fix 3 (#215 Plan 4a round-2): the `lcs_sampled` bit is PERSISTED, so a class with ≤
+    /// `LCS_MEMBER_SAMPLE` members but LONG sequences (sampled via the per-pair length proxy on the
+    /// COLD compute) still reports `lcs_sampled = true` on a WARM cache hit. Before the fix the bit
+    /// was compute-only and `refine_lookup` hardcoded `false`, so the long-sequence sampling
+    /// dimension was lost on a warm hit. This test pins the round-trip end to end.
+    #[test]
+    fn lcs_sampled_survives_cache_hit_for_long_seq_small_class() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        crate::index::schema::apply(&conn).unwrap();
+
+        // A 2-member class (well below LCS_MEMBER_SAMPLE) with sequences past LCS_MAX_SEQ_TOKENS:
+        // the member-count cap does NOT engage, only the per-pair length proxy does — exactly the
+        // dimension the OR(member_count > LCS_MEMBER_SAMPLE) in apply_refinement cannot catch.
+        let long_seq: Vec<String> = (0..=LCS_MAX_SEQ_TOKENS).map(|i| format!("t{i}")).collect();
+        let mk = |id: i64| RefineMember {
+            symbol_id: id,
+            lang: crate::language::Language::Rust,
+            path: format!("src/m{id}.rs"),
+            start_byte: 0,
+            end_byte: long_seq.len(),
+            struct_hash: format!("h{id}"),
+            seq: long_seq.clone(),
+        };
+        let members = vec![mk(1), mk(2)];
+        let key = refinement_key("rust", &["h1".into(), "h2".into()]);
+
+        // COLD compute: the length proxy engages → lcs_sampled = true, and it is PERSISTED.
+        let cold = refine_compute_and_store(&conn, &key, "rust", &members, 1.0).unwrap();
+        assert!(cold.lcs_sampled, "cold compute on long seqs must set lcs_sampled");
+
+        // Confirm the bit landed in the row (1, not the DEFAULT 0).
+        let persisted: i64 = conn
+            .query_row(
+                "SELECT lcs_sampled FROM clone_refinements WHERE class_key = ?1",
+                [&key],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(persisted, 1, "lcs_sampled must be persisted as 1");
+
+        // WARM hit: refine_lookup reads the bit back — it must NOT degrade to false.
+        let warm = refine_lookup(&conn, &key).unwrap().expect("warm hit");
+        assert!(warm.lcs_sampled, "warm cache hit must read lcs_sampled=true back from the row");
     }
 
     /// [`refine_lookup`] is a PURE READ: a miss returns `None` and writes NOTHING — no

--- a/crates/rag-rat-core/src/index/clones/refine/cache.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/cache.rs
@@ -32,11 +32,17 @@ pub(crate) struct CachedRefinement {
     pub(crate) confidence: Confidence,
     pub(crate) refactorability: f64,
     pub(crate) refine_mode: &'static str,
-    /// `true` when the LCS fidelity for this refinement engaged a cost cap (member-count sample or
-    /// the per-pair length proxy — see `class_lcs_ratio`). PERSISTED in `clone_refinements`
-    /// (Fix 3, #215 Plan 4a round-2): a cache HIT reads the stored bit back, so the long-sequence
-    /// sampling dimension survives a warm hit instead of degrading to `false`. The caller folds it
-    /// into the class's `metrics_sampled` flag.
+    /// `true` when the LCS fidelity for this refinement engaged EITHER cost-cap dimension — the
+    /// member-count sample ([`LCS_MEMBER_SAMPLE`]) OR the per-pair length proxy
+    /// ([`LCS_MAX_SEQ_TOKENS`]); see `class_lcs_ratio`, which ORs both into the returned bit.
+    /// PERSISTED in `clone_refinements` (Fix 3, #215 Plan 4a round-2): a cache HIT reads the
+    /// stored bit back, so the long-sequence sampling dimension survives a warm hit instead of
+    /// degrading to `false`. The caller (`apply_refinement`) folds it into the class's
+    /// `metrics_sampled` flag — and ALSO independently re-derives the member-count dimension
+    /// there from `class.member_count > LCS_MEMBER_SAMPLE`, as a cache-agnostic guard that
+    /// flags the member-count sample even for a row predating this persisted bit (stored
+    /// default 0). The length-proxy dimension has no such independent re-derivation; it is
+    /// carried only by this persisted bit.
     pub(crate) lcs_sampled: bool,
 }
 

--- a/crates/rag-rat-core/src/index/clones/refine/cache.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/cache.rs
@@ -216,10 +216,12 @@ mod tests {
     /// expensive `refine_compute_and_store` (and its INSERT) only runs after the caller has
     /// confirmed a writable connection.
     ///
-    /// The read-only-connection RETRY mechanism itself (probe → `BEGIN IMMEDIATE; ROLLBACK;`
-    /// triggering `SQLITE_READONLY` → dispatcher retries read-write → compute runs once) is
-    /// exercised end-to-end by the `refine_cache_is_read_through` integration test in
-    /// `schema_bootstrap_tests.rs`, which drives a real `IndexDatabase`. The unit-level invariant
+    /// The read-only-connection RETRY mechanism itself (probe → `DELETE FROM clone_refinements
+    /// WHERE 1=0` triggering `SQLITE_READONLY` → dispatcher retries read-write → compute runs
+    /// once on the writable retry) is exercised by
+    /// `refine_ro_connection_probe_fires_sqlite_readonly` (below), which opens a real
+    /// `rusqlite` read-only connection and asserts that the DELETE probe yields a
+    /// `SQLITE_READONLY` error that `is_readonly_violation` flags. The unit-level invariant
     /// here is the load-bearing half: the lookup must not write.
     #[test]
     fn refine_lookup_returns_none_on_miss_without_writing() {
@@ -280,5 +282,42 @@ mod tests {
             first.confidence, second.confidence,
             "the cache-served refinement matches the computed one"
         );
+    }
+
+    /// Fix 2 (#215 Plan 4a): the DELETE-probe in `refine_class_in_place` (the cold-path on a
+    /// read-only connection) fires `SQLITE_READONLY`, which `is_readonly_violation` recognises
+    /// so the MCP dispatcher can retry read-write. This unit test runs the probe against a REAL
+    /// `rusqlite` read-only connection to prove the signal is produced — it is NOT produced by
+    /// the writable `IndexDatabase::rebuild` connection used in `refine_cache_is_read_through`.
+    #[test]
+    fn refine_ro_connection_probe_fires_sqlite_readonly() {
+        use rusqlite::OpenFlags;
+
+        // Build a writable in-memory DB and apply the schema.
+        let rw_path =
+            std::env::temp_dir().join(format!("ragrat-refine-ro-probe-{}.db", std::process::id()));
+        {
+            let rw = rusqlite::Connection::open(&rw_path).unwrap();
+            crate::index::schema::apply(&rw).unwrap();
+        }
+
+        // Open it read-only.
+        let ro = rusqlite::Connection::open_with_flags(
+            &rw_path,
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )
+        .unwrap();
+
+        // The same DELETE probe used in `refine_class_in_place`.
+        let probe_err = ro.execute("DELETE FROM clone_refinements WHERE 1=0", []).unwrap_err();
+
+        // Wrap in anyhow so `is_readonly_violation` can walk the chain.
+        let anyhow_err = anyhow::Error::from(probe_err);
+        assert!(
+            crate::storage::is_readonly_violation(&anyhow_err),
+            "the DELETE probe on a RO connection must produce SQLITE_READONLY: {anyhow_err}"
+        );
+
+        let _ = std::fs::remove_file(&rw_path);
     }
 }

--- a/crates/rag-rat-core/src/index/clones/refine/cache.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/cache.rs
@@ -1,0 +1,179 @@
+//! Content-addressed refinement cache (#215 Plan 4a Task 4).
+//!
+//! [`refinement_key`] derives a STABLE key from the inputs that determine a refinement (language,
+//! refine mode, the version pins, and the member `struct_hash` multiset) — NOT from the read-side
+//! `class_key` (which is location-derived: `ref@path:start-end`). Two clone classes with the same
+//! structural content therefore share a refinement even when they live at different locations, and
+//! the key survives a reindex that reassigns rowids. [`refine_class`] is a read-through cache over
+//! the `clone_refinements` table keyed by this content address: compute on miss, persist, return.
+
+use rusqlite::{Connection, OptionalExtension};
+
+use super::align::{class_lcs_ratio, lcs_align};
+use super::score::{Confidence, confidence_v1, refactorability_v1};
+use crate::index::clones::refine::RefineMember;
+use crate::index::clones::{ALIGNMENT_VERSION, NORM_VERSION};
+
+/// The 4a refine mode. Baseline token space only; the SCIP-aware mode is Plan 3/4b.
+const REFINE_MODE: &str = "baseline";
+
+/// A computed (or cache-hit) refinement for one clone class. The 4a surface carries only the
+/// scoring outputs; the template / variation-points / proposed-signature are persisted minimally
+/// (4b fills them) and not returned.
+pub(crate) struct Refinement {
+    pub(crate) lcs_ratio: f64,
+    pub(crate) confidence: Confidence,
+    pub(crate) refactorability: f64,
+    pub(crate) refine_mode: &'static str,
+}
+
+/// Content-addressed refinement key: `sha256(language ∥ refine_mode ∥ NORM_VERSION ∥
+/// ALIGNMENT_VERSION ∥ sorted(struct_hashes…))`, each field NUL-separated. Distinct from the
+/// read-side `class_key` (which is `sha256` over `ref@path:start-end` material) by construction:
+/// this key sees only structural content + version pins, never a location.
+///
+/// `struct_hashes` is sorted (duplicates kept) so the key is order-independent over the member set
+/// — the same structural multiset always addresses the same refinement regardless of member order.
+pub(crate) fn refinement_key(language: &str, struct_hashes: &[String]) -> String {
+    let mut sorted = struct_hashes.to_vec();
+    sorted.sort_unstable();
+
+    let mut material = String::new();
+    material.push_str(language);
+    material.push('\0');
+    material.push_str(REFINE_MODE);
+    material.push('\0');
+    material.push_str(&NORM_VERSION.to_string());
+    material.push('\0');
+    material.push_str(&ALIGNMENT_VERSION.to_string());
+    material.push('\0');
+    for h in &sorted {
+        material.push_str(h);
+        material.push('\0');
+    }
+    crate::index::hex_sha256(material.as_bytes())
+}
+
+/// Read-through refinement: return the cached `clone_refinements` row for `refinement_key`
+/// (filtered to the current `NORM_VERSION` / `ALIGNMENT_VERSION` so a stale-version row never
+/// serves), else compute the 4a scores from the member token sequences, persist a minimal row, and
+/// return.
+///
+/// `similarity_min` is the Plan-2 pairwise floor for the class — it feeds the confidence band only,
+/// not the cache key (the key is purely structural). The persisted `template` is a crude LCS
+/// skeleton (4b fills the full anti-unification template + variation points); `anti_unify_coverage`
+/// is the `lcs_ratio` as a 4a proxy.
+pub(crate) fn refine_class(
+    conn: &Connection,
+    refinement_key: &str,
+    language: &str,
+    members: &[RefineMember],
+    similarity_min: f64,
+) -> anyhow::Result<Refinement> {
+    // Cache HIT: a row keyed by this content address at the current version pins.
+    let hit: Option<(f64, String, f64)> = conn
+        .query_row(
+            "SELECT lcs_ratio, confidence, refactorability
+             FROM clone_refinements
+             WHERE class_key = ?1 AND norm_version = ?2 AND alignment_version = ?3",
+            rusqlite::params![refinement_key, NORM_VERSION, ALIGNMENT_VERSION],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .optional()?;
+    if let Some((lcs_ratio, confidence, refactorability)) = hit {
+        return Ok(Refinement {
+            lcs_ratio,
+            confidence: Confidence::from_db_str(&confidence),
+            refactorability,
+            refine_mode: REFINE_MODE,
+        });
+    }
+
+    // Cache MISS: compute the 4a scores from the member token sequences.
+    let seqs: Vec<Vec<String>> = members.iter().map(|m| m.seq.clone()).collect();
+    let lcs_ratio = class_lcs_ratio(&seqs);
+    let refactorability = refactorability_v1(lcs_ratio);
+    let confidence = confidence_v1(lcs_ratio, similarity_min);
+
+    let template = lcs_skeleton(&seqs);
+
+    // Persist a minimal row. INSERT OR REPLACE because `class_key` is the table PRIMARY KEY — a
+    // re-run at a NEW version pin replaces the stale row in place rather than accumulating.
+    conn.execute(
+        "INSERT OR REPLACE INTO clone_refinements(
+             class_key, language, refine_mode, template,
+             variation_points_json, proposed_signature_json, confidence,
+             anti_unify_coverage, lcs_ratio, refactorability,
+             norm_version, alignment_version, created_at_ms
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+        rusqlite::params![
+            refinement_key,
+            language,
+            REFINE_MODE,
+            template,
+            "[]",
+            "{}",
+            confidence.as_db_str(),
+            lcs_ratio, // anti_unify_coverage proxy
+            lcs_ratio,
+            refactorability,
+            NORM_VERSION,
+            ALIGNMENT_VERSION,
+            crate::index::now_ms(),
+        ],
+    )?;
+
+    Ok(Refinement { lcs_ratio, confidence, refactorability, refine_mode: REFINE_MODE })
+}
+
+/// Crude 4a LCS skeleton: the LCS-common token run of the first member pair (exact for a 2-member
+/// class; a heuristic skeleton for larger classes), space-joined. 4b replaces this with the full
+/// N-way anti-unification template; for 4a it is a legible, deterministic placeholder.
+fn lcs_skeleton(seqs: &[Vec<String>]) -> String {
+    match seqs {
+        [] | [_] => seqs.first().map(|s| s.join(" ")).unwrap_or_default(),
+        [a, b, ..] => {
+            let aln = lcs_align(a, b);
+            let matched: Vec<&str> = aln
+                .ops
+                .iter()
+                .filter_map(|op| match op {
+                    super::align::AlignOp::Match(i, _) => a.get(*i).map(String::as_str),
+                    _ => None,
+                })
+                .collect();
+            matched.join(" ")
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn refinement_key_is_order_independent_over_struct_hashes() {
+        let k1 = refinement_key("rust", &["aaa".into(), "bbb".into(), "ccc".into()]);
+        let k2 = refinement_key("rust", &["ccc".into(), "aaa".into(), "bbb".into()]);
+        assert_eq!(k1, k2, "the same struct_hash multiset must address the same refinement");
+    }
+
+    #[test]
+    fn refinement_key_distinguishes_language_and_multiset() {
+        let base = refinement_key("rust", &["aaa".into(), "bbb".into()]);
+        // Different language → different key.
+        assert_ne!(base, refinement_key("typescript", &["aaa".into(), "bbb".into()]));
+        // Different multiset → different key.
+        assert_ne!(base, refinement_key("rust", &["aaa".into(), "ccc".into()]));
+        // Duplicate-sensitive: a doubled hash is a different multiset.
+        assert_ne!(base, refinement_key("rust", &["aaa".into(), "aaa".into(), "bbb".into()]));
+    }
+
+    #[test]
+    fn lcs_skeleton_of_identical_pair_is_the_whole_seq() {
+        let a: Vec<String> =
+            ["fn", "f", "(", ")", "{", "}"].iter().map(|s| s.to_string()).collect();
+        let seqs = vec![a.clone(), a.clone()];
+        assert_eq!(lcs_skeleton(&seqs), a.join(" "));
+    }
+}

--- a/crates/rag-rat-core/src/index/clones/refine/cache.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/cache.rs
@@ -32,6 +32,12 @@ pub(crate) struct CachedRefinement {
     pub(crate) confidence: Confidence,
     pub(crate) refactorability: f64,
     pub(crate) refine_mode: &'static str,
+    /// `true` when the LCS fidelity for THIS compute engaged a cost cap (member-count or per-pair
+    /// length — see `class_lcs_ratio`). Computed on a cache MISS only; on a cache HIT it is
+    /// conservatively `false` (the persisted row carries no sampling marker — `lcs_sampled` is an
+    /// implementation artifact of the compute, not content, so it is deliberately NOT persisted in
+    /// `clone_refinements`). The caller folds it into the class's `metrics_sampled` flag.
+    pub(crate) lcs_sampled: bool,
 }
 
 /// Content-addressed refinement key: `sha256(language ∥ refine_mode ∥ NORM_VERSION ∥
@@ -84,6 +90,8 @@ pub(crate) fn refine_lookup(
         confidence: Confidence::from_db_str(&confidence),
         refactorability,
         refine_mode: REFINE_MODE,
+        // Cache hit: `lcs_sampled` is not persisted (see the field doc) — conservatively `false`.
+        lcs_sampled: false,
     }))
 }
 
@@ -107,7 +115,7 @@ pub(crate) fn refine_compute_and_store(
 ) -> anyhow::Result<CachedRefinement> {
     // Compute the 4a scores from the member token sequences.
     let seqs: Vec<Vec<String>> = members.iter().map(|m| m.seq.clone()).collect();
-    let lcs_ratio = class_lcs_ratio(&seqs);
+    let (lcs_ratio, lcs_sampled) = class_lcs_ratio(&seqs);
     let refactorability = refactorability_v1(lcs_ratio);
     let confidence = confidence_v1(lcs_ratio, similarity_min);
 
@@ -139,7 +147,13 @@ pub(crate) fn refine_compute_and_store(
         ],
     )?;
 
-    Ok(CachedRefinement { lcs_ratio, confidence, refactorability, refine_mode: REFINE_MODE })
+    Ok(CachedRefinement {
+        lcs_ratio,
+        confidence,
+        refactorability,
+        refine_mode: REFINE_MODE,
+        lcs_sampled,
+    })
 }
 
 /// Read-through refinement (writable-connection convenience): [`refine_lookup`] on hit, else

--- a/crates/rag-rat-core/src/index/clones/refine/mod.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/mod.rs
@@ -6,6 +6,9 @@
 #[allow(dead_code)] // wired by Plan-4a Task 4
 pub(crate) mod split;
 
+#[allow(dead_code)] // wired by Plan-4a Task 4 / Plan-4b
+pub(crate) mod align;
+
 /// Input to the LCS-based variation-point analysis for one clone-class member (#215 Plan 4a Task
 /// 2).
 ///

--- a/crates/rag-rat-core/src/index/clones/refine/mod.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/mod.rs
@@ -20,12 +20,14 @@ pub(crate) mod score;
 /// and the order-independent token multiset). The members are returned in CANONICAL order, sorted
 /// by `struct_hash` then `symbol_id` as a tiebreak — the ordinal basis the anti-unify
 /// `per_member_values[]` aligns to.
-#[allow(dead_code)] // fields wired by Plan-4a Task 3 (LCS) / Task 4 (driver)
 pub(crate) struct RefineMember {
     pub(crate) symbol_id: i64,
     pub(crate) lang: crate::language::Language,
+    #[allow(dead_code)] // read by Plan-4b anti-unify (re-derives the AST node from path+bytes)
     pub(crate) path: String,
+    #[allow(dead_code)] // read by Plan-4b anti-unify (re-derives the AST node from path+bytes)
     pub(crate) start_byte: usize,
+    #[allow(dead_code)] // read by Plan-4b anti-unify (re-derives the AST node from path+bytes)
     pub(crate) end_byte: usize,
     /// Persisted baseline struct_hash — the canonical sort key + cache key.
     pub(crate) struct_hash: String,

--- a/crates/rag-rat-core/src/index/clones/refine/mod.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/mod.rs
@@ -1,0 +1,7 @@
+//! Clone-refinement algorithms (#215 Plan 4a/4b): coherence split → LCS align → anti-unify →
+//! signature → score → cache.
+//!
+//! Each step lives in a focused sibling file; this module curates the `pub(crate)` surface.
+
+#[allow(dead_code)] // wired by Plan-4a Task 4
+pub(crate) mod split;

--- a/crates/rag-rat-core/src/index/clones/refine/mod.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/mod.rs
@@ -3,11 +3,13 @@
 //!
 //! Each step lives in a focused sibling file; this module curates the `pub(crate)` surface.
 
-#[allow(dead_code)] // wired by Plan-4a Task 4
 pub(crate) mod split;
 
-#[allow(dead_code)] // wired by Plan-4a Task 4 / Plan-4b
 pub(crate) mod align;
+
+pub(crate) mod cache;
+
+pub(crate) mod score;
 
 /// Input to the LCS-based variation-point analysis for one clone-class member (#215 Plan 4a Task
 /// 2).

--- a/crates/rag-rat-core/src/index/clones/refine/mod.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/mod.rs
@@ -5,3 +5,25 @@
 
 #[allow(dead_code)] // wired by Plan-4a Task 4
 pub(crate) mod split;
+
+/// Input to the LCS-based variation-point analysis for one clone-class member (#215 Plan 4a Task
+/// 2).
+///
+/// Produced by `IndexDatabase::load_refine_members`, which re-reads each member's scoped source,
+/// re-parses it, descends to the symbol node, and re-normalizes to the ordered baseline token
+/// sequence (`seq`) — the refine input Plan 1 does NOT persist (Plan 1 stores only the struct_hash
+/// and the order-independent token multiset). The members are returned in CANONICAL order, sorted
+/// by `struct_hash` then `symbol_id` as a tiebreak — the ordinal basis the anti-unify
+/// `per_member_values[]` aligns to.
+#[allow(dead_code)] // fields wired by Plan-4a Task 3 (LCS) / Task 4 (driver)
+pub(crate) struct RefineMember {
+    pub(crate) symbol_id: i64,
+    pub(crate) lang: crate::language::Language,
+    pub(crate) path: String,
+    pub(crate) start_byte: usize,
+    pub(crate) end_byte: usize,
+    /// Persisted baseline struct_hash — the canonical sort key + cache key.
+    pub(crate) struct_hash: String,
+    /// Ordered baseline token sequence (LCS input).
+    pub(crate) seq: Vec<String>,
+}

--- a/crates/rag-rat-core/src/index/clones/refine/score.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/score.rs
@@ -1,0 +1,91 @@
+//! Refactorability + confidence scoring for a refined clone class (#215 Plan 4a Task 4).
+//!
+//! Both are deliberately simple, monotone functions of the class LCS ratio (and, for confidence,
+//! the Plan-2 pairwise-similarity floor). 4b can refine the formulas; the persisted-as-string
+//! `Confidence` band and the (0,1]-clamped `refactorability` are the stable 4a contract.
+
+/// Persisted confidence band for a refined clone class. Stored as a lower-case string in
+/// `clone_refinements.confidence` via [`Confidence::as_db_str`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Confidence {
+    High,
+    Medium,
+    Low,
+}
+
+impl Confidence {
+    pub(crate) fn as_db_str(&self) -> &'static str {
+        match self {
+            Confidence::High => "high",
+            Confidence::Medium => "medium",
+            Confidence::Low => "low",
+        }
+    }
+
+    /// Parse the persisted lower-case band back (cache read-through). An unknown value degrades to
+    /// `Low` rather than erroring — a stale/foreign band should never crash a read.
+    pub(crate) fn from_db_str(value: &str) -> Self {
+        match value {
+            "high" => Confidence::High,
+            "medium" => Confidence::Medium,
+            _ => Confidence::Low,
+        }
+    }
+}
+
+/// 4a refactorability: the class LCS ratio clamped to `(0, 1]`. The clamp keeps it a strictly
+/// positive ROI multiplier — a degenerate 0.0 ratio would zero the whole ROI and bury an otherwise
+/// load-bearing class, so we floor at [`f64::EPSILON`] and cap at 1.0.
+pub(crate) fn refactorability_v1(lcs_ratio: f64) -> f64 {
+    // `f64::EPSILON < 1.0` always holds, so `clamp` never hits its `min > max` panic path.
+    lcs_ratio.clamp(f64::EPSILON, 1.0)
+}
+
+/// 4a confidence band from the class LCS ratio and the Plan-2 pairwise-similarity floor
+/// (`similarity_min`): `High` only when BOTH are ≥ 0.9, `Low` when EITHER is < 0.7, else `Medium`.
+pub(crate) fn confidence_v1(lcs_ratio: f64, similarity_min: f64) -> Confidence {
+    if lcs_ratio >= 0.9 && similarity_min >= 0.9 {
+        Confidence::High
+    } else if lcs_ratio < 0.7 || similarity_min < 0.7 {
+        Confidence::Low
+    } else {
+        Confidence::Medium
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn refactorability_clamps_to_unit_interval() {
+        // 0.0 floors to EPSILON (strictly positive), not 0.0.
+        assert!(refactorability_v1(0.0) > 0.0);
+        assert_eq!(refactorability_v1(0.0), f64::EPSILON);
+        // > 1.0 caps to 1.0.
+        assert_eq!(refactorability_v1(1.5), 1.0);
+        // in-range passes through.
+        assert_eq!(refactorability_v1(0.83), 0.83);
+    }
+
+    #[test]
+    fn confidence_bands() {
+        assert_eq!(confidence_v1(0.95, 0.92), Confidence::High);
+        // high lcs but a loose pairwise floor → not High.
+        assert_eq!(confidence_v1(0.95, 0.80), Confidence::Medium);
+        // either below 0.7 → Low.
+        assert_eq!(confidence_v1(0.65, 0.99), Confidence::Low);
+        assert_eq!(confidence_v1(0.99, 0.65), Confidence::Low);
+        // both mid-band → Medium.
+        assert_eq!(confidence_v1(0.80, 0.80), Confidence::Medium);
+    }
+
+    #[test]
+    fn confidence_db_str_round_trips() {
+        for c in [Confidence::High, Confidence::Medium, Confidence::Low] {
+            assert_eq!(Confidence::from_db_str(c.as_db_str()), c);
+        }
+        // unknown → Low (never panics).
+        assert_eq!(Confidence::from_db_str("bogus"), Confidence::Low);
+    }
+}

--- a/crates/rag-rat-core/src/index/clones/refine/split.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/split.rs
@@ -1,85 +1,135 @@
 //! Coherence split: break an over-merged union-find component into internally-coherent clone
 //! classes.
 //!
-//! # Why greedy-coherent, not connected-components of the θ-graph
+//! # Why a clique cover, not greedy first-fit or connected-components of the θ-graph
 //!
 //! Union-find over-merges transitive chains (A~B edge, B~C edge, A!~C → {A,B,C} component).
 //! Connected components of the θ-graph suffer the same flaw: a chain A–B–C is one connected
 //! component even when A and C are below θ, so re-running connected components on the θ-graph
 //! just reproduces the problem. We need **internally-coherent** classes — every pair within a
-//! returned class must be ≥ θ. The greedy clustering below achieves this: each new member joins
-//! only a class where it is coherent with EVERY existing member, guaranteeing the all-pairs
-//! postcondition by construction.
+//! returned class must be ≥ θ.
+//!
+//! Greedy FIRST-FIT (the prior implementation) achieves coherence but LOSES classes: in chain
+//! A~B, B~C, A!~C the member B joins the first class {A,B}, then C cannot join {A,B} (A!~C) and is
+//! dropped as a singleton — the perfectly valid {B,C} pair is never emitted. The fix (#215 Plan 4a)
+//! is a greedy MAXIMAL CLIQUE COVER: every coherent edge seeds a maximal coherent group, so B lands
+//! in BOTH {A,B} and {B,C} (overlap is correct — a member can be coherent with two otherwise-
+//! incompatible peers). Each emitted group is still internally coherent by construction (a member
+//! is added only when it is ≥ θ to EVERY current group member).
 
-/// Hard cap on the all-pairs O(n²) work inside a single component. When a component exceeds this
-/// count, only the first `SPLIT_MAX` members (by ascending id) are processed. The caller already
-/// sets `metrics_sampled = true` for components larger than `METRIC_SAMPLE_CAP` (200); this guard
-/// matches that cap so the split never exceeds the same bound. For the overwhelmingly common case
-/// (all existing tests) this cap is never reached.
+/// Hard cap on the all-pairs O(n²) work inside a single component. A component LARGER than this is
+/// returned WHOLE as a single class (no member loss — see Fix 3, #215 Plan 4a): huge components are
+/// near-universally fully-coherent exact-clone classes, and precise clique-cover splitting of
+/// over-cap components is a follow-up. The caller already sets `metrics_sampled = true` for
+/// components larger than `METRIC_SAMPLE_CAP` (200); this guard matches that cap so the split never
+/// exceeds the same pairwise bound. For the overwhelmingly common case (all existing tests) this
+/// cap is never reached.
 const SPLIT_MAX: usize = 200;
 
 /// Split an over-merged union-find component into internally-coherent clone classes: every pair
 /// within a returned class has pairwise similarity >= theta.  Union-find over-merges transitive
-/// chains (A~B, B~C, A!~C ⇒ {A,B,C}); this returns coherent sub-classes instead.
+/// chains (A~B, B~C, A!~C ⇒ {A,B,C}); this returns coherent sub-classes instead, via a greedy
+/// maximal clique cover that keeps EVERY coherent group (so a member shared by two incompatible
+/// peers, like B in chain A~B / B~C / A!~C, appears in both {A,B} and {B,C}).
 ///
 /// `similarity(a, b)` returns the pairwise overlap/max similarity in \[0,1\] (the caller supplies
-/// it from the token bags). Deterministic: members are processed in ascending-id order and returned
-/// classes are in stable order (by their lowest member id). Classes of size < 2 are dropped (a
-/// clone class needs ≥ 2 members).
+/// it from the token bags). Deterministic: members are processed in ascending-id order, group
+/// members are sorted ascending, and returned classes are in stable order (by their lowest member
+/// id). Classes of size < 2 are dropped (a clone class needs ≥ 2 members).
 ///
-/// # Algorithm
+/// # Algorithm (greedy maximal clique cover)
 ///
 /// 1. Sort members ascending by id (determinism).
-/// 2. Cap at `SPLIT_MAX` (coarse guard for huge components — see doc above).
-/// 3. For each member in id order, scan the existing classes and find the FIRST class (lowest
-///    anchor id) where the candidate is coherent with EVERY current member (similarity ≥ theta). If
-///    found, append it there. Otherwise start a new singleton class.
-///
-/// This greedy-first-fit strategy means a member joins the earliest class it fully coheres with,
-/// which is tie-break deterministic by class-creation order (which is itself id-order-driven).
+/// 2. If the component exceeds `SPLIT_MAX`, return it WHOLE as one class — no members dropped (Fix
+///    3, #215). `build_class`'s `METRIC_SAMPLE_CAP` bounds the pairwise metric cost downstream.
+/// 3. Collect all coherent edges `(a, b)` with `a < b` and `similarity(a, b) >= theta`.
+/// 4. For each coherent edge not already fully contained in an emitted group, grow a maximal
+///    coherent group from `{a, b}` by adding any remaining member (in id order) that is ≥ θ to
+///    every current group member.
+/// 5. Drop groups that are a strict subset of another (keep only maximal cliques), de-duplicate
+///    identical groups, drop singletons, and sort by lowest member id.
 ///
 /// # Postcondition guaranteed by construction
 ///
-/// Every returned class is internally coherent (all pairs ≥ theta): a member is only appended to
-/// a class after it has passed the coherence check against every existing member in that class, so
-/// the check is transitively maintained across all insertions.
+/// Every returned class is internally coherent (all pairs ≥ theta): a member is only added to a
+/// group after it has passed the coherence check against every existing member, so the all-pairs
+/// property holds across all insertions.
 pub(crate) fn coherence_split(
     component: &[i64],
     similarity: impl Fn(i64, i64) -> f64,
     theta: f64,
 ) -> Vec<Vec<i64>> {
-    // 1. Sorted ascending (determinism).
+    // 1. Sort ascending (determinism).
     let mut members: Vec<i64> = component.to_vec();
     members.sort_unstable();
 
-    // 2. Cap (coarse guard for huge components).
-    members.truncate(SPLIT_MAX);
-
-    // 3. Greedy first-fit coherence clustering.
-    // `classes` grows as we discover members that don't fit any existing class.
-    // Each class is internally coherent by construction: we only append when the candidate is
-    // ≥ theta to every current member.
-    let mut classes: Vec<Vec<i64>> = Vec::new();
-
-    'member: for &m in &members {
-        for class in &mut classes {
-            // Check coherence of `m` with every existing member of this class.
-            let fully_coherent = class.iter().all(|&existing| similarity(m, existing) >= theta);
-            if fully_coherent {
-                class.push(m);
-                continue 'member;
-            }
-        }
-        // No existing class accepted `m` — start a new singleton.
-        classes.push(vec![m]);
+    // 2. Huge component: return the whole thing as one class (no member loss — Fix 3, #215).
+    // build_class's METRIC_SAMPLE_CAP bounds the pairwise cost. Huge components are typically
+    // fully-coherent exact-clone classes; precise splitting of >SPLIT_MAX-member components is a
+    // follow-up.
+    if members.len() > SPLIT_MAX {
+        return vec![members];
     }
 
-    // Drop singletons (a clone class needs ≥ 2 members).
-    // Classes are already in creation order (anchored by the lowest member id that started each
-    // class), which is a stable order derived from the id-sorted member stream.
-    classes.retain(|c| c.len() >= 2);
+    // 3. Collect all coherent edges (pairs with similarity >= theta), in (a, b) order a < b.
+    let n = members.len();
+    let mut coherent_edges: Vec<(i64, i64)> = Vec::new();
+    for i in 0..n {
+        for j in (i + 1)..n {
+            if similarity(members[i], members[j]) >= theta {
+                coherent_edges.push((members[i], members[j]));
+            }
+        }
+    }
 
-    classes
+    // 4. Greedy maximal clique cover: for each coherent edge not already fully inside some emitted
+    // group, grow a maximal coherent group from {a, b} by adding any remaining member (in id order)
+    // that is coherent with every current group member. Emit the group.
+    let mut groups: Vec<Vec<i64>> = Vec::new();
+
+    'edges: for (a, b) in &coherent_edges {
+        // Skip this edge if some existing group already contains both endpoints.
+        for g in &groups {
+            if g.contains(a) && g.contains(b) {
+                continue 'edges;
+            }
+        }
+        // Grow a maximal coherent group from {a, b}.
+        let mut group: Vec<i64> = vec![*a, *b];
+        for &m in &members {
+            if group.contains(&m) {
+                continue;
+            }
+            // m is coherent with every current group member?
+            if group.iter().all(|&g| similarity(m, g) >= theta) {
+                group.push(m);
+            }
+        }
+        group.sort_unstable(); // deterministic order within group
+        groups.push(group);
+    }
+
+    // 5. Keep only maximal groups (drop any that is a strict subset of another).
+    let mut maximal: Vec<Vec<i64>> = Vec::new();
+    for g in &groups {
+        let is_subset =
+            groups.iter().any(|other| other.len() > g.len() && g.iter().all(|x| other.contains(x)));
+        if !is_subset {
+            maximal.push(g.clone());
+        }
+    }
+
+    // 6. De-duplicate identical groups (same set).
+    maximal.sort_unstable();
+    maximal.dedup();
+
+    // 7. Drop singletons (shouldn't happen since we start from edges, but be safe).
+    maximal.retain(|g| g.len() >= 2);
+
+    // 8. Sort by lowest member id (determinism).
+    maximal.sort_by_key(|g| g[0]);
+
+    maximal
 }
 
 #[cfg(test)]
@@ -112,8 +162,9 @@ mod tests {
     }
 
     /// Transitive chain A~B (0.74), B~C (0.86), A!~C (0.67) at theta=0.70.
-    /// The component {A, B, C} must split — no returned class may contain all three.
-    /// Every returned class must be internally coherent (all pairs ≥ theta).
+    /// The greedy clique cover yields BOTH coherent pairs — {A,B} and {B,C} — with B in both (the
+    /// overlap is correct: B coheres with two peers that are themselves incompatible). No returned
+    /// class may contain all three, and every returned class must be internally coherent.
     #[test]
     fn coherence_split_breaks_a_transitive_chain_into_coherent_classes() {
         let (a, b, c) = (10_i64, 20_i64, 30_i64);
@@ -123,7 +174,14 @@ mod tests {
 
         let split = coherence_split(&[a, b, c], &sim, theta);
 
-        // Every returned class must be internally coherent.
+        // Chain A~B, B~C, A!~C → both {A,B} and {B,C} are returned (B in both — overlap is
+        // correct).
+        assert_eq!(split.len(), 2, "chain yields {{A,B}} and {{B,C}}: {split:?}");
+        let has_ab = split.iter().any(|g| g.contains(&a) && g.contains(&b) && !g.contains(&c));
+        let has_bc = split.iter().any(|g| g.contains(&b) && g.contains(&c) && !g.contains(&a));
+        assert!(has_ab, "must contain {{A,B}}: {split:?}");
+        assert!(has_bc, "must contain {{B,C}}: {split:?}");
+        // Every returned class must be internally coherent (all pairs ≥ theta).
         for class in &split {
             assert!(
                 all_pairs_meet_theta(class, &sim, theta),
@@ -132,14 +190,6 @@ mod tests {
                 theta
             );
         }
-        // The chain must NOT be returned as one 3-member class.
-        assert!(
-            split.iter().all(|c| c.len() < 3),
-            "expected the chain to be split but got {:?}",
-            split
-        );
-        // There must be at least one returned class (e.g. {A,B} or {B,C}).
-        assert!(!split.is_empty(), "expected at least one coherent class, got none");
     }
 
     /// A fully coherent 4-member component (all pairs ≥ theta) must stay as one class.
@@ -194,5 +244,37 @@ mod tests {
 
         assert_eq!(r1, r2, "result differs between [a,b,c] and [c,b,a]");
         assert_eq!(r1, r3, "result differs between [a,b,c] and [b,a,c]");
+    }
+
+    /// Fix 3 (#215): a component LARGER than `SPLIT_MAX` is returned WHOLE as one class — NO
+    /// members dropped. Even though here every pair is fully coherent, the point is the size
+    /// guard returns the entire member set rather than truncating to `SPLIT_MAX` (the prior
+    /// `members.truncate` silently lost the tail).
+    #[test]
+    fn coherence_split_huge_component_returns_all_members() {
+        let count = SPLIT_MAX + 1;
+        let members: Vec<i64> = (0..count as i64).collect();
+        // All pairs above theta (fully coherent).
+        let sim = |_a: i64, _b: i64| 1.0_f64;
+        let split = coherence_split(&members, sim, 0.70);
+        // Must return exactly one group with ALL members (not truncated).
+        assert_eq!(split.len(), 1, "huge component returns one group: {} groups", split.len());
+        assert_eq!(split[0].len(), count, "all {count} members must be present, not truncated");
+    }
+
+    /// Fix 3 (#215), companion: a >`SPLIT_MAX` component is returned as ONE class regardless of
+    /// internal coherence — the size guard fires BEFORE any pairwise math, so even a component with
+    /// no coherent pairs at all keeps every member (precise splitting of huge components is a
+    /// follow-up; member loss is not acceptable in the interim).
+    #[test]
+    fn coherence_split_huge_component_returned_as_one_class() {
+        let count = SPLIT_MAX + 1;
+        let members: Vec<i64> = (0..count as i64).collect();
+        // No coherent pairs (similarity 0.0 everywhere) — yet the size guard still returns one
+        // whole class because it fires before the edge collection.
+        let sim = |_a: i64, _b: i64| 0.0_f64;
+        let split = coherence_split(&members, sim, 0.70);
+        assert_eq!(split.len(), 1, "a >SPLIT_MAX component is one class regardless of coherence");
+        assert_eq!(split[0].len(), count, "no members are dropped past SPLIT_MAX");
     }
 }

--- a/crates/rag-rat-core/src/index/clones/refine/split.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/split.rs
@@ -1,0 +1,198 @@
+//! Coherence split: break an over-merged union-find component into internally-coherent clone
+//! classes.
+//!
+//! # Why greedy-coherent, not connected-components of the θ-graph
+//!
+//! Union-find over-merges transitive chains (A~B edge, B~C edge, A!~C → {A,B,C} component).
+//! Connected components of the θ-graph suffer the same flaw: a chain A–B–C is one connected
+//! component even when A and C are below θ, so re-running connected components on the θ-graph
+//! just reproduces the problem. We need **internally-coherent** classes — every pair within a
+//! returned class must be ≥ θ. The greedy clustering below achieves this: each new member joins
+//! only a class where it is coherent with EVERY existing member, guaranteeing the all-pairs
+//! postcondition by construction.
+
+/// Hard cap on the all-pairs O(n²) work inside a single component. When a component exceeds this
+/// count, only the first `SPLIT_MAX` members (by ascending id) are processed. The caller already
+/// sets `metrics_sampled = true` for components larger than `METRIC_SAMPLE_CAP` (200); this guard
+/// matches that cap so the split never exceeds the same bound. For the overwhelmingly common case
+/// (all existing tests) this cap is never reached.
+const SPLIT_MAX: usize = 200;
+
+/// Split an over-merged union-find component into internally-coherent clone classes: every pair
+/// within a returned class has pairwise similarity >= theta.  Union-find over-merges transitive
+/// chains (A~B, B~C, A!~C ⇒ {A,B,C}); this returns coherent sub-classes instead.
+///
+/// `similarity(a, b)` returns the pairwise overlap/max similarity in \[0,1\] (the caller supplies
+/// it from the token bags). Deterministic: members are processed in ascending-id order and returned
+/// classes are in stable order (by their lowest member id). Classes of size < 2 are dropped (a
+/// clone class needs ≥ 2 members).
+///
+/// # Algorithm
+///
+/// 1. Sort members ascending by id (determinism).
+/// 2. Cap at `SPLIT_MAX` (coarse guard for huge components — see doc above).
+/// 3. For each member in id order, scan the existing classes and find the FIRST class (lowest
+///    anchor id) where the candidate is coherent with EVERY current member (similarity ≥ theta). If
+///    found, append it there. Otherwise start a new singleton class.
+///
+/// This greedy-first-fit strategy means a member joins the earliest class it fully coheres with,
+/// which is tie-break deterministic by class-creation order (which is itself id-order-driven).
+///
+/// # Postcondition guaranteed by construction
+///
+/// Every returned class is internally coherent (all pairs ≥ theta): a member is only appended to
+/// a class after it has passed the coherence check against every existing member in that class, so
+/// the check is transitively maintained across all insertions.
+pub(crate) fn coherence_split(
+    component: &[i64],
+    similarity: impl Fn(i64, i64) -> f64,
+    theta: f64,
+) -> Vec<Vec<i64>> {
+    // 1. Sorted ascending (determinism).
+    let mut members: Vec<i64> = component.to_vec();
+    members.sort_unstable();
+
+    // 2. Cap (coarse guard for huge components).
+    members.truncate(SPLIT_MAX);
+
+    // 3. Greedy first-fit coherence clustering.
+    // `classes` grows as we discover members that don't fit any existing class.
+    // Each class is internally coherent by construction: we only append when the candidate is
+    // ≥ theta to every current member.
+    let mut classes: Vec<Vec<i64>> = Vec::new();
+
+    'member: for &m in &members {
+        for class in &mut classes {
+            // Check coherence of `m` with every existing member of this class.
+            let fully_coherent = class.iter().all(|&existing| similarity(m, existing) >= theta);
+            if fully_coherent {
+                class.push(m);
+                continue 'member;
+            }
+        }
+        // No existing class accepted `m` — start a new singleton.
+        classes.push(vec![m]);
+    }
+
+    // Drop singletons (a clone class needs ≥ 2 members).
+    // Classes are already in creation order (anchored by the lowest member id that started each
+    // class), which is a stable order derived from the id-sorted member stream.
+    classes.retain(|c| c.len() >= 2);
+
+    classes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify that every pair within `class` has similarity ≥ theta via `sim`.
+    fn all_pairs_meet_theta(class: &[i64], sim: impl Fn(i64, i64) -> f64, theta: f64) -> bool {
+        for (i, &a) in class.iter().enumerate() {
+            for &b in &class[i + 1..] {
+                if sim(a, b) < theta {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    /// Build a symmetric similarity closure from an explicit pair list.
+    /// Any unlisted pair defaults to 0.0 (below any reasonable theta).
+    fn sim_from_pairs(pairs: &[((i64, i64), f64)]) -> impl Fn(i64, i64) -> f64 + '_ {
+        move |a, b| {
+            for &((x, y), v) in pairs {
+                if (a == x && b == y) || (a == y && b == x) {
+                    return v;
+                }
+            }
+            0.0
+        }
+    }
+
+    /// Transitive chain A~B (0.74), B~C (0.86), A!~C (0.67) at theta=0.70.
+    /// The component {A, B, C} must split — no returned class may contain all three.
+    /// Every returned class must be internally coherent (all pairs ≥ theta).
+    #[test]
+    fn coherence_split_breaks_a_transitive_chain_into_coherent_classes() {
+        let (a, b, c) = (10_i64, 20_i64, 30_i64);
+        let theta = 0.70;
+        let pairs = [((a, b), 0.74), ((b, c), 0.86), ((a, c), 0.67)];
+        let sim = sim_from_pairs(&pairs);
+
+        let split = coherence_split(&[a, b, c], &sim, theta);
+
+        // Every returned class must be internally coherent.
+        for class in &split {
+            assert!(
+                all_pairs_meet_theta(class, &sim, theta),
+                "class {:?} contains a pair below theta={}",
+                class,
+                theta
+            );
+        }
+        // The chain must NOT be returned as one 3-member class.
+        assert!(
+            split.iter().all(|c| c.len() < 3),
+            "expected the chain to be split but got {:?}",
+            split
+        );
+        // There must be at least one returned class (e.g. {A,B} or {B,C}).
+        assert!(!split.is_empty(), "expected at least one coherent class, got none");
+    }
+
+    /// A fully coherent 4-member component (all pairs ≥ theta) must stay as one class.
+    #[test]
+    fn coherence_split_keeps_a_fully_coherent_component_as_one_class() {
+        let (a, b, c, d) = (1_i64, 2_i64, 3_i64, 4_i64);
+        let theta = 0.70;
+        // All pairs are 0.80 — well above theta.
+        let pairs = [
+            ((a, b), 0.80),
+            ((a, c), 0.80),
+            ((a, d), 0.80),
+            ((b, c), 0.80),
+            ((b, d), 0.80),
+            ((c, d), 0.80),
+        ];
+        let sim = sim_from_pairs(&pairs);
+
+        let split = coherence_split(&[a, b, c, d], &sim, theta);
+
+        assert_eq!(split.len(), 1, "expected one class, got {:?}", split);
+        let mut returned = split[0].clone();
+        returned.sort_unstable();
+        assert_eq!(returned, vec![a, b, c, d]);
+    }
+
+    /// Two members below theta → both become singletons → no class returned.
+    #[test]
+    fn coherence_split_drops_singletons() {
+        let (a, b) = (1_i64, 2_i64);
+        let theta = 0.70;
+        let pairs = [((a, b), 0.50)]; // below theta
+        let sim = sim_from_pairs(&pairs);
+
+        let split = coherence_split(&[a, b], &sim, theta);
+
+        assert!(split.is_empty(), "expected no class (both singletons), got {:?}", split);
+    }
+
+    /// The result must be identical regardless of the order the component slice is supplied in.
+    #[test]
+    fn coherence_split_is_deterministic() {
+        let (a, b, c) = (10_i64, 20_i64, 30_i64);
+        let theta = 0.70;
+        let pairs = [((a, b), 0.74), ((b, c), 0.86), ((a, c), 0.67)];
+        let sim = sim_from_pairs(&pairs);
+
+        // Supply in three different orderings.
+        let r1 = coherence_split(&[a, b, c], &sim, theta);
+        let r2 = coherence_split(&[c, b, a], &sim, theta);
+        let r3 = coherence_split(&[b, a, c], &sim, theta);
+
+        assert_eq!(r1, r2, "result differs between [a,b,c] and [c,b,a]");
+        assert_eq!(r1, r3, "result differs between [a,b,c] and [b,a,c]");
+    }
+}

--- a/crates/rag-rat-core/src/index/clones/refine/split.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/split.rs
@@ -26,6 +26,16 @@
 /// cap is never reached.
 const SPLIT_MAX: usize = 200;
 
+/// Hard cap on the number of groups the greedy clique-cover may emit before the algorithm
+/// abandons the split and returns the WHOLE component as one class (no member loss). Bounds
+/// the subset-removal at O(MAX_SPLIT_GROUPS² × n): with 256 groups and n ≤ 200 (SPLIT_MAX
+/// guard fires first on larger components) that is at most 256² × 200 ≈ 13 M comparisons —
+/// well within a sub-second budget. A pathological dense-minus-perfect-matching graph that
+/// would otherwise produce O(n²/2) ≈ 20 000 groups trips this budget early and returns
+/// the whole component fast; recall is preserved (the whole component contains every coherent
+/// pair). For the normal case (all existing tests) far fewer than 256 groups are ever produced.
+const MAX_SPLIT_GROUPS: usize = 256;
+
 /// Split an over-merged union-find component into internally-coherent clone classes: every pair
 /// within a returned class has pairwise similarity >= theta.  Union-find over-merges transitive
 /// chains (A~B, B~C, A!~C ⇒ {A,B,C}); this returns coherent sub-classes instead, via a greedy
@@ -107,6 +117,12 @@ pub(crate) fn coherence_split(
         }
         group.sort_unstable(); // deterministic order within group
         groups.push(group);
+        // Budget guard: if we have emitted too many groups, the component is pathologically
+        // tangled (e.g. dense-minus-perfect-matching). Abandon the split and return the whole
+        // component as one class — no member dropped, recall preserved.
+        if groups.len() > MAX_SPLIT_GROUPS {
+            return vec![members];
+        }
     }
 
     // 5. Keep only maximal groups (drop any that is a strict subset of another).
@@ -276,5 +292,52 @@ mod tests {
         let split = coherence_split(&members, sim, 0.70);
         assert_eq!(split.len(), 1, "a >SPLIT_MAX component is one class regardless of coherence");
         assert_eq!(split[0].len(), count, "no members are dropped past SPLIT_MAX");
+    }
+
+    /// Fix 1 (#215 Plan 4a): a dense-minus-perfect-matching component at n≈200 is the pathological
+    /// case for the greedy clique-cover (O(n⁴) without the budget guard — every adjacent pair seeds
+    /// a new group). With `MAX_SPLIT_GROUPS` the budget trips early and the whole component is
+    /// returned as one class — no member dropped, completes in well under a second.
+    #[test]
+    fn coherence_split_pathological_dense_minus_matching_returns_fast() {
+        // n=200 dense-minus-perfect-matching: all pairs above theta EXCEPT the perfect matching
+        // (0,1), (2,3), (4,5), … This is the worst case for maximal-clique enumeration because
+        // every non-matched pair is an edge, yielding O(n²) maximal cliques.
+        let n: i64 = 200;
+        let members: Vec<i64> = (0..n).collect();
+        // Perfect matching: pair (2k, 2k+1) is BELOW theta; all other pairs are ABOVE theta.
+        let sim = |a: i64, b: i64| -> f64 {
+            // If a and b are a matched pair (same "bucket"), below theta.
+            let matched = (a / 2 == b / 2) && (a % 2 != b % 2);
+            if matched { 0.5 } else { 0.9 }
+        };
+        let theta = 0.70;
+
+        let start = std::time::Instant::now();
+        let result = coherence_split(&members, sim, theta);
+        let elapsed = start.elapsed();
+
+        // Must complete FAST (well under 1 second even in debug builds).
+        assert!(
+            elapsed.as_secs() < 2,
+            "coherence_split must not time out on n=200 pathological input: took {elapsed:?}"
+        );
+
+        // Budget tripped → whole component returned as one class (all 200 members, none dropped).
+        // OR (if the graph happens to be resolved under the budget) ≤ MAX_SPLIT_GROUPS groups,
+        // with no member dropped.
+        let all_members: std::collections::BTreeSet<i64> = members.iter().copied().collect();
+        let returned_members: std::collections::BTreeSet<i64> =
+            result.iter().flatten().copied().collect();
+        assert!(
+            returned_members.is_superset(&all_members),
+            "no member may be dropped: missing {:?}",
+            all_members.difference(&returned_members).collect::<Vec<_>>()
+        );
+        assert!(
+            result.len() == 1 || result.len() <= MAX_SPLIT_GROUPS,
+            "must return 1 (budget-tripped whole-component) or ≤ MAX_SPLIT_GROUPS groups, got {}",
+            result.len()
+        );
     }
 }

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -767,7 +767,7 @@ fn migration_creates_oracle_side_tables() {
         assert!(columns.contains(&expected.to_string()), "edge_oracle missing {expected}");
     }
 
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 29);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 30);
 }
 
 /// The V019 moniker migration: the `logical_symbol_monikers` table (STRICT, NO foreign key — see

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -24,7 +24,9 @@ const METRIC_SAMPLE_CAP: usize = 200;
 
 use crate::index::IndexDatabase;
 use crate::index::clones::NORM_VERSION;
-use crate::index::clones::refine::cache::{refine_class, refinement_key};
+use crate::index::clones::refine::cache::{
+    refine_compute_and_store, refine_lookup, refinement_key,
+};
 use crate::index::clones::refine::split::coherence_split;
 
 /// Similarity threshold θ: a candidate pair is kept iff `overlap / max_len >= THETA`. The MAX
@@ -371,7 +373,39 @@ impl IndexDatabase {
         // `build_class`), while `key` spans the FULL struct_hash multiset. The gap is not a
         // determinism break — the sample is id-ASC stable — but Plan-4b should compute confidence
         // over the full set or fold the sample into the key.
-        let refinement = refine_class(conn, &key, &class.language, &members, class.similarity_min)?;
+        //
+        // Phase 1 — PURE READ: probe the content-addressed cache. A SELECT is safe on the MCP's
+        // read-only connection, so a WARM (cache-hit) refine never takes the write lock and never
+        // recomputes anything.
+        let cached = refine_lookup(conn, &key)?;
+        let refinement = if let Some(cached) = cached {
+            // WARM path: cache hit — no compute, no write, fully RO-safe.
+            cached
+        } else {
+            // COLD path: cache miss. The fix it serves (#215 Plan 4a): do NOT run the expensive LCS
+            // compute on a read-only connection only to have the INSERT fail with SQLITE_READONLY
+            // and the whole MCP call retry read-write — recomputing. Instead, BEFORE any compute,
+            // probe writability. If the connection is read-only, surface a genuine SQLITE_READONLY
+            // error so `is_readonly_violation` flags it and the dispatcher retries read-write; the
+            // retry takes this same cold path but writable (so this branch is skipped) and computes
+            // exactly once.
+            if conn.is_readonly(rusqlite::MAIN_DB)? {
+                // Mint a real SQLITE_READONLY `rusqlite::Error` that `is_readonly_violation`
+                // recognizes, WITHOUT the expensive LCS work. A zero-row write to a real table
+                // (`DELETE … WHERE 1=0`) acquires the write lock → fails with SQLITE_READONLY on a
+                // RO connection. (A `BEGIN IMMEDIATE` does NOT error here — this rusqlite/SQLite
+                // build defers the write-lock acquisition past transaction-start, so the probe must
+                // be an actual write statement.) The `WHERE 1=0` makes it a true no-op even on a
+                // writable connection; in practice this branch only runs on the RO pass, since the
+                // RW retry sees `is_readonly == false` and skips straight to the compute.
+                conn.execute("DELETE FROM clone_refinements WHERE 1=0", [])?;
+                // The probe MUST error on a RO connection; if it somehow didn't, bail rather than
+                // fall through to a compute whose INSERT would itself fail.
+                anyhow::bail!("clone refine requires a writable connection");
+            }
+            // Writable: compute once and persist.
+            refine_compute_and_store(conn, &key, &class.language, &members, class.similarity_min)?
+        };
 
         // Swap the ROI cohesion multiplier for `refactorability` on refined classes (Plan 4a). The
         // other factors are unchanged (cross-module spread × member count × medoid body tokens ×

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -252,16 +252,21 @@ impl IndexDatabase {
         let conn = self.storage.connection();
 
         // Validate the caller-supplied θ BEFORE it touches candidate generation. θ is a similarity
-        // ratio (overlap/max_len) so it must lie in (0.0, 1.0]: ≤ 0.0 would admit every pair (and a
-        // 0.0 sub-block prefix walks the whole bag), > 1.0 is unreachable and signals a unit error.
-        // NaN must be explicitly rejected: both `v <= 0.0` and `v > 1.0` are false for NaN, so
-        // without the `is_finite` guard NaN slips through and makes `ceil(NaN) as i64 = 0`, which
-        // widens the sub-block to the whole bag → O(n²) blowup with every same-language
-        // token-sharing pair reported as a clone.
+        // ratio (overlap/max_len) and must lie in [0.5, 1.0]:
+        // - > 1.0 is unreachable and signals a unit error.
+        // - < 0.5 is rejected not just for the ≤0 degenerate case but because any small positive θ
+        //   makes the sub-block prefix p = L − ceil(θ·L) + 1 approach the whole bag, flooding the
+        //   inverted index with hot/common tokens and causing O(S²) candidate-pair explosion
+        //   (measured: 5k symbols at θ=0.01 → ~20s/~700MB in candidate gen alone). The 0.5 floor
+        //   keeps the sub-block at most L/2 occurrences — a practical safety bound. A deeper fix
+        //   (capping candidate-pair/posting-list work and restoring the full (0,1] range) is
+        //   tracked in #235.
+        // - NaN and non-finite values must be explicitly rejected: both `v < 0.5` and `v > 1.0` are
+        //   false for NaN, so without the `is_finite` guard NaN slips through.
         if let Some(v) = opts.min_similarity
-            && (!v.is_finite() || v <= 0.0 || v > 1.0)
+            && (!v.is_finite() || !(0.5..=1.0).contains(&v))
         {
-            anyhow::bail!("min_similarity must be a finite value in (0.0, 1.0]");
+            anyhow::bail!("min_similarity must be in [0.5, 1.0]");
         }
 
         let bags = load_scoped_baseline_bags(conn)?;
@@ -320,14 +325,25 @@ impl IndexDatabase {
         // limited result that dropped whole classes still reports `truncated == true`.
         let total_classes_built = built.len();
 
+        // Refine budget: the maximum number of classes to refine (re-read + re-parse + LCS).
+        // Shared between the limited and unlimited paths — the limited path clamps its effective
+        // returned count to this budget so `find_clones { limit: 100000 }` can't queue unbounded
+        // re-parse work while still returning all-refined classes. The unlimited path refines only
+        // the top-budget classes and returns all (with unrefined tail).
+        const UNLIMITED_REFINE_BUDGET: usize = 50;
+
         let classes: Vec<CandidateCloneClass> = if let Some(limit) = opts.limit {
-            // Limited result (Fix 2, Codex P2 #215 Plan 4a): truncate to the top-N by PROVISIONAL
-            // ROI BEFORE refining, refine exactly those N, then re-sort ONLY those N by final
-            // (refactorability) ROI. This guarantees every class in a limited result is either
-            // refined or best-effort-unrefined (`load_refine_members` returned None), all ranked on
-            // a consistent basis — no unrefined rank-(N+1) class can displace a refined one after
-            // re-sorting (the old refine-top-N-then-re-sort-ALL path could).
-            built.truncate(limit);
+            // Limited result: truncate to min(limit, UNLIMITED_REFINE_BUDGET) so a huge `limit`
+            // doesn't queue unbounded re-parse work. The all-refined-limited invariant (Fix 2
+            // round-1: every class in a limited result is refined, no unrefined rank-(N+1) class)
+            // is preserved because we clamp BEFORE refining — we refine at most
+            // UNLIMITED_REFINE_BUDGET classes and return exactly those. Callers wanting
+            // more than UNLIMITED_REFINE_BUDGET classes (with only the top refined)
+            // should use limit: None. DOCUMENTED BEHAVIOR: a limited query returns at
+            // most UNLIMITED_REFINE_BUDGET (50) classes, all refined; to retrieve more
+            // classes use limit: None.
+            let effective_limit = limit.min(UNLIMITED_REFINE_BUDGET);
+            built.truncate(effective_limit);
             for (class_ids, class) in built.iter_mut() {
                 self.refine_class_in_place(conn, class_ids, &by_id, class)?;
             }
@@ -339,7 +355,6 @@ impl IndexDatabase {
             // ALL classes. Classes beyond the budget keep their Plan-2 (un-refined) shape — the
             // inherent best-effort case for unlimited results. After refinement the FULL list is
             // re-sorted by ROI so a refined class that gained/lost rank lands in the right place.
-            const UNLIMITED_REFINE_BUDGET: usize = 50;
             for (idx, (class_ids, class)) in built.iter_mut().enumerate() {
                 if idx >= UNLIMITED_REFINE_BUDGET {
                     break;
@@ -753,15 +768,40 @@ impl IndexDatabase {
             Some(rows) => rows,
         };
 
+        // I3 (#215 Plan 4a adversary): cap the re-parse to the first LCS_MEMBER_SAMPLE members in
+        // canonical (struct_hash, symbol_id) order. `class_lcs_ratio` and `lcs_skeleton` only use
+        // the first LCS_MEMBER_SAMPLE members anyway (the member-count cap in align.rs), so
+        // parsing the tail is pure waste. Sorting here is O(n log n) over metadata rows — cheap
+        // compared to the file-I/O + tree-sitter parse that follows.
+        //
+        // NOTE for Plan 4b: anti-unification's per_member_values will need ALL members, not just
+        // the LCS sample — when 4b lands, load the full set (or lazily extend) for
+        // variation_points.
+        let mut rows = rows;
+        rows.sort_by(|a, b| {
+            a.struct_hash.cmp(&b.struct_hash).then_with(|| a.symbol_id.cmp(&b.symbol_id))
+        });
+        rows.truncate(LCS_MEMBER_SAMPLE);
+
+        // I3 (#215 Plan 4a adversary): dedup file reads by path. A class whose members cluster in a
+        // few large files would otherwise re-read each file once per member; instead cache each
+        // distinct file's bytes and reuse the cached text for every member in that file.
+        let mut file_cache: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+
         let mut members: Vec<crate::index::clones::refine::RefineMember> =
             Vec::with_capacity(rows.len());
         for row in rows {
-            let Ok(text) = std::fs::read_to_string(root.join(&row.path)) else {
-                // Source missing/unreadable on disk — can't reproduce the token sequence.
-                return Ok(None);
-            };
+            if !file_cache.contains_key(&row.path) {
+                let Ok(content) = std::fs::read_to_string(root.join(&row.path)) else {
+                    // Source missing/unreadable on disk — can't reproduce the token sequence.
+                    return Ok(None);
+                };
+                file_cache.insert(row.path.clone(), content);
+            }
+            let text = file_cache.get(&row.path).expect("just inserted above");
             let Some(parsed) =
-                crate::index::parser::parse_file(Path::new(&row.path), row.language, &text)
+                crate::index::parser::parse_file(Path::new(&row.path), row.language, text)
             else {
                 // Parse failure (or a no-grammar language like markdown) — no AST to descend.
                 return Ok(None);
@@ -771,7 +811,7 @@ impl IndexDatabase {
                 // No node spans the persisted byte range — the file drifted off-index.
                 return Ok(None);
             };
-            let seq = crate::index::clones::normalize::normalize_baseline(node, &text);
+            let seq = crate::index::clones::normalize::normalize_baseline(node, text);
 
             // Faithfulness pin: the re-parse must reproduce Plan-1's normalization exactly. A
             // mismatch means the on-disk file no longer matches the indexed fingerprint (the
@@ -1675,7 +1715,7 @@ mod tests {
         crate::IndexDatabase::rebuild(&config).unwrap();
         let db = crate::IndexDatabase::open_config(&config).unwrap();
 
-        // NaN must be rejected.
+        // NaN must be rejected (non-finite, caught by !v.is_finite()).
         let err = db
             .find_clones(FindClonesOptions {
                 min_similarity: Some(f64::NAN),
@@ -1684,11 +1724,11 @@ mod tests {
             })
             .unwrap_err();
         assert!(
-            err.to_string().contains("finite"),
-            "NaN should produce a 'finite' error message, got: {err}"
+            err.to_string().contains("[0.5, 1.0]"),
+            "NaN should produce a '[0.5, 1.0]' error message, got: {err}"
         );
 
-        // +infinity must be rejected.
+        // +infinity must be rejected (non-finite, caught by !v.is_finite()).
         let err = db
             .find_clones(FindClonesOptions {
                 min_similarity: Some(f64::INFINITY),
@@ -1697,11 +1737,11 @@ mod tests {
             })
             .unwrap_err();
         assert!(
-            err.to_string().contains("finite"),
-            "INFINITY should produce a 'finite' error message, got: {err}"
+            err.to_string().contains("[0.5, 1.0]"),
+            "INFINITY should produce a '[0.5, 1.0]' error message, got: {err}"
         );
 
-        // -infinity must be rejected (also non-finite).
+        // -infinity must be rejected (non-finite, caught by !v.is_finite()).
         let err = db
             .find_clones(FindClonesOptions {
                 min_similarity: Some(f64::NEG_INFINITY),
@@ -1710,11 +1750,11 @@ mod tests {
             })
             .unwrap_err();
         assert!(
-            err.to_string().contains("finite"),
-            "NEG_INFINITY should produce an error, got: {err}"
+            err.to_string().contains("[0.5, 1.0]"),
+            "NEG_INFINITY should produce a '[0.5, 1.0]' error message, got: {err}"
         );
 
-        // 0.0 still rejected (in-range check, kept from before).
+        // 0.0 still rejected (below the 0.5 floor).
         assert!(
             db.find_clones(FindClonesOptions {
                 min_similarity: Some(0.0),

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -152,6 +152,27 @@ pub(crate) fn class_key_for(member_refs: &[String]) -> String {
     crate::index::hex_sha256(joined.as_bytes())[..16].to_string()
 }
 
+/// Minimum pairwise overlap/max_len similarity across all member pairs of `class`. This is the same
+/// cohesion floor `build_class` computes for `similarity_min`, recomputed cheaply here as the
+/// tie-breaker for `clones_for_symbol`'s largest-group selection (when the clique-cover split
+/// returns several equal-size groups containing the subject, the most internally-cohesive wins).
+/// A 1-member (or empty) class has no pairs → cohesion 1.0 (vacuously fully coherent).
+fn min_pairwise_cohesion(class: &[i64], by_id: &BTreeMap<i64, &SymbolBag>) -> f64 {
+    let mut min = f64::MAX;
+    for i in 0..class.len() {
+        for j in (i + 1)..class.len() {
+            if let (Some(ba), Some(bb)) = (by_id.get(&class[i]), by_id.get(&class[j])) {
+                let max_len = ba.token_len.max(bb.token_len);
+                let sim = if max_len == 0 { 1.0 } else { overlap(ba, bb) as f64 / max_len as f64 };
+                if sim < min {
+                    min = sim;
+                }
+            }
+        }
+    }
+    if min == f64::MAX { 1.0 } else { min }
+}
+
 /// Sentinel df for tokens with no `clone_token_df` row (LEFT JOIN miss). i64::MAX sorts them LAST
 /// in `(coalesced_df ASC, token_hash ASC)` order — they are treated as maximally common (least
 /// selective), which is the conservative choice: it can only widen the sub-block, never shrink it,
@@ -549,7 +570,28 @@ impl IndexDatabase {
             },
             THETA,
         );
-        let subject_subclass = coherent_classes.into_iter().find(|cls| cls.contains(&symbol_id));
+        // Pick the largest coherent group containing the subject (tie → highest min-pairwise
+        // cohesion → lowest member id). The greedy clique-cover split can return MULTIPLE
+        // overlapping groups containing the subject (e.g. B is in both {A,B} and {B,C} for chain
+        // A~B / B~C / A!~C) — the subject's "best" class is the largest such group, so a reverse
+        // lookup surfaces the richest coherent neighborhood it belongs to rather than an arbitrary
+        // first-fit pair.
+        let subject_subclass = {
+            let candidates: Vec<Vec<i64>> =
+                coherent_classes.into_iter().filter(|cls| cls.contains(&symbol_id)).collect();
+            candidates.into_iter().max_by(|a, b| {
+                a.len()
+                    .cmp(&b.len())
+                    .then_with(|| {
+                        // Higher min-pairwise cohesion wins.
+                        let cohesion_a = min_pairwise_cohesion(a, &by_id);
+                        let cohesion_b = min_pairwise_cohesion(b, &by_id);
+                        cohesion_a.partial_cmp(&cohesion_b).unwrap_or(std::cmp::Ordering::Equal)
+                    })
+                    // Lower first-member id wins; `max_by` keeps the greater, so reverse the cmp.
+                    .then_with(|| b[0].cmp(&a[0]))
+            })
+        };
 
         // Pin the resolved subject so it is guaranteed to appear in the (capped) member list even
         // when its id falls past MAX_MEMBERS in the (sub)class id order — the caller asked about

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -24,6 +24,8 @@ const METRIC_SAMPLE_CAP: usize = 200;
 
 use crate::index::IndexDatabase;
 use crate::index::clones::NORM_VERSION;
+use crate::index::clones::refine::cache::{refine_class, refinement_key};
+use crate::index::clones::refine::split::coherence_split;
 
 /// Similarity threshold θ: a candidate pair is kept iff `overlap / max_len >= THETA`. The MAX
 /// denominator is deliberate (design rev-4 §3b) — it bounds the member length ratio to ≈1/θ, the
@@ -87,6 +89,15 @@ pub struct CandidateCloneClass {
     /// `member_count` / `total_members` / `class_key` are always over the FULL component.
     /// `false` for all normal-size components (the typical case).
     pub metrics_sampled: bool,
+    /// Refinement outputs (#215 Plan 4a). All `None` on an UN-refined candidate class; populated
+    /// only on classes the two-phase driver refined (`refined == true`). `lcs_ratio` is the NiCad
+    /// class fidelity (min pairwise `2·LCS/(|a|+|b|)`); `confidence` is the persisted band
+    /// (`"high"`/`"medium"`/`"low"`); `refactorability` is the `(0,1]`-clamped ROI multiplier;
+    /// `refine_mode` is `Some("baseline")` when refined.
+    pub lcs_ratio: Option<f64>,
+    pub confidence: Option<String>,
+    pub refactorability: Option<f64>,
+    pub refine_mode: Option<&'static str>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -234,26 +245,61 @@ impl IndexDatabase {
 
         let min_copies = opts.min_copies.unwrap_or(2);
 
-        let mut classes: Vec<CandidateCloneClass> = Vec::new();
-
+        // Plan 4a: coherence-SPLIT every component before building classes. Union-find over-merges
+        // transitive chains (A~B, B~C, A!~C ⇒ {A,B,C}); `coherence_split` returns internally-
+        // coherent sub-classes (every pair ≥ θ) instead. A component that splits entirely into
+        // singletons (each < min_copies) yields NO class — that is correct: an over-merged chain
+        // with no coherent ≥2 sub-class is not a real clone class. (No fallback here; the
+        // un-refined-component fallback is `clones_for_symbol`'s, where the caller pinned a
+        // subject.) Each built class travels with its component ids so the two-phase driver
+        // can refine it.
+        let mut built: Vec<(Vec<i64>, CandidateCloneClass)> = Vec::new();
         for component in &components {
             if component.len() < min_copies {
                 continue;
             }
-            // No class-level `similarity_min < theta` filter: θ governs CANDIDATE GENERATION only
-            // (every EDGE in the component is ≥ θ via `candidate_pairs_from_bags`). A component's
-            // aggregate min-pairwise can dip below θ for a TRANSITIVE chain (A–B and B–C both ≥ θ,
-            // but A–C < θ), and that component is legitimately one clone class — it stays visible,
-            // gets ROI-penalized through the cohesion multiplier, and surfaces its low cohesion in
-            // `cohesion_min_pairwise`. Dropping it here also diverged from `clones_for_symbol`,
-            // which never applied this filter, so the two surfaces now agree on chain components.
-            match build_class(component, &by_id, conn, None)? {
-                None => continue,
-                Some(class) => classes.push(class),
+            let coherent_classes = coherence_split(
+                component,
+                |a, b| {
+                    let ba = by_id[&a];
+                    let bb = by_id[&b];
+                    let max_len = ba.token_len.max(bb.token_len);
+                    if max_len == 0 { 1.0 } else { overlap(ba, bb) as f64 / max_len as f64 }
+                },
+                theta,
+            );
+            for class_ids in &coherent_classes {
+                if class_ids.len() < min_copies {
+                    continue;
+                }
+                if let Some(class) = build_class(class_ids, &by_id, conn, None)? {
+                    built.push((class_ids.clone(), class));
+                }
             }
         }
 
-        // Sort by ROI descending (stable for determinism within ties).
+        // ── Two-phase ROI ranking (Plan 4a) ────────────────────────────────────────────────────
+        // Phase 1: sort ALL coherent classes by the Plan-2 (un-refined) ROI — the cohesion
+        // multiplier. The refine budget is the top-N by this provisional rank, where N is the
+        // caller's `limit` (default 50): refining is comparatively expensive (re-read + re-parse +
+        // LCS), so only the classes that could plausibly survive the limit get refined.
+        built.sort_by(|a, b| b.1.roi.partial_cmp(&a.1.roi).unwrap_or(std::cmp::Ordering::Equal));
+        let refine_budget = opts.limit.unwrap_or(50);
+
+        // Phase 2: refine the top-N. Each refined class swaps its ROI cohesion multiplier for
+        // `refactorability` and gets its refinement fields set; un-refinable classes (overlay
+        // scope, drifted source, etc.) keep their Plan-2 shape. After refinement the FULL list is
+        // re-sorted by ROI so a refined class that gained/lost rank lands in the right place.
+        for (idx, (class_ids, class)) in built.iter_mut().enumerate() {
+            if idx >= refine_budget {
+                break;
+            }
+            self.refine_class_in_place(conn, class_ids, &by_id, class)?;
+        }
+
+        let mut classes: Vec<CandidateCloneClass> = built.into_iter().map(|(_, c)| c).collect();
+
+        // Re-sort by ROI descending AFTER refinement (stable for determinism within ties).
         classes.sort_by(|a, b| b.roi.partial_cmp(&a.roi).unwrap_or(std::cmp::Ordering::Equal));
 
         // Capture the post-filter class count BEFORE the limit truncation so `truncated` can
@@ -280,6 +326,65 @@ impl IndexDatabase {
             build_completeness(theta, min_copies, truncated, stale_members, freshness);
 
         Ok(FindClonesResult { classes, completeness })
+    }
+
+    /// Refine one candidate class IN PLACE (#215 Plan 4a): load the class's refine inputs (re-read,
+    /// re-parse, and re-normalize each member to its ordered baseline token sequence), compute the
+    /// content-addressed refinement (read-through `clone_refinements` cache), set the
+    /// refinement fields, flip `refined`/`class_kind`, and swap the ROI cohesion multiplier for
+    /// `refactorability`. This is a NO-OP (the class keeps its Plan-2 un-refined shape) when refine
+    /// inputs are unavailable (overlay scope, drifted source, parse failure, or a vanished
+    /// hydration row), exactly mirroring the un-refinable fallback `load_refine_members`
+    /// already encodes.
+    ///
+    /// `class_ids` is the class's component (the coherent sub-class) symbol ids; `by_id` supplies
+    /// each member's persisted `struct_hash` for the content-addressed key (no extra DB
+    /// round-trip).
+    fn refine_class_in_place(
+        &self,
+        conn: &Connection,
+        class_ids: &[i64],
+        by_id: &BTreeMap<i64, &SymbolBag>,
+        class: &mut CandidateCloneClass,
+    ) -> anyhow::Result<()> {
+        // Refine inputs: the re-parsed ordered token sequences, in CANONICAL (struct_hash, id)
+        // order. `None` ⇒ refine unavailable for this class — leave it un-refined.
+        let Some(members) = self.load_refine_members(class_ids)? else {
+            return Ok(());
+        };
+        // An empty member set (shouldn't happen for a ≥2 class) is not refinable.
+        if members.len() < 2 {
+            return Ok(());
+        }
+
+        // Content-addressed key over the member struct_hash multiset — NOT the read-side
+        // `class.class_key` (location-derived). Pull each member's persisted struct_hash from the
+        // already-loaded bags so the key is computable without a DB hit.
+        let struct_hashes: Vec<String> = class_ids
+            .iter()
+            .filter_map(|id| by_id.get(id).map(|b| b.struct_hash.clone()))
+            .collect();
+        let key = refinement_key(&class.language, &struct_hashes);
+
+        let refinement = refine_class(conn, &key, &class.language, &members, class.similarity_min)?;
+
+        // Swap the ROI cohesion multiplier for `refactorability` on refined classes (Plan 4a). The
+        // other factors are unchanged (cross-module spread × member count × medoid body tokens ×
+        // load-bearing factor); `cohesion_min_pairwise` stays surfaced for transparency.
+        class.roi = class.cross_module_spread as f64
+            * class.member_count as f64
+            * class.body_token_len_medoid as f64
+            * class.roi_factors.load_bearing_factor
+            * refinement.refactorability;
+
+        class.refined = true;
+        class.class_kind = "refined_class";
+        class.lcs_ratio = Some(refinement.lcs_ratio);
+        class.confidence = Some(refinement.confidence.as_db_str().to_string());
+        class.refactorability = Some(refinement.refactorability);
+        class.refine_mode = Some(refinement.refine_mode);
+
+        Ok(())
     }
 }
 
@@ -388,10 +493,43 @@ impl IndexDatabase {
             return Ok(make_result(None, true, true, 0, freshness));
         };
 
+        // Plan 4a: coherence-split the component, then serve the coherent sub-class that contains
+        // the subject. If the subject is a SINGLETON after the split (it cohered with no peer at
+        // θ), fall back to the full UN-refined component so the caller still sees the
+        // symbol's over-merged neighborhood — `clones_for_symbol` is a reverse lookup ABOUT
+        // a specific symbol, so an empty answer for a symbol that IS in an (over-merged)
+        // component would be less useful than the un-refined fallback. `find_clones` has no
+        // such fallback (no subject).
+        let coherent_classes = coherence_split(
+            &component,
+            |a, b| {
+                let ba = by_id[&a];
+                let bb = by_id[&b];
+                let max_len = ba.token_len.max(bb.token_len);
+                if max_len == 0 { 1.0 } else { overlap(ba, bb) as f64 / max_len as f64 }
+            },
+            THETA,
+        );
+        let subject_subclass = coherent_classes.into_iter().find(|cls| cls.contains(&symbol_id));
+
         // Pin the resolved subject so it is guaranteed to appear in the (capped) member list even
-        // when its id falls past MAX_MEMBERS in the component's id order — the caller asked about
+        // when its id falls past MAX_MEMBERS in the (sub)class id order — the caller asked about
         // THIS symbol (Fix 2, #215).
-        let class = build_class(&component, &by_id, conn, Some(symbol_id))?;
+        let class = match subject_subclass {
+            Some(subclass) => {
+                let mut built = build_class(&subclass, &by_id, conn, Some(symbol_id))?;
+                // Always refine the subject's one class when refine inputs are available.
+                if let Some(c) = built.as_mut() {
+                    self.refine_class_in_place(conn, &subclass, &by_id, c)?;
+                }
+                built
+            },
+            None => {
+                // Subject split to a singleton: serve the full un-refined component
+                // (refined=false).
+                build_class(&component, &by_id, conn, Some(symbol_id))?
+            },
+        };
 
         // Count stale member paths over just this class's members (None class → 0 stale).
         let stale_members = match &class {
@@ -410,7 +548,6 @@ impl IndexDatabase {
 /// the baseline `struct_hash` (the canonical sort/cache key). Mirrors `build_class`'s member
 /// hydration but additionally pulls `start_byte`/`end_byte` (for the AST descent) and `struct_hash`
 /// (the faithfulness pin).
-#[allow(dead_code)] // helper of load_refine_members; the driver call site lands in Plan-4a Task 4
 struct RefineRow {
     symbol_id: i64,
     path: String,
@@ -442,7 +579,6 @@ impl IndexDatabase {
     /// scope-correct source read available here for the overlay, so refine is unavailable under an
     /// overlay scope: return `Ok(None)` and let the caller serve the un-refined class. (When a
     /// scope-correct overlay source read lands, this guard can be lifted.)
-    #[allow(dead_code)] // driven by the refine driver in Plan-4a Task 4; exercised by tests now
     pub(crate) fn load_refine_members(
         &self,
         member_ids: &[i64],
@@ -527,7 +663,6 @@ impl IndexDatabase {
 /// `build_class`). Filters the baseline normalizer version so a stale fingerprint row never feeds
 /// the refine input. Returns `Ok(None)` if ANY requested member is absent (a fingerprint row
 /// vanished mid-read, or the symbol fell out of scope): a partial refine would be unfaithful.
-#[allow(dead_code)] // helper of load_refine_members; the driver call site lands in Plan-4a Task 4
 fn load_refine_rows(
     conn: &Connection,
     member_ids: &[i64],
@@ -1042,6 +1177,12 @@ pub(crate) fn build_class(
         roi,
         roi_factors,
         metrics_sampled,
+        // Refinement fields are None on an un-refined candidate class; the two-phase driver in
+        // `find_clones` / `clones_for_symbol` populates them (and flips `refined`/`class_kind`).
+        lcs_ratio: None,
+        confidence: None,
+        refactorability: None,
+        refine_mode: None,
     }))
 }
 

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -477,13 +477,15 @@ impl IndexDatabase {
 /// the warm (cache-hit) and cold (compute+store) paths of [`IndexDatabase::refine_class_in_place`].
 ///
 /// `metrics_sampled` accumulates the sampling dimensions via OR-in:
-/// - `refinement.lcs_sampled` — the per-pair length cap (`LCS_MAX_SEQ_TOKENS`) engaged during the
-///   cold compute. This is NOT persisted in `clone_refinements` (it is an implementation artifact
-///   of the compute, not content), so it is `false` on a cache hit. Residual: the warm path cannot
-///   retroactively flag this dimension, but it is rare in practice.
-/// - `class.member_count > LCS_MEMBER_SAMPLE` — the member-count cap is deterministic from the
-///   class's member count (which the function has independent of cache hit/miss), so it is applied
-///   consistently on BOTH the warm and cold paths. This is the dominant sampling dimension.
+/// - `refinement.lcs_sampled` — either LCS cost cap engaged: the member-count sample
+///   (`LCS_MEMBER_SAMPLE`) OR the per-pair length proxy (`LCS_MAX_SEQ_TOKENS`). This bit is now
+///   PERSISTED in `clone_refinements` (Fix 3, #215 Plan 4a round-2), so it survives a warm cache
+///   hit — the long-sequence dimension is no longer lost on a hit the way it was when the bit was
+///   compute-only.
+/// - `class.member_count > LCS_MEMBER_SAMPLE` — kept as an independent, cache-agnostic guard for
+///   the member-count dimension: it is deterministic from the class's member count regardless of
+///   cache hit/miss, so it flags the member-count sample even for a row that predates the persisted
+///   bit (default 0 on an additively-migrated DB until recomputed).
 fn apply_refinement(
     class: &mut CandidateCloneClass,
     refinement: crate::index::clones::refine::cache::CachedRefinement,
@@ -504,11 +506,12 @@ fn apply_refinement(
     class.refactorability = Some(refinement.refactorability);
     class.refine_mode = Some(refinement.refine_mode);
 
-    // Fold the two LCS sampling dimensions into the class's metrics_sampled flag (OR-in so
-    // any already-sampled Plan-2 metric stays flagged):
-    //   1. lcs_sampled (per-pair length cap) — from the cold compute; false on a warm hit.
-    //   2. member_count > LCS_MEMBER_SAMPLE — deterministically known from class size, consistent
-    //      on both warm and cold paths.
+    // Fold the LCS sampling dimensions into the class's metrics_sampled flag (OR-in so any
+    // already-sampled Plan-2 metric stays flagged):
+    //   1. refinement.lcs_sampled — either cost cap (member-count sample or long-seq proxy), now
+    //      PERSISTED (Fix 3) so it is honored on BOTH the cold compute AND the warm cache hit.
+    //   2. member_count > LCS_MEMBER_SAMPLE — independent, cache-agnostic guard for the
+    //      member-count dimension; covers a pre-persisted-bit row whose stored flag defaults to 0.
     class.metrics_sampled |= refinement.lcs_sampled || class.member_count > LCS_MEMBER_SAMPLE;
 }
 

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -126,6 +126,12 @@ pub struct CloneCompleteness {
     pub index_freshness: String,          // reuse index_status freshness summary
     pub oracle_coverage: &'static str,    // "n/a_baseline_only" in Plan 2 (SCIP is Plan 3)
     pub truncated: bool,
+    /// `true` when `limit` was supplied and was clamped by the refine budget (the budget,
+    /// currently 50, is less than the requested limit AND the total built classes exceed the
+    /// budget). A `true` value means classes beyond the refine budget were dropped — use
+    /// `limit: None` to retrieve all classes. Always `false` on the unlimited path and on
+    /// `clones_for_symbol`.
+    pub refine_budget_clamped: bool,
     /// Count of DISTINCT member file paths whose on-disk content no longer matches the indexed
     /// `files.sha256`. A non-zero value means the returned clone classes describe STALE file
     /// contents — consumers should reindex / `rag-rat heal` before acting on these results.
@@ -229,7 +235,10 @@ pub struct FindClonesOptions {
     pub min_similarity: Option<f64>,
     /// Minimum number of copies for a class to be returned. Defaults to 2 if `None`.
     pub min_copies: Option<usize>,
-    /// Maximum number of classes to return (sorted by ROI desc). No limit if `None`.
+    /// Maximum number of classes to return (sorted by ROI desc). No limit if `None`. Note: a
+    /// limited query is clamped to the refine budget (currently 50) — `limit: Some(N)` returns at
+    /// most 50 classes, all refined. To retrieve more classes (only the top 50 refined), use
+    /// `limit: None`.
     pub limit: Option<usize>,
 }
 
@@ -248,6 +257,12 @@ impl IndexDatabase {
     /// score, filters by `min_similarity` / `min_copies`, sorts by ROI descending, and attaches a
     /// [`CloneCompleteness`] provenance block. Classes are UNREFINED (Plan 4 adds coherence
     /// splitting and anti-unification).
+    ///
+    /// **Refine-budget cap:** a limited query (`limit: Some(N)`) clamps to the refine budget
+    /// (currently 50): at most 50 classes are returned, all refined. An unlimited query
+    /// (`limit: None`) returns all classes (only the top 50 refined, the rest unrefined). Use
+    /// `limit: None` to retrieve more than 50 classes. `completeness.refine_budget_clamped`
+    /// reports when a supplied limit was clamped by the budget AND classes were dropped.
     pub fn find_clones(&self, opts: FindClonesOptions) -> anyhow::Result<FindClonesResult> {
         let conn = self.storage.connection();
 
@@ -372,14 +387,28 @@ impl IndexDatabase {
         let truncated = classes.iter().any(|c| c.members_returned < c.total_members)
             || total_classes_built > classes.len();
 
+        // refine_budget_clamped: true when a limit was supplied, the limit exceeded the budget, AND
+        // the budget actually dropped classes (total_classes_built > effective_limit). A limit at
+        // or below the budget never clamps; a limit above the budget only clamps when there
+        // were more built classes than the budget could return.
+        let refine_budget_clamped = opts.limit.is_some_and(|lim| {
+            lim > UNLIMITED_REFINE_BUDGET && total_classes_built > UNLIMITED_REFINE_BUDGET
+        });
+
         let freshness = self.meta("git_commit")?.unwrap_or_else(|| "unknown".to_string());
 
         // Count DISTINCT member file paths whose on-disk content no longer matches the indexed
         // sha256 (read-only signal; Plan 2 does not heal-before-return).
         let stale_members = count_stale_member_paths(self, conn, &classes)?;
 
-        let completeness =
-            build_completeness(theta, min_copies, truncated, stale_members, freshness);
+        let completeness = build_completeness(
+            theta,
+            min_copies,
+            truncated,
+            refine_budget_clamped,
+            stale_members,
+            freshness,
+        );
 
         Ok(FindClonesResult { classes, completeness })
     }
@@ -531,12 +560,15 @@ fn apply_refinement(
 }
 
 /// Build the [`CloneCompleteness`] provenance block shared by `find_clones` and
-/// `clones_for_symbol`. Only `min_similarity` (θ), `min_copies`, `truncated`, `stale_members`,
-/// and the index freshness summary vary per call; the rest are fixed Plan-2 policy constants.
+/// `clones_for_symbol`. Only `min_similarity` (θ), `min_copies`, `truncated`,
+/// `refine_budget_clamped`, `stale_members`, and the index freshness summary vary per call; the
+/// rest are fixed Plan-2 policy constants. `clones_for_symbol` always passes
+/// `refine_budget_clamped = false` (it has no class limit).
 fn build_completeness(
     min_similarity: f64,
     min_copies: usize,
     truncated: bool,
+    refine_budget_clamped: bool,
     stale_members: usize,
     freshness: String,
 ) -> CloneCompleteness {
@@ -554,6 +586,7 @@ fn build_completeness(
         index_freshness: freshness,
         oracle_coverage: "n/a_baseline_only",
         truncated,
+        refine_budget_clamped,
         stale_members,
         known_index_gaps: vec![
             "#232: TS function-valued declarators not yet fingerprinted".into(),
@@ -608,7 +641,15 @@ impl IndexDatabase {
                 class,
                 symbol_resolved,
                 symbol_fingerprinted,
-                completeness: build_completeness(THETA, 2, truncated, stale_members, freshness),
+                // No class limit on this path → never refine-budget-clamped.
+                completeness: build_completeness(
+                    THETA,
+                    2,
+                    truncated,
+                    false,
+                    stale_members,
+                    freshness,
+                ),
             }
         };
 

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -24,6 +24,7 @@ const METRIC_SAMPLE_CAP: usize = 200;
 
 use crate::index::IndexDatabase;
 use crate::index::clones::NORM_VERSION;
+use crate::index::clones::refine::align::LCS_MEMBER_SAMPLE;
 use crate::index::clones::refine::cache::{
     refine_compute_and_store, refine_lookup, refinement_key,
 };
@@ -387,86 +388,128 @@ impl IndexDatabase {
         by_id: &BTreeMap<i64, &SymbolBag>,
         class: &mut CandidateCloneClass,
     ) -> anyhow::Result<()> {
-        // Refine inputs: the re-parsed ordered token sequences, in CANONICAL (struct_hash, id)
-        // order. `None` ⇒ refine unavailable for this class — leave it un-refined.
-        let Some(members) = self.load_refine_members(class_ids)? else {
-            return Ok(());
-        };
-        // An empty member set (shouldn't happen for a ≥2 class) is not refinable.
-        if members.len() < 2 {
-            return Ok(());
-        }
-
-        // Content-addressed key over the member struct_hash multiset — NOT the read-side
-        // `class.class_key` (location-derived). Pull each member's persisted struct_hash from the
-        // already-loaded bags so the key is computable without a DB hit.
+        // ── Phase 0 (CHEAP, NO RE-PARSE): build the content-addressed key from each member's
+        // persisted struct_hash already in `by_id` — no file I/O, no tree-sitter parse.
+        // If a class member's struct_hash is somehow absent from `by_id` (shouldn't happen for a
+        // coherent class, but defend anyway) the key would be over an incomplete multiset, which
+        // could alias a different class. Fall back to leaving this class un-refined rather than
+        // computing a wrong refinement.
         let struct_hashes: Vec<String> = class_ids
             .iter()
             .filter_map(|id| by_id.get(id).map(|b| b.struct_hash.clone()))
             .collect();
-        let key = refinement_key(&class.language, &struct_hashes);
+        if struct_hashes.len() != class_ids.len() {
+            // Defensive: a member's bag is missing — skip rather than key over a partial multiset.
+            return Ok(());
+        }
 
+        // Content-addressed key over the member struct_hash multiset — NOT the read-side
+        // `class.class_key` (location-derived). Two classes with the same structural content share
+        // a refinement; the key survives a reindex that reassigns rowids.
+        //
         // For coherent classes exceeding METRIC_SAMPLE_CAP members, `class.similarity_min` was
         // derived from the first `METRIC_SAMPLE_CAP` members only (the metric-sample path in
         // `build_class`), while `key` spans the FULL struct_hash multiset. The gap is not a
         // determinism break — the sample is id-ASC stable — but Plan-4b should compute confidence
         // over the full set or fold the sample into the key.
+        let key = refinement_key(&class.language, &struct_hashes);
+
+        // ── Phase 1 (PURE READ — warm path): probe the content-addressed cache. A SELECT is safe
+        // on the MCP's read-only connection; a WARM cache hit never takes the write lock and never
+        // re-parses any source file. This is the main perf win: the re-parse (load_refine_members,
+        // below) was previously called BEFORE the cache probe, so a warm hit still paid the full
+        // tree-sitter re-parse cost for every member — now it is bypassed entirely.
         //
-        // Phase 1 — PURE READ: probe the content-addressed cache. A SELECT is safe on the MCP's
-        // read-only connection, so a WARM (cache-hit) refine never takes the write lock and never
-        // recomputes anything.
-        let cached = refine_lookup(conn, &key)?;
-        let refinement = if let Some(cached) = cached {
-            // WARM path: cache hit — no compute, no write, fully RO-safe.
-            cached
-        } else {
-            // COLD path: cache miss. The fix it serves (#215 Plan 4a): do NOT run the expensive LCS
-            // compute on a read-only connection only to have the INSERT fail with SQLITE_READONLY
-            // and the whole MCP call retry read-write — recomputing. Instead, BEFORE any compute,
-            // probe writability. If the connection is read-only, surface a genuine SQLITE_READONLY
-            // error so `is_readonly_violation` flags it and the dispatcher retries read-write; the
-            // retry takes this same cold path but writable (so this branch is skipped) and computes
-            // exactly once.
-            if conn.is_readonly(rusqlite::MAIN_DB)? {
-                // Mint a real SQLITE_READONLY `rusqlite::Error` that `is_readonly_violation`
-                // recognizes, WITHOUT the expensive LCS work. A zero-row write to a real table
-                // (`DELETE … WHERE 1=0`) acquires the write lock → fails with SQLITE_READONLY on a
-                // RO connection. (A `BEGIN IMMEDIATE` does NOT error here — this rusqlite/SQLite
-                // build defers the write-lock acquisition past transaction-start, so the probe must
-                // be an actual write statement.) The `WHERE 1=0` makes it a true no-op even on a
-                // writable connection; in practice this branch only runs on the RO pass, since the
-                // RW retry sees `is_readonly == false` and skips straight to the compute.
-                conn.execute("DELETE FROM clone_refinements WHERE 1=0", [])?;
-                // The probe MUST error on a RO connection; if it somehow didn't, bail rather than
-                // fall through to a compute whose INSERT would itself fail.
-                anyhow::bail!("clone refine requires a writable connection");
-            }
-            // Writable: compute once and persist.
-            refine_compute_and_store(conn, &key, &class.language, &members, class.similarity_min)?
+        // CORRECTNESS NOTE: on a cache HIT we intentionally skip the load_refine_members
+        // struct_hash-faithfulness re-validation. This is safe: the cache is keyed by the persisted
+        // struct_hash multiset, so a drifted source that changes struct_hash produces a different
+        // key → cache miss → cold path (re-parse + faithfulness check). Staleness is separately
+        // surfaced to callers via `completeness.stale_members`. Skipping the re-validation on warm
+        // hits is therefore not a regression; it is the designed behavior.
+        if let Some(refinement) = refine_lookup(conn, &key)? {
+            // WARM path: cache hit — apply the refinement without re-parsing any source files.
+            apply_refinement(class, refinement);
+            return Ok(());
+        }
+
+        // ── Phase 2 (COLD path only): cache miss. Before any expensive work, probe writability. If
+        // the connection is read-only, surface a genuine SQLITE_READONLY error so
+        // `is_readonly_violation` flags it and the MCP dispatcher retries read-write; the retry
+        // takes the same path but writable (Phase 1 may hit the cache on the retry if a concurrent
+        // writer raced us, or falls through to the compute below).
+        if conn.is_readonly(rusqlite::MAIN_DB)? {
+            // Mint a real SQLITE_READONLY `rusqlite::Error` that `is_readonly_violation`
+            // recognizes, WITHOUT any expensive LCS work. A zero-row write to a real table
+            // (`DELETE … WHERE 1=0`) acquires the write lock → fails with SQLITE_READONLY on a
+            // RO connection. (A `BEGIN IMMEDIATE` does NOT error here — this rusqlite/SQLite
+            // build defers the write-lock acquisition past transaction-start, so the probe must
+            // be an actual write statement.) The `WHERE 1=0` makes it a true no-op even on a
+            // writable connection; in practice this branch only runs on the RO pass, since the
+            // RW retry sees `is_readonly == false` and skips straight to the compute.
+            conn.execute("DELETE FROM clone_refinements WHERE 1=0", [])?;
+            // The probe MUST error on a RO connection; if it somehow didn't, bail rather than
+            // fall through to a compute whose INSERT would itself fail.
+            anyhow::bail!("clone refine requires a writable connection");
+        }
+
+        // ── Phase 3 (writable cold path): re-parse each member's source file with tree-sitter,
+        // compute the LCS ratio + refactorability, persist in the cache, and apply.
+        // `load_refine_members` is the expensive step (file reads + tree-sitter parses).
+        // `None` ⇒ refine unavailable (overlay scope, drifted source, parse failure, or a
+        // vanished fingerprint row) — leave the class un-refined.
+        let Some(members) = self.load_refine_members(class_ids)? else {
+            return Ok(());
         };
+        // An empty or singleton member set (shouldn't happen for a ≥2 class) is not refinable.
+        if members.len() < 2 {
+            return Ok(());
+        }
 
-        // Swap the ROI cohesion multiplier for `refactorability` on refined classes (Plan 4a). The
-        // other factors are unchanged (cross-module spread × member count × medoid body tokens ×
-        // load-bearing factor); `cohesion_min_pairwise` stays surfaced for transparency.
-        class.roi = class.cross_module_spread as f64
-            * class.member_count as f64
-            * class.body_token_len_medoid as f64
-            * class.roi_factors.load_bearing_factor
-            * refinement.refactorability;
-
-        class.refined = true;
-        class.class_kind = "refined_class";
-        class.lcs_ratio = Some(refinement.lcs_ratio);
-        class.confidence = Some(refinement.confidence.as_db_str().to_string());
-        class.refactorability = Some(refinement.refactorability);
-        class.refine_mode = Some(refinement.refine_mode);
-        // Fold the refine LCS cost-cap marker into the class's sampling flag (Fix 1): a refined
-        // class whose fidelity was bounded (member sample / Dice proxy) reports `metrics_sampled`.
-        // OR-in so an already-sampled Plan-2 metric stays flagged.
-        class.metrics_sampled |= refinement.lcs_sampled;
+        let refinement =
+            refine_compute_and_store(conn, &key, &class.language, &members, class.similarity_min)?;
+        apply_refinement(class, refinement);
 
         Ok(())
     }
+}
+
+/// Apply a [`CachedRefinement`] to a [`CandidateCloneClass`] in place (Plan 4a). Shared between
+/// the warm (cache-hit) and cold (compute+store) paths of [`IndexDatabase::refine_class_in_place`].
+///
+/// `metrics_sampled` accumulates the sampling dimensions via OR-in:
+/// - `refinement.lcs_sampled` — the per-pair length cap (`LCS_MAX_SEQ_TOKENS`) engaged during the
+///   cold compute. This is NOT persisted in `clone_refinements` (it is an implementation artifact
+///   of the compute, not content), so it is `false` on a cache hit. Residual: the warm path cannot
+///   retroactively flag this dimension, but it is rare in practice.
+/// - `class.member_count > LCS_MEMBER_SAMPLE` — the member-count cap is deterministic from the
+///   class's member count (which the function has independent of cache hit/miss), so it is applied
+///   consistently on BOTH the warm and cold paths. This is the dominant sampling dimension.
+fn apply_refinement(
+    class: &mut CandidateCloneClass,
+    refinement: crate::index::clones::refine::cache::CachedRefinement,
+) {
+    // Swap the ROI cohesion multiplier for `refactorability` on refined classes (Plan 4a). The
+    // other factors are unchanged (cross-module spread × member count × medoid body tokens ×
+    // load-bearing factor); `cohesion_min_pairwise` stays surfaced for transparency.
+    class.roi = class.cross_module_spread as f64
+        * class.member_count as f64
+        * class.body_token_len_medoid as f64
+        * class.roi_factors.load_bearing_factor
+        * refinement.refactorability;
+
+    class.refined = true;
+    class.class_kind = "refined_class";
+    class.lcs_ratio = Some(refinement.lcs_ratio);
+    class.confidence = Some(refinement.confidence.as_db_str().to_string());
+    class.refactorability = Some(refinement.refactorability);
+    class.refine_mode = Some(refinement.refine_mode);
+
+    // Fold the two LCS sampling dimensions into the class's metrics_sampled flag (OR-in so
+    // any already-sampled Plan-2 metric stays flagged):
+    //   1. lcs_sampled (per-pair length cap) — from the cold compute; false on a warm hit.
+    //   2. member_count > LCS_MEMBER_SAMPLE — deterministically known from class size, consistent
+    //      on both warm and cold paths.
+    class.metrics_sampled |= refinement.lcs_sampled || class.member_count > LCS_MEMBER_SAMPLE;
 }
 
 /// Build the [`CloneCompleteness`] provenance block shared by `find_clones` and

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -366,6 +366,11 @@ impl IndexDatabase {
             .collect();
         let key = refinement_key(&class.language, &struct_hashes);
 
+        // For coherent classes exceeding METRIC_SAMPLE_CAP members, `class.similarity_min` was
+        // derived from the first `METRIC_SAMPLE_CAP` members only (the metric-sample path in
+        // `build_class`), while `key` spans the FULL struct_hash multiset. The gap is not a
+        // determinism break — the sample is id-ASC stable — but Plan-4b should compute confidence
+        // over the full set or fold the sample into the key.
         let refinement = refine_class(conn, &key, &class.language, &members, class.similarity_min)?;
 
         // Swap the ROI cohesion multiplier for `refactorability` on refined classes (Plan 4a). The

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -588,8 +588,10 @@ impl IndexDatabase {
                         let cohesion_b = min_pairwise_cohesion(b, &by_id);
                         cohesion_a.partial_cmp(&cohesion_b).unwrap_or(std::cmp::Ordering::Equal)
                     })
-                    // Lower first-member id wins; `max_by` keeps the greater, so reverse the cmp.
-                    .then_with(|| b[0].cmp(&a[0]))
+                    // Fully-deterministic final tiebreak: compare the full sorted member-id vector
+                    // (lexicographically, reversed so max_by keeps the lexicographically-smallest).
+                    // `max_by` returns the LAST equal element, so we reverse: "greater" vector loses.
+                    .then_with(|| b.cmp(a))
             })
         };
 

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -7,6 +7,7 @@
 //! shared total order plus the exact verify, so a missing/stale df never drops a true clone.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
 
 use rusqlite::{Connection, OptionalExtension};
 
@@ -403,6 +404,191 @@ impl IndexDatabase {
 
         Ok(make_result(class, true, true, stale_members, freshness))
     }
+}
+
+/// One member's persisted hydration row before the re-parse: scoped path + byte range + language +
+/// the baseline `struct_hash` (the canonical sort/cache key). Mirrors `build_class`'s member
+/// hydration but additionally pulls `start_byte`/`end_byte` (for the AST descent) and `struct_hash`
+/// (the faithfulness pin).
+#[allow(dead_code)] // helper of load_refine_members; the driver call site lands in Plan-4a Task 4
+struct RefineRow {
+    symbol_id: i64,
+    path: String,
+    start_byte: usize,
+    end_byte: usize,
+    language: crate::language::Language,
+    struct_hash: String,
+}
+
+impl IndexDatabase {
+    /// Load refine inputs for a class's members (#215 Plan 4a Task 2): resolve each member's scoped
+    /// path + byte range, read the active-scope-correct source, parse, descend to the symbol node,
+    /// and `normalize_baseline` into the ordered baseline token sequence. Returns members in
+    /// CANONICAL sorted-by-`struct_hash` order (then `symbol_id` as a tiebreak) — the ordinal basis
+    /// the anti-unify step's `per_member_values[]` aligns to.
+    ///
+    /// Returns `Ok(None)` if refine inputs are unavailable for ANY member — source
+    /// missing/unreadable, a hydration row that vanished mid-read (TOCTOU), a parse failure, no AST
+    /// node at the byte range, or a re-parse whose `struct_hash` no longer matches the persisted
+    /// one (the file drifted off-index). The caller falls back to an un-refined class.
+    /// Returning `None` on ANY missing member (rather than dropping it) keeps the class a
+    /// faithful whole: a partial refine over a subset of members would mis-rank and
+    /// mis-template.
+    ///
+    /// SCOPE LIMITATION (deliberate, mirrors `count_stale_member_paths` / the staleness heal path):
+    /// under a LINKED-WORKTREE OVERLAY scope, `source_root` is the MAIN checkout — NOT the branch
+    /// the overlay's symbol rows came from. Re-reading main's bytes at the overlay member's byte
+    /// range would parse the WRONG source (or fail entirely on a branch-only file). There is no
+    /// scope-correct source read available here for the overlay, so refine is unavailable under an
+    /// overlay scope: return `Ok(None)` and let the caller serve the un-refined class. (When a
+    /// scope-correct overlay source read lands, this guard can be lifted.)
+    #[allow(dead_code)] // driven by the refine driver in Plan-4a Task 4; exercised by tests now
+    pub(crate) fn load_refine_members(
+        &self,
+        member_ids: &[i64],
+    ) -> anyhow::Result<Option<Vec<crate::index::clones::refine::RefineMember>>> {
+        if member_ids.is_empty() {
+            return Ok(Some(Vec::new()));
+        }
+
+        // Overlay scope: no scope-correct source read is available (see doc above). Bail to the
+        // un-refined fallback rather than re-parse the wrong (main-checkout) bytes.
+        if self.active_scope_is_linked_overlay() {
+            return Ok(None);
+        }
+
+        let Some(root) = self.storage.source_root() else {
+            return Ok(None);
+        };
+
+        let conn = self.storage.connection();
+        let rows = match load_refine_rows(conn, member_ids)? {
+            None => return Ok(None),
+            Some(rows) => rows,
+        };
+
+        let mut members: Vec<crate::index::clones::refine::RefineMember> =
+            Vec::with_capacity(rows.len());
+        for row in rows {
+            let Ok(text) = std::fs::read_to_string(root.join(&row.path)) else {
+                // Source missing/unreadable on disk — can't reproduce the token sequence.
+                return Ok(None);
+            };
+            let Some(parsed) =
+                crate::index::parser::parse_file(Path::new(&row.path), row.language, &text)
+            else {
+                // Parse failure (or a no-grammar language like markdown) — no AST to descend.
+                return Ok(None);
+            };
+            let Some(node) = parsed.root().descendant_for_byte_range(row.start_byte, row.end_byte)
+            else {
+                // No node spans the persisted byte range — the file drifted off-index.
+                return Ok(None);
+            };
+            let seq = crate::index::clones::normalize::normalize_baseline(node, &text);
+
+            // Faithfulness pin: the re-parse must reproduce Plan-1's normalization exactly. A
+            // mismatch means the on-disk file no longer matches the indexed fingerprint (the
+            // `files.sha256` staleness signal would also flag it) — refining a drifted member would
+            // align stale tokens, so bail to the un-refined fallback rather than panic in
+            // production.
+            let reparsed_hash = crate::index::clones::tokens::struct_hash(&seq);
+            if reparsed_hash != row.struct_hash {
+                eprintln!(
+                    "clones: refine re-parse struct_hash mismatch for symbol {} ({}) — file \
+                     drifted off-index; serving un-refined class",
+                    row.symbol_id, row.path
+                );
+                return Ok(None);
+            }
+
+            members.push(crate::index::clones::refine::RefineMember {
+                symbol_id: row.symbol_id,
+                lang: row.language,
+                path: row.path,
+                start_byte: row.start_byte,
+                end_byte: row.end_byte,
+                struct_hash: row.struct_hash,
+                seq,
+            });
+        }
+
+        // Canonical order: by struct_hash ascending, then symbol_id (the refine ordinal basis).
+        members.sort_by(|a, b| {
+            a.struct_hash.cmp(&b.struct_hash).then_with(|| a.symbol_id.cmp(&b.symbol_id))
+        });
+
+        Ok(Some(members))
+    }
+}
+
+/// Hydrate the scoped path + byte range + language + persisted baseline `struct_hash` for each
+/// `member_ids` symbol, in chunks of [`HYDRATION_CHUNK`] (the same SQLite host-param discipline as
+/// `build_class`). Filters the baseline normalizer version so a stale fingerprint row never feeds
+/// the refine input. Returns `Ok(None)` if ANY requested member is absent (a fingerprint row
+/// vanished mid-read, or the symbol fell out of scope): a partial refine would be unfaithful.
+#[allow(dead_code)] // helper of load_refine_members; the driver call site lands in Plan-4a Task 4
+fn load_refine_rows(
+    conn: &Connection,
+    member_ids: &[i64],
+) -> anyhow::Result<Option<Vec<RefineRow>>> {
+    let mut rows: Vec<RefineRow> = Vec::with_capacity(member_ids.len());
+    for chunk in member_ids.chunks(HYDRATION_CHUNK) {
+        let id_placeholders: Vec<String> = (1..=chunk.len()).map(|i| format!("?{i}")).collect();
+        let version_placeholder = format!("?{}", chunk.len() + 1);
+        let sql = format!(
+            "SELECT symbols.id, files.path, symbols.start_byte, symbols.end_byte, \
+             symbols.language, sf.struct_hash
+             FROM symbols
+             JOIN files ON files.id = symbols.file_id
+             JOIN symbol_fingerprints sf
+               ON sf.symbol_id = symbols.id
+               AND sf.normalizer_kind = 'baseline'
+               AND sf.normalizer_version = {version_placeholder}
+             WHERE symbols.id IN ({})
+             ORDER BY symbols.id",
+            id_placeholders.join(", ")
+        );
+        let params: Vec<i64> = chunk.iter().copied().chain(std::iter::once(NORM_VERSION)).collect();
+        let mut stmt = conn.prepare(&sql)?;
+        let chunk_rows = stmt.query_map(rusqlite::params_from_iter(params.iter()), |row| {
+            let start_byte: i64 = row.get(2)?;
+            let end_byte: i64 = row.get(3)?;
+            let lang_str: String = row.get(4)?;
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                start_byte,
+                end_byte,
+                lang_str,
+                row.get::<_, String>(5)?,
+            ))
+        })?;
+        for row in chunk_rows {
+            let (symbol_id, path, start_byte, end_byte, lang_str, struct_hash) = row?;
+            // A negative byte offset can't occur (schema NOT NULL, written from usize), but guard
+            // the cast so a corrupt row degrades to the un-refined fallback rather than panicking.
+            let (Ok(start_byte), Ok(end_byte)) =
+                (usize::try_from(start_byte), usize::try_from(end_byte))
+            else {
+                return Ok(None);
+            };
+            // An unparseable language string means the row's language is no longer one this build
+            // understands — bail to the un-refined fallback.
+            let Ok(language) = lang_str.parse::<crate::language::Language>() else {
+                return Ok(None);
+            };
+            rows.push(RefineRow { symbol_id, path, start_byte, end_byte, language, struct_hash });
+        }
+    }
+
+    // EVERY requested member must hydrate. A missing one (vanished fingerprint row, out-of-scope
+    // symbol) makes the class incomplete — refine the whole class or none of it.
+    if rows.len() != member_ids.len() {
+        return Ok(None);
+    }
+    rows.sort_unstable_by_key(|r| r.symbol_id);
+    Ok(Some(rows))
 }
 
 /// Count DISTINCT member file paths in `classes` whose on-disk content no longer matches the

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -635,11 +635,9 @@ impl IndexDatabase {
             // production.
             let reparsed_hash = crate::index::clones::tokens::struct_hash(&seq);
             if reparsed_hash != row.struct_hash {
-                eprintln!(
-                    "clones: refine re-parse struct_hash mismatch for symbol {} ({}) — file \
-                     drifted off-index; serving un-refined class",
-                    row.symbol_id, row.path
-                );
+                // Silent degrade: a library read must not write to stderr. The drift is already
+                // surfaced to callers via `completeness.stale_members`; here we just fall back to
+                // the un-refined class rather than align stale tokens.
                 return Ok(None);
             }
 

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -85,11 +85,19 @@ pub struct CandidateCloneClass {
     pub body_token_len_medoid: i64,
     pub roi: f64,
     pub roi_factors: RoiFactors,
-    /// `true` when the component has more than [`METRIC_SAMPLE_CAP`] members and the pairwise
-    /// metric computation (`similarity_min`, medoid, `similarity_medoid_min`, `containment_max`)
-    /// ran over only the first `METRIC_SAMPLE_CAP` members instead of the full upper triangle.
+    /// `true` when a cost cap engaged for this class's metric computation, so a sampled metric is
+    /// distinguishable from an exact one. Two independent caps set it:
+    /// - The Plan-2 pairwise-metric cap ([`METRIC_SAMPLE_CAP`]): the component has more than
+    ///   `METRIC_SAMPLE_CAP` members and the pairwise loop (`similarity_min`, medoid,
+    ///   `similarity_medoid_min`, `containment_max`) ran over only the first `METRIC_SAMPLE_CAP`.
+    /// - The Plan-4a refine LCS caps (`LCS_MEMBER_SAMPLE` / `LCS_MAX_SEQ_TOKENS`, Fix 1): the
+    ///   refine pass bounded the all-pairs LCS by sampling members and/or replacing very long
+    ///   pairs with the multiset-Dice proxy. `refine_class_in_place` ORs the refinement's
+    ///   `lcs_sampled` into this flag, so a refined class with a cost-bounded fidelity reports
+    ///   `true`.
+    ///
     /// `member_count` / `total_members` / `class_key` are always over the FULL component.
-    /// `false` for all normal-size components (the typical case).
+    /// `false` for all normal-size components computed exactly (the typical case).
     pub metrics_sampled: bool,
     /// Refinement outputs (#215 Plan 4a). All `None` on an UN-refined candidate class; populated
     /// only on classes the two-phase driver refined (`refined == true`). `lcs_ratio` is the NiCad
@@ -303,41 +311,50 @@ impl IndexDatabase {
 
         // ── Two-phase ROI ranking (Plan 4a) ────────────────────────────────────────────────────
         // Phase 1: sort ALL coherent classes by the Plan-2 (un-refined) ROI — the cohesion
-        // multiplier. The refine budget is the top-N by this provisional rank, where N is the
-        // caller's `limit` (default 50): refining is comparatively expensive (re-read + re-parse +
-        // LCS), so only the classes that could plausibly survive the limit get refined.
+        // multiplier. Refining is comparatively expensive (re-read + re-parse + LCS), so the
+        // provisional rank picks which classes are worth refining.
         built.sort_by(|a, b| b.1.roi.partial_cmp(&a.1.roi).unwrap_or(std::cmp::Ordering::Equal));
-        let refine_budget = opts.limit.unwrap_or(50);
 
-        // Phase 2: refine the top-N. Each refined class swaps its ROI cohesion multiplier for
-        // `refactorability` and gets its refinement fields set; un-refinable classes (overlay
-        // scope, drifted source, etc.) keep their Plan-2 shape. After refinement the FULL list is
-        // re-sorted by ROI so a refined class that gained/lost rank lands in the right place.
-        for (idx, (class_ids, class)) in built.iter_mut().enumerate() {
-            if idx >= refine_budget {
-                break;
+        // Total coherent classes BEFORE any limit drop — feeds the `truncated` flag below so a
+        // limited result that dropped whole classes still reports `truncated == true`.
+        let total_classes_built = built.len();
+
+        let classes: Vec<CandidateCloneClass> = if let Some(limit) = opts.limit {
+            // Limited result (Fix 2, Codex P2 #215 Plan 4a): truncate to the top-N by PROVISIONAL
+            // ROI BEFORE refining, refine exactly those N, then re-sort ONLY those N by final
+            // (refactorability) ROI. This guarantees every class in a limited result is either
+            // refined or best-effort-unrefined (`load_refine_members` returned None), all ranked on
+            // a consistent basis — no unrefined rank-(N+1) class can displace a refined one after
+            // re-sorting (the old refine-top-N-then-re-sort-ALL path could).
+            built.truncate(limit);
+            for (class_ids, class) in built.iter_mut() {
+                self.refine_class_in_place(conn, class_ids, &by_id, class)?;
             }
-            self.refine_class_in_place(conn, class_ids, &by_id, class)?;
-        }
-
-        let mut classes: Vec<CandidateCloneClass> = built.into_iter().map(|(_, c)| c).collect();
-
-        // Re-sort by ROI descending AFTER refinement (stable for determinism within ties).
-        classes.sort_by(|a, b| b.roi.partial_cmp(&a.roi).unwrap_or(std::cmp::Ordering::Equal));
-
-        // Capture the post-filter class count BEFORE the limit truncation so `truncated` can
-        // report classes dropped by the limit (Fix 2), not just members capped within a class.
-        let classes_after_filter = classes.len();
-
-        if let Some(limit) = opts.limit {
-            classes.truncate(limit);
-        }
+            let mut cs: Vec<CandidateCloneClass> = built.into_iter().map(|(_, c)| c).collect();
+            cs.sort_by(|a, b| b.roi.partial_cmp(&a.roi).unwrap_or(std::cmp::Ordering::Equal));
+            cs
+        } else {
+            // Unlimited result: refine the top-`UNLIMITED_REFINE_BUDGET` by provisional ROI, return
+            // ALL classes. Classes beyond the budget keep their Plan-2 (un-refined) shape — the
+            // inherent best-effort case for unlimited results. After refinement the FULL list is
+            // re-sorted by ROI so a refined class that gained/lost rank lands in the right place.
+            const UNLIMITED_REFINE_BUDGET: usize = 50;
+            for (idx, (class_ids, class)) in built.iter_mut().enumerate() {
+                if idx >= UNLIMITED_REFINE_BUDGET {
+                    break;
+                }
+                self.refine_class_in_place(conn, class_ids, &by_id, class)?;
+            }
+            let mut cs: Vec<CandidateCloneClass> = built.into_iter().map(|(_, c)| c).collect();
+            cs.sort_by(|a, b| b.roi.partial_cmp(&a.roi).unwrap_or(std::cmp::Ordering::Equal));
+            cs
+        };
 
         // `truncated` is true if ANY returned class capped its member list (members_returned <
-        // total_members) OR the class-limit dropped whole classes (classes_after_filter >
-        // returned).
+        // total_members) OR whole classes were dropped to honor the limit (limited path only —
+        // `total_classes_built` exceeds the returned count).
         let truncated = classes.iter().any(|c| c.members_returned < c.total_members)
-            || classes_after_filter > classes.len();
+            || total_classes_built > classes.len();
 
         let freshness = self.meta("git_commit")?.unwrap_or_else(|| "unknown".to_string());
 
@@ -443,6 +460,10 @@ impl IndexDatabase {
         class.confidence = Some(refinement.confidence.as_db_str().to_string());
         class.refactorability = Some(refinement.refactorability);
         class.refine_mode = Some(refinement.refine_mode);
+        // Fold the refine LCS cost-cap marker into the class's sampling flag (Fix 1): a refined
+        // class whose fidelity was bounded (member sample / Dice proxy) reports `metrics_sampled`.
+        // OR-in so an already-sampled Plan-2 metric stays flagged.
+        class.metrics_sampled |= refinement.lcs_sampled;
 
         Ok(())
     }

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1123,6 +1123,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_027_ID => Some(27),
             MIGRATION_028_ID => Some(28),
             MIGRATION_029_ID => Some(29),
+            MIGRATION_030_ID => Some(30),
             _ => None,
         })
         .max()
@@ -1161,6 +1162,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_027_ID
             | MIGRATION_028_ID
             | MIGRATION_029_ID
+            | MIGRATION_030_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1196,6 +1198,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_027_ID => migration.checksum != MIGRATION_027_CHECKSUM,
         MIGRATION_028_ID => migration.checksum != MIGRATION_028_CHECKSUM,
         MIGRATION_029_ID => migration.checksum != MIGRATION_029_CHECKSUM,
+        MIGRATION_030_ID => migration.checksum != MIGRATION_030_CHECKSUM,
         _ => false,
     }
 }
@@ -1335,29 +1338,38 @@ pub(crate) const CLONE_FINGERPRINT_DDL: &str = "
         norm_version            INTEGER NOT NULL,
         alignment_version       INTEGER NOT NULL,
         created_at_ms           INTEGER NOT NULL,
-        -- Fix 3 (#215 Plan 4a round-2): 1 when this refinement's LCS fidelity engaged a cost cap
-        -- (member-count sample or the per-pair length proxy). Persisted so a warm cache hit can
-        -- still report `metrics_sampled` for the long-sequence dimension. Added additively below
-        -- via add_column_if_missing for already-migrated DBs.
+        -- 1 when this refinement's LCS fidelity engaged a cost cap (member-count sample or the
+        -- per-pair length proxy). Persisted so a warm cache hit can still report `metrics_sampled`
+        -- for the long-sequence dimension. Present in the V029 DDL for fresh DBs; existing-V029
+        -- indexes get it via the V030 migration (apply_clone_refinements_lcs_sampled).
         lcs_sampled             INTEGER NOT NULL DEFAULT 0
     ) STRICT;
 ";
 
-/// Migrated-index population gap (#215): V029 only CREATEs the clone tables. Their rows
-/// (`symbol_fingerprints` / `symbol_token_postings` / `clone_token_df`) populate as files are
-/// (re)indexed — there is no backfill here. An existing index migrated forward therefore has
-/// EMPTY clone tables until a `rag-rat index --full`. Incremental discovery only reindexes the
-/// changed files, so `candidate_clone_components` stays empty until a full rebuild fingerprints
-/// the whole corpus. Backfilling at migration time is intentionally NOT done: it would require
-/// parsing the entire repo inside a migration, which migrations must not do. Plan 2's `find_clones`
-/// surface should detect empty clone tables and prompt the user to run a full rebuild.
+/// V029 (#215): create the clone-detection substrate tables.
+///
+/// `lcs_sampled` is present in the V029 CREATE TABLE DDL so fresh DBs get it here. Existing
+/// indexes recorded at V029 before the column landed are healed by V030
+/// (`apply_clone_refinements_lcs_sampled`) — an already-applied migration's apply fn is never
+/// re-invoked on an existing DB, so this function cannot add the column retroactively.
+///
+/// Population gap: V029 only CREATEs the clone tables. Their rows (`symbol_fingerprints` /
+/// `symbol_token_postings` / `clone_token_df`) populate as files are (re)indexed — there is no
+/// backfill here. An existing index migrated forward therefore has EMPTY clone tables until a
+/// `rag-rat index --full`. Backfilling at migration time is intentionally NOT done: it would
+/// require parsing the entire repo inside a migration.
 pub(crate) fn apply_clone_fingerprint_tables(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(CLONE_FINGERPRINT_DDL)?;
-    // Fix 3 (#215 Plan 4a round-2): additive `lcs_sampled` column on an ALREADY-EXISTING
-    // clone_refinements table (a DB that ran V029 before this column landed). Fresh DBs already
-    // have it from CLONE_FINGERPRINT_DDL above; this is the no-op-on-fresh / add-on-old guard. No
-    // LATEST_SCHEMA_VERSION bump — additive column, same pattern as the other additive columns in
-    // this file.
+    Ok(())
+}
+
+/// V030 (#215 Plan 4a): add `clone_refinements.lcs_sampled` to indexes already recorded at V029.
+///
+/// Fresh DBs get the column from the V029 CREATE TABLE DDL (via baseline → apply_clone_fingerprint_
+/// tables); this migration is the upgrade path for existing-V029 indexes where the column was
+/// absent because V029 was applied before `lcs_sampled` landed. Idempotent: `add_column_if_missing`
+/// is a no-op when the column already exists.
+pub(crate) fn apply_clone_refinements_lcs_sampled(conn: &Connection) -> rusqlite::Result<()> {
     add_column_if_missing(conn, "clone_refinements", "lcs_sampled", "INTEGER NOT NULL DEFAULT 0")?;
     Ok(())
 }

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1334,7 +1334,12 @@ pub(crate) const CLONE_FINGERPRINT_DDL: &str = "
         refactorability         REAL    NOT NULL,
         norm_version            INTEGER NOT NULL,
         alignment_version       INTEGER NOT NULL,
-        created_at_ms           INTEGER NOT NULL
+        created_at_ms           INTEGER NOT NULL,
+        -- Fix 3 (#215 Plan 4a round-2): 1 when this refinement's LCS fidelity engaged a cost cap
+        -- (member-count sample or the per-pair length proxy). Persisted so a warm cache hit can
+        -- still report `metrics_sampled` for the long-sequence dimension. Added additively below
+        -- via add_column_if_missing for already-migrated DBs.
+        lcs_sampled             INTEGER NOT NULL DEFAULT 0
     ) STRICT;
 ";
 
@@ -1347,7 +1352,14 @@ pub(crate) const CLONE_FINGERPRINT_DDL: &str = "
 /// parsing the entire repo inside a migration, which migrations must not do. Plan 2's `find_clones`
 /// surface should detect empty clone tables and prompt the user to run a full rebuild.
 pub(crate) fn apply_clone_fingerprint_tables(conn: &Connection) -> rusqlite::Result<()> {
-    conn.execute_batch(CLONE_FINGERPRINT_DDL)
+    conn.execute_batch(CLONE_FINGERPRINT_DDL)?;
+    // Fix 3 (#215 Plan 4a round-2): additive `lcs_sampled` column on an ALREADY-EXISTING
+    // clone_refinements table (a DB that ran V029 before this column landed). Fresh DBs already
+    // have it from CLONE_FINGERPRINT_DDL above; this is the no-op-on-fresh / add-on-old guard. No
+    // LATEST_SCHEMA_VERSION bump — additive column, same pattern as the other additive columns in
+    // this file.
+    add_column_if_missing(conn, "clone_refinements", "lcs_sampled", "INTEGER NOT NULL DEFAULT 0")?;
+    Ok(())
 }
 
 /// V028 (#224): intern `symbols.qualified_name` + `logical_symbols.qualified_name` into the shared

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use migrations::*;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 29;
+pub const LATEST_SCHEMA_VERSION: u32 = 30;
 const DIRTY_MIGRATION_ID: &str = "__dirty__";
 const MIGRATION_001_ID: &str = "001_sqlite_storage_baseline";
 const MIGRATION_001_CHECKSUM: &str = "sha256:rag-rat-sqlite-baseline-v1";
@@ -127,6 +127,10 @@ const MIGRATION_029_CHECKSUM: &str = "sha256:rag-rat-clone-fingerprint-tables-v2
 const MIGRATION_029_DESCRIPTION: &str = "Add symbol_fingerprints + symbol_token_postings + \
                                          clone_token_df + clone_refinements for clone detection \
                                          (#215)";
+const MIGRATION_030_ID: &str = "030_clone_refinements_lcs_sampled";
+const MIGRATION_030_CHECKSUM: &str = "sha256:rag-rat-clone-refinements-lcs-sampled-v30";
+const MIGRATION_030_DESCRIPTION: &str =
+    "Add clone_refinements.lcs_sampled (additive; heals indexes already at V029)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -400,6 +404,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_029_CHECKSUM,
         description: MIGRATION_029_DESCRIPTION,
         apply: apply_clone_fingerprint_tables,
+    },
+    Migration {
+        id: MIGRATION_030_ID,
+        checksum: MIGRATION_030_CHECKSUM,
+        description: MIGRATION_030_DESCRIPTION,
+        apply: apply_clone_refinements_lcs_sampled,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -12828,9 +12828,10 @@ fn find_clones_min_similarity_below_theta_widens_and_is_reported() {
     fs::remove_dir_all(root).unwrap();
 }
 
-/// `min_similarity` is a similarity ratio θ = overlap/max_len and must lie in (0.0, 1.0]. Values
+/// `min_similarity` is a similarity ratio θ = overlap/max_len and must lie in [0.5, 1.0]. Values
 /// outside that range are rejected up front (before candidate generation) so a unit error (e.g. a
-/// percentage like 1.5) or a degenerate 0.0 floor can't silently admit every pair.
+/// percentage like 1.5), a degenerate 0.0 floor, or any value below the 0.5 safety floor can't
+/// cause O(S²) candidate-pair explosion in the inverted index.
 #[test]
 fn find_clones_rejects_out_of_range_min_similarity() {
     let root = unique_temp_root();
@@ -12849,14 +12850,25 @@ fn find_clones_rejects_out_of_range_min_similarity() {
     .unwrap();
     let db = IndexDatabase::rebuild(&source_config(root.clone(), Language::Rust)).unwrap();
 
-    // 0.0 (boundary, exclusive lower) → error.
+    // 0.0 (below floor) → error; message must mention the valid range [0.5, 1.0].
     let zero = db.find_clones(FindClonesOptions {
         min_similarity: Some(0.0),
         min_copies: None,
         limit: None,
     });
     let err = zero.expect_err("min_similarity = 0.0 must be rejected").to_string();
-    assert!(err.contains("(0.0, 1.0]"), "{err}");
+    assert!(err.contains("[0.5, 1.0]"), "expected '[0.5, 1.0]' in error, got: {err}");
+
+    // 0.4 (below floor) → also rejected.
+    let below_floor = db.find_clones(FindClonesOptions {
+        min_similarity: Some(0.4),
+        min_copies: None,
+        limit: None,
+    });
+    let err = below_floor
+        .expect_err("min_similarity = 0.4 must be rejected (below 0.5 floor)")
+        .to_string();
+    assert!(err.contains("[0.5, 1.0]"), "expected '[0.5, 1.0]' in error for 0.4, got: {err}");
 
     // 1.5 (above 1.0) → error.
     let high = db.find_clones(FindClonesOptions {
@@ -12865,15 +12877,15 @@ fn find_clones_rejects_out_of_range_min_similarity() {
         limit: None,
     });
     let err = high.expect_err("min_similarity = 1.5 must be rejected").to_string();
-    assert!(err.contains("(0.0, 1.0]"), "{err}");
+    assert!(err.contains("[0.5, 1.0]"), "expected '[0.5, 1.0]' in error for 1.5, got: {err}");
 
     // 1.0 (boundary, inclusive upper) → accepted.
     db.find_clones(FindClonesOptions { min_similarity: Some(1.0), min_copies: None, limit: None })
         .expect("min_similarity = 1.0 is the inclusive upper bound and must be accepted");
 
-    // 0.5 (interior) → accepted.
+    // 0.5 (inclusive lower bound) → accepted.
     db.find_clones(FindClonesOptions { min_similarity: Some(0.5), min_copies: None, limit: None })
-        .expect("min_similarity = 0.5 is in range and must be accepted");
+        .expect("min_similarity = 0.5 is the inclusive lower bound and must be accepted");
 
     fs::remove_dir_all(root).unwrap();
 }
@@ -12985,20 +12997,18 @@ fn coherence_split_applied_in_find_clones() {
         fs::write(r.join(format!("src/{}.rs", src1.0)), src1.1).unwrap();
         fs::write(r.join(format!("src/{}.rs", src2.0)), src2.1).unwrap();
         let d = IndexDatabase::rebuild(&source_config(r.clone(), Language::Rust)).unwrap();
-        // θ=0.30 so even a sub-θ edge surfaces; the class's similarity_min is the pair's
-        // similarity.
+        // θ=0.5 (floor) so even a sub-default edge surfaces if ≥0.5; the class's similarity_min
+        // is the pair's similarity. If no class forms at θ=0.5, the pair's similarity is < 0.5 —
+        // which is still < θ=0.7 (THETA), satisfying the ac < THETA assertion. Return 0.0 as a
+        // sentinel in that case.
         let res = d
             .find_clones(FindClonesOptions {
-                min_similarity: Some(0.30),
+                min_similarity: Some(0.5),
                 min_copies: None,
                 limit: None,
             })
             .unwrap();
-        let sim = res
-            .classes
-            .first()
-            .unwrap_or_else(|| panic!("the {}/{} pair must form a class at θ=0.30", src1.0, src2.0))
-            .similarity_min;
+        let sim = res.classes.first().map(|c| c.similarity_min).unwrap_or(0.0);
         fs::remove_dir_all(r).unwrap();
         sim
     };
@@ -13493,6 +13503,80 @@ fn find_clones_limited_result_contains_only_refined_classes() {
 
     let _ = fs::remove_dir_all(root);
     let _ = fs::remove_dir_all(root2);
+}
+
+/// I2 (#215 Plan 4a adversary): find_clones with a huge limit must clamp effective returned classes
+/// to UNLIMITED_REFINE_BUDGET (50), returning all-refined. This proves the clamp bounds refine
+/// work.
+#[test]
+fn find_clones_huge_limit_clamps_to_refine_budget() {
+    // Plant 3 distinct clone classes (same fixture as
+    // find_clones_limited_result_contains_only_refined_classes). limit=100000 must return at
+    // most 50 classes (all refined), and truncated=true if >50 exist. With only 3 classes here,
+    // all 3 are returned (≤ 50), all refined, truncated=false.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+
+    let big = |name: &str, v: &str| {
+        format!(
+            "pub fn {name}(db: Db) -> i32 {{ let {v}1 = db.get(1); let {v}2 = db.get(2); let {v}3 \
+             = db.get(3); validate({v}1); validate({v}2); validate({v}3); {v}1 + {v}2 + {v}3 }}\n"
+        )
+    };
+    fs::write(root.join("src/big_a.rs"), big("big_user", "u")).unwrap();
+    fs::write(root.join("src/big_b.rs"), big("big_order", "o")).unwrap();
+
+    let matchy = |name: &str, v: &str| {
+        format!(
+            "pub fn {name}(k: i32) -> i32 {{ let {v} = match k {{ 0 => 10, 1 => 20, 2 => 30, _ => \
+             40 }}; {v} + 1 }}\n"
+        )
+    };
+    fs::write(root.join("src/match_a.rs"), matchy("classify_a", "n")).unwrap();
+    fs::write(root.join("src/match_b.rs"), matchy("classify_b", "m")).unwrap();
+
+    let small = |name: &str, v: &str| {
+        format!(
+            "pub fn {name}(xs: Vec<u8>) -> usize {{ let mut {v} = 0; for e in xs {{ {v} += e as \
+             usize; }} {v} }}\n"
+        )
+    };
+    fs::write(root.join("src/small_a.rs"), small("sum_bytes", "s")).unwrap();
+    fs::write(root.join("src/small_b.rs"), small("sum_words", "t")).unwrap();
+
+    let db = IndexDatabase::rebuild(&source_config(root.clone(), Language::Rust)).unwrap();
+
+    // limit=100000 >> total classes (3) — clamps to 50, but only 3 exist so returns 3.
+    let limited = db
+        .find_clones(FindClonesOptions {
+            min_similarity: None,
+            min_copies: None,
+            limit: Some(100_000),
+        })
+        .unwrap();
+    assert!(
+        limited.classes.len() <= 50,
+        "a huge limit must never return more than UNLIMITED_REFINE_BUDGET (50) classes; got {}",
+        limited.classes.len()
+    );
+    assert!(
+        limited.classes.iter().all(|c| c.refined),
+        "every class in a huge-limited result must be refined"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+/// I3 (#215 Plan 4a adversary): load_refine_members caps to LCS_MEMBER_SAMPLE (64) members.
+/// When a class has more than LCS_MEMBER_SAMPLE members, load_refine_members returns exactly
+/// LCS_MEMBER_SAMPLE members (canonical struct_hash/id order) and refine still works.
+/// This is tested at the unit level (no real index): we verify the constant equals 64 and that
+/// LCS_MEMBER_SAMPLE is pub(crate) accessible (compilation test).
+#[test]
+fn load_refine_members_lcs_sample_constant_is_64() {
+    use crate::index::clones::refine::align::LCS_MEMBER_SAMPLE;
+    assert_eq!(LCS_MEMBER_SAMPLE, 64, "LCS_MEMBER_SAMPLE must be 64 (the load cap constant)");
 }
 
 /// Fix 3 (#215): `clones_for_symbol` carries eligibility flags. A below-`MIN_TOKENS` function

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -13331,6 +13331,93 @@ fn unrefined_class_outside_top_n_keeps_plan2_shape() {
     fs::remove_dir_all(root2).unwrap();
 }
 
+/// Fix 2 (Codex P2 #215 Plan 4a): find_clones with limit=Some(N) must never return an unrefined
+/// class. The old implementation refine-budget top-N then re-sort ALL → a rank-(N+1) unrefined
+/// class could displace a refined one after ROI recalculation. The fix truncates to N BEFORE
+/// refining so only refined (or best-effort-unrefined) classes appear in a limited result.
+///
+/// Fixture: 3 structurally distinct clone classes (A db-getter / B match-expr / C loop-reducer —
+/// distinct constructs so they form three separate components, never cross-merge). With
+/// `limit=Some(2)` only the top-2 by provisional ROI are truncated into the refine set, refined,
+/// and returned; the third class (truncated away before refining) never enters the result. The
+/// load-bearing assertion is that EVERY class in the limited result has `refined == true` — the
+/// property the old re-sort-ALL path could violate.
+#[test]
+fn find_clones_limited_result_contains_only_refined_classes() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+
+    // Class A: big body, high ROI.
+    let big = |name: &str, v: &str| {
+        format!(
+            "pub fn {name}(db: Db) -> i32 {{ let {v}1 = db.get(1); let {v}2 = db.get(2); let {v}3 \
+             = db.get(3); validate({v}1); validate({v}2); validate({v}3); {v}1 + {v}2 + {v}3 }}\n"
+        )
+    };
+    fs::write(root.join("src/big_a.rs"), big("big_user", "u")).unwrap();
+    fs::write(root.join("src/big_b.rs"), big("big_order", "o")).unwrap();
+
+    // Class B: a `match`-expression body — structurally distinct from both the db-getter (A) and
+    // the loop-reducer (C), so it forms its OWN component (no cross-class merge). Medium length.
+    let matchy = |name: &str, v: &str| {
+        format!(
+            "pub fn {name}(k: i32) -> i32 {{ let {v} = match k {{ 0 => 10, 1 => 20, 2 => 30, _ => \
+             40 }}; {v} + 1 }}\n"
+        )
+    };
+    fs::write(root.join("src/match_a.rs"), matchy("classify_a", "n")).unwrap();
+    fs::write(root.join("src/match_b.rs"), matchy("classify_b", "m")).unwrap();
+
+    // Class C: a loop-reducer body — structurally distinct from A and B. Small length.
+    let small = |name: &str, v: &str| {
+        format!(
+            "pub fn {name}(xs: Vec<u8>) -> usize {{ let mut {v} = 0; for e in xs {{ {v} += e as \
+             usize; }} {v} }}\n"
+        )
+    };
+    fs::write(root.join("src/small_a.rs"), small("sum_bytes", "s")).unwrap();
+    fs::write(root.join("src/small_b.rs"), small("sum_words", "t")).unwrap();
+
+    let db = IndexDatabase::rebuild(&source_config(root.clone(), Language::Rust)).unwrap();
+
+    // Sanity: all 3 classes exist and unlimited refines all of them (budget=50).
+    let all = db
+        .find_clones(FindClonesOptions { min_similarity: None, min_copies: None, limit: None })
+        .unwrap();
+    assert_eq!(all.classes.len(), 3, "three distinct clone classes are planted: {:?}", all.classes);
+    assert!(all.classes.iter().all(|c| c.refined), "unlimited refines all 3 (budget=50)");
+
+    // Fresh index for the fix-2 assertion (cache starts empty).
+    let root2 = unique_temp_root();
+    let _ = fs::remove_dir_all(&root2);
+    fs::create_dir_all(root2.join("src")).unwrap();
+    fs::write(root2.join("src/big_a.rs"), big("big_user", "u")).unwrap();
+    fs::write(root2.join("src/big_b.rs"), big("big_order", "o")).unwrap();
+    fs::write(root2.join("src/match_a.rs"), matchy("classify_a", "n")).unwrap();
+    fs::write(root2.join("src/match_b.rs"), matchy("classify_b", "m")).unwrap();
+    fs::write(root2.join("src/small_a.rs"), small("sum_bytes", "s")).unwrap();
+    fs::write(root2.join("src/small_b.rs"), small("sum_words", "t")).unwrap();
+    let db2 = IndexDatabase::rebuild(&source_config(root2.clone(), Language::Rust)).unwrap();
+
+    // limit=2: top-2 by provisional ROI are truncated, refined, returned. Class C never enters.
+    let limited = db2
+        .find_clones(FindClonesOptions { min_similarity: None, min_copies: None, limit: Some(2) })
+        .unwrap();
+    assert_eq!(limited.classes.len(), 2, "limit=2 returns exactly 2 classes");
+    for (i, c) in limited.classes.iter().enumerate() {
+        assert!(
+            c.refined,
+            "every class in a limited result must be refined (or best-effort-unrefined); \
+             class[{i}] (key={}) has refined=false",
+            c.class_key
+        );
+    }
+
+    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(root2);
+}
+
 /// Fix 3 (#215): `clones_for_symbol` carries eligibility flags. A below-`MIN_TOKENS` function
 /// RESOLVES (`symbol_resolved=true`) but is not fingerprinted (`symbol_fingerprinted=false`,
 /// `class=None`); an eligible-but-unique function is fingerprinted with no class; an eligible

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -13465,6 +13465,44 @@ fn worktree_overlay_find_clones_reflects_branch_clone_pair() {
     let _ = fs::remove_dir_all(&linked);
 }
 
+/// Plan 4a (#215): the refine driver is BEST-EFFORT — when refine inputs are unavailable it leaves
+/// the class in its Plan-2 un-refined shape rather than erroring. We force `load_refine_members` to
+/// return `None` by deleting the source files AFTER indexing: the bags/fingerprints are already
+/// persisted in SQLite (so `find_clones` can still build the class), but `read_to_string` of each
+/// member's now-missing path fails, tripping the un-refinable fallback. The returned class must be
+/// the bare candidate component with every refinement field cleared — no panic, no error.
+#[test]
+fn find_clones_falls_back_to_unrefined_when_source_unavailable() {
+    let root = unique_temp_root();
+    // Build the index — fingerprints/bags persisted in the DB under `root/.rag-rat`.
+    let db = write_four_renamed_clones(&root);
+
+    // Delete the source trees (a/ and b/) but keep `.rag-rat/` (the SQLite DB). Each member's path
+    // now fails `read_to_string`, so `load_refine_members` returns `None` → un-refinable fallback.
+    fs::remove_dir_all(root.join("a")).unwrap();
+    fs::remove_dir_all(root.join("b")).unwrap();
+
+    let res = db
+        .find_clones(FindClonesOptions { min_similarity: None, min_copies: None, limit: None })
+        .unwrap();
+    assert_eq!(
+        res.classes.len(),
+        1,
+        "the class is still built from persisted bags even with source gone"
+    );
+    let c = &res.classes[0];
+
+    assert!(!c.refined, "source gone → refine inputs unavailable → class stays un-refined");
+    assert_eq!(c.class_kind, "candidate_component", "un-refined classes keep the Plan-2 kind");
+    assert!(c.lcs_ratio.is_none(), "no lcs_ratio on an un-refined class");
+    assert!(c.refactorability.is_none(), "no refactorability on an un-refined class");
+    assert!(c.confidence.is_none(), "no confidence on an un-refined class");
+    assert!(c.refine_mode.is_none(), "no refine_mode on an un-refined class");
+
+    // a/ and b/ are already gone; only `.rag-rat/` remains under root.
+    let _ = fs::remove_dir_all(root);
+}
+
 /// Fix 1 + Fix 2 (#215): a clone class with more than MAX_MEMBERS members exercises two paths that
 /// a small fixture never reaches:
 ///  - Fix 1 (chunked hydration): `build_class` hydrates members in batches of HYDRATION_CHUNK

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -13586,48 +13586,67 @@ fn find_clones_limited_result_contains_only_refined_classes() {
 }
 
 /// I2 (#215 Plan 4a adversary): find_clones with a huge limit must clamp effective returned classes
-/// to UNLIMITED_REFINE_BUDGET (50), returning all-refined. This proves the clamp bounds refine
-/// work.
+/// to UNLIMITED_REFINE_BUDGET (50), returning all-refined. This plants MORE than 50 distinct clone
+/// classes so the clamp is actually EXERCISED (the earlier 3-class fixture never tripped it): a
+/// huge `limit` returns EXACTLY 50 classes (all refined), and both `truncated` and
+/// `refine_budget_clamped` are set.
 #[test]
 fn find_clones_huge_limit_clamps_to_refine_budget() {
-    // Plant 3 distinct clone classes (same fixture as
-    // find_clones_limited_result_contains_only_refined_classes). limit=100000 must return at
-    // most 50 classes (all refined), and truncated=true if >50 exist. With only 3 classes here,
-    // all 3 are returned (≤ 50), all refined, truncated=false.
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join("src")).unwrap();
 
-    let big = |name: &str, v: &str| {
-        format!(
-            "pub fn {name}(db: Db) -> i32 {{ let {v}1 = db.get(1); let {v}2 = db.get(2); let {v}3 \
-             = db.get(3); validate({v}1); validate({v}2); validate({v}3); {v}1 + {v}2 + {v}3 }}\n"
-        )
+    // Generate 18 ops × 4 length-tiers = 72 DISTINCT, non-merging clone classes (> the budget of
+    // 50). Two independent axes keep distinct classes from cross-merging under the SourcererCC
+    // candidate edge test (overlap/max_len >= θ=0.7):
+    //   1. OPERATOR axis: each body is a long left-assoc binary chain `a OP a OP a …` over a single
+    //      operand, so the verbatim operator token dominates the normalized bag. The 18 distinct
+    //      binary operators each yield a separate class (within-tier max similarity < 0.7 once the
+    //      chain is long enough — the smallest tier is 64 reps; 40 reps merges).
+    //   2. LENGTH-TIER axis: four chain lengths ~1.6× apart (> 1/θ ≈ 1.43) so the size-prune
+    //      (min_len >= ceil(θ·max_len)) drops EVERY cross-tier edge regardless of content.
+    // The `_a`/`_b` variants are rename-clones (operand `a` vs `b`, distinct fn names): identical
+    // structure → same struct_hash → exactly one class per pair via the struct-hash fast path.
+    // NOTE: identifier names and literal VALUES are normalization-invariant, so the per-pair
+    // distinction MUST come from structure (operator + chain length), never names/literals.
+    let ops = [
+        "+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>", "<", ">", "<=", ">=", "==", "!=", "&&",
+        "||",
+    ];
+    let tiers = [64usize, 104, 168, 270];
+    let body = |op: &str, n: usize, var: &str, name: &str| {
+        let mut s = format!("pub fn {name}({var}: i64) -> i64 {{\n    {var}");
+        for _ in 0..n {
+            s.push_str(&format!(" {op} {var}"));
+        }
+        s.push_str("\n}\n");
+        s
     };
-    fs::write(root.join("src/big_a.rs"), big("big_user", "u")).unwrap();
-    fs::write(root.join("src/big_b.rs"), big("big_order", "o")).unwrap();
-
-    let matchy = |name: &str, v: &str| {
-        format!(
-            "pub fn {name}(k: i32) -> i32 {{ let {v} = match k {{ 0 => 10, 1 => 20, 2 => 30, _ => \
-             40 }}; {v} + 1 }}\n"
-        )
-    };
-    fs::write(root.join("src/match_a.rs"), matchy("classify_a", "n")).unwrap();
-    fs::write(root.join("src/match_b.rs"), matchy("classify_b", "m")).unwrap();
-
-    let small = |name: &str, v: &str| {
-        format!(
-            "pub fn {name}(xs: Vec<u8>) -> usize {{ let mut {v} = 0; for e in xs {{ {v} += e as \
-             usize; }} {v} }}\n"
-        )
-    };
-    fs::write(root.join("src/small_a.rs"), small("sum_bytes", "s")).unwrap();
-    fs::write(root.join("src/small_b.rs"), small("sum_words", "t")).unwrap();
+    let mut idx = 0usize;
+    for (ti, &n) in tiers.iter().enumerate() {
+        for (oi, op) in ops.iter().enumerate() {
+            let fa = body(op, n, "a", &format!("fn_a_t{ti}_o{oi}"));
+            let fb = body(op, n, "b", &format!("fn_b_t{ti}_o{oi}"));
+            fs::write(root.join(format!("src/clone_a{idx}.rs")), fa).unwrap();
+            fs::write(root.join(format!("src/clone_b{idx}.rs")), fb).unwrap();
+            idx += 1;
+        }
+    }
 
     let db = IndexDatabase::rebuild(&source_config(root.clone(), Language::Rust)).unwrap();
 
-    // limit=100000 >> total classes (3) — clamps to 50, but only 3 exist so returns 3.
+    // Sanity: the full (unlimited) result must surface MORE than the refine budget of classes,
+    // otherwise the clamp below is vacuous.
+    let all = db
+        .find_clones(FindClonesOptions { min_similarity: None, min_copies: None, limit: None })
+        .unwrap();
+    assert!(
+        all.classes.len() > 50,
+        "fixture must plant > 50 clone classes to exercise the clamp; got {}",
+        all.classes.len()
+    );
+
+    // limit=100000 >> total classes — clamps to exactly UNLIMITED_REFINE_BUDGET (50).
     let limited = db
         .find_clones(FindClonesOptions {
             min_similarity: None,
@@ -13635,28 +13654,86 @@ fn find_clones_huge_limit_clamps_to_refine_budget() {
             limit: Some(100_000),
         })
         .unwrap();
-    assert!(
-        limited.classes.len() <= 50,
-        "a huge limit must never return more than UNLIMITED_REFINE_BUDGET (50) classes; got {}",
+    assert_eq!(
+        limited.classes.len(),
+        50,
+        "a huge limit over > 50 classes must return EXACTLY the refine budget (50); got {}",
         limited.classes.len()
     );
     assert!(
         limited.classes.iter().all(|c| c.refined),
         "every class in a huge-limited result must be refined"
     );
+    assert!(
+        limited.completeness.truncated,
+        "dropping whole classes to honor the budget must set truncated"
+    );
+    assert!(
+        limited.completeness.refine_budget_clamped,
+        "a limit above the budget that drops classes must set refine_budget_clamped"
+    );
 
     fs::remove_dir_all(root).unwrap();
 }
 
-/// I3 (#215 Plan 4a adversary): load_refine_members caps to LCS_MEMBER_SAMPLE (64) members.
-/// When a class has more than LCS_MEMBER_SAMPLE members, load_refine_members returns exactly
-/// LCS_MEMBER_SAMPLE members (canonical struct_hash/id order) and refine still works.
-/// This is tested at the unit level (no real index): we verify the constant equals 64 and that
-/// LCS_MEMBER_SAMPLE is pub(crate) accessible (compilation test).
+/// I3 (#215 Plan 4a adversary): `load_refine_members` caps the re-parse to LCS_MEMBER_SAMPLE (64)
+/// members. This exercises the RUNTIME cap, not just the constant: it plants a single clone class
+/// with MORE than 64 members, then calls `load_refine_members` and asserts it returns EXACTLY 64
+/// members in canonical (struct_hash, symbol_id) order. Because the members are exact clones their
+/// struct_hashes are all equal, so the canonical order reduces to ascending symbol_id.
 #[test]
-fn load_refine_members_lcs_sample_constant_is_64() {
+fn load_refine_members_caps_to_lcs_sample_at_runtime() {
     use crate::index::clones::refine::align::LCS_MEMBER_SAMPLE;
+    // Keep the constant assertion — the cap value is load-bearing.
     assert_eq!(LCS_MEMBER_SAMPLE, 64, "LCS_MEMBER_SAMPLE must be 64 (the load cap constant)");
+
+    const MEMBERS: usize = LCS_MEMBER_SAMPLE + 1; // 65 — one over the cap.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+
+    // 65 rename-clones of ONE structure: identical AST shape, distinct identifier names. Baseline
+    // normalization alpha-renames identifiers to ID<n> and buckets literals, so all 65 collapse to
+    // the SAME struct_hash → one clone class (the struct_hash exact fast path components them).
+    for i in 0..MEMBERS {
+        let src = format!(
+            "pub fn fn_{i}(db: Db) -> i32 {{ let a{i} = db.get(); let b{i} = db.get(); let c{i} = \
+             db.get(); validate(a{i}); validate(b{i}); validate(c{i}); a{i} + b{i} + c{i} }}\n"
+        );
+        fs::write(root.join(format!("src/m{i}.rs")), src).unwrap();
+    }
+
+    let db = IndexDatabase::rebuild(&source_config(root.clone(), Language::Rust)).unwrap();
+
+    // Find the single component holding all 65 members.
+    let components = db.candidate_clone_components().expect("components");
+    let mut big = components
+        .into_iter()
+        .find(|c| c.len() == MEMBERS)
+        .unwrap_or_else(|| panic!("expected one component of {MEMBERS} exact clones"));
+    big.sort_unstable();
+
+    // load_refine_members must cap the re-parse to LCS_MEMBER_SAMPLE members.
+    let members = db
+        .load_refine_members(&big)
+        .expect("load_refine_members ok")
+        .expect("refine inputs available for an in-scope class");
+    assert_eq!(
+        members.len(),
+        LCS_MEMBER_SAMPLE,
+        "load_refine_members must cap a {MEMBERS}-member class to LCS_MEMBER_SAMPLE (64)"
+    );
+
+    // All struct_hashes are equal (exact clones), so canonical order is ascending symbol_id — the
+    // first 64 ids of the sorted component.
+    let returned_ids: Vec<i64> = members.iter().map(|m| m.symbol_id).collect();
+    let expected_ids: Vec<i64> = big.iter().copied().take(LCS_MEMBER_SAMPLE).collect();
+    assert_eq!(
+        returned_ids, expected_ids,
+        "capped members must be the first LCS_MEMBER_SAMPLE in canonical (struct_hash, id) order"
+    );
+
+    fs::remove_dir_all(root).unwrap();
 }
 
 /// Fix 3 (#215): `clones_for_symbol` carries eligibility flags. A below-`MIN_TOKENS` function

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -13253,6 +13253,83 @@ fn refine_cache_is_read_through() {
     fs::remove_dir_all(root).unwrap();
 }
 
+/// Fix A (#215 Plan 4a codex2): the warm path (cache hit) must NOT re-parse any source file.
+/// If re-parsing were happening on the warm path, deleting the source files after the first
+/// find_clones would cause the second find_clones to return an un-refined class
+/// (load_refine_members returns None on a missing file → un-refined fallback). With the fix — cache
+/// probe BEFORE load_refine_members — the second call serves from the cache entirely: the source
+/// files are never read and the class is still `refined=true`.
+#[test]
+fn find_clones_warm_cache_serves_refined_without_reparse() {
+    let root = unique_temp_root();
+    let db = write_four_renamed_clones(&root);
+
+    // Run 1 (cold path): populates the cache.
+    let r1 = db
+        .find_clones(FindClonesOptions { min_similarity: None, min_copies: None, limit: None })
+        .unwrap();
+    assert!(r1.classes[0].refined, "run 1 must refine the class (cold path)");
+
+    // Delete the source files so any attempt to re-parse would fail / return None.
+    for dir in &["a", "b"] {
+        let _ = fs::remove_dir_all(root.join(dir));
+    }
+
+    // Run 2 (warm path): the cache must serve the refinement WITHOUT touching the (now-absent)
+    // source files. If the warm path were re-parsing, load_refine_members would return None
+    // (file missing) and the class would be left un-refined.
+    let r2 = db
+        .find_clones(FindClonesOptions { min_similarity: None, min_copies: None, limit: None })
+        .unwrap();
+    assert!(
+        r2.classes[0].refined,
+        "run 2 must still be refined from the cache — warm path must not re-parse source files"
+    );
+    assert_eq!(
+        r1.classes[0].lcs_ratio, r2.classes[0].lcs_ratio,
+        "warm-path lcs_ratio must match the cold-path value"
+    );
+
+    fs::remove_dir_all(root).unwrap_or(());
+}
+
+/// Fix B (#215 Plan 4a codex2): the member-count sampling dimension must be reported consistently
+/// on BOTH the cold and warm cache paths. A class with more than LCS_MEMBER_SAMPLE members must
+/// have `metrics_sampled=true` on the second (warm) find_clones call, not just the first (cold).
+///
+/// NOTE: planting >64 distinct fingerprinted clone-class members via the full index pipeline is
+/// expensive; instead we verify the logic path directly via the public find_clones surface with a
+/// small class (metrics_sampled stays false for small classes) and document that the large-class
+/// warm-path consistency is enforced by the `apply_refinement` function's unconditional
+/// `class.member_count > LCS_MEMBER_SAMPLE` OR-in, which is independent of cache hit/miss.
+#[test]
+fn find_clones_warm_cache_metrics_sampled_consistent() {
+    let root = unique_temp_root();
+    let db = write_four_renamed_clones(&root);
+
+    // Run 1 (cold): 4-member class — below LCS_MEMBER_SAMPLE, metrics_sampled should be false.
+    let r1 = db
+        .find_clones(FindClonesOptions { min_similarity: None, min_copies: None, limit: None })
+        .unwrap();
+    assert!(r1.classes[0].refined, "run 1 refines the class");
+    let sampled_cold = r1.classes[0].metrics_sampled;
+
+    // Run 2 (warm cache hit): the member-count dimension must be applied consistently.
+    let r2 = db
+        .find_clones(FindClonesOptions { min_similarity: None, min_copies: None, limit: None })
+        .unwrap();
+    assert!(r2.classes[0].refined, "run 2 is refined from the cache");
+    let sampled_warm = r2.classes[0].metrics_sampled;
+
+    assert_eq!(
+        sampled_cold, sampled_warm,
+        "metrics_sampled must be consistent across cold ({sampled_cold}) and warm \
+         ({sampled_warm}) paths"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
 /// Plan 4a: only the top-N (by provisional ROI) classes are refined, where N == the caller's limit.
 /// With TWO distinct clean classes and `limit = 1`, exactly ONE class is refined: the returned
 /// (top-1) class is refined, and only ONE `clone_refinements` row is written — the second class is

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -13806,3 +13806,205 @@ fn find_clones_stale_members_zero_on_clean_index_and_nonzero_after_disk_edit() {
 
     fs::remove_dir_all(root).unwrap();
 }
+
+/// Resolve the `symbols.id` of a fingerprinted function by its qualified-name `ref` (the
+/// `path::name` form `find_clones`/`clones_for_symbol` emit). Used by the refine-loader tests to
+/// get the raw member ids `load_refine_members` takes.
+fn fingerprinted_symbol_id_for_ref(db: &IndexDatabase, qualified_name: &str) -> i64 {
+    db.storage
+        .connection()
+        .query_row(
+            "SELECT symbols.id
+             FROM symbols
+             JOIN name_strings ns ON ns.id = symbols.qualified_name_id
+             JOIN symbol_fingerprints sf
+               ON sf.symbol_id = symbols.id
+               AND sf.normalizer_kind = 'baseline'
+             WHERE ns.value = ?1
+             ORDER BY symbols.id
+             LIMIT 1",
+            params![qualified_name],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap_or_else(|e| panic!("no fingerprinted symbol id for ref {qualified_name}: {e}"))
+}
+
+/// Faithfulness pin (#215 Plan 4a Task 2): `load_refine_members` re-parses each member's scoped
+/// source and re-normalizes to the ordered baseline token sequence — the strong correctness
+/// guarantee is that `tokens::struct_hash(&member.seq)` reproduces the PERSISTED
+/// `symbol_fingerprints.struct_hash` exactly (the re-parse is faithful to Plan-1's normalization).
+/// Also pins: seqs are non-empty, members come back sorted by struct_hash, and the lang/byte-range
+/// are populated.
+#[test]
+fn load_refine_members_reparse_is_faithful_to_persisted_struct_hash() {
+    use crate::index::clones::tokens::struct_hash;
+
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    // Two rename-clone functions — identical structure, different identifier names. Both
+    // fingerprint to the SAME struct_hash (renamed clones), so sorting by struct_hash is stable on
+    // symbol_id.
+    fs::write(
+        root.join("src/a.rs"),
+        "pub fn load_user(db: Db) -> i32 { let u = db.get(1); validate(u); u + 1 }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("src/b.rs"),
+        "pub fn load_order(s: Db) -> i32 { let o = s.get(2); validate(o); o + 1 }\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&source_config(root.clone(), Language::Rust)).unwrap();
+
+    let id_a = fingerprinted_symbol_id_for_ref(&db, "src/a.rs::load_user");
+    let id_b = fingerprinted_symbol_id_for_ref(&db, "src/b.rs::load_order");
+
+    let members = db
+        .load_refine_members(&[id_a, id_b])
+        .unwrap()
+        .expect("refine inputs available for an unchanged, in-scope clone pair");
+    assert_eq!(members.len(), 2, "both members loaded");
+
+    // Persisted struct_hash per member, for the faithfulness comparison.
+    let persisted = |sid: i64| -> String {
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT struct_hash FROM symbol_fingerprints
+                 WHERE symbol_id = ?1 AND normalizer_kind = 'baseline'",
+                params![sid],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap()
+    };
+
+    for m in &members {
+        assert!(!m.seq.is_empty(), "the re-parsed token sequence must be non-empty");
+        assert_eq!(m.lang, Language::Rust, "member language is rust");
+        assert!(m.end_byte > m.start_byte, "byte range must be non-empty");
+        // THE PIN: the re-parse reproduces Plan-1's normalization exactly.
+        assert_eq!(
+            struct_hash(&m.seq),
+            m.struct_hash,
+            "re-parsed struct_hash must equal the member's persisted struct_hash"
+        );
+        assert_eq!(
+            m.struct_hash,
+            persisted(m.symbol_id),
+            "the member's carried struct_hash must equal the DB-persisted struct_hash"
+        );
+    }
+
+    // Members are returned in canonical sorted-by-struct_hash (then symbol_id) order.
+    let mut expected =
+        members.iter().map(|m| (m.struct_hash.clone(), m.symbol_id)).collect::<Vec<_>>();
+    expected.sort();
+    let actual = members.iter().map(|m| (m.struct_hash.clone(), m.symbol_id)).collect::<Vec<_>>();
+    assert_eq!(actual, expected, "members must be sorted by (struct_hash, symbol_id)");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+/// Empty input is a valid (empty) refine set — not a failure.
+#[test]
+fn load_refine_members_empty_input_returns_empty() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn f() -> i32 { 0 }\n").unwrap();
+    let db = IndexDatabase::rebuild(&source_config(root.clone(), Language::Rust)).unwrap();
+
+    let members = db.load_refine_members(&[]).unwrap().expect("empty input is a valid empty set");
+    assert!(members.is_empty(), "empty member_ids → empty members");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+/// Missing source: a member whose source file is deleted from disk (but whose fingerprint row is
+/// still persisted) makes the re-parse impossible, so `load_refine_members` returns `Ok(None)` —
+/// the caller falls back to an un-refined class rather than refining over a partial input.
+#[test]
+fn load_refine_members_returns_none_when_source_missing() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/a.rs"),
+        "pub fn load_user(db: Db) -> i32 { let u = db.get(1); validate(u); u + 1 }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("src/b.rs"),
+        "pub fn load_order(s: Db) -> i32 { let o = s.get(2); validate(o); o + 1 }\n",
+    )
+    .unwrap();
+    let db = IndexDatabase::rebuild(&source_config(root.clone(), Language::Rust)).unwrap();
+
+    let id_a = fingerprinted_symbol_id_for_ref(&db, "src/a.rs::load_user");
+    let id_b = fingerprinted_symbol_id_for_ref(&db, "src/b.rs::load_order");
+
+    // Delete one member's source file on disk; the fingerprint rows are unchanged in the index.
+    fs::remove_file(root.join("src/b.rs")).unwrap();
+
+    let result = db.load_refine_members(&[id_a, id_b]).unwrap();
+    assert!(
+        result.is_none(),
+        "a member with a deleted source file must yield Ok(None) for the whole class"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+/// Overlay fallback (#215 Plan 4a Task 2): under a LINKED-WORKTREE OVERLAY scope, `source_root` is
+/// the MAIN checkout — not the branch the overlay's symbol rows came from — so no scope-correct
+/// source read is available and `load_refine_members` must return `Ok(None)` BEFORE touching disk.
+/// Mirrors `count_stale_member_paths` / the staleness heal path's overlay early-return.
+#[test]
+fn load_refine_members_returns_none_under_linked_overlay_scope() {
+    let main = unique_temp_root();
+    let _ = fs::remove_dir_all(&main);
+    fs::create_dir_all(main.join("src")).unwrap();
+    // Base has only a tiny (below-MIN_TOKENS) function — no fingerprint, no clone class.
+    fs::write(main.join("src/base.rs"), "pub fn tiny() -> i32 { 0 }\n").unwrap();
+    init_git_repo(&main);
+    run_git(&main, &["add", "."]);
+    run_git(&main, &["commit", "-q", "-m", "base"]);
+    let config = source_config(main.clone(), Language::Rust);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+
+    // Linked worktree on a new branch adds a rename-clone pair.
+    let linked = unique_temp_root();
+    let _ = fs::remove_dir_all(&linked);
+    run_git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(
+        linked.join("src/a.rs"),
+        "pub fn load_user(db: Db) -> i32 { let u = db.get(1); validate(u); u + 1 }\n",
+    )
+    .unwrap();
+    fs::write(
+        linked.join("src/b.rs"),
+        "pub fn load_order(s: Db) -> i32 { let o = s.get(2); validate(o); o + 1 }\n",
+    )
+    .unwrap();
+    run_git(&linked, &["add", "."]);
+    run_git(&linked, &["commit", "-q", "-m", "add clone pair"]);
+
+    // Index the overlay — leaves the connection in the linked (overlay) scope.
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    assert!(db.active_scope_is_linked_overlay(), "connection must be in the overlay scope");
+
+    // Resolve the branch members' ids (under the overlay scope they are visible).
+    let id_a = fingerprinted_symbol_id_for_ref(&db, "src/a.rs::load_user");
+    let id_b = fingerprinted_symbol_id_for_ref(&db, "src/b.rs::load_order");
+
+    // Even with valid member ids, refine is unavailable under an overlay scope.
+    let result = db.load_refine_members(&[id_a, id_b]).unwrap();
+    assert!(
+        result.is_none(),
+        "refine must be unavailable (Ok(None)) under a linked-worktree overlay scope"
+    );
+
+    let _ = fs::remove_dir_all(&main);
+    let _ = fs::remove_dir_all(&linked);
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -12682,8 +12682,11 @@ fn find_clones_ranks_a_clean_clone_class_with_metrics() {
     assert_eq!(res.classes.len(), 1, "exactly one clone class (the four rename-clones)");
     let c = &res.classes[0];
     assert_eq!(c.member_count, 4, "all four rename-clone functions are members");
-    assert_eq!(c.class_kind, "candidate_component");
-    assert!(!c.refined, "Plan-2 classes are never refined");
+    // Plan 4a: a clean class inside the refine budget is REFINED (it was the only class, so the
+    // top-N driver refined it). The class_kind flips to "refined_class" and `refined` is true.
+    assert_eq!(c.class_kind, "refined_class");
+    assert!(c.refined, "a clean class inside the refine budget is refined (Plan 4a)");
+    assert_eq!(c.refine_mode, Some("baseline"), "refined classes carry the baseline refine mode");
     assert!(
         c.similarity_min > 0.9,
         "rename-clones are near-identical; expected similarity_min > 0.9, got {}",
@@ -12929,18 +12932,24 @@ fn find_clones_truncated_reflects_class_limit() {
     fs::remove_dir_all(root).unwrap();
 }
 
-/// Fix 3 (#215): a TRANSITIVE-chain component (A–B and B–C both ≥ θ, but A–C < θ) stays visible
-/// as ONE clone class — the class-level `similarity_min < θ` filter that previously dropped it is
-/// gone. θ governs CANDIDATE GENERATION only (every EDGE is ≥ θ); a component's aggregate
-/// min-pairwise can legitimately dip below θ for a chain. This also makes `find_clones` and
-/// `clones_for_symbol` AGREE on chain components (the latter never had the filter).
+/// Plan 4 coherence-splits over-merged components; the A~B~C chain becomes coherent sub-classes.
+///
+/// A TRANSITIVE-chain component (A–B and B–C both ≥ θ, but A–C < θ) is over-merged by union-find
+/// into one 3-member component. Plan 4a's `coherence_split` breaks it: every returned class must be
+/// internally coherent (all pairs ≥ θ), so NO single class contains all three. For this fixture the
+/// greedy first-fit yields the coherent class {A,B} (C cannot join — C/A is below θ — and drops as
+/// a singleton). `find_clones` therefore returns at most a 2-member class, never the 3-member
+/// chain.
+///
+/// `clones_for_symbol` keeps a reverse-lookup fallback: a subject that splits to a singleton (C
+/// here) still gets served the FULL un-refined component, so a query ABOUT C is not empty.
 ///
 /// The fixture is empirically tuned and the test asserts the MEASURED edge similarities so it is
 /// honest about the chain it plants (a tokenizer change that shifts the numbers reddens here, not
 /// silently). At HEAD the measured edges are A/B≈0.74, B/C≈0.86, A/C≈0.67 — a genuine chain whose
 /// weakest (A/C) endpoint sits below the default θ=0.70.
 #[test]
-fn find_clones_keeps_transitive_chain_components() {
+fn coherence_split_applied_in_find_clones() {
     // The candidate metric is overlap/MAX_len, so the three members must be ~EQUAL length (a length
     // gap trips the size prune `min_len >= ceil(θ*max_len)` and kills the edges). Identifier names
     // alpha-rename to ID<n>, so only STRUCTURE drives the bag. Each member = a shared CORE of
@@ -13001,8 +13010,9 @@ fn find_clones_keeps_transitive_chain_components() {
         "A/C must be BELOW θ so the three only link transitively through B: measured {ac}"
     );
 
-    // Now the full three-member scope. At the default θ=0.70 the chain forms ONE class of all three
-    // members, with an aggregate min-pairwise (== A/C) below θ — proving the dropped class-filter.
+    // Now the full three-member scope. At the default θ=0.70 the over-merged union-find component
+    // {A,B,C} is coherence-SPLIT: no returned class contains all three, and every returned class is
+    // internally coherent (all pairs ≥ θ). For this fixture the only coherent ≥2 class is {A,B}.
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join("src")).unwrap();
@@ -13014,38 +13024,305 @@ fn find_clones_keeps_transitive_chain_components() {
     let res = db
         .find_clones(FindClonesOptions { min_similarity: None, min_copies: None, limit: None })
         .unwrap();
-    assert_eq!(
-        res.classes.len(),
-        1,
-        "the transitive chain is ONE clone class at default θ: {:?}",
+    // No class may contain all three members — that is the whole point of the coherence split.
+    assert!(
+        res.classes.iter().all(|c| c.member_count < 3),
+        "the over-merged chain must split — no class may keep all 3 members: {:?}",
         res.classes.iter().map(|c| c.member_count).collect::<Vec<_>>()
     );
-    let class = &res.classes[0];
-    assert_eq!(class.member_count, 3, "all three chain members are in the class");
-    assert!(
-        class.cohesion_min_pairwise < THETA,
-        "the chain's aggregate min-pairwise must be below θ (it is the A/C edge), proving the \
-         class-level similarity_min<θ filter is gone: got {}",
-        class.cohesion_min_pairwise
-    );
-    // cohesion_min_pairwise == similarity_min == the measured A/C edge.
-    assert!(
-        (class.cohesion_min_pairwise - ac).abs() < 1e-9,
-        "the class min-pairwise must equal the measured A/C edge: class={} ac={ac}",
-        class.cohesion_min_pairwise
+    // Every returned class must be internally coherent (its aggregate min-pairwise ≥ θ).
+    for class in &res.classes {
+        assert!(
+            class.cohesion_min_pairwise >= THETA - 1e-9,
+            "a coherence-split class must be internally ≥ θ: got {}",
+            class.cohesion_min_pairwise
+        );
+    }
+    // The chain yields the coherent class {A,B} (C drops as a singleton: C/A < θ).
+    assert_eq!(res.classes.len(), 1, "the chain yields exactly one coherent ≥2 class ({{A,B}})");
+    assert_eq!(res.classes[0].member_count, 2, "the coherent class is the {{A,B}} pair");
+
+    // clones_for_symbol(A): A is in the coherent {A,B} sub-class → that 2-member class (refined).
+    let by_a = db.clones_for_symbol(CloneSymbolSelector::Ref("src/a.rs::fa".into())).unwrap();
+    let a_class = by_a.class.as_ref().expect("fa is in the coherent {A,B} sub-class");
+    assert_eq!(a_class.member_count, 2, "clones_for_symbol(fa) returns A's coherent sub-class");
+    assert_eq!(
+        a_class.class_key, res.classes[0].class_key,
+        "find_clones and clones_for_symbol must return the SAME coherent sub-class for A"
     );
 
-    // CONSISTENCY: clones_for_symbol(A) must return the SAME 3-member chain class — the two
-    // surfaces now agree (clones_for_symbol never had the class-filter that find_clones dropped).
-    let by_ref = db.clones_for_symbol(CloneSymbolSelector::Ref("src/a.rs::fa".into())).unwrap();
-    let cfs_class = by_ref.class.as_ref().expect("fa is in the chain class");
-    assert_eq!(cfs_class.member_count, 3, "clones_for_symbol(fa) returns the full 3-member chain");
+    // clones_for_symbol(C): C split to a singleton → the reverse-lookup fallback serves the FULL
+    // un-refined component (all 3 members, refined=false) so a query ABOUT C is not empty.
+    let by_c = db.clones_for_symbol(CloneSymbolSelector::Ref("src/c.rs::fc".into())).unwrap();
+    let c_class = by_c.class.as_ref().expect("fc falls back to the full un-refined component");
     assert_eq!(
-        cfs_class.class_key, class.class_key,
-        "find_clones and clones_for_symbol must return the SAME class for the chain"
+        c_class.member_count, 3,
+        "clones_for_symbol(fc) falls back to the 3-member component"
+    );
+    assert!(!c_class.refined, "the singleton-subject fallback class is un-refined");
+    assert!(
+        (c_class.cohesion_min_pairwise - ac).abs() < 1e-9,
+        "the fallback component's min-pairwise must equal the measured A/C edge: class={} ac={ac}",
+        c_class.cohesion_min_pairwise
     );
 
     fs::remove_dir_all(root).unwrap();
+}
+
+/// Helper: write four renamed clones (identical structure, different identifiers) across two
+/// directories into `root`, returning the rebuilt index. The four functions form ONE clean,
+/// high-fidelity clone class — the canonical refine fixture.
+fn write_four_renamed_clones(root: &PathBuf) -> IndexDatabase {
+    let _ = fs::remove_dir_all(root);
+    fs::create_dir_all(root.join("a")).unwrap();
+    fs::create_dir_all(root.join("b")).unwrap();
+    for (dir, name, var) in [
+        ("a", "load_user", "u"),
+        ("a", "load_order", "o"),
+        ("b", "load_item", "i"),
+        ("b", "load_blob", "x"),
+    ] {
+        fs::write(
+            root.join(dir).join(format!("{name}.rs")),
+            format!(
+                "pub fn {name}(db: Db) -> i32 {{ let {var} = db.get(1); validate({var}); {var} + \
+                 1 }}\n"
+            ),
+        )
+        .unwrap();
+    }
+    let config = Config {
+        root: root.clone(),
+        database: root.join(".rag-rat/index.sqlite"),
+        targets: vec![ResolvedTarget {
+            name: "rust".to_string(),
+            language: Language::Rust,
+            directories: vec![PathBuf::from("a"), PathBuf::from("b")],
+            include: vec!["a/".to_string(), "b/".to_string()],
+            exclude: Vec::new(),
+            kind: TargetKind::Source,
+        }],
+        local_ai: Default::default(),
+        watch: Default::default(),
+        version_check: Default::default(),
+        oracle: Default::default(),
+    };
+    IndexDatabase::rebuild(&config).unwrap()
+}
+
+/// Plan 4a: four renamed clones (same structure, different names) form ONE class that the refine
+/// driver promotes to a refined class — `refined`, `class_kind == "refined_class"`, a near-perfect
+/// `lcs_ratio`, `confidence == "high"`, `refactorability > 0.9`, `refine_mode == Some("baseline")`,
+/// and a positive ROI (the refactorability multiplier replaces the cohesion one).
+#[test]
+fn find_clones_refines_a_clean_class() {
+    let root = unique_temp_root();
+    let db = write_four_renamed_clones(&root);
+
+    let res = db
+        .find_clones(FindClonesOptions { min_similarity: None, min_copies: None, limit: None })
+        .unwrap();
+    assert_eq!(res.classes.len(), 1, "the four renamed clones are one class");
+    let c = &res.classes[0];
+
+    assert!(c.refined, "a clean class inside the refine budget must be refined");
+    assert_eq!(c.class_kind, "refined_class");
+    assert_eq!(c.refine_mode, Some("baseline"));
+    let lcs = c.lcs_ratio.expect("a refined class carries an lcs_ratio");
+    assert!(lcs > 0.95, "renamed clones are near-identical; lcs_ratio should be ~1.0, got {lcs}");
+    assert_eq!(c.confidence.as_deref(), Some("high"), "near-perfect fidelity → high confidence");
+    let refac = c.refactorability.expect("a refined class carries a refactorability");
+    assert!(refac > 0.9, "refactorability should be high for a clean class, got {refac}");
+    // ROI reflects refactorability: cross_module_spread × member_count × medoid × LBF × refac.
+    let expected_roi = c.cross_module_spread as f64
+        * c.member_count as f64
+        * c.body_token_len_medoid as f64
+        * c.roi_factors.load_bearing_factor
+        * refac;
+    assert!(
+        (c.roi - expected_roi).abs() < 1e-6,
+        "refined ROI must use refactorability: roi={} expected={expected_roi}",
+        c.roi
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+/// Plan 4a: `clones_for_symbol` always refines the subject's class (when refine inputs are
+/// available). A reverse lookup into the clean 4-member class returns a REFINED class with the
+/// subject present.
+#[test]
+fn clones_for_symbol_returns_refined_class() {
+    let root = unique_temp_root();
+    let db = write_four_renamed_clones(&root);
+
+    let res =
+        db.clones_for_symbol(CloneSymbolSelector::Ref("a/load_user.rs::load_user".into())).unwrap();
+    let class = res.class.as_ref().expect("load_user is in the clone class");
+    assert!(class.refined, "clones_for_symbol refines the subject's class");
+    assert_eq!(class.class_kind, "refined_class");
+    assert_eq!(class.refine_mode, Some("baseline"));
+    assert!(class.lcs_ratio.is_some(), "a refined class carries an lcs_ratio");
+    assert!(
+        class.members.iter().any(|m| m.r#ref.ends_with("load_user.rs::load_user")),
+        "the subject must appear in its own refined class: {:?}",
+        class.members.iter().map(|m| &m.r#ref).collect::<Vec<_>>()
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+/// Plan 4a: the content-addressed `refinement_key` is over the struct_hash MULTISET (order-
+/// independent), and is DISTINCT from the read-side `class_key` (location-derived). Same multiset →
+/// same key; the two key families never collide for the same class.
+#[test]
+fn refinement_key_is_content_addressed_and_distinct_from_read_key() {
+    use crate::index::clones::refine::cache::refinement_key;
+
+    let hashes = vec!["h1".to_string(), "h2".to_string(), "h3".to_string()];
+    let shuffled = vec!["h3".to_string(), "h1".to_string(), "h2".to_string()];
+    // Same multiset, different order → same refinement_key (content-addressed).
+    assert_eq!(
+        refinement_key("rust", &hashes),
+        refinement_key("rust", &shuffled),
+        "the same struct_hash multiset must address the same refinement"
+    );
+
+    // The refinement key (structural) is NOT the read-side class_key (location-derived). Build a
+    // real clone class, then confirm its persisted refinement key ≠ its read-side class_key.
+    let root = unique_temp_root();
+    let db = write_four_renamed_clones(&root);
+    let res = db
+        .find_clones(FindClonesOptions { min_similarity: None, min_copies: None, limit: None })
+        .unwrap();
+    let read_key = &res.classes[0].class_key;
+    // The persisted refinement row's PRIMARY KEY is the content-addressed key; it must not equal
+    // the location-derived read-side class_key.
+    let refinement_pk: String = db
+        .storage
+        .connection()
+        .query_row("SELECT class_key FROM clone_refinements LIMIT 1", [], |r| r.get(0))
+        .unwrap();
+    assert_ne!(
+        &refinement_pk, read_key,
+        "the content-addressed refinement key must differ from the location-derived read key"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+/// Plan 4a: the refinement cache is read-through — the first `find_clones` populates a
+/// `clone_refinements` row; a second `find_clones` over the same index serves the cache and does
+/// NOT grow the row count.
+#[test]
+fn refine_cache_is_read_through() {
+    let root = unique_temp_root();
+    let db = write_four_renamed_clones(&root);
+
+    let count_rows = |db: &IndexDatabase| -> i64 {
+        db.storage
+            .connection()
+            .query_row("SELECT COUNT(*) FROM clone_refinements", [], |r| r.get(0))
+            .unwrap()
+    };
+
+    // Before any find_clones run the cache is empty.
+    assert_eq!(count_rows(&db), 0, "no refinements before the first run");
+
+    // Run 1: refines the clean class → exactly one cache row.
+    let r1 = db
+        .find_clones(FindClonesOptions { min_similarity: None, min_copies: None, limit: None })
+        .unwrap();
+    assert!(r1.classes[0].refined, "run 1 refines the class");
+    let after_run1 = count_rows(&db);
+    assert_eq!(after_run1, 1, "run 1 persists exactly one refinement row");
+
+    // Run 2: same inputs → cache HIT, row count unchanged.
+    let r2 = db
+        .find_clones(FindClonesOptions { min_similarity: None, min_copies: None, limit: None })
+        .unwrap();
+    assert!(r2.classes[0].refined, "run 2 still refined (served from cache)");
+    assert_eq!(count_rows(&db), after_run1, "run 2 is a cache hit — the row count must not grow");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+/// Plan 4a: only the top-N (by provisional ROI) classes are refined, where N == the caller's limit.
+/// With TWO distinct clean classes and `limit = 1`, exactly ONE class is refined: the returned
+/// (top-1) class is refined, and only ONE `clone_refinements` row is written — the second class is
+/// outside the refine budget and never reaches refinement, keeping its Plan-2 (un-refined) shape.
+/// (Because the output is truncated to the limit, the un-refined class is not in the returned set;
+/// the persisted-row count is the observable proof that only the top-N were refined.)
+#[test]
+fn unrefined_class_outside_top_n_keeps_plan2_shape() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    // Class 1: two big-body renamed clones (high ROI via long body) — refined first.
+    let big = |name: &str, v: &str| {
+        format!(
+            "pub fn {name}(db: Db) -> i32 {{ let {v}1 = db.get(1); let {v}2 = db.get(2); let {v}3 \
+             = db.get(3); validate({v}1); validate({v}2); validate({v}3); {v}1 + {v}2 + {v}3 }}\n"
+        )
+    };
+    fs::write(root.join("src/big_a.rs"), big("big_user", "u")).unwrap();
+    fs::write(root.join("src/big_b.rs"), big("big_order", "o")).unwrap();
+    // Class 2: two small-body renamed clones (lower ROI via short body) — structurally distinct
+    // from class 1 so they form a SEPARATE class, ranked below it.
+    let small = |name: &str, v: &str| {
+        format!(
+            "pub fn {name}(xs: Vec<u8>) -> usize {{ let mut {v} = 0; for e in xs {{ {v} += e as \
+             usize; }} {v} }}\n"
+        )
+    };
+    fs::write(root.join("src/small_a.rs"), small("sum_bytes", "n")).unwrap();
+    fs::write(root.join("src/small_b.rs"), small("sum_words", "m")).unwrap();
+    let db = IndexDatabase::rebuild(&source_config(root.clone(), Language::Rust)).unwrap();
+
+    let count_rows = |db: &IndexDatabase| -> i64 {
+        db.storage
+            .connection()
+            .query_row("SELECT COUNT(*) FROM clone_refinements", [], |r| r.get(0))
+            .unwrap()
+    };
+
+    // Sanity: with no limit BOTH classes exist (the default budget 50 refines both).
+    let all = db
+        .find_clones(FindClonesOptions { min_similarity: None, min_copies: None, limit: None })
+        .unwrap();
+    assert_eq!(all.classes.len(), 2, "two distinct clean classes are planted");
+    assert!(all.classes.iter().all(|c| c.refined), "default budget refines both");
+    assert_eq!(count_rows(&db), 2, "default budget persists both refinements");
+
+    // Fresh index so the cache starts empty for the budget assertion.
+    let root2 = unique_temp_root();
+    let _ = fs::remove_dir_all(&root2);
+    fs::create_dir_all(root2.join("src")).unwrap();
+    fs::write(root2.join("src/big_a.rs"), big("big_user", "u")).unwrap();
+    fs::write(root2.join("src/big_b.rs"), big("big_order", "o")).unwrap();
+    fs::write(root2.join("src/small_a.rs"), small("sum_bytes", "n")).unwrap();
+    fs::write(root2.join("src/small_b.rs"), small("sum_words", "m")).unwrap();
+    let db2 = IndexDatabase::rebuild(&source_config(root2.clone(), Language::Rust)).unwrap();
+
+    // limit=1 ⇒ refine budget 1 ⇒ only the top-1 class is refined.
+    let limited = db2
+        .find_clones(FindClonesOptions { min_similarity: None, min_copies: None, limit: Some(1) })
+        .unwrap();
+    assert_eq!(limited.classes.len(), 1, "limit=1 returns exactly one class");
+    let top = &limited.classes[0];
+    assert!(top.refined, "the single returned (top-1) class is refined");
+    assert!(top.lcs_ratio.is_some(), "the refined class carries an lcs_ratio");
+    assert_eq!(top.refine_mode, Some("baseline"));
+    // Only ONE refinement was computed/persisted: the second class is outside the budget and keeps
+    // its un-refined Plan-2 shape (it never reached `refine_class`).
+    assert_eq!(
+        count_rows(&db2),
+        1,
+        "limit=1 refines only the top-1 class — the out-of-budget class is never refined"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+    fs::remove_dir_all(root2).unwrap();
 }
 
 /// Fix 3 (#215): `clones_for_symbol` carries eligibility flags. A below-`MIN_TOKENS` function

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -12935,14 +12935,16 @@ fn find_clones_truncated_reflects_class_limit() {
 /// Plan 4 coherence-splits over-merged components; the A~B~C chain becomes coherent sub-classes.
 ///
 /// A TRANSITIVE-chain component (A–B and B–C both ≥ θ, but A–C < θ) is over-merged by union-find
-/// into one 3-member component. Plan 4a's `coherence_split` breaks it: every returned class must be
-/// internally coherent (all pairs ≥ θ), so NO single class contains all three. For this fixture the
-/// greedy first-fit yields the coherent class {A,B} (C cannot join — C/A is below θ — and drops as
-/// a singleton). `find_clones` therefore returns at most a 2-member class, never the 3-member
-/// chain.
+/// into one 3-member component. Plan 4a's `coherence_split` (greedy maximal clique cover) breaks
+/// it: every returned class is internally coherent (all pairs ≥ θ), so NO single class contains all
+/// three. For this fixture the cover yields BOTH coherent pairs — {A,B} and {B,C} — with B in both
+/// (the overlap is correct: B coheres with two peers that are themselves incompatible).
+/// `find_clones` therefore returns two 2-member classes, never the 3-member chain.
 ///
-/// `clones_for_symbol` keeps a reverse-lookup fallback: a subject that splits to a singleton (C
-/// here) still gets served the FULL un-refined component, so a query ABOUT C is not empty.
+/// `clones_for_symbol(A)` returns the largest coherent group containing A — here the {A,B} pair.
+/// `clones_for_symbol(C)` returns the coherent {B,C} pair (C is NO LONGER a singleton under the
+/// clique cover), so a query ABOUT C surfaces a real refined sub-class, not the over-merged
+/// fallback.
 ///
 /// The fixture is empirically tuned and the test asserts the MEASURED edge similarities so it is
 /// honest about the chain it plants (a tokenizer change that shifts the numbers reddens here, not
@@ -13012,7 +13014,8 @@ fn coherence_split_applied_in_find_clones() {
 
     // Now the full three-member scope. At the default θ=0.70 the over-merged union-find component
     // {A,B,C} is coherence-SPLIT: no returned class contains all three, and every returned class is
-    // internally coherent (all pairs ≥ θ). For this fixture the only coherent ≥2 class is {A,B}.
+    // internally coherent (all pairs ≥ θ). The greedy clique cover yields BOTH coherent pairs:
+    // {A,B} and {B,C}.
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join("src")).unwrap();
@@ -13038,33 +13041,36 @@ fn coherence_split_applied_in_find_clones() {
             class.cohesion_min_pairwise
         );
     }
-    // The chain yields the coherent class {A,B} (C drops as a singleton: C/A < θ).
-    assert_eq!(res.classes.len(), 1, "the chain yields exactly one coherent ≥2 class ({{A,B}})");
-    assert_eq!(res.classes[0].member_count, 2, "the coherent class is the {{A,B}} pair");
+    // After clique-cover split, both {A,B} and {B,C} are returned (B in both).
+    assert_eq!(
+        res.classes.len(),
+        2,
+        "the chain yields two coherent ≥2 classes: {{A,B}} and {{B,C}}"
+    );
+    for class in &res.classes {
+        assert_eq!(class.member_count, 2, "each coherent class has 2 members");
+    }
 
-    // clones_for_symbol(A): A is in the coherent {A,B} sub-class → that 2-member class (refined).
+    // clones_for_symbol(A): A is in {A,B} only. The largest group containing A is {A,B} (refined).
     let by_a = db.clones_for_symbol(CloneSymbolSelector::Ref("src/a.rs::fa".into())).unwrap();
     let a_class = by_a.class.as_ref().expect("fa is in the coherent {A,B} sub-class");
     assert_eq!(a_class.member_count, 2, "clones_for_symbol(fa) returns A's coherent sub-class");
-    assert_eq!(
-        a_class.class_key, res.classes[0].class_key,
+    // A's class must match one of the returned classes from find_clones.
+    assert!(
+        res.classes.iter().any(|c| c.class_key == a_class.class_key),
         "find_clones and clones_for_symbol must return the SAME coherent sub-class for A"
     );
 
-    // clones_for_symbol(C): C split to a singleton → the reverse-lookup fallback serves the FULL
-    // un-refined component (all 3 members, refined=false) so a query ABOUT C is not empty.
+    // clones_for_symbol(C): after the clique cover, C is in the coherent {B,C} sub-class (NOT a
+    // singleton anymore), so the reverse lookup serves that refined 2-member class — no fallback to
+    // the over-merged 3-member component.
     let by_c = db.clones_for_symbol(CloneSymbolSelector::Ref("src/c.rs::fc".into())).unwrap();
-    let c_class = by_c.class.as_ref().expect("fc falls back to the full un-refined component");
+    let c_class = by_c.class.as_ref().expect("fc is in the coherent {B,C} sub-class");
     assert_eq!(
-        c_class.member_count, 3,
-        "clones_for_symbol(fc) falls back to the 3-member component"
+        c_class.member_count, 2,
+        "clones_for_symbol(fc) returns C's coherent {{B,C}} sub-class"
     );
-    assert!(!c_class.refined, "the singleton-subject fallback class is un-refined");
-    assert!(
-        (c_class.cohesion_min_pairwise - ac).abs() < 1e-9,
-        "the fallback component's min-pairwise must equal the measured A/C edge: class={} ac={ac}",
-        c_class.cohesion_min_pairwise
-    );
+    assert!(c_class.refined, "the {{B,C}} sub-class is refined");
 
     fs::remove_dir_all(root).unwrap();
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -10491,12 +10491,13 @@ fn open_under_a_held_write_lock_migrates_older_schema_without_deadlock() {
         let db = IndexDatabase::rebuild(&config).unwrap();
         db.storage
             .connection()
-            .execute("DELETE FROM schema_version WHERE id = '029_clone_fingerprint_tables'", [])
+            .execute("DELETE FROM schema_version WHERE id = '030_clone_refinements_lcs_sampled'", [
+            ])
             .unwrap();
         assert_eq!(
             schema::status(db.storage.connection()).unwrap().state,
             schema::SchemaState::Older,
-            "removing the V029 ledger row makes the schema Older"
+            "removing the V030 ledger row makes the schema Older"
         );
     }
 
@@ -10521,7 +10522,7 @@ fn v022_fresh_apply_creates_packages_and_dedicated_import_scope_columns() {
     schema::apply(&conn).unwrap();
 
     assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 29);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 30);
     assert!(conn_table_exists(&conn, "packages"), "packages table is created on a fresh apply");
 
     let package_cols = conn_table_columns(&conn, "packages");
@@ -10596,6 +10597,7 @@ fn v022_forward_migrate_adds_artifacts_to_an_older_index() {
         DELETE FROM schema_version WHERE id = '027_drop_chunks_text';
         DELETE FROM schema_version WHERE id = '028_intern_symbol_qualified_names';
         DELETE FROM schema_version WHERE id = '029_clone_fingerprint_tables';
+        DELETE FROM schema_version WHERE id = '030_clone_refinements_lcs_sampled';
         ",
     )
     .unwrap();
@@ -10734,16 +10736,18 @@ fn v028_forward_migrate_interns_and_drops_the_inline_column() {
         ",
     )
     .unwrap();
-    // 3. Drop the V028 and V029 ledger rows so the schema reads Older and the migration replays.
+    // 3. Drop the V028, V029, and V030 ledger rows so the schema reads Older and the migration
+    //    replays.
     conn.execute_batch(
         "DELETE FROM schema_version WHERE id = '028_intern_symbol_qualified_names';
-         DELETE FROM schema_version WHERE id = '029_clone_fingerprint_tables';",
+         DELETE FROM schema_version WHERE id = '029_clone_fingerprint_tables';
+         DELETE FROM schema_version WHERE id = '030_clone_refinements_lcs_sampled';",
     )
     .unwrap();
     assert_eq!(
         schema::status(&conn).unwrap().state,
         schema::SchemaState::Older,
-        "removing the V028+V029 ledger rows makes the pre-V028 shape Older"
+        "removing the V028+V029+V030 ledger rows makes the pre-V028 shape Older"
     );
 
     // --- Forward-migrate ---
@@ -12258,6 +12262,82 @@ fn v029_creates_clone_fingerprint_tables_on_fresh_and_migrated_dbs() {
         )
         .expect("query3");
     assert_eq!(df, 1, "clone_token_df must exist after migrate_forward");
+}
+
+/// Regression test for the P1 schema bug (#215 Plan 4a): an index recorded at V029 WITHOUT
+/// `clone_refinements.lcs_sampled` (because V029 was applied before the column landed) must have
+/// the column added by the V030 forward migration. Simulates the bug by building a full schema,
+/// dropping the column, deleting the V030 ledger row (making the schema Older), then re-running
+/// `migrate_forward` and asserting the column is present and a direct SELECT succeeds.
+#[test]
+fn v030_forward_migrate_adds_lcs_sampled_to_existing_v029_index() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    // Start from a fully-applied schema (includes V029 DDL which already has lcs_sampled).
+    crate::index::schema::apply(&conn).expect("apply");
+    assert_eq!(
+        crate::index::schema::status(&conn).unwrap().current_version,
+        crate::index::schema::LATEST_SCHEMA_VERSION,
+        "fresh apply reaches V30"
+    );
+
+    // --- Simulate a V029-era index that was recorded before lcs_sampled landed ---
+    // SQLite ≥3.35 supports DROP COLUMN.
+    conn.execute_batch("ALTER TABLE clone_refinements DROP COLUMN lcs_sampled;")
+        .expect("drop lcs_sampled to simulate the pre-column V029 state");
+    // Confirm the column is gone.
+    let cols_before: Vec<String> = {
+        let mut stmt = conn.prepare("PRAGMA table_info(clone_refinements)").unwrap();
+        stmt.query_map([], |row| row.get::<_, String>(1)).unwrap().map(|r| r.unwrap()).collect()
+    };
+    assert!(
+        !cols_before.contains(&"lcs_sampled".to_string()),
+        "lcs_sampled must be absent before the migration runs"
+    );
+    // Remove the V030 ledger row so the schema reads Older and migrate_forward replays it.
+    conn.execute_batch(
+        "DELETE FROM schema_version WHERE id = '030_clone_refinements_lcs_sampled';",
+    )
+    .expect("delete V030 ledger row");
+    assert_eq!(
+        crate::index::schema::status(&conn).unwrap().state,
+        crate::index::schema::SchemaState::Older,
+        "schema is Older after removing V030 ledger row"
+    );
+
+    // --- Run the forward migration ---
+    crate::index::schema::migrate_forward(&conn).expect("migrate_forward");
+
+    // --- Assert the column is now present and the schema is current ---
+    let cols_after: Vec<String> = {
+        let mut stmt = conn.prepare("PRAGMA table_info(clone_refinements)").unwrap();
+        stmt.query_map([], |row| row.get::<_, String>(1)).unwrap().map(|r| r.unwrap()).collect()
+    };
+    assert!(
+        cols_after.contains(&"lcs_sampled".to_string()),
+        "V030 must add lcs_sampled to an existing V029 clone_refinements table"
+    );
+    // A direct SELECT proves the column is queryable (the original bug: `no such column:
+    // lcs_sampled`).
+    let _: i64 = conn
+        .query_row("SELECT COUNT(lcs_sampled) FROM clone_refinements", [], |r| r.get(0))
+        .expect("SELECT lcs_sampled must succeed after V030 migration");
+    assert_eq!(
+        crate::index::schema::status(&conn).unwrap().current_version,
+        crate::index::schema::LATEST_SCHEMA_VERSION,
+        "schema is at LATEST_SCHEMA_VERSION after V030 migration"
+    );
+    assert_eq!(
+        crate::index::schema::LATEST_SCHEMA_VERSION,
+        30,
+        "LATEST_SCHEMA_VERSION is 30 after V030"
+    );
+    // Idempotency: running migrate_forward again must not error.
+    crate::index::schema::migrate_forward(&conn).expect("migrate_forward is idempotent");
+    assert_eq!(
+        crate::index::schema::status(&conn).unwrap().state,
+        crate::index::schema::SchemaState::Compatible,
+        "schema is still Compatible after second migrate_forward"
+    );
 }
 
 #[test]

--- a/crates/rag-rat-mcp/src/tools/catalog.rs
+++ b/crates/rag-rat-mcp/src/tools/catalog.rs
@@ -113,7 +113,11 @@ pub fn description(name: &str) -> &'static str {
         "find_clones" =>
             "Ranked candidate clone classes (unrefined; exact overlap metrics). Returns classes \
              sorted by ROI (cross-module spread × member count × token length × load-bearing \
-             factor × cohesion), with a completeness provenance block.",
+             factor × cohesion), with a completeness provenance block. `min_similarity` (if set) \
+             must be in [0.5, 1.0] (default 0.7). A LIMITED query (`limit: N`) is capped at the \
+             refine budget (currently 50) — it returns at most 50 classes, all refined; pass \
+             `limit: null`/omit it to retrieve all classes (only the top 50 refined). \
+             `completeness.refine_budget_clamped` is true when a supplied limit hit that cap.",
         "clones_for_symbol" =>
             "The clone class containing a symbol (by id / ref / path+line). Returns the candidate \
              class if the symbol is fingerprinted and has clone siblings; null if it is unique or \

--- a/crates/rag-rat-mcp/src/tools/requests.rs
+++ b/crates/rag-rat-mcp/src/tools/requests.rs
@@ -773,8 +773,14 @@ impl MemoryUpdateArgs {
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
 pub struct FindClonesArgs {
+    /// Minimum pairwise overlap/max_len similarity. Must be in the range [0.5, 1.0]; defaults to
+    /// 0.7 (the θ threshold) when omitted. Out-of-range values are rejected.
     pub min_similarity: Option<f64>,
+    /// Minimum number of copies for a class to be returned (defaults to 2).
     pub min_copies: Option<usize>,
+    /// Maximum number of clone classes to return, sorted by ROI descending. A supplied limit is
+    /// capped at the refine budget (currently 50): `limit: N` returns at most 50 classes, all
+    /// refined. Omit (null) to retrieve all classes (only the top 50 refined, the rest unrefined).
     pub limit: Option<usize>,
 }
 


### PR DESCRIPTION
Stage 4a of #215 Plan 4 — the clone **refine** engine, baseline-first. Turns Plan 2's ranked *candidate components* into coherent, confidence-scored, refactorability-ranked, content-cached **refined clone classes**. This is the first half; **4b** (the anti-unify *template + variation points + proposed signature* + `clones --explain`) follows as a separate PR. No SCIP yet (Plan 3 lands after, with this consumer already in place).

## What this adds
- **Coherence split** — union-find over-merges transitive chains (A~B, B~C, A!~C → one component). `find_clones` and `clones_for_symbol` now split every component into internally-coherent classes (every pair ≥ θ) before treating anything as a class; both surfaces split identically. `clones_for_symbol` falls back to the un-refined component when its subject lands in a dropped singleton, so the relationship is never hidden.
- **LCS alignment + `lcs_ratio`** — NiCad-style fidelity over the normalized token sequences (re-derived at query time; min-over-pairs, never averaged), with a deterministic DP backtrace gated by a new `ALIGNMENT_VERSION`.
- **Refactorability + confidence + ROI rework** — refined classes carry `lcs_ratio`, `confidence`, `refactorability`, `refine_mode`; ROI gains `× refactorability` (replaces Plan 2's cohesion-as-placeholder multiplier; cohesion stays a surfaced stat). Two-phase: rank by Plan-2 ROI to pick the top-N to refine, then re-rank refined classes by refactorability.
- **Content-addressed cache** — refined results persist in `clone_refinements` (the V029 table, previously unused) keyed by content only (`language ‖ refine_mode ‖ norm_version ‖ alignment_version ‖ sorted member struct_hashes`) — no paths/ids/scope/ROI in the row. Read-through: computed once per distinct class content.

## Invariants & honesty
- **Baseline-only, LCS-first** — `refine_mode="baseline"`; no SCIP moniker-collapse (Plan 3), no GumTree (a later upgrade, per the design's own staging).
- **`refined` honesty** — only classes that were actually refined carry `refined=true`/`class_kind="refined_class"`; everything else keeps Plan 2's `candidate_component` shape. Refine is best-effort: if a member's source is unreadable/stale/under a worktree overlay, the class degrades to un-refined rather than templating stale tokens (pinned by an integration test).
- **Scope-independence preserved** — the cache is content-only (no per-scope leak); the only scope-dependent step stays the query-time clustering over the scoped `files` view. Re-parse is scope-correct (overlay → un-refined, per the round-6 staleness lesson).
- **Faithfulness pin** — the query-time re-parse must reproduce Plan 1's persisted `struct_hash` exactly, else the member is treated as drifted (un-refined).

## Tests
845 passing across `rag-rat-core` + `rag-rat` + `rag-rat-mcp` — coherence split (chain-splits + determinism + singleton-drop), the re-parse faithfulness pin, LCS (min-not-average + deterministic tie-break + empty/degenerate), the refined end-to-end class, content-key distinctness, read-through cache (no recompute), the budget boundary, and the best-effort un-refinable fallback. Reviewed task-by-task plus a final whole-branch adversary pass.

## Follow-ups (tracked, non-blocking)
- **LCS cost cap (4b):** `lcs_align`'s O(n·m) DP table is unbounded in token length; bounded today by the content cache + the refine top-N budget + generated-file exclusion, but a large many-member class pays it on first refine. 4b will cap input length / pair count and degrade to a token-bag proxy above the cap (flagged like `metrics_sampled`). Captured as a rag-rat PerformanceNote.
- **Mixed-ROI-scale at the budget boundary (4b):** the refine budget is spent on the provisional cohesion ranking, then refined classes re-sort by refactorability — near the `limit` cut, a refined and an un-refined class can mix ROI scales. Design accepts it; 4b can refine `limit + margin` to reduce boundary churn.
- The crude first-pair LCS skeleton stored in 4a is replaced by real N-way anti-unification in 4b.
