### PR TITLE
feat(embed): user-selectable GPU for ephemeral cookbook provisioning

### DIFF
--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -262,6 +262,17 @@ pub struct RemoteEmbeddingConfig {
     /// Name of the environment variable holding the bearer token, if the server needs auth. Local
     /// Ollama needs none, so this is optional; the embedder reads the var once at construction.
     pub auth_env: Option<String>,
+    /// EPHEMERAL-only: the GPU the cookbook recipe should provision for the on-demand box. The
+    /// value is PROVIDER-specific and validated by the provider at provision time, not here —
+    /// Modal wants a GPU class (`A10G`/`T4`/`A100`), RunPod a `gpuTypeId`. `None` lets the
+    /// recipe pick its default (Modal defaults to CPU; RunPod to a cheap on-demand GPU). Set
+    /// together with a connect `endpoint` it is a config error (`RemoteGpuRequiresCookbook`).
+    ///
+    /// `#[serde(default)]`: this field post-dates the meta round-trip, so a config JSON persisted
+    /// by an older binary (no `gpu` key) must still deserialize (→ `None`) instead of
+    /// erroring.
+    #[serde(default)]
+    pub gpu: Option<String>,
     /// How many texts to send per `/api/embed` request.
     pub batch_size: u32,
     /// Per-request HTTP timeout, in seconds.
@@ -279,6 +290,7 @@ impl Default for RemoteEmbeddingConfig {
             cookbook: None,
             query_endpoint: None,
             auth_env: None,
+            gpu: None,
             batch_size: 256,
             request_timeout_s: 60,
         }
@@ -794,6 +806,7 @@ struct RawRemoteEmbedding {
     cookbook: Option<String>,
     query_endpoint: Option<String>,
     auth_env: Option<String>,
+    gpu: Option<String>,
     batch_size: Option<u32>,
     request_timeout_s: Option<u64>,
 }
@@ -880,12 +893,31 @@ impl TryFrom<RawRemoteEmbedding> for RemoteEmbeddingConfig {
         }
         // Optional — local Ollama needs no auth; trim if present.
         let auth_env = trimmed(raw.auth_env);
+        // EPHEMERAL-only: the GPU to provision. A PRESENT-but-empty/whitespace value is a config
+        // error (clearer than silently dropping a meant-to-be-set key). Set together with a connect
+        // `endpoint` it is meaningless — reject it rather than ignore it. The VALUE is
+        // provider-specific (Modal GPU class / RunPod gpuTypeId); we do NOT validate it against an
+        // allow-list — the provider does so at provision time.
+        let gpu = match raw.gpu {
+            Some(g) => {
+                let g = g.trim();
+                if g.is_empty() {
+                    return Err(ConfigError::RemoteGpuEmpty);
+                }
+                if endpoint.is_some() {
+                    return Err(ConfigError::RemoteGpuRequiresCookbook);
+                }
+                Some(g.to_string())
+            },
+            None => None,
+        };
         Ok(Self {
             model: model.to_string(),
             endpoint,
             cookbook,
             query_endpoint,
             auth_env,
+            gpu,
             batch_size: raw.batch_size.unwrap_or(default.batch_size),
             request_timeout_s: raw.request_timeout_s.unwrap_or(default.request_timeout_s),
         })
@@ -954,6 +986,17 @@ pub enum ConfigError {
          var and name it via `auth_env` instead"
     )]
     RemoteEmbeddingEndpointHasCredentials,
+    #[error(
+        "[llm.embedding.remote] `gpu` applies only to ephemeral `cookbook` provisioning, not a \
+         connect `endpoint` — remove `gpu`, or switch the remote block to a `cookbook` recipe"
+    )]
+    RemoteGpuRequiresCookbook,
+    #[error(
+        "[llm.embedding.remote] `gpu` is set but empty — give it a provider-specific value (a \
+         Modal GPU class like `A10G`, or a RunPod `gpuTypeId`), or remove the key to use the \
+         recipe default"
+    )]
+    RemoteGpuEmpty,
     #[error(
         "[llm.embedding.remote] can only serve a transformer model over Ollama, but `model = \
          \"{0}\"` is not a transformer (it is a static/hash model, or `none`/disabled) — remove \
@@ -1337,6 +1380,7 @@ mod tests {
                 cookbook: None,
                 query_endpoint: None, // connect mode: no local query box
                 auth_env: None,
+                gpu: None,
                 // defaults applied when omitted
                 batch_size: 256,
                 request_timeout_s: 60,
