### PR TITLE
[codex] perf(embed): parallelize remote ollama reconcile

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -64,9 +64,12 @@ Hard rules:
   "request_timeout_s": 30,     // optional: positive number — the Rust embedder's per-HTTP-request
                                //   timeout, passed through for completeness. NOT a provisioning
                                //   budget (~30–60s is far too short to boot a box).
-  "gpu": null                  // optional: string or null. For Modal this is a Modal GPU request
+  "gpu": null,                 // optional: string or null. For Modal this is a Modal GPU request
                                //   string like "A10", "L40S", "H100", or "B200+" (CPU default);
                                //   for RunPod a gpuTypeId like "NVIDIA RTX A4000".
+  "ollama_num_parallel": 32    // optional: positive integer — sets OLLAMA_NUM_PARALLEL in the
+                               //   remote Ollama container, normally matching rag-rat's remote
+                               //   embedding concurrency.
 }
 ```
 
@@ -140,6 +143,8 @@ Provider gotchas baked into the recipe (each one cost real time to find):
   model.
 - ollama defaults to `127.0.0.1:11434`, unreachable by the tunnel — the recipe sets
   `OLLAMA_HOST=0.0.0.0:11434`.
+- Ollama defaults to single-request handling — the recipe sets `OLLAMA_NUM_PARALLEL` from
+  `input.ollama_num_parallel` so Modal can serve the client-side remote concurrency window.
 - **GPU is off by default.** GPU on Modal must attach before ollama's discovery watchdog times out,
   or the box dies with exit 137 at cold start. CPU `serve` is the safe v1 path; pass `gpu` only if
   you've accepted that.
@@ -165,7 +170,7 @@ Provider gotchas baked into the recipe:
   (`"ollama serve"` would exec `ollama ollama serve`). `dockerArgs` sets the container CMD,
   appended to the entrypoint.
 - ollama defaults to `127.0.0.1:11434`, unreachable through the proxy — the recipe sets
-  `OLLAMA_HOST=0.0.0.0:11434` in the pod env.
+  `OLLAMA_HOST=0.0.0.0:11434` and `OLLAMA_NUM_PARALLEL` in the pod env.
 - There is **no in-pod exec** in `podFindAndDeployOnDemand`, so the model is pulled **client-side**
   over the proxy URL (`POST /api/pull`, non-streaming, retried until the pod finishes booting),
   then `/api/embed` is probed before the `ready` event.

--- a/cookbook/package-lock.json
+++ b/cookbook/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rag-rat/cookbook",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rag-rat/cookbook",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "modal": "^0.8.1"

--- a/cookbook/package.json
+++ b/cookbook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rag-rat/cookbook",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Ephemeral remote-runtime provisioning recipes for rag-rat. rag-rat (Rust) spawns a recipe as a subprocess, reads a typed JSONL event stream from its stdout (status/log/ready/error), embeds against the endpoint, then signals teardown.",
   "license": "MIT",
   "repository": {

--- a/cookbook/recipes/modal-ollama.mts
+++ b/cookbook/recipes/modal-ollama.mts
@@ -69,8 +69,12 @@ async function provision(ctx: ProvisionContext<Sandbox>): Promise<Provisioned<Sa
   // leaked box bills until then.) See N2.
   const deadline = Date.now() + provisionTimeoutMs;
   const gpu = input.gpu ?? null;
+  const ollamaNumParallel = String(input.ollama_num_parallel ?? 1);
 
-  ctx.status("provisioning", `creating Modal sandbox (model=${input.model}, gpu=${gpu ?? "cpu"})`);
+  ctx.status(
+    "provisioning",
+    `creating Modal sandbox (model=${input.model}, gpu=${gpu ?? "cpu"}, parallel=${ollamaNumParallel})`,
+  );
 
   // Creds resolve from env (MODAL_TOKEN_ID/MODAL_TOKEN_SECRET) or ~/.modal.toml.
   const modal = new ModalClient();
@@ -99,7 +103,10 @@ async function provision(ctx: ProvisionContext<Sandbox>): Promise<Provisioned<Sa
       createRef.promise = modal.sandboxes.create(app, image, {
         name: sandboxName,
         command: ["serve"],
-        env: { OLLAMA_HOST: `0.0.0.0:${OLLAMA_PORT}` },
+        env: {
+          OLLAMA_HOST: `0.0.0.0:${OLLAMA_PORT}`,
+          OLLAMA_NUM_PARALLEL: ollamaNumParallel,
+        },
         encryptedPorts: [OLLAMA_PORT],
         readinessProbe: Probe.withTcp(OLLAMA_PORT, { intervalMs: 1000 }),
         timeoutMs: BOX_MAX_LIFETIME_MS,

--- a/cookbook/recipes/runpod-ollama.mts
+++ b/cookbook/recipes/runpod-ollama.mts
@@ -102,11 +102,15 @@ async function provision(ctx: ProvisionContext<PodHandle>): Promise<Provisioned<
   }
   const apiKey = rawKey.trim();
   const gpuTypeId = input.gpu ?? DEFAULT_GPU_TYPE_ID;
+  const ollamaNumParallel = String(input.ollama_num_parallel ?? 1);
 
   // Unique pod name so a deploy-timeout orphan sweep can find a pod that RunPod created but whose
   // create-response we lost (see below). The instant suffix makes it unambiguous across runs.
   const podName = `${POD_NAME}-${Date.now()}`;
-  ctx.status("provisioning", `deploying RunPod pod (model=${input.model}, gpu=${gpuTypeId})`);
+  ctx.status(
+    "provisioning",
+    `deploying RunPod pod (model=${input.model}, gpu=${gpuTypeId}, parallel=${ollamaNumParallel})`,
+  );
 
   // Deploy the pod. dockerArgs="serve" → `ollama serve`; OLLAMA_HOST binds all interfaces;
   // ports "11434/http" exposes the proxy. No persistent volume (ephemeral box).
@@ -132,7 +136,10 @@ async function provision(ctx: ProvisionContext<PodHandle>): Promise<Provisioned<
           ports: `${OLLAMA_PORT}/http`,
           containerDiskInGb: CONTAINER_DISK_GB,
           volumeInGb: 0,
-          env: [{ key: "OLLAMA_HOST", value: `0.0.0.0:${OLLAMA_PORT}` }],
+          env: [
+            { key: "OLLAMA_HOST", value: `0.0.0.0:${OLLAMA_PORT}` },
+            { key: "OLLAMA_NUM_PARALLEL", value: ollamaNumParallel },
+          ],
         },
       },
       GRAPHQL_TIMEOUT_MS,

--- a/cookbook/src/contract.ts
+++ b/cookbook/src/contract.ts
@@ -92,6 +92,11 @@ export interface CookbookInput {
    * null/omitted for the recipe's default. CPU is the safe default where the provider supports it.
    */
   readonly gpu?: string | null;
+  /**
+   * Ollama server parallelism to set as OLLAMA_NUM_PARALLEL. rag-rat sends this from the remote
+   * embedding `concurrency` knob so server-side request handling can match the client window.
+   */
+  readonly ollama_num_parallel?: number | null;
 }
 
 /**
@@ -205,6 +210,10 @@ export function readInput(): CookbookInput {
   // like "60" would slip through to budget arithmetic as NaN and break every poll loop.
   const provisionTimeout = optionalPositiveNumber(obj["provision_timeout_s"], "provision_timeout_s");
   const requestTimeout = optionalPositiveNumber(obj["request_timeout_s"], "request_timeout_s");
+  const ollamaNumParallel = optionalPositiveInteger(
+    obj["ollama_num_parallel"],
+    "ollama_num_parallel",
+  );
 
   // gpu: optional; if present must be a string (provider spec) or null.
   const gpu = obj["gpu"];
@@ -217,6 +226,7 @@ export function readInput(): CookbookInput {
     ...(provisionTimeout !== undefined ? { provision_timeout_s: provisionTimeout } : {}),
     ...(requestTimeout !== undefined ? { request_timeout_s: requestTimeout } : {}),
     ...(typeof gpu === "string" ? { gpu } : gpu === null ? { gpu: null } : {}),
+    ...(ollamaNumParallel !== undefined ? { ollama_num_parallel: ollamaNumParallel } : {}),
   };
   return result;
 }
@@ -228,6 +238,16 @@ function optionalPositiveNumber(value: unknown, field: string): number | undefin
     throw new Error(`${COOKBOOK_INPUT_ENV}.${field} must be a positive number (got ${describe(value)}).`);
   }
   return value;
+}
+
+/** Validates an optional positive integer field; returns the number, or undefined if absent/null. */
+function optionalPositiveInteger(value: unknown, field: string): number | undefined {
+  const number = optionalPositiveNumber(value, field);
+  if (number === undefined) return undefined;
+  if (!Number.isInteger(number)) {
+    throw new Error(`${COOKBOOK_INPUT_ENV}.${field} must be a positive integer (got ${describe(value)}).`);
+  }
+  return number;
 }
 
 function describe(v: unknown): string {

--- a/crates/rag-rat-cli/src/init/render.rs
+++ b/crates/rag-rat-cli/src/init/render.rs
@@ -54,7 +54,7 @@ pub(crate) fn render_config(plan: &InitPlan) -> String {
          embedding).\n# [llm.embedding.remote]\n# endpoint = \"http://localhost:11434\"\n# model = \
          \"all-minilm\"          # Ollama-side model name for the selected embedding model\n# \
          batch_size = 256          # texts per /api/embed request\n# concurrency = 32          # \
-         concurrent /api/embed requests\n# max_batch_chars = 384000 # max input chars per \
+         1..=128 concurrent /api/embed requests\n# max_batch_chars = 384000 # max input chars per \
          /api/embed request\n# request_timeout_s = 60\n# num_ctx = 4096            # optional \
          Ollama context window\n\n",
     );

--- a/crates/rag-rat-cli/src/init/render.rs
+++ b/crates/rag-rat-cli/src/init/render.rs
@@ -50,6 +50,16 @@ pub(crate) fn render_config(plan: &InitPlan) -> String {
     );
 
     text.push_str(
+        "# Remote Ollama embedding (optional; defaults shown; uncomment to offload \
+         embedding).\n# [llm.embedding.remote]\n# endpoint = \"http://localhost:11434\"\n# model = \
+         \"all-minilm\"          # Ollama-side model name for the selected embedding model\n# \
+         batch_size = 256          # texts per /api/embed request\n# concurrency = 32          # \
+         concurrent /api/embed requests\n# max_batch_chars = 384000 # max input chars per \
+         /api/embed request\n# request_timeout_s = 60\n# num_ctx = 4096            # optional \
+         Ollama context window\n\n",
+    );
+
+    text.push_str(
         "# Init wizard cookbook catalog (optional). These entries only affect `rag-rat init` \
          selectors;\n# runtime uses the selected `[llm.embedding.remote] cookbook` and `gpu` \
          strings verbatim.\n# [init.cookbooks.modal]\n# label = \"Modal\"\n# command = \

--- a/crates/rag-rat-cli/src/init/render.rs
+++ b/crates/rag-rat-cli/src/init/render.rs
@@ -53,8 +53,8 @@ pub(crate) fn render_config(plan: &InitPlan) -> String {
         "# Remote Ollama embedding (optional; defaults shown; uncomment to offload \
          embedding).\n# [llm.embedding.remote]\n# endpoint = \"http://localhost:11434\"\n# model = \
          \"all-minilm\"          # Ollama-side model name for the selected embedding model\n# \
-         batch_size = 256          # texts per /api/embed request\n# concurrency = 32          # \
-         1..=128 concurrent /api/embed requests\n# max_batch_chars = 384000 # max input chars per \
+         batch_size = 256          # texts per /api/embed request\n# concurrency = 1           # \
+         CONNECT-safe; cookbook/ephemeral default = 32\n# max_batch_chars = 384000 # max input chars per \
          /api/embed request\n# request_timeout_s = 60\n# num_ctx = 4096            # optional \
          Ollama context window\n\n",
     );

--- a/crates/rag-rat-cli/src/init/wizard/draft.rs
+++ b/crates/rag-rat-cli/src/init/wizard/draft.rs
@@ -565,7 +565,12 @@ fn raw_remote_draft(doc: &DocumentMut) -> Option<RemoteDraft> {
         .get("concurrency")
         .and_then(Item::as_integer)
         .and_then(|n| u32::try_from(n).ok())
-        .unwrap_or_else(|| RemoteEmbeddingConfig::default().concurrency)
+        .unwrap_or_else(|| {
+            RemoteEmbeddingConfig::omitted_concurrency_default(matches!(
+                &mode,
+                RemoteMode::Connect(_)
+            ))
+        })
         .max(1);
     let max_batch_chars = remote
         .get("max_batch_chars")
@@ -897,7 +902,36 @@ mod tests {
             d.remote.as_ref().map(|remote| &remote.mode),
             Some(RemoteMode::Ephemeral(cookbook)) if cookbook == "./recipe.mjs"
         ));
+        assert_eq!(d.remote.as_ref().map(|remote| remote.concurrency), Some(32));
         assert_eq!(remote.get("cookbook").and_then(Item::as_str), Some("./recipe.mjs"));
+        assert_eq!(remote.get("concurrency").and_then(Item::as_integer), Some(32));
+    }
+
+    #[test]
+    fn from_existing_defaults_legacy_connect_concurrency_to_single_flight() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        let config_path = dir.path().join("rag-rat.toml");
+        let raw = "[index]\nroot = \".\"\n[target_bindings]\nrust = \
+                   [\"src\"]\n[llm.embedding]\nmodel = \
+                   \"sentence-transformers/all-MiniLM-L6-v2\"\n[llm.embedding.remote]\nmodel = \
+                   \"all-minilm\"\nendpoint = \"http://localhost:11434\"\n";
+        std::fs::write(&config_path, raw).unwrap();
+        let cfg = Config::load(&config_path).unwrap();
+        assert_eq!(cfg.llm.embedding.remote.as_ref().unwrap().concurrency, 1);
+
+        let d = WizardDraft::from_existing(raw, &cfg, &config_path);
+        let out = d.patch_existing(raw).unwrap();
+        let doc: DocumentMut = out.parse().unwrap();
+        let remote = doc["llm"]["embedding"]["remote"].as_table_like().unwrap();
+
+        assert!(matches!(
+            d.remote.as_ref().map(|remote| &remote.mode),
+            Some(RemoteMode::Connect(endpoint)) if endpoint == "http://localhost:11434"
+        ));
+        assert_eq!(d.remote.as_ref().map(|remote| remote.concurrency), Some(1));
+        assert_eq!(remote.get("endpoint").and_then(Item::as_str), Some("http://localhost:11434"));
+        assert_eq!(remote.get("concurrency").and_then(Item::as_integer), Some(1));
     }
 
     #[test]

--- a/crates/rag-rat-cli/src/init/wizard/draft.rs
+++ b/crates/rag-rat-cli/src/init/wizard/draft.rs
@@ -40,6 +40,10 @@ pub(crate) struct RemoteDraft {
     pub num_ctx: Option<u32>,
     /// How many texts per `/api/embed` request.
     pub batch_size: u32,
+    /// How many remote `/api/embed` requests to keep in flight.
+    pub concurrency: u32,
+    /// Maximum total input characters per `/api/embed` request.
+    pub max_batch_chars: usize,
     /// Name of the env-var holding the bearer token, if auth is needed.
     pub auth_env: Option<String>,
 }
@@ -436,6 +440,11 @@ impl WizardDraft {
                     },
                 }
                 t.insert("batch_size", toml_edit::value(i64::from(remote.batch_size)));
+                t.insert("concurrency", toml_edit::value(i64::from(remote.concurrency)));
+                t.insert(
+                    "max_batch_chars",
+                    toml_edit::value(i64::try_from(remote.max_batch_chars).unwrap_or(i64::MAX)),
+                );
                 if let Some(gpu) = &remote.gpu {
                     t.insert("gpu", toml_edit::value(gpu.clone()));
                 } else {
@@ -488,6 +497,8 @@ fn remote_draft_from_config(r: &RemoteEmbeddingConfig) -> RemoteDraft {
         gpu: r.gpu.clone(),
         num_ctx: r.num_ctx,
         batch_size: r.batch_size,
+        concurrency: r.concurrency,
+        max_batch_chars: r.max_batch_chars,
         auth_env: r.auth_env.clone(),
     }
 }
@@ -550,6 +561,18 @@ fn raw_remote_draft(doc: &DocumentMut) -> Option<RemoteDraft> {
         .and_then(Item::as_integer)
         .and_then(|n| u32::try_from(n).ok())
         .unwrap_or_else(|| RemoteEmbeddingConfig::default().batch_size);
+    let concurrency = remote
+        .get("concurrency")
+        .and_then(Item::as_integer)
+        .and_then(|n| u32::try_from(n).ok())
+        .unwrap_or_else(|| RemoteEmbeddingConfig::default().concurrency)
+        .max(1);
+    let max_batch_chars = remote
+        .get("max_batch_chars")
+        .and_then(Item::as_integer)
+        .and_then(|n| usize::try_from(n).ok())
+        .unwrap_or_else(|| RemoteEmbeddingConfig::default().max_batch_chars)
+        .max(1);
     Some(RemoteDraft {
         model,
         mode,
@@ -559,6 +582,8 @@ fn raw_remote_draft(doc: &DocumentMut) -> Option<RemoteDraft> {
             .and_then(Item::as_integer)
             .and_then(|n| u32::try_from(n).ok()),
         batch_size,
+        concurrency,
+        max_batch_chars,
         auth_env: string("auth_env"),
     })
 }
@@ -674,7 +699,8 @@ mod tests {
              [target_bindings]\nrust = [\"src\"]\n\n\
              [llm.embedding]\nmodel = \"sentence-transformers/all-MiniLM-L6-v2\"\n\n\
              [llm.embedding.remote]\nmodel = \"all-minilm\"\nendpoint = \
-             \"http://localhost:11434\"\nnum_ctx = 4096\nbatch_size = 64\n",
+             \"http://localhost:11434\"\nnum_ctx = 4096\nbatch_size = 64\nconcurrency = \
+             8\nmax_batch_chars = 96000\n",
         )
         .unwrap();
         let cfg = rag_rat_core::config::Config::load(&config_path).unwrap();
@@ -682,6 +708,8 @@ mod tests {
         let remote = d.remote.expect("remote block should be present");
         assert_eq!(remote.model, "all-minilm");
         assert_eq!(remote.num_ctx, Some(4096));
+        assert_eq!(remote.concurrency, 8);
+        assert_eq!(remote.max_batch_chars, 96_000);
         assert!(
             matches!(remote.mode, RemoteMode::Connect(ref ep) if ep == "http://localhost:11434")
         );
@@ -758,6 +786,8 @@ mod tests {
             gpu: None,
             num_ctx: None,
             batch_size: 128,
+            concurrency: 16,
+            max_batch_chars: 192_000,
             auth_env: Some("OLLAMA_TOKEN".to_string()),
         });
 
@@ -767,6 +797,8 @@ mod tests {
 
         assert_eq!(remote.get("cookbook").and_then(Item::as_str), Some("@rag-rat/cookbook modal"));
         assert_eq!(remote.get("batch_size").and_then(Item::as_integer), Some(128));
+        assert_eq!(remote.get("concurrency").and_then(Item::as_integer), Some(16));
+        assert_eq!(remote.get("max_batch_chars").and_then(Item::as_integer), Some(192_000));
         assert_eq!(remote.get("auth_env").and_then(Item::as_str), Some("OLLAMA_TOKEN"));
         assert_eq!(doc["version_check"]["enabled"].as_bool(), Some(false));
     }
@@ -786,6 +818,8 @@ mod tests {
             gpu: None,
             num_ctx: Some(4096),
             batch_size: 64,
+            concurrency: 12,
+            max_batch_chars: 144_000,
             auth_env: None,
         });
 
@@ -796,6 +830,8 @@ mod tests {
         assert_eq!(remote.get("endpoint").and_then(Item::as_str), Some("http://new:11434"));
         assert_eq!(remote.get("model").and_then(Item::as_str), Some("all-minilm"));
         assert_eq!(remote.get("num_ctx").and_then(Item::as_integer), Some(4096));
+        assert_eq!(remote.get("concurrency").and_then(Item::as_integer), Some(12));
+        assert_eq!(remote.get("max_batch_chars").and_then(Item::as_integer), Some(144_000));
         assert!(remote.get("cookbook").is_none());
     }
 

--- a/crates/rag-rat-cli/src/init/wizard/mod.rs
+++ b/crates/rag-rat-cli/src/init/wizard/mod.rs
@@ -807,6 +807,8 @@ mod tests {
             gpu: None,
             num_ctx: None,
             batch_size: 256,
+            concurrency: rag_rat_core::config::RemoteEmbeddingConfig::default().concurrency,
+            max_batch_chars: rag_rat_core::config::RemoteEmbeddingConfig::default().max_batch_chars,
             auth_env: None,
         });
         w.state.checks[StepId::Embedding.index()] = steps::CheckResult::ok();
@@ -863,6 +865,8 @@ mod tests {
             gpu: None,
             num_ctx: None,
             batch_size: 256,
+            concurrency: rag_rat_core::config::RemoteEmbeddingConfig::default().concurrency,
+            max_batch_chars: rag_rat_core::config::RemoteEmbeddingConfig::default().max_batch_chars,
             auth_env: None,
         });
         w.state.ui.ephemeral_keep_acknowledged = true;

--- a/crates/rag-rat-cli/src/init/wizard/review.rs
+++ b/crates/rag-rat-cli/src/init/wizard/review.rs
@@ -405,6 +405,8 @@ mod tests {
             gpu: None,
             num_ctx: None,
             batch_size: 32,
+            concurrency: rag_rat_core::config::RemoteEmbeddingConfig::default().concurrency,
+            max_batch_chars: rag_rat_core::config::RemoteEmbeddingConfig::default().max_batch_chars,
             auth_env: None,
         });
         st

--- a/crates/rag-rat-cli/src/init/wizard/steps.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps.rs
@@ -120,6 +120,7 @@ pub(crate) fn can_write(checks: &[CheckResult]) -> bool {
 }
 
 const ONE_LINE_FIELD_OUTER_HEIGHT: u16 = 3;
+const REMOTE_BATCH_SIZE_MAX: u32 = 4096;
 
 // ── per-step state ─────────────────────────────────────────────────────────────
 
@@ -132,6 +133,8 @@ pub(crate) enum EmbedFocus {
     ServerModel,
     Gpu,
     BatchSize,
+    Concurrency,
+    MaxBatchChars,
     AuthEnv,
     ProvisionConfirm,
 }
@@ -1108,6 +1111,12 @@ fn render_embedding(f: &mut Frame, area: Rect, state: &WizardState) {
     let m = remote.map_or("", |r| r.model.as_str());
     let g = remote.and_then(|r| r.gpu.as_deref()).unwrap_or("");
     let bs = remote.map_or(256, |r| r.batch_size).to_string();
+    let concurrency = remote
+        .map_or_else(|| RemoteEmbeddingConfig::default().concurrency, |r| r.concurrency)
+        .to_string();
+    let max_batch_chars = remote
+        .map_or_else(|| RemoteEmbeddingConfig::default().max_batch_chars, |r| r.max_batch_chars)
+        .to_string();
     let auth = remote.and_then(|r| r.auth_env.as_deref()).unwrap_or("");
 
     let dim = |f: EmbedFocus| if *focus == f { theme::focused_border() } else { theme::border() };
@@ -1195,28 +1204,55 @@ fn render_embedding(f: &mut Frame, area: Rect, state: &WizardState) {
 
     if rmode == 2 {
         let bottom = Layout::horizontal([
-            Constraint::Ratio(1, 3),
-            Constraint::Ratio(1, 3),
-            Constraint::Ratio(1, 3),
+            Constraint::Ratio(1, 5),
+            Constraint::Ratio(1, 5),
+            Constraint::Ratio(1, 5),
+            Constraint::Ratio(1, 5),
+            Constraint::Ratio(1, 5),
         ])
         .split(right[3]);
         f.render_widget(one_line_field(&bs, "batch", dim(EmbedFocus::BatchSize)), bottom[0]);
-        f.render_widget(one_line_field(auth, "auth env", dim(EmbedFocus::AuthEnv)), bottom[1]);
+        f.render_widget(
+            one_line_field(&concurrency, "parallel", dim(EmbedFocus::Concurrency)),
+            bottom[1],
+        );
+        f.render_widget(
+            one_line_field(&max_batch_chars, "chars", dim(EmbedFocus::MaxBatchChars)),
+            bottom[2],
+        );
+        f.render_widget(one_line_field(auth, "auth env", dim(EmbedFocus::AuthEnv)), bottom[3]);
         let confirm = if provision_confirm_satisfied(&state.ui) {
             "ready"
         } else {
             state.ui.provision_confirm.as_str()
         };
-        let confirm_title = format!("type: {PROVISION_CONFIRM_WORD}");
+        let confirm_title = if bottom[4].width >= (PROVISION_CONFIRM_WORD.len() as u16 + 8) {
+            format!("type: {PROVISION_CONFIRM_WORD}")
+        } else {
+            PROVISION_CONFIRM_WORD.to_string()
+        };
         f.render_widget(
             one_line_field(confirm, &confirm_title, dim(EmbedFocus::ProvisionConfirm)),
-            bottom[2],
+            bottom[4],
         );
     } else {
-        let bottom =
-            Layout::horizontal([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)]).split(right[3]);
+        let bottom = Layout::horizontal([
+            Constraint::Ratio(1, 4),
+            Constraint::Ratio(1, 4),
+            Constraint::Ratio(1, 4),
+            Constraint::Ratio(1, 4),
+        ])
+        .split(right[3]);
         f.render_widget(one_line_field(&bs, "batch", dim(EmbedFocus::BatchSize)), bottom[0]);
-        f.render_widget(one_line_field(auth, "auth env", dim(EmbedFocus::AuthEnv)), bottom[1]);
+        f.render_widget(
+            one_line_field(&concurrency, "parallel", dim(EmbedFocus::Concurrency)),
+            bottom[1],
+        );
+        f.render_widget(
+            one_line_field(&max_batch_chars, "max chars", dim(EmbedFocus::MaxBatchChars)),
+            bottom[2],
+        );
+        f.render_widget(one_line_field(auth, "auth env", dim(EmbedFocus::AuthEnv)), bottom[3]);
     }
 }
 
@@ -1478,6 +1514,8 @@ fn embed_focus_order(rmode: usize, model_none: bool) -> &'static [EmbedFocus] {
         EmbedFocus::Endpoint,
         EmbedFocus::ServerModel,
         EmbedFocus::BatchSize,
+        EmbedFocus::Concurrency,
+        EmbedFocus::MaxBatchChars,
         EmbedFocus::AuthEnv,
     ];
     const EPHEMERAL: &[EmbedFocus] = &[
@@ -1487,6 +1525,8 @@ fn embed_focus_order(rmode: usize, model_none: bool) -> &'static [EmbedFocus] {
         EmbedFocus::Gpu,
         EmbedFocus::ServerModel,
         EmbedFocus::BatchSize,
+        EmbedFocus::Concurrency,
+        EmbedFocus::MaxBatchChars,
         EmbedFocus::AuthEnv,
         EmbedFocus::ProvisionConfirm,
     ];
@@ -1532,8 +1572,8 @@ fn move_embedding_cursor(state: &mut WizardState, delta: isize) {
         Some(f) => f,
         None => return,
     };
-    if focus == EmbedFocus::BatchSize {
-        adjust_batch_size(state, delta);
+    if remote_numeric_focus(focus) {
+        adjust_remote_numeric(state, focus, delta);
         return;
     }
     let cookbook_len = cookbook_choices(state).len();
@@ -1810,16 +1850,19 @@ fn preserved_server_model(local_model: &str, existing: &RemoteDraft) -> String {
     }
 }
 
-fn adjust_batch_size(state: &mut WizardState, delta: isize) {
+fn remote_numeric_focus(focus: EmbedFocus) -> bool {
+    matches!(focus, EmbedFocus::BatchSize | EmbedFocus::Concurrency | EmbedFocus::MaxBatchChars)
+}
+
+fn adjust_remote_numeric(state: &mut WizardState, focus: EmbedFocus, delta: isize) {
     let changed = {
         let Some(remote) = &mut state.draft.remote else { return };
-        let current = remote.batch_size as isize;
-        let next = current.saturating_add(delta).clamp(1, 4096) as u32;
-        if remote.batch_size == next {
-            false
-        } else {
-            remote.batch_size = next;
-            true
+        match focus {
+            EmbedFocus::BatchSize =>
+                adjust_u32(&mut remote.batch_size, delta, 1, REMOTE_BATCH_SIZE_MAX),
+            EmbedFocus::Concurrency => adjust_u32(&mut remote.concurrency, delta, 1, u32::MAX),
+            EmbedFocus::MaxBatchChars => adjust_usize(&mut remote.max_batch_chars, delta, 1),
+            _ => false,
         }
     };
     if changed {
@@ -1827,11 +1870,35 @@ fn adjust_batch_size(state: &mut WizardState, delta: isize) {
     }
 }
 
+fn adjust_u32(value: &mut u32, delta: isize, min: u32, max: u32) -> bool {
+    let before = *value;
+    let next = if delta >= 0 {
+        value.saturating_add(delta as u32).min(max)
+    } else {
+        let magnitude = u32::try_from(delta.unsigned_abs()).unwrap_or(u32::MAX);
+        value.saturating_sub(magnitude).max(min)
+    };
+    *value = next;
+    before != next
+}
+
+fn adjust_usize(value: &mut usize, delta: isize, min: usize) -> bool {
+    let before = *value;
+    let next = if delta >= 0 {
+        value.saturating_add(delta as usize)
+    } else {
+        value.saturating_sub(delta.unsigned_abs()).max(min)
+    };
+    *value = next;
+    before != next
+}
+
 fn edit_embedding_field(key: KeyEvent, state: &mut WizardState) -> bool {
     let Some(focus) = embed_focus(state) else { return false };
     match focus {
         EmbedFocus::Endpoint => edit_endpoint(key, state),
-        EmbedFocus::BatchSize => edit_batch_size(key, state),
+        EmbedFocus::BatchSize | EmbedFocus::Concurrency | EmbedFocus::MaxBatchChars =>
+            edit_remote_numeric(focus, key, state),
         EmbedFocus::AuthEnv => edit_auth_env(key, state),
         EmbedFocus::ProvisionConfirm => edit_provision_confirm(key, state),
         _ => false,
@@ -1867,26 +1934,63 @@ fn edit_endpoint(key: KeyEvent, state: &mut WizardState) -> bool {
     }
 }
 
-fn edit_batch_size(key: KeyEvent, state: &mut WizardState) -> bool {
+fn edit_remote_numeric(focus: EmbedFocus, key: KeyEvent, state: &mut WizardState) -> bool {
     let Some(remote) = &mut state.draft.remote else { return false };
-    match key.code {
-        KeyCode::Backspace => {
-            remote.batch_size /= 10;
-            if remote.batch_size == 0 {
-                remote.batch_size = 1;
-            }
-            state.probes.bump(StepId::Embedding);
-            true
+    let changed = match key.code {
+        KeyCode::Backspace => match focus {
+            EmbedFocus::BatchSize => {
+                let before = remote.batch_size;
+                remote.batch_size = (remote.batch_size / 10).max(1);
+                before != remote.batch_size
+            },
+            EmbedFocus::Concurrency => {
+                let before = remote.concurrency;
+                remote.concurrency = (remote.concurrency / 10).max(1);
+                before != remote.concurrency
+            },
+            EmbedFocus::MaxBatchChars => {
+                let before = remote.max_batch_chars;
+                remote.max_batch_chars = (remote.max_batch_chars / 10).max(1);
+                before != remote.max_batch_chars
+            },
+            _ => return false,
         },
         KeyCode::Char(c) if c.is_ascii_digit() => {
             let digit = c.to_digit(10).unwrap_or(0);
-            remote.batch_size =
-                remote.batch_size.saturating_mul(10).saturating_add(digit).clamp(1, 4096);
-            state.probes.bump(StepId::Embedding);
-            true
+            match focus {
+                EmbedFocus::BatchSize => {
+                    let before = remote.batch_size;
+                    remote.batch_size = remote
+                        .batch_size
+                        .saturating_mul(10)
+                        .saturating_add(digit)
+                        .clamp(1, REMOTE_BATCH_SIZE_MAX);
+                    before != remote.batch_size
+                },
+                EmbedFocus::Concurrency => {
+                    let before = remote.concurrency;
+                    remote.concurrency =
+                        remote.concurrency.saturating_mul(10).saturating_add(digit).max(1);
+                    before != remote.concurrency
+                },
+                EmbedFocus::MaxBatchChars => {
+                    let before = remote.max_batch_chars;
+                    remote.max_batch_chars = remote
+                        .max_batch_chars
+                        .saturating_mul(10)
+                        .saturating_add(digit as usize)
+                        .max(1);
+                    before != remote.max_batch_chars
+                },
+                _ => return false,
+            }
         },
-        _ => false,
+        _ => return false,
+    };
+    if changed {
+        state.probes.bump(StepId::Embedding);
     }
+    true
 }
 
 fn edit_auth_env(key: KeyEvent, state: &mut WizardState) -> bool {
@@ -2912,6 +3016,37 @@ mod tests {
     }
 
     #[test]
+    fn embedding_remote_tuning_fields_are_focusable_and_editable() {
+        let mut state = empty_state();
+        state.draft.remote = Some(new_connect_remote(&state.draft.model));
+        state.step = Some(init_step(StepId::Embedding, &state));
+        let probe_id = state.probes.current(StepId::Embedding);
+        assert!(state.probes.apply(ProbeMsg {
+            probe_id,
+            kind: ProbeKind::ConnectTest,
+            result: CheckResult::ok(),
+        }));
+
+        while embed_focus(&state) != Some(EmbedFocus::Concurrency) {
+            step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        }
+        step_handle_key(StepId::Embedding, key(KeyCode::Char('4')), &mut state);
+        assert_eq!(state.draft.remote.as_ref().unwrap().concurrency, 324);
+        assert!(matches!(state.probes.status(StepId::Embedding), ProbeStatus::Idle));
+
+        while embed_focus(&state) != Some(EmbedFocus::MaxBatchChars) {
+            step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
+        }
+        step_handle_key(StepId::Embedding, key(KeyCode::Backspace), &mut state);
+        step_handle_key(StepId::Embedding, key(KeyCode::Up), &mut state);
+        assert_eq!(state.draft.remote.as_ref().unwrap().max_batch_chars, 38_399);
+
+        let remote = remote_config_for(state.draft.remote.as_ref().unwrap());
+        assert_eq!(remote.concurrency, 324);
+        assert_eq!(remote.max_batch_chars, 38_399);
+    }
+
+    #[test]
     fn embedding_provision_ignores_duplicate_running_probe() {
         use std::sync::mpsc::sync_channel;
 
@@ -3056,6 +3191,8 @@ mod tests {
             EmbedFocus::Gpu,
             EmbedFocus::ServerModel,
             EmbedFocus::BatchSize,
+            EmbedFocus::Concurrency,
+            EmbedFocus::MaxBatchChars,
             EmbedFocus::AuthEnv,
             EmbedFocus::ProvisionConfirm,
         ] {
@@ -3131,7 +3268,7 @@ mod tests {
     }
 
     #[test]
-    fn embedding_batch_and_auth_fields_have_one_content_row() {
+    fn embedding_remote_fields_have_one_content_row() {
         let mut state = empty_state();
         let mut remote = new_ephemeral_remote(&state.draft.model);
         remote.auth_env = Some("RR_AUTH".to_string());
@@ -3145,10 +3282,12 @@ mod tests {
         let bottom = row_segment(&cells, batch_y + 2, 45, 55);
 
         assert!(content.contains("256"));
+        assert!(content.contains("32"));
+        assert!(content.contains("384000"));
         assert!(content.contains("RR_AUTH"));
         assert!(bottom.contains('└'));
         assert!(bottom.contains('┘'));
-        assert!(screen_text(&cells).contains("type: provision"));
+        assert!(screen_text(&cells).contains("provision"));
     }
 
     #[test]

--- a/crates/rag-rat-cli/src/init/wizard/steps.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps.rs
@@ -7,7 +7,9 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 use std::sync::mpsc::Sender;
 
-use rag_rat_core::config::{DEFAULT_QUERY_ENDPOINT, RemoteEmbeddingConfig};
+use rag_rat_core::config::{
+    DEFAULT_QUERY_ENDPOINT, MAX_REMOTE_EMBEDDING_CONCURRENCY, RemoteEmbeddingConfig,
+};
 use rag_rat_core::embedding_models::{Backend, EMBEDDING_MODELS, EmbeddingModelSpec, spec};
 #[cfg(feature = "fastembed")]
 use rag_rat_core::index::ai::FastEmbedEmbedder;
@@ -1799,7 +1801,9 @@ fn new_connect_remote_from(local_model: &str, existing: Option<&RemoteDraft>) ->
         remote.model = preserved_server_model(local_model, existing);
         remote.num_ctx = existing.num_ctx;
         remote.batch_size = existing.batch_size;
-        remote.concurrency = existing.concurrency;
+        if matches!(existing.mode, RemoteMode::Connect(_)) {
+            remote.concurrency = existing.concurrency.min(MAX_REMOTE_EMBEDDING_CONCURRENCY);
+        }
         remote.max_batch_chars = existing.max_batch_chars;
         remote.auth_env = existing.auth_env.clone();
     }
@@ -1835,7 +1839,9 @@ fn new_ephemeral_remote_from(
         remote.gpu = existing.gpu.clone();
         remote.num_ctx = existing.num_ctx;
         remote.batch_size = existing.batch_size;
-        remote.concurrency = existing.concurrency;
+        if matches!(existing.mode, RemoteMode::Ephemeral(_)) {
+            remote.concurrency = existing.concurrency.min(MAX_REMOTE_EMBEDDING_CONCURRENCY);
+        }
         remote.max_batch_chars = existing.max_batch_chars;
         remote.auth_env = existing.auth_env.clone();
     }
@@ -1860,7 +1866,8 @@ fn adjust_remote_numeric(state: &mut WizardState, focus: EmbedFocus, delta: isiz
         match focus {
             EmbedFocus::BatchSize =>
                 adjust_u32(&mut remote.batch_size, delta, 1, REMOTE_BATCH_SIZE_MAX),
-            EmbedFocus::Concurrency => adjust_u32(&mut remote.concurrency, delta, 1, u32::MAX),
+            EmbedFocus::Concurrency =>
+                adjust_u32(&mut remote.concurrency, delta, 1, MAX_REMOTE_EMBEDDING_CONCURRENCY),
             EmbedFocus::MaxBatchChars => adjust_usize(&mut remote.max_batch_chars, delta, 1),
             _ => false,
         }
@@ -1969,8 +1976,11 @@ fn edit_remote_numeric(focus: EmbedFocus, key: KeyEvent, state: &mut WizardState
                 },
                 EmbedFocus::Concurrency => {
                     let before = remote.concurrency;
-                    remote.concurrency =
-                        remote.concurrency.saturating_mul(10).saturating_add(digit).max(1);
+                    remote.concurrency = remote
+                        .concurrency
+                        .saturating_mul(10)
+                        .saturating_add(digit)
+                        .clamp(1, MAX_REMOTE_EMBEDDING_CONCURRENCY);
                     before != remote.concurrency
                 },
                 EmbedFocus::MaxBatchChars => {
@@ -2738,6 +2748,36 @@ mod tests {
         step_handle_key(StepId::Embedding, key(KeyCode::Char(' ')), &mut state);
 
         assert_eq!(state.draft.remote.as_ref().and_then(|remote| remote.gpu.as_deref()), None);
+    }
+
+    #[test]
+    fn embedding_mode_switch_resets_mode_specific_concurrency_default() {
+        let mut state = empty_state();
+        state.draft.remote = Some(new_ephemeral_remote(&state.draft.model));
+        state.step = Some(init_step(StepId::Embedding, &state));
+        assert_eq!(
+            state.draft.remote.as_ref().map(|remote| remote.concurrency),
+            Some(RemoteEmbeddingConfig::omitted_concurrency_default(false))
+        );
+
+        if let Some(StepState::Embedding { focus, mode_cursor, .. }) = &mut state.step {
+            *focus = EmbedFocus::Mode;
+            *mode_cursor = 1;
+        }
+        step_handle_key(StepId::Embedding, key(KeyCode::Char(' ')), &mut state);
+
+        let remote = state.draft.remote.as_ref().unwrap();
+        assert!(matches!(remote.mode, RemoteMode::Connect(_)));
+        assert_eq!(remote.concurrency, RemoteEmbeddingConfig::omitted_concurrency_default(true));
+
+        if let Some(StepState::Embedding { mode_cursor, .. }) = &mut state.step {
+            *mode_cursor = 2;
+        }
+        step_handle_key(StepId::Embedding, key(KeyCode::Char(' ')), &mut state);
+
+        let remote = state.draft.remote.as_ref().unwrap();
+        assert!(matches!(remote.mode, RemoteMode::Ephemeral(_)));
+        assert_eq!(remote.concurrency, RemoteEmbeddingConfig::omitted_concurrency_default(false));
     }
 
     #[test]

--- a/crates/rag-rat-cli/src/init/wizard/steps.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps.rs
@@ -1787,7 +1787,7 @@ fn new_connect_remote(local_model: &str) -> RemoteDraft {
         gpu: None,
         num_ctx: None,
         batch_size: 256,
-        concurrency: RemoteEmbeddingConfig::default().concurrency,
+        concurrency: RemoteEmbeddingConfig::omitted_concurrency_default(true),
         max_batch_chars: RemoteEmbeddingConfig::default().max_batch_chars,
         auth_env: None,
     }
@@ -1818,7 +1818,7 @@ fn new_ephemeral_remote_with_command(local_model: &str, cookbook: &str) -> Remot
         gpu: None,
         num_ctx: None,
         batch_size: 256,
-        concurrency: RemoteEmbeddingConfig::default().concurrency,
+        concurrency: RemoteEmbeddingConfig::omitted_concurrency_default(false),
         max_batch_chars: RemoteEmbeddingConfig::default().max_batch_chars,
         auth_env: None,
     }
@@ -2699,6 +2699,7 @@ mod tests {
             matches!(remote.mode, RemoteMode::Connect(ref endpoint) if endpoint == DEFAULT_QUERY_ENDPOINT)
         );
         assert_eq!(remote.model, default_remote_model_for(&state.draft.model));
+        assert_eq!(remote.concurrency, RemoteEmbeddingConfig::omitted_concurrency_default(true));
         assert_eq!(compatible_server_models(&state.draft.model), vec![
             "all-minilm",
             "qllama/bge-small-en-v1.5:f16"
@@ -2728,6 +2729,10 @@ mod tests {
             Some(RemoteMode::Ephemeral(_))
         ));
         assert_eq!(state.draft.remote.as_ref().and_then(|remote| remote.gpu.as_deref()), None);
+        assert_eq!(
+            state.draft.remote.as_ref().map(|remote| remote.concurrency),
+            Some(RemoteEmbeddingConfig::omitted_concurrency_default(false))
+        );
 
         step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
         step_handle_key(StepId::Embedding, key(KeyCode::Char(' ')), &mut state);
@@ -3031,7 +3036,7 @@ mod tests {
             step_handle_key(StepId::Embedding, key(KeyCode::Tab), &mut state);
         }
         step_handle_key(StepId::Embedding, key(KeyCode::Char('4')), &mut state);
-        assert_eq!(state.draft.remote.as_ref().unwrap().concurrency, 324);
+        assert_eq!(state.draft.remote.as_ref().unwrap().concurrency, 14);
         assert!(matches!(state.probes.status(StepId::Embedding), ProbeStatus::Idle));
 
         while embed_focus(&state) != Some(EmbedFocus::MaxBatchChars) {
@@ -3042,7 +3047,7 @@ mod tests {
         assert_eq!(state.draft.remote.as_ref().unwrap().max_batch_chars, 38_399);
 
         let remote = remote_config_for(state.draft.remote.as_ref().unwrap());
-        assert_eq!(remote.concurrency, 324);
+        assert_eq!(remote.concurrency, 14);
         assert_eq!(remote.max_batch_chars, 38_399);
     }
 

--- a/crates/rag-rat-cli/src/init/wizard/steps.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps.rs
@@ -1747,6 +1747,8 @@ fn new_connect_remote(local_model: &str) -> RemoteDraft {
         gpu: None,
         num_ctx: None,
         batch_size: 256,
+        concurrency: RemoteEmbeddingConfig::default().concurrency,
+        max_batch_chars: RemoteEmbeddingConfig::default().max_batch_chars,
         auth_env: None,
     }
 }
@@ -1757,6 +1759,8 @@ fn new_connect_remote_from(local_model: &str, existing: Option<&RemoteDraft>) ->
         remote.model = preserved_server_model(local_model, existing);
         remote.num_ctx = existing.num_ctx;
         remote.batch_size = existing.batch_size;
+        remote.concurrency = existing.concurrency;
+        remote.max_batch_chars = existing.max_batch_chars;
         remote.auth_env = existing.auth_env.clone();
     }
     remote
@@ -1774,6 +1778,8 @@ fn new_ephemeral_remote_with_command(local_model: &str, cookbook: &str) -> Remot
         gpu: None,
         num_ctx: None,
         batch_size: 256,
+        concurrency: RemoteEmbeddingConfig::default().concurrency,
+        max_batch_chars: RemoteEmbeddingConfig::default().max_batch_chars,
         auth_env: None,
     }
 }
@@ -1789,6 +1795,8 @@ fn new_ephemeral_remote_from(
         remote.gpu = existing.gpu.clone();
         remote.num_ctx = existing.num_ctx;
         remote.batch_size = existing.batch_size;
+        remote.concurrency = existing.concurrency;
+        remote.max_batch_chars = existing.max_batch_chars;
         remote.auth_env = existing.auth_env.clone();
     }
     remote
@@ -2030,6 +2038,8 @@ fn remote_config_for(d: &RemoteDraft) -> RemoteEmbeddingConfig {
         gpu: d.gpu.clone(),
         num_ctx: d.num_ctx,
         batch_size: d.batch_size,
+        concurrency: d.concurrency,
+        max_batch_chars: d.max_batch_chars,
         request_timeout_s: RemoteEmbeddingConfig::default().request_timeout_s,
     }
 }
@@ -2706,6 +2716,8 @@ mod tests {
             gpu: None,
             num_ctx: Some(4096),
             batch_size: 17,
+            concurrency: 9,
+            max_batch_chars: 99_000,
             auth_env: Some("OLLAMA_TOKEN".to_string()),
         });
         state.step = Some(init_step(StepId::Embedding, &state));
@@ -2727,6 +2739,8 @@ mod tests {
         ));
         assert_eq!(remote.num_ctx, Some(4096));
         assert_eq!(remote.batch_size, 17);
+        assert_eq!(remote.concurrency, 9);
+        assert_eq!(remote.max_batch_chars, 99_000);
         assert_eq!(remote.auth_env.as_deref(), Some("OLLAMA_TOKEN"));
         assert!(matches!(state.probes.status(StepId::Embedding), ProbeStatus::Done {
             kind: ProbeKind::ConnectTest,

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -286,10 +286,10 @@ pub struct RemoteEmbeddingConfig {
     pub batch_size: u32,
     /// How many `/api/embed` requests the remote embedder may keep in flight.
     ///
-    /// `#[serde(default)]`: this field post-dates the meta round-trip, so a config JSON persisted
-    /// by an older binary (no `concurrency` key) must still deserialize with the default instead
-    /// of erroring.
-    #[serde(default = "default_remote_embedding_concurrency")]
+    /// `#[serde(default)]`: this field post-dates the meta round-trip. Older persisted remote meta
+    /// has no mode-aware TOML context, so deserialize it as single-flight instead of making an
+    /// existing connect endpoint fan out 32 requests after upgrade.
+    #[serde(default = "legacy_remote_embedding_concurrency")]
     pub concurrency: u32,
     /// Maximum total input characters to include in one `/api/embed` request.
     ///
