### PR TITLE
fix(clones): #256 follow-ups — de-flake dense-clique test + seed split by similarity (R-A)

### DIFF
--- a/crates/rag-rat-core/src/index/clones/refine/split.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/split.rs
@@ -114,6 +114,24 @@ pub(crate) fn coherence_split(
     coherent_edges.sort_unstable();
     coherent_edges.dedup();
 
+    // 2b. Seed high-similarity edges FIRST so tight real cliques grow WITHIN the MAX_SPLIT_GROUPS
+    // budget instead of falling into the bare-pair tail (#256 R-A). On the dogfood a true 7-member
+    // `collect_rows` clique (all pairs sim ≥ 0.959) was fragmented to 2-member pairs because its
+    // edges sorted late (by id) inside a 2,599-member sparse transitive component glued by generic
+    // low-`df` tokens — the budget tripped on 256 noise cliques before collect_rows was reached.
+    // Ordering by descending similarity grows the tight cliques first; the low-similarity
+    // transitive "glue" edges sort last and become the bare pairs after the trip — correct,
+    // since they are the over-merge noise, not real clones. Similarity is computed ONCE per
+    // edge here (O(edges)), NOT in the comparator. The descending-sim + `(a, b)` tie-break
+    // keeps the seed order deterministic.
+    let mut seeds: Vec<(f64, i64, i64)> =
+        coherent_edges.iter().map(|&(a, b)| (similarity(a, b), a, b)).collect();
+    seeds.sort_by(|x, y| {
+        y.0.partial_cmp(&x.0)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| (x.1, x.2).cmp(&(y.1, y.2)))
+    });
+
     // 3. Greedy maximal clique cover: for each coherent edge not already fully inside some emitted
     // group, grow a maximal coherent group from {a, b} by adding any remaining member (in id order)
     // that is coherent with every current group member. Emit the group.
