### PR TITLE
feat(embed): [embedding.remote] config block (#317 task 3)

### DIFF
--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -107,6 +107,12 @@ pub struct EmbeddingConfig {
     /// on repo size; see [`EmbeddingBackend`].
     pub backend: EmbeddingBackend,
     pub runtime: EmbeddingRuntimeConfig,
+    /// Optional remote-embedding offload (`[local_ai.embedding.remote]`). When present, the
+    /// indexer can hand embedding work to an HTTP server (Ollama's `/api/embed`) instead of
+    /// running the model in-process — see [`RemoteEmbeddingConfig`]. Absent → `None` → in-process
+    /// embedding only. Parsed + validated here; the dispatch that consumes it lands in #317 task
+    /// 5.
+    pub remote: Option<RemoteEmbeddingConfig>,
 }
 
 /// The embedding backend selector (`[local_ai.embedding] model = "..."`).
@@ -195,6 +201,84 @@ impl Default for EmbeddingRuntimeConfig {
             ort_threads: Some(4),
             omp_threads: Some(1),
             max_embedding_chars: 4000,
+        }
+    }
+}
+
+/// Remote-embedding offload (`[local_ai.embedding.remote]`). Hands embedding work to an HTTP
+/// server (Ollama's `/api/embed`) instead of running the model in-process — the lever for huge
+/// repos whose in-process backfill is too slow on the indexing box. Optional: absent → in-process
+/// embedding only.
+///
+/// Deliberately carries NO `dim` or `backend` field. The vector dimension comes from the registry
+/// spec of the selected model (the `ollama-all-minilm` row, dim 384) and is validated against the
+/// server's first response at runtime by the embedder (#317 task 4); the backend is implied by the
+/// selected registry model. Duplicating either here would be redundant and drift-prone.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteEmbeddingConfig {
+    /// How the remote server is reached. `Connect` (the v1 default) talks to an
+    /// already-running server at `endpoint`; `Ephemeral` (provision-on-demand) is not yet
+    /// supported — see [`RemoteMode`].
+    pub mode: RemoteMode,
+    /// The Ollama API model name sent to `/api/embed` (e.g. `"all-minilm"`). This is the server's
+    /// own model identifier, NOT a `rag-rat` registry alias — the registry only supplies the dim
+    /// parity contract.
+    pub model: String,
+    /// Base URL of the remote server (e.g. `"http://localhost:11434"`). Required in `Connect`
+    /// mode; `/api/embed` is appended by the embedder.
+    pub endpoint: Option<String>,
+    /// Name of the environment variable holding the bearer token, if the server needs auth. Local
+    /// Ollama needs none, so this is optional; the embedder reads the var once at construction.
+    pub auth_env: Option<String>,
+    /// How many texts to send per `/api/embed` request.
+    pub batch_size: u32,
+    /// Per-request HTTP timeout, in seconds.
+    pub request_timeout_s: u64,
+}
+
+impl Default for RemoteEmbeddingConfig {
+    fn default() -> Self {
+        Self {
+            mode: RemoteMode::Connect,
+            model: String::new(),
+            endpoint: None,
+            auth_env: None,
+            batch_size: 256,
+            request_timeout_s: 60,
+        }
+    }
+}
+
+/// How the remote-embedding server is obtained (`[local_ai.embedding.remote] mode = "..."`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RemoteMode {
+    /// Connect to an already-running server at the configured `endpoint`. The v1 default and the
+    /// only supported mode today.
+    #[default]
+    Connect,
+    /// Provision an ephemeral server on demand. Not yet supported — needs the provisioning
+    /// cookbook (#318); selecting it is a [`ConfigError::RemoteEmbeddingEphemeralUnsupported`].
+    Ephemeral,
+}
+
+impl RemoteMode {
+    /// The canonical toml selector for this mode.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Connect => "connect",
+            Self::Ephemeral => "ephemeral",
+        }
+    }
+}
+
+impl FromStr for RemoteMode {
+    type Err = ConfigError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "connect" => Ok(Self::Connect),
+            "ephemeral" => Ok(Self::Ephemeral),
+            other => Err(ConfigError::UnknownRemoteMode(other.to_string())),
         }
     }
 }
