### PR TITLE
feat(clones): write-time clone check — warn agents when they're duplicating existing code (#287)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ sequenceDiagram
   rationale, all queryable.
 - **Rides your existing grep.** A [PreToolUse hook](docs/grep-augmentation.md) injects the memories
   and symbols behind whatever you just searched for.
+- **Flags clones as you write them.** A PreToolUse hook on Write/Edit/MultiEdit fingerprints the
+  functions you're writing and warns when they're exact or near-duplicates of code already in the
+  repo — so an agent reuses instead of re-implementing. Read-only, and a silent no-op when the index
+  isn't ready, so it never blocks a write.
 
 ## Install
 

--- a/crates/rag-rat-cli/src/claude_hook/mod.rs
+++ b/crates/rag-rat-cli/src/claude_hook/mod.rs
@@ -16,11 +16,18 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use rag_rat_core::config::Config;
+use rag_rat_core::index::{CloneCheckInput, IndexDatabase, TextCloneMatch};
+use rag_rat_core::language::Language;
 use rag_rat_core::locks;
 use rag_rat_core::query::grep_augment;
 use rag_rat_core::query::orientation::Orientation;
 use rag_rat_core::storage::IndexConnection;
 use serde::Deserialize;
+
+/// Skip the write-time clone check above this many fingerprinted functions: the check builds an
+/// in-RAM inverted index over all of them (O(functions)) until the persisted-postings follow-up
+/// (#287) lands, so on a very large repo it no-ops rather than add a perceptible delay to a write.
+const MAX_CLONE_CHECK_FUNCTIONS: u64 = 40_000;
 
 // Only the unix Unix-socket listener path uses this; dead on Windows (which has no warm listener).
 #[cfg(unix)]
@@ -343,8 +350,12 @@ fn version_line(status: &rag_rat_core::version_check::VersionStatus) -> Option<S
     }
 }
 
-/// PreToolUse path (grep augmentation).
+/// PreToolUse path: the write-time clone check (#287) on the edit tools, grep augmentation
+/// otherwise.
 fn pretooluse(input: &HookInput) -> anyhow::Result<()> {
+    if matches!(input.tool_name.as_str(), "Write" | "Edit" | "MultiEdit") {
+        return clone_check(input);
+    }
     let Some(search) = extract_search(input) else { return Ok(()) };
     let Some(config) = find_config(Path::new(&input.cwd)) else { return Ok(()) };
 
@@ -367,6 +378,111 @@ fn pretooluse(input: &HookInput) -> anyhow::Result<()> {
         );
     }
     Ok(())
