### PR TITLE
feat(embed): wire Ollama end-to-end — connect mode (#317 task 5+6)

### DIFF
--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -475,7 +475,8 @@ pub(crate) fn models(config: &Config, args: &ModelsArgs) -> anyhow::Result<()> {
     let db = open_index(config)?;
     match &args.command {
         None | Some(ModelsCommand::List) => print_output(&db.list_models()?),
-        Some(ModelsCommand::Install { model_id }) => print_output(&db.install_model(model_id)?),
+        Some(ModelsCommand::Install { model_id }) =>
+            print_output(&db.install_model(model_id, config.local_ai.embedding.remote.as_ref())?),
     }
 }
 pub(crate) fn reconcile(config: &Config, args: &ReconcileArgs) -> anyhow::Result<()> {

--- a/crates/rag-rat-cli/src/init/run.rs
+++ b/crates/rag-rat-cli/src/init/run.rs
@@ -252,12 +252,14 @@ pub(crate) fn setup_model_and_reconcile(
         return Ok(());
     }
     eprintln!("init: installing model {model_id}");
-    match db.install_model(model_id) {
+    let remote = config.local_ai.embedding.remote.as_ref();
+    match db.install_model(model_id, remote) {
         Ok(model) => eprintln!("init: model status {} {}", model.model_id, model.status),
         Err(err) if model_id == FASTEMBED_MODEL_ID || model_id == MODEL2VEC_MODEL_ID => {
             eprintln!("init: {} install failed: {err}", backend.as_str());
             eprintln!("init: falling back to {HASH_MODEL_ID}");
-            db.install_model(HASH_MODEL_ID)?;
+            // Hash is a local backend — no remote config needed for the fallback.
+            db.install_model(HASH_MODEL_ID, None)?;
         },
         Err(err) => return Err(err),
     }

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -768,6 +768,16 @@ struct RawRemoteEmbedding {
     request_timeout_s: Option<u64>,
 }
 
+/// Whether the URL's authority embeds userinfo (`user[:pass]@host`). Parses the authority as
+/// everything after `scheme://` up to the next `/`, `?`, or `#`, and reports an `@` in it. A bare
+/// host, an `@` in the path/query, or a URL with no scheme separator all return false. Used to keep
+/// credentials out of the endpoint string before it is persisted into the index meta.
+fn endpoint_authority_has_userinfo(endpoint: &str) -> bool {
+    let after_scheme = endpoint.split_once("://").map_or(endpoint, |(_, rest)| rest);
+    let authority = after_scheme.split(['/', '?', '#']).next().unwrap_or(after_scheme);
+    authority.contains('@')
+}
+
 impl TryFrom<RawRemoteEmbedding> for RemoteEmbeddingConfig {
     type Error = ConfigError;
 
@@ -791,6 +801,16 @@ impl TryFrom<RawRemoteEmbedding> for RemoteEmbeddingConfig {
         let endpoint = raw.endpoint.map(|e| e.trim().to_string()).filter(|e| !e.is_empty());
         if mode == RemoteMode::Connect && endpoint.is_none() {
             return Err(ConfigError::RemoteEmbeddingMissingEndpoint);
+        }
+        // SECRET HYGIENE: the endpoint string is persisted WHOLE into the (secret-free) index meta
+        // at install. A URL with userinfo (`https://user:token@host`) would copy that credential
+        // into the SQLite index — reject it here and direct the user to `auth_env`. Checked against
+        // the URL authority only (between `scheme://` and the next `/`), so an `@` in a path/query
+        // is fine.
+        if let Some(endpoint) = endpoint.as_deref()
+            && endpoint_authority_has_userinfo(endpoint)
+        {
+            return Err(ConfigError::RemoteEmbeddingEndpointHasCredentials);
         }
         // Optional — local Ollama needs no auth; trim if present.
         let auth_env = raw.auth_env.map(|a| a.trim().to_string()).filter(|a| !a.is_empty());
@@ -867,6 +887,12 @@ pub enum ConfigError {
          provisioning cookbook, #318); use mode = \"connect\" for now"
     )]
     RemoteEmbeddingEphemeralUnsupported,
+    #[error(
+        "[local_ai.embedding.remote] `endpoint` must not embed credentials in the URL (no \
+         `user:pass@host`) — the endpoint is persisted into the index; put any token in an env \
+         var and name it via `auth_env` instead"
+    )]
+    RemoteEmbeddingEndpointHasCredentials,
     #[error(
         "an [local_ai.embedding.remote] block is set but `model` doesn't select an Ollama model; \
          set `model = \"ollama\"` or remove the remote block"
@@ -1329,6 +1355,65 @@ mod tests {
             matches!(err, ConfigError::RemoteEmbeddingMissingEndpoint),
             "connect mode without endpoint → RemoteEmbeddingMissingEndpoint, got {err:?}",
         );
+    }
+
+    #[test]
+    fn remote_embedding_endpoint_with_credentials_is_rejected() {
+        // The endpoint is persisted whole into the index meta, so a `user:token@host` URL would
+        // copy the credential into the index. Reject it and direct the user to `auth_env`.
+        let raw: RawConfig = toml::from_str(
+            r#"
+            [index]
+            root = "."
+
+            [local_ai.embedding]
+            model = "ollama"
+
+            [local_ai.embedding.remote]
+            model = "all-minilm"
+            endpoint = "https://user:token@host:11434"
+            "#,
+        )
+        .unwrap();
+        let err = LocalAiConfig::try_from(raw.local_ai).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::RemoteEmbeddingEndpointHasCredentials),
+            "endpoint with userinfo → RemoteEmbeddingEndpointHasCredentials, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn remote_embedding_endpoint_without_credentials_is_accepted() {
+        // A plain host and a loopback endpoint both pass the userinfo guard (and an `@` in a path
+        // is not userinfo).
+        for endpoint in [
+            "https://host:11434",
+            "http://127.0.0.1:11434",
+            "http://localhost:11434/v1/embeddings?user=a@b",
+        ] {
+            let raw: RawConfig = toml::from_str(&format!(
+                "[index]\nroot = \".\"\n\n[local_ai.embedding]\nmodel = \
+                 \"ollama\"\n\n[local_ai.embedding.remote]\nmodel = \"all-minilm\"\nendpoint = \
+                 \"{endpoint}\"\n"
+            ))
+            .unwrap();
+            let remote = LocalAiConfig::try_from(raw.local_ai)
+                .unwrap_or_else(|e| panic!("`{endpoint}` must be accepted: {e:?}"))
+                .embedding
+                .remote
+                .expect("remote block present");
+            assert_eq!(remote.endpoint.as_deref(), Some(endpoint));
+        }
+    }
+
+    #[test]
+    fn endpoint_authority_has_userinfo_classifies_urls() {
+        assert!(endpoint_authority_has_userinfo("https://user:token@host:11434"));
+        assert!(endpoint_authority_has_userinfo("http://u@127.0.0.1"));
+        assert!(!endpoint_authority_has_userinfo("https://host:11434"));
+        assert!(!endpoint_authority_has_userinfo("http://127.0.0.1:11434"));
+        // An `@` in the PATH/query is not userinfo.
+        assert!(!endpoint_authority_has_userinfo("http://host:11434/path?x=a@b"));
     }
 
     #[test]

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::embedding_models::{Backend, EmbeddingModelSpec, spec_for_alias};
@@ -222,7 +222,13 @@ impl Default for EmbeddingRuntimeConfig {
 /// spec of the selected model (the `ollama-all-minilm` row, dim 384) and is validated against the
 /// server's first response at runtime by the embedder (#317 task 4); the backend is implied by the
 /// selected registry model. Duplicating either here would be redundant and drift-prone.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// `Serialize` (#317 task 5) lets the install step persist this verbatim into the secret-free
+/// `active_embedding_remote_config` meta, so the `conn`-based `active_embedder` can reconstruct the
+/// remote embedder for both chunk-embed (reconcile) and query-embed (search) without threading
+/// config through the search path. SECRET-FREE: `auth_env` is the env-var NAME, never a token, so
+/// the serialized JSON holds no secret. `Deserialize` is the read side of that meta round-trip.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RemoteEmbeddingConfig {
     /// How the remote server is reached. `Connect` (the v1 default) talks to an
     /// already-running server at `endpoint`; `Ephemeral` (provision-on-demand) is not yet
@@ -258,7 +264,7 @@ impl Default for RemoteEmbeddingConfig {
 }
 
 /// How the remote-embedding server is obtained (`[local_ai.embedding.remote] mode = "..."`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum RemoteMode {
     /// Connect to an already-running server at the configured `endpoint`. The v1 default and the
     /// only supported mode today.

--- a/crates/rag-rat-core/src/eval.rs
+++ b/crates/rag-rat-core/src/eval.rs
@@ -1303,7 +1303,8 @@ mod tests {
         {
             let db = IndexDatabase::open_config(&config).unwrap();
             if let Some(model_id) = config.local_ai.embedding.backend.model_id() {
-                db.install_model(model_id).expect("install embedding model");
+                db.install_model(model_id, config.local_ai.embedding.remote.as_ref())
+                    .expect("install embedding model");
                 db.reconcile(None, None).expect("reconcile embeddings");
             }
         }

--- a/crates/rag-rat-core/src/index/ai/helpers.rs
+++ b/crates/rag-rat-core/src/index/ai/helpers.rs
@@ -10,7 +10,22 @@ pub(crate) fn embed_query(
     let Ok(embedder) = active_embedder(conn, None) else {
         return Ok(None);
     };
-    embed_query_with(&*embedder, query).map(Some)
+    // A RUNTIME embed failure on the QUERY path degrades to lexical (BM25), exactly like an
+    // unavailable model — `None` means "no query vector, fall back". This matters for the remote
+    // (Ollama) backend: a transient endpoint outage (timeout / connection refused / 5xx) must not
+    // make EVERY `search` call error; the user still gets BM25 results. This is the QUERY path ONLY
+    // — the reconcile/chunk path keeps propagating the error so chunks are marked failed/retryable
+    // and re-embedded once the endpoint recovers.
+    match embed_query_with(&*embedder, query) {
+        Ok(embedding) => Ok(Some(embedding)),
+        Err(err) => {
+            eprintln!(
+                "rag-rat: query embedding failed ({}), falling back to lexical search: {err}",
+                embedder.model_id()
+            );
+            Ok(None)
+        },
+    }
 }
 
 pub(crate) fn hash_query_embedding(query: &str) -> anyhow::Result<QueryEmbedding> {
@@ -49,7 +64,16 @@ pub(crate) fn active_embedding_model_version(
     conn: &Connection,
     model_id: &str,
 ) -> anyhow::Result<String> {
-    if let Some(version) = reconcile_meta(conn, ACTIVE_EMBEDDING_MODEL_VERSION_META)? {
+    // The `embedding_active_model_version` meta is the freshness key of the ACTIVE model ONLY (it
+    // carries the ollama endpoint hash when ollama is active). It must NOT be returned for a
+    // non-active model: `fastembed_operational_status` asks for FASTEMBED_MODEL_ID's version even
+    // when FastEmbed is inactive, and comparing existing FastEmbed rows against `hash-v1` (or the
+    // ollama endpoint hash) would spuriously report them stale/missing. For a non-active model,
+    // return its OWN static `spec.version`. The reconcile/active path always queries the active
+    // model, so it still gets the dynamic meta.
+    if model_id == active_embedding_model_id(conn)?
+        && let Some(version) = reconcile_meta(conn, ACTIVE_EMBEDDING_MODEL_VERSION_META)?
+    {
         return Ok(version);
     }
     Ok(default_model_version(model_id).to_string())
@@ -514,6 +538,73 @@ mod tests {
         set_meta(&conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META, "{not valid json").unwrap();
         let err = active_remote_config(&conn).expect_err("malformed meta must error");
         assert!(err.to_string().contains("malformed"), "{err}");
+    }
+
+    /// Mark `model_id` Ready + active in a manifest-seeded conn (mirrors a real install's DB
+    /// state).
+    fn activate_model(conn: &Connection, model_id: &str) {
+        ensure_model_manifest(conn).unwrap();
+        let dim = spec(model_id).unwrap().dim;
+        conn.execute(
+            "UPDATE ai_models
+             SET installed = 1, disabled = 0, status = 'Ready', embedding_dim = ?2
+             WHERE model_id = ?1",
+            params![model_id, i64::try_from(dim).unwrap()],
+        )
+        .unwrap();
+        set_meta(conn, ACTIVE_EMBEDDING_MODEL_META, model_id).unwrap();
+    }
+
+    #[test]
+    fn active_embedding_model_version_is_scoped_to_the_active_model() {
+        use crate::embedding_models::{FASTEMBED_MODEL_ID, OLLAMA_ALL_MINILM_MODEL_ID};
+
+        // Ollama is active with a dynamic endpoint-hash freshness key in the global meta.
+        let conn = schema_conn();
+        activate_model(&conn, OLLAMA_ALL_MINILM_MODEL_ID);
+        let endpoint_hash = "ollama-all-minilm-v1-deadbeefcafef00d";
+        set_reconcile_meta(&conn, ACTIVE_EMBEDDING_MODEL_VERSION_META, endpoint_hash).unwrap();
+
+        // The ACTIVE model gets the dynamic meta...
+        assert_eq!(
+            active_embedding_model_version(&conn, OLLAMA_ALL_MINILM_MODEL_ID).unwrap(),
+            endpoint_hash,
+        );
+        // ...but a NON-active model gets its OWN static spec.version, NOT the ollama hash — so
+        // fastembed_operational_status doesn't report existing FastEmbed rows stale against the
+        // active model's key.
+        let fastembed_version = active_embedding_model_version(&conn, FASTEMBED_MODEL_ID).unwrap();
+        assert_eq!(fastembed_version, spec(FASTEMBED_MODEL_ID).unwrap().version);
+        assert_ne!(fastembed_version, endpoint_hash, "must not leak the ollama hash to fastembed");
+    }
+
+    #[test]
+    fn embed_query_falls_back_to_lexical_when_the_remote_query_embed_fails() {
+        use crate::embedding_models::OLLAMA_ALL_MINILM_MODEL_ID;
+
+        // An ollama-active conn whose persisted endpoint points at a CLOSED port: construction
+        // succeeds (from_remote_config doesn't connect), but embed_batch fails (connection
+        // refused). The QUERY path must degrade to lexical — Ok(None), not Err — so search
+        // still returns BM25.
+        let port = {
+            let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            l.local_addr().unwrap().port()
+        };
+        let conn = schema_conn();
+        activate_model(&conn, OLLAMA_ALL_MINILM_MODEL_ID);
+        let remote = RemoteEmbeddingConfig {
+            mode: RemoteMode::Connect,
+            model: "all-minilm".to_string(),
+            endpoint: Some(format!("http://127.0.0.1:{port}")),
+            auth_env: None,
+            batch_size: 256,
+            request_timeout_s: 2,
+        };
+        set_active_remote_config(&conn, &remote).unwrap();
+
+        let result =
+            embed_query(&conn, "some query").expect("must NOT propagate the runtime error");
+        assert!(result.is_none(), "a failed remote query embed degrades to lexical (None)");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/helpers.rs
+++ b/crates/rag-rat-core/src/index/ai/helpers.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::config::RemoteEmbeddingConfig;
 use crate::embedding_models::{HASH_MODEL_ID, spec};
 
 pub(crate) fn embed_query(
@@ -373,6 +374,41 @@ pub(crate) fn meta(conn: &Connection, key: &str) -> anyhow::Result<Option<String
         .optional()?)
 }
 
+/// Persist the active remote-embedding connection params as secret-free JSON in the
+/// [`ACTIVE_EMBEDDING_REMOTE_CONFIG_META`] meta (#317 task 5). Written at install when an Ollama
+/// model is activated; the `conn`-based `active_embedder` reads it back via
+/// [`active_remote_config`] so reconcile (chunk-embed) and search (query-embed) reconstruct the
+/// SAME remote embedder without threading config through the search path. SECRET-FREE:
+/// `RemoteEmbeddingConfig::auth_env` is the env-var NAME, never the token, so the stored JSON
+/// contains no secret.
+pub(crate) fn set_active_remote_config(
+    conn: &Connection,
+    remote: &RemoteEmbeddingConfig,
+) -> anyhow::Result<()> {
+    let json = serde_json::to_string(remote)
+        .map_err(|e| anyhow::anyhow!("failed to serialize remote embedding config: {e}"))?;
+    set_meta(conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META, &json)
+}
+
+/// Read the persisted active remote-embedding config (the inverse of [`set_active_remote_config`]).
+/// `None` when no remote config has been written (the common local-embedder case). A present-but-
+/// malformed value is a hard error — a corrupted meta must surface loudly, not silently fall back
+/// to "no remote config" and then bail with the wrong message in the dispatch.
+pub(crate) fn active_remote_config(
+    conn: &Connection,
+) -> anyhow::Result<Option<RemoteEmbeddingConfig>> {
+    let Some(json) = meta(conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META)? else {
+        return Ok(None);
+    };
+    let remote = serde_json::from_str(&json).map_err(|e| {
+        anyhow::anyhow!(
+            "stored remote embedding config (`{ACTIVE_EMBEDDING_REMOTE_CONFIG_META}`) is \
+             malformed: {e}"
+        )
+    })?;
+    Ok(Some(remote))
+}
+
 pub(crate) fn set_reconcile_meta(conn: &Connection, key: &str, value: &str) -> anyhow::Result<()> {
     conn.execute(
         "INSERT INTO reconcile_meta(key, value) VALUES (?1, ?2)
@@ -419,6 +455,7 @@ pub(crate) fn find_existing_embedding(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::RemoteMode;
 
     fn unit(v: &[f32]) -> Vec<f32> {
         let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
@@ -426,6 +463,57 @@ mod tests {
     }
     fn dot_f32(a: &[f32], b: &[f32]) -> f32 {
         a.iter().zip(b).map(|(x, y)| x * y).sum()
+    }
+
+    fn schema_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::index::schema::apply(&conn).unwrap();
+        conn
+    }
+
+    fn sample_remote() -> RemoteEmbeddingConfig {
+        RemoteEmbeddingConfig {
+            mode: RemoteMode::Connect,
+            model: "all-minilm".to_string(),
+            endpoint: Some("http://localhost:11434".to_string()),
+            // The NAME of an env var — never a token. The round-trip test asserts this name is
+            // present and no token is.
+            auth_env: Some("OLLAMA_TOKEN".to_string()),
+            batch_size: 256,
+            request_timeout_s: 60,
+        }
+    }
+
+    #[test]
+    fn active_remote_config_is_none_when_unset() {
+        let conn = schema_conn();
+        assert_eq!(active_remote_config(&conn).unwrap(), None);
+    }
+
+    #[test]
+    fn remote_config_meta_round_trips_without_storing_a_token() {
+        let conn = schema_conn();
+        let remote = sample_remote();
+        set_active_remote_config(&conn, &remote).unwrap();
+
+        // Read-back equals what we wrote.
+        assert_eq!(active_remote_config(&conn).unwrap(), Some(remote));
+
+        // SECRET-FREE: the serialized JSON carries the auth_env NAME but no token value.
+        let json = meta(&conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META).unwrap().unwrap();
+        assert!(json.contains("OLLAMA_TOKEN"), "stores the env-var name: {json}");
+        // Belt-and-suspenders: no bearer/token-shaped material leaks into the meta.
+        assert!(!json.to_lowercase().contains("bearer"), "no bearer token in meta: {json}");
+        assert!(!json.to_lowercase().contains("secret"), "no secret material in meta: {json}");
+    }
+
+    #[test]
+    fn active_remote_config_errors_on_malformed_meta() {
+        // A corrupted meta must surface loudly, not silently degrade to "no remote config".
+        let conn = schema_conn();
+        set_meta(&conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META, "{not valid json").unwrap();
+        let err = active_remote_config(&conn).expect_err("malformed meta must error");
+        assert!(err.to_string().contains("malformed"), "{err}");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/mod.rs
@@ -45,6 +45,11 @@ use crate::language::Language;
 
 const ACTIVE_EMBEDDING_MODEL_META: &str = "active_embedding_model";
 const ACTIVE_EMBEDDING_MODEL_VERSION_META: &str = "embedding_active_model_version";
+/// Secret-free JSON of the active [`RemoteEmbeddingConfig`] (#317 task 5). Written at install when
+/// an Ollama model is activated; read by `active_embedder` to reconstruct the remote embedder for
+/// BOTH chunk-embed (reconcile) and query-embed (search), so the `conn`-based construction path
+/// needs no config threading. SECRET-FREE: `auth_env` is the env-var NAME, never the token.
+const ACTIVE_EMBEDDING_REMOTE_CONFIG_META: &str = "active_embedding_remote_config";
 const LAST_EMBEDDING_RECONCILE_STARTED_META: &str = "last_embedding_reconcile_started_at_ms";
 const LAST_EMBEDDING_RECONCILE_FINISHED_META: &str = "last_embedding_reconcile_finished_at_ms";
 const DEFAULT_BATCH_SIZE: usize = 64;

--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -26,8 +26,11 @@ pub use self::model2vec::Model2VecEmbedder;
 // visibility (same pattern as the other backends) exempts it from dead-code/unused-import
 // analysis under `-D warnings` until the dispatch arm lands.
 pub use self::ollama::OllamaEmbedder;
+use crate::config::RemoteEmbeddingConfig;
 use crate::embedding_models::{Backend, EmbeddingModelSpec, spec};
-use crate::index::ai::{active_embedding_model_id, model, validate_ready_model};
+use crate::index::ai::{
+    active_embedding_model_id, active_remote_config, model, validate_ready_model,
+};
 
 pub const MODEL2VEC_MISSING_FEATURE_MESSAGE: &str =
     "Model2Vec backend requested, but this binary was built without Model2Vec support.\nRebuild \
@@ -51,7 +54,16 @@ pub(crate) fn active_embedder(
     validate_ready_model(&model)?;
     let spec = spec(&model.model_id)
         .ok_or_else(|| anyhow::anyhow!("unknown active embedding model `{}`", model.model_id))?;
-    embedder_for_spec(spec, intra_threads)
+    // The remote config is read from the DB meta (persisted at install) ONLY for an Ollama-backed
+    // active model — every other backend ignores it. This is the single construction site, so both
+    // callers (reconcile's chunk-embed and `embed_query`'s query-embed) transparently get an
+    // `OllamaEmbedder` pointed at the same endpoint + model: connect mode has no chunk/query split
+    // (the mirror is deferred to ephemeral, #318).
+    let remote = match spec.backend {
+        Backend::Ollama => active_remote_config(conn)?,
+        _ => None,
+    };
+    embedder_for_spec(spec, intra_threads, remote.as_ref())
 }
 
 /// Build the embedder for a registry spec, dispatching on its `backend`. The single construction
@@ -62,6 +74,7 @@ pub(crate) fn active_embedder(
 pub(crate) fn embedder_for_spec(
     spec: &'static EmbeddingModelSpec,
     intra_threads: Option<usize>,
+    remote: Option<&RemoteEmbeddingConfig>,
 ) -> anyhow::Result<Box<dyn Embedder>> {
     match spec.backend {
         Backend::Hash => Ok(Box::new(HashEmbedder)),
@@ -92,10 +105,21 @@ pub(crate) fn embedder_for_spec(
                 anyhow::bail!("{}", MODEL2VEC_MISSING_FEATURE_MESSAGE)
             }
         },
-        // The Ollama HTTP backend is wired in #317 task 5 (dispatch + role split). The registry
-        // row + enum variant exist as of task 2 so the table is complete; constructing one bails
-        // until then.
-        Backend::Ollama => anyhow::bail!("ollama embedding backend not yet wired (#317 task 5)"),
+        // The Ollama HTTP backend (#317 task 5). `registry_dim` is `spec.dim` — the dim parity
+        // contract the embedder checks every batch against. The remote connection params come from
+        // the persisted meta (read in `active_embedder`), not from config threading; absence means
+        // an Ollama model was activated without its config being written — a corrupted/half-done
+        // install — so bail with the recovery hint rather than constructing a half-formed embedder.
+        Backend::Ollama => {
+            let _ = intra_threads;
+            let remote = remote.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "ollama backend active but no remote config persisted — run `rag-rat \
+                     reconcile`/install to re-activate the model"
+                )
+            })?;
+            Ok(Box::new(OllamaEmbedder::from_remote_config(remote, spec.dim)?))
+        },
     }
 }
 
@@ -124,5 +148,80 @@ impl Embedder for MockEmbedder {
 
     fn embed_batch(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {
         Ok(texts.iter().map(|text| crate::index::ai::hash_embed_text(text, self.dim)).collect())
+    }
+}
+
+#[cfg(test)]
+mod dispatch_tests {
+    use super::*;
+    use crate::config::RemoteMode;
+    use crate::embedding_models::{OLLAMA_ALL_MINILM_EMBEDDING_DIM, OLLAMA_ALL_MINILM_MODEL_ID};
+    use crate::index::ai::set_active_remote_config;
+
+    /// An in-memory index with the schema applied + the manifest seeded, with `model_id` forced
+    /// Ready and made the active embedding model. Mirrors how a real install leaves the DB, so
+    /// `active_embedder` resolves the active spec exactly as in production.
+    fn conn_with_active_model(model_id: &str) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::index::schema::apply(&conn).unwrap();
+        crate::index::ai::ensure_model_manifest(&conn).unwrap();
+        let spec = spec(model_id).unwrap();
+        conn.execute(
+            "UPDATE ai_models
+             SET installed = 1, disabled = 0, status = 'Ready', embedding_dim = ?2
+             WHERE model_id = ?1",
+            rusqlite::params![model_id, i64::try_from(spec.dim).unwrap()],
+        )
+        .unwrap();
+        crate::index::ai::set_meta(&conn, "active_embedding_model", model_id).unwrap();
+        conn
+    }
+
+    fn remote_at(endpoint: &str) -> RemoteEmbeddingConfig {
+        RemoteEmbeddingConfig {
+            mode: RemoteMode::Connect,
+            model: "all-minilm".to_string(),
+            endpoint: Some(endpoint.to_string()),
+            auth_env: None,
+            batch_size: 256,
+            request_timeout_s: 5,
+        }
+    }
+
+    #[test]
+    fn active_embedder_yields_an_ollama_embedder_when_remote_config_is_persisted() {
+        // Construction does not connect (from_remote_config only parses the endpoint), so a closed
+        // port is fine — we assert the resolved embedder's identity + dim, the construction path.
+        let port = {
+            let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            l.local_addr().unwrap().port()
+        };
+        let conn = conn_with_active_model(OLLAMA_ALL_MINILM_MODEL_ID);
+        set_active_remote_config(&conn, &remote_at(&format!("http://127.0.0.1:{port}"))).unwrap();
+
+        let embedder = active_embedder(&conn, None).expect("ollama embedder constructs");
+        assert_eq!(embedder.model_id(), OLLAMA_ALL_MINILM_MODEL_ID);
+        assert_eq!(embedder.dim(), OLLAMA_ALL_MINILM_EMBEDDING_DIM);
+    }
+
+    #[test]
+    fn active_embedder_bails_with_a_clear_message_when_remote_config_is_missing() {
+        // Ollama active but NO remote-config meta → the dispatch must refuse with the recovery
+        // hint, not panic or silently construct a half-formed embedder.
+        let conn = conn_with_active_model(OLLAMA_ALL_MINILM_MODEL_ID);
+        // `Box<dyn Embedder>` is not `Debug`, so `expect_err` won't compile — match the result.
+        let msg = match active_embedder(&conn, None) {
+            Ok(_) => panic!("must bail without persisted remote cfg"),
+            Err(err) => err.to_string(),
+        };
+        assert!(msg.contains("no remote config persisted"), "clear message: {msg}");
+    }
+
+    #[test]
+    fn embedder_for_spec_ignores_remote_for_the_hash_backend() {
+        // A non-ollama backend ignores `remote` entirely — passing Some or None is identical.
+        let spec = spec(crate::embedding_models::HASH_MODEL_ID).unwrap();
+        let with_none = embedder_for_spec(spec, None, None).unwrap();
+        assert_eq!(with_none.model_id(), crate::embedding_models::HASH_MODEL_ID);
     }
 }

--- a/crates/rag-rat-core/src/index/ai/providers/ollama.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/ollama.rs
@@ -40,6 +40,11 @@ pub struct OllamaEmbedder {
     embed_url: String,
     model: String,
     dim: usize,
+    /// Max texts per `/api/embed` request (`[local_ai.embedding.remote] batch_size`).
+    /// `embed_batch` splits its input into sub-batches of at most this, so a request never
+    /// exceeds the configured cap regardless of the reconcile/runtime batch size. Clamped to
+    /// `>= 1` at construction so the `chunks()` split can't panic on a misconfigured `0`.
+    batch_size: usize,
     /// `Some("Bearer <token>")` when the server needs auth, read from `auth_env` at construction.
     auth_header: Option<String>,
 }
@@ -85,8 +90,75 @@ impl OllamaEmbedder {
             embed_url,
             model: cfg.model.trim().to_string(),
             dim: registry_dim,
+            // Clamp to >= 1: a configured 0 would panic `slice::chunks`; treat it as "one per
+            // request" rather than failing construction.
+            batch_size: (cfg.batch_size as usize).max(1),
             auth_header,
         })
+    }
+
+    /// Send ONE `/api/embed` request for `texts` (already sized to `<= self.batch_size` by the
+    /// caller) and return the parsed vectors, enforcing the count + per-vector dim contracts.
+    /// Factored out of `embed_batch` so the sub-batch loop reuses the exact request/validation
+    /// logic.
+    fn embed_one_request(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {
+        let payload = EmbedRequest { model: &self.model, input: texts };
+        // The `json` ureq feature is not enabled (workspace ureq is rustls-only), so serialize the
+        // body ourselves and send it with an explicit content-type.
+        let body = serde_json::to_vec(&payload)
+            .map_err(|e| anyhow::anyhow!("failed to serialize ollama embed request: {e}"))?;
+
+        let mut request = self.agent.post(&self.embed_url).content_type("application/json");
+        if let Some(header) = &self.auth_header {
+            request = request.header("Authorization", header);
+        }
+
+        // `http_status_as_error` defaults to true in ureq 3, so a non-2xx status, a connection
+        // refusal, or a timeout all surface as `Err` here — all retryable by the reconcile loop.
+        let raw = request
+            .send(body)
+            .map_err(|e| {
+                anyhow::anyhow!("ollama embed request to `{}` failed: {e}", self.embed_url)
+            })?
+            .body_mut()
+            .read_to_string()
+            .map_err(|e| anyhow::anyhow!("reading ollama embed response failed: {e}"))?;
+
+        let parsed: EmbedResponse = serde_json::from_str(&raw)
+            .map_err(|e| anyhow::anyhow!("malformed ollama embed response: {e}"))?;
+        let embeddings = parsed.embeddings;
+
+        // Count contract: one vector per input, retryable on violation (a transient server fault
+        // can drop rows).
+        if embeddings.len() != texts.len() {
+            anyhow::bail!(
+                "ollama embed count mismatch: requested {} texts but server returned {} vectors",
+                texts.len(),
+                embeddings.len()
+            );
+        }
+
+        // Dim contract (LOUD): the int8 encoding, per-family centroids, and the linked-entries rail
+        // all assume a fixed dim. A server returning a different-width vector means the configured
+        // model and the server model disagree — naming both dims makes the misconfiguration
+        // obvious. EVERY vector is checked, not just the first: a late wrong-width vector that
+        // slipped through would make `store_embedding` bail and ABORT the whole reconcile instead
+        // of failing just that chunk, so we name the offending index and reject here.
+        for (i, vector) in embeddings.iter().enumerate() {
+            if vector.len() != self.dim {
+                anyhow::bail!(
+                    "ollama embed dim mismatch: server returned a {}-dim vector at index {} but \
+                     this model is configured for {} dims (model `{}`). The configured registry \
+                     model and the Ollama server model must match.",
+                    vector.len(),
+                    i,
+                    self.dim,
+                    self.model
+                );
+            }
+        }
+
+        Ok(embeddings)
     }
 }
 
@@ -146,63 +218,16 @@ impl Embedder for OllamaEmbedder {
             return Ok(Vec::new());
         }
 
-        let payload = EmbedRequest { model: &self.model, input: texts };
-        // The `json` ureq feature is not enabled (workspace ureq is rustls-only), so serialize the
-        // body ourselves and send it with an explicit content-type.
-        let body = serde_json::to_vec(&payload)
-            .map_err(|e| anyhow::anyhow!("failed to serialize ollama embed request: {e}"))?;
-
-        let mut request = self.agent.post(&self.embed_url).content_type("application/json");
-        if let Some(header) = &self.auth_header {
-            request = request.header("Authorization", header);
+        // Split into sub-batches of at most the configured `batch_size` and send one `/api/embed`
+        // per sub-batch, concatenating the results IN ORDER. This honors `[remote] batch_size`
+        // regardless of the (larger) reconcile/runtime batch the loop hands us — a user capping it
+        // for a server/proxy request-size limit is respected. The count + per-vector dim checks run
+        // per sub-batch (in `embed_one_request`).
+        let mut out = Vec::with_capacity(texts.len());
+        for sub_batch in texts.chunks(self.batch_size) {
+            out.extend(self.embed_one_request(sub_batch)?);
         }
-
-        // `http_status_as_error` defaults to true in ureq 3, so a non-2xx status, a connection
-        // refusal, or a timeout all surface as `Err` here — all retryable by the reconcile loop.
-        let raw = request
-            .send(body)
-            .map_err(|e| {
-                anyhow::anyhow!("ollama embed request to `{}` failed: {e}", self.embed_url)
-            })?
-            .body_mut()
-            .read_to_string()
-            .map_err(|e| anyhow::anyhow!("reading ollama embed response failed: {e}"))?;
-
-        let parsed: EmbedResponse = serde_json::from_str(&raw)
-            .map_err(|e| anyhow::anyhow!("malformed ollama embed response: {e}"))?;
-        let embeddings = parsed.embeddings;
-
-        // Count contract: one vector per input, retryable on violation (a transient server fault
-        // can drop rows).
-        if embeddings.len() != texts.len() {
-            anyhow::bail!(
-                "ollama embed count mismatch: requested {} texts but server returned {} vectors",
-                texts.len(),
-                embeddings.len()
-            );
-        }
-
-        // Dim contract (LOUD): the int8 encoding, per-family centroids, and the linked-entries rail
-        // all assume a fixed dim. A server returning a different-width vector means the configured
-        // model and the server model disagree — naming both dims makes the misconfiguration
-        // obvious. EVERY vector is checked, not just the first: a late wrong-width vector that
-        // slipped through would make `store_embedding` bail and ABORT the whole reconcile instead
-        // of failing just that chunk, so we name the offending index and reject here.
-        for (i, vector) in embeddings.iter().enumerate() {
-            if vector.len() != self.dim {
-                anyhow::bail!(
-                    "ollama embed dim mismatch: server returned a {}-dim vector at index {} but \
-                     this model is configured for {} dims (model `{}`). The configured registry \
-                     model and the Ollama server model must match.",
-                    vector.len(),
-                    i,
-                    self.dim,
-                    self.model
-                );
-            }
-        }
-
-        Ok(embeddings)
+        Ok(out)
     }
 }
 
@@ -294,6 +319,141 @@ mod tests {
         assert_eq!(got[1][0], 2.0);
         assert_eq!(got[2][0], 3.0);
         assert!(got.iter().all(|v| v.len() == DIM));
+    }
+
+    /// A multi-request HTTP stub: accepts `max_conns` connections, and for each request replies
+    /// with one DIM-wide vector PER input text in that request's body (so the per-sub-batch
+    /// count check passes). Each returned vector's first component is a monotonically
+    /// increasing global counter, so the concatenated `embed_batch` output reads `[0.0, 1.0,
+    /// 2.0, ...]` IFF the sub-batches are stitched back in order. Returns the URL, the join
+    /// handle, and the shared request COUNT so the test can assert the configured cap produced
+    /// the expected number of requests.
+    fn spawn_counting_stub(
+        max_conns: usize,
+    ) -> (String, thread::JoinHandle<()>, std::sync::Arc<std::sync::atomic::AtomicUsize>) {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let requests = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&requests);
+        let handle = thread::spawn(move || {
+            let mut next_value = 0u32;
+            for _ in 0..max_conns {
+                let Ok((mut stream, _)) = listener.accept() else { break };
+                stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+                // Read headers, parse Content-Length, then read EXACTLY that many body bytes. A
+                // single `read()` can return just the headers before the body arrives, so reading a
+                // fixed-size buffer once undercounts the inputs; this reads the whole request.
+                let mut raw = Vec::new();
+                let mut buf = [0u8; 8192];
+                let body = loop {
+                    let header_end = raw.windows(4).position(|w| w == b"\r\n\r\n");
+                    if let Some(end) = header_end {
+                        let headers = String::from_utf8_lossy(&raw[..end]).to_ascii_lowercase();
+                        let content_len = headers
+                            .lines()
+                            .find_map(|l| l.strip_prefix("content-length:"))
+                            .and_then(|v| v.trim().parse::<usize>().ok())
+                            .unwrap_or(0);
+                        let body_start = end + 4;
+                        while raw.len() < body_start + content_len {
+                            match stream.read(&mut buf) {
+                                Ok(0) => break,
+                                Ok(n) => raw.extend_from_slice(&buf[..n]),
+                                Err(_) => break,
+                            }
+                        }
+                        break String::from_utf8_lossy(&raw[body_start..]).to_string();
+                    }
+                    match stream.read(&mut buf) {
+                        Ok(0) => break String::new(),
+                        Ok(n) => raw.extend_from_slice(&buf[..n]),
+                        Err(_) => break String::new(),
+                    }
+                };
+                // Count inputs in THIS request by the `"text N"` markers the test sends.
+                let inputs = body.matches("text ").count().max(1);
+                counter.fetch_add(1, Ordering::SeqCst);
+                let vectors: Vec<Vec<f32>> = (0..inputs)
+                    .map(|_| {
+                        let v = vec![next_value as f32; DIM];
+                        // Encode the global order in the FIRST component only.
+                        let mut v = v;
+                        v[0] = next_value as f32;
+                        next_value += 1;
+                        v
+                    })
+                    .collect();
+                let json = embeddings_json(&vectors);
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: \
+                     {}\r\nConnection: close\r\n\r\n{json}",
+                    json.len()
+                );
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.flush();
+            }
+        });
+        (format!("http://127.0.0.1:{port}"), handle, requests)
+    }
+
+    #[test]
+    fn embed_batch_splits_into_sub_batches_of_at_most_the_configured_batch_size() {
+        // batch_size = 2, 5 texts → 3 requests (2 + 2 + 1), all 5 vectors returned IN ORDER. This
+        // is the P2 fix: `[remote] batch_size` caps the per-request size regardless of the
+        // larger batch the reconcile loop hands the embedder.
+        use std::sync::atomic::Ordering;
+
+        let (url, handle, requests) = spawn_counting_stub(3);
+        let mut cfg = config_for(&url, 5);
+        cfg.batch_size = 2;
+        let embedder = OllamaEmbedder::from_remote_config(&cfg, DIM).unwrap();
+
+        let got = embedder.embed_batch(&texts(5)).expect("sub-batched embed");
+        handle.join().unwrap();
+
+        assert_eq!(requests.load(Ordering::SeqCst), 3, "5 texts at batch_size 2 → 3 requests");
+        assert_eq!(got.len(), 5, "all 5 vectors returned");
+        // The global counter encodes order: sub-batch boundaries must not reorder the output.
+        for (i, v) in got.iter().enumerate() {
+            assert_eq!(v[0], i as f32, "vector {i} out of order: {}", v[0]);
+            assert_eq!(v.len(), DIM);
+        }
+    }
+
+    #[test]
+    fn embed_batch_with_a_large_batch_size_sends_a_single_request() {
+        // batch_size default (256) >> 3 texts → exactly one request (no needless fan-out).
+        use std::sync::atomic::Ordering;
+
+        let (url, handle, requests) = spawn_counting_stub(1);
+        let embedder = OllamaEmbedder::from_remote_config(&config_for(&url, 5), DIM).unwrap();
+
+        let got = embedder.embed_batch(&texts(3)).expect("single-request embed");
+        handle.join().unwrap();
+
+        assert_eq!(requests.load(Ordering::SeqCst), 1, "3 texts under the cap → one request");
+        assert_eq!(got.len(), 3);
+    }
+
+    #[test]
+    fn batch_size_zero_is_clamped_to_one_per_request() {
+        // A misconfigured `batch_size = 0` must NOT panic `chunks(0)`; it degrades to one text per
+        // request.
+        use std::sync::atomic::Ordering;
+
+        let (url, handle, requests) = spawn_counting_stub(3);
+        let mut cfg = config_for(&url, 5);
+        cfg.batch_size = 0;
+        let embedder = OllamaEmbedder::from_remote_config(&cfg, DIM).unwrap();
+
+        let got = embedder.embed_batch(&texts(3)).expect("clamped embed");
+        handle.join().unwrap();
+
+        assert_eq!(requests.load(Ordering::SeqCst), 3, "batch_size 0 → one text per request");
+        assert_eq!(got.len(), 3);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::config::RemoteEmbeddingConfig;
 #[cfg(feature = "fastembed")]
 use crate::embedding_models::FASTEMBED_EMBEDDING_DIM;
 use crate::embedding_models::{Backend, EMBEDDING_MODELS, FASTEMBED_MODEL_ID, HASH_MODEL_ID, spec};
@@ -174,7 +175,11 @@ pub(crate) fn fastembed_cache_ready(cache_dir: &Path) -> bool {
     !revision.is_empty() && repo.join("snapshots").join(revision).is_dir()
 }
 
-pub(crate) fn install_model(conn: &Connection, model_id: &str) -> anyhow::Result<ModelInfo> {
+pub(crate) fn install_model(
+    conn: &Connection,
+    model_id: &str,
+    remote: Option<&RemoteEmbeddingConfig>,
+) -> anyhow::Result<ModelInfo> {
     ensure_model_manifest(conn)?;
     let spec =
         spec(model_id).ok_or_else(|| anyhow::anyhow!("unknown local AI model `{model_id}`"))?;
@@ -190,8 +195,19 @@ pub(crate) fn install_model(conn: &Connection, model_id: &str) -> anyhow::Result
         },
         Backend::FastEmbed => install_fastembed_model(conn, model_id)?,
         Backend::Model2Vec => install_model2vec_model(conn, model_id)?,
-        // Ollama install (a reachability + dim probe, no download) is #317 task 6; bail until then.
-        Backend::Ollama => anyhow::bail!("ollama embedding backend not yet wired (#317 task 6)"),
+        // Ollama install is a reachability + dim probe (no download), #317 task 6. It REQUIRES the
+        // remote config — `model = "ollama"` without a `[remote]` block can't reach a server. The
+        // config layer already rejects that incoherence (`RemoteEmbeddingMissingConfig`), so a
+        // `None` here means a caller forgot to thread `config.local_ai.embedding.remote`.
+        Backend::Ollama => {
+            let remote = remote.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "installing the ollama model requires a [local_ai.embedding.remote] config \
+                     (endpoint + model)"
+                )
+            })?;
+            install_ollama_model(conn, model_id, remote)?;
+        },
     }
     set_meta(conn, ACTIVE_EMBEDDING_MODEL_META, model_id)?;
     model(conn, model_id)

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -210,6 +210,18 @@ pub(crate) fn install_model(
         },
     }
     set_meta(conn, ACTIVE_EMBEDDING_MODEL_META, model_id)?;
