### PR TITLE
feat(embed): content-address the vector cache so embeddings survive reindex

### DIFF
--- a/crates/rag-rat-core/src/index/ai/helpers.rs
+++ b/crates/rag-rat-core/src/index/ai/helpers.rs
@@ -476,17 +476,25 @@ pub(crate) fn collect_rows<T>(
     Ok(out)
 }
 
+/// Reuse an existing vector for content we've already embedded. Reads the CONTENT-ADDRESSED
+/// `embedding_cache` (keyed by `input_hash`, which folds model id + model version + the exact
+/// embedding input text), NOT `chunk_embeddings` — so a vector survives its chunk's deletion on
+/// reindex and is reusable across reindexes, branches, and worktrees (#357). An empty `input_hash`
+/// is never cacheable, so it never reuses.
 pub(crate) fn find_existing_embedding(
     conn: &Connection,
     model_id: &str,
     input_hash: &str,
     dim: usize,
 ) -> anyhow::Result<Option<Vec<f32>>> {
+    if input_hash.is_empty() {
+        return Ok(None);
+    }
     let vector: Option<Vec<u8>> = conn
         .query_row(
-            "SELECT vector_blob FROM chunk_embeddings
-         WHERE model_id = ?1 AND input_hash = ?2 AND status = 'Current' AND embedding_dim = ?3
-         LIMIT 1",
+            "SELECT vector_blob FROM embedding_cache
+             WHERE input_hash = ?2 AND model_id = ?1 AND embedding_dim = ?3
+             LIMIT 1",
             params![model_id, input_hash, i64::try_from(dim).unwrap_or(i64::MAX)],
             |row| row.get(0),
         )

--- a/crates/rag-rat-core/src/index/ai/reconcile.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile.rs
@@ -777,6 +777,9 @@ pub(crate) fn reconcile_with_options_progress(
         if !reused_jobs.is_empty() {
             let (reused_jobs_slice, reused_vectors_slice): (Vec<_>, Vec<_>) =
                 reused_jobs.into_iter().unzip();
+            // The reused vectors were decoded from the content cache (int8 -> f32); writing them
+            // back re-encodes to int8 — a negligible re-quantization (codes shift at most one
+            // level), well within the int8 scheme's accepted recall cost.
             write_current_embedding_batch(
                 conn,
                 embedder.as_ref(),
@@ -2010,6 +2013,68 @@ mod freshness_version_tests {
             )
             .unwrap();
         assert_eq!(current_rows, 2);
+    }
+
+    #[test]
+    fn embedding_cache_reuse_survives_chunk_deletion_and_gc_respects_grace() {
+        // #357: the content-addressed embedding_cache decouples the vector from chunk_id, so a
+        // reindex/branch-switch that deletes a chunk does NOT lose its vector.
+        let conn = schema_conn();
+        let dim = spec(FASTEMBED_MODEL_ID).unwrap().dim;
+        let embedder = RecordingEmbedder {
+            calls: AtomicUsize::new(0),
+            request_sizes: Mutex::new(Vec::new()),
+            dim,
+        };
+        let mut remote = remote_at("http://localhost:11434");
+        remote.batch_size = 8;
+
+        // Embed a chunk → writes chunk_embeddings AND the content-addressed embedding_cache.
+        let chunk_id = seed_embedding_chunk(&conn, 0);
+        let job = prepared_job(chunk_id, 0);
+        let input_hash = job.input_hash.clone();
+        let (written, failed) =
+            embed_and_write_jobs(&conn, &embedder, "v", vec![job], Some(&remote)).unwrap();
+        assert_eq!((written, failed), (1, 0));
+        assert!(
+            find_existing_embedding(&conn, embedder.model_id(), &input_hash, dim)
+                .unwrap()
+                .is_some(),
+            "embedding_cache is populated on write"
+        );
+
+        // REINDEX: deleting the chunk cascade-deletes its chunk_embeddings row (the pre-fix
+        // behavior that lost the vector). The content-addressed cache is NOT chunk-scoped.
+        conn.execute("DELETE FROM chunks WHERE id = ?1", params![chunk_id]).unwrap();
+        let live: i64 =
+            conn.query_row("SELECT COUNT(*) FROM chunk_embeddings", [], |r| r.get(0)).unwrap();
+        assert_eq!(live, 0, "chunk deletion cascade-deleted the embedding");
+        assert!(
+            find_existing_embedding(&conn, embedder.model_id(), &input_hash, dim)
+                .unwrap()
+                .is_some(),
+            "reuse survives reindex: the vector is still found in the durable cache"
+        );
+
+        // GC keeps a recently-used vector even with no live chunk (fast branch switch-back)...
+        assert_eq!(
+            prune_embedding_cache_unreferenced(&conn).unwrap(),
+            0,
+            "recently-used unreferenced entry is kept within the grace"
+        );
+        // ...and prunes it once it is past the grace with no live chunk referencing it.
+        conn.execute("UPDATE embedding_cache SET last_used_at_ms = 0", []).unwrap();
+        assert_eq!(
+            prune_embedding_cache_unreferenced(&conn).unwrap(),
+            1,
+            "stale unreferenced entry is pruned"
+        );
+        assert!(
+            find_existing_embedding(&conn, embedder.model_id(), &input_hash, dim)
+                .unwrap()
+                .is_none(),
+            "pruned entry is no longer reusable"
+        );
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/store.rs
+++ b/crates/rag-rat-core/src/index/ai/store.rs
@@ -446,7 +446,51 @@ pub(crate) fn store_embedding(
             now_ms()
         ],
     )?;
+    // Content-address the vector so it survives this chunk's deletion on the next reindex (#357):
+    // keep it in `embedding_cache` keyed by input_hash (which folds model + version + input text),
+    // so reconcile can reuse it for identical content across reindexes / branches / worktrees
+    // instead of re-embedding. An empty input_hash is not cacheable; a repeat write of the same
+    // content just bumps last_used for GC.
+    if !chunk.input_hash.is_empty() {
+        conn.execute(
+            "INSERT INTO embedding_cache(
+                 input_hash, model_id, embedding_dim, vector_blob, computed_at_ms, last_used_at_ms
+             )
+             VALUES (?1, ?2, ?3, ?4, ?5, ?5)
+             ON CONFLICT(input_hash) DO UPDATE SET last_used_at_ms = excluded.last_used_at_ms",
+            params![
+                chunk.input_hash,
+                embedder.model_id(),
+                i64::try_from(embedder.dim()).unwrap_or(i64::MAX),
+                encode_vector(vector),
+                now_ms()
+            ],
+        )?;
+    }
     Ok(())
+}
+
+/// GC grace for `embedding_cache` (#357): a content vector referenced by no live chunk is kept this
+/// long past its last use, so switching back to a branch you left recently reuses it instead of
+/// re-embedding. Vectors are small (int8-encoded), so a generous window costs little storage.
+const EMBEDDING_CACHE_GRACE_MS: i64 = 30 * 24 * 60 * 60 * 1000;
+
+/// Prune `embedding_cache` vectors that BOTH (a) are referenced by no Current `chunk_embeddings` in
+/// ANY context — a sibling branch / worktree still using the content keeps it, matching the
+/// oracle's global-sweep rule — AND (b) haven't been used within [`EMBEDDING_CACHE_GRACE_MS`]. The
+/// content key is `input_hash`. Called from gc; returns rows deleted.
+pub(crate) fn prune_embedding_cache_unreferenced(conn: &Connection) -> anyhow::Result<u64> {
+    let cutoff = now_ms().saturating_sub(EMBEDDING_CACHE_GRACE_MS);
+    let deleted = conn.execute(
+        "DELETE FROM embedding_cache
+         WHERE last_used_at_ms < ?1
+           AND input_hash NOT IN (
+               SELECT input_hash FROM chunk_embeddings
+               WHERE status = 'Current' AND input_hash != ''
+           )",
+        params![cutoff],
+    )?;
+    Ok(u64::try_from(deleted).unwrap_or(0))
 }
 
 pub(crate) fn store_failed_embedding(

--- a/crates/rag-rat-core/src/index/query_api/gc.rs
+++ b/crates/rag-rat-core/src/index/query_api/gc.rs
@@ -113,6 +113,15 @@ impl IndexDatabase {
         // edges it produced are dropped together.
         oracle::prune_edge_oracle_without_live_edge(conn)?;
         oracle::prune_oracle_runs_outside_scope(conn, live_commits, live_worktrees)?;
+        // #357: `embedding_cache` is content-keyed too (survives reindex, like the oracle above),
+        // so it needs the SAME global sweep — drop vectors no live chunk references in ANY
+        // context (a sibling worktree / branch may still use one, so this must not be
+        // checkout-scoped) that are also past the switch-back grace. ORDERING: this MUST stay AFTER
+        // `delete_staged_files_cascade` above, so a just-removed dead context's chunk_embeddings
+        // are already gone and this cycle also reclaims their now-unreferenced vectors.
+        // (Running it before the cascade is still safe — it would just keep dead vectors
+        // one extra cycle.)
+        crate::index::ai::prune_embedding_cache_unreferenced(conn)?;
         // Dictionary hygiene (#79, extended #224): drop `name_strings` values nothing references
         // any more. The pool has NO FKs by design (see the schema comment), so orphans
         // accumulate as edges/symbols are pruned; the vocabulary is small, but gc is the

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1170,6 +1170,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_033_ID => Some(33),
             MIGRATION_034_ID => Some(34),
             MIGRATION_035_ID => Some(35),
+            MIGRATION_036_ID => Some(36),
             _ => None,
         })
         .max()
@@ -1214,6 +1215,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_033_ID
             | MIGRATION_034_ID
             | MIGRATION_035_ID
+            | MIGRATION_036_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1255,6 +1257,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_033_ID => migration.checksum != MIGRATION_033_CHECKSUM,
         MIGRATION_034_ID => migration.checksum != MIGRATION_034_CHECKSUM,
         MIGRATION_035_ID => migration.checksum != MIGRATION_035_CHECKSUM,
+        MIGRATION_036_ID => migration.checksum != MIGRATION_036_CHECKSUM,
         _ => false,
     }
 }
