### PR TITLE
feat(log): config-gated tracing debug log + hook-embedding repro harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3332,6 +3332,7 @@ dependencies = [
  "tokio",
  "toml_edit",
  "toon-format",
+ "tracing",
  "tui-tree-widget",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2632,6 +2632,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2741,6 +2747,15 @@ name = "macro_rules_attribute-proc_macro"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matrixmultiply"
@@ -3345,6 +3360,9 @@ dependencies = [
  "thiserror 2.0.18",
  "toml",
  "toon-format",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-c",
  "tree-sitter-cpp",
@@ -3951,6 +3969,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4108,6 +4135,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4189,6 +4222,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -4538,6 +4580,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4555,6 +4610,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -4812,6 +4896,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3341,6 +3341,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror 2.0.18",
  "toml",
  "toon-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,11 @@ ureq = { version = "3", default-features = false, features = ["rustls"] }
 tempfile = "3"
 toon-format = { version = "0.5.0", default-features = false }
 toml = "1.1"
+# Structured debug logging (config-gated `[log]`; off by default). Native-only crate, so the
+# thread/file-based appender is unrestricted. See rag-rat-core/src/logging.
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "json", "registry"] }
+tracing-appender = "0.2"
 # Grammar crates are exact-pinned so parser node coverage changes deliberately.
 tree-sitter = "=0.26.9"
 tree-sitter-c = "=0.24.2"

--- a/crates/rag-rat-cli/Cargo.toml
+++ b/crates/rag-rat-cli/Cargo.toml
@@ -28,6 +28,7 @@ rag-rat-mcp = { workspace = true }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
+tracing.workspace = true
 
 # Consumed only by the unix-gated terminal-reset guard (`init/mod.rs`) — dead on non-unix targets,
 # so gate it there to match rag-rat-core / rag-rat-mcp (#240).

--- a/crates/rag-rat-cli/src/commands/clones.rs
+++ b/crates/rag-rat-cli/src/commands/clones.rs
@@ -291,6 +291,7 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
+            log: Default::default(),
         };
         IndexDatabase::rebuild(&config).unwrap();
 

--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -338,20 +338,22 @@ fn run_maintenance_pass(
     rag_rat_core::watch::refresh_worktree_overlays(&mut db, config, budget.as_ref());
     // The base reconcile gets whatever budget the overlays left; `None` → exhausted (or no cap left
     // at all), so skip it rather than start a fresh full-budget reconcile.
-    let reconcile_report =
-        match budget.as_ref().and_then(rag_rat_core::watch::ReconcileBudget::next_options) {
-            Some(options) => {
-                let report = db.reconcile_with_options_progress(options, render_reconcile_progress)?;
-                tracing::info!(target: "rag_rat_core::maintenance", phase = "reconcile", ran = true, status = %report.status, "phase complete");
-                Some(report)
-            },
-            None => {
-                // No budget left (overlays/reencode consumed it) or a 0-cap "skip embedding" pass —
-                // this is a common reason the base backlog stays non-empty across hook passes.
-                tracing::info!(target: "rag_rat_core::maintenance", phase = "reconcile", ran = false, skip_reason = "no_budget_remaining", "phase skipped");
-                None
-            },
-        };
+    let reconcile_report = match budget
+        .as_ref()
+        .and_then(rag_rat_core::watch::ReconcileBudget::next_options)
+    {
+        Some(options) => {
+            let report = db.reconcile_with_options_progress(options, render_reconcile_progress)?;
+            tracing::info!(target: "rag_rat_core::maintenance", phase = "reconcile", ran = true, status = %report.status, "phase complete");
+            Some(report)
+        },
+        None => {
+            // No budget left (overlays/reencode consumed it) or a 0-cap "skip embedding" pass —
+            // this is a common reason the base backlog stays non-empty across hook passes.
+            tracing::info!(target: "rag_rat_core::maintenance", phase = "reconcile", ran = false, skip_reason = "no_budget_remaining", "phase skipped");
+            None
+        },
+    };
     // Prune index rows for git contexts that are no longer live (worktree-safe; keeps every
     // live worktree's HEAD). Cheap and bounded, so it runs every maintenance pass.
     let gc_report = db.garbage_collect().ok();
@@ -465,6 +467,7 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
+            log: Default::default(),
         };
         IndexDatabase::rebuild(&config).unwrap();
 
@@ -529,6 +532,7 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
+            log: Default::default(),
         };
         IndexDatabase::rebuild(&config).unwrap();
 

