### PR TITLE
refactor: dedup credential and row-count helpers

### DIFF
--- a/crates/rag-rat-cli/src/init/wizard/steps.rs
+++ b/crates/rag-rat-cli/src/init/wizard/steps.rs
@@ -9,6 +9,7 @@ use std::sync::mpsc::Sender;
 
 use rag_rat_core::config::{
     DEFAULT_QUERY_ENDPOINT, MAX_REMOTE_EMBEDDING_CONCURRENCY, RemoteBackend, RemoteEmbeddingConfig,
+    endpoint_authority_has_userinfo,
 };
 use rag_rat_core::embedding_models::{Backend, EMBEDDING_MODELS, EmbeddingModelSpec, spec};
 #[cfg(feature = "fastembed")]
@@ -2318,12 +2319,6 @@ fn validate_remote_auth_env(auth_env: &str) -> Option<CheckResult> {
         Ok(value) if !value.trim().is_empty() => None,
         _ => Some(CheckResult::block(format!("remote auth env `{auth_env}` is not set"))),
     }
-}
-
-fn endpoint_authority_has_userinfo(endpoint: &str) -> bool {
-    let after_scheme = endpoint.split_once("://").map_or(endpoint, |(_, rest)| rest);
-    let authority = after_scheme.split(['/', '?', '#']).next().unwrap_or(after_scheme);
-    authority.contains('@')
 }
 
 fn remote_config_for(d: &RemoteDraft) -> RemoteEmbeddingConfig {

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -969,7 +969,7 @@ struct RawRemoteEmbedding {
 /// everything after `scheme://` up to the next `/`, `?`, or `#`, and reports an `@` in it. A bare
 /// host, an `@` in the path/query, or a URL with no scheme separator all return false. Used to keep
 /// credentials out of the endpoint string before it is persisted into the index meta.
-fn endpoint_authority_has_userinfo(endpoint: &str) -> bool {
+pub fn endpoint_authority_has_userinfo(endpoint: &str) -> bool {
     let after_scheme = endpoint.split_once("://").map_or(endpoint, |(_, rest)| rest);
     let authority = after_scheme.split(['/', '?', '#']).next().unwrap_or(after_scheme);
     authority.contains('@')

--- a/crates/rag-rat-core/src/index/git_history.rs
+++ b/crates/rag-rat-core/src/index/git_history.rs
@@ -7,6 +7,7 @@ use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
+use crate::index::table_row_count;
 use crate::search::lexical::SearchHit;
 
 #[derive(Debug, Clone, Serialize)]
@@ -214,8 +215,8 @@ pub fn index(conn: &Connection, root: &Path) -> anyhow::Result<GitHistoryIndexSt
 
 pub fn status(conn: &Connection, root: &Path) -> anyhow::Result<GitHistoryIndexStatus> {
     let repo = git_repo(root);
-    let commit_count = count_table(conn, "git_commits")?;
-    let file_change_count = count_table(conn, "git_file_changes")?;
+    let commit_count = table_row_count(conn, "git_commits")?;
+    let file_change_count = table_row_count(conn, "git_file_changes")?;
     Ok(GitHistoryIndexStatus {
         available: repo.is_some(),
         head: repo.map(|repo| repo.head),
@@ -864,12 +865,6 @@ fn collect_rows<T>(
     Ok(out)
 }
 
-fn count_table(conn: &Connection, table: &str) -> anyhow::Result<u64> {
-    let count =
-        conn.query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| row.get::<_, i64>(0))?;
-    Ok(u64::try_from(count).unwrap_or(0))
-}
-
 /// The enclosing Git worktree root for `root` (the directory `git rev-parse --show-toplevel`
 /// reports), or `None` when `root` is not inside a Git worktree (or `git` is unavailable). This is
 /// the single place the codebase shells `--show-toplevel`; reuse it rather than adding a parallel
@@ -923,7 +918,7 @@ pub(crate) fn is_history_current(conn: &Connection, root: &Path) -> bool {
         // not shallow even if HEAD is unchanged.
         let prior_was_full = meta(conn, "git_history_indexed_shallow")?.as_deref() == Some("0");
         // Guard against a torn/empty prior reload writing the meta without rows.
-        let has_rows = count_table(conn, "git_commits")? > 0;
+        let has_rows = table_row_count(conn, "git_commits")? > 0;
         Ok(head_matches && root_matches && prior_was_full && has_rows)
     };
     probe().unwrap_or(false)

--- a/crates/rag-rat-core/src/index/github/api.rs
+++ b/crates/rag-rat-core/src/index/github/api.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::index::table_row_count;
 
 pub(crate) fn sync_from_refs<C: GitHubClient>(
     conn: &Connection,
@@ -74,12 +75,12 @@ pub(crate) fn sync_issue<C: GitHubClient>(
 }
 pub(crate) fn status(conn: &Connection, ctx: &GitHubContext) -> anyhow::Result<GitHubStatus> {
     Ok(GitHubStatus {
-        refs: count_table(conn, "github_refs")?,
-        issues: count_table(conn, "github_issues")?,
-        comments: count_table(conn, "github_comments")?,
-        pulls: count_table(conn, "github_pull_requests")?,
-        reviews: count_table(conn, "github_reviews")?,
-        review_comments: count_table(conn, "github_review_comments")?,
+        refs: table_row_count(conn, "github_refs")?,
+        issues: table_row_count(conn, "github_issues")?,
+        comments: table_row_count(conn, "github_comments")?,
+        pulls: table_row_count(conn, "github_pull_requests")?,
+        reviews: table_row_count(conn, "github_reviews")?,
+        review_comments: table_row_count(conn, "github_review_comments")?,
         last_sync_ms: meta(conn, "github_last_sync_ms")?.and_then(|value| value.parse().ok()),
         capability: if ctx.gh_available {
             "gh_cli_available".to_string()

--- a/crates/rag-rat-core/src/index/github/parse.rs
+++ b/crates/rag-rat-core/src/index/github/parse.rs
@@ -242,11 +242,6 @@ pub(crate) fn collect_rows<T>(
     }
     Ok(out)
 }
-pub(crate) fn count_table(conn: &Connection, table: &str) -> anyhow::Result<u64> {
-    let count =
-        conn.query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| row.get::<_, i64>(0))?;
-    Ok(u64::try_from(count).unwrap_or(0))
-}
 pub(crate) fn meta(conn: &Connection, key: &str) -> anyhow::Result<Option<String>> {
     Ok(conn
         .query_row("SELECT value FROM index_meta WHERE key = ?1", [key], |row| row.get(0))

--- a/crates/rag-rat-core/src/query/repo_brief.rs
+++ b/crates/rag-rat-core/src/query/repo_brief.rs
@@ -4,6 +4,8 @@ use std::fmt;
 use rusqlite::{Connection, OptionalExtension, Row};
 use serde::Serialize;
 
+use crate::index::table_row_count;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RepoBriefMode {
     Spine,
@@ -502,9 +504,9 @@ pub(crate) fn summary_counts(conn: &Connection) -> anyhow::Result<SummaryCounts>
         conn.query_row("SELECT COUNT(*), COALESCE(SUM(generated), 0) FROM files", [], |row| {
             Ok((row_u64(row, 0)?, row_u64(row, 1)?))
         })?;
-    let graph_edges = count_table(conn, "edges")?;
-    let git_commits = count_table(conn, "git_commits")?;
-    let git_file_changes = count_table(conn, "git_file_changes")?;
+    let graph_edges = table_row_count(conn, "edges")?;
+    let git_commits = table_row_count(conn, "git_commits")?;
+    let git_file_changes = table_row_count(conn, "git_file_changes")?;
     let memories = memory_counts(conn, None)?;
     Ok(SummaryCounts {
         total_files,
@@ -514,11 +516,6 @@ pub(crate) fn summary_counts(conn: &Connection) -> anyhow::Result<SummaryCounts>
         git_file_changes,
         memories,
     })
-}
-
-fn count_table(conn: &Connection, table: &str) -> anyhow::Result<u64> {
-    let sql = format!("SELECT COUNT(*) FROM {table}");
-    Ok(conn.query_row(&sql, [], |row| row_u64(row, 0))?)
 }
 
 pub(crate) fn file_rows(


### PR DESCRIPTION
Removes two byte-identical code duplications surfaced while auditing the repo for code smells. Kept intentionally small and safe; the larger structural findings are tracked as follow-up issues rather than bundled here.

## Changes

- **`endpoint_authority_has_userinfo`** — this credential-safety check (strips `user[:pass]@` userinfo from a remote-embedding endpoint before it is persisted into the index meta) existed as two byte-for-byte copies in different crates: `config.rs` (core) and `init/wizard/steps.rs` (cli). Two copies of a security check can silently diverge. Made the core copy `pub` and had the wizard import it.
- **`count_table`** — the `SELECT COUNT(*) FROM <table>` → `try_from(...).unwrap_or(0)` helper was copied byte-for-byte into `git_history.rs`, `github/parse.rs`, and `query/repo_brief.rs`. Repointed all callers to the pre-existing `crate::index::table_row_count` and deleted the copies.

### No behavior change

The repointed `count_table` callers only count tables without a scoped temp-view shadow (`git_commits`, `git_file_changes`, `edges`, `github_*`), so `table_row_count`'s explicit `main.<table>` form is equivalent to the old bare-name form. The near-identical `chunk_count` / `count_callees` helpers are deliberately left alone — they count through the scoped `files` view / a `WHERE` filter and are different queries, not duplicates.

## Verification

- `cargo build` / `cargo check --all-targets` — clean (core + cli)
- `cargo clippy --all-targets` (deny warnings) — clean
- `cargo nextest run -p rag-rat-core -p rag-rat` — 1314 passed, 0 failed
- `cargo +nightly fmt` — clean

Net −17 lines.

## Follow-ups (not in this PR)

The same audit flagged larger structural items, filed separately so each can land as its own reviewable change:

- #361 — split god-module `query_api/clones.rs` (~3.3k lines, 92 symbols)
- #362 — split god-module `init/wizard/steps.rs` (fan_in 1002)
- #363 — extract oversized inline test modules (`antiunify.rs`, `schema_bootstrap_tests.rs`)

`config.rs`'s `Raw*` deserialization-shadow structs were also reviewed and left as-is — that mirror is a deliberate serde pattern (on-disk shape → validated config), not a defect.