@@ -631,6 +715,8 @@ struct RawEmbedding {
     model: Option<String>,
     #[serde(default)]
     runtime: RawEmbeddingRuntime,
+    /// `[local_ai.embedding.remote]` — absent → no remote offload (`remote: None`).
+    remote: Option<RawRemoteEmbedding>,
 }
 
 impl TryFrom<RawEmbedding> for EmbeddingConfig {
@@ -641,7 +727,55 @@ impl TryFrom<RawEmbedding> for EmbeddingConfig {
             Some(value) => value.parse()?,
             None => EmbeddingBackend::default(),
         };
-        Ok(Self { backend, runtime: raw.runtime.into() })
+        let remote = raw.remote.map(RemoteEmbeddingConfig::try_from).transpose()?;
+        Ok(Self { backend, runtime: raw.runtime.into(), remote })
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawRemoteEmbedding {
+    mode: Option<String>,
+    model: Option<String>,
+    endpoint: Option<String>,
+    auth_env: Option<String>,
+    batch_size: Option<u32>,
+    request_timeout_s: Option<u64>,
+}
+
+impl TryFrom<RawRemoteEmbedding> for RemoteEmbeddingConfig {
+    type Error = ConfigError;
+
+    fn try_from(raw: RawRemoteEmbedding) -> Result<Self, Self::Error> {
+        let default = RemoteEmbeddingConfig::default();
+        // `mode` absent → `Connect` (the v1 default). `Ephemeral` parses but isn't wired yet.
+        let mode = match raw.mode.as_deref() {
+            Some(value) => value.parse()?,
+            None => default.mode,
+        };
+        if mode == RemoteMode::Ephemeral {
+            return Err(ConfigError::RemoteEmbeddingEphemeralUnsupported);
+        }
+        // The Ollama API model name (e.g. `all-minilm`) — required, non-empty.
+        let model = raw.model.unwrap_or_default();
+        let model = model.trim();
+        if model.is_empty() {
+            return Err(ConfigError::RemoteEmbeddingMissingModel);
+        }
+        // `Connect` mode needs a non-empty server URL to reach.
+        let endpoint = raw.endpoint.map(|e| e.trim().to_string()).filter(|e| !e.is_empty());
+        if mode == RemoteMode::Connect && endpoint.is_none() {
+            return Err(ConfigError::RemoteEmbeddingMissingEndpoint);
+        }
+        // Optional — local Ollama needs no auth; trim if present.
+        let auth_env = raw.auth_env.map(|a| a.trim().to_string()).filter(|a| !a.is_empty());
+        Ok(Self {
+            mode,
+            model: model.to_string(),
+            endpoint,
+            auth_env,
+            batch_size: raw.batch_size.unwrap_or(default.batch_size),
+            request_timeout_s: raw.request_timeout_s.unwrap_or(default.request_timeout_s),
+        })
     }
 }
 
@@ -690,6 +824,23 @@ pub enum ConfigError {
          `bge`, `jina`, `model2vec`, or `none`)"
     )]
     UnknownEmbeddingBackend(String),
+    #[error("unknown remote embedding mode `{0}` (expected `connect` or `ephemeral`)")]
+    UnknownRemoteMode(String),
+    #[error(
+        "[local_ai.embedding.remote] requires a non-empty `model` (the Ollama API model name, \
+         such as `all-minilm`)"
+    )]
+    RemoteEmbeddingMissingModel,
+    #[error(
+        "[local_ai.embedding.remote] mode = \"connect\" requires a non-empty `endpoint` (the \
+         remote server URL, such as `http://localhost:11434`)"
+    )]
+    RemoteEmbeddingMissingEndpoint,
+    #[error(
+        "[local_ai.embedding.remote] mode = \"ephemeral\" is not yet supported (needs the \
+         provisioning cookbook, #318); use mode = \"connect\" for now"
+    )]
+    RemoteEmbeddingEphemeralUnsupported,
     #[error("duplicate target name `{0}`")]
     DuplicateTarget(String),
     #[error("configured directory does not exist: {0}")]
@@ -1014,6 +1165,177 @@ mod tests {
             omp_threads: Some(1),
             max_embedding_chars: 5000,
         });
