### PR TITLE
chore(ci): target workflow triggers to the crates they exercise

### DIFF
--- a/.github/workflows/bench-pr-run.yml
+++ b/.github/workflows/bench-pr-run.yml
@@ -6,8 +6,16 @@ name: bench-pr-run
 # Pattern mirrors Bencher's "Track Benchmarks with GitHub Actions" (fork PRs) docs.
 
 on:
+  # The criterion + iai benches live in crates/rag-rat-core/benches and exercise only core's
+  # index/query/clone paths — cli/mcp/docs changes can't move the numbers, so they skip (and the
+  # paired bench-pr-track tracker, gated on this workflow_run, then skips too).
   pull_request:
     types: [opened, reopened, edited, synchronize]
+    paths:
+      - 'crates/rag-rat-core/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/bench-pr-run.yml'
 
 # Fork-safe by construction: no secrets are used here, and the token is read-only.
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,17 @@
 name: CI
 
 on:
+  # The workspace fmt/clippy/test/build/coverage gate — stays broad over ALL code (it's the only
+  # --workspace lint+test pass), but a docs-only change can't break it, so skip pure-docs changes.
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
 
 # Least privilege: CI only reads the repo (codecov uploads use its own token, not GITHUB_TOKEN).
 permissions:

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -6,14 +6,16 @@ name: eval
 # (lexical + semantic) path the product ships (MiniLM, model download cached).
 on:
   # Targeted: the eval suite exercises core's search/eval path + the cli's eval-feature surface
-  # (the `--features eval` clippy runs ONLY here), plus the evals/ query data. mcp-only and
-  # docs-only changes can't move it, so they skip.
+  # (the `--features eval` clippy runs ONLY here), the evals/ query data, AND the tests/fixtures
+  # the eval_suite loads via fixture_root() (main CI runs core --no-default-features, so it never
+  # compiles the eval module — this is the only gate on those fixtures). mcp/docs-only changes skip.
   push:
     branches: [main]
     paths:
       - 'crates/rag-rat-core/**'
       - 'crates/rag-rat-cli/**'
       - 'evals/**'
+      - 'tests/fixtures/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.config/nextest.toml'
@@ -23,6 +25,7 @@ on:
       - 'crates/rag-rat-core/**'
       - 'crates/rag-rat-cli/**'
       - 'evals/**'
+      - 'tests/fixtures/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.config/nextest.toml'

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -5,9 +5,28 @@ name: eval
 # network-free baseline (hash embedder → lexical retrieval) and the real gate over the hybrid
 # (lexical + semantic) path the product ships (MiniLM, model download cached).
 on:
+  # Targeted: the eval suite exercises core's search/eval path + the cli's eval-feature surface
+  # (the `--features eval` clippy runs ONLY here), plus the evals/ query data. mcp-only and
+  # docs-only changes can't move it, so they skip.
   push:
     branches: [main]
+    paths:
+      - 'crates/rag-rat-core/**'
+      - 'crates/rag-rat-cli/**'
+      - 'evals/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.config/nextest.toml'
+      - '.github/workflows/eval.yml'
   pull_request:
+    paths:
+      - 'crates/rag-rat-core/**'
+      - 'crates/rag-rat-cli/**'
+      - 'evals/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.config/nextest.toml'
+      - '.github/workflows/eval.yml'
 
 # Read-only: this job only checks out the repo and runs cargo. No write scopes (CodeQL hardening).
 permissions:

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -15,7 +15,10 @@ name: oracle
 on:
   pull_request:
     paths:
-      - 'crates/**'
+      # oracle gates core's parser / call-graph / resolution health only — cli & mcp changes
+      # can't move it, so narrow from crates/** to the engine crate (saves a full oracle run per
+      # cli/mcp-only PR).
+      - 'crates/rag-rat-core/**'
       # Root Cargo.toml/Cargo.lock change the built rag-rat binary (workspace deps / pinned
       # versions) without touching crates/** — gate on them too so a dependency bump can't merge
       # parser/oracle behaviour changes past the resolution health gate.
