### PR TITLE
perf(reconcile): stream embedding_reconcile_plan candidate materialization (#379)

### DIFF
--- a/crates/rag-rat-core/src/index/ai/reconcile/status.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/status.rs
@@ -89,7 +89,6 @@ pub(crate) fn embedding_reconcile_plan(
     available: bool,
     message: Option<String>,
 ) -> anyhow::Result<EmbeddingReconcilePlan> {
-    let jobs = embedding_job_candidates(conn, &model.model_id, model_version, dim, None, false)?;
     let skipped_by_policy = embedding_policy_skip_summary(conn, DEFAULT_MAX_EMBEDDING_CHARS)?;
     let mut missing_by_priority = BTreeMap::new();
     let mut current = 0_u64;
@@ -100,10 +99,14 @@ pub(crate) fn embedding_reconcile_plan(
     let mut failed_retryable = 0_u64;
     let mut failed_waiting = 0_u64;
     let mut blocked = 0_u64;
-    for job in jobs {
+    // STREAM the candidates (need-first) and count — never materialize every candidate's
+    // decompressed text at once (#379). Same per-job classification as the old `for job in jobs`
+    // over `embedding_job_candidates(None)`, so the counts are identical; only the peak memory
+    // drops.
+    for_each_embedding_candidate(conn, &model.model_id, model_version, dim, None, false, |job| {
         let policy = policy_for_job(&job, DEFAULT_MAX_EMBEDDING_CHARS);
         if !policy.eligible {
-            continue;
+            return Ok(());
         }
         let current_artifact = job.embedding_status.as_deref() == Some("Current")
             && job.source_text_hash.as_deref() == Some(job.text_hash.as_str())
@@ -116,7 +119,7 @@ pub(crate) fn embedding_reconcile_plan(
             });
         if current_artifact {
             current += 1;
-            continue;
+            return Ok(());
         }
         let reason = job.reason(model_version, dim, now_ms(), DEFAULT_MAX_EMBEDDING_CHARS);
         match reason {
@@ -137,7 +140,8 @@ pub(crate) fn embedding_reconcile_plan(
         if job.embedding_status.as_deref() == Some("Blocked") {
             blocked += 1;
         }
-    }
+        Ok(())
+    })?;
     Ok(EmbeddingReconcilePlan {
         model_id: model.model_id.clone(),
         model_version: model_version.to_string(),

--- a/crates/rag-rat-core/src/index/ai/store.rs
+++ b/crates/rag-rat-core/src/index/ai/store.rs
@@ -40,14 +40,21 @@ pub(crate) fn current_chunk_row(
     Ok((chunk, text_row))
 }
 
-pub(crate) fn embedding_job_candidates(
+/// Stream ordered embedding candidates one at a time (need-first), decompressing each chunk's text
+/// on the fly and handing the owned [`CurrentChunk`] to `f` — WITHOUT collecting the whole set into
+/// a `Vec`. This bounds the resident memory of a full-index pass to one chunk's text at a time.
+/// `embedding_reconcile_plan` counts over it so a plan on a kernel-scale index never materializes
+/// every candidate's decompressed text at once (#379, mirroring the already-streamed
+/// `embedding_policy_skip_summary`). `limit == None` walks every candidate.
+pub(crate) fn for_each_embedding_candidate(
     conn: &Connection,
     model_id: &str,
     model_version: &str,
     dim: usize,
     limit: Option<u32>,
     changed_first: bool,
-) -> anyhow::Result<Vec<CurrentChunk>> {
+    mut f: impl FnMut(CurrentChunk) -> anyhow::Result<()>,
+) -> anyhow::Result<()> {
     let changed_order = if changed_first {
         "chunks.source_revision DESC,"
     } else {
@@ -93,6 +100,10 @@ pub(crate) fn embedding_job_candidates(
         LIMIT ?5
     "
     );
+    // One dict decoder for the whole stream (dict versions loaded once, reused per row). Loaded
+    // BEFORE the candidate statement so no second query runs while that statement is mid-iteration.
+    let dicts = crate::query::chunk_text_dicts(conn)?;
+    let mut decoder = ChunkTextDecoder::new(&dicts);
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(
         params![
@@ -104,19 +115,43 @@ pub(crate) fn embedding_job_candidates(
         ],
         current_chunk_row,
     )?;
-    // Decompress in a post-loop with a single dict decoder (versions loaded once per call, not per
-    // row) — decompress's anyhow::Result can't cross the rusqlite closure above.
-    let collected = collect_rows(rows)?;
-    let dicts = crate::query::chunk_text_dicts(conn)?;
-    let mut decoder = ChunkTextDecoder::new(&dicts);
-    let mut chunks = Vec::with_capacity(collected.len());
-    for (mut chunk, text_row) in collected {
+    // Decompress per row in the loop body (not inside the rusqlite closure above — decompress's
+    // `anyhow::Result` can't cross it), so only one chunk's text is resident at a time.
+    for row in rows {
+        let (mut chunk, text_row) = row?;
         chunk.text = text_row.resolve(&mut decoder)?;
         if !model_id.is_empty() {
             chunk.reason = ReconcileReason::Missing;
         }
-        chunks.push(chunk);
+        f(chunk)?;
     }
+    Ok(())
+}
+
+pub(crate) fn embedding_job_candidates(
+    conn: &Connection,
+    model_id: &str,
+    model_version: &str,
+    dim: usize,
+    limit: Option<u32>,
+    changed_first: bool,
+) -> anyhow::Result<Vec<CurrentChunk>> {
+    // Collector over the streaming iterator: identical rows/order, materialized for callers that
+    // want the whole (bounded) set. The unbounded `limit == None` counting path uses
+    // `for_each_embedding_candidate` directly so it never collects (#379).
+    let mut chunks = Vec::new();
+    for_each_embedding_candidate(
+        conn,
+        model_id,
+        model_version,
+        dim,
+        limit,
+        changed_first,
+        |chunk| {
+            chunks.push(chunk);
+            Ok(())
+        },
+    )?;
     Ok(chunks)
 }
 


### PR DESCRIPTION
## What

`embedding_reconcile_plan` (behind `reconcile --plan`) built its coverage counts by materializing **every** candidate chunk's decompressed text into a `Vec` up front (`embedding_job_candidates(None)`) just to iterate + count over it. On a kernel-scale index that Vec is the multi-GB resident peak, and it was the last unstreamed materialization on the reconcile path.

This extracts a `for_each_embedding_candidate` streaming iterator — decompresses one chunk's text at a time and hands it to a closure, never collecting — and has `embedding_reconcile_plan` count over it. Mirrors the already-streamed `embedding_policy_skip_summary` (`d5b834e`).

## Safety

- `embedding_job_candidates` is now a thin collector over the same iterator (same query, order, decompression, reason assignment), so its other callers are byte-for-byte unchanged.
- Only the unbounded `limit == None` plan path stops collecting.
- Counts are identical — the per-job classification is unchanged; `reconcile_plan_reports_policy_skips_for_fastembed_model` and the full reconcile/embedding suite (104 tests) pass.

## Scope note

The issue's headline symptom (`index --full` peak) is already handled elsewhere: the reconcile **work** loop streams via `embedding_candidate_ids` + windowed text, and the skip-count streamed in `d5b834e`. This PR closes the remaining gap — the `reconcile --plan` counting path — so peak RSS there is bounded independent of index size.

Fixes #379.