### PR TITLE
feat(init): add extensible ratatui wizard

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,10 @@
 # nextest profiles. The `ci` profile emits a JUnit report for Codecov Test Analytics.
 # Tests are parallel-safe (each uses its own temp DB; the library no longer shells out to `gh`),
 # so this runs at nextest's default per-core parallelism.
+[profile.ci]
+# A wedged test should fail with its test name instead of leaving the whole CI job running.
+slow-timeout = { period = "60s", terminate-after = 2 }
+
 [profile.ci.junit]
 # Written to target/nextest/ci/junit.xml.
 path = "junit.xml"

--- a/.github/workflows/ci-cross-platform.yml
+++ b/.github/workflows/ci-cross-platform.yml
@@ -32,6 +32,9 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # Keep ort-sys' downloaded ONNX Runtime under target/ so rust-cache restores the
+  # native library together with build-script link metadata.
+  ORT_CACHE_DIR: ${{ github.workspace }}/target/ort-cache
 
 jobs:
   clippy:
@@ -81,6 +84,9 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      # rust-cache restore keys can bring back ort-sys link metadata from before ORT_CACHE_DIR was
+      # target-local. Force the build script to re-emit -L for the current cache location.
+      - run: cargo clean -p ort-sys
       # Align the MSVC C runtime so the link succeeds. esaxx-rs (a C++ dep via
       # tokenizers <- model2vec/fastembed) hardcodes cc's .static_crt(true) => /MT, but the ort_sys
       # ONNX Runtime prebuilt is /MD; the mismatch is LNK2038/LNK1319 on Windows. cc appends env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # Keep ort-sys' downloaded ONNX Runtime under target/ so rust-cache restores the
+  # native library together with build-script link metadata.
+  ORT_CACHE_DIR: ${{ github.workspace }}/target/ort-cache
 
 jobs:
   fmt:
@@ -55,6 +58,7 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
@@ -80,6 +84,9 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      # rust-cache restore keys can bring back ort-sys link metadata from before ORT_CACHE_DIR was
+      # target-local. Force the build script to re-emit -L for the current cache location.
+      - run: cargo clean -p ort-sys
       # Compile the default feature set (downloads the ONNX runtime once, then cached) so the
       # released binary's embedding paths never break silently.
       - run: cargo build --workspace --locked
@@ -87,6 +94,7 @@ jobs:
   coverage:
     name: coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -42,6 +42,9 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # Keep ort-sys' downloaded ONNX Runtime under target/ so rust-cache restores the
+  # native library together with build-script link metadata.
+  ORT_CACHE_DIR: ${{ github.workspace }}/target/ort-cache
   # Stable, cacheable location for the MiniLM ONNX download (fastembed honours this env var; see
   # index/ai/helpers.rs::fastembed_cache_dir). The model is immutable, so the cache key is static.
   RAG_RAT_MODEL_CACHE: ${{ github.workspace }}/.rag-rat-models
@@ -57,6 +60,9 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
+      # rust-cache restore keys can bring back ort-sys link metadata from before ORT_CACHE_DIR was
+      # target-local. Force the build script to re-emit -L for the current cache location.
+      - run: cargo clean -p ort-sys
       # Cache the MiniLM model download (immutable → static key) so the semantic pass doesn't
       # re-fetch ~90 MB from Hugging Face every run; first run / cache-miss warms it.
       - name: cache embedding model

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,6 +240,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "byteorder"
@@ -424,6 +439,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +575,33 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.13.0",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -753,6 +804,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -913,6 +965,12 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastembed"
@@ -2393,6 +2451,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inotify"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,6 +2477,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2512,6 +2592,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2547,6 +2638,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2564,6 +2661,15 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2598,6 +2704,15 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "lru-slab"
@@ -2836,6 +2951,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2919,6 +3043,30 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3160,12 +3308,16 @@ dependencies = [
  "libc",
  "rag-rat-core",
  "rag-rat-mcp",
+ "ratatui",
  "serde",
  "serde_json",
+ "tempfile",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tokio",
+ "toml_edit",
  "toon-format",
+ "tui-tree-widget",
 ]
 
 [[package]]
@@ -3245,6 +3397,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags 2.13.0",
+ "compact_str",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
+ "kasuari",
+ "lru",
+ "palette",
+ "serde",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -3744,6 +3962,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3839,6 +4078,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -3968,7 +4228,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -4152,11 +4414,17 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_datetime"
@@ -4168,13 +4436,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -4357,6 +4643,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tui-tree-widget"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deca119555009eee2e0cfb9c020f39f632444dc4579918d5fc009d51d75dff92"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+ "unicode-width",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4399,10 +4696,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-truncate"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools 0.14.0",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode_categories"
@@ -4910,6 +5218,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ ureq = { version = "3", default-features = false, features = ["rustls"] }
 # than compact JSON on uniform-row payloads, neutral on nested ones — see rag_rat_core::output.
 # default-features = false drops its `cli` feature (ratatui/crossterm/arboard/syntect/tiktoken-rs/…)
 # — we only need the library encode/decode surface.
+tempfile = "3"
 toon-format = { version = "0.5.0", default-features = false }
 toml = "1.1"
 # Grammar crates are exact-pinned so parser node coverage changes deliberately.

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -64,8 +64,9 @@ Hard rules:
   "request_timeout_s": 30,     // optional: positive number — the Rust embedder's per-HTTP-request
                                //   timeout, passed through for completeness. NOT a provisioning
                                //   budget (~30–60s is far too short to boot a box).
-  "gpu": null                  // optional: string or null. For Modal this is "A10G"/"T4" (CPU
-                               //   default); for RunPod a gpuTypeId like "NVIDIA RTX A4000".
+  "gpu": null                  // optional: string or null. For Modal this is a Modal GPU request
+                               //   string like "A10", "L40S", "H100", or "B200+" (CPU default);
+                               //   for RunPod a gpuTypeId like "NVIDIA RTX A4000".
 }
 ```
 
@@ -133,8 +134,10 @@ image, serves an embedding model, and tunnels port `11434`.
 
 Provider gotchas baked into the recipe (each one cost real time to find):
 
-- The ollama image **entrypoint is `/bin/ollama`**, so the sandbox command is the bare subcommand
-  `["serve"]` — `["ollama", "serve"]` would exec `ollama ollama serve`.
+- Modal Sandbox `command` is passed as entrypoint args for registry images. The `ollama/ollama`
+  image already has `/bin/ollama` as its entrypoint, so the recipe uses `["serve"]`, attaches a TCP
+  readiness probe on port `11434`, and explicitly waits for readiness before pulling/verifying the
+  model.
 - ollama defaults to `127.0.0.1:11434`, unreachable by the tunnel — the recipe sets
   `OLLAMA_HOST=0.0.0.0:11434`.
 - **GPU is off by default.** GPU on Modal must attach before ollama's discovery watchdog times out,

--- a/cookbook/package-lock.json
+++ b/cookbook/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rag-rat/cookbook",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rag-rat/cookbook",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "modal": "^0.8.1"

--- a/cookbook/package.json
+++ b/cookbook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rag-rat/cookbook",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "description": "Ephemeral remote-runtime provisioning recipes for rag-rat. rag-rat (Rust) spawns a recipe as a subprocess, reads a typed JSONL event stream from its stdout (status/log/ready/error), embeds against the endpoint, then signals teardown.",
   "license": "MIT",
   "repository": {
@@ -16,7 +16,9 @@
   },
   "main": "dist/src/contract.js",
   "types": "dist/src/contract.d.ts",
-  "bin": "./dist/cli.mjs",
+  "bin": {
+    "cookbook": "dist/cli.mjs"
+  },
   "exports": {
     ".": {
       "types": "./dist/src/contract.d.ts",

--- a/cookbook/recipes/modal-ollama.mts
+++ b/cookbook/recipes/modal-ollama.mts
@@ -9,8 +9,9 @@
  * ~/.modal.toml — rag-rat does not pass creds through RAG_RAT_COOKBOOK_INPUT.
  *
  * Mirrors the proven Python provisioning. Provider gotchas, all load-bearing:
- *   - The ollama image ENTRYPOINT is `/bin/ollama`, so the Sandbox command is the bare
- *     subcommand `serve` — NOT `["ollama", "serve"]`, which would exec `ollama ollama serve`.
+ *   - Modal Sandbox `command` is passed as entrypoint args for registry images. The
+ *     `ollama/ollama` image already has `/bin/ollama` as ENTRYPOINT, so use `["serve"]`; passing
+ *     `["/bin/ollama", "serve"]` runs `ollama /bin/ollama serve` and exits with "unknown command".
  *   - ollama binds 127.0.0.1:11434 by default, which the Modal tunnel cannot reach. We set
  *     OLLAMA_HOST=0.0.0.0:11434 so it listens on all interfaces.
  *   - GPU is optional and OFF by default. GPU on Modal must be attached before ollama's
@@ -25,7 +26,8 @@
  * running past the Rust hard timeout and getting SIGKILLed with the box still billing (N2).
  */
 
-import { ModalClient } from "modal";
+import { randomUUID } from "node:crypto";
+import { ModalClient, Probe } from "modal";
 import type { Sandbox } from "modal";
 
 import {
@@ -85,29 +87,54 @@ async function provision(ctx: ProvisionContext<Sandbox>): Promise<Provisioned<Sa
   // give the sandbox a recoverable UNIQUE name; on ANY create throw, look it up by name and terminate
   // it before rethrowing. (Unlike RunPod, Modal HAS a provider backstop, so this only shortens the
   // worst case — but a leaked GPU box for up to 30 min is still real money.)
-  const sandboxName = `${APP_NAME}-${Date.now()}`;
+  const sandboxName = `${APP_NAME}-${Date.now()}-${randomUUID().slice(0, 8)}`;
 
-  // `command: ["serve"]` is appended to the image entrypoint (/bin/ollama) → `ollama serve`.
-  // OLLAMA_HOST goes in the sandbox env so the runtime process binds all interfaces.
+  // Modal passes `command` as ENTRYPOINT args for registry images. The ollama image's entrypoint is
+  // `/bin/ollama`, so `["serve"]` starts `ollama serve`; including `/bin/ollama` here would become
+  // `ollama /bin/ollama serve` and fail before readiness.
   let sb: Sandbox;
+  const createRef: { promise?: Promise<Sandbox> } = {};
   try {
-    sb = await withBudget(deadline, "sandboxes.create", () =>
-      modal.sandboxes.create(app, image, {
+    sb = await withBudget(deadline, "sandboxes.create", () => {
+      createRef.promise = modal.sandboxes.create(app, image, {
         name: sandboxName,
         command: ["serve"],
         env: { OLLAMA_HOST: `0.0.0.0:${OLLAMA_PORT}` },
         encryptedPorts: [OLLAMA_PORT],
+        readinessProbe: Probe.withTcp(OLLAMA_PORT, { intervalMs: 1000 }),
         timeoutMs: BOX_MAX_LIFETIME_MS,
         ...(gpu !== null ? { gpu } : {}),
-      }),
-    );
+      });
+      return createRef.promise;
+    });
   } catch (cause) {
+    const pendingCreate = createRef.promise;
+    if (pendingCreate !== undefined) {
+      void pendingCreate.then(
+        (lateSandbox: Sandbox) => terminateOrphanSandbox(lateSandbox, sandboxName, "late create"),
+        (lateCause: unknown) => {
+          log(
+            "info",
+            `orphan sweep: create promise for "${sandboxName}" later rejected: ${errorMessage(lateCause)}`,
+          );
+        },
+      );
+    }
     await sweepOrphanByName(modal, sandboxName);
     throw cause;
   }
-  // Report the box NOW so runRecipe tears it down if anything below throws.
+  // Report the box NOW so runRecipe tears it down if readiness, pull, or verify throws.
   ctx.onBox(sb);
   log("info", `sandbox created: ${sb.sandboxId ?? "(id unavailable)"}`);
+
+  ctx.status("provisioning", `waiting for ollama serve on port ${OLLAMA_PORT}`);
+  const readinessTimeoutMs = assertBudgetRemaining(deadline, "sandbox readiness");
+  await raceWithTimeout(
+    () => sb.waitUntilReady(readinessTimeoutMs),
+    readinessTimeoutMs,
+    "sandbox.waitUntilReady",
+  );
+  log("info", "ollama serve is listening");
 
   // Pull the model. The server (`serve`) is the box's main process; pull runs as an exec
   // against the same ollama install, populating the model store the server reads. Every step
@@ -169,12 +196,7 @@ async function sweepOrphanByName(modal: ModalClient, sandboxName: string): Promi
       TEARDOWN_TIMEOUT_MS,
       "sandboxes.fromName(orphan sweep)",
     );
-    await raceWithTimeout(
-      () => orphan.terminate(),
-      TEARDOWN_TIMEOUT_MS,
-      "orphan.terminate",
-    );
-    log("warn", `orphan sweep: terminated leaked sandbox "${sandboxName}" (${orphan.sandboxId})`);
+    await terminateOrphanSandbox(orphan, sandboxName, "orphan sweep");
   } catch (cause) {
     // fromName raises NotFoundError when no sandbox with that name exists — the common case (create
     // never made one). Distinguish it from a real failure so the log isn't alarming.
@@ -184,6 +206,23 @@ async function sweepOrphanByName(modal: ModalClient, sandboxName: string): Promi
     } else {
       log("error", `orphan sweep: could not reclaim a possible leak "${sandboxName}": ${message}`);
     }
+  }
+}
+
+async function terminateOrphanSandbox(
+  orphan: Sandbox,
+  sandboxName: string,
+  source: string,
+): Promise<void> {
+  try {
+    await raceWithTimeout(
+      () => orphan.terminate(),
+      TEARDOWN_TIMEOUT_MS,
+      `${source}.terminate`,
+    );
+    log("warn", `${source}: terminated leaked sandbox "${sandboxName}" (${orphan.sandboxId})`);
+  } catch (cause) {
+    log("error", `${source}: could not terminate leaked sandbox "${sandboxName}": ${errorMessage(cause)}`);
   }
 }
 

--- a/crates/rag-rat-cli/Cargo.toml
+++ b/crates/rag-rat-cli/Cargo.toml
@@ -19,6 +19,9 @@ path = "src/main.rs"
 anyhow.workspace = true
 clap = { version = "4.6", features = ["derive"] }
 dialoguer = "0.12"
+ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
+tui-tree-widget = "0.24"
+toml_edit = "0.22"
 gix.workspace = true
 rag-rat-core = { workspace = true }
 rag-rat-mcp = { workspace = true }
@@ -42,6 +45,7 @@ tikv-jemalloc-ctl = "0.6"
 [dev-dependencies]
 # MCP tool results render as TOON; integration tests decode them back to JSON Values to assert.
 toon-format.workspace = true
+tempfile.workspace = true
 
 [features]
 default = ["fastembed", "model2vec"]

--- a/crates/rag-rat-cli/src/init/mod.rs
+++ b/crates/rag-rat-cli/src/init/mod.rs
@@ -1,12 +1,13 @@
 mod render;
 mod run;
 mod scan;
+mod wizard;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::{env, fs, io};
 
-use dialoguer::{Confirm, MultiSelect, Select};
+use dialoguer::Confirm;
 use rag_rat_core::config::EmbeddingBackend;
 use rag_rat_core::embedding_models::{FASTEMBED_MODEL_ID, HASH_MODEL_ID, MODEL2VEC_MODEL_ID};
 use rag_rat_core::index::ai::ReconcileOptions;
@@ -21,7 +22,7 @@ use crate::{
     apply_embedding_runtime_env, git_paths, render_index_progress, render_reconcile_progress,
 };
 
-const DEFAULT_DATABASE: &str = ".rag-rat/index.sqlite";
+pub(crate) const DEFAULT_DATABASE: &str = ".rag-rat/index.sqlite";
 const SKIPPED_DIRS: &[&str] = &[
     ".git",
     ".rag-rat",
@@ -43,6 +44,11 @@ const SKIPPED_DIRS: &[&str] = &[
     "dist",
     "node_modules",
     "target",
+    // AI tooling directories — never project source (like .rag-rat above).
+    ".claude",
+    ".codex",
+    ".omc",
+    ".omx",
 ];
 
 #[derive(Debug, Clone)]
@@ -65,7 +71,7 @@ pub(crate) struct InitPlan {
     oracle_auto_run: bool,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct RepoScan {
     language_counts: BTreeMap<Language, usize>,
     dir_counts: BTreeMap<Language, BTreeMap<PathBuf, usize>>,
@@ -84,6 +90,31 @@ pub(crate) struct RepoScan {
     /// (`.cpp`/`.cc`/…), else to **C**. Bare `Language::from_path` calls every `.h` C, which would
     /// bind a C++ library's header tree as `c` and parse it as C — see [`scan::assign_headers`].
     deferred_headers: Vec<PathBuf>,
+}
+
+impl RepoScan {
+    /// Read-only access to language file counts — used by `wizard/draft.rs` to build
+    /// `WizardDraft::from_scan` without re-implementing `default_plan`'s language filtering.
+    pub(crate) fn language_counts(&self) -> &BTreeMap<Language, usize> {
+        &self.language_counts
+    }
+
+    /// Mutable access for tests in `wizard/draft.rs` that construct a `RepoScan` directly.
+    #[cfg(test)]
+    pub(crate) fn language_counts_mut(&mut self) -> &mut BTreeMap<Language, usize> {
+        &mut self.language_counts
+    }
+
+    /// Total source bytes scanned — used by `wizard/draft.rs` to call `estimated_chunks`.
+    pub(crate) fn total_source_bytes(&self) -> u64 {
+        self.total_source_bytes
+    }
+
+    /// Mutable setter for tests in `wizard/draft.rs`.
+    #[cfg(test)]
+    pub(crate) fn set_total_source_bytes(&mut self, n: u64) {
+        self.total_source_bytes = n;
+    }
 }
 
 impl InitOptions {
@@ -301,6 +332,8 @@ mod tests {
         assert!(text.contains("# [watch]"));
         assert!(text.contains("# [version_check]"));
         assert!(text.contains("# [llm.embedding.runtime]"));
+        assert!(text.contains("# [init.cookbooks.modal]"));
+        assert!(text.contains("# [init.cookbooks.my-provider]"));
         assert!(text.contains("`.h`"), "explains the cpp .h-header binding");
 
         std::fs::write(root.join("rag-rat.toml"), &text).unwrap();
@@ -310,6 +343,41 @@ mod tests {
         assert_eq!(config.targets[0].language, Language::Cpp);
         // Commented [watch] falls back to its default (enabled).
         assert!(config.watch.enabled);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn config_load_ignores_active_init_cookbook_catalog() {
+        let root = std::env::temp_dir().join(format!("ragrat-init-catalog-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(
+            root.join("rag-rat.toml"),
+            r#"
+            [index]
+            root = "."
+
+            [target_bindings]
+            rust = ["src"]
+
+            [llm.embedding]
+            model = "sentence-transformers/all-MiniLM-L6-v2"
+
+            [init.cookbooks.modal]
+            gpus = ["tiny", "huge"]
+
+            [init.cookbooks.custom]
+            label = "Custom"
+            command = "./recipes/custom.mjs"
+            gpus = []
+            "#,
+        )
+        .unwrap();
+
+        let config = Config::load(root.join("rag-rat.toml")).unwrap();
+
+        assert_eq!(config.targets.len(), 1);
+        assert_eq!(config.llm.embedding.backend.as_str(), "sentence-transformers/all-MiniLM-L6-v2");
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/crates/rag-rat-cli/src/init/render.rs
+++ b/crates/rag-rat-cli/src/init/render.rs
@@ -50,6 +50,15 @@ pub(crate) fn render_config(plan: &InitPlan) -> String {
     );
 
     text.push_str(
+        "# Init wizard cookbook catalog (optional). These entries only affect `rag-rat init` \
+         selectors;\n# runtime uses the selected `[llm.embedding.remote] cookbook` and `gpu` \
+         strings verbatim.\n# [init.cookbooks.modal]\n# label = \"Modal\"\n# command = \
+         \"@rag-rat/cookbook modal\"\n# gpus = [\"T4\", \"L4\", \"A10\", \"H100\"]\n#\n# \
+         [init.cookbooks.my-provider]\n# label = \"My Provider\"\n# command = \
+         \"./recipes/my-provider.mjs\"\n# gpus = [\"small\", \"large\"]\n\n",
+    );
+
+    text.push_str(
         "# Background file watcher — keeps the index fresh as files change (defaults shown).\n# \
          [watch]\n# enabled = true\n# debounce_ms = 400           # quiet window before a reindex \
          pass\n# max_latency_ms = 2500       # force a pass after this much continuous \

--- a/crates/rag-rat-cli/src/init/run.rs
+++ b/crates/rag-rat-cli/src/init/run.rs
@@ -1,16 +1,31 @@
+use super::wizard::{self, HookConflict, WizardResult, render_chained_hook};
 use super::*;
+use crate::{hook_script, install_hook, is_rag_rat_hook, make_executable, write_atomic};
 
 pub(crate) fn run(args: &crate::cli::InitArgs, config_path: &str) -> anyhow::Result<()> {
     let options = InitOptions::from_args(args, config_path);
     let _terminal_reset = TerminalResetGuard::install_if_interactive(!options.yes)?;
     let root = env::current_dir()?.canonicalize()?;
-    let scan = scan_repo(&root)?;
-    let root_value = config_root_value(&root, &options.config_path);
-    let plan = if options.yes {
-        default_plan(root_value, &scan)
-    } else {
-        prompt_plan(root, root_value, &scan)?
-    };
+
+    // The interactive path runs the full-screen ratatui wizard. `--yes` keeps the legacy
+    // `default_plan` + `render_config` flow; `--dry-run` remains interactive unless paired with
+    // `--yes`, so the preview reflects the wizard choices.
+    if options.yes {
+        let scan = scan_repo(&root)?;
+        let root_value = config_root_value(&root, &options.config_path);
+        return run_non_interactive(&options, root_value, &scan);
+    }
+    run_interactive(&options)
+}
+
+/// The non-interactive (`--yes`) / `--dry-run` flow: render from `default_plan` and either print
+/// (dry-run) or write + index + install. Unchanged from the pre-wizard implementation.
+fn run_non_interactive(
+    options: &InitOptions,
+    root_value: String,
+    scan: &RepoScan,
+) -> anyhow::Result<()> {
+    let plan = default_plan(root_value, scan);
     // A plan with no bindings would render an empty `[target_bindings]` and index nothing — a
     // useless config. `init -y` can reach this when every detected language drops to a dependency
     // tree (e.g. Python whose only `.py` live under a virtualenv); the interactive path already
@@ -54,130 +69,198 @@ pub(crate) fn run(args: &crate::cli::InitArgs, config_path: &str) -> anyhow::Res
     eprintln!("init: complete");
     Ok(())
 }
-pub(crate) fn prompt_plan(
-    root: PathBuf,
-    root_value: String,
-    scan: &RepoScan,
-) -> anyhow::Result<InitPlan> {
-    println!("Repository root: {}", root.display());
-    println!();
-    println!("Detected languages:");
-    print_language_summary(scan);
-    println!();
 
-    let language_items = supported_languages()
-        .iter()
-        .map(|language| {
-            let count = scan.language_counts.get(language).copied().unwrap_or_default();
-            format!("{} ({count} files)", language.as_str())
-        })
-        .collect::<Vec<_>>();
-    let defaults = supported_languages()
-        .iter()
-        .map(|language| scan.language_counts.get(language).copied().unwrap_or_default() > 0)
-        .collect::<Vec<_>>();
-    let selected = MultiSelect::new()
-        .with_prompt("Select languages to index")
-        .items(&language_items)
-        .defaults(&defaults)
-        .interact()?;
-    let languages =
-        selected.into_iter().map(|index| supported_languages()[index]).collect::<Vec<_>>();
-    if languages.is_empty() {
-        anyhow::bail!("init needs at least one selected language");
+/// The interactive flow: run the full-screen ratatui wizard, then write the TOML it returns and
+/// apply the hook selections.
+///
+/// `existing` reconfigure: when a `rag-rat.toml` is already present we load it (and keep its raw
+/// text) so the wizard renders a preserving patch / diff; otherwise it is a fresh init. The model
+/// is downloaded in-wizard (the Embedding step's verify probe), so the post-write reconcile is
+/// fast.
+fn run_interactive(options: &InitOptions) -> anyhow::Result<()> {
+    let existing = load_existing_for_wizard(options)?;
+    let scan_root = interactive_scan_root(Some(&existing))?;
+    let scan = scan_repo(&scan_root)?;
+
+    let Some(result) =
+        wizard::run_wizard(scan, existing.config, &options.config_path, scan_root.clone())?
+    else {
+        // The user quit the wizard — write nothing.
+        eprintln!("init: cancelled");
+        return Ok(());
+    };
+
+    if options.dry_run {
+        println!("{}", result.toml);
+        return Ok(());
     }
 
-    let mut bindings = BTreeMap::new();
-    for language in &languages {
-        let candidates = candidate_dirs(scan, *language);
-        if candidates.is_empty() {
-            bindings.insert(*language, vec![PathBuf::from(".")]);
-            continue;
-        }
-        println!();
-        println!("Candidate paths for {}:", language.as_str());
-        let items = candidates
-            .iter()
-            .map(|candidate| {
-                format!("{} ({} files)", display_rel(&candidate.path), candidate.count)
-            })
-            .collect::<Vec<_>>();
-        let defaults = candidates.iter().map(|candidate| candidate.default).collect::<Vec<_>>();
-        let selected = MultiSelect::new()
-            .with_prompt(format!("Select {} roots", language.as_str()))
-            .items(&items)
-            .defaults(&defaults)
-            .interact()?;
-        let dirs: Vec<_> =
-            selected.into_iter().map(|index| candidates[index].path.clone()).collect();
-        if dirs.is_empty() {
-            // No roots selected — drop the language (don't bind it), matching the non-interactive
-            // plan which omits a language with no safe default (e.g. env-only Python, whose
-            // candidates are all dependency trees and so default to none). Bailing here would make
-            // accepting the offered defaults fail for exactly that case (#181 review).
-            continue;
-        }
-        bindings.insert(*language, dirs);
+    if let Some(parent) = options.config_path.parent().filter(|path| !path.as_os_str().is_empty()) {
+        fs::create_dir_all(parent)?;
     }
-    // Keep `languages` consistent with the bindings actually chosen (a dropped language must not
-    // linger and make `render_config` emit an empty list).
-    let languages = languages
-        .into_iter()
-        .filter(|language| bindings.contains_key(language))
-        .collect::<Vec<_>>();
-    if bindings.is_empty() {
-        anyhow::bail!("init needs at least one selected root to index");
-    }
+    fs::write(&options.config_path, &result.toml)?;
+    eprintln!("init: wrote {}", options.config_path.display());
 
-    let backend = prompt_backend(scan)?;
-    let oracle_auto_run = prompt_oracle_auto_run()?;
-    Ok(InitPlan { root_value, languages, bindings, backend, oracle_auto_run })
+    let config = Config::load(&options.config_path)?;
+    apply_embedding_runtime_env(&config.llm.embedding.runtime);
+    let db = setup_index(&config)?;
+    setup_model_and_reconcile(&config, &db, false)?;
+    // `false` = prompt the user — the wizard didn't cover MCP install, so ask after completing.
+    offer_mcp_install(&config, &options.config_path, false)?;
+    apply_wizard_hooks(&config, &result)?;
+    eprintln!("init: complete");
+    Ok(())
 }
 
-/// Offer the opt-in background oracle. Default NO: it needs a language tool (e.g. rust-analyzer) on
-/// PATH and spends CPU on a throttled SCIP pass, so it should be a deliberate choice. Writing
-/// `auto_run = false` either way keeps the knob visible in the generated config.
-pub(crate) fn prompt_oracle_auto_run() -> anyhow::Result<bool> {
-    println!();
-    println!(
-        "Compiler-grade ranking: a background pass can refresh SCIP-based importance ranking as \
-         the"
-    );
-    println!(
-        "repo changes (needs a language tool such as rust-analyzer on PATH; runs only in the MCP"
-    );
-    println!("server, heavily throttled). You can flip `[oracle] auto_run` later.");
-    Ok(Confirm::new()
-        .with_prompt("Enable background compiler-grade ranking refresh?")
-        .default(false)
-        .interact()?)
+struct ExistingWizardConfig {
+    config: Option<(String, Config)>,
+    local_root: Option<PathBuf>,
 }
-pub(crate) fn prompt_backend(scan: &RepoScan) -> anyhow::Result<EmbeddingBackend> {
-    let estimate = estimated_chunks(scan.total_source_bytes);
-    let recommended = recommend_backend(estimate);
-    println!();
-    println!(
-        "Embedding backend (≈{estimate} chunks from {} of source):",
-        human_bytes(scan.total_source_bytes)
-    );
-    println!("  recommended: {}", backend_label(recommended));
-    let choices =
-        [EmbeddingBackend::fast_embed(), EmbeddingBackend::model2vec(), EmbeddingBackend::NONE];
-    let default_index = choices.iter().position(|backend| *backend == recommended).unwrap_or(0);
-    let items = choices.iter().map(|backend| backend_label(*backend)).collect::<Vec<_>>();
-    let selected = Select::new()
-        .with_prompt("Select embedding backend")
-        .items(&items)
-        .default(default_index)
-        .interact()?;
-    Ok(choices[selected])
+
+fn load_existing_for_wizard(options: &InitOptions) -> anyhow::Result<ExistingWizardConfig> {
+    if !options.config_path.exists() || options.force {
+        return Ok(ExistingWizardConfig { config: None, local_root: None });
+    }
+
+    let raw = fs::read_to_string(&options.config_path)?;
+    let local_root = local_config_root_from_raw(&raw, &options.config_path)?;
+    let config = match Config::load(&options.config_path) {
+        Ok(config) => Some((raw, config)),
+        Err(err) => {
+            eprintln!(
+                "init: existing config {} could not be loaded ({err}); starting from a fresh draft",
+                options.config_path.display()
+            );
+            None
+        },
+    };
+    Ok(ExistingWizardConfig { config, local_root })
 }
-pub(crate) fn human_bytes(bytes: u64) -> String {
-    if bytes >= 1 << 20 {
-        format!("{:.1} MB", bytes as f64 / (1u64 << 20) as f64)
+
+fn interactive_scan_root(existing: Option<&ExistingWizardConfig>) -> anyhow::Result<PathBuf> {
+    if let Some(root) = existing.and_then(|existing| existing.local_root.clone()) {
+        return Ok(root);
+    }
+    if let Some((_, config)) = existing.and_then(|existing| existing.config.as_ref()) {
+        return Ok(config.root.clone());
+    }
+    Ok(env::current_dir()?.canonicalize()?)
+}
+
+fn local_config_root_from_raw(raw: &str, config_path: &Path) -> anyhow::Result<Option<PathBuf>> {
+    let Ok(doc) = raw.parse::<toml_edit::DocumentMut>() else {
+        return Ok(None);
+    };
+    let Some(root) = doc
+        .get("index")
+        .and_then(|item| item.as_table_like())
+        .and_then(|table| table.get("root"))
+        .and_then(|item| item.as_str())
+    else {
+        return Ok(None);
+    };
+    let root_path = Path::new(root);
+    let candidate = if root_path.is_absolute() {
+        root_path.to_path_buf()
     } else {
-        format!("{:.0} KB", bytes as f64 / 1024.0)
+        config_dir(config_path)?.join(root_path)
+    };
+    match candidate.canonicalize() {
+        Ok(path) => Ok(Some(path)),
+        Err(_) => Ok(None),
     }
+}
+
+fn config_dir(config_path: &Path) -> anyhow::Result<PathBuf> {
+    let parent = config_path.parent().filter(|path| !path.as_os_str().is_empty());
+    let dir = match (config_path.is_absolute(), parent) {
+        (true, Some(parent)) => parent.to_path_buf(),
+        (true, None) => PathBuf::from("/"),
+        (false, Some(parent)) => env::current_dir()?.join(parent),
+        (false, None) => env::current_dir()?,
+    };
+    Ok(dir.canonicalize().unwrap_or(dir))
+}
+
+/// Apply the hook selections the wizard returned: git maintenance hooks (honoring each foreign-hook
+/// conflict resolution) and/or the Claude Code AI hooks (project-local or global).
+///
+/// Mirrors the install mechanics the `hooks` / `claude_hooks` commands use, but driven by the
+/// wizard's `HooksDraft` + per-hook `HookConflict` map instead of re-prompting.
+fn apply_wizard_hooks(config: &Config, result: &WizardResult) -> anyhow::Result<()> {
+    if result.hooks.git {
+        apply_git_hooks(config, &result.hook_conflicts)?;
+    }
+    if result.hooks.claude {
+        // The Claude install path is identical to `rag-rat hooks install --claude [--global]`.
+        crate::claude_hooks(config, "install", result.hooks.claude_global)?;
+    }
+    Ok(())
+}
+
+/// Install the rag-rat git maintenance hooks per the wizard's foreign-hook conflict resolutions.
+///
+/// For each managed hook: a clean slot (or one already managed by rag-rat) installs normally; a
+/// foreign file is resolved by the user's [`HookConflict`] choice — `Skip` leaves it, `Overwrite`
+/// replaces it, `Chain` wraps it via [`render_chained_hook`], `UninstallRagRatOnly` is a no-op for
+/// a foreign file, and `Abort` skips all hook changes.
+fn apply_git_hooks(
+    config: &Config,
+    conflicts: &std::collections::HashMap<&'static str, HookConflict>,
+) -> anyhow::Result<()> {
+    let git = match git_paths(&config.root) {
+        Ok(git) => git,
+        Err(err) => {
+            eprintln!("init: skipped git hooks (not a git worktree: {err})");
+            return Ok(());
+        },
+    };
+    // `Abort` on any resolved conflict means "don't touch hooks at all".
+    if conflicts.values().any(|c| *c == HookConflict::Abort) {
+        eprintln!("init: skipped git hooks (conflict aborted)");
+        return Ok(());
+    }
+    fs::create_dir_all(&git.hooks_dir)?;
+    let mut installed = Vec::new();
+    for &hook in crate::MANAGED_HOOKS {
+        let path = git.hooks_dir.join(hook);
+        let foreign = path.exists() && !is_rag_rat_hook(&path)?;
+        match conflicts.get(hook).copied() {
+            // A foreign file with an explicit resolution.
+            Some(HookConflict::Skip) | Some(HookConflict::UninstallRagRatOnly) => {
+                // Leave the foreign hook in place; install nothing for this slot.
+            },
+            Some(HookConflict::Overwrite) => {
+                write_atomic(&path, hook_script(hook).as_bytes())?;
+                make_executable(&path)?;
+                installed.push(hook);
+            },
+            Some(HookConflict::Chain) => {
+                let original = fs::read_to_string(&path).unwrap_or_default();
+                write_atomic(&path, render_chained_hook(&original, hook).as_bytes())?;
+                make_executable(&path)?;
+                installed.push(hook);
+            },
+            Some(HookConflict::Abort) => unreachable!("handled above"),
+            // No conflict recorded: a clean slot, or one already managed by rag-rat.
+            None => {
+                if foreign {
+                    // A foreign file with no resolution should have been caught by the wizard's
+                    // unresolved-conflict gate; be conservative and leave it untouched.
+                    eprintln!(
+                        "init: leaving unmanaged hook {} in place (no resolution recorded)",
+                        path.display()
+                    );
+                } else {
+                    // `install_hook` is safe here: the slot is empty or already a rag-rat hook.
+                    install_hook(&git.hooks_dir, hook)?;
+                    installed.push(hook);
+                }
+            },
+        }
+    }
+    eprintln!("init: installed git hooks in {} ({:?})", git.hooks_dir.display(), installed);
+    Ok(())
 }
 pub(crate) fn default_plan(root_value: String, scan: &RepoScan) -> InitPlan {
     let languages = supported_languages()
@@ -400,6 +483,88 @@ mod default_plan_tests {
     use std::path::Path;
 
     use super::*;
+
+    #[test]
+    fn wizard_git_hook_install_skips_non_git_roots() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("src")).unwrap();
+        std::fs::write(root.path().join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        let config_path = root.path().join("rag-rat.toml");
+        std::fs::write(
+            &config_path,
+            "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n",
+        )
+        .unwrap();
+        let config = Config::load(&config_path).unwrap();
+
+        apply_git_hooks(&config, &std::collections::HashMap::new()).unwrap();
+
+        assert!(!root.path().join(".git/hooks").exists());
+    }
+
+    #[test]
+    fn interactive_reconfigure_scans_configured_root() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("src")).unwrap();
+        let config_path = root.path().join("rag-rat.toml");
+        std::fs::write(
+            &config_path,
+            "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n",
+        )
+        .unwrap();
+        let options = InitOptions {
+            yes: false,
+            dry_run: false,
+            force: false,
+            config_path: config_path.clone(),
+        };
+        let existing = load_existing_for_wizard(&options).unwrap();
+
+        assert_eq!(
+            interactive_scan_root(Some(&existing)).unwrap(),
+            root.path().canonicalize().unwrap()
+        );
+        assert!(existing.config.is_some());
+    }
+
+    #[test]
+    fn local_config_root_resolves_relative_to_config_dir() {
+        let root = tempfile::tempdir().unwrap();
+        let config_dir = root.path().join("linked");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        let config_path = config_dir.join("rag-rat.toml");
+        let raw = "[index]\nroot = \".\"\n";
+
+        assert_eq!(
+            local_config_root_from_raw(raw, &config_path).unwrap(),
+            Some(config_dir.canonicalize().unwrap())
+        );
+    }
+
+    #[test]
+    fn invalid_existing_config_falls_back_to_fresh_draft() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("src")).unwrap();
+        let config_path = root.path().join("rag-rat.toml");
+        std::fs::write(
+            &config_path,
+            "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n\
+             [llm.embedding]\nmodel = \"none\"\n[llm.embedding.remote]\nmodel = \
+             \"all-minilm\"\nendpoint = \"http://localhost:11434\"\n",
+        )
+        .unwrap();
+        let options = InitOptions {
+            yes: false,
+            dry_run: false,
+            force: false,
+            config_path: config_path.clone(),
+        };
+
+        let existing = load_existing_for_wizard(&options).unwrap();
+
+        assert!(existing.config.is_none());
+        assert_eq!(existing.local_root, Some(root.path().canonicalize().unwrap()));
+    }
 
     /// #181: a repo whose only `.py` files live under a dependency tree must NOT get
     /// `python = ["."]` — `default_plan` carries the no-safe-default state through by omitting the

--- a/crates/rag-rat-cli/src/init/scan.rs
+++ b/crates/rag-rat-cli/src/init/scan.rs
@@ -143,6 +143,9 @@ pub(crate) fn candidate_dirs(scan: &RepoScan, language: Language) -> Vec<DirCand
     let Some(counts) = scan.dir_counts.get(&language) else {
         return Vec::new();
     };
+    // `dir_counts` is populated only by `scan_dir`, whose walk already applies the shared
+    // IgnoreMatcher and skips the hard floor. Do not rebuild that matcher here on every render; the
+    // candidate set is derived from the filtered scan.
     let mut candidates = counts
         .iter()
         .filter(|(path, _)| path_depth(path) <= 4)
@@ -275,14 +278,6 @@ pub(crate) fn directly_contains_source(scan: &RepoScan, language: Language, path
 }
 pub(crate) fn path_depth(path: &Path) -> usize {
     if path == Path::new(".") { 0 } else { path.components().count() }
-}
-pub(crate) fn print_language_summary(scan: &RepoScan) {
-    for language in supported_languages() {
-        let count = scan.language_counts.get(&language).copied().unwrap_or_default();
-        if count > 0 {
-            println!("  {}: {count} files", language.as_str());
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/rag-rat-cli/src/init/wizard/catalog.rs
+++ b/crates/rag-rat-cli/src/init/wizard/catalog.rs
@@ -1,0 +1,184 @@
+//! Repo-local init wizard catalogs.
+//!
+//! These entries drive selector UX only. Runtime still persists and consumes plain
+//! `[llm.embedding.remote] cookbook` / `gpu` strings.
+
+use toml_edit::{DocumentMut, Item, TableLike};
+
+use super::draft::{MODAL_GPUS, RUNPOD_GPUS};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CookbookEntry {
+    pub key: String,
+    pub label: String,
+    pub command: String,
+    pub gpus: Vec<String>,
+}
+
+impl CookbookEntry {
+    fn builtin(key: &str, label: &str, command: &str, gpus: &[&str]) -> Self {
+        Self {
+            key: key.to_string(),
+            label: label.to_string(),
+            command: command.to_string(),
+            gpus: gpus.iter().map(|gpu| (*gpu).to_string()).collect(),
+        }
+    }
+
+    pub(crate) fn custom_current(command: &str, gpu: Option<&str>) -> Self {
+        Self {
+            key: "custom".to_string(),
+            label: format!("Custom: {command}"),
+            command: command.to_string(),
+            gpus: gpu.into_iter().map(str::to_string).collect(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CookbookCatalog {
+    entries: Vec<CookbookEntry>,
+}
+
+impl Default for CookbookCatalog {
+    fn default() -> Self {
+        Self::builtins()
+    }
+}
+
+impl CookbookCatalog {
+    pub(crate) fn builtins() -> Self {
+        Self {
+            entries: vec![
+                CookbookEntry::builtin("modal", "Modal", "@rag-rat/cookbook modal", MODAL_GPUS),
+                CookbookEntry::builtin("runpod", "RunPod", "@rag-rat/cookbook runpod", RUNPOD_GPUS),
+            ],
+        }
+    }
+
+    pub(crate) fn from_raw(raw: &str) -> Self {
+        let Ok(doc) = raw.parse::<DocumentMut>() else {
+            return Self::builtins();
+        };
+        Self::from_doc(&doc)
+    }
+
+    pub(crate) fn from_doc(doc: &DocumentMut) -> Self {
+        let mut catalog = Self::builtins();
+        let Some(cookbooks) = doc
+            .get("init")
+            .and_then(Item::as_table_like)
+            .and_then(|init| init.get("cookbooks"))
+            .and_then(Item::as_table_like)
+        else {
+            return catalog;
+        };
+
+        for (key, item) in cookbooks.iter() {
+            let Some(table) = item.as_table_like() else {
+                continue;
+            };
+            catalog.merge_entry(key, table);
+        }
+        catalog
+    }
+
+    pub(crate) fn entries(&self) -> &[CookbookEntry] {
+        &self.entries
+    }
+
+    pub(crate) fn find_command(&self, command: &str) -> Option<usize> {
+        let command = command.trim();
+        self.entries.iter().position(|entry| entry.command == command)
+    }
+
+    fn merge_entry(&mut self, key: &str, table: &dyn TableLike) {
+        let existing = self.entries.iter().position(|entry| entry.key == key);
+        let base = existing.and_then(|index| self.entries.get(index).cloned());
+        let command = string_value(table, "command")
+            .filter(|command| !command.trim().is_empty())
+            .or_else(|| base.as_ref().map(|entry| entry.command.clone()));
+        let Some(command) = command else {
+            return;
+        };
+        let label = string_value(table, "label")
+            .filter(|label| !label.trim().is_empty())
+            .or_else(|| base.as_ref().map(|entry| entry.label.clone()))
+            .unwrap_or_else(|| key.to_string());
+        let gpus = string_array(table, "gpus")
+            .or_else(|| base.as_ref().map(|entry| entry.gpus.clone()))
+            .unwrap_or_default();
+        let entry = CookbookEntry { key: key.to_string(), label, command, gpus };
+        if let Some(index) = existing {
+            self.entries[index] = entry;
+        } else {
+            self.entries.push(entry);
+        }
+    }
+}
+
+fn string_value(table: &dyn TableLike, key: &str) -> Option<String> {
+    table.get(key)?.as_str().map(|value| value.trim().to_string())
+}
+
+fn string_array(table: &dyn TableLike, key: &str) -> Option<Vec<String>> {
+    let array = table.get(key)?.as_array()?;
+    Some(
+        array
+            .iter()
+            .filter_map(|value| value.as_str().map(str::trim))
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repo_catalog_extends_builtins_with_custom_cookbook() {
+        let catalog = CookbookCatalog::from_raw(
+            r#"
+            [init.cookbooks.acme]
+            label = "Acme GPU"
+            command = "./recipes/acme.mjs --pool small"
+            gpus = ["a10-small", "h100-large"]
+            "#,
+        );
+
+        assert_eq!(catalog.entries()[0].key, "modal");
+        let acme = catalog.entries().iter().find(|entry| entry.key == "acme").unwrap();
+        assert_eq!(acme.label, "Acme GPU");
+        assert_eq!(acme.command, "./recipes/acme.mjs --pool small");
+        assert_eq!(acme.gpus, ["a10-small", "h100-large"]);
+    }
+
+    #[test]
+    fn repo_catalog_overrides_builtin_gpu_list_without_repeating_command() {
+        let catalog = CookbookCatalog::from_raw(
+            r#"
+            [init.cookbooks.modal]
+            gpus = ["L4", "H200"]
+            "#,
+        );
+
+        let modal = catalog.entries().iter().find(|entry| entry.key == "modal").unwrap();
+        assert_eq!(modal.command, "@rag-rat/cookbook modal");
+        assert_eq!(modal.gpus, ["L4", "H200"]);
+    }
+
+    #[test]
+    fn repo_catalog_ignores_custom_entries_without_commands() {
+        let catalog = CookbookCatalog::from_raw(
+            r#"
+            [init.cookbooks.empty]
+            label = "No command"
+            gpus = ["A100"]
+            "#,
+        );
+
+        assert!(catalog.entries().iter().all(|entry| entry.key != "empty"));
+    }
+}

--- a/crates/rag-rat-cli/src/init/wizard/draft.rs
+++ b/crates/rag-rat-cli/src/init/wizard/draft.rs
@@ -1,0 +1,897 @@
+//! `WizardDraft` — the persistable model for the init wizard.
+//!
+//! This is the ONLY thing that renders to TOML. UI-only state (focused step, scroll, help
+//! visibility) lives in `WizardUiState` (see `state.rs`) and never leaks in here.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use rag_rat_core::config::{
+    Config, EmbeddingBackend, OracleConfig, RemoteEmbeddingConfig, VersionCheckConfig,
+};
+use rag_rat_core::language::Language;
+use toml_edit::{Array, DocumentMut, Item, Table};
+
+use crate::init::render::{config_root_value, display_rel, render_config};
+use crate::init::scan::{candidate_dirs, estimated_chunks, recommend_backend};
+use crate::init::{DEFAULT_DATABASE, InitPlan, RepoScan};
+
+/// The embedding remote connection mode, derived from `RemoteEmbeddingConfig`.
+///
+/// CONNECT: an already-running Ollama endpoint (the `endpoint` field was set).
+/// EPHEMERAL: provision an on-demand box via a cookbook recipe (the `cookbook` field was set).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum RemoteMode {
+    Connect(String),
+    Ephemeral(String),
+}
+
+/// The remote-embedding draft block — mirrors `RemoteEmbeddingConfig` with the mode explicit.
+#[derive(Clone, Debug)]
+pub(crate) struct RemoteDraft {
+    /// The Ollama API model name (e.g. `"all-minilm"`).
+    pub model: String,
+    /// CONNECT (existing Ollama endpoint) or EPHEMERAL (cookbook recipe).
+    pub mode: RemoteMode,
+    /// EPHEMERAL-only: GPU to provision (provider-specific value).
+    pub gpu: Option<String>,
+    /// Optional Ollama context window for `/api/embed` requests.
+    pub num_ctx: Option<u32>,
+    /// How many texts per `/api/embed` request.
+    pub batch_size: u32,
+    /// Name of the env-var holding the bearer token, if auth is needed.
+    pub auth_env: Option<String>,
+}
+
+// ── Cookbook + GPU constants ────────────────────────────────────────────────────
+
+/// GPUs available when provisioning via Modal.
+pub(crate) const MODAL_GPUS: &[&str] = &[
+    "T4",
+    "L4",
+    "A10",
+    "L40S",
+    "A100",
+    "A100-40GB",
+    "A100-80GB",
+    "RTX-PRO-6000",
+    "H100",
+    "H100!",
+    "H200",
+    "B200",
+    "B200+",
+];
+
+/// Current RunPod `gpuTypeId` values that are suitable for the NVIDIA Ollama image.
+pub(crate) const RUNPOD_GPUS: &[&str] = &[
+    "NVIDIA RTX A4000",
+    "NVIDIA RTX A4500",
+    "NVIDIA RTX A5000",
+    "NVIDIA RTX A6000",
+    "NVIDIA RTX 2000 Ada Generation",
+    "NVIDIA RTX 4000 Ada Generation",
+    "NVIDIA RTX 4000 SFF Ada Generation",
+    "NVIDIA RTX 5000 Ada Generation",
+    "NVIDIA RTX 6000 Ada Generation",
+    "NVIDIA RTX PRO 4000 Blackwell",
+    "NVIDIA RTX PRO 4500 Blackwell",
+    "NVIDIA RTX PRO 5000 Blackwell",
+    "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition",
+    "NVIDIA RTX PRO 6000 Blackwell Server Edition",
+    "NVIDIA RTX PRO 6000 Blackwell Workstation Edition",
+    "NVIDIA GeForce RTX 3090",
+    "NVIDIA GeForce RTX 4080",
+    "NVIDIA GeForce RTX 4080 SUPER",
+    "NVIDIA GeForce RTX 4090",
+    "NVIDIA GeForce RTX 5080",
+    "NVIDIA GeForce RTX 5090",
+    "NVIDIA L4",
+    "NVIDIA L40",
+    "NVIDIA L40S",
+    "NVIDIA A40",
+    "NVIDIA A100 80GB PCIe",
+    "NVIDIA A100-SXM4-40GB",
+    "NVIDIA A100-SXM4-80GB",
+    "NVIDIA H100 PCIe",
+    "NVIDIA H100 80GB HBM3",
+    "NVIDIA H100 NVL",
+    "NVIDIA H200",
+    "NVIDIA H200 NVL",
+    "NVIDIA B200",
+    "NVIDIA B300 SXM6 AC",
+    "Tesla V100-PCIE-16GB",
+    "Tesla V100-SXM2-16GB",
+];
+
+/// Common Ollama server-side embedding model names, with their dimension and size.
+/// These are all real, pullable models on Ollama Hub (verified June 2026).
+pub(crate) const OLLAMA_EMBEDDING_MODELS: &[&str] = &[
+    "all-minilm",                         // 384-dim · 46MB  — all-MiniLM-L6-v2
+    "qllama/bge-small-en-v1.5:f16",       // 384-dim · 68MB  — BGE-small exact family
+    "ordis/jina-embeddings-v2-base-code", // 768-dim · 323MB — Jina code exact family
+    "nomic-embed-text",                   // 768-dim · 274MB — general 768d alternative
+    "mxbai-embed-large",                  // 1024-dim · 670MB — best English retrieval
+    "bge-m3",                             // 1024-dim · 1.2GB — multilingual hybrid
+    "snowflake-arctic-embed2",            // 1024-dim · 1.2GB — highest throughput
+    "qwen3-embedding:0.6b",               // 1024-dim · 639MB — best quality/size ratio
+];
+
+/// Known output dimension for curated Ollama embedding models.
+pub(crate) fn ollama_model_dim(model: &str) -> Option<usize> {
+    match model {
+        "all-minilm" | "qllama/bge-small-en-v1.5:f16" => Some(384),
+        "ordis/jina-embeddings-v2-base-code" | "nomic-embed-text" => Some(768),
+        "mxbai-embed-large" | "bge-m3" | "snowflake-arctic-embed2" | "qwen3-embedding:0.6b" =>
+            Some(1024),
+        _ => None,
+    }
+}
+
+/// Best-effort mapping from the local embedding model_id to a commonly-available
+/// Ollama model name. Returns `None` for selectors the wizard cannot serve remotely.
+pub(crate) fn ollama_model_for(embedding_model_id: &str) -> Option<&'static str> {
+    match embedding_model_id {
+        // Prefer same-family Ollama builds; dimension-only alternatives stay selectable manually.
+        "sentence-transformers/all-MiniLM-L6-v2" => Some("all-minilm"),
+        "BAAI/bge-small-en-v1.5" => Some("qllama/bge-small-en-v1.5:f16"),
+        "jinaai/jina-embeddings-v2-base-code" => Some("ordis/jina-embeddings-v2-base-code"),
+        _ => None,
+    }
+}
+
+/// Hook installation selections.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct HooksDraft {
+    /// Whether to install the rag-rat git maintenance hooks (post-checkout/merge/rewrite/commit).
+    pub git: bool,
+    /// Whether to install the Claude Code AI hooks (`.claude/settings.json`).
+    pub claude: bool,
+    /// Whether to install the Claude Code hooks in the global settings (vs project-local).
+    pub claude_global: bool,
+}
+
+/// The persistable wizard model — the only thing that renders to `rag-rat.toml`.
+///
+/// Built either from a fresh `RepoScan` (`from_scan`) or by loading an existing `Config`
+/// (`from_config`). The writer reads ONLY this struct; no UI concept leaks in here.
+#[derive(Clone, Debug)]
+pub(crate) struct WizardDraft {
+    /// The `[index] root` value (a relative path such as `"."` or `".."`).
+    ///
+    /// ALWAYS a relative path — exactly what gets written to `[index] root` in the TOML.
+    /// Use `config_root_value` to derive this from an absolute root + config path.
+    pub root_value: String,
+    /// Resolved absolute repo root, for dir-existence validation; NOT serialized — only
+    /// `root_value` renders to TOML.
+    pub root_abs: PathBuf,
+    /// The `[index] database` value.
+    ///
+    /// Captured from the existing config (reconfigure) so a future Database step can surface/edit
+    /// it, but NOT yet emitted: `write_fresh` uses `DEFAULT_DATABASE` and `patch_existing` only
+    /// touches `[index] root` (toml_edit preserves any existing `database` key untouched).
+    /// Reserved seam — keep the narrow allow until a step writes it back.
+    #[allow(dead_code)]
+    pub db_path: String,
+    /// Per-language directory bindings (`[target_bindings]`).
+    pub bindings: BTreeMap<Language, Vec<PathBuf>>,
+    /// Whether the original TOML contains rich `[[target]]` blocks that the wizard preserves but
+    /// does not edit through `[target_bindings]`.
+    pub has_rich_targets: bool,
+    /// Names from preserved rich `[[target]]` blocks. Simple target bindings generate target
+    /// names from `Language::as_str()`, so the wizard must block collisions before writing.
+    pub rich_target_names: BTreeSet<String>,
+    /// The embedding model selector (`[llm.embedding] model`).
+    pub model: String,
+    /// Optional remote-embedding block (`[llm.embedding.remote]`); `None` → in-process only.
+    pub remote: Option<RemoteDraft>,
+    /// `[oracle] auto_run`.
+    pub oracle_auto_run: bool,
+    /// `[oracle] auto_run_quiet_period_secs`. Captured from config but not yet edited/emitted (the
+    /// Oracle step owns only `auto_run`; the interval knobs stay as `render_config` commented
+    /// defaults). Reserved seam — see the module doc on `oracle.rs`.
+    #[allow(dead_code)]
+    pub oracle_quiet_secs: u64,
+    /// `[oracle] auto_run_min_interval_secs`. Reserved seam alongside `oracle_quiet_secs`.
+    #[allow(dead_code)]
+    pub oracle_min_interval_secs: u64,
+    /// `[version_check] enabled`.
+    pub version_check: bool,
+    /// Hook installation selections (Task 16 fills `git`/`claude` from current hook status).
+    pub hooks: HooksDraft,
+}
+
+impl WizardDraft {
+    /// Build a fresh draft from a `RepoScan`, mirroring `init::run::default_plan` logic:
+    ///
+    /// - Languages: those with a non-zero file count in `scan`.
+    /// - Directories: the default-flagged candidates from `candidate_dirs`.
+    /// - Embedding backend: `recommend_backend` based on estimated chunk count.
+    /// - Oracle: off (must be opted in explicitly).
+    /// - Version check: on (the default).
+    /// - Hooks: all false (Task 16 fills in actual installed status).
+    ///
+    /// `root_value` is the relative `[index] root` string (e.g. `"."`) already computed by the
+    /// caller. `root_abs` is the absolute canonical repo root used for dir-existence validation.
+    pub(crate) fn from_scan(scan: &RepoScan, root_value: String, root_abs: PathBuf) -> Self {
+        let mut bindings: BTreeMap<Language, Vec<PathBuf>> = BTreeMap::new();
+
+        for &lang in Language::all() {
+            if scan.language_counts().get(&lang).copied().unwrap_or(0) == 0 {
+                continue;
+            }
+            let candidates = candidate_dirs(scan, lang);
+            let defaults: Vec<PathBuf> =
+                candidates.iter().filter(|c| c.default).map(|c| c.path.clone()).collect();
+
+            // Python env-only repo: no safe default → omit the binding entirely (matches
+            // default_plan's behaviour — `candidate_dirs` deliberately refuses to promote `.`
+            // over a dependency tree).
+            if lang == Language::Python && !candidates.is_empty() && defaults.is_empty() {
+                continue;
+            }
+
+            let dirs = if defaults.is_empty() {
+                // Non-Python with no default candidate: fall back to "." (index everything).
+                vec![PathBuf::from(".")]
+            } else {
+                defaults
+            };
+            bindings.insert(lang, dirs);
+        }
+
+        let backend = recommend_backend(estimated_chunks(scan.total_source_bytes()));
+        let oracle = OracleConfig::default();
+
+        Self {
+            root_value,
+            root_abs,
+            db_path: DEFAULT_DATABASE.to_string(),
+            bindings,
+            has_rich_targets: false,
+            rich_target_names: BTreeSet::new(),
+            model: backend.as_str().to_string(),
+            remote: None,
+            oracle_auto_run: false,
+            oracle_quiet_secs: oracle.auto_run_quiet_period_secs,
+            oracle_min_interval_secs: oracle.auto_run_min_interval_secs,
+            version_check: VersionCheckConfig::default().enabled,
+            hooks: HooksDraft::default(),
+        }
+    }
+
+    /// Build a draft from an existing `Config` (the reconfigure path).
+    ///
+    /// `config_path` is the path to the `rag-rat.toml` file being reconfigured; it is used to
+    /// derive the relative `[index] root` value (via `config_root_value`) so `root_value` is
+    /// always a relative path, never an absolute one.
+    ///
+    /// Field mappings:
+    /// - `cfg.targets` grouped by `ResolvedTarget.language` → `bindings`; directories merged in
+    ///   declaration order (stable — `Config` preserves the TOML `targets` order).
+    /// - `cfg.llm.embedding.backend.as_str()` → `model`.
+    /// - `cfg.llm.embedding.remote` → `remote` (`endpoint` → `RemoteMode::Connect`, `cookbook` →
+    ///   `RemoteMode::Ephemeral`).
+    /// - `cfg.oracle.*` → oracle fields.
+    /// - `cfg.version_check.enabled` → `version_check`.
+    /// - Hook status: Task 16 fills `git`/`claude`; defaulted to `false` here.
+    pub(crate) fn from_config(cfg: &Config, config_path: &std::path::Path) -> Self {
+        // Group target directories by language. Config preserves TOML order; BTreeMap gives a
+        // stable language-sorted order for the wizard display.
+        let mut bindings: BTreeMap<Language, Vec<PathBuf>> = BTreeMap::new();
+        for target in &cfg.targets {
+            bindings.entry(target.language).or_default().extend(target.directories.iter().cloned());
+        }
+
+        let remote = cfg.llm.embedding.remote.as_ref().map(remote_draft_from_config);
+        let oracle = &cfg.oracle;
+
+        Self {
+            // Derive the relative `[index] root` value from the absolute cfg.root + config_path,
+            // so reconfigure never bakes an absolute path into the user's TOML.
+            root_value: config_root_value(&cfg.root, config_path),
+            // cfg.root is the canonical absolute path from Config::load; kept for dir-existence
+            // validation (Directories step) but never written to TOML.
+            root_abs: cfg.root.clone(),
+            db_path: cfg.database.to_string_lossy().into_owned(),
+            bindings,
+            has_rich_targets: false,
+            rich_target_names: BTreeSet::new(),
+            model: cfg.llm.embedding.backend.as_str().to_string(),
+            remote,
+            oracle_auto_run: oracle.auto_run,
+            oracle_quiet_secs: oracle.auto_run_quiet_period_secs,
+            oracle_min_interval_secs: oracle.auto_run_min_interval_secs,
+            version_check: cfg.version_check.enabled,
+            // Task 16 fills git/claude from the current installed hook status.
+            hooks: HooksDraft::default(),
+        }
+    }
+
+    /// Build a reconfigure draft from both the resolved config and the original TOML text.
+    ///
+    /// `Config::load` intentionally resolves rich targets and relative cookbook paths for runtime
+    /// use. The wizard writer owns only `[target_bindings]` and the literal remote fields, so the
+    /// reconfigure path must recover those literals from the raw document before patching.
+    pub(crate) fn from_existing(raw: &str, cfg: &Config, config_path: &std::path::Path) -> Self {
+        let mut draft = Self::from_config(cfg, config_path);
+        let Ok(doc) = raw.parse::<DocumentMut>() else {
+            return draft;
+        };
+        if let Some(root) = raw_root_value(&doc) {
+            draft.root_value = root;
+        }
+        draft.has_rich_targets = has_rich_targets(&doc);
+        draft.rich_target_names = raw_rich_target_names(&doc);
+        draft.bindings = raw_target_bindings(&doc).unwrap_or_default();
+        if let Some(remote) = raw_remote_draft(&doc) {
+            draft.remote = Some(remote);
+        }
+        draft
+    }
+
+    pub(crate) fn conflicting_rich_target_names(&self) -> Vec<String> {
+        self.bindings
+            .keys()
+            .map(|lang| lang.as_str())
+            .filter(|name| self.rich_target_names.contains(*name))
+            .map(ToOwned::to_owned)
+            .collect()
+    }
+
+    /// Build an `InitPlan` from this draft — the bridge to `render_config`.
+    ///
+    /// Language order follows the `BTreeMap` key order (alphabetical by `Language::as_str`), which
+    /// is stable and matches the insertion order the wizard and `from_scan` use.
+    pub(crate) fn to_init_plan(&self) -> InitPlan {
+        let languages: Vec<Language> = self.bindings.keys().copied().collect();
+        let backend =
+            EmbeddingBackend::from_str(&self.model).unwrap_or(EmbeddingBackend::fast_embed());
+        InitPlan {
+            root_value: self.root_value.clone(),
+            languages,
+            bindings: self.bindings.clone(),
+            backend,
+            oracle_auto_run: self.oracle_auto_run,
+        }
+    }
+
+    /// Render a fresh `rag-rat.toml` by starting with the canonical legacy renderer, then applying
+    /// the wizard-owned fields that `InitPlan` cannot carry.
+    pub(crate) fn write_fresh(&self) -> String {
+        let base = render_config(&self.to_init_plan());
+        self.patch_existing(&base).unwrap_or(base)
+    }
+
+    /// Patch an existing `rag-rat.toml` in place, preserving all comments and unknown tables.
+    ///
+    /// Only wizard-owned keys are touched:
+    /// - `[index] root`
+    /// - `[target_bindings]` (rebuilt from `self.bindings`)
+    /// - `[llm.embedding] model`
+    /// - `[llm.embedding.remote]` block (set or removed depending on `self.remote`)
+    /// - `[oracle] auto_run`
+    /// - `[version_check] enabled`
+    ///
+    /// All other tables, keys, and comments are left intact.
+    pub(crate) fn patch_existing(&self, original: &str) -> anyhow::Result<String> {
+        let mut doc: DocumentMut = original.parse()?;
+
+        // [index] root
+        doc["index"]["root"] = toml_edit::value(self.root_value.clone());
+
+        // [target_bindings] — rebuild from scratch (wipes old bindings for owned languages, but
+        // leaves any unknown keys inside [target_bindings] by only inserting/overwriting our own).
+        // The simpler and correct approach for wizard ownership: replace the whole table's entries
+        // for languages we own, and leave any others alone. Since the wizard owns ALL languages we
+        // know about, we replace the whole table to match the canonical output.
+        {
+            let tb = if self.bindings.is_empty() {
+                doc.get_mut("target_bindings")
+            } else {
+                Some(doc["target_bindings"].or_insert(Item::Table(Table::new())))
+            };
+            if let Some(tb) = tb {
+                if tb.as_table_like_mut().is_none() {
+                    *tb = Item::Table(Table::new());
+                }
+                if let Some(table) = tb.as_table_like_mut() {
+                    // Remove any keys corresponding to languages we now own (to avoid stale
+                    // entries).
+                    for lang in Language::all() {
+                        table.remove(lang.as_str());
+                    }
+                    // Insert the current bindings.
+                    for (lang, paths) in &self.bindings {
+                        let mut arr = Array::new();
+                        for path in paths {
+                            arr.push(display_rel(path));
+                        }
+                        table.insert(lang.as_str(), toml_edit::value(arr));
+                    }
+                }
+            }
+        }
+
+        // [llm.embedding] model
+        doc["llm"]["embedding"]["model"] = toml_edit::value(self.model.clone());
+
+        // [llm.embedding.remote] — set or remove the block.
+        if let Some(remote) = &self.remote {
+            let remote_item =
+                doc["llm"]["embedding"]["remote"].or_insert(Item::Table(Table::new()));
+            if remote_item.as_table_like_mut().is_none() {
+                *remote_item = Item::Table(Table::new());
+            }
+            if let Some(t) = remote_item.as_table_like_mut() {
+                t.insert("model", toml_edit::value(remote.model.clone()));
+                match &remote.mode {
+                    RemoteMode::Connect(ep) => {
+                        t.insert("endpoint", toml_edit::value(ep.clone()));
+                        t.remove("cookbook");
+                    },
+                    RemoteMode::Ephemeral(cb) => {
+                        t.insert("cookbook", toml_edit::value(cb.clone()));
+                        t.remove("endpoint");
+                    },
+                }
+                t.insert("batch_size", toml_edit::value(i64::from(remote.batch_size)));
+                if let Some(gpu) = &remote.gpu {
+                    t.insert("gpu", toml_edit::value(gpu.clone()));
+                } else {
+                    t.remove("gpu");
+                }
+                if let Some(num_ctx) = remote.num_ctx {
+                    t.insert("num_ctx", toml_edit::value(i64::from(num_ctx)));
+                } else {
+                    t.remove("num_ctx");
+                }
+                if let Some(env) = &remote.auth_env {
+                    t.insert("auth_env", toml_edit::value(env.clone()));
+                } else {
+                    t.remove("auth_env");
+                }
+            }
+        } else if let Some(llm_table) = doc["llm"].as_table_like_mut()
+            && let Some(embed_item) = llm_table.get_mut("embedding")
+            && let Some(embed_table) = embed_item.as_table_like_mut()
+        {
+            embed_table.remove("remote");
+        }
+
+        // [oracle] auto_run
+        doc["oracle"]["auto_run"] = toml_edit::value(self.oracle_auto_run);
+
+        // [version_check] enabled
+        doc["version_check"]["enabled"] = toml_edit::value(self.version_check);
+
+        Ok(doc.to_string())
+    }
+}
+
+/// Convert a `RemoteEmbeddingConfig` to a `RemoteDraft`.
+///
+/// The mode is inferred from which field is set — config validation guarantees exactly one of
+/// `endpoint` (Connect) or `cookbook` (Ephemeral) is present.
+fn remote_draft_from_config(r: &RemoteEmbeddingConfig) -> RemoteDraft {
+    let mode = if let Some(ep) = &r.endpoint {
+        RemoteMode::Connect(ep.clone())
+    } else if let Some(cb) = &r.cookbook {
+        RemoteMode::Ephemeral(cb.clone())
+    } else {
+        // Unreachable: config validation requires exactly one of endpoint/cookbook.
+        RemoteMode::Connect(String::new())
+    };
+    RemoteDraft {
+        model: r.model.clone(),
+        mode,
+        gpu: r.gpu.clone(),
+        num_ctx: r.num_ctx,
+        batch_size: r.batch_size,
+        auth_env: r.auth_env.clone(),
+    }
+}
+
+fn raw_target_bindings(doc: &DocumentMut) -> Option<BTreeMap<Language, Vec<PathBuf>>> {
+    let table = doc.get("target_bindings")?.as_table_like()?;
+    let mut bindings = BTreeMap::new();
+    for lang in Language::all() {
+        let Some(array) = table.get(lang.as_str()).and_then(Item::as_array) else {
+            continue;
+        };
+        let paths =
+            array.iter().filter_map(|value| value.as_str().map(PathBuf::from)).collect::<Vec<_>>();
+        if !paths.is_empty() {
+            bindings.insert(*lang, paths);
+        }
+    }
+    Some(bindings)
+}
+
+fn has_rich_targets(doc: &DocumentMut) -> bool {
+    doc.get("target").and_then(Item::as_array_of_tables).is_some_and(|targets| !targets.is_empty())
+}
+
+fn raw_rich_target_names(doc: &DocumentMut) -> BTreeSet<String> {
+    doc.get("target")
+        .and_then(Item::as_array_of_tables)
+        .map(|targets| {
+            targets
+                .iter()
+                .filter_map(|target| target.get("name").and_then(Item::as_str).map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn raw_root_value(doc: &DocumentMut) -> Option<String> {
+    doc.get("index")?.as_table_like()?.get("root")?.as_str().map(ToOwned::to_owned)
+}
+
+fn raw_remote_draft(doc: &DocumentMut) -> Option<RemoteDraft> {
+    let remote = doc
+        .get("llm")?
+        .as_table_like()?
+        .get("embedding")?
+        .as_table_like()?
+        .get("remote")?
+        .as_table_like()?;
+    let string = |key: &str| remote.get(key).and_then(Item::as_str).map(str::to_string);
+    let model = string("model")?;
+    let mode = if let Some(endpoint) = string("endpoint") {
+        RemoteMode::Connect(endpoint)
+    } else if let Some(cookbook) = string("cookbook") {
+        RemoteMode::Ephemeral(cookbook)
+    } else {
+        return None;
+    };
+    let batch_size = remote
+        .get("batch_size")
+        .and_then(Item::as_integer)
+        .and_then(|n| u32::try_from(n).ok())
+        .unwrap_or_else(|| RemoteEmbeddingConfig::default().batch_size);
+    Some(RemoteDraft {
+        model,
+        mode,
+        gpu: string("gpu"),
+        num_ctx: remote
+            .get("num_ctx")
+            .and_then(Item::as_integer)
+            .and_then(|n| u32::try_from(n).ok()),
+        batch_size,
+        auth_env: string("auth_env"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use rag_rat_core::embedding_models::{Backend, EMBEDDING_MODELS};
+
+    use super::*;
+
+    #[test]
+    fn ollama_defaults_cover_remote_capable_models_with_matching_dimensions() {
+        for spec in EMBEDDING_MODELS {
+            let default = ollama_model_for(spec.model_id);
+            if spec.backend == Backend::FastEmbed {
+                let server_model = default.unwrap_or_else(|| {
+                    panic!("missing Ollama default for remote-capable model {}", spec.model_id)
+                });
+                assert!(
+                    OLLAMA_EMBEDDING_MODELS.contains(&server_model),
+                    "{server_model} must be listed in curated Ollama models"
+                );
+                assert_eq!(
+                    ollama_model_dim(server_model),
+                    Some(spec.dim),
+                    "{} must bind to a dimension-compatible Ollama model",
+                    spec.model_id
+                );
+            } else {
+                assert_eq!(
+                    default, None,
+                    "{} is not remote-capable and must not claim an Ollama default",
+                    spec.model_id
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn curated_ollama_models_have_known_dimensions() {
+        for model in OLLAMA_EMBEDDING_MODELS {
+            assert!(ollama_model_dim(model).is_some(), "{model} is missing its dimension");
+        }
+    }
+
+    #[test]
+    fn ollama_defaults_prefer_same_embedding_family() {
+        assert_eq!(ollama_model_for("sentence-transformers/all-MiniLM-L6-v2"), Some("all-minilm"));
+        assert_eq!(
+            ollama_model_for("BAAI/bge-small-en-v1.5"),
+            Some("qllama/bge-small-en-v1.5:f16")
+        );
+        assert_eq!(
+            ollama_model_for("jinaai/jina-embeddings-v2-base-code"),
+            Some("ordis/jina-embeddings-v2-base-code")
+        );
+    }
+
+    #[test]
+    fn cookbook_gpu_lists_use_current_provider_tokens() {
+        assert!(MODAL_GPUS.contains(&"A10"));
+        assert!(MODAL_GPUS.contains(&"H200"));
+        assert!(MODAL_GPUS.contains(&"B200+"));
+        assert!(!MODAL_GPUS.contains(&"A10G"));
+
+        assert!(RUNPOD_GPUS.contains(&"NVIDIA RTX A4000"));
+        assert!(RUNPOD_GPUS.contains(&"NVIDIA GeForce RTX 4090"));
+        assert!(RUNPOD_GPUS.contains(&"NVIDIA A100 80GB PCIe"));
+        assert!(RUNPOD_GPUS.contains(&"NVIDIA H100 PCIe"));
+        assert!(RUNPOD_GPUS.contains(&"NVIDIA H200"));
+        assert!(RUNPOD_GPUS.contains(&"NVIDIA B300 SXM6 AC"));
+        assert!(!RUNPOD_GPUS.contains(&"NVIDIA A100"));
+        assert!(!RUNPOD_GPUS.contains(&"NVIDIA H100"));
+        assert!(!RUNPOD_GPUS.contains(&"NVIDIA RTX 4090"));
+    }
+
+    #[test]
+    fn from_config_recovers_bindings_and_model() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        let config_path = dir.path().join("rag-rat.toml");
+        std::fs::write(
+            &config_path,
+            "[index]\nroot = \".\"\n[llm.embedding]\nmodel = \"none\"\n[target_bindings]\nrust = \
+             [\"src\"]\n",
+        )
+        .unwrap();
+        let cfg = rag_rat_core::config::Config::load(&config_path).unwrap();
+        let d = WizardDraft::from_config(&cfg, &config_path);
+        assert_eq!(d.model, "none");
+        assert_eq!(d.bindings.get(&Language::Rust).unwrap(), &vec![std::path::PathBuf::from(
+            "src"
+        )]);
+        // root_value must be the relative TOML value, not an absolute path.
+        assert_eq!(
+            d.root_value, ".",
+            "root_value should be relative \".\", got {:?}",
+            d.root_value
+        );
+        // root_abs must be the absolute canonical path.
+        assert!(d.root_abs.is_absolute(), "root_abs should be absolute, got {:?}", d.root_abs);
+        assert_eq!(d.root_abs, cfg.root);
+    }
+
+    #[test]
+    fn from_config_maps_remote_connect_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        let config_path = dir.path().join("rag-rat.toml");
+        std::fs::write(
+            &config_path,
+            "[index]\nroot = \".\"\n\
+             [target_bindings]\nrust = [\"src\"]\n\n\
+             [llm.embedding]\nmodel = \"sentence-transformers/all-MiniLM-L6-v2\"\n\n\
+             [llm.embedding.remote]\nmodel = \"all-minilm\"\nendpoint = \
+             \"http://localhost:11434\"\nnum_ctx = 4096\nbatch_size = 64\n",
+        )
+        .unwrap();
+        let cfg = rag_rat_core::config::Config::load(&config_path).unwrap();
+        let d = WizardDraft::from_config(&cfg, &config_path);
+        let remote = d.remote.expect("remote block should be present");
+        assert_eq!(remote.model, "all-minilm");
+        assert_eq!(remote.num_ctx, Some(4096));
+        assert!(
+            matches!(remote.mode, RemoteMode::Connect(ref ep) if ep == "http://localhost:11434")
+        );
+    }
+
+    #[test]
+    fn from_config_maps_oracle_and_version_check() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        let config_path = dir.path().join("rag-rat.toml");
+        std::fs::write(
+            &config_path,
+            "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n\n[llm.embedding]\nmodel \
+             = \"none\"\n\n[oracle]\nauto_run = true\nauto_run_quiet_period_secs = \
+             300\nauto_run_min_interval_secs = 7200\n\n[version_check]\nenabled = false\n",
+        )
+        .unwrap();
+        let cfg = rag_rat_core::config::Config::load(&config_path).unwrap();
+        let d = WizardDraft::from_config(&cfg, &config_path);
+        assert!(d.oracle_auto_run);
+        assert_eq!(d.oracle_quiet_secs, 300);
+        assert_eq!(d.oracle_min_interval_secs, 7200);
+        assert!(!d.version_check);
+    }
+
+    #[test]
+    fn patch_preserves_comments_and_unknown_keys() {
+        let original = "# my notes\n[index]\nroot = \".\"\n[future]\nthing = \
+                        1\n[target_bindings]\nrust = [\"src\"]\n";
+        let mut d =
+            WizardDraft::from_scan(&RepoScan::default(), ".".into(), std::path::PathBuf::from("."));
+        d.bindings.insert(rag_rat_core::language::Language::Rust, vec!["crates".into()]);
+        let out = d.patch_existing(original).unwrap();
+        assert!(out.contains("# my notes"), "comment must be kept");
+        assert!(out.contains("[future]"), "unknown table must be kept");
+        assert!(out.contains("rust = [\"crates\"]"), "owned binding must be patched");
+    }
+
+    #[test]
+    fn patch_replaces_non_table_target_bindings() {
+        // `target_bindings` is a scalar string — not a table. The patch must overwrite it with
+        // a proper table containing the draft's bindings rather than silently skipping the write.
+        let original = "[index]\nroot = \".\"\n[llm.embedding]\nmodel = \"none\"\ntarget_bindings \
+                        = \"garbage\"\n[oracle]\nauto_run = false\n[version_check]\nenabled = \
+                        true\n";
+        let mut d =
+            WizardDraft::from_scan(&RepoScan::default(), ".".into(), std::path::PathBuf::from("."));
+        d.bindings.insert(Language::Rust, vec!["src".into()]);
+        let out = d.patch_existing(original).unwrap();
+        let patched: toml_edit::DocumentMut = out.parse().expect("output must be valid TOML");
+        assert!(
+            patched["target_bindings"].is_table(),
+            "target_bindings must be a table after patch, got: {:?}",
+            patched["target_bindings"]
+        );
+        let rust_val = &patched["target_bindings"]["rust"];
+        assert!(
+            rust_val.is_value(),
+            "rust binding must be present in patched table, got: {:?}",
+            rust_val
+        );
+    }
+
+    #[test]
+    fn fresh_write_persists_remote_and_version_check() {
+        let mut d =
+            WizardDraft::from_scan(&RepoScan::default(), ".".into(), std::path::PathBuf::from("."));
+        d.bindings.insert(Language::Rust, vec!["src".into()]);
+        d.model = "sentence-transformers/all-MiniLM-L6-v2".to_string();
+        d.version_check = false;
+        d.remote = Some(RemoteDraft {
+            model: "all-minilm".to_string(),
+            mode: RemoteMode::Ephemeral("@rag-rat/cookbook modal".to_string()),
+            gpu: None,
+            num_ctx: None,
+            batch_size: 128,
+            auth_env: Some("OLLAMA_TOKEN".to_string()),
+        });
+
+        let out = d.write_fresh();
+        let doc: DocumentMut = out.parse().unwrap();
+        let remote = doc["llm"]["embedding"]["remote"].as_table_like().unwrap();
+
+        assert_eq!(remote.get("cookbook").and_then(Item::as_str), Some("@rag-rat/cookbook modal"));
+        assert_eq!(remote.get("batch_size").and_then(Item::as_integer), Some(128));
+        assert_eq!(remote.get("auth_env").and_then(Item::as_str), Some("OLLAMA_TOKEN"));
+        assert_eq!(doc["version_check"]["enabled"].as_bool(), Some(false));
+    }
+
+    #[test]
+    fn patch_updates_inline_remote_table() {
+        let original = "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n\
+                        [llm.embedding]\nmodel = \"sentence-transformers/all-MiniLM-L6-v2\"\n\
+                        remote = { model = \"old\", endpoint = \"http://old:11434\" }\n";
+        let mut d =
+            WizardDraft::from_scan(&RepoScan::default(), ".".into(), std::path::PathBuf::from("."));
+        d.bindings.insert(Language::Rust, vec!["src".into()]);
+        d.model = "sentence-transformers/all-MiniLM-L6-v2".to_string();
+        d.remote = Some(RemoteDraft {
+            model: "all-minilm".to_string(),
+            mode: RemoteMode::Connect("http://new:11434".to_string()),
+            gpu: None,
+            num_ctx: Some(4096),
+            batch_size: 64,
+            auth_env: None,
+        });
+
+        let out = d.patch_existing(original).unwrap();
+        let doc: DocumentMut = out.parse().unwrap();
+        let remote = doc["llm"]["embedding"]["remote"].as_table_like().unwrap();
+
+        assert_eq!(remote.get("endpoint").and_then(Item::as_str), Some("http://new:11434"));
+        assert_eq!(remote.get("model").and_then(Item::as_str), Some("all-minilm"));
+        assert_eq!(remote.get("num_ctx").and_then(Item::as_integer), Some(4096));
+        assert!(remote.get("cookbook").is_none());
+    }
+
+    #[test]
+    fn from_existing_keeps_rich_targets_out_of_simple_bindings() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        let config_path = dir.path().join("rag-rat.toml");
+        let raw = "[index]\nroot = \".\"\n[llm.embedding]\nmodel = \"none\"\n[[target]]\nname = \
+                   \"core\"\nlanguage = \"rust\"\ndirectories = [\"src\"]\n";
+        std::fs::write(&config_path, raw).unwrap();
+        let cfg = Config::load(&config_path).unwrap();
+
+        let d = WizardDraft::from_existing(raw, &cfg, &config_path);
+        let out = d.patch_existing(raw).unwrap();
+
+        assert!(d.bindings.is_empty());
+        assert!(d.has_rich_targets);
+        assert!(d.rich_target_names.contains("core"));
+        assert!(out.contains("[[target]]"));
+        assert!(!out.contains("[target_bindings]"));
+    }
+
+    #[test]
+    fn from_existing_preserves_raw_root_literal() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("crate/src")).unwrap();
+        let config_path = dir.path().join("crate/rag-rat.toml");
+        let raw = "[index]\nroot = \".\"\n[target_bindings]\nrust = \
+                   [\"src\"]\n[llm.embedding]\nmodel = \"none\"\n";
+        std::fs::write(&config_path, raw).unwrap();
+        let cfg = Config::load(&config_path).unwrap();
+
+        let d = WizardDraft::from_existing(raw, &cfg, &config_path);
+        let out = d.patch_existing(raw).unwrap();
+        let doc: DocumentMut = out.parse().unwrap();
+
+        assert_eq!(d.root_value, ".");
+        assert_eq!(doc["index"]["root"].as_str(), Some("."));
+    }
+
+    #[test]
+    fn from_existing_preserves_relative_cookbook_literal() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("recipe.mjs"), "export {}\n").unwrap();
+        let config_path = dir.path().join("rag-rat.toml");
+        let raw = "[index]\nroot = \".\"\n[target_bindings]\nrust = \
+                   [\"src\"]\n[llm.embedding]\nmodel = \
+                   \"sentence-transformers/all-MiniLM-L6-v2\"\n[llm.embedding.remote]\nmodel = \
+                   \"all-minilm\"\ncookbook = \"./recipe.mjs\"\n";
+        std::fs::write(&config_path, raw).unwrap();
+        let cfg = Config::load(&config_path).unwrap();
+        let resolved = cfg.llm.embedding.remote.as_ref().unwrap().cookbook.as_deref().unwrap();
+        assert!(PathBuf::from(resolved).is_absolute());
+
+        let d = WizardDraft::from_existing(raw, &cfg, &config_path);
+        let out = d.patch_existing(raw).unwrap();
+        let doc: DocumentMut = out.parse().unwrap();
+        let remote = doc["llm"]["embedding"]["remote"].as_table_like().unwrap();
+
+        assert!(matches!(
+            d.remote.as_ref().map(|remote| &remote.mode),
+            Some(RemoteMode::Ephemeral(cookbook)) if cookbook == "./recipe.mjs"
+        ));
+        assert_eq!(remote.get("cookbook").and_then(Item::as_str), Some("./recipe.mjs"));
+    }
+
+    #[test]
+    fn from_scan_selects_default_dirs_and_backend() {
+        use crate::init::scan::add_file_to_dir_counts;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // Create the source files so candidate_dirs can stat them.
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), "").unwrap();
+        std::fs::write(root.join("src/main.rs"), "").unwrap();
+
+        let mut scan = RepoScan::default();
+        *scan.language_counts_mut().entry(Language::Rust).or_default() += 2;
+        add_file_to_dir_counts(root, &root.join("src/lib.rs"), Language::Rust, &mut scan).unwrap();
+        add_file_to_dir_counts(root, &root.join("src/main.rs"), Language::Rust, &mut scan).unwrap();
+        scan.set_total_source_bytes(1_000);
+
+        let root_abs = root.to_path_buf();
+        let d = WizardDraft::from_scan(&scan, ".".to_string(), root_abs.clone());
+        assert!(d.bindings.contains_key(&Language::Rust));
+        assert_eq!(d.bindings[&Language::Rust], vec![PathBuf::from("src")]);
+        // Small repo (1 KB) → fast_embed (MiniLM).
+        assert!(d.model.contains("MiniLM"), "expected MiniLM for small repo, got {}", d.model);
+        assert!(!d.oracle_auto_run);
+        assert!(d.version_check);
+        assert!(!d.hooks.git);
+        assert!(!d.hooks.claude);
+        // root_abs must be the absolute path passed in.
+        assert_eq!(d.root_abs, root_abs);
+    }
+}

--- a/crates/rag-rat-cli/src/init/wizard/mod.rs
+++ b/crates/rag-rat-cli/src/init/wizard/mod.rs
@@ -1,0 +1,1292 @@
+//! Init wizard shell: event loop, tabs, footer, dispatch.
+//!
+//! Steps are plain functions in `steps.rs`.  No traits, no widget abstractions.
+//! Every frame starts with `Clear` on the full area so nothing bleeds.
+
+mod catalog;
+mod draft;
+mod probe;
+mod review;
+mod state;
+mod steps;
+mod theme;
+
+use std::collections::HashMap;
+use std::io::{Stdout, stdout};
+use std::path::Path;
+use std::time::Duration;
+
+use rag_rat_core::Config;
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use ratatui::crossterm::event::{
+    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind,
+    KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+};
+use ratatui::crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use ratatui::crossterm::{cursor, execute};
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Clear, Paragraph, Tabs, Wrap};
+
+use self::catalog::CookbookCatalog;
+pub(crate) use self::draft::{HooksDraft, WizardDraft};
+use self::review::ReviewModel;
+use self::state::{OneShotHelp, WizardState};
+pub(crate) use self::steps::hooks::{HookConflict, render_chained_hook};
+use self::steps::{StepId, init_step, render_step, step_footer, step_handle_key, step_title};
+use crate::init::RepoScan;
+use crate::init::render::config_root_value;
+
+pub(crate) struct WizardResult {
+    pub toml: String,
+    pub hooks: HooksDraft,
+    pub hook_conflicts: HashMap<&'static str, HookConflict>,
+}
+
+struct TerminalGuard(Terminal<CrosstermBackend<Stdout>>);
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = execute!(stdout(), DisableMouseCapture, LeaveAlternateScreen, cursor::Show);
+    }
+}
+
+fn install_panic_hook() {
+    let original = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = disable_raw_mode();
+        let _ = execute!(stdout(), DisableMouseCapture, LeaveAlternateScreen, cursor::Show);
+        original(info);
+    }));
+}
+
+enum Tick {
+    Continue,
+    Quit,
+    Confirm(WizardResult),
+}
+
+struct Wizard {
+    state: WizardState,
+    review_open: bool,
+    quit_prompt: bool,
+    original: Option<String>,
+    tab_area: Option<Rect>,
+}
+
+impl Wizard {
+    fn new(state: WizardState, original: Option<String>) -> Self {
+        let mut s =
+            Self { state, review_open: false, quit_prompt: false, original, tab_area: None };
+        // Init the focused step's state so the first render shows content, not a blank screen.
+        let id = s.state.ui.focused;
+        s.state.step = Some(init_step(id, &s.state));
+        s
+    }
+
+    fn dispatch(&mut self, key: KeyEvent) -> Tick {
+        if key.kind == KeyEventKind::Release {
+            return Tick::Continue;
+        }
+
+        // ── quit prompt traps all input ─────────────────────────────────────
+        if self.quit_prompt {
+            match key.code {
+                KeyCode::Char('y') | KeyCode::Char('Y') => {
+                    self.state.probes.on_quit();
+                    return Tick::Quit;
+                },
+                KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                    self.quit_prompt = false;
+                },
+                KeyCode::Char('w') | KeyCode::Char('W') => {
+                    self.quit_prompt = false;
+                    self.open_review();
+                },
+                _ => {},
+            }
+            return Tick::Continue;
+        }
+
+        if self.state.ui.provision_log_open {
+            self.dispatch_provision_log(key);
+            return Tick::Continue;
+        }
+
+        if self.state.ui.popup.take().is_some() {
+            return Tick::Continue;
+        }
+
+        if self.review_open {
+            return self.dispatch_review(key);
+        }
+
+        if matches!(key.code, KeyCode::Esc) {
+            self.quit_prompt = true;
+            return Tick::Continue;
+        }
+
+        // ── Ctrl+arrows: step navigation ────────────────────────────────────
+        if key.modifiers.contains(KeyModifiers::CONTROL) {
+            match key.code {
+                KeyCode::Right => {
+                    self.advance();
+                    return Tick::Continue;
+                },
+                KeyCode::Left => {
+                    self.advance_back();
+                    return Tick::Continue;
+                },
+                _ => {},
+            }
+        }
+
+        // ── step dispatch ───────────────────────────────────────────────────
+        let focused = self.state.ui.focused;
+        let outcome = step_handle_key(focused, key, &mut self.state);
+        if matches!(outcome, steps::Outcome::Advance | steps::Outcome::Consumed) {
+            self.refresh_check(focused);
+        }
+        match outcome {
+            steps::Outcome::Advance => self.advance(),
+            steps::Outcome::Back => self.advance_back(),
+            steps::Outcome::Consumed => {},
+            steps::Outcome::Pass => {
+                // ── globals ─────────────────────────────────────────────────
+                match key.code {
+                    KeyCode::Char('w') => self.open_review(),
+                    KeyCode::Char('q') => self.quit_prompt = true,
+                    KeyCode::Esc => self.quit_prompt = true,
+                    KeyCode::Char('?') => self.state.ui.help_visible = !self.state.ui.help_visible,
+                    KeyCode::Char('l') | KeyCode::Char('L')
+                        if !self.state.provision_log_lines.is_empty() =>
+                    {
+                        self.state.ui.provision_log_open = true;
+                    },
+                    _ => {},
+                }
+            },
+        }
+        Tick::Continue
+    }
+
+    fn open_review(&mut self) {
+        self.refresh_all_checks();
+        self.review_open = true;
+        self.state.ui.review_scroll = 0;
+        self.state.ui.ephemeral_keep_acknowledged = false;
+    }
+
+    fn dispatch_provision_log(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') => self.scroll_provision_log(-1),
+            KeyCode::Down | KeyCode::Char('j') => self.scroll_provision_log(1),
+            KeyCode::PageUp => self.scroll_provision_log(-10),
+            KeyCode::PageDown => self.scroll_provision_log(10),
+            KeyCode::Home => {
+                self.state.ui.provision_log_scroll = 0;
+                self.state.ui.provision_log_follow = false;
+            },
+            KeyCode::End => {
+                self.state.ui.provision_log_scroll = u16::MAX;
+                self.state.ui.provision_log_follow = true;
+            },
+            KeyCode::Char('q') | KeyCode::Esc => self.state.ui.provision_log_open = false,
+            _ => {},
+        }
+    }
+
+    fn dispatch_review(&mut self, key: KeyEvent) -> Tick {
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.scroll_review(-1);
+                Tick::Continue
+            },
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.scroll_review(1);
+                Tick::Continue
+            },
+            KeyCode::PageUp => {
+                self.scroll_review(-10);
+                Tick::Continue
+            },
+            KeyCode::PageDown => {
+                self.scroll_review(10);
+                Tick::Continue
+            },
+            KeyCode::Home => {
+                self.state.ui.review_scroll = 0;
+                Tick::Continue
+            },
+            KeyCode::End => {
+                self.state.ui.review_scroll = self.review_scroll_max() as u16;
+                Tick::Continue
+            },
+            KeyCode::Char('c') => {
+                self.refresh_all_checks();
+                let model = ReviewModel::build(&self.state, self.original.as_deref());
+                if model.can_confirm(self.state.ui.ephemeral_keep_acknowledged) {
+                    match self.build_result() {
+                        Ok(r) => {
+                            self.state.probes.on_quit();
+                            Tick::Confirm(r)
+                        },
+                        Err(_) => Tick::Continue,
+                    }
+                } else {
+                    Tick::Continue
+                }
+            },
+            KeyCode::Char('K') => {
+                self.state.ui.ephemeral_keep_acknowledged = true;
+                Tick::Continue
+            },
+            KeyCode::Char('q') | KeyCode::Esc => {
+                self.review_open = false;
+                Tick::Continue
+            },
+            _ => Tick::Continue,
+        }
+    }
+
+    fn dispatch_mouse(&mut self, mouse: MouseEvent) -> Tick {
+        if self.state.ui.provision_log_open {
+            match mouse.kind {
+                MouseEventKind::ScrollUp => self.scroll_provision_log(-3),
+                MouseEventKind::ScrollDown => self.scroll_provision_log(3),
+                _ => {},
+            }
+            return Tick::Continue;
+        }
+        if self.state.ui.popup.take().is_some() {
+            return Tick::Continue;
+        }
+        if self.quit_prompt {
+            return Tick::Continue;
+        }
+        if let MouseEventKind::Down(MouseButton::Left) = mouse.kind
+            && let Some(area) = self.tab_area
+            && let Some(next) = tab_at(area, mouse.column, mouse.row, &self.state.checks)
+        {
+            if next != self.state.ui.tab {
+                self.move_to_step(next);
+            }
+            return Tick::Continue;
+        }
+        match mouse.kind {
+            MouseEventKind::ScrollUp =>
+                if self.review_open {
+                    self.scroll_review(-3);
+                } else {
+                    steps::scroll_step(self.state.ui.focused, -3, &mut self.state);
+                },
+            MouseEventKind::ScrollDown =>
+                if self.review_open {
+                    self.scroll_review(3);
+                } else {
+                    steps::scroll_step(self.state.ui.focused, 3, &mut self.state);
+                },
+            _ => {},
+        }
+        Tick::Continue
+    }
+
+    fn scroll_review(&mut self, delta: isize) {
+        let max = self.review_scroll_max();
+        let cur = self.state.ui.review_scroll as isize;
+        self.state.ui.review_scroll = cur.saturating_add(delta).clamp(0, max as isize) as u16;
+    }
+
+    fn scroll_provision_log(&mut self, delta: isize) {
+        let max = self.state.provision_log_lines.len().saturating_sub(1);
+        let cur = self.state.ui.provision_log_scroll.min(max as u16) as isize;
+        let next = cur.saturating_add(delta).clamp(0, max as isize) as u16;
+        self.state.ui.provision_log_scroll = next;
+        self.state.ui.provision_log_follow = next as usize >= max;
+    }
+
+    fn review_scroll_max(&self) -> usize {
+        ReviewModel::build(&self.state, self.original.as_deref())
+            .body_line_count()
+            .saturating_sub(1)
+    }
+
+    fn advance(&mut self) {
+        self.move_step(true);
+    }
+    fn advance_back(&mut self) {
+        self.move_step(false);
+    }
+
+    fn move_step(&mut self, forward: bool) {
+        let i = self.state.ui.focused as usize;
+        let n = StepId::COUNT;
+        let next = if forward { (i + 1) % n } else { (i + n - 1) % n };
+        self.move_to_step(next);
+    }
+
+    fn move_to_step(&mut self, next: usize) {
+        self.refresh_check(self.state.ui.focused);
+        self.state.ui.focused = StepId::ALL[next];
+        self.state.ui.tab = next;
+        // Re-init step state for the newly focused step.
+        let id = self.state.ui.focused;
+        self.state.step = Some(init_step(id, &self.state));
+        self.refresh_check(id);
+    }
+
+    fn refresh_check(&mut self, id: StepId) {
+        let static_check = steps::validate_step(id, &self.state);
+        let probe_check = match self.state.probes.status(id) {
+            probe::ProbeStatus::Done { result, .. } => Some(result.clone()),
+            _ => None,
+        };
+        self.state.checks[id.index()] = merge_checks(static_check, probe_check);
+    }
+
+    fn refresh_all_checks(&mut self) {
+        for id in StepId::ALL {
+            self.refresh_check(id);
+        }
+    }
+
+    fn poll_probes_into_checks(&mut self) {
+        for (step, _kind, _result) in self.state.probes.poll() {
+            self.refresh_check(step);
+        }
+    }
+
+    fn build_result(&self) -> anyhow::Result<WizardResult> {
+        let draft = &self.state.draft;
+        let toml = match &self.original {
+            Some(orig) => draft.patch_existing(orig)?,
+            None => draft.write_fresh(),
+        };
+        Ok(WizardResult {
+            toml,
+            hooks: draft.hooks.clone(),
+            hook_conflicts: self.state.hook_conflicts.clone(),
+        })
+    }
+
+    // ── render ──────────────────────────────────────────────────────────────
+
+    fn render(&mut self, f: &mut ratatui::Frame) {
+        let area = f.area();
+        f.render_widget(Clear, area); // full-frame clear — no bleed ever
+        f.render_widget(Block::default().style(theme::base()), area);
+
+        if self.review_open {
+            self.tab_area = None;
+            review::render(
+                &ReviewModel::build(&self.state, self.original.as_deref()),
+                f,
+                area,
+                self.state.ui.review_scroll,
+            );
+            return;
+        }
+
+        let rows =
+            Layout::vertical([Constraint::Length(3), Constraint::Min(0), Constraint::Length(1)])
+                .split(area);
+
+        self.tab_area = Some(rows[0]);
+        self.render_tabs(f, rows[0]);
+        self.render_main(f, rows[1]);
+        self.render_footer(f, rows[2]);
+
+        if self.state.ui.help_visible {
+            self.render_help(f, area);
+        }
+        if let Some(help) = self.state.ui.popup {
+            self.render_one_shot_help(f, area, help);
+        }
+        if self.state.ui.provision_log_open {
+            self.render_provision_log(f, area);
+        }
+        if self.quit_prompt {
+            self.render_quit_prompt(f, area);
+        }
+    }
+
+    fn render_tabs(&self, f: &mut ratatui::Frame, area: Rect) {
+        let titles: Vec<Line> = StepId::ALL
+            .iter()
+            .enumerate()
+            .map(|(i, id)| tab_title_line(*id, self.state.checks[i].severity))
+            .collect();
+        f.render_widget(
+            Tabs::new(titles)
+                .select(self.state.ui.tab)
+                .block(theme::block("Steps"))
+                .style(theme::muted())
+                .highlight_style(theme::selected())
+                .divider(" ")
+                .padding("", ""),
+            area,
+        );
+    }
+
+    fn render_main(&mut self, f: &mut ratatui::Frame, area: Rect) {
+        let block = theme::block(step_title(self.state.ui.focused));
+        let inner = block.inner(area);
+        f.render_widget(block, area);
+        render_step(self.state.ui.focused, f, inner, &mut self.state);
+    }
+
+    fn render_footer(&self, f: &mut ratatui::Frame, area: Rect) {
+        let bar = theme::footer();
+        let footer = step_footer(self.state.ui.focused);
+        let mut spans = vec![Span::styled(format!(" {}  w review  ? help  q quit ", footer), bar)];
+        if let Some(msg) = &self.state.checks[self.state.ui.focused as usize].message {
+            spans.push(Span::styled(format!(" ⚠ {} ", msg), theme::footer_warning()));
+        }
+        f.render_widget(Paragraph::new(Line::from(spans)).style(bar), area);
+    }
+
+    fn render_help(&self, f: &mut ratatui::Frame, area: Rect) {
+        let popup = centered(50, 50, area);
+        f.render_widget(Clear, popup);
+        let lines = vec![
+            Line::from(Span::styled("Keys", theme::title())),
+            Line::from("  ↑↓/j/k    move cursor or scroll"),
+            Line::from("  PgUp/PgDn scroll containers"),
+            Line::from("  Space     toggle / select"),
+            Line::from("  Enter     advance / expand"),
+            Line::from("  Esc       back / quit prompt"),
+            Line::from("  Ctrl+←→   next/prev step"),
+            Line::from("  w         review"),
+            Line::from("  q         quit"),
+            Line::from("  ?         this help"),
+        ];
+        f.render_widget(
+            Paragraph::new(lines)
+                .style(theme::popup())
+                .wrap(Wrap { trim: true })
+                .block(theme::popup_block("Help")),
+            popup,
+        );
+    }
+
+    fn render_one_shot_help(&self, f: &mut ratatui::Frame, area: Rect, help: OneShotHelp) {
+        let popup = centered(58, 35, area);
+        f.render_widget(Clear, popup);
+        let (title, body): (&str, &[&str]) = match help {
+            OneShotHelp::EmbeddingOff => ("Remote mode: none", &[
+                "Remote embeddings are off. Search uses local lexical and structural signals only.",
+                "This is the cheapest setup, but it loses semantic recall on larger or more \
+                 ambiguous codebases.",
+            ]),
+            OneShotHelp::Connect => ("Remote mode: connect", &[
+                "Connect uses an existing Ollama server. Fill endpoint with the server URL, \
+                 choose the server model, then press t to test /api/embed.",
+                "Use this when the model is already running somewhere reliable.",
+            ]),
+            OneShotHelp::Ephemeral => ("Remote mode: ephemeral", &[
+                "Ephemeral can create a temporary provider box during reconcile or a provision \
+                 test.",
+                "Because that may start paid remote compute, the wizard asks you to type \
+                 provision in the confirm field before p will run the test.",
+            ]),
+        };
+        let lines = body
+            .iter()
+            .flat_map(|line| [Line::from(*line), Line::from("")])
+            .chain([Line::from("Press any key to continue.")])
+            .collect::<Vec<_>>();
+        f.render_widget(
+            Paragraph::new(lines)
+                .style(theme::popup())
+                .wrap(Wrap { trim: true })
+                .block(theme::popup_block(title)),
+            popup,
+        );
+    }
+
+    fn render_provision_log(&self, f: &mut ratatui::Frame, area: Rect) {
+        let popup = centered(78, 66, area);
+        f.render_widget(Clear, popup);
+        let inner_height = usize::from(popup.height.saturating_sub(2)).max(1);
+        let max = self.state.provision_log_lines.len().saturating_sub(inner_height);
+        let scroll = self.state.ui.provision_log_scroll.min(max as u16);
+        let title = if self.state.provision_log_rx.is_some() {
+            format!("{}: running", self.state.provision_log_title)
+        } else {
+            self.state.provision_log_title.clone()
+        };
+        let text = if self.state.provision_log_lines.is_empty() {
+            "No provision log yet.".to_string()
+        } else {
+            self.state.provision_log_lines.join("\n")
+        };
+        f.render_widget(
+            Paragraph::new(text)
+                .style(theme::popup())
+                .wrap(Wrap { trim: false })
+                .scroll((scroll, 0))
+                .block(theme::popup_block(title)),
+            popup,
+        );
+        if popup.height > 2 {
+            let footer = Rect::new(
+                popup.x.saturating_add(2),
+                popup.y + popup.height - 1,
+                popup.width.saturating_sub(4),
+                1,
+            );
+            f.render_widget(
+                Paragraph::new(" ↑↓/j/k PgUp/PgDn scroll  End follow  Esc/q close ")
+                    .style(theme::popup()),
+                footer,
+            );
+        }
+    }
+
+    fn render_quit_prompt(&self, f: &mut ratatui::Frame, area: Rect) {
+        let popup = centered(40, 32, area);
+        f.render_widget(Clear, popup);
+        let lines = vec![
+            Line::from(Span::styled("Quit without saving?", theme::title())),
+            Line::from(""),
+            Line::from("  y  quit (discard)"),
+            Line::from("  n  go back"),
+            Line::from("  w  review"),
+        ];
+        f.render_widget(
+            Paragraph::new(lines)
+                .style(theme::popup())
+                .block(theme::popup_block("Quit").border_style(theme::warning())),
+            popup,
+        );
+    }
+}
+
+fn merge_checks(
+    static_check: steps::CheckResult,
+    probe_check: Option<steps::CheckResult>,
+) -> steps::CheckResult {
+    let Some(probe_check) = probe_check else { return static_check };
+    match (static_check.severity, probe_check.severity) {
+        (steps::Sev::Block, _) => static_check,
+        (_, steps::Sev::Block) => probe_check,
+        (steps::Sev::Warn, steps::Sev::Warn) => combine_warnings(static_check, probe_check),
+        (steps::Sev::Warn, steps::Sev::Ok) => static_check,
+        (_, steps::Sev::Warn) => probe_check,
+        (steps::Sev::Ok, steps::Sev::Ok) => static_check,
+    }
+}
+
+fn combine_warnings(
+    static_check: steps::CheckResult,
+    probe_check: steps::CheckResult,
+) -> steps::CheckResult {
+    match (probe_check.message, static_check.message) {
+        (Some(probe), Some(static_msg)) if probe != static_msg =>
+            steps::CheckResult::warn(format!("{probe}; {static_msg}")),
+        (Some(message), _) | (None, Some(message)) => steps::CheckResult::warn(message),
+        (None, None) => steps::CheckResult { severity: steps::Sev::Warn, message: None },
+    }
+}
+
+fn centered(pct_x: u16, pct_y: u16, area: Rect) -> Rect {
+    let v = Layout::vertical([
+        Constraint::Percentage((100 - pct_y) / 2),
+        Constraint::Percentage(pct_y),
+        Constraint::Percentage((100 - pct_y) / 2),
+    ])
+    .split(area);
+    Layout::horizontal([
+        Constraint::Percentage((100 - pct_x) / 2),
+        Constraint::Percentage(pct_x),
+        Constraint::Percentage((100 - pct_x) / 2),
+    ])
+    .split(v[1])[1]
+}
+
+fn tab_at(area: Rect, column: u16, row: u16, checks: &[steps::CheckResult]) -> Option<usize> {
+    let inner = tab_inner(area)?;
+    if row != inner.y || column < inner.x || column >= inner.x.saturating_add(inner.width) {
+        return None;
+    }
+
+    let mut x = inner.x;
+    for (i, id) in StepId::ALL.iter().enumerate() {
+        let severity = checks.get(i).map_or(steps::Sev::Ok, |check| check.severity);
+        let Some((start, end)) = tab_hit_range(inner, x, *id, severity) else { break };
+        if column >= start && column < end {
+            return Some(i);
+        }
+        x = end;
+        if i + 1 < StepId::COUNT {
+            x = x.saturating_add(1);
+        }
+    }
+    None
+}
+
+fn tab_inner(area: Rect) -> Option<Rect> {
+    if area.width <= 2 || area.height <= 2 {
+        return None;
+    }
+    Some(Rect::new(
+        area.x.saturating_add(1),
+        area.y.saturating_add(1),
+        area.width.saturating_sub(2),
+        area.height.saturating_sub(2),
+    ))
+}
+
+fn tab_title_width(id: StepId, severity: steps::Sev) -> u16 {
+    tab_title_line(id, severity).width() as u16
+}
+
+fn tab_hit_range(inner: Rect, x: u16, id: StepId, severity: steps::Sev) -> Option<(u16, u16)> {
+    if x >= inner.right() {
+        return None;
+    }
+    let end = x.saturating_add(tab_title_width(id, severity)).min(inner.right());
+    (end > x).then_some((x, end))
+}
+
+fn tab_title_line(id: StepId, severity: steps::Sev) -> Line<'static> {
+    let Some((sev, sev_style)) = (match severity {
+        steps::Sev::Ok => None,
+        steps::Sev::Warn => Some(("!", theme::warning())),
+        steps::Sev::Block => Some(("✗", theme::error())),
+    }) else {
+        return Line::from(Span::raw(format!(" {} ", step_title(id))));
+    };
+    Line::from(vec![
+        Span::raw(" "),
+        Span::styled(sev, sev_style),
+        Span::raw(format!(" {} ", step_title(id))),
+    ])
+}
+
+// ── run_wizard ────────────────────────────────────────────────────────────
+
+pub(crate) fn run_wizard(
+    scan: RepoScan,
+    existing: Option<(String, Config)>,
+    config_path: &Path,
+    scan_root: std::path::PathBuf,
+) -> anyhow::Result<Option<WizardResult>> {
+    let (draft, original, cookbooks) =
+        initial_draft(&scan, existing.as_ref(), config_path, scan_root);
+    let mut wizard = Wizard::new(WizardState::with_cookbooks(draft, scan, cookbooks), original);
+    for id in StepId::ALL {
+        wizard.state.checks[id as usize] = steps::validate_step(id, &wizard.state);
+    }
+
+    install_panic_hook();
+    let mut guard = TerminalGuard(Terminal::new(CrosstermBackend::new(stdout()))?);
+    enable_raw_mode()?;
+    execute!(stdout(), EnterAlternateScreen, EnableMouseCapture, cursor::Hide)?;
+
+    let result = loop {
+        guard.0.draw(|f| wizard.render(f))?;
+        wizard.poll_probes_into_checks();
+        wizard.state.poll_provision_log();
+        if !event::poll(Duration::from_millis(100))? {
+            continue;
+        }
+        let tick = match event::read()? {
+            Event::Key(key) => {
+                if key.kind == KeyEventKind::Release {
+                    continue;
+                }
+                if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+                    wizard.state.probes.on_quit();
+                    break None;
+                }
+                wizard.dispatch(key)
+            },
+            Event::Mouse(mouse) => wizard.dispatch_mouse(mouse),
+            _ => continue,
+        };
+        match tick {
+            Tick::Continue => {},
+            Tick::Quit => break None,
+            Tick::Confirm(r) => {
+                wizard.state.probes.on_quit();
+                break Some(r);
+            },
+        }
+    };
+    drop(guard);
+    Ok(result)
+}
+
+fn initial_draft(
+    scan: &RepoScan,
+    existing: Option<&(String, Config)>,
+    config_path: &Path,
+    scan_root: std::path::PathBuf,
+) -> (WizardDraft, Option<String>, CookbookCatalog) {
+    match existing {
+        Some((raw, cfg)) => (
+            WizardDraft::from_existing(raw, cfg, config_path),
+            Some(raw.clone()),
+            CookbookCatalog::from_raw(raw),
+        ),
+        None => (fresh_draft(scan, config_path, scan_root), None, CookbookCatalog::default()),
+    }
+}
+
+fn fresh_draft(scan: &RepoScan, config_path: &Path, root_abs: std::path::PathBuf) -> WizardDraft {
+    let root_value = config_root_value(&root_abs, config_path);
+    WizardDraft::from_scan(scan, root_value, root_abs)
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::backend::TestBackend;
+    use ratatui::buffer::Buffer;
+    use ratatui::crossterm::event::{KeyCode, MouseButton, MouseEvent, MouseEventKind};
+    use ratatui::style::Color;
+
+    use super::*;
+
+    fn test_scan() -> RepoScan {
+        RepoScan::default()
+    }
+
+    #[test]
+    fn fresh_draft_roots_relative_to_config_file_parent() {
+        let root = std::path::PathBuf::from("/repo");
+        let draft = fresh_draft(&test_scan(), Path::new(".config/rag-rat.toml"), root);
+
+        assert_eq!(draft.root_value, "..");
+    }
+
+    #[test]
+    fn fresh_initial_draft_uses_scan_root_not_cwd() {
+        let root = std::path::PathBuf::from("/repo/sub");
+        let (draft, original, cookbooks) =
+            initial_draft(&test_scan(), None, Path::new("/repo/sub/rag-rat.toml"), root.clone());
+
+        assert_eq!(draft.root_abs, root);
+        assert_eq!(draft.root_value, ".");
+        assert!(original.is_none());
+        assert_eq!(cookbooks.entries()[0].key, "modal");
+    }
+
+    #[test]
+    fn polling_probe_results_updates_step_checks() {
+        let mut w = headless(test_scan(), None);
+        w.state.probes.spawn(StepId::Integration, probe::ProbeKind::VersionCheck, || {
+            steps::CheckResult::warn("new version available")
+        });
+
+        for _ in 0..100 {
+            w.poll_probes_into_checks();
+            if w.state.checks[StepId::Integration.index()]
+                .message
+                .as_deref()
+                .is_some_and(|message| message.contains("new version"))
+            {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+
+        panic!("probe result did not update Integration check");
+    }
+
+    #[test]
+    fn opening_review_refreshes_stale_embedding_check() {
+        let mut w = headless(test_scan(), None);
+        w.state.draft.model = "none".to_string();
+        w.state.draft.remote = Some(draft::RemoteDraft {
+            model: "all-minilm".to_string(),
+            mode: draft::RemoteMode::Connect("http://localhost:11434".to_string()),
+            gpu: None,
+            num_ctx: None,
+            batch_size: 256,
+            auth_env: None,
+        });
+        w.state.checks[StepId::Embedding.index()] = steps::CheckResult::ok();
+
+        w.dispatch(KeyEvent::from(KeyCode::Char('w')));
+
+        assert!(w.review_open);
+        assert_eq!(w.state.checks[StepId::Embedding.index()].severity, steps::Sev::Block);
+    }
+
+    #[test]
+    fn opening_review_preserves_probe_warning() {
+        let mut w = headless(test_scan(), None);
+        let probe_id = w.state.probes.current(StepId::Embedding);
+        assert!(w.state.probes.apply(probe::ProbeMsg {
+            probe_id,
+            kind: probe::ProbeKind::Download,
+            result: steps::CheckResult::warn("download failed"),
+        }));
+        w.state.checks[StepId::Embedding.index()] = steps::CheckResult::ok();
+
+        w.dispatch(KeyEvent::from(KeyCode::Char('w')));
+
+        assert!(w.review_open);
+        let check = &w.state.checks[StepId::Embedding.index()];
+        assert_eq!(check.severity, steps::Sev::Warn);
+        assert_eq!(check.message.as_deref(), Some("download failed"));
+    }
+
+    #[test]
+    fn merge_checks_combines_static_and_probe_warnings() {
+        let check = merge_checks(
+            steps::CheckResult::warn("quality may vary"),
+            Some(steps::CheckResult::warn("connect failed")),
+        );
+
+        assert_eq!(check.severity, steps::Sev::Warn);
+        assert_eq!(check.message.as_deref(), Some("connect failed; quality may vary"));
+    }
+
+    #[test]
+    fn confirming_review_aborts_running_ephemeral_probe() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let mut w = headless(test_scan(), None);
+        w.state
+            .draft
+            .bindings
+            .insert(rag_rat_core::language::Language::Rust, vec![Path::new(".").to_path_buf()]);
+        w.state.draft.remote = Some(draft::RemoteDraft {
+            model: "all-minilm".to_string(),
+            mode: draft::RemoteMode::Ephemeral("@rag-rat/cookbook modal".to_string()),
+            gpu: None,
+            num_ctx: None,
+            batch_size: 256,
+            auth_env: None,
+        });
+        w.state.ui.ephemeral_keep_acknowledged = true;
+        w.review_open = true;
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let finished = Arc::new(AtomicBool::new(false));
+        let worker_finished = Arc::clone(&finished);
+        w.state.probes.spawn(StepId::Embedding, probe::ProbeKind::EphemeralTest, move || {
+            let _ = started_tx.send(());
+            std::thread::sleep(Duration::from_millis(20));
+            worker_finished.store(true, Ordering::Release);
+            steps::CheckResult::ok()
+        });
+        started_rx.recv().unwrap();
+
+        let tick = w.dispatch(KeyEvent::from(KeyCode::Char('c')));
+
+        assert!(matches!(tick, Tick::Confirm(_)));
+        assert!(matches!(w.state.probes.status(StepId::Embedding), probe::ProbeStatus::Idle));
+        assert!(finished.load(Ordering::Acquire));
+    }
+
+    fn headless(scan: RepoScan, existing: Option<(String, Config)>) -> Wizard {
+        let (draft, original, cookbooks) = match existing {
+            Some((raw, cfg)) => (
+                WizardDraft::from_existing(&raw, &cfg, Path::new("rag-rat.toml")),
+                Some(raw.clone()),
+                CookbookCatalog::from_raw(&raw),
+            ),
+            None => (
+                WizardDraft::from_scan(&scan, ".".to_string(), Path::new(".").to_path_buf()),
+                None,
+                CookbookCatalog::default(),
+            ),
+        };
+        let mut w = Wizard::new(WizardState::with_cookbooks(draft, scan, cookbooks), original);
+        for id in StepId::ALL {
+            w.state.checks[id as usize] = steps::validate_step(id, &w.state);
+        }
+        w
+    }
+
+    fn feed(w: &mut Wizard, key: KeyEvent) -> Option<WizardResult> {
+        match w.dispatch(key) {
+            Tick::Confirm(r) => Some(r),
+            _ => None,
+        }
+    }
+
+    fn ctrl_right() -> KeyEvent {
+        KeyEvent::new(KeyCode::Right, KeyModifiers::CONTROL)
+    }
+
+    fn focus_embedding(w: &mut Wizard) {
+        w.state.ui.focused = StepId::Embedding;
+        w.state.ui.tab = StepId::Embedding.index();
+        w.state.step = Some(init_step(StepId::Embedding, &w.state));
+    }
+
+    fn tab_click_column(w: &Wizard, area: Rect, index: usize) -> u16 {
+        let y = area.y + 1;
+        (area.x..area.x + area.width)
+            .find(|column| tab_at(area, *column, y, &w.state.checks) == Some(index))
+            .expect("tab should fit in test area")
+    }
+
+    fn left_click(column: u16, row: u16) -> MouseEvent {
+        MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        }
+    }
+
+    fn selected_tab_bg_columns(w: &Wizard, area: Rect) -> Vec<u16> {
+        let backend = TestBackend::new(area.width, area.height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| w.render_tabs(f, area)).unwrap();
+        let buffer = terminal.backend().buffer();
+        let selected_bg = theme::selected().bg.expect("selected style has background");
+        let y = area.y + 1;
+        (area.x..area.x + area.width).filter(|x| buffer[(*x, y)].bg == selected_bg).collect()
+    }
+
+    fn tab_cell_symbol(w: &Wizard, area: Rect, column: u16) -> String {
+        let backend = TestBackend::new(area.width, area.height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| w.render_tabs(f, area)).unwrap();
+        terminal.backend().buffer()[(column, area.y + 1)].symbol().to_string()
+    }
+
+    fn assert_bg(buffer: &Buffer, area: Rect, bg: Color) {
+        for y in area.y..area.y + area.height {
+            for x in area.x..area.x + area.width {
+                assert_eq!(buffer[(x, y)].bg, bg, "cell {x},{y} has unexpected background");
+            }
+        }
+    }
+
+    fn buffer_text(buffer: &Buffer, width: u16, height: u16) -> String {
+        (0..height)
+            .map(|y| (0..width).map(|x| buffer[(x, y)].symbol()).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn enter_advances_and_w_opens_review() {
+        let mut w = headless(test_scan(), None);
+        for _ in 0..StepId::COUNT {
+            w.dispatch(ctrl_right());
+        }
+        w.dispatch(KeyEvent::from(KeyCode::Char('w')));
+        assert!(w.review_open);
+    }
+
+    #[test]
+    fn release_keys_are_ignored_and_ctrl_arrows_move_steps() {
+        let mut w = headless(test_scan(), None);
+
+        w.dispatch(KeyEvent::new(KeyCode::Right, KeyModifiers::CONTROL));
+        assert_eq!(w.state.ui.focused, StepId::Oracle);
+
+        w.dispatch(KeyEvent::new(KeyCode::Left, KeyModifiers::CONTROL));
+        assert_eq!(w.state.ui.focused, StepId::Indexing);
+
+        w.dispatch(KeyEvent::new_with_kind(
+            KeyCode::Right,
+            KeyModifiers::CONTROL,
+            KeyEventKind::Release,
+        ));
+        assert_eq!(w.state.ui.focused, StepId::Indexing);
+    }
+
+    #[test]
+    fn q_prompts_then_y_quits() {
+        let mut w = headless(test_scan(), None);
+        assert!(feed(&mut w, KeyEvent::from(KeyCode::Char('q'))).is_none()); // q → prompt
+        assert!(w.quit_prompt);
+        // y → quit
+        match w.dispatch(KeyEvent::from(KeyCode::Char('y'))) {
+            Tick::Quit => {},
+            _ => panic!("expected Quit"),
+        }
+    }
+
+    #[test]
+    fn quit_prompt_n_dismisses() {
+        let mut w = headless(test_scan(), None);
+        w.dispatch(KeyEvent::from(KeyCode::Char('q')));
+        assert!(w.quit_prompt);
+        w.dispatch(KeyEvent::from(KeyCode::Char('n')));
+        assert!(!w.quit_prompt);
+    }
+
+    #[test]
+    fn quit_prompt_w_opens_review() {
+        let area = Rect::new(0, 0, 80, 24);
+        let mut w = headless(test_scan(), None);
+        w.dispatch(KeyEvent::from(KeyCode::Char('q')));
+
+        let backend = TestBackend::new(area.width, area.height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| w.render_quit_prompt(f, area)).unwrap();
+        let rendered: String =
+            terminal.backend().buffer().content().iter().map(|cell| cell.symbol()).collect();
+        assert!(rendered.contains("w  review"), "{rendered:?}");
+
+        w.dispatch(KeyEvent::from(KeyCode::Char('w')));
+
+        assert!(!w.quit_prompt);
+        assert!(w.review_open);
+    }
+
+    #[test]
+    fn esc_opens_quit_prompt_without_moving_tabs() {
+        let mut w = headless(test_scan(), None);
+        w.state.ui.focused = StepId::Embedding;
+        w.state.ui.tab = StepId::Embedding.index();
+
+        w.dispatch(KeyEvent::from(KeyCode::Esc));
+
+        assert!(w.quit_prompt);
+        assert_eq!(w.state.ui.focused, StepId::Embedding);
+        assert_eq!(w.state.ui.tab, StepId::Embedding.index());
+    }
+
+    #[test]
+    fn clicking_tab_switches_step() {
+        let mut w = headless(test_scan(), None);
+        let area = Rect::new(0, 0, 120, 3);
+        w.tab_area = Some(area);
+
+        let target = StepId::Embedding.index();
+        let tick = w.dispatch_mouse(left_click(tab_click_column(&w, area, target), area.y + 1));
+
+        assert!(matches!(tick, Tick::Continue));
+        assert_eq!(w.state.ui.focused, StepId::Embedding);
+        assert_eq!(w.state.ui.tab, target);
+    }
+
+    #[test]
+    fn rendered_selected_tab_background_matches_hitbox() {
+        let mut w = headless(test_scan(), None);
+        let area = Rect::new(0, 0, 120, 3);
+        let target = StepId::Embedding.index();
+        w.state.ui.tab = target;
+
+        let y = area.y + 1;
+        let rendered = selected_tab_bg_columns(&w, area);
+        let hitbox: Vec<u16> = (area.x..area.x + area.width)
+            .filter(|x| tab_at(area, *x, y, &w.state.checks) == Some(target))
+            .collect();
+
+        assert_eq!(rendered, hitbox);
+        assert!(!rendered.is_empty());
+        assert_eq!(tab_cell_symbol(&w, area, rendered[0]), " ");
+        assert_ne!(tab_cell_symbol(&w, area, rendered[0] + 1), " ");
+        assert_eq!(tab_cell_symbol(&w, area, rendered[rendered.len() - 1]), " ");
+        assert_ne!(tab_at(area, rendered[0].saturating_sub(1), y, &w.state.checks), Some(target));
+        assert_ne!(
+            tab_at(area, rendered[rendered.len() - 1].saturating_add(1), y, &w.state.checks),
+            Some(target)
+        );
+    }
+
+    #[test]
+    fn review_scrolls_without_taking_keep_acknowledgement() {
+        let mut w = headless(test_scan(), None);
+        w.dispatch(KeyEvent::from(KeyCode::Char('w')));
+        assert!(w.review_open);
+        w.dispatch(KeyEvent::from(KeyCode::PageDown));
+        assert!(w.state.ui.review_scroll > 0);
+        w.dispatch(KeyEvent::from(KeyCode::Char('k')));
+        assert!(!w.state.ui.ephemeral_keep_acknowledged);
+        w.dispatch(KeyEvent::from(KeyCode::Char('K')));
+        assert!(w.state.ui.ephemeral_keep_acknowledged);
+    }
+
+    #[test]
+    fn remote_mode_help_popups_are_once_per_mode() {
+        let mut w = headless(test_scan(), None);
+        focus_embedding(&mut w);
+
+        w.dispatch(KeyEvent::from(KeyCode::Tab));
+        w.dispatch(KeyEvent::from(KeyCode::Down));
+        w.dispatch(KeyEvent::from(KeyCode::Char(' ')));
+        assert_eq!(w.state.ui.popup, Some(OneShotHelp::Connect));
+
+        w.dispatch(KeyEvent::from(KeyCode::Enter));
+        assert_eq!(w.state.ui.popup, None);
+        w.dispatch(KeyEvent::from(KeyCode::Char(' ')));
+        assert_eq!(w.state.ui.popup, None);
+
+        w.dispatch(KeyEvent::from(KeyCode::Down));
+        w.dispatch(KeyEvent::from(KeyCode::Char(' ')));
+        assert_eq!(w.state.ui.popup, Some(OneShotHelp::Ephemeral));
+    }
+
+    #[test]
+    fn provision_log_popup_captures_scrolls_and_reopens() {
+        let mut w = headless(test_scan(), None);
+        let (tx, rx) = std::sync::mpsc::channel();
+        w.state.start_provision_log(rx);
+        tx.send("first".to_string()).unwrap();
+        tx.send("second".to_string()).unwrap();
+        w.state.poll_provision_log();
+
+        assert!(w.state.ui.provision_log_open);
+        assert!(w.state.provision_log_lines.iter().any(|line| line == "first"));
+        assert_eq!(w.state.ui.provision_log_scroll, u16::MAX);
+
+        w.dispatch(KeyEvent::from(KeyCode::Home));
+        assert_eq!(w.state.ui.provision_log_scroll, 0);
+        assert!(!w.state.ui.provision_log_follow);
+
+        w.dispatch(KeyEvent::from(KeyCode::Esc));
+        assert!(!w.state.ui.provision_log_open);
+        w.dispatch(KeyEvent::from(KeyCode::Char('l')));
+        assert!(w.state.ui.provision_log_open);
+    }
+
+    #[test]
+    fn provision_log_scroll_keys_cover_edges() {
+        let mut w = headless(test_scan(), None);
+        let (tx, rx) = std::sync::mpsc::channel();
+        w.state.start_provision_log(rx);
+        for i in 0..40 {
+            tx.send(format!("line {i}")).unwrap();
+        }
+        w.state.poll_provision_log();
+
+        w.dispatch(KeyEvent::from(KeyCode::Home));
+        assert_eq!(w.state.ui.provision_log_scroll, 0);
+
+        w.dispatch(KeyEvent::from(KeyCode::PageDown));
+        assert!(w.state.ui.provision_log_scroll > 0);
+
+        w.dispatch(KeyEvent::from(KeyCode::End));
+        assert!(w.state.ui.provision_log_follow);
+
+        w.dispatch(KeyEvent::from(KeyCode::PageUp));
+        assert!(!w.state.ui.provision_log_follow);
+
+        w.dispatch(KeyEvent::from(KeyCode::Char('q')));
+        assert!(!w.state.ui.provision_log_open);
+    }
+
+    #[test]
+    fn full_render_covers_normal_review_help_popup_log_and_quit_layers() {
+        let area = Rect::new(0, 0, 120, 36);
+        let mut w = headless(test_scan(), None);
+        let (tx, rx) = std::sync::mpsc::channel();
+        w.state.start_provision_log(rx);
+        tx.send("first".to_string()).unwrap();
+        w.state.poll_provision_log();
+
+        for setup in [
+            |w: &mut Wizard| {
+                w.review_open = false;
+                w.quit_prompt = false;
+                w.state.ui.help_visible = false;
+                w.state.ui.popup = None;
+                w.state.ui.provision_log_open = false;
+            },
+            |w: &mut Wizard| {
+                w.review_open = true;
+            },
+            |w: &mut Wizard| {
+                w.review_open = false;
+                w.state.ui.help_visible = true;
+            },
+            |w: &mut Wizard| {
+                w.state.ui.help_visible = false;
+                w.state.ui.popup = Some(OneShotHelp::Ephemeral);
+            },
+            |w: &mut Wizard| {
+                w.state.ui.popup = None;
+                w.state.ui.provision_log_open = true;
+            },
+            |w: &mut Wizard| {
+                w.state.ui.provision_log_open = false;
+                w.quit_prompt = true;
+            },
+        ] {
+            setup(&mut w);
+            let backend = TestBackend::new(area.width, area.height);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal.draw(|f| w.render(f)).unwrap();
+            let rendered: String =
+                terminal.backend().buffer().content().iter().map(|cell| cell.symbol()).collect();
+            assert!(!rendered.trim().is_empty());
+        }
+    }
+
+    #[test]
+    fn modal_popups_use_main_background() {
+        let area = Rect::new(0, 0, 100, 40);
+        let mut w = headless(test_scan(), None);
+        let (tx, rx) = std::sync::mpsc::channel();
+        w.state.start_provision_log(rx);
+        tx.send("first".to_string()).unwrap();
+        w.state.poll_provision_log();
+        let popup_bg = theme::base().bg.expect("base style has background");
+
+        let backend = TestBackend::new(area.width, area.height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                w.render_help(f, area);
+                assert_bg(f.buffer_mut(), centered(50, 50, area), popup_bg);
+
+                w.render_one_shot_help(f, area, OneShotHelp::Ephemeral);
+                assert_bg(f.buffer_mut(), centered(58, 35, area), popup_bg);
+
+                w.render_provision_log(f, area);
+                assert_bg(f.buffer_mut(), centered(78, 66, area), popup_bg);
+
+                w.render_quit_prompt(f, area);
+                assert_bg(f.buffer_mut(), centered(40, 32, area), popup_bg);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn provision_log_wraps_long_lines_inside_popup() {
+        let area = Rect::new(0, 0, 80, 18);
+        let mut w = headless(test_scan(), None);
+        w.state.provision_log_title = "Oracle tool test".to_string();
+        w.state.provision_log_lines = vec![
+            concat!(
+                "oracle probe produced a long diagnostic with enough words to need wrapping \
+                 before ",
+                "the popup edge and it must still show tail-token-inside-popup"
+            )
+            .to_string(),
+        ];
+
+        let backend = TestBackend::new(area.width, area.height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| w.render_provision_log(f, area)).unwrap();
+        let rendered = buffer_text(terminal.backend().buffer(), area.width, area.height);
+
+        assert!(
+            rendered.contains("tail-token-inside-popup"),
+            "long provision log line should wrap instead of clipping:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn review_shortcut_is_visible_on_every_step_footer() {
+        let area = Rect::new(0, 0, 120, 1);
+        let mut w = headless(test_scan(), None);
+
+        for step in StepId::ALL {
+            w.state.ui.focused = step;
+            let backend = TestBackend::new(area.width, area.height);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal.draw(|f| w.render_footer(f, area)).unwrap();
+            let rendered: String =
+                terminal.backend().buffer().content().iter().map(|cell| cell.symbol()).collect();
+
+            assert!(rendered.contains("w review"), "{step:?} footer: {rendered:?}");
+        }
+    }
+}

--- a/crates/rag-rat-cli/src/init/wizard/probe.rs
+++ b/crates/rag-rat-cli/src/init/wizard/probe.rs
@@ -1,0 +1,402 @@
+//! Off-thread probe machinery: generation tokens, the per-step registry, and the
+//! quit/teardown policy. See docs/init-wizard-design.md ("Off-thread probes + cancellation").
+//!
+//! Slow I/O checks (model downloads, Ollama connects, ephemeral spin-up) never block the UI:
+//! a worker thread runs the probe and reports its `CheckResult` back over an `mpsc`. Results
+//! carry a [`ProbeId`] (`step` + `generation`); the registry **applies a result only if its
+//! generation still matches the current one** for that step. Any config-changing edit to a step
+//! [`bump`](ProbeRegistry::bump)s its generation, so a probe launched against the old config is
+//! dropped on arrival instead of mutating the now-current state.
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{Receiver, Sender, channel};
+use std::thread::{self, JoinHandle};
+
+use super::steps::{CheckResult, StepId};
+
+/// Stable match token for a probe: the step it belongs to plus the step's generation at launch.
+///
+/// A probe reply is applied only if its `probe_id` still equals the registry's current id for
+/// that step (same `generation`). This is what makes stale results inert.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) struct ProbeId {
+    pub step: StepId,
+    pub generation: u64,
+}
+
+/// What a probe is doing — drives the quit/teardown policy (see [`ProbeRegistry::on_quit`]).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum ProbeKind {
+    /// A real Hugging Face model download. Detaches on quit (resumable, nothing leaks).
+    Download,
+    /// A connect check against an already-running endpoint (e.g. Ollama). Cheap, detaches.
+    ConnectTest,
+    /// A billable ephemeral box spin-up. **Must tear down on quit** — no provider backstop.
+    EphemeralTest,
+    /// An oracle-tool availability probe.
+    OracleTool,
+    /// A crates.io latest-version fetch.
+    VersionCheck,
+}
+
+/// Per-step probe lifecycle state.
+#[derive(Clone, Debug)]
+pub(crate) enum ProbeStatus {
+    /// No probe has run (or the last result was superseded by an edit).
+    Idle,
+    /// A probe is in flight; `kind` records what, so [`on_quit`](ProbeRegistry::on_quit) can apply
+    /// the right teardown policy.
+    Running(ProbeKind),
+    /// The probe finished and its result was applied.
+    Done { kind: ProbeKind, result: CheckResult },
+}
+
+/// A worker's reply: the result plus the [`ProbeId`] it was launched under.
+#[derive(Clone, Debug)]
+pub(crate) struct ProbeMsg {
+    pub probe_id: ProbeId,
+    pub kind: ProbeKind,
+    pub result: CheckResult,
+}
+
+/// Per-step generation counters + statuses, fed by a single `mpsc` the workers send into.
+///
+/// `gen[step]` is the authority: it advances on every [`bump`](Self::bump) and is what
+/// [`apply`](Self::apply) compares an incoming message against.
+pub(crate) struct ProbeRegistry {
+    generations: [u64; StepId::COUNT],
+    status: [ProbeStatus; StepId::COUNT],
+    rx: Receiver<ProbeMsg>,
+    tx: Sender<ProbeMsg>,
+    active_ephemeral: Option<EphemeralWorker>,
+}
+
+struct EphemeralWorker {
+    step: StepId,
+    generation: u64,
+    cancel: Arc<AtomicBool>,
+    handle: JoinHandle<()>,
+}
+
+impl Clone for ProbeRegistry {
+    fn clone(&self) -> Self {
+        let (tx, rx) = channel();
+        Self {
+            generations: self.generations,
+            status: self.status.clone(),
+            rx,
+            tx,
+            active_ephemeral: None,
+        }
+    }
+}
+
+impl ProbeRegistry {
+    pub(crate) fn new() -> Self {
+        let (tx, rx) = channel();
+        Self {
+            generations: [0; StepId::COUNT],
+            status: std::array::from_fn(|_| ProbeStatus::Idle),
+            rx,
+            tx,
+            active_ephemeral: None,
+        }
+    }
+
+    /// The current match token for `step` — what a fresh probe should be tagged with, and what
+    /// [`apply`](Self::apply) checks replies against.
+    pub(crate) fn current(&self, step: StepId) -> ProbeId {
+        ProbeId { step, generation: self.generations[step.index()] }
+    }
+
+    /// Advance `step`'s generation. Call on every config-changing edit to that step: stale replies
+    /// will no longer match, and an in-flight ephemeral worker is cancelled before its status is
+    /// cleared.
+    pub(crate) fn bump(&mut self, step: StepId) {
+        self.cancel_active_ephemeral_for_step(step);
+        self.generations[step.index()] += 1;
+        self.status[step.index()] = ProbeStatus::Idle;
+    }
+
+    /// Apply a probe reply iff it is still current (`msg.probe_id == current(step)`).
+    ///
+    /// Returns whether it was applied. A stale message (older generation, because the step was
+    /// edited after the probe launched) is dropped and leaves status untouched.
+    pub(crate) fn apply(&mut self, msg: ProbeMsg) -> bool {
+        let step = msg.probe_id.step;
+        let generation = msg.probe_id.generation;
+        let kind = msg.kind;
+        if msg.probe_id == self.current(step) {
+            self.status[step.index()] = ProbeStatus::Done { kind: msg.kind, result: msg.result };
+            if kind == ProbeKind::EphemeralTest {
+                self.join_completed_ephemeral(step, generation);
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    /// The current lifecycle state of `step`'s probe.
+    pub(crate) fn status(&self, step: StepId) -> &ProbeStatus {
+        &self.status[step.index()]
+    }
+
+    /// Launch a probe for `step` on a worker thread.
+    ///
+    /// [`bump`](Self::bump)s the generation first, marks the step `Running(kind)`, then runs `work`
+    /// off-thread and sends a [`ProbeMsg`] tagged with the **new** [`ProbeId`]. The reply is
+    /// delivered to [`poll`](Self::poll), which only applies it if the generation still matches.
+    /// For ephemeral probes, later edits also cancel and join the worker before clearing
+    /// status, because the worker can own billable remote resources.
+    pub(crate) fn spawn(
+        &mut self,
+        step: StepId,
+        kind: ProbeKind,
+        work: impl FnOnce() -> CheckResult + Send + 'static,
+    ) {
+        if kind == ProbeKind::EphemeralTest {
+            self.spawn_ephemeral(step, move |_| work());
+            return;
+        }
+        self.bump(step);
+        self.status[step.index()] = ProbeStatus::Running(kind);
+        let probe_id = self.current(step);
+        let tx = self.tx.clone();
+        thread::spawn(move || {
+            let result = work();
+            // The receiver outlives the registry for the wizard's lifetime; if it's already
+            // gone (registry dropped mid-probe) the send fails harmlessly and
+            // the result is discarded.
+            let _ = tx.send(ProbeMsg { probe_id, kind, result });
+        });
+    }
+
+    pub(crate) fn spawn_ephemeral(
+        &mut self,
+        step: StepId,
+        work: impl FnOnce(Arc<AtomicBool>) -> CheckResult + Send + 'static,
+    ) {
+        self.bump(step);
+        self.status[step.index()] = ProbeStatus::Running(ProbeKind::EphemeralTest);
+        let probe_id = self.current(step);
+        let tx = self.tx.clone();
+        let cancel = Arc::new(AtomicBool::new(false));
+        let worker_cancel = Arc::clone(&cancel);
+        let handle = thread::spawn(move || {
+            if worker_cancel.load(Ordering::Acquire) {
+                return;
+            }
+            let result = work(Arc::clone(&worker_cancel));
+            if !worker_cancel.load(Ordering::Acquire) {
+                // The receiver outlives the registry for the wizard's lifetime; if it's already
+                // gone (registry dropped mid-probe) the send fails harmlessly and the result is
+                // discarded.
+                let _ = tx.send(ProbeMsg { probe_id, kind: ProbeKind::EphemeralTest, result });
+            }
+        });
+        self.active_ephemeral =
+            Some(EphemeralWorker { step, generation: probe_id.generation, cancel, handle });
+    }
+
+    /// Drain every pending worker reply and [`apply`](Self::apply) each. Called once per
+    /// event-loop tick. Non-blocking: returns immediately when the channel is empty.
+    pub(crate) fn poll(&mut self) -> Vec<(StepId, ProbeKind, CheckResult)> {
+        let mut applied = Vec::new();
+        while let Ok(msg) = self.rx.try_recv() {
+            let step = msg.probe_id.step;
+            let kind = msg.kind;
+            let result = msg.result.clone();
+            if self.apply(msg) {
+                applied.push((step, kind, result));
+            }
+        }
+        applied
+    }
+
+    /// Quit-time teardown policy, keyed on the in-flight [`ProbeKind`] of each `Running` step.
+    ///
+    /// The two probe kinds that can be airborne at quit have **opposite** correct behaviors:
+    ///
+    /// - [`ProbeKind::Download`] (and the other cheap/idempotent kinds — `ConnectTest`,
+    ///   `OracleTool`, `VersionCheck`): **detach freely.** A partial HF download is resumable and
+    ///   nothing is leaked by walking away, so we don't wait on them.
+    /// - [`ProbeKind::EphemeralTest`]: **must trigger a bounded teardown.** This probe provisions a
+    ///   *billable* ephemeral GPU box, and RunPod on-demand pods have **no provider-side backstop**
+    ///   (unlike Modal, which self-destructs at ~30 min). Abandoning the box on quit would leak a
+    ///   live, billing instance indefinitely. Quit must therefore drive the box down through the
+    ///   cookbook process-group teardown machinery (SIGTERM → grace → SIGKILL) and wait only for
+    ///   that bounded teardown to finish.
+    ///
+    /// Task 14 wired the ephemeral spin-up PATH (`steps::remote` → core `verify_ephemeral_remote` →
+    /// `provision_and_build`): the worker holds the `ProvisionedBox` for the whole provision→ping
+    /// round-trip, and that box's `Drop` IS the bounded SIGTERM → grace → SIGKILL process-group
+    /// teardown. So a probe that runs to completion (or whose worker thread unwinds) always tears
+    /// its box down. The cookbook provider ALSO installs a process-level SIGINT/SIGTERM handler
+    /// (`ACTIVE_PGID`) that reaps a live process group on SIGINT/SIGTERM, so a **signal** quit
+    /// (Ctrl-C / SIGTERM) is backstopped there.
+    ///
+    /// A clean-process-exit quit (`q`/`Esc`, no signal) is closed by Task 14b: this path calls
+    /// [`abort_active_provisioning`](rag_rat_core::index::ai::abort_active_provisioning), which
+    /// runs the same bounded SIGTERM → grace → SIGKILL teardown against the live `ACTIVE_PGID`
+    /// from outside the detached worker. It is a no-op when no box is live (`ACTIVE_PGID ==
+    /// 0`), so it is safe to call unconditionally on every in-flight ephemeral probe at quit.
+    pub(crate) fn on_quit(&mut self) {
+        self.cancel_active_ephemeral();
+        for status in &mut self.status {
+            if let ProbeStatus::Running(kind) = status {
+                match kind {
+                    // Detach: resumable / nothing to clean up.
+                    ProbeKind::Download
+                    | ProbeKind::ConnectTest
+                    | ProbeKind::OracleTool
+                    | ProbeKind::VersionCheck => {},
+                    // Billable box. Tear down the live process group from outside the detached
+                    // worker: a bounded SIGTERM → grace → SIGKILL against `ACTIVE_PGID`.
+                    ProbeKind::EphemeralTest => {
+                        rag_rat_core::index::ai::abort_active_provisioning();
+                    },
+                }
+                *status = ProbeStatus::Idle;
+            }
+        }
+    }
+
+    fn cancel_active_ephemeral_for_step(&mut self, step: StepId) {
+        if self.active_ephemeral.as_ref().is_some_and(|worker| worker.step == step) {
+            self.cancel_active_ephemeral();
+        }
+    }
+
+    fn cancel_active_ephemeral(&mut self) {
+        let Some(worker) = self.active_ephemeral.take() else { return };
+        worker.cancel.store(true, Ordering::Release);
+        rag_rat_core::index::ai::abort_active_provisioning();
+        let _ = worker.handle.join();
+        if self.generations[worker.step.index()] == worker.generation {
+            self.status[worker.step.index()] = ProbeStatus::Idle;
+        }
+    }
+
+    fn join_completed_ephemeral(&mut self, step: StepId, generation: u64) {
+        let Some(worker) = self.active_ephemeral.take() else { return };
+        if worker.step == step && worker.generation == generation {
+            let _ = worker.handle.join();
+        } else {
+            self.active_ephemeral = Some(worker);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stale_probe_result_is_dropped() {
+        let mut reg = ProbeRegistry::new();
+        let id0 = reg.current(StepId::Embedding);
+        reg.bump(StepId::Embedding); // user edited → generation advanced
+        let applied = reg.apply(ProbeMsg {
+            probe_id: id0,
+            kind: ProbeKind::ConnectTest,
+            result: CheckResult::ok(),
+        });
+        assert!(!applied); // id0 is stale → dropped
+        assert!(matches!(reg.status(StepId::Embedding), ProbeStatus::Idle));
+        let id1 = reg.current(StepId::Embedding);
+        assert!(reg.apply(ProbeMsg {
+            probe_id: id1,
+            kind: ProbeKind::ConnectTest,
+            result: CheckResult::ok(),
+        }));
+    }
+
+    #[test]
+    fn spawn_then_poll_applies_result() {
+        let mut reg = ProbeRegistry::new();
+        reg.spawn(StepId::Integration, ProbeKind::VersionCheck, CheckResult::ok);
+        // busy-wait briefly for the worker
+        for _ in 0..100 {
+            reg.poll();
+            if matches!(reg.status(StepId::Integration), ProbeStatus::Done { .. }) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert!(matches!(reg.status(StepId::Integration), ProbeStatus::Done {
+            kind: ProbeKind::VersionCheck,
+            ..
+        }));
+    }
+
+    #[test]
+    fn bump_cancels_active_ephemeral_before_clearing_status() {
+        use std::time::Duration;
+
+        let mut reg = ProbeRegistry::new();
+        let (started_tx, started_rx) = channel();
+        reg.spawn(StepId::Embedding, ProbeKind::EphemeralTest, move || {
+            let _ = started_tx.send(());
+            std::thread::sleep(Duration::from_millis(20));
+            CheckResult::ok()
+        });
+        started_rx.recv().unwrap();
+        assert!(matches!(
+            reg.status(StepId::Embedding),
+            ProbeStatus::Running(ProbeKind::EphemeralTest)
+        ));
+
+        reg.bump(StepId::Embedding);
+
+        assert!(matches!(reg.status(StepId::Embedding), ProbeStatus::Idle));
+        assert!(reg.poll().is_empty());
+    }
+
+    #[test]
+    fn bump_signals_active_ephemeral_worker_before_joining() {
+        use std::time::Duration;
+
+        let mut reg = ProbeRegistry::new();
+        let (started_tx, started_rx) = channel();
+        let saw_cancel = Arc::new(AtomicBool::new(false));
+        let worker_saw_cancel = Arc::clone(&saw_cancel);
+        reg.spawn_ephemeral(StepId::Embedding, move |cancel| {
+            let _ = started_tx.send(());
+            while !cancel.load(Ordering::Acquire) {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            worker_saw_cancel.store(true, Ordering::Release);
+            CheckResult::ok()
+        });
+        started_rx.recv().unwrap();
+
+        reg.bump(StepId::Embedding);
+
+        assert!(saw_cancel.load(Ordering::Acquire));
+        assert!(matches!(reg.status(StepId::Embedding), ProbeStatus::Idle));
+        assert!(reg.poll().is_empty());
+    }
+
+    #[test]
+    fn on_quit_waits_for_active_ephemeral_worker() {
+        use std::time::Duration;
+
+        let mut reg = ProbeRegistry::new();
+        let (started_tx, started_rx) = channel();
+        let finished = Arc::new(AtomicBool::new(false));
+        let worker_finished = Arc::clone(&finished);
+        reg.spawn(StepId::Embedding, ProbeKind::EphemeralTest, move || {
+            let _ = started_tx.send(());
+            std::thread::sleep(Duration::from_millis(20));
+            worker_finished.store(true, Ordering::Release);
+            CheckResult::ok()
+        });
+        started_rx.recv().unwrap();
+
+        reg.on_quit();
+
+        assert!(finished.load(Ordering::Acquire));
+        assert!(matches!(reg.status(StepId::Embedding), ProbeStatus::Idle));
+    }
+}

--- a/crates/rag-rat-cli/src/init/wizard/review.rs
+++ b/crates/rag-rat-cli/src/init/wizard/review.rs
@@ -1,0 +1,562 @@
+//! Review screen model — summary, reconfigure diff, and write gate.
+//!
+//! [`ReviewModel::build`] computes:
+//! - `summary`: human-readable lines describing the current draft config.
+//! - `warnings`: `Warn`-severity messages from `state.checks`.
+//! - `diff`: for reconfigure mode (`original` is `Some`), a minimal line diff between the original
+//!   TOML and the patched output. `None` for fresh init.
+//! - `ephemeral_unverified`: `true` when the draft uses an ephemeral remote BUT the Remote step's
+//!   spin-up probe has not completed successfully — prompts the user for an explicit "keep anyway"
+//!   acknowledgement before confirming.
+//!
+//! [`ReviewModel::can_confirm`] is false if any step carries a `Block` severity — the write gate
+//! is closed.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::Modifier;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Paragraph, Wrap};
+
+use super::draft::RemoteMode;
+use super::probe::{ProbeKind, ProbeStatus};
+use super::state::WizardState;
+use super::steps::{CheckResult, Sev as CheckSeverity, StepId, can_write};
+use super::theme;
+
+/// The computed review model — built once per render tick (or on demand in tests).
+#[derive(Debug)]
+pub(crate) struct ReviewModel {
+    /// Human-readable config summary lines, one concept per line.
+    pub summary: Vec<String>,
+    /// `Warn`-severity messages from `state.checks`; `Block`s surface via `can_confirm`.
+    pub warnings: Vec<String>,
+    /// Line diff (reconfigure mode only): changed/added/removed lines between the original TOML
+    /// and the patched output. `None` for fresh init.
+    pub diff: Option<String>,
+    /// `true` when the draft's remote is Ephemeral AND the Remote probe hasn't passed — the UI
+    /// must require an explicit "keep anyway" toggle before enabling Confirm.
+    pub ephemeral_unverified: bool,
+    /// Cached write-gate result — `true` if any step is `Block`. Set at build time.
+    blocked: bool,
+}
+
+impl ReviewModel {
+    /// Build the review model from the current wizard state.
+    ///
+    /// `original` is the raw contents of the existing `rag-rat.toml` (reconfigure path).
+    /// Pass `None` for a fresh `rag-rat init`.
+    pub(crate) fn build(state: &WizardState, original: Option<&str>) -> Self {
+        let draft = &state.draft;
+
+        // ── write gate ───────────────────────────────────────────────────────────
+        let blocked = !can_write(&state.checks);
+
+        // ── summary ──────────────────────────────────────────────────────────────
+        let mut summary: Vec<String> = Vec::new();
+
+        // Root
+        summary.push(format!("  root:       {}", draft.root_value));
+
+        // Languages + directories
+        if draft.bindings.is_empty() {
+            summary.push("  languages:  (none selected)".to_string());
+        } else {
+            for (lang, dirs) in &draft.bindings {
+                let dir_list: Vec<&str> = dirs.iter().filter_map(|p| p.to_str()).collect();
+                summary.push(format!("  {:10}  {}", lang.as_str(), dir_list.join(", ")));
+            }
+        }
+
+        // Embedding model
+        summary.push(format!("  model:      {}", draft.model));
+
+        // Remote mode
+        match &draft.remote {
+            None => summary.push("  remote:     none (in-process embeddings)".to_string()),
+            Some(r) => match &r.mode {
+                RemoteMode::Connect(ep) => {
+                    summary.push(format!("  remote:     connect  {}", ep));
+                },
+                RemoteMode::Ephemeral(cb) => {
+                    summary.push(format!("  remote:     ephemeral  cookbook={}", cb));
+                },
+            },
+        }
+
+        // Oracle auto_run
+        summary.push(format!(
+            "  oracle:     auto_run={}",
+            if draft.oracle_auto_run { "yes" } else { "no" }
+        ));
+
+        // Version check
+        summary.push(format!(
+            "  version:    check={}",
+            if draft.version_check { "yes" } else { "no" }
+        ));
+
+        // Hooks to install
+        {
+            let mut hooks: Vec<&str> = Vec::new();
+            if draft.hooks.git {
+                hooks.push("git");
+            }
+            if draft.hooks.claude {
+                if draft.hooks.claude_global {
+                    hooks.push("claude (global)");
+                } else {
+                    hooks.push("claude (project)");
+                }
+            }
+            if hooks.is_empty() {
+                summary.push("  hooks:      none".to_string());
+            } else {
+                summary.push(format!("  hooks:      {}", hooks.join(", ")));
+            }
+        }
+
+        // ── warnings ─────────────────────────────────────────────────────────────
+        let warnings: Vec<String> = state
+            .checks
+            .iter()
+            .filter(|c| c.severity == CheckSeverity::Warn)
+            .filter_map(|c| c.message.clone())
+            .collect();
+
+        // ── diff ─────────────────────────────────────────────────────────────────
+        let diff = original.and_then(|orig| {
+            let patched = draft.patch_existing(orig).ok()?;
+            Some(line_diff(orig, &patched))
+        });
+
+        // ── ephemeral_unverified ─────────────────────────────────────────────────
+        let ephemeral_unverified = matches!(&draft.remote, Some(r) if matches!(r.mode, RemoteMode::Ephemeral(_)))
+            && !matches!(state.probes.status(StepId::Embedding), ProbeStatus::Done {
+                kind: ProbeKind::EphemeralTest,
+                result: CheckResult { severity: CheckSeverity::Ok, .. },
+            });
+
+        Self { summary, warnings, diff, ephemeral_unverified, blocked }
+    }
+
+    /// `true` iff the write gate is open: no step is `Block`, AND an unverified ephemeral remote
+    /// has been explicitly kept (the user pressed `K`). `ephemeral_acknowledged` is the UI-state
+    /// "keep anyway" flag — irrelevant unless `ephemeral_unverified`, but always required to pass
+    /// when it is, so a billable-but-unproven remote can't be written on a single `c`.
+    pub(crate) fn can_confirm(&self, ephemeral_acknowledged: bool) -> bool {
+        if self.blocked {
+            return false;
+        }
+        if self.ephemeral_unverified && !ephemeral_acknowledged {
+            return false;
+        }
+        true
+    }
+
+    pub(crate) fn body_line_count(&self) -> usize {
+        let mut count = 1 + self.summary.len();
+        if !self.warnings.is_empty() {
+            count += 2 + self.warnings.len();
+        }
+        if self.ephemeral_unverified {
+            count += 2;
+        }
+        if let Some(diff) = &self.diff {
+            count += 2 + diff.lines().count();
+        }
+        if self.blocked {
+            count += 2;
+        }
+        count
+    }
+}
+
+/// Render the review screen into `area`.
+pub(crate) fn render(model: &ReviewModel, f: &mut Frame, area: Rect, scroll: u16) {
+    use ratatui::layout::{Constraint, Direction, Layout};
+    use ratatui::widgets::Clear;
+
+    // Clear the full area so step content doesn't bleed through.
+    f.render_widget(Clear, area);
+    f.render_widget(Block::default().style(theme::base()), area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(2), Constraint::Min(0), Constraint::Length(1)])
+        .split(area);
+
+    // Title bar
+    let title = Paragraph::new(Line::from(vec![
+        Span::styled("Review", theme::title()),
+        Span::raw(" — confirm to write"),
+    ]))
+    .style(theme::base());
+    f.render_widget(title, chunks[0]);
+
+    // Body
+    let mut lines: Vec<Line> = Vec::new();
+
+    lines.push(Line::from(Span::styled("Configuration", theme::heading())));
+    for s in &model.summary {
+        lines.push(Line::from(Span::raw(s.clone())));
+    }
+
+    if !model.warnings.is_empty() {
+        lines.push(Line::from(Span::raw("")));
+        lines.push(Line::from(Span::styled(
+            "Warnings",
+            theme::warning().add_modifier(Modifier::UNDERLINED),
+        )));
+        for w in &model.warnings {
+            lines
+                .push(Line::from(vec![Span::styled("! ", theme::warning()), Span::raw(w.clone())]));
+        }
+    }
+
+    if model.ephemeral_unverified {
+        lines.push(Line::from(Span::raw("")));
+        lines.push(Line::from(Span::styled(
+            "Ephemeral remote has not been verified — press 'K' to keep anyway.",
+            theme::warning(),
+        )));
+    }
+
+    if let Some(diff) = &model.diff {
+        lines.push(Line::from(Span::raw("")));
+        lines.push(Line::from(Span::styled("Changes", theme::heading())));
+        for diff_line in diff.lines() {
+            let style = if diff_line.starts_with('+') {
+                theme::success()
+            } else if diff_line.starts_with('-') {
+                theme::error()
+            } else {
+                theme::base()
+            };
+            lines.push(Line::from(Span::styled(diff_line.to_string(), style)));
+        }
+    }
+
+    // Blocking errors close the gate outright; the ephemeral-keep prompt above handles the softer
+    // "press K" gate. Use `blocked` directly (same module) rather than `can_confirm`, which also
+    // needs the UI-state acknowledgement the renderer doesn't carry.
+    if model.blocked {
+        lines.push(Line::from(Span::raw("")));
+        lines.push(Line::from(Span::styled(
+            "Cannot confirm: one or more steps have blocking errors.",
+            theme::error(),
+        )));
+    }
+
+    let body = Paragraph::new(lines)
+        .style(theme::base())
+        .block(theme::block("Summary"))
+        .scroll((scroll, 0))
+        .wrap(Wrap { trim: false });
+    f.render_widget(body, chunks[1]);
+
+    let footer = if model.ephemeral_unverified {
+        " c save changes after K  K keep unverified remote  q/Esc back "
+    } else if model.blocked {
+        " c save changes (blocked)  q/Esc back "
+    } else {
+        " c save changes  q/Esc back "
+    };
+    f.render_widget(Paragraph::new(footer).style(theme::footer()), chunks[2]);
+}
+
+// ── Minimal line diff ─────────────────────────────────────────────────────────
+
+/// Produce a minimal unified-style line diff between `before` and `after`.
+///
+/// Uses an LCS (longest common subsequence) algorithm so that structural changes —
+/// inserting or removing blocks — do not cause unchanged lines to appear as
+/// modified. Lines common to both are emitted as context (prefix `  `), lines only
+/// in `before` are prefixed with `-`, and lines only in `after` are prefixed with
+/// `+`. Context lines are included so the reader can orient themselves.
+///
+/// The algorithm is a standard O(mn) DP table backtrack, which is perfectly
+/// adequate for the small TOML files rag-rat manages. No external crate is used.
+fn line_diff(before: &str, after: &str) -> String {
+    let b: Vec<&str> = before.lines().collect();
+    let a: Vec<&str> = after.lines().collect();
+    let (m, n) = (b.len(), a.len());
+
+    // Build LCS length table.
+    // dp[i][j] = LCS length of b[..i] vs a[..j].
+    let mut dp = vec![vec![0usize; n + 1]; m + 1];
+    for i in 1..=m {
+        for j in 1..=n {
+            if b[i - 1] == a[j - 1] {
+                dp[i][j] = dp[i - 1][j - 1] + 1;
+            } else {
+                dp[i][j] = dp[i - 1][j].max(dp[i][j - 1]);
+            }
+        }
+    }
+
+    // Backtrack to produce the edit script.
+    #[derive(Debug)]
+    enum Edit<'s> {
+        Context(&'s str),
+        Remove(&'s str),
+        Add(&'s str),
+    }
+
+    let mut edits: Vec<Edit<'_>> = Vec::new();
+    let (mut i, mut j) = (m, n);
+    while i > 0 || j > 0 {
+        if i > 0 && j > 0 && b[i - 1] == a[j - 1] {
+            edits.push(Edit::Context(b[i - 1]));
+            i -= 1;
+            j -= 1;
+        } else if j > 0 && (i == 0 || dp[i][j - 1] >= dp[i - 1][j]) {
+            edits.push(Edit::Add(a[j - 1]));
+            j -= 1;
+        } else {
+            edits.push(Edit::Remove(b[i - 1]));
+            i -= 1;
+        }
+    }
+    edits.reverse();
+
+    // Render: only emit context lines that neighbour a change (one line either
+    // side) so the output stays compact for large unchanged configs. If there are
+    // no changes at all, return an empty string.
+    let has_change = edits.iter().any(|e| !matches!(e, Edit::Context(_)));
+    if !has_change {
+        return String::new();
+    }
+
+    // Mark which context lines are adjacent to a change.
+    let n_edits = edits.len();
+    let mut show = vec![false; n_edits];
+    for idx in 0..n_edits {
+        if !matches!(edits[idx], Edit::Context(_)) {
+            // Show one context line before and after each change.
+            if idx > 0 {
+                show[idx - 1] = true;
+            }
+            show[idx] = true;
+            if idx + 1 < n_edits {
+                show[idx + 1] = true;
+            }
+        }
+    }
+
+    let mut output: Vec<String> = Vec::new();
+    for (idx, edit) in edits.iter().enumerate() {
+        match edit {
+            Edit::Context(line) =>
+                if show[idx] {
+                    output.push(format!("  {}", line));
+                },
+            Edit::Remove(line) => output.push(format!("-{}", line)),
+            Edit::Add(line) => output.push(format!("+{}", line)),
+        }
+    }
+
+    output.join("\n")
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use rag_rat_core::language::Language;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    use super::*;
+    use crate::init::RepoScan;
+    use crate::init::wizard::draft::WizardDraft;
+    use crate::init::wizard::probe::{ProbeKind, ProbeMsg};
+    use crate::init::wizard::state::WizardState;
+    use crate::init::wizard::steps::CheckResult;
+
+    fn bare_state() -> WizardState {
+        let draft =
+            WizardDraft::from_scan(&RepoScan::default(), ".".to_string(), PathBuf::from("."));
+        WizardState::new(draft, RepoScan::default())
+    }
+
+    fn state_with_block(step: StepId) -> WizardState {
+        let mut st = bare_state();
+        st.checks[step.index()] = CheckResult::block("test block");
+        st
+    }
+
+    fn state_with_binding(dir: &str) -> WizardState {
+        let mut st = bare_state();
+        st.draft.bindings.insert(Language::Rust, vec![PathBuf::from(dir)]);
+        st
+    }
+
+    /// A state whose draft uses an EPHEMERAL remote with no passing spin-up probe → the Review
+    /// model is `ephemeral_unverified` (the probe registry has no `Done(Ok)` entry by default).
+    fn state_with_unverified_ephemeral() -> WizardState {
+        use crate::init::wizard::draft::{RemoteDraft, RemoteMode};
+        let mut st = bare_state();
+        st.draft.remote = Some(RemoteDraft {
+            model: "all-minilm".to_string(),
+            mode: RemoteMode::Ephemeral("some-cookbook".to_string()),
+            gpu: None,
+            num_ctx: None,
+            batch_size: 32,
+            auth_env: None,
+        });
+        st
+    }
+
+    // ── brief tests ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn review_blocks_confirm_when_a_step_blocks() {
+        let st = state_with_block(StepId::Indexing);
+        let r = ReviewModel::build(&st, None);
+        // A Block closes the gate regardless of the ephemeral acknowledgement.
+        assert!(!r.can_confirm(false));
+        assert!(!r.can_confirm(true));
+    }
+
+    #[test]
+    fn review_diff_shows_changed_lines() {
+        let original = "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n";
+        let st = state_with_binding("crates");
+        let r = ReviewModel::build(&st, Some(original));
+        assert!(r.diff.unwrap().contains("crates"));
+    }
+
+    // ── additional coverage ───────────────────────────────────────────────────
+
+    #[test]
+    fn review_allows_confirm_with_no_blocks() {
+        let st = bare_state();
+        let r = ReviewModel::build(&st, None);
+        // No ephemeral remote → the acknowledgement is irrelevant; the gate is open either way.
+        assert!(r.can_confirm(false));
+        assert!(r.can_confirm(true));
+    }
+
+    /// An unverified ephemeral remote gates Confirm on the `k` acknowledgement: closed without it,
+    /// open once granted (no step Blocks here, so only the keep-anyway gate applies).
+    #[test]
+    fn unverified_ephemeral_requires_keep_acknowledgement() {
+        let st = state_with_unverified_ephemeral();
+        let r = ReviewModel::build(&st, None);
+        assert!(
+            r.ephemeral_unverified,
+            "ephemeral remote with no passing probe must be unverified"
+        );
+        assert!(!r.can_confirm(false), "Confirm must be closed until the user presses K");
+        assert!(r.can_confirm(true), "pressing K (acknowledged) opens Confirm");
+    }
+
+    #[test]
+    fn only_ephemeral_probe_success_verifies_ephemeral_remote() {
+        let mut st = state_with_unverified_ephemeral();
+        let probe_id = st.probes.current(StepId::Embedding);
+        assert!(st.probes.apply(ProbeMsg {
+            probe_id,
+            kind: ProbeKind::Download,
+            result: CheckResult::ok(),
+        }));
+        assert!(
+            ReviewModel::build(&st, None).ephemeral_unverified,
+            "a download probe must not verify an ephemeral remote"
+        );
+
+        let probe_id = st.probes.current(StepId::Embedding);
+        assert!(st.probes.apply(ProbeMsg {
+            probe_id,
+            kind: ProbeKind::EphemeralTest,
+            result: CheckResult::ok(),
+        }));
+        assert!(!ReviewModel::build(&st, None).ephemeral_unverified);
+    }
+
+    #[test]
+    fn review_collects_warnings() {
+        let mut st = bare_state();
+        st.checks[StepId::Integration.index()] = CheckResult::warn("git not on PATH");
+        let r = ReviewModel::build(&st, None);
+        assert!(r.warnings.iter().any(|w| w.contains("git not on PATH")));
+    }
+
+    #[test]
+    fn review_diff_is_none_for_fresh_init() {
+        let st = bare_state();
+        let r = ReviewModel::build(&st, None);
+        assert!(r.diff.is_none());
+    }
+
+    #[test]
+    fn review_footer_explains_save_key() {
+        let st = bare_state();
+        let model = ReviewModel::build(&st, None);
+        let backend = TestBackend::new(80, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render(&model, f, f.area(), 0)).unwrap();
+        let buffer = terminal.backend().buffer();
+        let screen = (0..20)
+            .map(|y| (0..80).map(|x| buffer[(x, y)].symbol()).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(screen.contains("c save changes"));
+    }
+
+    #[test]
+    fn line_diff_shows_added_and_removed() {
+        let before = "a\nb\nc\n";
+        let after = "a\nX\nc\n";
+        let diff = line_diff(before, after);
+        assert!(diff.contains("-b"), "removed line must be prefixed -");
+        assert!(diff.contains("+X"), "added line must be prefixed +");
+        // "a" and "c" may appear as context (  a /  c) but must not appear as
+        // changes (i.e. must not be prefixed with + or -).
+        for line in diff.lines() {
+            if line.starts_with('+') || line.starts_with('-') {
+                assert!(
+                    !line.ends_with('a') || line.contains('X') || line.contains('b'),
+                    "unchanged line 'a' must not be marked changed"
+                );
+                assert!(!line.ends_with('c'), "unchanged line 'c' must not be marked changed");
+            }
+        }
+    }
+
+    /// Regression test: inserting a new block must not cause lines *after* the
+    /// insertion point to appear as changed.  The positional diff wrongly shifted
+    /// every post-insertion line onto the wrong counterpart; the LCS diff must not.
+    #[test]
+    fn line_diff_structural_insert_does_not_corrupt_trailing_unchanged_lines() {
+        // Minimal two-section TOML; `after` gains a new `[remote]` block between
+        // `[index]` and the trailing `version_check` line.
+        let before = "[index]\nroot = \".\"\nversion_check = true\n";
+        let after = "[index]\nroot = \".\"\n[remote]\nmode = \"connect\"\nversion_check = true\n";
+
+        let diff = line_diff(before, after);
+
+        // The two new lines must appear as additions.
+        assert!(
+            diff.lines().any(|l| l == "+[remote]"),
+            "new [remote] header must be marked added; diff:\n{diff}"
+        );
+        assert!(
+            diff.lines().any(|l| l == "+mode = \"connect\""),
+            "new mode line must be marked added; diff:\n{diff}"
+        );
+
+        // The `version_check` line exists in both — it must NOT be marked changed.
+        for line in diff.lines() {
+            assert!(
+                !(line.starts_with('+') || line.starts_with('-'))
+                    || !line.contains("version_check"),
+                "unchanged 'version_check' line must not be marked as changed; diff:\n{diff}"
+            );
+        }
+    }
+}

--- a/crates/rag-rat-cli/src/init/wizard/state.rs
+++ b/crates/rag-rat-cli/src/init/wizard/state.rs
@@ -1,0 +1,178 @@
+//! WizardState and WizardUiState — minimal state container.
+
+use std::collections::HashMap;
+use std::sync::mpsc::{Receiver, TryRecvError};
+
+use super::catalog::CookbookCatalog;
+use super::draft::WizardDraft;
+use super::probe::ProbeRegistry;
+use super::steps::hooks::HookConflict;
+use super::steps::{CheckResult, StepId, StepState};
+use crate::init::RepoScan;
+
+pub(crate) const PROVISION_CONFIRM_WORD: &str = "provision";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum OneShotHelp {
+    EmbeddingOff,
+    Connect,
+    Ephemeral,
+}
+
+impl OneShotHelp {
+    fn for_remote_mode(mode: usize) -> Option<Self> {
+        match mode {
+            0 => Some(Self::EmbeddingOff),
+            1 => Some(Self::Connect),
+            2 => Some(Self::Ephemeral),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct WizardUiState {
+    pub focused: StepId,
+    pub tab: usize,
+    pub help_visible: bool,
+    pub popup: Option<OneShotHelp>,
+    pub remote_mode_help_seen: [bool; 3],
+    pub review_scroll: u16,
+    pub provision_log_open: bool,
+    pub provision_log_scroll: u16,
+    pub provision_log_follow: bool,
+    pub provision_confirm: String,
+    pub ephemeral_keep_acknowledged: bool,
+}
+
+impl WizardUiState {
+    pub(crate) fn new() -> Self {
+        Self {
+            focused: StepId::Indexing,
+            tab: 0,
+            help_visible: false,
+            popup: None,
+            remote_mode_help_seen: [false; 3],
+            review_scroll: 0,
+            provision_log_open: false,
+            provision_log_scroll: 0,
+            provision_log_follow: true,
+            provision_confirm: String::new(),
+            ephemeral_keep_acknowledged: false,
+        }
+    }
+
+    pub(crate) fn show_remote_mode_help_once(&mut self, mode: usize) {
+        let Some(help) = OneShotHelp::for_remote_mode(mode) else { return };
+        if let Some(seen) = self.remote_mode_help_seen.get_mut(mode)
+            && !*seen
+        {
+            *seen = true;
+            self.popup = Some(help);
+        }
+    }
+}
+
+pub(crate) fn provision_confirm_satisfied(ui: &WizardUiState) -> bool {
+    ui.provision_confirm.trim() == PROVISION_CONFIRM_WORD
+}
+
+pub(crate) struct WizardState {
+    pub draft: WizardDraft,
+    pub cookbooks: CookbookCatalog,
+    pub ui: WizardUiState,
+    pub scan: RepoScan,
+    pub probes: ProbeRegistry,
+    pub checks: Vec<CheckResult>,
+    pub hook_conflicts: HashMap<&'static str, HookConflict>,
+    pub step: Option<StepState>,
+    pub provision_log_rx: Option<Receiver<String>>,
+    pub provision_log_lines: Vec<String>,
+    pub provision_log_title: String,
+}
+
+impl WizardState {
+    #[cfg(test)]
+    pub(crate) fn new(draft: WizardDraft, scan: RepoScan) -> Self {
+        Self::with_cookbooks(draft, scan, CookbookCatalog::default())
+    }
+
+    pub(crate) fn with_cookbooks(
+        draft: WizardDraft,
+        scan: RepoScan,
+        cookbooks: CookbookCatalog,
+    ) -> Self {
+        let n = StepId::COUNT;
+        Self {
+            draft,
+            cookbooks,
+            ui: WizardUiState::new(),
+            scan,
+            probes: ProbeRegistry::new(),
+            checks: vec![CheckResult::ok(); n],
+            hook_conflicts: HashMap::new(),
+            step: None,
+            provision_log_rx: None,
+            provision_log_lines: Vec::new(),
+            provision_log_title: "Log".to_string(),
+        }
+    }
+
+    pub(crate) fn start_provision_log(&mut self, rx: Receiver<String>) {
+        self.start_probe_log(rx, "Provision log", "Starting ephemeral provision test...");
+    }
+
+    pub(crate) fn start_oracle_log(&mut self, rx: Receiver<String>) {
+        self.start_probe_log(rx, "Oracle tool test", "Starting Oracle tool test...");
+    }
+
+    pub(crate) fn start_download_log(&mut self, rx: Receiver<String>, model_id: &str) {
+        self.start_probe_log(rx, "Model download", format!("Starting model download: {model_id}"));
+    }
+
+    fn start_probe_log(
+        &mut self,
+        rx: Receiver<String>,
+        title: impl Into<String>,
+        first_line: impl Into<String>,
+    ) {
+        self.provision_log_rx = Some(rx);
+        self.provision_log_title = title.into();
+        self.provision_log_lines.clear();
+        self.provision_log_lines.push(first_line.into());
+        self.ui.provision_log_open = true;
+        self.ui.provision_log_scroll = u16::MAX;
+        self.ui.provision_log_follow = true;
+    }
+
+    pub(crate) fn poll_provision_log(&mut self) {
+        let mut disconnected = false;
+        let mut received = false;
+        if let Some(rx) = &self.provision_log_rx {
+            loop {
+                match rx.try_recv() {
+                    Ok(line) => {
+                        self.provision_log_lines.push(line);
+                        received = true;
+                    },
+                    Err(TryRecvError::Empty) => break,
+                    Err(TryRecvError::Disconnected) => {
+                        disconnected = true;
+                        break;
+                    },
+                }
+            }
+        }
+        const MAX_PROVISION_LOG_LINES: usize = 1_000;
+        if self.provision_log_lines.len() > MAX_PROVISION_LOG_LINES {
+            let excess = self.provision_log_lines.len() - MAX_PROVISION_LOG_LINES;
+            self.provision_log_lines.drain(..excess);
+        }
+        if received && self.ui.provision_log_follow {
+            self.ui.provision_log_scroll = u16::MAX;
+        }
+        if disconnected {
+            self.provision_log_rx = None;
+        }
+    }
+}

--- a/crates/rag-rat-cli/src/init/wizard/steps.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps.rs
@@ -1,0 +1,3210 @@
+//! Step functions — render, handle_key, validate.  No traits, no widget abstractions.
+//!
+//! Per-step mutable state lives in [`StepState`], stored on [`WizardState`].
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::Ordering;
+use std::sync::mpsc::Sender;
+
+use rag_rat_core::config::{DEFAULT_QUERY_ENDPOINT, RemoteEmbeddingConfig};
+use rag_rat_core::embedding_models::{Backend, EMBEDDING_MODELS, EmbeddingModelSpec, spec};
+#[cfg(feature = "fastembed")]
+use rag_rat_core::index::ai::FastEmbedEmbedder;
+#[cfg(feature = "model2vec")]
+use rag_rat_core::index::ai::Model2VecEmbedder;
+use rag_rat_core::index::ai::{
+    Embedder, HashEmbedder, OllamaEmbedder, verify_ephemeral_remote_cancellable,
+};
+use rag_rat_core::index::oracle::{OracleTool, ToolAvailability, ToolManifest, probe_oracle_tool};
+use rag_rat_core::language::Language;
+use ratatui::Frame;
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{List, ListItem, Paragraph, Scrollbar, ScrollbarOrientation, Wrap};
+use tui_tree_widget::{Tree, TreeItem, TreeState};
+
+use super::catalog::CookbookEntry;
+use super::draft::{
+    OLLAMA_EMBEDDING_MODELS, RemoteDraft, RemoteMode, ollama_model_dim, ollama_model_for,
+};
+use super::probe::{ProbeKind, ProbeStatus};
+use super::state::{PROVISION_CONFIRM_WORD, WizardState, provision_confirm_satisfied};
+use super::theme;
+use crate::init::DirCandidate;
+use crate::init::scan::candidate_dirs;
+use crate::{MANAGED_HOOKS, git_paths, is_rag_rat_hook};
+
+// ── public types ───────────────────────────────────────────────────────────────
+
+pub(crate) mod hooks {
+    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+    #[allow(dead_code)] // The installer already supports these choices; the wizard conflict UI lands separately.
+    pub(crate) enum HookConflict {
+        Skip,
+        Overwrite,
+        Chain,
+        UninstallRagRatOnly,
+        Abort,
+    }
+    pub(crate) fn render_chained_hook(original: &str, hook_name: &str) -> String {
+        let body = original.trim_start();
+        let inner = if body.starts_with("#!") {
+            body.split_once('\n').map(|x| x.1).unwrap_or("").trim_start_matches('\n')
+        } else {
+            body
+        };
+        let rag = format!(
+            "repo_root=\"$(git rev-parse --show-toplevel 2>/dev/null)\" || exit 0\ncd \
+             \"$repo_root\" || exit 0\nunset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE \
+             GIT_PREFIX GIT_NAMESPACE GIT_OBJECT_DIRECTORY \
+             GIT_ALTERNATE_OBJECT_DIRECTORIES\nRAG_RAT_HOOK_DISABLE=1 rag-rat maintenance \
+             --trigger {hook_name} --max-seconds 30 \
+             >\"${{TMPDIR:-/tmp}}/rag-rat-{hook_name}.log\" 2>&1 &"
+        );
+        format!("#!/bin/sh\n# Chained hook\n\n{inner}\n\n{rag}\n\nexit 0\n")
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum StepId {
+    Indexing    = 0,
+    Oracle      = 1,
+    Embedding   = 2,
+    Integration = 3,
+}
+impl StepId {
+    pub const COUNT: usize = 4;
+    pub const ALL: [StepId; 4] = [Self::Indexing, Self::Oracle, Self::Embedding, Self::Integration];
+    pub fn index(self) -> usize {
+        self as usize
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum Outcome {
+    Consumed,
+    Pass,
+    Advance,
+    Back,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum Sev {
+    Ok,
+    Warn,
+    Block,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct CheckResult {
+    pub severity: Sev,
+    pub message: Option<String>,
+}
+impl CheckResult {
+    pub fn ok() -> Self {
+        Self { severity: Sev::Ok, message: None }
+    }
+    pub fn warn(m: impl Into<String>) -> Self {
+        Self { severity: Sev::Warn, message: Some(m.into()) }
+    }
+    pub fn block(m: impl Into<String>) -> Self {
+        Self { severity: Sev::Block, message: Some(m.into()) }
+    }
+}
+
+pub(crate) fn can_write(checks: &[CheckResult]) -> bool {
+    checks.iter().all(|c| c.severity != Sev::Block)
+}
+
+const ONE_LINE_FIELD_OUTER_HEIGHT: u16 = 3;
+
+// ── per-step state ─────────────────────────────────────────────────────────────
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum EmbedFocus {
+    Model,
+    Mode,
+    Endpoint,
+    Cookbook,
+    ServerModel,
+    Gpu,
+    BatchSize,
+    AuthEnv,
+    ProvisionConfirm,
+}
+
+pub(crate) enum StepState {
+    Indexing {
+        lang_toggles: Vec<(Language, bool)>,
+        lang_focus: usize,
+        zone: IndexZone,
+        tree: TreeState<PathBuf>,
+        dir_candidates: BTreeMap<Language, Vec<DirCandidate>>,
+    },
+    Embedding {
+        model_cursor: usize,
+        mode_cursor: usize,
+        cookbook_cursor: usize,
+        server_model_cursor: usize,
+        gpu_cursor: usize,
+        model_scroll: usize,
+        server_model_scroll: usize,
+        focus: EmbedFocus,
+    },
+    Oracle,
+    Integration {
+        focus: usize,
+    },
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum IndexZone {
+    Toggles,
+    Tree,
+}
+
+// ── step titles / footers ──────────────────────────────────────────────────────
+
+pub(crate) fn step_title(id: StepId) -> &'static str {
+    match id {
+        StepId::Indexing => "Indexing",
+        StepId::Oracle => "Oracle",
+        StepId::Embedding => "Embedding",
+        StepId::Integration => "Integration",
+    }
+}
+
+pub(crate) fn step_footer(id: StepId) -> &'static str {
+    match id {
+        StepId::Indexing =>
+            "←→ language/tree  Tab dirs  ↑↓/j/k move  PgUp/PgDn jump  Space toggle  a/A all",
+        StepId::Oracle => "Space toggle  t test tools  l log  Enter next",
+        StepId::Embedding =>
+            "Tab/Shift-Tab field  ↑↓/j/k move  PgUp/PgDn scroll  Space select  type edit  d \
+             download  t/p test  l log",
+        StepId::Integration =>
+            "↑↓ navigate  Space toggle  t version check  g git  c claude  Enter next",
+    }
+}
+
+// ── step constructors + state init ─────────────────────────────────────────────
+
+fn step_matches(id: StepId, step: &Option<StepState>) -> bool {
+    matches!(
+        (id, step),
+        (StepId::Indexing, Some(StepState::Indexing { .. }))
+            | (StepId::Oracle, Some(StepState::Oracle))
+            | (StepId::Embedding, Some(StepState::Embedding { .. }))
+            | (StepId::Integration, Some(StepState::Integration { .. }))
+    )
+}
+
+pub(crate) fn init_step(id: StepId, state: &WizardState) -> StepState {
+    match id {
+        StepId::Indexing => {
+            let toggles: Vec<(Language, bool)> = Language::all()
+                .iter()
+                .map(|&l| (l, state.draft.bindings.contains_key(&l)))
+                .collect();
+            let mut tree = TreeState::default();
+            tree.select(vec![PathBuf::from(".")]);
+            let dir_candidates = Language::all()
+                .iter()
+                .map(|&lang| (lang, base_candidates_for(&state.scan, lang)))
+                .collect();
+            StepState::Indexing {
+                lang_toggles: toggles,
+                lang_focus: 0,
+                zone: IndexZone::Toggles,
+                tree,
+                dir_candidates,
+            }
+        },
+        StepId::Embedding => init_embedding_step(state),
+        StepId::Oracle => StepState::Oracle,
+        StepId::Integration => StepState::Integration { focus: 0 },
+    }
+}
+
+fn init_embedding_step(state: &WizardState) -> StepState {
+    let rows = model_rows();
+    let model_cursor = rows.iter().position(|(id, _)| id == &state.draft.model).unwrap_or(0);
+    let mode_cursor = remote_mode(state);
+    let cookbook_cursor = selected_cookbook_idx(state).unwrap_or(0);
+    let server_model = state
+        .draft
+        .remote
+        .as_ref()
+        .map(|r| r.model.as_str())
+        .unwrap_or_else(|| default_remote_model_for(&state.draft.model));
+    let server_models = compatible_server_models(&state.draft.model);
+    let server_model_cursor = server_models.iter().position(|&m| m == server_model).unwrap_or(0);
+    let gpu_options = current_gpu_options(state);
+    let gpu_cursor = state
+        .draft
+        .remote
+        .as_ref()
+        .and_then(|r| r.gpu.as_deref())
+        .and_then(|gpu| gpu_options.iter().position(|g| g == gpu))
+        .unwrap_or(0);
+    StepState::Embedding {
+        model_cursor,
+        mode_cursor,
+        cookbook_cursor,
+        server_model_cursor,
+        gpu_cursor,
+        model_scroll: model_cursor.saturating_sub(4),
+        server_model_scroll: server_model_cursor.saturating_sub(4),
+        focus: EmbedFocus::Model,
+    }
+}
+
+fn compatible_server_models(local_model: &str) -> Vec<&'static str> {
+    let Some(local) = spec(local_model) else {
+        return Vec::new();
+    };
+    if local.backend != Backend::FastEmbed {
+        return Vec::new();
+    };
+    OLLAMA_EMBEDDING_MODELS
+        .iter()
+        .copied()
+        .filter(|model| ollama_model_dim(model).is_none_or(|dim| dim == local.dim))
+        .collect()
+}
+
+// ── dispatch ───────────────────────────────────────────────────────────────────
+
+pub(crate) fn render_step(id: StepId, f: &mut Frame, area: Rect, state: &mut WizardState) {
+    match id {
+        StepId::Indexing => render_indexing(f, area, state),
+        StepId::Oracle => render_oracle(f, area, state),
+        StepId::Embedding => render_embedding(f, area, state),
+        StepId::Integration => render_integration(f, area, state),
+    }
+}
+
+pub(crate) fn step_handle_key(id: StepId, key: KeyEvent, state: &mut WizardState) -> Outcome {
+    // Re-init if the variant doesn't match the active step after tab navigation.
+    if !step_matches(id, &state.step) {
+        state.step = Some(init_step(id, state));
+    }
+    match id {
+        StepId::Indexing => handle_indexing(key, state),
+        StepId::Oracle => handle_oracle(key, state),
+        StepId::Embedding => handle_embedding(key, state),
+        StepId::Integration => handle_integration(key, state),
+    }
+}
+
+pub(crate) fn validate_step(id: StepId, state: &WizardState) -> CheckResult {
+    match id {
+        StepId::Indexing => validate_indexing(state),
+        StepId::Oracle => CheckResult::ok(),
+        StepId::Embedding => validate_embedding(state),
+        StepId::Integration => validate_hooks(state),
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// INDEXING
+// ═══════════════════════════════════════════════════════════════════════════════
+
+fn checked_langs(state: &WizardState) -> Vec<Language> {
+    match &state.step {
+        Some(StepState::Indexing { lang_toggles, .. }) =>
+            lang_toggles.iter().filter(|(_, on)| *on).map(|(l, _)| *l).collect(),
+        _ => vec![],
+    }
+}
+
+fn active_tree_lang(state: &WizardState) -> Option<Language> {
+    let Some(StepState::Indexing { lang_toggles, lang_focus, .. }) = &state.step else {
+        return None;
+    };
+    lang_toggles
+        .get(*lang_focus)
+        .and_then(|(l, on)| on.then_some(*l))
+        .or_else(|| lang_toggles.iter().find_map(|(l, on)| on.then_some(*l)))
+}
+
+fn base_candidates_for(scan: &crate::init::RepoScan, lang: Language) -> Vec<DirCandidate> {
+    let cs = candidate_dirs(scan, lang);
+    if cs.is_empty() {
+        vec![DirCandidate { path: PathBuf::from("."), count: 0, default: true }]
+    } else {
+        cs
+    }
+}
+
+fn cached_base_candidates_for(lang: Language, state: &WizardState) -> Vec<DirCandidate> {
+    match &state.step {
+        Some(StepState::Indexing { dir_candidates, .. }) => dir_candidates
+            .get(&lang)
+            .cloned()
+            .unwrap_or_else(|| base_candidates_for(&state.scan, lang)),
+        _ => base_candidates_for(&state.scan, lang),
+    }
+}
+
+fn sync_languages(state: &mut WizardState) {
+    let checked = checked_langs(state);
+    state.draft.bindings.retain(|l, _| checked.contains(l));
+    for &l in &checked {
+        if !state.draft.bindings.contains_key(&l) {
+            let dirs: Vec<PathBuf> = cached_base_candidates_for(l, state)
+                .into_iter()
+                .filter(|c| c.default)
+                .map(|c| c.path)
+                .collect();
+            state
+                .draft
+                .bindings
+                .insert(l, if dirs.is_empty() { vec![PathBuf::from(".")] } else { dirs });
+        }
+    }
+}
+
+fn render_indexing(f: &mut Frame, area: Rect, state: &mut WizardState) {
+    let (lang_toggles, lang_focus, zone) = match &state.step {
+        Some(StepState::Indexing { lang_toggles, lang_focus, zone, .. }) =>
+            (lang_toggles.clone(), *lang_focus, *zone),
+        _ => return,
+    };
+    let chunks = Layout::vertical([Constraint::Length(3), Constraint::Min(0)]).split(area);
+
+    // Language toggles
+    let mut spans = Vec::new();
+    for (i, (l, on)) in lang_toggles.iter().enumerate() {
+        let style = if zone == IndexZone::Toggles && i == lang_focus {
+            theme::selected()
+        } else {
+            theme::base()
+        };
+        spans.push(Span::styled(
+            format!("{}{} {}  ", if *on { "[x]" } else { "[ ]" }, l.as_str(), ""),
+            style,
+        ));
+    }
+    f.render_widget(
+        Paragraph::new(Line::from(spans)).style(theme::base()).block(theme::focused_block(
+            "Languages ←→ move  Space toggle",
+            zone == IndexZone::Toggles,
+        )),
+        chunks[0],
+    );
+
+    if let Some(lang) = active_tree_lang(state) {
+        render_dir_tree(f, chunks[1], lang, state, zone == IndexZone::Tree);
+    } else {
+        f.render_widget(
+            Paragraph::new("Select at least one language to choose indexed directories.")
+                .style(theme::base())
+                .block(theme::block("Directories")),
+            chunks[1],
+        );
+    }
+}
+
+fn candidates_for(lang: Language, state: &WizardState) -> Vec<DirCandidate> {
+    let cs = cached_base_candidates_for(lang, state);
+    let draft = state.draft.bindings.get(&lang);
+    match (cs.is_empty(), draft) {
+        (true, None) => vec![DirCandidate { path: PathBuf::from("."), count: 0, default: true }],
+        (true, Some(paths)) => paths
+            .iter()
+            .map(|p| DirCandidate { path: p.clone(), count: 0, default: true })
+            .collect(),
+        (false, None) => cs,
+        (false, Some(paths)) =>
+            cs.into_iter().map(|c| DirCandidate { default: paths.contains(&c.path), ..c }).collect(),
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+struct DirMeta {
+    count: usize,
+    selected: bool,
+}
+
+fn dir_tree_items_for(lang: Language, state: &WizardState) -> Vec<TreeItem<'static, PathBuf>> {
+    let candidates = candidates_for(lang, state);
+    let mut metas = BTreeMap::<PathBuf, DirMeta>::new();
+    let root_selected =
+        state.draft.bindings.get(&lang).is_some_and(|v| v.contains(&PathBuf::from(".")));
+    metas.insert(PathBuf::from("."), DirMeta { count: 0, selected: root_selected });
+
+    for candidate in candidates {
+        insert_path_and_ancestors(&mut metas, &candidate.path);
+        metas.insert(candidate.path, DirMeta {
+            count: candidate.count,
+            selected: candidate.default,
+        });
+    }
+
+    vec![dir_tree_item(Path::new("."), &metas)]
+}
+
+fn insert_path_and_ancestors(metas: &mut BTreeMap<PathBuf, DirMeta>, path: &Path) {
+    metas.entry(PathBuf::from(".")).or_default();
+    if path == Path::new(".") {
+        return;
+    }
+    let mut current = PathBuf::new();
+    for component in path.components() {
+        if component.as_os_str() == "." {
+            continue;
+        }
+        current.push(component.as_os_str());
+        metas.entry(current.clone()).or_default();
+    }
+}
+
+fn dir_tree_item(path: &Path, metas: &BTreeMap<PathBuf, DirMeta>) -> TreeItem<'static, PathBuf> {
+    let children = child_dir_paths(path, metas)
+        .into_iter()
+        .map(|child| dir_tree_item(&child, metas))
+        .collect::<Vec<_>>();
+    let text = dir_tree_label(path, metas.get(path).copied().unwrap_or_default());
+    if children.is_empty() {
+        TreeItem::new_leaf(path.to_path_buf(), text)
+    } else {
+        TreeItem::new(path.to_path_buf(), text, children).expect("directory tree paths are unique")
+    }
+}
+
+fn child_dir_paths(parent: &Path, metas: &BTreeMap<PathBuf, DirMeta>) -> Vec<PathBuf> {
+    metas
+        .keys()
+        .filter(|path| path.as_path() != parent)
+        .filter(|path| parent_dir_path(path).as_deref() == Some(parent))
+        .cloned()
+        .collect()
+}
+
+fn parent_dir_path(path: &Path) -> Option<PathBuf> {
+    if path == Path::new(".") {
+        return None;
+    }
+    let parent = path.parent().filter(|p| !p.as_os_str().is_empty()).unwrap_or(Path::new("."));
+    Some(parent.to_path_buf())
+}
+
+fn dir_tree_label(path: &Path, meta: DirMeta) -> String {
+    let selected = if meta.selected { "[x]" } else { "[ ]" };
+    let name = if path == Path::new(".") {
+        ".".to_string()
+    } else {
+        path.file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or_else(|| path.to_string_lossy().to_string())
+    };
+    if meta.count == 0 {
+        format!("{selected} {name}")
+    } else {
+        format!("{selected} {name} ({})", meta.count)
+    }
+}
+
+fn render_dir_tree(
+    f: &mut Frame,
+    area: Rect,
+    lang: Language,
+    state: &mut WizardState,
+    focused: bool,
+) {
+    let items = dir_tree_items_for(lang, state);
+    let Some(StepState::Indexing { tree, .. }) = &mut state.step else { return };
+    open_dir_tree_nodes(tree, &items);
+    ensure_dir_tree_selection(tree, &items);
+    let visible = tree.flatten(&items);
+    let selected =
+        visible.iter().position(|item| item.identifier == tree.selected()).map_or(0, |i| i + 1);
+    let title = format!("Directories: {}  {}/{}", lang.as_str(), selected, visible.len());
+    let widget = Tree::new(&items)
+        .expect("directory tree paths are unique")
+        .style(theme::base())
+        .block(theme::focused_block(title, focused))
+        .experimental_scrollbar(Some(
+            Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                .begin_symbol(None)
+                .track_symbol(None)
+                .end_symbol(None),
+        ))
+        .highlight_style(theme::selected())
+        .highlight_symbol("> ")
+        .node_open_symbol("▾ ")
+        .node_closed_symbol("▸ ")
+        .node_no_children_symbol("  ");
+    f.render_stateful_widget(widget, area, tree);
+}
+
+fn open_dir_tree_nodes(tree: &mut TreeState<PathBuf>, items: &[TreeItem<'static, PathBuf>]) {
+    fn rec(
+        tree: &mut TreeState<PathBuf>,
+        items: &[TreeItem<'static, PathBuf>],
+        current: &mut Vec<PathBuf>,
+    ) {
+        for item in items {
+            current.push(item.identifier().clone());
+            if !item.children().is_empty() {
+                tree.open(current.clone());
+                rec(tree, item.children(), current);
+            }
+            current.pop();
+        }
+    }
+    rec(tree, items, &mut Vec::new());
+}
+
+fn ensure_dir_tree_selection(tree: &mut TreeState<PathBuf>, items: &[TreeItem<'static, PathBuf>]) {
+    let visible = tree.flatten(items);
+    if visible.is_empty() {
+        tree.select(Vec::new());
+        return;
+    }
+    if !visible.iter().any(|item| item.identifier == tree.selected()) {
+        tree.select(visible[0].identifier.clone());
+    }
+}
+
+fn handle_indexing(key: KeyEvent, state: &mut WizardState) -> Outcome {
+    let zone = match &state.step {
+        Some(StepState::Indexing { zone, .. }) => *zone,
+        _ => return Outcome::Pass,
+    };
+
+    match zone {
+        IndexZone::Toggles => match key.code {
+            KeyCode::Left => {
+                move_language_focus(state, -1);
+                Outcome::Consumed
+            },
+            KeyCode::Right => {
+                move_language_focus(state, 1);
+                Outcome::Consumed
+            },
+            KeyCode::Char(' ') => {
+                if let Some(StepState::Indexing { lang_toggles, lang_focus, .. }) = &mut state.step
+                {
+                    lang_toggles[*lang_focus].1 = !lang_toggles[*lang_focus].1;
+                }
+                sync_languages(state);
+                ensure_active_dir_tree_selection(state);
+                Outcome::Consumed
+            },
+            KeyCode::Tab => {
+                focus_tree_zone(state);
+                Outcome::Consumed
+            },
+            KeyCode::BackTab => {
+                focus_tree_zone(state);
+                Outcome::Consumed
+            },
+            KeyCode::Enter => Outcome::Advance,
+            KeyCode::Esc => Outcome::Back,
+            KeyCode::Char('a') => {
+                select_all(state);
+                Outcome::Consumed
+            },
+            KeyCode::Char('A') => {
+                deselect_all(state);
+                Outcome::Consumed
+            },
+            _ => Outcome::Pass,
+        },
+        IndexZone::Tree => match key.code {
+            KeyCode::Tab => {
+                focus_toggle_zone(state);
+                Outcome::Consumed
+            },
+            KeyCode::BackTab => {
+                focus_toggle_zone(state);
+                Outcome::Consumed
+            },
+            KeyCode::Enter => Outcome::Advance,
+            KeyCode::Esc => Outcome::Back,
+            KeyCode::Char('a') => {
+                select_all(state);
+                Outcome::Consumed
+            },
+            KeyCode::Char('A') => {
+                deselect_all(state);
+                Outcome::Consumed
+            },
+            KeyCode::Left => {
+                fold_dir_tree(state);
+                Outcome::Consumed
+            },
+            KeyCode::Right => {
+                unfold_dir_tree(state);
+                Outcome::Consumed
+            },
+            KeyCode::Up | KeyCode::Char('k') => {
+                move_dir_selection(state, -1);
+                Outcome::Consumed
+            },
+            KeyCode::Down | KeyCode::Char('j') => {
+                move_dir_selection(state, 1);
+                Outcome::Consumed
+            },
+            KeyCode::PageUp => {
+                move_dir_selection(state, -10);
+                Outcome::Consumed
+            },
+            KeyCode::PageDown => {
+                move_dir_selection(state, 10);
+                Outcome::Consumed
+            },
+            KeyCode::Home => {
+                move_dir_selection_to_edge(state, false);
+                Outcome::Consumed
+            },
+            KeyCode::End => {
+                move_dir_selection_to_edge(state, true);
+                Outcome::Consumed
+            },
+            KeyCode::Char(' ') => toggle_focused_dir(state),
+            _ => Outcome::Pass,
+        },
+    }
+}
+
+fn move_language_focus(state: &mut WizardState, delta: isize) {
+    if let Some(StepState::Indexing { lang_toggles, lang_focus, tree, .. }) = &mut state.step {
+        let last = lang_toggles.len().saturating_sub(1);
+        *lang_focus = (*lang_focus as isize).saturating_add(delta).clamp(0, last as isize) as usize;
+        tree.select(vec![PathBuf::from(".")]);
+    }
+    ensure_active_dir_tree_selection(state);
+}
+
+fn focus_tree_zone(state: &mut WizardState) {
+    if let Some(StepState::Indexing { lang_toggles, lang_focus, zone, tree, .. }) = &mut state.step
+    {
+        if lang_toggles.is_empty() || !lang_toggles.iter().any(|(_, on)| *on) {
+            return;
+        }
+        let already_tree = *zone == IndexZone::Tree;
+        if !lang_toggles.get(*lang_focus).is_some_and(|(_, on)| *on)
+            && let Some(i) = lang_toggles.iter().position(|(_, on)| *on)
+        {
+            *lang_focus = i;
+        }
+        *zone = IndexZone::Tree;
+        if !already_tree {
+            tree.select(vec![PathBuf::from(".")]);
+        }
+    }
+    ensure_active_dir_tree_selection(state);
+}
+
+fn focus_toggle_zone(state: &mut WizardState) {
+    if let Some(StepState::Indexing { zone, .. }) = &mut state.step {
+        *zone = IndexZone::Toggles;
+    }
+}
+
+fn ensure_active_dir_tree_selection(state: &mut WizardState) {
+    let Some(lang) = active_tree_lang(state) else { return };
+    let items = dir_tree_items_for(lang, state);
+    let Some(StepState::Indexing { tree, .. }) = &mut state.step else { return };
+    open_dir_tree_nodes(tree, &items);
+    ensure_dir_tree_selection(tree, &items);
+}
+
+fn move_dir_selection(state: &mut WizardState, delta: isize) {
+    let Some(lang) = active_tree_lang(state) else { return };
+    let items = dir_tree_items_for(lang, state);
+    let Some(StepState::Indexing { tree, .. }) = &mut state.step else { return };
+    open_dir_tree_nodes(tree, &items);
+    let visible = tree.flatten(&items);
+    if visible.is_empty() {
+        tree.select(Vec::new());
+        return;
+    }
+    let current = visible.iter().position(|item| item.identifier == tree.selected()).unwrap_or(0);
+    let last = visible.len().saturating_sub(1);
+    let next = (current as isize).saturating_add(delta).clamp(0, last as isize) as usize;
+    tree.select(visible[next].identifier.clone());
+}
+
+fn move_dir_selection_to_edge(state: &mut WizardState, end: bool) {
+    let Some(lang) = active_tree_lang(state) else { return };
+    let items = dir_tree_items_for(lang, state);
+    let Some(StepState::Indexing { tree, .. }) = &mut state.step else { return };
+    open_dir_tree_nodes(tree, &items);
+    let visible = tree.flatten(&items);
+    let Some(item) = (if end { visible.last() } else { visible.first() }) else { return };
+    tree.select(item.identifier.clone());
+}
+
+fn fold_dir_tree(state: &mut WizardState) {
+    let Some(StepState::Indexing { tree, .. }) = &mut state.step else { return };
+    tree.key_left();
+}
+
+fn unfold_dir_tree(state: &mut WizardState) {
+    let Some(StepState::Indexing { tree, .. }) = &mut state.step else { return };
+    tree.key_right();
+}
+
+fn scroll_dir_tree(state: &mut WizardState, delta: isize) {
+    let Some(StepState::Indexing { tree, .. }) = &mut state.step else { return };
+    let lines = delta.unsigned_abs();
+    if delta < 0 {
+        tree.scroll_up(lines);
+    } else {
+        tree.scroll_down(lines);
+    }
+}
+
+fn selected_dir_path(state: &WizardState) -> Option<PathBuf> {
+    match &state.step {
+        Some(StepState::Indexing { tree, .. }) => tree.selected().last().cloned(),
+        _ => None,
+    }
+}
+
+fn toggle_focused_dir(state: &mut WizardState) -> Outcome {
+    let Some(lang) = active_tree_lang(state) else { return Outcome::Pass };
+    let Some(path) = selected_dir_path(state) else { return Outcome::Pass };
+    let paths = state.draft.bindings.entry(lang).or_default();
+    if paths.contains(&path) {
+        paths.retain(|p| p != &path);
+    } else {
+        paths.push(path);
+    }
+    Outcome::Consumed
+}
+
+pub(crate) fn scroll_step(id: StepId, delta: isize, state: &mut WizardState) -> bool {
+    match id {
+        StepId::Indexing => {
+            focus_tree_zone(state);
+            scroll_dir_tree(state, delta);
+            true
+        },
+        StepId::Embedding => scroll_embedding(delta, state),
+        _ => false,
+    }
+}
+
+fn select_all(state: &mut WizardState) {
+    for lang in checked_langs(state) {
+        let cs = candidates_for(lang, state);
+        state.draft.bindings.insert(lang, cs.into_iter().map(|c| c.path).collect());
+    }
+}
+
+fn deselect_all(state: &mut WizardState) {
+    for lang in checked_langs(state) {
+        state.draft.bindings.insert(lang, vec![]);
+    }
+}
+
+fn validate_indexing(state: &WizardState) -> CheckResult {
+    if !state.draft.root_abs.exists() {
+        return CheckResult::block(format!("root not found: {}", state.draft.root_abs.display()));
+    }
+    let conflicts = state.draft.conflicting_rich_target_names();
+    if !conflicts.is_empty() {
+        return CheckResult::block(format!(
+            "simple bindings conflict with preserved [[target]] names: {}",
+            conflicts.join(", ")
+        ));
+    }
+    if !state.draft.has_rich_targets && !has_effective_simple_bindings(state) {
+        return CheckResult::block("select at least one indexed directory");
+    }
+    let mut missing = Vec::new();
+    for (l, dirs) in &state.draft.bindings {
+        for d in dirs {
+            let abs = if d.is_absolute() { d.clone() } else { state.draft.root_abs.join(d) };
+            if !abs.exists() {
+                missing.push(format!("{}: {}", l.as_str(), d.display()));
+            }
+        }
+    }
+    if !missing.is_empty() {
+        CheckResult::warn(format!("not found: {}", missing.join(", ")))
+    } else {
+        CheckResult::ok()
+    }
+}
+
+fn has_effective_simple_bindings(state: &WizardState) -> bool {
+    state.draft.bindings.values().any(|dirs| !dirs.is_empty())
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ORACLE
+// ═══════════════════════════════════════════════════════════════════════════════
+
+fn render_oracle(f: &mut Frame, area: Rect, state: &WizardState) {
+    let chunks = Layout::vertical([Constraint::Length(3), Constraint::Min(0)]).split(area);
+
+    let on = state.draft.oracle_auto_run;
+    let label = if on { "[ ON  ]" } else { "[ OFF ]" };
+    f.render_widget(
+        Paragraph::new(Span::styled(label, theme::focus()))
+            .style(theme::base())
+            .block(theme::block("space: toggle  t: test")),
+        chunks[0],
+    );
+
+    let detected: Vec<&str> = Language::all()
+        .iter()
+        .filter(|&&l| state.scan.language_counts().get(&l).copied().unwrap_or(0) > 0)
+        .map(|&l| l.as_str())
+        .collect();
+
+    let mut lines = vec![
+        Line::from(Span::styled("SCIP tools for your languages:", theme::base())),
+        Line::from(""),
+    ];
+    match state.probes.status(StepId::Oracle) {
+        ProbeStatus::Running(ProbeKind::OracleTool) => {
+            lines.push(Line::from(Span::styled(" Tool test running...", theme::warning())));
+            lines.push(Line::from(""));
+        },
+        ProbeStatus::Done { result, .. } => {
+            let style = match result.severity {
+                Sev::Ok => theme::success(),
+                Sev::Warn => theme::warning(),
+                Sev::Block => theme::error(),
+            };
+            let msg = result.message.as_deref().unwrap_or("Oracle tool test passed.");
+            lines.push(Line::from(Span::styled(format!(" Tool test: {msg}"), style)));
+            lines.push(Line::from(""));
+        },
+        _ => {},
+    }
+    for tool in OracleTool::ALL {
+        let m = ToolManifest::for_tool(*tool);
+        let relevant = m.languages.iter().any(|l| detected.contains(l));
+        let style = if relevant { theme::accent() } else { theme::muted() };
+        let name = format!("{:?}", tool)
+            .replace("RustAnalyzer", "rust-analyzer")
+            .replace("ScipClang", "scip-clang")
+            .replace("ScipPython", "scip-python")
+            .replace("ScipTypescript", "scip-typescript")
+            .replace("ScipJava", "scip-java");
+        lines.push(Line::from(vec![
+            Span::styled(format!(" {} {} ", if relevant { "▶" } else { " " }, name), style),
+            Span::styled(format!("— {}", m.languages.join(", ")), theme::muted()),
+        ]));
+    }
+    f.render_widget(
+        Paragraph::new(lines)
+            .style(theme::base())
+            .wrap(Wrap { trim: false })
+            .block(theme::block("Tool availability")),
+        chunks[1],
+    );
+}
+
+fn handle_oracle(key: KeyEvent, state: &mut WizardState) -> Outcome {
+    match key.code {
+        KeyCode::Char(' ') => {
+            state.draft.oracle_auto_run = !state.draft.oracle_auto_run;
+            Outcome::Consumed
+        },
+        KeyCode::Char('t') | KeyCode::Char('T') => {
+            let tools = tools_for_scan(state);
+            let (log_tx, log_rx) = std::sync::mpsc::channel();
+            state.start_oracle_log(log_rx);
+            state.probes.spawn(StepId::Oracle, ProbeKind::OracleTool, move || {
+                probe_oracle_tools(tools, log_tx)
+            });
+            Outcome::Consumed
+        },
+        KeyCode::Enter => Outcome::Advance,
+        KeyCode::Esc => Outcome::Back,
+        _ => Outcome::Pass,
+    }
+}
+
+fn tools_for_scan(state: &WizardState) -> Vec<OracleTool> {
+    let detected: Vec<&str> = Language::all()
+        .iter()
+        .filter(|&&l| state.scan.language_counts().get(&l).copied().unwrap_or(0) > 0)
+        .map(|&l| l.as_str())
+        .collect();
+    OracleTool::ALL
+        .iter()
+        .copied()
+        .filter(|&t| ToolManifest::for_tool(t).languages.iter().any(|l| detected.contains(l)))
+        .collect()
+}
+
+fn probe_oracle_tools(tools: Vec<OracleTool>, log_tx: Sender<String>) -> CheckResult {
+    if tools.is_empty() {
+        send_log(&log_tx, "No detected languages need Oracle tools.");
+        return CheckResult::ok();
+    }
+
+    send_log(&log_tx, format!("Checking {} Oracle tool(s)...", tools.len()));
+    for tool in tools {
+        let manifest = ToolManifest::for_tool(tool);
+        send_log(&log_tx, format!("Checking {} ({})...", tool.as_db_str(), manifest.program));
+        match probe_oracle_tool(tool) {
+            ToolAvailability::Available { program, version, .. } => {
+                send_log(&log_tx, format!("available: {program} {version}"));
+            },
+            ToolAvailability::Blocked { program, hint, .. } => {
+                send_log(&log_tx, format!("blocked: {program}"));
+                send_log(&log_tx, hint.clone());
+                return CheckResult::warn(hint);
+            },
+        }
+    }
+    send_log(&log_tx, "All relevant Oracle tools are available.");
+    CheckResult::ok()
+}
+
+fn send_log(log_tx: &Sender<String>, line: impl Into<String>) {
+    let _ = log_tx.send(line.into());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// EMBEDDING
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const NONE_MODEL: &str = "none";
+
+fn model_rows() -> Vec<(String, String)> {
+    EMBEDDING_MODELS
+        .iter()
+        .map(|s| {
+            (s.model_id.to_string(), format!("{} ({}, {}d)", s.display, s.backend.runtime(), s.dim))
+        })
+        .chain(std::iter::once((
+            NONE_MODEL.to_string(),
+            "none — BM25 + structure only".to_string(),
+        )))
+        .collect()
+}
+
+fn default_remote_model_for(local_model: &str) -> &'static str {
+    ollama_model_for(local_model).unwrap_or("all-minilm")
+}
+
+fn remote_mode(state: &WizardState) -> usize {
+    match state.draft.remote.as_ref().map(|r| &r.mode) {
+        Some(RemoteMode::Connect(_)) => 1,
+        Some(RemoteMode::Ephemeral(_)) => 2,
+        None => 0,
+    }
+}
+
+fn current_ephemeral_cookbook(state: &WizardState) -> Option<&str> {
+    match state.draft.remote.as_ref().map(|r| &r.mode) {
+        Some(RemoteMode::Ephemeral(cookbook)) => Some(cookbook.trim()),
+        _ => None,
+    }
+}
+
+fn cookbook_choices(state: &WizardState) -> Vec<CookbookEntry> {
+    let mut choices = state.cookbooks.entries().to_vec();
+    if let Some(cookbook) = current_ephemeral_cookbook(state)
+        && state.cookbooks.find_command(cookbook).is_none()
+    {
+        choices.push(CookbookEntry::custom_current(
+            cookbook,
+            state.draft.remote.as_ref().and_then(|remote| remote.gpu.as_deref()),
+        ));
+    }
+    choices
+}
+
+fn selected_cookbook_idx(state: &WizardState) -> Option<usize> {
+    let cookbook = current_ephemeral_cookbook(state)?;
+    cookbook_choices(state).iter().position(|entry| entry.command == cookbook)
+}
+
+fn current_gpu_options(state: &WizardState) -> Vec<String> {
+    let choices = cookbook_choices(state);
+    let selected = selected_cookbook_idx(state).unwrap_or(0);
+    choices.get(selected).map(|entry| entry.gpus.clone()).unwrap_or_default()
+}
+
+fn default_cookbook_command(state: &WizardState) -> String {
+    state
+        .cookbooks
+        .entries()
+        .first()
+        .map(|entry| entry.command.clone())
+        .unwrap_or_else(|| "@rag-rat/cookbook modal".to_string())
+}
+
+fn render_embedding(f: &mut Frame, area: Rect, state: &WizardState) {
+    let Some(StepState::Embedding {
+        model_cursor,
+        mode_cursor,
+        cookbook_cursor,
+        server_model_cursor,
+        gpu_cursor,
+        model_scroll,
+        server_model_scroll,
+        focus,
+    }) = &state.step
+    else {
+        return;
+    };
+    let model_none = state.draft.model == NONE_MODEL || state.draft.model.is_empty();
+    let rows = model_rows();
+
+    let cols =
+        Layout::horizontal([Constraint::Percentage(45), Constraint::Percentage(55)]).split(area);
+    let left = Layout::vertical([Constraint::Min(7), Constraint::Length(7)]).split(cols[0]);
+    render_model_list(
+        f,
+        left[0],
+        state,
+        &rows,
+        *model_cursor,
+        *model_scroll,
+        *focus == EmbedFocus::Model,
+    );
+    render_model_help(f, left[1], rows.get(*model_cursor).map(|(id, _)| id.as_str()));
+
+    let right = Layout::vertical([
+        Constraint::Length(5),
+        Constraint::Length(7),
+        Constraint::Min(5),
+        Constraint::Length(ONE_LINE_FIELD_OUTER_HEIGHT),
+    ])
+    .split(cols[1]);
+
+    let modes = ["none", "connect", "ephemeral"];
+    let mode_items: Vec<ListItem> = modes
+        .iter()
+        .enumerate()
+        .map(|(i, m)| {
+            let selected = if i == remote_mode(state) { "*" } else { " " };
+            let cursor = if i == *mode_cursor { ">" } else { " " };
+            let style = if i == *mode_cursor { theme::selected() } else { theme::base() };
+            ListItem::new(format!("{cursor} [{selected}] {m}")).style(style)
+        })
+        .collect();
+    let focused = *focus == EmbedFocus::Mode;
+    f.render_widget(
+        List::new(mode_items)
+            .style(theme::base())
+            .block(theme::focused_block("Remote mode", focused)),
+        right[0],
+    );
+
+    let rmode = remote_mode(state);
+    let remote = state.draft.remote.as_ref();
+    let ep = match remote.map(|r| &r.mode) {
+        Some(RemoteMode::Connect(u)) => u.as_str(),
+        _ => "",
+    };
+    let m = remote.map_or("", |r| r.model.as_str());
+    let g = remote.and_then(|r| r.gpu.as_deref()).unwrap_or("");
+    let bs = remote.map_or(256, |r| r.batch_size).to_string();
+    let auth = remote.and_then(|r| r.auth_env.as_deref()).unwrap_or("");
+
+    let dim = |f: EmbedFocus| if *focus == f { theme::focused_border() } else { theme::border() };
+
+    if model_none {
+        f.render_widget(
+            Paragraph::new("Select an embedding model before configuring a remote.")
+                .style(theme::base())
+                .block(theme::block("Remote")),
+            right[1],
+        );
+        return;
+    }
+
+    if rmode == 1 {
+        let endpoint =
+            Layout::vertical([Constraint::Length(ONE_LINE_FIELD_OUTER_HEIGHT), Constraint::Min(0)])
+                .split(right[1]);
+        f.render_widget(one_line_field(ep, "endpoint", dim(EmbedFocus::Endpoint)), endpoint[0]);
+    } else if rmode == 2 {
+        let fields =
+            Layout::horizontal([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)]).split(right[1]);
+        let cookbook_entries = cookbook_choices(state);
+        let selected_cookbook = selected_cookbook_idx(state);
+        let cookbook_visible = usize::from(fields[0].height.saturating_sub(2)).max(1);
+        let (cookbook_scroll, cookbook_end) =
+            visible_list_bounds(cookbook_entries.len(), *cookbook_cursor, 0, cookbook_visible);
+        let cookbook_items: Vec<ListItem> = cookbook_entries[cookbook_scroll..cookbook_end]
+            .iter()
+            .enumerate()
+            .map(|(offset, entry)| {
+                let i = cookbook_scroll + offset;
+                let cursor = if i == *cookbook_cursor { ">" } else { " " };
+                let selected = if Some(i) == selected_cookbook { "*" } else { " " };
+                let style = if i == *cookbook_cursor { theme::selected() } else { theme::base() };
+                ListItem::new(format!("{cursor} [{selected}] {}", entry.label)).style(style)
+            })
+            .collect();
+        f.render_widget(
+            List::new(cookbook_items)
+                .style(theme::base())
+                .block(theme::block("cookbook").border_style(dim(EmbedFocus::Cookbook))),
+            fields[0],
+        );
+        let gpu_opts = current_gpu_options(state);
+        let gpu_visible = usize::from(fields[1].height.saturating_sub(2)).max(1);
+        let (gpu_scroll, gpu_end) =
+            visible_list_bounds(gpu_opts.len(), *gpu_cursor, 0, gpu_visible);
+        let gpu_items: Vec<ListItem> = gpu_opts[gpu_scroll..gpu_end]
+            .iter()
+            .enumerate()
+            .map(|(offset, gpu)| {
+                let i = gpu_scroll + offset;
+                let cursor = if i == *gpu_cursor { ">" } else { " " };
+                let selected = if gpu == g { "*" } else { " " };
+                let style = if i == *gpu_cursor { theme::selected() } else { theme::base() };
+                ListItem::new(format!("{cursor} [{selected}] {gpu}")).style(style)
+            })
+            .collect();
+        f.render_widget(
+            List::new(gpu_items)
+                .style(theme::base())
+                .block(theme::block("gpu").border_style(dim(EmbedFocus::Gpu))),
+            fields[1],
+        );
+    } else {
+        f.render_widget(
+            Paragraph::new("Remote disabled. Select connect or ephemeral to configure Ollama.")
+                .style(theme::base())
+                .block(theme::block("Remote")),
+            right[1],
+        );
+    }
+
+    let server_models = compatible_server_models(&state.draft.model);
+    render_server_model_list(
+        f,
+        right[2],
+        &server_models,
+        m,
+        *server_model_cursor,
+        *server_model_scroll,
+        *focus == EmbedFocus::ServerModel,
+    );
+
+    if rmode == 2 {
+        let bottom = Layout::horizontal([
+            Constraint::Ratio(1, 3),
+            Constraint::Ratio(1, 3),
+            Constraint::Ratio(1, 3),
+        ])
+        .split(right[3]);
+        f.render_widget(one_line_field(&bs, "batch", dim(EmbedFocus::BatchSize)), bottom[0]);
+        f.render_widget(one_line_field(auth, "auth env", dim(EmbedFocus::AuthEnv)), bottom[1]);
+        let confirm = if provision_confirm_satisfied(&state.ui) {
+            "ready"
+        } else {
+            state.ui.provision_confirm.as_str()
+        };
+        let confirm_title = format!("type: {PROVISION_CONFIRM_WORD}");
+        f.render_widget(
+            one_line_field(confirm, &confirm_title, dim(EmbedFocus::ProvisionConfirm)),
+            bottom[2],
+        );
+    } else {
+        let bottom =
+            Layout::horizontal([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)]).split(right[3]);
+        f.render_widget(one_line_field(&bs, "batch", dim(EmbedFocus::BatchSize)), bottom[0]);
+        f.render_widget(one_line_field(auth, "auth env", dim(EmbedFocus::AuthEnv)), bottom[1]);
+    }
+}
+
+fn one_line_field<'a>(value: &'a str, title: &'a str, border: Style) -> Paragraph<'a> {
+    Paragraph::new(Line::from(Span::raw(value)))
+        .style(theme::base())
+        .block(theme::block(title).border_style(border))
+}
+
+fn visible_list_bounds(len: usize, cursor: usize, scroll: usize, visible: usize) -> (usize, usize) {
+    if len == 0 {
+        return (0, 0);
+    }
+    let visible = visible.max(1);
+    let cursor = cursor.min(len - 1);
+    let max_scroll = len.saturating_sub(visible);
+    let mut scroll = scroll.min(max_scroll);
+    if cursor < scroll {
+        scroll = cursor;
+    } else if cursor >= scroll.saturating_add(visible) {
+        scroll = cursor.saturating_sub(visible - 1);
+    }
+    scroll = scroll.min(max_scroll);
+    (scroll, (scroll + visible).min(len))
+}
+
+fn render_model_list(
+    f: &mut Frame,
+    area: Rect,
+    state: &WizardState,
+    rows: &[(String, String)],
+    cursor: usize,
+    scroll: usize,
+    focused: bool,
+) {
+    let visible = usize::from(area.height.saturating_sub(2)).max(1);
+    let (scroll, end) = visible_list_bounds(rows.len(), cursor, scroll, visible);
+    let items: Vec<ListItem> = rows[scroll..end]
+        .iter()
+        .enumerate()
+        .map(|(offset, (id, label))| {
+            let idx = scroll + offset;
+            let cursor_marker = if idx == cursor { ">" } else { " " };
+            let selected = if id == &state.draft.model { "*" } else { " " };
+            let style = if idx == cursor { theme::selected() } else { theme::base() };
+            ListItem::new(format!("{cursor_marker} [{selected}] {label}")).style(style)
+        })
+        .collect();
+    f.render_widget(
+        List::new(items).style(theme::base()).block(theme::focused_block("Model", focused)),
+        area,
+    );
+}
+
+fn render_model_help(f: &mut Frame, area: Rect, model_id: Option<&str>) {
+    let text = model_help_lines(model_id);
+    f.render_widget(
+        Paragraph::new(text)
+            .style(theme::base())
+            .wrap(Wrap { trim: true })
+            .block(theme::block("Model help")),
+        area,
+    );
+}
+
+fn model_help_lines(model_id: Option<&str>) -> Vec<Line<'static>> {
+    let Some(model_id) = model_id else {
+        return vec![Line::from(
+            "Move through the model list to compare cost and retrieval tradeoffs.",
+        )];
+    };
+    if model_id == NONE_MODEL {
+        return vec![
+            Line::from("No vector embeddings: lowest CPU, disk, and setup cost."),
+            Line::from("Not recommended for big codebases or fuzzy natural-language queries."),
+        ];
+    }
+    let Some(s) = spec(model_id) else {
+        return vec![Line::from("Unknown model. Pick a registered model before continuing.")];
+    };
+    let weight = match s.dim {
+        0..=384 => "light",
+        385..=512 => "medium",
+        _ => "heavy",
+    };
+    let guidance = match s.backend {
+        Backend::Hash =>
+            "Dependency-free fallback; very fast, but weak semantic recall. Not recommended for \
+             big codebases.",
+        Backend::FastEmbed if s.display.contains("MiniLM") =>
+            "Default balanced choice. Good first pick for most repos; measured as hard to beat \
+             here.",
+        Backend::FastEmbed if s.display.contains("bge") =>
+            "General-purpose 384d model. Similar weight to MiniLM; useful for comparison, not a \
+             clear default win.",
+        Backend::FastEmbed if s.display.contains("jina") =>
+            "Code-focused 768d model. Heavier storage and reconcile cost; not a measured recall \
+             win here.",
+        Backend::FastEmbed =>
+            "Local fastembed model. Good when you want local semantic search without a remote \
+             server.",
+        Backend::Model2Vec =>
+            "Small and fast local model. Use when speed matters more than maximum semantic recall.",
+        Backend::Ollama =>
+            "Remote runtime. Use only with a configured Ollama endpoint or ephemeral provider.",
+    };
+    vec![
+        Line::from(format!("{}: {weight}, {}d, {}.", s.display, s.dim, s.backend.runtime())),
+        Line::from(guidance),
+    ]
+}
+
+fn render_server_model_list(
+    f: &mut Frame,
+    area: Rect,
+    models: &[&str],
+    selected_model: &str,
+    cursor: usize,
+    scroll: usize,
+    focused: bool,
+) {
+    let visible = usize::from(area.height.saturating_sub(2)).max(1);
+    let (scroll, end) = visible_list_bounds(models.len(), cursor, scroll, visible);
+    let items: Vec<ListItem> = models[scroll..end]
+        .iter()
+        .enumerate()
+        .map(|(offset, model)| {
+            let idx = scroll + offset;
+            let cursor_marker = if idx == cursor { ">" } else { " " };
+            let selected = if *model == selected_model { "*" } else { " " };
+            let style = if idx == cursor { theme::selected() } else { theme::base() };
+            ListItem::new(format!("{cursor_marker} [{selected}] {model}")).style(style)
+        })
+        .collect();
+    f.render_widget(
+        List::new(items).style(theme::base()).block(theme::focused_block("server model", focused)),
+        area,
+    );
+}
+
+fn handle_embedding(key: KeyEvent, state: &mut WizardState) -> Outcome {
+    match key.code {
+        KeyCode::Tab => {
+            cycle_embed_focus(state, 1);
+            return Outcome::Consumed;
+        },
+        KeyCode::BackTab => {
+            cycle_embed_focus(state, -1);
+            return Outcome::Consumed;
+        },
+        _ => {},
+    }
+    if edit_embedding_field(key, state) {
+        return Outcome::Consumed;
+    }
+
+    match key.code {
+        KeyCode::Enter => {
+            sync_embedding(state);
+            Outcome::Advance
+        },
+        KeyCode::Esc => Outcome::Back,
+        KeyCode::Up | KeyCode::Char('k') => {
+            move_embedding_cursor(state, -1);
+            Outcome::Consumed
+        },
+        KeyCode::Down | KeyCode::Char('j') => {
+            move_embedding_cursor(state, 1);
+            Outcome::Consumed
+        },
+        KeyCode::PageUp => {
+            move_embedding_cursor(state, -10);
+            Outcome::Consumed
+        },
+        KeyCode::PageDown => {
+            move_embedding_cursor(state, 10);
+            Outcome::Consumed
+        },
+        KeyCode::Home => {
+            move_embedding_cursor_to_edge(state, false);
+            Outcome::Consumed
+        },
+        KeyCode::End => {
+            move_embedding_cursor_to_edge(state, true);
+            Outcome::Consumed
+        },
+        KeyCode::Char(' ') => {
+            select_embedding_focus(state);
+            sync_embedding(state);
+            Outcome::Consumed
+        },
+        KeyCode::Char('d') | KeyCode::Char('D') => {
+            let id = state.draft.model.clone();
+            let (log_tx, log_rx) = std::sync::mpsc::channel();
+            state.start_download_log(log_rx, &id);
+            if id == NONE_MODEL {
+                send_log(&log_tx, "No downloadable embedding model is selected.");
+            } else {
+                state.probes.spawn(StepId::Embedding, ProbeKind::Download, move || {
+                    probe_download(id, log_tx)
+                });
+            }
+            Outcome::Consumed
+        },
+        KeyCode::Char('t') | KeyCode::Char('T') => {
+            sync_embedding(state);
+            let remote = state.draft.remote.as_ref().map(remote_config_for);
+            let s = spec(&state.draft.model);
+            if let (Some(r), Some(s)) = (remote, s) {
+                state
+                    .probes
+                    .spawn(StepId::Embedding, ProbeKind::ConnectTest, move || probe_connect(r, s));
+            }
+            Outcome::Consumed
+        },
+        KeyCode::Char('p') | KeyCode::Char('P') => {
+            sync_embedding(state);
+            if matches!(
+                state.probes.status(StepId::Embedding),
+                ProbeStatus::Running(ProbeKind::EphemeralTest)
+            ) {
+                state.provision_log_lines.push("Provision test already running.".to_string());
+                state.ui.provision_log_open = true;
+                state.ui.provision_log_scroll = u16::MAX;
+                state.ui.provision_log_follow = true;
+                return Outcome::Consumed;
+            }
+            if provision_confirm_satisfied(&state.ui) {
+                let remote = state.draft.remote.as_ref().map(remote_config_for);
+                let s = spec(&state.draft.model);
+                if let (Some(r), Some(s)) = (remote, s) {
+                    let (log_tx, log_rx) = std::sync::mpsc::channel();
+                    state.start_provision_log(log_rx);
+                    state.probes.spawn_ephemeral(StepId::Embedding, move |cancel| {
+                        let _guard = rag_rat_core::index::ai::install_provision_log_sink(log_tx);
+                        probe_ephemeral(r, s, cancel.as_ref())
+                    });
+                }
+            }
+            Outcome::Consumed
+        },
+        _ => Outcome::Pass,
+    }
+}
+
+fn embed_focus(state: &WizardState) -> Option<EmbedFocus> {
+    match &state.step {
+        Some(StepState::Embedding { focus, .. }) => Some(*focus),
+        _ => None,
+    }
+}
+
+fn embed_focus_order(rmode: usize, model_none: bool) -> &'static [EmbedFocus] {
+    const MODEL_ONLY: &[EmbedFocus] = &[EmbedFocus::Model];
+    const LOCAL: &[EmbedFocus] = &[EmbedFocus::Model, EmbedFocus::Mode];
+    const CONNECT: &[EmbedFocus] = &[
+        EmbedFocus::Model,
+        EmbedFocus::Mode,
+        EmbedFocus::Endpoint,
+        EmbedFocus::ServerModel,
+        EmbedFocus::BatchSize,
+        EmbedFocus::AuthEnv,
+    ];
+    const EPHEMERAL: &[EmbedFocus] = &[
+        EmbedFocus::Model,
+        EmbedFocus::Mode,
+        EmbedFocus::Cookbook,
+        EmbedFocus::Gpu,
+        EmbedFocus::ServerModel,
+        EmbedFocus::BatchSize,
+        EmbedFocus::AuthEnv,
+        EmbedFocus::ProvisionConfirm,
+    ];
+
+    if model_none {
+        MODEL_ONLY
+    } else {
+        match rmode {
+            1 => CONNECT,
+            2 => EPHEMERAL,
+            _ => LOCAL,
+        }
+    }
+}
+
+fn cycle_embed_focus(state: &mut WizardState, delta: isize) {
+    let rmode = remote_mode(state);
+    let model_none = state.draft.model == NONE_MODEL || state.draft.model.is_empty();
+    let order = embed_focus_order(rmode, model_none);
+    if let Some(StepState::Embedding { focus, .. }) = &mut state.step {
+        let current = order.iter().position(|candidate| candidate == focus).unwrap_or(0);
+        let len = order.len();
+        let next = if delta >= 0 {
+            (current + 1) % len
+        } else {
+            current.checked_sub(1).unwrap_or(len - 1)
+        };
+        *focus = order[next];
+    }
+}
+
+fn list_window(cursor: usize, scroll: &mut usize) {
+    const WINDOW: usize = 8;
+    if cursor < *scroll {
+        *scroll = cursor;
+    } else if cursor >= scroll.saturating_add(WINDOW) {
+        *scroll = cursor.saturating_sub(WINDOW - 1);
+    }
+}
+
+fn move_embedding_cursor(state: &mut WizardState, delta: isize) {
+    let focus = match embed_focus(state) {
+        Some(f) => f,
+        None => return,
+    };
+    if focus == EmbedFocus::BatchSize {
+        adjust_batch_size(state, delta);
+        return;
+    }
+    let cookbook_len = cookbook_choices(state).len();
+    let gpu_len = current_gpu_options(state).len();
+    let server_model_len = if focus == EmbedFocus::ServerModel {
+        compatible_server_models(&state.draft.model).len()
+    } else {
+        0
+    };
+    if let Some(StepState::Embedding {
+        model_cursor,
+        mode_cursor,
+        cookbook_cursor,
+        server_model_cursor,
+        gpu_cursor,
+        model_scroll,
+        server_model_scroll,
+        ..
+    }) = &mut state.step
+    {
+        match focus {
+            EmbedFocus::Model => {
+                let last = model_rows().len().saturating_sub(1);
+                *model_cursor =
+                    (*model_cursor as isize).saturating_add(delta).clamp(0, last as isize) as usize;
+                list_window(*model_cursor, model_scroll);
+            },
+            EmbedFocus::Mode => {
+                *mode_cursor = (*mode_cursor as isize).saturating_add(delta).clamp(0, 2) as usize;
+            },
+            EmbedFocus::Cookbook => {
+                let last = cookbook_len.saturating_sub(1);
+                *cookbook_cursor = (*cookbook_cursor as isize)
+                    .saturating_add(delta)
+                    .clamp(0, last as isize) as usize;
+            },
+            EmbedFocus::ServerModel => {
+                let last = server_model_len.saturating_sub(1);
+                *server_model_cursor = (*server_model_cursor as isize)
+                    .saturating_add(delta)
+                    .clamp(0, last as isize) as usize;
+                list_window(*server_model_cursor, server_model_scroll);
+            },
+            EmbedFocus::Gpu => {
+                let last = gpu_len.saturating_sub(1);
+                *gpu_cursor =
+                    (*gpu_cursor as isize).saturating_add(delta).clamp(0, last as isize) as usize;
+            },
+            _ => {},
+        }
+    }
+}
+
+fn move_embedding_cursor_to_edge(state: &mut WizardState, end: bool) {
+    let focus = match embed_focus(state) {
+        Some(f) => f,
+        None => return,
+    };
+    let server_model_len = if focus == EmbedFocus::ServerModel {
+        compatible_server_models(&state.draft.model).len()
+    } else {
+        0
+    };
+    let cookbook_len = cookbook_choices(state).len();
+    let gpu_len = current_gpu_options(state).len();
+    let target = match focus {
+        EmbedFocus::Model => model_rows().len().saturating_sub(1),
+        EmbedFocus::Mode => 2,
+        EmbedFocus::Cookbook => cookbook_len.saturating_sub(1),
+        EmbedFocus::ServerModel => server_model_len.saturating_sub(1),
+        EmbedFocus::Gpu => gpu_len.saturating_sub(1),
+        _ => 0,
+    };
+    if let Some(StepState::Embedding {
+        model_cursor,
+        mode_cursor,
+        cookbook_cursor,
+        server_model_cursor,
+        gpu_cursor,
+        model_scroll,
+        server_model_scroll,
+        ..
+    }) = &mut state.step
+    {
+        let value = if end { target } else { 0 };
+        match focus {
+            EmbedFocus::Model => {
+                *model_cursor = value;
+                list_window(*model_cursor, model_scroll);
+            },
+            EmbedFocus::Mode => *mode_cursor = value,
+            EmbedFocus::Cookbook => *cookbook_cursor = value,
+            EmbedFocus::ServerModel => {
+                *server_model_cursor = value;
+                list_window(*server_model_cursor, server_model_scroll);
+            },
+            EmbedFocus::Gpu => *gpu_cursor = value,
+            _ => {},
+        }
+    }
+}
+
+fn scroll_embedding(delta: isize, state: &mut WizardState) -> bool {
+    move_embedding_cursor(state, delta);
+    true
+}
+
+fn select_embedding_focus(state: &mut WizardState) {
+    let focus = match embed_focus(state) {
+        Some(f) => f,
+        None => return,
+    };
+    let mut changed = false;
+    match focus {
+        EmbedFocus::Model => {
+            let rows = model_rows();
+            let cursor = match &state.step {
+                Some(StepState::Embedding { model_cursor, .. }) => *model_cursor,
+                _ => 0,
+            };
+            if let Some((id, _)) = rows.get(cursor) {
+                let previous_default = default_remote_model_for(&state.draft.model).to_string();
+                changed |= state.draft.model != *id;
+                state.draft.model = id.clone();
+                let default_model = default_remote_model_for(&state.draft.model).to_string();
+                if let Some(remote) = &mut state.draft.remote
+                    && (remote.model.is_empty() || remote.model == previous_default)
+                {
+                    changed |= remote.model != default_model;
+                    remote.model = default_model;
+                }
+            }
+        },
+        EmbedFocus::Mode => {
+            let cursor = match &state.step {
+                Some(StepState::Embedding { mode_cursor, .. }) => *mode_cursor,
+                _ => 0,
+            };
+            let current = remote_mode(state);
+            if cursor != current {
+                let existing = state.draft.remote.as_ref().cloned();
+                let default_cookbook = default_cookbook_command(state);
+                state.draft.remote = match cursor {
+                    0 => None,
+                    1 => Some(new_connect_remote_from(&state.draft.model, existing.as_ref())),
+                    2 => Some(new_ephemeral_remote_from(
+                        &state.draft.model,
+                        existing.as_ref(),
+                        &default_cookbook,
+                    )),
+                    _ => None,
+                };
+                changed = true;
+            }
+            state.ui.show_remote_mode_help_once(cursor);
+        },
+        EmbedFocus::Cookbook => {
+            let cursor = match &state.step {
+                Some(StepState::Embedding { cookbook_cursor, .. }) => *cookbook_cursor,
+                _ => 0,
+            };
+            let choices = cookbook_choices(state);
+            if let Some(entry) = choices.get(cursor)
+                && let Some(remote) = &mut state.draft.remote
+            {
+                let mode = RemoteMode::Ephemeral(entry.command.clone());
+                if remote.mode != mode {
+                    remote.mode = mode;
+                    remote.gpu = None;
+                    changed = true;
+                }
+            }
+        },
+        EmbedFocus::ServerModel => {
+            let cursor = match &state.step {
+                Some(StepState::Embedding { server_model_cursor, .. }) => *server_model_cursor,
+                _ => 0,
+            };
+            let server_models = compatible_server_models(&state.draft.model);
+            if let Some(model) = server_models.get(cursor)
+                && let Some(remote) = &mut state.draft.remote
+            {
+                changed |= remote.model != *model;
+                remote.model = (*model).to_string();
+            }
+        },
+        EmbedFocus::Gpu => {
+            let cursor = match &state.step {
+                Some(StepState::Embedding { gpu_cursor, .. }) => *gpu_cursor,
+                _ => 0,
+            };
+            let gpu = current_gpu_options(state).get(cursor).cloned();
+            if let Some(gpu) = gpu
+                && let Some(remote) = &mut state.draft.remote
+            {
+                changed |= remote.gpu.as_deref() != Some(gpu.as_str());
+                remote.gpu = Some(gpu);
+            }
+        },
+        _ => {},
+    }
+    if changed {
+        state.probes.bump(StepId::Embedding);
+    }
+}
+
+fn new_connect_remote(local_model: &str) -> RemoteDraft {
+    RemoteDraft {
+        model: default_remote_model_for(local_model).to_string(),
+        mode: RemoteMode::Connect(DEFAULT_QUERY_ENDPOINT.to_string()),
+        gpu: None,
+        num_ctx: None,
+        batch_size: 256,
+        auth_env: None,
+    }
+}
+
+fn new_connect_remote_from(local_model: &str, existing: Option<&RemoteDraft>) -> RemoteDraft {
+    let mut remote = new_connect_remote(local_model);
+    if let Some(existing) = existing {
+        remote.model = preserved_server_model(local_model, existing);
+        remote.num_ctx = existing.num_ctx;
+        remote.batch_size = existing.batch_size;
+        remote.auth_env = existing.auth_env.clone();
+    }
+    remote
+}
+
+#[cfg(test)]
+fn new_ephemeral_remote(local_model: &str) -> RemoteDraft {
+    new_ephemeral_remote_with_command(local_model, "@rag-rat/cookbook modal")
+}
+
+fn new_ephemeral_remote_with_command(local_model: &str, cookbook: &str) -> RemoteDraft {
+    RemoteDraft {
+        model: default_remote_model_for(local_model).to_string(),
+        mode: RemoteMode::Ephemeral(cookbook.to_string()),
+        gpu: None,
+        num_ctx: None,
+        batch_size: 256,
+        auth_env: None,
+    }
+}
+
+fn new_ephemeral_remote_from(
+    local_model: &str,
+    existing: Option<&RemoteDraft>,
+    default_cookbook: &str,
+) -> RemoteDraft {
+    let mut remote = new_ephemeral_remote_with_command(local_model, default_cookbook);
+    if let Some(existing) = existing {
+        remote.model = preserved_server_model(local_model, existing);
+        remote.gpu = existing.gpu.clone();
+        remote.num_ctx = existing.num_ctx;
+        remote.batch_size = existing.batch_size;
+        remote.auth_env = existing.auth_env.clone();
+    }
+    remote
+}
+
+fn preserved_server_model(local_model: &str, existing: &RemoteDraft) -> String {
+    if existing.model.trim().is_empty() {
+        default_remote_model_for(local_model).to_string()
+    } else {
+        existing.model.clone()
+    }
+}
+
+fn adjust_batch_size(state: &mut WizardState, delta: isize) {
+    let changed = {
+        let Some(remote) = &mut state.draft.remote else { return };
+        let current = remote.batch_size as isize;
+        let next = current.saturating_add(delta).clamp(1, 4096) as u32;
+        if remote.batch_size == next {
+            false
+        } else {
+            remote.batch_size = next;
+            true
+        }
+    };
+    if changed {
+        state.probes.bump(StepId::Embedding);
+    }
+}
+
+fn edit_embedding_field(key: KeyEvent, state: &mut WizardState) -> bool {
+    let Some(focus) = embed_focus(state) else { return false };
+    match focus {
+        EmbedFocus::Endpoint => edit_endpoint(key, state),
+        EmbedFocus::BatchSize => edit_batch_size(key, state),
+        EmbedFocus::AuthEnv => edit_auth_env(key, state),
+        EmbedFocus::ProvisionConfirm => edit_provision_confirm(key, state),
+        _ => false,
+    }
+}
+
+fn editable_char(key: KeyEvent) -> Option<char> {
+    match key.code {
+        KeyCode::Char(c)
+            if !key.modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            Some(c),
+        _ => None,
+    }
+}
+
+fn edit_endpoint(key: KeyEvent, state: &mut WizardState) -> bool {
+    let Some(remote) = &mut state.draft.remote else { return false };
+    let RemoteMode::Connect(endpoint) = &mut remote.mode else { return false };
+    match key.code {
+        KeyCode::Backspace => {
+            endpoint.pop();
+            state.probes.bump(StepId::Embedding);
+            true
+        },
+        _ =>
+            if let Some(c) = editable_char(key) {
+                endpoint.push(c);
+                state.probes.bump(StepId::Embedding);
+                true
+            } else {
+                false
+            },
+    }
+}
+
+fn edit_batch_size(key: KeyEvent, state: &mut WizardState) -> bool {
+    let Some(remote) = &mut state.draft.remote else { return false };
+    match key.code {
+        KeyCode::Backspace => {
+            remote.batch_size /= 10;
+            if remote.batch_size == 0 {
+                remote.batch_size = 1;
+            }
+            state.probes.bump(StepId::Embedding);
+            true
+        },
+        KeyCode::Char(c) if c.is_ascii_digit() => {
+            let digit = c.to_digit(10).unwrap_or(0);
+            remote.batch_size =
+                remote.batch_size.saturating_mul(10).saturating_add(digit).clamp(1, 4096);
+            state.probes.bump(StepId::Embedding);
+            true
+        },
+        _ => false,
+    }
+}
+
+fn edit_auth_env(key: KeyEvent, state: &mut WizardState) -> bool {
+    let Some(remote) = &mut state.draft.remote else { return false };
+    let mut value = remote.auth_env.take().unwrap_or_default();
+    let handled = match key.code {
+        KeyCode::Backspace => {
+            value.pop();
+            true
+        },
+        _ =>
+            if let Some(c) = editable_char(key) {
+                value.push(c);
+                true
+            } else {
+                false
+            },
+    };
+    remote.auth_env = (!value.is_empty()).then_some(value);
+    if handled {
+        state.probes.bump(StepId::Embedding);
+    }
+    handled
+}
+
+fn edit_provision_confirm(key: KeyEvent, state: &mut WizardState) -> bool {
+    if provision_confirm_satisfied(&state.ui)
+        && matches!(key.code, KeyCode::Char('p') | KeyCode::Char('P'))
+    {
+        return false;
+    }
+    match key.code {
+        KeyCode::Backspace => {
+            state.ui.provision_confirm.pop();
+            true
+        },
+        _ =>
+            if let Some(c) = editable_char(key) {
+                state.ui.provision_confirm.push(c);
+                true
+            } else {
+                false
+            },
+    }
+}
+
+fn sync_embedding(_state: &mut WizardState) {
+    // state.draft is mutated directly in handle_key
+}
+
+fn validate_embedding(state: &WizardState) -> CheckResult {
+    if state.draft.remote.is_some()
+        && !matches!(spec(&state.draft.model).map(|s| s.backend), Some(Backend::FastEmbed))
+    {
+        return CheckResult::block(
+            "remote Ollama embeddings require a transformer model; select MiniLM, BGE, or Jina, \
+             or disable remote mode",
+        );
+    }
+    if let Some(r) = &state.draft.remote {
+        if r.model.trim().is_empty() {
+            return CheckResult::block("remote server model is required");
+        }
+        if let Some(local) = spec(&state.draft.model)
+            && let Some(server_dim) = ollama_model_dim(r.model.trim())
+            && server_dim != local.dim
+        {
+            return CheckResult::block(format!(
+                "remote server model `{}` is {server_dim}d but selected model `{}` is {}d",
+                r.model.trim(),
+                local.model_id,
+                local.dim
+            ));
+        }
+        if let Some(auth_env) = &r.auth_env
+            && let Some(check) = validate_remote_auth_env(auth_env)
+        {
+            return check;
+        }
+        match &r.mode {
+            RemoteMode::Connect(endpoint) => {
+                if endpoint.trim().is_empty() {
+                    return CheckResult::block("connect endpoint is required");
+                }
+                if endpoint_authority_has_userinfo(endpoint) {
+                    return CheckResult::block(
+                        "connect endpoint must not include credentials; use auth env instead",
+                    );
+                }
+                if r.gpu.is_some() {
+                    return CheckResult::warn("gpu only applies to ephemeral mode");
+                }
+            },
+            RemoteMode::Ephemeral(cookbook) =>
+                if cookbook.trim().is_empty() {
+                    return CheckResult::block("ephemeral cookbook command is required");
+                },
+        }
+        if let Some(warning) = remote_model_quality_warning(&state.draft.model, r.model.trim()) {
+            return CheckResult::warn(warning);
+        }
+    }
+    CheckResult::ok()
+}
+
+fn remote_model_quality_warning(local_model: &str, server_model: &str) -> Option<String> {
+    let expected = ollama_model_for(local_model)?;
+    if server_model == expected || !OLLAMA_EMBEDDING_MODELS.contains(&server_model) {
+        return None;
+    }
+    let local = spec(local_model)?;
+    if ollama_model_dim(server_model) != Some(local.dim) {
+        return None;
+    }
+    Some(format!(
+        "remote server model `{server_model}` is dimension-compatible with `{}` but not the same \
+         embedding family; quality may vary",
+        local.model_id
+    ))
+}
+
+fn validate_remote_auth_env(auth_env: &str) -> Option<CheckResult> {
+    if auth_env.trim().is_empty() {
+        return Some(CheckResult::block("remote auth env name is empty"));
+    }
+    match std::env::var(auth_env) {
+        Ok(value) if !value.trim().is_empty() => None,
+        _ => Some(CheckResult::block(format!("remote auth env `{auth_env}` is not set"))),
+    }
+}
+
+fn endpoint_authority_has_userinfo(endpoint: &str) -> bool {
+    let after_scheme = endpoint.split_once("://").map_or(endpoint, |(_, rest)| rest);
+    let authority = after_scheme.split(['/', '?', '#']).next().unwrap_or(after_scheme);
+    authority.contains('@')
+}
+
+fn remote_config_for(d: &RemoteDraft) -> RemoteEmbeddingConfig {
+    let (ep, cb) = match &d.mode {
+        RemoteMode::Connect(u) => (Some(u.clone()), None),
+        RemoteMode::Ephemeral(c) => (None, Some(c.clone())),
+    };
+    RemoteEmbeddingConfig {
+        model: d.model.clone(),
+        endpoint: ep,
+        cookbook: cb,
+        query_endpoint: None,
+        auth_env: d.auth_env.clone(),
+        gpu: d.gpu.clone(),
+        num_ctx: d.num_ctx,
+        batch_size: d.batch_size,
+        request_timeout_s: RemoteEmbeddingConfig::default().request_timeout_s,
+    }
+}
+
+fn probe_download(id: String, log_tx: Sender<String>) -> CheckResult {
+    if id == NONE_MODEL {
+        send_log(&log_tx, "No downloadable embedding model is selected.");
+        return CheckResult::ok();
+    }
+    send_log(&log_tx, format!("Preparing embedder for {id}..."));
+    match build_embedder(&id) {
+        Ok(e) => {
+            send_log(&log_tx, "Verifying model with a ping embedding...");
+            match e.embed_batch(&["ping".to_string()]) {
+                Ok(v) if v.first().is_some_and(|x| !x.is_empty()) => {
+                    send_log(&log_tx, "Model download and verification completed.");
+                    CheckResult::ok()
+                },
+                Ok(_) => {
+                    let msg = format!("{id} empty embedding");
+                    send_log(&log_tx, msg.clone());
+                    CheckResult::warn(msg)
+                },
+                Err(e) => {
+                    let msg = format!("verify: {e}");
+                    send_log(&log_tx, msg.clone());
+                    CheckResult::warn(msg)
+                },
+            }
+        },
+        Err(e) => {
+            let msg = format!("download: {e}");
+            send_log(&log_tx, msg.clone());
+            CheckResult::warn(msg)
+        },
+    }
+}
+
+fn probe_connect(r: RemoteEmbeddingConfig, s: &EmbeddingModelSpec) -> CheckResult {
+    match OllamaEmbedder::from_remote_config(&r, s.model_id, s.dim) {
+        Ok(e) => match e.embed_batch(&["ping".to_string()]) {
+            Ok(v) if v.first().is_some_and(|x| !x.is_empty()) => CheckResult::ok(),
+            Ok(_) => CheckResult::warn("empty embedding"),
+            Err(e) => CheckResult::warn(format!("connect: {e}")),
+        },
+        Err(e) => CheckResult::warn(format!("build: {e}")),
+    }
+}
+
+fn probe_ephemeral(
+    r: RemoteEmbeddingConfig,
+    s: &EmbeddingModelSpec,
+    cancel: &std::sync::atomic::AtomicBool,
+) -> CheckResult {
+    match verify_ephemeral_remote_cancellable(&r, s, || cancel.load(Ordering::Acquire)) {
+        Ok(()) => CheckResult::ok(),
+        Err(e) => CheckResult::warn(format!("ephemeral: {e}")),
+    }
+}
+
+fn build_embedder(id: &str) -> anyhow::Result<Box<dyn Embedder>> {
+    let s = spec(id).ok_or_else(|| anyhow::anyhow!("unknown model {id}"))?;
+    match s.backend {
+        Backend::Hash => Ok(Box::new(HashEmbedder)),
+        Backend::FastEmbed => {
+            #[cfg(feature = "fastembed")]
+            {
+                Ok(Box::new(FastEmbedEmbedder::for_model_id(s.model_id, s.dim, None)?))
+            }
+            #[cfg(not(feature = "fastembed"))]
+            {
+                anyhow::bail!("no fastembed")
+            }
+        },
+        Backend::Model2Vec => {
+            #[cfg(feature = "model2vec")]
+            {
+                Ok(Box::new(Model2VecEmbedder::new()?))
+            }
+            #[cfg(not(feature = "model2vec"))]
+            {
+                anyhow::bail!("no model2vec")
+            }
+        },
+        Backend::Ollama => anyhow::bail!("ollama is transport, not local"),
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// INTEGRATION
+// ═══════════════════════════════════════════════════════════════════════════════
+
+fn render_integration(f: &mut Frame, area: Rect, state: &WizardState) {
+    let Some(StepState::Integration { focus }) = state.step else { return };
+    let chunks = Layout::vertical([
+        Constraint::Length(3),
+        Constraint::Length(3),
+        Constraint::Length(3),
+        Constraint::Length(3),
+        Constraint::Min(0),
+    ])
+    .split(area);
+
+    let rows = [
+        ("version check (t)", state.draft.version_check),
+        ("git hooks (g)", state.draft.hooks.git),
+        ("Claude hooks (c)", state.draft.hooks.claude),
+        ("global hooks", state.draft.hooks.claude_global),
+    ];
+    for (i, (label, on)) in rows.iter().enumerate() {
+        let style = if focus == i { theme::selected() } else { theme::base() };
+        let text = if *on { format!("[x] {}", label) } else { format!("[ ] {}", label) };
+        f.render_widget(
+            Paragraph::new(Span::styled(text, style))
+                .style(theme::base())
+                .block(theme::focused_block("", focus == i)),
+            chunks[i],
+        );
+    }
+}
+
+fn handle_integration(key: KeyEvent, state: &mut WizardState) -> Outcome {
+    let Some(StepState::Integration { focus }) = &mut state.step else { return Outcome::Pass };
+    match key.code {
+        KeyCode::Up | KeyCode::Char('k') => {
+            if *focus > 0 {
+                *focus -= 1;
+            }
+            Outcome::Consumed
+        },
+        KeyCode::Down | KeyCode::Char('j') => {
+            if *focus + 1 < 4 {
+                *focus += 1;
+            }
+            Outcome::Consumed
+        },
+        KeyCode::Home => {
+            *focus = 0;
+            Outcome::Consumed
+        },
+        KeyCode::End => {
+            *focus = 3;
+            Outcome::Consumed
+        },
+        KeyCode::Char(' ') => {
+            match *focus {
+                0 => {
+                    state.draft.version_check = !state.draft.version_check;
+                },
+                1 => {
+                    state.draft.hooks.git = !state.draft.hooks.git;
+                },
+                2 => {
+                    state.draft.hooks.claude = !state.draft.hooks.claude;
+                },
+                _ => {
+                    state.draft.hooks.claude_global = !state.draft.hooks.claude_global;
+                },
+            };
+            Outcome::Consumed
+        },
+        KeyCode::Char('t') | KeyCode::Char('T') => {
+            state.probes.spawn(StepId::Integration, ProbeKind::VersionCheck, || {
+                match rag_rat_core::version_check::fetch_latest() {
+                    Some(v) =>
+                        CheckResult { severity: Sev::Ok, message: Some(format!("latest: {v}")) },
+                    None => CheckResult::warn("couldn't reach crates.io"),
+                }
+            });
+            Outcome::Consumed
+        },
+        KeyCode::Char('g') | KeyCode::Char('G') => {
+            state.draft.hooks.git = !state.draft.hooks.git;
+            Outcome::Consumed
+        },
+        KeyCode::Char('c') | KeyCode::Char('C') => {
+            state.draft.hooks.claude = !state.draft.hooks.claude;
+            Outcome::Consumed
+        },
+        KeyCode::Enter => Outcome::Advance,
+        KeyCode::Esc => Outcome::Back,
+        _ => Outcome::Pass,
+    }
+}
+
+fn validate_hooks(state: &WizardState) -> CheckResult {
+    if !state.draft.hooks.git {
+        return CheckResult::ok();
+    }
+    let Ok(gp) = git_paths(&state.draft.root_abs) else {
+        return CheckResult::block(
+            "git hooks require a git worktree; disable git hooks or choose a git repo root",
+        );
+    };
+    for &hook in MANAGED_HOOKS {
+        let path = gp.hooks_dir.join(hook);
+        if path.exists()
+            && !is_rag_rat_hook(&path).unwrap_or(false)
+            && !state.hook_conflicts.contains_key(hook)
+        {
+            return CheckResult::block(format!(
+                "resolve foreign hook `{}` before saving or disable git hooks",
+                hook
+            ));
+        }
+    }
+    CheckResult::ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::init::RepoScan;
+    use crate::init::scan::scan_repo;
+    use crate::init::wizard::catalog::CookbookCatalog;
+    use crate::init::wizard::draft::{MODAL_GPUS, WizardDraft};
+    use crate::init::wizard::probe::ProbeMsg;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn empty_state() -> WizardState {
+        let scan = RepoScan::default();
+        let draft = WizardDraft::from_scan(&scan, ".".to_string(), PathBuf::from("."));
+        WizardState::new(draft, scan)
+    }
+
+    fn state_with_catalog(raw: &str) -> WizardState {
+        let scan = RepoScan::default();
+        let draft = WizardDraft::from_scan(&scan, ".".to_string(), PathBuf::from("."));
+        WizardState::with_cookbooks(draft, scan, CookbookCatalog::from_raw(raw))
+    }
+
+    #[test]
+    fn oracle_test_key_opens_log_immediately() {
+        let mut state = empty_state();
+        state.step = Some(init_step(StepId::Oracle, &state));
+
+        assert_eq!(handle_oracle(key(KeyCode::Char('t')), &mut state), Outcome::Consumed);
+
+        assert!(state.ui.provision_log_open);
+        assert_eq!(state.provision_log_title, "Oracle tool test");
+        assert!(
+            state
+                .provision_log_lines
+                .first()
+                .is_some_and(|line| line.contains("Starting Oracle tool test"))
+        );
+    }
+
+    #[test]
+    fn embedding_download_key_opens_log_immediately() {
+        let mut state = empty_state();
+        let hash_model =
+            EMBEDDING_MODELS.iter().find(|spec| spec.backend == Backend::Hash).unwrap().model_id;
+        state.draft.model = hash_model.to_string();
+        state.step = Some(init_step(StepId::Embedding, &state));
+
+        assert_eq!(handle_embedding(key(KeyCode::Char('d')), &mut state), Outcome::Consumed);
+
+        assert!(state.ui.provision_log_open);
+        assert_eq!(state.provision_log_title, "Model download");
+        assert!(
+            state
+                .provision_log_lines
+                .first()
+                .is_some_and(|line| line.contains("Starting model download"))
+        );
+    }
+
+    fn rust_state(dir_count: usize) -> (TempDir, WizardState) {
+        let dir = tempfile::tempdir().unwrap();
+        for i in 0..dir_count {
+            let path = dir.path().join(format!("src/module_{i}"));
+            std::fs::create_dir_all(&path).unwrap();
+            std::fs::write(path.join("lib.rs"), "").unwrap();
+        }
+        let scan = scan_repo(dir.path()).unwrap();
+        let draft = WizardDraft::from_scan(&scan, ".".to_string(), dir.path().to_path_buf());
+        let mut state = WizardState::new(draft, scan);
+        state.step = Some(init_step(StepId::Indexing, &state));
+        (dir, state)
+    }
+
+    fn language_toggle(state: &WizardState, lang: Language) -> Option<bool> {
+        match &state.step {
+            Some(StepState::Indexing { lang_toggles, .. }) =>
+                lang_toggles.iter().find(|(candidate, _)| *candidate == lang).map(|(_, on)| *on),
+            _ => None,
+        }
+    }
+
+    fn render_embedding_cells(state: &WizardState, width: u16, height: u16) -> Vec<Vec<String>> {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render_embedding(f, f.area(), state)).unwrap();
+        let buffer = terminal.backend().buffer();
+
+        (0..height)
+            .map(|y| (0..width).map(|x| buffer[(x, y)].symbol().to_string()).collect())
+            .collect()
+    }
+
+    fn row_text(row: &[String]) -> String {
+        row.concat()
+    }
+
+    fn row_segment(cells: &[Vec<String>], y: usize, x: usize, width: usize) -> String {
+        cells[y][x..x + width].concat()
+    }
+
+    fn screen_text(cells: &[Vec<String>]) -> String {
+        cells.iter().map(|row| row_text(row)).collect::<Vec<_>>().join("\n")
+    }
+
+    #[test]
+    fn oracle_tool_result_wraps_inside_availability_box() {
+        let mut state = empty_state();
+        state.step = Some(init_step(StepId::Oracle, &state));
+        let probe_id = state.probes.current(StepId::Oracle);
+        state.probes.apply(ProbeMsg {
+            probe_id,
+            kind: ProbeKind::OracleTool,
+            result: CheckResult::warn(concat!(
+                "scip probe emitted a long diagnostic with enough words to require wrapping ",
+                "inside the availability box and still show tail-token-inside-oracle"
+            )),
+        });
+
+        let width = 52;
+        let height = 20;
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render_oracle(f, f.area(), &state)).unwrap();
+        let cells = (0..height)
+            .map(|y| {
+                (0..width)
+                    .map(|x| terminal.backend().buffer()[(x, y)].symbol().to_string())
+                    .collect::<Vec<String>>()
+            })
+            .collect::<Vec<Vec<String>>>();
+        let screen = screen_text(&cells);
+
+        assert!(
+            screen.contains("tail-token-inside-oracle"),
+            "long Oracle result should wrap instead of clipping:\n{screen}"
+        );
+    }
+
+    #[test]
+    fn step_dispatch_render_and_validation_smoke() {
+        for step in StepId::ALL {
+            let mut state = empty_state();
+            state.step = Some(init_step(step, &state));
+
+            let backend = TestBackend::new(120, 32);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal.draw(|f| render_step(step, f, f.area(), &mut state)).unwrap();
+            let rendered: String =
+                terminal.backend().buffer().content().iter().map(|cell| cell.symbol()).collect();
+
+            assert!(!rendered.trim().is_empty(), "{step:?} rendered an empty screen");
+            let _ = validate_step(step, &state);
+            let _ = step_handle_key(step, key(KeyCode::Tab), &mut state);
+            let _ = step_handle_key(step, key(KeyCode::BackTab), &mut state);
+            let _ = step_handle_key(step, key(KeyCode::Enter), &mut state);
+        }
+    }
+
+    #[test]
+    fn chained_hook_renderer_preserves_existing_body_and_appends_maintenance() {
+        let rendered = hooks::render_chained_hook("#!/bin/sh\necho before\n", "pre-commit");
+
+        assert!(rendered.starts_with("#!/bin/sh\n# Chained hook"));
+        assert!(rendered.contains("echo before"));
+        assert!(rendered.contains("rag-rat maintenance"));
+        assert!(rendered.contains("--trigger pre-commit"));
+    }
+
+    #[test]
+    fn indexing_tree_cursor_toggles_the_focused_directory() {
+        let (_dir, mut state) = rust_state(1);
+        assert!(state.draft.bindings.get(&Language::Rust).unwrap().contains(&PathBuf::from("src")));
+
+        step_handle_key(StepId::Indexing, key(KeyCode::Tab), &mut state);
+        step_handle_key(StepId::Indexing, key(KeyCode::Down), &mut state);
+        step_handle_key(StepId::Indexing, key(KeyCode::Char(' ')), &mut state);
+
+        assert!(
+            !state.draft.bindings.get(&Language::Rust).unwrap().contains(&PathBuf::from("src"))
+        );
+    }
+
+    #[test]
+    fn indexing_reentry_preserves_disabled_detected_languages() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::create_dir_all(dir.path().join("py")).unwrap();
+        std::fs::write(dir.path().join("src/lib.rs"), "").unwrap();
+        std::fs::write(dir.path().join("py/app.py"), "").unwrap();
+        let scan = scan_repo(dir.path()).unwrap();
+        let mut draft = WizardDraft::from_scan(&scan, ".".to_string(), dir.path().to_path_buf());
+        assert!(draft.bindings.contains_key(&Language::Python));
+        draft.bindings.remove(&Language::Python);
+        let mut state = WizardState::new(draft, scan);
+
+        state.step = Some(init_step(StepId::Indexing, &state));
+
+        assert_eq!(language_toggle(&state, Language::Rust), Some(true));
+        assert_eq!(language_toggle(&state, Language::Python), Some(false));
+        assert!(!state.draft.bindings.contains_key(&Language::Python));
+    }
+
+    #[test]
+    fn indexing_tree_page_down_moves_selection() {
+        let (_dir, mut state) = rust_state(18);
+        step_handle_key(StepId::Indexing, key(KeyCode::Tab), &mut state);
+        step_handle_key(StepId::Indexing, key(KeyCode::PageDown), &mut state);
+
+        let selected = selected_dir_path(&state).expect("tree selection");
+        assert_ne!(selected, PathBuf::from("."));
+    }
+
+    #[test]
+    fn indexing_shift_tab_wraps_to_previous_focus_zone() {
+        let (_dir, mut state) = rust_state(1);
+
+        assert_eq!(
+            step_handle_key(StepId::Indexing, key(KeyCode::BackTab), &mut state),
+            Outcome::Consumed
+        );
+        assert!(matches!(&state.step, Some(StepState::Indexing { zone: IndexZone::Tree, .. })));
+
+        assert_eq!(
+            step_handle_key(StepId::Indexing, key(KeyCode::BackTab), &mut state),
+            Outcome::Consumed
+        );
+        assert!(matches!(&state.step, Some(StepState::Indexing { zone: IndexZone::Toggles, .. })));
+    }
+
+    #[test]
+    fn indexing_render_and_navigation_edges_are_stable() {
+        let (_dir, mut state) = rust_state(6);
+        let backend = TestBackend::new(100, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| render_indexing(f, f.area(), &mut state)).unwrap();
+        assert!(
+            screen_text(
+                &(0..24)
+                    .map(|y| {
+                        (0..100)
+                            .map(|x| terminal.backend().buffer()[(x, y)].symbol().to_string())
+                            .collect()
+                    })
+                    .collect::<Vec<Vec<String>>>()
+            )
+            .contains("Directories")
+        );
+
+        assert_eq!(
+            step_handle_key(StepId::Indexing, key(KeyCode::Char(' ')), &mut state),
+            Outcome::Consumed
+        );
+        assert_eq!(
+            step_handle_key(StepId::Indexing, key(KeyCode::Char('a')), &mut state),
+            Outcome::Consumed
+        );
+        assert_eq!(
+            step_handle_key(StepId::Indexing, key(KeyCode::Char('A')), &mut state),
+            Outcome::Consumed
+        );
+
+        assert_eq!(
+            step_handle_key(StepId::Indexing, key(KeyCode::Tab), &mut state),
+            Outcome::Consumed
+        );
+        for code in [
+            KeyCode::Down,
+            KeyCode::Up,
+            KeyCode::PageDown,
+            KeyCode::PageUp,
+            KeyCode::End,
+            KeyCode::Home,
+            KeyCode::Left,
+            KeyCode::Right,
+            KeyCode::Enter,
+        ] {
+            let _ = step_handle_key(StepId::Indexing, key(code), &mut state);
+        }
+        assert_eq!(step_handle_key(StepId::Indexing, key(KeyCode::Esc), &mut state), Outcome::Back);
+    }
+
+    #[test]
+    fn indexing_candidates_cover_empty_cache_and_missing_paths() {
+        let mut state = empty_state();
+        state.step = Some(init_step(StepId::Indexing, &state));
+        state.draft.bindings.insert(Language::Rust, vec![PathBuf::from("missing")]);
+
+        let candidates = candidates_for(Language::Rust, &state);
+        assert_eq!(candidates[0].path, PathBuf::from("."));
+        assert!(matches!(validate_indexing(&state).severity, Sev::Warn));
+    }
+
+    #[test]
+    fn indexing_blocks_empty_simple_bindings() {
+        let mut state = empty_state();
+        state.draft.bindings.clear();
+
+        let check = validate_indexing(&state);
+
+        assert_eq!(check.severity, Sev::Block);
+        assert!(check.message.unwrap().contains("indexed directory"));
+    }
+
+    #[test]
+    fn indexing_allows_preserved_rich_targets_without_simple_bindings() {
+        let mut state = empty_state();
+        state.draft.bindings.clear();
+        state.draft.has_rich_targets = true;
+
+        assert_eq!(validate_indexing(&state).severity, Sev::Ok);
+    }
+
+    #[test]
+    fn indexing_blocks_simple_binding_names_that_conflict_with_preserved_rich_targets() {
+        let mut state = empty_state();
+        state.draft.has_rich_targets = true;
+        state.draft.rich_target_names.insert(Language::Rust.as_str().to_string());
+        state.draft.bindings.insert(Language::Rust, Vec::new());
+
+        let check = validate_indexing(&state);
+
+        assert_eq!(check.severity, Sev::Block);
+        assert!(check.message.unwrap().contains("rust"));
+    }
+
+    #[test]
+    fn embedding_server_model_selector_allows_dimension_compatible_alternatives() {
+        let mut state = empty_state();
+        state.step = Some(init_step(StepId::Embedding, &state));
+
+        step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Down), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Char(' ')), &mut state);
+
+        let remote = state.draft.remote.as_ref().expect("connect remote should be selected");
+        assert!(
+            matches!(remote.mode, RemoteMode::Connect(ref endpoint) if endpoint == DEFAULT_QUERY_ENDPOINT)
+        );
+        assert_eq!(remote.model, default_remote_model_for(&state.draft.model));
+        assert_eq!(compatible_server_models(&state.draft.model), vec![
+            "all-minilm",
+            "qllama/bge-small-en-v1.5:f16"
+        ]);
+
+        step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Down), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Char(' ')), &mut state);
+
+        assert_eq!(state.draft.remote.as_ref().unwrap().model, "qllama/bge-small-en-v1.5:f16");
+        assert_eq!(validate_embedding(&state).severity, Sev::Warn);
+    }
+
+    #[test]
+    fn embedding_ephemeral_defaults_without_gpu() {
+        let mut state = empty_state();
+        state.step = Some(init_step(StepId::Embedding, &state));
+
+        step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Down), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Down), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Char(' ')), &mut state);
+
+        assert!(matches!(
+            state.draft.remote.as_ref().map(|remote| &remote.mode),
+            Some(RemoteMode::Ephemeral(_))
+        ));
+        assert_eq!(state.draft.remote.as_ref().and_then(|remote| remote.gpu.as_deref()), None);
+
+        step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Char(' ')), &mut state);
+
+        assert_eq!(state.draft.remote.as_ref().and_then(|remote| remote.gpu.as_deref()), None);
+    }
+
+    #[test]
+    fn embedding_remote_requires_transformer_model() {
+        let mut state = empty_state();
+        state.draft.model = "none".to_string();
+        state.draft.remote = Some(new_connect_remote("sentence-transformers/all-MiniLM-L6-v2"));
+
+        let check = validate_embedding(&state);
+
+        assert_eq!(check.severity, Sev::Block);
+        assert!(check.message.unwrap().contains("transformer"));
+    }
+
+    #[test]
+    fn embedding_blocks_known_server_model_dimension_mismatch() {
+        let mut state = empty_state();
+        let mut remote = new_connect_remote(&state.draft.model);
+        remote.model = "mxbai-embed-large".to_string();
+        state.draft.remote = Some(remote);
+
+        let check = validate_embedding(&state);
+
+        assert_eq!(check.severity, Sev::Block);
+        let message = check.message.unwrap();
+        assert!(message.contains("1024d"));
+        assert!(message.contains("384d"));
+    }
+
+    #[test]
+    fn embedding_warns_when_dimension_match_uses_different_model_family() {
+        let mut state = empty_state();
+        state.draft.model = "jinaai/jina-embeddings-v2-base-code".to_string();
+        state.draft.remote = Some(new_connect_remote(&state.draft.model));
+
+        assert_eq!(validate_embedding(&state).severity, Sev::Ok);
+
+        state.draft.remote.as_mut().unwrap().model = "nomic-embed-text".to_string();
+        let check = validate_embedding(&state);
+
+        assert_eq!(check.severity, Sev::Warn);
+        assert!(check.message.unwrap().contains("quality may vary"));
+    }
+
+    #[test]
+    fn embedding_model_change_refreshes_default_server_model() {
+        let mut state = empty_state();
+        state.draft.remote = Some(new_connect_remote(&state.draft.model));
+        let original_server_model = state.draft.remote.as_ref().unwrap().model.clone();
+        state.step = Some(init_step(StepId::Embedding, &state));
+        let target_cursor = model_rows()
+            .iter()
+            .position(|(id, _)| default_remote_model_for(id) != original_server_model)
+            .expect("registry should contain a model with a different remote default");
+        if let Some(StepState::Embedding { model_cursor, .. }) = &mut state.step {
+            *model_cursor = target_cursor;
+        }
+
+        step_handle_key(StepId::Embedding, key(KeyCode::Char(' ')), &mut state);
+
+        let remote = state.draft.remote.as_ref().unwrap();
+        assert_ne!(remote.model, original_server_model);
+        assert_eq!(remote.model, default_remote_model_for(&state.draft.model));
+    }
+
+    #[test]
+    fn embedding_model_change_preserves_custom_server_model() {
+        let mut state = empty_state();
+        state.draft.remote = Some(new_connect_remote(&state.draft.model));
+        state.draft.remote.as_mut().unwrap().model = "custom-ollama-model".to_string();
+        state.step = Some(init_step(StepId::Embedding, &state));
+
+        step_handle_key(StepId::Embedding, key(KeyCode::Down), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Char(' ')), &mut state);
+
+        assert_eq!(state.draft.remote.as_ref().unwrap().model, "custom-ollama-model");
+    }
+
+    #[test]
+    fn embedding_mode_reselect_preserves_remote_settings() {
+        let mut state = empty_state();
+        state.draft.remote = Some(RemoteDraft {
+            model: "custom-model".to_string(),
+            mode: RemoteMode::Connect("http://remote:11434".to_string()),
+            gpu: None,
+            num_ctx: Some(4096),
+            batch_size: 17,
+            auth_env: Some("OLLAMA_TOKEN".to_string()),
+        });
+        state.step = Some(init_step(StepId::Embedding, &state));
+        let probe_id = state.probes.current(StepId::Embedding);
+        assert!(state.probes.apply(ProbeMsg {
+            probe_id,
+            kind: ProbeKind::ConnectTest,
+            result: CheckResult::warn("connect failed"),
+        }));
+
+        step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Char(' ')), &mut state);
+
+        let remote = state.draft.remote.as_ref().unwrap();
+        assert_eq!(remote.model, "custom-model");
+        assert!(matches!(
+            &remote.mode,
+            RemoteMode::Connect(endpoint) if endpoint == "http://remote:11434"
+        ));
+        assert_eq!(remote.num_ctx, Some(4096));
+        assert_eq!(remote.batch_size, 17);
+        assert_eq!(remote.auth_env.as_deref(), Some("OLLAMA_TOKEN"));
+        assert!(matches!(state.probes.status(StepId::Embedding), ProbeStatus::Done {
+            kind: ProbeKind::ConnectTest,
+            ..
+        }));
+    }
+
+    #[test]
+    fn embedding_connect_endpoint_must_be_nonempty_and_secret_free() {
+        let mut state = empty_state();
+        state.draft.remote = Some(new_connect_remote(&state.draft.model));
+        if let Some(RemoteDraft { mode: RemoteMode::Connect(endpoint), .. }) =
+            state.draft.remote.as_mut()
+        {
+            endpoint.clear();
+        }
+        let empty = validate_embedding(&state);
+        assert_eq!(empty.severity, Sev::Block);
+        assert!(empty.message.unwrap().contains("endpoint"));
+
+        if let Some(RemoteDraft { mode: RemoteMode::Connect(endpoint), .. }) =
+            state.draft.remote.as_mut()
+        {
+            *endpoint = "http://user:token@localhost:11434".to_string();
+        }
+        let secret = validate_embedding(&state);
+        assert_eq!(secret.severity, Sev::Block);
+        assert!(secret.message.unwrap().contains("credentials"));
+    }
+
+    #[test]
+    fn embedding_connect_auth_env_must_exist_when_named() {
+        let mut state = empty_state();
+        let mut remote = new_connect_remote(&state.draft.model);
+        remote.auth_env =
+            Some(format!("__RAG_RAT_WIZARD_MISSING_AUTH_ENV_{}__", std::process::id()));
+        state.draft.remote = Some(remote);
+
+        let check = validate_embedding(&state);
+
+        assert_eq!(check.severity, Sev::Block);
+        assert!(check.message.unwrap().contains("auth env"));
+    }
+
+    #[test]
+    fn embedding_ephemeral_auth_env_must_exist_when_named() {
+        let mut state = empty_state();
+        let mut remote = new_ephemeral_remote(&state.draft.model);
+        remote.auth_env =
+            Some(format!("__RAG_RAT_WIZARD_MISSING_EPHEMERAL_AUTH_ENV_{}__", std::process::id()));
+        state.draft.remote = Some(remote);
+
+        let check = validate_embedding(&state);
+
+        assert_eq!(check.severity, Sev::Block);
+        assert!(check.message.unwrap().contains("auth env"));
+    }
+
+    #[test]
+    fn embedding_custom_cookbook_is_not_rendered_as_modal_selected() {
+        let mut state = empty_state();
+        let mut remote = new_ephemeral_remote(&state.draft.model);
+        remote.mode = RemoteMode::Ephemeral("./recipes/custom.mts --provider test".to_string());
+        state.draft.remote = Some(remote);
+        state.step = Some(init_step(StepId::Embedding, &state));
+
+        assert_eq!(selected_cookbook_idx(&state), Some(2));
+        let cells = render_embedding_cells(&state, 100, 24);
+        let screen = screen_text(&cells);
+
+        assert!(!screen.contains("[*] Modal"));
+        assert!(screen.contains("[*] Custom:"), "{screen}");
+    }
+
+    #[test]
+    fn embedding_custom_catalog_cookbook_selection_writes_command() {
+        let mut state = state_with_catalog(
+            r#"
+            [init.cookbooks.acme]
+            label = "Acme GPU"
+            command = "./recipes/acme.mjs --pool small"
+            gpus = ["acme-small", "acme-large"]
+            "#,
+        );
+        state.draft.remote = Some(new_ephemeral_remote(&state.draft.model));
+        state.step = Some(init_step(StepId::Embedding, &state));
+
+        while embed_focus(&state) != Some(EmbedFocus::Cookbook) {
+            step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        }
+        step_handle_key(StepId::Embedding, key(KeyCode::End), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Char(' ')), &mut state);
+
+        assert!(matches!(
+            state.draft.remote.as_ref().map(|remote| &remote.mode),
+            Some(RemoteMode::Ephemeral(command)) if command == "./recipes/acme.mjs --pool small"
+        ));
+        let cells = render_embedding_cells(&state, 100, 24);
+        let screen = screen_text(&cells);
+        assert!(screen.contains("Acme GPU"), "{screen}");
+    }
+
+    #[test]
+    fn embedding_custom_catalog_gpu_list_drives_picker() {
+        let mut state = state_with_catalog(
+            r#"
+            [init.cookbooks.modal]
+            gpus = ["tiny", "huge"]
+            "#,
+        );
+        state.draft.remote = Some(new_ephemeral_remote(&state.draft.model));
+        state.step = Some(init_step(StepId::Embedding, &state));
+
+        while embed_focus(&state) != Some(EmbedFocus::Gpu) {
+            step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        }
+        step_handle_key(StepId::Embedding, key(KeyCode::End), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Char(' ')), &mut state);
+
+        assert_eq!(
+            state.draft.remote.as_ref().and_then(|remote| remote.gpu.as_deref()),
+            Some("huge")
+        );
+        let cells = render_embedding_cells(&state, 100, 24);
+        let screen = screen_text(&cells);
+        assert!(screen.contains("[*] huge"), "{screen}");
+        assert!(!screen.contains("A10"), "{screen}");
+    }
+
+    #[test]
+    fn embedding_field_edit_clears_stale_probe_success() {
+        let mut state = empty_state();
+        state.draft.remote = Some(new_connect_remote(&state.draft.model));
+        state.step = Some(init_step(StepId::Embedding, &state));
+        let probe_id = state.probes.current(StepId::Embedding);
+        assert!(state.probes.apply(ProbeMsg {
+            probe_id,
+            kind: ProbeKind::ConnectTest,
+            result: CheckResult::ok(),
+        }));
+
+        step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Char('/')), &mut state);
+
+        assert!(matches!(state.probes.status(StepId::Embedding), ProbeStatus::Idle));
+    }
+
+    #[test]
+    fn embedding_batch_arrows_clear_stale_probe_success() {
+        let mut state = empty_state();
+        state.draft.remote = Some(new_connect_remote(&state.draft.model));
+        state.step = Some(init_step(StepId::Embedding, &state));
+        let probe_id = state.probes.current(StepId::Embedding);
+        assert!(state.probes.apply(ProbeMsg {
+            probe_id,
+            kind: ProbeKind::ConnectTest,
+            result: CheckResult::ok(),
+        }));
+        while embed_focus(&state) != Some(EmbedFocus::BatchSize) {
+            step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        }
+        let before = state.draft.remote.as_ref().unwrap().batch_size;
+
+        step_handle_key(StepId::Embedding, key(KeyCode::Up), &mut state);
+
+        assert_eq!(state.draft.remote.as_ref().unwrap().batch_size, before.saturating_sub(1));
+        assert!(matches!(state.probes.status(StepId::Embedding), ProbeStatus::Idle));
+    }
+
+    #[test]
+    fn embedding_provision_ignores_duplicate_running_probe() {
+        use std::sync::mpsc::sync_channel;
+
+        let mut state = empty_state();
+        state.draft.remote = Some(new_ephemeral_remote(&state.draft.model));
+        state.ui.provision_confirm = PROVISION_CONFIRM_WORD.to_string();
+        state.step = Some(init_step(StepId::Embedding, &state));
+        let (release_tx, release_rx) = sync_channel::<()>(0);
+        state.probes.spawn(StepId::Embedding, ProbeKind::EphemeralTest, move || {
+            let _ = release_rx.recv();
+            CheckResult::ok()
+        });
+        let before = state.probes.current(StepId::Embedding);
+
+        assert_eq!(
+            step_handle_key(StepId::Embedding, key(KeyCode::Char('p')), &mut state),
+            Outcome::Consumed
+        );
+
+        assert_eq!(state.probes.current(StepId::Embedding), before);
+        assert!(matches!(
+            state.probes.status(StepId::Embedding),
+            ProbeStatus::Running(ProbeKind::EphemeralTest)
+        ));
+        assert!(state.provision_log_lines.iter().any(|line| line.contains("already running")));
+        let _ = release_tx.send(());
+    }
+
+    #[test]
+    fn embedding_ephemeral_tab_order_visits_gpu_before_server_model() {
+        let mut state = empty_state();
+        state.step = Some(init_step(StepId::Embedding, &state));
+
+        step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        assert_eq!(embed_focus(&state), Some(EmbedFocus::Mode));
+
+        step_handle_key(StepId::Embedding, key(KeyCode::Down), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Down), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Char(' ')), &mut state);
+        assert!(matches!(
+            state.draft.remote.as_ref().map(|remote| &remote.mode),
+            Some(RemoteMode::Ephemeral(_))
+        ));
+
+        step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        assert_eq!(embed_focus(&state), Some(EmbedFocus::Cookbook));
+
+        step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        assert_eq!(embed_focus(&state), Some(EmbedFocus::Gpu));
+
+        step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        assert_eq!(embed_focus(&state), Some(EmbedFocus::ServerModel));
+    }
+
+    #[test]
+    fn embedding_server_model_list_hides_incompatible_dimensions() {
+        let mut state = empty_state();
+        state.draft.remote = Some(new_connect_remote(&state.draft.model));
+        state.step = Some(init_step(StepId::Embedding, &state));
+
+        let cells = render_embedding_cells(&state, 100, 18);
+        let screen = screen_text(&cells);
+
+        assert!(screen.contains("all-minilm"), "{screen}");
+        assert!(screen.contains("qllama/bge-small-en-v1.5:f16"), "{screen}");
+        assert!(!screen.contains("nomic-embed-text"), "{screen}");
+        assert!(!screen.contains("mxbai-embed-large"), "{screen}");
+
+        state.draft.model = "jinaai/jina-embeddings-v2-base-code".to_string();
+        state.draft.remote = Some(new_connect_remote(&state.draft.model));
+        state.step = Some(init_step(StepId::Embedding, &state));
+
+        let cells = render_embedding_cells(&state, 100, 18);
+        let screen = screen_text(&cells);
+
+        assert!(screen.contains("ordis/jina-embeddings-v2-base-code"), "{screen}");
+        assert!(screen.contains("nomic-embed-text"), "{screen}");
+        assert!(!screen.contains("all-minilm"), "{screen}");
+        assert!(!screen.contains("mxbai-embed-large"), "{screen}");
+
+        let hash_model =
+            EMBEDDING_MODELS.iter().find(|spec| spec.backend == Backend::Hash).unwrap().model_id;
+        assert!(
+            compatible_server_models(hash_model).is_empty(),
+            "unsupported local models must not expose remote server choices"
+        );
+    }
+
+    #[test]
+    fn embedding_gpu_list_scrolls_to_keep_cursor_visible() {
+        let mut state = empty_state();
+        state.draft.remote = Some(new_ephemeral_remote(&state.draft.model));
+        state.step = Some(init_step(StepId::Embedding, &state));
+
+        step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        assert_eq!(embed_focus(&state), Some(EmbedFocus::Gpu));
+        step_handle_key(StepId::Embedding, key(KeyCode::End), &mut state);
+
+        let cells = render_embedding_cells(&state, 100, 24);
+        let screen = screen_text(&cells);
+        let expected = format!("> [ ] {}", MODAL_GPUS.last().unwrap());
+
+        assert!(
+            screen.contains(&expected),
+            "selected GPU should stay visible when the list is taller than its box:\n{screen}"
+        );
+    }
+
+    #[test]
+    fn embedding_text_fields_accept_typing_and_backspace() {
+        let mut state = empty_state();
+        state.step = Some(init_step(StepId::Embedding, &state));
+        step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Down), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Char(' ')), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+
+        step_handle_key(StepId::Embedding, key(KeyCode::Char('/')), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Backspace), &mut state);
+
+        let remote = state.draft.remote.as_ref().unwrap();
+        assert!(
+            matches!(remote.mode, RemoteMode::Connect(ref endpoint) if endpoint == DEFAULT_QUERY_ENDPOINT)
+        );
+    }
+
+    #[test]
+    fn embedding_focus_navigation_covers_selectors_and_numeric_fields() {
+        let mut state = empty_state();
+        state.draft.remote = Some(new_ephemeral_remote(&state.draft.model));
+        state.step = Some(init_step(StepId::Embedding, &state));
+
+        for code in [KeyCode::Down, KeyCode::End, KeyCode::Home, KeyCode::Char(' ')] {
+            let _ = step_handle_key(StepId::Embedding, key(code), &mut state);
+        }
+
+        for expected in [
+            EmbedFocus::Mode,
+            EmbedFocus::Cookbook,
+            EmbedFocus::Gpu,
+            EmbedFocus::ServerModel,
+            EmbedFocus::BatchSize,
+            EmbedFocus::AuthEnv,
+            EmbedFocus::ProvisionConfirm,
+        ] {
+            step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+            assert_eq!(embed_focus(&state), Some(expected));
+            let _ = step_handle_key(StepId::Embedding, key(KeyCode::Down), &mut state);
+            let _ = step_handle_key(StepId::Embedding, key(KeyCode::End), &mut state);
+            let _ = step_handle_key(StepId::Embedding, key(KeyCode::Home), &mut state);
+        }
+
+        assert_eq!(
+            step_handle_key(StepId::Embedding, key(KeyCode::BackTab), &mut state),
+            Outcome::Consumed
+        );
+        assert_eq!(embed_focus(&state), Some(EmbedFocus::AuthEnv));
+
+        while embed_focus(&state) != Some(EmbedFocus::BatchSize) {
+            step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        }
+        step_handle_key(StepId::Embedding, key(KeyCode::Char('4')), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Backspace), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Char('+')), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Char('-')), &mut state);
+        assert!(state.draft.remote.as_ref().unwrap().batch_size >= 1);
+
+        while embed_focus(&state) != Some(EmbedFocus::ProvisionConfirm) {
+            step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        }
+        for c in PROVISION_CONFIRM_WORD.chars() {
+            step_handle_key(StepId::Embedding, key(KeyCode::Char(c)), &mut state);
+        }
+        assert!(provision_confirm_satisfied(&state.ui));
+
+        let remote = remote_config_for(state.draft.remote.as_ref().unwrap());
+        assert_eq!(remote.cookbook.as_deref(), Some("@rag-rat/cookbook modal"));
+    }
+
+    #[test]
+    fn embedding_model_help_covers_heavier_model_copy() {
+        let mut state = empty_state();
+        for needle in ["bge", "jina"] {
+            let model =
+                EMBEDDING_MODELS.iter().find(|s| s.display.contains(needle)).unwrap().model_id;
+            state.draft.model = model.to_string();
+            state.step = Some(init_step(StepId::Embedding, &state));
+
+            let cells = render_embedding_cells(&state, 100, 24);
+            let screen = screen_text(&cells);
+
+            assert!(screen.contains("Model help"));
+        }
+    }
+
+    #[test]
+    fn embedding_endpoint_field_has_one_content_row() {
+        let mut state = empty_state();
+        state.draft.remote = Some(new_connect_remote(&state.draft.model));
+        state.step = Some(init_step(StepId::Embedding, &state));
+
+        let cells = render_embedding_cells(&state, 100, 24);
+        let endpoint_y = cells
+            .iter()
+            .position(|row| row_text(row).contains("endpoint"))
+            .expect("endpoint field");
+        let after_endpoint = row_segment(&cells, endpoint_y + 3, 45, 55);
+
+        assert!(row_text(&cells[endpoint_y + 1]).contains(DEFAULT_QUERY_ENDPOINT));
+        assert!(
+            after_endpoint.trim().is_empty(),
+            "endpoint field should leave blank space after a single content row: \
+             {after_endpoint:?}"
+        );
+    }
+
+    #[test]
+    fn embedding_batch_and_auth_fields_have_one_content_row() {
+        let mut state = empty_state();
+        let mut remote = new_ephemeral_remote(&state.draft.model);
+        remote.auth_env = Some("RR_AUTH".to_string());
+        state.draft.remote = Some(remote);
+        state.step = Some(init_step(StepId::Embedding, &state));
+
+        let cells = render_embedding_cells(&state, 100, 24);
+        let batch_y =
+            cells.iter().position(|row| row_text(row).contains("batch")).expect("batch field");
+        let content = row_text(&cells[batch_y + 1]);
+        let bottom = row_segment(&cells, batch_y + 2, 45, 55);
+
+        assert!(content.contains("256"));
+        assert!(content.contains("RR_AUTH"));
+        assert!(bottom.contains('└'));
+        assert!(bottom.contains('┘'));
+        assert!(screen_text(&cells).contains("type: provision"));
+    }
+
+    #[test]
+    fn embedding_model_help_describes_selected_model_tradeoffs() {
+        let mut state = empty_state();
+        state.draft.model = NONE_MODEL.to_string();
+        state.step = Some(init_step(StepId::Embedding, &state));
+
+        let cells = render_embedding_cells(&state, 100, 24);
+        let screen = screen_text(&cells);
+
+        assert!(screen.contains("Model help"));
+        assert!(screen.contains("Not recommended for big codebases"));
+    }
+
+    #[test]
+    fn integration_combines_version_check_and_hooks() {
+        let mut state = empty_state();
+        state.step = Some(init_step(StepId::Integration, &state));
+        let initial_version_check = state.draft.version_check;
+
+        step_handle_key(StepId::Integration, key(KeyCode::Char(' ')), &mut state);
+        assert_eq!(state.draft.version_check, !initial_version_check);
+
+        step_handle_key(StepId::Integration, key(KeyCode::Down), &mut state);
+        step_handle_key(StepId::Integration, key(KeyCode::Char(' ')), &mut state);
+        assert!(state.draft.hooks.git);
+
+        step_handle_key(StepId::Integration, key(KeyCode::Char('c')), &mut state);
+        assert!(state.draft.hooks.claude);
+    }
+
+    #[test]
+    fn integration_blocks_unresolved_foreign_hook_conflicts() {
+        let dir = tempfile::tempdir().unwrap();
+        let status = std::process::Command::new("git")
+            .arg("init")
+            .arg(dir.path())
+            .status()
+            .expect("git init should run");
+        assert!(status.success());
+        let gp = git_paths(dir.path()).unwrap();
+        std::fs::create_dir_all(&gp.hooks_dir).unwrap();
+        let hook = MANAGED_HOOKS[0];
+        std::fs::write(gp.hooks_dir.join(hook), "#!/bin/sh\necho custom\n").unwrap();
+        let scan = scan_repo(dir.path()).unwrap();
+        let mut draft = WizardDraft::from_scan(&scan, ".".to_string(), dir.path().to_path_buf());
+        draft.hooks.git = true;
+        let mut state = WizardState::new(draft, scan);
+
+        let unresolved = validate_hooks(&state);
+        state.hook_conflicts.insert(hook, hooks::HookConflict::Skip);
+        let resolved = validate_hooks(&state);
+
+        assert_eq!(unresolved.severity, Sev::Block);
+        assert!(unresolved.message.unwrap().contains(hook));
+        assert_eq!(resolved.severity, Sev::Ok);
+    }
+
+    #[test]
+    fn integration_blocks_git_hooks_outside_worktrees() {
+        let dir = tempfile::tempdir().unwrap();
+        let scan = scan_repo(dir.path()).unwrap();
+        let mut draft = WizardDraft::from_scan(&scan, ".".to_string(), dir.path().to_path_buf());
+        draft.hooks.git = true;
+        let state = WizardState::new(draft, scan);
+
+        let check = validate_hooks(&state);
+
+        assert_eq!(check.severity, Sev::Block);
+        assert!(check.message.unwrap().contains("git worktree"));
+    }
+}

--- a/crates/rag-rat-cli/src/init/wizard/theme.rs
+++ b/crates/rag-rat-cli/src/init/wizard/theme.rs
@@ -1,0 +1,93 @@
+//! Darcula-style palette and TUI style helpers for the init wizard.
+
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::Block;
+
+const BACKGROUND: Color = Color::Rgb(40, 42, 54);
+const TEXT: Color = Color::Rgb(187, 187, 187);
+const TEXT_STRONG: Color = Color::Rgb(214, 214, 214);
+const MUTED: Color = Color::Rgb(128, 128, 128);
+const BORDER: Color = Color::Rgb(158, 159, 166);
+const ACCENT: Color = Color::Rgb(104, 151, 187);
+const FOCUSED_BORDER: Color = Color::Rgb(255, 184, 108);
+const SELECTION: Color = Color::Rgb(68, 71, 90);
+const WARNING: Color = Color::Rgb(255, 198, 109);
+const ERROR: Color = Color::Rgb(204, 102, 102);
+const SUCCESS: Color = Color::Rgb(106, 135, 89);
+const FOOTER_BG: Color = Color::Rgb(78, 82, 84);
+
+pub(crate) fn base() -> Style {
+    Style::default().fg(TEXT).bg(BACKGROUND)
+}
+
+pub(crate) fn popup() -> Style {
+    Style::default().fg(TEXT).bg(BACKGROUND)
+}
+
+pub(crate) fn title() -> Style {
+    Style::default().fg(TEXT_STRONG).add_modifier(Modifier::BOLD)
+}
+
+pub(crate) fn heading() -> Style {
+    title().add_modifier(Modifier::UNDERLINED)
+}
+
+pub(crate) fn muted() -> Style {
+    Style::default().fg(MUTED)
+}
+
+pub(crate) fn accent() -> Style {
+    Style::default().fg(ACCENT)
+}
+
+pub(crate) fn focus() -> Style {
+    accent().add_modifier(Modifier::BOLD)
+}
+
+pub(crate) fn selected() -> Style {
+    Style::default().fg(TEXT_STRONG).bg(SELECTION).add_modifier(Modifier::BOLD)
+}
+
+pub(crate) fn border() -> Style {
+    Style::default().fg(BORDER).bg(BACKGROUND)
+}
+
+pub(crate) fn focused_border() -> Style {
+    Style::default().fg(FOCUSED_BORDER).bg(BACKGROUND)
+}
+
+pub(crate) fn popup_border() -> Style {
+    Style::default().fg(FOCUSED_BORDER).bg(BACKGROUND)
+}
+
+pub(crate) fn warning() -> Style {
+    Style::default().fg(WARNING)
+}
+
+pub(crate) fn error() -> Style {
+    Style::default().fg(ERROR)
+}
+
+pub(crate) fn success() -> Style {
+    Style::default().fg(SUCCESS)
+}
+
+pub(crate) fn footer() -> Style {
+    Style::default().fg(TEXT_STRONG).bg(FOOTER_BG)
+}
+
+pub(crate) fn footer_warning() -> Style {
+    Style::default().fg(WARNING).bg(FOOTER_BG)
+}
+
+pub(crate) fn block(title: impl Into<String>) -> Block<'static> {
+    Block::bordered().title(title.into()).style(base()).border_style(border())
+}
+
+pub(crate) fn focused_block(title: impl Into<String>, focused: bool) -> Block<'static> {
+    block(title).border_style(if focused { focused_border() } else { border() })
+}
+
+pub(crate) fn popup_block(title: impl Into<String>) -> Block<'static> {
+    Block::bordered().title(title.into()).style(popup()).border_style(popup_border())
+}

--- a/crates/rag-rat-cli/tests/init_yes_writes_valid_config.rs
+++ b/crates/rag-rat-cli/tests/init_yes_writes_valid_config.rs
@@ -1,0 +1,84 @@
+//! `rag-rat init --yes` regression guard (Task 19): wiring the ratatui wizard into the INTERACTIVE
+//! branch of `init::run` must leave the non-interactive (`--yes`) path byte-for-byte unchanged. It
+//! still renders from `default_plan` + `render_config`, writes the file, and produces a
+//! `rag-rat.toml` that `Config::load` accepts.
+//!
+//! This drives the real `init -y` write path (NOT `--dry-run`), so the config is genuinely written
+//! to disk and then re-parsed. The model install/reconcile runs downstream of the write; it is
+//! sandboxed to a per-test cache (an offline run falls back to the dependency-free `hash` embedder,
+//! an online run resolves from cache) so the test never leaks into the developer's model cache and
+//! never depends on a specific model being present.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use rag_rat_core::Config;
+
+static TEMP_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn unique_temp_root() -> PathBuf {
+    let id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!("rag-rat-init-yes-{}-{id}", std::process::id()))
+}
+
+/// Initialize a quiet git repo at `dir` (identity configured so any commit would succeed).
+fn git_init(dir: &std::path::Path) {
+    for args in
+        [&["init", "-q"][..], &["config", "user.email", "t@e.com"], &["config", "user.name", "t"]]
+    {
+        let out = Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
+        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+    }
+}
+
+#[test]
+fn init_yes_writes_a_config_that_config_load_accepts() {
+    let root = unique_temp_root();
+    let cache = root.join("model-cache");
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::create_dir_all(&cache).unwrap();
+    // A trivial Rust source tree so the scan binds `rust = ["src"]` (a non-empty plan; an empty
+    // plan would make `init` bail by design — that path is covered in `init_dir_selection.rs`).
+    std::fs::write(root.join("src/lib.rs"), "pub fn alpha() -> u32 {\n    1\n}\n").unwrap();
+    // `init --yes` auto-accepts the git-maintenance-hook install (its pre-wizard behavior, which
+    // this test pins as unchanged), and that install needs a real git repo — so make one. The
+    // hooks themselves never fire here: `RAG_RAT_HOOK_DISABLE=1` short-circuits them.
+    git_init(&root);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+        .args(["init", "--yes"])
+        .current_dir(&root)
+        // Keep the run hermetic: no git hooks firing, no background watcher, and the model
+        // cache/HOME sandboxed to this test's temp dir so a model install can't touch the real
+        // cache (offline → hash fallback; online → downloads into `cache`).
+        .env("RAG_RAT_HOOK_DISABLE", "1")
+        .env("RAG_RAT_NO_WATCH", "1")
+        .env("RAG_RAT_MODEL_CACHE", &cache)
+        .env("HOME", &root)
+        .env("XDG_CACHE_HOME", &cache)
+        .output()
+        .expect("run rag-rat init --yes");
+
+    assert!(
+        output.status.success(),
+        "init --yes must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The non-interactive path WROTE the config (it is not `--dry-run`).
+    let config_path = root.join("rag-rat.toml");
+    assert!(config_path.exists(), "init --yes must write rag-rat.toml");
+
+    // The written config round-trips through the real loader, and reflects the `default_plan`
+    // rendering the `--yes` path has always used (active `rust = ["src"]` binding + the documented
+    // oracle/version surface).
+    let config = Config::load(&config_path).expect("Config::load must accept the written config");
+    assert!(
+        config.targets.iter().any(|t| t.language == rag_rat_core::language::Language::Rust),
+        "the rust source tree must bind a rust target, got: {:?}",
+        config.targets
+    );
+
+    std::fs::remove_dir_all(&root).ok();
+}

--- a/crates/rag-rat-core/src/index/ai/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/mod.rs
@@ -32,6 +32,8 @@ pub(crate) use providers::{
 pub use providers::{
     CookbookInput, CookbookProvisioner, Embedder, FASTEMBED_MISSING_FEATURE_MESSAGE, HashEmbedder,
     MODEL2VEC_HF_REPO, MODEL2VEC_MISSING_FEATURE_MESSAGE, OllamaEmbedder, ProvisionedBox,
+    abort_active_provisioning, install_provision_log_sink, verify_ephemeral_remote,
+    verify_ephemeral_remote_cancellable,
 };
 pub(crate) use reconcile::*;
 pub(crate) use reencode::*;

--- a/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
@@ -33,12 +33,17 @@ use std::io::{BufRead, BufReader};
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicI32, Ordering};
-use std::sync::{OnceLock, mpsc};
+#[cfg(unix)]
+use std::sync::atomic::AtomicI32;
+#[cfg(windows)]
+use std::sync::atomic::AtomicU32;
+use std::sync::atomic::Ordering;
+use std::sync::{Mutex, OnceLock, mpsc};
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
+use super::Embedder;
 use super::ollama::{OllamaEmbedder, ProvisionedEmbedderParams};
 use crate::config::RemoteEmbeddingConfig;
 use crate::embedding_models::EmbeddingModelSpec;
@@ -67,6 +72,11 @@ const MAX_CAPTURED_LINES: usize = 200;
 /// 1).
 #[cfg(unix)]
 static ACTIVE_PGID: AtomicI32 = AtomicI32::new(0);
+
+/// The active cookbook child on Windows. Windows has no Unix-style process group, so quit-time
+/// abort uses `taskkill /T` to terminate the child and descendants.
+#[cfg(windows)]
+static ACTIVE_CHILD_PID: AtomicU32 = AtomicU32::new(0);
 
 /// One-time install guard for the process-wide SIGINT/SIGTERM handler.
 #[cfg(unix)]
@@ -97,6 +107,25 @@ const SIGNAL_TEARDOWN_POLL_NSEC: i64 = 50 * 1_000_000;
 static mut SAVED_SIGINT: Option<libc::sigaction> = None;
 #[cfg(unix)]
 static mut SAVED_SIGTERM: Option<libc::sigaction> = None;
+
+static PROVISION_LOG_SINK: OnceLock<Mutex<Option<mpsc::Sender<String>>>> = OnceLock::new();
+
+pub struct ProvisionLogSinkGuard {
+    previous: Option<mpsc::Sender<String>>,
+}
+
+impl Drop for ProvisionLogSinkGuard {
+    fn drop(&mut self) {
+        let sink = PROVISION_LOG_SINK.get_or_init(|| Mutex::new(None));
+        *sink.lock().expect("provision log sink poisoned") = self.previous.take();
+    }
+}
+
+pub fn install_provision_log_sink(tx: mpsc::Sender<String>) -> ProvisionLogSinkGuard {
+    let sink = PROVISION_LOG_SINK.get_or_init(|| Mutex::new(None));
+    let previous = sink.lock().expect("provision log sink poisoned").replace(tx);
+    ProvisionLogSinkGuard { previous }
+}
 
 /// The JSON written to `RAG_RAT_COOKBOOK_INPUT` for the cookbook subprocess.
 #[derive(Debug, Clone, Serialize)]
@@ -157,19 +186,33 @@ enum CookbookEvent {
 /// handshake the caller consumes); `error`'s message is ALSO retained by the caller for the
 /// provision-failed context.
 fn handle_event(event: &CookbookEvent) {
-    match event {
+    let line = match event {
         CookbookEvent::Status { phase, provider, detail } => {
             let provider = if provider.is_empty() { String::new() } else { format!("{provider} ") };
             let detail = if detail.is_empty() { String::new() } else { format!(": {detail}") };
-            eprintln!("[cookbook] {provider}{phase}{detail}");
+            format!("[cookbook] {provider}{phase}{detail}")
         },
         CookbookEvent::Log { level, message } => {
             let level = if level.is_empty() { "info" } else { level.as_str() };
-            eprintln!("[cookbook] {level}: {message}");
+            format!("[cookbook] {level}: {message}")
         },
-        CookbookEvent::Error { message } => eprintln!("[cookbook] error: {message}"),
+        CookbookEvent::Error { message } => format!("[cookbook] error: {message}"),
         // `Ready` is the handshake, consumed by the caller — never routed here.
-        CookbookEvent::Ready { .. } => {},
+        CookbookEvent::Ready { .. } => return,
+    };
+    emit_provision_log(line);
+}
+
+fn emit_provision_log(line: String) {
+    let tx = PROVISION_LOG_SINK
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+        .expect("provision log sink poisoned")
+        .clone();
+    if let Some(tx) = tx {
+        let _ = tx.send(line);
+    } else {
+        eprintln!("{line}");
     }
 }
 
@@ -215,15 +258,39 @@ impl CookbookProvisioner {
         Self::provision_with_command(cookbook_command(cookbook), cookbook, input, PROVISION_TIMEOUT)
     }
 
+    fn provision_cancellable(
+        cookbook: &str,
+        input: &CookbookInput,
+        cancel: impl Fn() -> bool,
+    ) -> anyhow::Result<ProvisionedBox> {
+        Self::provision_with_command_cancellable(
+            cookbook_command(cookbook),
+            cookbook,
+            input,
+            PROVISION_TIMEOUT,
+            cancel,
+        )
+    }
+
     /// The provisioning core, given an already-built `Command` (the public `provision` builds it
     /// via `cookbook_command`) and the handshake `timeout`. Split out so tests can drive the
     /// lifecycle with a portable stub recipe + a short timeout, without needing `node`/`npx` on
     /// the test machine; `label` names the cookbook in errors.
     fn provision_with_command(
+        command: Command,
+        label: &str,
+        input: &CookbookInput,
+        timeout: Duration,
+    ) -> anyhow::Result<ProvisionedBox> {
+        Self::provision_with_command_cancellable(command, label, input, timeout, || false)
+    }
+
+    fn provision_with_command_cancellable(
         mut command: Command,
         label: &str,
         input: &CookbookInput,
         timeout: Duration,
+        cancel: impl Fn() -> bool,
     ) -> anyhow::Result<ProvisionedBox> {
         let input_json = serde_json::to_string(input)
             .map_err(|e| anyhow::anyhow!("failed to serialize cookbook input: {e}"))?;
@@ -244,6 +311,10 @@ impl CookbookProvisioner {
         #[cfg(unix)]
         install_signal_handler();
 
+        if cancel() {
+            anyhow::bail!("cookbook `{label}` provisioning cancelled before start");
+        }
+
         let mut child = command.spawn().map_err(|e| {
             anyhow::anyhow!("failed to spawn cookbook `{label}`: {e} (is `node`/`npx` on PATH?)")
         })?;
@@ -254,6 +325,26 @@ impl CookbookProvisioner {
         let pgid = child.id() as i32;
         #[cfg(unix)]
         ACTIVE_PGID.store(pgid, Ordering::SeqCst);
+        #[cfg(windows)]
+        ACTIVE_CHILD_PID.store(child.id(), Ordering::SeqCst);
+
+        if cancel() {
+            #[cfg(unix)]
+            teardown_group(pgid, &mut child);
+            #[cfg(windows)]
+            {
+                let pid = child.id();
+                taskkill_tree(pid);
+                clear_active_child_pid(pid);
+                let _ = child.wait();
+            }
+            #[cfg(all(not(unix), not(windows)))]
+            {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+            anyhow::bail!("cookbook `{label}` provisioning cancelled before handshake");
+        }
 
         let stdout = child.stdout.take().expect("piped stdout");
         let stderr = child.stderr.take().expect("piped stderr");
@@ -270,7 +361,7 @@ impl CookbookProvisioner {
             // is drained, not buffered) — `BufRead::lines()` would allocate the whole
             // line first.
             while let Ok(Some(line)) = read_capped_line(&mut reader) {
-                eprintln!("cookbook: {line}");
+                emit_provision_log(format!("cookbook: {line}"));
                 captured.push_back(line);
                 if captured.len() > MAX_CAPTURED_LINES {
                     captured.pop_front();
@@ -308,7 +399,7 @@ impl CookbookProvisioner {
                     },
                     // Not a typed event (e.g. npx install noise) → forward raw. `line` is already
                     // length-capped by `read_capped_line`, so no further truncation is needed.
-                    Err(_) => eprintln!("cookbook: {line}"),
+                    Err(_) => emit_provision_log(format!("cookbook: {line}")),
                 }
             }
         });
@@ -328,6 +419,8 @@ impl CookbookProvisioner {
                     // (exited).
                     #[cfg(unix)]
                     reap_group(pgid);
+                    #[cfg(windows)]
+                    clear_active_child_pid(child.id());
                     return Err(provision_failed(
                         label,
                         &mut child,
@@ -341,6 +434,8 @@ impl CookbookProvisioner {
                         // Child exited before a `ready` event.
                         #[cfg(unix)]
                         reap_group(pgid);
+                        #[cfg(windows)]
+                        clear_active_child_pid(child.id());
                         return Err(provision_failed(
                             label,
                             &mut child,
@@ -362,6 +457,8 @@ impl CookbookProvisioner {
                             let _ = child.kill();
                             let _ = child.wait();
                         }
+                        #[cfg(windows)]
+                        clear_active_child_pid(child.id());
                         let _ = stdout_handle.join();
                         let _ = stderr_handle.join();
                         anyhow::bail!(
@@ -416,12 +513,20 @@ pub(crate) fn provision_and_build(
     remote: &RemoteEmbeddingConfig,
     spec: &EmbeddingModelSpec,
 ) -> anyhow::Result<(OllamaEmbedder, ProvisionedBox)> {
+    provision_and_build_cancellable(remote, spec, || false)
+}
+
+fn provision_and_build_cancellable(
+    remote: &RemoteEmbeddingConfig,
+    spec: &EmbeddingModelSpec,
+    cancel: impl Fn() -> bool,
+) -> anyhow::Result<(OllamaEmbedder, ProvisionedBox)> {
     let cookbook = remote
         .cookbook
         .as_deref()
         .ok_or_else(|| anyhow::anyhow!("ephemeral remote config has no cookbook"))?;
     let input = cookbook_input_for(remote);
-    let provisioned = CookbookProvisioner::provision(cookbook, &input)?;
+    let provisioned = CookbookProvisioner::provision_cancellable(cookbook, &input, cancel)?;
     let embedder = OllamaEmbedder::from_provisioned(ProvisionedEmbedderParams {
         endpoint: &provisioned.endpoint,
         auth_token: provisioned.auth_token.as_deref(),
@@ -433,6 +538,39 @@ pub(crate) fn provision_and_build(
         num_ctx: remote.num_ctx,
     });
     Ok((embedder, provisioned))
+}
+
+/// Init-wizard ephemeral spin-up TEST: provision a cookbook box for `remote` + `spec`, embed a
+/// single `"ping"` to confirm the full provision→handshake→embed chain works, then tear the box
+/// down (the [`ProvisionedBox`] guard's `Drop` at end of scope). Returns `Ok(())` on a clean
+/// round-trip, an error otherwise. Bounded by the same internal [`PROVISION_TIMEOUT`] (300s) that
+/// gates `provision`, so the wizard never has to thread a deadline.
+///
+/// This is the `pub` seam the CLI's Remote step probes against: `provision_and_build` is
+/// `pub(crate)`, so a connection-less verify that the CLI can call lives HERE, not in the wizard.
+/// The box is ALWAYS torn down before this returns (Drop is the teardown), so a passing test leaks
+/// no billing instance. The caller still confirms intent via the type-`provision` gate; this fn
+/// trusts that gate and just runs the round-trip.
+pub fn verify_ephemeral_remote(
+    remote: &RemoteEmbeddingConfig,
+    spec: &EmbeddingModelSpec,
+) -> anyhow::Result<()> {
+    verify_ephemeral_remote_cancellable(remote, spec, || false)
+}
+
+pub fn verify_ephemeral_remote_cancellable(
+    remote: &RemoteEmbeddingConfig,
+    spec: &EmbeddingModelSpec,
+    cancel: impl Fn() -> bool,
+) -> anyhow::Result<()> {
+    // `_box` is bound (not `_`) so it lives to end of scope — `OllamaEmbedder` holds only the
+    // endpoint URL, not the process, so dropping the box early would tear down the server before
+    // the ping. Drop at function exit is the teardown (SIGTERM → grace → SIGKILL on the group).
+    let (embedder, _box) = provision_and_build_cancellable(remote, spec, cancel)?;
+    embedder.embed_batch(&["ping".to_string()]).map_err(|err| {
+        anyhow::anyhow!("ephemeral spin-up test embed failed for `{}`: {err}", spec.model_id)
+    })?;
+    Ok(())
 }
 
 /// The published cookbook npm scope+name. The single-token slash form
@@ -630,6 +768,8 @@ impl Drop for ProvisionedBox {
     fn drop(&mut self) {
         let _ = self.child.kill();
         let _ = self.child.wait();
+        #[cfg(windows)]
+        clear_active_child_pid(self.child.id());
     }
 }
 
@@ -765,6 +905,73 @@ fn reap_group(pgid: i32) {
     ACTIVE_PGID.store(0, Ordering::SeqCst);
 }
 
+/// Abort the currently-active provisioning process group from outside the cookbook lifecycle —
+/// used by the init wizard's quit path to tear down an in-flight ephemeral probe (Task 14b).
+///
+/// On unix: if `ACTIVE_PGID` is non-zero (a box is live), runs the same bounded
+/// SIGTERM → grace → SIGKILL teardown as [`ProvisionedBox::drop`] does via `teardown_group`.
+/// On non-unix: no-op (no process group machinery exists on non-unix).
+///
+/// INVARIANT (#330-6 leak fix — same as `teardown_group`/`reap_group`): `ACTIVE_PGID` is LOADED,
+/// not swapped, at the START and stays VISIBLE until the group is FULLY reclaimed; it is cleared
+/// ONLY at the END. Clearing it up front re-opened the money-leak race: a second SIGINT/SIGTERM
+/// arriving during the ≤10s grace would have `handle_terminating_signal` read `ACTIVE_PGID == 0`,
+/// do NOTHING, and `_exit` — interrupting THIS in-progress abort BEFORE its SIGKILL backstop → a
+/// leaked live box. With the pgid kept visible, a mid-teardown signal's `swap(0)` takes OWNERSHIP
+/// and runs its OWN complete SIGTERM→grace→SIGKILL, so the group is reaped either way (the `swap`
+/// also prevents a double-teardown — whoever clears it owns it; our `store(0)` at the end is an
+/// idempotent re-clear if the handler already took it).
+///
+/// Note: `teardown_group` requires a `&mut Child` to reap the leader (avoid a zombie). We don't
+/// hold the `Child` here (the worker owns it), so we run the same bounded teardown inline against
+/// the GROUP — SIGTERM, poll `group_alive`, SIGKILL backstop — and clear `ACTIVE_PGID` at the END.
+/// The worker's detached thread (or the OS at exit) reaps the real leader.
+pub fn abort_active_provisioning() {
+    #[cfg(unix)]
+    {
+        // LOAD, not swap: keep the pgid VISIBLE to the signal handler until teardown finishes, so a
+        // mid-grace signal can take ownership and SIGKILL-backstop rather than reading a cleared 0.
+        let pgid = ACTIVE_PGID.load(Ordering::SeqCst);
+        if pgid > 1 {
+            killpg(pgid, libc::SIGTERM);
+            let deadline = std::time::Instant::now() + TEARDOWN_GRACE;
+            loop {
+                if !group_alive(pgid) {
+                    // The group is gone (graceful teardown finished) → release the pgid at the END.
+                    ACTIVE_PGID.store(0, Ordering::SeqCst);
+                    return;
+                }
+                if std::time::Instant::now() >= deadline {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+            // Still alive past the grace → force the whole group, THEN clear the pgid (only now is
+            // the group actually gone). Clearing at the END is the load-bearing half of the fix.
+            killpg(pgid, libc::SIGKILL);
+            ACTIVE_PGID.store(0, Ordering::SeqCst);
+        }
+    }
+    #[cfg(windows)]
+    {
+        let pid = ACTIVE_CHILD_PID.swap(0, Ordering::SeqCst);
+        if pid != 0 {
+            taskkill_tree(pid);
+        }
+    }
+}
+
+#[cfg(windows)]
+fn clear_active_child_pid(pid: u32) {
+    let _ = ACTIVE_CHILD_PID.compare_exchange(pid, 0, Ordering::SeqCst, Ordering::SeqCst);
+}
+
+#[cfg(windows)]
+fn taskkill_tree(pid: u32) {
+    let pid = pid.to_string();
+    let _ = Command::new("taskkill").args(["/PID", &pid, "/T", "/F"]).status();
+}
+
 /// `killpg(pgid, sig)` — signal the whole process group. SAFETY: `killpg(2)` with a valid signal; a
 /// vanished group just returns an ignored error and touches no memory.
 #[cfg(unix)]
@@ -878,7 +1085,7 @@ extern "C" fn handle_terminating_signal(signo: libc::c_int) {
 mod tests {
     use std::os::unix::process::ExitStatusExt;
     use std::path::PathBuf;
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
     use super::*;
 
@@ -907,6 +1114,50 @@ mod tests {
             provision_timeout_s: 280,
             gpu: None,
         }
+    }
+
+    #[test]
+    fn provision_cancellation_returns_before_spawning_command() {
+        let err = CookbookProvisioner::provision_with_command_cancellable(
+            Command::new("definitely-missing-rag-rat-cookbook-test-command"),
+            "cancelled",
+            &input(),
+            Duration::from_millis(10),
+            || true,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("cancelled before start"), "{err:#}");
+    }
+
+    #[test]
+    fn provision_cancellation_after_spawn_tears_down_before_handshake() {
+        let calls = AtomicUsize::new(0);
+        let err = CookbookProvisioner::provision_with_command_cancellable(
+            stub_command("stub_hang.sh", &[]),
+            "cancelled",
+            &input(),
+            Duration::from_millis(50),
+            || calls.fetch_add(1, Ordering::SeqCst) > 0,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("cancelled before handshake"), "{err:#}");
+    }
+
+    #[test]
+    fn verify_ephemeral_remote_cancellable_stops_before_recipe_spawn() {
+        let remote = RemoteEmbeddingConfig {
+            model: "all-minilm".to_string(),
+            cookbook: Some("definitely-missing-rag-rat-cookbook-test-command".to_string()),
+            query_endpoint: Some(crate::config::DEFAULT_QUERY_ENDPOINT.to_string()),
+            ..RemoteEmbeddingConfig::default()
+        };
+        let spec = crate::embedding_models::spec("sentence-transformers/all-MiniLM-L6-v2").unwrap();
+
+        let err = verify_ephemeral_remote_cancellable(&remote, spec, || true).unwrap_err();
+
+        assert!(err.to_string().contains("cancelled before start"), "{err:#}");
     }
 
     fn tmp(name: &str) -> PathBuf {

--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -19,7 +19,12 @@ mod ollama;
 use rusqlite::Connection;
 
 pub(crate) use self::cookbook::provision_and_build;
-pub use self::cookbook::{CookbookInput, CookbookProvisioner, ProvisionedBox};
+// `verify_ephemeral_remote` is the `pub` init-wizard seam (the CLI's Remote step calls it);
+// the underlying `provision_and_build` stays `pub(crate)`.
+pub use self::cookbook::{
+    CookbookInput, CookbookProvisioner, ProvisionedBox, abort_active_provisioning,
+    install_provision_log_sink, verify_ephemeral_remote, verify_ephemeral_remote_cancellable,
+};
 #[cfg(feature = "fastembed")]
 pub use self::fastembed::FastEmbedEmbedder;
 pub use self::hash::HashEmbedder;

--- a/crates/rag-rat-core/src/index/ignore_rules.rs
+++ b/crates/rag-rat-core/src/index/ignore_rules.rs
@@ -58,6 +58,8 @@ use crate::index::git_history;
 const FLOOR_DIRS: &[&str] = &[
     ".git",
     ".rag-rat",
+    ".claude",
+    ".codex",
     ".omx",
     ".omc",
     "node_modules",
@@ -406,6 +408,8 @@ mod tests {
         assert!(m.is_ignored(&tmp.join("target"), true));
         assert!(m.is_ignored(&tmp.join("target/debug/foo.rs"), false));
         assert!(m.is_ignored(&tmp.join(".rag-rat"), true));
+        assert!(m.is_ignored(&tmp.join(".claude/settings.json"), false));
+        assert!(m.is_ignored(&tmp.join(".codex/config.toml"), false));
         assert!(m.is_ignored(&tmp.join("node_modules/pkg/index.ts"), false));
         assert!(!m.is_ignored(&tmp.join("src/lib.rs"), false));
         fs::remove_dir_all(&tmp).ok();

--- a/docs/config.md
+++ b/docs/config.md
@@ -91,17 +91,41 @@ model = "all-minilm"                        # the Ollama-side model name
 # query_endpoint = "http://localhost:11434" # the LOCAL ollama for QUERY embedding
                                             #   (defaults to http://localhost:11434)
 # auth_env = "OLLAMA_TOKEN"                 # optional bearer-token env var NAME
-# gpu = "A10G"                              # cookbook-only: the GPU the recipe provisions.
+# gpu = "A10"                               # cookbook-only: the GPU the recipe provisions.
                                             #   Provider-specific, validated at provision time:
-                                            #   Modal = a GPU CLASS (A10G / T4 / A100; default CPU
-                                            #     — the modal recipe WARNS that GPU there has an
-                                            #     exit-137 cold-start risk);
-                                            #   RunPod = a gpuTypeId (default: a cheap on-demand GPU).
+                                            #   Modal = a GPU request string (T4 / L4 / A10 / L40S /
+                                            #     A100 / H100 / H200 / B200; default CPU — the modal
+                                            #     recipe WARNS that GPU there has an exit-137
+                                            #     cold-start risk);
+                                            #   RunPod = a gpuTypeId (default: NVIDIA RTX A4000).
 ```
 
 `gpu` applies **only** to the EPHEMERAL `cookbook` path; setting it alongside a connect `endpoint` is
 a config error. Its value is **not** validated by rag-rat — the provider rejects an unknown GPU when
 it tries to provision.
+
+### Init cookbook catalog
+
+`rag-rat init` has a repo-local cookbook catalog for its EPHEMERAL selector. This catalog affects
+only wizard choices; runtime still uses the selected `[llm.embedding.remote] cookbook` and `gpu`
+strings verbatim. Use it to add custom recipes or override provider GPU lists without waiting for a
+new rag-rat release:
+
+```toml
+[init.cookbooks.modal]
+label = "Modal"
+command = "@rag-rat/cookbook modal"
+gpus = ["T4", "L4", "A10", "H100"]
+
+[init.cookbooks.my-provider]
+label = "My Provider"
+command = "./recipes/my-provider.mjs"
+gpus = ["small", "large"]
+```
+
+Built-in keys are `modal` and `runpod`. A table with the same key overrides the wizard entry; a new
+key appends a new choice. `command` is required for new entries. `gpus = []` is valid and means the
+wizard shows no GPU choices for that cookbook.
 
 Provisioning happens **only on an explicit `rag-rat reconcile`** (the deliberate bulk pass) — the
 background watcher/maintenance pass does **not** cold-start a GPU box for a few changed chunks (it


### PR DESCRIPTION
## Summary

Adds the full-screen ratatui init wizard and keeps the non-interactive init path intact.

The wizard now covers indexing, Oracle, embedding, integration checks, review/write, probe logs, and hook installation. It also supports repo-local cookbook catalog overrides via `[init.cookbooks.*]`, so custom cookbook commands and provider GPU lists can be surfaced in `rag-rat init` without changing runtime remote config.

## What changed

- Added the wizard runtime, tab navigation, review flow, preserving TOML patcher, and focused validation/probe lifecycle.
- Added remote embedding setup for connect and ephemeral cookbook modes, including log popups and provision confirmation guardrails.
- Added repo-local cookbook catalog parsing for wizard selectors; runtime still consumes plain `cookbook` and `gpu` strings.
- Updated cookbook docs, generated config comments, and config docs for GPU/provider behavior and cookbook overrides.
- Added focused regression tests for wizard navigation, layout, probes, TOML preservation, cookbook catalog overrides, and active `[init.cookbooks.*]` runtime tolerance.

## Validation

- `cargo +nightly fmt`
- `cargo test -p rag-rat --locked init::`
- `cargo test -p rag-rat --locked init::wizard::catalog --no-default-features`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`

Closes #329.
