### PR TITLE
feat(clones): precompute the clone-edge graph in the background so find_clones scales (#286)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ The highest-leverage ones (full catalog + JSON schemas in [`docs/mcp-tools.md`](
 - **`important_symbols`** — load-bearing symbols by (SCIP-aware) PageRank; see
   [`docs/oracle.md`](docs/oracle.md).
 - **`repo_brief` / `repo_clusters`** — orientation: spine / churn / god-modules / ownership clusters.
+- **`find_clones` / `clones_for_symbol`** — exact + near-miss duplicate functions ranked by refactor
+  ROI; the candidate graph is precomputed in the background so it scales to large repos.
 - **`read_chunk`** — current text for a chunk with anchor validation.
 - Git/GitHub: `commit_search`, `git_history_for_path|symbol`, `git_blame_chunk`,
   `papertrail_for_*`, `rationale_search`.

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -223,6 +223,18 @@ pub(crate) struct ClonesArgs {
     /// without false alarms from the member cap. Ignores `--limit`.
     #[arg(long)]
     pub recall_symbols: bool,
+    /// Precompute + persist the clone-edge graph (a background-style writer pass), so subsequent
+    /// `find_clones` / `clones-for` queries read the persisted graph instead of recomputing the
+    /// super-linear candidate pairs every call — the way the graph scales to large repos (#286).
+    /// Runs to completion under a write lock; re-running on unchanged content is a no-op. Prints a
+    /// build report instead of the clone listing.
+    #[arg(long)]
+    pub precompute: bool,
+    /// Soft per-pass time budget (seconds) for `--precompute`; the build checkpoints and resumes,
+    /// so a bound leaves a partial graph that the next pass continues. Omit to run
+    /// uninterrupted.
+    #[arg(long, value_name = "SECONDS")]
+    pub max_seconds: Option<u64>,
 }
 
 /// Selector for `clones-for`: positional `SYMBOL` (a qualified ref or `sym_<hex>` handle), or

--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -953,6 +953,18 @@ fn run_maintenance_pass(
     // Prune index rows for git contexts that are no longer live (worktree-safe; keeps every
     // live worktree's HEAD). Cheap and bounded, so it runs every maintenance pass.
     let gc_report = db.garbage_collect().ok();
+    // Clone-edge graph (#286): refresh the persisted graph when absent/stale with whatever budget
+    // the embedding reconcile left (shared so the pass can't overrun), so the git-hook
+    // maintenance keeps the graph warm too — not just the foreground watcher. Best-effort +
+    // resumable across passes.
+    let clone_graph_report = if db.pending_clone_graph().unwrap_or(false) {
+        match budget.as_ref().and_then(rag_rat_core::watch::ReconcileBudget::next_options) {
+            Some(options) => db.reconcile_clone_edges_with_budget(options.max_seconds).ok(),
+            None => None,
+        }
+    } else {
+        None
+    };
     // Re-anchor repo memories: post-checkout/merge/rewrite/commit are exactly when files move,
     // rename, or change, so relocate symbol/chunk bindings (or flag them) here rather than
     // leaving stale anchors until a manual memory_validate.
@@ -967,6 +979,7 @@ fn run_maintenance_pass(
         "max_seconds": max_seconds,
         "elapsed_seconds": started.elapsed().as_secs_f64(),
         "reconcile": reconcile_report,
+        "clone_graph": clone_graph_report,
         "gc": gc_report,
         "memory_validation": memory_validation,
         "remaining_backlog": {

--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -150,6 +150,16 @@ pub(crate) fn dream(config: &Config, args: &DreamArgs) -> anyhow::Result<()> {
 }
 
 pub(crate) fn clones(config: &Config, args: &ClonesArgs) -> anyhow::Result<()> {
+    // `--precompute`: the WRITER path — build/refresh the persisted clone-edge graph (#286) under a
+    // write lock (mirroring `maintenance`), then print the build report instead of a clone listing.
+    if args.precompute {
+        let _lock = rag_rat_core::locks::WriteLock::acquire_blocking(&config.database)?;
+        let db = open_index(config)?;
+        let report: rag_rat_core::index::CloneEdgeReport =
+            db.precompute_clone_graph(args.max_seconds)?;
+        return print_output(&report);
+    }
+
     let db = open_index(config)?;
 
     // `--recall-symbols`: the UNCAPPED symbol-level recall set (#282 follow-up) — via the dedicated
@@ -1066,6 +1076,8 @@ mod tests {
             explain: None,
             recall_signature: false,
             recall_symbols: false,
+            precompute: false,
+            max_seconds: None,
         };
         // The handler must not error.
         super::clones(&config, &args).unwrap_or_else(|err| panic!("clones handler failed: {err}"));

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -49,7 +49,7 @@ pub(crate) use mem_diag::{maybe_set_sqlite_soft_heap_limit, mem_trace};
 pub use parser_failures::ParserFailure;
 pub(crate) use prep::*;
 pub use query_api::{
-    CandidateCloneClass, CloneCompleteness, CloneMember, CloneSymbolSelector,
+    CandidateCloneClass, CloneCompleteness, CloneEdgeReport, CloneMember, CloneSymbolSelector,
     ClonesForSymbolResult, FindClonesOptions, FindClonesResult, GcReport, ImportantSymbolsRequest,
     OracleShaSnapshots, RoiFactors, SearchRequest,
 };

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -371,7 +371,7 @@ impl IndexDatabase {
         let by_id: BTreeMap<i64, &SymbolBag> = bags.iter().map(|b| (b.symbol_id, b)).collect();
         let theta = min_similarity.unwrap_or(THETA);
         let min_copies = min_copies.unwrap_or(2);
-        let pairs = candidate_pairs_from_bags(&bags, theta);
+        let pairs = pairs_for_query(conn, &bags, theta)?;
         let components = components_from_pairs(&pairs);
         let edges_by_component = bucket_edges_by_component(&pairs, &components);
 
@@ -491,7 +491,7 @@ impl IndexDatabase {
         // actually widens the candidate set instead of being clamped by the const-θ sub-block /
         // verify, and a θ above [`THETA`] narrows it.
         let theta = opts.min_similarity.unwrap_or(THETA);
-        let pairs = candidate_pairs_from_bags(&bags, theta);
+        let pairs = pairs_for_query(conn, &bags, theta)?;
         let components = components_from_pairs(&pairs);
         // Bucket the θ-verified candidate pairs per component (#256): the coherence split seeds its
         // clique cover from these edges instead of an O(n²) all-pairs scan, so a giant component
@@ -998,7 +998,7 @@ impl IndexDatabase {
         }
 
         let by_id: BTreeMap<i64, &SymbolBag> = bags.iter().map(|b| (b.symbol_id, b)).collect();
-        let pairs = candidate_pairs_from_bags(&bags, THETA);
+        let pairs = pairs_for_query(conn, &bags, THETA)?;
         let components = components_from_pairs(&pairs);
 
         // Find the component that contains this symbol_id (with its index so we can pull its edge
@@ -1578,6 +1578,24 @@ fn candidate_pairs_from_bags(bags: &[SymbolBag], theta: f64) -> Vec<(i64, i64)> 
     pairs.into_iter().collect()
 }
 
+/// Candidate pairs for a query: the persisted clone-graph FAST PATH (#286) when one is eligible
+/// (present, fresh-enough, θ≥0.7, base scope), else the live [`candidate_pairs_from_bags`]
+/// recompute. The fast path is a pure optimization — it returns the SAME pair set the live path
+/// would (the parity test pins this), so every downstream stage (`components_from_pairs` →
+/// `coherence_split` → `build_class` → refine) is identical regardless of which source produced the
+/// pairs.
+fn pairs_for_query(
+    conn: &Connection,
+    bags: &[SymbolBag],
+    theta: f64,
+) -> anyhow::Result<Vec<(i64, i64)>> {
+    let by_id: BTreeMap<i64, &SymbolBag> = bags.iter().map(|b| (b.symbol_id, b)).collect();
+    if let Some(pairs) = precompute::precomputed_pairs_if_eligible(conn, &by_id, theta)? {
+        return Ok(pairs);
+    }
+    Ok(candidate_pairs_from_bags(bags, theta))
+}
+
 /// Build a [`CandidateCloneClass`] from a component (a slice of symbol ids). Returns `None` if
 /// any id is missing from `by_id` (shouldn't happen for a well-formed component derived from the
 /// same bag set), or if member hydration yields nothing (TOCTOU: fingerprint rows vanished
@@ -1916,30 +1934,11 @@ pub(crate) fn build_class(
 /// Combines the `struct_hash` exact fast path with the sub-block + exact-verify candidate read
 /// (design rev 4 §3b). Returns deduplicated `(a, b)` pairs with `a < b` for the union-find.
 fn candidate_pairs(conn: &Connection) -> anyhow::Result<Vec<(i64, i64)>> {
+    // `candidate_clone_components` keeps the const THETA; the persisted-graph fast path serves it
+    // when eligible, else the live SourcererCC recompute (struct-hash + sub-block@THETA + exact
+    // verify) runs in `candidate_pairs_from_bags`.
     let bags = load_scoped_baseline_bags(conn)?;
-
-    let mut pairs: std::collections::BTreeSet<(i64, i64)> = std::collections::BTreeSet::new();
-
-    // 1. Exact fast path: every same-struct_hash set contributes all its pairwise pairs.
-    add_struct_hash_pairs(&bags, &mut pairs);
-
-    // 2. Sub-block candidate pairs via the inverted index over sub-block tokens only.
-    //    `candidate_clone_components` keeps the const THETA (behavior unchanged) — only
-    //    `find_clones` threads the caller's `min_similarity` through candidate generation.
-    let candidate = sub_block_candidate_pairs(&bags, THETA);
-
-    // 3. Size prune + EXACT max-denominator verify over the FULL bags — in parallel
-    //    (`verified_clone`
-    // is pure, `by_id` read-only). The sorted `pairs` BTreeSet keeps output deterministic
-    // regardless of completion order.
-    let by_id: BTreeMap<i64, &SymbolBag> = bags.iter().map(|b| (b.symbol_id, b)).collect();
-    let verified: Vec<(i64, i64)> = candidate
-        .into_par_iter()
-        .filter(|&(a, b)| verified_clone(by_id[&a], by_id[&b], THETA))
-        .collect();
-    pairs.extend(verified);
-
-    Ok(pairs.into_iter().collect())
+    pairs_for_query(conn, &bags, THETA)
 }
 
 /// Load every scoped baseline symbol's fingerprint + full token bag with LEFT-JOINed df. Both the

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -13,6 +13,13 @@ use std::sync::Arc;
 use rayon::prelude::*;
 use rusqlite::{Connection, OptionalExtension};
 
+/// The background clone-edge-graph precompute (#286): the resumable, generation-staged build that
+/// persists `clone_edges`, plus (Phase C) the `find_clones` fast path that reads it. A child module
+/// so it can reuse this module's private candidate-gen primitives (`load_scoped_baseline_bags`,
+/// `sub_block_tokens`, `overlap`, `verified_clone`) — guaranteeing the persisted set equals the
+/// live `candidate_pairs_from_bags` set.
+pub(crate) mod precompute;
+
 /// Pairwise metric work cap for huge components: when a component exceeds this count, the
 /// O(n²) pairwise metric loop (`similarity_min`, medoid, `similarity_medoid_min`,
 /// `containment_max`) runs over ONLY the first `METRIC_SAMPLE_CAP` members instead of the full

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -14,7 +14,7 @@
 //! on `(path, start_byte, file_sha)` (the #248 rule — no `symbol_id` FK); reads resolve back to
 //! live symbols.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::time::{Duration, Instant};
 
 use rusqlite::{Connection, params};
@@ -325,42 +325,91 @@ pub(super) fn precomputed_pairs_if_eligible(
         return Ok(None);
     }
 
+    // Resolve each stored edge's content-anchored endpoints to LIVE symbol ids IN RAM. A per-edge
+    // 4-way SQL join (files×symbols, twice) is catastrophically slow at scale — measured SLOWER
+    // than a full live recompute on net/ipv4 (the whole point is to be faster). Instead build a
+    // `(path, start_byte) -> (symbol_id, live_sha)` index once from the scoped symbols, then look
+    // up each endpoint: a `file_sha` mismatch (file edited since the build) or a missing key
+    // (file deleted) drops the now-stale edge — the #248 read discipline, done in memory.
+    let by_anchor = build_anchor_index(conn)?;
+
     let mut stmt = conn.prepare(
-        "SELECT sa.id, sb.id, e.overlap, e.a_token_len, e.b_token_len
-           FROM clone_edges e
-           JOIN files fa   ON fa.path = e.a_path AND fa.sha256 = e.a_file_sha
-           JOIN symbols sa ON sa.file_id = fa.id AND sa.start_byte = e.a_start_byte
-           JOIN files fb   ON fb.path = e.b_path AND fb.sha256 = e.b_file_sha
-           JOIN symbols sb ON sb.file_id = fb.id AND sb.start_byte = e.b_start_byte
-          WHERE e.build_generation = ?1",
+        "SELECT a_path, a_start_byte, a_file_sha, b_path, b_start_byte, b_file_sha,
+                overlap, a_token_len, b_token_len
+           FROM clone_edges WHERE build_generation = ?1",
     )?;
     let rows = stmt.query_map(params![live.generation], |r| {
         Ok((
-            r.get::<_, i64>(0)?,
+            r.get::<_, String>(0)?,
             r.get::<_, i64>(1)?,
-            r.get::<_, i64>(2)?,
-            r.get::<_, i64>(3)?,
+            r.get::<_, String>(2)?,
+            r.get::<_, String>(3)?,
             r.get::<_, i64>(4)?,
+            r.get::<_, String>(5)?,
+            r.get::<_, i64>(6)?,
+            r.get::<_, i64>(7)?,
+            r.get::<_, i64>(8)?,
         ))
     })?;
 
     let mut pairs: Vec<(i64, i64)> = Vec::new();
     for row in rows {
-        let (a, b, overlap, a_token_len, b_token_len) = row?;
-        // Scope guard: keep only pairs whose BOTH resolved endpoints are in the active bag set (so
-        // a multi-worktree `files` row resolving to an out-of-scope symbol can't leak in).
-        if !by_id.contains_key(&a) || !by_id.contains_key(&b) {
+        let (
+            a_path,
+            a_start_byte,
+            a_file_sha,
+            b_path,
+            b_start_byte,
+            b_file_sha,
+            overlap,
+            a_len,
+            b_len,
+        ) = row?;
+        let Some((sa, live_sha_a)) = by_anchor.get(&(a_path, a_start_byte)) else { continue };
+        if *live_sha_a != a_file_sha {
+            continue; // endpoint's file edited since the build → stale edge drops
+        }
+        let Some((sb, live_sha_b)) = by_anchor.get(&(b_path, b_start_byte)) else { continue };
+        if *live_sha_b != b_file_sha {
             continue;
         }
-        let max_len = a_token_len.max(b_token_len);
-        let threshold = (theta * max_len as f64).ceil() as i64;
-        if overlap >= threshold {
-            pairs.push((a.min(b), a.max(b)));
+        let (sa, sb) = (*sa, *sb);
+        // Scope guard: both endpoints must be in the active bag set (a multi-worktree `files` row
+        // can't leak an out-of-scope symbol in).
+        if !by_id.contains_key(&sa) || !by_id.contains_key(&sb) {
+            continue;
+        }
+        let max_len = a_len.max(b_len);
+        if overlap >= (theta * max_len as f64).ceil() as i64 {
+            pairs.push((sa.min(sb), sa.max(sb)));
         }
     }
     pairs.sort_unstable();
     pairs.dedup();
     Ok(Some(pairs))
+}
+
+/// `(path, start_byte) -> (symbol_id, file_sha)` over the scoped non-generated symbols — the
+/// inverse of [`resolve_symbol_anchors`], used by the read fast path to resolve content-anchored
+/// edges in RAM (one scan + hash lookups) instead of a per-edge SQL join.
+fn build_anchor_index(conn: &Connection) -> anyhow::Result<HashMap<(String, i64), (i64, String)>> {
+    let mut stmt = conn.prepare(
+        "SELECT s.id, f.path, s.start_byte, f.sha256
+           FROM symbols s JOIN files f ON f.id = s.file_id
+          WHERE f.generated = 0",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            (r.get::<_, String>(1)?, r.get::<_, i64>(2)?),
+            (r.get::<_, i64>(0)?, r.get::<_, String>(3)?),
+        ))
+    })?;
+    let mut map: HashMap<(String, i64), (i64, String)> = HashMap::new();
+    for row in rows {
+        let (key, value) = row?;
+        map.insert(key, value);
+    }
+    Ok(map)
 }
 
 /// The `(struct_hash, language) -> [symbol_id]` buckets — the exact key `add_struct_hash_pairs`

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -293,6 +293,76 @@ impl IndexDatabase {
     }
 }
 
+/// The `find_clones` / `clones_for_symbol` READ fast path (Phase C): the verified candidate pairs
+/// for the active scope, read from the persisted graph instead of recomputed — when one is
+/// eligible. Returns `None` (→ caller falls back to the live `candidate_pairs_from_bags`) when:
+/// - `theta < CLONE_PRECOMPUTE_THETA` (the persisted θ=0.7 set is a SUPERSET of any θ≥0.7 set, but
+///   not of a wider θ<0.7 set), or
+/// - no `Complete` generation is published, or
+/// - the live generation was built under a different `NORM_VERSION`.
+///
+/// Otherwise it resolves every stored edge's content-anchored endpoints back to LIVE `symbol_id`s
+/// by joining `files`/`symbols` on `(path, start_byte)` AND `files.sha256 = *_file_sha` — so a
+/// deleted or edited endpoint does not resolve and its (now-stale) edge drops (the #248 read
+/// discipline). It then SCOPE-filters to pairs whose both endpoints are in the active `by_id` bag
+/// set, and θ-FILTERS with the exact `verified_clone` gate (`overlap >= ceil(theta * max_len)`) so
+/// θ>0.7 reproduces the live result precisely (struct-hash edges carry `similarity = 1.0` /
+/// `overlap = token_len`, so they survive every θ). A present-but-STALE generation
+/// (content_revision drifted) is still served — the "mildly stale OK" contract; per-edge staleness
+/// is dropped by the `file_sha` join.
+pub(super) fn precomputed_pairs_if_eligible(
+    conn: &Connection,
+    by_id: &BTreeMap<i64, &SymbolBag>,
+    theta: f64,
+) -> anyhow::Result<Option<Vec<(i64, i64)>>> {
+    if theta < CLONE_PRECOMPUTE_THETA {
+        return Ok(None);
+    }
+    let Some(live) = live_generation_row(conn)? else {
+        return Ok(None);
+    };
+    if live.normalizer_version != NORM_VERSION {
+        return Ok(None);
+    }
+
+    let mut stmt = conn.prepare(
+        "SELECT sa.id, sb.id, e.overlap, e.a_token_len, e.b_token_len
+           FROM clone_edges e
+           JOIN files fa   ON fa.path = e.a_path AND fa.sha256 = e.a_file_sha
+           JOIN symbols sa ON sa.file_id = fa.id AND sa.start_byte = e.a_start_byte
+           JOIN files fb   ON fb.path = e.b_path AND fb.sha256 = e.b_file_sha
+           JOIN symbols sb ON sb.file_id = fb.id AND sb.start_byte = e.b_start_byte
+          WHERE e.build_generation = ?1",
+    )?;
+    let rows = stmt.query_map(params![live.generation], |r| {
+        Ok((
+            r.get::<_, i64>(0)?,
+            r.get::<_, i64>(1)?,
+            r.get::<_, i64>(2)?,
+            r.get::<_, i64>(3)?,
+            r.get::<_, i64>(4)?,
+        ))
+    })?;
+
+    let mut pairs: Vec<(i64, i64)> = Vec::new();
+    for row in rows {
+        let (a, b, overlap, a_token_len, b_token_len) = row?;
+        // Scope guard: keep only pairs whose BOTH resolved endpoints are in the active bag set (so
+        // a multi-worktree `files` row resolving to an out-of-scope symbol can't leak in).
+        if !by_id.contains_key(&a) || !by_id.contains_key(&b) {
+            continue;
+        }
+        let max_len = a_token_len.max(b_token_len);
+        let threshold = (theta * max_len as f64).ceil() as i64;
+        if overlap >= threshold {
+            pairs.push((a.min(b), a.max(b)));
+        }
+    }
+    pairs.sort_unstable();
+    pairs.dedup();
+    Ok(Some(pairs))
+}
+
 /// The `(struct_hash, language) -> [symbol_id]` buckets — the exact key `add_struct_hash_pairs`
 /// uses, so the emitted struct-hash pairs match the live path.
 fn build_struct_hash_buckets(bags: &[SymbolBag]) -> BTreeMap<(&str, &str), Vec<i64>> {
@@ -656,5 +726,47 @@ mod tests {
             "the resumed (checkpointed) graph equals the single-pass graph — the smaller-endpoint \
              partition is correct across checkpoints"
         );
+    }
+
+    /// A stable, symbol-id-independent projection of a `find_clones` result: each class as its
+    /// sorted member refs, classes sorted. Equal projections ⇒ the same clone classes.
+    fn class_projection(result: &crate::index::FindClonesResult) -> Vec<Vec<String>> {
+        let mut classes: Vec<Vec<String>> = result
+            .classes
+            .iter()
+            .map(|c| {
+                let mut refs: Vec<String> = c.members.iter().map(|m| m.r#ref.clone()).collect();
+                refs.sort();
+                refs
+            })
+            .collect();
+        classes.sort();
+        classes
+    }
+
+    /// THE CORNERSTONE (#286 Phase C): `find_clones` served from the persisted graph is IDENTICAL
+    /// to `find_clones` recomputed live, at θ = 0.7 (the precompute floor) and above (where the
+    /// stored edges are θ-filtered). Proven on the same index: capture live first (no graph →
+    /// live path), precompute, capture again (graph present → fast path), assert equal. This is
+    /// what makes the fast path a pure optimization rather than a behavior change.
+    #[test]
+    fn find_clones_precomputed_matches_live() {
+        use crate::index::FindClonesOptions;
+
+        for theta in [0.7_f64, 0.8, 0.9] {
+            let db = build_clone_fixture(&format!("parity-{}", (theta * 100.0) as i64));
+            let opts =
+                || FindClonesOptions { min_similarity: Some(theta), min_copies: None, limit: None };
+
+            // No graph yet → live path.
+            let live = class_projection(&db.find_clones(opts()).unwrap());
+            assert!(!live.is_empty(), "renamed-clone fixture has classes at θ={theta}");
+
+            // Build the graph → subsequent find_clones takes the fast path.
+            assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
+            let fast = class_projection(&db.find_clones(opts()).unwrap());
+
+            assert_eq!(fast, live, "precomputed find_clones must equal live at θ={theta}");
+        }
     }
 }

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -108,12 +108,22 @@ impl IndexDatabase {
         }
     }
 
+    /// One budgeted clone-graph pass for the watcher / `maintenance` tail (#286): a single
+    /// resumable pass bounded by the remaining shared pass budget. A thin wrapper over
+    /// [`Self::reconcile_clone_edges_pass`] so those callers needn't name `CloneEdgeOptions`.
+    pub fn reconcile_clone_edges_with_budget(
+        &self,
+        max_seconds: Option<u64>,
+    ) -> anyhow::Result<CloneEdgeReport> {
+        self.reconcile_clone_edges_pass(&CloneEdgeOptions {
+            max_seconds,
+            ..CloneEdgeOptions::default()
+        })
+    }
+
     /// True when the precomputed graph is ABSENT or STALE vs the current content — the gate the
     /// watcher / maintenance pass uses to decide whether to spend budget on a recompute.
-    // Wired into the watcher/maintenance pass in Phase D (#286); built now so the gate ships with
-    // the pass it guards.
-    #[allow(dead_code)]
-    pub(crate) fn pending_clone_graph(&self) -> anyhow::Result<bool> {
+    pub fn pending_clone_graph(&self) -> anyhow::Result<bool> {
         let conn = self.storage.connection();
         let Some(live) = live_generation_row(conn)? else {
             return Ok(true); // no completed generation yet

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -1,0 +1,660 @@
+//! Background precompute of the clone-edge graph (#286): the resumable, generation-staged build
+//! that writes `clone_edges` so `find_clones` reads a persisted graph instead of recomputing the
+//! super-linear SourcererCC candidate pairs every query (it does not finish in 240s on a
+//! 118k-function index). The read side (the `find_clones` fast path) is Phase C.
+//!
+//! Generation-staged: each build writes a fresh `clone_graph_generations` row; reads serve the
+//! latest `Complete` generation (the `clone_graph_live_generation` meta key); the pointer flips
+//! atomically on completion so a half-built generation is never served. The build streams symbols
+//! in `symbol_id` order and emits each clone pair from its SMALLER endpoint exactly once (the
+//! SourcererCC structure), so it is chunkable + cursor-resumable under a `max_seconds` budget and
+//! dedup is structural. It reuses the EXACT candidate-gen primitives of the parent `clones` module
+//! (`sub_block_tokens`, `overlap`, `verified_clone`) so the persisted set equals the live
+//! `candidate_pairs_from_bags` set (the Phase-C parity test pins this). Edges are CONTENT-ANCHORED
+//! on `(path, start_byte, file_sha)` (the #248 rule — no `symbol_id` FK); reads resolve back to
+//! live symbols.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::{Duration, Instant};
+
+use rusqlite::{Connection, params};
+use serde::Serialize;
+
+use super::{
+    SymbolBag, THETA, load_scoped_baseline_bags, overlap, sub_block_tokens, verified_clone,
+};
+use crate::index::IndexDatabase;
+use crate::index::clones::NORM_VERSION;
+use crate::index::util::now_ms;
+
+/// θ the graph is precomputed at — the default `find_clones` threshold. Queries at θ ≥ this read
+/// the stored edges (filtering the exact gate inputs); θ below falls back to the live path.
+pub(crate) const CLONE_PRECOMPUTE_THETA: f64 = THETA;
+
+const DEFAULT_BATCH_SIZE: usize = 512;
+
+/// Soft per-pass budget + checkpoint granularity for one
+/// [`IndexDatabase::reconcile_clone_edges_pass`].
+#[derive(Debug, Clone)]
+pub struct CloneEdgeOptions {
+    /// Stop the pass once this many seconds elapse (after ≥1 batch, so progress is always made);
+    /// `None` runs the pass to completion.
+    pub max_seconds: Option<u64>,
+    pub batch_size: usize,
+    /// Rebuild even when the live generation already matches the current content.
+    pub force: bool,
+}
+
+impl Default for CloneEdgeOptions {
+    fn default() -> Self {
+        Self { max_seconds: None, batch_size: DEFAULT_BATCH_SIZE, force: false }
+    }
+}
+
+/// Outcome of a precompute pass (or loop). `status`: `Current` (skip — already fresh), `Complete`
+/// (the generation finished and is now live), or `Partial` (budget tripped mid-build; resume next).
+#[derive(Debug, Clone, Serialize)]
+pub struct CloneEdgeReport {
+    pub status: String,
+    pub generation: i64,
+    pub symbols_total: u64,
+    pub symbols_processed: u64,
+    pub edges_written: u64,
+    pub source_revision: String,
+    pub elapsed_ms: u64,
+}
+
+/// Reindex-stable identity of a symbol endpoint: `(path, start_byte, file_sha)`.
+type Anchor = (String, i64, String);
+
+struct EdgeRow {
+    a_path: String,
+    a_start_byte: i64,
+    a_file_sha: String,
+    b_path: String,
+    b_start_byte: i64,
+    b_file_sha: String,
+    overlap: i64,
+    a_token_len: i64,
+    b_token_len: i64,
+    similarity: f64,
+    edge_source: &'static str,
+}
+
+struct GenerationRow {
+    generation: i64,
+    source_revision: String,
+    normalizer_version: i64,
+    cursor_symbol_id: i64,
+    edges_written: u64,
+}
+
+impl IndexDatabase {
+    /// Precompute the clone-edge graph to completion under the caller's write lock (loops resumable
+    /// passes until the generation is `Complete` or already `Current`). `max_seconds` bounds a
+    /// SINGLE pass (checkpoint granularity); the loop still runs to completion.
+    pub fn precompute_clone_graph(
+        &self,
+        max_seconds: Option<u64>,
+    ) -> anyhow::Result<CloneEdgeReport> {
+        loop {
+            let report = self.reconcile_clone_edges_pass(&CloneEdgeOptions {
+                max_seconds,
+                ..CloneEdgeOptions::default()
+            })?;
+            if report.status != "Partial" {
+                return Ok(report);
+            }
+        }
+    }
+
+    /// True when the precomputed graph is ABSENT or STALE vs the current content — the gate the
+    /// watcher / maintenance pass uses to decide whether to spend budget on a recompute.
+    // Wired into the watcher/maintenance pass in Phase D (#286); built now so the gate ships with
+    // the pass it guards.
+    #[allow(dead_code)]
+    pub(crate) fn pending_clone_graph(&self) -> anyhow::Result<bool> {
+        let conn = self.storage.connection();
+        let Some(live) = live_generation_row(conn)? else {
+            return Ok(true); // no completed generation yet
+        };
+        Ok(live.source_revision != self.content_revision()?
+            || live.normalizer_version != NORM_VERSION)
+    }
+
+    /// ONE precompute pass: resume (or start) the building generation toward the current content
+    /// revision, stream symbols from the resume cursor emitting verified clone edges, checkpoint
+    /// per batch, and — if the walk finishes within budget — publish the generation as live.
+    /// Mirrors the embedding `reconcile` pass shape (skip-when-current, budgeted batch loop,
+    /// `Partial`/`Complete`).
+    pub(crate) fn reconcile_clone_edges_pass(
+        &self,
+        options: &CloneEdgeOptions,
+    ) -> anyhow::Result<CloneEdgeReport> {
+        let started = Instant::now();
+        let conn = self.storage.connection();
+        let source_revision = self.content_revision()?;
+
+        // Phase 0 — skip-when-current: a live generation built against the current revision +
+        // normalizer is already fresh, so do nothing (no write lock churn on an idle repo).
+        if !options.force
+            && let Some(live) = live_generation_row(conn)?
+            && live.source_revision == source_revision
+            && live.normalizer_version == NORM_VERSION
+        {
+            return Ok(CloneEdgeReport {
+                status: "Current".to_string(),
+                generation: live.generation,
+                symbols_total: 0,
+                symbols_processed: 0,
+                edges_written: live.edges_written,
+                source_revision,
+                elapsed_ms: started.elapsed().as_millis() as u64,
+            });
+        }
+
+        // Phase 1 — open or resume a Building generation toward THIS revision. A Building
+        // generation toward a different revision (a reindex landed since it started) is
+        // discarded — its symbol-id cursor is meaningless against the new symbol rows.
+        let building = open_building_generation(conn, &source_revision)?;
+
+        // Load the scoped baseline bags + the content anchors for every scoped symbol, and build
+        // the struct-hash buckets + sub-block inverted index in RAM (rebuilt each pass —
+        // cheap relative to the pair emission this avoids persisting postings for).
+        let bags = load_scoped_baseline_bags(conn)?;
+        let symbols_total = bags.len() as u64;
+        let by_id: BTreeMap<i64, &SymbolBag> = bags.iter().map(|b| (b.symbol_id, b)).collect();
+        let anchors = resolve_symbol_anchors(conn)?;
+        let struct_buckets = build_struct_hash_buckets(&bags);
+        let inverted = build_sub_block_index(&bags, CLONE_PRECOMPUTE_THETA);
+
+        let deadline = options.max_seconds.map(|s| started + Duration::from_secs(s));
+        let mut cursor = building.cursor_symbol_id;
+        let mut edges_written = building.edges_written;
+        let mut processed: u64 = 0;
+        let mut batch: Vec<EdgeRow> = Vec::with_capacity(options.batch_size);
+        let mut budget_tripped = false;
+
+        for bag in bags.iter().filter(|b| b.symbol_id > building.cursor_symbol_id) {
+            let s = bag.symbol_id;
+            let Some(s_anchor) = anchors.get(&s) else { continue }; // unscoped/raced symbol — skip
+
+            // Struct-hash exact partners (t > s, same (struct_hash, language)) — similarity 1.0, no
+            // verify.
+            let mut struct_partners: BTreeSet<i64> = BTreeSet::new();
+            if let Some(ids) =
+                struct_buckets.get(&(bag.struct_hash.as_str(), bag.language.as_str()))
+            {
+                for &t in ids {
+                    if t > s
+                        && let Some(t_anchor) = anchors.get(&t)
+                    {
+                        struct_partners.insert(t);
+                        batch.push(make_edge(
+                            s_anchor,
+                            bag.token_len,
+                            t_anchor,
+                            by_id[&t].token_len,
+                            bag.token_len,
+                            1.0,
+                            "struct_hash",
+                        ));
+                    }
+                }
+            }
+
+            // Sub-block candidates (t > s, same language, sharing a sub-block token) — verified. A
+            // pair already emitted as a struct-hash exact pair is skipped (it would
+            // re-verify to sim 1.0).
+            let mut candidates: BTreeSet<i64> = BTreeSet::new();
+            for token in sub_block_tokens(bag, CLONE_PRECOMPUTE_THETA) {
+                if let Some(ids) = inverted.get(&token) {
+                    for &t in ids {
+                        if t > s
+                            && !struct_partners.contains(&t)
+                            && by_id[&t].language == bag.language
+                        {
+                            candidates.insert(t);
+                        }
+                    }
+                }
+            }
+            for t in candidates {
+                let Some(t_anchor) = anchors.get(&t) else { continue };
+                let other = by_id[&t];
+                if verified_clone(bag, other, CLONE_PRECOMPUTE_THETA) {
+                    let ov = overlap(bag, other);
+                    let max_len = bag.token_len.max(other.token_len);
+                    let sim = ov as f64 / max_len as f64;
+                    batch.push(make_edge(
+                        s_anchor,
+                        bag.token_len,
+                        t_anchor,
+                        other.token_len,
+                        ov,
+                        sim,
+                        "sub_block",
+                    ));
+                }
+            }
+
+            processed += 1;
+            cursor = s;
+
+            if batch.len() >= options.batch_size {
+                edges_written +=
+                    flush_batch(conn, building.generation, &mut batch, cursor, edges_written)?;
+                if let Some(dl) = deadline
+                    && Instant::now() >= dl
+                {
+                    budget_tripped = true;
+                    break;
+                }
+            }
+        }
+        // Flush the remainder + checkpoint the final cursor for this pass.
+        edges_written += flush_batch(conn, building.generation, &mut batch, cursor, edges_written)?;
+
+        let status = if budget_tripped {
+            "Partial"
+        } else {
+            // The walk reached the last symbol: publish this generation as live, GC the rest.
+            self.complete_generation(building.generation, edges_written)?;
+            "Complete"
+        };
+
+        Ok(CloneEdgeReport {
+            status: status.to_string(),
+            generation: building.generation,
+            symbols_total,
+            symbols_processed: processed,
+            edges_written,
+            source_revision,
+            elapsed_ms: started.elapsed().as_millis() as u64,
+        })
+    }
+
+    /// Mark a generation `Complete`, flip the live pointer to it (the atomic publish), and GC every
+    /// other generation (CASCADE drops their edges). The `set_meta` flip is the last write, so a
+    /// reader sees either the previous live generation or this one, never a half-built one.
+    fn complete_generation(&self, generation: i64, edges_written: u64) -> anyhow::Result<()> {
+        let conn = self.storage.connection();
+        conn.execute(
+            "UPDATE clone_graph_generations
+                SET status = 'Complete', finished_at_ms = ?1, edges_written = ?2
+              WHERE generation = ?3",
+            params![now_ms(), edges_written as i64, generation],
+        )?;
+        self.set_meta("clone_graph_live_generation", &generation.to_string())?;
+        conn.execute("DELETE FROM clone_graph_generations WHERE generation != ?1", params![
+            generation
+        ])?;
+        Ok(())
+    }
+}
+
+/// The `(struct_hash, language) -> [symbol_id]` buckets — the exact key `add_struct_hash_pairs`
+/// uses, so the emitted struct-hash pairs match the live path.
+fn build_struct_hash_buckets(bags: &[SymbolBag]) -> BTreeMap<(&str, &str), Vec<i64>> {
+    let mut buckets: BTreeMap<(&str, &str), Vec<i64>> = BTreeMap::new();
+    for bag in bags {
+        buckets
+            .entry((bag.struct_hash.as_str(), bag.language.as_str()))
+            .or_default()
+            .push(bag.symbol_id);
+    }
+    buckets
+}
+
+/// The `token_hash -> [symbol_id]` inverted index over sub-block tokens — the same index
+/// `sub_block_candidate_pairs` builds, so a symbol's candidates match the live path.
+fn build_sub_block_index(bags: &[SymbolBag], theta: f64) -> BTreeMap<i64, Vec<i64>> {
+    let mut inverted: BTreeMap<i64, Vec<i64>> = BTreeMap::new();
+    for bag in bags {
+        for token_hash in sub_block_tokens(bag, theta) {
+            inverted.entry(token_hash).or_default().push(bag.symbol_id);
+        }
+    }
+    inverted
+}
+
+/// Resolve every scoped, non-generated symbol to its reindex-stable content anchor `(path,
+/// start_byte, file_sha)`. Mirrors `load_scoped_baseline_bags`'s `symbols JOIN files` + `generated
+/// = 0` scope so the anchor set covers exactly the bag symbols.
+fn resolve_symbol_anchors(conn: &Connection) -> anyhow::Result<BTreeMap<i64, Anchor>> {
+    let mut stmt = conn.prepare(
+        "SELECT s.id, f.path, s.start_byte, f.sha256
+           FROM symbols s
+           JOIN files f ON f.id = s.file_id
+          WHERE f.generated = 0",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, i64>(0)?,
+            (row.get::<_, String>(1)?, row.get::<_, i64>(2)?, row.get::<_, String>(3)?),
+        ))
+    })?;
+    let mut map = BTreeMap::new();
+    for row in rows {
+        let (id, anchor) = row?;
+        map.insert(id, anchor);
+    }
+    Ok(map)
+}
+
+/// Build a content-anchored edge with endpoints in canonical `(path, start_byte)` order (the PK
+/// order). `overlap`/`similarity` are symmetric; the per-endpoint `token_len`s follow the chosen
+/// orientation.
+fn make_edge(
+    s_anchor: &Anchor,
+    s_token_len: i64,
+    t_anchor: &Anchor,
+    t_token_len: i64,
+    overlap: i64,
+    similarity: f64,
+    edge_source: &'static str,
+) -> EdgeRow {
+    let s_key = (s_anchor.0.as_str(), s_anchor.1);
+    let t_key = (t_anchor.0.as_str(), t_anchor.1);
+    let ((a, a_len), (b, b_len)) = if s_key <= t_key {
+        ((s_anchor, s_token_len), (t_anchor, t_token_len))
+    } else {
+        ((t_anchor, t_token_len), (s_anchor, s_token_len))
+    };
+    EdgeRow {
+        a_path: a.0.clone(),
+        a_start_byte: a.1,
+        a_file_sha: a.2.clone(),
+        b_path: b.0.clone(),
+        b_start_byte: b.1,
+        b_file_sha: b.2.clone(),
+        overlap,
+        a_token_len: a_len,
+        b_token_len: b_len,
+        similarity,
+        edge_source,
+    }
+}
+
+/// Insert a batch of edges (idempotent under resume via `INSERT OR IGNORE` on the content-key PK)
+/// and checkpoint the generation's cursor + edge count, in one transaction. Returns the rows
+/// actually inserted (dedup-ignored rows don't count).
+fn flush_batch(
+    conn: &Connection,
+    generation: i64,
+    batch: &mut Vec<EdgeRow>,
+    cursor: i64,
+    cumulative_edges: u64,
+) -> anyhow::Result<u64> {
+    conn.execute_batch("BEGIN IMMEDIATE")?;
+    let result = (|| -> anyhow::Result<u64> {
+        let mut inserted = 0u64;
+        {
+            let mut stmt = conn.prepare_cached(
+                "INSERT OR IGNORE INTO clone_edges
+                    (build_generation, a_path, a_start_byte, a_file_sha, b_path, b_start_byte,
+                     b_file_sha, overlap, a_token_len, b_token_len, similarity, edge_source)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            )?;
+            for e in batch.iter() {
+                inserted += stmt.execute(params![
+                    generation,
+                    e.a_path,
+                    e.a_start_byte,
+                    e.a_file_sha,
+                    e.b_path,
+                    e.b_start_byte,
+                    e.b_file_sha,
+                    e.overlap,
+                    e.a_token_len,
+                    e.b_token_len,
+                    e.similarity,
+                    e.edge_source,
+                ])? as u64;
+            }
+        }
+        conn.execute(
+            "UPDATE clone_graph_generations SET cursor_symbol_id = ?1, edges_written = ?2
+              WHERE generation = ?3",
+            params![cursor, (cumulative_edges + inserted) as i64, generation],
+        )?;
+        Ok(inserted)
+    })();
+    match result {
+        Ok(inserted) => {
+            conn.execute_batch("COMMIT")?;
+            batch.clear();
+            Ok(inserted)
+        },
+        Err(err) => {
+            let _ = conn.execute_batch("ROLLBACK");
+            Err(err)
+        },
+    }
+}
+
+/// The live (Complete) generation row, if one is published.
+fn live_generation_row(conn: &Connection) -> anyhow::Result<Option<GenerationRow>> {
+    let Some(live) = read_meta(conn, "clone_graph_live_generation")? else {
+        return Ok(None);
+    };
+    let Ok(generation) = live.parse::<i64>() else {
+        return Ok(None);
+    };
+    read_generation(conn, generation)
+}
+
+/// Open the Building generation toward `source_revision`: resume it if it already targets this
+/// revision + normalizer, otherwise discard any stale Building generation and allocate a fresh one.
+fn open_building_generation(
+    conn: &Connection,
+    source_revision: &str,
+) -> anyhow::Result<GenerationRow> {
+    let existing: Option<GenerationRow> = conn
+        .query_row(
+            "SELECT generation, source_revision, normalizer_version, cursor_symbol_id, \
+             edges_written
+               FROM clone_graph_generations WHERE status = 'Building'
+              ORDER BY generation DESC LIMIT 1",
+            [],
+            map_generation_row,
+        )
+        .ok();
+    if let Some(row) = existing {
+        if row.source_revision == source_revision && row.normalizer_version == NORM_VERSION {
+            return Ok(row);
+        }
+        // Stale partial (a reindex landed): discard it (CASCADE drops its edges) and start over.
+        conn.execute("DELETE FROM clone_graph_generations WHERE status = 'Building'", [])?;
+    }
+    let generation: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(generation), 0) + 1 FROM clone_graph_generations",
+        [],
+        |r| r.get(0),
+    )?;
+    conn.execute(
+        "INSERT INTO clone_graph_generations
+            (generation, status, theta_floor, normalizer_kind, normalizer_version, source_revision,
+             cursor_symbol_id, edges_written, started_at_ms)
+         VALUES (?1, 'Building', ?2, 'baseline', ?3, ?4, 0, 0, ?5)",
+        params![generation, CLONE_PRECOMPUTE_THETA, NORM_VERSION, source_revision, now_ms()],
+    )?;
+    Ok(GenerationRow {
+        generation,
+        source_revision: source_revision.to_string(),
+        normalizer_version: NORM_VERSION,
+        cursor_symbol_id: 0,
+        edges_written: 0,
+    })
+}
+
+fn read_generation(conn: &Connection, generation: i64) -> anyhow::Result<Option<GenerationRow>> {
+    Ok(conn
+        .query_row(
+            "SELECT generation, source_revision, normalizer_version, cursor_symbol_id, \
+             edges_written
+               FROM clone_graph_generations WHERE generation = ?1",
+            params![generation],
+            map_generation_row,
+        )
+        .ok())
+}
+
+fn map_generation_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<GenerationRow> {
+    Ok(GenerationRow {
+        generation: row.get(0)?,
+        source_revision: row.get(1)?,
+        normalizer_version: row.get(2)?,
+        cursor_symbol_id: row.get(3)?,
+        edges_written: row.get::<_, i64>(4)? as u64,
+    })
+}
+
+fn read_meta(conn: &Connection, key: &str) -> anyhow::Result<Option<String>> {
+    Ok(conn
+        .query_row("SELECT value FROM index_meta WHERE key = ?1", params![key], |r| {
+            r.get::<_, String>(0)
+        })
+        .ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A fixed two-file fixture with two renamed-clone groups (load_user/load_order +
+    /// compute_totals/tally_amounts). Identical file CONTENT across tags → identical content-key
+    /// edges, so two builds are directly comparable.
+    fn build_clone_fixture(tag: &str) -> crate::IndexDatabase {
+        let root = std::env::temp_dir().join(format!(
+            "rag-rat-precompute-{tag}-{}-{}",
+            std::process::id(),
+            now_ms()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(
+            root.join("src/a.rs"),
+            "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\npub fn \
+             compute_totals(items: Vec<i64>) -> i64 { let mut s = 0; for it in items { s += it * \
+             2; } s + 1 }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("src/b.rs"),
+            "pub fn load_order(store: Db) -> i32 { let o = store.get(20); validate(o); o + 1 \
+             }\npub fn tally_amounts(values: Vec<i64>) -> i64 { let mut t = 0; for v in values { \
+             t += v * 2; } t + 1 }\n",
+        )
+        .unwrap();
+        let config = crate::Config {
+            root: root.clone(),
+            database: root.join(".rag-rat/index.sqlite"),
+            targets: vec![crate::config::ResolvedTarget {
+                name: "rust".to_string(),
+                language: crate::language::Language::Rust,
+                directories: vec![std::path::PathBuf::from("src")],
+                include: vec!["src/".to_string()],
+                exclude: Vec::new(),
+                kind: crate::config::TargetKind::Source,
+            }],
+            local_ai: Default::default(),
+            watch: Default::default(),
+            version_check: Default::default(),
+            oracle: Default::default(),
+        };
+        crate::IndexDatabase::rebuild(&config).unwrap()
+    }
+
+    /// The content-key set of the live-or-only generation's edges, sorted — the build-stable
+    /// identity of the persisted graph (symbol_id-independent).
+    fn edge_keys(db: &crate::IndexDatabase) -> Vec<(String, i64, String, i64)> {
+        let conn = db.storage.connection();
+        let mut stmt = conn
+            .prepare(
+                "SELECT a_path, a_start_byte, b_path, b_start_byte FROM clone_edges
+                 ORDER BY a_path, a_start_byte, b_path, b_start_byte",
+            )
+            .unwrap();
+        stmt.query_map([], |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, i64>(1)?,
+                r.get::<_, String>(2)?,
+                r.get::<_, i64>(3)?,
+            ))
+        })
+        .unwrap()
+        .map(Result::unwrap)
+        .collect()
+    }
+
+    #[test]
+    fn precompute_writes_graph_and_skips_when_current() {
+        let db = build_clone_fixture("write");
+        let report = db.precompute_clone_graph(None).unwrap();
+        assert_eq!(report.status, "Complete", "fresh precompute completes");
+        assert!(!edge_keys(&db).is_empty(), "renamed-clone fixture writes edges");
+
+        let conn = db.storage.connection();
+        let live: i64 = conn
+            .query_row(
+                "SELECT CAST(value AS INTEGER) FROM index_meta WHERE key = \
+                 'clone_graph_live_generation'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let status: String = conn
+            .query_row(
+                "SELECT status FROM clone_graph_generations WHERE generation = ?1",
+                [live],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(status, "Complete", "the live generation is Complete");
+
+        // Re-running on unchanged content is a skip-when-current no-op (no new generation).
+        let again = db.precompute_clone_graph(None).unwrap();
+        assert_eq!(again.status, "Current");
+        let generations: i64 = conn
+            .query_row("SELECT COUNT(*) FROM clone_graph_generations", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(generations, 1, "skip-when-current adds no generation");
+    }
+
+    #[test]
+    fn precompute_resume_matches_single_pass() {
+        // Reference: one uninterrupted pass.
+        let single = build_clone_fixture("single");
+        single.precompute_clone_graph(None).unwrap();
+        let expected = edge_keys(&single);
+        assert!(!expected.is_empty());
+
+        // Resumed: a per-symbol budget that trips after every batch forces many resumable passes.
+        let resumed = build_clone_fixture("resume");
+        let mut passes = 0;
+        loop {
+            let report = resumed
+                .reconcile_clone_edges_pass(&CloneEdgeOptions {
+                    max_seconds: Some(0),
+                    batch_size: 1,
+                    force: false,
+                })
+                .unwrap();
+            passes += 1;
+            assert!(passes < 10_000, "must converge");
+            if report.status != "Partial" {
+                assert_eq!(report.status, "Complete");
+                break;
+            }
+        }
+        assert!(passes >= 2, "a tiny budget forces multiple resumable passes, got {passes}");
+        assert_eq!(
+            edge_keys(&resumed),
+            expected,
+            "the resumed (checkpointed) graph equals the single-pass graph — the smaller-endpoint \
+             partition is correct across checkpoints"
+        );
+    }
+}

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -21,6 +21,7 @@ mod search;
 // the capped-class semantics by name (instead of hardcoding 50). Keeps the `clones` module
 // private so `build_class`'s reachability stays narrow (no `private_interfaces` widening of
 // `SymbolBag`).
+pub use clones::precompute::CloneEdgeReport;
 pub use clones::{
     CandidateCloneClass, CloneCompleteness, CloneMember, CloneSymbolSelector,
     ClonesForSymbolResult, FindClonesOptions, FindClonesResult, RoiFactors,

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1168,6 +1168,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_031_ID => Some(31),
             MIGRATION_032_ID => Some(32),
             MIGRATION_033_ID => Some(33),
+            MIGRATION_034_ID => Some(34),
             _ => None,
         })
         .max()
@@ -1210,6 +1211,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_031_ID
             | MIGRATION_032_ID
             | MIGRATION_033_ID
+            | MIGRATION_034_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1249,6 +1251,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_031_ID => migration.checksum != MIGRATION_031_CHECKSUM,
         MIGRATION_032_ID => migration.checksum != MIGRATION_032_CHECKSUM,
         MIGRATION_033_ID => migration.checksum != MIGRATION_033_CHECKSUM,
+        MIGRATION_034_ID => migration.checksum != MIGRATION_034_CHECKSUM,
         _ => false,
     }
 }
@@ -1410,6 +1413,83 @@ pub(crate) const CLONE_FINGERPRINT_DDL: &str = "
 /// require parsing the entire repo inside a migration.
 pub(crate) fn apply_clone_fingerprint_tables(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(CLONE_FINGERPRINT_DDL)?;
+    Ok(())
+}
+
+/// V034: the precomputed clone-edge graph, so `find_clones` reads a persisted graph instead of
+/// recomputing the super-linear SourcererCC candidate pairs every query (it does not finish in 240s
+/// on a 118k-function index). Computed at θ = `CLONE_PRECOMPUTE_THETA` (0.7).
+///
+/// Generation-staged: the resumable background recompute writes a new `build_generation`; reads
+/// serve the latest `Complete` generation (the `clone_graph_live_generation` meta key); the pointer
+/// flips atomically on completion so a half-built generation is never served. GC of a superseded
+/// generation CASCADEs its edges — `clone_graph_generations` is DURABLE precompute metadata, not a
+/// `REINDEX_VOLATILE_PARENT`, so that CASCADE FK is allowed.
+///
+/// CONTENT-ANCHORED endpoints (the #248 bug-class rule, enforced by
+/// `no_table_has_a_reindex_cascading_fk_to_a_volatile_parent`): this is durable output that MUST
+/// survive reindex, so it carries NO `ON DELETE CASCADE` FK to `symbols` (a
+/// `REINDEX_VOLATILE_PARENT` whose ids are reassigned on reindex — keying on `symbol_id` is the
+/// exact #248 bug that wiped `edge_oracle` verdicts). Each endpoint is the reindex-stable `(path,
+/// start_byte)` of a symbol plus the `file_sha` (`files.sha256`) at compute time — the same
+/// content-key/staleness pattern as `edge_oracle`. Reads resolve an endpoint by joining live
+/// `symbols`/`files` on `(path, start_byte)` AND `files.sha256 = *_file_sha`; a deleted or edited
+/// endpoint simply does not resolve, so a dangling/stale edge is dropped at read (never a ghost
+/// member).
+///
+/// `overlap` + both `token_len`s are the exact `verified_clone` gate inputs, so any query θ ≥ 0.7
+/// reproduces `overlap >= ceil(θ * max_len)` precisely by filtering stored rows. Struct-hash exact
+/// pairs carry `similarity = 1.0` so they survive every θ.
+///
+/// Population gap (as with the V029 clone tables): this migration only CREATEs the tables. They
+/// populate when a precompute pass runs (watcher maintenance / `rag-rat clones --precompute`);
+/// there is no backfill at migration time. Until then `find_clones` uses its live path unchanged.
+/// The sub-block inverted index the resumable build streams against is rebuilt in RAM from
+/// `symbol_fingerprints.token_bag` each pass (cheap relative to pair emission); a PERSISTED
+/// postings table is deferred to the incremental-maintenance follow-up, where it would itself be
+/// content-anchored.
+pub(crate) const CLONE_GRAPH_DDL: &str = "
+    CREATE TABLE IF NOT EXISTS clone_graph_generations(
+        generation         INTEGER PRIMARY KEY,
+        status             TEXT    NOT NULL CHECK (status IN ('Building', 'Complete')),
+        theta_floor        REAL    NOT NULL,
+        normalizer_kind    TEXT    NOT NULL,            -- baseline
+        normalizer_version INTEGER NOT NULL,            -- NORM_VERSION at build
+        source_revision    TEXT    NOT NULL,            -- content_revision() this generation \
+                                          builds toward
+        cursor_symbol_id   INTEGER NOT NULL DEFAULT 0,  -- build-local resume point (last \
+                                          symbol_id emitted)
+        edges_written      INTEGER NOT NULL DEFAULT 0,
+        started_at_ms      INTEGER NOT NULL,
+        finished_at_ms     INTEGER
+    ) STRICT;
+    CREATE TABLE IF NOT EXISTS clone_edges(
+        build_generation INTEGER NOT NULL REFERENCES clone_graph_generations(generation) ON DELETE \
+                                          CASCADE,
+        -- Content-anchored endpoints: NO symbol_id FK (#248 rule). Canonical a < b by (path, \
+                                          start_byte).
+        a_path           TEXT    NOT NULL,
+        a_start_byte     INTEGER NOT NULL,
+        a_file_sha       TEXT    NOT NULL,              -- files.sha256 at compute; read-time \
+                                          staleness filter
+        b_path           TEXT    NOT NULL,
+        b_start_byte     INTEGER NOT NULL,
+        b_file_sha       TEXT    NOT NULL,
+        overlap          INTEGER NOT NULL,              -- Σ min(freq) = verified_clone overlap
+        a_token_len      INTEGER NOT NULL,
+        b_token_len      INTEGER NOT NULL,
+        similarity       REAL    NOT NULL,              -- overlap/max_len; 1.0 for \
+                                          struct-hash-exact pairs
+        edge_source      TEXT    NOT NULL,              -- 'struct_hash' | 'sub_block'
+        PRIMARY KEY (build_generation, a_path, a_start_byte, b_path, b_start_byte)
+    ) STRICT;
+    CREATE INDEX IF NOT EXISTS idx_clone_edges_b
+        ON clone_edges(build_generation, b_path, b_start_byte);
+";
+
+/// V034: create the precomputed clone-graph tables (see [`CLONE_GRAPH_DDL`]).
+pub(crate) fn apply_clone_graph_tables(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(CLONE_GRAPH_DDL)?;
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use migrations::*;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 33;
+pub const LATEST_SCHEMA_VERSION: u32 = 34;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -213,6 +213,11 @@ const MIGRATION_033_CHECKSUM: &str = "sha256:rag-rat-dream-findings-v33";
 const MIGRATION_033_DESCRIPTION: &str = "Add dream_findings (dream-mode worklist: findings ABOUT \
                                          memories, identity-keyed supersede/decay, never mutate \
                                          memories) (#122)";
+const MIGRATION_034_ID: &str = "034_clone_graph_precompute";
+const MIGRATION_034_CHECKSUM: &str = "sha256:rag-rat-clone-graph-precompute-v34";
+const MIGRATION_034_DESCRIPTION: &str =
+    "Add clone_graph_generations + clone_edges (content-anchored precomputed clone-edge graph so \
+     find_clones reads a persisted graph instead of recomputing candidate pairs every query)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -510,6 +515,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_033_CHECKSUM,
         description: MIGRATION_033_DESCRIPTION,
         apply: apply_dream_findings,
+    },
+    Migration {
+        id: MIGRATION_034_ID,
+        checksum: MIGRATION_034_CHECKSUM,
+        description: MIGRATION_034_DESCRIPTION,
+        apply: apply_clone_graph_tables,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -12339,6 +12339,87 @@ fn migration_032_adds_token_bag_drops_postings() {
     ));
 }
 
+/// V034 (#286): the precomputed clone-graph tables exist after a forward migration from V033, are
+/// CONTENT-ANCHORED (no `symbol_id` FK — the #248 rule the volatile-FK trip-wire enforces), and are
+/// usable. A V033 index migrates forward to LATEST and gains `clone_graph_generations` +
+/// `clone_edges` with the content-key endpoints; the deferred postings table is NOT created.
+#[test]
+fn migration_034_adds_content_anchored_clone_graph_tables() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    crate::index::schema::apply(&conn).expect("apply");
+
+    // --- Simulate a V033-era index: clone-graph tables absent, schema rolled back to V033 ---
+    conn.execute_batch(
+        "DROP TABLE IF EXISTS clone_edges; DROP TABLE IF EXISTS clone_graph_generations;",
+    )
+    .expect("revert to V033 shape");
+    truncate_schema_to(&conn, 33);
+    assert!(!conn_table_exists(&conn, "clone_edges"), "clone_edges absent at V033");
+    assert_eq!(
+        crate::index::schema::status(&conn).unwrap().state,
+        crate::index::schema::SchemaState::Older,
+        "schema is Older after removing the V034 ledger row"
+    );
+
+    // --- Run the forward migration ---
+    crate::index::schema::migrate_forward(&conn).expect("migrate_forward");
+    assert!(
+        conn_table_exists(&conn, "clone_graph_generations"),
+        "V034 adds clone_graph_generations"
+    );
+    assert!(conn_table_exists(&conn, "clone_edges"), "V034 adds clone_edges");
+    assert!(
+        !conn_table_exists(&conn, "clone_subblock_postings"),
+        "the persisted postings table is deferred to the incremental follow-up — not created in \
+         V034"
+    );
+
+    // Content-anchored: clone_edges must carry NO foreign key to a reindex-volatile parent
+    // (symbols). Its only FK is to clone_graph_generations (durable). This is the #248
+    // invariant in situ.
+    let edge_fk_parents: Vec<String> = {
+        let mut stmt =
+            conn.prepare("SELECT \"table\" FROM pragma_foreign_key_list('clone_edges')").unwrap();
+        stmt.query_map([], |r| r.get::<_, String>(0)).unwrap().map(Result::unwrap).collect()
+    };
+    assert!(
+        !edge_fk_parents.iter().any(|p| p == "symbols"),
+        "clone_edges must NOT FK symbols (content-anchored, #248); FKs = {edge_fk_parents:?}"
+    );
+    let cols = conn_table_columns(&conn, "clone_edges");
+    for endpoint_col in
+        ["a_path", "a_start_byte", "a_file_sha", "b_path", "b_start_byte", "b_file_sha"]
+    {
+        assert!(
+            cols.contains(&endpoint_col.to_string()),
+            "clone_edges has content-key {endpoint_col}"
+        );
+    }
+
+    // The tables are usable: a generation + an edge round-trips.
+    conn.execute_batch(
+        "INSERT INTO clone_graph_generations
+             (generation, status, theta_floor, normalizer_kind, normalizer_version, \
+         source_revision,
+              started_at_ms)
+         VALUES (1, 'Building', 0.7, 'baseline', 3, 'rev', 0);
+         INSERT INTO clone_edges
+             (build_generation, a_path, a_start_byte, a_file_sha, b_path, b_start_byte, b_file_sha,
+              overlap, a_token_len, b_token_len, similarity, edge_source)
+         VALUES (1, 'a.rs', 10, 'sha_a', 'b.rs', 20, 'sha_b', 8, 10, 9, 0.9, 'sub_block');",
+    )
+    .expect("clone-graph tables are usable");
+    let edges: i64 =
+        conn.query_row("SELECT COUNT(*) FROM clone_edges", [], |r| r.get(0)).expect("count edges");
+    assert_eq!(edges, 1, "round-tripped one edge");
+
+    assert_eq!(
+        crate::index::schema::status(&conn).unwrap().current_version,
+        crate::index::schema::LATEST_SCHEMA_VERSION,
+        "schema is at LATEST_SCHEMA_VERSION after V034"
+    );
+}
+
 /// Regression test for the P1 schema bug (#215 Plan 4a): an index recorded at V029 WITHOUT
 /// `clone_refinements.lcs_sampled` (because V029 was applied before the column landed) must have
 /// the column added by the V030 forward migration. Simulates the bug by building a full schema,
