### PR TITLE
feat(schema): V037 — clone_subblock_postings table + postings_written gate (#296 phase 1)

### DIFF
--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1171,6 +1171,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_034_ID => Some(34),
             MIGRATION_035_ID => Some(35),
             MIGRATION_036_ID => Some(36),
+            MIGRATION_037_ID => Some(37),
             _ => None,
         })
         .max()
@@ -1216,6 +1217,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_034_ID
             | MIGRATION_035_ID
             | MIGRATION_036_ID
+            | MIGRATION_037_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1258,6 +1260,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_034_ID => migration.checksum != MIGRATION_034_CHECKSUM,
         MIGRATION_035_ID => migration.checksum != MIGRATION_035_CHECKSUM,
         MIGRATION_036_ID => migration.checksum != MIGRATION_036_CHECKSUM,
+        MIGRATION_037_ID => migration.checksum != MIGRATION_037_CHECKSUM,
         _ => false,
     }
 }
@@ -1496,6 +1499,63 @@ pub(crate) const CLONE_GRAPH_DDL: &str = "
 /// V034: create the precomputed clone-graph tables (see [`CLONE_GRAPH_DDL`]).
 pub(crate) fn apply_clone_graph_tables(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(CLONE_GRAPH_DDL)?;
+    Ok(())
+}
+
+/// V037 (#296): PERSIST the sub-block postings the write-time clone check reads, so that check
+/// SCALES past the 40k-function guard. `clones_of_text` (the write-time hook engine) today rebuilds
+/// the whole `(sub_block_token -> symbol)` inverted index in RAM on every call (O(functions)), so
+/// the hook no-ops above `MAX_CLONE_CHECK_FUNCTIONS`; persisting the postings lets it do a bounded
+/// indexed lookup per new function instead. This is the follow-up the V034 doc named: the slot was
+/// deliberately DEFERRED there (see [`CLONE_GRAPH_DDL`]) and is filled here.
+///
+/// CONTENT-ANCHORED endpoints (the #248 bug-class rule, enforced by
+/// `no_table_has_a_reindex_cascading_fk_to_a_volatile_parent`): a posting anchors to the
+/// reindex-stable `(path, start_byte)` of a symbol plus the `file_sha` (`files.sha256`) at compute
+/// time — NEVER a `symbol_id` FK (`symbols` is a `REINDEX_VOLATILE_PARENT` whose ids are reassigned
+/// on reindex; keying on `symbol_id` is the exact #248 bug that wiped `edge_oracle` verdicts). The
+/// read resolves an anchor by joining live `symbols`/`files` on `(path, start_byte)` and drops any
+/// row whose `file_sha` no longer matches the last-indexed `files.sha256`, so a stale posting is
+/// silently ignored rather than matched against changed content. The ONLY FK is the `ON DELETE
+/// CASCADE` to the DURABLE `clone_graph_generations` (precompute metadata, not a
+/// `REINDEX_VOLATILE_PARENT`, so that CASCADE is allowed): postings live and die with their build
+/// generation, and a superseded generation's postings are GC'd by that cascade — the same
+/// generation-staged lifecycle `clone_edges` uses, no independent freshness key.
+///
+/// The write-time lookup is `WHERE build_generation = ? AND token_hash IN (…)`, which
+/// `idx_clone_subblock_postings_token` covers directly. This migration only CREATEs the empty table
+/// (population + the read-path switch land in later phases of #296); until then the write-time
+/// check keeps its RAM-index fallback unchanged.
+pub(crate) const CLONE_SUBBLOCK_POSTINGS_DDL: &str = "
+    CREATE TABLE IF NOT EXISTS clone_subblock_postings(
+        build_generation INTEGER NOT NULL REFERENCES clone_graph_generations(generation) ON DELETE \
+                                                      CASCADE,
+        token_hash       INTEGER NOT NULL,
+        -- Content anchor (reindex-stable), NOT symbol_id (the #248 rule).
+        path             TEXT    NOT NULL,
+        start_byte       INTEGER NOT NULL,
+        file_sha         TEXT    NOT NULL,              -- files.sha256 at compute; read-time \
+                                                      staleness key
+        PRIMARY KEY (build_generation, token_hash, path, start_byte)
+    ) STRICT;
+    CREATE INDEX IF NOT EXISTS idx_clone_subblock_postings_token
+        ON clone_subblock_postings(build_generation, token_hash);
+";
+
+/// V037 (#296): create the persisted sub-block postings table (see
+/// [`CLONE_SUBBLOCK_POSTINGS_DDL`]) and add `clone_graph_generations.postings_written` — the
+/// upgrade-repopulation gate (review R2). A clone-graph generation built before this feature has
+/// `postings_written = 0`, which the (phase-2) precompute reads as "not postings-complete" and uses
+/// to force one rebuild pass that fills the postings, instead of leaving an upgraded DB with an
+/// empty table forever. Idempotent: `CREATE TABLE IF NOT EXISTS` + `add_column_if_missing`.
+pub(crate) fn apply_clone_subblock_postings_tables(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(CLONE_SUBBLOCK_POSTINGS_DDL)?;
+    add_column_if_missing(
+        conn,
+        "clone_graph_generations",
+        "postings_written",
+        "INTEGER NOT NULL DEFAULT 0",
+    )?;
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use migrations::*;
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 36;
+pub const LATEST_SCHEMA_VERSION: u32 = 37;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -230,6 +230,13 @@ const MIGRATION_036_DESCRIPTION: &str =
     "Add embedding_cache (content-addressed vectors keyed by input_hash) so embeddings survive \
      reindex / branch-switch and reconcile reuses unchanged content across contexts instead of \
      re-embedding; seeded from current chunk_embeddings (#357)";
+const MIGRATION_037_ID: &str = "037_clone_subblock_postings";
+const MIGRATION_037_CHECKSUM: &str = "sha256:rag-rat-clone-subblock-postings-v37";
+const MIGRATION_037_DESCRIPTION: &str =
+    "Add clone_subblock_postings (persisted content-anchored sub-block postings, \
+     generation-staged like clone_edges) + clone_graph_generations.postings_written so the \
+     write-time clone check does a bounded indexed lookup instead of rebuilding the RAM index and \
+     scales past the 40k guard (#296)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -545,6 +552,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_036_CHECKSUM,
         description: MIGRATION_036_DESCRIPTION,
         apply: apply_embedding_content_cache,
+    },
+    Migration {
+        id: MIGRATION_037_ID,
+        checksum: MIGRATION_037_CHECKSUM,
+        description: MIGRATION_037_DESCRIPTION,
+        apply: apply_clone_subblock_postings_tables,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
@@ -87,10 +87,16 @@ fn migration_034_adds_content_anchored_clone_graph_tables() {
         "V034 adds clone_graph_generations"
     );
     assert!(conn_table_exists(&conn, "clone_edges"), "V034 adds clone_edges");
+    // V034 DEFERS the persisted postings table (it lands in V037, #296). Assert the V034 DDL itself
+    // does NOT create it — checked in ISOLATION on a bare connection, so a later migration (V037)
+    // that DOES add it cannot mask the deferral. (`conn` above was migrated to LATEST and therefore
+    // now HAS the table — that is V037's job, verified by
+    // `migration_037_adds_content_anchored_clone_subblock_postings`.)
+    let v034_only = rusqlite::Connection::open_in_memory().expect("open v034-only conn");
+    crate::index::schema::apply_clone_graph_tables(&v034_only).expect("apply V034 clone-graph DDL");
     assert!(
-        !conn_table_exists(&conn, "clone_subblock_postings"),
-        "the persisted postings table is deferred to the incremental follow-up — not created in \
-         V034"
+        !conn_table_exists(&v034_only, "clone_subblock_postings"),
+        "the persisted postings table is deferred to V037 — the V034 DDL must NOT create it"
     );
 
     // Content-anchored: clone_edges must carry NO foreign key to a reindex-volatile parent
@@ -178,11 +184,6 @@ fn migration_035_adds_symbols_is_test() {
 fn migration_036_adds_content_addressed_embedding_cache() {
     let conn = rusqlite::Connection::open_in_memory().expect("open");
     crate::index::schema::apply(&conn).expect("apply");
-    assert_eq!(
-        crate::index::schema::LATEST_SCHEMA_VERSION,
-        36,
-        "LATEST_SCHEMA_VERSION is 36 after V036"
-    );
 
     conn.execute_batch("DROP TABLE embedding_cache;").expect("revert to V035 shape");
     truncate_schema_to(&conn, 35);
@@ -201,6 +202,136 @@ fn migration_036_adds_content_addressed_embedding_cache() {
     let _: i64 = conn
         .query_row("SELECT COUNT(*) FROM embedding_cache", [], |r| r.get(0))
         .expect("SELECT from embedding_cache must succeed after V036");
+}
+
+/// V037 (#296): after the FULL migration ladder, the persisted sub-block postings table exists, is
+/// STRICT, is CONTENT-ANCHORED (its only FK is the CASCADE to the DURABLE `clone_graph_generations`
+/// — NO `symbol_id` column/FK, the #248 rule), carries the anchor PK
+/// `(build_generation, token_hash, path, start_byte)` + the `(build_generation, token_hash)` lookup
+/// index, and `clone_graph_generations` gained the `postings_written` upgrade-repopulation gate
+/// (review R2). Also drives the forward-migration path from a V036 index.
+#[test]
+fn migration_037_adds_content_anchored_clone_subblock_postings() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    crate::index::schema::apply(&conn).expect("apply");
+    assert_eq!(
+        crate::index::schema::LATEST_SCHEMA_VERSION,
+        37,
+        "LATEST_SCHEMA_VERSION is 37 after V037"
+    );
+
+    // The full ladder creates the postings table + the generation completeness column.
+    assert!(
+        conn_table_exists(&conn, "clone_subblock_postings"),
+        "V037 creates clone_subblock_postings"
+    );
+    assert!(
+        conn_table_columns(&conn, "clone_graph_generations")
+            .contains(&"postings_written".to_string()),
+        "V037 adds clone_graph_generations.postings_written (upgrade-repopulation gate, R2)"
+    );
+
+    // STRICT mode (the schema convention for every new table).
+    let create_sql: String = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='clone_subblock_postings'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("read clone_subblock_postings DDL");
+    assert!(
+        create_sql.to_ascii_uppercase().contains("STRICT"),
+        "clone_subblock_postings is STRICT: {create_sql}"
+    );
+
+    // CONTENT-ANCHORED (#248): the PK is (path, start_byte)-based, never symbol_id.
+    let pk_cols: Vec<String> = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT name FROM pragma_table_info('clone_subblock_postings') WHERE pk > 0 ORDER \
+                 BY pk",
+            )
+            .unwrap();
+        stmt.query_map([], |r| r.get::<_, String>(0)).unwrap().map(Result::unwrap).collect()
+    };
+    assert_eq!(
+        pk_cols,
+        vec!["build_generation", "token_hash", "path", "start_byte"],
+        "content-anchored PK (path/start_byte, never symbol_id)"
+    );
+    let cols = conn_table_columns(&conn, "clone_subblock_postings");
+    for expected in ["build_generation", "token_hash", "path", "start_byte", "file_sha"] {
+        assert!(cols.contains(&expected.to_string()), "clone_subblock_postings has {expected}");
+    }
+    assert!(
+        !cols.contains(&"symbol_id".to_string()),
+        "clone_subblock_postings is content-anchored — no symbol_id column (#248)"
+    );
+
+    // The ONLY FK is the CASCADE to the DURABLE clone_graph_generations, NEVER to a
+    // reindex-volatile parent (symbols). The volatile-FK trip-wire enforces this at the
+    // whole-schema level too.
+    let fk_parents: Vec<String> = {
+        let mut stmt = conn
+            .prepare("SELECT \"table\" FROM pragma_foreign_key_list('clone_subblock_postings')")
+            .unwrap();
+        stmt.query_map([], |r| r.get::<_, String>(0)).unwrap().map(Result::unwrap).collect()
+    };
+    assert_eq!(
+        fk_parents,
+        vec!["clone_graph_generations"],
+        "the only FK is to the durable generations table; got {fk_parents:?}"
+    );
+
+    // The lookup index the write-time check queries exists.
+    assert!(
+        conn_index_exists(&conn, "idx_clone_subblock_postings_token"),
+        "V037 creates idx_clone_subblock_postings_token"
+    );
+
+    // Forward-migration path: a V036 index gains the table + column on migrate_forward.
+    conn.execute_batch(
+        "DROP TABLE clone_subblock_postings;
+         ALTER TABLE clone_graph_generations DROP COLUMN postings_written;",
+    )
+    .expect("revert to V036 shape");
+    truncate_schema_to(&conn, 36);
+    assert_eq!(
+        crate::index::schema::status(&conn).unwrap().state,
+        crate::index::schema::SchemaState::Older,
+        "schema is Older after removing the V037 ledger row"
+    );
+    crate::index::schema::migrate_forward(&conn).expect("migrate_forward");
+    assert!(
+        conn_table_exists(&conn, "clone_subblock_postings"),
+        "V037 recreates clone_subblock_postings on forward migrate"
+    );
+    assert!(
+        conn_table_columns(&conn, "clone_graph_generations")
+            .contains(&"postings_written".to_string()),
+        "V037 re-adds postings_written on forward migrate"
+    );
+
+    // The table is usable + generation-staged: a posting anchored under a generation round-trips.
+    conn.execute_batch(
+        "INSERT INTO clone_graph_generations
+             (generation, status, theta_floor, normalizer_kind, normalizer_version, \
+         source_revision, started_at_ms)
+         VALUES (1, 'Building', 0.7, 'baseline', 3, 'rev', 0);
+         INSERT INTO clone_subblock_postings
+             (build_generation, token_hash, path, start_byte, file_sha)
+         VALUES (1, 42, 'a.rs', 10, 'sha_a');",
+    )
+    .expect("clone_subblock_postings is usable");
+    let postings: i64 = conn
+        .query_row("SELECT COUNT(*) FROM clone_subblock_postings", [], |r| r.get(0))
+        .expect("count postings");
+    assert_eq!(postings, 1, "round-tripped one posting");
+    assert_eq!(
+        crate::index::schema::status(&conn).unwrap().current_version,
+        crate::index::schema::LATEST_SCHEMA_VERSION,
+        "schema is at LATEST_SCHEMA_VERSION after V037"
+    );
 }
 
 /// Regression test for the P1 schema bug (#215 Plan 4a): an index recorded at V029 WITHOUT


### PR DESCRIPTION
**Phase 1 of #296** (design: `docs/plans/296-clone-subblock-postings.md`, Codex-reviewed). Schema-only, additive — the table ships **empty**; population + the read-path switch + guard relaxation are phases 2–4 (#387–#389).

## What

Fills the postings slot V034 deliberately deferred:

- **`clone_subblock_postings`** (STRICT) — content-anchored on `(build_generation, token_hash, path, start_byte)` + `file_sha`, index `(build_generation, token_hash)` for the `token_hash IN (…)` lookup. The **sole FK is the `ON DELETE CASCADE` to the durable `clone_graph_generations`** — **no `symbol_id`** (the #248 rule; `symbols` is reindex-volatile). Postings live/die with their build generation, same lifecycle as `clone_edges`.
- **`clone_graph_generations.postings_written`** — the upgrade-repopulation gate (review R2): a generation built before this feature reads as *not postings-complete*, so phase 2's precompute forces one rebuild that fills them instead of leaving an upgraded DB with an empty table forever.
- Registration: `LATEST_SCHEMA_VERSION` 36→37, `MIGRATION_037_*` consts, `ADDITIVE_MIGRATIONS`, `known_version`/`known_migration`/checksum.

## Tests

- **New** `migration_037_adds_content_anchored_clone_subblock_postings`: table exists, STRICT, content-anchored PK (never `symbol_id`), sole durable FK, the index, `postings_written`, V036→V037 forward-migrate, round-trip insert.
- `migration_034…` reworked: it asserted the postings table absent *after migrating to LATEST*, which V037 now creates — so it checks the **V034 DDL in isolation** on a bare connection, keeping "V034 must not create it" a durable assertion.
- `no_table_has_a_reindex_cascading_fk_to_a_volatile_parent` passes unchanged.
- Full schema suite green (274 tests); clippy + nightly fmt clean.

Refs #386, #296.