### PR TITLE
chore(clones): consolidate the three test-path detectors into one canonical helper (#294)

### DIFF
--- a/crates/rag-rat-core/src/index/parser.rs
+++ b/crates/rag-rat-core/src/index/parser.rs
@@ -651,7 +651,7 @@ fn detect_is_test(
     scope_path: &str,
     name: &str,
 ) -> bool {
-    if is_test_file_path(path) {
+    if is_test_path(path) {
         return true;
     }
     match language {
@@ -675,11 +675,20 @@ fn detect_is_test(
     }
 }
 
-/// Cross-language test-FILE conventions: a `tests`/`spec` directory, or a filename like
-/// `test_*` / `*_test` / `*_tests` / `*Test` / `*Tests` / `*.test.*` / `*.spec.*` / `conftest.py`.
-fn is_test_file_path(path: &Path) -> bool {
+/// The CANONICAL cross-language test-path detector (#294) — the one reused by the indexer (the
+/// `is_test` computation) AND the query layer (`staleness` test-file skip, `graph` test-callsite
+/// filter, `repo_brief` support-path down-weight). A test path is any of: a test directory segment
+/// (`tests`/`test`/`__tests__`/`__mocks__`/`spec`, case-insensitive), `conftest.py`, a `*.test.*` /
+/// `*.spec.*` filename, or a stem like `test`/`tests` / `test_*` / `*_test` / `*_tests` / `*Test` /
+/// `*Tests` / `*TestCase`. Takes `impl AsRef<Path>` so both `&Path` (parser) and `&str` (the query
+/// callers' stored path strings) pass directly.
+pub(crate) fn is_test_path(path: impl AsRef<Path>) -> bool {
+    let path = path.as_ref();
     if path.components().filter_map(|component| component.as_os_str().to_str()).any(|segment| {
-        matches!(segment, "tests" | "test" | "__tests__" | "__test__" | "spec" | "specs")
+        matches!(
+            segment.to_ascii_lowercase().as_str(),
+            "tests" | "test" | "__tests__" | "__test__" | "__mocks__" | "spec" | "specs"
+        )
     }) {
         return true;
     }
@@ -687,15 +696,19 @@ fn is_test_file_path(path: &Path) -> bool {
     if file == "conftest.py" {
         return true;
     }
+    let lower = file.to_ascii_lowercase();
+    if lower.contains(".test.") || lower.contains(".spec.") {
+        return true;
+    }
     let stem = file.split('.').next().unwrap_or(file);
-    stem.starts_with("test_")
+    stem == "test"
+        || stem == "tests"
+        || stem.starts_with("test_")
         || stem.ends_with("_test")
         || stem.ends_with("_tests")
         || stem.ends_with("Test")
         || stem.ends_with("Tests")
         || stem.ends_with("TestCase")
-        || file.contains(".test.")
-        || file.contains(".spec.")
 }
 
 /// A Rust attribute that marks a test function: `#[test]`, `#[tokio::test]`, `#[rstest]`,
@@ -970,5 +983,40 @@ mod is_test_detection {
             "function anything() {}\n",
             "anything"
         ));
+    }
+
+    #[test]
+    fn canonical_is_test_path_covers_the_union_of_conventions() {
+        use super::is_test_path;
+        // Directory segments (case-insensitive), incl. repo_brief's `__mocks__`.
+        for p in [
+            "crates/x/tests/foo.rs",
+            "src/test/foo.rs",
+            "web/__tests__/util.ts",
+            "web/__mocks__/api.ts",
+            "app/Spec/x.rb",
+            "pkg/Tests/Thing.cs",
+        ] {
+            assert!(is_test_path(p), "dir segment: {p}");
+        }
+        // Filenames, incl. repo_brief's `tests.rs`/`_tests.rs` and cross-language stems.
+        for p in [
+            "src/widget_test.rs",
+            "src/widget_tests.rs",
+            "pkg/foo_test.go",
+            "tests.rs",
+            "test_app.py",
+            "conftest.py",
+            "app/Button.spec.tsx",
+            "app/Button.test.tsx",
+            "FooTest.kt",
+            "FooTestCase.java",
+        ] {
+            assert!(is_test_path(p), "filename: {p}");
+        }
+        // Negatives — including near-misses that must NOT match.
+        for p in ["src/widget.rs", "src/contest.rs", "src/latest.rs", "lib/manifest.rs"] {
+            assert!(!is_test_path(p), "non-test: {p}");
+        }
     }
 }

--- a/crates/rag-rat-core/src/index/query_api/graph.rs
+++ b/crates/rag-rat-core/src/index/query_api/graph.rs
@@ -271,7 +271,9 @@ impl IndexDatabase {
         )?;
         if !include_tests {
             graph_edges.retain(|edge| {
-                edge.callsite.as_ref().is_none_or(|callsite| !is_test_like_path(&callsite.path))
+                edge.callsite
+                    .as_ref()
+                    .is_none_or(|callsite| !crate::index::parser::is_test_path(&callsite.path))
             });
         }
         let (logical_symbol, variants) =

--- a/crates/rag-rat-core/src/index/staleness.rs
+++ b/crates/rag-rat-core/src/index/staleness.rs
@@ -2,7 +2,6 @@
 //! stale, regex/line reads over current source.
 
 use super::*;
-use crate::query::text_compare::*;
 
 /// Whether `search_with_heal` may lazily re-index files whose chunks have drifted from disk.
 /// `Allow` heals once and retries; `Skip` is the recursion's base case (and the explicit
@@ -38,7 +37,7 @@ impl IndexDatabase {
             stmt.query_map([], |row| row.get::<_, String>(0))?.collect::<Result<Vec<_>, _>>()?;
         let mut hits = Vec::new();
         for path in paths {
-            if !include_tests && is_test_like_path(&path) {
+            if !include_tests && crate::index::parser::is_test_path(&path) {
                 continue;
             }
             let full_path = root.join(&path);

--- a/crates/rag-rat-core/src/query/repo_brief.rs
+++ b/crates/rag-rat-core/src/query/repo_brief.rs
@@ -625,29 +625,32 @@ pub(crate) fn enrich_symbol_kinds(
     conn: &Connection,
     rows: &mut [FileBriefRow],
 ) -> anyhow::Result<()> {
-    if rows.is_empty() {
-        return Ok(());
-    }
-    let paths = rows.iter().map(|row| row.path.clone()).collect::<Vec<_>>();
-    let symbol_kinds = symbol_kind_counts_by_path(conn, &paths)?;
-
-    for row in rows {
-        row.symbol_kinds = symbol_kinds.get(&row.path).cloned().unwrap_or_default();
-    }
-    Ok(())
+    enrich_rows(conn, rows, symbol_kind_counts_by_path, |row, value| row.symbol_kinds = value)
 }
 
 pub(crate) fn enrich_memory_counts(
     conn: &Connection,
     rows: &mut [FileBriefRow],
 ) -> anyhow::Result<()> {
+    enrich_rows(conn, rows, memory_counts_by_path, |row, value| row.memories = value)
+}
+
+/// Shared per-path enrichment: build the `path -> T` map (via `counts_by_path`) once, then `assign`
+/// each row its value (defaulting when the path is absent). `enrich_symbol_kinds` /
+/// `enrich_memory_counts` were ~identical but for the lookup fn and the target field (#294 dedup).
+fn enrich_rows<T: Clone + Default>(
+    conn: &Connection,
+    rows: &mut [FileBriefRow],
+    counts_by_path: impl Fn(&Connection, &[String]) -> anyhow::Result<BTreeMap<String, T>>,
+    assign: impl Fn(&mut FileBriefRow, T),
+) -> anyhow::Result<()> {
     if rows.is_empty() {
         return Ok(());
     }
     let paths = rows.iter().map(|row| row.path.clone()).collect::<Vec<_>>();
-    let memory_counts = memory_counts_by_path(conn, &paths)?;
+    let counts = counts_by_path(conn, &paths)?;
     for row in rows {
-        row.memories = memory_counts.get(&row.path).cloned().unwrap_or_default();
+        assign(row, counts.get(&row.path).cloned().unwrap_or_default());
     }
     Ok(())
 }

--- a/crates/rag-rat-core/src/query/repo_brief.rs
+++ b/crates/rag-rat-core/src/query/repo_brief.rs
@@ -290,7 +290,7 @@ fn capped(value: f64) -> f64 {
 }
 
 fn support_path_multiplier(mode: RepoBriefMode, path: &str) -> f64 {
-    if !is_test_or_mock_path(path) {
+    if !crate::index::parser::is_test_path(path) {
         return 1.0;
     }
     match mode {
@@ -298,19 +298,6 @@ fn support_path_multiplier(mode: RepoBriefMode, path: &str) -> f64 {
         RepoBriefMode::Spine => 0.70,
         RepoBriefMode::Churn => 1.0,
     }
-}
-
-fn is_test_or_mock_path(path: &str) -> bool {
-    path.contains("/__tests__/")
-        || path.contains("/__mocks__/")
-        || path.contains("/tests/")
-        || path.ends_with("/tests.rs")
-        || path.ends_with("_test.rs")
-        || path.ends_with("_tests.rs")
-        || path.ends_with(".test.ts")
-        || path.ends_with(".test.tsx")
-        || path.ends_with(".spec.ts")
-        || path.ends_with(".spec.tsx")
 }
 
 fn category_for(

--- a/crates/rag-rat-core/src/query/text_compare.rs
+++ b/crates/rag-rat-core/src/query/text_compare.rs
@@ -138,7 +138,7 @@ pub(crate) fn classify_text_only_hit(
     if is_import_or_declaration_text(trimmed) {
         return "declaration_text_mention";
     }
-    if is_test_like_path(path) && is_test_scaffolding_text(trimmed) {
+    if crate::index::parser::is_test_path(path) && is_test_scaffolding_text(trimmed) {
         return "test_scaffolding_text_mention";
     }
     "parser_call_extraction"
@@ -209,18 +209,6 @@ pub(crate) fn compare_pattern_match_mode(pattern: &str, symbol_name: &str) -> St
     "regex".to_string()
 }
 
-pub(crate) fn is_test_like_path(path: &str) -> bool {
-    let lower = path.to_ascii_lowercase();
-    lower.contains("/test/")
-        || lower.contains("/tests/")
-        || lower.contains("/__tests__/")
-        || lower.ends_with("_test.rs")
-        || lower.ends_with(".test.ts")
-        || lower.ends_with(".test.tsx")
-        || lower.ends_with(".spec.ts")
-        || lower.ends_with(".spec.tsx")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -278,15 +266,6 @@ mod tests {
         assert!(is_test_scaffolding_text("  expect(foo()).toBe(1)"));
         assert!(is_test_scaffolding_text("describe('x', () => {"));
         assert!(!is_test_scaffolding_text("let y = bar();"));
-    }
-
-    #[test]
-    fn test_like_path_detection() {
-        assert!(is_test_like_path("crates/x/tests/foo.rs"));
-        assert!(is_test_like_path("src/widget_test.rs"));
-        assert!(is_test_like_path("app/Button.spec.tsx"));
-        assert!(is_test_like_path("web/__tests__/util.ts"));
-        assert!(!is_test_like_path("src/widget.rs"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #294. Three functions independently answered "is this a test path?" — `is_test_like_path` (query/text_compare), `is_test_or_mock_path` (query/repo_brief), and the #292 `is_test_file_path` (index/parser) — each with slightly different conventions. Semantic duplication the structural clone check doesn't flag; `semantic_search` surfaced it while reviewing #293.

## Change
One canonical **`parser::is_test_path(impl AsRef<Path>)`** — the **union** of all three:
- dir segments `tests`/`test`/`__tests__`/`__mocks__`/`spec` (case-insensitive — `__mocks__` was repo_brief-only)
- `conftest.py`, `*.test.*`, `*.spec.*`
- stems `test`/`tests`/`test_*`/`*_test`/`*_tests`/`*Test`/`*Tests`/`*TestCase` (cross-language — the `*Test`/`*TestCase` forms were parser-only)

`impl AsRef<Path>` lets the `&str` query callers and the `&Path` parser caller share it. The two query copies are **deleted**; all four call sites (`text_compare`, `repo_brief`, `staleness`, `graph`) repoint to the canonical — which also **drops `staleness`'s index→query dependency** (bonus layering cleanup).

`is_test_scaffolding_text` is intentionally left alone — it's CONTENT detection (`.mock`/`jest.`/`expect(`), a different concern that the clone graph had grouped with `is_test_like_path` at 86% structural similarity.

## Behavior
The query callers (`staleness` test-skip, `graph` test-callsite filter, `repo_brief` support-path down-weight) now use the broader union, so they catch more genuine test paths (e.g. root-level `tests/`, `*Test.kt`, `conftest.py`) — and `repo_brief` keeps `__mocks__`. No path that matched before stops matching.

## Tests
A direct union-coverage test (every convention + near-miss negatives `latest.rs`/`contest.rs`/`manifest.rs`) plus the existing cross-language integration tests. 1045 workspace tests, clippy `--all-targets`, nightly fmt.