+    // SINGLE WRITER of the active freshness version — for EVERY backend, AFTER activation. It must
+    // run for the local backends too, not just ollama: `active_embedding_model_version` reads this
+    // meta UNCONDITIONALLY for whatever model is active, so switching back from ollama to a
+    // hash/fastembed model would otherwise leave the stale ollama endpoint-hash as the freshness
+    // key — reconciling/searching the local model under the wrong key (worst case reusing vectors
+    // across models). Ollama folds the endpoint+model into the key (so re-pointing forces a clean
+    // re-embed); every other backend uses its static `spec.version`.
+    let freshness = match (spec.backend, remote) {
+        (Backend::Ollama, Some(remote)) => remote_freshness_version(spec, remote),
+        _ => spec.version.to_string(),
+    };
+    set_reconcile_meta(conn, ACTIVE_EMBEDDING_MODEL_VERSION_META, &freshness)?;
     model(conn, model_id)
 }
 
@@ -924,5 +936,113 @@ mod manifest_idempotence_tests {
         }
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+}
+
+#[cfg(test)]
+mod freshness_version_tests {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    use super::*;
+    use crate::config::RemoteMode;
+    use crate::embedding_models::{
+        HASH_MODEL_ID, OLLAMA_ALL_MINILM_EMBEDDING_DIM, OLLAMA_ALL_MINILM_MODEL_ID,
+    };
+
+    /// One-shot HTTP/1.1 stub replying to the install probe's `/api/embed` with a `dim`-wide
+    /// vector.
+    fn spawn_embed_stub(dim: usize) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handle = thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = [0u8; 4096];
+                let _ = stream.read(&mut buf);
+                let nums = vec!["0.1"; dim].join(",");
+                let body = format!("{{\"embeddings\":[[{nums}]]}}");
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: \
+                     {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.flush();
+            }
+        });
+        (format!("http://127.0.0.1:{port}"), handle)
+    }
+
+    fn schema_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::index::schema::apply(&conn).unwrap();
+        ensure_model_manifest(&conn).unwrap();
+        conn
+    }
+
+    fn remote_at(endpoint: &str) -> RemoteEmbeddingConfig {
+        RemoteEmbeddingConfig {
+            mode: RemoteMode::Connect,
+            model: "all-minilm".to_string(),
+            endpoint: Some(endpoint.to_string()),
+            auth_env: None,
+            batch_size: 256,
+            request_timeout_s: 5,
+        }
+    }
+
+    fn active_version(conn: &Connection) -> String {
+        reconcile_meta(conn, ACTIVE_EMBEDDING_MODEL_VERSION_META).unwrap().unwrap()
+    }
+
+    #[test]
+    fn install_model_stamps_the_endpoint_hash_for_ollama() {
+        let (url, handle) = spawn_embed_stub(OLLAMA_ALL_MINILM_EMBEDDING_DIM);
+        let conn = schema_conn();
+        let remote = remote_at(&url);
+
+        install_model(&conn, OLLAMA_ALL_MINILM_MODEL_ID, Some(&remote)).expect("ollama installs");
+        handle.join().unwrap();
+
+        let spec = spec(OLLAMA_ALL_MINILM_MODEL_ID).unwrap();
+        assert_eq!(active_version(&conn), remote_freshness_version(spec, &remote));
+        assert_ne!(active_version(&conn), spec.version, "ollama folds the endpoint, not bare ver");
+    }
+
+    #[test]
+    fn switching_from_ollama_to_a_local_model_resets_the_freshness_version() {
+        // THE P2-1 REGRESSION: install ollama (meta = endpoint hash), then install the local hash
+        // model. `active_embedding_model_version` reads this meta unconditionally for the active
+        // model, so it MUST become the hash model's static `spec.version` — not the stale ollama
+        // endpoint-hash. A stale key would reconcile/search the local model under the wrong
+        // freshness and could reuse vectors across models.
+        let (url, handle) = spawn_embed_stub(OLLAMA_ALL_MINILM_EMBEDDING_DIM);
+        let conn = schema_conn();
+        let remote = remote_at(&url);
+
+        install_model(&conn, OLLAMA_ALL_MINILM_MODEL_ID, Some(&remote)).expect("ollama installs");
+        handle.join().unwrap();
+        let ollama_version = active_version(&conn);
+
+        // Now switch back to the local hash model — no remote config.
+        install_model(&conn, HASH_MODEL_ID, None).expect("hash installs");
+
+        let hash_spec = spec(HASH_MODEL_ID).unwrap();
+        assert_eq!(
+            active_version(&conn),
+            hash_spec.version,
+            "switching to a local model must reset the freshness key to its static spec.version",
+        );
+        assert_ne!(active_version(&conn), ollama_version, "must NOT keep the stale ollama hash");
+    }
+
+    #[test]
+    fn installing_a_local_model_stamps_its_static_version() {
+        // Even with no prior ollama install, a local-model install writes its static version (the
+        // meta is no longer ollama-only).
+        let conn = schema_conn();
+        install_model(&conn, HASH_MODEL_ID, None).expect("hash installs");
+        assert_eq!(active_version(&conn), spec(HASH_MODEL_ID).unwrap().version);
     }
 }

