### PR TITLE
chore: release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.12.0...rag-rat-core-v0.13.0) - 2026-07-05
+
+### Added
+
+- *(dream)* human review surface — dream <id> --accept|--dismiss|--reset ([#262](https://github.com/cq27-dev/rag-rat/pull/262)) ([#440](https://github.com/cq27-dev/rag-rat/pull/440))
+- *(dream)* run the verdict/compaction model on an ephemeral remote GPU (`[llm.dream.remote]`) ([#438](https://github.com/cq27-dev/rag-rat/pull/438))
+- *(dream)* v2 memory passes — reality verdicts + compact summaries ([#428](https://github.com/cq27-dev/rag-rat/pull/428))
+- *(index)* global database by default, rag-rat consolidate importer ([#402](https://github.com/cq27-dev/rag-rat/pull/402)) ([#419](https://github.com/cq27-dev/rag-rat/pull/419))
+- *(index)* generation-staged full rebuild, per-repo write locks (V043) ([#416](https://github.com/cq27-dev/rag-rat/pull/416))
+- *(index)* repo-scoped clones, oracle, reconcile, memories (V042) ([#415](https://github.com/cq27-dev/rag-rat/pull/415))
+- *(search)* repo-scoped FTS and papertrail queries (V041) ([#414](https://github.com/cq27-dev/rag-rat/pull/414))
+- *(index)* V040 — repo_id scoping on core tables, scope view, gc (#398 phase A3) ([#413](https://github.com/cq27-dev/rag-rat/pull/413))
+- *(schema)* V039 — move per-repo meta singletons to repo_meta (#397 phase A2) ([#412](https://github.com/cq27-dev/rag-rat/pull/412))
+- *(schema)* V038 repos registry, repo identity, and data_dir helper (#396 phase A1) ([#408](https://github.com/cq27-dev/rag-rat/pull/408))
+
+### Fixed
+
+- *(locks)* release flock explicitly on drop — close alone races fork-inherited fds ([#409](https://github.com/cq27-dev/rag-rat/pull/409)) ([#410](https://github.com/cq27-dev/rag-rat/pull/410))
+
 ## [0.12.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.11.0...rag-rat-core-v0.12.0) - 2026-07-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3314,7 +3314,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rag-rat"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-core"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3378,7 +3378,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-mcp"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "3"
 # and the internal path deps below pin the same literal, so the three crates always publish in
 # lockstep. Bump this one line (and the two internal-dep `version`s under workspace.dependencies)
 # to release.
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Kristaps Karlsons"]
 edition = "2024"
 # Bundled SQLite (rusqlite `bundled` -> libsqlite3-sys 0.38.1) compiles a build script that uses the
@@ -28,8 +28,8 @@ categories = ["command-line-utilities", "development-tools"]
 # Internal crates — declared once here so the version requirement is set in lockstep with
 # [workspace.package].version above. Members reference these via `{ workspace = true }` and add
 # their own feature toggles at the use site.
-rag-rat-core = { version = "0.12.0", path = "crates/rag-rat-core", default-features = false }
-rag-rat-mcp = { version = "0.12.0", path = "crates/rag-rat-mcp", default-features = false }
+rag-rat-core = { version = "0.13.0", path = "crates/rag-rat-core", default-features = false }
+rag-rat-mcp = { version = "0.13.0", path = "crates/rag-rat-mcp", default-features = false }
 anyhow = "1.0"
 fastembed = { version = "5.17.2", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
 gix = { version = "0.84.0", default-features = false, features = ["status", "parallel", "sha1", "sha256", "revision", "blob-diff", "blame"] }


### PR DESCRIPTION



## 🤖 New release

* `rag-rat-core`: 0.12.0 -> 0.13.0 (⚠ API breaking changes)
* `rag-rat-mcp`: 0.12.0 -> 0.13.0 (✓ API compatible changes)
* `rag-rat`: 0.12.0 -> 0.13.0

### ⚠ `rag-rat-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Config.memory in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/config.rs:26
  field Config.repo_id_override in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/config.rs:32
  field Config.database_key_pinned in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/config.rs:38
  field Config.memory in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/config.rs:26
  field Config.repo_id_override in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/config.rs:32
  field Config.database_key_pinned in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/config.rs:38
  field CookbookInput.capability in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/index/ai/providers/cookbook.rs:147
  field ImpactSurfaceOptions.surface in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/query/impact/mod.rs:61
  field CompactRepoMemory.summary in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/query/memory/mod.rs:330
  field CompactRepoMemory.verdict in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/query/memory/mod.rs:335
  field DreamOptions.verify in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/dream/mod.rs:104
  field DreamOptions.include_reviewed in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/dream/mod.rs:108
  field LlmConfig.dream in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/config.rs:245

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant ConfigError:GlobalPinWithoutIdentity in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/config.rs:1906
  variant ConfigError:DreamRemoteMissingModel in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/config.rs:1974
  variant ConfigError:DreamBackendCannotServeChat in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/config.rs:1980
  variant ConfigError:DreamRemoteModeAmbiguous in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/config.rs:1985
  variant ConfigError:DreamRemoteEndpointHasCredentials in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/config.rs:1990
  variant ConfigError:DreamRemoteGpuRequiresCookbook in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/config.rs:1995
  variant ConfigError:DreamTableMoved in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/config.rs:2008
  variant ConfigError:UnknownMemorySurface in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/config.rs:2018

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_parameter_count_changed.ron

Failed in:
  rag_rat_core::index::install_worktree_scope_view now takes 4 parameters instead of 3, in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/index/lifecycle.rs:548
  rag_rat_core::query::orientation::orientation now takes 4 parameters instead of 3, in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/query/orientation.rs:51
  rag_rat_core::locks::maintenance_pending_path now takes 2 parameters instead of 1, in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/locks.rs:172
  rag_rat_core::locks::maintenance_lock_path now takes 2 parameters instead of 1, in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/locks.rs:162
  rag_rat_core::locks::write_lock_path now takes 2 parameters instead of 1, in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/locks.rs:125

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  rag_rat_core::locks::WriteLock::acquire_blocking takes 1 parameters in /tmp/.tmpARoWHW/rag-rat-core/src/locks.rs:151, but now takes 2 parameters in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/locks.rs:281
  rag_rat_core::locks::WriteLock::acquire_timeout takes 2 parameters in /tmp/.tmpARoWHW/rag-rat-core/src/locks.rs:164, but now takes 3 parameters in /tmp/.tmpGaFWAT/rag-rat/crates/rag-rat-core/src/locks.rs:287
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rag-rat-core`

<blockquote>

## [0.13.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.12.0...rag-rat-core-v0.13.0) - 2026-07-05

### Added

- *(dream)* human review surface — dream <id> --accept|--dismiss|--reset ([#262](https://github.com/cq27-dev/rag-rat/pull/262)) ([#440](https://github.com/cq27-dev/rag-rat/pull/440))
- *(dream)* run the verdict/compaction model on an ephemeral remote GPU (`[llm.dream.remote]`) ([#438](https://github.com/cq27-dev/rag-rat/pull/438))
- *(dream)* v2 memory passes — reality verdicts + compact summaries ([#428](https://github.com/cq27-dev/rag-rat/pull/428))
- *(index)* global database by default, rag-rat consolidate importer ([#402](https://github.com/cq27-dev/rag-rat/pull/402)) ([#419](https://github.com/cq27-dev/rag-rat/pull/419))
- *(index)* generation-staged full rebuild, per-repo write locks (V043) ([#416](https://github.com/cq27-dev/rag-rat/pull/416))
- *(index)* repo-scoped clones, oracle, reconcile, memories (V042) ([#415](https://github.com/cq27-dev/rag-rat/pull/415))
- *(search)* repo-scoped FTS and papertrail queries (V041) ([#414](https://github.com/cq27-dev/rag-rat/pull/414))
- *(index)* V040 — repo_id scoping on core tables, scope view, gc (#398 phase A3) ([#413](https://github.com/cq27-dev/rag-rat/pull/413))
- *(schema)* V039 — move per-repo meta singletons to repo_meta (#397 phase A2) ([#412](https://github.com/cq27-dev/rag-rat/pull/412))
- *(schema)* V038 repos registry, repo identity, and data_dir helper (#396 phase A1) ([#408](https://github.com/cq27-dev/rag-rat/pull/408))

### Fixed

- *(locks)* release flock explicitly on drop — close alone races fork-inherited fds ([#409](https://github.com/cq27-dev/rag-rat/pull/409)) ([#410](https://github.com/cq27-dev/rag-rat/pull/410))
</blockquote>

## `rag-rat-mcp`

<blockquote>

## [0.13.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.12.0...rag-rat-core-v0.13.0) - 2026-07-05

### Added

- *(dream)* human review surface — dream <id> --accept|--dismiss|--reset ([#262](https://github.com/cq27-dev/rag-rat/pull/262)) ([#440](https://github.com/cq27-dev/rag-rat/pull/440))
- *(dream)* run the verdict/compaction model on an ephemeral remote GPU (`[llm.dream.remote]`) ([#438](https://github.com/cq27-dev/rag-rat/pull/438))
- *(dream)* v2 memory passes — reality verdicts + compact summaries ([#428](https://github.com/cq27-dev/rag-rat/pull/428))
- *(index)* global database by default, rag-rat consolidate importer ([#402](https://github.com/cq27-dev/rag-rat/pull/402)) ([#419](https://github.com/cq27-dev/rag-rat/pull/419))
- *(index)* generation-staged full rebuild, per-repo write locks (V043) ([#416](https://github.com/cq27-dev/rag-rat/pull/416))
- *(index)* repo-scoped clones, oracle, reconcile, memories (V042) ([#415](https://github.com/cq27-dev/rag-rat/pull/415))
- *(search)* repo-scoped FTS and papertrail queries (V041) ([#414](https://github.com/cq27-dev/rag-rat/pull/414))
- *(index)* V040 — repo_id scoping on core tables, scope view, gc (#398 phase A3) ([#413](https://github.com/cq27-dev/rag-rat/pull/413))
- *(schema)* V039 — move per-repo meta singletons to repo_meta (#397 phase A2) ([#412](https://github.com/cq27-dev/rag-rat/pull/412))
- *(schema)* V038 repos registry, repo identity, and data_dir helper (#396 phase A1) ([#408](https://github.com/cq27-dev/rag-rat/pull/408))

### Fixed

- *(locks)* release flock explicitly on drop — close alone races fork-inherited fds ([#409](https://github.com/cq27-dev/rag-rat/pull/409)) ([#410](https://github.com/cq27-dev/rag-rat/pull/410))
</blockquote>

## `rag-rat`

<blockquote>

## [0.13.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.12.0...rag-rat-core-v0.13.0) - 2026-07-05

### Added

- *(dream)* human review surface — dream <id> --accept|--dismiss|--reset ([#262](https://github.com/cq27-dev/rag-rat/pull/262)) ([#440](https://github.com/cq27-dev/rag-rat/pull/440))
- *(dream)* run the verdict/compaction model on an ephemeral remote GPU (`[llm.dream.remote]`) ([#438](https://github.com/cq27-dev/rag-rat/pull/438))
- *(dream)* v2 memory passes — reality verdicts + compact summaries ([#428](https://github.com/cq27-dev/rag-rat/pull/428))
- *(index)* global database by default, rag-rat consolidate importer ([#402](https://github.com/cq27-dev/rag-rat/pull/402)) ([#419](https://github.com/cq27-dev/rag-rat/pull/419))
- *(index)* generation-staged full rebuild, per-repo write locks (V043) ([#416](https://github.com/cq27-dev/rag-rat/pull/416))
- *(index)* repo-scoped clones, oracle, reconcile, memories (V042) ([#415](https://github.com/cq27-dev/rag-rat/pull/415))
- *(search)* repo-scoped FTS and papertrail queries (V041) ([#414](https://github.com/cq27-dev/rag-rat/pull/414))
- *(index)* V040 — repo_id scoping on core tables, scope view, gc (#398 phase A3) ([#413](https://github.com/cq27-dev/rag-rat/pull/413))
- *(schema)* V039 — move per-repo meta singletons to repo_meta (#397 phase A2) ([#412](https://github.com/cq27-dev/rag-rat/pull/412))
- *(schema)* V038 repos registry, repo identity, and data_dir helper (#396 phase A1) ([#408](https://github.com/cq27-dev/rag-rat/pull/408))

### Fixed

- *(locks)* release flock explicitly on drop — close alone races fork-inherited fds ([#409](https://github.com/cq27-dev/rag-rat/pull/409)) ([#410](https://github.com/cq27-dev/rag-rat/pull/410))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).