### PR TITLE
fix(clones): Kotlin boolean/null + C/C++ char-value normalize recall gaps (#253)

### DIFF
--- a/crates/rag-rat-core/src/index/clones/mod.rs
+++ b/crates/rag-rat-core/src/index/clones/mod.rs
@@ -23,7 +23,15 @@ use tree_sitter::Node;
 /// fingerprint read) auto-EXCLUDES the v1 rows, which are recomputed at v2 on the next reindex; the
 /// 4b refinement cache invalidates via `NORM_VERSION` in the content-addressed `refinement_key` +
 /// the freshness predicate (`refine::cache`). No schema migration is needed.
-pub(crate) const NORM_VERSION: i64 = 2;
+///
+/// `3` (#253): two intra-language literal-bucketing recall gaps close, both partition-contained
+/// (the language partition already blocks cross-language pairing, so these are MISSED-clone recall,
+/// never false positives) — (1) Kotlin `true`/`false` (lexed as bare `identifier` leaves) now
+/// value-erase to `LIT_BOOL` instead of alpha-renaming to `ID<n>`, and `null` stays verbatim
+/// instead of alpha-renaming; (2) the C/C++ `char_literal` VALUE leaf (`character`) now buckets to
+/// `LIT_CHARACTER` instead of leaking the char value verbatim. Same auto-exclude-then-recompute
+/// path as the v2 bump (no schema migration); a bump forces re-fingerprinting on the next reindex.
+pub(crate) const NORM_VERSION: i64 = 3;
 /// Bumped when the LCS alignment / refinement algorithm changes; participates in the content-
 /// addressed `refinement_key` and in the `clone_refinements` cache freshness predicate, so a bump
 /// invalidates every cached refinement without a schema migration (the same discipline as
@@ -83,8 +91,14 @@ pub(crate) struct SymbolFingerprint {
 }
 
 /// Baseline fingerprint for a symbol's AST node, or `None` if it normalizes below `MIN_TOKENS`.
-pub(crate) fn fingerprint_symbol(node: Node<'_>, text: &str) -> Option<SymbolFingerprint> {
-    let tokens = normalize::normalize_baseline(node, text);
+/// `lang` selects the per-language normalization overrides (Kotlin boolean/null leaves, C/C++ char
+/// value — #253); it must match the grammar that produced `node`.
+pub(crate) fn fingerprint_symbol(
+    node: Node<'_>,
+    text: &str,
+    lang: crate::language::Language,
+) -> Option<SymbolFingerprint> {
+    let tokens = normalize::normalize_baseline(node, text, lang);
     if tokens.len() < MIN_TOKENS {
         return None;
     }
@@ -123,6 +137,7 @@ fn symbol_is_function_valued(node: Node<'_>) -> bool {
 pub(crate) fn fingerprint_symbols(
     root: Node<'_>,
     text: &str,
+    lang: crate::language::Language,
     symbols: &[crate::index::symbols::Symbol],
 ) -> Vec<(usize, SymbolFingerprint)> {
     let mut out = Vec::new();
@@ -135,7 +150,7 @@ pub(crate) fn fingerprint_symbols(
         if symbol.kind != "function" && !symbol_is_function_valued(node) {
             continue;
         }
-        if let Some(fp) = fingerprint_symbol(node, text) {
+        if let Some(fp) = fingerprint_symbol(node, text, lang) {
             out.push((i, fp));
         }
     }
@@ -163,13 +178,13 @@ mod tests {
             .iter()
             .filter_map(|s| {
                 let node = parsed.root().descendant_for_byte_range(s.start_byte, s.end_byte)?;
-                let len = normalize::normalize_baseline(node, src).len();
+                let len = normalize::normalize_baseline(node, src, language).len();
                 Some((len, node))
             })
             .max_by_key(|(len, _)| *len)
             .map(|(_, node)| node)
             .expect("at least one symbol with a normalizable subtree");
-        fingerprint_symbol(node, src)
+        fingerprint_symbol(node, src, language)
     }
 
     /// Rust-only wrapper — the existing Rust fingerprint tests call this unchanged.
@@ -178,12 +193,13 @@ mod tests {
     }
 
     #[test]
-    fn norm_version_is_2() {
-        // #232: the comment-skip (T2) + multi-language literal bucketing (T3) changed the
-        // normalization stream, so NORM_VERSION must be 2. The read filter + content-addressed
-        // refinement key both key off this constant, so a stream change without the bump silently
-        // serves stale fingerprints/refinements.
-        assert_eq!(NORM_VERSION, 2);
+    fn norm_version_is_3() {
+        // #253: the Kotlin boolean/null leaf-text override + the C/C++ `character` value bucket
+        // changed the normalization stream again (on top of the #232 comment-skip + multi-language
+        // bucketing that took it to 2), so NORM_VERSION must be 3. The read filter + content-
+        // addressed refinement key both key off this constant, so a stream change without the bump
+        // silently serves stale fingerprints/refinements.
+        assert_eq!(NORM_VERSION, 3);
     }
 
     #[test]
@@ -209,6 +225,38 @@ mod tests {
     #[test]
     fn trivial_bodies_below_min_tokens_are_not_fingerprinted() {
         assert!(fp("fn x() -> i32 { 0 }").is_none());
+    }
+
+    /// #253: two Kotlin fns differing ONLY in a boolean leaf fingerprint identically. Pre-#253 the
+    /// `true`/`false` leaves alpha-renamed to `ID<n>` (and into the shared identifier numbering),
+    /// so the struct_hash diverged and the clone was MISSED. The Kotlin-gated `LIT_BOOL`
+    /// override makes them a clone. (Both bodies clear MIN_TOKENS.)
+    #[test]
+    fn kotlin_boolean_only_diff_is_a_clone() {
+        let t = "fun f(): Boolean { val a = compute(); val b = check(a); val c = wrap(b); val x = \
+                 true; return x }";
+        let f = "fun f(): Boolean { val a = compute(); val b = check(a); val c = wrap(b); val x = \
+                 false; return x }";
+        let ft = fp_lang(t, "t.kt", Language::Kotlin).expect("true body fingerprinted");
+        let ff = fp_lang(f, "t.kt", Language::Kotlin).expect("false body fingerprinted");
+        assert_eq!(ft.struct_hash, ff.struct_hash, "Kotlin boolean-only diff must be a clone");
+        assert_eq!(ft.token_bag, ff.token_bag);
+    }
+
+    /// #253: two C++ fns differing ONLY in a char value (`'p'` vs `'q'`) fingerprint identically.
+    /// Pre-#253 the inner `character` leaf leaked the value verbatim, diverging the struct_hash and
+    /// MISSING the clone; the C/C++-gated `LIT_CHARACTER` bucket value-erases it. (Both bodies
+    /// clear MIN_TOKENS.) C and C++ share the `character` leaf; the C/C++ gate covers both.
+    #[test]
+    fn cpp_char_value_only_diff_is_a_clone() {
+        let p = "int f() { int a = compute(); int b = check(a); int c = wrap(b); char x = 'p'; \
+                 return c; }";
+        let q = "int f() { int a = compute(); int b = check(a); int c = wrap(b); char x = 'q'; \
+                 return c; }";
+        let fp_p = fp_lang(p, "t.cpp", Language::Cpp).expect("'p' body fingerprinted");
+        let fp_q = fp_lang(q, "t.cpp", Language::Cpp).expect("'q' body fingerprinted");
+        assert_eq!(fp_p.struct_hash, fp_q.struct_hash, "C++ char-value-only diff must be a clone");
+        assert_eq!(fp_p.token_bag, fp_q.token_bag);
     }
 
     // ── Task 5 (#232): function-valued declarators are fingerprinted (kind unchanged)
@@ -262,15 +310,20 @@ mod tests {
             parsed.root().descendant_for_byte_range(decl.start_byte, decl.end_byte).expect("node");
         // Clears MIN_TOKENS (so this isn't the size gate) but is NOT function-valued.
         assert!(
-            normalize::normalize_baseline(node, big_object).len() >= MIN_TOKENS,
+            normalize::normalize_baseline(node, big_object, Language::TypeScript).len()
+                >= MIN_TOKENS,
             "fixture must clear MIN_TOKENS so the negative isolates the value guard"
         );
         assert!(
             !symbol_is_function_valued(node),
             "object-literal const must not be function-valued"
         );
-        let fps =
-            fingerprint_symbols(parsed.root(), big_object, &symbols::from_parsed(&parsed.symbols));
+        let fps = fingerprint_symbols(
+            parsed.root(),
+            big_object,
+            Language::TypeScript,
+            &symbols::from_parsed(&parsed.symbols),
+        );
         assert!(
             fps.is_empty(),
             "a large non-function-value const must NOT be fingerprinted: {fps:?}"

--- a/crates/rag-rat-core/src/index/clones/normalize.rs
+++ b/crates/rag-rat-core/src/index/clones/normalize.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 
 use tree_sitter::Node;
 
+use crate::language::Language;
+
 /// A leaf tree-sitter kind that names a binding/reference identifier (kept language-agnostic by
 /// matching the `*identifier` suffix tree-sitter grammars use).
 fn is_identifier_kind(kind: &str) -> bool {
@@ -14,12 +16,21 @@ fn is_identifier_kind(kind: &str) -> bool {
 /// counterpart to Python's `string_content` — both are the value-bearing inner leaf, #232 #2a). It
 /// buckets to `LIT_STRING_FRAGMENT`, which the anti-unify/signature contract maps to `&str` (see
 /// `signature::literal_bucket_to_type`).
-fn is_literal_kind(kind: &str) -> bool {
+///
+/// `character` is the C/C++ char-LITERAL VALUE leaf: `tree-sitter-c`/`-cpp` parse `'x'` as a
+/// `char_literal` node (which already buckets via the `ends_with("literal")` arm) wrapping a
+/// `'` / `character` / `'` leaf triple — the quotes are structural (identical for any char), but
+/// the inner `character` leaf carries the value, so `'x'` vs `'y'` would leak verbatim without it
+/// (#253). GATED to C/C++ via `lang`: `character` is a generic-enough kind name that we only bucket
+/// it where it's known to be the char-literal value leaf, never speculatively across other
+/// grammars.
+fn is_literal_kind(kind: &str, lang: Language) -> bool {
     kind.ends_with("literal")
         || matches!(
             kind,
             "string_content" | "string_fragment" | "integer" | "float" | "number" | "char"
         )
+        || (matches!(lang, Language::C | Language::Cpp) && kind == "character")
 }
 
 /// A leaf kind that is a boolean literal in the grammars that expose booleans as their own leaf
@@ -31,12 +42,33 @@ fn is_literal_kind(kind: &str) -> bool {
 /// is why this is NOT routed through the generic `LIT_{kind.uppercased}` path — that would encode
 /// the value.
 ///
-/// NOT covered: `tree-sitter-kotlin-ng` emits `true`/`false`/`null` as plain `identifier` leaves,
-/// so Kotlin booleans are alpha-renamed (`ID<n>`) rather than value-erased. This is a deferred
-/// recall gap, not a correctness bug — the language partition guarantees Kotlin only ever
-/// clone-matches Kotlin, where identifiers and booleans are treated consistently (#232 follow-up).
+/// Kotlin is handled separately by leaf TEXT (see [`kotlin_identifier_token`]):
+/// `tree-sitter-kotlin` emits `true`/`false`/`null` as plain `identifier` leaves, so they never
+/// reach this kind-based predicate. The fix (#253) intercepts them under the identifier branch in
+/// `walk_spanned`, GATED to Kotlin, mapping `true`/`false` to `LIT_BOOL` (was alpha-renamed to
+/// `ID<n>` — a recall leak, partition-contained since Kotlin only clone-matches Kotlin).
 fn is_boolean_leaf_kind(kind: &str) -> bool {
     matches!(kind, "true" | "false")
+}
+
+/// Kotlin-only override for an `identifier`-kind leaf whose TEXT is a boolean or null keyword.
+/// `tree-sitter-kotlin` lexes `true`/`false`/`null` as bare `identifier` leaves (not their own
+/// kinds), so the generic `is_boolean_leaf_kind`/`is_identifier_kind` path would alpha-rename them
+/// to `ID<n>` and leak the value into matching (#253). Returns:
+/// - `Some("LIT_BOOL")` for `true`/`false` — value-erased to the same single bucket every other
+///   grammar's booleans use, so a Kotlin `true`↔`false`-only diff normalizes equal.
+/// - `Some("null")` for `null` — kept VERBATIM (the cross-language null-family policy, #232 #2c:
+///   not bucketed, but also not alpha-renamed to an `ID<n>`).
+/// - `None` for any other identifier text — falls through to the normal `ID<n>` alpha-rename.
+///
+/// GATED to Kotlin by the caller; other grammars emit these as dedicated leaf kinds and must not be
+/// matched by text here.
+fn kotlin_identifier_token(leaf: &str) -> Option<&'static str> {
+    match leaf {
+        "true" | "false" => Some("LIT_BOOL"),
+        "null" => Some("null"),
+        _ => None,
+    }
 }
 
 /// `true` for a tree-sitter node kind that names a Rust type position — a bare type name
@@ -95,11 +127,12 @@ pub(crate) struct NodeSpan {
 pub(crate) fn normalize_baseline_spanned(
     node: Node<'_>,
     text: &str,
+    lang: Language,
 ) -> (Vec<String>, Vec<NodeSpan>) {
     let mut tokens = Vec::new();
     let mut spans = Vec::new();
     let mut idents: HashMap<String, usize> = HashMap::new();
-    walk_spanned(node, text.as_bytes(), &mut idents, &mut tokens, &mut spans);
+    walk_spanned(node, text.as_bytes(), lang, &mut idents, &mut tokens, &mut spans);
     (tokens, spans)
 }
 
@@ -107,13 +140,14 @@ pub(crate) fn normalize_baseline_spanned(
 /// node — structural node kinds for internal nodes; for leaves, an alpha-renamed `ID<n>` for
 /// identifiers (numbered by first occurrence), a `LIT_<KIND>` bucket for literals, and the verbatim
 /// text for operators/keywords/punctuation. Scope-independent: depends only on this node's subtree.
-pub(crate) fn normalize_baseline(node: Node<'_>, text: &str) -> Vec<String> {
-    normalize_baseline_spanned(node, text).0
+pub(crate) fn normalize_baseline(node: Node<'_>, text: &str, lang: Language) -> Vec<String> {
+    normalize_baseline_spanned(node, text, lang).0
 }
 
 fn walk_spanned(
     node: Node<'_>,
     src: &[u8],
+    lang: Language,
     idents: &mut HashMap<String, usize>,
     tokens: &mut Vec<String>,
     spans: &mut Vec<NodeSpan>,
@@ -139,14 +173,24 @@ fn walk_spanned(
         // Leaf: push the token and its span.
         let leaf = node.utf8_text(src).unwrap_or("");
         let token = if is_identifier_kind(kind) {
-            let next = idents.len();
-            let id = *idents.entry(leaf.to_string()).or_insert(next);
-            format!("ID{id}")
+            // (#253) Kotlin lexes `true`/`false`/`null` as bare `identifier` leaves, so they reach
+            // the identifier branch FIRST. GATED to Kotlin, intercept by leaf text: `true`/`false`
+            // value-erase to `LIT_BOOL` (same single bucket as every other grammar's booleans),
+            // `null` stays verbatim (null-family policy). Every other identifier alpha-renames.
+            if let Some(tok) =
+                (lang == Language::Kotlin).then(|| kotlin_identifier_token(leaf)).flatten()
+            {
+                tok.to_string()
+            } else {
+                let next = idents.len();
+                let id = *idents.entry(leaf.to_string()).or_insert(next);
+                format!("ID{id}")
+            }
         } else if is_boolean_leaf_kind(kind) {
             // Value-erase booleans to ONE bucket (NOT `LIT_{kind.uppercased}`): `true`/`false`
             // collapse to `LIT_BOOL` so a true↔false-only diff is a clone (#232 #2b).
             "LIT_BOOL".to_string()
-        } else if is_literal_kind(kind) {
+        } else if is_literal_kind(kind, lang) {
             format!("LIT_{}", kind.to_ascii_uppercase())
         } else {
             // (#232 #2c) NULL-FAMILY out of scope (low value + wrapped-node hazard): `null` /
@@ -166,7 +210,7 @@ fn walk_spanned(
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        walk_spanned(child, src, idents, tokens, spans);
+        walk_spanned(child, src, lang, idents, tokens, spans);
     }
 }
 
@@ -184,13 +228,17 @@ mod tests {
     /// `function`, TS `const`/function-valued declarators, and Python `function` symbols — the
     /// languages disagree on the symbol `kind` string but agree that the biggest normalized subtree
     /// is the body we want to compare.
-    fn target_node_for<'a>(parsed: &'a parser::ParsedFile, src: &str) -> tree_sitter::Node<'a> {
+    fn target_node_for<'a>(
+        parsed: &'a parser::ParsedFile,
+        src: &str,
+        language: Language,
+    ) -> tree_sitter::Node<'a> {
         parsed
             .symbols
             .iter()
             .filter_map(|s| {
                 let node = parsed.root().descendant_for_byte_range(s.start_byte, s.end_byte)?;
-                let len = normalize_baseline(node, src).len();
+                let len = normalize_baseline(node, src, language).len();
                 Some((len, node))
             })
             .max_by_key(|(len, _)| *len)
@@ -202,13 +250,13 @@ mod tests {
     /// grammar / generated heuristics), select the target symbol, return its normalized stream.
     fn norm_lang(src: &str, path: &str, language: Language) -> Vec<String> {
         let parsed = parser::parse_file(Path::new(path), language, src).expect("parse");
-        normalize_baseline(target_node_for(&parsed, src), src)
+        normalize_baseline(target_node_for(&parsed, src, language), src, language)
     }
 
     /// Generalized spanned-normalize harness (token stream + parallel `NodeSpan`s).
     fn spanned_lang(src: &str, path: &str, language: Language) -> (Vec<String>, Vec<NodeSpan>) {
         let parsed = parser::parse_file(Path::new(path), language, src).expect("parse");
-        normalize_baseline_spanned(target_node_for(&parsed, src), src)
+        normalize_baseline_spanned(target_node_for(&parsed, src, language), src, language)
     }
 
     /// Rust-only wrappers — the existing Rust tests call these unchanged.
@@ -372,6 +420,84 @@ mod tests {
         assert!(
             nt.iter().any(|tok| tok == "boolean_literal"),
             "wrapping boolean_literal node kind still pushed: {nt:?}"
+        );
+    }
+
+    // ── #253: intra-language literal-bucketing recall gaps
+    // ──────────────────────────────────────
+
+    /// Kotlin lexes `true`/`false` as bare `identifier` leaves (not their own kinds), so before
+    /// #253 they alpha-renamed to `ID<n>` and a `true`↔`false`-only diff did NOT normalize equal.
+    /// The Kotlin-gated leaf-TEXT override now value-erases them to the SAME `LIT_BOOL` bucket
+    /// every other grammar's booleans use, so two Kotlin fns differing only in a boolean ARE a
+    /// clone. Also pins that `null` (also a bare `identifier` leaf in Kotlin) stays VERBATIM —
+    /// neither bucketed nor alpha-renamed to an `ID<n>` — matching the cross-language
+    /// null-family policy.
+    #[test]
+    fn kotlin_booleans_bucket_to_lit_bool() {
+        let t = "fun f(): Boolean { val a = compute(); val b = a; val x = true; return x }";
+        let f = "fun f(): Boolean { val a = compute(); val b = a; val x = false; return x }";
+        let nt = norm_lang(t, "t.kt", Language::Kotlin);
+        let nf = norm_lang(f, "t.kt", Language::Kotlin);
+        assert_eq!(nt, nf, "Kotlin true/false-only diff must normalize equal (LIT_BOOL)");
+        assert_eq!(
+            nt.iter().filter(|tok| *tok == "LIT_BOOL").count(),
+            1,
+            "exactly one LIT_BOOL leaf for the Kotlin boolean: {nt:?}"
+        );
+        // The boolean must NOT have leaked as a verbatim `true`/`false` NOR as an alpha-renamed ID
+        // sharing the identifier numbering (the pre-#253 bug).
+        assert!(
+            !nt.iter().any(|tok| tok == "true" || tok == "false"),
+            "no verbatim Kotlin bool: {nt:?}"
+        );
+
+        // `null` stays verbatim — not bucketed, not alpha-renamed.
+        let n = "fun g(): String? { val a = compute(); val b = a; val x = null; return x }";
+        let nn = norm_lang(n, "t.kt", Language::Kotlin);
+        assert!(
+            nn.iter().any(|tok| tok == "null"),
+            "Kotlin null stays verbatim (null-family policy): {nn:?}"
+        );
+        assert!(
+            !nn.iter().any(|tok| tok.starts_with("LIT_")),
+            "Kotlin null must NOT bucket to any LIT_ token: {nn:?}"
+        );
+    }
+
+    /// C and C++ parse `'x'` as a `char_literal` node wrapping a `'` / `character` / `'` leaf
+    /// triple. The quotes are structural (identical for any char) but the inner `character`
+    /// leaf carries the VALUE — before #253 it leaked verbatim, so two fns differing only in a
+    /// char (`'x'` vs `'y'`) did NOT normalize equal. The C/C++-gated `character` bucket
+    /// value-erases it to `LIT_CHARACTER`, so a char-value-only diff IS a clone. Checked for
+    /// both C and C++.
+    #[test]
+    fn c_and_cpp_char_value_buckets() {
+        // C: differ only in the char value.
+        let c_x = "int f(void) { int a = compute(); int b = a; char x = 'p'; return b; }";
+        let c_y = "int f(void) { int a = compute(); int b = a; char x = 'q'; return b; }";
+        let nc_x = norm_lang(c_x, "t.c", Language::C);
+        let nc_y = norm_lang(c_y, "t.c", Language::C);
+        assert_eq!(nc_x, nc_y, "C char-value-only diff must normalize equal (LIT_CHARACTER)");
+        assert!(
+            nc_x.iter().any(|tok| tok == "LIT_CHARACTER"),
+            "C char value must bucket to LIT_CHARACTER: {nc_x:?}"
+        );
+        // The value must not have leaked verbatim.
+        assert!(
+            !nc_x.iter().any(|tok| tok == "p"),
+            "C char value must not leak verbatim: {nc_x:?}"
+        );
+
+        // C++: differ only in the char value.
+        let cpp_x = "int f() { int a = compute(); int b = a; char x = 'p'; return b; }";
+        let cpp_y = "int f() { int a = compute(); int b = a; char x = 'q'; return b; }";
+        let ncpp_x = norm_lang(cpp_x, "t.cpp", Language::Cpp);
+        let ncpp_y = norm_lang(cpp_y, "t.cpp", Language::Cpp);
+        assert_eq!(ncpp_x, ncpp_y, "C++ char-value-only diff must normalize equal (LIT_CHARACTER)");
+        assert!(
+            ncpp_x.iter().any(|tok| tok == "LIT_CHARACTER"),
+            "C++ char value must bucket to LIT_CHARACTER: {ncpp_x:?}"
         );
     }
 

--- a/crates/rag-rat-core/src/index/clones/refine/antiunify.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/antiunify.rs
@@ -2746,7 +2746,7 @@ mod tests {
         let func = parsed.symbols.iter().find(|s| s.kind == "function").expect("a function symbol");
         let node =
             parsed.root().descendant_for_byte_range(func.start_byte, func.end_byte).expect("node");
-        let (seq, node_spans) = normalize_baseline_spanned(node, &text);
+        let (seq, node_spans) = normalize_baseline_spanned(node, &text, Language::Rust);
         let struct_hash = tokens::struct_hash(&seq);
         RefineMember { symbol_id, lang: Language::Rust, struct_hash, seq, node_spans, text }
     }
@@ -2764,12 +2764,12 @@ mod tests {
             .iter()
             .filter_map(|s| {
                 let n = parsed.root().descendant_for_byte_range(s.start_byte, s.end_byte)?;
-                Some((normalize_baseline_spanned(n, &text).0.len(), n))
+                Some((normalize_baseline_spanned(n, &text, Language::TypeScript).0.len(), n))
             })
             .max_by_key(|(len, _)| *len)
             .map(|(_, n)| n)
             .expect("a body symbol");
-        let (seq, node_spans) = normalize_baseline_spanned(node, &text);
+        let (seq, node_spans) = normalize_baseline_spanned(node, &text, Language::TypeScript);
         let struct_hash = tokens::struct_hash(&seq);
         RefineMember { symbol_id, lang: Language::TypeScript, struct_hash, seq, node_spans, text }
     }

--- a/crates/rag-rat-core/src/index/clones/refine/cache.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/cache.rs
@@ -331,7 +331,7 @@ mod tests {
         let func = parsed.symbols.iter().find(|s| s.kind == "function").expect("a function symbol");
         let node =
             parsed.root().descendant_for_byte_range(func.start_byte, func.end_byte).expect("node");
-        let (seq, node_spans) = normalize_baseline_spanned(node, &text);
+        let (seq, node_spans) = normalize_baseline_spanned(node, &text, Language::Rust);
         let struct_hash = tokens::struct_hash(&seq);
         RefineMember { symbol_id, lang: Language::Rust, struct_hash, seq, node_spans, text }
     }

--- a/crates/rag-rat-core/src/index/clones/refine/signature.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/signature.rs
@@ -383,6 +383,9 @@ fn literal_bucket_to_type(bucket: &str) -> Option<&'static str> {
         // them — booleans route to `LIT_BOOL`) but are kept as defensive aliases.
         "LIT_BOOL" | "LIT_BOOLEAN_LITERAL" | "LIT_BOOL_LITERAL" => Some("bool"),
         // Unmapped bucket: NO stable Rust type → unresolved, never the opaque `{literal}`-as-typed.
+        // `LIT_CHARACTER` (the C/C++ char-literal VALUE leaf, #253) lands here DELIBERATELY: it has
+        // no stable Rust type cross-language (like `LIT_CHAR`), so it stays unresolved rather than
+        // over-claim a `char` type. Recall-only fix; never promotes typedness.
         _ => None,
     }
 }
@@ -675,7 +678,7 @@ mod tests {
         let func = parsed.symbols.iter().find(|s| s.kind == "function").expect("a function symbol");
         let node =
             parsed.root().descendant_for_byte_range(func.start_byte, func.end_byte).expect("node");
-        let (seq, node_spans) = normalize_baseline_spanned(node, &text);
+        let (seq, node_spans) = normalize_baseline_spanned(node, &text, Language::Rust);
         let struct_hash = tokens::struct_hash(&seq);
         RefineMember { symbol_id, lang: Language::Rust, struct_hash, seq, node_spans, text }
     }

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -261,7 +261,7 @@ impl IndexDatabase {
         let Some(parsed) = parser::parse_file(path, language, text) else {
             return Ok(());
         };
-        let fingerprints = clones::fingerprint_symbols(parsed.root(), text, symbols);
+        let fingerprints = clones::fingerprint_symbols(parsed.root(), text, language, symbols);
         // Heal/inline path runs no full-rebuild finalize, so the df must be kept current here via
         // the per-token bump (drift-tolerated; see write_symbol_fingerprints).
         self.write_symbol_fingerprints(symbol_ids, &fingerprints, BumpDf(true))

--- a/crates/rag-rat-core/src/index/prep.rs
+++ b/crates/rag-rat-core/src/index/prep.rs
@@ -303,7 +303,7 @@ pub(crate) fn prepare_index_content(file: &IndexFile) -> anyhow::Result<Prepared
     } else {
         parsed
             .as_ref()
-            .map(|p| clones::fingerprint_symbols(p.root(), &text, &symbols))
+            .map(|p| clones::fingerprint_symbols(p.root(), &text, file.language, &symbols))
             .unwrap_or_default()
     };
 

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -797,9 +797,10 @@ fn build_completeness(
         refine_budget_clamped,
         stale_members,
         // #232 closed the previously-advertised multi-language gaps: comments are now skipped,
-        // string + boolean literals bucket multi-language (NORM_VERSION = 2), and TS
-        // function-valued declarators are fingerprinted. No clone-substrate gaps are
-        // currently advertised open.
+        // string + boolean literals bucket multi-language, and TS function-valued declarators are
+        // fingerprinted. #253 closed two more intra-language literal-bucketing recall gaps (Kotlin
+        // boolean/null leaves, the C/C++ char value leaf) — see `NORM_VERSION` (now 3). No
+        // clone-substrate gaps are currently advertised open.
         known_index_gaps: Vec::new(),
     }
 }
@@ -1088,8 +1089,11 @@ impl IndexDatabase {
             // Plan 4b: use normalize_baseline_spanned so each token carries its AST span.
             // The seq (.0) is byte-identical to the old normalize_baseline output (faithfulness
             // pin).
-            let (seq, node_spans) =
-                crate::index::clones::normalize::normalize_baseline_spanned(node, &text);
+            let (seq, node_spans) = crate::index::clones::normalize::normalize_baseline_spanned(
+                node,
+                &text,
+                row.language,
+            );
 
             // Faithfulness pin: the re-parse must reproduce Plan-1's normalization exactly. A
             // mismatch means the on-disk file no longer matches the indexed fingerprint (the


### PR DESCRIPTION
Two intra-language literal-bucketing recall gaps (partition-contained — cross-language pairing is already blocked, so these are MISSED-clone recall, never false positives):

1. **Kotlin booleans/null** — tree-sitter-kotlin-ng emits `true`/`false`/`null` as plain `identifier` leaves, so they alpha-renamed to `ID<n>` instead of bucketing to `LIT_BOOL`. Now handled by leaf TEXT under the identifier check, **gated to Kotlin**.
2. **C/C++ char value** — `char_literal` is a literal kind but its content child `character` wasn't bucketed, so `'x'` vs `'y'` leaked verbatim. Now `character` is added to the literal bucket for C/C++.

Both ride a **`NORM_VERSION` bump (2→3)**.

### Verification (rebased onto current main + thoroughly tested)
Rebased past #276/#277. A clean textual rebase hid one semantic break — #253 added a `language: Language` param to `normalize_baseline_spanned`, and #276 added a new test helper `member_ts` (a caller #253 never saw); fixed both of its calls to pass `Language::TypeScript`. Then:
- `cargo +nightly fmt`, `cargo clippy --workspace --all-targets` — clean
- `cargo nextest run --workspace` — **1022 passed, 0 failed**
- cross-cutting spot-checks green: #276 `ts_template_literal_*` (use `member_ts`), `norm_version_is_3`, all 14 normalize tests, #277 `structural` tests.
- 4 new tests: Kotlin bool-bucket clone, Kotlin null-bucket, C char-value clone, C++ char-value.

### ⚠️ Caveats for the reviewer (read before merge)
1. **`NORM_VERSION` 2→3 forces re-fingerprinting on the live index.** The read filter (`sf.normalizer_version = NORM_VERSION`) auto-excludes the v2 rows, which recompute at v3 on the next reindex; the content-addressed `refinement_key` + freshness predicate invalidate cached refinements. No schema migration.
2. **Recall NOT measured.** The issue asked to *"measure real recall impact first"*, but there's no eval harness in the worktree — the recall gain is unquantified. Weigh the forced-reindex cost against an unmeasured (but partition-safe, false-positive-free) recall gain. The change is correct + tested; only the *value* is unmeasured.

Fixes #253