### PR TITLE
Cross-platform support (macOS + Windows)

### DIFF
--- a/.github/workflows/ci-cross-platform.yml
+++ b/.github/workflows/ci-cross-platform.yml
@@ -1,0 +1,98 @@
+name: CI (cross-platform)
+
+# macOS + Windows coverage for the test/clippy/build-full legs. These platforms are NOT exercised on
+# every PR/push (that would multiply CI minutes for the rare platform regression); the per-PR + main
+# matrix in ci.yml stays Linux-only. Instead this runs only when a release is published — the same
+# `release: published` trigger oracle.yml and bench-release.yml already key off (release-plz cuts the
+# GitHub release, authored with RELEASE_PLZ_TOKEN so downstream workflows fire, once the Release PR's
+# version commit lands on main). workflow_dispatch is kept so the matrix can be validated manually.
+#
+# Jobs mirror ci.yml's Linux legs exactly (toolchain, rust-cache, feature flags) so a real mac/win
+# break surfaces the same way it would on Linux:
+#   - clippy / test run --no-default-features (hash embedder, no ONNX/model download — network-free);
+#   - build-full compiles the default feature set (fastembed + model2vec / ort), the load-bearing leg
+#     where the ONNX Runtime download+link path would actually break on a new platform.
+#
+# NOTE: the Windows legs depend on #237 (rusqlite must be `bundled` so it links without a system
+# SQLite). With that landed, windows-latest links the vendored SQLite amalgamation via cc.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+# Least privilege: CI only reads the repo.
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-cross-platform-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  clippy:
+    name: clippy (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      # --no-default-features = hash-only build: no ONNX/model downloads, fast and network-free.
+      # The full feature set is compile-checked by the build-full job below.
+      - run: cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings
+
+  test:
+    name: test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@nextest
+      # Hash embedder only (no model downloads). Mirrors ci.yml's test leg; the Codecov upload is
+      # intentionally dropped here (coverage / test-analytics stay Linux-only).
+      - name: Run tests (nextest)
+        # --no-fail-fast: this matrix runs only on release (rare), so surface EVERY platform-specific
+        # failure in a single run rather than stopping at the first (the ci profile fails fast).
+        run: cargo nextest run --workspace --no-default-features --locked --profile ci --no-fail-fast
+
+  build-full:
+    name: build (fastembed + model2vec) (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # Align the MSVC C runtime so the link succeeds. esaxx-rs (a C++ dep via
+      # tokenizers <- model2vec/fastembed) hardcodes cc's .static_crt(true) => /MT, but the ort_sys
+      # ONNX Runtime prebuilt is /MD; the mismatch is LNK2038/LNK1319 on Windows. cc appends env
+      # CFLAGS/CXXFLAGS AFTER its own /MT and cl.exe is last-flag-wins, so /MD here overrides
+      # esaxx's /MT to match ort. Windows-only: on macOS the esaxx build is clang, where -MD means
+      # "emit make dependencies" and would break the build.
+      - name: Align MSVC CRT to dynamic (/MD) to match the ort prebuilt
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          echo "CFLAGS=-MD" >> "$GITHUB_ENV"
+          echo "CXXFLAGS=-MD" >> "$GITHUB_ENV"
+      # Compile the default feature set (downloads the ONNX runtime once, then cached) so the
+      # released binary's embedding paths never break silently on mac/Windows.
+      - run: cargo build --workspace --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +187,12 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
@@ -193,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -225,9 +240,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cast"
@@ -246,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -472,23 +487,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -496,12 +510,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -656,13 +670,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "derive_builder"
@@ -744,7 +787,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid",
  "crypto-common 0.2.2",
 ]
@@ -873,15 +916,15 @@ dependencies = [
 
 [[package]]
 name = "fastembed"
-version = "5.16.0"
+version = "5.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add59222e7bc3787285f993744b244cd454d78571845623606bdc45b22b23a4e"
+checksum = "545e4fb17fc48768ff36c2a3854aa5b0b809d0ed595ab5530fa8ac94f31bd0ea"
 dependencies = [
  "anyhow",
  "hf-hub 0.5.0",
  "ndarray 0.17.2",
  "ort",
- "safetensors 0.7.0",
+ "safetensors 0.8.0",
  "serde",
  "serde_json",
  "tokenizers 0.22.2",
@@ -934,12 +977,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1092,15 +1129,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1273,7 +1308,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bstr",
  "gix-path",
  "libc",
@@ -1422,7 +1457,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bstr",
  "gix-features",
  "gix-path",
@@ -1481,7 +1516,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e6b28cc592dc753adb58302bb14a64e412ee591a3bec77aa4df87bff74fa80d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bstr",
  "filetime",
  "fnv",
@@ -1575,9 +1610,9 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline"
-version = "0.21.4"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb18337ba2830bb43367d1af43819c8c78f31337f079fc76d0f1f1750a173126"
+checksum = "b217dd0ee0c4021ecf169a4a519b1b4f80d15e3f3765f3dc466223dc0ac891d7"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -1603,7 +1638,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3050783b41ee11511e1e8fb35623df81806194f4030395f14f48ea37c2798c9f"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bstr",
  "gix-attributes",
  "gix-config-value",
@@ -1684,7 +1719,7 @@ version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b47c88884dd3c1a19a39da19d10211fcdea2809aadc86869b6e824a1774340f"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bstr",
  "gix-commitgraph",
  "gix-date",
@@ -1719,7 +1754,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8519976e4c7e486270740a5400369f37940779b80bd1377d94cfa1125d01b3"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "gix-path",
  "libc",
  "windows-sys 0.61.2",
@@ -1817,7 +1852,7 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8de590ecc86a3b2870665f2288324fa9f7f8672c7fc2d4e020fdd81cd1f7aed"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -1937,22 +1972,13 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
  "serde",
  "serde_core",
 ]
@@ -1965,7 +1991,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1992,12 +2018,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hf-hub"
@@ -2125,7 +2145,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -2294,12 +2314,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2350,8 +2364,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -2386,7 +2398,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
@@ -2407,17 +2419,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2425,9 +2426,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2449,10 +2450,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
 dependencies = [
+ "defmt",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
@@ -2464,9 +2466,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2500,13 +2502,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2526,7 +2527,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -2538,12 +2539,6 @@ checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
 dependencies = [
  "static_assertions",
 ]
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -2566,6 +2561,7 @@ version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2599,9 +2595,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -2654,9 +2650,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
@@ -2785,7 +2781,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -2803,7 +2799,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2863,7 +2859,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -2913,6 +2909,16 @@ dependencies = [
  "hmac-sha256",
  "lzma-rust2",
  "ureq 3.3.0",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3005,16 +3011,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
 ]
 
 [[package]]
@@ -3201,7 +3197,7 @@ dependencies = [
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
- "ureq 2.12.1",
+ "ureq 3.3.0",
  "zstd",
 ]
 
@@ -3291,7 +3287,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3327,9 +3323,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3350,9 +3346,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -3392,7 +3388,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -3460,7 +3456,7 @@ version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3490,7 +3486,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3557,13 +3553,15 @@ dependencies = [
 
 [[package]]
 name = "safetensors"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+checksum = "79b079b829cb27a1c3c374341345ed2e8b2c0c839034522cee576c140bd7f846"
 dependencies = [
  "hashbrown 0.16.1",
+ "libc",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -3766,9 +3764,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
@@ -3847,9 +3845,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3883,7 +3881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3931,12 +3929,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -3946,15 +3943,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4184,7 +4181,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -4369,15 +4366,9 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode_categories"
@@ -4434,7 +4425,7 @@ dependencies = [
  "socks",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -4518,27 +4509,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4549,9 +4531,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4559,9 +4541,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4569,9 +4551,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4582,33 +4564,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -4625,22 +4585,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4662,14 +4610,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4937,97 +4885,9 @@ checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -5060,18 +4920,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5101,9 +4961,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,10 @@ resolver = "3"
 version = "0.8.0"
 authors = ["Kristaps Karlsons"]
 edition = "2024"
-rust-version = "1.89"
+# Bundled SQLite (rusqlite `bundled` -> libsqlite3-sys 0.38.1) compiles a build script that uses the
+# `cfg_select!` macro, stabilized in Rust 1.95 — so the whole workspace's MSRV is 1.95 on every
+# platform. (Latest non-SQLite deps need only 1.88: darling, ort-sys.)
+rust-version = "1.95"
 license = "MIT"
 repository = "https://github.com/cq27-dev/rag-rat"
 readme = "README.md"
@@ -28,22 +31,22 @@ categories = ["command-line-utilities", "development-tools"]
 rag-rat-core = { version = "0.8.0", path = "crates/rag-rat-core", default-features = false }
 rag-rat-mcp = { version = "0.8.0", path = "crates/rag-rat-mcp", default-features = false }
 anyhow = "1.0"
-fastembed = { version = "5.1.0", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
+fastembed = { version = "5.17.2", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
 gix = { version = "0.84.0", default-features = false, features = ["status", "parallel", "sha1", "sha256", "revision", "blob-diff", "blame"] }
 libc = "0.2"
 rmcp = { version = "1.7.0", features = ["transport-io"] }
-rusqlite = "0.40"
-rayon = "1.11"
-regex = "1.11"
+rusqlite = { version = "0.40", features = ["bundled"] }
+rayon = "1.12"
+regex = "1.12"
 schemars = { version = "1.2.1", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.11"
 thiserror = "2.0"
-tokio = { version = "1.48", features = ["rt-multi-thread", "macros", "io-std"] }
+tokio = { version = "1.52", features = ["rt-multi-thread", "macros", "io-std"] }
 # Minimal blocking HTTP for the crates.io version check (and future GitHub/GitLab/Bitbucket REST).
 # rustls (no system OpenSSL); gzip off — the responses are tiny. The only HTTP at the core edge.
-ureq = { version = "2", default-features = false, features = ["tls"] }
+ureq = { version = "3", default-features = false, features = ["rustls"] }
 # TOON (Token-Oriented Object Notation): the default render for CLI + MCP output. ~34% fewer tokens
 # than compact JSON on uniform-row payloads, neutral on nested ones — see rag_rat_core::output.
 # default-features = false drops its `cli` feature (ratatui/crossterm/arboard/syntect/tiktoken-rs/…)
@@ -58,3 +61,10 @@ tree-sitter-kotlin = { package = "tree-sitter-kotlin-ng", version = "1.1.0" }
 tree-sitter-python = "=0.25.0"
 tree-sitter-rust = "=0.24.2"
 tree-sitter-typescript = "=0.23.2"
+
+# `cc` compiles the bundled SQLite amalgamation at the profile's opt-level, which is 0 for
+# `cargo build`/`cargo test` — an unoptimized SQLite is dramatically slower at the heavy INSERT
+# workload the indexing tests run. Build just this one C-heavy dep at opt-level 3 so dev/test stays
+# fast; it's compiled once then cached.
+[profile.dev.package.libsqlite3-sys]
+opt-level = 3

--- a/README.md
+++ b/README.md
@@ -54,8 +54,31 @@ From a checkout:
 cargo install --path crates/rag-rat-cli --bin rag-rat
 ```
 
-Add `--no-default-features` for a smaller hash-only build without real embeddings. rag-rat links
-against the system SQLite via `rusqlite`.
+Add `--no-default-features` for a smaller hash-only build without real embeddings. SQLite is bundled
+(compiled in via `rusqlite`), so there is no system-library prerequisite — see
+[Platform support](#platform-support) for the per-OS C-toolchain note.
+
+## Platform support
+
+rag-rat builds and tests on Linux, macOS, and Windows. Linux is covered on every PR and on every
+push to main; macOS and Windows are exercised on release, so `cargo install rag-rat` builds and
+links on all three.
+SQLite is bundled (compiled from source via `rusqlite`), so there's no system-library prerequisite,
+but each platform needs a C toolchain: Linux ships one; on macOS install the Xcode Command Line
+Tools (`xcode-select --install`); on Windows install the Visual Studio Build Tools with the C++
+workload (MSVC). Requires **Rust 1.95+** (the bundled SQLite build uses the `cfg_select!` macro,
+stabilized in 1.95).
+
+A few maintenance conveniences are Unix- or Linux-only by design and degrade quietly elsewhere — no
+feature of the index, query, or MCP surface is affected:
+
+- **Hot-upgrade of a running MCP server** (the `SIGUSR1` in-place re-exec) is Unix-only. On Windows,
+  restart `rag-rat mcp` to pick up a new binary.
+- **Fleet auto-upgrade** (signalling other running servers when a new binary lands) is Linux-only —
+  it walks `/proc` — and is a no-op elsewhere.
+- **The grep-augmentation hook** uses a warm Unix-socket listener (with per-session dedupe) on
+  Linux and macOS; on Windows it falls back to a per-call read-only query straight against the
+  index, which works the same but without cross-call dedupe.
 
 ## Quickstart
 

--- a/crates/rag-rat-cli/Cargo.toml
+++ b/crates/rag-rat-cli/Cargo.toml
@@ -17,15 +17,19 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow.workspace = true
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 dialoguer = "0.12"
 gix.workspace = true
-libc.workspace = true
 rag-rat-core = { workspace = true }
 rag-rat-mcp = { workspace = true }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
+
+# Consumed only by the unix-gated terminal-reset guard (`init/mod.rs`) — dead on non-unix targets,
+# so gate it there to match rag-rat-core / rag-rat-mcp (#240).
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
 
 [dev-dependencies]
 # MCP tool results render as TOON; integration tests decode them back to JSON Values to assert.

--- a/crates/rag-rat-cli/src/claude_hook/mod.rs
+++ b/crates/rag-rat-cli/src/claude_hook/mod.rs
@@ -8,7 +8,11 @@
 //! Exit 0 on every path — the hook must never block a tool call or session start.
 
 use std::io::Read as _;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+// PathBuf (socket_path) and Duration (SOCKET_BUDGET) back the unix-only listener path.
+#[cfg(unix)]
+use std::path::PathBuf;
+#[cfg(unix)]
 use std::time::Duration;
 
 use rag_rat_core::config::Config;
@@ -18,6 +22,8 @@ use rag_rat_core::query::orientation::Orientation;
 use rag_rat_core::storage::IndexConnection;
 use serde::Deserialize;
 
+// Only the unix Unix-socket listener path uses this; dead on Windows (which has no warm listener).
+#[cfg(unix)]
 const SOCKET_BUDGET: Duration = Duration::from_millis(250);
 
 /// Parsed hook input.  Fields absent on `SessionStart` (`tool_name`, `tool_input`) are
@@ -43,6 +49,9 @@ pub struct HookInput {
 pub struct Search {
     pub pattern: String,
     pub search_path: Option<String>,
+    // Set on every platform but read only by the unix listener path (it's sent in the socket
+    // request); on Windows there is no listener, so it's intentionally unread there.
+    #[cfg_attr(not(unix), allow(dead_code))]
     pub source: &'static str,
 }
 
@@ -559,6 +568,8 @@ fn ask_listener(
 
 /// Single source of truth via `locks::hook_socket_path_for`; same computation as the MCP
 /// listener's `socket_path_for`, guaranteed not to diverge.
+// Only the unix listener path calls this; dead on Windows.
+#[cfg(unix)]
 fn socket_path(config: &Config) -> PathBuf {
     locks::hook_socket_path_for(config)
 }

--- a/crates/rag-rat-cli/src/claude_settings.rs
+++ b/crates/rag-rat-cli/src/claude_settings.rs
@@ -190,7 +190,11 @@ pub fn hook_status(settings: &Value) -> HookStatus {
 /// Project `.claude/settings.json` or, with `--global`, `~/.claude/settings.json`.
 pub fn settings_path(repo_root: &Path, global: bool) -> anyhow::Result<PathBuf> {
     if global {
-        let home = std::env::var_os("HOME").ok_or_else(|| anyhow::anyhow!("HOME not set"))?;
+        // Resolve the user home portably: $HOME on unix, %USERPROFILE% on stock Windows
+        // (where HOME is usually unset).
+        let home = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .ok_or_else(|| anyhow::anyhow!("neither HOME nor USERPROFILE is set"))?;
         Ok(PathBuf::from(home).join(".claude/settings.json"))
     } else {
         Ok(repo_root.join(".claude/settings.json"))

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -63,7 +63,7 @@ eval = []
 iai-callgrind = "0.16"
 # Wall-clock benchmarking (full-index time on a larger corpus). default-features off to skip the
 # plotting deps — Bencher parses criterion's stdout estimates.
-criterion = { version = "0.5", default-features = false }
+criterion = { version = "0.8", default-features = false }
 
 # iai-callgrind: deterministic instruction counts (index + cold/warm query).
 [[bench]]

--- a/crates/rag-rat-core/src/fleet.rs
+++ b/crates/rag-rat-core/src/fleet.rs
@@ -20,6 +20,9 @@ use std::path::Path;
 pub const UPGRADE_BIN_ENV: &str = "RAG_RAT_UPGRADE_BIN";
 
 /// A candidate process discovered under `/proc`, reduced to what target selection needs.
+// Linux-only: the only consumers are `trigger`/`scan_proc`/`select_targets`, all gated to Linux —
+// without this gate it is dead code under `-D warnings` on macOS/Windows.
+#[cfg(target_os = "linux")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ProcInfo {
     pub pid: i32,
@@ -33,6 +36,7 @@ pub(crate) struct ProcInfo {
 /// Choose which PIDs to `SIGUSR1`, ordered so this process upgrades **last** (others ascending,
 /// self appended). A process is a target iff it is [`ProcInfo::eligible`] and running an outdated
 /// binary (`exe_inode != installed_inode`). Pure, so it is unit-testable without `/proc`.
+#[cfg(target_os = "linux")]
 pub(crate) fn select_targets(procs: &[ProcInfo], installed_inode: u64) -> Vec<i32> {
     let mut others: Vec<i32> = Vec::new();
     let mut own: Option<i32> = None;
@@ -146,7 +150,8 @@ mod linux {
     }
 }
 
-#[cfg(test)]
+// `select_targets`/`ProcInfo` exist only on Linux, so their unit tests are Linux-only too.
+#[cfg(all(test, target_os = "linux"))]
 mod tests {
     use super::*;
 

--- a/crates/rag-rat-core/src/index/ai/helpers.rs
+++ b/crates/rag-rat-core/src/index/ai/helpers.rs
@@ -179,6 +179,12 @@ pub(crate) fn fastembed_cache_dir() -> PathBuf {
     if let Ok(home) = std::env::var("HOME") {
         return PathBuf::from(home).join(".cache").join("rag-rat").join("models");
     }
+    // On Windows HOME/XDG_CACHE_HOME are usually unset; land the model cache per-user under
+    // %LOCALAPPDATA% rather than per-checkout in the repo-relative fallback below.
+    #[cfg(windows)]
+    if let Ok(local) = std::env::var("LOCALAPPDATA") {
+        return PathBuf::from(local).join("rag-rat").join("models");
+    }
     PathBuf::from(".rag-rat").join("models")
 }
 

--- a/crates/rag-rat-core/src/index/chunker.rs
+++ b/crates/rag-rat-core/src/index/chunker.rs
@@ -38,7 +38,8 @@ fn markdown_chunks(text: &str) -> Vec<Chunk> {
     let mut buffer = String::new();
     let mut byte = 0;
 
-    for (idx, line) in text.lines().enumerate() {
+    for (idx, raw) in text.split_inclusive('\n').enumerate() {
+        let line = raw.trim_end_matches('\n').trim_end_matches('\r');
         if line.starts_with('#') && !buffer.trim().is_empty() {
             chunks.push(make_chunk(
                 "markdown",
@@ -57,7 +58,7 @@ fn markdown_chunks(text: &str) -> Vec<Chunk> {
         }
         buffer.push_str(line);
         buffer.push('\n');
-        byte += line.len() + 1;
+        byte += raw.len();
     }
 
     if !buffer.trim().is_empty() {
@@ -199,16 +200,19 @@ fn line_span(text: &str, start_line: usize, end_line: usize) -> Option<LineSpan>
     let mut byte = 0;
     let mut start_byte = None;
     let mut out = String::new();
-    for (idx, line) in text.lines().enumerate() {
+    for (idx, raw) in text.split_inclusive('\n').enumerate() {
         let line_no = idx + 1;
         if line_no == start_line {
             start_byte = Some(byte);
         }
         if line_no >= start_line && line_no <= end_line {
-            out.push_str(line);
-            out.push('\n');
+            // Keep the raw on-disk bytes (incl. any CRLF) so the returned span's length equals its
+            // real byte length; `split_symbol` re-normalizes each line when it builds chunk text,
+            // and advances its byte cursor over these raw lengths so code-chunk offsets stay
+            // aligned with the tree-sitter symbol offsets `query::graph_meta` joins against.
+            out.push_str(raw);
         }
-        byte += line.len() + 1;
+        byte += raw.len();
         if line_no >= end_line {
             break;
         }
@@ -235,10 +239,11 @@ fn split_text_chunks(path: &Path, kind: &'static str, text: &str, max_lines: usi
     let mut start_byte = 0;
     let mut byte = 0;
     let mut buffer = String::new();
-    for (idx, line) in text.lines().enumerate() {
+    for (idx, raw) in text.split_inclusive('\n').enumerate() {
+        let line = raw.trim_end_matches('\n').trim_end_matches('\r');
         buffer.push_str(line);
         buffer.push('\n');
-        byte += line.len() + 1;
+        byte += raw.len();
         let line_no = idx + 1;
         if line_no - start_line + 1 >= max_lines {
             chunks.push(make_chunk(
@@ -317,10 +322,11 @@ fn split_symbol(
     let mut start_line = base_line;
     let mut byte = base_byte;
     let mut buffer = String::new();
-    for (idx, line) in text.lines().enumerate() {
+    for (idx, raw) in text.split_inclusive('\n').enumerate() {
+        let line = raw.trim_end_matches('\n').trim_end_matches('\r');
         buffer.push_str(line);
         buffer.push('\n');
-        byte += line.len() + 1;
+        byte += raw.len();
         let line_no = base_line + idx;
         if line_no - start_line + 1 >= max_lines {
             parts.push(ChunkPart {

--- a/crates/rag-rat-core/src/index/chunker_tests.rs
+++ b/crates/rag-rat-core/src/index/chunker_tests.rs
@@ -1,0 +1,134 @@
+//! CRLF byte-offset correctness for the chunker (#241).
+//!
+//! `text.lines()` strips `\n` and `\r\n` alike, so the old `byte += line.len() + 1` advance
+//! under-counted CRLF terminators by one byte per line — drifting `start_byte`/`end_byte` behind
+//! the real on-disk positions that `query::graph_meta` joins against tree-sitter symbol offsets
+//! (which count raw bytes, CR included). These tests pin chunk byte ranges to the actual on-disk
+//! bytes across all three chunker entry points (markdown, generated/split-text, and the
+//! tree-sitter code path) and — crucially — exercise the MULTI-chunk tiling path, where the running
+//! byte accumulator (the value the bug corrupted) becomes an intermediate chunk boundary. The
+//! single-chunk cases pin their `end_byte` to `text.len()` regardless, so an in-range assertion
+//! over them would pass even on the buggy code; the intermediate-boundary assertions below would
+//! not.
+
+use std::path::Path;
+
+use crate::index::chunker::{self, Chunk};
+use crate::language::Language;
+
+/// A chunk's `[start_byte, end_byte)` must slice the real on-disk bytes whose CRLF-normalized form
+/// reproduces the chunk's stored (LF-normalized) text. Trailing newlines are compared loosely (a
+/// chunk's final line may gain a synthetic `\n`, or the `whole_file` fallback may keep raw bytes);
+/// the exact-boundary assertions in each test are what discriminate the #241 bug.
+fn assert_chunk_bytes_match_disk(chunks: &[Chunk], text: &str) {
+    assert!(!chunks.is_empty(), "expected at least one chunk");
+    for c in chunks {
+        assert!(c.start_byte <= c.end_byte, "start>end: {c:?}");
+        assert!(c.end_byte <= text.len(), "end {} past EOF {}: {c:?}", c.end_byte, text.len());
+        let disk = text[c.start_byte..c.end_byte].replace("\r\n", "\n");
+        let stored = c.text.replace("\r\n", "\n");
+        assert_eq!(
+            stored.trim_end_matches('\n'),
+            disk.trim_end_matches('\n'),
+            "chunk [{}..{}] stored text != on-disk bytes",
+            c.start_byte,
+            c.end_byte,
+        );
+    }
+}
+
+/// Generated/markdown chunks tile the file contiguously from 0 to EOF with no gap or overlap.
+fn assert_contiguous(chunks: &[Chunk], text: &str) {
+    for pair in chunks.windows(2) {
+        assert_eq!(pair[0].end_byte, pair[1].start_byte, "gap/overlap between chunks");
+    }
+    assert_eq!(chunks.first().unwrap().start_byte, 0, "first chunk must start at 0");
+    assert_eq!(chunks.last().unwrap().end_byte, text.len(), "last chunk must end at EOF");
+}
+
+#[test]
+fn crlf_generated_single_chunk_matches_disk() {
+    let lf = "line one\nline two\nline three\n";
+    let crlf = "line one\r\nline two\r\nline three\r\n";
+    let p = Path::new("x.txt");
+    let lf_chunks = chunker::generated_chunks_for_file(p, lf);
+    let crlf_chunks = chunker::generated_chunks_for_file(p, crlf);
+    assert_chunk_bytes_match_disk(&lf_chunks, lf);
+    assert_chunk_bytes_match_disk(&crlf_chunks, crlf);
+    assert_contiguous(&crlf_chunks, crlf);
+}
+
+#[test]
+fn crlf_generated_multi_chunk_boundaries_are_on_disk_exact() {
+    // split_text_chunks flushes a chunk every 160 lines (generated_chunks_for_file). With >160 CRLF
+    // lines the flushed chunk's end_byte IS the running accumulator — exactly what the
+    // `line.len() + 1` bug corrupted. Uniform 6-byte lines ("xxxx\r\n") make the true boundary
+    // obvious: line k ends at on-disk byte 6*k (the bug would put it at 5*k).
+    let crlf = "xxxx\r\n".repeat(400);
+    let chunks = chunker::generated_chunks_for_file(Path::new("big.txt"), &crlf);
+    assert!(chunks.len() >= 3, "expected multiple chunks, got {}", chunks.len());
+    assert_chunk_bytes_match_disk(&chunks, &crlf);
+    assert_contiguous(&chunks, &crlf);
+    assert_eq!(chunks[0].end_byte, 160 * 6, "first flush must land on the real on-disk byte");
+    assert_eq!(chunks[1].start_byte, 160 * 6, "next chunk must abut the on-disk boundary");
+}
+
+#[test]
+fn crlf_markdown_intermediate_boundary_is_on_disk_exact() {
+    let crlf = "# Title\r\n\r\nbody text\r\n\r\n## Section\r\n\r\nmore body\r\n";
+    let chunks = chunker::chunks_for_file(Path::new("d.md"), Language::Markdown, crlf);
+    assert_chunk_bytes_match_disk(&chunks, crlf);
+    assert_contiguous(&chunks, crlf);
+    // The heading split must land on the real on-disk offset of "## Section", not the
+    // CR-undercounted position the bug produced.
+    let section = crlf.find("## Section").unwrap();
+    assert!(
+        chunks.iter().any(|c| c.start_byte == section),
+        "no chunk starts at the on-disk '## Section' offset {section}: {:?}",
+        chunks.iter().map(|c| (c.start_byte, c.end_byte)).collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn crlf_code_path_chunk_offsets_match_disk() {
+    // The tree-sitter code path (code_chunks_for_symbols -> line_span -> split_symbol) is the path
+    // whose offsets graph_meta joins against tree-sitter symbol byte offsets. line_span returns the
+    // on-disk span so split_symbol's end_byte stays byte-aligned with the raw file on CRLF input
+    // (the pre-#241-completion code computed end_byte in LF-normalized space and drifted short).
+    let crlf = "fn alpha() {\r\n    let x = 1;\r\n    let y = 2;\r\n}\r\n\r\nfn beta() {\r\n    \
+                alpha();\r\n}\r\n";
+    let chunks = chunker::chunks_for_file(Path::new("x.rs"), Language::Rust, crlf);
+    assert_chunk_bytes_match_disk(&chunks, crlf);
+    // alpha's chunk must end at the real on-disk end of its closing brace line (byte after the
+    // first "}\r\n"), not short by the swallowed CR bytes.
+    let alpha_end = crlf.find("}\r\n").unwrap() + "}\r\n".len();
+    let alpha = chunks.iter().find(|c| c.start_byte == 0).expect("a chunk starting at byte 0");
+    assert_eq!(alpha.end_byte, alpha_end, "alpha code-chunk end_byte must be on-disk exact");
+    // beta's chunk must start at beta's real on-disk offset.
+    let beta = crlf.find("fn beta").unwrap();
+    assert!(
+        chunks.iter().any(|c| c.start_byte == beta),
+        "no code chunk starts at the on-disk 'fn beta' offset {beta}: {:?}",
+        chunks
+            .iter()
+            .map(|c| (c.start_byte, c.end_byte, c.symbol_path.clone()))
+            .collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn crlf_no_trailing_newline_has_no_phantom_terminator() {
+    let crlf = "a\r\nb\r\nc";
+    let chunks = chunker::generated_chunks_for_file(Path::new("x.txt"), crlf);
+    assert_chunk_bytes_match_disk(&chunks, crlf);
+    assert_eq!(chunks.last().unwrap().end_byte, crlf.len(), "must end exactly at EOF");
+}
+
+#[test]
+fn lf_offsets_unchanged_regression() {
+    // The common case must stay byte-identical to pre-fix behaviour.
+    let lf = "alpha\nbeta\ngamma\n";
+    let chunks = chunker::generated_chunks_for_file(Path::new("x.txt"), lf);
+    assert_chunk_bytes_match_disk(&chunks, lf);
+    assert_contiguous(&chunks, lf);
+}

--- a/crates/rag-rat-core/src/index/ignore_rules.rs
+++ b/crates/rag-rat-core/src/index/ignore_rules.rs
@@ -154,8 +154,15 @@ impl IgnoreMatcher {
         // The gitignore frame: the worktree root if `root` is inside a Git worktree, else `root`.
         // Only accept it when `root` is actually a descendant (or equal) — a `--show-toplevel`
         // result we can't relate to `root` is unusable as a prefix-stripping base.
+        //
+        // `gix`'s `workdir()` is not canonicalized, so on Windows it can carry a different prefix
+        // representation than `root` (e.g. plain `C:\…` vs a verbatim `\\?\C:\…` from a
+        // canonicalized `config.root`) — a raw `root.starts_with(wt)` then wrongly fails and the
+        // ancestor `.gitignore` chain is dropped. Decide the ancestor relationship on canonicalized
+        // forms, but derive `base` by trimming components off `root` itself so it stays a textual
+        // prefix of `root` (and of every caller path `is_ignored` strips against it).
         let base = git_history::worktree_root(root)
-            .filter(|wt| root.starts_with(wt))
+            .and_then(|wt| base_under_worktree(root, &wt))
             .unwrap_or_else(|| root.to_path_buf());
 
         let mut matcher = Self { root: root.to_path_buf(), base, stack: Vec::new() };
@@ -342,6 +349,24 @@ impl IgnoreMatcher {
 /// Whether any component of the (`config.root`-relative) `rel` path is a floor directory name.
 fn rel_contains_floor_dir(rel: &Path) -> bool {
     rel.components().any(|component| component.as_os_str().to_str().is_some_and(is_floor_dir))
+}
+
+/// The gitignore base for `root` given an enclosing worktree root `wt`, or `None` when `wt` is not
+/// an ancestor of (or equal to) `root`. Returns the matching ancestor in `root`'s OWN
+/// representation so it stays a textual prefix of `root` (which `is_ignored`'s
+/// `strip_prefix(&self.base)` — and watch.rs's strip — require for caller paths).
+///
+/// We walk `root`'s own ancestors and pick the one whose CANONICAL form equals the canonical `wt`.
+/// Comparing canonicalized forms tolerates both a prefix-representation mismatch (Windows verbatim
+/// `\\?\C:\…` vs `gix`'s plain `C:\…` workdir) and a symlinked path segment, while keeping the
+/// returned base in `root`'s representation. (A depth-count derived from the canonical paths would
+/// misindex `root.ancestors()` when a symlink makes `root`'s own component count differ.)
+///
+/// Shared with `watch.rs` (gitignore watch-dir + subdir-prefix derivation hit the same mismatch).
+pub(crate) fn base_under_worktree(root: &Path, wt: &Path) -> Option<PathBuf> {
+    let canon = |p: &Path| p.canonicalize().unwrap_or_else(|_| p.to_path_buf());
+    let canon_wt = canon(wt);
+    root.ancestors().find(|ancestor| canon(ancestor) == canon_wt).map(Path::to_path_buf)
 }
 
 #[cfg(test)]
@@ -589,5 +614,29 @@ mod tests {
         // Canonicalize so the absolute paths we build match what worktree-root resolution returns
         // (macOS /tmp is a symlink to /private/tmp; git reports the canonical form).
         dir.canonicalize().unwrap_or(dir)
+    }
+
+    // base_under_worktree must return the worktree root in `root`'s OWN representation even when a
+    // symlinked segment makes `root`'s component count differ from its canonical form — a depth
+    // count derived from the canonical paths would misindex `root.ancestors()` and return a wrong
+    // base (the parent of the worktree root, here), breaking the strip_prefix contract.
+    #[cfg(unix)]
+    #[test]
+    fn base_under_worktree_handles_symlinked_root_segment() {
+        use std::os::unix::fs::symlink;
+        let wt = tempdir(); // canonical worktree root
+        fs::create_dir_all(wt.join("a/b")).unwrap();
+        // `<wt>/link` (1 component) resolves to `<wt>/a/b` (2 components) — counts differ.
+        let link = wt.join("link");
+        symlink(wt.join("a/b"), &link).unwrap();
+        // `root` (= the symlink) is NOT canonicalized — the case the helper must tolerate; `wt` is
+        // a genuine textual ancestor of it.
+        let base = base_under_worktree(&link, &wt);
+        assert_eq!(base.as_deref(), Some(wt.as_path()), "base must be wt in root's representation");
+        assert!(
+            link.strip_prefix(base.unwrap()).is_ok(),
+            "base must stay a textual prefix of root"
+        );
+        let _ = fs::remove_dir_all(&wt);
     }
 }

--- a/crates/rag-rat-core/src/index/meta.rs
+++ b/crates/rag-rat-core/src/index/meta.rs
@@ -43,9 +43,15 @@ impl IndexDatabase {
     /// digest is scope-invariant, so the freshness check is stable regardless of the active
     /// connection scope.
     pub(super) fn content_revision(&self) -> anyhow::Result<String> {
+        // group_concat over an ORDER BY subquery, not `string_agg(... ORDER BY path)`: string_agg()
+        // and aggregate ORDER BY are SQLite 3.44+, and this portable idiom (works on any SQLite)
+        // avoids tying the query to a SQLite version. The subquery's ORDER BY feeds rows to
+        // group_concat in path order, so the digest input is the same deterministic string. Order
+        // only has to be stable per-machine (this digest is compared against a previously-stored
+        // value on the same DB), which this idiom guarantees.
         let value = self.storage.connection().query_row(
-            "SELECT COALESCE(string_agg(path || ':' || sha256, ',' ORDER BY path), '') FROM \
-             main.files WHERE kind != 'deleted'",
+            "SELECT COALESCE(group_concat(pv, ','), '') FROM (SELECT path || ':' || sha256 AS pv \
+             FROM main.files WHERE kind != 'deleted' ORDER BY path)",
             [],
             |row| row.get::<_, String>(0),
         )?;

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -58,6 +58,8 @@ pub(crate) use util::*;
 #[cfg(test)]
 mod anchor_tests;
 #[cfg(test)]
+mod chunker_tests;
+#[cfg(test)]
 mod parser_tests;
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/crates/rag-rat-core/src/index/oracle/manifest.rs
+++ b/crates/rag-rat-core/src/index/oracle/manifest.rs
@@ -395,9 +395,14 @@ mod tests {
         assert_eq!(manifest.program, "scip-clang");
         let cmd = manifest.scip_command(Path::new("/repo"), Path::new("/tmp/out.scip"));
         let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy().into_owned()).collect();
+        // `--compdb-path` is synthesized via `root.join(..).display()`, so it carries the
+        // platform's path separator (`\` on Windows) — scip-clang runs locally and wants
+        // the native path. Build the expectation the same way rather than hardcoding `/`,
+        // so the assertion holds on Windows.
+        let compdb = Path::new("/repo").join("compile_commands.json");
         assert_eq!(args, vec![
-            "--compdb-path=/repo/compile_commands.json",
-            "--index-output-path=/tmp/out.scip"
+            format!("--compdb-path={}", compdb.display()),
+            "--index-output-path=/tmp/out.scip".to_string()
         ]);
         // No compile_commands.json under a bogus root → prerequisite Blocked (not a run error).
         assert!(

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -96,7 +96,7 @@ fn rebuild_bootstraps_sqlite_schema_for_empty_target_root() {
         schema::LATEST_SCHEMA_VERSION
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -127,7 +127,7 @@ fn symbols_store_true_source_line_spans() {
     assert_eq!(line_span("alpha"), (2, 2));
     assert_eq!(line_span("beta"), (4, 6));
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -150,7 +150,7 @@ fn rebuild_reports_file_preparation_progress() {
         "missing indexing progress event: {events:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -181,7 +181,7 @@ fn open_refuses_a_legacy_schema_without_version_table() {
     let err = IndexDatabase::open(&database).unwrap_err().to_string();
     assert!(err.contains("rebuild"), "{err}");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -221,7 +221,7 @@ fn forward_migration_does_not_rerun_already_applied_migrations() {
         schema::SchemaState::Compatible
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -266,7 +266,7 @@ fn forward_migration_reprovisions_missing_baseline_tables() {
     drop(conn);
     assert_eq!(edge_strings_exists, 1, "baseline did not reprovision name_strings before replay");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -298,7 +298,7 @@ fn open_auto_migrates_a_forward_older_schema_to_latest() {
     assert_eq!(after.state, schema::SchemaState::Compatible);
     assert_eq!(after.current_version, after.latest_version);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -374,7 +374,7 @@ fn migrate_adds_edge_name_columns_before_indexing_them() {
     assert_eq!(table_count(&db, "idx_edges_from_name"), 1);
     assert_eq!(table_count(&db, "idx_edges_to_name"), 1);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -417,7 +417,7 @@ fn migrate_preserves_github_papertrail_cache() {
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].number, 42);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -451,7 +451,7 @@ fn full_rebuild_preserves_github_papertrail_cache() {
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].number, 42);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -471,7 +471,7 @@ fn full_rebuild_preserves_installed_model_manifest() {
     assert!(after.embedding.installed);
     assert_eq!(after.embedding.state, "Ready");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -600,7 +600,7 @@ fn full_rebuild_preserves_other_worktree_contexts() {
         1
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -645,7 +645,7 @@ fn compatible_open_refuses_dirty_and_newer_schema() {
     let err = IndexDatabase::open(&database).unwrap_err().to_string();
     assert!(err.contains("newer rag-rat"), "{err}");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -688,7 +688,7 @@ fn discover_mode_indexes_new_files_and_removes_deleted_files() {
     );
     assert_eq!(db.symbols("new_symbol", Some(Language::Rust), 10).unwrap().len(), 1);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[cfg(unix)]
@@ -705,7 +705,7 @@ fn indexing_skips_symlink_loops() {
 
     assert_eq!(db.symbols("loop_safe_symbol", Some(Language::Rust), 10).unwrap().len(), 1);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -756,7 +756,7 @@ fn dirty_git_files_are_indexed_as_worktree_overlay() {
     assert_eq!(overlay_hits.len(), 1);
     assert!(overlay_hits[0].summary.contains("overlay token"));
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -794,7 +794,7 @@ fn rebuild_populates_revision_metadata_and_fresh_fts_state() {
     assert_eq!(indexed_revision_count(&db), 1);
     assert_eq!(chunk_source_revision_count(&db), 1);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[cfg(not(feature = "fastembed"))]
@@ -812,7 +812,7 @@ fn fastembed_missing_feature_reports_rebuild_command() {
     assert_eq!(status.fastembed.message.as_deref(), Some(ai::FASTEMBED_MISSING_FEATURE_MESSAGE));
     assert_eq!(status.fastembed.next.as_deref(), Some("cargo install rag-rat"));
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -898,7 +898,7 @@ fn reconcile_requires_explicit_model_install_and_ignores_stale_artifacts() {
     let stale_embedding_hits = db.search("alpha", 10, false).unwrap();
     assert_eq!(stale_embedding_hits.len(), 1);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[cfg(feature = "fastembed")]
@@ -923,7 +923,7 @@ fn cached_fastembed_model_recovers_ready_state() {
     assert_eq!(status.fastembed.status, "Ready");
     assert!(status.fastembed.active);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[cfg(feature = "fastembed")]
@@ -954,7 +954,7 @@ fn compatible_migrate_recovers_cached_fastembed_model() {
     assert_eq!(status.fastembed.status, "Ready");
     assert!(status.fastembed.active);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -976,7 +976,7 @@ fn reconcile_without_limit_processes_all_chunks() {
     let second = db.reconcile(None, Some(2)).unwrap();
     assert_eq!(second.processed_chunks, 0);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -999,7 +999,7 @@ fn force_reconcile_processes_each_chunk_once_and_terminates() {
     assert_eq!(report.embeddings_written, 2, "force re-embedded chunks: {report:?}");
     assert_eq!(report.processed_chunks, 2, "force re-processed chunks: {report:?}");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -1046,7 +1046,7 @@ fn force_reconcile_progress_is_honest_and_terminates_without_limit() {
         }
     }
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -1070,7 +1070,7 @@ fn status_counts_only_active_context_chunks() {
     assert_eq!(scoped.total_chunks, 0, "status ignored active context scope");
     assert_eq!(scoped.current, 0);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -1091,7 +1091,7 @@ fn watch_maintenance_pass_indexes_new_files() {
     let hits = db.symbols("newly_added_symbol", Some(Language::Rust), 10).unwrap();
     assert!(!hits.is_empty(), "watcher pass did not index the new file");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -1145,7 +1145,7 @@ fn discover_deletion_is_worktree_scoped() {
     assert_eq!(active("src/a.rs"), 0, "deleted file still active in own worktree");
     assert_eq!(active("src/b.rs"), 1, "live file dropped from own worktree");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -1193,7 +1193,7 @@ fn gc_prunes_dead_context_rows_and_keeps_live_ones() {
         "live chunks were pruned",
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -1209,7 +1209,7 @@ fn gc_refuses_to_prune_with_no_live_context() {
     assert_eq!(report.files_pruned, 0);
     assert_eq!(table_row_count(db.storage.connection(), "files").unwrap(), before);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -1246,7 +1246,7 @@ int main(void)
     let report = db.reconcile(None, Some(8)).unwrap();
     assert!(report.embeddings_written > 0, "report: {report:?}");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -1264,7 +1264,7 @@ fn reconcile_policy_skips_tiny_chunks_before_embedding() {
     assert_eq!(report.skipped_by_policy.get("SkipTooSmall"), Some(&1));
     assert_eq!(db.current_embedding_count(ai::HASH_MODEL_ID).unwrap(), 0);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -1295,7 +1295,7 @@ fn reconcile_plan_reports_policy_skips_for_fastembed_model() {
     assert_eq!(plan.embeddings.missing, 0);
     assert_eq!(plan.embeddings.skipped_by_policy.get("SkipTooSmall"), Some(&1));
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[cfg(not(feature = "fastembed"))]
@@ -1317,7 +1317,7 @@ fn blocked_fastembed_reconcile_still_reports_policy_skips() {
     assert_eq!(report.status, "Blocked");
     assert_eq!(report.skipped_by_policy.get("SkipTooSmall"), Some(&1));
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -1353,7 +1353,7 @@ fn search_explain_reports_weighted_score_components() {
     assert!(components.github <= 0.02);
     assert!(db.search("runtime shutdown", 10, false).unwrap()[0].score_components.is_none());
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -1375,7 +1375,7 @@ fn search_explain_labels_missing_vector_runtime() {
         Some("vector search unavailable: no current embedding model")
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -1472,7 +1472,7 @@ fn git_history_indexes_commits_paths_queries_and_blame() {
     let cached = db.git_blame_chunk(chunk_id).unwrap().unwrap();
     assert_eq!(cached.source_text_hash, blame.source_text_hash);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// A recognizable bogus row that only a git-history *reload* (full table wipe) would remove.
@@ -1573,7 +1573,7 @@ fn git_history_reload_is_skipped_when_head_is_unchanged() {
     // Real history is left intact (the 2 real commits are untouched by the skip).
     assert_eq!(db.status(&config.database).unwrap().git_history.commit_count, 2);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -1595,7 +1595,7 @@ fn git_history_reloads_after_a_new_commit() {
     assert_eq!(sentinel_commit_count(&db), 0, "a new commit must force a reload");
     assert_eq!(db.commit_search("gamma", 10).unwrap().len(), 1, "new commit is indexed");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -1620,7 +1620,7 @@ fn git_history_reloads_after_a_history_rewrite() {
     assert_eq!(db.commit_search("delta", 10).unwrap().len(), 1, "rewritten subject is indexed");
     assert_eq!(db.commit_search("beta", 10).unwrap().len(), 0, "old subject is gone after rewrite");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -1651,8 +1651,8 @@ fn git_history_reload_is_not_skipped_on_a_shallow_clone() {
     let db = IndexDatabase::index_changed(&config).unwrap();
     assert_eq!(sentinel_commit_count(&db), 0, "a shallow clone must never skip the reload");
 
-    fs::remove_dir_all(origin).unwrap();
-    fs::remove_dir_all(shallow).unwrap();
+    let _ = fs::remove_dir_all(origin);
+    let _ = fs::remove_dir_all(shallow);
 }
 
 fn read_meta(db: &IndexDatabase, key: &str) -> Option<String> {
@@ -1702,7 +1702,7 @@ fn idle_discover_sweep_does_not_rewrite_indexed_at_ms() {
         "a sweep that indexes a new file must update indexed_at_ms"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -1721,7 +1721,7 @@ fn index_discover_reporting_flags_content_changes() {
     let (_db, changed) = IndexDatabase::index_discover_reporting(&config).unwrap();
     assert!(changed, "a discover sweep that indexes a new file must report a content change");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -1755,7 +1755,7 @@ fn discover_relanguages_h_when_binding_changes_c_to_cpp() {
         .unwrap();
     assert_eq!(lang, "cpp", "the .h must be reindexed as C++ after the binding change");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -1805,7 +1805,7 @@ fn caller() {
         "helper callers: {callers:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// The callee identifier byte range (#67) stored on the single edge matching
@@ -1902,7 +1902,7 @@ fn driver() {
     let contains = callee_byte_range(&db, "Obj", "method", "contains");
     assert_eq!(contains, None, "contains edges must have a NULL callee range");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -1920,7 +1920,7 @@ fn imports_edge_has_null_callee_byte_range() {
     let import = callee_byte_range(&db, "src/lib.rs", "worker", "imports");
     assert_eq!(import, None, "imports edges must have a NULL callee range");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -1954,7 +1954,7 @@ int runtime_open(Runtime *runtime) {
     let (start, end) = (start as usize, end as usize);
     assert_eq!(&source[start..end], "helper", "C callee range must span exactly `helper`");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -2036,7 +2036,7 @@ pub fn exported_fn() {}
         "comment-only UniFFI mentions must not create FFI surface rows: {surface:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -2064,7 +2064,7 @@ fn find_callers_sees_calls_in_let_bindings() {
     assert!(has("via_let"), "missing `let x = target()` caller; got {names:?}");
     assert!(has("via_let_else"), "missing `let-else` caller; got {names:?}");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -2148,7 +2148,7 @@ pub fn upsert_journal_embedding(_id: i64) {}
         "an arm side-effect call must not become a dispatch target: {log_callers:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -2202,7 +2202,7 @@ pub fn upsert(_id: i64) {}
     // The synthesized real edge is visible through the view.
     assert!(view_count("dispatches") > 0, "the synthesized dispatches edge must stay visible");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -2269,7 +2269,7 @@ pub fn run_stop() {}
         "a guard/predicate call must not become a dispatch handler"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -2334,7 +2334,7 @@ pub fn banana_handler() {}
         "Self::Variant must not cross-link distinct enums: apple={apple:?} banana={banana:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -2385,7 +2385,7 @@ pub fn deliver() {}
     // External/aliased head (`Status` has no local enum definition) is admitted.
     assert!(dispatch_from("deliver", "emit"), "external enum-head dispatch missing");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -2445,7 +2445,7 @@ fn embed_text(_text: String) -> Result<i32, ()> { Ok(0) }
         "a wrapper constructor must not be a dispatch handler"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -2523,7 +2523,7 @@ fn run_setup() -> Result<Resp, ()> { Ok(Resp::Blank) }
         );
     }
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -2600,7 +2600,7 @@ fn start_span() {}
         );
     }
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -2702,7 +2702,7 @@ fn finish_response() -> Result<u8, ()> { Ok(0) }
         );
     }
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -2787,7 +2787,7 @@ fn finish_b() -> Result<u8, ()> { Ok(0) }
         );
     }
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -2901,7 +2901,7 @@ fn start_span() -> u8 { 0 }
         "const-generic call must resolve to the callee name"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -2984,7 +2984,7 @@ fn e() -> E { E::Ready(0) }
         );
     }
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -3071,7 +3071,7 @@ fn finish_c() -> Result<u8, ()> { Ok(0) }
         );
     }
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -3186,7 +3186,7 @@ fn build_deref() -> Result<u8, ()> { Ok(0) }
         );
     }
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -3258,7 +3258,7 @@ fn handler_c() -> Result<u8, ()> { Ok(0) }
         );
     }
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -3351,7 +3351,7 @@ fn finish_fp() -> Result<u8, ()> { Ok(0) }
         );
     }
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -3415,7 +3415,7 @@ fn make_worker() -> W { W }
         );
     }
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -3465,7 +3465,7 @@ pub fn run() {}
         "a nested-payload variant must not be treated as the handled variant: {senders:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -3519,7 +3519,7 @@ pub mod b {
         );
     }
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -3582,7 +3582,7 @@ fn symbol_search_excludes_generated_bindings_unless_opted_in() {
     assert_eq!(id_hits.candidates.len(), 1, "explicit id must resolve the generated symbol");
     assert!(id_hits.candidates[0].path.contains("/generated/"));
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -3635,7 +3635,7 @@ fn stale_generated_flags_are_rederived_on_open() {
         after.candidates.iter().map(|c| &c.path).collect::<Vec<_>>()
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -3689,7 +3689,7 @@ fn search_and_read_chunk_attach_bounded_graph_evidence() {
     );
     assert!(full_graph.notes.iter().any(|note| note.contains("tree-sitter/syntactic")));
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -3746,7 +3746,7 @@ fn graph_exact_mode_requires_verified_symbol_identity() {
     );
     assert!(exact_callees.iter().all(|edge| edge.verified_target_symbol));
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -3777,7 +3777,7 @@ pub struct Database;
         "impl Database should still be available after the struct: {hits:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -3842,7 +3842,7 @@ impl B {
         .collect();
     assert_eq!(reindexed_ids, logical_ids, "logical ids must be stable across reindex");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -3961,7 +3961,7 @@ pub fn caller() {
         "a handle in the ref slot is not ambiguous: {by_ref_handle:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -4002,7 +4002,7 @@ fn indexes_real_world_rust_graph_patterns() {
         "serve callers: {callers:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -4045,7 +4045,7 @@ export const callRun = () => run();
         "callRun callees: {callees:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -4077,7 +4077,7 @@ int runtime_open(Runtime *runtime) {
 
     assert_edge(&db, "runtime_open", "helper", "calls_name", "Syntactic");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -4131,7 +4131,7 @@ DEVICE_DT_INST_DEFINE(0, entropy_init, NULL, NULL, NULL,
         "DEVICE_API hits: {hits:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -4162,7 +4162,7 @@ void Runtime::open() {
 
     assert_edge(&db, "open", "helper", "calls_name", "Syntactic");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -4197,7 +4197,7 @@ fn indexes_real_world_typescript_graph_patterns() {
         "Shell callees: {callees:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -4250,7 +4250,7 @@ fn execute_one() {
     assert_eq!(edge.4, "unresolved");
     assert!(edge.5.as_deref().is_some_and(|value| value.contains("format!")));
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -4322,7 +4322,7 @@ fn execute_one() {
     assert_eq!(edge.3, "unresolved");
     assert!(edge.4.as_deref().is_some_and(|value| value.contains("format!")));
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -4379,7 +4379,7 @@ pub fn caller() {
     assert_eq!(edge.3, "NameOnly");
     assert_eq!(edge.4, "unresolved");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -4438,7 +4438,7 @@ fn rust_entry() {
     assert_eq!(edge.4, "unresolved");
     assert!(edge.5.as_deref().is_some_and(|value| value.contains("json!")));
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -4483,7 +4483,7 @@ pub fn second() {
         "spawn_blocking callers: {callers:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -4580,7 +4580,7 @@ pub fn related_spawn_with_text() {
         "qualified caller lookup leaked related names or chain evidence: {qualified_callers:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -4630,7 +4630,7 @@ pub fn caller() {{
         "impact: {impact:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -4692,7 +4692,7 @@ pub fn caller() {
         "type references should not appear as direct impact: {impact:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -4746,7 +4746,7 @@ pub fn hub() {
         "an uncapped result must NOT carry a sentinel: {full:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -4779,7 +4779,7 @@ fn impact_surface_flat_signals_truncation_from_a_capped_textual_fallback() {
     let real_items = impact.iter().filter(|item| item.category != "completeness").count();
     assert_eq!(real_items, limit as usize, "exactly `limit` real items, plus the sentinel");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -4843,7 +4843,7 @@ fn impact_surface_collapses_file_matches_to_one_row_per_file() {
         .count();
     assert_eq!(store_rows, 1, "a file with four symbols collapses to one fallback row");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -4912,7 +4912,7 @@ where
         "path-local task_spawn docs should outrank unrelated phrase docs: {hits:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -4940,7 +4940,7 @@ fn broken( {
     assert!(symbols.iter().any(|symbol| symbol.name == "caller"), "caller symbols: {symbols:?}");
     assert_edge(&db, "caller", "helper", "calls_name", "Syntactic");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -4996,7 +4996,7 @@ pub struct JoinSet;
     assert_eq!(edge.4, "unresolved");
     assert_eq!(edge.5.as_deref(), Some("joinset"));
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5085,7 +5085,7 @@ where
         "unresolved-enabled callees: {with_unresolved:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5145,7 +5145,7 @@ pub fn caller(input: Result<String, String>) -> String {
         "common-method-enabled callees: {expanded:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5187,7 +5187,7 @@ fun helper() {}
         "impact: {impact:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5219,7 +5219,7 @@ fn indexes_real_world_kotlin_graph_patterns() {
         "cleaned callers: {callers:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5285,7 +5285,7 @@ fun unrelatedBuilderCalls(dialog: AndroidDialogBuilder) {
         "unrelated builder calls should not resolve to WatchProposalBuilder.build: {callers:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5355,7 +5355,7 @@ fn github_sync_caches_papertrail_and_rationale_without_query_time_crawling() {
         })
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5392,7 +5392,7 @@ fn papertrail_for_commit_prefers_commit_sourced_github_refs() {
         "structured commit refs should suppress noisy fallback evidence: {papertrail:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5425,7 +5425,7 @@ fn papertrail_for_symbol_dedupes_duplicate_file_refs() {
         "duplicate #42 refs in one file should collapse to one issue evidence row: {papertrail:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5457,7 +5457,7 @@ fn github_sync_keeps_partial_cache_and_skips_synced_refs_after_404() {
     assert_eq!(second.skipped_refs, 2);
     assert_eq!(second.failed_refs, 0);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5477,7 +5477,7 @@ fn search_recovers_when_fts_is_marked_dirty() {
     assert!(!fresh.fts_dirty);
     assert!(fresh.fts_fresh);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5492,7 +5492,7 @@ fn read_chunk_relocates_small_line_drift_to_current_text() {
     assert_eq!(chunk.end_line, 3);
     assert_eq!(chunk.text, "# Title\nalpha token\n");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5508,7 +5508,7 @@ fn read_chunk_large_drift_reindexes_and_reports_stale_chunk() {
     assert_eq!(hits.len(), 1);
     assert!(db.search("alpha", 10, false).unwrap().is_empty());
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5523,7 +5523,7 @@ fn search_retries_after_healing_stale_hit() {
     assert_eq!(beta_hits.len(), 1);
     assert!(beta_hits[0].summary.contains("beta"));
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5538,7 +5538,7 @@ fn search_heals_relocated_hits_before_returning_line_spans() {
     assert_eq!(hits[0].end_line, 3);
     assert!(hits[0].summary.contains("alpha"));
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5552,7 +5552,7 @@ fn read_chunk_deleted_source_reports_gone() {
     assert!(err.contains("Gone"), "{err}");
     assert!(db.search("alpha", 10, false).unwrap().is_empty());
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5573,7 +5573,7 @@ fn search_returns_needs_reindex_when_heal_cap_is_exceeded() {
     let err = db.search("common", 20, false).unwrap_err().to_string();
     assert!(err.contains("needs_reindex"), "{err}");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5600,7 +5600,7 @@ fn search_drops_deleted_file_instead_of_erroring() {
     assert!(hits.iter().all(|hit| !hit.path.ends_with("drop.md")), "{hits:?}");
     assert!(hits.iter().any(|hit| hit.path.ends_with("keep.md")), "{hits:?}");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5621,7 +5621,7 @@ fn heal_index_limit_does_not_warn_when_only_fresh_files_are_skipped() {
     assert_eq!(report.skipped_files, 2);
     assert_eq!(report.message, None);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5640,7 +5640,7 @@ fn search_recovers_when_fts_revision_is_stale() {
     assert_eq!(fresh.fts_source_revision.as_deref(), Some(fresh.content_revision.as_str()));
     assert!(fresh.fts_fresh);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5672,7 +5672,7 @@ fn parser_failures_report_paths() {
     assert_eq!(status.parser_failures, 1);
     assert_eq!(status.parser_failure_paths[0].path, "src/broken.rs");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5756,7 +5756,7 @@ fn repo_memory_bound_to_logical_symbol_surfaces_in_symbol_chunk_and_impact() {
     assert_eq!(impact.completeness_and_caveats.memory_status.active, 1);
     assert_eq!(impact.completeness_and_caveats.memory_status.stale, 0);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5841,7 +5841,7 @@ fn compact_repo_memory_view_projects_primary_binding_then_full_mode_round_trips(
     assert_eq!(full.direct[0].body, full_body);
     assert_eq!(full.direct[0].bindings[0].binding_kind, "logical_symbol");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -5930,7 +5930,7 @@ fn compact_repo_memory_view_separates_the_stale_lane() {
     assert_eq!(after.stale[0].memory_id, created.memory.memory_id);
     assert_eq!(after.stale[0].anchor_status.as_deref(), Some("stale"));
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -6007,7 +6007,7 @@ fn repo_memory_survives_reindex_and_relocates_when_symbol_moves() {
     assert_eq!(anchored.len(), 1, "memory did not re-anchor to moved symbol");
     assert_ne!(anchored[0].bindings[0].anchor_status, "gone");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -6094,7 +6094,7 @@ fn repo_memory_validate_marks_changed_or_missing_anchors_non_current() {
     let gone = db.memory_for_symbol(&symbol, 10).unwrap();
     assert_eq!(gone[0].bindings[0].anchor_status, "gone");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -6219,7 +6219,7 @@ fn repo_memory_bound_to_edge_surfaces_when_impact_crosses_call_path() {
     assert_eq!(call_path[0].memory_id, call_path_memory.memory.memory_id);
     assert_eq!(call_path[0].call_paths[0].path_summary, "caller_edge -> target_edge");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -6334,7 +6334,7 @@ fn server_derived_call_path_hash_is_stable_and_validates_through_edge_churn() {
     db.memory_validate().unwrap();
     assert_eq!(call_path_status(&db), "gone", "deleting the call site makes the path gone");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -6429,7 +6429,7 @@ fn impact_surface_surfaces_call_path_memory_when_path_crossed() {
         compact.call_path_crossed.iter().map(|m| &m.title).collect::<Vec<_>>()
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -6526,7 +6526,7 @@ fn memory_relocates_when_symbol_moves_to_another_file() {
     assert!(path.contains("b.rs"), "binding path should be b.rs after relocation: {path}");
     assert_ne!(binding.anchor_status, "gone");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -6620,7 +6620,7 @@ fn memory_relocation_is_durable_across_a_second_reindex() {
     );
     assert!(!binding.contains("a.rs"), "binding_id must not still reference a.rs: {binding}");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -6726,7 +6726,7 @@ fn relocation_persists_refreshed_symbol_and_logical_ids() {
         "persisted symbol_id must resolve to a live symbol row"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -6760,7 +6760,7 @@ fn full_rebuild_leaves_no_orphan_symbol_rows_for_a_path() {
         "repeated full rebuilds must not accumulate orphan symbol rows for the same path"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -6828,7 +6828,7 @@ fn memory_stays_gone_when_moved_symbol_body_changed() {
     assert_eq!(report.gone, 1, "changed body must not trigger relocate, expected gone: {report:?}");
     assert_eq!(report.relocated, 0, "must not relocate when body changed: {report:?}");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -6939,7 +6939,7 @@ fn memory_stays_gone_when_two_files_define_the_same_name() {
         "must not relocate when two identical bodies exist: {report:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -7061,7 +7061,7 @@ fn memory_logical_binding_relocates_across_files() {
         "logical binding path should be b.rs after relocation, got: {path}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -7186,7 +7186,7 @@ fn memory_chunk_binding_relocates_by_hash() {
         "binding path must reference target.rs: {binding_path:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -7343,7 +7343,7 @@ fn memory_rebind_reanchors_and_refreshes_hash() {
         "binding must be current or relocated after validate: {post_rebind_report:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -7428,7 +7428,7 @@ fn anchor_health_counts_tallies_persisted_statuses() {
     assert_eq!(health.gone, 0, "expected no gone bindings, got {health:?}");
     assert_eq!(health.stale, 0, "expected no stale bindings, got {health:?}");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -7520,7 +7520,7 @@ fn memory_doctor_lists_gone_and_suggests_candidates() {
         entry.candidates
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -7586,7 +7586,7 @@ fn memory_doctor_dedupes_cfg_split_candidates() {
         entry.candidates.iter().filter(|c| c.ends_with("cfg_helper")).collect();
     assert_eq!(cfg_candidates.len(), 1, "cfg twins collapse to one suggestion: {cfg_candidates:?}");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -7621,7 +7621,7 @@ fn symbol_path_selector_is_exact_not_substring() {
         .expect("one hit");
     assert_eq!(hit.name, "spawn_blocking");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -7699,7 +7699,7 @@ fn select_symbol_for_bind_collapses_cfg_split_group() {
         .expect("one member returned");
     assert_eq!(hit.logical_symbol_id, Some(logical_id));
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -7768,7 +7768,7 @@ fn repo_brief_ranks_churn_and_god_module_candidates() {
     assert!(!god_modules.candidates[0].split_hints.is_empty());
     assert!(god_modules.candidates[0].next_tools.iter().any(|tool| tool.tool == "impact_surface"));
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -7835,7 +7835,7 @@ fn repo_clusters_groups_cotouched_files() {
     assert!(sync_cluster.representative_paths.contains(&"src/sync/msg.rs".to_string()));
     assert!(sync_cluster.metrics.co_touch_edges >= 2);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 fn hot_module_text(revision: usize) -> String {
@@ -9221,6 +9221,12 @@ fn worktree_overlay_serves_a_subdir_rooted_config() {
     let main = unique_temp_root();
     let _ = fs::remove_dir_all(&main);
     fs::create_dir_all(main.join("crate/src")).unwrap();
+    // Canonicalize the root, mirroring `Config::load`'s `normalize_existing_dir`: production
+    // `config.root` is always canonical, and `linked_config_subdir_and_root` strips it against the
+    // canonicalized base workdir. On macOS `std::env::temp_dir()` is `/var/folders/...` (a symlink
+    // to `/private/var/folders/...`), so an un-canonicalized root fails the `strip_prefix` and the
+    // subdir derivation collapses → zero overlay rows.
+    let main = main.canonicalize().unwrap();
     fs::write(main.join("crate/src/lib.rs"), "pub fn base_fn() {}\n").unwrap();
     init_git_repo(&main);
     run_git(&main, &["add", "."]);
@@ -9347,7 +9353,7 @@ fn rebuild_restores_durable_wal_after_bulk_build() {
     // The index is intact and queryable after the bulk build.
     assert!(!db.symbols("alpha", Some(Language::Rust), 10).unwrap().is_empty());
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -9397,7 +9403,7 @@ fn dir_memory_binds_to_a_directory() {
     assert_eq!(binding.binding_id, "src");
     assert_eq!(binding.anchor_status, "current");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -9475,7 +9481,7 @@ fn dir_memory_validation_current_and_gone() {
     assert_eq!(report.current, 2, "expected 2 current dir bindings");
     assert_eq!(report.gone, 1, "expected 1 gone dir binding");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -9585,7 +9591,7 @@ fn list_memories_returns_summaries_and_filters_by_binding_kind() {
     assert_eq!(path_only.len(), 1, "expected 1 path-kind summary, got: {path_only:?}");
     assert_eq!(path_only[0].binding_kind, "path");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 // ─── dir_tree tests ──────────────────────────────────────────────────────────
@@ -9681,7 +9687,7 @@ fn dir_tree_label_depth_flat_siblings() {
     assert_eq!(b.label, "b", "src/b label");
 
     assert_eq!(tree.truncated, 0);
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -9748,7 +9754,7 @@ fn dir_tree_label_depth_collapse_single_child_chain() {
         tree.nodes.iter().map(|n| &n.path).collect::<Vec<_>>()
     );
     assert_eq!(tree.truncated, 0);
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 // ─── Fix 1 + memory-only inclusion ───────────────────────────────────────────
@@ -9789,7 +9795,7 @@ fn dir_tree_memory_only_dir_appears_without_min_files() {
     assert_eq!(node_a.depth, 1, "src/a depth");
     assert_eq!(node_a.label, "a", "src/a label");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 // ─── Fix 2: generated exclusion ──────────────────────────────────────────────
@@ -9850,7 +9856,7 @@ fn dir_tree_excludes_generated_files_from_count() {
     });
     assert_eq!(real_node.file_count, 3, "src/real file_count must be 3 (non-generated only)");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 // ─── Fix 3: real multi-context scoping ───────────────────────────────────────
@@ -9905,7 +9911,7 @@ fn dir_tree_scope_excludes_other_worktree_files() {
         node_a.file_count
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 // ─── Fix 3: max_nodes cap ────────────────────────────────────────────────────
@@ -9947,7 +9953,7 @@ fn dir_tree_truncates_at_max_nodes() {
     assert!(tree.nodes.len() <= 3, "nodes.len()={} must be <= max_nodes=3", tree.nodes.len());
     assert!(tree.truncated > 0, "truncated must be >0 when nodes were dropped");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 // ─── original integration test (extended) ────────────────────────────────────
@@ -10038,7 +10044,7 @@ fn dir_tree_builds_annotated_layout() {
     let node_a2 = tree2.nodes.iter().find(|n| n.path == "src/a").unwrap();
     assert_eq!(node_a2.file_count, 3, "file_count changed after scope reinstall");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 // ─── Bug fix: children of collapsed node must use leaf labels ─────────────────
@@ -10124,7 +10130,7 @@ fn dir_tree_children_of_collapsed_node_use_leaf_labels() {
     );
 
     assert_eq!(tree.truncated, 0);
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 fn table_count(db: &IndexDatabase, table: &str) -> i64 {
@@ -10330,7 +10336,7 @@ fn rebuild_fts_repopulates_contentless_chunk_fts_from_the_store() {
         "rebuild_fts repopulates contentless chunk_fts from chunk_text"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -11062,7 +11068,7 @@ fn full_rebuild_applies_per_package_import_scope() {
         "a `Display` use'd from external std must not bind to the local `Display` struct"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 fn indexed_revision_count(db: &IndexDatabase) -> i64 {
@@ -11361,7 +11367,7 @@ fn orientation_composes_read_only() {
     );
     assert_eq!(o2.total_files, o1.total_files, "second call: total_files changed");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -11395,7 +11401,7 @@ fn orientation_composes_through_read_only_connection() {
     assert!(!o.tree.nodes.is_empty(), "tree.nodes empty through read-only conn");
     assert_eq!(o.total_files, 6, "total_files mismatch through read-only conn");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// A git fixture with one committed source file, configured like production (absolute DB path).
@@ -11484,7 +11490,7 @@ fn full_rebuild_survives_stale_overlay_rows() {
     assert_eq!(rows.len(), 1, "exactly one row per path after an authoritative rebuild: {rows:?}");
     assert_eq!(rows[0], (commit, String::new()), "the clean tree indexes at the commit scope");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// #59: a FOREIGN file row — a path the real tree never produces — leaked into the index at the
@@ -11525,7 +11531,7 @@ fn full_rebuild_clears_foreign_leaked_rows_at_the_active_scope() {
         .unwrap();
     assert_eq!(leaked, 0, "the authoritative full rebuild clears foreign rows at the active scope");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// #1 / #106: in a REAL git checkout the active context is `(commit_sha=HEAD, worktree_id=<root
@@ -11626,7 +11632,7 @@ fn clean_checkout_file_resolves_against_its_own_package_roots() {
          symbol"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// #87 (self-heal half): an incremental pass drops a stale overlay row whose path is clean.
@@ -11691,7 +11697,7 @@ fn incremental_pass_heals_stale_overlay_rows() {
         "re-stamp is in place — the row id (and ids hanging off it) survive"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Phase 3: the LOCAL structural-load enrichment (`scoped weighted fan-in`) rides along on BOTH the
@@ -11781,7 +11787,7 @@ pub fn caller_three() -> i32 { load_bearing_hub() }
         assert_eq!(importance.label, "local structural load", "search hit labeled correctly");
     }
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Phase 3 regression: a CALLEE neighbor whose call was written with a `::` path carries a
@@ -11861,7 +11867,7 @@ pub fn qualified_caller_two() -> i32 { crate::helper::deep_helper() }
     assert_eq!(importance.signal, "scoped weighted fan-in");
     assert!(importance.score > 0.0, "two callers give the callee positive fan-in");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -11904,7 +11910,7 @@ fn read_only_open_serves_current_index_and_declines_when_heal_is_owed() {
         "a stale graph index owes a heal write → the read-only path must decline"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -11977,7 +11983,7 @@ fn impact_report_flags_a_section_truncated_at_limit() {
         full.completeness_and_caveats.truncated_sections
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -12016,7 +12022,7 @@ fn symbol_lookup_heals_stale_line_numbers_after_an_edit() {
         after.candidates[0].start_byte
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -12066,7 +12072,7 @@ fn symbol_lookup_heals_a_just_added_symbol_without_waiting_for_the_watcher() {
         "a genuine miss must stay empty"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -12096,7 +12102,7 @@ fn impact_completeness_flags_dirty_result_files() {
         dirty.completeness_and_caveats
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -12135,7 +12141,7 @@ fn symbol_lookup_does_not_resurrect_a_deleted_symbol_after_heal() {
         after.candidates
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -12166,7 +12172,7 @@ fn symbol_lookup_by_id_keeps_pre_heal_candidate_flagged_stale() {
     assert!(!res.candidates.is_empty(), "symbol_id selector keeps the pre-heal candidate");
     assert!(!res.stale_files.is_empty(), "and flags the file stale: {:?}", res.stale_files);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -12206,7 +12212,7 @@ fn impact_completeness_flags_a_dirty_callee_definition_file() {
         dirty.completeness_and_caveats
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -12436,7 +12442,7 @@ fn candidate_components_group_renamed_clones_and_exclude_unrelated() {
     assert_eq!(components.len(), 1, "exactly one clone component: {components:?}");
     assert_eq!(components[0].len(), 2, "the component is the two renamed clones: {components:?}");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Adversarial containment (design rev-4 §8): a small function A whose entire token bag is
@@ -12500,7 +12506,7 @@ fn candidate_components_reject_small_function_contained_in_large_one() {
         "a small function contained in a large one is NOT a whole-symbol clone: {components:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// df is a selectivity hint only (design rev-4 §2, §8): emptying `clone_token_df` must NOT change
@@ -12535,7 +12541,7 @@ fn candidate_components_unchanged_when_clone_token_df_is_empty() {
         "df is selectivity-only: emptying clone_token_df must not change components"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// The `files.generated = 0` predicate is a READ-SIDE filter: generated files are still
@@ -12599,7 +12605,7 @@ fn candidate_components_exclude_generated_files_via_read_filter() {
         "generated b.rs must be excluded from clone components by the read filter: {after:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Max-denominator overlap gate regression: two structurally different functions whose
@@ -12665,7 +12671,7 @@ fn candidate_components_reject_partial_overlap_below_max_denominator_theta() {
          containment): min_len={min_len} max_len={max_len} threshold={threshold} {comps:?}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// normalizer_version filter: after a NORM_VERSION bump the old rows are stale and the read
@@ -12700,7 +12706,7 @@ fn candidate_read_ignores_stale_normalizer_version_rows() {
         "stale-version fingerprints must be ignored by the read"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// `find_clones` integration test: four near-identical rename-clone functions across two
@@ -12781,7 +12787,7 @@ fn find_clones_ranks_a_clean_clone_class_with_metrics() {
     assert_eq!(res.completeness.normalizer_version, NORM_VERSION);
     assert!(!res.completeness.truncated);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// `clones_for_symbol` integration test: two rename-clone functions (a.rs / b.rs) form one
@@ -12843,7 +12849,7 @@ fn clones_for_symbol_returns_the_class_by_ref_and_by_path_line() {
     assert!(solo_res.symbol_resolved, "the solo symbol still resolves");
     assert!(solo_res.symbol_fingerprinted, "the solo function is eligible (fingerprinted)");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Fix 1 (#215): `min_similarity` is honored ALL the way through candidate generation, not merely
@@ -12905,7 +12911,7 @@ fn find_clones_min_similarity_below_theta_widens_and_is_reported() {
     );
     assert_eq!(default.completeness.min_similarity, 0.7, "default completeness θ is 0.7");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// `min_similarity` is a similarity ratio θ = overlap/max_len and must lie in [0.5, 1.0]. Values
@@ -12967,7 +12973,7 @@ fn find_clones_rejects_out_of_range_min_similarity() {
     db.find_clones(FindClonesOptions { min_similarity: Some(0.5), min_copies: None, limit: None })
         .expect("min_similarity = 0.5 is the inclusive lower bound and must be accepted");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Fix 2 (#215): `completeness.truncated` reflects whole CLASSES dropped by `limit`, not only
@@ -13021,7 +13027,7 @@ fn find_clones_truncated_reflects_class_limit() {
         "dropping a whole class via the limit must set completeness.truncated"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Plan 4 coherence-splits over-merged components; the A~B~C chain becomes coherent sub-classes.
@@ -13089,7 +13095,7 @@ fn coherence_split_applied_in_find_clones() {
             })
             .unwrap();
         let sim = res.classes.first().map(|c| c.similarity_min).unwrap_or(0.0);
-        fs::remove_dir_all(r).unwrap();
+        let _ = fs::remove_dir_all(r);
         sim
     };
     let ab = edge_sim(("a", a), ("b", b));
@@ -13162,7 +13168,7 @@ fn coherence_split_applied_in_find_clones() {
     );
     assert!(c_class.refined, "the {{B,C}} sub-class is refined");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Helper: write four renamed clones (identical structure, different identifiers) across two
@@ -13241,7 +13247,7 @@ fn find_clones_refines_a_clean_class() {
         c.roi
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Plan 4a: `clones_for_symbol` always refines the subject's class (when refine inputs are
@@ -13265,7 +13271,7 @@ fn clones_for_symbol_returns_refined_class() {
         class.members.iter().map(|m| &m.r#ref).collect::<Vec<_>>()
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Plan 4a: the content-addressed `refinement_key` is over the struct_hash MULTISET (order-
@@ -13304,7 +13310,7 @@ fn refinement_key_is_content_addressed_and_distinct_from_read_key() {
         "the content-addressed refinement key must differ from the location-derived read key"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Plan 4a: the refinement cache is read-through — the first `find_clones` populates a
@@ -13340,7 +13346,7 @@ fn refine_cache_is_read_through() {
     assert!(r2.classes[0].refined, "run 2 still refined (served from cache)");
     assert_eq!(count_rows(&db), after_run1, "run 2 is a cache hit — the row count must not grow");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Fix A (#215 Plan 4a codex2): the warm path (cache hit) must NOT re-parse any source file.
@@ -13417,7 +13423,7 @@ fn find_clones_warm_cache_metrics_sampled_consistent() {
          ({sampled_warm}) paths"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Plan 4a: only the top-N (by provisional ROI) classes are refined, where N == the caller's limit.
@@ -13494,8 +13500,8 @@ fn unrefined_class_outside_top_n_keeps_plan2_shape() {
         "limit=1 refines only the top-1 class — the out-of-budget class is never refined"
     );
 
-    fs::remove_dir_all(root).unwrap();
-    fs::remove_dir_all(root2).unwrap();
+    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(root2);
 }
 
 /// Fix 2 (Codex P2 #215 Plan 4a): find_clones with limit=Some(N) must never return an unrefined
@@ -13673,7 +13679,7 @@ fn find_clones_huge_limit_clamps_to_refine_budget() {
         "a limit above the budget that drops classes must set refine_budget_clamped"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// I3 (#215 Plan 4a adversary): `load_refine_members` caps the re-parse to LCS_MEMBER_SAMPLE (64)
@@ -13733,7 +13739,7 @@ fn load_refine_members_caps_to_lcs_sample_at_runtime() {
         "capped members must be the first LCS_MEMBER_SAMPLE in canonical (struct_hash, id) order"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Fix 3 (#215): `clones_for_symbol` carries eligibility flags. A below-`MIN_TOKENS` function
@@ -13786,7 +13792,7 @@ fn clones_for_symbol_reports_eligibility() {
     let class = clone.class.expect("load_user is in a clone class");
     assert_eq!(class.member_count, 2, "the clone class has both rename-clones");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Worktree-overlay scope: `find_clones` returns the BRANCH-ONLY clone class under the overlay
@@ -13890,8 +13896,8 @@ fn find_clones_falls_back_to_unrefined_when_source_unavailable() {
 
     // Delete the source trees (a/ and b/) but keep `.rag-rat/` (the SQLite DB). Each member's path
     // now fails `read_to_string`, so `load_refine_members` returns `None` → un-refinable fallback.
-    fs::remove_dir_all(root.join("a")).unwrap();
-    fs::remove_dir_all(root.join("b")).unwrap();
+    let _ = fs::remove_dir_all(root.join("a"));
+    let _ = fs::remove_dir_all(root.join("b"));
 
     let res = db
         .find_clones(FindClonesOptions { min_similarity: None, min_copies: None, limit: None })
@@ -14002,7 +14008,7 @@ fn find_clones_caps_large_class_and_pins_late_subject() {
         pinned.members.iter().map(|m| &m.r#ref).collect::<Vec<_>>()
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Fix 5 (#215): the clone surface stays empty (and errors NOT) when no fingerprint rows survive —
@@ -14041,7 +14047,7 @@ fn find_clones_returns_no_class_when_fingerprints_vanish() {
         .unwrap();
     assert!(after.classes.is_empty(), "no fingerprints ⇒ no clone classes (no error): {after:?}");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Fix 4 (#215): the `Ref` and `PathLine` resolution arms now LEFT JOIN symbol_fingerprints and
@@ -14082,7 +14088,7 @@ fn clones_for_symbol_prefers_fingerprinted_row_on_resolution() {
         "Ref and PathLine must resolve to the same fingerprinted class"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 // ── Fix 1 regression guard (PathLine tightest-span PRIMARY) ──────────────────────────────────
@@ -14155,7 +14161,7 @@ fn pathline_tightest_span_wins_over_fingerprinted_enclosing() {
         .unwrap();
     if lu_fp_count == 0 {
         // load_user not fingerprinted — can't run this test; skip gracefully.
-        fs::remove_dir_all(root).unwrap();
+        let _ = fs::remove_dir_all(root);
         return;
     }
 
@@ -14317,7 +14323,7 @@ fn pathline_tightest_span_wins_over_fingerprinted_enclosing() {
          (span=19)"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 // ── Fix 2: Ref ambiguity rejection ───────────────────────────────────────────────────────────
@@ -14363,7 +14369,7 @@ fn clones_for_symbol_ref_single_fingerprinted_resolves_unfingerprinted_falls_bac
     assert!(!tiny_res.symbol_fingerprinted, "tiny is below MIN_TOKENS");
     assert!(tiny_res.class.is_none());
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Fix 2 (#215): injecting TWO distinct fingerprinted `symbols` rows that share the SAME
@@ -14432,7 +14438,7 @@ fn clones_for_symbol_ref_ambiguous_fingerprinted_returns_err() {
 
     let Some((nk, nv, tl, sh)) = fp else {
         // If there's no fingerprint yet the ambiguity path can't be reached; skip gracefully.
-        fs::remove_dir_all(root).unwrap();
+        let _ = fs::remove_dir_all(root);
         return;
     };
 
@@ -14457,7 +14463,7 @@ fn clones_for_symbol_ref_ambiguous_fingerprinted_returns_err() {
         .unwrap();
     if dup_fp_count == 0 {
         // fp INSERT was silently ignored (shouldn't happen) — skip the test.
-        fs::remove_dir_all(root).unwrap();
+        let _ = fs::remove_dir_all(root);
         return;
     }
 
@@ -14472,7 +14478,7 @@ fn clones_for_symbol_ref_ambiguous_fingerprinted_returns_err() {
         "error message must name the ambiguous ref, got: {msg}"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 // ── Fix 3: stale_members in completeness ────────────────────────────────────────────────────
@@ -14530,7 +14536,7 @@ fn find_clones_stale_members_zero_on_clean_index_and_nonzero_after_disk_edit() {
         stale.completeness.stale_members
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Resolve the `symbols.id` of a fingerprinted function by its qualified-name `ref` (the
@@ -14629,7 +14635,7 @@ fn load_refine_members_reparse_is_faithful_to_persisted_struct_hash() {
     let actual = members.iter().map(|m| (m.struct_hash.clone(), m.symbol_id)).collect::<Vec<_>>();
     assert_eq!(actual, expected, "members must be sorted by (struct_hash, symbol_id)");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Empty input is a valid (empty) refine set — not a failure.
@@ -14644,7 +14650,7 @@ fn load_refine_members_empty_input_returns_empty() {
     let members = db.load_refine_members(&[]).unwrap().expect("empty input is a valid empty set");
     assert!(members.is_empty(), "empty member_ids → empty members");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Missing source: a member whose source file is deleted from disk (but whose fingerprint row is
@@ -14679,7 +14685,7 @@ fn load_refine_members_returns_none_when_source_missing() {
         "a member with a deleted source file must yield Ok(None) for the whole class"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 /// Overlay fallback (#215 Plan 4a Task 2): under a LINKED-WORKTREE OVERLAY scope, `source_root` is

--- a/crates/rag-rat-core/src/locks.rs
+++ b/crates/rag-rat-core/src/locks.rs
@@ -357,9 +357,15 @@ mod tests {
 
     #[test]
     fn hook_socket_path_lives_under_base_sockets_dir() {
-        let base = temp_dir();
-        let root = temp_dir();
-        let socket = hook_socket_path(&base, &root);
+        // Short, fixed paths (they need not exist — `hook_socket_path` only builds the string) so
+        // the preferred `<base>/sockets/<hash>.sock` stays within MAX_SOCKET_PATH_LEN on
+        // every platform. The real `temp_dir()` helper roots under `std::env::temp_dir()`,
+        // which on macOS is a long `/var/folders/…` path that busts the budget and falls
+        // back to the XDG candidate (parent `rag-rat`, not `sockets`) — the over-budget
+        // fallback is covered separately via `long_base_dir`.
+        let base = Path::new("/r");
+        let root = Path::new("/repo");
+        let socket = hook_socket_path(base, root);
         assert_eq!(socket.parent().unwrap().file_name().unwrap(), "sockets");
         assert!(socket.extension().is_some_and(|ext| ext == "sock"));
     }

--- a/crates/rag-rat-core/src/version_check.rs
+++ b/crates/rag-rat-core/src/version_check.rs
@@ -108,14 +108,13 @@ pub fn needs_refresh(cached: Option<&CachedVersion>, now_ms: i64, ttl_ms: i64) -
 /// mandatory: crates.io 403s a request without one.
 pub fn fetch_latest() -> Option<String> {
     let url = format!("https://crates.io/api/v1/crates/{CRATE_NAME}");
-    let agent = ureq::AgentBuilder::new().timeout(FETCH_TIMEOUT).build();
-    let body = agent
-        .get(&url)
-        .set("User-Agent", concat!("rag-rat/", env!("CARGO_PKG_VERSION"), " (version-check)"))
-        .call()
-        .ok()?
-        .into_string()
-        .ok()?;
+    // crates.io 403s a request without a User-Agent, so set it on the agent config (ureq 3).
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_global(Some(FETCH_TIMEOUT))
+        .user_agent(concat!("rag-rat/", env!("CARGO_PKG_VERSION"), " (version-check)"))
+        .build()
+        .into();
+    let body = agent.get(&url).call().ok()?.body_mut().read_to_string().ok()?;
     parse_latest_response(&body)
 }
 

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -287,7 +287,11 @@ fn kind_is_mutation(kind: &EventKind) -> bool {
 /// worktree root) it returns just `config.root` — already covered by the recursive target watches,
 /// so the extra non-recursive watch is a harmless no-op duplicate.
 fn gitignore_watch_dirs(root: &Path) -> Vec<PathBuf> {
-    let base = crate::index::git_history::worktree_root(root).filter(|wt| root.starts_with(wt));
+    // Decide the worktree-root ancestor on canonicalized forms but keep `base` in `root`'s own
+    // representation — gix's workdir isn't canonicalized, so on Windows a raw `starts_with` fails
+    // when `root` is verbatim (`\\?\C:\…`) and the workdir is plain (`C:\…`). See ignore_rules.
+    let base = crate::index::git_history::worktree_root(root)
+        .and_then(|wt| crate::index::ignore_rules::base_under_worktree(root, &wt));
     let mut dirs = Vec::new();
     if let Some(base) = base
         && let Ok(rel) = root.strip_prefix(&base)
@@ -395,7 +399,10 @@ fn event_touches_worktree(
 /// when `config.root` IS the worktree root (the common case) or in a non-git tree.
 fn config_subdir_prefix(config: &Config) -> PathBuf {
     crate::index::git_history::worktree_root(&config.root)
-        .and_then(|wt| config.root.strip_prefix(&wt).ok().map(Path::to_path_buf))
+        // base_under_worktree returns the worktree root in config.root's representation, so the
+        // strip_prefix below succeeds on Windows (verbatim vs plain prefix) — see ignore_rules.
+        .and_then(|wt| crate::index::ignore_rules::base_under_worktree(&config.root, &wt))
+        .and_then(|base| config.root.strip_prefix(&base).ok().map(Path::to_path_buf))
         .unwrap_or_default()
 }
 

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -343,7 +343,7 @@ fn index_status_surfaces_version_when_cached_and_enabled() {
     assert_eq!(version["update_available"], true);
     assert_eq!(version["update_command"], "cargo install rag-rat --force");
 
-    std::fs::remove_dir_all(root).unwrap();
+    let _ = std::fs::remove_dir_all(root);
 }
 
 #[test]
@@ -391,7 +391,7 @@ fn mcp_tool_calls_preserve_compatibility_shapes() {
     let local_ai = call_tool(&config.database, "local_ai_status", json!({})).unwrap();
     assert_eq!(local_ai["embedding"]["state"], "MissingModel");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -485,7 +485,7 @@ fn mcp_memory_tools_create_surface_validate_and_obsolete_symbol_memory() {
             .unwrap();
     assert_eq!(obsolete["status"], "obsolete");
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -513,7 +513,7 @@ fn mcp_read_chunk_and_heal_index_do_not_return_stale_text() {
     let fresh = call_tool_for_config(&config, "semantic_search", json!({"query": "beta"})).unwrap();
     assert_eq!(fresh.as_array().unwrap().len(), 1);
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -684,7 +684,7 @@ fn mcp_handle_selection_disambiguates_graph_tools() {
     .unwrap();
     assert!(papertrail["current_source"]["symbol"].as_str().unwrap().contains("shared"));
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]
@@ -720,7 +720,7 @@ fn find_callers_zero_callers_is_not_low_completeness() {
     assert_eq!(callee["summary"]["completeness_risk"], "low");
     assert!(callee["summary"]["completeness_note"].is_null());
 
-    fs::remove_dir_all(root).unwrap();
+    let _ = fs::remove_dir_all(root);
 }
 
 fn assert_schema_requires(tools: &[Value], name: &str, field: &str) {
@@ -845,7 +845,7 @@ fn mcp_rewrites_ranking_hint_when_auto_run_enabled() {
         Some(rag_rat_core::query::pagerank::RANKING_HINT_RUN_ORACLE),
     );
 
-    std::fs::remove_dir_all(root).unwrap();
+    let _ = std::fs::remove_dir_all(root);
 }
 
 fn tool_schema<'a>(tools: &'a [Value], name: &str) -> &'a Value {
@@ -1180,7 +1180,7 @@ fn read_tool_lazy_write_retries_read_write_not_readonly_error() {
         "the lazy write must be retried read-write, never surfaced as SQLITE_READONLY: {err:?}"
     );
 
-    std::fs::remove_dir_all(root).unwrap();
+    let _ = std::fs::remove_dir_all(root);
 }
 
 #[test]

--- a/docs/binary-size.md
+++ b/docs/binary-size.md
@@ -1,8 +1,9 @@
 # Binary Size
 
-`rag-rat` keeps storage dependencies small. SQLite is provided by the system through
-`rusqlite`; heavyweight embedded database runtimes such as DuckDB are out of scope unless
-a dedicated issue records the need, expected size impact, and accepted tradeoff.
+`rag-rat` keeps storage dependencies small. SQLite is compiled in (bundled) via `rusqlite`, so there
+is no system-library prerequisite and `cargo install` is self-contained on every platform;
+heavyweight embedded database runtimes such as DuckDB are out of scope unless a dedicated issue
+records the need, expected size impact, and accepted tradeoff.
 
 Use this manual check after storage dependency changes:
 

--- a/tools/bench.Containerfile
+++ b/tools/bench.Containerfile
@@ -26,9 +26,8 @@ ARG RUST_ANALYZER_URL=https://github.com/rust-lang/rust-analyzer/releases/latest
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        # rag-rat build + general (libsqlite3-dev: rusqlite is non-bundled, links system sqlite3)
+        # rag-rat build + general (rusqlite bundles SQLite via cc; build-essential covers the C compiler)
         build-essential pkg-config git python3 curl ca-certificates xz-utils gzip \
-        libsqlite3-dev \
         # Linux kernel build (for compile_commands.json: the bc-class deps that bit us)
         bc flex bison libelf-dev libssl-dev \
         # scip-clang / rust-analyzer prebuilt-binary runtime libs


### PR DESCRIPTION
Resolves the **Cross-platform support (macOS + Windows)** milestone.

## What changed

| # | Area | Change |
|---|------|--------|
| #237 | deps | `rusqlite` declared with the `bundled` feature — libsqlite3-sys compiles the vendored SQLite amalgamation via `cc` on every OS, so Windows links without a system SQLite. `Cargo.lock` gains the `cc` build edge; `bench.Containerfile` drops `libsqlite3-dev`. |
| #240 | cli | `libc` moved to `[target.'cfg(unix)'.dependencies]` (matches core/mcp) — dead dep dropped on Windows. |
| #239 | runtime | `settings_path` falls back `$HOME → %USERPROFILE%` (`hooks install --global` works on stock Windows shells); `fastembed_cache_dir` gains a `#[cfg(windows)]` `%LOCALAPPDATA%` branch (per-user model cache). Unix XDG/HOME precedence unchanged. |
| #241 | index | Chunker byte offsets are CRLF-correct: `split_inclusive('\n')` + raw-slice advance across all sites, and `line_span` returns the on-disk span so the tree-sitter code path's `end_byte` stays byte-aligned with the symbol offsets `query::graph_meta` joins against. New `chunker_tests` assert exact on-disk boundaries on the multi-chunk path. |
| #238 | ci | New `ci-cross-platform.yml` runs clippy/test/build-full on macOS + Windows, gated to `release: published` (+ `workflow_dispatch`). `ci.yml` stays Linux-only on every PR/push, so per-commit cost is unchanged. |
| #242 | docs | README **Platform support** section: per-OS C-toolchain prereq, dropped stale "system SQLite" caveat, documented the Unix/Linux-only maintenance conveniences. |

## CI cadence (per request)
macOS/Windows are **release-gated**, not run on every PR — they fire on the same `release: published` trigger `oracle.yml`/`bench-release.yml` already use. Linux keeps full per-PR/main coverage in `ci.yml`.

## Verification
`cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets --no-default-features --locked -D warnings`, `cargo build --workspace --no-default-features --locked`, and `cargo nextest run --workspace --no-default-features --locked` all green — **870/870 tests** (6 new CRLF chunker tests). Verified on Linux; the macOS/Windows legs will run on the next release.

> Note: #237 makes two repo memories ("rusqlite is non-bundled" / "must apt-get libsqlite3-dev") stale once this merges — they should be updated/obsoleted post-merge.

Fixes #237
Fixes #238
Fixes #239
Fixes #240
Fixes #241
Fixes #242