--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -264,12 +264,19 @@ fn run_maintenance_pass(
     let max_seconds = args.max_seconds.unwrap_or(DEFAULT_MAINTENANCE_SECONDS);
     let started = Instant::now();
 
+    // Debug-log span for the whole pass (off unless `[log]`/`RAG_RAT_LOG`). This is the entry point
+    // for "git action → maintenance → embedding"; the per-phase events below make it legible.
+    let _span = tracing::info_span!("maintenance_pass", %trigger, max_seconds).entered();
+    tracing::info!(target: "rag_rat_core::maintenance", "maintenance pass started");
+
     // Serialize with the background watcher (and other writers). The hook backgrounds this command,
     // so blocking here never holds up the git operation; busy_timeout backstops the query-path
     // heal.
     let _lock = rag_rat_core::locks::WriteLock::acquire_blocking(&config.database)?;
+    tracing::debug!(target: "rag_rat_core::maintenance", phase = "lock_acquired", elapsed_ms = started.elapsed().as_millis() as u64, "write lock acquired");
 
     let mut db = IndexDatabase::index_discover_with_progress(config, render_index_progress)?;
+    tracing::debug!(target: "rag_rat_core::maintenance", phase = "index_discover", elapsed_ms = started.elapsed().as_millis() as u64, "phase complete");
     // One-time on upgrade: re-encode any legacy f32 vector blobs to the compact int8 format (#312).
     // Meta-gated, so this runs once and then skips the table scan cheaply on every later pass; run
     // on the BASE index (not per-overlay) before the worktree refresh re-scopes the connection.
@@ -333,9 +340,17 @@ fn run_maintenance_pass(
     // at all), so skip it rather than start a fresh full-budget reconcile.
     let reconcile_report =
         match budget.as_ref().and_then(rag_rat_core::watch::ReconcileBudget::next_options) {
-            Some(options) =>
-                Some(db.reconcile_with_options_progress(options, render_reconcile_progress)?),
-            None => None,
+            Some(options) => {
+                let report = db.reconcile_with_options_progress(options, render_reconcile_progress)?;
+                tracing::info!(target: "rag_rat_core::maintenance", phase = "reconcile", ran = true, status = %report.status, "phase complete");
+                Some(report)
+            },
+            None => {
+                // No budget left (overlays/reencode consumed it) or a 0-cap "skip embedding" pass —
+                // this is a common reason the base backlog stays non-empty across hook passes.
+                tracing::info!(target: "rag_rat_core::maintenance", phase = "reconcile", ran = false, skip_reason = "no_budget_remaining", "phase skipped");
+                None
+            },
         };
     // Prune index rows for git contexts that are no longer live (worktree-safe; keeps every
     // live worktree's HEAD). Cheap and bounded, so it runs every maintenance pass.
@@ -356,7 +371,19 @@ fn run_maintenance_pass(
     // rename, or change, so relocate symbol/chunk bindings (or flag them) here rather than
     // leaving stale anchors until a manual memory_validate.
     let memory_validation = db.memory_validate().ok();
+    tracing::debug!(target: "rag_rat_core::maintenance", phase = "gc_clone_memory", gc = gc_report.is_some(), clone_graph = clone_graph_report.is_some(), memory_validated = memory_validation.is_some(), "post-reconcile phases complete");
     let plan = db.reconcile_plan()?;
+    // Remaining backlog. NOTE: these plan counts are UNSCOPED (global `files`, all worktrees — see
+    // #360), so a non-zero `missing` here can be sibling-worktree chunks, not the active branch.
+    tracing::info!(
+        target: "rag_rat_core::maintenance",
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        current = plan.embeddings.current,
+        missing = plan.embeddings.missing,
+        stale = plan.embeddings.stale,
+        skipped = plan.embeddings.skipped_total,
+        "maintenance pass complete (remaining backlog is unscoped/cross-worktree, #360)"
+    );
     Ok(serde_json::json!({
         "trigger": trigger,
         "status": "complete",

--- a/crates/rag-rat-cli/src/commands/oracle.rs
+++ b/crates/rag-rat-cli/src/commands/oracle.rs
@@ -479,6 +479,7 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
+            log: Default::default(),
         };
         (root, config)
     }
@@ -524,6 +525,7 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
+            log: Default::default(),
         };
         let config = config_with(vec!["**/*.rs".to_string()], Vec::new());
         let profile = |dirs: &[&str]| {

--- a/crates/rag-rat-cli/src/init/mod.rs
+++ b/crates/rag-rat-cli/src/init/mod.rs
@@ -331,6 +331,7 @@ mod tests {
         assert!(text.contains("# [[target]]"), "documents the expanded target form");
         assert!(text.contains("# [watch]"));
         assert!(text.contains("# [version_check]"));
+        assert!(text.contains("# [log]"));
         assert!(text.contains("# [llm.embedding.runtime]"));
         assert!(text.contains("# [init.cookbooks.modal]"));
         assert!(text.contains("# [init.cookbooks.my-provider]"));
@@ -343,6 +344,8 @@ mod tests {
         assert_eq!(config.targets[0].language, Language::Cpp);
         // Commented [watch] falls back to its default (enabled).
         assert!(config.watch.enabled);
+        // Commented [log] falls back to its default (disabled).
+        assert!(!config.log.enabled);
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/crates/rag-rat-cli/src/init/render.rs
+++ b/crates/rag-rat-cli/src/init/render.rs
@@ -80,6 +80,17 @@ pub(crate) fn render_config(plan: &InitPlan) -> String {
          blocks.\n# [version_check]\n# enabled = true\n\n",
     );
 
+    text.push_str(
+        "# Debug logging — per-process files under `.rag-rat/logs/` (off by default). Traces the \
+         git-hook\n# maintenance / reconcile / embedding lifecycle. `RAG_RAT_LOG` \
+         (RUST_LOG-style) overrides\n# `level`/`filter` and can force-enable it for a single \
+         command.\n# [log]\n# enabled = false\n# level = \"info\"              # off | error | \
+         warn | info | debug | trace\n# filter = \"rag_rat_core::index::ai=debug\"   # optional \
+         per-subsystem directives\n# format = \"text\"             # text | json\n# \
+         retention_days = 7          # prune log files older than this on startup\n# max_files = \
+         200             # cap on files kept (oldest pruned first)\n\n",
+    );
+
     text.push_str("[oracle]\n");
     text.push_str(
         "# Background auto-refresh of compiler-grade (SCIP) importance ranking. Needs a \

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -78,8 +78,8 @@ fn main() -> anyhow::Result<()> {
     let config = load_config_or_hint(&cli.config)?;
     apply_embedding_runtime_env(&config.llm.embedding.runtime);
 
-    // Debug logging (off unless `[log] enabled` or `RAG_RAT_LOG`). Held for the whole command,
-    // including the long-lived `run_stdio` under `Cmd::Mcp`, so the guard flushes on process exit.
+    // Debug logging (off unless `[log] enabled` or `RAG_RAT_LOG`). Writes are blocking (synchronous
+    // to the file), so nothing is lost on exit or on the `Cmd::Mcp` hot-upgrade `exec()`.
     // `Cmd::Init` / `Cmd::ClaudeHook` returned above (no config, and claude-hook fires
     // per-tool-call — logging it would flood the per-process dir and evict the mcp/maintenance
     // signal).

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -78,6 +78,13 @@ fn main() -> anyhow::Result<()> {
     let config = load_config_or_hint(&cli.config)?;
     apply_embedding_runtime_env(&config.llm.embedding.runtime);
 
+    // Debug logging (off unless `[log] enabled` or `RAG_RAT_LOG`). Held for the whole command,
+    // including the long-lived `run_stdio` under `Cmd::Mcp`, so the guard flushes on process exit.
+    // `Cmd::Init` / `Cmd::ClaudeHook` returned above (no config, and claude-hook fires
+    // per-tool-call — logging it would flood the per-process dir and evict the mcp/maintenance
+    // signal).
+    let _log = rag_rat_core::logging::init_logging(&config, log_role(&cli.command));
+
     match cli.command {
         Cmd::Init(_) | Cmd::ClaudeHook => unreachable!("handled before the config load above"),
         Cmd::Index(args) => index(&config, &args)?,
@@ -338,6 +345,30 @@ pub(crate) fn load_config_or_hint(path: &str) -> anyhow::Result<Config> {
         );
     }
     Ok(Config::load(path)?)
+}
+
+/// Map the invoked subcommand to a debug-log [`Role`](rag_rat_core::logging::Role) (drives the log
+/// file name + startup event). The git hooks invoke `rag-rat maintenance --trigger post-*`, so a
+/// maintenance pass with a git-origin trigger is the `hook` role — the reconcile/embedding path we
+/// most want to trace. A manual `maintenance` and every other command are `cli:<name>`.
+fn log_role(cmd: &Cmd) -> rag_rat_core::logging::Role {
+    use rag_rat_core::logging::Role;
+    match cmd {
+        Cmd::Mcp => Role::Mcp,
+        Cmd::Maintenance(args) if is_git_hook_trigger(args.trigger.as_deref()) => Role::Hook,
+        Cmd::Maintenance(_) => Role::Cli("maintenance".to_string()),
+        Cmd::Reconcile(_) => Role::Cli("reconcile".to_string()),
+        Cmd::Index(_) => Role::Cli("index".to_string()),
+        Cmd::Doctor => Role::Cli("doctor".to_string()),
+        Cmd::Gc => Role::Cli("gc".to_string()),
+        _ => Role::Cli("cmd".to_string()),
+    }
+}
+
+/// The git-hook `--trigger` values that mark a maintenance pass as hook-originated (vs a manual
+/// run).
+fn is_git_hook_trigger(trigger: Option<&str>) -> bool {
+    matches!(trigger, Some("post-commit" | "post-checkout" | "post-merge" | "post-rewrite"))
 }
 
 /// Open the index for a read command, mapping a not-yet-built index to a friendly hint instead

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -33,6 +33,9 @@ sha2.workspace = true
 thiserror.workspace = true
 toml.workspace = true
 toon-format.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+tracing-appender.workspace = true
 ureq.workspace = true
 # Dictionary-trained zstd compression of stored chunk text (#77 Phase 2). One shared dictionary
 # trained on a corpus sample (zdict_builder) + bulk one-shot compress/decompress per chunk blob.

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -64,6 +64,7 @@ iai-callgrind = "0.16"
 # Wall-clock benchmarking (full-index time on a larger corpus). default-features off to skip the
 # plotting deps — Bencher parses criterion's stdout estimates.
 criterion = { version = "0.8", default-features = false }
+tempfile.workspace = true
 
 # iai-callgrind: deterministic instruction counts (index + cold/warm query).
 [[bench]]

--- a/crates/rag-rat-core/benches/shared/mod.rs
+++ b/crates/rag-rat-core/benches/shared/mod.rs
@@ -68,6 +68,7 @@ pub fn bench_config(subdir: &str) -> Config {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     }
 }
 

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -19,6 +19,7 @@ pub struct Config {
     pub targets: Vec<ResolvedTarget>,
     pub llm: LlmConfig,
     pub watch: WatchConfig,
+    pub log: LogConfig,
     pub version_check: VersionCheckConfig,
     pub oracle: OracleConfig,
     pub search: SearchConfig,
@@ -96,6 +97,89 @@ pub struct WatchConfig {
 impl Default for WatchConfig {
     fn default() -> Self {
         Self { enabled: true, debounce_ms: 400, max_latency_ms: 2500, periodic_sweep_secs: 300 }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogLevel {
+    Off,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl LogLevel {
+    fn parse(s: &str) -> Option<Self> {
+        Some(match s.trim().to_ascii_lowercase().as_str() {
+            "off" => Self::Off,
+            "error" => Self::Error,
+            "warn" => Self::Warn,
+            "info" => Self::Info,
+            "debug" => Self::Debug,
+            "trace" => Self::Trace,
+            _ => return None,
+        })
+    }
+
+    /// The EnvFilter directive string for this level.
+    pub fn as_filter_str(&self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Error => "error",
+            Self::Warn => "warn",
+            Self::Info => "info",
+            Self::Debug => "debug",
+            Self::Trace => "trace",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogFormat {
+    Text,
+    Json,
+}
+
+impl LogFormat {
+    fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "text" => Some(Self::Text),
+            "json" => Some(Self::Json),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogConfig {
+    /// Master switch (default false). `RAG_RAT_LOG` can force-enable at init even when false.
+    pub enabled: bool,
+    pub level: LogLevel,
+    /// Optional per-subsystem EnvFilter directives (e.g. `rag_rat_core::index::ai=debug`).
+    pub filter: Option<String>,
+    /// Resolved absolute log dir (finalized in `load()` to the db sibling by default).
+    pub dir: PathBuf,
+    pub format: LogFormat,
+    /// Roll/prune a file once it exceeds this many bytes (0 disables the size check).
+    pub max_file_bytes: u64,
+    pub retention_days: u64,
+    pub max_files: u64,
+}
+
+impl Default for LogConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            level: LogLevel::Info,
+            filter: None,
+            dir: PathBuf::from(".rag-rat/logs"),
+            format: LogFormat::Text,
+            max_file_bytes: 50 * 1024 * 1024,
+            retention_days: 7,
+            max_files: 200,
+        }
     }
 }
 
@@ -647,8 +731,18 @@ impl Config {
         let version_check = raw.version_check.into();
         let oracle = raw.oracle.into();
         let search = raw.search.into();
+        let mut log = LogConfig::try_from(raw.log)?;
+        // Finalize `dir`: empty (unset) → sibling of the db (`<db_parent>/logs`); a set value is
+        // resolved relative to the config dir (absolute honored). Mirrors the cookbook-path rule.
+        log.dir = if log.dir.as_os_str().is_empty() {
+            database.parent().map(|p| p.join("logs")).unwrap_or_else(|| PathBuf::from("logs"))
+        } else if log.dir.is_absolute() {
+            log.dir.clone()
+        } else {
+            config_dir.join(&log.dir)
+        };
 
-        Ok(Self { root, database, targets, llm, watch, version_check, oracle, search })
+        Ok(Self { root, database, targets, llm, watch, version_check, oracle, search, log })
     }
 }
 
@@ -809,6 +903,8 @@ struct RawConfig {
     #[serde(default)]
     watch: RawWatch,
     #[serde(default)]
+    log: RawLog,
+    #[serde(default)]
     version_check: RawVersionCheck,
     #[serde(default)]
     oracle: RawOracle,
@@ -837,6 +933,45 @@ impl From<RawWatch> for WatchConfig {
             max_latency_ms: raw.max_latency_ms.unwrap_or(default.max_latency_ms),
             periodic_sweep_secs: raw.periodic_sweep_secs.unwrap_or(default.periodic_sweep_secs),
         }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawLog {
+    enabled: Option<bool>,
+    level: Option<String>,
+    filter: Option<String>,
+    dir: Option<String>,
+    format: Option<String>,
+    max_file_bytes: Option<u64>,
+    retention_days: Option<u64>,
+    max_files: Option<u64>,
+}
+
+impl TryFrom<RawLog> for LogConfig {
+    type Error = ConfigError;
+
+    fn try_from(raw: RawLog) -> Result<Self, Self::Error> {
+        let d = LogConfig::default();
+        let level = match raw.level {
+            Some(s) => LogLevel::parse(&s).ok_or(ConfigError::UnknownLogLevel(s))?,
+            None => d.level,
+        };
+        let format = match raw.format {
+            Some(s) => LogFormat::parse(&s).ok_or(ConfigError::UnknownLogFormat(s))?,
+            None => d.format,
+        };
+        Ok(Self {
+            enabled: raw.enabled.unwrap_or(d.enabled),
+            level,
+            filter: raw.filter.filter(|s| !s.trim().is_empty()),
+            // `dir` is finalized in `load()` (needs the db path); raw value passed through as-is.
+            dir: raw.dir.map(PathBuf::from).unwrap_or_default(),
+            format,
+            max_file_bytes: raw.max_file_bytes.unwrap_or(d.max_file_bytes),
+            retention_days: raw.retention_days.unwrap_or(d.retention_days),
+            max_files: raw.max_files.unwrap_or(d.max_files),
+        })
     }
 }
 
@@ -1231,6 +1366,10 @@ pub enum ConfigError {
     DuplicateTarget(String),
     #[error("configured directory does not exist: {0}")]
     MissingDirectory(PathBuf),
+    #[error("[log] `level` must be one of off|error|warn|info|debug|trace (got `{0}`)")]
+    UnknownLogLevel(String),
+    #[error("[log] `format` must be `text` or `json` (got `{0}`)")]
+    UnknownLogFormat(String),
 }
 
 #[cfg(test)]
@@ -2310,5 +2449,44 @@ mod tests {
         let err = resolve_targets(&root, simple, Vec::new()).unwrap_err();
 
         assert!(err.to_string().contains("unknown language"));
+    }
+
+    #[test]
+    fn log_config_defaults_off() {
+        let raw: RawConfig = toml::from_str("").unwrap();
+        let log: LogConfig = raw.log.try_into().unwrap();
+        assert!(!log.enabled);
+        assert_eq!(log.level, LogLevel::Info);
+        assert_eq!(log.format, LogFormat::Text);
+        assert_eq!(log.retention_days, 7);
+        assert_eq!(log.max_files, 200);
+    }
+
+    #[test]
+    fn log_config_parses_and_rejects_unknown_level_and_format() {
+        let raw: RawConfig = toml::from_str(
+            "[log]\nenabled=true\nlevel=\"debug\"\nformat=\"json\"\nfilter=\"\
+             rag_rat_core::index::ai=trace\"\nmax_files=10",
+        )
+        .unwrap();
+        let log: LogConfig = raw.log.try_into().unwrap();
+        assert!(log.enabled);
+        assert_eq!(log.level, LogLevel::Debug);
+        assert_eq!(log.format, LogFormat::Json);
+        assert_eq!(log.filter.as_deref(), Some("rag_rat_core::index::ai=trace"));
+        assert_eq!(log.max_files, 10);
+
+        let bad_level: RawConfig = toml::from_str("[log]\nlevel=\"loud\"").unwrap();
+        assert!(matches!(LogConfig::try_from(bad_level.log), Err(ConfigError::UnknownLogLevel(_))));
+        let bad_fmt: RawConfig = toml::from_str("[log]\nformat=\"xml\"").unwrap();
+        assert!(matches!(LogConfig::try_from(bad_fmt.log), Err(ConfigError::UnknownLogFormat(_))));
+    }
+
+    #[test]
+    fn log_dir_defaults_to_db_sibling_and_custom_is_config_relative() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("rag-rat.toml"), "[log]\nenabled=true\n").unwrap();
+        let cfg = Config::load(dir.path().join("rag-rat.toml")).unwrap();
+        assert_eq!(cfg.log.dir, cfg.database.parent().unwrap().join("logs"));
     }
 }

--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -197,6 +197,24 @@ pub(crate) enum ChunkEmbedder {
 /// usual `active_embedder`. Provisioning happens ONCE here, not per batch. `provision_remote` gates
 /// the cold-start (only an explicit `rag-rat reconcile` sets it); `scan`/`options` size the
 /// provision-path pending-work check.
+/// Strip credentials + path from an endpoint URL before logging it: keep `scheme://host[:port]`
+/// only. A debug log is a shared, greppable on-disk artifact, and an endpoint may carry inline
+/// `user:pass@` userinfo (the connect/query endpoints support it — see `endpoint_is_loopback`), so
+/// the raw URL must never land in a log line.
+pub(crate) fn sanitize_endpoint(url: &str) -> String {
+    let (scheme, rest) = match url.split_once("://") {
+        Some((scheme, rest)) => (Some(scheme), rest),
+        None => (None, url),
+    };
+    // Authority is up to the first path/query/fragment delimiter; drop any `user:pass@` userinfo.
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest);
+    let host_port = authority.rsplit_once('@').map_or(authority, |(_, host_port)| host_port);
+    match scheme {
+        Some(scheme) => format!("{scheme}://{host_port}"),
+        None => host_port.to_string(),
+    }
+}
+
 pub(crate) fn acquire_chunk_embedder(
     conn: &Connection,
     intra_threads: Option<usize>,
@@ -245,7 +263,7 @@ pub(crate) fn acquire_chunk_embedder(
             }
             // The #356 light path: this is the "local embedding after a git action" the maintenance
             // hook triggers — embeds changed chunks against the LOCAL query_endpoint, no paid box.
-            tracing::debug!(target: "rag_rat_core::index::ai::providers", path = "local_query_endpoint", endpoint = remote.query_endpoint.as_deref().unwrap_or(""), "light/incremental reconcile embeds locally against query_endpoint");
+            tracing::debug!(target: "rag_rat_core::index::ai::providers", path = "local_query_endpoint", endpoint = %sanitize_endpoint(remote.query_endpoint.as_deref().unwrap_or("")), "light/incremental reconcile embeds locally against query_endpoint");
             return ChunkEmbedder::Ready {
                 embedder,
                 provisioned: None,
@@ -549,5 +567,16 @@ mod dispatch_tests {
         let connect = remote_at("http://box:11434");
         let q = query_embed_config(&connect);
         assert_eq!(q, connect, "connect query config is the config unchanged");
+    }
+
+    #[test]
+    fn sanitize_endpoint_strips_credentials_and_path() {
+        assert_eq!(sanitize_endpoint("http://u:p@h:7997/embeddings"), "http://h:7997");
+        assert_eq!(sanitize_endpoint("http://localhost:7997"), "http://localhost:7997");
+        assert_eq!(
+            sanitize_endpoint("https://user:secret@gpu.host/v1/embeddings"),
+            "https://gpu.host"
+        );
+        assert_eq!(sanitize_endpoint(""), "");
     }
 }

--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -229,6 +229,7 @@ pub(crate) fn acquire_chunk_embedder(
             // pays. The probe (and every light embed) is bounded by the transport's clamped
             // timeout, so a hung server can't stall the watcher.
             if remote.query_endpoint.is_none() {
+                tracing::debug!(target: "rag_rat_core::index::ai::providers", path = "skip_ephemeral", reason = "no_query_endpoint", "light reconcile: no local query_endpoint, deferring to explicit reconcile");
                 return ChunkEmbedder::SkipEphemeral;
             }
             let transport = light_incremental_config(remote);
@@ -239,8 +240,12 @@ pub(crate) fn acquire_chunk_embedder(
                 Err(_) => return ChunkEmbedder::SkipEphemeral,
             };
             if embedder.embed_batch(&["ping".to_string()]).is_err() {
+                tracing::debug!(target: "rag_rat_core::index::ai::providers", path = "skip_ephemeral", reason = "local_probe_failed", "light reconcile: query_endpoint probe failed, deferring");
                 return ChunkEmbedder::SkipEphemeral;
             }
+            // The #356 light path: this is the "local embedding after a git action" the maintenance
+            // hook triggers — embeds changed chunks against the LOCAL query_endpoint, no paid box.
+            tracing::debug!(target: "rag_rat_core::index::ai::providers", path = "local_query_endpoint", endpoint = remote.query_endpoint.as_deref().unwrap_or(""), "light/incremental reconcile embeds locally against query_endpoint");
             return ChunkEmbedder::Ready {
                 embedder,
                 provisioned: None,
@@ -254,7 +259,10 @@ pub(crate) fn acquire_chunk_embedder(
         // to provisioning rather than skip real work on a transient query failure. The estimate is
         // reused below to decide whether a concurrency sweep is worthwhile.
         let estimated_jobs = match estimated_reconcile_jobs(conn, scan, options) {
-            Ok(0) => return ChunkEmbedder::NoEphemeralWork,
+            Ok(0) => {
+                tracing::debug!(target: "rag_rat_core::index::ai::providers", path = "no_ephemeral_work", "explicit reconcile: no candidate work, skipping paid-box provisioning");
+                return ChunkEmbedder::NoEphemeralWork;
+            },
             Ok(n) => Some(n),
             Err(_) => None,
         };
@@ -291,6 +299,7 @@ pub(crate) fn acquire_chunk_embedder(
                 scan.max_embedding_chars,
             ),
         };
+        tracing::info!(target: "rag_rat_core::index::ai::providers", path = "provision_ephemeral", estimated_jobs = ?estimated_jobs, "explicit reconcile: provisioning ephemeral embedding box");
         return match provision_and_build(remote, spec, Some(tune)) {
             Ok((embedder, provisioned, effective_remote, window_concurrency)) => {
                 // Size the reconcile selection window by the EMBEDDER's real fan-out (the tuned

--- a/crates/rag-rat-core/src/index/ai/providers/openai.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/openai.rs
@@ -509,8 +509,11 @@ impl Embedder for OpenAiEmbedder {
         // configured concurrency at once. Results are joined in request/input order, so HTTP
         // completion order cannot reorder vectors.
         let ranges = self.sub_batch_ranges(texts);
+        let started = std::time::Instant::now();
         if ranges.len() == 1 {
-            return self.embed_one_request(texts);
+            let result = self.embed_one_request(texts);
+            tracing::debug!(target: "rag_rat_core::index::ai::embed", endpoint = %self.embed_url, model = %self.server_model, texts = texts.len(), sub_batches = 1usize, dim = self.dim, ok = result.is_ok(), duration_ms = started.elapsed().as_millis() as u64, "embed request");
+            return result;
         }
         let mut out = Vec::with_capacity(texts.len());
         for window in ranges.chunks(self.concurrency) {
@@ -541,6 +544,7 @@ impl Embedder for OpenAiEmbedder {
                 out.extend(result?);
             }
         }
+        tracing::debug!(target: "rag_rat_core::index::ai::embed", endpoint = %self.embed_url, model = %self.server_model, texts = texts.len(), sub_batches = ranges.len(), dim = self.dim, ok = true, duration_ms = started.elapsed().as_millis() as u64, "embed request (fan-out)");
         Ok(out)
     }
 }

--- a/crates/rag-rat-core/src/index/ai/providers/openai.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/openai.rs
@@ -512,7 +512,7 @@ impl Embedder for OpenAiEmbedder {
         let started = std::time::Instant::now();
         if ranges.len() == 1 {
             let result = self.embed_one_request(texts);
-            tracing::debug!(target: "rag_rat_core::index::ai::embed", endpoint = %self.embed_url, model = %self.server_model, texts = texts.len(), sub_batches = 1usize, dim = self.dim, ok = result.is_ok(), duration_ms = started.elapsed().as_millis() as u64, "embed request");
+            tracing::debug!(target: "rag_rat_core::index::ai::embed", endpoint = %super::sanitize_endpoint(&self.embed_url), model = %self.server_model, texts = texts.len(), sub_batches = 1usize, dim = self.dim, ok = result.is_ok(), duration_ms = started.elapsed().as_millis() as u64, "embed request");
             return result;
         }
         let mut out = Vec::with_capacity(texts.len());
@@ -544,7 +544,7 @@ impl Embedder for OpenAiEmbedder {
                 out.extend(result?);
             }
         }
-        tracing::debug!(target: "rag_rat_core::index::ai::embed", endpoint = %self.embed_url, model = %self.server_model, texts = texts.len(), sub_batches = ranges.len(), dim = self.dim, ok = true, duration_ms = started.elapsed().as_millis() as u64, "embed request (fan-out)");
+        tracing::debug!(target: "rag_rat_core::index::ai::embed", endpoint = %super::sanitize_endpoint(&self.embed_url), model = %self.server_model, texts = texts.len(), sub_batches = ranges.len(), dim = self.dim, ok = true, duration_ms = started.elapsed().as_millis() as u64, "embed request (fan-out)");
         Ok(out)
     }
 }

--- a/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
@@ -377,6 +377,19 @@ pub(crate) fn reconcile_with_options_progress(
         failed_chunks: report.failed_chunks,
         blocked_chunks: report.blocked_chunks,
     });
+    // `report.status` is the stop-reason (Current | Partial | Failed | Blocked); `remote` shows
+    // whether an offload backend was configured (a local light/incremental pass has none). The
+    // active-scope proof for #360 (commit/worktree/view-installed, raw-vs-scoped counts) is a
+    // deferred follow-up — it needs a conn-level scope introspection helper.
+    tracing::info!(
+        target: "rag_rat_core::index::ai::reconcile",
+        status = %report.status,
+        embedded = report.embeddings_written,
+        processed = report.processed_chunks,
+        failed = report.failed_chunks,
+        remote = remote_config.is_some(),
+        "reconcile complete"
+    );
     Ok(report)
 }
 

--- a/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
@@ -377,8 +377,9 @@ pub(crate) fn reconcile_with_options_progress(
         failed_chunks: report.failed_chunks,
         blocked_chunks: report.blocked_chunks,
     });
-    // `report.status` is the stop-reason (Current | Partial | Failed | Blocked); `remote` shows
-    // whether an offload backend was configured (a local light/incremental pass has none). The
+    // `report.status` is the stop-reason reaching here (Current | Partial | Failed — the Blocked /
+    // NotReady acquire outcomes returned earlier); `remote` shows whether an offload backend was
+    // configured (a local light/incremental pass has none). The
     // active-scope proof for #360 (commit/worktree/view-installed, raw-vs-scoped counts) is a
     // deferred follow-up — it needs a conn-level scope introspection helper.
     tracing::info!(

--- a/crates/rag-rat-core/src/index/mem_diag.rs
+++ b/crates/rag-rat-core/src/index/mem_diag.rs
@@ -57,10 +57,15 @@ pub(crate) fn mem_trace(label: &str) {
     // the 1 s sampler's spike window falls inside.
     static FIRST: std::sync::OnceLock<std::time::Instant> = std::sync::OnceLock::new();
     let elapsed = FIRST.get_or_init(std::time::Instant::now).elapsed().as_secs_f64();
+    let rss_gb = vmrss_kb as f64 / 1024.0 / 1024.0;
+    let sqlite_gb = sqlite_bytes as f64 / 1_073_741_824.0;
+    let sqlite_peak_gb = sqlite_peak as f64 / 1_073_741_824.0;
     eprintln!(
-        "MEMTRACE {label}: t+{elapsed:.0}s rss={:.2}GB sqlite={:.2}GB sqlite_peak={:.2}GB",
-        vmrss_kb as f64 / 1024.0 / 1024.0,
-        sqlite_bytes as f64 / 1_073_741_824.0,
-        sqlite_peak as f64 / 1_073_741_824.0,
+        "MEMTRACE {label}: t+{elapsed:.0}s rss={rss_gb:.2}GB sqlite={sqlite_gb:.2}GB \
+         sqlite_peak={sqlite_peak_gb:.2}GB"
     );
+    // Also capture in the debug log (when `[log]` is on). The `RAG_RAT_MEM_TRACE` env gate above
+    // still guards whether this runs at all, so a broad `debug` filter never enables memtrace spam;
+    // the dedicated `rag_rat_core::index::mem_diag` target keeps it filterable on its own.
+    tracing::debug!(target: "rag_rat_core::index::mem_diag", label, elapsed_s = elapsed, rss_gb, sqlite_gb, sqlite_peak_gb, "memtrace");
 }

--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -442,6 +442,7 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
+            log: Default::default(),
         };
         crate::IndexDatabase::rebuild(&config).unwrap()
     }
@@ -551,6 +552,7 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
+            log: Default::default(),
         };
         let db = crate::IndexDatabase::rebuild(&config).unwrap();
 
@@ -614,6 +616,7 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
+            log: Default::default(),
         };
         let db = crate::IndexDatabase::rebuild(&config).unwrap();
 

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -693,6 +693,7 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
+            log: Default::default(),
         };
         crate::IndexDatabase::rebuild(&config).unwrap()
     }

--- a/crates/rag-rat-core/src/index/query_api/clones/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/tests.rs
@@ -208,6 +208,7 @@ fn find_clones_rejects_nan_and_non_finite_min_similarity() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     };
     crate::IndexDatabase::rebuild(&config).unwrap();
     let db = crate::IndexDatabase::open_config(&config).unwrap();
@@ -735,6 +736,7 @@ fn recall_candidates_identical_blob_vs_postings_grouping() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     };
     let db = crate::IndexDatabase::rebuild(&config).unwrap();
     let conn = db.storage.connection();

--- a/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
@@ -44,6 +44,7 @@ fn rust_config(root: PathBuf) -> Config {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     }
 }
 