@@ -305,10 +305,11 @@ pub struct RemoteEmbeddingConfig {
 /// The default LOCAL Ollama URL for ephemeral query embedding when `query_endpoint` is omitted.
 pub const DEFAULT_QUERY_ENDPOINT: &str = "http://localhost:11434";
 const DEFAULT_REMOTE_EMBEDDING_CONCURRENCY: u32 = 32;
+const LEGACY_REMOTE_EMBEDDING_CONCURRENCY: u32 = 1;
 const DEFAULT_REMOTE_EMBEDDING_MAX_BATCH_CHARS: usize = 384_000;
 
-fn default_remote_embedding_concurrency() -> u32 {
-    DEFAULT_REMOTE_EMBEDDING_CONCURRENCY
+fn legacy_remote_embedding_concurrency() -> u32 {
+    LEGACY_REMOTE_EMBEDDING_CONCURRENCY
 }
 
 fn default_remote_embedding_max_batch_chars() -> usize {
@@ -334,6 +335,20 @@ impl Default for RemoteEmbeddingConfig {
 }
 
 impl RemoteEmbeddingConfig {
+    /// Default for a missing TOML `concurrency` field after the mode has been inferred.
+    ///
+    /// Connect-mode configs may point at ordinary Ollama servers that were not started with
+    /// matching `OLLAMA_NUM_PARALLEL`, so omitted connect concurrency stays single-flight. Cookbook
+    /// configs are provisioned by rag-rat recipes that align server-side parallelism, so omitted
+    /// ephemeral configs use the new parallel default.
+    pub fn omitted_concurrency_default(is_connect: bool) -> u32 {
+        if is_connect {
+            LEGACY_REMOTE_EMBEDDING_CONCURRENCY
+        } else {
+            DEFAULT_REMOTE_EMBEDDING_CONCURRENCY
+        }
+    }
+
     /// CONNECT mode: an already-running server at `endpoint`. Exactly one of connect/ephemeral
     /// holds (config validation guarantees it), so `is_connect() == !is_ephemeral()`.
     pub fn is_connect(&self) -> bool {
@@ -953,6 +968,7 @@ impl TryFrom<RawRemoteEmbedding> for RemoteEmbeddingConfig {
         if matches!(raw.num_ctx, Some(0)) {
             return Err(ConfigError::RemoteEmbeddingInvalidNumCtx);
         }
+        let is_connect = endpoint.is_some();
         Ok(Self {
             model: model.to_string(),
             endpoint,
@@ -962,7 +978,10 @@ impl TryFrom<RawRemoteEmbedding> for RemoteEmbeddingConfig {
             gpu,
             num_ctx: raw.num_ctx,
             batch_size: raw.batch_size.unwrap_or(default.batch_size),
-            concurrency: raw.concurrency.unwrap_or(default.concurrency).max(1),
+            concurrency: raw
+                .concurrency
+                .unwrap_or_else(|| RemoteEmbeddingConfig::omitted_concurrency_default(is_connect))
+                .max(1),
             max_batch_chars: raw.max_batch_chars.unwrap_or(default.max_batch_chars).max(1),
             request_timeout_s: raw.request_timeout_s.unwrap_or(default.request_timeout_s),
         })
@@ -1434,7 +1453,7 @@ mod tests {
                 num_ctx: None,
                 // defaults applied when omitted
                 batch_size: 256,
-                concurrency: 32,
+                concurrency: 1,
                 max_batch_chars: 384_000,
                 request_timeout_s: 60,
             })
@@ -1472,6 +1491,7 @@ mod tests {
         assert_eq!(remote.cookbook.as_deref(), Some("@rag-rat/cookbook/modal"));
         assert_eq!(remote.endpoint, None);
         assert_eq!(remote.query_endpoint.as_deref(), Some(DEFAULT_QUERY_ENDPOINT));
+        assert_eq!(remote.concurrency, 32);
     }
 
     #[test]
@@ -1639,7 +1659,7 @@ mod tests {
     }
 
     #[test]
-    fn older_remote_embedding_meta_json_deserializes_with_new_defaults() {
+    fn older_remote_embedding_meta_json_deserializes_with_legacy_safe_defaults() {
         let json = r#"{
             "model": "all-minilm",
             "endpoint": "http://localhost:11434",
@@ -1652,7 +1672,7 @@ mod tests {
             "request_timeout_s": 60
         }"#;
         let remote: RemoteEmbeddingConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(remote.concurrency, 32);
+        assert_eq!(remote.concurrency, 1);
         assert_eq!(remote.max_batch_chars, 384_000);
     }
 

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -284,12 +284,36 @@ pub struct RemoteEmbeddingConfig {
     pub num_ctx: Option<u32>,
     /// How many texts to send per `/api/embed` request.
     pub batch_size: u32,
+    /// How many `/api/embed` requests the remote embedder may keep in flight.
+    ///
+    /// `#[serde(default)]`: this field post-dates the meta round-trip, so a config JSON persisted
+    /// by an older binary (no `concurrency` key) must still deserialize with the default instead
+    /// of erroring.
+    #[serde(default = "default_remote_embedding_concurrency")]
+    pub concurrency: u32,
+    /// Maximum total input characters to include in one `/api/embed` request.
+    ///
+    /// `#[serde(default)]`: this field post-dates the meta round-trip, so a config JSON persisted
+    /// by an older binary (no `max_batch_chars` key) must still deserialize with the default
+    /// instead of erroring.
+    #[serde(default = "default_remote_embedding_max_batch_chars")]
+    pub max_batch_chars: usize,
     /// Per-request HTTP timeout, in seconds.
     pub request_timeout_s: u64,
 }
 
 /// The default LOCAL Ollama URL for ephemeral query embedding when `query_endpoint` is omitted.
 pub const DEFAULT_QUERY_ENDPOINT: &str = "http://localhost:11434";
+const DEFAULT_REMOTE_EMBEDDING_CONCURRENCY: u32 = 32;
+const DEFAULT_REMOTE_EMBEDDING_MAX_BATCH_CHARS: usize = 384_000;
+
+fn default_remote_embedding_concurrency() -> u32 {
+    DEFAULT_REMOTE_EMBEDDING_CONCURRENCY
+}
+
+fn default_remote_embedding_max_batch_chars() -> usize {
+    DEFAULT_REMOTE_EMBEDDING_MAX_BATCH_CHARS
+}
 
 impl Default for RemoteEmbeddingConfig {
     fn default() -> Self {
@@ -302,6 +326,8 @@ impl Default for RemoteEmbeddingConfig {
             gpu: None,
             num_ctx: None,
             batch_size: 256,
+            concurrency: DEFAULT_REMOTE_EMBEDDING_CONCURRENCY,
+            max_batch_chars: DEFAULT_REMOTE_EMBEDDING_MAX_BATCH_CHARS,
             request_timeout_s: 60,
         }
     }
@@ -819,6 +845,8 @@ struct RawRemoteEmbedding {
     gpu: Option<String>,
     num_ctx: Option<u32>,
     batch_size: Option<u32>,
+    concurrency: Option<u32>,
+    max_batch_chars: Option<usize>,
     request_timeout_s: Option<u64>,
 }
 
@@ -934,6 +962,8 @@ impl TryFrom<RawRemoteEmbedding> for RemoteEmbeddingConfig {
             gpu,
             num_ctx: raw.num_ctx,
             batch_size: raw.batch_size.unwrap_or(default.batch_size),
+            concurrency: raw.concurrency.unwrap_or(default.concurrency).max(1),
+            max_batch_chars: raw.max_batch_chars.unwrap_or(default.max_batch_chars).max(1),
             request_timeout_s: raw.request_timeout_s.unwrap_or(default.request_timeout_s),
         })
     }
@@ -1404,6 +1434,8 @@ mod tests {
                 num_ctx: None,
                 // defaults applied when omitted
                 batch_size: 256,
+                concurrency: 32,
+                max_batch_chars: 384_000,
                 request_timeout_s: 60,
             })
         );
@@ -1558,6 +1590,8 @@ mod tests {
             auth_env = "OLLAMA_TOKEN"
             num_ctx = 4096
             batch_size = 512
+            concurrency = 16
+            max_batch_chars = 128000
             request_timeout_s = 120
             "#,
         )
@@ -1574,9 +1608,52 @@ mod tests {
                 gpu: None,
                 num_ctx: Some(4096),
                 batch_size: 512,
+                concurrency: 16,
+                max_batch_chars: 128_000,
                 request_timeout_s: 120,
             })
         );
+    }
+
+    #[test]
+    fn remote_embedding_zero_concurrency_and_char_budget_are_clamped() {
+        let raw: RawConfig = toml::from_str(
+            r#"
+            [index]
+            root = "."
+
+            [llm.embedding]
+            model = "sentence-transformers/all-MiniLM-L6-v2"
+
+            [llm.embedding.remote]
+            model = "all-minilm"
+            endpoint = "http://localhost:11434"
+            concurrency = 0
+            max_batch_chars = 0
+            "#,
+        )
+        .unwrap();
+        let remote = LlmConfig::try_from(raw.llm).unwrap().embedding.remote.unwrap();
+        assert_eq!(remote.concurrency, 1);
+        assert_eq!(remote.max_batch_chars, 1);
+    }
+
+    #[test]
+    fn older_remote_embedding_meta_json_deserializes_with_new_defaults() {
+        let json = r#"{
+            "model": "all-minilm",
+            "endpoint": "http://localhost:11434",
+            "cookbook": null,
+            "query_endpoint": null,
+            "auth_env": null,
+            "gpu": null,
+            "num_ctx": null,
+            "batch_size": 256,
+            "request_timeout_s": 60
+        }"#;
+        let remote: RemoteEmbeddingConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(remote.concurrency, 32);
+        assert_eq!(remote.max_batch_chars, 384_000);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -304,6 +304,7 @@ pub struct RemoteEmbeddingConfig {
 
 /// The default LOCAL Ollama URL for ephemeral query embedding when `query_endpoint` is omitted.
 pub const DEFAULT_QUERY_ENDPOINT: &str = "http://localhost:11434";
+pub const MAX_REMOTE_EMBEDDING_CONCURRENCY: u32 = 128;
 const DEFAULT_REMOTE_EMBEDDING_CONCURRENCY: u32 = 32;
 const LEGACY_REMOTE_EMBEDDING_CONCURRENCY: u32 = 1;
 const DEFAULT_REMOTE_EMBEDDING_MAX_BATCH_CHARS: usize = 384_000;
@@ -347,6 +348,17 @@ impl RemoteEmbeddingConfig {
         } else {
             DEFAULT_REMOTE_EMBEDDING_CONCURRENCY
         }
+    }
+
+    /// Runtime-safe concurrency for deserialized/persisted configs. TOML parsing rejects explicit
+    /// values above [`MAX_REMOTE_EMBEDDING_CONCURRENCY`], but older or manually-edited DB metadata
+    /// can bypass that validation.
+    pub fn bounded_concurrency(&self) -> u32 {
+        Self::bounded_concurrency_value(self.concurrency)
+    }
+
+    pub fn bounded_concurrency_value(value: u32) -> u32 {
+        value.clamp(1, MAX_REMOTE_EMBEDDING_CONCURRENCY)
     }
 
     /// CONNECT mode: an already-running server at `endpoint`. Exactly one of connect/ephemeral
@@ -969,6 +981,16 @@ impl TryFrom<RawRemoteEmbedding> for RemoteEmbeddingConfig {
             return Err(ConfigError::RemoteEmbeddingInvalidNumCtx);
         }
         let is_connect = endpoint.is_some();
+        let concurrency = raw
+            .concurrency
+            .unwrap_or_else(|| RemoteEmbeddingConfig::omitted_concurrency_default(is_connect))
+            .max(1);
+        if concurrency > MAX_REMOTE_EMBEDDING_CONCURRENCY {
+            return Err(ConfigError::RemoteEmbeddingConcurrencyTooHigh {
+                value: concurrency,
+                max: MAX_REMOTE_EMBEDDING_CONCURRENCY,
+            });
+        }
         Ok(Self {
             model: model.to_string(),
             endpoint,
@@ -978,10 +1000,7 @@ impl TryFrom<RawRemoteEmbedding> for RemoteEmbeddingConfig {
             gpu,
             num_ctx: raw.num_ctx,
             batch_size: raw.batch_size.unwrap_or(default.batch_size),
-            concurrency: raw
-                .concurrency
-                .unwrap_or_else(|| RemoteEmbeddingConfig::omitted_concurrency_default(is_connect))
-                .max(1),
+            concurrency,
             max_batch_chars: raw.max_batch_chars.unwrap_or(default.max_batch_chars).max(1),
             request_timeout_s: raw.request_timeout_s.unwrap_or(default.request_timeout_s),
         })
@@ -1066,6 +1085,10 @@ pub enum ConfigError {
          Ollama's default context, or set a positive context window such as 4096"
     )]
     RemoteEmbeddingInvalidNumCtx,
+    #[error(
+        "[llm.embedding.remote] `concurrency` is {value}, but the maximum supported value is {max}"
+    )]
+    RemoteEmbeddingConcurrencyTooHigh { value: u32, max: u32 },
     #[error(
         "[llm.embedding.remote] can only serve a transformer model over Ollama, but `model = \
          \"{0}\"` is not a transformer (it is a static/hash model, or `none`/disabled) — remove \
@@ -1656,6 +1679,35 @@ mod tests {
         let remote = LlmConfig::try_from(raw.llm).unwrap().embedding.remote.unwrap();
         assert_eq!(remote.concurrency, 1);
         assert_eq!(remote.max_batch_chars, 1);
