### PR TITLE
fix(ollama): handle local embedding limits

### DIFF
--- a/crates/rag-rat-cli/src/render.rs
+++ b/crates/rag-rat-cli/src/render.rs
@@ -167,22 +167,24 @@ pub(crate) fn render_reconcile_progress(progress: rag_rat_core::index::ai::Recon
             processed_chunks,
             total_chunks,
             embeddings_written,
+            failed_chunks,
             blocked_chunks,
         } => {
             let percent = progress_percent(processed_chunks, total_chunks);
             eprintln!(
                 "reconcile: {processed_chunks}/{total_chunks} ({percent:>3}%) \
-                 written={embeddings_written} blocked={blocked_chunks}"
+                 written={embeddings_written} failed={failed_chunks} blocked={blocked_chunks}"
             );
         },
         rag_rat_core::index::ai::ReconcileProgress::Finished {
             processed_chunks,
             embeddings_written,
+            failed_chunks,
             blocked_chunks,
         } => {
             eprintln!(
                 "reconcile: complete processed={processed_chunks} written={embeddings_written} \
-                 blocked={blocked_chunks}"
+                 failed={failed_chunks} blocked={blocked_chunks}"
             );
         },
     }

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -273,6 +273,15 @@ pub struct RemoteEmbeddingConfig {
     /// erroring.
     #[serde(default)]
     pub gpu: Option<String>,
+    /// Optional Ollama context window (`options.num_ctx`) for `/api/embed` requests. Some local
+    /// embedding GGUFs default too small for rag-rat's code chunks; this lets config raise the
+    /// server context without shrinking chunk size or batch throughput.
+    ///
+    /// `#[serde(default)]`: this field post-dates the meta round-trip, so a config JSON persisted
+    /// by an older binary (no `num_ctx` key) must still deserialize (→ `None`) instead of
+    /// erroring.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub num_ctx: Option<u32>,
     /// How many texts to send per `/api/embed` request.
     pub batch_size: u32,
     /// Per-request HTTP timeout, in seconds.
@@ -291,6 +300,7 @@ impl Default for RemoteEmbeddingConfig {
             query_endpoint: None,
             auth_env: None,
             gpu: None,
+            num_ctx: None,
             batch_size: 256,
             request_timeout_s: 60,
         }
@@ -807,6 +817,7 @@ struct RawRemoteEmbedding {
     query_endpoint: Option<String>,
     auth_env: Option<String>,
     gpu: Option<String>,
+    num_ctx: Option<u32>,
     batch_size: Option<u32>,
     request_timeout_s: Option<u64>,
 }
@@ -911,6 +922,9 @@ impl TryFrom<RawRemoteEmbedding> for RemoteEmbeddingConfig {
             },
             None => None,
         };
+        if matches!(raw.num_ctx, Some(0)) {
+            return Err(ConfigError::RemoteEmbeddingInvalidNumCtx);
+        }
         Ok(Self {
             model: model.to_string(),
             endpoint,
@@ -918,6 +932,7 @@ impl TryFrom<RawRemoteEmbedding> for RemoteEmbeddingConfig {
             query_endpoint,
             auth_env,
             gpu,
+            num_ctx: raw.num_ctx,
             batch_size: raw.batch_size.unwrap_or(default.batch_size),
             request_timeout_s: raw.request_timeout_s.unwrap_or(default.request_timeout_s),
         })
@@ -997,6 +1012,11 @@ pub enum ConfigError {
          recipe default"
     )]
     RemoteGpuEmpty,
+    #[error(
+        "[llm.embedding.remote] `num_ctx` must be greater than zero when set — remove it to use \
+         Ollama's default context, or set a positive context window such as 4096"
+    )]
+    RemoteEmbeddingInvalidNumCtx,
     #[error(
         "[llm.embedding.remote] can only serve a transformer model over Ollama, but `model = \
          \"{0}\"` is not a transformer (it is a static/hash model, or `none`/disabled) — remove \
@@ -1381,6 +1401,7 @@ mod tests {
                 query_endpoint: None, // connect mode: no local query box
                 auth_env: None,
                 gpu: None,
+                num_ctx: None,
                 // defaults applied when omitted
                 batch_size: 256,
                 request_timeout_s: 60,
