### PR TITLE
feat(clones): name why a resolved symbol is clone-ineligible — eligibility reason enum (#274 item 3a)

### DIFF
--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -49,10 +49,10 @@ pub(crate) use mem_diag::{maybe_set_sqlite_soft_heap_limit, mem_trace};
 pub use parser_failures::ParserFailure;
 pub(crate) use prep::*;
 pub use query_api::{
-    CandidateCloneClass, CloneCheckInput, CloneCompleteness, CloneEdgeReport,
-    CloneFingerprintHealth, CloneMember, CloneSymbolSelector, ClonesForSymbolResult,
-    FindClonesOptions, FindClonesResult, GcReport, ImportantSymbolsRequest, OracleShaSnapshots,
-    RoiFactors, SearchRequest, TextCloneMatch,
+    CandidateCloneClass, CloneCheckInput, CloneCompleteness, CloneEdgeReport, CloneEligibility,
+    CloneFingerprintHealth, CloneIneligibilityReason, CloneMember, CloneSymbolSelector,
+    ClonesForSymbolResult, FindClonesOptions, FindClonesResult, GcReport, ImportantSymbolsRequest,
+    OracleShaSnapshots, RoiFactors, SearchRequest, TextCloneMatch,
 };
 pub(crate) use util::*;
 

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -239,6 +239,80 @@ pub struct CloneCompleteness {
     pub known_index_gaps: Vec<String>,
 }
 
+/// Why a *resolved* symbol is not clone-eligible (#274 item 3a). The `symbol_fingerprinted = false`
+/// bool conflated several distinct causes — this names them so a consumer can tell "below
+/// `MIN_TOKENS`" (a near-miss worth nothing) from "the file is generated" (excluded by policy) from
+/// "the index is stale at this symbol" (a reindex would fix it). It is a closed, persisted-style
+/// enum: [`as_db_str`](Self::as_db_str) / [`from_db_str`](Self::from_db_str) give the stable wire
+/// token that crosses the MCP/CLI serde boundary, and `serde` emits that same snake_case token.
+///
+/// Reasons are determined in PRIORITY order (see [`classify_ineligibility_reason`]), so exactly one
+/// is reported even when several apply (a generated file ALSO has a non-function `_` symbol, etc.):
+/// `Generated` ⊃ `StaleNormalizerVersion` ⊃ `NonFunctionKind` ⊃ `BelowMinTokens`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CloneIneligibilityReason {
+    /// The symbol's file is generated (`files.generated = 1` — a `kind = generated` target or a
+    /// path-heuristic codegen file like `src/generated/…`/`.d.ts`). Generated code is excluded from
+    /// clone recall by policy; checked FIRST because a generated file's symbols are never
+    /// fingerprinted regardless of kind/size.
+    Generated,
+    /// The symbol is not a function-shaped declaration: its `kind` is neither `"function"` nor a
+    /// function-valued declarator (`const f = () => …`, a class-field arrow — #232 #5). Only
+    /// function-shaped symbols are fingerprinted, so this can never be a clone-class member.
+    NonFunctionKind,
+    /// A baseline fingerprint row EXISTS for this symbol but at a `normalizer_version` other than
+    /// the current [`NORM_VERSION`] — the index was last fingerprinted by an older binary and
+    /// the read filter excludes it. A `rag-rat index --full` with the current binary fixes it.
+    /// Distinct from `BelowMinTokens` (where NO row exists at all): here the symbol WAS
+    /// eligible, the index is just stale.
+    StaleNormalizerVersion,
+    /// The symbol is function-shaped and in a non-generated file, but no current-version
+    /// fingerprint row exists — its body normalized below [`MIN_TOKENS`](crate::index::clones)
+    /// tokens (the size floor), so it was never fingerprinted. The residual catch-all once
+    /// `Generated` / `NonFunctionKind` / `StaleNormalizerVersion` are ruled out.
+    BelowMinTokens,
+}
+
+impl CloneIneligibilityReason {
+    /// The stable wire/DB token for this reason (matches the `serde` snake_case rename).
+    pub fn as_db_str(self) -> &'static str {
+        match self {
+            CloneIneligibilityReason::Generated => "generated",
+            CloneIneligibilityReason::NonFunctionKind => "non_function_kind",
+            CloneIneligibilityReason::StaleNormalizerVersion => "stale_normalizer_version",
+            CloneIneligibilityReason::BelowMinTokens => "below_min_tokens",
+        }
+    }
+
+    /// Parse a wire/DB token back into a reason (inverse of [`as_db_str`](Self::as_db_str)).
+    pub fn from_db_str(value: &str) -> Option<Self> {
+        match value {
+            "generated" => Some(CloneIneligibilityReason::Generated),
+            "non_function_kind" => Some(CloneIneligibilityReason::NonFunctionKind),
+            "stale_normalizer_version" => Some(CloneIneligibilityReason::StaleNormalizerVersion),
+            "below_min_tokens" => Some(CloneIneligibilityReason::BelowMinTokens),
+            _ => None,
+        }
+    }
+}
+
+/// The clone-eligibility verdict for a [`clones_for_symbol`](IndexDatabase::clones_for_symbol)
+/// selector — the richer companion to the `symbol_resolved` / `symbol_fingerprinted` bools (#274
+/// item 3a). Serializes as an internally-tagged object (`{ "status": "eligible" }`,
+/// `{ "status": "ineligible", "reason": "below_min_tokens" }`,
+/// `{ "status": "symbol_not_resolved" }`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum CloneEligibility {
+    /// The selector matched no scoped symbol (`symbol_resolved = false`).
+    SymbolNotResolved,
+    /// The symbol resolved AND carries a current-version baseline fingerprint (clone-eligible).
+    Eligible,
+    /// The symbol resolved but is not clone-eligible; `reason` says why.
+    Ineligible { reason: CloneIneligibilityReason },
+}
+
 /// Result of [`IndexDatabase::clones_for_symbol`]. Carries eligibility flags + a completeness block
 /// so a caller can distinguish "selector matched nothing" from "matched a symbol that is not
 /// eligible for fingerprinting" from "eligible but unique (in no clone class)".
