### PR TITLE
feat(embed): model context-awareness — warn short-context models truncate long code, steer to a long-context model

### DIFF
--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -507,9 +507,29 @@ pub(crate) fn models(config: &Config, args: &ModelsArgs) -> anyhow::Result<()> {
     match &args.command {
         None | Some(ModelsCommand::List) => print_output(&db.list_models()?),
         Some(ModelsCommand::Install { model_id }) => {
+            warn_if_short_context(model_id);
             let remote = remote_for_install(config, model_id)?;
             print_output(&db.install_model(model_id, remote)?)
         },
+    }
+}
+
+/// One-line heads-up when installing a SHORT-CONTEXT embedding model — one whose token window is
+/// smaller than the default chunk-embed budget, so typical code chunks get truncated (their tail is
+/// not embedded), costing precision/recall on large functions. `rag-rat init`'s model help covers
+/// this interactively; this catches the `rag-rat models install` CLI path.
+fn warn_if_short_context(model_id: &str) {
+    let Some(spec) = rag_rat_core::embedding_models::spec(model_id) else { return };
+    let (Some(max_tokens), Some(model_chars)) = (spec.max_tokens, spec.max_input_chars()) else {
+        return;
+    };
+    if model_chars < rag_rat_core::index::ai::DEFAULT_MAX_EMBEDDING_CHARS {
+        eprintln!(
+            "note: {model_id} has a {max_tokens}-token context, so code chunks longer than that \
+             are truncated — their tail is not embedded, costing precision/recall on large \
+             functions. For code, a long-context model like jinaai/jina-embeddings-v2-base-code \
+             (8192 tokens) embeds whole chunks."
+        );
     }
 }
 pub(crate) fn reconcile(config: &Config, args: &ReconcileArgs) -> anyhow::Result<()> {

--- a/crates/rag-rat-cli/src/init/wizard/steps.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps.rs
@@ -1340,29 +1340,40 @@ fn model_help_lines(model_id: Option<&str>) -> Vec<Line<'static>> {
         385..=512 => "medium",
         _ => "heavy",
     };
+    // The model's context window (in tokens) — the axis this help now leads with, because a short
+    // window silently truncates long code chunks and costs precision/recall.
+    let window = s.max_tokens.map(|t| format!(", {t}-token window")).unwrap_or_default();
     let guidance = match s.backend {
         Backend::Hash =>
             "Dependency-free fallback; very fast, but weak semantic recall. Not recommended for \
              big codebases.",
         Backend::FastEmbed if s.display.contains("MiniLM") =>
-            "Default balanced choice. Good first pick for most repos; measured as hard to beat \
-             here.",
+            "Good default for general text, but its 256-token window TRUNCATES long functions — \
+             their tail is not embedded, so it loses precision/recall on large code chunks. For \
+             code-heavy repos prefer jina (8192 tokens), which embeds whole chunks.",
         Backend::FastEmbed if s.display.contains("bge") =>
-            "General-purpose 384d model. Similar weight to MiniLM; useful for comparison, not a \
-             clear default win.",
+            "General-purpose 384d model with a 512-token window — a bit more context than MiniLM, \
+             but still truncates long code. Useful for comparison.",
         Backend::FastEmbed if s.display.contains("jina") =>
-            "Code-focused 768d model. Heavier storage and reconcile cost; not a measured recall \
-             win here.",
+            "Code-focused 768d model with an 8192-token window: embeds WHOLE functions with no \
+             truncation (unlike MiniLM's 256), so it keeps precision/recall on long chunks. \
+             Heavier storage + reconcile — the best fit for code.",
         Backend::FastEmbed =>
             "Local fastembed model. Good when you want local semantic search without a remote \
              server.",
         Backend::Model2Vec =>
-            "Small and fast local model. Use when speed matters more than maximum semantic recall.",
+            "Small and fast local model (mean-pooled, no token limit). Use when speed matters more \
+             than maximum semantic recall.",
         Backend::Ollama =>
             "Remote runtime. Use only with a configured Ollama endpoint or ephemeral provider.",
     };
     vec![
-        Line::from(format!("{}: {weight}, {}d, {}.", s.display, s.dim, s.backend.runtime())),
+        Line::from(format!(
+            "{}: {weight}, {}d, {}{window}.",
+            s.display,
+            s.dim,
+            s.backend.runtime()
+        )),
         Line::from(guidance),
     ]
 }