@@ -1399,6 +1443,85 @@ mod tests {
     }
 
     #[test]
+    fn remote_embedding_ephemeral_gpu_is_parsed_and_trimmed() {
+        // EPHEMERAL: `gpu` picks the GPU the cookbook recipe provisions. The value is
+        // provider-specific (Modal class / RunPod gpuTypeId) and NOT validated against an
+        // allow-list here — only trimmed.
+        let raw: RawConfig = toml::from_str(
+            r#"
+            [index]
+            root = "."
+
+            [llm.embedding]
+            model = "sentence-transformers/all-MiniLM-L6-v2"
+
+            [llm.embedding.remote]
+            model = "all-minilm"
+            cookbook = "@rag-rat/cookbook/modal"
+            gpu = "  A10G  "
+            "#,
+        )
+        .unwrap();
+        let remote = LlmConfig::try_from(raw.llm).unwrap().embedding.remote.unwrap();
+        assert_eq!(remote.gpu.as_deref(), Some("A10G"));
+    }
+
+    #[test]
+    fn remote_embedding_gpu_with_connect_endpoint_is_rejected() {
+        // `gpu` only applies to ephemeral `cookbook` provisioning. Set alongside a connect
+        // `endpoint` it is meaningless → rejected (not silently ignored).
+        let raw: RawConfig = toml::from_str(
+            r#"
+            [index]
+            root = "."
+
+            [llm.embedding]
+            model = "sentence-transformers/all-MiniLM-L6-v2"
+
+            [llm.embedding.remote]
+            model = "all-minilm"
+            endpoint = "http://localhost:11434"
+            gpu = "A10G"
+            "#,
+        )
+        .unwrap();
+        let err = LlmConfig::try_from(raw.llm).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::RemoteGpuRequiresCookbook),
+            "gpu + endpoint → RemoteGpuRequiresCookbook, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn remote_embedding_empty_gpu_is_rejected() {
+        // A present-but-empty/whitespace `gpu` is a config error — clearer than silently dropping a
+        // key the user meant to set. (Omitting `gpu` entirely is fine: the recipe uses its
+        // default.)
+        for value in ["\"\"", "\"   \""] {
+            let raw: RawConfig = toml::from_str(&format!(
+                r#"
+                [index]
+                root = "."
+
+                [llm.embedding]
+                model = "sentence-transformers/all-MiniLM-L6-v2"
+
+                [llm.embedding.remote]
+                model = "all-minilm"
+                cookbook = "@rag-rat/cookbook/modal"
+                gpu = {value}
+                "#,
+            ))
+            .unwrap();
+            let err = LlmConfig::try_from(raw.llm).unwrap_err();
+            assert!(
+                matches!(err, ConfigError::RemoteGpuEmpty),
+                "gpu={value} → RemoteGpuEmpty, got {err:?}",
+            );
+        }
+    }
+
+    #[test]
     fn remote_embedding_overrides_batch_and_timeout() {
         let raw: RawConfig = toml::from_str(
             r#"
@@ -1426,6 +1549,7 @@ mod tests {
                 cookbook: None,
                 query_endpoint: None,
                 auth_env: Some("OLLAMA_TOKEN".to_string()),
+                gpu: None,
                 batch_size: 512,
                 request_timeout_s: 120,
             })

--- a/crates/rag-rat-core/src/index/ai/helpers.rs
+++ b/crates/rag-rat-core/src/index/ai/helpers.rs
@@ -521,6 +521,7 @@ mod tests {
             // The NAME of an env var — never a token. The round-trip test asserts this name is
             // present and no token is.
             auth_env: Some("OLLAMA_TOKEN".to_string()),
+            gpu: None,
             batch_size: 256,
             request_timeout_s: 60,
         }
@@ -614,6 +615,7 @@ mod tests {
             cookbook: None,
             query_endpoint: None,
             auth_env: None,
+            gpu: None,
             batch_size: 256,
             request_timeout_s: 2,
         };

--- a/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
@@ -388,6 +388,24 @@ impl CookbookProvisioner {
     }
 }
 
