### PR TITLE
feat(cookbook): infinity + vLLM ephemeral recipes over OpenAI /v1/embeddings (Phase 2)

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -1,9 +1,10 @@
 # @rag-rat/cookbook
 
 Ephemeral remote-runtime provisioning recipes for [rag-rat](https://github.com/cq27-dev/rag-rat). A **recipe** is a standalone
-Node program that rag-rat spawns as a subprocess: it provisions a remote box (e.g. an Ollama
-embedding server), streams typed JSONL events to stdout (handing rag-rat the endpoint via a
-`ready` event), holds the box while rag-rat works, then tears it down on signal.
+Node program that rag-rat spawns as a subprocess: it provisions a remote box serving an embedding
+model (ollama, [michaelfeil/infinity](https://github.com/michaelfeil/infinity), or
+[vLLM](https://docs.vllm.ai) — chosen per run), streams typed JSONL events to stdout (handing rag-rat
+the endpoint via a `ready` event), holds the box while rag-rat works, then tears it down on signal.
 
 This is the JS/TS half of rag-rat's remote-runtime rework. rag-rat (Rust) owns the
 lifecycle and the embedding traffic; the cookbook owns provider provisioning.
@@ -14,6 +15,33 @@ lifecycle and the embedding traffic; the cookbook owns provider provisioning.
 > resolves to** — `npx -y <name>` runs arbitrary downloaded code as you. Pin and trust the cookbook
 > spec like any dependency; never point rag-rat at an untrusted package name or a recipe path you
 > have not read.
+
+## Provider × backend
+
+Two axes, kept orthogonal:
+
+- **Provider** (`modal`, `runpod`) — *where* the box runs. Selected by the subcommand
+  (`cookbook modal` / `cookbook runpod`). Owns the box lifecycle: create, tunnel/proxy, teardown,
+  leak-safety. One recipe file per provider (`recipes/modal.mts`, `recipes/runpod.mts`).
+- **Backend** (`ollama`, `infinity`, `vllm`) — *what* serves the model. Selected by the
+  `backend` field in `CookbookInput` (NOT a subcommand), so a single provider recipe serves all
+  three. The per-backend differences — image, launch command, port, embeddings route, model-load —
+  are declared in `recipes/backends.mts`.
+
+All three backends speak the **OpenAI-compatible embeddings API** (`POST <embedPath>` with `{model,
+input:[…], encoding_format:"float"}` → `{data:[{embedding,index}]}`), so the embed call and the
+readiness probe are backend-independent. Only the **route** differs:
+
+| Backend | Image | Port | Embeddings route | GPU | Model load |
+|---|---|---|---|---|---|
+| `ollama` | `ollama/ollama:latest` | 11434 | `/v1/embeddings` | optional | `ollama pull` after boot |
+| `infinity` | `michaelf34/infinity:latest[-cpu]` | 7997 | `/embeddings` | optional | auto-download on boot |
+| `vllm` | `vllm/vllm-openai:latest` | 8000 | `/v1/embeddings` | **required** | auto-download on boot |
+
+`model` is backend-specific: an **ollama model name** (`all-minilm`) for ollama, a **HuggingFace
+model id** (`sentence-transformers/all-MiniLM-L6-v2`) for infinity/vLLM (which download it from HF on
+start). The `embedPath` for each backend **must mirror `RemoteBackend::embed_path` on the Rust
+side** — the recipe's verification probe and rag-rat's real embed call have to hit the same URL.
 
 ## The process contract
 
@@ -36,8 +64,8 @@ Hard rules:
 - **stdout carries ONLY JSONL events** — one `CookbookEvent` per line, nothing else. Use `log(level,
   message)` / `ctx.status(phase, detail)` / the `emit()` helper; never `console.log`. **stderr is
   for genuine crashes only** (an uncaught throw).
-- **`ready` only after serving.** Don't emit `ready` until the box answers a real request (the
-  recipes probe `/api/embed` and wait for a vector).
+- **`ready` only after serving.** Don't emit `ready` until the box answers a real request — the
+  recipes probe the backend's OpenAI embeddings route (`verifyEmbed`) and wait for a vector.
 - **Stay alive after `ready`** until signaled.
 - **Tear down on `SIGTERM`/`SIGINT`** (a `tearing_down` status precedes it), then `exit(0)`.
 - **Bound EVERY await — fetch AND SDK call.** Anything that can stall past the Rust-side grace gets
@@ -55,22 +83,31 @@ Hard rules:
 
 ```jsonc
 {
-  "model": "all-minilm",       // required: non-empty string — the embedding model to pull + serve
+  "model": "all-minilm",       // required: non-empty string — the model to serve. An ollama model
+                               //   name for the ollama backend; a HuggingFace model id for
+                               //   infinity/vLLM (e.g. "sentence-transformers/all-MiniLM-L6-v2").
+  "backend": "ollama",         // optional: "ollama" | "infinity" | "vllm". Omitted/null → "ollama".
+                               //   Selects the image/launch/port/route; the embed wire call is
+                               //   identical across all three.
   "provision_timeout_s": 280,  // optional: positive number — wall-clock budget for the WHOLE
-                               //   provisioning sequence (box boot + model pull + first serving
-                               //   response). A remote cold start takes MINUTES; rag-rat sends
-                               //   ~280s. THIS is the recipes' poll-loop budget. Omitted/null →
-                               //   the recipe's default.
+                               //   provisioning sequence (box boot + model download/pull + first
+                               //   serving response). A remote cold start takes MINUTES; rag-rat
+                               //   sends ~280s. THIS is the recipes' poll-loop budget. Omitted/null
+                               //   → the recipe's default.
   "request_timeout_s": 30,     // optional: positive number — the Rust embedder's per-HTTP-request
                                //   timeout, passed through for completeness. NOT a provisioning
                                //   budget (~30–60s is far too short to boot a box).
   "gpu": null,                 // optional: string or null. For Modal this is a Modal GPU request
-                               //   string like "A10", "L40S", "H100", or "B200+" (CPU default);
-                               //   for RunPod a gpuTypeId like "NVIDIA RTX A4000".
-  "ollama_num_parallel": 32    // optional: positive integer — sets OLLAMA_NUM_PARALLEL in the
-                               //   remote Ollama container. rag-rat sends the user's `[remote]
-                               //   concurrency` CAP so the box can serve up to that many parallel
-                               //   /api/embed requests; rag-rat then auto-tunes the actual client
+                               //   string like "A10G", "L40S", "H100" (CPU default for ollama/
+                               //   infinity; a GPU is defaulted in for vLLM); for RunPod a gpuTypeId
+                               //   like "NVIDIA RTX A4000".
+  "num_ctx": null,             // optional: positive integer — the OLLAMA context window baked into
+                               //   the box (OLLAMA_CONTEXT_LENGTH), so chunk vectors match rag-rat's
+                               //   freshness key. Ignored by infinity/vLLM. Omitted/null → default.
+  "server_concurrency": 32     // optional: positive integer — server-side request parallelism.
+                               //   rag-rat sends the user's `[remote] concurrency` CAP; each backend
+                               //   maps it (ollama → OLLAMA_NUM_PARALLEL; vLLM → --max-num-seqs;
+                               //   infinity ignores it). rag-rat then auto-tunes the actual client
                                //   fan-out (within the cap) itself, against the box, after `ready`.
 }
 ```
@@ -78,8 +115,8 @@ Hard rules:
 The provisioning budget is **`provision_timeout_s`**, never `request_timeout_s` — conflating the
 two (using the ~30–60s per-request timeout as the boot budget) is what made the first live e2e time
 out before the box finished booting. `readInput` validates each field up front (a string timeout
-would otherwise become `NaN` and break the poll loops); a malformed input emits an `error` event and
-`exit(1)`, no `ready`.
+would otherwise become `NaN` and break the poll loops; an unknown `backend` is a hard error); a
+malformed input emits an `error` event and `exit(1)`, no `ready`.
 
 ### The stdout event stream (`CookbookEvent`)
 
@@ -93,8 +130,8 @@ stdout is JSONL — one of these objects per line. Every event carries `ts` (epo
 // diagnostics: level ∈ {"info","warn","error"}
 {"type":"log","level":"info","message":"pod deployed: abc123","ts":1782489011405}
 
-// the box is serving — REPLACES the old bare handshake line. Carries only the endpoint and an
-// optional auth token; rag-rat does the throughput tuning itself after this event.
+// the box is serving. Carries only the endpoint and an optional auth token; rag-rat does the
+// throughput tuning itself after this event.
 {"type":"ready","endpoint":"https://abc123.modal.host","auth_token":null,"ts":1782489011405}
 
 // provisioning failed before `ready`
@@ -108,21 +145,19 @@ with exit 1 and no `ready`).
 
 ### Throughput tuning lives in rag-rat, not the recipe
 
-The recipe is a **dumb provisioner**: it boots the box, sets `OLLAMA_NUM_PARALLEL` to the user's
-`[remote] concurrency` cap (passed as `ollama_num_parallel`), verifies `/api/embed` serves, and
-emits `ready`. It does **no** throughput sweeping.
+The recipe is a **dumb provisioner**: it boots the box, maps `server_concurrency` to the backend's
+own knob, verifies the embeddings route serves, and emits `ready`. It does **no** throughput
+sweeping.
 
 rag-rat owns the tuning. After `ready`, rag-rat runs a short client-concurrency micro-sweep against
-the box **with its real `OllamaEmbedder`** — the same request shape (num_ctx, batch size, char
-budget) reconcile will use — so the measured knee can't drift from real load the way a recipe-side
-re-implementation did. The tuned knee is a **hard-clamped-to-cap** client fan-out: rag-rat treats
-`[remote] concurrency` as a ceiling it optimizes *within* and never exceeds or overwrites. The
-result is cached in the index's `index_meta` (keyed by runtime + provider + GPU + model + request
-shape) with a TTL, so routine re-provisions reuse it without re-sweeping. See rag-rat's
-`RAG_RAT_TUNE_MS` / `RAG_RAT_TUNE_TTL_MS` / `RAG_RAT_DISABLE_TUNING` env knobs, not any cookbook-side
-ones.
+the box **with its real `OpenAiEmbedder`** — the same request shape (batch size, char budget) that
+reconcile will use — so the measured knee can't drift from real load. The tuned knee is a
+**hard-clamped-to-cap** client fan-out: rag-rat treats `[remote] concurrency` as a ceiling it
+optimizes *within* and never exceeds. The result is cached in the index's `index_meta` (keyed by
+backend + provider + GPU + model + request shape) with a TTL, so routine re-provisions reuse it
+without re-sweeping. See rag-rat's tuning env knobs, not any cookbook-side ones.
 
-## Invoking — provider as a subcommand
+## Invoking — provider as a subcommand, backend in the input
 
 The published form is **one package, provider as a subcommand**, via the package bin:
 
@@ -132,52 +167,53 @@ npx @rag-rat/cookbook runpod    # provision on RunPod
 ```
 
 The bin (`dist/cli.mjs`) reads the provider from `argv[2]` and dynamically imports the matching
-recipe (`recipes/<provider>-ollama.mjs`). Recipes self-run on import, so the dispatcher adds only
-routing — no contract logic. An unknown or missing provider emits an `error` event listing the
-available providers and exits `1` (no `ready`). The recipe files stay **directly runnable** too,
+recipe (`recipes/<provider>.mjs`). The **backend** (ollama/infinity/vLLM) arrives in
+`RAG_RAT_COOKBOOK_INPUT.backend`, not the subcommand. Recipes self-run on import, so the dispatcher
+adds only routing — no contract logic. An unknown or missing provider emits an `error` event listing
+the available providers and exits `1` (no `ready`). The recipe files stay **directly runnable** too,
 which is what rag-rat actually spawns:
 
 ```bash
-node dist/recipes/modal-ollama.mjs     # equivalent to `cookbook modal`
-node dist/recipes/runpod-ollama.mjs    # equivalent to `cookbook runpod`
+node dist/recipes/modal.mjs     # equivalent to `cookbook modal`
+node dist/recipes/runpod.mjs    # equivalent to `cookbook runpod`
 ```
 
 ## Recipes
 
 | Recipe | Provider | Subcommand | Entry (post-build) |
 |---|---|---|---|
-| `recipes/modal-ollama.mts` | [Modal](https://modal.com) Sandboxes | `modal` | `dist/recipes/modal-ollama.mjs` |
-| `recipes/runpod-ollama.mts` | [RunPod](https://runpod.io) GPU pods | `runpod` | `dist/recipes/runpod-ollama.mjs` |
+| `recipes/modal.mts` | [Modal](https://modal.com) Sandboxes | `modal` | `dist/recipes/modal.mjs` |
+| `recipes/runpod.mts` | [RunPod](https://runpod.io) GPU pods | `runpod` | `dist/recipes/runpod.mjs` |
 
-### modal-ollama
+Each provider recipe owns only the box lifecycle; the backend spec (`recipes/backends.mts`) supplies
+image, entrypoint args, env, port, embeddings route, and model-load strategy.
 
-Provisions a [Modal Sandbox](https://modal.com/docs/guide/sandboxes) from the `ollama/ollama:latest`
-image, serves an embedding model, and tunnels port `11434`.
+### modal
+
+Provisions a [Modal Sandbox](https://modal.com/docs/guide/sandboxes) from the backend's image, serves
+the model, and tunnels the backend's port.
 
 Provider gotchas baked into the recipe (each one cost real time to find):
 
-- Modal Sandbox `command` is passed as entrypoint args for registry images. The `ollama/ollama`
-  image already has `/bin/ollama` as its entrypoint, so the recipe uses `["serve"]`, attaches a TCP
-  readiness probe on port `11434`, and explicitly waits for readiness before pulling/verifying the
-  model.
-- ollama defaults to `127.0.0.1:11434`, unreachable by the tunnel — the recipe sets
-  `OLLAMA_HOST=0.0.0.0:11434`.
-- Ollama defaults to single-request handling — the recipe sets `OLLAMA_NUM_PARALLEL` from
-  `input.ollama_num_parallel` (the user's `[remote] concurrency` cap). rag-rat tunes the actual
-  client fan-out itself after `ready`.
-- **GPU is off by default.** GPU on Modal must attach before ollama's discovery watchdog times out,
-  or the box dies with exit 137 at cold start. CPU `serve` is the safe v1 path; pass `gpu` only if
-  you've accepted that.
+- Modal Sandbox `command` is passed as **entrypoint args** for registry images — the backend spec
+  supplies exactly those (never the entrypoint itself: ollama's is `/bin/ollama` so args are
+  `["serve"]`; infinity's is `infinity_emb` so args start `["v2", …]`; vLLM's is `vllm serve` so the
+  first arg is the model id). A TCP readiness probe waits for the port before pulling/verifying.
+- The box must listen on `0.0.0.0` for the tunnel to reach it — ollama needs `OLLAMA_HOST` (spec
+  env); infinity binds `0.0.0.0` by default; vLLM gets an explicit `--host 0.0.0.0`.
+- **GPU is off by default for ollama/infinity** (and, for ollama, must attach before its discovery
+  watchdog times out or the box dies exit 137 at cold start). vLLM's image is CUDA-only, so when the
+  backend `requiresGpu` and the caller passed none, the recipe defaults a GPU in.
 - `timeoutMs: 1_800_000` (30 min) is the provider-side lifetime backstop.
 
 Auth comes from the ambient env (`MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET`) or `~/.modal.toml` —
 rag-rat does not pass Modal creds through `RAG_RAT_COOKBOOK_INPUT`.
 
-### runpod-ollama
+### runpod
 
-Provisions an ephemeral **GPU pod** on [RunPod](https://runpod.io) from the `ollama/ollama:latest`
-image and serves an embedding model on port `11434`. RunPod proxies that HTTP port at
-`https://<podId>-11434.proxy.runpod.net` — that proxy URL is the endpoint.
+Provisions an ephemeral **GPU pod** on [RunPod](https://runpod.io) from the backend's image and
+serves the model on the backend's port. RunPod proxies that HTTP port at
+`https://<podId>-<port>.proxy.runpod.net` — that proxy URL is the endpoint.
 
 It talks to RunPod's **GraphQL API directly over `fetch`** (`podFindAndDeployOnDemand` to deploy,
 `podTerminate` to tear down). The `runpod-sdk` npm package is deliberately **not** a dependency: it
@@ -186,26 +222,26 @@ pod-management surface.
 
 Provider gotchas baked into the recipe:
 
-- The ollama image **entrypoint is `/bin/ollama`**, so `dockerArgs: "serve"` runs `ollama serve`
-  (`"ollama serve"` would exec `ollama ollama serve`). `dockerArgs` sets the container CMD,
-  appended to the entrypoint.
-- ollama defaults to `127.0.0.1:11434`, unreachable through the proxy — the recipe sets
-  `OLLAMA_HOST=0.0.0.0:11434` and `OLLAMA_NUM_PARALLEL` (from `input.ollama_num_parallel`, the user's
-  `[remote] concurrency` cap) in the pod env. rag-rat tunes the client fan-out itself after `ready`.
-- There is **no in-pod exec** in `podFindAndDeployOnDemand`, so the model is pulled **client-side**
-  over the proxy URL (`POST /api/pull`, non-streaming, retried until the pod finishes booting),
-  then `/api/embed` is probed before the `ready` event.
+- `dockerArgs` is the container CMD, **appended to the image's baked entrypoint** — the backend spec
+  supplies exactly the args (ollama's entrypoint is `/bin/ollama` so args are `serve`; infinity's is
+  `infinity_emb` so args start `v2 …`; vLLM's is `vllm serve` so the first arg is the model id).
+- The server must listen on `0.0.0.0` for the proxy to reach it — ollama needs `OLLAMA_HOST` (spec
+  env); infinity binds `0.0.0.0` by default; vLLM gets `--host 0.0.0.0`.
+- There is **no in-pod exec** in `podFindAndDeployOnDemand`. For **ollama** (which boots empty) the
+  model is pulled **client-side** over the proxy URL (`POST /api/pull`, non-streaming, retried until
+  the pod finishes booting). infinity/vLLM auto-download the HF model on boot — no pull step. Then
+  the embeddings route is probed before the `ready` event.
 - **No provider-side backstop.** RunPod's `podFindAndDeployOnDemand` has **no** field that
   auto-stops or auto-terminates an on-demand GPU pod after a duration or after idle (`idleTimeout`
   is a serverless/flex-worker concept, not an on-demand-pod control — verified against the RunPod
   GraphQL spec). So **reliable teardown is the only thing that stops the billing**: every fetch is
   `AbortSignal`-bounded, and `podTerminate` runs under a tight (~8 s) timeout to finish inside the
   Rust-side grace.
-- **Deploy-timeout orphan sweep.** The pod is deployed with a unique name
-  (`rag-rat-cookbook-ollama-<ts>`). If the deploy call throws (e.g. RunPod created the pod but the
-  response was lost/slow) before the pod handle is reported, the recipe queries `myself { pods }`,
-  terminates any pod matching that name, then rethrows — so a created-but-unacknowledged pod can't
-  bill forever. Best-effort and bounded; it only logs, never masks the original deploy error.
+- **Deploy-timeout orphan sweep.** The pod is deployed with a unique name (`rag-rat-cookbook-<ts>`).
+  If the deploy call throws (e.g. RunPod created the pod but the response was lost/slow) before the
+  pod handle is reported, the recipe queries `myself { pods }`, terminates any pod matching that
+  name, then rethrows — so a created-but-unacknowledged pod can't bill forever. Best-effort and
+  bounded; it only logs, never masks the original deploy error.
 - Default GPU is a cheap `NVIDIA RTX A4000`; `input.gpu` is a `gpuTypeId` override.
 
 Auth: `RUNPOD_API_KEY` in the process env — the recipe emits an `error` event and exits `1` (no
@@ -222,11 +258,11 @@ npm run typecheck    # tsc --noEmit
 RAG_RAT_COOKBOOK_INPUT='{"model":"all-minilm"}' node dist/cli.mjs modal
 RUNPOD_API_KEY=… RAG_RAT_COOKBOOK_INPUT='{"model":"all-minilm"}' node dist/cli.mjs runpod
 
-# or a recipe directly (what rag-rat spawns):
-RAG_RAT_COOKBOOK_INPUT='{"model":"all-minilm"}' node dist/recipes/modal-ollama.mjs
+# or a recipe directly (what rag-rat spawns), with a non-default backend:
+RAG_RAT_COOKBOOK_INPUT='{"model":"sentence-transformers/all-MiniLM-L6-v2","backend":"infinity"}' node dist/recipes/modal.mjs
 
 # dev (no build step), via tsx:
-RAG_RAT_COOKBOOK_INPUT='{"model":"all-minilm"}' npx tsx recipes/runpod-ollama.mts
+RAG_RAT_COOKBOOK_INPUT='{"model":"all-minilm"}' npx tsx recipes/runpod.mts
 ```
 
 The recipe runs until you `SIGTERM`/`SIGINT` it (Ctrl-C), at which point it tears down the box.
@@ -236,22 +272,34 @@ The recipe runs until you `SIGTERM`/`SIGINT` it (Ctrl-C), at which point it tear
 A recipe is a `.mts` file that hands a `Recipe<H>` to `runRecipe` from `@rag-rat/cookbook`. The
 harness owns all the contract plumbing **and** the terminate-on-error wrapper and the
 provision-timeout clamp, so a recipe is just: provision, report the box via `ctx.onBox`, emit
-progress via `ctx.status`, verify, and return.
+progress via `ctx.status`, verify, and return. Select the backend spec with `selectBackendSpec` so
+one recipe serves every backend.
 
 ```ts
 import {
   type ProvisionContext, type Provisioned, type Recipe,
   runRecipe, verifyEmbed, log,
 } from "@rag-rat/cookbook"; // or "../src/contract.js" in-repo
+import { selectBackendSpec } from "./backends.mjs";
 
 async function provision(ctx: ProvisionContext<MyBox>): Promise<Provisioned<MyBox>> {
-  const { input, provisionTimeoutMs } = ctx;       // already clamped from provision_timeout_s
-  ctx.status("provisioning", "creating box");      // status events tag the recipe's provider
-  const box = await myProvider.spawn(/* … */);
-  ctx.onBox(box);                                  // report NOW → runRecipe tears down if we throw
-  log("info", `box ${box.id} created`);            // log(level, message) → a `log` event
-  ctx.status("verifying", "probing /api/embed");
-  await verifyEmbed(box.url, { model: input.model, budgetMs: provisionTimeoutMs });
+  const { input, provisionTimeoutMs } = ctx;        // already clamped from provision_timeout_s
+  const spec = selectBackendSpec(input.backend ?? "ollama");
+  ctx.status("provisioning", "creating box");       // status events tag the recipe's provider
+  const box = await myProvider.spawn({
+    image: spec.image(input),
+    command: [...spec.entrypointArgs(input)],
+    env: spec.env(input),
+    port: spec.port,
+  });
+  ctx.onBox(box);                                   // report NOW → runRecipe tears down if we throw
+  log("info", `box ${box.id} created`);             // log(level, message) → a `log` event
+  ctx.status("verifying", `probing ${spec.embedPath}`);
+  await verifyEmbed(box.url, {
+    model: input.model,
+    embedPath: spec.embedPath,
+    budgetMs: provisionTimeoutMs,
+  });
   return { handle: box, endpoint: box.url, auth_token: null };
 }
 
@@ -287,9 +335,10 @@ that is what lets the harness clean up a half-provisioned box.
 The contract module also exports the shared bounding helpers — call these instead of a bare `fetch`
 or a bare SDK `await`:
 
-- **`verifyEmbed(endpoint, { model, budgetMs, headers? })`** — poll `<endpoint>/api/embed` until a
-  real vector comes back. Call it before returning from `provision` (a reachable box is not a
-  serving box).
+- **`verifyEmbed(endpoint, { model, embedPath, budgetMs, headers? })`** — poll
+  `<endpoint><embedPath>` with the OpenAI embeddings request until a real vector comes back. Call it
+  before returning from `provision` (a reachable box is not a serving box). `embedPath` comes from
+  the backend spec.
 - **`pollUntil(url, { label, body, isReady, budgetMs, pollIntervalMs?, perAttemptTimeoutMs? })`** —
   the generic retry-until-ready loop. Each attempt is `AbortSignal`-bounded AND clamped to the
   remaining budget, so no attempt runs past the deadline. `verifyEmbed` and the RunPod model pull
@@ -303,8 +352,9 @@ or a bare SDK `await`:
 - **`assertBudgetRemaining(deadline, label)` / `remainingBudgetMs(deadline)`** — compute/guard the
   one shared provisioning deadline that `verifyEmbed`/`pullModel` budgets derive from.
 
-To add a provider, drop a `recipes/<name>-ollama.mts` and register it in the `PROVIDERS` map in
-`cli.mts`.
+To add a provider, drop a `recipes/<name>.mts` and register it in the `PROVIDERS` map in `cli.mts`.
+To add a backend, add a `BackendServerSpec` to `recipes/backends.mts` and extend the `Backend` union
+in `src/contract.ts` (keep it in sync with `RemoteBackend` on the Rust side).
 
 ## Layout
 
@@ -314,7 +364,8 @@ cookbook/
   tsconfig.json                strict, ESM (NodeNext)
   cli.mts                      the bin dispatcher: `cookbook <provider>` → imports the recipe (→ dist/cli.mjs)
   src/contract.ts              the published contract: CookbookEvent + emit/log/status + runRecipe() + pollUntil/verifyEmbed/fetchWithTimeout (→ dist/src/contract.js)
-  recipes/modal-ollama.mts     the Modal + Ollama recipe       (→ dist/recipes/modal-ollama.mjs)
-  recipes/runpod-ollama.mts    the RunPod + Ollama recipe       (→ dist/recipes/runpod-ollama.mjs)
+  recipes/backends.mts         per-backend server specs (image/launch/port/route/model-load)  (→ dist/recipes/backends.mjs)
+  recipes/modal.mts            the Modal provider recipe        (→ dist/recipes/modal.mjs)
+  recipes/runpod.mts           the RunPod provider recipe       (→ dist/recipes/runpod.mjs)
   README.md                    this file
 ```

--- a/cookbook/cli.mts
+++ b/cookbook/cli.mts
@@ -8,7 +8,10 @@
  * It reads the provider from argv[2] and dynamically imports the matching recipe. Recipes
  * self-run on import (each ends with `await runRecipe(...)`), so importing one IS running it —
  * the dispatcher adds no logic to the contract beyond routing. The recipe files stay directly
- * runnable too (`node dist/recipes/<provider>-ollama.mjs`); the dispatcher is just sugar.
+ * runnable too (`node dist/recipes/<provider>.mjs`); the dispatcher is just sugar.
+ *
+ * The BACKEND (ollama/infinity/vLLM) is NOT a subcommand — it arrives in the JSON input
+ * (`RAG_RAT_COOKBOOK_INPUT.backend`), so one `<provider>` recipe serves every backend.
  *
  * Unknown or missing provider → an `error` event (pre-`ready` failure) + exit 1. Like the recipes,
  * the dispatcher writes ONLY JSONL events to stdout.
@@ -18,8 +21,8 @@ import { emit, log } from "./src/contract.js";
 
 /** provider keyword → recipe module specifier (relative to this file's location in dist/). */
 const PROVIDERS: Readonly<Record<string, string>> = {
-  modal: "./recipes/modal-ollama.mjs",
-  runpod: "./recipes/runpod-ollama.mjs",
+  modal: "./recipes/modal.mjs",
+  runpod: "./recipes/runpod.mjs",
 };
 
 function fail(message: string): never {

--- a/cookbook/package-lock.json
+++ b/cookbook/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rag-rat/cookbook",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rag-rat/cookbook",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "modal": "^0.8.1"

--- a/cookbook/package.json
+++ b/cookbook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rag-rat/cookbook",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Ephemeral remote-runtime provisioning recipes for rag-rat. rag-rat (Rust) spawns a recipe as a subprocess, reads a typed JSONL event stream from its stdout (status/log/ready/error), embeds against the endpoint, then signals teardown.",
   "license": "MIT",
   "repository": {
@@ -37,8 +37,8 @@
     "typecheck": "tsc --noEmit",
     "prepare": "npm run build",
     "prepack": "npm run build",
-    "recipe:modal-ollama": "node dist/recipes/modal-ollama.mjs",
-    "recipe:runpod-ollama": "node dist/recipes/runpod-ollama.mjs"
+    "recipe:modal": "node dist/recipes/modal.mjs",
+    "recipe:runpod": "node dist/recipes/runpod.mjs"
   },
   "dependencies": {
     "modal": "^0.8.1"

--- a/cookbook/recipes/backends.mts
+++ b/cookbook/recipes/backends.mts
@@ -1,0 +1,145 @@
+/**
+ * Per-backend server specs: the declarative differences between the three embedding servers a
+ * recipe can provision (ollama, michaelfeil/infinity, vLLM). The PROVIDER recipes (modal.mts,
+ * runpod.mts) own the box lifecycle (create/tunnel/teardown, all provider-specific); a
+ * {@link BackendServerSpec} supplies the pieces that vary by SERVER — image, launch args, env, port,
+ * the embeddings route, and how the model gets loaded — so one provider recipe serves all backends.
+ *
+ * All three speak the OpenAI-compatible embeddings API, so the embed CALL and {@link verifyEmbed}
+ * are backend-independent; only the ROUTE differs (`embedPath`) — see the per-backend note on it.
+ *
+ * Launch facts (verified against upstream docs/live probes, 2026-07):
+ *   - ollama    `ollama/ollama:latest`         entrypoint `/bin/ollama`  → `serve` (empty server;
+ *               model pulled AFTER boot); binds 127.0.0.1 by default so OLLAMA_HOST must open it;
+ *               serves `/v1/embeddings`; port 11434; CPU-capable.
+ *   - infinity  `michaelf34/infinity:latest[-cpu]`  entrypoint `infinity_emb`
+ *               → `v2 --model-id <hf> --port 7997`; auto-downloads the HF model on boot; binds
+ *               0.0.0.0 by default; serves `/embeddings`; port 7997; CPU-capable.
+ *   - vLLM      `vllm/vllm-openai:latest`      entrypoint `vllm serve`
+ *               → `<hf> --runner pooling --host 0.0.0.0 --port 8000`; auto-downloads on boot; serves
+ *               `/v1/embeddings`; port 8000; GPU-REQUIRED (no official CPU image).
+ */
+
+import type { Backend, CookbookInput } from "../src/contract.js";
+
+/** The declarative, provider-independent description of one embedding backend. */
+export interface BackendServerSpec {
+  /** Which backend this spec serves — matches {@link CookbookInput.backend}. */
+  readonly backend: Backend;
+  /**
+   * The internal port the server listens on — the one port a provider tunnels/proxies out. Fixed
+   * per backend (we also pass it to the server via `entrypointArgs`, so the two never drift).
+   */
+  readonly port: number;
+  /**
+   * The OpenAI embeddings route this server answers on. MUST mirror `RemoteBackend::embed_path` on
+   * the Rust side (ollama/vLLM → `/v1/embeddings`; infinity → `/embeddings`) — the recipe's
+   * verification probe and rag-rat's real embed call have to hit the same URL.
+   */
+  readonly embedPath: string;
+  /**
+   * Whether this backend needs a GPU. vLLM's published image is CUDA-only, so a provider MUST attach
+   * a GPU for it (the recipe defaults one in when the caller didn't). ollama/infinity are
+   * CPU-capable, so a GPU is opt-in there.
+   */
+  readonly requiresGpu: boolean;
+  /**
+   * Model-load strategy once the server is listening:
+   *   - `"in-launch"` — the launch args already name the model; the server auto-downloads it from
+   *     HuggingFace on boot (infinity, vLLM). Nothing to do post-boot; {@link verifyEmbed} covers
+   *     the download wait.
+   *   - `"ollama-pull"` — the model must be pulled into a running ollama AFTER boot. The mechanism
+   *     is provider-specific (Modal in-box exec vs RunPod client-side `/api/pull`), so the provider
+   *     recipe owns it; this flag just says a pull step is needed.
+   */
+  readonly modelLoad: "in-launch" | "ollama-pull";
+  /** The container image to run. May differ by CPU vs GPU (infinity), hence a function of `input`. */
+  image(input: CookbookInput): string;
+  /**
+   * The args to pass AFTER the image's baked entrypoint. A provider hands these to the box verbatim
+   * (Modal as a `command` array, RunPod joined into `dockerArgs`). Never include the entrypoint
+   * itself — that's baked into the image.
+   */
+  entrypointArgs(input: CookbookInput): readonly string[];
+  /** Container env as a plain record; a provider maps it to its own shape. */
+  env(input: CookbookInput): Record<string, string>;
+}
+
+/** ollama serves on 11434 and binds loopback by default (OLLAMA_HOST opens it to the tunnel). */
+const OLLAMA_PORT = 11434;
+/** infinity's `v2` server default port. */
+const INFINITY_PORT = 7997;
+/** vLLM's OpenAI server default port. */
+const VLLM_PORT = 8000;
+
+const OLLAMA_SPEC: BackendServerSpec = {
+  backend: "ollama",
+  port: OLLAMA_PORT,
+  embedPath: "/v1/embeddings",
+  requiresGpu: false,
+  modelLoad: "ollama-pull",
+  image: () => "ollama/ollama:latest",
+  entrypointArgs: () => ["serve"],
+  env: (input) => ({
+    // ollama binds 127.0.0.1 by default, unreachable through a tunnel/proxy — open all interfaces.
+    OLLAMA_HOST: `0.0.0.0:${OLLAMA_PORT}`,
+    // The server's max parallel requests (rag-rat's cap); rag-rat tunes client fan-out within it.
+    OLLAMA_NUM_PARALLEL: String(input.server_concurrency ?? 1),
+    // Bake the context window for THIS box's models when configured, so chunk vectors match the
+    // freshness key that folds `num_ctx` in. Applies to every model this `serve` loads — including
+    // one serving queries — which is exactly the chunk↔query consistency we need.
+    ...(input.num_ctx != null ? { OLLAMA_CONTEXT_LENGTH: String(input.num_ctx) } : {}),
+  }),
+};
+
+const INFINITY_SPEC: BackendServerSpec = {
+  backend: "infinity",
+  port: INFINITY_PORT,
+  // infinity's OpenAI shape lives at `/embeddings` (it also mounts `/v1/embeddings`, but `/embeddings`
+  // is canonical and is what `RemoteBackend::embed_path` uses).
+  embedPath: "/embeddings",
+  requiresGpu: false,
+  modelLoad: "in-launch",
+  // CPU image unless a GPU was explicitly requested (infinity is CPU-capable; the CPU tag is slimmer).
+  image: (input) => (input.gpu != null ? "michaelf34/infinity:latest" : "michaelf34/infinity:latest-cpu"),
+  // `infinity_emb` is the entrypoint; `v2` is the subcommand. `--model-id` is the HF id. infinity
+  // binds 0.0.0.0 by default, so no host flag is needed. server_concurrency is intentionally NOT
+  // mapped: infinity's async engine batches dynamically, so there's no concurrent-request knob —
+  // rag-rat's client-side fan-out tune still applies.
+  entrypointArgs: (input) => ["v2", "--model-id", input.model, "--port", String(INFINITY_PORT)],
+  env: () => ({}),
+};
+
+const VLLM_SPEC: BackendServerSpec = {
+  backend: "vllm",
+  port: VLLM_PORT,
+  embedPath: "/v1/embeddings",
+  // vLLM's published image (`vllm/vllm-openai`) is CUDA-only — a provider must attach a GPU.
+  requiresGpu: true,
+  modelLoad: "in-launch",
+  image: () => "vllm/vllm-openai:latest",
+  // Entrypoint is `vllm serve`, so the model id is the first positional. `--runner pooling` puts
+  // vLLM in embedding mode (current flag; the old `--task embed` is deprecated as of v0.11). vLLM
+  // binds loopback unless `--host 0.0.0.0` is passed — the classic "up but unreachable" trap.
+  entrypointArgs: (input) => {
+    const args = [input.model, "--runner", "pooling", "--host", "0.0.0.0", "--port", String(VLLM_PORT)];
+    // Map the concurrency cap to vLLM's max concurrent sequences when set.
+    if (input.server_concurrency != null) {
+      args.push("--max-num-seqs", String(input.server_concurrency));
+    }
+    return args;
+  },
+  env: () => ({}),
+};
+
+/** All backend specs, keyed by backend. The one lookup table {@link selectBackendSpec} resolves. */
+const SPECS: Readonly<Record<Backend, BackendServerSpec>> = {
+  ollama: OLLAMA_SPEC,
+  infinity: INFINITY_SPEC,
+  vllm: VLLM_SPEC,
+};
+
+/** Resolve the {@link BackendServerSpec} for `backend`. Total over the {@link Backend} union. */
+export function selectBackendSpec(backend: Backend): BackendServerSpec {
+  return SPECS[backend];
+}

--- a/cookbook/recipes/modal.mts
+++ b/cookbook/recipes/modal.mts
@@ -1,27 +1,32 @@
 /**
- * Recipe: provision an ephemeral Ollama box on Modal, serve an embedding model, hand rag-rat
- * the tunnel endpoint, and tear the box down on signal.
+ * Recipe: provision an ephemeral embedding box on Modal, serve the model with the selected backend
+ * (ollama, infinity, or vLLM), hand rag-rat the tunnel endpoint, and tear the box down on signal.
  *
- * Run (post-build):  RAG_RAT_COOKBOOK_INPUT='{"model":"all-minilm"}' node dist/recipes/modal-ollama.mjs
- * Run (dev):         RAG_RAT_COOKBOOK_INPUT='{"model":"all-minilm"}' npx tsx recipes/modal-ollama.mts
+ * Run (post-build):  RAG_RAT_COOKBOOK_INPUT='{"model":"all-minilm"}' node dist/recipes/modal.mjs
+ * Run (dev):         RAG_RAT_COOKBOOK_INPUT='{"model":"all-minilm","backend":"infinity"}' npx tsx recipes/modal.mts
  *
  * Modal auth comes from the ambient process env (MODAL_TOKEN_ID / MODAL_TOKEN_SECRET) or
  * ~/.modal.toml — rag-rat does not pass creds through RAG_RAT_COOKBOOK_INPUT.
  *
- * Mirrors the proven Python provisioning. Provider gotchas, all load-bearing:
- *   - Modal Sandbox `command` is passed as entrypoint args for registry images. The
- *     `ollama/ollama` image already has `/bin/ollama` as ENTRYPOINT, so use `["serve"]`; passing
- *     `["/bin/ollama", "serve"]` runs `ollama /bin/ollama serve` and exits with "unknown command".
- *   - ollama binds 127.0.0.1:11434 by default, which the Modal tunnel cannot reach. We set
- *     OLLAMA_HOST=0.0.0.0:11434 so it listens on all interfaces.
- *   - GPU is optional and OFF by default. GPU on Modal must be attached before ollama's
- *     discovery watchdog times out, or the box dies with exit 137 at cold start; CPU `serve`
- *     is the safe v1 path. Pass input.gpu only when you've accepted that risk.
+ * WHAT VARIES BY BACKEND lives in {@link selectBackendSpec} (image, entrypoint args, env, port, the
+ * embeddings route, and whether a post-boot model pull is needed). THIS file owns only the Modal box
+ * lifecycle, which is backend-independent.
+ *
+ * Modal gotchas, all load-bearing:
+ *   - Modal Sandbox `command` is passed as ENTRYPOINT ARGS for registry images (the spec supplies
+ *     exactly those, never the entrypoint itself: ollama's is `/bin/ollama` so args are `["serve"]`;
+ *     infinity's is `infinity_emb` so args start `["v2", …]`; vLLM's is `vllm serve` so the first
+ *     arg is the model id).
+ *   - The box must listen on 0.0.0.0 for the tunnel to reach it — ollama needs OLLAMA_HOST (set in
+ *     its spec env); infinity binds 0.0.0.0 by default; vLLM gets an explicit `--host 0.0.0.0`.
+ *   - GPU: ollama/infinity default to CPU (GPU is opt-in and, for ollama, must attach before its
+ *     discovery watchdog times out or the box dies exit 137). vLLM's image is CUDA-only, so when the
+ *     backend `requiresGpu` and the caller passed none we default one in ({@link MODAL_DEFAULT_GPU}).
  *   - timeout=1800s (30 min) is the provider-side max-lifetime backstop: if rag-rat dies or
  *     SIGKILLs us before teardown runs, Modal self-destructs the box. (RunPod has no equivalent.)
  *
  * The harness ({@link runRecipe}) owns the terminate-on-error wrapper and the provision-timeout
- * clamp, so this recipe is just: create the box, report it via `ctx.onBox`, pull, verify, return.
+ * clamp, so this recipe is just: create the box, report it via `ctx.onBox`, (pull,) verify, return.
  * Every Modal SDK await here is wrapped in `withBudget` so a hang aborts into teardown rather than
  * running past the Rust hard timeout and getting SIGKILLed with the box still billing (N2).
  */
@@ -42,15 +47,16 @@ import {
   verifyEmbed,
   withBudget,
 } from "../src/contract.js";
+import { selectBackendSpec } from "./backends.mjs";
 
-/** Port ollama serves on inside the box; the one port we tunnel out. */
-const OLLAMA_PORT = 11434;
 /** Provider-side max-lifetime backstop in ms — a leaked box self-destructs after this. */
 const BOX_MAX_LIFETIME_MS = 1_800_000; // 30 minutes
 /** Default provisioning budget (boot + pull + first serving response) when input omits it. */
 const DEFAULT_PROVISION_TIMEOUT_S = 600;
 /** Modal app the sandboxes are grouped under (created on first use). */
 const APP_NAME = "rag-rat-cookbook";
+/** GPU attached when a backend REQUIRES one (vLLM) and the caller passed no `gpu`. */
+const MODAL_DEFAULT_GPU = "A10G";
 /**
  * Bound on the teardown `sb.terminate()` — kept under the Rust side's ~10s teardown grace (like
  * RunPod's `TEARDOWN_TIMEOUT_MS`) so terminate completes-or-aborts BEFORE rag-rat SIGKILLs us; a
@@ -58,9 +64,11 @@ const APP_NAME = "rag-rat-cookbook";
  */
 const TEARDOWN_TIMEOUT_MS = 8_000;
 
-/** Provision an Ollama box serving `input.model` and return its tunnel endpoint. */
+/** Provision an embedding box serving `input.model` on the selected backend; return its endpoint. */
 async function provision(ctx: ProvisionContext<Sandbox>): Promise<Provisioned<Sandbox>> {
   const { input, provisionTimeoutMs } = ctx;
+  const spec = selectBackendSpec(input.backend ?? "ollama");
+  const port = spec.port;
   // ONE deadline for the WHOLE sequence (create + pull + verify). EVERY SDK await below — none of
   // which has a native timeout — is raced against the time REMAINING until this deadline via
   // `withBudget`, so a single hung Modal call can't run past the Rust provisioner's hard timeout
@@ -68,15 +76,12 @@ async function provision(ctx: ProvisionContext<Sandbox>): Promise<Provisioned<Sa
   // which tears the box down gracefully. (Modal's `timeoutMs` is only a last-resort backstop; a
   // leaked box bills until then.) See N2.
   const deadline = Date.now() + provisionTimeoutMs;
-  const gpu = input.gpu ?? null;
-  // rag-rat sends the user's `[remote] concurrency` cap as `ollama_num_parallel`; the box's server
-  // parallelism is set to it so rag-rat can fan out up to the cap. rag-rat tunes the actual client
-  // concurrency (within the cap) itself, against the box, after `ready`.
-  const ollamaNumParallel = String(input.ollama_num_parallel ?? 1);
+  // ollama/infinity default to CPU; a GPU-required backend (vLLM) gets a default GPU when none given.
+  const gpu = input.gpu ?? (spec.requiresGpu ? MODAL_DEFAULT_GPU : null);
 
   ctx.status(
     "provisioning",
-    `creating Modal sandbox (model=${input.model}, gpu=${gpu ?? "cpu"}, parallel=${ollamaNumParallel})`,
+    `creating Modal sandbox (backend=${spec.backend}, model=${input.model}, gpu=${gpu ?? "cpu"})`,
   );
 
   // Creds resolve from env (MODAL_TOKEN_ID/MODAL_TOKEN_SECRET) or ~/.modal.toml.
@@ -85,7 +90,7 @@ async function provision(ctx: ProvisionContext<Sandbox>): Promise<Provisioned<Sa
     modal.apps.fromName(APP_NAME, { createIfMissing: true }),
   );
 
-  const image = modal.images.fromRegistry("ollama/ollama:latest");
+  const image = modal.images.fromRegistry(spec.image(input));
 
   // CREATE-TIMEOUT ORPHAN (#330-1, the Modal analog of RunPod's N3 deploy-orphan sweep): the create
   // is `withBudget`-bounded, but Modal can REACH the backend and CREATE the sandbox and then have the
@@ -96,22 +101,17 @@ async function provision(ctx: ProvisionContext<Sandbox>): Promise<Provisioned<Sa
   // worst case — but a leaked GPU box for up to 30 min is still real money.)
   const sandboxName = `${APP_NAME}-${Date.now()}-${randomUUID().slice(0, 8)}`;
 
-  // Modal passes `command` as ENTRYPOINT args for registry images. The ollama image's entrypoint is
-  // `/bin/ollama`, so `["serve"]` starts `ollama serve`; including `/bin/ollama` here would become
-  // `ollama /bin/ollama serve` and fail before readiness.
+  // The backend spec supplies the entrypoint ARGS (never the entrypoint) + env + the served port.
   let sb: Sandbox;
   const createRef: { promise?: Promise<Sandbox> } = {};
   try {
     sb = await withBudget(deadline, "sandboxes.create", () => {
       createRef.promise = modal.sandboxes.create(app, image, {
         name: sandboxName,
-        command: ["serve"],
-        env: {
-          OLLAMA_HOST: `0.0.0.0:${OLLAMA_PORT}`,
-          OLLAMA_NUM_PARALLEL: ollamaNumParallel,
-        },
-        encryptedPorts: [OLLAMA_PORT],
-        readinessProbe: Probe.withTcp(OLLAMA_PORT, { intervalMs: 1000 }),
+        command: [...spec.entrypointArgs(input)],
+        env: spec.env(input),
+        encryptedPorts: [port],
+        readinessProbe: Probe.withTcp(port, { intervalMs: 1000 }),
         timeoutMs: BOX_MAX_LIFETIME_MS,
         ...(gpu !== null ? { gpu } : {}),
       });
@@ -137,34 +137,26 @@ async function provision(ctx: ProvisionContext<Sandbox>): Promise<Provisioned<Sa
   ctx.onBox(sb);
   log("info", `sandbox created: ${sb.sandboxId ?? "(id unavailable)"}`);
 
-  ctx.status("provisioning", `waiting for ollama serve on port ${OLLAMA_PORT}`);
+  ctx.status("provisioning", `waiting for ${spec.backend} to listen on port ${port}`);
   const readinessTimeoutMs = assertBudgetRemaining(deadline, "sandbox readiness");
   await raceWithTimeout(
     () => sb.waitUntilReady(readinessTimeoutMs),
     readinessTimeoutMs,
     "sandbox.waitUntilReady",
   );
-  log("info", "ollama serve is listening");
+  log("info", `${spec.backend} is listening`);
 
-  // Pull the model. The server (`serve`) is the box's main process; pull runs as an exec
-  // against the same ollama install, populating the model store the server reads. Every step
-  // (exec dispatch, wait, stderr read) is budget-bounded.
-  ctx.status("pulling", `pulling model "${input.model}" (cold-start cost)`);
-  const pull = await withBudget(deadline, "exec(ollama pull)", () =>
-    sb.exec(["ollama", "pull", input.model], { mode: "text", stdout: "pipe", stderr: "pipe" }),
-  );
-  const pullCode = await withBudget(deadline, "pull.wait", () => pull.wait());
-  if (pullCode !== 0) {
-    const err = await withBudget(deadline, "pull.stderr.readText", () => pull.stderr.readText());
-    throw new Error(`"ollama pull ${input.model}" exited ${pullCode}: ${err.trim()}`);
+  // Load the model. infinity/vLLM auto-download on boot (nothing to do); ollama boots empty, so pull
+  // the model into the running server via an in-box exec.
+  if (spec.modelLoad === "ollama-pull") {
+    await pullOllamaModel(sb, input.model, deadline, ctx);
   }
-  log("info", `model "${input.model}" pulled`);
 
   // Resolve the public tunnel URL for the served port.
   const tunnels = await withBudget(deadline, "sb.tunnels", () => sb.tunnels());
-  const tunnel = tunnels[OLLAMA_PORT];
+  const tunnel = tunnels[port];
   if (tunnel === undefined) {
-    throw new Error(`no tunnel for port ${OLLAMA_PORT}; got ports [${Object.keys(tunnels).join(", ")}]`);
+    throw new Error(`no tunnel for port ${port}; got ports [${Object.keys(tunnels).join(", ")}]`);
   }
   const endpoint = tunnel.url;
   log("info", `tunnel up: ${endpoint}`);
@@ -172,15 +164,39 @@ async function provision(ctx: ProvisionContext<Sandbox>): Promise<Provisioned<Sa
   // Verify the server actually embeds before we emit `ready`. This catches a box that booted but
   // isn't serving (the whole point of waiting before the ready event). Budget = the time REMAINING
   // until the shared deadline (create + pull already consumed some); throws if it's spent.
-  ctx.status("verifying", "probing /api/embed for a real vector");
+  ctx.status("verifying", `probing ${spec.embedPath} for a real vector`);
   await verifyEmbed(endpoint, {
     model: input.model,
+    embedPath: spec.embedPath,
     budgetMs: assertBudgetRemaining(deadline, "embed verification"),
   });
   log("info", "embed verification passed; box is serving");
 
   // Open tunnel via encryptedPorts → no per-request token needed. auth_token stays null.
   return { handle: sb, endpoint, auth_token: null };
+}
+
+/**
+ * Pull `model` into the running ollama via an in-box exec (the server `serve` is the main process;
+ * the pull populates the model store it reads). Every step (exec dispatch, wait, stderr read) is
+ * budget-bounded. ollama-only — infinity/vLLM auto-download on boot.
+ */
+async function pullOllamaModel(
+  sb: Sandbox,
+  model: string,
+  deadline: number,
+  ctx: ProvisionContext<Sandbox>,
+): Promise<void> {
+  ctx.status("pulling", `pulling model "${model}" (cold-start cost)`);
+  const pull = await withBudget(deadline, "exec(ollama pull)", () =>
+    sb.exec(["ollama", "pull", model], { mode: "text", stdout: "pipe", stderr: "pipe" }),
+  );
+  const pullCode = await withBudget(deadline, "pull.wait", () => pull.wait());
+  if (pullCode !== 0) {
+    const err = await withBudget(deadline, "pull.stderr.readText", () => pull.stderr.readText());
+    throw new Error(`"ollama pull ${model}" exited ${pullCode}: ${err.trim()}`);
+  }
+  log("info", `model "${model}" pulled`);
 }
 
 /**

--- a/cookbook/recipes/runpod.mts
+++ b/cookbook/recipes/runpod.mts
@@ -1,12 +1,16 @@
 /**
- * Recipe: provision an ephemeral GPU pod on RunPod, serve an embedding model with Ollama, hand
- * rag-rat the proxy endpoint, and terminate the pod on signal.
+ * Recipe: provision an ephemeral GPU pod on RunPod, serve the model with the selected backend
+ * (ollama, infinity, or vLLM), hand rag-rat the proxy endpoint, and terminate the pod on signal.
  *
- * Run (post-build):  RAG_RAT_COOKBOOK_INPUT='{"model":"all-minilm"}' node dist/recipes/runpod-ollama.mjs
- * Run (dev):         RAG_RAT_COOKBOOK_INPUT='{"model":"all-minilm"}' npx tsx recipes/runpod-ollama.mts
+ * Run (post-build):  RAG_RAT_COOKBOOK_INPUT='{"model":"all-minilm"}' node dist/recipes/runpod.mjs
+ * Run (dev):         RAG_RAT_COOKBOOK_INPUT='{"model":"sentence-transformers/all-MiniLM-L6-v2","backend":"vllm"}' npx tsx recipes/runpod.mts
  *
  * Auth: RUNPOD_API_KEY in the process env (NOT in RAG_RAT_COOKBOOK_INPUT). rag-rat puts the key in
  * the child env from the user's shell; this recipe errors + exits 1 before any handshake if unset.
+ *
+ * WHAT VARIES BY BACKEND lives in {@link selectBackendSpec} (image, entrypoint args, env, port, the
+ * embeddings route, and whether a post-boot model pull is needed). THIS file owns only the RunPod
+ * pod lifecycle, which is backend-independent.
  *
  * Why GraphQL-over-fetch and not the `runpod-sdk` npm package: that SDK only covers SERVERLESS
  * endpoints (run/runSync/status/stream/health) — it has NO pod-management surface. Pod create/
@@ -20,20 +24,22 @@
  * fetch here is timeout-bounded (a stalled call must abort, not hang past the Rust grace and get
  * SIGKILLed with the pod still up) and why teardown uses a tight bound to finish inside that grace.
  *
- * Provider gotchas, all load-bearing:
- *   - The ollama image ENTRYPOINT is `/bin/ollama`, so `dockerArgs: "serve"` runs `ollama serve`
- *     (NOT `"ollama serve"`, which would exec `ollama ollama serve`). dockerArgs sets the
- *     container CMD; it is appended to the entrypoint.
- *   - ollama binds 127.0.0.1:11434 by default, unreachable through the RunPod proxy. We set
- *     OLLAMA_HOST=0.0.0.0:11434 via the pod env so it listens on all interfaces.
+ * Backend gotchas, all load-bearing:
+ *   - `dockerArgs` is the container CMD, appended to the image's baked entrypoint. The spec supplies
+ *     exactly the args (never the entrypoint) — ollama's entrypoint is `/bin/ollama` so args are
+ *     `serve`; infinity's is `infinity_emb` so args start `v2 …`; vLLM's is `vllm serve` so the
+ *     first arg is the model id.
+ *   - The server must listen on 0.0.0.0 for the RunPod proxy to reach it — ollama needs OLLAMA_HOST
+ *     (spec env); infinity binds 0.0.0.0 by default; vLLM gets `--host 0.0.0.0`.
  *   - RunPod exposes an HTTP container port as `https://<podId>-<port>.proxy.runpod.net`. There is
- *     no in-pod exec primitive in podFindAndDeployOnDemand, so we PULL the model CLIENT-SIDE over
- *     that proxy URL (`POST /api/pull`) once `serve` is up — no shell/exec inside the pod needed.
+ *     no in-pod exec primitive in podFindAndDeployOnDemand, so for ollama (which boots empty) we PULL
+ *     the model CLIENT-SIDE over that proxy URL (`POST /api/pull`) once `serve` is up. infinity/vLLM
+ *     auto-download the HF model on boot — no pull step.
  *   - The proxy URL is known the instant the pod id is returned, but the pod takes time to boot;
- *     the pull + embed probes retry until the request-timeout budget runs out.
+ *     the pull + embed probes retry until the provisioning budget runs out.
  *
- * The harness ({@link runRecipe}) owns the terminate-on-error wrapper and the request-timeout
- * clamp, so this recipe is just: deploy, report via `ctx.onBox`, pull, verify, return.
+ * The harness ({@link runRecipe}) owns the terminate-on-error wrapper and the provision-timeout
+ * clamp, so this recipe is just: deploy, report via `ctx.onBox`, (pull,) verify, return.
  */
 
 import {
@@ -49,9 +55,8 @@ import {
   runRecipe,
   verifyEmbed,
 } from "../src/contract.js";
+import { selectBackendSpec } from "./backends.mjs";
 
-/** HTTP port ollama serves on inside the pod; the one port we proxy out. */
-const OLLAMA_PORT = 11434;
 /**
  * Default provisioning budget (boot + pull + first serving response) when input omits it. A GPU
  * pod cold start + image pull + model pull takes minutes; this is generous on purpose.
@@ -60,9 +65,13 @@ const DEFAULT_PROVISION_TIMEOUT_S = 900;
 /** Cheap, broadly-available on-demand GPU. `input.gpu` overrides this. */
 const DEFAULT_GPU_TYPE_ID = "NVIDIA RTX A4000";
 /** Pod name prefix (RunPod shows this in the console). */
-const POD_NAME = "rag-rat-cookbook-ollama";
-/** Container scratch disk (GiB). Model weights live here; all-minilm is tiny, keep headroom. */
-const CONTAINER_DISK_GB = 20;
+const POD_NAME = "rag-rat-cookbook";
+/**
+ * Container scratch disk (GiB). Holds the pulled image's writable layer + downloaded model weights.
+ * Generous because the vLLM image alone is ~10–15 GiB; all-minilm weights are tiny, so the image is
+ * the driver. Ephemeral, so the marginal disk cost is negligible.
+ */
+const CONTAINER_DISK_GB = 40;
 /** RunPod GraphQL endpoint; the API key rides as a query param (RunPod's documented scheme). */
 const RUNPOD_GRAPHQL_URL = "https://api.runpod.io/graphql";
 /** Bound on each GraphQL call (deploy/terminate). Generous for deploy; tight enough not to hang. */
@@ -89,9 +98,11 @@ interface DeployedPod {
   readonly id: string;
 }
 
-/** Provision a RunPod GPU pod serving `input.model` via Ollama and return its proxy endpoint. */
+/** Provision a RunPod GPU pod serving `input.model` on the selected backend; return its endpoint. */
 async function provision(ctx: ProvisionContext<PodHandle>): Promise<Provisioned<PodHandle>> {
   const { input, provisionTimeoutMs } = ctx;
+  const spec = selectBackendSpec(input.backend ?? "ollama");
+  const port = spec.port;
   // ONE deadline for the WHOLE sequence (deploy + pull + verify). Each step below uses the budget
   // REMAINING until this deadline — never a fresh full budget — so the total stays inside the
   // provisioning budget and we abort (→ teardown) before the Rust provisioner's hard timeout
@@ -103,21 +114,17 @@ async function provision(ctx: ProvisionContext<PodHandle>): Promise<Provisioned<
   }
   const apiKey = rawKey.trim();
   const gpuTypeId = input.gpu ?? DEFAULT_GPU_TYPE_ID;
-  // rag-rat sends the user's `[remote] concurrency` cap as `ollama_num_parallel`; the box's server
-  // parallelism is set to it so rag-rat can fan out up to the cap. rag-rat tunes the actual client
-  // concurrency (within the cap) itself, against the box, after `ready`.
-  const ollamaNumParallel = String(input.ollama_num_parallel ?? 1);
 
   // Unique pod name so a deploy-timeout orphan sweep can find a pod that RunPod created but whose
   // create-response we lost (see below). The instant suffix makes it unambiguous across runs.
   const podName = `${POD_NAME}-${Date.now()}`;
   ctx.status(
     "provisioning",
-    `deploying RunPod pod (model=${input.model}, gpu=${gpuTypeId}, parallel=${ollamaNumParallel})`,
+    `deploying RunPod pod (backend=${spec.backend}, model=${input.model}, gpu=${gpuTypeId})`,
   );
 
-  // Deploy the pod. dockerArgs="serve" → `ollama serve`; OLLAMA_HOST binds all interfaces;
-  // ports "11434/http" exposes the proxy. No persistent volume (ephemeral box).
+  // Deploy the pod. The backend spec supplies the image, the dockerArgs (entrypoint args joined),
+  // and the container env; `ports "<port>/http"` exposes the proxy. No persistent volume (ephemeral).
   //
   // DEPLOY-TIMEOUT ORPHAN (N3): the call is bounded at GRAPHQL_TIMEOUT_MS, but RunPod can CREATE the
   // pod and then lose/slow the response — `graphql` throws BEFORE `ctx.onBox`, so `runRecipe` would
@@ -135,15 +142,12 @@ async function provision(ctx: ProvisionContext<PodHandle>): Promise<Provisioned<
           gpuCount: 1,
           gpuTypeId,
           name: podName,
-          imageName: "ollama/ollama:latest",
-          dockerArgs: "serve",
-          ports: `${OLLAMA_PORT}/http`,
+          imageName: spec.image(input),
+          dockerArgs: spec.entrypointArgs(input).join(" "),
+          ports: `${port}/http`,
           containerDiskInGb: CONTAINER_DISK_GB,
           volumeInGb: 0,
-          env: [
-            { key: "OLLAMA_HOST", value: `0.0.0.0:${OLLAMA_PORT}` },
-            { key: "OLLAMA_NUM_PARALLEL", value: ollamaNumParallel },
-          ],
+          env: Object.entries(spec.env(input)).map(([key, value]) => ({ key, value })),
         },
       },
       GRAPHQL_TIMEOUT_MS,
@@ -165,20 +169,23 @@ async function provision(ctx: ProvisionContext<PodHandle>): Promise<Provisioned<
   log("info", `pod deployed: ${handle.podId}`);
 
   // RunPod proxies the HTTP container port at this stable host. Known immediately from the id.
-  const endpoint = `https://${handle.podId}-${OLLAMA_PORT}.proxy.runpod.net`;
+  const endpoint = `https://${handle.podId}-${port}.proxy.runpod.net`;
   log("info", `proxy endpoint: ${endpoint}`);
 
-  // Pull the model CLIENT-SIDE over the proxy (no in-pod exec). Retries cover pod boot time. Budget
-  // = whatever is LEFT until the shared deadline (deploy already consumed some); throws if spent.
-  ctx.status("pulling", `pulling model "${input.model}" over the proxy (covers pod boot)`);
-  await pullModel(endpoint, input.model, assertBudgetRemaining(deadline, "model pull"));
-  log("info", `model "${input.model}" pulled`);
+  // Load the model. ollama boots empty, so pull CLIENT-SIDE over the proxy (no in-pod exec); retries
+  // cover pod boot. infinity/vLLM auto-download the HF model on boot — nothing to do here.
+  if (spec.modelLoad === "ollama-pull") {
+    ctx.status("pulling", `pulling model "${input.model}" over the proxy (covers pod boot)`);
+    await pullModel(endpoint, input.model, assertBudgetRemaining(deadline, "model pull"));
+    log("info", `model "${input.model}" pulled`);
+  }
 
   // Confirm the server actually embeds before we emit `ready`. Budget = the REMAINING time after the
   // pull, so deploy+pull+verify together stay inside the single provisioning budget.
-  ctx.status("verifying", "probing /api/embed for a real vector");
+  ctx.status("verifying", `probing ${spec.embedPath} for a real vector`);
   await verifyEmbed(endpoint, {
     model: input.model,
+    embedPath: spec.embedPath,
     budgetMs: assertBudgetRemaining(deadline, "embed verification"),
   });
   log("info", "embed verification passed; pod is serving");
@@ -190,7 +197,7 @@ async function provision(ctx: ProvisionContext<PodHandle>): Promise<Provisioned<
 /**
  * Pull `model` via the Ollama proxy (`POST /api/pull`, non-streaming), retrying until the budget
  * runs out — the pod is still booting for the first several attempts. Each attempt is bounded so a
- * stalled proxy aborts rather than hanging past the budget.
+ * stalled proxy aborts rather than hanging past the budget. ollama-only.
  */
 function pullModel(endpoint: string, model: string, budgetMs: number): Promise<void> {
   const url = endpointPath(endpoint, "/api/pull");

--- a/cookbook/src/contract.ts
+++ b/cookbook/src/contract.ts
@@ -31,6 +31,23 @@ export const COOKBOOK_INPUT_ENV = "RAG_RAT_COOKBOOK_INPUT";
 /** The providers a recipe can target. Tags every `status` event. */
 export type Provider = "modal" | "runpod";
 
+/**
+ * The embedding server a recipe provisions. All three speak the OpenAI-compatible embeddings API
+ * (`POST <embedPath>` with `{model, input:[…]}` → `{data:[{embedding,index}]}`), so the Rust client
+ * and {@link verifyEmbed} are backend-independent; the backend only selects the container image,
+ * launch command, port, model-load strategy, and the embeddings ROUTE (ollama/vLLM serve
+ * `/v1/embeddings`; michaelfeil/infinity's `v2` server serves `/embeddings`).
+ */
+export type Backend = "ollama" | "infinity" | "vllm";
+
+/** The backends a recipe understands, for input validation. Keep in sync with {@link Backend}. */
+export const BACKENDS: readonly Backend[] = ["ollama", "infinity", "vllm"] as const;
+
+/** Narrows an arbitrary string to a known {@link Backend}, or `undefined` if unrecognized. */
+export function asBackend(value: string): Backend | undefined {
+  return (BACKENDS as readonly string[]).includes(value) ? (value as Backend) : undefined;
+}
+
 /** Provisioning lifecycle phases reported by a `status` event. */
 export type Phase = "provisioning" | "pulling" | "verifying" | "tearing_down";
 
@@ -69,8 +86,24 @@ export function emit(event: CookbookEvent): void {
  * fields off the same object, but every recipe must honor at least `model`.
  */
 export interface CookbookInput {
-  /** Embedding model to pull and serve, e.g. "all-minilm". */
+  /**
+   * Embedding model to serve. Its meaning is BACKEND-specific: an ollama model name (`all-minilm`)
+   * for ollama, or a HuggingFace model id (`sentence-transformers/all-MiniLM-L6-v2`) for infinity
+   * and vLLM, which auto-download it from HF on server start.
+   */
   readonly model: string;
+  /**
+   * Which embedding server to provision. Omitted/null → `ollama` (the default backend, e.g. a bare
+   * hand-run dev invocation). {@link readInput} validates it against {@link BACKENDS}.
+   */
+  readonly backend?: Backend | null;
+  /**
+   * Ollama context window (`OLLAMA_CONTEXT_LENGTH`) to bake into the ephemeral box for the OLLAMA
+   * backend, so chunk vectors match the freshness key that folds `num_ctx` in. Ignored by
+   * infinity/vLLM (context length is a model/server property there, not a per-box knob). Omitted/null
+   * → the server default. See `RemoteEmbeddingConfig::num_ctx` on the Rust side.
+   */
+  readonly num_ctx?: number | null;
   /**
    * Wall-clock budget (seconds) for the WHOLE provisioning sequence — box boot + model pull +
    * first serving response. A remote box's cold start takes MINUTES, so this is generous (the Rust
@@ -93,11 +126,13 @@ export interface CookbookInput {
    */
   readonly gpu?: string | null;
   /**
-   * Ollama server parallelism to set as `OLLAMA_NUM_PARALLEL` on the box. rag-rat sends the user's
-   * `[remote] concurrency` CAP so the server can handle up to that many parallel `/api/embed`
-   * requests. rag-rat then tunes the actual client fan-out (within the cap) itself, against the box.
+   * Server-side request parallelism the box should accept. rag-rat sends the user's `[remote]
+   * concurrency` CAP so the server can handle up to that many parallel embed requests; rag-rat then
+   * tunes the actual client fan-out (within the cap) itself, against the box. Each backend maps it
+   * to its own knob (ollama → `OLLAMA_NUM_PARALLEL`; vLLM → `--max-num-seqs`; infinity ignores it —
+   * its async engine batches dynamically).
    */
-  readonly ollama_num_parallel?: number | null;
+  readonly server_concurrency?: number | null;
 }
 
 /**
@@ -211,10 +246,16 @@ export function readInput(): CookbookInput {
   // like "60" would slip through to budget arithmetic as NaN and break every poll loop.
   const provisionTimeout = optionalPositiveNumber(obj["provision_timeout_s"], "provision_timeout_s");
   const requestTimeout = optionalPositiveNumber(obj["request_timeout_s"], "request_timeout_s");
-  const ollamaNumParallel = optionalPositiveInteger(
-    obj["ollama_num_parallel"],
-    "ollama_num_parallel",
+  const serverConcurrency = optionalPositiveInteger(
+    obj["server_concurrency"],
+    "server_concurrency",
   );
+  const numCtx = optionalPositiveInteger(obj["num_ctx"], "num_ctx");
+
+  // backend: optional; if present must be a KNOWN backend string. Absent/null → ollama (the default
+  // backend, e.g. a bare hand-run dev invocation). A malformed value is a hard error (a typo'd
+  // config beats a silent wrong-backend provision).
+  const backend = optionalBackend(obj["backend"]);
 
   // gpu: optional; if present must be a string (provider spec) or null.
   const gpu = obj["gpu"];
@@ -224,12 +265,32 @@ export function readInput(): CookbookInput {
 
   const result: CookbookInput = {
     model: obj["model"],
+    backend,
     ...(provisionTimeout !== undefined ? { provision_timeout_s: provisionTimeout } : {}),
     ...(requestTimeout !== undefined ? { request_timeout_s: requestTimeout } : {}),
     ...(typeof gpu === "string" ? { gpu } : gpu === null ? { gpu: null } : {}),
-    ...(ollamaNumParallel !== undefined ? { ollama_num_parallel: ollamaNumParallel } : {}),
+    ...(serverConcurrency !== undefined ? { server_concurrency: serverConcurrency } : {}),
+    ...(numCtx !== undefined ? { num_ctx: numCtx } : {}),
   };
   return result;
+}
+
+/**
+ * Validate the optional `backend` field: absent/null → `"ollama"` (the default backend); a known
+ * {@link Backend} string passes through; anything else is a hard error naming the accepted values.
+ */
+function optionalBackend(value: unknown): Backend {
+  if (value === undefined || value === null) return "ollama";
+  if (typeof value !== "string") {
+    throw new Error(`${COOKBOOK_INPUT_ENV}.backend must be a string or null (got ${describe(value)}).`);
+  }
+  const backend = asBackend(value);
+  if (backend === undefined) {
+    throw new Error(
+      `${COOKBOOK_INPUT_ENV}.backend "${value}" is not a known backend (one of: ${BACKENDS.join(", ")}).`,
+    );
+  }
+  return backend;
 }
 
 /** Validates an optional positive-number field; returns the number, or undefined if absent/null. */
@@ -450,6 +511,13 @@ const VERIFY_EMBED_ATTEMPT_TIMEOUT_MS = 30_000;
 export interface VerifyEmbedOptions {
   /** Embedding model name to probe with (the value the server keys on). */
   readonly model: string;
+  /**
+   * Backend-specific embeddings route to probe, e.g. `/v1/embeddings` (ollama/vLLM) or `/embeddings`
+   * (infinity). MUST match the route the Rust client posts to (`RemoteBackend::embed_path`) — the
+   * probe and the real embed call have to hit the same URL, or a box that passes verification still
+   * 404s under load.
+   */
+  readonly embedPath: string;
   /** Wall-clock budget in ms to keep retrying before giving up. Use the provisioning budget. */
   readonly budgetMs: number;
   /** Extra headers (e.g. an auth bearer) to send with each probe. Defaults to none. */
@@ -471,32 +539,40 @@ export function endpointPath(endpoint: string, path: string): string {
 }
 
 /**
- * Polls `<endpoint>/api/embed` until it returns a real embedding vector, or the budget runs out.
+ * Polls `<endpoint><options.embedPath>` with the OpenAI-compatible embeddings request until it
+ * returns a real vector, or the budget runs out.
  *
  * Every recipe must call this BEFORE handing rag-rat the endpoint: a box can be reachable (tunnel
- * up) while ollama is still loading the model, so "box created" is not "box serving". A non-empty
- * `embeddings[0]` vector is the readiness signal. Throws if the budget elapses with no vector.
+ * up) while the server is still loading/downloading the model, so "box created" is not "box
+ * serving". The probe posts the SAME shape the Rust client uses — `{model, input:["…"],
+ * encoding_format:"float"}` — so a server that rejects the array/encoding_format form fails HERE, at
+ * provision time, not later on the reconcile hot path. A non-empty `data[0].embedding` vector is the
+ * readiness signal. Throws if the budget elapses with no vector.
  */
 export function verifyEmbed(endpoint: string, options: VerifyEmbedOptions): Promise<void> {
-  const url = endpointPath(endpoint, "/api/embed");
-  return pollUntil<{ embeddings?: unknown }>(url, {
+  const url = endpointPath(endpoint, options.embedPath);
+  return pollUntil<{ data?: unknown }>(url, {
     label: "embed probe",
     budgetMs: options.budgetMs,
     body: {
       model: options.model,
-      input: "rag-rat embed readiness probe",
+      // ARRAY input (not a bare string) to match the Rust client's batch shape exactly — see the
+      // per-backend embed_path invariant in `RemoteBackend`.
+      input: ["rag-rat embed readiness probe"],
+      encoding_format: "float",
     },
     pollIntervalMs: options.pollIntervalMs ?? VERIFY_EMBED_POLL_INTERVAL_MS,
     perAttemptTimeoutMs: options.perAttemptTimeoutMs ?? VERIFY_EMBED_ATTEMPT_TIMEOUT_MS,
     ...(options.headers !== undefined ? { headers: options.headers } : {}),
     isReady: (body) => {
-      const embeddings = body.embeddings;
-      if (
-        Array.isArray(embeddings) &&
-        embeddings.length > 0 &&
-        Array.isArray(embeddings[0]) &&
-        embeddings[0].length > 0
-      ) {
+      // OpenAI shape: {data:[{embedding:[…], index:0}, …]}. A non-empty first vector = serving.
+      const data = body.data;
+      const first = Array.isArray(data) && data.length > 0 ? data[0] : undefined;
+      const embedding =
+        typeof first === "object" && first !== null
+          ? (first as { embedding?: unknown }).embedding
+          : undefined;
+      if (Array.isArray(embedding) && embedding.length > 0) {
         return { ready: true };
       }
       return {

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -316,9 +316,12 @@ pub struct RemoteEmbeddingConfig {
     /// package spec (`"@rag-rat/cookbook/modal"`, run via `npx -y`) or a recipe file path
     /// (`.mjs`/`.js` → `node`, `.ts` → `npx tsx`). Mutually exclusive with `endpoint`.
     pub cookbook: Option<String>,
-    /// EPHEMERAL: the LOCAL Ollama used for QUERY embedding (queries embed the same model as the
-    /// remote-embedded chunks → identical vector space). Defaults to `http://localhost:11434` when
-    /// ephemeral and omitted. Ignored in connect mode.
+    /// EPHEMERAL: the LOCAL server used for QUERY embedding after the box is torn down (queries
+    /// embed the same model on the same `backend` → identical vector space). Defaults to
+    /// `http://localhost:11434` (local Ollama) ONLY for `backend = ollama`; a non-ollama backend
+    /// must set this explicitly (its route/model differ, so the Ollama default would silently
+    /// break query embedding — see `ConfigError::RemoteQueryEndpointRequiredForBackend`).
+    /// Ignored in connect mode.
     pub query_endpoint: Option<String>,
     /// Name of the environment variable holding the bearer token, if the server needs auth. Local
     /// Ollama needs none, so this is optional; the embedder reads the var once at construction.
@@ -1015,10 +1018,26 @@ impl TryFrom<RawRemoteEmbedding> for RemoteEmbeddingConfig {
         // into the SQLite index — reject it and direct the user to `auth_env`. Checked against the
         // URL authority only (between `scheme://` and the next `/`), so an `@` in a path/query is
         // fine. `cookbook` is a recipe spec, not a URL, so it is not checked.
-        // EPHEMERAL: the LOCAL query box. Defaults to `DEFAULT_QUERY_ENDPOINT`; ignored for
-        // connect.
+        // EPHEMERAL: the LOCAL query box. Ephemeral chunks embed on the provisioned box, but that
+        // box is torn down after reconcile, so QUERIES embed against `query_endpoint` (a local
+        // server running the same model) — and `query_embed_config` PRESERVES the backend when it
+        // rewrites the ephemeral config to a connect-shaped query config. `DEFAULT_QUERY_ENDPOINT`
+        // is a local OLLAMA URL, so it only fits `backend = ollama`. For a non-ollama backend the
+        // default would build a query embedder posting the wrong route (`/embeddings`) / an HF
+        // model id at local Ollama → every query embed fails → silent, permanent BM25
+        // fallback. So require an explicit `query_endpoint` there. Ignored for connect
+        // (queries hit the connect endpoint).
         let query_endpoint = if cookbook.is_some() {
-            Some(trimmed(raw.query_endpoint).unwrap_or_else(|| DEFAULT_QUERY_ENDPOINT.to_string()))
+            match trimmed(raw.query_endpoint) {
+                Some(qe) => Some(qe),
+                None if backend == RemoteBackend::Ollama =>
+                    Some(DEFAULT_QUERY_ENDPOINT.to_string()),
+                None => {
+                    return Err(ConfigError::RemoteQueryEndpointRequiredForBackend {
+                        backend: backend.as_db_str(),
+                    });
+                },
+            }
         } else {
             None
         };
@@ -1134,6 +1153,13 @@ pub enum ConfigError {
          `{0}`)"
     )]
     RemoteBackendUnknown(String),
+    #[error(
+        "[llm.embedding.remote] `backend = \"{backend}\"` with an ephemeral `cookbook` requires \
+         an explicit `query_endpoint` — queries embed against a LOCAL server after the box is \
+         torn down, and the default (a local Ollama URL) only fits `backend = \"ollama\"`. Point \
+         `query_endpoint` at a local `{backend}` server serving the same model"
+    )]
+    RemoteQueryEndpointRequiredForBackend { backend: &'static str },
     #[error(
         "[llm.embedding.remote] requires EXACTLY ONE of `endpoint` (connect to a running server) \
          or `cookbook` (provision an ephemeral box) — set neither both nor zero"
@@ -1613,6 +1639,55 @@ mod tests {
         .unwrap();
         let remote = LlmConfig::try_from(raw.llm).unwrap().embedding.remote.unwrap();
         assert_eq!(remote.query_endpoint.as_deref(), Some("http://127.0.0.1:11999"));
+    }
+
+    #[test]
+    fn ephemeral_non_ollama_backend_requires_an_explicit_query_endpoint() {
+        // The DEFAULT_QUERY_ENDPOINT is a local OLLAMA URL; it only fits `backend = ollama`. A
+        // non-ollama ephemeral backend that omits `query_endpoint` must be REJECTED (not silently
+        // defaulted), or after teardown queries embed against local Ollama with the wrong route /
+        // model → silent BM25 fallback. See `RemoteQueryEndpointRequiredForBackend`.
+        let build = |backend: &str, query_line: &str| {
+            let raw: RawConfig = toml::from_str(&format!(
+                r#"
+                [index]
+                root = "."
+
+                [llm.embedding]
+                model = "sentence-transformers/all-MiniLM-L6-v2"
+
+                [llm.embedding.remote]
+                model = "sentence-transformers/all-MiniLM-L6-v2"
+                backend = "{backend}"
+                cookbook = "@rag-rat/cookbook modal"
+                {query_line}
+                "#,
+            ))
+            .unwrap();
+            LlmConfig::try_from(raw.llm).map(|l| l.embedding.remote.unwrap())
+        };
+
+        for backend in ["infinity", "vllm"] {
+            let err = build(backend, "").unwrap_err();
+            assert!(
+                matches!(
+                    err,
+                    ConfigError::RemoteQueryEndpointRequiredForBackend { backend: b } if b == backend
+                ),
+                "{backend} ephemeral without query_endpoint → \
+                 RemoteQueryEndpointRequiredForBackend, got {err:?}",
+            );
+            // An explicit query_endpoint is accepted, and the backend is preserved for the query
+            // path.
+            let remote = build(backend, r#"query_endpoint = "http://127.0.0.1:7997""#).unwrap();
+            assert_eq!(remote.query_endpoint.as_deref(), Some("http://127.0.0.1:7997"));
+            assert_eq!(remote.backend.as_db_str(), backend);
+        }
+        // ollama still defaults (its default IS a local Ollama).
+        assert_eq!(
+            build("ollama", "").unwrap().query_endpoint.as_deref(),
+            Some(DEFAULT_QUERY_ENDPOINT),
+        );
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
@@ -1,11 +1,12 @@
 //! The EPHEMERAL cookbook lifecycle (#318): rag-rat spawns a "cookbook" recipe as a subprocess that
-//! provisions an on-demand Ollama box (e.g. a Modal GPU sandbox), prints a one-line handshake when
-//! the box is serving, then stays alive until rag-rat tears it down at the end of the bulk
-//! reconcile.
+//! provisions an on-demand embedding box (ollama, infinity, or vLLM — selected by `backend`; e.g. a
+//! Modal GPU sandbox), prints a one-line handshake when the box is serving, then stays alive until
+//! rag-rat tears it down at the end of the bulk reconcile.
 //!
 //! THE PROCESS CONTRACT (rag-rat ⇄ cookbook — both sides build to this exact shape):
 //! - INPUT via env `RAG_RAT_COOKBOOK_INPUT` = JSON
-//!   `{"model","request_timeout_s","provision_timeout_s","gpu","ollama_num_parallel"}`.
+//!   `{"model","backend","request_timeout_s","provision_timeout_s","gpu","num_ctx",
+//!   "server_concurrency"}`.
 //! - The cookbook's STDOUT is a TYPED JSONL event stream — one JSON object per line, each with a
 //!   `"type"` tag and a `"ts"` (epoch-ms) field (see [`CookbookEvent`]). The four `type`s are
 //!   `status` (a provisioning-phase update: `provisioning`/`pulling`/`verifying`/`tearing_down`),
@@ -130,11 +131,17 @@ pub fn install_provision_log_sink(tx: mpsc::Sender<String>) -> ProvisionLogSinkG
 /// The JSON written to `RAG_RAT_COOKBOOK_INPUT` for the cookbook subprocess.
 #[derive(Debug, Clone, Serialize)]
 pub struct CookbookInput {
-    /// The Ollama server-side model name the box should serve (the `[remote] model`).
+    /// The server-side model name the box should serve (the `[remote] model`): an ollama model
+    /// name for the ollama backend, or a HuggingFace model id for infinity/vLLM.
     pub model: String,
+    /// Which embedding backend the recipe should provision — the `RemoteBackend::as_db_str` of the
+    /// configured backend (`ollama`/`infinity`/`vllm`). Selects the recipe's image, launch
+    /// command, port, embeddings route, and model-load strategy; the embed WIRE CALL is
+    /// identical across all three (OpenAI `/v1/embeddings` shape).
+    pub backend: &'static str,
     /// Per-REQUEST HTTP timeout the cookbook may forward to its box config — the
-    /// `OpenAiEmbedder`'s per-`/api/embed` budget. UNRELATED to provisioning; do NOT use it as
-    /// the boot budget.
+    /// `OpenAiEmbedder`'s per-request budget. UNRELATED to provisioning; do NOT use it as the
+    /// boot budget.
     pub request_timeout_s: u64,
     /// The cookbook's PROVISIONING budget (seconds): how long the recipe may spend booting the
     /// box, pulling the model, and verifying it serves before giving up. Decoupled from
@@ -146,11 +153,17 @@ pub struct CookbookInput {
     /// GPU hint for the recipe (e.g. `"T4"`); `None` lets the recipe decide. Carried as JSON
     /// `null` when absent so the contract field is always present.
     pub gpu: Option<String>,
-    /// Ollama server parallelism the recipe should set as `OLLAMA_NUM_PARALLEL`. rag-rat sends the
-    /// user's `[remote] concurrency` CAP; the box is provisioned to handle up to that many
-    /// parallel requests, and rag-rat tunes the actual client fan-out (within the cap) itself
-    /// against the box.
-    pub ollama_num_parallel: u32,
+    /// Context window (`num_ctx`) to bake into the ephemeral box for the OLLAMA backend
+    /// (`OLLAMA_CONTEXT_LENGTH`), so chunk vectors match the freshness key that folds `num_ctx`
+    /// in. `None` → the server default; ignored by infinity/vLLM. Carried as JSON `null` when
+    /// absent.
+    pub num_ctx: Option<u32>,
+    /// Server-side request parallelism the box should accept. rag-rat sends the user's `[remote]
+    /// concurrency` CAP; the box is provisioned to handle up to that many parallel requests, and
+    /// rag-rat tunes the actual client fan-out (within the cap) itself against the box. Each
+    /// backend maps it to its own knob (ollama → `OLLAMA_NUM_PARALLEL`; vLLM →
+    /// `--max-num-seqs`; infinity ignores it).
+    pub server_concurrency: u32,
 }
 
 /// One line of the cookbook's typed JSONL stdout stream. Tagged on `"type"`; the `"ts"` field and
@@ -493,10 +506,13 @@ impl CookbookProvisioner {
 
 /// Build the `CookbookInput` (the env-passed provisioning request) from an ephemeral remote config.
 /// Split out from `provision_and_build` so the config→input mapping — notably that the configured
-/// `gpu` is forwarded — is unit-testable without spawning a real recipe.
+/// `backend`, `gpu`, and `num_ctx` are forwarded — is unit-testable without spawning a real recipe.
 fn cookbook_input_for(remote: &RemoteEmbeddingConfig) -> CookbookInput {
     CookbookInput {
         model: remote.model.trim().to_string(),
+        // The selected backend routes the recipe's image/launch/port/route; the embed wire call is
+        // identical across all three.
+        backend: remote.backend.as_db_str(),
         request_timeout_s: remote.request_timeout_s,
         // Give the recipe a provisioning budget just under the Rust hard ceiling, so ITS budget
         // runs out first (clean provider-side teardown) before the Rust SIGKILL backstop
@@ -506,9 +522,12 @@ fn cookbook_input_for(remote: &RemoteEmbeddingConfig) -> CookbookInput {
         // recipe picks its own default when `None`. Config validation guarantees `gpu` is only set
         // in ephemeral mode, which is the only mode reaching this function.
         gpu: remote.gpu.clone(),
+        // The configured context window, baked into the ephemeral ollama box so chunk vectors match
+        // the freshness key (ignored by infinity/vLLM). `None` → the server default.
+        num_ctx: remote.num_ctx,
         // The user's `[remote] concurrency` cap — the box's server parallelism ceiling. rag-rat
         // fans out up to this many parallel requests and auto-tunes the client knee within it.
-        ollama_num_parallel: remote.bounded_concurrency(),
+        server_concurrency: remote.bounded_concurrency(),
     }
 }
 
@@ -1163,10 +1182,12 @@ mod tests {
     fn input() -> CookbookInput {
         CookbookInput {
             model: "all-minilm".to_string(),
+            backend: "ollama",
             request_timeout_s: 30,
             provision_timeout_s: 280,
             gpu: None,
-            ollama_num_parallel: 32,
+            num_ctx: None,
+            server_concurrency: 32,
         }
     }
 
@@ -1220,10 +1241,10 @@ mod tests {
     }
 
     #[test]
-    fn cookbook_input_carries_configured_gpu_and_parallelism() {
+    fn cookbook_input_carries_configured_gpu_parallelism_backend_and_num_ctx() {
         // The config→CookbookInput mapping must forward provider/runtime knobs to the recipe:
-        // `gpu` selects the provider shape, and `ollama_num_parallel` aligns server concurrency
-        // with the client-side remote request window.
+        // `gpu` selects the provider shape, `server_concurrency` aligns the server-side parallelism
+        // with the client-side remote request window, and `backend`/`num_ctx` route provisioning.
         let ephemeral = |gpu: Option<&str>, concurrency: u32| RemoteEmbeddingConfig {
             model: "all-minilm".to_string(),
             cookbook: Some("@rag-rat/cookbook modal".to_string()),
@@ -1234,18 +1255,32 @@ mod tests {
         };
         assert_eq!(cookbook_input_for(&ephemeral(Some("A10G"), 16)).gpu.as_deref(), Some("A10G"));
         assert_eq!(cookbook_input_for(&ephemeral(None, 16)).gpu, None);
-        assert_eq!(cookbook_input_for(&ephemeral(None, 16)).ollama_num_parallel, 16);
-        assert_eq!(cookbook_input_for(&ephemeral(None, 0)).ollama_num_parallel, 1);
+        assert_eq!(cookbook_input_for(&ephemeral(None, 16)).server_concurrency, 16);
+        assert_eq!(cookbook_input_for(&ephemeral(None, 0)).server_concurrency, 1);
         assert_eq!(
             cookbook_input_for(&ephemeral(
                 None,
                 crate::config::MAX_REMOTE_EMBEDDING_CONCURRENCY + 1
             ))
-            .ollama_num_parallel,
+            .server_concurrency,
             crate::config::MAX_REMOTE_EMBEDDING_CONCURRENCY
         );
         // The model is trimmed into the input regardless of gpu.
         assert_eq!(cookbook_input_for(&ephemeral(Some("A100"), 16)).model, "all-minilm");
+        // Backend defaults to ollama and `num_ctx` is absent unless configured.
+        assert_eq!(cookbook_input_for(&ephemeral(None, 16)).backend, "ollama");
+        assert_eq!(cookbook_input_for(&ephemeral(None, 16)).num_ctx, None);
+        // A configured backend + context window are forwarded verbatim.
+        let infinity = RemoteEmbeddingConfig {
+            model: "sentence-transformers/all-MiniLM-L6-v2".to_string(),
+            cookbook: Some("@rag-rat/cookbook modal".to_string()),
+            query_endpoint: Some(crate::config::DEFAULT_QUERY_ENDPOINT.to_string()),
+            backend: crate::config::RemoteBackend::Infinity,
+            num_ctx: Some(4096),
+            ..RemoteEmbeddingConfig::default()
+        };
+        assert_eq!(cookbook_input_for(&infinity).backend, "infinity");
+        assert_eq!(cookbook_input_for(&infinity).num_ctx, Some(4096));
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -85,6 +85,12 @@ pub(crate) fn active_embedder(
 /// `query_endpoint`, so the query embeds against the local box (same model) rather than
 /// provisioning a remote GPU. Used only on the query/connect-chunk path; the ephemeral CHUNK path
 /// provisions.
+///
+/// The `backend` is PRESERVED (via `..remote.clone()`) — the query embedder uses the same route +
+/// server-side model name as the chunk backend — so `query_endpoint` must point at a LOCAL server
+/// running that backend + model. Config parsing enforces this for non-ollama backends (an ephemeral
+/// infinity/vLLM config must set `query_endpoint` explicitly; there is no ollama-shaped default —
+/// see `ConfigError::RemoteQueryEndpointRequiredForBackend`).
 fn query_embed_config(remote: &RemoteEmbeddingConfig) -> RemoteEmbeddingConfig {
     if remote.is_ephemeral() {
         RemoteEmbeddingConfig {

--- a/crates/rag-rat-core/tests/fixtures/cookbook/stub_ok.sh
+++ b/crates/rag-rat-core/tests/fixtures/cookbook/stub_ok.sh
@@ -22,7 +22,7 @@ trap teardown TERM
 
 throughput=""
 if [ -n "$STUB_THROUGHPUT" ]; then
-  throughput=',"throughput":{"concurrency":4,"batch_size":128,"ollama_num_parallel":4,"max_batch_chars":96000}'
+  throughput=',"throughput":{"concurrency":4,"batch_size":128,"server_concurrency":4,"max_batch_chars":96000}'
 fi
 
 # The `ready` event (the handshake) — type-tagged JSONL with a ts field.

--- a/docs/config.md
+++ b/docs/config.md
@@ -91,9 +91,19 @@ cookbook = "@rag-rat/cookbook modal"        # EPHEMERAL: an npm package + a prov
                                             #   First token picks the runner: .mjs/.js → node,
                                             #   .ts/.mts → npx tsx, else → npx -y. The value is split
                                             #   on whitespace — paths with spaces are unsupported.
-model = "all-minilm"                        # the Ollama-side model name
-# query_endpoint = "http://localhost:11434" # the LOCAL ollama for QUERY embedding
-                                            #   (defaults to http://localhost:11434)
+backend = "ollama"                          # "ollama" | "infinity" | "vllm" (default "ollama").
+                                            #   Selects the box image/launch/route; the embed wire
+                                            #   call is the OpenAI shape for all three. vLLM requires
+                                            #   a GPU (its image is CUDA-only).
+model = "all-minilm"                        # server-side model NAME: an ollama name for ollama, a
+                                            #   HuggingFace id (e.g.
+                                            #   sentence-transformers/all-MiniLM-L6-v2) for
+                                            #   infinity/vLLM (auto-downloaded on the box).
+# query_endpoint = "http://localhost:11434" # LOCAL server for QUERY embedding (the box is torn down
+                                            #   after reconcile). Defaults to local Ollama ONLY for
+                                            #   backend="ollama"; REQUIRED for infinity/vLLM — point
+                                            #   it at a local server of the SAME backend + model.
+# num_ctx = 4096                            # ollama-only: baked as OLLAMA_CONTEXT_LENGTH on the box
 # auth_env = "OLLAMA_TOKEN"                 # optional bearer-token env var NAME
 # gpu = "A10"                               # cookbook-only: the GPU the recipe provisions.
                                             #   Provider-specific, validated at provision time:


### PR DESCRIPTION
Phase 2 of the switchable-embedding-backends work (umbrella #347). Generalizes the ephemeral cookbook recipes from ollama-only to a **backend selector** — `ollama | infinity | vllm` — carried in `CookbookInput.backend` (not the provider subcommand), so one provider recipe serves every backend.

## What changed

**Cookbook (TS, `@rag-rat/cookbook` 0.4.0 → 0.5.0)**
- `recipes/backends.mts` (new): declarative per-backend server specs — image (CPU/GPU variant), entrypoint args, env, port, embeddings route, model-load strategy. `embedPath` mirrors `RemoteBackend::embed_path` on the Rust side (ollama/vLLM `/v1/embeddings`; infinity `/embeddings`).
- `src/contract.ts`: `CookbookInput` gains `backend`, `num_ctx`, `server_concurrency` (supersedes `ollama_num_parallel` — no legacy alias, pre-launch). `verifyEmbed` now probes the OpenAI shape (`input:["…"]`, `encoding_format:"float"`) at the backend's `embedPath`, matching the Rust client's batch call exactly.
- `recipes/modal.mts`, `recipes/runpod.mts`: renamed from `*-ollama.mts`; select the backend spec and drive the (unchanged) leak-safe lifecycle. ollama pulls after boot (Modal exec / RunPod client-side `/api/pull`); infinity/vLLM auto-download the HF model on boot.
- `cli.mts` dispatcher + README rewritten for the **provider × backend** model.

**Rust (`cookbook.rs`)**
- `CookbookInput` carries `backend` (`RemoteBackend::as_db_str`), `num_ctx` (baked as `OLLAMA_CONTEXT_LENGTH` for ollama, so chunk vectors match the freshness key), and `server_concurrency` (was `ollama_num_parallel`). `cookbook_input_for` threads them from the config.

## Backend matrix

| Backend | Image | Port | Route | GPU | Model load |
|---|---|---|---|---|---|
| ollama | `ollama/ollama:latest` | 11434 | `/v1/embeddings` | optional | `ollama pull` after boot |
| infinity | `michaelf34/infinity:latest[-cpu]` | 7997 | `/embeddings` | optional | auto-download |
| vllm | `vllm/vllm-openai:latest` | 8000 | `/v1/embeddings` | required | auto-download |

vLLM launch (image entrypoint `vllm serve`, `--runner pooling`, `--host 0.0.0.0`) and infinity launch (`v2 --model-id … --port 7997`, `/embeddings`) verified against upstream docs; per-backend spec commands smoke-tested.

## Verification
- `cargo +nightly fmt`, `cargo clippy --all-targets -p rag-rat-core`, `cargo nextest run -p rag-rat-core` (cookbook/config/ai): **175 pass, 0 fail**.
- `tsc --noEmit` clean; `readInput` + `selectBackendSpec` smoke-tested via node (backend validation, exact docker commands per backend).

## Follow-ups (not in this PR)
- Publish `@rag-rat/cookbook` 0.5.0 to npm (coordinate with merge — infinity/vLLM need the published package, since `npx @rag-rat/cookbook@latest` resolves the recipe).
- Live Modal/RunPod e2e for infinity + vLLM (needs cloud creds + spend).

Part of #347. Fixes #345.