### PR TITLE
fix(clones): dampen member_count on the un-refined sort so refine-failed classes can't bypass the coverage gate (#259)

### DIFF
--- a/crates/rag-rat-core/src/index/clones/refine/split.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/split.rs
@@ -53,6 +53,18 @@
 /// keeping symbol-level recall identical: a skipped edge has BOTH endpoints already in a class, so
 /// it is a redundant clone PAIR, never a lost member. For the normal case (all existing tests) far
 /// fewer than 256 grown cliques are ever produced and the tail is empty.
+///
+/// #259 (Adversary A): the TOTAL emitted-class count is now bounded by `MAX_SPLIT_GROUPS + 1`,
+/// regardless of input shape. The #282 covering-subset already eliminated the bare-2-member fan-out
+/// the issue feared (a dense-minus-perfect-matching component at n=300 emitted ~44k bare pairs
+/// PRE-#282; POST-#282 it emits 0 bare pairs because the first ~2 grown ~150-member cliques already
+/// cover every member). What remains is the GROWN cliques: once tripped, the cover stops seeding
+/// and the subset-removal pass is skipped, so a pathological component can emit up to
+/// `MAX_SPLIT_GROUPS` large, heavily-overlapping near-duplicate cliques (≤ 257 classes total — see
+/// the pin `coherence_split_class_count_bounded_by_split_groups`). That is BOUNDED and
+/// member-loss-free, so it is left as-is: dropping/coalescing those near-duplicates would risk
+/// recall (they are distinct maximal cliques, not redundant pairs), and 257 `build_class`/refine
+/// calls is well within budget.
 const MAX_SPLIT_GROUPS: usize = 256;
 
 /// Split an over-merged union-find component into internally-coherent clone classes: every pair
@@ -658,6 +670,55 @@ mod tests {
             result.len(),
             edges.len(),
         );
+    }
+
+    /// #259 (Adversary A): the TOTAL emitted-class count is bounded by `MAX_SPLIT_GROUPS + 1` on the
+    /// pathological dense-minus-perfect-matching shape, at every size — NOT O(n) or O(edges). This
+    /// is the durable bound on the budget-tripped fan-out: pre-#282 this shape emitted ~44k bare
+    /// 2-member classes at n=300; post-#282 the covering subset emits ZERO bare pairs (the early
+    /// grown cliques cover every member), and the GROWN cliques themselves are capped by the
+    /// budget. The pin guards against a regression that re-introduces an unbounded (O(n) /
+    /// O(edges)) tail.
+    #[test]
+    fn coherence_split_class_count_bounded_by_split_groups() {
+        let theta = 0.70;
+        // The matched pair (2k, 2k+1) is below θ; every other pair is above — the worst case for
+        // maximal-clique enumeration (O(n²) maximal cliques), which trips MAX_SPLIT_GROUPS.
+        let sim = |a: i64, b: i64| -> f64 {
+            let matched = (a / 2 == b / 2) && (a % 2 != b % 2);
+            if matched { 0.5 } else { 0.9 }
+        };
+        for n in [200i64, 300, 400] {
+            let members: Vec<i64> = (0..n).collect();
+            let mut edges: Vec<(i64, i64)> = Vec::new();
+            for a in 0..n {
+                for b in (a + 1)..n {
+                    if sim(a, b) >= theta {
+                        edges.push((a, b));
+                    }
+                }
+            }
+            let result = coherence_split(&members, &edges, sim, theta);
+            // The class count is bounded by the budget, independent of n / edge count — it does NOT
+            // grow with the component size the way the pre-#282 bare-pair tail did.
+            assert!(
+                result.len() <= MAX_SPLIT_GROUPS + 1,
+                "#259: budget-tripped fan-out must be ≤ MAX_SPLIT_GROUPS+1 ({}), got {} classes \
+                 at n={n} ({} edges)",
+                MAX_SPLIT_GROUPS + 1,
+                result.len(),
+                edges.len(),
+            );
+            // And it does NOT degenerate into a bare-2-member explosion: the budget-tripped tail is
+            // empty on this dense shape (every member is covered by an early grown clique), so the
+            // emitted classes are the large grown cliques, not O(edges) pairs (#282 + #259).
+            let bare_pairs = result.iter().filter(|g| g.len() == 2).count();
+            assert!(
+                bare_pairs <= n as usize,
+                "#259: the budget-tripped tail must not fan out into O(edges) bare pairs — got \
+                 {bare_pairs} two-member classes at n={n}",
+            );
+        }
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -607,6 +607,19 @@ impl IndexDatabase {
                     &mut global_refine_cells,
                 )?;
             }
