### PR TITLE
fix(ci): add .dockerignore so the bench image context excludes .git (unbreaks the kernel bench)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Docker build context exclusions.
+#
+# The only repo Dockerfile is `tools/bench.Containerfile` (built by bench-release.yml and
+# oracle.yml). It is a PURE TOOLCHAIN image — it COPYs nothing from the build context; the repo is
+# bind-mounted at `docker run`. So the whole repo was being sent as context for nothing.
+#
+# Without this file, Docker scans `.git` while assembling the context, which intermittently races a
+# pack/gc and fails with `checking context: file ('.git/objects/..') not found` — that is what broke
+# the v0.9.0 Linux-kernel indexing bench (bench-release). Excluding `.git` makes the context
+# deterministic; excluding the build/state dirs shrinks a multi-GB context to ~nothing.
+.git
+target
+.rag-rat
+.claude
+*.sqlite
+*.sqlite-shm
+*.sqlite-wal


### PR DESCRIPTION
The **v0.9.0 Linux-kernel indexing bench** (`bench-release`) didn't produce a number — it **failed** at the *Build bench image* step:

```
checking context: file ('.git/objects/81') not found or excluded by .dockerignore
```

That's Docker racing a pack/gc while scanning `.git` to assemble the build context — intermittent, which is why v0.7.0/v0.8.0 succeeded and v0.9.0 didn't.

## Root cause
`tools/bench.Containerfile` is a **pure toolchain image** — it `COPY`s **nothing** from the build context (the repo is bind-mounted at `docker run`, then `cargo build … && bash tools/bench-kernel.sh` runs inside). So Docker was sending the entire repo — `.git` (the race) plus a multi-GB `target/` — as context for no reason. There was no `.dockerignore`.

## Fix
Add a `.dockerignore` excluding `.git` (the deterministic fix — Docker never scans it) plus `target` / `.rag-rat` / `.claude` / sqlite (context size). The same image is built by `oracle.yml`, which benefits identically. Since neither build copies from the context, nothing is lost — just a far smaller, race-free context.

## Validation
The proof is the next `bench-release` run. After this merges, **re-run `bench-release` via `workflow_dispatch`** to backfill the v0.9.0 kernel index number into Bencher (the release-triggered run already failed). Future releases run it cleanly.