+/// Build the `CookbookInput` (the env-passed provisioning request) from an ephemeral remote config.
+/// Split out from `provision_and_build` so the config→input mapping — notably that the configured
+/// `gpu` is forwarded — is unit-testable without spawning a real recipe.
+fn cookbook_input_for(remote: &RemoteEmbeddingConfig) -> CookbookInput {
+    CookbookInput {
+        model: remote.model.trim().to_string(),
+        request_timeout_s: remote.request_timeout_s,
+        // Give the recipe a provisioning budget just under the Rust hard ceiling, so ITS budget
+        // runs out first (clean provider-side teardown) before the Rust SIGKILL backstop
+        // fires.
+        provision_timeout_s: PROVISION_TIMEOUT.as_secs().saturating_sub(20),
+        // The configured GPU (provider-specific; validated by the provider at provision time). The
+        // recipe picks its own default when `None`. Config validation guarantees `gpu` is only set
+        // in ephemeral mode, which is the only mode reaching this function.
+        gpu: remote.gpu.clone(),
+    }
+}
+
 /// Provision an ephemeral cookbook box for the selected `spec` over `remote` and build an
 /// [`OllamaEmbedder`] against it. The single place that wires `cookbook` → `CookbookInput` →
 /// `CookbookProvisioner::provision` → `OllamaEmbedder::from_provisioned`; shared by the reconcile
