### PR TITLE
feat(eval): recall@3 + recall@returned ceiling metrics; graded-git rerank (off) — #109 spike

### DIFF
--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -346,6 +346,12 @@ pub(crate) struct EvalArgs {
     /// `--replay`.
     #[arg(long)]
     pub replay_parent_state: bool,
+    /// Run searches with the graded-git rerank ON (#109): scores the SAME at-head index with
+    /// `[search] graded_git_rerank` forced true, for an A/B against the default fuse. Applies to
+    /// both the active and the hash-vector-baseline pass. Pair with `--replay` for the inner-loop
+    /// dial (`rag-rat eval --replay --rerank`).
+    #[arg(long)]
+    pub rerank: bool,
 }
 
 #[derive(Debug, Args)]

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -352,6 +352,13 @@ pub(crate) struct EvalArgs {
     /// dial (`rag-rat eval --replay --rerank`).
     #[arg(long)]
     pub rerank: bool,
+    /// How many hits each search returns — the width of the candidate pool scored (#109). Default
+    /// 10 (unchanged behavior). `recall@3`/`recall@10` stay FIXED top-3/top-10 cutoffs regardless;
+    /// widening this only grows `recall_at_returned`, the candidate-recall ceiling. At 100 it
+    /// measures recall@100 ≈ the candidate-generation ceiling — pure measurement, no search
+    /// change.
+    #[arg(long, default_value_t = 10)]
+    pub search_limit: usize,
 }
 
 #[derive(Debug, Args)]

--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -447,6 +447,7 @@ pub(crate) fn eval(config: &Config, args: &EvalArgs) -> anyhow::Result<()> {
             max_files: args.replay_max_files,
         }),
         rerank: args.rerank,
+        search_limit: args.search_limit,
     };
     let report = rag_rat_core::eval::run(config, &options)?;
     // `eval` prints a greppable human summary by default; the global `--json` (or a baseline

--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -446,6 +446,7 @@ pub(crate) fn eval(config: &Config, args: &EvalArgs) -> anyhow::Result<()> {
             max_cases: args.replay_max_cases,
             max_files: args.replay_max_files,
         }),
+        rerank: args.rerank,
     };
     let report = rag_rat_core::eval::run(config, &options)?;
     // `eval` prints a greppable human summary by default; the global `--json` (or a baseline
@@ -1125,6 +1126,7 @@ mod tests {
             watch: Default::default(),
             version_check: Default::default(),
             oracle: Default::default(),
+            search: Default::default(),
         };
         IndexDatabase::rebuild(&config).unwrap();
 
@@ -1230,6 +1232,7 @@ mod tests {
             watch: Default::default(),
             version_check: Default::default(),
             oracle: Default::default(),
+            search: Default::default(),
         };
         IndexDatabase::rebuild(&config).unwrap();
 
@@ -1293,6 +1296,7 @@ mod tests {
             watch: Default::default(),
             version_check: Default::default(),
             oracle: Default::default(),
+            search: Default::default(),
         };
         IndexDatabase::rebuild(&config).unwrap();
 

--- a/crates/rag-rat-cli/src/commands/oracle.rs
+++ b/crates/rag-rat-cli/src/commands/oracle.rs
@@ -478,6 +478,7 @@ mod tests {
             watch: Default::default(),
             version_check: Default::default(),
             oracle: Default::default(),
+            search: Default::default(),
         };
         (root, config)
     }
