### PR TITLE
feat(embed): add BGE-small-en-v1.5 as a selectable embedder (#112)

### DIFF
--- a/crates/rag-rat-core/src/index/ai/helpers.rs
+++ b/crates/rag-rat-core/src/index/ai/helpers.rs
@@ -19,11 +19,7 @@ pub(crate) fn embed_query_with(
     embedder: &dyn Embedder,
     query: &str,
 ) -> anyhow::Result<QueryEmbedding> {
-    // Apply the model's query-side instruction prefix (BGE asymmetric retrieval); empty for
-    // symmetric models, so this is a no-op for hash / all-MiniLM / model2vec (#112 review).
-    let prefix = embedder.query_prefix();
-    let text = if prefix.is_empty() { query.to_string() } else { format!("{prefix}{query}") };
-    let texts = vec![text];
+    let texts = vec![query.to_string()];
     let mut vectors = embedder.embed_batch(&texts)?;
     let Some(vector) = vectors.pop() else {
         anyhow::bail!("embedder {} returned no query vector", embedder.model_id());

--- a/crates/rag-rat-core/src/index/ai/helpers.rs
+++ b/crates/rag-rat-core/src/index/ai/helpers.rs
@@ -19,7 +19,11 @@ pub(crate) fn embed_query_with(
     embedder: &dyn Embedder,
     query: &str,
 ) -> anyhow::Result<QueryEmbedding> {
-    let texts = vec![query.to_string()];
+    // Apply the model's query-side instruction prefix (BGE asymmetric retrieval); empty for
+    // symmetric models, so this is a no-op for hash / all-MiniLM / model2vec (#112 review).
+    let prefix = embedder.query_prefix();
+    let text = if prefix.is_empty() { query.to_string() } else { format!("{prefix}{query}") };
+    let texts = vec![text];
     let mut vectors = embedder.embed_batch(&texts)?;
     let Some(vector) = vectors.pop() else {
         anyhow::bail!("embedder {} returned no query vector", embedder.model_id());

--- a/crates/rag-rat-core/src/index/ai/helpers.rs
+++ b/crates/rag-rat-core/src/index/ai/helpers.rs
@@ -57,6 +57,7 @@ pub(crate) fn default_model_version(model_id: &str) -> &'static str {
     match model_id {
         HASH_MODEL_ID => "hash-v1",
         FASTEMBED_MODEL_ID => "fastembed-all-minilm-l6-v2-v1",
+        BGE_SMALL_MODEL_ID => "fastembed-bge-small-en-v1.5-v1",
         MODEL2VEC_MODEL_ID => "model2vec-potion-retrieval-32m-v1",
         _ => "v1",
     }
@@ -98,6 +99,7 @@ pub(crate) fn active_embedder(
     match model.model_id.as_str() {
         HASH_MODEL_ID => Ok(Box::new(HashEmbedder)),
         FASTEMBED_MODEL_ID => fastembed_embedder(intra_threads),
+        BGE_SMALL_MODEL_ID => bge_small_embedder(intra_threads),
         MODEL2VEC_MODEL_ID => model2vec_embedder(),
         other => anyhow::bail!("unknown active embedding model `{other}`"),
     }
@@ -150,6 +152,7 @@ pub(crate) fn expected_dim(model_id: &str) -> Option<usize> {
     match model_id {
         HASH_MODEL_ID => Some(HASH_EMBEDDING_DIM),
         FASTEMBED_MODEL_ID => Some(FASTEMBED_EMBEDDING_DIM),
+        BGE_SMALL_MODEL_ID => Some(BGE_SMALL_EMBEDDING_DIM),
         MODEL2VEC_MODEL_ID => Some(MODEL2VEC_EMBEDDING_DIM),
         _ => None,
     }
@@ -161,6 +164,20 @@ pub(crate) fn fastembed_embedder(
     #[cfg(feature = "fastembed")]
     {
         Ok(Box::new(FastEmbedEmbedder::new(intra_threads)?))
+    }
+    #[cfg(not(feature = "fastembed"))]
+    {
+        let _ = intra_threads;
+        anyhow::bail!("{}", FASTEMBED_MISSING_FEATURE_MESSAGE)
+    }
+}
+
+pub(crate) fn bge_small_embedder(
+    intra_threads: Option<usize>,
+) -> anyhow::Result<Box<dyn Embedder>> {
+    #[cfg(feature = "fastembed")]
+    {
+        Ok(Box::new(FastEmbedEmbedder::new_bge_small(intra_threads)?))
     }
     #[cfg(not(feature = "fastembed"))]
     {

--- a/crates/rag-rat-core/src/index/ai/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/mod.rs
@@ -32,6 +32,11 @@ pub const FASTEMBED_EMBEDDING_DIM: usize = 384;
 pub const BGE_SMALL_MODEL_ID: &str = "fastembed-bge-small-en-v1.5";
 pub const BGE_SMALL_DISPLAY_MODEL: &str = "BAAI/bge-small-en-v1.5";
 pub const BGE_SMALL_EMBEDDING_DIM: usize = 384;
+/// BGE retrieval expects a query-side instruction prefix (queries only; passages stay raw), per the
+/// model card. Applied at query-embed time (`embed_query_with`), so stored passage embeddings are
+/// unchanged — no re-embed needed when this lands, and symmetric models keep the empty default.
+pub const BGE_SMALL_QUERY_PREFIX: &str =
+    "Represent this sentence for searching relevant passages: ";
 
 /// Model2Vec static-embedding backend: a token→vector lookup + mean-pool (no transformer forward
 /// pass), ~100-500× faster than FastEmbed on CPU at some retrieval-quality cost. The right choice
@@ -62,6 +67,12 @@ pub trait Embedder {
     fn model_id(&self) -> &str;
     fn dim(&self) -> usize;
     fn embed_batch(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>>;
+    /// Instruction prepended to QUERIES (not passages) before embedding. Empty for symmetric models
+    /// (hash, all-MiniLM, model2vec); BGE returns its retrieval instruction. See
+    /// `embed_query_with`.
+    fn query_prefix(&self) -> &str {
+        ""
+    }
 }
 
 pub struct HashEmbedder;
@@ -113,27 +124,31 @@ pub struct FastEmbedEmbedder {
     model: std::sync::Mutex<fastembed::TextEmbedding>,
     model_id: &'static str,
     dim: usize,
+    query_prefix: &'static str,
 }
 
 #[cfg(feature = "fastembed")]
 impl FastEmbedEmbedder {
-    /// all-MiniLM-L6-v2 (384-dim) — the default general-purpose backend.
+    /// all-MiniLM-L6-v2 (384-dim) — the default general-purpose backend (symmetric, no prefix).
     pub fn new(intra_threads: Option<usize>) -> anyhow::Result<Self> {
         Self::with_model(
             fastembed::EmbeddingModel::AllMiniLML6V2,
             FASTEMBED_MODEL_ID,
             FASTEMBED_EMBEDDING_DIM,
+            "",
             intra_threads,
         )
     }
 
     /// BGE-small-en-v1.5 (384-dim, #112) — a stronger general-retrieval embedder, same dimension as
-    /// all-MiniLM so swapping it is a re-embed rather than a schema/dim change.
+    /// all-MiniLM so swapping it is a re-embed rather than a schema/dim change. Asymmetric: queries
+    /// get the retrieval instruction prefix (passages stay raw).
     pub fn new_bge_small(intra_threads: Option<usize>) -> anyhow::Result<Self> {
         Self::with_model(
             fastembed::EmbeddingModel::BGESmallENV15,
             BGE_SMALL_MODEL_ID,
             BGE_SMALL_EMBEDDING_DIM,
+            BGE_SMALL_QUERY_PREFIX,
             intra_threads,
         )
     }
@@ -142,6 +157,7 @@ impl FastEmbedEmbedder {
         model: fastembed::EmbeddingModel,
         model_id: &'static str,
         dim: usize,
+        query_prefix: &'static str,
         intra_threads: Option<usize>,
     ) -> anyhow::Result<Self> {
         use fastembed::{InitOptions, TextEmbedding};
@@ -155,7 +171,12 @@ impl FastEmbedEmbedder {
         if let Some(threads) = intra_threads.filter(|threads| *threads > 0) {
             options = options.with_intra_threads(threads);
         }
-        Ok(Self { model: std::sync::Mutex::new(TextEmbedding::try_new(options)?), model_id, dim })
+        Ok(Self {
+            model: std::sync::Mutex::new(TextEmbedding::try_new(options)?),
+            model_id,
+            dim,
+            query_prefix,
+        })
     }
 }
 
@@ -167,6 +188,10 @@ impl Embedder for FastEmbedEmbedder {
 
     fn dim(&self) -> usize {
         self.dim
+    }
+
+    fn query_prefix(&self) -> &str {
+        self.query_prefix
     }
 
     fn embed_batch(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {

--- a/crates/rag-rat-core/src/index/ai/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/mod.rs
@@ -32,11 +32,11 @@ pub const FASTEMBED_EMBEDDING_DIM: usize = 384;
 pub const BGE_SMALL_MODEL_ID: &str = "fastembed-bge-small-en-v1.5";
 pub const BGE_SMALL_DISPLAY_MODEL: &str = "BAAI/bge-small-en-v1.5";
 pub const BGE_SMALL_EMBEDDING_DIM: usize = 384;
-/// BGE retrieval expects a query-side instruction prefix (queries only; passages stay raw), per the
-/// model card. Applied at query-embed time (`embed_query_with`), so stored passage embeddings are
-/// unchanged — no re-embed needed when this lands, and symmetric models keep the empty default.
-pub const BGE_SMALL_QUERY_PREFIX: &str =
-    "Represent this sentence for searching relevant passages: ";
+// NB (#308 review): BGE-small-en-v1.5 does NOT take a query instruction prefix here. v1.5 needs no
+// instruction (BAAI: "no instruction only [a] slight degradation… without instruction in all cases
+// for convenience"), and on SHORT CODE queries the 9-word NL instruction dominates the query vector
+// — it collapsed every query together and tanked replay recall 0.562 → 0.000. Passages never take
+// it either. So queries embed raw, same as all-MiniLM.
 
 /// Model2Vec static-embedding backend: a token→vector lookup + mean-pool (no transformer forward
 /// pass), ~100-500× faster than FastEmbed on CPU at some retrieval-quality cost. The right choice
@@ -67,12 +67,6 @@ pub trait Embedder {
     fn model_id(&self) -> &str;
     fn dim(&self) -> usize;
     fn embed_batch(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>>;
-    /// Instruction prepended to QUERIES (not passages) before embedding. Empty for symmetric models
-    /// (hash, all-MiniLM, model2vec); BGE returns its retrieval instruction. See
-    /// `embed_query_with`.
-    fn query_prefix(&self) -> &str {
-        ""
-    }
 }
 
 pub struct HashEmbedder;
@@ -124,31 +118,28 @@ pub struct FastEmbedEmbedder {
     model: std::sync::Mutex<fastembed::TextEmbedding>,
     model_id: &'static str,
     dim: usize,
-    query_prefix: &'static str,
 }
 
 #[cfg(feature = "fastembed")]
 impl FastEmbedEmbedder {
-    /// all-MiniLM-L6-v2 (384-dim) — the default general-purpose backend (symmetric, no prefix).
+    /// all-MiniLM-L6-v2 (384-dim) — the default general-purpose backend.
     pub fn new(intra_threads: Option<usize>) -> anyhow::Result<Self> {
         Self::with_model(
             fastembed::EmbeddingModel::AllMiniLML6V2,
             FASTEMBED_MODEL_ID,
             FASTEMBED_EMBEDDING_DIM,
-            "",
             intra_threads,
         )
     }
 
     /// BGE-small-en-v1.5 (384-dim, #112) — a stronger general-retrieval embedder, same dimension as
-    /// all-MiniLM so swapping it is a re-embed rather than a schema/dim change. Asymmetric: queries
-    /// get the retrieval instruction prefix (passages stay raw).
+    /// all-MiniLM so swapping it is a re-embed rather than a schema/dim change. v1.5 needs no query
+    /// instruction (see the const note above), so queries embed raw, like all-MiniLM.
     pub fn new_bge_small(intra_threads: Option<usize>) -> anyhow::Result<Self> {
         Self::with_model(
             fastembed::EmbeddingModel::BGESmallENV15,
             BGE_SMALL_MODEL_ID,
             BGE_SMALL_EMBEDDING_DIM,
-            BGE_SMALL_QUERY_PREFIX,
             intra_threads,
         )
     }
@@ -157,7 +148,6 @@ impl FastEmbedEmbedder {
         model: fastembed::EmbeddingModel,
         model_id: &'static str,
         dim: usize,
-        query_prefix: &'static str,
         intra_threads: Option<usize>,
     ) -> anyhow::Result<Self> {
         use fastembed::{InitOptions, TextEmbedding};
@@ -171,12 +161,7 @@ impl FastEmbedEmbedder {
         if let Some(threads) = intra_threads.filter(|threads| *threads > 0) {
             options = options.with_intra_threads(threads);
         }
-        Ok(Self {
-            model: std::sync::Mutex::new(TextEmbedding::try_new(options)?),
-            model_id,
-            dim,
-            query_prefix,
-        })
+        Ok(Self { model: std::sync::Mutex::new(TextEmbedding::try_new(options)?), model_id, dim })
     }
 }
 
@@ -188,10 +173,6 @@ impl Embedder for FastEmbedEmbedder {
 
     fn dim(&self) -> usize {
         self.dim
-    }
-
-    fn query_prefix(&self) -> &str {
-        self.query_prefix
     }
 
     fn embed_batch(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {

--- a/crates/rag-rat-core/src/index/ai/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/mod.rs
@@ -25,6 +25,14 @@ pub const FASTEMBED_MODEL_ID: &str = "fastembed-all-minilm-l6-v2";
 pub const FASTEMBED_DISPLAY_MODEL: &str = "sentence-transformers/all-MiniLM-L6-v2";
 pub const HASH_EMBEDDING_DIM: usize = 384;
 pub const FASTEMBED_EMBEDDING_DIM: usize = 384;
+
+/// BGE-small-en-v1.5 (#112): a stronger general-retrieval embedder than all-MiniLM at the SAME
+/// 384-dim — switching to it is a re-embed, not a schema/dim change. MIT-licensed; ships via
+/// fastembed (downloads on first use). Measured against `FASTEMBED_MODEL_ID` on the replay eval.
+pub const BGE_SMALL_MODEL_ID: &str = "fastembed-bge-small-en-v1.5";
+pub const BGE_SMALL_DISPLAY_MODEL: &str = "BAAI/bge-small-en-v1.5";
+pub const BGE_SMALL_EMBEDDING_DIM: usize = 384;
+
 /// Model2Vec static-embedding backend: a token→vector lookup + mean-pool (no transformer forward
 /// pass), ~100-500× faster than FastEmbed on CPU at some retrieval-quality cost. The right choice
 /// for very large repos where the FastEmbed backfill is infeasible. See `EmbeddingBackend`.
@@ -103,13 +111,41 @@ impl Embedder for MockEmbedder {
 #[cfg(feature = "fastembed")]
 pub struct FastEmbedEmbedder {
     model: std::sync::Mutex<fastembed::TextEmbedding>,
+    model_id: &'static str,
+    dim: usize,
 }
 
 #[cfg(feature = "fastembed")]
 impl FastEmbedEmbedder {
+    /// all-MiniLM-L6-v2 (384-dim) — the default general-purpose backend.
     pub fn new(intra_threads: Option<usize>) -> anyhow::Result<Self> {
-        use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
-        let mut options = InitOptions::new(EmbeddingModel::AllMiniLML6V2)
+        Self::with_model(
+            fastembed::EmbeddingModel::AllMiniLML6V2,
+            FASTEMBED_MODEL_ID,
+            FASTEMBED_EMBEDDING_DIM,
+            intra_threads,
+        )
+    }
+
+    /// BGE-small-en-v1.5 (384-dim, #112) — a stronger general-retrieval embedder, same dimension as
+    /// all-MiniLM so swapping it is a re-embed rather than a schema/dim change.
+    pub fn new_bge_small(intra_threads: Option<usize>) -> anyhow::Result<Self> {
+        Self::with_model(
+            fastembed::EmbeddingModel::BGESmallENV15,
+            BGE_SMALL_MODEL_ID,
+            BGE_SMALL_EMBEDDING_DIM,
+            intra_threads,
+        )
+    }
+
+    fn with_model(
+        model: fastembed::EmbeddingModel,
+        model_id: &'static str,
+        dim: usize,
+        intra_threads: Option<usize>,
+    ) -> anyhow::Result<Self> {
+        use fastembed::{InitOptions, TextEmbedding};
+        let mut options = InitOptions::new(model)
             .with_cache_dir(fastembed_cache_dir())
             .with_show_download_progress(true);
         // `ort_threads` caps the ONNX Runtime intra-op thread pool. Microsoft's prebuilt ORT
@@ -119,18 +155,18 @@ impl FastEmbedEmbedder {
         if let Some(threads) = intra_threads.filter(|threads| *threads > 0) {
             options = options.with_intra_threads(threads);
         }
-        Ok(Self { model: std::sync::Mutex::new(TextEmbedding::try_new(options)?) })
+        Ok(Self { model: std::sync::Mutex::new(TextEmbedding::try_new(options)?), model_id, dim })
     }
 }
 
 #[cfg(feature = "fastembed")]
 impl Embedder for FastEmbedEmbedder {
     fn model_id(&self) -> &str {
-        FASTEMBED_MODEL_ID
+        self.model_id
     }
 
     fn dim(&self) -> usize {
-        FASTEMBED_EMBEDDING_DIM
+        self.dim
     }
 
     fn embed_batch(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -22,6 +22,14 @@ pub(crate) fn ensure_model_manifest(conn: &Connection) -> anyhow::Result<()> {
     )?;
     upsert_model(
         conn,
+        BGE_SMALL_MODEL_ID,
+        "embedding",
+        Some(BGE_SMALL_EMBEDDING_DIM),
+        "fastembed",
+        false,
+    )?;
+    upsert_model(
+        conn,
         MODEL2VEC_MODEL_ID,
         "embedding",
         Some(MODEL2VEC_EMBEDDING_DIM),
@@ -52,7 +60,7 @@ pub(crate) fn model_manifest_is_current(conn: &Connection) -> anyhow::Result<boo
             return Ok(false);
         }
     }
-    for model_id in [HASH_MODEL_ID, FASTEMBED_MODEL_ID, MODEL2VEC_MODEL_ID] {
+    for model_id in [HASH_MODEL_ID, FASTEMBED_MODEL_ID, BGE_SMALL_MODEL_ID, MODEL2VEC_MODEL_ID] {
         let present: bool = conn.query_row(
             "SELECT EXISTS(SELECT 1 FROM ai_models WHERE model_id = ?1)",
             params![model_id],
@@ -194,7 +202,7 @@ pub(crate) fn install_model(conn: &Connection, model_id: &str) -> anyhow::Result
             )?;
             set_meta(conn, ACTIVE_EMBEDDING_MODEL_META, model_id)?;
         },
-        FASTEMBED_MODEL_ID => {
+        FASTEMBED_MODEL_ID | BGE_SMALL_MODEL_ID => {
             install_fastembed_model(conn, model_id)?;
             set_meta(conn, ACTIVE_EMBEDDING_MODEL_META, model_id)?;
         },

--- a/crates/rag-rat-core/src/index/ai/status.rs
+++ b/crates/rag-rat-core/src/index/ai/status.rs
@@ -3,8 +3,13 @@ use super::*;
 pub(crate) fn install_fastembed_model(conn: &Connection, model_id: &str) -> anyhow::Result<()> {
     #[cfg(feature = "fastembed")]
     {
-        let embedder = FastEmbedEmbedder::new(None)
-            .map_err(|err| anyhow::anyhow!("failed to initialize fastembed model: {err}"))?;
+        // Init the model that matches `model_id` (triggers its download + yields the right dim),
+        // not always all-MiniLM — both are 384-dim, but BGE-small (#112) must pull its own weights.
+        let embedder = match model_id {
+            BGE_SMALL_MODEL_ID => FastEmbedEmbedder::new_bge_small(None),
+            _ => FastEmbedEmbedder::new(None),
+        }
+        .map_err(|err| anyhow::anyhow!("failed to initialize fastembed model: {err}"))?;
         conn.execute(
             "UPDATE ai_models
              SET installed = 1, disabled = 0, status = 'Ready', installed_at_ms = ?2,

--- a/crates/rag-rat-core/src/index/ai/status.rs
+++ b/crates/rag-rat-core/src/index/ai/status.rs
@@ -36,7 +36,19 @@ pub(crate) fn fastembed_operational_status(
     active_model_id: &str,
     total_chunks: u64,
 ) -> anyhow::Result<FastEmbedOperationalStatus> {
-    let model = model(conn, FASTEMBED_MODEL_ID)?;
+    // Report the ACTIVE fastembed model (all-MiniLM or BGE-small), not always all-MiniLM — else
+    // installing BGE makes status/doctor flag MiniLM as missing or needing reconcile (#112 review).
+    let report_model_id = if matches!(active_model_id, FASTEMBED_MODEL_ID | BGE_SMALL_MODEL_ID) {
+        active_model_id
+    } else {
+        FASTEMBED_MODEL_ID
+    };
+    let report_display = if report_model_id == BGE_SMALL_MODEL_ID {
+        BGE_SMALL_DISPLAY_MODEL
+    } else {
+        FASTEMBED_DISPLAY_MODEL
+    };
+    let model = model(conn, report_model_id)?;
     // PERF: report coverage from CHEAP persisted counts (the `embedding_artifacts` rows + the chunk
     // total) rather than `embedding_reconcile_plan` — which loads EVERY chunk and rebuilds +
     // re-hashes its embedding input (~200s on a 174k-chunk index, paid with OR without an active
@@ -45,12 +57,11 @@ pub(crate) fn fastembed_operational_status(
     // same basis it uses for the generic `capability_status` counts); the exact policy-skip +
     // live-drift breakdown is the `reconcile --plan` command's job, where the per-chunk scan
     // belongs.
-    let current = current_artifact_count(conn, "embedding", FASTEMBED_MODEL_ID)?;
-    let stale = stale_artifact_count(conn, "embedding", FASTEMBED_MODEL_ID)?;
-    let failed =
-        status_artifact_count(conn, "embedding", FASTEMBED_MODEL_ID, ArtifactStatus::Failed)?;
+    let current = current_artifact_count(conn, "embedding", report_model_id)?;
+    let stale = stale_artifact_count(conn, "embedding", report_model_id)?;
+    let failed = status_artifact_count(conn, "embedding", report_model_id, ArtifactStatus::Failed)?;
     let blocked =
-        status_artifact_count(conn, "embedding", FASTEMBED_MODEL_ID, ArtifactStatus::Blocked)?;
+        status_artifact_count(conn, "embedding", report_model_id, ArtifactStatus::Blocked)?;
     // Exact `skipped` (embedding input too large) needs the decompressed text per chunk — deferred
     // to `reconcile --plan`. The status treats every chunk as eligible, so the invariant
     // `eligible + skipped == total` holds with `skipped == 0`.
@@ -61,7 +72,7 @@ pub(crate) fn fastembed_operational_status(
     let next = if !fastembed_build_feature_enabled() {
         Some("cargo install rag-rat".to_string())
     } else if validate_ready_model(&model).is_err() {
-        Some(format!("rag-rat models install {FASTEMBED_MODEL_ID}"))
+        Some(format!("rag-rat models install {report_model_id}"))
     } else if missing > 0 || stale > 0 || failed > 0 {
         Some("rag-rat reconcile --limit 500".to_string())
     } else {
@@ -70,12 +81,12 @@ pub(crate) fn fastembed_operational_status(
     Ok(FastEmbedOperationalStatus {
         backend: "fastembed".to_string(),
         build_feature_enabled: fastembed_build_feature_enabled(),
-        model_id: FASTEMBED_MODEL_ID.to_string(),
-        model: FASTEMBED_DISPLAY_MODEL.to_string(),
+        model_id: report_model_id.to_string(),
+        model: report_display.to_string(),
         dim: FASTEMBED_EMBEDDING_DIM,
         cache: fastembed_cache_dir().display().to_string(),
         installed: model.installed,
-        active: active_model_id == FASTEMBED_MODEL_ID,
+        active: matches!(active_model_id, FASTEMBED_MODEL_ID | BGE_SMALL_MODEL_ID),
         status: model.status,
         current_embeddings: current,
         eligible_embeddings: eligible,


### PR DESCRIPTION
## What

Adds **BGE-small-en-v1.5** as a selectable embedder alongside the default all-MiniLM-L6-v2. BGE-small is a stronger general-retrieval model at the **same 384-dim**, so switching is a re-embed — no schema/dim change.

- Parameterizes `FastEmbedEmbedder` (`new` / `new_bge_small` / `with_model`).
- Registers the model in the manifest + the manifest-current check.
- Wires the factory / model-version / expected-dim / install paths; `install_fastembed_model` now inits the model matching the requested id (BGE pulls its own weights).
- Builds with and without the `fastembed` feature.

Activate: `rag-rat models install fastembed-bge-small-en-v1.5` + reconcile.

## Measurement

recall@10 / symbol-recall vs all-MiniLM on the commit-replay eval (#120) — running in an isolated bench checkout; delta to follow here. (Hash baseline: recall@10 0.420 / symbol 0.276 — the question is how much a real embedder moves it.)

## Follow-ups
- `fastembed_cache_ready` status display is still MiniLM-shaped (cosmetic; the embedder downloads via fastembed regardless).
- CodeRankEmbed (code-specific, 768-dim) is the bigger-win tier (T16) once this drop-in is validated.
