### PR TITLE
chore: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.10.0...rag-rat-core-v0.11.0) - 2026-07-01
+
+### Added
+
+- *(embed)* content-address the vector cache so embeddings survive reindex ([#357](https://github.com/cq27-dev/rag-rat/pull/357)) ([#358](https://github.com/cq27-dev/rag-rat/pull/358))
+- *(embed)* benchmark-embedding CLI behind the eval feature (Phase 3) ([#354](https://github.com/cq27-dev/rag-rat/pull/354))
+- *(embed)* embed light/incremental reconciles against the local query_endpoint ([#356](https://github.com/cq27-dev/rag-rat/pull/356))
+- *(embed)* model context-awareness — warn short-context models truncate long code, steer to a long-context model ([#351](https://github.com/cq27-dev/rag-rat/pull/351))
+- *(cookbook)* infinity + vLLM ephemeral recipes over OpenAI /v1/embeddings (Phase 2) ([#349](https://github.com/cq27-dev/rag-rat/pull/349))
+- *(embed)* centralize remote embedding on OpenAI /v1/embeddings + backend selector (Phase 1) ([#348](https://github.com/cq27-dev/rag-rat/pull/348))
+- *(embed)* auto-tune ephemeral remote embedding concurrency ([#342](https://github.com/cq27-dev/rag-rat/pull/342))
+- *(init)* add extensible ratatui wizard ([#337](https://github.com/cq27-dev/rag-rat/pull/337))
+- *(embed)* user-selectable GPU for ephemeral cookbook provisioning ([llm.embedding.remote] gpu) ([#335](https://github.com/cq27-dev/rag-rat/pull/335))
+- *(embed)* remote Ollama embedding — connect + ephemeral cookbook, hardened (#317/#318) ([#330](https://github.com/cq27-dev/rag-rat/pull/330))
+- *(embed)* wire Ollama end-to-end — connect mode (#317 task 5+6) ([#326](https://github.com/cq27-dev/rag-rat/pull/326))
+- *(embed)* OllamaEmbedder backend (#317 task 4) ([#325](https://github.com/cq27-dev/rag-rat/pull/325))
+- *(embed)* [embedding.remote] config block (#317 task 3) ([#324](https://github.com/cq27-dev/rag-rat/pull/324))
+- *(embed)* register the ollama backend — Backend::Ollama + registry row ([#317](https://github.com/cq27-dev/rag-rat/pull/317)) ([#322](https://github.com/cq27-dev/rag-rat/pull/322))
+
+### Fixed
+
+- *(ollama)* handle local embedding limits ([#340](https://github.com/cq27-dev/rag-rat/pull/340))
+- *(watch)* honor .gitignore in watch placement — stop exhausting inotify watches ([#331](https://github.com/cq27-dev/rag-rat/pull/331)) ([#332](https://github.com/cq27-dev/rag-rat/pull/332))
+- *(embed)* restore the public index::ai::MODEL2VEC_HF_REPO path (#320 review) ([#323](https://github.com/cq27-dev/rag-rat/pull/323))
+
+### Other
+
+- *(readme)* reframe as an agent-workflow conversion path ([#359](https://github.com/cq27-dev/rag-rat/pull/359))
+- *(embed)* unlock GPU-backend throughput — sweep visibility, higher cap, backend-aware provision timeout ([#350](https://github.com/cq27-dev/rag-rat/pull/350))
+- *(embed)* parallelize remote ollama reconcile ([#341](https://github.com/cq27-dev/rag-rat/pull/341))
+- *(embed)* extract index/ai/providers/ — single resolution chokepoint ([#317](https://github.com/cq27-dev/rag-rat/pull/317)) ([#320](https://github.com/cq27-dev/rag-rat/pull/320))
+
 ## [0.10.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.9.0...rag-rat-core-v0.10.0) - 2026-06-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3299,7 +3299,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rag-rat"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3322,7 +3322,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-mcp"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "3"
 # and the internal path deps below pin the same literal, so the three crates always publish in
 # lockstep. Bump this one line (and the two internal-dep `version`s under workspace.dependencies)
 # to release.
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Kristaps Karlsons"]
 edition = "2024"
 # Bundled SQLite (rusqlite `bundled` -> libsqlite3-sys 0.38.1) compiles a build script that uses the
@@ -28,8 +28,8 @@ categories = ["command-line-utilities", "development-tools"]
 # Internal crates — declared once here so the version requirement is set in lockstep with
 # [workspace.package].version above. Members reference these via `{ workspace = true }` and add
 # their own feature toggles at the use site.
-rag-rat-core = { version = "0.10.0", path = "crates/rag-rat-core", default-features = false }
-rag-rat-mcp = { version = "0.10.0", path = "crates/rag-rat-mcp", default-features = false }
+rag-rat-core = { version = "0.11.0", path = "crates/rag-rat-core", default-features = false }
+rag-rat-mcp = { version = "0.11.0", path = "crates/rag-rat-mcp", default-features = false }
 anyhow = "1.0"
 fastembed = { version = "5.17.2", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
 gix = { version = "0.84.0", default-features = false, features = ["status", "parallel", "sha1", "sha256", "revision", "blob-diff", "blame"] }


### PR DESCRIPTION



## 🤖 New release

* `rag-rat-core`: 0.10.0 -> 0.11.0 (⚠ API breaking changes)
* `rag-rat-mcp`: 0.10.0 -> 0.11.0 (✓ API compatible changes)
* `rag-rat`: 0.10.0 -> 0.11.0

### ⚠ `rag-rat-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ReconcileOptions.provision_remote in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/index/ai/mod.rs:309
  field EmbeddingModelSpec.max_tokens in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/embedding_models.rs:68
  field EmbeddingConfig.remote in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/config.rs:118
  field Config.llm in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/config.rs:20
  field Config.llm in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/config.rs:20
  field IndexStatus.llm in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/index/mod.rs:185
  field IndexStatus.llm in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/index/mod.rs:185

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field failed_chunks of variant ReconcileProgress::Batch in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/index/ai/mod.rs:348
  field failed_chunks of variant ReconcileProgress::Finished in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/index/ai/mod.rs:354

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant ConfigError:RemoteEmbeddingMissingModel in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/config.rs:1172
  variant ConfigError:RemoteBackendUnknown in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/config.rs:1177
  variant ConfigError:RemoteQueryEndpointRequiredForBackend in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/config.rs:1184
  variant ConfigError:RemoteEmbeddingModeAmbiguous in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/config.rs:1189
  variant ConfigError:RemoteEmbeddingEndpointHasCredentials in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/config.rs:1195
  variant ConfigError:RemoteGpuRequiresCookbook in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/config.rs:1200
  variant ConfigError:RemoteGpuEmpty in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/config.rs:1206
  variant ConfigError:RemoteEmbeddingInvalidNumCtx in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/config.rs:1211
  variant ConfigError:RemoteEmbeddingConcurrencyTooHigh in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/config.rs:1215
  variant ConfigError:RemoteEmbeddingNonTransformerModel in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/config.rs:1223
  variant ConfigError:LocalAiTableRenamed in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/config.rs:1229
  variant Backend:Ollama in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/embedding_models.rs:35

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function rag_rat_core::embedding_models::spec_for_alias, previously in file /tmp/.tmpk5wIFG/rag-rat-core/src/embedding_models.rs:155

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  IndexDatabase::local_ai_status, previously in file /tmp/.tmpk5wIFG/rag-rat-core/src/index/query_api/ai_lifecycle.rs:8
  IndexDatabase::local_ai_status, previously in file /tmp/.tmpk5wIFG/rag-rat-core/src/index/query_api/ai_lifecycle.rs:8

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  rag_rat_core::index::IndexDatabase::install_model takes 1 parameters in /tmp/.tmpk5wIFG/rag-rat-core/src/index/query_api/ai_lifecycle.rs:16, but now takes 2 parameters in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/index/query_api/ai_lifecycle.rs:20
  rag_rat_core::IndexDatabase::install_model takes 1 parameters in /tmp/.tmpk5wIFG/rag-rat-core/src/index/query_api/ai_lifecycle.rs:16, but now takes 2 parameters in /tmp/.tmpMCIYoc/rag-rat/crates/rag-rat-core/src/index/query_api/ai_lifecycle.rs:20

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct rag_rat_core::index::ai::LocalAiStatus, previously in file /tmp/.tmpk5wIFG/rag-rat-core/src/index/ai/mod.rs:231
  struct rag_rat_core::config::LocalAiConfig, previously in file /tmp/.tmpk5wIFG/rag-rat-core/src/config.rs:100

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field local_ai of struct Config, previously in file /tmp/.tmpk5wIFG/rag-rat-core/src/config.rs:17
  field local_ai of struct Config, previously in file /tmp/.tmpk5wIFG/rag-rat-core/src/config.rs:17
  field aliases of struct EmbeddingModelSpec, previously in file /tmp/.tmpk5wIFG/rag-rat-core/src/embedding_models.rs:58
  field local_ai of struct IndexStatus, previously in file /tmp/.tmpk5wIFG/rag-rat-core/src/index/mod.rs:185
  field local_ai of struct IndexStatus, previously in file /tmp/.tmpk5wIFG/rag-rat-core/src/index/mod.rs:185
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rag-rat-core`

<blockquote>

## [0.11.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.10.0...rag-rat-core-v0.11.0) - 2026-07-01

### Added

- *(embed)* content-address the vector cache so embeddings survive reindex ([#357](https://github.com/cq27-dev/rag-rat/pull/357)) ([#358](https://github.com/cq27-dev/rag-rat/pull/358))
- *(embed)* benchmark-embedding CLI behind the eval feature (Phase 3) ([#354](https://github.com/cq27-dev/rag-rat/pull/354))
- *(embed)* embed light/incremental reconciles against the local query_endpoint ([#356](https://github.com/cq27-dev/rag-rat/pull/356))
- *(embed)* model context-awareness — warn short-context models truncate long code, steer to a long-context model ([#351](https://github.com/cq27-dev/rag-rat/pull/351))
- *(cookbook)* infinity + vLLM ephemeral recipes over OpenAI /v1/embeddings (Phase 2) ([#349](https://github.com/cq27-dev/rag-rat/pull/349))
- *(embed)* centralize remote embedding on OpenAI /v1/embeddings + backend selector (Phase 1) ([#348](https://github.com/cq27-dev/rag-rat/pull/348))
- *(embed)* auto-tune ephemeral remote embedding concurrency ([#342](https://github.com/cq27-dev/rag-rat/pull/342))
- *(init)* add extensible ratatui wizard ([#337](https://github.com/cq27-dev/rag-rat/pull/337))
- *(embed)* user-selectable GPU for ephemeral cookbook provisioning ([llm.embedding.remote] gpu) ([#335](https://github.com/cq27-dev/rag-rat/pull/335))
- *(embed)* remote Ollama embedding — connect + ephemeral cookbook, hardened (#317/#318) ([#330](https://github.com/cq27-dev/rag-rat/pull/330))
- *(embed)* wire Ollama end-to-end — connect mode (#317 task 5+6) ([#326](https://github.com/cq27-dev/rag-rat/pull/326))
- *(embed)* OllamaEmbedder backend (#317 task 4) ([#325](https://github.com/cq27-dev/rag-rat/pull/325))
- *(embed)* [embedding.remote] config block (#317 task 3) ([#324](https://github.com/cq27-dev/rag-rat/pull/324))
- *(embed)* register the ollama backend — Backend::Ollama + registry row ([#317](https://github.com/cq27-dev/rag-rat/pull/317)) ([#322](https://github.com/cq27-dev/rag-rat/pull/322))

### Fixed

- *(ollama)* handle local embedding limits ([#340](https://github.com/cq27-dev/rag-rat/pull/340))
- *(watch)* honor .gitignore in watch placement — stop exhausting inotify watches ([#331](https://github.com/cq27-dev/rag-rat/pull/331)) ([#332](https://github.com/cq27-dev/rag-rat/pull/332))
- *(embed)* restore the public index::ai::MODEL2VEC_HF_REPO path (#320 review) ([#323](https://github.com/cq27-dev/rag-rat/pull/323))

### Other

- *(readme)* reframe as an agent-workflow conversion path ([#359](https://github.com/cq27-dev/rag-rat/pull/359))
- *(embed)* unlock GPU-backend throughput — sweep visibility, higher cap, backend-aware provision timeout ([#350](https://github.com/cq27-dev/rag-rat/pull/350))
- *(embed)* parallelize remote ollama reconcile ([#341](https://github.com/cq27-dev/rag-rat/pull/341))
- *(embed)* extract index/ai/providers/ — single resolution chokepoint ([#317](https://github.com/cq27-dev/rag-rat/pull/317)) ([#320](https://github.com/cq27-dev/rag-rat/pull/320))
</blockquote>

## `rag-rat-mcp`

<blockquote>

## [0.11.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.10.0...rag-rat-core-v0.11.0) - 2026-07-01

### Added

- *(embed)* content-address the vector cache so embeddings survive reindex ([#357](https://github.com/cq27-dev/rag-rat/pull/357)) ([#358](https://github.com/cq27-dev/rag-rat/pull/358))
- *(embed)* benchmark-embedding CLI behind the eval feature (Phase 3) ([#354](https://github.com/cq27-dev/rag-rat/pull/354))
- *(embed)* embed light/incremental reconciles against the local query_endpoint ([#356](https://github.com/cq27-dev/rag-rat/pull/356))
- *(embed)* model context-awareness — warn short-context models truncate long code, steer to a long-context model ([#351](https://github.com/cq27-dev/rag-rat/pull/351))
- *(cookbook)* infinity + vLLM ephemeral recipes over OpenAI /v1/embeddings (Phase 2) ([#349](https://github.com/cq27-dev/rag-rat/pull/349))
- *(embed)* centralize remote embedding on OpenAI /v1/embeddings + backend selector (Phase 1) ([#348](https://github.com/cq27-dev/rag-rat/pull/348))
- *(embed)* auto-tune ephemeral remote embedding concurrency ([#342](https://github.com/cq27-dev/rag-rat/pull/342))
- *(init)* add extensible ratatui wizard ([#337](https://github.com/cq27-dev/rag-rat/pull/337))
- *(embed)* user-selectable GPU for ephemeral cookbook provisioning ([llm.embedding.remote] gpu) ([#335](https://github.com/cq27-dev/rag-rat/pull/335))
- *(embed)* remote Ollama embedding — connect + ephemeral cookbook, hardened (#317/#318) ([#330](https://github.com/cq27-dev/rag-rat/pull/330))
- *(embed)* wire Ollama end-to-end — connect mode (#317 task 5+6) ([#326](https://github.com/cq27-dev/rag-rat/pull/326))
- *(embed)* OllamaEmbedder backend (#317 task 4) ([#325](https://github.com/cq27-dev/rag-rat/pull/325))
- *(embed)* [embedding.remote] config block (#317 task 3) ([#324](https://github.com/cq27-dev/rag-rat/pull/324))
- *(embed)* register the ollama backend — Backend::Ollama + registry row ([#317](https://github.com/cq27-dev/rag-rat/pull/317)) ([#322](https://github.com/cq27-dev/rag-rat/pull/322))

### Fixed

- *(ollama)* handle local embedding limits ([#340](https://github.com/cq27-dev/rag-rat/pull/340))
- *(watch)* honor .gitignore in watch placement — stop exhausting inotify watches ([#331](https://github.com/cq27-dev/rag-rat/pull/331)) ([#332](https://github.com/cq27-dev/rag-rat/pull/332))
- *(embed)* restore the public index::ai::MODEL2VEC_HF_REPO path (#320 review) ([#323](https://github.com/cq27-dev/rag-rat/pull/323))

### Other

- *(readme)* reframe as an agent-workflow conversion path ([#359](https://github.com/cq27-dev/rag-rat/pull/359))
- *(embed)* unlock GPU-backend throughput — sweep visibility, higher cap, backend-aware provision timeout ([#350](https://github.com/cq27-dev/rag-rat/pull/350))
- *(embed)* parallelize remote ollama reconcile ([#341](https://github.com/cq27-dev/rag-rat/pull/341))
- *(embed)* extract index/ai/providers/ — single resolution chokepoint ([#317](https://github.com/cq27-dev/rag-rat/pull/317)) ([#320](https://github.com/cq27-dev/rag-rat/pull/320))
</blockquote>

## `rag-rat`

<blockquote>

## [0.11.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.10.0...rag-rat-core-v0.11.0) - 2026-07-01

### Added

- *(embed)* content-address the vector cache so embeddings survive reindex ([#357](https://github.com/cq27-dev/rag-rat/pull/357)) ([#358](https://github.com/cq27-dev/rag-rat/pull/358))
- *(embed)* benchmark-embedding CLI behind the eval feature (Phase 3) ([#354](https://github.com/cq27-dev/rag-rat/pull/354))
- *(embed)* embed light/incremental reconciles against the local query_endpoint ([#356](https://github.com/cq27-dev/rag-rat/pull/356))
- *(embed)* model context-awareness — warn short-context models truncate long code, steer to a long-context model ([#351](https://github.com/cq27-dev/rag-rat/pull/351))
- *(cookbook)* infinity + vLLM ephemeral recipes over OpenAI /v1/embeddings (Phase 2) ([#349](https://github.com/cq27-dev/rag-rat/pull/349))
- *(embed)* centralize remote embedding on OpenAI /v1/embeddings + backend selector (Phase 1) ([#348](https://github.com/cq27-dev/rag-rat/pull/348))
- *(embed)* auto-tune ephemeral remote embedding concurrency ([#342](https://github.com/cq27-dev/rag-rat/pull/342))
- *(init)* add extensible ratatui wizard ([#337](https://github.com/cq27-dev/rag-rat/pull/337))
- *(embed)* user-selectable GPU for ephemeral cookbook provisioning ([llm.embedding.remote] gpu) ([#335](https://github.com/cq27-dev/rag-rat/pull/335))
- *(embed)* remote Ollama embedding — connect + ephemeral cookbook, hardened (#317/#318) ([#330](https://github.com/cq27-dev/rag-rat/pull/330))
- *(embed)* wire Ollama end-to-end — connect mode (#317 task 5+6) ([#326](https://github.com/cq27-dev/rag-rat/pull/326))
- *(embed)* OllamaEmbedder backend (#317 task 4) ([#325](https://github.com/cq27-dev/rag-rat/pull/325))
- *(embed)* [embedding.remote] config block (#317 task 3) ([#324](https://github.com/cq27-dev/rag-rat/pull/324))
- *(embed)* register the ollama backend — Backend::Ollama + registry row ([#317](https://github.com/cq27-dev/rag-rat/pull/317)) ([#322](https://github.com/cq27-dev/rag-rat/pull/322))

### Fixed

- *(ollama)* handle local embedding limits ([#340](https://github.com/cq27-dev/rag-rat/pull/340))
- *(watch)* honor .gitignore in watch placement — stop exhausting inotify watches ([#331](https://github.com/cq27-dev/rag-rat/pull/331)) ([#332](https://github.com/cq27-dev/rag-rat/pull/332))
- *(embed)* restore the public index::ai::MODEL2VEC_HF_REPO path (#320 review) ([#323](https://github.com/cq27-dev/rag-rat/pull/323))

### Other

- *(readme)* reframe as an agent-workflow conversion path ([#359](https://github.com/cq27-dev/rag-rat/pull/359))
- *(embed)* unlock GPU-backend throughput — sweep visibility, higher cap, backend-aware provision timeout ([#350](https://github.com/cq27-dev/rag-rat/pull/350))
- *(embed)* parallelize remote ollama reconcile ([#341](https://github.com/cq27-dev/rag-rat/pull/341))
- *(embed)* extract index/ai/providers/ — single resolution chokepoint ([#317](https://github.com/cq27-dev/rag-rat/pull/317)) ([#320](https://github.com/cq27-dev/rag-rat/pull/320))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).