### PR TITLE
perf(clones): BLOB-pack the token bag — drop per-token symbol_token_postings (#231)

### DIFF
--- a/crates/rag-rat-core/src/index/clones/bag_blob.rs
+++ b/crates/rag-rat-core/src/index/clones/bag_blob.rs
@@ -25,6 +25,7 @@ const PAIR_LEN: usize = 16;
 /// order verbatim, so the decode is byte-lossless and the bag never needs re-sorting on read.
 pub(crate) fn encode_token_bag(bag: &[(i64, i64)]) -> Vec<u8> {
     let count = bag.len();
+    debug_assert!(count <= u32::MAX as usize, "token bag exceeds u32 count header");
     let mut buf = Vec::with_capacity(HEADER_LEN + count * PAIR_LEN);
     buf.extend_from_slice(&BAG_BLOB_VERSION.to_le_bytes());
     buf.extend_from_slice(&(count as u32).to_le_bytes());

--- a/crates/rag-rat-core/src/index/clones/bag_blob.rs
+++ b/crates/rag-rat-core/src/index/clones/bag_blob.rs
@@ -1,0 +1,145 @@
+//! Serialized token-bag BLOB codec (#231). A symbol's `(token_hash, freq)` multiset is packed into
+//! ONE `symbol_fingerprints.token_bag` BLOB instead of N `symbol_token_postings` rows — the
+//! dominant clone-indexing write cost (~490k single-row INSERTs per full rebuild). Recall stays
+//! byte-identical because the decoded bag is the same `(token_hash, freq)` multiset, sorted by
+//! `token_hash`.
+//!
+//! Format (little-endian, fixed width):
+//!   `u32 version` | `u32 count` | `count × (i64 token_hash, i64 freq)` sorted by `token_hash` ASC.
+//! So `len == HEADER_LEN + count * PAIR_LEN`. The sort makes the BLOB deterministic + content-
+//! addressable, and the read needs no re-sort (`overlap` requires token_hash order). The version
+//! header guards against a format change: a mismatch (or any truncation / length violation) decodes
+//! to `None`, treated as an absent/stale bag that a reindex repopulates.
+
+/// Codec format version. Bumped only when the BLOB layout itself changes — independent of
+/// `NORM_VERSION` (which invalidates fingerprint CONTENT). A decode of any other version is `None`.
+const BAG_BLOB_VERSION: u32 = 1;
+
+/// `u32 version` + `u32 count`.
+const HEADER_LEN: usize = 8;
+/// `i64 token_hash` + `i64 freq`.
+const PAIR_LEN: usize = 16;
+
+/// Pack a `(token_hash, freq)` multiset into the versioned BLOB. The input is expected sorted by
+/// `token_hash` with no duplicate hashes (the contract of `tokens::token_bag`); this preserves that
+/// order verbatim, so the decode is byte-lossless and the bag never needs re-sorting on read.
+pub(crate) fn encode_token_bag(bag: &[(i64, i64)]) -> Vec<u8> {
+    let count = bag.len();
+    let mut buf = Vec::with_capacity(HEADER_LEN + count * PAIR_LEN);
+    buf.extend_from_slice(&BAG_BLOB_VERSION.to_le_bytes());
+    buf.extend_from_slice(&(count as u32).to_le_bytes());
+    for &(token_hash, freq) in bag {
+        buf.extend_from_slice(&token_hash.to_le_bytes());
+        buf.extend_from_slice(&freq.to_le_bytes());
+    }
+    buf
+}
+
+/// Decode a token-bag BLOB back to its `(token_hash, freq)` pairs, or `None` if the bytes are not a
+/// current-version, well-formed bag. `None` cases (all treated as "no bag", forcing a recompute on
+/// the next reindex — never a panic): wrong version, header shorter than [`HEADER_LEN`], or a
+/// length that disagrees with the declared count. The returned pairs keep the stored order
+/// (token_hash ASC).
+pub(crate) fn decode_token_bag(blob: &[u8]) -> Option<Vec<(i64, i64)>> {
+    if blob.len() < HEADER_LEN {
+        return None;
+    }
+    let version = u32::from_le_bytes(blob[0..4].try_into().ok()?);
+    if version != BAG_BLOB_VERSION {
+        return None;
+    }
+    let count = u32::from_le_bytes(blob[4..8].try_into().ok()?) as usize;
+    // Reject any length that disagrees with the declared count: a truncated/over-long blob is
+    // corrupt, not a partial bag.
+    if blob.len() != HEADER_LEN + count * PAIR_LEN {
+        return None;
+    }
+    let mut bag = Vec::with_capacity(count);
+    for i in 0..count {
+        let base = HEADER_LEN + i * PAIR_LEN;
+        let token_hash = i64::from_le_bytes(blob[base..base + 8].try_into().ok()?);
+        let freq = i64::from_le_bytes(blob[base + 8..base + 16].try_into().ok()?);
+        bag.push((token_hash, freq));
+    }
+    Some(bag)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::index::clones::tokens;
+
+    #[test]
+    fn token_bag_blob_round_trips() {
+        let bag = vec![(-9_223_372_036_854_775_808, 3), (0, 1), (42, 7), (i64::MAX, 2)];
+        let blob = encode_token_bag(&bag);
+        assert_eq!(decode_token_bag(&blob).expect("decodes"), bag, "round-trips exactly");
+    }
+
+    #[test]
+    fn empty_bag_round_trips() {
+        let blob = encode_token_bag(&[]);
+        assert_eq!(blob.len(), HEADER_LEN, "empty bag is header-only");
+        assert_eq!(decode_token_bag(&blob).expect("decodes"), Vec::<(i64, i64)>::new());
+    }
+
+    #[test]
+    fn large_bag_round_trips() {
+        let bag: Vec<(i64, i64)> =
+            (0..5000).map(|i| (i as i64 * 31 - 1000, (i % 9 + 1) as i64)).collect();
+        let blob = encode_token_bag(&bag);
+        assert_eq!(blob.len(), HEADER_LEN + bag.len() * PAIR_LEN);
+        assert_eq!(decode_token_bag(&blob).expect("decodes"), bag);
+    }
+
+    #[test]
+    fn wrong_version_decodes_to_none() {
+        let mut blob = encode_token_bag(&[(1, 1)]);
+        blob[0] = blob[0].wrapping_add(1); // corrupt the version byte
+        assert_eq!(decode_token_bag(&blob), None, "version mismatch is None, not a panic");
+    }
+
+    #[test]
+    fn truncated_blob_decodes_to_none() {
+        let blob = encode_token_bag(&[(1, 1), (2, 2), (3, 3)]);
+        // Drop the final byte: the length no longer matches the declared count.
+        assert_eq!(decode_token_bag(&blob[..blob.len() - 1]), None);
+        // A header claiming a count its body can't satisfy.
+        assert_eq!(decode_token_bag(&blob[..HEADER_LEN]), None);
+        // Too short even for a header.
+        assert_eq!(decode_token_bag(&blob[..4]), None);
+        assert_eq!(decode_token_bag(&[]), None);
+    }
+
+    #[test]
+    fn over_long_blob_decodes_to_none() {
+        let mut blob = encode_token_bag(&[(1, 1)]);
+        blob.push(0); // trailing junk past the declared count
+        assert_eq!(decode_token_bag(&blob), None);
+    }
+
+    /// R11: decoding the REAL `tokens::token_bag` output yields NO duplicate token_hash, and the
+    /// decoded length equals `tokens::token_bag().len()` (so `token_len` stays derivable from the
+    /// BLOB — the codec is lossless and the bag is a true multiset).
+    #[test]
+    fn decoded_real_token_bag_has_no_duplicate_hashes_and_is_lossless() {
+        let toks: Vec<String> = ["if", "x", "(", "y", ")", "x", "y", "x", "y", "if", "z", "z", "z"]
+            .iter()
+            .map(|w| w.to_string())
+            .collect();
+        let bag = tokens::token_bag(&toks);
+        let blob = encode_token_bag(&bag);
+        let decoded = decode_token_bag(&blob).expect("decodes");
+
+        assert_eq!(decoded, bag, "byte-lossless against the real producer");
+
+        let mut hashes: Vec<i64> = decoded.iter().map(|&(h, _)| h).collect();
+        let distinct = hashes.len();
+        hashes.dedup();
+        assert_eq!(hashes.len(), distinct, "no duplicate token_hash after decode");
+
+        let mut sorted = hashes.clone();
+        sorted.sort_unstable();
+        assert_eq!(hashes, sorted, "decoded bag is token_hash-sorted (no re-sort needed on read)");
+    }
+}

--- a/crates/rag-rat-core/src/index/clones/mod.rs
+++ b/crates/rag-rat-core/src/index/clones/mod.rs
@@ -6,6 +6,7 @@
 // They are dead until Plan 3 lands; the rest of the module is live (R4's candidate read uses it).
 #![allow(dead_code)]
 
+pub(crate) mod bag_blob;
 pub(crate) mod normalize;
 pub(crate) mod refine;
 pub(crate) mod tokens;
@@ -59,7 +60,8 @@ impl NormalizerKind {
 pub(crate) struct SymbolFingerprint {
     pub struct_hash: String,
     pub token_len: i64,
-    /// `(token_hash, freq)` multiset sorted by `token_hash`. Stored in `symbol_token_postings`.
+    /// `(token_hash, freq)` multiset sorted by `token_hash`. Serialized into the
+    /// `symbol_fingerprints.token_bag` BLOB column (#231; `bag_blob::encode_token_bag`).
     pub token_bag: Vec<(i64, i64)>,
 }
 

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -264,13 +264,16 @@ impl IndexDatabase {
     /// full-rebuild prepare phase (#230) and the incremental `store_symbol_fingerprints` wrapper,
     /// so the per-row insert discipline lives in exactly one place.
     ///
+    /// The token bag is serialized into the `symbol_fingerprints.token_bag` BLOB column (#231),
+    /// one BLOB per symbol — there is no longer a `symbol_token_postings` row-per-token write.
+    ///
     /// `bump_df` gates the per-token `clone_token_df` upsert. On the full-rebuild path it is
     /// `BumpDf(false)`: `refresh_clone_token_df` (rebuild.rs) recomputes df exactly from the
-    /// postings at finalize, so bumping it per token here is recomputed-and-discarded work plus
-    /// hot-row B-tree contention on common tokens. On the incremental/heal paths it is
+    /// token-bag BLOBs at finalize, so bumping it per token here is recomputed-and-discarded work
+    /// plus hot-row B-tree contention on common tokens. On the incremental/heal paths it is
     /// `BumpDf(true)` — no finalize runs there, so the drift-tolerated bump is how df stays current
-    /// (df is a selectivity hint only; the candidate read LEFT-JOINs + COALESCEs it, so drift never
-    /// changes a result — see query_api/clones.rs).
+    /// (df is a selectivity hint only; the candidate read COALESCEs it, so drift never changes a
+    /// result — see query_api/clones.rs).
     fn write_symbol_fingerprints(
         &self,
         symbol_db_ids: &[i64],
@@ -281,10 +284,15 @@ impl IndexDatabase {
         let normalizer_kind = clones::NormalizerKind::Baseline.as_db_str();
         for (local_index, fp) in fingerprints {
             let symbol_id = symbol_db_ids[*local_index];
+            // The token bag rides the fingerprint row as ONE serialized BLOB (#231), replacing the
+            // ~N-rows-per-symbol symbol_token_postings INSERTs (the dominant full-rebuild write
+            // cost). `fp.token_bag` is already token_hash-sorted with no duplicate hashes, so the
+            // BLOB is deterministic and the candidate read decodes it without re-sorting.
+            let token_bag_blob = clones::bag_blob::encode_token_bag(&fp.token_bag);
             conn.prepare_cached(
                 "INSERT INTO symbol_fingerprints(symbol_id, normalizer_kind, normalizer_version, \
-                 oracle_run_id, struct_hash, token_len, created_at_ms)
-                 VALUES (?1, ?2, ?3, NULL, ?4, ?5, ?6)",
+                 oracle_run_id, struct_hash, token_len, token_bag, created_at_ms)
+                 VALUES (?1, ?2, ?3, NULL, ?4, ?5, ?6, ?7)",
             )?
             .execute(params![
                 symbol_id,
@@ -292,22 +300,16 @@ impl IndexDatabase {
                 clones::NORM_VERSION,
                 fp.struct_hash,
                 fp.token_len,
+                token_bag_blob,
                 now_ms(),
             ])?;
-            // Write the inverted index: one posting row per distinct token (#215). The global
-            // document frequency for the token is bumped here ONLY when `bump_df`
-            // (incremental/heal): df is a selectivity hint only (the candidate read
-            // LEFT-JOINs + COALESCEs it), so the bump is drift-tolerated. A full
-            // rebuild skips the bump and instead recomputes df authoritatively from the
-            // postings at finalize (refresh_clone_token_df, rebuild.rs).
-            for &(token_hash, freq) in &fp.token_bag {
-                conn.prepare_cached(
-                    "INSERT INTO symbol_token_postings(symbol_id, normalizer_kind, token_hash, \
-                     freq)
-                     VALUES (?1, ?2, ?3, ?4)",
-                )?
-                .execute(params![symbol_id, normalizer_kind, token_hash, freq])?;
-                if bump_df.0 {
+            // Bump the global document frequency per distinct token ONLY when `bump_df`
+            // (incremental/heal): df is a selectivity hint only (the candidate read COALESCEs it),
+            // so the bump is drift-tolerated. A full rebuild skips the bump and instead recomputes
+            // df authoritatively from the token-bag BLOBs at finalize (refresh_clone_token_df,
+            // rebuild.rs). R7: iterate the IN-MEMORY `fp.token_bag` here — no decode round-trip.
+            if bump_df.0 {
+                for &(token_hash, _freq) in &fp.token_bag {
                     conn.prepare_cached(
                         "INSERT INTO clone_token_df(normalizer_kind, token_hash, df)
                          VALUES (?1, ?2, 1)

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -874,7 +874,7 @@ fn migration_creates_oracle_side_tables() {
     }
     assert!(!columns.contains(&"edge_id".to_string()), "edge_id column was dropped");
 
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 31);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 32);
 }
 
 /// The V019 moniker migration: the `logical_symbol_monikers` table (STRICT, NO foreign key — see

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -1924,7 +1924,8 @@ fn verified_clone(a: &SymbolBag, b: &SymbolBag, theta: f64) -> bool {
 /// Exact multiset overlap `Σ min(freq_a, freq_b)` over the two FULL token bags.
 ///
 /// Requires both bags' `tokens` slices to be sorted by `token_hash` ascending (guaranteed by
-/// [`load_scoped_baseline_bags`], which sorts once after collection). Uses an allocation-free
+/// the encoded token-bag BLOB, which is sorted at encode time by `tokens::token_bag` and
+/// asserted by the `debug_assert` in `bag_blob::encode_token_bag`). Uses an allocation-free
 /// two-pointer merge: no `BTreeMap` rebuild per call — O(|a| + |b|) time, zero heap allocation.
 fn overlap(a: &SymbolBag, b: &SymbolBag) -> i64 {
     let (mut ia, mut ib) = (0, 0);

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -1737,11 +1737,22 @@ fn candidate_pairs(conn: &Connection) -> anyhow::Result<Vec<(i64, i64)>> {
 /// so only the ACTIVE version of each file participates (SCOPED-VIEW REQUIREMENT #89). df is read
 /// via LEFT JOIN + COALESCE so a missing-df token is never dropped (design rev-4 §2).
 fn load_scoped_baseline_bags(conn: &Connection) -> anyhow::Result<Vec<SymbolBag>> {
-    // Scoped baseline fingerprints: struct_hash + token_len per in-scope symbol.
+    // Load `clone_token_df` ONCE into a map (#231 R3): the token bag now lives in an opaque
+    // `token_bag` BLOB, so df can no longer be a per-token SQL JOIN. Each decoded token's df is
+    // looked up here in Rust and COALESCEd to the fallback sentinel — a missing-df token must NOT
+    // be dropped (design rev-4 §2). Only the baseline normalizer feeds candidate recall.
+    let mut df_stmt = conn
+        .prepare("SELECT token_hash, df FROM clone_token_df WHERE normalizer_kind = 'baseline'")?;
+    let df_by_token: std::collections::HashMap<i64, i64> = df_stmt
+        .query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)))?
+        .collect::<Result<_, _>>()?;
+
+    // Scoped baseline fingerprints + their token-bag BLOB, in one read (no per-token join).
     // `files.generated = 0` excludes generated files (e.g. `src/generated/…`, `.d.ts`) from the
     // candidate read — they are fingerprinted on write but must not enter clone components.
+    // `token_len` comes from the COLUMN (R3); the bag itself is decoded from the BLOB.
     let mut fp_stmt = conn.prepare(
-        "SELECT sf.symbol_id, symbols.language, sf.struct_hash, sf.token_len
+        "SELECT sf.symbol_id, symbols.language, sf.struct_hash, sf.token_len, sf.token_bag
          FROM symbol_fingerprints sf
          JOIN symbols ON symbols.id = sf.symbol_id
          JOIN files ON files.id = symbols.file_id
@@ -1749,59 +1760,50 @@ fn load_scoped_baseline_bags(conn: &Connection) -> anyhow::Result<Vec<SymbolBag>
            AND sf.normalizer_version = ?1
            AND files.generated = 0",
     )?;
-    let mut bags: BTreeMap<i64, SymbolBag> = fp_stmt
-        .query_map([NORM_VERSION], |row| {
-            let symbol_id: i64 = row.get(0)?;
-            Ok((symbol_id, SymbolBag {
-                symbol_id,
-                language: row.get(1)?,
-                struct_hash: row.get(2)?,
-                token_len: row.get(3)?,
-                tokens: Vec::new(),
-            }))
-        })?
-        .collect::<Result<_, _>>()?;
-
-    // Full token bag per scoped baseline symbol, with each token's df LEFT-JOINed + COALESCEd to
-    // the fallback sentinel (missing-df tokens must NOT be dropped — rev-4 §2).
-    // `files.generated = 0` mirrors the fingerprint load: only non-generated symbols get postings
-    // loaded, so their bags never enter the inverted index or the exact verify.
-    let mut tok_stmt = conn.prepare(
-        "SELECT stp.symbol_id, stp.token_hash, stp.freq, COALESCE(df.df, ?1)
-         FROM symbol_token_postings stp
-         JOIN symbols ON symbols.id = stp.symbol_id
-         JOIN files ON files.id = symbols.file_id
-         LEFT JOIN clone_token_df df
-           ON df.normalizer_kind = stp.normalizer_kind AND df.token_hash = stp.token_hash
-         WHERE stp.normalizer_kind = 'baseline'
-           AND files.generated = 0",
-    )?;
-    let rows = tok_stmt.query_map([DF_FALLBACK], |row| {
-        Ok((row.get::<_, i64>(0)?, TokenPosting {
-            token_hash: row.get(1)?,
-            freq: row.get(2)?,
-            coalesced_df: row.get(3)?,
-        }))
-    })?;
-    for row in rows {
-        let (symbol_id, posting) = row?;
-        // `bags` keyset is already `normalizer_version`-filtered by the fingerprint query above,
-        // so a stale-version symbol (absent from `bags`) has its postings silently dropped here.
-        if let Some(bag) = bags.get_mut(&symbol_id) {
-            bag.tokens.push(posting);
-        }
+    let mut bags: Vec<SymbolBag> = Vec::new();
+    let mut rows = fp_stmt.query([NORM_VERSION])?;
+    while let Some(row) = rows.next()? {
+        // R4: a NULL `token_bag` (un-reindexed after the V032 migration) is a NO-BAG row — SKIP it
+        // (not an empty bag, no panic). Byte-identical recall holds only for a FULLY (re)indexed
+        // DB; clone recall is undefined for NULL-bag symbols until the post-migration
+        // reindex.
+        let Some(blob) = row.get::<_, Option<Vec<u8>>>(4)? else {
+            continue;
+        };
+        let Some(bag_pairs) = crate::index::clones::bag_blob::decode_token_bag(&blob) else {
+            // A stale/corrupt blob (version mismatch / truncation) decodes to None — treat as
+            // no-bag, same as NULL. It is repopulated on the next reindex.
+            continue;
+        };
+        let tokens: Vec<TokenPosting> = bag_pairs
+            .into_iter()
+            .map(|(token_hash, freq)| TokenPosting {
+                token_hash,
+                freq,
+                coalesced_df: df_by_token.get(&token_hash).copied().unwrap_or(DF_FALLBACK),
+            })
+            .collect();
+        // The BLOB is stored token_hash-sorted (the producer's invariant), which is exactly the
+        // order `overlap`'s two-pointer merge and `sub_block_tokens` expect — so no re-sort is
+        // needed on read. Assert it in debug to catch a producer regression.
+        debug_assert!(
+            tokens.windows(2).all(|w| w[0].token_hash <= w[1].token_hash),
+            "decoded token_bag must be token_hash-sorted"
+        );
+        bags.push(SymbolBag {
+            symbol_id: row.get(0)?,
+            language: row.get(1)?,
+            struct_hash: row.get(2)?,
+            token_len: row.get(3)?,
+            tokens,
+        });
     }
 
-    // Sort each bag's token list by `token_hash` once, here, so `overlap` can use an
-    // allocation-free two-pointer merge instead of rebuilding a `BTreeMap` on every call.
-    // Consumers that care about order (sub_block_tokens, struct_hash, inverted-index build,
-    // token_len) are all order-independent — they sort by (df, hash) themselves or use a separate
-    // field — so this re-ordering is safe.
-    for bag in bags.values_mut() {
-        bag.tokens.sort_unstable_by_key(|t| t.token_hash);
-    }
-
-    Ok(bags.into_values().collect())
+    // Return bags in `symbol_id` order, matching the prior `BTreeMap<symbol_id, _>` keyset (the SQL
+    // has no ORDER BY). The candidate set is order-independent (it dedups into a BTreeSet), but a
+    // stable order keeps any incidental iteration deterministic.
+    bags.sort_unstable_by_key(|bag| bag.symbol_id);
+    Ok(bags)
 }
 
 /// Exact fast path: every group of symbols sharing a `struct_hash` AND `language` is
@@ -2485,5 +2487,149 @@ mod tests {
             "a {}-member class is truncated to {MEMBER_VALUE_CAP} refine inputs → metrics_sampled",
             MEMBER_VALUE_CAP + 1
         );
+    }
+
+    // ── T5a (#231): the LOAD-BEARING recall-parity pin ──────────────────────────────────────────
+
+    /// THE recall-correctness pin for the BLOB-pack (#231). Builds a real index, then proves the
+    /// BLOB read path produces SymbolBags BYTE-IDENTICAL to the pre-BLOB postings grouping — same
+    /// token lists, freqs, AND coalesced df — and that the resulting `candidate_pairs` are
+    /// unchanged. The "postings-era" expectation is reconstructed independently in the test from
+    /// the same BLOBs + df, replicating the old `GROUP BY symbol_token_postings` + per-token
+    /// `LEFT JOIN clone_token_df` + `COALESCE(df, DF_FALLBACK)` + sort-by-token_hash semantics. If
+    /// these diverge, recall has regressed.
+    #[test]
+    fn recall_candidates_identical_blob_vs_postings_grouping() {
+        use std::collections::HashMap;
+
+        use super::{DF_FALLBACK, candidate_pairs, load_scoped_baseline_bags};
+
+        let root = std::env::temp_dir().join(format!(
+            "rag-rat-recall-parity-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.subsec_nanos())
+                .unwrap_or(0)
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        // Two renamed-clone groups + one unrelated function, across files.
+        std::fs::write(
+            root.join("src/a.rs"),
+            "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\npub fn \
+             compute_totals(items: Vec<i64>) -> i64 { let mut s = 0; for it in items { s += it * \
+             2; } s + 1 }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("src/b.rs"),
+            "pub fn load_order(store: Db) -> i32 { let o = store.get(20); validate(o); o + 1 \
+             }\npub fn tally_amounts(values: Vec<i64>) -> i64 { let mut t = 0; for v in values { \
+             t += v * 2; } t + 1 }\n",
+        )
+        .unwrap();
+        let config = crate::Config {
+            root: root.clone(),
+            database: root.join(".rag-rat/index.sqlite"),
+            targets: vec![crate::config::ResolvedTarget {
+                name: "rust".to_string(),
+                language: crate::language::Language::Rust,
+                directories: vec![std::path::PathBuf::from("src")],
+                include: vec!["src/".to_string()],
+                exclude: Vec::new(),
+                kind: crate::config::TargetKind::Source,
+            }],
+            local_ai: Default::default(),
+            watch: Default::default(),
+            version_check: Default::default(),
+            oracle: Default::default(),
+        };
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        let conn = db.storage.connection();
+
+        // --- Independently reconstruct the postings-era SymbolBags from the BLOBs + df ---
+        // df map, exactly as the old per-token `LEFT JOIN clone_token_df` would have resolved.
+        let mut df_stmt = conn
+            .prepare("SELECT token_hash, df FROM clone_token_df WHERE normalizer_kind = 'baseline'")
+            .unwrap();
+        let df_by_token: HashMap<i64, i64> = df_stmt
+            .query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, i64>(1)?)))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+
+        // For each scoped baseline fingerprint (generated = 0, matching the production filter),
+        // decode its bag into the same `(symbol_id, language, struct_hash, token_len, [(hash, freq,
+        // coalesced_df)])` shape, with the per-token list sorted by token_hash.
+        let mut fp_stmt = conn
+            .prepare(
+                "SELECT sf.symbol_id, symbols.language, sf.struct_hash, sf.token_len, sf.token_bag
+                 FROM symbol_fingerprints sf
+                 JOIN symbols ON symbols.id = sf.symbol_id
+                 JOIN files ON files.id = symbols.file_id
+                 WHERE sf.normalizer_kind = 'baseline'
+                   AND sf.normalizer_version = ?1
+                   AND files.generated = 0",
+            )
+            .unwrap();
+        // (symbol_id, language, struct_hash, token_len, sorted [(token_hash, freq, df)])
+        type ExpectedBag = (i64, String, String, i64, Vec<(i64, i64, i64)>);
+        let mut expected: Vec<ExpectedBag> = fp_stmt
+            .query_map([super::NORM_VERSION], |r| {
+                let blob: Option<Vec<u8>> = r.get(4)?;
+                let pairs = blob
+                    .and_then(|b| crate::index::clones::bag_blob::decode_token_bag(&b))
+                    .unwrap_or_default();
+                let mut tokens: Vec<(i64, i64, i64)> = pairs
+                    .into_iter()
+                    .map(|(h, f)| (h, f, df_by_token.get(&h).copied().unwrap_or(DF_FALLBACK)))
+                    .collect();
+                tokens.sort_unstable_by_key(|&(h, _, _)| h);
+                Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, tokens))
+            })
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        expected.sort_unstable_by_key(|b| b.0);
+        assert!(expected.len() >= 4, "fixture indexed at least 4 fingerprinted functions");
+
+        // --- The production read path must produce byte-identical bags ---
+        let mut actual: Vec<ExpectedBag> = load_scoped_baseline_bags(conn)
+            .unwrap()
+            .into_iter()
+            .map(|bag| {
+                let tokens: Vec<(i64, i64, i64)> =
+                    bag.tokens.iter().map(|t| (t.token_hash, t.freq, t.coalesced_df)).collect();
+                (bag.symbol_id, bag.language, bag.struct_hash, bag.token_len, tokens)
+            })
+            .collect();
+        actual.sort_unstable_by_key(|b| b.0);
+        assert_eq!(
+            actual, expected,
+            "BLOB-decoded SymbolBags must equal the postings-era grouping (token lists, freqs, df)"
+        );
+
+        // --- And the candidate pairs are unchanged: the two renamed groups each pair up ---
+        let pairs = candidate_pairs(conn).unwrap();
+        let id_of = |name: &str| -> i64 {
+            conn.query_row(
+                "SELECT s.id FROM symbols s WHERE s.name = ?1 AND s.kind = 'function'",
+                [name],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+        let (lu, lo) = (id_of("load_user"), id_of("load_order"));
+        let (ct, ta) = (id_of("compute_totals"), id_of("tally_amounts"));
+        let has = |a: i64, b: i64| pairs.contains(&(a.min(b), a.max(b)));
+        assert!(has(lu, lo), "load_user/load_order are renamed clones → a candidate pair");
+        assert!(has(ct, ta), "compute_totals/tally_amounts are renamed clones → a candidate pair");
+        assert!(
+            !has(lu, ct) && !has(lu, ta) && !has(lo, ct) && !has(lo, ta),
+            "the two clone GROUPS do not cross-pair"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -88,12 +88,11 @@ impl IndexDatabase {
             // needs the bulk 'rebuild' here (#77 Phase 2).
             db.finalize_full_rebuild_fts()?;
             mem_trace("after finalize_full_rebuild_fts");
-            // Recompute clone token document-frequency authoritatively from the postings just
-            // written (#215). The per-symbol incremental bump in store_symbol_fingerprints drifts
-            // over edits; a full rebuild owns the whole checkout, so derive df exactly here. df is
-            // a selectivity hint only (candidate read LEFT-JOINs + COALESCEs it), never
-            // a correctness input — but keeping it exact maximizes the rare-first
-            // sub-block prune.
+            // Recompute clone token document-frequency authoritatively from the token-bag BLOBs
+            // just written (#231). The per-symbol incremental bump in store_symbol_fingerprints
+            // drifts over edits; a full rebuild owns the whole checkout, so derive df exactly here.
+            // df is a selectivity hint only (candidate read COALESCEs it), never a correctness
+            // input — but keeping it exact maximizes the rare-first sub-block prune.
             db.refresh_clone_token_df()?;
             mem_trace("after refresh_clone_token_df");
             db.set_meta("indexed_at_ms", &now_ms().to_string())?;
@@ -115,18 +114,53 @@ impl IndexDatabase {
         Ok(db)
     }
 
-    /// Recompute `clone_token_df` exactly from `symbol_token_postings` (#215). One GROUP BY over
-    /// the postings replaces the drift-prone incremental bumps with the authoritative document
-    /// frequency (count of distinct symbols containing each token per normalizer). Runs inside
-    /// the rebuild transaction so the df and the postings it summarizes commit atomically.
+    /// Recompute `clone_token_df` exactly from the `symbol_fingerprints.token_bag` BLOBs (#231).
+    /// A Rust aggregate over the decoded bags replaces the former `GROUP BY symbol_token_postings`
+    /// (that table is dropped in V032) with the same authoritative document frequency: the count of
+    /// distinct symbols whose bag contains each token, per `(normalizer_kind, token_hash)`. Runs
+    /// inside the rebuild transaction so the df and the fingerprints it summarizes commit
+    /// atomically.
+    ///
+    /// R6 — SCOPE PARITY: this must match the old GROUP BY EXACTLY. That query had NO
+    /// `files.generated` filter, so it counted generated-file symbols too; this aggregate likewise
+    /// reads EVERY `symbol_fingerprints` row (generated included). df feeds candidate GENERATION
+    /// (the `sub_block_tokens` ordering), not just ranking, so a scope mismatch would change
+    /// recall. Each symbol's decoded bag has no duplicate `token_hash` (the codec invariant),
+    /// so counting one increment per (symbol, token) pair equals `COUNT(DISTINCT symbol_id)`.
     fn refresh_clone_token_df(&self) -> anyhow::Result<()> {
-        self.storage.execute_batch(
-            "DELETE FROM clone_token_df;
-             INSERT INTO clone_token_df(normalizer_kind, token_hash, df)
-               SELECT normalizer_kind, token_hash, COUNT(DISTINCT symbol_id)
-               FROM symbol_token_postings
-               GROUP BY normalizer_kind, token_hash;",
-        )?;
+        // Phase 1 (read): decode every fingerprint's bag and accumulate df in memory, off the
+        // connection borrow. NULL `token_bag` rows (un-reindexed after the V032 migration) and any
+        // stale/corrupt blob (decode → None) contribute nothing, exactly as a missing postings row
+        // would have.
+        let mut df: BTreeMap<(String, i64), i64> = BTreeMap::new();
+        {
+            let conn = self.storage.connection();
+            let mut stmt =
+                conn.prepare("SELECT normalizer_kind, token_bag FROM symbol_fingerprints")?;
+            let mut rows = stmt.query([])?;
+            while let Some(row) = rows.next()? {
+                let normalizer_kind: String = row.get(0)?;
+                let Some(blob) = row.get::<_, Option<Vec<u8>>>(1)? else {
+                    continue;
+                };
+                let Some(bag) = clones::bag_blob::decode_token_bag(&blob) else {
+                    continue;
+                };
+                for (token_hash, _freq) in bag {
+                    *df.entry((normalizer_kind.clone(), token_hash)).or_insert(0) += 1;
+                }
+            }
+        }
+
+        // Phase 2 (write): replace the table contents with the recomputed df.
+        let conn = self.storage.connection();
+        conn.execute_batch("DELETE FROM clone_token_df;")?;
+        for ((normalizer_kind, token_hash), count) in df {
+            conn.prepare_cached(
+                "INSERT INTO clone_token_df(normalizer_kind, token_hash, df) VALUES (?1, ?2, ?3)",
+            )?
+            .execute(params![normalizer_kind, token_hash, count])?;
+        }
         Ok(())
     }
 

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -274,12 +274,10 @@ impl IndexDatabase {
                 FROM main.symbols
                 JOIN temp.staged_file_ids ON staged_file_ids.id = symbols.file_id
             );
-            DELETE FROM main.symbol_token_postings
-            WHERE symbol_id IN (
-                SELECT symbols.id
-                FROM main.symbols
-                JOIN temp.staged_file_ids ON staged_file_ids.id = symbols.file_id
-            );
+            -- The token bag rides the symbol_fingerprints row deleted above as the `token_bag`
+            -- BLOB column (#231); symbol_token_postings was dropped in V032, so there is no
+            -- separate per-token table to cascade here (R1: a DELETE on it would error
+            -- `no such table` on every reindex).
             DELETE FROM main.symbols
             WHERE file_id IN (SELECT id FROM temp.staged_file_ids);
             DELETE FROM main.chunks

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -132,7 +132,9 @@ impl IndexDatabase {
         // connection borrow. NULL `token_bag` rows (un-reindexed after the V032 migration) and any
         // stale/corrupt blob (decode → None) contribute nothing, exactly as a missing postings row
         // would have.
-        let mut df: BTreeMap<(String, i64), i64> = BTreeMap::new();
+        // Outer key: normalizer_kind (cloned once per kind, not per (symbol, token) pair).
+        // Inner key: token_hash → df count.
+        let mut df: BTreeMap<String, BTreeMap<i64, i64>> = BTreeMap::new();
         {
             let conn = self.storage.connection();
             let mut stmt =
@@ -146,8 +148,9 @@ impl IndexDatabase {
                 let Some(bag) = clones::bag_blob::decode_token_bag(&blob) else {
                     continue;
                 };
+                let inner = df.entry(normalizer_kind).or_default();
                 for (token_hash, _freq) in bag {
-                    *df.entry((normalizer_kind.clone(), token_hash)).or_insert(0) += 1;
+                    *inner.entry(token_hash).or_insert(0) += 1;
                 }
             }
         }
@@ -155,11 +158,14 @@ impl IndexDatabase {
         // Phase 2 (write): replace the table contents with the recomputed df.
         let conn = self.storage.connection();
         conn.execute_batch("DELETE FROM clone_token_df;")?;
-        for ((normalizer_kind, token_hash), count) in df {
-            conn.prepare_cached(
-                "INSERT INTO clone_token_df(normalizer_kind, token_hash, df) VALUES (?1, ?2, ?3)",
-            )?
-            .execute(params![normalizer_kind, token_hash, count])?;
+        for (normalizer_kind, inner) in df {
+            for (token_hash, count) in inner {
+                conn.prepare_cached(
+                    "INSERT INTO clone_token_df(normalizer_kind, token_hash, df) VALUES (?1, ?2, \
+                     ?3)",
+                )?
+                .execute(params![normalizer_kind, token_hash, count])?;
+            }
         }
         Ok(())
     }

--- a/crates/rag-rat-core/src/index/schema/baseline.rs
+++ b/crates/rag-rat-core/src/index/schema/baseline.rs
@@ -601,6 +601,13 @@ pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
     apply_graph_file_lookup_indexes(conn)?;
     interned_qualified_name_indexes(conn)?;
     apply_clone_fingerprint_tables(conn)?;
+    // V032 (#231): converge the clone substrate to its BLOB-packed shape. The line above
+    // (re)creates `symbol_token_postings` from V029's DDL; this transform adds the
+    // `symbol_fingerprints.token_bag` column and DROPs the postings table — so the baseline
+    // produces the CURRENT schema directly, and a routine `migrate_forward` (which re-runs the
+    // baseline) cannot leave the postings table behind it. R5: V029's DDL is not edited; the
+    // convergence lives here, not in the checksummed migration body.
+    apply_token_bag_blob(conn)?;
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1166,6 +1166,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_029_ID => Some(29),
             MIGRATION_030_ID => Some(30),
             MIGRATION_031_ID => Some(31),
+            MIGRATION_032_ID => Some(32),
             _ => None,
         })
         .max()
@@ -1206,6 +1207,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_029_ID
             | MIGRATION_030_ID
             | MIGRATION_031_ID
+            | MIGRATION_032_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1243,6 +1245,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_029_ID => migration.checksum != MIGRATION_029_CHECKSUM,
         MIGRATION_030_ID => migration.checksum != MIGRATION_030_CHECKSUM,
         MIGRATION_031_ID => migration.checksum != MIGRATION_031_CHECKSUM,
+        MIGRATION_032_ID => migration.checksum != MIGRATION_032_CHECKSUM,
         _ => false,
     }
 }
@@ -1492,6 +1495,40 @@ pub(crate) fn apply_edge_oracle_content_anchor(conn: &Connection) -> rusqlite::R
         return result;
     }
     conn.execute_batch("COMMIT; PRAGMA foreign_keys = ON;")?;
+    Ok(())
+}
+
+/// V032 (#231): BLOB-pack the clone token bag. Add `symbol_fingerprints.token_bag BLOB` and DROP
+/// `symbol_token_postings` — collapsing the ~490k single-row postings INSERTs of a full rebuild
+/// into ONE serialized `(token_hash, freq)` BLOB per fingerprint row
+/// (`bag_blob::encode_token_bag`). The candidate read decodes the BLOB back into the same
+/// `(token_hash, freq)` multiset, so recall is byte-identical on a fully (re)indexed DB;
+/// `clone_token_df` is recomputed by aggregating the BLOBs.
+///
+/// SHAPE (R5): follows the V031 idempotency-guarded-transform pattern — V029's
+/// `CLONE_FINGERPRINT_DDL` (which still CREATEs both tables) is NEVER edited. On a FRESH DB, V029
+/// creates `symbol_token_postings` and this migration drops it; on an EXISTING DB it does the same.
+/// Guard on the `token_bag` column so a re-run (or a fresh DB already transformed) is a clean
+/// no-op.
+///
+/// NO BACK-FILL (R8): existing fingerprint rows get `token_bag = NULL` on `ADD COLUMN`. The
+/// candidate read SKIPs NULL-bag rows, so clone recall is undefined for those symbols until the
+/// post-migration reindex repopulates them — the same one-time-loss posture as V029/V031 (clone
+/// data is rebuildable; no parse-the-whole-repo work belongs in a migration).
+pub(crate) fn apply_token_bag_blob(conn: &Connection) -> rusqlite::Result<()> {
+    // Both operations are individually idempotent — NO early-return guard. A short-circuit on the
+    // column's presence would be a bug here: `apply` runs this transform from BOTH the baseline
+    // (apply_baseline) AND the V032 migration step, and V029's `CREATE TABLE IF NOT EXISTS
+    // symbol_token_postings` runs BETWEEN them (the migration replay re-creates the table the
+    // baseline already dropped). An early return keyed on the now-present `token_bag` column would
+    // skip the DROP and leave that re-created postings table behind. Running both ops
+    // unconditionally (each a no-op when already in the target state) converges regardless of
+    // call order.
+    //
+    // Additive column — STRICT-valid BLOB type; existing rows default to NULL (R8).
+    add_column_if_missing(conn, "symbol_fingerprints", "token_bag", "BLOB")?;
+    // The per-token inverted-index table is replaced by the BLOB; its indexes drop with it.
+    conn.execute_batch("DROP TABLE IF EXISTS symbol_token_postings;")?;
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use migrations::*;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 31;
+pub const LATEST_SCHEMA_VERSION: u32 = 32;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -202,6 +202,11 @@ const MIGRATION_031_ID: &str = "031_edge_oracle_content_anchor";
 const MIGRATION_031_CHECKSUM: &str = "sha256:rag-rat-edge-oracle-content-anchor-v31";
 const MIGRATION_031_DESCRIPTION: &str = "Rebuild edge_oracle content-anchored (drop edges_data FK \
                                          + edge_id PK) so verdicts survive reindex (#248)";
+const MIGRATION_032_ID: &str = "032_clone_token_bag_blob";
+const MIGRATION_032_CHECKSUM: &str = "sha256:rag-rat-clone-token-bag-blob-v32";
+const MIGRATION_032_DESCRIPTION: &str = "Add symbol_fingerprints.token_bag BLOB + drop \
+                                         symbol_token_postings (BLOB-pack the clone token bag) \
+                                         (#231)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -487,6 +492,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_031_CHECKSUM,
         description: MIGRATION_031_DESCRIPTION,
         apply: apply_edge_oracle_content_anchor,
+    },
+    Migration {
+        id: MIGRATION_032_ID,
+        checksum: MIGRATION_032_CHECKSUM,
+        description: MIGRATION_032_DESCRIPTION,
+        apply: apply_token_bag_blob,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -68,9 +68,10 @@ pub(crate) const CASCADE_FK_ALLOWLIST: &[(&str, &str)] = &[
     ("logical_symbol_members", "logical_symbols"),
     // Per-symbol derived facts, rebuilt with the symbols they describe.
     ("symbol_facts", "symbols"),
-    // Clone-detection fingerprints + their inverted-index postings, rebuilt with the symbols.
+    // Clone-detection fingerprints, rebuilt with the symbols. The token bag rides this row as the
+    // `token_bag` BLOB column (#231) — `symbol_token_postings` was dropped in V032, so its former
+    // allowlist entry is gone.
     ("symbol_fingerprints", "symbols"),
-    ("symbol_token_postings", "symbols"),
 ];
 
 const DIRTY_MIGRATION_ID: &str = "__dirty__";

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -12456,12 +12456,17 @@ fn migration_031_edge_oracle_no_fk_content_key() {
         ",
     )
     .expect("recreate legacy V018 edge_oracle");
-    conn.execute_batch("DELETE FROM schema_version WHERE id = '031_edge_oracle_content_anchor';")
-        .expect("drop V031 ledger row");
+    // Drop the V031 AND V032 ledger rows: `known_version` reads the MAX applied version, so
+    // leaving V032 recorded would keep the schema Compatible and skip the forward migrate.
+    conn.execute_batch(
+        "DELETE FROM schema_version WHERE id = '031_edge_oracle_content_anchor';
+         DELETE FROM schema_version WHERE id = '032_clone_token_bag_blob';",
+    )
+    .expect("drop V031+ ledger rows");
     assert_eq!(
         schema::status(&conn).unwrap().state,
         schema::SchemaState::Older,
-        "schema is Older after dropping the V031 ledger row + reverting the table shape"
+        "schema is Older after dropping the V031/V032 ledger rows + reverting the table shape"
     );
     // Confirm the legacy FK is really there before migrating.
     let fk_before: i64 = conn

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -12737,6 +12737,66 @@ fn indexing_writes_baseline_fingerprints_for_functions() {
     let _ = fs::remove_dir_all(root);
 }
 
+/// T4 (#231): `refresh_clone_token_df` recomputed from the token-bag BLOBs equals the postings-era
+/// `GROUP BY symbol_token_postings` semantics — df = the count of DISTINCT symbols whose decoded
+/// bag contains each `(normalizer_kind, token_hash)`, with NO generated-file filter (R6). Build a
+/// real index, then independently re-derive the expected df from the BLOBs and assert it equals the
+/// persisted `clone_token_df` row-for-row.
+#[test]
+fn clone_token_df_recomputed_from_blobs_matches_postings_era() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    // Two renamed clones (shared tokens → some df == 2) + one distinct function (its tokens → df
+    // 1).
+    fs::write(
+        root.join("src/lib.rs"),
+        "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\npub fn \
+         load_order(store: Db) -> i32 { let o = store.get(20); validate(o); o + 1 }\npub fn \
+         compute_totals(items: Vec<i64>) -> i64 { let mut s = 0; for it in items { s += it * 2; } \
+         s + 1 }\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+
+    // Independently re-derive df from EVERY fingerprint BLOB (no generated filter — R6).
+    let mut stmt =
+        conn.prepare("SELECT normalizer_kind, token_bag FROM symbol_fingerprints").unwrap();
+    let mut expected: std::collections::BTreeMap<(String, i64), i64> =
+        std::collections::BTreeMap::new();
+    let mut rows = stmt.query([]).unwrap();
+    while let Some(row) = rows.next().unwrap() {
+        let kind: String = row.get(0).unwrap();
+        let Some(blob) = row.get::<_, Option<Vec<u8>>>(1).unwrap() else {
+            continue;
+        };
+        let bag = crate::index::clones::bag_blob::decode_token_bag(&blob).expect("decodes");
+        for (token_hash, _freq) in bag {
+            *expected.entry((kind.clone(), token_hash)).or_insert(0) += 1;
+        }
+    }
+    assert!(!expected.is_empty(), "fixture produced fingerprints");
+
+    // The persisted clone_token_df must match the independent recompute exactly.
+    let mut df_stmt =
+        conn.prepare("SELECT normalizer_kind, token_hash, df FROM clone_token_df").unwrap();
+    let mut persisted: std::collections::BTreeMap<(String, i64), i64> =
+        std::collections::BTreeMap::new();
+    let mut df_rows = df_stmt.query([]).unwrap();
+    while let Some(row) = df_rows.next().unwrap() {
+        persisted.insert((row.get(0).unwrap(), row.get(1).unwrap()), row.get(2).unwrap());
+    }
+    assert_eq!(persisted, expected, "clone_token_df == distinct-symbol count per token from BLOBs");
+    assert!(
+        expected.values().any(|&d| d == 2),
+        "the two renamed clones share at least one token (df == 2)"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
 #[test]
 fn candidate_components_group_renamed_clones_and_exclude_unrelated() {
     let root = unique_temp_root();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -12676,21 +12676,44 @@ fn indexing_writes_baseline_fingerprints_for_functions() {
         .unwrap();
     assert_eq!(fps, 2, "the two functions are fingerprinted; tiny() is below MIN_TOKENS");
 
-    // The inverted index carries postings for exactly the two fingerprinted symbols (R3).
-    let posting_symbols: i64 = conn
+    // The token bag rides each fingerprint row as a non-NULL `token_bag` BLOB (#231) — there is no
+    // symbol_token_postings table any more. Both fingerprinted symbols carry a bag that decodes to
+    // a non-empty `(token_hash, freq)` multiset matching their `token_len`.
+    let bagged_symbols: i64 = conn
         .query_row(
-            "SELECT count(DISTINCT symbol_id) FROM symbol_token_postings WHERE \
-             normalizer_kind='baseline'",
+            "SELECT count(*) FROM symbol_fingerprints
+             WHERE normalizer_kind='baseline' AND token_bag IS NOT NULL",
             [],
             |r| r.get(0),
         )
         .unwrap();
-    assert_eq!(
-        posting_symbols, 2,
-        "both fingerprinted functions get postings rows; tiny() does not"
-    );
+    assert_eq!(bagged_symbols, 2, "both fingerprinted functions carry a non-NULL token_bag BLOB");
 
-    // df is populated from the postings.
+    // Decode each BLOB and confirm it is a real bag (lossless: token_len == sum of freqs, no
+    // duplicate token_hash — the codec invariants exercised against indexed data).
+    let mut stmt = conn
+        .prepare(
+            "SELECT token_len, token_bag FROM symbol_fingerprints
+             WHERE normalizer_kind='baseline'",
+        )
+        .unwrap();
+    let rows: Vec<(i64, Vec<u8>)> = stmt
+        .query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, Vec<u8>>(1)?)))
+        .unwrap()
+        .map(|r| r.unwrap())
+        .collect();
+    for (token_len, blob) in &rows {
+        let bag = crate::index::clones::bag_blob::decode_token_bag(blob).expect("BLOB decodes");
+        assert!(!bag.is_empty(), "a fingerprinted symbol has a non-empty bag");
+        let total_freq: i64 = bag.iter().map(|&(_, f)| f).sum();
+        assert_eq!(total_freq, *token_len, "token_len == sum of freqs (lossless bag)");
+        let mut hashes: Vec<i64> = bag.iter().map(|&(h, _)| h).collect();
+        let distinct = hashes.len();
+        hashes.dedup();
+        assert_eq!(hashes.len(), distinct, "no duplicate token_hash in the indexed bag");
+    }
+
+    // df is populated (recomputed from the BLOBs at finalize).
     let df_rows: i64 =
         conn.query_row("SELECT count(*) FROM clone_token_df", [], |r| r.get(0)).unwrap();
     assert!(df_rows > 0, "clone_token_df is populated during indexing");
@@ -12705,14 +12728,11 @@ fn indexing_writes_baseline_fingerprints_for_functions() {
         .unwrap();
     assert!(max_df >= 2, "a token shared by both clones has df >= 2, got {max_df}");
 
-    // Cascade: deleting a symbol drops its fingerprint AND postings rows (FK + reindex freshness).
+    // Cascade: deleting a symbol drops its fingerprint row (the bag rides it as the BLOB column).
     conn.execute("DELETE FROM symbols", []).unwrap();
     let after_fps: i64 =
         conn.query_row("SELECT count(*) FROM symbol_fingerprints", [], |r| r.get(0)).unwrap();
-    assert_eq!(after_fps, 0, "fingerprints cascade on symbol delete");
-    let after_postings: i64 =
-        conn.query_row("SELECT count(*) FROM symbol_token_postings", [], |r| r.get(0)).unwrap();
-    assert_eq!(after_postings, 0, "postings cascade on symbol delete");
+    assert_eq!(after_fps, 0, "fingerprints (and their token_bag BLOBs) cascade on symbol delete");
 
     let _ = fs::remove_dir_all(root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -10497,12 +10497,12 @@ fn open_under_a_held_write_lock_migrates_older_schema_without_deadlock() {
         let db = IndexDatabase::rebuild(&config).unwrap();
         db.storage
             .connection()
-            .execute("DELETE FROM schema_version WHERE id = '031_edge_oracle_content_anchor'", [])
+            .execute("DELETE FROM schema_version WHERE id = '032_clone_token_bag_blob'", [])
             .unwrap();
         assert_eq!(
             schema::status(db.storage.connection()).unwrap().state,
             schema::SchemaState::Older,
-            "removing the newest (V031) ledger row makes the schema Older"
+            "removing the newest (V032) ledger row makes the schema Older"
         );
     }
 
@@ -10527,7 +10527,7 @@ fn v022_fresh_apply_creates_packages_and_dedicated_import_scope_columns() {
     schema::apply(&conn).unwrap();
 
     assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 31);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 32);
     assert!(conn_table_exists(&conn, "packages"), "packages table is created on a fresh apply");
 
     let package_cols = conn_table_columns(&conn, "packages");
@@ -10604,6 +10604,7 @@ fn v022_forward_migrate_adds_artifacts_to_an_older_index() {
         DELETE FROM schema_version WHERE id = '029_clone_fingerprint_tables';
         DELETE FROM schema_version WHERE id = '030_clone_refinements_lcs_sampled';
         DELETE FROM schema_version WHERE id = '031_edge_oracle_content_anchor';
+        DELETE FROM schema_version WHERE id = '032_clone_token_bag_blob';
         ",
     )
     .unwrap();
@@ -10749,13 +10750,14 @@ fn v028_forward_migrate_interns_and_drops_the_inline_column() {
         "DELETE FROM schema_version WHERE id = '028_intern_symbol_qualified_names';
          DELETE FROM schema_version WHERE id = '029_clone_fingerprint_tables';
          DELETE FROM schema_version WHERE id = '030_clone_refinements_lcs_sampled';
-         DELETE FROM schema_version WHERE id = '031_edge_oracle_content_anchor';",
+         DELETE FROM schema_version WHERE id = '031_edge_oracle_content_anchor';
+         DELETE FROM schema_version WHERE id = '032_clone_token_bag_blob';",
     )
     .unwrap();
     assert_eq!(
         schema::status(&conn).unwrap().state,
         schema::SchemaState::Older,
-        "removing the V028..V031 ledger rows makes the pre-V028 shape Older"
+        "removing the V028..V032 ledger rows makes the pre-V028 shape Older"
     );
 
     // --- Forward-migrate ---
@@ -12218,14 +12220,14 @@ fn impact_completeness_flags_a_dirty_callee_definition_file() {
 }
 
 #[test]
-fn v029_creates_clone_fingerprint_tables_on_fresh_and_migrated_dbs() {
-    // Fresh DB: apply() must create the SourcererCC postings tables + refinements, and report
-    // Compatible at the latest version. fingerprint_bands must NOT exist (dropped in R1 rework).
+fn clone_substrate_has_token_bag_blob_and_no_postings_on_fresh_and_migrated_dbs() {
+    // V032 (#231) BLOB-packs the token bag: `symbol_token_postings` is dropped and a `token_bag`
+    // BLOB column rides `symbol_fingerprints`. V029 still CREATEs the postings table; V032 drops it
+    // (R5 — V029 is never edited), so after apply()/migrate_forward the postings table must be GONE
+    // and the column present. The other clone tables (refinements, df) survive.
     let conn = rusqlite::Connection::open_in_memory().expect("open");
     crate::index::schema::apply(&conn).expect("apply");
-    for table in
-        ["symbol_fingerprints", "symbol_token_postings", "clone_token_df", "clone_refinements"]
-    {
+    for table in ["symbol_fingerprints", "clone_token_df", "clone_refinements"] {
         let n: i64 = conn
             .query_row(
                 "SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?1",
@@ -12235,21 +12237,27 @@ fn v029_creates_clone_fingerprint_tables_on_fresh_and_migrated_dbs() {
             .expect("query");
         assert_eq!(n, 1, "{table} should exist after apply()");
     }
-    // fingerprint_bands was replaced by symbol_token_postings + clone_token_df in R1.
-    let bands: i64 = conn
-        .query_row(
-            "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='fingerprint_bands'",
-            [],
-            |r| r.get(0),
-        )
-        .expect("query bands");
-    assert_eq!(bands, 0, "fingerprint_bands must not exist after R1 rework");
+    // symbol_token_postings is dropped by V032; fingerprint_bands was already gone (R1 rework).
+    for absent in ["symbol_token_postings", "fingerprint_bands"] {
+        let n: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?1",
+                [absent],
+                |r| r.get(0),
+            )
+            .expect("query absent");
+        assert_eq!(n, 0, "{absent} must not exist after V032");
+    }
+    assert!(
+        conn_table_columns(&conn, "symbol_fingerprints").contains(&"token_bag".to_string()),
+        "symbol_fingerprints gains the token_bag BLOB column on a fresh apply()"
+    );
 
     let status = crate::index::schema::status(&conn).expect("status");
     assert_eq!(status.current_version, crate::index::schema::LATEST_SCHEMA_VERSION);
     assert!(matches!(status.state, crate::index::schema::SchemaState::Compatible));
 
-    // Migrated DB: a DB at the prior baseline that runs migrate_forward gains the new tables too.
+    // Migrated DB: a DB driven through migrate_forward reaches the same post-V032 shape.
     let conn2 = rusqlite::Connection::open_in_memory().expect("open2");
     crate::index::schema::apply(&conn2).expect("apply2"); // already-latest is a no-op forward
     crate::index::schema::migrate_forward(&conn2).expect("migrate_forward");
@@ -12261,7 +12269,11 @@ fn v029_creates_clone_fingerprint_tables_on_fresh_and_migrated_dbs() {
             |r| r.get(0),
         )
         .expect("query2");
-    assert_eq!(postings, 1, "symbol_token_postings must exist after migrate_forward");
+    assert_eq!(postings, 0, "symbol_token_postings must be gone after migrate_forward");
+    assert!(
+        conn_table_columns(&conn2, "symbol_fingerprints").contains(&"token_bag".to_string()),
+        "symbol_fingerprints carries token_bag after migrate_forward"
+    );
     let df: i64 = conn2
         .query_row(
             "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='clone_token_df'",
@@ -12270,6 +12282,64 @@ fn v029_creates_clone_fingerprint_tables_on_fresh_and_migrated_dbs() {
         )
         .expect("query3");
     assert_eq!(df, 1, "clone_token_df must exist after migrate_forward");
+}
+
+/// V032 forward migrate (#231): an index recorded at V031 (postings table present, NO `token_bag`
+/// column) must, after migrate_forward, gain the `token_bag` BLOB column and lose
+/// `symbol_token_postings`. Simulates the pre-V032 shape by re-creating the postings table +
+/// dropping the column + deleting the V032 ledger row (making the schema Older), then replays.
+#[test]
+fn migration_032_adds_token_bag_drops_postings() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    crate::index::schema::apply(&conn).expect("apply");
+
+    // --- Simulate a V031-era index: postings table present, no token_bag column ---
+    conn.execute_batch(
+        "ALTER TABLE symbol_fingerprints DROP COLUMN token_bag;
+         CREATE TABLE IF NOT EXISTS symbol_token_postings(
+             symbol_id       INTEGER NOT NULL REFERENCES symbols(id) ON DELETE CASCADE,
+             normalizer_kind TEXT    NOT NULL,
+             token_hash      INTEGER NOT NULL,
+             freq            INTEGER NOT NULL,
+             PRIMARY KEY (symbol_id, normalizer_kind, token_hash)
+         ) STRICT;
+         DELETE FROM schema_version WHERE id = '032_clone_token_bag_blob';",
+    )
+    .expect("revert to V031 shape");
+    assert!(
+        !conn_table_columns(&conn, "symbol_fingerprints").contains(&"token_bag".to_string()),
+        "token_bag is absent before the migration runs"
+    );
+    assert!(conn_table_exists(&conn, "symbol_token_postings"), "postings present at V031");
+    assert_eq!(
+        crate::index::schema::status(&conn).unwrap().state,
+        crate::index::schema::SchemaState::Older,
+        "schema is Older after removing the V032 ledger row"
+    );
+
+    // --- Run the forward migration ---
+    crate::index::schema::migrate_forward(&conn).expect("migrate_forward");
+
+    assert!(
+        conn_table_columns(&conn, "symbol_fingerprints").contains(&"token_bag".to_string()),
+        "V032 adds the token_bag BLOB column"
+    );
+    assert!(!conn_table_exists(&conn, "symbol_token_postings"), "V032 drops symbol_token_postings");
+    // The column is a queryable BLOB.
+    let _: i64 = conn
+        .query_row("SELECT COUNT(token_bag) FROM symbol_fingerprints", [], |r| r.get(0))
+        .expect("SELECT token_bag must succeed after V032");
+    assert_eq!(
+        crate::index::schema::status(&conn).unwrap().current_version,
+        crate::index::schema::LATEST_SCHEMA_VERSION,
+        "schema is at LATEST_SCHEMA_VERSION after V032"
+    );
+    // Idempotency: a second migrate_forward is a clean no-op (guarded on the token_bag column).
+    crate::index::schema::migrate_forward(&conn).expect("migrate_forward is idempotent");
+    assert!(matches!(
+        crate::index::schema::status(&conn).unwrap().state,
+        crate::index::schema::SchemaState::Compatible
+    ));
 }
 
 /// Regression test for the P1 schema bug (#215 Plan 4a): an index recorded at V029 WITHOUT
@@ -12306,7 +12376,8 @@ fn v030_forward_migrate_adds_lcs_sampled_to_existing_v029_index() {
     // `known_version` would still report LATEST and the schema would read Compatible.
     conn.execute_batch(
         "DELETE FROM schema_version
-         WHERE id IN ('030_clone_refinements_lcs_sampled', '031_edge_oracle_content_anchor');",
+         WHERE id IN ('030_clone_refinements_lcs_sampled', '031_edge_oracle_content_anchor',
+                      '032_clone_token_bag_blob');",
     )
     .expect("delete V030+ ledger rows");
     assert_eq!(
@@ -12339,8 +12410,8 @@ fn v030_forward_migrate_adds_lcs_sampled_to_existing_v029_index() {
     );
     assert_eq!(
         crate::index::schema::LATEST_SCHEMA_VERSION,
-        31,
-        "LATEST_SCHEMA_VERSION is 31 after V031"
+        32,
+        "LATEST_SCHEMA_VERSION is 32 after V032"
     );
     // Idempotency: running migrate_forward again must not error.
     crate::index::schema::migrate_forward(&conn).expect("migrate_forward is idempotent");


### PR DESCRIPTION
Fixes #231. Addresses the genuine #215/#247 residual indexing cost.

## What
Store each function symbol's normalized clone token bag as **one serialized BLOB column** (`token_bag`) on `symbol_fingerprints` instead of **N per-token `symbol_token_postings` rows**, and drop `symbol_token_postings` entirely. On the cargo bench corpus that collapses the dominant clone-indexing write from **~484k single-row INSERTs to ~9.4k** (one BLOB folded into the existing fingerprint INSERT).

## Why
A controlled A/B on current main isolated the per-token `symbol_token_postings` write as **~1.18s (~19%) of `full_rebuild_cargo`** — essentially 100% of the #215 index-path cost (the fingerprint *compute* is within noise). It's the #231 lever, held in reserve until the cheap fixes (#229) weren't enough.

## How it stays correct (recall is the load-bearing invariant)
The candidate read already loaded bags **by `symbol_id`** and built the inverted index (token_hash→symbols) **in Rust** — there is **no SQL reverse lookup** anywhere — so BLOB-pack just swaps "GROUP BY rows" for "decode one BLOB":
- `load_scoped_baseline_bags` decodes the BLOB and looks up df from a one-shot `HashMap` (no per-token join), producing the identical `SymbolBag`.
- `clone_token_df` is recomputed by aggregating the BLOBs in Rust, matching the old GROUP BY scope **exactly** (incl. generated-file symbols; df feeds candidate *generation*, not just ranking).
- **`recall_candidates_identical_blob_vs_postings_grouping`** pins byte-identical candidates on a real multi-file renamed-clone index; `clone_token_df_recomputed_from_blobs_matches_postings_era` pins the df.
- BLOB codec: fixed-width LE `(token_hash, freq)` pairs sorted by token_hash + a version header (NORM_VERSION-guarded); round-trip + no-duplicate-token + lossless tests.

## Migration (V032) + lifecycle
`ADD COLUMN token_bag BLOB` + `DROP TABLE symbol_token_postings` as an idempotency-guarded unconditional transform (the V031 pattern — does **not** edit the V029 DDL). Existing rows get `token_bag = NULL` and repopulate on the next index (the V029/V031 one-time-rebuild precedent); **clone recall is undefined until the post-migration reindex** (the struct_hash fast path would otherwise pair NULL-bag symbols). `token_bag` rides `symbol_fingerprints` (symbol_id-keyed, FK-cascade on symbol removal), so the #248 reindex-survival trip-wire still passes (its stale `symbol_token_postings` allowlist entry is removed). The `delete_staged_files_cascade` postings DELETE is removed (would otherwise error `no such table` on every reindex).

## Verification
983 tests green across `rag-rat-core` + `rag-rat` + `rag-rat-mcp`; clippy `-D warnings` + nightly fmt clean. The fix went through plan → 3-explorer adversarial plan review (NO-GO findings folded: the 4th DELETE site, the full set of version-assertion/table-existence/Older-fixture test sites, the df-as-Rust-HashMap correction, the NULL-bag-transient clarification, the don't-edit-V029 migration shape) → implementation.

**Perf:** the local `index_time` criterion bench can't run reliably on the dev box (a pre-existing bench-harness bug: it leaks one full-corpus temp DB per iteration → ~80-110GB transient; tracked as a follow-up). The win is established by the A/B (~1.18s postings-write removed) + the 484k→9.4k structural reduction; **CI `bench-pr-track` measures the actual `full_rebuild_cargo` delta** vs the (just-rebaselined, #247) main threshold.

## Follow-ups
- `index_time` bench harness leaks a temp DB per iteration — should clean per-iteration (separate hygiene issue).
- Plan-3 SCIP secondary bag (deferred) would BLOB-pack the same way (`normalizer_kind` already on `symbol_fingerprints`).