@@ -1163,6 +1164,7 @@ fn deleted_and_generated_paths_counted_in_skipped() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     };
     git(&root, &["init", "-q"]);
     git(&root, &["add", "-A"]);

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
@@ -970,6 +970,7 @@ fn multi_language_clone_integration_finds_within_language_no_cross() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
 
@@ -1161,6 +1162,7 @@ fn find_clones_ranks_a_clean_clone_class_with_metrics() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dir_memory_tree.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dir_memory_tree.rs
@@ -316,6 +316,7 @@ fn dir_tree_label_depth_collapse_single_child_chain() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let conn = db.storage.connection();
@@ -542,6 +543,7 @@ fn dir_tree_truncates_at_max_nodes() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let conn = db.storage.connection();
@@ -685,6 +687,7 @@ fn dir_tree_children_of_collapsed_node_use_leaf_labels() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let conn = db.storage.connection();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/github_papertrail.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/github_papertrail.rs
@@ -308,6 +308,7 @@ fn parser_failures_report_paths() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     };
 
     let db = IndexDatabase::rebuild(&config).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -76,6 +76,7 @@ fn rag_rat_config(root: &Path) -> Config {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     }
 }
 
@@ -204,6 +205,7 @@ fn markdown_config_for_root(root: PathBuf) -> Config {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     }
 }
 
