### PR TITLE
feat(eval): track commit-replay search recall in Bencher on main

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -86,3 +86,76 @@ jobs:
             --threshold-upper-boundary 0.95 \
             --thresholds-reset \
             "cargo bench --no-default-features --bench index_time"
+
+  # Search-quality headline (#19): commit-replay recall over the self-index at HEAD, tracked in
+  # Bencher. recall@3 is the metric an agent actually feels — "did the right chunk land in the first
+  # 3 reads". The 200-case replay is ~8-10 min, so it lives HERE on main (post-merge), never on the
+  # PR path: it would be both too slow to gate and too noisy to gate (the replay gold is each
+  # commit's changed paths, so a single PR's recall delta is usually below the per-case noise floor).
+  # Tracking only, NO `--err` — a real regression ALERTS via the statistical lower boundary on
+  # recall@3; a noisy dip doesn't hard-fail the run. Same stance as the iai/criterion series above.
+  eval_recall:
+    name: search recall (commit-replay)
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    env:
+      # Stable, cacheable location for the MiniLM ONNX download (fastembed honours this env var;
+      # mirrors eval.yml). The model is immutable, so the cache key is static.
+      RAG_RAT_MODEL_CACHE: ${{ github.workspace }}/.rag-rat-models
+    steps:
+      - uses: actions/checkout@v5
+        # FULL history: the commit-replay derives its cases from git history (commit message = query,
+        # changed paths = recall gold), so the default depth-1 shallow checkout would leave it with
+        # only HEAD and zero cases. fetch-depth: 0 fetches every commit for `index` to ingest.
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Cache embedding model (MiniLM)
+        uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}/.rag-rat-models
+          key: rag-rat-models-minilm-v1
+      - uses: bencherdev/bencher@main
+
+      - name: Build the eval-feature binary
+        run: cargo build --release -p rag-rat --features eval --locked
+
+      # Build + embed the index AT HEAD. The replay scores commit-message queries against the hybrid
+      # (lexical + semantic) path, so the chunks must be embedded — and reconcile only embeds at-head
+      # chunks, so a fresh checkout must index -> install the model -> reconcile first. The off-head
+      # footgun: a stale/absent index makes EVERY recall read a bogus 0.000.
+      - name: Index + embed at HEAD
+        run: |
+          ./target/release/rag-rat index --discover
+          ./target/release/rag-rat models install fastembed-all-minilm-l6-v2
+          ./target/release/rag-rat reconcile
+
+      - name: Run commit-replay eval -> JSON -> BMF
+        run: |
+          ./target/release/rag-rat --json eval --replay --replay-max-cases 200 > eval.json
+          python3 tools/eval-report-bmf.py eval.json > eval_bmf.json
+          cat eval_bmf.json
+
+      # recall@3 carries the statistical lower-boundary threshold; recall@10 + mrr@10 are tracked
+      # without one (`--thresholds-reset` clears any boundary not re-set here). No `--err`.
+      - name: Track search recall (Bencher)
+        run: |
+          bencher run \
+            --branch main \
+            --adapter json \
+            --file eval_bmf.json \
+            --threshold-measure recall_at_3 \
+            --threshold-test t_test \
+            --threshold-lower-boundary 0.95 \
+            --thresholds-reset
+
+      - name: Upload eval report + BMF
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-recall
+          path: |
+            eval.json
+            eval_bmf.json
+          if-no-files-found: warn

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -138,7 +138,12 @@ jobs:
           cat eval_bmf.json
 
       # recall@3 carries the statistical lower-boundary threshold; recall@10 + mrr@10 are tracked
-      # without one (`--thresholds-reset` clears any boundary not re-set here). No `--err`.
+      # without one. NO --thresholds-reset here: it removes every threshold NOT named in this run,
+      # and the `bench` job above publishes its instruction/latency thresholds to the SAME
+      # main/ubuntu-latest branch+testbed — resetting here could wipe those (and vice versa). Each
+      # job owns only its own measure's threshold and resets nothing; recall@3 is created/updated in
+      # place. No `--err` (tracking, not a gate) — a real drop alerts via the boundary; a noisy dip
+      # doesn't fail the run.
       - name: Track search recall (Bencher)
         run: |
           bencher run \
