### PR TITLE
feat(embed): auto-tune ephemeral remote embedding concurrency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ target/
 
 # Plans/specs are kept on disk for review, never committed (see dont-commit-plans).
 docs/plans/
+throughput-tune-rust-refactor-plan.md
+
+# RunPod e2e creds (never commit)
+.runpod-e2e.env

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -26,7 +26,7 @@ Rust parser is built against the exact event shapes below; implement them precis
 | spawn | runs `node recipe.mjs` (or `npx tsx recipe.mts`), with `RAG_RAT_COOKBOOK_INPUT` set in env | starts up |
 | input | sets `RAG_RAT_COOKBOOK_INPUT` = JSON `CookbookInput`; provider creds already in env / `~/.modal.toml` | reads + parses that env var |
 | progress | reads `status` / `log` events from **stdout** | emits `status` (provisioning → pulling → verifying) and `log` events as it works |
-| ready | reads the `ready` event → uses `endpoint` | once the box is up **and serving**, emits one `ready` event |
+| ready | reads the `ready` event → uses `endpoint` (+ optional `auth_token`) | once the box is up **and serving**, emits one `ready` event |
 | liveness | uses the endpoint | stays running, holding the box |
 | teardown | sends `SIGTERM` (or `SIGINT`) | emits a `tearing_down` status, destroys the box, exits `0` |
 | failure | sees an `error` event + non-zero exit, no `ready` | on provisioning failure: emits an `error` event, exits non-zero, **before** any `ready` |
@@ -68,8 +68,10 @@ Hard rules:
                                //   string like "A10", "L40S", "H100", or "B200+" (CPU default);
                                //   for RunPod a gpuTypeId like "NVIDIA RTX A4000".
   "ollama_num_parallel": 32    // optional: positive integer — sets OLLAMA_NUM_PARALLEL in the
