### PR TITLE
feat(clones): global cross-class refine cell budget (#272)

### DIFF
--- a/crates/rag-rat-core/src/index/clones/refine/align.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/align.rs
@@ -197,6 +197,29 @@ pub(crate) fn class_lcs_ratio(seqs: &[Vec<String>]) -> (f64, bool) {
     (ratio, sampled)
 }
 
+/// Like [`class_lcs_ratio`] but draws its exact-DP allowance from a SHARED CROSS-CLASS budget
+/// (`*remaining_cells`) instead of a fresh per-class [`LCS_AGGREGATE_CELLS_BUDGET`]. The per-class
+/// cap is `min(LCS_AGGREGATE_CELLS_BUDGET, *remaining_cells)` — so the fidelity lane stays bounded
+/// per class AND the WHOLE `find_clones` refine pass is bounded by the global allowance the driver
+/// seeds. `*remaining_cells` is decremented by the exact-DP cells this call actually charged (it
+/// never goes negative — `saturating_sub`). Once the global allowance is exhausted, subsequent
+/// classes get a `0` per-class budget → every pair takes the [`multiset_dice`] proxy and
+/// `lcs_sampled` latches, so a globally-degraded class is never reported as exact.
+///
+/// DETERMINISM: the per-class budget is a pure function of `*remaining_cells` at entry, and the
+/// classes are refined in a fixed provisional-ROI order, so the same input always truncates at the
+/// same class and the same pair — byte-identical output. With a generous (or default
+/// `LCS_AGGREGATE_CELLS_BUDGET`-sized) allowance this is byte-identical to [`class_lcs_ratio`].
+pub(crate) fn class_lcs_ratio_global(
+    seqs: &[Vec<String>],
+    remaining_cells: &mut u64,
+) -> (f64, bool) {
+    let per_class = LCS_AGGREGATE_CELLS_BUDGET.min(*remaining_cells);
+    let (ratio, sampled, cells_spent) = class_lcs_ratio_counted_with_cells(seqs, per_class);
+    *remaining_cells = remaining_cells.saturating_sub(cells_spent);
+    (ratio, sampled)
+}
+
 /// The body of [`class_lcs_ratio`], additionally returning how many pairs actually ran the exact
 /// O(n·m) DP (the rest took the [`multiset_dice`] proxy). The count is what the aggregate-budget
 /// test asserts is BOUNDED — it is otherwise an implementation detail, so the public wrapper drops
@@ -212,8 +235,22 @@ fn class_lcs_ratio_counted(seqs: &[Vec<String>]) -> (f64, bool, u64) {
 /// s). The cutover logic is byte-identical regardless of the budget value, so the fast test
 /// exercises the same code path as production.
 fn class_lcs_ratio_counted_with_budget(seqs: &[Vec<String>], budget: u64) -> (f64, bool, u64) {
+    let (ratio, sampled, pairs, _cells) = class_lcs_ratio_full(seqs, budget);
+    (ratio, sampled, pairs)
+}
+
+/// [`class_lcs_ratio_counted_with_budget`] but additionally returning the exact-DP CELLS charged
+/// (not just the pair count). The cross-class global driver ([`class_lcs_ratio_global`]) decrements
+/// its shared allowance by this so the WHOLE refine pass — not just each class — is cell-bounded.
+fn class_lcs_ratio_counted_with_cells(seqs: &[Vec<String>], budget: u64) -> (f64, bool, u64) {
+    let (ratio, sampled, _pairs, cells) = class_lcs_ratio_full(seqs, budget);
+    (ratio, sampled, cells)
+}
+
+/// Shared body: returns `(min_ratio, lcs_sampled, exact_dp_pairs, exact_dp_cells)`.
+fn class_lcs_ratio_full(seqs: &[Vec<String>], budget: u64) -> (f64, bool, u64, u64) {
     if seqs.len() < 2 {
-        return (1.0, false, 0);
+        return (1.0, false, 0, 0);
     }
 
     // Member-count cap: use at most LCS_MEMBER_SAMPLE members. The slice is already in canonical
@@ -272,7 +309,7 @@ fn class_lcs_ratio_counted_with_budget(seqs: &[Vec<String>], budget: u64) -> (f6
     // loop body (i=0, j=1) executes at least once and `min_ratio` is updated from `f64::INFINITY`.
     // The `f64::INFINITY` fallback is therefore unreachable — assert it in debug, return min_ratio.
     debug_assert!(min_ratio.is_finite(), "min_ratio must be set: effective.len() >= 2");
-    (min_ratio, lcs_sampled, exact_dp_pairs)
+    (min_ratio, lcs_sampled, exact_dp_pairs, exact_dp_cells)
 }
 
 #[cfg(test)]
@@ -610,6 +647,70 @@ mod tests {
         assert!(
             (ratio - expected).abs() < 1e-12,
             "small-class ratio unchanged by the budget: expected {expected}, got {ratio}"
+        );
+    }
+
+    /// #272 GLOBAL (cross-class) refine budget: a tiny shared allowance threaded across SEVERAL
+    /// classes caps the AGGREGATE exact-DP work of the WHOLE pass, not just each class. Once the
+    /// shared counter is drained, later classes get a `0` per-class budget → every pair takes the
+    /// proxy and `lcs_sampled` latches, so the global truncation is honest. This is the
+    /// fidelity-lane mechanism the driver (`find_clones`) threads through
+    /// `class_lcs_ratio_global`.
+    #[test]
+    fn class_lcs_ratio_global_budget_caps_aggregate_across_classes() {
+        // Each "class" is 4 members × 10 tokens → 6 pairs × 100 cells = 600 cells of exact DP if
+        // fully run. With a 250-cell GLOBAL allowance shared across THREE classes, only the first
+        // class can run any exact DP at all; by the time class 2 starts the counter is drained, so
+        // classes 2 and 3 are fully proxied (sampled) and charge nothing.
+        let mk_class = |salt: usize| -> Vec<Vec<String>> {
+            (0..4).map(|m| (0..10).map(|i| format!("c{salt}m{m}t{i}")).collect()).collect()
+        };
+        let classes = [mk_class(0), mk_class(1), mk_class(2)];
+
+        let mut remaining: u64 = 250;
+        let mut sampled_flags = Vec::new();
+        for seqs in &classes {
+            let (_ratio, sampled) = class_lcs_ratio_global(seqs, &mut remaining);
+            sampled_flags.push(sampled);
+        }
+
+        // The global allowance is fully drained (saturating_sub clamps at 0).
+        assert_eq!(remaining, 0, "the shared allowance must be fully consumed");
+        // Every class that ran out of allowance is sampled — the later classes are honestly
+        // degraded, never reported exact.
+        assert!(sampled_flags[0], "class 1 trips its share of the budget → sampled");
+        assert!(sampled_flags[1], "class 2 sees a drained allowance → fully proxied → sampled");
+        assert!(sampled_flags[2], "class 3 sees a drained allowance → fully proxied → sampled");
+    }
+
+    /// #272 UNDER-budget determinism: a GLOBAL run with a generous allowance is BYTE-IDENTICAL to
+    /// the per-class `class_lcs_ratio` path (same ratio, same not-sampled flag) — the global
+    /// counter only changes behavior PAST the allowance. This is the "under-budget runs stay
+    /// byte-identical" guarantee the #272 fix must preserve.
+    #[test]
+    fn class_lcs_ratio_global_under_budget_is_byte_identical() {
+        let a = strs(&["fn", "foo", "(", ")", "{", "x", "}"]);
+        let b = strs(&["fn", "bar", "(", ")", "{", "x", "}"]);
+        let c = a.clone();
+        let seqs = [a, b, c];
+
+        let (ratio_ref, sampled_ref) = class_lcs_ratio(&seqs);
+
+        // A generous global allowance → the per-class budget is the full lane const → identical.
+        let mut remaining: u64 = LCS_AGGREGATE_CELLS_BUDGET * 8;
+        let before = remaining;
+        let (ratio_global, sampled_global) = class_lcs_ratio_global(&seqs, &mut remaining);
+
+        assert_eq!(ratio_ref, ratio_global, "under-budget ratio must be byte-identical");
+        assert_eq!(sampled_ref, sampled_global, "under-budget sampled flag must match");
+        assert!(!sampled_global, "a small class under a generous global budget is not sampled");
+        assert!(
+            remaining < before,
+            "the global counter is decremented by the exact-DP cells spent"
+        );
+        assert!(
+            remaining > LCS_AGGREGATE_CELLS_BUDGET,
+            "a tiny exact-DP charge leaves the generous allowance largely intact"
         );
     }
 

--- a/crates/rag-rat-core/src/index/clones/refine/antiunify.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/antiunify.rs
@@ -513,6 +513,38 @@ pub(crate) fn anti_unify(members: &[RefineMember], alignment: &ClassAlignment) -
     anti_unify_with_budget(members, alignment, &mut budget)
 }
 
+/// Star-align + anti-unify the class drawing the WHOLE template lane (parent star-align + every
+/// matched-statement re-descent) from a SHARED CROSS-CLASS allowance (`*remaining_cells`), rather
+/// than a fresh per-class [`ALIGN_AGGREGATE_CELLS_BUDGET`]. The per-class cap is
+/// `min(ALIGN_AGGREGATE_CELLS_BUDGET, *remaining_cells)`, so the template lane stays bounded per
+/// class AND the whole `find_clones` refine pass is bounded by the global allowance. `*remaining`
+/// is decremented (`saturating_sub`) by the cells this class's whole anti-unify actually charged.
+///
+/// Returns the `(ClassAlignment, Template)` pair so the caller persists both. DETERMINISM + the
+/// `sampled` honesty chain are preserved exactly as the per-class budget path: the cutover is a
+/// pure function of `*remaining` at entry, consumed in deterministic member/statement order, and
+/// any budget-degraded member/statement latches `alignment.sampled` / `template.sampled`. With a
+/// generous (or `ALIGN_AGGREGATE_CELLS_BUDGET`-sized) allowance the output is byte-identical to the
+/// `align_to_anchor` + `anti_unify` pair.
+pub(crate) fn anti_unify_global(
+    members: &[RefineMember],
+    anchor_idx: usize,
+    remaining_cells: &mut u64,
+) -> (ClassAlignment, Template) {
+    let per_class = ALIGN_AGGREGATE_CELLS_BUDGET.min(*remaining_cells);
+    let mut budget = CellBudget::new(per_class);
+    let alignment = align_to_anchor_with_budget(members, anchor_idx, &mut budget);
+    // The same budget rides into the anti-unify: `spent` already carries the star-align charge, so
+    // the re-descent continues from where the parent left off (one per-class budget across both
+    // sub-lanes), exactly as `anti_unify` seeds itself from `alignment.spent_cells`.
+    let template = anti_unify_with_budget(members, &alignment, &mut budget);
+    // Decrement the shared allowance by everything this class charged. `spent` can exceed
+    // `per_class` by at most "one pair" (charge-then-check), but never the global remaining beyond
+    // saturation, so subsequent classes correctly see a smaller (or zero) allowance.
+    *remaining_cells = remaining_cells.saturating_sub(budget.spent);
+    (alignment, template)
+}
+
 /// [`anti_unify`] drawing from a CALLER-OWNED [`CellBudget`]. The budget bounds the exact
 /// `lcs_align` work the matched-statement re-descent ([`emit_matched_statement_redescent`]) adds:
 /// once it is exhausted, remaining matched statements are left whole-fixed (no further exact DP)

--- a/crates/rag-rat-core/src/index/clones/refine/cache.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/cache.rs
@@ -16,8 +16,8 @@
 
 use rusqlite::{Connection, OptionalExtension};
 
-use super::align::class_lcs_ratio;
-use super::antiunify::{align_to_anchor, anti_unify, resolve_anchor_idx};
+use super::align::{class_lcs_ratio, class_lcs_ratio_global};
+use super::antiunify::{align_to_anchor, anti_unify, anti_unify_global, resolve_anchor_idx};
 use super::score::{Confidence, confidence_v2, metavar_profile, refactorability_v2};
 use super::signature::propose_signature;
 use crate::index::clones::refine::RefineMember;
@@ -206,22 +206,63 @@ pub(crate) fn refine_compute_and_store(
     similarity_min: f64,
     medoid_symbol_id: Option<i64>,
 ) -> anyhow::Result<CachedRefinement> {
+    refine_compute_and_store_budgeted(
+        conn,
+        refinement_key,
+        language,
+        members,
+        similarity_min,
+        medoid_symbol_id,
+        None,
+    )
+}
+
+/// [`refine_compute_and_store`] with an OPTIONAL shared CROSS-CLASS cell allowance
+/// (`global_remaining`). When `Some`, both LCS lanes (fidelity + template) draw their per-class
+/// exact-DP budget from `min(<lane const>, *remaining)` and decrement the shared counter, so the
+/// WHOLE `find_clones` refine pass — not just each class — is cell-bounded (#272). When `None`,
+/// each lane gets a fresh full per-class budget (the pre-#272 behavior; used by
+/// `clones_for_symbol`, which refines exactly one class, and by direct callers/tests).
+///
+/// Only the COLD compute path charges the allowance; a warm `refine_lookup` hit never reaches here,
+/// so cached classes don't consume the global budget. DETERMINISM: the per-class budget is a pure
+/// function of `*remaining` at entry and the driver refines classes in a fixed provisional-ROI
+/// order, so the same input always truncates at the same class/pair — byte-identical output.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn refine_compute_and_store_budgeted(
+    conn: &Connection,
+    refinement_key: &str,
+    language: &str,
+    members: &[RefineMember],
+    similarity_min: f64,
+    medoid_symbol_id: Option<i64>,
+    mut global_remaining: Option<&mut u64>,
+) -> anyhow::Result<CachedRefinement> {
     // `lcs_ratio` stays the NiCad class fidelity (min pairwise 2·LCS/(|a|+|b|)) + its sampling bit.
     let seqs: Vec<Vec<String>> = members.iter().map(|m| m.seq.clone()).collect();
-    let (lcs_ratio, lcs_sampled) = class_lcs_ratio(&seqs);
+    let (lcs_ratio, lcs_sampled) = match global_remaining.as_deref_mut() {
+        Some(remaining) => class_lcs_ratio_global(&seqs, remaining),
+        None => class_lcs_ratio(&seqs),
+    };
 
     // ── Anti-unification (Plan 4b §1.1-§1.10): medoid-anchored star LCS → template + VPs
     // ──────────
     let anchor_idx = resolve_anchor_idx(members, medoid_symbol_id);
-    let alignment = align_to_anchor(members, anchor_idx);
     // The anti-unify alignment has its own cost guards (P1 + the aggregate cell budget): a member
-    // or anchor seq past `LCS_MAX_SEQ_TOKENS`, OR a member past the per-class
+    // or anchor seq past `LCS_MAX_SEQ_TOKENS`, OR a member past the (per-class OR global)
     // `ALIGN_AGGREGATE_CELLS_BUDGET`, is skipped/degraded rather than allocating/running the huge
     // DP. `alignment.sampled` covers the parent star-align; `template.sampled` (below) covers a
     // budget-degraded matched-statement re-descent. Fold BOTH into `lcs_sampled` so the persisted
     // sampling bit reflects the fidelity-metric cap AND the whole template lane — a
     // degraded/skipped template is never reported as exact.
-    let template = anti_unify(members, &alignment);
+    let (alignment, template) = match global_remaining {
+        Some(remaining) => anti_unify_global(members, anchor_idx, remaining),
+        None => {
+            let alignment = align_to_anchor(members, anchor_idx);
+            let template = anti_unify(members, &alignment);
+            (alignment, template)
+        },
+    };
     let lcs_sampled = lcs_sampled || alignment.sampled || template.sampled;
 
     // ── Proposed signature (Plan 4b §1.11) ───────────────────────────────────────────────────────

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -26,7 +26,7 @@ const METRIC_SAMPLE_CAP: usize = 200;
 use crate::index::IndexDatabase;
 use crate::index::clones::NORM_VERSION;
 use crate::index::clones::refine::cache::{
-    refine_compute_and_store, refine_lookup, refinement_key,
+    refine_compute_and_store_budgeted, refine_lookup, refinement_key,
 };
 use crate::index::clones::refine::split::coherence_split;
 
@@ -464,6 +464,22 @@ impl IndexDatabase {
         // the top-budget classes and returns all (with unrefined tail).
         const UNLIMITED_REFINE_BUDGET: usize = 50;
 
+        // GLOBAL (cross-class) refine cost budget (#272). The per-class
+        // `LCS_AGGREGATE_CELLS_BUDGET` / `ALIGN_AGGREGATE_CELLS_BUDGET` (~100M cells each)
+        // bound ONE class's exact-DP work, but 50 classes each near their per-class cap
+        // summed to ~48–52 s cold (paid TWICE under the RW busy-retry dispatcher). This
+        // shared allowance bounds the WHOLE refine pass: each cold class draws its
+        // per-class budget from `min(<lane const>, remaining)` and decrements the
+        // counter, so once it is exhausted later classes degrade-and-sample (their
+        // `metrics_sampled` latches) instead of running full exact DP. Warm cache hits
+        // never touch it (they bypass the compute path). DETERMINISM: classes refine in a
+        // fixed provisional-ROI order and each lane consumes deterministically, so the same
+        // input truncates at the same class/pair. The allowance is sized so an all-cold
+        // pass stays well under the MCP timeout; a single class can still spend up to its
+        // full per-class budget when the global counter is fresh.
+        const GLOBAL_REFINE_CELLS_BUDGET: u64 = 600_000_000;
+        let mut global_refine_cells: u64 = GLOBAL_REFINE_CELLS_BUDGET;
+
         let classes: Vec<CandidateCloneClass> = if let Some(limit) = opts.limit {
             // Limited result: truncate to min(limit, UNLIMITED_REFINE_BUDGET) so a huge `limit`
             // doesn't queue unbounded re-parse work. The all-refined-limited invariant (Fix 2
@@ -477,7 +493,13 @@ impl IndexDatabase {
             let effective_limit = limit.min(UNLIMITED_REFINE_BUDGET);
             built.truncate(effective_limit);
             for (class_ids, class) in built.iter_mut() {
-                self.refine_class_in_place(conn, class_ids, &by_id, class)?;
+                self.refine_class_in_place(
+                    conn,
+                    class_ids,
+                    &by_id,
+                    class,
+                    &mut global_refine_cells,
+                )?;
             }
             let mut cs: Vec<CandidateCloneClass> = built.into_iter().map(|(_, c)| c).collect();
             cs.sort_by(|a, b| b.roi.partial_cmp(&a.roi).unwrap_or(std::cmp::Ordering::Equal));
@@ -491,7 +513,13 @@ impl IndexDatabase {
                 if idx >= UNLIMITED_REFINE_BUDGET {
                     break;
                 }
-                self.refine_class_in_place(conn, class_ids, &by_id, class)?;
+                self.refine_class_in_place(
+                    conn,
+                    class_ids,
+                    &by_id,
+                    class,
+                    &mut global_refine_cells,
+                )?;
             }
             let mut cs: Vec<CandidateCloneClass> = built.into_iter().map(|(_, c)| c).collect();
             cs.sort_by(|a, b| b.roi.partial_cmp(&a.roi).unwrap_or(std::cmp::Ordering::Equal));
@@ -548,6 +576,10 @@ impl IndexDatabase {
         class_ids: &[i64],
         by_id: &BTreeMap<i64, &SymbolBag>,
         class: &mut CandidateCloneClass,
+        // SHARED cross-class cell allowance (#272): the cold compute path draws each lane's
+        // per-class budget from this and decrements it, so the WHOLE `find_clones` refine pass is
+        // cell-bounded. Warm cache hits return BEFORE the compute, so they never consume it.
+        global_refine_cells: &mut u64,
     ) -> anyhow::Result<()> {
         // ── Phase 0 (CHEAP, NO RE-PARSE): build the content-addressed key from each member's
         // persisted struct_hash already in `by_id` — no file I/O, no tree-sitter parse.
@@ -644,13 +676,14 @@ impl IndexDatabase {
 
         // Thread the bag-overlap medoid (Plan 4b §1.1) as the anti-unify spine anchor; the compute
         // half falls back to the canonical-first member when it is `None`.
-        let refinement = refine_compute_and_store(
+        let refinement = refine_compute_and_store_budgeted(
             conn,
             &key,
             &class.language,
             &members,
             class.similarity_min,
             class.medoid_symbol_id,
+            Some(global_refine_cells),
         )?;
         apply_refinement(class, refinement);
 
@@ -941,8 +974,19 @@ impl IndexDatabase {
             Some(subclass) => {
                 let mut built = build_class(&subclass, &by_id, conn, Some(symbol_id))?;
                 // Always refine the subject's one class when refine inputs are available.
+                // `clones_for_symbol` refines exactly ONE class, so it is not subject to the
+                // cross-class throttle (#272): seed a fresh full per-class allowance so its single
+                // class always gets the whole `min(<lane const>, remaining)` = the lane const,
+                // identical to the pre-#272 single-class behavior.
+                let mut single_class_cells: u64 = u64::MAX;
                 if let Some(c) = built.as_mut() {
-                    self.refine_class_in_place(conn, &subclass, &by_id, c)?;
+                    self.refine_class_in_place(
+                        conn,
+                        &subclass,
+                        &by_id,
+                        c,
+                        &mut single_class_cells,
+                    )?;
                 }
                 built
             },


### PR DESCRIPTION
Adds a GLOBAL (cross-class) refine cell budget — the aggregate analog of the existing per-class `LCS_AGGREGATE_CELLS_BUDGET` / `ALIGN_AGGREGATE_CELLS_BUDGET` (100M cells each). A shared `&mut u64` remaining-cells counter is threaded through both LCS lanes (`class_lcs_ratio_global` fidelity + `anti_unify_global` template), each drawing `min(lane_const, remaining)`; `find_clones` seeds `GLOBAL_REFINE_CELLS_BUDGET = 600_000_000` once. This bounds the worst case — 50 huge refined classes × 100M = ~5B cells (~50s+) — down to ~600M (~6s). `clones_for_symbol` (single class) seeds `u64::MAX`, so it's byte-identical to today.

### Invariants
- Both LCS lanes stay aggregate-cell-budgeted; the global counter only LOWERS each per-class cap.
- DETERMINISTIC: consumed in the existing member/class order → same truncation point → byte-identical output.
- HONEST: a budget-degraded class latches `sampled` → `lcs_sampled` → `metrics_sampled` (never reported exact).
- UNDER-BUDGET classes are byte-identical to today (pinned by `class_lcs_ratio_global_under_budget_is_byte_identical`); the cap-across-classes mechanism is pinned by `class_lcs_ratio_global_budget_caps_aggregate_across_classes`.

### Gated against the #279 measurement infra (cargo `src/cargo`)
- **Recall membership IDENTICAL** with the budget on vs off (`clones --recall-signature` byte-identical) — the budget degrades refine *quality* (more sampling), never which clones are found.
- Cold `find_clones`: ~167s (budget) vs ~171s (no budget) — it **barely binds (~2%)** here. That's expected and fine: cargo's top-50 refined classes don't aggregate past 600M, so the budget is near-inert. The value is the **worst-case bound** for a repo whose refined classes *do* blow past it (the #272 timeout scenario), where it can't hurt the normal case (byte-identical when inert).

**Honest finding (separate from this PR):** the gate revealed cargo's real cold-`find_clones` bottleneck is NOT refine — it's the giant over-merged component shattering into **87,397 classes** (the `coherence_split` budget-tripped 2-member cliques). That over-clustering, not refine cost, dominates the cold pass on cargo; worth its own look.

1024 workspace tests + clippy + nightly fmt green.

Fixes #272