### PR TITLE
feat(embed): benchmark-embedding CLI behind the eval feature (Phase 3)

### DIFF
--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -95,6 +95,12 @@ pub(crate) enum Command {
     #[cfg(feature = "eval")]
     Eval(EvalArgs),
 
+    /// Benchmark ephemeral remote embedding throughput across concurrency candidates, emitting
+    /// per-candidate texts/s as JSON (requires the `eval` build feature). Provisions an ephemeral
+    /// cookbook box, runs the sweep, and tears it down.
+    #[cfg(feature = "eval")]
+    BenchmarkEmbedding(BenchmarkEmbeddingArgs),
+
     /// SCIP-oracle pass: compiler-grade edge resolution from a language indexer.
     Oracle(OracleArgs),
 
@@ -366,6 +372,50 @@ pub(crate) struct EvalArgs {
     /// change.
     #[arg(long, default_value_t = 10)]
     pub search_limit: usize,
+}
+
+/// `benchmark-embedding` (#346): provision an ephemeral cookbook box and sweep embedding throughput
+/// across concurrency candidates, emitting per-candidate texts/s as JSON. The PRIMARY output is
+/// JSON regardless of the global render flag (the point of the command is machine-readable
+/// backend/concurrency comparison).
+#[cfg(feature = "eval")]
+#[derive(Debug, Args)]
+pub(crate) struct BenchmarkEmbeddingArgs {
+    /// The ephemeral cookbook provider spec that provisions the on-demand box (e.g.
+    /// `"@rag-rat/cookbook modal"`). Required — this command only benchmarks ephemeral boxes.
+    #[arg(long)]
+    pub cookbook: String,
+    /// Which OpenAI-compatible backend to provision + benchmark (`ollama` | `infinity` | `vllm`).
+    #[arg(long, default_value = "ollama", value_parser = parse_remote_backend)]
+    pub backend: rag_rat_core::config::RemoteBackend,
+    /// The server-side model to serve: an ollama model name (ollama backend) or a HuggingFace id
+    /// (infinity/vLLM). Required. Off-registry HF models fall back to a measured dim (one probe
+    /// embed) since they have no registry spec.
+    #[arg(long)]
+    pub model: String,
+    /// GPU hint for the recipe (provider-specific, e.g. `A10G`/`T4`). Omit to let the recipe pick.
+    #[arg(long)]
+    pub gpu: Option<String>,
+    /// Concurrency candidates to measure, comma-separated (e.g. `1,2,4,8,16,32`). Omit to sweep
+    /// the tuner's default ladder (powers of two up to the config's concurrency cap, plus the
+    /// cap).
+    #[arg(long, value_delimiter = ',')]
+    pub candidates: Vec<u32>,
+    /// Total sweep budget in milliseconds (split across candidates). Omit for the tuner default.
+    #[arg(long)]
+    pub budget_ms: Option<u64>,
+    /// Write the JSON report to this path instead of stdout.
+    #[arg(long)]
+    pub output: Option<PathBuf>,
+}
+
+/// clap `value_parser` for `--backend`: parse the backend selector via the SAME
+/// [`RemoteBackend::from_db_str`](rag_rat_core::config::RemoteBackend::from_db_str) the config
+/// layer uses, so the CLI and config accept identical spellings.
+#[cfg(feature = "eval")]
+fn parse_remote_backend(s: &str) -> Result<rag_rat_core::config::RemoteBackend, String> {
+    rag_rat_core::config::RemoteBackend::from_db_str(s)
+        .ok_or_else(|| format!("unknown backend `{s}` (expected ollama, infinity, or vllm)"))
 }
 
 #[derive(Debug, Args)]
@@ -745,6 +795,84 @@ mod tests {
             },
             other => panic!("expected clones-for, got {other:?}"),
         }
