### PR TITLE
feat(embed): embed light/incremental reconciles against the local query_endpoint

### DIFF
--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -126,7 +126,10 @@ pub(crate) enum ChunkEmbedder {
         provisioned: Option<ProvisionedBox>,
         remote: Option<Box<RemoteEmbeddingConfig>>,
     },
-    /// Ephemeral active model on a non-provisioning pass — skip remote chunk embedding entirely.
+    /// Ephemeral active model on a non-provisioning pass WITH NO local `query_endpoint` server —
+    /// defer incremental embedding to an explicit provisioning `rag-rat reconcile`. When a
+    /// `query_endpoint` IS set, the light path embeds locally against it instead (returns `Ready`
+    /// with `provisioned: None`) — see [`acquire_chunk_embedder`].
     SkipEphemeral,
     /// Ephemeral active model on a PROVISIONING reconcile, but there is NOTHING to embed (the model
     /// is already current). We return this INSTEAD of provisioning so a no-op `rag-rat reconcile`
@@ -141,10 +144,13 @@ pub(crate) enum ChunkEmbedder {
 /// Acquire the CHUNK-embed embedder for a reconcile. EPHEMERAL active model: on a provisioning
 /// reconcile, FIRST check for pending candidate chunks — if none, `NoEphemeralWork` (never
 /// provision a paid box for zero work, #330-6); otherwise provision the cookbook box + build an
-/// embedder against it (the bulk path, `provision_and_build`). On a non-provisioning pass
-/// (watcher), `SkipEphemeral`. CONNECT/local: the usual `active_embedder`. Provisioning happens
-/// ONCE here, not per batch. `provision_remote` gates the cold-start (only an explicit `rag-rat
-/// reconcile` sets it); `scan`/`options` size the pending-work check exactly like the embed loop.
+/// embedder against it (the bulk path, `provision_and_build`). On a non-provisioning pass (watcher
+/// / maintenance): embed the changed chunks LOCALLY against `query_endpoint` if one is set (the
+/// light/incremental path — no cold-start, same vector space as the box), gated by the cheap
+/// pending-work check (`NoEphemeralWork` when idle); `SkipEphemeral` only when there is no local
+/// query server. CONNECT/local: the usual `active_embedder`. Provisioning happens ONCE here, not
+/// per batch. `provision_remote` gates the cold-start (only an explicit `rag-rat reconcile` sets
+/// it); `scan`/`options` size the pending-work check exactly like the embed loop.
 pub(crate) fn acquire_chunk_embedder(
     conn: &Connection,
     intra_threads: Option<usize>,
@@ -157,7 +163,36 @@ pub(crate) fn acquire_chunk_embedder(
     };
     if let Some(remote) = remote.as_ref().filter(|r| r.is_ephemeral()) {
         if !options.provision_remote {
-            return ChunkEmbedder::SkipEphemeral;
+            // LIGHT / incremental pass (watcher, maintenance): NEVER cold-start a paid box. If a
+            // local `query_endpoint` server is configured, embed the changed chunks against IT —
+            // the same backend + model the cookbook box uses, so the vectors share ONE
+            // space (freshness is endpoint-independent) and semantic search stays
+            // current between big reindexes. Without a local server, defer to an
+            // explicit provisioning `rag-rat reconcile` as before.
+            if remote.query_endpoint.is_none() {
+                return ChunkEmbedder::SkipEphemeral;
+            }
+            // Cheap pending-work gate BEFORE the O(repo) policy summary (mirrors the provision path
+            // below): an idle watcher pass stays cheap (`NoEphemeralWork`), and only a pass with
+            // real work pays the summary + walks the local embed loop. A count error is
+            // non-fatal — fall through and let the embed loop try rather than wedge
+            // incremental embedding on a transient DB hiccup.
+            if let Ok(0) = estimated_reconcile_jobs(conn, scan, options) {
+                return ChunkEmbedder::NoEphemeralWork;
+            }
+            // `active_embedder` builds the CONNECT-shaped embedder against `query_endpoint` (the
+            // exact embedder queries use) — no provisioning, no box. On a construction
+            // error, defer rather than fail the pass. `remote` is `query_embed_config`
+            // (connect-shaped, local endpoint) for window sizing, matching the
+            // `active_embedder` transport.
+            return match active_embedder(conn, intra_threads) {
+                Ok(embedder) => ChunkEmbedder::Ready {
+                    embedder,
+                    provisioned: None,
+                    remote: Some(Box::new(query_embed_config(remote))),
+                },
+                Err(_) => ChunkEmbedder::SkipEphemeral,
+            };
         }
         // BEFORE provisioning a paid box, confirm there's actually work to do. An explicit
         // `rag-rat reconcile` on an already-current ephemeral model would otherwise cold-start +

--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -113,14 +113,26 @@ fn query_embed_config(remote: &RemoteEmbeddingConfig) -> RemoteEmbeddingConfig {
     }
 }
 
+/// Per-request timeout ceiling for the LIGHT (local `query_endpoint`) path — bounds both the route
+/// probe and each single-flight incremental embed so a slow/hung local server can't stall a watcher
+/// pass. The provisioned-box path is unaffected (it keeps the configured timeout).
+const LIGHT_REQUEST_TIMEOUT_S: u64 = 30;
+
 /// The remote config for a LIGHT (watcher / incremental) embed against the local `query_endpoint`:
 /// `query_embed_config` (connect-shaped, local endpoint, backend preserved) but clamped to
-/// SINGLE-FLIGHT concurrency. The query server is a user's local box that may not have been
-/// launched with the cookbook's parallelism, so a background watcher edit must not fan out
-/// concurrent requests at it — connect endpoints are kept single-flight for the same reason. Only
-/// this local light path is clamped; the provisioned-box path keeps its tuned concurrency.
+/// SINGLE-FLIGHT concurrency and a SHORT request timeout. The query server is a user's local box
+/// that may not have been launched with the cookbook's parallelism, so a background watcher edit
+/// must not fan out concurrent requests at it (connect endpoints are single-flight for the same
+/// reason); the short timeout bounds the route probe + each incremental request so a slow/hung
+/// local server can't stall the watcher. Only this local light path is clamped; the provisioned-box
+/// path keeps its tuned concurrency + timeout.
 fn light_incremental_config(remote: &RemoteEmbeddingConfig) -> RemoteEmbeddingConfig {
-    RemoteEmbeddingConfig { concurrency: 1, ..query_embed_config(remote) }
+    let transport = query_embed_config(remote);
+    RemoteEmbeddingConfig {
+        concurrency: 1,
+        request_timeout_s: transport.request_timeout_s.min(LIGHT_REQUEST_TIMEOUT_S),
+        ..transport
+    }
 }
 
 /// Build the active model's embedder against a caller-supplied connect-shaped `transport` — used by
@@ -154,9 +166,11 @@ pub(crate) enum ChunkEmbedder {
         remote: Option<Box<RemoteEmbeddingConfig>>,
     },
     /// Ephemeral active model on a non-provisioning pass whose local `query_endpoint` is absent or
-    /// UNREACHABLE — defer incremental embedding to an explicit provisioning `rag-rat reconcile`.
-    /// When a `query_endpoint` IS set and answers, the light path embeds locally against it instead
-    /// (returns `Ready` with `provisioned: None`) — see [`acquire_chunk_embedder`].
+    /// fails a probe embed (down, a wrong service on the port, the model not pulled, a dim
+    /// mismatch) — defer incremental embedding to an explicit provisioning `rag-rat reconcile`.
+    /// When a `query_endpoint` IS set and a probe embed SUCCEEDS, the light path embeds locally
+    /// against it instead (returns `Ready` with `provisioned: None`) — see
+    /// [`acquire_chunk_embedder`].
     SkipEphemeral,
     /// Ephemeral active model on a PROVISIONING reconcile, but there is NOTHING to embed (the model
     /// is already current). We return this INSTEAD of provisioning so a no-op `rag-rat reconcile`
@@ -172,9 +186,9 @@ pub(crate) enum ChunkEmbedder {
 /// reconcile, FIRST check for pending candidate chunks — if none, `NoEphemeralWork` (never
 /// provision a paid box for zero work, #330-6); otherwise provision the cookbook box + build an
 /// embedder against it (the bulk path, `provision_and_build`). On a non-provisioning pass (watcher
-/// / maintenance): embed the changed chunks LOCALLY against `query_endpoint` when it is REACHABLE
-/// (the light/incremental path — no cold-start, single-flight, same vector space as the box);
-/// `SkipEphemeral` when there is no local query server or it doesn't answer. CONNECT/local: the
+/// / maintenance): embed the changed chunks LOCALLY against `query_endpoint` when a probe embed on
+/// it SUCCEEDS (the light/incremental path — no cold-start, single-flight, same vector space as the
+/// box); `SkipEphemeral` when there is no local query server or the probe fails. CONNECT/local: the
 /// usual `active_embedder`. Provisioning happens ONCE here, not per batch. `provision_remote` gates
 /// the cold-start (only an explicit `rag-rat reconcile` sets it); `scan`/`options` size the
 /// provision-path pending-work check.
@@ -191,37 +205,41 @@ pub(crate) fn acquire_chunk_embedder(
     if let Some(remote) = remote.as_ref().filter(|r| r.is_ephemeral()) {
         if !options.provision_remote {
             // LIGHT / incremental pass (watcher, maintenance): NEVER cold-start a paid box. Embed
-            // the changed chunks against the local `query_endpoint` — but ONLY when it is actually
-            // REACHABLE. The reachability probe is the gate:
-            //  - no `query_endpoint`, or one that doesn't answer → `SkipEphemeral` (defer to an
-            //    explicit provisioning reconcile). This keeps a watcher pass cheap for the common
-            //    no-local-server case (a refused connect returns at once, BEFORE any O(repo)
-            //    candidate scan) and avoids writing `Failed` chunk_embeddings against a down server
-            //    — the pre-existing immediate-defer behavior is preserved for those cases.
-            //  - reachable → embed locally at SINGLE-FLIGHT concurrency
-            //    (`light_incremental_config`), same backend + model as the box, so the vectors
-            //    share ONE space (freshness is endpoint-independent) and semantic search stays
-            //    current between big reindexes.
+            // the changed chunks against the local `query_endpoint` — but ONLY after PROVING the
+            // configured model can actually embed on it. Build the single-flight light embedder,
+            // then probe the real embeddings route with a tiny request:
+            //  - no `query_endpoint`, or the probe fails (server down, a DIFFERENT service on the
+            //    port, the model not pulled, a dim mismatch) → `SkipEphemeral` (defer to an
+            //    explicit provisioning reconcile). A refused connect returns at once, so the common
+            //    no-local-server pass stays cheap (BEFORE any O(repo) candidate scan), and a broken
+            //    or wrong endpoint never persists `Failed` chunk_embeddings — a bare TCP connect
+            //    would only prove SOMETHING listens, so the actual embed probe is what makes this
+            //    safe.
+            //  - probe OK → embed locally, same backend + model as the box, so the vectors share
+            //    ONE space (freshness is endpoint-independent) and semantic search stays current
+            //    between big reindexes.
             // NO work-count gate here on purpose: `estimated_reconcile_jobs` decompresses the whole
-            // repo, so it is NOT a cheap idle-pass guard — the reachability probe is. A reachable
+            // repo, so it is NOT a cheap idle-pass guard — the fast-failing probe is. A reachable
             // server's no-work pass then costs the same policy summary a connect-mode pass already
-            // pays.
-            let Some(query_endpoint) = remote.query_endpoint.as_deref() else {
-                return ChunkEmbedder::SkipEphemeral;
-            };
-            if !openai::endpoint_reachable(query_endpoint) {
+            // pays. The probe (and every light embed) is bounded by the transport's clamped
+            // timeout, so a hung server can't stall the watcher.
+            if remote.query_endpoint.is_none() {
                 return ChunkEmbedder::SkipEphemeral;
             }
             let transport = light_incremental_config(remote);
-            return match light_embedder(conn, intra_threads, &transport) {
-                Ok(embedder) => ChunkEmbedder::Ready {
-                    embedder,
-                    provisioned: None,
-                    remote: Some(Box::new(transport)),
-                },
+            let embedder = match light_embedder(conn, intra_threads, &transport) {
+                Ok(embedder) => embedder,
                 // Construction shouldn't fail for a Ready model, but on any error defer rather than
                 // fail the watcher pass.
-                Err(_) => ChunkEmbedder::SkipEphemeral,
+                Err(_) => return ChunkEmbedder::SkipEphemeral,
+            };
+            if embedder.embed_batch(&["ping".to_string()]).is_err() {
+                return ChunkEmbedder::SkipEphemeral;
+            }
+            return ChunkEmbedder::Ready {
+                embedder,
+                provisioned: None,
+                remote: Some(Box::new(transport)),
             };
         }
         // BEFORE provisioning a paid box, confirm there's actually work to do. An explicit

--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -113,6 +113,33 @@ fn query_embed_config(remote: &RemoteEmbeddingConfig) -> RemoteEmbeddingConfig {
     }
 }
 
+/// The remote config for a LIGHT (watcher / incremental) embed against the local `query_endpoint`:
+/// `query_embed_config` (connect-shaped, local endpoint, backend preserved) but clamped to
+/// SINGLE-FLIGHT concurrency. The query server is a user's local box that may not have been
+/// launched with the cookbook's parallelism, so a background watcher edit must not fan out
+/// concurrent requests at it — connect endpoints are kept single-flight for the same reason. Only
+/// this local light path is clamped; the provisioned-box path keeps its tuned concurrency.
+fn light_incremental_config(remote: &RemoteEmbeddingConfig) -> RemoteEmbeddingConfig {
+    RemoteEmbeddingConfig { concurrency: 1, ..query_embed_config(remote) }
+}
+
+/// Build the active model's embedder against a caller-supplied connect-shaped `transport` — used by
+/// the light path to point at the local `query_endpoint` at clamped concurrency. Like
+/// `active_embedder`, but the transport is the passed config, not `query_embed_config` of the
+/// persisted remote.
+fn light_embedder(
+    conn: &Connection,
+    intra_threads: Option<usize>,
+    transport: &RemoteEmbeddingConfig,
+) -> anyhow::Result<Box<dyn Embedder>> {
+    let model_id = active_embedding_model_id(conn)?;
+    let model = model(conn, &model_id)?;
+    validate_ready_model(&model)?;
+    let spec = spec(&model.model_id)
+        .ok_or_else(|| anyhow::anyhow!("unknown active embedding model `{}`", model.model_id))?;
+    embedder_for_spec(spec, intra_threads, Some(transport))
+}
+
 /// The outcome of acquiring the CHUNK-embed embedder for a reconcile. `Ready` carries the optional
 /// `ProvisionedBox` guard so the caller keeps it alive for the whole embed loop (its `Drop` is the
 /// box teardown). This is the ONE place that branches on `is_ephemeral()` for chunk embedding — the
@@ -126,10 +153,10 @@ pub(crate) enum ChunkEmbedder {
         provisioned: Option<ProvisionedBox>,
         remote: Option<Box<RemoteEmbeddingConfig>>,
     },
-    /// Ephemeral active model on a non-provisioning pass WITH NO local `query_endpoint` server —
-    /// defer incremental embedding to an explicit provisioning `rag-rat reconcile`. When a
-    /// `query_endpoint` IS set, the light path embeds locally against it instead (returns `Ready`
-    /// with `provisioned: None`) — see [`acquire_chunk_embedder`].
+    /// Ephemeral active model on a non-provisioning pass whose local `query_endpoint` is absent or
+    /// UNREACHABLE — defer incremental embedding to an explicit provisioning `rag-rat reconcile`.
+    /// When a `query_endpoint` IS set and answers, the light path embeds locally against it instead
+    /// (returns `Ready` with `provisioned: None`) — see [`acquire_chunk_embedder`].
     SkipEphemeral,
     /// Ephemeral active model on a PROVISIONING reconcile, but there is NOTHING to embed (the model
     /// is already current). We return this INSTEAD of provisioning so a no-op `rag-rat reconcile`
@@ -145,12 +172,12 @@ pub(crate) enum ChunkEmbedder {
 /// reconcile, FIRST check for pending candidate chunks — if none, `NoEphemeralWork` (never
 /// provision a paid box for zero work, #330-6); otherwise provision the cookbook box + build an
 /// embedder against it (the bulk path, `provision_and_build`). On a non-provisioning pass (watcher
-/// / maintenance): embed the changed chunks LOCALLY against `query_endpoint` if one is set (the
-/// light/incremental path — no cold-start, same vector space as the box), gated by the cheap
-/// pending-work check (`NoEphemeralWork` when idle); `SkipEphemeral` only when there is no local
-/// query server. CONNECT/local: the usual `active_embedder`. Provisioning happens ONCE here, not
-/// per batch. `provision_remote` gates the cold-start (only an explicit `rag-rat reconcile` sets
-/// it); `scan`/`options` size the pending-work check exactly like the embed loop.
+/// / maintenance): embed the changed chunks LOCALLY against `query_endpoint` when it is REACHABLE
+/// (the light/incremental path — no cold-start, single-flight, same vector space as the box);
+/// `SkipEphemeral` when there is no local query server or it doesn't answer. CONNECT/local: the
+/// usual `active_embedder`. Provisioning happens ONCE here, not per batch. `provision_remote` gates
+/// the cold-start (only an explicit `rag-rat reconcile` sets it); `scan`/`options` size the
+/// provision-path pending-work check.
 pub(crate) fn acquire_chunk_embedder(
     conn: &Connection,
     intra_threads: Option<usize>,
@@ -163,34 +190,37 @@ pub(crate) fn acquire_chunk_embedder(
     };
     if let Some(remote) = remote.as_ref().filter(|r| r.is_ephemeral()) {
         if !options.provision_remote {
-            // LIGHT / incremental pass (watcher, maintenance): NEVER cold-start a paid box. If a
-            // local `query_endpoint` server is configured, embed the changed chunks against IT —
-            // the same backend + model the cookbook box uses, so the vectors share ONE
-            // space (freshness is endpoint-independent) and semantic search stays
-            // current between big reindexes. Without a local server, defer to an
-            // explicit provisioning `rag-rat reconcile` as before.
-            if remote.query_endpoint.is_none() {
+            // LIGHT / incremental pass (watcher, maintenance): NEVER cold-start a paid box. Embed
+            // the changed chunks against the local `query_endpoint` — but ONLY when it is actually
+            // REACHABLE. The reachability probe is the gate:
+            //  - no `query_endpoint`, or one that doesn't answer → `SkipEphemeral` (defer to an
+            //    explicit provisioning reconcile). This keeps a watcher pass cheap for the common
+            //    no-local-server case (a refused connect returns at once, BEFORE any O(repo)
+            //    candidate scan) and avoids writing `Failed` chunk_embeddings against a down server
+            //    — the pre-existing immediate-defer behavior is preserved for those cases.
+            //  - reachable → embed locally at SINGLE-FLIGHT concurrency
+            //    (`light_incremental_config`), same backend + model as the box, so the vectors
+            //    share ONE space (freshness is endpoint-independent) and semantic search stays
+            //    current between big reindexes.
+            // NO work-count gate here on purpose: `estimated_reconcile_jobs` decompresses the whole
+            // repo, so it is NOT a cheap idle-pass guard — the reachability probe is. A reachable
+            // server's no-work pass then costs the same policy summary a connect-mode pass already
+            // pays.
+            let Some(query_endpoint) = remote.query_endpoint.as_deref() else {
+                return ChunkEmbedder::SkipEphemeral;
+            };
+            if !openai::endpoint_reachable(query_endpoint) {
                 return ChunkEmbedder::SkipEphemeral;
             }
-            // Cheap pending-work gate BEFORE the O(repo) policy summary (mirrors the provision path
-            // below): an idle watcher pass stays cheap (`NoEphemeralWork`), and only a pass with
-            // real work pays the summary + walks the local embed loop. A count error is
-            // non-fatal — fall through and let the embed loop try rather than wedge
-            // incremental embedding on a transient DB hiccup.
-            if let Ok(0) = estimated_reconcile_jobs(conn, scan, options) {
-                return ChunkEmbedder::NoEphemeralWork;
-            }
-            // `active_embedder` builds the CONNECT-shaped embedder against `query_endpoint` (the
-            // exact embedder queries use) — no provisioning, no box. On a construction
-            // error, defer rather than fail the pass. `remote` is `query_embed_config`
-            // (connect-shaped, local endpoint) for window sizing, matching the
-            // `active_embedder` transport.
-            return match active_embedder(conn, intra_threads) {
+            let transport = light_incremental_config(remote);
+            return match light_embedder(conn, intra_threads, &transport) {
                 Ok(embedder) => ChunkEmbedder::Ready {
                     embedder,
                     provisioned: None,
-                    remote: Some(Box::new(query_embed_config(remote))),
+                    remote: Some(Box::new(transport)),
                 },
+                // Construction shouldn't fail for a Ready model, but on any error defer rather than
+                // fail the watcher pass.
                 Err(_) => ChunkEmbedder::SkipEphemeral,
             };
         }

--- a/crates/rag-rat-core/src/index/ai/providers/openai.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/openai.rs
@@ -11,6 +11,7 @@
 //! missing-feature message. The cloneable `ureq::Agent` is held bare (no `Mutex`) and cloned into
 //! bounded blocking worker threads for remote request fan-out.
 
+use std::net::ToSocketAddrs;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -424,6 +425,51 @@ fn endpoint_is_loopback(endpoint: &str) -> bool {
         || host.starts_with("127.")
 }
 
+/// Best-effort reachability probe for a query/connect endpoint: resolve the URL's `host:port` and
+/// attempt a short TCP connect. GATES the ephemeral light-embed path — an unreachable local query
+/// server must DEFER (never embed-and-fail into `Failed` chunk_embeddings), and the fast refusal
+/// keeps a watcher/maintenance pass cheap when no local server is running (it returns before any
+/// O(repo) scan). A refused connection returns at once; only an unroutable host waits out the ~1s
+/// timeout. An endpoint we can't parse a `host:port` from is treated as unreachable.
+pub(crate) fn endpoint_reachable(endpoint: &str) -> bool {
+    let Some(host_port) = endpoint_host_port(endpoint) else {
+        return false;
+    };
+    host_port
+        .to_socket_addrs()
+        .map(|addrs| {
+            addrs.into_iter().any(|addr| {
+                std::net::TcpStream::connect_timeout(&addr, Duration::from_secs(1)).is_ok()
+            })
+        })
+        .unwrap_or(false)
+}
+
+/// Extract `host:port` from an endpoint URL for a socket connect, defaulting the port by scheme
+/// (`https` → 443, else 80) when the authority omits it. Mirrors the host parse in
+/// `endpoint_is_loopback` but keeps the port.
+fn endpoint_host_port(endpoint: &str) -> Option<String> {
+    let (scheme, after_scheme) =
+        endpoint.split_once("://").map_or(("http", endpoint), |(s, rest)| (s, rest));
+    let authority = after_scheme.split(['/', '?', '#']).next().unwrap_or(after_scheme);
+    let host_port = authority.rsplit('@').next().unwrap_or(authority).trim();
+    if host_port.is_empty() {
+        return None;
+    }
+    let has_port = match host_port.strip_prefix('[') {
+        // Bracketed IPv6 (`[::1]:8000`) has a port iff `]` is followed by `:`.
+        Some(rest) => rest.split_once(']').is_some_and(|(_, tail)| tail.starts_with(':')),
+        // Bare host / IPv4: exactly one `:` separates host and port.
+        None => host_port.matches(':').count() == 1,
+    };
+    if has_port {
+        Some(host_port.to_string())
+    } else {
+        let port = if scheme.eq_ignore_ascii_case("https") { 443 } else { 80 };
+        Some(format!("{host_port}:{port}"))
+    }
+}
+
 impl Embedder for OpenAiEmbedder {
     fn model_id(&self) -> &str {
         // The SELECTED model's registry id (e.g. `fastembed-all-minilm-l6-v2`), NOT the server-side
@@ -494,6 +540,49 @@ mod tests {
     const DIM: usize = 384;
     // The SELECTED model's registry id — what `model_id()` must return regardless of the runtime.
     const SELECTED_ID: &str = crate::embedding_models::FASTEMBED_MODEL_ID;
+
+    #[test]
+    fn endpoint_host_port_keeps_explicit_ports_and_defaults_by_scheme() {
+        // Explicit port preserved.
+        assert_eq!(endpoint_host_port("http://localhost:7997").as_deref(), Some("localhost:7997"));
+        assert_eq!(
+            endpoint_host_port("http://127.0.0.1:11434").as_deref(),
+            Some("127.0.0.1:11434")
+        );
+        // Bracketed IPv6 with a port.
+        assert_eq!(endpoint_host_port("http://[::1]:8000").as_deref(), Some("[::1]:8000"));
+        // No port → default by scheme.
+        assert_eq!(endpoint_host_port("http://example.com").as_deref(), Some("example.com:80"));
+        assert_eq!(endpoint_host_port("https://example.com").as_deref(), Some("example.com:443"));
+        // Userinfo stripped; trailing path ignored.
+        assert_eq!(
+            endpoint_host_port("http://user:pass@host:9000/v1").as_deref(),
+            Some("host:9000")
+        );
+    }
+
+    #[test]
+    fn endpoint_reachable_is_false_for_a_closed_port() {
+        // Bind then drop → the port refuses connections; the probe must return false FAST (a
+        // refusal returns immediately, it does not wait out the timeout).
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        assert!(!endpoint_reachable(&format!("http://127.0.0.1:{port}")));
+        assert!(!endpoint_reachable("not a url"));
+    }
+
+    #[test]
+    fn endpoint_reachable_is_true_for_a_live_listener() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handle = thread::spawn(move || {
+            // Accept one connection (the probe) so the listener stays bound for the check.
+            let _ = listener.accept();
+        });
+        assert!(endpoint_reachable(&format!("http://127.0.0.1:{port}")));
+        let _ = handle.join();
+    }
 
     /// Construct the embedder for the selected model over the given remote config + dim. Thin
     /// wrapper so the many tests don't repeat the `selected_model_id` arg.

--- a/crates/rag-rat-core/src/index/ai/providers/openai.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/openai.rs
@@ -11,7 +11,6 @@
 //! missing-feature message. The cloneable `ureq::Agent` is held bare (no `Mutex`) and cloned into
 //! bounded blocking worker threads for remote request fan-out.
 
-use std::net::ToSocketAddrs;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -425,51 +424,6 @@ fn endpoint_is_loopback(endpoint: &str) -> bool {
         || host.starts_with("127.")
 }
 
-/// Best-effort reachability probe for a query/connect endpoint: resolve the URL's `host:port` and
-/// attempt a short TCP connect. GATES the ephemeral light-embed path — an unreachable local query
-/// server must DEFER (never embed-and-fail into `Failed` chunk_embeddings), and the fast refusal
-/// keeps a watcher/maintenance pass cheap when no local server is running (it returns before any
-/// O(repo) scan). A refused connection returns at once; only an unroutable host waits out the ~1s
-/// timeout. An endpoint we can't parse a `host:port` from is treated as unreachable.
-pub(crate) fn endpoint_reachable(endpoint: &str) -> bool {
-    let Some(host_port) = endpoint_host_port(endpoint) else {
-        return false;
-    };
-    host_port
-        .to_socket_addrs()
-        .map(|addrs| {
-            addrs.into_iter().any(|addr| {
-                std::net::TcpStream::connect_timeout(&addr, Duration::from_secs(1)).is_ok()
-            })
-        })
-        .unwrap_or(false)
-}
-
-/// Extract `host:port` from an endpoint URL for a socket connect, defaulting the port by scheme
-/// (`https` → 443, else 80) when the authority omits it. Mirrors the host parse in
-/// `endpoint_is_loopback` but keeps the port.
-fn endpoint_host_port(endpoint: &str) -> Option<String> {
-    let (scheme, after_scheme) =
-        endpoint.split_once("://").map_or(("http", endpoint), |(s, rest)| (s, rest));
-    let authority = after_scheme.split(['/', '?', '#']).next().unwrap_or(after_scheme);
-    let host_port = authority.rsplit('@').next().unwrap_or(authority).trim();
-    if host_port.is_empty() {
-        return None;
-    }
-    let has_port = match host_port.strip_prefix('[') {
-        // Bracketed IPv6 (`[::1]:8000`) has a port iff `]` is followed by `:`.
-        Some(rest) => rest.split_once(']').is_some_and(|(_, tail)| tail.starts_with(':')),
-        // Bare host / IPv4: exactly one `:` separates host and port.
-        None => host_port.matches(':').count() == 1,
-    };
-    if has_port {
-        Some(host_port.to_string())
-    } else {
-        let port = if scheme.eq_ignore_ascii_case("https") { 443 } else { 80 };
-        Some(format!("{host_port}:{port}"))
-    }
-}
-
 impl Embedder for OpenAiEmbedder {
     fn model_id(&self) -> &str {
         // The SELECTED model's registry id (e.g. `fastembed-all-minilm-l6-v2`), NOT the server-side
@@ -540,49 +494,6 @@ mod tests {
     const DIM: usize = 384;
     // The SELECTED model's registry id — what `model_id()` must return regardless of the runtime.
     const SELECTED_ID: &str = crate::embedding_models::FASTEMBED_MODEL_ID;
-
-    #[test]
-    fn endpoint_host_port_keeps_explicit_ports_and_defaults_by_scheme() {
-        // Explicit port preserved.
-        assert_eq!(endpoint_host_port("http://localhost:7997").as_deref(), Some("localhost:7997"));
-        assert_eq!(
-            endpoint_host_port("http://127.0.0.1:11434").as_deref(),
-            Some("127.0.0.1:11434")
-        );
-        // Bracketed IPv6 with a port.
-        assert_eq!(endpoint_host_port("http://[::1]:8000").as_deref(), Some("[::1]:8000"));
-        // No port → default by scheme.
-        assert_eq!(endpoint_host_port("http://example.com").as_deref(), Some("example.com:80"));
-        assert_eq!(endpoint_host_port("https://example.com").as_deref(), Some("example.com:443"));
-        // Userinfo stripped; trailing path ignored.
-        assert_eq!(
-            endpoint_host_port("http://user:pass@host:9000/v1").as_deref(),
-            Some("host:9000")
-        );
-    }
-
-    #[test]
-    fn endpoint_reachable_is_false_for_a_closed_port() {
-        // Bind then drop → the port refuses connections; the probe must return false FAST (a
-        // refusal returns immediately, it does not wait out the timeout).
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = listener.local_addr().unwrap().port();
-        drop(listener);
-        assert!(!endpoint_reachable(&format!("http://127.0.0.1:{port}")));
-        assert!(!endpoint_reachable("not a url"));
-    }
-
-    #[test]
-    fn endpoint_reachable_is_true_for_a_live_listener() {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = listener.local_addr().unwrap().port();
-        let handle = thread::spawn(move || {
-            // Accept one connection (the probe) so the listener stays bound for the check.
-            let _ = listener.accept();
-        });
-        assert!(endpoint_reachable(&format!("http://127.0.0.1:{port}")));
-        let _ = handle.join();
-    }
 
     /// Construct the embedder for the selected model over the given remote config + dim. Thin
     /// wrapper so the many tests don't repeat the `selected_model_id` arg.

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -543,12 +543,15 @@ pub(crate) fn reconcile_with_options_progress(
 
     // SkipEphemeral and NoEphemeralWork are the ONLY paths that return BEFORE the policy scan, and
     // both embed nothing:
-    //  - SkipEphemeral: the watcher/maintenance pass with an ephemeral active model +
-    //    `provision_remote=false`. It fires on every file change, so paying the O(repo)
-    //    `embedding_policy_skip_summary` just to return "Blocked" is pure per-edit waste.
-    //  - NoEphemeralWork: an explicit provisioning reconcile on an already-current ephemeral model.
-    //    `acquire_chunk_embedder` already confirmed ZERO candidates, so it deliberately did NOT
-    //    provision a paid box (#330-6) — and the policy scan would likewise be wasted work.
+    //  - SkipEphemeral: an ephemeral active model on a watcher/maintenance pass
+    //    (`provision_remote=false`) with NO local `query_endpoint` server — defer incremental
+    //    embedding to an explicit reconcile. (WITH a `query_endpoint`, that pass takes the light
+    //    local-embed path → `Ready`, not here.) Returning here avoids paying the O(repo)
+    //    `embedding_policy_skip_summary` just to report a deferral.
+    //  - NoEphemeralWork: nothing pending — either an explicit provisioning reconcile on an
+    //    already-current ephemeral model (never cold-start a paid box for zero work, #330-6) or an
+    //    idle light pass. `acquire_chunk_embedder` confirmed ZERO candidates, so the policy scan
+    //    would likewise be wasted work.
     // Both carry an empty `skipped_by_policy` (no policy counts on these early-return paths). The
     // NotReady path below DOES report policy skips
     // (`blocked_fastembed_reconcile_still_reports_policy_skips` pins that), so it runs the scan
@@ -559,8 +562,9 @@ pub(crate) fn reconcile_with_options_progress(
                 ChunkEmbedder::SkipEphemeral => (
                     "Blocked",
                     Some(
-                        "ephemeral remote embedding needs an explicit `rag-rat reconcile` (the \
-                         watcher does not provision a GPU box for incremental edits)"
+                        "ephemeral remote embedding needs an explicit `rag-rat reconcile`, or a \
+                         local `[remote] query_endpoint` server to embed incremental edits \
+                         against (the watcher does not provision a GPU box)"
                             .to_string(),
                     ),
                 ),
@@ -2246,6 +2250,13 @@ mod freshness_version_tests {
     /// Activate an ephemeral remote config WITHOUT provisioning (mark the model Ready + persist a
     /// cookbook remote config + freshness meta), mirroring a real ephemeral install's DB state.
     fn activate_ephemeral(conn: &Connection) {
+        activate_ephemeral_with_query_endpoint(conn, Some("http://localhost:11434"));
+    }
+
+    /// Activate an ephemeral (`cookbook`) remote config with the given local `query_endpoint`.
+    /// `None` models the "no local query server" case whose light/watcher pass defers
+    /// (`SkipEphemeral`); `Some(..)` models the local light-embed path.
+    fn activate_ephemeral_with_query_endpoint(conn: &Connection, query_endpoint: Option<&str>) {
         let spec = spec(FASTEMBED_MODEL_ID).unwrap();
         conn.execute(
             "UPDATE ai_models
@@ -2261,7 +2272,7 @@ mod freshness_version_tests {
             backend: crate::config::RemoteBackend::Ollama,
             endpoint: None,
             cookbook: Some("@rag-rat/cookbook/modal".to_string()),
-            query_endpoint: Some("http://localhost:11434".to_string()),
+            query_endpoint: query_endpoint.map(str::to_string),
             auth_env: None,
             gpu: None,
             num_ctx: None,
@@ -2281,13 +2292,15 @@ mod freshness_version_tests {
 
     #[test]
     fn reconcile_skips_ephemeral_chunk_embed_without_provision_remote() {
-        // The watcher/maintenance pass (`provision_remote: false`) must NOT cold-start a cookbook
-        // box for an ephemeral active model — it returns Blocked with a "needs explicit
-        // reconcile" message and never spawns a subprocess. (No cookbook is actually
-        // runnable here, so a provisioning attempt would error/hang; the skip is what keeps
-        // this test fast + offline.)
+        // The watcher/maintenance pass (`provision_remote: false`) on an ephemeral model with NO
+        // local `query_endpoint` server must NOT cold-start a cookbook box — it returns Blocked
+        // with a "needs explicit reconcile" message and never spawns a subprocess. (No
+        // cookbook is actually runnable here, so a provisioning attempt would error/hang;
+        // the skip is what keeps this test fast + offline.) With a `query_endpoint` set,
+        // the light path embeds locally instead — see
+        // `light_pass_with_query_endpoint_embeds_locally_without_provisioning`.
         let conn = schema_conn();
-        activate_ephemeral(&conn);
+        activate_ephemeral_with_query_endpoint(&conn, None);
 
         let report = reconcile_with_options_progress(
             &conn,
@@ -2303,6 +2316,57 @@ mod freshness_version_tests {
             "skip message: {:?}",
             report.message
         );
+    }
+
+    /// Build the light-path acquire for an ephemeral active model (mirrors the scan
+    /// `reconcile_with_options_progress` builds), on a non-provisioning (watcher) pass.
+    fn ephemeral_light_acquire(conn: &Connection) -> ChunkEmbedder {
+        let model_id = active_embedding_model_id(conn).unwrap();
+        let dim = spec(&model_id).unwrap().dim;
+        let version = active_version(conn);
+        let scan = EmbeddingScan {
+            model_id: &model_id,
+            model_version: &version,
+            dim,
+            max_embedding_chars: 4000,
+        };
+        acquire_chunk_embedder(conn, None, &scan, &ReconcileOptions {
+            provision_remote: false,
+            ..ReconcileOptions::default()
+        })
+    }
+
+    #[test]
+    fn light_pass_without_query_endpoint_defers_to_explicit_reconcile() {
+        // Ephemeral watcher pass with NO local query server → SkipEphemeral (defer), even with
+        // pending work: the "watcher never cold-starts a paid box" guarantee is preserved.
+        let conn = schema_conn();
+        activate_ephemeral_with_query_endpoint(&conn, None);
+        seed_embedding_chunk(&conn, 1);
+        assert!(matches!(ephemeral_light_acquire(&conn), ChunkEmbedder::SkipEphemeral));
+    }
+
+    #[test]
+    fn light_pass_with_query_endpoint_embeds_locally_without_provisioning() {
+        // Ephemeral watcher pass, `query_endpoint` set, pending work → Ready with NO provisioned
+        // box: the light path builds the LOCAL query-endpoint embedder, so incremental edits embed
+        // into the SAME vector space as the cookbook-provisioned chunks — no paid cold-start.
+        let conn = schema_conn();
+        activate_ephemeral(&conn);
+        seed_embedding_chunk(&conn, 1);
+        assert!(matches!(ephemeral_light_acquire(&conn), ChunkEmbedder::Ready {
+            provisioned: None,
+            ..
+        }));
+    }
+
+    #[test]
+    fn light_pass_with_query_endpoint_but_no_work_is_no_ephemeral_work() {
+        // Ephemeral watcher pass, `query_endpoint` set, nothing pending → NoEphemeralWork: an idle
+        // pass stays cheap (no O(repo) policy summary, no cold-start).
+        let conn = schema_conn();
+        activate_ephemeral(&conn);
+        assert!(matches!(ephemeral_light_acquire(&conn), ChunkEmbedder::NoEphemeralWork));
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -2347,10 +2347,11 @@ mod freshness_version_tests {
 
     #[test]
     fn light_pass_with_reachable_query_endpoint_embeds_locally_single_flight() {
-        // Ephemeral watcher pass, `query_endpoint` REACHABLE → Ready with NO provisioned box: the
-        // light path builds the LOCAL query-endpoint embedder (same vector space as the cookbook
-        // box, no cold-start) and clamps it to SINGLE-FLIGHT concurrency so a background edit can't
-        // overload the local server.
+        // Ephemeral watcher pass, `query_endpoint` answers a probe embed → Ready with NO
+        // provisioned box: the light path builds the LOCAL query-endpoint embedder (same
+        // vector space as the cookbook box, no cold-start), the probe embed succeeds, and
+        // concurrency is clamped to SINGLE-FLIGHT so a background edit can't overload the
+        // local server.
         let conn = schema_conn();
         let (endpoint, _stub) = spawn_embed_stub(fastembed_dim());
         activate_ephemeral_with_query_endpoint(&conn, Some(&endpoint));
@@ -2370,9 +2371,9 @@ mod freshness_version_tests {
 
     #[test]
     fn light_pass_with_unreachable_query_endpoint_defers() {
-        // Ephemeral watcher pass, `query_endpoint` set but NOT reachable (a closed port) → defer
-        // (SkipEphemeral), NOT embed-and-fail into `Failed` chunk_embeddings — and without paying
-        // an O(repo) candidate scan first.
+        // Ephemeral watcher pass, `query_endpoint` set but the server is DOWN (a closed port) → the
+        // probe embed's connect is refused, so defer (SkipEphemeral), NOT embed-and-fail into
+        // `Failed` chunk_embeddings, and without paying an O(repo) candidate scan first.
         let conn = schema_conn();
         let closed = {
             let listener = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -2381,6 +2382,19 @@ mod freshness_version_tests {
             format!("http://127.0.0.1:{port}")
         };
         activate_ephemeral_with_query_endpoint(&conn, Some(&closed));
+        seed_embedding_chunk(&conn, 1);
+        assert!(matches!(ephemeral_light_acquire(&conn), ChunkEmbedder::SkipEphemeral));
+    }
+
+    #[test]
+    fn light_pass_with_wrong_model_on_the_endpoint_defers() {
+        // The port ACCEPTS connections but the embeddings route returns the WRONG dim (a different
+        // service, or the configured model not pulled) — a bare TCP connect would pass, but the
+        // probe embed catches the dim mismatch and defers (SkipEphemeral) instead of persisting
+        // `Failed` chunk rows.
+        let conn = schema_conn();
+        let (endpoint, _stub) = spawn_embed_stub(fastembed_dim() + 1); // wrong dim on the route
+        activate_ephemeral_with_query_endpoint(&conn, Some(&endpoint));
         seed_embedding_chunk(&conn, 1);
         assert!(matches!(ephemeral_light_acquire(&conn), ChunkEmbedder::SkipEphemeral));
     }

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -544,14 +544,13 @@ pub(crate) fn reconcile_with_options_progress(
     // SkipEphemeral and NoEphemeralWork are the ONLY paths that return BEFORE the policy scan, and
     // both embed nothing:
     //  - SkipEphemeral: an ephemeral active model on a watcher/maintenance pass
-    //    (`provision_remote=false`) with NO local `query_endpoint` server — defer incremental
-    //    embedding to an explicit reconcile. (WITH a `query_endpoint`, that pass takes the light
-    //    local-embed path → `Ready`, not here.) Returning here avoids paying the O(repo)
-    //    `embedding_policy_skip_summary` just to report a deferral.
-    //  - NoEphemeralWork: nothing pending — either an explicit provisioning reconcile on an
-    //    already-current ephemeral model (never cold-start a paid box for zero work, #330-6) or an
-    //    idle light pass. `acquire_chunk_embedder` confirmed ZERO candidates, so the policy scan
-    //    would likewise be wasted work.
+    //    (`provision_remote=false`) whose local `query_endpoint` is absent or UNREACHABLE — defer
+    //    incremental embedding to an explicit reconcile. (WITH a REACHABLE `query_endpoint`, that
+    //    pass takes the light local-embed path → `Ready`, not here.) Returning here avoids paying
+    //    the O(repo) `embedding_policy_skip_summary` just to report a deferral.
+    //  - NoEphemeralWork: an explicit provisioning reconcile on an already-current ephemeral model
+    //    (never cold-start a paid box for zero work, #330-6). `acquire_chunk_embedder` confirmed
+    //    ZERO candidates, so the policy scan would likewise be wasted work.
     // Both carry an empty `skipped_by_policy` (no policy counts on these early-return paths). The
     // NotReady path below DOES report policy skips
     // (`blocked_fastembed_reconcile_still_reports_policy_skips` pins that), so it runs the scan
@@ -563,8 +562,8 @@ pub(crate) fn reconcile_with_options_progress(
                     "Blocked",
                     Some(
                         "ephemeral remote embedding needs an explicit `rag-rat reconcile`, or a \
-                         local `[remote] query_endpoint` server to embed incremental edits \
-                         against (the watcher does not provision a GPU box)"
+                         REACHABLE local `[remote] query_endpoint` server to embed incremental \
+                         edits against (the watcher does not provision a GPU box)"
                             .to_string(),
                     ),
                 ),
@@ -2347,26 +2346,43 @@ mod freshness_version_tests {
     }
 
     #[test]
-    fn light_pass_with_query_endpoint_embeds_locally_without_provisioning() {
-        // Ephemeral watcher pass, `query_endpoint` set, pending work → Ready with NO provisioned
-        // box: the light path builds the LOCAL query-endpoint embedder, so incremental edits embed
-        // into the SAME vector space as the cookbook-provisioned chunks — no paid cold-start.
+    fn light_pass_with_reachable_query_endpoint_embeds_locally_single_flight() {
+        // Ephemeral watcher pass, `query_endpoint` REACHABLE → Ready with NO provisioned box: the
+        // light path builds the LOCAL query-endpoint embedder (same vector space as the cookbook
+        // box, no cold-start) and clamps it to SINGLE-FLIGHT concurrency so a background edit can't
+        // overload the local server.
         let conn = schema_conn();
-        activate_ephemeral(&conn);
+        let (endpoint, _stub) = spawn_embed_stub(fastembed_dim());
+        activate_ephemeral_with_query_endpoint(&conn, Some(&endpoint));
         seed_embedding_chunk(&conn, 1);
-        assert!(matches!(ephemeral_light_acquire(&conn), ChunkEmbedder::Ready {
-            provisioned: None,
-            ..
-        }));
+        match ephemeral_light_acquire(&conn) {
+            ChunkEmbedder::Ready { provisioned: None, remote: Some(r), .. } => {
+                assert_eq!(r.concurrency, 1, "light path must be single-flight");
+                assert_eq!(
+                    r.endpoint.as_deref(),
+                    Some(endpoint.as_str()),
+                    "embeds against the query_endpoint"
+                );
+            },
+            _ => panic!("expected a local Ready with provisioned=None"),
+        }
     }
 
     #[test]
-    fn light_pass_with_query_endpoint_but_no_work_is_no_ephemeral_work() {
-        // Ephemeral watcher pass, `query_endpoint` set, nothing pending → NoEphemeralWork: an idle
-        // pass stays cheap (no O(repo) policy summary, no cold-start).
+    fn light_pass_with_unreachable_query_endpoint_defers() {
+        // Ephemeral watcher pass, `query_endpoint` set but NOT reachable (a closed port) → defer
+        // (SkipEphemeral), NOT embed-and-fail into `Failed` chunk_embeddings — and without paying
+        // an O(repo) candidate scan first.
         let conn = schema_conn();
-        activate_ephemeral(&conn);
-        assert!(matches!(ephemeral_light_acquire(&conn), ChunkEmbedder::NoEphemeralWork));
+        let closed = {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let port = listener.local_addr().unwrap().port();
+            drop(listener); // the port now refuses connections
+            format!("http://127.0.0.1:{port}")
+        };
+        activate_ephemeral_with_query_endpoint(&conn, Some(&closed));
+        seed_embedding_chunk(&conn, 1);
+        assert!(matches!(ephemeral_light_acquire(&conn), ChunkEmbedder::SkipEphemeral));
     }
 
     #[test]


### PR DESCRIPTION
## What

In ephemeral remote-embedding mode (`[remote] cookbook = ...`), the watcher / maintenance passes run with `provision_remote = false` and returned `SkipEphemeral` — they embed *nothing* and defer every incremental change to the next explicit (provisioning) `rag-rat reconcile`. So after editing a few files, those chunks stayed semantically unindexed (BM25 / graph only) until a bulk pass ran on the paid box.

An ephemeral config already has a **local** embedding server: `query_endpoint`, which queries embed against — same backend + model as the provisioned box, so one vector space (freshness is endpoint-independent). This routes light/incremental chunk embeds there too.

## Change

In `acquire_chunk_embedder`, on a non-provisioning pass for an ephemeral active model:

- **`query_endpoint` set** → embed the changed chunks **locally** against it, reusing `active_embedder` (the same connect-shaped query embedder), `provisioned: None` — no cold-start. Gated on the cheap `estimated_reconcile_jobs` first, so an idle pass stays cheap (`NoEphemeralWork`, no O(repo) policy summary) and only a pass with real work walks the local embed loop.
- **`query_endpoint` unset** → `SkipEphemeral` (defer to an explicit reconcile), as before.

The explicit-reconcile provisioning path (big reindex → cookbook box) is unchanged. Net: **local for light/incremental + queries, the cookbook box for big reindexes** — one vector space throughout.

## Tests

- `light_pass_with_query_endpoint_embeds_locally_without_provisioning` — Ready with `provisioned: None` (local embedder, no box).
- `light_pass_with_query_endpoint_but_no_work_is_no_ephemeral_work` — idle pass → `NoEphemeralWork`.
- `light_pass_without_query_endpoint_defers_to_explicit_reconcile` — no local server → `SkipEphemeral`.
- Existing `reconcile_skips_ephemeral_chunk_embed_without_provision_remote` reworked to the no-`query_endpoint` defer path.

Full `rag-rat-core` suite (1075) + clippy `--all-targets` + nightly fmt green.

Closes #355