### PR TITLE
feat(clones): bounded postings fast path in the write-time clone check (#296 phase 3)

### DIFF
--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -94,10 +94,12 @@ impl IndexDatabase {
         min_similarity: f64,
     ) -> anyhow::Result<Vec<TextCloneMatch>> {
         let conn = self.storage.connection();
-        let Some(corpus) = self.load_clone_corpus(conn)? else {
-            return Ok(Vec::new());
-        };
-        check_against(corpus.as_ref(), conn, text, language, path, min_similarity)
+        with_clone_read_snapshot(conn, || {
+            let Some(corpus) = self.load_clone_corpus(conn)? else {
+                return Ok(Vec::new());
+            };
+            check_against(corpus.as_ref(), conn, text, language, path, min_similarity)
+        })
     }
 
     /// Cheap count of fingerprinted baseline functions — a write-time hook reads it to BOUND its
@@ -155,21 +157,23 @@ impl IndexDatabase {
         min_similarity: f64,
     ) -> anyhow::Result<Vec<TextCloneMatch>> {
         let conn = self.storage.connection();
-        let Some(corpus) = self.load_clone_corpus(conn)? else {
-            return Ok(Vec::new());
-        };
-        let mut all = Vec::new();
-        for input in inputs {
-            all.extend(check_against(
-                corpus.as_ref(),
-                conn,
-                &input.text,
-                input.language,
-                &input.path,
-                min_similarity,
-            )?);
-        }
-        Ok(all)
+        with_clone_read_snapshot(conn, || {
+            let Some(corpus) = self.load_clone_corpus(conn)? else {
+                return Ok(Vec::new());
+            };
+            let mut all = Vec::new();
+            for input in inputs {
+                all.extend(check_against(
+                    corpus.as_ref(),
+                    conn,
+                    &input.text,
+                    input.language,
+                    &input.path,
+                    min_similarity,
+                )?);
+            }
+            Ok(all)
+        })
     }
 
     /// Pick the clone-check corpus: the BOUNDED postings fast path when a live clone-graph
@@ -456,6 +460,25 @@ impl CloneCorpus for IndexedCorpus {
         }
         Ok(out)
     }
+}
+
+/// Run a clone-check read `f` inside a deferred READ transaction (one WAL snapshot) when the
+/// connection is idle, so the eligibility decision and the postings/exact reads see a CONSISTENT
+/// view. Without it, a concurrent writer that completes a new clone generation between the
+/// eligibility read and `near_candidate_bags` would GC the current generation's postings out from
+/// under the fast path, silently dropping near matches. A no-op when a transaction is already open
+/// (the caller's snapshot governs). The check is read-only, so the snapshot is only ever released.
+fn with_clone_read_snapshot<T>(
+    conn: &Connection,
+    f: impl FnOnce() -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    if !conn.is_autocommit() {
+        return f();
+    }
+    conn.execute_batch("BEGIN DEFERRED")?;
+    let result = f();
+    let _ = conn.execute_batch(if result.is_ok() { "COMMIT" } else { "ROLLBACK" });
+    result
 }
 
 /// Clone-check one file's `text` against a `corpus` (RAM fallback or postings fast path), resolving
@@ -1087,6 +1110,24 @@ mod tests {
         assert!(
             db2.clone_check_indexed_generation().unwrap().is_none(),
             "a postings-less generation disqualifies the fast path"
+        );
+    }
+
+    /// The postings are built in BASE scope, so the fast path must be disabled under a
+    /// linked-worktree OVERLAY scope — else it would serve base-only postings and miss the overlay's
+    /// branch-only near-clones that the RAM fallback (which reads the overlay scope) would find.
+    /// Overlays fall back to RAM.
+    #[test]
+    fn clone_check_fast_path_disabled_under_worktree_overlay() {
+        let (mut db, _path) = parity_fixture("overlay-scope");
+        assert!(
+            db.clone_check_indexed_generation().unwrap().is_some(),
+            "base scope (empty worktree id) is fast-path eligible"
+        );
+        db.active_worktree_id = "linked-worktree-1".to_string();
+        assert!(
+            db.clone_check_indexed_generation().unwrap().is_none(),
+            "a linked-worktree overlay scope disqualifies the base-built postings fast path"
         );
     }
 }