@@ -402,15 +420,7 @@ pub(crate) fn provision_and_build(
         .cookbook
         .as_deref()
         .ok_or_else(|| anyhow::anyhow!("ephemeral remote config has no cookbook"))?;
-    let input = CookbookInput {
-        model: remote.model.trim().to_string(),
-        request_timeout_s: remote.request_timeout_s,
-        // Give the recipe a provisioning budget just under the Rust hard ceiling, so ITS budget
-        // runs out first (clean provider-side teardown) before the Rust SIGKILL backstop
-        // fires.
-        provision_timeout_s: PROVISION_TIMEOUT.as_secs().saturating_sub(20),
-        gpu: None,
-    };
+    let input = cookbook_input_for(remote);
     let provisioned = CookbookProvisioner::provision(cookbook, &input)?;
     let embedder = OllamaEmbedder::from_provisioned(ProvisionedEmbedderParams {
         endpoint: &provisioned.endpoint,
@@ -901,6 +911,24 @@ mod tests {
     fn tmp(name: &str) -> PathBuf {
         let id = N.fetch_add(1, Ordering::Relaxed);
         std::env::temp_dir().join(format!("ragrat-cookbook-{}-{id}-{name}", std::process::id()))
+    }
+
+    #[test]
+    fn cookbook_input_carries_the_configured_gpu() {
+        // The config→CookbookInput mapping must forward the configured `gpu` to the recipe (it's
+        // the only way a user picks a GPU — the contract.ts side reads `input.gpu`). `None`
+        // stays `None` so the recipe keeps its own default.
+        let ephemeral = |gpu: Option<&str>| RemoteEmbeddingConfig {
+            model: "all-minilm".to_string(),
+            cookbook: Some("@rag-rat/cookbook modal".to_string()),
+            query_endpoint: Some(crate::config::DEFAULT_QUERY_ENDPOINT.to_string()),
+            gpu: gpu.map(str::to_string),
+            ..RemoteEmbeddingConfig::default()
+        };
+        assert_eq!(cookbook_input_for(&ephemeral(Some("A10G"))).gpu.as_deref(), Some("A10G"));
+        assert_eq!(cookbook_input_for(&ephemeral(None)).gpu, None);
+        // The model is trimmed into the input regardless of gpu.
+        assert_eq!(cookbook_input_for(&ephemeral(Some("A100"))).model, "all-minilm");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -89,6 +89,10 @@ fn query_embed_config(remote: &RemoteEmbeddingConfig) -> RemoteEmbeddingConfig {
             // query embed → `embed_query` returns None → silent, PERMANENT BM25.
             // `auth_env` is a secret-free NAME.
             auth_env: remote.auth_env.clone(),
+            // DROP `gpu`: this is now a CONNECT-shaped config (it has `endpoint`), and `gpu` is
+            // cookbook-only. The query path never reads it, but keep the "gpu ⟹ ephemeral"
+            // invariant true for derived configs too.
+            gpu: None,
             ..remote.clone()
         }
     } else {
@@ -287,6 +291,7 @@ mod dispatch_tests {
             cookbook: None,
             query_endpoint: None,
             auth_env: None,
+            gpu: None,
             batch_size: 256,
             request_timeout_s: 5,
         }
@@ -337,6 +342,7 @@ mod dispatch_tests {
             cookbook: Some("@rag-rat/cookbook/modal".to_string()),
             query_endpoint: Some(query_endpoint.to_string()),
             auth_env: auth_env.map(str::to_string),
+            gpu: None,
             batch_size: 256,
             request_timeout_s: 5,
         }

--- a/crates/rag-rat-core/src/index/ai/providers/ollama.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/ollama.rs
@@ -382,6 +382,7 @@ mod tests {
             cookbook: None,
             query_endpoint: None,
             auth_env: None,
+            gpu: None,
             batch_size: 256,
             request_timeout_s: timeout_s,
         }

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -1143,6 +1143,7 @@ mod freshness_version_tests {
             cookbook: None,
             query_endpoint: None,
             auth_env: None,
+            gpu: None,
             batch_size: 256,
             request_timeout_s: 5,
         }
@@ -1398,6 +1399,7 @@ mod freshness_version_tests {
             cookbook: Some("@rag-rat/cookbook/modal".to_string()),
             query_endpoint: Some("http://localhost:11434".to_string()),
             auth_env: None,
+            gpu: None,
             batch_size: 256,
             request_timeout_s: 5,
         };

--- a/crates/rag-rat-core/src/index/ai/status.rs
+++ b/crates/rag-rat-core/src/index/ai/status.rs
@@ -301,6 +301,7 @@ mod ollama_install_tests {
             cookbook: None,
             query_endpoint: None,
             auth_env: None,
+            gpu: None,
             batch_size: 256,
             request_timeout_s: 5,
         }

--- a/docs/config.md
+++ b/docs/config.md
@@ -91,7 +91,17 @@ model = "all-minilm"                        # the Ollama-side model name
 # query_endpoint = "http://localhost:11434" # the LOCAL ollama for QUERY embedding
                                             #   (defaults to http://localhost:11434)
 # auth_env = "OLLAMA_TOKEN"                 # optional bearer-token env var NAME
+# gpu = "A10G"                              # cookbook-only: the GPU the recipe provisions.
+                                            #   Provider-specific, validated at provision time:
+                                            #   Modal = a GPU CLASS (A10G / T4 / A100; default CPU
+                                            #     — the modal recipe WARNS that GPU there has an
+                                            #     exit-137 cold-start risk);
+                                            #   RunPod = a gpuTypeId (default: a cheap on-demand GPU).
 ```
+
+`gpu` applies **only** to the EPHEMERAL `cookbook` path; setting it alongside a connect `endpoint` is
+a config error. Its value is **not** validated by rag-rat — the provider rejects an unknown GPU when
+it tries to provision.
 
 Provisioning happens **only on an explicit `rag-rat reconcile`** (the deliberate bulk pass) — the
 background watcher/maintenance pass does **not** cold-start a GPU box for a few changed chunks (it

--- a/rag-rat.toml
+++ b/rag-rat.toml
@@ -17,6 +17,9 @@ model = "sentence-transformers/all-MiniLM-L6-v2"
 endpoint = "http://localhost:11434"   # this box's Ollama server
 model = "all-minilm"                  # the Ollama-side model name
 batch_size = 256                      # texts per /api/embed request
+# To EPHEMERALLY provision a box instead, drop `endpoint` and set `cookbook` (see docs/config.md).
+# Only then may you pick the GPU (a connect endpoint + gpu is rejected):
+# gpu = "A10G"                        # cookbook-only; Modal GPU class / RunPod gpuTypeId
 
 [llm.embedding.runtime]
 batch_size = 64


### PR DESCRIPTION
feat(embed): user-selectable GPU for ephemeral cookbook provisioning ([llm.embedding.remote] gpu)

The cookbook recipe + contract.ts already read input.gpu (Modal sandboxes.create({gpu}), RunPod
gpuTypeId); Rust just hardcoded CookbookInput.gpu = None. Wire a config field through:

- config.rs: gpu: Option<String> on RawRemoteEmbedding + RemoteEmbeddingConfig (serde(default), so
  remote-config meta written by an older binary still deserializes after upgrade). Validation:
  present-but-empty/whitespace -> ConfigError::RemoteGpuEmpty; gpu + a connect endpoint ->
  RemoteGpuRequiresCookbook (gpu is ephemeral/cookbook-only). No value allow-list — the provider
  validates the GPU at provision time.
- cookbook.rs: cookbook_input_for(remote) sets gpu: remote.gpu.clone() (extracted from
  provision_and_build so the config->input mapping is unit-testable).
- gpu is deliberately NOT folded into remote_freshness_version: the same model on A10G vs T4 yields
  identical embeddings, so a GPU change must not re-embed the repo. query_embed_config clears gpu.
- docs/config.md + rag-rat.toml document it (cookbook-only; Modal GPU class + the exit-137
  cold-start caveat; RunPod gpuTypeId).

5 new tests; 1174/1172 both feature configs; clippy both; +nightly fmt; cookbook tsc.