+    }
+
+    #[test]
+    fn remote_embedding_absent_is_none() {
+        let raw: RawConfig = toml::from_str(
+            r#"
+            [index]
+            root = "."
+
+            [local_ai.embedding]
+            model = "minilm"
+            "#,
+        )
+        .unwrap();
+        let local_ai = LocalAiConfig::try_from(raw.local_ai).unwrap();
+        assert_eq!(local_ai.embedding.remote, None, "no [remote] block → remote: None");
+    }
+
+    #[test]
+    fn remote_embedding_connect_happy_path_applies_defaults() {
+        let raw: RawConfig = toml::from_str(
+            r#"
+            [index]
+            root = "."
+
+            [local_ai.embedding.remote]
+            mode = "connect"
+            model = "all-minilm"
+            endpoint = "http://localhost:11434"
+            "#,
+        )
+        .unwrap();
+        let local_ai = LocalAiConfig::try_from(raw.local_ai).unwrap();
+        assert_eq!(
+            local_ai.embedding.remote,
+            Some(RemoteEmbeddingConfig {
+                mode: RemoteMode::Connect,
+                model: "all-minilm".to_string(),
+                endpoint: Some("http://localhost:11434".to_string()),
+                auth_env: None,
+                // defaults applied when omitted
+                batch_size: 256,
+                request_timeout_s: 60,
+            })
+        );
+    }
+
+    #[test]
+    fn remote_embedding_mode_omitted_defaults_to_connect() {
+        let raw: RawConfig = toml::from_str(
+            r#"
+            [index]
+            root = "."
+
+            [local_ai.embedding.remote]
+            model = "all-minilm"
+            endpoint = "http://localhost:11434"
+            "#,
+        )
+        .unwrap();
+        let local_ai = LocalAiConfig::try_from(raw.local_ai).unwrap();
+        let remote = local_ai.embedding.remote.expect("remote block present");
+        assert_eq!(remote.mode, RemoteMode::Connect, "absent mode → Connect (the v1 default)");
+    }
+
+    #[test]
+    fn remote_embedding_overrides_batch_and_timeout() {
+        let raw: RawConfig = toml::from_str(
+            r#"
+            [index]
+            root = "."
+
+            [local_ai.embedding.remote]
+            model = "all-minilm"
+            endpoint = "http://localhost:11434"
+            auth_env = "OLLAMA_TOKEN"
+            batch_size = 512
+            request_timeout_s = 120
+            "#,
+        )
+        .unwrap();
+        let local_ai = LocalAiConfig::try_from(raw.local_ai).unwrap();
+        assert_eq!(
+            local_ai.embedding.remote,
+            Some(RemoteEmbeddingConfig {
+                mode: RemoteMode::Connect,
+                model: "all-minilm".to_string(),
+                endpoint: Some("http://localhost:11434".to_string()),
+                auth_env: Some("OLLAMA_TOKEN".to_string()),
+                batch_size: 512,
+                request_timeout_s: 120,
+            })
+        );
+    }
+
+    #[test]
+    fn remote_embedding_connect_without_endpoint_is_rejected() {
+        let raw: RawConfig = toml::from_str(
+            r#"
+            [index]
+            root = "."
+
+            [local_ai.embedding.remote]
+            mode = "connect"
+            model = "all-minilm"
+            "#,
+        )
+        .unwrap();
+        let err = LocalAiConfig::try_from(raw.local_ai).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::RemoteEmbeddingMissingEndpoint),
+            "connect mode without endpoint → RemoteEmbeddingMissingEndpoint, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn remote_embedding_ephemeral_mode_is_unsupported() {
+        let raw: RawConfig = toml::from_str(
+            r#"
+            [index]
+            root = "."
+
+            [local_ai.embedding.remote]
+            mode = "ephemeral"
+            model = "all-minilm"
+            "#,
+        )
+        .unwrap();
+        let err = LocalAiConfig::try_from(raw.local_ai).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::RemoteEmbeddingEphemeralUnsupported),
+            "ephemeral mode → RemoteEmbeddingEphemeralUnsupported, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn remote_embedding_missing_model_is_rejected() {
+        // Block present (so it parses to Some) but `model` omitted → missing-model error.
+        let raw: RawConfig = toml::from_str(
+            r#"
+            [index]
+            root = "."
+
+            [local_ai.embedding.remote]
+            endpoint = "http://localhost:11434"
+            "#,
+        )
+        .unwrap();
+        let err = LocalAiConfig::try_from(raw.local_ai).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::RemoteEmbeddingMissingModel),
+            "omitted model → RemoteEmbeddingMissingModel, got {err:?}",
+        );
+
+        // A whitespace-only `model` trims to empty and is rejected the same way.
+        let raw: RawConfig = toml::from_str(
+            r#"
+            [index]
+            root = "."
+
+            [local_ai.embedding.remote]
+            model = "   "
+            endpoint = "http://localhost:11434"
+            "#,
+        )
+        .unwrap();
+        let err = LocalAiConfig::try_from(raw.local_ai).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::RemoteEmbeddingMissingModel),
+            "whitespace-only model → RemoteEmbeddingMissingModel, got {err:?}",
+        );
     }
 
     #[test]

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use serde::Deserialize;
 use thiserror::Error;
 
