### PR TITLE
fix(clones): close two #235 follow-ups — load_source_discriminators test + scoped-path callee reopen

### DIFF
--- a/crates/rag-rat-core/src/index/clones/refine/antiunify.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/antiunify.rs
@@ -2279,6 +2279,24 @@ fn run_in_callee_position(anchor: &RefineMember, lo: usize, hi: usize) -> bool {
     if run.kind == "field_identifier" {
         return true;
     }
+    // Scoped-path callee head: for `m::foo()` the call's callee child is the `scoped_identifier`
+    // `m::foo` (an internal node beginning at the call), so the FINAL segment `foo` (a plain
+    // `identifier` ending where that `scoped_identifier` ends) is the actual callee name yet does
+    // NOT itself share the call's start byte — only the FIRST segment `m` does. Without this a
+    // differing MODULE (`m::foo` vs `n::foo`) reopened the matched column but a differing FUNCTION
+    // NAME (`m::foo` vs `m::bar`) did not — the #235 asymmetry. Gated by the SAME no-method-head
+    // check as a free callee, so a scoped RECEIVER (`m::obj.foo()`, whose head is the `.foo`
+    // `field_identifier`) is excluded — its final segment is the receiver, not the callee.
+    if run.kind == "identifier"
+        && !call_has_method_name_head(anchor, call, run_end)
+        && anchor.node_spans.iter().any(|sp| {
+            sp.kind == "scoped_identifier"
+                && sp.start_byte == call.start_byte
+                && sp.end_byte == run_end
+        })
+    {
+        return true;
+    }
     // Otherwise the run is a head candidate only if it begins at the call and the call has NO
     // separate method-name head (a free fn / macro). If the call DOES have a method-name head, a
     // start-byte run is the receiver, not the callee.
@@ -3563,6 +3581,52 @@ mod tests {
         assert!(
             template.text.contains(&format!("⟨{}⟩", callee_vp.metavar_id)),
             "the differing callee must render a hole, not a hard-coded `foo`, got {:?}",
+            template.text
+        );
+    }
+
+    #[test]
+    fn differing_scoped_path_callee_tail_at_matched_column_is_closure_param() {
+        // #235 item 18: `m::foo()` vs `m::bar()` differ only in the FINAL path segment. Both
+        // alpha-rename to the same normalized seq (`m`→ID0, `foo`/`bar`→ID1), so LCS matches the
+        // callee column. The call's callee child is the `scoped_identifier` `m::foo`, whose final
+        // segment `foo` is a plain `identifier` that does NOT share the call's start byte — only
+        // the module `m` does. Before the fix this asymmetry meant a differing module
+        // reopened but a differing function name did not (coverage 1.0, callee hard-coded);
+        // `run_in_callee_position` now recognizes the scoped-path tail, so it reopens like a free
+        // callee.
+        let a = member(1, "fn a(){ m::foo(); }");
+        let b = member(2, "fn b(){ m::bar(); }");
+        let (members, template) = run(vec![a, b]);
+
+        assert_eq!(
+            template.variation_points.len(),
+            1,
+            "the differing scoped-path callee tail is one variation point, got {:?}",
+            template.variation_points
+        );
+        let vp = &template.variation_points[0];
+        assert_eq!(
+            vp.kind,
+            MetavarKind::ClosureParam,
+            "a differing scoped-path callee tail must be closure_param, got {vp:?}"
+        );
+        assert!(
+            vp.differing_callee,
+            "the reopened scoped callee must set differing_callee=true, got {vp:?}"
+        );
+        assert_eq!(vp.per_member_values.len(), members.len());
+        let mut vals = vp.per_member_values.clone();
+        vals.sort();
+        assert_eq!(vals, vec!["bar".to_string(), "foo".to_string()]);
+        assert!(
+            template.anti_unify_coverage < 1.0,
+            "a differing scoped callee tail must drop coverage below 1.0, got {}",
+            template.anti_unify_coverage
+        );
+        assert!(
+            template.text.contains(&format!("⟨{}⟩", vp.metavar_id)),
+            "the differing callee tail must render a hole, got {:?}",
             template.text
         );
     }

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -2775,4 +2775,51 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&root);
     }