--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -19,7 +19,8 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use rusqlite::Connection;
+use rusqlite::types::Value;
+use rusqlite::{Connection, params, params_from_iter};
 use serde::Serialize;
 
 use super::substrate::{
@@ -27,6 +28,7 @@ use super::substrate::{
     verified_clone,
 };
 use super::{HYDRATION_CHUNK, THETA};
+use crate::index::clones::bag_blob::decode_token_bag;
 use crate::index::clones::{NORM_VERSION, SymbolFingerprint, fingerprint_symbols};
 use crate::index::{IndexDatabase, parser, symbols};
 use crate::language::Language;
@@ -41,7 +43,7 @@ pub struct CloneCheckInput {
 }
 
 /// One just-written function that duplicates existing indexed code.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct TextCloneMatch {
     /// The input file (relative path) the new function is in — set on every match so a batch
     /// result is self-describing.
@@ -92,10 +94,10 @@ impl IndexDatabase {
         min_similarity: f64,
     ) -> anyhow::Result<Vec<TextCloneMatch>> {
         let conn = self.storage.connection();
-        let Some(index) = CheckIndex::load(conn)? else {
+        let Some(corpus) = self.load_clone_corpus(conn)? else {
             return Ok(Vec::new());
         };
-        index.check(conn, text, language, path, min_similarity)
+        check_against(corpus.as_ref(), conn, text, language, path, min_similarity)
     }
 
     /// Cheap count of fingerprinted baseline functions — a write-time hook reads it to BOUND its
@@ -153,12 +155,13 @@ impl IndexDatabase {
         min_similarity: f64,
     ) -> anyhow::Result<Vec<TextCloneMatch>> {
         let conn = self.storage.connection();
-        let Some(index) = CheckIndex::load(conn)? else {
+        let Some(corpus) = self.load_clone_corpus(conn)? else {
             return Ok(Vec::new());
         };
         let mut all = Vec::new();
         for input in inputs {
-            all.extend(index.check(
+            all.extend(check_against(
+                corpus.as_ref(),
                 conn,
                 &input.text,
                 input.language,
@@ -167,6 +170,20 @@ impl IndexDatabase {
             )?);
         }
         Ok(all)
+    }
+
+    /// Pick the clone-check corpus: the BOUNDED postings fast path when a live clone-graph
+    /// generation is exactly current + postings-complete
+    /// ([`Self::clone_check_indexed_generation`]), else the RAM fallback that builds the whole
+    /// inverted index ([`CheckIndex::load`]). `None` only when neither is available
+    /// (empty/unusable index) — a best-effort no-op for the caller. This is the seam that lets
+    /// the write-time check skip the O(functions) RAM build once a generation is published,
+    /// without changing what it reports (the fast/fallback equivalence test pins it).
+    fn load_clone_corpus(&self, conn: &Connection) -> anyhow::Result<Option<Box<dyn CloneCorpus>>> {
+        if let Some(generation) = self.clone_check_indexed_generation()? {
+            return Ok(Some(Box::new(IndexedCorpus::load(conn, generation)?)));
+        }
+        Ok(CheckIndex::load(conn)?.map(|idx| Box::new(idx) as Box<dyn CloneCorpus>))
     }
 }
 
@@ -216,122 +233,331 @@ impl CheckIndex {
     fn bag(&self, id: i64) -> &SymbolBag {
         &self.indexed[self.id_to_idx[&id]]
     }
+}
 
-    /// Clone-check one file's `text` against the loaded index, resolving refs and excluding
-    /// self-file matches.
-    fn check(
+/// The corpus a [`check_against`] pass looks up EXACT + NEAR clone candidates in. Two
+/// implementations — the RAM [`CheckIndex`] (fallback, builds the whole inverted index) and the
+/// bounded [`IndexedCorpus`] (fast path, reads persisted `clone_subblock_postings`) — return the
+/// SAME candidate sets for a fully-current index, so the pass reports identical clones either way
+/// (the fast-vs-fallback equivalence test pins this). #296 phase 3.
+trait CloneCorpus {
+    /// `token_hash -> df` for building a NEW (not-yet-indexed) bag's `sub_block_tokens` ordering.
+    fn df_by_token(&self) -> &HashMap<i64, i64>;
+
+    /// EXACT (identical `struct_hash`) partner symbol ids of the given language — scope-,
+    /// generated-, and test-filtered, matching the corpus that feeds `find_clones`.
+    fn exact_partner_ids(
         &self,
         conn: &Connection,
-        text: &str,
-        language: Language,
-        path: &Path,
-        min_similarity: f64,
-    ) -> anyhow::Result<Vec<TextCloneMatch>> {
-        let syms = symbols::symbols_for_file(path, language, text);
-        let Some(parsed) = parser::parse_file(path, language, text) else {
-            return Ok(Vec::new());
-        };
-        let new_fps = fingerprint_symbols(parsed.root(), text, language, &syms);
-        if new_fps.is_empty() {
+        struct_hash: &str,
+        lang: &str,
+    ) -> anyhow::Result<Vec<i64>>;
+
+    /// NEAR candidate bags — indexed functions sharing a sub-block token with `new_bag` (same
+    /// scope/generated/test filters). The verify (`verified_clone`) is applied by the caller, so
+    /// this only needs to be a superset of the true near clones. Deduplicated by symbol.
+    fn near_candidate_bags(
+        &self,
+        conn: &Connection,
+        new_bag: &SymbolBag,
+        lang: &str,
+    ) -> anyhow::Result<Vec<SymbolBag>>;
+}
+
+impl CloneCorpus for CheckIndex {
+    fn df_by_token(&self) -> &HashMap<i64, i64> {
+        &self.df_by_token
+    }
+
+    fn exact_partner_ids(
+        &self,
+        _conn: &Connection,
+        struct_hash: &str,
+        lang: &str,
+    ) -> anyhow::Result<Vec<i64>> {
+        Ok(self
+            .by_struct
+            .get(&(struct_hash.to_string(), lang.to_string()))
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    fn near_candidate_bags(
+        &self,
+        _conn: &Connection,
+        new_bag: &SymbolBag,
+        _lang: &str,
+    ) -> anyhow::Result<Vec<SymbolBag>> {
+        // Candidate ids sharing a sub-block token (any language; the caller applies the language +
+        // verify gate), deduplicated. Bags are cloned from RAM — cheap: a batch checks only the few
+        // functions the agent just wrote, so this runs per-new-function over a bounded candidate
+        // set.
+        let mut ids: BTreeSet<i64> = BTreeSet::new();
+        for token in sub_block_tokens(new_bag, THETA) {
+            if let Some(bag_ids) = self.inverted.get(&token) {
+                ids.extend(bag_ids);
+            }
+        }
+        Ok(ids.into_iter().map(|id| self.bag(id).clone()).collect())
+    }
+}
+
+/// The BOUNDED postings fast path (#296 phase 3): resolve EXACT + NEAR candidates for each new
+/// function with index-covered SQL against the live clone-graph generation's persisted
+/// `clone_subblock_postings`, instead of preloading every scoped bag into a RAM inverted index.
+/// Held per batch; the only up-front load is `clone_token_df` (a small selectivity table, NOT
+/// O(functions)) for the new bags' token ordering.
+struct IndexedCorpus {
+    generation: i64,
+    df_by_token: HashMap<i64, i64>,
+}
+
+impl IndexedCorpus {
+    fn load(conn: &Connection, generation: i64) -> anyhow::Result<Self> {
+        Ok(Self { generation, df_by_token: load_clone_token_df(conn)? })
+    }
+}
+
+impl CloneCorpus for IndexedCorpus {
+    fn df_by_token(&self) -> &HashMap<i64, i64> {
+        &self.df_by_token
+    }
+
+    fn exact_partner_ids(
+        &self,
+        conn: &Connection,
+        struct_hash: &str,
+        lang: &str,
+    ) -> anyhow::Result<Vec<i64>> {
+        // A bounded indexed read on idx_symbol_fingerprints_struct. The filters reproduce the RAM
+        // `by_struct` corpus exactly: scoped `files` view, `generated = 0`, `is_test = 0`, matching
+        // language, and `token_bag IS NOT NULL` (the RAM path skips NULL-bag symbols in `load`).
+        let mut stmt = conn.prepare(
+            "SELECT sf.symbol_id
+               FROM symbol_fingerprints sf
+               JOIN symbols ON symbols.id = sf.symbol_id
+               JOIN files ON files.id = symbols.file_id
+              WHERE sf.normalizer_kind = 'baseline' AND sf.normalizer_version = ?1
+                AND files.generated = 0 AND symbols.is_test = 0
+                AND symbols.language = ?2 AND sf.struct_hash = ?3
+                AND sf.token_bag IS NOT NULL",
+        )?;
+        let ids = stmt
+            .query_map(params![NORM_VERSION, lang, struct_hash], |r| r.get::<_, i64>(0))?
+            .collect::<rusqlite::Result<Vec<i64>>>()?;
+        Ok(ids)
+    }
+
+    fn near_candidate_bags(
+        &self,
+        conn: &Connection,
+        new_bag: &SymbolBag,
+        lang: &str,
+    ) -> anyhow::Result<Vec<SymbolBag>> {
+        let tokens = sub_block_tokens(new_bag, THETA);
+        if tokens.is_empty() {
             return Ok(Vec::new());
         }
 
-        let lang = language.as_str();
-        let in_file = path.to_string_lossy().into_owned();
-        let self_prefix = format!("{in_file}::"); // refs starting with this are the file's own code
+        // 1. Query the postings for candidate anchors sharing any of the new bag's sub-block
+        //    tokens, chunked under the bind-variable cap. Dedup to `(path, start_byte) -> file_sha`
+        //    (a symbol appears under many tokens; its anchor sha is the same across them).
+        let mut anchor_sha: HashMap<(String, i64), String> = HashMap::new();
+        for chunk in tokens.chunks(HYDRATION_CHUNK) {
+            let placeholders: Vec<String> =
+                (0..chunk.len()).map(|i| format!("?{}", i + 2)).collect();
+            let sql = format!(
+                "SELECT path, start_byte, file_sha FROM clone_subblock_postings
+                  WHERE build_generation = ?1 AND token_hash IN ({})",
+                placeholders.join(", ")
+            );
+            let mut params: Vec<i64> = Vec::with_capacity(chunk.len() + 1);
+            params.push(self.generation);
+            params.extend_from_slice(chunk);
+            let mut stmt = conn.prepare(&sql)?;
+            let rows = stmt.query_map(params_from_iter(params), |r| {
+                Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?, r.get::<_, String>(2)?))
+            })?;
+            for row in rows {
+                let (path, start_byte, file_sha) = row?;
+                anchor_sha.entry((path, start_byte)).or_insert(file_sha);
+            }
+        }
+        if anchor_sha.is_empty() {
+            return Ok(Vec::new());
+        }
 
-        let mut id_set: BTreeSet<i64> = BTreeSet::new();
-        let mut pending: Vec<(String, usize, &'static str, f64, Vec<i64>)> = Vec::new();
+        // 2. Hydrate ONLY those candidate anchors (NOT every scoped symbol — review R3) via a
+        //    row-value `IN (VALUES …)` over the scoped `files` view, chunked. Same corpus filters
+        //    as EXACT, plus: drop a posting whose anchor sha no longer matches the last-indexed
+        //    `files.sha256` (the file changed since the build — the #248 read-staleness
+        //    discipline), and skip NULL/corrupt `token_bag` (a no-bag symbol, as the RAM `load`
+        //    does).
+        let anchors: Vec<(String, i64)> = anchor_sha.keys().cloned().collect();
+        let mut out: Vec<SymbolBag> = Vec::new();
+        for chunk in anchors.chunks(HYDRATION_CHUNK) {
+            let tuples: Vec<String> =
+                (0..chunk.len()).map(|i| format!("(?{}, ?{})", 2 * i + 3, 2 * i + 4)).collect();
+            let sql = format!(
+                "SELECT files.path, symbols.start_byte, files.sha256, symbols.id, \
+                 symbols.language,
+                        sf.struct_hash, sf.token_len, sf.token_bag
+                   FROM symbol_fingerprints sf
+                   JOIN symbols ON symbols.id = sf.symbol_id
+                   JOIN files ON files.id = symbols.file_id
+                  WHERE sf.normalizer_kind = 'baseline' AND sf.normalizer_version = ?1
+                    AND files.generated = 0 AND symbols.is_test = 0 AND symbols.language = ?2
+                    AND (files.path, symbols.start_byte) IN (VALUES {})",
+                tuples.join(", ")
+            );
+            let mut values: Vec<Value> = Vec::with_capacity(2 + 2 * chunk.len());
+            values.push(Value::Integer(NORM_VERSION));
+            values.push(Value::Text(lang.to_string()));
+            for (path, start_byte) in chunk {
+                values.push(Value::Text(path.clone()));
+                values.push(Value::Integer(*start_byte));
+            }
+            let mut stmt = conn.prepare(&sql)?;
+            let rows = stmt.query_map(params_from_iter(values), |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, i64>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, i64>(3)?,
+                    r.get::<_, String>(4)?,
+                    r.get::<_, String>(5)?,
+                    r.get::<_, i64>(6)?,
+                    r.get::<_, Option<Vec<u8>>>(7)?,
+                ))
+            })?;
+            for row in rows {
+                let (path, start_byte, live_sha, symbol_id, language, struct_hash, token_len, blob) =
+                    row?;
+                // Staleness: the anchor's build-time sha must still equal the last-indexed sha.
+                if anchor_sha.get(&(path, start_byte)).is_none_or(|s| *s != live_sha) {
+                    continue;
+                }
+                let Some(blob) = blob else { continue };
+                let Some(bag_pairs) = decode_token_bag(&blob) else { continue };
+                let tokens = bag_pairs
+                    .into_iter()
+                    .map(|(token_hash, freq)| TokenPosting {
+                        token_hash,
+                        freq,
+                        coalesced_df: self
+                            .df_by_token
+                            .get(&token_hash)
+                            .copied()
+                            .unwrap_or(DF_FALLBACK),
+                    })
+                    .collect();
+                out.push(SymbolBag { symbol_id, language, struct_hash, token_len, tokens });
+            }
+        }
+        Ok(out)
+    }
+}
 
-        for (local, fp) in &new_fps {
-            let symbol = &syms[*local];
-            // #292: don't clone-check test code the agent is writing — a new test is expected to
-            // resemble existing tests, and flagging it is pure noise.
-            if symbol.is_test {
+/// Clone-check one file's `text` against a `corpus` (RAM fallback or postings fast path), resolving
+/// refs and excluding self-file matches. The per-new-function EXACT + NEAR candidate lookups come
+/// from the `corpus`; everything else — fingerprinting the new text, the `verified_clone`/`overlap`
+/// verify at `min_similarity`, ref resolution, and self-file exclusion — is identical for both,
+/// which is what makes the postings fast path a pure optimization rather than a behavior change.
+fn check_against(
+    corpus: &dyn CloneCorpus,
+    conn: &Connection,
+    text: &str,
+    language: Language,
+    path: &Path,
+    min_similarity: f64,
+) -> anyhow::Result<Vec<TextCloneMatch>> {
+    let syms = symbols::symbols_for_file(path, language, text);
+    let Some(parsed) = parser::parse_file(path, language, text) else {
+        return Ok(Vec::new());
+    };
+    let new_fps = fingerprint_symbols(parsed.root(), text, language, &syms);
+    if new_fps.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let lang = language.as_str();
+    let in_file = path.to_string_lossy().into_owned();
+    let self_prefix = format!("{in_file}::"); // refs starting with this are the file's own code
+
+    let mut id_set: BTreeSet<i64> = BTreeSet::new();
+    let mut pending: Vec<(String, usize, &'static str, f64, Vec<i64>)> = Vec::new();
+
+    for (local, fp) in &new_fps {
+        let symbol = &syms[*local];
+        // #292: don't clone-check test code the agent is writing — a new test is expected to
+        // resemble existing tests, and flagging it is pure noise.
+        if symbol.is_test {
+            continue;
+        }
+        let new_bag = bag_from_fingerprint(fp, lang, corpus.df_by_token());
+
+        // EXACT: identical structure (same struct_hash + language) → similarity 1.0.
+        let exact = corpus.exact_partner_ids(conn, &fp.struct_hash, lang)?;
+        let exact_set: BTreeSet<i64> = exact.iter().copied().collect();
+        if !exact.is_empty() {
+            id_set.extend(&exact);
+            pending.push((symbol.name.clone(), symbol.start_line, "exact", 1.0, exact));
+        }
+
+        // NEAR: candidates share a sub-block token; kept by the exact overlap verify. Exclude ids
+        // already reported as exact for this function.
+        let mut near_ids: Vec<i64> = Vec::new();
+        let mut best_sim = 0.0_f64;
+        for other in corpus.near_candidate_bags(conn, &new_bag, lang)? {
+            if exact_set.contains(&other.symbol_id) {
                 continue;
             }
-            let new_bag = bag_from_fingerprint(fp, lang, &self.df_by_token);
-
-            // EXACT: identical structure (same struct_hash + language) → similarity 1.0.
-            let exact: Vec<i64> = self
-                .by_struct
-                .get(&(fp.struct_hash.clone(), lang.to_string()))
-                .cloned()
-                .unwrap_or_default();
-            let exact_set: BTreeSet<i64> = exact.iter().copied().collect();
-            if !exact.is_empty() {
-                id_set.extend(&exact);
-                pending.push((symbol.name.clone(), symbol.start_line, "exact", 1.0, exact));
+            // Candidate generation stays at THETA (generous recall); the NEAR match is kept only at
+            // `min_similarity` (the write-time hook raises this to cut boilerplate near-noise).
+            // Exact (struct_hash) matches are unaffected — they're similarity 1.0.
+            if other.language != lang || !verified_clone(&new_bag, &other, min_similarity) {
+                continue;
             }
-
-            // NEAR: candidates share a sub-block token; kept by the exact overlap verify. Exclude
-            // ids already reported as exact for this function.
-            let mut cand: BTreeSet<i64> = BTreeSet::new();
-            for token in sub_block_tokens(&new_bag, THETA) {
-                if let Some(ids) = self.inverted.get(&token) {
-                    cand.extend(ids);
-                }
-            }
-            let mut near_ids: Vec<i64> = Vec::new();
-            let mut best_sim = 0.0_f64;
-            for id in cand {
-                if exact_set.contains(&id) {
-                    continue;
-                }
-                let other = self.bag(id);
-                // Candidate generation stays at THETA (generous recall); the NEAR match is kept
-                // only at `min_similarity` (the write-time hook raises this to cut boilerplate
-                // near-noise). Exact (struct_hash) matches are unaffected — they're similarity 1.0.
-                if other.language != lang || !verified_clone(&new_bag, other, min_similarity) {
-                    continue;
-                }
-                let max_len = new_bag.token_len.max(other.token_len);
-                let sim = if max_len == 0 {
-                    1.0
-                } else {
-                    overlap(&new_bag, other) as f64 / max_len as f64
-                };
-                best_sim = best_sim.max(sim);
-                near_ids.push(id);
-            }
-            if !near_ids.is_empty() {
-                id_set.extend(&near_ids);
-                pending.push((symbol.name.clone(), symbol.start_line, "near", best_sim, near_ids));
-            }
+            let max_len = new_bag.token_len.max(other.token_len);
+            let sim =
+                if max_len == 0 { 1.0 } else { overlap(&new_bag, &other) as f64 / max_len as f64 };
+            best_sim = best_sim.max(sim);
+            near_ids.push(other.symbol_id);
         }
-
-        let refs = resolve_refs(conn, &id_set)?;
-        let mut matches: Vec<TextCloneMatch> = pending
-            .into_iter()
-            .map(|(name, start_line, kind, similarity, ids)| {
-                let mut clone_of: Vec<String> = ids
-                    .iter()
-                    .filter_map(|id| refs.get(id).cloned())
-                    // Self-file exclusion: a function isn't a clone of code in its own file (so an
-                    // in-place edit doesn't flag against its own indexed copy).
-                    .filter(|r| !r.starts_with(&self_prefix))
-                    .collect();
-                clone_of.sort();
-                clone_of.dedup();
-                TextCloneMatch {
-                    in_file: in_file.clone(),
-                    name,
-                    start_line,
-                    kind,
-                    similarity,
-                    clone_of,
-                }
-            })
-            .filter(|m| !m.clone_of.is_empty())
-            .collect();
-        matches.sort_by(|a, b| {
-            a.start_line
-                .cmp(&b.start_line)
-                .then_with(|| a.name.cmp(&b.name))
-                .then(a.kind.cmp(b.kind))
-        });
-        Ok(matches)
+        if !near_ids.is_empty() {
+            id_set.extend(&near_ids);
+            pending.push((symbol.name.clone(), symbol.start_line, "near", best_sim, near_ids));
+        }
     }
+
+    let refs = resolve_refs(conn, &id_set)?;
+    let mut matches: Vec<TextCloneMatch> = pending
+        .into_iter()
+        .map(|(name, start_line, kind, similarity, ids)| {
+            let mut clone_of: Vec<String> = ids
+                .iter()
+                .filter_map(|id| refs.get(id).cloned())
+                // Self-file exclusion: a function isn't a clone of code in its own file (so an
+                // in-place edit doesn't flag against its own indexed copy).
+                .filter(|r| !r.starts_with(&self_prefix))
+                .collect();
+            clone_of.sort();
+            clone_of.dedup();
+            TextCloneMatch {
+                in_file: in_file.clone(),
+                name,
+                start_line,
+                kind,
+                similarity,
+                clone_of,
+            }
+        })
+        .filter(|m| !m.clone_of.is_empty())
+        .collect();
+    matches.sort_by(|a, b| {
+        a.start_line.cmp(&b.start_line).then_with(|| a.name.cmp(&b.name)).then(a.kind.cmp(b.kind))
+    });
+    Ok(matches)
 }
 
 /// Symbol ids the index marked as test code (`symbols.is_test`), across all git contexts — the
@@ -650,5 +876,217 @@ mod tests {
             )
             .unwrap();
         assert!(test_hits.is_empty(), "new test code is not clone-checked: {test_hits:?}");
+    }
+
+    // ---- #296 phase 3: the bounded postings fast path -----------------------------------------
+
+    /// A richer fixture for the fast-vs-fallback equivalence: `load_user` (src/a.rs) has a renamed
+    /// clone `load_order` (src/b.rs) plus a `#[cfg(test)]` clone `helper` (must be excluded), and a
+    /// cross-language Python `load_user` (py/p.py, must never match a Rust check). Rebuilt AND
+    /// precomputed, so a live postings-complete generation exists. Returns the db + its path (for
+    /// the 2nd-connection mutations the eligibility / staleness tests need).
+    fn parity_fixture(tag: &str) -> (crate::IndexDatabase, std::path::PathBuf) {
+        let root = std::env::temp_dir().join(format!(
+            "rag-rat-of-text-parity-{tag}-{}-{}",
+            std::process::id(),
+            crate::index::util::now_ms()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(root.join("py")).unwrap();
+        std::fs::write(
+            root.join("src/a.rs"),
+            "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\npub fn \
+             compute_totals(items: Vec<i64>) -> i64 { let mut s = 0; for it in items { s += it * \
+             2; } s + 1 }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("src/b.rs"),
+            "pub fn load_order(store: Db) -> i32 { let o = store.get(20); validate(o); o + 1 \
+             }\n#[cfg(test)]\nmod tests { fn helper(db: Db) -> i32 { let u = db.get(10); \
+             validate(u); u + 1 } }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("py/p.py"),
+            "def load_user(db):\n    u = db.get(10)\n    validate(u)\n    return u + 1\n",
+        )
+        .unwrap();
+        let target = |name: &str, language, dir: &str| crate::config::ResolvedTarget {
+            name: name.to_string(),
+            language,
+            directories: vec![std::path::PathBuf::from(dir)],
+            include: vec![format!("{dir}/")],
+            exclude: Vec::new(),
+            kind: crate::config::TargetKind::Source,
+        };
+        let config = crate::Config {
+            root: root.clone(),
+            database: root.join(".rag-rat/index.sqlite"),
+            targets: vec![
+                target("rust", crate::language::Language::Rust, "src"),
+                target("python", crate::language::Language::Python, "py"),
+            ],
+            llm: Default::default(),
+            watch: Default::default(),
+            version_check: Default::default(),
+            oracle: Default::default(),
+            search: Default::default(),
+            log: Default::default(),
+        };
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
+        let db_path = root.join(".rag-rat/index.sqlite");
+        (db, db_path)
+    }
+
+    /// Run the SAME text through the postings fast path (`IndexedCorpus`) and the RAM fallback
+    /// (`CheckIndex`) on the same index, returning both results for an equality assertion.
+    fn fast_and_fallback(
+        db: &crate::IndexDatabase,
+        text: &str,
+        path: &str,
+    ) -> (Vec<super::TextCloneMatch>, Vec<super::TextCloneMatch>) {
+        let conn = db.storage.connection();
+        let generation = db
+            .clone_check_indexed_generation()
+            .unwrap()
+            .expect("a fresh precomputed generation is fast-path eligible");
+        let indexed = super::IndexedCorpus::load(conn, generation).unwrap();
+        let fallback = super::CheckIndex::load(conn).unwrap().expect("non-empty index");
+        let run = |corpus: &dyn super::CloneCorpus| {
+            super::check_against(
+                corpus,
+                conn,
+                text,
+                crate::language::Language::Rust,
+                std::path::Path::new(path),
+                super::THETA,
+            )
+            .unwrap()
+        };
+        (run(&indexed), run(&fallback))
+    }
+
+    /// Fingerprint the single function in `text` into a candidate-gen bag (the shape
+    /// `check_against` builds per new function) so a test can call `near_candidate_bags` directly.
+    fn probe_bag(text: &str, df: &std::collections::HashMap<i64, i64>) -> super::SymbolBag {
+        let path = std::path::Path::new("probe.rs");
+        let lang = crate::language::Language::Rust;
+        let syms = crate::index::symbols::symbols_for_file(path, lang, text);
+        let parsed = crate::index::parser::parse_file(path, lang, text).unwrap();
+        let fps = crate::index::clones::fingerprint_symbols(parsed.root(), text, lang, &syms);
+        let (_, fp) = fps.into_iter().next().expect("one function in probe text");
+        super::bag_from_fingerprint(&fp, "rust", df)
+    }
+
+    /// THE CORNERSTONE (#296 phase 3, review R4): the postings fast path returns the EXACT same
+    /// `TextCloneMatch`es as the RAM fallback — across a cross-file clone, a `#[cfg(test)]` clone
+    /// that must stay excluded, a cross-language collision, and a self-file edit. This is what
+    /// makes the fast path a pure optimization rather than a behavior change.
+    #[test]
+    fn fast_postings_path_equals_ram_fallback() {
+        let (db, _path) = parity_fixture("equiv");
+
+        // A clone of load_user written to a NEW file → matches load_user + load_order, never the
+        // #[cfg(test)] helper or the cross-language python load_user.
+        let clone_text = "pub fn fetch_account(store: Db) -> i32 { let a = store.get(20); \
+                          validate(a); a + 1 }\n";
+        let (fast, fallback) = fast_and_fallback(&db, clone_text, "new.rs");
+        assert_eq!(fast, fallback, "fast == fallback for a cross-file clone");
+        assert!(!fast.is_empty(), "the clone is found");
+        let refs: Vec<&str> =
+            fast.iter().flat_map(|m| m.clone_of.iter()).map(String::as_str).collect();
+        assert!(refs.iter().any(|r| r.contains("load_user")), "matches the real fn: {refs:?}");
+        assert!(
+            refs.iter().any(|r| r.contains("load_order")),
+            "matches the renamed clone: {refs:?}"
+        );
+        assert!(
+            !refs.iter().any(|r| r.contains("helper")),
+            "#[cfg(test)] clone excluded: {refs:?}"
+        );
+        assert!(!refs.iter().any(|r| r.contains("p.py")), "cross-language excluded: {refs:?}");
+
+        // Self-file edit: the own-file ref is excluded in BOTH modes (the cross-file clone
+        // remains).
+        let self_edit =
+            "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\n";
+        let (fast_self, fallback_self) = fast_and_fallback(&db, self_edit, "src/a.rs");
+        assert_eq!(fast_self, fallback_self, "fast == fallback for a self-file edit");
+        let self_refs: Vec<&str> =
+            fast_self.iter().flat_map(|m| m.clone_of.iter()).map(String::as_str).collect();
+        assert!(
+            self_refs.iter().all(|r| !r.starts_with("src/a.rs::")),
+            "own-file ref excluded in fast mode: {self_refs:?}"
+        );
+
+        // Unrelated code: both empty.
+        let (fu, fbu) = fast_and_fallback(&db, "pub fn unrelated() -> i32 { 42 }\n", "u.rs");
+        assert_eq!(fu, fbu);
+    }
+
+    /// Review R1/R5 staleness: a candidate whose posting anchor sha no longer matches the
+    /// last-indexed `files.sha256` (the file was edited since the build) is dropped by the fast
+    /// path — so it never matches against stale content. Exercised directly on
+    /// `near_candidate_bags` (below the eligibility gate, which would otherwise fall back on
+    /// the same content drift).
+    #[test]
+    fn indexed_fast_path_drops_stale_postings() {
+        use super::CloneCorpus; // the `near_candidate_bags` trait method
+        let (db, db_path) = parity_fixture("stale");
+        let conn = db.storage.connection();
+        let generation = db.clone_check_indexed_generation().unwrap().unwrap();
+        let corpus = super::IndexedCorpus::load(conn, generation).unwrap();
+
+        let probe = probe_bag(
+            "pub fn probe(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\n",
+            &corpus.df_by_token,
+        );
+        let fresh = corpus.near_candidate_bags(conn, &probe, "rust").unwrap();
+        assert!(!fresh.is_empty(), "near candidates present when postings are fresh");
+
+        // Every indexed file is now 'edited since the build': its last-indexed sha no longer
+        // matches the postings' anchor sha (2nd WAL connection; the index handle is idle).
+        {
+            let c = rusqlite::Connection::open(&db_path).unwrap();
+            c.execute("UPDATE files SET sha256 = 'stale-not-matching-any-posting'", []).unwrap();
+        }
+        let stale = corpus.near_candidate_bags(conn, &probe, "rust").unwrap();
+        assert!(stale.is_empty(), "stale postings dropped, {} candidates left", stale.len());
+    }
+
+    /// The fast path is eligible ONLY for an exactly-current, postings-complete generation — the
+    /// strict-freshness gate (review R1 + R2). A content edit (source_revision drift) or a
+    /// postings-less generation both disqualify it, so the check falls back to the RAM path.
+    #[test]
+    fn clone_check_fast_path_eligibility_gate() {
+        // Fresh + postings-complete + exactly current → eligible.
+        let (db, db_path) = parity_fixture("elig-fresh");
+        assert!(
+            db.clone_check_indexed_generation().unwrap().is_some(),
+            "a current postings-complete generation is fast-path eligible"
+        );
+        // A content edit since the build → source_revision drift → NOT eligible (review R1).
+        {
+            let c = rusqlite::Connection::open(&db_path).unwrap();
+            c.execute("UPDATE files SET sha256 = 'drift-' || sha256", []).unwrap();
+        }
+        assert!(
+            db.clone_check_indexed_generation().unwrap().is_none(),
+            "content drift disqualifies the fast path (postings need EXACT freshness)"
+        );
+
+        // A postings-less (pre-feature) live generation → NOT eligible (review R2).
+        let (db2, db_path2) = parity_fixture("elig-pw");
+        {
+            let c = rusqlite::Connection::open(&db_path2).unwrap();
+            c.execute("UPDATE clone_graph_generations SET postings_written = 0", []).unwrap();
+        }
+        assert!(
+            db2.clone_check_indexed_generation().unwrap().is_none(),
+            "a postings-less generation disqualifies the fast path"
+        );
     }
 }

--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -1114,9 +1114,9 @@ mod tests {
     }
 
     /// The postings are built in BASE scope, so the fast path must be disabled under a
-    /// linked-worktree OVERLAY scope — else it would serve base-only postings and miss the overlay's
-    /// branch-only near-clones that the RAM fallback (which reads the overlay scope) would find.
-    /// Overlays fall back to RAM.
+    /// linked-worktree OVERLAY scope — else it would serve base-only postings and miss the
+    /// overlay's branch-only near-clones that the RAM fallback (which reads the overlay scope)
+    /// would find. Overlays fall back to RAM.
     #[test]
     fn clone_check_fast_path_disabled_under_worktree_overlay() {
         let (mut db, _path) = parity_fixture("overlay-scope");

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -154,6 +154,29 @@ impl IndexDatabase {
             || !live.postings_written)
     }
 
+    /// The live clone-graph generation the write-time postings fast path may read from —
+    /// `Some(gen)` ONLY when the persisted postings are safe to serve, `None` otherwise (→ the
+    /// caller uses the RAM fallback). Eligibility is EXACT-freshness, deliberately STRICTER
+    /// than the `find_clones` edge fast path's "mildly-stale-OK" (review R1): the persisted
+    /// sub-block token set for a symbol depends on `sub_block_tokens`' ordering by the CURRENT
+    /// `clone_token_df`, so a generation whose `source_revision` has drifted from
+    /// `content_revision()` could disagree with what the live index would compute — a silent
+    /// missed near-clone. So require:
+    /// - a `Complete` live generation (the meta live-pointer only ever names a Complete one),
+    /// - `normalizer_version == NORM_VERSION`,
+    /// - `postings_written` (a postings-complete, postings-aware generation — review R2), AND
+    /// - `source_revision == content_revision()` EXACTLY (not merely present).
+    pub(crate) fn clone_check_indexed_generation(&self) -> anyhow::Result<Option<i64>> {
+        let conn = self.storage.connection();
+        let Some(live) = live_generation_row(conn)? else {
+            return Ok(None);
+        };
+        let eligible = live.normalizer_version == NORM_VERSION
+            && live.postings_written
+            && live.source_revision == self.content_revision()?;
+        Ok(eligible.then_some(live.generation))
+    }
+
     /// ONE precompute pass: resume (or start) the building generation toward the current content
     /// revision, stream symbols from the resume cursor emitting verified clone edges, checkpoint
     /// per batch, and — if the walk finishes within budget — publish the generation as live.

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -167,6 +167,16 @@ impl IndexDatabase {
     /// - `postings_written` (a postings-complete, postings-aware generation — review R2), AND
     /// - `source_revision == content_revision()` EXACTLY (not merely present).
     pub(crate) fn clone_check_indexed_generation(&self) -> anyhow::Result<Option<i64>> {
+        // BASE-SCOPE ONLY. The clone graph (edges + postings) is built in the BASE scope —
+        // maintenance restores it before the clone-graph pass, and `content_revision()` is GLOBAL
+        // over `main.files` so it CANNOT encode which scope produced the postings. Under a
+        // linked-worktree OVERLAY the postings cover only base-scope symbols, while the RAM
+        // fallback reads the overlay's branch-only symbols; serving the fast path there
+        // would silently miss overlay near-clones. So disable it under a linked overlay —
+        // those scopes fall back to the correct, overlay-scoped RAM build.
+        if self.active_scope_is_linked_overlay() {
+            return Ok(None);
+        }
         let conn = self.storage.connection();
         let Some(live) = live_generation_row(conn)? else {
             return Ok(None);

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -154,6 +154,25 @@ impl IndexDatabase {
             || !live.postings_written)
     }
 
+    /// Invalidate the persisted clone-graph postings — mark EVERY generation postings-stale
+    /// (`postings_written = 0`) so `pending_clone_graph` reports pending and the next maintenance
+    /// pass rebuilds the graph. Called when `clone_token_df` is recomputed (a full rebuild): the
+    /// postings freeze `sub_block_tokens`' ordering by the df table AS OF their build, but a full
+    /// rebuild corrects df drift WITHOUT changing file content, so `content_revision()` (the
+    /// clone-graph freshness key) stays equal and nothing else would catch the drift. Serving those
+    /// postings would rank a new function with the current df while reading postings ordered by the
+    /// old df, silently missing near-clones whose selected sub-block token shifted. Until the
+    /// rebuild, the write-time fast path falls back to the RAM build; `find_clones`' edges are
+    /// df-INDEPENDENT (they store the verified overlap) and are unaffected. Incremental indexing
+    /// bumps df alongside file-content changes, so `content_revision()` already gates that path —
+    /// only this content-invariant refresh needs the explicit nudge.
+    pub(crate) fn invalidate_clone_graph_postings(&self) -> anyhow::Result<()> {
+        self.storage
+            .connection()
+            .execute("UPDATE clone_graph_generations SET postings_written = 0", [])?;
+        Ok(())
+    }
+
     /// The live clone-graph generation the write-time postings fast path may read from —
     /// `Some(gen)` ONLY when the persisted postings are safe to serve, `None` otherwise (→ the
     /// caller uses the RAM fallback). Eligibility is EXACT-freshness, deliberately STRICTER
@@ -769,10 +788,12 @@ fn read_meta(conn: &Connection, key: &str) -> anyhow::Result<Option<String>> {
 mod tests {
     use super::*;
 
-    /// A fixed two-file fixture with two renamed-clone groups (load_user/load_order +
-    /// compute_totals/tally_amounts). Identical file CONTENT across tags → identical content-key
-    /// edges, so two builds are directly comparable.
-    fn build_clone_fixture(tag: &str) -> crate::IndexDatabase {
+    /// The config for a fixed two-file fixture with two renamed-clone groups
+    /// (load_user/load_order and compute_totals/tally_amounts). Identical file CONTENT across tags
+    /// → identical content-key edges, so two builds are directly comparable. Split out so a
+    /// test can `rebuild` the SAME config twice (identical content) to exercise the
+    /// full-rebuild df refresh.
+    fn clone_fixture_config(tag: &str) -> crate::Config {
         let root = std::env::temp_dir().join(format!(
             "rag-rat-precompute-{tag}-{}-{}",
             std::process::id(),
@@ -794,7 +815,7 @@ mod tests {
              t += v * 2; } t + 1 }\n",
         )
         .unwrap();
-        let config = crate::Config {
+        crate::Config {
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![crate::config::ResolvedTarget {
@@ -811,8 +832,12 @@ mod tests {
             oracle: Default::default(),
             search: Default::default(),
             log: Default::default(),
-        };
-        crate::IndexDatabase::rebuild(&config).unwrap()
+        }
+    }
+
+    /// A fixed two-file fixture (see [`clone_fixture_config`]), rebuilt fresh.
+    fn build_clone_fixture(tag: &str) -> crate::IndexDatabase {
+        crate::IndexDatabase::rebuild(&clone_fixture_config(tag)).unwrap()
     }
 
     /// The content-key set of the live-or-only generation's edges, sorted — the build-stable
@@ -1080,5 +1105,41 @@ mod tests {
             .unwrap();
         assert!(postings > 0, "the upgrade rebuild fills clone_subblock_postings");
         assert!(!db.pending_clone_graph().unwrap(), "no longer pending after the rebuild");
+    }
+
+    /// A full rebuild recomputes `clone_token_df` authoritatively (correcting incremental drift)
+    /// WITHOUT changing file content, so `content_revision()` — the clone-graph freshness key —
+    /// stays equal. The persisted postings freeze the OLD df ordering, so serving them under
+    /// the fresh df could silently miss near-clones; the rebuild must therefore INVALIDATE the
+    /// postings (mark the generation stale) so they rebuild against the fresh df. The
+    /// write-time fast path falls back to RAM until then. Self-heals on the next precompute.
+    #[test]
+    fn full_rebuild_invalidates_postings_for_df_freshness() {
+        let config = clone_fixture_config("df-refresh");
+        let db1 = crate::IndexDatabase::rebuild(&config).unwrap();
+        db1.precompute_clone_graph(None).unwrap();
+        assert!(!db1.pending_clone_graph().unwrap(), "a fresh precompute is current");
+        assert!(
+            db1.clone_check_indexed_generation().unwrap().is_some(),
+            "and the write-time fast path is eligible"
+        );
+        drop(db1); // release the DB file before the second rebuild takes the write lock
+
+        // Second FULL rebuild over IDENTICAL content: the clone graph survives (it is content-
+        // anchored), but `refresh_clone_token_df` runs, so the postings must be invalidated.
+        let db2 = crate::IndexDatabase::rebuild(&config).unwrap();
+        assert!(
+            db2.pending_clone_graph().unwrap(),
+            "the full-rebuild df refresh invalidates the postings, so the graph is pending"
+        );
+        assert!(
+            db2.clone_check_indexed_generation().unwrap().is_none(),
+            "and the write-time fast path falls back to RAM until the postings are rebuilt"
+        );
+
+        // Self-heals: re-precompute rebuilds the postings against the fresh df.
+        assert_eq!(db2.precompute_clone_graph(None).unwrap().status, "Complete");
+        assert!(!db2.pending_clone_graph().unwrap(), "current again after the rebuild");
+        assert!(db2.clone_check_indexed_generation().unwrap().is_some(), "eligible again");
     }
 }

--- a/crates/rag-rat-core/src/index/query_api/clones/substrate.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/substrate.rs
@@ -52,6 +52,7 @@ pub(crate) const DF_FALLBACK: i64 = i64::MAX;
 pub(crate) const HOT_TOKEN_POSTINGS_CAP: usize = 256;
 
 /// One scoped baseline symbol's fingerprint, loaded for the candidate read.
+#[derive(Clone)]
 pub(crate) struct SymbolBag {
     pub(crate) symbol_id: i64,
     pub(crate) language: String,
@@ -61,6 +62,7 @@ pub(crate) struct SymbolBag {
     pub(crate) tokens: Vec<TokenPosting>,
 }
 
+#[derive(Clone)]
 pub(crate) struct TokenPosting {
     pub(crate) token_hash: i64,
     pub(crate) freq: i64,

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -169,6 +169,12 @@ impl IndexDatabase {
                 .execute(params![normalizer_kind, token_hash, count])?;
             }
         }
+        // The recomputed df may reorder `sub_block_tokens`, so the persisted clone-graph postings
+        // (frozen at their build-time df) can no longer be served against the current df without
+        // silently missing near-clones. Invalidate them so the next maintenance pass rebuilds the
+        // graph; this refresh keeps file content (and `content_revision()`) unchanged, so nothing
+        // else would catch it. See `invalidate_clone_graph_postings`.
+        self.invalidate_clone_graph_postings()?;
         Ok(())
     }
 


### PR DESCRIPTION
Phase 3 of #296. Reads the persisted `clone_subblock_postings` (phase 2) instead of rebuilding the whole RAM inverted index on every write-time clone check — when a live clone-graph generation is exactly current and postings-complete. Depends on #391 (merged).

## What changed (`of_text.rs`, + a gate in `precompute.rs`)
- **`CloneCorpus` trait** abstracts the EXACT + NEAR candidate lookup behind a shared `check_against` pass. The postings fast path (`IndexedCorpus`) and the RAM fallback (`CheckIndex`) run **identical** fingerprinting, `verified_clone` verify, ref resolution, and self-file exclusion — so the fast path is a pure optimization, not a behavior change.
- **`IndexedCorpus`** resolves candidates with index-covered SQL: an exact `struct_hash` read, and a postings `token_hash IN (…)` lookup whose anchors are hydrated by a **bounded** row-value `IN (VALUES …)` over the scoped `files` view — only the candidate anchors, **not** every scoped symbol (review R3). It reproduces every fallback filter — scope view, `generated = 0`, `is_test = 0`, language, NULL `token_bag` — and **drops a posting whose anchor sha no longer matches the last-indexed `files.sha256`** (the #248 read-staleness discipline).
- **`clone_check_indexed_generation`** gates the fast path on **exact freshness** — `source_revision == content_revision()`, normalizer match, and postings-complete — deliberately stricter than the `find_clones` edge fast path's mildly-stale-OK, because a symbol's persisted sub-block tokens depend on the current `clone_token_df` ordering (review R1). Anything less falls back to the RAM path, so the check is never wrong, only sometimes slower.

## Tests
- `fast_postings_path_equals_ram_fallback` — the cornerstone (review R4): fast == fallback across a cross-file clone, a `#[cfg(test)]` clone (excluded), a cross-language collision (excluded), and a self-file edit.
- `indexed_fast_path_drops_stale_postings` — a candidate whose anchor sha drifted is dropped.
- `clone_check_fast_path_eligibility_gate` — content drift (R1) and a postings-less generation (R2) both disqualify the fast path.

`cargo nextest run -p rag-rat-core` = 1100 passed; `cargo clippy -p rag-rat-core --all-targets -- -D warnings` clean; `cargo +nightly fmt` clean.

The 40k function guard (`MAX_CLONE_CHECK_FUNCTIONS`) is unchanged here; it becomes mode-aware in phase 4.

Refs #296