### PR TITLE
perf(maintenance): skip the git-hook pass when a watcher is already live

### DIFF
--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -889,6 +889,25 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
         return Ok(());
     }
 
+    // If an MCP watcher is already live for this worktree, it runs the identical pass
+    // (`watch::run_pass`) on its own schedule whenever a tracked FILE changes — so for the
+    // file-changing triggers (checkout/merge) the eager hook pass here is redundant and just
+    // doubles the work + memory pressure. Defer to the watcher; the query-path heal covers the
+    // brief staleness gap. post-commit / post-rewrite touch only git metadata, which the
+    // file-watcher can't see, so those still run (and are cheap — no file content changed).
+    if matches!(trigger.as_str(), "post-checkout" | "post-merge")
+        && crate::claude_hook::watcher_state(config).0
+    {
+        print_output(&serde_json::json!({
+            "trigger": trigger,
+            "status": "skipped",
+            "reason": "watcher live — deferring to the watcher's pass",
+            "old_head": old_head,
+            "new_head": new_head,
+        }))?;
+        return Ok(());
+    }
+
     // Single-flight coalescing (#267): a single amend/merge/rebase fires several git hooks
     // (post-commit + post-rewrite, post-merge + post-commit, post-rewrite + post-checkouts), each
     // backgrounding `rag-rat maintenance`. Without coalescing they serialize on the write lock and


### PR DESCRIPTION
## Why

The git hook (`rag-rat maintenance`, run on every checkout/commit/merge) does the **same** heavy pass as the MCP watcher: `index_discover` → `refresh_worktree_overlays` → embedding `reconcile` → `reconcile_clone_edges` → `garbage_collect` → `memory_validate` (compare `commands/mod.rs::run_maintenance_pass` with `watch.rs::run_pass`).

So when an MCP server's watcher is live, the eager hook pass on a checkout/merge is fully redundant — it just doubles the work and the memory peak. With editor sessions open this stacks with the watcher's own pass and the per-session idle heap, and was a contributor to terminal OOMs.

## What

Gate the hook on `watcher_state(config).0` (the existing per-worktree election-lock probe):

- **post-checkout / post-merge** + watcher live → **skip** — the watcher sees the file change and runs the identical pass; query-path `search_with_heal` covers the brief staleness gap.
- **post-commit / post-rewrite** → still run. These touch only git metadata, which the file-watcher can't see (it subscribes through target-language globs, not `.git`), and they're cheap (no file content changed).

No behavior change when no watcher is running (CI, headless, no editor session) — the hook does its full pass as before.

Pairs with the jemalloc idle-RSS fix (#305) and the replay-worktree hook suppression (#306) — together they cut the steady-state heap and the redundant eager passes behind the OOMs.