@@ -1535,6 +1556,7 @@ mod tests {
             model = "all-minilm"
             endpoint = "http://localhost:11434"
             auth_env = "OLLAMA_TOKEN"
+            num_ctx = 4096
             batch_size = 512
             request_timeout_s = 120
             "#,
@@ -1550,6 +1572,7 @@ mod tests {
                 query_endpoint: None,
                 auth_env: Some("OLLAMA_TOKEN".to_string()),
                 gpu: None,
+                num_ctx: Some(4096),
                 batch_size: 512,
                 request_timeout_s: 120,
             })

--- a/crates/rag-rat-core/src/index/ai/helpers.rs
+++ b/crates/rag-rat-core/src/index/ai/helpers.rs
@@ -522,6 +522,7 @@ mod tests {
             // present and no token is.
             auth_env: Some("OLLAMA_TOKEN".to_string()),
             gpu: None,
+            num_ctx: None,
             batch_size: 256,
             request_timeout_s: 60,
         }
@@ -616,6 +617,7 @@ mod tests {
             query_endpoint: None,
             auth_env: None,
             gpu: None,
+            num_ctx: None,
             batch_size: 256,
             request_timeout_s: 2,
         };

--- a/crates/rag-rat-core/src/index/ai/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/mod.rs
@@ -321,9 +321,24 @@ pub struct EmbeddingPolicyDecision {
 
 #[derive(Debug, Clone, Serialize)]
 pub enum ReconcileProgress {
-    Started { model_id: String, total_chunks: u64, batch_size: usize },
-    Batch { processed_chunks: u64, total_chunks: u64, embeddings_written: u64, blocked_chunks: u64 },
-    Finished { processed_chunks: u64, embeddings_written: u64, blocked_chunks: u64 },
+    Started {
+        model_id: String,
+        total_chunks: u64,
+        batch_size: usize,
+    },
+    Batch {
+        processed_chunks: u64,
+        total_chunks: u64,
+        embeddings_written: u64,
+        failed_chunks: u64,
+        blocked_chunks: u64,
+    },
+    Finished {
+        processed_chunks: u64,
+        embeddings_written: u64,
+        failed_chunks: u64,
+        blocked_chunks: u64,
+    },
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
@@ -430,6 +430,7 @@ pub(crate) fn provision_and_build(
         dim: spec.dim,
         request_timeout_s: remote.request_timeout_s,
         batch_size: remote.batch_size,
+        num_ctx: remote.num_ctx,
     });
     Ok((embedder, provisioned))
 }

--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -292,6 +292,7 @@ mod dispatch_tests {
             query_endpoint: None,
             auth_env: None,
             gpu: None,
+            num_ctx: None,
             batch_size: 256,
             request_timeout_s: 5,
         }
@@ -343,6 +344,7 @@ mod dispatch_tests {
             query_endpoint: Some(query_endpoint.to_string()),
             auth_env: auth_env.map(str::to_string),
             gpu: None,
+            num_ctx: None,
             batch_size: 256,
             request_timeout_s: 5,
         }

--- a/crates/rag-rat-core/src/index/ai/providers/ollama.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/ollama.rs
@@ -21,6 +21,14 @@ use crate::config::RemoteEmbeddingConfig;
 struct EmbedRequest<'a> {
     model: &'a str,
     input: &'a [String],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    options: Option<EmbedOptions>,
+}
+
+/// Ollama runtime options for `/api/embed`.
+#[derive(Clone, Copy, Serialize)]
+struct EmbedOptions {
+    num_ctx: u32,
 }
 
 /// Response body from Ollama's `/api/embed`: one vector per input, in order.
@@ -51,13 +59,16 @@ pub struct OllamaEmbedder {
     /// exceeds the configured cap regardless of the reconcile/runtime batch size. Clamped to
     /// `>= 1` at construction so the `chunks()` split can't panic on a misconfigured `0`.
     batch_size: usize,
+    /// Optional Ollama context window (`options.num_ctx`) to avoid context-length 400s without
+    /// shrinking rag-rat's chunk size.
+    num_ctx: Option<u32>,
     /// `Some("Bearer <token>")` when the server needs auth, read from `auth_env` at construction.
     auth_header: Option<String>,
 }
 
 /// Construction params for [`OllamaEmbedder::from_provisioned`] — groups the handshake outputs
 /// (`endpoint`, `auth_token`) with the model identity + transport knobs so the constructor takes
-/// one struct instead of seven positional args.
+/// one struct instead of positional args.
 pub struct ProvisionedEmbedderParams<'a> {
     /// The serving endpoint from the cookbook handshake (`https://...`).
     pub endpoint: &'a str,
