### PR TITLE
feat(clones): make the write-time clone-check size guard mode-aware (#296 phase 4)

### DIFF
--- a/crates/rag-rat-cli/src/claude_hook/mod.rs
+++ b/crates/rag-rat-cli/src/claude_hook/mod.rs
@@ -24,9 +24,11 @@ use rag_rat_core::query::orientation::Orientation;
 use rag_rat_core::storage::IndexConnection;
 use serde::Deserialize;
 
-/// Skip the write-time clone check above this many fingerprinted functions: the check builds an
-/// in-RAM inverted index over all of them (O(functions)) until the persisted-postings follow-up
-/// (#287) lands, so on a very large repo it no-ops rather than add a perceptible delay to a write.
+/// Skip the write-time clone check above this many fingerprinted functions — but ONLY in the RAM
+/// FALLBACK mode, which builds an in-RAM inverted index over all of them (O(functions)) and so
+/// would add a perceptible delay to a write on a very large repo. When the persisted-postings fast
+/// path is eligible (#296), the check is a bounded indexed lookup independent of corpus size, so
+/// this guard does not apply — see [`clone_check_skipped_for_size`].
 const MAX_CLONE_CHECK_FUNCTIONS: u64 = 40_000;
 
 /// Minimum similarity for a NEAR clone to be surfaced by the WRITE-TIME hook (#292). Higher than
@@ -390,6 +392,14 @@ fn pretooluse(input: &HookInput) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// The write-time clone-check size guard, factored out for testing. Skip the check ONLY when the
+/// RAM fallback would run (`!indexed`) over more than [`MAX_CLONE_CHECK_FUNCTIONS`] functions. In
+/// indexed mode the postings fast path is a bounded indexed lookup independent of corpus size, so
+/// it never skips on size (#296 phase 4).
+fn clone_check_skipped_for_size(indexed: bool, function_count: u64) -> bool {
+    !indexed && function_count > MAX_CLONE_CHECK_FUNCTIONS
+}
+
 /// Write-time clone check (#287): fingerprint the just-written functions and warn if they duplicate
 /// existing indexed code. Best-effort + READ-ONLY — every "not ready" path (no config, DB absent,
 /// index owes a heal/migrate, index too large, no parseable functions) is a SILENT no-op, so it
@@ -402,8 +412,12 @@ fn clone_check(input: &HookInput) -> anyhow::Result<()> {
     // `try_open_config_read_only` returns None when the index still owes a heal/migrate (NOT
     // ready), so this is the no-op-when-not-ready guard — the same gate the MCP read tools use.
     let Some(db) = IndexDatabase::try_open_config_read_only(&config)? else { return Ok(()) };
-    if db.clone_check_function_count().unwrap_or(u64::MAX) > MAX_CLONE_CHECK_FUNCTIONS {
-        return Ok(()); // too large for the in-RAM check — no-op until the persisted postings land
+    // The size guard bounds ONLY the RAM fallback. When a live postings generation is eligible the
+    // check is a bounded indexed lookup (#296 phase 4), so run it regardless of corpus size; only
+    // the fallback no-ops above the cap.
+    let indexed = db.clone_check_indexed_generation().unwrap_or(None).is_some();
+    if clone_check_skipped_for_size(indexed, db.clone_check_function_count().unwrap_or(u64::MAX)) {
+        return Ok(());
     }
     let inputs = extract_clone_inputs(input, &config.root);
     if inputs.is_empty() {

--- a/crates/rag-rat-cli/src/claude_hook/tests.rs
+++ b/crates/rag-rat-cli/src/claude_hook/tests.rs
@@ -614,3 +614,18 @@ fn format_clone_warning_caps_the_ref_list() {
     );
     assert!(!out.contains("src/m11.rs::f11"), "doesn't list every ref: {out}");
 }
+
+// ─── #296 phase 4: the 40k size guard is fallback-only ──────────────────────
+
+#[test]
+fn clone_check_size_guard_is_fallback_only() {
+    // RAM fallback (no eligible postings generation): skip strictly ABOVE the cap, run at/below it.
+    assert!(super::clone_check_skipped_for_size(false, super::MAX_CLONE_CHECK_FUNCTIONS + 1));
+    assert!(!super::clone_check_skipped_for_size(false, super::MAX_CLONE_CHECK_FUNCTIONS));
+    assert!(!super::clone_check_skipped_for_size(false, 0));
+
+    // Indexed (postings fast path eligible): the bounded lookup is corpus-size-independent, so it
+    // NEVER skips on size — not even far past the cap.
+    assert!(!super::clone_check_skipped_for_size(true, super::MAX_CLONE_CHECK_FUNCTIONS + 1));
+    assert!(!super::clone_check_skipped_for_size(true, u64::MAX));
+}

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -185,7 +185,7 @@ impl IndexDatabase {
     /// - `normalizer_version == NORM_VERSION`,
     /// - `postings_written` (a postings-complete, postings-aware generation — review R2), AND
     /// - `source_revision == content_revision()` EXACTLY (not merely present).
-    pub(crate) fn clone_check_indexed_generation(&self) -> anyhow::Result<Option<i64>> {
+    pub fn clone_check_indexed_generation(&self) -> anyhow::Result<Option<i64>> {
         // BASE-SCOPE ONLY. The clone graph (edges + postings) is built in the BASE scope —
         // maintenance restores it before the clone-graph pass, and `content_revision()` is GLOBAL
         // over `main.files` so it CANNOT encode which scope produced the postings. Under a


### PR DESCRIPTION
Phase 4 of #296 — the final phase. Stacked on #392 (phase 3); **base is `feat/296-p3-postings-fast-read`** so the diff shows only phase 4. Rebase to `main` once #392 merges.

## What changed
`MAX_CLONE_CHECK_FUNCTIONS` (40k) bounded the RAM fallback, which builds an O(functions) inverted index per write-time check. With the persisted-postings fast path (phases 2–3) the check is a **bounded indexed lookup independent of corpus size**, so the guard should not apply when a live postings generation is eligible.

- `clone_check` skips on size **only in fallback mode**: it runs unconditionally when `clone_check_indexed_generation()` is `Some` (fast path available), and keeps the 40k cap as the fallback backstop otherwise.
- The decision is factored into `clone_check_skipped_for_size(indexed, function_count)` for a unit test (`clone_check_size_guard_is_fallback_only`): fallback skips strictly above the cap; indexed never skips on size, even at `u64::MAX`.
- `clone_check_indexed_generation` is promoted `pub` so the CLI hook can consult the same eligibility the fast path uses.

## Verification
`cargo nextest run -p rag-rat` = 239 passed (incl. the new guard test); `cargo clippy -p rag-rat -p rag-rat-core --all-targets -- -D warnings` clean; `cargo +nightly fmt` clean.

Closes #389. Final phase of the #296 series (phases 1–4).