### PR TITLE
chore: release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.11.0...rag-rat-core-v0.12.0) - 2026-07-02
+
+### Added
+
+- *(clones)* make the write-time clone-check size guard mode-aware (#296 phase 4) ([#393](https://github.com/cq27-dev/rag-rat/pull/393))
+- *(clones)* bounded postings fast path in the write-time clone check (#296 phase 3) ([#392](https://github.com/cq27-dev/rag-rat/pull/392))
+- *(clones)* populate clone_subblock_postings in the generation-staged precompute (#296 phase 2) ([#391](https://github.com/cq27-dev/rag-rat/pull/391))
+- *(schema)* V037 — clone_subblock_postings + postings_written gate (#296 phase 1) ([#390](https://github.com/cq27-dev/rag-rat/pull/390))
+- *(log)* config-gated tracing debug log + hook-embedding repro harness ([#377](https://github.com/cq27-dev/rag-rat/pull/377))
+
+### Fixed
+
+- *(embed)* a fresh index adopts the configured embedding model, not the hash fallback ([#394](https://github.com/cq27-dev/rag-rat/pull/394)) ([#395](https://github.com/cq27-dev/rag-rat/pull/395))
+
+### Other
+
+- *(clones)* BFS the subject's component in clones_for_symbol on the live path ([#270](https://github.com/cq27-dev/rag-rat/pull/270)) ([#384](https://github.com/cq27-dev/rag-rat/pull/384))
+- *(store)* rewrap two doc comments to satisfy nightly rustfmt ([#385](https://github.com/cq27-dev/rag-rat/pull/385))
+- *(reconcile)* stream estimated_reconcile_jobs — the last materialize-everything site ([#64](https://github.com/cq27-dev/rag-rat/pull/64)) ([#383](https://github.com/cq27-dev/rag-rat/pull/383))
+- *(reconcile)* stream embedding_reconcile_plan candidate materialization ([#379](https://github.com/cq27-dev/rag-rat/pull/379)) ([#382](https://github.com/cq27-dev/rag-rat/pull/382))
+- *(embed)* split index/ai/reconcile.rs god-module into cohesive siblings ([#375](https://github.com/cq27-dev/rag-rat/pull/375))
+- *(clones)* split god-module query_api/clones.rs into cohesive siblings ([#368](https://github.com/cq27-dev/rag-rat/pull/368))
+- extract oversized inline test modules into sibling files ([#366](https://github.com/cq27-dev/rag-rat/pull/366))
+- dedup credential and row-count helpers ([#364](https://github.com/cq27-dev/rag-rat/pull/364))
+
 ## [0.11.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.10.0...rag-rat-core-v0.11.0) - 2026-07-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3314,7 +3314,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rag-rat"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3338,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3377,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-mcp"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "3"
 # and the internal path deps below pin the same literal, so the three crates always publish in
 # lockstep. Bump this one line (and the two internal-dep `version`s under workspace.dependencies)
 # to release.
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Kristaps Karlsons"]
 edition = "2024"
 # Bundled SQLite (rusqlite `bundled` -> libsqlite3-sys 0.38.1) compiles a build script that uses the
@@ -28,8 +28,8 @@ categories = ["command-line-utilities", "development-tools"]
 # Internal crates — declared once here so the version requirement is set in lockstep with
 # [workspace.package].version above. Members reference these via `{ workspace = true }` and add
 # their own feature toggles at the use site.
-rag-rat-core = { version = "0.11.0", path = "crates/rag-rat-core", default-features = false }
-rag-rat-mcp = { version = "0.11.0", path = "crates/rag-rat-mcp", default-features = false }
+rag-rat-core = { version = "0.12.0", path = "crates/rag-rat-core", default-features = false }
+rag-rat-mcp = { version = "0.12.0", path = "crates/rag-rat-mcp", default-features = false }
 anyhow = "1.0"
 fastembed = { version = "5.17.2", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
 gix = { version = "0.84.0", default-features = false, features = ["status", "parallel", "sha1", "sha256", "revision", "blob-diff", "blame"] }


### PR DESCRIPTION



## 🤖 New release

* `rag-rat-core`: 0.11.0 -> 0.12.0 (⚠ API breaking changes)
* `rag-rat-mcp`: 0.11.0 -> 0.12.0 (✓ API compatible changes)
* `rag-rat`: 0.11.0 -> 0.12.0

### ⚠ `rag-rat-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Config.log in /tmp/.tmpGgPsbx/rag-rat/crates/rag-rat-core/src/config.rs:22
  field Config.log in /tmp/.tmpGgPsbx/rag-rat/crates/rag-rat-core/src/config.rs:22

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant ConfigError:UnknownLogLevel in /tmp/.tmpGgPsbx/rag-rat/crates/rag-rat-core/src/config.rs:1370
  variant ConfigError:UnknownLogFormat in /tmp/.tmpGgPsbx/rag-rat/crates/rag-rat-core/src/config.rs:1372
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rag-rat-core`

<blockquote>

## [0.12.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.11.0...rag-rat-core-v0.12.0) - 2026-07-02

### Added

- *(clones)* make the write-time clone-check size guard mode-aware (#296 phase 4) ([#393](https://github.com/cq27-dev/rag-rat/pull/393))
- *(clones)* bounded postings fast path in the write-time clone check (#296 phase 3) ([#392](https://github.com/cq27-dev/rag-rat/pull/392))
- *(clones)* populate clone_subblock_postings in the generation-staged precompute (#296 phase 2) ([#391](https://github.com/cq27-dev/rag-rat/pull/391))
- *(schema)* V037 — clone_subblock_postings + postings_written gate (#296 phase 1) ([#390](https://github.com/cq27-dev/rag-rat/pull/390))
- *(log)* config-gated tracing debug log + hook-embedding repro harness ([#377](https://github.com/cq27-dev/rag-rat/pull/377))

### Fixed

- *(embed)* a fresh index adopts the configured embedding model, not the hash fallback ([#394](https://github.com/cq27-dev/rag-rat/pull/394)) ([#395](https://github.com/cq27-dev/rag-rat/pull/395))

### Other

- *(clones)* BFS the subject's component in clones_for_symbol on the live path ([#270](https://github.com/cq27-dev/rag-rat/pull/270)) ([#384](https://github.com/cq27-dev/rag-rat/pull/384))
- *(store)* rewrap two doc comments to satisfy nightly rustfmt ([#385](https://github.com/cq27-dev/rag-rat/pull/385))
- *(reconcile)* stream estimated_reconcile_jobs — the last materialize-everything site ([#64](https://github.com/cq27-dev/rag-rat/pull/64)) ([#383](https://github.com/cq27-dev/rag-rat/pull/383))
- *(reconcile)* stream embedding_reconcile_plan candidate materialization ([#379](https://github.com/cq27-dev/rag-rat/pull/379)) ([#382](https://github.com/cq27-dev/rag-rat/pull/382))
- *(embed)* split index/ai/reconcile.rs god-module into cohesive siblings ([#375](https://github.com/cq27-dev/rag-rat/pull/375))
- *(clones)* split god-module query_api/clones.rs into cohesive siblings ([#368](https://github.com/cq27-dev/rag-rat/pull/368))
- extract oversized inline test modules into sibling files ([#366](https://github.com/cq27-dev/rag-rat/pull/366))
- dedup credential and row-count helpers ([#364](https://github.com/cq27-dev/rag-rat/pull/364))
</blockquote>

## `rag-rat-mcp`

<blockquote>

## [0.12.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.11.0...rag-rat-core-v0.12.0) - 2026-07-02

### Added

- *(clones)* make the write-time clone-check size guard mode-aware (#296 phase 4) ([#393](https://github.com/cq27-dev/rag-rat/pull/393))
- *(clones)* bounded postings fast path in the write-time clone check (#296 phase 3) ([#392](https://github.com/cq27-dev/rag-rat/pull/392))
- *(clones)* populate clone_subblock_postings in the generation-staged precompute (#296 phase 2) ([#391](https://github.com/cq27-dev/rag-rat/pull/391))
- *(schema)* V037 — clone_subblock_postings + postings_written gate (#296 phase 1) ([#390](https://github.com/cq27-dev/rag-rat/pull/390))
- *(log)* config-gated tracing debug log + hook-embedding repro harness ([#377](https://github.com/cq27-dev/rag-rat/pull/377))

### Fixed

- *(embed)* a fresh index adopts the configured embedding model, not the hash fallback ([#394](https://github.com/cq27-dev/rag-rat/pull/394)) ([#395](https://github.com/cq27-dev/rag-rat/pull/395))

### Other

- *(clones)* BFS the subject's component in clones_for_symbol on the live path ([#270](https://github.com/cq27-dev/rag-rat/pull/270)) ([#384](https://github.com/cq27-dev/rag-rat/pull/384))
- *(store)* rewrap two doc comments to satisfy nightly rustfmt ([#385](https://github.com/cq27-dev/rag-rat/pull/385))
- *(reconcile)* stream estimated_reconcile_jobs — the last materialize-everything site ([#64](https://github.com/cq27-dev/rag-rat/pull/64)) ([#383](https://github.com/cq27-dev/rag-rat/pull/383))
- *(reconcile)* stream embedding_reconcile_plan candidate materialization ([#379](https://github.com/cq27-dev/rag-rat/pull/379)) ([#382](https://github.com/cq27-dev/rag-rat/pull/382))
- *(embed)* split index/ai/reconcile.rs god-module into cohesive siblings ([#375](https://github.com/cq27-dev/rag-rat/pull/375))
- *(clones)* split god-module query_api/clones.rs into cohesive siblings ([#368](https://github.com/cq27-dev/rag-rat/pull/368))
- extract oversized inline test modules into sibling files ([#366](https://github.com/cq27-dev/rag-rat/pull/366))
- dedup credential and row-count helpers ([#364](https://github.com/cq27-dev/rag-rat/pull/364))
</blockquote>

## `rag-rat`

<blockquote>

## [0.12.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.11.0...rag-rat-core-v0.12.0) - 2026-07-02

### Added

- *(clones)* make the write-time clone-check size guard mode-aware (#296 phase 4) ([#393](https://github.com/cq27-dev/rag-rat/pull/393))
- *(clones)* bounded postings fast path in the write-time clone check (#296 phase 3) ([#392](https://github.com/cq27-dev/rag-rat/pull/392))
- *(clones)* populate clone_subblock_postings in the generation-staged precompute (#296 phase 2) ([#391](https://github.com/cq27-dev/rag-rat/pull/391))
- *(schema)* V037 — clone_subblock_postings + postings_written gate (#296 phase 1) ([#390](https://github.com/cq27-dev/rag-rat/pull/390))
- *(log)* config-gated tracing debug log + hook-embedding repro harness ([#377](https://github.com/cq27-dev/rag-rat/pull/377))

### Fixed

- *(embed)* a fresh index adopts the configured embedding model, not the hash fallback ([#394](https://github.com/cq27-dev/rag-rat/pull/394)) ([#395](https://github.com/cq27-dev/rag-rat/pull/395))

### Other

- *(clones)* BFS the subject's component in clones_for_symbol on the live path ([#270](https://github.com/cq27-dev/rag-rat/pull/270)) ([#384](https://github.com/cq27-dev/rag-rat/pull/384))
- *(store)* rewrap two doc comments to satisfy nightly rustfmt ([#385](https://github.com/cq27-dev/rag-rat/pull/385))
- *(reconcile)* stream estimated_reconcile_jobs — the last materialize-everything site ([#64](https://github.com/cq27-dev/rag-rat/pull/64)) ([#383](https://github.com/cq27-dev/rag-rat/pull/383))
- *(reconcile)* stream embedding_reconcile_plan candidate materialization ([#379](https://github.com/cq27-dev/rag-rat/pull/379)) ([#382](https://github.com/cq27-dev/rag-rat/pull/382))
- *(embed)* split index/ai/reconcile.rs god-module into cohesive siblings ([#375](https://github.com/cq27-dev/rag-rat/pull/375))
- *(clones)* split god-module query_api/clones.rs into cohesive siblings ([#368](https://github.com/cq27-dev/rag-rat/pull/368))
- extract oversized inline test modules into sibling files ([#366](https://github.com/cq27-dev/rag-rat/pull/366))
- dedup credential and row-count helpers ([#364](https://github.com/cq27-dev/rag-rat/pull/364))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).