@@ -254,6 +328,13 @@ pub struct ClonesForSymbolResult {
     /// …`, a class-field arrow handler, #232 #5 — ≥ `MIN_TOKENS` in a non-generated, in-scope
     /// file).
     pub symbol_fingerprinted: bool,
+    /// The richer eligibility verdict (#274 item 3a): when `symbol_fingerprinted = false` this
+    /// names WHY the symbol is not clone-eligible (generated file / non-function kind / stale
+    /// normalizer_version / below `MIN_TOKENS`) instead of conflating all four into one bool.
+    /// Stays consistent with the bools: `Eligible` ⇔ `symbol_fingerprinted`,
+    /// `SymbolNotResolved` ⇔ `!symbol_resolved`, `Ineligible { .. }` ⇔ `symbol_resolved &&
+    /// !symbol_fingerprinted`.
+    pub eligibility: CloneEligibility,
     /// Same provenance block as [`FindClonesResult::completeness`].
     pub completeness: CloneCompleteness,
 }
@@ -978,11 +1059,14 @@ impl IndexDatabase {
     ) -> anyhow::Result<ClonesForSymbolResult> {
         let conn = self.storage.connection();
 
+        // `eligibility` is the single source of truth; `symbol_resolved` / `symbol_fingerprinted`
+        // are derived from it so the bool fields and the richer enum can never disagree (#274 3a).
         let make_result = |class: Option<CandidateCloneClass>,
-                           symbol_resolved: bool,
-                           symbol_fingerprinted: bool,
+                           eligibility: CloneEligibility,
                            stale_members: usize,
                            freshness: String| {
+            let symbol_resolved = !matches!(eligibility, CloneEligibility::SymbolNotResolved);
+            let symbol_fingerprinted = matches!(eligibility, CloneEligibility::Eligible);
             // A single class can only truncate by capping its own member list; there is no
             // class-limit here, so reuse the same member-cap signal as `find_clones`.
             let truncated = class.as_ref().is_some_and(|c| c.members_returned < c.total_members);
@@ -990,6 +1074,7 @@ impl IndexDatabase {
                 class,
                 symbol_resolved,
                 symbol_fingerprinted,
+                eligibility,
                 // No class limit on this path → never refine-budget-clamped.
                 completeness: build_completeness(
                     THETA,
@@ -1006,14 +1091,17 @@ impl IndexDatabase {
 
         let resolved_id = resolve_selector_to_symbol_id(conn, &selector)?;
         let Some(symbol_id) = resolved_id else {
-            return Ok(make_result(None, false, false, 0, freshness));
+            return Ok(make_result(None, CloneEligibility::SymbolNotResolved, 0, freshness));
         };
 
         let bags = load_scoped_baseline_bags(conn)?;
-        // If the resolved symbol has no fingerprint row it is not eligible — it can't be in any
-        // clone class (generated file, below MIN_TOKENS, or a non-function symbol).
+        // If the resolved symbol has no current-version fingerprint row it is not eligible — it
+        // can't be in any clone class. Classify WHY (generated file, non-function kind,
+        // stale normalizer_version, or below MIN_TOKENS) instead of collapsing all four
+        // into one bool.
         if !bags.iter().any(|b| b.symbol_id == symbol_id) {
-            return Ok(make_result(None, true, false, 0, freshness));
+            let reason = classify_ineligibility_reason(conn, symbol_id)?;
+            return Ok(make_result(None, CloneEligibility::Ineligible { reason }, 0, freshness));
         }
 
         let by_id: BTreeMap<i64, &SymbolBag> = bags.iter().map(|b| (b.symbol_id, b)).collect();
@@ -1023,7 +1111,7 @@ impl IndexDatabase {
         // Find the component that contains this symbol_id (with its index so we can pull its edge
         // bucket).
         let Some(comp_idx) = components.iter().position(|comp| comp.contains(&symbol_id)) else {
-            return Ok(make_result(None, true, true, 0, freshness));
+            return Ok(make_result(None, CloneEligibility::Eligible, 0, freshness));
         };
         let component = components[comp_idx].clone();
         // The θ-verified edge subset for THIS component (#256) — feeds the scalable clique cover so
@@ -1115,7 +1203,7 @@ impl IndexDatabase {
             },
         };
 
-        Ok(make_result(class, true, true, stale_members, freshness))
+        Ok(make_result(class, CloneEligibility::Eligible, stale_members, freshness))
     }
 }
 
@@ -1573,6 +1661,64 @@ fn resolve_selector_to_symbol_id(
             Ok(id)
         },
     }
+}
+
+/// Classify WHY a *resolved* symbol is not clone-eligible (#274 item 3a) — only called once
+/// `clones_for_symbol` has established `symbol_resolved = true` AND the symbol is absent from the
+/// candidate bags (`symbol_fingerprinted = false`). Queries the DB for the three discriminating
+/// facts — is the file generated, what is the symbol's `kind`, and does ANY baseline fingerprint
+/// row exist (at any `normalizer_version`) — and resolves them in PRIORITY order so exactly one
+/// reason is reported:
+///
+/// 1. [`Generated`](CloneIneligibilityReason::Generated) — `files.generated = 1`. Checked first
+///    because generated symbols are never fingerprinted regardless of kind/size, AND the read
+///    filter (`load_scoped_baseline_bags`) excludes them even if a stale row lingers from before a
+///    target-reclassification.
+/// 2. [`StaleNormalizerVersion`](CloneIneligibilityReason::StaleNormalizerVersion) — a baseline row
+///    EXISTS but not at the current [`NORM_VERSION`]. Checked before the kind test because a
+///    function-VALUED declarator (`const f = () => …`, #232 #5) keeps `kind = "const"` yet IS
+///    fingerprinted, so an existing row is the authoritative "this symbol was eligible" signal —
+///    the index is merely stale.
+/// 3. [`NonFunctionKind`](CloneIneligibilityReason::NonFunctionKind) — `kind != "function"` and no
+///    fingerprint row exists. (A large function-valued declarator is caught by rule 2; a tiny one
+///    with a non-`function` kind is honestly reported here — both `NonFunctionKind` and
+///    `BelowMinTokens` are true, and the literal `kind` fact is the one the DB can attest to
+///    without the AST.)
+/// 4. [`BelowMinTokens`](CloneIneligibilityReason::BelowMinTokens) — the residual: a `kind =
+///    "function"` symbol in a non-generated file with no current-version row, i.e. its normalized
+///    body fell below [`MIN_TOKENS`](crate::index::clones).
+fn classify_ineligibility_reason(
+    conn: &Connection,
+    symbol_id: i64,
+) -> anyhow::Result<CloneIneligibilityReason> {
+    // The three discriminating facts in one read: the file's generated flag, the symbol kind, and
+    // whether ANY baseline fingerprint row exists (any normalizer_version) — `EXISTS` so the kind
+    // and generated columns stay single-row.
+    let (generated, kind, has_any_baseline_fp): (bool, String, bool) = conn.query_row(
+        "SELECT files.generated,
+                symbols.kind,
+                EXISTS(
+                    SELECT 1 FROM symbol_fingerprints sf
+                    WHERE sf.symbol_id = symbols.id AND sf.normalizer_kind = 'baseline'
+                )
+         FROM symbols
+         JOIN files ON files.id = symbols.file_id
+         WHERE symbols.id = ?1",
+        rusqlite::params![symbol_id],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )?;
+
+    Ok(if generated {
+        CloneIneligibilityReason::Generated
+    } else if has_any_baseline_fp {
+        // A row exists but the current-version read missed it (the caller already established
+        // `symbol_fingerprinted = false`) ⇒ the only stored row is at a stale normalizer_version.
+        CloneIneligibilityReason::StaleNormalizerVersion
+    } else if kind != "function" {
+        CloneIneligibilityReason::NonFunctionKind
+    } else {
+        CloneIneligibilityReason::BelowMinTokens
+    })
 }
 
 /// Extract candidate pairs from already-loaded bags (avoids a second DB round-trip in

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -24,8 +24,9 @@ mod search;
 pub use clones::of_text::{CloneCheckInput, CloneFingerprintHealth, TextCloneMatch};
 pub use clones::precompute::CloneEdgeReport;
 pub use clones::{
-    CandidateCloneClass, CloneCompleteness, CloneMember, CloneSymbolSelector,
-    ClonesForSymbolResult, FindClonesOptions, FindClonesResult, RoiFactors,
+    CandidateCloneClass, CloneCompleteness, CloneEligibility, CloneIneligibilityReason,
+    CloneMember, CloneSymbolSelector, ClonesForSymbolResult, FindClonesOptions, FindClonesResult,
+    RoiFactors,
 };
 #[cfg(test)]
 pub(crate) use clones::{MAX_MEMBERS, MEMBER_VALUE_CAP};

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -14766,6 +14766,195 @@ fn clones_for_symbol_reports_eligibility() {
     let _ = fs::remove_dir_all(root);
 }
 
+/// #274 item 3a: `clones_for_symbol` reports a RICHER eligibility reason than the bare
+/// `symbol_fingerprinted = false` bool, distinguishing the four "not eligible" causes:
+/// `BelowMinTokens`, `NonFunctionKind`, `Generated`, and `StaleNormalizerVersion`. Each variant is
+/// exercised with a symbol that triggers exactly it, plus the `Eligible` and `SymbolNotResolved`
+/// verdicts and the bool/enum consistency invariant.
+#[test]
+fn clones_for_symbol_distinguishes_ineligibility_reasons() {
+    use crate::index::clones::NORM_VERSION;
+
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::create_dir_all(root.join("src/generated")).unwrap();
+
+    // tiny: a `function` below MIN_TOKENS ⇒ no fingerprint row ⇒ BelowMinTokens.
+    fs::write(root.join("src/tiny.rs"), "pub fn tiny() -> i32 { 0 }\n").unwrap();
+    // a struct: a non-function symbol ⇒ NonFunctionKind. (A struct never fingerprints.)
+    fs::write(
+        root.join("src/shape.rs"),
+        "pub struct Shape { pub width: i32, pub height: i32, pub depth: i32 }\n",
+    )
+    .unwrap();
+    // generated: a SUBSTANTIAL function (clears MIN_TOKENS) in a path-heuristic generated file.
+    // It keeps `kind = source` and gets symbols, but `files.generated = 1`, so the index-time
+    // fingerprint compute is skipped — Generated must win over BelowMinTokens (it clears the size
+    // floor, so the only reason it is unfingerprinted is the generated flag).
+    fs::write(
+        root.join("src/generated/bindings.rs"),
+        "pub fn shared_symbol(v: Vec<u8>) -> usize { let mut n = 0; for b in v { n ^= b as usize; \
+         } n }\n",
+    )
+    .unwrap();
+    // stale: a substantial, structurally distinct function ⇒ normally fingerprinted (eligible). We
+    // demote its fingerprint row to NORM_VERSION - 1 below so the current-version read misses it
+    // while a baseline row still EXISTS ⇒ StaleNormalizerVersion.
+    fs::write(
+        root.join("src/stale.rs"),
+        "pub fn stale_fn(v: Vec<u8>) -> usize { let mut n = 0; for b in v { n += b as usize; } n \
+         }\n",
+    )
+    .unwrap();
+    // eligible: two rename-clones so each is fingerprinted AND in a clone class ⇒ Eligible.
+    fs::write(
+        root.join("src/a.rs"),
+        "pub fn load_user(db: Db) -> i32 { let u = db.get(1); validate(u); u + 1 }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("src/b.rs"),
+        "pub fn load_order(s: Db) -> i32 { let o = s.get(2); validate(o); o + 1 }\n",
+    )
+    .unwrap();
+
+    let db = IndexDatabase::rebuild(&source_config(root.clone(), Language::Rust)).unwrap();
+
+    // Demote stale_fn's baseline fingerprint to a PRIOR normalizer_version: the row still exists,
+    // but the current-NORM_VERSION read filter excludes it.
+    {
+        let conn = db.storage.connection();
+        let updated = conn
+            .execute(
+                "UPDATE symbol_fingerprints
+                 SET normalizer_version = ?2
+                 WHERE normalizer_kind = 'baseline'
+                   AND normalizer_version = ?1
+                   AND symbol_id IN (
+                       SELECT symbols.id FROM symbols
+                       JOIN name_strings ns ON ns.id = symbols.qualified_name_id
+                       WHERE ns.value = 'src/stale.rs::stale_fn'
+                   )",
+                rusqlite::params![NORM_VERSION, NORM_VERSION - 1],
+            )
+            .unwrap();
+        assert_eq!(updated, 1, "exactly one stale_fn baseline row should be demoted");
+    }
+
+    // Helper: assert the bool fields stay consistent with the enum verdict (the invariant the
+    // result type documents).
+    let assert_consistent = |res: &crate::index::ClonesForSymbolResult| match res.eligibility {
+        crate::index::CloneEligibility::SymbolNotResolved => {
+            assert!(!res.symbol_resolved && !res.symbol_fingerprinted);
+        },
+        crate::index::CloneEligibility::Eligible => {
+            assert!(res.symbol_resolved && res.symbol_fingerprinted);
+        },
+        crate::index::CloneEligibility::Ineligible { .. } => {
+            assert!(res.symbol_resolved && !res.symbol_fingerprinted);
+        },
+    };
+
+    // BelowMinTokens.
+    let tiny = db.clones_for_symbol(CloneSymbolSelector::Ref("src/tiny.rs::tiny".into())).unwrap();
+    assert_eq!(
+        tiny.eligibility,
+        crate::index::CloneEligibility::Ineligible {
+            reason: crate::index::CloneIneligibilityReason::BelowMinTokens
+        },
+        "a below-MIN_TOKENS function reports BelowMinTokens"
+    );
+    assert_consistent(&tiny);
+
+    // NonFunctionKind.
+    let shape =
+        db.clones_for_symbol(CloneSymbolSelector::Ref("src/shape.rs::Shape".into())).unwrap();
+    assert_eq!(
+        shape.eligibility,
+        crate::index::CloneEligibility::Ineligible {
+            reason: crate::index::CloneIneligibilityReason::NonFunctionKind
+        },
+        "a struct (non-function kind) reports NonFunctionKind"
+    );
+    assert_consistent(&shape);
+
+    // Generated (wins over BelowMinTokens even though the body clears the size floor).
+    let generated = db
+        .clones_for_symbol(CloneSymbolSelector::Ref(
+            "src/generated/bindings.rs::shared_symbol".into(),
+        ))
+        .unwrap();
+    assert_eq!(
+        generated.eligibility,
+        crate::index::CloneEligibility::Ineligible {
+            reason: crate::index::CloneIneligibilityReason::Generated
+        },
+        "a substantial function in a generated file reports Generated"
+    );
+    assert_consistent(&generated);
+
+    // StaleNormalizerVersion (a baseline row exists, just not at the current version).
+    let stale =
+        db.clones_for_symbol(CloneSymbolSelector::Ref("src/stale.rs::stale_fn".into())).unwrap();
+    assert_eq!(
+        stale.eligibility,
+        crate::index::CloneEligibility::Ineligible {
+            reason: crate::index::CloneIneligibilityReason::StaleNormalizerVersion
+        },
+        "a symbol whose only fingerprint row is at a prior normalizer_version reports \
+         StaleNormalizerVersion"
+    );
+    assert_consistent(&stale);
+
+    // Eligible (fingerprinted + in a clone class).
+    let eligible =
+        db.clones_for_symbol(CloneSymbolSelector::Ref("src/a.rs::load_user".into())).unwrap();
+    assert_eq!(
+        eligible.eligibility,
+        crate::index::CloneEligibility::Eligible,
+        "a fingerprinted symbol reports Eligible"
+    );
+    assert!(eligible.class.is_some(), "load_user is in a clone class");
+    assert_consistent(&eligible);
+
+    // SymbolNotResolved (no such symbol).
+    let missing = db
+        .clones_for_symbol(CloneSymbolSelector::Ref("src/nope.rs::does_not_exist".into()))
+        .unwrap();
+    assert_eq!(
+        missing.eligibility,
+        crate::index::CloneEligibility::SymbolNotResolved,
+        "an unresolved selector reports SymbolNotResolved"
+    );
+    assert_consistent(&missing);
+
+    // The enum serializes as an internally-tagged object with the snake_case wire tokens that
+    // cross the MCP/CLI boundary.
+    let json = serde_json::to_value(&tiny).unwrap();
+    assert_eq!(json["eligibility"]["status"], "ineligible");
+    assert_eq!(json["eligibility"]["reason"], "below_min_tokens");
+    let json_ok = serde_json::to_value(&eligible).unwrap();
+    assert_eq!(json_ok["eligibility"]["status"], "eligible");
+
+    // as_db_str / from_db_str round-trip for every variant.
+    for reason in [
+        crate::index::CloneIneligibilityReason::Generated,
+        crate::index::CloneIneligibilityReason::NonFunctionKind,
+        crate::index::CloneIneligibilityReason::StaleNormalizerVersion,
+        crate::index::CloneIneligibilityReason::BelowMinTokens,
+    ] {
+        assert_eq!(
+            crate::index::CloneIneligibilityReason::from_db_str(reason.as_db_str()),
+            Some(reason),
+            "as_db_str/from_db_str must round-trip"
+        );
+    }
+    assert_eq!(crate::index::CloneIneligibilityReason::from_db_str("bogus"), None);
+
+    let _ = fs::remove_dir_all(root);
+}
+
 /// Plan 4b Task 5c: `build_class` threads the medoid's `symbol_id` out as
 /// `CandidateCloneClass::medoid_symbol_id`. For a normal (non-sampled) clone class:
 ///   - `medoid_symbol_id` is `Some`.


### PR DESCRIPTION
Closes #274 (item 3a). `clones_for_symbol`'s `symbol_fingerprinted = false` conflated four distinct "not eligible" reasons into one bool. Now a closed/persisted `CloneIneligibilityReason` enum (`as_db_str`/`from_db_str`) names which one, surfaced on `ClonesForSymbolResult.eligibility`, with `classify_ineligibility_reason` resolving exactly one in priority order: `Generated ⊃ StaleNormalizerVersion ⊃ NonFunctionKind ⊃ BelowMinTokens`.

## Additive — parity preserved (independently validated)
The two existing bools (`symbol_resolved`, `symbol_fingerprinted`) are now **derived** from the enum, value-identical to the prior explicit triples at every call site. The clone-detection path, the eligible path, and the MCP/CLI handlers are untouched (diff is 4 files, none a handler or parity test). The independent validator re-ran all gates green and confirmed the change is purely additive.

## Tests
A test per reason variant (a generated symbol, a below-MIN_TOKENS symbol, a non-function kind, a stale-normalizer symbol → each yields the right reason). 1047 workspace tests, clippy `--all-targets`, nightly fmt.

(The validator flagged one doc-only inconsistency — the enum summary listed two variants in swapped priority order vs the implementation — fixed in this branch.)