+}
+
+/// Write-time clone check (#287): fingerprint the just-written functions and warn if they duplicate
+/// existing indexed code. Best-effort + READ-ONLY — every "not ready" path (no config, DB absent,
+/// index owes a heal/migrate, index too large, no parseable functions) is a SILENT no-op, so it
+/// never blocks or perceptibly delays a write.
+fn clone_check(input: &HookInput) -> anyhow::Result<()> {
+    let Some(config) = find_config(Path::new(&input.cwd)) else { return Ok(()) };
+    if !config.database.is_file() {
+        return Ok(()); // index not built yet
+    }
+    // `try_open_config_read_only` returns None when the index still owes a heal/migrate (NOT
+    // ready), so this is the no-op-when-not-ready guard — the same gate the MCP read tools use.
+    let Some(db) = IndexDatabase::try_open_config_read_only(&config)? else { return Ok(()) };
+    if db.clone_check_function_count().unwrap_or(u64::MAX) > MAX_CLONE_CHECK_FUNCTIONS {
+        return Ok(()); // too large for the in-RAM check — no-op until the persisted postings land
+    }
+    let inputs = extract_clone_inputs(input, &config.root);
+    if inputs.is_empty() {
+        return Ok(());
+    }
+    let matches = db.clones_of_texts(&inputs)?;
+    if let Some(context) = format_clone_warning(&matches) {
+        // PreToolUse contract: allow + additionalContext (a warning, not a block).
+        println!(
+            "{}",
+            serde_json::json!({
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "allow",
+                    "additionalContext": context,
+                }
+            })
+        );
+    }
+    Ok(())
+}
+
+/// Pull the (relative-path, text) inputs to clone-check from a Write/Edit/MultiEdit tool call:
+/// Write → the whole `content`; Edit → the `new_string`; MultiEdit → each edit's `new_string` (a
+/// batch). A fragment that isn't a complete function simply yields no fingerprints downstream (a
+/// no-op).
+fn extract_clone_inputs(input: &HookInput, root: &Path) -> Vec<CloneCheckInput> {
+    let ti = &input.tool_input;
+    let Some(file_path) = ti.get("file_path").and_then(|v| v.as_str()) else { return Vec::new() };
+    let abs = Path::new(file_path);
+    let Some(language) = Language::from_path(abs) else { return Vec::new() };
+    // The indexed refs are root-relative, so relativize for the parse + the self-file exclusion.
+    let rel = abs.strip_prefix(root).unwrap_or(abs).to_path_buf();
+    let texts: Vec<String> = match input.tool_name.as_str() {
+        "Write" => ti
+            .get("content")
+            .and_then(|v| v.as_str())
+            .map(|s| vec![s.to_string()])
+            .unwrap_or_default(),
+        "Edit" => ti
+            .get("new_string")
+            .and_then(|v| v.as_str())
+            .map(|s| vec![s.to_string()])
+            .unwrap_or_default(),
+        "MultiEdit" => ti
+            .get("edits")
+            .and_then(|v| v.as_array())
+            .map(|edits| {
+                edits
+                    .iter()
+                    .filter_map(|e| {
+                        e.get("new_string").and_then(|v| v.as_str()).map(str::to_string)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    };
+    texts.into_iter().map(|text| CloneCheckInput { text, language, path: rel.clone() }).collect()
+}
+
+/// Render clone-check findings as the `additionalContext` injected back to the agent, or `None`
+/// when there are none (stay silent).
+fn format_clone_warning(matches: &[TextCloneMatch]) -> Option<String> {
+    if matches.is_empty() {
+        return None;
+    }
+    let mut out = String::from(
+        "▶ rag-rat clone check — code you're writing duplicates existing functions:\n",
+    );
+    for m in matches {
+        let label = if m.kind == "exact" {
+            "identical to".to_string()
+        } else {
+            format!("~{:.0}% similar to", m.similarity * 100.0)
+        };
+        out.push_str(&format!(
+            "  • `{}` (line {}) is {} {}\n",
+            m.name,
+            m.start_line,
+            label,
+            m.clone_of.join(", ")
+        ));
+    }
+    out.push_str(
+        "Prefer reusing the existing function(s) over duplicating — impact_surface / \
+         symbol_lookup to inspect them.\n",
+    );
+    Some(out)
 }
 
 /// One-liner shown when the DB file is absent (no config directory walk — `find_config` already

--- a/crates/rag-rat-cli/src/claude_hook/tests.rs
+++ b/crates/rag-rat-cli/src/claude_hook/tests.rs
@@ -520,3 +520,75 @@ fn format_digest_parser_failures_shown_when_nonzero() {
     let s = format_digest(&o, true, true);
     assert!(s.contains("parser failures: 5"), "missing parser failures note");
 }
+
+// ─── write-time clone check (#287) ────────────────────────────────────────────
+
+fn write_event(tool: &str, tool_input: serde_json::Value) -> HookInput {
+    HookInput {
+        hook_event_name: Some("PreToolUse".to_string()),
+        tool_name: tool.to_string(),
+        tool_input,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn extract_clone_inputs_write_edit_multiedit() {
+    let root = std::path::Path::new("/repo");
+
+    let write = write_event(
+        "Write",
+        serde_json::json!({"file_path": "/repo/src/a.rs", "content": "fn f() {}"}),
+    );
+    let w = super::extract_clone_inputs(&write, root);
+    assert_eq!(w.len(), 1);
+    assert_eq!(w[0].text, "fn f() {}");
+    assert_eq!(w[0].path, std::path::PathBuf::from("src/a.rs"), "path relativized to root");
+
+    let edit = write_event(
+        "Edit",
+        serde_json::json!({"file_path": "/repo/src/a.rs", "new_string": "fn g() {}"}),
+    );
+    assert_eq!(super::extract_clone_inputs(&edit, root)[0].text, "fn g() {}");
+
+    // MultiEdit fans out to one input per edit (the batch case).
+    let multi = write_event(
+        "MultiEdit",
+        serde_json::json!({"file_path": "/repo/src/a.rs", "edits": [{"new_string": "fn a() {}"}, {"new_string": "fn b() {}"}]}),
+    );
+    let m = super::extract_clone_inputs(&multi, root);
+    assert_eq!(m.iter().map(|i| i.text.as_str()).collect::<Vec<_>>(), vec![
+        "fn a() {}",
+        "fn b() {}"
+    ]);
+}
+
+#[test]
+fn extract_clone_inputs_skips_non_code_and_missing_path() {
+    let root = std::path::Path::new("/repo");
+    // Unknown extension → no language → nothing to check.
+    let txt =
+        write_event("Write", serde_json::json!({"file_path": "/repo/notes.txt", "content": "hi"}));
+    assert!(super::extract_clone_inputs(&txt, root).is_empty());
+    // No file_path → nothing.
+    let nofile = write_event("Write", serde_json::json!({"content": "x"}));
+    assert!(super::extract_clone_inputs(&nofile, root).is_empty());
+}
+
+#[test]
+fn format_clone_warning_renders_matches_and_is_silent_when_empty() {
+    assert!(super::format_clone_warning(&[]).is_none());
+    let m = rag_rat_core::index::TextCloneMatch {
+        in_file: "src/a.rs".to_string(),
+        name: "foo".to_string(),
+        start_line: 3,
+        kind: "exact",
+        similarity: 1.0,
+        clone_of: vec!["src/b.rs::bar".to_string()],
+    };
+    let out = super::format_clone_warning(&[m]).unwrap();
+    assert!(
+        out.contains("foo") && out.contains("identical to") && out.contains("src/b.rs::bar"),
+        "{out}"
+    );
+}

--- a/crates/rag-rat-cli/src/claude_settings.rs
+++ b/crates/rag-rat-cli/src/claude_settings.rs
@@ -1,5 +1,6 @@
-//! Claude Code settings.json management for the grep-augment PreToolUse hook and the
-//! SessionStart orientation hook (`rag-rat hooks install|uninstall|status --claude [--global]`).
+//! Claude Code settings.json management for the PreToolUse hooks (grep-augmentation on Grep/Bash +
+//! the write-time clone check on Write/Edit/MultiEdit, #287) and the SessionStart orientation hook
+//! (`rag-rat hooks install|uninstall|status --claude [--global]`).
 //!
 //! Edits are additive and marker-aware: our entries are recognized by `HOOK_COMMAND`;
 //! everything else in the file is preserved byte-for-byte at the JSON level (read → modify
@@ -10,7 +11,9 @@ use std::path::{Path, PathBuf};
 use serde_json::{Value, json};
 
 pub const HOOK_COMMAND: &str = "rag-rat claude-hook";
-const MATCHERS: &[&str] = &["Grep", "Bash"];
+// `Grep`/`Bash` drive the grep-augmentation; `Write`/`Edit`/`MultiEdit` drive the write-time clone
+// check (#287). All five fire the one `rag-rat claude-hook` command, which dispatches on tool name.
+const MATCHERS: &[&str] = &["Grep", "Bash", "Write", "Edit", "MultiEdit"];
 const SESSION_START_MATCHER: &str = "startup|clear|compact";
 const SESSION_START_TIMEOUT: u64 = 5;
 
@@ -224,13 +227,16 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn install_into_empty_settings_creates_both_matchers() {
+    fn install_into_empty_settings_creates_all_matchers() {
         let mut settings = serde_json::json!({});
         let changed = merge_hook_entries(&mut settings);
         assert!(changed);
         let entries = settings["hooks"]["PreToolUse"].as_array().unwrap();
         let matchers: Vec<&str> = entries.iter().map(|e| e["matcher"].as_str().unwrap()).collect();
-        assert!(matchers.contains(&"Grep") && matchers.contains(&"Bash"));
+        // Grep/Bash (grep-augment) + Write/Edit/MultiEdit (clone check, #287).
+        for expected in ["Grep", "Bash", "Write", "Edit", "MultiEdit"] {
+            assert!(matchers.contains(&expected), "missing {expected} matcher");
+        }
         for entry in entries {
             let hook = &entry["hooks"][0];
             assert_eq!(hook["command"], HOOK_COMMAND);
@@ -249,7 +255,15 @@ mod tests {
         assert!(merge_hook_entries(&mut settings));
         assert!(!merge_hook_entries(&mut settings), "second install is a no-op");
         let entries = settings["hooks"]["PreToolUse"].as_array().unwrap();
-        assert_eq!(entries.len(), 3, "foreign Edit entry preserved alongside Grep+Bash");
+        // The foreign `Edit` (other-tool) is preserved, and our 5 matchers are added alongside it —
+        // our `Edit` entry (is-ours) coexists with the foreign one.
+        assert_eq!(entries.len(), 6, "foreign Edit preserved alongside our 5 matchers");
+        assert!(
+            entries
+                .iter()
+                .any(|e| e["matcher"] == "Edit" && e["hooks"][0]["command"] == "other-tool"),
+            "foreign Edit entry preserved"
+        );
         assert_eq!(settings["permissions"]["allow"][0], "Bash(ls:*)");
     }
 

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -51,7 +51,7 @@ pub(crate) use prep::*;
 pub use query_api::{
     CandidateCloneClass, CloneCompleteness, CloneMember, CloneSymbolSelector,
     ClonesForSymbolResult, FindClonesOptions, FindClonesResult, GcReport, ImportantSymbolsRequest,
-    OracleShaSnapshots, RoiFactors, SearchRequest,
+    OracleShaSnapshots, RoiFactors, SearchRequest, TextCloneMatch,
 };
 pub(crate) use util::*;
 

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -49,7 +49,7 @@ pub(crate) use mem_diag::{maybe_set_sqlite_soft_heap_limit, mem_trace};
 pub use parser_failures::ParserFailure;
 pub(crate) use prep::*;
 pub use query_api::{
-    CandidateCloneClass, CloneCompleteness, CloneMember, CloneSymbolSelector,
+    CandidateCloneClass, CloneCheckInput, CloneCompleteness, CloneMember, CloneSymbolSelector,
     ClonesForSymbolResult, FindClonesOptions, FindClonesResult, GcReport, ImportantSymbolsRequest,
     OracleShaSnapshots, RoiFactors, SearchRequest, TextCloneMatch,
 };

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -13,6 +13,11 @@ use std::sync::Arc;
 use rayon::prelude::*;
 use rusqlite::{Connection, OptionalExtension};
 
+/// Clone-check of arbitrary not-yet-indexed text (#287): `clones_of_text` fingerprints the
+/// functions in a string and finds their exact + near clones among the indexed symbols — a child
+/// module so it can reuse this module's private candidate-gen primitives.
+pub(crate) mod of_text;
+
 /// Pairwise metric work cap for huge components: when a component exceeds this count, the
 /// O(n²) pairwise metric loop (`similarity_min`, medoid, `similarity_medoid_min`,
 /// `containment_max`) runs over ONLY the first `METRIC_SAMPLE_CAP` members instead of the full

--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -1,19 +1,23 @@
-//! Clone-check of arbitrary, not-yet-indexed text (#287): fingerprint the functions in `text`
-//! in-memory and find their EXACT (`struct_hash`) and NEAR (≥θ overlap) clones among the INDEXED
-//! symbols — the engine behind a write-time "you just wrote a clone" check for coding agents.
+//! Clone-check of arbitrary, not-yet-indexed text (#287): fingerprint the functions in one or more
+//! in-memory files and find their EXACT (`struct_hash`) and NEAR (≥θ overlap) clones among the
+//! INDEXED symbols — the engine behind a write-time "you just wrote a clone" check for coding
+//! agents.
+//!
+//! BATCH-first: [`IndexDatabase::clones_of_texts`] loads + structures the index ONCE and checks N
+//! files against it (a MultiEdit, or a batch that touches several files, pays the load once).
+//! [`IndexDatabase::clones_of_text`] is the single-file convenience.
 //!
 //! Read-only and best-effort: it never writes and returns an empty list (a no-op) when there's
-//! nothing to compare against (empty/absent fingerprints) or the text doesn't parse — so a caller
-//! (e.g. a Write/Edit hook) can run it unconditionally without ever blocking the agent. It reuses
-//! the parent `clones` module's EXACT candidate-gen primitives (`sub_block_tokens`, `overlap`,
-//! `verified_clone`) so a near match is the same relation `find_clones` would report.
+//! nothing to compare against (empty/absent fingerprints) or a file doesn't parse — so a Write/Edit
+//! hook can run it unconditionally without ever blocking the agent. It reuses the parent `clones`
+//! module's EXACT candidate-gen primitives (`sub_block_tokens`, `overlap`, `verified_clone`) so a
+//! near match is the same relation `find_clones` reports.
 //!
-//! Self-matches (a function vs its own already-indexed copy, when editing in place) are NOT
-//! filtered here — the engine is pure; the caller, which knows the file being written, excludes its
-//! own path.
+//! Self-matches are filtered: a function is never reported as a clone of code in its OWN file
+//! (`in_file`), so editing a function in place doesn't flag it against its own indexed copy.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::path::Path;
+use std::collections::{BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
 
 use rusqlite::Connection;
 use serde::Serialize;
@@ -26,26 +30,37 @@ use crate::index::clones::{SymbolFingerprint, fingerprint_symbols};
 use crate::index::{IndexDatabase, parser, symbols};
 use crate::language::Language;
 
+/// One file to clone-check (owns its data so a batch can be assembled from disparate sources).
+pub struct CloneCheckInput {
+    pub text: String,
+    pub language: Language,
+    /// Path of the file the text belongs to, RELATIVE to the index root — used both for parsing
+    /// and to exclude self-matches (so it must match the indexed `path::name` ref form).
+    pub path: PathBuf,
+}
+
 /// One just-written function that duplicates existing indexed code.
 #[derive(Debug, Clone, Serialize)]
 pub struct TextCloneMatch {
-    /// The new function's name, as parsed from the text.
+    /// The input file (relative path) the new function is in — set on every match so a batch
+    /// result is self-describing.
+    pub in_file: String,
+    /// The new function's name, as parsed.
     pub name: String,
-    /// 1-based line of the new function within the supplied text.
+    /// 1-based line of the new function within its file's text.
     pub start_line: usize,
     /// `"exact"` (identical structure — same `struct_hash`) or `"near"` (≥θ overlap).
     pub kind: &'static str,
     /// `overlap / max_len` similarity in `[θ, 1.0]`; `1.0` for an exact match.
     pub similarity: f64,
-    /// Existing indexed refs (`path::name`) this function clones — sorted, deduplicated.
+    /// Existing indexed refs (`path::name`) this function clones — sorted, deduplicated, self-file
+    /// excluded.
     pub clone_of: Vec<String>,
 }
 
 impl IndexDatabase {
     /// Find EXACT + NEAR clones of every fingerprintable function in `text` among the indexed
-    /// symbols. `path`/`language` drive PARSING only — `text` need not be saved or indexed. An
-    /// empty result means no clones OR nothing to compare against (a best-effort no-op, never
-    /// an error for an unparseable/empty input).
+    /// symbols (single-file convenience over [`Self::clones_of_texts`]).
     pub fn clones_of_text(
         &self,
         text: &str,
@@ -53,8 +68,79 @@ impl IndexDatabase {
         path: &Path,
     ) -> anyhow::Result<Vec<TextCloneMatch>> {
         let conn = self.storage.connection();
+        let Some(index) = CheckIndex::load(conn)? else {
+            return Ok(Vec::new());
+        };
+        index.check(conn, text, language, path)
+    }
 
-        // Fingerprint the new functions in-memory — the exact pipeline indexing uses.
+    /// BATCH clone-check: load + structure the index ONCE, then check every input file against it.
+    /// An empty index (nothing to compare against) yields an empty result — a best-effort no-op.
+    pub fn clones_of_texts(
+        &self,
+        inputs: &[CloneCheckInput],
+    ) -> anyhow::Result<Vec<TextCloneMatch>> {
+        let conn = self.storage.connection();
+        let Some(index) = CheckIndex::load(conn)? else {
+            return Ok(Vec::new());
+        };
+        let mut all = Vec::new();
+        for input in inputs {
+            all.extend(index.check(conn, &input.text, input.language, &input.path)?);
+        }
+        Ok(all)
+    }
+}
+
+/// The indexed baseline bags + the lookup structures a clone-check needs, built ONCE so a batch
+/// reuses them. Holds the bags by value + an id→index map (rather than a borrowing `by_id`) so it
+/// is not a self-referential struct.
+struct CheckIndex {
+    indexed: Vec<SymbolBag>,
+    id_to_idx: HashMap<i64, usize>,
+    /// `(struct_hash, language) -> ids` for the exact fast path.
+    by_struct: HashMap<(String, String), Vec<i64>>,
+    /// sub-block `token -> ids` inverted index for the near path.
+    inverted: HashMap<i64, Vec<i64>>,
+    df_by_token: HashMap<i64, i64>,
+}
+
+impl CheckIndex {
+    fn load(conn: &Connection) -> anyhow::Result<Option<Self>> {
+        let indexed = load_scoped_baseline_bags(conn)?;
+        if indexed.is_empty() {
+            return Ok(None);
+        }
+        let df_by_token = load_clone_token_df(conn)?;
+        let mut id_to_idx = HashMap::with_capacity(indexed.len());
+        let mut by_struct: HashMap<(String, String), Vec<i64>> = HashMap::new();
+        let mut inverted: HashMap<i64, Vec<i64>> = HashMap::new();
+        for (idx, bag) in indexed.iter().enumerate() {
+            id_to_idx.insert(bag.symbol_id, idx);
+            by_struct
+                .entry((bag.struct_hash.clone(), bag.language.clone()))
+                .or_default()
+                .push(bag.symbol_id);
+            for token in sub_block_tokens(bag, THETA) {
+                inverted.entry(token).or_default().push(bag.symbol_id);
+            }
+        }
+        Ok(Some(Self { indexed, id_to_idx, by_struct, inverted, df_by_token }))
+    }
+
+    fn bag(&self, id: i64) -> &SymbolBag {
+        &self.indexed[self.id_to_idx[&id]]
+    }
+
+    /// Clone-check one file's `text` against the loaded index, resolving refs and excluding
+    /// self-file matches.
+    fn check(
+        &self,
+        conn: &Connection,
+        text: &str,
+        language: Language,
+        path: &Path,
+    ) -> anyhow::Result<Vec<TextCloneMatch>> {
         let syms = symbols::symbols_for_file(path, language, text);
         let Some(parsed) = parser::parse_file(path, language, text) else {
             return Ok(Vec::new());
@@ -64,40 +150,23 @@ impl IndexDatabase {
             return Ok(Vec::new());
         }
 
-        // Compare against the indexed baseline bags. Empty/absent index → nothing to clone → no-op.
-        let indexed = load_scoped_baseline_bags(conn)?;
-        if indexed.is_empty() {
-            return Ok(Vec::new());
-        }
-        let by_id: BTreeMap<i64, &SymbolBag> = indexed.iter().map(|b| (b.symbol_id, b)).collect();
-        let df_by_token = load_clone_token_df(conn)?;
-
-        // `(struct_hash, language) -> ids` (exact) and the sub-block `token -> ids` inverted index
-        // (near) — built once over the indexed bags.
-        let mut by_struct: HashMap<(&str, &str), Vec<i64>> = HashMap::new();
-        let mut inverted: HashMap<i64, Vec<i64>> = HashMap::new();
-        for bag in &indexed {
-            by_struct
-                .entry((bag.struct_hash.as_str(), bag.language.as_str()))
-                .or_default()
-                .push(bag.symbol_id);
-            for token in sub_block_tokens(bag, THETA) {
-                inverted.entry(token).or_default().push(bag.symbol_id);
-            }
-        }
-
         let lang = language.as_str();
+        let in_file = path.to_string_lossy().into_owned();
+        let self_prefix = format!("{in_file}::"); // refs starting with this are the file's own code
+
         let mut id_set: BTreeSet<i64> = BTreeSet::new();
-        // (name, start_line, kind, similarity, existing_ids)
         let mut pending: Vec<(String, usize, &'static str, f64, Vec<i64>)> = Vec::new();
 
         for (local, fp) in &new_fps {
             let symbol = &syms[*local];
-            let new_bag = bag_from_fingerprint(fp, lang, &df_by_token);
+            let new_bag = bag_from_fingerprint(fp, lang, &self.df_by_token);
 
             // EXACT: identical structure (same struct_hash + language) → similarity 1.0.
-            let exact: Vec<i64> =
-                by_struct.get(&(fp.struct_hash.as_str(), lang)).cloned().unwrap_or_default();
+            let exact: Vec<i64> = self
+                .by_struct
+                .get(&(fp.struct_hash.clone(), lang.to_string()))
+                .cloned()
+                .unwrap_or_default();
             let exact_set: BTreeSet<i64> = exact.iter().copied().collect();
             if !exact.is_empty() {
                 id_set.extend(&exact);
@@ -108,7 +177,7 @@ impl IndexDatabase {
             // ids already reported as exact for this function.
             let mut cand: BTreeSet<i64> = BTreeSet::new();
             for token in sub_block_tokens(&new_bag, THETA) {
-                if let Some(ids) = inverted.get(&token) {
+                if let Some(ids) = self.inverted.get(&token) {
                     cand.extend(ids);
                 }
             }
@@ -118,7 +187,7 @@ impl IndexDatabase {
                 if exact_set.contains(&id) {
                     continue;
                 }
-                let other = by_id[&id];
+                let other = self.bag(id);
                 if other.language != lang || !verified_clone(&new_bag, other, THETA) {
                     continue;
                 }
@@ -141,11 +210,23 @@ impl IndexDatabase {
         let mut matches: Vec<TextCloneMatch> = pending
             .into_iter()
             .map(|(name, start_line, kind, similarity, ids)| {
-                let mut clone_of: Vec<String> =
-                    ids.iter().filter_map(|id| refs.get(id).cloned()).collect();
+                let mut clone_of: Vec<String> = ids
+                    .iter()
+                    .filter_map(|id| refs.get(id).cloned())
+                    // Self-file exclusion: a function isn't a clone of code in its own file (so an
+                    // in-place edit doesn't flag against its own indexed copy).
+                    .filter(|r| !r.starts_with(&self_prefix))
+                    .collect();
                 clone_of.sort();
                 clone_of.dedup();
-                TextCloneMatch { name, start_line, kind, similarity, clone_of }
+                TextCloneMatch {
+                    in_file: in_file.clone(),
+                    name,
+                    start_line,
+                    kind,
+                    similarity,
+                    clone_of,
+                }
             })
             .filter(|m| !m.clone_of.is_empty())
             .collect();
@@ -227,6 +308,8 @@ fn resolve_refs(conn: &Connection, ids: &BTreeSet<i64>) -> anyhow::Result<HashMa
 
 #[cfg(test)]
 mod tests {
+    use super::CloneCheckInput;
+
     fn fixture_db(tag: &str) -> crate::IndexDatabase {
         let root = std::env::temp_dir().join(format!(
             "rag-rat-of-text-{tag}-{}-{}",
@@ -235,7 +318,6 @@ mod tests {
         ));
         let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(root.join("src")).unwrap();
-        // An indexed function the new text will clone.
         std::fs::write(
             root.join("src/lib.rs"),
             "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\n",
@@ -261,33 +343,65 @@ mod tests {
     }
 
     #[test]
-    fn finds_exact_and_near_clones_of_new_text() {
+    fn finds_exact_clone_of_new_text() {
         let db = fixture_db("hit");
-
-        // EXACT: byte-identical structure (renamed identifiers normalize away) to the indexed fn.
         let exact_text = "pub fn fetch_account(store: Db) -> i32 { let a = store.get(20); \
                           validate(a); a + 1 }\n";
-        let exact = db
+        let hits = db
             .clones_of_text(
                 exact_text,
                 crate::language::Language::Rust,
                 std::path::Path::new("new.rs"),
             )
             .unwrap();
-        assert_eq!(exact.len(), 1, "one new function checked");
-        assert_eq!(exact[0].kind, "exact");
-        assert_eq!(exact[0].similarity, 1.0);
-        assert!(
-            exact[0].clone_of.iter().any(|r| r.contains("load_user")),
-            "exact clone of load_user, got {:?}",
-            exact[0].clone_of
-        );
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].kind, "exact");
+        assert_eq!(hits[0].in_file, "new.rs");
+        assert!(hits[0].clone_of.iter().any(|r| r.contains("load_user")), "{:?}", hits[0].clone_of);
     }
 
     #[test]
-    fn no_op_on_empty_index_and_unparseable_text() {
+    fn batch_checks_multiple_files_and_tags_in_file() {
+        let db = fixture_db("batch");
+        let inputs = vec![
+            CloneCheckInput {
+                text: "pub fn a_clone(s: Db) -> i32 { let x = s.get(1); validate(x); x + 1 }\n"
+                    .to_string(),
+                language: crate::language::Language::Rust,
+                path: std::path::PathBuf::from("a.rs"),
+            },
+            CloneCheckInput {
+                text: "pub fn unrelated() -> i32 { 42 }\n".to_string(),
+                language: crate::language::Language::Rust,
+                path: std::path::PathBuf::from("b.rs"),
+            },
+        ];
+        let hits = db.clones_of_texts(&inputs).unwrap();
+        // a.rs's clone is flagged; b.rs's trivial fn is below MIN_TOKENS / not a clone.
+        assert_eq!(hits.len(), 1, "{hits:?}");
+        assert_eq!(hits[0].in_file, "a.rs");
+        assert!(hits[0].clone_of.iter().any(|r| r.contains("load_user")));
+    }
+
+    #[test]
+    fn excludes_self_file_so_in_place_edits_dont_self_flag() {
+        let db = fixture_db("self");
+        // Re-write load_user IN its own file: it must NOT be reported as a clone of its indexed
+        // self.
+        let edited = "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\n";
+        let hits = db
+            .clones_of_text(
+                edited,
+                crate::language::Language::Rust,
+                std::path::Path::new("src/lib.rs"),
+            )
+            .unwrap();
+        assert!(hits.is_empty(), "self-file match must be excluded, got {hits:?}");
+    }
+
+    #[test]
+    fn no_op_on_unparseable_text() {
         let db = fixture_db("noop");
-        // Garbage / non-function text → no fingerprints → empty, never an error.
         let none = db
             .clones_of_text(
                 "not real code !!!",

--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -1,0 +1,300 @@
+//! Clone-check of arbitrary, not-yet-indexed text (#287): fingerprint the functions in `text`
+//! in-memory and find their EXACT (`struct_hash`) and NEAR (≥θ overlap) clones among the INDEXED
+//! symbols — the engine behind a write-time "you just wrote a clone" check for coding agents.
+//!
+//! Read-only and best-effort: it never writes and returns an empty list (a no-op) when there's
+//! nothing to compare against (empty/absent fingerprints) or the text doesn't parse — so a caller
+//! (e.g. a Write/Edit hook) can run it unconditionally without ever blocking the agent. It reuses
+//! the parent `clones` module's EXACT candidate-gen primitives (`sub_block_tokens`, `overlap`,
+//! `verified_clone`) so a near match is the same relation `find_clones` would report.
+//!
+//! Self-matches (a function vs its own already-indexed copy, when editing in place) are NOT
+//! filtered here — the engine is pure; the caller, which knows the file being written, excludes its
+//! own path.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::path::Path;
+
+use rusqlite::Connection;
+use serde::Serialize;
+
+use super::{
+    DF_FALLBACK, HYDRATION_CHUNK, SymbolBag, THETA, TokenPosting, load_scoped_baseline_bags,
+    overlap, sub_block_tokens, verified_clone,
+};
+use crate::index::clones::{SymbolFingerprint, fingerprint_symbols};
+use crate::index::{IndexDatabase, parser, symbols};
+use crate::language::Language;
+
+/// One just-written function that duplicates existing indexed code.
+#[derive(Debug, Clone, Serialize)]
+pub struct TextCloneMatch {
+    /// The new function's name, as parsed from the text.
+    pub name: String,
+    /// 1-based line of the new function within the supplied text.
+    pub start_line: usize,
+    /// `"exact"` (identical structure — same `struct_hash`) or `"near"` (≥θ overlap).
+    pub kind: &'static str,
+    /// `overlap / max_len` similarity in `[θ, 1.0]`; `1.0` for an exact match.
+    pub similarity: f64,
+    /// Existing indexed refs (`path::name`) this function clones — sorted, deduplicated.
+    pub clone_of: Vec<String>,
+}
+
+impl IndexDatabase {
+    /// Find EXACT + NEAR clones of every fingerprintable function in `text` among the indexed
+    /// symbols. `path`/`language` drive PARSING only — `text` need not be saved or indexed. An
+    /// empty result means no clones OR nothing to compare against (a best-effort no-op, never
+    /// an error for an unparseable/empty input).
+    pub fn clones_of_text(
+        &self,
+        text: &str,
+        language: Language,
+        path: &Path,
+    ) -> anyhow::Result<Vec<TextCloneMatch>> {
+        let conn = self.storage.connection();
+
+        // Fingerprint the new functions in-memory — the exact pipeline indexing uses.
+        let syms = symbols::symbols_for_file(path, language, text);
+        let Some(parsed) = parser::parse_file(path, language, text) else {
+            return Ok(Vec::new());
+        };
+        let new_fps = fingerprint_symbols(parsed.root(), text, language, &syms);
+        if new_fps.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Compare against the indexed baseline bags. Empty/absent index → nothing to clone → no-op.
+        let indexed = load_scoped_baseline_bags(conn)?;
+        if indexed.is_empty() {
+            return Ok(Vec::new());
+        }
+        let by_id: BTreeMap<i64, &SymbolBag> = indexed.iter().map(|b| (b.symbol_id, b)).collect();
+        let df_by_token = load_clone_token_df(conn)?;
+
+        // `(struct_hash, language) -> ids` (exact) and the sub-block `token -> ids` inverted index
+        // (near) — built once over the indexed bags.
+        let mut by_struct: HashMap<(&str, &str), Vec<i64>> = HashMap::new();
+        let mut inverted: HashMap<i64, Vec<i64>> = HashMap::new();
+        for bag in &indexed {
+            by_struct
+                .entry((bag.struct_hash.as_str(), bag.language.as_str()))
+                .or_default()
+                .push(bag.symbol_id);
+            for token in sub_block_tokens(bag, THETA) {
+                inverted.entry(token).or_default().push(bag.symbol_id);
+            }
+        }
+
+        let lang = language.as_str();
+        let mut id_set: BTreeSet<i64> = BTreeSet::new();
+        // (name, start_line, kind, similarity, existing_ids)
+        let mut pending: Vec<(String, usize, &'static str, f64, Vec<i64>)> = Vec::new();
+
+        for (local, fp) in &new_fps {
+            let symbol = &syms[*local];
+            let new_bag = bag_from_fingerprint(fp, lang, &df_by_token);
+
+            // EXACT: identical structure (same struct_hash + language) → similarity 1.0.
+            let exact: Vec<i64> =
+                by_struct.get(&(fp.struct_hash.as_str(), lang)).cloned().unwrap_or_default();
+            let exact_set: BTreeSet<i64> = exact.iter().copied().collect();
+            if !exact.is_empty() {
+                id_set.extend(&exact);
+                pending.push((symbol.name.clone(), symbol.start_line, "exact", 1.0, exact));
+            }
+
+            // NEAR: candidates share a sub-block token; kept by the exact overlap verify. Exclude
+            // ids already reported as exact for this function.
+            let mut cand: BTreeSet<i64> = BTreeSet::new();
+            for token in sub_block_tokens(&new_bag, THETA) {
+                if let Some(ids) = inverted.get(&token) {
+                    cand.extend(ids);
+                }
+            }
+            let mut near_ids: Vec<i64> = Vec::new();
+            let mut best_sim = 0.0_f64;
+            for id in cand {
+                if exact_set.contains(&id) {
+                    continue;
+                }
+                let other = by_id[&id];
+                if other.language != lang || !verified_clone(&new_bag, other, THETA) {
+                    continue;
+                }
+                let max_len = new_bag.token_len.max(other.token_len);
+                let sim = if max_len == 0 {
+                    1.0
+                } else {
+                    overlap(&new_bag, other) as f64 / max_len as f64
+                };
+                best_sim = best_sim.max(sim);
+                near_ids.push(id);
+            }
+            if !near_ids.is_empty() {
+                id_set.extend(&near_ids);
+                pending.push((symbol.name.clone(), symbol.start_line, "near", best_sim, near_ids));
+            }
+        }
+
+        let refs = resolve_refs(conn, &id_set)?;
+        let mut matches: Vec<TextCloneMatch> = pending
+            .into_iter()
+            .map(|(name, start_line, kind, similarity, ids)| {
+                let mut clone_of: Vec<String> =
+                    ids.iter().filter_map(|id| refs.get(id).cloned()).collect();
+                clone_of.sort();
+                clone_of.dedup();
+                TextCloneMatch { name, start_line, kind, similarity, clone_of }
+            })
+            .filter(|m| !m.clone_of.is_empty())
+            .collect();
+        matches.sort_by(|a, b| {
+            a.start_line
+                .cmp(&b.start_line)
+                .then_with(|| a.name.cmp(&b.name))
+                .then(a.kind.cmp(b.kind))
+        });
+        Ok(matches)
+    }
+}
+
+/// `token_hash -> df` over the baseline normalizer — the selectivity source for a NEW bag's
+/// sub-block ordering. A token absent from the index is maximally selective (`DF_FALLBACK`),
+/// matching `load_scoped_baseline_bags`.
+fn load_clone_token_df(conn: &Connection) -> anyhow::Result<HashMap<i64, i64>> {
+    let mut stmt = conn
+        .prepare("SELECT token_hash, df FROM clone_token_df WHERE normalizer_kind = 'baseline'")?;
+    let rows = stmt.query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, i64>(1)?)))?;
+    let mut map = HashMap::new();
+    for row in rows {
+        let (token_hash, df) = row?;
+        map.insert(token_hash, df);
+    }
+    Ok(map)
+}
+
+/// A candidate-gen [`SymbolBag`] for a fresh, not-yet-indexed fingerprint (`symbol_id = -1`).
+/// Tokens carry the indexed df (or `DF_FALLBACK`), matching `load_scoped_baseline_bags` so
+/// `sub_block_tokens` orders identically.
+fn bag_from_fingerprint(
+    fp: &SymbolFingerprint,
+    language: &str,
+    df_by_token: &HashMap<i64, i64>,
+) -> SymbolBag {
+    let tokens = fp
+        .token_bag
+        .iter()
+        .map(|&(token_hash, freq)| TokenPosting {
+            token_hash,
+            freq,
+            coalesced_df: df_by_token.get(&token_hash).copied().unwrap_or(DF_FALLBACK),
+        })
+        .collect();
+    SymbolBag {
+        symbol_id: -1,
+        language: language.to_string(),
+        struct_hash: fp.struct_hash.clone(),
+        token_len: fp.token_len,
+        tokens,
+    }
+}
+
+/// Resolve indexed symbol ids → `path::name` refs (the same `name_strings` source as
+/// `CloneMember.ref`), chunked to respect SQLite's bound-parameter limit.
+fn resolve_refs(conn: &Connection, ids: &BTreeSet<i64>) -> anyhow::Result<HashMap<i64, String>> {
+    let ids: Vec<i64> = ids.iter().copied().collect();
+    let mut refs = HashMap::new();
+    for chunk in ids.chunks(HYDRATION_CHUNK) {
+        let placeholders: Vec<String> = (1..=chunk.len()).map(|i| format!("?{i}")).collect();
+        let sql = format!(
+            "SELECT symbols.id, ns.value FROM symbols
+             JOIN name_strings ns ON ns.id = symbols.qualified_name_id
+             WHERE symbols.id IN ({})",
+            placeholders.join(", ")
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(rusqlite::params_from_iter(chunk.iter()), |r| {
+            Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?))
+        })?;
+        for row in rows {
+            let (id, value) = row?;
+            refs.insert(id, value);
+        }
+    }
+    Ok(refs)
+}
+
+#[cfg(test)]
+mod tests {
+    fn fixture_db(tag: &str) -> crate::IndexDatabase {
+        let root = std::env::temp_dir().join(format!(
+            "rag-rat-of-text-{tag}-{}-{}",
+            std::process::id(),
+            crate::index::util::now_ms()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        // An indexed function the new text will clone.
+        std::fs::write(
+            root.join("src/lib.rs"),
+            "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\n",
+        )
+        .unwrap();
+        let config = crate::Config {
+            root: root.clone(),
+            database: root.join(".rag-rat/index.sqlite"),
+            targets: vec![crate::config::ResolvedTarget {
+                name: "rust".to_string(),
+                language: crate::language::Language::Rust,
+                directories: vec![std::path::PathBuf::from("src")],
+                include: vec!["src/".to_string()],
+                exclude: Vec::new(),
+                kind: crate::config::TargetKind::Source,
+            }],
+            local_ai: Default::default(),
+            watch: Default::default(),
+            version_check: Default::default(),
+            oracle: Default::default(),
+        };
+        crate::IndexDatabase::rebuild(&config).unwrap()
+    }
+
+    #[test]
+    fn finds_exact_and_near_clones_of_new_text() {
+        let db = fixture_db("hit");
+
+        // EXACT: byte-identical structure (renamed identifiers normalize away) to the indexed fn.
+        let exact_text = "pub fn fetch_account(store: Db) -> i32 { let a = store.get(20); \
+                          validate(a); a + 1 }\n";
+        let exact = db
+            .clones_of_text(
+                exact_text,
+                crate::language::Language::Rust,
+                std::path::Path::new("new.rs"),
+            )
+            .unwrap();
+        assert_eq!(exact.len(), 1, "one new function checked");
+        assert_eq!(exact[0].kind, "exact");
+        assert_eq!(exact[0].similarity, 1.0);
+        assert!(
+            exact[0].clone_of.iter().any(|r| r.contains("load_user")),
+            "exact clone of load_user, got {:?}",
+            exact[0].clone_of
+        );
+    }
+
+    #[test]
+    fn no_op_on_empty_index_and_unparseable_text() {
+        let db = fixture_db("noop");
+        // Garbage / non-function text → no fingerprints → empty, never an error.
+        let none = db
+            .clones_of_text(
+                "not real code !!!",
+                crate::language::Language::Rust,
+                std::path::Path::new("x.rs"),
+            )
+            .unwrap();
+        assert!(none.is_empty());
+    }
+}

--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -74,6 +74,19 @@ impl IndexDatabase {
         index.check(conn, text, language, path)
     }
 
+    /// Cheap count of fingerprinted baseline functions — a write-time hook reads it to BOUND its
+    /// cost: `clones_of_text(s)` loads every bag + builds an in-RAM inverted index (O(functions))
+    /// until the persisted-postings follow-up lands, so a hook skips (no-ops) above a threshold
+    /// rather than risk a perceptible delay on a very large repo.
+    pub fn clone_check_function_count(&self) -> anyhow::Result<u64> {
+        let count: i64 = self.storage.connection().query_row(
+            "SELECT COUNT(*) FROM symbol_fingerprints WHERE normalizer_kind = 'baseline'",
+            [],
+            |r| r.get(0),
+        )?;
+        Ok(count.max(0) as u64)
+    }
+
     /// BATCH clone-check: load + structure the index ONCE, then check every input file against it.
     /// An empty index (nothing to compare against) yields an empty result — a best-effort no-op.
     pub fn clones_of_texts(

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -21,6 +21,7 @@ mod search;
 // the capped-class semantics by name (instead of hardcoding 50). Keeps the `clones` module
 // private so `build_class`'s reachability stays narrow (no `private_interfaces` widening of
 // `SymbolBag`).
+pub use clones::of_text::TextCloneMatch;
 pub use clones::{
     CandidateCloneClass, CloneCompleteness, CloneMember, CloneSymbolSelector,
     ClonesForSymbolResult, FindClonesOptions, FindClonesResult, RoiFactors,

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -21,7 +21,7 @@ mod search;
 // the capped-class semantics by name (instead of hardcoding 50). Keeps the `clones` module
 // private so `build_class`'s reachability stays narrow (no `private_interfaces` widening of
 // `SymbolBag`).
-pub use clones::of_text::TextCloneMatch;
+pub use clones::of_text::{CloneCheckInput, TextCloneMatch};
 pub use clones::{
     CandidateCloneClass, CloneCompleteness, CloneMember, CloneSymbolSelector,
     ClonesForSymbolResult, FindClonesOptions, FindClonesResult, RoiFactors,

--- a/docs/clone-graph-precompute-design.md
+++ b/docs/clone-graph-precompute-design.md
@@ -1,0 +1,226 @@
+# Precomputed clone-edge graph for `find_clones`
+
+Status: design approved (2026-06-24), implementation in progress on `feat/clone-graph-precompute`.
+This doc is intentionally uncommitted — review artifact.
+
+## Problem
+
+`find_clones` recomputes a super-linear SourcererCC candidate-pair graph on every query
+(`candidate_pairs_from_bags` → `sub_block_candidate_pairs` builds the inverted index in RAM and
+emits the upper triangle of every token's posting list, then `verified_clone`). Fine at single-crate
+scale (cargo: 3,332 functions, ~15s) but does **not** scale: the Linux kernel `drivers/net` (118k
+functions) does not complete in 240s — candidate generation is the wall (CPU-bound, not OOM; it
+stayed under a 22GB cap). Verified empirically (see repo memory `find_clones does NOT scale to
+~118k functions`).
+
+## Goal
+
+Precompute and persist the **verified clone-edge graph** as a bounded, resumable **background** pass
+(mirroring the embedding `reconcile`), so `find_clones` reads a persisted graph instead of
+recomputing candidates. The pass cannot make candidate generation itself cheaper — it moves it off
+the query path, bounds it by a time budget, and makes it resumable so a huge codebase converges over
+several passes.
+
+## Locked decisions
+
+1. **Freshness = "mildly stale OK"** — eventually-consistent background recompute; `find_clones`
+   serves the last *completed* graph (stale-serving), not incremental always-fresh maintenance.
+2. **Persist depth = edges** (revised from "edges + postings" during implementation). A persisted
+   token→symbol postings table would, under the #248 volatile-FK invariant (see Data model), itself
+   have to be content-anchored — extra surface for a benefit only the incremental follow-up realizes.
+   The resumable recompute instead rebuilds the in-RAM inverted index from the existing
+   `symbol_fingerprints.token_bag` BLOBs each pass (cheap relative to pair emission). **Persisted
+   postings are deferred to the incremental-maintenance follow-up.**
+3. **Precompute at θ=0.7** (default `min_similarity`). Queries at θ>0.7 filter stored per-edge gate
+   inputs (a 0.7 edge set is a superset of any θ≥0.7 set). Queries at θ<0.7 fall back to live.
+4. **MCP is read-only** — writers are the watcher maintenance pass, the git-hook `maintenance`
+   command, and explicit `rag-rat clones --precompute`.
+5. **Fast path, never a correctness dependency** — graph absent / no completed generation / θ<0.7 /
+   non-base scope → today's live path, unchanged.
+6. **MVP scope = base index only**; worktree overlays fall back to live (follow-up).
+
+## Data model (migration V034 — implemented)
+
+Generation-staged so a half-built graph is never served: the recompute writes a new
+`build_generation`; reads serve the latest **Complete** generation; the live pointer flips
+atomically on completion.
+
+**Endpoints are content-anchored, NOT `symbol_id`.** A repo invariant (the #248 bug class, enforced
+by the `no_table_has_a_reindex_cascading_fk_to_a_volatile_parent` trip-wire) forbids a durable table
+from carrying an `ON DELETE CASCADE` FK to a `REINDEX_VOLATILE_PARENT` (`symbols`, `files`,
+`edges_data`, `logical_symbols`) — `symbol_id` is reassigned on every reindex, so keying on it is the
+exact bug that silently wiped `edge_oracle` verdicts. `clone_edges` therefore anchors each endpoint
+on the reindex-stable `(path, start_byte)` + the `file_sha` (`files.sha256`) at compute time — the
+same content-key/staleness pattern as `edge_oracle`. Reads resolve an endpoint by joining live
+`symbols`/`files` on `(path, start_byte)` AND `files.sha256 = *_file_sha`; a deleted or edited
+endpoint simply does not resolve, so a dangling/stale edge is dropped at read (never a ghost). The
+`build_generation` FK targets `clone_graph_generations`, which is **durable** precompute metadata
+(not volatile), so that CASCADE is allowed and powers generation GC.
+
+```sql
+CREATE TABLE clone_graph_generations(
+    generation         INTEGER PRIMARY KEY,
+    status             TEXT    NOT NULL CHECK (status IN ('Building','Complete')),
+    theta_floor        REAL    NOT NULL,   -- 0.7
+    normalizer_kind    TEXT    NOT NULL,   -- 'baseline'
+    normalizer_version INTEGER NOT NULL,   -- NORM_VERSION at build
+    source_revision    TEXT    NOT NULL,   -- content_revision() this generation builds toward
+    cursor_symbol_id   INTEGER NOT NULL DEFAULT 0,  -- build-local resume point
+    edges_written      INTEGER NOT NULL DEFAULT 0,
+    started_at_ms      INTEGER NOT NULL,
+    finished_at_ms     INTEGER
+) STRICT;
+
+CREATE TABLE clone_edges(
+    build_generation INTEGER NOT NULL REFERENCES clone_graph_generations(generation) ON DELETE CASCADE,
+    a_path           TEXT    NOT NULL,     -- content anchor (canonical a < b by path,start_byte)
+    a_start_byte     INTEGER NOT NULL,
+    a_file_sha       TEXT    NOT NULL,     -- files.sha256 at compute; read-time staleness filter
+    b_path           TEXT    NOT NULL,
+    b_start_byte     INTEGER NOT NULL,
+    b_file_sha       TEXT    NOT NULL,
+    overlap          INTEGER NOT NULL,     -- exact verified_clone gate inputs (theta>=0.7 re-filters)
+    a_token_len      INTEGER NOT NULL,
+    b_token_len      INTEGER NOT NULL,
+    similarity       REAL    NOT NULL,     -- overlap/max_len; 1.0 for struct-hash-exact pairs
+    edge_source      TEXT    NOT NULL,     -- 'struct_hash' | 'sub_block'
+    PRIMARY KEY (build_generation, a_path, a_start_byte, b_path, b_start_byte)
+) STRICT;
+CREATE INDEX idx_clone_edges_b ON clone_edges(build_generation, b_path, b_start_byte);
+-- (clone_subblock_postings deferred: the in-RAM index is rebuilt from symbol_fingerprints.token_bag
+--  each pass; a persisted, content-anchored postings table lands with incremental maintenance.)
+```
+
+Meta key (in `index_meta`, via `set_meta`): `clone_graph_live_generation` → the generation the read
+path serves (the newest `Complete`).
+
+## Recompute pass (resumable, generation-staged)
+
+New module `index/clones/reconcile.rs`, mirroring `index/ai/reconcile.rs`. Entry:
+`reconcile_clone_edges(conn, CloneEdgeOptions{max_seconds, batch_size, force}, progress) ->
+CloneEdgeReport`.
+
+- **Phase 0 — skip-when-current.** If the latest `Complete` generation's `source_revision ==
+  content_revision()` and `normalizer_version == NORM_VERSION` and `!force` → return `Current`,
+  zero writes (the `model_manifest_is_current` no-op pattern; keeps idle passes free).
+- **Phase 1 — open/resume a building generation.** Reuse an existing `Building` row (resume at its
+  `cursor_symbol_id`) or allocate `generation = max+1`, `status='Building'`, `source_revision =
+  content_revision()` snapshot.
+- **Phase 2 — refresh postings** for the building generation (stream fingerprint BLOBs → emit
+  `(sub_block_token → symbol_id)` rows). Chunkable by symbol-id cursor.
+- **Phase 3 — gen edges (the streaming SourcererCC form).** Walk symbols in `symbol_id` ASC from
+  `cursor_symbol_id + 1`. For each symbol `s`: its sub-block tokens → query `clone_subblock_postings`
+  for partners `t > s` only (smaller-endpoint partition → each unordered pair emitted once, dedup is
+  structural) → `verified_clone(B_s, B_t, 0.7)` → on pass insert `(s, t, overlap, token_lens,
+  similarity, struct_hashes)`. Also emit the struct-hash exact pairs for `s` (`similarity = 1.0`).
+  Batch by `batch_size`; per-symbol (not just per-batch) budget check; checkpoint `cursor_symbol_id`
+  after each batch in one txn with that batch's edge inserts.
+- **Completion.** When the walk reaches the last symbol: set the generation `status='Complete'`,
+  `finished_at_ms`, `edges_written`, then set `clone_graph_live_generation = generation` and delete
+  superseded generations (CASCADE drops their edges/postings) — the live-pointer flip is the **last**
+  write (publish-after-build, so readers see old-Complete or new-Complete, never Building).
+- **Budget trip.** Persist the cursor, leave `status='Building'`, return `Partial`. Next pass resumes.
+- **Mid-build reindex** (between passes): CASCADE may drop some staging edges the cursor already
+  passed → the completed generation has *false negatives* (missing edges), never wrong edges. Under
+  "mildly stale OK" this is acceptable; the next clean pass (after edits settle) repairs them.
+
+`CloneEdgeReport`/`CloneEdgeProgress` mirror `ReconcileReport`/`ReconcileProgress`.
+
+## `find_clones` read path
+
+One branch in `find_clones` (and `clones_for_symbol`) replaces how `pairs` is sourced; everything
+downstream is unchanged.
+
+```rust
+let pairs = match precomputed_pairs_if_eligible(conn, &by_id, theta)? {
+    Some(pairs) => pairs,                       // FAST
+    None        => candidate_pairs_from_bags(&bags, theta),  // LIVE (unchanged)
+};
+```
+
+`precomputed_pairs_if_eligible` returns `Some` iff: θ ≥ 0.7, a `Complete` generation exists with
+`normalizer_version == NORM_VERSION`, and base scope. It then, inside one read transaction:
+1. loads `clone_edges` for `clone_graph_live_generation`;
+2. **resolves + validates each endpoint** by joining live `symbols`/`files` on `(path, start_byte)`
+   AND `files.sha256 = *_file_sha` (→ a live `symbol_id`); an endpoint that doesn't resolve
+   (deleted / edited file) drops the edge (count them as `graph_edges_dropped_stale`);
+3. **scope-filters** to pairs whose both resolved endpoints are in `by_id`;
+4. **θ-filters**: keep iff `overlap >= ceil(theta * max(a_token_len, b_token_len))` (exact parity
+   with `verified_clone`; struct-hash pairs have `overlap == token_len` → similarity 1.0 → always
+   survive).
+
+Downstream `components_from_pairs` → `coherence_split` (fed the stored `similarity`) → `build_class`
+→ refine (already cached) runs unchanged. Stale-serving: a present-but-stale live generation is still
+served; `CloneCompleteness` gains `served_from: "precomputed" | "live"`, `graph_source_revision`, and
+`graph_edges_dropped_stale`, so staleness is honest. Member hydration safety is already handled by
+`build_class`'s existing TOCTOU defenses + the endpoint validation in (2).
+
+## Freshness model
+
+`graph_fresh` = `clone_graph_live_generation` row exists AND `source_revision == content_revision()`
+AND `normalizer_version == NORM_VERSION`. `content_revision` (files-sha digest) + the explicit
+`normalizer_version` pin together catch the common edits and a NORM bump (which `content_revision`
+alone misses). A generated-flag flip without a file edit is a known residual gap → full
+fingerprint-digest freshness is a follow-up if it ever bites. Staleness never blocks reads (locked).
+
+## Triggers / wiring
+
+All three writers share one `ReconcileBudget` (embeddings claim first, clone-edges take the
+remainder), so a pass stays within one `PASS_RECONCILE_MAX_SECONDS`:
+- **`watch.rs::run_pass`** — sibling step after the base embedding reconcile, inside the existing
+  idle-backstop guard, gated by `pending_clone_graph()` (absent or stale).
+- **`commands/mod.rs::run_maintenance_pass`** (git-hook) — same insertion; clone report joins the
+  JSON under `clone_graph`.
+- **`rag-rat clones --precompute [--max-seconds N]`** — explicit foreground writer (RW open under
+  `WriteLock`), loops passes to `Complete`.
+- **Full rebuild does NOT force-complete edges** (would regress index time per #251/#285 lessons);
+  CASCADE leaves the graph consistent, background passes fill it.
+
+## Status / CLI surface
+
+`status()` gains `clone_graph_fresh: bool`, `clone_graph_source_revision`, `clone_graph_built_at_ms`,
+`clone_graph_edge_count` (read from the live generation row — NOT a `COUNT(*)`; honors the #285
+"status stays cheap" rule). `clones --precompute` prints a `CloneEdgeReport`.
+
+## Module layout / files touched
+
+- `index/schema/migrations.rs` + `mod.rs` — V034 DDL const + `apply_*` fn; consts + 3 match arms +
+  `ADDITIVE_MIGRATIONS` entry; bump `LATEST_SCHEMA_VERSION` to 34.
+- `index/clones/reconcile.rs` (new) — `reconcile_clone_edges`, options/report/progress, the streaming
+  build, checkpoint/resume.
+- `index/clones/edges_store.rs` (new) — `clone_edges`/`clone_subblock_postings`/generation read+write
+  helpers, `precomputed_pairs_if_eligible`, `pending_clone_graph`, freshness getters.
+- `index/clones/mod.rs` — add the two modules to the curated index.
+- `query_api/clones.rs` — the fast-path branch in `find_clones` + `clones_for_symbol`; `CloneCompleteness`
+  provenance fields; `CLONE_PRECOMPUTE_THETA`.
+- `query_api/mod.rs` + `index/mod.rs` — status fields (cheap reads).
+- `watch.rs`, `commands/mod.rs`, `cli.rs` — trigger wiring + CLI flag.
+
+## Testing
+
+1. **Parity (cornerstone)** — on the cargo fixture, `find_clones` via precomputed graph ==
+   via live path, byte-identical `recall_signature`, for θ ∈ {0.7, 0.8, 0.9} × several `min_copies`.
+2. **Resume** — tiny `max_seconds` trips `Partial` mid-walk; resume to `Complete`; final edge set ==
+   one uninterrupted pass (proves the smaller-endpoint partition is correct across a checkpoint).
+3. **CASCADE / stale** — delete a symbol's file / reindex; dependent edges vanish; no dangling
+   hydrate. Endpoint struct_hash mismatch drops the edge + increments `graph_edges_dropped_stale`.
+4. **Skip-when-current** — second pass takes zero write locks; no generation row added.
+5. **Fallback** — θ<0.7, no Complete generation, wrong norm_version, overlay scope → live path,
+   result == today.
+6. **Budget sharing** — embeddings first, clone-edges remainder; near-exhausted budget skips cleanly.
+7. **Schema** — V034 fresh-DB + forward-migrate + checksum-stable; `CHECK(a<b)` rejection.
+
+## Phasing
+
+- **A — substrate**: V034 migration (3 tables + meta) + `edges_store.rs` skeleton + status fields.
+  No read-path change; ships safe.
+- **B — recompute**: `reconcile.rs` streaming build + `clones --precompute` CLI. Writer only.
+- **C — read path**: `precomputed_pairs_if_eligible` + the two splices + parity test. The behavior
+  change, gated on parity.
+- **D — auto-maintenance**: `watch.rs` + `maintenance` budgeted sibling step.
+
+## Non-goals / follow-ups
+
+Incremental delta maintenance (always-fresh); worktree-overlay graphs; θ<0.7 coverage; full
+fingerprint-digest freshness; serving built/ranked classes (only candidate gen is precomputed —
+`coherence_split`/`build_class`/refine stay live, bounded by #272/#282 + `min_copies`).


### PR DESCRIPTION
Closes #287. **Independent of #286** (uses the existing live candidate-gen primitives, not the precomputed graph) — the two can merge in any order.

Coding agents routinely re-implement a function that already exists. This fingerprints the functions an agent is *about to write* and warns when they duplicate indexed code, so it reuses instead.

## Engine — `clones_of_text` / `clones_of_texts`
Fingerprints the functions in arbitrary, not-yet-indexed text (the exact `symbols_for_file` + `fingerprint_symbols` pipeline) and finds, for each:
- **1:1 / exact** — identical structure (same `struct_hash`), a hash-bucket lookup;
- **near-identical** — ≥θ=0.7 overlap, via the candidate-gen primitives (`sub_block_tokens` → shared-token candidates → exact `overlap` verify), the same relation `find_clones` reports.

**Batch-first**: `clones_of_texts` loads + structures the index ONCE and checks N files (a MultiEdit, or a multi-file batch). Each match carries `in_file`; self-file matches are excluded (an in-place edit doesn't flag against its own indexed copy).

## Hook — `claude-hook` on Write/Edit/MultiEdit
Injects a PreToolUse `additionalContext` warning (an *allow*, never a block). Write → the whole content; Edit → the new_string; MultiEdit → each edit's new_string (a batch). Auto-fires once `rag-rat hooks install --claude` registers the matchers.

## Never freezes the agent (the non-negotiable)
Every not-ready path is a silent no-op: no rag-rat.toml / DB not built → skip; `try_open_config_read_only` is None (index owes a heal/migrate) → skip; `> 40k` fingerprints → skip (the in-RAM check is O(functions) until the persisted-postings follow-up); unparseable / no functions → skip. Read-only; all errors swallowed.

## Tests
Engine (exact, batch + `in_file`, self-file exclusion, no-op), hook input extraction (Write/Edit/MultiEdit + path relativization), warning rendering, install matchers. 1032 workspace tests, clippy `--all-targets`, nightly fmt.

Follow-up: a persisted sub-block postings index makes the near tier sub-second per write on very large repos (above the 40k guard it currently no-ops).