### PR TITLE
feat(dream): deterministic memory-maintenance worklist v1 (#122)

### DIFF
--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -69,6 +69,10 @@ pub(crate) enum Command {
     /// Inspect and re-anchor source-anchored repo memories.
     Memory(MemoryArgs),
 
+    /// Dream-mode memory-maintenance worklist (#122): deterministic coverage-gap + stale-reference
+    /// findings written to `dream_findings`. Surfaces findings ABOUT memories; never mutates them.
+    Dream(DreamArgs),
+
     /// GitHub papertrail sync.
     Github(GithubArgs),
 
@@ -175,6 +179,13 @@ pub(crate) struct ImportantSymbolsArgs {
     /// global-by-default — it never auto-seeds from the git diff).
     #[arg(long, value_delimiter = ',')]
     pub personalize: Vec<String>,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct DreamArgs {
+    /// Max coverage-gap findings to surface (stale-reference findings are always all reported).
+    #[arg(long)]
+    pub limit: Option<u32>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -132,6 +132,9 @@ pub(crate) fn important_symbols(
 /// stale references), sync it into `dream_findings`, and render the open worklist. Writes ONLY to
 /// `dream_findings` — never mutates a memory.
 pub(crate) fn dream(config: &Config, args: &DreamArgs) -> anyhow::Result<()> {
+    // `dream` WRITES dream_findings — serialize with the watcher/index like every other write
+    // command (index/maintenance/oracle); WriteLock is reentrant so the open-time migrate is safe.
+    let _lock = rag_rat_core::locks::WriteLock::acquire_blocking(&config.database)?;
     let db = open_index(config)?;
     let now_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/crates/rag-rat-cli/src/commands.rs
+++ b/crates/rag-rat-cli/src/commands.rs
@@ -6,10 +6,10 @@ use super::*;
 #[cfg(feature = "eval")]
 use crate::cli::EvalArgs;
 use crate::cli::{
-    BriefArgs, ClonesArgs, ClonesForArgs, ClustersArgs, GithubArgs, GithubCommand, HookAction,
-    HooksArgs, ImportantSymbolsArgs, IndexArgs, MaintenanceArgs, MemoryArgs, MemoryCommand,
-    ModelsArgs, ModelsCommand, OracleArgs, OracleCommand, OracleReportArgs, OracleRunArgs,
-    OracleStatusArgs, QueryArgs, ReconcileArgs,
+    BriefArgs, ClonesArgs, ClonesForArgs, ClustersArgs, DreamArgs, GithubArgs, GithubCommand,
+    HookAction, HooksArgs, ImportantSymbolsArgs, IndexArgs, MaintenanceArgs, MemoryArgs,
+    MemoryCommand, ModelsArgs, ModelsCommand, OracleArgs, OracleCommand, OracleReportArgs,
+    OracleRunArgs, OracleStatusArgs, QueryArgs, ReconcileArgs,
 };
 
 /// Process-wide output format, set once from the global `--json` flag in `main` before any command
@@ -126,6 +126,22 @@ pub(crate) fn important_symbols(
     })?;
     apply_auto_run_ranking_hint(&mut result, config);
     print_output(&result)
+}
+
+/// Dream-mode worklist (#122): run the deterministic memory-maintenance pass (coverage gaps +
+/// stale references), sync it into `dream_findings`, and render the open worklist. Writes ONLY to
+/// `dream_findings` — never mutates a memory.
+pub(crate) fn dream(config: &Config, args: &DreamArgs) -> anyhow::Result<()> {
+    let db = open_index(config)?;
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+    let report = db.dream_run(rag_rat_core::dream::DreamOptions {
+        now_ms,
+        limit: args.limit.unwrap_or(20) as usize,
+    })?;
+    print_output(&report)
 }
 
 pub(crate) fn clones(config: &Config, args: &ClonesArgs) -> anyhow::Result<()> {

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -87,6 +87,7 @@ fn main() -> anyhow::Result<()> {
                 ))?;
         },
         Cmd::Memory(args) => memory(&config, &args)?,
+        Cmd::Dream(args) => dream(&config, &args)?,
         Cmd::Github(args) => github(&config, &args)?,
         Cmd::Hooks(args) => hooks(&config, &args)?,
         Cmd::Maintenance(args) => maintenance(&config, &args)?,

--- a/crates/rag-rat-core/src/dream.rs
+++ b/crates/rag-rat-core/src/dream.rs
@@ -1,0 +1,297 @@
+//! Dream Mode (#122) — deterministic memory-maintenance worklist.
+//!
+//! Surfaces findings ABOUT memories into `dream_findings`; it NEVER mutates a `repo_memories` row
+//! (dream mode proposes, a human/strong-agent confirms). Two v1 finding kinds, both deterministic
+//! and rate-independent (the spike's commit-replay evals showed change-based signals saturate on an
+//! active repo; these check structure/truth, not churn):
+//!   - `coverage_gap`   — load-bearing symbols (high call-graph in-degree) with no memory binding.
+//!   - `stale_reference`— a memory references a `.rs` path that no longer resolves against the
+//!     index (suffix-aware, so prose shorthand like `src/lib.rs` still resolves).
+//!
+//! Findings are identity-keyed `(kind, subject, claim_hash)`: a re-run with the same evidence
+//! REFRESHES (no duplicate); a materially-changed finding SUPERSEDES the prior one; a finding the
+//! run no longer reports is RESOLVED. Lifecycle verified in the spike prototype before this port.
+
+use std::collections::HashSet;
+
+use regex::Regex;
+use rusqlite::Connection;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+const COVERAGE_GAP_SCAN: usize = 400; // in-degree candidates to consider before filtering/limiting
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DreamFinding {
+    pub kind: String,
+    pub subject: String,
+    pub evidence: String,
+    pub rank: f64,
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct DreamReport {
+    pub findings: Vec<DreamFinding>, // the open worklist, ranked
+    pub opened: usize,
+    pub refreshed: usize,
+    pub superseded: usize,
+    pub resolved: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct DreamOptions {
+    pub now_ms: i64,
+    pub limit: usize, // max coverage_gap findings
+}
+
+fn claim_hash(kind: &str, subject: &str, evidence: &str) -> String {
+    let mut h = Sha256::new();
+    h.update(kind.as_bytes());
+    h.update([0x1f]);
+    h.update(subject.as_bytes());
+    h.update([0x1f]);
+    h.update(evidence.as_bytes());
+    hex16(&h.finalize())
+}
+
+fn finding_id(kind: &str, subject: &str, ch: &str) -> String {
+    let mut h = Sha256::new();
+    h.update(kind.as_bytes());
+    h.update([0x1f]);
+    h.update(subject.as_bytes());
+    h.update([0x1f]);
+    h.update(ch.as_bytes());
+    hex16(&h.finalize())
+}
+
+fn hex16(bytes: &[u8]) -> String {
+    bytes.iter().take(8).map(|b| format!("{b:02x}")).collect()
+}
+
+/// `coverage_gap`: top call-graph in-degree symbols with no memory binding (load-bearing code with
+/// no institutional memory). Importance proxy = raw in-degree; rank normalized to the top.
+fn coverage_gap(conn: &Connection, limit: usize) -> rusqlite::Result<Vec<DreamFinding>> {
+    let covered_syms: HashSet<i64> = conn
+        .prepare("SELECT DISTINCT symbol_id FROM repo_memory_bindings WHERE symbol_id IS NOT NULL")?
+        .query_map([], |r| r.get::<_, i64>(0))?
+        .collect::<rusqlite::Result<_>>()?;
+    let covered_paths: HashSet<String> = conn
+        .prepare("SELECT DISTINCT path FROM repo_memory_bindings WHERE path IS NOT NULL")?
+        .query_map([], |r| r.get::<_, String>(0))?
+        .collect::<rusqlite::Result<_>>()?;
+
+    let mut stmt = conn.prepare(
+        "SELECT to_symbol_id, COUNT(*) AS d FROM edges_data WHERE to_symbol_id IS NOT NULL GROUP \
+         BY to_symbol_id ORDER BY d DESC LIMIT ?1",
+    )?;
+    let candidates: Vec<(i64, i64)> = stmt
+        .query_map([COVERAGE_GAP_SCAN as i64], |r| Ok((r.get(0)?, r.get(1)?)))?
+        .collect::<rusqlite::Result<_>>()?;
+    let top_d = candidates.first().map(|(_, d)| *d).unwrap_or(1).max(1) as f64;
+
+    let mut out = Vec::new();
+    for (sym_id, d) in candidates {
+        if out.len() >= limit {
+            break;
+        }
+        if covered_syms.contains(&sym_id) {
+            continue;
+        }
+        let row = conn
+            .query_row(
+                "SELECT s.name, f.path FROM symbols s JOIN files f ON f.id = s.file_id WHERE s.id \
+                 = ?1",
+                [sym_id],
+                |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)),
+            )
+            .ok();
+        let Some((name, path)) = row else { continue };
+        if covered_paths.contains(&path) || path.to_lowercase().contains("test") {
+            continue; // test infra is high-in-degree but not a real coverage gap (spike eval: 4/20)
+        }
+        out.push(DreamFinding {
+            kind: "coverage_gap".into(),
+            subject: format!("{path}::{name}"),
+            evidence: format!("{d} callers, no memory binding [E0 importance proxy]"),
+            rank: d as f64 / top_d,
+        });
+    }
+    Ok(out)
+}
+
+/// `stale_reference`: a memory body references a `.rs` path that no longer resolves against the
+/// index. Suffix-aware so prose shorthand (`src/lib.rs` for `crates/x/src/lib.rs`) is NOT flagged.
+fn stale_reference(conn: &Connection) -> rusqlite::Result<Vec<DreamFinding>> {
+    let all_paths: HashSet<String> = conn
+        .prepare("SELECT path FROM files")?
+        .query_map([], |r| r.get::<_, String>(0))?
+        .collect::<rusqlite::Result<_>>()?;
+    let resolves = |p: &str| {
+        all_paths.contains(p) || all_paths.iter().any(|fp| fp.ends_with(&format!("/{p}")))
+    };
+    let re = Regex::new(r"\b((?:crates|apps|tools|src)/[\w./-]+\.rs)\b").expect("static regex");
+
+    let mut out = Vec::new();
+    let mut stmt = conn.prepare("SELECT id, body FROM repo_memories WHERE status = 'active'")?;
+    let mems: Vec<(String, String)> =
+        stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?.collect::<rusqlite::Result<_>>()?;
+    for (id, body) in mems {
+        let mut gone: Vec<String> = re
+            .captures_iter(&body)
+            .filter_map(|c| c.get(1).map(|m| m.as_str().to_string()))
+            .filter(|p| !resolves(p))
+            .collect();
+        gone.sort();
+        gone.dedup();
+        if !gone.is_empty() {
+            out.push(DreamFinding {
+                kind: "stale_reference".into(),
+                subject: id,
+                evidence: format!("references unresolved path(s): {} [E0]", gone.join(", ")),
+                rank: 0.5,
+            });
+        }
+    }
+    Ok(out)
+}
+
+/// Sync findings into `dream_findings` with the identity-keyed lifecycle (refresh / supersede /
+/// resolve). Returns (opened, refreshed, superseded, resolved).
+fn sync(
+    conn: &Connection,
+    findings: &[DreamFinding],
+    now_ms: i64,
+) -> rusqlite::Result<(usize, usize, usize, usize)> {
+    let (mut opened, mut refreshed, mut superseded, mut resolved) = (0, 0, 0, 0);
+    let mut seen: HashSet<(String, String)> = HashSet::new();
+    for f in findings {
+        let ch = claim_hash(&f.kind, &f.subject, &f.evidence);
+        seen.insert((f.kind.clone(), f.subject.clone()));
+        let existing: Option<String> = conn
+            .query_row(
+                "SELECT id FROM dream_findings WHERE kind = ?1 AND subject = ?2 AND claim_hash = \
+                 ?3",
+                rusqlite::params![f.kind, f.subject, ch],
+                |r| r.get(0),
+            )
+            .ok();
+        if existing.is_some() {
+            conn.execute(
+                "UPDATE dream_findings SET last_seen_at_ms = ?1, base_rank = ?2 WHERE kind = ?3 \
+                 AND subject = ?4 AND claim_hash = ?5",
+                rusqlite::params![now_ms, f.rank, f.kind, f.subject, ch],
+            )?;
+            refreshed += 1;
+            continue;
+        }
+        // new claim for this (kind, subject): supersede any current (open/verdict) finding, open
+        // fresh
+        let id = finding_id(&f.kind, &f.subject, &ch);
+        conn.execute(
+            "INSERT INTO dream_findings(id, kind, subject, claim_hash, evidence, base_rank, \
+             status, first_seen_at_ms, last_seen_at_ms) VALUES(?1,?2,?3,?4,?5,?6,'open',?7,?7)",
+            rusqlite::params![id, f.kind, f.subject, ch, f.evidence, f.rank, now_ms],
+        )?;
+        opened += 1;
+        superseded += conn.execute(
+            "UPDATE dream_findings SET status = 'superseded', superseded_by = ?1 WHERE kind = ?2 \
+             AND subject = ?3 AND id != ?1 AND status NOT IN ('resolved','superseded','archived')",
+            rusqlite::params![id, f.kind, f.subject],
+        )?;
+    }
+    // resolve: any current finding whose (kind, subject) was not reported this run -> drift gone
+    let current: Vec<(String, String, String)> = conn
+        .prepare(
+            "SELECT id, kind, subject FROM dream_findings WHERE status IN \
+             ('open','accepted','dismissed')",
+        )?
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))?
+        .collect::<rusqlite::Result<_>>()?;
+    for (id, kind, subject) in current {
+        if !seen.contains(&(kind, subject)) {
+            conn.execute("UPDATE dream_findings SET status = 'resolved' WHERE id = ?1", [&id])?;
+            resolved += 1;
+        }
+    }
+    Ok((opened, refreshed, superseded, resolved))
+}
+
+/// Run the deterministic dream-mode pass: compute findings, sync the worklist, return the open
+/// worklist (ranked) + lifecycle counts. Writes ONLY to `dream_findings`; never touches memories.
+pub fn dream_run(conn: &Connection, opts: DreamOptions) -> rusqlite::Result<DreamReport> {
+    let mut findings = coverage_gap(conn, opts.limit)?;
+    findings.extend(stale_reference(conn)?);
+    let (opened, refreshed, superseded, resolved) = sync(conn, &findings, opts.now_ms)?;
+
+    // emit the OPEN worklist from the store (post-sync), ranked
+    let mut open: Vec<DreamFinding> = conn
+        .prepare(
+            "SELECT kind, subject, evidence, base_rank FROM dream_findings WHERE status = 'open'",
+        )?
+        .query_map([], |r| {
+            Ok(DreamFinding {
+                kind: r.get(0)?,
+                subject: r.get(1)?,
+                evidence: r.get(2)?,
+                rank: r.get(3)?,
+            })
+        })?
+        .collect::<rusqlite::Result<_>>()?;
+    open.sort_by(|a, b| b.rank.partial_cmp(&a.rank).unwrap_or(std::cmp::Ordering::Equal));
+    Ok(DreamReport { findings: open, opened, refreshed, superseded, resolved })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mem_db() -> Connection {
+        let c = Connection::open_in_memory().unwrap();
+        crate::index::schema::apply(&c).unwrap();
+        c
+    }
+
+    #[test]
+    fn sync_is_idempotent_and_supersedes_on_change() {
+        let c = mem_db();
+        let f1 = vec![DreamFinding {
+            kind: "coverage_gap".into(),
+            subject: "x::F".into(),
+            evidence: "10 callers".into(),
+            rank: 1.0,
+        }];
+        let (o, r, s, res) = sync(&c, &f1, 1000).unwrap();
+        assert_eq!((o, r, s, res), (1, 0, 0, 0), "first run opens");
+        let (o, r, _, _) = sync(&c, &f1, 2000).unwrap();
+        assert_eq!((o, r), (0, 1), "same finding refreshes, no duplicate");
+        // material change -> supersede prior, open fresh
+        let f2 = vec![DreamFinding {
+            kind: "coverage_gap".into(),
+            subject: "x::F".into(),
+            evidence: "40 callers".into(),
+            rank: 1.0,
+        }];
+        let (o, _, s, _) = sync(&c, &f2, 3000).unwrap();
+        assert_eq!((o, s), (1, 1), "changed evidence supersedes + opens fresh");
+        let opened: i64 = c
+            .query_row("SELECT COUNT(*) FROM dream_findings WHERE status='open'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(opened, 1, "exactly one open finding for the (kind,subject)");
+        // run with no findings -> the (kind,subject) resolves
+        let (_, _, _, res) = sync(&c, &[], 4000).unwrap();
+        assert_eq!(res, 1, "absent finding resolves");
+    }
+
+    #[test]
+    fn dream_run_writes_findings_never_touches_memories() {
+        let c = mem_db();
+        let before: i64 =
+            c.query_row("SELECT COUNT(*) FROM repo_memories", [], |r| r.get(0)).unwrap();
+        let report = dream_run(&c, DreamOptions { now_ms: 1000, limit: 10 }).unwrap();
+        let after: i64 =
+            c.query_row("SELECT COUNT(*) FROM repo_memories", [], |r| r.get(0)).unwrap();
+        assert_eq!(before, after, "dream_run must never mutate repo_memories");
+        // empty index -> no findings, but the call succeeds and the table is usable
+        assert!(report.findings.is_empty());
+    }
+}

--- a/crates/rag-rat-core/src/dream.rs
+++ b/crates/rag-rat-core/src/dream.rs
@@ -42,6 +42,17 @@ pub struct DreamOptions {
     pub limit: usize, // max coverage_gap findings
 }
 
+/// Half-life for worklist rank decay: an unreviewed finding loses half its rank every 2 weeks, so a
+/// stale item sinks below fresh ones instead of squatting the top forever (anti-rot).
+const RANK_HALF_LIFE_MS: f64 = 14.0 * 86_400_000.0;
+
+/// `base_rank` decayed by age since the finding was first surfaced (`first_seen_at_ms`). This is
+/// the effective ordering rank the worklist exposes — the schema's documented age-decay, made real.
+fn effective_rank(base_rank: f64, first_seen_at_ms: i64, now_ms: i64) -> f64 {
+    let age = (now_ms - first_seen_at_ms).max(0) as f64;
+    base_rank * 0.5_f64.powf(age / RANK_HALF_LIFE_MS)
+}
+
 fn claim_hash(kind: &str, subject: &str, evidence: &str) -> String {
     let mut h = Sha256::new();
     h.update(kind.as_bytes());
@@ -68,17 +79,26 @@ fn hex16(bytes: &[u8]) -> String {
 
 /// `coverage_gap`: top call-graph in-degree symbols with no memory binding (load-bearing code with
 /// no institutional memory). Importance = DISTINCT caller count (`edges_data` carries several rows
-/// per caller pair, so `COUNT(*)` would over-count). The covered-symbol/path and test-infra filters
-/// are applied IN SQL *before* the LIMIT, so the budget is spent on ELIGIBLE rows — a pre-filter
-/// LIMIT lets high-in-degree covered/test symbols starve real gaps below the window.
+/// per caller pair, so `COUNT(*)` would over-count). COVERAGE mirrors the canonical memory query
+/// (query/memory/api.rs): a callee is covered if a binding matches its `symbol_id`, its logical
+/// symbol (mapped through `logical_symbol_members` — a logical_symbol binding covers ALL its member
+/// variants, not just the one stored `symbol_id`), or its file path. Test infra is filtered by
+/// `has_test_code`, NOT an unanchored `path LIKE '%test%'` (which would drop real files like
+/// `attestation.rs`/`latest.rs`). All filters run IN SQL *before* the LIMIT so the budget is spent
+/// on ELIGIBLE rows. The `files` join resolves to the active-checkout `temp.files` view so callees
+/// are checkout-scoped; the caller in-degree is not yet scoped (follow-up: reuse the scoped
+/// `important_symbols` PageRank instead of this raw in-degree proxy).
 fn coverage_gap(conn: &Connection, limit: usize) -> rusqlite::Result<Vec<DreamFinding>> {
     let mut stmt = conn.prepare(
         "SELECT s.name, f.path, COUNT(DISTINCT e.from_symbol_id) AS d FROM edges_data e JOIN \
          symbols s ON s.id = e.to_symbol_id JOIN files f ON f.id = s.file_id WHERE e.to_symbol_id \
-         IS NOT NULL AND e.from_symbol_id IS NOT NULL AND f.path NOT LIKE '%test%' AND \
-         e.to_symbol_id NOT IN (SELECT symbol_id FROM repo_memory_bindings WHERE symbol_id IS NOT \
-         NULL) AND f.path NOT IN (SELECT path FROM repo_memory_bindings WHERE path IS NOT NULL) \
-         GROUP BY e.to_symbol_id ORDER BY d DESC LIMIT ?1",
+         IS NOT NULL AND e.from_symbol_id IS NOT NULL AND f.has_test_code = 0 AND e.to_symbol_id \
+         NOT IN (SELECT symbol_id FROM repo_memory_bindings WHERE symbol_id IS NOT NULL) AND \
+         e.to_symbol_id NOT IN (SELECT lsm.symbol_id FROM logical_symbol_members lsm JOIN \
+         repo_memory_bindings b ON b.logical_symbol_id = lsm.logical_symbol_id WHERE \
+         b.logical_symbol_id IS NOT NULL) AND f.path NOT IN (SELECT path FROM \
+         repo_memory_bindings WHERE path IS NOT NULL) GROUP BY e.to_symbol_id ORDER BY d DESC \
+         LIMIT ?1",
     )?;
     let rows: Vec<(String, String, i64)> = stmt
         .query_map([limit as i64], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))?
@@ -108,7 +128,10 @@ fn stale_reference(conn: &Connection) -> rusqlite::Result<Vec<DreamFinding>> {
     let re = Regex::new(r"\b((?:crates|apps|tools|src)/[\w./-]+\.rs)\b").expect("static regex");
 
     let mut out = Vec::new();
-    let mut stmt = conn.prepare("SELECT id, body FROM repo_memories WHERE status = 'active'")?;
+    // 'stale'-status memories are still LIVE (just flagged) and are the ones most likely to hold a
+    // moved/deleted path — scan them too, matching the memory layer's status IN ('active','stale').
+    let mut stmt =
+        conn.prepare("SELECT id, body FROM repo_memories WHERE status IN ('active', 'stale')")?;
     let mems: Vec<(String, String)> =
         stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?.collect::<rusqlite::Result<_>>()?;
     for (id, body) in mems {
@@ -138,8 +161,21 @@ fn stale_reference(conn: &Connection) -> rusqlite::Result<Vec<DreamFinding>> {
 }
 
 /// Sync findings into `dream_findings` with the identity-keyed lifecycle (refresh / supersede /
-/// resolve). Returns (opened, refreshed, superseded, resolved).
+/// resolve), ATOMICALLY: all writes run in one transaction so a mid-run failure can't leave a torn
+/// worklist (the per-finding upserts + the resolve pass commit together or not at all). Returns
+/// (opened, refreshed, superseded, resolved).
 fn sync(
+    conn: &Connection,
+    findings: &[DreamFinding],
+    now_ms: i64,
+) -> rusqlite::Result<(usize, usize, usize, usize)> {
+    let tx = conn.unchecked_transaction()?;
+    let counts = sync_in_tx(&tx, findings, now_ms)?;
+    tx.commit()?;
+    Ok(counts)
+}
+
+fn sync_in_tx(
     conn: &Connection,
     findings: &[DreamFinding],
     now_ms: i64,
@@ -228,23 +264,27 @@ pub fn dream_run(conn: &Connection, opts: DreamOptions) -> rusqlite::Result<Drea
     findings.extend(stale_reference(conn)?);
     let (opened, refreshed, superseded, resolved) = sync(conn, &findings, opts.now_ms)?;
 
-    // emit the OPEN worklist from the store (post-sync), ranked
+    // emit the OPEN worklist from the store (post-sync); each finding's exposed rank is its
+    // base_rank DECAYED by age since first_seen (effective_rank) — a stale unreviewed finding
+    // sinks below fresh ones (the documented anti-rot, now real, not just base_rank DESC).
     let mut open: Vec<DreamFinding> = conn
         .prepare(
-            "SELECT kind, subject, evidence, base_rank FROM dream_findings WHERE status = 'open' \
-             ORDER BY base_rank DESC, subject",
+            "SELECT kind, subject, evidence, base_rank, first_seen_at_ms FROM dream_findings \
+             WHERE status = 'open'",
         )?
         .query_map([], |r| {
+            let base: f64 = r.get(3)?;
+            let first_seen: i64 = r.get(4)?;
             Ok(DreamFinding {
                 kind: r.get(0)?,
                 subject: r.get(1)?,
                 evidence: r.get(2)?,
-                rank: r.get(3)?,
+                rank: effective_rank(base, first_seen, opts.now_ms),
             })
         })?
         .collect::<rusqlite::Result<_>>()?;
-    // deterministic order: rank desc, then subject (ties — e.g. all stale_reference at 0.5 — are
-    // stable across runs/reindexes instead of arbitrary SQLite row order).
+    // deterministic order: effective rank desc, then subject (ties — e.g. fresh stale_reference at
+    // base 0.5 — are stable across runs/reindexes instead of arbitrary SQLite row order).
     open.sort_by(|a, b| {
         b.rank
             .partial_cmp(&a.rank)
@@ -380,6 +420,17 @@ mod tests {
         assert!(
             report.findings.iter().any(|f| f.kind == "stale_reference" && f.subject == "m1"),
             "non-vacuous: the seeded memory produced a stale_reference finding"
+        );
+    }
+
+    #[test]
+    fn rank_decays_with_age() {
+        let hl = RANK_HALF_LIFE_MS as i64;
+        assert!((effective_rank(1.0, 0, 0) - 1.0).abs() < 1e-9, "no decay at age 0");
+        assert!((effective_rank(1.0, 0, hl) - 0.5).abs() < 0.01, "one half-life halves the rank");
+        assert!(
+            effective_rank(1.0, 0, 2 * hl) < effective_rank(1.0, 0, hl),
+            "older unreviewed findings sink further"
         );
     }
 }

--- a/crates/rag-rat-core/src/dream.rs
+++ b/crates/rag-rat-core/src/dream.rs
@@ -19,8 +19,6 @@ use rusqlite::Connection;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
-const COVERAGE_GAP_SCAN: usize = 400; // in-degree candidates to consider before filtering/limiting
-
 #[derive(Debug, Clone, Serialize)]
 pub struct DreamFinding {
     pub kind: String,
@@ -69,54 +67,32 @@ fn hex16(bytes: &[u8]) -> String {
 }
 
 /// `coverage_gap`: top call-graph in-degree symbols with no memory binding (load-bearing code with
-/// no institutional memory). Importance proxy = raw in-degree; rank normalized to the top.
+/// no institutional memory). Importance = DISTINCT caller count (`edges_data` carries several rows
+/// per caller pair, so `COUNT(*)` would over-count). The covered-symbol/path and test-infra filters
+/// are applied IN SQL *before* the LIMIT, so the budget is spent on ELIGIBLE rows — a pre-filter
+/// LIMIT lets high-in-degree covered/test symbols starve real gaps below the window.
 fn coverage_gap(conn: &Connection, limit: usize) -> rusqlite::Result<Vec<DreamFinding>> {
-    let covered_syms: HashSet<i64> = conn
-        .prepare("SELECT DISTINCT symbol_id FROM repo_memory_bindings WHERE symbol_id IS NOT NULL")?
-        .query_map([], |r| r.get::<_, i64>(0))?
-        .collect::<rusqlite::Result<_>>()?;
-    let covered_paths: HashSet<String> = conn
-        .prepare("SELECT DISTINCT path FROM repo_memory_bindings WHERE path IS NOT NULL")?
-        .query_map([], |r| r.get::<_, String>(0))?
-        .collect::<rusqlite::Result<_>>()?;
-
     let mut stmt = conn.prepare(
-        "SELECT to_symbol_id, COUNT(*) AS d FROM edges_data WHERE to_symbol_id IS NOT NULL GROUP \
-         BY to_symbol_id ORDER BY d DESC LIMIT ?1",
+        "SELECT s.name, f.path, COUNT(DISTINCT e.from_symbol_id) AS d FROM edges_data e JOIN \
+         symbols s ON s.id = e.to_symbol_id JOIN files f ON f.id = s.file_id WHERE e.to_symbol_id \
+         IS NOT NULL AND e.from_symbol_id IS NOT NULL AND f.path NOT LIKE '%test%' AND \
+         e.to_symbol_id NOT IN (SELECT symbol_id FROM repo_memory_bindings WHERE symbol_id IS NOT \
+         NULL) AND f.path NOT IN (SELECT path FROM repo_memory_bindings WHERE path IS NOT NULL) \
+         GROUP BY e.to_symbol_id ORDER BY d DESC LIMIT ?1",
     )?;
-    let candidates: Vec<(i64, i64)> = stmt
-        .query_map([COVERAGE_GAP_SCAN as i64], |r| Ok((r.get(0)?, r.get(1)?)))?
+    let rows: Vec<(String, String, i64)> = stmt
+        .query_map([limit as i64], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))?
         .collect::<rusqlite::Result<_>>()?;
-    let top_d = candidates.first().map(|(_, d)| *d).unwrap_or(1).max(1) as f64;
-
-    let mut out = Vec::new();
-    for (sym_id, d) in candidates {
-        if out.len() >= limit {
-            break;
-        }
-        if covered_syms.contains(&sym_id) {
-            continue;
-        }
-        let row = conn
-            .query_row(
-                "SELECT s.name, f.path FROM symbols s JOIN files f ON f.id = s.file_id WHERE s.id \
-                 = ?1",
-                [sym_id],
-                |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)),
-            )
-            .ok();
-        let Some((name, path)) = row else { continue };
-        if covered_paths.contains(&path) || path.to_lowercase().contains("test") {
-            continue; // test infra is high-in-degree but not a real coverage gap (spike eval: 4/20)
-        }
-        out.push(DreamFinding {
+    let top_d = rows.first().map(|(_, _, d)| *d).unwrap_or(1).max(1) as f64;
+    Ok(rows
+        .into_iter()
+        .map(|(name, path, d)| DreamFinding {
             kind: "coverage_gap".into(),
             subject: format!("{path}::{name}"),
-            evidence: format!("{d} callers, no memory binding [E0 importance proxy]"),
+            evidence: format!("{d} distinct callers, no memory binding [E0 importance proxy]"),
             rank: d as f64 / top_d,
-        });
-    }
-    Ok(out)
+        })
+        .collect())
 }
 
 /// `stale_reference`: a memory body references a `.rs` path that no longer resolves against the
@@ -136,9 +112,15 @@ fn stale_reference(conn: &Connection) -> rusqlite::Result<Vec<DreamFinding>> {
     let mems: Vec<(String, String)> =
         stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?.collect::<rusqlite::Result<_>>()?;
     for (id, body) in mems {
+        let bytes = body.as_bytes();
         let mut gone: Vec<String> = re
             .captures_iter(&body)
-            .filter_map(|c| c.get(1).map(|m| m.as_str().to_string()))
+            .filter_map(|c| c.get(1))
+            // skip refs embedded in a URL or a longer path (preceded by '/' or ':') — a common
+            // false-positive source; a genuine reference is preceded by whitespace/punctuation.
+            // (Rust's regex has no lookbehind, so this is a post-filter on the match start.)
+            .filter(|m| m.start() == 0 || !matches!(bytes[m.start() - 1], b'/' | b':'))
+            .map(|m| m.as_str().to_string())
             .filter(|p| !resolves(p))
             .collect();
         gone.sort();
@@ -167,37 +149,60 @@ fn sync(
     for f in findings {
         let ch = claim_hash(&f.kind, &f.subject, &f.evidence);
         seen.insert((f.kind.clone(), f.subject.clone()));
-        let existing: Option<String> = conn
+        // Look up by the EXACT claim (incl. its current status) — NOT status-blind, or an evidence
+        // flip-back (A→B→A) or a resolved-then-reappears would match a terminal row and silently
+        // refresh it, stranding the actually-current finding.
+        let existing: Option<(String, String)> = conn
             .query_row(
-                "SELECT id FROM dream_findings WHERE kind = ?1 AND subject = ?2 AND claim_hash = \
-                 ?3",
+                "SELECT id, status FROM dream_findings WHERE kind = ?1 AND subject = ?2 AND \
+                 claim_hash = ?3",
                 rusqlite::params![f.kind, f.subject, ch],
-                |r| r.get(0),
+                |r| Ok((r.get(0)?, r.get(1)?)),
             )
             .ok();
-        if existing.is_some() {
+        // supersede any OTHER current row for this (kind, subject) — used by both the revive and
+        // the brand-new branches (the world changed, so a prior verdict no longer applies).
+        let supersede_others = |id: &str| {
             conn.execute(
-                "UPDATE dream_findings SET last_seen_at_ms = ?1, base_rank = ?2 WHERE kind = ?3 \
-                 AND subject = ?4 AND claim_hash = ?5",
-                rusqlite::params![now_ms, f.rank, f.kind, f.subject, ch],
-            )?;
-            refreshed += 1;
-            continue;
+                "UPDATE dream_findings SET status = 'superseded', superseded_by = ?1 WHERE kind = \
+                 ?2 AND subject = ?3 AND id != ?1 AND status IN ('open','accepted','dismissed')",
+                rusqlite::params![id, f.kind, f.subject],
+            )
+        };
+        match existing {
+            // same claim still current: refresh, preserving any human verdict (accepted/dismissed)
+            Some((id, status)) if matches!(status.as_str(), "open" | "accepted" | "dismissed") => {
+                conn.execute(
+                    "UPDATE dream_findings SET last_seen_at_ms = ?1, base_rank = ?2 WHERE id = ?3",
+                    rusqlite::params![now_ms, f.rank, id],
+                )?;
+                refreshed += 1;
+            },
+            // same claim was terminal (resolved/superseded/archived) but REAPPEARED: revive to open
+            // (UNIQUE(kind,subject,claim_hash) forbids a fresh insert) + supersede other current
+            // rows.
+            Some((id, _terminal)) => {
+                conn.execute(
+                    "UPDATE dream_findings SET status = 'open', superseded_by = NULL, \
+                     last_seen_at_ms = ?1, base_rank = ?2 WHERE id = ?3",
+                    rusqlite::params![now_ms, f.rank, id],
+                )?;
+                opened += 1;
+                superseded += supersede_others(&id)?;
+            },
+            // brand-new claim for this (kind, subject): open fresh + supersede prior current rows
+            None => {
+                let id = finding_id(&f.kind, &f.subject, &ch);
+                conn.execute(
+                    "INSERT INTO dream_findings(id, kind, subject, claim_hash, evidence, \
+                     base_rank, status, first_seen_at_ms, last_seen_at_ms) \
+                     VALUES(?1,?2,?3,?4,?5,?6,'open',?7,?7)",
+                    rusqlite::params![id, f.kind, f.subject, ch, f.evidence, f.rank, now_ms],
+                )?;
+                opened += 1;
+                superseded += supersede_others(&id)?;
+            },
         }
-        // new claim for this (kind, subject): supersede any current (open/verdict) finding, open
-        // fresh
-        let id = finding_id(&f.kind, &f.subject, &ch);
-        conn.execute(
-            "INSERT INTO dream_findings(id, kind, subject, claim_hash, evidence, base_rank, \
-             status, first_seen_at_ms, last_seen_at_ms) VALUES(?1,?2,?3,?4,?5,?6,'open',?7,?7)",
-            rusqlite::params![id, f.kind, f.subject, ch, f.evidence, f.rank, now_ms],
-        )?;
-        opened += 1;
-        superseded += conn.execute(
-            "UPDATE dream_findings SET status = 'superseded', superseded_by = ?1 WHERE kind = ?2 \
-             AND subject = ?3 AND id != ?1 AND status NOT IN ('resolved','superseded','archived')",
-            rusqlite::params![id, f.kind, f.subject],
-        )?;
     }
     // resolve: any current finding whose (kind, subject) was not reported this run -> drift gone
     let current: Vec<(String, String, String)> = conn
@@ -226,7 +231,8 @@ pub fn dream_run(conn: &Connection, opts: DreamOptions) -> rusqlite::Result<Drea
     // emit the OPEN worklist from the store (post-sync), ranked
     let mut open: Vec<DreamFinding> = conn
         .prepare(
-            "SELECT kind, subject, evidence, base_rank FROM dream_findings WHERE status = 'open'",
+            "SELECT kind, subject, evidence, base_rank FROM dream_findings WHERE status = 'open' \
+             ORDER BY base_rank DESC, subject",
         )?
         .query_map([], |r| {
             Ok(DreamFinding {
@@ -237,7 +243,14 @@ pub fn dream_run(conn: &Connection, opts: DreamOptions) -> rusqlite::Result<Drea
             })
         })?
         .collect::<rusqlite::Result<_>>()?;
-    open.sort_by(|a, b| b.rank.partial_cmp(&a.rank).unwrap_or(std::cmp::Ordering::Equal));
+    // deterministic order: rank desc, then subject (ties — e.g. all stale_reference at 0.5 — are
+    // stable across runs/reindexes instead of arbitrary SQLite row order).
+    open.sort_by(|a, b| {
+        b.rank
+            .partial_cmp(&a.rank)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.subject.cmp(&b.subject))
+    });
     Ok(DreamReport { findings: open, opened, refreshed, superseded, resolved })
 }
 
@@ -283,15 +296,90 @@ mod tests {
     }
 
     #[test]
-    fn dream_run_writes_findings_never_touches_memories() {
+    fn flip_back_and_resolved_reappears_keep_the_worklist_correct() {
         let c = mem_db();
-        let before: i64 =
-            c.query_row("SELECT COUNT(*) FROM repo_memories", [], |r| r.get(0)).unwrap();
+        let cg = |ev: &str, rank: f64| {
+            vec![DreamFinding {
+                kind: "coverage_gap".into(),
+                subject: "x::F".into(),
+                evidence: ev.into(),
+                rank,
+            }]
+        };
+        let open_evidence = |c: &Connection| -> (String, f64) {
+            c.query_row(
+                "SELECT evidence, base_rank FROM dream_findings WHERE status='open'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap()
+        };
+        let count = |c: &Connection, status: &str| -> i64 {
+            c.query_row("SELECT COUNT(*) FROM dream_findings WHERE status=?1", [status], |r| {
+                r.get(0)
+            })
+            .unwrap()
+        };
+        // A -> B -> A: the flip-back must leave A current with A's evidence, NOT strand B as open.
+        sync(&c, &cg("10 callers", 0.1), 1000).unwrap();
+        sync(&c, &cg("40 callers", 0.9), 2000).unwrap();
+        sync(&c, &cg("10 callers", 0.1), 3000).unwrap();
+        assert_eq!(count(&c, "open"), 1, "exactly one open row after flip-back");
+        assert_eq!(
+            open_evidence(&c),
+            ("10 callers".into(), 0.1),
+            "current (A) is open, not stale B"
+        );
+        // resolve, then reappear with the SAME evidence: must revive to open, not stay resolved.
+        sync(&c, &[], 4000).unwrap();
+        assert!(count(&c, "resolved") >= 1, "absent finding resolves");
+        sync(&c, &cg("10 callers", 0.1), 5000).unwrap();
+        assert_eq!(count(&c, "open"), 1, "reappearing resolved finding is revived to open");
+    }
+
+    #[test]
+    fn dream_run_never_mutates_any_memory_column() {
+        let c = mem_db();
+        // seed a memory whose body references a gone path so stale_reference is forced to READ it
+        // and emit a finding keyed on this memory (makes the assertion non-vacuous).
+        c.execute(
+            "INSERT INTO repo_memories(id, kind, title, body, confidence, status, created_by, \
+             created_at_ms, updated_at_ms, source, memory_version) VALUES \
+             ('m1','Invariant','t','refs \
+             crates/ghost/src/vanished.rs','high','active','agent',1,1,'agent','v1')",
+            [],
+        )
+        .unwrap();
+        // snapshot every column dream could plausibly mutate (stronger than a row COUNT: an
+        // in-place UPDATE to body/status/etc. would pass a count check but fail this).
+        let snap = |c: &Connection| {
+            c.query_row(
+                "SELECT body, status, confidence, kind, title, created_by, created_at_ms, \
+                 updated_at_ms, source, memory_version FROM repo_memories WHERE id='m1'",
+                [],
+                |r| {
+                    Ok((
+                        r.get::<_, String>(0)?,
+                        r.get::<_, String>(1)?,
+                        r.get::<_, String>(2)?,
+                        r.get::<_, String>(3)?,
+                        r.get::<_, String>(4)?,
+                        r.get::<_, String>(5)?,
+                        r.get::<_, i64>(6)?,
+                        r.get::<_, i64>(7)?,
+                        r.get::<_, String>(8)?,
+                        r.get::<_, String>(9)?,
+                    ))
+                },
+            )
+            .unwrap()
+        };
+        let before = snap(&c);
         let report = dream_run(&c, DreamOptions { now_ms: 1000, limit: 10 }).unwrap();
-        let after: i64 =
-            c.query_row("SELECT COUNT(*) FROM repo_memories", [], |r| r.get(0)).unwrap();
-        assert_eq!(before, after, "dream_run must never mutate repo_memories");
-        // empty index -> no findings, but the call succeeds and the table is usable
-        assert!(report.findings.is_empty());
+        assert_eq!(before, snap(&c), "dream_run must leave EVERY repo_memories column unchanged");
+        assert!(
+            report.findings.iter().any(|f| f.kind == "stale_reference" && f.subject == "m1"),
+            "non-vacuous: the seeded memory produced a stale_reference finding"
+        );
     }
 }

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -874,7 +874,7 @@ fn migration_creates_oracle_side_tables() {
     }
     assert!(!columns.contains(&"edge_id".to_string()), "edge_id column was dropped");
 
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 32);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 33);
 }
 
 /// The V019 moniker migration: the `logical_symbol_monikers` table (STRICT, NO foreign key — see

--- a/crates/rag-rat-core/src/index/query_api/dream.rs
+++ b/crates/rag-rat-core/src/index/query_api/dream.rs
@@ -1,0 +1,13 @@
+//! Dream Mode worklist on `IndexDatabase` (#122): a thin pass-through to `crate::dream`. Computes
+//! the deterministic memory-maintenance worklist (coverage gaps + stale references), syncs it into
+//! `dream_findings`, and returns the open worklist. Writes ONLY to `dream_findings` — never mutates
+//! a `repo_memories` row.
+
+use super::*;
+use crate::dream::{DreamOptions, DreamReport};
+
+impl IndexDatabase {
+    pub fn dream_run(&self, opts: DreamOptions) -> anyhow::Result<DreamReport> {
+        Ok(crate::dream::dream_run(self.storage.connection(), opts)?)
+    }
+}

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -8,6 +8,7 @@ use crate::search::lexical::SearchOptions;
 
 mod ai_lifecycle;
 mod clones;
+mod dream;
 mod gc;
 mod graph;
 mod history;

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1167,6 +1167,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_030_ID => Some(30),
             MIGRATION_031_ID => Some(31),
             MIGRATION_032_ID => Some(32),
+            MIGRATION_033_ID => Some(33),
             _ => None,
         })
         .max()
@@ -1208,6 +1209,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_030_ID
             | MIGRATION_031_ID
             | MIGRATION_032_ID
+            | MIGRATION_033_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1246,6 +1248,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_030_ID => migration.checksum != MIGRATION_030_CHECKSUM,
         MIGRATION_031_ID => migration.checksum != MIGRATION_031_CHECKSUM,
         MIGRATION_032_ID => migration.checksum != MIGRATION_032_CHECKSUM,
+        MIGRATION_033_ID => migration.checksum != MIGRATION_033_CHECKSUM,
         _ => false,
     }
 }
@@ -1529,6 +1532,39 @@ pub(crate) fn apply_token_bag_blob(conn: &Connection) -> rusqlite::Result<()> {
     add_column_if_missing(conn, "symbol_fingerprints", "token_bag", "BLOB")?;
     // The per-token inverted-index table is replaced by the BLOB; its indexes drop with it.
     conn.execute_batch("DROP TABLE IF EXISTS symbol_token_postings;")?;
+    Ok(())
+}
+
+/// V033 (#122): the dream-mode worklist. Findings are ABOUT memories (a reviewable triage list),
+/// NEVER mutations of them — dream mode proposes, a human/strong-agent confirms; nothing here ever
+/// rewrites a `repo_memories` row. Identity is `(kind, subject, claim_hash)`: a re-run with the
+/// same claim_hash REFRESHES (no duplicate), a materially-changed finding SUPERSEDES the prior one,
+/// and a finding the run no longer reports is RESOLVED. `subject` is polymorphic (a
+/// `repo_memories.id` for memory-scoped kinds, a symbol/path ref for `coverage_gap`) so it carries
+/// NO FK. `status` drives the lifecycle; `base_rank` + the `first_seen_at_ms` clock drive age
+/// decay. Additive + idempotent.
+pub(crate) fn apply_dream_findings(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS dream_findings(
+            id TEXT PRIMARY KEY,
+            kind TEXT NOT NULL,
+            subject TEXT NOT NULL,
+            claim_hash TEXT NOT NULL,
+            evidence TEXT NOT NULL,
+            base_rank REAL NOT NULL,
+            status TEXT NOT NULL DEFAULT 'open',
+            superseded_by TEXT,
+            first_seen_at_ms INTEGER NOT NULL,
+            last_seen_at_ms INTEGER NOT NULL,
+            reviewed_at_ms INTEGER,
+            UNIQUE(kind, subject, claim_hash)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_dream_findings_status ON dream_findings(status);
+        CREATE INDEX IF NOT EXISTS idx_dream_findings_subject ON dream_findings(kind, subject);
+        ",
+    )?;
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1559,7 +1559,7 @@ pub(crate) fn apply_dream_findings(conn: &Connection) -> rusqlite::Result<()> {
             last_seen_at_ms INTEGER NOT NULL,
             reviewed_at_ms INTEGER,
             UNIQUE(kind, subject, claim_hash)
-        );
+        ) STRICT;
 
         CREATE INDEX IF NOT EXISTS idx_dream_findings_status ON dream_findings(status);
         CREATE INDEX IF NOT EXISTS idx_dream_findings_subject ON dream_findings(kind, subject);

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use migrations::*;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 32;
+pub const LATEST_SCHEMA_VERSION: u32 = 33;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -208,6 +208,11 @@ const MIGRATION_032_CHECKSUM: &str = "sha256:rag-rat-clone-token-bag-blob-v32";
 const MIGRATION_032_DESCRIPTION: &str = "Add symbol_fingerprints.token_bag BLOB + drop \
                                          symbol_token_postings (BLOB-pack the clone token bag) \
                                          (#231)";
+const MIGRATION_033_ID: &str = "033_dream_findings";
+const MIGRATION_033_CHECKSUM: &str = "sha256:rag-rat-dream-findings-v33";
+const MIGRATION_033_DESCRIPTION: &str = "Add dream_findings (dream-mode worklist: findings ABOUT \
+                                         memories, identity-keyed supersede/decay, never mutate \
+                                         memories) (#122)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -499,6 +504,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_032_CHECKSUM,
         description: MIGRATION_032_DESCRIPTION,
         apply: apply_token_bag_blob,
+    },
+    Migration {
+        id: MIGRATION_033_ID,
+        checksum: MIGRATION_033_CHECKSUM,
+        description: MIGRATION_033_DESCRIPTION,
+        apply: apply_dream_findings,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -10497,12 +10497,16 @@ fn open_under_a_held_write_lock_migrates_older_schema_without_deadlock() {
         let db = IndexDatabase::rebuild(&config).unwrap();
         db.storage
             .connection()
-            .execute("DELETE FROM schema_version WHERE id = '032_clone_token_bag_blob'", [])
+            .execute(
+                "DELETE FROM schema_version WHERE id = (SELECT id FROM schema_version ORDER BY id \
+                 DESC LIMIT 1)",
+                [],
+            )
             .unwrap();
         assert_eq!(
             schema::status(db.storage.connection()).unwrap().state,
             schema::SchemaState::Older,
-            "removing the newest (V032) ledger row makes the schema Older"
+            "removing the newest ledger row makes the schema Older"
         );
     }
 
@@ -10527,7 +10531,7 @@ fn v022_fresh_apply_creates_packages_and_dedicated_import_scope_columns() {
     schema::apply(&conn).unwrap();
 
     assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 32);
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 33);
     assert!(conn_table_exists(&conn, "packages"), "packages table is created on a fresh apply");
 
     let package_cols = conn_table_columns(&conn, "packages");