@@ -31,7 +34,10 @@ on:
   push:
     branches: [main]
     paths:
-      - 'crates/**'
+      # oracle gates core's parser / call-graph / resolution health only — cli & mcp changes
+      # can't move it, so narrow from crates/** to the engine crate (saves a full oracle run per
+      # cli/mcp-only PR).
+      - 'crates/rag-rat-core/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'tools/oracle-corpora.toml'

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -15,10 +15,11 @@ name: oracle
 on:
   pull_request:
     paths:
-      # oracle gates core's parser / call-graph / resolution health only — cli & mcp changes
-      # can't move it, so narrow from crates/** to the engine crate (saves a full oracle run per
-      # cli/mcp-only PR).
+      # oracle runs the `rag-rat` binary (`index --full` + `oracle report`, see tools/oracle-run.sh)
+      # over external corpora, so it gates core's parser/resolution AND the cli entry points that
+      # drive it. Only the mcp crate can't move it — narrow from crates/** to core + cli (drops mcp).
       - 'crates/rag-rat-core/**'
+      - 'crates/rag-rat-cli/**'
       # Root Cargo.toml/Cargo.lock change the built rag-rat binary (workspace deps / pinned
       # versions) without touching crates/** — gate on them too so a dependency bump can't merge
       # parser/oracle behaviour changes past the resolution health gate.
@@ -34,10 +35,11 @@ on:
   push:
     branches: [main]
     paths:
-      # oracle gates core's parser / call-graph / resolution health only — cli & mcp changes
-      # can't move it, so narrow from crates/** to the engine crate (saves a full oracle run per
-      # cli/mcp-only PR).
+      # oracle runs the `rag-rat` binary (`index --full` + `oracle report`, see tools/oracle-run.sh)
+      # over external corpora, so it gates core's parser/resolution AND the cli entry points that
+      # drive it. Only the mcp crate can't move it — narrow from crates/** to core + cli (drops mcp).
       - 'crates/rag-rat-core/**'
+      - 'crates/rag-rat-cli/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'tools/oracle-corpora.toml'


### PR DESCRIPTION
## What

Make the PR-triggered CI workflows **crate-targeted** so an irrelevant change stops fanning out the whole matrix. The motivating case: a `rag-rat-cli`-only PR was triggering the full **oracle** resolution gate, which only tests the core engine's parser/graph.

## The change (pure trigger filters — no job logic touched)

| Workflow | Before | After |
|---|---|---|
| `oracle.yml` | `crates/**` (matches cli/mcp) | `crates/rag-rat-core/**` + Cargo + oracle tooling |
| `bench-pr-run.yml` | *(no filter)* | `crates/rag-rat-core/**` + Cargo (benches are core-only) |
| `eval.yml` | *(no filter)* | core **+ cli** + `evals/` + Cargo + nextest |
| `ci.yml` | *(no filter)* | `paths-ignore` `**/*.md`, `docs/**` (stays broad for code) |

**Net effect:** mcp-only PR → `ci` only · docs-only PR → nothing · cli-only PR → `ci` + `eval`, no oracle/bench.

## Why it's safe

`main` has **no branch protection / no required status checks** (verified), so a path-skipped run can't deadlock a merge — these filters only save runner minutes and review noise. Every filter still carries the shared triggers (`Cargo.toml`, `Cargo.lock`, `.config/nextest.toml`) and its own workflow file, so a dep bump or workflow edit re-triggers everything. The `workflow_run` followups (`oracle-pr-comment`, `bench-pr-track`) auto-skip when their upstream skips.

## Two judgment calls

- **`eval` includes `cli`** — the `--features eval` clippy runs *only* in `eval.yml`, so a cli eval-surface break would otherwise slip through.
- **`ci.yml` stays broad for all code** — it's the only `--workspace` lint+test gate; trimmed only for pure-docs.

Untouched: `bench.yml` (main-only), `release-plz`, release/dispatch workflows.