-use crate::embedding_models::{EmbeddingModelSpec, spec_for_alias};
+use crate::embedding_models::{Backend, EmbeddingModelSpec, spec_for_alias};
 use crate::language::{Language, LanguageError};
 
 #[derive(Debug, Clone)]
@@ -163,6 +163,14 @@ impl EmbeddingBackend {
     /// embeddings-off choice.
     pub fn model_id(self) -> Option<&'static str> {
         self.0.map(|spec| spec.model_id)
+    }
+
+    /// The registry [`Backend`] this selector resolves to (`None` for the embeddings-off choice).
+    /// Lets `config` reason about which runtime a `model = "..."` picks — e.g. the
+    /// `[embedding.remote]` coherence check that pairs an Ollama backend with a remote block —
+    /// without re-deriving the mapping the registry already owns.
+    pub fn registry_backend(self) -> Option<Backend> {
+        self.0.map(|spec| spec.backend)
     }
 }
 
@@ -728,6 +736,18 @@ impl TryFrom<RawEmbedding> for EmbeddingConfig {
             None => EmbeddingBackend::default(),
         };
         let remote = raw.remote.map(RemoteEmbeddingConfig::try_from).transpose()?;
+        // Cross-field coherence: the `[embedding.remote]` block and the `model = "..."` selector
+        // must AGREE on whether embedding is remote. Run AFTER `RemoteEmbeddingConfig::try_from`
+        // (above) so a malformed block fails with its own specific error first. We REJECT
+        // incoherent configs rather than auto-selecting a backend — silently running the LOCAL
+        // model while the user believes remote offload is on (a remote block but a fastembed
+        // `model`) is the trap this guards.
+        let selects_ollama = backend.registry_backend() == Some(Backend::Ollama);
+        match (selects_ollama, remote.is_some()) {
+            (false, true) => return Err(ConfigError::RemoteEmbeddingBackendMismatch),
+            (true, false) => return Err(ConfigError::RemoteEmbeddingMissingConfig),
+            _ => {},
+        }
         Ok(Self { backend, runtime: raw.runtime.into(), remote })
     }
 }
@@ -841,6 +861,16 @@ pub enum ConfigError {
          provisioning cookbook, #318); use mode = \"connect\" for now"
     )]
     RemoteEmbeddingEphemeralUnsupported,
+    #[error(
+        "an [local_ai.embedding.remote] block is set but `model` doesn't select an Ollama model; \
+         set `model = \"ollama\"` or remove the remote block"
+    )]
+    RemoteEmbeddingBackendMismatch,
+    #[error(
+        "the Ollama embedding backend (`model = \"ollama\"`) requires an \
+         [local_ai.embedding.remote] block with `endpoint` + `model`"
+    )]
+    RemoteEmbeddingMissingConfig,
     #[error("duplicate target name `{0}`")]
     DuplicateTarget(String),
     #[error("configured directory does not exist: {0}")]