--- a/crates/rag-rat-core/src/index/ai/status.rs
+++ b/crates/rag-rat-core/src/index/ai/status.rs
@@ -44,10 +44,11 @@ pub(crate) fn install_fastembed_model(conn: &Connection, model_id: &str) -> anyh
 /// loop will use. A probe failure REFUSES the install loudly (the row is left not-installed); we do
 /// not write a half-ready model that would then fail every reconcile batch.
 ///
-/// On success: write the `ai_models` row Ready, persist the remote config to the secret-free meta
-/// so `active_embedder` can reconstruct the embedder, and stamp the freshness version
-/// ([`remote_freshness_version`]) — which folds in the endpoint + model so switching either forces
-/// a clean re-embed instead of silently reusing vectors from a different server.
+/// On success: write the `ai_models` row Ready and persist the remote config to the secret-free
+/// meta so `active_embedder` can reconstruct the embedder. The freshness version is NOT written
+/// here — it is stamped centrally by the caller (`install_model`) for EVERY backend, so switching
+/// away from ollama can't leave a stale ollama endpoint-hash as the active freshness key (see
+/// [`remote_freshness_version`] + the `install_model` single-writer comment).
 pub(crate) fn install_ollama_model(
     conn: &Connection,
     model_id: &str,
@@ -76,11 +77,6 @@ pub(crate) fn install_ollama_model(
         params![model_id, now_ms(), i64::try_from(spec.dim).unwrap_or(i64::MAX)],
     )?;
     set_active_remote_config(conn, remote)?;
-    set_reconcile_meta(
-        conn,
-        ACTIVE_EMBEDDING_MODEL_VERSION_META,
-        &remote_freshness_version(spec, remote),
-    )?;
     Ok(())
 }
 