@@ -145,7 +163,7 @@ pub(crate) fn coherence_split(
         std::collections::HashMap::new();
     let mut budget_tripped = false;
 
-    for &(a, b) in &coherent_edges {
+    for &(_sim, a, b) in &seeds {
         if budget_tripped {
             // Over budget: emit the edge directly as a 2-member clique (still internally coherent —
             // it is a θ-edge). No grow, no containment bookkeeping. The later dedup/subset pass is
@@ -409,6 +427,63 @@ mod tests {
             elapsed.as_secs() < 30,
             "dense clique of {count} must split in ~O(edges), not O(n³); took {elapsed:?}"
         );
+    }
+
+    /// #256 R-A regression: a true high-similarity clique buried in a giant transitive component
+    /// (whose generic low-`df` "glue" trips `MAX_SPLIT_GROUPS`) must still be GROWN, not fragmented
+    /// to bare pairs. Pre-fix the clique's edges sorted late (by id) into the post-budget bare-pair
+    /// tail — on the dogfood the real 7-copy `collect_rows` clique came back as 2-member pairs.
+    /// Seeding by descending similarity grows the tight clique first.
+    #[test]
+    fn coherence_split_grows_tight_clique_before_budget_trips() {
+        let theta = 0.70;
+        // A 7-member tight clique (high ids, sim 1.0) connected to a 300-leaf star hub (sim 0.70);
+        // the star's 301 disjoint 2-cliques trip MAX_SPLIT_GROUPS (256) before any id-ordered pass
+        // would reach the high-id clique edges.
+        let clique: Vec<i64> = (1000..=1006).collect();
+        let clique_set: std::collections::HashSet<i64> = clique.iter().copied().collect();
+        let mut members: Vec<i64> = vec![0];
+        members.extend(1..=300);
+        members.extend(clique.iter().copied());
+
+        let sim = |a: i64, b: i64| -> f64 {
+            if clique_set.contains(&a) && clique_set.contains(&b) {
+                1.0 // tight clique: every pair maximally coherent
+            } else if (a == 0 && ((1..=300).contains(&b) || b == 1000))
+                || (b == 0 && ((1..=300).contains(&a) || a == 1000))
+            {
+                0.70 // hub↔leaf (and the hub↔clique connector that joins the component)
+            } else {
+                0.0 // leaves don't cohere with each other or the clique → small cliques
+            }
+        };
+
+        let mut edges: Vec<(i64, i64)> = Vec::new();
+        for i in 1..=300 {
+            edges.push((0, i)); // star: 300 disjoint 2-cliques
+        }
+        edges.push((0, 1000)); // connector: clique shares the star's component
+        for i in 0..clique.len() {
+            for j in (i + 1)..clique.len() {
+                edges.push((clique[i], clique[j])); // 21 tight-clique pairs, high ids
+            }
+        }
+
+        let split = coherence_split(&members, &edges, sim, theta);
+
+        // The tight 7-clique is GROWN as ONE group (descending-sim seed), not 21 bare pairs.
+        assert!(
+            split.iter().any(|g| {
+                let s: std::collections::HashSet<i64> = g.iter().copied().collect();
+                s == clique_set
+            }),
+            "the tight high-similarity clique must be grown as ONE group, not fragmented: \
+             {split:?}"
+        );
+        // Zero member loss across the whole (budget-tripping) component.
+        let union: std::collections::BTreeSet<i64> = split.iter().flatten().copied().collect();
+        let expected: std::collections::BTreeSet<i64> = members.iter().copied().collect();
+        assert_eq!(union, expected, "no member may be dropped");
     }
 
     /// #256 pin (a): a 250-member LOOSE clique — every pair coherent at exactly 0.80 (> θ), well

--- a/crates/rag-rat-core/src/index/clones/refine/split.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/split.rs
@@ -376,7 +376,7 @@ mod tests {
     #[test]
     fn coherence_split_dense_clique_scales() {
         let theta = 0.70;
-        let count: i64 = 1000; // ~5.9s pre-fix (O(n³)); ~0.45s standalone post-fix (O(edges)).
+        let count: i64 = 1500; // O(n³) regression ~40-60s+ under load; O(edges) cover ~10s.
         let members: Vec<i64> = (0..count).collect();
         // Every pair is coherent at 0.90 — a genuinely dense full clique above θ.
         let sim = |_a: i64, _b: i64| 0.90_f64;
@@ -399,13 +399,15 @@ mod tests {
         let union: std::collections::BTreeSet<i64> = split.iter().flatten().copied().collect();
         let expected: std::collections::BTreeSet<i64> = members.iter().copied().collect();
         assert_eq!(union, expected, "the union of class members must equal the input members");
-        // Hang-detector, not a microbenchmark: the O(n³) scan took ~5.9s standalone in debug at
-        // n=1000 (tens of seconds under full-suite contention); the O(edges) cover is ~0.45s
-        // standalone, ~2-3s under full-suite CPU saturation. The 4s ceiling sits between them so an
-        // O(n³) reintroduction reddens here while scheduler noise does not.
+        // COARSE hang-detector, NOT a microbenchmark — the durable guard is the correctness
+        // assertion above. A wall-clock ceiling under nextest's per-core parallelism is inherently
+        // noisy: the old 4s ceiling at n=1000 flaked at ~4.25s under full-suite CPU saturation. So
+        // this uses generous headroom — at n=1500 the O(edges) cover is ~10s under load while an
+        // O(n³) reintroduction is ~40-60s+; the 30s ceiling sits ~3x clear of the pass case (no
+        // scheduler-noise flake) yet still reddens on a cubic regression.
         assert!(
-            elapsed.as_secs() < 4,
-            "dense clique of {count} must split fast (O(edges)), took {elapsed:?}"
+            elapsed.as_secs() < 30,
+            "dense clique of {count} must split in ~O(edges), not O(n³); took {elapsed:?}"
         );
     }
 


### PR DESCRIPTION
Two #256 follow-ups surfaced by exercising clone detection on the live dogfood index.

## (a) De-flake `coherence_split_dense_clique_scales`
The dense-clique scalability pin used a 4s wall-clock ceiling that flakes under nextest's per-core parallelism (observed at ~4.25s under full-suite CPU saturation → red CI on main + every branch). Replaced with n=1500 + a **30s coarse hang-ceiling** (~3x clear of the ~10s under-load pass, still reddens on the ~40-60s O(n³) regression). The durable guard is the correctness assertion (one class, all members); the wall-clock is now explicitly a coarse hang-detector with parallelism headroom, not a microbenchmark.

## (b) R-A: seed `coherence_split` by descending similarity
A live investigation found a **true 7-member `collect_rows` clique** (all 21 pairs sim ≥0.959) was being fragmented into 2-member pairs by `clones-for`. Root cause: the 7 sit inside a **2,599-member / 38,287-edge sparse transitive component** (glued by generic low-`df` tokens like `new`/`as_str`/`default`). `coherence_split` seeded edges in `(a,b)`-id order, grew 256 noise cliques, tripped `MAX_SPLIT_GROUPS`, then emitted every remaining edge — including the late-sorting (high-id) collect_rows edges — as bare 2-member pairs. The clique was never grown.

**Fix:** seed the clique-cover by **descending similarity** (computed once, O(edges); no comparator recompute; descending-sim + `(a,b)` tie-break stays deterministic). Tight real cliques (collect_rows at 0.959-1.0) now grow *within* the 256-budget; the low-similarity transitive "glue" edges sort last and become the bare-pair tail — which is correct, they're the over-merge noise, not clones. No runtime risk (still ≤256 grown cliques; the budget cap that prevents the O(grown²·n) hang is unchanged). A regression test (`coherence_split_grows_tight_clique_before_budget_trips`) reproduces the exact scenario — a tight clique buried in a budget-tripping star — and asserts it grows as one group with zero member loss.

## R-B (coverage ranking) — investigated, NOT a real issue
The earlier "coverage-1.0 class ranks #20" was a measurement error on my part (misreading a *sorted coverage distribution*, where 1.0 is last in the sorted values ≠ rank #20). On the live index the coverage-1.0 class ranks **#1** (roi 31,011) and the `coverage_roi_gate` correctly sinks the cov≈0 classes (×0.10). No fix needed.

## Verification
1008 tests green across `rag-rat-core` + `rag-rat` + `rag-rat-mcp`; clippy `-D warnings` + nightly fmt clean. The new R-A regression test + all existing `coherence_split` pins (dense-scale, loose-clique, chain, determinism, pathological-dense) pass — the seed-ordering change preserves determinism and doesn't regress any pin.

## Still open (deeper, follow-ups)
- The 2,599-member transitive **giant component still forms** — the seed-ordering rescues the tight cliques inside it, but a `df`-ceiling on generic glue tokens at candidate-generation would attack the over-merge at the source (needs a recall check). 
- #258 (O(n²) grow via edge-adjacency), #259 (refine-failed classes bypass the coverage gate) remain.

Refs #256.
