### PR TITLE
feat(embed): re-encode existing f32 embedding blobs to int8 (#312)

### DIFF
--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -313,6 +313,11 @@ pub(crate) struct ReconcileArgs {
     /// Truncate chunk text to this many chars before embedding.
     #[arg(long)]
     pub max_embedding_chars: Option<usize>,
+    /// Force the legacy-f32 → int8 vector re-encode now (#312), ignoring the run-once meta gate.
+    /// A format-only conversion (no model inference); idempotent — converts only rows still in
+    /// f32.
+    #[arg(long)]
+    pub reencode_vectors: bool,
 }
 
 #[cfg(feature = "eval")]

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -315,7 +315,9 @@ pub(crate) struct ReconcileArgs {
     pub max_embedding_chars: Option<usize>,
     /// Force the legacy-f32 → int8 vector re-encode now (#312), ignoring the run-once meta gate.
     /// A format-only conversion (no model inference); idempotent — converts only rows still in
-    /// f32.
+    /// f32. SHORT-CIRCUITS: re-encodes and exits, ignoring the other reconcile flags (no
+    /// embeddings are computed). Honors `--max-seconds` (the conversion is bounded and resumes
+    /// on a later run).
     #[arg(long)]
     pub reencode_vectors: bool,
 }

--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -480,12 +480,8 @@ pub(crate) fn models(config: &Config, args: &ModelsArgs) -> anyhow::Result<()> {
 }
 pub(crate) fn reconcile(config: &Config, args: &ReconcileArgs) -> anyhow::Result<()> {
     let db = open_index(config)?;
-    // Force the legacy-f32 → int8 vector re-encode (#312) when asked, ignoring the run-once gate —
-    // for users who want it now on a huge index. Format-only, idempotent.
-    if args.reencode_vectors {
-        let converted = db.reencode_legacy_vectors_now()?;
-        eprintln!("rag-rat: re-encoded {converted} legacy f32 vector blobs to int8");
-    }
+    // `--plan` is a READ-ONLY dry run: it must return before any mutation, so it stays read-only
+    // even when combined with a mutating flag like `--reencode-vectors` (#312).
     if args.plan {
         let plan = db.reconcile_plan()?;
         // `--plan` prints a human summary by default; the global `--json` switches to the
@@ -496,6 +492,13 @@ pub(crate) fn reconcile(config: &Config, args: &ReconcileArgs) -> anyhow::Result
             print_reconcile_plan(&plan);
         }
         return Ok(());
+    }
+    // Force the legacy-f32 → int8 vector re-encode (#312) when asked, ignoring the run-once gate —
+    // for users who want it now on a huge index. Format-only, idempotent. Runs only on a real
+    // (non-`--plan`) reconcile.
+    if args.reencode_vectors {
+        let converted = db.reencode_legacy_vectors_now()?;
+        eprintln!("rag-rat: re-encoded {converted} legacy f32 vector blobs to int8");
     }
     let options = rag_rat_core::index::ai::ReconcileOptions {
         limit: args.limit,
@@ -971,8 +974,15 @@ fn run_maintenance_pass(
     // One-time on upgrade: re-encode any legacy f32 vector blobs to the compact int8 format (#312).
     // Meta-gated, so this runs once and then skips the table scan cheaply on every later pass; run
     // on the BASE index (not per-overlay) before the worktree refresh re-scopes the connection.
-    // Format-only (decode f32 → encode int8), so it's cheap — no model inference.
-    let _ = db.reencode_legacy_vectors_if_needed();
+    // Format-only (decode f32 → encode int8), so it's cheap — no model inference. BUDGETED: skipped
+    // entirely when `max_seconds == 0` (the "no embedding work" cap, mirroring `budget` below), and
+    // otherwise bounded by the same shared `started + max_seconds` deadline so a huge index can't
+    // hold the write lock for a full-table conversion past the cap — it stops at the deadline and
+    // resumes from a persisted cursor on the next pass.
+    if max_seconds > 0 {
+        let deadline = started + std::time::Duration::from_secs(max_seconds);
+        let _ = db.reencode_legacy_vectors_if_needed(Some(deadline));
+    }
     // ONE time budget for the whole pass — the per-overlay embedding reconciles AND the base
     // reconcile below — measured from `started` so discovery already counts against it. Without a
     // shared budget each overlay (each call starts its own `max_seconds` timer) plus the base could

--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -480,6 +480,12 @@ pub(crate) fn models(config: &Config, args: &ModelsArgs) -> anyhow::Result<()> {
 }
 pub(crate) fn reconcile(config: &Config, args: &ReconcileArgs) -> anyhow::Result<()> {
     let db = open_index(config)?;
+    // Force the legacy-f32 → int8 vector re-encode (#312) when asked, ignoring the run-once gate —
+    // for users who want it now on a huge index. Format-only, idempotent.
+    if args.reencode_vectors {
+        let converted = db.reencode_legacy_vectors_now()?;
+        eprintln!("rag-rat: re-encoded {converted} legacy f32 vector blobs to int8");
+    }
     if args.plan {
         let plan = db.reconcile_plan()?;
         // `--plan` prints a human summary by default; the global `--json` switches to the
@@ -962,6 +968,11 @@ fn run_maintenance_pass(
     let _lock = rag_rat_core::locks::WriteLock::acquire_blocking(&config.database)?;
 
     let mut db = IndexDatabase::index_discover_with_progress(config, render_index_progress)?;
+    // One-time on upgrade: re-encode any legacy f32 vector blobs to the compact int8 format (#312).
+    // Meta-gated, so this runs once and then skips the table scan cheaply on every later pass; run
+    // on the BASE index (not per-overlay) before the worktree refresh re-scopes the connection.
+    // Format-only (decode f32 → encode int8), so it's cheap — no model inference.
+    let _ = db.reencode_legacy_vectors_if_needed();
     // ONE time budget for the whole pass — the per-overlay embedding reconciles AND the base
     // reconcile below — measured from `started` so discovery already counts against it. Without a
     // shared budget each overlay (each call starts its own `max_seconds` timer) plus the base could

--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -480,8 +480,10 @@ pub(crate) fn models(config: &Config, args: &ModelsArgs) -> anyhow::Result<()> {
 }
 pub(crate) fn reconcile(config: &Config, args: &ReconcileArgs) -> anyhow::Result<()> {
     let db = open_index(config)?;
-    // `--plan` is a READ-ONLY dry run: it must return before any mutation, so it stays read-only
-    // even when combined with a mutating flag like `--reencode-vectors` (#312).
+    // INVARIANT (#312): this `--plan` early-return MUST stay ABOVE the `--reencode-vectors`
+    // mutation below. `--plan` is a READ-ONLY dry run; returning here first is what keeps
+    // `reconcile --plan --reencode-vectors` from mutating the index during a dry run. Do not
+    // reorder.
     if args.plan {
         let plan = db.reconcile_plan()?;
         // `--plan` prints a human summary by default; the global `--json` switches to the
@@ -494,11 +496,20 @@ pub(crate) fn reconcile(config: &Config, args: &ReconcileArgs) -> anyhow::Result
         return Ok(());
     }
     // Force the legacy-f32 → int8 vector re-encode (#312) when asked, ignoring the run-once gate —
-    // for users who want it now on a huge index. Format-only, idempotent. Runs only on a real
-    // (non-`--plan`) reconcile.
+    // for users who want it now on a huge index. Format-only, idempotent. This SHORT-CIRCUITS: it
+    // re-encodes and RETURNS, ignoring the other reconcile flags (no embedding inference runs), so
+    // `--reencode-vectors` is a re-encode-only action. Bounded by `--max-seconds` (resumable via
+    // the persisted cursor) when given. Runs only on a real (non-`--plan`) reconcile.
     if args.reencode_vectors {
-        let converted = db.reencode_legacy_vectors_now()?;
-        eprintln!("rag-rat: re-encoded {converted} legacy f32 vector blobs to int8");
+        let deadline = args.max_seconds.map(|s| Instant::now() + std::time::Duration::from_secs(s));
+        let converted = db.reencode_legacy_vectors_now(deadline)?;
+        let report = serde_json::json!({ "reencoded_vectors": converted });
+        if output_format() == OutputFormat::Json {
+            print_output(&report)?;
+        } else {
+            eprintln!("rag-rat: re-encoded {converted} legacy f32 vector blobs to int8");
+        }
+        return Ok(());
     }
     let options = rag_rat_core::index::ai::ReconcileOptions {
         limit: args.limit,
@@ -974,15 +985,30 @@ fn run_maintenance_pass(
     // One-time on upgrade: re-encode any legacy f32 vector blobs to the compact int8 format (#312).
     // Meta-gated, so this runs once and then skips the table scan cheaply on every later pass; run
     // on the BASE index (not per-overlay) before the worktree refresh re-scopes the connection.
-    // Format-only (decode f32 → encode int8), so it's cheap — no model inference. BUDGETED: skipped
-    // entirely when `max_seconds == 0` (the "no embedding work" cap, mirroring `budget` below), and
-    // otherwise bounded by the same shared `started + max_seconds` deadline so a huge index can't
-    // hold the write lock for a full-table conversion past the cap — it stops at the deadline and
-    // resumes from a persisted cursor on the next pass.
-    if max_seconds > 0 {
-        let deadline = started + std::time::Duration::from_secs(max_seconds);
-        let _ = db.reencode_legacy_vectors_if_needed(Some(deadline));
-    }
+    // Format-only (decode f32 → encode int8), so it's cheap — no model inference.
+    //
+    // BUDGETED, and only gets a SHARE of the budget: skipped entirely when `max_seconds == 0` (the
+    // "no embedding work" cap, mirroring `budget` below), and otherwise bounded by `started +
+    // max_seconds/2` — only HALF the window. Giving it the full window would let a multi-pass
+    // conversion consume the whole budget every pass, so `budget.next_options()` returns None and
+    // new/changed chunks go un-embedded (BM25-only) for the whole window. With the half cap the
+    // embedding reconcile always gets the rest; and `max_seconds == 1` → `max_seconds/2 == 0` → an
+    // already-expired deadline → the re-encode does nothing this pass (the embedding reconcile
+    // wins), which is correct. Resumes from the persisted cursor across passes until complete.
+    let vector_reencode = if max_seconds > 0 {
+        let deadline = started + std::time::Duration::from_secs(max_seconds / 2);
+        match db.reencode_legacy_vectors_if_needed(Some(deadline)) {
+            Ok(converted) => Some(converted),
+            Err(e) => {
+                // Don't swallow it: the gate is set only on success, so a persistent error
+                // (SQLITE_BUSY, disk full) would otherwise retry-and-fail invisibly every pass.
+                eprintln!("rag-rat: vector re-encode pass failed (will retry): {e}");
+                None
+            },
+        }
+    } else {
+        None
+    };
     // ONE time budget for the whole pass — the per-overlay embedding reconciles AND the base
     // reconcile below — measured from `started` so discovery already counts against it. Without a
     // shared budget each overlay (each call starts its own `max_seconds` timer) plus the base could
@@ -1048,6 +1074,10 @@ fn run_maintenance_pass(
         "max_seconds": max_seconds,
         "elapsed_seconds": started.elapsed().as_secs_f64(),
         "reconcile": reconcile_report,
+        // #312: rows the legacy-f32 → int8 re-encode converted this pass, or null when it was
+        // skipped (max_seconds == 0, or already done/the gate was set so the call returned 0 — note
+        // a gate-skip also reports {"converted": 0}) or errored. Lets a --json consumer see progress.
+        "vector_reencode": vector_reencode.map(|n| serde_json::json!({ "converted": n })),
         "clone_graph": clone_graph_report,
         "gc": gc_report,
         "memory_validation": memory_validation,

--- a/crates/rag-rat-core/src/index/ai/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/mod.rs
@@ -1,6 +1,7 @@
 mod helpers;
 mod policy;
 mod reconcile;
+mod reencode;
 mod status;
 mod store;
 use std::collections::{BTreeMap, HashSet};
@@ -10,6 +11,7 @@ use std::time::Instant;
 pub(crate) use helpers::*;
 pub(crate) use policy::*;
 pub(crate) use reconcile::*;
+pub(crate) use reencode::*;
 use rusqlite::types::Value;
 use rusqlite::{Connection, OptionalExtension, params, params_from_iter};
 use serde::Serialize;

--- a/crates/rag-rat-core/src/index/ai/reencode.rs
+++ b/crates/rag-rat-core/src/index/ai/reencode.rs
@@ -11,7 +11,8 @@ const VECTOR_INT8_REENCODE_DONE_META: &str = "vector_int8_reencode_done";
 /// and writes a chunk, then commits and loops.
 const REENCODE_BATCH_SIZE: usize = 4_000;
 
-/// One legacy f32 row to re-encode: its compound key plus the stored vector bytes.
+/// One legacy f32 row to re-encode: its compound key plus the stored vector bytes. `(chunk_id,
+/// model_id)` is the `chunk_embeddings` PK and doubles as the keyset cursor.
 struct LegacyVectorRow {
     chunk_id: i64,
     model_id: String,
@@ -30,62 +31,93 @@ struct LegacyVectorRow {
 /// length-based format dispatch.
 ///
 /// Works in bounded batches inside per-batch transactions and is IDEMPOTENT + resumable: re-running
-/// converts only the rows still in f32; once every row is int8 the detect query returns nothing and
-/// it returns `Ok(0)`. Returns the total number of rows converted.
+/// converts only the rows still in f32. Returns the total number of rows converted.
 pub(crate) fn reencode_legacy_f32_blobs(conn: &Connection) -> anyhow::Result<usize> {
+    reencode_legacy_f32_blobs_batched(conn, REENCODE_BATCH_SIZE)
+}
+
+/// The conversion loop, parameterized by `batch_size` so tests can drive multi-batch behavior with
+/// a tiny size. The public wrapper passes [`REENCODE_BATCH_SIZE`].
+///
+/// Termination is CURSOR-driven, not "did this batch convert anything"-driven: a `(chunk_id,
+/// model_id)` keyset cursor walks the f32 rows in PK order, advancing past every row it reads
+/// (whether or not that row was actually converted). So a row skipped by the concurrent-rewrite
+/// guard or by a decode failure is simply passed over — never re-selected, never looped — and the
+/// loop ends when a batch comes back short of `batch_size`. The cursor also avoids the quadratic
+/// rescan a bare `LIMIT` would cause (each batch would otherwise re-scan from the table start past
+/// every already-converted row).
+fn reencode_legacy_f32_blobs_batched(
+    conn: &Connection,
+    batch_size: usize,
+) -> anyhow::Result<usize> {
     let mut total = 0usize;
+    // Cursor starts before every real row: `chunk_id >= ` any actual id, and the empty model_id
+    // sorts first, so `(chunk_id, model_id) > (i64::MIN, "")` matches all rows.
+    let mut cursor = (i64::MIN, String::new());
     loop {
         // Collect a whole batch BEFORE writing — the SELECT statement must be finalized (its borrow
-        // of `conn` dropped) before the per-row UPDATE takes the connection. `LIMIT` keeps each
-        // batch bounded; the `length(vector_blob) = 4 * embedding_dim` predicate is self-clearing
-        // (a converted row stops matching), so the same LIMIT walks the remaining f32 rows each
-        // pass.
-        let batch = collect_legacy_f32_batch(conn, REENCODE_BATCH_SIZE)?;
-        if batch.is_empty() {
+        // of `conn` dropped) before the per-row UPDATE takes the connection.
+        let batch = collect_legacy_f32_batch(conn, &cursor, batch_size)?;
+        let Some(last) = batch.last() else {
             break;
-        }
-        let converted = convert_batch(conn, &batch)?;
-        total += converted;
-        // Defensive termination: a non-empty batch that converted nothing means every row in it was
-        // un-decodable. That can't happen today — a length-selected row always decodes — but
-        // breaking (rather than re-selecting the same stuck rows forever) keeps the loop
-        // provably terminating regardless of `decode_vector`'s behavior. Un-convertible
-        // rows stay f32; they already decode-fail in search too, so leaving them is
-        // correct.
-        if converted == 0 {
+        };
+        // Advance the cursor to the batch's LAST key, so the next SELECT resumes via the PK index
+        // instead of rescanning. Done before the UPDATE (which mutates the rows) using the read
+        // values.
+        cursor = (last.chunk_id, last.model_id.clone());
+        let exhausted = batch.len() < batch_size;
+        total += convert_batch(conn, &batch)?;
+        if exhausted {
             break;
         }
     }
     Ok(total)
 }
 
-/// Read up to `limit` legacy f32 rows. The blob-length predicate is the format detector: f32 is
-/// `4 * embedding_dim` bytes, int8 is `embedding_dim + 4` — disjoint for `dim >= 1`.
+/// Read up to `limit` legacy f32 rows past `cursor`, in PK order. The blob-length predicate is the
+/// format detector (f32 is `4 * embedding_dim` bytes, int8 is `embedding_dim + 4` — disjoint for
+/// `dim >= 1`); the `(chunk_id, model_id) > cursor` keyset resumes past already-walked rows without
+/// rescanning, and ORDER BY makes "the batch's last row is the new cursor" well-defined.
 fn collect_legacy_f32_batch(
     conn: &Connection,
+    cursor: &(i64, String),
     limit: usize,
 ) -> anyhow::Result<Vec<LegacyVectorRow>> {
     let mut stmt = conn.prepare(
         "SELECT chunk_id, model_id, embedding_dim, vector_blob
          FROM chunk_embeddings
          WHERE length(vector_blob) = 4 * embedding_dim
-         LIMIT ?1",
+           AND (chunk_id, model_id) > (?1, ?2)
+         ORDER BY chunk_id, model_id
+         LIMIT ?3",
     )?;
-    let rows = stmt.query_map(params![i64::try_from(limit).unwrap_or(i64::MAX)], |row| {
-        let dim: i64 = row.get(2)?;
-        Ok(LegacyVectorRow {
-            chunk_id: row.get(0)?,
-            model_id: row.get(1)?,
-            dim: usize::try_from(dim).unwrap_or(0),
-            blob: row.get(3)?,
-        })
-    })?;
+    let rows = stmt.query_map(
+        params![cursor.0, cursor.1, i64::try_from(limit).unwrap_or(i64::MAX)],
+        |row| {
+            let dim: i64 = row.get(2)?;
+            Ok(LegacyVectorRow {
+                chunk_id: row.get(0)?,
+                model_id: row.get(1)?,
+                dim: usize::try_from(dim).unwrap_or(0),
+                blob: row.get(3)?,
+            })
+        },
+    )?;
     collect_rows(rows)
 }
 
-/// Convert one already-collected batch inside a single transaction. Returns the count successfully
-/// re-encoded (a row whose f32 blob fails to decode — e.g. a corrupt length/`dim` mismatch — is
-/// skipped, not aborted, so one bad row can't wedge the whole conversion).
+/// Convert one already-collected batch inside a single transaction. Returns the count actually
+/// re-encoded.
+///
+/// CONCURRENT-REWRITE GUARD: another writer (a reconcile re-embedding this chunk) can replace the
+/// row's `vector_blob` — and its `source_text_hash`/`input_hash` — between
+/// [`collect_legacy_f32_batch`] (the read) and this UPDATE. So the UPDATE is guarded on the
+/// ORIGINAL blob (`vector_blob = ?4`): if the row changed concurrently it no longer matches (new
+/// writes are always int8), the UPDATE is a no-op, and the row is left in its valid,
+/// freshly-embedded state instead of being clobbered with the stale f32 vector. Only rows whose
+/// UPDATE affected exactly one row count as converted; a row skipped by the guard, or one whose f32
+/// blob fails to decode (corrupt length/`dim` mismatch), is passed over — not an error, so one
+/// bad/raced row can't wedge the conversion.
 fn convert_batch(conn: &Connection, batch: &[LegacyVectorRow]) -> anyhow::Result<usize> {
     conn.execute_batch("BEGIN IMMEDIATE")?;
     let result = (|| {
@@ -94,12 +126,12 @@ fn convert_batch(conn: &Connection, batch: &[LegacyVectorRow]) -> anyhow::Result
             let Some(vector) = decode_vector(&row.blob, row.dim) else {
                 continue;
             };
-            conn.execute(
+            let changed = conn.execute(
                 "UPDATE chunk_embeddings SET vector_blob = ?1
-                 WHERE chunk_id = ?2 AND model_id = ?3",
-                params![encode_vector(&vector), row.chunk_id, row.model_id],
+                 WHERE chunk_id = ?2 AND model_id = ?3 AND vector_blob = ?4",
+                params![encode_vector(&vector), row.chunk_id, row.model_id, row.blob],
             )?;
-            converted += 1;
+            converted += changed;
         }
         Ok(converted)
     })();
@@ -124,6 +156,19 @@ pub(crate) fn reencode_legacy_vectors_if_needed(conn: &Connection) -> anyhow::Re
     if meta(conn, VECTOR_INT8_REENCODE_DONE_META)?.is_some() {
         return Ok(0);
     }
+    reencode_and_mark_done(conn)
+}
+
+/// FORCE the conversion, IGNORING the run-once gate at the start (the `--reencode-vectors` path) —
+/// but still SET the gate on success, so the next maintenance pass doesn't do a pointless full
+/// table scan it would otherwise skip. Returns the number of rows converted.
+pub(crate) fn reencode_legacy_vectors_now(conn: &Connection) -> anyhow::Result<usize> {
+    reencode_and_mark_done(conn)
+}
+
+/// Run the conversion then mark the run-once gate done. Shared by the gated and forced entry points
+/// (the only difference is whether the gate is CHECKED first).
+fn reencode_and_mark_done(conn: &Connection) -> anyhow::Result<usize> {
     let converted = reencode_legacy_f32_blobs(conn)?;
     set_meta(conn, VECTOR_INT8_REENCODE_DONE_META, "1")?;
     Ok(converted)
@@ -214,6 +259,15 @@ mod tests {
         assert_eq!(stored_blob(&conn, 2), b"", "empty failed-row blob untouched");
     }
 
+    fn count_remaining_f32(conn: &Connection) -> i64 {
+        conn.query_row(
+            "SELECT COUNT(*) FROM chunk_embeddings WHERE length(vector_blob) = 4 * embedding_dim",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap()
+    }
+
     #[test]
     fn reencode_walks_multiple_batches() {
         let conn = setup_conn();
@@ -226,15 +280,54 @@ mod tests {
         }
         assert_eq!(reencode_legacy_f32_blobs(&conn).unwrap(), total);
         // Every row is now int8.
-        let remaining: i64 = conn
-            .query_row(
-                "SELECT COUNT(*) FROM chunk_embeddings WHERE length(vector_blob) = 4 * \
-                 embedding_dim",
-                [],
-                |row| row.get(0),
-            )
-            .unwrap();
-        assert_eq!(remaining, 0);
+        assert_eq!(count_remaining_f32(&conn), 0);
+    }
+
+    #[test]
+    fn keyset_cursor_walks_every_row_across_chunk_ids_and_models_with_tiny_batches() {
+        // The keyset cursor is `(chunk_id, model_id)`, so a chunk_id with multiple models and many
+        // chunk_ids must ALL convert even when the batch boundary splits a chunk_id's models. Drive
+        // a tiny batch_size so the loop iterates many times over a handful of rows: any cursor bug
+        // (skipping the rest of a chunk_id's models, or re-selecting + looping) shows here.
+        let conn = setup_conn();
+        let vector = vec![0.5_f32, -0.5, 0.25, -0.25];
+        let blob = f32_blob(&vector);
+        // 5 chunk_ids, each with 2 model_ids (model-a, model-b) = 10 rows; batch_size 2 ⇒ ≥5
+        // passes, and the (chunk_id, model_id) ordering means a batch boundary lands
+        // mid-chunk_id.
+        for chunk_id in 0..5 {
+            for model in ["model-a", "model-b"] {
+                insert_row(&conn, chunk_id, model, &blob, vector.len());
+            }
+        }
+        let converted = reencode_legacy_f32_blobs_batched(&conn, 2).unwrap();
+        assert_eq!(converted, 10, "every (chunk_id, model_id) row must convert");
+        assert_eq!(count_remaining_f32(&conn), 0);
+    }
+
+    #[test]
+    fn concurrent_rewrite_guard_leaves_a_changed_row_untouched() {
+        // Simulate the race: the row was re-embedded (now a different blob) between the read and
+        // the UPDATE. We model it by passing a `LegacyVectorRow` whose `blob` (the f32
+        // bytes we "read") differs from what is now stored. The blob-guarded UPDATE must
+        // NOT match, so the stored row is left exactly as the concurrent writer left it,
+        // and it is NOT counted.
+        let conn = setup_conn();
+        let dim = 4;
+        // What the concurrent writer left in place: a valid int8 blob (new writes are always int8).
+        let current_int8 = encode_vector(&[0.1_f32, -0.4, 0.9, -0.2]);
+        insert_row(&conn, 1, "model-a", &current_int8, dim);
+
+        // The row WE think we read, with a STALE f32 blob that no longer matches what is stored.
+        let stale = LegacyVectorRow {
+            chunk_id: 1,
+            model_id: "model-a".to_string(),
+            dim,
+            blob: f32_blob(&[0.9_f32, 0.9, 0.9, 0.9]),
+        };
+        let converted = convert_batch(&conn, std::slice::from_ref(&stale)).unwrap();
+        assert_eq!(converted, 0, "guarded UPDATE must not touch a concurrently-changed row");
+        assert_eq!(stored_blob(&conn, 1), current_int8, "stored row left as the writer left it");
     }
 
     #[test]
@@ -253,5 +346,19 @@ mod tests {
         insert_row(&conn, 2, "model-a", &f32_blob(&vector), vector.len());
         assert_eq!(reencode_legacy_vectors_if_needed(&conn).unwrap(), 0);
         assert_eq!(stored_blob(&conn, 2).len(), 4 * vector.len());
+    }
+
+    #[test]
+    fn forced_path_converts_ignoring_gate_then_sets_it() {
+        let conn = setup_conn();
+        let vector = vec![0.3_f32, -0.6, 0.9, -0.1];
+        insert_row(&conn, 1, "model-a", &f32_blob(&vector), vector.len());
+        // Pre-set the gate: the forced path must IGNORE it at the start and still convert.
+        set_meta(&conn, VECTOR_INT8_REENCODE_DONE_META, "1").unwrap();
+
+        assert_eq!(reencode_legacy_vectors_now(&conn).unwrap(), 1);
+        // ... and it leaves the gate set, so a later maintenance pass skips the full scan.
+        assert_eq!(meta(&conn, VECTOR_INT8_REENCODE_DONE_META).unwrap().as_deref(), Some("1"));
+        assert_eq!(reencode_legacy_vectors_if_needed(&conn).unwrap(), 0);
     }
 }

--- a/crates/rag-rat-core/src/index/ai/reencode.rs
+++ b/crates/rag-rat-core/src/index/ai/reencode.rs
@@ -1,0 +1,257 @@
+use super::*;
+
+/// Meta key marking the one-time legacy-f32 → int8 vector re-encode as done. Once set to `"1"`,
+/// [`reencode_legacy_vectors_if_needed`] skips the (full-table) detect query on every later
+/// maintenance pass. Safe as a run-once gate because new writes are ALWAYS int8 (`encode_vector`),
+/// so no fresh f32 rows ever appear after the conversion.
+const VECTOR_INT8_REENCODE_DONE_META: &str = "vector_int8_reencode_done";
+
+/// Rows converted per transaction. Bounded so a huge index (millions of embeddings) never builds
+/// one giant transaction or holds the write lock for the whole table — each batch reads, converts,
+/// and writes a chunk, then commits and loops.
+const REENCODE_BATCH_SIZE: usize = 4_000;
+
+/// One legacy f32 row to re-encode: its compound key plus the stored vector bytes.
+struct LegacyVectorRow {
+    chunk_id: i64,
+    model_id: String,
+    dim: usize,
+    blob: Vec<u8>,
+}
+
+/// Re-encode every `chunk_embeddings` row still stored in the legacy f32 format to the compact int8
+/// format (#312). This is a FORMAT-ONLY conversion — decode the f32 blob, re-encode it with
+/// [`encode_vector`] (now int8); NO model inference runs, so it is cheap and quality-identical to a
+/// fresh int8 reconcile.
+///
+/// The f32 rows are detected purely by blob length: an f32 blob is `4 * embedding_dim` bytes, an
+/// int8 blob is `embedding_dim + 4`, and the two never collide for `dim >= 1` (so a freshly-int8
+/// row, or a `Failed` row's empty `x''` blob, is never selected). Matches [`decode_vector`]'s
+/// length-based format dispatch.
+///
+/// Works in bounded batches inside per-batch transactions and is IDEMPOTENT + resumable: re-running
+/// converts only the rows still in f32; once every row is int8 the detect query returns nothing and
+/// it returns `Ok(0)`. Returns the total number of rows converted.
+pub(crate) fn reencode_legacy_f32_blobs(conn: &Connection) -> anyhow::Result<usize> {
+    let mut total = 0usize;
+    loop {
+        // Collect a whole batch BEFORE writing — the SELECT statement must be finalized (its borrow
+        // of `conn` dropped) before the per-row UPDATE takes the connection. `LIMIT` keeps each
+        // batch bounded; the `length(vector_blob) = 4 * embedding_dim` predicate is self-clearing
+        // (a converted row stops matching), so the same LIMIT walks the remaining f32 rows each
+        // pass.
+        let batch = collect_legacy_f32_batch(conn, REENCODE_BATCH_SIZE)?;
+        if batch.is_empty() {
+            break;
+        }
+        let converted = convert_batch(conn, &batch)?;
+        total += converted;
+        // Defensive termination: a non-empty batch that converted nothing means every row in it was
+        // un-decodable. That can't happen today — a length-selected row always decodes — but
+        // breaking (rather than re-selecting the same stuck rows forever) keeps the loop
+        // provably terminating regardless of `decode_vector`'s behavior. Un-convertible
+        // rows stay f32; they already decode-fail in search too, so leaving them is
+        // correct.
+        if converted == 0 {
+            break;
+        }
+    }
+    Ok(total)
+}
+
+/// Read up to `limit` legacy f32 rows. The blob-length predicate is the format detector: f32 is
+/// `4 * embedding_dim` bytes, int8 is `embedding_dim + 4` — disjoint for `dim >= 1`.
+fn collect_legacy_f32_batch(
+    conn: &Connection,
+    limit: usize,
+) -> anyhow::Result<Vec<LegacyVectorRow>> {
+    let mut stmt = conn.prepare(
+        "SELECT chunk_id, model_id, embedding_dim, vector_blob
+         FROM chunk_embeddings
+         WHERE length(vector_blob) = 4 * embedding_dim
+         LIMIT ?1",
+    )?;
+    let rows = stmt.query_map(params![i64::try_from(limit).unwrap_or(i64::MAX)], |row| {
+        let dim: i64 = row.get(2)?;
+        Ok(LegacyVectorRow {
+            chunk_id: row.get(0)?,
+            model_id: row.get(1)?,
+            dim: usize::try_from(dim).unwrap_or(0),
+            blob: row.get(3)?,
+        })
+    })?;
+    collect_rows(rows)
+}
+
+/// Convert one already-collected batch inside a single transaction. Returns the count successfully
+/// re-encoded (a row whose f32 blob fails to decode — e.g. a corrupt length/`dim` mismatch — is
+/// skipped, not aborted, so one bad row can't wedge the whole conversion).
+fn convert_batch(conn: &Connection, batch: &[LegacyVectorRow]) -> anyhow::Result<usize> {
+    conn.execute_batch("BEGIN IMMEDIATE")?;
+    let result = (|| {
+        let mut converted = 0usize;
+        for row in batch {
+            let Some(vector) = decode_vector(&row.blob, row.dim) else {
+                continue;
+            };
+            conn.execute(
+                "UPDATE chunk_embeddings SET vector_blob = ?1
+                 WHERE chunk_id = ?2 AND model_id = ?3",
+                params![encode_vector(&vector), row.chunk_id, row.model_id],
+            )?;
+            converted += 1;
+        }
+        Ok(converted)
+    })();
+    match result {
+        Ok(converted) => {
+            conn.execute_batch("COMMIT")?;
+            Ok(converted)
+        },
+        Err(err) => {
+            let _ = conn.execute_batch("ROLLBACK");
+            Err(err)
+        },
+    }
+}
+
+/// Run the legacy-f32 → int8 conversion the FIRST time after upgrade, then skip cheaply on every
+/// later pass via the [`VECTOR_INT8_REENCODE_DONE_META`] gate (so maintenance does not full-scan
+/// `chunk_embeddings` every pass). Returns the number of rows converted this call (`0` once the
+/// gate is set). Safe to call repeatedly and from the base index only — the meta gate AND the
+/// f32-detect query both make a stray double-call a no-op.
+pub(crate) fn reencode_legacy_vectors_if_needed(conn: &Connection) -> anyhow::Result<usize> {
+    if meta(conn, VECTOR_INT8_REENCODE_DONE_META)?.is_some() {
+        return Ok(0);
+    }
+    let converted = reencode_legacy_f32_blobs(conn)?;
+    set_meta(conn, VECTOR_INT8_REENCODE_DONE_META, "1")?;
+    Ok(converted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal `chunk_embeddings` shape — only the columns the re-encode touches, so the test does
+    /// not depend on the full schema/bootstrap. `index_meta` is the gate store.
+    fn setup_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE chunk_embeddings(
+                 chunk_id INTEGER NOT NULL,
+                 model_id TEXT NOT NULL,
+                 embedding_dim INTEGER NOT NULL,
+                 vector_blob BLOB NOT NULL,
+                 PRIMARY KEY(chunk_id, model_id)
+             );
+             CREATE TABLE index_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn f32_blob(vector: &[f32]) -> Vec<u8> {
+        vector.iter().flat_map(|v| v.to_le_bytes()).collect()
+    }
+
+    fn insert_row(conn: &Connection, chunk_id: i64, model_id: &str, blob: &[u8], dim: usize) {
+        conn.execute(
+            "INSERT INTO chunk_embeddings(chunk_id, model_id, embedding_dim, vector_blob)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![chunk_id, model_id, i64::try_from(dim).unwrap(), blob],
+        )
+        .unwrap();
+    }
+
+    fn stored_blob(conn: &Connection, chunk_id: i64) -> Vec<u8> {
+        conn.query_row(
+            "SELECT vector_blob FROM chunk_embeddings WHERE chunk_id = ?1",
+            params![chunk_id],
+            |row| row.get(0),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn reencode_converts_f32_row_to_int8_and_is_idempotent() {
+        let conn = setup_conn();
+        let vector = vec![0.12_f32, -0.5, 0.97, -0.2, 0.0, 0.33, -0.81];
+        let dim = vector.len();
+        let original = f32_blob(&vector);
+        assert_eq!(original.len(), 4 * dim, "fixture must be the 4*dim f32 format");
+        insert_row(&conn, 1, "model-a", &original, dim);
+
+        let converted = reencode_legacy_f32_blobs(&conn).unwrap();
+        assert_eq!(converted, 1);
+
+        // (a) the stored blob is now the compact int8 format (4-byte scale + one byte per dim).
+        let new_blob = stored_blob(&conn, 1);
+        assert_eq!(new_blob.len(), 4 + dim);
+
+        // (b) decode of the new blob matches the original within one quantization step.
+        let decoded = decode_vector(&new_blob, dim).unwrap();
+        let step = 0.97 / 127.0; // max|v| / 127
+        for (a, b) in vector.iter().zip(&decoded) {
+            assert!((a - b).abs() <= step + 1e-6, "{a} vs {b} (step {step})");
+        }
+
+        // (c) a second run converts nothing — once int8, the row no longer matches the detector.
+        assert_eq!(reencode_legacy_f32_blobs(&conn).unwrap(), 0);
+    }
+
+    #[test]
+    fn reencode_leaves_existing_int8_and_empty_blobs_untouched() {
+        let conn = setup_conn();
+        // An already-int8 row (4 + dim bytes) and a Failed row's empty blob must NOT be selected:
+        // `4*dim` collides with neither `dim+4` (dim>=1) nor `0`.
+        let int8 = encode_vector(&[0.1_f32, -0.4, 0.9, -0.2]);
+        insert_row(&conn, 1, "model-a", &int8, 4);
+        insert_row(&conn, 2, "model-a", b"", 4);
+
+        assert_eq!(reencode_legacy_f32_blobs(&conn).unwrap(), 0);
+        assert_eq!(stored_blob(&conn, 1), int8, "int8 row must be byte-identical");
+        assert_eq!(stored_blob(&conn, 2), b"", "empty failed-row blob untouched");
+    }
+
+    #[test]
+    fn reencode_walks_multiple_batches() {
+        let conn = setup_conn();
+        // More rows than one batch so the loop must iterate; build a count that crosses the bound.
+        let total = REENCODE_BATCH_SIZE + 37;
+        let vector = vec![0.5_f32, -0.5, 0.25, -0.25];
+        let blob = f32_blob(&vector);
+        for id in 0..total {
+            insert_row(&conn, id as i64, "model-a", &blob, vector.len());
+        }
+        assert_eq!(reencode_legacy_f32_blobs(&conn).unwrap(), total);
+        // Every row is now int8.
+        let remaining: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM chunk_embeddings WHERE length(vector_blob) = 4 * \
+                 embedding_dim",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(remaining, 0);
+    }
+
+    #[test]
+    fn if_needed_runs_once_then_meta_gate_skips() {
+        let conn = setup_conn();
+        let vector = vec![0.3_f32, -0.6, 0.9, -0.1];
+        insert_row(&conn, 1, "model-a", &f32_blob(&vector), vector.len());
+
+        // First call converts and sets the gate.
+        assert_eq!(reencode_legacy_vectors_if_needed(&conn).unwrap(), 1);
+        assert_eq!(meta(&conn, VECTOR_INT8_REENCODE_DONE_META).unwrap().as_deref(), Some("1"));
+
+        // Insert a fresh f32 row AFTER the gate is set — the second call must be a no-op (it does
+        // not even run the detect query), so the new row stays f32. This models the invariant that
+        // no new f32 rows ever appear in practice (writes are always int8), so the gate is safe.
+        insert_row(&conn, 2, "model-a", &f32_blob(&vector), vector.len());
+        assert_eq!(reencode_legacy_vectors_if_needed(&conn).unwrap(), 0);
+        assert_eq!(stored_blob(&conn, 2).len(), 4 * vector.len());
+    }
+}

--- a/crates/rag-rat-core/src/index/ai/reencode.rs
+++ b/crates/rag-rat-core/src/index/ai/reencode.rs
@@ -6,10 +6,25 @@ use super::*;
 /// so no fresh f32 rows ever appear after the conversion.
 const VECTOR_INT8_REENCODE_DONE_META: &str = "vector_int8_reencode_done";
 
+/// Reconcile-meta key persisting the keyset cursor (the last converted `(chunk_id, model_id)`)
+/// across maintenance passes, so a deadline-stopped conversion RESUMES from where it left off
+/// instead of rescanning from the table head. Serialized as `"<chunk_id>\n<model_id>"`. Only
+/// meaningful while the done-gate ([`VECTOR_INT8_REENCODE_DONE_META`]) is unset.
+const VECTOR_INT8_REENCODE_CURSOR_META: &str = "vector_int8_reencode_cursor";
+
 /// Rows converted per transaction. Bounded so a huge index (millions of embeddings) never builds
 /// one giant transaction or holds the write lock for the whole table — each batch reads, converts,
 /// and writes a chunk, then commits and loops.
 const REENCODE_BATCH_SIZE: usize = 4_000;
+
+/// Outcome of a conversion run: how many rows it re-encoded, and whether it ran to the NATURAL end
+/// (`completed == true` — a batch came back short, so no f32 rows remain past the cursor) versus
+/// being cut short by the deadline (`completed == false`). The wrapper sets the run-once done-gate
+/// only when `completed`.
+struct ReencodeOutcome {
+    converted: usize,
+    completed: bool,
+}
 
 /// One legacy f32 row to re-encode: its compound key plus the stored vector bytes. `(chunk_id,
 /// model_id)` is the `chunk_embeddings` PK and doubles as the keyset cursor.
@@ -31,13 +46,11 @@ struct LegacyVectorRow {
 /// length-based format dispatch.
 ///
 /// Works in bounded batches inside per-batch transactions and is IDEMPOTENT + resumable: re-running
-/// converts only the rows still in f32. Returns the total number of rows converted.
-pub(crate) fn reencode_legacy_f32_blobs(conn: &Connection) -> anyhow::Result<usize> {
-    reencode_legacy_f32_blobs_batched(conn, REENCODE_BATCH_SIZE)
-}
-
-/// The conversion loop, parameterized by `batch_size` so tests can drive multi-batch behavior with
-/// a tiny size. The public wrapper passes [`REENCODE_BATCH_SIZE`].
+/// converts only the rows still in f32.
+///
+/// The conversion loop, parameterized by `batch_size` (so tests can drive multi-batch behavior with
+/// a tiny size; the public wrapper passes [`REENCODE_BATCH_SIZE`]) and a `deadline` (so the
+/// budgeted maintenance path can stop mid-conversion).
 ///
 /// Termination is CURSOR-driven, not "did this batch convert anything"-driven: a `(chunk_id,
 /// model_id)` keyset cursor walks the f32 rows in PK order, advancing past every row it reads
@@ -46,32 +59,75 @@ pub(crate) fn reencode_legacy_f32_blobs(conn: &Connection) -> anyhow::Result<usi
 /// loop ends when a batch comes back short of `batch_size`. The cursor also avoids the quadratic
 /// rescan a bare `LIMIT` would cause (each batch would otherwise re-scan from the table start past
 /// every already-converted row).
+///
+/// The cursor is PERSISTED (`VECTOR_INT8_REENCODE_CURSOR_META`) after each committed batch and
+/// LOADED at the start, so a deadline-stopped run resumes from where it left off on the next call
+/// rather than rescanning. `completed` is `true` only when the loop reached the natural end (a
+/// short batch = no f32 rows remain); a deadline stop returns `completed == false` with the cursor
+/// left persisted.
 fn reencode_legacy_f32_blobs_batched(
     conn: &Connection,
     batch_size: usize,
-) -> anyhow::Result<usize> {
+    deadline: Option<Instant>,
+) -> anyhow::Result<ReencodeOutcome> {
     let mut total = 0usize;
-    // Cursor starts before every real row: `chunk_id >= ` any actual id, and the empty model_id
-    // sorts first, so `(chunk_id, model_id) > (i64::MIN, "")` matches all rows.
-    let mut cursor = (i64::MIN, String::new());
+    // Resume from the persisted cursor if one is stored (a prior deadline-stopped run); otherwise
+    // start before every real row — `chunk_id >= ` any actual id, and the empty model_id sorts
+    // first, so `(chunk_id, model_id) > (i64::MIN, "")` matches all rows.
+    let mut cursor = load_cursor(conn)?;
     loop {
         // Collect a whole batch BEFORE writing — the SELECT statement must be finalized (its borrow
         // of `conn` dropped) before the per-row UPDATE takes the connection.
         let batch = collect_legacy_f32_batch(conn, &cursor, batch_size)?;
         let Some(last) = batch.last() else {
-            break;
+            // No rows past the cursor → conversion is complete.
+            return Ok(ReencodeOutcome { converted: total, completed: true });
         };
         // Advance the cursor to the batch's LAST key, so the next SELECT resumes via the PK index
-        // instead of rescanning. Done before the UPDATE (which mutates the rows) using the read
+        // instead of rescanning. Computed before the UPDATE (which mutates the rows) from the read
         // values.
         cursor = (last.chunk_id, last.model_id.clone());
         let exhausted = batch.len() < batch_size;
         total += convert_batch(conn, &batch)?;
+        // Persist the cursor only after the batch's transaction has committed, so a crash never
+        // leaves the cursor ahead of the durably-converted rows (it can lag — those rows are simply
+        // re-checked and skipped — but must never skip an unconverted row).
+        save_cursor(conn, &cursor)?;
         if exhausted {
-            break;
+            return Ok(ReencodeOutcome { converted: total, completed: true });
+        }
+        // Deadline check AFTER a committed batch (never mid-batch): stop without marking complete
+        // so the next pass resumes from the just-persisted cursor.
+        if deadline.is_some_and(|dl| Instant::now() >= dl) {
+            return Ok(ReencodeOutcome { converted: total, completed: false });
         }
     }
-    Ok(total)
+}
+
+/// Load the persisted keyset cursor, or the start-of-table sentinel `(i64::MIN, "")` when none is
+/// stored (first run, or after a completed conversion cleared it). A malformed stored value falls
+/// back to the sentinel — re-walking from the head is correct (already-int8 rows are skipped),
+/// never wrong.
+fn load_cursor(conn: &Connection) -> anyhow::Result<(i64, String)> {
+    let Some(raw) = reconcile_meta(conn, VECTOR_INT8_REENCODE_CURSOR_META)? else {
+        return Ok((i64::MIN, String::new()));
+    };
+    let Some((chunk_id, model_id)) = raw.split_once('\n') else {
+        return Ok((i64::MIN, String::new()));
+    };
+    match chunk_id.parse::<i64>() {
+        Ok(chunk_id) => Ok((chunk_id, model_id.to_string())),
+        Err(_) => Ok((i64::MIN, String::new())),
+    }
+}
+
+/// Persist the keyset cursor as `"<chunk_id>\n<model_id>"` (model ids never contain a newline).
+fn save_cursor(conn: &Connection, cursor: &(i64, String)) -> anyhow::Result<()> {
+    set_reconcile_meta(
+        conn,
+        VECTOR_INT8_REENCODE_CURSOR_META,
+        &format!("{}\n{}", cursor.0, cursor.1),
+    )
 }
 
 /// Read up to `limit` legacy f32 rows past `cursor`, in PK order. The blob-length predicate is the
@@ -152,26 +208,53 @@ fn convert_batch(conn: &Connection, batch: &[LegacyVectorRow]) -> anyhow::Result
 /// `chunk_embeddings` every pass). Returns the number of rows converted this call (`0` once the
 /// gate is set). Safe to call repeatedly and from the base index only — the meta gate AND the
 /// f32-detect query both make a stray double-call a no-op.
-pub(crate) fn reencode_legacy_vectors_if_needed(conn: &Connection) -> anyhow::Result<usize> {
+///
+/// `deadline` bounds the work so the conversion honors the maintenance time budget: when the
+/// deadline passes mid-conversion the run STOPS, leaves the done-gate UNSET, and persists its
+/// keyset cursor — so the next maintenance pass resumes from there (no rescan) rather than redoing
+/// the whole table. `None` runs to completion. The gate is set ONLY when the conversion fully
+/// completes.
+pub(crate) fn reencode_legacy_vectors_if_needed(
+    conn: &Connection,
+    deadline: Option<Instant>,
+) -> anyhow::Result<usize> {
     if meta(conn, VECTOR_INT8_REENCODE_DONE_META)?.is_some() {
         return Ok(0);
     }
-    reencode_and_mark_done(conn)
+    reencode_and_mark_if_complete(conn, deadline)
 }
 
 /// FORCE the conversion, IGNORING the run-once gate at the start (the `--reencode-vectors` path) —
-/// but still SET the gate on success, so the next maintenance pass doesn't do a pointless full
-/// table scan it would otherwise skip. Returns the number of rows converted.
+/// runs to completion (no deadline) and SETS the gate on success, so the next maintenance pass
+/// doesn't do a pointless full table scan it would otherwise skip. May resume from a persisted
+/// cursor left by a prior deadline-stopped maintenance run. Returns the number of rows converted.
 pub(crate) fn reencode_legacy_vectors_now(conn: &Connection) -> anyhow::Result<usize> {
-    reencode_and_mark_done(conn)
+    reencode_and_mark_if_complete(conn, None)
 }
 
-/// Run the conversion then mark the run-once gate done. Shared by the gated and forced entry points
-/// (the only difference is whether the gate is CHECKED first).
-fn reencode_and_mark_done(conn: &Connection) -> anyhow::Result<usize> {
-    let converted = reencode_legacy_f32_blobs(conn)?;
-    set_meta(conn, VECTOR_INT8_REENCODE_DONE_META, "1")?;
-    Ok(converted)
+/// Run the conversion (resuming from / persisting the keyset cursor) and mark the run-once gate
+/// done ONLY when it ran to the natural end. On a deadline stop the gate stays unset and the cursor
+/// remains persisted, so the next call resumes. On completion the cursor key is cleared (it is no
+/// longer meaningful, and a future stray re-run starts clean). Shared by the gated and forced entry
+/// points — they differ only in whether the gate is CHECKED first and whether a deadline is passed.
+fn reencode_and_mark_if_complete(
+    conn: &Connection,
+    deadline: Option<Instant>,
+) -> anyhow::Result<usize> {
+    let outcome = reencode_legacy_f32_blobs_batched(conn, REENCODE_BATCH_SIZE, deadline)?;
+    if outcome.completed {
+        set_meta(conn, VECTOR_INT8_REENCODE_DONE_META, "1")?;
+        clear_cursor(conn)?;
+    }
+    Ok(outcome.converted)
+}
+
+/// Drop the persisted keyset cursor once the conversion is complete (it is no longer meaningful).
+fn clear_cursor(conn: &Connection) -> anyhow::Result<()> {
+    conn.execute("DELETE FROM reconcile_meta WHERE key = ?1", params![
+        VECTOR_INT8_REENCODE_CURSOR_META
+    ])?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -179,7 +262,8 @@ mod tests {
     use super::*;
 
     /// Minimal `chunk_embeddings` shape — only the columns the re-encode touches, so the test does
-    /// not depend on the full schema/bootstrap. `index_meta` is the gate store.
+    /// not depend on the full schema/bootstrap. `index_meta` is the done-gate store;
+    /// `reconcile_meta` is the keyset-cursor store.
     fn setup_conn() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(
@@ -190,7 +274,8 @@ mod tests {
                  vector_blob BLOB NOT NULL,
                  PRIMARY KEY(chunk_id, model_id)
              );
-             CREATE TABLE index_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);",
+             CREATE TABLE index_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             CREATE TABLE reconcile_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);",
         )
         .unwrap();
         conn
@@ -218,6 +303,14 @@ mod tests {
         .unwrap()
     }
 
+    /// Run the full conversion (production batch size, no deadline) and return the converted count
+    /// — the common shape the basic round-trip/idempotency tests want.
+    fn run_to_completion(conn: &Connection) -> usize {
+        let outcome = reencode_legacy_f32_blobs_batched(conn, REENCODE_BATCH_SIZE, None).unwrap();
+        assert!(outcome.completed, "a no-deadline run must reach the natural end");
+        outcome.converted
+    }
+
     #[test]
     fn reencode_converts_f32_row_to_int8_and_is_idempotent() {
         let conn = setup_conn();
@@ -227,7 +320,7 @@ mod tests {
         assert_eq!(original.len(), 4 * dim, "fixture must be the 4*dim f32 format");
         insert_row(&conn, 1, "model-a", &original, dim);
 
-        let converted = reencode_legacy_f32_blobs(&conn).unwrap();
+        let converted = run_to_completion(&conn);
         assert_eq!(converted, 1);
 
         // (a) the stored blob is now the compact int8 format (4-byte scale + one byte per dim).
@@ -242,7 +335,7 @@ mod tests {
         }
 
         // (c) a second run converts nothing — once int8, the row no longer matches the detector.
-        assert_eq!(reencode_legacy_f32_blobs(&conn).unwrap(), 0);
+        assert_eq!(run_to_completion(&conn), 0);
     }
 
     #[test]
@@ -254,7 +347,7 @@ mod tests {
         insert_row(&conn, 1, "model-a", &int8, 4);
         insert_row(&conn, 2, "model-a", b"", 4);
 
-        assert_eq!(reencode_legacy_f32_blobs(&conn).unwrap(), 0);
+        assert_eq!(run_to_completion(&conn), 0);
         assert_eq!(stored_blob(&conn, 1), int8, "int8 row must be byte-identical");
         assert_eq!(stored_blob(&conn, 2), b"", "empty failed-row blob untouched");
     }
@@ -278,7 +371,7 @@ mod tests {
         for id in 0..total {
             insert_row(&conn, id as i64, "model-a", &blob, vector.len());
         }
-        assert_eq!(reencode_legacy_f32_blobs(&conn).unwrap(), total);
+        assert_eq!(run_to_completion(&conn), total);
         // Every row is now int8.
         assert_eq!(count_remaining_f32(&conn), 0);
     }
@@ -300,8 +393,9 @@ mod tests {
                 insert_row(&conn, chunk_id, model, &blob, vector.len());
             }
         }
-        let converted = reencode_legacy_f32_blobs_batched(&conn, 2).unwrap();
-        assert_eq!(converted, 10, "every (chunk_id, model_id) row must convert");
+        let outcome = reencode_legacy_f32_blobs_batched(&conn, 2, None).unwrap();
+        assert_eq!(outcome.converted, 10, "every (chunk_id, model_id) row must convert");
+        assert!(outcome.completed, "a no-deadline run reaches the natural end");
         assert_eq!(count_remaining_f32(&conn), 0);
     }
 
@@ -337,14 +431,14 @@ mod tests {
         insert_row(&conn, 1, "model-a", &f32_blob(&vector), vector.len());
 
         // First call converts and sets the gate.
-        assert_eq!(reencode_legacy_vectors_if_needed(&conn).unwrap(), 1);
+        assert_eq!(reencode_legacy_vectors_if_needed(&conn, None).unwrap(), 1);
         assert_eq!(meta(&conn, VECTOR_INT8_REENCODE_DONE_META).unwrap().as_deref(), Some("1"));
 
         // Insert a fresh f32 row AFTER the gate is set — the second call must be a no-op (it does
         // not even run the detect query), so the new row stays f32. This models the invariant that
         // no new f32 rows ever appear in practice (writes are always int8), so the gate is safe.
         insert_row(&conn, 2, "model-a", &f32_blob(&vector), vector.len());
-        assert_eq!(reencode_legacy_vectors_if_needed(&conn).unwrap(), 0);
+        assert_eq!(reencode_legacy_vectors_if_needed(&conn, None).unwrap(), 0);
         assert_eq!(stored_blob(&conn, 2).len(), 4 * vector.len());
     }
 
@@ -359,6 +453,57 @@ mod tests {
         assert_eq!(reencode_legacy_vectors_now(&conn).unwrap(), 1);
         // ... and it leaves the gate set, so a later maintenance pass skips the full scan.
         assert_eq!(meta(&conn, VECTOR_INT8_REENCODE_DONE_META).unwrap().as_deref(), Some("1"));
-        assert_eq!(reencode_legacy_vectors_if_needed(&conn).unwrap(), 0);
+        assert_eq!(reencode_legacy_vectors_if_needed(&conn, None).unwrap(), 0);
+    }
+
+    fn stored_cursor(conn: &Connection) -> Option<String> {
+        reconcile_meta(conn, VECTOR_INT8_REENCODE_CURSOR_META).unwrap()
+    }
+
+    #[test]
+    fn deadline_stop_leaves_gate_unset_and_persists_cursor_then_resumes_to_completion() {
+        let conn = setup_conn();
+        let vector = vec![0.5_f32, -0.5, 0.25, -0.25];
+        let blob = f32_blob(&vector);
+        for chunk_id in 0..6 {
+            insert_row(&conn, chunk_id, "model-a", &blob, vector.len());
+        }
+
+        // An ALREADY-ELAPSED deadline: the loop converts its first batch (the deadline is only
+        // checked AFTER a committed batch, so progress is always made), then stops because
+        // `Instant::now() >= deadline`. With batch_size 2 over 6 rows it converts exactly 2, leaves
+        // the done-gate UNSET, and persists the cursor at the 2nd row's key.
+        let past = Instant::now() - std::time::Duration::from_secs(1);
+        let outcome = reencode_legacy_f32_blobs_batched(&conn, 2, Some(past)).unwrap();
+        assert_eq!(outcome.converted, 2, "one batch runs before the deadline halts the loop");
+        assert!(!outcome.completed, "a deadline stop is not a completion");
+        assert_eq!(count_remaining_f32(&conn), 4, "the rest are still f32");
+        assert_eq!(stored_cursor(&conn).as_deref(), Some("1\nmodel-a"), "cursor at the 2nd row");
+
+        // The gated entry point STOPPED here would NOT set the done-gate (verified via the loop
+        // above returning completed=false). A follow-up call with NO deadline resumes FROM THE
+        // PERSISTED CURSOR (not a rescan) and finishes the remaining 4 rows, sets the gate, and
+        // clears the cursor.
+        let converted = reencode_legacy_vectors_if_needed(&conn, None).unwrap();
+        assert_eq!(converted, 4, "resumes the remaining rows, not all 6");
+        assert_eq!(count_remaining_f32(&conn), 0, "all rows now int8");
+        assert_eq!(meta(&conn, VECTOR_INT8_REENCODE_DONE_META).unwrap().as_deref(), Some("1"));
+        assert_eq!(stored_cursor(&conn), None, "cursor cleared on completion");
+    }
+
+    #[test]
+    fn if_needed_with_deadline_completes_and_sets_gate_when_work_fits() {
+        // A normal (deadline far in the future) run via the gated entry point still fully converts
+        // and sets the done-gate — the deadline plumbing doesn't change the happy path.
+        let conn = setup_conn();
+        let vector = vec![0.3_f32, -0.6, 0.9, -0.1];
+        for chunk_id in 0..3 {
+            insert_row(&conn, chunk_id, "model-a", &f32_blob(&vector), vector.len());
+        }
+        let far = Instant::now() + std::time::Duration::from_secs(3600);
+        assert_eq!(reencode_legacy_vectors_if_needed(&conn, Some(far)).unwrap(), 3);
+        assert_eq!(count_remaining_f32(&conn), 0);
+        assert_eq!(meta(&conn, VECTOR_INT8_REENCODE_DONE_META).unwrap().as_deref(), Some("1"));
+        assert_eq!(stored_cursor(&conn), None);
     }
 }

--- a/crates/rag-rat-core/src/index/ai/reencode.rs
+++ b/crates/rag-rat-core/src/index/ai/reencode.rs
@@ -27,7 +27,8 @@ struct ReencodeOutcome {
 }
 
 /// One legacy f32 row to re-encode: its compound key plus the stored vector bytes. `(chunk_id,
-/// model_id)` is the `chunk_embeddings` PK and doubles as the keyset cursor.
+/// model_id)` is the `chunk_embeddings` UNIQUE secondary index (the table's PK is the surrogate
+/// `id`) and doubles as the keyset cursor.
 struct LegacyVectorRow {
     chunk_id: i64,
     model_id: String,
@@ -40,10 +41,14 @@ struct LegacyVectorRow {
 /// [`encode_vector`] (now int8); NO model inference runs, so it is cheap and quality-identical to a
 /// fresh int8 reconcile.
 ///
-/// The f32 rows are detected purely by blob length: an f32 blob is `4 * embedding_dim` bytes, an
-/// int8 blob is `embedding_dim + 4`, and the two never collide for `dim >= 1` (so a freshly-int8
-/// row, or a `Failed` row's empty `x''` blob, is never selected). Matches [`decode_vector`]'s
-/// length-based format dispatch.
+/// The f32 rows are detected by blob length AND a positive `embedding_dim`: an f32 blob is
+/// `4 * embedding_dim` bytes and an int8 blob is `embedding_dim + 4`, disjoint for `dim >= 1`. The
+/// `embedding_dim > 0` guard is what excludes the `Failed` row's empty `x''` blob — by length alone
+/// `length(x'') = 0 = 4 * 0` would COLLIDE with an `embedding_dim = 0` row (Failed rows store
+/// `x''`, and a row written before migration 002 added `embedding_dim DEFAULT 0` keeps `0`, never
+/// backfilled), so the guard is REQUIRED to keep the Failed-row empty-blob invariant intact (see
+/// the [`collect_legacy_f32_batch`] / `count_remaining_f32` SQL). Otherwise this matches
+/// [`decode_vector`]'s length-based format dispatch.
 ///
 /// Works in bounded batches inside per-batch transactions and is IDEMPOTENT + resumable: re-running
 /// converts only the rows still in f32.
@@ -53,12 +58,12 @@ struct LegacyVectorRow {
 /// budgeted maintenance path can stop mid-conversion).
 ///
 /// Termination is CURSOR-driven, not "did this batch convert anything"-driven: a `(chunk_id,
-/// model_id)` keyset cursor walks the f32 rows in PK order, advancing past every row it reads
-/// (whether or not that row was actually converted). So a row skipped by the concurrent-rewrite
-/// guard or by a decode failure is simply passed over — never re-selected, never looped — and the
-/// loop ends when a batch comes back short of `batch_size`. The cursor also avoids the quadratic
-/// rescan a bare `LIMIT` would cause (each batch would otherwise re-scan from the table start past
-/// every already-converted row).
+/// model_id)` keyset cursor walks the f32 rows in `(chunk_id, model_id)` order (the table's UNIQUE
+/// secondary index), advancing past every row it reads (whether or not that row was actually
+/// converted). So a row skipped by the concurrent-rewrite guard or by a decode failure is simply
+/// passed over — never re-selected, never looped — and the loop ends when a batch comes back short
+/// of `batch_size`. The cursor also avoids the quadratic rescan a bare `LIMIT` would cause (each
+/// batch would otherwise re-scan from the table start past every already-converted row).
 ///
 /// The cursor is PERSISTED (`VECTOR_INT8_REENCODE_CURSOR_META`) after each committed batch and
 /// LOADED at the start, so a deadline-stopped run resumes from where it left off on the next call
@@ -76,6 +81,13 @@ fn reencode_legacy_f32_blobs_batched(
     // first, so `(chunk_id, model_id) > (i64::MIN, "")` matches all rows.
     let mut cursor = load_cursor(conn)?;
     loop {
+        // Deadline check at the TOP of the loop, BEFORE collecting/writing a batch — an
+        // already-expired deadline (e.g. `max_seconds / 2 == 0`, or no budget left when this runs)
+        // must do ZERO work, not one 4000-row write. Returns `completed == false` so the gate stays
+        // unset; the persisted cursor (if any) is untouched, so a later pass resumes.
+        if deadline.is_some_and(|dl| Instant::now() >= dl) {
+            return Ok(ReencodeOutcome { converted: total, completed: false });
+        }
         // Collect a whole batch BEFORE writing — the SELECT statement must be finalized (its borrow
         // of `conn` dropped) before the per-row UPDATE takes the connection.
         let batch = collect_legacy_f32_batch(conn, &cursor, batch_size)?;
@@ -83,9 +95,9 @@ fn reencode_legacy_f32_blobs_batched(
             // No rows past the cursor → conversion is complete.
             return Ok(ReencodeOutcome { converted: total, completed: true });
         };
-        // Advance the cursor to the batch's LAST key, so the next SELECT resumes via the PK index
-        // instead of rescanning. Computed before the UPDATE (which mutates the rows) from the read
-        // values.
+        // Advance the cursor to the batch's LAST key, so the next SELECT resumes via the UNIQUE
+        // `(chunk_id, model_id)` index instead of rescanning. Computed before the UPDATE (which
+        // mutates the rows) from the read values.
         cursor = (last.chunk_id, last.model_id.clone());
         let exhausted = batch.len() < batch_size;
         total += convert_batch(conn, &batch)?;
@@ -96,11 +108,8 @@ fn reencode_legacy_f32_blobs_batched(
         if exhausted {
             return Ok(ReencodeOutcome { converted: total, completed: true });
         }
-        // Deadline check AFTER a committed batch (never mid-batch): stop without marking complete
-        // so the next pass resumes from the just-persisted cursor.
-        if deadline.is_some_and(|dl| Instant::now() >= dl) {
-            return Ok(ReencodeOutcome { converted: total, completed: false });
-        }
+        // The next iteration's top-of-loop check re-tests the deadline before doing more work; the
+        // loop only continues here when there is a full batch still to walk.
     }
 }
 
@@ -130,10 +139,14 @@ fn save_cursor(conn: &Connection, cursor: &(i64, String)) -> anyhow::Result<()> 
     )
 }
 
-/// Read up to `limit` legacy f32 rows past `cursor`, in PK order. The blob-length predicate is the
-/// format detector (f32 is `4 * embedding_dim` bytes, int8 is `embedding_dim + 4` — disjoint for
-/// `dim >= 1`); the `(chunk_id, model_id) > cursor` keyset resumes past already-walked rows without
-/// rescanning, and ORDER BY makes "the batch's last row is the new cursor" well-defined.
+/// Read up to `limit` legacy f32 rows past `cursor`, in `(chunk_id, model_id)` order (the UNIQUE
+/// secondary index). The detector is `length(vector_blob) = 4 * embedding_dim AND embedding_dim >
+/// 0`: f32 is `4 * embedding_dim` bytes, int8 is `embedding_dim + 4` — disjoint for `dim >= 1` —
+/// and the `embedding_dim > 0` guard is LOAD-BEARING, excluding `Failed` rows that store `x''` with
+/// `embedding_dim` possibly `0` (which `length(x'') = 0 = 4 * 0` would otherwise match, corrupting
+/// the empty-blob invariant). The `(chunk_id, model_id) > cursor` keyset resumes past
+/// already-walked rows without rescanning, and ORDER BY makes "the batch's last row is the new
+/// cursor" well-defined.
 fn collect_legacy_f32_batch(
     conn: &Connection,
     cursor: &(i64, String),
@@ -143,6 +156,7 @@ fn collect_legacy_f32_batch(
         "SELECT chunk_id, model_id, embedding_dim, vector_blob
          FROM chunk_embeddings
          WHERE length(vector_blob) = 4 * embedding_dim
+           AND embedding_dim > 0
            AND (chunk_id, model_id) > (?1, ?2)
          ORDER BY chunk_id, model_id
          LIMIT ?3",
@@ -224,12 +238,17 @@ pub(crate) fn reencode_legacy_vectors_if_needed(
     reencode_and_mark_if_complete(conn, deadline)
 }
 
-/// FORCE the conversion, IGNORING the run-once gate at the start (the `--reencode-vectors` path) —
-/// runs to completion (no deadline) and SETS the gate on success, so the next maintenance pass
-/// doesn't do a pointless full table scan it would otherwise skip. May resume from a persisted
-/// cursor left by a prior deadline-stopped maintenance run. Returns the number of rows converted.
-pub(crate) fn reencode_legacy_vectors_now(conn: &Connection) -> anyhow::Result<usize> {
-    reencode_and_mark_if_complete(conn, None)
+/// FORCE the conversion, IGNORING the run-once gate at the start (the `--reencode-vectors` path),
+/// bounded by `deadline` so `--reencode-vectors --max-seconds N` can cap the work. SETS the gate on
+/// success (so the next maintenance pass doesn't do a pointless full table scan it would otherwise
+/// skip); a deadline stop leaves the gate unset and the keyset cursor persisted, so a later forced
+/// run (or maintenance pass) resumes from there. `None` runs to completion. Returns the number of
+/// rows converted.
+pub(crate) fn reencode_legacy_vectors_now_within(
+    conn: &Connection,
+    deadline: Option<Instant>,
+) -> anyhow::Result<usize> {
+    reencode_and_mark_if_complete(conn, deadline)
 }
 
 /// Run the conversion (resuming from / persisting the keyset cursor) and mark the run-once gate
@@ -261,18 +280,21 @@ fn clear_cursor(conn: &Connection) -> anyhow::Result<()> {
 mod tests {
     use super::*;
 
-    /// Minimal `chunk_embeddings` shape — only the columns the re-encode touches, so the test does
-    /// not depend on the full schema/bootstrap. `index_meta` is the done-gate store;
-    /// `reconcile_meta` is the keyset-cursor store.
+    /// `chunk_embeddings` with the columns the re-encode touches, matching the PROD shape from
+    /// `schema/baseline.rs`: a surrogate `id INTEGER PRIMARY KEY AUTOINCREMENT` plus a
+    /// `UNIQUE(chunk_id, model_id)` secondary index — so the keyset `ORDER BY chunk_id, model_id`
+    /// exercises that UNIQUE index (not a clustered PK), as in production. `index_meta` is the
+    /// done-gate store; `reconcile_meta` is the keyset-cursor store.
     fn setup_conn() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(
             "CREATE TABLE chunk_embeddings(
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                  chunk_id INTEGER NOT NULL,
                  model_id TEXT NOT NULL,
-                 embedding_dim INTEGER NOT NULL,
+                 embedding_dim INTEGER NOT NULL DEFAULT 0,
                  vector_blob BLOB NOT NULL,
-                 PRIMARY KEY(chunk_id, model_id)
+                 UNIQUE(chunk_id, model_id)
              );
              CREATE TABLE index_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);
              CREATE TABLE reconcile_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);",
@@ -341,20 +363,31 @@ mod tests {
     #[test]
     fn reencode_leaves_existing_int8_and_empty_blobs_untouched() {
         let conn = setup_conn();
-        // An already-int8 row (4 + dim bytes) and a Failed row's empty blob must NOT be selected:
-        // `4*dim` collides with neither `dim+4` (dim>=1) nor `0`.
+        // Rows that must NOT be selected:
+        // (1) an already-int8 row (4 + dim bytes) — `dim + 4` never equals `4 * dim` for dim>=1.
         let int8 = encode_vector(&[0.1_f32, -0.4, 0.9, -0.2]);
         insert_row(&conn, 1, "model-a", &int8, 4);
+        // (2) a Failed row with a non-zero dim and an empty `x''` blob — `length('') = 0` never
+        //     equals `4 * 4`.
         insert_row(&conn, 2, "model-a", b"", 4);
+        // (3) THE FIX-1 CASE: a Failed (or pre-migration-002) row with `embedding_dim = 0` and the
+        //     empty `x''` blob. By LENGTH alone `length('') = 0 = 4 * 0` would MATCH — only the
+        //     `embedding_dim > 0` guard keeps the re-encode from rewriting `x''` into a bogus
+        //     4-byte scale-only blob and breaking the Failed-row empty-blob invariant.
+        insert_row(&conn, 3, "model-a", b"", 0);
 
         assert_eq!(run_to_completion(&conn), 0);
         assert_eq!(stored_blob(&conn, 1), int8, "int8 row must be byte-identical");
         assert_eq!(stored_blob(&conn, 2), b"", "empty failed-row blob untouched");
+        assert_eq!(stored_blob(&conn, 3), b"", "empty dim=0 failed-row blob untouched (FIX 1)");
     }
 
     fn count_remaining_f32(conn: &Connection) -> i64 {
+        // Mirror the detector exactly — including the load-bearing `embedding_dim > 0` guard, so a
+        // Failed `x''`/`embedding_dim = 0` row is not miscounted as a remaining f32 row.
         conn.query_row(
-            "SELECT COUNT(*) FROM chunk_embeddings WHERE length(vector_blob) = 4 * embedding_dim",
+            "SELECT COUNT(*) FROM chunk_embeddings
+             WHERE length(vector_blob) = 4 * embedding_dim AND embedding_dim > 0",
             [],
             |row| row.get(0),
         )
@@ -450,7 +483,7 @@ mod tests {
         // Pre-set the gate: the forced path must IGNORE it at the start and still convert.
         set_meta(&conn, VECTOR_INT8_REENCODE_DONE_META, "1").unwrap();
 
-        assert_eq!(reencode_legacy_vectors_now(&conn).unwrap(), 1);
+        assert_eq!(reencode_legacy_vectors_now_within(&conn, None).unwrap(), 1);
         // ... and it leaves the gate set, so a later maintenance pass skips the full scan.
         assert_eq!(meta(&conn, VECTOR_INT8_REENCODE_DONE_META).unwrap().as_deref(), Some("1"));
         assert_eq!(reencode_legacy_vectors_if_needed(&conn, None).unwrap(), 0);
@@ -461,7 +494,10 @@ mod tests {
     }
 
     #[test]
-    fn deadline_stop_leaves_gate_unset_and_persists_cursor_then_resumes_to_completion() {
+    fn already_expired_deadline_does_no_work_and_leaves_gate_unset() {
+        // FIX 2: an ALREADY-ELAPSED deadline must do ZERO work — the top-of-loop check fires before
+        // the first collect/write, so no row is converted, no cursor is persisted, the gate stays
+        // unset, and every f32 row remains.
         let conn = setup_conn();
         let vector = vec![0.5_f32, -0.5, 0.25, -0.25];
         let blob = f32_blob(&vector);
@@ -469,21 +505,41 @@ mod tests {
             insert_row(&conn, chunk_id, "model-a", &blob, vector.len());
         }
 
-        // An ALREADY-ELAPSED deadline: the loop converts its first batch (the deadline is only
-        // checked AFTER a committed batch, so progress is always made), then stops because
-        // `Instant::now() >= deadline`. With batch_size 2 over 6 rows it converts exactly 2, leaves
-        // the done-gate UNSET, and persists the cursor at the 2nd row's key.
         let past = Instant::now() - std::time::Duration::from_secs(1);
-        let outcome = reencode_legacy_f32_blobs_batched(&conn, 2, Some(past)).unwrap();
-        assert_eq!(outcome.converted, 2, "one batch runs before the deadline halts the loop");
-        assert!(!outcome.completed, "a deadline stop is not a completion");
-        assert_eq!(count_remaining_f32(&conn), 4, "the rest are still f32");
-        assert_eq!(stored_cursor(&conn).as_deref(), Some("1\nmodel-a"), "cursor at the 2nd row");
+        let converted = reencode_legacy_vectors_if_needed(&conn, Some(past)).unwrap();
+        assert_eq!(converted, 0, "an expired deadline converts nothing");
+        assert_eq!(count_remaining_f32(&conn), 6, "all rows still f32");
+        assert_eq!(meta(&conn, VECTOR_INT8_REENCODE_DONE_META).unwrap(), None, "gate unset");
+        assert_eq!(stored_cursor(&conn), None, "no cursor persisted (no batch ran)");
+    }
 
-        // The gated entry point STOPPED here would NOT set the done-gate (verified via the loop
-        // above returning completed=false). A follow-up call with NO deadline resumes FROM THE
-        // PERSISTED CURSOR (not a rescan) and finishes the remaining 4 rows, sets the gate, and
-        // clears the cursor.
+    #[test]
+    fn deadline_stop_persists_cursor_then_a_follow_up_resumes_to_completion() {
+        // The resume path: a run that stops AFTER >=1 batch persists its cursor; a later call
+        // resumes FROM THAT CURSOR (not a rescan) and finishes only the remaining rows. We model
+        // the "stopped after one batch" state deterministically by persisting a cursor by
+        // hand (the same value `save_cursor` would have written), avoiding timing
+        // flakiness.
+        let conn = setup_conn();
+        let vector = vec![0.5_f32, -0.5, 0.25, -0.25];
+        let blob = f32_blob(&vector);
+        for chunk_id in 0..6 {
+            insert_row(&conn, chunk_id, "model-a", &blob, vector.len());
+        }
+        // Pretend a prior deadline-stopped pass converted chunk_ids 0 and 1, then stopped with the
+        // cursor at (1, "model-a"). Reflect that: those two are already int8, the cursor is stored.
+        for chunk_id in [0, 1] {
+            conn.execute(
+                "UPDATE chunk_embeddings SET vector_blob = ?1 WHERE chunk_id = ?2",
+                params![encode_vector(&vector), chunk_id],
+            )
+            .unwrap();
+        }
+        set_reconcile_meta(&conn, VECTOR_INT8_REENCODE_CURSOR_META, "1\nmodel-a").unwrap();
+        assert_eq!(count_remaining_f32(&conn), 4, "4 f32 rows remain past the cursor");
+
+        // A follow-up call with NO deadline resumes from the persisted cursor and finishes the
+        // remaining 4 rows — NOT all 6 — then sets the gate and clears the cursor.
         let converted = reencode_legacy_vectors_if_needed(&conn, None).unwrap();
         assert_eq!(converted, 4, "resumes the remaining rows, not all 6");
         assert_eq!(count_remaining_f32(&conn), 0, "all rows now int8");

--- a/crates/rag-rat-core/src/index/query_api/ai_lifecycle.rs
+++ b/crates/rag-rat-core/src/index/query_api/ai_lifecycle.rs
@@ -61,10 +61,17 @@ impl IndexDatabase {
     /// One-time upgrade: re-encode any `chunk_embeddings` row still stored in the legacy f32 format
     /// to the compact int8 format (#312), gated by a meta key so later maintenance passes skip the
     /// table scan. A format-only conversion (decode f32 → encode int8), no model inference. Returns
-    /// the number of rows converted this call (`0` once the gate is set). See
+    /// the number of rows converted this call (`0` once the gate is set).
+    ///
+    /// `deadline` bounds the conversion so it honors the maintenance time budget: a deadline stop
+    /// leaves the gate unset and persists a keyset cursor, so the next pass resumes without a
+    /// rescan (the gate is set only on full completion). `None` runs to completion. See
     /// [`ai::reencode_legacy_vectors_if_needed`].
-    pub fn reencode_legacy_vectors_if_needed(&self) -> anyhow::Result<usize> {
-        ai::reencode_legacy_vectors_if_needed(self.storage.connection())
+    pub fn reencode_legacy_vectors_if_needed(
+        &self,
+        deadline: Option<std::time::Instant>,
+    ) -> anyhow::Result<usize> {
+        ai::reencode_legacy_vectors_if_needed(self.storage.connection(), deadline)
     }
 
     /// FORCE the legacy-f32 → int8 re-encode (#312), ignoring the run-once meta gate at the start —

--- a/crates/rag-rat-core/src/index/query_api/ai_lifecycle.rs
+++ b/crates/rag-rat-core/src/index/query_api/ai_lifecycle.rs
@@ -67,10 +67,11 @@ impl IndexDatabase {
         ai::reencode_legacy_vectors_if_needed(self.storage.connection())
     }
 
-    /// FORCE the legacy-f32 → int8 re-encode (#312), ignoring the run-once meta gate — for users
-    /// who want it now on a huge index without waiting for the next maintenance pass.
+    /// FORCE the legacy-f32 → int8 re-encode (#312), ignoring the run-once meta gate at the start —
+    /// for users who want it now on a huge index without waiting for the next maintenance pass.
+    /// Sets the gate on success so a later maintenance pass doesn't redo the table scan.
     /// Idempotent: converts only rows still in f32. Returns the number of rows converted.
     pub fn reencode_legacy_vectors_now(&self) -> anyhow::Result<usize> {
-        ai::reencode_legacy_f32_blobs(self.storage.connection())
+        ai::reencode_legacy_vectors_now(self.storage.connection())
     }
 }

--- a/crates/rag-rat-core/src/index/query_api/ai_lifecycle.rs
+++ b/crates/rag-rat-core/src/index/query_api/ai_lifecycle.rs
@@ -77,8 +77,15 @@ impl IndexDatabase {
     /// FORCE the legacy-f32 → int8 re-encode (#312), ignoring the run-once meta gate at the start —
     /// for users who want it now on a huge index without waiting for the next maintenance pass.
     /// Sets the gate on success so a later maintenance pass doesn't redo the table scan.
-    /// Idempotent: converts only rows still in f32. Returns the number of rows converted.
-    pub fn reencode_legacy_vectors_now(&self) -> anyhow::Result<usize> {
-        ai::reencode_legacy_vectors_now(self.storage.connection())
+    /// Idempotent: converts only rows still in f32.
+    ///
+    /// `deadline` bounds the work so `reconcile --reencode-vectors --max-seconds N` can cap it; a
+    /// deadline stop leaves the gate unset and persists a keyset cursor, so a follow-up run resumes
+    /// from there. `None` runs to completion. Returns the number of rows converted.
+    pub fn reencode_legacy_vectors_now(
+        &self,
+        deadline: Option<std::time::Instant>,
+    ) -> anyhow::Result<usize> {
+        ai::reencode_legacy_vectors_now_within(self.storage.connection(), deadline)
     }
 }

--- a/crates/rag-rat-core/src/index/query_api/ai_lifecycle.rs
+++ b/crates/rag-rat-core/src/index/query_api/ai_lifecycle.rs
@@ -57,4 +57,20 @@ impl IndexDatabase {
     pub fn pending_embedding_jobs(&self) -> anyhow::Result<u64> {
         ai::pending_embedding_jobs(self.storage.connection())
     }
+
+    /// One-time upgrade: re-encode any `chunk_embeddings` row still stored in the legacy f32 format
+    /// to the compact int8 format (#312), gated by a meta key so later maintenance passes skip the
+    /// table scan. A format-only conversion (decode f32 → encode int8), no model inference. Returns
+    /// the number of rows converted this call (`0` once the gate is set). See
+    /// [`ai::reencode_legacy_vectors_if_needed`].
+    pub fn reencode_legacy_vectors_if_needed(&self) -> anyhow::Result<usize> {
+        ai::reencode_legacy_vectors_if_needed(self.storage.connection())
+    }
+
+    /// FORCE the legacy-f32 → int8 re-encode (#312), ignoring the run-once meta gate — for users
+    /// who want it now on a huge index without waiting for the next maintenance pass.
+    /// Idempotent: converts only rows still in f32. Returns the number of rows converted.
+    pub fn reencode_legacy_vectors_now(&self) -> anyhow::Result<usize> {
+        ai::reencode_legacy_f32_blobs(self.storage.connection())
+    }
 }


### PR DESCRIPTION
Follow-up to int8 quantization (#311): re-encode **existing** f32 vector blobs to int8.

## Why
New writes are int8 (#311), but existing f32 `chunk_embeddings.vector_blob` rows for unchanged files stay f32 forever (Current, never re-embedded), so an existing index keeps ~4× larger vectors for stable code. `decode_vector` reads both formats so it's correct — it just misses the disk win.

## What
A **format-only** re-encode (decode f32 → encode int8, **no model inference**, quality-identical to a fresh int8 reconcile):
- `reencode_legacy_f32_blobs` detects f32 rows by length (`length(vector_blob) = 4*embedding_dim`; int8 is `dim+4`, disjoint for dim≥1), converts in bounded per-batch transactions (4000/txn), idempotent + resumable + provably terminating.
- **Automatic, run-once**: a meta-gated wrapper (`vector_int8_reencode_done`) wired into `run_maintenance_pass` on the base index — the disk win applies after upgrade with no user action, and no full-table scan on later passes (the gate short-circuits; safe because new writes are always int8).
- **Explicit**: `rag-rat reconcile --reencode-vectors` forces the conversion one-shot (for a huge index now).

Tested: f32→int8 within one quant step, idempotent, the meta gate. Full suite green (924 default / 927 `--features eval`), clippy + fmt clean both configs.

Closes #312.