@@ -1502,6 +1505,39 @@ pub(crate) fn apply_clone_graph_tables(conn: &Connection) -> rusqlite::Result<()
 /// repopulates them — accurate `is_test` needs a reindex with this binary.
 pub(crate) fn apply_symbols_is_test(conn: &Connection) -> rusqlite::Result<()> {
     add_column_if_missing(conn, "symbols", "is_test", "INTEGER NOT NULL DEFAULT 0")?;
+    Ok(())
+}
+
+/// V036 (#357): content-address embeddings so they SURVIVE reindex. `chunk_embeddings` is keyed by
+/// `chunk_id` with `ON DELETE CASCADE`, so every reindex / branch-switch deletes a chunk and its
+/// embedding — even when the content is unchanged — forcing a re-embed. `embedding_cache` keys the
+/// vector by `input_hash` alone (which already folds model id + model version + the exact embedding
+/// input text), so it is context-INDEPENDENT: reconcile reuses a vector for identical content
+/// across reindexes, branches, and worktrees instead of paying the embedder. Seeded from the
+/// current embeddings so existing vectors are preserved through the first post-migration reindex.
+/// Idempotent (`CREATE TABLE IF NOT EXISTS` + `INSERT OR IGNORE`); seeding an empty table is a
+/// no-op on a fresh DB.
+pub(crate) fn apply_embedding_content_cache(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS embedding_cache(
+             input_hash TEXT NOT NULL PRIMARY KEY,
+             model_id TEXT NOT NULL,
+             embedding_dim INTEGER NOT NULL,
+             vector_blob BLOB NOT NULL,
+             computed_at_ms INTEGER NOT NULL,
+             last_used_at_ms INTEGER NOT NULL
+         ) STRICT;
+         -- Preserve existing vectors: seed the cache from the current embeddings by content so the
+         -- first reindex after this migration reuses instead of re-embedding.
+         INSERT OR IGNORE INTO embedding_cache(
+             input_hash, model_id, embedding_dim, vector_blob, computed_at_ms, last_used_at_ms
+         )
+         SELECT input_hash, model_id, embedding_dim, vector_blob,
+                COALESCE(computed_at_ms, created_at_ms, 0), COALESCE(computed_at_ms, \
+         created_at_ms, 0)
+         FROM chunk_embeddings
+         WHERE status = 'Current' AND input_hash != '' AND length(vector_blob) > 0;",
+    )?;
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use migrations::*;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 35;
+pub const LATEST_SCHEMA_VERSION: u32 = 36;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -224,6 +224,12 @@ const MIGRATION_035_DESCRIPTION: &str = "Add symbols.is_test (cross-language tes
                                          test-file path, Rust #[test]/#[cfg(test)], Kotlin @Test, \
                                          Python test_*/TestCase) so clone detection can exclude \
                                          tests from the corpus";
