### PR TITLE
feat(clones): multi-language correctness — comments, literals, TS function-valued declarators, generated-skip (#232)

### DIFF
--- a/crates/rag-rat-core/src/index/clones/mod.rs
+++ b/crates/rag-rat-core/src/index/clones/mod.rs
@@ -15,7 +15,15 @@ use tree_sitter::Node;
 
 /// Bumped when normalization changes; invalidates fingerprints (and the later refine cache) without
 /// a schema migration.
-pub(crate) const NORM_VERSION: i64 = 1;
+///
+/// `2` (#232): the normalization stream changed in two ways that affect every fingerprint — (1)
+/// comments and other tree-sitter EXTRAs are skipped (`walk_spanned`), and (2) multi-language
+/// literal leaves bucket (TS `string_fragment` → `LIT_STRING_FRAGMENT`; `true`/`false` value-erase
+/// to `LIT_BOOL`). The already-shipped read filter (`sf.normalizer_version = NORM_VERSION` on every
+/// fingerprint read) auto-EXCLUDES the v1 rows, which are recomputed at v2 on the next reindex; the
+/// 4b refinement cache invalidates via `NORM_VERSION` in the content-addressed `refinement_key` +
+/// the freshness predicate (`refine::cache`). No schema migration is needed.
+pub(crate) const NORM_VERSION: i64 = 2;
 /// Bumped when the LCS alignment / refinement algorithm changes; participates in the content-
 /// addressed `refinement_key` and in the `clone_refinements` cache freshness predicate, so a bump
 /// invalidates every cached refinement without a schema migration (the same discipline as
@@ -137,6 +145,15 @@ mod tests {
     /// Rust-only wrapper — the existing Rust fingerprint tests call this unchanged.
     fn fp(src: &str) -> Option<SymbolFingerprint> {
         fp_lang(src, "t.rs", Language::Rust)
+    }
+
+    #[test]
+    fn norm_version_is_2() {
+        // #232: the comment-skip (T2) + multi-language literal bucketing (T3) changed the
+        // normalization stream, so NORM_VERSION must be 2. The read filter + content-addressed
+        // refinement key both key off this constant, so a stream change without the bump silently
+        // serves stale fingerprints/refinements.
+        assert_eq!(NORM_VERSION, 2);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/clones/mod.rs
+++ b/crates/rag-rat-core/src/index/clones/mod.rs
@@ -112,12 +112,41 @@ mod tests {
     use crate::index::parser;
     use crate::language::Language;
 
-    fn fp(src: &str) -> Option<SymbolFingerprint> {
-        let parsed = parser::parse_file(Path::new("t.rs"), Language::Rust, src).expect("parse");
-        let func = parsed.symbols.iter().find(|s| s.kind == "function").expect("function");
-        let node =
-            parsed.root().descendant_for_byte_range(func.start_byte, func.end_byte).expect("node");
+    /// Generalized fingerprint harness (#232): parse `src` with `language` (under `path`), select
+    /// the target symbol — the one whose subtree normalizes to the MOST tokens, language-agnostic
+    /// so it works for Rust `function`, TS `const`/function-valued declarators, and Python
+    /// `function` alike — and return its fingerprint (`None` below `MIN_TOKENS`). Test fixtures
+    /// MUST clear `MIN_TOKENS` (20) or `fp_lang` returns `None` for the size gate, not the
+    /// property under test.
+    fn fp_lang(src: &str, path: &str, language: Language) -> Option<SymbolFingerprint> {
+        let parsed = parser::parse_file(Path::new(path), language, src).expect("parse");
+        let node = parsed
+            .symbols
+            .iter()
+            .filter_map(|s| {
+                let node = parsed.root().descendant_for_byte_range(s.start_byte, s.end_byte)?;
+                let len = normalize::normalize_baseline(node, src).len();
+                Some((len, node))
+            })
+            .max_by_key(|(len, _)| *len)
+            .map(|(_, node)| node)
+            .expect("at least one symbol with a normalizable subtree");
         fingerprint_symbol(node, src)
+    }
+
+    /// Rust-only wrapper — the existing Rust fingerprint tests call this unchanged.
+    fn fp(src: &str) -> Option<SymbolFingerprint> {
+        fp_lang(src, "t.rs", Language::Rust)
+    }
+
+    #[test]
+    fn fp_lang_fingerprints_ts_and_python() {
+        // Smoke test for the generalized fingerprint harness — both fixtures clear MIN_TOKENS (20).
+        let ts = "function f() { const a = get(1); const b = get(2); const c = get(3); return a + \
+                  b + c; }";
+        assert!(fp_lang(ts, "t.ts", Language::TypeScript).is_some(), "TS fn must fingerprint");
+        let py = "def f():\n    a = get(1)\n    b = get(2)\n    c = get(3)\n    return a + b + c\n";
+        assert!(fp_lang(py, "t.py", Language::Python).is_some(), "Python fn must fingerprint");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/clones/mod.rs
+++ b/crates/rag-rat-core/src/index/clones/mod.rs
@@ -86,12 +86,31 @@ pub(crate) fn fingerprint_symbol(node: Node<'_>, text: &str) -> Option<SymbolFin
     })
 }
 
-/// Baseline fingerprints for a file's function symbols, walking the SHARED parse tree (no re-parse,
-/// no DB). Returns `(local_symbol_index, fingerprint)` pairs keyed by index into `symbols`, so the
-/// caller maps each to the right DB id when it writes. Non-function symbols, symbols that can't be
-/// located in the tree, and bodies that normalize below `MIN_TOKENS` are skipped. The full-rebuild
-/// prepare phase calls this from the parse it already did for symbols/edges; the incremental path
-/// re-parses and calls it from `store_symbol_fingerprints`.
+/// `true` when a symbol's AST node is a FUNCTION-VALUED declarator: a `variable_declarator`
+/// (`const f = () => {…}`, `let f = function(){…}`) or `public_field_definition` (a class-field
+/// arrow handler) whose `value` child is an `arrow_function` / `function_expression` (#232 #5).
+///
+/// These carry symbol `kind = "const"` in `parser.rs` (NOT changed — `kind` drives chunking, graph
+/// edges, and search facets; see the plan's invariant) but ARE real function bodies worth
+/// fingerprinting: two `const x = () => {…}` clones match each other (same declarator shape). The
+/// node-level check is what keeps a plain-value `const x = 5;` excluded — its `value` child is a
+/// `number`, not a function. Probe-confirmed against the wired TS grammar: matches const-arrow,
+/// const-func-expr, let-async-arrow, and class-field-arrow; rejects destructure / number / object.
+fn symbol_is_function_valued(node: Node<'_>) -> bool {
+    matches!(node.kind(), "variable_declarator" | "public_field_definition")
+        && node
+            .child_by_field_name("value")
+            .is_some_and(|v| matches!(v.kind(), "arrow_function" | "function_expression"))
+}
+
+/// Baseline fingerprints for a file's fingerprintable symbols, walking the SHARED parse tree (no
+/// re-parse, no DB). Returns `(local_symbol_index, fingerprint)` pairs keyed by index into
+/// `symbols`, so the caller maps each to the right DB id when it writes. A symbol is fingerprinted
+/// when it is a `kind == "function"` symbol OR a function-valued declarator
+/// ([`symbol_is_function_valued`], #232 #5); symbols that can't be located in the tree and bodies
+/// that normalize below `MIN_TOKENS` are skipped. The full-rebuild prepare phase calls this from
+/// the parse it already did for symbols/edges; the incremental path re-parses and calls it from
+/// `store_symbol_fingerprints`.
 pub(crate) fn fingerprint_symbols(
     root: Node<'_>,
     text: &str,
@@ -99,12 +118,14 @@ pub(crate) fn fingerprint_symbols(
 ) -> Vec<(usize, SymbolFingerprint)> {
     let mut out = Vec::new();
     for (i, symbol) in symbols.iter().enumerate() {
-        if symbol.kind != "function" {
-            continue;
-        }
         let Some(node) = root.descendant_for_byte_range(symbol.start_byte, symbol.end_byte) else {
             continue;
         };
+        // Fingerprint a `function` symbol OR a function-valued declarator (the node check rejects
+        // plain-value consts — `const x = 5;` — so symbol `kind` stays unchanged, #232 #5 / R2).
+        if symbol.kind != "function" && !symbol_is_function_valued(node) {
+            continue;
+        }
         if let Some(fp) = fingerprint_symbol(node, text) {
             out.push((i, fp));
         }
@@ -117,7 +138,7 @@ mod tests {
     use std::path::Path;
 
     use super::*;
-    use crate::index::parser;
+    use crate::index::{parser, symbols};
     use crate::language::Language;
 
     /// Generalized fingerprint harness (#232): parse `src` with `language` (under `path`), select
@@ -179,5 +200,82 @@ mod tests {
     #[test]
     fn trivial_bodies_below_min_tokens_are_not_fingerprinted() {
         assert!(fp("fn x() -> i32 { 0 }").is_none());
+    }
+
+    // ── Task 5 (#232): function-valued declarators are fingerprinted (kind unchanged)
+    // ─────────
+
+    #[test]
+    fn ts_function_valued_declarator_is_fingerprinted() {
+        // A `const`-bound arrow function (>20 tokens, clears MIN_TOKENS) IS fingerprinted even
+        // though its symbol `kind` is "const" (#232 #5).
+        let arrow = "const load = (id) => { const row = get(id); const ok = check(row); return ok \
+                     ? row : null; }";
+        assert!(
+            fp_lang(arrow, "t.ts", Language::TypeScript).is_some(),
+            "const-bound arrow function must be fingerprinted"
+        );
+
+        // A `let`-bound async arrow (>20 tokens) IS fingerprinted too.
+        let async_arrow = "let run = async (q) => { const a = await fetch(q); const b = await \
+                           parse(a); return b.value; }";
+        assert!(
+            fp_lang(async_arrow, "t.ts", Language::TypeScript).is_some(),
+            "let-bound async arrow must be fingerprinted"
+        );
+    }
+
+    #[test]
+    fn ts_class_field_arrow_handler_is_fingerprinted() {
+        // A class-field arrow handler (`public_field_definition` with arrow value, >20 tokens) IS
+        // fingerprinted (#232 #5).
+        let field = "class C { handler = (ev) => { const x = read(ev); const y = norm(x); \
+                     send(y); return y; } }";
+        assert!(
+            fp_lang(field, "t.ts", Language::TypeScript).is_some(),
+            "class-field arrow handler must be fingerprinted"
+        );
+    }
+
+    #[test]
+    fn ts_large_non_function_value_const_is_not_fingerprinted() {
+        // R3: the negative MUST be a >20-token NON-function value to isolate
+        // `symbol_is_function_valued` (a <20-token `const x = 5` would pass for the WRONG
+        // reason — the MIN_TOKENS size gate). A large object-literal const clears
+        // MIN_TOKENS but its `value` child is an `object`, not a function, so it is NOT
+        // fingerprinted.
+        let big_object =
+            "const cfg = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10, k: 11 };";
+        let parsed =
+            parser::parse_file(Path::new("t.ts"), Language::TypeScript, big_object).expect("parse");
+        let decl = parsed.symbols.iter().find(|s| s.kind == "const").expect("a const symbol");
+        let node =
+            parsed.root().descendant_for_byte_range(decl.start_byte, decl.end_byte).expect("node");
+        // Clears MIN_TOKENS (so this isn't the size gate) but is NOT function-valued.
+        assert!(
+            normalize::normalize_baseline(node, big_object).len() >= MIN_TOKENS,
+            "fixture must clear MIN_TOKENS so the negative isolates the value guard"
+        );
+        assert!(
+            !symbol_is_function_valued(node),
+            "object-literal const must not be function-valued"
+        );
+        let fps =
+            fingerprint_symbols(parsed.root(), big_object, &symbols::from_parsed(&parsed.symbols));
+        assert!(
+            fps.is_empty(),
+            "a large non-function-value const must NOT be fingerprinted: {fps:?}"
+        );
+    }
+
+    #[test]
+    fn ts_const_kind_is_unchanged_by_fingerprint_guard() {
+        // #232 #5 must NOT change symbol `kind`: a function-valued declarator is still classified
+        // `const` (the guard is fingerprint-local; parser.rs is untouched).
+        let arrow = "const load = (id) => { const row = get(id); return row; }";
+        let parsed =
+            parser::parse_file(Path::new("t.ts"), Language::TypeScript, arrow).expect("parse");
+        let sym = parsed.symbols.iter().find(|s| s.name == "load").expect("load symbol");
+        assert_eq!(sym.kind, "const", "function-valued declarator keeps kind=const");
     }
 }

--- a/crates/rag-rat-core/src/index/clones/normalize.rs
+++ b/crates/rag-rat-core/src/index/clones/normalize.rs
@@ -97,6 +97,19 @@ fn walk_spanned(
     let start_byte = node.start_byte();
     let end_byte = node.end_byte();
 
+    // (#232 #1) Comments and other tree-sitter EXTRAs (e.g. Python `line_continuation`) carry no
+    // semantic token: skip the WHOLE subtree, pushing NEITHER a token NOR a span so the seq↔span
+    // bijection is preserved. The OR is load-bearing (R4): `is_extra()` catches every grammar's
+    // comments via the runtime EXTRA flag PLUS non-comment extras like `line_continuation`, while
+    // the explicit `kind.contains("comment")` is a belt-and-braces guard for any grammar that
+    // flags a comment as a normal (non-extra) node — neither predicate alone covers all six
+    // grammars, so we keep both. (Comments themselves never anchor a clone variation point;
+    // skipping them at the source means no caller — antiunify, signature recovery — ever sees a
+    // comment span.)
+    if node.is_extra() || kind.contains("comment") {
+        return;
+    }
+
     if node.child_count() == 0 {
         // Leaf: push the token and its span.
         let leaf = node.utf8_text(src).unwrap_or("");
@@ -198,6 +211,57 @@ mod tests {
         );
         assert!(!py.is_empty(), "Python normalize stream must be non-empty");
         assert!(py.iter().any(|t| t == "return_statement"), "Python stream missing body: {py:?}");
+    }
+
+    // ── Task 2 (#232): comments are ignored
+    // ──────────────────────────────────────────
+
+    /// For Rust (`//`, `/* */`), TS (`//`, `/* */`), and Python (`#`): two function bodies that
+    /// differ ONLY by comments normalize to the SAME token stream (comments carry no semantic
+    /// token), and the seq↔span bijection holds throughout.
+    #[test]
+    fn comments_are_ignored_across_languages() {
+        // Rust — line + block comments.
+        let rust_plain = "fn f(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }";
+        let rust_commented = "fn f(db: Db) -> i32 {\n    // load it\n    let u = db.get(10); /* \
+                              hmm */ validate(u); u + 1 }";
+        let (tp, sp) = spanned(rust_plain);
+        let (tc, sc) = spanned(rust_commented);
+        assert_eq!(tp, tc, "Rust comment-only diff must normalize equal");
+        assert_eq!(tp.len(), sp.len(), "bijection broken (rust plain)");
+        assert_eq!(tc.len(), sc.len(), "bijection broken (rust commented)");
+
+        // TypeScript — line + block comments.
+        let ts_plain = "function f() { const a = get(1); const b = get(2); return a + b; }";
+        let ts_commented =
+            "function f() {\n  // a\n  const a = get(1); /* b */ const b = get(2); return a + b; }";
+        let (ttp, _) = spanned_lang(ts_plain, "t.ts", Language::TypeScript);
+        let (ttc, ttcs) = spanned_lang(ts_commented, "t.ts", Language::TypeScript);
+        assert_eq!(ttp, ttc, "TS comment-only diff must normalize equal");
+        assert_eq!(ttc.len(), ttcs.len(), "bijection broken (ts commented)");
+
+        // Python — `#` comments.
+        let py_plain = "def f():\n    a = get(1)\n    b = get(2)\n    return a + b\n";
+        let py_commented =
+            "def f():\n    # load a\n    a = get(1)\n    b = get(2)  # and b\n    return a + b\n";
+        let (typ, _) = spanned_lang(py_plain, "t.py", Language::Python);
+        let (tyc, tycs) = spanned_lang(py_commented, "t.py", Language::Python);
+        assert_eq!(typ, tyc, "Python comment-only diff must normalize equal");
+        assert_eq!(tyc.len(), tycs.len(), "bijection broken (py commented)");
+    }
+
+    /// Python `line_continuation` (`\` at EOL) is a tree-sitter EXTRA leaf, not a comment — the
+    /// `is_extra()` arm of the skip catches it (R4). It carries no semantic token, so a body with a
+    /// line continuation normalizes equal to the same body written on one line, and the bijection
+    /// still holds.
+    #[test]
+    fn python_line_continuation_is_skipped() {
+        let one_line = "def f():\n    x = aaa + bbb + ccc\n    return x\n";
+        let continued = "def f():\n    x = aaa + \\\n        bbb + ccc\n    return x\n";
+        let (t1, _) = spanned_lang(one_line, "t.py", Language::Python);
+        let (t2, s2) = spanned_lang(continued, "t.py", Language::Python);
+        assert_eq!(t1, t2, "line_continuation must not change the normalized stream");
+        assert_eq!(t2.len(), s2.len(), "bijection broken (py line_continuation)");
     }
 
     // ── Original tests (must stay green)

--- a/crates/rag-rat-core/src/index/clones/normalize.rs
+++ b/crates/rag-rat-core/src/index/clones/normalize.rs
@@ -9,9 +9,28 @@ fn is_identifier_kind(kind: &str) -> bool {
 }
 
 /// A leaf kind that is a literal whose *value* must not drive matching.
+///
+/// `string_fragment` is the TypeScript/JavaScript string-body leaf (the text inside the quotes, the
+/// counterpart to Python's `string_content` — both are the value-bearing inner leaf, #232 #2a). It
+/// buckets to `LIT_STRING_FRAGMENT`, which the anti-unify/signature contract maps to `&str` (see
+/// `signature::literal_bucket_to_type`).
 fn is_literal_kind(kind: &str) -> bool {
     kind.ends_with("literal")
-        || matches!(kind, "string_content" | "integer" | "float" | "number" | "char")
+        || matches!(
+            kind,
+            "string_content" | "string_fragment" | "integer" | "float" | "number" | "char"
+        )
+}
+
+/// A leaf kind that is a boolean literal across the wired grammars: Rust emits `true`/`false` as
+/// leaves under an internal `boolean_literal`; TypeScript and Python emit bare `true`/`false`
+/// leaves (Python lexemes `True`/`False` map to kinds `true`/`false`). Bucketing both to ONE
+/// `LIT_BOOL` token (not `LIT_TRUE`/`LIT_FALSE`) value-ERASES the boolean: two bodies differing
+/// only in `true` vs `false` then normalize equal, and `LIT_BOOL` recovers `bool` typing in the
+/// signature contract (#232 #2b). The single bucket is why this is NOT routed through the generic
+/// `LIT_{kind.uppercased}` path — that would encode the value.
+fn is_boolean_leaf_kind(kind: &str) -> bool {
+    matches!(kind, "true" | "false")
 }
 
 /// `true` for a tree-sitter node kind that names a Rust type position — a bare type name
@@ -117,10 +136,17 @@ fn walk_spanned(
             let next = idents.len();
             let id = *idents.entry(leaf.to_string()).or_insert(next);
             format!("ID{id}")
+        } else if is_boolean_leaf_kind(kind) {
+            // Value-erase booleans to ONE bucket (NOT `LIT_{kind.uppercased}`): `true`/`false`
+            // collapse to `LIT_BOOL` so a true↔false-only diff is a clone (#232 #2b).
+            "LIT_BOOL".to_string()
         } else if is_literal_kind(kind) {
             format!("LIT_{}", kind.to_ascii_uppercase())
         } else {
-            // keyword / operator / punctuation — structural, kept verbatim
+            // (#232 #2c) NULL-FAMILY out of scope (low value + wrapped-node hazard): `null` /
+            // `undefined` (TS), `none` (Python), and the C/C++ `NULL`/`nullptr` leaves stay
+            // verbatim. keyword / operator / punctuation / null-family — structural,
+            // kept verbatim
             leaf.to_string()
         };
         tokens.push(token);
@@ -262,6 +288,85 @@ mod tests {
         let (t2, s2) = spanned_lang(continued, "t.py", Language::Python);
         assert_eq!(t1, t2, "line_continuation must not change the normalized stream");
         assert_eq!(t2.len(), s2.len(), "bijection broken (py line_continuation)");
+    }
+
+    // ── Task 3 (#232): multi-language literal bucketing
+    // ───────────────────────────────────
+
+    /// TS strings (`string_fragment`) and booleans (`true`/`false` → `LIT_BOOL`) bucket: two bodies
+    /// differing ONLY in string contents normalize equal, and two differing ONLY in `true` vs
+    /// `false` normalize equal (the `LIT_BOOL` value-erase, #232 #2b).
+    #[test]
+    fn ts_strings_and_booleans_bucket() {
+        // Strings — differ only in the quoted contents.
+        let s1 = "function f() { const a = log(\"hello\"); const b = log(\"world\"); return a; }";
+        let s2 = "function f() { const a = log(\"foo\"); const b = log(\"bar\"); return a; }";
+        assert_eq!(
+            norm_lang(s1, "t.ts", Language::TypeScript),
+            norm_lang(s2, "t.ts", Language::TypeScript),
+            "TS string-content-only diff must normalize equal (string_fragment bucketed)"
+        );
+
+        // Booleans — differ only in true vs false.
+        let b_true = "function f() { const x = check(); const y = x; return true; }";
+        let b_false = "function f() { const x = check(); const y = x; return false; }";
+        let nt = norm_lang(b_true, "t.ts", Language::TypeScript);
+        let nf = norm_lang(b_false, "t.ts", Language::TypeScript);
+        assert_eq!(nt, nf, "TS true/false-only diff must normalize equal (LIT_BOOL)");
+        assert!(nt.iter().any(|t| t == "LIT_BOOL"), "TS boolean must emit LIT_BOOL: {nt:?}");
+    }
+
+    /// Python booleans (`True`/`False`, leaf kinds `true`/`false`) bucket to `LIT_BOOL`; `None`
+    /// (the null-family) stays verbatim — out of scope (#232 #2c).
+    #[test]
+    fn python_booleans_bucket_null_stays_verbatim() {
+        let t = "def f():\n    x = check()\n    y = x\n    return True\n";
+        let f = "def f():\n    x = check()\n    y = x\n    return False\n";
+        let nt = norm_lang(t, "t.py", Language::Python);
+        let nf = norm_lang(f, "t.py", Language::Python);
+        assert_eq!(nt, nf, "Python True/False-only diff must normalize equal (LIT_BOOL)");
+        assert!(
+            nt.iter().any(|tok| tok == "LIT_BOOL"),
+            "Python boolean must emit LIT_BOOL: {nt:?}"
+        );
+
+        // null-family deferred: `None` stays VERBATIM (the leaf kind is `none`, but the verbatim
+        // branch pushes the leaf TEXT `None` — no LIT_ bucket, #232 #2c).
+        let n = "def f():\n    x = check()\n    y = x\n    return None\n";
+        let nn = norm_lang(n, "t.py", Language::Python);
+        assert!(
+            nn.iter().any(|tok| tok == "None"),
+            "Python None stays verbatim (null-family deferred): {nn:?}"
+        );
+        assert!(
+            !nn.iter().any(|tok| tok.starts_with("LIT_")),
+            "Python None must NOT bucket to any LIT_ token: {nn:?}"
+        );
+    }
+
+    /// Rust regression / post-#2 stream pin: `let x = true` now emits `LIT_BOOL` for the boolean
+    /// leaf (where pre-#232 the `true`/`false` leaf fell through VERBATIM). This pins the NEW
+    /// stream — exactly one `LIT_BOOL` token, no `true` token left, the wrapping
+    /// `boolean_literal` node kind still pushed before it. A true↔false-only Rust diff now
+    /// normalizes equal.
+    #[test]
+    fn rust_booleans_bucket_to_lit_bool() {
+        let t = "fn f() -> bool { let a = compute(); let b = a; let x = true; x }";
+        let f = "fn f() -> bool { let a = compute(); let b = a; let x = false; x }";
+        let nt = norm(t);
+        let nf = norm(f);
+        assert_eq!(nt, nf, "Rust true/false-only diff must normalize equal (LIT_BOOL)");
+        // Exactly one LIT_BOOL, no bare `true`/`false` survivor, wrapping node kind still present.
+        assert_eq!(
+            nt.iter().filter(|tok| *tok == "LIT_BOOL").count(),
+            1,
+            "exactly one LIT_BOOL leaf: {nt:?}"
+        );
+        assert!(!nt.iter().any(|tok| tok == "true" || tok == "false"), "no verbatim bool: {nt:?}");
+        assert!(
+            nt.iter().any(|tok| tok == "boolean_literal"),
+            "wrapping boolean_literal node kind still pushed: {nt:?}"
+        );
     }
 
     // ── Original tests (must stay green)

--- a/crates/rag-rat-core/src/index/clones/normalize.rs
+++ b/crates/rag-rat-core/src/index/clones/normalize.rs
@@ -22,13 +22,19 @@ fn is_literal_kind(kind: &str) -> bool {
         )
 }
 
-/// A leaf kind that is a boolean literal across the wired grammars: Rust emits `true`/`false` as
-/// leaves under an internal `boolean_literal`; TypeScript and Python emit bare `true`/`false`
-/// leaves (Python lexemes `True`/`False` map to kinds `true`/`false`). Bucketing both to ONE
-/// `LIT_BOOL` token (not `LIT_TRUE`/`LIT_FALSE`) value-ERASES the boolean: two bodies differing
-/// only in `true` vs `false` then normalize equal, and `LIT_BOOL` recovers `bool` typing in the
-/// signature contract (#232 #2b). The single bucket is why this is NOT routed through the generic
-/// `LIT_{kind.uppercased}` path — that would encode the value.
+/// A leaf kind that is a boolean literal in the grammars that expose booleans as their own leaf
+/// kind: Rust emits `true`/`false` as leaves under an internal `boolean_literal`; TypeScript,
+/// Python, C and C++ emit bare `true`/`false` leaves (Python lexemes `True`/`False` map to kinds
+/// `true`/`false`). Bucketing both to ONE `LIT_BOOL` token (not `LIT_TRUE`/`LIT_FALSE`)
+/// value-ERASES the boolean: two bodies differing only in `true` vs `false` then normalize equal,
+/// and `LIT_BOOL` recovers `bool` typing in the signature contract (#232 #2b). The single bucket
+/// is why this is NOT routed through the generic `LIT_{kind.uppercased}` path — that would encode
+/// the value.
+///
+/// NOT covered: `tree-sitter-kotlin-ng` emits `true`/`false`/`null` as plain `identifier` leaves,
+/// so Kotlin booleans are alpha-renamed (`ID<n>`) rather than value-erased. This is a deferred
+/// recall gap, not a correctness bug — the language partition guarantees Kotlin only ever
+/// clone-matches Kotlin, where identifiers and booleans are treated consistently (#232 follow-up).
 fn is_boolean_leaf_kind(kind: &str) -> bool {
     matches!(kind, "true" | "false")
 }

--- a/crates/rag-rat-core/src/index/clones/normalize.rs
+++ b/crates/rag-rat-core/src/index/clones/normalize.rs
@@ -133,20 +133,71 @@ mod tests {
     use crate::index::parser;
     use crate::language::Language;
 
+    /// Pick the target symbol's AST node for a normalization test: the symbol whose subtree
+    /// normalizes to the MOST tokens (the actual body under test, language-agnostic). Choosing by
+    /// token count instead of `kind == "function"` is what lets the same harness drive Rust
+    /// `function`, TS `const`/function-valued declarators, and Python `function` symbols — the
+    /// languages disagree on the symbol `kind` string but agree that the biggest normalized subtree
+    /// is the body we want to compare.
+    fn target_node_for<'a>(parsed: &'a parser::ParsedFile, src: &str) -> tree_sitter::Node<'a> {
+        parsed
+            .symbols
+            .iter()
+            .filter_map(|s| {
+                let node = parsed.root().descendant_for_byte_range(s.start_byte, s.end_byte)?;
+                let len = normalize_baseline(node, src).len();
+                Some((len, node))
+            })
+            .max_by_key(|(len, _)| *len)
+            .map(|(_, node)| node)
+            .expect("at least one symbol with a normalizable subtree")
+    }
+
+    /// Generalized normalize harness: parse `src` with `language` (under `path`, which selects the
+    /// grammar / generated heuristics), select the target symbol, return its normalized stream.
+    fn norm_lang(src: &str, path: &str, language: Language) -> Vec<String> {
+        let parsed = parser::parse_file(Path::new(path), language, src).expect("parse");
+        normalize_baseline(target_node_for(&parsed, src), src)
+    }
+
+    /// Generalized spanned-normalize harness (token stream + parallel `NodeSpan`s).
+    fn spanned_lang(src: &str, path: &str, language: Language) -> (Vec<String>, Vec<NodeSpan>) {
+        let parsed = parser::parse_file(Path::new(path), language, src).expect("parse");
+        normalize_baseline_spanned(target_node_for(&parsed, src), src)
+    }
+
+    /// Rust-only wrappers — the existing Rust tests call these unchanged.
     fn norm(src: &str) -> Vec<String> {
-        let parsed = parser::parse_file(Path::new("t.rs"), Language::Rust, src).expect("parse");
-        let func = parsed.symbols.iter().find(|s| s.kind == "function").expect("a function symbol");
-        let node =
-            parsed.root().descendant_for_byte_range(func.start_byte, func.end_byte).expect("node");
-        normalize_baseline(node, src)
+        norm_lang(src, "t.rs", Language::Rust)
     }
 
     fn spanned(src: &str) -> (Vec<String>, Vec<NodeSpan>) {
-        let parsed = parser::parse_file(Path::new("t.rs"), Language::Rust, src).expect("parse");
-        let func = parsed.symbols.iter().find(|s| s.kind == "function").expect("a function symbol");
-        let node =
-            parsed.root().descendant_for_byte_range(func.start_byte, func.end_byte).expect("node");
-        normalize_baseline_spanned(node, src)
+        spanned_lang(src, "t.rs", Language::Rust)
+    }
+
+    // ── Task 1 (#232): multi-language harness smoke test
+    // ───────────────────────────────────────
+
+    /// The generalized harness parses TypeScript and Python (not just Rust) and returns a non-empty
+    /// normalized stream carrying the function-body tokens. Pure harness smoke test — proves the
+    /// grammar selection + target-symbol picker work cross-language before T2/T3/T5 lean on them.
+    #[test]
+    fn harness_parses_ts_and_python() {
+        let ts = norm_lang(
+            "function f() { const a = get(1); const b = get(2); return a + b; }",
+            "t.ts",
+            Language::TypeScript,
+        );
+        assert!(!ts.is_empty(), "TS normalize stream must be non-empty");
+        assert!(ts.iter().any(|t| t == "return_statement"), "TS stream missing body: {ts:?}");
+
+        let py = norm_lang(
+            "def f():\n    a = get(1)\n    b = get(2)\n    return a + b\n",
+            "t.py",
+            Language::Python,
+        );
+        assert!(!py.is_empty(), "Python normalize stream must be non-empty");
+        assert!(py.iter().any(|t| t == "return_statement"), "Python stream missing body: {py:?}");
     }
 
     // ── Original tests (must stay green)

--- a/crates/rag-rat-core/src/index/clones/refine/antiunify.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/antiunify.rs
@@ -1661,29 +1661,44 @@ fn subtree_token_count(anchor: &RefineMember, root: usize) -> usize {
     count
 }
 
-/// Widen a Raw run that is a bare `string_content` LEAF to the enclosing `string_literal` node's
-/// whole span, so the hole covers the WHOLE `"hello"` (quotes included) — not just the inner text
-/// (Fix 3, #215 Plan 4b Codex round-5). A non-string run is returned unchanged.
+/// The string-BODY leaf kinds whose value the baseline normalizer erases (buckets to
+/// `LIT_STRING_CONTENT` / `LIT_STRING_FRAGMENT`): Rust/Python `string_content` and TS/JS
+/// `string_fragment` (#232 #2a). Both are the inner text leaf that needs widening to its enclosing
+/// quote-bearing node so the hole covers the WHOLE `"hello"`.
+fn is_string_body_leaf_kind(kind: &str) -> bool {
+    matches!(kind, "string_content" | "string_fragment")
+}
+
+/// The quote-bearing string-NODE kinds that wrap a string-body leaf: Rust/Python `string_literal`
+/// and TS/JS `string` (#232 #2a).
+fn is_string_node_kind(kind: &str) -> bool {
+    matches!(kind, "string_literal" | "string")
+}
+
+/// Widen a Raw run that is a bare string-body LEAF (`string_content` / `string_fragment`) to the
+/// enclosing quote-bearing string NODE's whole span, so the hole covers the WHOLE `"hello"` (quotes
+/// included) — not just the inner text (Fix 3, #215 Plan 4b Codex round-5; extended to TS/JS in
+/// #232 #2a). A non-string run is returned unchanged.
 ///
-/// Reconstructs the enclosing `string_literal` from the pre-order `node_spans` (no parent
-/// pointers): the tightest `string_literal` node whose byte span CONTAINS the content leaf, then
-/// the contiguous pre-order token range of that node (its root column through the last column
-/// inside its byte span). Falls back to the original run if no enclosing `string_literal` is found
-/// (defensive — a bare `string_content` with no wrapper, which Rust never emits).
+/// Reconstructs the enclosing string node from the pre-order `node_spans` (no parent pointers): the
+/// tightest `string_literal`/`string` node whose byte span CONTAINS the content leaf, then the
+/// contiguous pre-order token range of that node (its root column through the last column inside
+/// its byte span). Falls back to the original run if no enclosing string node is found (defensive —
+/// a bare body leaf with no wrapper, which the grammars never emit).
 fn widen_string_content_run(anchor: &RefineMember, lo: usize, hi: usize) -> (usize, usize) {
-    // Only a single `string_content` leaf needs widening — a wider run already covers its quotes.
+    // Only a single string-body leaf needs widening — a wider run already covers its quotes.
     if lo != hi {
         return (lo, hi);
     }
     let leaf = &anchor.node_spans[lo];
-    if !(leaf.is_leaf && leaf.kind == "string_content") {
+    if !(leaf.is_leaf && is_string_body_leaf_kind(leaf.kind)) {
         return (lo, hi);
     }
-    // Tightest enclosing `string_literal` (smallest byte span containing the content leaf).
+    // Tightest enclosing string node (smallest byte span containing the content leaf).
     let mut best: Option<usize> = None;
     let mut best_width = usize::MAX;
     for (c, sp) in anchor.node_spans.iter().enumerate() {
-        if sp.kind != "string_literal" {
+        if !is_string_node_kind(sp.kind) {
             continue;
         }
         if sp.start_byte <= leaf.start_byte && leaf.end_byte <= sp.end_byte {
@@ -1695,7 +1710,7 @@ fn widen_string_content_run(anchor: &RefineMember, lo: usize, hi: usize) -> (usi
         }
     }
     let Some(str_col) = best else { return (lo, hi) };
-    // The whole pre-order token range of the string_literal subtree.
+    // The whole pre-order token range of the string node subtree.
     let new_hi = str_col + subtree_token_count(anchor, str_col) - 1;
     (str_col, new_hi)
 }
@@ -2118,12 +2133,14 @@ fn classify_run(
         }
     }
 
-    // (2a) value_param — a `string_literal` run widened from a differing `string_content` leaf
-    //      (Fix 3). The run is the WHOLE `"hello"` node (quotes included), so the anchor at `lo` is
-    //      the internal `string_literal` node, not a leaf — it cannot reach the single-leaf
-    //      value_param rule (2) below. A string literal is a clean by-value `&str` parameter: emit
-    //      value_param High with the `LIT_STRING_CONTENT` bucket so the signature recovers `&str`.
-    if anchor_kind == "string_literal" {
+    // (2a) value_param — a string-node run widened from a differing string-body leaf (Fix 3;
+    //      extended to TS/JS `string` in #232 #2a). The run is the WHOLE `"hello"` node (quotes
+    //      included), so the anchor at `lo` is the internal `string_literal` (Rust/Python) or
+    //      `string` (TS/JS) node, not a leaf — it cannot reach the single-leaf value_param rule (2)
+    //      below. A string literal is a clean by-value `&str` parameter: emit value_param High with
+    //      the `LIT_STRING_CONTENT` bucket so the signature recovers `&str` (both string-body
+    // buckets      map to `&str` in `literal_bucket_to_type`).
+    if is_string_node_kind(anchor_kind) {
         return RunClass {
             kind: MetavarKind::ValueParam,
             type_hint: Some("LIT_STRING_CONTENT".to_string()),

--- a/crates/rag-rat-core/src/index/clones/refine/signature.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/signature.rs
@@ -333,21 +333,34 @@ fn anchor_leaf_is_literal(anchor: &RefineMember, lo: usize) -> bool {
 /// promote the signature to `Syntactic` (`{literal}` is not a type — the signature is not actually
 /// syntactically typed). `None` routes the slot to `unresolved_type_slots` in the caller, capping
 /// typedness at `Partial`. The buckets the baseline normalizer can emit are `LIT_{kind.uppercased}`
-/// for every `is_literal_kind` tree-sitter kind (see `clones::normalize::is_literal_kind`): the
-/// Rust `*_literal` kinds (integer/float/string/raw_string/char/boolean/byte_string/negative) PLUS
-/// the cross-language explicit set (`string_content`, `integer`, `float`, `number`, `char`). Every
-/// one either maps to a real Rust type here or falls to `None` — none silently becomes a typed
-/// `{literal}`. The common remaining Rust buckets are mapped: `char` → `char`, raw string → `&str`,
-/// byte string → `&[u8]`. The cross-language numeric/string buckets (`LIT_INTEGER`/`LIT_FLOAT`/
+/// for every `is_literal_kind` tree-sitter kind (see `clones::normalize::is_literal_kind`) PLUS the
+/// special value-erased `LIT_BOOL` bucket (#232 #2b — `true`/`false` collapse to ONE bucket, NOT
+/// `LIT_TRUE`/`LIT_FALSE`):
+/// - Rust `*_literal` kinds (integer/float/string/raw_string/char/byte_string/negative);
+/// - the cross-language explicit set (`string_content`, `string_fragment`, `integer`, `float`,
+///   `number`, `char`) — `string_fragment` is the TS/JS string-body leaf, the sibling of Python's
+///   `string_content`, both → `&str` (#232 #2a);
+/// - `LIT_BOOL` (#232 #2b) → `bool` — the single bucket every grammar's `true`/`false` collapses
+///   to.
+///
+/// Every one either maps to a real Rust type here or falls to `None` — none silently becomes a
+/// typed `{literal}`. The common remaining Rust buckets are mapped: `char` → `char`, raw string →
+/// `&str`, byte string → `&[u8]`. The cross-language numeric buckets (`LIT_INTEGER`/`LIT_FLOAT`/
 /// `LIT_NUMBER`/`LIT_CHAR`) and anything else fall to `None` (no stable Rust type cross-language).
 fn literal_bucket_to_type(bucket: &str) -> Option<&'static str> {
     match bucket {
         "LIT_INTEGER_LITERAL" => Some("i64"),
         "LIT_FLOAT_LITERAL" => Some("f64"),
-        "LIT_STRING_LITERAL" | "LIT_STRING_CONTENT" | "LIT_RAW_STRING_LITERAL" => Some("&str"),
+        "LIT_STRING_LITERAL"
+        | "LIT_STRING_CONTENT"
+        | "LIT_STRING_FRAGMENT"
+        | "LIT_RAW_STRING_LITERAL" => Some("&str"),
         "LIT_BYTE_STRING_LITERAL" => Some("&[u8]"),
         "LIT_CHAR_LITERAL" => Some("char"),
-        "LIT_BOOLEAN_LITERAL" | "LIT_BOOL_LITERAL" => Some("bool"),
+        // `LIT_BOOL` is the value-erased boolean bucket (#232 #2b). The legacy
+        // `LIT_BOOLEAN_LITERAL`/`LIT_BOOL_LITERAL` arms are now dead (the normalizer never emits
+        // them — booleans route to `LIT_BOOL`) but are kept as defensive aliases.
+        "LIT_BOOL" | "LIT_BOOLEAN_LITERAL" | "LIT_BOOL_LITERAL" => Some("bool"),
         // Unmapped bucket: NO stable Rust type → unresolved, never the opaque `{literal}`-as-typed.
         _ => None,
     }
@@ -714,6 +727,12 @@ mod tests {
         assert_eq!(literal_bucket_to_type("LIT_CHAR_LITERAL"), Some("char"));
         assert_eq!(literal_bucket_to_type("LIT_RAW_STRING_LITERAL"), Some("&str"));
         assert_eq!(literal_bucket_to_type("LIT_BYTE_STRING_LITERAL"), Some("&[u8]"));
+        // #232 #2a: the TS/JS string-body bucket maps to `&str`, same as Python's `string_content`.
+        assert_eq!(literal_bucket_to_type("LIT_STRING_FRAGMENT"), Some("&str"));
+        assert_eq!(literal_bucket_to_type("LIT_STRING_CONTENT"), Some("&str"));
+        // #232 #2b: the value-erased boolean bucket maps to `bool` (the one the normalizer emits
+        // now).
+        assert_eq!(literal_bucket_to_type("LIT_BOOL"), Some("bool"));
         // Fix 3: a bucket with NO stable Rust type returns `None` (NEVER the opaque
         // `Some("{literal}")` that used to count as typed) — so the slot goes unresolved and cannot
         // lift typedness to Syntactic.

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -243,10 +243,13 @@ impl IndexDatabase {
         symbols: &[Symbol],
         symbol_ids: &[i64],
     ) -> anyhow::Result<()> {
-        // Only `kind == "function"` symbols are fingerprinted (#215). Bail before re-parsing the
-        // file when none qualify — the parse is the expensive part of this incremental/heal
-        // wrapper.
-        if symbols.iter().all(|s| s.kind != "function") {
+        // `kind == "function"` symbols AND function-valued `const` declarators are fingerprinted
+        // (#215; #232 #5). This is a node-free PRE-PARSE early-bail, so it can only widen on the
+        // `kind` SUPERSET — a function-valued declarator is `kind == "const"` (parser.rs) — and let
+        // `fingerprint_symbols` + `symbol_is_function_valued` reject plain-value consts AFTER the
+        // parse. Bail before re-parsing only when NO `function` and NO `const` symbol exists — the
+        // parse is the expensive part of this incremental/heal wrapper.
+        if symbols.iter().all(|s| s.kind != "function" && s.kind != "const") {
             return Ok(());
         }
         let Some(parsed) = parser::parse_file(path, language, text) else {

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -125,7 +125,13 @@ impl IndexDatabase {
         // desync the external-content index until the next forced rebuild).
         self.insert_chunks(ChunkInsertFile { file_id, source_revision: &sha256 }, &chunks)?;
         let symbol_ids = self.insert_symbols(file_id, language, &symbols)?;
-        self.store_symbol_fingerprints(language, path, text, &symbols, &symbol_ids)?;
+        // (#232 #6) Skip generated files on the incremental/heal path too — same write-side hygiene
+        // and the same `file_is_generated` arg as the full-rebuild prepare gate (prep.rs). Catches
+        // PATH-heuristic codegen under a Source target (`src/generated/*.rs`, `*.d.ts`); the
+        // `kind=Generated` case is already symbol-empty above.
+        if !file_is_generated(kind, &path_string(path)) {
+            self.store_symbol_fingerprints(language, path, text, &symbols, &symbol_ids)?;
+        }
         if kind != TargetKind::Generated && text.len() <= edges::MAX_GRAPH_PARSE_BYTES {
             edges::index_file_edges(self.storage.connection(), file_id, path, language, text)?;
         }

--- a/crates/rag-rat-core/src/index/prep.rs
+++ b/crates/rag-rat-core/src/index/prep.rs
@@ -291,10 +291,21 @@ pub(crate) fn prepare_index_content(file: &IndexFile) -> anyhow::Result<Prepared
     // Baseline clone fingerprints walk the SAME shared tree (no re-parse, no DB). Keyed by local
     // symbol index; insert_prepared_file maps each to its DB id and writes. This is what lets the
     // full-rebuild insert stage skip the second read + second parse the fingerprints used to need.
-    let symbol_fingerprints = parsed
-        .as_ref()
-        .map(|p| clones::fingerprint_symbols(p.root(), &text, &symbols))
-        .unwrap_or_default();
+    //
+    // (#232 #6) Skip generated files at index time — write-side storage hygiene only (ZERO recall /
+    // precision effect: the candidate read already filters `files.generated = 0`). `kind=Generated`
+    // files are already symbol-empty (no parse), so this gate is what catches PATH-heuristic
+    // codegen under a SOURCE target (`src/generated/*.rs`, `*.d.ts`) — those DO get symbols and
+    // so used to get fingerprints. The arg is byte-identical to the `files.generated` INSERT
+    // (file_index.rs), so the index skip and the read filter agree.
+    let symbol_fingerprints = if file_is_generated(file.kind, &path_string(&file.relative_path)) {
+        Vec::new()
+    } else {
+        parsed
+            .as_ref()
+            .map(|p| clones::fingerprint_symbols(p.root(), &text, &symbols))
+            .unwrap_or_default()
+    };
 
     Ok(PreparedIndexContent {
         modified_at_ms,

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -219,8 +219,11 @@ pub struct CloneCompleteness {
     /// contents — consumers should reindex / `rag-rat heal` before acting on these results.
     /// This is a read-only signal; Plan 2 does not heal-before-return.
     pub stale_members: usize,
-    pub known_index_gaps: Vec<String>, /* e.g. "#232: TS function-valued declarators not yet
-                                        * fingerprinted" */
+    /// Advertised-open clone-substrate gaps (a deliberately self-honest provenance signal). Empty
+    /// since #232 closed the multi-language gaps (comments skipped, string/boolean literals
+    /// bucketed, TS function-valued declarators fingerprinted); a future known limitation goes
+    /// here.
+    pub known_index_gaps: Vec<String>,
 }
 
 /// Result of [`IndexDatabase::clones_for_symbol`]. Carries eligibility flags + a completeness block
@@ -234,7 +237,9 @@ pub struct ClonesForSymbolResult {
     /// The selector matched a scoped symbol.
     pub symbol_resolved: bool,
     /// That symbol has a current-version baseline fingerprint loaded into the candidate set
-    /// (eligible: a `kind="function"` symbol ≥ `MIN_TOKENS` in a non-generated, in-scope file).
+    /// (eligible: a `kind="function"` symbol OR a function-valued declarator — `const f = () =>
+    /// …`, a class-field arrow handler, #232 #5 — ≥ `MIN_TOKENS` in a non-generated, in-scope
+    /// file).
     pub symbol_fingerprinted: bool,
     /// Same provenance block as [`FindClonesResult::completeness`].
     pub completeness: CloneCompleteness,
@@ -737,10 +742,11 @@ fn build_completeness(
         truncated,
         refine_budget_clamped,
         stale_members,
-        known_index_gaps: vec![
-            "#232: TS function-valued declarators not yet fingerprinted".into(),
-            "#232: comments/multi-language literals not yet normalized".into(),
-        ],
+        // #232 closed the previously-advertised multi-language gaps: comments are now skipped,
+        // string + boolean literals bucket multi-language (NORM_VERSION = 2), and TS
+        // function-valued declarators are fingerprinted. No clone-substrate gaps are
+        // currently advertised open.
+        known_index_gaps: Vec::new(),
     }
 }
 

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -1749,7 +1749,10 @@ fn load_scoped_baseline_bags(conn: &Connection) -> anyhow::Result<Vec<SymbolBag>
 
     // Scoped baseline fingerprints + their token-bag BLOB, in one read (no per-token join).
     // `files.generated = 0` excludes generated files (e.g. `src/generated/…`, `.d.ts`) from the
-    // candidate read — they are fingerprinted on write but must not enter clone components.
+    // candidate read. As of #232 #6 generated files are NO LONGER fingerprinted at index time
+    // (`prep.rs` / `file_index.rs` gate the compute on `!file_is_generated`), so this filter is now
+    // defense-in-depth: it still guards a file that flipped to `generated = 1` AFTER its
+    // fingerprints were written (a target reclassification without a reindex of that file).
     // `token_len` comes from the COLUMN (R3); the bag itself is decoded from the BLOB.
     let mut fp_stmt = conn.prepare(
         "SELECT sf.symbol_id, symbols.language, sf.struct_hash, sf.token_len, sf.token_bag

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -121,11 +121,13 @@ impl IndexDatabase {
     /// inside the rebuild transaction so the df and the fingerprints it summarizes commit
     /// atomically.
     ///
-    /// R6 — SCOPE PARITY: this must match the old GROUP BY EXACTLY. That query had NO
-    /// `files.generated` filter, so it counted generated-file symbols too; this aggregate likewise
-    /// reads EVERY `symbol_fingerprints` row (generated included). df feeds candidate GENERATION
-    /// (the `sub_block_tokens` ordering), not just ranking, so a scope mismatch would change
-    /// recall. Each symbol's decoded bag has no duplicate `token_hash` (the codec invariant),
+    /// R6 — SCOPE PARITY: this reads EVERY `symbol_fingerprints` row (no `files.generated` filter),
+    /// matching the original GROUP BY's scope over whatever rows exist. (Since #232, generated
+    /// files are no longer fingerprinted at index time, so there are no generated-file fp rows to
+    /// count — the df scope now lines up with the `generated = 0` candidate read rather than being
+    /// deliberately wider; df is selectivity-only and drift-tolerated, so this is not load-bearing
+    /// for recall either way.) df feeds candidate GENERATION (the `sub_block_tokens` ordering), not
+    /// just ranking. Each symbol's decoded bag has no duplicate `token_hash` (the codec invariant),
     /// so counting one increment per (symbol, token) pair equals `COUNT(DISTINCT symbol_id)`.
     fn refresh_clone_token_df(&self) -> anyhow::Result<()> {
         // Phase 1 (read): decode every fingerprint's bag and accumulate df in memory, off the

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -12997,6 +12997,82 @@ fn candidate_components_exclude_generated_files_via_read_filter() {
     let _ = fs::remove_dir_all(root);
 }
 
+/// #232 #6: a PATH-heuristic-generated file under a SOURCE target (`src/generated/*.rs`,
+/// `is_generated_path` true, `kind = source`) gets full symbols but must NOT be fingerprinted at
+/// index time — neither on a full rebuild NOR on a single-file heal. (`kind = Generated` files are
+/// already symbol-empty, so the gate is needed only for the path-heuristic case.) This is pure
+/// write-side storage hygiene — zero recall/precision effect (the read already filters
+/// `generated = 0`); the assertion is on the absence of `symbol_fingerprints` ROWS.
+#[test]
+fn generated_files_are_not_fingerprinted_at_index_time() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    std::fs::create_dir_all(root.join("src/generated")).unwrap();
+    // A normal source file (fingerprinted) and a path-heuristic-generated file under the SAME
+    // source target. Both bodies clear MIN_TOKENS so the absence of a generated fp row is the gate,
+    // not the size prune.
+    std::fs::write(
+        root.join("src/normal.rs"),
+        "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("src/generated/bindings.rs"),
+        "pub fn load_order(store: Db) -> i32 { let o = store.get(20); validate(o); o + 1 }\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let fp_rows_for = |db: &IndexDatabase, like: &str| -> i64 {
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT count(*) FROM symbol_fingerprints sf
+                 JOIN symbols ON symbols.id = sf.symbol_id
+                 JOIN main.files ON main.files.id = symbols.file_id
+                 WHERE main.files.path LIKE ?1 AND sf.normalizer_kind = 'baseline'",
+                [like],
+                |r| r.get(0),
+            )
+            .unwrap()
+    };
+
+    // The path-heuristic-generated file got symbols but NO fingerprint rows; the normal file did.
+    assert!(fp_rows_for(&db, "%normal.rs") > 0, "normal source file must be fingerprinted");
+    assert_eq!(
+        fp_rows_for(&db, "%/generated/%"),
+        0,
+        "generated file must NOT be fingerprinted on a full rebuild"
+    );
+    // It DOES still get symbols (the gate is fingerprint-only, not symbol extraction).
+    let gen_symbols: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT count(*) FROM symbols JOIN main.files ON main.files.id = symbols.file_id
+             WHERE main.files.path LIKE '%/generated/%'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(
+        gen_symbols > 0,
+        "generated file must still get symbols (only fingerprints are skipped)"
+    );
+
+    // Single-file heal path: re-index the generated file through heal_file → index_file →
+    // store_symbol_fingerprints (gated). It must still write NO fingerprint rows.
+    db.heal_file(std::path::Path::new("src/generated/bindings.rs")).unwrap();
+    assert_eq!(
+        fp_rows_for(&db, "%/generated/%"),
+        0,
+        "generated file must NOT be fingerprinted after a single-file heal"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
 /// Max-denominator overlap gate regression: two structurally different functions whose
 /// token_len ratio is ≥ θ (they SURVIVE the size prune) but whose token-overlap/max_len < θ
 /// (the gate rejects them). This is distinct from the containment test

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -13073,6 +13073,134 @@ fn generated_files_are_not_fingerprinted_at_index_time() {
     let _ = fs::remove_dir_all(root);
 }
 
+/// #232 multi-language integration: a Rust + TS + Python repo with WITHIN-language planted clones
+/// (Rust comment-only variant; TS function-valued declarators differing only in string contents;
+/// Python comment-only variant) — exercises #1 (comments), #2a (TS strings) and #5 (TS
+/// function-valued declarators) end-to-end through a real index. Asserts a within-language clone
+/// component forms in EACH language and NO component mixes two languages (the #3 language
+/// partition).
+#[test]
+fn multi_language_clone_integration_finds_within_language_no_cross() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("rs")).unwrap();
+    fs::create_dir_all(root.join("ts")).unwrap();
+    fs::create_dir_all(root.join("py")).unwrap();
+
+    // Rust: two functions identical EXCEPT comments (comment-only clone → #1). >= MIN_TOKENS.
+    fs::write(
+        root.join("rs/a.rs"),
+        "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("rs/b.rs"),
+        "pub fn load_order(s: Db) -> i32 {\n    // a different comment\n    let o = s.get(20); /* \
+         x */ validate(o); o + 1 }\n",
+    )
+    .unwrap();
+
+    // TS: two `const`-arrow function-valued declarators identical EXCEPT string contents (#5 +
+    // #2a).
+    fs::write(
+        root.join("ts/a.ts"),
+        "const load = (id) => { const row = get(id); const tag = label(\"alpha\"); send(row, \
+         tag); return row; }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("ts/b.ts"),
+        "const fetch2 = (key) => { const item = get(key); const note = label(\"omega\"); \
+         send(item, note); return item; }\n",
+    )
+    .unwrap();
+
+    // Python: two functions identical EXCEPT comments (comment-only clone → #1). >= MIN_TOKENS.
+    fs::write(
+        root.join("py/a.py"),
+        "def load_user(db):\n    u = db.get(10)\n    validate(u)\n    return u + 1\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("py/b.py"),
+        "def load_order(s):\n    # a comment\n    o = s.get(20)  # trailing\n    validate(o)\n    \
+         return o + 1\n",
+    )
+    .unwrap();
+
+    let config = Config {
+        root: root.clone(),
+        database: root.join(".rag-rat/index.sqlite"),
+        targets: vec![
+            ResolvedTarget {
+                name: "rust".to_string(),
+                language: Language::Rust,
+                directories: vec![PathBuf::from("rs")],
+                include: vec!["rs/".to_string()],
+                exclude: Vec::new(),
+                kind: TargetKind::Source,
+            },
+            ResolvedTarget {
+                name: "typescript".to_string(),
+                language: Language::TypeScript,
+                directories: vec![PathBuf::from("ts")],
+                include: vec!["ts/".to_string()],
+                exclude: Vec::new(),
+                kind: TargetKind::Source,
+            },
+            ResolvedTarget {
+                name: "python".to_string(),
+                language: Language::Python,
+                directories: vec![PathBuf::from("py")],
+                include: vec!["py/".to_string()],
+                exclude: Vec::new(),
+                kind: TargetKind::Source,
+            },
+        ],
+        local_ai: Default::default(),
+        watch: Default::default(),
+        version_check: Default::default(),
+        oracle: Default::default(),
+    };
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    // Map each component's symbol ids → the set of languages it spans.
+    let conn = db.storage.connection();
+    let lang_of = |symbol_id: i64| -> String {
+        conn.query_row(
+            "SELECT files.language FROM symbols JOIN main.files ON main.files.id = symbols.file_id
+             WHERE symbols.id = ?1",
+            [symbol_id],
+            |r| r.get::<_, String>(0),
+        )
+        .unwrap()
+    };
+
+    let components = db.candidate_clone_components().unwrap();
+    let mut langs_with_clone: std::collections::BTreeSet<String> = Default::default();
+    for component in &components {
+        let langs: std::collections::BTreeSet<String> =
+            component.iter().map(|&id| lang_of(id)).collect();
+        // No component may mix two languages (the #3 language partition).
+        assert_eq!(
+            langs.len(),
+            1,
+            "a clone component must be single-language (no cross-language pairs): {langs:?}"
+        );
+        langs_with_clone.insert(langs.into_iter().next().unwrap());
+    }
+
+    // A within-language clone was recalled in EACH of the three languages.
+    for expected in ["rust", "typescript", "python"] {
+        assert!(
+            langs_with_clone.contains(expected),
+            "expected a within-language clone in {expected}; got {langs_with_clone:?}"
+        );
+    }
+
+    let _ = fs::remove_dir_all(root);
+}
+
 /// Max-denominator overlap gate regression: two structurally different functions whose
 /// token_len ratio is ≥ θ (they SURVIVE the size prune) but whose token-overlap/max_len < θ
 /// (the gate rejects them). This is distinct from the containment test


### PR DESCRIPTION
Fixes #232. Multi-language correctness hardening for the #215 clone substrate.

## What
Four correctness fixes so clone recall/precision hold beyond Rust, plus a Rust/TS/Python test harness and one `NORM_VERSION` bump:
1. **Ignore comments** — comment leaves were emitted as verbatim structural tokens, so comment-only differences broke `struct_hash`/overlap. `walk_spanned` now skips `node.is_extra() || kind.contains("comment")` (pushing neither token nor span — the seq↔span bijection is preserved).
2. **Bucket strings + value-erase booleans** — TS `string_fragment` bodies join the literal bucket (Python `string_content` was already covered); `true`/`false` collapse to a **single value-erased `LIT_BOOL`** (not per-value `LIT_TRUE`/`LIT_FALSE`), so two bodies differing only in a boolean are clones. The null-family is deferred (single fixed lexemes, ~0 recall value, and a cross-language wrapped-node hazard).
3. **Fingerprint TS function-valued declarators** — `const load = () => {…}` and class-field arrow handlers (parsed as `variable_declarator`/`public_field_definition`, kind `const`) were dropped by the `kind == "function"` guard. The clone fingerprint guard is now function-value-aware (`child_by_field_name("value") ∈ {arrow_function, function_expression}`) — **symbol `kind` is unchanged** (no ripple into chunking/graph/search).
4. **Skip fingerprinting generated files at index time** — path-heuristic generated files (`src/generated/*`, `*.d.ts`) were fingerprinted then never read. Pure write-side storage hygiene (the candidate read already filters `files.generated = 0`).

Items #3 (language partition) and #4 (`normalizer_version` filter) from the issue were **already shipped** by the #231 BLOB-pack — confirmed, not re-done.

## How it stays correct
- **Grammar-verified:** every tree-sitter kind name was checked against a live AST probe of the pinned grammars (tree-sitter 0.26.9 / -rust 0.24.2 / -typescript 0.23.2 / -python 0.25.0 / -c 0.24.2 / -cpp 0.23.4).
- **Type-recovery contract updated (a net improvement):** `literal_bucket_to_type` (signature.rs, the exhaustive-buckets source of truth) + the antiunify `widen_string_content_run`/type-hint paths now map `LIT_BOOL → bool` and `string_fragment → &str`. Rust bool typing was previously *dead* (booleans went verbatim; the old `LIT_BOOLEAN_LITERAL→bool` arm was never emitted), so `LIT_BOOL` both erases the value *and* recovers `bool`.
- **`NORM_VERSION` 1→2** auto-invalidates old fingerprints (the read binds `sf.normalizer_version = NORM_VERSION`) and the 4b refinement cache (folded into the content-addressed key). Existing indexes recompute clone fingerprints on the next index — no schema migration.

## Verification
997 tests green across `rag-rat-core` + `rag-rat` + `rag-rat-mcp`; clippy `-D warnings` + nightly fmt clean. The #231 recall-parity pin + the #248 reindex-survival trip-wire still pass. A multi-language integration test plants within-language clones (comment-only, string-literal, TS function-valued) in a Rust+TS+Python fixture and asserts clones are found within each language with **no cross-language components**.

The change went through plan → 3-explorer **grammar-verified** adversarial review (4 blockers folded: the boolean value-erase semantics, the `literal_bucket_to_type`/antiunify contract audit, the pre-parse early-bail widen for #5, and the MIN_TOKENS fixture sizing) → implementation.

## Deferred / follow-up
- Null-family literal bucketing (`null`/`undefined`/`none`/`nullptr`/C `NULL`) — low recall value + cross-language leaf-kind inconsistency; left verbatim.