@@ -147,8 +152,7 @@ jobs:
             --file eval_bmf.json \
             --threshold-measure recall_at_3 \
             --threshold-test t_test \
-            --threshold-lower-boundary 0.95 \
-            --thresholds-reset
+            --threshold-lower-boundary 0.95
 
       - name: Upload eval report + BMF
         if: always()

--- a/crates/rag-rat-core/src/eval.rs
+++ b/crates/rag-rat-core/src/eval.rs
@@ -334,8 +334,27 @@ pub fn generate_replay_suite(
     options: &ReplayOptions,
 ) -> anyhow::Result<EvalSuite> {
     let cases = db.replay_commit_cases(options.max_cases, options.max_files)?;
-    let query = cases.iter().map(replay_eval_query).collect();
-    Ok(EvalSuite { query })
+    let indexed = db.indexed_path_set()?;
+    Ok(EvalSuite { query: replay_queries_with_indexed_gold(&cases, &indexed) })
+}
+
+/// Turn replay cases into eval queries, restricting each case's path gold to paths the index
+/// actually contains. The repo config indexes only a subset of the tree, so a commit touching
+/// `.github/**`, `tools/**`, or a root manifest contributes gold that can never be retrieved;
+/// counting it as a miss would make recall track the file mix of recent commits, not search quality
+/// (#315). Cases left with no indexed gold are dropped — nothing measurable remains.
+fn replay_queries_with_indexed_gold(
+    cases: &[git_history::ReplayCase],
+    indexed: &BTreeSet<String>,
+) -> Vec<EvalQuery> {
+    cases
+        .iter()
+        .filter_map(|case| {
+            let mut query = replay_eval_query(case);
+            query.must_include_paths.retain(|path| indexed.contains(path));
+            (!query.must_include_paths.is_empty()).then_some(query)
+        })
+        .collect()
 }
 
 /// Aggregate result of a parent-state replay run (#120) — the leakage-free MRR/recall@10 over the