@@ -313,6 +315,7 @@ fn source_config(root: PathBuf, language: Language) -> Config {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     }
 }
 
@@ -657,6 +660,7 @@ fn git_fixture_for_overlay_tests() -> (PathBuf, Config) {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     };
     (root, config)
 }
@@ -758,6 +762,7 @@ fn write_four_renamed_clones(root: &PathBuf) -> IndexDatabase {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     };
     IndexDatabase::rebuild(&config).unwrap()
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
@@ -169,6 +169,7 @@ fn clean_checkout_file_resolves_against_its_own_package_roots() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     };
 
     let db = IndexDatabase::rebuild(&config).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -749,6 +749,7 @@ fn git_history_indexes_commits_paths_queries_and_blame() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let status = db.status(&config.database).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -2063,6 +2063,7 @@ fn repo_brief_ranks_churn_and_god_module_candidates() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
 
@@ -2144,6 +2145,7 @@ fn repo_clusters_groups_cotouched_files() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -23,6 +23,7 @@ fn rebuild_bootstraps_sqlite_schema_for_empty_target_root() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     };
 
     let db = IndexDatabase::rebuild(&config).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
@@ -536,6 +536,7 @@ DEVICE_DT_INST_DEFINE(0, entropy_init, NULL, NULL, NULL,
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
 
@@ -1317,6 +1318,7 @@ where
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let symbol = db.symbols("spawn_blocking", Some(Language::Rust), 10).unwrap().remove(0);

--- a/crates/rag-rat-core/src/lib.rs
+++ b/crates/rag-rat-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod fleet;
 pub mod index;
 pub mod language;
 pub mod locks;
+pub mod logging;
 pub mod output;
 pub mod query;
 pub mod search;

--- a/crates/rag-rat-core/src/logging/mod.rs
+++ b/crates/rag-rat-core/src/logging/mod.rs
@@ -10,7 +10,6 @@
 use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -48,30 +47,33 @@ impl Role {
     }
 }
 
-/// Held by the caller (`main`) for the process lifetime; `Drop` flushes the non-blocking writer, so
-/// short-lived hook/CLI processes don't lose their tail on exit.
+/// Returned by [`init_logging`] and held by the caller (`main`). Writes are BLOCKING (synchronous
+/// to the file), so there is no buffered tail to flush — nothing is lost on a normal exit, a
+/// short-lived hook/CLI process, or the MCP hot-upgrade `exec()` (which never runs destructors).
+/// This handle is just a marker today; keeping it lets the writer strategy change without touching
+/// call sites.
 pub struct LogHandle {
-    _guard: Option<WorkerGuard>,
+    _private: (),
 }
 
 /// A global `tracing` subscriber may be installed only once per process.
 static INIT: OnceLock<()> = OnceLock::new();
 
-/// Install the process-global debug-log subscriber. No-op (returns a guard-less handle) when
-/// logging is disabled, already initialized, or init fails — logging never affects correctness.
+/// Install the process-global debug-log subscriber. No-op (returns an inert handle) when logging is
+/// disabled, already initialized, or init fails — logging never affects correctness.
 pub fn init_logging(config: &Config, role: Role) -> LogHandle {
     let env = std::env::var("RAG_RAT_LOG").ok().filter(|s| !s.trim().is_empty());
     if !config.log.enabled && env.is_none() {
-        return LogHandle { _guard: None };
+        return LogHandle { _private: () };
     }
     if INIT.set(()).is_err() {
-        return LogHandle { _guard: None };
+        return LogHandle { _private: () };
     }
     match try_init(config, &role, env) {
         Ok(handle) => handle,
         Err(err) => {
             eprintln!("rag-rat: debug logging disabled (init failed: {err})");
-            LogHandle { _guard: None }
+            LogHandle { _private: () }
         },
     }
 }
@@ -94,13 +96,15 @@ fn try_init(config: &Config, role: &Role, env: Option<String>) -> anyhow::Result
     let start_ms = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_millis()).unwrap_or(0);
     let file_name = format!("{}-{}-{}.log", role.file_stem(), pid, start_ms);
 
-    // One file per process (no date suffix), non-blocking so the hot MCP path never blocks on IO;
-    // the guard in `LogHandle` flushes on drop for short-lived processes too.
+    // One file per process (no date suffix). BLOCKING writes (the appender is its own `MakeWriter`,
+    // no `non_blocking` worker): every record is synchronously on disk, so nothing is buffered to
+    // lose on a normal exit, a short-lived process, or the MCP hot-upgrade `exec()` (which never
+    // runs destructors). Debug logging is off by default, so the per-event write cost is only
+    // paid when a user has deliberately turned it on to diagnose.
     let appender = tracing_appender::rolling::never(&log.dir, &file_name);
-    let (writer, guard) = tracing_appender::non_blocking(appender);
 
     let registry = tracing_subscriber::registry().with(filter);
-    let fmt_layer = tracing_subscriber::fmt::layer().with_ansi(false).with_writer(writer);
+    let fmt_layer = tracing_subscriber::fmt::layer().with_ansi(false).with_writer(appender);
     match log.format {
         LogFormat::Json => registry.with(fmt_layer.json()).try_init()?,
         LogFormat::Text => registry.with(fmt_layer).try_init()?,
@@ -115,7 +119,7 @@ fn try_init(config: &Config, role: &Role, env: Option<String>) -> anyhow::Result
         version = env!("CARGO_PKG_VERSION"),
         "rag-rat logging started"
     );
-    Ok(LogHandle { _guard: Some(guard) })
+    Ok(LogHandle { _private: () })
 }
 
 #[cfg(test)]
@@ -164,7 +168,7 @@ mod tests {
         {
             let _handle = init_logging(&config, Role::Hook);
             tracing::info!(target: "rag_rat_core::probe", "hello");
-        } // guard drop flushes the non-blocking writer
+        } // blocking writer: both records are already on disk
         let files: Vec<_> =
             std::fs::read_dir(&config.log.dir).unwrap().filter_map(|e| e.ok()).collect();
         assert_eq!(files.len(), 1, "exactly one per-process file");

--- a/crates/rag-rat-core/src/logging/mod.rs
+++ b/crates/rag-rat-core/src/logging/mod.rs
@@ -154,6 +154,9 @@ mod tests {
         assert!(empty, "disabled logging must not create any file");
     }
 
+    // NOTE: `init_logging` installs a PROCESS-GLOBAL subscriber guarded by `INIT` (a `OnceLock`),
+    // so there can be only ONE enabled-logging test per test binary — a second would get a
+    // guard-less no-op handle and see no file. Keep this the sole enabled case in this module.
     #[test]
     fn enabled_config_writes_a_per_process_file_with_startup_event() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/rag-rat-core/src/logging/mod.rs
+++ b/crates/rag-rat-core/src/logging/mod.rs
@@ -1,0 +1,174 @@
+//! Process-level debug logging. Off by default; enabled via `[log]` or `RAG_RAT_LOG`.
+//!
+//! Each process writes its OWN file (`<role>-<pid>-<start_ms>.log`) so concurrent processes (an MCP
+//! server, git-hook maintenance passes, sibling worktrees) never contend on one file. Correlation
+//! is the filename plus a one-shot startup event: the subscriber is process-global, so events from
+//! worker threads (e.g. the embedder's scoped threads) land in the same file — we do NOT rely on
+//! span context propagating across threads/tasks. Growth is bounded by [`retention`] at init (age,
+//! count, size); size-rolling a live file within one long session is a deferred extension.
+
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+use crate::config::{Config, LogFormat};
+
+mod retention;
+
+/// Which kind of process is logging — drives the file name and (for merged-timeline reads) the
+/// `role` field on the startup event.
+#[derive(Debug, Clone)]
+pub enum Role {
+    Mcp,
+    Hook,
+    Cli(String),
+}
+
+impl Role {
+    /// Human-facing role tag (`mcp` | `hook` | `cli:<subcommand>`).
+    pub fn as_str(&self) -> String {
+        match self {
+            Role::Mcp => "mcp".to_string(),
+            Role::Hook => "hook".to_string(),
+            Role::Cli(sub) => format!("cli:{sub}"),
+        }
+    }
+
+    /// Filesystem-safe file-name stem (no `:` — `cli-<subcommand>`).
+    fn file_stem(&self) -> String {
+        match self {
+            Role::Mcp => "mcp".to_string(),
+            Role::Hook => "hook".to_string(),
+            Role::Cli(sub) => format!("cli-{sub}"),
+        }
+    }
+}
+
+/// Held by the caller (`main`) for the process lifetime; `Drop` flushes the non-blocking writer, so
+/// short-lived hook/CLI processes don't lose their tail on exit.
+pub struct LogHandle {
+    _guard: Option<WorkerGuard>,
+}
+
+/// A global `tracing` subscriber may be installed only once per process.
+static INIT: OnceLock<()> = OnceLock::new();
+
+/// Install the process-global debug-log subscriber. No-op (returns a guard-less handle) when
+/// logging is disabled, already initialized, or init fails — logging never affects correctness.
+pub fn init_logging(config: &Config, role: Role) -> LogHandle {
+    let env = std::env::var("RAG_RAT_LOG").ok().filter(|s| !s.trim().is_empty());
+    if !config.log.enabled && env.is_none() {
+        return LogHandle { _guard: None };
+    }
+    if INIT.set(()).is_err() {
+        return LogHandle { _guard: None };
+    }
+    match try_init(config, &role, env) {
+        Ok(handle) => handle,
+        Err(err) => {
+            eprintln!("rag-rat: debug logging disabled (init failed: {err})");
+            LogHandle { _guard: None }
+        },
+    }
+}
+
+fn try_init(config: &Config, role: &Role, env: Option<String>) -> anyhow::Result<LogHandle> {
+    let log = &config.log;
+    std::fs::create_dir_all(&log.dir)?;
+    retention::sweep_retention(&log.dir, log.retention_days, log.max_files, log.max_file_bytes);
+
+    // Filter precedence: RAG_RAT_LOG (if set) overrides the config level+filter; an invalid value
+    // falls back to the config level rather than aborting.
+    let directives = env.unwrap_or_else(|| match &log.filter {
+        Some(filter) => format!("{},{}", log.level.as_filter_str(), filter),
+        None => log.level.as_filter_str().to_string(),
+    });
+    let filter = EnvFilter::try_new(&directives)
+        .unwrap_or_else(|_| EnvFilter::new(log.level.as_filter_str()));
+
+    let pid = std::process::id();
+    let start_ms = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_millis()).unwrap_or(0);
+    let file_name = format!("{}-{}-{}.log", role.file_stem(), pid, start_ms);
+
+    // One file per process (no date suffix), non-blocking so the hot MCP path never blocks on IO;
+    // the guard in `LogHandle` flushes on drop for short-lived processes too.
+    let appender = tracing_appender::rolling::never(&log.dir, &file_name);
+    let (writer, guard) = tracing_appender::non_blocking(appender);
+
+    let registry = tracing_subscriber::registry().with(filter);
+    let fmt_layer = tracing_subscriber::fmt::layer().with_ansi(false).with_writer(writer);
+    match log.format {
+        LogFormat::Json => registry.with(fmt_layer.json()).try_init()?,
+        LogFormat::Text => registry.with(fmt_layer).try_init()?,
+    }
+
+    // The startup event carries the full correlation metadata once (the filename carries role+pid).
+    tracing::info!(
+        target: "rag_rat_core::logging",
+        role = %role.as_str(),
+        pid,
+        root = %config.root.display(),
+        version = env!("CARGO_PKG_VERSION"),
+        "rag-rat logging started"
+    );
+    Ok(LogHandle { _guard: Some(guard) })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Role, init_logging};
+    use crate::config::{Config, LogConfig};
+
+    fn test_config(dir: &std::path::Path, enabled: bool) -> Config {
+        Config {
+            root: dir.to_path_buf(),
+            database: dir.join(".rag-rat/index.sqlite"),
+            targets: Vec::new(),
+            llm: Default::default(),
+            watch: Default::default(),
+            version_check: Default::default(),
+            oracle: Default::default(),
+            search: Default::default(),
+            log: LogConfig { enabled, dir: dir.join("logs"), ..LogConfig::default() },
+        }
+    }
+
+    #[test]
+    fn role_as_str() {
+        assert_eq!(Role::Mcp.as_str(), "mcp");
+        assert_eq!(Role::Hook.as_str(), "hook");
+        assert_eq!(Role::Cli("reconcile".into()).as_str(), "cli:reconcile");
+    }
+
+    #[test]
+    fn disabled_config_creates_no_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path(), false);
+        let _handle = init_logging(&config, Role::Cli("gc".into()));
+        let empty = !config.log.dir.exists()
+            || std::fs::read_dir(&config.log.dir).unwrap().next().is_none();
+        assert!(empty, "disabled logging must not create any file");
+    }
+
+    #[test]
+    fn enabled_config_writes_a_per_process_file_with_startup_event() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_config(dir.path(), true);
+        {
+            let _handle = init_logging(&config, Role::Hook);
+            tracing::info!(target: "rag_rat_core::probe", "hello");
+        } // guard drop flushes the non-blocking writer
+        let files: Vec<_> =
+            std::fs::read_dir(&config.log.dir).unwrap().filter_map(|e| e.ok()).collect();
+        assert_eq!(files.len(), 1, "exactly one per-process file");
+        let name = files[0].file_name().into_string().unwrap();
+        assert!(name.starts_with("hook-"), "role-prefixed file name, got {name}");
+        let body = std::fs::read_to_string(files[0].path()).unwrap();
+        assert!(body.contains("rag-rat logging started"), "startup event present");
+        assert!(body.contains("hello"), "subsequent event present");
+    }
+}

