### PR TITLE
ci(codecov): add config — patch informational, project is the gate

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+# Coverage runs with `--no-default-features` (see the `coverage` job in .github/workflows/ci.yml), so
+# code behind the fastembed / model2vec feature gates is never exercised and always reports as
+# uncovered. Combined with routine module-split refactors — which make relocated, already-tested
+# lines look "new" to the patch status — patch coverage is a noisy merge signal rather than a real
+# regression indicator. Keep the patch status as an informational report and let the project status
+# be the enforced gate (with a small drift threshold so a sub-percent move doesn't flip it red).
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Adds the missing `codecov.yml`.

Without it, codecov uses default settings, and the `coverage` job runs `cargo llvm-cov --workspace --no-default-features` — so `#[cfg(feature = ...)]` code (fastembed/model2vec) is never exercised and reports as uncovered. Module-split refactors then make relocated, already-tested lines look brand-new to the `patch` status, so `codecov/patch` fails red even when project coverage is flat (e.g. #374: 91.39% base to 91.38% head).

This keeps **project** coverage as the enforced gate (target auto, 1% drift threshold) and demotes **patch** to informational — it still reports, but no longer blocks/red-flags refactors. Fixes the spurious `codecov/patch` failures on #374 and #375.