@@ -318,12 +314,10 @@ mod ollama_install_tests {
         // The remote config is persisted so active_embedder can reconstruct the embedder.
         assert_eq!(active_remote_config(&conn).unwrap(), Some(remote.clone()));
 
-        // The freshness version is the endpoint-folded one, NOT the static spec version.
-        let spec = spec(OLLAMA_ALL_MINILM_MODEL_ID).unwrap();
-        let persisted =
-            reconcile_meta(&conn, ACTIVE_EMBEDDING_MODEL_VERSION_META).unwrap().unwrap();
-        assert_eq!(persisted, remote_freshness_version(spec, &remote));
-        assert_ne!(persisted, spec.version, "must not persist the bare static version");
+        // NOTE: the freshness version meta is NOT written by `install_ollama_model` — it is stamped
+        // centrally by `install_model` for every backend (so switching away can't leave a stale
+        // ollama hash). That single-writer behavior is covered by the `install_model` tests in
+        // reconcile.rs (`install_model_*_freshness_version`).
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/status.rs
+++ b/crates/rag-rat-core/src/index/ai/status.rs
@@ -1,6 +1,8 @@
 use super::*;
+use crate::config::RemoteEmbeddingConfig;
 use crate::embedding_models::{
-    Backend, FASTEMBED_DISPLAY_MODEL, FASTEMBED_EMBEDDING_DIM, FASTEMBED_MODEL_ID, spec,
+    Backend, EmbeddingModelSpec, FASTEMBED_DISPLAY_MODEL, FASTEMBED_EMBEDDING_DIM,
+    FASTEMBED_MODEL_ID, spec,
 };
 
 pub(crate) fn install_fastembed_model(conn: &Connection, model_id: &str) -> anyhow::Result<()> {
@@ -32,6 +34,81 @@ pub(crate) fn install_fastembed_model(conn: &Connection, model_id: &str) -> anyh
         )?;
         anyhow::bail!("{}", FASTEMBED_MISSING_FEATURE_MESSAGE)
     }