@@ -73,6 +84,19 @@ pub struct ProvisionedEmbedderParams<'a> {
     pub request_timeout_s: u64,
     /// Max texts per `/api/embed` request.
     pub batch_size: u32,
+    /// Optional Ollama context window (`options.num_ctx`) for `/api/embed`.
+    pub num_ctx: Option<u32>,
+}
+
+struct BuildParams<'a> {
+    endpoint: &'a str,
+    auth_header: Option<String>,
+    selected_model_id: &'a str,
+    server_model: &'a str,
+    dim: usize,
+    request_timeout_s: u64,
+    batch_size: u32,
+    num_ctx: Option<u32>,
 }
 
 impl OllamaEmbedder {
@@ -102,15 +126,16 @@ impl OllamaEmbedder {
         // CONNECT auth comes from the env var NAMED by `auth_env` (the token never enters config).
         let auth_header =
             resolve_auth_header(cfg.auth_env.as_deref(), |var| std::env::var(var).ok())?;
-        Ok(Self::build(
+        Ok(Self::build(BuildParams {
             endpoint,
             auth_header,
             selected_model_id,
-            cfg.model.trim(),
+            server_model: cfg.model.trim(),
             dim,
-            cfg.request_timeout_s,
-            cfg.batch_size,
-        ))
+            request_timeout_s: cfg.request_timeout_s,
+            batch_size: cfg.batch_size,
+            num_ctx: cfg.num_ctx,
+        }))
     }
 
     /// Build the embedder against a freshly PROVISIONED ephemeral box (#318) from
@@ -125,31 +150,35 @@ impl OllamaEmbedder {
             .map(str::trim)
             .filter(|t| !t.is_empty())
             .map(|token| format!("Bearer {token}"));
-        Self::build(
-            params.endpoint.trim(),
+        Self::build(BuildParams {
+            endpoint: params.endpoint.trim(),
             auth_header,
-            params.selected_model_id,
-            params.server_model.trim(),
-            params.dim,
-            params.request_timeout_s,
-            params.batch_size,
-        )
+            selected_model_id: params.selected_model_id,
+            server_model: params.server_model.trim(),
+            dim: params.dim,
+            request_timeout_s: params.request_timeout_s,
+            batch_size: params.batch_size,
+            num_ctx: params.num_ctx,
+        })
     }
 
     /// Shared assembler: build the `ureq::Agent` (with the loopback proxy bypass) + the struct.
     /// `endpoint` is already trimmed/validated by the caller.
-    fn build(
-        endpoint: &str,
-        auth_header: Option<String>,
-        selected_model_id: &str,
-        server_model: &str,
-        dim: usize,
-        request_timeout_s: u64,
-        batch_size: u32,
-    ) -> Self {
+    fn build(params: BuildParams<'_>) -> Self {
+        let BuildParams {
+            endpoint,
+            auth_header,
+            selected_model_id,
+            server_model,
+            dim,
+            request_timeout_s,
+            batch_size,
+            num_ctx,
+        } = params;
         let embed_url = format!("{}/api/embed", endpoint.trim_end_matches('/'));
         let mut builder = ureq::Agent::config_builder()
             .timeout_global(Some(Duration::from_secs(request_timeout_s)))
+            .http_status_as_error(false)
             .user_agent(concat!("rag-rat/", env!("CARGO_PKG_VERSION"), " (ollama-embed)"));
         // ureq's default config inherits `HTTP_PROXY`/`HTTPS_PROXY` from the env. A local Ollama
         // (`http://127.0.0.1:11434`) routed through a corporate proxy 403s, so disable the proxy for
@@ -168,6 +197,7 @@ impl OllamaEmbedder {
             // Clamp to >= 1: a configured 0 would panic `slice::chunks`; treat it as "one per
             // request" rather than failing construction.
             batch_size: (batch_size as usize).max(1),
+            num_ctx,
             auth_header,
         }
     }
@@ -177,7 +207,11 @@ impl OllamaEmbedder {
     /// Factored out of `embed_batch` so the sub-batch loop reuses the exact request/validation
     /// logic.
     fn embed_one_request(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {
-        let payload = EmbedRequest { model: &self.server_model, input: texts };
+        let payload = EmbedRequest {
+            model: &self.server_model,
+            input: texts,
+            options: self.num_ctx.map(|num_ctx| EmbedOptions { num_ctx }),
+        };
         // The `json` ureq feature is not enabled (workspace ureq is rustls-only), so serialize the
         // body ourselves and send it with an explicit content-type.
         let body = serde_json::to_vec(&payload)
@@ -188,16 +222,24 @@ impl OllamaEmbedder {
             request = request.header("Authorization", header);
         }
 
-        // `http_status_as_error` defaults to true in ureq 3, so a non-2xx status, a connection
-        // refusal, or a timeout all surface as `Err` here — all retryable by the reconcile loop.
-        let raw = request
-            .send(body)
-            .map_err(|e| {
-                anyhow::anyhow!("ollama embed request to `{}` failed: {e}", self.embed_url)
-            })?
+        // `http_status_as_error(false)` lets us read Ollama's JSON error body on 4xx/5xx instead
+        // of losing the actionable reason behind ureq's bare `http status: N` error.
+        let mut response = request.send(body).map_err(|e| {
+            anyhow::anyhow!("ollama embed request to `{}` failed: {e}", self.embed_url)
+        })?;
+        let status = response.status();
+        let raw = response
             .body_mut()
             .read_to_string()
             .map_err(|e| anyhow::anyhow!("reading ollama embed response failed: {e}"))?;
+        if !status.is_success() {
+            anyhow::bail!(
+                "ollama embed request to `{}` failed: http status {}: {}",
+                self.embed_url,
+                status.as_u16(),
+                response_excerpt(&raw)
+            );
+        }
 
         let parsed: EmbedResponse = serde_json::from_str(&raw)
             .map_err(|e| anyhow::anyhow!("malformed ollama embed response: {e}"))?;
@@ -235,6 +277,15 @@ impl OllamaEmbedder {
 
         Ok(embeddings)
     }
+}
+
+fn response_excerpt(body: &str) -> String {
+    let trimmed = body.trim();
+    let mut excerpt = trimmed.chars().take(500).collect::<String>();
+    if trimmed.chars().count() > 500 {
+        excerpt.push_str("...");
+    }
+    excerpt
 }
 
 /// Resolve the `Authorization` header from the configured `auth_env` name, looking the value up
@@ -355,6 +406,59 @@ mod tests {
         (format!("http://127.0.0.1:{port}"), handle)
     }
 
+    /// Spawn a one-shot stub that captures the request JSON body before replying.
+    fn spawn_body_capture_stub(response_body: String) -> (String, thread::JoinHandle<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let port = listener.local_addr().unwrap().port();
+        let handle = thread::spawn(move || {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return String::new();
+            };
+            let request_body = read_request_body(&mut stream);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: \
+                 {}\r\nConnection: close\r\n\r\n{response_body}",
+                response_body.len()
+            );
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.flush();
+            request_body
+        });
+        (format!("http://127.0.0.1:{port}"), handle)
+    }
+
+    /// Read headers, parse Content-Length, then read exactly the request body bytes.
+    fn read_request_body(stream: &mut TcpStream) -> String {
+        stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+        let mut raw = Vec::new();
+        let mut buf = [0u8; 8192];
+        loop {
+            let header_end = raw.windows(4).position(|w| w == b"\r\n\r\n");
+            if let Some(end) = header_end {
+                let headers = String::from_utf8_lossy(&raw[..end]).to_ascii_lowercase();
+                let content_len = headers
+                    .lines()
+                    .find_map(|l| l.strip_prefix("content-length:"))
+                    .and_then(|v| v.trim().parse::<usize>().ok())
+                    .unwrap_or(0);
+                let body_start = end + 4;
+                while raw.len() < body_start + content_len {
+                    match stream.read(&mut buf) {
+                        Ok(0) => break,
+                        Ok(n) => raw.extend_from_slice(&buf[..n]),
+                        Err(_) => break,
+                    }
+                }
+                return String::from_utf8_lossy(&raw[body_start..body_start + content_len])
+                    .to_string();
+            }
+            match stream.read(&mut buf) {
+                Ok(0) | Err(_) => return String::new(),
+                Ok(n) => raw.extend_from_slice(&buf[..n]),
+            }
+        }
+    }
+
     /// Read the request headers (up to the blank line) so the client's write completes before we
     /// reply — a one-shot read is enough for these small test bodies.
     fn drain_request(stream: &mut TcpStream) {
@@ -383,6 +487,7 @@ mod tests {
             query_endpoint: None,
             auth_env: None,
             gpu: None,
+            num_ctx: None,
             batch_size: 256,
             request_timeout_s: timeout_s,
         }
@@ -406,6 +511,22 @@ mod tests {
         assert_eq!(got[1][0], 2.0);
         assert_eq!(got[2][0], 3.0);
         assert!(got.iter().all(|v| v.len() == DIM));
+    }
+
+    #[test]
+    fn embed_request_includes_num_ctx_when_configured() {
+        let want = vec![vec![1.0f32; DIM]];
+        let (url, handle) = spawn_body_capture_stub(embeddings_json(&want));
+        let mut cfg = config_for(&url, 5);
+        cfg.num_ctx = Some(4096);
+        let embedder = build(&cfg, DIM).unwrap();
+
+        embedder.embed_batch(&texts(1)).expect("embed succeeds");
+        let body = handle.join().unwrap();
+
+        let payload: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(payload["model"], "all-minilm");
+        assert_eq!(payload["options"]["num_ctx"], 4096);
     }
 
     /// A multi-request HTTP stub: accepts `max_conns` connections, and for each request replies
@@ -601,7 +722,9 @@ mod tests {
 
         let err = embedder.embed_batch(&texts(1)).expect_err("non-2xx must error");
         handle.join().unwrap();
-        assert!(!err.to_string().is_empty());
+        let msg = err.to_string();
+        assert!(msg.contains("http status 500"), "{msg}");
+        assert!(msg.contains("boom"), "{msg}");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -599,6 +599,7 @@ pub(crate) fn reconcile_with_options_progress(
             progress(ReconcileProgress::Finished {
                 processed_chunks: 0,
                 embeddings_written: 0,
+                failed_chunks: 0,
                 blocked_chunks: 0,
             });
             return Ok(report);
@@ -660,13 +661,15 @@ pub(crate) fn reconcile_with_options_progress(
             progress(ReconcileProgress::Finished {
                 processed_chunks: 0,
                 embeddings_written: 0,
+                failed_chunks: 0,
                 blocked_chunks: 0,
             });
             return Ok(report);
         },
         // SkipEphemeral / NoEphemeralWork already returned above.
-        ChunkEmbedder::SkipEphemeral | ChunkEmbedder::NoEphemeralWork =>
-            unreachable!("SkipEphemeral / NoEphemeralWork handled before the policy scan"),
+        ChunkEmbedder::SkipEphemeral | ChunkEmbedder::NoEphemeralWork => {
+            unreachable!("SkipEphemeral / NoEphemeralWork handled before the policy scan")
+        },
     };
     let mut progress_total_chunks = estimated_reconcile_jobs(conn, &scan, &options)?;
     progress(ReconcileProgress::Started {
@@ -816,6 +819,7 @@ pub(crate) fn reconcile_with_options_progress(
                 + report.blocked_chunks,
             total_chunks: progress_total_chunks,
             embeddings_written: report.embeddings_written,
+            failed_chunks: report.failed_chunks,
             blocked_chunks: report.blocked_chunks,
         });
     }
@@ -830,6 +834,7 @@ pub(crate) fn reconcile_with_options_progress(
     progress(ReconcileProgress::Finished {
         processed_chunks: report.processed_chunks,
         embeddings_written: report.embeddings_written,
+        failed_chunks: report.failed_chunks,
         blocked_chunks: report.blocked_chunks,
     });
     Ok(report)
@@ -1144,6 +1149,7 @@ mod freshness_version_tests {
             query_endpoint: None,
             auth_env: None,
             gpu: None,
+            num_ctx: None,
             batch_size: 256,
             request_timeout_s: 5,
         }
@@ -1400,6 +1406,7 @@ mod freshness_version_tests {
             query_endpoint: Some("http://localhost:11434".to_string()),
             auth_env: None,
             gpu: None,
+            num_ctx: None,
             batch_size: 256,
             request_timeout_s: 5,
         };

--- a/crates/rag-rat-core/src/index/ai/status.rs
+++ b/crates/rag-rat-core/src/index/ai/status.rs
@@ -92,13 +92,14 @@ pub(crate) fn install_ollama_model(
 
 /// The reconcile freshness key for the SELECTED model when served over Ollama. Distinct from the
 /// static `spec.version` (the local key) so a local↔remote flip re-embeds, and folds in the
-/// server-side `remote.model` so switching THAT re-embeds too.
+/// server-side `remote.model` plus vector-affecting Ollama options so switching THOSE re-embeds
+/// too.
 ///
 /// DELIBERATELY ENDPOINT-INDEPENDENT (#317 rework — the key fix). The endpoint does NOT define the
 /// vector space; the model + runtime do. Folding the endpoint host would re-embed the WHOLE repo on
 /// every run for ephemeral/cookbook boxes (each gets a fresh URL). So: new URL + same
-/// `remote.model` → SAME freshness → no re-embed; a different `remote.model`, or a local↔remote
-/// flip → re-embed.
+/// `remote.model` + `num_ctx` → SAME freshness → no re-embed; a different `remote.model`, a
+/// different vector-affecting Ollama option, or a local↔remote flip → re-embed.
 pub(crate) fn remote_freshness_version(
     spec: &EmbeddingModelSpec,
     remote: &RemoteEmbeddingConfig,
@@ -112,6 +113,10 @@ pub(crate) fn remote_freshness_version(
     hasher.update(Backend::Ollama.runtime().as_bytes());
     hasher.update([0]);
     hasher.update(remote.model.trim().as_bytes());
+    hasher.update([0]);
+    if let Some(num_ctx) = remote.num_ctx {
+        hasher.update(num_ctx.to_le_bytes());
+    }
     let digest = hasher.finalize();
     // 8 hex bytes (16 chars) is ample to separate model/runtime combinations; keep the
     // human-legible `spec.version` prefix so the persisted value still reads as this model.
@@ -302,6 +307,7 @@ mod ollama_install_tests {
             query_endpoint: None,
             auth_env: None,
             gpu: None,
+            num_ctx: None,
             batch_size: 256,
             request_timeout_s: 5,
         }
@@ -379,6 +385,19 @@ mod ollama_install_tests {
             remote_freshness_version(spec, &a),
             remote_freshness_version(spec, &b),
             "switching the server-side model must bump the freshness version",
+        );
+    }
+
+    #[test]
+    fn remote_freshness_version_differs_by_num_ctx() {
+        let spec = spec(FASTEMBED_MODEL_ID).unwrap();
+        let default_ctx = remote_at("http://localhost:11434");
+        let mut wider_ctx = default_ctx.clone();
+        wider_ctx.num_ctx = Some(4096);
+        assert_ne!(
+            remote_freshness_version(spec, &default_ctx),
+            remote_freshness_version(spec, &wider_ctx),
+            "changing Ollama's context window can change long-input embeddings and must refresh",
         );
     }
 }

--- a/rag-rat.toml
+++ b/rag-rat.toml
@@ -16,7 +16,8 @@ model = "sentence-transformers/all-MiniLM-L6-v2"
 [llm.embedding.remote]
 endpoint = "http://localhost:11434"   # this box's Ollama server
 model = "all-minilm"                  # the Ollama-side model name
-batch_size = 256                      # texts per /api/embed request
+num_ctx = 4096                        # Ollama context window for code chunks
+batch_size = 32                       # texts per /api/embed request
 # To EPHEMERALLY provision a box instead, drop `endpoint` and set `cookbook` (see docs/config.md).
 # Only then may you pick the GPU (a connect endpoint + gpu is rejected):
 # gpu = "A10G"                        # cookbook-only; Modal GPU class / RunPod gpuTypeId
@@ -25,7 +26,7 @@ batch_size = 256                      # texts per /api/embed request
 batch_size = 64
 ort_threads = 4
 omp_threads = 1
-max_embedding_chars = 4000
+max_embedding_chars = 1400
 
 [target_bindings]
 rust = ["crates"]


### PR DESCRIPTION
## Summary

This PR fixes the local-Ollama embedding path so reconcile no longer hides failed chunks or hides the useful Ollama error body.

Changes:
- add `[llm.embedding.remote] num_ctx` and send it as Ollama `options.num_ctx`
- include `num_ctx` in the remote freshness key so reinstalling refreshes the persisted remote config
- render `failed=` in reconcile progress and final output
- read Ollama non-2xx response bodies before surfacing the error
- tune the repo-local Ollama config to keep reconcile batching at 64 while capping local `all-minilm` input to a working size

## Root Cause

Baked-in FastEmbed tokenized and truncated locally. Local Ollama `all-minilm` rejects token-dense code chunks with HTTP 400 `{"error":"the input length exceeds the context length"}`. Without reading the response body, reconcile only showed a misleading `written=0 blocked=0` shape.

## Validation

- `cargo test -p rag-rat-core embed_request_includes_num_ctx_when_configured`
- `cargo test -p rag-rat-core remote_freshness_version_differs_by_num_ctx`
- `cargo test -p rag-rat-core embed_batch_errors_on_http_500`
- `cargo test -p rag-rat --no-run`
- `cargo +nightly fmt --check`
- live smoke against local Ollama: `reconcile --limit 64 --force` wrote 64, failed 0 with the tuned values
