### PR TITLE
feat(schema): V038 repos registry, repo identity, and data_dir helper (#396 phase A1)

### DIFF
--- a/crates/rag-rat-cli/src/commands/clones.rs
+++ b/crates/rag-rat-cli/src/commands/clones.rs
@@ -276,6 +276,7 @@ mod tests {
         std::fs::write(root.join("src/b.rs"), &clone_body).unwrap();
 
         let config = Config {
+            repo_id_override: None,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {

--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -466,6 +466,7 @@ mod tests {
         git(&main, &["add", "-A"]);
         git(&main, &["commit", "-qm", "base"]);
         let config = Config {
+            repo_id_override: None,
             root: main.clone(),
             database: main.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
@@ -542,6 +543,7 @@ mod tests {
         git(&main, &["add", "-A"]);
         git(&main, &["commit", "-qm", "base"]);
         let config = Config {
+            repo_id_override: None,
             root: main.clone(),
             database: main.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
@@ -616,6 +618,7 @@ mod tests {
         git(&root, &["add", "-A"]);
         git(&root, &["commit", "-qm", "base"]);
         let config = Config {
+            repo_id_override: None,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
@@ -683,6 +686,7 @@ mod tests {
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
         let config = Config {
+            repo_id_override: None,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {

--- a/crates/rag-rat-cli/src/commands/oracle.rs
+++ b/crates/rag-rat-cli/src/commands/oracle.rs
@@ -464,6 +464,7 @@ mod tests {
         std::fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n")
             .unwrap();
         let config = Config {
+            repo_id_override: None,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
@@ -510,6 +511,7 @@ mod tests {
         // A target carrying the SAME default filters the simple `[target_bindings]` form renders
         // (`include = ["**/*.rs"]`, no exclude), so the bindings-match check accepts it.
         let config_with = |include: Vec<String>, exclude: Vec<String>| Config {
+            repo_id_override: None,
             root: PathBuf::from("/x"),
             database: PathBuf::from("/x/db"),
             targets: vec![ResolvedTarget {

--- a/crates/rag-rat-core/benches/shared/mod.rs
+++ b/crates/rag-rat-core/benches/shared/mod.rs
@@ -53,6 +53,7 @@ pub fn temp_db_path() -> PathBuf {
 /// A Config indexing `subdir` of the corpus into a fresh temp DB.
 pub fn bench_config(subdir: &str) -> Config {
     Config {
+        repo_id_override: None,
         root: corpus_dir(),
         database: temp_db_path(),
         targets: vec![ResolvedTarget {

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -23,6 +23,10 @@ pub struct Config {
     pub version_check: VersionCheckConfig,
     pub oracle: OracleConfig,
     pub search: SearchConfig,
+    /// Optional `[index] repo_id` override for the consolidated global store — pins the repo's
+    /// identity instead of deriving it from the root-commit hash. `None` = derive. Consumed by
+    /// `crate::repo_identity::resolve_repo_identity`; it does NOT influence the database path.
+    pub repo_id_override: Option<String>,
 }
 
 /// Search-ranking knobs (`[search]`). Default OFF so the shipped fuse is byte-identical to today;
@@ -742,7 +746,22 @@ impl Config {
             config_dir.join(&log.dir)
         };
 
-        Ok(Self { root, database, targets, llm, watch, version_check, oracle, search, log })
+        // Parse-only: the override is threaded into repo identity resolution by a later workstream
+        // and deliberately does NOT affect the database path resolved above.
+        let repo_id_override =
+            raw.index.repo_id.map(|id| id.trim().to_string()).filter(|id| !id.is_empty());
+        Ok(Self {
+            root,
+            database,
+            targets,
+            llm,
+            watch,
+            version_check,
+            oracle,
+            search,
+            log,
+            repo_id_override,
+        })
     }
 }
 
@@ -1027,6 +1046,11 @@ impl From<RawSearch> for SearchConfig {
 struct RawIndex {
     root: Option<String>,
     database: Option<String>,
+    /// `[index] repo_id` — pins the repo's identity for the consolidated global store instead of
+    /// deriving it from the root-commit hash. Set it for a fork that must NOT share memories with
+    /// its upstream, or a repo with no commits yet. Parsed here; consumed by
+    /// `resolve_repo_identity` in a later workstream (no effect on path resolution).
+    repo_id: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1422,6 +1446,51 @@ mod tests {
             main.canonicalize().unwrap(),
             "a linked worktree's config root anchors to the main worktree",
         );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn repo_id_override_is_parsed_and_does_not_change_the_database_path() {
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let tmp = std::env::temp_dir().join(format!("ragrat-repoid-{}-{id}", std::process::id()));
+        std::fs::create_dir_all(tmp.join("src")).unwrap();
+        std::fs::write(tmp.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        std::fs::write(
+            tmp.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\nrepo_id = \"  pinned-id  \"\n[target_bindings]\nrust = \
+             [\"src\"]\n",
+        )
+        .unwrap();
+
+        let config = Config::load(tmp.join("rag-rat.toml")).unwrap();
+        assert_eq!(
+            config.repo_id_override.as_deref(),
+            Some("pinned-id"),
+            "the [index] repo_id override is parsed and trimmed",
+        );
+        // Parse-only: the override must NOT influence path resolution — the database stays at the
+        // per-repo default beside `root`.
+        assert_eq!(config.database, config.root.join(".rag-rat/index.sqlite"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn repo_id_override_absent_is_none() {
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let tmp =
+            std::env::temp_dir().join(format!("ragrat-repoid-none-{}-{id}", std::process::id()));
+        std::fs::create_dir_all(tmp.join("src")).unwrap();
+        std::fs::write(tmp.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        std::fs::write(
+            tmp.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n",
+        )
+        .unwrap();
+
+        let config = Config::load(tmp.join("rag-rat.toml")).unwrap();
+        assert_eq!(config.repo_id_override, None, "no [index] repo_id → None");
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -746,10 +746,15 @@ impl Config {
             config_dir.join(&log.dir)
         };
 
-        // Parse-only: the override is threaded into repo identity resolution by a later workstream
-        // and deliberately does NOT affect the database path resolved above.
-        let repo_id_override =
+        // The branch-local override (trim + drop empty), then ANCHORED to the MAIN worktree's
+        // config. Repo IDENTITY is per-repo, not per-branch: every worktree of a repo must resolve
+        // the SAME override regardless of which checkout launched — consistent with the
+        // root/database/targets anchoring above. A linked branch whose `rag-rat.toml` omits or pins
+        // a DIFFERENT `[index] repo_id` would otherwise split identity by launch point. Parse-only:
+        // the override never affects the database path resolved above.
+        let local_repo_id_override =
             raw.index.repo_id.map(|id| id.trim().to_string()).filter(|id| !id.is_empty());
+        let repo_id_override = main_repo_id_override(&root, &local_root, local_repo_id_override);
         Ok(Self {
             root,
             database,
@@ -880,6 +885,59 @@ fn main_base_targets(root: &Path, local_root: &Path) -> Option<Vec<ResolvedTarge
     // Main's targets are root-relative; validate (and store) them against the anchored `root`,
     // which is the equivalent path under the main worktree the base index is discovered from.
     resolve_targets(root, raw.target_bindings, raw.target).ok()
+}
+
+/// The `[index] repo_id` override anchored to the MAIN worktree's `rag-rat.toml`, mirroring
+/// [`main_base_targets`]: repo identity is per-repo, so every worktree must resolve the same override
+/// no matter which checkout launched. `local_override` (already trimmed + non-empty-or-`None`) is
+/// returned unchanged when this config is NOT anchored away from its own checkout (`root ==
+/// local_root`: the main checkout or a non-git dir), or when main's `rag-rat.toml` is unreadable /
+/// unparsable (best-effort fallback, exactly as `main_base_targets` does for targets).
+///
+/// When anchored to main, MAIN's value is authoritative — INCLUDING when main OMITS the override
+/// (→ `None`, derive from the root commit): honoring the branch's pin there would make identity
+/// launch-point-dependent, the exact split this guards. A branch that pins a DIFFERENT non-empty id
+/// than main is warned (identity is per-repo; main wins), matching how the base-target anchoring
+/// silently prefers main. This re-reads main's config rather than sharing `main_base_targets`'
+/// read, because the two have different fallback semantics (targets fall back on VALIDATION
+/// failure; the override has nothing to validate) — a second read of one small TOML at load time.
+fn main_repo_id_override(
+    root: &Path,
+    local_root: &Path,
+    local_override: Option<String>,
+) -> Option<String> {
+    if root == local_root {
+        return local_override; // not anchored away — the local config IS the base config
+    }
+    // Anchored to a different (main) root. Read MAIN's config; its `[index] repo_id` is the
+    // per-repo identity. If main's config can't be located/read/parsed, fall back to the local
+    // override (best effort, as `main_base_targets` does).
+    let Some(main_config_path) = main_worktree_root(root).map(|main| main.join("rag-rat.toml"))
+    else {
+        return local_override;
+    };
+    let Ok(text) = fs::read_to_string(&main_config_path) else {
+        return local_override;
+    };
+    let Ok(raw) = toml::from_str::<RawConfig>(&text) else {
+        return local_override;
+    };
+    let main_override =
+        raw.index.repo_id.map(|id| id.trim().to_string()).filter(|id| !id.is_empty());
+    // A linked branch pinning a different non-empty id than main is a divergence: identity is
+    // per-repo, so main's value wins. Warn (eprintln, this file's only user-facing channel) so the
+    // mismatch is visible rather than silently dropped.
+    if let Some(local) = local_override.as_deref()
+        && local != main_override.as_deref().unwrap_or_default()
+    {
+        eprintln!(
+            "rag-rat: [index] repo_id in the linked worktree config ({local}) differs from the \
+             main worktree config ({}); using the main worktree's value so every worktree of this \
+             repo shares one identity",
+            main_override.as_deref().unwrap_or("<derived from root commit>")
+        );
+    }
+    main_override
 }
 
 /// The main worktree root, derived from the git common dir (`<main>/.git`). Returns `None` outside
@@ -1615,6 +1673,110 @@ mod tests {
         assert!(
             dirs.contains(&PathBuf::from("extra")),
             "base keeps main's `extra` even though the branch dropped it: {dirs:?}",
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn config_load_anchors_repo_id_override_to_main_when_the_branch_diverges() {
+        // FINDING 4: repo IDENTITY is per-repo, so the `[index] repo_id` override is read from the
+        // MAIN worktree's config, NOT the launching (branch-local) one. A linked worktree that pins
+        // a DIFFERENT id must still resolve MAIN's — otherwise identity splits by which checkout
+        // launched. This mirrors the root/database/targets anchoring above.
+        let git = |dir: &Path, args: &[&str]| {
+            std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
+        };
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let tmp =
+            std::env::temp_dir().join(format!("ragrat-repoid-anchor-{}-{id}", std::process::id()));
+        let main = tmp.join("main");
+        std::fs::create_dir_all(main.join("src")).unwrap();
+        std::fs::write(main.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        // Main pins a canonical repo_id.
+        std::fs::write(
+            main.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\nrepo_id = \"canonical-id\"\n[target_bindings]\nrust = \
+             [\"src\"]\n",
+        )
+        .unwrap();
+        git(&main, &["init", "-q"]);
+        git(&main, &["config", "user.email", "t@example.com"]);
+        git(&main, &["config", "user.name", "t"]);
+        git(&main, &["add", "-A"]);
+        git(&main, &["commit", "-qm", "seed"]);
+
+        // The branch pins a DIVERGENT id, committed on the branch and checked out in the worktree.
+        let linked = tmp.join("wt");
+        git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+        std::fs::write(
+            linked.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\nrepo_id = \"branch-divergent-id\"\n[target_bindings]\nrust = \
+             [\"src\"]\n",
+        )
+        .unwrap();
+        git(&linked, &["add", "-A"]);
+        git(&linked, &["commit", "-qm", "branch pins a different repo_id"]);
+
+        let from_main = Config::load(main.join("rag-rat.toml")).unwrap();
+        let from_linked = Config::load(linked.join("rag-rat.toml")).unwrap();
+        assert_eq!(
+            from_main.repo_id_override.as_deref(),
+            Some("canonical-id"),
+            "the main checkout resolves its own override",
+        );
+        assert_eq!(
+            from_linked.repo_id_override.as_deref(),
+            Some("canonical-id"),
+            "a linked worktree resolves MAIN's repo_id override, not its own branch-local pin",
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn config_load_anchors_repo_id_override_to_main_when_main_omits_it() {
+        // The strong form of FINDING 4: MAIN omits `[index] repo_id` (identity derives from the
+        // root commit), but the branch pins one. The anchored value is MAIN's absence →
+        // None, so identity stays derived and launch-point-independent; the branch pin is
+        // NOT honored for the shared identity (honoring it would make identity depend on
+        // which worktree launched).
+        let git = |dir: &Path, args: &[&str]| {
+            std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap()
+        };
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let tmp = std::env::temp_dir()
+            .join(format!("ragrat-repoid-mainomit-{}-{id}", std::process::id()));
+        let main = tmp.join("main");
+        std::fs::create_dir_all(main.join("src")).unwrap();
+        std::fs::write(main.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        // Main OMITS repo_id.
+        std::fs::write(
+            main.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n",
+        )
+        .unwrap();
+        git(&main, &["init", "-q"]);
+        git(&main, &["config", "user.email", "t@example.com"]);
+        git(&main, &["config", "user.name", "t"]);
+        git(&main, &["add", "-A"]);
+        git(&main, &["commit", "-qm", "seed"]);
+
+        let linked = tmp.join("wt");
+        git(&main, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+        std::fs::write(
+            linked.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\nrepo_id = \"branch-only-id\"\n[target_bindings]\nrust = \
+             [\"src\"]\n",
+        )
+        .unwrap();
+        git(&linked, &["add", "-A"]);
+        git(&linked, &["commit", "-qm", "branch pins a repo_id main lacks"]);
+
+        let from_linked = Config::load(linked.join("rag-rat.toml")).unwrap();
+        assert_eq!(
+            from_linked.repo_id_override, None,
+            "main omits the override, so the anchored identity derives — the branch pin is ignored",
         );
 
         let _ = std::fs::remove_dir_all(&tmp);

--- a/crates/rag-rat-core/src/data_dir.rs
+++ b/crates/rag-rat-core/src/data_dir.rs
@@ -1,0 +1,141 @@
+//! The per-machine data directory for rag-rat's consolidated global store. The cascade mirrors
+//! `index::ai::helpers::fastembed_cache_dir`, but targets the XDG *data* dir (durable, authored
+//! state) rather than the *cache* dir (disposable, re-derivable) — memories and the op log live
+//! here and must survive `git clean -fdx` of any checkout.
+
+use std::path::PathBuf;
+
+/// The rag-rat data directory, resolved by env cascade. An env var set to the empty string is
+/// treated as unset (XDG semantics), so the cascade falls through:
+///
+/// 1. `RAG_RAT_DATA_DIR` — explicit override, honored verbatim.
+/// 2. `$XDG_DATA_HOME/rag-rat`.
+/// 3. `$HOME/.local/share/rag-rat` (the XDG default when `XDG_DATA_HOME` is unset).
+/// 4. (Windows) `%APPDATA%/rag-rat`.
+///
+/// Returns `None` when none resolve. There is deliberately NO repo-relative fallback: the global
+/// DB is machine-scoped, and silently landing it inside a checkout would defeat its purpose — the
+/// caller decides what to do without a data dir (e.g. keep using the per-repo `.rag-rat/` path).
+pub fn data_dir() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("RAG_RAT_DATA_DIR")
+        && !dir.is_empty()
+    {
+        return Some(PathBuf::from(dir));
+    }
+    if let Ok(data_home) = std::env::var("XDG_DATA_HOME")
+        && !data_home.is_empty()
+    {
+        return Some(PathBuf::from(data_home).join("rag-rat"));
+    }
+    if let Ok(home) = std::env::var("HOME")
+        && !home.is_empty()
+    {
+        return Some(PathBuf::from(home).join(".local").join("share").join("rag-rat"));
+    }
+    #[cfg(windows)]
+    if let Ok(appdata) = std::env::var("APPDATA")
+        && !appdata.is_empty()
+    {
+        return Some(PathBuf::from(appdata).join("rag-rat"));
+    }
+    None
+}
+
+/// The consolidated global database path: [`data_dir`]`/"rag-rat.sqlite"`. `None` when no data dir
+/// resolves (see [`data_dir`]).
+pub fn global_database_path() -> Option<PathBuf> {
+    data_dir().map(|dir| dir.join("rag-rat.sqlite"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Mutex, PoisonError};
+
+    use super::*;
+
+    /// Serializes the env-mutating tests. `set_var`/`remove_var` mutate PROCESS-global state, so
+    /// under a thread-based runner (`cargo test`) two of these racing would flake; nextest's
+    /// process-per-test isolation makes it moot there, but the mutex keeps both runners honest.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Run `body` with the four cascade vars forced to `values` (`None` = removed), restoring the
+    /// prior environment afterward so tests never leak state into each other.
+    fn with_env(values: &[(&str, Option<&str>)], body: impl FnOnce()) {
+        const KEYS: [&str; 4] = ["RAG_RAT_DATA_DIR", "XDG_DATA_HOME", "HOME", "APPDATA"];
+        let _guard = ENV_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
+        let saved: Vec<(&str, Option<String>)> =
+            KEYS.iter().map(|&key| (key, std::env::var(key).ok())).collect();
+        // SAFETY: env access is serialized by ENV_LOCK for the duration of this call.
+        unsafe {
+            for &key in &KEYS {
+                std::env::remove_var(key);
+            }
+            for &(key, value) in values {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+        body();
+        // SAFETY: still under ENV_LOCK; restore exactly what was there before.
+        unsafe {
+            for (key, value) in saved {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn rag_rat_data_dir_override_wins() {
+        with_env(
+            &[
+                ("RAG_RAT_DATA_DIR", Some("/custom/data")),
+                ("XDG_DATA_HOME", Some("/xdg")),
+                ("HOME", Some("/home/u")),
+            ],
+            || {
+                assert_eq!(data_dir(), Some(PathBuf::from("/custom/data")));
+                assert_eq!(
+                    global_database_path(),
+                    Some(PathBuf::from("/custom/data/rag-rat.sqlite"))
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn xdg_data_home_is_next() {
+        with_env(&[("XDG_DATA_HOME", Some("/xdg")), ("HOME", Some("/home/u"))], || {
+            assert_eq!(data_dir(), Some(PathBuf::from("/xdg/rag-rat")));
+        });
+    }
+
+    #[test]
+    fn home_is_the_xdg_default() {
+        with_env(&[("HOME", Some("/home/u"))], || {
+            assert_eq!(data_dir(), Some(PathBuf::from("/home/u/.local/share/rag-rat")));
+        });
+    }
+
+    #[test]
+    fn empty_var_is_treated_as_unset() {
+        // An empty XDG_DATA_HOME must fall through to HOME (XDG spec), not resolve to `/rag-rat`.
+        with_env(&[("XDG_DATA_HOME", Some("")), ("HOME", Some("/home/u"))], || {
+            assert_eq!(data_dir(), Some(PathBuf::from("/home/u/.local/share/rag-rat")));
+        });
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn none_when_nothing_resolves() {
+        // On non-Windows the cascade ends at HOME; with every var unset there is no data dir.
+        with_env(&[], || {
+            assert_eq!(data_dir(), None);
+            assert_eq!(global_database_path(), None);
+        });
+    }
+}

--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -676,6 +676,7 @@ mod tests {
         )
         .unwrap();
         let config = crate::Config {
+            repo_id_override: None,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![crate::config::ResolvedTarget {
@@ -786,6 +787,7 @@ mod tests {
         .unwrap();
         let db_path = root.join(".rag-rat/index.sqlite");
         let config = crate::Config {
+            repo_id_override: None,
             root: root.clone(),
             database: db_path.clone(),
             targets: vec![crate::config::ResolvedTarget {
@@ -850,6 +852,7 @@ mod tests {
         )
         .unwrap();
         let config = crate::Config {
+            repo_id_override: None,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![crate::config::ResolvedTarget {
@@ -945,6 +948,7 @@ mod tests {
             kind: crate::config::TargetKind::Source,
         };
         let config = crate::Config {
+            repo_id_override: None,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -816,6 +816,7 @@ mod tests {
         )
         .unwrap();
         crate::Config {
+            repo_id_override: None,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![crate::config::ResolvedTarget {

--- a/crates/rag-rat-core/src/index/query_api/clones/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/tests.rs
@@ -193,6 +193,7 @@ fn find_clones_rejects_nan_and_non_finite_min_similarity() {
     std::fs::create_dir_all(root.join("src")).unwrap();
     std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
     let config = crate::Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![crate::config::ResolvedTarget {
@@ -774,6 +775,7 @@ fn recall_candidates_identical_blob_vs_postings_grouping() {
     )
     .unwrap();
     let config = crate::Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![crate::config::ResolvedTarget {

--- a/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
@@ -29,6 +29,7 @@ fn temp_root() -> PathBuf {
 
 fn rust_config(root: PathBuf) -> Config {
     Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
@@ -1139,6 +1140,7 @@ fn deleted_and_generated_paths_counted_in_skipped() {
     fs::write(root.join("gen/out.rs"), "pub fn generated_fn() {}\n").unwrap();
     // A config with a Generated target for `gen/` so `out.rs` indexes generated.
     let config = Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1172,6 +1172,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_035_ID => Some(35),
             MIGRATION_036_ID => Some(36),
             MIGRATION_037_ID => Some(37),
+            MIGRATION_038_ID => Some(38),
             _ => None,
         })
         .max()
@@ -1218,6 +1219,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_035_ID
             | MIGRATION_036_ID
             | MIGRATION_037_ID
+            | MIGRATION_038_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1261,6 +1263,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_035_ID => migration.checksum != MIGRATION_035_CHECKSUM,
         MIGRATION_036_ID => migration.checksum != MIGRATION_036_CHECKSUM,
         MIGRATION_037_ID => migration.checksum != MIGRATION_037_CHECKSUM,
+        MIGRATION_038_ID => migration.checksum != MIGRATION_038_CHECKSUM,
         _ => false,
     }
 }
@@ -1558,6 +1561,54 @@ pub(crate) fn apply_clone_subblock_postings_tables(conn: &Connection) -> rusqlit
     )?;
     Ok(())
 }
+
+/// V038 (memory-sync phase A1): the per-machine `repos` registry + per-repo `repo_meta` k/v store —
+/// the substrate the global-DB consolidation scopes every other table against. All greenfield,
+/// STRICT per repo convention.
+///
+/// The seed placeholder row (`repo_id = '__unassigned__'`, which MUST equal
+/// [`super::LEGACY_REPO_ID`]) marks a legacy single-repo DB awaiting adoption: the first
+/// post-migration open calls [`super::register_repo`], which rewrites the placeholder to the real
+/// content-derived `repo_id` in one step. A consolidated DB holding more than one repo never
+/// carries the placeholder — `register_repo` refuses to adopt when a different real id already
+/// owns the DB.
+///
+/// `repo_roots`/`repo_meta` carry an `ON DELETE CASCADE` FK to `repos` (NOT to a reindex-volatile
+/// parent), so the volatile-FK trip-wire does not flag them and they need no allowlist entry.
+///
+/// Idempotent: `CREATE TABLE IF NOT EXISTS` + `INSERT OR IGNORE` the placeholder, so a fresh DB
+/// (the full `apply` ladder) and a forward-migrated V037 index converge on the identical shape,
+/// and a re-run is a no-op.
+pub(crate) fn apply_repos_registry(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(REPOS_REGISTRY_DDL)
+}
+
+/// V038 DDL. The placeholder literal `'__unassigned__'` MUST equal [`super::LEGACY_REPO_ID`] —
+/// `super::register_repo` reads that constant when it adopts the row (a matching bootstrap test
+/// pins the two together).
+pub(crate) const REPOS_REGISTRY_DDL: &str = "
+    CREATE TABLE IF NOT EXISTS repos(
+        repo_id          TEXT PRIMARY KEY,
+        display_name     TEXT NOT NULL,
+        registered_at_ms INTEGER NOT NULL
+    ) STRICT;
+    CREATE TABLE IF NOT EXISTS repo_roots(
+        repo_id          TEXT NOT NULL REFERENCES repos(repo_id) ON DELETE CASCADE,
+        root             TEXT NOT NULL,
+        registered_at_ms INTEGER NOT NULL,
+        PRIMARY KEY(repo_id, root)
+    ) STRICT;
+    CREATE TABLE IF NOT EXISTS repo_meta(
+        repo_id TEXT NOT NULL REFERENCES repos(repo_id) ON DELETE CASCADE,
+        key     TEXT NOT NULL,
+        value   TEXT,
+        PRIMARY KEY(repo_id, key)
+    ) STRICT;
+    -- Adoption placeholder (MUST equal schema::LEGACY_REPO_ID). A legacy single-repo DB carries
+    -- exactly this one row until register_repo() rewrites it to the real content-derived repo_id.
+    INSERT OR IGNORE INTO repos(repo_id, display_name, registered_at_ms)
+        VALUES ('__unassigned__', '', 0);
+";
 
 /// V035: add `symbols.is_test` (cross-language test-code marker computed at parse time; see
 /// `parser::detect_is_test`) so clone detection can keep tests out of the corpus. Idempotent via

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1576,9 +1576,13 @@ pub(crate) fn apply_clone_subblock_postings_tables(conn: &Connection) -> rusqlit
 /// `repo_roots`/`repo_meta` carry an `ON DELETE CASCADE` FK to `repos` (NOT to a reindex-volatile
 /// parent), so the volatile-FK trip-wire does not flag them and they need no allowlist entry.
 ///
-/// Idempotent: `CREATE TABLE IF NOT EXISTS` + `INSERT OR IGNORE` the placeholder, so a fresh DB
-/// (the full `apply` ladder) and a forward-migrated V037 index converge on the identical shape,
-/// and a re-run is a no-op.
+/// Idempotent AND adoption-safe: `CREATE TABLE IF NOT EXISTS` + a placeholder seed guarded by "no
+/// real repo row exists yet". `schema::apply` re-runs every additive migration, and
+/// `IndexDatabase::rebuild` takes that path (via `create_or_migrate`) on an ALREADY-adopted DB — so
+/// the seed must not re-mint the placeholder after `register_repo` UPDATE'd its PK to the real id.
+/// A fresh DB (empty `repos`), a forward-migrated V037 index (empty `repos`), and a re-apply of an
+/// adopted DB (a real row present) all converge correctly: the first two seed the placeholder, the
+/// last leaves the real row untouched.
 pub(crate) fn apply_repos_registry(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(REPOS_REGISTRY_DDL)
 }
@@ -1606,8 +1610,17 @@ pub(crate) const REPOS_REGISTRY_DDL: &str = "
     ) STRICT;
     -- Adoption placeholder (MUST equal schema::LEGACY_REPO_ID). A legacy single-repo DB carries
     -- exactly this one row until register_repo() rewrites it to the real content-derived repo_id.
+    -- Seed ONLY when no real (non-placeholder) repo already owns the DB: schema::apply re-runs \
+                                             every
+    -- additive migration, and IndexDatabase::rebuild reaches it (via create_or_migrate) on an
+    -- ALREADY-adopted DB — where the placeholder's PK has been UPDATE'd to the real id, so a plain
+    -- INSERT OR IGNORE would find no conflict and resurrect the marker beside the real row. The
+    -- WHERE NOT EXISTS guard makes the seed a no-op once a real repo exists; INSERT OR IGNORE \
+                                             keeps
+    -- it idempotent when only the placeholder is present (fresh / forward-migrated re-apply).
     INSERT OR IGNORE INTO repos(repo_id, display_name, registered_at_ms)
-        VALUES ('__unassigned__', '', 0);
+        SELECT '__unassigned__', '', 0
+        WHERE NOT EXISTS (SELECT 1 FROM repos WHERE repo_id != '__unassigned__');
 ";
 
 /// V035: add `symbols.is_test` (cross-language test-code marker computed at parse time; see

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -1,11 +1,13 @@
 mod baseline;
 mod migrations;
+mod registry;
 pub(crate) use baseline::*;
 pub(crate) use migrations::*;
+pub use registry::{LEGACY_REPO_ID, register_repo};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 37;
+pub const LATEST_SCHEMA_VERSION: u32 = 38;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -237,6 +239,12 @@ const MIGRATION_037_DESCRIPTION: &str =
      generation-staged like clone_edges) + clone_graph_generations.postings_written so the \
      write-time clone check does a bounded indexed lookup instead of rebuilding the RAM index and \
      scales past the 40k guard (#296)";
+const MIGRATION_038_ID: &str = "038_repos_registry";
+const MIGRATION_038_CHECKSUM: &str = "sha256:rag-rat-repos-registry-v38";
+const MIGRATION_038_DESCRIPTION: &str =
+    "Add repos registry + repo_roots + repo_meta (per-machine repo identity registry and per-repo \
+     key/value store) with the __unassigned__ adoption placeholder — the substrate for the global \
+     consolidated database and repo_id scoping (memory-sync phase A)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -558,6 +566,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_037_CHECKSUM,
         description: MIGRATION_037_DESCRIPTION,
         apply: apply_clone_subblock_postings_tables,
+    },
+    Migration {
+        id: MIGRATION_038_ID,
+        checksum: MIGRATION_038_CHECKSUM,
+        description: MIGRATION_038_DESCRIPTION,
+        apply: apply_repos_registry,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema/registry.rs
+++ b/crates/rag-rat-core/src/index/schema/registry.rs
@@ -32,6 +32,21 @@ pub fn register_repo(
     root: &Path,
     now_ms: i64,
 ) -> rusqlite::Result<String> {
+    // Defense in depth: the resolver already refuses a pinned placeholder and never derives it, but
+    // a caller can hand-build a `RepoIdentity`. Registering the placeholder (or an empty/whitespace
+    // id) would degenerate adoption — `real_repo_ids` filters the marker, so the adoption UPDATE
+    // would rewrite the placeholder PK to itself, roots would pool under the marker, and this would
+    // return success while the DB stayed unadopted (a later real registration then trips the child
+    // FK or orphans roots under the marker).
+    let trimmed_id = identity.repo_id.trim();
+    if trimmed_id.is_empty() || trimmed_id == LEGACY_REPO_ID {
+        return Err(registry_refusal(format!(
+            "refusing to register the reserved or empty repo_id {:?}: `{LEGACY_REPO_ID}` is the \
+             pre-adoption placeholder and an empty id cannot scope rows",
+            identity.repo_id
+        )));
+    }
+
     let root = root.to_string_lossy();
     let real_ids = real_repo_ids(conn)?;
 
@@ -44,13 +59,10 @@ pub fn register_repo(
     // A different real repo already owns this DB — refuse rather than adopt (single-repo invariant
     // for phase A; multi-repo registration lands with the default-path flip).
     if let Some(other) = real_ids.first() {
-        return Err(rusqlite::Error::SqliteFailure(
-            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CONSTRAINT),
-            Some(format!(
-                "cannot register repo {}: this index is already registered to a different repo {}",
-                identity.repo_id, other
-            )),
-        ));
+        return Err(registry_refusal(format!(
+            "cannot register repo {}: this index is already registered to a different repo {}",
+            identity.repo_id, other
+        )));
     }
 
     // No real repo yet: adopt the placeholder in place, or insert fresh if it is somehow absent.
@@ -72,6 +84,17 @@ pub fn register_repo(
     }
     record_repo_root(conn, &identity.repo_id, &root, now_ms)?;
     Ok(identity.repo_id.clone())
+}
+
+/// A `SQLITE_CONSTRAINT` failure carrying `msg` — the registry's refusal shape. These are
+/// single-repo-invariant violations (a reserved/empty id, or a different repo already owning the
+/// DB), not real SQL constraint trips; the shape keeps them on `rusqlite::Result` without a bespoke
+/// error type for the phase-A registry.
+fn registry_refusal(msg: String) -> rusqlite::Error {
+    rusqlite::Error::SqliteFailure(
+        rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CONSTRAINT),
+        Some(msg),
+    )
 }
 
 /// Every registered `repo_id` that is a real (adopted) id — i.e. excluding the [`LEGACY_REPO_ID`]

--- a/crates/rag-rat-core/src/index/schema/registry.rs
+++ b/crates/rag-rat-core/src/index/schema/registry.rs
@@ -1,0 +1,99 @@
+use std::path::Path;
+
+use rusqlite::{Connection, OptionalExtension, params};
+
+use crate::repo_identity::RepoIdentity;
+
+/// The placeholder `repo_id` a freshly-migrated single-repo DB carries until it is adopted (see the
+/// V038 DDL) — and the backfill value every direct-scoped table gets when later migrations add
+/// `repo_id` columns (phase A3). A consolidated DB holding more than one repo NEVER carries this id
+/// (enforced by [`register_repo`]).
+pub const LEGACY_REPO_ID: &str = "__unassigned__";
+
+/// Register `identity` in this database's `repos`/`repo_roots` registry, returning the stored
+/// `repo_id`.
+///
+/// Idempotent and safe to call on every open:
+/// - **Fresh legacy DB** (only the [`LEGACY_REPO_ID`] placeholder row present) → *adoption*: the
+///   placeholder row is rewritten to `identity.repo_id` in place (A1 rewrites only `repos`; phase
+///   A3 extends adoption to every direct-scoped table once they gain `repo_id`). The working-tree
+///   `root` is recorded in `repo_roots`.
+/// - **Already this repo** → a no-op except that a not-yet-seen `root` is appended to `repo_roots`
+///   (worktrees of one repo share a `repo_id`, so several roots on one machine are expected).
+/// - **A different real repo_id already owns the DB** → refuses (returns an error) rather than
+///   corrupting a single-repo DB. Multi-repo registration is deliberately out of scope until the
+///   default-path flip (phase A7); until then one DB == one repo.
+///
+/// `now_ms` is the injected clock (see the repo's time-injection convention), stamped as the
+/// registration time on adoption / first insert.
+pub fn register_repo(
+    conn: &Connection,
+    identity: &RepoIdentity,
+    root: &Path,
+    now_ms: i64,
+) -> rusqlite::Result<String> {
+    let root = root.to_string_lossy();
+    let real_ids = real_repo_ids(conn)?;
+
+    // Already registered under this id → idempotent; just make sure the root is recorded.
+    if real_ids.iter().any(|id| id == &identity.repo_id) {
+        record_repo_root(conn, &identity.repo_id, &root, now_ms)?;
+        return Ok(identity.repo_id.clone());
+    }
+
+    // A different real repo already owns this DB — refuse rather than adopt (single-repo invariant
+    // for phase A; multi-repo registration lands with the default-path flip).
+    if let Some(other) = real_ids.first() {
+        return Err(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CONSTRAINT),
+            Some(format!(
+                "cannot register repo {}: this index is already registered to a different repo {}",
+                identity.repo_id, other
+            )),
+        ));
+    }
+
+    // No real repo yet: adopt the placeholder in place, or insert fresh if it is somehow absent.
+    let placeholder_present = conn
+        .query_row("SELECT 1 FROM repos WHERE repo_id = ?1", [LEGACY_REPO_ID], |_| Ok(()))
+        .optional()?
+        .is_some();
+    if placeholder_present {
+        conn.execute(
+            "UPDATE repos SET repo_id = ?1, display_name = ?2, registered_at_ms = ?3
+             WHERE repo_id = ?4",
+            params![identity.repo_id, identity.display_name, now_ms, LEGACY_REPO_ID],
+        )?;
+    } else {
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, ?2, ?3)",
+            params![identity.repo_id, identity.display_name, now_ms],
+        )?;
+    }
+    record_repo_root(conn, &identity.repo_id, &root, now_ms)?;
+    Ok(identity.repo_id.clone())
+}
+
+/// Every registered `repo_id` that is a real (adopted) id — i.e. excluding the [`LEGACY_REPO_ID`]
+/// placeholder. A single-repo DB returns at most one.
+fn real_repo_ids(conn: &Connection) -> rusqlite::Result<Vec<String>> {
+    let mut stmt =
+        conn.prepare("SELECT repo_id FROM repos WHERE repo_id != ?1 ORDER BY repo_id")?;
+    let ids = stmt.query_map([LEGACY_REPO_ID], |row| row.get::<_, String>(0))?;
+    ids.collect()
+}
+
+/// Append a working-tree root for `repo_id` (idempotent per `(repo_id, root)` — worktrees of one
+/// repo pool under the same id, so several roots are expected).
+fn record_repo_root(
+    conn: &Connection,
+    repo_id: &str,
+    root: &str,
+    now_ms: i64,
+) -> rusqlite::Result<()> {
+    conn.execute(
+        "INSERT OR IGNORE INTO repo_roots(repo_id, root, registered_at_ms) VALUES (?1, ?2, ?3)",
+        params![repo_id, root, now_ms],
+    )?;
+    Ok(())
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
@@ -214,11 +214,8 @@ fn migration_036_adds_content_addressed_embedding_cache() {
 fn migration_037_adds_content_anchored_clone_subblock_postings() {
     let conn = rusqlite::Connection::open_in_memory().expect("open");
     crate::index::schema::apply(&conn).expect("apply");
-    assert_eq!(
-        crate::index::schema::LATEST_SCHEMA_VERSION,
-        37,
-        "LATEST_SCHEMA_VERSION is 37 after V037"
-    );
+    // NB: V037 is no longer the schema tip (V038 added the repos registry), so this test no longer
+    // pins LATEST_SCHEMA_VERSION to an absolute number — that pin lives on the current-tip test.
 
     // The full ladder creates the postings table + the generation completeness column.
     assert!(
@@ -1068,6 +1065,7 @@ fn multi_language_clone_integration_finds_within_language_no_cross() {
     .unwrap();
 
     let config = Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![
@@ -1278,6 +1276,7 @@ fn find_clones_ranks_a_clean_clone_class_with_metrics() {
     .unwrap();
 
     let config = Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dir_memory_tree.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dir_memory_tree.rs
@@ -301,6 +301,7 @@ fn dir_tree_label_depth_collapse_single_child_chain() {
         fs::write(root.join("src/pkg/inner/deep").join(name), "pub fn f() {}\n").unwrap();
     }
     let config = Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
@@ -528,6 +529,7 @@ fn dir_tree_truncates_at_max_nodes() {
         fs::write(dir.join("lib.rs"), "pub fn f() {}\n").unwrap();
     }
     let config = Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
@@ -672,6 +674,7 @@ fn dir_tree_children_of_collapsed_node_use_leaf_labels() {
         fs::write(root.join("top/mid/y").join(name), "pub fn fy() {}\n").unwrap();
     }
     let config = Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/github_papertrail.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/github_papertrail.rs
@@ -293,6 +293,7 @@ fn parser_failures_report_paths() {
     fs::create_dir_all(&src).unwrap();
     fs::write(src.join("broken.rs"), "pub fn broken(").unwrap();
     let config = Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -68,6 +68,7 @@ fn git_history_targets() -> Vec<ResolvedTarget> {
 
 fn rag_rat_config(root: &Path) -> Config {
     Config {
+        repo_id_override: None,
         root: root.to_path_buf(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: git_history_targets(),
@@ -190,6 +191,7 @@ fn markdown_config(text: &str) -> (PathBuf, Config) {
 
 fn markdown_config_for_root(root: PathBuf) -> Config {
     Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
@@ -300,6 +302,7 @@ fn overlay_row_count(db: &IndexDatabase) -> i64 {
 
 fn source_config(root: PathBuf, language: Language) -> Config {
     Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
@@ -645,6 +648,7 @@ fn git_fixture_for_overlay_tests() -> (PathBuf, Config) {
     run_git(&root, &["add", "."]);
     run_git(&root, &["commit", "-m", "init"]);
     let config = Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
@@ -747,6 +751,7 @@ fn write_four_renamed_clones(root: &PathBuf) -> IndexDatabase {
         .unwrap();
     }
     let config = Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
@@ -799,6 +804,7 @@ mod graph_edges;
 mod orientation_healing;
 mod reconcile_embeddings;
 mod repo_memory;
+mod repo_registry;
 mod schema_migrations;
 mod symbol_search_lookup;
 mod worktree_overlay;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
@@ -154,6 +154,7 @@ fn clean_checkout_file_resolves_against_its_own_package_roots() {
     run_git(&root, &["commit", "-m", "init"]);
 
     let config = Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -800,6 +800,7 @@ fn git_history_indexes_commits_paths_queries_and_blame() {
     run_git(&root, &["commit", "-m", "Refresh beta docs"]);
 
     let config = Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -2048,6 +2048,7 @@ fn repo_brief_ranks_churn_and_god_module_candidates() {
     }
 
     let config = Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
@@ -2130,6 +2131,7 @@ fn repo_clusters_groups_cotouched_files() {
     }
 
     let config = Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -170,6 +170,56 @@ fn reapplying_schema_after_adoption_does_not_resurrect_the_placeholder() {
     assert_eq!(repo_row_count(&conn, "repo-abc"), 1, "the adopted repo survives the re-apply");
 }
 
+/// Defense in depth (FINDING 3): even though the resolver refuses a pinned placeholder, a
+/// hand-built `RepoIdentity` carrying the reserved marker must be REFUSED by `register_repo` —
+/// otherwise adoption degenerates: `real_repo_ids` filters the marker, the adoption UPDATE rewrites
+/// the placeholder PK to itself, roots pool under the marker, and registration reports success
+/// while the DB stays unadopted. The exact degenerate sequence: pin the marker → register → assert
+/// error, DB unchanged; then a real registration still adopts cleanly.
+#[test]
+fn register_repo_refuses_the_reserved_placeholder_and_stays_adoptable() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+
+    let err =
+        register_repo(&conn, &identity(LEGACY_REPO_ID, "myrepo"), Path::new("/src/myrepo"), 1)
+            .expect_err("registering the reserved placeholder must be refused");
+    assert!(err.to_string().contains(LEGACY_REPO_ID), "refusal names the reserved value: {err}");
+
+    // DB unchanged: exactly the placeholder row, no real repo, no root recorded under the marker.
+    assert_eq!(repo_row_count(&conn, LEGACY_REPO_ID), 1, "placeholder untouched");
+    let total: i64 = conn.query_row("SELECT COUNT(*) FROM repos", [], |r| r.get(0)).unwrap();
+    assert_eq!(total, 1, "no extra repos row minted");
+    let roots: i64 = conn.query_row("SELECT COUNT(*) FROM repo_roots", [], |r| r.get(0)).unwrap();
+    assert_eq!(roots, 0, "no root recorded under the marker");
+
+    // A subsequent REAL registration adopts cleanly (the failed attempt left nothing behind).
+    register_repo(&conn, &identity("repo-abc", "myrepo"), Path::new("/src/myrepo"), 2)
+        .expect("a real repo still adopts after the refused placeholder attempt");
+    assert_eq!(repo_row_count(&conn, LEGACY_REPO_ID), 0, "placeholder adopted away");
+    assert_eq!(repo_row_count(&conn, "repo-abc"), 1, "the real repo owns the DB");
+    assert_eq!(root_count(&conn, "repo-abc"), 1, "its root is recorded");
+}
+
+/// An empty or whitespace-only repo_id cannot scope rows, so `register_repo` refuses it (defense in
+/// depth alongside the reserved-marker guard) rather than adopting the placeholder under a blank
+/// id.
+#[test]
+fn register_repo_refuses_an_empty_or_whitespace_repo_id() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+
+    for blank in ["", "   "] {
+        let err = register_repo(&conn, &identity(blank, "myrepo"), Path::new("/src/myrepo"), 1)
+            .expect_err("an empty/whitespace repo_id must be refused");
+        assert!(err.to_string().contains("empty"), "refusal explains the empty id: {err}");
+    }
+    // Untouched: still just the placeholder, nothing minted by the refusals.
+    assert_eq!(repo_row_count(&conn, LEGACY_REPO_ID), 1, "placeholder untouched by refusals");
+    let total: i64 = conn.query_row("SELECT COUNT(*) FROM repos", [], |r| r.get(0)).unwrap();
+    assert_eq!(total, 1, "no rows minted by the refused blank registrations");
+}
+
 /// Re-registering the same repo+root is a no-op (no duplicate rows).
 #[test]
 fn register_repo_is_idempotent() {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -1,0 +1,193 @@
+//! V038 (memory-sync phase A): the `repos` / `repo_roots` / `repo_meta` registry + `register_repo`
+//! adoption. Bootstrap-migration coverage follows the directory conventions (fresh `apply`, forward
+//! path, deferred-absence anchored to the migration DDL in isolation — see the directory memory).
+
+use super::*;
+use crate::index::schema::{self, LEGACY_REPO_ID, register_repo};
+use crate::repo_identity::RepoIdentity;
+
+fn identity(repo_id: &str, display_name: &str) -> RepoIdentity {
+    RepoIdentity { repo_id: repo_id.to_string(), display_name: display_name.to_string() }
+}
+
+fn repo_row_count(conn: &rusqlite::Connection, repo_id: &str) -> i64 {
+    conn.query_row("SELECT COUNT(*) FROM repos WHERE repo_id = ?1", [repo_id], |r| r.get(0))
+        .unwrap()
+}
+
+fn root_count(conn: &rusqlite::Connection, repo_id: &str) -> i64 {
+    conn.query_row("SELECT COUNT(*) FROM repo_roots WHERE repo_id = ?1", [repo_id], |r| r.get(0))
+        .unwrap()
+}
+
+/// Fresh `apply` creates the three registry tables with their exact columns, STRICT, and seeds the
+/// single adoption placeholder whose id MUST equal `LEGACY_REPO_ID`. This is also the current
+/// schema-tip test, so it owns the absolute `LATEST_SCHEMA_VERSION` pin (V037's test relinquished
+/// it — see the hardcoded-LATEST footgun).
+#[test]
+fn migration_038_creates_repos_registry_tables() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 38, "V038 is the schema tip");
+
+    assert_eq!(conn_table_columns(&conn, "repos"), vec![
+        "repo_id",
+        "display_name",
+        "registered_at_ms"
+    ]);
+    assert_eq!(conn_table_columns(&conn, "repo_roots"), vec![
+        "repo_id",
+        "root",
+        "registered_at_ms"
+    ]);
+    assert_eq!(conn_table_columns(&conn, "repo_meta"), vec!["repo_id", "key", "value"]);
+
+    // STRICT on every new table (schema convention).
+    for table in ["repos", "repo_roots", "repo_meta"] {
+        let sql: String = conn
+            .query_row(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name=?1",
+                [table],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(sql.to_ascii_uppercase().contains("STRICT"), "{table} is STRICT: {sql}");
+    }
+
+    // Exactly the adoption placeholder, and its id is the LEGACY_REPO_ID constant (the DDL literal
+    // and the constant must stay coupled — register_repo reads the constant to adopt the row).
+    let repos: Vec<(String, String, i64)> = {
+        let mut stmt =
+            conn.prepare("SELECT repo_id, display_name, registered_at_ms FROM repos").unwrap();
+        stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect()
+    };
+    assert_eq!(repos, vec![(LEGACY_REPO_ID.to_string(), String::new(), 0)]);
+
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema is at LATEST after V038"
+    );
+}
+
+/// The V038 DDL is self-contained: it references only its own tables, so `apply_repos_registry`
+/// runs on a BARE connection (no baseline) and is exactly what introduces the registry. Anchoring
+/// this to the migration function (not the full ladder) keeps it valid when a future migration also
+/// touches these tables (the directory's "assert absence/DDL in isolation" rule).
+#[test]
+fn v038_registry_ddl_is_self_contained_and_introduces_the_registry() {
+    let bare = rusqlite::Connection::open_in_memory().expect("open");
+    assert!(!conn_table_exists(&bare, "repos"), "no registry before the migration runs");
+
+    schema::apply_repos_registry(&bare).expect("V038 DDL applies standalone on a bare conn");
+
+    for table in ["repos", "repo_roots", "repo_meta"] {
+        assert!(conn_table_exists(&bare, table), "V038 creates {table}");
+    }
+    assert_eq!(repo_row_count(&bare, LEGACY_REPO_ID), 1, "seeds the adoption placeholder");
+}
+
+/// A V037 index gains the registry on `migrate_forward`.
+#[test]
+fn migration_038_forward_migrates_a_v037_index() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+
+    // Revert to the V037 shape: drop children before the parent (FK), then drop the ledger row.
+    conn.execute_batch("DROP TABLE repo_meta; DROP TABLE repo_roots; DROP TABLE repos;")
+        .expect("revert to V037 shape");
+    truncate_schema_to(&conn, 37);
+    assert_eq!(
+        schema::status(&conn).unwrap().state,
+        schema::SchemaState::Older,
+        "schema is Older after removing the V038 ledger row"
+    );
+
+    schema::migrate_forward(&conn).expect("migrate_forward");
+    for table in ["repos", "repo_roots", "repo_meta"] {
+        assert!(conn_table_exists(&conn, table), "V038 recreates {table} on forward migrate");
+    }
+    assert_eq!(repo_row_count(&conn, LEGACY_REPO_ID), 1, "placeholder re-seeded");
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema is at LATEST after forward migrate"
+    );
+}
+
+/// Fresh registration ADOPTS the placeholder in place: the `__unassigned__` row becomes the real
+/// repo, no placeholder remains, and the working-tree root is recorded.
+#[test]
+fn register_repo_adopts_the_placeholder() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+
+    let returned =
+        register_repo(&conn, &identity("repo-abc", "myrepo"), Path::new("/src/myrepo"), 123)
+            .expect("register");
+    assert_eq!(returned, "repo-abc");
+
+    assert_eq!(repo_row_count(&conn, LEGACY_REPO_ID), 0, "placeholder is gone after adoption");
+    let (display, at_ms): (String, i64) = conn
+        .query_row(
+            "SELECT display_name, registered_at_ms FROM repos WHERE repo_id=?1",
+            ["repo-abc"],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(display, "myrepo");
+    assert_eq!(at_ms, 123, "adoption stamps the injected now_ms");
+
+    let root: String = conn
+        .query_row("SELECT root FROM repo_roots WHERE repo_id=?1", ["repo-abc"], |r| r.get(0))
+        .unwrap();
+    assert_eq!(root, "/src/myrepo");
+}
+
+/// Re-registering the same repo+root is a no-op (no duplicate rows).
+#[test]
+fn register_repo_is_idempotent() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    let id = identity("repo-abc", "myrepo");
+
+    register_repo(&conn, &id, Path::new("/src/myrepo"), 1).unwrap();
+    register_repo(&conn, &id, Path::new("/src/myrepo"), 2).unwrap();
+
+    assert_eq!(repo_row_count(&conn, "repo-abc"), 1);
+    assert_eq!(root_count(&conn, "repo-abc"), 1, "same root is not duplicated");
+}
+
+/// A second root path for the SAME repo (a worktree/clone on the same machine) appends a
+/// `repo_roots` row without minting a new repo.
+#[test]
+fn register_repo_appends_a_second_root() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    let id = identity("repo-abc", "myrepo");
+
+    register_repo(&conn, &id, Path::new("/src/myrepo"), 1).unwrap();
+    register_repo(&conn, &id, Path::new("/src/myrepo-worktree"), 2).unwrap();
+
+    assert_eq!(repo_row_count(&conn, "repo-abc"), 1, "still one repo");
+    assert_eq!(root_count(&conn, "repo-abc"), 2, "both roots recorded");
+}
+
+/// Once a real repo owns the DB, registering a DIFFERENT real repo is REFUSED (the single-repo
+/// invariant for phase A — multi-repo registration lands with the default-path flip).
+#[test]
+fn register_repo_refuses_a_different_real_repo() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    register_repo(&conn, &identity("repo-abc", "a"), Path::new("/src/a"), 1).unwrap();
+
+    let err = register_repo(&conn, &identity("repo-xyz", "b"), Path::new("/src/b"), 2)
+        .expect_err("a different real repo must be refused");
+    assert!(err.to_string().contains("repo-abc"), "refusal names the incumbent repo: {err}");
+    // The incumbent is untouched; the intruder never landed.
+    assert_eq!(repo_row_count(&conn, "repo-abc"), 1);
+    assert_eq!(repo_row_count(&conn, "repo-xyz"), 0);
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -147,6 +147,29 @@ fn register_repo_adopts_the_placeholder() {
     assert_eq!(root, "/src/myrepo");
 }
 
+/// Re-applying the full schema AFTER adoption must NOT resurrect the `__unassigned__` placeholder.
+/// `schema::apply` re-runs every additive migration (this is the exact path
+/// `IndexDatabase::rebuild` takes via `create_or_migrate` on an already-migrated DB), so the V038
+/// seed is conditional on "no real repo row yet". An unconditional `INSERT OR IGNORE` would re-mint
+/// the placeholder after adoption UPDATE'd its PK away — leaving both the real repo and the legacy
+/// marker. A3 extends adoption to more direct-scoped tables, so this invariant has to hold before
+/// then.
+#[test]
+fn reapplying_schema_after_adoption_does_not_resurrect_the_placeholder() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    register_repo(&conn, &identity("repo-abc", "myrepo"), Path::new("/src/myrepo"), 1).unwrap();
+    assert_eq!(repo_row_count(&conn, LEGACY_REPO_ID), 0, "adopted: placeholder gone");
+
+    // The exact re-run `create_or_migrate` (hence `rebuild`) performs on an existing index.
+    schema::apply(&conn).expect("re-apply is idempotent on an already-migrated DB");
+
+    assert_eq!(repo_row_count(&conn, LEGACY_REPO_ID), 0, "placeholder must NOT reappear");
+    let total: i64 = conn.query_row("SELECT COUNT(*) FROM repos", [], |r| r.get(0)).unwrap();
+    assert_eq!(total, 1, "exactly one repos row (the real one) remains");
+    assert_eq!(repo_row_count(&conn, "repo-abc"), 1, "the adopted repo survives the re-apply");
+}
+
 /// Re-registering the same repo+root is a no-op (no duplicate rows).
 #[test]
 fn register_repo_is_idempotent() {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -8,6 +8,7 @@ fn rebuild_bootstraps_sqlite_schema_for_empty_target_root() {
     fs::create_dir_all(&docs).unwrap();
 
     let config = Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
@@ -521,6 +521,7 @@ DEVICE_DT_INST_DEFINE(0, entropy_init, NULL, NULL, NULL,
     )
     .unwrap();
     let config = Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
@@ -1293,6 +1294,7 @@ where
     )
     .unwrap();
     let config = Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![

--- a/crates/rag-rat-core/src/lib.rs
+++ b/crates/rag-rat-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod data_dir;
 pub mod dream;
 pub mod embedding_models;
 #[cfg(feature = "eval")]
@@ -10,6 +11,7 @@ pub mod locks;
 pub mod logging;
 pub mod output;
 pub mod query;
+pub mod repo_identity;
 pub mod search;
 pub mod serde_big_id;
 pub mod storage;

--- a/crates/rag-rat-core/src/logging/mod.rs
+++ b/crates/rag-rat-core/src/logging/mod.rs
@@ -129,6 +129,7 @@ mod tests {
 
     fn test_config(dir: &std::path::Path, enabled: bool) -> Config {
         Config {
+            repo_id_override: None,
             root: dir.to_path_buf(),
             database: dir.join(".rag-rat/index.sqlite"),
             targets: Vec::new(),

--- a/crates/rag-rat-core/src/repo_identity.rs
+++ b/crates/rag-rat-core/src/repo_identity.rs
@@ -5,9 +5,8 @@
 
 use std::path::Path;
 
-use anyhow::Context;
-
 /// A repo's identity for the registry: the scoping key + a human label.
+#[derive(Debug, Clone)]
 pub struct RepoIdentity {
     /// Machine-stable, content-derived (root-commit hash) unless pinned via `rag-rat.toml`. Never
     /// derived from the on-disk path.
@@ -25,10 +24,12 @@ pub struct RepoIdentity {
 ///
 /// `override_id` (from `rag-rat.toml`'s `[index] repo_id`) wins outright when set and non-empty —
 /// the escape hatch for forks that must NOT share identity with their upstream, and for pinning an
-/// id on a repo that has no commits yet.
+/// id on a repo whose root is unreachable (an empty repo, or a shallow clone that cut history).
 ///
-/// Errors when the directory is not a git repository, has no commits (unborn HEAD), or has no
-/// reachable root commit — and no override was supplied.
+/// Errors — each with an actionable remedy — when no override was supplied and the id cannot be
+/// derived: the directory is not a git repository, the repo has no commits (unborn HEAD), or its
+/// history is a cut shallow clone (the root is unreachable, so any derived id would depend on clone
+/// depth and split identity across machines).
 pub fn resolve_repo_identity(
     root: &Path,
     override_id: Option<&str>,
@@ -47,23 +48,67 @@ pub fn resolve_repo_identity(
 /// The lexicographically smallest hash among the parentless commits reachable from HEAD. Mirrors
 /// the git-history walk (`index::git_history`): discover the repo, resolve HEAD, `rev_walk`, and
 /// keep the commits whose first parent is absent.
+///
+/// Refuses (with an actionable error) when no parentless root is reachable — the exact signature of
+/// a shallow clone that CUT history: gix reads parents from the commit object and does not apply
+/// shallow grafts, so the boundary commit reports parents whose objects are absent (never a root),
+/// while the walk itself honors the boundary and yields no true root. Deriving an id from that
+/// boundary would make identity depend on clone depth, so we reject rather than mint a
+/// depth-varying id. A shallow clone whose depth COVERS the whole history keeps its true root
+/// reachable and resolves normally — hence the "no reachable root" signal rather than
+/// `repo.is_shallow()` alone, which is also set for those fully-present clones.
 fn smallest_root_commit(root: &Path) -> anyhow::Result<String> {
     let repo = crate::index::discover_repo(root)?;
-    // Fails on a non-git dir (already handled above) and on an unborn HEAD (empty repo).
-    let head_id = repo.head_id().context("repository has no commits (unborn HEAD)")?.detach();
+    // Unborn HEAD (`git init` with no commits) has no history to derive an id from.
+    let Ok(head) = repo.head_id() else {
+        anyhow::bail!(empty_repo_error(root));
+    };
+    let head_id = head.detach();
 
     let mut roots: Vec<String> = Vec::new();
     for info in repo.rev_walk([head_id]).all()? {
         let info = info?;
         let commit = repo.find_commit(info.id)?;
         // A root commit has no parents; `parent_ids().next().is_none()` is the same predicate the
-        // history walk uses to detect roots / shallow boundaries.
+        // history walk uses to detect roots. A cut shallow boundary reports (absent) parents, so it
+        // is deliberately NOT counted here.
         if commit.parent_ids().next().is_none() {
             roots.push(info.id.to_hex().to_string());
         }
     }
     roots.sort();
-    roots.into_iter().next().context("repository history has no root commit")
+    if let Some(smallest) = roots.into_iter().next() {
+        return Ok(smallest);
+    }
+
+    // No reachable parentless root: a cut shallow clone (the common case) or a corrupt object
+    // graph.
+    if repo.is_shallow() {
+        anyhow::bail!(shallow_clone_error(root));
+    }
+    anyhow::bail!("repository at {} has no reachable root commit", root.display());
+}
+
+/// The remedy-naming error for a shallow clone that cut history: identity would depend on clone
+/// depth, so refuse and point at the two fixes (unshallow, or pin the id).
+fn shallow_clone_error(root: &Path) -> String {
+    format!(
+        "cannot derive a stable repo_id from the shallow clone at {}: its history is cut, so the \
+         root commit is unreachable and any derived id would depend on clone depth (splitting \
+         this repo's identity across machines). Run `git fetch --unshallow`, or pin `[index] \
+         repo_id = \"…\"` in rag-rat.toml.",
+        root.display()
+    )
+}
+
+/// The remedy-naming error for an empty repo (unborn HEAD): there is no commit graph to derive
+/// from.
+fn empty_repo_error(root: &Path) -> String {
+    format!(
+        "cannot derive a repo_id: the repository at {} has no commits (unborn HEAD). Make a \
+         commit, or pin `[index] repo_id = \"…\"` in rag-rat.toml.",
+        root.display()
+    )
 }
 
 #[cfg(test)]
@@ -160,6 +205,84 @@ mod tests {
         // An empty/whitespace override falls through to the derived id.
         let blank = resolve_repo_identity(&root, Some("   ")).unwrap();
         assert_eq!(blank.repo_id, derived);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// Build an origin repo with `commits` empty commits under `base/origin`, then a `--depth`
+    /// clone of it at `base/<dest>`. Returns `(clone_root, origin_root_hash)`.
+    fn shallow_clone(base: &Path, commits: usize, depth: usize, dest: &str) -> (PathBuf, String) {
+        let origin = base.join("origin");
+        std::fs::create_dir_all(&origin).unwrap();
+        init_repo(&origin);
+        for i in 0..commits {
+            git(&origin, &["commit", "--allow-empty", "-q", "-m", &format!("c{i}")]);
+        }
+        let origin_root = root_hashes(&origin).remove(0);
+        let url = format!("file://{}", origin.display());
+        git(base, &["clone", "-q", "--depth", &depth.to_string(), &url, dest]);
+        (base.join(dest), origin_root)
+    }
+
+    /// A genuinely-cut shallow clone (`--depth` < history) has no reachable parentless root: the
+    /// boundary commit records parents whose objects are absent. Deriving an id from the boundary
+    /// would make identity depend on clone depth and split it across machines — so it is REFUSED,
+    /// with an error naming both remedies (`git fetch --unshallow` or a pinned `repo_id`).
+    #[test]
+    fn shallow_clone_that_cuts_history_is_refused_with_an_actionable_error() {
+        let base = temp_root();
+        let (shallow, _origin_root) = shallow_clone(&base, 5, 1, "shallow");
+        // Sanity: the fixture is really a shallow clone that cut history.
+        assert!(crate::index::discover_repo(&shallow).unwrap().is_shallow());
+
+        let err = resolve_repo_identity(&shallow, None)
+            .expect_err("a depth-cut shallow clone must not derive a depth-dependent id");
+        let msg = err.to_string();
+        assert!(msg.contains("shallow"), "error names the cause: {msg}");
+        assert!(msg.contains("git fetch --unshallow"), "error names the unshallow remedy: {msg}");
+        assert!(msg.contains("repo_id"), "error names the pin remedy: {msg}");
+
+        // The override escape hatch still lets a shallow clone be pinned deterministically.
+        let pinned = resolve_repo_identity(&shallow, Some("pinned-shallow")).unwrap();
+        assert_eq!(pinned.repo_id, "pinned-shallow");
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    /// A clone flagged shallow whose `--depth` COVERS the whole history is NOT depth-dependent: the
+    /// boundary commit IS the true root (all its ancestors are present), so identity resolves to
+    /// the real root hash and matches the origin. `is_shallow()` alone would wrongly reject
+    /// this; the "no reachable parentless root" signal correctly accepts it.
+    #[test]
+    fn shallow_clone_covering_full_history_resolves_the_real_root() {
+        let base = temp_root();
+        // depth == commit count: git still writes `.git/shallow`, but nothing is actually cut.
+        let (shallow, origin_root) = shallow_clone(&base, 5, 5, "shallow");
+        assert!(
+            crate::index::discover_repo(&shallow).unwrap().is_shallow(),
+            "git flags a depth-exact clone shallow"
+        );
+
+        let identity = resolve_repo_identity(&shallow, None)
+            .expect("full history present → the real root is reachable");
+        assert_eq!(identity.repo_id, origin_root, "id is the real root, depth-independent");
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    /// An empty repo (`git init`, unborn HEAD, zero commits) cannot derive an id; the error names
+    /// the remedy (pin a `repo_id`) instead of surfacing a raw gix "unborn HEAD" error.
+    #[test]
+    fn empty_repo_without_override_is_an_actionable_error() {
+        let root = temp_root();
+        init_repo(&root); // git init, but no commits
+
+        let err = resolve_repo_identity(&root, None)
+            .expect_err("an empty repo has no commit graph to derive an id from");
+        let msg = err.to_string();
+        assert!(msg.contains("no commits"), "error names the cause: {msg}");
+        assert!(msg.contains("repo_id"), "error names the pin remedy: {msg}");
+
+        // A pin still lets an empty repo be registered.
+        let pinned = resolve_repo_identity(&root, Some("pinned-empty")).unwrap();
+        assert_eq!(pinned.repo_id, "pinned-empty");
         std::fs::remove_dir_all(&root).ok();
     }
 

--- a/crates/rag-rat-core/src/repo_identity.rs
+++ b/crates/rag-rat-core/src/repo_identity.rs
@@ -5,6 +5,8 @@
 
 use std::path::Path;
 
+use crate::index::schema::LEGACY_REPO_ID;
+
 /// A repo's identity for the registry: the scoping key + a human label.
 #[derive(Debug, Clone)]
 pub struct RepoIdentity {
@@ -38,11 +40,30 @@ pub fn resolve_repo_identity(
         root.file_name().map(|name| name.to_string_lossy().into_owned()).unwrap_or_default();
 
     if let Some(id) = override_id.map(str::trim).filter(|id| !id.is_empty()) {
+        // The placeholder marker is reserved for a pre-adoption single-repo DB; pinning it would
+        // degenerate registry adoption (see `register_repo`). Refuse with a remedy-naming error
+        // rather than mint an identity that can never be adopted.
+        if id == LEGACY_REPO_ID {
+            anyhow::bail!(reserved_repo_id_error());
+        }
         return Ok(RepoIdentity { repo_id: id.to_string(), display_name });
     }
 
     let repo_id = smallest_root_commit(root)?;
     Ok(RepoIdentity { repo_id, display_name })
+}
+
+/// The remedy-naming error for pinning the reserved placeholder id: it marks a pre-adoption
+/// single-repo DB, so adopting under it would rewrite the placeholder PK to itself and leave the DB
+/// unadopted while reporting success (see [`register_repo`]).
+///
+/// [`register_repo`]: crate::index::schema::register_repo
+fn reserved_repo_id_error() -> String {
+    format!(
+        "`{LEGACY_REPO_ID}` is a reserved repo_id (the pre-adoption placeholder marker) and \
+         cannot be pinned via `[index] repo_id` in rag-rat.toml. Choose a different stable \
+         string, or omit the override to derive the id from the root commit."
+    )
 }
 
 /// The lexicographically smallest hash among the parentless commits reachable from HEAD. Mirrors
@@ -205,6 +226,30 @@ mod tests {
         // An empty/whitespace override falls through to the derived id.
         let blank = resolve_repo_identity(&root, Some("   ")).unwrap();
         assert_eq!(blank.repo_id, derived);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// The pre-adoption placeholder marker ([`LEGACY_REPO_ID`]) is a RESERVED repo_id: pinning it
+    /// via `[index] repo_id` would degenerate registry adoption (the adoption UPDATE rewrites the
+    /// placeholder PK to itself, leaving the DB unadopted while reporting success). The resolver
+    /// refuses it — before and after trimming — with an error naming the reserved value.
+    #[test]
+    fn override_equal_to_the_reserved_placeholder_is_refused() {
+        let root = temp_root();
+        init_repo(&root);
+        git(&root, &["commit", "--allow-empty", "-q", "-m", "genesis"]);
+
+        let err = resolve_repo_identity(&root, Some(LEGACY_REPO_ID))
+            .expect_err("the reserved placeholder id must not be pinnable");
+        let msg = err.to_string();
+        assert!(msg.contains(LEGACY_REPO_ID), "error names the reserved value: {msg}");
+        assert!(msg.contains("reserved"), "error explains it is reserved: {msg}");
+
+        // Whitespace padding must not sneak the marker past the trim.
+        let padded = format!("  {LEGACY_REPO_ID}  ");
+        let err_padded = resolve_repo_identity(&root, Some(&padded))
+            .expect_err("the trimmed reserved id is still refused");
+        assert!(err_padded.to_string().contains("reserved"), "{err_padded}");
         std::fs::remove_dir_all(&root).ok();
     }
 

--- a/crates/rag-rat-core/src/repo_identity.rs
+++ b/crates/rag-rat-core/src/repo_identity.rs
@@ -1,0 +1,176 @@
+//! Machine-stable repo identity: a content-derived `repo_id` (the repo's root-commit hash) plus a
+//! cosmetic display name. This id is what the consolidated global database scopes every repo's
+//! rows and memories by (memory-sync phase A). It is deliberately derived from the commit graph,
+//! not the on-disk path, so worktrees, clones, and re-clones of the same repo share one identity.
+
+use std::path::Path;
+
+use anyhow::Context;
+
+/// A repo's identity for the registry: the scoping key + a human label.
+pub struct RepoIdentity {
+    /// Machine-stable, content-derived (root-commit hash) unless pinned via `rag-rat.toml`. Never
+    /// derived from the on-disk path.
+    pub repo_id: String,
+    /// The working-tree directory name — cosmetic only, never an identity input.
+    pub display_name: String,
+}
+
+/// Resolve a repo's identity from its working tree at `root`.
+///
+/// The default `repo_id` is the **lexicographically smallest root-commit hash** reachable from
+/// HEAD. A linear history has exactly one root (parentless) commit; a history stitched from
+/// several orphan branches has several, and choosing the smallest by byte order makes the id
+/// deterministic across machines regardless of which root the walk reaches first.
+///
+/// `override_id` (from `rag-rat.toml`'s `[index] repo_id`) wins outright when set and non-empty —
+/// the escape hatch for forks that must NOT share identity with their upstream, and for pinning an
+/// id on a repo that has no commits yet.
+///
+/// Errors when the directory is not a git repository, has no commits (unborn HEAD), or has no
+/// reachable root commit — and no override was supplied.
+pub fn resolve_repo_identity(
+    root: &Path,
+    override_id: Option<&str>,
+) -> anyhow::Result<RepoIdentity> {
+    let display_name =
+        root.file_name().map(|name| name.to_string_lossy().into_owned()).unwrap_or_default();
+
+    if let Some(id) = override_id.map(str::trim).filter(|id| !id.is_empty()) {
+        return Ok(RepoIdentity { repo_id: id.to_string(), display_name });
+    }
+
+    let repo_id = smallest_root_commit(root)?;
+    Ok(RepoIdentity { repo_id, display_name })
+}
+
+/// The lexicographically smallest hash among the parentless commits reachable from HEAD. Mirrors
+/// the git-history walk (`index::git_history`): discover the repo, resolve HEAD, `rev_walk`, and
+/// keep the commits whose first parent is absent.
+fn smallest_root_commit(root: &Path) -> anyhow::Result<String> {
+    let repo = crate::index::discover_repo(root)?;
+    // Fails on a non-git dir (already handled above) and on an unborn HEAD (empty repo).
+    let head_id = repo.head_id().context("repository has no commits (unborn HEAD)")?.detach();
+
+    let mut roots: Vec<String> = Vec::new();
+    for info in repo.rev_walk([head_id]).all()? {
+        let info = info?;
+        let commit = repo.find_commit(info.id)?;
+        // A root commit has no parents; `parent_ids().next().is_none()` is the same predicate the
+        // history walk uses to detect roots / shallow boundaries.
+        if commit.parent_ids().next().is_none() {
+            roots.push(info.id.to_hex().to_string());
+        }
+    }
+    roots.sort();
+    roots.into_iter().next().context("repository history has no root commit")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_root() -> PathBuf {
+        let mut root = std::env::temp_dir();
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        root.push(format!("rag-rat-repo-identity-{}-{n}", std::process::id()));
+        std::fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    fn git(root: &Path, args: &[&str]) {
+        let out = Command::new("git").args(args).current_dir(root).output().unwrap();
+        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+    }
+
+    fn git_out(root: &Path, args: &[&str]) -> String {
+        let out = Command::new("git").args(args).current_dir(root).output().unwrap();
+        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        String::from_utf8(out.stdout).unwrap().trim().to_string()
+    }
+
+    fn init_repo(root: &Path) {
+        git(root, &["init", "-q", "-b", "main"]);
+        git(root, &["config", "user.email", "t@e"]);
+        git(root, &["config", "user.name", "t"]);
+    }
+
+    /// All root (parentless) commit hashes reachable from HEAD, sorted — the ground truth the
+    /// resolver's "smallest root commit" must agree with, computed independently via git.
+    fn root_hashes(root: &Path) -> Vec<String> {
+        let mut hashes: Vec<String> = git_out(root, &["rev-list", "--max-parents=0", "HEAD"])
+            .lines()
+            .map(str::to_string)
+            .collect();
+        hashes.sort();
+        hashes
+    }
+
+    #[test]
+    fn single_root_repo_resolves_to_its_root_commit() {
+        let root = temp_root();
+        init_repo(&root);
+        git(&root, &["commit", "--allow-empty", "-q", "-m", "genesis"]);
+
+        let expected = root_hashes(&root);
+        assert_eq!(expected.len(), 1, "a linear history has exactly one root");
+
+        let identity = resolve_repo_identity(&root, None).unwrap();
+        assert_eq!(identity.repo_id, expected[0]);
+        assert_eq!(identity.display_name, root.file_name().unwrap().to_string_lossy());
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn multi_root_history_resolves_to_lexicographically_smallest() {
+        let root = temp_root();
+        init_repo(&root);
+        // Root A on main, then an unrelated orphan root B, then merge so HEAD reaches BOTH.
+        git(&root, &["commit", "--allow-empty", "-q", "-m", "root-a"]);
+        git(&root, &["checkout", "-q", "--orphan", "orphan-b"]);
+        git(&root, &["commit", "--allow-empty", "-q", "-m", "root-b"]);
+        git(&root, &["checkout", "-q", "main"]);
+        git(&root, &["merge", "-q", "--allow-unrelated-histories", "--no-edit", "orphan-b"]);
+
+        let roots = root_hashes(&root);
+        assert_eq!(roots.len(), 2, "merged orphan histories give two roots");
+
+        let identity = resolve_repo_identity(&root, None).unwrap();
+        assert_eq!(identity.repo_id, roots[0], "smallest root hash by byte order wins");
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn override_wins_over_derived_id() {
+        let root = temp_root();
+        init_repo(&root);
+        git(&root, &["commit", "--allow-empty", "-q", "-m", "genesis"]);
+        let derived = root_hashes(&root).remove(0);
+
+        let identity = resolve_repo_identity(&root, Some("  pinned-id  ")).unwrap();
+        assert_eq!(identity.repo_id, "pinned-id", "override is trimmed and wins");
+        assert_ne!(identity.repo_id, derived);
+
+        // An empty/whitespace override falls through to the derived id.
+        let blank = resolve_repo_identity(&root, Some("   ")).unwrap();
+        assert_eq!(blank.repo_id, derived);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn non_git_dir_without_override_is_an_error() {
+        let root = temp_root(); // created, but never `git init`ed
+        assert!(resolve_repo_identity(&root, None).is_err());
+        // ...but an override lets a non-git dir resolve (a repo with no commits can still be
+        // pinned).
+        let identity = resolve_repo_identity(&root, Some("pinned")).unwrap();
+        assert_eq!(identity.repo_id, "pinned");
+        std::fs::remove_dir_all(&root).ok();
+    }
+}

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -838,6 +838,7 @@ mod tests {
     /// `&Config` for the under-a-target gate, #332).
     fn whole_root_config(root: &Path, target_dirs: &[PathBuf]) -> Config {
         Config {
+            repo_id_override: None,
             root: root.to_path_buf(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
@@ -860,6 +861,7 @@ mod tests {
     #[test]
     fn event_touches_worktree_matches_checkout_targets_and_registry() {
         let config = Config {
+            repo_id_override: None,
             root: PathBuf::from("/main"),
             database: PathBuf::from("/main/.rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
@@ -957,6 +959,7 @@ mod tests {
         // `config.root` is the `crate` SUBDIR of the repo.
         let config_root = repo.join("crate").canonicalize().unwrap();
         let config = Config {
+            repo_id_override: None,
             root: config_root,
             database: repo.join("crate/.rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
@@ -1001,6 +1004,7 @@ mod tests {
         std::fs::write(root.join(".gitignore"), "gen/\n").unwrap();
 
         let config = Config {
+            repo_id_override: None,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
@@ -1063,6 +1067,7 @@ mod tests {
         std::fs::write(root.join(".gitignore"), "").unwrap();
 
         let config = Config {
+            repo_id_override: None,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
@@ -1136,6 +1141,7 @@ mod tests {
         let sub = wt.join("crates"); // config.root is the subdirectory.
         let target_dirs = vec![PathBuf::from(".")];
         let config = Config {
+            repo_id_override: None,
             root: sub.clone(),
             database: sub.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
@@ -1281,6 +1287,7 @@ mod tests {
 
         let sub = main.join("crate").canonicalize().unwrap(); // config.root is the subdir.
         let config = Config {
+            repo_id_override: None,
             root: sub.clone(),
             database: sub.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
@@ -1543,6 +1550,7 @@ mod tests {
         std::fs::create_dir_all(root.join("src")).unwrap();
         let root = root.canonicalize().unwrap();
         let config = Config {
+            repo_id_override: None,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -267,6 +267,7 @@ mod tests {
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/lib.rs"), "pub fn open_database() {}\n").unwrap();
         let config = Config {
+            repo_id_override: None,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -863,6 +863,7 @@ fn mixed_config() -> (PathBuf, Config) {
     fs::write(root.join("docs/search.md"), "# Title\nalpha token\n").unwrap();
     fs::write(root.join("src/lib.rs"), "pub fn alpha_symbol() {}\n").unwrap();
     (root.clone(), Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![
@@ -897,6 +898,7 @@ fn markdown_config(text: &str) -> (PathBuf, Config) {
     fs::create_dir_all(root.join("docs")).unwrap();
     fs::write(root.join("docs/search.md"), text).unwrap();
     (root.clone(), Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
@@ -918,6 +920,7 @@ fn markdown_config(text: &str) -> (PathBuf, Config) {
 
 fn rust_config(root: PathBuf) -> Config {
     Config {
+        repo_id_override: None,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {


### PR DESCRIPTION
Foundation step of the global-DB consolidation (#396, milestone "Memory durability & p2p sync").

- **V038**: `repos` / `repo_roots` / `repo_meta` (all STRICT), with a `__unassigned__` placeholder row marking a legacy single-repo DB awaiting adoption. Idempotent DDL, checksum-registered like every migration.
- **`repo_identity`**: `resolve_repo_identity` derives the stable repo id as the lexicographically smallest root-commit hash (deterministic for multi-root histories); a new `[index] repo_id` override in rag-rat.toml wins when set (parse-only in this PR — nothing consumes it yet).
- **`register_repo`** (`schema/registry.rs`): idempotent registration; adopts a legacy DB by rewriting the placeholder; refuses adoption when a different real repo id is already present (multi-repo DBs arrive later in the sequence).
- **`data_dir`**: `RAG_RAT_DATA_DIR` → `$XDG_DATA_HOME/rag-rat` → `~/.local/share/rag-rat` (Windows `%APPDATA%`), plus `global_database_path()`. No repo-relative fallback — callers decide.
- **No behavior change**: the default database path is untouched; every `Config` literal gains `repo_id_override: None` mechanically.

Tests: V038 bootstrap (exact columns, forward-migration from V037, DDL-in-isolation deferred-absence), identity resolution (single root / multi-root / override / non-git), env-cascade for `data_dir` (mutex-serialized), `register_repo` adoption/idempotence/refusal, config parse. Workspace suite 1406 passed; clippy `-D warnings` clean.

Fixes #396