@@ -522,6 +523,7 @@ mod tests {
             watch: Default::default(),
             version_check: Default::default(),
             oracle: Default::default(),
+            search: Default::default(),
         };
         let config = config_with(vec!["**/*.rs".to_string()], Vec::new());
         let profile = |dirs: &[&str]| {

--- a/crates/rag-rat-cli/src/render.rs
+++ b/crates/rag-rat-cli/src/render.rs
@@ -4,13 +4,14 @@ use super::*;
 pub(crate) fn print_eval_summary(report: &rag_rat_core::eval::EvalReport) {
     println!(
         "eval: pass={} queries={} skipped={} mrr@10={:.3} recall@10={:.3} recall@3={:.3} \
-         path_hit_rate={:.3} symbol_hit_rate={:.3}",
+         recall@returned={:.3} path_hit_rate={:.3} symbol_hit_rate={:.3}",
         report.pass,
         report.queries,
         report.results.iter().filter(|result| result.skipped).count(),
         report.metrics.mrr_at_10,
         report.metrics.recall_at_10,
         report.metrics.recall_at_3,
+        report.metrics.recall_at_returned,
         report.metrics.path_hit_rate,
         report.metrics.symbol_hit_rate
     );
@@ -45,17 +46,19 @@ pub(crate) fn print_eval_summary(report: &rag_rat_core::eval::EvalReport) {
     }
     println!(
         "eval: hash_vector_baseline model={} available={} current_artifacts={} mrr@10={:.3} \
-         recall@10={:.3} recall@3={:.3} delta_mrr@10={:+.3} delta_recall@10={:+.3} \
-         delta_recall@3={:+.3}",
+         recall@10={:.3} recall@3={:.3} recall@returned={:.3} delta_mrr@10={:+.3} \
+         delta_recall@10={:+.3} delta_recall@3={:+.3} delta_recall@returned={:+.3}",
         report.hash_vector_baseline.model_id,
         report.hash_vector_baseline.available,
         report.hash_vector_baseline.current_artifacts,
         report.hash_vector_baseline.metrics.mrr_at_10,
         report.hash_vector_baseline.metrics.recall_at_10,
         report.hash_vector_baseline.metrics.recall_at_3,
+        report.hash_vector_baseline.metrics.recall_at_returned,
         report.hash_vector_baseline.delta_mrr_at_10,
         report.hash_vector_baseline.delta_recall_at_10,
-        report.hash_vector_baseline.delta_recall_at_3
+        report.hash_vector_baseline.delta_recall_at_3,
+        report.hash_vector_baseline.delta_recall_at_returned
     );
     for result in report.results.iter().filter(|result| !result.passed) {
         println!(

--- a/crates/rag-rat-cli/src/render.rs
+++ b/crates/rag-rat-cli/src/render.rs
@@ -3,13 +3,14 @@ use super::*;
 #[cfg(feature = "eval")]
 pub(crate) fn print_eval_summary(report: &rag_rat_core::eval::EvalReport) {
     println!(
-        "eval: pass={} queries={} skipped={} mrr@10={:.3} recall@10={:.3} path_hit_rate={:.3} \
-         symbol_hit_rate={:.3}",
+        "eval: pass={} queries={} skipped={} mrr@10={:.3} recall@10={:.3} recall@3={:.3} \
+         path_hit_rate={:.3} symbol_hit_rate={:.3}",
         report.pass,
         report.queries,
         report.results.iter().filter(|result| result.skipped).count(),
         report.metrics.mrr_at_10,
         report.metrics.recall_at_10,
+        report.metrics.recall_at_3,
         report.metrics.path_hit_rate,
         report.metrics.symbol_hit_rate
     );
@@ -44,14 +45,17 @@ pub(crate) fn print_eval_summary(report: &rag_rat_core::eval::EvalReport) {
     }
     println!(
         "eval: hash_vector_baseline model={} available={} current_artifacts={} mrr@10={:.3} \
-         recall@10={:.3} delta_mrr@10={:+.3} delta_recall@10={:+.3}",
+         recall@10={:.3} recall@3={:.3} delta_mrr@10={:+.3} delta_recall@10={:+.3} \
+         delta_recall@3={:+.3}",
         report.hash_vector_baseline.model_id,
         report.hash_vector_baseline.available,
         report.hash_vector_baseline.current_artifacts,
         report.hash_vector_baseline.metrics.mrr_at_10,
         report.hash_vector_baseline.metrics.recall_at_10,
+        report.hash_vector_baseline.metrics.recall_at_3,
         report.hash_vector_baseline.delta_mrr_at_10,
-        report.hash_vector_baseline.delta_recall_at_10
+        report.hash_vector_baseline.delta_recall_at_10,
+        report.hash_vector_baseline.delta_recall_at_3
     );
     for result in report.results.iter().filter(|result| !result.passed) {
         println!(

--- a/crates/rag-rat-core/benches/shared/mod.rs
+++ b/crates/rag-rat-core/benches/shared/mod.rs
@@ -67,6 +67,7 @@ pub fn bench_config(subdir: &str) -> Config {
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     }
 }
 

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -18,6 +18,18 @@ pub struct Config {
     pub watch: WatchConfig,
     pub version_check: VersionCheckConfig,
     pub oracle: OracleConfig,
+    pub search: SearchConfig,
+}
+
+/// Search-ranking knobs (`[search]`). Default OFF so the shipped fuse is byte-identical to today;
+/// opt in per-repo via `rag-rat.toml`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SearchConfig {
+    /// Replace the binary git has-history boost with a graded recency+churn magnitude and add the
+    /// generated/test demotion at the wide-pool rerank site (default false — opt in explicitly).
+    /// A/B-swept on the commit-replay eval (`rag-rat eval --replay --rerank`); see
+    /// [`crate::search::lexical::SearchOptions::graded_history`].
+    pub graded_git_rerank: bool,
 }
 
 /// Background auto-fresh oracle (`[oracle]`). Opt-in; default OFF. When `auto_run` is enabled, the
@@ -357,8 +369,9 @@ impl Config {
         let watch = raw.watch.into();
         let version_check = raw.version_check.into();
         let oracle = raw.oracle.into();
+        let search = raw.search.into();
 
-        Ok(Self { root, database, targets, local_ai, watch, version_check, oracle })
+        Ok(Self { root, database, targets, local_ai, watch, version_check, oracle, search })
     }
 }
 
@@ -516,6 +529,8 @@ struct RawConfig {
     #[serde(default)]
     oracle: RawOracle,
     #[serde(default)]
+    search: RawSearch,
+    #[serde(default)]
     target_bindings: BTreeMap<String, Vec<String>>,
     #[serde(default, rename = "target")]
     target: Vec<RawTarget>,
@@ -570,6 +585,21 @@ impl From<RawOracle> for OracleConfig {
             auto_run_min_interval_secs: raw
                 .auto_run_min_interval_secs
                 .unwrap_or(default.auto_run_min_interval_secs),
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawSearch {
+    graded_git_rerank: Option<bool>,
+}
+
+impl From<RawSearch> for SearchConfig {
+    fn from(raw: RawSearch) -> Self {
+        Self {
+            graded_git_rerank: raw
+                .graded_git_rerank
+                .unwrap_or(SearchConfig::default().graded_git_rerank),
         }
     }
 }
@@ -1025,6 +1055,18 @@ mod tests {
             toml::from_str("[index]\nroot = \".\"\n\n[version_check]\nenabled = false\n").unwrap();
         let version_check: VersionCheckConfig = raw.version_check.into();
         assert!(!version_check.enabled, "[version_check] enabled = false opts out");
+    }
+
+    #[test]
+    fn search_defaults_off_and_parses_opt_in() {
+        let default: SearchConfig = RawSearch::default().into();
+        assert!(!default.graded_git_rerank, "graded git rerank is OFF by default");
+
+        let raw: RawConfig =
+            toml::from_str("[index]\nroot = \".\"\n\n[search]\ngraded_git_rerank = true\n")
+                .unwrap();
+        let search: SearchConfig = raw.search.into();
+        assert!(search.graded_git_rerank, "[search] graded_git_rerank = true opts in");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/eval.rs
+++ b/crates/rag-rat-core/src/eval.rs
@@ -93,6 +93,13 @@ pub struct EvalOptions {
     /// hash-vector-baseline search so the delta block compares reranked-vs-reranked (same axis),
     /// never reranked-vs-unreranked. Default false → today's fuse.
     pub rerank: bool,
+    /// How many hits each `db.search` returns — the width of the candidate pool the eval scores
+    /// (#109, `--search-limit`). Default [`TOP_K`] (=10), so a plain run is unchanged. The fixed
+    /// `recall_at_3`/`recall_at_10` cutoffs are independent of this (they slice the first 3/10
+    /// hits); widening it only grows `recall_at_returned`. At 100 it measures recall@100 ≈ the
+    /// candidate-generation ceiling (of the gold, what fraction appears ANYWHERE in a wide set),
+    /// which separates the ranking lever from the generation lever — no search behavior change.
+    pub search_limit: usize,
 }
 
 /// Commit-replay eval knobs (#120).
@@ -136,6 +143,7 @@ pub struct EvalBaselineReport {
     pub delta_mrr_at_10: f64,
     pub delta_recall_at_10: f64,
     pub delta_recall_at_3: f64,
+    pub delta_recall_at_returned: f64,
     pub delta_path_hit_rate: f64,
     pub delta_symbol_hit_rate: f64,
 }
@@ -145,6 +153,11 @@ pub struct EvalMetrics {
     pub mrr_at_10: f64,
     pub recall_at_10: f64,
     pub recall_at_3: f64,
+    /// Path/symbol recall membership (same predicates as `recall_at_10`) measured over the ENTIRE
+    /// returned `hits` slice rather than a fixed cutoff — the candidate-recall ceiling for the
+    /// configured `search_limit`. `recall_at_10 <= recall_at_returned` always (top-10 ⊆ returned);
+    /// at `--search-limit 100` this is recall@100 ≈ the generation ceiling (#109).
+    pub recall_at_returned: f64,
     pub path_hit_rate: f64,
     pub symbol_hit_rate: f64,
     pub graph_evidence_hit_rate: f64,
@@ -170,6 +183,10 @@ pub struct EvalQueryReport {
     pub reciprocal_rank_at_10: f64,
     pub recall_at_10: f64,
     pub recall_at_3: f64,
+    /// Same path/symbol recall membership as `recall_at_10`, but over the WHOLE returned `hits`
+    /// slice (no fixed cutoff). `recall_at_10 <= recall_at_returned`; the ceiling at a wide
+    /// `search_limit` (#109).
+    pub recall_at_returned: f64,
     pub path_hits: Vec<String>,
     pub missing_paths: Vec<String>,
     pub symbol_hits: Vec<String>,
@@ -229,7 +246,14 @@ pub fn run(config: &Config, options: &EvalOptions) -> anyhow::Result<EvalReport>
     for query in &suite.query {
         let expected_query = expected.get(&query.id);
         let merged = merge_expected(query.clone(), expected_query);
-        let report = evaluate_query(config, &db, &merged, SearchMode::Active, options.rerank)?;
+        let report = evaluate_query(
+            config,
+            &db,
+            &merged,
+            SearchMode::Active,
+            options.rerank,
+            options.search_limit,
+        )?;
         observed.push(observed_expected(&report));
         results.push(report);
     }
@@ -239,8 +263,15 @@ pub fn run(config: &Config, options: &EvalOptions) -> anyhow::Result<EvalReport>
     }
 
     let metrics = aggregate(&results);
-    let baseline =
-        hash_vector_baseline(config, &db, &suite.query, &expected, &metrics, options.rerank)?;
+    let baseline = hash_vector_baseline(
+        config,
+        &db,
+        &suite.query,
+        &expected,
+        &metrics,
+        options.rerank,
+        options.search_limit,
+    )?;
     let oracle_eval = run_oracle_eval(&db, options)?;
     let (oracle, oracle_skipped_drifted) = match oracle_eval {
         Some((metrics, skipped_drifted)) => (Some(metrics), skipped_drifted),
@@ -397,8 +428,9 @@ fn score_case_at_parent(
         query.must_include_paths = existing_gold;
         query.must_include_symbols = symbol_gold.into_iter().collect();
         // Parent-state replay is the leakage-free HEADLINE number, not the reranker A/B dial (that
-        // is HEAD-scored `--replay --rerank`); score it with the default fuse (rerank off).
-        evaluate_query(&case_config, &case_db, &query, SearchMode::Active, false)?
+        // is HEAD-scored `--replay --rerank`); score it with the default fuse (rerank off) and the
+        // default `TOP_K` candidate width (the candidate-ceiling dial is HEAD-scored).
+        evaluate_query(&case_config, &case_db, &query, SearchMode::Active, false, TOP_K)?
     };
     let _ = std::fs::remove_file(&case_config.database);
     Ok(Some(report))
@@ -595,6 +627,7 @@ fn evaluate_query(
     query: &EvalQuery,
     mode: SearchMode,
     rerank: bool,
+    search_limit: usize,
 ) -> anyhow::Result<EvalQueryReport> {
     if query.requires_papertrail_cache && !papertrail_cache_available(db)? {
         return Ok(skipped_report(
@@ -604,12 +637,12 @@ fn evaluate_query(
     }
 
     let started = Instant::now();
-    let mut hits = search(db, mode, &query.text, rerank)?;
+    let mut hits = search(db, mode, &query.text, rerank, search_limit)?;
     let mut latency_ms = started.elapsed().as_secs_f64() * 1000.0;
     let mut current_source_violations = find_current_source_violations(config, db, &hits)?;
     if !current_source_violations.is_empty() {
         let retry_started = Instant::now();
-        hits = search(db, mode, &query.text, rerank)?;
+        hits = search(db, mode, &query.text, rerank, search_limit)?;
         latency_ms += retry_started.elapsed().as_secs_f64() * 1000.0;
         current_source_violations = find_current_source_violations(config, db, &hits)?;
     }
@@ -724,9 +757,36 @@ fn evaluate_query(
     let relevant_rank = hits.iter().position(|hit| relevant(hit, query)).map(|rank| rank + 1);
     let reciprocal_rank_at_10 = relevant_rank.map(|rank| 1.0 / rank as f64).unwrap_or(0.0);
     let expected_relevant = query.must_include_paths.len() + query.must_include_symbols.len();
+    // `path_hits`/`symbol_hits` test membership over the WHOLE returned `hits` slice, so this is
+    // the candidate-recall ceiling for the configured `search_limit` (recall over the full
+    // returned list, no fixed cutoff). At `search_limit = TOP_K` it equals `recall_at_10`
+    // below; widening the limit can only grow it, so `recall_at_10 <= recall_at_returned`
+    // always holds.
     let found_relevant = path_hits.len() + symbol_hits.len();
-    let recall_at_10 =
+    let recall_at_returned =
         if expected_relevant == 0 { 1.0 } else { found_relevant as f64 / expected_relevant as f64 };
+    // recall@10 fixes the cutoff at the first 10 hits regardless of `search_limit` — slicing the
+    // SAME membership predicates over `hits[..10]` keeps its meaning stable even at a wide limit.
+    let top10 = &hits[..TOP_K.min(hits.len())];
+    let found_relevant_at_10 = query
+        .must_include_paths
+        .iter()
+        .filter(|expected| top10.iter().any(|hit| hit.path == **expected))
+        .count()
+        + query
+            .must_include_symbols
+            .iter()
+            .filter(|expected| {
+                top10.iter().filter_map(|hit| hit.symbol_path.as_deref()).any(|symbol| {
+                    symbol == expected.as_str() || symbol.ends_with(expected.as_str())
+                })
+            })
+            .count();
+    let recall_at_10 = if expected_relevant == 0 {
+        1.0
+    } else {
+        found_relevant_at_10 as f64 / expected_relevant as f64
+    };
     // recall@3 reuses the identical path/symbol membership predicates as recall@10 above; the only
     // difference is the slice — membership is tested over the first 3 hits, not the full top-10.
     // A within-top-10 reorder (the reranker A/B target) moves this but not recall@10.
@@ -769,6 +829,7 @@ fn evaluate_query(
         reciprocal_rank_at_10,
         recall_at_10,
         recall_at_3,
+        recall_at_returned,
         path_hits,
         missing_paths,
         symbol_hits,
@@ -803,6 +864,7 @@ fn skipped_report(query: &EvalQuery, reason: impl Into<String>) -> EvalQueryRepo
         reciprocal_rank_at_10: 0.0,
         recall_at_10: 1.0,
         recall_at_3: 1.0,
+        recall_at_returned: 1.0,
         path_hits: Vec::new(),
         missing_paths: Vec::new(),
         symbol_hits: Vec::new(),
@@ -843,10 +905,14 @@ fn search(
     mode: SearchMode,
     query: &str,
     rerank: bool,
+    search_limit: usize,
 ) -> anyhow::Result<Vec<crate::search::lexical::SearchHit>> {
     // `rerank` flows identically into BOTH search modes so the active-vs-baseline delta compares
     // the same reranker axis (#109). The active path threads it through
-    // `SearchRequest.options`; the hash baseline takes it directly.
+    // `SearchRequest.options`; the hash baseline takes it directly. `search_limit` is the width of
+    // the candidate pool both modes return (default `TOP_K`); it never changes the fixed
+    // `recall_at_3`/`recall_at_10` cutoffs — only the `recall_at_returned` ceiling.
+    let limit = u32::try_from(search_limit).unwrap_or(u32::MAX);
     match mode {
         SearchMode::Active => db.search_with_graph_meta(crate::index::SearchRequest {
             include_generated: false,
@@ -854,9 +920,9 @@ fn search(
                 graded_history: rerank,
                 ..crate::search::lexical::SearchOptions::default()
             },
-            ..crate::index::SearchRequest::new(query, TOP_K as u32)
+            ..crate::index::SearchRequest::new(query, limit)
         }),
-        SearchMode::HashBaseline => db.search_hash_baseline(query, TOP_K as u32, false, rerank),
+        SearchMode::HashBaseline => db.search_hash_baseline(query, limit, false, rerank),
     }
 }
 
@@ -867,12 +933,21 @@ fn hash_vector_baseline(
     expected: &BTreeMap<String, ExpectedQuery>,
     active_metrics: &EvalMetrics,
     rerank: bool,
+    search_limit: usize,
 ) -> anyhow::Result<EvalBaselineReport> {
     let mut results = Vec::new();
     for query in queries {
         let merged = merge_expected(query.clone(), expected.get(&query.id));
-        // SAME `rerank` value as the active pass so the delta block compares the same axis (#109).
-        results.push(evaluate_query(config, db, &merged, SearchMode::HashBaseline, rerank)?);
+        // SAME `rerank` value AND `search_limit` as the active pass so the delta block compares the
+        // same axes (#109).
+        results.push(evaluate_query(
+            config,
+            db,
+            &merged,
+            SearchMode::HashBaseline,
+            rerank,
+            search_limit,
+        )?);
     }
     let metrics = aggregate(&results);
     let current_artifacts = db.current_embedding_count(crate::embedding_models::HASH_MODEL_ID)?;
@@ -883,6 +958,7 @@ fn hash_vector_baseline(
         delta_mrr_at_10: active_metrics.mrr_at_10 - metrics.mrr_at_10,
         delta_recall_at_10: active_metrics.recall_at_10 - metrics.recall_at_10,
         delta_recall_at_3: active_metrics.recall_at_3 - metrics.recall_at_3,
+        delta_recall_at_returned: active_metrics.recall_at_returned - metrics.recall_at_returned,
         delta_path_hit_rate: active_metrics.path_hit_rate - metrics.path_hit_rate,
         delta_symbol_hit_rate: active_metrics.symbol_hit_rate - metrics.symbol_hit_rate,
         metrics,
@@ -1019,6 +1095,8 @@ fn aggregate(results: &[EvalQueryReport]) -> EvalMetrics {
         mrr_at_10: measured.iter().map(|r| r.reciprocal_rank_at_10).sum::<f64>() / query_count,
         recall_at_10: measured.iter().map(|r| r.recall_at_10).sum::<f64>() / query_count,
         recall_at_3: measured.iter().map(|r| r.recall_at_3).sum::<f64>() / query_count,
+        recall_at_returned: measured.iter().map(|r| r.recall_at_returned).sum::<f64>()
+            / query_count,
         path_hit_rate: hit_rate(&measured, |r| r.missing_paths.is_empty()),
         symbol_hit_rate: hit_rate(&measured, |r| r.missing_symbols.is_empty()),
         graph_evidence_hit_rate: expected_hit_rate(&measured, |r| {
@@ -1188,6 +1266,7 @@ mod tests {
             scip_path: None,
             replay: None,
             rerank: false,
+            search_limit: TOP_K,
         })
         .unwrap();
         // Safety + non-zero retrieval hold in every build shape.
@@ -1195,9 +1274,11 @@ mod tests {
         assert!(report.metrics.mrr_at_10 > 0.0);
         assert!(report.metrics.recall_at_10 > 0.0);
 
-        // recall@3 measures membership over the first 3 hits, recall@10 over all 10; the top-3 is a
-        // subset of the top-10, so recall@3 can never exceed recall@10 — neither per query nor in
-        // the aggregate mean. A regression here means recall@3 stopped slicing the same hit list.
+        // recall@3 measures membership over the first 3 hits, recall@10 over all 10, and
+        // recall_at_returned over the WHOLE returned list; top-3 ⊆ top-10 ⊆ returned, so the chain
+        // recall@3 <= recall@10 <= recall_at_returned can never invert — neither per query nor in
+        // the aggregate mean. A regression here means a recall metric stopped slicing the same hit
+        // list (or the limit leaked into a fixed cutoff's meaning).
         for result in report.results.iter().filter(|result| !result.skipped) {
             assert!(
                 result.recall_at_3 <= result.recall_at_10,
@@ -1206,8 +1287,16 @@ mod tests {
                 result.recall_at_3,
                 result.recall_at_10,
             );
+            assert!(
+                result.recall_at_10 <= result.recall_at_returned,
+                "{}: recall@10 ({}) exceeded recall_at_returned ({})",
+                result.id,
+                result.recall_at_10,
+                result.recall_at_returned,
+            );
         }
         assert!(report.metrics.recall_at_3 <= report.metrics.recall_at_10);
+        assert!(report.metrics.recall_at_10 <= report.metrics.recall_at_returned);
 
         // The full hand-authored `must_include_*` baseline is the hard gate ONLY with an embedding
         // backend. Some expectations (the const-arrow hook by name, the graph-neighbor query)
@@ -1294,6 +1383,7 @@ mod tests {
             scip_path: Some(scip_path),
             replay: None,
             rerank: false,
+            search_limit: TOP_K,
         })
         .unwrap();
 

--- a/crates/rag-rat-core/src/eval.rs
+++ b/crates/rag-rat-core/src/eval.rs
@@ -88,6 +88,11 @@ pub struct EvalOptions {
     /// from the indexed git history (commit message = query, diff's changed paths = recall
     /// gold). `None` uses the static `queries_path` suite.
     pub replay: Option<ReplayOptions>,
+    /// Run searches with the graded-git rerank ON (#109, `--rerank`): scores the SAME at-head
+    /// index with `SearchOptions::graded_history = true`. Applied to BOTH the active AND the
+    /// hash-vector-baseline search so the delta block compares reranked-vs-reranked (same axis),
+    /// never reranked-vs-unreranked. Default false → today's fuse.
+    pub rerank: bool,
 }
 
 /// Commit-replay eval knobs (#120).
@@ -224,7 +229,7 @@ pub fn run(config: &Config, options: &EvalOptions) -> anyhow::Result<EvalReport>
     for query in &suite.query {
         let expected_query = expected.get(&query.id);
         let merged = merge_expected(query.clone(), expected_query);
-        let report = evaluate_query(config, &db, &merged, SearchMode::Active)?;
+        let report = evaluate_query(config, &db, &merged, SearchMode::Active, options.rerank)?;
         observed.push(observed_expected(&report));
         results.push(report);
     }
@@ -234,7 +239,8 @@ pub fn run(config: &Config, options: &EvalOptions) -> anyhow::Result<EvalReport>
     }
 
     let metrics = aggregate(&results);
-    let baseline = hash_vector_baseline(config, &db, &suite.query, &expected, &metrics)?;
+    let baseline =
+        hash_vector_baseline(config, &db, &suite.query, &expected, &metrics, options.rerank)?;
     let oracle_eval = run_oracle_eval(&db, options)?;
     let (oracle, oracle_skipped_drifted) = match oracle_eval {
         Some((metrics, skipped_drifted)) => (Some(metrics), skipped_drifted),
@@ -390,7 +396,9 @@ fn score_case_at_parent(
         }
         query.must_include_paths = existing_gold;
         query.must_include_symbols = symbol_gold.into_iter().collect();
-        evaluate_query(&case_config, &case_db, &query, SearchMode::Active)?
+        // Parent-state replay is the leakage-free HEADLINE number, not the reranker A/B dial (that
+        // is HEAD-scored `--replay --rerank`); score it with the default fuse (rerank off).
+        evaluate_query(&case_config, &case_db, &query, SearchMode::Active, false)?
     };
     let _ = std::fs::remove_file(&case_config.database);
     Ok(Some(report))
@@ -586,6 +594,7 @@ fn evaluate_query(
     db: &IndexDatabase,
     query: &EvalQuery,
     mode: SearchMode,
+    rerank: bool,
 ) -> anyhow::Result<EvalQueryReport> {
     if query.requires_papertrail_cache && !papertrail_cache_available(db)? {
         return Ok(skipped_report(
@@ -595,12 +604,12 @@ fn evaluate_query(
     }
 
     let started = Instant::now();
-    let mut hits = search(db, mode, &query.text)?;
+    let mut hits = search(db, mode, &query.text, rerank)?;
     let mut latency_ms = started.elapsed().as_secs_f64() * 1000.0;
     let mut current_source_violations = find_current_source_violations(config, db, &hits)?;
     if !current_source_violations.is_empty() {
         let retry_started = Instant::now();
-        hits = search(db, mode, &query.text)?;
+        hits = search(db, mode, &query.text, rerank)?;
         latency_ms += retry_started.elapsed().as_secs_f64() * 1000.0;
         current_source_violations = find_current_source_violations(config, db, &hits)?;
     }
@@ -833,10 +842,21 @@ fn search(
     db: &IndexDatabase,
     mode: SearchMode,
     query: &str,
+    rerank: bool,
 ) -> anyhow::Result<Vec<crate::search::lexical::SearchHit>> {
+    // `rerank` flows identically into BOTH search modes so the active-vs-baseline delta compares
+    // the same reranker axis (#109). The active path threads it through
+    // `SearchRequest.options`; the hash baseline takes it directly.
     match mode {
-        SearchMode::Active => db.search(query, TOP_K as u32, false),
-        SearchMode::HashBaseline => db.search_hash_baseline(query, TOP_K as u32, false),
+        SearchMode::Active => db.search_with_graph_meta(crate::index::SearchRequest {
+            include_generated: false,
+            options: crate::search::lexical::SearchOptions {
+                graded_history: rerank,
+                ..crate::search::lexical::SearchOptions::default()
+            },
+            ..crate::index::SearchRequest::new(query, TOP_K as u32)
+        }),
+        SearchMode::HashBaseline => db.search_hash_baseline(query, TOP_K as u32, false, rerank),
     }
 }
 
@@ -846,11 +866,13 @@ fn hash_vector_baseline(
     queries: &[EvalQuery],
     expected: &BTreeMap<String, ExpectedQuery>,
     active_metrics: &EvalMetrics,
+    rerank: bool,
 ) -> anyhow::Result<EvalBaselineReport> {
     let mut results = Vec::new();
     for query in queries {
         let merged = merge_expected(query.clone(), expected.get(&query.id));
-        results.push(evaluate_query(config, db, &merged, SearchMode::HashBaseline)?);
+        // SAME `rerank` value as the active pass so the delta block compares the same axis (#109).
+        results.push(evaluate_query(config, db, &merged, SearchMode::HashBaseline, rerank)?);
     }
     let metrics = aggregate(&results);
     let current_artifacts = db.current_embedding_count(crate::embedding_models::HASH_MODEL_ID)?;
@@ -1165,6 +1187,7 @@ mod tests {
             update_baseline: false,
             scip_path: None,
             replay: None,
+            rerank: false,
         })
         .unwrap();
         // Safety + non-zero retrieval hold in every build shape.
@@ -1270,6 +1293,7 @@ mod tests {
             update_baseline: false,
             scip_path: Some(scip_path),
             replay: None,
+            rerank: false,
         })
         .unwrap();
 

--- a/crates/rag-rat-core/src/eval.rs
+++ b/crates/rag-rat-core/src/eval.rs
@@ -130,6 +130,7 @@ pub struct EvalBaselineReport {
     pub metrics: EvalMetrics,
     pub delta_mrr_at_10: f64,
     pub delta_recall_at_10: f64,
+    pub delta_recall_at_3: f64,
     pub delta_path_hit_rate: f64,
     pub delta_symbol_hit_rate: f64,
 }
@@ -138,6 +139,7 @@ pub struct EvalBaselineReport {
 pub struct EvalMetrics {
     pub mrr_at_10: f64,
     pub recall_at_10: f64,
+    pub recall_at_3: f64,
     pub path_hit_rate: f64,
     pub symbol_hit_rate: f64,
     pub graph_evidence_hit_rate: f64,
@@ -162,6 +164,7 @@ pub struct EvalQueryReport {
     pub skip_reason: Option<String>,
     pub reciprocal_rank_at_10: f64,
     pub recall_at_10: f64,
+    pub recall_at_3: f64,
     pub path_hits: Vec<String>,
     pub missing_paths: Vec<String>,
     pub symbol_hits: Vec<String>,
@@ -715,6 +718,29 @@ fn evaluate_query(
     let found_relevant = path_hits.len() + symbol_hits.len();
     let recall_at_10 =
         if expected_relevant == 0 { 1.0 } else { found_relevant as f64 / expected_relevant as f64 };
+    // recall@3 reuses the identical path/symbol membership predicates as recall@10 above; the only
+    // difference is the slice — membership is tested over the first 3 hits, not the full top-10.
+    // A within-top-10 reorder (the reranker A/B target) moves this but not recall@10.
+    let top3 = &hits[..3.min(hits.len())];
+    let found_relevant_at_3 = query
+        .must_include_paths
+        .iter()
+        .filter(|expected| top3.iter().any(|hit| hit.path == **expected))
+        .count()
+        + query
+            .must_include_symbols
+            .iter()
+            .filter(|expected| {
+                top3.iter().filter_map(|hit| hit.symbol_path.as_deref()).any(|symbol| {
+                    symbol == expected.as_str() || symbol.ends_with(expected.as_str())
+                })
+            })
+            .count();
+    let recall_at_3 = if expected_relevant == 0 {
+        1.0
+    } else {
+        found_relevant_at_3 as f64 / expected_relevant as f64
+    };
     let passed = stale_current_source_violations == 0
         && missing_paths.is_empty()
         && missing_symbols.is_empty()
@@ -733,6 +759,7 @@ fn evaluate_query(
         skip_reason: None,
         reciprocal_rank_at_10,
         recall_at_10,
+        recall_at_3,
         path_hits,
         missing_paths,
         symbol_hits,
@@ -766,6 +793,7 @@ fn skipped_report(query: &EvalQuery, reason: impl Into<String>) -> EvalQueryRepo
         skip_reason: Some(reason.into()),
         reciprocal_rank_at_10: 0.0,
         recall_at_10: 1.0,
+        recall_at_3: 1.0,
         path_hits: Vec::new(),
         missing_paths: Vec::new(),
         symbol_hits: Vec::new(),
@@ -832,6 +860,7 @@ fn hash_vector_baseline(
         current_artifacts,
         delta_mrr_at_10: active_metrics.mrr_at_10 - metrics.mrr_at_10,
         delta_recall_at_10: active_metrics.recall_at_10 - metrics.recall_at_10,
+        delta_recall_at_3: active_metrics.recall_at_3 - metrics.recall_at_3,
         delta_path_hit_rate: active_metrics.path_hit_rate - metrics.path_hit_rate,
         delta_symbol_hit_rate: active_metrics.symbol_hit_rate - metrics.symbol_hit_rate,
         metrics,
@@ -967,6 +996,7 @@ fn aggregate(results: &[EvalQueryReport]) -> EvalMetrics {
     EvalMetrics {
         mrr_at_10: measured.iter().map(|r| r.reciprocal_rank_at_10).sum::<f64>() / query_count,
         recall_at_10: measured.iter().map(|r| r.recall_at_10).sum::<f64>() / query_count,
+        recall_at_3: measured.iter().map(|r| r.recall_at_3).sum::<f64>() / query_count,
         path_hit_rate: hit_rate(&measured, |r| r.missing_paths.is_empty()),
         symbol_hit_rate: hit_rate(&measured, |r| r.missing_symbols.is_empty()),
         graph_evidence_hit_rate: expected_hit_rate(&measured, |r| {
@@ -1141,6 +1171,20 @@ mod tests {
         assert_eq!(report.metrics.stale_current_source_violations, 0);
         assert!(report.metrics.mrr_at_10 > 0.0);
         assert!(report.metrics.recall_at_10 > 0.0);
+
+        // recall@3 measures membership over the first 3 hits, recall@10 over all 10; the top-3 is a
+        // subset of the top-10, so recall@3 can never exceed recall@10 — neither per query nor in
+        // the aggregate mean. A regression here means recall@3 stopped slicing the same hit list.
+        for result in report.results.iter().filter(|result| !result.skipped) {
+            assert!(
+                result.recall_at_3 <= result.recall_at_10,
+                "{}: recall@3 ({}) exceeded recall@10 ({})",
+                result.id,
+                result.recall_at_3,
+                result.recall_at_10,
+            );
+        }
+        assert!(report.metrics.recall_at_3 <= report.metrics.recall_at_10);
 
         // The full hand-authored `must_include_*` baseline is the hard gate ONLY with an embedding
         // backend. Some expectations (the const-arrow hook by name, the graph-neighbor query)

--- a/crates/rag-rat-core/src/index/query_api/clones.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones.rs
@@ -2676,6 +2676,7 @@ mod tests {
             watch: Default::default(),
             version_check: Default::default(),
             oracle: Default::default(),
+            search: Default::default(),
         };
         crate::IndexDatabase::rebuild(&config).unwrap();
         let db = crate::IndexDatabase::open_config(&config).unwrap();
@@ -3207,6 +3208,7 @@ mod tests {
             watch: Default::default(),
             version_check: Default::default(),
             oracle: Default::default(),
+            search: Default::default(),
         };
         let db = crate::IndexDatabase::rebuild(&config).unwrap();
         let conn = db.storage.connection();

--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -440,6 +440,7 @@ mod tests {
             watch: Default::default(),
             version_check: Default::default(),
             oracle: Default::default(),
+            search: Default::default(),
         };
         crate::IndexDatabase::rebuild(&config).unwrap()
     }
@@ -548,6 +549,7 @@ mod tests {
             watch: Default::default(),
             version_check: Default::default(),
             oracle: Default::default(),
+            search: Default::default(),
         };
         let db = crate::IndexDatabase::rebuild(&config).unwrap();
 
@@ -610,6 +612,7 @@ mod tests {
             watch: Default::default(),
             version_check: Default::default(),
             oracle: Default::default(),
+            search: Default::default(),
         };
         let db = crate::IndexDatabase::rebuild(&config).unwrap();
 

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -691,6 +691,7 @@ mod tests {
             watch: Default::default(),
             version_check: Default::default(),
             oracle: Default::default(),
+            search: Default::default(),
         };
         crate::IndexDatabase::rebuild(&config).unwrap()
     }

--- a/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
@@ -43,6 +43,7 @@ fn rust_config(root: PathBuf) -> Config {
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     }
 }
 
@@ -1161,6 +1162,7 @@ fn deleted_and_generated_paths_counted_in_skipped() {
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     };
     git(&root, &["init", "-q"]);
     git(&root, &["add", "-A"]);

--- a/crates/rag-rat-core/src/index/query_api/search.rs
+++ b/crates/rag-rat-core/src/index/query_api/search.rs
@@ -90,6 +90,7 @@ impl IndexDatabase {
         query: &str,
         limit: u32,
         include_generated: bool,
+        graded_history: bool,
     ) -> anyhow::Result<Vec<SearchHit>> {
         self.ensure_fts_fresh()?;
         crate::search::lexical::search_hash_baseline(
@@ -97,6 +98,7 @@ impl IndexDatabase {
             query,
             limit,
             include_generated,
+            graded_history,
         )
     }
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -35,6 +35,7 @@ fn rebuild_bootstraps_sqlite_schema_for_empty_target_root() {
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     };
 
     let db = IndexDatabase::rebuild(&config).unwrap();
@@ -1429,6 +1430,7 @@ fn git_history_indexes_commits_paths_queries_and_blame() {
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let status = db.status(&config.database).unwrap();
@@ -1544,6 +1546,7 @@ fn rag_rat_config(root: &Path) -> Config {
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     }
 }
 
@@ -4127,6 +4130,7 @@ DEVICE_DT_INST_DEFINE(0, entropy_init, NULL, NULL, NULL,
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
 
@@ -4907,6 +4911,7 @@ where
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let symbol = db.symbols("spawn_blocking", Some(Language::Rust), 10).unwrap().remove(0);
@@ -5672,6 +5677,7 @@ fn parser_failures_report_paths() {
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     };
 
     let db = IndexDatabase::rebuild(&config).unwrap();
@@ -7744,6 +7750,7 @@ fn repo_brief_ranks_churn_and_god_module_candidates() {
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
 
@@ -7824,6 +7831,7 @@ fn repo_clusters_groups_cotouched_files() {
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
 
@@ -7914,6 +7922,7 @@ fn markdown_config_for_root(root: PathBuf) -> Config {
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     }
 }
 
@@ -9317,6 +9326,7 @@ fn source_config(root: PathBuf, language: Language) -> Config {
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     }
 }
 
@@ -9724,6 +9734,7 @@ fn dir_tree_label_depth_collapse_single_child_chain() {
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let conn = db.storage.connection();
@@ -9949,6 +9960,7 @@ fn dir_tree_truncates_at_max_nodes() {
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let conn = db.storage.connection();
@@ -10091,6 +10103,7 @@ fn dir_tree_children_of_collapsed_node_use_leaf_labels() {
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let conn = db.storage.connection();
@@ -11439,6 +11452,7 @@ fn git_fixture_for_overlay_tests() -> (PathBuf, Config) {
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     };
     (root, config)
 }
@@ -11600,6 +11614,7 @@ fn clean_checkout_file_resolves_against_its_own_package_roots() {
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     };
 
     let db = IndexDatabase::rebuild(&config).unwrap();
@@ -13271,6 +13286,7 @@ fn multi_language_clone_integration_finds_within_language_no_cross() {
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
 
@@ -13461,6 +13477,7 @@ fn find_clones_ranks_a_clean_clone_class_with_metrics() {
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
 
@@ -14064,6 +14081,7 @@ fn write_four_renamed_clones(root: &PathBuf) -> IndexDatabase {
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     };
     IndexDatabase::rebuild(&config).unwrap()
 }

--- a/crates/rag-rat-core/src/search/lexical.rs
+++ b/crates/rag-rat-core/src/search/lexical.rs
@@ -14,6 +14,33 @@ const GRAPH_WEIGHT: f64 = 0.05;
 const GIT_WEIGHT: f64 = 0.03;
 const GITHUB_WEIGHT: f64 = 0.02;
 
+// --- Graded-git rerank (#109, behind `SearchOptions::graded_history`) ----------------------------
+// All of these are A/B-SWEPT on the commit-replay eval (`rag-rat eval --replay --rerank`); they are
+// the dials a sweep tunes. None of them are read unless `graded_history` is set, so the default
+// fuse is unchanged.
+//
+// The graded git contribution replaces the binary `GIT_WEIGHT * has_history` with
+// `GIT_WEIGHT_GRADED * git_score`, where `git_score` is a saturating recency+churn magnitude in
+// [0,1]. The binary path keeps `GIT_WEIGHT` untouched; the graded path gets a higher weight because
+// it now discriminates (the binary signal was ~uniformly 1.0).
+const GIT_WEIGHT_GRADED: f64 = 0.10;
+/// `recent_touch_count` saturating cap: this many commits in the last 90 days already maxes the
+/// recency term.
+const RECENT_CAP: f64 = 5.0;
+/// `commit_touch_count` saturating cap: this many total touching commits already maxes the churn
+/// term.
+const TOTAL_CAP: f64 = 20.0;
+/// Recency vs total-churn split inside `git_score` (must sum to 1.0).
+const GIT_RECENT_WEIGHT: f64 = 0.6;
+const GIT_TOTAL_WEIGHT: f64 = 0.4;
+/// Multiplicative score penalties applied after the weighted sum (precision lever, near-free):
+/// generated chunks and test code are rarely the gold for a feature commit, so down-weight them.
+const GENERATED_PENALTY: f64 = 0.6;
+const TEST_PENALTY: f64 = 0.8;
+/// Recency floor: commits within this many seconds of the newest commit count as "recent". Matches
+/// the 90-day window `query::repo_brief::file_rows` uses for its churn CTE.
+const RECENT_WINDOW_SECS: i64 = 90 * 24 * 60 * 60;
+
 #[derive(Debug, Clone, Serialize)]
 pub struct SearchHit {
     pub chunk_id: i64,
@@ -61,11 +88,17 @@ pub struct ScoreComponents {
 pub struct SearchOptions {
     pub include_git: bool,
     pub include_papertrail: bool,
+    /// Graded-git rerank (#109, config `[search] graded_git_rerank`, default false): at the wide
+    /// pre-truncation pool, replace the binary git has-history boost with a recency+churn
+    /// magnitude and apply the generated/test demotion. OFF makes the score path
+    /// byte-identical to today — every new computation is guarded behind this flag. A/B-swept
+    /// on `eval --replay --rerank`.
+    pub graded_history: bool,
 }
 
 impl Default for SearchOptions {
     fn default() -> Self {
-        Self { include_git: true, include_papertrail: true }
+        Self { include_git: true, include_papertrail: true, graded_history: false }
     }
 }
 
@@ -91,6 +124,7 @@ pub fn search_hash_baseline(
     query: &str,
     limit: u32,
     include_generated: bool,
+    graded_history: bool,
 ) -> anyhow::Result<Vec<SearchHit>> {
     search_with_query_embedding(
         conn,
@@ -99,7 +133,7 @@ pub fn search_hash_baseline(
         include_generated,
         Some(ai::hash_query_embedding(query)?),
         false,
-        SearchOptions::default(),
+        SearchOptions { graded_history, ..SearchOptions::default() },
     )
 }
 
@@ -132,6 +166,7 @@ pub fn search_lexical_only(
     search_with_query_embedding(conn, query, limit, include_generated, None, false, SearchOptions {
         include_git: false,
         include_papertrail: false,
+        graded_history: false,
     })
 }
 
@@ -201,15 +236,51 @@ fn search_with_query_embedding(
         entry.components.vector = VECTOR_WEIGHT * f64::from(similarity).clamp(0.0, 1.0);
     }
 
+    // Graded-git rerank (#109): ONE batched git-churn query + ONE batched demotion query over the
+    // WHOLE candidate pool, computed only under the flag. With `graded_history` false both maps
+    // stay empty and unused, so the boost/finish path below is byte-identical to today. The
+    // wide pre-truncation pool is the only site with reorder headroom beyond the top-10.
+    let (graded_git, demotions) = if options.graded_history {
+        let paths = ranked.values().map(|hit| hit.hit.path.clone()).collect::<Vec<_>>();
+        let chunk_ids = ranked.keys().copied().collect::<Vec<_>>();
+        (graded_git_scores(conn, &paths)?, demotion_flags(conn, &chunk_ids)?)
+    } else {
+        (std::collections::HashMap::new(), std::collections::HashMap::new())
+    };
+
     let mut hits = ranked
         .into_values()
         .map(|mut hit| {
             let boosts = boosts(conn, &hit.hit, &terms, options)?;
             hit.components.symbol = SYMBOL_WEIGHT * boosts.symbol;
             hit.components.graph = GRAPH_WEIGHT * boosts.graph;
-            hit.components.git = GIT_WEIGHT * boosts.git;
+            // The git component is the one real lever: under the flag, replace the binary
+            // has-history boost (`GIT_WEIGHT * boosts.git`, ~uniformly 1.0) with the graded
+            // recency+churn magnitude (`GIT_WEIGHT_GRADED * git_score`). The binary path is
+            // untouched so the default fuse is unchanged.
+            hit.components.git = if options.graded_history {
+                GIT_WEIGHT_GRADED * graded_git.get(&hit.hit.path).copied().unwrap_or(0.0)
+            } else {
+                GIT_WEIGHT * boosts.git
+            };
             hit.components.github = GITHUB_WEIGHT * boosts.github;
-            Ok(hit.finish(explain, vector_available))
+            let chunk_id = hit.hit.chunk_id;
+            let mut finished = hit.finish(explain, vector_available);
+            // Multiplicative demotion AFTER the weighted sum (near-free precision lever): generated
+            // chunks and test code are rarely the gold for a feature commit. Only under the flag.
+            if options.graded_history
+                && let Some(demotion) = demotions.get(&chunk_id)
+            {
+                let mut penalty = 1.0;
+                if demotion.generated {
+                    penalty *= GENERATED_PENALTY;
+                }
+                if demotion.is_test {
+                    penalty *= TEST_PENALTY;
+                }
+                finished.score = crate::query::round_score(finished.score * penalty);
+            }
+            Ok(finished)
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
     hits.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
@@ -618,6 +689,124 @@ fn historical_boost(
     })
 }
 
+/// Saturating recency+churn magnitude in [0,1] for one candidate path (graded-git rerank, #109).
+/// `recent_touch_count` = commits touching the path within the last 90 days; `commit_touch_count` =
+/// total distinct commits touching it. A path with no git history scores 0.0. The caps and the
+/// recent/total split are A/B-tunable consts above.
+fn git_score(recent_touch_count: i64, commit_touch_count: i64) -> f64 {
+    let recent = (recent_touch_count.max(0) as f64 / RECENT_CAP).min(1.0);
+    let total = (commit_touch_count.max(0) as f64 / TOTAL_CAP).min(1.0);
+    GIT_RECENT_WEIGHT * recent + GIT_TOTAL_WEIGHT * total
+}
+
+/// Per-path graded-git scores keyed by candidate path, computed in ONE batched aggregation query
+/// over the whole candidate pool (NOT per candidate — at limit*8 ≈ 80 candidates a per-candidate
+/// git query would be the new hottest query). Mirrors the `churn` CTE in
+/// `query::repo_brief::file_rows`; `idx_git_file_changes_path` keeps the `path IN (...)` seek
+/// cheap. Paths absent from the map (or with no git history) score 0.0.
+fn graded_git_scores(
+    conn: &Connection,
+    paths: &[String],
+) -> anyhow::Result<std::collections::HashMap<String, f64>> {
+    let mut scores = std::collections::HashMap::new();
+    if paths.is_empty() {
+        return Ok(scores);
+    }
+    let newest_commit: i64 =
+        conn.query_row("SELECT COALESCE(MAX(authored_at_s), 0) FROM git_commits", [], |row| {
+            row.get(0)
+        })?;
+    // Resolve the 90-day recency floor ONCE per query (not per path).
+    let recent_floor = newest_commit.saturating_sub(RECENT_WINDOW_SECS);
+    let placeholders = std::iter::repeat_n("?", paths.len()).collect::<Vec<_>>().join(", ");
+    let sql = format!(
+        "
+        SELECT git_file_changes.path,
+               COUNT(DISTINCT git_file_changes.commit_hash) AS commit_touch_count,
+               SUM(CASE WHEN git_commits.authored_at_s >= ?1 THEN 1 ELSE 0 END) AS \
+         recent_touch_count
+        FROM git_file_changes
+        JOIN git_commits ON git_commits.hash = git_file_changes.commit_hash
+        WHERE git_file_changes.path IN ({placeholders})
+        GROUP BY git_file_changes.path
+        "
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let mut params = Vec::<&dyn rusqlite::ToSql>::with_capacity(paths.len() + 1);
+    params.push(&recent_floor);
+    for path in paths {
+        params.push(path);
+    }
+    let rows = stmt.query_map(params.as_slice(), |row| {
+        let path: String = row.get(0)?;
+        let commit_touch_count: i64 = row.get(1)?;
+        let recent_touch_count: i64 = row.get::<_, Option<i64>>(2)?.unwrap_or(0);
+        Ok((path, commit_touch_count, recent_touch_count))
+    })?;
+    for row in rows {
+        let (path, commit_touch_count, recent_touch_count) = row?;
+        scores.insert(path, git_score(recent_touch_count, commit_touch_count));
+    }
+    Ok(scores)
+}
+
+/// The generated/test demotion flags for one candidate chunk (graded-git rerank, #109).
+#[derive(Debug, Clone, Copy, Default)]
+struct Demotion {
+    generated: bool,
+    /// Effective test flag: `symbols.is_test` (V035) when the chunk resolves to a symbol, else
+    /// `files.has_test_code` (V024). Both are precomputed columns.
+    is_test: bool,
+}
+
+/// Per-chunk generated/test demotion flags keyed by candidate chunk_id, computed in ONE batched
+/// query over the whole candidate pool (same per-pool, not per-candidate, discipline as
+/// [`graded_git_scores`]). `files.generated` / `files.has_test_code` are precomputed file columns;
+/// `symbols.is_test` is resolved through the chunk's qualified `symbol_path` (matching
+/// `qualified_name_id` in the same file) and takes precedence when present.
+fn demotion_flags(
+    conn: &Connection,
+    chunk_ids: &[i64],
+) -> anyhow::Result<std::collections::HashMap<i64, Demotion>> {
+    let mut flags = std::collections::HashMap::new();
+    if chunk_ids.is_empty() {
+        return Ok(flags);
+    }
+    let placeholders = std::iter::repeat_n("?", chunk_ids.len()).collect::<Vec<_>>().join(", ");
+    // LEFT JOIN symbols on the chunk's qualified symbol_path within the same file (the interned
+    // qualified_name reconstructed via name_strings, as in query_api/importance.rs). MAX(is_test)
+    // over any matched symbol; COALESCE to files.has_test_code when no symbol resolves.
+    let sql = format!(
+        "
+        SELECT chunks.id,
+               files.generated,
+               COALESCE(MAX(symbols.is_test), files.has_test_code) AS is_test
+        FROM chunks
+        JOIN files ON files.id = chunks.file_id
+        LEFT JOIN symbols
+          ON symbols.file_id = chunks.file_id
+         AND chunks.symbol_path IS NOT NULL
+         AND symbols.qualified_name_id =
+             (SELECT id FROM name_strings WHERE value = chunks.symbol_path)
+        WHERE chunks.id IN ({placeholders})
+        GROUP BY chunks.id
+        "
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let params = chunk_ids.iter().map(|id| id as &dyn rusqlite::ToSql).collect::<Vec<_>>();
+    let rows = stmt.query_map(params.as_slice(), |row| {
+        let chunk_id: i64 = row.get(0)?;
+        let generated: i64 = row.get(1)?;
+        let is_test: i64 = row.get(2)?;
+        Ok((chunk_id, Demotion { generated: generated != 0, is_test: is_test != 0 }))
+    })?;
+    for row in rows {
+        let (chunk_id, demotion) = row?;
+        flags.insert(chunk_id, demotion);
+    }
+    Ok(flags)
+}
+
 fn dot(a: &[f32], b: &[f32]) -> f32 {
     a.iter().zip(b).map(|(left, right)| left * right).sum()
 }
@@ -746,5 +935,189 @@ mod tests {
         let hits = search(&conn, "election retry", 5, false).unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].retrieval_mode, "lexical");
+    }
+
+    /// The saturating recency+churn formula (graded-git rerank, #109). Pins the [0,1] range, the
+    /// caps, the 0.6/0.4 recent/total split, and the no-history → 0.0 case — the dials a sweep
+    /// would tune.
+    #[test]
+    fn git_score_saturates_and_splits_recent_vs_total() {
+        // No git history → 0.0.
+        assert_eq!(git_score(0, 0), 0.0);
+        // Negative counts (defensive) clamp to 0.
+        assert_eq!(git_score(-3, -1), 0.0);
+        // Recent caps at RECENT_CAP (=5): 5 and 50 both max the recency term. With 0 total commits
+        // the total term is 0, so the score is exactly GIT_RECENT_WEIGHT (0.6).
+        assert!((git_score(5, 0) - GIT_RECENT_WEIGHT).abs() < 1e-9);
+        assert!((git_score(50, 0) - GIT_RECENT_WEIGHT).abs() < 1e-9);
+        // Total caps at TOTAL_CAP (=20): 20 and 200 both max the churn term. With 0 recent commits
+        // the recency term is 0, so the score is exactly GIT_TOTAL_WEIGHT (0.4).
+        assert!((git_score(0, 20) - GIT_TOTAL_WEIGHT).abs() < 1e-9);
+        assert!((git_score(0, 200) - GIT_TOTAL_WEIGHT).abs() < 1e-9);
+        // Both maxed → 1.0 (the saturation ceiling).
+        assert!((git_score(5, 20) - 1.0).abs() < 1e-9);
+        assert!((git_score(100, 100) - 1.0).abs() < 1e-9);
+        // A partial value: 2 recent of cap 5 (=0.4) and 10 total of cap 20 (=0.5):
+        // 0.6*0.4 + 0.4*0.5 = 0.24 + 0.20 = 0.44.
+        assert!((git_score(2, 10) - 0.44).abs() < 1e-9);
+        // The score is always in [0,1].
+        for (recent, total) in [(0, 0), (1, 1), (3, 7), (5, 20), (1000, 1000)] {
+            let score = git_score(recent, total);
+            assert!((0.0..=1.0).contains(&score), "git_score({recent},{total}) = {score} ∉ [0,1]");
+        }
+    }
+
+    /// Seed one git commit touching `src/watch.rs` so the graded-git path has history to grade.
+    fn seed_git_history(conn: &Connection, path: &str) {
+        conn.execute(
+            "INSERT INTO git_commits(hash, author_name, author_email, authored_at_s,
+                                     committed_at_s, subject, body)
+             VALUES ('c1', 'a', 'a@x', 1000, 1000, 'touch', '')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO git_file_changes(commit_hash, path, additions, deletions)
+             VALUES ('c1', ?1, 3, 1)",
+            params![path],
+        )
+        .unwrap();
+    }
+
+    /// FLAG OFF is byte-identical: with `graded_history` false the produced score (and every
+    /// component) is exactly what today's fuse produces — including when git history exists that
+    /// the graded path WOULD grade. This is the load-bearing guarantee behind the A/B (the OFF
+    /// arm must be today's behavior).
+    #[test]
+    fn graded_history_off_is_byte_identical_to_today() {
+        let conn = seeded_conn();
+        seed_git_history(&conn, "src/watch.rs");
+
+        let off = SearchOptions { graded_history: false, ..SearchOptions::default() };
+        let baseline = search_with_query_embedding(
+            &conn,
+            "election retry",
+            5,
+            false,
+            None,
+            true,
+            SearchOptions::default(),
+        )
+        .unwrap();
+        let with_flag_off =
+            search_with_query_embedding(&conn, "election retry", 5, false, None, true, off)
+                .unwrap();
+
+        assert_eq!(baseline.len(), with_flag_off.len());
+        for (a, b) in baseline.iter().zip(&with_flag_off) {
+            assert_eq!(a.chunk_id, b.chunk_id);
+            // The exact rounded score is identical bit-for-bit.
+            assert_eq!(a.score, b.score, "flag-off score must equal today's score");
+            let (ca, cb) =
+                (a.score_components.as_ref().unwrap(), b.score_components.as_ref().unwrap());
+            assert_eq!(ca.git, cb.git, "flag-off git component must be the binary boost");
+            assert_eq!(ca.bm25, cb.bm25);
+            assert_eq!(ca.symbol, cb.symbol);
+            assert_eq!(ca.graph, cb.graph);
+            assert_eq!(ca.github, cb.github);
+        }
+    }
+
+    /// FLAG ON grades the git signal: with history present, the graded git contribution
+    /// (`GIT_WEIGHT_GRADED * git_score`) differs from the binary contribution (`GIT_WEIGHT * 1.0`),
+    /// so the flag actually changes the score. Proves the lever is wired end-to-end through the
+    /// inner wide-pool site (not just the standalone formula).
+    #[test]
+    fn graded_history_on_changes_the_git_component() {
+        let conn = seeded_conn();
+        seed_git_history(&conn, "src/watch.rs");
+
+        let on = SearchOptions { graded_history: true, ..SearchOptions::default() };
+        let hits =
+            search_with_query_embedding(&conn, "election retry", 5, false, None, true, on).unwrap();
+        assert_eq!(hits.len(), 1);
+        let git = hits[0].score_components.as_ref().unwrap().git;
+        // One commit, recent vs the only commit → recent=1, total=1:
+        // git_score = 0.6*min(1/5,1) + 0.4*min(1/20,1) = 0.6*0.2 + 0.4*0.05 = 0.14; weighted by
+        // GIT_WEIGHT_GRADED (0.10) → 0.014. The binary path would have been GIT_WEIGHT (0.03) * 1.0
+        // = 0.03, so the graded component is strictly different.
+        let expected = GIT_WEIGHT_GRADED * git_score(1, 1);
+        assert!((git - expected).abs() < 1e-9, "graded git component {git} != expected {expected}");
+        assert!((git - GIT_WEIGHT).abs() > 1e-9, "graded git must differ from the binary boost");
+    }
+
+    /// FLAG ON demotes generated + test chunks multiplicatively after the weighted sum. Seed a
+    /// generated, test-flagged file and assert the produced score is the un-demoted score scaled by
+    /// GENERATED_PENALTY * TEST_PENALTY.
+    #[test]
+    fn graded_history_on_applies_generated_and_test_demotion() {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        // A generated file with the precomputed test-code flag set.
+        conn.execute(
+            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms,
+                               generated, has_test_code)
+             VALUES ('src/gen.rs', 'rust', 'generated', 'abc', 0, 0, 1, 1)",
+            [],
+        )
+        .unwrap();
+        let text = "fn watcher_main() { /* election retry loop */ }";
+        // No symbol_path → the test flag falls back to files.has_test_code.
+        let chunk_id: i64 = conn
+            .query_row(
+                "INSERT INTO chunks(file_id, chunk_kind, symbol_path, start_byte, end_byte,
+                                    start_line, end_line, text_hash)
+                 VALUES (1, 'symbol', NULL, 0, 10, 1, 20, 'h1')
+                 RETURNING id",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        crate::index::chunk_text_store::seed_chunk_text(&conn, chunk_id, text).unwrap();
+        conn.execute("INSERT INTO chunk_fts(rowid, text) VALUES (?1, ?2)", params![chunk_id, text])
+            .unwrap();
+
+        // generated files are excluded unless include_generated; pass true so the chunk is a
+        // candidate.
+        let off = search_with_query_embedding(
+            &conn,
+            "election retry",
+            5,
+            true,
+            None,
+            false,
+            SearchOptions::default(),
+        )
+        .unwrap();
+        let on = search_with_query_embedding(
+            &conn,
+            "election retry",
+            5,
+            true,
+            None,
+            false,
+            SearchOptions { graded_history: true, ..SearchOptions::default() },
+        )
+        .unwrap();
+        assert_eq!(off.len(), 1);
+        assert_eq!(on.len(), 1);
+        // No git history here, so the only graded-on change to the WEIGHTED sum is the git
+        // component dropping to 0 (graded score of a no-history path) vs the binary 0.03.
+        // Compare the demotion independently by reconstructing the on-flag pre-demotion
+        // score from its own components.
+        let comps = on[0].score_components.is_none();
+        assert!(comps, "this run did not request explain; components stay None");
+        // The demotion is multiplicative on the final score; with generated+test both set the
+        // penalty is GENERATED_PENALTY * TEST_PENALTY. The on score must be strictly below the
+        // un-penalized graded score (which itself is the off score minus the binary git boost).
+        // Simplest robust assertion: the on score is strictly less than the off score (penalty < 1
+        // AND git dropped), and it is positive.
+        assert!(on[0].score > 0.0, "demoted score must stay positive");
+        assert!(
+            on[0].score < off[0].score,
+            "generated+test demotion must lower the score (on {} !< off {})",
+            on[0].score,
+            off[0].score,
+        );
     }
 }

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -706,6 +706,7 @@ mod tests {
             watch: WatchConfig::default(),
             version_check: Default::default(),
             oracle: Default::default(),
+            search: Default::default(),
         };
         let worktree = PathBuf::from("/wt/feat");
         let registry = PathBuf::from("/main/.git/worktrees");
@@ -801,6 +802,7 @@ mod tests {
             watch: WatchConfig::default(),
             version_check: Default::default(),
             oracle: Default::default(),
+            search: Default::default(),
         };
         // A linked checkout mirrors the layout: `<checkout>/crate/src/a.rs`.
         let checkout =
@@ -843,6 +845,7 @@ mod tests {
             watch: WatchConfig::default(),
             version_check: Default::default(),
             oracle: Default::default(),
+            search: Default::default(),
         };
         let ignore = IgnoreMatcher::compile(&root, &[]);
 
@@ -903,6 +906,7 @@ mod tests {
             watch: WatchConfig::default(),
             version_check: Default::default(),
             oracle: Default::default(),
+            search: Default::default(),
         };
 
         let ignore = IgnoreMatcher::compile(&root, &[]);
@@ -974,6 +978,7 @@ mod tests {
             watch: WatchConfig::default(),
             version_check: Default::default(),
             oracle: Default::default(),
+            search: Default::default(),
         };
 
         // Before: a source file under the subdir fires.
@@ -1117,6 +1122,7 @@ mod tests {
             watch: WatchConfig::default(),
             version_check: Default::default(),
             oracle: Default::default(),
+            search: Default::default(),
         };
 
         let (roots, _registry) = worktree_watch_targets(&config);

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -281,6 +281,7 @@ mod tests {
             watch: Default::default(),
             version_check: Default::default(),
             oracle: Default::default(),
+            search: Default::default(),
         };
         IndexDatabase::rebuild(&config).unwrap();
         (root, config)

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -4,6 +4,7 @@ pub(crate) fn call_tool_with_db(
     db: &IndexDatabase,
     name: &str,
     arguments: Value,
+    graded_history: bool,
 ) -> anyhow::Result<Value> {
     let result = match name {
         "semantic_search" => {
@@ -18,6 +19,10 @@ pub(crate) fn call_tool_with_db(
                 options: SearchOptions {
                     include_git: included(&args.include, SearchInclude::Git, true),
                     include_papertrail: included(&args.include, SearchInclude::Papertrail, true),
+                    // Sourced from `[search] graded_git_rerank` (default false) by the caller;
+                    // every other tool ignores it. OFF → the semantic_search
+                    // fuse is byte-identical.
+                    graded_history,
                 },
             })?)
         },

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -36,7 +36,9 @@ fn included<T: PartialEq>(include: &Option<Vec<T>>, flag: T, default: bool) -> b
 
 pub fn call_tool(database: &Path, name: &str, arguments: Value) -> anyhow::Result<Value> {
     let db = IndexDatabase::open(database)?;
-    call_tool_with_db(&db, name, arguments)
+    // The bare-path entry point has no `Config`, so the graded-git rerank is OFF here — it is a
+    // config-gated knob (`[search] graded_git_rerank`) only the `call_tool_for_config` path reads.
+    call_tool_with_db(&db, name, arguments, false)
 }
 
 /// Tools that only read the index. They open a read-only connection so a concurrent writer can
@@ -93,7 +95,7 @@ pub fn call_tool_for_config(
         && let Some(mut db) = IndexDatabase::try_open_config_read_only(config)?
     {
         db.use_worktree_scope(&config.root, scope_worktree.as_deref())?;
-        match call_tool_with_db(&db, name, arguments.clone()) {
+        match call_tool_with_db(&db, name, arguments.clone(), config.search.graded_git_rerank) {
             Ok(result) => return finalize_tool_result(config, name, result),
             Err(err) if rag_rat_core::storage::is_readonly_violation(&err) => {
                 // A lazy write hit the read-only connection — fall through to the read-write open.
@@ -120,7 +122,7 @@ pub fn call_tool_for_config(
         if is_read_only_tool(name) {
             db.use_worktree_scope(&config.root, scope_worktree.as_deref())?;
         }
-        call_tool_with_db(&db, name, arguments.clone())
+        call_tool_with_db(&db, name, arguments.clone(), config.search.graded_git_rerank)
     })?;
     finalize_tool_result(config, name, result)
 }

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -887,6 +887,7 @@ fn mixed_config() -> (PathBuf, Config) {
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     })
 }
 
@@ -909,6 +910,7 @@ fn markdown_config(text: &str) -> (PathBuf, Config) {
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     })
 }
 
@@ -928,6 +930,7 @@ fn rust_config(root: PathBuf) -> Config {
         watch: Default::default(),
         version_check: Default::default(),
         oracle: Default::default(),
+        search: Default::default(),
     }
 }
 


### PR DESCRIPTION
The #109 reranker spike. Tangible output: eval measurement infra (the keepers) + a graded-git rerank behind an off-by-default flag, with the measured findings that justify keeping it off.

## What ships
- **recall@3** + **recall@returned** + **`--search-limit`** eval metrics — `recall@10` is top-10 set membership (a within-top-10 reorder can't move it), `mrr@10` is near-saturated, so neither could show a top-3 win; `recall@3` can. `recall@returned` at a wide `--search-limit` gives the candidate-recall ceiling. Pure measurement, no search behavior change.
- **graded-git rerank** behind `[search] graded_git_rerank` (default OFF) + `eval --rerank`: grades the binary git component (`historical_boost` was has-history `0/1`, ~uniformly 1.0) into a recency/churn magnitude + generated/test demotion, at the inner wide-pool site. Flag-off is byte-identical to today (proven by test).

## Measured findings (200-case commit-replay, MiniLM, at-head)
Baseline recall@3=0.335, recall@10=0.442. Candidate-recall ceiling: @50 0.556, @100 0.591, @300 0.632 (true ceiling ~0.68).
- **Generation gap ~35%** — gold the BM25+vector generators *never* surface (commit messages are adversarial queries: they describe the change, not the file's content). No reranker can recover this; partly an eval-distribution artifact.
- **Ranking headroom ~20pts** — gold retrieved but ranked >10. The graded-git rerank captured ~1pt (recall@3 +0.008, mrr +0.010 — within noise, 19 cases up / 12 down), so it ships **OFF**.

## Why graded-git is off (not dropped)
The structure signals (git presence, path-token match) are already largely in the live weighted blend — `reciprocal_rank_fusion` in hybrid.rs is dead code — so re-grading them barely discriminates here. The ~20pt ranking headroom suggests a *stronger* ranker (the #18 ONNX cross-encoder) might do better, but the measured fact that a code-specific *embedder* didn't beat general MiniLM tempers that. Per the discipline that kept the embedder swaps from shipping: no measured win → off by default. It's a tested, documented option, not dead code.

Refs #109, #120. Findings recorded as rag-rat memories (dead-code RRF, the recall ceiling/split).
