### PR TITLE
perf(clones): parallelize candidate-gen (sub_block 3.8×) + uncapped --recall-symbols (#282 follow-ups)

### DIFF
--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -215,6 +215,14 @@ pub(crate) struct ClonesArgs {
     /// (ignores `--limit`).
     #[arg(long)]
     pub recall_signature: bool,
+    /// Print the SORTED, UNCAPPED set of clone-symbol refs (one `path::symbol` per line) — every
+    /// symbol that is in any coherent clone class. The SYMBOL-level recall signal for the #279
+    /// harness, and the one to use when a change alters clustering granularity: unlike
+    /// `--recall-signature` (class lines, capped at the per-class member limit), this counts every
+    /// member of every class, so `diff`-ing two builds catches a symbol that stopped being a clone
+    /// without false alarms from the member cap. Ignores `--limit`.
+    #[arg(long)]
+    pub recall_symbols: bool,
 }
 
 /// Selector for `clones-for`: positional `SYMBOL` (a qualified ref or `sym_<hex>` handle), or

--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -151,6 +151,16 @@ pub(crate) fn dream(config: &Config, args: &DreamArgs) -> anyhow::Result<()> {
 
 pub(crate) fn clones(config: &Config, args: &ClonesArgs) -> anyhow::Result<()> {
     let db = open_index(config)?;
+
+    // `--recall-symbols`: the UNCAPPED symbol-level recall set (#282 follow-up) — via the dedicated
+    // pipeline, NOT find_clones (whose per-class member list is capped). One ref per line, sorted.
+    if args.recall_symbols {
+        for r in db.clone_symbol_refs(args.min_similarity, args.min_copies)? {
+            println!("{r}");
+        }
+        return Ok(());
+    }
+
     let result = db.find_clones(rag_rat_core::index::FindClonesOptions {
         min_similarity: args.min_similarity,
         min_copies: args.min_copies,
@@ -1055,6 +1065,7 @@ mod tests {
             limit: None,
             explain: None,
             recall_signature: false,
+            recall_symbols: false,
         };
         // The handler must not error.
         super::clones(&config, &args).unwrap_or_else(|err| panic!("clones handler failed: {err}"));
@@ -1093,6 +1104,19 @@ mod tests {
             clone_line.find("src/a.rs") < clone_line.find("src/b.rs"),
             "member refs must be sorted within a class line: {clone_line}"
         );
+
+        // #282 follow-up: clone_symbol_refs is the UNCAPPED symbol-level recall set — the 3 planted
+        // clone-symbols, sorted, one per ref (no member cap).
+        let syms = db.clone_symbol_refs(None, Some(2)).unwrap();
+        for member in
+            ["src/a.rs::cloned_helper", "src/b.rs::cloned_helper", "src/lib.rs::cloned_helper"]
+        {
+            assert!(
+                syms.iter().any(|s| s == member),
+                "clone_symbol_refs missing {member}: {syms:?}"
+            );
+        }
+        assert!(syms.windows(2).all(|w| w[0] < w[1]), "clone_symbol_refs must be sorted+unique");
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -2041,10 +2041,15 @@ fn add_struct_hash_pairs(bags: &[SymbolBag], pairs: &mut std::collections::BTree
 ///
 /// Language partition: only same-language pairs are emitted — different languages have disjoint
 /// grammar token spaces, so a token-hash collision across languages is a false positive.
-fn sub_block_candidate_pairs(
-    bags: &[SymbolBag],
-    theta: f64,
-) -> std::collections::BTreeSet<(i64, i64)> {
+/// Returns the candidate pair set as a SORTED, deduplicated `Vec` (canonical `a < b`). The upper-
+/// triangle emission per posting list is the dominant candidate-gen cost (millions of pairs on a
+/// dense corpus — ~4.5M / ~11s release on cargo's `src/cargo`, vs ~0.5s to verify them), so it runs
+/// in PARALLEL: each posting list is independent, so `par_iter` over the inverted index emits each
+/// list's pairs across cores, then one `par_sort_unstable` + `dedup` canonicalizes the set.
+/// Deterministic: the sort+dedup is order-independent, so the result is byte-identical regardless
+/// of completion order (returns a sorted `Vec`, not a `BTreeSet`, to keep the merge parallel — a
+/// 4.5M-element `BTreeSet` build is sequential).
+fn sub_block_candidate_pairs(bags: &[SymbolBag], theta: f64) -> Vec<(i64, i64)> {
     // id → language for the partition guard applied at pair-emit time.
     let lang_of: BTreeMap<i64, &str> =
         bags.iter().map(|b| (b.symbol_id, b.language.as_str())).collect();
@@ -2056,18 +2061,23 @@ fn sub_block_candidate_pairs(
         }
     }
 
-    let mut candidate: std::collections::BTreeSet<(i64, i64)> = std::collections::BTreeSet::new();
-    for ids in inverted.values() {
-        for (i, &a) in ids.iter().enumerate() {
-            for &b in &ids[i + 1..] {
-                // Language partition: skip cross-language pairs.
-                if lang_of[&a] != lang_of[&b] {
-                    continue;
+    let mut candidate: Vec<(i64, i64)> = inverted
+        .par_iter()
+        .flat_map_iter(|(_token, ids)| {
+            let mut local: Vec<(i64, i64)> = Vec::new();
+            for (i, &a) in ids.iter().enumerate() {
+                for &b in &ids[i + 1..] {
+                    // Language partition: skip cross-language pairs.
+                    if lang_of[&a] == lang_of[&b] {
+                        local.push((a.min(b), a.max(b)));
+                    }
                 }
-                candidate.insert((a.min(b), a.max(b)));
             }
-        }
-    }
+            local
+        })
+        .collect();
+    candidate.par_sort_unstable();
+    candidate.dedup();
     candidate
 }
 

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -10,6 +10,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 use std::sync::Arc;
 
+use rayon::prelude::*;
 use rusqlite::{Connection, OptionalExtension};
 
 /// Pairwise metric work cap for huge components: when a component exceeds this count, the
@@ -335,6 +336,85 @@ impl IndexDatabase {
         let conn = self.storage.connection();
         let pairs = candidate_pairs(conn)?;
         Ok(components_from_pairs(&pairs))
+    }
+
+    /// The SORTED, UNCAPPED set of symbol refs (`path::name`) that are in ANY coherent clone class
+    /// (≥ `min_copies` members) over the active scope — the symbol-level recall signal for the #279
+    /// harness. `find_clones`'s per-class member list is capped at [`MAX_MEMBERS`], so the union of
+    /// its returned members UNDERCOUNTS symbols in large classes (the #282 covering-subset yields
+    /// 100+-member families); this counts EVERY member of every coherent class. Runs the SAME
+    /// candidate → component → `coherence_split` pipeline as `find_clones`, but collects the
+    /// uncapped member ids instead of building/refining/capping classes, then resolves them to
+    /// refs. Two builds' outputs diff with plain `diff`: a removed ref is a symbol that stopped
+    /// being a clone (a real recall regression) — unlike the class-level recall signature,
+    /// which legitimately changes when clustering granularity changes.
+    pub fn clone_symbol_refs(
+        &self,
+        min_similarity: Option<f64>,
+        min_copies: Option<usize>,
+    ) -> anyhow::Result<Vec<String>> {
+        let conn = self.storage.connection();
+        // Validate θ the same way `find_clones` does (see its doc): a ratio in [0.5, 1.0].
+        if let Some(v) = min_similarity
+            && (!v.is_finite() || !(0.5..=1.0).contains(&v))
+        {
+            anyhow::bail!("min_similarity must be in [0.5, 1.0]");
+        }
+        let bags = load_scoped_baseline_bags(conn)?;
+        let by_id: BTreeMap<i64, &SymbolBag> = bags.iter().map(|b| (b.symbol_id, b)).collect();
+        let theta = min_similarity.unwrap_or(THETA);
+        let min_copies = min_copies.unwrap_or(2);
+        let pairs = candidate_pairs_from_bags(&bags, theta);
+        let components = components_from_pairs(&pairs);
+        let edges_by_component = bucket_edges_by_component(&pairs, &components);
+
+        // Union of EVERY coherent class's uncapped member ids (mirrors find_clones's split loop).
+        let mut symbol_ids: BTreeSet<i64> = BTreeSet::new();
+        for (comp_idx, component) in components.iter().enumerate() {
+            if component.len() < min_copies {
+                continue;
+            }
+            let coherent_classes = coherence_split(
+                component,
+                &edges_by_component[comp_idx],
+                |a, b| {
+                    let ba = by_id[&a];
+                    let bb = by_id[&b];
+                    let max_len = ba.token_len.max(bb.token_len);
+                    if max_len == 0 { 1.0 } else { overlap(ba, bb) as f64 / max_len as f64 }
+                },
+                theta,
+            );
+            for class in &coherent_classes {
+                if class.len() >= min_copies {
+                    symbol_ids.extend(class.iter().copied());
+                }
+            }
+        }
+
+        // Resolve ids → qualified-name refs (`path::name`) via `name_strings` — the SAME source as
+        // `CloneMember.ref`. Chunked to respect SQLite's bound-parameter limit.
+        let ids: Vec<i64> = symbol_ids.into_iter().collect();
+        let mut refs: Vec<String> = Vec::with_capacity(ids.len());
+        for chunk in ids.chunks(HYDRATION_CHUNK) {
+            let placeholders: Vec<String> = (1..=chunk.len()).map(|i| format!("?{i}")).collect();
+            let sql = format!(
+                "SELECT ns.value FROM symbols
+                 JOIN name_strings ns ON ns.id = symbols.qualified_name_id
+                 WHERE symbols.id IN ({})",
+                placeholders.join(", ")
+            );
+            let mut stmt = conn.prepare(&sql)?;
+            let rows = stmt.query_map(rusqlite::params_from_iter(chunk.iter()), |row| {
+                row.get::<_, String>(0)
+            })?;
+            for r in rows {
+                refs.push(r?);
+            }
+        }
+        refs.sort_unstable();
+        refs.dedup();
+        Ok(refs)
     }
 }
 
@@ -1479,11 +1559,15 @@ fn candidate_pairs_from_bags(bags: &[SymbolBag], theta: f64) -> Vec<(i64, i64)> 
     add_struct_hash_pairs(bags, &mut pairs);
     let candidate = sub_block_candidate_pairs(bags, theta);
     let by_id: BTreeMap<i64, &SymbolBag> = bags.iter().map(|b| (b.symbol_id, b)).collect();
-    for (a, b) in candidate {
-        if verified_clone(by_id[&a], by_id[&b], theta) {
-            pairs.insert((a, b));
-        }
-    }
+    // Verify candidates in parallel: `verified_clone` is pure token math (no DB, no shared
+    // mutation; `by_id` is read-only), so the candidate set — the bulk of candidate-gen cost —
+    // fans out across cores. Output stays deterministic: the verified pairs land in the sorted
+    // `pairs` BTreeSet regardless of completion order.
+    let verified: Vec<(i64, i64)> = candidate
+        .into_par_iter()
+        .filter(|&(a, b)| verified_clone(by_id[&a], by_id[&b], theta))
+        .collect();
+    pairs.extend(verified);
     pairs.into_iter().collect()
 }
 
@@ -1837,14 +1921,16 @@ fn candidate_pairs(conn: &Connection) -> anyhow::Result<Vec<(i64, i64)>> {
     //    `find_clones` threads the caller's `min_similarity` through candidate generation.
     let candidate = sub_block_candidate_pairs(&bags, THETA);
 
-    // 3. Size prune + EXACT max-denominator verify over the FULL bags.
+    // 3. Size prune + EXACT max-denominator verify over the FULL bags — in parallel
+    //    (`verified_clone`
+    // is pure, `by_id` read-only). The sorted `pairs` BTreeSet keeps output deterministic
+    // regardless of completion order.
     let by_id: BTreeMap<i64, &SymbolBag> = bags.iter().map(|b| (b.symbol_id, b)).collect();
-    for (a, b) in candidate {
-        let (ba, bb) = (by_id[&a], by_id[&b]);
-        if verified_clone(ba, bb, THETA) {
-            pairs.insert((a, b));
-        }
-    }
+    let verified: Vec<(i64, i64)> = candidate
+        .into_par_iter()
+        .filter(|&(a, b)| verified_clone(by_id[&a], by_id[&b], THETA))
+        .collect();
+    pairs.extend(verified);
 
     Ok(pairs.into_iter().collect())
 }


### PR DESCRIPTION
The #282 follow-ups, all gated against the #279 infra. The headline is a **3.8× candidate-gen speedup** found by profiling.

## 1. Parallelize `sub_block_candidate_pairs` — the real candidate-gen bottleneck
Profiling the candidate-gen sub-phases (release, cargo `src/cargo`) showed the *verify* is NOT the bottleneck — it's the candidate-pair **emission**:

| phase | time |
|---|---|
| `load_scoped_baseline_bags` | 71ms |
| `struct_hash` | 1.7ms |
| **`sub_block_candidate_pairs`** | **~11s** (4.5M candidate pairs) ← bottleneck |
| verify (parallel) | 481ms (→ 92k verified) |

Each posting list's upper-triangle emission is independent, so emit in **parallel** (`par_iter` over the inverted index) into a Vec, then one `par_sort_unstable` + `dedup`. Returns a sorted `Vec` (not a `BTreeSet`) so the merge stays parallel — a 4.5M-element `BTreeSet` build is sequential. **Deterministic** (sort+dedup is order-independent; the determinism guards pass).

**Measured (release, 8 cores):** `candidate_components` **5.9s → 1.55s (3.8×)**; cold `find_clones` **18.9s → 15.3s** (refine, already bounded by #272, now dominates). **Recall identical** (`--recall-symbols` == 2,929, 0 lost/extra).

## 2. Parallelize the candidate verify
`candidate_pairs` / `candidate_pairs_from_bags` verify with rayon `par_iter`. Honest: this one is **inert on cargo** (verify is only 481ms — not the bottleneck), but it's a correct, deterministic "all cores" change that helps verify-heavy workloads and can't hurt. (Profiling it as inert is what pointed at #1.)

## 3. Uncapped `clones --recall-symbols`
New `IndexDatabase::clone_symbol_refs` → the **sorted, uncapped** set of clone-symbol refs (every symbol in any coherent class). Fixes the #279 harness gap the #282 gate exposed: `--recall-signature` lists only the first `MAX_MEMBERS=50` per class, so it undercounted (2,904 of the true 2,929 on cargo) once #282 produced 100+-member families. `--recall-symbols` recovers all 2,929 — the correct symbol-level recall gate when clustering granularity changes.

## Verification
1025 workspace tests (determinism guards + the planted-clone `clone_symbol_refs` assertion), clippy `--all-targets`, nightly fmt — green. Recall preserved (verified).

Refs #282