--- a/crates/rag-rat-core/src/embedding_models.rs
+++ b/crates/rag-rat-core/src/embedding_models.rs
@@ -86,6 +86,13 @@ pub struct EmbeddingModelSpec {
 /// tokenization could fit, saving bytes without changing the embedded content.
 const CHARS_PER_TOKEN_ESTIMATE: usize = 4;
 
+/// The char budget rag-rat allots for `tokens` tokens of embedding input (see
+/// [`CHARS_PER_TOKEN_ESTIMATE`]). Shared so a token window from any source — a model's static
+/// `max_tokens` or an ollama remote's `num_ctx` override — maps to chars the same way.
+pub(crate) fn tokens_to_char_budget(tokens: usize) -> usize {
+    tokens.saturating_mul(CHARS_PER_TOKEN_ESTIMATE)
+}
+
 impl EmbeddingModelSpec {
     /// The embedding input length (in CHARS) worth sending this model: `max_tokens × ~4`, or `None`
     /// for a model with no sequence limit. Past this the transformer truncates anyway, so a caller
@@ -94,7 +101,7 @@ impl EmbeddingModelSpec {
     /// strict server (vLLM) won't reject a pathologically dense chunk — it only narrows the
     /// margin.
     pub fn max_input_chars(&self) -> Option<usize> {
-        self.max_tokens.map(|t| t.saturating_mul(CHARS_PER_TOKEN_ESTIMATE))
+        self.max_tokens.map(tokens_to_char_budget)
     }
 }
 

--- a/crates/rag-rat-core/src/embedding_models.rs
+++ b/crates/rag-rat-core/src/embedding_models.rs
@@ -58,6 +58,14 @@ pub struct EmbeddingModelSpec {
     pub display: &'static str,
     /// Embedding dimension. A change here is a re-embed (new vectors), not a schema migration.
     pub dim: usize,
+    /// The model's maximum input length in TOKENS (its transformer context window), or `None` for
+    /// models with no sequence limit (the char-hash fallback; Model2Vec, which mean-pools token
+    /// vectors with no attention). A transformer embedder SILENTLY TRUNCATES input past this —
+    /// content beyond it is not represented in the vector, so a short window (all-MiniLM's
+    /// 256) costs precision/recall on long code chunks. Used to cap the embedding input to
+    /// something the model can actually use ([`Self::max_input_chars`]) and to warn when
+    /// chunks exceed it.
+    pub max_tokens: Option<usize>,
     /// The reconcile freshness key (formerly `default_model_version`). Bumping it forces a
     /// re-embed of every chunk for this model. MUST be unique across the table and never the
     /// bare `"v1"` fallback — the registry test guards both.
@@ -70,6 +78,24 @@ pub struct EmbeddingModelSpec {
     /// model (e.g. CodeRankEmbed) would set this; `embed_query_with` would prepend it on the
     /// query path only.
     pub query_prefix: &'static str,
+}
+
+/// Rough UPPER-BOUND chars-per-token for deriving a char cap from a token limit. Deliberately an
+/// over-estimate (English prose ≈ 4, code is denser ≈ 3) so the derived char cap never truncates
+/// BEFORE the model's own token limit would — it only trims input clearly beyond what any plausible
+/// tokenization could fit, saving bytes without changing the embedded content.
+const CHARS_PER_TOKEN_ESTIMATE: usize = 4;
+
+impl EmbeddingModelSpec {
+    /// The embedding input length (in CHARS) worth sending this model: `max_tokens × ~4`, or `None`
+    /// for a model with no sequence limit. Past this the transformer truncates anyway, so a caller
+    /// caps `max_embedding_chars` to `min(configured, this)` — recall-neutral (the model ignored
+    /// the rest) while saving bandwidth. NOTE: an over-estimate, so it does NOT guarantee a
+    /// strict server (vLLM) won't reject a pathologically dense chunk — it only narrows the
+    /// margin.
+    pub fn max_input_chars(&self) -> Option<usize> {
+        self.max_tokens.map(|t| t.saturating_mul(CHARS_PER_TOKEN_ESTIMATE))
+    }
 }
 
 /// Locality-sensitive hash embedder id — the dependency-free fallback tier.
@@ -118,6 +144,8 @@ pub const EMBEDDING_MODELS: &[EmbeddingModelSpec] = &[
         model_id: HASH_MODEL_ID,
         display: "hash",
         dim: HASH_EMBEDDING_DIM,
+        // A char-level locality hash, not a transformer — no token window.
+        max_tokens: None,
         version: "hash-v1",
         backend: Backend::Hash,
         query_prefix: "",
@@ -126,6 +154,8 @@ pub const EMBEDDING_MODELS: &[EmbeddingModelSpec] = &[
         model_id: FASTEMBED_MODEL_ID,
         display: FASTEMBED_DISPLAY_MODEL,
         dim: FASTEMBED_EMBEDDING_DIM,
+        // all-MiniLM-L6-v2's context is 256 tokens — short for code; long chunks lose their tail.
+        max_tokens: Some(256),
         version: "sentence-transformers/all-MiniLM-L6-v2-v1",
         backend: Backend::FastEmbed,
         query_prefix: "",
@@ -134,6 +164,8 @@ pub const EMBEDDING_MODELS: &[EmbeddingModelSpec] = &[
         model_id: BGE_SMALL_MODEL_ID,
         display: BGE_SMALL_DISPLAY_MODEL,
         dim: BGE_SMALL_EMBEDDING_DIM,
+        // BGE-small-en-v1.5's context is 512 tokens.
+        max_tokens: Some(512),
         version: "BAAI/bge-small-en-v1.5-v1",
         backend: Backend::FastEmbed,
         query_prefix: "",
@@ -142,6 +174,8 @@ pub const EMBEDDING_MODELS: &[EmbeddingModelSpec] = &[
         model_id: JINA_CODE_MODEL_ID,
         display: JINA_CODE_DISPLAY_MODEL,
         dim: JINA_CODE_EMBEDDING_DIM,
+        // jina-v2-base-code handles 8192 tokens (ALiBi) — whole code chunks fit; no tail loss.
+        max_tokens: Some(8192),
         version: "jinaai/jina-embeddings-v2-base-code-v1",
         backend: Backend::FastEmbed,
         query_prefix: "",
@@ -150,6 +184,8 @@ pub const EMBEDDING_MODELS: &[EmbeddingModelSpec] = &[
         model_id: MODEL2VEC_MODEL_ID,
         display: MODEL2VEC_DISPLAY_MODEL,
         dim: MODEL2VEC_EMBEDDING_DIM,
+        // Model2Vec mean-pools token vectors with no attention — no sequence limit to truncate at.
+        max_tokens: None,
         version: "minishlab/potion-retrieval-32M-v1",
         backend: Backend::Model2Vec,
         query_prefix: "",
@@ -215,6 +251,33 @@ mod tests {
         for s in EMBEDDING_MODELS {
             assert_eq!(spec(s.model_id).map(|x| x.model_id), Some(s.model_id));
         }
+    }
+
+    #[test]
+    fn transformer_models_declare_a_token_window_static_ones_do_not() {
+        // A transformer embedder (FastEmbed) has a finite context window that truncates long input;
+        // the char-hash and Model2Vec (mean-pool) tiers have none. `max_input_chars` is derived iff
+        // there's a token limit.
+        for s in EMBEDDING_MODELS {
+            match s.backend {
+                Backend::FastEmbed => {
+                    assert!(
+                        s.max_tokens.is_some(),
+                        "{} (transformer) must declare max_tokens",
+                        s.model_id
+                    )
+                },
+                Backend::Hash | Backend::Model2Vec => {
+                    assert_eq!(s.max_tokens, None, "{} has no token window", s.model_id)
+                },
+                _ => {},
+            }
+            assert_eq!(s.max_input_chars().is_some(), s.max_tokens.is_some());
+        }
+        // The default all-MiniLM is short-context (the init help warns about this); jina-code is
+        // long.
+        assert_eq!(spec(FASTEMBED_MODEL_ID).unwrap().max_tokens, Some(256));
+        assert_eq!(spec(JINA_CODE_MODEL_ID).unwrap().max_tokens, Some(8192));
     }
 
     #[test]

--- a/crates/rag-rat-core/src/embedding_models.rs
+++ b/crates/rag-rat-core/src/embedding_models.rs
@@ -62,9 +62,9 @@ pub struct EmbeddingModelSpec {
     /// models with no sequence limit (the char-hash fallback; Model2Vec, which mean-pools token
     /// vectors with no attention). A transformer embedder SILENTLY TRUNCATES input past this —
     /// content beyond it is not represented in the vector, so a short window (all-MiniLM's
-    /// 256) costs precision/recall on long code chunks. Used to cap the embedding input to
-    /// something the model can actually use ([`Self::max_input_chars`]) and to warn when
-    /// chunks exceed it.
+    /// 256) costs precision/recall on long code chunks. Drives [`Self::max_input_chars`], which
+    /// `rag-rat init` + `models install` use to WARN when a short-context model is picked for a
+    /// code repo (steering to a long-context model like jina-code).
     pub max_tokens: Option<usize>,
     /// The reconcile freshness key (formerly `default_model_version`). Bumping it forces a
     /// re-embed of every chunk for this model. MUST be unique across the table and never the
@@ -86,22 +86,17 @@ pub struct EmbeddingModelSpec {
 /// tokenization could fit, saving bytes without changing the embedded content.
 const CHARS_PER_TOKEN_ESTIMATE: usize = 4;
 
-/// The char budget rag-rat allots for `tokens` tokens of embedding input (see
-/// [`CHARS_PER_TOKEN_ESTIMATE`]). Shared so a token window from any source — a model's static
-/// `max_tokens` or an ollama remote's `num_ctx` override — maps to chars the same way.
-pub(crate) fn tokens_to_char_budget(tokens: usize) -> usize {
-    tokens.saturating_mul(CHARS_PER_TOKEN_ESTIMATE)
-}
-
 impl EmbeddingModelSpec {
-    /// The embedding input length (in CHARS) worth sending this model: `max_tokens × ~4`, or `None`
-    /// for a model with no sequence limit. Past this the transformer truncates anyway, so a caller
-    /// caps `max_embedding_chars` to `min(configured, this)` — recall-neutral (the model ignored
-    /// the rest) while saving bandwidth. NOTE: an over-estimate, so it does NOT guarantee a
-    /// strict server (vLLM) won't reject a pathologically dense chunk — it only narrows the
-    /// margin.
+    /// The embedding input length (in CHARS) this model can actually use: `max_tokens × ~4`, or
+    /// `None` for a model with no sequence limit. A rough over-estimate (see
+    /// [`CHARS_PER_TOKEN_ESTIMATE`]) used to judge whether a model is "short-context" for typical
+    /// chunks — `rag-rat init` + `models install` warn when this falls below the default
+    /// chunk-embed budget, steering code repos to a long-context model. NOT used to truncate
+    /// reconcile input: the model truncates past its own window anyway, and forcing a smaller
+    /// cap there interacts badly with the `SkipTooLarge` policy threshold (`max_embedding_chars
+    /// × 4`) and an ollama `num_ctx` override.
     pub fn max_input_chars(&self) -> Option<usize> {
-        self.max_tokens.map(tokens_to_char_budget)
+        self.max_tokens.map(|t| t.saturating_mul(CHARS_PER_TOKEN_ESTIMATE))
     }
 }
 

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -341,33 +341,6 @@ pub(crate) fn status(conn: &Connection) -> anyhow::Result<LlmStatus> {
 /// pending count means embeddings were left behind (#219 review). Returns 0 when no embedding model
 /// is ready (nothing to retry) rather than erroring — the watcher must not abort a pass over a
 /// missing embedder.
-/// The embedding-input char cap for the ACTIVE model — the SINGLE source of truth applied
-/// identically by the reconcile scan, `reconcile_plan` (`--plan`), and `pending_embedding_jobs`
-/// (the watcher backlog gate), so all three hash the SAME truncated input. Diverging here made
-/// `--plan` mispredict the real reconcile: it would report a row `Current` while reconcile treated
-/// it as `InputChanged`, because the two hashed inputs were truncated at different lengths.
-///
-/// The window is the LARGER of two token budgets, so it never clamps below either:
-///   - the model's static context (`EmbeddingModelSpec::max_tokens`), and
-///   - an OLLAMA remote's explicit `num_ctx` override, which widens the served context
-///     (infinity/vLLM ignore `num_ctx`, and a local model has no remote, so those use the static
-///     window only).
-///
-/// A model with no sequence limit (hash / Model2Vec, with no `num_ctx`) is left uncapped.
-fn effective_embedding_char_cap(conn: &Connection, model_id: &str, configured: usize) -> usize {
-    let static_cap = spec(model_id).and_then(|s| s.max_input_chars());
-    let ctx_cap = active_remote_config(conn)
-        .ok()
-        .flatten()
-        .filter(|r| r.backend == crate::config::RemoteBackend::Ollama)
-        .and_then(|r| r.num_ctx)
-        .map(|nc| crate::embedding_models::tokens_to_char_budget(nc as usize));
-    match static_cap.into_iter().chain(ctx_cap).max() {
-        Some(window) => configured.min(window),
-        None => configured,
-    }
-}
-
 pub(crate) fn pending_embedding_jobs(conn: &Connection) -> anyhow::Result<u64> {
     ensure_model_manifest(conn)?;
     let model_id = active_embedding_model_id(conn)?;
@@ -381,11 +354,7 @@ pub(crate) fn pending_embedding_jobs(conn: &Connection) -> anyhow::Result<u64> {
         model_id: &model_id,
         model_version: &model_version,
         dim,
-        max_embedding_chars: effective_embedding_char_cap(
-            conn,
-            &model_id,
-            DEFAULT_MAX_EMBEDDING_CHARS,
-        ),
+        max_embedding_chars: DEFAULT_MAX_EMBEDDING_CHARS,
     };
     estimated_reconcile_jobs(conn, &scan, &ReconcileOptions::default())
 }
@@ -423,11 +392,7 @@ pub(crate) fn embedding_reconcile_plan(
     message: Option<String>,
 ) -> anyhow::Result<EmbeddingReconcilePlan> {
     let jobs = embedding_job_candidates(conn, &model.model_id, model_version, dim, None, false)?;
-    // The SAME model-window cap the real reconcile applies, so `--plan`'s current/stale accounting
-    // hashes the identical truncated input (see `effective_embedding_char_cap`).
-    let max_embedding_chars =
-        effective_embedding_char_cap(conn, &model.model_id, DEFAULT_MAX_EMBEDDING_CHARS);
-    let skipped_by_policy = embedding_policy_skip_summary(conn, max_embedding_chars)?;
+    let skipped_by_policy = embedding_policy_skip_summary(conn, DEFAULT_MAX_EMBEDDING_CHARS)?;
     let mut missing_by_priority = BTreeMap::new();
     let mut current = 0_u64;
     let mut missing = 0_u64;
@@ -438,7 +403,7 @@ pub(crate) fn embedding_reconcile_plan(
     let mut failed_waiting = 0_u64;
     let mut blocked = 0_u64;
     for job in jobs {
-        let policy = policy_for_job(&job, max_embedding_chars);
+        let policy = policy_for_job(&job, DEFAULT_MAX_EMBEDDING_CHARS);
         if !policy.eligible {
             continue;
         }
@@ -448,14 +413,14 @@ pub(crate) fn embedding_reconcile_plan(
             && job.embedding_dim == Some(i64::try_from(dim).unwrap_or(i64::MAX))
             && job.embedding_text_version.as_deref() == Some(EMBEDDING_TEXT_VERSION)
             && job.input_hash.as_deref().is_some_and(|input_hash| {
-                let input = build_embedding_input(&job, max_embedding_chars);
+                let input = build_embedding_input(&job, DEFAULT_MAX_EMBEDDING_CHARS);
                 input_hash == embedding_input_hash(&model.model_id, model_version, &input.text)
             });
         if current_artifact {
             current += 1;
             continue;
         }
-        let reason = job.reason(model_version, dim, now_ms(), max_embedding_chars);
+        let reason = job.reason(model_version, dim, now_ms(), DEFAULT_MAX_EMBEDDING_CHARS);
         match reason {
             ReconcileReason::Missing => missing += 1,
             ReconcileReason::SourceChanged => stale += 1,
@@ -538,9 +503,7 @@ pub(crate) fn reconcile_with_options_progress(
         .transpose()?
         .filter(|value| *value > 0)
         .unwrap_or(DEFAULT_BATCH_SIZE);
-    let max_embedding_chars =
-        effective_embedding_char_cap(conn, &active_model_id, options.max_embedding_chars)
-            .max(MIN_EMBEDDING_CHARS);
+    let max_embedding_chars = options.max_embedding_chars.max(MIN_EMBEDDING_CHARS);
     let started = now_ms();
     set_reconcile_meta(conn, LAST_EMBEDDING_RECONCILE_STARTED_META, &started.to_string())?;
     conn.execute(
@@ -1441,31 +1404,6 @@ mod freshness_version_tests {
             max_batch_chars: 384_000,
             request_timeout_s: 5,
         }
-    }
-
-    #[test]
-    fn effective_char_cap_honors_model_window_and_ollama_num_ctx() {
-        let conn = schema_conn();
-        // Local (no remote): capped to all-MiniLM's static 256-token window (256 × 4 = 1024 chars).
-        assert_eq!(effective_embedding_char_cap(&conn, FASTEMBED_MODEL_ID, 4000), 1024);
-
-        // An OLLAMA remote's `num_ctx` widens the served context, so the configured 4000 chars are
-        // NOT clamped below it: window = max(1024, 4096 × 4) = 16384 → min(4000, 16384) = 4000.
-        // (Regression: the cap must respect an explicit num_ctx, not the static window alone.)
-        let mut ollama = remote_at("http://box:11434");
-        ollama.num_ctx = Some(4096);
-        set_active_remote_config(&conn, &ollama).unwrap();
-        assert_eq!(effective_embedding_char_cap(&conn, FASTEMBED_MODEL_ID, 4000), 4000);
-
-        // infinity/vLLM IGNORE `num_ctx` (they don't read it), so the static window still caps.
-        let mut infinity = ollama.clone();
-        infinity.backend = crate::config::RemoteBackend::Infinity;
-        set_active_remote_config(&conn, &infinity).unwrap();
-        assert_eq!(effective_embedding_char_cap(&conn, FASTEMBED_MODEL_ID, 4000), 1024);
-
-        // A no-limit tier (hash / Model2Vec) with no num_ctx is never capped.
-        let bare = schema_conn();
-        assert_eq!(effective_embedding_char_cap(&bare, HASH_MODEL_ID, 4000), 4000);
     }
 
     struct TimeoutsThenOkEmbedder {

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -341,6 +341,33 @@ pub(crate) fn status(conn: &Connection) -> anyhow::Result<LlmStatus> {
 /// pending count means embeddings were left behind (#219 review). Returns 0 when no embedding model
 /// is ready (nothing to retry) rather than erroring — the watcher must not abort a pass over a
 /// missing embedder.
+/// The embedding-input char cap for the ACTIVE model — the SINGLE source of truth applied
+/// identically by the reconcile scan, `reconcile_plan` (`--plan`), and `pending_embedding_jobs`
+/// (the watcher backlog gate), so all three hash the SAME truncated input. Diverging here made
+/// `--plan` mispredict the real reconcile: it would report a row `Current` while reconcile treated
+/// it as `InputChanged`, because the two hashed inputs were truncated at different lengths.
+///
+/// The window is the LARGER of two token budgets, so it never clamps below either:
+///   - the model's static context (`EmbeddingModelSpec::max_tokens`), and
+///   - an OLLAMA remote's explicit `num_ctx` override, which widens the served context
+///     (infinity/vLLM ignore `num_ctx`, and a local model has no remote, so those use the static
+///     window only).
+///
+/// A model with no sequence limit (hash / Model2Vec, with no `num_ctx`) is left uncapped.
+fn effective_embedding_char_cap(conn: &Connection, model_id: &str, configured: usize) -> usize {
+    let static_cap = spec(model_id).and_then(|s| s.max_input_chars());
+    let ctx_cap = active_remote_config(conn)
+        .ok()
+        .flatten()
+        .filter(|r| r.backend == crate::config::RemoteBackend::Ollama)
+        .and_then(|r| r.num_ctx)
+        .map(|nc| crate::embedding_models::tokens_to_char_budget(nc as usize));
+    match static_cap.into_iter().chain(ctx_cap).max() {
+        Some(window) => configured.min(window),
+        None => configured,
+    }
+}
+
 pub(crate) fn pending_embedding_jobs(conn: &Connection) -> anyhow::Result<u64> {
     ensure_model_manifest(conn)?;
     let model_id = active_embedding_model_id(conn)?;
@@ -354,7 +381,11 @@ pub(crate) fn pending_embedding_jobs(conn: &Connection) -> anyhow::Result<u64> {
         model_id: &model_id,
         model_version: &model_version,
         dim,
-        max_embedding_chars: DEFAULT_MAX_EMBEDDING_CHARS,
+        max_embedding_chars: effective_embedding_char_cap(
+            conn,
+            &model_id,
+            DEFAULT_MAX_EMBEDDING_CHARS,
+        ),
     };
     estimated_reconcile_jobs(conn, &scan, &ReconcileOptions::default())
 }
@@ -392,7 +423,11 @@ pub(crate) fn embedding_reconcile_plan(
     message: Option<String>,
 ) -> anyhow::Result<EmbeddingReconcilePlan> {
     let jobs = embedding_job_candidates(conn, &model.model_id, model_version, dim, None, false)?;
-    let skipped_by_policy = embedding_policy_skip_summary(conn, DEFAULT_MAX_EMBEDDING_CHARS)?;
+    // The SAME model-window cap the real reconcile applies, so `--plan`'s current/stale accounting
+    // hashes the identical truncated input (see `effective_embedding_char_cap`).
+    let max_embedding_chars =
+        effective_embedding_char_cap(conn, &model.model_id, DEFAULT_MAX_EMBEDDING_CHARS);
+    let skipped_by_policy = embedding_policy_skip_summary(conn, max_embedding_chars)?;
     let mut missing_by_priority = BTreeMap::new();
     let mut current = 0_u64;
     let mut missing = 0_u64;
@@ -403,7 +438,7 @@ pub(crate) fn embedding_reconcile_plan(
     let mut failed_waiting = 0_u64;
     let mut blocked = 0_u64;
     for job in jobs {
-        let policy = policy_for_job(&job, DEFAULT_MAX_EMBEDDING_CHARS);
+        let policy = policy_for_job(&job, max_embedding_chars);
         if !policy.eligible {
             continue;
         }
@@ -413,14 +448,14 @@ pub(crate) fn embedding_reconcile_plan(
             && job.embedding_dim == Some(i64::try_from(dim).unwrap_or(i64::MAX))
             && job.embedding_text_version.as_deref() == Some(EMBEDDING_TEXT_VERSION)
             && job.input_hash.as_deref().is_some_and(|input_hash| {
-                let input = build_embedding_input(&job, DEFAULT_MAX_EMBEDDING_CHARS);
+                let input = build_embedding_input(&job, max_embedding_chars);
                 input_hash == embedding_input_hash(&model.model_id, model_version, &input.text)
             });
         if current_artifact {
             current += 1;
             continue;
         }
-        let reason = job.reason(model_version, dim, now_ms(), DEFAULT_MAX_EMBEDDING_CHARS);
+        let reason = job.reason(model_version, dim, now_ms(), max_embedding_chars);
         match reason {
             ReconcileReason::Missing => missing += 1,
             ReconcileReason::SourceChanged => stale += 1,
@@ -503,15 +538,9 @@ pub(crate) fn reconcile_with_options_progress(
         .transpose()?
         .filter(|value| *value > 0)
         .unwrap_or(DEFAULT_BATCH_SIZE);
-    let max_embedding_chars = options.max_embedding_chars.max(MIN_EMBEDDING_CHARS);
-    // Never send more than the ACTIVE model can read: a transformer silently truncates input past
-    // its context window, so the excess is wasted bytes (and can overflow a strict server like
-    // vLLM). Recall-neutral — the model ignored it anyway. The user-facing "a short-context model
-    // loses recall on long code" guidance lives in `rag-rat init` + `models install`, NOT here
-    // (this runs on every watcher tick — a warning would spam).
-    let max_embedding_chars = crate::embedding_models::spec(&active_model_id)
-        .and_then(|s| s.max_input_chars())
-        .map_or(max_embedding_chars, |model_cap| max_embedding_chars.min(model_cap));
+    let max_embedding_chars =
+        effective_embedding_char_cap(conn, &active_model_id, options.max_embedding_chars)
+            .max(MIN_EMBEDDING_CHARS);
     let started = now_ms();
     set_reconcile_meta(conn, LAST_EMBEDDING_RECONCILE_STARTED_META, &started.to_string())?;
     conn.execute(
@@ -1412,6 +1441,31 @@ mod freshness_version_tests {
             max_batch_chars: 384_000,
             request_timeout_s: 5,
         }
+    }
+
+    #[test]
+    fn effective_char_cap_honors_model_window_and_ollama_num_ctx() {
+        let conn = schema_conn();
+        // Local (no remote): capped to all-MiniLM's static 256-token window (256 × 4 = 1024 chars).
+        assert_eq!(effective_embedding_char_cap(&conn, FASTEMBED_MODEL_ID, 4000), 1024);
+
+        // An OLLAMA remote's `num_ctx` widens the served context, so the configured 4000 chars are
+        // NOT clamped below it: window = max(1024, 4096 × 4) = 16384 → min(4000, 16384) = 4000.
+        // (Regression: the cap must respect an explicit num_ctx, not the static window alone.)
+        let mut ollama = remote_at("http://box:11434");
+        ollama.num_ctx = Some(4096);
+        set_active_remote_config(&conn, &ollama).unwrap();
+        assert_eq!(effective_embedding_char_cap(&conn, FASTEMBED_MODEL_ID, 4000), 4000);
+
+        // infinity/vLLM IGNORE `num_ctx` (they don't read it), so the static window still caps.
+        let mut infinity = ollama.clone();
+        infinity.backend = crate::config::RemoteBackend::Infinity;
+        set_active_remote_config(&conn, &infinity).unwrap();
+        assert_eq!(effective_embedding_char_cap(&conn, FASTEMBED_MODEL_ID, 4000), 1024);
+
+        // A no-limit tier (hash / Model2Vec) with no num_ctx is never capped.
+        let bare = schema_conn();
+        assert_eq!(effective_embedding_char_cap(&bare, HASH_MODEL_ID, 4000), 4000);
     }
 
     struct TimeoutsThenOkEmbedder {

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -504,6 +504,14 @@ pub(crate) fn reconcile_with_options_progress(
         .filter(|value| *value > 0)
         .unwrap_or(DEFAULT_BATCH_SIZE);
     let max_embedding_chars = options.max_embedding_chars.max(MIN_EMBEDDING_CHARS);
+    // Never send more than the ACTIVE model can read: a transformer silently truncates input past
+    // its context window, so the excess is wasted bytes (and can overflow a strict server like
+    // vLLM). Recall-neutral — the model ignored it anyway. The user-facing "a short-context model
+    // loses recall on long code" guidance lives in `rag-rat init` + `models install`, NOT here
+    // (this runs on every watcher tick — a warning would spam).
+    let max_embedding_chars = crate::embedding_models::spec(&active_model_id)
+        .and_then(|s| s.max_input_chars())
+        .map_or(max_embedding_chars, |model_cap| max_embedding_chars.min(model_cap));
     let started = now_ms();
     set_reconcile_meta(conn, LAST_EMBEDDING_RECONCILE_STARTED_META, &started.to_string())?;
     conn.execute(


### PR DESCRIPTION
all-MiniLM (the default embedder) has a **256-token context** — a code chunk longer than that is silently truncated, costing precision/recall on long functions. rag-rat had no notion of a model's window, so users had no signal. This makes rag-rat model-context-aware and surfaces the tradeoff where users pick a model.

## Changes

- **`EmbeddingModelSpec.max_tokens: Option<usize>`** — all-MiniLM 256, BGE 512, jina-code 8192; `None` for the hash + Model2Vec tiers (no sequence limit). Plus `max_input_chars()` (≈ `max_tokens × 4`).
- **`rag-rat init` model help** now leads with each model's token window and warns that all-MiniLM truncates long code, recommending jina-code for code repos. **`rag-rat models install`** prints the same one-line note on the CLI path.

## Measured evidence (local fastembed A/B)

Two ~1900-char functions with near-identical boilerplate heads and distinctive tails (backoff vs LRU). Query = a semantic paraphrase of the *backoff tail* with ~zero lexical overlap; comparing the `--explain` **vector** (semantic) component:

| model | correct fn (backoff) | distractor (LRU) | semantic gap | truncated |
|---|---|---|---|---|
| all-MiniLM (256 tok) | 0.097 | 0.095 | **+0.002** (can't tell them apart) | 2/2 |
| jina-code (8192 tok) | **0.171** | 0.151 | **+0.020** (~10× separation) | 0/2 |

For a query about a long function's tail, all-MiniLM's embeddings are semantically flat (both are just the shared head); jina-code separates them ~10× and matches the correct function 76% more strongly.

## Scope note — dropped the reconcile input cap

An earlier revision of this PR also **capped** the reconcile `max_embedding_chars` to the model window. That was a premature optimization: `max_embedding_chars` also drives the `SkipTooLarge` policy threshold (`× 4`), so capping it dropped medium chunks entirely; it diverged the `--plan`/backlog input hash from the real reconcile; and the ollama `num_ctx` direction is ambiguous. Marginal value (a few saved bytes; didn't reliably fix vLLM either), so it's **removed** — reconcile reverts to known-good behavior. The awareness + guidance (the actual goal) stand on their own. This resolves all four Codex P2 findings by removing their shared cause.

## Verification
`cargo +nightly fmt`, `cargo clippy --all-targets -p rag-rat-core -p rag-rat`, `cargo nextest run` (embedding_models / reconcile / wizard help): all pass.