--- a/crates/rag-rat-core/src/logging/retention.rs
+++ b/crates/rag-rat-core/src/logging/retention.rs
@@ -1,0 +1,104 @@
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+/// Best-effort cleanup of the per-process log dir. Any IO error is swallowed — logging cleanup must
+/// never abort a command. Order: (1) drop files older than `retention_days`; (2) drop files larger
+/// than `max_file_bytes` (0 disables); (3) enforce `max_files` (oldest by mtime first).
+pub(super) fn sweep_retention(
+    dir: &Path,
+    retention_days: u64,
+    max_files: u64,
+    max_file_bytes: u64,
+) {
+    let mut entries: Vec<(std::path::PathBuf, SystemTime, u64)> = match std::fs::read_dir(dir) {
+        Ok(rd) => rd
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|x| x == "log"))
+            .filter_map(|e| {
+                let meta = e.metadata().ok()?;
+                Some((e.path(), meta.modified().ok()?, meta.len()))
+            })
+            .collect(),
+        Err(_) => return,
+    };
+
+    if retention_days > 0
+        && let Some(cutoff) = SystemTime::now()
+            .checked_sub(Duration::from_secs(retention_days.saturating_mul(86_400)))
+    {
+        entries.retain(|(path, mtime, _)| {
+            if *mtime < cutoff {
+                let _ = std::fs::remove_file(path);
+                false
+            } else {
+                true
+            }
+        });
+    }
+
+    if max_file_bytes > 0 {
+        entries.retain(|(path, _, len)| {
+            if *len > max_file_bytes {
+                let _ = std::fs::remove_file(path);
+                false
+            } else {
+                true
+            }
+        });
+    }
+
+    if max_files > 0 && entries.len() as u64 > max_files {
+        entries.sort_by_key(|(_, mtime, _)| *mtime); // oldest first
+        let remove = entries.len() - max_files as usize;
+        for (path, _, _) in entries.into_iter().take(remove) {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sweep_retention;
+
+    #[test]
+    fn prunes_by_age_then_count() {
+        let dir = tempfile::tempdir().unwrap();
+        for i in 0..5 {
+            std::fs::write(dir.path().join(format!("mcp-{i}.log")), "x").unwrap();
+        }
+        // Age out the first two via an mtime deep in the past.
+        let old = std::time::SystemTime::UNIX_EPOCH;
+        for i in 0..2 {
+            let file = std::fs::File::options()
+                .write(true)
+                .open(dir.path().join(format!("mcp-{i}.log")))
+                .unwrap();
+            file.set_modified(old).unwrap();
+        }
+        sweep_retention(
+            dir.path(),
+            /* days */ 7,
+            /* max_files */ 100,
+            /* max_bytes */ 0,
+        );
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 3, "2 aged out");
+
+        // Cap the count at 1 → oldest-first prune to 1.
+        sweep_retention(dir.path(), /* days */ 3650, /* max_files */ 1, 0);
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn prunes_oversize_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("mcp-big.log"), vec![b'x'; 4096]).unwrap();
+        std::fs::write(dir.path().join("mcp-small.log"), b"x").unwrap();
+        sweep_retention(dir.path(), 0, 0, /* max_bytes */ 1024);
+        let names: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().into_string().unwrap())
+            .collect();
+        assert_eq!(names, vec!["mcp-small.log".to_string()], "oversize pruned, small kept");
+    }
+}

--- a/crates/rag-rat-core/src/logging/retention.rs
+++ b/crates/rag-rat-core/src/logging/retention.rs
@@ -14,11 +14,10 @@ const RECENT_SECS: u64 = 300;
 /// recently; otherwise it is PROTECTED (a live process may hold the fd — unlinking it would strand
 /// the writer on a deleted inode). Protected files are still COUNTED against `max_files`.
 ///
