### PR TITLE
feat(embed): register the ollama backend — enum + registry row (#317 task 2)

### DIFF
--- a/crates/rag-rat-core/src/embedding_models.rs
+++ b/crates/rag-rat-core/src/embedding_models.rs
@@ -23,6 +23,10 @@ pub enum Backend {
     FastEmbed,
     /// A Model2Vec static token→vector lookup; gated behind the `model2vec` feature.
     Model2Vec,
+    /// A remote Ollama server (`POST /api/embed`); gated behind the `remote-embed` feature. The
+    /// endpoint/auth/timeout come from the `[embedding.remote]` config block, not the static
+    /// registry — the row carries only identity + dim (#317).
+    Ollama,
 }
 
 impl Backend {
@@ -33,6 +37,7 @@ impl Backend {
             Self::Hash => "hash",
             Self::FastEmbed => "fastembed",
             Self::Model2Vec => "model2vec",
+            Self::Ollama => "ollama",
         }
     }
 }
@@ -96,6 +101,14 @@ pub const MODEL2VEC_MODEL_ID: &str = "model2vec-potion-retrieval-32m";
 pub const MODEL2VEC_DISPLAY_MODEL: &str = "minishlab/potion-retrieval-32M";
 pub const MODEL2VEC_EMBEDDING_DIM: usize = 512;
 
+/// all-MiniLM-L6-v2 served by Ollama (#317): the remote/GPU mirror of the local FastEmbed default.
+/// Same 384-dim model family, so chunks can embed remotely while a query embeds locally in the SAME
+/// vector space. Endpoint/auth/timeout come from the `[embedding.remote]` config block, never this
+/// `&'static` registry — the row carries only the model's identity + dim.
+pub const OLLAMA_ALL_MINILM_MODEL_ID: &str = "ollama-all-minilm";
+pub const OLLAMA_ALL_MINILM_DISPLAY_MODEL: &str = "all-MiniLM-L6-v2 (Ollama)";
+pub const OLLAMA_ALL_MINILM_EMBEDDING_DIM: usize = 384;
+
 /// The embedding-model registry. ONE row per model — adding a model is adding a row here. Pure
 /// data, no feature gates; the embedder construction is gated in `index::ai`.
 pub const EMBEDDING_MODELS: &[EmbeddingModelSpec] = &[
@@ -142,6 +155,15 @@ pub const EMBEDDING_MODELS: &[EmbeddingModelSpec] = &[
         version: "model2vec-potion-retrieval-32m-v1",
         backend: Backend::Model2Vec,
         aliases: &["model2vec", "potion", "static"],
+        query_prefix: "",
+    },
+    EmbeddingModelSpec {
+        model_id: OLLAMA_ALL_MINILM_MODEL_ID,
+        display: OLLAMA_ALL_MINILM_DISPLAY_MODEL,
+        dim: OLLAMA_ALL_MINILM_EMBEDDING_DIM,
+        version: "ollama-all-minilm-v1",
+        backend: Backend::Ollama,
+        aliases: &["ollama", "ollama-minilm"],
         query_prefix: "",
     },
 ];

--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -82,6 +82,10 @@ pub(crate) fn embedder_for_spec(
                 anyhow::bail!("{}", MODEL2VEC_MISSING_FEATURE_MESSAGE)
             }
         },
+        // The Ollama HTTP backend is wired in #317 task 5 (dispatch + role split). The registry
+        // row + enum variant exist as of task 2 so the table is complete; constructing one bails
+        // until then.
+        Backend::Ollama => anyhow::bail!("ollama embedding backend not yet wired (#317 task 5)"),
     }
 }
 

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -190,6 +190,8 @@ pub(crate) fn install_model(conn: &Connection, model_id: &str) -> anyhow::Result
         },
         Backend::FastEmbed => install_fastembed_model(conn, model_id)?,
         Backend::Model2Vec => install_model2vec_model(conn, model_id)?,
+        // Ollama install (a reachability + dim probe, no download) is #317 task 6; bail until then.
+        Backend::Ollama => anyhow::bail!("ollama embedding backend not yet wired (#317 task 6)"),
     }
     set_meta(conn, ACTIVE_EMBEDDING_MODEL_META, model_id)?;
     model(conn, model_id)


### PR DESCRIPTION
**Task 2 of 7** toward the Ollama embedding provider (#317). No behavior change — adds the static identity so the registry table is complete; construction/install bail until wired (tasks 5/6).

- `Backend::Ollama` + `.runtime()="ollama"`.
- One `EMBEDDING_MODELS` row: `ollama-all-minilm` (dim 384, version `ollama-all-minilm-v1`, aliases `[ollama, ollama-minilm]`) — **static identity only**; endpoint/auth live in `[embedding.remote]` (task 3).
- Temporary `Backend::Ollama => bail!` arms in `embedder_for_spec` (task 5) + `install_model` (task 6) keep the matches exhaustive.

Nothing selects the model by default, so it's dormant.

**Verified:** build default **and** `--no-default-features` (exhaustiveness); registry tests (unique non-`v1` version + first-alias round-trip); 930 core suite; clippy `--all-targets` clean both configs; fmt.