+const MIGRATION_036_ID: &str = "036_embedding_content_cache";
+const MIGRATION_036_CHECKSUM: &str = "sha256:rag-rat-embedding-content-cache-v36";
+const MIGRATION_036_DESCRIPTION: &str =
+    "Add embedding_cache (content-addressed vectors keyed by input_hash) so embeddings survive \
+     reindex / branch-switch and reconcile reuses unchanged content across contexts instead of \
+     re-embedding; seeded from current chunk_embeddings (#357)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -533,6 +539,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_035_CHECKSUM,
         description: MIGRATION_035_DESCRIPTION,
         apply: apply_symbols_is_test,
+    },
+    Migration {
+        id: MIGRATION_036_ID,
+        checksum: MIGRATION_036_CHECKSUM,
+        description: MIGRATION_036_DESCRIPTION,
+        apply: apply_embedding_content_cache,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests.rs
@@ -12489,11 +12489,38 @@ fn migration_035_adds_symbols_is_test() {
     let _: i64 = conn
         .query_row("SELECT COUNT(*) FROM symbols WHERE is_test = 0", [], |r| r.get(0))
         .expect("SELECT is_test must succeed after V035");
+}
+
+/// V036 (#357): `embedding_cache` (content-addressed vectors) is added by the forward migration and
+/// is the schema tip; a DB at V035 gains the table on `migrate_forward`, and it seeds from existing
+/// current embeddings so vectors survive the next reindex.
+#[test]
+fn migration_036_adds_content_addressed_embedding_cache() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    crate::index::schema::apply(&conn).expect("apply");
     assert_eq!(
         crate::index::schema::LATEST_SCHEMA_VERSION,
-        35,
-        "LATEST_SCHEMA_VERSION is 35 after V035"
+        36,
+        "LATEST_SCHEMA_VERSION is 36 after V036"
     );
+
+    conn.execute_batch("DROP TABLE embedding_cache;").expect("revert to V035 shape");
+    truncate_schema_to(&conn, 35);
+    assert_eq!(
+        crate::index::schema::status(&conn).unwrap().state,
+        crate::index::schema::SchemaState::Older,
+        "schema is Older after removing the V036 ledger row"
+    );
+
+    crate::index::schema::migrate_forward(&conn).expect("migrate_forward");
+    assert!(
+        conn_table_columns(&conn, "embedding_cache").contains(&"input_hash".to_string()),
+        "V036 adds the embedding_cache table"
+    );
+    // Content-keyed by input_hash: a lookup query is valid after the migration.
+    let _: i64 = conn
+        .query_row("SELECT COUNT(*) FROM embedding_cache", [], |r| r.get(0))
+        .expect("SELECT from embedding_cache must succeed after V036");
 }
 
 /// Regression test for the P1 schema bug (#215 Plan 4a): an index recorded at V029 WITHOUT
