### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.9.0...rag-rat-core-v0.10.0) - 2026-06-25
+
+### Added
+
+- *(eval)* track commit-replay search recall in Bencher on main ([#315](https://github.com/cq27-dev/rag-rat/pull/315))
+- *(embed)* re-encode existing f32 embedding blobs to int8 ([#312](https://github.com/cq27-dev/rag-rat/pull/312)) ([#313](https://github.com/cq27-dev/rag-rat/pull/313))
+- *(embed)* int8 scalar quantization for chunk_embeddings — ~4x smaller, neutral quality ([#112](https://github.com/cq27-dev/rag-rat/pull/112)) ([#311](https://github.com/cq27-dev/rag-rat/pull/311))
+- *(eval)* recall@3 + recall@returned ceiling metrics; graded-git rerank (off) — #109 spike ([#310](https://github.com/cq27-dev/rag-rat/pull/310))
+- *(eval)* commit-replay retrieval eval harness ([#120](https://github.com/cq27-dev/rag-rat/pull/120)) ([#303](https://github.com/cq27-dev/rag-rat/pull/303))
+
+### Fixed
+
+- *(eval)* suppress git hooks on the replay's throwaway worktrees ([#306](https://github.com/cq27-dev/rag-rat/pull/306))
+
+### Other
+
+- *(embed)* centralize the embedding-model registry; BGE + jina as selectable options ([#112](https://github.com/cq27-dev/rag-rat/pull/112)) ([#309](https://github.com/cq27-dev/rag-rat/pull/309))
+
 ## [0.9.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.8.0...rag-rat-core-v0.9.0) - 2026-06-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3151,7 +3151,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rag-rat"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3170,7 +3170,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-mcp"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "3"
 # and the internal path deps below pin the same literal, so the three crates always publish in
 # lockstep. Bump this one line (and the two internal-dep `version`s under workspace.dependencies)
 # to release.
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Kristaps Karlsons"]
 edition = "2024"
 # Bundled SQLite (rusqlite `bundled` -> libsqlite3-sys 0.38.1) compiles a build script that uses the
@@ -28,8 +28,8 @@ categories = ["command-line-utilities", "development-tools"]
 # Internal crates — declared once here so the version requirement is set in lockstep with
 # [workspace.package].version above. Members reference these via `{ workspace = true }` and add
 # their own feature toggles at the use site.
-rag-rat-core = { version = "0.9.0", path = "crates/rag-rat-core", default-features = false }
-rag-rat-mcp = { version = "0.9.0", path = "crates/rag-rat-mcp", default-features = false }
+rag-rat-core = { version = "0.10.0", path = "crates/rag-rat-core", default-features = false }
+rag-rat-mcp = { version = "0.10.0", path = "crates/rag-rat-mcp", default-features = false }
 anyhow = "1.0"
 fastembed = { version = "5.17.2", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
 gix = { version = "0.84.0", default-features = false, features = ["status", "parallel", "sha1", "sha256", "revision", "blob-diff", "blame"] }


### PR DESCRIPTION



## 🤖 New release

* `rag-rat-core`: 0.9.0 -> 0.10.0 (⚠ API breaking changes)
* `rag-rat-mcp`: 0.9.0 -> 0.10.0 (✓ API compatible changes)
* `rag-rat`: 0.9.0 -> 0.10.0

### ⚠ `rag-rat-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field EvalQueryReport.recall_at_3 in /tmp/.tmp5KFgMG/rag-rat/crates/rag-rat-core/src/eval.rs:185
  field EvalQueryReport.recall_at_returned in /tmp/.tmp5KFgMG/rag-rat/crates/rag-rat-core/src/eval.rs:189
  field EvalMetrics.recall_at_3 in /tmp/.tmp5KFgMG/rag-rat/crates/rag-rat-core/src/eval.rs:155
  field EvalMetrics.recall_at_returned in /tmp/.tmp5KFgMG/rag-rat/crates/rag-rat-core/src/eval.rs:160
  field Config.search in /tmp/.tmp5KFgMG/rag-rat/crates/rag-rat-core/src/config.rs:21
  field Config.search in /tmp/.tmp5KFgMG/rag-rat/crates/rag-rat-core/src/config.rs:21
  field EvalOptions.replay in /tmp/.tmp5KFgMG/rag-rat/crates/rag-rat-core/src/eval.rs:90
  field EvalOptions.rerank in /tmp/.tmp5KFgMG/rag-rat/crates/rag-rat-core/src/eval.rs:95
  field EvalOptions.search_limit in /tmp/.tmp5KFgMG/rag-rat/crates/rag-rat-core/src/eval.rs:102
  field SearchOptions.graded_history in /tmp/.tmp5KFgMG/rag-rat/crates/rag-rat-core/src/search/lexical.rs:96
  field EvalBaselineReport.delta_recall_at_3 in /tmp/.tmp5KFgMG/rag-rat/crates/rag-rat-core/src/eval.rs:145
  field EvalBaselineReport.delta_recall_at_returned in /tmp/.tmp5KFgMG/rag-rat/crates/rag-rat-core/src/eval.rs:146

--- failure enum_changed_kind: pub enum changed kind ---

Description:
A public enum has been replaced by a different kind of item at the same path, which breaks code that relied on the enum's variants and representation.
        ref: https://github.com/obi1kenobi/cargo-semver-checks/issues/302
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_changed_kind.ron

Failed in:
  enum rag_rat_core::config::EmbeddingBackend became struct in /tmp/.tmp5KFgMG/rag-rat/crates/rag-rat-core/src/config.rs:130

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_parameter_count_changed.ron

Failed in:
  rag_rat_core::search::lexical::search_hash_baseline now takes 5 parameters instead of 4, in /tmp/.tmp5KFgMG/rag-rat/crates/rag-rat-core/src/search/lexical.rs:122

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  FastEmbedEmbedder::new, previously in file /tmp/.tmpQIMNKl/rag-rat-core/src/index/ai/mod.rs:110

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  rag_rat_core::index::IndexDatabase::search_hash_baseline takes 3 parameters in /tmp/.tmpQIMNKl/rag-rat-core/src/index/query_api/search.rs:88, but now takes 4 parameters in /tmp/.tmp5KFgMG/rag-rat/crates/rag-rat-core/src/index/query_api/search.rs:88
  rag_rat_core::IndexDatabase::search_hash_baseline takes 3 parameters in /tmp/.tmpQIMNKl/rag-rat-core/src/index/query_api/search.rs:88, but now takes 4 parameters in /tmp/.tmp5KFgMG/rag-rat/crates/rag-rat-core/src/index/query_api/search.rs:88

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  FASTEMBED_EMBEDDING_DIM in file /tmp/.tmpQIMNKl/rag-rat-core/src/index/ai/mod.rs:27
  HASH_EMBEDDING_DIM in file /tmp/.tmpQIMNKl/rag-rat-core/src/index/ai/mod.rs:26
  FASTEMBED_DISPLAY_MODEL in file /tmp/.tmpQIMNKl/rag-rat-core/src/index/ai/mod.rs:25
  MODEL2VEC_EMBEDDING_DIM in file /tmp/.tmpQIMNKl/rag-rat-core/src/index/ai/mod.rs:34
  FASTEMBED_MODEL_ID in file /tmp/.tmpQIMNKl/rag-rat-core/src/index/ai/mod.rs:24
  HASH_MODEL_ID in file /tmp/.tmpQIMNKl/rag-rat-core/src/index/ai/mod.rs:23
  MODEL2VEC_DISPLAY_MODEL in file /tmp/.tmpQIMNKl/rag-rat-core/src/index/ai/mod.rs:32
  MODEL2VEC_MODEL_ID in file /tmp/.tmpQIMNKl/rag-rat-core/src/index/ai/mod.rs:31
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rag-rat-core`

<blockquote>

## [0.10.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.9.0...rag-rat-core-v0.10.0) - 2026-06-25

### Added

- *(eval)* track commit-replay search recall in Bencher on main ([#315](https://github.com/cq27-dev/rag-rat/pull/315))
- *(embed)* re-encode existing f32 embedding blobs to int8 ([#312](https://github.com/cq27-dev/rag-rat/pull/312)) ([#313](https://github.com/cq27-dev/rag-rat/pull/313))
- *(embed)* int8 scalar quantization for chunk_embeddings — ~4x smaller, neutral quality ([#112](https://github.com/cq27-dev/rag-rat/pull/112)) ([#311](https://github.com/cq27-dev/rag-rat/pull/311))
- *(eval)* recall@3 + recall@returned ceiling metrics; graded-git rerank (off) — #109 spike ([#310](https://github.com/cq27-dev/rag-rat/pull/310))
- *(eval)* commit-replay retrieval eval harness ([#120](https://github.com/cq27-dev/rag-rat/pull/120)) ([#303](https://github.com/cq27-dev/rag-rat/pull/303))

### Fixed

- *(eval)* suppress git hooks on the replay's throwaway worktrees ([#306](https://github.com/cq27-dev/rag-rat/pull/306))

### Other

- *(embed)* centralize the embedding-model registry; BGE + jina as selectable options ([#112](https://github.com/cq27-dev/rag-rat/pull/112)) ([#309](https://github.com/cq27-dev/rag-rat/pull/309))
</blockquote>

## `rag-rat-mcp`

<blockquote>

## [0.10.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.9.0...rag-rat-core-v0.10.0) - 2026-06-25

### Added

- *(eval)* track commit-replay search recall in Bencher on main ([#315](https://github.com/cq27-dev/rag-rat/pull/315))
- *(embed)* re-encode existing f32 embedding blobs to int8 ([#312](https://github.com/cq27-dev/rag-rat/pull/312)) ([#313](https://github.com/cq27-dev/rag-rat/pull/313))
- *(embed)* int8 scalar quantization for chunk_embeddings — ~4x smaller, neutral quality ([#112](https://github.com/cq27-dev/rag-rat/pull/112)) ([#311](https://github.com/cq27-dev/rag-rat/pull/311))
- *(eval)* recall@3 + recall@returned ceiling metrics; graded-git rerank (off) — #109 spike ([#310](https://github.com/cq27-dev/rag-rat/pull/310))
- *(eval)* commit-replay retrieval eval harness ([#120](https://github.com/cq27-dev/rag-rat/pull/120)) ([#303](https://github.com/cq27-dev/rag-rat/pull/303))

### Fixed

- *(eval)* suppress git hooks on the replay's throwaway worktrees ([#306](https://github.com/cq27-dev/rag-rat/pull/306))

### Other

- *(embed)* centralize the embedding-model registry; BGE + jina as selectable options ([#112](https://github.com/cq27-dev/rag-rat/pull/112)) ([#309](https://github.com/cq27-dev/rag-rat/pull/309))
</blockquote>

## `rag-rat`

<blockquote>

## [0.10.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.9.0...rag-rat-core-v0.10.0) - 2026-06-25

### Added

- *(eval)* track commit-replay search recall in Bencher on main ([#315](https://github.com/cq27-dev/rag-rat/pull/315))
- *(embed)* re-encode existing f32 embedding blobs to int8 ([#312](https://github.com/cq27-dev/rag-rat/pull/312)) ([#313](https://github.com/cq27-dev/rag-rat/pull/313))
- *(embed)* int8 scalar quantization for chunk_embeddings — ~4x smaller, neutral quality ([#112](https://github.com/cq27-dev/rag-rat/pull/112)) ([#311](https://github.com/cq27-dev/rag-rat/pull/311))
- *(eval)* recall@3 + recall@returned ceiling metrics; graded-git rerank (off) — #109 spike ([#310](https://github.com/cq27-dev/rag-rat/pull/310))
- *(eval)* commit-replay retrieval eval harness ([#120](https://github.com/cq27-dev/rag-rat/pull/120)) ([#303](https://github.com/cq27-dev/rag-rat/pull/303))

### Fixed

- *(eval)* suppress git hooks on the replay's throwaway worktrees ([#306](https://github.com/cq27-dev/rag-rat/pull/306))

### Other

- *(embed)* centralize the embedding-model registry; BGE + jina as selectable options ([#112](https://github.com/cq27-dev/rag-rat/pull/112)) ([#309](https://github.com/cq27-dev/rag-rat/pull/309))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).