### PR TITLE
fix(embed): restore public index::ai::MODEL2VEC_HF_REPO (#320 review)

### DIFF
--- a/crates/rag-rat-core/src/index/ai/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/mod.rs
@@ -15,8 +15,6 @@ pub(crate) use policy::*;
 pub use providers::FastEmbedEmbedder;
 #[cfg(test)]
 pub use providers::MockEmbedder;
-#[cfg(feature = "model2vec")]
-pub use providers::Model2VecEmbedder;
 pub(crate) use providers::active_embedder;
 // Curate the provider surface onto the `index::ai` path so existing `super::*` callers
 // (`reconcile`, `status`, `helpers`) and the external `ai::Embedder` /
@@ -30,6 +28,8 @@ pub(crate) use providers::active_embedder;
 pub use providers::{
     Embedder, FASTEMBED_MISSING_FEATURE_MESSAGE, HashEmbedder, MODEL2VEC_MISSING_FEATURE_MESSAGE,
 };
+#[cfg(feature = "model2vec")]
+pub use providers::{MODEL2VEC_HF_REPO, Model2VecEmbedder};
 pub(crate) use reconcile::*;
 pub(crate) use reencode::*;
 use rusqlite::types::Value;

--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -15,7 +15,7 @@ use rusqlite::Connection;
 pub use self::fastembed::FastEmbedEmbedder;
 pub use self::hash::HashEmbedder;
 #[cfg(feature = "model2vec")]
-pub use self::model2vec::Model2VecEmbedder;
+pub use self::model2vec::{MODEL2VEC_HF_REPO, Model2VecEmbedder};
 use crate::embedding_models::{Backend, EmbeddingModelSpec, spec};
 use crate::index::ai::{active_embedding_model_id, model, validate_ready_model};
 


### PR DESCRIPTION
Addresses the Codex P2 on the merged #320 (providers/ extraction).

**The regression:** the move put `MODEL2VEC_HF_REPO` into the now-private `providers::model2vec`, and `ai/mod.rs` re-exported only `Model2VecEmbedder` — so the public `index::ai::MODEL2VEC_HF_REPO` const (published-crate API) vanished. Silent public-API change in a 'no-behavior' refactor. (Practical impact ~nil — its sole user is `Model2VecEmbedder` — but worth fixing to keep the refactor honest.)

**Fix:** keep the const **in `model2vec.rs`** where it belongs, and add it to the existing feature-gated re-exports (`providers/mod.rs` → `ai/mod.rs`), restoring `index::ai::MODEL2VEC_HF_REPO`. Re-exported **feature-gated** (not the pre-move unconditional): a model2vec const is only meaningful with the `model2vec` feature, so it now exists only in builds that use it — no dead-code-exemption gymnastics, and arguably more correct than the pre-move unconditional wart.

**Verified:** build default + `--features model2vec` + `--no-default-features`; clippy `--all-targets` clean both configs; full core suite; fmt.