+    }
+
+    #[test]
+    fn remote_embedding_rejects_oversized_concurrency() {
+        let raw: RawConfig = toml::from_str(&format!(
+            r#"
+            [index]
+            root = "."
+
+            [llm.embedding]
+            model = "sentence-transformers/all-MiniLM-L6-v2"
+
+            [llm.embedding.remote]
+            model = "all-minilm"
+            endpoint = "http://localhost:11434"
+            concurrency = {}
+            "#,
+            MAX_REMOTE_EMBEDDING_CONCURRENCY + 1
+        ))
+        .unwrap();
+
+        let err = LlmConfig::try_from(raw.llm).expect_err("oversized concurrency should reject");
+        assert!(matches!(
+            err,
+            ConfigError::RemoteEmbeddingConcurrencyTooHigh {
+                value,
+                max: MAX_REMOTE_EMBEDDING_CONCURRENCY
+            } if value == MAX_REMOTE_EMBEDDING_CONCURRENCY + 1
+        ));
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/helpers.rs
+++ b/crates/rag-rat-core/src/index/ai/helpers.rs
@@ -524,6 +524,8 @@ mod tests {
             gpu: None,
             num_ctx: None,
             batch_size: 256,
+            concurrency: 32,
+            max_batch_chars: 384_000,
             request_timeout_s: 60,
         }
     }
