### PR TITLE
feat(embed): centralize remote embedding on OpenAI /v1/embeddings + backend selector (Phase 1)

### DIFF
--- a/crates/rag-rat-cli/src/init/wizard/steps.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps.rs
@@ -2145,6 +2145,10 @@ fn remote_config_for(d: &RemoteDraft) -> RemoteEmbeddingConfig {
     };
     RemoteEmbeddingConfig {
         model: d.model.clone(),
+        // The wizard's Remote step does not yet offer a backend picker (follow-up), so it drafts
+        // the default `ollama` backend; a user wanting infinity/vLLM sets `[remote]
+        // backend` in the TOML.
+        backend: rag_rat_core::config::RemoteBackend::Ollama,
         endpoint: ep,
         cookbook: cb,
         query_endpoint: None,

--- a/crates/rag-rat-cli/src/init/wizard/steps.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps.rs
@@ -16,7 +16,7 @@ use rag_rat_core::index::ai::FastEmbedEmbedder;
 #[cfg(feature = "model2vec")]
 use rag_rat_core::index::ai::Model2VecEmbedder;
 use rag_rat_core::index::ai::{
-    Embedder, HashEmbedder, OllamaEmbedder, verify_ephemeral_remote_cancellable,
+    Embedder, HashEmbedder, OpenAiEmbedder, verify_ephemeral_remote_cancellable,
 };
 use rag_rat_core::index::oracle::{OracleTool, ToolAvailability, ToolManifest, probe_oracle_tool};
 use rag_rat_core::language::Language;
@@ -2193,7 +2193,7 @@ fn probe_download(id: String, log_tx: Sender<String>) -> CheckResult {
 }
 
 fn probe_connect(r: RemoteEmbeddingConfig, s: &EmbeddingModelSpec) -> CheckResult {
-    match OllamaEmbedder::from_remote_config(&r, s.model_id, s.dim) {
+    match OpenAiEmbedder::from_remote_config(&r, s.model_id, s.dim) {
         Ok(e) => match e.embed_batch(&["ping".to_string()]) {
             Ok(v) if v.first().is_some_and(|x| !x.is_empty()) => CheckResult::ok(),
             Ok(_) => CheckResult::warn("empty embedding"),

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -219,16 +219,56 @@ impl Default for EmbeddingRuntimeConfig {
     }
 }
 
-/// Remote-embedding offload (`[llm.embedding.remote]`). Hands embedding work to an HTTP
-/// server (Ollama's `/api/embed`) instead of running the model in-process — the lever for huge
-/// repos whose in-process backfill is too slow on the indexing box. Optional: absent → in-process
-/// embedding only.
+/// Which OpenAI-compatible embedding server serves a `[remote]` block. All three speak the SAME
+/// wire API (`POST /v1/embeddings`), so the embedding client is IDENTICAL regardless of backend —
+/// the selector only routes ephemeral provisioning (which cookbook container), the freshness /
+/// vector- identity marker (different backends can produce slightly different vectors), the tune
+/// cache key, and the `ai_models.runtime` install marker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RemoteBackend {
+    /// ollama, via its `/v1/embeddings` OpenAI-compatibility route (the default; back-compat).
+    #[default]
+    Ollama,
+    /// michaelfeil/infinity (`infinity_emb v2 --model-id <hf>`).
+    Infinity,
+    /// vLLM in embedding mode (`vllm serve <hf> --task embed`).
+    Vllm,
+}
+
+impl RemoteBackend {
+    /// The stable wire/DB string (matches the serde repr): the `ai_models.runtime` marker, and the
+    /// backend discriminator folded into the freshness key + the tune cache key.
+    pub fn as_db_str(self) -> &'static str {
+        match self {
+            RemoteBackend::Ollama => "ollama",
+            RemoteBackend::Infinity => "infinity",
+            RemoteBackend::Vllm => "vllm",
+        }
+    }
+
+    /// Parse a config `backend = "..."` value (case-insensitive). `None` for an unknown value — the
+    /// config layer turns that into `ConfigError::RemoteBackendUnknown`.
+    pub fn from_db_str(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "ollama" => Some(RemoteBackend::Ollama),
+            "infinity" => Some(RemoteBackend::Infinity),
+            "vllm" => Some(RemoteBackend::Vllm),
+            _ => None,
+        }
+    }
+}
+
+/// Remote-embedding offload (`[llm.embedding.remote]`). Hands embedding work to an
+/// OpenAI-compatible HTTP server (`POST /v1/embeddings` on ollama/infinity/vLLM) instead of running
+/// the model in-process — the lever for huge repos whose in-process backfill is too slow on the
+/// indexing box. Optional: absent → in-process embedding only.
 ///
-/// Deliberately carries NO `dim` or `backend` field. The vector dimension comes from the registry
-/// spec of the SELECTED model (`model = "sentence-transformers/all-MiniLM-L6-v2"`, dim 384) and is
-/// validated against the server's first response at runtime by the embedder; the runtime is implied
-/// by this block's mere PRESENCE (#317 rework). Duplicating either here would be redundant and
-/// drift-prone.
+/// Carries NO `dim` field: the vector dimension comes from the registry spec of the SELECTED model
+/// (`model = "sentence-transformers/all-MiniLM-L6-v2"`, dim 384) and is validated against the
+/// server's first response at runtime by the embedder; duplicating it here would be redundant and
+/// drift-prone. The `backend` selector (default `ollama`) picks WHICH server; the runtime is
+/// implied by this block's mere PRESENCE (#317 rework).
 ///
 /// The mode is INFERRED, not configured — there is no `mode` field (#318). EXACTLY ONE of
 /// `endpoint` / `cookbook` is set:
@@ -244,10 +284,19 @@ impl Default for EmbeddingRuntimeConfig {
 /// the serialized JSON holds no secret. `Deserialize` is the read side of that meta round-trip.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RemoteEmbeddingConfig {
-    /// The Ollama API model name sent to `/api/embed` (e.g. `"all-minilm"`). This is the server's
-    /// own model identifier, NOT a `rag-rat` registry alias — the registry only supplies the dim
-    /// parity contract.
+    /// The SERVER-side model name sent in the `/v1/embeddings` request body — the server's own
+    /// identifier, NOT a `rag-rat` registry alias (the registry only supplies the dim parity
+    /// contract). For `backend = "ollama"` this is the ollama model name (e.g. `"all-minilm"`);
+    /// for infinity/vLLM it is the HuggingFace id the server was launched with (e.g.
+    /// `"sentence-transformers/all-MiniLM-L6-v2"`).
     pub model: String,
+    /// Which OpenAI-compatible server serves this block (`ollama` | `infinity` | `vllm`). The wire
+    /// call is identical across backends; this only routes provisioning + the
+    /// freshness/tune/install markers. `#[serde(default)]` → `Ollama` so config JSON persisted
+    /// before this field (and any omitted TOML) still deserializes as the pre-existing ollama
+    /// behavior.
+    #[serde(default)]
+    pub backend: RemoteBackend,
     /// CONNECT: base URL of an already-running Ollama (e.g. `"http://localhost:11434"`);
     /// `/api/embed` is appended by the embedder. Mutually exclusive with `cookbook`.
     pub endpoint: Option<String>,
@@ -321,6 +370,7 @@ impl Default for RemoteEmbeddingConfig {
     fn default() -> Self {
         Self {
             model: String::new(),
+            backend: RemoteBackend::Ollama,
             endpoint: None,
             cookbook: None,
             query_endpoint: None,
@@ -865,6 +915,7 @@ impl TryFrom<RawEmbedding> for EmbeddingConfig {
 #[derive(Debug, Default, Deserialize)]
 struct RawRemoteEmbedding {
     model: Option<String>,
+    backend: Option<String>,
     endpoint: Option<String>,
     cookbook: Option<String>,
     query_endpoint: Option<String>,
@@ -924,12 +975,19 @@ impl TryFrom<RawRemoteEmbedding> for RemoteEmbeddingConfig {
     fn try_from(raw: RawRemoteEmbedding) -> Result<Self, Self::Error> {
         let default = RemoteEmbeddingConfig::default();
         let trimmed = |s: Option<String>| s.map(|v| v.trim().to_string()).filter(|v| !v.is_empty());
-        // The Ollama API model name (e.g. `all-minilm`) — required, non-empty.
+        // The SERVER-side model name — required, non-empty. For ollama the ollama model name; for
+        // infinity/vLLM the HF id the server was launched with.
         let model = raw.model.unwrap_or_default();
         let model = model.trim();
         if model.is_empty() {
             return Err(ConfigError::RemoteEmbeddingMissingModel);
         }
+        // Which OpenAI-compatible server serves this block. Omitted → `ollama` (back-compat).
+        let backend = match trimmed(raw.backend) {
+            None => RemoteBackend::default(),
+            Some(raw_backend) => RemoteBackend::from_db_str(&raw_backend)
+                .ok_or(ConfigError::RemoteBackendUnknown(raw_backend))?,
+        };
         // The MODE is INFERRED from which URL field is set (#318): EXACTLY ONE of `endpoint`
         // (connect) / `cookbook` (ephemeral). Both → ambiguous; neither → no server to reach.
         let endpoint = trimmed(raw.endpoint);
@@ -993,6 +1051,7 @@ impl TryFrom<RawRemoteEmbedding> for RemoteEmbeddingConfig {
         }
         Ok(Self {
             model: model.to_string(),
+            backend,
             endpoint,
             cookbook,
             query_endpoint,
@@ -1059,7 +1118,12 @@ pub enum ConfigError {
     )]
     RemoteEmbeddingMissingModel,
     #[error(
-        "[llm.embedding.remote] requires EXACTLY ONE of `endpoint` (connect to a running Ollama) \
+        "[llm.embedding.remote] `backend` must be one of `ollama`, `infinity`, or `vllm` (got \
+         `{0}`)"
+    )]
+    RemoteBackendUnknown(String),
+    #[error(
+        "[llm.embedding.remote] requires EXACTLY ONE of `endpoint` (connect to a running server) \
          or `cookbook` (provision an ephemeral box) — set neither both nor zero"
     )]
     RemoteEmbeddingModeAmbiguous,
@@ -1468,6 +1532,7 @@ mod tests {
             llm.embedding.remote,
             Some(RemoteEmbeddingConfig {
                 model: "all-minilm".to_string(),
+                backend: RemoteBackend::Ollama,
                 endpoint: Some("http://localhost:11434".to_string()),
                 cookbook: None,
                 query_endpoint: None, // connect mode: no local query box
@@ -1644,6 +1709,7 @@ mod tests {
             llm.embedding.remote,
             Some(RemoteEmbeddingConfig {
                 model: "all-minilm".to_string(),
+                backend: RemoteBackend::Ollama,
                 endpoint: Some("http://localhost:11434".to_string()),
                 cookbook: None,
                 query_endpoint: None,
@@ -1917,6 +1983,48 @@ mod tests {
             matches!(err, ConfigError::RemoteEmbeddingMissingModel),
             "whitespace-only [remote] model → RemoteEmbeddingMissingModel, got {err:?}",
         );
+    }
+
+    #[test]
+    fn remote_backend_parses_defaults_to_ollama_and_rejects_unknown() {
+        let parse = |backend_line: &str| -> Result<RemoteEmbeddingConfig, ConfigError> {
+            let raw: RawConfig = toml::from_str(&format!(
+                r#"
+                [index]
+                root = "."
+
+                [llm.embedding]
+                model = "sentence-transformers/all-MiniLM-L6-v2"
+
+                [llm.embedding.remote]
+                model = "all-minilm"
+                endpoint = "http://localhost:11434"
+                {backend_line}
+                "#
+            ))
+            .unwrap();
+            LlmConfig::try_from(raw.llm).map(|llm| llm.embedding.remote.unwrap())
+        };
+        // Omitted → ollama (back-compat with pre-selector configs).
+        assert_eq!(parse("").unwrap().backend, RemoteBackend::Ollama);
+        // Explicit, case-insensitive.
+        assert_eq!(parse(r#"backend = "infinity""#).unwrap().backend, RemoteBackend::Infinity);
+        assert_eq!(parse(r#"backend = "VLLM""#).unwrap().backend, RemoteBackend::Vllm);
+        // Unknown → a clear config error naming the bad value.
+        let err = parse(r#"backend = "tgi""#).unwrap_err();
+        assert!(matches!(&err, ConfigError::RemoteBackendUnknown(v) if v == "tgi"), "got {err:?}");
+    }
+
+    #[test]
+    fn remote_backend_db_str_round_trips_and_matches_serde() {
+        for b in [RemoteBackend::Ollama, RemoteBackend::Infinity, RemoteBackend::Vllm] {
+            assert_eq!(RemoteBackend::from_db_str(b.as_db_str()), Some(b));
+            // The serde repr (persisted into the index meta) MUST equal `as_db_str` (the runtime
+            // marker + freshness/tune-key discriminator) so the two representations never drift.
+            let json = serde_json::to_string(&b).unwrap();
+            assert_eq!(json, format!("\"{}\"", b.as_db_str()));
+        }
+        assert_eq!(RemoteBackend::from_db_str("nope"), None);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -257,6 +257,18 @@ impl RemoteBackend {
             _ => None,
         }
     }
+
+    /// The HTTP path (appended to the endpoint) of this backend's embeddings route. The
+    /// request/response SHAPE is identical across backends (OpenAI `{model,input}` →
+    /// `{data:[{embedding,index}]}`); only the PATH differs: ollama and vLLM expose the
+    /// OpenAI-standard `/v1/embeddings`, while michaelfeil/infinity's `v2` server serves it at
+    /// `/embeddings` (verified live against `michaelf34/infinity:latest-cpu`).
+    pub fn embed_path(self) -> &'static str {
+        match self {
+            RemoteBackend::Ollama | RemoteBackend::Vllm => "/v1/embeddings",
+            RemoteBackend::Infinity => "/embeddings",
+        }
+    }
 }
 
 /// Remote-embedding offload (`[llm.embedding.remote]`). Hands embedding work to an
@@ -2025,6 +2037,15 @@ mod tests {
             assert_eq!(json, format!("\"{}\"", b.as_db_str()));
         }
         assert_eq!(RemoteBackend::from_db_str("nope"), None);
+    }
+
+    #[test]
+    fn remote_backend_embed_path_is_per_backend() {
+        // ollama + vLLM expose the OpenAI-standard route; infinity's v2 server serves `/embeddings`
+        // (verified live). Same request/response shape — only the path differs.
+        assert_eq!(RemoteBackend::Ollama.embed_path(), "/v1/embeddings");
+        assert_eq!(RemoteBackend::Vllm.embed_path(), "/v1/embeddings");
+        assert_eq!(RemoteBackend::Infinity.embed_path(), "/embeddings");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/helpers.rs
+++ b/crates/rag-rat-core/src/index/ai/helpers.rs
@@ -515,6 +515,7 @@ mod tests {
     fn sample_remote() -> RemoteEmbeddingConfig {
         RemoteEmbeddingConfig {
             model: "all-minilm".to_string(),
+            backend: crate::config::RemoteBackend::Ollama,
             endpoint: Some("http://localhost:11434".to_string()),
             cookbook: None,
             query_endpoint: None,
@@ -614,6 +615,7 @@ mod tests {
         activate_model(&conn, FASTEMBED_MODEL_ID);
         let remote = RemoteEmbeddingConfig {
             model: "all-minilm".to_string(),
+            backend: crate::config::RemoteBackend::Ollama,
             endpoint: Some(format!("http://127.0.0.1:{port}")),
             cookbook: None,
             query_endpoint: None,

--- a/crates/rag-rat-core/src/index/ai/helpers.rs
+++ b/crates/rag-rat-core/src/index/ai/helpers.rs
@@ -435,7 +435,7 @@ pub(crate) fn active_remote_config(
 }
 
 /// Drop the persisted remote-embedding config meta — called when a model is installed LOCALLY, so
-/// `active_embedder` stops reconstructing an `OllamaEmbedder` from a stale prior remote install of
+/// `active_embedder` stops reconstructing an `OpenAiEmbedder` from a stale prior remote install of
 /// the same model (a no-op when the meta is already absent).
 pub(crate) fn clear_active_remote_config(conn: &Connection) -> anyhow::Result<()> {
     conn.execute("DELETE FROM index_meta WHERE key = ?1", params![

--- a/crates/rag-rat-core/src/index/ai/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/mod.rs
@@ -32,7 +32,7 @@ pub(crate) use providers::{
 // warnings`.
 pub use providers::{
     CookbookInput, CookbookProvisioner, Embedder, FASTEMBED_MISSING_FEATURE_MESSAGE, HashEmbedder,
-    MODEL2VEC_HF_REPO, MODEL2VEC_MISSING_FEATURE_MESSAGE, OllamaEmbedder, ProvisionedBox,
+    MODEL2VEC_HF_REPO, MODEL2VEC_MISSING_FEATURE_MESSAGE, OpenAiEmbedder, ProvisionedBox,
     abort_active_provisioning, install_provision_log_sink, verify_ephemeral_remote,
     verify_ephemeral_remote_cancellable,
 };

--- a/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
@@ -44,7 +44,7 @@ use std::time::{Duration, Instant};
 use serde::{Deserialize, Serialize};
 
 use super::Embedder;
-use super::ollama::{OllamaEmbedder, ProvisionedEmbedderParams};
+use super::openai::{OpenAiEmbedder, ProvisionedEmbedderParams};
 use crate::config::RemoteEmbeddingConfig;
 use crate::embedding_models::EmbeddingModelSpec;
 
@@ -133,7 +133,7 @@ pub struct CookbookInput {
     /// The Ollama server-side model name the box should serve (the `[remote] model`).
     pub model: String,
     /// Per-REQUEST HTTP timeout the cookbook may forward to its box config — the
-    /// `OllamaEmbedder`'s per-`/api/embed` budget. UNRELATED to provisioning; do NOT use it as
+    /// `OpenAiEmbedder`'s per-`/api/embed` budget. UNRELATED to provisioning; do NOT use it as
     /// the boot budget.
     pub request_timeout_s: u64,
     /// The cookbook's PROVISIONING budget (seconds): how long the recipe may spend booting the
@@ -513,8 +513,8 @@ fn cookbook_input_for(remote: &RemoteEmbeddingConfig) -> CookbookInput {
 }
 
 /// Provision an ephemeral cookbook box for the selected `spec` over `remote` and build an
-/// [`OllamaEmbedder`] against it. The single place that wires `cookbook` → `CookbookInput` →
-/// `CookbookProvisioner::provision` → `OllamaEmbedder::from_provisioned`; shared by the reconcile
+/// [`OpenAiEmbedder`] against it. The single place that wires `cookbook` → `CookbookInput` →
+/// `CookbookProvisioner::provision` → `OpenAiEmbedder::from_provisioned`; shared by the reconcile
 /// ephemeral chunk path AND the install probe (status.rs) so the model→input→handshake→embedder
 /// chain isn't duplicated. The returned [`ProvisionedBox`] MUST be kept alive for as long as the
 /// embedder is used (its `Drop` is the box teardown).
@@ -540,7 +540,7 @@ pub(crate) fn provision_and_build(
     remote: &RemoteEmbeddingConfig,
     spec: &EmbeddingModelSpec,
     tune: Option<TuneRequest<'_>>,
-) -> anyhow::Result<(OllamaEmbedder, ProvisionedBox, RemoteEmbeddingConfig, u32)> {
+) -> anyhow::Result<(OpenAiEmbedder, ProvisionedBox, RemoteEmbeddingConfig, u32)> {
     provision_and_build_cancellable(remote, spec, || false, tune)
 }
 
@@ -549,7 +549,7 @@ fn provision_and_build_cancellable(
     spec: &EmbeddingModelSpec,
     cancel: impl Fn() -> bool,
     tune: Option<TuneRequest<'_>>,
-) -> anyhow::Result<(OllamaEmbedder, ProvisionedBox, RemoteEmbeddingConfig, u32)> {
+) -> anyhow::Result<(OpenAiEmbedder, ProvisionedBox, RemoteEmbeddingConfig, u32)> {
     let cookbook = remote
         .cookbook
         .as_deref()
@@ -575,7 +575,7 @@ fn provision_and_build_cancellable(
         ),
         None => cap,
     };
-    let embedder = OllamaEmbedder::from_provisioned(ProvisionedEmbedderParams {
+    let embedder = OpenAiEmbedder::from_provisioned(ProvisionedEmbedderParams {
         endpoint: &provisioned.endpoint,
         auth_token: provisioned.auth_token.as_deref(),
         server_model: effective_remote.model.trim(),
@@ -585,7 +585,6 @@ fn provision_and_build_cancellable(
         batch_size: effective_remote.batch_size,
         concurrency: client_concurrency,
         max_batch_chars: effective_remote.max_batch_chars,
-        num_ctx: effective_remote.num_ctx,
     });
     Ok((embedder, provisioned, effective_remote, client_concurrency))
 }
@@ -615,7 +614,7 @@ pub fn verify_ephemeral_remote_cancellable(
     spec: &EmbeddingModelSpec,
     cancel: impl Fn() -> bool,
 ) -> anyhow::Result<()> {
-    // `_box` is bound (not `_`) so it lives to end of scope — `OllamaEmbedder` holds only the
+    // `_box` is bound (not `_`) so it lives to end of scope — `OpenAiEmbedder` holds only the
     // endpoint URL, not the process, so dropping the box early would tear down the server before
     // the ping. Drop at function exit is the teardown (SIGTERM → grace → SIGKILL on the group).
     let (embedder, _box, _effective_remote, _knee) =

--- a/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
@@ -577,6 +577,7 @@ fn provision_and_build_cancellable(
     };
     let embedder = OpenAiEmbedder::from_provisioned(ProvisionedEmbedderParams {
         endpoint: &provisioned.endpoint,
+        embed_path: effective_remote.backend.embed_path(),
         auth_token: provisioned.auth_token.as_deref(),
         server_model: effective_remote.model.trim(),
         selected_model_id: spec.model_id,

--- a/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
@@ -563,7 +563,7 @@ fn provision_and_build_cancellable(
     let effective_remote = remote.clone();
     let cap = remote.bounded_concurrency();
     let client_concurrency = match tune {
-        Some(t) => crate::index::ai::throughput_tune::tune_ollama_concurrency(
+        Some(t) => crate::index::ai::throughput_tune::tune_remote_concurrency(
             t.conn,
             remote.cookbook.as_deref().unwrap_or("cookbook"),
             &provisioned.endpoint,

--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -204,7 +204,7 @@ pub(crate) fn acquire_chunk_embedder(
                 // multiplies by `concurrency`, so a 128-cap config with a knee of 4
                 // would otherwise load a 32x-too-wide window the embedder only
                 // drains 4-at-a-time. This `remote` is window-sizing only (NOT persisted
-                // — the active-config meta is written from the cap by `install_ollama_model`).
+                // — the active-config meta is written from the cap by `install_remote_model`).
                 let mut window_remote = effective_remote;
                 window_remote.concurrency = window_concurrency;
                 ChunkEmbedder::Ready {

--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -14,7 +14,7 @@ mod hash;
 mod model2vec;
 // Ungated: the Ollama backend uses `ureq` (already a non-optional workspace dep — see the crates.io
 // version check), so there is no heavy optional dependency to gate. No `remote-embed` feature.
-mod ollama;
+mod openai;
 
 use rusqlite::Connection;
 
@@ -31,13 +31,13 @@ pub use self::hash::HashEmbedder;
 pub use self::model2vec::MODEL2VEC_HF_REPO;
 #[cfg(feature = "model2vec")]
 pub use self::model2vec::Model2VecEmbedder;
-// Ungated `pub` re-export (crate-public path `crate::index::ai::providers::OllamaEmbedder`):
+// Ungated `pub` re-export (crate-public path `crate::index::ai::providers::OpenAiEmbedder`):
 // wired into `embedder_for_spec` in #317 task 5, so nothing constructs it yet. The `pub`
 // visibility (same pattern as the other backends) exempts it from dead-code/unused-import
 // analysis under `-D warnings` until the dispatch arm lands.
-pub use self::ollama::OllamaEmbedder;
+pub use self::openai::OpenAiEmbedder;
 // The tuning sweep (index::ai::throughput_tune) builds embedders at varied concurrencies.
-pub(crate) use self::ollama::ProvisionedEmbedderParams;
+pub(crate) use self::openai::ProvisionedEmbedderParams;
 use crate::config::RemoteEmbeddingConfig;
 use crate::embedding_models::{Backend, EmbeddingModelSpec, spec};
 use crate::index::ai::{
@@ -240,7 +240,7 @@ pub(crate) fn embedder_for_spec(
     // vectors against that dim.
     if let Some(remote) = remote {
         let _ = intra_threads;
-        return Ok(Box::new(OllamaEmbedder::from_remote_config(remote, spec.model_id, spec.dim)?));
+        return Ok(Box::new(OpenAiEmbedder::from_remote_config(remote, spec.model_id, spec.dim)?));
     }
     // No remote block → in-process embedder, dispatched on the model's local backend. `Ollama` is a
     // transport-only runtime (no registry row carries it), so it cannot appear here.
@@ -373,7 +373,7 @@ mod dispatch_tests {
     #[test]
     fn embedder_for_spec_with_remote_serves_any_model_over_ollama() {
         // The effective runtime is `remote.is_some() ? Ollama : spec.backend`: passing a remote
-        // config builds an OllamaEmbedder for the selected spec regardless of its local backend.
+        // config builds an OpenAiEmbedder for the selected spec regardless of its local backend.
         let spec = spec(FASTEMBED_MODEL_ID).unwrap();
         let embedder =
             embedder_for_spec(spec, None, Some(&remote_at("http://127.0.0.1:1"))).unwrap();

--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -338,6 +338,7 @@ mod dispatch_tests {
     fn remote_at(endpoint: &str) -> RemoteEmbeddingConfig {
         RemoteEmbeddingConfig {
             model: "all-minilm".to_string(),
+            backend: crate::config::RemoteBackend::Ollama,
             endpoint: Some(endpoint.to_string()),
             cookbook: None,
             query_endpoint: None,
@@ -392,6 +393,7 @@ mod dispatch_tests {
     fn ephemeral_at(query_endpoint: &str, auth_env: Option<&str>) -> RemoteEmbeddingConfig {
         RemoteEmbeddingConfig {
             model: "all-minilm".to_string(),
+            backend: crate::config::RemoteBackend::Ollama,
             endpoint: None,
             cookbook: Some("@rag-rat/cookbook/modal".to_string()),
             query_endpoint: Some(query_endpoint.to_string()),

--- a/crates/rag-rat-core/src/index/ai/providers/openai.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/openai.rs
@@ -1,7 +1,10 @@
-//! The Ollama HTTP embedding backend: the ONLY code that connects to an Ollama server. All HTTP to
-//! `/api/embed` lives in [`OllamaEmbedder::embed_batch`]; everything else (install-time
-//! reachability probes, the dispatch in `providers/mod.rs`) reaches Ollama by constructing and
-//! calling one of these. One connection implementation, one place to audit/secure/retry.
+//! The OpenAI-compatible HTTP embedding backend: the ONLY code that connects to a remote embedding
+//! server. All HTTP to `/v1/embeddings` lives in [`OpenAiEmbedder::embed_batch`]; everything else
+//! (install-time reachability probes, the dispatch in `providers/mod.rs`) reaches the server by
+//! constructing and calling one of these. ONE client for every OpenAI-speaking backend — ollama
+//! (its `/v1/embeddings` compatibility route), michaelfeil/infinity, and vLLM — so there is one
+//! place to audit/secure/retry. The `[remote] backend` selector routes provisioning + the
+//! freshness/tune markers, NOT the wire call (identical across backends).
 //!
 //! Native, blocking HTTP via `ureq` (v3, rustls) — already a non-optional workspace dep (the
 //! crates.io version check uses it), so this backend ships unconditionally: no cargo feature, no
@@ -15,35 +18,52 @@ use serde::{Deserialize, Serialize};
 use super::Embedder;
 use crate::config::RemoteEmbeddingConfig;
 
-/// Request body for Ollama's `/api/embed`. `input` is an array — the batch endpoint embeds every
-/// text in one request.
+/// Request body for the OpenAI-compatible `POST /v1/embeddings`. `input` is an array — the batch
+/// endpoint embeds every text in one request. `encoding_format: "float"` is the OpenAI default,
+/// sent explicitly so a server that might otherwise emit base64 stays on plain `f32` arrays. NOTE:
+/// the OpenAI schema has no `options`/`num_ctx` — context length is a model-load setting on the
+/// server (a Modelfile for ollama), not a per-request field (see `RemoteEmbeddingConfig::num_ctx`).
 #[derive(Serialize)]
 struct EmbedRequest<'a> {
     model: &'a str,
     input: &'a [String],
-    #[serde(skip_serializing_if = "Option::is_none")]
-    options: Option<EmbedOptions>,
+    encoding_format: &'static str,
 }
 
-/// Ollama runtime options for `/api/embed`.
-#[derive(Clone, Copy, Serialize)]
-struct EmbedOptions {
-    num_ctx: u32,
+/// One item of the `/v1/embeddings` response `data` array. `index` is the position of this
+/// embedding's input WITHIN the request (0-based); a server may return items out of order, so we
+/// reorder by it and require the indices to cover exactly `0..len` (see `embed_one_request_with`).
+#[derive(Deserialize)]
+struct EmbedData {
+    embedding: Vec<f32>,
+    index: usize,
 }
 
-/// Response body from Ollama's `/api/embed`: one vector per input, in order.
+/// Success response body from `POST /v1/embeddings`: `{ "data": [ { embedding, index }, ... ] }`.
 #[derive(Deserialize)]
 struct EmbedResponse {
-    embeddings: Vec<Vec<f32>>,
+    data: Vec<EmbedData>,
 }
 
-/// A native HTTP embedder that offloads embedding work to an Ollama server's `/api/embed`. The dim
-/// is the SELECTED model's registry dim (the parity contract); every response vector is checked
-/// against it on each batch.
+/// Error body most OpenAI-compatible servers return on 4xx/5xx (`{ "error": { "message" } }`),
+/// parsed on non-2xx for a clearer message than the raw excerpt.
+#[derive(Deserialize)]
+struct ErrorResponse {
+    error: ErrorDetail,
+}
+
+#[derive(Deserialize)]
+struct ErrorDetail {
+    message: String,
+}
+
+/// A native HTTP embedder that offloads embedding work to an OpenAI-compatible `/v1/embeddings`
+/// server (ollama/infinity/vLLM). The dim is the SELECTED model's registry dim (the parity
+/// contract); every response vector is checked against it on each batch.
 #[derive(Debug)]
-pub struct OllamaEmbedder {
+pub struct OpenAiEmbedder {
     agent: ureq::Agent,
-    /// `<endpoint>/api/embed`, precomputed once at construction.
+    /// `<endpoint>/v1/embeddings`, precomputed once at construction.
     embed_url: String,
     /// The SELECTED model's persisted registry id (e.g. `fastembed-all-minilm-l6-v2`).
     /// `model_id()` returns THIS — chunk_embeddings key by the selected model regardless of
@@ -61,16 +81,13 @@ pub struct OllamaEmbedder {
     batch_size: usize,
     /// Max concurrent `/api/embed` requests in one `embed_batch` call.
     concurrency: usize,
-    /// Max total input characters per `/api/embed` request.
+    /// Max total input characters per `/v1/embeddings` request.
     max_batch_chars: usize,
-    /// Optional Ollama context window (`options.num_ctx`) to avoid context-length 400s without
-    /// shrinking rag-rat's chunk size.
-    num_ctx: Option<u32>,
     /// `Some("Bearer <token>")` when the server needs auth, read from `auth_env` at construction.
     auth_header: Option<String>,
 }
 
-/// Construction params for [`OllamaEmbedder::from_provisioned`] — groups the handshake outputs
+/// Construction params for [`OpenAiEmbedder::from_provisioned`] — groups the handshake outputs
 /// (`endpoint`, `auth_token`) with the model identity + transport knobs so the constructor takes
 /// one struct instead of positional args.
 pub struct ProvisionedEmbedderParams<'a> {
@@ -90,10 +107,8 @@ pub struct ProvisionedEmbedderParams<'a> {
     pub batch_size: u32,
     /// Max concurrent `/api/embed` requests.
     pub concurrency: u32,
-    /// Max total input characters per `/api/embed` request.
+    /// Max total input characters per `/v1/embeddings` request.
     pub max_batch_chars: usize,
-    /// Optional Ollama context window (`options.num_ctx`) for `/api/embed`.
-    pub num_ctx: Option<u32>,
 }
 
 struct BuildParams<'a> {
@@ -106,10 +121,9 @@ struct BuildParams<'a> {
     batch_size: u32,
     concurrency: u32,
     max_batch_chars: usize,
-    num_ctx: Option<u32>,
 }
 
-impl OllamaEmbedder {
+impl OpenAiEmbedder {
     /// Build the embedder for the SELECTED model served over Ollama. `selected_model_id` + `dim`
     /// come from the model the user picked (`model = "sentence-transformers/all-MiniLM-L6-v2"`,
     /// 384): `model_id()` returns that id so chunk_embeddings key by the model regardless of
@@ -146,7 +160,6 @@ impl OllamaEmbedder {
             batch_size: cfg.batch_size,
             concurrency: cfg.concurrency,
             max_batch_chars: cfg.max_batch_chars,
-            num_ctx: cfg.num_ctx,
         }))
     }
 
@@ -172,7 +185,6 @@ impl OllamaEmbedder {
             batch_size: params.batch_size,
             concurrency: params.concurrency,
             max_batch_chars: params.max_batch_chars,
-            num_ctx: params.num_ctx,
         })
     }
 
@@ -189,13 +201,12 @@ impl OllamaEmbedder {
             batch_size,
             concurrency,
             max_batch_chars,
-            num_ctx,
         } = params;
-        let embed_url = format!("{}/api/embed", endpoint.trim_end_matches('/'));
+        let embed_url = format!("{}/v1/embeddings", endpoint.trim_end_matches('/'));
         let mut builder = ureq::Agent::config_builder()
             .timeout_global(Some(Duration::from_secs(request_timeout_s)))
             .http_status_as_error(false)
-            .user_agent(concat!("rag-rat/", env!("CARGO_PKG_VERSION"), " (ollama-embed)"));
+            .user_agent(concat!("rag-rat/", env!("CARGO_PKG_VERSION"), " (openai-embed)"));
         // ureq's default config inherits `HTTP_PROXY`/`HTTPS_PROXY` from the env. A local Ollama
         // (`http://127.0.0.1:11434`) routed through a corporate proxy 403s, so disable the proxy for
         // loopback endpoints only — a non-loopback (truly remote) endpoint may legitimately need
@@ -215,7 +226,6 @@ impl OllamaEmbedder {
             batch_size: (batch_size as usize).max(1),
             concurrency: RemoteEmbeddingConfig::bounded_concurrency_value(concurrency) as usize,
             max_batch_chars: max_batch_chars.max(1),
-            num_ctx,
             auth_header,
         }
     }
@@ -246,57 +256,78 @@ impl OllamaEmbedder {
         embed_url: &str,
         server_model: &str,
         dim: usize,
-        num_ctx: Option<u32>,
         auth_header: Option<&str>,
         texts: &[String],
     ) -> anyhow::Result<Vec<Vec<f32>>> {
-        let payload = EmbedRequest {
-            model: server_model,
-            input: texts,
-            options: num_ctx.map(|num_ctx| EmbedOptions { num_ctx }),
-        };
+        let payload = EmbedRequest { model: server_model, input: texts, encoding_format: "float" };
         // The `json` ureq feature is not enabled (workspace ureq is rustls-only), so serialize the
         // body ourselves and send it with an explicit content-type.
         let body = serde_json::to_vec(&payload)
-            .map_err(|e| anyhow::anyhow!("failed to serialize ollama embed request: {e}"))?;
+            .map_err(|e| anyhow::anyhow!("failed to serialize embed request: {e}"))?;
 
         let mut request = agent.post(embed_url).content_type("application/json");
         if let Some(header) = auth_header {
             request = request.header("Authorization", header);
         }
 
-        // `http_status_as_error(false)` lets us read Ollama's JSON error body on 4xx/5xx instead
-        // of losing the actionable reason behind ureq's bare `http status: N` error.
+        // `http_status_as_error(false)` lets us read the server's JSON error body on 4xx/5xx
+        // instead of losing the actionable reason behind ureq's bare `http status: N`
+        // error.
         let mut response = request
             .send(body)
-            .map_err(|e| anyhow::anyhow!("ollama embed request to `{embed_url}` failed: {e}"))?;
+            .map_err(|e| anyhow::anyhow!("embed request to `{embed_url}` failed: {e}"))?;
         let status = response.status();
         let raw = response
             .body_mut()
             .read_to_string()
-            .map_err(|e| anyhow::anyhow!("reading ollama embed response failed: {e}"))?;
+            .map_err(|e| anyhow::anyhow!("reading embed response failed: {e}"))?;
         if !status.is_success() {
+            // OpenAI-compatible servers usually return `{"error":{"message":...}}`; surface that
+            // clean message when present, else a bounded raw excerpt.
+            let detail = serde_json::from_str::<ErrorResponse>(&raw)
+                .map(|e| e.error.message)
+                .unwrap_or_else(|_| response_excerpt(&raw));
             anyhow::bail!(
-                "ollama embed request to `{}` failed: http status {}: {}",
+                "embed request to `{}` failed: http status {}: {}",
                 embed_url,
                 status.as_u16(),
-                response_excerpt(&raw)
+                detail
             );
         }
 
         let parsed: EmbedResponse = serde_json::from_str(&raw)
-            .map_err(|e| anyhow::anyhow!("malformed ollama embed response: {e}"))?;
-        let embeddings = parsed.embeddings;
+            .map_err(|e| anyhow::anyhow!("malformed embed response: {e}"))?;
 
-        // Count contract: one vector per input, retryable on violation (a transient server fault
+        // Count contract: one embedding per input, retryable on violation (a transient server fault
         // can drop rows).
-        if embeddings.len() != texts.len() {
+        let n = texts.len();
+        if parsed.data.len() != n {
             anyhow::bail!(
-                "ollama embed count mismatch: requested {} texts but server returned {} vectors",
-                texts.len(),
-                embeddings.len()
+                "embed count mismatch: requested {n} texts but server returned {} embeddings",
+                parsed.data.len()
             );
         }
+
+        // The OpenAI `data[]` carries a per-request `index`; a server MAY return items out of
+        // order. Place each embedding at its `index` and require the indices to cover
+        // EXACTLY `0..n` with no duplicate or out-of-range — sorting alone would silently
+        // accept a dup/gap and misalign vectors with their chunks.
+        let mut ordered: Vec<Option<Vec<f32>>> = std::iter::repeat_with(|| None).take(n).collect();
+        for item in parsed.data {
+            let idx = item.index;
+            if idx >= n {
+                anyhow::bail!("embed response index {idx} out of range for {n} inputs");
+            }
+            if ordered[idx].is_some() {
+                anyhow::bail!("embed response has a duplicate index {idx}");
+            }
+            ordered[idx] = Some(item.embedding);
+        }
+        let embeddings = ordered
+            .into_iter()
+            .enumerate()
+            .map(|(i, v)| v.ok_or_else(|| anyhow::anyhow!("embed response is missing index {i}")))
+            .collect::<anyhow::Result<Vec<Vec<f32>>>>()?;
 
         // Dim contract (LOUD): the int8 encoding, per-family centroids, and the linked-entries rail
         // all assume a fixed dim. A server returning a different-width vector means the configured
@@ -307,9 +338,9 @@ impl OllamaEmbedder {
         for (i, vector) in embeddings.iter().enumerate() {
             if vector.len() != dim {
                 anyhow::bail!(
-                    "ollama embed dim mismatch: server returned a {}-dim vector at index {} but \
-                     this model is configured for {} dims (server model `{}`). The selected \
-                     registry model and the Ollama server model must match.",
+                    "embed dim mismatch: server returned a {}-dim vector at index {} but this \
+                     model is configured for {} dims (server model `{}`). The selected registry \
+                     model and the server model must match.",
                     vector.len(),
                     i,
                     dim,
@@ -321,7 +352,7 @@ impl OllamaEmbedder {
         Ok(embeddings)
     }
 
-    /// Send ONE `/api/embed` request for `texts` (already sized to `<= self.batch_size` by the
+    /// Send ONE `/v1/embeddings` request for `texts` (already sized to `<= self.batch_size` by the
     /// caller) and return the parsed vectors, enforcing the count + per-vector dim contracts.
     /// Factored out of `embed_batch` so the sub-batch loop reuses the exact request/validation
     /// logic.
@@ -331,7 +362,6 @@ impl OllamaEmbedder {
             &self.embed_url,
             &self.server_model,
             self.dim,
-            self.num_ctx,
             self.auth_header.as_deref(),
             texts,
         )
@@ -387,7 +417,7 @@ fn endpoint_is_loopback(endpoint: &str) -> bool {
         || host.starts_with("127.")
 }
 
-impl Embedder for OllamaEmbedder {
+impl Embedder for OpenAiEmbedder {
     fn model_id(&self) -> &str {
         // The SELECTED model's registry id (e.g. `fastembed-all-minilm-l6-v2`), NOT the server-side
         // Ollama model name (`self.server_model`): chunk_embeddings key by the selected model, so
@@ -422,7 +452,6 @@ impl Embedder for OllamaEmbedder {
                     let server_model = self.server_model.clone();
                     let auth_header = self.auth_header.clone();
                     let dim = self.dim;
-                    let num_ctx = self.num_ctx;
                     let sub_batch = &texts[start..end];
                     handles.push(scope.spawn(move || {
                         Self::embed_one_request_with(
@@ -430,7 +459,6 @@ impl Embedder for OllamaEmbedder {
                             &embed_url,
                             &server_model,
                             dim,
-                            num_ctx,
                             auth_header.as_deref(),
                             sub_batch,
                         )
@@ -438,7 +466,7 @@ impl Embedder for OllamaEmbedder {
                 }
                 handles.into_iter().map(|handle| handle.join()).collect::<Result<Vec<_>, _>>()
             })
-            .map_err(|_| anyhow::anyhow!("ollama embed worker thread panicked"))?;
+            .map_err(|_| anyhow::anyhow!("embed worker thread panicked"))?;
             for result in results {
                 out.extend(result?);
             }
@@ -462,8 +490,8 @@ mod tests {
 
     /// Construct the embedder for the selected model over the given remote config + dim. Thin
     /// wrapper so the many tests don't repeat the `selected_model_id` arg.
-    fn build(cfg: &RemoteEmbeddingConfig, dim: usize) -> anyhow::Result<OllamaEmbedder> {
-        OllamaEmbedder::from_remote_config(cfg, SELECTED_ID, dim)
+    fn build(cfg: &RemoteEmbeddingConfig, dim: usize) -> anyhow::Result<OpenAiEmbedder> {
+        OpenAiEmbedder::from_remote_config(cfg, SELECTED_ID, dim)
     }
 
     /// Spawn a one-shot HTTP/1.1 server on `127.0.0.1:0` that accepts a single connection, drains
@@ -555,16 +583,19 @@ mod tests {
         let _ = stream.read(&mut buf);
     }
 
+    /// OpenAI `/v1/embeddings` success body: `{"data":[{"embedding":[..],"index":i}, ...]}` where
+    /// `index` is the position within THIS request (0-based).
     fn embeddings_json(vectors: &[Vec<f32>]) -> String {
         let rows = vectors
             .iter()
-            .map(|v| {
+            .enumerate()
+            .map(|(i, v)| {
                 let nums = v.iter().map(|f| f.to_string()).collect::<Vec<_>>().join(",");
-                format!("[{nums}]")
+                format!("{{\"embedding\":[{nums}],\"index\":{i}}}")
             })
             .collect::<Vec<_>>()
             .join(",");
-        format!("{{\"embeddings\":[{rows}]}}")
+        format!("{{\"data\":[{rows}]}}")
     }
 
     fn config_for(endpoint: &str, timeout_s: u64) -> RemoteEmbeddingConfig {
@@ -604,10 +635,12 @@ mod tests {
     }
 
     #[test]
-    fn embed_request_includes_num_ctx_when_configured() {
+    fn embed_request_uses_the_openai_shape_and_omits_num_ctx() {
         let want = vec![vec![1.0f32; DIM]];
         let (url, handle) = spawn_body_capture_stub(embeddings_json(&want));
         let mut cfg = config_for(&url, 5);
+        // `num_ctx` stays a config field (freshness + model-load) but has NO per-request wire form
+        // on `/v1/embeddings` — it must NOT appear in the request body.
         cfg.num_ctx = Some(4096);
         let embedder = build(&cfg, DIM).unwrap();
 
@@ -616,7 +649,12 @@ mod tests {
 
         let payload: serde_json::Value = serde_json::from_str(&body).unwrap();
         assert_eq!(payload["model"], "all-minilm");
-        assert_eq!(payload["options"]["num_ctx"], 4096);
+        assert!(payload["input"].is_array());
+        assert_eq!(payload["encoding_format"], "float");
+        assert!(
+            payload.get("options").is_none(),
+            "num_ctx/options must not be sent to /v1/embeddings"
+        );
     }
 
     /// A multi-request HTTP stub: accepts `max_conns` connections, and for each request replies

--- a/crates/rag-rat-core/src/index/ai/providers/openai.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/openai.rs
@@ -601,6 +601,7 @@ mod tests {
     fn config_for(endpoint: &str, timeout_s: u64) -> RemoteEmbeddingConfig {
         RemoteEmbeddingConfig {
             model: "all-minilm".to_string(),
+            backend: crate::config::RemoteBackend::Ollama,
             endpoint: Some(endpoint.to_string()),
             cookbook: None,
             query_endpoint: None,

--- a/crates/rag-rat-core/src/index/ai/providers/openai.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/openai.rs
@@ -93,6 +93,9 @@ pub struct OpenAiEmbedder {
 pub struct ProvisionedEmbedderParams<'a> {
     /// The serving endpoint from the cookbook handshake (`https://...`).
     pub endpoint: &'a str,
+    /// The backend's embeddings route appended to `endpoint` (`RemoteBackend::embed_path()` —
+    /// `/v1/embeddings` for ollama/vLLM, `/embeddings` for infinity).
+    pub embed_path: &'a str,
     /// A DIRECT bearer token from the handshake (NOT an env-var name), or `None` for an open box.
     pub auth_token: Option<&'a str>,
     /// The Ollama API model name sent in the request body (`[remote] model`).
@@ -113,6 +116,7 @@ pub struct ProvisionedEmbedderParams<'a> {
 
 struct BuildParams<'a> {
     endpoint: &'a str,
+    embed_path: &'a str,
     auth_header: Option<String>,
     selected_model_id: &'a str,
     server_model: &'a str,
@@ -152,6 +156,7 @@ impl OpenAiEmbedder {
             resolve_auth_header(cfg.auth_env.as_deref(), |var| std::env::var(var).ok())?;
         Ok(Self::build(BuildParams {
             endpoint,
+            embed_path: cfg.backend.embed_path(),
             auth_header,
             selected_model_id,
             server_model: cfg.model.trim(),
@@ -177,6 +182,7 @@ impl OpenAiEmbedder {
             .map(|token| format!("Bearer {token}"));
         Self::build(BuildParams {
             endpoint: params.endpoint.trim(),
+            embed_path: params.embed_path,
             auth_header,
             selected_model_id: params.selected_model_id,
             server_model: params.server_model.trim(),
@@ -193,6 +199,7 @@ impl OpenAiEmbedder {
     fn build(params: BuildParams<'_>) -> Self {
         let BuildParams {
             endpoint,
+            embed_path,
             auth_header,
             selected_model_id,
             server_model,
@@ -202,7 +209,7 @@ impl OpenAiEmbedder {
             concurrency,
             max_batch_chars,
         } = params;
-        let embed_url = format!("{}/v1/embeddings", endpoint.trim_end_matches('/'));
+        let embed_url = format!("{}{}", endpoint.trim_end_matches('/'), embed_path);
         let mut builder = ureq::Agent::config_builder()
             .timeout_global(Some(Duration::from_secs(request_timeout_s)))
             .http_status_as_error(false)

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -85,7 +85,7 @@ pub(crate) fn remove_legacy_models(conn: &Connection) -> anyhow::Result<()> {
         // If this legacy id was the ACTIVE model, its active-model meta AND any persisted
         // remote-config meta (a legacy `ollama-*` id was a remote install — #317) must both go.
         // Leaving the remote config behind would let `active_embedder` keep reconstructing an
-        // `OllamaEmbedder` against a now-removed endpoint after the active model fell back to hash,
+        // `OpenAiEmbedder` against a now-removed endpoint after the active model fell back to hash,
         // so clear it whenever we delete the matching active-model meta.
         let was_active =
             conn.execute("DELETE FROM index_meta WHERE key = ?1 AND value = ?2", params![
@@ -272,7 +272,7 @@ pub(crate) fn install_model(
         }
         // A LOCAL install must drop any remote-config meta a PRIOR Ollama install of this model
         // left behind — otherwise `active_embedder` reads it back unconditionally and keeps
-        // building an OllamaEmbedder against the now-removed endpoint instead of the local
+        // building an OpenAiEmbedder against the now-removed endpoint instead of the local
         // model.
         clear_active_remote_config(conn)?;
     }
@@ -1365,7 +1365,7 @@ mod freshness_version_tests {
                 let mut buf = [0u8; 4096];
                 let _ = stream.read(&mut buf);
                 let nums = vec!["0.1"; dim].join(",");
-                let body = format!("{{\"embeddings\":[[{nums}]]}}");
+                let body = format!("{{\"data\":[{{\"embedding\":[{nums}],\"index\":0}}]}}");
                 let response = format!(
                     "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: \
                      {}\r\nConnection: close\r\n\r\n{body}",
@@ -1526,10 +1526,10 @@ mod freshness_version_tests {
                             let inputs = body.matches("path: ").count().max(1);
                             let vector = vec!["0.1"; dim].join(",");
                             let rows = (0..inputs)
-                                .map(|_| format!("[{vector}]"))
+                                .map(|i| format!("{{\"embedding\":[{vector}],\"index\":{i}}}"))
                                 .collect::<Vec<_>>()
                                 .join(",");
-                            let response_body = format!("{{\"embeddings\":[{rows}]}}");
+                            let response_body = format!("{{\"data\":[{rows}]}}");
                             let response = format!(
                                 "HTTP/1.1 200 OK\r\nContent-Type: \
                                  application/json\r\nContent-Length: {}\r\nConnection: \
@@ -1589,10 +1589,10 @@ mod freshness_version_tests {
                                 let inputs = body.matches("path: ").count().max(1);
                                 let vector = vec!["0.1"; dim].join(",");
                                 let rows = (0..inputs)
-                                    .map(|_| format!("[{vector}]"))
+                                    .map(|i| format!("{{\"embedding\":[{vector}],\"index\":{i}}}"))
                                     .collect::<Vec<_>>()
                                     .join(",");
-                                let response_body = format!("{{\"embeddings\":[{rows}]}}");
+                                let response_body = format!("{{\"data\":[{rows}]}}");
                                 format!(
                                     "HTTP/1.1 200 OK\r\nContent-Type: \
                                      application/json\r\nContent-Length: {}\r\nConnection: \
@@ -2062,7 +2062,7 @@ mod freshness_version_tests {
     #[test]
     fn local_install_clears_a_stale_remote_config_meta() {
         // After an Ollama install persists a remote config, re-installing the model LOCALLY must
-        // DELETE that meta — otherwise active_embedder keeps building an OllamaEmbedder against the
+        // DELETE that meta — otherwise active_embedder keeps building an OpenAiEmbedder against the
         // dead endpoint. Uses the hash model so the local install is feature-free.
         let conn = schema_conn();
         set_active_remote_config(&conn, &remote_at("http://box:11434")).unwrap();
@@ -2114,7 +2114,7 @@ mod freshness_version_tests {
         assert_eq!(meta(&conn, ACTIVE_EMBEDDING_MODEL_META).unwrap(), None, "active meta cleared");
         assert!(
             active_remote_config(&conn).unwrap().is_none(),
-            "the stale remote config is cleared so no OllamaEmbedder is reconstructed",
+            "the stale remote config is cleared so no OpenAiEmbedder is reconstructed",
         );
 
         // With no active model + no remote config, the active model falls back to hash. Mark the

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -1392,6 +1392,7 @@ mod freshness_version_tests {
     fn remote_at(endpoint: &str) -> RemoteEmbeddingConfig {
         RemoteEmbeddingConfig {
             model: "all-minilm".to_string(),
+            backend: crate::config::RemoteBackend::Ollama,
             endpoint: Some(endpoint.to_string()),
             cookbook: None,
             query_endpoint: None,
@@ -2257,6 +2258,7 @@ mod freshness_version_tests {
         set_meta(conn, ACTIVE_EMBEDDING_MODEL_META, FASTEMBED_MODEL_ID).unwrap();
         let remote = RemoteEmbeddingConfig {
             model: "all-minilm".to_string(),
+            backend: crate::config::RemoteBackend::Ollama,
             endpoint: None,
             cookbook: Some("@rag-rat/cookbook/modal".to_string()),
             query_endpoint: Some("http://localhost:11434".to_string()),

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -245,12 +245,12 @@ pub(crate) fn install_model(
         if spec.backend != Backend::FastEmbed {
             anyhow::bail!(
                 "remote embedding requires a transformer model, but `{model_id}` is a {} model — \
-                 remove the [llm.embedding.remote] block to install it locally, or install a \
-                 transformer model over Ollama",
+                 remove the [llm.embedding.remote] block to install it locally, or select a \
+                 transformer model to serve over the remote backend",
                 spec.backend.runtime()
             );
         }
-        install_ollama_model(conn, model_id, spec, remote)?;
+        install_remote_model(conn, model_id, spec, remote)?;
     } else {
         match spec.backend {
             Backend::Hash => {

--- a/crates/rag-rat-core/src/index/ai/status.rs
+++ b/crates/rag-rat-core/src/index/ai/status.rs
@@ -311,6 +311,7 @@ mod ollama_install_tests {
     fn remote_at(endpoint: &str) -> RemoteEmbeddingConfig {
         RemoteEmbeddingConfig {
             model: "all-minilm".to_string(),
+            backend: crate::config::RemoteBackend::Ollama,
             endpoint: Some(endpoint.to_string()),
             cookbook: None,
             query_endpoint: None,

--- a/crates/rag-rat-core/src/index/ai/status.rs
+++ b/crates/rag-rat-core/src/index/ai/status.rs
@@ -44,11 +44,12 @@ pub(crate) fn install_fastembed_model(conn: &Connection, model_id: &str) -> anyh
 /// reconcile loop will use. A probe failure REFUSES the install loudly (the row is left
 /// not-installed); we do not write a half-ready model that would then fail every reconcile batch.
 ///
-/// On success: toggle the SAME `ai_models` row to `runtime='ollama'`, Ready, and persist the remote
-/// config to the secret-free meta so `active_embedder` can reconstruct the embedder. The freshness
-/// version is NOT written here — it is stamped centrally by the caller (`install_model`) for every
-/// runtime (see [`remote_freshness_version`] + the `install_model` single-writer comment).
-pub(crate) fn install_ollama_model(
+/// On success: toggle the SAME `ai_models` row to `runtime = remote.backend` (`ollama`/`infinity`/
+/// `vllm`), Ready, and persist the remote config to the secret-free meta so `active_embedder` can
+/// reconstruct the embedder. The freshness version is NOT written here — it is stamped centrally by
+/// the caller (`install_model`) for every runtime (see [`remote_freshness_version`] + the
+/// `install_model` single-writer comment).
+pub(crate) fn install_remote_model(
     conn: &Connection,
     model_id: &str,
     spec: &EmbeddingModelSpec,
@@ -75,14 +76,15 @@ pub(crate) fn install_ollama_model(
     } else {
         let embedder = OpenAiEmbedder::from_remote_config(remote, spec.model_id, spec.dim)
             .map_err(|err| {
-                anyhow::anyhow!("failed to construct ollama embedder for `{model_id}`: {err}")
+                anyhow::anyhow!("failed to construct remote embedder for `{model_id}`: {err}")
             })?;
         (embedder, None, remote.clone())
     };
     embedder.embed_batch(&["ping".to_string()]).map_err(|err| {
         anyhow::anyhow!(
-            "ollama reachability/dim probe failed for `{model_id}` (endpoint `{}`, model `{}`): \
-             {err}",
+            "remote reachability/dim probe failed for `{model_id}` (backend `{}`, endpoint `{}`, \
+             model `{}`): {err}",
+            remote.backend.as_db_str(),
             remote.endpoint.as_deref().unwrap_or("<ephemeral>"),
             remote.model
         )
@@ -90,24 +92,37 @@ pub(crate) fn install_ollama_model(
     conn.execute(
         "UPDATE ai_models
          SET installed = 1, disabled = 0, status = 'Ready', installed_at_ms = ?2,
-             embedding_dim = ?3, runtime = 'ollama', last_error = NULL
+             embedding_dim = ?3, runtime = ?4, last_error = NULL
          WHERE model_id = ?1",
-        params![model_id, now_ms(), i64::try_from(spec.dim).unwrap_or(i64::MAX)],
+        params![
+            model_id,
+            now_ms(),
+            i64::try_from(spec.dim).unwrap_or(i64::MAX),
+            effective_remote.backend.as_db_str()
+        ],
     )?;
     set_active_remote_config(conn, &effective_remote)?;
     Ok(())
 }
 
-/// The reconcile freshness key for the SELECTED model when served over Ollama. Distinct from the
-/// static `spec.version` (the local key) so a local↔remote flip re-embeds, and folds in the
-/// server-side `remote.model` plus vector-affecting Ollama options so switching THOSE re-embeds
-/// too.
+/// Salt bumped whenever the remote WIRE PROTOCOL changes in a way that can shift vectors even for
+/// an unchanged model+config. `openai-v1` marks the move off ollama's native `/api/embed`
+/// (per-request `num_ctx`) onto the OpenAI-compatible `/v1/embeddings` (no per-request context):
+/// folding it into the freshness key forces ONE clean re-embed on upgrade for existing
+/// `num_ctx`-set configs whose vectors could otherwise silently drift. Bump the suffix on any
+/// future protocol-affecting change.
+const REMOTE_EMBED_PROTOCOL: &str = "openai-v1";
+
+/// The reconcile freshness key for the SELECTED model when served remotely. Distinct from the
+/// static `spec.version` (the local key) so a local↔remote flip re-embeds, and folds in the BACKEND
+/// (ollama/infinity/vLLM — different servers can pool/normalize differently), the wire-protocol
+/// salt, the server-side `remote.model`, and `num_ctx` so switching any of THOSE re-embeds too.
 ///
 /// DELIBERATELY ENDPOINT-INDEPENDENT (#317 rework — the key fix). The endpoint does NOT define the
-/// vector space; the model + runtime do. Folding the endpoint host would re-embed the WHOLE repo on
-/// every run for ephemeral/cookbook boxes (each gets a fresh URL). So: new URL + same
-/// `remote.model` + `num_ctx` → SAME freshness → no re-embed; a different `remote.model`, a
-/// different vector-affecting Ollama option, or a local↔remote flip → re-embed.
+/// vector space; the model + backend + protocol do. Folding the endpoint host would re-embed the
+/// WHOLE repo on every run for ephemeral/cookbook boxes (each gets a fresh URL). So: new URL + same
+/// `backend` + `remote.model` + `num_ctx` → SAME freshness → no re-embed; a different `backend`,
+/// `remote.model`, or vector-affecting option, or a local↔remote flip → re-embed.
 pub(crate) fn remote_freshness_version(
     spec: &EmbeddingModelSpec,
     remote: &RemoteEmbeddingConfig,
@@ -115,10 +130,12 @@ pub(crate) fn remote_freshness_version(
     let mut hasher = Sha256::new();
     hasher.update(spec.version.as_bytes());
     hasher.update([0]);
-    // The "ollama" runtime marker is what distinguishes this remote key from the local
-    // `spec.version` even when `remote.model` happens to be empty — a local↔remote flip always
-    // re-embeds.
-    hasher.update(Backend::Ollama.runtime().as_bytes());
+    // The wire-protocol salt + the backend marker distinguish this remote key from the local
+    // `spec.version` (a local↔remote flip always re-embeds) AND from a different remote backend
+    // serving the same model (whose vectors may differ).
+    hasher.update(REMOTE_EMBED_PROTOCOL.as_bytes());
+    hasher.update([0]);
+    hasher.update(remote.backend.as_db_str().as_bytes());
     hasher.update([0]);
     hasher.update(remote.model.trim().as_bytes());
     hasher.update([0]);
@@ -326,7 +343,7 @@ mod ollama_install_tests {
     }
 
     #[test]
-    fn install_ollama_model_toggles_the_selected_models_row_to_ollama_runtime() {
+    fn install_remote_model_toggles_the_selected_models_row_to_ollama_runtime() {
         // #317 rework: serving a real model (fastembed all-minilm) over Ollama toggles ITS row's
         // runtime to `ollama` — the same model_id + dim, transport overridden.
         let selected = spec(FASTEMBED_MODEL_ID).unwrap();
@@ -334,7 +351,7 @@ mod ollama_install_tests {
         let conn = schema_conn();
         let remote = remote_at(&url);
 
-        install_ollama_model(&conn, FASTEMBED_MODEL_ID, selected, &remote).expect("probe succeeds");
+        install_remote_model(&conn, FASTEMBED_MODEL_ID, selected, &remote).expect("probe succeeds");
         handle.join().unwrap();
 
         let model = model(&conn, FASTEMBED_MODEL_ID).unwrap();
@@ -352,7 +369,7 @@ mod ollama_install_tests {
     }
 
     #[test]
-    fn install_ollama_model_refuses_on_a_dim_mismatch() {
+    fn install_remote_model_refuses_on_a_dim_mismatch() {
         // The server returns a 512-dim vector; the selected model is 384 — the probe's per-batch
         // dim contract rejects it, so the install must refuse and leave the row not
         // flipped.
@@ -360,7 +377,7 @@ mod ollama_install_tests {
         let (url, handle) = spawn_embed_stub(512);
         let conn = schema_conn();
 
-        let err = install_ollama_model(&conn, FASTEMBED_MODEL_ID, selected, &remote_at(&url))
+        let err = install_remote_model(&conn, FASTEMBED_MODEL_ID, selected, &remote_at(&url))
             .expect_err("dim mismatch must refuse the install");
         handle.join().unwrap();
         assert!(err.to_string().contains("384") || err.to_string().contains("512"), "{err}");
@@ -411,5 +428,24 @@ mod ollama_install_tests {
             remote_freshness_version(spec, &wider_ctx),
             "changing Ollama's context window can change long-input embeddings and must refresh",
         );
+    }
+
+    #[test]
+    fn remote_freshness_version_differs_by_backend() {
+        use crate::config::RemoteBackend;
+        // The SAME model served by a DIFFERENT backend can pool/normalize differently, so the
+        // backend is part of the vector-space identity — switching it must re-embed.
+        let spec = spec(FASTEMBED_MODEL_ID).unwrap();
+        let ollama = remote_at("http://localhost:11434");
+        let mut infinity = ollama.clone();
+        infinity.backend = RemoteBackend::Infinity;
+        let mut vllm = ollama.clone();
+        vllm.backend = RemoteBackend::Vllm;
+        let f_ollama = remote_freshness_version(spec, &ollama);
+        let f_infinity = remote_freshness_version(spec, &infinity);
+        let f_vllm = remote_freshness_version(spec, &vllm);
+        assert_ne!(f_ollama, f_infinity, "ollama vs infinity must differ");
+        assert_ne!(f_ollama, f_vllm, "ollama vs vLLM must differ");
+        assert_ne!(f_infinity, f_vllm, "infinity vs vLLM must differ");
     }
 }

--- a/crates/rag-rat-core/src/index/ai/status.rs
+++ b/crates/rag-rat-core/src/index/ai/status.rs
@@ -38,7 +38,7 @@ pub(crate) fn install_fastembed_model(conn: &Connection, model_id: &str) -> anyh
 
 /// Install (activate) the SELECTED model served over Ollama (#317 rework). Unlike the local
 /// backends there is NO download: the "install" is a reachability + dim-parity PROBE. We construct
-/// the real [`OllamaEmbedder`] for the selected model and embed a single `"ping"` — that one call
+/// the real [`OpenAiEmbedder`] for the selected model and embed a single `"ping"` — that one call
 /// validates the endpoint is reachable, auth resolves, AND the server's vector width matches the
 /// selected model's dim (the embedder's per-batch dim contract), reusing the exact connection the
 /// reconcile loop will use. A probe failure REFUSES the install loudly (the row is left
@@ -60,7 +60,7 @@ pub(crate) fn install_ollama_model(
     // `provision_and_build`), pings it, then tears it down (the `_box` guard's Drop at the end of
     // this fn) — exactly the connection the reconcile will later provision.
     let (embedder, _box, effective_remote): (
-        OllamaEmbedder,
+        OpenAiEmbedder,
         Option<ProvisionedBox>,
         RemoteEmbeddingConfig,
     ) = if remote.is_ephemeral() {
@@ -73,7 +73,7 @@ pub(crate) fn install_ollama_model(
             })?;
         (embedder, Some(provisioned), tuned_remote)
     } else {
-        let embedder = OllamaEmbedder::from_remote_config(remote, spec.model_id, spec.dim)
+        let embedder = OpenAiEmbedder::from_remote_config(remote, spec.model_id, spec.dim)
             .map_err(|err| {
                 anyhow::anyhow!("failed to construct ollama embedder for `{model_id}`: {err}")
             })?;
@@ -277,8 +277,9 @@ mod ollama_install_tests {
     use super::*;
     use crate::embedding_models::FASTEMBED_MODEL_ID;
 
-    /// One-shot HTTP/1.1 stub on an ephemeral port that replies to the probe's single `/api/embed`
-    /// POST with `{"embeddings":[[<dim floats>]]}`. Returns the base URL + the server join handle.
+    /// One-shot HTTP/1.1 stub on an ephemeral port that replies to the probe's single
+    /// `/v1/embeddings` POST with `{"data":[{"embedding":[<dim floats>],"index":0}]}`. Returns the
+    /// base URL + the server join handle.
     fn spawn_embed_stub(dim: usize) -> (String, thread::JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
@@ -287,7 +288,7 @@ mod ollama_install_tests {
                 let mut buf = [0u8; 4096];
                 let _ = stream.read(&mut buf);
                 let nums = vec!["0.1"; dim].join(",");
-                let body = format!("{{\"embeddings\":[[{nums}]]}}");
+                let body = format!("{{\"data\":[{{\"embedding\":[{nums}],\"index\":0}}]}}");
                 let response = format!(
                     "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: \
                      {}\r\nConnection: close\r\n\r\n{body}",

--- a/crates/rag-rat-core/src/index/ai/throughput_tune.rs
+++ b/crates/rag-rat-core/src/index/ai/throughput_tune.rs
@@ -24,7 +24,7 @@ use sha2::{Digest, Sha256};
 use crate::config::RemoteEmbeddingConfig;
 use crate::embedding_models::EmbeddingModelSpec;
 use crate::index::ai::helpers::{meta, set_meta};
-use crate::index::ai::providers::{Embedder, OllamaEmbedder, ProvisionedEmbedderParams};
+use crate::index::ai::providers::{Embedder, OpenAiEmbedder, ProvisionedEmbedderParams};
 use crate::index::util::now_ms;
 
 /// `index_meta` key holding the throughput-tune cache (a JSON map, so no schema migration).
@@ -106,7 +106,7 @@ pub(crate) fn tune_ollama_concurrency(
     if tuning_disabled() {
         return cap;
     }
-    // Normalize `batch_size` the SAME way `OllamaEmbedder` does (clamp to >=1): a configured 0
+    // Normalize `batch_size` the SAME way `OpenAiEmbedder` does (clamp to >=1): a configured 0
     // serves one text per request live, so the probe (and cache key) must treat it as 1 —
     // otherwise every candidate window collapses to a single text and the sweep never exercises
     // fan-out.
@@ -141,8 +141,8 @@ pub(crate) fn tune_ollama_concurrency(
     // is cacheable) except: `concurrency` is the fan-out being measured, and
     // `request_timeout_s` is bounded by the tune budget so one blocking probe can't hold the
     // box for the full HTTP timeout.
-    let build = |concurrency: u32, request_timeout_s: u64| -> OllamaEmbedder {
-        OllamaEmbedder::from_provisioned(ProvisionedEmbedderParams {
+    let build = |concurrency: u32, request_timeout_s: u64| -> OpenAiEmbedder {
+        OpenAiEmbedder::from_provisioned(ProvisionedEmbedderParams {
             endpoint,
             auth_token,
             server_model: remote.model.trim(),
@@ -152,7 +152,6 @@ pub(crate) fn tune_ollama_concurrency(
             batch_size,
             concurrency,
             max_batch_chars: remote.max_batch_chars,
-            num_ctx: remote.num_ctx,
         })
     };
 
@@ -215,7 +214,7 @@ pub(crate) fn sweep_is_worthwhile(
     estimated_jobs.is_none_or(|jobs| jobs > u64::from(per_request))
 }
 
-/// Texts the live `OllamaEmbedder` puts in ONE `/api/embed` request: bounded by BOTH the count cap
+/// Texts the live `OpenAiEmbedder` puts in ONE `/api/embed` request: bounded by BOTH the count cap
 /// (`batch_size`, clamped to >=1 like the embedder) and the char budget (`max_batch_chars` / a
 /// representative per-text size), whichever is smaller. A small `max_batch_chars` splits work into
 /// many small requests, so the fan-out threshold must use the smaller of the two.

--- a/crates/rag-rat-core/src/index/ai/throughput_tune.rs
+++ b/crates/rag-rat-core/src/index/ai/throughput_tune.rs
@@ -7,7 +7,7 @@
 //!
 //! BACKEND-AGNOSTIC. The sweep engine ([`run_sweep`]) knows nothing about ollama — it measures
 //! texts/s for each candidate over the `Embedder` trait and picks the knee. A per-backend adapter
-//! (today [`tune_ollama_concurrency`]) supplies the candidate list, a `build(candidate) ->
+//! (today [`tune_remote_concurrency`]) supplies the candidate list, a `build(candidate) ->
 //! Embedder` closure, and a RUNTIME discriminator folded into the cache key so an ollama tune and a
 //! future infinity/vLLM tune for the same model never collide.
 //!
@@ -56,7 +56,7 @@ struct SweepResult {
 }
 
 /// The result of a sweep, so the caller can distinguish "measured a knee" from "ran but nothing was
-/// stable" from "didn't run" — each wants a DIFFERENT fallback (see [`tune_ollama_concurrency`]).
+/// stable" from "didn't run" — each wants a DIFFERENT fallback (see [`tune_remote_concurrency`]).
 #[cfg_attr(test, derive(Debug))]
 enum SweepOutcome {
     /// A knee (already clamped to the cap) and its measured texts/s. `complete` is false if the
@@ -92,7 +92,7 @@ struct TuneCacheFile {
 /// `endpoint`/`auth_token` from the handshake. Never errors — any failure falls back to the cap
 /// (tuning is best-effort).
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn tune_ollama_concurrency(
+pub(crate) fn tune_remote_concurrency(
     conn: &Connection,
     provider: &str,
     endpoint: &str,
@@ -112,7 +112,11 @@ pub(crate) fn tune_ollama_concurrency(
     // fan-out.
     let batch_size = remote.batch_size.max(1);
     let key = tune_cache_key(TuneKey {
-        runtime: "ollama",
+        // The backend discriminator keeps an ollama tune from colliding with an infinity/vLLM tune
+        // for the same box shape (each server has its own throughput curve). Server-launch knobs
+        // (vLLM `--max-num-seqs`, infinity batch) are set at PROVISION time — fold them in here
+        // once the cookbook input carries them (Phase 2).
+        runtime: remote.backend.as_db_str(),
         provider,
         gpu: remote.gpu.as_deref().unwrap_or("cpu"),
         model: remote.model.trim(),
@@ -748,7 +752,7 @@ mod tests {
     }
 
     #[test]
-    fn tune_ollama_concurrency_returns_a_fresh_cached_knee_without_probing() {
+    fn tune_remote_concurrency_returns_a_fresh_cached_knee_without_probing() {
         let conn = mem_conn();
         let remote = tune_remote(32);
         let spec =
@@ -768,7 +772,7 @@ mod tests {
         });
         write_cached_knee(&conn, &key, 6, 32, 100.0);
         // The endpoint is never contacted: the cache hits first, even with `allow_sweep = false`.
-        let knee = tune_ollama_concurrency(
+        let knee = tune_remote_concurrency(
             &conn,
             "modal",
             "http://127.0.0.1:1",
@@ -782,14 +786,14 @@ mod tests {
     }
 
     #[test]
-    fn tune_ollama_concurrency_uses_the_cap_on_a_miss_when_sweep_disallowed() {
+    fn tune_remote_concurrency_uses_the_cap_on_a_miss_when_sweep_disallowed() {
         let conn = mem_conn();
         let remote = tune_remote(8);
         let spec =
             crate::embedding_models::spec(crate::embedding_models::FASTEMBED_MODEL_ID).unwrap();
         // No cache entry + `allow_sweep = false` (a bounded / non-fan-out run) → the raw cap, and
         // the unreachable endpoint is never probed (no sweep runs).
-        let knee = tune_ollama_concurrency(
+        let knee = tune_remote_concurrency(
             &conn,
             "modal",
             "http://127.0.0.1:1",
@@ -804,14 +808,14 @@ mod tests {
     }
 
     #[test]
-    fn tune_ollama_concurrency_falls_back_conservatively_when_every_probe_fails() {
+    fn tune_remote_concurrency_falls_back_conservatively_when_every_probe_fails() {
         let conn = mem_conn();
         // Small cap → few candidates; unreachable endpoint → every probe fails fast (connection
         // refused), so the sweep finds no stable candidate.
         let remote = tune_remote(2);
         let spec =
             crate::embedding_models::spec(crate::embedding_models::FASTEMBED_MODEL_ID).unwrap();
-        let knee = tune_ollama_concurrency(
+        let knee = tune_remote_concurrency(
             &conn,
             "modal",
             "http://127.0.0.1:1",

--- a/crates/rag-rat-core/src/index/ai/throughput_tune.rs
+++ b/crates/rag-rat-core/src/index/ai/throughput_tune.rs
@@ -148,6 +148,7 @@ pub(crate) fn tune_remote_concurrency(
     let build = |concurrency: u32, request_timeout_s: u64| -> OpenAiEmbedder {
         OpenAiEmbedder::from_provisioned(ProvisionedEmbedderParams {
             endpoint,
+            embed_path: remote.backend.embed_path(),
             auth_token,
             server_model: remote.model.trim(),
             selected_model_id: spec.model_id,


### PR DESCRIPTION
Phase 1 of switchable embedding backends (#347): centralize all remote embedding on the OpenAI-compatible `/v1/embeddings` API and add a `[remote] backend` selector. **Rust-only, testable in connect mode against a local docker — no paid boxes.** Phases 2 (cookbook recipes) and 3 (benchmark CLI) follow separately.

### What changed
- **One client for every backend.** `providers/ollama.rs` → `openai.rs`, `OllamaEmbedder` → `OpenAiEmbedder`. Request/response swapped from ollama's `/api/embed` (`{embeddings:[[...]]}`) to the OpenAI shape (`{model,input,encoding_format}` → `{data:[{embedding,index}]}`), with **strict validation** (`data.len()==texts.len()`, indices present/unique/in-range/cover `0..n` — not just a sort) and `{error:{message}}` parsing on non-2xx. All call sites + re-exports migrated (no shims). Per-request `num_ctx` dropped (no OpenAI equivalent; stays a config field for freshness + model-load).
- **`[remote] backend = "ollama" | "infinity" | "vllm"`** selector (`RemoteBackend` closed enum, `#[serde(default)]` → `ollama` for back-compat with persisted meta + omitted TOML), validated in `TryFrom`.
- **Per-backend routing only.** The wire call is identical across backends; the selector routes the freshness/vector-identity marker, the tune cache key, the install runtime marker, and the **embeddings path** (see below). `remote_freshness_version` folds in `backend` + an `openai-v1` protocol salt (forces one clean re-embed on the `/api/embed`→`/v1/embeddings` migration). `install_ollama_model` → `install_remote_model`; `tune_ollama_concurrency` → `tune_remote_concurrency`.
- **Per-backend embeddings path (live-test finding).** infinity's `v2` server serves the OpenAI-shaped route at `/embeddings`, NOT `/v1/embeddings` (ollama + vLLM use `/v1/embeddings`). `RemoteBackend::embed_path()` handles it — same shape, correct path.

### Validation
- `cargo nextest run -p rag-rat-core -p rag-rat` → **1290 pass, 0 fail**; `clippy --all-targets` + `+nightly fmt` clean.
- **Live connect-mode against real servers** (throwaway repo → index → `models install` probe → `reconcile`):
  - **ollama** `/v1/embeddings`: wrote 3× 384-dim embeddings, 0 failures, `runtime: ollama`.
  - **infinity** (`michaelf34/infinity:latest-cpu`) `/embeddings`: wrote 3× 384-dim embeddings, 0 failures, `runtime: infinity`.
- New unit tests: OpenAI response parse/index-ordering (existing suite retargeted), config `backend` round-trip (default/case-insensitive/unknown) + serde↔db-str pinning, `embed_path` per backend, freshness differs across ollama/infinity/vllm.

Reviewed by Codex before implementation; its refinements (rename-seam enumeration incl. re-exports, strict index validation, freshness protocol salt, backend-neutral install/errors) are folded in.

Part of #347. Fixes #344.