-/// Candidates are pruned by (a) age > `retention_days` — every platform; (b) size >
-/// `max_file_bytes` and (c) total-count > `max_files` — only where process liveness is verifiable
-/// (unix). On a platform without a liveness probe the size/count rules could evict a live-but-idle
-/// log, so they are skipped there and only the age rule (which reaps files untouched for whole
-/// days) runs.
+/// Candidates are pruned by (a) age > `retention_days`, (b) size > `max_file_bytes`, and (c) total
+/// count > `max_files` — but ONLY where process liveness is verifiable (unix). On a platform
+/// without a liveness probe none of the rules run (a live-but-idle log is indistinguishable from a
+/// dead one), so per-process files simply accumulate there until a proper probe lands.
 pub(super) fn sweep_retention(
     dir: &Path,
     retention_days: u64,
@@ -49,23 +48,27 @@ pub(super) fn sweep_retention(
         Err(_) => return,
     }
 
-    // Age rule — safe on every platform (a file untouched for whole days can't be an active log).
-    if retention_days > 0
-        && let Some(cutoff) = SystemTime::now()
-            .checked_sub(Duration::from_secs(retention_days.saturating_mul(86_400)))
-    {
-        candidates.retain(|(path, mtime, _)| {
-            if *mtime < cutoff {
-                let _ = std::fs::remove_file(path);
-                false
-            } else {
-                true
-            }
-        });
-    }
-
-    // Size + count could evict a live-but-idle log where liveness can't be checked — unix only.
+    // ALL pruning is gated on a verifiable process-liveness probe. Without one (non-unix) a
+    // live-but-idle log can't be told from a dead one — and Rust opens files share-delete on
+    // Windows, so even deleting an open log succeeds (delete-pending) and strands the writer.
+    // So on a platform without the probe we prune NOTHING and let per-process files accumulate
+    // (logging is off by default); a Windows liveness probe is the follow-up. On unix the pid
+    // check makes every rule safe: (a) age > retention_days; (b) size > max_file_bytes; (c)
+    // total count > max_files.
     if cfg!(unix) {
+        if retention_days > 0
+            && let Some(cutoff) = SystemTime::now()
+                .checked_sub(Duration::from_secs(retention_days.saturating_mul(86_400)))
+        {
+            candidates.retain(|(path, mtime, _)| {
+                if *mtime < cutoff {
+                    let _ = std::fs::remove_file(path);
+                    false
+                } else {
+                    true
+                }
+            });
+        }
         if max_file_bytes > 0 {
             candidates.retain(|(path, _, len)| {
                 if *len > max_file_bytes {
@@ -121,8 +124,8 @@ fn process_is_alive(pid: u32) -> bool {
 
 #[cfg(not(unix))]
 fn process_is_alive(_pid: u32) -> bool {
-    // No cheap portable liveness probe; size/count pruning is skipped on this platform (see
-    // `sweep_retention`), so a live log is protected by the recent-mtime window + age-only pruning.
+    // No cheap portable liveness probe. `sweep_retention` skips ALL pruning on this platform, so a
+    // live log is never deleted; this return value is unused there. A Windows probe is a follow-up.
     false
 }
 
@@ -153,6 +156,9 @@ mod tests {
         assert_eq!(rag_rat_log_pid("random-1-2.log"), None); // wrong role prefix
     }
 
+    // All pruning (age/size/count) is unix-only — it needs the pid-liveness probe (see
+    // `sweep_retention` / `process_is_alive`).
+    #[cfg(unix)]
     #[test]
     fn prunes_by_age() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/rag-rat-core/src/logging/retention.rs
+++ b/crates/rag-rat-core/src/logging/retention.rs
@@ -1,35 +1,53 @@
 use std::path::Path;
 use std::time::{Duration, SystemTime};
 
+/// How recently a file must have been touched to be spared regardless of process liveness — a
+/// belt-and-suspenders guard beside the pid-liveness check (e.g. across a pid recycle).
+const RECENT_SECS: u64 = 300;
+
 /// Best-effort cleanup of the per-process log dir. Any IO error is swallowed — logging cleanup must
-/// never abort a command. Order: (1) drop files older than `retention_days`; (2) drop files larger
-/// than `max_file_bytes` (0 disables); (3) enforce `max_files` (oldest by mtime first).
+/// never abort a command.
+///
+/// A file is a prune CANDIDATE only if BOTH hold, so the sweep never deletes something it
+/// shouldn't:
+/// 1. it is one of rag-rat's own per-process logs — `<role>-<pid>-<start_ms>.log` with `role` in
+///    `mcp`/`hook`/`cli-*` (so a shared `[log].dir` containing other apps' `*.log` is untouched);
+///    and
+/// 2. the process that created it (`<pid>`) is no longer alive AND it wasn't touched in the last
+///    few minutes — a live process may still hold the file open, and unlinking it would leave that
+///    process writing to a deleted inode (losing exactly the debug log this feature preserves).
+///
+/// Candidates are then pruned by (a) age > `retention_days`, (b) size > `max_file_bytes` (0
+/// disables), (c) count > `max_files` (oldest by mtime first).
 pub(super) fn sweep_retention(
     dir: &Path,
     retention_days: u64,
     max_files: u64,
     max_file_bytes: u64,
 ) {
+    let recent_cutoff = SystemTime::now().checked_sub(Duration::from_secs(RECENT_SECS));
     let mut entries: Vec<(std::path::PathBuf, SystemTime, u64)> = match std::fs::read_dir(dir) {
         Ok(rd) => rd
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().is_some_and(|x| x == "log"))
-            .filter_map(|e| {
-                let meta = e.metadata().ok()?;
-                Some((e.path(), meta.modified().ok()?, meta.len()))
+            .filter_map(|entry| entry.ok())
+            .filter_map(|entry| {
+                let name = entry.file_name();
+                let pid = rag_rat_log_pid(name.to_str()?)?;
+                // A live creating process may still hold the fd — never a candidate.
+                if process_is_alive(pid) {
+                    return None;
+                }
+                let meta = entry.metadata().ok()?;
+                let mtime = meta.modified().ok()?;
+                // Recently touched → likely still active; spare it (pid recycle / clock skew
+                // guard).
+                if recent_cutoff.is_some_and(|cutoff| mtime >= cutoff) {
+                    return None;
+                }
+                Some((entry.path(), mtime, meta.len()))
             })
             .collect(),
         Err(_) => return,
     };
-
-    // Never prune a file a sibling process is likely still writing: an mcp server's active log can
-    // exceed `max_file_bytes` or fall outside `max_files`, and unlinking it here would leave the
-    // server writing to a now-deleted inode (lost logs, unreclaimed disk). Skip anything touched in
-    // the last few minutes — retention only ever reaps clearly-idle files.
-    const RECENT_SECS: u64 = 300;
-    if let Some(recent_cutoff) = SystemTime::now().checked_sub(Duration::from_secs(RECENT_SECS)) {
-        entries.retain(|(_, mtime, _)| *mtime < recent_cutoff);
-    }
 
     if retention_days > 0
         && let Some(cutoff) = SystemTime::now()
@@ -65,32 +83,81 @@ pub(super) fn sweep_retention(
     }
 }
 
+/// The pid of a rag-rat per-process log named `<role>-<pid>-<start_ms>.log` (`role` may itself
+/// contain `-`, e.g. `cli-reconcile`). Returns `None` for any file that is not one of ours — the
+/// naming filter that keeps the sweep off unrelated `*.log` files.
+fn rag_rat_log_pid(name: &str) -> Option<u32> {
+    if !(name.starts_with("mcp-") || name.starts_with("hook-") || name.starts_with("cli-")) {
+        return None;
+    }
+    let stem = name.strip_suffix(".log")?;
+    // Trailing two `-`-fields are `<pid>-<start_ms>`; require a leading role field too.
+    let mut tail = stem.rsplitn(3, '-');
+    let _start_ms = tail.next()?;
+    let pid = tail.next()?;
+    tail.next()?; // role segment must exist (rejects a bare `mcp-123.log`)
+    pid.parse::<u32>().ok()
+}
+
+/// Whether `pid` names a currently-running process (so its log may still be open). `kill(pid, 0)`
+/// probes without signalling: `Ok` → alive; `EPERM` → alive but owned by another user; `ESRCH` →
+/// gone. Conservative on error (treats an unknown state as alive → don't prune).
+#[cfg(unix)]
+fn process_is_alive(pid: u32) -> bool {
+    let Ok(pid) = libc::pid_t::try_from(pid) else {
+        return false; // out of pid_t range → cannot name a real process
+    };
+    // SAFETY: `kill` with signal 0 performs only the existence/permission check, no signal
+    // delivery.
+    let rc = unsafe { libc::kill(pid, 0) };
+    rc == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(not(unix))]
+fn process_is_alive(_pid: u32) -> bool {
+    // No cheap portable liveness probe; rely on the recent-mtime window alone.
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::{Duration, SystemTime};
 
-    use super::sweep_retention;
+    use super::{rag_rat_log_pid, sweep_retention};
 
-    /// Backdate a file's mtime `secs` into the past (clear of the RECENT_SECS protection window) so
-    /// the sweep treats it as an idle prune candidate.
-    fn age_file(path: &std::path::Path, secs: u64) {
-        let when = SystemTime::now() - Duration::from_secs(secs);
-        std::fs::File::options().write(true).open(path).unwrap().set_modified(when).unwrap();
+    /// A pid above Linux's default `pid_max` — `kill(_, 0)` reports it gone, so files named with it
+    /// are always treated as belonging to a dead process (deterministic in tests).
+    const DEAD_PID: u32 = 2_147_483_646;
+
+    fn write_log(dir: &std::path::Path, name: &str, bytes: usize, age_secs: u64) {
+        let path = dir.join(name);
+        std::fs::write(&path, vec![b'x'; bytes.max(1)]).unwrap();
+        let when = SystemTime::now() - Duration::from_secs(age_secs);
+        std::fs::File::options().write(true).open(&path).unwrap().set_modified(when).unwrap();
+    }
+
+    #[test]
+    fn parses_pid_only_from_our_log_names() {
+        assert_eq!(rag_rat_log_pid("mcp-1234-5678.log"), Some(1234));
+        assert_eq!(rag_rat_log_pid("hook-42-1.log"), Some(42));
+        assert_eq!(rag_rat_log_pid("cli-reconcile-99-1000.log"), Some(99)); // role with a '-'
+        assert_eq!(rag_rat_log_pid("mcp-123.log"), None); // no start field
+        assert_eq!(rag_rat_log_pid("app.log"), None); // not ours
+        assert_eq!(rag_rat_log_pid("random-1-2.log"), None); // wrong role prefix
     }
 
     #[test]
     fn prunes_by_age_then_count() {
         let dir = tempfile::tempdir().unwrap();
         for i in 0..5 {
-            let path = dir.path().join(format!("mcp-{i}.log"));
-            std::fs::write(&path, "x").unwrap();
-            age_file(&path, 3600); // all past the recent window → eligible
+            write_log(dir.path(), &format!("mcp-{DEAD_PID}-{i}.log"), 1, 3600);
         }
-        // Age out the first two via an mtime deep in the past.
+        // Age out the first two deep into the past.
         for i in 0..2 {
+            let path = dir.path().join(format!("mcp-{DEAD_PID}-{i}.log"));
             std::fs::File::options()
                 .write(true)
-                .open(dir.path().join(format!("mcp-{i}.log")))
+                .open(&path)
                 .unwrap()
                 .set_modified(SystemTime::UNIX_EPOCH)
                 .unwrap();
@@ -103,7 +170,6 @@ mod tests {
         );
         assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 3, "2 aged out");
 
-        // Cap the count at 1 → oldest-first prune to 1.
         sweep_retention(dir.path(), /* days */ 3650, /* max_files */ 1, 0);
         assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
     }
@@ -111,31 +177,64 @@ mod tests {
     #[test]
     fn prunes_oversize_files() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("mcp-big.log"), vec![b'x'; 4096]).unwrap();
-        std::fs::write(dir.path().join("mcp-small.log"), b"x").unwrap();
-        age_file(&dir.path().join("mcp-big.log"), 3600);
-        age_file(&dir.path().join("mcp-small.log"), 3600);
+        write_log(dir.path(), &format!("mcp-{DEAD_PID}-1.log"), 4096, 3600);
+        write_log(dir.path(), &format!("mcp-{DEAD_PID}-2.log"), 1, 3600);
         sweep_retention(dir.path(), 0, 0, /* max_bytes */ 1024);
         let names: Vec<_> = std::fs::read_dir(dir.path())
             .unwrap()
             .filter_map(|e| e.ok())
             .map(|e| e.file_name().into_string().unwrap())
             .collect();
-        assert_eq!(names, vec!["mcp-small.log".to_string()], "oversize pruned, small kept");
+        assert_eq!(names, vec![format!("mcp-{DEAD_PID}-2.log")], "oversize pruned, small kept");
     }
 
     #[test]
     fn keeps_recently_modified_files() {
         let dir = tempfile::tempdir().unwrap();
-        // A large, freshly-written file (mtime ~= now) may be a live sibling's active log — even an
-        // aggressive sweep must leave it alone.
-        std::fs::write(dir.path().join("mcp-live.log"), vec![b'x'; 8192]).unwrap();
+        // Dead pid but touched just now → spared by the recent-mtime window.
+        write_log(dir.path(), &format!("mcp-{DEAD_PID}-9.log"), 8192, 0);
         sweep_retention(
             dir.path(),
             /* days */ 1,
             /* max_files */ 1,
             /* max_bytes */ 1,
         );
-        assert!(dir.path().join("mcp-live.log").exists(), "recent file must not be pruned");
+        assert!(
+            dir.path().join(format!("mcp-{DEAD_PID}-9.log")).exists(),
+            "recent file not pruned"
+        );
+    }
+
+    #[test]
+    fn keeps_files_of_live_processes() {
+        let dir = tempfile::tempdir().unwrap();
+        // Our OWN pid is alive; an old, oversized log named with it must survive an aggressive
+        // sweep.
+        let live = std::process::id();
+        write_log(dir.path(), &format!("mcp-{live}-1.log"), 8192, 3600);
+        sweep_retention(
+            dir.path(),
+            /* days */ 1,
+            /* max_files */ 1,
+            /* max_bytes */ 1,
+        );
+        assert!(
+            dir.path().join(format!("mcp-{live}-1.log")).exists(),
+            "live-process log not pruned"
+        );
+    }
+
+    #[test]
+    fn ignores_foreign_log_files() {
+        let dir = tempfile::tempdir().unwrap();
+        // A non-rag-rat `*.log` in a shared dir must never be a candidate.
+        write_log(dir.path(), "some-other-app.log", 8192, 7 * 86_400);
+        sweep_retention(
+            dir.path(),
+            /* days */ 1,
+            /* max_files */ 1,
+            /* max_bytes */ 1,
+        );
+        assert!(dir.path().join("some-other-app.log").exists(), "foreign log untouched");
     }
 }

--- a/crates/rag-rat-core/src/logging/retention.rs
+++ b/crates/rag-rat-core/src/logging/retention.rs
@@ -8,17 +8,17 @@ const RECENT_SECS: u64 = 300;
 /// Best-effort cleanup of the per-process log dir. Any IO error is swallowed — logging cleanup must
 /// never abort a command.
 ///
-/// A file is a prune CANDIDATE only if BOTH hold, so the sweep never deletes something it
-/// shouldn't:
-/// 1. it is one of rag-rat's own per-process logs — `<role>-<pid>-<start_ms>.log` with `role` in
-///    `mcp`/`hook`/`cli-*` (so a shared `[log].dir` containing other apps' `*.log` is untouched);
-///    and
-/// 2. the process that created it (`<pid>`) is no longer alive AND it wasn't touched in the last
-///    few minutes — a live process may still hold the file open, and unlinking it would leave that
-///    process writing to a deleted inode (losing exactly the debug log this feature preserves).
+/// Only rag-rat's own per-process logs (`<role>-<pid>-<start_ms>.log`, `role` in
+/// `mcp`/`hook`/`cli-*`) are ever considered, so a shared `[log].dir` with other apps' `*.log` is
+/// untouched. A log is a prune CANDIDATE only if its creating process is gone AND it wasn't touched
+/// recently; otherwise it is PROTECTED (a live process may hold the fd — unlinking it would strand
+/// the writer on a deleted inode). Protected files are still COUNTED against `max_files`.
 ///
-/// Candidates are then pruned by (a) age > `retention_days`, (b) size > `max_file_bytes` (0
-/// disables), (c) count > `max_files` (oldest by mtime first).
+/// Candidates are pruned by (a) age > `retention_days` — every platform; (b) size >
+/// `max_file_bytes` and (c) total-count > `max_files` — only where process liveness is verifiable
+/// (unix). On a platform without a liveness probe the size/count rules could evict a live-but-idle
+/// log, so they are skipped there and only the age rule (which reaps files untouched for whole
+/// days) runs.
 pub(super) fn sweep_retention(
     dir: &Path,
     retention_days: u64,
@@ -26,34 +26,35 @@ pub(super) fn sweep_retention(
     max_file_bytes: u64,
 ) {
     let recent_cutoff = SystemTime::now().checked_sub(Duration::from_secs(RECENT_SECS));
-    let mut entries: Vec<(std::path::PathBuf, SystemTime, u64)> = match std::fs::read_dir(dir) {
-        Ok(rd) => rd
-            .filter_map(|entry| entry.ok())
-            .filter_map(|entry| {
+    let mut candidates: Vec<(std::path::PathBuf, SystemTime, u64)> = Vec::new();
+    let mut protected: u64 = 0;
+    match std::fs::read_dir(dir) {
+        Ok(rd) => {
+            for entry in rd.flatten() {
                 let name = entry.file_name();
-                let pid = rag_rat_log_pid(name.to_str()?)?;
-                // A live creating process may still hold the fd — never a candidate.
-                if process_is_alive(pid) {
-                    return None;
+                let Some(pid) = name.to_str().and_then(rag_rat_log_pid) else {
+                    continue; // not one of ours
+                };
+                let Ok(meta) = entry.metadata() else { continue };
+                let Ok(mtime) = meta.modified() else { continue };
+                let live_or_recent =
+                    process_is_alive(pid) || recent_cutoff.is_some_and(|cutoff| mtime >= cutoff);
+                if live_or_recent {
+                    protected += 1;
+                } else {
+                    candidates.push((entry.path(), mtime, meta.len()));
                 }
-                let meta = entry.metadata().ok()?;
-                let mtime = meta.modified().ok()?;
-                // Recently touched → likely still active; spare it (pid recycle / clock skew
-                // guard).
-                if recent_cutoff.is_some_and(|cutoff| mtime >= cutoff) {
-                    return None;
-                }
-                Some((entry.path(), mtime, meta.len()))
-            })
-            .collect(),
+            }
+        },
         Err(_) => return,
-    };
+    }
 
+    // Age rule — safe on every platform (a file untouched for whole days can't be an active log).
     if retention_days > 0
         && let Some(cutoff) = SystemTime::now()
             .checked_sub(Duration::from_secs(retention_days.saturating_mul(86_400)))
     {
-        entries.retain(|(path, mtime, _)| {
+        candidates.retain(|(path, mtime, _)| {
             if *mtime < cutoff {
                 let _ = std::fs::remove_file(path);
                 false
@@ -63,22 +64,27 @@ pub(super) fn sweep_retention(
         });
     }
 
-    if max_file_bytes > 0 {
-        entries.retain(|(path, _, len)| {
-            if *len > max_file_bytes {
+    // Size + count could evict a live-but-idle log where liveness can't be checked — unix only.
+    if cfg!(unix) {
+        if max_file_bytes > 0 {
+            candidates.retain(|(path, _, len)| {
+                if *len > max_file_bytes {
+                    let _ = std::fs::remove_file(path);
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+        // `max_files` bounds the WHOLE dir: protected files count too, so delete oldest candidates
+        // until the total is within the cap (or no removable candidates remain).
+        let total = protected + candidates.len() as u64;
+        if max_files > 0 && total > max_files {
+            candidates.sort_by_key(|(_, mtime, _)| *mtime); // oldest first
+            let remove = ((total - max_files) as usize).min(candidates.len());
+            for (path, _, _) in candidates.into_iter().take(remove) {
                 let _ = std::fs::remove_file(path);
-                false
-            } else {
-                true
             }
-        });
-    }
-
-    if max_files > 0 && entries.len() as u64 > max_files {
-        entries.sort_by_key(|(_, mtime, _)| *mtime); // oldest first
-        let remove = entries.len() - max_files as usize;
-        for (path, _, _) in entries.into_iter().take(remove) {
-            let _ = std::fs::remove_file(path);
         }
     }
 }
@@ -101,7 +107,7 @@ fn rag_rat_log_pid(name: &str) -> Option<u32> {
 
 /// Whether `pid` names a currently-running process (so its log may still be open). `kill(pid, 0)`
 /// probes without signalling: `Ok` → alive; `EPERM` → alive but owned by another user; `ESRCH` →
-/// gone. Conservative on error (treats an unknown state as alive → don't prune).
+/// gone. Conservative on error (an unknown state counts as alive → don't prune).
 #[cfg(unix)]
 fn process_is_alive(pid: u32) -> bool {
     let Ok(pid) = libc::pid_t::try_from(pid) else {
@@ -115,7 +121,8 @@ fn process_is_alive(pid: u32) -> bool {
 
 #[cfg(not(unix))]
 fn process_is_alive(_pid: u32) -> bool {
-    // No cheap portable liveness probe; rely on the recent-mtime window alone.
+    // No cheap portable liveness probe; size/count pruning is skipped on this platform (see
+    // `sweep_retention`), so a live log is protected by the recent-mtime window + age-only pruning.
     false
 }
 
@@ -147,51 +154,31 @@ mod tests {
     }
 
     #[test]
-    fn prunes_by_age_then_count() {
+    fn prunes_by_age() {
         let dir = tempfile::tempdir().unwrap();
-        for i in 0..5 {
+        for i in 0..3 {
             write_log(dir.path(), &format!("mcp-{DEAD_PID}-{i}.log"), 1, 3600);
         }
-        // Age out the first two deep into the past.
-        for i in 0..2 {
-            let path = dir.path().join(format!("mcp-{DEAD_PID}-{i}.log"));
-            std::fs::File::options()
-                .write(true)
-                .open(&path)
-                .unwrap()
-                .set_modified(SystemTime::UNIX_EPOCH)
-                .unwrap();
-        }
+        // Age the first one deep into the past; the age rule runs on every platform.
+        std::fs::File::options()
+            .write(true)
+            .open(dir.path().join(format!("mcp-{DEAD_PID}-0.log")))
+            .unwrap()
+            .set_modified(SystemTime::UNIX_EPOCH)
+            .unwrap();
         sweep_retention(
             dir.path(),
             /* days */ 7,
-            /* max_files */ 100,
+            /* max_files */ 0,
             /* max_bytes */ 0,
         );
-        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 3, "2 aged out");
-
-        sweep_retention(dir.path(), /* days */ 3650, /* max_files */ 1, 0);
-        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
-    }
-
-    #[test]
-    fn prunes_oversize_files() {
-        let dir = tempfile::tempdir().unwrap();
-        write_log(dir.path(), &format!("mcp-{DEAD_PID}-1.log"), 4096, 3600);
-        write_log(dir.path(), &format!("mcp-{DEAD_PID}-2.log"), 1, 3600);
-        sweep_retention(dir.path(), 0, 0, /* max_bytes */ 1024);
-        let names: Vec<_> = std::fs::read_dir(dir.path())
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .map(|e| e.file_name().into_string().unwrap())
-            .collect();
-        assert_eq!(names, vec![format!("mcp-{DEAD_PID}-2.log")], "oversize pruned, small kept");
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 2, "the aged-out file is gone");
     }
 
     #[test]
     fn keeps_recently_modified_files() {
         let dir = tempfile::tempdir().unwrap();
-        // Dead pid but touched just now → spared by the recent-mtime window.
+        // Dead pid but touched just now → spared by the recent-mtime window (every platform).
         write_log(dir.path(), &format!("mcp-{DEAD_PID}-9.log"), 8192, 0);
         sweep_retention(
             dir.path(),
@@ -205,6 +192,38 @@ mod tests {
         );
     }
 
+    #[test]
+    fn ignores_foreign_log_files() {
+        let dir = tempfile::tempdir().unwrap();
+        // A non-rag-rat `*.log` in a shared dir must never be a candidate.
+        write_log(dir.path(), "some-other-app.log", 8192, 7 * 86_400);
+        sweep_retention(
+            dir.path(),
+            /* days */ 1,
+            /* max_files */ 1,
+            /* max_bytes */ 1,
+        );
+        assert!(dir.path().join("some-other-app.log").exists(), "foreign log untouched");
+    }
+
+    // Size / count pruning + pid-liveness are unix-only (see `sweep_retention` /
+    // `process_is_alive`).
+    #[cfg(unix)]
+    #[test]
+    fn prunes_oversize_then_count() {
+        let dir = tempfile::tempdir().unwrap();
+        write_log(dir.path(), &format!("mcp-{DEAD_PID}-1.log"), 4096, 3600);
+        write_log(dir.path(), &format!("mcp-{DEAD_PID}-2.log"), 1, 3600);
+        sweep_retention(dir.path(), 0, 0, /* max_bytes */ 1024);
+        let names: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().into_string().unwrap())
+            .collect();
+        assert_eq!(names, vec![format!("mcp-{DEAD_PID}-2.log")], "oversize pruned, small kept");
+    }
+
+    #[cfg(unix)]
     #[test]
     fn keeps_files_of_live_processes() {
         let dir = tempfile::tempdir().unwrap();
@@ -224,17 +243,34 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
-    fn ignores_foreign_log_files() {
+    fn max_files_counts_protected_files() {
         let dir = tempfile::tempdir().unwrap();
-        // A non-rag-rat `*.log` in a shared dir must never be a candidate.
-        write_log(dir.path(), "some-other-app.log", 8192, 7 * 86_400);
+        let live = std::process::id();
+        // 2 live (protected) + 3 dead+idle (candidates); cap the whole dir at 2.
+        for i in 0..2 {
+            write_log(dir.path(), &format!("mcp-{live}-{i}.log"), 1, 3600);
+        }
+        for i in 0..3 {
+            write_log(dir.path(), &format!("mcp-{DEAD_PID}-{i}.log"), 1, 3600);
+        }
+        // `days` high so the age rule doesn't fire — this exercises the count rule alone.
         sweep_retention(
             dir.path(),
-            /* days */ 1,
-            /* max_files */ 1,
-            /* max_bytes */ 1,
+            /* days */ 3650,
+            /* max_files */ 2,
+            /* max_bytes */ 0,
         );
-        assert!(dir.path().join("some-other-app.log").exists(), "foreign log untouched");
+        let names: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().into_string().unwrap())
+            .collect();
+        assert_eq!(names.len(), 2, "trimmed to max_files, counting the 2 protected files");
+        assert!(
+            names.iter().all(|n| n.contains(&live.to_string())),
+            "only the live/protected logs remain, got {names:?}"
+        );
     }
 }

--- a/crates/rag-rat-core/src/logging/retention.rs
+++ b/crates/rag-rat-core/src/logging/retention.rs
@@ -22,6 +22,15 @@ pub(super) fn sweep_retention(
         Err(_) => return,
     };
 
+    // Never prune a file a sibling process is likely still writing: an mcp server's active log can
+    // exceed `max_file_bytes` or fall outside `max_files`, and unlinking it here would leave the
+    // server writing to a now-deleted inode (lost logs, unreclaimed disk). Skip anything touched in
+    // the last few minutes — retention only ever reaps clearly-idle files.
+    const RECENT_SECS: u64 = 300;
+    if let Some(recent_cutoff) = SystemTime::now().checked_sub(Duration::from_secs(RECENT_SECS)) {
+        entries.retain(|(_, mtime, _)| *mtime < recent_cutoff);
+    }
+
     if retention_days > 0
         && let Some(cutoff) = SystemTime::now()
             .checked_sub(Duration::from_secs(retention_days.saturating_mul(86_400)))
@@ -58,22 +67,33 @@ pub(super) fn sweep_retention(
 
 #[cfg(test)]
 mod tests {
+    use std::time::{Duration, SystemTime};
+
     use super::sweep_retention;
+
+    /// Backdate a file's mtime `secs` into the past (clear of the RECENT_SECS protection window) so
+    /// the sweep treats it as an idle prune candidate.
+    fn age_file(path: &std::path::Path, secs: u64) {
+        let when = SystemTime::now() - Duration::from_secs(secs);
+        std::fs::File::options().write(true).open(path).unwrap().set_modified(when).unwrap();
+    }
 
     #[test]
     fn prunes_by_age_then_count() {
         let dir = tempfile::tempdir().unwrap();
         for i in 0..5 {
-            std::fs::write(dir.path().join(format!("mcp-{i}.log")), "x").unwrap();
+            let path = dir.path().join(format!("mcp-{i}.log"));
+            std::fs::write(&path, "x").unwrap();
+            age_file(&path, 3600); // all past the recent window → eligible
         }
         // Age out the first two via an mtime deep in the past.
-        let old = std::time::SystemTime::UNIX_EPOCH;
         for i in 0..2 {
-            let file = std::fs::File::options()
+            std::fs::File::options()
                 .write(true)
                 .open(dir.path().join(format!("mcp-{i}.log")))
+                .unwrap()
+                .set_modified(SystemTime::UNIX_EPOCH)
                 .unwrap();
-            file.set_modified(old).unwrap();
         }
         sweep_retention(
             dir.path(),
@@ -93,6 +113,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("mcp-big.log"), vec![b'x'; 4096]).unwrap();
         std::fs::write(dir.path().join("mcp-small.log"), b"x").unwrap();
+        age_file(&dir.path().join("mcp-big.log"), 3600);
+        age_file(&dir.path().join("mcp-small.log"), 3600);
         sweep_retention(dir.path(), 0, 0, /* max_bytes */ 1024);
         let names: Vec<_> = std::fs::read_dir(dir.path())
             .unwrap()
@@ -100,5 +122,20 @@ mod tests {
             .map(|e| e.file_name().into_string().unwrap())
             .collect();
         assert_eq!(names, vec!["mcp-small.log".to_string()], "oversize pruned, small kept");
+    }
+
+    #[test]
+    fn keeps_recently_modified_files() {
+        let dir = tempfile::tempdir().unwrap();
+        // A large, freshly-written file (mtime ~= now) may be a live sibling's active log — even an
+        // aggressive sweep must leave it alone.
+        std::fs::write(dir.path().join("mcp-live.log"), vec![b'x'; 8192]).unwrap();
+        sweep_retention(
+            dir.path(),
+            /* days */ 1,
+            /* max_files */ 1,
+            /* max_bytes */ 1,
+        );
+        assert!(dir.path().join("mcp-live.log").exists(), "recent file must not be pruned");
     }
 }

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -853,6 +853,7 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
+            log: Default::default(),
         }
     }
 
@@ -874,6 +875,7 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
+            log: Default::default(),
         };
         let worktree = PathBuf::from("/wt/feat");
         let registry = PathBuf::from("/main/.git/worktrees");
@@ -970,6 +972,7 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
+            log: Default::default(),
         };
         // A linked checkout mirrors the layout: `<checkout>/crate/src/a.rs`.
         let checkout =
@@ -1013,6 +1016,7 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
+            log: Default::default(),
         };
         let ignore = IgnoreMatcher::compile(&root, &[]);
 
@@ -1074,6 +1078,7 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
+            log: Default::default(),
         };
 
         let ignore = IgnoreMatcher::compile(&root, &[]);
@@ -1146,6 +1151,7 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
+            log: Default::default(),
         };
 
         // Before: a source file under the subdir fires.
@@ -1290,6 +1296,7 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
+            log: Default::default(),
         };
 
         let (roots, _registry) = worktree_watch_targets(&config);
@@ -1551,6 +1558,7 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
+            log: Default::default(),
         };
         let ignore = IgnoreMatcher::compile(&root, &[PathBuf::from("src")]);
         let dir_create =

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -282,6 +282,7 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
+            log: Default::default(),
         };
         IndexDatabase::rebuild(&config).unwrap();
         (root, config)

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -888,6 +888,7 @@ fn mixed_config() -> (PathBuf, Config) {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     })
 }
 
@@ -911,6 +912,7 @@ fn markdown_config(text: &str) -> (PathBuf, Config) {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     })
 }
 
@@ -931,6 +933,7 @@ fn rust_config(root: PathBuf) -> Config {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
+        log: Default::default(),
     }
 }
 

--- a/scripts/repro-hook-embedding.sh
+++ b/scripts/repro-hook-embedding.sh
@@ -95,6 +95,12 @@ case "$db" in
   "$source_root"/*) echo "refusing: db '$db' resolves into the source checkout" >&2; exit 1 ;;
 esac
 
+# Activate the configured embedding model + persist its remote config. A fresh `index` only builds
+# the SOURCE index; it does not install/activate the embedding model, so without this the git-hook
+# `maintenance` reconcile would fall back to the not-ready default and never take the light/embed
+# path this harness is meant to reproduce.
+rag-rat --config rag-rat.toml models install "jinaai/jina-embeddings-v2-base-code"
+
 rag-rat index --config rag-rat.toml
 rag-rat hooks install
 

--- a/scripts/repro-hook-embedding.sh
+++ b/scripts/repro-hook-embedding.sh
@@ -68,6 +68,7 @@ model = "jinaai/jina-embeddings-v2-base-code"
 [llm.embedding.remote]
 cookbook = "@rag-rat/cookbook modal"
 backend = "infinity"
+model = "jinaai/jina-embeddings-v2-base-code"
 gpu = "L4"
 query_endpoint = "http://localhost:7997"
 batch_size = 8
@@ -86,6 +87,7 @@ model = "jinaai/jina-embeddings-v2-base-code"
 [llm.embedding.remote]
 endpoint = "http://localhost:7997"
 backend = "infinity"
+model = "jinaai/jina-embeddings-v2-base-code"
 TOML
 fi
 
@@ -95,16 +97,18 @@ case "$db" in
   "$source_root"/*) echo "refusing: db '$db' resolves into the source checkout" >&2; exit 1 ;;
 esac
 
-# Activate the configured embedding model + persist its remote config. A fresh `index` only builds
-# the SOURCE index; it does not install/activate the embedding model, so without this the git-hook
-# `maintenance` reconcile would fall back to the not-ready default and never take the light/embed
-# path this harness is meant to reproduce.
-rag-rat --config rag-rat.toml models install "jinaai/jina-embeddings-v2-base-code"
-
 rag-rat index --config rag-rat.toml
+# Activate the configured embedding model + persist its remote config AFTER the index exists:
+# `models install` opens the index (and errors if it isn't built yet). A fresh `index` only builds
+# the SOURCE index, so without this the git-hook `maintenance` reconcile falls back to the not-ready
+# default and never takes the light/embed path this harness is meant to reproduce.
+rag-rat --config rag-rat.toml models install "jinaai/jina-embeddings-v2-base-code"
 rag-rat hooks install
 
-# Drive git actions to fire the hooks (the light/incremental maintenance path).
+# Drive git actions to fire the hooks (the light/incremental maintenance path). Give the throwaway
+# clone its own identity so `git commit` works in a clean container / CI user with no global config.
+git config user.email "repro@rag-rat.local"
+git config user.name "rag-rat repro"
 git checkout -q -b repro-branch
 git commit -q --allow-empty -m "repro: fire post-commit hook"
 git checkout -q -

--- a/scripts/repro-hook-embedding.sh
+++ b/scripts/repro-hook-embedding.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Reproduce "git action -> local embedding -> items remaining" in an ISOLATED clone.
+#
+# Git hooks (post-commit/checkout/merge) spawn `rag-rat maintenance`, which runs a time-boxed,
+# light/incremental reconcile that embeds changed chunks against the LOCAL query_endpoint. This
+# harness fires those hooks against a throwaway clone with `[log] enabled`, then prints the resulting
+# debug-log narrative + `doctor` so you can see WHICH phase embeds and why the plan backlog stays
+# non-empty (often the unscoped cross-worktree count — see issue #360).
+#
+# It runs ENTIRELY OUTSIDE the source checkout (own temp dir, DB, logs) and fails closed if anything
+# resolves back inside it, so it never touches an index other tools/agents are using.
+set -euo pipefail
+
+MODE="local"
+REPO=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --local) MODE="local" ;;
+    --hybrid) MODE="hybrid" ;;
+    --repo) REPO="${2:?--repo needs a path or url}"; shift ;;
+    -h | --help)
+      echo "usage: $0 [--local|--hybrid] [--repo <url|path>]"
+      echo "  --local   (default) embed against local infinity only (connect mode); no Modal"
+      echo "  --hybrid  mirror the ephemeral setup: Modal L4 for the big reconcile + local infinity for queries"
+      exit 0
+      ;;
+    *) echo "usage: $0 [--local|--hybrid] [--repo <url|path>]" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+# The repo to clone: an explicit --repo, else the checkout this script lives in (rag-rat itself is a
+# large-enough corpus that the reconcile is time-boxed and "Partial" shows).
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+source_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
+src="${REPO:-$source_root}"
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/rag-rat-repro.XXXXXX")"
+# Fail closed: the work dir must NOT be inside the source checkout.
+case "$work/" in
+  "$source_root"/*) echo "refusing: work dir '$work' is inside the source checkout" >&2; exit 1 ;;
+esac
+echo "source: $src"
+echo "work:   $work"
+
+clone="$work/repo"
+git clone --quiet "$src" "$clone"
+cd "$clone"
+
+# Both modes embed QUERIES (and the light/incremental hook path) against local infinity, so it must
+# be reachable. The `infinity` backend requires an explicit query_endpoint (only Ollama defaults).
+if ! curl -fsS "http://localhost:7997/health" >/dev/null 2>&1; then
+  echo "local infinity not reachable at http://localhost:7997 (needed for query/light embedding)" >&2
+  exit 1
+fi
+
+if [ "$MODE" = "hybrid" ]; then
+  cat > rag-rat.toml <<'TOML'
+[index]
+root = "."
+[target_bindings]
+rust = ["crates"]
+[log]
+enabled = true
+level = "debug"
+[llm.embedding]
+model = "jinaai/jina-embeddings-v2-base-code"
+[llm.embedding.remote]
+cookbook = "@rag-rat/cookbook modal"
+backend = "infinity"
+gpu = "L4"
+query_endpoint = "http://localhost:7997"
+batch_size = 8
+TOML
+else
+  cat > rag-rat.toml <<'TOML'
+[index]
+root = "."
+[target_bindings]
+rust = ["crates"]
+[log]
+enabled = true
+level = "debug"
+[llm.embedding]
+model = "jinaai/jina-embeddings-v2-base-code"
+[llm.embedding.remote]
+endpoint = "http://localhost:7997"
+backend = "infinity"
+TOML
+fi
+
+# Confirm the resolved DB is inside the isolated clone before building anything.
+db="$(rag-rat --config rag-rat.toml dump-config 2>/dev/null | grep -oE '/[^" ]*index\.sqlite' | head -1 || true)"
+case "$db" in
+  "$source_root"/*) echo "refusing: db '$db' resolves into the source checkout" >&2; exit 1 ;;
+esac
+
+rag-rat index --config rag-rat.toml
+rag-rat hooks install
+
+# Drive git actions to fire the hooks (the light/incremental maintenance path).
+git checkout -q -b repro-branch
+git commit -q --allow-empty -m "repro: fire post-commit hook"
+git checkout -q -
+git merge -q --no-edit repro-branch || true
+# The hook backgrounds `rag-rat maintenance &`; give it a moment to write its log.
+sleep 5
+
+echo "=== doctor ==="
+rag-rat --config rag-rat.toml doctor || true
+echo "=== logs ($clone/.rag-rat/logs) ==="
+ls -la "$clone/.rag-rat/logs/" 2>/dev/null || true
+echo "=== maintenance / reconcile / embed narrative ==="
+grep -h -E "maintenance pass|phase =|reconcile complete|light/incremental|no_budget|no_ephemeral|embed request|remaining backlog" \
+  "$clone/.rag-rat/logs/"*.log 2>/dev/null | tail -50 || true
+echo
+echo "work dir kept for inspection: $work"


### PR DESCRIPTION
## Motivation

Git-hook-spawned `rag-rat maintenance` runs the reconcile/embedding lifecycle in short-lived, headless processes whose stderr goes nowhere, sometimes overlapping the MCP server and sibling worktrees. There's no durable record to diagnose behavior like "a git action triggers local embedding, and `doctor` then reports items remaining."

## What ships

A permanent, first-class debug-logging feature (off by default):

- **`[log]` config section** (`Raw*` → validated, reject-unknown enums): `enabled`, `level`, `filter` (per-subsystem `EnvFilter` directives), `dir`, `format` (text|json), `max_file_bytes`, `retention_days`, `max_files`. `RAG_RAT_LOG` overrides/force-enables; an invalid filter/dir/format never aborts a command.
- **`tracing` + `tracing-subscriber` + `tracing-appender`**, initialized once in the CLI `main` (single binary; role derived from the subcommand: `mcp` | `hook` | `cli:<sub>`, where git-hook `maintenance` is `hook`).
- **Per-process files** `<role>-<pid>-<start>.log` under `.rag-rat/logs/` — zero write contention across concurrent processes/worktrees; correlation via the filename plus a one-shot startup metadata event (the subscriber is process-global, so worker-thread events land in the same file — no reliance on span propagation across threads). A best-effort retention sweep bounds growth (age/count/size) and never deletes a file a live sibling process is still writing. Endpoints are logged as `host:port` only (credentials stripped).
- **Instrumentation** of the maintenance/reconcile/embedder lifecycle: hook entry, `run_maintenance_pass` phases (with reconcile ran/skipped + reason), a reconcile summary + stop-reason, embedder routing (`acquire_chunk_embedder`) and the `embed_batch` HTTP call, and the diagnostic `mem_trace` (now also emitted through `tracing`, still behind its existing env gate). The maintenance backlog event notes the counts are unscoped/cross-worktree (see #360).
- **Isolated repro harness** (`scripts/repro-hook-embedding.sh`): runs entirely outside the source checkout (fails closed if the temp dir or db resolves inside it), asserts local infinity reachability, with `--local` (no Modal) and `--hybrid` modes; drives git actions to fire the hooks and prints the resulting log narrative + `doctor`.

Off by default (no subscriber, no files, zero overhead until enabled); logging is best-effort and never affects command correctness; native-only, so `tracing-appender` is unrestricted.

## Non-goal

The fix for the "items remaining" behavior is out of scope — this delivers the instrument + repro. The root cause is tracked in #360 (the CLI plan/status path computes embedding counts without installing a worktree scope view, so they aggregate across worktrees).

## Testing

Full workspace suite green (1361 tests, 0 failures), `clippy --all-targets -D warnings` clean, `+nightly fmt` clean. New unit tests cover config parse/defaults/reject-unknown, subscriber init (disabled ⇒ no file; enabled ⇒ per-process file + startup event), retention (age/size/count + live-file protection), and endpoint sanitization; a smoke test verifies the per-process file end-to-end.

Fixes #369. Related #360.