@@ -619,6 +621,8 @@ mod tests {
             gpu: None,
             num_ctx: None,
             batch_size: 256,
+            concurrency: 32,
+            max_batch_chars: 384_000,
             request_timeout_s: 2,
         };
         set_active_remote_config(&conn, &remote).unwrap();

--- a/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
@@ -5,7 +5,7 @@
 //!
 //! THE PROCESS CONTRACT (rag-rat ⇄ cookbook — both sides build to this exact shape):
 //! - INPUT via env `RAG_RAT_COOKBOOK_INPUT` = JSON
-//!   `{"model","request_timeout_s","provision_timeout_s","gpu"}`.
+//!   `{"model","request_timeout_s","provision_timeout_s","gpu","ollama_num_parallel"}`.
 //! - The cookbook's STDOUT is a TYPED JSONL event stream — one JSON object per line, each with a
 //!   `"type"` tag and a `"ts"` (epoch-ms) field (see [`CookbookEvent`]). The four `type`s are
 //!   `status` (a provisioning-phase update: `provisioning`/`pulling`/`verifying`/`tearing_down`),
@@ -146,6 +146,9 @@ pub struct CookbookInput {
     /// GPU hint for the recipe (e.g. `"T4"`); `None` lets the recipe decide. Carried as JSON
     /// `null` when absent so the contract field is always present.
     pub gpu: Option<String>,
+    /// Ollama server parallelism the recipe should set as `OLLAMA_NUM_PARALLEL`, aligned to the
+    /// remote client's configured in-flight request count.
+    pub ollama_num_parallel: u32,
 }
 
 /// One line of the cookbook's typed JSONL stdout stream. Tagged on `"type"`; the `"ts"` field and
@@ -500,6 +503,7 @@ fn cookbook_input_for(remote: &RemoteEmbeddingConfig) -> CookbookInput {
         // recipe picks its own default when `None`. Config validation guarantees `gpu` is only set
         // in ephemeral mode, which is the only mode reaching this function.
         gpu: remote.gpu.clone(),
+        ollama_num_parallel: remote.concurrency.max(1),
     }
 }
 
@@ -535,6 +539,8 @@ fn provision_and_build_cancellable(
         dim: spec.dim,
         request_timeout_s: remote.request_timeout_s,
         batch_size: remote.batch_size,
+        concurrency: remote.concurrency,
+        max_batch_chars: remote.max_batch_chars,
         num_ctx: remote.num_ctx,
     });
     Ok((embedder, provisioned))
@@ -1113,6 +1119,7 @@ mod tests {
             request_timeout_s: 30,
             provision_timeout_s: 280,
             gpu: None,
+            ollama_num_parallel: 32,
         }
     }
 
@@ -1166,21 +1173,24 @@ mod tests {
     }
 
     #[test]
-    fn cookbook_input_carries_the_configured_gpu() {
-        // The config→CookbookInput mapping must forward the configured `gpu` to the recipe (it's
-        // the only way a user picks a GPU — the contract.ts side reads `input.gpu`). `None`
-        // stays `None` so the recipe keeps its own default.
-        let ephemeral = |gpu: Option<&str>| RemoteEmbeddingConfig {
+    fn cookbook_input_carries_configured_gpu_and_parallelism() {
+        // The config→CookbookInput mapping must forward provider/runtime knobs to the recipe:
+        // `gpu` selects the provider shape, and `ollama_num_parallel` aligns server concurrency
+        // with the client-side remote request window.
+        let ephemeral = |gpu: Option<&str>, concurrency: u32| RemoteEmbeddingConfig {
             model: "all-minilm".to_string(),
             cookbook: Some("@rag-rat/cookbook modal".to_string()),
             query_endpoint: Some(crate::config::DEFAULT_QUERY_ENDPOINT.to_string()),
             gpu: gpu.map(str::to_string),
+            concurrency,
             ..RemoteEmbeddingConfig::default()
         };
-        assert_eq!(cookbook_input_for(&ephemeral(Some("A10G"))).gpu.as_deref(), Some("A10G"));
-        assert_eq!(cookbook_input_for(&ephemeral(None)).gpu, None);
+        assert_eq!(cookbook_input_for(&ephemeral(Some("A10G"), 16)).gpu.as_deref(), Some("A10G"));
+        assert_eq!(cookbook_input_for(&ephemeral(None, 16)).gpu, None);
+        assert_eq!(cookbook_input_for(&ephemeral(None, 16)).ollama_num_parallel, 16);
+        assert_eq!(cookbook_input_for(&ephemeral(None, 0)).ollama_num_parallel, 1);
         // The model is trimmed into the input regardless of gpu.
-        assert_eq!(cookbook_input_for(&ephemeral(Some("A100"))).model, "all-minilm");
+        assert_eq!(cookbook_input_for(&ephemeral(Some("A100"), 16)).model, "all-minilm");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
@@ -503,7 +503,7 @@ fn cookbook_input_for(remote: &RemoteEmbeddingConfig) -> CookbookInput {
         // recipe picks its own default when `None`. Config validation guarantees `gpu` is only set
         // in ephemeral mode, which is the only mode reaching this function.
         gpu: remote.gpu.clone(),
-        ollama_num_parallel: remote.concurrency.max(1),
+        ollama_num_parallel: remote.bounded_concurrency(),
     }
 }
 
@@ -539,7 +539,7 @@ fn provision_and_build_cancellable(
         dim: spec.dim,
         request_timeout_s: remote.request_timeout_s,
         batch_size: remote.batch_size,
-        concurrency: remote.concurrency,
+        concurrency: remote.bounded_concurrency(),
         max_batch_chars: remote.max_batch_chars,
         num_ctx: remote.num_ctx,
     });
@@ -1189,6 +1189,14 @@ mod tests {
         assert_eq!(cookbook_input_for(&ephemeral(None, 16)).gpu, None);
         assert_eq!(cookbook_input_for(&ephemeral(None, 16)).ollama_num_parallel, 16);
         assert_eq!(cookbook_input_for(&ephemeral(None, 0)).ollama_num_parallel, 1);
+        assert_eq!(
+            cookbook_input_for(&ephemeral(
+                None,
+                crate::config::MAX_REMOTE_EMBEDDING_CONCURRENCY + 1
+            ))
+            .ollama_num_parallel,
+            crate::config::MAX_REMOTE_EMBEDDING_CONCURRENCY
+        );
         // The model is trimmed into the input regardless of gpu.
         assert_eq!(cookbook_input_for(&ephemeral(Some("A100"), 16)).model, "all-minilm");
     }

--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -111,8 +111,13 @@ fn query_embed_config(remote: &RemoteEmbeddingConfig) -> RemoteEmbeddingConfig {
 /// reconcile loop just calls [`acquire_chunk_embedder`] and matches.
 pub(crate) enum ChunkEmbedder {
     /// An embedder is ready. `provisioned` is `Some` only for an ephemeral box; `None` for
-    /// connect/local.
-    Ready { embedder: Box<dyn Embedder>, provisioned: Option<ProvisionedBox> },
+    /// connect/local. `remote` is the already-read active remote config, if any, so reconcile does
+    /// not need to re-read potentially malformed meta outside the NotReady path.
+    Ready {
+        embedder: Box<dyn Embedder>,
+        provisioned: Option<ProvisionedBox>,
+        remote: Option<Box<RemoteEmbeddingConfig>>,
+    },
     /// Ephemeral active model on a non-provisioning pass — skip remote chunk embedding entirely.
     SkipEphemeral,
     /// Ephemeral active model on a PROVISIONING reconcile, but there is NOTHING to embed (the model
@@ -167,13 +172,15 @@ pub(crate) fn acquire_chunk_embedder(
             Ok((embedder, provisioned)) => ChunkEmbedder::Ready {
                 embedder: Box::new(embedder),
                 provisioned: Some(provisioned),
+                remote: Some(Box::new(remote.clone())),
             },
             Err(err) => ChunkEmbedder::NotReady(err),
         };
     }
     // Connect / local: the usual single construction site.
     match active_embedder(conn, intra_threads) {
-        Ok(embedder) => ChunkEmbedder::Ready { embedder, provisioned: None },
+        Ok(embedder) =>
+            ChunkEmbedder::Ready { embedder, provisioned: None, remote: remote.map(Box::new) },
         Err(err) => ChunkEmbedder::NotReady(err),
     }
 }

--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -299,6 +299,8 @@ mod dispatch_tests {
             gpu: None,
             num_ctx: None,
             batch_size: 256,
+            concurrency: 32,
+            max_batch_chars: 384_000,
             request_timeout_s: 5,
         }
     }
@@ -351,6 +353,8 @@ mod dispatch_tests {
             gpu: None,
             num_ctx: None,
             batch_size: 256,
+            concurrency: 32,
+            max_batch_chars: 384_000,
             request_timeout_s: 5,
         }
     }

--- a/crates/rag-rat-core/src/index/ai/providers/ollama.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/ollama.rs
@@ -5,8 +5,8 @@
 //!
 //! Native, blocking HTTP via `ureq` (v3, rustls) — already a non-optional workspace dep (the
 //! crates.io version check uses it), so this backend ships unconditionally: no cargo feature, no
-//! missing-feature message. The reconcile loop is single-threaded, so the cloneable `ureq::Agent`
-//! is held bare (no `Mutex`).
+//! missing-feature message. The cloneable `ureq::Agent` is held bare (no `Mutex`) and cloned into
+//! bounded blocking worker threads for remote request fan-out.
 
 use std::time::Duration;
 
@@ -59,6 +59,10 @@ pub struct OllamaEmbedder {
     /// exceeds the configured cap regardless of the reconcile/runtime batch size. Clamped to
     /// `>= 1` at construction so the `chunks()` split can't panic on a misconfigured `0`.
     batch_size: usize,
+    /// Max concurrent `/api/embed` requests in one `embed_batch` call.
+    concurrency: usize,
+    /// Max total input characters per `/api/embed` request.
+    max_batch_chars: usize,
     /// Optional Ollama context window (`options.num_ctx`) to avoid context-length 400s without
     /// shrinking rag-rat's chunk size.
     num_ctx: Option<u32>,
@@ -84,6 +88,10 @@ pub struct ProvisionedEmbedderParams<'a> {
     pub request_timeout_s: u64,
     /// Max texts per `/api/embed` request.
     pub batch_size: u32,
+    /// Max concurrent `/api/embed` requests.
+    pub concurrency: u32,
+    /// Max total input characters per `/api/embed` request.
+    pub max_batch_chars: usize,
     /// Optional Ollama context window (`options.num_ctx`) for `/api/embed`.
     pub num_ctx: Option<u32>,
 }
@@ -96,6 +104,8 @@ struct BuildParams<'a> {
     dim: usize,
     request_timeout_s: u64,
     batch_size: u32,
+    concurrency: u32,
+    max_batch_chars: usize,
     num_ctx: Option<u32>,
 }
 
@@ -134,6 +144,8 @@ impl OllamaEmbedder {
             dim,
             request_timeout_s: cfg.request_timeout_s,
             batch_size: cfg.batch_size,
+            concurrency: cfg.concurrency,
+            max_batch_chars: cfg.max_batch_chars,
             num_ctx: cfg.num_ctx,
         }))
     }
@@ -158,6 +170,8 @@ impl OllamaEmbedder {
             dim: params.dim,
             request_timeout_s: params.request_timeout_s,
             batch_size: params.batch_size,
+            concurrency: params.concurrency,
+            max_batch_chars: params.max_batch_chars,
             num_ctx: params.num_ctx,
         })
     }
@@ -173,6 +187,8 @@ impl OllamaEmbedder {
             dim,
             request_timeout_s,
             batch_size,
+            concurrency,
+            max_batch_chars,
             num_ctx,
         } = params;
         let embed_url = format!("{}/api/embed", endpoint.trim_end_matches('/'));
@@ -197,36 +213,63 @@ impl OllamaEmbedder {
             // Clamp to >= 1: a configured 0 would panic `slice::chunks`; treat it as "one per
             // request" rather than failing construction.
             batch_size: (batch_size as usize).max(1),
+            concurrency: (concurrency as usize).max(1),
+            max_batch_chars: max_batch_chars.max(1),
             num_ctx,
             auth_header,
         }
     }
 