@@ -10605,6 +10609,7 @@ fn v022_forward_migrate_adds_artifacts_to_an_older_index() {
         DELETE FROM schema_version WHERE id = '030_clone_refinements_lcs_sampled';
         DELETE FROM schema_version WHERE id = '031_edge_oracle_content_anchor';
         DELETE FROM schema_version WHERE id = '032_clone_token_bag_blob';
+        DELETE FROM schema_version WHERE id = '033_dream_findings';
         ",
     )
     .unwrap();
@@ -10751,7 +10756,8 @@ fn v028_forward_migrate_interns_and_drops_the_inline_column() {
          DELETE FROM schema_version WHERE id = '029_clone_fingerprint_tables';
          DELETE FROM schema_version WHERE id = '030_clone_refinements_lcs_sampled';
          DELETE FROM schema_version WHERE id = '031_edge_oracle_content_anchor';
-         DELETE FROM schema_version WHERE id = '032_clone_token_bag_blob';",
+         DELETE FROM schema_version WHERE id = '032_clone_token_bag_blob';
+         DELETE FROM schema_version WHERE id = '033_dream_findings';",
     )
     .unwrap();
     assert_eq!(
@@ -12303,7 +12309,8 @@ fn migration_032_adds_token_bag_drops_postings() {
              freq            INTEGER NOT NULL,
              PRIMARY KEY (symbol_id, normalizer_kind, token_hash)
          ) STRICT;
-         DELETE FROM schema_version WHERE id = '032_clone_token_bag_blob';",
+         DELETE FROM schema_version WHERE id = '032_clone_token_bag_blob';
+         DELETE FROM schema_version WHERE id = '033_dream_findings';",
     )
     .expect("revert to V031 shape");
     assert!(
@@ -12377,7 +12384,7 @@ fn v030_forward_migrate_adds_lcs_sampled_to_existing_v029_index() {
     conn.execute_batch(
         "DELETE FROM schema_version
          WHERE id IN ('030_clone_refinements_lcs_sampled', '031_edge_oracle_content_anchor',
-                      '032_clone_token_bag_blob');",
+                      '032_clone_token_bag_blob', '033_dream_findings');",
     )
     .expect("delete V030+ ledger rows");
     assert_eq!(
@@ -12410,8 +12417,8 @@ fn v030_forward_migrate_adds_lcs_sampled_to_existing_v029_index() {
     );
     assert_eq!(
         crate::index::schema::LATEST_SCHEMA_VERSION,
-        32,
-        "LATEST_SCHEMA_VERSION is 32 after V032"
+        33,
+        "LATEST_SCHEMA_VERSION is 33 after V033"
     );
     // Idempotency: running migrate_forward again must not error.
     crate::index::schema::migrate_forward(&conn).expect("migrate_forward is idempotent");
@@ -12456,11 +12463,12 @@ fn migration_031_edge_oracle_no_fk_content_key() {
         ",
     )
     .expect("recreate legacy V018 edge_oracle");
-    // Drop the V031 AND V032 ledger rows: `known_version` reads the MAX applied version, so
-    // leaving V032 recorded would keep the schema Compatible and skip the forward migrate.
+    // Drop the V031 AND every newer ledger row: `known_version` reads the MAX applied version, so
+    // leaving any later row recorded would keep the schema Compatible and skip the forward migrate.
     conn.execute_batch(
         "DELETE FROM schema_version WHERE id = '031_edge_oracle_content_anchor';
-         DELETE FROM schema_version WHERE id = '032_clone_token_bag_blob';",
+         DELETE FROM schema_version WHERE id = '032_clone_token_bag_blob';
+         DELETE FROM schema_version WHERE id = '033_dream_findings';",
     )
     .expect("drop V031+ ledger rows");
     assert_eq!(

--- a/crates/rag-rat-core/src/lib.rs
+++ b/crates/rag-rat-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod dream;
 #[cfg(feature = "eval")]
 pub mod eval;
 pub mod fleet;


### PR DESCRIPTION
First shippable slice of dream mode (#122): a **zero-LLM, deterministic** `rag-rat dream` command that surfaces a reviewable worklist of findings **about** memories — and never mutates one.

## What it adds
- **Migration V033 `dream_findings`** — the worklist table. Findings are identity-keyed `(kind, subject, claim_hash)` with a refresh / supersede / resolve lifecycle. Polymorphic `subject` (memory id or symbol/path), so no FK.
- **`rag-rat dream`** command (TOON/JSON, via `output::render`) with two finding kinds:
  - `coverage_gap` — load-bearing symbols (call-graph in-degree, distinct callers) with no memory binding; test-infra filtered.
  - `stale_reference` — memory bodies referencing a `.rs` path that no longer resolves against the index (suffix-aware, so prose shorthand still resolves).

## Safety
`dream_run` writes **only** to `dream_findings` — it never mutates a `repo_memories` row (dream mode proposes; a human/strong-agent confirms). The command takes the `WriteLock` like every other write command. A column-snapshot test guards the no-mutation invariant.

## Why deterministic / what's deferred
The spike (write-up in #122) found that **change-based** staleness signals (churn, struct-drift) are *unmeasurable* on this young repo — base rates saturate. So v1 ships the **rate-independent** signals (`coverage_gap` + reference-resolution) and explicitly defers the semantic-contradiction layer and the staleness-efficacy validation (which needs an accumulated review ledger over time). Details + the four commit-replay evals are in the #122 write-up.

## Quality
Hardened by three internal adversarial reviews, which caught and fixed: a status-blind lifecycle bug (flip-back / resolved-reappears), `coverage_gap` scan-budget starvation + caller over-count + an N+1, the missing `WriteLock`, a `stale_reference` false-positive source, and non-deterministic tie ordering. Full `rag-rat-core` suite green (865/865), clippy clean, fmt clean. Rebased on current `main`.

Refs #122. Does not close it — the deferred semantic layer + staleness-efficacy validation remain.