-                               //   remote Ollama container, normally matching rag-rat's remote
-                               //   embedding concurrency.
+                               //   remote Ollama container. rag-rat sends the user's `[remote]
+                               //   concurrency` CAP so the box can serve up to that many parallel
+                               //   /api/embed requests; rag-rat then auto-tunes the actual client
+                               //   fan-out (within the cap) itself, against the box, after `ready`.
 }
 ```
 
@@ -91,7 +93,8 @@ stdout is JSONL — one of these objects per line. Every event carries `ts` (epo
 // diagnostics: level ∈ {"info","warn","error"}
 {"type":"log","level":"info","message":"pod deployed: abc123","ts":1782489011405}
 
-// the box is serving — REPLACES the old bare handshake line
+// the box is serving — REPLACES the old bare handshake line. Carries only the endpoint and an
+// optional auth token; rag-rat does the throughput tuning itself after this event.
 {"type":"ready","endpoint":"https://abc123.modal.host","auth_token":null,"ts":1782489011405}
 
 // provisioning failed before `ready`
@@ -102,6 +105,22 @@ stdout is JSONL — one of these objects per line. Every event carries `ts` (epo
 normalized to explicit `null`. A run emits zero-or-more `status`/`log` events, then **either** one
 `ready` (success — followed later by a `tearing_down` status on signal) **or** one `error` (failure,
 with exit 1 and no `ready`).
+
+### Throughput tuning lives in rag-rat, not the recipe
+
+The recipe is a **dumb provisioner**: it boots the box, sets `OLLAMA_NUM_PARALLEL` to the user's
+`[remote] concurrency` cap (passed as `ollama_num_parallel`), verifies `/api/embed` serves, and
+emits `ready`. It does **no** throughput sweeping.
+
+rag-rat owns the tuning. After `ready`, rag-rat runs a short client-concurrency micro-sweep against
+the box **with its real `OllamaEmbedder`** — the same request shape (num_ctx, batch size, char
+budget) reconcile will use — so the measured knee can't drift from real load the way a recipe-side
+re-implementation did. The tuned knee is a **hard-clamped-to-cap** client fan-out: rag-rat treats
+`[remote] concurrency` as a ceiling it optimizes *within* and never exceeds or overwrites. The
+result is cached in the index's `index_meta` (keyed by runtime + provider + GPU + model + request
+shape) with a TTL, so routine re-provisions reuse it without re-sweeping. See rag-rat's
+`RAG_RAT_TUNE_MS` / `RAG_RAT_TUNE_TTL_MS` / `RAG_RAT_DISABLE_TUNING` env knobs, not any cookbook-side
+ones.
 
 ## Invoking — provider as a subcommand
 
@@ -144,7 +163,8 @@ Provider gotchas baked into the recipe (each one cost real time to find):
 - ollama defaults to `127.0.0.1:11434`, unreachable by the tunnel — the recipe sets
   `OLLAMA_HOST=0.0.0.0:11434`.
 - Ollama defaults to single-request handling — the recipe sets `OLLAMA_NUM_PARALLEL` from
-  `input.ollama_num_parallel` so Modal can serve the client-side remote concurrency window.
+  `input.ollama_num_parallel` (the user's `[remote] concurrency` cap). rag-rat tunes the actual
+  client fan-out itself after `ready`.
 - **GPU is off by default.** GPU on Modal must attach before ollama's discovery watchdog times out,
   or the box dies with exit 137 at cold start. CPU `serve` is the safe v1 path; pass `gpu` only if
   you've accepted that.
@@ -170,7 +190,8 @@ Provider gotchas baked into the recipe:
   (`"ollama serve"` would exec `ollama ollama serve`). `dockerArgs` sets the container CMD,
   appended to the entrypoint.
 - ollama defaults to `127.0.0.1:11434`, unreachable through the proxy — the recipe sets
-  `OLLAMA_HOST=0.0.0.0:11434` and `OLLAMA_NUM_PARALLEL` in the pod env.
+  `OLLAMA_HOST=0.0.0.0:11434` and `OLLAMA_NUM_PARALLEL` (from `input.ollama_num_parallel`, the user's
+  `[remote] concurrency` cap) in the pod env. rag-rat tunes the client fan-out itself after `ready`.
 - There is **no in-pod exec** in `podFindAndDeployOnDemand`, so the model is pulled **client-side**
   over the proxy URL (`POST /api/pull`, non-streaming, retried until the pod finishes booting),
   then `/api/embed` is probed before the `ready` event.

--- a/cookbook/package-lock.json
+++ b/cookbook/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rag-rat/cookbook",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rag-rat/cookbook",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "modal": "^0.8.1"

--- a/cookbook/package.json
+++ b/cookbook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rag-rat/cookbook",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "description": "Ephemeral remote-runtime provisioning recipes for rag-rat. rag-rat (Rust) spawns a recipe as a subprocess, reads a typed JSONL event stream from its stdout (status/log/ready/error), embeds against the endpoint, then signals teardown.",
   "license": "MIT",
   "repository": {

--- a/cookbook/recipes/modal-ollama.mts
+++ b/cookbook/recipes/modal-ollama.mts
@@ -69,6 +69,9 @@ async function provision(ctx: ProvisionContext<Sandbox>): Promise<Provisioned<Sa
   // leaked box bills until then.) See N2.
   const deadline = Date.now() + provisionTimeoutMs;
   const gpu = input.gpu ?? null;
+  // rag-rat sends the user's `[remote] concurrency` cap as `ollama_num_parallel`; the box's server
+  // parallelism is set to it so rag-rat can fan out up to the cap. rag-rat tunes the actual client
+  // concurrency (within the cap) itself, against the box, after `ready`.
   const ollamaNumParallel = String(input.ollama_num_parallel ?? 1);
 
   ctx.status(

--- a/cookbook/recipes/runpod-ollama.mts
+++ b/cookbook/recipes/runpod-ollama.mts
@@ -41,6 +41,7 @@ import {
   type Provisioned,
   type Recipe,
   assertBudgetRemaining,
+  endpointPath,
   errorMessage,
   fetchWithTimeout,
   log,
@@ -102,6 +103,9 @@ async function provision(ctx: ProvisionContext<PodHandle>): Promise<Provisioned<
   }
   const apiKey = rawKey.trim();
   const gpuTypeId = input.gpu ?? DEFAULT_GPU_TYPE_ID;
+  // rag-rat sends the user's `[remote] concurrency` cap as `ollama_num_parallel`; the box's server
+  // parallelism is set to it so rag-rat can fan out up to the cap. rag-rat tunes the actual client
+  // concurrency (within the cap) itself, against the box, after `ready`.
   const ollamaNumParallel = String(input.ollama_num_parallel ?? 1);
 
   // Unique pod name so a deploy-timeout orphan sweep can find a pod that RunPod created but whose
@@ -189,7 +193,7 @@ async function provision(ctx: ProvisionContext<PodHandle>): Promise<Provisioned<
  * stalled proxy aborts rather than hanging past the budget.
  */
 function pullModel(endpoint: string, model: string, budgetMs: number): Promise<void> {
-  const url = `${endpoint.replace(/\/+$/, "")}/api/pull`;
+  const url = endpointPath(endpoint, "/api/pull");
   return pollUntil<{ status?: unknown; error?: unknown }>(url, {
     label: `pull "${model}"`,
     budgetMs,

--- a/cookbook/src/contract.ts
+++ b/cookbook/src/contract.ts
@@ -93,8 +93,9 @@ export interface CookbookInput {
    */
   readonly gpu?: string | null;
   /**
-   * Ollama server parallelism to set as OLLAMA_NUM_PARALLEL. rag-rat sends this from the remote
-   * embedding `concurrency` knob so server-side request handling can match the client window.
+   * Ollama server parallelism to set as `OLLAMA_NUM_PARALLEL` on the box. rag-rat sends the user's
+   * `[remote] concurrency` CAP so the server can handle up to that many parallel `/api/embed`
+   * requests. rag-rat then tunes the actual client fan-out (within the cap) itself, against the box.
    */
   readonly ollama_num_parallel?: number | null;
 }
@@ -143,8 +144,8 @@ export interface ProvisionContext<H> {
   readonly onBox: (handle: H) => void;
   /**
    * Emit a `status` event tagged with this recipe's provider. Call it at each lifecycle phase:
-   * `provisioning` when creating the box, `pulling` around the model pull, `verifying` around the
-   * embed probe. (`tearing_down` is emitted by `runRecipe`, not the recipe.)
+   * `provisioning` when creating the box, `pulling` around the model pull, and `verifying` around
+   * the embed probe. (`tearing_down` is emitted by `runRecipe`, not the recipe.)
    */
   readonly status: (phase: Phase, detail: string) => void;
 }
@@ -459,6 +460,16 @@ export interface VerifyEmbedOptions {
   readonly perAttemptTimeoutMs?: number;
 }
 
+/** Builds an endpoint-relative API URL without a regex over provider/user input. */
+export function endpointPath(endpoint: string, path: string): string {
+  let endpointEnd = endpoint.length;
+  while (endpointEnd > 0 && endpoint.charCodeAt(endpointEnd - 1) === 47) {
+    endpointEnd -= 1;
+  }
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${endpoint.slice(0, endpointEnd)}${normalizedPath}`;
+}
+
 /**
  * Polls `<endpoint>/api/embed` until it returns a real embedding vector, or the budget runs out.
  *
@@ -467,11 +478,14 @@ export interface VerifyEmbedOptions {
  * `embeddings[0]` vector is the readiness signal. Throws if the budget elapses with no vector.
  */
 export function verifyEmbed(endpoint: string, options: VerifyEmbedOptions): Promise<void> {
-  const url = `${endpoint.replace(/\/+$/, "")}/api/embed`;
+  const url = endpointPath(endpoint, "/api/embed");
   return pollUntil<{ embeddings?: unknown }>(url, {
     label: "embed probe",
     budgetMs: options.budgetMs,
-    body: { model: options.model, input: "rag-rat embed readiness probe" },
+    body: {
+      model: options.model,
+      input: "rag-rat embed readiness probe",
+    },
     pollIntervalMs: options.pollIntervalMs ?? VERIFY_EMBED_POLL_INTERVAL_MS,
     perAttemptTimeoutMs: options.perAttemptTimeoutMs ?? VERIFY_EMBED_ATTEMPT_TIMEOUT_MS,
     ...(options.headers !== undefined ? { headers: options.headers } : {}),

--- a/crates/rag-rat-cli/src/init/wizard/mod.rs
+++ b/crates/rag-rat-cli/src/init/wizard/mod.rs
@@ -354,6 +354,9 @@ impl Wizard {
     }
 
     fn poll_probes_into_checks(&mut self) {
+        // The ephemeral provision test is a throwaway pass/fail spin-up (`tune = None`); it runs no
+        // throughput sweep and never touches the user's configured `[remote] concurrency` cap, so
+        // there is nothing to apply back to the draft here.
         for (step, _kind, _result) in self.state.probes.poll() {
             self.refresh_check(step);
         }
@@ -795,6 +798,46 @@ mod tests {
         }
 
         panic!("probe result did not update Integration check");
+    }
+
+    #[test]
+    fn ephemeral_probe_does_not_overwrite_the_concurrency_cap() {
+        // Cap model: a passing ephemeral provision test must NOT change the user's configured
+        // `[remote] concurrency` (the cap) — the tuned knee is surfaced in the provision log and
+        // the host cache, never baked back over the cap.
+        let mut w = headless(test_scan(), None);
+        w.state.draft.remote = Some(draft::RemoteDraft {
+            model: "all-minilm".to_string(),
+            mode: draft::RemoteMode::Ephemeral("@rag-rat/cookbook modal".to_string()),
+            gpu: None,
+            num_ctx: None,
+            batch_size: 256,
+            concurrency: 32,
+            max_batch_chars: rag_rat_core::config::RemoteEmbeddingConfig::default().max_batch_chars,
+            auth_env: None,
+        });
+        w.state.probes.spawn(
+            StepId::Embedding,
+            probe::ProbeKind::EphemeralTest,
+            steps::CheckResult::ok,
+        );
+
+        for _ in 0..100 {
+            w.poll_probes_into_checks();
+            if matches!(w.state.probes.status(StepId::Embedding), probe::ProbeStatus::Done {
+                kind: probe::ProbeKind::EphemeralTest,
+                ..
+            }) {
+                assert_eq!(
+                    w.state.draft.remote.as_ref().unwrap().concurrency,
+                    32,
+                    "the configured concurrency cap must be left untouched",
+                );
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        panic!("ephemeral probe never completed");
     }
 
     #[test]

--- a/crates/rag-rat-cli/src/init/wizard/steps.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps.rs
@@ -2208,6 +2208,9 @@ fn probe_ephemeral(
     s: &EmbeddingModelSpec,
     cancel: &std::sync::atomic::AtomicBool,
 ) -> CheckResult {
+    // A throwaway spin-up test: provision, embed one "ping", tear down. It passes `tune = None`, so
+    // it does NOT run the throughput sweep (that runs at reconcile, against a box the index keeps);
+    // the probe only reports pass/fail at the user's configured `[remote] concurrency` cap.
     match verify_ephemeral_remote_cancellable(&r, s, || cancel.load(Ordering::Acquire)) {
         Ok(()) => CheckResult::ok(),
         Err(e) => CheckResult::warn(format!("ephemeral: {e}")),

--- a/crates/rag-rat-core/src/index/ai/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/mod.rs
@@ -5,6 +5,7 @@ mod reconcile;
 mod reencode;
 mod status;
 mod store;
+mod throughput_tune;
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::time::Instant;

--- a/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
@@ -146,8 +146,10 @@ pub struct CookbookInput {
     /// GPU hint for the recipe (e.g. `"T4"`); `None` lets the recipe decide. Carried as JSON
     /// `null` when absent so the contract field is always present.
     pub gpu: Option<String>,
-    /// Ollama server parallelism the recipe should set as `OLLAMA_NUM_PARALLEL`, aligned to the
-    /// remote client's configured in-flight request count.
+    /// Ollama server parallelism the recipe should set as `OLLAMA_NUM_PARALLEL`. rag-rat sends the
+    /// user's `[remote] concurrency` CAP; the box is provisioned to handle up to that many
+    /// parallel requests, and rag-rat tunes the actual client fan-out (within the cap) itself
+    /// against the box.
     pub ollama_num_parallel: u32,
 }
 
@@ -175,7 +177,8 @@ enum CookbookEvent {
         message: String,
     },
     /// The box is SERVING — the handshake. `auth_token` is a DIRECT bearer token (NOT an env-var
-    /// name), or `null` for an unauthenticated box.
+    /// name), or `null` for an unauthenticated box. `ready` carries only the endpoint + token;
+    /// throughput tuning runs in rag-rat (Rust) against the box after this event.
     Ready { endpoint: String, auth_token: Option<String> },
     /// Provisioning failed before `ready`.
     Error { message: String },
@@ -503,6 +506,8 @@ fn cookbook_input_for(remote: &RemoteEmbeddingConfig) -> CookbookInput {
         // recipe picks its own default when `None`. Config validation guarantees `gpu` is only set
         // in ephemeral mode, which is the only mode reaching this function.
         gpu: remote.gpu.clone(),
+        // The user's `[remote] concurrency` cap — the box's server parallelism ceiling. rag-rat
+        // fans out up to this many parallel requests and auto-tunes the client knee within it.
         ollama_num_parallel: remote.bounded_concurrency(),
     }
 }
@@ -513,44 +518,85 @@ fn cookbook_input_for(remote: &RemoteEmbeddingConfig) -> CookbookInput {
 /// ephemeral chunk path AND the install probe (status.rs) so the model→input→handshake→embedder
 /// chain isn't duplicated. The returned [`ProvisionedBox`] MUST be kept alive for as long as the
 /// embedder is used (its `Drop` is the box teardown).
+/// Returns `(embedder, box, persisted_remote, window_concurrency)`. `persisted_remote` keeps the
+/// user's `concurrency` CAP (for the active-config meta); `window_concurrency` is the tuned client
+/// knee (<= cap) — the embedder's real fan-out, which the reconcile path uses to size its selection
+/// window so it doesn't load a cap-wide window the embedder will only drain `knee`-at-a-time.
+/// Context for the in-Rust throughput sweep (see [`crate::index::ai::throughput_tune`]). Present
+/// only on the reconcile path (which has the DB `conn` for the tune cache and the configured chunk
+/// size); the install probe / wizard verify pass `None` (they just ping — no sweep).
+pub(crate) struct TuneRequest<'a> {
+    pub conn: &'a rusqlite::Connection,
+    pub max_embedding_chars: usize,
+    /// Whether to run a NEW concurrency sweep on a cache miss. The tune cache is ALWAYS consulted
+    /// (a prior knee beats the raw cap); this only gates a fresh sweep — false for a bounded
+    /// `--max-seconds` pass or a run too small to fan out, so we don't spend paid-box time
+    /// measuring a fan-out the live loop can't use. See
+    /// `throughput_tune::sweep_is_worthwhile`.
+    pub allow_sweep: bool,
+}
+
 pub(crate) fn provision_and_build(
     remote: &RemoteEmbeddingConfig,
     spec: &EmbeddingModelSpec,
-) -> anyhow::Result<(OllamaEmbedder, ProvisionedBox)> {
-    provision_and_build_cancellable(remote, spec, || false)
+    tune: Option<TuneRequest<'_>>,
+) -> anyhow::Result<(OllamaEmbedder, ProvisionedBox, RemoteEmbeddingConfig, u32)> {
+    provision_and_build_cancellable(remote, spec, || false, tune)
 }
 
 fn provision_and_build_cancellable(
     remote: &RemoteEmbeddingConfig,
     spec: &EmbeddingModelSpec,
     cancel: impl Fn() -> bool,
-) -> anyhow::Result<(OllamaEmbedder, ProvisionedBox)> {
+    tune: Option<TuneRequest<'_>>,
+) -> anyhow::Result<(OllamaEmbedder, ProvisionedBox, RemoteEmbeddingConfig, u32)> {
     let cookbook = remote
         .cookbook
         .as_deref()
         .ok_or_else(|| anyhow::anyhow!("ephemeral remote config has no cookbook"))?;
     let input = cookbook_input_for(remote);
     let provisioned = CookbookProvisioner::provision_cancellable(cookbook, &input, cancel)?;
+    // `effective_remote` PERSISTS the user's `concurrency` CAP unchanged (cap model). The live
+    // embedder + reconcile window use the tuned knee, CLAMPED to that cap. The knee comes from the
+    // in-Rust sweep against the box with the REAL embedder (reconcile path); the install/verify
+    // pings pass `tune = None` and just use the cap.
+    let effective_remote = remote.clone();
+    let cap = remote.bounded_concurrency();
+    let client_concurrency = match tune {
+        Some(t) => crate::index::ai::throughput_tune::tune_ollama_concurrency(
+            t.conn,
+            remote.cookbook.as_deref().unwrap_or("cookbook"),
+            &provisioned.endpoint,
+            provisioned.auth_token.as_deref(),
+            remote,
+            spec,
+            t.max_embedding_chars,
+            t.allow_sweep,
+        ),
+        None => cap,
+    };
     let embedder = OllamaEmbedder::from_provisioned(ProvisionedEmbedderParams {
         endpoint: &provisioned.endpoint,
         auth_token: provisioned.auth_token.as_deref(),
-        server_model: remote.model.trim(),
+        server_model: effective_remote.model.trim(),
         selected_model_id: spec.model_id,
         dim: spec.dim,
-        request_timeout_s: remote.request_timeout_s,
-        batch_size: remote.batch_size,
-        concurrency: remote.bounded_concurrency(),
-        max_batch_chars: remote.max_batch_chars,
-        num_ctx: remote.num_ctx,
+        request_timeout_s: effective_remote.request_timeout_s,
+        batch_size: effective_remote.batch_size,
+        concurrency: client_concurrency,
+        max_batch_chars: effective_remote.max_batch_chars,
+        num_ctx: effective_remote.num_ctx,
     });
-    Ok((embedder, provisioned))
+    Ok((embedder, provisioned, effective_remote, client_concurrency))
 }
 
 /// Init-wizard ephemeral spin-up TEST: provision a cookbook box for `remote` + `spec`, embed a
 /// single `"ping"` to confirm the full provision→handshake→embed chain works, then tear the box
-/// down (the [`ProvisionedBox`] guard's `Drop` at end of scope). Returns `Ok(())` on a clean
-/// round-trip, an error otherwise. Bounded by the same internal [`PROVISION_TIMEOUT`] (300s) that
-/// gates `provision`, so the wizard never has to thread a deadline.
+/// down (the [`ProvisionedBox`] guard's `Drop` at end of scope). `Ok(())` on a clean round-trip, an
+/// error otherwise. This path passes `tune = None`, so it does NOT run the throughput sweep (a
+/// throwaway box wouldn't warm the reconcile cache) — it just verifies the round-trip at the user's
+/// `[remote] concurrency` cap. Bounded by the same internal [`PROVISION_TIMEOUT`] (300s) that gates
+/// `provision`.
 ///
 /// This is the `pub` seam the CLI's Remote step probes against: `provision_and_build` is
 /// `pub(crate)`, so a connection-less verify that the CLI can call lives HERE, not in the wizard.
@@ -572,7 +618,8 @@ pub fn verify_ephemeral_remote_cancellable(
     // `_box` is bound (not `_`) so it lives to end of scope — `OllamaEmbedder` holds only the
     // endpoint URL, not the process, so dropping the box early would tear down the server before
     // the ping. Drop at function exit is the teardown (SIGTERM → grace → SIGKILL on the group).
-    let (embedder, _box) = provision_and_build_cancellable(remote, spec, cancel)?;
+    let (embedder, _box, _effective_remote, _knee) =
+        provision_and_build_cancellable(remote, spec, cancel, None)?;
     embedder.embed_batch(&["ping".to_string()]).map_err(|err| {
         anyhow::anyhow!("ephemeral spin-up test embed failed for `{}`: {err}", spec.model_id)
     })?;
@@ -1418,7 +1465,9 @@ mod tests {
             parse(r#"{"type":"ready","endpoint":"http://x","auth_token":"tok","ts":1}"#),
             CookbookEvent::Ready { auth_token: Some(_), .. }
         ));
-        // Unknown extra field is tolerated.
+        // Unknown extra fields (a `ts`, or anything a future recipe adds) are tolerated — the
+        // variants intentionally don't `deny_unknown_fields` so the contract stays
+        // forward-compatible.
         assert!(matches!(
             parse(
                 r#"{"type":"status","phase":"pulling","provider":"modal","detail":"d","ts":2,"extra":true}"#

--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -36,6 +36,8 @@ pub use self::model2vec::Model2VecEmbedder;
 // visibility (same pattern as the other backends) exempts it from dead-code/unused-import
 // analysis under `-D warnings` until the dispatch arm lands.
 pub use self::ollama::OllamaEmbedder;
+// The tuning sweep (index::ai::throughput_tune) builds embedders at varied concurrencies.
+pub(crate) use self::ollama::ProvisionedEmbedderParams;
 use crate::config::RemoteEmbeddingConfig;
 use crate::embedding_models::{Backend, EmbeddingModelSpec, spec};
 use crate::index::ai::{
@@ -155,10 +157,13 @@ pub(crate) fn acquire_chunk_embedder(
         // `rag-rat reconcile` on an already-current ephemeral model would otherwise cold-start +
         // tear down a GPU/pod for nothing (#330-6). `--force` makes every chunk a candidate, so a
         // forced reconcile still provisions (count > 0). A count error is non-fatal — fall through
-        // to provisioning rather than skip real work on a transient query failure.
-        if let Ok(0) = estimated_reconcile_jobs(conn, scan, options) {
-            return ChunkEmbedder::NoEphemeralWork;
-        }
+        // to provisioning rather than skip real work on a transient query failure. The estimate is
+        // reused below to decide whether a concurrency sweep is worthwhile.
+        let estimated_jobs = match estimated_reconcile_jobs(conn, scan, options) {
+            Ok(0) => return ChunkEmbedder::NoEphemeralWork,
+            Ok(n) => Some(n),
+            Err(_) => None,
+        };
         let active_model_id = match active_embedding_model_id(conn) {
             Ok(id) => id,
             Err(err) => return ChunkEmbedder::NotReady(err),
@@ -168,11 +173,45 @@ pub(crate) fn acquire_chunk_embedder(
                 "unknown active embedding model `{active_model_id}`"
             ));
         };
-        return match provision_and_build(remote, spec) {
-            Ok((embedder, provisioned)) => ChunkEmbedder::Ready {
-                embedder: Box::new(embedder),
-                provisioned: Some(provisioned),
-                remote: Some(Box::new(remote.clone())),
+        // Tune in Rust against the box before the bulk reconcile: this is the ONLY provision path
+        // with the DB `conn` (for the tune cache) + the configured chunk size, so it's where the
+        // sweep runs. The install probe / wizard verify pass `None` (throwaway boxes — no sweep).
+        // Only sweep when the live run will actually fan out: a `--max-seconds` / maintenance pass
+        // isn't widened (`remote_reconcile_batch_size`), and a tiny `--limit` / few-chunk run sends
+        // one request — tuning either would just burn paid-box time the loop can't use. Use
+        // `scan.max_embedding_chars` (already clamped to MIN_EMBEDDING_CHARS), NOT the raw option,
+        // so the probe texts + tune cache key match the size reconcile actually embeds.
+        // ALWAYS pass a TuneRequest so the tune cache is consulted (a prior tuned knee beats the
+        // raw cap even on a bounded/tiny pass); `allow_sweep` gates only a fresh sweep —
+        // off for a bounded `--max-seconds` run or one too small to fan out
+        // (`sweep_is_worthwhile`).
+        let tune = self::cookbook::TuneRequest {
+            conn,
+            max_embedding_chars: scan.max_embedding_chars,
+            allow_sweep: crate::index::ai::throughput_tune::sweep_is_worthwhile(
+                options.max_seconds,
+                estimated_jobs,
+                remote.bounded_concurrency(),
+                remote.batch_size,
+                remote.max_batch_chars,
+                scan.max_embedding_chars,
+            ),
+        };
+        return match provision_and_build(remote, spec, Some(tune)) {
+            Ok((embedder, provisioned, effective_remote, window_concurrency)) => {
+                // Size the reconcile selection window by the EMBEDDER's real fan-out (the tuned
+                // knee), not the user's cap: `remote_reconcile_batch_size`
+                // multiplies by `concurrency`, so a 128-cap config with a knee of 4
+                // would otherwise load a 32x-too-wide window the embedder only
+                // drains 4-at-a-time. This `remote` is window-sizing only (NOT persisted
+                // — the active-config meta is written from the cap by `install_ollama_model`).
+                let mut window_remote = effective_remote;
+                window_remote.concurrency = window_concurrency;
+                ChunkEmbedder::Ready {
+                    embedder: Box::new(embedder),
+                    provisioned: Some(provisioned),
+                    remote: Some(Box::new(window_remote)),
+                }
             },
             Err(err) => ChunkEmbedder::NotReady(err),
         };

--- a/crates/rag-rat-core/src/index/ai/status.rs
+++ b/crates/rag-rat-core/src/index/ai/status.rs
@@ -59,17 +59,25 @@ pub(crate) fn install_ollama_model(
     // dim). EPHEMERAL has no static endpoint, so the probe PROVISIONS a box (via the shared
     // `provision_and_build`), pings it, then tears it down (the `_box` guard's Drop at the end of
     // this fn) — exactly the connection the reconcile will later provision.
-    let (embedder, _box): (OllamaEmbedder, Option<ProvisionedBox>) = if remote.is_ephemeral() {
-        let (embedder, provisioned) = provision_and_build(remote, spec).map_err(|err| {
-            anyhow::anyhow!("failed to provision ephemeral box for `{model_id}`: {err}")
-        })?;
-        (embedder, Some(provisioned))
+    let (embedder, _box, effective_remote): (
+        OllamaEmbedder,
+        Option<ProvisionedBox>,
+        RemoteEmbeddingConfig,
+    ) = if remote.is_ephemeral() {
+        // The install probe just provisions + pings + tears down (a throwaway box), so it passes
+        // `None` (no throughput sweep — that runs at reconcile). It PERSISTS `tuned_remote`, which
+        // keeps the user's `concurrency` cap (the cap model never persists a tuned knee).
+        let (embedder, provisioned, tuned_remote, _knee) = provision_and_build(remote, spec, None)
+            .map_err(|err| {
+                anyhow::anyhow!("failed to provision ephemeral box for `{model_id}`: {err}")
+            })?;
+        (embedder, Some(provisioned), tuned_remote)
     } else {
         let embedder = OllamaEmbedder::from_remote_config(remote, spec.model_id, spec.dim)
             .map_err(|err| {
                 anyhow::anyhow!("failed to construct ollama embedder for `{model_id}`: {err}")
             })?;
-        (embedder, None)
+        (embedder, None, remote.clone())
     };
     embedder.embed_batch(&["ping".to_string()]).map_err(|err| {
         anyhow::anyhow!(
@@ -86,7 +94,7 @@ pub(crate) fn install_ollama_model(
          WHERE model_id = ?1",
         params![model_id, now_ms(), i64::try_from(spec.dim).unwrap_or(i64::MAX)],
     )?;
-    set_active_remote_config(conn, remote)?;
+    set_active_remote_config(conn, &effective_remote)?;
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/ai/throughput_tune.rs
+++ b/crates/rag-rat-core/src/index/ai/throughput_tune.rs
@@ -1,0 +1,829 @@
+//! In-Rust embedding throughput tuning.
+//!
+//! The concurrency sweep runs HERE (against the provisioned box, with the real [`Embedder`]), not
+//! in the cookbook recipe — so the probe IS the reconcile request by construction: `batch_size`,
+//! `max_batch_chars`, `num_ctx`, `request_timeout_s`, `max_embedding_chars` are all correct because
+//! the exact embedder is used. The recipe just provisions + serves.
+//!
+//! BACKEND-AGNOSTIC. The sweep engine ([`run_sweep`]) knows nothing about ollama — it measures
+//! texts/s for each candidate over the `Embedder` trait and picks the knee. A per-backend adapter
+//! (today [`tune_ollama_concurrency`]) supplies the candidate list, a `build(candidate) ->
+//! Embedder` closure, and a RUNTIME discriminator folded into the cache key so an ollama tune and a
+//! future infinity/vLLM tune for the same model never collide.
+//!
+//! CAP MODEL: `[remote] concurrency` is the user's hard cap. The tuner returns the knee CLAMPED to
+//! the cap; it never exceeds or overwrites it. The persisted active-config concurrency stays the
+//! cap.
+
+use std::time::Instant;
+
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::config::RemoteEmbeddingConfig;
+use crate::embedding_models::EmbeddingModelSpec;
+use crate::index::ai::helpers::{meta, set_meta};
+use crate::index::ai::providers::{Embedder, OllamaEmbedder, ProvisionedEmbedderParams};
+use crate::index::util::now_ms;
+
+/// `index_meta` key holding the throughput-tune cache (a JSON map, so no schema migration).
+const TUNE_CACHE_META_KEY: &str = "embedding_throughput_tune_v1";
+/// Powers of two the concurrency sweep tries (plus the exact cap; filtered to `<= cap`).
+const CONCURRENCY_CANDIDATES: [u32; 8] = [1, 2, 4, 8, 16, 32, 64, 128];
+/// Byte budget on the synthetic probe texts a single candidate may allocate, so a huge
+/// `max_batch_chars` (or per-text `max_embedding_chars`) can't balloon the sweep to GBs. A
+/// candidate whose window bytes exceed this is SKIPPED (leaving the sweep incomplete → not cached);
+/// since the window bytes are `candidate * min(batch_size * per_text_chars, max_batch_chars)`, 128
+/// MB covers every sane config at full fan-out (e.g. the default 128 × 384 KB ≈ 49 MB).
+const MAX_PROBE_WINDOW_BYTES: usize = 128 * 1024 * 1024;
+/// Fan-out to reconcile with when the sweep RAN but found no stable candidate (every concurrency
+/// was lossy/failed): the safest value, NOT the cap — reconcile's scoped-retry handles the rest,
+/// and blasting a struggling box at the full cap would just write failed chunk groups.
+const SWEEP_FALLBACK_CONCURRENCY: u32 = 1;
+const DEFAULT_TUNE_BUDGET_MS: u64 = 60_000;
+const MIN_TUNE_BUDGET_MS: u64 = 5_000;
+const DEFAULT_TUNE_TTL_MS: u64 = 7 * 24 * 60 * 60 * 1_000;
+
+/// One measured candidate.
+struct SweepResult {
+    candidate: u32,
+    texts_per_second: f64,
+    requests: u64,
+    failures: u64,
+    /// The failure breaker tripped — the candidate is unstable, drop it from the knee search.
+    aborted: bool,
+}
+
+/// The result of a sweep, so the caller can distinguish "measured a knee" from "ran but nothing was
+/// stable" from "didn't run" — each wants a DIFFERENT fallback (see [`tune_ollama_concurrency`]).
+#[cfg_attr(test, derive(Debug))]
+enum SweepOutcome {
+    /// A knee (already clamped to the cap) and its measured texts/s. `complete` is false if the
+    /// budget truncated the sweep before every candidate ran — the knee is still the best measured
+    /// for THIS run, but the caller must NOT cache a partial sweep (it would pin an under-measured
+    /// fan-out until the TTL).
+    Knee { knee: u32, texts_per_second: f64, complete: bool },
+    /// The sweep ran but every candidate was lossy/failed — reconcile conservatively, don't blast
+    /// the box at the full cap.
+    NoStableCandidate,
+    /// The sweep didn't run (tune budget below the minimum) — use the user's cap unchanged.
+    NotRun,
+}
+
+/// A cache entry (per runtime + request shape).
+#[derive(Serialize, Deserialize)]
+struct TuneCacheEntry {
+    /// The chosen client knee (`<= cap`).
+    knee: u32,
+    /// The cap this was tuned under (so a RAISED cap forces a re-sweep).
+    cap: u32,
+    texts_per_second: f64,
+    updated_at_ms: i64,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+struct TuneCacheFile {
+    entries: std::collections::HashMap<String, TuneCacheEntry>,
+}
+
+/// Tune the CLIENT concurrency (the ollama fan-out) for a provisioned box, returning the knee
+/// clamped to the user's cap. `provider`/`gpu` come from the cookbook config;
+/// `endpoint`/`auth_token` from the handshake. Never errors — any failure falls back to the cap
+/// (tuning is best-effort).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn tune_ollama_concurrency(
+    conn: &Connection,
+    provider: &str,
+    endpoint: &str,
+    auth_token: Option<&str>,
+    remote: &RemoteEmbeddingConfig,
+    spec: &EmbeddingModelSpec,
+    max_embedding_chars: usize,
+    allow_sweep: bool,
+) -> u32 {
+    let cap = remote.bounded_concurrency();
+    if tuning_disabled() {
+        return cap;
+    }
+    // Normalize `batch_size` the SAME way `OllamaEmbedder` does (clamp to >=1): a configured 0
+    // serves one text per request live, so the probe (and cache key) must treat it as 1 —
+    // otherwise every candidate window collapses to a single text and the sweep never exercises
+    // fan-out.
+    let batch_size = remote.batch_size.max(1);
+    let key = tune_cache_key(TuneKey {
+        runtime: "ollama",
+        provider,
+        gpu: remote.gpu.as_deref().unwrap_or("cpu"),
+        model: remote.model.trim(),
+        num_ctx: remote.num_ctx.unwrap_or(0),
+        batch_size,
+        max_batch_chars: remote.max_batch_chars,
+        max_embedding_chars,
+        request_timeout_s: remote.request_timeout_s,
+    });
+
+    // ALWAYS consult the cache first — even when a new sweep isn't warranted (a bounded
+    // `--max-seconds` pass, or a run too small to fan out), a PRIOR tuned knee is still the right
+    // fan-out, better than the raw cap.
+    if let Some(knee) = fresh_cached_knee(conn, &key, cap) {
+        return knee;
+    }
+    // Cache miss and a new sweep isn't warranted for this run (bounded / no fan-out /
+    // single-flight): don't burn paid-box time sweeping a fan-out the loop can't use — fall
+    // back to the cap.
+    if !allow_sweep {
+        return cap;
+    }
+
+    // Build an ollama embedder for a probe — identical to the reconcile embedder in every respect
+    // (same `batch_size`, so the measured per-request cost matches the live requests and the knee
+    // is cacheable) except: `concurrency` is the fan-out being measured, and
+    // `request_timeout_s` is bounded by the tune budget so one blocking probe can't hold the
+    // box for the full HTTP timeout.
+    let build = |concurrency: u32, request_timeout_s: u64| -> OllamaEmbedder {
+        OllamaEmbedder::from_provisioned(ProvisionedEmbedderParams {
+            endpoint,
+            auth_token,
+            server_model: remote.model.trim(),
+            selected_model_id: spec.model_id,
+            dim: spec.dim,
+            request_timeout_s,
+            batch_size,
+            concurrency,
+            max_batch_chars: remote.max_batch_chars,
+            num_ctx: remote.num_ctx,
+        })
+    };
+
+    let per_text_chars = probe_text_chars(max_embedding_chars);
+    // Texts per probe request = how the live embedder splits (count cap AND char budget), so each
+    // probe request matches a real `/api/embed` request's weight.
+    let request_texts =
+        effective_request_texts(batch_size, remote.max_batch_chars, max_embedding_chars);
+    match run_sweep(
+        sweep_candidates(cap),
+        cap,
+        per_text_chars,
+        request_texts,
+        remote.request_timeout_s,
+        tune_budget_ms(),
+        build,
+    ) {
+        SweepOutcome::Knee { knee, texts_per_second, complete } => {
+            // Only cache a COMPLETE sweep — one where every candidate was measured. If the budget
+            // truncated the loop, or high candidates were skipped for allocation, the knee is still
+            // the best measured for THIS run but caching it would pin the repo to an under-measured
+            // fan-out until the TTL — let the next provision re-tune.
+            if complete {
+                write_cached_knee(conn, &key, knee, cap, texts_per_second);
+            }
+            knee
+        },
+        // Sweep ran, nothing served stably: reconcile at the safest fan-out (NOT the cap) so we
+        // don't just write failed chunk groups; reconcile's scoped-retry copes with the rest.
+        SweepOutcome::NoStableCandidate => SWEEP_FALLBACK_CONCURRENCY.min(cap).max(1),
+        // Tune budget too small to measure anything: use the user's cap unchanged.
+        SweepOutcome::NotRun => cap,
+    }
+}
+
+/// Whether a client-concurrency sweep is worth running for THIS reconcile — only when the live run
+/// can actually fan out. Skip when:
+/// - `max_seconds` is set — a bounded `--max-seconds`/maintenance pass is NOT widened
+///   (`remote_reconcile_batch_size` returns the plain batch size), so no fan-out.
+/// - `cap <= 1` — a single-flight config has no fan-out to optimize (`sweep_candidates(1) == [1]`).
+/// - the work fits a single `/api/embed` request — `estimated_jobs <= per_request`, where
+///   `per_request` accounts for BOTH the count cap (`batch_size`) AND the char budget
+///   (`max_batch_chars`): a small `max_batch_chars` splits even a few chunks into many small
+///   requests that DO fan out, so the count alone is the wrong threshold.
+///
+/// `estimated_jobs = None` (the count query errored) is treated as "maybe" — sweep if unbounded
+/// rather than skip real tuning on a transient error.
+pub(crate) fn sweep_is_worthwhile(
+    max_seconds: Option<u64>,
+    estimated_jobs: Option<u64>,
+    cap: u32,
+    batch_size: u32,
+    max_batch_chars: usize,
+    max_embedding_chars: usize,
+) -> bool {
+    if max_seconds.is_some() || cap <= 1 {
+        return false;
+    }
+    let per_request = effective_request_texts(batch_size, max_batch_chars, max_embedding_chars);
+    estimated_jobs.is_none_or(|jobs| jobs > u64::from(per_request))
+}
+
+/// Texts the live `OllamaEmbedder` puts in ONE `/api/embed` request: bounded by BOTH the count cap
+/// (`batch_size`, clamped to >=1 like the embedder) and the char budget (`max_batch_chars` / a
+/// representative per-text size), whichever is smaller. A small `max_batch_chars` splits work into
+/// many small requests, so the fan-out threshold must use the smaller of the two.
+fn effective_request_texts(
+    batch_size: u32,
+    max_batch_chars: usize,
+    max_embedding_chars: usize,
+) -> u32 {
+    let by_count = batch_size.max(1);
+    let by_chars =
+        (max_batch_chars / probe_text_chars(max_embedding_chars)).clamp(1, u32::MAX as usize);
+    by_count.min(by_chars as u32)
+}
+
+/// GENERIC sweep engine (backend-agnostic): measure texts/s at each `candidate` (built via `build`)
+/// against a representative workload, then pick the knee via [`select_knee`]. `build(concurrency,
+/// request_timeout_s)` gets a per-request HTTP timeout bounded by the tune budget so no single
+/// probe can hold the box past the budget.
+fn run_sweep<E: Embedder>(
+    candidates: Vec<u32>,
+    cap: u32,
+    per_text_chars: usize,
+    request_texts: u32,
+    request_timeout_s: u64,
+    budget_ms: u64,
+    build: impl Fn(u32, u64) -> E,
+) -> SweepOutcome {
+    if budget_ms < MIN_TUNE_BUDGET_MS {
+        return SweepOutcome::NotRun;
+    }
+    let per_candidate_ms = (budget_ms / candidates.len().max(1) as u64).max(1_000);
+    // Bound each blocking probe by its budget slice: a short RAG_RAT_TUNE_MS with a long configured
+    // request_timeout_s must not let one probe hold the paid box for the full HTTP timeout.
+    let probe_timeout = probe_timeout_s(request_timeout_s, per_candidate_ms);
+    let deadline = Instant::now() + std::time::Duration::from_millis(budget_ms);
+    let total_candidates = candidates.len();
+    let mut attempted = 0usize;
+    let mut results: Vec<SweepResult> = Vec::new();
+    for candidate in candidates {
+        if deadline.saturating_duration_since(Instant::now()).as_millis() < 1_000 {
+            break;
+        }
+        // A window of `candidate * request_texts` texts (each ~`per_text_chars`) splits — by the
+        // embedder's own count + char budget, which `request_texts` mirrors — into `candidate`
+        // sub-requests: one parallel wave exercising concurrency `candidate` at the LIVE
+        // per-request size. Candidates are ascending, so once the window BYTES exceed the
+        // allocation cap every higher one does too: stop (leaving the sweep incomplete →
+        // not cached), rather than shrink the request (which would measure a lighter cost
+        // than reconcile actually sends).
+        let window = (candidate as usize).saturating_mul(request_texts as usize).max(1);
+        if window.saturating_mul(per_text_chars) > MAX_PROBE_WINDOW_BYTES {
+            break;
+        }
+        attempted += 1;
+        let embedder = build(candidate, probe_timeout);
+        let texts = probe_texts(window, per_text_chars);
+        let candidate_deadline =
+            Instant::now() + std::time::Duration::from_millis(per_candidate_ms);
+        let started = Instant::now();
+        let mut embedded: u64 = 0;
+        let mut requests: u64 = 0;
+        let mut failures: u64 = 0;
+        while Instant::now() < candidate_deadline {
+            match embedder.embed_batch(&texts) {
+                Ok(vectors) => {
+                    embedded += vectors.len() as u64;
+                    requests += 1;
+                },
+                Err(_) => {
+                    failures += 1;
+                    if failures > u64::from(candidate) * 2 {
+                        break;
+                    }
+                },
+            }
+        }
+        let elapsed = started.elapsed().as_secs_f64().max(0.001);
+        results.push(SweepResult {
+            candidate,
+            texts_per_second: embedded as f64 / elapsed,
+            requests,
+            failures,
+            aborted: failures > u64::from(candidate) * 2,
+        });
+    }
+
+    match select_knee(&results, cap) {
+        // `complete` gates caching: a budget-truncated sweep (didn't attempt every candidate) is
+        // usable for this run but must not be persisted as the tuned knee for the full cap.
+        Some((knee, texts_per_second)) =>
+            SweepOutcome::Knee { knee, texts_per_second, complete: attempted == total_candidates },
+        None => SweepOutcome::NoStableCandidate,
+    }
+}
+
+/// Per-request HTTP timeout for a probe: the configured `request_timeout_s`, capped by this
+/// candidate's budget slice so one blocking `embed_batch` can't outlast the tune budget. Always
+/// ≥1s.
+fn probe_timeout_s(request_timeout_s: u64, per_candidate_ms: u64) -> u64 {
+    request_timeout_s.min(per_candidate_ms.div_ceil(1_000)).max(1)
+}
+
+/// Throughput scaled by the success ratio: a candidate that intermittently times out or resets is
+/// penalized in proportion to its failures, so a lossy fan-out can't win the knee on its successful
+/// requests alone (reconcile would treat those failures as failed chunk groups). Zero when it
+/// landed no successful request.
+fn penalized_tps(r: &SweepResult) -> f64 {
+    let total = r.requests + r.failures;
+    if r.requests == 0 || total == 0 {
+        return 0.0;
+    }
+    r.texts_per_second * (r.requests as f64 / total as f64)
+}
+
+/// Pick the knee from measured candidates: rank by failure-penalized throughput, drop
+/// breaker-tripped / no-success candidates, and return `(knee, raw texts/s)` — the
+/// LOWEST-concurrency candidate within 8% of the penalized peak, clamped to `cap`. `None` when
+/// nothing served stably.
+fn select_knee(results: &[SweepResult], cap: u32) -> Option<(u32, f64)> {
+    // `results` is concurrency-ascending (candidates are), so preserving order makes the FIRST hit
+    // at/above the threshold the lowest-concurrency knee.
+    let stable: Vec<(&SweepResult, f64)> = results
+        .iter()
+        .filter(|r| !r.aborted && r.requests > 0)
+        .map(|r| (r, penalized_tps(r)))
+        .filter(|(_, tps)| *tps > 0.0)
+        .collect();
+    let peak = stable.iter().map(|(_, tps)| *tps).fold(0.0_f64, f64::max);
+    if peak <= 0.0 {
+        return None;
+    }
+    let threshold = peak * 0.92;
+    let knee = stable
+        .iter()
+        .find(|(_, tps)| *tps >= threshold)
+        .or_else(|| stable.iter().max_by(|(_, a), (_, b)| a.total_cmp(b)))?;
+    Some((knee.0.candidate.min(cap).max(1), knee.0.texts_per_second))
+}
+
+/// Powers of two `<= cap`, plus the EXACT cap (a non-power-of-two cap like 24/127 must be tested so
+/// the tuner can use all the capacity the user allowed).
+fn sweep_candidates(cap: u32) -> Vec<u32> {
+    let cap = cap.clamp(1, 128);
+    let mut values: Vec<u32> = CONCURRENCY_CANDIDATES.into_iter().filter(|c| *c <= cap).collect();
+    if values.last() != Some(&cap) {
+        values.push(cap);
+    }
+    if values.is_empty() {
+        values.push(1);
+    }
+    values
+}
+
+/// Per-text size (chars) for synthetic probes: the configured live chunk cap
+/// (`max_embedding_chars`, what `build_embedding_input` truncates each chunk to), NOT a smaller
+/// fixed default — so the probe request's per-text compute/peak-memory matches the heaviest request
+/// reconcile will actually send, and the cached knee can't be measured on artificially cheap
+/// requests.
+fn probe_text_chars(max_embedding_chars: usize) -> usize {
+    max_embedding_chars.max(1)
+}
+
+/// `count` unique synthetic texts of ~`chars` each (unique prefix so a server input cache can't
+/// make the probe artificially fast).
+fn probe_texts(count: usize, chars: usize) -> Vec<String> {
+    (0..count)
+        .map(|i| {
+            let prefix = format!("rag-rat throughput probe {i}: ");
+            let mut text = prefix;
+            while text.len() < chars {
+                text.push_str("fn example() { let x = 1; return x; } ");
+            }
+            text.truncate(chars);
+            text
+        })
+        .collect()
+}
+
+// ── cache (index_meta JSON map) ──────────────────────────────────────────────
+
+#[derive(Clone, Copy)]
+struct TuneKey<'a> {
+    runtime: &'a str,
+    provider: &'a str,
+    gpu: &'a str,
+    model: &'a str,
+    num_ctx: u32,
+    batch_size: u32,
+    max_batch_chars: usize,
+    max_embedding_chars: usize,
+    request_timeout_s: u64,
+}
+
+fn tune_cache_key(k: TuneKey<'_>) -> String {
+    let raw = format!(
+        "{}\0{}\0{}\0{}\0{}\0{}\0{}\0{}\0{}",
+        k.runtime,
+        k.provider,
+        k.gpu,
+        k.model,
+        k.num_ctx,
+        k.batch_size,
+        k.max_batch_chars,
+        k.max_embedding_chars,
+        k.request_timeout_s,
+    );
+    let digest = Sha256::digest(raw.as_bytes());
+    digest.iter().take(16).map(|b| format!("{b:02x}")).collect()
+}
+
+fn read_cache(conn: &Connection) -> TuneCacheFile {
+    meta(conn, TUNE_CACHE_META_KEY)
+        .ok()
+        .flatten()
+        .and_then(|json| serde_json::from_str(&json).ok())
+        .unwrap_or_default()
+}
+
+/// The cached knee IF a recent sweep produced it under a cap `>=` the current cap (a RAISED cap
+/// re-sweeps to use the new capacity). Clamped down to the current cap so a LOWERED cap takes
+/// effect.
+fn fresh_cached_knee(conn: &Connection, key: &str, cap: u32) -> Option<u32> {
+    let entry = read_cache(conn).entries.remove(key)?;
+    fresh_knee_from_entry(&entry, cap, tune_ttl_ms(), now_ms())
+}
+
+/// The freshness decision for one cache entry, split out (pure) from the DB read so it's testable
+/// without env/clock: fresh (within `ttl_ms`, not future-dated) AND tuned under a cap `>=` the
+/// current `cap`; the knee is clamped down to the current cap so a LOWERED cap takes effect.
+/// `ttl_ms == 0` (the always-re-sweep env override) never returns a cached knee.
+fn fresh_knee_from_entry(
+    entry: &TuneCacheEntry,
+    cap: u32,
+    ttl_ms: u64,
+    now_ms: i64,
+) -> Option<u32> {
+    if ttl_ms == 0 {
+        return None;
+    }
+    let age = now_ms.saturating_sub(entry.updated_at_ms);
+    if age < 0 || age as u64 > ttl_ms {
+        return None;
+    }
+    if cap > entry.cap {
+        return None; // cap raised → re-sweep to use the new headroom
+    }
+    if entry.knee > cap {
+        // Cap lowered BELOW the measured knee: that exact fan-out (`cap`) was never swept, so don't
+        // fabricate it — re-sweep to measure a knee at or under the new cap.
+        return None;
+    }
+    Some(entry.knee.max(1))
+}
+
+fn write_cached_knee(conn: &Connection, key: &str, knee: u32, cap: u32, texts_per_second: f64) {
+    let mut cache = read_cache(conn);
+    cache.entries.insert(key.to_string(), TuneCacheEntry {
+        knee,
+        cap,
+        texts_per_second,
+        updated_at_ms: now_ms(),
+    });
+    if let Ok(json) = serde_json::to_string(&cache) {
+        let _ = set_meta(conn, TUNE_CACHE_META_KEY, &json);
+    }
+}
+
+// ── env knobs ────────────────────────────────────────────────────────────────
+
+fn tuning_disabled() -> bool {
+    matches!(std::env::var("RAG_RAT_DISABLE_TUNING").ok().as_deref(), Some("1") | Some("true"))
+}
+
+fn tune_budget_ms() -> u64 {
+    env_ms("RAG_RAT_TUNE_MS", DEFAULT_TUNE_BUDGET_MS)
+}
+
+fn tune_ttl_ms() -> u64 {
+    // 0 is a valid override (always re-sweep), so parse it explicitly rather than via `env_ms`.
+    match std::env::var("RAG_RAT_TUNE_TTL_MS") {
+        Ok(raw) => raw.trim().parse::<u64>().unwrap_or(DEFAULT_TUNE_TTL_MS),
+        Err(_) => DEFAULT_TUNE_TTL_MS,
+    }
+}
+
+fn env_ms(var: &str, default: u64) -> u64 {
+    match std::env::var(var) {
+        Ok(raw) => match raw.trim().parse::<u64>() {
+            Ok(v) if v > 0 => v,
+            _ => default,
+        },
+        Err(_) => default,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sweep_candidates_include_the_exact_cap() {
+        assert_eq!(sweep_candidates(32), vec![1, 2, 4, 8, 16, 32]);
+        assert_eq!(sweep_candidates(24), vec![1, 2, 4, 8, 16, 24]);
+        assert_eq!(sweep_candidates(127), vec![1, 2, 4, 8, 16, 32, 64, 127]);
+        assert_eq!(sweep_candidates(1), vec![1]);
+    }
+
+    #[test]
+    fn tune_cache_key_folds_the_request_shape_and_runtime() {
+        let base = TuneKey {
+            runtime: "ollama",
+            provider: "modal",
+            gpu: "L4",
+            model: "all-minilm",
+            num_ctx: 0,
+            batch_size: 256,
+            max_batch_chars: 384_000,
+            max_embedding_chars: 4_000,
+            request_timeout_s: 60,
+        };
+        let k = tune_cache_key(base);
+        // A different runtime (future infinity/vLLM) must NOT collide.
+        let infinity = tune_cache_key(TuneKey { runtime: "infinity", ..base });
+        assert_ne!(k, infinity);
+        // A different request-shape knob re-tunes.
+        let bigger_ctx = tune_cache_key(TuneKey { num_ctx: 8192, ..base });
+        assert_ne!(k, bigger_ctx);
+        let bigger_chunk = tune_cache_key(TuneKey { max_embedding_chars: 8_000, ..base });
+        assert_ne!(k, bigger_chunk);
+    }
+
+    #[test]
+    fn probe_texts_are_sized_and_unique() {
+        let texts = probe_texts(4, 512);
+        assert_eq!(texts.len(), 4);
+        for t in &texts {
+            assert_eq!(t.len(), 512);
+        }
+        assert_ne!(texts[0], texts[1]);
+    }
+
+    #[test]
+    fn sweep_is_worthwhile_only_when_the_live_run_fans_out() {
+        // cap, batch_size, max_batch_chars, max_embedding_chars — a big char budget so `batch_size`
+        // is the binding per-request size (256).
+        let big_chars = 10_000_000;
+        // Unbounded run, single-flight cap, > one batch of work → sweep.
+        assert!(sweep_is_worthwhile(None, Some(10_000), 32, 256, big_chars, 4_000));
+        // Bounded (`--max-seconds`) never widens the window → skip regardless of work.
+        assert!(!sweep_is_worthwhile(Some(30), Some(10_000), 32, 256, big_chars, 4_000));
+        // cap == 1: single-flight, nothing to optimize → skip.
+        assert!(!sweep_is_worthwhile(None, Some(10_000), 1, 256, big_chars, 4_000));
+        // Work fits one request (<= per_request 256) → no fan-out → skip.
+        assert!(!sweep_is_worthwhile(None, Some(256), 32, 256, big_chars, 4_000));
+        assert!(!sweep_is_worthwhile(None, Some(10), 32, 256, big_chars, 4_000));
+        // Just over one request → fans out → sweep.
+        assert!(sweep_is_worthwhile(None, Some(257), 32, 256, big_chars, 4_000));
+        // Unknown job count (query errored) but unbounded → sweep (don't skip on a transient
+        // error).
+        assert!(sweep_is_worthwhile(None, None, 32, 256, big_chars, 4_000));
+        // CHAR-SPLIT: a tiny max_batch_chars makes per_request ~1, so even 10 chunks fan out over
+        // ~10 one-text requests → sweep (the count-only threshold would have wrongly skipped).
+        assert!(sweep_is_worthwhile(None, Some(10), 32, 256, 500, 4_000));
+    }
+
+    #[test]
+    fn effective_request_texts_is_the_smaller_of_count_and_char_bounds() {
+        // Big char budget → the count cap binds (batch_size).
+        assert_eq!(effective_request_texts(256, 10_000_000, 4_000), 256);
+        // Small char budget → it binds: 500 chars / 4000-char texts → 0 → clamped to 1.
+        assert_eq!(effective_request_texts(256, 500, 4_000), 1);
+        // 5 texts of 4000 chars fit a 20000-char budget < batch_size → char bound wins.
+        assert_eq!(effective_request_texts(256, 20_000, 4_000), 5);
+        // batch_size 0 is clamped to 1 like the embedder (never a 0 per-request size).
+        assert_eq!(effective_request_texts(0, 10_000_000, 4_000), 1);
+    }
+
+    #[test]
+    fn probe_timeout_is_capped_by_the_budget_slice() {
+        // A short per-candidate slice caps a long configured request timeout.
+        assert_eq!(probe_timeout_s(60, 1_000), 1);
+        assert_eq!(probe_timeout_s(60, 4_500), 5); // 4.5s slice → ceil to 5s
+        // A generous slice leaves the configured timeout untouched.
+        assert_eq!(probe_timeout_s(30, 60_000), 30);
+        // Never zero.
+        assert_eq!(probe_timeout_s(0, 0), 1);
+    }
+
+    fn sr(candidate: u32, tps: f64, requests: u64, failures: u64, aborted: bool) -> SweepResult {
+        SweepResult { candidate, texts_per_second: tps, requests, failures, aborted }
+    }
+
+    #[test]
+    fn select_knee_picks_the_lowest_candidate_within_8pct_of_peak() {
+        // c=2 (100) and c=4 (104, within 8% of peak 104) are both clean → knee is the LOWER, c=2.
+        let results =
+            vec![sr(1, 60.0, 10, 0, false), sr(2, 100.0, 10, 0, false), sr(4, 104.0, 10, 0, false)];
+        assert_eq!(select_knee(&results, 32), Some((2, 100.0)));
+        // The knee is clamped to the cap.
+        assert_eq!(select_knee(&[sr(8, 100.0, 10, 0, false)], 4), Some((4, 100.0)));
+    }
+
+    #[test]
+    fn select_knee_penalizes_lossy_candidates() {
+        // c=16 has a higher RAW tps (180) but half its requests failed → penalized 90 < c=2's 100,
+        // so the lossy high fan-out must NOT win the knee on successful requests alone.
+        let results = vec![sr(2, 100.0, 10, 0, false), sr(16, 180.0, 5, 5, false)];
+        assert_eq!(select_knee(&results, 32), Some((2, 100.0)));
+    }
+
+    #[test]
+    fn select_knee_is_none_when_nothing_served_stably() {
+        // Every candidate breaker-tripped / landed no successful request.
+        let dead = vec![sr(1, 0.0, 0, 8, true), sr(2, 0.0, 0, 12, true)];
+        assert_eq!(select_knee(&dead, 32), None);
+    }
+
+    fn mem_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::index::schema::apply(&conn).unwrap();
+        conn
+    }
+
+    #[test]
+    fn cache_write_then_read_roundtrips_in_index_meta() {
+        let conn = mem_conn();
+        assert!(read_cache(&conn).entries.is_empty(), "fresh DB has no tune cache");
+        write_cached_knee(&conn, "k1", 8, 32, 123.0);
+        write_cached_knee(&conn, "k2", 2, 16, 50.0);
+        let cache = read_cache(&conn);
+        let e1 = cache.entries.get("k1").expect("k1 present");
+        assert_eq!((e1.knee, e1.cap), (8, 32));
+        let e2 = cache.entries.get("k2").expect("k2 present");
+        assert_eq!((e2.knee, e2.cap), (2, 16));
+        // A second write to an existing key overwrites in place (same JSON map).
+        write_cached_knee(&conn, "k1", 4, 32, 99.0);
+        assert_eq!(read_cache(&conn).entries.get("k1").unwrap().knee, 4);
+        assert_eq!(read_cache(&conn).entries.len(), 2);
+    }
+
+    #[test]
+    fn fresh_knee_from_entry_respects_ttl_and_cap() {
+        let entry = |knee, cap, updated_at_ms| TuneCacheEntry {
+            knee,
+            cap,
+            texts_per_second: 1.0,
+            updated_at_ms,
+        };
+        let now = 1_000_000i64;
+        // Fresh, cap still above the knee → reuse the measured knee.
+        assert_eq!(fresh_knee_from_entry(&entry(8, 32, now), 32, 10_000, now), Some(8));
+        assert_eq!(fresh_knee_from_entry(&entry(8, 32, now), 8, 10_000, now), Some(8));
+        // Cap lowered BELOW the measured knee → re-sweep (don't fabricate an untested fan-out).
+        assert_eq!(fresh_knee_from_entry(&entry(8, 32, now), 4, 10_000, now), None);
+        // Raised cap re-sweeps (don't reuse a knee measured under a smaller ceiling).
+        assert_eq!(fresh_knee_from_entry(&entry(8, 32, now), 64, 10_000, now), None);
+        // Expired (age > ttl) → miss.
+        assert_eq!(fresh_knee_from_entry(&entry(8, 32, now - 20_000), 32, 10_000, now), None);
+        // Future-dated (clock skew) → miss.
+        assert_eq!(fresh_knee_from_entry(&entry(8, 32, now + 5_000), 32, 10_000, now), None);
+        // ttl == 0 (always-re-sweep override) → miss.
+        assert_eq!(fresh_knee_from_entry(&entry(8, 32, now), 32, 0, now), None);
+    }
+
+    /// Deterministic fake: succeeds up to `fail_above` concurrency, errors above it (the ollama
+    /// high-concurrency cliff). A tiny sleep keeps the timed sweep from pure-spinning a core.
+    struct FakeEmbedder {
+        concurrency: u32,
+        fail_above: u32,
+    }
+    impl Embedder for FakeEmbedder {
+        fn model_id(&self) -> &str {
+            "fake"
+        }
+        fn dim(&self) -> usize {
+            3
+        }
+        fn embed_batch(&self, texts: &[String]) -> anyhow::Result<Vec<Vec<f32>>> {
+            std::thread::sleep(std::time::Duration::from_millis(1));
+            if self.concurrency > self.fail_above {
+                anyhow::bail!("overloaded at concurrency {}", self.concurrency);
+            }
+            Ok(texts.iter().map(|_| vec![0.0; 3]).collect())
+        }
+    }
+
+    #[test]
+    fn run_sweep_does_not_run_below_min_budget() {
+        // Budget under the minimum → the sweep is skipped entirely (caller uses the cap).
+        let outcome =
+            run_sweep(sweep_candidates(4), 4, 16, 4, 1, 1_000, |concurrency, _timeout| {
+                FakeEmbedder { concurrency, fail_above: 8 }
+            });
+        assert!(matches!(outcome, SweepOutcome::NotRun));
+    }
+
+    #[test]
+    fn run_sweep_selects_a_stable_low_knee_and_marks_it_complete() {
+        // cap 4 → candidates [1, 2, 4]; the box fails above concurrency 2, so 4 aborts and the knee
+        // is a stable low value. All candidates fit the budget → complete → cacheable.
+        let outcome = run_sweep(
+            sweep_candidates(4),
+            4,
+            16, // per_text_chars (tiny)
+            4,  // batch_size (tiny window)
+            1,  // request_timeout_s
+            MIN_TUNE_BUDGET_MS,
+            |concurrency, _timeout| FakeEmbedder { concurrency, fail_above: 2 },
+        );
+        match outcome {
+            SweepOutcome::Knee { knee, complete, .. } => {
+                assert!(knee <= 2, "knee {knee} should be a stable low value (box fails above 2)");
+                assert!(complete, "every candidate was attempted within the budget");
+            },
+            other => panic!("expected a Knee, got {other:?}"),
+        }
+    }
+
+    fn tune_remote(cap: u32) -> RemoteEmbeddingConfig {
+        RemoteEmbeddingConfig {
+            model: "all-minilm".to_string(),
+            cookbook: Some("@rag-rat/cookbook modal".to_string()),
+            concurrency: cap,
+            batch_size: 4,
+            max_batch_chars: 384_000,
+            request_timeout_s: 1,
+            num_ctx: None,
+            gpu: None,
+            ..RemoteEmbeddingConfig::default()
+        }
+    }
+
+    #[test]
+    fn tune_ollama_concurrency_returns_a_fresh_cached_knee_without_probing() {
+        let conn = mem_conn();
+        let remote = tune_remote(32);
+        let spec =
+            crate::embedding_models::spec(crate::embedding_models::FASTEMBED_MODEL_ID).unwrap();
+        // Pre-seed the cache with the exact key the tuner will compute (gpu None → "cpu", num_ctx
+        // 0).
+        let key = tune_cache_key(TuneKey {
+            runtime: "ollama",
+            provider: "modal",
+            gpu: "cpu",
+            model: "all-minilm",
+            num_ctx: 0,
+            batch_size: remote.batch_size,
+            max_batch_chars: remote.max_batch_chars,
+            max_embedding_chars: 4_000,
+            request_timeout_s: remote.request_timeout_s,
+        });
+        write_cached_knee(&conn, &key, 6, 32, 100.0);
+        // The endpoint is never contacted: the cache hits first, even with `allow_sweep = false`.
+        let knee = tune_ollama_concurrency(
+            &conn,
+            "modal",
+            "http://127.0.0.1:1",
+            None,
+            &remote,
+            spec,
+            4_000,
+            false,
+        );
+        assert_eq!(knee, 6);
+    }
+
+    #[test]
+    fn tune_ollama_concurrency_uses_the_cap_on_a_miss_when_sweep_disallowed() {
+        let conn = mem_conn();
+        let remote = tune_remote(8);
+        let spec =
+            crate::embedding_models::spec(crate::embedding_models::FASTEMBED_MODEL_ID).unwrap();
+        // No cache entry + `allow_sweep = false` (a bounded / non-fan-out run) → the raw cap, and
+        // the unreachable endpoint is never probed (no sweep runs).
+        let knee = tune_ollama_concurrency(
+            &conn,
+            "modal",
+            "http://127.0.0.1:1",
+            None,
+            &remote,
+            spec,
+            4_000,
+            false,
+        );
+        assert_eq!(knee, 8);
+        assert!(read_cache(&conn).entries.is_empty());
+    }
+
+    #[test]
+    fn tune_ollama_concurrency_falls_back_conservatively_when_every_probe_fails() {
+        let conn = mem_conn();
+        // Small cap → few candidates; unreachable endpoint → every probe fails fast (connection
+        // refused), so the sweep finds no stable candidate.
+        let remote = tune_remote(2);
+        let spec =
+            crate::embedding_models::spec(crate::embedding_models::FASTEMBED_MODEL_ID).unwrap();
+        let knee = tune_ollama_concurrency(
+            &conn,
+            "modal",
+            "http://127.0.0.1:1",
+            None,
+            &remote,
+            spec,
+            4_000,
+            true,
+        );
+        assert_eq!(knee, SWEEP_FALLBACK_CONCURRENCY);
+        // A failed sweep is never cached (nothing to reuse next time).
+        assert!(read_cache(&conn).entries.is_empty());
+    }
+}

--- a/crates/rag-rat-core/tests/fixtures/cookbook/stub_ok.sh
+++ b/crates/rag-rat-core/tests/fixtures/cookbook/stub_ok.sh
@@ -20,11 +20,16 @@ teardown() {
 }
 trap teardown TERM
 
+throughput=""
+if [ -n "$STUB_THROUGHPUT" ]; then
+  throughput=',"throughput":{"concurrency":4,"batch_size":128,"ollama_num_parallel":4,"max_batch_chars":96000}'
+fi
+
 # The `ready` event (the handshake) — type-tagged JSONL with a ts field.
 if [ -n "$STUB_AUTH" ]; then
-  printf '{"type":"ready","endpoint":"%s","auth_token":"%s","ts":1}\n' "$STUB_ENDPOINT" "$STUB_AUTH"
+  printf '{"type":"ready","endpoint":"%s","auth_token":"%s","ts":1%s}\n' "$STUB_ENDPOINT" "$STUB_AUTH" "$throughput"
 else
-  printf '{"type":"ready","endpoint":"%s","auth_token":null,"ts":1}\n' "$STUB_ENDPOINT"
+  printf '{"type":"ready","endpoint":"%s","auth_token":null,"ts":1%s}\n' "$STUB_ENDPOINT" "$throughput"
 fi
 
 # Stay alive until SIGTERM. `wait` lets the trap fire promptly; the background sleep loop keeps the

--- a/docs/config.md
+++ b/docs/config.md
@@ -76,9 +76,10 @@ model = "all-minilm"              # the Ollama-side model name (the server's own
 
 **EPHEMERAL** — provision an on-demand GPU box (e.g. Modal) for the bulk reconcile, then tear it
 down. rag-rat spawns the **cookbook** recipe as a subprocess; it provisions a box, prints a handshake
-when it's serving, and is torn down (SIGTERM) when the reconcile finishes. Queries embed against a
-**local** Ollama (`query_endpoint`) running the same model — so the query vectors share the same
-space as the remote-embedded chunks.
+(`ready`, carrying the endpoint) when it's serving, and is torn down (SIGTERM) when the reconcile
+finishes. rag-rat auto-tunes the client concurrency against the box itself (see below). Queries embed
+against a **local** Ollama (`query_endpoint`) running the same model — so the query vectors share the
+same space as the remote-embedded chunks.
 
 ```toml
 [llm.embedding]
@@ -102,7 +103,7 @@ model = "all-minilm"                        # the Ollama-side model name
                                             #     cold-start risk);
                                             #   RunPod = a gpuTypeId (default: NVIDIA RTX A4000).
 # batch_size = 256                          # texts per /api/embed request
-# concurrency = 32                          # 1..=128 concurrent /api/embed requests
+# concurrency = 32                          # 1..=128 — a CAP; rag-rat auto-tunes the client fan-out within it
 # max_batch_chars = 384000                  # max total input chars per /api/embed request
 # request_timeout_s = 60
 ```
@@ -117,8 +118,15 @@ need-first/id-first; rag-rat does not size-sort chunks.
 
 When `concurrency` is omitted, CONNECT configs default to `1` for upgrade safety with ordinary
 Ollama servers. Set it explicitly after starting the server with matching parallelism. EPHEMERAL
-cookbook configs default to `32`; the cookbook recipe is responsible for aligning server-side
-parallelism. Values above `128` are rejected to keep worker threads and reconcile windows bounded.
+cookbook configs default to `32`. For ephemeral configs `concurrency` is a **cap**: after the box
+boots, **rag-rat** (not the recipe) runs a short micro-sweep with its real `OllamaEmbedder` and
+auto-tunes the client fan-out *within* the cap, caching the chosen knee in the index's `index_meta`
+per `(runtime, provider, GPU, model, request-shape)` with a TTL. It uses that knee for the live
+reconcile but never raises it above — or overwrites — your configured value. Lower `concurrency` to
+tighten the cap; the tuner re-tunes within the new limit. `batch_size`/`max_batch_chars` are left
+untouched (the sweep does not vary them). Values above `128` are rejected to keep worker threads and
+reconcile windows bounded. `RAG_RAT_TUNE_MS` overrides the sweep budget, `RAG_RAT_TUNE_TTL_MS` the
+cache TTL (0 = re-sweep every time), and `RAG_RAT_DISABLE_TUNING=1` skips the sweep (uses the cap).
 
 ### Init cookbook catalog
 


### PR DESCRIPTION
## Summary

Closes #328.

For ephemeral cookbook-provisioned remote Ollama boxes (Modal / RunPod), rag-rat now **auto-tunes how many `/api/embed` requests it keeps in flight** during the bulk reconcile, instead of running the whole thing at a fixed guess. After the box verifies it's serving, rag-rat runs a short client-concurrency micro-sweep against it, picks the throughput knee, and uses that for the live reconcile fan-out.

### Cap model

`[remote] concurrency` is the user's **hard cap**, not a target. The tuner only ever optimizes *within* it:

- the tuned knee is clamped to the cap,
- the box's `OLLAMA_NUM_PARALLEL` is set to the cap, and
- the persisted config is never overwritten.

Lower `concurrency` to tighten the cap; the tuner re-tunes under the new limit.

### Tuning lives in rag-rat, not the cookbook recipe

The sweep runs the **real `OllamaEmbedder`** ([`throughput_tune.rs`](crates/rag-rat-core/src/index/ai/throughput_tune.rs)), so the measured request shape (num_ctx, batch size, char budget) matches what reconcile actually sends. The previous approach re-implemented that request inside the TS recipe and drifted from the real one on every knob — the root cause of a long tail of review churn.

- The sweep engine is **backend-agnostic**: a generic `run_sweep` over the `Embedder` trait plus a per-backend adapter, so the planned Infinity / vLLM backends reuse it.
- The chosen knee is cached in the index's `index_meta`, keyed by `runtime + provider + GPU + model + request-shape`, with a TTL.
- Env knobs: `RAG_RAT_TUNE_MS` (sweep budget), `RAG_RAT_TUNE_TTL_MS` (cache TTL; `0` = re-sweep every time), `RAG_RAT_DISABLE_TUNING=1` (skip the sweep, use the cap).

### Cookbook is now a dumb provisioner (`@rag-rat/cookbook` 0.4.0)

The recipe sets `OLLAMA_NUM_PARALLEL` straight from the cap (`ollama_num_parallel`) and emits only the endpoint (+ optional auth) on `ready`. It no longer sweeps or carries request-shape knobs. A legacy recipe's `throughput` field on `ready` is a tolerated unknown key on the Rust side, so an older published recipe still works.

## Validation

- `cargo nextest run -p rag-rat-core -p rag-rat` — 1273 pass
- `cargo clippy -p rag-rat-core --all-targets` — clean
- `cargo +nightly fmt`
- `npm run typecheck` + `npm run build` in `cookbook`
- Live end-to-end: Modal (L4 / A100) and RunPod (A4000) with all-minilm and nomic-embed-text; every box torn down and verified leak-free. Empirically, ollama embedding over the cookbook proxy is overhead/server-bound (not GPU-bound), so a bigger GPU doesn't move the knee — the tuner converges to a low value and stops.
