### PR TITLE
fix(oracle): edge_oracle survives reindex (content-anchored verdicts) + enforcing regression guards (#248)

### DIFF
--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -556,14 +556,24 @@ pub(crate) fn any_run_in_scope(
     store::any_run_in_scope(conn, commit_sha, worktree_id)
 }
 
-/// Prune `oracle_runs` rows for dead `(commit_sha, worktree_id)` contexts — the gc companion to the
-/// `edge_oracle` FK cascade. See [`store::prune_oracle_runs_outside_scope`]. Returns rows deleted.
+/// Prune `oracle_runs` rows for dead `(commit_sha, worktree_id)` contexts — a gc companion that
+/// drops a dead checkout's run rows (nothing cascades `oracle_runs`, keyed by `(commit,
+/// worktree)`). See [`store::prune_oracle_runs_outside_scope`]. Returns rows deleted.
 pub fn prune_oracle_runs_outside_scope(
     conn: &Connection,
     live_commits: &[String],
     live_worktrees: &[String],
 ) -> anyhow::Result<u64> {
     store::prune_oracle_runs_outside_scope(conn, live_commits, live_worktrees)
+}
+
+/// Sweep `edge_oracle` verdicts whose content key matches no live edge ANYWHERE — the gc
+/// replacement for the `edges_data` FK cascade dropped in #248 (correctness no longer depends on
+/// it; it is anti-growth hygiene). GLOBAL, not checkout-scoped, so a sweep never deletes a sibling
+/// worktree's live verdict. See [`store::prune_edge_oracle_without_live_edge`]. Returns rows
+/// deleted.
+pub fn prune_edge_oracle_without_live_edge(conn: &Connection) -> anyhow::Result<u64> {
+    store::prune_edge_oracle_without_live_edge(conn)
 }
 
 /// The `tool_version` the surfacing reads (the `Compiler` tier) should key on for `tool` in the

--- a/crates/rag-rat-core/src/index/oracle/run.rs
+++ b/crates/rag-rat-core/src/index/oracle/run.rs
@@ -317,8 +317,16 @@ pub(crate) fn run_in_tx(
         }
 
         join::tally(&mut report, verdict.kind);
+        // Persist by the edge's CONTENT key (#248), not its rowid, so the verdict re-anchors to the
+        // reindexed edge on an unchanged file. `edge_kind` is the candidate's resolved TEXT (the
+        // `edges` view already joined `name_strings`).
         store::write_edge_oracle(conn, input.tool, input.tool_version, &EdgeOracleRow {
-            edge_id: candidate.edge_id,
+            source_path: &candidate.source_path,
+            source_start_byte: candidate.source_start_byte,
+            source_end_byte: candidate.source_end_byte,
+            callee_start_byte: candidate.callee_start_byte,
+            callee_end_byte: candidate.callee_end_byte,
+            edge_kind: &candidate.edge_kind,
             file_sha: &candidate.file_sha,
             resolved_symbol_id: verdict.resolved_symbol_id,
             scip_symbol: &verdict.scip_symbol,

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -1012,6 +1012,46 @@ pub(crate) fn prune_oracle_runs_outside_scope(
     Ok(u64::try_from(deleted).unwrap_or(0))
 }
 
+/// Prune `edge_oracle` verdicts whose CONTENT key matches ZERO live edges anywhere in the index —
+/// the gc replacement for the `edges_data` FK cascade dropped in #248. With no FK, a deleted edge
+/// no longer cascades its verdict away, so an incremental reindex (`remove_file_in_scope` DELETEs a
+/// changed file's edges every pass) leaves dangling verdict rows behind; this sweep is what stops
+/// them accumulating without bound.
+///
+/// GLOBAL by design (R6, #248): the match is against live edges across ALL scopes (no
+/// `active_checkout_file_predicate`), so a sweep run in one worktree never deletes a SIBLING
+/// worktree's still-live verdict. A verdict is swept iff NO live edge anywhere shares its content
+/// key (`source_path`, source/callee byte spans, `edge_kind` text) — matched by joining live
+/// `edges_data` to `files.path` + one `name_strings` for the `edge_kind` text, the same content key
+/// the read join uses. Returns the number of rows deleted.
+///
+/// CORRECTNESS DOES NOT DEPEND ON THIS SWEEP. The read path joins live `edges` by content key +
+/// `files.sha256 = file_sha`, so a dangling verdict simply produces no row and is never counted or
+/// surfaced — exactly the moniker model. This is anti-unbounded-growth hygiene, nothing more, so it
+/// is deliberately decoupled from sweep timing (the next `oracle run`'s authoritative clear also
+/// removes content-matching stale rows; this catches the rows that have no live edge at all).
+pub(crate) fn prune_edge_oracle_without_live_edge(conn: &Connection) -> anyhow::Result<u64> {
+    let deleted = conn.execute(
+        "
+        DELETE FROM edge_oracle
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM edges_data
+            JOIN files ON files.id = edges_data.source_file_id
+            JOIN name_strings ek ON ek.id = edges_data.edge_kind_id
+            WHERE files.path = edge_oracle.source_path
+              AND edges_data.source_start_byte = edge_oracle.source_start_byte
+              AND edges_data.source_end_byte = edge_oracle.source_end_byte
+              AND edges_data.callee_start_byte = edge_oracle.callee_start_byte
+              AND edges_data.callee_end_byte = edge_oracle.callee_end_byte
+              AND ek.value = edge_oracle.edge_kind
+        )
+        ",
+        [],
+    )?;
+    Ok(u64::try_from(deleted).unwrap_or(0))
+}
+
 /// Render a slice of strings as a SQL `IN (...)` value list with single-quote escaping. Inputs are
 /// commit shas / worktree ids (hex / path-derived), never user free-text, but we escape `'` anyway
 /// so the list can't break the statement. An empty slice yields `''` (a value nothing matches),

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -95,9 +95,21 @@ pub(crate) fn count_symbols_with_moniker(
 /// plus enough context to write a verdict and to recognise agreement/disagreement.
 #[derive(Debug, Clone)]
 pub(crate) struct EdgeJoinCandidate {
+    /// The live edge rowid. Since #248 the write path keys verdicts by the CONTENT fields below
+    /// (not this rowid), so production no longer reads `edge_id` — it is retained as the
+    /// candidate's live identity and asserted by `edge_join_candidates` ordering tests.
+    /// `allow(dead_code)` because the lib build (no test cfg) sees no reader.
+    #[allow(dead_code)]
     pub(crate) edge_id: i64,
     pub(crate) source_path: String,
     pub(crate) file_sha: String,
+    /// The call SITE byte range (`edges_data.source_start_byte`/`source_end_byte`). Part of the
+    /// content key (#248): the call site disambiguates two callee-range-equal edges (a
+    /// `calls_name` and a `references_type` on the same identifier token, or repeated calls).
+    /// Both default to 0 on edges that predate source spans, but the resolvable population the
+    /// oracle rows carries real spans, so the content key stays unique.
+    pub(crate) source_start_byte: i64,
+    pub(crate) source_end_byte: i64,
     pub(crate) callee_start_byte: i64,
     pub(crate) callee_end_byte: i64,
     pub(crate) confidence: String,
@@ -139,6 +151,8 @@ pub(crate) fn edge_join_candidates(
         SELECT edges.id,
                files.path,
                files.sha256,
+               edges.source_start_byte,
+               edges.source_end_byte,
                edges.callee_start_byte,
                edges.callee_end_byte,
                edges.confidence,
@@ -158,11 +172,13 @@ pub(crate) fn edge_join_candidates(
             edge_id: row.get(0)?,
             source_path: row.get(1)?,
             file_sha: row.get(2)?,
-            callee_start_byte: row.get(3)?,
-            callee_end_byte: row.get(4)?,
-            confidence: row.get(5)?,
-            edge_kind: row.get(6)?,
-            to_symbol_id: row.get(7)?,
+            source_start_byte: row.get(3)?,
+            source_end_byte: row.get(4)?,
+            callee_start_byte: row.get(5)?,
+            callee_end_byte: row.get(6)?,
+            confidence: row.get(7)?,
+            edge_kind: row.get(8)?,
+            to_symbol_id: row.get(9)?,
         })
     })?;
     let mut out = Vec::new();
@@ -335,16 +351,29 @@ pub(crate) fn clear_edge_oracle_for_tool(
     commit_sha: &str,
     worktree_id: &str,
 ) -> anyhow::Result<()> {
+    // CONTENT-JOIN scope (#248): with no `edge_id` FK there is no rowid to match — restrict the
+    // DELETE to verdicts whose CONTENT key has a live edge in the active checkout, the same key the
+    // read join uses. `edges_data` is queried directly (not the 7-LEFT-JOIN `edges` view) with ONE
+    // `name_strings` join for the `edge_kind` text match. The callsite-file `files.sha256` is NOT
+    // gated here: the authoritative clear must drop the prior verdict for a content-matching edge
+    // even when the file drifted (the run rewrites it), exactly as the old rowid clear did.
     conn.execute(
         &format!(
             "
         DELETE FROM edge_oracle
         WHERE tool = ?1 AND tool_version = ?2
-          AND edge_id IN (
-            SELECT edges.id
-            FROM edges
-            JOIN files ON files.id = edges.source_file_id
-            WHERE {scope}
+          AND EXISTS (
+            SELECT 1
+            FROM edges_data
+            JOIN files ON files.id = edges_data.source_file_id
+            JOIN name_strings ek ON ek.id = edges_data.edge_kind_id
+            WHERE files.path = edge_oracle.source_path
+              AND edges_data.source_start_byte = edge_oracle.source_start_byte
+              AND edges_data.source_end_byte = edge_oracle.source_end_byte
+              AND edges_data.callee_start_byte = edge_oracle.callee_start_byte
+              AND edges_data.callee_end_byte = edge_oracle.callee_end_byte
+              AND ek.value = edge_oracle.edge_kind
+              AND {scope}
           )
         ",
             scope = active_checkout_file_predicate("?3", "?4"),
@@ -354,17 +383,29 @@ pub(crate) fn clear_edge_oracle_for_tool(
     Ok(())
 }
 
-/// A verdict to persist for one edge.
+/// A verdict to persist for one edge, keyed by the edge's CONTENT identity (#248) rather than the
+/// volatile `edges_data.id` rowid — so the verdict survives reindex and re-anchors to the
+/// reindexed edge for free. The content key is `(tool, tool_version, source_path,
+/// source_start_byte, source_end_byte, callee_start_byte, callee_end_byte, edge_kind)`; `edge_kind`
+/// is stored as TEXT (the candidate already carries the resolved text via the `edges` view's
+/// `name_strings` join), NOT the interned id (which is not reindex-stable).
 pub(crate) struct EdgeOracleRow<'a> {
-    pub(crate) edge_id: i64,
+    pub(crate) source_path: &'a str,
+    pub(crate) source_start_byte: i64,
+    pub(crate) source_end_byte: i64,
+    pub(crate) callee_start_byte: i64,
+    pub(crate) callee_end_byte: i64,
+    pub(crate) edge_kind: &'a str,
     pub(crate) file_sha: &'a str,
     pub(crate) resolved_symbol_id: Option<i64>,
     pub(crate) scip_symbol: &'a str,
     pub(crate) kind: OracleResolutionKind,
 }
 
-/// Upsert one `edge_oracle` row. Keyed by `(edge_id, tool, tool_version)`; re-running the same tool
-/// version overwrites the prior verdict (content addressed by `file_sha`). NEVER touches `edges`.
+/// Upsert one `edge_oracle` row. Keyed by the content key
+/// `(tool, tool_version, source_path, source_start_byte, source_end_byte, callee_start_byte,
+/// callee_end_byte, edge_kind)`; re-running the same tool version overwrites the prior verdict
+/// (staleness still content-addressed by `file_sha`). NEVER touches `edges`.
 pub(crate) fn write_edge_oracle(
     conn: &Connection,
     tool: OracleTool,
@@ -374,11 +415,17 @@ pub(crate) fn write_edge_oracle(
     conn.execute(
         "
         INSERT INTO edge_oracle(
-            edge_id, file_sha, tool, tool_version,
+            source_path, source_start_byte, source_end_byte,
+            callee_start_byte, callee_end_byte, edge_kind,
+            file_sha, tool, tool_version,
             resolved_symbol_id, scip_symbol, kind, computed_at
         )
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
-        ON CONFLICT(edge_id, tool, tool_version) DO UPDATE SET
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+        ON CONFLICT(
+            tool, tool_version, source_path,
+            source_start_byte, source_end_byte,
+            callee_start_byte, callee_end_byte, edge_kind
+        ) DO UPDATE SET
             file_sha = excluded.file_sha,
             resolved_symbol_id = excluded.resolved_symbol_id,
             scip_symbol = excluded.scip_symbol,
@@ -386,7 +433,12 @@ pub(crate) fn write_edge_oracle(
             computed_at = excluded.computed_at
         ",
         params![
-            row.edge_id,
+            row.source_path,
+            row.source_start_byte,
+            row.source_end_byte,
+            row.callee_start_byte,
+            row.callee_end_byte,
+            row.edge_kind,
             row.file_sha,
             tool.as_db_str(),
             tool_version,
@@ -558,12 +610,35 @@ pub(crate) fn any_run_in_scope(
 /// `AND` — #82 P0. Slots `?3`/`?4` (commit_sha / worktree_id) flow into it; `?1`/`?2`
 /// (tool / version) gate the side table. Callers append ` AND <extra>` exactly as before — the
 /// statement still ends in a trailing `WHERE`, so a JOIN can't legally follow.
+///
+/// CONTENT JOIN (load-bearing, #248): the join to live `edges` is by the edge's CONTENT key
+/// (`source_path → files.path`, source/callee byte spans, `edge_kind` text), NOT by the old
+/// `edges.id = edge_oracle.edge_id` rowid — there is no `edge_id` column any more. After a reindex
+/// rewrites `edges_data` with new ids, an UNCHANGED file's verdict re-anchors to the reindexed edge
+/// for free (its content key + `files.sha256` are unchanged); a dangling verdict (no content match)
+/// simply produces no row, so the COUNT paths exclude it WITHOUT the FK pre-delete that V018 used.
+/// `files.sha256 = edge_oracle.file_sha` is part of the join so a CHANGED file's verdict (sha
+/// mismatch) never matches — the metric reads see only live, current-content verdicts.
+///
+/// ALIASING (R7): bare table names (`edges`/`files`) are kept — no `e`/`f` aliases — so the
+/// appended [`edge_oracle_current_predicate`] (bare `files.sha256` + its inner `JOIN files`) and
+/// the consumer SELECTs (`edges.confidence`/`edge_kind`/`to_symbol_id`/`to_name`/`id`,
+/// `files.path`) still resolve. The `edges` VIEW (not `edges_data`) is used here because consumers
+/// need its `name_strings`-joined text columns (`edge_kind`, `confidence`, `to_name`); the
+/// surfacing reads are bound by an `edge_id IN (...)` list or the staleness/anchor indexes, so the
+/// view's joins are not on an unbounded hot scan.
 pub(crate) fn edge_oracle_scope_join() -> String {
     format!(
         "
     FROM edge_oracle
-    JOIN edges ON edges.id = edge_oracle.edge_id
-    JOIN files ON files.id = edges.source_file_id
+    JOIN files ON files.path = edge_oracle.source_path
+              AND files.sha256 = edge_oracle.file_sha
+    JOIN edges ON edges.source_file_id = files.id
+              AND edges.source_start_byte = edge_oracle.source_start_byte
+              AND edges.source_end_byte = edge_oracle.source_end_byte
+              AND edges.callee_start_byte = edge_oracle.callee_start_byte
+              AND edges.callee_end_byte = edge_oracle.callee_end_byte
+              AND edges.edge_kind = edge_oracle.edge_kind
     WHERE edge_oracle.tool = ?1 AND edge_oracle.tool_version = ?2
       AND {scope}",
         scope = active_checkout_file_predicate("?3", "?4"),
@@ -715,12 +790,15 @@ pub(crate) fn current_oracle_verdicts_for_edges(
         // deleted/reinserted
         // resolved symbol yields NULL here, so the `Upgrade` target can't be surfaced and the hop
         // is left heuristic (#82 finding 2).
+        // Re-project the LIVE edge id (#248): `edge_oracle.edge_id` is gone — the verdict joins to
+        // the reindexed `edges` row by content key, so its CURRENT rowid is `edges.id`. Callers key
+        // this map by the heuristic-traversal edge id (graph.rs `hop.edge_id`), which is that same
+        // live id, and the `edge_ids` filter is against live edges.
         let sql = format!(
-            "SELECT edge_oracle.edge_id, edge_oracle.kind, edge_oracle.resolved_symbol_id, \
-             (SELECT value FROM name_strings WHERE name_strings.id = (SELECT qualified_name_id \
-             FROM symbols WHERE symbols.id = edge_oracle.resolved_symbol_id)), \
-             edge_oracle.scip_symbol{scope_join}{current} AND edge_oracle.edge_id IN \
-             ({placeholders})",
+            "SELECT edges.id, edge_oracle.kind, edge_oracle.resolved_symbol_id, (SELECT value \
+             FROM name_strings WHERE name_strings.id = (SELECT qualified_name_id FROM symbols \
+             WHERE symbols.id = edge_oracle.resolved_symbol_id)), \
+             edge_oracle.scip_symbol{scope_join}{current} AND edges.id IN ({placeholders})",
             scope_join = edge_oracle_scope_join(),
             current = edge_oracle_current_predicate(),
         );
@@ -776,9 +854,10 @@ pub(crate) fn current_oracle_verdicts_all(
     commit_sha: &str,
     worktree_id: &str,
 ) -> anyhow::Result<std::collections::HashMap<i64, (OracleResolutionKind, Option<i64>)>> {
+    // Re-project the LIVE edge id (#248): keyed by `edges.id` (the reindexed rowid the content join
+    // resolves to), which is the id the importance ranker's heuristic traversal carries.
     let sql = format!(
-        "SELECT edge_oracle.edge_id, edge_oracle.kind, \
-         edge_oracle.resolved_symbol_id{scope_join}{current}",
+        "SELECT edges.id, edge_oracle.kind, edge_oracle.resolved_symbol_id{scope_join}{current}",
         scope_join = edge_oracle_scope_join(),
         current = edge_oracle_current_predicate(),
     );
@@ -842,10 +921,12 @@ pub(crate) fn current_oracle_comparisons(
     // The heuristic target's qualified name is fetched via a correlated subquery rather than a
     // trailing LEFT JOIN, so the shared `edge_oracle_scope_join` string (which already ends in a
     // WHERE) stays the single source of the scope predicate — a JOIN can't legally follow a WHERE.
+    // Re-project the LIVE edge id (#248): `edge_oracle.edge_id` is gone; the compare surface keys
+    // on `edges.id` (the reindexed rowid the content join resolves to).
     let sql = format!(
-        "SELECT edge_oracle.edge_id, edge_oracle.kind, edges.edge_kind, edges.confidence, (SELECT \
-         value FROM name_strings WHERE name_strings.id = (SELECT qualified_name_id FROM symbols \
-         WHERE symbols.id = edges.to_symbol_id)), edges.to_name, edge_oracle.resolved_symbol_id, \
+        "SELECT edges.id, edge_oracle.kind, edges.edge_kind, edges.confidence, (SELECT value FROM \
+         name_strings WHERE name_strings.id = (SELECT qualified_name_id FROM symbols WHERE \
+         symbols.id = edges.to_symbol_id)), edges.to_name, edge_oracle.resolved_symbol_id, \
          edge_oracle.scip_symbol, files.path, COALESCE(NULLIF(edges.source_start_line, 0), 1) \
          {scope_join}{current} ORDER BY files.path, edges.source_start_line",
         scope_join = edge_oracle_scope_join(),

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -658,14 +658,25 @@ pub(crate) fn count_edge_oracle_scoped(
     kind: Option<OracleResolutionKind>,
 ) -> anyhow::Result<u64> {
     let scope_join = edge_oracle_scope_join();
+    // COUNT(DISTINCT edge_oracle.rowid), not COUNT(*): the scope join joins each `edge_oracle` row
+    // to its LIVE edge by the content key. That key is measured 1:1 with a live edge (0
+    // collisions / 1.03M rows — the call-site source span makes it unique), so today this
+    // equals COUNT(*). The DISTINCT is defense-in-depth (#248): if a future extract/resolve
+    // span change ever made one content key fan onto MULTIPLE live edges, COUNT(*) would
+    // inflate the verdict total by counting the row once per matched edge — DISTINCT on the
+    // physical verdict's rowid pins the count to the number of persisted verdicts regardless.
+    // (`edge_oracle` is STRICT, not WITHOUT ROWID, so it has an implicit rowid.) Pairs with
+    // `edge_oracle_same_full_content_key_upserts_one_row`.
     let count: i64 = match kind {
         Some(kind) => conn.query_row(
-            &format!("SELECT COUNT(*){scope_join} AND edge_oracle.kind = ?5"),
+            &format!(
+                "SELECT COUNT(DISTINCT edge_oracle.rowid){scope_join} AND edge_oracle.kind = ?5"
+            ),
             params![tool.as_db_str(), tool_version, commit_sha, worktree_id, kind.as_db_str()],
             |row| row.get(0),
         )?,
         None => conn.query_row(
-            &format!("SELECT COUNT(*){scope_join}"),
+            &format!("SELECT COUNT(DISTINCT edge_oracle.rowid){scope_join}"),
             params![tool.as_db_str(), tool_version, commit_sha, worktree_id],
             |row| row.get(0),
         )?,

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -2146,6 +2146,50 @@ fn edge_oracle_collision_same_callee_range_different_kind_disambiguated() {
     assert_eq!(ref_scip, "scip x `Thing`#");
 }
 
+/// #248 content-key collision SEMANTICS (the schema-permitted, organically-unreachable edge case):
+/// two verdicts with the SAME FULL content key
+/// `(tool, tool_version, source_path, source_start_byte, source_end_byte, callee_start_byte,
+/// callee_end_byte, edge_kind)` — differing only in the resolved target (`resolved_symbol_id` /
+/// `scip_symbol`) and verdict `kind` — collapse to EXACTLY ONE physical `edge_oracle` row via the
+/// PRIMARY-KEY upsert (last write wins). The unique-key disambiguation test above keeps two rows by
+/// changing `edge_kind`; THIS test pins what happens when even `edge_kind` matches.
+///
+/// This is DOCUMENTED as schema-PERMITTED but organically UNREACHABLE for real extracted edges: the
+/// call-site source span (`source_start_byte`/`source_end_byte`) is part of the key, and two
+/// distinct call sites always carry distinct source spans (measured 0 collisions / 1.03M rows). The
+/// key is NOT schema-enforced to be 1:1 with a live edge — it is unique only because real call-site
+/// spans are. Pinning the upsert here means a FUTURE extract/resolve span change that made the same
+/// full key reachable for two genuinely-different edges would surface as a behavior change this
+/// test catches (the count helpers assume this measured 1:1, per `count_edge_oracle_scoped`).
+#[test]
+fn edge_oracle_same_full_content_key_upserts_one_row() {
+    let h = Harness::new();
+    let f = h.add_file("a.rs", "fn caller() { thing(); }\n");
+    let sha = h.file_sha("a.rs");
+    // ONE edge → ONE content key. Writing two verdicts for it reuses the identical full key.
+    let edge = h.add_edge(f, "thing", 14, 19, "Exact", None);
+
+    // First verdict: an Upgrade naming target A.
+    h.write_verdict(edge, &sha, Some(101), "scip x `thing`#A().", OracleResolutionKind::Upgrade);
+    // Second verdict, SAME full content key (same edge → same path + spans + edge_kind, same
+    // TOOL/VERSION), differing only in the resolved target and the verdict kind.
+    h.write_verdict(edge, &sha, Some(202), "scip x `thing`#B().", OracleResolutionKind::Confirm);
+
+    // EXACTLY ONE physical row — the second write UPSERTED the first (it did not insert a sibling).
+    let rows: i64 = h.conn.query_row("SELECT COUNT(*) FROM edge_oracle", [], |r| r.get(0)).unwrap();
+    assert_eq!(rows, 1, "same full content key collapses to one edge_oracle row (PK upsert)");
+
+    // Last write wins: the surviving row carries the SECOND verdict's target + kind.
+    let (kind, resolved, scip) = h.verdict(edge).expect("the single upserted verdict");
+    assert_eq!(
+        kind,
+        OracleResolutionKind::Confirm.as_db_str(),
+        "the later verdict's kind survives"
+    );
+    assert_eq!(resolved, Some(202), "the later verdict's resolved target survives");
+    assert_eq!(scip, "scip x `thing`#B().", "the later verdict's scip symbol survives");
+}
+
 /// #248 counts: after a reindex that CHANGES one file (its `files.sha256` drifts), status/eval
 /// counts reflect only LIVE + CURRENT verdicts — the changed file's verdict drops out (file_sha
 /// mismatch in the scope join) and never inflates the totals, while the unchanged file's verdict

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -3552,6 +3552,128 @@ fn oracle_rerun_clears_prior_monikers_for_tool() {
     assert!(h.moniker(1001).is_none(), "authoritative clear removed the stale moniker");
 }
 
+/// BEHAVIORAL LIFECYCLE GUARD (#248): the integration test the suite never had. Every prior oracle
+/// test wrote+read its outputs with NO reindex in between — which is exactly why the CASCADE-on-
+/// reindex bug was invisible for so long. This runs the oracle to populate BOTH oracle-derived
+/// outputs (`edge_oracle` via a call/def join, `logical_symbol_monikers` via the def→logical map),
+/// then exercises the two reindex shapes that rewrite the volatile parents, and asserts BOTH
+/// outputs still resolve through their LIVE-JOIN reads afterward. The two shapes are a FULL reindex
+/// (`DELETE FROM edges_data` + a wholesale `logical_symbols` rebuild — DELETE-all + reinsert with
+/// the SAME content-derived id, modelling an UNCHANGED symbol) and a per-file INCREMENTAL reindex
+/// on an UNCHANGED file (`remove_file_in_scope` deletes + the indexer re-inserts the same edge, the
+/// `file_rows.rs` path). It is paired with a CHANGED-file/CHANGED-symbol staleness assertion, so it
+/// pins BOTH directions: unchanged content survives, changed content goes stale.
+#[test]
+fn oracle_outputs_survive_full_and_incremental_reindex() {
+    use crate::query::memory::{MonikerResolution, resolve_moniker};
+
+    let h = Harness::new();
+    // A caller + a def file. The def's symbol is grouped into a logical symbol (content-derived id
+    // 1001 here; stable across rebuilds in production), so the moniker pass writes a moniker for
+    // it.
+    let caller = h.add_file("caller.rs", "fn caller() { target(); }\n");
+    let defs = h.add_file("defs.rs", "fn target() {}\n");
+    let target_sym = h.add_symbol_qualified(defs, "target", "defs.rs::target", "function", 0, 14);
+    h.add_chunk(defs, "defs.rs::target", "fn target() {}\n");
+    h.add_logical_symbol(1001, "defs.rs", "target", "defs.rs::target", target_sym);
+    // The heuristic resolved the call; the oracle CONFIRMS it (an in-corpus verdict + a moniker).
+    let edge_v1 = h.add_edge(caller, "target", 14, 20, "Exact", Some(target_sym));
+
+    let bytes = scip_bytes_docs(vec![
+        ("caller.rs", vec![occurrence(
+            0,
+            14,
+            20,
+            TARGET_MONIKER,
+            SymbolRole::UnspecifiedSymbolRole as i32,
+        )]),
+        ("defs.rs", vec![occurrence(0, 3, 9, TARGET_MONIKER, SymbolRole::Definition as i32)]),
+    ]);
+    let report =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
+    assert_eq!(report.rows_written, 1, "the run wrote a verdict");
+    assert_eq!(report.monikers_written, 1, "the run wrote a moniker");
+
+    // Both outputs resolve through their LIVE-JOIN reads before any reindex (sanity).
+    assert_eq!(
+        store::count_edge_oracle_scoped(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, None).unwrap(),
+        1,
+        "verdict counted before reindex"
+    );
+    assert!(
+        matches!(
+            resolve_moniker(&h.conn, TARGET_MONIKER, TOOL.as_db_str()).unwrap(),
+            MonikerResolution::Unique { logical_symbol_id: 1001, .. }
+        ),
+        "moniker resolves to the live logical symbol before reindex"
+    );
+
+    // --- FULL reindex: rewrite edges_data (DELETE + re-insert the SAME edge → new rowid) AND
+    // rebuild logical_symbols wholesale (DELETE-all + reinsert the SAME content-derived id 1001,
+    // the unchanged-symbol case). The caller/def file shas are untouched. ---
+    h.conn.execute("DELETE FROM edges WHERE id = ?1", params![edge_v1]).unwrap();
+    let edge_v2 = h.add_edge(caller, "target", 14, 20, "Exact", Some(target_sym));
+    assert_ne!(edge_v2, edge_v1, "full reindex minted a new edge rowid");
+    // Wholesale logical_symbols rebuild: drop the members + the logical row, reinsert with the SAME
+    // id (unchanged symbol → stable content-derived id).
+    h.conn
+        .execute("DELETE FROM logical_symbol_members WHERE logical_symbol_id = 1001", [])
+        .unwrap();
+    h.conn.execute("DELETE FROM logical_symbols WHERE id = 1001", []).unwrap();
+    h.add_logical_symbol(1001, "defs.rs", "target", "defs.rs::target", target_sym);
+
+    // BOTH outputs still resolve after the full reindex (re-anchored by content key / stable id).
+    assert_eq!(
+        store::count_edge_oracle_scoped(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, None).unwrap(),
+        1,
+        "edge_oracle survives the FULL reindex (re-anchored by content key)"
+    );
+    assert!(
+        matches!(
+            resolve_moniker(&h.conn, TARGET_MONIKER, TOOL.as_db_str()).unwrap(),
+            MonikerResolution::Unique { logical_symbol_id: 1001, .. }
+        ),
+        "moniker survives the FULL logical_symbols rebuild (stable content-derived id)"
+    );
+
+    // --- INCREMENTAL reindex on the UNCHANGED caller.rs: the per-file path deletes the file's
+    // edges then the indexer re-inserts the same one. Model `remove_file_in_scope`'s edge
+    // delete + the re-insert; the file row + sha stay put. ---
+    h.conn.execute("DELETE FROM edges WHERE id = ?1", params![edge_v2]).unwrap();
+    let edge_v3 = h.add_edge(caller, "target", 14, 20, "Exact", Some(target_sym));
+    assert_ne!(edge_v3, edge_v2, "incremental reindex minted a new edge rowid");
+    assert_eq!(
+        store::count_edge_oracle_scoped(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, None).unwrap(),
+        1,
+        "edge_oracle survives the per-file INCREMENTAL reindex of an unchanged file"
+    );
+
+    // --- CHANGED-content staleness (the other direction): drift the caller's sha → its verdict
+    // goes stale (file_sha mismatch); mint a new logical id for the symbol → its moniker
+    // dangles. ---
+    h.conn
+        .execute("UPDATE files SET sha256 = 'caller-changed' WHERE id = ?1", params![caller])
+        .unwrap();
+    assert_eq!(
+        store::count_edge_oracle_scoped(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, None).unwrap(),
+        0,
+        "a CHANGED file's verdict is stale (file_sha mismatch) — not counted"
+    );
+    // A changed symbol mints a NEW content-derived logical id; the old moniker row dangles.
+    h.conn
+        .execute("DELETE FROM logical_symbol_members WHERE logical_symbol_id = 1001", [])
+        .unwrap();
+    h.conn.execute("DELETE FROM logical_symbols WHERE id = 1001", []).unwrap();
+    h.add_logical_symbol(2002, "defs.rs", "target", "defs.rs::target", target_sym);
+    assert!(
+        matches!(
+            resolve_moniker(&h.conn, TARGET_MONIKER, TOOL.as_db_str()).unwrap(),
+            MonikerResolution::Dangling
+        ),
+        "a CHANGED symbol's moniker dangles (its content-derived logical id died) — not resolved"
+    );
+}
+
 /// Create a memory bound to the harness symbol, asserting the automatic `scip_moniker` binding.
 fn create_target_memory(h: &Harness, symbol_id: i64) -> String {
     let created = create_memory(&h.conn, RepoMemoryCreate {

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -3221,6 +3221,75 @@ fn prune_oracle_runs_drops_dead_contexts_only() {
     assert_eq!(remaining, 2);
 }
 
+/// gc (#248): `prune_edge_oracle_without_live_edge` is a GLOBAL sweep — it deletes a verdict whose
+/// content key matches NO live edge in ANY scope, but KEEPS one that matches a live edge anywhere
+/// (so a sibling worktree's still-live verdict is never swept by a sweep run in another checkout).
+/// This is the gc hygiene that replaces the dropped FK cascade; correctness never depended on it
+/// (dangling verdicts already never resolve via the live join — see
+/// `edge_oracle_survives_reindex_for_unchanged_file`), so this only guards unbounded growth.
+#[test]
+fn gc_prunes_edge_oracle_rows_with_no_live_edge() {
+    let h = Harness::new();
+
+    // (A) A verdict whose edge is LIVE in the active checkout — must be kept.
+    let live_file = h.add_file("live.rs", "fn caller() { target(); }\n");
+    let live_sha = h.file_sha("live.rs");
+    let live_edge = h.add_edge(live_file, "target", 14, 20, "Exact", None);
+    h.write_verdict(
+        live_edge,
+        &live_sha,
+        None,
+        "scip x `target`().",
+        OracleResolutionKind::Confirm,
+    );
+
+    // (B) A verdict whose edge lives in a SIBLING checkout (another commit). The global sweep does
+    // NOT apply the active-checkout predicate, so it must still see this edge as live and keep its
+    // verdict — a sweep in THIS checkout must never delete a sibling's live verdict.
+    let sibling_file = h.add_file_in_scope("sibling.rs", OTHER_COMMIT, OTHER_WORKTREE);
+    let sibling_sha = h.file_sha_for_commit("sibling.rs", OTHER_COMMIT);
+    let sibling_edge = h.add_edge(sibling_file, "thing", 14, 19, "Exact", None);
+    h.write_verdict(
+        sibling_edge,
+        &sibling_sha,
+        None,
+        "scip x `thing`().",
+        OracleResolutionKind::Confirm,
+    );
+
+    // (C) A DANGLING verdict — content key matches no live edge anywhere (the edge was deleted in a
+    // reindex, leaving the FK-less verdict behind). Build it by writing a verdict, then deleting
+    // its edge (simulating `remove_file_in_scope` dropping a changed file's edges).
+    let dangling_file = h.add_file("dangling.rs", "fn caller() { gone(); }\n");
+    let dangling_sha = h.file_sha("dangling.rs");
+    let dangling_edge = h.add_edge(dangling_file, "gone", 14, 18, "Exact", None);
+    h.write_verdict(
+        dangling_edge,
+        &dangling_sha,
+        None,
+        "scip x `gone`().",
+        OracleResolutionKind::Confirm,
+    );
+    h.conn.execute("DELETE FROM edges WHERE id = ?1", params![dangling_edge]).unwrap();
+
+    let before: i64 =
+        h.conn.query_row("SELECT COUNT(*) FROM edge_oracle", [], |r| r.get(0)).unwrap();
+    assert_eq!(before, 3, "three verdicts before the sweep (live, sibling, dangling)");
+
+    let deleted = store::prune_edge_oracle_without_live_edge(&h.conn).unwrap();
+    assert_eq!(deleted, 1, "only the dangling verdict (no live edge anywhere) is swept");
+
+    let after: i64 =
+        h.conn.query_row("SELECT COUNT(*) FROM edge_oracle", [], |r| r.get(0)).unwrap();
+    assert_eq!(after, 2, "the live + sibling verdicts survive the global sweep");
+    // The two survivors still resolve to their live edges by content key.
+    assert!(h.verdict(live_edge).is_some(), "the active-checkout verdict is kept");
+    assert!(
+        h.verdict(sibling_edge).is_some(),
+        "the sibling-checkout verdict is kept (global sweep)"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Moniker anchors (#70, phase 3): oracle-run moniker pass + memory relocation.
 // ---------------------------------------------------------------------------

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -2034,6 +2034,178 @@ fn edge_oracle_stale_after_file_change_not_counted() {
     );
 }
 
+/// #248 END-TO-END (the regression that started the issue): a full `run_oracle` writes verdicts,
+/// then a reindex of the UNCHANGED file rewrites `edges_data` with new ids — and the compare
+/// surface (`current_oracle_comparisons`, the data behind `compare_graph_to_scip`) is STILL
+/// non-empty, re-anchored to the reindexed edge by content key. Before #248 the `ON DELETE CASCADE`
+/// FK wiped the verdict on reindex and the compare surface went empty (the opt-in oracle never
+/// repopulated). Exercises the REAL join+write path (`run_oracle` over a built `.scip` with a call
+/// + def occurrence), not a hand-written verdict.
+#[test]
+fn oracle_run_then_reindex_then_compare_graph_to_scip_nonempty() {
+    let h = Harness::new();
+    let caller = h.add_file("caller.rs", "fn caller() { target(); }\n");
+    let defs = h.add_file("defs.rs", "fn target() {}\nfn other() {}\n");
+    // Heuristic resolved `target` to the WRONG symbol; the oracle CONTRADICTS it (Contradict rows
+    // are exactly what `current_oracle_comparisons` keeps).
+    let wrong_sym = h.add_symbol(defs, "other", 18, 23);
+    let right_sym = h.add_symbol(defs, "target", 3, 9);
+    let edge_v1 = h.add_edge(caller, "target", 14, 20, "Exact", Some(wrong_sym));
+
+    let symbol = "scip-rust crate v1 `target`().";
+    let mut index = Index {
+        documents: vec![Document {
+            relative_path: "caller.rs".to_string(),
+            occurrences: vec![occurrence(
+                0,
+                14,
+                20,
+                symbol,
+                SymbolRole::UnspecifiedSymbolRole as i32,
+            )],
+            position_encoding: EnumOrUnknown::new(
+                PositionEncoding::UTF8CodeUnitOffsetFromLineStart,
+            ),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    index.documents.push(Document {
+        relative_path: "defs.rs".to_string(),
+        occurrences: vec![occurrence(0, 3, 9, symbol, SymbolRole::Definition as i32)],
+        position_encoding: EnumOrUnknown::new(PositionEncoding::UTF8CodeUnitOffsetFromLineStart),
+        ..Default::default()
+    });
+    let bytes = index.write_to_bytes().unwrap();
+
+    let report =
+        run_oracle(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, &bytes, h.root(), None, None).unwrap();
+    assert_eq!(report.rows_written, 1, "the run wrote one verdict");
+
+    // Compare surface is non-empty before reindex (sanity).
+    let before =
+        store::current_oracle_comparisons(&h.conn, TOOL, VERSION, COMMIT, WORKTREE).unwrap();
+    assert_eq!(before.len(), 1, "the contradiction surfaces in compare before reindex");
+    assert_eq!(before[0].edge_id, edge_v1);
+    assert_eq!(before[0].kind, OracleResolutionKind::Contradict);
+
+    // --- Simulate a reindex of the UNCHANGED caller.rs: rewrite the edge (new edges_data rowid),
+    // SAME file content/sha. (The defs.rs symbols are untouched so the def-drift gate stays
+    // satisfied.) ---
+    h.conn.execute("DELETE FROM edges WHERE id = ?1", params![edge_v1]).unwrap();
+    let edge_v2 = h.add_edge(caller, "target", 14, 20, "Exact", Some(wrong_sym));
+    assert_ne!(edge_v2, edge_v1, "reindex minted a new edge rowid");
+
+    // THE REGRESSION ASSERTION: compare surface is STILL non-empty, re-anchored to the new edge id.
+    let after =
+        store::current_oracle_comparisons(&h.conn, TOOL, VERSION, COMMIT, WORKTREE).unwrap();
+    assert_eq!(after.len(), 1, "compare surface survives reindex (re-anchored by content key)");
+    assert_eq!(
+        after[0].edge_id, edge_v2,
+        "the comparison re-projects onto the LIVE reindexed edge"
+    );
+    assert_eq!(after[0].kind, OracleResolutionKind::Contradict);
+    assert_eq!(
+        after[0].resolved_symbol_id,
+        Some(right_sym),
+        "the re-anchored verdict still names the oracle's correct target",
+    );
+}
+
+/// #248 collision: a `calls_name` edge and a `references_type` edge that share the SAME callee token
+/// (same callee byte range, same call site) get DISTINCT verdicts — the content key includes
+/// `edge_kind`, so the two never collide onto one `edge_oracle` row, and a verdict for one never
+/// leaks onto the other. (This is the design's disambiguation claim — R1: the call-site span + the
+/// callee span + the edge kind make the key unique per edge.)
+#[test]
+fn edge_oracle_collision_same_callee_range_different_kind_disambiguated() {
+    let h = Harness::new();
+    let f = h.add_file("a.rs", "fn caller() { Thing(); }\n");
+    let sha = h.file_sha("a.rs");
+    // Two edges on the SAME identifier token `Thing` (callee bytes 14..19, same call site span):
+    // one a `calls_name` (constructor call), one a `references_type`. Same callee range, different
+    // kind — the pre-#248 callee-range-only key would have collided them.
+    let call_edge = h.add_edge_with_kind(f, "Thing", 14, 19, "calls_name", "Exact", None);
+    let ref_edge = h.add_edge_with_kind(f, "Thing", 14, 19, "references_type", "Exact", None);
+    assert_ne!(call_edge, ref_edge, "two distinct edges share the callee token");
+
+    // Distinct verdicts: the call resolves to a function symbol, the type-ref to a type symbol.
+    h.write_verdict(call_edge, &sha, None, "scip x `Thing`#new().", OracleResolutionKind::Upgrade);
+    h.write_verdict(ref_edge, &sha, None, "scip x `Thing`#", OracleResolutionKind::Confirm);
+
+    // Two physical rows (the content key disambiguated by edge_kind), not one overwritten row.
+    let rows: i64 = h.conn.query_row("SELECT COUNT(*) FROM edge_oracle", [], |r| r.get(0)).unwrap();
+    assert_eq!(rows, 2, "edge_kind in the content key keeps the two verdicts distinct");
+
+    // Each edge resolves to ITS OWN verdict — no cross-contamination.
+    let (call_kind, _, call_scip) = h.verdict(call_edge).expect("call verdict");
+    assert_eq!(call_kind, OracleResolutionKind::Upgrade.as_db_str());
+    assert_eq!(call_scip, "scip x `Thing`#new().");
+    let (ref_kind, _, ref_scip) = h.verdict(ref_edge).expect("ref verdict");
+    assert_eq!(ref_kind, OracleResolutionKind::Confirm.as_db_str());
+    assert_eq!(ref_scip, "scip x `Thing`#");
+}
+
+/// #248 counts: after a reindex that CHANGES one file (its `files.sha256` drifts), status/eval
+/// counts reflect only LIVE + CURRENT verdicts — the changed file's verdict drops out (file_sha
+/// mismatch in the scope join) and never inflates the totals, while the unchanged file's verdict
+/// stays counted. Without the live-edge content join + the sha gate, dangling/stale verdicts would
+/// inflate the count.
+#[test]
+fn status_eval_counts_unaffected_by_dangling() {
+    let h = Harness::new();
+    // Two files each with a confirmed verdict — both counted initially.
+    let stable = h.add_file("stable.rs", "fn caller() { keep(); }\n");
+    let stable_sha = h.file_sha("stable.rs");
+    let stable_edge = h.add_edge(stable, "keep", 14, 18, "Exact", None);
+    h.write_verdict(
+        stable_edge,
+        &stable_sha,
+        None,
+        "scip x `keep`().",
+        OracleResolutionKind::Confirm,
+    );
+
+    let churn = h.add_file("churn.rs", "fn caller() { drift(); }\n");
+    let churn_sha = h.file_sha("churn.rs");
+    let churn_edge = h.add_edge(churn, "drift", 14, 19, "Exact", None);
+    h.write_verdict(
+        churn_edge,
+        &churn_sha,
+        None,
+        "scip x `drift`().",
+        OracleResolutionKind::Confirm,
+    );
+
+    let status0 = super::oracle_status(&h.conn, TOOL, VERSION, COMMIT, WORKTREE).unwrap();
+    assert_eq!(status0.total_verdicts, 2, "both verdicts counted before any change");
+    assert_eq!(status0.confirmed, 2);
+
+    // Reindex churn.rs with CHANGED content: rewrite its edge (new rowid) AND drift its
+    // files.sha256 — the verdict's file_sha no longer matches, so it is stale. The stable file
+    // is untouched.
+    h.conn.execute("DELETE FROM edges WHERE id = ?1", params![churn_edge]).unwrap();
+    let _churn_edge_v2 = h.add_edge(churn, "drift", 14, 19, "Exact", None);
+    h.conn
+        .execute("UPDATE files SET sha256 = 'churn-changed' WHERE id = ?1", params![churn])
+        .unwrap();
+
+    let status1 = super::oracle_status(&h.conn, TOOL, VERSION, COMMIT, WORKTREE).unwrap();
+    assert_eq!(
+        status1.total_verdicts, 1,
+        "only the live + current (unchanged-file) verdict counts; the changed file's is stale",
+    );
+    assert_eq!(status1.confirmed, 1);
+
+    // Eval metrics use the SAME scoped counts — the stale verdict does not inflate them either.
+    let m = super::oracle_eval_metrics(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, RecallCalls {
+        covered: 1,
+        oracle_only: 0,
+    })
+    .unwrap();
+    assert_eq!(m.confirmed, 1, "eval confirmed count is live + current only");
+}
+
 /// Finding 2: a low-confidence edge in ANOTHER worktree must not inflate the current run's
 /// `oracle_upgradeable_fraction` denominator. With one upgraded low-conf edge in-scope and an
 /// extra unresolved low-conf edge out-of-scope, the scoped fraction is 1/1 = 1.0 (not 1/2).

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -51,6 +51,17 @@ const VERSION: &str = "test";
 const COMMIT: &str = "deadbeefcafef00d";
 const WORKTREE: &str = "";
 
+/// The content-key fields of a live edge, owned so an [`EdgeOracleRow`] borrowing them outlives the
+/// borrow (#248: verdicts are content-keyed, not rowid-keyed).
+struct EdgeContentKey {
+    source_path: String,
+    source_start_byte: i64,
+    source_end_byte: i64,
+    callee_start_byte: i64,
+    callee_end_byte: i64,
+    edge_kind: String,
+}
+
 /// A test corpus written to a temp checkout + an index DB seeded to match.
 struct Harness {
     conn: Connection,
@@ -283,11 +294,23 @@ impl Harness {
         self.conn.last_insert_rowid()
     }
 
-    /// The persisted oracle verdict for an edge, if any.
+    /// The persisted oracle verdict for an edge, if any. Looks the row up by the edge's CONTENT key
+    /// (#248: `edge_oracle` no longer carries `edge_id`) — joining the live edge by path + source +
+    /// callee spans + edge_kind, the same key the production read join uses. NOTE: unlike the
+    /// surfacing reads, this does NOT gate on `files.sha256 = file_sha`, so a test that wrote a
+    /// non-matching `file_sha` still sees its row (the persisted-population view).
     fn verdict(&self, edge_id: i64) -> Option<(String, Option<i64>, String)> {
         self.conn
             .query_row(
-                "SELECT kind, resolved_symbol_id, scip_symbol FROM edge_oracle WHERE edge_id = ?1",
+                "SELECT eo.kind, eo.resolved_symbol_id, eo.scip_symbol
+                 FROM edge_oracle eo
+                 JOIN edges ON edges.source_start_byte = eo.source_start_byte
+                           AND edges.source_end_byte = eo.source_end_byte
+                           AND edges.callee_start_byte = eo.callee_start_byte
+                           AND edges.callee_end_byte = eo.callee_end_byte
+                           AND edges.edge_kind = eo.edge_kind
+                 JOIN files ON files.id = edges.source_file_id AND files.path = eo.source_path
+                 WHERE edges.id = ?1",
                 params![edge_id],
                 |row| {
                     Ok((
@@ -298,6 +321,78 @@ impl Harness {
                 },
             )
             .ok()
+    }
+
+    /// The recorded `files.sha256` for a path in the active checkout — the "current content" sha a
+    /// verdict must carry to be counted/surfaced (the scope join + current predicate gate on it).
+    fn file_sha(&self, path: &str) -> String {
+        self.conn
+            .query_row("SELECT sha256 FROM files WHERE path = ?1", params![path], |r| r.get(0))
+            .unwrap()
+    }
+
+    /// The recorded `files.sha256` for a path in a specific commit scope — for verdicts written
+    /// against a sibling checkout's file (disambiguates the same path across two commits).
+    fn file_sha_for_commit(&self, path: &str, commit: &str) -> String {
+        self.conn
+            .query_row(
+                "SELECT sha256 FROM files WHERE path = ?1 AND commit_sha = ?2",
+                params![path, commit],
+                |r| r.get(0),
+            )
+            .unwrap()
+    }
+
+    /// The content-key fields of a live edge (`source_path`, source/callee byte spans,
+    /// `edge_kind`), for building an [`EdgeOracleRow`] in tests that reference an edge by id.
+    /// Mirrors what the production write path reads from each [`store::EdgeJoinCandidate`].
+    fn edge_content_key(&self, edge_id: i64) -> EdgeContentKey {
+        self.conn
+            .query_row(
+                "SELECT files.path, edges.source_start_byte, edges.source_end_byte,
+                        edges.callee_start_byte, edges.callee_end_byte, edges.edge_kind
+                 FROM edges JOIN files ON files.id = edges.source_file_id
+                 WHERE edges.id = ?1",
+                params![edge_id],
+                |row| {
+                    Ok(EdgeContentKey {
+                        source_path: row.get(0)?,
+                        source_start_byte: row.get(1)?,
+                        source_end_byte: row.get(2)?,
+                        callee_start_byte: row.get(3)?,
+                        callee_end_byte: row.get(4)?,
+                        edge_kind: row.get(5)?,
+                    })
+                },
+            )
+            .unwrap()
+    }
+
+    /// Write an `edge_oracle` verdict for a live edge, deriving the content key from the edge so
+    /// the row matches the production read join by construction. The `EdgeContentKey` outlives
+    /// the row.
+    fn write_verdict(
+        &self,
+        edge_id: i64,
+        file_sha: &str,
+        resolved_symbol_id: Option<i64>,
+        scip_symbol: &str,
+        kind: OracleResolutionKind,
+    ) {
+        let key = self.edge_content_key(edge_id);
+        store::write_edge_oracle(&self.conn, TOOL, VERSION, &EdgeOracleRow {
+            source_path: &key.source_path,
+            source_start_byte: key.source_start_byte,
+            source_end_byte: key.source_end_byte,
+            callee_start_byte: key.callee_start_byte,
+            callee_end_byte: key.callee_end_byte,
+            edge_kind: &key.edge_kind,
+            file_sha,
+            resolved_symbol_id,
+            scip_symbol,
+            kind,
+        })
+        .unwrap();
     }
 
     /// The heuristic resolution on the `edges` row (must never change).
@@ -747,15 +842,26 @@ fn migration_creates_oracle_side_tables() {
         assert_eq!(count, 1, "{table} table must exist");
     }
 
-    // STRICT mode (repo convention for new tables).
+    // STRICT mode (repo convention for new tables); NO FK to edges_data (#248 — the V018 cascade
+    // wiped verdicts on reindex).
     let edge_oracle_sql: String = conn
         .query_row("SELECT sql FROM sqlite_master WHERE name = 'edge_oracle'", [], |row| row.get(0))
         .unwrap();
     assert!(edge_oracle_sql.contains("STRICT"), "edge_oracle must be STRICT");
+    assert!(
+        !edge_oracle_sql.to_uppercase().contains("FOREIGN KEY"),
+        "edge_oracle must NOT carry an FK to edges_data — a reindex CASCADE would wipe verdicts"
+    );
 
+    // Content-key columns (#248) replace the volatile `edge_id`.
     let columns = table_columns(&conn, "edge_oracle");
     for expected in [
-        "edge_id",
+        "source_path",
+        "source_start_byte",
+        "source_end_byte",
+        "callee_start_byte",
+        "callee_end_byte",
+        "edge_kind",
         "file_sha",
         "tool",
         "tool_version",
@@ -766,8 +872,9 @@ fn migration_creates_oracle_side_tables() {
     ] {
         assert!(columns.contains(&expected.to_string()), "edge_oracle missing {expected}");
     }
+    assert!(!columns.contains(&"edge_id".to_string()), "edge_id column was dropped");
 
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 30);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 31);
 }
 
 /// The V019 moniker migration: the `logical_symbol_monikers` table (STRICT, NO foreign key — see
@@ -819,31 +926,41 @@ fn table_columns(conn: &Connection, table: &str) -> Vec<String> {
         .unwrap()
 }
 
-/// Deleting an `edges` row cascades to its `edge_oracle` verdict (FK `ON DELETE CASCADE`, V018), so
-/// no orphan verdict survives for `status`/eval to keep counting. The rebuild +
-/// `remove_file_in_scope` edge deletes reinsert edges with new ids and recompute the oracle, so
-/// cascading old verdicts away is correct.
+/// #248: deleting an `edges` row no longer cascades to its `edge_oracle` verdict (the FK is gone —
+/// it CASCADE-wiped every verdict on reindex). Instead the verdict stops RESOLVING: the content
+/// join finds no live edge, so the surfacing/metric reads return nothing — the moniker model
+/// (dangling never resolves). The physical row persists until the next run's clear or gc sweeps it.
 #[test]
-fn deleting_an_edge_cascades_away_its_oracle_verdict() {
+fn deleting_an_edge_leaves_a_dangling_verdict_that_does_not_resolve() {
     let h = Harness::new();
     let f = h.add_file("a.rs", "fn caller() { target(); }\n");
     let edge = h.add_edge(f, "target", 14, 20, "NameOnly", None);
-    store::write_edge_oracle(&h.conn, TOOL, VERSION, &EdgeOracleRow {
-        edge_id: edge,
-        file_sha: "s",
-        resolved_symbol_id: None,
-        scip_symbol: "s",
-        kind: OracleResolutionKind::Upgrade,
-    })
-    .unwrap();
-    assert!(h.verdict(edge).is_some(), "verdict present before delete");
+    let file_sha: String = h
+        .conn
+        .query_row("SELECT sha256 FROM files WHERE id = ?1", params![f], |r| r.get(0))
+        .unwrap();
+    h.write_verdict(edge, &file_sha, None, "s", OracleResolutionKind::Upgrade);
+    assert!(h.verdict(edge).is_some(), "verdict resolves before delete");
+    assert_eq!(
+        store::count_edge_oracle_scoped(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, None).unwrap(),
+        1,
+        "the live verdict is counted before delete"
+    );
 
     h.conn.execute("DELETE FROM edges WHERE id = ?1", params![edge]).unwrap();
 
-    assert!(h.verdict(edge).is_none(), "verdict cascaded away with its edge");
+    assert!(h.verdict(edge).is_none(), "no live edge → the verdict no longer resolves");
+    assert_eq!(
+        store::count_edge_oracle_scoped(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, None).unwrap(),
+        0,
+        "the dangling verdict is excluded from the scoped count (live-edge join)"
+    );
     let remaining: i64 =
         h.conn.query_row("SELECT COUNT(*) FROM edge_oracle", [], |r| r.get(0)).unwrap();
-    assert_eq!(remaining, 0, "no orphan edge_oracle rows survive the edge delete");
+    assert_eq!(
+        remaining, 1,
+        "no FK cascade: the physical row survives the edge delete (swept later)"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -908,9 +1025,11 @@ fn symbol_spans_for_path_returns_scoped_ordered_spans() {
     );
 }
 
-/// Writing an `edge_oracle` row and reading it back round-trips every field; re-writing the same
-/// `(edge_id, tool, tool_version)` upserts (new file_sha/kind) rather than inserting a duplicate.
-/// The matching `edges` row is never touched (side-table invariant).
+/// #248: writing an `edge_oracle` row keyed by the edge's CONTENT key round-trips every field;
+/// re-writing the SAME content key upserts (new file_sha/kind) rather than inserting a duplicate.
+/// The row resolves through the live-edge content join, and the matching `edges` row is never
+/// touched (side-table invariant). The write uses the real `files.sha256` so the count path (which
+/// now gates on current content via the scope join) tallies it.
 #[test]
 fn write_edge_oracle_round_trips_and_upserts_without_touching_edges() {
     let h = Harness::new();
@@ -918,48 +1037,58 @@ fn write_edge_oracle_round_trips_and_upserts_without_touching_edges() {
     let defs = h.add_file("defs.rs", "fn target() {}\n");
     let target_sym = h.add_symbol(defs, "target", 3, 9);
     let edge = h.add_edge(caller, "target", 14, 20, "Exact", Some(target_sym));
+    let caller_sha: String = h
+        .conn
+        .query_row("SELECT sha256 FROM files WHERE path = 'caller.rs'", [], |r| r.get(0))
+        .unwrap();
 
-    store::write_edge_oracle(&h.conn, TOOL, VERSION, &EdgeOracleRow {
-        edge_id: edge,
-        file_sha: "sha-v1",
-        resolved_symbol_id: Some(7),
-        scip_symbol: "scip `target`().",
-        kind: OracleResolutionKind::Upgrade,
-    })
-    .unwrap();
+    h.write_verdict(
+        edge,
+        &caller_sha,
+        Some(target_sym),
+        "scip `target`().",
+        OracleResolutionKind::Upgrade,
+    );
 
     let (kind, resolved, scip) = h.verdict(edge).expect("row written");
     assert_eq!(kind, OracleResolutionKind::Upgrade.as_db_str());
-    assert_eq!(resolved, Some(7));
+    assert_eq!(resolved, Some(target_sym));
     assert_eq!(scip, "scip `target`().");
     assert_eq!(
         store::count_edge_oracle_scoped(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, None).unwrap(),
         1
     );
 
-    // Re-write the same key with a new sha + verdict → upsert, still one row.
-    store::write_edge_oracle(&h.conn, TOOL, VERSION, &EdgeOracleRow {
-        edge_id: edge,
-        file_sha: "sha-v2",
-        resolved_symbol_id: None,
-        scip_symbol: "scip cargo tokio `target`().",
-        kind: OracleResolutionKind::ResolvedExternal,
-    })
-    .unwrap();
+    // Re-write the SAME content key (same edge) with a new sha + verdict → upsert, still one row.
+    // Use the same `caller_sha` so the count path keeps it (a different sha would read as stale).
+    h.write_verdict(
+        edge,
+        &caller_sha,
+        None,
+        "scip cargo tokio `target`().",
+        OracleResolutionKind::ResolvedExternal,
+    );
     assert_eq!(
         store::count_edge_oracle_scoped(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, None).unwrap(),
-        1
+        1,
+        "upsert overwrote the row by content key — no duplicate"
     );
     let (kind2, resolved2, _) = h.verdict(edge).expect("row still present");
     assert_eq!(kind2, OracleResolutionKind::ResolvedExternal.as_db_str());
     assert_eq!(resolved2, None);
+    let physical_rows: i64 =
+        h.conn.query_row("SELECT COUNT(*) FROM edge_oracle", [], |r| r.get(0)).unwrap();
+    assert_eq!(physical_rows, 1, "the upsert kept a single physical row");
     let file_sha: String = h
         .conn
-        .query_row("SELECT file_sha FROM edge_oracle WHERE edge_id = ?1", params![edge], |r| {
-            r.get(0)
-        })
+        .query_row(
+            "SELECT file_sha FROM edge_oracle WHERE source_path = 'caller.rs' AND \
+             callee_start_byte = 14 AND callee_end_byte = 20 AND edge_kind = 'calls_name'",
+            [],
+            |r| r.get(0),
+        )
         .unwrap();
-    assert_eq!(file_sha, "sha-v2", "upsert refreshed the staleness sha");
+    assert_eq!(file_sha, caller_sha, "upsert refreshed the staleness sha");
 
     // The heuristic edges row is untouched by either write.
     assert_eq!(h.heuristic_resolution(edge), ("exact".to_string(), Some(target_sym)));
@@ -975,15 +1104,8 @@ fn staleness_key_distinguishes_rows_by_file_sha_tool_and_version() {
     let e1 = h.add_edge(f, "x", 1, 2, "NameOnly", None);
     let e2 = h.add_edge(f, "y", 3, 4, "NameOnly", None);
 
-    let row = |edge: i64, sha: &'static str| EdgeOracleRow {
-        edge_id: edge,
-        file_sha: sha,
-        resolved_symbol_id: None,
-        scip_symbol: "s",
-        kind: OracleResolutionKind::Upgrade,
-    };
-    store::write_edge_oracle(&h.conn, TOOL, VERSION, &row(e1, "sha-fresh")).unwrap();
-    store::write_edge_oracle(&h.conn, TOOL, VERSION, &row(e2, "sha-old")).unwrap();
+    h.write_verdict(e1, "sha-fresh", None, "s", OracleResolutionKind::Upgrade);
+    h.write_verdict(e2, "sha-old", None, "s", OracleResolutionKind::Upgrade);
 
     let count_for_sha = |sha: &str| -> i64 {
         h.conn
@@ -1048,19 +1170,11 @@ fn record_oracle_run_and_count_by_kind() {
     assert!(id2 > id1, "row id increments");
 
     let f = h.add_file("a.rs", "x\n");
+    let sha = h.file_sha("a.rs");
     let e_up = h.add_edge(f, "u", 0, 1, "NameOnly", None);
     let e_conf = h.add_edge(f, "c", 1, 2, "Exact", None);
-    let mk = |edge, kind| EdgeOracleRow {
-        edge_id: edge,
-        file_sha: "s",
-        resolved_symbol_id: None,
-        scip_symbol: "s",
-        kind,
-    };
-    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(e_up, OracleResolutionKind::Upgrade))
-        .unwrap();
-    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(e_conf, OracleResolutionKind::Confirm))
-        .unwrap();
+    h.write_verdict(e_up, &sha, None, "s", OracleResolutionKind::Upgrade);
+    h.write_verdict(e_conf, &sha, None, "s", OracleResolutionKind::Confirm);
 
     assert_eq!(
         store::count_edge_oracle_scoped(
@@ -1109,19 +1223,11 @@ fn oracle_status_reports_counts_and_last_run() {
     store::record_oracle_run(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, "Blocked", "{}").unwrap();
 
     let f = h.add_file("a.rs", "x\n");
+    let sha = h.file_sha("a.rs");
     let e1 = h.add_edge(f, "a", 0, 1, "NameOnly", None);
     let e2 = h.add_edge(f, "b", 1, 2, "Exact", None);
-    let mk = |edge, kind| EdgeOracleRow {
-        edge_id: edge,
-        file_sha: "s",
-        resolved_symbol_id: None,
-        scip_symbol: "s",
-        kind,
-    };
-    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(e1, OracleResolutionKind::Upgrade))
-        .unwrap();
-    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(e2, OracleResolutionKind::Contradict))
-        .unwrap();
+    h.write_verdict(e1, &sha, None, "s", OracleResolutionKind::Upgrade);
+    h.write_verdict(e2, &sha, None, "s", OracleResolutionKind::Contradict);
 
     let status = super::oracle_status(&h.conn, TOOL, VERSION, COMMIT, WORKTREE).unwrap();
     assert_eq!(status.tool, "rust-analyzer");
@@ -1350,6 +1456,7 @@ fn recall_gap_counts_only_call_like_occurrences() {
 fn eval_metrics_derive_rates_from_persisted_verdicts() {
     let h = Harness::new();
     let f = h.add_file("a.rs", "fn caller() {}\n");
+    let sha = h.file_sha("a.rs");
     // Exact edges judged: one confirmed, one contradicted. (to_symbol_id NULL keeps the FK happy;
     // precision is derived from the persisted edge_oracle rows, not the edges row.)
     let e_conf = h.add_edge(f, "c", 0, 1, "Exact", None);
@@ -1357,34 +1464,9 @@ fn eval_metrics_derive_rates_from_persisted_verdicts() {
     // A NameOnly edge the oracle upgraded.
     let e_up = h.add_edge(f, "u", 2, 3, "NameOnly", None);
 
-    let mk = |edge, kind, resolved| EdgeOracleRow {
-        edge_id: edge,
-        file_sha: "s",
-        resolved_symbol_id: resolved,
-        scip_symbol: "s",
-        kind,
-    };
-    store::write_edge_oracle(
-        &h.conn,
-        TOOL,
-        VERSION,
-        &mk(e_conf, OracleResolutionKind::Confirm, Some(1)),
-    )
-    .unwrap();
-    store::write_edge_oracle(
-        &h.conn,
-        TOOL,
-        VERSION,
-        &mk(e_contra, OracleResolutionKind::Contradict, Some(3)),
-    )
-    .unwrap();
-    store::write_edge_oracle(
-        &h.conn,
-        TOOL,
-        VERSION,
-        &mk(e_up, OracleResolutionKind::Upgrade, Some(4)),
-    )
-    .unwrap();
+    h.write_verdict(e_conf, &sha, Some(1), "s", OracleResolutionKind::Confirm);
+    h.write_verdict(e_contra, &sha, Some(3), "s", OracleResolutionKind::Contradict);
+    h.write_verdict(e_up, &sha, Some(4), "s", OracleResolutionKind::Upgrade);
 
     // Recall sides come from the run, occurrence-counted over the call population: 3 covered call
     // occurrences + 1 oracle-only gap. (Recall no longer derives from the per-kind verdict sum.)
@@ -1418,27 +1500,14 @@ fn eval_metrics_derive_rates_from_persisted_verdicts() {
 fn oracle_upgradeable_fraction_is_bounded_by_one() {
     let h = Harness::new();
     let f = h.add_file("a.rs", "fn caller() {}\n");
+    let sha = h.file_sha("a.rs");
     // The only low-confidence candidate (denominator = 1): a NameOnly edge the oracle upgraded.
     let e_low = h.add_edge(f, "u", 0, 1, "NameOnly", None);
     // An already-Exact edge the oracle placed to an EXTERNAL dep — NOT in the low-conf denominator.
     let e_exact = h.add_edge(f, "x", 1, 2, "Exact", None);
 
-    let mk = |edge, kind| EdgeOracleRow {
-        edge_id: edge,
-        file_sha: "s",
-        resolved_symbol_id: None,
-        scip_symbol: "s",
-        kind,
-    };
-    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(e_low, OracleResolutionKind::Upgrade))
-        .unwrap();
-    store::write_edge_oracle(
-        &h.conn,
-        TOOL,
-        VERSION,
-        &mk(e_exact, OracleResolutionKind::ResolvedExternal),
-    )
-    .unwrap();
+    h.write_verdict(e_low, &sha, None, "s", OracleResolutionKind::Upgrade);
+    h.write_verdict(e_exact, &sha, None, "s", OracleResolutionKind::ResolvedExternal);
 
     let m = super::oracle_eval_metrics(
         &h.conn,
@@ -1817,28 +1886,28 @@ fn parse_utf16_astral_character_shifts_offset_by_surrogate_width() {
 const OTHER_COMMIT: &str = "5ad1f1ce5ad1f1ce";
 const OTHER_WORKTREE: &str = "";
 
-/// Finding 1: `clear_edge_oracle_for_tool` must delete ONLY the active checkout's verdicts. With
-/// two worktrees' verdicts for the same `(tool, tool_version)` in one DB, clearing one leaves the
-/// other's intact (the clear is scoped via `edge_oracle -> edges -> files`).
+/// Finding 1 + #248: `clear_edge_oracle_for_tool` must delete ONLY the active checkout's verdicts.
+/// With two worktrees' verdicts for the same `(tool, tool_version)` in one DB, clearing one leaves
+/// the other's intact — the clear is scoped via a CONTENT join to the live edges in the active
+/// checkout (path + source/callee spans + edge_kind), not the old `edge_id` rowid subquery. The two
+/// checkouts use DISTINCT callee ranges so their content keys differ (a content-key COLLISION
+/// across checkouts is the intentional "same resolution → shared verdict" case, which would defeat
+/// the per-checkout isolation this test asserts).
 #[test]
-fn clear_edge_oracle_is_scoped_to_active_checkout() {
+fn clear_edge_oracle_for_tool_scopes_by_checkout_content() {
     let h = Harness::new();
-    // Active-checkout edge (commit_sha="" / worktree_id="") + a verdict.
-    let active_file = h.add_file("a.rs", "fn caller() { target(); }\n");
+    // Active-checkout edge + a verdict (real file sha so the scoped count tallies it).
+    let active_file = h.add_file("a.rs", "fn caller() { target(); other(); }\n");
+    let active_sha = h.file_sha("a.rs");
     let active_edge = h.add_edge(active_file, "target", 14, 20, "NameOnly", None);
-    // Another worktree's edge (same DB) + a verdict for the SAME tool/version.
+    // Another worktree's edge (same DB, same path, DIFFERENT callee range → distinct content key) +
+    // a verdict for the SAME tool/version.
     let other_file = h.add_file_in_scope("a.rs", OTHER_COMMIT, OTHER_WORKTREE);
-    let other_edge = h.add_edge(other_file, "target", 14, 20, "NameOnly", None);
+    let other_sha = h.file_sha_for_commit("a.rs", OTHER_COMMIT);
+    let other_edge = h.add_edge(other_file, "other", 22, 27, "NameOnly", None);
 
-    let mk = |edge| EdgeOracleRow {
-        edge_id: edge,
-        file_sha: "s",
-        resolved_symbol_id: None,
-        scip_symbol: "s",
-        kind: OracleResolutionKind::Upgrade,
-    };
-    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(active_edge)).unwrap();
-    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(other_edge)).unwrap();
+    h.write_verdict(active_edge, &active_sha, None, "s", OracleResolutionKind::Upgrade);
+    h.write_verdict(other_edge, &other_sha, None, "s", OracleResolutionKind::Upgrade);
     // Whole-table count (both worktrees) — the production count helper is intentionally scoped to
     // ONE checkout, so this test reads the raw total directly to prove the cross-checkout state.
     let total_rows = || -> i64 {
@@ -1864,6 +1933,107 @@ fn clear_edge_oracle_is_scoped_to_active_checkout() {
     );
 }
 
+/// #248 THE killer test: an `edge_oracle` verdict SURVIVES reindex for an UNCHANGED file. A reindex
+/// rewrites `edges_data` (DELETE + reinsert with NEW rowids); before the content-key fix the
+/// `ON DELETE CASCADE` FK wiped every verdict and the opt-in oracle never repopulated. Now the
+/// verdict is content-keyed with no FK, so the reindexed edge (same path + spans + edge_kind, same
+/// `files.sha256`) RE-ANCHORS the verdict by content — `count_edge_oracle_scoped` /
+/// `current_oracle_comparisons` still return it, re-projected onto the NEW edge id.
+#[test]
+fn edge_oracle_survives_reindex_for_unchanged_file() {
+    let h = Harness::new();
+    let f = h.add_file("a.rs", "fn caller() { target(); }\n");
+    let sha = h.file_sha("a.rs");
+    let target = h.add_symbol(f, "target", 3, 9);
+    // An Exact edge the heuristic resolved to `target`; the oracle CONTRADICTS it (so it shows up
+    // in `current_oracle_comparisons`, which keeps Contradict rows).
+    let edge_v1 = h.add_edge(f, "target", 14, 20, "Exact", Some(target));
+    h.write_verdict(
+        edge_v1,
+        &sha,
+        None,
+        "scip-rust cargo other 1.0 `target`().",
+        OracleResolutionKind::Contradict,
+    );
+
+    // Sanity before reindex: counted + surfaced in compare.
+    assert_eq!(
+        store::count_edge_oracle_scoped(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, None).unwrap(),
+        1,
+        "verdict counted before reindex"
+    );
+    assert_eq!(
+        store::current_oracle_comparisons(&h.conn, TOOL, VERSION, COMMIT, WORKTREE).unwrap().len(),
+        1
+    );
+    let physical_before: i64 =
+        h.conn.query_row("SELECT COUNT(*) FROM edge_oracle", [], |r| r.get(0)).unwrap();
+
+    // --- Simulate a reindex of the UNCHANGED file: DELETE the edge (rewriting edges_data) and
+    // re-insert the SAME edge content, which mints a NEW edges_data rowid. files.sha256 unchanged.
+    // ---
+    h.conn.execute("DELETE FROM edges WHERE id = ?1", params![edge_v1]).unwrap();
+    let edge_v2 = h.add_edge(f, "target", 14, 20, "Exact", Some(target));
+    assert_ne!(edge_v2, edge_v1, "reindex minted a new edge rowid");
+
+    // The verdict was NOT touched (no cascade) — same physical row count.
+    let physical_after: i64 =
+        h.conn.query_row("SELECT COUNT(*) FROM edge_oracle", [], |r| r.get(0)).unwrap();
+    assert_eq!(physical_after, physical_before, "no FK cascade wiped the verdict on reindex");
+
+    // And it RE-ANCHORS to the new edge by content key: still counted, still in compare, now keyed
+    // on the NEW edge id.
+    assert_eq!(
+        store::count_edge_oracle_scoped(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, None).unwrap(),
+        1,
+        "verdict still counted after reindex (re-anchored by content)"
+    );
+    let comparisons =
+        store::current_oracle_comparisons(&h.conn, TOOL, VERSION, COMMIT, WORKTREE).unwrap();
+    assert_eq!(comparisons.len(), 1, "verdict re-surfaces in compare after reindex");
+    assert_eq!(
+        comparisons[0].edge_id, edge_v2,
+        "the comparison is re-projected onto the LIVE edge id"
+    );
+    assert_eq!(
+        h.verdict(edge_v2).map(|(kind, _, _)| kind),
+        Some(OracleResolutionKind::Contradict.as_db_str().to_string()),
+        "the reindexed edge resolves the re-anchored verdict by content"
+    );
+}
+
+/// #248: a verdict for a CHANGED file (its `files.sha256` no longer matches the verdict's
+/// `file_sha`) is NOT counted — the scope join gates `files.sha256 = edge_oracle.file_sha`, so a
+/// stale verdict drops out of the metrics until the next run rewrites it.
+#[test]
+fn edge_oracle_stale_after_file_change_not_counted() {
+    let h = Harness::new();
+    let f = h.add_file("a.rs", "fn caller() { target(); }\n");
+    let sha = h.file_sha("a.rs");
+    let edge = h.add_edge(f, "target", 14, 20, "Exact", None);
+    h.write_verdict(edge, &sha, None, "scip x `target`().", OracleResolutionKind::Confirm);
+    assert_eq!(
+        store::count_edge_oracle_scoped(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, None).unwrap(),
+        1,
+        "current verdict counted"
+    );
+
+    // The file content changed: its recorded sha no longer matches the verdict's file_sha.
+    h.conn.execute("UPDATE files SET sha256 = 'changed-sha' WHERE id = ?1", params![f]).unwrap();
+
+    assert_eq!(
+        store::count_edge_oracle_scoped(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, None).unwrap(),
+        0,
+        "a changed file's verdict is stale → not counted (file_sha mismatch)"
+    );
+    assert!(
+        store::current_oracle_comparisons(&h.conn, TOOL, VERSION, COMMIT, WORKTREE)
+            .unwrap()
+            .is_empty(),
+        "a stale verdict does not surface in compare either"
+    );
+}
+
 /// Finding 2: a low-confidence edge in ANOTHER worktree must not inflate the current run's
 /// `oracle_upgradeable_fraction` denominator. With one upgraded low-conf edge in-scope and an
 /// extra unresolved low-conf edge out-of-scope, the scoped fraction is 1/1 = 1.0 (not 1/2).
@@ -1872,15 +2042,9 @@ fn upgradeable_fraction_denominator_is_scoped_to_active_checkout() {
     let h = Harness::new();
     // Active checkout: one NameOnly edge the oracle upgraded → numerator 1, denominator 1.
     let active = h.add_file("a.rs", "fn caller() {}\n");
+    let active_sha = h.file_sha("a.rs");
     let e_low = h.add_edge(active, "u", 0, 1, "NameOnly", None);
-    store::write_edge_oracle(&h.conn, TOOL, VERSION, &EdgeOracleRow {
-        edge_id: e_low,
-        file_sha: "s",
-        resolved_symbol_id: Some(1),
-        scip_symbol: "s",
-        kind: OracleResolutionKind::Upgrade,
-    })
-    .unwrap();
+    h.write_verdict(e_low, &active_sha, Some(1), "s", OracleResolutionKind::Upgrade);
 
     // Another worktree: an unresolved NameOnly candidate carrying a callee range, NO verdict. If
     // the denominator weren't scoped, it would count → fraction 1/2.
@@ -2026,40 +2190,28 @@ fn recall_gap_excludes_occurrences_in_unindexed_source_files() {
 #[test]
 fn verdict_counts_and_metrics_ignore_sibling_checkout_rows() {
     let h = Harness::new();
-    let mk = |edge, kind| EdgeOracleRow {
-        edge_id: edge,
-        file_sha: "s",
-        resolved_symbol_id: None,
-        scip_symbol: "s",
-        kind,
-    };
 
     // Active checkout A: one confirmed + one contradicted Exact edge → precision 1/2.
     let a_file = h.add_file("a.rs", "fn caller() {}\n");
+    let a_sha = h.file_sha("a.rs");
     let a_conf = h.add_edge(a_file, "c", 0, 1, "Exact", None);
     let a_contra = h.add_edge(a_file, "d", 1, 2, "Exact", None);
-    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(a_conf, OracleResolutionKind::Confirm))
-        .unwrap();
-    store::write_edge_oracle(
-        &h.conn,
-        TOOL,
-        VERSION,
-        &mk(a_contra, OracleResolutionKind::Contradict),
-    )
-    .unwrap();
+    h.write_verdict(a_conf, &a_sha, None, "s", OracleResolutionKind::Confirm);
+    h.write_verdict(a_contra, &a_sha, None, "s", OracleResolutionKind::Contradict);
 
-    // Sibling checkout B (same DB, same tool/version): TWO confirms + an upgrade. If A's counts
-    // leaked B's rows, A's precision would jump to 3/4 and its recall would change.
-    let b_file = h.add_file_in_scope("a.rs", OTHER_COMMIT, OTHER_WORKTREE);
+    // Sibling checkout B (same DB, same tool/version): TWO confirms + an upgrade. Uses a DISTINCT
+    // path ("b.rs") so the content keys never collide with A's (#248: the content key omits
+    // commit/worktree, so a same-path same-span edge in B would SHARE A's verdict row — that is the
+    // intentional "same resolution" case; this test asserts SCOPE isolation, so it keeps the
+    // populations physically distinct). If A's counts leaked B's rows, A's precision would jump.
+    let b_file = h.add_file_in_scope("b.rs", OTHER_COMMIT, OTHER_WORKTREE);
+    let b_sha = h.file_sha_for_commit("b.rs", OTHER_COMMIT);
     let b_conf1 = h.add_edge(b_file, "e", 0, 1, "Exact", None);
     let b_conf2 = h.add_edge(b_file, "f", 1, 2, "Exact", None);
     let b_up = h.add_edge(b_file, "g", 2, 3, "NameOnly", None);
-    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(b_conf1, OracleResolutionKind::Confirm))
-        .unwrap();
-    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(b_conf2, OracleResolutionKind::Confirm))
-        .unwrap();
-    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(b_up, OracleResolutionKind::Upgrade))
-        .unwrap();
+    h.write_verdict(b_conf1, &b_sha, None, "s", OracleResolutionKind::Confirm);
+    h.write_verdict(b_conf2, &b_sha, None, "s", OracleResolutionKind::Confirm);
+    h.write_verdict(b_up, &b_sha, None, "s", OracleResolutionKind::Upgrade);
 
     // A's metrics: precision = 1 confirm / (1 confirm + 1 contradict) = 0.5; recall over A's
     // covered call set (2 covered call occurrences) and 0 oracle-only = 2/2 = 1.0. The recall
@@ -2734,18 +2886,10 @@ fn name_only_recovery_rate_excludes_exact_upgrades() {
     // low-confidence denominator, so admitting it in the numerator (the old raw `counts.upgraded`)
     // would push the rate to 2/1 = 2.0.
     let e_exact = h.add_edge(f, "x", 1, 2, "Exact", None);
+    let sha = h.file_sha("a.rs");
 
-    let mk = |edge, kind| EdgeOracleRow {
-        edge_id: edge,
-        file_sha: "s",
-        resolved_symbol_id: None,
-        scip_symbol: "s",
-        kind,
-    };
-    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(e_low, OracleResolutionKind::Upgrade))
-        .unwrap();
-    store::write_edge_oracle(&h.conn, TOOL, VERSION, &mk(e_exact, OracleResolutionKind::Upgrade))
-        .unwrap();
+    h.write_verdict(e_low, &sha, None, "s", OracleResolutionKind::Upgrade);
+    h.write_verdict(e_exact, &sha, None, "s", OracleResolutionKind::Upgrade);
 
     let m = super::oracle_eval_metrics(
         &h.conn,
@@ -2808,14 +2952,7 @@ fn seed_verdict_full(
     // `edge_oracle_current_predicate` filters a dangling `resolved_symbol_id`.
     let resolved_symbol_id = in_corpus.then(|| h.add_symbol(f, "target", 3, 9));
     let edge = h.add_edge(f, "target", 14, 20, "NameOnly", None);
-    store::write_edge_oracle(&h.conn, TOOL, VERSION, &EdgeOracleRow {
-        edge_id: edge,
-        file_sha: &file_sha,
-        resolved_symbol_id,
-        scip_symbol,
-        kind,
-    })
-    .unwrap();
+    h.write_verdict(edge, &file_sha, resolved_symbol_id, scip_symbol, kind);
     (h, edge, file_sha, resolved_symbol_id)
 }
 
@@ -2914,14 +3051,13 @@ fn overlay_shadowed_def_verdict_is_not_surfaced() {
     let defs = h.add_file_in_scope("defs.rs", COMMIT, "");
     let resolved = h.add_symbol(defs, "target", 3, 9);
     let edge = h.add_edge(caller, "target", 14, 20, "NameOnly", None);
-    store::write_edge_oracle(&h.conn, TOOL, VERSION, &EdgeOracleRow {
-        edge_id: edge,
-        file_sha: "caller-sha",
-        resolved_symbol_id: Some(resolved),
-        scip_symbol: "scip x `target`().",
-        kind: OracleResolutionKind::Upgrade,
-    })
-    .unwrap();
+    h.write_verdict(
+        edge,
+        "caller-sha",
+        Some(resolved),
+        "scip x `target`().",
+        OracleResolutionKind::Upgrade,
+    );
 
     // Sanity: with no overlay, the committed def is in scope → the verdict surfaces.
     let before =
@@ -3013,14 +3149,13 @@ fn comparisons_return_current_contradictions_only() {
     // An Exact edge the heuristic resolved to `target`; the oracle CONTRADICTS it (points
     // elsewhere).
     let edge = h.add_edge(f, "target", 14, 20, "Exact", Some(target));
-    store::write_edge_oracle(&h.conn, TOOL, VERSION, &EdgeOracleRow {
-        edge_id: edge,
-        file_sha: &sha,
-        resolved_symbol_id: None,
-        scip_symbol: "scip-rust cargo other 1.0 `target`().",
-        kind: OracleResolutionKind::Contradict,
-    })
-    .unwrap();
+    h.write_verdict(
+        edge,
+        &sha,
+        None,
+        "scip-rust cargo other 1.0 `target`().",
+        OracleResolutionKind::Contradict,
+    );
 
     let comparisons =
         store::current_oracle_comparisons(&h.conn, TOOL, VERSION, COMMIT, WORKTREE).unwrap();
@@ -4334,14 +4469,7 @@ fn resolution_report_assembles_before_after_from_index() {
         .query_row("SELECT sha256 FROM files WHERE id = ?1", params![f], |r| r.get(0))
         .unwrap();
     let write = |edge: i64, kind: OracleResolutionKind, resolved: Option<i64>| {
-        store::write_edge_oracle(&h.conn, TOOL, VERSION, &EdgeOracleRow {
-            edge_id: edge,
-            file_sha: &file_sha,
-            resolved_symbol_id: resolved,
-            scip_symbol: "scip x `t`().",
-            kind,
-        })
-        .unwrap();
+        h.write_verdict(edge, &file_sha, resolved, "scip x `t`().", kind);
     };
     write(up, OracleResolutionKind::Upgrade, Some(target));
     write(ext, OracleResolutionKind::ResolvedExternal, None);

--- a/crates/rag-rat-core/src/index/query_api/gc.rs
+++ b/crates/rag-rat-core/src/index/query_api/gc.rs
@@ -100,11 +100,18 @@ impl IndexDatabase {
         )?;
         self.delete_staged_files_cascade()?;
         conn.execute_batch("DELETE FROM temp.staged_file_ids;")?;
-        // `edge_oracle` verdicts cascade away with their edges via the FK ON DELETE CASCADE (fired
-        // by the cascade above, with `PRAGMA foreign_keys=ON`). `oracle_runs`, however, is keyed by
-        // `(commit_sha, worktree_id)` directly — nothing cascades it — so a dead checkout's run
-        // rows would survive the file pruning. Prune them with the SAME live sets, so a run and the
+        // Since #248 `edge_oracle` is content-keyed with NO `edges_data` FK (it survives reindex,
+        // the moniker model), so the file/edge prune above no longer cascades verdicts
+        // away. Dangling verdicts are harmless for correctness — every read joins live
+        // `edges` by content key, so a verdict whose edge is gone never resolves — but the
+        // per-file incremental reindex (`remove_file_in_scope`) DELETEs a changed file's
+        // edges every pass and would otherwise let those orphan rows grow without bound.
+        // Sweep them GLOBALLY here (rows with no live edge in ANY scope; a checkout-scoped
+        // sweep would wrongly delete a sibling worktree's live verdict). `oracle_runs` is
+        // keyed by `(commit_sha, worktree_id)` directly — nothing cascades it either — so
+        // prune a dead checkout's run rows with the SAME live sets, so a run and the
         // edges it produced are dropped together.
+        oracle::prune_edge_oracle_without_live_edge(conn)?;
         oracle::prune_oracle_runs_outside_scope(conn, live_commits, live_worktrees)?;
         // Dictionary hygiene (#79, extended #224): drop `name_strings` values nothing references
         // any more. The pool has NO FKs by design (see the schema comment), so orphans

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1049,15 +1049,20 @@ pub(crate) fn apply_edge_string_interning(conn: &Connection) -> rusqlite::Result
                 DROP TABLE main.edges;
                 ",
             )?;
-            // Re-point edge_oracle's FK from the (now dropped) legacy table at edges_data. The
-            // rebuilt table keeps the V018 shape; verdict rows survive byte-for-byte.
+            // Re-point edge_oracle's FK from the (now dropped) legacy table at edges_data — ONLY
+            // for the OLD `edge_id`-keyed V018 shape (the FK points at
+            // `edges`/`edges_data`). On a fresh `apply`, V018's `apply_oracle_tables`
+            // already created the V031 content-anchored shape (cols `source_path`, NO
+            // FK), so there is nothing to re-point and copying its 13 columns
+            // into the 8-column legacy template below would fail (#248). Skip when `source_path`
+            // exists — V031 owns the final shape.
             let has_oracle: bool = conn.query_row(
                 "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = \
                  'edge_oracle')",
                 [],
                 |row| row.get(0),
             )?;
-            if has_oracle {
+            if has_oracle && !column_exists(conn, "edge_oracle", "source_path")? {
                 conn.execute_batch(
                     "
                     ALTER TABLE main.edge_oracle RENAME TO edge_oracle_legacy;

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -549,6 +549,14 @@ pub(crate) fn apply_edge_callee_byte_range(conn: &Connection) -> rusqlite::Resul
 pub(crate) fn apply_oracle_tables(conn: &Connection) -> rusqlite::Result<()> {
     // SCIP-oracle side tables (#68). Greenfield, STRICT per repo convention.
     //
+    // INVARIANT (load-bearing, #248): every oracle-DERIVED persisted table here is enumerated in
+    // `schema::ORACLE_PERSISTED_TABLES` and MUST survive reindex — content-keyed with NO
+    // reindex-cascading FK to a volatile parent (`schema::REINDEX_VOLATILE_PARENTS`); reads join
+    // the live parents so a dangling row never resolves. A NEW oracle-derived table created
+    // here must be added to that const, which forces it through the
+    // `oracle_persisted_tables_have_no_ reindex_cascading_fk` trip-wire. See the const's doc
+    // comment for the full rationale + the `logical_symbol_monikers` precedent.
+    //
     // `oracle_runs`: one row per oracle pass (a `.scip` consumed against a checkout). `stats_json`
     // is an opaque per-run `OracleReport` snapshot, suffixed `_json` per the naming convention.
     //

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -557,6 +557,26 @@ pub(crate) fn apply_oracle_tables(conn: &Connection) -> rusqlite::Result<()> {
     // can diff the two and `compare_graph_to_scip` (#69) has both. INVARIANT: writing an
     // `edge_oracle` row must not UPDATE `edges.resolution` / `edges.to_symbol_id`.
     //
+    // CONTENT-ANCHORED (V031, #248): a verdict is keyed by the edge's CONTENT identity, NOT the
+    // volatile `edges_data.id` rowid, and there is NO FK to `edges_data`. The original V018 shape
+    // keyed on `edge_id` with `FOREIGN KEY(edge_id) REFERENCES edges_data(id) ON DELETE CASCADE` —
+    // but every reindex rewrites `edges_data` (full rebuild + `remove_file_in_scope`), so the
+    // cascade wiped EVERY verdict and the opt-in oracle never repopulated (it does not auto-run).
+    // This mirrors `logical_symbol_monikers`: a content key + no reindex-cascading FK, with reads
+    // joining LIVE `edges` so a dangling row never resolves. An UNCHANGED file (same
+    // `files.sha256`) re-anchors its verdict to the reindexed edge for free; a CHANGED file's
+    // sha differs so its verdict no longer matches (stale → not surfaced/counted, swept by the
+    // next run's clear / gc).
+    //
+    // Content key = `(tool, tool_version, source_path, source_start_byte, source_end_byte,
+    // callee_start_byte, callee_end_byte, edge_kind)`. Measured UNIQUE over the resolvable
+    // (non-NULL callee range) edge population the oracle rows — the call SITE span + the callee
+    // span
+    // + the edge kind disambiguate (a `calls_name` and a `references_type` on the same identifier
+    // token differ in `edge_kind`). `edge_kind` is stored as TEXT (resolved from
+    // `edges_data.edge_kind_id` via `name_strings` at write time), NOT the interned id (which is
+    // not guaranteed stable across reindex).
+    //
     // Staleness key is `(file_sha, tool, tool_version)` (content addressing, exactly like the
     // embedding `input_hash`): a row is valid iff the file bytes it was computed against are
     // unchanged. `file_sha` is the `files.sha256` of the edge's source file at compute time, so a
@@ -586,7 +606,12 @@ pub(crate) fn apply_oracle_tables(conn: &Connection) -> rusqlite::Result<()> {
         ) STRICT;
 
         CREATE TABLE IF NOT EXISTS edge_oracle(
-            edge_id INTEGER NOT NULL,
+            source_path TEXT NOT NULL,
+            source_start_byte INTEGER NOT NULL,
+            source_end_byte INTEGER NOT NULL,
+            callee_start_byte INTEGER NOT NULL,
+            callee_end_byte INTEGER NOT NULL,
+            edge_kind TEXT NOT NULL,
             file_sha TEXT NOT NULL,
             tool TEXT NOT NULL,
             tool_version TEXT NOT NULL,
@@ -594,19 +619,22 @@ pub(crate) fn apply_oracle_tables(conn: &Connection) -> rusqlite::Result<()> {
             scip_symbol TEXT NOT NULL,
             kind TEXT NOT NULL,
             computed_at INTEGER NOT NULL,
-            PRIMARY KEY(edge_id, tool, tool_version),
-            -- A verdict is meaningless once its edge is gone. The full rebuild and
-            -- `remove_file_in_scope` delete + reinsert edges with new ids and recompute the \
-         oracle,
-            -- so cascading old verdicts away (rather than orphaning them, where status/eval would
-            -- keep counting them) is correct. `PRAGMA foreign_keys=ON` is set, so this fires.
-            FOREIGN KEY(edge_id) REFERENCES edges_data(id) ON DELETE CASCADE
+            -- Content key (#248): reindex-stable, no rowid. NO FK to edges_data — the read join to
+            -- live edges (by this key + `files.sha256 = file_sha`) is what filters dangling rows,
+            -- exactly like the moniker model.
+            PRIMARY KEY(
+                tool, tool_version, source_path,
+                source_start_byte, source_end_byte,
+                callee_start_byte, callee_end_byte, edge_kind
+            )
         ) STRICT;
 
         CREATE INDEX IF NOT EXISTS idx_edge_oracle_staleness
             ON edge_oracle(file_sha, tool, tool_version);
         CREATE INDEX IF NOT EXISTS idx_edge_oracle_symbol
             ON edge_oracle(resolved_symbol_id);
+        CREATE INDEX IF NOT EXISTS idx_edge_oracle_anchor
+            ON edge_oracle(source_path, callee_start_byte, callee_end_byte, edge_kind);
         ",
     )?;
     Ok(())
@@ -1124,6 +1152,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_028_ID => Some(28),
             MIGRATION_029_ID => Some(29),
             MIGRATION_030_ID => Some(30),
+            MIGRATION_031_ID => Some(31),
             _ => None,
         })
         .max()
@@ -1163,6 +1192,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_028_ID
             | MIGRATION_029_ID
             | MIGRATION_030_ID
+            | MIGRATION_031_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1199,6 +1229,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_028_ID => migration.checksum != MIGRATION_028_CHECKSUM,
         MIGRATION_029_ID => migration.checksum != MIGRATION_029_CHECKSUM,
         MIGRATION_030_ID => migration.checksum != MIGRATION_030_CHECKSUM,
+        MIGRATION_031_ID => migration.checksum != MIGRATION_031_CHECKSUM,
         _ => false,
     }
 }
@@ -1371,6 +1402,83 @@ pub(crate) fn apply_clone_fingerprint_tables(conn: &Connection) -> rusqlite::Res
 /// is a no-op when the column already exists.
 pub(crate) fn apply_clone_refinements_lcs_sampled(conn: &Connection) -> rusqlite::Result<()> {
     add_column_if_missing(conn, "clone_refinements", "lcs_sampled", "INTEGER NOT NULL DEFAULT 0")?;
+    Ok(())
+}
+
+/// V031 (#248): rebuild `edge_oracle` content-anchored — drop the `edges_data` FK + the volatile
+/// `edge_id` PK, key by the edge's CONTENT identity instead, so verdicts SURVIVE reindex.
+///
+/// THE BUG: V018 keyed `edge_oracle` on `edge_id` with `FOREIGN KEY(edge_id) REFERENCES
+/// edges_data(id) ON DELETE CASCADE`. Every reindex rewrites `edges_data` (full rebuild +
+/// `remove_file_in_scope`), so the cascade wiped every verdict; the oracle is opt-in (no auto-run)
+/// so it never repopulated. The fix mirrors `logical_symbol_monikers`: content key + no
+/// reindex-cascading FK, reads join LIVE edges so a dangling row never resolves.
+///
+/// DATA: the rebuild RENAME→CREATE→DROP **drops** any legacy verdicts. A DB where the oracle ran
+/// but hasn't reindexed has rows, but the legacy rows lack the content-key columns and back-filling
+/// them via `edge_id → edges_data` is lossy (the edges may already be gone). `edge_oracle` is
+/// ephemeral + opt-in; the next `oracle run` repopulates with the new shape. We accept the one-time
+/// drop — NO INSERT SELECT.
+///
+/// SQLite can't drop a FK in place, so this is a table REBUILD using the V020 recipe: `PRAGMA
+/// foreign_keys=OFF` OUTSIDE `BEGIN IMMEDIATE`, RENAME→CREATE→DROP, recreate indexes, ROLLBACK on
+/// error, then `COMMIT; PRAGMA foreign_keys=ON`.
+///
+/// IDEMPOTENT: a fresh DB ran the NEW `apply_oracle_tables` shape at V018, so V031 must be a no-op
+/// there — short-circuit when `edge_oracle` already has the content-key columns (or no
+/// `edges_data` FK). `migrate_forward` only replays unapplied steps, but a re-run after a partial
+/// apply must still be safe, hence the guard.
+pub(crate) fn apply_edge_oracle_content_anchor(conn: &Connection) -> rusqlite::Result<()> {
+    // Short-circuit if already on the content-anchored shape (fresh DB at V018, or a re-run): the
+    // new table has `source_path` and no `edges_data` FK. Detect via the column; the FK-list check
+    // is the belt-and-suspenders companion (an empty foreign_key_list == no cascade to wipe).
+    if column_exists(conn, "edge_oracle", "source_path")? {
+        return Ok(());
+    }
+
+    conn.execute_batch("PRAGMA foreign_keys = OFF; BEGIN IMMEDIATE;")?;
+    let result = (|| -> rusqlite::Result<()> {
+        conn.execute_batch(
+            "
+            ALTER TABLE main.edge_oracle RENAME TO edge_oracle_legacy;
+            CREATE TABLE main.edge_oracle(
+                source_path TEXT NOT NULL,
+                source_start_byte INTEGER NOT NULL,
+                source_end_byte INTEGER NOT NULL,
+                callee_start_byte INTEGER NOT NULL,
+                callee_end_byte INTEGER NOT NULL,
+                edge_kind TEXT NOT NULL,
+                file_sha TEXT NOT NULL,
+                tool TEXT NOT NULL,
+                tool_version TEXT NOT NULL,
+                resolved_symbol_id INTEGER,
+                scip_symbol TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                computed_at INTEGER NOT NULL,
+                PRIMARY KEY(
+                    tool, tool_version, source_path,
+                    source_start_byte, source_end_byte,
+                    callee_start_byte, callee_end_byte, edge_kind
+                )
+            ) STRICT;
+            -- NO INSERT SELECT: the legacy rows lack the content-key columns; we accept the
+            -- one-time verdict drop (ephemeral/opt-in; the next oracle run repopulates).
+            DROP TABLE main.edge_oracle_legacy;
+            CREATE INDEX IF NOT EXISTS idx_edge_oracle_staleness
+                ON edge_oracle(file_sha, tool, tool_version);
+            CREATE INDEX IF NOT EXISTS idx_edge_oracle_symbol
+                ON edge_oracle(resolved_symbol_id);
+            CREATE INDEX IF NOT EXISTS idx_edge_oracle_anchor
+                ON edge_oracle(source_path, callee_start_byte, callee_end_byte, edge_kind);
+            ",
+        )?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = conn.execute_batch("ROLLBACK; PRAGMA foreign_keys = ON;");
+        return result;
+    }
+    conn.execute_batch("COMMIT; PRAGMA foreign_keys = ON;")?;
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -18,14 +18,17 @@ pub const LATEST_SCHEMA_VERSION: u32 = 31;
 /// (#248) after its `FOREIGN KEY(edge_id) REFERENCES edges_data(id) ON DELETE CASCADE` silently
 /// wiped every verdict on the first reindex.
 ///
-/// The structural trip-wire `oracle_persisted_tables_have_no_reindex_cascading_fk` asserts every
-/// table here has no `ON DELETE CASCADE`/`RESTRICT` FK to a volatile parent — the exact check that
-/// would have caught the original `edge_oracle` FK. A NEW oracle-derived table is FORCED to opt in
-/// here (and thus to satisfy the trip-wire), so the next agent can't add a CASCADE-on-reindex table
-/// without the guard catching it.
-// Consumed only by the `oracle_persisted_tables_have_no_reindex_cascading_fk` trip-wire
-// (#[cfg(test)]), so the non-test lib build sees no reader; it is intentionally a durable
-// schema-invariant declaration.
+/// The ENFORCING structural trip-wire `no_table_has_a_reindex_cascading_fk_to_a_volatile_parent`
+/// scans EVERY table in `sqlite_master` (not this list) and asserts none carries an `ON DELETE
+/// CASCADE`/`RESTRICT` FK to a volatile parent except the explicit [`CASCADE_FK_ALLOWLIST`] — the
+/// exact check that would have caught the original `edge_oracle` FK, and which catches a future
+/// oracle/durable table automatically even if it forgets to opt into any list. This const remains
+/// the canonical DECLARATION of which outputs must survive reindex — the same trip-wire asserts
+/// each listed table exists, and the lifecycle guard
+/// `oracle_outputs_survive_full_and_incremental_reindex` exercises their survival behaviorally
+/// across both reindex shapes.
+// Consumed only by the reindex trip-wires (#[cfg(test)]), so the non-test lib build sees no reader;
+// it is intentionally a durable schema-invariant declaration.
 #[cfg_attr(not(test), allow(dead_code))]
 pub(crate) const ORACLE_PERSISTED_TABLES: &[&str] =
     &["edge_oracle", "logical_symbol_monikers", "oracle_runs"];
@@ -38,6 +41,37 @@ pub(crate) const ORACLE_PERSISTED_TABLES: &[&str] =
 #[cfg_attr(not(test), allow(dead_code))]
 pub(crate) const REINDEX_VOLATILE_PARENTS: &[&str] =
     &["edges_data", "symbols", "logical_symbols", "files"];
+
+/// The `(child_table, volatile_parent)` pairs that LEGITIMATELY carry an `ON DELETE
+/// CASCADE`/`RESTRICT` FK to a reindex-volatile parent ([`REINDEX_VOLATILE_PARENTS`]) — every one a
+/// table that is *rebuilt with its parent* on every reindex and holds NO oracle/durable state, so
+/// the cascade is the desired freshness behavior (the child must die with the parent row that
+/// produced it), not the #248 data-loss bug.
+///
+/// INVARIANT (#248): this is the EXPLICIT opt-out the enforcing trip-wire
+/// [`no_table_has_a_reindex_cascading_fk_to_a_volatile_parent`] consults. The trip-wire scans EVERY
+/// table in `sqlite_master` (not a hand-maintained list), so a NEW table that adds a cascading FK
+/// to a volatile parent FAILS the test automatically unless it is added here WITH a reason. Never
+/// allowlist a table that holds oracle/durable state — that re-creates the #248 bug; re-anchor such
+/// a table on a content key + drop the FK instead.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) const CASCADE_FK_ALLOWLIST: &[(&str, &str)] = &[
+    // `chunks` are per-file text/embedding inputs, re-chunked from scratch when a file is
+    // reindexed.
+    ("chunks", "files"),
+    // `edges_data` is the heuristic graph itself, rebuilt per-file (it IS a volatile parent).
+    ("edges_data", "files"),
+    // `symbols` are rebuilt per-file (AUTOINCREMENT rowids re-mint on reindex).
+    ("symbols", "files"),
+    // Logical-symbol grouping is rebuilt wholesale from the live symbols on every pass.
+    ("logical_symbol_members", "symbols"),
+    ("logical_symbol_members", "logical_symbols"),
+    // Per-symbol derived facts, rebuilt with the symbols they describe.
+    ("symbol_facts", "symbols"),
+    // Clone-detection fingerprints + their inverted-index postings, rebuilt with the symbols.
+    ("symbol_fingerprints", "symbols"),
+    ("symbol_token_postings", "symbols"),
+];
 
 const DIRTY_MIGRATION_ID: &str = "__dirty__";
 const MIGRATION_001_ID: &str = "001_sqlite_storage_baseline";

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use migrations::*;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 30;
+pub const LATEST_SCHEMA_VERSION: u32 = 31;
 const DIRTY_MIGRATION_ID: &str = "__dirty__";
 const MIGRATION_001_ID: &str = "001_sqlite_storage_baseline";
 const MIGRATION_001_CHECKSUM: &str = "sha256:rag-rat-sqlite-baseline-v1";
@@ -131,6 +131,10 @@ const MIGRATION_030_ID: &str = "030_clone_refinements_lcs_sampled";
 const MIGRATION_030_CHECKSUM: &str = "sha256:rag-rat-clone-refinements-lcs-sampled-v30";
 const MIGRATION_030_DESCRIPTION: &str =
     "Add clone_refinements.lcs_sampled (additive; heals indexes already at V029)";
+const MIGRATION_031_ID: &str = "031_edge_oracle_content_anchor";
+const MIGRATION_031_CHECKSUM: &str = "sha256:rag-rat-edge-oracle-content-anchor-v31";
+const MIGRATION_031_DESCRIPTION: &str = "Rebuild edge_oracle content-anchored (drop edges_data FK \
+                                         + edge_id PK) so verdicts survive reindex (#248)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -410,6 +414,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_030_CHECKSUM,
         description: MIGRATION_030_DESCRIPTION,
         apply: apply_clone_refinements_lcs_sampled,
+    },
+    Migration {
+        id: MIGRATION_031_ID,
+        checksum: MIGRATION_031_CHECKSUM,
+        description: MIGRATION_031_DESCRIPTION,
+        apply: apply_edge_oracle_content_anchor,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -6,6 +6,39 @@ use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
 pub const LATEST_SCHEMA_VERSION: u32 = 31;
+
+/// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
+/// reindex.
+///
+/// INVARIANT (load-bearing, #248): oracle-derived outputs MUST survive reindex. They achieve this
+/// by being **content-keyed with NO reindex-cascading FK** to a reindex-volatile parent
+/// ([`REINDEX_VOLATILE_PARENTS`]); their reads JOIN the live parents by that content key, so a
+/// dangling row (whose parent was rewritten) simply never resolves rather than being CASCADE-wiped.
+/// This is the model `logical_symbol_monikers` shipped (#70) and `edge_oracle` was retrofitted to
+/// (#248) after its `FOREIGN KEY(edge_id) REFERENCES edges_data(id) ON DELETE CASCADE` silently
+/// wiped every verdict on the first reindex.
+///
+/// The structural trip-wire `oracle_persisted_tables_have_no_reindex_cascading_fk` asserts every
+/// table here has no `ON DELETE CASCADE`/`RESTRICT` FK to a volatile parent — the exact check that
+/// would have caught the original `edge_oracle` FK. A NEW oracle-derived table is FORCED to opt in
+/// here (and thus to satisfy the trip-wire), so the next agent can't add a CASCADE-on-reindex table
+/// without the guard catching it.
+// Consumed only by the `oracle_persisted_tables_have_no_reindex_cascading_fk` trip-wire
+// (#[cfg(test)]), so the non-test lib build sees no reader; it is intentionally a durable
+// schema-invariant declaration.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) const ORACLE_PERSISTED_TABLES: &[&str] =
+    &["edge_oracle", "logical_symbol_monikers", "oracle_runs"];
+
+/// The parent tables a reindex REWRITES (full rebuild and/or per-file `remove_file_in_scope`), so
+/// an `ON DELETE CASCADE`/`RESTRICT` FK from an oracle-derived table to one of these wipes the
+/// oracle output on every reindex — the #248 bug class. The trip-wire forbids exactly such an FK.
+/// `files` is rowid-keyed and rewritten per file; `edges_data` / `symbols` / `logical_symbols` are
+/// all rebuilt (DELETE-all + reinsert) on a full reindex.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) const REINDEX_VOLATILE_PARENTS: &[&str] =
+    &["edges_data", "symbols", "logical_symbols", "files"];
+
 const DIRTY_MIGRATION_ID: &str = "__dirty__";
 const MIGRATION_001_ID: &str = "001_sqlite_storage_baseline";
 const MIGRATION_001_CHECKSUM: &str = "sha256:rag-rat-sqlite-baseline-v1";

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -10603,6 +10603,7 @@ fn v022_forward_migrate_adds_artifacts_to_an_older_index() {
         DELETE FROM schema_version WHERE id = '028_intern_symbol_qualified_names';
         DELETE FROM schema_version WHERE id = '029_clone_fingerprint_tables';
         DELETE FROM schema_version WHERE id = '030_clone_refinements_lcs_sampled';
+        DELETE FROM schema_version WHERE id = '031_edge_oracle_content_anchor';
         ",
     )
     .unwrap();
@@ -10741,18 +10742,20 @@ fn v028_forward_migrate_interns_and_drops_the_inline_column() {
         ",
     )
     .unwrap();
-    // 3. Drop the V028, V029, and V030 ledger rows so the schema reads Older and the migration
-    //    replays.
+    // 3. Drop the V028..V031 ledger rows so the schema reads Older and the migration replays. Every
+    //    later row must go — `known_version` reads the MAX applied version, so leaving any (e.g.
+    //    V031) would keep the schema Compatible and skip the forward migrate.
     conn.execute_batch(
         "DELETE FROM schema_version WHERE id = '028_intern_symbol_qualified_names';
          DELETE FROM schema_version WHERE id = '029_clone_fingerprint_tables';
-         DELETE FROM schema_version WHERE id = '030_clone_refinements_lcs_sampled';",
+         DELETE FROM schema_version WHERE id = '030_clone_refinements_lcs_sampled';
+         DELETE FROM schema_version WHERE id = '031_edge_oracle_content_anchor';",
     )
     .unwrap();
     assert_eq!(
         schema::status(&conn).unwrap().state,
         schema::SchemaState::Older,
-        "removing the V028+V029+V030 ledger rows makes the pre-V028 shape Older"
+        "removing the V028..V031 ledger rows makes the pre-V028 shape Older"
     );
 
     // --- Forward-migrate ---

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -12464,35 +12464,20 @@ fn migration_031_edge_oracle_no_fk_content_key() {
     assert_eq!(remaining, 1, "edge_oracle survives a full edges_data delete (no cascade)");
 }
 
-/// STRUCTURAL TRIP-WIRE (#248): the "can't happen again" guard for the whole bug CLASS. Every
-/// oracle-DERIVED persisted table (`schema::ORACLE_PERSISTED_TABLES`) is introspected via
-/// `PRAGMA foreign_key_list`, and NONE may carry an `ON DELETE CASCADE` (or `RESTRICT`) FK to a
-/// reindex-VOLATILE parent (`schema::REINDEX_VOLATILE_PARENTS`: `edges_data`, `symbols`,
-/// `logical_symbols`, the rowid-keyed `files`). This is the exact check that would have FAILED on
-/// the original `edge_oracle` `FOREIGN KEY(edge_id) REFERENCES edges_data(id) ON DELETE CASCADE` —
-/// the FK that silently wiped every verdict on the first reindex. A new oracle-derived table is
-/// forced to opt into the const, so it cannot reintroduce the bug without this test catching it.
-/// (If this test ever fails on a CURRENT table, that is ANOTHER instance of the #248 bug to FIX —
-/// re-anchor the table on a content key + drop the FK — not a test to relax.)
-#[test]
-fn oracle_persisted_tables_have_no_reindex_cascading_fk() {
-    let conn = rusqlite::Connection::open_in_memory().expect("open");
-    crate::index::schema::apply(&conn).expect("apply reaches LATEST");
-
-    for &table in crate::index::schema::ORACLE_PERSISTED_TABLES {
-        // The table must exist (a typo in the const would otherwise silently skip the check).
-        let exists: i64 = conn
-            .query_row(
-                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
-                params![table],
-                |r| r.get(0),
-            )
+/// Every `ON DELETE CASCADE`/`RESTRICT` FK to a reindex-volatile parent, as
+/// `(child_table, parent_table, on_delete)`, scanned from a FULLY-MIGRATED DB. Enumerates EVERY
+/// table in `sqlite_master` (not a hand-maintained list) so a new offender is caught automatically.
+fn cascading_fks_to_volatile_parents(conn: &rusqlite::Connection) -> Vec<(String, String, String)> {
+    let tables: Vec<String> = {
+        let mut stmt = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
             .unwrap();
-        assert_eq!(exists, 1, "ORACLE_PERSISTED_TABLES lists `{table}` but it does not exist");
-
+        stmt.query_map([], |r| r.get::<_, String>(0)).unwrap().map(Result::unwrap).collect()
+    };
+    let mut found = Vec::new();
+    for table in tables {
         // `pragma_foreign_key_list` columns: `id`, `seq`, `table` (parent), `from`, `to`,
-        // `on_update`, `on_delete`, `match`. A CASCADE/RESTRICT FK to a volatile parent is the #248
-        // bug shape.
+        // `on_update`, `on_delete`, `match`.
         let mut stmt = conn
             .prepare(&format!(
                 "SELECT \"table\", on_delete FROM pragma_foreign_key_list('{table}')"
@@ -12501,22 +12486,97 @@ fn oracle_persisted_tables_have_no_reindex_cascading_fk() {
         let fks: Vec<(String, String)> = stmt
             .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))
             .unwrap()
-            .map(|r| r.unwrap())
+            .map(Result::unwrap)
             .collect();
-
         for (parent, on_delete) in fks {
             let is_volatile_parent =
                 crate::index::schema::REINDEX_VOLATILE_PARENTS.contains(&parent.as_str());
             let is_cascading = matches!(on_delete.to_uppercase().as_str(), "CASCADE" | "RESTRICT");
-            assert!(
-                !(is_volatile_parent && is_cascading),
-                "oracle-derived table `{table}` has an ON DELETE {on_delete} FK to the \
-                 reindex-volatile parent `{parent}` — that wipes the oracle output on every \
-                 reindex (the #248 bug). Re-anchor `{table}` on a content key + drop the FK; \
-                 reads must join the live parent so dangling rows never resolve.",
-            );
+            if is_volatile_parent && is_cascading {
+                found.push((table.clone(), parent, on_delete));
+            }
         }
     }
+    found
+}
+
+/// ENFORCING STRUCTURAL TRIP-WIRE (#248): the "can't happen again" guard for the whole bug CLASS,
+/// rewritten to ENUMERATE EVERY table in a fully-migrated DB (via
+/// [`cascading_fks_to_volatile_parents`]) rather than iterate a hand-maintained list. It asserts NO
+/// table carries an `ON DELETE CASCADE`/`RESTRICT` FK to a reindex-VOLATILE parent
+/// (`schema::REINDEX_VOLATILE_PARENTS`: `edges_data`, `symbols`, `logical_symbols`, the rowid-keyed
+/// `files`) EXCEPT the explicit `schema::CASCADE_FK_ALLOWLIST` of `(child, parent)` pairs that are
+/// rebuilt-with-their-parent and hold no oracle/durable state.
+///
+/// This is the exact check that would have FAILED on the original `edge_oracle`
+/// `FOREIGN KEY(edge_id) REFERENCES edges_data(id) ON DELETE CASCADE` — the FK that silently wiped
+/// every verdict on the first reindex. Crucially, because it scans `sqlite_master` (not
+/// `ORACLE_PERSISTED_TABLES`), a FUTURE oracle/durable table that forgets to opt into any list
+/// still FAILS automatically: the author must EITHER content-anchor it (no cascading FK) OR
+/// consciously add it to the allowlist with a reason — and the allowlist is explicitly NOT for
+/// durable state.
+///
+/// If this fails on a NEW table that genuinely holds oracle/durable output, that is ANOTHER
+/// instance of the #248 bug to FIX (re-anchor on a content key + drop the FK), not to allowlist.
+#[test]
+fn no_table_has_a_reindex_cascading_fk_to_a_volatile_parent() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    crate::index::schema::apply(&conn).expect("apply reaches LATEST");
+
+    // Every declared oracle-derived table exists and is implicitly covered by the scan below (a
+    // typo in the const would otherwise drift from reality unnoticed). The const stays the
+    // canonical declaration of which outputs MUST survive reindex; the scan is what ENFORCES
+    // the FK shape.
+    for &table in crate::index::schema::ORACLE_PERSISTED_TABLES {
+        let exists: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
+                params![table],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(exists, 1, "ORACLE_PERSISTED_TABLES lists `{table}` but it does not exist");
+    }
+
+    let disallowed: Vec<(String, String, String)> = cascading_fks_to_volatile_parents(&conn)
+        .into_iter()
+        .filter(|(table, parent, _)| {
+            !crate::index::schema::CASCADE_FK_ALLOWLIST.contains(&(table.as_str(), parent.as_str()))
+        })
+        .collect();
+
+    assert!(
+        disallowed.is_empty(),
+        "table(s) carry a reindex-cascading FK to a volatile parent (the #248 bug class): \
+         {disallowed:?}\noracle/durable outputs MUST survive reindex — content-key + no \
+         reindex-cascading FK; reads join the live parent so dangling rows never resolve. If a \
+         flagged table is genuinely ephemeral-with-its-parent (rebuilt with it, no durable \
+         state), add (table, parent) to schema::CASCADE_FK_ALLOWLIST with a reason. Never \
+         allowlist a table that holds oracle/durable state.",
+    );
+
+    // NEGATIVE SUB-ASSERTION (the trip-wire has teeth): a synthetic table WITH a cascading FK to a
+    // volatile parent (`edges_data`) IS flagged by the scan — proving a future offender would not
+    // slip through. Built on its own connection so the production scan above stays clean.
+    let probe = rusqlite::Connection::open_in_memory().expect("open probe");
+    crate::index::schema::apply(&probe).expect("apply reaches LATEST");
+    probe
+        .execute_batch(
+            "CREATE TABLE __trip_wire_probe__(
+                 id INTEGER PRIMARY KEY,
+                 x INTEGER,
+                 FOREIGN KEY(x) REFERENCES edges_data(id) ON DELETE CASCADE
+             );",
+        )
+        .unwrap();
+    let probe_hits = cascading_fks_to_volatile_parents(&probe);
+    assert!(
+        probe_hits.iter().any(|(t, p, od)| t == "__trip_wire_probe__"
+            && p == "edges_data"
+            && od.eq_ignore_ascii_case("CASCADE")),
+        "the scan must flag a synthetic CASCADE FK to edges_data — otherwise the trip-wire is \
+         toothless; got {probe_hits:?}",
+    );
 }
 
 #[test]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -12464,6 +12464,61 @@ fn migration_031_edge_oracle_no_fk_content_key() {
     assert_eq!(remaining, 1, "edge_oracle survives a full edges_data delete (no cascade)");
 }
 
+/// STRUCTURAL TRIP-WIRE (#248): the "can't happen again" guard for the whole bug CLASS. Every
+/// oracle-DERIVED persisted table (`schema::ORACLE_PERSISTED_TABLES`) is introspected via
+/// `PRAGMA foreign_key_list`, and NONE may carry an `ON DELETE CASCADE` (or `RESTRICT`) FK to a
+/// reindex-VOLATILE parent (`schema::REINDEX_VOLATILE_PARENTS`: `edges_data`, `symbols`,
+/// `logical_symbols`, the rowid-keyed `files`). This is the exact check that would have FAILED on
+/// the original `edge_oracle` `FOREIGN KEY(edge_id) REFERENCES edges_data(id) ON DELETE CASCADE` —
+/// the FK that silently wiped every verdict on the first reindex. A new oracle-derived table is
+/// forced to opt into the const, so it cannot reintroduce the bug without this test catching it.
+/// (If this test ever fails on a CURRENT table, that is ANOTHER instance of the #248 bug to FIX —
+/// re-anchor the table on a content key + drop the FK — not a test to relax.)
+#[test]
+fn oracle_persisted_tables_have_no_reindex_cascading_fk() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    crate::index::schema::apply(&conn).expect("apply reaches LATEST");
+
+    for &table in crate::index::schema::ORACLE_PERSISTED_TABLES {
+        // The table must exist (a typo in the const would otherwise silently skip the check).
+        let exists: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
+                params![table],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(exists, 1, "ORACLE_PERSISTED_TABLES lists `{table}` but it does not exist");
+
+        // `pragma_foreign_key_list` columns: `id`, `seq`, `table` (parent), `from`, `to`,
+        // `on_update`, `on_delete`, `match`. A CASCADE/RESTRICT FK to a volatile parent is the #248
+        // bug shape.
+        let mut stmt = conn
+            .prepare(&format!(
+                "SELECT \"table\", on_delete FROM pragma_foreign_key_list('{table}')"
+            ))
+            .unwrap();
+        let fks: Vec<(String, String)> = stmt
+            .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+
+        for (parent, on_delete) in fks {
+            let is_volatile_parent =
+                crate::index::schema::REINDEX_VOLATILE_PARENTS.contains(&parent.as_str());
+            let is_cascading = matches!(on_delete.to_uppercase().as_str(), "CASCADE" | "RESTRICT");
+            assert!(
+                !(is_volatile_parent && is_cascading),
+                "oracle-derived table `{table}` has an ON DELETE {on_delete} FK to the \
+                 reindex-volatile parent `{parent}` — that wipes the oracle output on every \
+                 reindex (the #248 bug). Re-anchor `{table}` on a content key + drop the FK; \
+                 reads must join the live parent so dangling rows never resolve.",
+            );
+        }
+    }
+}
+
 #[test]
 fn indexing_writes_baseline_fingerprints_for_functions() {
     let root = unique_temp_root();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -10497,13 +10497,12 @@ fn open_under_a_held_write_lock_migrates_older_schema_without_deadlock() {
         let db = IndexDatabase::rebuild(&config).unwrap();
         db.storage
             .connection()
-            .execute("DELETE FROM schema_version WHERE id = '030_clone_refinements_lcs_sampled'", [
-            ])
+            .execute("DELETE FROM schema_version WHERE id = '031_edge_oracle_content_anchor'", [])
             .unwrap();
         assert_eq!(
             schema::status(db.storage.connection()).unwrap().state,
             schema::SchemaState::Older,
-            "removing the V030 ledger row makes the schema Older"
+            "removing the newest (V031) ledger row makes the schema Older"
         );
     }
 
@@ -10528,7 +10527,7 @@ fn v022_fresh_apply_creates_packages_and_dedicated_import_scope_columns() {
     schema::apply(&conn).unwrap();
 
     assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 30);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 31);
     assert!(conn_table_exists(&conn, "packages"), "packages table is created on a fresh apply");
 
     let package_cols = conn_table_columns(&conn, "packages");
@@ -12299,11 +12298,14 @@ fn v030_forward_migrate_adds_lcs_sampled_to_existing_v029_index() {
         !cols_before.contains(&"lcs_sampled".to_string()),
         "lcs_sampled must be absent before the migration runs"
     );
-    // Remove the V030 ledger row so the schema reads Older and migrate_forward replays it.
+    // Remove the V030 ledger row (and every later one) so the schema reads Older and
+    // migrate_forward replays V030. Later migrations (V031+) must also be unrecorded or
+    // `known_version` would still report LATEST and the schema would read Compatible.
     conn.execute_batch(
-        "DELETE FROM schema_version WHERE id = '030_clone_refinements_lcs_sampled';",
+        "DELETE FROM schema_version
+         WHERE id IN ('030_clone_refinements_lcs_sampled', '031_edge_oracle_content_anchor');",
     )
-    .expect("delete V030 ledger row");
+    .expect("delete V030+ ledger rows");
     assert_eq!(
         crate::index::schema::status(&conn).unwrap().state,
         crate::index::schema::SchemaState::Older,
@@ -12334,8 +12336,8 @@ fn v030_forward_migrate_adds_lcs_sampled_to_existing_v029_index() {
     );
     assert_eq!(
         crate::index::schema::LATEST_SCHEMA_VERSION,
-        30,
-        "LATEST_SCHEMA_VERSION is 30 after V030"
+        31,
+        "LATEST_SCHEMA_VERSION is 31 after V031"
     );
     // Idempotency: running migrate_forward again must not error.
     crate::index::schema::migrate_forward(&conn).expect("migrate_forward is idempotent");
@@ -12344,6 +12346,119 @@ fn v030_forward_migrate_adds_lcs_sampled_to_existing_v029_index() {
         crate::index::schema::SchemaState::Compatible,
         "schema is still Compatible after second migrate_forward"
     );
+}
+
+/// V031 (#248): a DB migrated to LATEST has `edge_oracle` content-anchored — NO `edges_data` FK,
+/// the content-key columns present, and a `DELETE FROM edges_data` does NOT cascade-wipe a manually
+/// inserted `edge_oracle` row (the bug: V018's `ON DELETE CASCADE` wiped every verdict on reindex).
+/// Drives the migration path explicitly: build the OLD (V018) FK shape, record the ledger one short
+/// of V031, then `migrate_forward` and assert the rebuilt shape.
+#[test]
+fn migration_031_edge_oracle_no_fk_content_key() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    crate::index::schema::apply(&conn).expect("apply reaches V31");
+
+    // Simulate a V030-era index whose `edge_oracle` still has the OLD edge_id-keyed FK shape: drop
+    // the content-anchored table and recreate the V018 shape, then remove the V031 ledger row so
+    // migrate_forward replays the rebuild.
+    conn.execute_batch(
+        "
+        PRAGMA foreign_keys = OFF;
+        DROP TABLE edge_oracle;
+        CREATE TABLE edge_oracle(
+            edge_id INTEGER NOT NULL,
+            file_sha TEXT NOT NULL,
+            tool TEXT NOT NULL,
+            tool_version TEXT NOT NULL,
+            resolved_symbol_id INTEGER,
+            scip_symbol TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            computed_at INTEGER NOT NULL,
+            PRIMARY KEY(edge_id, tool, tool_version),
+            FOREIGN KEY(edge_id) REFERENCES edges_data(id) ON DELETE CASCADE
+        ) STRICT;
+        PRAGMA foreign_keys = ON;
+        ",
+    )
+    .expect("recreate legacy V018 edge_oracle");
+    conn.execute_batch("DELETE FROM schema_version WHERE id = '031_edge_oracle_content_anchor';")
+        .expect("drop V031 ledger row");
+    assert_eq!(
+        schema::status(&conn).unwrap().state,
+        schema::SchemaState::Older,
+        "schema is Older after dropping the V031 ledger row + reverting the table shape"
+    );
+    // Confirm the legacy FK is really there before migrating.
+    let fk_before: i64 = conn
+        .query_row("SELECT COUNT(*) FROM pragma_foreign_key_list('edge_oracle')", [], |r| r.get(0))
+        .unwrap();
+    assert!(fk_before > 0, "legacy edge_oracle has an edges_data FK before V031");
+
+    crate::index::schema::migrate_forward(&conn).expect("migrate_forward replays V031");
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema is at LATEST after V031"
+    );
+
+    // (1) No FK on edge_oracle.
+    let fk_after: i64 = conn
+        .query_row("SELECT COUNT(*) FROM pragma_foreign_key_list('edge_oracle')", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(fk_after, 0, "V031 edge_oracle has NO foreign key");
+
+    // (2) The content-key columns exist.
+    let cols = conn_table_columns(&conn, "edge_oracle");
+    for expected in [
+        "source_path",
+        "source_start_byte",
+        "source_end_byte",
+        "callee_start_byte",
+        "callee_end_byte",
+        "edge_kind",
+    ] {
+        assert!(cols.contains(&expected.to_string()), "edge_oracle missing {expected}");
+    }
+    assert!(!cols.contains(&"edge_id".to_string()), "edge_id column is gone");
+
+    // (3) A DELETE FROM edges_data does NOT delete a manually-inserted edge_oracle row (no
+    // cascade). Seed a file + an edge so edges_data is non-empty, then insert a verdict whose
+    // content key is independent of any edge id.
+    conn.execute(
+        "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+         commit_sha, worktree_id) VALUES ('a.rs', 'rust', 'source', 'sha-a', 0, 0, 'c', '')",
+        [],
+    )
+    .unwrap();
+    let file_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO name_strings(value) VALUES ('target'), ('calls_name'), ('unresolved'), \
+         ('NameOnly') ON CONFLICT DO NOTHING",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO edges_data(source_file_id, to_name_id, callee_start_byte, callee_end_byte, \
+         resolution_id, edge_kind_id, confidence_id) VALUES (?1, (SELECT id FROM name_strings \
+         WHERE value='target'), 14, 20, (SELECT id FROM name_strings WHERE value='unresolved'), \
+         (SELECT id FROM name_strings WHERE value='calls_name'), (SELECT id FROM name_strings \
+         WHERE value='NameOnly'))",
+        params![file_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO edge_oracle(source_path, source_start_byte, source_end_byte, \
+         callee_start_byte, callee_end_byte, edge_kind, file_sha, tool, tool_version, \
+         resolved_symbol_id, scip_symbol, kind, computed_at) VALUES ('a.rs', 0, 0, 14, 20, \
+         'calls_name', 'sha-a', 'rust-analyzer', 'v', NULL, 's', 'upgrade', 0)",
+        [],
+    )
+    .unwrap();
+    conn.execute("DELETE FROM edges_data", []).unwrap();
+    let remaining: i64 =
+        conn.query_row("SELECT COUNT(*) FROM edge_oracle", [], |r| r.get(0)).unwrap();
+    assert_eq!(remaining, 1, "edge_oracle survives a full edges_data delete (no cascade)");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #248.

## The bug
`edge_oracle` holds the per-edge SCIP resolution written by `oracle run` (a real run wrote 41,167 rows), but the live index had **0 rows** despite the oracle having run — the resolution was silently lost on the first reindex.

**Root cause:** `edge_oracle` was keyed on the volatile `edge_id` rowid with `FOREIGN KEY(edge_id) REFERENCES edges_data(id) ON DELETE CASCADE`. Every reindex rewrites `edges_data` (full + incremental), so the CASCADE wiped all verdicts; the oracle is opt-in (`auto_run=false`) so it never repopulated. The DDL comment assumed reindex "recompute[s] the oracle" — false in the default config. `logical_symbol_monikers` survives only because it was deliberately made content-keyed with no FK; `edge_oracle` never got that treatment.

**Impact:** every reader was dormant on real indexes — `compare_graph_to_scip`, oracle status/eval coverage, and any SCIP-aware feature.

## The fix — content-anchored verdicts (the moniker survive-reindex pattern)
- **V031 migration:** rebuild `edge_oracle` with **no FK** and a content-derived PK `(tool, tool_version, source_path, source_start_byte, source_end_byte, callee_start_byte, callee_end_byte, edge_kind)` — all reindex-stable (no rowid). Measured unique over the resolvable-edge population (1,033,110 rows, zero collisions). `edge_kind` stored as text. The V020 footgun (its edge_oracle re-point vs the updated fresh-DB shape) is double-guarded; PRAGMA recipe follows V020 (foreign_keys OFF outside the transaction). One-time verdict drop on migration is intentional (ephemeral/opt-in; next run repopulates).
- **Reads join live edges by the content key** + `files.sha256 = edge_oracle.file_sha`: an unchanged file (same sha) re-anchors its verdict to the reindexed edge for free; a changed file's sha differs so its verdict drops (stale, repopulated on the next run). All three readers re-project the live `edges.id`.
- **gc** gains an explicit global sweep (`prune_edge_oracle_without_live_edge`) since the FK cascade is gone (correctness doesn't depend on it — dangling never resolves via the live join; it's anti-growth hygiene).

## Regression guards (so this class of bug can't recur)
The real failure was that **no test exercised the oracle → reindex → read lifecycle** — every prior test wrote and read with no reindex between, so the wipe was invisible. Added:
- **Enforcing structural trip-wire** (`no_table_has_a_reindex_cascading_fk_to_a_volatile_parent`): scans **every** table in `sqlite_master` and fails on any `ON DELETE CASCADE`/`RESTRICT` FK to a reindex-volatile parent (`edges_data`/`symbols`/`logical_symbols`/`files`) unless it's in an explicit `CASCADE_FK_ALLOWLIST` (8 legit rebuilt-with-parent pairs, each with a reason, none holding durable state). A negative sub-assertion proves it has teeth; a forgotten future oracle/durable table fails automatically. This is the exact check that would have caught the original `edge_oracle` FK.
- **Behavioral lifecycle guard** (`oracle_outputs_survive_full_and_incremental_reindex`): the integration test the suite lacked — runs the oracle, then actually reindexes (full + incremental) between write and read, asserting `edge_oracle` + `logical_symbol_monikers` survive for unchanged files and are correctly stale for changed ones.
- Plus the headline regression e2e (`oracle_run_then_reindex_then_compare_graph_to_scip_nonempty`) and content-key collision-semantics tests.

## Verification
973 tests across `rag-rat-core` + `rag-rat` + `rag-rat-mcp`; clippy `-D warnings` + nightly fmt clean. The migration chain was verified fresh (full V001..V031 ladder) and incremental (V030→V031), and the fix went through plan → 3-explorer adversarial plan review → implementation → 3-lens adversarial implementation verification (which surfaced and resolved the migration-registration sites, the reader live-id re-projection, and hardened the trip-wire from list-based to enforcing).

## Follow-ups (non-blocking, in the issue)
- A `UNIQUE` index on `edges_data` over the content tuple would make the live side provably 1:1 (currently the collision is organically unreachable — measured 0 — and pinned by a test).
- One stale memory title.
