### PR TITLE
fix(clones): drop stale theta arg from coherence_split's #259 budget test — unbreak main

### DIFF
--- a/crates/rag-rat-core/src/index/clones/refine/split.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/split.rs
@@ -755,7 +755,7 @@ mod tests {
                     }
                 }
             }
-            let result = coherence_split(&members, &edges, sim, theta);
+            let result = coherence_split(&members, &edges, sim);
             // The class count is bounded by the budget, independent of n / edge count — it does NOT
             // grow with the component size the way the pre-#282 bare-pair tail did.
             assert!(


### PR DESCRIPTION
**Main is red.** Sequential-merge interaction between two PRs that were each green independently:
- **#259 (#299)** added `coherence_split_class_count_bounded_by_split_groups`, calling `coherence_split(&members, &edges, sim, theta)` — 4 args (correct at the time).
- **#258 (#298)** dropped `theta` from `coherence_split` (now 3 args), updating the call sites *it* knew about.

Neither PR's CI compiled the other's change, and the textual merge produced no conflict markers, so `main` broke on the semantic mismatch. The `eval`-feature clippy job reported it first, but the test is in `#[cfg(test)] mod tests` (not eval-gated) so the default build breaks too.

## Fix
Remove the extra `theta` argument from the one stale call site (`split.rs:758`). `theta` is still used in the edge-construction loop just above, so no unused-variable fallout. All other `coherence_split` call sites already pass 3 args.

## Verified
`cargo +nightly fmt`; `cargo clippy --workspace --all-targets` **and** `cargo clippy -p rag-rat-core --features eval --all-targets` both clean; **1053** workspace tests + the eval-feature coherence tests all green.