### PR TITLE
fix(embed): a fresh index adopts the configured embedding model, not the hash fallback (#394)

### DIFF
--- a/crates/rag-rat-core/src/index/ai/helpers.rs
+++ b/crates/rag-rat-core/src/index/ai/helpers.rs
@@ -398,6 +398,13 @@ pub(crate) fn meta(conn: &Connection, key: &str) -> anyhow::Result<Option<String
         .optional()?)
 }
 
+/// Delete an `index_meta` key (a no-op when absent) — the `index_meta` counterpart of
+/// [`clear_reconcile_meta`].
+pub(crate) fn delete_meta(conn: &Connection, key: &str) -> anyhow::Result<()> {
+    conn.execute("DELETE FROM index_meta WHERE key = ?1", params![key])?;
+    Ok(())
+}
+
 /// Persist the active remote-embedding connection params as secret-free JSON in the
 /// [`ACTIVE_EMBEDDING_REMOTE_CONFIG_META`] meta (#317 task 5). Written at install when an Ollama
 /// model is activated; the `conn`-based `active_embedder` reads it back via
@@ -438,10 +445,7 @@ pub(crate) fn active_remote_config(
 /// `active_embedder` stops reconstructing an `OpenAiEmbedder` from a stale prior remote install of
 /// the same model (a no-op when the meta is already absent).
 pub(crate) fn clear_active_remote_config(conn: &Connection) -> anyhow::Result<()> {
-    conn.execute("DELETE FROM index_meta WHERE key = ?1", params![
-        ACTIVE_EMBEDDING_REMOTE_CONFIG_META
-    ])?;
-    Ok(())
+    delete_meta(conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META)
 }
 
 pub(crate) fn set_reconcile_meta(conn: &Connection, key: &str, value: &str) -> anyhow::Result<()> {

--- a/crates/rag-rat-core/src/index/ai/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/mod.rs
@@ -62,6 +62,14 @@ use crate::language::Language;
 
 const ACTIVE_EMBEDDING_MODEL_META: &str = "active_embedding_model";
 const ACTIVE_EMBEDDING_MODEL_VERSION_META: &str = "embedding_active_model_version";
+/// `"1"` when the active embedding model was set AUTOMATICALLY — a config seed
+/// (`seed_active_embedding_model`) or a fastembed-cache recovery (`recover_cached_fastembed_model`)
+/// — and NOT confirmed by the user. Set to `"0"` when the user selects it explicitly
+/// (`install_model`) or a reconcile commits embeddings under it. A PROVISIONAL active model yields
+/// to a differing config on the next config-aware open; an explicit / committed one is respected.
+/// Absent ⇒ treated as non-provisional (a pre-#394 index, or an explicit choice), so the seed never
+/// clobbers it (#394).
+const ACTIVE_EMBEDDING_MODEL_PROVISIONAL_META: &str = "active_embedding_model_provisional";
 /// Secret-free JSON of the active [`RemoteEmbeddingConfig`] (#317 task 5). Written at install when
 /// an Ollama model is activated; read by `active_embedder` to reconstruct the remote embedder for
 /// BOTH chunk-embed (reconcile) and query-embed (search), so the `conn`-based construction path

--- a/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
@@ -368,6 +368,12 @@ pub(crate) fn reconcile_with_options_progress(
         report.message =
             Some(format!("{} chunks failed; retry after backoff", report.failed_chunks));
     }
+    // Embeddings committed under the active model CONFIRM it as the working choice — clear the
+    // provisional flag so a later config-model edit no longer reseeds away from it (that would
+    // strand these vectors). The active model is what `embed_and_write_jobs` wrote under (#394).
+    if report.embeddings_written > 0 {
+        clear_active_embedding_model_provisional(conn)?;
+    }
     finalize_reconcile_throughput(&mut report, timer.elapsed().as_millis());
 
     finish_reconcile_attempt(conn, attempt_id, &report)?;
@@ -1643,16 +1649,18 @@ mod freshness_version_tests {
     }
 
     #[test]
-    fn activate_model_with_version_writes_both_metas() {
-        // R3b centralization: the helper every activation site goes through stamps BOTH the active
-        // model AND its version — so no site can activate without a version (the recovery bug).
+    fn activate_model_with_version_writes_all_metas() {
+        // R3b centralization: the helper every activation site goes through stamps the active
+        // model, its version, AND its provenance — so no site can activate without any of
+        // them (the recovery bug for the version; the #394 masquerade bug for provenance).
         let conn = schema_conn();
-        activate_model_with_version(&conn, HASH_MODEL_ID, "hash-v1").unwrap();
+        activate_model_with_version(&conn, HASH_MODEL_ID, "hash-v1", false).unwrap();
         assert_eq!(
             meta(&conn, ACTIVE_EMBEDDING_MODEL_META).unwrap().as_deref(),
             Some(HASH_MODEL_ID)
         );
         assert_eq!(active_version(&conn), "hash-v1");
+        assert!(!active_embedding_model_is_provisional(&conn).unwrap(), "false ⇒ non-provisional");
     }
 
     // Needs a real fastembed install (the no-default-features CI build bails without the feature);

--- a/crates/rag-rat-core/src/index/ai/reconcile/model_lifecycle.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/model_lifecycle.rs
@@ -125,21 +125,40 @@ pub(crate) fn clear_active_embedding_model_provisional(conn: &Connection) -> any
     set_meta(conn, ACTIVE_EMBEDDING_MODEL_PROVISIONAL_META, "0")
 }
 
+/// Clear the active embedding model entirely — the inverse of [`activate_model_with_version`].
+/// Removes the model id, its freshness version, the provenance flag, AND any remote-config meta, so
+/// `active_embedding_model_id` returns to the hash fallback and no stale version / endpoint lingers
+/// to mislead a later activation. Called when the config disables embeddings (`model = "none"`)
+/// while a PROVISIONAL model was active: the embeddings-off choice must supersede an automatic
+/// activation, restoring the "embeddings-off ⇒ active model unset" invariant (#394 review).
+/// Idempotent (each delete is a no-op when its key is absent).
+pub(crate) fn clear_active_embedding_model(conn: &Connection) -> anyhow::Result<()> {
+    delete_meta(conn, ACTIVE_EMBEDDING_MODEL_META)?;
+    clear_reconcile_meta(conn, ACTIVE_EMBEDDING_MODEL_VERSION_META)?;
+    delete_meta(conn, ACTIVE_EMBEDDING_MODEL_PROVISIONAL_META)?;
+    clear_active_remote_config(conn)
+}
+
 /// Seed the active embedding model from the CONFIG's selection when the index has none yet (#394),
 /// so a fresh index adopts the configured model instead of silently defaulting to the hash fallback
 /// (`active_embedding_model_id`'s `HASH_MODEL_ID` default — which the config never selects, since
 /// `EmbeddingBackend::default()` is all-MiniLM). Read-first via
 /// [`active_embedding_model_seed_owed`]: a no-op once the active model is EXPLICIT (an
 /// `install_model`) or CONFIRMED (a reconcile committed embeddings under it) — that model is
-/// respected — and for the embeddings-off choice (`configured_model_id == None`). While the active
-/// model is PROVISIONAL (a prior seed or a fastembed-cache recovery) config stays authoritative — a
-/// config-model edit is adopted.
+/// respected. While the active model is PROVISIONAL (a prior seed or a fastembed-cache recovery)
+/// config stays authoritative — a config-model edit is adopted, and the embeddings-off case below
+/// clears it.
 ///
 /// This does NOT install the model — reconcile still blocks with an accurate
 /// `models install <configured>` hint until it is — it only makes the index's active model reflect
 /// the config so that hint (and every model-scoped read) names the RIGHT model rather than the hash
 /// fallback. Runs on the write-bearing `open_config`, so any write-bearing open heals an index
 /// built before this fix.
+///
+/// The embeddings-off choice (`configured_model_id == None`) is symmetric: it CLEARS a still-active
+/// PROVISIONAL model via [`clear_active_embedding_model`] (an explicit / confirmed install is
+/// preserved), so switching the config to `model = "none"` stops reconcile / status naming a model
+/// the config no longer wants — restoring the "embeddings-off ⇒ active model unset" invariant.
 pub(crate) fn seed_active_embedding_model(
     conn: &Connection,
     configured_model_id: Option<&str>,
@@ -147,7 +166,11 @@ pub(crate) fn seed_active_embedding_model(
     if !active_embedding_model_seed_owed(conn, configured_model_id)? {
         return Ok(());
     }
-    let model_id = configured_model_id.expect("seed_owed is true only when the id is Some");
+    let Some(model_id) = configured_model_id else {
+        // Embeddings-off, and `seed_owed` already confirmed a PROVISIONAL model is still active:
+        // clear it so the meta stops naming a model the config disabled.
+        return clear_active_embedding_model(conn);
+    };
     let Some(spec) = spec(model_id) else {
         return Ok(()); // unknown id (defensive) — leave unset so the hash fallback stands
     };
@@ -173,12 +196,20 @@ pub(crate) fn seed_active_embedding_model(
 /// An absent provenance flag (a pre-#394 index, or a committed / explicit model) reads as
 /// non-provisional → respected. Provenance is an O(1) meta read — no per-open embedding scan, and a
 /// RECOVERED cache no longer masquerades as an explicit install (#394 review).
+///
+/// The embeddings-off choice (`None`) owes a write only to CLEAR a still-active PROVISIONAL model
+/// (an explicit / confirmed install is preserved; an already-unset active model needs nothing) —
+/// symmetric with the model-selected case, where a provisional active always yields to config.
 pub(crate) fn active_embedding_model_seed_owed(
     conn: &Connection,
     configured_model_id: Option<&str>,
 ) -> anyhow::Result<bool> {
     let Some(configured) = configured_model_id else {
-        return Ok(false); // embeddings-off — nothing to seed
+        // Embeddings-off: a write is owed only when a PROVISIONAL model is still active and must be
+        // cleared. An unset active (nothing to clear) or an explicit / confirmed one (preserved)
+        // owes nothing.
+        return Ok(meta(conn, ACTIVE_EMBEDDING_MODEL_META)?.is_some()
+            && active_embedding_model_is_provisional(conn)?);
     };
     match meta(conn, ACTIVE_EMBEDDING_MODEL_META)? {
         None => Ok(true),
@@ -408,5 +439,50 @@ mod seed_active_embedding_model_tests {
             meta(&conn, ACTIVE_EMBEDDING_MODEL_META).unwrap().is_none(),
             "the embeddings-off choice leaves the active model unset (hash fallback stands)"
         );
+    }
+
+    #[test]
+    fn embeddings_off_clears_a_provisional_active_model() {
+        let conn = fresh_conn();
+        // A prior open seeded jina PROVISIONALLY, and a remote-config meta was left behind. The
+        // user then edits the config to `model = "none"`.
+        seed_active_embedding_model(&conn, Some(JINA)).unwrap();
+        set_meta(&conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META, "{\"stale\":true}").unwrap();
+        assert!(active_embedding_model_is_provisional(&conn).unwrap());
+
+        assert!(
+            active_embedding_model_seed_owed(&conn, None).unwrap(),
+            "clearing a still-active provisional model is owed on the switch to embeddings-off"
+        );
+        seed_active_embedding_model(&conn, None).unwrap();
+
+        // The active model, its freshness version, the provenance flag, and the stale remote config
+        // are all gone — `active_embedding_model_id` returns to the hash fallback.
+        assert!(meta(&conn, ACTIVE_EMBEDDING_MODEL_META).unwrap().is_none());
+        assert!(reconcile_meta(&conn, ACTIVE_EMBEDDING_MODEL_VERSION_META).unwrap().is_none());
+        assert!(meta(&conn, ACTIVE_EMBEDDING_MODEL_PROVISIONAL_META).unwrap().is_none());
+        assert!(meta(&conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META).unwrap().is_none());
+        assert_eq!(active_embedding_model_id(&conn).unwrap(), HASH);
+        assert!(
+            !active_embedding_model_seed_owed(&conn, None).unwrap(),
+            "idempotent — nothing left to clear"
+        );
+    }
+
+    #[test]
+    fn embeddings_off_preserves_an_explicit_active_model() {
+        let conn = fresh_conn();
+        // An EXPLICIT install is a deliberate user choice (NON-provisional). Switching the config
+        // to embeddings-off must NOT wipe it — only automatic (provisional) activations
+        // yield.
+        install_model(&conn, HASH, None).unwrap();
+        assert!(!active_embedding_model_is_provisional(&conn).unwrap());
+
+        assert!(
+            !active_embedding_model_seed_owed(&conn, None).unwrap(),
+            "an explicit install is preserved across a switch to embeddings-off"
+        );
+        seed_active_embedding_model(&conn, None).unwrap();
+        assert_eq!(active_embedding_model_id(&conn).unwrap(), HASH, "explicit model kept");
     }
 }

--- a/crates/rag-rat-core/src/index/ai/reconcile/model_lifecycle.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/model_lifecycle.rs
@@ -112,10 +112,11 @@ pub(crate) fn activate_model_with_version(
 /// so a fresh index adopts the configured model instead of silently defaulting to the hash fallback
 /// (`active_embedding_model_id`'s `HASH_MODEL_ID` default — which the config never selects, since
 /// `EmbeddingBackend::default()` is all-MiniLM). Read-first via
-/// [`active_embedding_model_seed_owed`]: a no-op once an INSTALLED model is active (an explicit
-/// `models install <other>` is respected) and for the embeddings-off choice (`configured_model_id
-/// == None`); an uninstalled seed PLACEHOLDER is re-adopted when the config model changes before
-/// install.
+/// [`active_embedding_model_seed_owed`]: a no-op once embeddings are COMMITTED under the active model
+/// (that model is respected) and for the embeddings-off choice (`configured_model_id == None`).
+/// While nothing is committed (a seed placeholder, a recovered cache, or an
+/// installed-but-unreconciled model) config stays authoritative — a config-model edit made before
+/// reconcile is adopted.
 ///
 /// This does NOT install the model — reconcile still blocks with an accurate
 /// `models install <configured>` hint until it is — it only makes the index's active model reflect
@@ -143,12 +144,14 @@ pub(crate) fn seed_active_embedding_model(
 /// Read-only test of whether [`seed_active_embedding_model`] would WRITE. The read-only open
 /// consults it to fall back to the write path so the seed heals once (same posture as the
 /// model-manifest / generated-flags gates). A seed is owed when the config selects a model AND
-/// either (a) no active model is set yet, or (b) the active model differs from config AND is an
-/// uninstalled SEED PLACEHOLDER — `install_model` / `recover_cached_fastembed_model` both mark the
-/// `ai_models` row installed, so an uninstalled active model can only have come from a prior seed.
-/// (b) lets a config-model edit made BEFORE install be adopted (the placeholder tracks config),
-/// while an installed / explicitly-activated model is respected — switching an INSTALLED model on a
-/// config change is a separate re-embed concern, out of scope here (#394 review).
+/// either (a) no active model is set yet, or (b) the active model DIFFERS from config AND has NO
+/// embeddings committed under it. CONFIG is authoritative until embeddings are committed: a seed
+/// placeholder, a `recover_cached_fastembed_model` cache activation, and an installed-but-not-yet-
+/// reconciled model all read `current_embedding_count == 0`, so config wins over any of them on a
+/// fresh index. Once embeddings exist under the active model it is respected (switching a committed
+/// model on a config change is a separate re-embed concern, out of scope here). Using the embedding
+/// count — not the `ai_models.installed` flag — is what keeps a RECOVERED cache from masquerading
+/// as an explicit user install (#394 review).
 pub(crate) fn active_embedding_model_seed_owed(
     conn: &Connection,
     configured_model_id: Option<&str>,
@@ -159,18 +162,8 @@ pub(crate) fn active_embedding_model_seed_owed(
     match meta(conn, ACTIVE_EMBEDDING_MODEL_META)? {
         None => Ok(true),
         Some(active) if active == configured => Ok(false),
-        Some(active) => Ok(!active_model_is_installed(conn, &active)?),
+        Some(active) => Ok(current_embedding_count(conn, &active)? == 0),
     }
-}
-
-/// Whether the given model's `ai_models` row is installed. A missing row counts as not installed.
-fn active_model_is_installed(conn: &Connection, model_id: &str) -> anyhow::Result<bool> {
-    Ok(conn
-        .query_row("SELECT installed FROM ai_models WHERE model_id = ?1", [model_id], |r| {
-            r.get::<_, i64>(0)
-        })
-        .optional()?
-        .is_some_and(|installed: i64| installed != 0))
 }
 
 pub(crate) fn install_model(
@@ -320,19 +313,20 @@ mod seed_active_embedding_model_tests {
     }
 
     #[test]
-    fn respects_an_installed_model() {
+    fn reseeds_over_an_installed_but_uncommitted_model() {
         let conn = fresh_conn();
-        // An EXPLICIT install (hash is a no-download local install) activates + marks it installed.
+        // A model installed but with NO embeddings yet — a recovered fastembed cache, or an install
+        // before reconcile. Config is authoritative until something is committed, so it wins.
         install_model(&conn, HASH, None).unwrap();
         assert_eq!(active_embedding_model_id(&conn).unwrap(), HASH);
+        assert_eq!(current_embedding_count(&conn, HASH).unwrap(), 0, "nothing committed yet");
 
-        // A config selecting a DIFFERENT model must NOT override an INSTALLED selection.
-        assert!(!active_embedding_model_seed_owed(&conn, Some(JINA)).unwrap());
+        assert!(active_embedding_model_seed_owed(&conn, Some(JINA)).unwrap());
         seed_active_embedding_model(&conn, Some(JINA)).unwrap();
         assert_eq!(
             active_embedding_model_id(&conn).unwrap(),
-            HASH,
-            "an installed model is kept — the seed never overrides an explicit install"
+            JINA,
+            "config wins over an installed-but-uncommitted model (e.g. a recovered cache)"
         );
     }
 

--- a/crates/rag-rat-core/src/index/ai/reconcile/model_lifecycle.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/model_lifecycle.rs
@@ -57,7 +57,9 @@ pub(crate) fn recover_cached_fastembed_model_at(
         // re-embed.
         let spec = spec(FASTEMBED_MODEL_ID)
             .ok_or_else(|| anyhow::anyhow!("unknown model `{FASTEMBED_MODEL_ID}`"))?;
-        activate_model_with_version(conn, FASTEMBED_MODEL_ID, spec.version)?;
+        // PROVISIONAL: a cache recovery is automatic, not a user choice — a differing config seed
+        // must still win over it on a fresh index (#394 review).
+        activate_model_with_version(conn, FASTEMBED_MODEL_ID, spec.version, true)?;
     }
     Ok(())
 }
@@ -94,29 +96,44 @@ pub(crate) fn fastembed_cache_ready(cache_dir: &Path) -> bool {
     !revision.is_empty() && repo.join("snapshots").join(revision).is_dir()
 }
 
-/// Activate `model_id` as the active embedding model AND stamp its freshness `version` in ONE call
-/// — the SINGLE place that writes both metas, so no activation site can set the active model
-/// without its version (the bug R3b fixed in recovery). `install_model` and
-/// `recover_cached_fastembed_model` both go through here.
+/// Activate `model_id` as the active embedding model, stamp its freshness `version`, and record its
+/// PROVENANCE — all in ONE call, the SINGLE place that writes these metas, so no activation site
+/// can set the active model without its version (the bug R3b fixed in recovery) or its provenance.
+/// `provisional = true` for an AUTOMATIC activation (config seed, fastembed-cache recovery),
+/// `false` for an EXPLICIT one (`install_model`). See [`ACTIVE_EMBEDDING_MODEL_PROVISIONAL_META`].
 pub(crate) fn activate_model_with_version(
     conn: &Connection,
     model_id: &str,
     version: &str,
+    provisional: bool,
 ) -> anyhow::Result<()> {
     set_meta(conn, ACTIVE_EMBEDDING_MODEL_META, model_id)?;
     set_reconcile_meta(conn, ACTIVE_EMBEDDING_MODEL_VERSION_META, version)?;
+    set_meta(conn, ACTIVE_EMBEDDING_MODEL_PROVISIONAL_META, if provisional { "1" } else { "0" })?;
     Ok(())
+}
+
+/// Whether the active embedding model is PROVISIONAL — set automatically (seed / cache recovery)
+/// and not yet confirmed by an explicit install or a committed reconcile. Absent ⇒ non-provisional.
+pub(crate) fn active_embedding_model_is_provisional(conn: &Connection) -> anyhow::Result<bool> {
+    Ok(meta(conn, ACTIVE_EMBEDDING_MODEL_PROVISIONAL_META)?.as_deref() == Some("1"))
+}
+
+/// Clear the provisional flag — the active model is now the CONFIRMED choice (an explicit install,
+/// or a reconcile that committed embeddings under it). Idempotent.
+pub(crate) fn clear_active_embedding_model_provisional(conn: &Connection) -> anyhow::Result<()> {
+    set_meta(conn, ACTIVE_EMBEDDING_MODEL_PROVISIONAL_META, "0")
 }
 
 /// Seed the active embedding model from the CONFIG's selection when the index has none yet (#394),
 /// so a fresh index adopts the configured model instead of silently defaulting to the hash fallback
 /// (`active_embedding_model_id`'s `HASH_MODEL_ID` default — which the config never selects, since
 /// `EmbeddingBackend::default()` is all-MiniLM). Read-first via
-/// [`active_embedding_model_seed_owed`]: a no-op once embeddings are COMMITTED under the active model
-/// (that model is respected) and for the embeddings-off choice (`configured_model_id == None`).
-/// While nothing is committed (a seed placeholder, a recovered cache, or an
-/// installed-but-unreconciled model) config stays authoritative — a config-model edit made before
-/// reconcile is adopted.
+/// [`active_embedding_model_seed_owed`]: a no-op once the active model is EXPLICIT (an
+/// `install_model`) or CONFIRMED (a reconcile committed embeddings under it) — that model is
+/// respected — and for the embeddings-off choice (`configured_model_id == None`). While the active
+/// model is PROVISIONAL (a prior seed or a fastembed-cache recovery) config stays authoritative — a
+/// config-model edit is adopted.
 ///
 /// This does NOT install the model — reconcile still blocks with an accurate
 /// `models install <configured>` hint until it is — it only makes the index's active model reflect
@@ -134,24 +151,28 @@ pub(crate) fn seed_active_embedding_model(
     let Some(spec) = spec(model_id) else {
         return Ok(()); // unknown id (defensive) — leave unset so the hash fallback stands
     };
-    // Activate + stamp the freshness version through the single writer (never the active meta
-    // alone, per the R3b footgun). The static `spec.version` is correct pre-install;
-    // `install_model` re-stamps the runtime-accurate version, and a fresh index has no
-    // embeddings to re-embed.
-    activate_model_with_version(conn, spec.model_id, spec.version)
+    // Drop any remote-config meta a prior remote install left behind: the seed activates the model
+    // as a LOCAL placeholder, so without this `active_embedder` would build an OpenAiEmbedder for
+    // the new active model against the STALE endpoint / server-side model — vectors in the
+    // wrong embedding space (#394 review). `install_model`'s local branch clears it the same
+    // way.
+    clear_active_remote_config(conn)?;
+    // Activate as PROVISIONAL (an automatic config seed, not a user choice) + stamp the freshness
+    // version through the single writer (never the active meta alone, per the R3b footgun). The
+    // static `spec.version` is correct pre-install; `install_model` re-stamps the runtime-accurate
+    // version and clears the provisional flag.
+    activate_model_with_version(conn, spec.model_id, spec.version, true)
 }
 
 /// Read-only test of whether [`seed_active_embedding_model`] would WRITE. The read-only open
 /// consults it to fall back to the write path so the seed heals once (same posture as the
 /// model-manifest / generated-flags gates). A seed is owed when the config selects a model AND
-/// either (a) no active model is set yet, or (b) the active model DIFFERS from config AND has NO
-/// embeddings committed under it. CONFIG is authoritative until embeddings are committed: a seed
-/// placeholder, a `recover_cached_fastembed_model` cache activation, and an installed-but-not-yet-
-/// reconciled model all read `current_embedding_count == 0`, so config wins over any of them on a
-/// fresh index. Once embeddings exist under the active model it is respected (switching a committed
-/// model on a config change is a separate re-embed concern, out of scope here). Using the embedding
-/// count — not the `ai_models.installed` flag — is what keeps a RECOVERED cache from masquerading
-/// as an explicit user install (#394 review).
+/// either (a) no active model is set yet, or (b) the active model DIFFERS from config AND is
+/// PROVISIONAL — set automatically by a prior seed or a fastembed-cache recovery, NOT by an
+/// explicit `models install` and NOT confirmed by a reconcile that committed embeddings under it.
+/// An absent provenance flag (a pre-#394 index, or a committed / explicit model) reads as
+/// non-provisional → respected. Provenance is an O(1) meta read — no per-open embedding scan, and a
+/// RECOVERED cache no longer masquerades as an explicit install (#394 review).
 pub(crate) fn active_embedding_model_seed_owed(
     conn: &Connection,
     configured_model_id: Option<&str>,
@@ -162,7 +183,7 @@ pub(crate) fn active_embedding_model_seed_owed(
     match meta(conn, ACTIVE_EMBEDDING_MODEL_META)? {
         None => Ok(true),
         Some(active) if active == configured => Ok(false),
-        Some(active) => Ok(current_embedding_count(conn, &active)? == 0),
+        Some(_) => active_embedding_model_is_provisional(conn),
     }
 }
 
@@ -230,7 +251,9 @@ pub(crate) fn install_model(
         Some(remote) => remote_freshness_version(spec, remote),
         None => spec.version.to_string(),
     };
-    activate_model_with_version(conn, model_id, &freshness)?;
+    // EXPLICIT: `models install` is a user choice — not provisional, so the config seed never
+    // overrides it (#394 review).
+    activate_model_with_version(conn, model_id, &freshness, false)?;
     model(conn, model_id)
 }
 
@@ -313,36 +336,67 @@ mod seed_active_embedding_model_tests {
     }
 
     #[test]
-    fn reseeds_over_an_installed_but_uncommitted_model() {
+    fn respects_an_explicitly_installed_model() {
         let conn = fresh_conn();
-        // A model installed but with NO embeddings yet — a recovered fastembed cache, or an install
-        // before reconcile. Config is authoritative until something is committed, so it wins.
+        // An EXPLICIT install (hash is a no-download local install) is a user choice →
+        // NON-provisional provenance, so the config seed must not override it even before
+        // any reconcile (#394 review).
         install_model(&conn, HASH, None).unwrap();
         assert_eq!(active_embedding_model_id(&conn).unwrap(), HASH);
-        assert_eq!(current_embedding_count(&conn, HASH).unwrap(), 0, "nothing committed yet");
+        assert!(
+            !active_embedding_model_is_provisional(&conn).unwrap(),
+            "install is not provisional"
+        );
 
-        assert!(active_embedding_model_seed_owed(&conn, Some(JINA)).unwrap());
+        assert!(!active_embedding_model_seed_owed(&conn, Some(JINA)).unwrap());
         seed_active_embedding_model(&conn, Some(JINA)).unwrap();
         assert_eq!(
             active_embedding_model_id(&conn).unwrap(),
-            JINA,
-            "config wins over an installed-but-uncommitted model (e.g. a recovered cache)"
+            HASH,
+            "an explicitly installed model is respected — the seed never overrides it"
         );
     }
 
     #[test]
-    fn reseeds_an_uninstalled_placeholder_when_the_config_changes() {
+    fn config_wins_over_a_provisionally_recovered_model() {
         let conn = fresh_conn();
-        // Seed jina — a PLACEHOLDER (activated by the seed, but NOT installed).
+        // Simulate a fastembed-cache recovery: activated, but PROVISIONAL (automatic, not a user
+        // choice). A `models install` would be non-provisional; this must NOT masquerade as one.
+        let minilm = spec(MINILM).expect("registry has all-MiniLM");
+        activate_model_with_version(&conn, minilm.model_id, minilm.version, true).unwrap();
+        assert!(active_embedding_model_is_provisional(&conn).unwrap());
+
+        assert!(active_embedding_model_seed_owed(&conn, Some(JINA)).unwrap());
+        seed_active_embedding_model(&conn, Some(JINA)).unwrap();
+        assert_eq!(active_embedding_model_id(&conn).unwrap(), JINA, "config wins over a recovery");
+    }
+
+    #[test]
+    fn reseeds_a_provisional_model_when_the_config_changes() {
+        let conn = fresh_conn();
+        // Seed jina — PROVISIONAL (an automatic config seed, not confirmed).
         seed_active_embedding_model(&conn, Some(JINA)).unwrap();
         assert_eq!(active_embedding_model_id(&conn).unwrap(), JINA);
+        assert!(active_embedding_model_is_provisional(&conn).unwrap());
 
-        // The config is edited to all-MiniLM BEFORE jina is installed → the placeholder is
-        // re-adopted (#394 review: a seeded placeholder must not masquerade as an explicit
-        // selection).
+        // The config is edited to all-MiniLM BEFORE jina is confirmed → the provisional model
+        // yields.
         assert!(active_embedding_model_seed_owed(&conn, Some(MINILM)).unwrap());
         seed_active_embedding_model(&conn, Some(MINILM)).unwrap();
         assert_eq!(active_embedding_model_id(&conn).unwrap(), MINILM);
+    }
+
+    #[test]
+    fn a_confirmed_model_is_respected_over_a_config_change() {
+        let conn = fresh_conn();
+        // Seed jina (provisional), then CONFIRM it (as a reconcile committing embeddings would).
+        seed_active_embedding_model(&conn, Some(JINA)).unwrap();
+        clear_active_embedding_model_provisional(&conn).unwrap();
+
+        // A later config change is now respected — a confirmed model is not reseeded.
+        assert!(!active_embedding_model_seed_owed(&conn, Some(MINILM)).unwrap());
+        seed_active_embedding_model(&conn, Some(MINILM)).unwrap();
+        assert_eq!(active_embedding_model_id(&conn).unwrap(), JINA, "a confirmed model is kept");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/reconcile/model_lifecycle.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/model_lifecycle.rs
@@ -112,9 +112,10 @@ pub(crate) fn activate_model_with_version(
 /// so a fresh index adopts the configured model instead of silently defaulting to the hash fallback
 /// (`active_embedding_model_id`'s `HASH_MODEL_ID` default — which the config never selects, since
 /// `EmbeddingBackend::default()` is all-MiniLM). Read-first via
-/// [`active_embedding_model_seed_owed`]: a no-op once an active model is set (so an explicit
+/// [`active_embedding_model_seed_owed`]: a no-op once an INSTALLED model is active (an explicit
 /// `models install <other>` is respected) and for the embeddings-off choice (`configured_model_id
-/// == None`).
+/// == None`); an uninstalled seed PLACEHOLDER is re-adopted when the config model changes before
+/// install.
 ///
 /// This does NOT install the model — reconcile still blocks with an accurate
 /// `models install <configured>` hint until it is — it only makes the index's active model reflect
@@ -139,14 +140,37 @@ pub(crate) fn seed_active_embedding_model(
     activate_model_with_version(conn, spec.model_id, spec.version)
 }
 
-/// Read-only test of whether [`seed_active_embedding_model`] would WRITE — the config selects a
-/// model AND the active-model meta is unset. The read-only open consults it to fall back to the
-/// write path so the seed heals once (same posture as the model-manifest / generated-flags gates).
+/// Read-only test of whether [`seed_active_embedding_model`] would WRITE. The read-only open
+/// consults it to fall back to the write path so the seed heals once (same posture as the
+/// model-manifest / generated-flags gates). A seed is owed when the config selects a model AND
+/// either (a) no active model is set yet, or (b) the active model differs from config AND is an
+/// uninstalled SEED PLACEHOLDER — `install_model` / `recover_cached_fastembed_model` both mark the
+/// `ai_models` row installed, so an uninstalled active model can only have come from a prior seed.
+/// (b) lets a config-model edit made BEFORE install be adopted (the placeholder tracks config),
+/// while an installed / explicitly-activated model is respected — switching an INSTALLED model on a
+/// config change is a separate re-embed concern, out of scope here (#394 review).
 pub(crate) fn active_embedding_model_seed_owed(
     conn: &Connection,
     configured_model_id: Option<&str>,
 ) -> anyhow::Result<bool> {
-    Ok(configured_model_id.is_some() && meta(conn, ACTIVE_EMBEDDING_MODEL_META)?.is_none())
+    let Some(configured) = configured_model_id else {
+        return Ok(false); // embeddings-off — nothing to seed
+    };
+    match meta(conn, ACTIVE_EMBEDDING_MODEL_META)? {
+        None => Ok(true),
+        Some(active) if active == configured => Ok(false),
+        Some(active) => Ok(!active_model_is_installed(conn, &active)?),
+    }
+}
+
+/// Whether the given model's `ai_models` row is installed. A missing row counts as not installed.
+fn active_model_is_installed(conn: &Connection, model_id: &str) -> anyhow::Result<bool> {
+    Ok(conn
+        .query_row("SELECT installed FROM ai_models WHERE model_id = ?1", [model_id], |r| {
+            r.get::<_, i64>(0)
+        })
+        .optional()?
+        .is_some_and(|installed: i64| installed != 0))
 }
 
 pub(crate) fn install_model(
@@ -259,79 +283,82 @@ pub(crate) fn install_model2vec_model(conn: &Connection, model_id: &str) -> anyh
 #[cfg(test)]
 mod seed_active_embedding_model_tests {
     use super::*;
-    use crate::storage::IndexConnection;
 
     const JINA: &str = "jinaai/jina-embeddings-v2-base-code";
     const MINILM: &str = "sentence-transformers/all-MiniLM-L6-v2";
+    const HASH: &str = "embedding-hash";
 
-    /// A fresh, schema-applied index connection with the model manifest seeded (no active model).
-    fn fresh_index() -> (std::path::PathBuf, IndexConnection) {
-        let dir = std::env::temp_dir().join(format!(
-            "ragrat-seed-model-{}-{}",
-            std::process::id(),
-            now_ms()
-        ));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        let conn = IndexConnection::open(&dir.join("index.db")).unwrap();
-        crate::index::schema::apply(conn.connection()).unwrap();
-        ensure_model_manifest(conn.connection()).unwrap();
-        (dir, conn)
+    /// A schema-applied, manifest-seeded IN-MEMORY connection — no temp dir, so parallel tests
+    /// never collide on a shared path (#394 review).
+    fn fresh_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::index::schema::apply(&conn).unwrap();
+        ensure_model_manifest(&conn).unwrap();
+        conn
     }
 
     #[test]
     fn seeds_the_configured_model_when_active_is_unset() {
-        let (dir, conn) = fresh_index();
-        let conn = conn.connection();
+        let conn = fresh_conn();
         assert!(
-            meta(conn, ACTIVE_EMBEDDING_MODEL_META).unwrap().is_none(),
+            meta(&conn, ACTIVE_EMBEDDING_MODEL_META).unwrap().is_none(),
             "a fresh index has no active embedding model"
         );
         assert!(
-            active_embedding_model_seed_owed(conn, Some(JINA)).unwrap(),
+            active_embedding_model_seed_owed(&conn, Some(JINA)).unwrap(),
             "seed owed when unset"
         );
 
-        seed_active_embedding_model(conn, Some(JINA)).unwrap();
+        seed_active_embedding_model(&conn, Some(JINA)).unwrap();
 
         // The fresh index adopts the CONFIGURED model, NOT the HASH_MODEL_ID fallback.
-        assert_eq!(active_embedding_model_id(conn).unwrap(), JINA);
+        assert_eq!(active_embedding_model_id(&conn).unwrap(), JINA);
         assert!(
-            !active_embedding_model_seed_owed(conn, Some(JINA)).unwrap(),
+            !active_embedding_model_seed_owed(&conn, Some(JINA)).unwrap(),
             "no longer owed once seeded"
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
-    fn respects_an_already_selected_model() {
-        let (dir, conn) = fresh_index();
-        let conn = conn.connection();
-        // Simulate an explicit `models install all-MiniLM` having activated a model.
-        let minilm = spec(MINILM).expect("registry has all-MiniLM");
-        activate_model_with_version(conn, minilm.model_id, minilm.version).unwrap();
+    fn respects_an_installed_model() {
+        let conn = fresh_conn();
+        // An EXPLICIT install (hash is a no-download local install) activates + marks it installed.
+        install_model(&conn, HASH, None).unwrap();
+        assert_eq!(active_embedding_model_id(&conn).unwrap(), HASH);
 
-        // A config selecting a DIFFERENT model must NOT override the explicit selection.
-        assert!(!active_embedding_model_seed_owed(conn, Some(JINA)).unwrap());
-        seed_active_embedding_model(conn, Some(JINA)).unwrap();
+        // A config selecting a DIFFERENT model must NOT override an INSTALLED selection.
+        assert!(!active_embedding_model_seed_owed(&conn, Some(JINA)).unwrap());
+        seed_active_embedding_model(&conn, Some(JINA)).unwrap();
         assert_eq!(
-            active_embedding_model_id(conn).unwrap(),
-            minilm.model_id,
-            "an already-active model is kept — the seed only fills an EMPTY selection"
+            active_embedding_model_id(&conn).unwrap(),
+            HASH,
+            "an installed model is kept — the seed never overrides an explicit install"
         );
-        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn reseeds_an_uninstalled_placeholder_when_the_config_changes() {
+        let conn = fresh_conn();
+        // Seed jina — a PLACEHOLDER (activated by the seed, but NOT installed).
+        seed_active_embedding_model(&conn, Some(JINA)).unwrap();
+        assert_eq!(active_embedding_model_id(&conn).unwrap(), JINA);
+
+        // The config is edited to all-MiniLM BEFORE jina is installed → the placeholder is
+        // re-adopted (#394 review: a seeded placeholder must not masquerade as an explicit
+        // selection).
+        assert!(active_embedding_model_seed_owed(&conn, Some(MINILM)).unwrap());
+        seed_active_embedding_model(&conn, Some(MINILM)).unwrap();
+        assert_eq!(active_embedding_model_id(&conn).unwrap(), MINILM);
     }
 
     #[test]
     fn embeddings_off_leaves_the_active_model_unset() {
-        let (dir, conn) = fresh_index();
-        let conn = conn.connection();
-        assert!(!active_embedding_model_seed_owed(conn, None).unwrap(), "off ⇒ nothing to seed");
-        seed_active_embedding_model(conn, None).unwrap();
+        let conn = fresh_conn();
+        assert!(!active_embedding_model_seed_owed(&conn, None).unwrap(), "off ⇒ nothing to seed");
+        seed_active_embedding_model(&conn, None).unwrap();
         assert!(
-            meta(conn, ACTIVE_EMBEDDING_MODEL_META).unwrap().is_none(),
+            meta(&conn, ACTIVE_EMBEDDING_MODEL_META).unwrap().is_none(),
             "the embeddings-off choice leaves the active model unset (hash fallback stands)"
         );
-        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/rag-rat-core/src/index/ai/reconcile/model_lifecycle.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/model_lifecycle.rs
@@ -108,6 +108,47 @@ pub(crate) fn activate_model_with_version(
     Ok(())
 }
 
+/// Seed the active embedding model from the CONFIG's selection when the index has none yet (#394),
+/// so a fresh index adopts the configured model instead of silently defaulting to the hash fallback
+/// (`active_embedding_model_id`'s `HASH_MODEL_ID` default — which the config never selects, since
+/// `EmbeddingBackend::default()` is all-MiniLM). Read-first via
+/// [`active_embedding_model_seed_owed`]: a no-op once an active model is set (so an explicit
+/// `models install <other>` is respected) and for the embeddings-off choice (`configured_model_id
+/// == None`).
+///
+/// This does NOT install the model — reconcile still blocks with an accurate
+/// `models install <configured>` hint until it is — it only makes the index's active model reflect
+/// the config so that hint (and every model-scoped read) names the RIGHT model rather than the hash
+/// fallback. Runs on the write-bearing `open_config`, so any write-bearing open heals an index
+/// built before this fix.
+pub(crate) fn seed_active_embedding_model(
+    conn: &Connection,
+    configured_model_id: Option<&str>,
+) -> anyhow::Result<()> {
+    if !active_embedding_model_seed_owed(conn, configured_model_id)? {
+        return Ok(());
+    }
+    let model_id = configured_model_id.expect("seed_owed is true only when the id is Some");
+    let Some(spec) = spec(model_id) else {
+        return Ok(()); // unknown id (defensive) — leave unset so the hash fallback stands
+    };
+    // Activate + stamp the freshness version through the single writer (never the active meta
+    // alone, per the R3b footgun). The static `spec.version` is correct pre-install;
+    // `install_model` re-stamps the runtime-accurate version, and a fresh index has no
+    // embeddings to re-embed.
+    activate_model_with_version(conn, spec.model_id, spec.version)
+}
+
+/// Read-only test of whether [`seed_active_embedding_model`] would WRITE — the config selects a
+/// model AND the active-model meta is unset. The read-only open consults it to fall back to the
+/// write path so the seed heals once (same posture as the model-manifest / generated-flags gates).
+pub(crate) fn active_embedding_model_seed_owed(
+    conn: &Connection,
+    configured_model_id: Option<&str>,
+) -> anyhow::Result<bool> {
+    Ok(configured_model_id.is_some() && meta(conn, ACTIVE_EMBEDDING_MODEL_META)?.is_none())
+}
+
 pub(crate) fn install_model(
     conn: &Connection,
     model_id: &str,
@@ -212,5 +253,85 @@ pub(crate) fn install_model2vec_model(conn: &Connection, model_id: &str) -> anyh
             params![model_id, MODEL2VEC_MISSING_FEATURE_MESSAGE],
         )?;
         anyhow::bail!("{}", MODEL2VEC_MISSING_FEATURE_MESSAGE)
+    }
+}
+
+#[cfg(test)]
+mod seed_active_embedding_model_tests {
+    use super::*;
+    use crate::storage::IndexConnection;
+
+    const JINA: &str = "jinaai/jina-embeddings-v2-base-code";
+    const MINILM: &str = "sentence-transformers/all-MiniLM-L6-v2";
+
+    /// A fresh, schema-applied index connection with the model manifest seeded (no active model).
+    fn fresh_index() -> (std::path::PathBuf, IndexConnection) {
+        let dir = std::env::temp_dir().join(format!(
+            "ragrat-seed-model-{}-{}",
+            std::process::id(),
+            now_ms()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let conn = IndexConnection::open(&dir.join("index.db")).unwrap();
+        crate::index::schema::apply(conn.connection()).unwrap();
+        ensure_model_manifest(conn.connection()).unwrap();
+        (dir, conn)
+    }
+
+    #[test]
+    fn seeds_the_configured_model_when_active_is_unset() {
+        let (dir, conn) = fresh_index();
+        let conn = conn.connection();
+        assert!(
+            meta(conn, ACTIVE_EMBEDDING_MODEL_META).unwrap().is_none(),
+            "a fresh index has no active embedding model"
+        );
+        assert!(
+            active_embedding_model_seed_owed(conn, Some(JINA)).unwrap(),
+            "seed owed when unset"
+        );
+
+        seed_active_embedding_model(conn, Some(JINA)).unwrap();
+
+        // The fresh index adopts the CONFIGURED model, NOT the HASH_MODEL_ID fallback.
+        assert_eq!(active_embedding_model_id(conn).unwrap(), JINA);
+        assert!(
+            !active_embedding_model_seed_owed(conn, Some(JINA)).unwrap(),
+            "no longer owed once seeded"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn respects_an_already_selected_model() {
+        let (dir, conn) = fresh_index();
+        let conn = conn.connection();
+        // Simulate an explicit `models install all-MiniLM` having activated a model.
+        let minilm = spec(MINILM).expect("registry has all-MiniLM");
+        activate_model_with_version(conn, minilm.model_id, minilm.version).unwrap();
+
+        // A config selecting a DIFFERENT model must NOT override the explicit selection.
+        assert!(!active_embedding_model_seed_owed(conn, Some(JINA)).unwrap());
+        seed_active_embedding_model(conn, Some(JINA)).unwrap();
+        assert_eq!(
+            active_embedding_model_id(conn).unwrap(),
+            minilm.model_id,
+            "an already-active model is kept — the seed only fills an EMPTY selection"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn embeddings_off_leaves_the_active_model_unset() {
+        let (dir, conn) = fresh_index();
+        let conn = conn.connection();
+        assert!(!active_embedding_model_seed_owed(conn, None).unwrap(), "off ⇒ nothing to seed");
+        seed_active_embedding_model(conn, None).unwrap();
+        assert!(
+            meta(conn, ACTIVE_EMBEDDING_MODEL_META).unwrap().is_none(),
+            "the embeddings-off choice leaves the active model unset (hash fallback stands)"
+        );
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -50,6 +50,14 @@ impl IndexDatabase {
         let mut db = Self::open(&config.database)?;
         let (commit_sha, worktree_id) = resolve_git_context(&config.root);
         db.set_context(&commit_sha, &worktree_id)?;
+        // The incremental/maintenance/watch path opens config-blind (`Self::open`), so seed the
+        // active embedding model from config here too — else a pre-fix index (active unset) would
+        // keep reconciling via the hash fallback on watcher/maintenance passes until some other
+        // `open_config` command heals it (#394 review).
+        ai::seed_active_embedding_model(
+            db.storage.connection(),
+            config.llm.embedding.backend.model_id(),
+        )?;
         if db.indexed_file_count()? == 0 {
             return Self::rebuild_with_progress(config, progress).map(|db| (db, true));
         }

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -50,14 +50,6 @@ impl IndexDatabase {
         let mut db = Self::open(&config.database)?;
         let (commit_sha, worktree_id) = resolve_git_context(&config.root);
         db.set_context(&commit_sha, &worktree_id)?;
-        // The incremental/maintenance/watch path opens config-blind (`Self::open`), so seed the
-        // active embedding model from config here too — else a pre-fix index (active unset) would
-        // keep reconciling via the hash fallback on watcher/maintenance passes until some other
-        // `open_config` command heals it (#394 review).
-        ai::seed_active_embedding_model(
-            db.storage.connection(),
-            config.llm.embedding.backend.model_id(),
-        )?;
         if db.indexed_file_count()? == 0 {
             return Self::rebuild_with_progress(config, progress).map(|db| (db, true));
         }
@@ -87,6 +79,25 @@ impl IndexDatabase {
                 db.set_meta_if_changed("source_root", &config.root.display().to_string())?;
             db.storage.set_source_root(config.root.clone());
             let git_meta_changed = db.write_git_meta(&config.root)?;
+            // Heal the active embedding model from config INSIDE the txn: the incremental /
+            // maintenance / watch path opens config-blind via `Self::open` and can't seed on its
+            // own, so a pre-#394 index (active unset or still provisional) would
+            // otherwise keep reconciling via the hash fallback here. Doing it in-txn
+            // means a failed pass rolls the reseed back with everything else, rather
+            // than stranding the active model on a possibly-uninstalled configured
+            // model (#394 review). A no-op unless a seed is owed, preserving the idle-pass
+            // no-write invariant (#63); when owed it counts as a mutation so the COMMIT persists
+            // it.
+            let embedding_model_seeded = ai::active_embedding_model_seed_owed(
+                db.storage.connection(),
+                config.llm.embedding.backend.model_id(),
+            )?;
+            if embedding_model_seeded {
+                ai::seed_active_embedding_model(
+                    db.storage.connection(),
+                    config.llm.embedding.backend.model_id(),
+                )?;
+            }
             let (indexed, manifest_in_change_set) = match mode {
                 IndexMode::Changed => db.index_changed_files_with_progress(config, progress)?,
                 IndexMode::Discover => db.index_discovered_files_with_progress(config, progress)?,
@@ -102,7 +113,11 @@ impl IndexDatabase {
                 // Non-git roots have no commit scope; overlays are their canonical rows.
                 Err(_) => 0,
             };
-            let mut mutated = indexed > 0 || healed > 0 || source_root_changed || git_meta_changed;
+            let mut mutated = indexed > 0
+                || healed > 0
+                || source_root_changed
+                || git_meta_changed
+                || embedding_model_seeded;
             // None when the gate above found git history already current — skip the reload.
             if let Some(handle) = git_history.take() {
                 db.apply_prepared_git_history(&config.root, handle)?;

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -73,6 +73,13 @@ impl IndexDatabase {
         db.config = Some(config.clone());
         db.ensure_graph_index_current()?;
         db.ensure_generated_flags_current()?;
+        // Adopt the configured embedding model as the index's active model when it has none yet, so
+        // reconcile targets it (and its "install" hint names it) instead of the hash fallback
+        // (#394).
+        ai::seed_active_embedding_model(
+            db.storage.connection(),
+            config.llm.embedding.backend.model_id(),
+        )?;
         Ok(db)
     }
 
@@ -114,6 +121,14 @@ impl IndexDatabase {
             return Ok(None);
         }
         if !ai::model_manifest_is_current(storage.connection())? {
+            return Ok(None);
+        }
+        // A fresh index owes an active-embedding-model seed from config (a write); fall back to the
+        // read-write open so it heals once (#394, same posture as the manifest / graph gates).
+        if ai::active_embedding_model_seed_owed(
+            storage.connection(),
+            config.llm.embedding.backend.model_id(),
+        )? {
             return Ok(None);
         }
         storage.set_source_root(config.root.clone());

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -16,6 +16,12 @@ impl IndexDatabase {
         let mut db = Self::create_or_migrate(&config.database)?;
         let (commit_sha, worktree_id) = resolve_git_context(&config.root);
         db.set_context(&commit_sha, &worktree_id)?;
+        // Adopt the configured embedding model as this fresh index's active model, so reconcile
+        // targets it (and read-only opens serve immediately) rather than the hash fallback (#394).
+        ai::seed_active_embedding_model(
+            db.storage.connection(),
+            config.llm.embedding.backend.model_id(),
+        )?;
         progress(IndexProgress::IndexingGitHistory);
         let mut git_history = Some(spawn_git_history_prepare(&config.root));
         // RAM-first bulk build: a full rebuild is one big atomic write, so skip per-commit fsyncs

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -16,12 +16,6 @@ impl IndexDatabase {
         let mut db = Self::create_or_migrate(&config.database)?;
         let (commit_sha, worktree_id) = resolve_git_context(&config.root);
         db.set_context(&commit_sha, &worktree_id)?;
-        // Adopt the configured embedding model as this fresh index's active model, so reconcile
-        // targets it (and read-only opens serve immediately) rather than the hash fallback (#394).
-        ai::seed_active_embedding_model(
-            db.storage.connection(),
-            config.llm.embedding.backend.model_id(),
-        )?;
         progress(IndexProgress::IndexingGitHistory);
         let mut git_history = Some(spawn_git_history_prepare(&config.root));
         // RAM-first bulk build: a full rebuild is one big atomic write, so skip per-commit fsyncs
@@ -102,6 +96,15 @@ impl IndexDatabase {
             db.refresh_clone_token_df()?;
             mem_trace("after refresh_clone_token_df");
             db.set_meta("indexed_at_ms", &now_ms().to_string())?;
+            // Adopt the configured embedding model as this index's active model INSIDE the rebuild
+            // transaction, so reconcile targets it (and read-only opens serve immediately) rather
+            // than the hash fallback (#394) — and a failed rebuild rolls the seed back with the
+            // rest, leaving the pre-rebuild active model intact rather than pointing at
+            // a missing model (#394 review).
+            ai::seed_active_embedding_model(
+                db.storage.connection(),
+                config.llm.embedding.backend.model_id(),
+            )?;
             db.storage.execute_batch("COMMIT")?;
             mem_trace("after COMMIT");
             progress(IndexProgress::Finished { files: indexed });

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -259,6 +259,34 @@ fn reconcile_confirms_a_provisional_model_against_a_config_change() {
     let _ = fs::remove_dir_all(root);
 }
 
+#[test]
+fn an_incremental_pass_heals_a_missing_active_model_atomically() {
+    // A pre-#394 index (active model unset) opened on the config-blind incremental / maintenance /
+    // watch path must re-seed the active model from config — and, because the seed lives INSIDE the
+    // incremental transaction and counts as a mutation, the heal is COMMITTED rather than rolled
+    // back as an idle no-write pass (#394 review).
+    let (root, mut config) = markdown_config("alpha token\nenough detail for a chunk to survive\n");
+    config.llm.embedding.backend = HASH_MODEL_ID.parse().unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    // Simulate a pre-#394 index: drop the seeded active-model meta.
+    db.storage
+        .connection()
+        .execute("DELETE FROM index_meta WHERE key = 'active_embedding_model'", [])
+        .unwrap();
+    drop(db);
+
+    // An incremental discover pass re-seeds inside its transaction and commits the heal (had it
+    // been treated as an idle pass, the ROLLBACK would leave the active model unset).
+    let db = IndexDatabase::index_discover(&config).unwrap();
+    assert_eq!(
+        ai::active_embedding_model_id(db.storage.connection()).unwrap(),
+        HASH_MODEL_ID,
+        "the incremental pass healed the active model and committed it"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
 #[cfg(feature = "fastembed")]
 #[test]
 fn cached_fastembed_model_recovers_ready_state() {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -216,6 +216,39 @@ fn reconcile_requires_explicit_model_install_and_ignores_stale_artifacts() {
     let _ = fs::remove_dir_all(root);
 }
 
+#[test]
+fn a_committed_embedding_model_is_respected_over_a_config_change() {
+    // #394 review: the config seed makes a fresh index adopt the configured model, but once
+    // embeddings are COMMITTED under the active model a later config-model edit must NOT silently
+    // switch it (that would strand the vectors and force a re-embed) — the seed yields to the
+    // committed model. (Uncommitted actives — placeholders / recovered caches — DO yield to config;
+    // that is covered by the model_lifecycle unit tests.)
+    let (root, mut config) = markdown_config(
+        "alpha token\nsecond line with enough detail for the semantic embedding policy to keep \
+         this chunk\nthird line with runtime context\n",
+    );
+    config.llm.embedding.backend = HASH_MODEL_ID.parse().unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    db.install_model(HASH_MODEL_ID, None).unwrap();
+    assert!(
+        db.reconcile(None, Some(8)).unwrap().embeddings_written >= 1,
+        "hash embeddings are committed"
+    );
+    drop(db);
+
+    // Edit the config to a DIFFERENT model, then reopen: the active model stays hash because its
+    // embeddings are committed — the seed only fills an empty / uncommitted selection.
+    config.llm.embedding.backend = "sentence-transformers/all-MiniLM-L6-v2".parse().unwrap();
+    let db = IndexDatabase::open_config(&config).unwrap();
+    assert_eq!(
+        ai::active_embedding_model_id(db.storage.connection()).unwrap(),
+        HASH_MODEL_ID,
+        "a model with committed embeddings is not switched by a config change"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
 #[cfg(feature = "fastembed")]
 #[test]
 fn cached_fastembed_model_recovers_ready_state() {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -125,10 +125,15 @@ fn fastembed_missing_feature_reports_rebuild_command() {
 
 #[test]
 fn reconcile_requires_explicit_model_install_and_ignores_stale_artifacts() {
-    let (root, config) = markdown_config(
+    let (root, mut config) = markdown_config(
         "alpha token\nsecond line with enough detail for the semantic embedding policy to keep \
          this chunk\nthird line with runtime context\n",
     );
+    // Select the deterministic hash embedder explicitly — this test exercises the reconcile flow
+    // with the no-download test embedder. A fresh index adopts the CONFIGURED model (#394), so
+    // without this it would adopt the default all-MiniLM and the HASH_MODEL_ID assertions below
+    // would not hold.
+    config.llm.embedding.backend = HASH_MODEL_ID.parse().unwrap();
     let db = IndexDatabase::rebuild(&config).unwrap();
     let chunk_id = first_chunk_id(&db);
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -217,12 +217,11 @@ fn reconcile_requires_explicit_model_install_and_ignores_stale_artifacts() {
 }
 
 #[test]
-fn a_committed_embedding_model_is_respected_over_a_config_change() {
-    // #394 review: the config seed makes a fresh index adopt the configured model, but once
-    // embeddings are COMMITTED under the active model a later config-model edit must NOT silently
-    // switch it (that would strand the vectors and force a re-embed) — the seed yields to the
-    // committed model. (Uncommitted actives — placeholders / recovered caches — DO yield to config;
-    // that is covered by the model_lifecycle unit tests.)
+fn reconcile_confirms_a_provisional_model_against_a_config_change() {
+    // #394 review: a PROVISIONAL active model (a config seed or a fastembed-cache recovery) yields
+    // to a differing config — but once a reconcile COMMITS embeddings under it, the model is
+    // confirmed (provisional flag cleared) and a later config-model edit must NOT silently switch
+    // it (that would strand the vectors and force a re-embed).
     let (root, mut config) = markdown_config(
         "alpha token\nsecond line with enough detail for the semantic embedding policy to keep \
          this chunk\nthird line with runtime context\n",
@@ -230,20 +229,31 @@ fn a_committed_embedding_model_is_respected_over_a_config_change() {
     config.llm.embedding.backend = HASH_MODEL_ID.parse().unwrap();
     let db = IndexDatabase::rebuild(&config).unwrap();
     db.install_model(HASH_MODEL_ID, None).unwrap();
+    // Simulate a PROVISIONAL-but-Ready active model, as a fastembed-cache recovery produces: Ready
+    // to embed, but not yet user-confirmed. (Mirrors ACTIVE_EMBEDDING_MODEL_PROVISIONAL_META.)
+    db.storage
+        .connection()
+        .execute(
+            "INSERT OR REPLACE INTO index_meta(key, value) VALUES \
+             ('active_embedding_model_provisional', '1')",
+            [],
+        )
+        .unwrap();
+    // A reconcile that commits embeddings CONFIRMS the model — it clears the provisional flag.
     assert!(
         db.reconcile(None, Some(8)).unwrap().embeddings_written >= 1,
         "hash embeddings are committed"
     );
     drop(db);
 
-    // Edit the config to a DIFFERENT model, then reopen: the active model stays hash because its
-    // embeddings are committed — the seed only fills an empty / uncommitted selection.
+    // Edit the config to a DIFFERENT model, then reopen: the active model stays hash because the
+    // reconcile confirmed it — the seed only reseeds a still-provisional model.
     config.llm.embedding.backend = "sentence-transformers/all-MiniLM-L6-v2".parse().unwrap();
     let db = IndexDatabase::open_config(&config).unwrap();
     assert_eq!(
         ai::active_embedding_model_id(db.storage.connection()).unwrap(),
         HASH_MODEL_ID,
-        "a model with committed embeddings is not switched by a config change"
+        "a reconcile-confirmed model is not switched by a config change"
     );
 
     let _ = fs::remove_dir_all(root);

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -452,7 +452,10 @@ fn full_rebuild_preserves_github_papertrail_cache() {
 
 #[test]
 fn full_rebuild_preserves_installed_model_manifest() {
-    let (root, config) = markdown_config("alpha token with enough detail for embeddings\n");
+    let (root, mut config) = markdown_config("alpha token with enough detail for embeddings\n");
+    // Select the hash embedder (the model this test installs) so config and the install agree — a
+    // fresh index seeds the CONFIGURED model (#394), so a mismatched default would be re-seeded.
+    config.llm.embedding.backend = HASH_MODEL_ID.parse().unwrap();
     let db = IndexDatabase::rebuild(&config).unwrap();
     db.install_model(HASH_MODEL_ID, None).unwrap();
     let before = db.llm_status().unwrap();


### PR DESCRIPTION
Fixes #394.

## Problem
On a freshly built index, `rag-rat reconcile` reported it couldn't embed and told the user to `rag-rat models install embedding-hash` — the built-in hash fallback — instead of the model selected in `rag-rat.toml`.

`active_embedding_model_id` defaults to `HASH_MODEL_ID` when the active-model meta is unset, and nothing seeded that meta from config, so a fresh index silently used `embedding-hash` regardless of `[llm.embedding] model`. `EmbeddingBackend::default()` is all-MiniLM, **never** hash — so the hash default is wrong whenever a config exists.

## Fix
Seed the active embedding model from `config.llm.embedding.backend.model_id()` when the index has none yet:
- **`rebuild`** seeds a fresh index (immediately correct),
- **`open_config`** seeds on the write-bearing open (heals indexes built before this fix),
- **`try_open_config_read_only`** declines when the seed is owed, so a read-only tool falls back to the write path that heals — same posture as the manifest / graph / generated-flags gates.

`seed_active_embedding_model` / `active_embedding_model_seed_owed` are read-first: a no-op once a model is set (an explicit `models install <other>` is respected) and for the embeddings-off choice. It does **not** install the model — reconcile still blocks until it is — but the block message now names the configured model.

## Verified end-to-end
A fresh index with `model = "jinaai/jina-embeddings-v2-base-code"`:
```
active_embedding_model = jinaai/jina-embeddings-v2-base-code   (was: embedding-hash)
reconcile: "jinaai/jina-embeddings-v2-base-code model is not ready;
            run `rag-rat models install jinaai/jina-embeddings-v2-base-code`"
```

## Tests
`cargo nextest run -p rag-rat-core` = 1105 passed, `-p rag-rat` = 239 passed; clippy `-D warnings` clean; `cargo +nightly fmt` clean. New unit tests: seed adopts the configured model / respects an already-active model / leaves embeddings-off unset. The one test that codified the old hash default (`reconcile_requires_explicit_model_install_and_ignores_stale_artifacts`) now selects the hash embedder explicitly.