@@ -1221,6 +1240,36 @@ mod tests {
         // Empty/whitespace body: the query is the subject alone (no dangling newline).
         let no_body = ReplayCase { body: "  ".into(), ..with_body };
         assert_eq!(replay_eval_query(&no_body).text, "fix(x): handle empty input");
+    }
+
+    #[test]
+    fn replay_gold_is_filtered_to_indexed_paths() {
+        use crate::index::git_history::ReplayCase;
+        let case = |paths: &[&str]| ReplayCase {
+            hash: "0123456789abcdef0123".into(),
+            subject: "fix something".into(),
+            body: String::new(),
+            changed_paths: paths.iter().map(|path| (*path).to_string()).collect(),
+        };
+        // The repo config indexes crates/** only; .github/**, tools/**, and root manifests are not.
+        let indexed: BTreeSet<String> =
+            ["crates/a.rs".to_string(), "crates/b.rs".to_string()].into_iter().collect();
+        let cases = vec![
+            case(&["crates/a.rs", ".github/workflows/ci.yml", "tools/x.sh"]), /* mixed -> keep
+                                                                               * crates/a.rs */
+            case(&[".github/only.yml", "Cargo.toml"]), // all non-indexed -> dropped
+        ];
+        let queries = replay_queries_with_indexed_gold(&cases, &indexed);
+        assert_eq!(
+            queries.len(),
+            1,
+            "the all-non-indexed case is dropped (no measurable gold left)"
+        );
+        assert_eq!(
+            queries[0].must_include_paths,
+            vec!["crates/a.rs".to_string()],
+            "non-indexed gold (.github/**, tools/**, manifests) is filtered out of the denominator",
+        );
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/git_history.rs
+++ b/crates/rag-rat-core/src/index/git_history.rs
@@ -276,6 +276,19 @@ pub fn replay_commit_cases(
     Ok(cases)
 }
 
+/// The set of paths the repo config currently indexes (live `files` rows, excluding deletion
+/// tombstones). The commit-replay eval (#120) restricts its gold to this set: a path the config
+/// doesn't index (`.github/**`, `tools/**`, a root manifest, …) can never be retrieved, so counting
+/// it as missing gold would make recall@k track the file mix of recent commits rather than search
+/// quality (#315).
+pub fn indexed_path_set(conn: &Connection) -> anyhow::Result<BTreeSet<String>> {
+    let mut stmt = conn.prepare("SELECT path FROM files WHERE kind != 'deleted'")?;
+    let paths = stmt
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<BTreeSet<String>>>()?;
+    Ok(paths)
+}
+
 /// Distinct `chunks.symbol_path` for chunks in `path` whose line span overlaps any of `ranges`
 /// (inclusive). Commit-replay (#120) uses this to derive symbol-level gold: the symbols a commit
 /// touched, in the SAME `symbol_path` format the search results carry, so symbol-recall is

--- a/crates/rag-rat-core/src/index/query_api/history.rs
+++ b/crates/rag-rat-core/src/index/query_api/history.rs
@@ -18,6 +18,12 @@ impl IndexDatabase {
         git_history::replay_commit_cases(self.storage.connection(), limit, max_files)
     }
 
+    /// The indexed-path set the commit-replay eval filters its gold against, so recall counts only
+    /// retrievable paths (#315). See [`git_history::indexed_path_set`].
+    pub fn indexed_path_set(&self) -> anyhow::Result<std::collections::BTreeSet<String>> {
+        git_history::indexed_path_set(self.storage.connection())
+    }
+
     /// Symbol-level replay gold (#120): distinct chunk `symbol_path`s overlapping `ranges` in
     /// `path`. See [`git_history::chunk_symbol_paths_in_ranges`].
     pub fn chunk_symbol_paths_in_ranges(

--- a/docs/bencher.md
+++ b/docs/bencher.md
@@ -1,13 +1,15 @@
 # Continuous benchmarking (Bencher)
 
-rag-rat tracks performance over time with [Bencher](https://bencher.dev). Two lightweight signals
-are recorded on every push to `main` and gated on every pull request; a third, heavyweight signal
-runs only on a published release:
+rag-rat tracks performance over time with [Bencher](https://bencher.dev). Two lightweight
+*performance* signals are recorded on every push to `main` and gated on every pull request; a
+*search-quality* signal (commit-replay recall) is tracked on `main` only; and a heavyweight
+Linux-kernel indexing signal runs only on a published release:
 
 | Signal | Harness | When | What it measures | Why |
 |---|---|---|---|---|
 | `rag_pipeline` | [iai-callgrind](https://github.com/iai-callgrind/iai-callgrind) | push + PR | CPU **instruction counts** for index rebuild + cold/warm query | Deterministic — immune to CI runner noise, so it catches small *relative* regressions a wall-clock bench would drown out. |
 | `index_time` | [criterion](https://github.com/bheisler/criterion.rs) | push + PR | **Wall-clock** time for a full index rebuild (whole cargo checkout) | The number users actually feel. Noisy, so it's gated statistically (t-test), not on a tight percentage. |
+| `search_replay` | commit-replay eval → [`tools/eval-report-bmf.py`](../tools/eval-report-bmf.py) | **push to `main` only** | **recall@3 / recall@10 / mrr@10** of hybrid search over the self-index at HEAD | The retrieval quality an agent actually feels ("did the right chunk land in the first 3 reads"). ~8–10 min + noisy (the replay gold is recent commit paths), so it's tracked + alerted on `main`, never a PR gate. |
 | `linux-kernel-v7.0/full-index` | single-shot ([`tools/bench-kernel.sh`](../tools/bench-kernel.sh)) | **release only** | **Wall-clock + throughput + peak memory** to index the whole Linux kernel | The headline "indexes the Linux kernel in X seconds" number on a huge real C codebase. Too slow (~tens of minutes) for per-push. |
 
 The push/PR harnesses run on different corpus sizes on purpose — see "Corpus" below.
@@ -66,13 +68,54 @@ reports the indexed `file_count_by_language` and files/sec throughput so the out
 If you bump the pinned SHA, update the cache key (`bench-corpus-cargo-<version>`) in all three
 workflow files too.
 
+## Search-quality: commit-replay recall
+
+`bench.yml`'s `eval_recall` job tracks how well search retrieves the right code over time, using the
+commit-replay eval (#120): each recent commit becomes a case (commit message = query, the commit's
+changed paths = recall gold), scored against the hybrid (lexical + semantic) index at HEAD. Three
+measures go to Bencher under the `search_replay` benchmark:
+
+- `recall_at_3` — the headline: |gold ∩ top-3| / |gold|, "did the right chunk land in the first 3
+  reads". It carries a statistical **lower**-boundary t-test threshold (a recall regression is a
+  *drop*, unlike the latency/instruction signals, which alert on an *increase*).
+- `recall_at_10`, `mrr_at_10` — tracked without a threshold (context for a recall@3 move).
+
+Values are fractions in [0, 1] — the same numbers `eval` prints — so a Bencher plot reads identically
+to a local run.
+
+The job builds an embedded index at HEAD (`index --discover` → `models install
+fastembed-all-minilm-l6-v2` → `reconcile`), then `rag-rat --json eval --replay --replay-max-cases
+200` → [`tools/eval-report-bmf.py`](../tools/eval-report-bmf.py) → `bencher run --adapter json`. Two
+footguns it has to handle:
+
+- **Off-head ⇒ bogus 0.000.** `reconcile` only embeds *at-head* chunks, so the index must be built +
+  embedded at HEAD before scoring; a stale/absent index makes every recall read 0.000.
+- **Shallow checkout ⇒ no cases.** The replay walks git history, so the job checks out with
+  `fetch-depth: 0` — the default depth-1 checkout would leave it with only HEAD and zero cases.
+
+**Main-only, no `--err`, by design.** At ~8–10 min over 200 cases it's too slow for the PR critical
+path, and the metric is noisy — the gold is recent commit paths, so a single PR's recall delta is
+usually below the per-case noise floor (≥200 cases are needed for signal). So it's tracked +
+*alerted* on `main` (the statistical threshold flags a real regression in Bencher) rather than
+hard-failing a run — the same "headline signal, not a gate" stance as the iai/criterion series. Reset
+the baseline after an embedder or replay-parameter change with **Actions → bench → Run workflow** (the
+`workflow_dispatch` reruns `--thresholds-reset`).
+
+Run it locally (needs the `eval` feature + an embedded at-head index):
+
+```bash
+cargo build --release -p rag-rat --features eval
+target/release/rag-rat --json eval --replay --replay-max-cases 200 > eval.json
+python3 tools/eval-report-bmf.py eval.json > eval_bmf.json
+```
+
 ## CI workflows
 
 Four workflows under `.github/workflows/`:
 
 | Workflow | Trigger | Has the token? | Role |
 |---|---|---|---|
-| `bench.yml` | push to `main` | yes | Records both lightweight signals against the `main` branch; sets/refreshes the thresholds new PRs are compared against. |
+| `bench.yml` | push to `main` | yes | Records the lightweight perf signals **and** the `search_replay` recall signal (a separate `eval_recall` job) against `main`; sets/refreshes the thresholds new PRs are compared against. |
 | `bench-pr-run.yml` | `pull_request` (incl. forks) | **no** | Runs the benches, uploads raw output + the PR event as an artifact. Never sees secrets, so a fork PR can't exfiltrate the token. |
 | `bench-pr-track.yml` | `workflow_run` of bench-pr-run | yes | Runs in the base-repo context: downloads the artifact, uploads results to Bencher, comments the comparison on the PR. |
 | `bench-release.yml` | `release: published` + manual `workflow_dispatch` | yes | The heavyweight Linux-kernel headline bench (below). Not a gate — tracks latency/throughput/memory over releases. |

--- a/tools/eval-report-bmf.py
+++ b/tools/eval-report-bmf.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Convert a commit-replay eval report (JSON) into Bencher Metric Format (BMF).
+
+`rag-rat --json eval --replay` emits the typed `EvalReport` as JSON; turning it into the shape
+Bencher ingests is a glue concern (mirrors tools/oracle-report-bmf.py). This carries the
+search-quality headline for the main-branch `bench` workflow: one BMF benchmark `search_replay`
+with recall@3 / recall@10 / mrr@10 over the self-index at HEAD, so Bencher tracks how retrieval
+quality moves over time and alerts on a real recall regression.
+
+recall@3 is the headline (#120, #109): "did the right chunk land in the first 3 reads". The values
+are fractions in [0, 1] — the SAME numbers `eval` prints — so a Bencher plot reads identically to a
+local run. Higher is better, so the gate is a statistical LOWER boundary, and it is tracking-only
+(no `--err`): a noisy quality metric is alerted on, not hard-failed (see .github/workflows/bench.yml,
+and the same stance on the iai/criterion series).
+
+Usage:
+  rag-rat --json eval --replay --replay-max-cases 200 > eval.json
+  eval-report-bmf.py eval.json > eval_bmf.json
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+# Stable series name over main. There is ONE self-corpus (the rag-rat repo at HEAD), unlike oracle's
+# many external corpora, so a benchmark-name comparability hash isn't needed here — an embedder or
+# replay-parameter change that makes runs incomparable is handled by re-resetting the baseline
+# (bench.yml `--thresholds-reset`, plus the manual workflow_dispatch), not by forking the series.
+BENCHMARK = "search_replay"
+
+# The three tracked measures (#19): recall@3 (headline, carries the threshold in bench.yml),
+# recall@10, and mrr@10. All are means over the replayed cases, already computed by the harness.
+MEASURES = ("recall_at_3", "recall_at_10", "mrr_at_10")
+
+
+def to_bmf(report: dict) -> dict:
+    """One EvalReport JSON -> a single-benchmark BMF object carrying the three recall measures."""
+    metrics = report.get("metrics")
+    if not isinstance(metrics, dict):
+        sys.exit("eval-report-bmf: report has no `metrics` object (not an eval report?)")
+    body: dict[str, dict] = {}
+    for measure in MEASURES:
+        if measure not in metrics:
+            sys.exit(f"eval-report-bmf: report.metrics missing `{measure}` (not a --replay report?)")
+        body[measure] = {"value": float(metrics[measure])}
+    return {BENCHMARK: body}
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        sys.exit("usage: eval-report-bmf.py <eval-report.json>")
+    with open(sys.argv[1]) as fh:
+        report = json.load(fh)
+    json.dump(to_bmf(report), sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Wire the commit-replay search-quality eval (#120) into the existing Bencher pipeline as a **main-only tracked signal** — the search-**quality** counterpart to the iai/criterion **performance** signals. Completes the "wire eval into CI" work.

## Why main-only + tracking (no `--err`)

Measured: a 200-case at-head replay is **~8–10 min** and the metric is **noisy** — the replay gold is each commit's changed paths, so a single PR's recall delta is usually below the per-case noise floor (≥200 cases needed for signal). A per-PR hard gate would be both too slow for the critical path and mostly false-alarm.

Instead `recall@3` carries a statistical **lower**-boundary `t_test` threshold (a recall regression is a *drop*) that **alerts** on a real regression in Bencher but never hard-fails the run — the same "headline signal, not a gate" stance the repo already documents for the iai/criterion series and oracle's heavy push.

## The change

- **`tools/eval-report-bmf.py`** — `EvalReport` JSON → Bencher Metric Format, mirroring `tools/oracle-report-bmf.py`. One `search_replay` benchmark, `recall_at_3` / `recall_at_10` / `mrr_at_10` as fractions in [0,1] (the same numbers `eval` prints).
- **`bench.yml`** — new `eval_recall` job (main / `workflow_dispatch`): builds an embedded index at HEAD (`index --discover` → `models install fastembed-all-minilm-l6-v2` → `reconcile`), runs `rag-rat --json eval --replay --replay-max-cases 200`, converts to BMF, pushes via `bencher run --adapter json`. recall@3 gets the lower-boundary threshold; recall@10 + mrr@10 are tracked. Two CI footguns handled: **`fetch-depth: 0`** (the replay walks git history; a shallow checkout → zero cases) and the cached MiniLM model (`RAG_RAT_MODEL_CACHE`, mirrors `eval.yml`).
- **`docs/bencher.md`** — documents the signal + both footguns.

**No Rust change** — `eval --json` already emits the structured `EvalReport` via `print_output`.

## Validation

- BMF converter tested on a real report + malformed input (clean error).
- **End-to-end from a fresh clone** (no `.rag-rat/` index, exactly what CI gets): `index → reconcile → replay → BMF` ran clean with non-zero recall (proves at-HEAD + history present + embeddings working). The `eval_recall` job is main-only (`if: refs/heads/main`), so it first executes on merge to main, not on this PR. Only `bencher run` itself isn't locally testable (needs the token) — it mirrors the working oracle invocation exactly.

Independent of #314 (CI targeting) — different files, no conflict.
