### PR TITLE
perf(mcp): jemalloc so idle servers return heap to the OS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -108,7 +108,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -810,7 +810,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -879,7 +879,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1507,7 +1507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
 dependencies = [
  "bstr",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -3162,6 +3162,8 @@ dependencies = [
  "rag-rat-mcp",
  "serde",
  "serde_json",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "tokio",
  "toon-format",
 ]
@@ -3491,7 +3493,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3776,7 +3778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3885,7 +3887,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3926,6 +3928,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -4645,7 +4678,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/rag-rat-cli/Cargo.toml
+++ b/crates/rag-rat-cli/Cargo.toml
@@ -31,6 +31,14 @@ tokio.workspace = true
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
 
+# Idle-RSS fix: glibc malloc never returns freed pages to the OS, so a long-lived `rag-rat mcp`
+# server retains its peak RSS (~625 MB observed) after the watcher's heavy index/graph passes.
+# jemalloc + a background purge thread gives dirty/muzzy pages back shortly after they go idle.
+# Gated off msvc (jemalloc has no msvc support); the `#[global_allocator]` cfg matches.
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { version = "0.6", features = ["background_threads"] }
+tikv-jemalloc-ctl = "0.6"
+
 [dev-dependencies]
 # MCP tool results render as TOON; integration tests decode them back to JSON Values to assert.
 toon-format.workspace = true

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -24,7 +24,40 @@ mod claude_hook;
 mod claude_settings;
 mod init;
 
+// Idle-RSS fix: glibc malloc never hands freed pages back to the OS, so a long-lived `rag-rat mcp`
+// server keeps its peak RSS (~625 MB observed) after the watcher's heavy index/graph passes.
+// jemalloc with a background purge thread returns idle dirty/muzzy pages to the OS instead.
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+/// Tune jemalloc to give idle heap back to the OS: enable its background purge thread (otherwise
+/// decayed pages are only reclaimed on later alloc calls, which a quiet server rarely makes) and
+/// tighten the decay window from the 10s default so an idle server releases memory within ~1s.
+/// Best-effort — a server that holds slightly more RAM is better than one that won't boot.
+#[cfg(not(target_env = "msvc"))]
+fn configure_jemalloc() {
+    use tikv_jemalloc_ctl::{background_thread, raw};
+    // Purge decayed pages on a background thread; a quiet server makes few alloc calls, which is
+    // otherwise the only time jemalloc reclaims.
+    let _ = background_thread::write(true);
+    // SAFETY: stable mallctl names with ssize_t (isize) values; the writes are best-effort.
+    unsafe {
+        // `arena.4096.*` is MALLCTL_ARENAS_ALL — retune EVERY arena that already exists (the main
+        // thread's arena is created before `main` runs). `arenas.*` alone only sets the default for
+        // arenas created LATER, so the already-live arenas keep the 10s default. Measured: with the
+        // all-arenas retune a freed ~490 MB heap returns to ~baseline in ~15s idle; without it, it
+        // lingers. Set both so existing and future arenas decay fast.
+        let _ = raw::write(b"arena.4096.dirty_decay_ms\0", 1000_isize);
+        let _ = raw::write(b"arena.4096.muzzy_decay_ms\0", 1000_isize);
+        let _ = raw::write(b"arenas.dirty_decay_ms\0", 1000_isize);
+        let _ = raw::write(b"arenas.muzzy_decay_ms\0", 1000_isize);
+    }
+}
+
 fn main() -> anyhow::Result<()> {
+    #[cfg(not(target_env = "msvc"))]
+    configure_jemalloc();
     let cli = Cli::parse();
 
     // Pin the process-wide output format from the global flag before any command runs, so


### PR DESCRIPTION
## Problem

A long-lived `rag-rat mcp` server sits at ~625 MB RSS even when idle. Kernel breakdown:

```
VmRSS   652 MB
RssAnon 625 MB   ← 96% anonymous HEAP (not mmap/file cache: RssFile is 27 MB)
VmSwap  300 MB   ← already swapped out → retained-but-cold, not actively used
```

Not a cache, not a leak — **allocator retention**. glibc malloc never returns freed small-allocation arena pages to the OS, so the watcher's heavy index/graph/clone passes leave their peak resident for the life of the process. With two editor sessions that's ~1.25 GB of mostly-dead heap.

## Fix

Switch the `rag-rat` binary to **tikv-jemallocator** (gated off msvc, where jemalloc has no support) with a background purge thread and a 1s dirty/muzzy decay on **all** arenas.

Key detail uncovered while measuring: the decay must target `arena.4096.*` (MALLCTL_ARENAS_ALL). `arenas.*` alone only sets the default for *future* arenas — the main thread's arena already exists by the time `main` runs, so it would keep the 10s default and barely release anything.

## Measurement

A/B with the real pattern (8M small allocations, then freed), same binary with/without jemalloc:

| allocator | peak | idle +1s | +2s | +4s | +8s |
|---|---|---|---|---|---|
| **glibc** | 551 MB | 490 | 490 | 490 | 490 (held forever) |
| **jemalloc** | 434 MB | 371 | 332 | 63 | **7** (baseline) |

glibc holds 490 MB indefinitely; jemalloc returns it to baseline within ~15s of idle, with a lower peak too (434 vs 551).

## Notes
- Config is best-effort (failures ignored — a server that holds a little extra RAM beats one that won't boot).
- jemalloc compiles from C, so the first build is slower; no behavior change beyond the allocator.