+}
+
+/// Install (activate) an Ollama-backed embedding model (#317 task 6). Unlike fastembed/model2vec
+/// there is NO download: the "install" is a reachability + dim-parity PROBE. We construct the real
+/// [`OllamaEmbedder`] from the remote config and embed a single `"ping"` — that one call validates
+/// the endpoint is reachable, auth resolves, AND the server's vector width matches the registry
+/// spec's dim (the embedder's per-batch dim contract), reusing the exact connection the reconcile
+/// loop will use. A probe failure REFUSES the install loudly (the row is left not-installed); we do
+/// not write a half-ready model that would then fail every reconcile batch.
+///
+/// On success: write the `ai_models` row Ready, persist the remote config to the secret-free meta
+/// so `active_embedder` can reconstruct the embedder, and stamp the freshness version
+/// ([`remote_freshness_version`]) — which folds in the endpoint + model so switching either forces
+/// a clean re-embed instead of silently reusing vectors from a different server.
+pub(crate) fn install_ollama_model(
+    conn: &Connection,
+    model_id: &str,
+    remote: &RemoteEmbeddingConfig,
+) -> anyhow::Result<()> {
+    let spec =
+        spec(model_id).ok_or_else(|| anyhow::anyhow!("unknown ollama model `{model_id}`"))?;
+    // Probe: construct + one-shot embed. Reachability, auth, AND the dim contract are validated in
+    // this single call (the embedder checks every returned vector against `spec.dim`).
+    let embedder = OllamaEmbedder::from_remote_config(remote, spec.dim).map_err(|err| {
+        anyhow::anyhow!("failed to construct ollama embedder for `{model_id}`: {err}")
+    })?;
+    embedder.embed_batch(&["ping".to_string()]).map_err(|err| {
+        anyhow::anyhow!(
+            "ollama reachability/dim probe failed for `{model_id}` (endpoint `{}`, model `{}`): \
+             {err}",
+            remote.endpoint.as_deref().unwrap_or("<none>"),
+            remote.model
+        )
+    })?;
+    conn.execute(
+        "UPDATE ai_models
+         SET installed = 1, disabled = 0, status = 'Ready', installed_at_ms = ?2,
+             embedding_dim = ?3, runtime = 'ollama', last_error = NULL
+         WHERE model_id = ?1",
+        params![model_id, now_ms(), i64::try_from(spec.dim).unwrap_or(i64::MAX)],
+    )?;
+    set_active_remote_config(conn, remote)?;
+    set_reconcile_meta(
+        conn,
+        ACTIVE_EMBEDDING_MODEL_VERSION_META,
+        &remote_freshness_version(spec, remote),
+    )?;
+    Ok(())
+}
+
+/// The reconcile freshness key for a remote (Ollama) model. Distinct from the static `spec.version`
+/// (which only identifies the registry model, never bare `"v1"`): it folds in the endpoint host +
+/// the Ollama API model name, so re-pointing the endpoint or switching the server-side model bumps
+/// the version → every chunk's `model_version` mismatches → a clean re-embed against the new
+/// server. Without this, vectors produced by endpoint A would be silently reused after switching to
+/// endpoint B (a different model behind the same registry id).
+pub(crate) fn remote_freshness_version(
+    spec: &EmbeddingModelSpec,
+    remote: &RemoteEmbeddingConfig,
+) -> String {
+    // Host (scheme+authority, path/query stripped) is enough to distinguish endpoints without
+    // baking the full URL — and never carries auth material. Empty endpoint (shouldn't happen in
+    // connect mode) folds in as the empty string, still distinct from a real host.
+    let endpoint = remote.endpoint.as_deref().unwrap_or("").trim();
+    let mut hasher = Sha256::new();
+    hasher.update(spec.version.as_bytes());
+    hasher.update([0]);
+    hasher.update(endpoint.as_bytes());
+    hasher.update([0]);
+    hasher.update(remote.model.trim().as_bytes());
+    let digest = hasher.finalize();
+    // 8 hex bytes (16 chars) of the digest is ample to separate endpoint/model combinations; keep
+    // the human-legible `spec.version` prefix so the persisted value still reads as this model.
+    let short: String = digest.iter().take(8).map(|b| format!("{b:02x}")).collect();
+    format!("{}-{short}", spec.version)
 }
 
 pub(crate) fn fastembed_operational_status(
@@ -168,4 +245,126 @@ pub(crate) fn model_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ModelInfo> 
         installed_at_ms: row.get(7)?,
         last_error: row.get(8)?,
     })
