### PR TITLE
feat(clones): exclude tests from the write-time clone check + raise its precision (#292)

### DIFF
--- a/crates/rag-rat-cli/src/claude_hook/mod.rs
+++ b/crates/rag-rat-cli/src/claude_hook/mod.rs
@@ -29,6 +29,16 @@ use serde::Deserialize;
 /// (#287) lands, so on a very large repo it no-ops rather than add a perceptible delay to a write.
 const MAX_CLONE_CHECK_FUNCTIONS: u64 = 40_000;
 
+/// Minimum similarity for a NEAR clone to be surfaced by the WRITE-TIME hook (#292). Higher than
+/// `find_clones`' 0.7: boilerplate-heavy code (esp. across a whole repo) pushes unrelated functions
+/// to ~0.7-0.8 token overlap, so a lower bar floods the agent with non-actionable matches. Exact
+/// (struct_hash) matches are always surfaced regardless of this.
+const HOOK_NEAR_THRESHOLD: f64 = 0.85;
+
+/// Cap the existing-function refs listed per clone match in the hook output — a single new function
+/// can be similar to many indexed ones; listing them all is noise. Show the first few + a count.
+const MAX_CLONE_REFS: usize = 5;
+
 // Only the unix Unix-socket listener path uses this; dead on Windows (which has no warm listener).
 #[cfg(unix)]
 const SOCKET_BUDGET: Duration = Duration::from_millis(250);
@@ -399,7 +409,7 @@ fn clone_check(input: &HookInput) -> anyhow::Result<()> {
     if inputs.is_empty() {
         return Ok(());
     }
-    let matches = db.clones_of_texts(&inputs)?;
+    let matches = db.clones_of_texts(&inputs, HOOK_NEAR_THRESHOLD)?;
     if let Some(context) = format_clone_warning(&matches) {
         // PreToolUse contract: allow + additionalContext (a warning, not a block).
         println!(
@@ -470,12 +480,12 @@ fn format_clone_warning(matches: &[TextCloneMatch]) -> Option<String> {
         } else {
             format!("~{:.0}% similar to", m.similarity * 100.0)
         };
+        let shown = m.clone_of.iter().take(MAX_CLONE_REFS).cloned().collect::<Vec<_>>().join(", ");
+        let extra = m.clone_of.len().saturating_sub(MAX_CLONE_REFS);
+        let more = if extra > 0 { format!(" (+{extra} more)") } else { String::new() };
         out.push_str(&format!(
-            "  • `{}` (line {}) is {} {}\n",
-            m.name,
-            m.start_line,
-            label,
-            m.clone_of.join(", ")
+            "  • `{}` (line {}) is {} {shown}{more}\n",
+            m.name, m.start_line, label,
         ));
     }
     out.push_str(

--- a/crates/rag-rat-cli/src/claude_hook/tests.rs
+++ b/crates/rag-rat-cli/src/claude_hook/tests.rs
@@ -592,3 +592,25 @@ fn format_clone_warning_renders_matches_and_is_silent_when_empty() {
         "{out}"
     );
 }
+
+#[test]
+fn format_clone_warning_caps_the_ref_list() {
+    // #292: a single near match can resemble many indexed fns — the hook shows only the first few
+    // plus a "+N more" count instead of a wall of refs.
+    let clone_of: Vec<String> = (0..12).map(|i| format!("src/m{i}.rs::f{i}")).collect();
+    let m = rag_rat_core::index::TextCloneMatch {
+        in_file: "src/a.rs".to_string(),
+        name: "wide".to_string(),
+        start_line: 1,
+        kind: "near",
+        similarity: 0.9,
+        clone_of,
+    };
+    let out = super::format_clone_warning(&[m]).unwrap();
+    assert!(out.contains("src/m0.rs::f0"), "shows the first ref: {out}");
+    assert!(
+        out.contains(&format!("(+{} more)", 12 - super::MAX_CLONE_REFS)),
+        "caps with a count: {out}"
+    );
+    assert!(!out.contains("src/m11.rs::f11"), "doesn't list every ref: {out}");
+}

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -448,8 +448,8 @@ impl IndexDatabase {
                 crate::index::edges::intern_edge_string(conn, &symbol.qualified_name)?;
             conn.prepare_cached(
                 "INSERT INTO symbols(file_id, language, name, qualified_name_id, scope_path, \
-                 kind, start_byte, end_byte, start_line, end_line, signature, docs)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                 kind, start_byte, end_byte, start_line, end_line, signature, docs, is_test)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
             )?
             .execute(params![
                 file_id,
@@ -464,6 +464,7 @@ impl IndexDatabase {
                 i64::try_from(symbol.end_line)?,
                 symbol.signature,
                 symbol.docs,
+                symbol.is_test,
             ])?;
             let symbol_id = conn.last_insert_rowid();
             symbol_ids.push(symbol_id);

--- a/crates/rag-rat-core/src/index/parser.rs
+++ b/crates/rag-rat-core/src/index/parser.rs
@@ -179,6 +179,12 @@ pub struct ParsedSymbol {
     pub end_line: usize,
     pub signature: Option<String>,
     pub docs: Option<String>,
+    /// Test code — a test FILE (cross-language path conventions) or a language-specific test
+    /// marker (Rust `#[test]`/`#[cfg(test)]`, Kotlin `@Test`, Python `test_*` / `*Test*` class
+    /// / conftest). Persisted as `symbols.is_test` so clone detection can keep tests out of
+    /// the corpus (tests are repetitive by construction, so they otherwise dominate near-clone
+    /// results with noise).
+    pub is_test: bool,
     pub facts: Vec<ParsedSymbolFact>,
 }
 
@@ -616,6 +622,7 @@ fn make_symbol(
     let start_line = node.start_position().row + 1;
     let end_line = node.end_position().row + 1;
     let scope_path = scope_path(language, node, text, &name);
+    let is_test = detect_is_test(path, language, text, node, &scope_path, &name);
     ParsedSymbol {
         qualified_name: format!("{}::{name}", path.to_string_lossy().replace('\\', "/")),
         scope_path,
@@ -627,8 +634,125 @@ fn make_symbol(
         end_line,
         signature: signature_for(text, signature_node.start_byte(), signature_node.end_byte()),
         docs: docs_before(text, start_byte),
+        is_test,
         facts: symbol_facts(language, text, node),
     }
+}
+
+/// Whether a symbol is test code — persisted as `symbols.is_test` so clone detection can exclude
+/// it. Cross-language: a test FILE path (every language) OR a language-specific in-source marker.
+/// Tests are repetitive by construction (fixture → call → assert), so leaving them in the clone
+/// corpus floods near-clone results — the write-time clone check is the main consumer.
+fn detect_is_test(
+    path: &Path,
+    language: Language,
+    text: &str,
+    node: Node<'_>,
+    scope_path: &str,
+    name: &str,
+) -> bool {
+    if is_test_file_path(path) {
+        return true;
+    }
+    match language {
+        // Rust unit tests live INLINE in source files, so the path check misses them: a `#[test]`
+        // (or `#[tokio::test]`/`#[rstest]`/…) on the fn, or any ancestor `#[cfg(test)]` module
+        // (catches test helpers too).
+        Language::Rust =>
+            rust_attribute_items(text, node)
+                .iter()
+                .any(|attribute| rust_attribute_is_test(attribute))
+                || rust_in_cfg_test_module(node, text),
+        // Kotlin: a JUnit `@Test`-family annotation on the fn (path catches `*Test.kt` /
+        // `src/test/`).
+        Language::Kotlin => kotlin_has_test_annotation(text, node),
+        // Python: pytest/unittest by convention — `test_*` functions, methods of a `*Test*`/
+        // `*TestCase` class (via scope_path), or anything in `conftest.py` (path).
+        Language::Python => name.starts_with("test_") || scope_path_has_test_class(scope_path),
+        // C / C++ / TypeScript: test bodies aren't named symbols (macros / closures), so the file
+        // path conventions above carry these.
+        _ => false,
+    }
+}
+
+/// Cross-language test-FILE conventions: a `tests`/`spec` directory, or a filename like
+/// `test_*` / `*_test` / `*_tests` / `*Test` / `*Tests` / `*.test.*` / `*.spec.*` / `conftest.py`.
+fn is_test_file_path(path: &Path) -> bool {
+    if path.components().filter_map(|component| component.as_os_str().to_str()).any(|segment| {
+        matches!(segment, "tests" | "test" | "__tests__" | "__test__" | "spec" | "specs")
+    }) {
+        return true;
+    }
+    let file = path.file_name().and_then(|name| name.to_str()).unwrap_or_default();
+    if file == "conftest.py" {
+        return true;
+    }
+    let stem = file.split('.').next().unwrap_or(file);
+    stem.starts_with("test_")
+        || stem.ends_with("_test")
+        || stem.ends_with("_tests")
+        || stem.ends_with("Test")
+        || stem.ends_with("Tests")
+        || stem.ends_with("TestCase")
+        || file.contains(".test.")
+        || file.contains(".spec.")
+}
+
+/// A Rust attribute that marks a test function: `#[test]`, `#[tokio::test]`, `#[rstest]`,
+/// `#[test_case(..)]`, etc. (a `#[cfg(test)]` is the MODULE marker — handled separately so it
+/// doesn't read as a per-fn test attribute).
+fn rust_attribute_is_test(attribute: &str) -> bool {
+    let inner = attribute
+        .trim()
+        .trim_start_matches('#')
+        .trim_start_matches('!')
+        .trim_start_matches('[')
+        .trim_end_matches(']');
+    let head = inner.split(['(', '[']).next().unwrap_or_default().trim();
+    let last = head.rsplit("::").next().unwrap_or(head).trim();
+    last == "test" || last == "rstest" || last.starts_with("test_case")
+}
+
+/// Whether `node` is nested in any `#[cfg(test)]` module — catches inline unit tests AND their
+/// helpers (a fixture fn in `#[cfg(test)] mod tests` has no `#[test]` of its own).
+fn rust_in_cfg_test_module(node: Node<'_>, text: &str) -> bool {
+    let mut current = node.parent();
+    while let Some(ancestor) = current {
+        if ancestor.kind() == "mod_item"
+            && rust_attribute_items(text, ancestor)
+                .iter()
+                .any(|attribute| attribute.contains("cfg") && attribute.contains("test"))
+        {
+            return true;
+        }
+        current = ancestor.parent();
+    }
+    false
+}
+
+/// Whether a Kotlin function carries a JUnit `@Test`-family annotation (in its `modifiers`).
+fn kotlin_has_test_annotation(text: &str, node: Node<'_>) -> bool {
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor).any(|child| {
+        child.kind() == "modifiers"
+            && node_text(child, text).as_deref().map(kotlin_modifiers_have_test).unwrap_or(false)
+    })
+}
+
+fn kotlin_modifiers_have_test(modifiers: &str) -> bool {
+    modifiers.split('@').skip(1).any(|annotation| {
+        let name = annotation.split(['(', ' ', '\n', '\t', '\r']).next().unwrap_or_default();
+        let last = name.rsplit('.').next().unwrap_or(name);
+        matches!(last, "Test" | "ParameterizedTest" | "RepeatedTest" | "TestFactory")
+    })
+}
+
+/// Whether a Python symbol's enclosing scope is a test class (`Test*` / `*Test` / `*TestCase`),
+/// e.g. a `unittest.TestCase` subclass. `scope_path` is `Class::method`-style.
+fn scope_path_has_test_class(scope_path: &str) -> bool {
+    scope_path.split("::").any(|segment| {
+        segment.starts_with("Test") || segment.ends_with("Test") || segment.ends_with("TestCase")
+    })
 }
 
 /// The node a symbol's signature is read from. For a decorated Python def this is the inner
@@ -770,5 +894,81 @@ mod budget_tests {
             parse_within_budget(grammar, src, PARSE_BUDGET).is_none(),
             "memoized-as-timed-out content must short-circuit to a parser failure"
         );
+    }
+}
+
+#[cfg(test)]
+mod is_test_detection {
+    use std::path::Path;
+
+    use super::parse_symbols;
+    use crate::language::Language;
+
+    fn is_test(path: &str, language: Language, text: &str, name: &str) -> bool {
+        parse_symbols(Path::new(path), language, text)
+            .unwrap()
+            .into_iter()
+            .find(|symbol| symbol.name == name)
+            .unwrap_or_else(|| panic!("symbol `{name}` not parsed"))
+            .is_test
+    }
+
+    #[test]
+    fn rust_test_attribute_and_cfg_test_module() {
+        let src = "pub fn real(a: i32) -> i32 { a + 1 }\n#[cfg(test)]\nmod tests {\nfn helper() \
+                   -> i32 { 1 }\n#[test]\nfn checks_things() { assert_eq!(helper(), 1); }\n}\n";
+        assert!(!is_test("src/lib.rs", Language::Rust, src, "real"), "plain fn is not a test");
+        assert!(is_test("src/lib.rs", Language::Rust, src, "checks_things"), "#[test] fn");
+        assert!(
+            is_test("src/lib.rs", Language::Rust, src, "helper"),
+            "a helper in a #[cfg(test)] module is test code too"
+        );
+    }
+
+    #[test]
+    fn rust_tokio_test_attribute() {
+        let src = "#[tokio::test]\nasync fn runs() {}\n";
+        assert!(is_test("src/lib.rs", Language::Rust, src, "runs"));
+    }
+
+    #[test]
+    fn python_test_function_and_test_class() {
+        let src = "def real():\n    return 1\n\ndef test_thing():\n    assert real() == \
+                   1\n\nclass TestSuite:\n    def checks(self):\n        assert True\n";
+        assert!(!is_test("src/app.py", Language::Python, src, "real"));
+        assert!(is_test("src/app.py", Language::Python, src, "test_thing"), "test_* function");
+        assert!(is_test("src/app.py", Language::Python, src, "checks"), "method of a Test* class");
+    }
+
+    #[test]
+    fn kotlin_test_annotation() {
+        let src = "class Thing {\n    @Test\n    fun verifies() {}\n    fun real() {}\n}\n";
+        assert!(is_test("src/Main.kt", Language::Kotlin, src, "verifies"), "@Test fun");
+        assert!(!is_test("src/Main.kt", Language::Kotlin, src, "real"), "plain fun");
+    }
+
+    #[test]
+    fn test_file_paths_across_languages() {
+        // A plain function in a conventional test FILE is test code regardless of markers/language.
+        assert!(is_test("tests/integration.rs", Language::Rust, "fn anything() {}\n", "anything"));
+        assert!(is_test(
+            "test_app.py",
+            Language::Python,
+            "def anything():\n    pass\n",
+            "anything"
+        ));
+        assert!(is_test(
+            "src/__tests__/util.ts",
+            Language::TypeScript,
+            "function anything() {}\n",
+            "anything"
+        ));
+        assert!(is_test("FooTest.kt", Language::Kotlin, "fun anything() {}\n", "anything"));
+        assert!(is_test(
+            "widget.test.ts",
+            Language::TypeScript,
+            "function anything() {}\n",
+            "anything"
+        ));
     }
 }

--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -16,7 +16,7 @@
 //! Self-matches are filtered: a function is never reported as a clone of code in its OWN file
 //! (`in_file`), so editing a function in place doesn't flag it against its own indexed copy.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use rusqlite::Connection;
@@ -88,12 +88,13 @@ impl IndexDatabase {
         text: &str,
         language: Language,
         path: &Path,
+        min_similarity: f64,
     ) -> anyhow::Result<Vec<TextCloneMatch>> {
         let conn = self.storage.connection();
         let Some(index) = CheckIndex::load(conn)? else {
             return Ok(Vec::new());
         };
-        index.check(conn, text, language, path)
+        index.check(conn, text, language, path, min_similarity)
     }
 
     /// Cheap count of fingerprinted baseline functions — a write-time hook reads it to BOUND its
@@ -148,6 +149,7 @@ impl IndexDatabase {
     pub fn clones_of_texts(
         &self,
         inputs: &[CloneCheckInput],
+        min_similarity: f64,
     ) -> anyhow::Result<Vec<TextCloneMatch>> {
         let conn = self.storage.connection();
         let Some(index) = CheckIndex::load(conn)? else {
@@ -155,7 +157,13 @@ impl IndexDatabase {
         };
         let mut all = Vec::new();
         for input in inputs {
-            all.extend(index.check(conn, &input.text, input.language, &input.path)?);
+            all.extend(index.check(
+                conn,
+                &input.text,
+                input.language,
+                &input.path,
+                min_similarity,
+            )?);
         }
         Ok(all)
     }
@@ -176,7 +184,14 @@ struct CheckIndex {
 
 impl CheckIndex {
     fn load(conn: &Connection) -> anyhow::Result<Option<Self>> {
-        let indexed = load_scoped_baseline_bags(conn)?;
+        let mut indexed = load_scoped_baseline_bags(conn)?;
+        // #292: keep test code out of the corpus. Tests are repetitive by construction (fixture →
+        // call → assert), so they otherwise dominate near-clone results — a function the agent
+        // writes would match dozens of unrelated test fns. `is_test` is computed at index time
+        // (cross-language: test-file path, Rust `#[test]`/`#[cfg(test)]`, Kotlin `@Test`, Python
+        // `test_*`/`TestCase`) — see `parser::detect_is_test`.
+        let test_ids = load_test_symbol_ids(conn)?;
+        indexed.retain(|bag| !test_ids.contains(&bag.symbol_id));
         if indexed.is_empty() {
             return Ok(None);
         }
@@ -209,6 +224,7 @@ impl CheckIndex {
         text: &str,
         language: Language,
         path: &Path,
+        min_similarity: f64,
     ) -> anyhow::Result<Vec<TextCloneMatch>> {
         let syms = symbols::symbols_for_file(path, language, text);
         let Some(parsed) = parser::parse_file(path, language, text) else {
@@ -228,6 +244,11 @@ impl CheckIndex {
 
         for (local, fp) in &new_fps {
             let symbol = &syms[*local];
+            // #292: don't clone-check test code the agent is writing — a new test is expected to
+            // resemble existing tests, and flagging it is pure noise.
+            if symbol.is_test {
+                continue;
+            }
             let new_bag = bag_from_fingerprint(fp, lang, &self.df_by_token);
 
             // EXACT: identical structure (same struct_hash + language) → similarity 1.0.
@@ -257,7 +278,10 @@ impl CheckIndex {
                     continue;
                 }
                 let other = self.bag(id);
-                if other.language != lang || !verified_clone(&new_bag, other, THETA) {
+                // Candidate generation stays at THETA (generous recall); the NEAR match is kept
+                // only at `min_similarity` (the write-time hook raises this to cut boilerplate
+                // near-noise). Exact (struct_hash) matches are unaffected — they're similarity 1.0.
+                if other.language != lang || !verified_clone(&new_bag, other, min_similarity) {
                     continue;
                 }
                 let max_len = new_bag.token_len.max(other.token_len);
@@ -307,6 +331,15 @@ impl CheckIndex {
         });
         Ok(matches)
     }
+}
+
+/// Symbol ids the index marked as test code (`symbols.is_test`), across all git contexts — the
+/// clone-check corpus drops these (#292). A bag's `symbol_id` is a row id, so membership is exact.
+fn load_test_symbol_ids(conn: &Connection) -> anyhow::Result<HashSet<i64>> {
+    let mut stmt = conn.prepare("SELECT id FROM symbols WHERE is_test = 1")?;
+    let ids =
+        stmt.query_map([], |r| r.get::<_, i64>(0))?.collect::<rusqlite::Result<HashSet<i64>>>()?;
+    Ok(ids)
 }
 
 /// `token_hash -> df` over the baseline normalizer — the selectivity source for a NEW bag's
@@ -421,6 +454,7 @@ mod tests {
                 exact_text,
                 crate::language::Language::Rust,
                 std::path::Path::new("new.rs"),
+                super::THETA,
             )
             .unwrap();
         assert_eq!(hits.len(), 1);
@@ -445,7 +479,7 @@ mod tests {
                 path: std::path::PathBuf::from("b.rs"),
             },
         ];
-        let hits = db.clones_of_texts(&inputs).unwrap();
+        let hits = db.clones_of_texts(&inputs, super::THETA).unwrap();
         // a.rs's clone is flagged; b.rs's trivial fn is below MIN_TOKENS / not a clone.
         assert_eq!(hits.len(), 1, "{hits:?}");
         assert_eq!(hits[0].in_file, "a.rs");
@@ -463,6 +497,7 @@ mod tests {
                 edited,
                 crate::language::Language::Rust,
                 std::path::Path::new("src/lib.rs"),
+                super::THETA,
             )
             .unwrap();
         assert!(hits.is_empty(), "self-file match must be excluded, got {hits:?}");
@@ -476,6 +511,7 @@ mod tests {
                 "not real code !!!",
                 crate::language::Language::Rust,
                 std::path::Path::new("x.rs"),
+                super::THETA,
             )
             .unwrap();
         assert!(none.is_empty());
@@ -538,5 +574,74 @@ mod tests {
         assert!(stale.total > 0 && stale.usable == 0, "{stale:?}");
         assert!(stale.needs_reindex, "{stale:?}");
         assert!(stale.message.unwrap().contains("index --full"), "actionable command");
+    }
+
+    #[test]
+    fn excludes_indexed_tests_from_corpus_and_skips_new_test_code() {
+        // #292: a real function PLUS a structurally identical helper inside a `#[cfg(test)]` module
+        // (so the helper is `is_test` though it shares the real fn's body).
+        let root = std::env::temp_dir().join(format!(
+            "rag-rat-of-text-exclude-{}-{}",
+            std::process::id(),
+            crate::index::util::now_ms()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(
+            root.join("src/scoring.rs"),
+            "pub fn compute_score(items: Vec<i32>) -> i32 { let mut total = 0; for item in items \
+             { total += item * 2; } total }\n#[cfg(test)]\nmod tests { fn scoring_helper(items: \
+             Vec<i32>) -> i32 { let mut total = 0; for item in items { total += item * 2; } total \
+             } }\n",
+        )
+        .unwrap();
+        let config = crate::Config {
+            root: root.clone(),
+            database: root.join(".rag-rat/index.sqlite"),
+            targets: vec![crate::config::ResolvedTarget {
+                name: "rust".to_string(),
+                language: crate::language::Language::Rust,
+                directories: vec![std::path::PathBuf::from("src")],
+                include: vec!["src/".to_string()],
+                exclude: Vec::new(),
+                kind: crate::config::TargetKind::Source,
+            }],
+            local_ai: Default::default(),
+            watch: Default::default(),
+            version_check: Default::default(),
+            oracle: Default::default(),
+        };
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+
+        // New code that is an exact clone of BOTH `compute_score` and the `#[cfg(test)]` helper.
+        let new_code = "pub fn tally(items: Vec<i32>) -> i32 { let mut total = 0; for item in \
+                        items { total += item * 2; } total }\n";
+        let hits = db
+            .clones_of_text(
+                new_code,
+                crate::language::Language::Rust,
+                std::path::Path::new("src/other.rs"),
+                super::THETA,
+            )
+            .unwrap();
+        assert_eq!(hits.len(), 1, "the one new function is checked: {hits:?}");
+        let refs = &hits[0].clone_of;
+        assert!(refs.iter().any(|r| r.contains("compute_score")), "matches the real fn: {refs:?}");
+        assert!(
+            !refs.iter().any(|r| r.contains("scoring_helper")),
+            "the #[cfg(test)] clone is EXCLUDED from the corpus: {refs:?}"
+        );
+
+        // The SAME code written to a test file is skipped entirely — the agent writing a test is
+        // expected to resemble other tests, so flagging it is noise.
+        let test_hits = db
+            .clones_of_text(
+                new_code,
+                crate::language::Language::Rust,
+                std::path::Path::new("tests/it.rs"),
+                super::THETA,
+            )
+            .unwrap();
+        assert!(test_hits.is_empty(), "new test code is not clone-checked: {test_hits:?}");
     }
 }

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1169,6 +1169,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_032_ID => Some(32),
             MIGRATION_033_ID => Some(33),
             MIGRATION_034_ID => Some(34),
+            MIGRATION_035_ID => Some(35),
             _ => None,
         })
         .max()
@@ -1212,6 +1213,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_032_ID
             | MIGRATION_033_ID
             | MIGRATION_034_ID
+            | MIGRATION_035_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1252,6 +1254,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_032_ID => migration.checksum != MIGRATION_032_CHECKSUM,
         MIGRATION_033_ID => migration.checksum != MIGRATION_033_CHECKSUM,
         MIGRATION_034_ID => migration.checksum != MIGRATION_034_CHECKSUM,
+        MIGRATION_035_ID => migration.checksum != MIGRATION_035_CHECKSUM,
         _ => false,
     }
 }
@@ -1490,6 +1493,15 @@ pub(crate) const CLONE_GRAPH_DDL: &str = "
 /// V034: create the precomputed clone-graph tables (see [`CLONE_GRAPH_DDL`]).
 pub(crate) fn apply_clone_graph_tables(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(CLONE_GRAPH_DDL)?;
+    Ok(())
+}
+
+/// V035: add `symbols.is_test` (cross-language test-code marker computed at parse time; see
+/// `parser::detect_is_test`) so clone detection can keep tests out of the corpus. Idempotent via
+/// `add_column_if_missing`. Existing rows default to 0 (non-test) until the next reindex
+/// repopulates them — accurate `is_test` needs a reindex with this binary.
+pub(crate) fn apply_symbols_is_test(conn: &Connection) -> rusqlite::Result<()> {
+    add_column_if_missing(conn, "symbols", "is_test", "INTEGER NOT NULL DEFAULT 0")?;
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use migrations::*;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 34;
+pub const LATEST_SCHEMA_VERSION: u32 = 35;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -218,6 +218,12 @@ const MIGRATION_034_CHECKSUM: &str = "sha256:rag-rat-clone-graph-precompute-v34"
 const MIGRATION_034_DESCRIPTION: &str =
     "Add clone_graph_generations + clone_edges (content-anchored precomputed clone-edge graph so \
      find_clones reads a persisted graph instead of recomputing candidate pairs every query)";
+const MIGRATION_035_ID: &str = "035_symbols_is_test";
+const MIGRATION_035_CHECKSUM: &str = "sha256:rag-rat-symbols-is-test-v35";
+const MIGRATION_035_DESCRIPTION: &str = "Add symbols.is_test (cross-language test-code marker: \
+                                         test-file path, Rust #[test]/#[cfg(test)], Kotlin @Test, \
+                                         Python test_*/TestCase) so clone detection can exclude \
+                                         tests from the corpus";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -521,6 +527,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_034_CHECKSUM,
         description: MIGRATION_034_DESCRIPTION,
         apply: apply_clone_graph_tables,
+    },
+    Migration {
+        id: MIGRATION_035_ID,
+        checksum: MIGRATION_035_CHECKSUM,
+        description: MIGRATION_035_DESCRIPTION,
+        apply: apply_symbols_is_test,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -12420,6 +12420,43 @@ fn migration_034_adds_content_anchored_clone_graph_tables() {
     );
 }
 
+/// V035 (#292): `symbols.is_test` exists after a forward migration from V034 and is queryable. A
+/// V034 index migrates forward to LATEST and gains the column (default 0 — accurate values need a
+/// reindex with this binary). Simulates a V034 index by dropping the column + rolling the ledger
+/// back one step, then asserts `migrate_forward` re-adds it.
+#[test]
+fn migration_035_adds_symbols_is_test() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    crate::index::schema::apply(&conn).expect("apply");
+
+    conn.execute_batch("ALTER TABLE symbols DROP COLUMN is_test;").expect("revert to V034 shape");
+    truncate_schema_to(&conn, 34);
+    assert!(
+        !conn_table_columns(&conn, "symbols").contains(&"is_test".to_string()),
+        "is_test absent at V034"
+    );
+    assert_eq!(
+        crate::index::schema::status(&conn).unwrap().state,
+        crate::index::schema::SchemaState::Older,
+        "schema is Older after removing the V035 ledger row"
+    );
+
+    crate::index::schema::migrate_forward(&conn).expect("migrate_forward");
+    assert!(
+        conn_table_columns(&conn, "symbols").contains(&"is_test".to_string()),
+        "V035 adds symbols.is_test"
+    );
+    // The column is queryable + defaults to 0 (non-test) on existing rows.
+    let _: i64 = conn
+        .query_row("SELECT COUNT(*) FROM symbols WHERE is_test = 0", [], |r| r.get(0))
+        .expect("SELECT is_test must succeed after V035");
+    assert_eq!(
+        crate::index::schema::LATEST_SCHEMA_VERSION,
+        35,
+        "LATEST_SCHEMA_VERSION is 35 after V035"
+    );
+}
+
 /// Regression test for the P1 schema bug (#215 Plan 4a): an index recorded at V029 WITHOUT
 /// `clone_refinements.lcs_sampled` (because V029 was applied before the column landed) must have
 /// the column added by the V030 forward migration. Simulates the bug by building a full schema,
@@ -12481,8 +12518,8 @@ fn v030_forward_migrate_adds_lcs_sampled_to_existing_v029_index() {
     );
     assert_eq!(
         crate::index::schema::LATEST_SCHEMA_VERSION,
-        34,
-        "LATEST_SCHEMA_VERSION is 34 after V034"
+        35,
+        "LATEST_SCHEMA_VERSION is 35 after V035"
     );
     // Idempotency: running migrate_forward again must not error.
     crate::index::schema::migrate_forward(&conn).expect("migrate_forward is idempotent");

--- a/crates/rag-rat-core/src/index/symbols.rs
+++ b/crates/rag-rat-core/src/index/symbols.rs
@@ -23,6 +23,9 @@ pub struct Symbol {
     pub end_line: usize,
     pub signature: Option<String>,
     pub docs: Option<String>,
+    /// Test code (see [`parser::ParsedSymbol::is_test`]) — persisted so clone detection can keep
+    /// tests out of the corpus.
+    pub is_test: bool,
     pub facts: Vec<SymbolFact>,
 }
 
@@ -46,6 +49,7 @@ pub fn from_parsed(parsed: &[parser::ParsedSymbol]) -> Vec<Symbol> {
             end_line: symbol.end_line,
             signature: symbol.signature.clone(),
             docs: symbol.docs.clone(),
+            is_test: symbol.is_test,
             facts: symbol
                 .facts
                 .iter()


### PR DESCRIPTION
Closes #292. The #287 write-time clone check flooded on boilerplate — writing a single test function flagged it as **~88% similar to 50+ unrelated test functions**. Three fixes, per the agreed design (index-time `is_test` flag + raised near threshold).

## 1. Cross-language test exclusion (index-time)
New **`symbols.is_test`** (V035 migration), computed at parse time in `parser::detect_is_test`:
- **Path** (every language): `tests/`, `test/`, `__tests__/`, `test_*.py`, `*_test.*`, `*.test.ts`, `*.spec.*`, `*Test.kt`, `*Tests.kt`, `conftest.py`, …
- **In-source markers**: Rust `#[test]`/`#[tokio::test]`/… and any ancestor `#[cfg(test)]` module (catches inline unit tests *and* their helpers); Kotlin `@Test`-family; Python `test_*` functions and `*Test*`/`*TestCase` classes.

The clone check **drops `is_test` symbols from the corpus** and **skips new test code** the agent is writing — tests resemble each other by construction, so both directions are pure noise.

## 2. Higher near threshold for the hook
`clones_of_text(s)` gains a `min_similarity` param. The write-time hook passes **0.85**; `find_clones`/`clones_for_symbol` stay at 0.7. Boilerplate-heavy code pushes unrelated functions to ~0.7–0.8 token overlap, so a lower bar is non-actionable. **Exact (struct_hash) matches are always surfaced.**

## 3. Cap the ref list
A single near match can resemble many indexed functions — the hook now shows the first **5** + `(+N more)` instead of a wall of refs.

## Tests
Cross-language detection (Rust attr/cfg, Kotlin `@Test`, Python `test_*`/class, test-file paths across 5 languages), the V035 migration, corpus-exclusion + new-test-skip end-to-end, and the ref cap. **1045 workspace tests**, clippy `--all-targets`, nightly fmt.

## Adoption note
Existing indexes need a **reindex** to populate `is_test` (the V035 migration adds it defaulting to 0, so tests stay *included* until then). New/reindexed repos get it automatically.