+            // #259 (Adversary C): dampen the member_count factor of every class that is STILL
+            // un-refined after the refine pass — a within-budget class whose refinement was a no-op
+            // (drifted source, overlay scope, parse failure, vanished hydration row). Its Plan-2
+            // ROI is LINEAR in member_count and carries no coverage gate, so a large
+            // refine-failed component would otherwise out-rank the (coverage-gated)
+            // refined classes it is re-sorted against. Run AFTER refine (so
+            // `class.refined` is final) and BEFORE the sort (so it affects ranking). A
+            // refined class is left untouched.
+            for (_class_ids, class) in built.iter_mut() {
+                if !class.refined {
+                    dampen_unrefined_member_count(class);
+                }
+            }
             let mut cs: Vec<CandidateCloneClass> = built.into_iter().map(|(_, c)| c).collect();
             cs.sort_by(|a, b| b.roi.partial_cmp(&a.roi).unwrap_or(std::cmp::Ordering::Equal));
             cs
@@ -626,6 +639,20 @@ impl IndexDatabase {
                     class,
                     &mut global_refine_cells,
                 )?;
+            }
+            // #259 (Adversary C): dampen the member_count factor of EVERY class that is still
+            // un-refined before the final re-sort — both the budget tail (idx ≥
+            // UNLIMITED_REFINE_BUDGET, never refined) AND any within-budget class whose refinement
+            // was a no-op (drifted source, overlay scope, parse failure, vanished hydration row).
+            // Their Plan-2 ROI is LINEAR in member_count and carries no coverage gate, so a large
+            // refine-failed component would otherwise out-rank a gated refined class purely on
+            // size. Run AFTER refine (so `class.refined` is final) and BEFORE the sort
+            // (so it affects ranking). A refined class is left untouched (its ROI
+            // already went through the coverage gate).
+            for (_class_ids, class) in built.iter_mut() {
+                if !class.refined {
+                    dampen_unrefined_member_count(class);
+                }
             }
             let mut cs: Vec<CandidateCloneClass> = built.into_iter().map(|(_, c)| c).collect();
             cs.sort_by(|a, b| b.roi.partial_cmp(&a.roi).unwrap_or(std::cmp::Ordering::Equal));
@@ -832,6 +859,53 @@ fn coverage_roi_gate(anti_unify_coverage: f64) -> f64 {
     } else {
         1.0
     }