+}
+
+#[cfg(test)]
+mod ollama_install_tests {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    use super::*;
+    use crate::config::RemoteMode;
+    use crate::embedding_models::{OLLAMA_ALL_MINILM_EMBEDDING_DIM, OLLAMA_ALL_MINILM_MODEL_ID};
+
+    /// One-shot HTTP/1.1 stub on an ephemeral port that replies to the probe's single `/api/embed`
+    /// POST with `{"embeddings":[[<dim floats>]]}`. Returns the base URL + the server join handle.
+    fn spawn_embed_stub(dim: usize) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handle = thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = [0u8; 4096];
+                let _ = stream.read(&mut buf);
+                let nums = vec!["0.1"; dim].join(",");
+                let body = format!("{{\"embeddings\":[[{nums}]]}}");
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: \
+                     {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.flush();
+            }
+        });
+        (format!("http://127.0.0.1:{port}"), handle)
+    }
+
+    fn schema_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::index::schema::apply(&conn).unwrap();
+        ensure_model_manifest(&conn).unwrap();
+        conn
+    }
+
+    fn remote_at(endpoint: &str) -> RemoteEmbeddingConfig {
+        RemoteEmbeddingConfig {
+            mode: RemoteMode::Connect,
+            model: "all-minilm".to_string(),
+            endpoint: Some(endpoint.to_string()),
+            auth_env: None,
+            batch_size: 256,
+            request_timeout_s: 5,
+        }
+    }
+
+    #[test]
+    fn install_ollama_model_writes_the_row_and_metas_on_a_successful_probe() {
+        let (url, handle) = spawn_embed_stub(OLLAMA_ALL_MINILM_EMBEDDING_DIM);
+        let conn = schema_conn();
+        let remote = remote_at(&url);
+
+        install_ollama_model(&conn, OLLAMA_ALL_MINILM_MODEL_ID, &remote).expect("probe succeeds");
+        handle.join().unwrap();
+
+        // ai_models row is Ready with the ollama runtime + the registry dim.
+        let model = model(&conn, OLLAMA_ALL_MINILM_MODEL_ID).unwrap();
+        assert!(model.installed);
+        assert_eq!(model.status, "Ready");
+        assert_eq!(model.runtime, "ollama");
+        assert_eq!(model.embedding_dim, Some(OLLAMA_ALL_MINILM_EMBEDDING_DIM as i64));
+        assert_eq!(model.last_error, None);
+
+        // The remote config is persisted so active_embedder can reconstruct the embedder.
+        assert_eq!(active_remote_config(&conn).unwrap(), Some(remote.clone()));
+
+        // The freshness version is the endpoint-folded one, NOT the static spec version.
+        let spec = spec(OLLAMA_ALL_MINILM_MODEL_ID).unwrap();
+        let persisted =
+            reconcile_meta(&conn, ACTIVE_EMBEDDING_MODEL_VERSION_META).unwrap().unwrap();
+        assert_eq!(persisted, remote_freshness_version(spec, &remote));
+        assert_ne!(persisted, spec.version, "must not persist the bare static version");
+    }
+
+    #[test]
+    fn install_ollama_model_refuses_on_a_dim_mismatch() {
+        // The server returns a 512-dim vector; the registry spec is 384 — the probe's per-batch dim
+        // contract rejects it, so the install must refuse and leave the model not-installed.
+        let (url, handle) = spawn_embed_stub(512);
+        let conn = schema_conn();
+
+        let err = install_ollama_model(&conn, OLLAMA_ALL_MINILM_MODEL_ID, &remote_at(&url))
+            .expect_err("dim mismatch must refuse the install");
+        handle.join().unwrap();
+        assert!(err.to_string().contains("384") || err.to_string().contains("512"), "{err}");
+
+        // The row was NOT flipped to Ready, and no remote config was persisted.
+        let model = model(&conn, OLLAMA_ALL_MINILM_MODEL_ID).unwrap();
+        assert!(!model.installed, "a failed probe must not mark the model installed");
+        assert_eq!(active_remote_config(&conn).unwrap(), None);
+    }
+
+    #[test]
+    fn remote_freshness_version_differs_by_endpoint_and_is_not_the_bare_version() {
+        let spec = spec(OLLAMA_ALL_MINILM_MODEL_ID).unwrap();
+        let a = remote_freshness_version(spec, &remote_at("http://a.example:11434"));
+        let b = remote_freshness_version(spec, &remote_at("http://b.example:11434"));
+        assert_ne!(a, b, "switching endpoint must bump the freshness version");
+        assert_ne!(a, spec.version, "freshness version must not be the bare static version");
+        assert!(a.starts_with(spec.version), "keeps the legible model prefix: {a}");
+    }
+
+    #[test]
+    fn remote_freshness_version_differs_by_model() {
+        let spec = spec(OLLAMA_ALL_MINILM_MODEL_ID).unwrap();
+        let mut a = remote_at("http://localhost:11434");
+        let mut b = a.clone();
+        a.model = "all-minilm".to_string();
+        b.model = "nomic-embed-text".to_string();
+        assert_ne!(
+            remote_freshness_version(spec, &a),
+            remote_freshness_version(spec, &b),
+            "switching the server-side model must bump the freshness version",
+        );
+    }
 }

