### PR TITLE
refactor(embed): centralize the embedding-model registry; BGE + jina as selectable options (#112)

### DIFF
--- a/crates/rag-rat-cli/src/init/mod.rs
+++ b/crates/rag-rat-cli/src/init/mod.rs
@@ -8,9 +8,8 @@ use std::{env, fs, io};
 
 use dialoguer::{Confirm, MultiSelect, Select};
 use rag_rat_core::config::EmbeddingBackend;
-use rag_rat_core::index::ai::{
-    FASTEMBED_MODEL_ID, HASH_MODEL_ID, MODEL2VEC_MODEL_ID, ReconcileOptions,
-};
+use rag_rat_core::embedding_models::{FASTEMBED_MODEL_ID, HASH_MODEL_ID, MODEL2VEC_MODEL_ID};
+use rag_rat_core::index::ai::ReconcileOptions;
 use rag_rat_core::index::ignore_rules::{IgnoreMatcher, is_virtualenv_dir};
 use rag_rat_core::language::Language;
 use rag_rat_core::{Config, IndexDatabase};
@@ -248,7 +247,7 @@ mod tests {
                 (Language::Rust, vec![PathBuf::from("crates/app/src")]),
                 (Language::TypeScript, vec![PathBuf::from("web/src"), PathBuf::from("app/src")]),
             ]),
-            backend: EmbeddingBackend::Model2Vec,
+            backend: EmbeddingBackend::model2vec(),
             oracle_auto_run: false,
         };
 
@@ -271,7 +270,7 @@ mod tests {
             root_value: ".".to_string(),
             languages: vec![Language::Rust],
             bindings: BTreeMap::from([(Language::Rust, vec![PathBuf::from("src")])]),
-            backend: EmbeddingBackend::FastEmbed,
+            backend: EmbeddingBackend::fast_embed(),
             oracle_auto_run: true,
         };
         assert!(render_config(&plan).contains("auto_run = true"));
@@ -293,7 +292,7 @@ mod tests {
                 PathBuf::from("include"),
                 PathBuf::from("src"),
             ])]),
-            backend: EmbeddingBackend::FastEmbed,
+            backend: EmbeddingBackend::fast_embed(),
             oracle_auto_run: false,
         };
         let text = render_config(&plan);
@@ -315,8 +314,8 @@ mod tests {
 
     #[test]
     fn recommend_backend_scales_with_repo_size() {
-        assert_eq!(recommend_backend(estimated_chunks(500_000)), EmbeddingBackend::FastEmbed);
-        assert_eq!(recommend_backend(estimated_chunks(50_000_000)), EmbeddingBackend::Model2Vec);
+        assert_eq!(recommend_backend(estimated_chunks(500_000)), EmbeddingBackend::fast_embed());
+        assert_eq!(recommend_backend(estimated_chunks(50_000_000)), EmbeddingBackend::model2vec());
     }
 
     #[test]

--- a/crates/rag-rat-cli/src/init/run.rs
+++ b/crates/rag-rat-cli/src/init/run.rs
@@ -162,7 +162,7 @@ pub(crate) fn prompt_backend(scan: &RepoScan) -> anyhow::Result<EmbeddingBackend
     );
     println!("  recommended: {}", backend_label(recommended));
     let choices =
-        [EmbeddingBackend::FastEmbed, EmbeddingBackend::Model2Vec, EmbeddingBackend::None];
+        [EmbeddingBackend::fast_embed(), EmbeddingBackend::model2vec(), EmbeddingBackend::NONE];
     let default_index = choices.iter().position(|backend| *backend == recommended).unwrap_or(0);
     let items = choices.iter().map(|backend| backend_label(*backend)).collect::<Vec<_>>();
     let selected = Select::new()

--- a/crates/rag-rat-cli/src/init/scan.rs
+++ b/crates/rag-rat-cli/src/init/scan.rs
@@ -10,18 +10,18 @@ pub(crate) fn estimated_chunks(total_source_bytes: u64) -> u64 {
 /// repos default to the static Model2Vec backend (orders of magnitude faster, some quality cost).
 pub(crate) fn recommend_backend(estimated_chunks: u64) -> EmbeddingBackend {
     if estimated_chunks <= 5_000 {
-        EmbeddingBackend::FastEmbed
+        EmbeddingBackend::fast_embed()
     } else {
-        EmbeddingBackend::Model2Vec
+        EmbeddingBackend::model2vec()
     }
 }
 pub(crate) fn backend_label(backend: EmbeddingBackend) -> &'static str {
-    match backend {
-        EmbeddingBackend::FastEmbed =>
-            "minilm — MiniLM transformer; best quality, CPU backfill ~10-100 chunks/sec",
-        EmbeddingBackend::Model2Vec =>
-            "model2vec — static embeddings; ~100-500x faster on CPU, some quality cost",
-        EmbeddingBackend::None => "none — BM25 + structure only, no dense vectors",
+    if backend == EmbeddingBackend::NONE {
+        "none — BM25 + structure only, no dense vectors"
+    } else if backend == EmbeddingBackend::model2vec() {
+        "model2vec — static embeddings; ~100-500x faster on CPU, some quality cost"
+    } else {
+        "minilm — MiniLM transformer; best quality, CPU backfill ~10-100 chunks/sec"
     }
 }
 pub(crate) fn scan_repo(root: &Path) -> anyhow::Result<RepoScan> {

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 use serde::Deserialize;
 use thiserror::Error;
 
+use crate::embedding_models::{EmbeddingModelSpec, spec_for_alias};
 use crate::language::{Language, LanguageError};
 
 #[derive(Debug, Clone)]
@@ -98,39 +99,58 @@ pub struct EmbeddingConfig {
 
 /// The embedding backend selector (`[local_ai.embedding] model = "..."`).
 ///
-/// - `FastEmbed` (default): MiniLM transformer — best quality, but the cold backfill is CPU-bound
-///   (~10-100 chunks/sec), so impractical for very large repos.
-/// - `Model2Vec`: static token-vector lookup + mean-pool — ~100-500× faster on CPU at some
+/// Resolves the toml `model = "..."` string through the [`crate::embedding_models`] registry, so
+/// ANY registered model (`minilm` / `bge` / `jina` / `model2vec` / `hash`, or any of their aliases)
+/// is selectable — adding a model to the registry makes it selectable here with no edit. The
+/// embeddings-off choice (`none` / `off`) carries `None`. Kept a thin wrapper over a registry spec
+/// reference so `config` resolves model identity without depending on `index`
+/// (`crate::embedding_models` has no `index` dependency, so there is no cycle).
+///
+/// The common tiers, for reference:
+/// - `minilm` (the `EmbeddingBackend::default`): MiniLM transformer — best general quality, but the
+///   cold backfill is CPU-bound (~10-100 chunks/sec), so impractical for very large repos.
+/// - `model2vec`: static token-vector lookup + mean-pool — ~100-500× faster on CPU at some
 ///   retrieval-quality cost (no context/word-order). The choice for huge repos that still want
 ///   vectors.
-/// - `None`: structural + BM25 only; no dense vectors. `semantic_search` degrades to BM25. The
+/// - `none`: structural + BM25 only; no dense vectors. `semantic_search` degrades to BM25. The
 ///   cheapest option for enormous codebases where any embedding backfill is too slow.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum EmbeddingBackend {
-    #[default]
-    FastEmbed,
-    Model2Vec,
-    None,
-}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EmbeddingBackend(Option<&'static EmbeddingModelSpec>);
 
 impl EmbeddingBackend {
+    /// Embeddings off — structural + BM25 only.
+    pub const NONE: Self = Self(None);
+
+    /// The FastEmbed MiniLM tier — the default backend (`init` recommends it for smaller repos).
+    /// Resolved from the registry; the `minilm` alias is guaranteed present by the registry test.
+    pub fn fast_embed() -> Self {
+        Self(spec_for_alias("minilm"))
+    }
+
+    /// The Model2Vec static tier (`init` recommends it for very large repos).
+    pub fn model2vec() -> Self {
+        Self(spec_for_alias("model2vec"))
+    }
+
+    /// The canonical toml selector for this backend — the spec's FIRST alias (`init` renders this
+    /// back into `rag-rat.toml`), or `"none"` for the embeddings-off choice.
     pub fn as_str(self) -> &'static str {
-        match self {
-            Self::FastEmbed => "minilm",
-            Self::Model2Vec => "model2vec",
-            Self::None => "none",
+        match self.0 {
+            Some(spec) => spec.aliases.first().copied().unwrap_or(spec.model_id),
+            None => "none",
         }
     }
 
     /// The persisted embedding-model id this backend installs/activates, or `None` for the
-    /// embeddings-off choice. Kept as a string so `rag-rat-core::index::ai` model ids stay the
-    /// single source of truth without `config` depending on `index`.
+    /// embeddings-off choice.
     pub fn model_id(self) -> Option<&'static str> {
-        match self {
-            Self::FastEmbed => Some("fastembed-all-minilm-l6-v2"),
-            Self::Model2Vec => Some("model2vec-potion-retrieval-32m"),
-            Self::None => None,
-        }
+        self.0.map(|spec| spec.model_id)
+    }
+}
+
+impl Default for EmbeddingBackend {
+    fn default() -> Self {
+        Self::fast_embed()
     }
 }
 
@@ -138,11 +158,12 @@ impl FromStr for EmbeddingBackend {
     type Err = ConfigError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value.trim().to_ascii_lowercase().as_str() {
-            "minilm" | "fastembed" | "minilm-l6" => Ok(Self::FastEmbed),
-            "model2vec" | "potion" | "static" => Ok(Self::Model2Vec),
-            "none" | "off" | "bm25" => Ok(Self::None),
-            other => Err(ConfigError::UnknownEmbeddingBackend(other.to_string())),
+        let value = value.trim().to_ascii_lowercase();
+        match value.as_str() {
+            "none" | "off" | "bm25" => Ok(Self::NONE),
+            other => spec_for_alias(other)
+                .map(|spec| Self(Some(spec)))
+                .ok_or_else(|| ConfigError::UnknownEmbeddingBackend(other.to_string())),
         }
     }
 }
@@ -575,7 +596,8 @@ impl TryFrom<RawLocalAi> for LocalAiConfig {
 
 #[derive(Debug, Default, Deserialize)]
 struct RawEmbedding {
-    /// `model = "minilm" | "model2vec" | "none"` — the embedding backend selector.
+    /// `model = "<registered alias>" | "none"` — the embedding backend selector (`minilm`, `bge`,
+    /// `jina`, `model2vec`, … resolve through the embedding-model registry).
     model: Option<String>,
     #[serde(default)]
     runtime: RawEmbeddingRuntime,
@@ -633,7 +655,10 @@ pub enum ConfigError {
     Language(#[from] LanguageError),
     #[error("unknown target kind `{0}`")]
     UnknownTargetKind(String),
-    #[error("unknown embedding backend `{0}` (expected `minilm`, `model2vec`, or `none`)")]
+    #[error(
+        "unknown embedding backend `{0}` (expected a registered model alias such as `minilm`, \
+         `bge`, `jina`, `model2vec`, or `none`)"
+    )]
     UnknownEmbeddingBackend(String),
     #[error("duplicate target name `{0}`")]
     DuplicateTarget(String),

--- a/crates/rag-rat-core/src/embedding_models.rs
+++ b/crates/rag-rat-core/src/embedding_models.rs
@@ -1,0 +1,196 @@
+//! The single source of truth for every embedding model rag-rat knows about.
+//!
+//! Adding a model is adding ONE row to [`EMBEDDING_MODELS`] — the persisted model id, its display
+//! name, dimension, reconcile-freshness version key, backend, the toml `model = "..."` aliases that
+//! select it, and (for asymmetric models) a query instruction prefix. Everything else —
+//! `expected_dim`, `default_model_version`, the manifest upsert list, the install dispatch, the
+//! `EmbeddingBackend` config selector, the operational-status reporting — reads this table instead
+//! of carrying its own hardcoded model-id match arm.
+//!
+//! This module lives at the crate ROOT (not under `index::ai`) on purpose: [`crate::config`]
+//! resolves the toml `model = "..."` selector through [`spec_for_alias`], and config must NOT
+//! depend on `index`. Pure data only — no feature gates here, so the table compiles on every
+//! feature set; the embedder CONSTRUCTION (which needs `fastembed` / `model2vec`) is gated in
+//! `index::ai`.
+
+/// The runtime that actually produces vectors for a model. Maps 1:1 to the `ai_models.runtime`
+/// column persisted in the index, and selects which embedder `index::ai` constructs.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Backend {
+    /// The dependency-free locality-sensitive hash embedder — always available, the fallback tier.
+    Hash,
+    /// A FastEmbed (ONNX) transformer model; gated behind the `fastembed` feature.
+    FastEmbed,
+    /// A Model2Vec static token→vector lookup; gated behind the `model2vec` feature.
+    Model2Vec,
+}
+
+impl Backend {
+    /// The `ai_models.runtime` column value for this backend. Stable wire string — keep in sync
+    /// with the persisted manifest (`upsert_model`), never reorder/rename without a migration.
+    pub fn runtime(self) -> &'static str {
+        match self {
+            Self::Hash => "hash",
+            Self::FastEmbed => "fastembed",
+            Self::Model2Vec => "model2vec",
+        }
+    }
+}
+
+/// One row in the embedding-model registry: everything the rest of the codebase needs to know about
+/// a model, in one place. See the module docs for why this is the single source of truth.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct EmbeddingModelSpec {
+    /// The persisted `ai_models.model_id` — the stable identity used everywhere in the index.
+    pub model_id: &'static str,
+    /// Human-facing model name (the upstream HF repo / canonical name) for status output.
+    pub display: &'static str,
+    /// Embedding dimension. A change here is a re-embed (new vectors), not a schema migration.
+    pub dim: usize,
+    /// The reconcile freshness key (formerly `default_model_version`). Bumping it forces a
+    /// re-embed of every chunk for this model. MUST be unique across the table and never the
+    /// bare `"v1"` fallback — the registry test guards both.
+    pub version: &'static str,
+    /// Which runtime produces this model's vectors.
+    pub backend: Backend,
+    /// The toml `model = "..."` selectors that pick this model. The FIRST alias is the canonical
+    /// one `init` renders back into `rag-rat.toml`, so it must be a valid, stable spelling.
+    pub aliases: &'static [&'static str],
+    /// A query-side instruction prefix for ASYMMETRIC models (queries and passages embed
+    /// differently). `""` for every model shipping today — they are all symmetric, so queries
+    /// embed RAW (see the BGE instruction-collapse note in `index::ai`). A future asymmetric
+    /// model (e.g. CodeRankEmbed) would set this; `embed_query_with` would prepend it on the
+    /// query path only.
+    pub query_prefix: &'static str,
+}
+
+/// Locality-sensitive hash embedder id — the dependency-free fallback tier.
+pub const HASH_MODEL_ID: &str = "embedding-hash";
+pub const HASH_EMBEDDING_DIM: usize = 384;
+
+/// all-MiniLM-L6-v2 (384-dim) — the default FastEmbed general-purpose backend.
+pub const FASTEMBED_MODEL_ID: &str = "fastembed-all-minilm-l6-v2";
+pub const FASTEMBED_DISPLAY_MODEL: &str = "sentence-transformers/all-MiniLM-L6-v2";
+pub const FASTEMBED_EMBEDDING_DIM: usize = 384;
+
+/// BGE-small-en-v1.5 (#112): a stronger general-retrieval embedder than all-MiniLM at the SAME
+/// 384-dim — switching to it is a re-embed, not a schema/dim change. MIT-licensed; ships via
+/// fastembed (downloads on first use). Measured against `FASTEMBED_MODEL_ID` on the replay eval.
+pub const BGE_SMALL_MODEL_ID: &str = "fastembed-bge-small-en-v1.5";
+pub const BGE_SMALL_DISPLAY_MODEL: &str = "BAAI/bge-small-en-v1.5";
+pub const BGE_SMALL_EMBEDDING_DIM: usize = 384;
+
+/// jina-embeddings-v2-base-code (#112): a CODE-specific embedder — 768-dim, Apache-2.0, a built-in
+/// fastembed model. SYMMETRIC: queries and code both embed RAW (no query instruction, unlike
+/// CodeRankEmbed), so it slots into the raw embed path with no prefix. 768-dim → a re-embed, not a
+/// schema change. Measured against all-MiniLM / BGE on the commit-replay eval before it ships as
+/// the code tier.
+pub const JINA_CODE_MODEL_ID: &str = "fastembed-jina-v2-base-code";
+pub const JINA_CODE_DISPLAY_MODEL: &str = "jinaai/jina-embeddings-v2-base-code";
+pub const JINA_CODE_EMBEDDING_DIM: usize = 768;
+
+/// Model2Vec static-embedding backend: a token→vector lookup + mean-pool (no transformer forward
+/// pass), ~100-500× faster than FastEmbed on CPU at some retrieval-quality cost. The right choice
+/// for very large repos where the FastEmbed backfill is infeasible.
+pub const MODEL2VEC_MODEL_ID: &str = "model2vec-potion-retrieval-32m";
+pub const MODEL2VEC_DISPLAY_MODEL: &str = "minishlab/potion-retrieval-32M";
+pub const MODEL2VEC_EMBEDDING_DIM: usize = 512;
+
+/// The embedding-model registry. ONE row per model — adding a model is adding a row here. Pure
+/// data, no feature gates; the embedder construction is gated in `index::ai`.
+pub const EMBEDDING_MODELS: &[EmbeddingModelSpec] = &[
+    EmbeddingModelSpec {
+        model_id: HASH_MODEL_ID,
+        display: "hash",
+        dim: HASH_EMBEDDING_DIM,
+        version: "hash-v1",
+        backend: Backend::Hash,
+        aliases: &["hash"],
+        query_prefix: "",
+    },
+    EmbeddingModelSpec {
+        model_id: FASTEMBED_MODEL_ID,
+        display: FASTEMBED_DISPLAY_MODEL,
+        dim: FASTEMBED_EMBEDDING_DIM,
+        version: "fastembed-all-minilm-l6-v2-v1",
+        backend: Backend::FastEmbed,
+        aliases: &["minilm", "fastembed", "minilm-l6"],
+        query_prefix: "",
+    },
+    EmbeddingModelSpec {
+        model_id: BGE_SMALL_MODEL_ID,
+        display: BGE_SMALL_DISPLAY_MODEL,
+        dim: BGE_SMALL_EMBEDDING_DIM,
+        version: "fastembed-bge-small-en-v1.5-v1",
+        backend: Backend::FastEmbed,
+        aliases: &["bge", "bge-small"],
+        query_prefix: "",
+    },
+    EmbeddingModelSpec {
+        model_id: JINA_CODE_MODEL_ID,
+        display: JINA_CODE_DISPLAY_MODEL,
+        dim: JINA_CODE_EMBEDDING_DIM,
+        version: "fastembed-jina-v2-base-code-v1",
+        backend: Backend::FastEmbed,
+        aliases: &["jina", "jina-code"],
+        query_prefix: "",
+    },
+    EmbeddingModelSpec {
+        model_id: MODEL2VEC_MODEL_ID,
+        display: MODEL2VEC_DISPLAY_MODEL,
+        dim: MODEL2VEC_EMBEDDING_DIM,
+        version: "model2vec-potion-retrieval-32m-v1",
+        backend: Backend::Model2Vec,
+        aliases: &["model2vec", "potion", "static"],
+        query_prefix: "",
+    },
+];
+
+/// Look up a spec by its persisted `model_id`.
+pub fn spec(model_id: &str) -> Option<&'static EmbeddingModelSpec> {
+    EMBEDDING_MODELS.iter().find(|s| s.model_id == model_id)
+}
+
+/// Look up a spec by a toml `model = "..."` alias.
+pub fn spec_for_alias(alias: &str) -> Option<&'static EmbeddingModelSpec> {
+    EMBEDDING_MODELS.iter().find(|s| s.aliases.contains(&alias))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    #[test]
+    fn every_spec_has_a_unique_non_default_version() {
+        // The version is the reconcile freshness key: a duplicate would make two models share a
+        // freshness state, and the bare "v1" fallback means the model-version match silently fell
+        // through. Both are wrong, so guard against them at the table.
+        let mut seen = HashSet::new();
+        for spec in EMBEDDING_MODELS {
+            assert_ne!(spec.version, "v1", "{} fell back to the default version", spec.model_id);
+            assert!(
+                seen.insert(spec.version),
+                "duplicate version {} (shared by {})",
+                spec.version,
+                spec.model_id
+            );
+        }
+    }
+
+    #[test]
+    fn first_alias_round_trips_to_its_model_id() {
+        // `init` renders the canonical (first) alias into the toml; loading it back must resolve
+        // the same model. A regression here breaks `init` → config round-trips.
+        for spec in EMBEDDING_MODELS {
+            let first = spec.aliases.first().expect("every model needs at least one alias");
+            assert_eq!(
+                spec_for_alias(first).map(|s| s.model_id),
+                Some(spec.model_id),
+                "alias {first} did not round-trip to {}",
+                spec.model_id
+            );
+        }
+    }
+}

