### PR TITLE
perf(embed): unlock GPU-backend throughput — sweep visibility, cap 512, backend-aware provision timeout

### DIFF
--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -232,7 +233,7 @@ pub enum RemoteBackend {
     Ollama,
     /// michaelfeil/infinity (`infinity_emb v2 --model-id <hf>`).
     Infinity,
-    /// vLLM in embedding mode (`vllm serve <hf> --task embed`).
+    /// vLLM in embedding mode (`vllm serve <hf> --runner pooling --host 0.0.0.0`).
     Vllm,
 }
 
@@ -267,6 +268,21 @@ impl RemoteBackend {
         match self {
             RemoteBackend::Ollama | RemoteBackend::Vllm => "/v1/embeddings",
             RemoteBackend::Infinity => "/embeddings",
+        }
+    }
+
+    /// How long the ephemeral cookbook may take to provision + serve a box for this backend before
+    /// rag-rat gives up — BOTH the Rust-side handshake deadline and (minus a margin) the
+    /// `provision_timeout_s` the recipe budgets against.
+    ///
+    /// vLLM's published image (`vllm/vllm-openai`, a ~10–15 GB CUDA image) is an order of magnitude
+    /// larger than ollama's or infinity's, so its cold start (image pull + GPU model load) needs a
+    /// much longer ceiling: 300s times it out on Modal (the create alone can eat most of it,
+    /// leaving too little for `waitUntilReady`). ollama/infinity cold-start in well under 300s.
+    pub fn provision_timeout(self) -> Duration {
+        match self {
+            RemoteBackend::Ollama | RemoteBackend::Infinity => Duration::from_secs(300),
+            RemoteBackend::Vllm => Duration::from_secs(900),
         }
     }
 }