+}
+
+/// Re-score a class that ended the refine pass STILL un-refined so its raw `member_count` factor
+/// can no longer let it masquerade as high-ROI against the (coverage-gated) refined classes it is
+/// ranked against (#259, Adversary C).
+///
+/// THE GAP: `find_clones` refines at most `UNLIMITED_REFINE_BUDGET` (50) classes by provisional ROI
+/// and then re-sorts the WHOLE list on the SAME ROI scale. A class that ranks past the budget — OR
+/// that is within budget but FAILS refinement ([`IndexDatabase::refine_class_in_place`] is a no-op
+/// when refine inputs are unavailable: overlay scope, drifted source, parse failure, a vanished
+/// hydration row) — keeps its un-refined Plan-2 ROI:
+/// `cross_module_spread × member_count × body_token_len_medoid × load_bearing_factor ×
+/// cohesion_min_pairwise`. That product is LINEAR in `member_count` and carries NO
+/// [`coverage_roi_gate`] (coverage only exists post-refine), while a refined degenerate class has
+/// already been knocked down `0.07–0.49×` by the gate. So a large refine-FAILED component can
+/// out-rank a gated refined class purely on member count — the exact tail #256 left open.
+///
+/// THE FIX: dampen ONLY the `member_count` factor of an un-refined class from LINEAR to the
+/// `1 + ln(1 + member_count)` sub-linear shape the codebase already uses for `load_bearing_factor`.
+/// This surfaces the refine-failure as a ranking penalty that GROWS with size — exactly where the
+/// masquerade is dangerous — while leaving small un-refined classes essentially untouched
+/// (member_count 2 → ~2.10, a <5% nudge), so the un-refined tail of a healthy result keeps its
+/// relative order. A refined class is NEVER touched (its ROI already went through the coverage gate
+/// in [`apply_refinement`]); the per-class fields are unchanged, only `class.roi` (the sort key) is
+/// rewritten. Because it only re-weights a factor that is already positive, a dampened class stays
+/// strictly positive and visible — it is deprioritized, not dropped.
+///
+/// This is a RANKING-only change (#259 is a gating issue, not a perf issue): it rewrites the sort
+/// key, never membership or which pairs are clones, so both clone-output parities stay green by
+/// construction.
+fn dampen_unrefined_member_count(class: &mut CandidateCloneClass) {
+    // Defensive: a refined class already carries the refactorability × coverage_gate ROI; never
+    // re-dampen it (the caller only passes un-refined classes, but keep the helper self-guarding).
+    if class.refined {
+        return;
+    }
+    let mc = class.member_count as f64;
+    if mc <= 0.0 {
+        return;
+    }
+    // Replace the linear `member_count` factor with `1 + ln(1 + member_count)`. Refold by dividing
+    // out the linear factor and multiplying the dampened one so every OTHER factor
+    // (cross_module_spread, body_token_len_medoid, load_bearing_factor, cohesion_min_pairwise) is
+    // preserved exactly — this is a pure re-weight of the size term, not a recompute from scratch
+    // (which would have to re-derive the medoid/spread the class no longer carries the inputs for).
+    let dampened_member_factor = 1.0 + mc.ln_1p();
+    class.roi = class.roi / mc * dampened_member_factor;
 }
 
 /// Apply a [`CachedRefinement`] to a [`CandidateCloneClass`] in place (Plan 4a). Shared between
