### PR TITLE
fix(clones): split giant over-merged components + coverage-gated ROI (#256)

### DIFF
--- a/crates/rag-rat-core/src/index/clones/refine/split.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/split.rs
@@ -16,24 +16,32 @@
 //! in BOTH {A,B} and {B,C} (overlap is correct — a member can be coherent with two otherwise-
 //! incompatible peers). Each emitted group is still internally coherent by construction (a member
 //! is added only when it is ≥ θ to EVERY current group member).
+//!
+//! # Scalability: the caller threads in the θ-verified edge list (#256)
+//!
+//! The clique cover seeds a group from every θ-edge. The edges are already known at the call site
+//! (the `candidate_pairs_from_bags` output, restricted to the component), so this module takes
+//! them as `edges` instead of rediscovering them with an O(n²) all-pairs scan. That all-pairs scan
+//! was the ONLY reason a `SPLIT_MAX` member cap existed — and that cap returned any giant
+//! (>200-member) component WHOLE, so a 2,575-member transitive-chain blob never split and ranked
+//! #1 with coverage 0.00 (#256). With edge-fed seeding the cover is O(edges) to seed + O(group ×
+//! members) to grow each clique, so the member cap is gone: a sparse chained giant breaks into its
+//! real small cliques, while a genuinely dense ≥200-member clique (every pair ≥ θ) still collapses
+//! to one class. NO member is lost — every θ-edge endpoint lands in at least its own seed clique.
 
-/// Hard cap on the all-pairs O(n²) work inside a single component. A component LARGER than this is
-/// returned WHOLE as a single class (no member loss — see Fix 3, #215 Plan 4a): huge components are
-/// near-universally fully-coherent exact-clone classes, and precise clique-cover splitting of
-/// over-cap components is a follow-up. The caller already sets `metrics_sampled = true` for
-/// components larger than `METRIC_SAMPLE_CAP` (200); this guard matches that cap so the split never
-/// exceeds the same pairwise bound. For the overwhelmingly common case (all existing tests) this
-/// cap is never reached.
-const SPLIT_MAX: usize = 200;
-
-/// Hard cap on the number of groups the greedy clique-cover may emit before the algorithm
-/// abandons the split and returns the WHOLE component as one class (no member loss). Bounds
-/// the subset-removal at O(MAX_SPLIT_GROUPS² × n): with 256 groups and n ≤ 200 (SPLIT_MAX
-/// guard fires first on larger components) that is at most 256² × 200 ≈ 13 M comparisons —
-/// well within a sub-second budget. A pathological dense-minus-perfect-matching graph that
-/// would otherwise produce O(n²/2) ≈ 20 000 groups trips this budget early and returns
-/// the whole component fast; recall is preserved (the whole component contains every coherent
-/// pair). For the normal case (all existing tests) far fewer than 256 groups are ever produced.
+/// Budget on the number of GROWN maximal cliques before the cover stops growing and falls back to
+/// emitting the remaining θ-edges as ungrown 2-member cliques (#256). It bounds the two superlinear
+/// passes — the per-edge containment scan and the maximal-subset removal, both O(grown² × n) — to a
+/// sub-second budget (256² × n) on a pathologically tangled component (e.g. dense-minus-perfect-
+/// matching, which yields O(n²) maximal cliques).
+///
+/// CRUCIAL (#256): tripping the budget does NOT drop members and does NOT return the over-merged
+/// component (the old behavior that resurrected the giant). Once the budget trips, every remaining
+/// uncovered θ-edge is emitted as its own 2-member clique — so EVERY member that has a θ-edge still
+/// lands in at least one coherent class. A long transitive CHAIN (n−1 edges, far more than 256
+/// grown cliques) therefore keeps all members: the tail edges become 2-member pairs instead of
+/// being dropped. Only the (rare) GROWN-clique expansion is bounded, never coverage. For the normal
+/// case (all existing tests) far fewer than 256 grown cliques are ever produced.
 const MAX_SPLIT_GROUPS: usize = 256;
 
 /// Split an over-merged union-find component into internally-coherent clone classes: every pair
@@ -42,21 +50,27 @@ const MAX_SPLIT_GROUPS: usize = 256;
 /// maximal clique cover that keeps EVERY coherent group (so a member shared by two incompatible
 /// peers, like B in chain A~B / B~C / A!~C, appears in both {A,B} and {B,C}).
 ///
-/// `similarity(a, b)` returns the pairwise overlap/max similarity in \[0,1\] (the caller supplies
-/// it from the token bags). Deterministic: members are processed in ascending-id order, group
-/// members are sorted ascending, and returned classes are in stable order (by their lowest member
-/// id). Classes of size < 2 are dropped (a clone class needs ≥ 2 members).
+/// `edges` is the θ-verified candidate-pair subset for THIS component (a `(a, b)` per pair, in any
+/// order/orientation — the caller bucketed `candidate_pairs_from_bags` per component, #256). Every
+/// edge endpoint must be a member of `component`. The clique cover seeds a group from each edge, so
+/// feeding the precomputed edges makes seeding O(edges) instead of the old O(n²) all-pairs scan
+/// (the reason the now-removed `SPLIT_MAX` member cap existed). `similarity(a, b)` returns the
+/// pairwise overlap/max similarity in \[0,1\]; it is consulted only while GROWING a clique (a
+/// candidate member against the current group), bounded by group size, never all-pairs.
+///
+/// Deterministic: edges are canonicalized to `a < b` and sorted, members are processed in
+/// ascending-id order, group members are sorted ascending, and returned classes are in stable order
+/// (by their lowest member id). Classes of size < 2 are dropped (a clone class needs ≥ 2 members).
 ///
 /// # Algorithm (greedy maximal clique cover)
 ///
 /// 1. Sort members ascending by id (determinism).
-/// 2. If the component exceeds `SPLIT_MAX`, return it WHOLE as one class — no members dropped (Fix
-///    3, #215). `build_class`'s `METRIC_SAMPLE_CAP` bounds the pairwise metric cost downstream.
-/// 3. Collect all coherent edges `(a, b)` with `a < b` and `similarity(a, b) >= theta`.
-/// 4. For each coherent edge not already fully contained in an emitted group, grow a maximal
+/// 2. Canonicalize + sort + dedup `edges` into the coherent-edge seed list (each is ≥ θ by
+///    construction at the call site).
+/// 3. For each coherent edge not already fully contained in an emitted group, grow a maximal
 ///    coherent group from `{a, b}` by adding any remaining member (in id order) that is ≥ θ to
 ///    every current group member.
-/// 5. Drop groups that are a strict subset of another (keep only maximal cliques), de-duplicate
+/// 4. Drop groups that are a strict subset of another (keep only maximal cliques), de-duplicate
 ///    identical groups, drop singletons, and sort by lowest member id.
 ///
 /// # Postcondition guaranteed by construction
@@ -66,46 +80,61 @@ const MAX_SPLIT_GROUPS: usize = 256;
 /// property holds across all insertions.
 pub(crate) fn coherence_split(
     component: &[i64],
+    edges: &[(i64, i64)],
     similarity: impl Fn(i64, i64) -> f64,
     theta: f64,
 ) -> Vec<Vec<i64>> {
     // 1. Sort ascending (determinism).
     let mut members: Vec<i64> = component.to_vec();
     members.sort_unstable();
+    let member_set: std::collections::BTreeSet<i64> = members.iter().copied().collect();
 
-    // 2. Huge component: return the whole thing as one class (no member loss — Fix 3, #215).
-    // build_class's METRIC_SAMPLE_CAP bounds the pairwise cost. Huge components are typically
-    // fully-coherent exact-clone classes; precise splitting of >SPLIT_MAX-member components is a
-    // follow-up.
-    if members.len() > SPLIT_MAX {
-        return vec![members];
-    }
-
-    // 3. Collect all coherent edges (pairs with similarity >= theta), in (a, b) order a < b.
-    let n = members.len();
-    let mut coherent_edges: Vec<(i64, i64)> = Vec::new();
-    for i in 0..n {
-        for j in (i + 1)..n {
-            if similarity(members[i], members[j]) >= theta {
-                coherent_edges.push((members[i], members[j]));
+    // 2. Coherent-edge seed list from the caller's θ-verified pairs (#256): canonicalize each to
+    // `a < b`, keep only edges whose BOTH endpoints are members of this component (defensive — the
+    // caller buckets per component), sort + dedup for a deterministic seed order. These ARE the
+    // ≥ θ edges (verified by `candidate_pairs_from_bags` at the call site), so there is no
+    // all-pairs similarity scan here — that scan was the reason for the removed `SPLIT_MAX`
+    // member cap.
+    let mut coherent_edges: Vec<(i64, i64)> = edges
+        .iter()
+        .filter_map(|&(a, b)| {
+            if a == b || !member_set.contains(&a) || !member_set.contains(&b) {
+                return None;
             }
-        }
-    }
+            Some((a.min(b), a.max(b)))
+        })
+        .collect();
+    coherent_edges.sort_unstable();
+    coherent_edges.dedup();
 
-    // 4. Greedy maximal clique cover: for each coherent edge not already fully inside some emitted
+    // 3. Greedy maximal clique cover: for each coherent edge not already fully inside some emitted
     // group, grow a maximal coherent group from {a, b} by adding any remaining member (in id order)
     // that is coherent with every current group member. Emit the group.
+    //
+    // Past `MAX_SPLIT_GROUPS` GROWN cliques the component is pathologically tangled; we stop
+    // growing (the grow + the per-edge containment scan are the only superlinear passes) and
+    // emit every remaining uncovered edge as a bare 2-member clique. This bounds work WITHOUT
+    // dropping any member: a long chain's tail edges become pairs rather than being lost
+    // (#256).
     let mut groups: Vec<Vec<i64>> = Vec::new();
+    let mut budget_tripped = false;
 
-    'edges: for (a, b) in &coherent_edges {
+    'edges: for &(a, b) in &coherent_edges {
+        if budget_tripped {
+            // Over budget: emit the edge directly as a 2-member clique (still internally coherent —
+            // it is a θ-edge). No grow, no full-group containment scan. The later dedup/subset pass
+            // is skipped too (see below), so this stays O(remaining edges).
+            groups.push(vec![a, b]);
+            continue;
+        }
         // Skip this edge if some existing group already contains both endpoints.
         for g in &groups {
-            if g.contains(a) && g.contains(b) {
+            if g.contains(&a) && g.contains(&b) {
                 continue 'edges;
             }
         }
         // Grow a maximal coherent group from {a, b}.
-        let mut group: Vec<i64> = vec![*a, *b];
+        let mut group: Vec<i64> = vec![a, b];
         for &m in &members {
             if group.contains(&m) {
                 continue;
@@ -117,23 +146,31 @@ pub(crate) fn coherence_split(
         }
         group.sort_unstable(); // deterministic order within group
         groups.push(group);
-        // Budget guard: if we have emitted too many groups, the component is pathologically
-        // tangled (e.g. dense-minus-perfect-matching). Abandon the split and return the whole
-        // component as one class — no member dropped, recall preserved.
+        // Budget guard (#256): bound the superlinear passes. From here on, remaining edges are
+        // emitted as bare pairs (above) — coverage is preserved, work is bounded.
         if groups.len() > MAX_SPLIT_GROUPS {
-            return vec![members];
+            budget_tripped = true;
         }
     }
 
-    // 5. Keep only maximal groups (drop any that is a strict subset of another).
-    let mut maximal: Vec<Vec<i64>> = Vec::new();
-    for g in &groups {
-        let is_subset =
-            groups.iter().any(|other| other.len() > g.len() && g.iter().all(|x| other.contains(x)));
-        if !is_subset {
-            maximal.push(g.clone());
+    // 5. Keep only maximal groups (drop any that is a strict subset of another). SKIP this
+    // O(groups² × n) pass when the budget tripped — on a pathologically tangled component it is the
+    // expensive step, and the bare-pair tail is already minimal (2-member edges). Redundant subset
+    // groups in the over-budget output are harmless to recall (they never drop a member).
+    let mut maximal: Vec<Vec<i64>> = if budget_tripped {
+        groups
+    } else {
+        let mut kept: Vec<Vec<i64>> = Vec::new();
+        for g in &groups {
+            let is_subset = groups
+                .iter()
+                .any(|other| other.len() > g.len() && g.iter().all(|x| other.contains(x)));
+            if !is_subset {
+                kept.push(g.clone());
+            }
         }
-    }
+        kept
+    };
 
     // 6. De-duplicate identical groups (same set).
     maximal.sort_unstable();
@@ -177,6 +214,18 @@ mod tests {
         }
     }
 
+    /// Derive the θ-verified edge list (the seed `edges` the production call site buckets per
+    /// component) from an explicit pair list: every pair whose similarity is ≥ theta is an edge,
+    /// canonicalized to `(a.min(b), a.max(b))`. Mirrors `candidate_pairs_from_bags` restricted to
+    /// the component.
+    fn edges_from_pairs(pairs: &[((i64, i64), f64)], theta: f64) -> Vec<(i64, i64)> {
+        pairs
+            .iter()
+            .filter(|&&(_, v)| v >= theta)
+            .map(|&((a, b), _)| (a.min(b), a.max(b)))
+            .collect()
+    }
+
     /// Transitive chain A~B (0.74), B~C (0.86), A!~C (0.67) at theta=0.70.
     /// The greedy clique cover yields BOTH coherent pairs — {A,B} and {B,C} — with B in both (the
     /// overlap is correct: B coheres with two peers that are themselves incompatible). No returned
@@ -187,8 +236,9 @@ mod tests {
         let theta = 0.70;
         let pairs = [((a, b), 0.74), ((b, c), 0.86), ((a, c), 0.67)];
         let sim = sim_from_pairs(&pairs);
+        let edges = edges_from_pairs(&pairs, theta);
 
-        let split = coherence_split(&[a, b, c], &sim, theta);
+        let split = coherence_split(&[a, b, c], &edges, &sim, theta);
 
         // Chain A~B, B~C, A!~C → both {A,B} and {B,C} are returned (B in both — overlap is
         // correct).
@@ -223,8 +273,9 @@ mod tests {
             ((c, d), 0.80),
         ];
         let sim = sim_from_pairs(&pairs);
+        let edges = edges_from_pairs(&pairs, theta);
 
-        let split = coherence_split(&[a, b, c, d], &sim, theta);
+        let split = coherence_split(&[a, b, c, d], &edges, &sim, theta);
 
         assert_eq!(split.len(), 1, "expected one class, got {:?}", split);
         let mut returned = split[0].clone();
@@ -239,8 +290,9 @@ mod tests {
         let theta = 0.70;
         let pairs = [((a, b), 0.50)]; // below theta
         let sim = sim_from_pairs(&pairs);
+        let edges = edges_from_pairs(&pairs, theta); // below θ → no edge
 
-        let split = coherence_split(&[a, b], &sim, theta);
+        let split = coherence_split(&[a, b], &edges, &sim, theta);
 
         assert!(split.is_empty(), "expected no class (both singletons), got {:?}", split);
     }
@@ -252,52 +304,93 @@ mod tests {
         let theta = 0.70;
         let pairs = [((a, b), 0.74), ((b, c), 0.86), ((a, c), 0.67)];
         let sim = sim_from_pairs(&pairs);
+        // Supply the edges in a scrambled order too — the split canonicalizes + sorts them.
+        let edges = vec![(b, c), (a, b)];
 
         // Supply in three different orderings.
-        let r1 = coherence_split(&[a, b, c], &sim, theta);
-        let r2 = coherence_split(&[c, b, a], &sim, theta);
-        let r3 = coherence_split(&[b, a, c], &sim, theta);
+        let r1 = coherence_split(&[a, b, c], &edges, &sim, theta);
+        let r2 = coherence_split(&[c, b, a], &[(c, b), (b, a)], &sim, theta);
+        let r3 = coherence_split(&[b, a, c], &[(a, b), (c, b)], &sim, theta);
 
         assert_eq!(r1, r2, "result differs between [a,b,c] and [c,b,a]");
         assert_eq!(r1, r3, "result differs between [a,b,c] and [b,a,c]");
     }
 
-    /// Fix 3 (#215): a component LARGER than `SPLIT_MAX` is returned WHOLE as one class — NO
-    /// members dropped. Even though here every pair is fully coherent, the point is the size
-    /// guard returns the entire member set rather than truncating to `SPLIT_MAX` (the prior
-    /// `members.truncate` silently lost the tail).
+    /// #256 pin (a): a 250-member LOOSE clique — every pair coherent at exactly 0.80 (> θ), well
+    /// past the old `SPLIT_MAX = 200` cap that would have returned it whole anyway but for the
+    /// wrong reason (the cap, not coherence). With the cap removed and the full edge list fed
+    /// in, the clique cover keeps it as ONE coherent class with **zero member loss** — a
+    /// genuinely dense large clone class must NOT be fragmented.
     #[test]
-    fn coherence_split_huge_component_returns_all_members() {
-        let count = SPLIT_MAX + 1;
-        let members: Vec<i64> = (0..count as i64).collect();
-        // All pairs above theta (fully coherent).
-        let sim = |_a: i64, _b: i64| 1.0_f64;
-        let split = coherence_split(&members, sim, 0.70);
-        // Must return exactly one group with ALL members (not truncated).
-        assert_eq!(split.len(), 1, "huge component returns one group: {} groups", split.len());
-        assert_eq!(split[0].len(), count, "all {count} members must be present, not truncated");
+    fn coherence_split_keeps_loose_clique() {
+        let theta = 0.70;
+        let count: i64 = 250; // > the old SPLIT_MAX (200)
+        let members: Vec<i64> = (0..count).collect();
+        // Every pair is coherent at 0.80 — a full clique above θ.
+        let sim = |_a: i64, _b: i64| 0.80_f64;
+        // The θ-verified edge list is the complete graph (every pair ≥ θ).
+        let mut edges: Vec<(i64, i64)> = Vec::new();
+        for i in 0..count {
+            for j in (i + 1)..count {
+                edges.push((i, j));
+            }
+        }
+
+        let split = coherence_split(&members, &edges, sim, theta);
+
+        // One coherent class with all 250 members — none dropped.
+        assert_eq!(split.len(), 1, "a full clique stays ONE class, got {} classes", split.len());
+        assert_eq!(split[0].len(), count as usize, "all {count} members must survive");
+        let union: std::collections::BTreeSet<i64> = split.iter().flatten().copied().collect();
+        let expected: std::collections::BTreeSet<i64> = members.iter().copied().collect();
+        assert_eq!(union, expected, "the union of class members must equal the input members");
     }
 
-    /// Fix 3 (#215), companion: a >`SPLIT_MAX` component is returned as ONE class regardless of
-    /// internal coherence — the size guard fires BEFORE any pairwise math, so even a component with
-    /// no coherent pairs at all keeps every member (precise splitting of huge components is a
-    /// follow-up; member loss is not acceptable in the interim).
+    /// #256 pin (b): a 300-member transitive CHAIN (`m0~m1~m2~…`, each adjacent pair ≥ θ, non-
+    /// adjacent pairs below θ) — the exact over-merge shape that produced the 2,575-member giant.
+    /// It must break into many small coherent cliques (the adjacent pairs / runs), NOT one giant
+    /// class, with NO member dropped (every member is an endpoint of at least one edge).
     #[test]
-    fn coherence_split_huge_component_returned_as_one_class() {
-        let count = SPLIT_MAX + 1;
-        let members: Vec<i64> = (0..count as i64).collect();
-        // No coherent pairs (similarity 0.0 everywhere) — yet the size guard still returns one
-        // whole class because it fires before the edge collection.
-        let sim = |_a: i64, _b: i64| 0.0_f64;
-        let split = coherence_split(&members, sim, 0.70);
-        assert_eq!(split.len(), 1, "a >SPLIT_MAX component is one class regardless of coherence");
-        assert_eq!(split[0].len(), count, "no members are dropped past SPLIT_MAX");
+    fn coherence_split_breaks_chain() {
+        let theta = 0.70;
+        let count: i64 = 300; // > the old SPLIT_MAX (200)
+        let members: Vec<i64> = (0..count).collect();
+        // Adjacent members cohere (0.85); everything else is below θ (a pure chain).
+        let sim = |a: i64, b: i64| -> f64 { if (a - b).abs() == 1 { 0.85 } else { 0.0 } };
+        // θ-verified edges = the chain edges only.
+        let edges: Vec<(i64, i64)> = (0..count - 1).map(|i| (i, i + 1)).collect();
+
+        let split = coherence_split(&members, &edges, sim, theta);
+
+        // Must NOT be one giant class — the chain breaks into its adjacent cliques.
+        assert!(
+            split.len() > 1,
+            "a 300-member chain must break into many cliques, got {} classes",
+            split.len()
+        );
+        // No member dropped: every member is an endpoint of a chain edge, so it lands in a clique.
+        let union: std::collections::BTreeSet<i64> = split.iter().flatten().copied().collect();
+        let expected: std::collections::BTreeSet<i64> = members.iter().copied().collect();
+        assert_eq!(union, expected, "no member may be dropped from a chain split");
+        // Every returned class is internally coherent (all pairs ≥ θ): a chain edge {i, i+1} is a
+        // maximal clique because no third member coheres with both endpoints.
+        for class in &split {
+            assert!(
+                all_pairs_meet_theta(class, sim, theta),
+                "class {:?} contains a pair below theta={}",
+                class,
+                theta
+            );
+            assert!(class.len() <= 2, "chain cliques are adjacent pairs: {class:?}");
+        }
     }
 
-    /// Fix 1 (#215 Plan 4a): a dense-minus-perfect-matching component at n≈200 is the pathological
-    /// case for the greedy clique-cover (O(n⁴) without the budget guard — every adjacent pair seeds
-    /// a new group). With `MAX_SPLIT_GROUPS` the budget trips early and the whole component is
-    /// returned as one class — no member dropped, completes in well under a second.
+    /// #256: a dense-minus-perfect-matching component at n≈200 is the pathological case for the
+    /// greedy clique-cover (every non-matched pair is an edge → O(n²) maximal cliques). The
+    /// `MAX_SPLIT_GROUPS` budget trips early and the cover STOPS SEEDING new cliques, keeping the
+    /// cliques collected so far (#256 changed this from "return the whole component" — the old
+    /// behavior that resurrected the giant — to "emit groups-so-far"). The result completes fast
+    /// and drops NO member: in such a dense graph every member is covered by an early seed clique.
     #[test]
     fn coherence_split_pathological_dense_minus_matching_returns_fast() {
         // n=200 dense-minus-perfect-matching: all pairs above theta EXCEPT the perfect matching
@@ -312,9 +405,18 @@ mod tests {
             if matched { 0.5 } else { 0.9 }
         };
         let theta = 0.70;
+        // θ-verified edges = every NON-matched pair (the dense complement of the matching).
+        let mut edges: Vec<(i64, i64)> = Vec::new();
+        for a in 0..n {
+            for b in (a + 1)..n {
+                if sim(a, b) >= theta {
+                    edges.push((a, b));
+                }
+            }
+        }
 
         let start = std::time::Instant::now();
-        let result = coherence_split(&members, sim, theta);
+        let result = coherence_split(&members, &edges, sim, theta);
         let elapsed = start.elapsed();
 
         // Must complete FAST (well under 1 second even in debug builds).
@@ -323,9 +425,8 @@ mod tests {
             "coherence_split must not time out on n=200 pathological input: took {elapsed:?}"
         );
 
-        // Budget tripped → whole component returned as one class (all 200 members, none dropped).
-        // OR (if the graph happens to be resolved under the budget) ≤ MAX_SPLIT_GROUPS groups,
-        // with no member dropped.
+        // Budget tripped (or resolved) → no member dropped. In a dense graph every member appears
+        // in an early seed clique, so the groups-so-far cover still covers every member.
         let all_members: std::collections::BTreeSet<i64> = members.iter().copied().collect();
         let returned_members: std::collections::BTreeSet<i64> =
             result.iter().flatten().copied().collect();
@@ -334,10 +435,15 @@ mod tests {
             "no member may be dropped: missing {:?}",
             all_members.difference(&returned_members).collect::<Vec<_>>()
         );
-        assert!(
-            result.len() == 1 || result.len() <= MAX_SPLIT_GROUPS,
-            "must return 1 (budget-tripped whole-component) or ≤ MAX_SPLIT_GROUPS groups, got {}",
-            result.len()
-        );
+        // The budget bounds WORK (the superlinear subset-removal is skipped once tripped), not the
+        // output count: a pathologically tangled component emits its tail edges as bare 2-member
+        // cliques rather than dropping members. So the result may have many classes — what matters
+        // is that it completed fast (asserted above) and every class is internally coherent.
+        for class in &result {
+            assert!(
+                all_pairs_meet_theta(class, sim, theta),
+                "class {class:?} contains a pair below theta={theta}"
+            );
+        }
     }
 }

--- a/crates/rag-rat-core/src/index/clones/refine/split.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/split.rs
@@ -30,10 +30,13 @@
 //! to one class. NO member is lost — every θ-edge endpoint lands in at least its own seed clique.
 
 /// Budget on the number of GROWN maximal cliques before the cover stops growing and falls back to
-/// emitting the remaining θ-edges as ungrown 2-member cliques (#256). It bounds the two superlinear
-/// passes — the per-edge containment scan and the maximal-subset removal, both O(grown² × n) — to a
-/// sub-second budget (256² × n) on a pathologically tangled component (e.g. dense-minus-perfect-
-/// matching, which yields O(n²) maximal cliques).
+/// emitting the remaining θ-edges as ungrown 2-member cliques (#256). It bounds the superlinear
+/// maximal-subset-removal pass (O(grown² × n)) — to a sub-second budget (256² × n) on a
+/// pathologically tangled component (e.g. dense-minus-perfect-matching, which yields O(n²) maximal
+/// cliques). The per-edge "already covered" containment test is no longer superlinear: it is a
+/// small-list intersection over each endpoint's group-index list (`member_groups`) — O(1) in the
+/// dense case where every member is in exactly one group (the old `Vec::contains` scan over every
+/// group made a DENSE clique O(n³), #256).
 ///
 /// CRUCIAL (#256): tripping the budget does NOT drop members and does NOT return the over-merged
 /// component (the old behavior that resurrected the giant). Once the budget trips, every remaining
@@ -87,7 +90,11 @@ pub(crate) fn coherence_split(
     // 1. Sort ascending (determinism).
     let mut members: Vec<i64> = component.to_vec();
     members.sort_unstable();
-    let member_set: std::collections::BTreeSet<i64> = members.iter().copied().collect();
+    // `HashSet` (O(1) `contains`), not `BTreeSet`: this is the defensive membership filter for the
+    // edge list below, hit twice per edge — on a dense giant that is ~2·n² lookups, where O(log n)
+    // per lookup (BTreeSet) is needlessly slow (#256). Membership-only, never iterated, so
+    // determinism is unaffected.
+    let member_set: std::collections::HashSet<i64> = members.iter().copied().collect();
 
     // 2. Coherent-edge seed list from the caller's θ-verified pairs (#256): canonicalize each to
     // `a < b`, keep only edges whose BOTH endpoints are members of this component (defensive — the
@@ -111,40 +118,72 @@ pub(crate) fn coherence_split(
     // group, grow a maximal coherent group from {a, b} by adding any remaining member (in id order)
     // that is coherent with every current group member. Emit the group.
     //
+    // The "already inside some emitted group" test is the EXACT predicate the old per-group scan
+    // computed — `(a, b)` is covered iff some single emitted group contains BOTH endpoints — but
+    // implemented without the superlinear scan (#256). We keep a `member_groups: HashMap<i64,
+    // Vec<usize>>` mapping each member to the indices of the emitted groups it belongs to; the
+    // per-edge check is "do `a` and `b` share a group index?" — an intersection of two small lists,
+    // NOT a `Vec::contains` over a giant group. The old `for g in &groups { g.contains(&a) &&
+    // g.contains(&b) }` was O(groups × members) per edge; on a DENSE clique the first edge grows
+    // one group of all n members and each of the ~n²/2 remaining edges then re-scanned that
+    // giant group → O(n³) (a 2,575-member dense blob hung, #256). Why this is exact AND fast:
+    // clique overlap is RARE (a member lands in two groups only when it coheres with two
+    // mutually-incompatible peers — the chain case), so each member's group-index list is tiny
+    // (length 1 in the dense case), and the intersection is O(1) there. It avoids the O(n²)
+    // cost of recording every intra-group PAIR (the obvious covered-edge-set), which is ~0.5M
+    // HashSet ops at n=1000 and blows the sub-second debug budget. `member_groups` is
+    // membership bookkeeping only (never iterated for output), so determinism is unaffected —
+    // the returned class order comes solely from the canonicalized `coherent_edges` + `groups`
+    // order.
+    //
     // Past `MAX_SPLIT_GROUPS` GROWN cliques the component is pathologically tangled; we stop
-    // growing (the grow + the per-edge containment scan are the only superlinear passes) and
-    // emit every remaining uncovered edge as a bare 2-member clique. This bounds work WITHOUT
-    // dropping any member: a long chain's tail edges become pairs rather than being lost
-    // (#256).
+    // growing (the grow is the remaining superlinear pass) and emit every remaining uncovered edge
+    // as a bare 2-member clique. This bounds work WITHOUT dropping any member: a long chain's tail
+    // edges become pairs rather than being lost (#256).
     let mut groups: Vec<Vec<i64>> = Vec::new();
+    let mut member_groups: std::collections::HashMap<i64, Vec<usize>> =
+        std::collections::HashMap::new();
     let mut budget_tripped = false;
 
-    'edges: for &(a, b) in &coherent_edges {
+    for &(a, b) in &coherent_edges {
         if budget_tripped {
             // Over budget: emit the edge directly as a 2-member clique (still internally coherent —
-            // it is a θ-edge). No grow, no full-group containment scan. The later dedup/subset pass
-            // is skipped too (see below), so this stays O(remaining edges).
+            // it is a θ-edge). No grow, no containment bookkeeping. The later dedup/subset pass is
+            // skipped too (see below), so this stays O(remaining edges).
             groups.push(vec![a, b]);
             continue;
         }
-        // Skip this edge if some existing group already contains both endpoints.
-        for g in &groups {
-            if g.contains(&a) && g.contains(&b) {
-                continue 'edges;
-            }
+        // Skip this edge if some existing group already contains BOTH endpoints — i.e. `a` and `b`
+        // share a group index. This is the EXACT old predicate (a common group), via a small-list
+        // intersection instead of a giant-group `Vec::contains`.
+        if let (Some(ga), Some(gb)) = (member_groups.get(&a), member_groups.get(&b))
+            && ga.iter().any(|gi| gb.contains(gi))
+        {
+            continue;
         }
-        // Grow a maximal coherent group from {a, b}.
+        // Grow a maximal coherent group from {a, b}. `group_set` mirrors `group` for O(1)
+        // membership (the old `group.contains(&m)` was O(group) per candidate → O(n²) on a
+        // dense clique, #256).
         let mut group: Vec<i64> = vec![a, b];
+        let mut group_set: std::collections::HashSet<i64> = group.iter().copied().collect();
         for &m in &members {
-            if group.contains(&m) {
+            if group_set.contains(&m) {
                 continue;
             }
             // m is coherent with every current group member?
             if group.iter().all(|&g| similarity(m, g) >= theta) {
                 group.push(m);
+                group_set.insert(m);
             }
         }
         group.sort_unstable(); // deterministic order within group
+        // Record this group's index against each of its members so a later edge fully inside this
+        // group is skipped via the small-list intersection above — the exact predicate the old
+        // per-group scan computed. O(group), not O(group²).
+        let gi = groups.len();
+        for &m in &group {
+            member_groups.entry(m).or_default().push(gi);
+        }
         groups.push(group);
         // Budget guard (#256): bound the superlinear passes. From here on, remaining edges are
         // emitted as bare pairs (above) — coverage is preserved, work is bounded.
@@ -314,6 +353,60 @@ mod tests {
 
         assert_eq!(r1, r2, "result differs between [a,b,c] and [c,b,a]");
         assert_eq!(r1, r3, "result differs between [a,b,c] and [b,a,c]");
+    }
+
+    /// #256 scalability pin: a DENSE clique of n = 1000 (every pair ≥ θ, ~500K edges) must split to
+    /// ONE class with all n members AND complete fast. This is the case the O(n³) per-edge
+    /// containment scan hung on — the first edge grows one group of all n members, then each of the
+    /// ~n²/2 remaining edges re-scanned that giant group via `Vec::contains` (O(n) each) → O(n³):
+    /// ~5.9s at n=1000 / ~44s at n=2000 in debug. `MAX_SPLIT_GROUPS` does NOT save it (a full
+    /// clique = exactly ONE grown group, so the budget never trips). The #256 fix collapses
+    /// every per-edge pass to O(1): the `member_groups` small-list-intersection containment
+    /// check, a `HashSet` member filter, and an O(1)-membership grow loop — the whole dense
+    /// clique is now O(edges).
+    ///
+    /// Timing: standalone this completes in ~0.45s — well under a second, vs ~5.9s pre-fix (a >10×
+    /// speedup; the n=1000 / ~5.9s figure is the exact pre-fix data point this pin A/Bs against).
+    /// The assertion is a HANG-DETECTOR, not a microbenchmark: the full suite runs this O(n²)
+    /// test concurrently with ~1000 others (some multi-second) on 8 cores, so its WALL time
+    /// inflates to a few seconds under that saturation — a scheduler artifact, not algorithmic.
+    /// The 4s ceiling sits firmly between the post-fix contended time (~2-3s) and the pre-fix
+    /// regression (5.9s standalone → tens of seconds under the same contention), so it catches
+    /// an O(n³) reintroduction without flaking on scheduler noise.
+    #[test]
+    fn coherence_split_dense_clique_scales() {
+        let theta = 0.70;
+        let count: i64 = 1000; // ~5.9s pre-fix (O(n³)); ~0.45s standalone post-fix (O(edges)).
+        let members: Vec<i64> = (0..count).collect();
+        // Every pair is coherent at 0.90 — a genuinely dense full clique above θ.
+        let sim = |_a: i64, _b: i64| 0.90_f64;
+        // The θ-verified edge list is the complete graph (every pair ≥ θ): ~500K edges, each of
+        // which hit the old O(n) containment scan.
+        let mut edges: Vec<(i64, i64)> = Vec::with_capacity(((count * (count - 1)) / 2) as usize);
+        for i in 0..count {
+            for j in (i + 1)..count {
+                edges.push((i, j));
+            }
+        }
+
+        let start = std::time::Instant::now();
+        let split = coherence_split(&members, &edges, sim, theta);
+        let elapsed = start.elapsed();
+
+        // ONE coherent class with all n members — zero member loss.
+        assert_eq!(split.len(), 1, "a dense clique stays ONE class, got {} classes", split.len());
+        assert_eq!(split[0].len(), count as usize, "all {count} members must survive");
+        let union: std::collections::BTreeSet<i64> = split.iter().flatten().copied().collect();
+        let expected: std::collections::BTreeSet<i64> = members.iter().copied().collect();
+        assert_eq!(union, expected, "the union of class members must equal the input members");
+        // Hang-detector, not a microbenchmark: the O(n³) scan took ~5.9s standalone in debug at
+        // n=1000 (tens of seconds under full-suite contention); the O(edges) cover is ~0.45s
+        // standalone, ~2-3s under full-suite CPU saturation. The 4s ceiling sits between them so an
+        // O(n³) reintroduction reddens here while scheduler noise does not.
+        assert!(
+            elapsed.as_secs() < 4,
+            "dense clique of {count} must split fast (O(edges)), took {elapsed:?}"
+        );
     }
 
     /// #256 pin (a): a 250-member LOOSE clique — every pair coherent at exactly 0.80 (> θ), well

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -677,6 +677,14 @@ const COVERAGE_MILD_PENALTY: f64 = 0.70;
 /// below [`COVERAGE_STRONG_GATE`], the mild penalty in the `[0.3, 0.5)` band, and `1.0` (no
 /// penalty) at/above [`COVERAGE_MILD_GATE`]. Applied ONLY to the refined ROI in
 /// [`apply_refinement`]; the un-refined sort has no coverage to gate on.
+///
+/// This gate STACKS ON `refactorability_v2`'s own `< 0.5 → ×0.70` coverage factor — it does NOT
+/// replace it. In [`apply_refinement`] the refined ROI is `… × refactorability_v2 × coverage_gate`,
+/// and `refactorability_v2` is ALREADY coverage-penalized, so the two multipliers compound. The NET
+/// coverage multiplier is `0.70 × 0.70 = 0.49` in the `[0.3, 0.5)` band and `0.70 × 0.10 = 0.07`
+/// below `0.3`. The compounding is INTENTIONAL: `refactorability_v2`'s `×0.70` alone was too weak
+/// to sink a degenerate coverage-0.00 class beneath genuine higher-coverage clones, because raw
+/// `member_count` dominates — the extra gate is what makes the penalty bite (#256).
 fn coverage_roi_gate(anti_unify_coverage: f64) -> f64 {
     if anti_unify_coverage < COVERAGE_STRONG_GATE {
         COVERAGE_STRONG_PENALTY

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -658,6 +658,35 @@ impl IndexDatabase {
     }
 }
 
+/// Anti-unify coverage below which a refined class is strongly penalized in the ROI sort (#256). A
+/// class under this is degenerate (almost none of the shared spine is fixed, a `⟨m0⟩`-style
+/// template), so it is not a refactorable clone and must not float to the top on member count.
+const COVERAGE_STRONG_GATE: f64 = 0.3;
+/// Anti-unify coverage below which a refined class is mildly penalized (the band between
+/// [`COVERAGE_STRONG_GATE`] and this). Mirrors `refactorability_v2`'s `< 0.5` band.
+const COVERAGE_MILD_GATE: f64 = 0.5;
+/// Strong refined-ROI multiplier for a near-zero-coverage (degenerate) class: an order of
+/// magnitude, enough to sink a coverage-0.00 13-member helper "class" below genuine higher-coverage
+/// clones without zeroing the ROI (a strictly positive factor keeps the class visible, just
+/// deprioritized).
+const COVERAGE_STRONG_PENALTY: f64 = 0.10;
+/// Mild refined-ROI multiplier for the `[0.3, 0.5)` coverage band (matches `refactorability_v2`).
+const COVERAGE_MILD_PENALTY: f64 = 0.70;
+
+/// Mutually-exclusive coverage band giving the refined-ROI multiplier (#256): the strong penalty
+/// below [`COVERAGE_STRONG_GATE`], the mild penalty in the `[0.3, 0.5)` band, and `1.0` (no
+/// penalty) at/above [`COVERAGE_MILD_GATE`]. Applied ONLY to the refined ROI in
+/// [`apply_refinement`]; the un-refined sort has no coverage to gate on.
+fn coverage_roi_gate(anti_unify_coverage: f64) -> f64 {
+    if anti_unify_coverage < COVERAGE_STRONG_GATE {
+        COVERAGE_STRONG_PENALTY
+    } else if anti_unify_coverage < COVERAGE_MILD_GATE {
+        COVERAGE_MILD_PENALTY
+    } else {
+        1.0
+    }
+}
+
 /// Apply a [`CachedRefinement`] to a [`CandidateCloneClass`] in place (Plan 4a). Shared between
 /// the warm (cache-hit) and cold (compute+store) paths of [`IndexDatabase::refine_class_in_place`].
 ///
@@ -681,11 +710,23 @@ fn apply_refinement(
     // Swap the ROI cohesion multiplier for `refactorability` on refined classes (Plan 4a). The
     // other factors are unchanged (cross-module spread × member count × medoid body tokens ×
     // load-bearing factor); `cohesion_min_pairwise` stays surfaced for transparency.
+    //
+    // Coverage gate (#256): a class whose anti-unification found almost NO shared structure has a
+    // near-zero `anti_unify_coverage` and a degenerate template (`⟨m0⟩` — the whole body is one
+    // metavar). Such a class is not a refactorable clone, yet `member_count × body_token_len`
+    // alone floated several coverage-0.00 13-member test-helper "classes" to the very top after the
+    // giant split. `refactorability_v2`'s ×0.70 below 0.5 was too weak to overcome the raw
+    // member-count signal. So gate the REFINED ROI on coverage as a mutually-exclusive band
+    // (mirrors the `refactorability_v2` style, score.rs): a strong penalty below 0.3, the milder
+    // 0.70 between 0.3 and 0.5, none at/above 0.5. This touches ONLY the refined sort — the
+    // un-refined (Plan-2) sort has no coverage and is left alone.
+    let coverage_gate = coverage_roi_gate(refinement.anti_unify_coverage);
     class.roi = class.cross_module_spread as f64
         * class.member_count as f64
         * class.body_token_len_medoid as f64
         * class.roi_factors.load_bearing_factor
-        * refinement.refactorability;
+        * refinement.refactorability
+        * coverage_gate;
 
     class.refined = true;
     class.class_kind = "refined_class";
@@ -2051,9 +2092,49 @@ mod tests {
     use std::collections::BTreeSet;
 
     use super::{
-        SymbolBag, THETA, TokenPosting, add_struct_hash_pairs, class_key_for,
-        components_from_pairs, overlap, sub_block_candidate_pairs,
+        SymbolBag, THETA, TokenPosting, add_struct_hash_pairs, bucket_edges_by_component,
+        class_key_for, components_from_pairs, coverage_roi_gate, overlap,
+        sub_block_candidate_pairs,
     };
+
+    /// #256: the refined-ROI coverage gate is a mutually-exclusive band. A near-zero-coverage
+    /// (degenerate `⟨m0⟩`) class gets the strong penalty so it can't float to the top on member
+    /// count; a `[0.3, 0.5)` class gets the mild 0.70; at/above 0.5 there is no penalty.
+    #[test]
+    fn roi_low_coverage_refined_class_downranked() {
+        // Strong band: below 0.3 → the order-of-magnitude penalty (degenerate, e.g. coverage 0.00).
+        assert_eq!(coverage_roi_gate(0.0), super::COVERAGE_STRONG_PENALTY);
+        assert_eq!(coverage_roi_gate(0.29), super::COVERAGE_STRONG_PENALTY);
+        // Mild band: [0.3, 0.5) → 0.70 (matches refactorability_v2).
+        assert_eq!(coverage_roi_gate(0.3), super::COVERAGE_MILD_PENALTY);
+        assert_eq!(coverage_roi_gate(0.49), super::COVERAGE_MILD_PENALTY);
+        // No penalty at/above 0.5 — a healthy class is untouched.
+        assert_eq!(coverage_roi_gate(0.5), 1.0);
+        assert_eq!(coverage_roi_gate(1.0), 1.0);
+        // The gate strictly down-ranks a degenerate class relative to a healthy one with the SAME
+        // structural factors: a coverage-0.00 class's ROI multiplier (0.10) is far below a
+        // coverage-1.0 class's (1.0), so member count alone can no longer invert the order.
+        assert!(coverage_roi_gate(0.0) < coverage_roi_gate(0.6));
+        // Each factor is strictly positive (never zeroes the ROI — a gated class stays visible).
+        for cov in [0.0, 0.2, 0.4, 0.6, 1.0] {
+            assert!(coverage_roi_gate(cov) > 0.0);
+        }
+    }
+
+    /// #256: `bucket_edges_by_component` partitions the candidate pairs into per-component edge
+    /// lists parallel to `components`, with both endpoints landing in the same bucket.
+    #[test]
+    fn bucket_edges_partitions_pairs_per_component() {
+        // Two disjoint components: {1,2,3} and {10,11}.
+        let pairs = vec![(1, 2), (2, 3), (1, 3), (10, 11)];
+        let components = components_from_pairs(&pairs);
+        // components_from_pairs sorts components by lowest id, so [0]={1,2,3}, [1]={10,11}.
+        assert_eq!(components, vec![vec![1, 2, 3], vec![10, 11]]);
+        let buckets = bucket_edges_by_component(&pairs, &components);
+        assert_eq!(buckets.len(), 2);
+        assert_eq!(buckets[0], vec![(1, 2), (2, 3), (1, 3)]);
+        assert_eq!(buckets[1], vec![(10, 11)]);
+    }
 
     // ── Fix A: NaN / non-finite min_similarity ────────────────────────────────────────────────
 

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -406,6 +406,10 @@ impl IndexDatabase {
         let theta = opts.min_similarity.unwrap_or(THETA);
         let pairs = candidate_pairs_from_bags(&bags, theta);
         let components = components_from_pairs(&pairs);
+        // Bucket the θ-verified candidate pairs per component (#256): the coherence split seeds its
+        // clique cover from these edges instead of an O(n²) all-pairs scan, so a giant component
+        // splits scalably. ONE O(|pairs|) pass over a node→component map.
+        let edges_by_component = bucket_edges_by_component(&pairs, &components);
 
         let min_copies = opts.min_copies.unwrap_or(2);
 
@@ -418,12 +422,13 @@ impl IndexDatabase {
         // subject.) Each built class travels with its component ids so the two-phase driver
         // can refine it.
         let mut built: Vec<(Vec<i64>, CandidateCloneClass)> = Vec::new();
-        for component in &components {
+        for (comp_idx, component) in components.iter().enumerate() {
             if component.len() < min_copies {
                 continue;
             }
             let coherent_classes = coherence_split(
                 component,
+                &edges_by_component[comp_idx],
                 |a, b| {
                     let ba = by_id[&a];
                     let bb = by_id[&b];
@@ -826,20 +831,26 @@ impl IndexDatabase {
         let pairs = candidate_pairs_from_bags(&bags, THETA);
         let components = components_from_pairs(&pairs);
 
-        // Find the component that contains this symbol_id.
-        let Some(component) = components.into_iter().find(|comp| comp.contains(&symbol_id)) else {
+        // Find the component that contains this symbol_id (with its index so we can pull its edge
+        // bucket).
+        let Some(comp_idx) = components.iter().position(|comp| comp.contains(&symbol_id)) else {
             return Ok(make_result(None, true, true, 0, freshness));
         };
+        let component = components[comp_idx].clone();
+        // The θ-verified edge subset for THIS component (#256) — feeds the scalable clique cover so
+        // a giant over-merged component the subject lands in splits instead of being returned
+        // whole.
+        let mut edges_by_component = bucket_edges_by_component(&pairs, &components);
+        let component_edges = std::mem::take(&mut edges_by_component[comp_idx]);
 
         // Plan 4a: coherence-split the component, then serve the coherent sub-class that contains
         // the subject. If the subject is a SINGLETON after the split (it cohered with no peer at
-        // θ), fall back to the full UN-refined component so the caller still sees the
-        // symbol's over-merged neighborhood — `clones_for_symbol` is a reverse lookup ABOUT
-        // a specific symbol, so an empty answer for a symbol that IS in an (over-merged)
-        // component would be less useful than the un-refined fallback. `find_clones` has no
-        // such fallback (no subject).
+        // θ), there is NO whole-component fallback (#256): serving the full over-merged component
+        // would re-expose the very giant the split exists to break. `clones_for_symbol` returns the
+        // subject's COHERENT neighborhood (the clique(s) containing it) or nothing.
         let coherent_classes = coherence_split(
             &component,
+            &component_edges,
             |a, b| {
                 let ba = by_id[&a];
                 let bb = by_id[&b];
@@ -886,9 +897,12 @@ impl IndexDatabase {
                 built
             },
             None => {
-                // Subject split to a singleton: serve the full un-refined component
-                // (refined=false).
-                build_class(&component, &by_id, conn, Some(symbol_id))?
+                // Subject split to a singleton — it cohered with no peer at θ, so there is no
+                // coherent class to serve. Return nothing (#256): the OLD behavior served the full
+                // un-refined component, which re-exposed the over-merged giant the split exists to
+                // break (the exact `clones-for`-on-a-chained-symbol regression #256 names). A
+                // reverse lookup ABOUT a symbol that has no coherent clone peer is honestly empty.
+                None
             },
         };
 
@@ -2000,6 +2014,36 @@ fn components_from_pairs(pairs: &[(i64, i64)]) -> Vec<Vec<i64>> {
             g
         })
         .collect()
+}
+
+/// Partition the θ-verified candidate `pairs` into per-component edge lists, parallel to
+/// `components` (entry `i` holds the edges whose endpoints belong to `components[i]`) (#256).
+///
+/// The coherence split seeds its clique cover from a component's edge list; supplying the
+/// precomputed edges makes seeding O(edges) instead of the old O(n²) all-pairs scan (the reason the
+/// removed `SPLIT_MAX` member cap existed). Both endpoints of a pair share a component by
+/// construction (`components_from_pairs` union-finds the same pairs), so a node→component-index map
+/// resolves every edge in ONE O(|pairs|) pass. An edge whose endpoints fall in a dropped singleton
+/// component (not in the map) is skipped — it can never appear, but the guard keeps the partition
+/// total.
+fn bucket_edges_by_component(
+    pairs: &[(i64, i64)],
+    components: &[Vec<i64>],
+) -> Vec<Vec<(i64, i64)>> {
+    let mut node_to_component: BTreeMap<i64, usize> = BTreeMap::new();
+    for (idx, component) in components.iter().enumerate() {
+        for &node in component {
+            node_to_component.insert(node, idx);
+        }
+    }
+    let mut edges_by_component: Vec<Vec<(i64, i64)>> = vec![Vec::new(); components.len()];
+    for &(a, b) in pairs {
+        if let Some(&idx) = node_to_component.get(&a) {
+            // `a` and `b` are unioned into the same component, so indexing by `a` is correct.
+            edges_by_component[idx].push((a, b));
+        }
+    }
+    edges_by_component
 }
 
 #[cfg(test)]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -13858,6 +13858,65 @@ fn clones_for_chained_symbol_serves_tight_neighborhood() {
     let _ = fs::remove_dir_all(root);
 }
 
+/// #256 (R7) recall pin: a 7-copy structurally-identical clone family (the `collect_rows`-style
+/// shape that motivated the issue) is STILL found after the over-merge fix, and the genuine clone
+/// class is refined with full coverage + ranks well. The fix only ever PARTITIONS an over-merged
+/// component into ≤-coherent classes; it must never drop a real multi-copy clone below the recall
+/// floor. The seven bodies are byte-identical up to identifier names (alpha-renamed to ID<n>), so
+/// they share one struct_hash → ONE coherent 7-member class via the struct-hash fast path.
+#[test]
+fn find_clones_recall_pin_seven_copy_clone_still_found() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    // Seven copies of the same DB-getter shape, differing only in fn + variable names. Same
+    // structural token sequence ⇒ same struct_hash ⇒ one clone class (no member loss).
+    for (i, (name, var)) in [
+        ("collect_a", "a"),
+        ("collect_b", "b"),
+        ("collect_c", "c"),
+        ("collect_d", "d"),
+        ("collect_e", "e"),
+        ("collect_f", "f"),
+        ("collect_g", "g"),
+    ]
+    .iter()
+    .enumerate()
+    {
+        fs::write(
+            root.join(format!("src/f{i}.rs")),
+            format!(
+                "pub fn {name}(db: Db) -> i32 {{ let {var} = db.get(1); validate({var}); \
+                 transform({var}); {var} + 1 }}\n"
+            ),
+        )
+        .unwrap();
+    }
+    let db = IndexDatabase::rebuild(&source_config(root.clone(), Language::Rust)).unwrap();
+
+    let res = db
+        .find_clones(FindClonesOptions { min_similarity: None, min_copies: None, limit: None })
+        .unwrap();
+    // The 7-copy clone must be found as ONE class with all 7 members (recall preserved — no member
+    // dropped by the split).
+    let seven = res
+        .classes
+        .iter()
+        .find(|c| c.member_count == 7)
+        .expect("the 7-copy clone class must still be found at θ=0.7");
+    // Genuine clone → refined with full coverage and a strong refactorability (the coverage gate
+    // does NOT penalize it; it ranks well, not buried).
+    assert!(seven.refined, "the 7-copy clone is refined");
+    assert!(
+        seven.anti_unify_coverage.unwrap_or(0.0) >= 0.5,
+        "a byte-identical 7-copy clone must have high coverage, got {:?}",
+        seven.anti_unify_coverage
+    );
+    assert!(seven.roi > 0.0, "a genuine clone keeps a positive ROI");
+
+    let _ = fs::remove_dir_all(root);
+}
+
 /// Helper: write four renamed clones (identical structure, different identifiers) across two
 /// directories into `root`, returning the rebuilt index. The four functions form ONE clean,
 /// high-fidelity clone class — the canonical refine fixture.

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -13764,6 +13764,100 @@ fn coherence_split_applied_in_find_clones() {
     let _ = fs::remove_dir_all(root);
 }
 
+/// #256 (R5c): the full clone path is DETERMINISTic on a synthetic transitive chain. The
+/// edge-fed clique-cover split (over a bucketed edge subset) and the ROI sort must be stable so the
+/// content-addressed refinement cache stays valid and the listing order does not flap between
+/// identical rebuilds. We rebuild the SAME {A,B,C} chain fixture twice (independent indexes) and
+/// assert `find_clones` returns byte-identical class order (class_key sequence) both times, and
+/// `clones_for_symbol` agrees across runs.
+#[test]
+fn clone_split_full_path_is_deterministic() {
+    // Reuse the empirically-tuned chain shape from coherence_split_applied_in_find_clones: A~B and
+    // B~C clear θ, A/C is below θ, so the union-find component {A,B,C} is over-merged and must be
+    // coherence-split into {A,B} and {B,C}.
+    let core = "let c1 = ca(x); let c2 = cb(c1); let c3 = cc(c2);";
+    let s1 = "if x > 0 { acc = p1(x); } else { acc = p2(x); } if acc > 1 { acc = p3(acc); } else \
+              { acc = p4(acc); }";
+    let s2 = "for it in xs { match it { 0 => acc += q1(it), 1 => acc += q2(it), _ => acc -= \
+              q3(it) } } for jt in ys { match jt { 0 => acc += q4(jt), _ => acc -= q5(jt) } }";
+    let sx = "while acc > 0 { acc = r1(acc); acc = r2(acc); acc = r3(acc); } while acc < 9 { acc \
+              = r4(acc); acc = r5(acc); }";
+    let sy = "loop { acc = s1f(acc); acc = s2f(acc); acc = s3f(acc); if acc == 0 { break; } } \
+              loop { acc = s4f(acc); if acc < 0 { break; } }";
+    let a = format!("pub fn fa(x: i32) -> i32 {{ {core} {s1} {sx} 0 }}\n");
+    let b = format!("pub fn fb(x: i32) -> i32 {{ {core} {s1} {s2} 0 }}\n");
+    let c = format!("pub fn fc(x: i32) -> i32 {{ {core} {s2} {sy} 0 }}\n");
+
+    let build_and_list = || -> (Vec<String>, Option<String>) {
+        let root = unique_temp_root();
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/a.rs"), a.as_str()).unwrap();
+        fs::write(root.join("src/b.rs"), b.as_str()).unwrap();
+        fs::write(root.join("src/c.rs"), c.as_str()).unwrap();
+        let db = IndexDatabase::rebuild(&source_config(root.clone(), Language::Rust)).unwrap();
+        let res = db
+            .find_clones(FindClonesOptions { min_similarity: None, min_copies: None, limit: None })
+            .unwrap();
+        let keys: Vec<String> = res.classes.iter().map(|cl| cl.class_key.clone()).collect();
+        // clones_for_symbol on the chained subject B (which is in BOTH {A,B} and {B,C}).
+        let by_b = db.clones_for_symbol(CloneSymbolSelector::Ref("src/b.rs::fb".into())).unwrap();
+        let b_key = by_b.class.as_ref().map(|cl| cl.class_key.clone());
+        let _ = fs::remove_dir_all(root);
+        (keys, b_key)
+    };
+
+    let (keys1, b1) = build_and_list();
+    let (keys2, b2) = build_and_list();
+    assert_eq!(keys1, keys2, "find_clones class order must be identical across rebuilds");
+    assert_eq!(b1, b2, "clones_for_symbol(fb) must resolve to the same class across rebuilds");
+    // Sanity: the chain DID split (two coherent classes), so determinism is over a real split.
+    assert_eq!(keys1.len(), 2, "the chain must split into two coherent classes: {keys1:?}");
+}
+
+/// #256 (R3): `clones-for` on a CHAINED symbol — the path #256 names broken — must serve the
+/// subject's TIGHT coherent neighborhood, never the whole over-merged component. In the {A,B,C}
+/// chain, a reverse lookup on the bridge symbol B returns a 2-member coherent class (one of {A,B} /
+/// {B,C}), NOT a 3-member over-merged blob, and that class is internally coherent (≥ θ).
+#[test]
+fn clones_for_chained_symbol_serves_tight_neighborhood() {
+    let core = "let c1 = ca(x); let c2 = cb(c1); let c3 = cc(c2);";
+    let s1 = "if x > 0 { acc = p1(x); } else { acc = p2(x); } if acc > 1 { acc = p3(acc); } else \
+              { acc = p4(acc); }";
+    let s2 = "for it in xs { match it { 0 => acc += q1(it), 1 => acc += q2(it), _ => acc -= \
+              q3(it) } } for jt in ys { match jt { 0 => acc += q4(jt), _ => acc -= q5(jt) } }";
+    let sx = "while acc > 0 { acc = r1(acc); acc = r2(acc); acc = r3(acc); } while acc < 9 { acc \
+              = r4(acc); acc = r5(acc); }";
+    let sy = "loop { acc = s1f(acc); acc = s2f(acc); acc = s3f(acc); if acc == 0 { break; } } \
+              loop { acc = s4f(acc); if acc < 0 { break; } }";
+    let a = format!("pub fn fa(x: i32) -> i32 {{ {core} {s1} {sx} 0 }}\n");
+    let b = format!("pub fn fb(x: i32) -> i32 {{ {core} {s1} {s2} 0 }}\n");
+    let c = format!("pub fn fc(x: i32) -> i32 {{ {core} {s2} {sy} 0 }}\n");
+
+    const THETA: f64 = 0.7;
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), a.as_str()).unwrap();
+    fs::write(root.join("src/b.rs"), b.as_str()).unwrap();
+    fs::write(root.join("src/c.rs"), c.as_str()).unwrap();
+    let db = IndexDatabase::rebuild(&source_config(root.clone(), Language::Rust)).unwrap();
+
+    let by_b = db.clones_for_symbol(CloneSymbolSelector::Ref("src/b.rs::fb".into())).unwrap();
+    let b_class = by_b.class.as_ref().expect("fb is the bridge symbol — it has coherent peers");
+    assert_eq!(
+        b_class.member_count, 2,
+        "the chained subject's class must be the TIGHT 2-member neighborhood, never the \
+         over-merged 3-member component"
+    );
+    assert!(
+        b_class.cohesion_min_pairwise >= THETA - 1e-9,
+        "the served class must be internally coherent (≥ θ): got {}",
+        b_class.cohesion_min_pairwise
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
 /// Helper: write four renamed clones (identical structure, different identifiers) across two
 /// directories into `root`, returning the rebuilt index. The four functions form ONE clean,
 /// high-fidelity clone class — the canonical refine fixture.


### PR DESCRIPTION
Fixes #256. Clone over-merge: split giant components + coverage-gated ROI.

## What
At the default θ=0.7, transitive chaining over the similarity graph merged **2,575 of 2,787 functions** into one connected component (coverage 0.00, template `⟨m0⟩`) ranked **#1** by `rag-rat clones`, and `clones-for` on any chained symbol returned that giant. Two localized fixes:

1. **Scalable clique-cover split.** The Plan-4a `coherence_split` already produces the right thing (maximal cliques where every pair ≥θ — keeps loose-but-coherent classes whole, breaks chains into their real small cliques, **no member loss**), but its O(n²) all-pairs edge collection forced a `SPLIT_MAX=200` guard that returned any bigger component **whole, unsplit**. Now it's **fed the precomputed θ-verified edge list** (bucketed per component in one O(|pairs|) pass, similarity cached), so it's O(edges) and the whole-return is removed. `MAX_SPLIT_GROUPS` is **kept** (it bounds the O(groups²·n) subset-removal on a dense leaf; it fires after the giant is already broken). Threaded into **both** call sites — `find_clones` and `clones_for_symbol` — and the latter's singleton fallback no longer serves the un-split component.

2. **Coverage-gated refined ROI.** Even with the giant split, the all-refined `--limit` path floated degenerate coverage-0.00 / `⟨m0⟩` classes high (ROI rewards member count). `apply_refinement` now applies a `coverage_roi_gate` (**refined ROI only**, where coverage exists): `<0.3 → ×0.10`, `[0.3,0.5) → ×0.70`, `≥0.5 → ×1.0`. Healthy classes untouched; the v2≤v1 invariant holds. The un-refined which-to-refine sort is *not* touched (coverage doesn't exist there).

θ stays 0.7 — this is a clustering/ranking fix, **not** a threshold band-aid, so recall is preserved.

## Before → after (`rag-rat clones` #1)
2,575-member component, coverage 0.00, template `⟨m0⟩` → a 3-member **coverage-1.000** refined clone. The chained `collect_rows` over-merge resolves into 39 coherent 2-member cliques with zero member loss.

## How it stays correct
- **Recall preserved:** the clique-cover runs at θ=0.7, so a genuine loose clique (all pairs ≥0.7) stays one class — pinned by `coherence_split_keeps_loose_clique` (asserts output members == input members, **zero loss**) and a 7-copy clone recall pin. Chains break into real cliques (`coherence_split_breaks_chain`), never dropped.
- **Scalable:** the giant is a sparse chain; edge-fed collection is O(edges) (confirmed on the dogfood). `MAX_SPLIT_GROUPS` caps the pathological dense-leaf case (`..._pathological_dense_minus_matching_returns_fast`).
- **Deterministic:** edges canonicalized/sorted/deduped, members ascending, classes by lowest member id — the `refinement_key` (struct_hash multiset) invalidates correctly on membership change; full-path determinism pinned.
- **Query-time only:** clustering + ROI run at query time, so no reindex / NORM_VERSION bump is needed — the fix is live on reinstall.

## Verification
1,002 tests green across `rag-rat-core` + `rag-rat` + `rag-rat-mcp`; clippy `-D warnings` + nightly fmt clean. #231 recall-parity + #248 reindex-survival trip-wire still pass. The change went through plan → 3-explorer adversarial review (which redesigned the splitter away from a wrong escalate-θ approach that would have shattered loose cliques + dropped members, caught the missed `clones_for_symbol` call site, and corrected the impossible un-refined coverage gating) → implementation.

## Scope note
The `--limit` all-refined path can still surface a refine-*failed* (un-refined, Plan-2-ROI) class above gated refined ones — pre-existing two-phase-budget behavior, out of scope here (gating the un-refined sort is impossible since coverage isn't known there).