@@ -368,7 +384,13 @@ pub struct RemoteEmbeddingConfig {
 
 /// The default LOCAL Ollama URL for ephemeral query embedding when `query_endpoint` is omitted.
 pub const DEFAULT_QUERY_ENDPOINT: &str = "http://localhost:11434";
-pub const MAX_REMOTE_EMBEDDING_CONCURRENCY: u32 = 128;
+/// Upper bound a user may set for `[remote] concurrency`. Headroom for GPU backends
+/// (infinity/vLLM), which do real dynamic-batched inference and keep scaling with client fan-out
+/// well past 128 (an L4 serving all-MiniLM via infinity was still climbing at 128 with zero
+/// failures). ollama is server-bound (a higher value doesn't help it), so this is opt-in per
+/// config; the defaults stay low. The auto-tuner sweeps within whatever cap the user sets and
+/// clamps the knee to it.
+pub const MAX_REMOTE_EMBEDDING_CONCURRENCY: u32 = 512;
 const DEFAULT_REMOTE_EMBEDDING_CONCURRENCY: u32 = 32;
 const LEGACY_REMOTE_EMBEDDING_CONCURRENCY: u32 = 1;
 const DEFAULT_REMOTE_EMBEDDING_MAX_BATCH_CHARS: usize = 384_000;
@@ -2121,6 +2143,20 @@ mod tests {
         assert_eq!(RemoteBackend::Ollama.embed_path(), "/v1/embeddings");
         assert_eq!(RemoteBackend::Vllm.embed_path(), "/v1/embeddings");
         assert_eq!(RemoteBackend::Infinity.embed_path(), "/embeddings");
+    }
+
+    #[test]
+    fn remote_backend_provision_timeout_is_longer_for_vllm() {
+        // vLLM's ~10-15 GB image needs a longer cold-start ceiling than ollama/infinity, or it
+        // times out on Modal. ollama/infinity share the shorter default.
+        assert_eq!(
+            RemoteBackend::Ollama.provision_timeout(),
+            RemoteBackend::Infinity.provision_timeout()
+        );
+        assert!(
+            RemoteBackend::Vllm.provision_timeout() > RemoteBackend::Infinity.provision_timeout(),
+            "vLLM must get a longer provisioning ceiling than infinity",
+        );
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
@@ -46,7 +46,7 @@ use serde::{Deserialize, Serialize};
 
 use super::Embedder;
 use super::openai::{OpenAiEmbedder, ProvisionedEmbedderParams};
-use crate::config::RemoteEmbeddingConfig;
+use crate::config::{RemoteBackend, RemoteEmbeddingConfig};
 use crate::embedding_models::EmbeddingModelSpec;
 
 /// The env var carrying the cookbook's JSON input. The recipe reads + parses it at startup.
@@ -274,19 +274,24 @@ impl CookbookProvisioner {
     /// `cookbook` resolution: a `.mjs`/`.js` path → `node <path>`; a `.ts` path → `npx tsx <path>`;
     /// anything else → `npx -y <cookbook>` (an npm package spec).
     pub fn provision(cookbook: &str, input: &CookbookInput) -> anyhow::Result<ProvisionedBox> {
-        Self::provision_with_command(cookbook_command(cookbook), cookbook, input, PROVISION_TIMEOUT)
+        // Backend-aware handshake deadline (vLLM's huge image needs longer than ollama/infinity);
+        // fall back to the default if `input.backend` is somehow unrecognized.
+        let timeout = RemoteBackend::from_db_str(input.backend)
+            .map_or(PROVISION_TIMEOUT, RemoteBackend::provision_timeout);
+        Self::provision_with_command(cookbook_command(cookbook), cookbook, input, timeout)
     }
 
     fn provision_cancellable(
         cookbook: &str,
         input: &CookbookInput,
+        provision_timeout: Duration,
         cancel: impl Fn() -> bool,
     ) -> anyhow::Result<ProvisionedBox> {
         Self::provision_with_command_cancellable(
             cookbook_command(cookbook),
             cookbook,
             input,
-            PROVISION_TIMEOUT,
+            provision_timeout,
             cancel,
         )
     }
@@ -514,10 +519,10 @@ fn cookbook_input_for(remote: &RemoteEmbeddingConfig) -> CookbookInput {
         // identical across all three.
         backend: remote.backend.as_db_str(),
         request_timeout_s: remote.request_timeout_s,
-        // Give the recipe a provisioning budget just under the Rust hard ceiling, so ITS budget
-        // runs out first (clean provider-side teardown) before the Rust SIGKILL backstop
-        // fires.
-        provision_timeout_s: PROVISION_TIMEOUT.as_secs().saturating_sub(20),
+        // Give the recipe a provisioning budget just under the Rust hard ceiling (backend-aware:
+        // vLLM's large image needs longer), so ITS budget runs out first (clean provider-side
+        // teardown) before the Rust SIGKILL backstop fires.
+        provision_timeout_s: remote.backend.provision_timeout().as_secs().saturating_sub(20),
         // The configured GPU (provider-specific; validated by the provider at provision time). The
         // recipe picks its own default when `None`. Config validation guarantees `gpu` is only set
         // in ephemeral mode, which is the only mode reaching this function.
@@ -574,7 +579,12 @@ fn provision_and_build_cancellable(
         .as_deref()
         .ok_or_else(|| anyhow::anyhow!("ephemeral remote config has no cookbook"))?;
     let input = cookbook_input_for(remote);
-    let provisioned = CookbookProvisioner::provision_cancellable(cookbook, &input, cancel)?;
+    let provisioned = CookbookProvisioner::provision_cancellable(
+        cookbook,
+        &input,
+        remote.backend.provision_timeout(),
+        cancel,
+    )?;
     // `effective_remote` PERSISTS the user's `concurrency` CAP unchanged (cap model). The live
     // embedder + reconcile window use the tuned knee, CLAMPED to that cap. The knee comes from the
     // in-Rust sweep against the box with the REAL embedder (reconcile path); the install/verify
@@ -614,7 +624,8 @@ fn provision_and_build_cancellable(
 /// down (the [`ProvisionedBox`] guard's `Drop` at end of scope). `Ok(())` on a clean round-trip, an
 /// error otherwise. This path passes `tune = None`, so it does NOT run the throughput sweep (a
 /// throwaway box wouldn't warm the reconcile cache) — it just verifies the round-trip at the user's
-/// `[remote] concurrency` cap. Bounded by the same internal [`PROVISION_TIMEOUT`] (300s) that gates
+/// `[remote] concurrency` cap. Bounded by the same backend-aware provisioning deadline
+/// (`RemoteBackend::provision_timeout` — 300s ollama/infinity, longer for vLLM) that gates
 /// `provision`.
 ///
 /// This is the `pub` seam the CLI's Remote step probes against: `provision_and_build` is

--- a/crates/rag-rat-core/src/index/ai/throughput_tune.rs
+++ b/crates/rag-rat-core/src/index/ai/throughput_tune.rs
@@ -30,13 +30,13 @@ use crate::index::util::now_ms;
 /// `index_meta` key holding the throughput-tune cache (a JSON map, so no schema migration).
 const TUNE_CACHE_META_KEY: &str = "embedding_throughput_tune_v1";
 /// Powers of two the concurrency sweep tries (plus the exact cap; filtered to `<= cap`).
-const CONCURRENCY_CANDIDATES: [u32; 8] = [1, 2, 4, 8, 16, 32, 64, 128];
+const CONCURRENCY_CANDIDATES: [u32; 10] = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512];
 /// Byte budget on the synthetic probe texts a single candidate may allocate, so a huge
 /// `max_batch_chars` (or per-text `max_embedding_chars`) can't balloon the sweep to GBs. A
 /// candidate whose window bytes exceed this is SKIPPED (leaving the sweep incomplete → not cached);
-/// since the window bytes are `candidate * min(batch_size * per_text_chars, max_batch_chars)`, 128
-/// MB covers every sane config at full fan-out (e.g. the default 128 × 384 KB ≈ 49 MB).
-const MAX_PROBE_WINDOW_BYTES: usize = 128 * 1024 * 1024;
+/// since the window bytes are `candidate * min(batch_size * per_text_chars, max_batch_chars)`, 256
+/// MB covers every sane config at full fan-out up to the 512 cap (e.g. 512 × 384 KB ≈ 196 MB).
+const MAX_PROBE_WINDOW_BYTES: usize = 256 * 1024 * 1024;
 /// Fan-out to reconcile with when the sweep RAN but found no stable candidate (every concurrency
 /// was lossy/failed): the safest value, NOT the cap — reconcile's scoped-retry handles the rest,
 /// and blasting a struggling box at the full cap would just write failed chunk groups.
@@ -306,12 +306,45 @@ fn run_sweep<E: Embedder>(
         });
     }
 
-    match select_knee(&results, cap) {
+    let outcome = match select_knee(&results, cap) {
         // `complete` gates caching: a budget-truncated sweep (didn't attempt every candidate) is
         // usable for this run but must not be persisted as the tuned knee for the full cap.
         Some((knee, texts_per_second)) =>
             SweepOutcome::Knee { knee, texts_per_second, complete: attempted == total_candidates },
         None => SweepOutcome::NoStableCandidate,
+    };
+    if tune_log_enabled() {
+        log_sweep(&results, &outcome, attempted, total_candidates);
+    }
+    outcome
+}
+
+/// Print the sweep's per-candidate throughput table + the selected knee to stderr (opt-in via
+/// `RAG_RAT_TUNE_LOG`). The visible-benchmark surface over the auto-tuner: each row is one
+/// concurrency candidate's measured texts/s at the LIVE per-request size (so it reflects the real
+/// reconcile load, not a synthetic micro-benchmark), and the footer names the chosen knee.
+fn log_sweep(results: &[SweepResult], outcome: &SweepOutcome, attempted: usize, total: usize) {
+    eprintln!("rag-rat tune: concurrency sweep — {attempted}/{total} candidates measured");
+    for r in results {
+        eprintln!(
+            "rag-rat tune:   c={:<4} {:>8.1} texts/s   requests={:<4} failures={}{}",
+            r.candidate,
+            r.texts_per_second,
+            r.requests,
+            r.failures,
+            if r.aborted { "   [aborted: breaker tripped]" } else { "" },
+        );
+    }
+    match outcome {
+        SweepOutcome::Knee { knee, texts_per_second, complete } => eprintln!(
+            "rag-rat tune: selected knee c={knee} ({texts_per_second:.1} texts/s){}",
+            if *complete { "" } else { "   [budget-truncated: not cached]" },
+        ),
+        SweepOutcome::NoStableCandidate => {
+            eprintln!("rag-rat tune: no stable candidate — reconcile falls back to the cap");
+        },
+        // NotRun is returned before any measurement, so it never reaches this logger.
+        SweepOutcome::NotRun => {},
     }
 }
 
@@ -362,7 +395,7 @@ fn select_knee(results: &[SweepResult], cap: u32) -> Option<(u32, f64)> {
 /// Powers of two `<= cap`, plus the EXACT cap (a non-power-of-two cap like 24/127 must be tested so
 /// the tuner can use all the capacity the user allowed).
 fn sweep_candidates(cap: u32) -> Vec<u32> {
-    let cap = cap.clamp(1, 128);
+    let cap = cap.clamp(1, crate::config::MAX_REMOTE_EMBEDDING_CONCURRENCY);
     let mut values: Vec<u32> = CONCURRENCY_CANDIDATES.into_iter().filter(|c| *c <= cap).collect();
     if values.last() != Some(&cap) {
         values.push(cap);
@@ -493,6 +526,15 @@ fn tuning_disabled() -> bool {
     matches!(std::env::var("RAG_RAT_DISABLE_TUNING").ok().as_deref(), Some("1") | Some("true"))
 }
 
+/// When set (`RAG_RAT_TUNE_LOG=1`), the concurrency sweep prints its per-candidate throughput table
+/// and the chosen knee to stderr — turning the (otherwise silent) auto-tuner into a visible
+/// benchmark. Off by default so a normal reconcile stays quiet; pair it with
+/// `RAG_RAT_TUNE_TTL_MS=0` (force a fresh sweep) + `RAG_RAT_TUNE_MS` (budget) to benchmark a
+/// provisioned box.
+fn tune_log_enabled() -> bool {
+    matches!(std::env::var("RAG_RAT_TUNE_LOG").ok().as_deref(), Some("1") | Some("true"))
+}
+
 fn tune_budget_ms() -> u64 {
     env_ms("RAG_RAT_TUNE_MS", DEFAULT_TUNE_BUDGET_MS)
 }
@@ -525,6 +567,9 @@ mod tests {
         assert_eq!(sweep_candidates(24), vec![1, 2, 4, 8, 16, 24]);
         assert_eq!(sweep_candidates(127), vec![1, 2, 4, 8, 16, 32, 64, 127]);
         assert_eq!(sweep_candidates(1), vec![1]);
+        // GPU-backend headroom: the cap can now reach 512, adding the 256/512 rungs.
+        assert_eq!(sweep_candidates(256), vec![1, 2, 4, 8, 16, 32, 64, 128, 256]);
+        assert_eq!(sweep_candidates(512), vec![1, 2, 4, 8, 16, 32, 64, 128, 256, 512]);
     }
 
     #[test]


### PR DESCRIPTION
infinity/vLLM do real dynamic-batched GPU inference, so — unlike ollama — they keep scaling with client concurrency. Three changes so rag-rat can use that, all validated live on a Modal **L4** (all-MiniLM-L6-v2).

## Changes

1. **Sweep observability** — `RAG_RAT_TUNE_LOG=1` prints the concurrency sweep's per-candidate throughput table + chosen knee to stderr. The auto-tuner was silent (`run_sweep` measured per-candidate texts/s and discarded all but the knee). Pairs with `RAG_RAT_TUNE_TTL_MS` / `RAG_RAT_TUNE_MS`.
2. **Higher concurrency cap** — `MAX_REMOTE_EMBEDDING_CONCURRENCY` 128 → 512, sweep candidates extended (256, 512), `MAX_PROBE_WINDOW_BYTES` 128 → 256 MB (so a full-cap probe window isn't skipped). Opt-in per config; defaults unchanged. ollama is server-bound so this is for the GPU backends.
3. **Backend-aware provision timeout** — `RemoteBackend::provision_timeout()`: vLLM gets 900s (its ~10-15 GB CUDA image blows the flat 300s ceiling on Modal — the create alone eats most of it), ollama/infinity keep 300s. Threaded through `provision` + `cookbook_input_for`.

Also fixes a stale `--task embed` → `--runner pooling` doc on `RemoteBackend::Vllm`.

## Live benchmark (Modal L4, all-MiniLM, cap 512)

| backend | knee | knee texts/s | peak | vs ollama baseline |
|---|---|---|---|---|
| infinity | c=256 | **1517** | 1616 @ c512 | ~5.4× |
| vLLM (truncated¹) | c=256 | **1029** | 1029 @ c256 | ~3.4× |
| ollama | c≈2 | 299 | 299 @ c4 | 1× |

- infinity scales monotonically to a c=256 knee, **zero failures** at every candidate 1→512. The old 128 cap was leaving ~30% on the table (1122 → 1517 texts/s).
- The backend-aware timeout **fixed vLLM on Modal** (timed out at 300s before, provisions cleanly at 900s — validated live).
- ¹ vLLM strictly rejects inputs over the model's `max_model_len` (all-MiniLM = 256 tok) where infinity/ollama truncate; needs `max_embedding_chars` lowered to fit. Captured as a repo memory + noted as a follow-up (auto-cap for vLLM).

## Verification
`cargo +nightly fmt`, `cargo clippy --all-targets -p rag-rat-core`, `cargo nextest run -p rag-rat-core` (config/throughput_tune/cookbook/reconcile/status/providers): all pass. New tests for the raised sweep candidates + the backend-aware timeout.