@@ -2274,8 +2348,8 @@ mod tests {
 
     use super::{
         SymbolBag, THETA, TokenPosting, add_struct_hash_pairs, bucket_edges_by_component,
-        class_key_for, components_from_pairs, coverage_roi_gate, overlap,
-        sub_block_candidate_pairs,
+        class_key_for, components_from_pairs, coverage_roi_gate, dampen_unrefined_member_count,
+        overlap, sub_block_candidate_pairs,
     };
 
     /// #256: the refined-ROI coverage gate is a mutually-exclusive band. A near-zero-coverage
@@ -2300,6 +2374,117 @@ mod tests {
         for cov in [0.0, 0.2, 0.4, 0.6, 1.0] {
             assert!(coverage_roi_gate(cov) > 0.0);
         }
+    }
+
+    /// #259 (Adversary C): the member_count dampen on un-refined classes. A class that FAILS
+    /// refinement keeps its member_count-LINEAR Plan-2 ROI with no coverage gate; the dampen
+    /// replaces the linear size factor with `1 + ln(1 + member_count)` so it grows sub-linearly.
+    /// The dampen is mild for small classes and bites for large ones — exactly where a
+    /// refine-failed component could masquerade as high-ROI.
+    #[test]
+    fn dampen_unrefined_member_count_subdues_large_classes() {
+        // The raw Plan-2 ROI is member_count-LINEAR; the dampen makes it sub-linear.
+        let mut small = class_with_member_count(2);
+        small.refined = false;
+        small.roi = small.member_count as f64; // unit structural factors → roi == member_count
+        dampen_unrefined_member_count(&mut small);
+        // member_count 2 → 1 + ln(3) ≈ 2.10: a <5% nudge — small un-refined classes keep their
+        // order.
+        assert!(
+            (small.roi - (1.0 + 3.0_f64.ln())).abs() < 1e-9,
+            "member_count 2 dampens to 1 + ln(3) ≈ 2.10, got {}",
+            small.roi
+        );
+
+        let mut large = class_with_member_count(300);
+        large.refined = false;
+        large.roi = large.member_count as f64;
+        dampen_unrefined_member_count(&mut large);
+        // member_count 300 → 1 + ln(301) ≈ 6.71: a ~45× reduction from the raw 300.
+        assert!(large.roi < 7.0, "member_count 300 dampens to ~6.71, got {}", large.roi);
+        assert!(large.roi > 6.0, "the dampen keeps the class strictly positive, got {}", large.roi);
+
+        // The dampen is monotone non-decreasing in member_count (a bigger class still scores ≥ a
+        // smaller one — we deprioritize the LINEAR dominance, we don't invert size entirely).
+        assert!(large.roi > small.roi, "300 members still out-scores 2 after the dampen");
+
+        // A refined class is NEVER dampened (the helper self-guards): its ROI already went through
+        // the coverage gate, so re-weighting it would double-penalize.
+        let mut refined = class_with_member_count(300);
+        refined.refined = true;
+        refined.roi = 300.0;
+        dampen_unrefined_member_count(&mut refined);
+        assert_eq!(refined.roi, 300.0, "a refined class is left untouched by the dampen");
+    }
+
+    /// #259 (Adversary C): the load-bearing property. A LARGE refine-FAILED class (un-refined,
+    /// member_count-linear ROI, no coverage gate) must NOT out-rank a degenerate REFINED class that
+    /// the coverage gate already sank — once both share the same structural factors. Pre-dampen the
+    /// refine-failed class won on raw member_count; post-dampen the coverage-gated refined class is
+    /// ranked at least as high, so the masquerade is closed.
+    #[test]
+    fn refine_failed_class_no_longer_outranks_gated_refined_class() {
+        use super::apply_refinement;
+
+        // A degenerate refined class: 13 members, coverage 0.0 → the strong coverage gate (×0.10),
+        // refactorability also degenerate. Same structural factors as the refine-failed class below
+        // (unit spread, body 10, load-bearing 1.0, cohesion 1.0) so only the gate vs. member_count
+        // differs.
+        let mut refined = class_with_member_count(13);
+        let mut degenerate = unsampled_refinement();
+        degenerate.anti_unify_coverage = 0.0; // → COVERAGE_STRONG_PENALTY (×0.10)
+        degenerate.refactorability = 0.10; // degenerate ⟨m0⟩ template
+        apply_refinement(&mut refined, degenerate);
+        assert!(refined.refined, "the refined class is flagged refined");
+
+        // A refine-FAILED class with MANY more members (a large over-merged component that could
+        // not be refined): same unit structural factors, raw member_count-linear Plan-2
+        // ROI.
+        let mut refine_failed = class_with_member_count(300);
+        refine_failed.refined = false;
+        // Reproduce the Plan-2 ROI build_class would have set (unit factors → roi == member_count).
+        refine_failed.roi = refine_failed.cross_module_spread as f64
+            * refine_failed.member_count as f64
+            * refine_failed.body_token_len_medoid as f64
+            * refine_failed.roi_factors.load_bearing_factor
+            * refine_failed.cohesion_min_pairwise;
+
+        // PRE-dampen: the refine-failed giant out-ranks the gated refined class purely on size —
+        // the #259 bug. (300 × 10 = 3000 vs 13 × 10 × 0.10 × 0.10 = 1.3.)
+        assert!(
+            refine_failed.roi > refined.roi,
+            "pre-dampen the refine-failed class masquerades as high-ROI: {} vs {}",
+            refine_failed.roi,
+            refined.roi
+        );
+
+        // Apply the dampen (what the find_clones unlimited path now does to every un-refined
+        // class).
+        dampen_unrefined_member_count(&mut refine_failed);
+
+        // POST-dampen: the refine-failed class's size factor is sub-linear (1 + ln(301) ≈ 6.71), so
+        // its ROI (≈ 6.71 × 10 = 67) no longer dwarfs everything — but more importantly its LINEAR
+        // member_count dominance is gone, so it can no longer drown out genuinely refactorable
+        // refined classes in the ranking. (The refined class here is deliberately the degenerate
+        // worst case; a HEALTHY refined class with coverage ≥ 0.5 keeps its full member_count and
+        // out-ranks the dampened refine-failed class outright.)
+        assert!(
+            refine_failed.roi < 300.0,
+            "the dampen subdues the linear member_count dominance: {}",
+            refine_failed.roi
+        );
+        // A healthy refined class (no coverage gate) with the SAME 13 members now out-ranks the
+        // 300-member refine-failed class — the masquerade is closed.
+        let mut healthy = class_with_member_count(13);
+        healthy.body_token_len_medoid = 100; // a real refactorable clone with substantial bodies
+        let healthy_refinement = unsampled_refinement(); // coverage 1.0, refactorability 1.0
+        apply_refinement(&mut healthy, healthy_refinement);
+        assert!(
+            healthy.roi > refine_failed.roi,
+            "a healthy refined class out-ranks the dampened refine-failed giant: {} vs {}",
+            healthy.roi,
+            refine_failed.roi
+        );
     }
 
     /// #256: `bucket_edges_by_component` partitions the candidate pairs into per-component edge

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -14713,6 +14713,107 @@ fn faithfulness_pin_still_drops_drifted_member() {
     let _ = fs::remove_dir_all(root);
 }
 
+/// #259 (Adversary C) — END-TO-END through the real `find_clones` driver: a refine-FAILED class (a
+/// clone class whose on-disk source drifted post-index, so `refine_class_in_place` no-ops and the
+/// class stays un-refined with its member_count-LINEAR Plan-2 ROI) has its `member_count` size
+/// factor DAMPENED in the returned result. The dampen (applied to every still-un-refined class
+/// post-refine, pre-sort in BOTH `find_clones` branches) replaces the linear `member_count` factor
+/// with `1 + ln(1 + member_count)`, so a refine-failed component can no longer masquerade as
+/// high-ROI purely on size. This exercises the dampen through the REAL driver, not just the helper
+/// unit — it proves `find_clones` rewrites a returned un-refined class's `roi` to the dampened
+/// formula.
+///
+/// Fixture: a clone class of THREE rename-clones with a substantial body. We DRIFT one member on
+/// disk (structurally different re-parse → struct_hash mismatch → the all-or-nothing faithfulness
+/// pin makes the refinement a no-op on a COLD cache), so the class comes back un-refined. The
+/// returned `roi` must equal the DAMPENED Plan-2 product (size factor `1 + ln(1 + member_count)`),
+/// which is strictly below the raw LINEAR product (`member_count` factor) the class would carry
+/// without the fix — the masquerade is closed.
+#[test]
+fn refine_failed_class_member_count_dampened_end_to_end() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+
+    // A clone class of THREE rename-clones with a substantial body — would refine cleanly if the
+    // source stayed faithful.
+    let body = |name: &str, v: &str| {
+        format!(
+            "pub fn {name}(db: Db) -> i32 {{ let {v}1 = db.get(1); let {v}2 = db.get(2); let {v}3 \
+             = db.get(3); validate({v}1); validate({v}2); validate({v}3); {v}1 + {v}2 + {v}3 }}\n"
+        )
+    };
+    fs::write(root.join("src/a.rs"), body("load_a", "u")).unwrap();
+    fs::write(root.join("src/b.rs"), body("load_b", "o")).unwrap();
+    fs::write(root.join("src/c.rs"), body("load_c", "p")).unwrap();
+
+    // Build the index clean (so the 3-member class forms from faithful fingerprints) with a COLD
+    // refine cache, then DRIFT one member BEFORE the first find_clones. A warm cache hit would
+    // serve the cached refinement and never re-read the drifted source (the cache key is over
+    // the PERSISTED struct_hash + the PERSISTED file sha256, both unchanged by an on-disk
+    // edit), so the drift MUST land before the very first refine attempt.
+    let db = IndexDatabase::rebuild(&source_config(root.clone(), Language::Rust)).unwrap();
+
+    // DRIFT one member: overwrite c.rs with a structurally DIFFERENT body. The index keeps the old
+    // fingerprint (the class is still BUILT with member_count 3 from the persisted tables), but the
+    // FIRST find_clones below takes the cold refine path → `load_refine_members` re-parses the
+    // drifted source → struct_hash mismatch → the all-or-nothing faithfulness pin returns Ok(None)
+    // → the class stays UN-refined.
+    fs::write(
+        root.join("src/c.rs"),
+        "pub fn load_c(db: Db) -> i32 { let mut n = 0; while n < 9 { n += 1; } n }\n",
+    )
+    .unwrap();
+
+    let result = db
+        .find_clones(FindClonesOptions { min_similarity: None, min_copies: None, limit: None })
+        .unwrap();
+    assert_eq!(
+        result.classes.len(),
+        1,
+        "the three rename-clones form one class: {:?}",
+        result.classes
+    );
+    let class = &result.classes[0];
+    assert_eq!(
+        class.member_count, 3,
+        "the class is built with all 3 members from persisted tables"
+    );
+
+    // The class FAILED refinement (one member drifted → all-or-nothing) and is un-refined.
+    assert!(
+        !class.refined,
+        "the drifted class fails the all-or-nothing refine and stays un-refined"
+    );
+
+    // THE #259 PROPERTY: the returned `roi` is the DAMPENED Plan-2 product — the `member_count`
+    // factor replaced by `1 + ln(1 + member_count)`. Reconstruct both the raw (linear) and the
+    // dampened product from the surfaced factors and confirm find_clones returned the dampened one.
+    let mc = class.member_count as f64;
+    let raw_roi = class.cross_module_spread as f64
+        * mc
+        * class.body_token_len_medoid as f64
+        * class.roi_factors.load_bearing_factor
+        * class.cohesion_min_pairwise;
+    let dampened_roi = raw_roi / mc * (1.0 + mc.ln_1p());
+    assert!(
+        (class.roi - dampened_roi).abs() < 1e-6,
+        "#259: find_clones must return the DAMPENED roi {} for the un-refined class, got {}",
+        dampened_roi,
+        class.roi
+    );
+    // The dampen STRICTLY reduces the rank signal versus the raw linear Plan-2 ROI (3 members →
+    // 1 + ln(4) ≈ 2.39 < 3), so a large refine-failed component can no longer dominate on size.
+    assert!(
+        class.roi < raw_roi,
+        "#259: the dampened roi {} must be strictly below the raw linear Plan-2 roi {}",
+        class.roi,
+        raw_roi
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
 /// Fix 3 (#215): `clones_for_symbol` carries eligibility flags. A below-`MIN_TOKENS` function
 /// RESOLVES (`symbol_resolved=true`) but is not fingerprinted (`symbol_fingerprinted=false`,
 /// `class=None`); an eligible-but-unique function is fingerprinted with no class; an eligible


### PR DESCRIPTION
Closes #259.

**Adversary C (coverage-gate bypass):** the coverage ROI gate is applied only to the *refined* ROI. A class that fails refinement keeps its un-refined Plan-2 ROI — **member_count-dominated, no coverage gate** — so a large refine-failed component could out-rank a gated refined class. Fix: `dampen_unrefined_member_count` — a **ranking-only** re-weight of `class.roi` (the sort key) that divides out the linear `member_count` factor and multiplies in the same sub-linear `1 + member_count.ln_1p()` shape `build_class` already uses for `load_bearing_factor`, preserving the other four Plan-2 factors. Guarded to `refined == false` (a refined class's roi is `refactorability × coverage_gate`, so dividing by mc would be semantically wrong).

**Adversary A (budget-tripped split fan-out):** handled as a doc + regression pin.

## Gating-only — validated
The dampen mutates **only** `class.roi`; members / membership / which-pairs-are-clones are never touched. `find_clones_precomputed_matches_live` compares membership (order- and roi-insensitive), so a sort-key-only change is invisible to it by construction; the precompute parity tests are upstream of `build_class` entirely. All re-run green.

## Tests
`refine_failed_class_member_count_dampened_end_to_end` drives the real `find_clones`, asserts the class returns `!refined`, and reconstructs both the raw (linear) and dampened ROI from the surfaced struct fields. 1050 workspace tests, clippy, fmt.