### PR TITLE
chore(cookbook): repo metadata + README link/issue-number cleanup (v0.1.1)

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -1,11 +1,11 @@
 # @rag-rat/cookbook
 
-Ephemeral remote-runtime provisioning recipes for [rag-rat](../). A **recipe** is a standalone
+Ephemeral remote-runtime provisioning recipes for [rag-rat](https://github.com/cq27-dev/rag-rat). A **recipe** is a standalone
 Node program that rag-rat spawns as a subprocess: it provisions a remote box (e.g. an Ollama
 embedding server), streams typed JSONL events to stdout (handing rag-rat the endpoint via a
 `ready` event), holds the box while rag-rat works, then tears it down on signal.
 
-This is the JS/TS half of rag-rat's remote-runtime rework (#317/#318). rag-rat (Rust) owns the
+This is the JS/TS half of rag-rat's remote-runtime rework. rag-rat (Rust) owns the
 lifecycle and the embedding traffic; the cookbook owns provider provisioning.
 
 > **Security — a cookbook spec must be TRUSTED.** A recipe runs with your full privileges and
@@ -18,7 +18,7 @@ lifecycle and the embedding traffic; the cookbook owns provider provisioning.
 ## The process contract
 
 rag-rat and a recipe communicate over a strict process protocol. **stdout is a typed JSONL event
-stream** — one JSON object per line — which a future ratatui `log` view (#329) renders live. The
+stream** — one JSON object per line — which a future ratatui `log` view renders live. The
 Rust parser is built against the exact event shapes below; implement them precisely.
 
 | Stage | rag-rat | recipe |

--- a/cookbook/package.json
+++ b/cookbook/package.json
@@ -1,8 +1,15 @@
 {
   "name": "@rag-rat/cookbook",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Ephemeral remote-runtime provisioning recipes for rag-rat. rag-rat (Rust) spawns a recipe as a subprocess, reads a typed JSONL event stream from its stdout (status/log/ready/error), embeds against the endpoint, then signals teardown.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cq27-dev/rag-rat.git",
+    "directory": "cookbook"
+  },
+  "homepage": "https://github.com/cq27-dev/rag-rat/tree/main/cookbook#readme",
+  "bugs": "https://github.com/cq27-dev/rag-rat/issues",
   "type": "module",
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
chore(cookbook): add repo metadata + fix README repo link, drop issue numbers (v0.1.1)

The published npm page had no Repository link (package.json had no `repository`) and the README's
`[rag-rat](../)` relative link is dead on npm. Add repository/homepage/bugs pointing at the public
repo (cookbook subdir), make the README link absolute, and drop the internal issue-number refs.
Bump 0.1.0 -> 0.1.1 for the republish.