-    /// Send ONE `/api/embed` request for `texts` (already sized to `<= self.batch_size` by the
-    /// caller) and return the parsed vectors, enforcing the count + per-vector dim contracts.
-    /// Factored out of `embed_batch` so the sub-batch loop reuses the exact request/validation
-    /// logic.
-    fn embed_one_request(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {
+    fn sub_batch_ranges(&self, texts: &[String]) -> Vec<(usize, usize)> {
+        let mut ranges = Vec::new();
+        let mut start = 0usize;
+        let mut chars = 0usize;
+        for (idx, text) in texts.iter().enumerate() {
+            let text_chars = text.chars().count();
+            let count_full = idx.saturating_sub(start) >= self.batch_size;
+            let chars_full = idx > start && chars.saturating_add(text_chars) > self.max_batch_chars;
+            if count_full || chars_full {
+                ranges.push((start, idx));
+                start = idx;
+                chars = 0;
+            }
+            chars = chars.saturating_add(text_chars);
+        }
+        if start < texts.len() {
+            ranges.push((start, texts.len()));
+        }
+        ranges
+    }
+
+    fn embed_one_request_with(
+        agent: ureq::Agent,
+        embed_url: &str,
+        server_model: &str,
+        dim: usize,
+        num_ctx: Option<u32>,
+        auth_header: Option<&str>,
+        texts: &[String],
+    ) -> anyhow::Result<Vec<Vec<f32>>> {
         let payload = EmbedRequest {
-            model: &self.server_model,
+            model: server_model,
             input: texts,
-            options: self.num_ctx.map(|num_ctx| EmbedOptions { num_ctx }),
+            options: num_ctx.map(|num_ctx| EmbedOptions { num_ctx }),
         };
         // The `json` ureq feature is not enabled (workspace ureq is rustls-only), so serialize the
         // body ourselves and send it with an explicit content-type.
         let body = serde_json::to_vec(&payload)
             .map_err(|e| anyhow::anyhow!("failed to serialize ollama embed request: {e}"))?;
 
-        let mut request = self.agent.post(&self.embed_url).content_type("application/json");
-        if let Some(header) = &self.auth_header {
+        let mut request = agent.post(embed_url).content_type("application/json");
+        if let Some(header) = auth_header {
             request = request.header("Authorization", header);
         }
 
         // `http_status_as_error(false)` lets us read Ollama's JSON error body on 4xx/5xx instead
         // of losing the actionable reason behind ureq's bare `http status: N` error.
-        let mut response = request.send(body).map_err(|e| {
-            anyhow::anyhow!("ollama embed request to `{}` failed: {e}", self.embed_url)
-        })?;
+        let mut response = request
+            .send(body)
+            .map_err(|e| anyhow::anyhow!("ollama embed request to `{embed_url}` failed: {e}"))?;
         let status = response.status();
         let raw = response
             .body_mut()
@@ -235,7 +278,7 @@ impl OllamaEmbedder {
         if !status.is_success() {
             anyhow::bail!(
                 "ollama embed request to `{}` failed: http status {}: {}",
-                self.embed_url,
+                embed_url,
                 status.as_u16(),
                 response_excerpt(&raw)
             );
@@ -262,20 +305,36 @@ impl OllamaEmbedder {
         // slipped through would make `store_embedding` bail and ABORT the whole reconcile instead
         // of failing just that chunk, so we name the offending index and reject here.
         for (i, vector) in embeddings.iter().enumerate() {
-            if vector.len() != self.dim {
+            if vector.len() != dim {
                 anyhow::bail!(
                     "ollama embed dim mismatch: server returned a {}-dim vector at index {} but \
                      this model is configured for {} dims (server model `{}`). The selected \
                      registry model and the Ollama server model must match.",
                     vector.len(),
                     i,
-                    self.dim,
-                    self.server_model
+                    dim,
+                    server_model
                 );
             }
         }
 
         Ok(embeddings)
+    }
+
+    /// Send ONE `/api/embed` request for `texts` (already sized to `<= self.batch_size` by the
+    /// caller) and return the parsed vectors, enforcing the count + per-vector dim contracts.
+    /// Factored out of `embed_batch` so the sub-batch loop reuses the exact request/validation
+    /// logic.
+    fn embed_one_request(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {
+        Self::embed_one_request_with(
+            self.agent.clone(),
+            &self.embed_url,
+            &self.server_model,
+            self.dim,
+            self.num_ctx,
+            self.auth_header.as_deref(),
+            texts,
+        )
     }
 }
 
@@ -346,14 +405,43 @@ impl Embedder for OllamaEmbedder {
             return Ok(Vec::new());
         }
 
-        // Split into sub-batches of at most the configured `batch_size` and send one `/api/embed`
-        // per sub-batch, concatenating the results IN ORDER. This honors `[remote] batch_size`
-        // regardless of the (larger) reconcile/runtime batch the loop hands us — a user capping it
-        // for a server/proxy request-size limit is respected. The count + per-vector dim checks run
-        // per sub-batch (in `embed_one_request`).
+        // Split into sub-batches by both text count and total input chars, then send up to the
+        // configured concurrency at once. Results are joined in request/input order, so HTTP
+        // completion order cannot reorder vectors.
+        let ranges = self.sub_batch_ranges(texts);
+        if ranges.len() == 1 {
+            return self.embed_one_request(texts);
+        }
         let mut out = Vec::with_capacity(texts.len());
-        for sub_batch in texts.chunks(self.batch_size) {
-            out.extend(self.embed_one_request(sub_batch)?);
+        for window in ranges.chunks(self.concurrency) {
+            let results = std::thread::scope(|scope| {
+                let mut handles = Vec::with_capacity(window.len());
+                for &(start, end) in window {
+                    let agent = self.agent.clone();
+                    let embed_url = self.embed_url.clone();
+                    let server_model = self.server_model.clone();
+                    let auth_header = self.auth_header.clone();
+                    let dim = self.dim;
+                    let num_ctx = self.num_ctx;
+                    let sub_batch = &texts[start..end];
+                    handles.push(scope.spawn(move || {
+                        Self::embed_one_request_with(
+                            agent,
+                            &embed_url,
+                            &server_model,
+                            dim,
+                            num_ctx,
+                            auth_header.as_deref(),
+                            sub_batch,
+                        )
+                    }));
+                }
+                handles.into_iter().map(|handle| handle.join()).collect::<Result<Vec<_>, _>>()
+            })
+            .map_err(|_| anyhow::anyhow!("ollama embed worker thread panicked"))?;
+            for result in results {
+                out.extend(result?);
+            }
         }
         Ok(out)
     }
@@ -489,6 +577,8 @@ mod tests {
             gpu: None,
             num_ctx: None,
             batch_size: 256,
+            concurrency: 32,
+            max_batch_chars: 384_000,
             request_timeout_s: timeout_s,
         }
     }
@@ -531,80 +621,222 @@ mod tests {
 
     /// A multi-request HTTP stub: accepts `max_conns` connections, and for each request replies
     /// with one DIM-wide vector PER input text in that request's body (so the per-sub-batch
-    /// count check passes). Each returned vector's first component is a monotonically
-    /// increasing global counter, so the concatenated `embed_batch` output reads `[0.0, 1.0,
-    /// 2.0, ...]` IFF the sub-batches are stitched back in order. Returns the URL, the join
-    /// handle, and the shared request COUNT so the test can assert the configured cap produced
-    /// the expected number of requests.
+    /// count check passes). Each returned vector's first component is the `N` from `text N`, so
+    /// the concatenated `embed_batch` output reads `[0.0, 1.0, 2.0, ...]` iff sub-batches are
+    /// stitched back in input order. Returns the URL, the join handle, and the shared request
+    /// COUNT so the test can assert the configured cap produced the expected number of requests.
     fn spawn_counting_stub(
         max_conns: usize,
     ) -> (String, thread::JoinHandle<()>, std::sync::Arc<std::sync::atomic::AtomicUsize>) {
+        let (url, handle, requests, _) = spawn_parallel_counting_stub(max_conns, Vec::new());
+        (url, handle, requests)
+    }
+
+    fn spawn_parallel_counting_stub(
+        max_conns: usize,
+        delays: Vec<(usize, Duration)>,
+    ) -> (
+        String,
+        thread::JoinHandle<()>,
+        std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    ) {
         use std::sync::Arc;
         use std::sync::atomic::{AtomicUsize, Ordering};
 
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         let requests = Arc::new(AtomicUsize::new(0));
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
         let counter = Arc::clone(&requests);
+        let delays = Arc::new(delays);
+        let max_seen = Arc::clone(&max_in_flight);
         let handle = thread::spawn(move || {
-            let mut next_value = 0u32;
+            let mut workers = Vec::new();
             for _ in 0..max_conns {
                 let Ok((mut stream, _)) = listener.accept() else { break };
-                stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
-                // Read headers, parse Content-Length, then read EXACTLY that many body bytes. A
-                // single `read()` can return just the headers before the body arrives, so reading a
-                // fixed-size buffer once undercounts the inputs; this reads the whole request.
-                let mut raw = Vec::new();
-                let mut buf = [0u8; 8192];
-                let body = loop {
-                    let header_end = raw.windows(4).position(|w| w == b"\r\n\r\n");
-                    if let Some(end) = header_end {
-                        let headers = String::from_utf8_lossy(&raw[..end]).to_ascii_lowercase();
-                        let content_len = headers
-                            .lines()
-                            .find_map(|l| l.strip_prefix("content-length:"))
-                            .and_then(|v| v.trim().parse::<usize>().ok())
-                            .unwrap_or(0);
-                        let body_start = end + 4;
-                        while raw.len() < body_start + content_len {
-                            match stream.read(&mut buf) {
-                                Ok(0) => break,
-                                Ok(n) => raw.extend_from_slice(&buf[..n]),
-                                Err(_) => break,
-                            }
-                        }
-                        break String::from_utf8_lossy(&raw[body_start..]).to_string();
+                let counter = Arc::clone(&counter);
+                let in_flight = Arc::clone(&in_flight);
+                let max_seen = Arc::clone(&max_seen);
+                let delays = Arc::clone(&delays);
+                workers.push(thread::spawn(move || {
+                    let now = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                    raise_max(&max_seen, now);
+                    let body = read_request_body(&mut stream);
+                    let indices = request_text_indices(&body);
+                    if let Some(first) = indices.first().copied()
+                        && let Some((_, delay)) = delays.iter().find(|(idx, _)| *idx == first)
+                    {
+                        thread::sleep(*delay);
                     }
-                    match stream.read(&mut buf) {
-                        Ok(0) => break String::new(),
-                        Ok(n) => raw.extend_from_slice(&buf[..n]),
-                        Err(_) => break String::new(),
-                    }
-                };
-                // Count inputs in THIS request by the `"text N"` markers the test sends.
-                let inputs = body.matches("text ").count().max(1);
-                counter.fetch_add(1, Ordering::SeqCst);
-                let vectors: Vec<Vec<f32>> = (0..inputs)
-                    .map(|_| {
-                        let v = vec![next_value as f32; DIM];
-                        // Encode the global order in the FIRST component only.
-                        let mut v = v;
-                        v[0] = next_value as f32;
-                        next_value += 1;
-                        v
-                    })
-                    .collect();
-                let json = embeddings_json(&vectors);
-                let response = format!(
-                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: \
-                     {}\r\nConnection: close\r\n\r\n{json}",
-                    json.len()
-                );
-                let _ = stream.write_all(response.as_bytes());
-                let _ = stream.flush();
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    let vector_ids = if indices.is_empty() { vec![0] } else { indices };
+                    let vectors: Vec<Vec<f32>> = vector_ids
+                        .into_iter()
+                        .map(|idx| {
+                            let mut v = vec![idx as f32; DIM];
+                            v[0] = idx as f32;
+                            v
+                        })
+                        .collect();
+                    let json = embeddings_json(&vectors);
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: \
+                         {}\r\nConnection: close\r\n\r\n{json}",
+                        json.len()
+                    );
+                    let _ = stream.write_all(response.as_bytes());
+                    let _ = stream.flush();
+                    in_flight.fetch_sub(1, Ordering::SeqCst);
+                }));
+            }
+            for worker in workers {
+                let _ = worker.join();
             }
         });
-        (format!("http://127.0.0.1:{port}"), handle, requests)
+        (format!("http://127.0.0.1:{port}"), handle, requests, max_in_flight)
+    }
+
+    fn request_text_indices(body: &str) -> Vec<usize> {
+        body.match_indices("text ")
+            .filter_map(|(start, _)| {
+                body[start + 5..]
+                    .chars()
+                    .take_while(|c| c.is_ascii_digit())
+                    .collect::<String>()
+                    .parse::<usize>()
+                    .ok()
+            })
+            .collect()
+    }
+
+    fn raise_max(max_seen: &std::sync::atomic::AtomicUsize, value: usize) {
+        use std::sync::atomic::Ordering;
+
+        let mut current = max_seen.load(Ordering::SeqCst);
+        while value > current {
+            match max_seen.compare_exchange(current, value, Ordering::SeqCst, Ordering::SeqCst) {
+                Ok(_) => break,
+                Err(next) => current = next,
+            }
+        }
+    }
+
+    fn indexed_texts(n: usize) -> Vec<String> {
+        (0..n).map(|i| format!("text {i}")).collect()
+    }
+
+    fn first_components(vectors: &[Vec<f32>]) -> Vec<f32> {
+        vectors.iter().map(|vector| vector.first().copied().unwrap_or_default()).collect()
+    }
+
+    #[test]
+    fn embed_batch_splits_by_char_budget_as_well_as_count_budget() {
+        use std::sync::atomic::Ordering;
+
+        let (url, handle, requests) = spawn_counting_stub(2);
+        let mut cfg = config_for(&url, 5);
+        cfg.batch_size = 10;
+        cfg.max_batch_chars = 13;
+        let embedder = build(&cfg, DIM).unwrap();
+
+        let got = embedder.embed_batch(&indexed_texts(3)).expect("char-budgeted embed");
+        handle.join().unwrap();
+
+        assert_eq!(
+            requests.load(Ordering::SeqCst),
+            2,
+            "three 6-char texts at max_batch_chars 13 → 2 requests"
+        );
+        assert_eq!(first_components(&got), vec![0.0, 1.0, 2.0]);
+    }
+
+    #[test]
+    fn embed_batch_dispatches_sub_batches_concurrently() {
+        use std::sync::atomic::Ordering;
+
+        let delay = Duration::from_millis(120);
+        let all_delayed = (0..8).map(|i| (i, delay)).collect::<Vec<_>>();
+
+        let (seq_url, seq_handle, _, seq_max) =
+            spawn_parallel_counting_stub(8, all_delayed.clone());
+        let mut seq_cfg = config_for(&seq_url, 5);
+        seq_cfg.batch_size = 1;
+        seq_cfg.concurrency = 1;
+        let seq_embedder = build(&seq_cfg, DIM).unwrap();
+        let started = std::time::Instant::now();
+        seq_embedder.embed_batch(&indexed_texts(8)).expect("sequential delayed embed");
+        let sequential = started.elapsed();
+        seq_handle.join().unwrap();
+
+        let (conc_url, conc_handle, _, conc_max) = spawn_parallel_counting_stub(8, all_delayed);
+        let mut conc_cfg = config_for(&conc_url, 5);
+        conc_cfg.batch_size = 1;
+        conc_cfg.concurrency = 4;
+        let conc_embedder = build(&conc_cfg, DIM).unwrap();
+        let started = std::time::Instant::now();
+        conc_embedder.embed_batch(&indexed_texts(8)).expect("concurrent delayed embed");
+        let concurrent = started.elapsed();
+        conc_handle.join().unwrap();
+
+        assert_eq!(seq_max.load(Ordering::SeqCst), 1, "sequential config has one in flight");
+        assert!(conc_max.load(Ordering::SeqCst) > 1, "concurrent config must overlap requests");
+        assert!(
+            concurrent < sequential,
+            "concurrent dispatch should be faster than sequential: {concurrent:?} vs \
+             {sequential:?}"
+        );
+    }
+
+    #[test]
+    fn embed_batch_keeps_output_order_when_later_requests_finish_first() {
+        let (url, handle, _, max_in_flight) =
+            spawn_parallel_counting_stub(2, vec![(0, Duration::from_millis(200))]);
+        let mut cfg = config_for(&url, 5);
+        cfg.batch_size = 1;
+        cfg.concurrency = 2;
+        let embedder = build(&cfg, DIM).unwrap();
+
+        let got = embedder.embed_batch(&indexed_texts(2)).expect("out-of-order responses succeed");
+        handle.join().unwrap();
+
+        assert!(
+            max_in_flight.load(std::sync::atomic::Ordering::SeqCst) > 1,
+            "test must overlap the delayed and fast requests"
+        );
+        assert_eq!(first_components(&got), vec![0.0, 1.0]);
+    }
+
+    #[test]
+    fn embed_batch_single_over_char_budget_text_is_sent_alone() {
+        use std::sync::atomic::Ordering;
+
+        let (url, handle, requests) = spawn_counting_stub(2);
+        let mut cfg = config_for(&url, 5);
+        cfg.batch_size = 10;
+        cfg.max_batch_chars = 1;
+        let embedder = build(&cfg, DIM).unwrap();
+
+        let got = embedder.embed_batch(&indexed_texts(2)).expect("over-budget singletons embed");
+        handle.join().unwrap();
+
+        assert_eq!(requests.load(Ordering::SeqCst), 2);
+        assert_eq!(first_components(&got), vec![0.0, 1.0]);
+    }
+
+    #[test]
+    fn sub_batch_ranges_respects_exact_char_budget_boundary() {
+        let embedder = build(&config_for("http://127.0.0.1:1", 5), DIM).unwrap();
+        let mut sized = embedder;
+        sized.batch_size = 10;
+        sized.max_batch_chars = 12;
+        assert_eq!(sized.sub_batch_ranges(&indexed_texts(3)), vec![(0, 2), (2, 3)]);
+    }
+
+    #[test]
+    fn request_text_indices_finds_json_string_markers_in_order() {
+        assert_eq!(request_text_indices(r#"{"input":["text 7","text 2"]}"#), vec![7, 2]);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/providers/ollama.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/ollama.rs
@@ -213,7 +213,7 @@ impl OllamaEmbedder {
             // Clamp to >= 1: a configured 0 would panic `slice::chunks`; treat it as "one per
             // request" rather than failing construction.
             batch_size: (batch_size as usize).max(1),
-            concurrency: (concurrency as usize).max(1),
+            concurrency: RemoteEmbeddingConfig::bounded_concurrency_value(concurrency) as usize,
             max_batch_chars: max_batch_chars.max(1),
             num_ctx,
             auth_header,

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use super::*;
 use crate::config::RemoteEmbeddingConfig;
 use crate::embedding_models::{Backend, EMBEDDING_MODELS, HASH_MODEL_ID, spec};
@@ -787,7 +789,7 @@ pub(crate) fn reconcile_with_options_progress(
                 conn,
                 embedder.as_ref(),
                 &model_version,
-                &to_embed_jobs,
+                to_embed_jobs,
                 remote_config.as_deref(),
             )?;
             report.embeddings_written = report.embeddings_written.saturating_add(written);
@@ -841,92 +843,167 @@ fn remote_reconcile_batch_size(
     batch_size.max(remote_batch_size.saturating_mul(concurrency))
 }
 
+struct EmbeddingJobGroup {
+    primary: PreparedEmbeddingJob,
+    duplicates: Vec<PreparedEmbeddingJob>,
+}
+
+impl EmbeddingJobGroup {
+    fn input_text(&self) -> &str {
+        &self.primary.input_text
+    }
+
+    fn jobs(&self) -> impl Iterator<Item = &PreparedEmbeddingJob> {
+        std::iter::once(&self.primary).chain(self.duplicates.iter())
+    }
+}
+
+fn group_embedding_jobs_by_input_hash(jobs: Vec<PreparedEmbeddingJob>) -> Vec<EmbeddingJobGroup> {
+    let mut groups: Vec<EmbeddingJobGroup> = Vec::new();
+    let mut group_by_input_hash: HashMap<String, usize> = HashMap::new();
+    for job in jobs {
+        if let Some(&group_idx) = group_by_input_hash.get(&job.input_hash) {
+            groups[group_idx].duplicates.push(job);
+        } else {
+            let group_idx = groups.len();
+            group_by_input_hash.insert(job.input_hash.clone(), group_idx);
+            groups.push(EmbeddingJobGroup { primary: job, duplicates: Vec::new() });
+        }
+    }
+    groups
+}
+
 fn embed_and_write_jobs(
     conn: &Connection,
     embedder: &dyn Embedder,
     model_version: &str,
-    jobs: &[PreparedEmbeddingJob],
+    jobs: Vec<PreparedEmbeddingJob>,
     remote: Option<&RemoteEmbeddingConfig>,
 ) -> anyhow::Result<(u64, u64)> {
-    let texts = jobs.iter().map(|chunk| chunk.input_text.clone()).collect::<Vec<_>>();
+    let groups = group_embedding_jobs_by_input_hash(jobs);
+    let texts = groups.iter().map(|group| group.input_text().to_string()).collect::<Vec<_>>();
     match embedder.embed_batch(&texts) {
-        Ok(vectors) if vectors.len() == jobs.len() => {
-            write_current_embedding_batch(conn, embedder, model_version, jobs, &vectors)?;
-            Ok((u64::try_from(jobs.len()).unwrap_or(u64::MAX), 0))
+        Ok(vectors) if vectors.len() == groups.len() => {
+            let written =
+                write_current_embedding_groups(conn, embedder, model_version, &groups, &vectors)?;
+            Ok((written, 0))
         },
         Ok(vectors) => {
-            let error = vector_count_error(embedder, vectors.len(), jobs.len());
-            write_remote_scoped_or_failed(conn, embedder, model_version, jobs, remote, &error)
+            let error = vector_count_error(embedder, vectors.len(), groups.len());
+            write_remote_scoped_or_failed(conn, embedder, model_version, &groups, remote, &error)
         },
         Err(err) => {
             let error = err.to_string();
-            write_remote_scoped_or_failed(conn, embedder, model_version, jobs, remote, &error)
+            write_remote_scoped_or_failed(conn, embedder, model_version, &groups, remote, &error)
         },
     }
+}
+
+fn write_current_embedding_groups(
+    conn: &Connection,
+    embedder: &dyn Embedder,
+    model_version: &str,
+    groups: &[EmbeddingJobGroup],
+    vectors: &[Vec<f32>],
+) -> anyhow::Result<u64> {
+    let mut written = 0u64;
+    conn.execute_batch("BEGIN IMMEDIATE")?;
+    let write_result = (|| {
+        for (group, vector) in groups.iter().zip(vectors) {
+            for job in group.jobs() {
+                store_embedding(conn, embedder, model_version, job, vector)?;
+                written = written.saturating_add(1);
+            }
+        }
+        Ok(())
+    })();
+    finish_batch_transaction(conn, write_result)?;
+    Ok(written)
+}
+
+fn write_failed_embedding_groups(
+    conn: &Connection,
+    embedder: &dyn Embedder,
+    model_version: &str,
+    groups: &[EmbeddingJobGroup],
+    error: &str,
+) -> anyhow::Result<u64> {
+    let mut failed = 0u64;
+    conn.execute_batch("BEGIN IMMEDIATE")?;
+    let write_result = (|| {
+        for group in groups {
+            for job in group.jobs() {
+                store_failed_embedding(conn, embedder, model_version, job, error)?;
+                failed = failed.saturating_add(1);
+            }
+        }
+        Ok(())
+    })();
+    finish_batch_transaction(conn, write_result)?;
+    Ok(failed)
 }
 
 fn write_remote_scoped_or_failed(
     conn: &Connection,
     embedder: &dyn Embedder,
     model_version: &str,
-    jobs: &[PreparedEmbeddingJob],
+    groups: &[EmbeddingJobGroup],
     remote: Option<&RemoteEmbeddingConfig>,
     error: &str,
 ) -> anyhow::Result<(u64, u64)> {
     let Some(remote) = remote else {
-        write_failed_embedding_batch(conn, embedder, model_version, jobs, error)?;
-        return Ok((0, u64::try_from(jobs.len()).unwrap_or(u64::MAX)));
+        let failed = write_failed_embedding_groups(conn, embedder, model_version, groups, error)?;
+        return Ok((0, failed));
     };
 
     let mut written = 0u64;
     let mut failed = 0u64;
     let mut abort_remaining_error = None::<String>;
     let mut consecutive_endpoint_failures = 0usize;
-    for (start, end) in remote_request_job_ranges(jobs, remote) {
-        let scoped_jobs = &jobs[start..end];
+    for (start, end) in remote_request_group_ranges(groups, remote) {
+        let scoped_groups = &groups[start..end];
         if let Some(error) = abort_remaining_error.as_deref() {
-            write_failed_embedding_batch(conn, embedder, model_version, scoped_jobs, error)?;
-            failed = failed.saturating_add(u64::try_from(scoped_jobs.len()).unwrap_or(u64::MAX));
+            let scoped_failed =
+                write_failed_embedding_groups(conn, embedder, model_version, scoped_groups, error)?;
+            failed = failed.saturating_add(scoped_failed);
             continue;
         }
-        let texts = scoped_jobs.iter().map(|chunk| chunk.input_text.clone()).collect::<Vec<_>>();
+        let texts =
+            scoped_groups.iter().map(|group| group.input_text().to_string()).collect::<Vec<_>>();
         match embedder.embed_batch(&texts) {
-            Ok(vectors) if vectors.len() == scoped_jobs.len() => {
+            Ok(vectors) if vectors.len() == scoped_groups.len() => {
                 consecutive_endpoint_failures = 0;
-                write_current_embedding_batch(
+                let scoped_written = write_current_embedding_groups(
                     conn,
                     embedder,
                     model_version,
-                    scoped_jobs,
+                    scoped_groups,
                     &vectors,
                 )?;
-                written =
-                    written.saturating_add(u64::try_from(scoped_jobs.len()).unwrap_or(u64::MAX));
+                written = written.saturating_add(scoped_written);
             },
             Ok(vectors) => {
                 consecutive_endpoint_failures = 0;
-                let scoped_error = vector_count_error(embedder, vectors.len(), scoped_jobs.len());
-                write_failed_embedding_batch(
+                let scoped_error = vector_count_error(embedder, vectors.len(), scoped_groups.len());
+                let scoped_failed = write_failed_embedding_groups(
                     conn,
                     embedder,
                     model_version,
-                    scoped_jobs,
+                    scoped_groups,
                     &scoped_error,
                 )?;
-                failed =
-                    failed.saturating_add(u64::try_from(scoped_jobs.len()).unwrap_or(u64::MAX));
+                failed = failed.saturating_add(scoped_failed);
             },
             Err(err) => {
                 let scoped_error = err.to_string();
-                write_failed_embedding_batch(
+                let scoped_failed = write_failed_embedding_groups(
                     conn,
                     embedder,
                     model_version,
-                    scoped_jobs,
+                    scoped_groups,
                     &scoped_error,
                 )?;
-                failed =
-                    failed.saturating_add(u64::try_from(scoped_jobs.len()).unwrap_or(u64::MAX));
+                failed = failed.saturating_add(scoped_failed);
                 match classify_remote_scoped_retry_error(&scoped_error) {
                     RemoteScopedRetryError::AbortImmediately => {
                         abort_remaining_error = Some(scoped_error);
@@ -982,8 +1059,8 @@ fn classify_remote_scoped_retry_error(error: &str) -> RemoteScopedRetryError {
     RemoteScopedRetryError::Other
 }
 
-fn remote_request_job_ranges(
-    jobs: &[PreparedEmbeddingJob],
+fn remote_request_group_ranges(
+    groups: &[EmbeddingJobGroup],
     remote: &RemoteEmbeddingConfig,
 ) -> Vec<(usize, usize)> {
     let batch_size = (remote.batch_size as usize).max(1);
@@ -991,8 +1068,8 @@ fn remote_request_job_ranges(
     let mut ranges = Vec::new();
     let mut start = 0usize;
     let mut chars = 0usize;
-    for (idx, job) in jobs.iter().enumerate() {
-        let text_chars = job.input_text.chars().count();
+    for (idx, group) in groups.iter().enumerate() {
+        let text_chars = group.input_text().chars().count();
         let count_full = idx.saturating_sub(start) >= batch_size;
         let chars_full = idx > start && chars.saturating_add(text_chars) > max_batch_chars;
         if count_full || chars_full {
@@ -1002,8 +1079,8 @@ fn remote_request_job_ranges(
         }
         chars = chars.saturating_add(text_chars);
     }
-    if start < jobs.len() {
-        ranges.push((start, jobs.len()));
+    if start < groups.len() {
+        ranges.push((start, groups.len()));
     }
     ranges
 }
@@ -1270,8 +1347,8 @@ mod manifest_idempotence_tests {
 mod freshness_version_tests {
     use std::io::{Read, Write};
     use std::net::{TcpListener, TcpStream};
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
     use std::thread;
     use std::time::{Duration, Instant};
 
@@ -1348,6 +1425,28 @@ mod freshness_version_tests {
             if call < self.failures {
                 anyhow::bail!("request timed out");
             }
+            Ok(vec![vec![0.1; self.dim]; texts.len()])
+        }
+    }
+
+    struct RecordingEmbedder {
+        calls: AtomicUsize,
+        request_sizes: Mutex<Vec<usize>>,
+        dim: usize,
+    }
+
+    impl Embedder for RecordingEmbedder {
+        fn model_id(&self) -> &str {
+            FASTEMBED_MODEL_ID
+        }
+
+        fn dim(&self) -> usize {
+            self.dim
+        }
+
+        fn embed_batch(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.request_sizes.lock().unwrap().push(texts.len());
             Ok(vec![vec![0.1; self.dim]; texts.len()])
         }
     }
@@ -1791,12 +1890,13 @@ mod freshness_version_tests {
             dim: spec(FASTEMBED_MODEL_ID).unwrap().dim,
             failures: 1,
         };
+        let groups = group_embedding_jobs_by_input_hash(jobs);
 
         let (written, failed) = write_remote_scoped_or_failed(
             &conn,
             &embedder,
             "test-version",
-            &jobs,
+            &groups,
             Some(&remote),
             "initial failure",
         )
@@ -1842,12 +1942,13 @@ mod freshness_version_tests {
             dim: spec(FASTEMBED_MODEL_ID).unwrap().dim,
             failures: usize::MAX,
         };
+        let groups = group_embedding_jobs_by_input_hash(jobs);
 
         let (written, failed) = write_remote_scoped_or_failed(
             &conn,
             &embedder,
             "test-version",
-            &jobs,
+            &groups,
             Some(&remote),
             "initial failure",
         )
@@ -1860,6 +1961,51 @@ mod freshness_version_tests {
             REMOTE_SCOPED_RETRY_CONSECUTIVE_ENDPOINT_FAILURE_LIMIT,
             "repeated timeout-like failures should stop before serially retrying every range"
         );
+    }
+
+    #[test]
+    fn embed_and_write_jobs_reuses_same_window_duplicate_input_hashes() {
+        let conn = schema_conn();
+        let first_chunk_id = seed_embedding_chunk(&conn, 0);
+        let duplicate_chunk_id = seed_embedding_chunk(&conn, 1);
+        let first_job = prepared_job(first_chunk_id, 0);
+        let mut duplicate_job = prepared_job(duplicate_chunk_id, 1);
+        duplicate_job.input_hash = first_job.input_hash.clone();
+        duplicate_job.input_text = first_job.input_text.clone();
+        let embedder = RecordingEmbedder {
+            calls: AtomicUsize::new(0),
+            request_sizes: Mutex::new(Vec::new()),
+            dim: spec(FASTEMBED_MODEL_ID).unwrap().dim,
+        };
+        let mut remote = remote_at("http://localhost:11434");
+        remote.batch_size = 1;
+        remote.concurrency = 4;
+
+        let (written, failed) = embed_and_write_jobs(
+            &conn,
+            &embedder,
+            "test-version",
+            vec![first_job, duplicate_job],
+            Some(&remote),
+        )
+        .unwrap();
+
+        assert_eq!(written, 2);
+        assert_eq!(failed, 0);
+        assert_eq!(embedder.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            *embedder.request_sizes.lock().unwrap(),
+            vec![1],
+            "duplicate input_hashes in one reconcile window should issue one embed text"
+        );
+        let current_rows: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM chunk_embeddings WHERE status = 'Current'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(current_rows, 2);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -881,6 +881,7 @@ fn write_remote_scoped_or_failed(
     let mut written = 0u64;
     let mut failed = 0u64;
     let mut abort_remaining_error = None::<String>;
+    let mut consecutive_endpoint_failures = 0usize;
     for (start, end) in remote_request_job_ranges(jobs, remote) {
         let scoped_jobs = &jobs[start..end];
         if let Some(error) = abort_remaining_error.as_deref() {
@@ -891,6 +892,7 @@ fn write_remote_scoped_or_failed(
         let texts = scoped_jobs.iter().map(|chunk| chunk.input_text.clone()).collect::<Vec<_>>();
         match embedder.embed_batch(&texts) {
             Ok(vectors) if vectors.len() == scoped_jobs.len() => {
+                consecutive_endpoint_failures = 0;
                 write_current_embedding_batch(
                     conn,
                     embedder,
@@ -902,6 +904,7 @@ fn write_remote_scoped_or_failed(
                     written.saturating_add(u64::try_from(scoped_jobs.len()).unwrap_or(u64::MAX));
             },
             Ok(vectors) => {
+                consecutive_endpoint_failures = 0;
                 let scoped_error = vector_count_error(embedder, vectors.len(), scoped_jobs.len());
                 write_failed_embedding_batch(
                     conn,
@@ -924,8 +927,22 @@ fn write_remote_scoped_or_failed(
                 )?;
                 failed =
                     failed.saturating_add(u64::try_from(scoped_jobs.len()).unwrap_or(u64::MAX));
-                if remote_error_should_abort_scoped_retries(&scoped_error) {
-                    abort_remaining_error = Some(scoped_error);
+                match classify_remote_scoped_retry_error(&scoped_error) {
+                    RemoteScopedRetryError::AbortImmediately => {
+                        abort_remaining_error = Some(scoped_error);
+                    },
+                    RemoteScopedRetryError::EndpointFailure => {
+                        consecutive_endpoint_failures =
+                            consecutive_endpoint_failures.saturating_add(1);
+                        if consecutive_endpoint_failures
+                            >= REMOTE_SCOPED_RETRY_CONSECUTIVE_ENDPOINT_FAILURE_LIMIT
+                        {
+                            abort_remaining_error = Some(scoped_error);
+                        }
+                    },
+                    RemoteScopedRetryError::Other => {
+                        consecutive_endpoint_failures = 0;
+                    },
                 }
             },
         }
@@ -937,16 +954,32 @@ fn vector_count_error(embedder: &dyn Embedder, got: usize, expected: usize) -> S
     format!("embedder {} returned {} vectors for {} texts", embedder.model_id(), got, expected)
 }
 
-fn remote_error_should_abort_scoped_retries(error: &str) -> bool {
+const REMOTE_SCOPED_RETRY_CONSECUTIVE_ENDPOINT_FAILURE_LIMIT: usize = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RemoteScopedRetryError {
+    AbortImmediately,
+    EndpointFailure,
+    Other,
+}
+
+fn classify_remote_scoped_retry_error(error: &str) -> RemoteScopedRetryError {
     let lower = error.to_ascii_lowercase();
-    lower.contains("timed out")
-        || lower.contains("timeout")
-        || lower.contains("connection refused")
-        || lower.contains("connection reset")
-        || lower.contains("connection closed")
+    if lower.contains("connection refused")
         || lower.contains("failed to connect")
         || lower.contains("connect error")
+    {
+        return RemoteScopedRetryError::AbortImmediately;
+    }
+    if lower.contains("timed out")
+        || lower.contains("timeout")
+        || lower.contains("connection reset")
+        || lower.contains("connection closed")
         || lower.contains("http status 504")
+    {
+        return RemoteScopedRetryError::EndpointFailure;
+    }
+    RemoteScopedRetryError::Other
 }
 
 fn remote_request_job_ranges(
@@ -1295,6 +1328,30 @@ mod freshness_version_tests {
         }
     }
 
+    struct TimeoutsThenOkEmbedder {
+        calls: AtomicUsize,
+        dim: usize,
+        failures: usize,
+    }
+
+    impl Embedder for TimeoutsThenOkEmbedder {
+        fn model_id(&self) -> &str {
+            FASTEMBED_MODEL_ID
+        }
+
+        fn dim(&self) -> usize {
+            self.dim
+        }
+
+        fn embed_batch(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            if call < self.failures {
+                anyhow::bail!("request timed out");
+            }
+            Ok(vec![vec![0.1; self.dim]; texts.len()])
+        }
+    }
+
     fn read_request_body(stream: &mut TcpStream) -> String {
         stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
         let mut raw = Vec::new();
@@ -1461,7 +1518,7 @@ mod freshness_version_tests {
         (format!("http://127.0.0.1:{port}"), handle)
     }
 
-    fn seed_embedding_chunk(conn: &Connection, i: i64) {
+    fn seed_embedding_chunk(conn: &Connection, i: i64) -> i64 {
         conn.execute(
             "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
              VALUES (?1, 'rust', 'source', ?2, 0, 0)",
@@ -1490,6 +1547,22 @@ mod freshness_version_tests {
         .unwrap();
         let chunk_id = conn.last_insert_rowid();
         crate::index::chunk_text_store::seed_chunk_text(conn, chunk_id, &text).unwrap();
+        chunk_id
+    }
+
+    fn prepared_job(chunk_id: i64, i: i64) -> PreparedEmbeddingJob {
+        let input_text = format!("path: src/file_{i}.rs\n\npub fn item_{i}() {{}}");
+        PreparedEmbeddingJob {
+            id: chunk_id,
+            text_hash: format!("hash-{i}"),
+            input_hash: format!("input-hash-{i}"),
+            input_chars: input_text.chars().count(),
+            input_text,
+            input_truncated: false,
+            policy: "Embed".to_string(),
+            priority: 0,
+            reason: ReconcileReason::Missing,
+        }
     }
 
     fn active_version(conn: &Connection) -> String {
@@ -1670,20 +1743,123 @@ mod freshness_version_tests {
     }
 
     #[test]
-    fn remote_scoped_retry_aborts_on_endpoint_level_errors_only() {
+    fn remote_scoped_retry_classifies_endpoint_failures() {
+        for error in ["connection refused", "failed to connect", "connect error"] {
+            assert_eq!(
+                classify_remote_scoped_retry_error(error),
+                RemoteScopedRetryError::AbortImmediately,
+                "{error}"
+            );
+        }
         for error in [
             "request timed out",
             "timeout",
-            "connection refused",
-            "failed to connect",
+            "connection reset",
+            "connection closed",
             "http status 504: gateway timeout",
         ] {
-            assert!(remote_error_should_abort_scoped_retries(error), "{error}");
+            assert_eq!(
+                classify_remote_scoped_retry_error(error),
+                RemoteScopedRetryError::EndpointFailure,
+                "{error}"
+            );
         }
-        assert!(!remote_error_should_abort_scoped_retries("http status 500: transient"));
-        assert!(!remote_error_should_abort_scoped_retries(
-            "embedder model returned 2 vectors for 3 texts"
-        ));
+        for error in ["http status 500: transient", "embedder model returned 2 vectors for 3 texts"]
+        {
+            assert_eq!(
+                classify_remote_scoped_retry_error(error),
+                RemoteScopedRetryError::Other,
+                "{error}"
+            );
+        }
+    }
+
+    #[test]
+    fn remote_scoped_retry_keeps_later_ranges_after_one_timeout() {
+        let conn = schema_conn();
+        let jobs = (0..3)
+            .map(|i| {
+                let chunk_id = seed_embedding_chunk(&conn, i);
+                prepared_job(chunk_id, i)
+            })
+            .collect::<Vec<_>>();
+        let mut remote = remote_at("http://localhost:11434");
+        remote.batch_size = 1;
+        remote.max_batch_chars = usize::MAX;
+        let embedder = TimeoutsThenOkEmbedder {
+            calls: AtomicUsize::new(0),
+            dim: spec(FASTEMBED_MODEL_ID).unwrap().dim,
+            failures: 1,
+        };
+
+        let (written, failed) = write_remote_scoped_or_failed(
+            &conn,
+            &embedder,
+            "test-version",
+            &jobs,
+            Some(&remote),
+            "initial failure",
+        )
+        .unwrap();
+
+        assert_eq!(written, 2);
+        assert_eq!(failed, 1);
+        assert_eq!(
+            embedder.calls.load(Ordering::SeqCst),
+            3,
+            "a single timeout should not skip later request ranges"
+        );
+        let failed_rows: i64 = conn
+            .query_row("SELECT count(*) FROM chunk_embeddings WHERE status = 'Failed'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        let current_rows: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM chunk_embeddings WHERE status = 'Current'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(failed_rows, 1);
+        assert_eq!(current_rows, 2);
+    }
+
+    #[test]
+    fn remote_scoped_retry_aborts_after_repeated_endpoint_failures() {
+        let conn = schema_conn();
+        let jobs = (0..4)
+            .map(|i| {
+                let chunk_id = seed_embedding_chunk(&conn, i);
+                prepared_job(chunk_id, i)
+            })
+            .collect::<Vec<_>>();
+        let mut remote = remote_at("http://localhost:11434");
+        remote.batch_size = 1;
+        remote.max_batch_chars = usize::MAX;
+        let embedder = TimeoutsThenOkEmbedder {
+            calls: AtomicUsize::new(0),
+            dim: spec(FASTEMBED_MODEL_ID).unwrap().dim,
+            failures: usize::MAX,
+        };
+
+        let (written, failed) = write_remote_scoped_or_failed(
+            &conn,
+            &embedder,
+            "test-version",
+            &jobs,
+            Some(&remote),
+            "initial failure",
+        )
+        .unwrap();
+
+        assert_eq!(written, 0);
+        assert_eq!(failed, 4);
+        assert_eq!(
+            embedder.calls.load(Ordering::SeqCst),
+            REMOTE_SCOPED_RETRY_CONSECUTIVE_ENDPOINT_FAILURE_LIMIT,
+            "repeated timeout-like failures should stop before serially retrying every range"
+        );
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -524,7 +524,7 @@ pub(crate) fn reconcile_with_options_progress(
         max_embedding_chars,
     };
     let selection_batch_size = active_remote_config(conn)?
-        .map(|remote| remote_reconcile_batch_size(&remote, batch_size))
+        .map(|remote| remote_reconcile_batch_size(&remote, batch_size, options.max_seconds))
         .unwrap_or(batch_size);
 
     // The chunk-embed embedder. For an EPHEMERAL active model on a provisioning reconcile, this
@@ -843,7 +843,14 @@ pub(crate) fn reconcile_with_options_progress(
     Ok(report)
 }
 
-fn remote_reconcile_batch_size(remote: &RemoteEmbeddingConfig, batch_size: usize) -> usize {
+fn remote_reconcile_batch_size(
+    remote: &RemoteEmbeddingConfig,
+    batch_size: usize,
+    max_seconds: Option<u64>,
+) -> usize {
+    if max_seconds.is_some() {
+        return batch_size.max(1);
+    }
     let remote_batch_size = (remote.batch_size as usize).max(1);
     let concurrency = (remote.concurrency as usize).max(1);
     batch_size.max(remote_batch_size.saturating_mul(concurrency))
@@ -1374,6 +1381,16 @@ mod freshness_version_tests {
             max_in_flight.load(Ordering::SeqCst) > 1,
             "remote reconcile should hand multiple ordered texts to one concurrent embedder call"
         );
+    }
+
+    #[test]
+    fn remote_reconcile_keeps_caller_batch_size_when_time_bounded() {
+        let mut remote = remote_at("http://localhost:11434");
+        remote.batch_size = 256;
+        remote.concurrency = 32;
+
+        assert_eq!(remote_reconcile_batch_size(&remote, 8, Some(1)), 8);
+        assert_eq!(remote_reconcile_batch_size(&remote, 8, None), 8192);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -523,10 +523,6 @@ pub(crate) fn reconcile_with_options_progress(
         dim: embedding_dim,
         max_embedding_chars,
     };
-    let selection_batch_size = active_remote_config(conn)?
-        .map(|remote| remote_reconcile_batch_size(&remote, batch_size, options.max_seconds))
-        .unwrap_or(batch_size);
-
     // The chunk-embed embedder. For an EPHEMERAL active model on a provisioning reconcile, this
     // PROVISIONS a cookbook box (held by `_provisioned` for the whole loop — its `Drop` tears the
     // box down on success/error/panic) — but only AFTER confirming there's pending work, so a no-op
@@ -643,8 +639,8 @@ pub(crate) fn reconcile_with_options_progress(
 
     // `_provisioned` MUST outlive the embed loop: its `Drop` is the box teardown. Bound at function
     // scope here (not inside the match) so it lives until the function returns.
-    let (embedder, _provisioned) = match acquired {
-        ChunkEmbedder::Ready { embedder, provisioned } => (embedder, provisioned),
+    let (embedder, _provisioned, remote_config) = match acquired {
+        ChunkEmbedder::Ready { embedder, provisioned, remote } => (embedder, provisioned, remote),
         ChunkEmbedder::NotReady(err) => {
             // Surface the cause (e.g. a cookbook provisioning failure with its captured stderr) so
             // a remote outage isn't swallowed; the report keeps the actionable "install" hint AND
@@ -674,6 +670,10 @@ pub(crate) fn reconcile_with_options_progress(
             unreachable!("SkipEphemeral / NoEphemeralWork handled before the policy scan")
         },
     };
+    let selection_batch_size = remote_config
+        .as_deref()
+        .map(|remote| remote_reconcile_batch_size(remote, batch_size, options.max_seconds))
+        .unwrap_or(batch_size);
     let mut progress_total_chunks = estimated_reconcile_jobs(conn, &scan, &options)?;
     progress(ReconcileProgress::Started {
         model_id: active_model_id.clone(),
@@ -766,47 +766,15 @@ pub(crate) fn reconcile_with_options_progress(
         }
 
         if !to_embed_jobs.is_empty() {
-            let texts =
-                to_embed_jobs.iter().map(|chunk| chunk.input_text.clone()).collect::<Vec<_>>();
-            match embedder.embed_batch(&texts) {
-                Ok(vectors) if vectors.len() == to_embed_jobs.len() => {
-                    write_current_embedding_batch(
-                        conn,
-                        embedder.as_ref(),
-                        &model_version,
-                        &to_embed_jobs,
-                        &vectors,
-                    )?;
-                    report.embeddings_written +=
-                        u64::try_from(to_embed_jobs.len()).unwrap_or(u64::MAX);
-                },
-                Ok(vectors) => {
-                    let error = format!(
-                        "embedder {} returned {} vectors for {} texts",
-                        embedder.model_id(),
-                        vectors.len(),
-                        to_embed_jobs.len()
-                    );
-                    write_failed_embedding_batch(
-                        conn,
-                        embedder.as_ref(),
-                        &model_version,
-                        &to_embed_jobs,
-                        &error,
-                    )?;
-                    report.failed_chunks += u64::try_from(to_embed_jobs.len()).unwrap_or(u64::MAX);
-                },
-                Err(err) => {
-                    write_failed_embedding_batch(
-                        conn,
-                        embedder.as_ref(),
-                        &model_version,
-                        &to_embed_jobs,
-                        &err.to_string(),
-                    )?;
-                    report.failed_chunks += u64::try_from(to_embed_jobs.len()).unwrap_or(u64::MAX);
-                },
-            }
+            let (written, failed) = embed_and_write_jobs(
+                conn,
+                embedder.as_ref(),
+                &model_version,
+                &to_embed_jobs,
+                remote_config.as_deref(),
+            )?;
+            report.embeddings_written = report.embeddings_written.saturating_add(written);
+            report.failed_chunks = report.failed_chunks.saturating_add(failed);
         }
         report.processed_chunks = report
             .embeddings_written
@@ -854,6 +822,118 @@ fn remote_reconcile_batch_size(
     let remote_batch_size = (remote.batch_size as usize).max(1);
     let concurrency = (remote.concurrency as usize).max(1);
     batch_size.max(remote_batch_size.saturating_mul(concurrency))
+}
+
+fn embed_and_write_jobs(
+    conn: &Connection,
+    embedder: &dyn Embedder,
+    model_version: &str,
+    jobs: &[PreparedEmbeddingJob],
+    remote: Option<&RemoteEmbeddingConfig>,
+) -> anyhow::Result<(u64, u64)> {
+    let texts = jobs.iter().map(|chunk| chunk.input_text.clone()).collect::<Vec<_>>();
+    match embedder.embed_batch(&texts) {
+        Ok(vectors) if vectors.len() == jobs.len() => {
+            write_current_embedding_batch(conn, embedder, model_version, jobs, &vectors)?;
+            Ok((u64::try_from(jobs.len()).unwrap_or(u64::MAX), 0))
+        },
+        Ok(vectors) => {
+            let error = vector_count_error(embedder, vectors.len(), jobs.len());
+            write_remote_scoped_or_failed(conn, embedder, model_version, jobs, remote, &error)
+        },
+        Err(err) => {
+            let error = err.to_string();
+            write_remote_scoped_or_failed(conn, embedder, model_version, jobs, remote, &error)
+        },
+    }
+}
+
+fn write_remote_scoped_or_failed(
+    conn: &Connection,
+    embedder: &dyn Embedder,
+    model_version: &str,
+    jobs: &[PreparedEmbeddingJob],
+    remote: Option<&RemoteEmbeddingConfig>,
+    error: &str,
+) -> anyhow::Result<(u64, u64)> {
+    let Some(remote) = remote else {
+        write_failed_embedding_batch(conn, embedder, model_version, jobs, error)?;
+        return Ok((0, u64::try_from(jobs.len()).unwrap_or(u64::MAX)));
+    };
+
+    let mut written = 0u64;
+    let mut failed = 0u64;
+    for (start, end) in remote_request_job_ranges(jobs, remote) {
+        let scoped_jobs = &jobs[start..end];
+        let texts = scoped_jobs.iter().map(|chunk| chunk.input_text.clone()).collect::<Vec<_>>();
+        match embedder.embed_batch(&texts) {
+            Ok(vectors) if vectors.len() == scoped_jobs.len() => {
+                write_current_embedding_batch(
+                    conn,
+                    embedder,
+                    model_version,
+                    scoped_jobs,
+                    &vectors,
+                )?;
+                written =
+                    written.saturating_add(u64::try_from(scoped_jobs.len()).unwrap_or(u64::MAX));
+            },
+            Ok(vectors) => {
+                let scoped_error = vector_count_error(embedder, vectors.len(), scoped_jobs.len());
+                write_failed_embedding_batch(
+                    conn,
+                    embedder,
+                    model_version,
+                    scoped_jobs,
+                    &scoped_error,
+                )?;
+                failed =
+                    failed.saturating_add(u64::try_from(scoped_jobs.len()).unwrap_or(u64::MAX));
+            },
+            Err(err) => {
+                write_failed_embedding_batch(
+                    conn,
+                    embedder,
+                    model_version,
+                    scoped_jobs,
+                    &err.to_string(),
+                )?;
+                failed =
+                    failed.saturating_add(u64::try_from(scoped_jobs.len()).unwrap_or(u64::MAX));
+            },
+        }
+    }
+    Ok((written, failed))
+}
+
+fn vector_count_error(embedder: &dyn Embedder, got: usize, expected: usize) -> String {
+    format!("embedder {} returned {} vectors for {} texts", embedder.model_id(), got, expected)
+}
+
+fn remote_request_job_ranges(
+    jobs: &[PreparedEmbeddingJob],
+    remote: &RemoteEmbeddingConfig,
+) -> Vec<(usize, usize)> {
+    let batch_size = (remote.batch_size as usize).max(1);
+    let max_batch_chars = remote.max_batch_chars.max(1);
+    let mut ranges = Vec::new();
+    let mut start = 0usize;
+    let mut chars = 0usize;
+    for (idx, job) in jobs.iter().enumerate() {
+        let text_chars = job.input_text.chars().count();
+        let count_full = idx.saturating_sub(start) >= batch_size;
+        let chars_full = idx > start && chars.saturating_add(text_chars) > max_batch_chars;
+        if count_full || chars_full {
+            ranges.push((start, idx));
+            start = idx;
+            chars = 0;
+        }
+        chars = chars.saturating_add(text_chars);
+    }
+    if start < jobs.len() {
+        ranges.push((start, jobs.len()));
+    }
+    ranges
 }
 
 pub(crate) fn embedding_policy_skip_summary(
@@ -1279,6 +1359,69 @@ mod freshness_version_tests {
         (format!("http://127.0.0.1:{port}"), handle, max_in_flight)
     }
 
+    fn spawn_selective_failure_embed_stub(
+        dim: usize,
+        max_conns: usize,
+        fail_marker: &'static str,
+    ) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handle = thread::spawn(move || {
+            let mut workers = Vec::new();
+            let mut accepted = 0usize;
+            let started = Instant::now();
+            let mut last_accept = started;
+            while accepted < max_conns
+                && started.elapsed() < Duration::from_secs(5)
+                && (accepted == 0 || last_accept.elapsed() < Duration::from_millis(500))
+            {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        accepted += 1;
+                        last_accept = Instant::now();
+                        workers.push(thread::spawn(move || {
+                            let body = read_request_body(&mut stream);
+                            let response = if body.contains(fail_marker) {
+                                let response_body = "{\"error\":\"transient\"}";
+                                format!(
+                                    "HTTP/1.1 500 Internal Server Error\r\nContent-Type: \
+                                     application/json\r\nContent-Length: {}\r\nConnection: \
+                                     close\r\n\r\n{response_body}",
+                                    response_body.len()
+                                )
+                            } else {
+                                let inputs = body.matches("path: ").count().max(1);
+                                let vector = vec!["0.1"; dim].join(",");
+                                let rows = (0..inputs)
+                                    .map(|_| format!("[{vector}]"))
+                                    .collect::<Vec<_>>()
+                                    .join(",");
+                                let response_body = format!("{{\"embeddings\":[{rows}]}}");
+                                format!(
+                                    "HTTP/1.1 200 OK\r\nContent-Type: \
+                                     application/json\r\nContent-Length: {}\r\nConnection: \
+                                     close\r\n\r\n{response_body}",
+                                    response_body.len()
+                                )
+                            };
+                            let _ = stream.write_all(response.as_bytes());
+                            let _ = stream.flush();
+                        }));
+                    },
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    },
+                    Err(_) => break,
+                }
+            }
+            for worker in workers {
+                let _ = worker.join();
+            }
+        });
+        (format!("http://127.0.0.1:{port}"), handle)
+    }
+
     fn seed_embedding_chunk(conn: &Connection, i: i64) {
         conn.execute(
             "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
@@ -1384,6 +1527,60 @@ mod freshness_version_tests {
     }
 
     #[test]
+    fn remote_reconcile_scopes_request_failure_to_remote_request_batch() {
+        let conn = schema_conn();
+        let spec = spec(FASTEMBED_MODEL_ID).unwrap();
+        for i in 0..4 {
+            seed_embedding_chunk(&conn, i);
+        }
+        let (url, handle) = spawn_selective_failure_embed_stub(spec.dim, 8, "item_2");
+        let mut remote = remote_at(&url);
+        remote.batch_size = 1;
+        remote.concurrency = 4;
+        set_active_remote_config(&conn, &remote).unwrap();
+        conn.execute(
+            "UPDATE ai_models
+             SET installed = 1, disabled = 0, status = 'Ready', embedding_dim = ?2, runtime = \
+             'ollama'
+             WHERE model_id = ?1",
+            params![FASTEMBED_MODEL_ID, i64::try_from(spec.dim).unwrap()],
+        )
+        .unwrap();
+        set_meta(&conn, ACTIVE_EMBEDDING_MODEL_META, FASTEMBED_MODEL_ID).unwrap();
+        set_reconcile_meta(
+            &conn,
+            ACTIVE_EMBEDDING_MODEL_VERSION_META,
+            &remote_freshness_version(spec, &remote),
+        )
+        .unwrap();
+
+        let report = reconcile_with_options_progress(
+            &conn,
+            ReconcileOptions { batch_size: Some(1), ..ReconcileOptions::default() },
+            |_| {},
+        )
+        .unwrap();
+        handle.join().unwrap();
+
+        assert_eq!(report.embeddings_written, 3);
+        assert_eq!(report.failed_chunks, 1);
+        let failed_rows: i64 = conn
+            .query_row("SELECT count(*) FROM chunk_embeddings WHERE status = 'Failed'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        let current_rows: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM chunk_embeddings WHERE status = 'Current'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(failed_rows, 1);
+        assert_eq!(current_rows, 3);
+    }
+
+    #[test]
     fn remote_reconcile_keeps_caller_batch_size_when_time_bounded() {
         let mut remote = remote_at("http://localhost:11434");
         remote.batch_size = 256;
@@ -1391,6 +1588,36 @@ mod freshness_version_tests {
 
         assert_eq!(remote_reconcile_batch_size(&remote, 8, Some(1)), 8);
         assert_eq!(remote_reconcile_batch_size(&remote, 8, None), 8192);
+    }
+
+    #[test]
+    fn remote_reconcile_malformed_remote_meta_finishes_blocked_attempt() {
+        let conn = schema_conn();
+        let spec = spec(FASTEMBED_MODEL_ID).unwrap();
+        conn.execute(
+            "UPDATE ai_models
+             SET installed = 1, disabled = 0, status = 'Ready', embedding_dim = ?2, runtime = \
+             'ollama'
+             WHERE model_id = ?1",
+            params![FASTEMBED_MODEL_ID, i64::try_from(spec.dim).unwrap()],
+        )
+        .unwrap();
+        set_meta(&conn, ACTIVE_EMBEDDING_MODEL_META, FASTEMBED_MODEL_ID).unwrap();
+        set_reconcile_meta(&conn, ACTIVE_EMBEDDING_MODEL_VERSION_META, spec.version).unwrap();
+        set_meta(&conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META, "{not valid json").unwrap();
+
+        let report =
+            reconcile_with_options_progress(&conn, ReconcileOptions::default(), |_| {}).unwrap();
+
+        assert_eq!(report.status, "Blocked");
+        let attempt_status: String = conn
+            .query_row(
+                "SELECT status FROM reconcile_attempts ORDER BY id DESC LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(attempt_status, "Blocked");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -523,6 +523,9 @@ pub(crate) fn reconcile_with_options_progress(
         dim: embedding_dim,
         max_embedding_chars,
     };
+    let selection_batch_size = active_remote_config(conn)?
+        .map(|remote| remote_reconcile_batch_size(&remote, batch_size))
+        .unwrap_or(batch_size);
 
     // The chunk-embed embedder. For an EPHEMERAL active model on a provisioning reconcile, this
     // PROVISIONS a cookbook box (held by `_provisioned` for the whole loop — its `Drop` tears the
@@ -708,9 +711,9 @@ pub(crate) fn reconcile_with_options_progress(
             break;
         }
         let batch_limit = remaining
-            .map(|value| value.min(u64::try_from(batch_size).unwrap_or(u64::MAX)))
+            .map(|value| value.min(u64::try_from(selection_batch_size).unwrap_or(u64::MAX)))
             .and_then(|value| usize::try_from(value).ok())
-            .unwrap_or(batch_size);
+            .unwrap_or(selection_batch_size);
         // Pull the next batch of unprocessed candidate ids.
         let mut batch_ids = Vec::with_capacity(batch_limit);
         while cursor < candidate_ids.len() && batch_ids.len() < batch_limit {
@@ -838,6 +841,12 @@ pub(crate) fn reconcile_with_options_progress(
         blocked_chunks: report.blocked_chunks,
     });
     Ok(report)
+}
+
+fn remote_reconcile_batch_size(remote: &RemoteEmbeddingConfig, batch_size: usize) -> usize {
+    let remote_batch_size = (remote.batch_size as usize).max(1);
+    let concurrency = (remote.concurrency as usize).max(1);
+    batch_size.max(remote_batch_size.saturating_mul(concurrency))
 }
 
 pub(crate) fn embedding_policy_skip_summary(
@@ -1101,8 +1110,11 @@ mod manifest_idempotence_tests {
 #[cfg(test)]
 mod freshness_version_tests {
     use std::io::{Read, Write};
-    use std::net::TcpListener;
+    use std::net::{TcpListener, TcpStream};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::thread;
+    use std::time::{Duration, Instant};
 
     use super::*;
     use crate::embedding_models::{FASTEMBED_MODEL_ID, HASH_MODEL_ID};
@@ -1151,8 +1163,144 @@ mod freshness_version_tests {
             gpu: None,
             num_ctx: None,
             batch_size: 256,
+            concurrency: 32,
+            max_batch_chars: 384_000,
             request_timeout_s: 5,
         }
+    }
+
+    fn read_request_body(stream: &mut TcpStream) -> String {
+        stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+        let mut raw = Vec::new();
+        let mut buf = [0u8; 8192];
+        loop {
+            let header_end = raw.windows(4).position(|w| w == b"\r\n\r\n");
+            if let Some(end) = header_end {
+                let headers = String::from_utf8_lossy(&raw[..end]).to_ascii_lowercase();
+                let content_len = headers
+                    .lines()
+                    .find_map(|l| l.strip_prefix("content-length:"))
+                    .and_then(|v| v.trim().parse::<usize>().ok())
+                    .unwrap_or(0);
+                let body_start = end + 4;
+                while raw.len() < body_start + content_len {
+                    match stream.read(&mut buf) {
+                        Ok(0) => break,
+                        Ok(n) => raw.extend_from_slice(&buf[..n]),
+                        Err(_) => break,
+                    }
+                }
+                return String::from_utf8_lossy(&raw[body_start..body_start + content_len])
+                    .to_string();
+            }
+            match stream.read(&mut buf) {
+                Ok(0) | Err(_) => return String::new(),
+                Ok(n) => raw.extend_from_slice(&buf[..n]),
+            }
+        }
+    }
+
+    fn raise_max(max_seen: &AtomicUsize, value: usize) {
+        let mut current = max_seen.load(Ordering::SeqCst);
+        while value > current {
+            match max_seen.compare_exchange(current, value, Ordering::SeqCst, Ordering::SeqCst) {
+                Ok(_) => break,
+                Err(next) => current = next,
+            }
+        }
+    }
+
+    fn spawn_reconcile_embed_stub(
+        dim: usize,
+        max_conns: usize,
+        delay: Duration,
+    ) -> (String, thread::JoinHandle<()>, Arc<AtomicUsize>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
+        let max_seen = Arc::clone(&max_in_flight);
+        let handle = thread::spawn(move || {
+            let mut workers = Vec::new();
+            let mut accepted = 0usize;
+            let started = Instant::now();
+            let mut last_accept = started;
+            while accepted < max_conns
+                && started.elapsed() < Duration::from_secs(5)
+                && (accepted == 0 || last_accept.elapsed() < Duration::from_millis(500))
+            {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        accepted += 1;
+                        last_accept = Instant::now();
+                        let in_flight = Arc::clone(&in_flight);
+                        let max_seen = Arc::clone(&max_seen);
+                        workers.push(thread::spawn(move || {
+                            let now = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                            raise_max(&max_seen, now);
+                            let body = read_request_body(&mut stream);
+                            thread::sleep(delay);
+                            let inputs = body.matches("path: ").count().max(1);
+                            let vector = vec!["0.1"; dim].join(",");
+                            let rows = (0..inputs)
+                                .map(|_| format!("[{vector}]"))
+                                .collect::<Vec<_>>()
+                                .join(",");
+                            let response_body = format!("{{\"embeddings\":[{rows}]}}");
+                            let response = format!(
+                                "HTTP/1.1 200 OK\r\nContent-Type: \
+                                 application/json\r\nContent-Length: {}\r\nConnection: \
+                                 close\r\n\r\n{response_body}",
+                                response_body.len()
+                            );
+                            let _ = stream.write_all(response.as_bytes());
+                            let _ = stream.flush();
+                            in_flight.fetch_sub(1, Ordering::SeqCst);
+                        }));
+                    },
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    },
+                    Err(_) => break,
+                }
+            }
+            for worker in workers {
+                let _ = worker.join();
+            }
+        });
+        (format!("http://127.0.0.1:{port}"), handle, max_in_flight)
+    }
+
+    fn seed_embedding_chunk(conn: &Connection, i: i64) {
+        conn.execute(
+            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
+             VALUES (?1, 'rust', 'source', ?2, 0, 0)",
+            params![format!("src/file_{i}.rs"), format!("sha-{i}")],
+        )
+        .unwrap();
+        let file_id = conn.last_insert_rowid();
+        let text = format!(
+            "pub fn item_{i}(input: usize) -> usize {{\n    let mut value = input + {i};\n    for \
+             step in 0..16 {{ value = value.saturating_add(step); }}\n    value\n}}"
+        );
+        conn.execute(
+            "INSERT INTO chunks(
+                 file_id, chunk_kind, symbol_path, start_byte, end_byte, start_line, end_line,
+                 text_hash, source_revision
+             )
+             VALUES (?1, 'code', ?2, 0, ?3, 1, 3, ?4, ?5)",
+            params![
+                file_id,
+                format!("crate::item_{i}"),
+                i64::try_from(text.len()).unwrap(),
+                format!("hash-{i}"),
+                format!("rev-{i}")
+            ],
+        )
+        .unwrap();
+        let chunk_id = conn.last_insert_rowid();
+        crate::index::chunk_text_store::seed_chunk_text(conn, chunk_id, &text).unwrap();
     }
 
     fn active_version(conn: &Connection) -> String {
@@ -1179,6 +1327,52 @@ mod freshness_version_tests {
             active_version(&conn),
             spec.version,
             "remote key differs from the local version"
+        );
+    }
+
+    #[test]
+    fn remote_reconcile_accumulates_enough_work_to_fill_concurrent_embedder_window() {
+        let conn = schema_conn();
+        let spec = spec(FASTEMBED_MODEL_ID).unwrap();
+        for i in 0..4 {
+            seed_embedding_chunk(&conn, i);
+        }
+        let (url, handle, max_in_flight) =
+            spawn_reconcile_embed_stub(spec.dim, 4, Duration::from_millis(150));
+        let mut remote = remote_at(&url);
+        remote.batch_size = 1;
+        remote.concurrency = 4;
+        set_active_remote_config(&conn, &remote).unwrap();
+        conn.execute(
+            "UPDATE ai_models
+             SET installed = 1, disabled = 0, status = 'Ready', embedding_dim = ?2, runtime = \
+             'ollama'
+             WHERE model_id = ?1",
+            params![FASTEMBED_MODEL_ID, i64::try_from(spec.dim).unwrap()],
+        )
+        .unwrap();
+        set_meta(&conn, ACTIVE_EMBEDDING_MODEL_META, FASTEMBED_MODEL_ID).unwrap();
+        set_reconcile_meta(
+            &conn,
+            ACTIVE_EMBEDDING_MODEL_VERSION_META,
+            &remote_freshness_version(spec, &remote),
+        )
+        .unwrap();
+
+        let report = reconcile_with_options_progress(
+            &conn,
+            ReconcileOptions { batch_size: Some(1), ..ReconcileOptions::default() },
+            |_| {},
+        )
+        .unwrap();
+        handle.join().unwrap();
+
+        assert_eq!(report.batch_size, 1, "public/report batch size is preserved");
+        assert_eq!(report.embeddings_written, 4);
+        assert_eq!(report.failed_chunks, 0);
+        assert!(
+            max_in_flight.load(Ordering::SeqCst) > 1,
+            "remote reconcile should hand multiple ordered texts to one concurrent embedder call"
         );
     }
 
@@ -1408,6 +1602,8 @@ mod freshness_version_tests {
             gpu: None,
             num_ctx: None,
             batch_size: 256,
+            concurrency: 32,
+            max_batch_chars: 384_000,
             request_timeout_s: 5,
         };
         set_active_remote_config(conn, &remote).unwrap();

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -8,6 +8,8 @@ use crate::embedding_models::{Backend, EMBEDDING_MODELS, HASH_MODEL_ID, spec};
 #[cfg(feature = "fastembed")]
 use crate::embedding_models::{FASTEMBED_EMBEDDING_DIM, FASTEMBED_MODEL_ID};
 
+const RECONCILE_SELECT_ID_BATCH_LIMIT: usize = 900;
+
 pub(crate) fn ensure_model_manifest(conn: &Connection) -> anyhow::Result<()> {
     // Read-first: skip the (write-locking) DML entirely when the manifest already matches what we
     // would write. `ensure_model_manifest` runs on EVERY `IndexDatabase::open*`, so issuing
@@ -710,29 +712,44 @@ pub(crate) fn reconcile_with_options_progress(
             ));
             break;
         }
-        let batch_limit = remaining
+        let window_limit = remaining
             .map(|value| value.min(u64::try_from(selection_batch_size).unwrap_or(u64::MAX)))
             .and_then(|value| usize::try_from(value).ok())
             .unwrap_or(selection_batch_size);
-        // Pull the next batch of unprocessed candidate ids.
-        let mut batch_ids = Vec::with_capacity(batch_limit);
-        while cursor < candidate_ids.len() && batch_ids.len() < batch_limit {
-            let id = candidate_ids[cursor];
-            cursor += 1;
-            if !processed_ids.contains(&id) {
-                batch_ids.push(id);
+        // Pull the next ordered embed window while keeping each DB lookup under SQLite's default
+        // bind-variable limit. Selected jobs are appended in candidate order, so remote reconcile
+        // still hands the embedder one window large enough to fill its HTTP concurrency.
+        let mut window_jobs = Vec::new();
+        let mut ids_seen = 0usize;
+        while cursor < candidate_ids.len() && ids_seen < window_limit {
+            let id_limit = RECONCILE_SELECT_ID_BATCH_LIMIT.min(window_limit - ids_seen);
+            let mut batch_ids = Vec::with_capacity(id_limit);
+            while cursor < candidate_ids.len()
+                && batch_ids.len() < id_limit
+                && ids_seen < window_limit
+            {
+                let id = candidate_ids[cursor];
+                cursor += 1;
+                ids_seen = ids_seen.saturating_add(1);
+                if !processed_ids.contains(&id) {
+                    batch_ids.push(id);
+                }
             }
+            if batch_ids.is_empty() {
+                break;
+            }
+            let selected = select_reconcile_batch(conn, &scan, &batch_ids, &options, &mut decoder)?;
+            window_jobs.extend(selected.jobs);
         }
-        if batch_ids.is_empty() {
-            break; // candidate list exhausted
-        }
-        let selected = select_reconcile_batch(conn, &scan, &batch_ids, &options, &mut decoder)?;
-        if selected.jobs.is_empty() {
-            // Every id in this batch was filtered (ineligible/already current); keep walking the
+        if window_jobs.is_empty() {
+            if cursor >= candidate_ids.len() {
+                break; // candidate list exhausted
+            }
+            // Every id in this window was filtered (ineligible/already current); keep walking the
             // rest of the candidate list rather than stopping.
             continue;
         }
-        for job in &selected.jobs {
+        for job in &window_jobs {
             processed_ids.insert(job.id);
             *report.work_reasons.entry(job.reason.as_str().to_string()).or_default() += 1;
             report.input_chars = report
@@ -742,10 +759,10 @@ pub(crate) fn reconcile_with_options_progress(
                 report.truncated_inputs += 1;
             }
         }
-        let jobs_len = selected.jobs.len();
+        let jobs_len = window_jobs.len();
         let mut reused_jobs = Vec::new();
         let mut to_embed_jobs = Vec::new();
-        for job in selected.jobs {
+        for job in window_jobs {
             match find_existing_embedding(conn, &active_model_id, &job.input_hash, embedding_dim)? {
                 Some(vector) => reused_jobs.push((job, vector)),
                 None => to_embed_jobs.push(job),
@@ -820,7 +837,7 @@ fn remote_reconcile_batch_size(
         return batch_size.max(1);
     }
     let remote_batch_size = (remote.batch_size as usize).max(1);
-    let concurrency = (remote.concurrency as usize).max(1);
+    let concurrency = remote.bounded_concurrency() as usize;
     batch_size.max(remote_batch_size.saturating_mul(concurrency))
 }
 
@@ -863,8 +880,14 @@ fn write_remote_scoped_or_failed(
 
     let mut written = 0u64;
     let mut failed = 0u64;
+    let mut abort_remaining_error = None::<String>;
     for (start, end) in remote_request_job_ranges(jobs, remote) {
         let scoped_jobs = &jobs[start..end];
+        if let Some(error) = abort_remaining_error.as_deref() {
+            write_failed_embedding_batch(conn, embedder, model_version, scoped_jobs, error)?;
+            failed = failed.saturating_add(u64::try_from(scoped_jobs.len()).unwrap_or(u64::MAX));
+            continue;
+        }
         let texts = scoped_jobs.iter().map(|chunk| chunk.input_text.clone()).collect::<Vec<_>>();
         match embedder.embed_batch(&texts) {
             Ok(vectors) if vectors.len() == scoped_jobs.len() => {
@@ -891,15 +914,19 @@ fn write_remote_scoped_or_failed(
                     failed.saturating_add(u64::try_from(scoped_jobs.len()).unwrap_or(u64::MAX));
             },
             Err(err) => {
+                let scoped_error = err.to_string();
                 write_failed_embedding_batch(
                     conn,
                     embedder,
                     model_version,
                     scoped_jobs,
-                    &err.to_string(),
+                    &scoped_error,
                 )?;
                 failed =
                     failed.saturating_add(u64::try_from(scoped_jobs.len()).unwrap_or(u64::MAX));
+                if remote_error_should_abort_scoped_retries(&scoped_error) {
+                    abort_remaining_error = Some(scoped_error);
+                }
             },
         }
     }
@@ -908,6 +935,18 @@ fn write_remote_scoped_or_failed(
 
 fn vector_count_error(embedder: &dyn Embedder, got: usize, expected: usize) -> String {
     format!("embedder {} returned {} vectors for {} texts", embedder.model_id(), got, expected)
+}
+
+fn remote_error_should_abort_scoped_retries(error: &str) -> bool {
+    let lower = error.to_ascii_lowercase();
+    lower.contains("timed out")
+        || lower.contains("timeout")
+        || lower.contains("connection refused")
+        || lower.contains("connection reset")
+        || lower.contains("connection closed")
+        || lower.contains("failed to connect")
+        || lower.contains("connect error")
+        || lower.contains("http status 504")
 }
 
 fn remote_request_job_ranges(
@@ -1527,6 +1566,46 @@ mod freshness_version_tests {
     }
 
     #[test]
+    fn remote_reconcile_chunks_large_selection_below_sqlite_bind_limit() {
+        let conn = schema_conn();
+        let spec = spec(FASTEMBED_MODEL_ID).unwrap();
+        for i in 0..1005 {
+            seed_embedding_chunk(&conn, i);
+        }
+        let (url, handle, _) = spawn_reconcile_embed_stub(spec.dim, 1, Duration::ZERO);
+        let mut remote = remote_at(&url);
+        remote.batch_size = 4096;
+        remote.concurrency = 32;
+        set_active_remote_config(&conn, &remote).unwrap();
+        conn.execute(
+            "UPDATE ai_models
+             SET installed = 1, disabled = 0, status = 'Ready', embedding_dim = ?2, runtime = \
+             'ollama'
+             WHERE model_id = ?1",
+            params![FASTEMBED_MODEL_ID, i64::try_from(spec.dim).unwrap()],
+        )
+        .unwrap();
+        set_meta(&conn, ACTIVE_EMBEDDING_MODEL_META, FASTEMBED_MODEL_ID).unwrap();
+        set_reconcile_meta(
+            &conn,
+            ACTIVE_EMBEDDING_MODEL_VERSION_META,
+            &remote_freshness_version(spec, &remote),
+        )
+        .unwrap();
+
+        let report = reconcile_with_options_progress(
+            &conn,
+            ReconcileOptions { batch_size: Some(64), ..ReconcileOptions::default() },
+            |_| {},
+        )
+        .unwrap();
+        handle.join().unwrap();
+
+        assert_eq!(report.embeddings_written, 1005);
+        assert_eq!(report.failed_chunks, 0);
+    }
+
+    #[test]
     fn remote_reconcile_scopes_request_failure_to_remote_request_batch() {
         let conn = schema_conn();
         let spec = spec(FASTEMBED_MODEL_ID).unwrap();
@@ -1588,6 +1667,23 @@ mod freshness_version_tests {
 
         assert_eq!(remote_reconcile_batch_size(&remote, 8, Some(1)), 8);
         assert_eq!(remote_reconcile_batch_size(&remote, 8, None), 8192);
+    }
+
+    #[test]
+    fn remote_scoped_retry_aborts_on_endpoint_level_errors_only() {
+        for error in [
+            "request timed out",
+            "timeout",
+            "connection refused",
+            "failed to connect",
+            "http status 504: gateway timeout",
+        ] {
+            assert!(remote_error_should_abort_scoped_retries(error), "{error}");
+        }
+        assert!(!remote_error_should_abort_scoped_retries("http status 500: transient"));
+        assert!(!remote_error_should_abort_scoped_retries(
+            "embedder model returned 2 vectors for 3 texts"
+        ));
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/status.rs
+++ b/crates/rag-rat-core/src/index/ai/status.rs
@@ -309,6 +309,8 @@ mod ollama_install_tests {
             gpu: None,
             num_ctx: None,
             batch_size: 256,
+            concurrency: 32,
+            max_batch_chars: 384_000,
             request_timeout_s: 5,
         }
     }

--- a/crates/rag-rat-core/src/index/ai/store.rs
+++ b/crates/rag-rat-core/src/index/ai/store.rs
@@ -369,23 +369,6 @@ pub(crate) fn write_current_embedding_batch(
     finish_batch_transaction(conn, write_result)
 }
 
-pub(crate) fn write_failed_embedding_batch(
-    conn: &Connection,
-    embedder: &dyn Embedder,
-    model_version: &str,
-    batch: &[PreparedEmbeddingJob],
-    error: &str,
-) -> anyhow::Result<()> {
-    conn.execute_batch("BEGIN IMMEDIATE")?;
-    let write_result = (|| {
-        for chunk in batch {
-            store_failed_embedding(conn, embedder, model_version, chunk, error)?;
-        }
-        Ok(())
-    })();
-    finish_batch_transaction(conn, write_result)
-}
-
 pub(crate) fn finish_batch_transaction(
     conn: &Connection,
     result: anyhow::Result<()>,

--- a/docs/config.md
+++ b/docs/config.md
@@ -68,7 +68,7 @@ endpoint = "http://box:11434"     # CONNECT: the Ollama server URL (required)
 model = "all-minilm"              # the Ollama-side model name (the server's own identifier)
 # auth_env = "OLLAMA_TOKEN"       # NAME of an env var holding a bearer token (never the token itself)
 # batch_size = 256                # texts per /api/embed request
-# concurrency = 32                # concurrent /api/embed requests in one reconcile batch
+# concurrency = 32                # opt in to concurrent /api/embed requests; omitted CONNECT = 1
 # max_batch_chars = 384000        # max total input chars per /api/embed request
 # num_ctx = 4096                  # optional Ollama context window (options.num_ctx)
 # request_timeout_s = 60          # per-request HTTP timeout
@@ -114,6 +114,11 @@ it tries to provision.
 For remote Ollama, `batch_size` and `max_batch_chars` cap one HTTP request; `concurrency` controls
 how many of those capped requests reconcile may keep in flight. Candidate chunk order stays
 need-first/id-first; rag-rat does not size-sort chunks.
+
+When `concurrency` is omitted, CONNECT configs default to `1` for upgrade safety with ordinary
+Ollama servers. Set it explicitly after starting the server with matching parallelism. EPHEMERAL
+cookbook configs default to `32`; the cookbook recipe is responsible for aligning server-side
+parallelism.
 
 ### Init cookbook catalog
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -68,7 +68,7 @@ endpoint = "http://box:11434"     # CONNECT: the Ollama server URL (required)
 model = "all-minilm"              # the Ollama-side model name (the server's own identifier)
 # auth_env = "OLLAMA_TOKEN"       # NAME of an env var holding a bearer token (never the token itself)
 # batch_size = 256                # texts per /api/embed request
-# concurrency = 32                # opt in to concurrent /api/embed requests; omitted CONNECT = 1
+# concurrency = 32                # 1..=128; omitted CONNECT = 1
 # max_batch_chars = 384000        # max total input chars per /api/embed request
 # num_ctx = 4096                  # optional Ollama context window (options.num_ctx)
 # request_timeout_s = 60          # per-request HTTP timeout
@@ -102,7 +102,7 @@ model = "all-minilm"                        # the Ollama-side model name
                                             #     cold-start risk);
                                             #   RunPod = a gpuTypeId (default: NVIDIA RTX A4000).
 # batch_size = 256                          # texts per /api/embed request
-# concurrency = 32                          # concurrent /api/embed requests
+# concurrency = 32                          # 1..=128 concurrent /api/embed requests
 # max_batch_chars = 384000                  # max total input chars per /api/embed request
 # request_timeout_s = 60
 ```
@@ -118,7 +118,7 @@ need-first/id-first; rag-rat does not size-sort chunks.
 When `concurrency` is omitted, CONNECT configs default to `1` for upgrade safety with ordinary
 Ollama servers. Set it explicitly after starting the server with matching parallelism. EPHEMERAL
 cookbook configs default to `32`; the cookbook recipe is responsible for aligning server-side
-parallelism.
+parallelism. Values above `128` are rejected to keep worker threads and reconcile windows bounded.
 
 ### Init cookbook catalog
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -68,7 +68,7 @@ endpoint = "http://box:11434"     # CONNECT: the Ollama server URL (required)
 model = "all-minilm"              # the Ollama-side model name (the server's own identifier)
 # auth_env = "OLLAMA_TOKEN"       # NAME of an env var holding a bearer token (never the token itself)
 # batch_size = 256                # texts per /api/embed request
-# concurrency = 32                # 1..=128; omitted CONNECT = 1
+# concurrency = 1                 # 1..=128; connect-safe (cookbook/ephemeral default = 32)
 # max_batch_chars = 384000        # max total input chars per /api/embed request
 # num_ctx = 4096                  # optional Ollama context window (options.num_ctx)
 # request_timeout_s = 60          # per-request HTTP timeout

--- a/docs/config.md
+++ b/docs/config.md
@@ -68,6 +68,9 @@ endpoint = "http://box:11434"     # CONNECT: the Ollama server URL (required)
 model = "all-minilm"              # the Ollama-side model name (the server's own identifier)
 # auth_env = "OLLAMA_TOKEN"       # NAME of an env var holding a bearer token (never the token itself)
 # batch_size = 256                # texts per /api/embed request
+# concurrency = 32                # concurrent /api/embed requests in one reconcile batch
+# max_batch_chars = 384000        # max total input chars per /api/embed request
+# num_ctx = 4096                  # optional Ollama context window (options.num_ctx)
 # request_timeout_s = 60          # per-request HTTP timeout
 ```
 
@@ -98,11 +101,19 @@ model = "all-minilm"                        # the Ollama-side model name
                                             #     recipe WARNS that GPU there has an exit-137
                                             #     cold-start risk);
                                             #   RunPod = a gpuTypeId (default: NVIDIA RTX A4000).
+# batch_size = 256                          # texts per /api/embed request
+# concurrency = 32                          # concurrent /api/embed requests
+# max_batch_chars = 384000                  # max total input chars per /api/embed request
+# request_timeout_s = 60
 ```
 
 `gpu` applies **only** to the EPHEMERAL `cookbook` path; setting it alongside a connect `endpoint` is
 a config error. Its value is **not** validated by rag-rat — the provider rejects an unknown GPU when
 it tries to provision.
+
+For remote Ollama, `batch_size` and `max_batch_chars` cap one HTTP request; `concurrency` controls
+how many of those capped requests reconcile may keep in flight. Candidate chunk order stays
+need-first/id-first; rag-rat does not size-sort chunks.
 
 ### Init cookbook catalog
 

--- a/rag-rat.toml
+++ b/rag-rat.toml
@@ -18,6 +18,8 @@ endpoint = "http://localhost:11434"   # this box's Ollama server
 model = "all-minilm"                  # the Ollama-side model name
 num_ctx = 4096                        # Ollama context window for code chunks
 batch_size = 32                       # texts per /api/embed request
+concurrency = 32                      # concurrent /api/embed requests
+max_batch_chars = 384000              # max input chars per /api/embed request
 # To EPHEMERALLY provision a box instead, drop `endpoint` and set `cookbook` (see docs/config.md).
 # Only then may you pick the GPU (a connect endpoint + gpu is rejected):
 # gpu = "A10G"                        # cookbook-only; Modal GPU class / RunPod gpuTypeId

--- a/rag-rat.toml
+++ b/rag-rat.toml
@@ -18,7 +18,7 @@ endpoint = "http://localhost:11434"   # this box's Ollama server
 model = "all-minilm"                  # the Ollama-side model name
 num_ctx = 4096                        # Ollama context window for code chunks
 batch_size = 32                       # texts per /api/embed request
-concurrency = 32                      # concurrent /api/embed requests
+concurrency = 32                      # 1..=128 concurrent /api/embed requests
 max_batch_chars = 384000              # max input chars per /api/embed request
 # To EPHEMERALLY provision a box instead, drop `endpoint` and set `cookbook` (see docs/config.md).
 # Only then may you pick the GPU (a connect endpoint + gpu is rejected):


### PR DESCRIPTION
## Summary
- add remote embedding `concurrency` and `max_batch_chars` config with persisted serde defaults
- split Ollama embed batches by count and char budget, then dispatch bounded concurrent `/api/embed` requests while preserving output order
- widen remote reconcile accumulation so each remote `embed_batch` can fill the concurrent request window without changing local embedder behavior
- expose `batch_size`, `concurrency`, and `max_batch_chars` as editable `rag-rat init` wizard controls with probe invalidation
- pass configured remote concurrency into Modal and RunPod cookbook recipes as `OLLAMA_NUM_PARALLEL`
- release `@rag-rat/cookbook@0.2.0` to npm with the cookbook concurrency updates

Closes #327

## Validation
- `npm run typecheck`
- `npm pack --dry-run`
- `npm publish --access public`
- `npm view @rag-rat/cookbook version dist-tags --json` -> `latest: 0.2.0`
- `cargo test -p rag-rat-core --locked index::ai::providers::ollama`
- `cargo test -p rag-rat-core --locked index::ai::providers::cookbook`
- `cargo test -p rag-rat-core --locked config`
- `cargo test -p rag-rat-core --locked index::ai::reconcile`
- `cargo test -p rag-rat --locked init::wizard`
- `cargo test -p rag-rat-core --no-default-features --locked blocked_fastembed_reconcile_still_reports_policy_skips`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo clippy -p rag-rat --all-targets --locked -- -D warnings`
- `cargo +nightly fmt --check`
- `git diff --check`

## Live Validation
- Modal cold ephemeral T4: 5243 written, 0 failed, 0 blocked; 148.74s wall including provisioning and model pull.
- Modal hot connect T4: 5243 written, 0 failed, 0 blocked; 19.381s reported reconcile time, 270.52 chunks/s.
- RunPod smoke: sourced local `.runpod-e2e.env`, pod `yb1krd9k8w06px` reported `parallel=32`, `/api/embed` verification passed, teardown complete.