### PR TITLE
perf(reconcile): stream estimated_reconcile_jobs — the last materialize-everything site (#64)

### DIFF
--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -241,11 +241,13 @@ pub(crate) fn acquire_chunk_embedder(
             //  - probe OK → embed locally, same backend + model as the box, so the vectors share
             //    ONE space (freshness is endpoint-independent) and semantic search stays current
             //    between big reindexes.
-            // NO work-count gate here on purpose: `estimated_reconcile_jobs` decompresses the whole
-            // repo, so it is NOT a cheap idle-pass guard — the fast-failing probe is. A reachable
-            // server's no-work pass then costs the same policy summary a connect-mode pass already
-            // pays. The probe (and every light embed) is bounded by the transport's clamped
-            // timeout, so a hung server can't stall the watcher.
+            // NO work-count gate here on purpose: `estimated_reconcile_jobs` still decompresses
+            // every candidate's text to count (its policy-size + freshness checks read the text) —
+            // streamed now so it no longer PEAKS memory (#64), but still O(repo) CPU, so NOT a
+            // cheap idle-pass guard. The fast-failing probe is. A reachable server's
+            // no-work pass then costs the same policy summary a connect-mode pass
+            // already pays. The probe (and every light embed) is bounded by the
+            // transport's clamped timeout, so a hung server can't stall the watcher.
             if remote.query_endpoint.is_none() {
                 tracing::debug!(target: "rag_rat_core::index::ai::providers", path = "skip_ephemeral", reason = "no_query_endpoint", "light reconcile: no local query_endpoint, deferring to explicit reconcile");
                 return ChunkEmbedder::SkipEphemeral;

--- a/crates/rag-rat-core/src/index/ai/store.rs
+++ b/crates/rag-rat-core/src/index/ai/store.rs
@@ -1,13 +1,6 @@
 use super::*;
 use crate::index::text_compression::{ChunkTextDecoder, ChunkTextRow};
 
-pub(crate) fn current_chunks(
-    conn: &Connection,
-    limit: Option<u32>,
-) -> anyhow::Result<Vec<CurrentChunk>> {
-    embedding_job_candidates(conn, "", "", 0, limit, false)
-}
-
 /// Map one candidate row to its `CurrentChunk` (with a placeholder `text`) plus the
 /// [`ChunkTextRow`] carrying the chunk's stored text (the compressed `chunk_text` blob + `raw_len`;
 /// the `chunks.text` column is gone, so the SELECT INNER JOINs `chunk_text`). The real `text` is
@@ -128,35 +121,8 @@ pub(crate) fn for_each_embedding_candidate(
     Ok(())
 }
 
-pub(crate) fn embedding_job_candidates(
-    conn: &Connection,
-    model_id: &str,
-    model_version: &str,
-    dim: usize,
-    limit: Option<u32>,
-    changed_first: bool,
-) -> anyhow::Result<Vec<CurrentChunk>> {
-    // Collector over the streaming iterator: identical rows/order, materialized for callers that
-    // want the whole (bounded) set. The unbounded `limit == None` counting path uses
-    // `for_each_embedding_candidate` directly so it never collects (#379).
-    let mut chunks = Vec::new();
-    for_each_embedding_candidate(
-        conn,
-        model_id,
-        model_version,
-        dim,
-        limit,
-        changed_first,
-        |chunk| {
-            chunks.push(chunk);
-            Ok(())
-        },
-    )?;
-    Ok(chunks)
-}
-
 /// Ordered candidate chunk ids for one reconcile run, fetched ONCE (ids only, no text), need-first
-/// exactly like `embedding_job_candidates`. The loop walks this list in batches and loads text per
+/// exactly like `for_each_embedding_candidate`. The loop walks this list in batches and loads text per
 /// batch via [`current_chunks_by_ids`], so each chunk's text is read at most once per run. The old
 /// path re-queried *every* candidate's text on *every* batch — O(n²) SQLite work that dominated
 /// reconcile on large repos (it looked like model time but was query/row-materialization CPU).
@@ -236,7 +202,7 @@ pub(crate) fn current_chunks_by_ids(
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(params_from_iter(bind), current_chunk_row)?;
     // Decompress in a post-loop — decompress's anyhow::Result can't cross the rusqlite closure.
-    // Mirror embedding_job_candidates: a non-empty model_id means this is a real (non-force) run,
+    // Mirror for_each_embedding_candidate: a non-empty model_id means this is a real (non-force) run,
     // so the default reason is Missing (the precise reason is recomputed in
     // select_reconcile_batch).
     let mut by_id: std::collections::HashMap<i64, CurrentChunk> =
@@ -256,33 +222,45 @@ pub(crate) fn estimated_reconcile_jobs(
     scan: &EmbeddingScan<'_>,
     options: &ReconcileOptions,
 ) -> anyhow::Result<u64> {
-    let candidates = if options.force {
-        current_chunks(conn, options.limit)?
+    // STREAM the candidates and count — never materialize EVERY candidate's decompressed text into
+    // a `Vec` just to size the backlog (#64 audit; mirrors the streamed
+    // `embedding_reconcile_plan`, #379). This runs on the watcher/maintenance gate
+    // (`pending_embedding_jobs`), so materializing the whole index here was a per-pass memory
+    // peak. The `force` branch queries with an empty model_id (no embedding rows join, so every
+    // chunk is a candidate — matching the old `current_chunks`); otherwise use the active model
+    // so `needs_embedding` sees each chunk's embedding row. Text is still decompressed per row
+    // (both `policy_for_job` and `needs_embedding` read it), but only ONE chunk is resident at
+    // a time now.
+    let (model_id, model_version, dim, changed_first) = if options.force {
+        ("", "", 0, false)
     } else {
-        embedding_job_candidates(
-            conn,
-            scan.model_id,
-            scan.model_version,
-            scan.dim,
-            options.limit,
-            options.changed_first,
-        )?
+        (scan.model_id, scan.model_version, scan.dim, options.changed_first)
     };
-    let count = candidates
-        .iter()
-        .filter(|candidate| {
-            policy_for_job(candidate, scan.max_embedding_chars).eligible
+    let mut count = 0_u64;
+    for_each_embedding_candidate(
+        conn,
+        model_id,
+        model_version,
+        dim,
+        options.limit,
+        changed_first,
+        |candidate| {
+            let eligible = policy_for_job(&candidate, scan.max_embedding_chars).eligible
                 && (options.force
                     || needs_embedding(
-                        candidate,
+                        &candidate,
                         scan.model_id,
                         scan.model_version,
                         scan.dim,
                         scan.max_embedding_chars,
-                    ))
-        })
-        .count();
-    Ok(u64::try_from(count).unwrap_or(u64::MAX))
+                    ));
+            if eligible {
+                count = count.saturating_add(1);
+            }
+            Ok(())
+        },
+    )?;
+    Ok(count)
 }
 
 /// Build the embedding jobs for one batch of candidate ids. Text is loaded only for `ids` (the


### PR DESCRIPTION
## What

`estimated_reconcile_jobs` — the watcher/maintenance work-count gate (`pending_embedding_jobs`) — materialized **every** candidate chunk's decompressed text into a `Vec` just to *count* the backlog. On a large index that's a per-pass memory peak, and it's the last unstreamed materialize-for-count site named by **#64's audit clause** ("audit the other `current_chunks(conn, None)` / unbounded chunk `collect()` call sites"). `providers/mod.rs` even routed around it ("NO work-count gate here on purpose: `estimated_reconcile_jobs` decompresses the whole repo").

This counts over the `for_each_embedding_candidate` streaming iterator (my #379/#382 helper) instead — one chunk resident at a time.

## Safety

- Exact count is **unchanged**: same query params per `force`/non-`force` branch, same `policy_for_job(...).eligible && (force || needs_embedding(...))` filter.
- Text is still decompressed per row (both checks read `chunk.text`), so the gate stays O(repo) **CPU** — this bounds **memory** (the `providers.rs` note is updated to say so).
- Removes the now-dead `current_chunks` + `embedding_job_candidates` collectors — every caller streams now.
- `worktree_overlay_pending_embeddings_are_detectable_for_retry` (the watcher-gate count) + `reconcile_plan_reports_policy_skips` + the full reconcile/embedding suite (36 tests) pass.

## #64 status

This is the **last** of #64's materialize-everything sites; the others already stream — skip-count (`d5b834e`), the reconcile WORK loop (`embedding_candidate_ids` + windowed text), and `embedding_reconcile_plan` (#379/#382). The `index --full` headline peak is addressed by that combination; a kernel-scale re-benchmark would confirm the plateau dropped to the edge-phase baseline.

Fixes #64.