@@ -12554,11 +12581,6 @@ fn v030_forward_migrate_adds_lcs_sampled_to_existing_v029_index() {
         crate::index::schema::status(&conn).unwrap().current_version,
         crate::index::schema::LATEST_SCHEMA_VERSION,
         "schema is at LATEST_SCHEMA_VERSION after V030 migration"
-    );
-    assert_eq!(
-        crate::index::schema::LATEST_SCHEMA_VERSION,
-        35,
-        "LATEST_SCHEMA_VERSION is 35 after V035"
     );
     // Idempotency: running migrate_forward again must not error.
     crate::index::schema::migrate_forward(&conn).expect("migrate_forward is idempotent");


### PR DESCRIPTION
## Problem

`chunk_embeddings` is keyed by `chunk_id` with `FOREIGN KEY(chunk_id) REFERENCES chunks(id) ON DELETE CASCADE`. Reindexing a file (`DELETE FROM chunks` → new rows with new ids) **cascade-deletes the embeddings even when the content is unchanged**, so a branch switch, a worktree's commit hook, or a full rebuild re-embeds from zero. On a slow local embedder that's minutes-to-hours, and it silently discards already-computed vectors.

## Fix

A content-addressed vector store, mirroring #248 (which anchored `edge_oracle` verdicts by content so they survive reindex):

- **`embedding_cache` (V036)** keyed by `input_hash` — which already folds `model_id` + `model_version` + the exact (post-truncation) embedding input text, so it is **context-independent**.
- **`find_existing_embedding`** reads `embedding_cache` instead of `chunk_embeddings`, so reconcile reuses a vector for identical content across **reindexes, branches, and worktrees** instead of paying the embedder.
- **`store_embedding`** upserts the cache on every `Current` write (`store_failed_embedding` never touches it, so the cache holds only real vectors).
- **Migration seeds** the cache from existing `Current` embeddings, so vectors survive the first reindex after upgrade.
- **GC** (`prune_embedding_cache_unreferenced`, in `prune_to_live`) drops entries referenced by no `Current` chunk_embeddings **in any context** (a sibling worktree keeps its vectors — a global, non-checkout-scoped sweep, like the oracle prune it sits beside) that are also past a 30-day switch-back grace.

Multi-worktree/branch support is preserved: files stay scoped by `commit_sha`/`worktree_id`; the cache is content-keyed and global, which is exactly what makes switching contexts cheap. A spurious prune is self-healing — reconcile re-selects any chunk lacking a matching `Current` embedding, so the worst case is one re-embed, never data loss or wrong reuse.

## Tests

- `embedding_cache_reuse_survives_chunk_deletion_and_gc_respects_grace` — embed → delete the chunk (cascade-deletes its embedding) → reuse still hits the durable cache; GC keeps a recent unreferenced entry and prunes a stale one.
- `migration_036_adds_content_addressed_embedding_cache` — fresh + `migrate_forward` both produce the table; content-keyed lookup works.
- Full `rag-rat-core` suite (1078) + clippy `--all-targets` + nightly fmt green.

## Known limitation

In a non-git repo (or when GC can't determine live contexts) the cache isn't pruned and grows by distinct content. Vectors are int8 so this is small, but an absolute cap / LRU trim is a possible follow-up.

Closes #357