+    }
+
+    #[cfg(feature = "eval")]
+    #[test]
+    fn benchmark_embedding_parses_candidates_and_backend() {
+        let cli = Cli::try_parse_from([
+            "rag-rat",
+            "benchmark-embedding",
+            "--cookbook",
+            "@rag-rat/cookbook modal",
+            "--backend",
+            "infinity",
+            "--model",
+            "sentence-transformers/all-MiniLM-L6-v2",
+            "--candidates",
+            "1,2,4",
+            "--budget-ms",
+            "30000",
+            "--gpu",
+            "A10G",
+        ])
+        .expect("parse");
+        match cli.command {
+            Command::BenchmarkEmbedding(args) => {
+                assert_eq!(args.cookbook, "@rag-rat/cookbook modal");
+                assert_eq!(args.backend, rag_rat_core::config::RemoteBackend::Infinity);
+                assert_eq!(args.model, "sentence-transformers/all-MiniLM-L6-v2");
+                assert_eq!(args.candidates, vec![1, 2, 4]);
+                assert_eq!(args.budget_ms, Some(30_000));
+                assert_eq!(args.gpu.as_deref(), Some("A10G"));
+                assert!(args.output.is_none());
+            },
+            other => panic!("expected benchmark-embedding, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "eval")]
+    #[test]
+    fn benchmark_embedding_defaults_backend_ollama_and_omits_candidates() {
+        // `--cookbook` + `--model` are the only required flags; backend defaults to ollama and the
+        // candidate list is empty (→ the handler uses the default ladder).
+        let cli = Cli::try_parse_from([
+            "rag-rat",
+            "benchmark-embedding",
+            "--cookbook",
+            "@rag-rat/cookbook modal",
+            "--model",
+            "all-minilm",
+        ])
+        .expect("parse");
+        match cli.command {
+            Command::BenchmarkEmbedding(args) => {
+                assert_eq!(args.backend, rag_rat_core::config::RemoteBackend::Ollama);
+                assert!(args.candidates.is_empty());
+                assert!(args.budget_ms.is_none());
+            },
+            other => panic!("expected benchmark-embedding, got {other:?}"),
+        }
+        // An unknown backend is rejected by the value_parser.
+        assert!(
+            Cli::try_parse_from([
+                "rag-rat",
+                "benchmark-embedding",
+                "--cookbook",
+                "cb",
+                "--model",
+                "m",
+                "--backend",
+                "bogus",
+            ])
+            .is_err(),
+            "an unknown --backend must be rejected"
+        );
+        // `--cookbook` and `--model` are both required.
+        assert!(Cli::try_parse_from(["rag-rat", "benchmark-embedding", "--model", "m"]).is_err());
+        assert!(
+            Cli::try_parse_from(["rag-rat", "benchmark-embedding", "--cookbook", "cb"]).is_err()
+        );
     }
 
     #[test]

--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -586,13 +586,32 @@ pub(crate) fn benchmark_embedding(
         budget_ms,
     );
 
-    // Peak = the highest-throughput row among rows that actually measured something (`requests >
-    // 0`). If EVERY row failed (a reachable box but every probe errored — wrong `--model`, bad
-    // auth/path, dim mismatch), peak is `null`, not a misleading 0-TPS "result" a consumer
-    // would treat as a valid backend comparison.
+    // Surface any REQUESTED candidates the sweep did NOT measure. `measure_candidates` drops a
+    // candidate (and every higher one) when its probe window exceeds `MAX_PROBE_WINDOW_BYTES` or
+    // the budget runs out, rather than caching a partial sweep — fine for the auto-tuner, but
+    // the benchmark would otherwise exit successfully with rows silently missing after starting
+    // a paid box. Report them (and warn on stderr) so the JSON is honest about coverage.
+    let measured_set: std::collections::BTreeSet<u32> =
+        measured.iter().map(|m| m.concurrency).collect();
+    let skipped: Vec<u32> =
+        candidates.iter().copied().filter(|c| !measured_set.contains(c)).collect();
+    if !skipped.is_empty() {
+        eprintln!(
+            "benchmark-embedding: WARNING — {} requested candidate(s) not measured (probe window \
+             / budget limit): {skipped:?}. Lower --candidates or [runtime] max_embedding_chars, \
+             or raise --budget-ms.",
+            skipped.len(),
+        );
+    }
+
+    // Peak = the highest-throughput row among rows that actually measured something AND stayed
+    // stable (`requests > 0 && !aborted`). A failed row (`requests == 0`) or a breaker-tripped
+    // overloaded row (`aborted`) must not be advertised as the best result — `peak` is the
+    // machine-readable backend/concurrency selector, so an all-failed or all-unstable run reports
+    // `peak: null` rather than a misleading number.
     let peak = measured
         .iter()
-        .filter(|m| m.requests > 0)
+        .filter(|m| m.requests > 0 && !m.aborted)
         .max_by(|a, b| a.texts_per_second.total_cmp(&b.texts_per_second))
         .map(|m| serde_json::json!({ "concurrency": m.concurrency, "texts_per_second": m.texts_per_second }));
 
@@ -604,6 +623,7 @@ pub(crate) fn benchmark_embedding(
         "dim": dim,
         "budget_ms": budget_ms,
         "candidates": measured,
+        "skipped_candidates": skipped,
         "peak": peak,
     });
 

--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -489,13 +489,32 @@ pub(crate) fn benchmark_embedding(
 
     // Build an EPHEMERAL remote config directly (no rag-rat.toml round-trip): `cookbook` set,
     // `endpoint` None. Struct construction bypasses the config layer's connect/ephemeral
-    // validation, which is fine — the benchmark only provisions + sweeps, it never reconciles,
-    // so the only knobs that matter are the provisioning inputs (cookbook/backend/gpu/model)
-    // and the request shape (batch_size/max_batch_chars/concurrency/timeout), which come from
-    // the defaults.
-    let cap = config.llm.embedding.remote.as_ref().map_or_else(
-        || RemoteEmbeddingConfig::default().bounded_concurrency(),
-        RemoteEmbeddingConfig::bounded_concurrency,
+    // validation, which is fine — the benchmark only provisions + sweeps, it never reconciles.
+    //
+    // Base it on the repo's configured `[remote]` block (or defaults) so the benchmark mirrors the
+    // LIVE reconcile REQUEST SHAPE — `batch_size` / `max_batch_chars` / `request_timeout_s` /
+    // `num_ctx` are carried over via `..base`; only the provisioning + CLI-selected fields are
+    // overridden. Filling the request shape from `default()` instead would benchmark a different
+    // request than this repo's reconcile actually sends.
+    let base = config.llm.embedding.remote.clone().unwrap_or_default();
+    let cap = base.bounded_concurrency();
+
+    let max_embedding_chars = config.llm.embedding.runtime.max_embedding_chars;
+    // The candidate ladder: explicit `--candidates` when given, else the tuner's default ladder for
+    // the config's concurrency cap (powers of two up to the cap, plus the exact cap).
+    let candidates: Vec<u32> = if args.candidates.is_empty() {
+        rag_rat_core::index::ai::default_benchmark_candidates(cap)
+    } else {
+        args.candidates.clone()
+    };
+
+    // Size the provisioned server for the HIGHEST fan-out the sweep will test: `concurrency` is
+    // forwarded as `server_concurrency` (ollama `OLLAMA_NUM_PARALLEL` / vLLM `--max-num-seqs`;
+    // infinity ignores it). Explicit `--candidates` above the cap would otherwise drive client
+    // fan-outs the server was NOT launched to handle, so those rows would look slow / fail for the
+    // wrong reason. Take the max candidate (never below the cap), clamped to the global ceiling.
+    let provision_concurrency = RemoteEmbeddingConfig::bounded_concurrency_value(
+        candidates.iter().copied().max().unwrap_or(cap).max(cap),
     );
     let remote = RemoteEmbeddingConfig {
         model: args.model.clone(),
@@ -505,19 +524,8 @@ pub(crate) fn benchmark_embedding(
         query_endpoint: None,
         auth_env: None,
         gpu: args.gpu.clone(),
-        // The benchmark measures the request shape from the config defaults; `concurrency` here is
-        // only the CAP that sizes the default candidate ladder, not a live fan-out.
-        concurrency: cap,
-        ..RemoteEmbeddingConfig::default()
-    };
-
-    let max_embedding_chars = config.llm.embedding.runtime.max_embedding_chars;
-    // The candidate ladder: explicit `--candidates` when given, else the tuner's default ladder for
-    // the config's concurrency cap (powers of two up to the cap, plus the exact cap).
-    let candidates: Vec<u32> = if args.candidates.is_empty() {
-        rag_rat_core::index::ai::default_benchmark_candidates(cap)
-    } else {
-        args.candidates.clone()
+        concurrency: provision_concurrency,
+        ..base
     };
     let budget_ms =
         args.budget_ms.unwrap_or_else(rag_rat_core::index::ai::default_benchmark_budget_ms);

--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -4,7 +4,7 @@ use rag_rat_core::OutputFormat;
 
 use super::*;
 #[cfg(feature = "eval")]
-use crate::cli::EvalArgs;
+use crate::cli::{BenchmarkEmbeddingArgs, EvalArgs};
 use crate::cli::{
     BriefArgs, ClonesArgs, ClonesForArgs, ClustersArgs, DreamArgs, GithubArgs, GithubCommand,
     HookAction, HooksArgs, ImportantSymbolsArgs, IndexArgs, MaintenanceArgs, MemoryArgs,
@@ -469,6 +469,141 @@ pub(crate) fn eval(config: &Config, args: &EvalArgs) -> anyhow::Result<()> {
 #[cfg(feature = "eval")]
 pub(crate) fn default_eval_path(config: &Config, file_name: &str) -> PathBuf {
     config.root.join("evals").join(file_name)
+}
+
+/// `benchmark-embedding` (#346): provision an ephemeral cookbook box, sweep embedding throughput
+/// across concurrency candidates, and emit per-candidate texts/s as JSON — then tear the box down.
+/// The point is a machine-readable comparison of backends (ollama/infinity/vLLM) and concurrency
+/// levels, so the PRIMARY output is JSON regardless of the global `--json` render flag.
+///
+/// This runs its OWN measured sweep (`benchmark_remote_concurrency`), NOT the caching auto-tuner:
+/// every candidate is measured and reported (no knee selection, no tune-cache write). The box is
+/// provisioned with `tune = None` and kept bound for the whole sweep — `ProvisionedBox::drop` is
+/// the teardown, so letting it live to the end of scope is what tears it down cleanly.
+#[cfg(feature = "eval")]
+pub(crate) fn benchmark_embedding(
+    config: &Config,
+    args: &BenchmarkEmbeddingArgs,
+) -> anyhow::Result<()> {
+    use rag_rat_core::config::RemoteEmbeddingConfig;
+
+    // Build an EPHEMERAL remote config directly (no rag-rat.toml round-trip): `cookbook` set,
+    // `endpoint` None. Struct construction bypasses the config layer's connect/ephemeral
+    // validation, which is fine — the benchmark only provisions + sweeps, it never reconciles,
+    // so the only knobs that matter are the provisioning inputs (cookbook/backend/gpu/model)
+    // and the request shape (batch_size/max_batch_chars/concurrency/timeout), which come from
+    // the defaults.
+    let cap = config.llm.embedding.remote.as_ref().map_or_else(
+        || RemoteEmbeddingConfig::default().bounded_concurrency(),
+        RemoteEmbeddingConfig::bounded_concurrency,
+    );
+    let remote = RemoteEmbeddingConfig {
+        model: args.model.clone(),
+        backend: args.backend,
+        endpoint: None,
+        cookbook: Some(args.cookbook.clone()),
+        query_endpoint: None,
+        auth_env: None,
+        gpu: args.gpu.clone(),
+        // The benchmark measures the request shape from the config defaults; `concurrency` here is
+        // only the CAP that sizes the default candidate ladder, not a live fan-out.
+        concurrency: cap,
+        ..RemoteEmbeddingConfig::default()
+    };
+
+    let max_embedding_chars = config.llm.embedding.runtime.max_embedding_chars;
+    // The candidate ladder: explicit `--candidates` when given, else the tuner's default ladder for
+    // the config's concurrency cap (powers of two up to the cap, plus the exact cap).
+    let candidates: Vec<u32> = if args.candidates.is_empty() {
+        rag_rat_core::index::ai::default_benchmark_candidates(cap)
+    } else {
+        args.candidates.clone()
+    };
+    let budget_ms =
+        args.budget_ms.unwrap_or_else(rag_rat_core::index::ai::default_benchmark_budget_ms);
+
+    // Registry model → trust `spec.dim`. Off-registry HF model → provision, measure the dim from
+    // one probe embed, then benchmark. Either way the ProvisionedBox is kept bound for the
+    // whole sweep.
+    let spec = rag_rat_core::embedding_models::spec(&args.model);
+    let provisioned = rag_rat_core::index::ai::provision_box_for_benchmark(
+        &remote,
+        spec_or_measure_placeholder(spec),
+    )?;
+    let (selected_model_id, dim) = match spec {
+        Some(spec) => (spec.model_id.to_string(), spec.dim),
+        None => {
+            // Off-registry: learn the dim from the server's first response.
+            let dim = rag_rat_core::index::ai::measure_remote_dim(
+                &provisioned.endpoint,
+                provisioned.auth_token.as_deref(),
+                &remote,
+            )?;
+            (args.model.clone(), dim)
+        },
+    };
+
+    let measured = rag_rat_core::index::ai::benchmark_remote_concurrency(
+        &provisioned.endpoint,
+        provisioned.auth_token.as_deref(),
+        &remote,
+        &selected_model_id,
+        dim,
+        max_embedding_chars,
+        &candidates,
+        budget_ms,
+    );
+
+    // Peak = the highest measured texts/s row (informational; the benchmark reports every row and
+    // lets the reader compare). `None` only if no candidate was measured (empty ladder).
+    let peak = measured
+        .iter()
+        .max_by(|a, b| a.texts_per_second.total_cmp(&b.texts_per_second))
+        .map(|m| serde_json::json!({ "concurrency": m.concurrency, "texts_per_second": m.texts_per_second }));
+
+    let report = serde_json::json!({
+        "backend": args.backend.as_db_str(),
+        "model": args.model,
+        "cookbook": args.cookbook,
+        "gpu": args.gpu,
+        "dim": dim,
+        "budget_ms": budget_ms,
+        "candidates": measured,
+        "peak": peak,
+    });
+
+    // JSON is the PRIMARY output (#346), regardless of the global render flag. To a file when
+    // `--output` is set, else stdout.
+    let json = serde_json::to_string_pretty(&report)?;
+    match &args.output {
+        Some(path) => {
+            write_atomic(path, json.as_bytes())?;
+            eprintln!(
+                "benchmark-embedding: wrote {} candidate rows to {}",
+                measured.len(),
+                path.display()
+            );
+        },
+        None => println!("{json}"),
+    }
+    // `provisioned` drops here → the box is torn down (SIGTERM → grace → SIGKILL on its group).
+    Ok(())
+}
+
+/// The `spec` param `provision_box_for_benchmark` needs is `&EmbeddingModelSpec`; an off-registry
+/// model has none, so provisioning uses the FALLBACK all-MiniLM spec purely to satisfy the type —
+/// it only feeds `spec.model_id`/`spec.dim` into the built-but-discarded probe embedder inside
+/// `provision_and_build`, which the benchmark never uses (it constructs its own per-candidate
+/// embedders against the box). The real server-side model is `remote.model`; the real dim is
+/// measured separately via `measure_remote_dim`.
+#[cfg(feature = "eval")]
+fn spec_or_measure_placeholder(
+    spec: Option<&'static rag_rat_core::embedding_models::EmbeddingModelSpec>,
+) -> &'static rag_rat_core::embedding_models::EmbeddingModelSpec {
+    spec.unwrap_or_else(|| {
+        rag_rat_core::embedding_models::spec(rag_rat_core::embedding_models::FASTEMBED_MODEL_ID)
+            .expect("the fallback all-MiniLM spec is always registered")
+    })
 }
 
 /// Decide whether a `models install <model_id>` should use the configured `[llm.embedding.remote]`

--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -505,7 +505,20 @@ pub(crate) fn benchmark_embedding(
     let candidates: Vec<u32> = if args.candidates.is_empty() {
         rag_rat_core::index::ai::default_benchmark_candidates(cap)
     } else {
-        args.candidates.clone()
+        // Normalize explicit `--candidates`: clamp each to the effective range (the server +
+        // embedder cap concurrency at 1..=MAX, so a raw 1024 would measure the 512 cap
+        // while labeled 1024), then sort + dedupe — the sweep assumes ASCENDING candidates
+        // (it stops on the first over-allocation window). Without this, `--candidates
+        // 1024,1` could stop before the valid `1` row or mislabel a row after starting a
+        // paid box.
+        let mut c: Vec<u32> = args
+            .candidates
+            .iter()
+            .map(|&c| RemoteEmbeddingConfig::bounded_concurrency_value(c))
+            .collect();
+        c.sort_unstable();
+        c.dedup();
+        c
     };
 
     // Size the provisioned server for the HIGHEST fan-out the sweep will test: `concurrency` is
@@ -529,6 +542,17 @@ pub(crate) fn benchmark_embedding(
     };
     let budget_ms =
         args.budget_ms.unwrap_or_else(rag_rat_core::index::ai::default_benchmark_budget_ms);
+
+    // Reject a budget too small to measure ANY candidate BEFORE provisioning a paid box: the sweep
+    // floors each candidate at a ~1s slice and stops once <1s of the budget remains, so a tiny
+    // `--budget-ms` would provision + tear down a box while measuring zero rows.
+    let min_budget = rag_rat_core::index::ai::min_benchmark_budget_ms(candidates.len());
+    anyhow::ensure!(
+        budget_ms >= min_budget,
+        "--budget-ms {budget_ms} is too small to benchmark {} candidate(s): need at least \
+         {min_budget} ms (~1s per candidate). Raise --budget-ms or pass fewer --candidates.",
+        candidates.len(),
+    );
 
     // Registry model → trust `spec.dim`. Off-registry HF model → provision, measure the dim from
     // one probe embed, then benchmark. Either way the ProvisionedBox is kept bound for the
@@ -562,10 +586,13 @@ pub(crate) fn benchmark_embedding(
         budget_ms,
     );
 
-    // Peak = the highest measured texts/s row (informational; the benchmark reports every row and
-    // lets the reader compare). `None` only if no candidate was measured (empty ladder).
+    // Peak = the highest-throughput row among rows that actually measured something (`requests >
+    // 0`). If EVERY row failed (a reachable box but every probe errored — wrong `--model`, bad
+    // auth/path, dim mismatch), peak is `null`, not a misleading 0-TPS "result" a consumer
+    // would treat as a valid backend comparison.
     let peak = measured
         .iter()
+        .filter(|m| m.requests > 0)
         .max_by(|a, b| a.texts_per_second.total_cmp(&b.texts_per_second))
         .map(|m| serde_json::json!({ "concurrency": m.concurrency, "texts_per_second": m.texts_per_second }));
 

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -132,6 +132,8 @@ fn main() -> anyhow::Result<()> {
         },
         #[cfg(feature = "eval")]
         Cmd::Eval(args) => eval(&config, &args)?,
+        #[cfg(feature = "eval")]
+        Cmd::BenchmarkEmbedding(args) => benchmark_embedding(&config, &args)?,
         Cmd::Oracle(args) => oracle(&config, &args)?,
         Cmd::DumpConfig => dump_config(&config)?,
         Cmd::VersionCheck => version_check(&config)?,

--- a/crates/rag-rat-core/src/index/ai/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/mod.rs
@@ -54,7 +54,7 @@ pub(crate) use store::*;
 #[cfg(feature = "eval")]
 pub use throughput_tune::{
     MeasuredCandidate, benchmark_remote_concurrency, default_benchmark_budget_ms,
-    default_benchmark_candidates, measure_remote_dim,
+    default_benchmark_candidates, measure_remote_dim, min_benchmark_budget_ms,
 };
 
 use crate::index::now_ms;

--- a/crates/rag-rat-core/src/index/ai/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/mod.rs
@@ -18,6 +18,13 @@ pub use providers::FastEmbedEmbedder;
 pub use providers::MockEmbedder;
 #[cfg(feature = "model2vec")]
 pub use providers::Model2VecEmbedder;
+// EVAL-ONLY seam for the `rag-rat benchmark-embedding` subcommand (#346): the CLI (a separate
+// crate) provisions an ephemeral box (`provision_box_for_benchmark`, holding the
+// `ProvisionedBox` for teardown) and runs its OWN measured concurrency sweep
+// (`benchmark_remote_concurrency`), emitting every per-candidate `MeasuredCandidate`. No knee
+// selection, no tune-cache write — those stay on the reconcile path.
+#[cfg(feature = "eval")]
+pub use providers::provision_box_for_benchmark;
 pub(crate) use providers::{
     ChunkEmbedder, acquire_chunk_embedder, active_embedder, provision_and_build,
 };
@@ -44,6 +51,11 @@ use serde::Serialize;
 use sha2::{Digest, Sha256};
 pub(crate) use status::*;
 pub(crate) use store::*;
+#[cfg(feature = "eval")]
+pub use throughput_tune::{
+    MeasuredCandidate, benchmark_remote_concurrency, default_benchmark_budget_ms,
+    default_benchmark_candidates, measure_remote_dim,
+};
 
 use crate::index::now_ms;
 use crate::language::Language;

--- a/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
@@ -568,6 +568,25 @@ pub(crate) fn provision_and_build(
     provision_and_build_cancellable(remote, spec, || false, tune)
 }
 
+/// EVAL-ONLY (#346): provision an ephemeral cookbook box for `remote` + `spec` and hand the caller
+/// the live [`ProvisionedBox`] — the `pub` seam the `benchmark-embedding` subcommand uses. It calls
+/// [`provision_and_build`] with `tune = None` (the benchmark runs its OWN measured concurrency
+/// sweep via [`crate::index::ai::benchmark_remote_concurrency`]; it must NOT warm the reconcile
+/// tune cache), discards the built embedder (the benchmark builds its own per-candidate embedders
+/// against the box's `endpoint`/`auth_token`), and returns ONLY the box. The caller MUST keep the
+/// returned box bound for the whole sweep — its `Drop` is the teardown, so an early drop kills the
+/// server mid-benchmark. `TuneRequest` stays crate-private: this seam never names it (always
+/// `None`).
+#[cfg(feature = "eval")]
+pub fn provision_box_for_benchmark(
+    remote: &RemoteEmbeddingConfig,
+    spec: &EmbeddingModelSpec,
+) -> anyhow::Result<ProvisionedBox> {
+    let (_embedder, provisioned, _effective_remote, _knee) =
+        provision_and_build_cancellable(remote, spec, || false, None)?;
+    Ok(provisioned)
+}
+
 fn provision_and_build_cancellable(
     remote: &RemoteEmbeddingConfig,
     spec: &EmbeddingModelSpec,

--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -19,6 +19,11 @@ mod openai;
 use rusqlite::Connection;
 
 pub(crate) use self::cookbook::provision_and_build;
+// EVAL-ONLY `pub` seam (#346): the `benchmark-embedding` subcommand (a separate crate)
+// provisions an ephemeral box and runs its own measured sweep against it; re-exported `pub`
+// under `eval` so it reaches the CLI through `index::ai`.
+#[cfg(feature = "eval")]
+pub use self::cookbook::provision_box_for_benchmark;
 // `verify_ephemeral_remote` is the `pub` init-wizard seam (the CLI's Remote step calls it);
 // the underlying `provision_and_build` stays `pub(crate)`.
 pub use self::cookbook::{

--- a/crates/rag-rat-core/src/index/ai/providers/openai.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/openai.rs
@@ -373,6 +373,69 @@ impl OpenAiEmbedder {
             texts,
         )
     }
+
+    /// EVAL-ONLY (#346): embed a single probe text and return the server's response vector LENGTH,
+    /// WITHOUT enforcing the dim-parity contract. The `benchmark-embedding` CLI uses this to learn
+    /// the dimension of an OFF-REGISTRY HF model (no registry `spec.dim` to check against) before
+    /// the throughput sweep. It calls the shared request path with `dim = observed` — i.e. it
+    /// reads the first vector's length and validates against ITSELF, so no mismatch is
+    /// possible; the point is to LEARN the dim, not enforce a known one.
+    #[cfg(feature = "eval")]
+    pub(crate) fn probe_dim(&self) -> anyhow::Result<usize> {
+        let probe = ["rag-rat benchmark dim probe".to_string()];
+        // Two-phase: send the request with the dim guard DISABLED (a sentinel `0` never equals a
+        // real vector width, so `embed_one_request_with` would reject it — instead we read
+        // the raw length directly here via a guard-free variant).
+        let vectors = Self::embed_first_vector_unchecked(
+            self.agent.clone(),
+            &self.embed_url,
+            &self.server_model,
+            self.auth_header.as_deref(),
+            &probe,
+        )?;
+        vectors.first().map(Vec::len).ok_or_else(|| anyhow::anyhow!("dim probe returned no vector"))
+    }
+
+    /// EVAL-ONLY (#346): the request + parse of [`Self::embed_one_request_with`] WITHOUT the
+    /// per-vector dim-parity check — the guard-free path [`Self::probe_dim`] uses to LEARN an
+    /// off-registry model's dim. Enforces the count contract still (one embedding per input), just
+    /// not the dim (there is no known dim to enforce yet).
+    #[cfg(feature = "eval")]
+    fn embed_first_vector_unchecked(
+        agent: ureq::Agent,
+        embed_url: &str,
+        server_model: &str,
+        auth_header: Option<&str>,
+        texts: &[String],
+    ) -> anyhow::Result<Vec<Vec<f32>>> {
+        let payload = EmbedRequest { model: server_model, input: texts, encoding_format: "float" };
+        let body = serde_json::to_vec(&payload)
+            .map_err(|e| anyhow::anyhow!("failed to serialize embed request: {e}"))?;
+        let mut request = agent.post(embed_url).content_type("application/json");
+        if let Some(header) = auth_header {
+            request = request.header("Authorization", header);
+        }
+        let mut response = request
+            .send(body)
+            .map_err(|e| anyhow::anyhow!("dim probe request to `{embed_url}` failed: {e}"))?;
+        let status = response.status();
+        let raw = response
+            .body_mut()
+            .read_to_string()
+            .map_err(|e| anyhow::anyhow!("reading dim probe response failed: {e}"))?;
+        if !status.is_success() {
+            let detail = serde_json::from_str::<ErrorResponse>(&raw)
+                .map(|e| e.error.message)
+                .unwrap_or_else(|_| response_excerpt(&raw));
+            anyhow::bail!(
+                "dim probe request to `{embed_url}` failed: http status {}: {detail}",
+                status.as_u16(),
+            );
+        }
+        let parsed: EmbedResponse = serde_json::from_str(&raw)
+            .map_err(|e| anyhow::anyhow!("malformed dim probe response: {e}"))?;
+        Ok(parsed.data.into_iter().map(|item| item.embedding).collect())
+    }
 }
 
 fn response_excerpt(body: &str) -> String {

--- a/crates/rag-rat-core/src/index/ai/throughput_tune.rs
+++ b/crates/rag-rat-core/src/index/ai/throughput_tune.rs
@@ -329,12 +329,13 @@ pub fn default_benchmark_budget_ms() -> u64 {
 
 /// EVAL-ONLY (#346): the smallest `--budget-ms` that lets `measure_candidates` actually measure
 /// every candidate. `per_candidate_ms` floors at 1000ms and the sweep stops once <1s of the budget
-/// remains, so a budget below `1s × candidates` (never under the tuner's `MIN_TUNE_BUDGET_MS`)
-/// provisions a box and then measures ZERO rows. The CLI validates against this BEFORE provisioning
-/// so a too-small `--budget-ms` never silently burns a box.
+/// remains, so a budget of exactly `1s × candidates` loses the LAST row to loop/request overhead.
+/// Require ONE extra 1s slice of slack (`(candidates + 1) × 1s`, never under the tuner's
+/// `MIN_TUNE_BUDGET_MS`). The CLI validates against this BEFORE provisioning so a too-small
+/// `--budget-ms` never burns a box for a partial (or empty) sweep.
 #[cfg(feature = "eval")]
 pub fn min_benchmark_budget_ms(num_candidates: usize) -> u64 {
-    (num_candidates.max(1) as u64 * 1_000).max(MIN_TUNE_BUDGET_MS)
+    ((num_candidates.max(1) as u64 + 1) * 1_000).max(MIN_TUNE_BUDGET_MS)
 }
 
 /// Whether a client-concurrency sweep is worth running for THIS reconcile — only when the live run
@@ -998,12 +999,13 @@ mod tests {
     #[cfg(feature = "eval")]
     #[test]
     fn min_benchmark_budget_scales_with_candidates_but_floors_at_the_tuner_min() {
-        // ~1s per candidate, never below MIN_TUNE_BUDGET_MS (the sweep stops when <1s of the budget
-        // remains, so a smaller budget provisions a box and measures ZERO rows).
-        assert_eq!(min_benchmark_budget_ms(0), MIN_TUNE_BUDGET_MS);
-        assert_eq!(min_benchmark_budget_ms(1), MIN_TUNE_BUDGET_MS);
-        assert_eq!(min_benchmark_budget_ms(5), MIN_TUNE_BUDGET_MS); // 5 * 1000 == the 5000 floor
-        assert_eq!(min_benchmark_budget_ms(9), 9_000); // above the floor → 1s per candidate
+        // (candidates + 1) * 1s of slack (the extra slice covers loop/request overhead so the LAST
+        // candidate isn't skipped), never below MIN_TUNE_BUDGET_MS.
+        assert_eq!(min_benchmark_budget_ms(0), MIN_TUNE_BUDGET_MS); // (1+1)*1000=2000 → floor 5000
+        assert_eq!(min_benchmark_budget_ms(1), MIN_TUNE_BUDGET_MS); // (1+1)*1000=2000 → floor
+        assert_eq!(min_benchmark_budget_ms(4), MIN_TUNE_BUDGET_MS); // (4+1)*1000=5000 == the floor
+        assert_eq!(min_benchmark_budget_ms(5), 6_000); // (5+1)*1000, above the floor + slack
+        assert_eq!(min_benchmark_budget_ms(9), 10_000); // (9+1)*1000
     }
 
     #[cfg(feature = "eval")]

--- a/crates/rag-rat-core/src/index/ai/throughput_tune.rs
+++ b/crates/rag-rat-core/src/index/ai/throughput_tune.rs
@@ -327,6 +327,16 @@ pub fn default_benchmark_budget_ms() -> u64 {
     DEFAULT_TUNE_BUDGET_MS
 }
 
+/// EVAL-ONLY (#346): the smallest `--budget-ms` that lets `measure_candidates` actually measure
+/// every candidate. `per_candidate_ms` floors at 1000ms and the sweep stops once <1s of the budget
+/// remains, so a budget below `1s × candidates` (never under the tuner's `MIN_TUNE_BUDGET_MS`)
+/// provisions a box and then measures ZERO rows. The CLI validates against this BEFORE provisioning
+/// so a too-small `--budget-ms` never silently burns a box.
+#[cfg(feature = "eval")]
+pub fn min_benchmark_budget_ms(num_candidates: usize) -> u64 {
+    (num_candidates.max(1) as u64 * 1_000).max(MIN_TUNE_BUDGET_MS)
+}
+
 /// Whether a client-concurrency sweep is worth running for THIS reconcile — only when the live run
 /// can actually fan out. Skip when:
 /// - `max_seconds` is set — a bounded `--max-seconds`/maintenance pass is NOT widened
@@ -983,6 +993,17 @@ mod tests {
         // Low fan-outs served; high ones tripped the breaker (aborted) but are STILL reported.
         assert!(results[0].requests > 0 && !results[0].aborted, "c=1 served");
         assert!(results[3].aborted, "c=8 (> fail_above 2) breaker-tripped, but row is present");
+    }
+
+    #[cfg(feature = "eval")]
+    #[test]
+    fn min_benchmark_budget_scales_with_candidates_but_floors_at_the_tuner_min() {
+        // ~1s per candidate, never below MIN_TUNE_BUDGET_MS (the sweep stops when <1s of the budget
+        // remains, so a smaller budget provisions a box and measures ZERO rows).
+        assert_eq!(min_benchmark_budget_ms(0), MIN_TUNE_BUDGET_MS);
+        assert_eq!(min_benchmark_budget_ms(1), MIN_TUNE_BUDGET_MS);
+        assert_eq!(min_benchmark_budget_ms(5), MIN_TUNE_BUDGET_MS); // 5 * 1000 == the 5000 floor
+        assert_eq!(min_benchmark_budget_ms(9), 9_000); // above the floor → 1s per candidate
     }
 
     #[cfg(feature = "eval")]

--- a/crates/rag-rat-core/src/index/ai/throughput_tune.rs
+++ b/crates/rag-rat-core/src/index/ai/throughput_tune.rs
@@ -192,6 +192,141 @@ pub(crate) fn tune_remote_concurrency(
     }
 }
 
+/// One measured concurrency candidate from [`benchmark_remote_concurrency`] — the eval-gated,
+/// machine-readable analogue of a [`SweepResult`], carrying the full per-candidate throughput row
+/// (NOT a single knee) so the `benchmark-embedding` CLI can compare backends/concurrencies (#346).
+#[cfg(feature = "eval")]
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct MeasuredCandidate {
+    /// The client fan-out (in-flight `/v1/embeddings` requests) measured for this row.
+    pub concurrency: u32,
+    /// Texts embedded per second at this concurrency (raw, un-penalized — the benchmark reports
+    /// the measured number and lets the caller compare; it does NOT run the knee's failure
+    /// penalty).
+    pub texts_per_second: f64,
+    /// Successful probe requests during this candidate's budget slice.
+    pub requests: u64,
+    /// Failed probe requests during this candidate's budget slice.
+    pub failures: u64,
+    /// Whether the failure breaker tripped (this fan-out was unstable — informational for the
+    /// benchmark, which reports it rather than dropping the row like `select_knee` does).
+    pub aborted: bool,
+}
+
+/// EVAL-ONLY (#346): benchmark a provisioned box at every concurrency candidate and return the FULL
+/// per-candidate throughput table — no knee selection, no caching. The measured counterpart to
+/// [`tune_remote_concurrency`]: it builds the probe params + per-candidate `build` closure the SAME
+/// way (so each probe request matches a live reconcile request's weight), runs the shared
+/// [`measure_candidates`] loop, and maps every [`SweepResult`] to a [`MeasuredCandidate`]. The
+/// caller owns the [`crate::index::ai::ProvisionedBox`] (keep it alive for the whole call — the
+/// embedders only hold the endpoint URL). `endpoint`/`auth_token` come from the cookbook handshake.
+///
+/// Takes `selected_model_id` + `dim` DIRECTLY rather than an [`EmbeddingModelSpec`]: an
+/// off-registry HF model (`--model` naming something with no registry row) has no `spec`, and the
+/// CLI supplies a MEASURED dim (one probe embed) for that case — an `EmbeddingModelSpec`'s
+/// `'static` fields can't carry a runtime-chosen model id/dim. For a registry model the caller
+/// passes `spec.model_id` / `spec.dim`.
+#[cfg(feature = "eval")]
+#[allow(clippy::too_many_arguments)]
+pub fn benchmark_remote_concurrency(
+    endpoint: &str,
+    auth_token: Option<&str>,
+    remote: &RemoteEmbeddingConfig,
+    selected_model_id: &str,
+    dim: usize,
+    max_embedding_chars: usize,
+    candidates: &[u32],
+    budget_ms: u64,
+) -> Vec<MeasuredCandidate> {
+    // Mirror `tune_remote_concurrency`'s probe construction so a benchmarked candidate embeds the
+    // SAME per-request weight the live reconcile would: `batch_size` normalized to >=1 like the
+    // embedder, probe texts sized to the live chunk cap, request texts split by BOTH the count and
+    // char budgets.
+    let batch_size = remote.batch_size.max(1);
+    let per_text_chars = probe_text_chars(max_embedding_chars);
+    let request_texts =
+        effective_request_texts(batch_size, remote.max_batch_chars, max_embedding_chars);
+    let build = |concurrency: u32, request_timeout_s: u64| -> OpenAiEmbedder {
+        OpenAiEmbedder::from_provisioned(ProvisionedEmbedderParams {
+            endpoint,
+            embed_path: remote.backend.embed_path(),
+            auth_token,
+            server_model: remote.model.trim(),
+            selected_model_id,
+            dim,
+            request_timeout_s,
+            batch_size,
+            concurrency,
+            max_batch_chars: remote.max_batch_chars,
+        })
+    };
+    measure_candidates(MeasureParams {
+        candidates: candidates.to_vec(),
+        per_text_chars,
+        request_texts,
+        request_timeout_s: remote.request_timeout_s,
+        budget_ms,
+        build,
+    })
+    .into_iter()
+    .map(|r| MeasuredCandidate {
+        concurrency: r.candidate,
+        texts_per_second: r.texts_per_second,
+        requests: r.requests,
+        failures: r.failures,
+        aborted: r.aborted,
+    })
+    .collect()
+}
+
+/// EVAL-ONLY (#346): measure the embedding DIMENSION a provisioned box serves for `remote.model`,
+/// by embedding a single probe text and returning the response vector's length. Used by the
+/// `benchmark-embedding` CLI for an OFF-REGISTRY HF model (`--model` with no registry spec): there
+/// is no `spec.dim` to trust, so the dim comes from the server's first response. The probe goes
+/// through [`OpenAiEmbedder::probe_dim`], which reads the raw response length WITHOUT the
+/// dim-parity guard (the guard needs a known dim, which is exactly what we don't have yet). Errors
+/// if the probe embed fails or returns no vector.
+#[cfg(feature = "eval")]
+pub fn measure_remote_dim(
+    endpoint: &str,
+    auth_token: Option<&str>,
+    remote: &RemoteEmbeddingConfig,
+) -> anyhow::Result<usize> {
+    let embedder = OpenAiEmbedder::from_provisioned(ProvisionedEmbedderParams {
+        endpoint,
+        embed_path: remote.backend.embed_path(),
+        auth_token,
+        server_model: remote.model.trim(),
+        selected_model_id: remote.model.trim(),
+        // A placeholder dim: `probe_dim` never checks against it (it reads the true length off the
+        // response), so any non-zero value is fine.
+        dim: 1,
+        request_timeout_s: remote.request_timeout_s,
+        batch_size: remote.batch_size.max(1),
+        concurrency: 1,
+        max_batch_chars: remote.max_batch_chars,
+    });
+    embedder
+        .probe_dim()
+        .map_err(|err| anyhow::anyhow!("dim probe failed for `{}`: {err}", remote.model))
+}
+
+/// EVAL-ONLY (#346): the default concurrency ladder the `benchmark-embedding` CLI sweeps when
+/// `--candidates` is omitted — the SAME powers-of-two-plus-exact-cap list the auto-tuner uses, so a
+/// benchmark with no explicit list mirrors what a real reconcile would tune over. Exposed so the
+/// CLI need not duplicate the ladder logic.
+#[cfg(feature = "eval")]
+pub fn default_benchmark_candidates(cap: u32) -> Vec<u32> {
+    sweep_candidates(cap)
+}
+
+/// EVAL-ONLY (#346): the auto-tuner's default sweep budget (ms), so the `benchmark-embedding` CLI
+/// defaults `--budget-ms` to the same value a real reconcile tune would use.
+#[cfg(feature = "eval")]
+pub fn default_benchmark_budget_ms() -> u64 {
+    DEFAULT_TUNE_BUDGET_MS
+}
+
 /// Whether a client-concurrency sweep is worth running for THIS reconcile — only when the live run
 /// can actually fan out. Skip when:
 /// - `max_seconds` is set — a bounded `--max-seconds`/maintenance pass is NOT widened
@@ -234,29 +369,42 @@ fn effective_request_texts(
     by_count.min(by_chars as u32)
 }
 
-/// GENERIC sweep engine (backend-agnostic): measure texts/s at each `candidate` (built via `build`)
-/// against a representative workload, then pick the knee via [`select_knee`]. `build(concurrency,
-/// request_timeout_s)` gets a per-request HTTP timeout bounded by the tune budget so no single
-/// probe can hold the box past the budget.
-fn run_sweep<E: Embedder>(
+/// Inputs to the per-candidate MEASUREMENT loop ([`measure_candidates`]) — the workload shape and
+/// the per-candidate embedder builder, grouped so both the auto-tuner ([`run_sweep`]) and the
+/// eval-gated benchmark ([`benchmark_remote_concurrency`]) drive the SAME loop with one struct.
+struct MeasureParams<E: Embedder, F: Fn(u32, u64) -> E> {
     candidates: Vec<u32>,
-    cap: u32,
     per_text_chars: usize,
     request_texts: u32,
     request_timeout_s: u64,
     budget_ms: u64,
-    build: impl Fn(u32, u64) -> E,
-) -> SweepOutcome {
-    if budget_ms < MIN_TUNE_BUDGET_MS {
-        return SweepOutcome::NotRun;
-    }
+    build: F,
+}
+
+/// The per-candidate MEASUREMENT loop, extracted from [`run_sweep`] so the eval-gated
+/// [`benchmark_remote_concurrency`] can reuse it and emit EVERY measured row (no knee selection).
+/// Measures texts/s for each `candidate` (built via `build`) against a representative workload,
+/// returning one [`SweepResult`] per ATTEMPTED candidate. Candidates are ascending; the loop stops
+/// early on the overall budget deadline or the first over-allocation window (every higher candidate
+/// would over-allocate too), so a short/allocation-bounded run returns FEWER rows than candidates —
+/// which is exactly how [`run_sweep`] detects an incomplete (non-cacheable) sweep. This function
+/// owns NONE of the selection/caching/breaker/knee policy — it only measures.
+fn measure_candidates<E: Embedder>(
+    params: MeasureParams<E, impl Fn(u32, u64) -> E>,
+) -> Vec<SweepResult> {
+    let MeasureParams {
+        candidates,
+        per_text_chars,
+        request_texts,
+        request_timeout_s,
+        budget_ms,
+        build,
+    } = params;
     let per_candidate_ms = (budget_ms / candidates.len().max(1) as u64).max(1_000);
     // Bound each blocking probe by its budget slice: a short RAG_RAT_TUNE_MS with a long configured
     // request_timeout_s must not let one probe hold the paid box for the full HTTP timeout.
     let probe_timeout = probe_timeout_s(request_timeout_s, per_candidate_ms);
     let deadline = Instant::now() + std::time::Duration::from_millis(budget_ms);
-    let total_candidates = candidates.len();
-    let mut attempted = 0usize;
     let mut results: Vec<SweepResult> = Vec::new();
     for candidate in candidates {
         if deadline.saturating_duration_since(Instant::now()).as_millis() < 1_000 {
@@ -273,7 +421,6 @@ fn run_sweep<E: Embedder>(
         if window.saturating_mul(per_text_chars) > MAX_PROBE_WINDOW_BYTES {
             break;
         }
-        attempted += 1;
         let embedder = build(candidate, probe_timeout);
         let texts = probe_texts(window, per_text_chars);
         let candidate_deadline =
@@ -305,6 +452,39 @@ fn run_sweep<E: Embedder>(
             aborted: failures > u64::from(candidate) * 2,
         });
     }
+    results
+}
+
+/// GENERIC sweep engine (backend-agnostic): measure texts/s at each `candidate` (built via `build`)
+/// against a representative workload, then pick the knee via [`select_knee`]. `build(concurrency,
+/// request_timeout_s)` gets a per-request HTTP timeout bounded by the tune budget so no single
+/// probe can hold the box past the budget.
+fn run_sweep<E: Embedder>(
+    candidates: Vec<u32>,
+    cap: u32,
+    per_text_chars: usize,
+    request_texts: u32,
+    request_timeout_s: u64,
+    budget_ms: u64,
+    build: impl Fn(u32, u64) -> E,
+) -> SweepOutcome {
+    if budget_ms < MIN_TUNE_BUDGET_MS {
+        return SweepOutcome::NotRun;
+    }
+    let total_candidates = candidates.len();
+    let results = measure_candidates(MeasureParams {
+        candidates,
+        per_text_chars,
+        request_texts,
+        request_timeout_s,
+        budget_ms,
+        build,
+    });
+    // Every attempted candidate pushes exactly one result (nothing between `attempted += 1` and the
+    // push in the loop short-circuits), so the measured-row count IS the attempt count — the gate
+    // `select_knee`'s caller uses to decide `complete` (a budget-truncated / allocation-skipped
+    // sweep left fewer rows than candidates).
+    let attempted = results.len();
 
     let outcome = match select_knee(&results, cap) {
         // `complete` gates caching: a budget-truncated sweep (didn't attempt every candidate) is
@@ -781,6 +961,70 @@ mod tests {
             },
             other => panic!("expected a Knee, got {other:?}"),
         }
+    }
+
+    #[cfg(feature = "eval")]
+    #[test]
+    fn measure_candidates_returns_a_row_per_attempted_candidate_not_just_a_knee() {
+        // The benchmark path measures EVERY candidate (no knee selection). With a stub embedder
+        // that fails above concurrency 2, every candidate is still ATTEMPTED and returns a
+        // row — the high fan-outs simply come back `aborted` (breaker tripped), rather than
+        // being dropped the way `select_knee` drops them.
+        let results = measure_candidates(MeasureParams {
+            candidates: vec![1, 2, 4, 8],
+            per_text_chars: 16,
+            request_texts: 4,
+            request_timeout_s: 1,
+            budget_ms: MIN_TUNE_BUDGET_MS,
+            build: |concurrency, _timeout| FakeEmbedder { concurrency, fail_above: 2 },
+        });
+        // One row per candidate, in ascending order — the whole table, not a single winner.
+        assert_eq!(results.iter().map(|r| r.candidate).collect::<Vec<_>>(), vec![1, 2, 4, 8]);
+        // Low fan-outs served; high ones tripped the breaker (aborted) but are STILL reported.
+        assert!(results[0].requests > 0 && !results[0].aborted, "c=1 served");
+        assert!(results[3].aborted, "c=8 (> fail_above 2) breaker-tripped, but row is present");
+    }
+
+    #[cfg(feature = "eval")]
+    #[test]
+    fn benchmark_maps_sweep_rows_to_measured_candidates_one_to_one() {
+        // `benchmark_remote_concurrency` builds real OpenAiEmbedders against an UNREACHABLE
+        // endpoint, so every probe fails fast (connection refused) — but the mapping
+        // contract still holds: one `MeasuredCandidate` per requested candidate, in order,
+        // each carrying the per-candidate counters (here: all failures, no successes). We
+        // assert the SHAPE (per-candidate rows), not throughput.
+        let remote = tune_remote(4);
+        let spec =
+            crate::embedding_models::spec(crate::embedding_models::FASTEMBED_MODEL_ID).unwrap();
+        let candidates = [1u32, 2, 4];
+        let measured = benchmark_remote_concurrency(
+            "http://127.0.0.1:1",
+            None,
+            &remote,
+            spec.model_id,
+            spec.dim,
+            4_000,
+            &candidates,
+            MIN_TUNE_BUDGET_MS,
+        );
+        assert_eq!(
+            measured.iter().map(|m| m.concurrency).collect::<Vec<_>>(),
+            candidates.to_vec(),
+            "every requested candidate maps to exactly one measured row, in order"
+        );
+        for m in &measured {
+            // Unreachable endpoint → no successful request; the row still reports its counters.
+            assert_eq!(m.requests, 0, "no successful request against a closed port");
+            assert!(m.failures > 0, "the closed port produced probe failures");
+        }
+    }
+
+    #[cfg(feature = "eval")]
+    #[test]
+    fn default_benchmark_candidates_matches_the_sweep_ladder() {
+        // The no-`--candidates` default is the SAME ladder the auto-tuner sweeps.
+        assert_eq!(default_benchmark_candidates(32), sweep_candidates(32));
+        assert_eq!(default_benchmark_candidates(24), vec![1, 2, 4, 8, 16, 24]);
     }
 
     fn tune_remote(cap: u32) -> RemoteEmbeddingConfig {


### PR DESCRIPTION
Phase 3 of the switchable-embedding-backends work (#347). A `rag-rat benchmark-embedding` subcommand — gated behind the `eval` cargo feature, same posture as `rag-rat eval` — that provisions an ephemeral box, runs the throughput sweep, and emits **per-candidate texts/s as JSON**, then tears the box down. Lets backends (ollama/infinity/vLLM) and concurrency levels be compared with machine-readable output.

## Changes

- **`throughput_tune.rs`** — extracted the per-candidate *measurement loop* from `run_sweep` into `measure_candidates()`. `run_sweep` is otherwise **byte-identical**: the `NotRun` budget guard, `select_knee`, the `complete`/caching gate, the `failures > candidate×2` breaker, the 256 MB window-skip, and the `RAG_RAT_TUNE_LOG` output are all unchanged, and its tests pass verbatim. Added eval-gated `MeasuredCandidate` + `benchmark_remote_concurrency()` (returns *every* candidate, no knee selection, no cache) + `measure_remote_dim()` for off-registry HF models.
- **`cookbook.rs`** — eval-gated `provision_box_for_benchmark()` wraps `provision_and_build(.., None)` so the benchmark holds a live box without exposing `TuneRequest`.
- **CLI** — eval-gated `benchmark-embedding` subcommand: `--cookbook`, `--backend`, `--model`, `--gpu`, `--candidates` (default = the sweep ladder for the cap), `--budget-ms`, `--output`. Builds an ephemeral config, provisions, sweeps, emits JSON, box torn down on scope exit.

## JSON shape
```json
{ "backend": "infinity", "model": "...", "cookbook": "...", "gpu": "L4", "dim": 384,
  "budget_ms": 60000,
  "candidates": [ { "concurrency": 1, "texts_per_second": 246.0, "requests": 28, "failures": 0, "aborted": false }, ... ],
  "peak": { "concurrency": 512, "texts_per_second": 1616.0 } }
```

## Verification
Compiles clean in **both** builds (`--all-targets` and `--all-targets --features eval`); tuner tests 16 (default) / 19 (eval); `nextest -p rag-rat` 236 / 239 (eval); full core-eval 1079 — all green. New tests cover `measure_candidates` returning a row per candidate (not just a knee), the sweep→`MeasuredCandidate` mapping, and arg parsing.

Follow-up (not in this PR): the live per-backend benchmark run. `RAG_RAT_TUNE_LOG` already produced the equivalent numbers during #350 (infinity ~1517 > vLLM ~1029 > ollama ~299 @ their knees on L4); this gives the same data as structured JSON on demand.

Fixes #346.