@@ -12400,8 +12481,8 @@ fn v030_forward_migrate_adds_lcs_sampled_to_existing_v029_index() {
     );
     assert_eq!(
         crate::index::schema::LATEST_SCHEMA_VERSION,
-        33,
-        "LATEST_SCHEMA_VERSION is 33 after V033"
+        34,
+        "LATEST_SCHEMA_VERSION is 34 after V034"
     );
     // Idempotency: running migrate_forward again must not error.
     crate::index::schema::migrate_forward(&conn).expect("migrate_forward is idempotent");

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -135,6 +135,17 @@ fn run_pass(config: &Config, run_gc: bool) -> anyhow::Result<()> {
     if let Some(options) = budget.next_options() {
         db.reconcile_with_options_progress(options, |_| {})?;
     }
+    // Clone-edge graph (#286): refresh the persisted graph when it's ABSENT or STALE, with whatever
+    // budget the embedding reconcile left — sharing the same PASS_RECONCILE_MAX_SECONDS so a pass
+    // can't overrun. Best-effort + resumable: a bounded pass makes partial progress and the next
+    // pass continues, so a large/dense repo's graph converges over several passes, entirely off
+    // the query path. `None` budget → skip (rides the next pass), exactly like the base
+    // reconcile.
+    if db.pending_clone_graph().unwrap_or(false)
+        && let Some(options) = budget.next_options()
+    {
+        let _ = db.reconcile_clone_edges_with_budget(options.max_seconds);
+    }
     if run_gc {
         let _ = db.garbage_collect();
     }


### PR DESCRIPTION
Closes #286.

`find_clones` recomputes a super-linear SourcererCC candidate-pair graph on every query — fine for a single crate (cargo: 3,332 fns, ~15s) but it does **not** finish in 240s on the Linux kernel `drivers/net` (118k fns). This precomputes + persists the verified clone-edge graph as a bounded, resumable **background** pass (mirroring the embedding `reconcile`), so `find_clones` reads it instead of recomputing.

## Phases (one commit each)
- **A — V034 migration**: `clone_graph_generations` + `clone_edges`, generation-staged. **Content-anchored** per the #248 rule — endpoints keyed on `(path, start_byte, file_sha)`, **no FK to `symbols`** (the volatile-FK trip-wire caught the initial `symbol_id` keying); reads resolve back to live symbols, so a deleted/edited endpoint drops rather than surfacing a ghost.
- **B — resumable writer + `clones --precompute`**: streams symbols emitting each pair from its smaller endpoint (chunkable + cursor-resumable under a `max_seconds` budget); generation-staged with publish-after-build (a half-built graph is never served); skip-when-current is a zero-write no-op.
- **C — read fast path**: `find_clones`/`clones_for_symbol` read the graph when present, fresh-enough, θ≥0.7, base scope, else live. **Parity test** pins it byte-identical to live at θ∈{0.7,0.8,0.9}.
- **perf — RAM resolution**: resolve content-keys in RAM, not a per-edge SQL join (the join measured *slower* than live; after the fix, 2.0s vs 4.4s on net/ipv4 = **2.2×**, identical results).
- **D — auto-maintenance**: a budgeted sibling step in the watcher + git-hook `maintenance` passes (gated by `pending_clone_graph`, sharing the `ReconcileBudget`), so the graph stays warm off the query path.

## Validation (118k-fn kernel `drivers/net`)
The writer is **resumable + RAM-bounded** — it survived timeout kills and resumed, never OOM'd (where live `find_clones` OOM'd/hung). It also surfaced that `drivers/net` is *pathologically* θ=0.7-dense (5.67M `sub_block` edges from 2,874 fns) — an O(K²) cost inherent to pairwise clone detection on boilerplate; a recall-gated cluster-size cap is the documented follow-up.

## Tests
1029 workspace tests incl. the parity + resume-parity + V034 content-anchor tests; clippy `--all-targets`; nightly fmt. Additive migration (tables populate via the first background pass); `find_clones` is a pure fast path that falls back to the live path unchanged.