--- a/crates/rag-rat-core/src/eval.rs
+++ b/crates/rag-rat-core/src/eval.rs
@@ -825,9 +825,9 @@ fn hash_vector_baseline(
         results.push(evaluate_query(config, db, &merged, SearchMode::HashBaseline)?);
     }
     let metrics = aggregate(&results);
-    let current_artifacts = db.current_embedding_count(ai::HASH_MODEL_ID)?;
+    let current_artifacts = db.current_embedding_count(crate::embedding_models::HASH_MODEL_ID)?;
     Ok(EvalBaselineReport {
-        model_id: ai::HASH_MODEL_ID.to_string(),
+        model_id: crate::embedding_models::HASH_MODEL_ID.to_string(),
         available: current_artifacts > 0,
         current_artifacts,
         delta_mrr_at_10: active_metrics.mrr_at_10 - metrics.mrr_at_10,

--- a/crates/rag-rat-core/src/eval.rs
+++ b/crates/rag-rat-core/src/eval.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use serde::{Deserialize, Serialize};
 
 use crate::index::oracle::{OracleEvalMetrics, OracleTool, RecallCalls};
-use crate::index::{OracleShaSnapshots, ai, git_history};
+use crate::index::{OracleShaSnapshots, git_history};
 use crate::{Config, IndexDatabase};
 
 const TOP_K: usize = 10;

--- a/crates/rag-rat-core/src/index/ai/helpers.rs
+++ b/crates/rag-rat-core/src/index/ai/helpers.rs
@@ -19,11 +19,7 @@ pub(crate) fn embed_query_with(
     embedder: &dyn Embedder,
     query: &str,
 ) -> anyhow::Result<QueryEmbedding> {
-    // Apply the model's query-side instruction prefix (BGE asymmetric retrieval); empty for
-    // symmetric models, so this is a no-op for hash / all-MiniLM / model2vec (#112 review).
-    let prefix = embedder.query_prefix();
-    let text = if prefix.is_empty() { query.to_string() } else { format!("{prefix}{query}") };
-    let texts = vec![text];
+    let texts = vec![query.to_string()];
     let mut vectors = embedder.embed_batch(&texts)?;
     let Some(vector) = vectors.pop() else {
         anyhow::bail!("embedder {} returned no query vector", embedder.model_id());

--- a/crates/rag-rat-core/src/index/ai/helpers.rs
+++ b/crates/rag-rat-core/src/index/ai/helpers.rs
@@ -19,7 +19,11 @@ pub(crate) fn embed_query_with(
     embedder: &dyn Embedder,
     query: &str,
 ) -> anyhow::Result<QueryEmbedding> {
-    let texts = vec![query.to_string()];
+    // Apply the model's query-side instruction prefix (BGE asymmetric retrieval); empty for
+    // symmetric models, so this is a no-op for hash / all-MiniLM / model2vec (#112 review).
+    let prefix = embedder.query_prefix();
+    let text = if prefix.is_empty() { query.to_string() } else { format!("{prefix}{query}") };
+    let texts = vec![text];
     let mut vectors = embedder.embed_batch(&texts)?;
     let Some(vector) = vectors.pop() else {
         anyhow::bail!("embedder {} returned no query vector", embedder.model_id());

--- a/crates/rag-rat-core/src/index/ai/helpers.rs
+++ b/crates/rag-rat-core/src/index/ai/helpers.rs
@@ -57,6 +57,7 @@ pub(crate) fn default_model_version(model_id: &str) -> &'static str {
     match model_id {
         HASH_MODEL_ID => "hash-v1",
         FASTEMBED_MODEL_ID => "fastembed-all-minilm-l6-v2-v1",
+        BGE_SMALL_MODEL_ID => "fastembed-bge-small-en-v1.5-v1",
         MODEL2VEC_MODEL_ID => "model2vec-potion-retrieval-32m-v1",
         _ => "v1",
     }
@@ -98,6 +99,7 @@ pub(crate) fn active_embedder(
     match model.model_id.as_str() {
         HASH_MODEL_ID => Ok(Box::new(HashEmbedder)),
         FASTEMBED_MODEL_ID => fastembed_embedder(intra_threads),
+        BGE_SMALL_MODEL_ID => bge_small_embedder(intra_threads),
         MODEL2VEC_MODEL_ID => model2vec_embedder(),
         other => anyhow::bail!("unknown active embedding model `{other}`"),
     }
@@ -150,6 +152,7 @@ pub(crate) fn expected_dim(model_id: &str) -> Option<usize> {
     match model_id {
         HASH_MODEL_ID => Some(HASH_EMBEDDING_DIM),
         FASTEMBED_MODEL_ID => Some(FASTEMBED_EMBEDDING_DIM),
+        BGE_SMALL_MODEL_ID => Some(BGE_SMALL_EMBEDDING_DIM),
         MODEL2VEC_MODEL_ID => Some(MODEL2VEC_EMBEDDING_DIM),
         _ => None,
     }
@@ -161,6 +164,20 @@ pub(crate) fn fastembed_embedder(
     #[cfg(feature = "fastembed")]
     {
         Ok(Box::new(FastEmbedEmbedder::new(intra_threads)?))
+    }
+    #[cfg(not(feature = "fastembed"))]
+    {
+        let _ = intra_threads;
+        anyhow::bail!("{}", FASTEMBED_MISSING_FEATURE_MESSAGE)
+    }
+}
+
+pub(crate) fn bge_small_embedder(
+    intra_threads: Option<usize>,
+) -> anyhow::Result<Box<dyn Embedder>> {
+    #[cfg(feature = "fastembed")]
+    {
+        Ok(Box::new(FastEmbedEmbedder::new_bge_small(intra_threads)?))
     }
     #[cfg(not(feature = "fastembed"))]
     {

--- a/crates/rag-rat-core/src/index/ai/helpers.rs
+++ b/crates/rag-rat-core/src/index/ai/helpers.rs
@@ -58,6 +58,7 @@ pub(crate) fn default_model_version(model_id: &str) -> &'static str {
         HASH_MODEL_ID => "hash-v1",
         FASTEMBED_MODEL_ID => "fastembed-all-minilm-l6-v2-v1",
         BGE_SMALL_MODEL_ID => "fastembed-bge-small-en-v1.5-v1",
+        JINA_CODE_MODEL_ID => "fastembed-jina-v2-base-code-v1",
         MODEL2VEC_MODEL_ID => "model2vec-potion-retrieval-32m-v1",
         _ => "v1",
     }
@@ -100,6 +101,7 @@ pub(crate) fn active_embedder(
         HASH_MODEL_ID => Ok(Box::new(HashEmbedder)),
         FASTEMBED_MODEL_ID => fastembed_embedder(intra_threads),
         BGE_SMALL_MODEL_ID => bge_small_embedder(intra_threads),
+        JINA_CODE_MODEL_ID => jina_code_embedder(intra_threads),
         MODEL2VEC_MODEL_ID => model2vec_embedder(),
         other => anyhow::bail!("unknown active embedding model `{other}`"),
     }
@@ -153,6 +155,7 @@ pub(crate) fn expected_dim(model_id: &str) -> Option<usize> {
         HASH_MODEL_ID => Some(HASH_EMBEDDING_DIM),
         FASTEMBED_MODEL_ID => Some(FASTEMBED_EMBEDDING_DIM),
         BGE_SMALL_MODEL_ID => Some(BGE_SMALL_EMBEDDING_DIM),
+        JINA_CODE_MODEL_ID => Some(JINA_CODE_EMBEDDING_DIM),
         MODEL2VEC_MODEL_ID => Some(MODEL2VEC_EMBEDDING_DIM),
         _ => None,
     }
@@ -178,6 +181,20 @@ pub(crate) fn bge_small_embedder(
     #[cfg(feature = "fastembed")]
     {
         Ok(Box::new(FastEmbedEmbedder::new_bge_small(intra_threads)?))
+    }
+    #[cfg(not(feature = "fastembed"))]
+    {
+        let _ = intra_threads;
+        anyhow::bail!("{}", FASTEMBED_MISSING_FEATURE_MESSAGE)
+    }
+}
+
+pub(crate) fn jina_code_embedder(
+    intra_threads: Option<usize>,
+) -> anyhow::Result<Box<dyn Embedder>> {
+    #[cfg(feature = "fastembed")]
+    {
+        Ok(Box::new(FastEmbedEmbedder::new_jina_code(intra_threads)?))
     }
     #[cfg(not(feature = "fastembed"))]
     {
@@ -446,4 +463,34 @@ pub(crate) fn find_existing_embedding(
         )
         .optional()?;
     if let Some(blob) = vector { Ok(decode_vector(&blob, dim)) } else { Ok(None) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registered_embedding_models_have_consistent_dim_and_version() {
+        // Every registered model id must resolve a dim and a NON-fallback version string — else the
+        // reconcile freshness key (model_version) is wrong and embeddings silently mis-track.
+        // Regression guard for the model-id match arms in expected_dim / default_model_version
+        // (#112).
+        for (id, dim) in [
+            (HASH_MODEL_ID, HASH_EMBEDDING_DIM),
+            (FASTEMBED_MODEL_ID, FASTEMBED_EMBEDDING_DIM),
+            (BGE_SMALL_MODEL_ID, BGE_SMALL_EMBEDDING_DIM),
+            (JINA_CODE_MODEL_ID, JINA_CODE_EMBEDDING_DIM),
+            (MODEL2VEC_MODEL_ID, MODEL2VEC_EMBEDDING_DIM),
+        ] {
+            assert_eq!(expected_dim(id), Some(dim), "expected_dim missing/wrong for {id}");
+            assert_ne!(
+                default_model_version(id),
+                "v1",
+                "version fell back to the default for {id}"
+            );
+        }
+        // jina-v2-base-code is the 768-dim code tier; pin its identity explicitly.
+        assert_eq!(expected_dim(JINA_CODE_MODEL_ID), Some(768));
+        assert_eq!(default_model_version(JINA_CODE_MODEL_ID), "fastembed-jina-v2-base-code-v1");
+    }
 }

--- a/crates/rag-rat-core/src/index/ai/helpers.rs
+++ b/crates/rag-rat-core/src/index/ai/helpers.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::embedding_models::{Backend, EmbeddingModelSpec, spec};
 
 pub(crate) fn embed_query(
     conn: &Connection,
@@ -54,14 +55,7 @@ pub(crate) fn active_embedding_model_version(
 }
 
 pub(crate) fn default_model_version(model_id: &str) -> &'static str {
-    match model_id {
-        HASH_MODEL_ID => "hash-v1",
-        FASTEMBED_MODEL_ID => "fastembed-all-minilm-l6-v2-v1",
-        BGE_SMALL_MODEL_ID => "fastembed-bge-small-en-v1.5-v1",
-        JINA_CODE_MODEL_ID => "fastembed-jina-v2-base-code-v1",
-        MODEL2VEC_MODEL_ID => "model2vec-potion-retrieval-32m-v1",
-        _ => "v1",
-    }
+    spec(model_id).map_or("v1", |s| s.version)
 }
 
 pub(crate) fn current_embedding_count(conn: &Connection, model_id: &str) -> anyhow::Result<u64> {
@@ -97,24 +91,49 @@ pub(crate) fn active_embedder(
     let model_id = active_embedding_model_id(conn)?;
     let model = model(conn, &model_id)?;
     validate_ready_model(&model)?;
-    match model.model_id.as_str() {
-        HASH_MODEL_ID => Ok(Box::new(HashEmbedder)),
-        FASTEMBED_MODEL_ID => fastembed_embedder(intra_threads),
-        BGE_SMALL_MODEL_ID => bge_small_embedder(intra_threads),
-        JINA_CODE_MODEL_ID => jina_code_embedder(intra_threads),
-        MODEL2VEC_MODEL_ID => model2vec_embedder(),
-        other => anyhow::bail!("unknown active embedding model `{other}`"),
-    }
+    let spec = spec(&model.model_id)
+        .ok_or_else(|| anyhow::anyhow!("unknown active embedding model `{}`", model.model_id))?;
+    embedder_for_spec(spec, intra_threads)
 }
 
-pub(crate) fn model2vec_embedder() -> anyhow::Result<Box<dyn Embedder>> {
-    #[cfg(feature = "model2vec")]
-    {
-        Ok(Box::new(Model2VecEmbedder::new()?))
-    }
-    #[cfg(not(feature = "model2vec"))]
-    {
-        anyhow::bail!("{}", MODEL2VEC_MISSING_FEATURE_MESSAGE)
+/// Build the embedder for a registry spec, dispatching on its `backend`. The single construction
+/// site for every model — the per-model factory fns this replaced (`fastembed_embedder`,
+/// `bge_small_embedder`, `jina_code_embedder`, `model2vec_embedder`) collapsed into this dispatch.
+/// The `#[cfg]` gating + missing-feature bails for builds without `fastembed` / `model2vec` are
+/// preserved here.
+pub(crate) fn embedder_for_spec(
+    spec: &'static EmbeddingModelSpec,
+    intra_threads: Option<usize>,
+) -> anyhow::Result<Box<dyn Embedder>> {
+    match spec.backend {
+        Backend::Hash => Ok(Box::new(HashEmbedder)),
+        Backend::FastEmbed => {
+            #[cfg(feature = "fastembed")]
+            {
+                Ok(Box::new(FastEmbedEmbedder::for_model_id(
+                    spec.model_id,
+                    spec.dim,
+                    intra_threads,
+                )?))
+            }
+            #[cfg(not(feature = "fastembed"))]
+            {
+                let _ = intra_threads;
+                anyhow::bail!("{}", FASTEMBED_MISSING_FEATURE_MESSAGE)
+            }
+        },
+        Backend::Model2Vec => {
+            #[cfg(feature = "model2vec")]
+            {
+                let _ = intra_threads;
+                Ok(Box::new(Model2VecEmbedder::new()?))
+            }
+            #[cfg(not(feature = "model2vec"))]
+            {
+                let _ = intra_threads;
+                anyhow::bail!("{}", MODEL2VEC_MISSING_FEATURE_MESSAGE)
+            }
+        },
     }
 }
 
@@ -151,56 +170,7 @@ pub(crate) fn model_not_ready_reason(model: &ModelInfo) -> String {
 }
 
 pub(crate) fn expected_dim(model_id: &str) -> Option<usize> {
-    match model_id {
-        HASH_MODEL_ID => Some(HASH_EMBEDDING_DIM),
-        FASTEMBED_MODEL_ID => Some(FASTEMBED_EMBEDDING_DIM),
-        BGE_SMALL_MODEL_ID => Some(BGE_SMALL_EMBEDDING_DIM),
-        JINA_CODE_MODEL_ID => Some(JINA_CODE_EMBEDDING_DIM),
-        MODEL2VEC_MODEL_ID => Some(MODEL2VEC_EMBEDDING_DIM),
-        _ => None,
-    }
-}
-
-pub(crate) fn fastembed_embedder(
-    intra_threads: Option<usize>,
-) -> anyhow::Result<Box<dyn Embedder>> {
-    #[cfg(feature = "fastembed")]
-    {
-        Ok(Box::new(FastEmbedEmbedder::new(intra_threads)?))
-    }
-    #[cfg(not(feature = "fastembed"))]
-    {
-        let _ = intra_threads;
-        anyhow::bail!("{}", FASTEMBED_MISSING_FEATURE_MESSAGE)
-    }
-}
-
-pub(crate) fn bge_small_embedder(
-    intra_threads: Option<usize>,
-) -> anyhow::Result<Box<dyn Embedder>> {
-    #[cfg(feature = "fastembed")]
-    {
-        Ok(Box::new(FastEmbedEmbedder::new_bge_small(intra_threads)?))
-    }
-    #[cfg(not(feature = "fastembed"))]
-    {
-        let _ = intra_threads;
-        anyhow::bail!("{}", FASTEMBED_MISSING_FEATURE_MESSAGE)
-    }
-}
-
-pub(crate) fn jina_code_embedder(
-    intra_threads: Option<usize>,
-) -> anyhow::Result<Box<dyn Embedder>> {
-    #[cfg(feature = "fastembed")]
-    {
-        Ok(Box::new(FastEmbedEmbedder::new_jina_code(intra_threads)?))
-    }
-    #[cfg(not(feature = "fastembed"))]
-    {
-        let _ = intra_threads;
-        anyhow::bail!("{}", FASTEMBED_MISSING_FEATURE_MESSAGE)
-    }
+    spec(model_id).map(|s| s.dim)
 }
 
 pub(crate) fn fastembed_cache_dir() -> PathBuf {
@@ -471,25 +441,26 @@ mod tests {
 
     #[test]
     fn registered_embedding_models_have_consistent_dim_and_version() {
-        // Every registered model id must resolve a dim and a NON-fallback version string — else the
-        // reconcile freshness key (model_version) is wrong and embeddings silently mis-track.
-        // Regression guard for the model-id match arms in expected_dim / default_model_version
-        // (#112).
-        for (id, dim) in [
-            (HASH_MODEL_ID, HASH_EMBEDDING_DIM),
-            (FASTEMBED_MODEL_ID, FASTEMBED_EMBEDDING_DIM),
-            (BGE_SMALL_MODEL_ID, BGE_SMALL_EMBEDDING_DIM),
-            (JINA_CODE_MODEL_ID, JINA_CODE_EMBEDDING_DIM),
-            (MODEL2VEC_MODEL_ID, MODEL2VEC_EMBEDDING_DIM),
-        ] {
-            assert_eq!(expected_dim(id), Some(dim), "expected_dim missing/wrong for {id}");
+        // Every registered model id must resolve a dim and a NON-fallback version string through
+        // the table-driven helpers — else the reconcile freshness key (model_version) is
+        // wrong and embeddings silently mis-track. Regression guard for `expected_dim` /
+        // `default_model_version` now reading the `EMBEDDING_MODELS` registry (#112).
+        for spec in crate::embedding_models::EMBEDDING_MODELS {
+            assert_eq!(
+                expected_dim(spec.model_id),
+                Some(spec.dim),
+                "expected_dim missing/wrong for {}",
+                spec.model_id
+            );
             assert_ne!(
-                default_model_version(id),
+                default_model_version(spec.model_id),
                 "v1",
-                "version fell back to the default for {id}"
+                "version fell back to the default for {}",
+                spec.model_id
             );
         }
         // jina-v2-base-code is the 768-dim code tier; pin its identity explicitly.
+        use crate::embedding_models::JINA_CODE_MODEL_ID;
         assert_eq!(expected_dim(JINA_CODE_MODEL_ID), Some(768));
         assert_eq!(default_model_version(JINA_CODE_MODEL_ID), "fastembed-jina-v2-base-code-v1");
     }

--- a/crates/rag-rat-core/src/index/ai/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/mod.rs
@@ -32,6 +32,11 @@ pub const FASTEMBED_EMBEDDING_DIM: usize = 384;
 pub const BGE_SMALL_MODEL_ID: &str = "fastembed-bge-small-en-v1.5";
 pub const BGE_SMALL_DISPLAY_MODEL: &str = "BAAI/bge-small-en-v1.5";
 pub const BGE_SMALL_EMBEDDING_DIM: usize = 384;
+/// BGE retrieval expects a query-side instruction prefix (queries only; passages stay raw), per the
+/// model card. Applied at query-embed time (`embed_query_with`), so stored passage embeddings are
+/// unchanged — no re-embed needed when this lands, and symmetric models keep the empty default.
+pub const BGE_SMALL_QUERY_PREFIX: &str =
+    "Represent this sentence for searching relevant passages: ";
 
 /// Model2Vec static-embedding backend: a token→vector lookup + mean-pool (no transformer forward
 /// pass), ~100-500× faster than FastEmbed on CPU at some retrieval-quality cost. The right choice
@@ -62,6 +67,12 @@ pub trait Embedder {
     fn model_id(&self) -> &str;
     fn dim(&self) -> usize;
     fn embed_batch(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>>;
+    /// Instruction prepended to QUERIES (not passages) before embedding. Empty for symmetric models
+    /// (hash, all-MiniLM, model2vec); BGE returns its retrieval instruction. See
+    /// `embed_query_with`.
+    fn query_prefix(&self) -> &str {
+        ""
+    }
 }
 
 pub struct HashEmbedder;
@@ -113,27 +124,31 @@ pub struct FastEmbedEmbedder {
     model: std::sync::Mutex<fastembed::TextEmbedding>,
     model_id: &'static str,
     dim: usize,
+    query_prefix: &'static str,
 }
 
 #[cfg(feature = "fastembed")]
 impl FastEmbedEmbedder {
-    /// all-MiniLM-L6-v2 (384-dim) — the default general-purpose backend.
+    /// all-MiniLM-L6-v2 (384-dim) — the default general-purpose backend (symmetric, no prefix).
     pub fn new(intra_threads: Option<usize>) -> anyhow::Result<Self> {
         Self::with_model(
             fastembed::EmbeddingModel::AllMiniLML6V2,
             FASTEMBED_MODEL_ID,
             FASTEMBED_EMBEDDING_DIM,
+            "",
             intra_threads,
         )
     }
 
     /// BGE-small-en-v1.5 (384-dim, #112) — a stronger general-retrieval embedder, same dimension as
-    /// all-MiniLM so swapping it is a re-embed rather than a schema/dim change.
+    /// all-MiniLM so swapping it is a re-embed rather than a schema/dim change. Asymmetric: queries
+    /// get the retrieval instruction prefix (passages stay raw).
     pub fn new_bge_small(intra_threads: Option<usize>) -> anyhow::Result<Self> {
         Self::with_model(
             fastembed::EmbeddingModel::BGESmallENV15,
             BGE_SMALL_MODEL_ID,
             BGE_SMALL_EMBEDDING_DIM,
+            BGE_SMALL_QUERY_PREFIX,
             intra_threads,
         )
     }
@@ -142,6 +157,7 @@ impl FastEmbedEmbedder {
         model: fastembed::EmbeddingModel,
         model_id: &'static str,
         dim: usize,
+        query_prefix: &'static str,
         intra_threads: Option<usize>,
     ) -> anyhow::Result<Self> {
         use fastembed::{InitOptions, TextEmbedding};
@@ -155,7 +171,12 @@ impl FastEmbedEmbedder {
         if let Some(threads) = intra_threads.filter(|threads| *threads > 0) {
             options = options.with_intra_threads(threads);
         }
-        Ok(Self { model: std::sync::Mutex::new(TextEmbedding::try_new(options)?), model_id, dim })
+        Ok(Self {
+            model: std::sync::Mutex::new(TextEmbedding::try_new(options)?),
+            model_id,
+            dim,
+            query_prefix,
+        })
     }
 }
 
@@ -167,6 +188,10 @@ impl Embedder for FastEmbedEmbedder {
 
     fn dim(&self) -> usize {
         self.dim
+    }
+
+    fn query_prefix(&self) -> &str {
+        self.query_prefix
     }
 
     fn embed_batch(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {

--- a/crates/rag-rat-core/src/index/ai/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/mod.rs
@@ -32,11 +32,11 @@ pub const FASTEMBED_EMBEDDING_DIM: usize = 384;
 pub const BGE_SMALL_MODEL_ID: &str = "fastembed-bge-small-en-v1.5";
 pub const BGE_SMALL_DISPLAY_MODEL: &str = "BAAI/bge-small-en-v1.5";
 pub const BGE_SMALL_EMBEDDING_DIM: usize = 384;
-/// BGE retrieval expects a query-side instruction prefix (queries only; passages stay raw), per the
-/// model card. Applied at query-embed time (`embed_query_with`), so stored passage embeddings are
-/// unchanged — no re-embed needed when this lands, and symmetric models keep the empty default.
-pub const BGE_SMALL_QUERY_PREFIX: &str =
-    "Represent this sentence for searching relevant passages: ";
+// NB (#308 review): BGE-small-en-v1.5 does NOT take a query instruction prefix here. v1.5 needs no
+// instruction (BAAI: "no instruction only [a] slight degradation… without instruction in all cases
+// for convenience"), and on SHORT CODE queries the 9-word NL instruction dominates the query vector
+// — it collapsed every query together and tanked replay recall 0.562 → 0.000. Passages never take
+// it either. So queries embed raw, same as all-MiniLM.
 
 /// Model2Vec static-embedding backend: a token→vector lookup + mean-pool (no transformer forward
 /// pass), ~100-500× faster than FastEmbed on CPU at some retrieval-quality cost. The right choice
@@ -67,12 +67,6 @@ pub trait Embedder {
     fn model_id(&self) -> &str;
     fn dim(&self) -> usize;
     fn embed_batch(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>>;
-    /// Instruction prepended to QUERIES (not passages) before embedding. Empty for symmetric models
-    /// (hash, all-MiniLM, model2vec); BGE returns its retrieval instruction. See
-    /// `embed_query_with`.
-    fn query_prefix(&self) -> &str {
-        ""
-    }
 }
 
 pub struct HashEmbedder;
@@ -124,31 +118,28 @@ pub struct FastEmbedEmbedder {
     model: std::sync::Mutex<fastembed::TextEmbedding>,
     model_id: &'static str,
     dim: usize,
-    query_prefix: &'static str,
 }
 
 #[cfg(feature = "fastembed")]
 impl FastEmbedEmbedder {
-    /// all-MiniLM-L6-v2 (384-dim) — the default general-purpose backend (symmetric, no prefix).
+    /// all-MiniLM-L6-v2 (384-dim) — the default general-purpose backend.
     pub fn new(intra_threads: Option<usize>) -> anyhow::Result<Self> {
         Self::with_model(
             fastembed::EmbeddingModel::AllMiniLML6V2,
             FASTEMBED_MODEL_ID,
             FASTEMBED_EMBEDDING_DIM,
-            "",
             intra_threads,
         )
     }
 
     /// BGE-small-en-v1.5 (384-dim, #112) — a stronger general-retrieval embedder, same dimension as
-    /// all-MiniLM so swapping it is a re-embed rather than a schema/dim change. Asymmetric: queries
-    /// get the retrieval instruction prefix (passages stay raw).
+    /// all-MiniLM so swapping it is a re-embed rather than a schema/dim change. v1.5 needs no query
+    /// instruction (see the const note above), so queries embed raw, like all-MiniLM.
     pub fn new_bge_small(intra_threads: Option<usize>) -> anyhow::Result<Self> {
         Self::with_model(
             fastembed::EmbeddingModel::BGESmallENV15,
             BGE_SMALL_MODEL_ID,
             BGE_SMALL_EMBEDDING_DIM,
-            BGE_SMALL_QUERY_PREFIX,
             intra_threads,
         )
     }
@@ -157,7 +148,6 @@ impl FastEmbedEmbedder {
         model: fastembed::EmbeddingModel,
         model_id: &'static str,
         dim: usize,
-        query_prefix: &'static str,
         intra_threads: Option<usize>,
     ) -> anyhow::Result<Self> {
         use fastembed::{InitOptions, TextEmbedding};
@@ -171,12 +161,7 @@ impl FastEmbedEmbedder {
         if let Some(threads) = intra_threads.filter(|threads| *threads > 0) {
             options = options.with_intra_threads(threads);
         }
-        Ok(Self {
-            model: std::sync::Mutex::new(TextEmbedding::try_new(options)?),
-            model_id,
-            dim,
-            query_prefix,
-        })
+        Ok(Self { model: std::sync::Mutex::new(TextEmbedding::try_new(options)?), model_id, dim })
     }
 }
 
@@ -188,10 +173,6 @@ impl Embedder for FastEmbedEmbedder {
 
     fn dim(&self) -> usize {
         self.dim
-    }
-
-    fn query_prefix(&self) -> &str {
-        self.query_prefix
     }
 
     fn embed_batch(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {

--- a/crates/rag-rat-core/src/index/ai/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/mod.rs
@@ -38,6 +38,15 @@ pub const BGE_SMALL_EMBEDDING_DIM: usize = 384;
 // — it collapsed every query together and tanked replay recall 0.562 → 0.000. Passages never take
 // it either. So queries embed raw, same as all-MiniLM.
 
+/// jina-embeddings-v2-base-code (#112): a CODE-specific embedder — 768-dim, Apache-2.0, a built-in
+/// fastembed model. SYMMETRIC: queries and code both embed RAW (no query instruction, unlike
+/// CodeRankEmbed), so it slots into the raw embed path with no prefix, dodging the BGE
+/// instruction-collapse footgun above. 768-dim → a re-embed, not a schema change. Measured against
+/// all-MiniLM / BGE on the commit-replay eval before it ships as the code tier.
+pub const JINA_CODE_MODEL_ID: &str = "fastembed-jina-v2-base-code";
+pub const JINA_CODE_DISPLAY_MODEL: &str = "jinaai/jina-embeddings-v2-base-code";
+pub const JINA_CODE_EMBEDDING_DIM: usize = 768;
+
 /// Model2Vec static-embedding backend: a token→vector lookup + mean-pool (no transformer forward
 /// pass), ~100-500× faster than FastEmbed on CPU at some retrieval-quality cost. The right choice
 /// for very large repos where the FastEmbed backfill is infeasible. See `EmbeddingBackend`.
@@ -140,6 +149,18 @@ impl FastEmbedEmbedder {
             fastembed::EmbeddingModel::BGESmallENV15,
             BGE_SMALL_MODEL_ID,
             BGE_SMALL_EMBEDDING_DIM,
+            intra_threads,
+        )
+    }
+
+    /// jina-embeddings-v2-base-code (768-dim, #112) — a CODE-specific embedder. Symmetric, so
+    /// queries and code both embed raw (no instruction). fastembed applies its Mean pooling +
+    /// L2-normalize internally; nothing to override here.
+    pub fn new_jina_code(intra_threads: Option<usize>) -> anyhow::Result<Self> {
+        Self::with_model(
+            fastembed::EmbeddingModel::JinaEmbeddingsV2BaseCode,
+            JINA_CODE_MODEL_ID,
+            JINA_CODE_EMBEDDING_DIM,
             intra_threads,
         )
     }

--- a/crates/rag-rat-core/src/index/ai/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/mod.rs
@@ -25,6 +25,14 @@ pub const FASTEMBED_MODEL_ID: &str = "fastembed-all-minilm-l6-v2";
 pub const FASTEMBED_DISPLAY_MODEL: &str = "sentence-transformers/all-MiniLM-L6-v2";
 pub const HASH_EMBEDDING_DIM: usize = 384;
 pub const FASTEMBED_EMBEDDING_DIM: usize = 384;
+
+/// BGE-small-en-v1.5 (#112): a stronger general-retrieval embedder than all-MiniLM at the SAME
+/// 384-dim — switching to it is a re-embed, not a schema/dim change. MIT-licensed; ships via
+/// fastembed (downloads on first use). Measured against `FASTEMBED_MODEL_ID` on the replay eval.
+pub const BGE_SMALL_MODEL_ID: &str = "fastembed-bge-small-en-v1.5";
+pub const BGE_SMALL_DISPLAY_MODEL: &str = "BAAI/bge-small-en-v1.5";
+pub const BGE_SMALL_EMBEDDING_DIM: usize = 384;
+
 /// Model2Vec static-embedding backend: a token→vector lookup + mean-pool (no transformer forward
 /// pass), ~100-500× faster than FastEmbed on CPU at some retrieval-quality cost. The right choice
 /// for very large repos where the FastEmbed backfill is infeasible. See `EmbeddingBackend`.
@@ -103,13 +111,41 @@ impl Embedder for MockEmbedder {
 #[cfg(feature = "fastembed")]
 pub struct FastEmbedEmbedder {
     model: std::sync::Mutex<fastembed::TextEmbedding>,
+    model_id: &'static str,
+    dim: usize,
 }
 
 #[cfg(feature = "fastembed")]
 impl FastEmbedEmbedder {
+    /// all-MiniLM-L6-v2 (384-dim) — the default general-purpose backend.
     pub fn new(intra_threads: Option<usize>) -> anyhow::Result<Self> {
-        use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
-        let mut options = InitOptions::new(EmbeddingModel::AllMiniLML6V2)
+        Self::with_model(
+            fastembed::EmbeddingModel::AllMiniLML6V2,
+            FASTEMBED_MODEL_ID,
+            FASTEMBED_EMBEDDING_DIM,
+            intra_threads,
+        )
+    }
+
+    /// BGE-small-en-v1.5 (384-dim, #112) — a stronger general-retrieval embedder, same dimension as
+    /// all-MiniLM so swapping it is a re-embed rather than a schema/dim change.
+    pub fn new_bge_small(intra_threads: Option<usize>) -> anyhow::Result<Self> {
+        Self::with_model(
+            fastembed::EmbeddingModel::BGESmallENV15,
+            BGE_SMALL_MODEL_ID,
+            BGE_SMALL_EMBEDDING_DIM,
+            intra_threads,
+        )
+    }
+
+    fn with_model(
+        model: fastembed::EmbeddingModel,
+        model_id: &'static str,
+        dim: usize,
+        intra_threads: Option<usize>,
+    ) -> anyhow::Result<Self> {
+        use fastembed::{InitOptions, TextEmbedding};
+        let mut options = InitOptions::new(model)
             .with_cache_dir(fastembed_cache_dir())
             .with_show_download_progress(true);
         // `ort_threads` caps the ONNX Runtime intra-op thread pool. Microsoft's prebuilt ORT
@@ -119,18 +155,18 @@ impl FastEmbedEmbedder {
         if let Some(threads) = intra_threads.filter(|threads| *threads > 0) {
             options = options.with_intra_threads(threads);
         }
-        Ok(Self { model: std::sync::Mutex::new(TextEmbedding::try_new(options)?) })
+        Ok(Self { model: std::sync::Mutex::new(TextEmbedding::try_new(options)?), model_id, dim })
     }
 }
 
 #[cfg(feature = "fastembed")]
 impl Embedder for FastEmbedEmbedder {
     fn model_id(&self) -> &str {
-        FASTEMBED_MODEL_ID
+        self.model_id
     }
 
     fn dim(&self) -> usize {
-        FASTEMBED_EMBEDDING_DIM
+        self.dim
     }
 
     fn embed_batch(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {

--- a/crates/rag-rat-core/src/index/ai/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/mod.rs
@@ -17,43 +17,17 @@ use sha2::{Digest, Sha256};
 pub(crate) use status::*;
 pub(crate) use store::*;
 
+#[cfg(feature = "fastembed")]
+use crate::embedding_models::{BGE_SMALL_MODEL_ID, JINA_CODE_MODEL_ID};
+use crate::embedding_models::{HASH_EMBEDDING_DIM, HASH_MODEL_ID};
+#[cfg(feature = "model2vec")]
+use crate::embedding_models::{MODEL2VEC_EMBEDDING_DIM, MODEL2VEC_MODEL_ID};
 use crate::index::now_ms;
 use crate::language::Language;
 
-pub const HASH_MODEL_ID: &str = "embedding-hash";
-pub const FASTEMBED_MODEL_ID: &str = "fastembed-all-minilm-l6-v2";
-pub const FASTEMBED_DISPLAY_MODEL: &str = "sentence-transformers/all-MiniLM-L6-v2";
-pub const HASH_EMBEDDING_DIM: usize = 384;
-pub const FASTEMBED_EMBEDDING_DIM: usize = 384;
-
-/// BGE-small-en-v1.5 (#112): a stronger general-retrieval embedder than all-MiniLM at the SAME
-/// 384-dim — switching to it is a re-embed, not a schema/dim change. MIT-licensed; ships via
-/// fastembed (downloads on first use). Measured against `FASTEMBED_MODEL_ID` on the replay eval.
-pub const BGE_SMALL_MODEL_ID: &str = "fastembed-bge-small-en-v1.5";
-pub const BGE_SMALL_DISPLAY_MODEL: &str = "BAAI/bge-small-en-v1.5";
-pub const BGE_SMALL_EMBEDDING_DIM: usize = 384;
-// NB (#308 review): BGE-small-en-v1.5 does NOT take a query instruction prefix here. v1.5 needs no
-// instruction (BAAI: "no instruction only [a] slight degradation… without instruction in all cases
-// for convenience"), and on SHORT CODE queries the 9-word NL instruction dominates the query vector
-// — it collapsed every query together and tanked replay recall 0.562 → 0.000. Passages never take
-// it either. So queries embed raw, same as all-MiniLM.
-
-/// jina-embeddings-v2-base-code (#112): a CODE-specific embedder — 768-dim, Apache-2.0, a built-in
-/// fastembed model. SYMMETRIC: queries and code both embed RAW (no query instruction, unlike
-/// CodeRankEmbed), so it slots into the raw embed path with no prefix, dodging the BGE
-/// instruction-collapse footgun above. 768-dim → a re-embed, not a schema change. Measured against
-/// all-MiniLM / BGE on the commit-replay eval before it ships as the code tier.
-pub const JINA_CODE_MODEL_ID: &str = "fastembed-jina-v2-base-code";
-pub const JINA_CODE_DISPLAY_MODEL: &str = "jinaai/jina-embeddings-v2-base-code";
-pub const JINA_CODE_EMBEDDING_DIM: usize = 768;
-
-/// Model2Vec static-embedding backend: a token→vector lookup + mean-pool (no transformer forward
-/// pass), ~100-500× faster than FastEmbed on CPU at some retrieval-quality cost. The right choice
-/// for very large repos where the FastEmbed backfill is infeasible. See `EmbeddingBackend`.
-pub const MODEL2VEC_MODEL_ID: &str = "model2vec-potion-retrieval-32m";
-pub const MODEL2VEC_DISPLAY_MODEL: &str = "minishlab/potion-retrieval-32M";
+/// The Model2Vec HF repo to pull weights from. Not a registry field — it is a construction detail
+/// of `Model2VecEmbedder`, not part of the model's index identity.
 pub const MODEL2VEC_HF_REPO: &str = "minishlab/potion-retrieval-32M";
-pub const MODEL2VEC_EMBEDDING_DIM: usize = 512;
 pub const MODEL2VEC_MISSING_FEATURE_MESSAGE: &str =
     "Model2Vec backend requested, but this binary was built without Model2Vec support.\nRebuild \
      with default features enabled:\n  cargo install rag-rat";
@@ -131,38 +105,26 @@ pub struct FastEmbedEmbedder {
 
 #[cfg(feature = "fastembed")]
 impl FastEmbedEmbedder {
-    /// all-MiniLM-L6-v2 (384-dim) — the default general-purpose backend.
-    pub fn new(intra_threads: Option<usize>) -> anyhow::Result<Self> {
-        Self::with_model(
-            fastembed::EmbeddingModel::AllMiniLML6V2,
-            FASTEMBED_MODEL_ID,
-            FASTEMBED_EMBEDDING_DIM,
-            intra_threads,
-        )
-    }
-
-    /// BGE-small-en-v1.5 (384-dim, #112) — a stronger general-retrieval embedder, same dimension as
-    /// all-MiniLM so swapping it is a re-embed rather than a schema/dim change. v1.5 needs no query
-    /// instruction (see the const note above), so queries embed raw, like all-MiniLM.
-    pub fn new_bge_small(intra_threads: Option<usize>) -> anyhow::Result<Self> {
-        Self::with_model(
-            fastembed::EmbeddingModel::BGESmallENV15,
-            BGE_SMALL_MODEL_ID,
-            BGE_SMALL_EMBEDDING_DIM,
-            intra_threads,
-        )
-    }
-
-    /// jina-embeddings-v2-base-code (768-dim, #112) — a CODE-specific embedder. Symmetric, so
-    /// queries and code both embed raw (no instruction). fastembed applies its Mean pooling +
-    /// L2-normalize internally; nothing to override here.
-    pub fn new_jina_code(intra_threads: Option<usize>) -> anyhow::Result<Self> {
-        Self::with_model(
-            fastembed::EmbeddingModel::JinaEmbeddingsV2BaseCode,
-            JINA_CODE_MODEL_ID,
-            JINA_CODE_EMBEDDING_DIM,
-            intra_threads,
-        )
+    /// Construct the FastEmbed embedder for a registered model id. This is the ONLY place that maps
+    /// a `model_id` to a `fastembed::EmbeddingModel` enum — every fastembed model the registry
+    /// knows about is selected here, defaulting to all-MiniLM for the (registry-guaranteed)
+    /// MiniLM id. The `dim` comes from the registry spec so the embedder reports the right
+    /// dimension without a second source of truth.
+    ///
+    /// All current fastembed models are SYMMETRIC (queries and code embed raw); fastembed applies
+    /// each model's Mean pooling + L2-normalize internally, so nothing is overridden here. See the
+    /// BGE instruction-collapse note in `embedding_models`.
+    pub fn for_model_id(
+        model_id: &'static str,
+        dim: usize,
+        intra_threads: Option<usize>,
+    ) -> anyhow::Result<Self> {
+        let model = match model_id {
+            BGE_SMALL_MODEL_ID => fastembed::EmbeddingModel::BGESmallENV15,
+            JINA_CODE_MODEL_ID => fastembed::EmbeddingModel::JinaEmbeddingsV2BaseCode,
+            _ => fastembed::EmbeddingModel::AllMiniLML6V2,
+        };
+        Self::with_model(model, model_id, dim, intra_threads)
     }
 
     fn with_model(

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -30,6 +30,14 @@ pub(crate) fn ensure_model_manifest(conn: &Connection) -> anyhow::Result<()> {
     )?;
     upsert_model(
         conn,
+        JINA_CODE_MODEL_ID,
+        "embedding",
+        Some(JINA_CODE_EMBEDDING_DIM),
+        "fastembed",
+        false,
+    )?;
+    upsert_model(
+        conn,
         MODEL2VEC_MODEL_ID,
         "embedding",
         Some(MODEL2VEC_EMBEDDING_DIM),
@@ -60,7 +68,13 @@ pub(crate) fn model_manifest_is_current(conn: &Connection) -> anyhow::Result<boo
             return Ok(false);
         }
     }
-    for model_id in [HASH_MODEL_ID, FASTEMBED_MODEL_ID, BGE_SMALL_MODEL_ID, MODEL2VEC_MODEL_ID] {
+    for model_id in [
+        HASH_MODEL_ID,
+        FASTEMBED_MODEL_ID,
+        BGE_SMALL_MODEL_ID,
+        JINA_CODE_MODEL_ID,
+        MODEL2VEC_MODEL_ID,
+    ] {
         let present: bool = conn.query_row(
             "SELECT EXISTS(SELECT 1 FROM ai_models WHERE model_id = ?1)",
             params![model_id],
@@ -202,7 +216,7 @@ pub(crate) fn install_model(conn: &Connection, model_id: &str) -> anyhow::Result
             )?;
             set_meta(conn, ACTIVE_EMBEDDING_MODEL_META, model_id)?;
         },
-        FASTEMBED_MODEL_ID | BGE_SMALL_MODEL_ID => {
+        FASTEMBED_MODEL_ID | BGE_SMALL_MODEL_ID | JINA_CODE_MODEL_ID => {
             install_fastembed_model(conn, model_id)?;
             set_meta(conn, ACTIVE_EMBEDDING_MODEL_META, model_id)?;
         },

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -1,4 +1,7 @@
 use super::*;
+#[cfg(feature = "fastembed")]
+use crate::embedding_models::FASTEMBED_EMBEDDING_DIM;
+use crate::embedding_models::{Backend, EMBEDDING_MODELS, FASTEMBED_MODEL_ID, HASH_MODEL_ID, spec};
 
 pub(crate) fn ensure_model_manifest(conn: &Connection) -> anyhow::Result<()> {
     // Read-first: skip the (write-locking) DML entirely when the manifest already matches what we
@@ -11,39 +14,13 @@ pub(crate) fn ensure_model_manifest(conn: &Connection) -> anyhow::Result<()> {
         return Ok(());
     }
     remove_legacy_models(conn)?;
-    upsert_model(conn, HASH_MODEL_ID, "embedding", Some(HASH_EMBEDDING_DIM), "hash", false)?;
-    upsert_model(
-        conn,
-        FASTEMBED_MODEL_ID,
-        "embedding",
-        Some(FASTEMBED_EMBEDDING_DIM),
-        "fastembed",
-        false,
-    )?;
-    upsert_model(
-        conn,
-        BGE_SMALL_MODEL_ID,
-        "embedding",
-        Some(BGE_SMALL_EMBEDDING_DIM),
-        "fastembed",
-        false,
-    )?;
-    upsert_model(
-        conn,
-        JINA_CODE_MODEL_ID,
-        "embedding",
-        Some(JINA_CODE_EMBEDDING_DIM),
-        "fastembed",
-        false,
-    )?;
-    upsert_model(
-        conn,
-        MODEL2VEC_MODEL_ID,
-        "embedding",
-        Some(MODEL2VEC_EMBEDDING_DIM),
-        "model2vec",
-        false,
-    )?;
+    // One row per registered model, straight from the registry — adding a model needs no edit here.
+    // `installed_by_default` is false for EVERY model (including hash): a model is installed only
+    // on explicit `install_model`. `upsert_model` is `ON CONFLICT DO NOTHING`, so this only
+    // seeds rows.
+    for s in EMBEDDING_MODELS {
+        upsert_model(conn, s.model_id, "embedding", Some(s.dim), s.backend.runtime(), false)?;
+    }
     normalize_embedding_model_versions(conn)?;
     Ok(())
 }
@@ -68,16 +45,10 @@ pub(crate) fn model_manifest_is_current(conn: &Connection) -> anyhow::Result<boo
             return Ok(false);
         }
     }
-    for model_id in [
-        HASH_MODEL_ID,
-        FASTEMBED_MODEL_ID,
-        BGE_SMALL_MODEL_ID,
-        JINA_CODE_MODEL_ID,
-        MODEL2VEC_MODEL_ID,
-    ] {
+    for s in EMBEDDING_MODELS {
         let present: bool = conn.query_row(
             "SELECT EXISTS(SELECT 1 FROM ai_models WHERE model_id = ?1)",
-            params![model_id],
+            params![s.model_id],
             |row| row.get(0),
         )?;
         if !present {
@@ -205,27 +176,22 @@ pub(crate) fn fastembed_cache_ready(cache_dir: &Path) -> bool {
 
 pub(crate) fn install_model(conn: &Connection, model_id: &str) -> anyhow::Result<ModelInfo> {
     ensure_model_manifest(conn)?;
-    match model_id {
-        HASH_MODEL_ID => {
+    let spec =
+        spec(model_id).ok_or_else(|| anyhow::anyhow!("unknown local AI model `{model_id}`"))?;
+    match spec.backend {
+        Backend::Hash => {
             conn.execute(
                 "UPDATE ai_models
                  SET installed = 1, disabled = 0, status = 'Ready', installed_at_ms = ?2,
                      embedding_dim = ?3, runtime = 'hash', last_error = NULL
                  WHERE model_id = ?1",
-                params![model_id, now_ms(), i64::try_from(HASH_EMBEDDING_DIM).unwrap_or(i64::MAX)],
+                params![model_id, now_ms(), i64::try_from(spec.dim).unwrap_or(i64::MAX)],
             )?;
-            set_meta(conn, ACTIVE_EMBEDDING_MODEL_META, model_id)?;
         },
-        FASTEMBED_MODEL_ID | BGE_SMALL_MODEL_ID | JINA_CODE_MODEL_ID => {
-            install_fastembed_model(conn, model_id)?;
-            set_meta(conn, ACTIVE_EMBEDDING_MODEL_META, model_id)?;
-        },
-        MODEL2VEC_MODEL_ID => {
-            install_model2vec_model(conn, model_id)?;
-            set_meta(conn, ACTIVE_EMBEDDING_MODEL_META, model_id)?;
-        },
-        other => anyhow::bail!("unknown local AI model `{other}`"),
+        Backend::FastEmbed => install_fastembed_model(conn, model_id)?,
+        Backend::Model2Vec => install_model2vec_model(conn, model_id)?,
     }
+    set_meta(conn, ACTIVE_EMBEDDING_MODEL_META, model_id)?;
     model(conn, model_id)
 }
 

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -22,6 +22,14 @@ pub(crate) fn ensure_model_manifest(conn: &Connection) -> anyhow::Result<()> {
     )?;
     upsert_model(
         conn,
+        BGE_SMALL_MODEL_ID,
+        "embedding",
+        Some(BGE_SMALL_EMBEDDING_DIM),
+        "fastembed",
+        false,
+    )?;
+    upsert_model(
+        conn,
         MODEL2VEC_MODEL_ID,
         "embedding",
         Some(MODEL2VEC_EMBEDDING_DIM),
@@ -52,7 +60,7 @@ pub(crate) fn model_manifest_is_current(conn: &Connection) -> anyhow::Result<boo
             return Ok(false);
         }
     }
-    for model_id in [HASH_MODEL_ID, FASTEMBED_MODEL_ID, MODEL2VEC_MODEL_ID] {
+    for model_id in [HASH_MODEL_ID, FASTEMBED_MODEL_ID, BGE_SMALL_MODEL_ID, MODEL2VEC_MODEL_ID] {
         let present: bool = conn.query_row(
             "SELECT EXISTS(SELECT 1 FROM ai_models WHERE model_id = ?1)",
             params![model_id],
@@ -194,7 +202,7 @@ pub(crate) fn install_model(conn: &Connection, model_id: &str) -> anyhow::Result
             )?;
             set_meta(conn, ACTIVE_EMBEDDING_MODEL_META, model_id)?;
         },
-        FASTEMBED_MODEL_ID => {
+        FASTEMBED_MODEL_ID | BGE_SMALL_MODEL_ID => {
             install_fastembed_model(conn, model_id)?;
             set_meta(conn, ACTIVE_EMBEDDING_MODEL_META, model_id)?;
         },

--- a/crates/rag-rat-core/src/index/ai/status.rs
+++ b/crates/rag-rat-core/src/index/ai/status.rs
@@ -3,10 +3,12 @@ use super::*;
 pub(crate) fn install_fastembed_model(conn: &Connection, model_id: &str) -> anyhow::Result<()> {
     #[cfg(feature = "fastembed")]
     {
-        // Init the model that matches `model_id` (triggers its download + yields the right dim),
-        // not always all-MiniLM — both are 384-dim, but BGE-small (#112) must pull its own weights.
+        // Init the model that matches `model_id` (triggers its download + yields the right dim) —
+        // each fastembed model pulls its own weights and reports its own dim (#112). jina-v2-code
+        // is 768-dim, not 384.
         let embedder = match model_id {
             BGE_SMALL_MODEL_ID => FastEmbedEmbedder::new_bge_small(None),
+            JINA_CODE_MODEL_ID => FastEmbedEmbedder::new_jina_code(None),
             _ => FastEmbedEmbedder::new(None),
         }
         .map_err(|err| anyhow::anyhow!("failed to initialize fastembed model: {err}"))?;
@@ -38,15 +40,18 @@ pub(crate) fn fastembed_operational_status(
 ) -> anyhow::Result<FastEmbedOperationalStatus> {
     // Report the ACTIVE fastembed model (all-MiniLM or BGE-small), not always all-MiniLM — else
     // installing BGE makes status/doctor flag MiniLM as missing or needing reconcile (#112 review).
-    let report_model_id = if matches!(active_model_id, FASTEMBED_MODEL_ID | BGE_SMALL_MODEL_ID) {
+    let report_model_id = if matches!(
+        active_model_id,
+        FASTEMBED_MODEL_ID | BGE_SMALL_MODEL_ID | JINA_CODE_MODEL_ID
+    ) {
         active_model_id
     } else {
         FASTEMBED_MODEL_ID
     };
-    let report_display = if report_model_id == BGE_SMALL_MODEL_ID {
-        BGE_SMALL_DISPLAY_MODEL
-    } else {
-        FASTEMBED_DISPLAY_MODEL
+    let report_display = match report_model_id {
+        BGE_SMALL_MODEL_ID => BGE_SMALL_DISPLAY_MODEL,
+        JINA_CODE_MODEL_ID => JINA_CODE_DISPLAY_MODEL,
+        _ => FASTEMBED_DISPLAY_MODEL,
     };
     let model = model(conn, report_model_id)?;
     // PERF: report coverage from CHEAP persisted counts (the `embedding_artifacts` rows + the chunk
@@ -83,10 +88,13 @@ pub(crate) fn fastembed_operational_status(
         build_feature_enabled: fastembed_build_feature_enabled(),
         model_id: report_model_id.to_string(),
         model: report_display.to_string(),
-        dim: FASTEMBED_EMBEDDING_DIM,
+        dim: expected_dim(report_model_id).unwrap_or(FASTEMBED_EMBEDDING_DIM),
         cache: fastembed_cache_dir().display().to_string(),
         installed: model.installed,
-        active: matches!(active_model_id, FASTEMBED_MODEL_ID | BGE_SMALL_MODEL_ID),
+        active: matches!(
+            active_model_id,
+            FASTEMBED_MODEL_ID | BGE_SMALL_MODEL_ID | JINA_CODE_MODEL_ID
+        ),
         status: model.status,
         current_embeddings: current,
         eligible_embeddings: eligible,

--- a/crates/rag-rat-core/src/index/ai/status.rs
+++ b/crates/rag-rat-core/src/index/ai/status.rs
@@ -1,17 +1,18 @@
 use super::*;
+use crate::embedding_models::{
+    Backend, FASTEMBED_DISPLAY_MODEL, FASTEMBED_EMBEDDING_DIM, FASTEMBED_MODEL_ID, spec,
+};
 
 pub(crate) fn install_fastembed_model(conn: &Connection, model_id: &str) -> anyhow::Result<()> {
     #[cfg(feature = "fastembed")]
     {
         // Init the model that matches `model_id` (triggers its download + yields the right dim) —
-        // each fastembed model pulls its own weights and reports its own dim (#112). jina-v2-code
-        // is 768-dim, not 384.
-        let embedder = match model_id {
-            BGE_SMALL_MODEL_ID => FastEmbedEmbedder::new_bge_small(None),
-            JINA_CODE_MODEL_ID => FastEmbedEmbedder::new_jina_code(None),
-            _ => FastEmbedEmbedder::new(None),
-        }
-        .map_err(|err| anyhow::anyhow!("failed to initialize fastembed model: {err}"))?;
+        // each fastembed model pulls its own weights and reports its own dim (#112). The dim comes
+        // from the registry spec; jina-v2-code is 768-dim, not 384.
+        let spec = spec(model_id)
+            .ok_or_else(|| anyhow::anyhow!("unknown fastembed model `{model_id}`"))?;
+        let embedder = FastEmbedEmbedder::for_model_id(spec.model_id, spec.dim, None)
+            .map_err(|err| anyhow::anyhow!("failed to initialize fastembed model: {err}"))?;
         conn.execute(
             "UPDATE ai_models
              SET installed = 1, disabled = 0, status = 'Ready', installed_at_ms = ?2,
@@ -38,21 +39,13 @@ pub(crate) fn fastembed_operational_status(
     active_model_id: &str,
     total_chunks: u64,
 ) -> anyhow::Result<FastEmbedOperationalStatus> {
-    // Report the ACTIVE fastembed model (all-MiniLM or BGE-small), not always all-MiniLM — else
-    // installing BGE makes status/doctor flag MiniLM as missing or needing reconcile (#112 review).
-    let report_model_id = if matches!(
-        active_model_id,
-        FASTEMBED_MODEL_ID | BGE_SMALL_MODEL_ID | JINA_CODE_MODEL_ID
-    ) {
-        active_model_id
-    } else {
-        FASTEMBED_MODEL_ID
-    };
-    let report_display = match report_model_id {
-        BGE_SMALL_MODEL_ID => BGE_SMALL_DISPLAY_MODEL,
-        JINA_CODE_MODEL_ID => JINA_CODE_DISPLAY_MODEL,
-        _ => FASTEMBED_DISPLAY_MODEL,
-    };
+    // Report the ACTIVE fastembed model (all-MiniLM / BGE-small / jina-code), not always all-MiniLM
+    // — else installing another fastembed model makes status/doctor flag MiniLM as missing or
+    // needing reconcile (#112 review). A model is "a fastembed model" iff its registry backend is
+    // FastEmbed; everything non-fastembed falls back to the MiniLM report identity.
+    let active_is_fastembed = spec(active_model_id).map(|s| s.backend) == Some(Backend::FastEmbed);
+    let report_model_id = if active_is_fastembed { active_model_id } else { FASTEMBED_MODEL_ID };
+    let report_display = spec(report_model_id).map_or(FASTEMBED_DISPLAY_MODEL, |s| s.display);
     let model = model(conn, report_model_id)?;
     // PERF: report coverage from CHEAP persisted counts (the `embedding_artifacts` rows + the chunk
     // total) rather than `embedding_reconcile_plan` — which loads EVERY chunk and rebuilds +
@@ -88,13 +81,12 @@ pub(crate) fn fastembed_operational_status(
         build_feature_enabled: fastembed_build_feature_enabled(),
         model_id: report_model_id.to_string(),
         model: report_display.to_string(),
-        dim: expected_dim(report_model_id).unwrap_or(FASTEMBED_EMBEDDING_DIM),
+        // The reported dim must reflect the ACTIVE model (jina-code is 768, not 384) — driven off
+        // the registry spec so it never regresses to the MiniLM default for a 768-dim active model.
+        dim: spec(report_model_id).map_or(FASTEMBED_EMBEDDING_DIM, |s| s.dim),
         cache: fastembed_cache_dir().display().to_string(),
         installed: model.installed,
-        active: matches!(
-            active_model_id,
-            FASTEMBED_MODEL_ID | BGE_SMALL_MODEL_ID | JINA_CODE_MODEL_ID
-        ),
+        active: active_is_fastembed,
         status: model.status,
         current_embeddings: current,
         eligible_embeddings: eligible,

--- a/crates/rag-rat-core/src/index/ai/status.rs
+++ b/crates/rag-rat-core/src/index/ai/status.rs
@@ -3,8 +3,13 @@ use super::*;
 pub(crate) fn install_fastembed_model(conn: &Connection, model_id: &str) -> anyhow::Result<()> {
     #[cfg(feature = "fastembed")]
     {
-        let embedder = FastEmbedEmbedder::new(None)
-            .map_err(|err| anyhow::anyhow!("failed to initialize fastembed model: {err}"))?;
+        // Init the model that matches `model_id` (triggers its download + yields the right dim),
+        // not always all-MiniLM — both are 384-dim, but BGE-small (#112) must pull its own weights.
+        let embedder = match model_id {
+            BGE_SMALL_MODEL_ID => FastEmbedEmbedder::new_bge_small(None),
+            _ => FastEmbedEmbedder::new(None),
+        }
+        .map_err(|err| anyhow::anyhow!("failed to initialize fastembed model: {err}"))?;
         conn.execute(
             "UPDATE ai_models
              SET installed = 1, disabled = 0, status = 'Ready', installed_at_ms = ?2,

--- a/crates/rag-rat-core/src/index/ai/status.rs
+++ b/crates/rag-rat-core/src/index/ai/status.rs
@@ -36,7 +36,19 @@ pub(crate) fn fastembed_operational_status(
     active_model_id: &str,
     total_chunks: u64,
 ) -> anyhow::Result<FastEmbedOperationalStatus> {
-    let model = model(conn, FASTEMBED_MODEL_ID)?;
+    // Report the ACTIVE fastembed model (all-MiniLM or BGE-small), not always all-MiniLM — else
+    // installing BGE makes status/doctor flag MiniLM as missing or needing reconcile (#112 review).
+    let report_model_id = if matches!(active_model_id, FASTEMBED_MODEL_ID | BGE_SMALL_MODEL_ID) {
+        active_model_id
+    } else {
+        FASTEMBED_MODEL_ID
+    };
+    let report_display = if report_model_id == BGE_SMALL_MODEL_ID {
+        BGE_SMALL_DISPLAY_MODEL
+    } else {
+        FASTEMBED_DISPLAY_MODEL
+    };
+    let model = model(conn, report_model_id)?;
     // PERF: report coverage from CHEAP persisted counts (the `embedding_artifacts` rows + the chunk
     // total) rather than `embedding_reconcile_plan` — which loads EVERY chunk and rebuilds +
     // re-hashes its embedding input (~200s on a 174k-chunk index, paid with OR without an active
@@ -45,12 +57,11 @@ pub(crate) fn fastembed_operational_status(
     // same basis it uses for the generic `capability_status` counts); the exact policy-skip +
     // live-drift breakdown is the `reconcile --plan` command's job, where the per-chunk scan
     // belongs.
-    let current = current_artifact_count(conn, "embedding", FASTEMBED_MODEL_ID)?;
-    let stale = stale_artifact_count(conn, "embedding", FASTEMBED_MODEL_ID)?;
-    let failed =
-        status_artifact_count(conn, "embedding", FASTEMBED_MODEL_ID, ArtifactStatus::Failed)?;
+    let current = current_artifact_count(conn, "embedding", report_model_id)?;
+    let stale = stale_artifact_count(conn, "embedding", report_model_id)?;
+    let failed = status_artifact_count(conn, "embedding", report_model_id, ArtifactStatus::Failed)?;
     let blocked =
-        status_artifact_count(conn, "embedding", FASTEMBED_MODEL_ID, ArtifactStatus::Blocked)?;
+        status_artifact_count(conn, "embedding", report_model_id, ArtifactStatus::Blocked)?;
     // Exact `skipped` (embedding input too large) needs the decompressed text per chunk — deferred
     // to `reconcile --plan`. The status treats every chunk as eligible, so the invariant
     // `eligible + skipped == total` holds with `skipped == 0`.
@@ -61,7 +72,7 @@ pub(crate) fn fastembed_operational_status(
     let next = if !fastembed_build_feature_enabled() {
         Some("cargo install rag-rat".to_string())
     } else if validate_ready_model(&model).is_err() {
-        Some(format!("rag-rat models install {FASTEMBED_MODEL_ID}"))
+        Some(format!("rag-rat models install {report_model_id}"))
     } else if missing > 0 || stale > 0 || failed > 0 {
         Some("rag-rat reconcile --limit 500".to_string())
     } else {
@@ -70,12 +81,12 @@ pub(crate) fn fastembed_operational_status(
     Ok(FastEmbedOperationalStatus {
         backend: "fastembed".to_string(),
         build_feature_enabled: fastembed_build_feature_enabled(),
-        model_id: FASTEMBED_MODEL_ID.to_string(),
-        model: FASTEMBED_DISPLAY_MODEL.to_string(),
+        model_id: report_model_id.to_string(),
+        model: report_display.to_string(),
         dim: FASTEMBED_EMBEDDING_DIM,
         cache: fastembed_cache_dir().display().to_string(),
         installed: model.installed,
-        active: active_model_id == FASTEMBED_MODEL_ID,
+        active: matches!(active_model_id, FASTEMBED_MODEL_ID | BGE_SMALL_MODEL_ID),
         status: model.status,
         current_embeddings: current,
         eligible_embeddings: eligible,

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -3,6 +3,13 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::*;
 use crate::config::ResolvedTarget;
+// The embedding-model constants moved from `index::ai` to the crate-root registry (#112).
+// Import them here so the existing `HASH_MODEL_ID` / `FASTEMBED_*` references resolve to the
+// new path.
+use crate::embedding_models::{
+    FASTEMBED_DISPLAY_MODEL, FASTEMBED_EMBEDDING_DIM, FASTEMBED_MODEL_ID, HASH_EMBEDDING_DIM,
+    HASH_MODEL_ID,
+};
 
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -458,16 +465,16 @@ fn full_rebuild_preserves_github_papertrail_cache() {
 fn full_rebuild_preserves_installed_model_manifest() {
     let (root, config) = markdown_config("alpha token with enough detail for embeddings\n");
     let db = IndexDatabase::rebuild(&config).unwrap();
-    db.install_model(ai::HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID).unwrap();
     let before = db.local_ai_status().unwrap();
-    assert_eq!(before.embedding.model_id, ai::HASH_MODEL_ID);
+    assert_eq!(before.embedding.model_id, HASH_MODEL_ID);
     assert!(before.embedding.installed);
     drop(db);
 
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     let after = db.local_ai_status().unwrap();
-    assert_eq!(after.embedding.model_id, ai::HASH_MODEL_ID);
+    assert_eq!(after.embedding.model_id, HASH_MODEL_ID);
     assert!(after.embedding.installed);
     assert_eq!(after.embedding.state, "Ready");
 
@@ -777,8 +784,8 @@ fn rebuild_populates_revision_metadata_and_fresh_fts_state() {
     assert_eq!(status.git_history.commit_count, 0);
     assert_eq!(status.local_ai.embedding.state, "MissingModel");
     assert_eq!(status.local_ai.fastembed.backend, "fastembed");
-    assert_eq!(status.local_ai.fastembed.model, ai::FASTEMBED_DISPLAY_MODEL);
-    assert_eq!(status.local_ai.fastembed.dim, ai::FASTEMBED_EMBEDDING_DIM);
+    assert_eq!(status.local_ai.fastembed.model, FASTEMBED_DISPLAY_MODEL);
+    assert_eq!(status.local_ai.fastembed.dim, FASTEMBED_EMBEDDING_DIM);
     assert!(!status.local_ai.fastembed.cache.is_empty());
     assert_eq!(status.local_ai.fastembed.build_feature_enabled, cfg!(feature = "fastembed"));
     assert_eq!(status.local_ai.artifacts.total_chunks, 1);
@@ -803,7 +810,7 @@ fn fastembed_missing_feature_reports_rebuild_command() {
     let (root, config) = markdown_config("alpha token\n");
     let db = IndexDatabase::rebuild(&config).unwrap();
 
-    let err = db.install_model(ai::FASTEMBED_MODEL_ID).unwrap_err();
+    let err = db.install_model(FASTEMBED_MODEL_ID).unwrap_err();
     assert!(err.to_string().contains(ai::FASTEMBED_MISSING_FEATURE_MESSAGE));
 
     let status = db.local_ai_status().unwrap();
@@ -825,7 +832,7 @@ fn reconcile_requires_explicit_model_install_and_ignores_stale_artifacts() {
     let chunk_id = first_chunk_id(&db);
 
     let models = db.list_models().unwrap();
-    let embedding = models.iter().find(|model| model.model_id == ai::HASH_MODEL_ID).unwrap();
+    let embedding = models.iter().find(|model| model.model_id == HASH_MODEL_ID).unwrap();
     assert!(!embedding.installed);
     assert_eq!(embedding.status, "MissingModel");
 
@@ -837,7 +844,7 @@ fn reconcile_requires_explicit_model_install_and_ignores_stale_artifacts() {
     assert_eq!(blocked.processed_chunks, 0);
     assert_eq!(blocked.embeddings_written, 0);
     assert_eq!(blocked.blocked_chunks, 0);
-    assert_eq!(blocked.model_id, ai::HASH_MODEL_ID);
+    assert_eq!(blocked.model_id, HASH_MODEL_ID);
     assert_eq!(blocked.batch_size, 8);
     assert_eq!(blocked.status, "Blocked");
 
@@ -845,15 +852,15 @@ fn reconcile_requires_explicit_model_install_and_ignores_stale_artifacts() {
     assert_eq!(status.embedding.state, "MissingModel");
     assert_eq!(status.embedding.blocked_artifacts, 0);
 
-    db.install_model(ai::HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID).unwrap();
     let plan = db.reconcile_plan().unwrap();
     assert_eq!(plan.embeddings.missing, 1);
     assert_eq!(plan.embeddings.current, 0);
     let current = db.reconcile(Some(1), Some(8)).unwrap();
     assert_eq!(current.embeddings_written, 1);
-    assert_eq!(current.model_id, ai::HASH_MODEL_ID);
+    assert_eq!(current.model_id, HASH_MODEL_ID);
     assert_eq!(current.model_version, "hash-v1");
-    assert_eq!(current.embedding_dim, ai::HASH_EMBEDDING_DIM);
+    assert_eq!(current.embedding_dim, HASH_EMBEDDING_DIM);
     assert_eq!(current.status, "Current");
     assert_eq!(current.work_reasons.get("Missing"), Some(&1));
     let noop = db.reconcile(None, Some(8)).unwrap();
@@ -872,7 +879,7 @@ fn reconcile_requires_explicit_model_install_and_ignores_stale_artifacts() {
             |row| row.get(0),
         )
         .unwrap();
-    assert_eq!(embedding_bytes, (ai::HASH_EMBEDDING_DIM * 4) as i64);
+    assert_eq!(embedding_bytes, (HASH_EMBEDDING_DIM * 4) as i64);
 
     let hits = db.search("alpha", 10, false).unwrap();
     assert!(hits[0].summary.contains("alpha token"));
@@ -894,7 +901,7 @@ fn reconcile_requires_explicit_model_install_and_ignores_stale_artifacts() {
     let refreshed = db.reconcile(None, Some(8)).unwrap();
     assert_eq!(refreshed.processed_chunks, 1);
     assert_eq!(refreshed.work_reasons.get("SourceChanged"), Some(&1));
-    assert_eq!(db.current_embedding_count(ai::HASH_MODEL_ID).unwrap(), 1);
+    assert_eq!(db.current_embedding_count(HASH_MODEL_ID).unwrap(), 1);
     let stale_embedding_hits = db.search("alpha", 10, false).unwrap();
     assert_eq!(stale_embedding_hits.len(), 1);
 
@@ -916,7 +923,7 @@ fn cached_fastembed_model_recovers_ready_state() {
     ai::recover_cached_fastembed_model_at(db.storage.connection(), &cache_dir).unwrap();
 
     let models = db.list_models().unwrap();
-    let fastembed = models.iter().find(|model| model.model_id == ai::FASTEMBED_MODEL_ID).unwrap();
+    let fastembed = models.iter().find(|model| model.model_id == FASTEMBED_MODEL_ID).unwrap();
     assert!(fastembed.installed);
     assert_eq!(fastembed.status, "Ready");
     let status = db.local_ai_status().unwrap();
@@ -943,7 +950,7 @@ fn compatible_migrate_recovers_cached_fastembed_model() {
             "UPDATE ai_models
                  SET installed = 0, status = 'MissingModel', installed_at_ms = NULL
                  WHERE model_id = ?1",
-            [ai::FASTEMBED_MODEL_ID],
+            [FASTEMBED_MODEL_ID],
         )
         .unwrap();
 
@@ -965,14 +972,14 @@ fn reconcile_without_limit_processes_all_chunks() {
          eligibility and useful semantic context\n",
     );
     let db = IndexDatabase::rebuild(&config).unwrap();
-    db.install_model(ai::HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID).unwrap();
 
     let report = db.reconcile(None, Some(2)).unwrap();
 
     assert_eq!(report.processed_chunks, 2);
     assert_eq!(report.embeddings_written, 2);
     assert_eq!(report.batch_size, 2);
-    assert_eq!(db.current_embedding_count(ai::HASH_MODEL_ID).unwrap(), 2);
+    assert_eq!(db.current_embedding_count(HASH_MODEL_ID).unwrap(), 2);
     let second = db.reconcile(None, Some(2)).unwrap();
     assert_eq!(second.processed_chunks, 0);
 
@@ -991,7 +998,7 @@ fn force_reconcile_processes_each_chunk_once_and_terminates() {
          eligibility and useful semantic context\n",
     );
     let db = IndexDatabase::rebuild(&config).unwrap();
-    db.install_model(ai::HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID).unwrap();
 
     // Two eligible chunks; force with a limit far above the chunk count.
     let report = db.reconcile_with_progress(Some(50), Some(2), true, |_| {}).unwrap();
@@ -1010,7 +1017,7 @@ fn force_reconcile_progress_is_honest_and_terminates_without_limit() {
          eligibility and useful semantic context\n",
     );
     let db = IndexDatabase::rebuild(&config).unwrap();
-    db.install_model(ai::HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID).unwrap();
 
     // No --limit. max_seconds is only a safety net: if the force loop regressed to
     // re-embedding forever it would trip max_seconds and report "Partial" rather than
@@ -1057,7 +1064,7 @@ fn status_counts_only_active_context_chunks() {
          eligibility and useful semantic context\n",
     );
     let mut db = IndexDatabase::rebuild(&config).unwrap();
-    db.install_model(ai::HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID).unwrap();
 
     let active = db.local_ai_status().unwrap().artifacts.total_chunks;
     assert!(active > 0, "expected active chunks, got {active}");
@@ -1156,7 +1163,7 @@ fn gc_prunes_dead_context_rows_and_keeps_live_ones() {
          eligibility and useful semantic context\n",
     );
     let db = IndexDatabase::rebuild(&config).unwrap();
-    db.install_model(ai::HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID).unwrap();
     db.reconcile(None, Some(8)).unwrap();
 
     let live_files = table_row_count(db.storage.connection(), "files").unwrap();
@@ -1236,7 +1243,7 @@ int main(void)
     .unwrap();
     let config = source_config(root.clone(), Language::C);
     let db = IndexDatabase::rebuild(&config).unwrap();
-    db.install_model(ai::HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID).unwrap();
 
     let plan = db.reconcile_plan().unwrap();
 
@@ -1253,7 +1260,7 @@ int main(void)
 fn reconcile_policy_skips_tiny_chunks_before_embedding() {
     let (root, config) = markdown_config("tiny\n");
     let db = IndexDatabase::rebuild(&config).unwrap();
-    db.install_model(ai::HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID).unwrap();
 
     let plan = db.reconcile_plan().unwrap();
     assert_eq!(plan.embeddings.missing, 0);
@@ -1262,7 +1269,7 @@ fn reconcile_policy_skips_tiny_chunks_before_embedding() {
     let report = db.reconcile(None, Some(8)).unwrap();
     assert_eq!(report.embeddings_written, 0);
     assert_eq!(report.skipped_by_policy.get("SkipTooSmall"), Some(&1));
-    assert_eq!(db.current_embedding_count(ai::HASH_MODEL_ID).unwrap(), 0);
+    assert_eq!(db.current_embedding_count(HASH_MODEL_ID).unwrap(), 0);
 
     let _ = fs::remove_dir_all(root);
 }
@@ -1277,7 +1284,7 @@ fn reconcile_plan_reports_policy_skips_for_fastembed_model() {
             "UPDATE ai_models
                  SET installed = 1, disabled = 0, status = 'Ready', embedding_dim = ?2
                  WHERE model_id = ?1",
-            params![ai::FASTEMBED_MODEL_ID, i64::try_from(ai::FASTEMBED_EMBEDDING_DIM).unwrap()],
+            params![FASTEMBED_MODEL_ID, i64::try_from(FASTEMBED_EMBEDDING_DIM).unwrap()],
         )
         .unwrap();
     db.storage
@@ -1285,13 +1292,13 @@ fn reconcile_plan_reports_policy_skips_for_fastembed_model() {
         .execute(
             "INSERT INTO index_meta(key, value) VALUES ('active_embedding_model', ?1)
                  ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-            [ai::FASTEMBED_MODEL_ID],
+            [FASTEMBED_MODEL_ID],
         )
         .unwrap();
 
     let plan = db.reconcile_plan().unwrap();
 
-    assert_eq!(plan.embeddings.model_id, ai::FASTEMBED_MODEL_ID);
+    assert_eq!(plan.embeddings.model_id, FASTEMBED_MODEL_ID);
     assert_eq!(plan.embeddings.missing, 0);
     assert_eq!(plan.embeddings.skipped_by_policy.get("SkipTooSmall"), Some(&1));
 
@@ -1308,7 +1315,7 @@ fn blocked_fastembed_reconcile_still_reports_policy_skips() {
         .execute(
             "INSERT INTO index_meta(key, value) VALUES ('active_embedding_model', ?1)
                  ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-            [ai::FASTEMBED_MODEL_ID],
+            [FASTEMBED_MODEL_ID],
         )
         .unwrap();
 
@@ -1327,7 +1334,7 @@ fn search_explain_reports_weighted_score_components() {
          semantic vector scoring\nthird line\n",
     );
     let db = IndexDatabase::rebuild(&config).unwrap();
-    db.install_model(ai::HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID).unwrap();
     db.reconcile(None, Some(8)).unwrap();
 
     let hits = db.search_explain("runtime shutdown", 10, false).unwrap();
@@ -8200,7 +8207,7 @@ fn refresh_worktree_overlays_reconciles_overlay_scope_embeddings() {
     run_git(&main, &["commit", "-q", "-m", "base"]);
     let config = source_config(main.clone(), Language::Rust);
     let mut db = IndexDatabase::rebuild(&config).unwrap();
-    db.install_model(ai::HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID).unwrap();
     db.reconcile(None, Some(8)).unwrap();
 
     let linked = unique_temp_root();
@@ -8741,7 +8748,7 @@ fn worktree_overlay_pending_embeddings_are_detectable_for_retry() {
     run_git(&main, &["commit", "-q", "-m", "base"]);
     let config = source_config(main.clone(), Language::Rust);
     let mut db = IndexDatabase::rebuild(&config).unwrap();
-    db.install_model(ai::HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID).unwrap();
     // The base has at least one embeddable chunk before reconcile (so the test isn't vacuous)...
     set_base_scope(&mut db, &main);
     assert!(db.pending_embedding_jobs().unwrap() > 0, "base has an embeddable chunk to begin with");

--- a/crates/rag-rat-core/src/lib.rs
+++ b/crates/rag-rat-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod dream;
+pub mod embedding_models;
 #[cfg(feature = "eval")]
 pub mod eval;
 pub mod fleet;


### PR DESCRIPTION
Supersedes #308 (BGE alone): the registry refactor here rewrites BGE's wiring, so BGE ships as one registry row alongside jina rather than as its own change.

## What
- New crate-root `embedding_models` module — a single `EMBEDDING_MODELS` table, one row per model (`model_id`, `display`, `dim`, `version`, `backend`, toml `aliases`, `query_prefix`) + `spec()` / `spec_for_alias()`.
- Adds **bge-small-en-v1.5** (384-dim, general) and **jina-v2-base-code** (768-dim, code-specific) as selectable embedders: `[local_ai.embedding] model = "bge"` / `"jina"` in `rag-rat.toml`.
- **MiniLM stays the default** — see the measurement below.

## Why a registry
Adding one model (jina) previously meant editing ~10 scattered match arms across 4 files, plus a *separate* hardcoded model list in `config` — so a model could half-wire (install `Ready`, embed nothing) if you missed an arm. Now every former arm reads the table:

| was scattered across… | now |
|---|---|
| `expected_dim`, `default_model_version` | `spec(id)` |
| `active_embedder` + 4 factory fns | one `embedder_for_spec(spec)` |
| 3× `FastEmbedEmbedder::new_*` | one `for_model_id` (the lone unavoidable fastembed-enum match) |
| `ensure_model_manifest`, `model_manifest_is_current` | iterate the table |
| `install_model`, status reporting | dispatch on `spec().backend` |
| config `EmbeddingBackend` (separate hardcoded list) | resolves any alias via `spec_for_alias` |

Net **−77 lines**. The module lives at the crate root (not under `index/ai`) so `config` resolves the selector without depending on `index`. Adding the next model (e.g. CodeRankEmbed) is one row + (for asymmetric models) its `query_prefix` — the hook is already plumbed.

## Measured: no drop-in embedder beats MiniLM
Clean A/B on the commit-replay eval harness (#120) — all three at the same at-head index, `--replay-max-cases 40`:

| model | recall@10 | mrr@10 | path_hit |
|---|---|---|---|
| all-MiniLM-L6-v2 (384, general) | **0.611** | 0.860 | 0.300 |
| bge-small-en-v1.5 (384, general) | 0.612 | 0.863 | 0.325 |
| jina-v2-base-code (768, code) | 0.592 | 0.879 | 0.275 |

All within noise (0.02 spread on 40 cases is <1 case). A code-specific 768-dim model doesn't beat general MiniLM here — likely because the replay queries are commit messages (NL, not code) and chunks carry a `path/language/kind` preamble that dilutes code-specialization. So BGE + jina ship as **options**, not the default. The real retrieval lever is the reranker (#109), which reorders the candidate set with graph/PageRank/git-recency signals no embedder has.

## Verification
- `cargo build` (default + `--no-default-features`) + `--workspace`: clean
- `cargo nextest run -p rag-rat-core`: 910 passed · `-p rag-rat`: 109 passed
- `cargo clippy --all-targets` + `cargo +nightly fmt`: clean
- The #143 write-lock-on-open fix is preserved — `model_manifest_is_current` still gates `ensure_model_manifest`, and its guard test passes.

Refs #112, #120, #109.