@@ -1190,6 +1220,9 @@ mod tests {
             [index]
             root = "."
 
+            [local_ai.embedding]
+            model = "ollama"
+
             [local_ai.embedding.remote]
             mode = "connect"
             model = "all-minilm"
@@ -1219,6 +1252,9 @@ mod tests {
             [index]
             root = "."
 
+            [local_ai.embedding]
+            model = "ollama"
+
             [local_ai.embedding.remote]
             model = "all-minilm"
             endpoint = "http://localhost:11434"
@@ -1236,6 +1272,9 @@ mod tests {
             r#"
             [index]
             root = "."
+
+            [local_ai.embedding]
+            model = "ollama"
 
             [local_ai.embedding.remote]
             model = "all-minilm"
@@ -1262,10 +1301,16 @@ mod tests {
 
     #[test]
     fn remote_embedding_connect_without_endpoint_is_rejected() {
+        // `model = "ollama"` keeps the config coherent on the cross-field axis, so the block's own
+        // missing-endpoint error (which fires first, in RemoteEmbeddingConfig::try_from) is the
+        // ONLY error in play — not the mismatch guard.
         let raw: RawConfig = toml::from_str(
             r#"
             [index]
             root = "."
+
+            [local_ai.embedding]
+            model = "ollama"
 
             [local_ai.embedding.remote]
             mode = "connect"
@@ -1287,6 +1332,9 @@ mod tests {
             [index]
             root = "."
 
+            [local_ai.embedding]
+            model = "ollama"
+
             [local_ai.embedding.remote]
             mode = "ephemeral"
             model = "all-minilm"
@@ -1302,11 +1350,18 @@ mod tests {
 
     #[test]
     fn remote_embedding_missing_model_is_rejected() {
-        // Block present (so it parses to Some) but `model` omitted → missing-model error.
+        // `model = "ollama"` (the backend selector) keeps the config coherent so the block's own
+        // missing-model error is the only one in play. NOTE the two `model` keys are distinct: the
+        // `[local_ai.embedding] model` is the registry SELECTOR; the `[remote] model` is the Ollama
+        // API model name — it's the latter that's missing here.
+        // Block present (so it parses to Some) but `[remote] model` omitted → missing-model error.
         let raw: RawConfig = toml::from_str(
             r#"
             [index]
             root = "."
+
+            [local_ai.embedding]
+            model = "ollama"
 
             [local_ai.embedding.remote]
             endpoint = "http://localhost:11434"
@@ -1319,11 +1374,14 @@ mod tests {
             "omitted model → RemoteEmbeddingMissingModel, got {err:?}",
         );
 
-        // A whitespace-only `model` trims to empty and is rejected the same way.
+        // A whitespace-only `[remote] model` trims to empty and is rejected the same way.
         let raw: RawConfig = toml::from_str(
             r#"
             [index]
             root = "."
+
+            [local_ai.embedding]
+            model = "ollama"
 
             [local_ai.embedding.remote]
             model = "   "
@@ -1335,6 +1393,50 @@ mod tests {
         assert!(
             matches!(err, ConfigError::RemoteEmbeddingMissingModel),
             "whitespace-only model → RemoteEmbeddingMissingModel, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn remote_block_without_ollama_backend_is_a_mismatch() {
+        // A fully-valid [remote] block but `model` selects (defaults to) fastembed — the trap: the
+        // user believes remote offload is on, but the LOCAL model would run. Rejected, not
+        // auto-selected.
+        let raw: RawConfig = toml::from_str(
+            r#"
+            [index]
+            root = "."
+
+            [local_ai.embedding.remote]
+            model = "all-minilm"
+            endpoint = "http://localhost:11434"
+            "#,
+        )
+        .unwrap();
+        let err = LocalAiConfig::try_from(raw.local_ai).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::RemoteEmbeddingBackendMismatch),
+            "remote block + non-ollama model → RemoteEmbeddingBackendMismatch, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn ollama_backend_without_remote_block_is_missing_config() {
+        // `model = "ollama"` selects the Ollama backend, but there's no [remote] block to tell it
+        // where/how to reach the server → incoherent, rejected.
+        let raw: RawConfig = toml::from_str(
+            r#"
+            [index]
+            root = "."
+
+            [local_ai.embedding]
+            model = "ollama"
+            "#,
+        )
+        .unwrap();
+        let err = LocalAiConfig::try_from(raw.local_ai).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::RemoteEmbeddingMissingConfig),
+            "ollama backend without remote block → RemoteEmbeddingMissingConfig, got {err:?}",
         );
     }
 

--- a/crates/rag-rat-core/src/index/ai/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/mod.rs
@@ -15,6 +15,8 @@ pub(crate) use policy::*;
 pub use providers::FastEmbedEmbedder;
 #[cfg(test)]
 pub use providers::MockEmbedder;
+#[cfg(feature = "model2vec")]
+pub use providers::Model2VecEmbedder;
 pub(crate) use providers::active_embedder;
 // Curate the provider surface onto the `index::ai` path so existing `super::*` callers
 // (`reconcile`, `status`, `helpers`) and the external `ai::Embedder` /
@@ -26,10 +28,9 @@ pub(crate) use providers::active_embedder;
 // `#[cfg(not(...))]`-only consts). A `pub(crate)` re-export would narrow that and redden `-D
 // warnings`.
 pub use providers::{
-    Embedder, FASTEMBED_MISSING_FEATURE_MESSAGE, HashEmbedder, MODEL2VEC_MISSING_FEATURE_MESSAGE,
+    Embedder, FASTEMBED_MISSING_FEATURE_MESSAGE, HashEmbedder, MODEL2VEC_HF_REPO,
+    MODEL2VEC_MISSING_FEATURE_MESSAGE,
 };
-#[cfg(feature = "model2vec")]
-pub use providers::{MODEL2VEC_HF_REPO, Model2VecEmbedder};
 pub(crate) use reconcile::*;
 pub(crate) use reencode::*;
 use rusqlite::types::Value;

--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -6,7 +6,8 @@
 #[cfg(feature = "fastembed")]
 mod fastembed;
 mod hash;
-#[cfg(feature = "model2vec")]
+// Ungated: the module compiles in all builds so its dep-free `MODEL2VEC_HF_REPO` const stays
+// available; only `Model2VecEmbedder` (which needs `model2vec-rs`) is feature-gated inside it.
 mod model2vec;
 
 use rusqlite::Connection;
@@ -14,8 +15,9 @@ use rusqlite::Connection;
 #[cfg(feature = "fastembed")]
 pub use self::fastembed::FastEmbedEmbedder;
 pub use self::hash::HashEmbedder;
+pub use self::model2vec::MODEL2VEC_HF_REPO;
 #[cfg(feature = "model2vec")]
-pub use self::model2vec::{MODEL2VEC_HF_REPO, Model2VecEmbedder};
+pub use self::model2vec::Model2VecEmbedder;
 use crate::embedding_models::{Backend, EmbeddingModelSpec, spec};
 use crate::index::ai::{active_embedding_model_id, model, validate_ready_model};
 

--- a/crates/rag-rat-core/src/index/ai/providers/model2vec.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/model2vec.rs
@@ -1,14 +1,24 @@
-use super::Embedder;
-use crate::embedding_models::{MODEL2VEC_EMBEDDING_DIM, MODEL2VEC_MODEL_ID};
+//! The Model2Vec backend. `Model2VecEmbedder` is gated behind the `model2vec` feature (it needs the
+//! `model2vec-rs` dep); `MODEL2VEC_HF_REPO` is a dep-free string and stays UNCONDITIONAL so its
+//! public path `index::ai::MODEL2VEC_HF_REPO` survives in hash-only / `--no-default-features`
+//! builds (it was an unconditional `pub const` before the `providers/` extraction — #320/#323
+//! review).
 
-/// The Model2Vec HF repo to pull weights from. Not a registry field — it is a construction detail
-/// of `Model2VecEmbedder`, not part of the model's index identity.
+/// The Model2Vec HF repo to pull weights from. Not a registry field — a construction detail of
+/// `Model2VecEmbedder`, not part of the model's index identity. Dep-free, so it's not gated.
 pub const MODEL2VEC_HF_REPO: &str = "minishlab/potion-retrieval-32M";
 
+#[cfg(feature = "model2vec")]
+use super::Embedder;
+#[cfg(feature = "model2vec")]
+use crate::embedding_models::{MODEL2VEC_EMBEDDING_DIM, MODEL2VEC_MODEL_ID};
+
+#[cfg(feature = "model2vec")]
 pub struct Model2VecEmbedder {
     model: model2vec_rs::model::StaticModel,
 }
 
+#[cfg(feature = "model2vec")]
 impl Model2VecEmbedder {
     pub fn new() -> anyhow::Result<Self> {
         // Downloads (and caches) the static model from the Hugging Face hub on first use; L2-
@@ -24,6 +34,7 @@ impl Model2VecEmbedder {
     }
 }
 
+#[cfg(feature = "model2vec")]
 impl Embedder for Model2VecEmbedder {
     fn model_id(&self) -> &str {
         MODEL2VEC_MODEL_ID


### PR DESCRIPTION
**Task 3 of 7** toward the Ollama embedding provider (#317). Parses + validates the `[embedding.remote]` block; **parse-only** (consumed by dispatch in task 5).

- `RemoteEmbeddingConfig { mode, model, endpoint, auth_env, batch_size=256, request_timeout_s=60 }` on `EmbeddingConfig`. **No `dim`/`backend`** — dim comes from the registry spec (the `ollama-all-minilm` row, dim 384, runtime-validated by the embedder), backend implied by the selected model.
- `RemoteMode { Connect, Ephemeral }`, default **Connect**. `model` = the **Ollama API model name** (e.g. `all-minilm`), not a registry alias.
- Validation: mode absent → Connect; `ephemeral` → `RemoteEmbeddingEphemeralUnsupported` (needs the cookbook #318); model required; Connect requires `endpoint`; `auth_env` optional.
- `ConfigError`: `UnknownRemoteMode`, `RemoteEmbeddingMissingModel`, `RemoteEmbeddingMissingEndpoint`, `RemoteEmbeddingEphemeralUnsupported`.

**Verified:** +7 unit tests; core suite **937** (930 + 7); clippy `--all-targets` clean default **and** `--no-default-features`; fmt.