+
+    /// #235 item 12: a focused unit test for `load_source_discriminators`, the production
+    /// symbols→files SELECT that builds the per-member `{files.sha256}:{start}-{end}` discriminator
+    /// folded into `refinement_key` (the cross-file cache-poisoning fix). Previously covered only
+    /// transitively by the e2e real-index tests + cache.rs's test-local helper.
+    #[test]
+    fn load_source_discriminators_builds_sha_span_strings_and_needs_full_hydration() {
+        use rusqlite::params;
+
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        crate::index::schema::apply(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO files(id, path, language, kind, sha256, modified_at_ms, indexed_at_ms)
+             VALUES (1, 'a.rs', 'rust', 'source', 'shaAAA', 0, 0),
+                    (2, 'b.rs', 'rust', 'source', 'shaBBB', 0, 0)",
+            [],
+        )
+        .unwrap();
+        for (id, file_id, name, start, end) in
+            [(10i64, 1i64, "foo", 0i64, 12i64), (20, 2, "bar", 40, 73)]
+        {
+            let qn = format!("{name}.rs::{name}");
+            conn.execute("INSERT OR IGNORE INTO name_strings(value) VALUES (?1)", params![qn])
+                .unwrap();
+            conn.execute(
+                "INSERT INTO symbols(id, file_id, language, name, qualified_name_id, kind,
+                                     start_byte, end_byte, signature, docs)
+                 VALUES (?1, ?2, 'rust', ?3, (SELECT id FROM name_strings WHERE value = ?4),
+                         'function', ?5, ?6, NULL, NULL)",
+                params![id, file_id, name, qn, start, end],
+            )
+            .unwrap();
+        }
+
+        // The discriminator is `{files.sha256}:{start_byte}-{end_byte}`. The query has no ORDER BY
+        // and `refinement_key` sorts before hashing, so compare sorted (order is unspecified).
+        let mut got = super::load_source_discriminators(&conn, &[10, 20]).unwrap().unwrap();
+        got.sort();
+        assert_eq!(got, vec!["shaAAA:0-12".to_string(), "shaBBB:40-73".to_string()]);
+
+        // Empty input hydrates to an empty multiset (Some, not None).
+        assert_eq!(super::load_source_discriminators(&conn, &[]).unwrap(), Some(Vec::new()));
+
+        // A member that does not hydrate (no such symbol row) → None: a partial multiset would
+        // alias a different class, so the class is left un-refined rather than mis-keyed.
+        assert_eq!(super::load_source_discriminators(&conn, &[10, 999]).unwrap(), None);
+    }
 }


### PR DESCRIPTION
Closes two bounded loose ends from the #235 triage (the rest are either now tracked as their own issues — #270/#271/#272 — or epic-blocked on Plan 3 SCIP / Plan 5 GumTree).

### item 12 — focused unit test for `load_source_discriminators`
The production symbols→files SELECT that builds the per-member `{files.sha256}:{start}-{end}` discriminator folded into `refinement_key` (the cross-file cache-poisoning fix) was covered only transitively by the e2e index tests + a cache.rs test-local helper. Adds a unit test inserting files+symbols rows and asserting the discriminator string + the **None-on-partial-hydration** contract (a missing member leaves the class un-refined rather than mis-keyed).

### item 18 — scoped-path-tail callee reopen
`m::foo()` vs `m::bar()` differ only in the final path segment. Both alpha-rename to the same normalized seq, so LCS matches the callee column — but the final segment `foo` is a plain `identifier` that doesn't share the call's start byte (only the module `m` does), so it never reached callee position. Result: a differing **module** reopened the matched column, but a differing **function name** did not (coverage 1.0, callee hard-coded) — the #235 asymmetry.

Fix: extend `run_in_callee_position` to recognize the final segment of a `scoped_identifier` callee head, gated by the **same** no-method-head check as a free callee (so a scoped *receiver* `m::obj.foo()` is excluded). It routes through the existing `matched_column_reopen` → differing-callee guard — **no parallel classifier** (per the round-6 consolidation invariant). Over-claim-safe: only the callee head begins at the call's start byte, so a non-callee scoped path can't satisfy the gate. This is exactly the documented fix the round-6 verification memory pointed at.

### Verification
fmt, clippy `--all-targets`, full `rag-rat-core` nextest (871, incl. all 113 refine tests — the existing free-callee / method-name / receiver-exclusion / module-segment / literal / type reopen tests are the over-claim regression guard).

Refs #235 (partial — the perf items #270/#271/#272 and the epic-blocked items remain).