--- a/crates/rag-rat-core/src/index/query_api/ai_lifecycle.rs
+++ b/crates/rag-rat-core/src/index/query_api/ai_lifecycle.rs
@@ -13,8 +13,16 @@ impl IndexDatabase {
         ai::models(self.storage.connection())
     }
 
-    pub fn install_model(&self, model_id: &str) -> anyhow::Result<ModelInfo> {
-        ai::install_model(self.storage.connection(), model_id)
+    /// Install/activate an embedding model. `remote` carries the `[local_ai.embedding.remote]`
+    /// connection params and is REQUIRED for the Ollama backend (the install is a reachability +
+    /// dim probe against that endpoint); every other backend ignores it. Callers pass
+    /// `config.local_ai.embedding.remote.as_ref()` — `None` for the local backends.
+    pub fn install_model(
+        &self,
+        model_id: &str,
+        remote: Option<&crate::config::RemoteEmbeddingConfig>,
+    ) -> anyhow::Result<ModelInfo> {
+        ai::install_model(self.storage.connection(), model_id, remote)
     }
 
     pub fn reconcile(

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -466,7 +466,7 @@ fn full_rebuild_preserves_github_papertrail_cache() {
 fn full_rebuild_preserves_installed_model_manifest() {
     let (root, config) = markdown_config("alpha token with enough detail for embeddings\n");
     let db = IndexDatabase::rebuild(&config).unwrap();
-    db.install_model(HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID, None).unwrap();
     let before = db.local_ai_status().unwrap();
     assert_eq!(before.embedding.model_id, HASH_MODEL_ID);
     assert!(before.embedding.installed);
@@ -811,7 +811,7 @@ fn fastembed_missing_feature_reports_rebuild_command() {
     let (root, config) = markdown_config("alpha token\n");
     let db = IndexDatabase::rebuild(&config).unwrap();
 
-    let err = db.install_model(FASTEMBED_MODEL_ID).unwrap_err();
+    let err = db.install_model(FASTEMBED_MODEL_ID, None).unwrap_err();
     assert!(err.to_string().contains(ai::FASTEMBED_MISSING_FEATURE_MESSAGE));
 
     let status = db.local_ai_status().unwrap();
@@ -853,7 +853,7 @@ fn reconcile_requires_explicit_model_install_and_ignores_stale_artifacts() {
     assert_eq!(status.embedding.state, "MissingModel");
     assert_eq!(status.embedding.blocked_artifacts, 0);
 
-    db.install_model(HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID, None).unwrap();
     let plan = db.reconcile_plan().unwrap();
     assert_eq!(plan.embeddings.missing, 1);
     assert_eq!(plan.embeddings.current, 0);
@@ -975,7 +975,7 @@ fn reconcile_without_limit_processes_all_chunks() {
          eligibility and useful semantic context\n",
     );
     let db = IndexDatabase::rebuild(&config).unwrap();
-    db.install_model(HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID, None).unwrap();
 
     let report = db.reconcile(None, Some(2)).unwrap();
 
@@ -1001,7 +1001,7 @@ fn force_reconcile_processes_each_chunk_once_and_terminates() {
          eligibility and useful semantic context\n",
     );
     let db = IndexDatabase::rebuild(&config).unwrap();
-    db.install_model(HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID, None).unwrap();
 
     // Two eligible chunks; force with a limit far above the chunk count.
     let report = db.reconcile_with_progress(Some(50), Some(2), true, |_| {}).unwrap();
@@ -1020,7 +1020,7 @@ fn force_reconcile_progress_is_honest_and_terminates_without_limit() {
          eligibility and useful semantic context\n",
     );
     let db = IndexDatabase::rebuild(&config).unwrap();
-    db.install_model(HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID, None).unwrap();
 
     // No --limit. max_seconds is only a safety net: if the force loop regressed to
     // re-embedding forever it would trip max_seconds and report "Partial" rather than
@@ -1067,7 +1067,7 @@ fn status_counts_only_active_context_chunks() {
          eligibility and useful semantic context\n",
     );
     let mut db = IndexDatabase::rebuild(&config).unwrap();
-    db.install_model(HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID, None).unwrap();
 
     let active = db.local_ai_status().unwrap().artifacts.total_chunks;
     assert!(active > 0, "expected active chunks, got {active}");
@@ -1166,7 +1166,7 @@ fn gc_prunes_dead_context_rows_and_keeps_live_ones() {
          eligibility and useful semantic context\n",
     );
     let db = IndexDatabase::rebuild(&config).unwrap();
-    db.install_model(HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID, None).unwrap();
     db.reconcile(None, Some(8)).unwrap();
 
     let live_files = table_row_count(db.storage.connection(), "files").unwrap();
@@ -1246,7 +1246,7 @@ int main(void)
     .unwrap();
     let config = source_config(root.clone(), Language::C);
     let db = IndexDatabase::rebuild(&config).unwrap();
-    db.install_model(HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID, None).unwrap();
 
     let plan = db.reconcile_plan().unwrap();
 
@@ -1263,7 +1263,7 @@ int main(void)
 fn reconcile_policy_skips_tiny_chunks_before_embedding() {
     let (root, config) = markdown_config("tiny\n");
     let db = IndexDatabase::rebuild(&config).unwrap();
-    db.install_model(HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID, None).unwrap();
 
     let plan = db.reconcile_plan().unwrap();
     assert_eq!(plan.embeddings.missing, 0);
@@ -1337,7 +1337,7 @@ fn search_explain_reports_weighted_score_components() {
          semantic vector scoring\nthird line\n",
     );
     let db = IndexDatabase::rebuild(&config).unwrap();
-    db.install_model(HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID, None).unwrap();
     db.reconcile(None, Some(8)).unwrap();
 
     let hits = db.search_explain("runtime shutdown", 10, false).unwrap();
@@ -8218,7 +8218,7 @@ fn refresh_worktree_overlays_reconciles_overlay_scope_embeddings() {
     run_git(&main, &["commit", "-q", "-m", "base"]);
     let config = source_config(main.clone(), Language::Rust);
     let mut db = IndexDatabase::rebuild(&config).unwrap();
-    db.install_model(HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID, None).unwrap();
     db.reconcile(None, Some(8)).unwrap();
 
     let linked = unique_temp_root();
@@ -8759,7 +8759,7 @@ fn worktree_overlay_pending_embeddings_are_detectable_for_retry() {
     run_git(&main, &["commit", "-q", "-m", "base"]);
     let config = source_config(main.clone(), Language::Rust);
     let mut db = IndexDatabase::rebuild(&config).unwrap();
-    db.install_model(HASH_MODEL_ID).unwrap();
+    db.install_model(HASH_MODEL_ID, None).unwrap();
     // The base has at least one embeddable chunk before reconcile (so the test isn't vacuous)...
     set_base_scope(&mut db, &main);
     assert!(db.pending_embedding_jobs().unwrap() > 0, "base has an embeddable chunk to begin with");


### PR DESCRIPTION
**Tasks 5+6 merged** — the keystone. The active Ollama model now embeds **chunks and queries** through the configured endpoint. Connect mode is functional end-to-end.

### v1 = connect-only, NO chunk/query split
Both reconcile (chunk-embed) and search (query-embed) use the **same** endpoint → same model + runtime → consistent vector space (offline iff the endpoint is local). The chunk-remote / query-local split — and a *local-Ollama* query mirror — are deferred to ephemeral (#318). The original plan's fastembed query mirror was **wrong**: ONNX (fastembed) vs GGUF (Ollama) is a runtime mismatch that silently degrades recall.

### How (option b — DB-persisted params)
The remote params reach the embedder via a **secret-free DB meta written at install**, so `active_embedder` stays `conn`-based and the search path needs zero config threading:
- `embedder_for_spec` gains `remote`; the `Backend::Ollama` arm builds `OllamaEmbedder::from_remote_config(remote, spec.dim)`. `active_embedder` reads `active_remote_config(conn)` **only** for an ollama-active spec — both callers transparently get the same embedder. **Single construction site preserved.**
- `install_ollama_model` **probes via `OllamaEmbedder::embed_batch(["ping"])`** (reachability + dim for free), writes the Ready row, persists the config (secret-free — `auth_env` is a name), and writes the freshness version (SHA256 fold of `spec.version` + endpoint host + model → switching forces re-embed).
- `install_model` gains `remote`, threaded from the CLI.

**Verified:** +10 tests (meta round-trip incl. no-token assertion; dispatch with/without meta; freshness differs by endpoint+model; install probe success / wrong-dim refusal). Core suite **963** (953+10); clippy `--all-targets` clean default **and** `--no-default-features`; fmt; CLI builds.