### PR TITLE
feat(clones): clone measurement infrastructure — perf microbench + recall signature (#279)

### DIFF
--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -207,6 +207,14 @@ pub(crate) struct ClonesArgs {
     /// instead of the JSON/TOON listing.
     #[arg(long, value_name = "CLASS_KEY")]
     pub explain: Option<String>,
+    /// Print a canonical, cross-build-stable RECALL signature instead of the listing: one sorted
+    /// line per clone class (`<member_count>\t<sorted member refs>`), keyed on `path::symbol` refs
+    /// (not rowids). This is the recall half of the clone measurement harness (#279): dump it on
+    /// two builds (e.g. before/after a candidate-pruning change like #271's hot-token cap) and
+    /// `diff` them — a removed or shrunk line is a recall regression. Forces a complete pass
+    /// (ignores `--limit`).
+    #[arg(long)]
+    pub recall_signature: bool,
 }
 
 /// Selector for `clones-for`: positional `SYMBOL` (a qualified ref or `sym_<hex>` handle), or

--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -154,8 +154,16 @@ pub(crate) fn clones(config: &Config, args: &ClonesArgs) -> anyhow::Result<()> {
     let result = db.find_clones(rag_rat_core::index::FindClonesOptions {
         min_similarity: args.min_similarity,
         min_copies: args.min_copies,
-        limit: args.limit,
+        // A recall signature must be COMPLETE (every class), so never clamp it to a class limit.
+        limit: if args.recall_signature { None } else { args.limit },
     })?;
+
+    // `--recall-signature`: a canonical, cross-build-stable recall dump for the #279 harness,
+    // instead of the listing/explain.
+    if args.recall_signature {
+        print!("{}", recall_signature(&result));
+        return Ok(());
+    }
 
     // `--explain <CLASS_KEY>`: print a human-readable refinement breakdown for one class from the
     // SAME result set (so the explained class went through the same refine pass as the listing),
@@ -169,6 +177,37 @@ pub(crate) fn clones(config: &Config, args: &ClonesArgs) -> anyhow::Result<()> {
     }
 
     print_output(&result)
+}
+
+/// A canonical, cross-build-STABLE recall signature of the clone classes — one line per class
+/// (`<member_count>\t<comma-joined sorted member refs>`), lines sorted, after a `#`-comment
+/// summary; trailing newline included. Stable because it keys on member REFS (`path::symbol`), not
+/// rowids, so two builds (before/after a candidate-pruning change like #271's hot-token cap) diff
+/// with plain `diff`: a removed or shrunk line is a recall regression. The recall half of #279.
+/// `member_count` is the FULL class size (the returned member list may be member-capped, but the
+/// count plus the deterministic capped subset still pin the class, so a class that vanishes /
+/// splits / shrinks always changes its line). Pure (returns the text) so it is unit-testable.
+fn recall_signature(result: &rag_rat_core::index::FindClonesResult) -> String {
+    let mut lines: Vec<String> = result
+        .classes
+        .iter()
+        .map(|c| {
+            let mut refs: Vec<&str> = c.members.iter().map(|m| m.r#ref.as_str()).collect();
+            refs.sort_unstable();
+            format!("{}\t{}", c.member_count, refs.join(","))
+        })
+        .collect();
+    lines.sort_unstable();
+    let total_members: usize = result.classes.iter().map(|c| c.member_count).sum();
+    let mut out = format!(
+        "# clone recall signature — {} classes, {total_members} clone members\n",
+        result.classes.len(),
+    );
+    for line in &lines {
+        out.push_str(line);
+        out.push('\n');
+    }
+    out
 }
 
 /// Render a human-readable explanation of a refined clone class: the anti-unification template,
@@ -1010,8 +1049,13 @@ mod tests {
         };
         IndexDatabase::rebuild(&config).unwrap();
 
-        let args =
-            ClonesArgs { min_similarity: None, min_copies: Some(2), limit: None, explain: None };
+        let args = ClonesArgs {
+            min_similarity: None,
+            min_copies: Some(2),
+            limit: None,
+            explain: None,
+            recall_signature: false,
+        };
         // The handler must not error.
         super::clones(&config, &args).unwrap_or_else(|err| panic!("clones handler failed: {err}"));
 
@@ -1028,6 +1072,26 @@ mod tests {
             result.classes.iter().any(|c| c.member_count >= 2),
             "expected at least one clone class with >=2 members for the planted pair: {:?}",
             result.classes
+        );
+
+        // #279 recall harness: the canonical signature is a sorted, ref-keyed dump — the planted
+        // 3-way clone surfaces as one `3\t<sorted refs>` line under the `#` summary header, keyed
+        // on stable `path::symbol` refs (so two builds diff with plain `diff`).
+        let sig = super::recall_signature(&result);
+        assert!(sig.starts_with("# clone recall signature —"), "signature header missing:\n{sig}");
+        let clone_line = sig
+            .lines()
+            .find(|l| l.starts_with("3\t"))
+            .unwrap_or_else(|| panic!("no 3-member class line in signature:\n{sig}"));
+        for member in
+            ["src/lib.rs::cloned_helper", "src/a.rs::cloned_helper", "src/b.rs::cloned_helper"]
+        {
+            assert!(clone_line.contains(member), "signature line missing {member}: {clone_line}");
+        }
+        // Refs are sorted WITHIN a line (a.rs < b.rs < lib.rs) — the cross-build-stable ordering.
+        assert!(
+            clone_line.find("src/a.rs") < clone_line.find("src/b.rs"),
+            "member refs must be sorted within a class line: {clone_line}"
         );
 
         let _ = std::fs::remove_dir_all(&root);

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -74,3 +74,8 @@ harness = false
 [[bench]]
 name = "index_time"
 harness = false
+
+# criterion: wall-clock clone-query time (candidate gen, reverse lookup, cold find_clones) — #279.
+[[bench]]
+name = "clone_time"
+harness = false

--- a/crates/rag-rat-core/benches/clone_time.rs
+++ b/crates/rag-rat-core/benches/clone_time.rs
@@ -1,0 +1,126 @@
+//! Wall-clock clone-query time (criterion) — the perf half of the clone measurement infrastructure
+//! (#279). Gives the three clone-perf prototypes a real before/after signal so none merges on faith
+//! of a speedup:
+//!
+//! - `candidate_components` — `candidate_clone_components` (the SourcererCC candidate-pair gen +
+//!   union-find, NO refine, NO cache). This is the bulk of what the #270 full-scan reverse lookup
+//!   pays and the exact step the #271 hot-token cap prunes.
+//! - `clones_for_symbol` — the #270 reverse-lookup entry point on a real clone-member subject. Its
+//!   candidate scan is recomputed every call (only refine is cached), so this measures the
+//!   full-scan cost the #270 BFS prototype targets.
+//! - `find_clones_cold` — the whole ranked pass incl. refine, with an EMPTY refine cache each
+//!   iteration (a fresh rebuild in the untimed `iter_batched` setup). This is the ~48–52 s pass the
+//!   #272 global refine budget bounds. There is no public refine-cache clear, so a fresh build is
+//!   the only honest cold measurement.
+//!
+//! Noisy (wall-clock, small sample) — rely on Bencher's statistical threshold to gate regressions.
+//! Corpus harness shared (benches/shared); subdir kept moderate so the cold rebuild-per-iteration
+//! stays tractable.
+
+mod shared;
+
+use std::path::PathBuf;
+use std::time::Duration;
+use std::{fs, hint};
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use rag_rat_core::index::{CloneSymbolSelector, FindClonesOptions};
+use shared::{built_config, corpus_dir, open_like_production};
+
+/// A moderate, clone-dense subtree of the corpus — big enough to exercise real candidate generation
+/// and refine, small enough that the cold bench's per-iteration rebuild stays bounded. `src/cargo`
+/// is guaranteed present (the corpus-clone marker checks it).
+const SUBDIR: &str = "src/cargo";
+
+fn default_opts() -> FindClonesOptions {
+    FindClonesOptions { min_similarity: None, min_copies: None, limit: None }
+}
+
+/// Best-effort removal of a bench DB's on-disk files (`.sqlite` + `-wal`/`-shm`) when dropped, so a
+/// long run doesn't leak a corpus-sized DB per build — the same discipline as `index_time`'s
+/// `TempIndexDb` (#251). Declared so it drops AFTER the `IndexDatabase` handle it pairs with (the
+/// handle closes the connection first, then the files are unlinked).
+struct DbFiles(PathBuf);
+
+impl Drop for DbFiles {
+    fn drop(&mut self) {
+        let db = self.0.display().to_string();
+        for suffix in ["", "-wal", "-shm"] {
+            let _ = fs::remove_file(format!("{db}{suffix}"));
+        }
+    }
+}
+
+fn clone_queries(c: &mut Criterion) {
+    // Clone the corpus once, before timing.
+    let _ = corpus_dir();
+
+    // One shared index for the cache-free / warm benches and to resolve a real subject. Declared
+    // before `db` so `db` (the open handle) drops first and `DbFiles` unlinks afterwards.
+    let config = built_config(SUBDIR);
+    let _shared_cleanup = DbFiles(config.database.clone());
+    let db = open_like_production(&config);
+
+    let components = db.candidate_clone_components().expect("candidate components");
+    // Resolve a real clone-member `ref` (a `path::symbol`) to drive `clones_for_symbol`; `None`
+    // when the subtree has no clone class (then that bench is skipped rather than measuring a
+    // miss).
+    let subject_ref = db
+        .find_clones(FindClonesOptions { limit: Some(5), ..default_opts() })
+        .ok()
+        .and_then(|r| r.classes.into_iter().find_map(|cls| cls.members.into_iter().next()))
+        .map(|m| m.r#ref);
+    eprintln!(
+        "clone_time: {SUBDIR} → {} candidate components; subject = {subject_ref:?}",
+        components.len()
+    );
+
+    let mut group = c.benchmark_group("clone_time");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(60));
+
+    // 1. Candidate generation only — cache-free, recomputed every call (#270 full-scan / #271 cap).
+    group.bench_function("candidate_components", |b| {
+        b.iter(|| hint::black_box(db.candidate_clone_components().expect("candidate components")));
+    });
+
+    // 2. The #270 reverse lookup on a real subject (skip if the subtree has no clone class).
+    if let Some(subject) = subject_ref {
+        group.bench_function("clones_for_symbol", |b| {
+            b.iter(|| {
+                let r = db
+                    .clones_for_symbol(CloneSymbolSelector::Ref(subject.clone()))
+                    .expect("clones_for_symbol");
+                hint::black_box(r);
+            });
+        });
+    }
+    group.finish();
+
+    // 3. Cold `find_clones` — the whole ranked+refined pass with an EMPTY refine cache each
+    // iteration. A fresh rebuild in the (untimed) `iter_batched` setup gives the empty cache; only
+    // the `find_clones` call is measured. The per-iteration DB is dropped via `DbFiles` so at most
+    // one corpus-sized DB sits on disk at a time (#251).
+    let mut cold = c.benchmark_group("clone_time_cold");
+    cold.sample_size(10);
+    cold.measurement_time(Duration::from_secs(180));
+    cold.bench_function("find_clones_cold", |b| {
+        b.iter_batched_ref(
+            || {
+                let config = built_config(SUBDIR);
+                let cleanup = DbFiles(config.database.clone());
+                let db = open_like_production(&config);
+                // (db, cleanup): db drops first (closes the connection), then cleanup unlinks.
+                (db, cleanup)
+            },
+            |(db, _cleanup)| {
+                hint::black_box(db.find_clones(default_opts()).expect("find_clones"));
+            },
+            BatchSize::PerIteration,
+        );
+    });
+    cold.finish();
+}
+
+criterion_group!(benches, clone_queries);
+criterion_main!(benches);


### PR DESCRIPTION
Builds the measurement infrastructure that gates the three clone-perf prototypes (#270 BFS reverse lookup, #271 hot-token cap, #272 global refine budget) — so none of them merges on faith of a speedup or a recall guarantee. Closes both parts of #279.

## Part 1 — perf microbench (`benches/clone_time.rs`, criterion)
| Bench | Measures | Gates |
|---|---|---|
| `candidate_components` | cache-free candidate-pair gen + union-find | #270 full-scan / #271 cap |
| `clones_for_symbol` | the #270 reverse lookup on a real resolved subject | #270 |
| `find_clones_cold` | the whole ranked+refined pass with an EMPTY refine cache each iteration (fresh rebuild in the untimed `iter_batched` setup; there's no public cache-clear) | #272 |

Per-iteration `DbFiles` cleanup so a long cold run keeps at most one corpus-sized DB on disk (the #251 discipline). Subject resolved via `find_clones` member refs; `clones_for_symbol` is skipped when the subtree has no clone class.

**Smoke run on `src/cargo`:** candidate gen **~5.9 s**, reverse lookup **~6.3 s**, cold pass **~69 s** — which already validates (and exceeds) #272's stated ~48–52 s, and confirms #270's premise that the reverse lookup pays the full scan every call.

## Part 2 — recall harness (`rag-rat clones --recall-signature`)
Prints a canonical, **cross-build-stable** dump — one sorted line per clone class (`<member_count>\t<sorted path::symbol refs>`), keyed on refs not rowids — after a `#` summary. Gate a candidate-pruning change (e.g. #271's cap) by dumping on two builds and `diff`-ing: a removed or shrunk line is a recall regression. Forces a complete pass (ignores `--limit`). The render is a pure `recall_signature()` fn, unit-tested on a planted 3-way clone.

```
rag-rat clones --recall-signature > before.txt   # on main
rag-rat clones --recall-signature > after.txt    # on the change branch
diff before.txt after.txt                        # any removed/shrunk line = recall loss
```

## Notes
- The three prototypes are preserved on `spike/270-*`, `spike/271-*`, `spike/272-*` and can now be gated against this infra.
- Verification: `cargo +nightly fmt`, `cargo clippy --workspace --all-targets`, `cargo nextest run --workspace` (1022 passed).

Fixes #279