### PR TITLE
feat(doctor): flag stale clone fingerprints + stop listing migrations twice

### DIFF
--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -525,16 +525,24 @@ pub(crate) fn set_env_if_absent(key: &str, value: Option<u32>) {
 }
 pub(crate) fn doctor(config: &Config) -> anyhow::Result<()> {
     let schema = IndexDatabase::migration_check(&config.database)?;
-    let (index, discovery, storage) =
+    let (index, discovery, storage, clone_fingerprints) =
         if schema.state == rag_rat_core::index::schema::SchemaState::Compatible {
             let db = IndexDatabase::open_config(config)?;
+            let mut index_status = serde_json::to_value(db.status(&config.database)?)?;
+            // Schema (incl. the migrations list) is reported once at the top level from
+            // `migration_check`; drop the duplicate copy nested in `index` so `doctor` doesn't list
+            // migrations twice.
+            if let Some(object) = index_status.as_object_mut() {
+                object.remove("schema");
+            }
             (
-                Some(serde_json::to_value(db.status(&config.database)?)?),
+                Some(index_status),
                 Some(serde_json::to_value(db.discovery_status(config)?)?),
                 Some(serde_json::to_value(db.storage_status()?)?),
+                Some(serde_json::to_value(db.clone_fingerprint_health()?)?),
             )
         } else {
-            (None, None, None)
+            (None, None, None, None)
         };
     print_output(&serde_json::json!({
         "config_root": config.root,
@@ -542,6 +550,7 @@ pub(crate) fn doctor(config: &Config) -> anyhow::Result<()> {
         "schema": schema,
         "storage": storage,
         "discovery": discovery,
+        "clone_fingerprints": clone_fingerprints,
         "targets": config.targets.iter().map(|target| serde_json::json!({
             "name": target.name,
             "language": target.language.as_str(),

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -49,9 +49,10 @@ pub(crate) use mem_diag::{maybe_set_sqlite_soft_heap_limit, mem_trace};
 pub use parser_failures::ParserFailure;
 pub(crate) use prep::*;
 pub use query_api::{
-    CandidateCloneClass, CloneCheckInput, CloneCompleteness, CloneEdgeReport, CloneMember,
-    CloneSymbolSelector, ClonesForSymbolResult, FindClonesOptions, FindClonesResult, GcReport,
-    ImportantSymbolsRequest, OracleShaSnapshots, RoiFactors, SearchRequest, TextCloneMatch,
+    CandidateCloneClass, CloneCheckInput, CloneCompleteness, CloneEdgeReport,
+    CloneFingerprintHealth, CloneMember, CloneSymbolSelector, ClonesForSymbolResult,
+    FindClonesOptions, FindClonesResult, GcReport, ImportantSymbolsRequest, OracleShaSnapshots,
+    RoiFactors, SearchRequest, TextCloneMatch,
 };
 pub(crate) use util::*;
 

--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -26,7 +26,7 @@ use super::{
     DF_FALLBACK, HYDRATION_CHUNK, SymbolBag, THETA, TokenPosting, load_scoped_baseline_bags,
     overlap, sub_block_tokens, verified_clone,
 };
-use crate::index::clones::{SymbolFingerprint, fingerprint_symbols};
+use crate::index::clones::{NORM_VERSION, SymbolFingerprint, fingerprint_symbols};
 use crate::index::{IndexDatabase, parser, symbols};
 use crate::language::Language;
 
@@ -58,6 +58,28 @@ pub struct TextCloneMatch {
     pub clone_of: Vec<String>,
 }
 
+/// Whether the index's baseline clone fingerprints are usable by clone detection. The clone read
+/// path filters `normalizer_version = NORM_VERSION`, so an index last fingerprinted by an OLDER
+/// binary (one built before a NORM_VERSION bump) has ZERO usable bags and every clone feature
+/// (`find_clones`, `clones_of_text`, the precompute) silently returns empty. `doctor` surfaces this
+/// so the fix — a reindex — is obvious rather than a mysterious "no clones found".
+#[derive(Debug, Clone, Serialize)]
+pub struct CloneFingerprintHealth {
+    /// The `NORM_VERSION` the clone read path requires.
+    pub required_norm_version: i64,
+    /// Baseline fingerprints AT the required version — the functions clone detection can actually
+    /// use. Zero here (with `total > 0`) means clone detection is disabled.
+    pub usable: u64,
+    /// Total baseline fingerprints across ALL normalizer versions. Stale rows from older binaries
+    /// or other git contexts inflate this above `usable`.
+    pub total: u64,
+    /// True when fingerprints exist but NONE are at the required version: clone detection is fully
+    /// disabled until a reindex recomputes them.
+    pub needs_reindex: bool,
+    /// Actionable note (the exact command) when `needs_reindex`; `None` otherwise.
+    pub message: Option<String>,
+}
+
 impl IndexDatabase {
     /// Find EXACT + NEAR clones of every fingerprintable function in `text` among the indexed
     /// symbols (single-file convenience over [`Self::clones_of_texts`]).
@@ -85,6 +107,40 @@ impl IndexDatabase {
             |r| r.get(0),
         )?;
         Ok(count.max(0) as u64)
+    }
+
+    /// Report whether the baseline clone fingerprints are at the [`NORM_VERSION`] the clone read
+    /// path requires. Cheap (two COUNTs). `doctor` surfaces it so the silent-empty failure mode
+    /// after a NORM_VERSION bump (an index maintained by an older binary) is diagnosable —
+    /// the fix is `rag-rat index --full`.
+    pub fn clone_fingerprint_health(&self) -> anyhow::Result<CloneFingerprintHealth> {
+        let conn = self.storage.connection();
+        let total: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM symbol_fingerprints WHERE normalizer_kind = 'baseline'",
+            [],
+            |r| r.get(0),
+        )?;
+        let usable: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM symbol_fingerprints WHERE normalizer_kind = 'baseline' AND \
+             normalizer_version = ?1",
+            [NORM_VERSION],
+            |r| r.get(0),
+        )?;
+        let needs_reindex = total > 0 && usable == 0;
+        let message = needs_reindex.then(|| {
+            format!(
+                "Clone fingerprints predate NORM_VERSION {NORM_VERSION}; clone detection \
+                 (find_clones, the write-time clone check) sees 0 functions. Run `rag-rat index \
+                 --full` to recompute them."
+            )
+        });
+        Ok(CloneFingerprintHealth {
+            required_norm_version: NORM_VERSION,
+            usable: usable.max(0) as u64,
+            total: total.max(0) as u64,
+            needs_reindex,
+            message,
+        })
     }
 
     /// BATCH clone-check: load + structure the index ONCE, then check every input file against it.
@@ -423,5 +479,64 @@ mod tests {
             )
             .unwrap();
         assert!(none.is_empty());
+    }
+
+    #[test]
+    fn clone_fingerprint_health_flags_stale_normalizer_version_for_reindex() {
+        // Self-contained build (not `fixture_db`) so we keep the db path for the downgrade step.
+        let root = std::env::temp_dir().join(format!(
+            "rag-rat-of-text-health-{}-{}",
+            std::process::id(),
+            crate::index::util::now_ms()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(
+            root.join("src/lib.rs"),
+            "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\n",
+        )
+        .unwrap();
+        let db_path = root.join(".rag-rat/index.sqlite");
+        let config = crate::Config {
+            root: root.clone(),
+            database: db_path.clone(),
+            targets: vec![crate::config::ResolvedTarget {
+                name: "rust".to_string(),
+                language: crate::language::Language::Rust,
+                directories: vec![std::path::PathBuf::from("src")],
+                include: vec!["src/".to_string()],
+                exclude: Vec::new(),
+                kind: crate::config::TargetKind::Source,
+            }],
+            local_ai: Default::default(),
+            watch: Default::default(),
+            version_check: Default::default(),
+            oracle: Default::default(),
+        };
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+
+        // Fresh index: fingerprints land at the current NORM_VERSION → healthy, no reindex prompt.
+        let healthy = db.clone_fingerprint_health().unwrap();
+        assert_eq!(healthy.required_norm_version, crate::index::clones::NORM_VERSION);
+        assert!(healthy.usable > 0 && healthy.total > 0, "{healthy:?}");
+        assert!(!healthy.needs_reindex && healthy.message.is_none(), "{healthy:?}");
+
+        // Simulate an index last fingerprinted by an OLDER binary (pre-NORM_VERSION bump): every
+        // baseline row drops a version, so the clone read path's `= NORM_VERSION` filter matches
+        // none — exactly the silent-empty state `doctor` must surface. (2nd WAL connection; the
+        // index handle is idle.)
+        {
+            let c = rusqlite::Connection::open(&db_path).unwrap();
+            c.execute(
+                "UPDATE symbol_fingerprints SET normalizer_version = ?1 WHERE normalizer_kind = \
+                 'baseline'",
+                [crate::index::clones::NORM_VERSION - 1],
+            )
+            .unwrap();
+        }
+        let stale = db.clone_fingerprint_health().unwrap();
+        assert!(stale.total > 0 && stale.usable == 0, "{stale:?}");
+        assert!(stale.needs_reindex, "{stale:?}");
+        assert!(stale.message.unwrap().contains("index --full"), "actionable command");
     }
 }

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -21,7 +21,7 @@ mod search;
 // the capped-class semantics by name (instead of hardcoding 50). Keeps the `clones` module
 // private so `build_class`'s reachability stays narrow (no `private_interfaces` widening of
 // `SymbolBag`).
-pub use clones::of_text::{CloneCheckInput, TextCloneMatch};
+pub use clones::of_text::{CloneCheckInput, CloneFingerprintHealth, TextCloneMatch};
 pub use clones::precompute::CloneEdgeReport;
 pub use clones::{
     CandidateCloneClass, CloneCompleteness, CloneMember, CloneSymbolSelector,


### PR DESCRIPTION
Two `doctor` fixes, both prompted by a real debugging session where the write-time clone check silently no-op'd.

## 1. Surface stale clone fingerprints (the main ask)
An index last fingerprinted by an **older binary** (built before a NORM_VERSION bump — currently 3, bumped in #253) carries baseline fingerprints at the old version. Every clone feature — `find_clones`, the write-time clone check (#287), the precompute (#286) — filters `normalizer_version = NORM_VERSION`, so it sees **0 functions and silently returns empty**, with no error and no hint. (This is exactly what bit the rag-rat self-index, maintained by the old 0.8.0 binary.)

`doctor` now reports a `clone_fingerprints` block:
```
clone_fingerprints:
  required_norm_version: 3
  usable: 2939          # baseline fingerprints AT that version — what clone detection can use
  total: ...            # all versions (stale rows from old binaries / other git contexts inflate this)
  needs_reindex: false
  message: null         # when needs_reindex: "...Run `rag-rat index --full` to recompute them."
```
New `IndexDatabase::clone_fingerprint_health()` — two cheap COUNTs.

## 2. Stop listing migrations twice
`doctor` reported schema (incl. the full `migrations[]` array) **twice**: once at the top level from `migration_check`, and again nested under `index.schema` (from `IndexStatus`). The top-level one is kept (it's present even when the DB can't open); the nested duplicate is stripped from the doctor output.

## Tests
`clone_fingerprint_health_flags_stale_normalizer_version_for_reindex`: builds a fresh index (healthy → `needs_reindex: false`), downgrades the fingerprints' `normalizer_version`, asserts `needs_reindex` flips to true with the `index --full` hint. 1037 workspace tests, clippy `--all-targets`, nightly fmt.

## Follow-up (noted, not in this PR)
While writing this, the live #287 hook flagged its own test functions as ~88% similar to 50+ other test fns — the near tier (θ=0.7) is very noisy on boilerplate-heavy test code. Worth a separate issue: exclude `#[test]`/`#[cfg(test)]` fns from the write-time check, cap the match list, and/or raise the hook's near threshold.