### PR TITLE
feat(schema): V039 — move per-repo meta singletons to repo_meta (#397 phase A2)

### DIFF
--- a/crates/rag-rat-core/src/index/ai/helpers.rs
+++ b/crates/rag-rat-core/src/index/ai/helpers.rs
@@ -54,7 +54,7 @@ pub(crate) fn embed_query_with(
 
 pub(crate) fn active_embedding_model_id(conn: &Connection) -> anyhow::Result<String> {
     ensure_model_manifest(conn)?;
-    if let Some(model_id) = meta(conn, ACTIVE_EMBEDDING_MODEL_META)? {
+    if let Some(model_id) = repo_meta(conn, ACTIVE_EMBEDDING_MODEL_META)? {
         return Ok(model_id);
     }
     Ok(HASH_MODEL_ID.to_string())
@@ -72,7 +72,7 @@ pub(crate) fn active_embedding_model_version(
     // return its OWN static `spec.version`. The reconcile/active path always queries the active
     // model, so it still gets the dynamic meta.
     if model_id == active_embedding_model_id(conn)?
-        && let Some(version) = reconcile_meta(conn, ACTIVE_EMBEDDING_MODEL_VERSION_META)?
+        && let Some(version) = repo_meta(conn, ACTIVE_EMBEDDING_MODEL_VERSION_META)?
     {
         return Ok(version);
     }
@@ -399,9 +399,33 @@ pub(crate) fn meta(conn: &Connection, key: &str) -> anyhow::Result<Option<String
 }
 
 /// Delete an `index_meta` key (a no-op when absent) — the `index_meta` counterpart of
-/// [`clear_reconcile_meta`].
+/// [`delete_repo_meta`].
 pub(crate) fn delete_meta(conn: &Connection, key: &str) -> anyhow::Result<()> {
     conn.execute("DELETE FROM index_meta WHERE key = ?1", params![key])?;
+    Ok(())
+}
+
+/// Read a per-repo meta value (`repo_meta`) for the repo owning `conn` — the repo-scoped twin of
+/// [`meta`], resolving the active repo via `single_repo_id` (phase A3 replaces that with a real
+/// scope context). Used for the per-repo keys V039 relocated out of `index_meta` /
+/// `reconcile_meta`: the active embedding model and its freshness version, and the int8 reencode
+/// cursor.
+pub(crate) fn repo_meta(conn: &Connection, key: &str) -> anyhow::Result<Option<String>> {
+    let repo_id = crate::index::schema::single_repo_id(conn)?;
+    Ok(crate::index::repo_meta(conn, &repo_id, key)?)
+}
+
+/// Upsert a per-repo meta value — the repo-scoped twin of [`set_meta`].
+pub(crate) fn set_repo_meta(conn: &Connection, key: &str, value: &str) -> anyhow::Result<()> {
+    let repo_id = crate::index::schema::single_repo_id(conn)?;
+    crate::index::set_repo_meta(conn, &repo_id, key, value)?;
+    Ok(())
+}
+
+/// Delete a per-repo meta key (a no-op when absent) — the repo-scoped twin of [`delete_meta`].
+pub(crate) fn delete_repo_meta(conn: &Connection, key: &str) -> anyhow::Result<()> {
+    let repo_id = crate::index::schema::single_repo_id(conn)?;
+    crate::index::delete_repo_meta(conn, &repo_id, key)?;
     Ok(())
 }
 
@@ -454,19 +478,6 @@ pub(crate) fn set_reconcile_meta(conn: &Connection, key: &str, value: &str) -> a
          ON CONFLICT(key) DO UPDATE SET value = excluded.value",
         params![key, value],
     )?;
-    Ok(())
-}
-
-pub(crate) fn reconcile_meta(conn: &Connection, key: &str) -> anyhow::Result<Option<String>> {
-    Ok(conn
-        .query_row("SELECT value FROM reconcile_meta WHERE key = ?1", [key], |row| row.get(0))
-        .optional()?)
-}
-
-/// Delete a `reconcile_meta` key (a no-op when absent). Used to clear the stale freshness-version
-/// meta when the active model goes away, so the hash fallback doesn't inherit a legacy model's key.
-pub(crate) fn clear_reconcile_meta(conn: &Connection, key: &str) -> anyhow::Result<()> {
-    conn.execute("DELETE FROM reconcile_meta WHERE key = ?1", params![key])?;
     Ok(())
 }
 
@@ -587,7 +598,7 @@ mod tests {
             params![model_id, i64::try_from(dim).unwrap()],
         )
         .unwrap();
-        set_meta(conn, ACTIVE_EMBEDDING_MODEL_META, model_id).unwrap();
+        set_repo_meta(conn, ACTIVE_EMBEDDING_MODEL_META, model_id).unwrap();
     }
 
     #[test]
@@ -599,7 +610,7 @@ mod tests {
         let conn = schema_conn();
         activate_model(&conn, FASTEMBED_MODEL_ID);
         let dynamic_key = "fastembed-all-minilm-l6-v2-v1-deadbeefcafef00d";
-        set_reconcile_meta(&conn, ACTIVE_EMBEDDING_MODEL_VERSION_META, dynamic_key).unwrap();
+        set_repo_meta(&conn, ACTIVE_EMBEDDING_MODEL_VERSION_META, dynamic_key).unwrap();
 
         // The ACTIVE model gets the dynamic meta...
         assert_eq!(active_embedding_model_version(&conn, FASTEMBED_MODEL_ID).unwrap(), dynamic_key,);

--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -454,7 +454,7 @@ mod dispatch_tests {
             rusqlite::params![model_id, i64::try_from(spec.dim).unwrap()],
         )
         .unwrap();
-        crate::index::ai::set_meta(&conn, "active_embedding_model", model_id).unwrap();
+        crate::index::ai::set_repo_meta(&conn, "active_embedding_model", model_id).unwrap();
         conn
     }
 

--- a/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
@@ -1082,7 +1082,7 @@ mod freshness_version_tests {
     }
 
     fn active_version(conn: &Connection) -> String {
-        reconcile_meta(conn, ACTIVE_EMBEDDING_MODEL_VERSION_META).unwrap().unwrap()
+        repo_meta(conn, ACTIVE_EMBEDDING_MODEL_VERSION_META).unwrap().unwrap()
     }
 
     #[test]
@@ -1129,8 +1129,8 @@ mod freshness_version_tests {
             params![FASTEMBED_MODEL_ID, i64::try_from(spec.dim).unwrap()],
         )
         .unwrap();
-        set_meta(&conn, ACTIVE_EMBEDDING_MODEL_META, FASTEMBED_MODEL_ID).unwrap();
-        set_reconcile_meta(
+        set_repo_meta(&conn, ACTIVE_EMBEDDING_MODEL_META, FASTEMBED_MODEL_ID).unwrap();
+        set_repo_meta(
             &conn,
             ACTIVE_EMBEDDING_MODEL_VERSION_META,
             &remote_freshness_version(spec, &remote),
@@ -1174,8 +1174,8 @@ mod freshness_version_tests {
             params![FASTEMBED_MODEL_ID, i64::try_from(spec.dim).unwrap()],
         )
         .unwrap();
-        set_meta(&conn, ACTIVE_EMBEDDING_MODEL_META, FASTEMBED_MODEL_ID).unwrap();
-        set_reconcile_meta(
+        set_repo_meta(&conn, ACTIVE_EMBEDDING_MODEL_META, FASTEMBED_MODEL_ID).unwrap();
+        set_repo_meta(
             &conn,
             ACTIVE_EMBEDDING_MODEL_VERSION_META,
             &remote_freshness_version(spec, &remote),
@@ -1214,8 +1214,8 @@ mod freshness_version_tests {
             params![FASTEMBED_MODEL_ID, i64::try_from(spec.dim).unwrap()],
         )
         .unwrap();
-        set_meta(&conn, ACTIVE_EMBEDDING_MODEL_META, FASTEMBED_MODEL_ID).unwrap();
-        set_reconcile_meta(
+        set_repo_meta(&conn, ACTIVE_EMBEDDING_MODEL_META, FASTEMBED_MODEL_ID).unwrap();
+        set_repo_meta(
             &conn,
             ACTIVE_EMBEDDING_MODEL_VERSION_META,
             &remote_freshness_version(spec, &remote),
@@ -1499,8 +1499,8 @@ mod freshness_version_tests {
             params![FASTEMBED_MODEL_ID, i64::try_from(spec.dim).unwrap()],
         )
         .unwrap();
-        set_meta(&conn, ACTIVE_EMBEDDING_MODEL_META, FASTEMBED_MODEL_ID).unwrap();
-        set_reconcile_meta(&conn, ACTIVE_EMBEDDING_MODEL_VERSION_META, spec.version).unwrap();
+        set_repo_meta(&conn, ACTIVE_EMBEDDING_MODEL_META, FASTEMBED_MODEL_ID).unwrap();
+        set_repo_meta(&conn, ACTIVE_EMBEDDING_MODEL_VERSION_META, spec.version).unwrap();
         set_meta(&conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META, "{not valid json").unwrap();
 
         let report =
@@ -1575,7 +1575,7 @@ mod freshness_version_tests {
             params![LEGACY_OLLAMA_ID],
         )
         .unwrap();
-        set_meta(&conn, ACTIVE_EMBEDDING_MODEL_META, LEGACY_OLLAMA_ID).unwrap();
+        set_repo_meta(&conn, ACTIVE_EMBEDDING_MODEL_META, LEGACY_OLLAMA_ID).unwrap();
         set_active_remote_config(&conn, &remote_at("http://box:11434")).unwrap();
         assert!(!model_manifest_is_current(&conn).unwrap(), "a lingering legacy active id is work");
 
@@ -1590,7 +1590,11 @@ mod freshness_version_tests {
             )
             .unwrap();
         assert!(!row_present, "the legacy ai_models row is removed");
-        assert_eq!(meta(&conn, ACTIVE_EMBEDDING_MODEL_META).unwrap(), None, "active meta cleared");
+        assert_eq!(
+            repo_meta(&conn, ACTIVE_EMBEDDING_MODEL_META).unwrap(),
+            None,
+            "active meta cleared"
+        );
         assert!(
             active_remote_config(&conn).unwrap().is_none(),
             "the stale remote config is cleared so no OpenAiEmbedder is reconstructed",
@@ -1623,13 +1627,9 @@ mod freshness_version_tests {
             params![LEGACY_OLLAMA_ID],
         )
         .unwrap();
-        set_meta(&conn, ACTIVE_EMBEDDING_MODEL_META, LEGACY_OLLAMA_ID).unwrap();
-        set_reconcile_meta(
-            &conn,
-            ACTIVE_EMBEDDING_MODEL_VERSION_META,
-            "ollama-all-minilm-v1-deadbeef",
-        )
-        .unwrap();
+        set_repo_meta(&conn, ACTIVE_EMBEDDING_MODEL_META, LEGACY_OLLAMA_ID).unwrap();
+        set_repo_meta(&conn, ACTIVE_EMBEDDING_MODEL_VERSION_META, "ollama-all-minilm-v1-deadbeef")
+            .unwrap();
 
         ensure_model_manifest(&conn).unwrap();
 
@@ -1637,7 +1637,7 @@ mod freshness_version_tests {
         // `active_embedding_model_version(HASH)` falls back to the hash spec's static version — NOT
         // the legacy key.
         assert_eq!(
-            reconcile_meta(&conn, ACTIVE_EMBEDDING_MODEL_VERSION_META).unwrap(),
+            repo_meta(&conn, ACTIVE_EMBEDDING_MODEL_VERSION_META).unwrap(),
             None,
             "the legacy freshness-version meta is cleared",
         );
@@ -1656,7 +1656,7 @@ mod freshness_version_tests {
         let conn = schema_conn();
         activate_model_with_version(&conn, HASH_MODEL_ID, "hash-v1", false).unwrap();
         assert_eq!(
-            meta(&conn, ACTIVE_EMBEDDING_MODEL_META).unwrap().as_deref(),
+            repo_meta(&conn, ACTIVE_EMBEDDING_MODEL_META).unwrap().as_deref(),
             Some(HASH_MODEL_ID)
         );
         assert_eq!(active_version(&conn), "hash-v1");
@@ -1742,7 +1742,7 @@ mod freshness_version_tests {
             params![FASTEMBED_MODEL_ID, i64::try_from(spec.dim).unwrap()],
         )
         .unwrap();
-        set_meta(conn, ACTIVE_EMBEDDING_MODEL_META, FASTEMBED_MODEL_ID).unwrap();
+        set_repo_meta(conn, ACTIVE_EMBEDDING_MODEL_META, FASTEMBED_MODEL_ID).unwrap();
         let remote = RemoteEmbeddingConfig {
             model: "all-minilm".to_string(),
             backend: crate::config::RemoteBackend::Ollama,
@@ -1758,7 +1758,7 @@ mod freshness_version_tests {
             request_timeout_s: 5,
         };
         set_active_remote_config(conn, &remote).unwrap();
-        set_reconcile_meta(
+        set_repo_meta(
             conn,
             ACTIVE_EMBEDDING_MODEL_VERSION_META,
             &remote_freshness_version(spec, &remote),

--- a/crates/rag-rat-core/src/index/ai/reconcile/manifest.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/manifest.rs
@@ -31,12 +31,14 @@ pub(crate) fn ensure_model_manifest(conn: &Connection) -> anyhow::Result<()> {
 /// write path (#143) and to let the read-only MCP open refuse to serve when a manifest write is
 /// still owed (falling back to the read-write open, which heals once).
 pub(crate) fn model_manifest_is_current(conn: &Connection) -> anyhow::Result<bool> {
+    // The active-model meta moved to `repo_meta` (V039); check the active repo's row there.
+    let repo_id = crate::index::schema::single_repo_id(conn)?;
     for model_id in LEGACY_MODEL_IDS {
         let lingering: bool = conn.query_row(
             "SELECT EXISTS(SELECT 1 FROM ai_models WHERE model_id = ?1)
                  OR EXISTS(SELECT 1 FROM chunk_embeddings WHERE model_id = ?1)
-                 OR EXISTS(SELECT 1 FROM index_meta WHERE key = ?2 AND value = ?1)",
-            params![model_id, ACTIVE_EMBEDDING_MODEL_META],
+                 OR EXISTS(SELECT 1 FROM repo_meta WHERE repo_id = ?3 AND key = ?2 AND value = ?1)",
+            params![model_id, ACTIVE_EMBEDDING_MODEL_META, repo_id],
             |row| row.get(0),
         )?;
         if lingering {
@@ -68,6 +70,8 @@ pub(crate) fn model_manifest_is_current(conn: &Connection) -> anyhow::Result<boo
 }
 
 pub(crate) fn remove_legacy_models(conn: &Connection) -> anyhow::Result<()> {
+    // The active-model meta moved to `repo_meta` (V039); clear it for the active repo.
+    let repo_id = crate::index::schema::single_repo_id(conn)?;
     for model_id in LEGACY_MODEL_IDS {
         conn.execute("DELETE FROM chunk_embeddings WHERE model_id = ?1", params![model_id])?;
         conn.execute("DELETE FROM ai_models WHERE model_id = ?1", params![model_id])?;
@@ -76,18 +80,17 @@ pub(crate) fn remove_legacy_models(conn: &Connection) -> anyhow::Result<()> {
         // Leaving the remote config behind would let `active_embedder` keep reconstructing an
         // `OpenAiEmbedder` against a now-removed endpoint after the active model fell back to hash,
         // so clear it whenever we delete the matching active-model meta.
-        let was_active =
-            conn.execute("DELETE FROM index_meta WHERE key = ?1 AND value = ?2", params![
-                ACTIVE_EMBEDDING_MODEL_META,
-                model_id
-            ])?;
+        let was_active = conn.execute(
+            "DELETE FROM repo_meta WHERE repo_id = ?1 AND key = ?2 AND value = ?3",
+            params![repo_id, ACTIVE_EMBEDDING_MODEL_META, model_id],
+        )?;
         if was_active > 0 {
             clear_active_remote_config(conn)?;
             // ALSO drop the legacy model's freshness-version meta (R3a): otherwise the hash
             // fallback inherits the removed model's `model_version` key and reports the
             // wrong freshness. The next install re-stamps it; clearing here keeps the
             // gap correct.
-            clear_reconcile_meta(conn, ACTIVE_EMBEDDING_MODEL_VERSION_META)?;
+            delete_repo_meta(conn, ACTIVE_EMBEDDING_MODEL_VERSION_META)?;
         }
     }
     Ok(())

--- a/crates/rag-rat-core/src/index/ai/reconcile/model_lifecycle.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/model_lifecycle.rs
@@ -66,7 +66,7 @@ pub(crate) fn recover_cached_fastembed_model_at(
 
 #[cfg(feature = "fastembed")]
 pub(crate) fn active_embedding_model_is_missing(conn: &Connection) -> anyhow::Result<bool> {
-    let Some(active_model_id) = meta(conn, ACTIVE_EMBEDDING_MODEL_META)? else {
+    let Some(active_model_id) = repo_meta(conn, ACTIVE_EMBEDDING_MODEL_META)? else {
         return Ok(true);
     };
     let active = conn
@@ -107,8 +107,11 @@ pub(crate) fn activate_model_with_version(
     version: &str,
     provisional: bool,
 ) -> anyhow::Result<()> {
-    set_meta(conn, ACTIVE_EMBEDDING_MODEL_META, model_id)?;
-    set_reconcile_meta(conn, ACTIVE_EMBEDDING_MODEL_VERSION_META, version)?;
+    // Model id + freshness version are per-repo (V039 → repo_meta); the provenance flag is NOT in
+    // the phase-A2 move list, so it stays in the global `index_meta` (A3/A5 scope it later). Split
+    // across tables but still stamped together in this single writer's one call.
+    set_repo_meta(conn, ACTIVE_EMBEDDING_MODEL_META, model_id)?;
+    set_repo_meta(conn, ACTIVE_EMBEDDING_MODEL_VERSION_META, version)?;
     set_meta(conn, ACTIVE_EMBEDDING_MODEL_PROVISIONAL_META, if provisional { "1" } else { "0" })?;
     Ok(())
 }
@@ -133,8 +136,8 @@ pub(crate) fn clear_active_embedding_model_provisional(conn: &Connection) -> any
 /// activation, restoring the "embeddings-off ⇒ active model unset" invariant (#394 review).
 /// Idempotent (each delete is a no-op when its key is absent).
 pub(crate) fn clear_active_embedding_model(conn: &Connection) -> anyhow::Result<()> {
-    delete_meta(conn, ACTIVE_EMBEDDING_MODEL_META)?;
-    clear_reconcile_meta(conn, ACTIVE_EMBEDDING_MODEL_VERSION_META)?;
+    delete_repo_meta(conn, ACTIVE_EMBEDDING_MODEL_META)?;
+    delete_repo_meta(conn, ACTIVE_EMBEDDING_MODEL_VERSION_META)?;
     delete_meta(conn, ACTIVE_EMBEDDING_MODEL_PROVISIONAL_META)?;
     clear_active_remote_config(conn)
 }
@@ -208,10 +211,10 @@ pub(crate) fn active_embedding_model_seed_owed(
         // Embeddings-off: a write is owed only when a PROVISIONAL model is still active and must be
         // cleared. An unset active (nothing to clear) or an explicit / confirmed one (preserved)
         // owes nothing.
-        return Ok(meta(conn, ACTIVE_EMBEDDING_MODEL_META)?.is_some()
+        return Ok(repo_meta(conn, ACTIVE_EMBEDDING_MODEL_META)?.is_some()
             && active_embedding_model_is_provisional(conn)?);
     };
-    match meta(conn, ACTIVE_EMBEDDING_MODEL_META)? {
+    match repo_meta(conn, ACTIVE_EMBEDDING_MODEL_META)? {
         None => Ok(true),
         Some(active) if active == configured => Ok(false),
         Some(_) => active_embedding_model_is_provisional(conn),
@@ -348,7 +351,7 @@ mod seed_active_embedding_model_tests {
     fn seeds_the_configured_model_when_active_is_unset() {
         let conn = fresh_conn();
         assert!(
-            meta(&conn, ACTIVE_EMBEDDING_MODEL_META).unwrap().is_none(),
+            repo_meta(&conn, ACTIVE_EMBEDDING_MODEL_META).unwrap().is_none(),
             "a fresh index has no active embedding model"
         );
         assert!(
@@ -436,7 +439,7 @@ mod seed_active_embedding_model_tests {
         assert!(!active_embedding_model_seed_owed(&conn, None).unwrap(), "off ⇒ nothing to seed");
         seed_active_embedding_model(&conn, None).unwrap();
         assert!(
-            meta(&conn, ACTIVE_EMBEDDING_MODEL_META).unwrap().is_none(),
+            repo_meta(&conn, ACTIVE_EMBEDDING_MODEL_META).unwrap().is_none(),
             "the embeddings-off choice leaves the active model unset (hash fallback stands)"
         );
     }
@@ -458,8 +461,8 @@ mod seed_active_embedding_model_tests {
 
         // The active model, its freshness version, the provenance flag, and the stale remote config
         // are all gone — `active_embedding_model_id` returns to the hash fallback.
-        assert!(meta(&conn, ACTIVE_EMBEDDING_MODEL_META).unwrap().is_none());
-        assert!(reconcile_meta(&conn, ACTIVE_EMBEDDING_MODEL_VERSION_META).unwrap().is_none());
+        assert!(repo_meta(&conn, ACTIVE_EMBEDDING_MODEL_META).unwrap().is_none());
+        assert!(repo_meta(&conn, ACTIVE_EMBEDDING_MODEL_VERSION_META).unwrap().is_none());
         assert!(meta(&conn, ACTIVE_EMBEDDING_MODEL_PROVISIONAL_META).unwrap().is_none());
         assert!(meta(&conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META).unwrap().is_none());
         assert_eq!(active_embedding_model_id(&conn).unwrap(), HASH);

--- a/crates/rag-rat-core/src/index/ai/reencode.rs
+++ b/crates/rag-rat-core/src/index/ai/reencode.rs
@@ -118,7 +118,7 @@ fn reencode_legacy_f32_blobs_batched(
 /// back to the sentinel — re-walking from the head is correct (already-int8 rows are skipped),
 /// never wrong.
 fn load_cursor(conn: &Connection) -> anyhow::Result<(i64, String)> {
-    let Some(raw) = reconcile_meta(conn, VECTOR_INT8_REENCODE_CURSOR_META)? else {
+    let Some(raw) = repo_meta(conn, VECTOR_INT8_REENCODE_CURSOR_META)? else {
         return Ok((i64::MIN, String::new()));
     };
     let Some((chunk_id, model_id)) = raw.split_once('\n') else {
@@ -132,11 +132,7 @@ fn load_cursor(conn: &Connection) -> anyhow::Result<(i64, String)> {
 
 /// Persist the keyset cursor as `"<chunk_id>\n<model_id>"` (model ids never contain a newline).
 fn save_cursor(conn: &Connection, cursor: &(i64, String)) -> anyhow::Result<()> {
-    set_reconcile_meta(
-        conn,
-        VECTOR_INT8_REENCODE_CURSOR_META,
-        &format!("{}\n{}", cursor.0, cursor.1),
-    )
+    set_repo_meta(conn, VECTOR_INT8_REENCODE_CURSOR_META, &format!("{}\n{}", cursor.0, cursor.1))
 }
 
 /// Read up to `limit` legacy f32 rows past `cursor`, in `(chunk_id, model_id)` order (the UNIQUE
@@ -270,9 +266,7 @@ fn reencode_and_mark_if_complete(
 
 /// Drop the persisted keyset cursor once the conversion is complete (it is no longer meaningful).
 fn clear_cursor(conn: &Connection) -> anyhow::Result<()> {
-    conn.execute("DELETE FROM reconcile_meta WHERE key = ?1", params![
-        VECTOR_INT8_REENCODE_CURSOR_META
-    ])?;
+    delete_repo_meta(conn, VECTOR_INT8_REENCODE_CURSOR_META)?;
     Ok(())
 }
 
@@ -297,7 +291,16 @@ mod tests {
                  UNIQUE(chunk_id, model_id)
              );
              CREATE TABLE index_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);
-             CREATE TABLE reconcile_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);",
+             CREATE TABLE reconcile_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             -- The reencode cursor moved to `repo_meta` (V039), read/written through
+             -- `single_repo_id` → the `repos` registry; seed the placeholder so the cursor path
+             -- resolves the same lone repo production does.
+             CREATE TABLE repos(repo_id TEXT PRIMARY KEY, display_name TEXT NOT NULL, \
+             registered_at_ms INTEGER NOT NULL);
+             INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('__unassigned__', \
+             '', 0);
+             CREATE TABLE repo_meta(repo_id TEXT NOT NULL, key TEXT NOT NULL, value TEXT, PRIMARY \
+             KEY(repo_id, key));",
         )
         .unwrap();
         conn
@@ -490,7 +493,7 @@ mod tests {
     }
 
     fn stored_cursor(conn: &Connection) -> Option<String> {
-        reconcile_meta(conn, VECTOR_INT8_REENCODE_CURSOR_META).unwrap()
+        repo_meta(conn, VECTOR_INT8_REENCODE_CURSOR_META).unwrap()
     }
 
     #[test]
@@ -535,7 +538,7 @@ mod tests {
             )
             .unwrap();
         }
-        set_reconcile_meta(&conn, VECTOR_INT8_REENCODE_CURSOR_META, "1\nmodel-a").unwrap();
+        set_repo_meta(&conn, VECTOR_INT8_REENCODE_CURSOR_META, "1\nmodel-a").unwrap();
         assert_eq!(count_remaining_f32(&conn), 4, "4 f32 rows remain past the cursor");
 
         // A follow-up call with NO deadline resumes from the persisted cursor and finishes the

--- a/crates/rag-rat-core/src/index/edges/imports.rs
+++ b/crates/rag-rat-core/src/index/edges/imports.rs
@@ -18,22 +18,21 @@
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
-use rusqlite::{Connection, OptionalExtension};
+use rusqlite::Connection;
 
 use super::{ImportScopeRange, MOD_FILE_ROOT};
 
-/// Load the persisted GLOBAL local-crate-root set — newline-joined under `local_crate_roots` in
-/// `index_meta`, written at rebuild by [`local_crate_roots`]. Empty when absent (a non-Cargo corpus
-/// or a pre-V021 index), which makes [`ImportScope`] suppress nothing.
+/// Load the persisted per-repo local-crate-root set — newline-joined under `local_crate_roots` in
+/// `repo_meta` (V039 relocated it there), written at rebuild by [`local_crate_roots`]. Empty when
+/// absent (a non-Cargo corpus, a pre-V021 index, or a raw conn without the registry), which makes
+/// [`ImportScope`] suppress nothing.
 pub(crate) fn load_local_roots(conn: &Connection) -> HashSet<String> {
-    conn.query_row("SELECT value FROM index_meta WHERE key = 'local_crate_roots'", [], |row| {
-        row.get::<_, String>(0)
-    })
-    .optional()
-    .ok()
-    .flatten()
-    .map(|value| value.lines().filter(|line| !line.is_empty()).map(str::to_string).collect())
-    .unwrap_or_default()
+    crate::index::schema::single_repo_id(conn)
+        .and_then(|repo_id| crate::index::repo_meta(conn, &repo_id, "local_crate_roots"))
+        .ok()
+        .flatten()
+        .map(|value| value.lines().filter(|line| !line.is_empty()).map(str::to_string).collect())
+        .unwrap_or_default()
 }
 
 /// One Cargo package discovered in the corpus: the directory of its manifest and the set of crate

--- a/crates/rag-rat-core/src/index/edges/resolve/tests.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/tests.rs
@@ -407,7 +407,8 @@ fn same_file_same_scope_variants_still_bind_via_logical_variant() {
 
 fn set_local_crate_roots(conn: &Connection, roots: &str) {
     conn.execute(
-        "INSERT OR REPLACE INTO index_meta(key, value) VALUES ('local_crate_roots', ?1)",
+        "INSERT OR REPLACE INTO repo_meta(repo_id, key, value)
+         VALUES ('__unassigned__', 'local_crate_roots', ?1)",
         params![roots],
     )
     .unwrap();

--- a/crates/rag-rat-core/src/index/fts.rs
+++ b/crates/rag-rat-core/src/index/fts.rs
@@ -11,7 +11,7 @@ impl IndexDatabase {
         schema::rebuild_commit_fts(self.storage.connection())?;
         self.record_content_revision()?;
         self.record_fts_current()?;
-        self.set_meta("fts_dirty", "false")?;
+        self.set_repo_meta("fts_dirty", "false")?;
         Ok(())
     }
 
@@ -22,7 +22,7 @@ impl IndexDatabase {
         schema::rebuild_commit_fts(self.storage.connection())?;
         self.record_content_revision()?;
         self.record_fts_current()?;
-        self.set_meta("fts_dirty", "false")?;
+        self.set_repo_meta("fts_dirty", "false")?;
         Ok(())
     }
 
@@ -75,29 +75,29 @@ impl IndexDatabase {
     pub fn sync_fts(&self) -> anyhow::Result<()> {
         self.record_content_revision()?;
         self.record_fts_current()?;
-        self.set_meta("fts_dirty", "false")?;
+        self.set_repo_meta("fts_dirty", "false")?;
         Ok(())
     }
 
     fn record_fts_current(&self) -> anyhow::Result<()> {
-        self.set_meta("fts_synced_at_ms", &now_ms().to_string())?;
+        self.set_repo_meta("fts_synced_at_ms", &now_ms().to_string())?;
         let revision = self.content_revision()?;
-        self.set_meta("fts_source_revision", &revision)?;
+        self.set_repo_meta("fts_source_revision", &revision)?;
         Ok(())
     }
 
     pub(super) fn mark_fts_dirty(&self) -> anyhow::Result<()> {
-        self.set_meta("fts_dirty", "true")
+        self.set_repo_meta("fts_dirty", "true")
     }
 
     pub(super) fn ensure_fts_fresh(&self) -> anyhow::Result<()> {
         let content_revision = self.content_revision()?;
-        let fts_source_revision = self.meta("fts_source_revision")?;
+        let fts_source_revision = self.repo_meta("fts_source_revision")?;
         if !self.fts_dirty()? && fts_source_revision.as_deref() == Some(content_revision.as_str()) {
             return Ok(());
         }
         self.rebuild_fts()?;
-        let refreshed_revision = self.meta("fts_source_revision")?;
+        let refreshed_revision = self.repo_meta("fts_source_revision")?;
         if refreshed_revision.as_deref() != Some(content_revision.as_str()) {
             anyhow::bail!(
                 "FTS freshness invariant failed: content_revision={content_revision}, \
@@ -109,6 +109,6 @@ impl IndexDatabase {
     }
 
     pub(super) fn fts_dirty(&self) -> anyhow::Result<bool> {
-        Ok(self.meta("fts_dirty")?.as_deref() == Some("true"))
+        Ok(self.repo_meta("fts_dirty")?.as_deref() == Some("true"))
     }
 }

--- a/crates/rag-rat-core/src/index/git_history.rs
+++ b/crates/rag-rat-core/src/index/git_history.rs
@@ -7,7 +7,7 @@ use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
-use crate::index::table_row_count;
+use crate::index::{delete_repo_meta, repo_meta, schema, set_repo_meta, table_row_count};
 use crate::search::lexical::SearchHit;
 
 #[derive(Debug, Clone, Serialize)]
@@ -202,9 +202,15 @@ pub(crate) fn apply_prepared(
     )?;
     // Reload-gate key: head + root + shallow flag. `is_history_current` skips the next reload
     // only when all three still match and git_commits is non-empty.
-    set_meta(conn, "git_history_indexed_head", &repo.head)?;
-    set_meta(conn, "git_history_indexed_root", &root_key(root))?;
-    set_meta(conn, "git_history_indexed_shallow", if repo.shallow { "1" } else { "0" })?;
+    let repo_id = schema::single_repo_id(conn)?;
+    set_repo_meta(conn, &repo_id, "git_history_indexed_head", &repo.head)?;
+    set_repo_meta(conn, &repo_id, "git_history_indexed_root", &root_key(root))?;
+    set_repo_meta(
+        conn,
+        &repo_id,
+        "git_history_indexed_shallow",
+        if repo.shallow { "1" } else { "0" },
+    )?;
     status(conn, root)
 }
 
@@ -217,10 +223,11 @@ pub fn status(conn: &Connection, root: &Path) -> anyhow::Result<GitHistoryIndexS
     let repo = git_repo(root);
     let commit_count = table_row_count(conn, "git_commits")?;
     let file_change_count = table_row_count(conn, "git_file_changes")?;
+    let repo_id = schema::single_repo_id(conn)?;
     Ok(GitHistoryIndexStatus {
         available: repo.is_some(),
         head: repo.map(|repo| repo.head),
-        indexed_head: meta(conn, "git_history_indexed_head")?,
+        indexed_head: repo_meta(conn, &repo_id, "git_history_indexed_head")?,
         commit_count,
         file_change_count,
     })
@@ -588,11 +595,15 @@ fn clear(conn: &Connection) -> anyhow::Result<()> {
         DELETE FROM git_chunk_blame;
         DELETE FROM git_file_changes;
         DELETE FROM git_commits;
-        DELETE FROM index_meta
-        WHERE key IN ('git_history_indexed_head', 'git_history_indexed_root',
-                      'git_history_indexed_shallow');
         ",
     )?;
+    // The reload-gate keys moved to `repo_meta` (V039); clear them for the active repo.
+    let repo_id = schema::single_repo_id(conn)?;
+    for key in
+        ["git_history_indexed_head", "git_history_indexed_root", "git_history_indexed_shallow"]
+    {
+        delete_repo_meta(conn, &repo_id, key)?;
+    }
     Ok(())
 }
 
@@ -910,13 +921,15 @@ pub(crate) fn is_history_current(conn: &Connection, root: &Path) -> bool {
         return false;
     }
     let probe = || -> anyhow::Result<bool> {
-        let head_matches =
-            meta(conn, "git_history_indexed_head")?.as_deref() == Some(repo.head.as_str());
-        let root_matches =
-            meta(conn, "git_history_indexed_root")?.as_deref() == Some(root_key(root).as_str());
+        let repo_id = schema::single_repo_id(conn)?;
+        let head_matches = repo_meta(conn, &repo_id, "git_history_indexed_head")?.as_deref()
+            == Some(repo.head.as_str());
+        let root_matches = repo_meta(conn, &repo_id, "git_history_indexed_root")?.as_deref()
+            == Some(root_key(root).as_str());
         // A prior reload done while shallow only saw truncated history; redo it now that we are
         // not shallow even if HEAD is unchanged.
-        let prior_was_full = meta(conn, "git_history_indexed_shallow")?.as_deref() == Some("0");
+        let prior_was_full =
+            repo_meta(conn, &repo_id, "git_history_indexed_shallow")?.as_deref() == Some("0");
         // Guard against a torn/empty prior reload writing the meta without rows.
         let has_rows = table_row_count(conn, "git_commits")? > 0;
         Ok(head_matches && root_matches && prior_was_full && has_rows)
@@ -931,21 +944,6 @@ fn fts_query(query: &str) -> String {
         .map(|term| format!("\"{}\"", term.replace('"', "\"\"")))
         .collect::<Vec<_>>();
     if terms.is_empty() { "\"\"".to_string() } else { terms.join(" OR ") }
-}
-
-fn meta(conn: &Connection, key: &str) -> anyhow::Result<Option<String>> {
-    Ok(conn
-        .query_row("SELECT value FROM index_meta WHERE key = ?1", [key], |row| row.get(0))
-        .optional()?)
-}
-
-fn set_meta(conn: &Connection, key: &str, value: &str) -> anyhow::Result<()> {
-    conn.execute(
-        "INSERT INTO index_meta(key, value) VALUES (?1, ?2)
-         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-        params![key, value],
-    )?;
-    Ok(())
 }
 
 fn hex_sha256(bytes: &[u8]) -> String {

--- a/crates/rag-rat-core/src/index/git_meta.rs
+++ b/crates/rag-rat-core/src/index/git_meta.rs
@@ -8,9 +8,9 @@ impl IndexDatabase {
     pub(super) fn write_git_meta(&self, root: &Path) -> anyhow::Result<bool> {
         let commit = head_sha(root);
         let dirty = is_worktree_dirty(root);
-        let commit_changed = self.set_meta_if_changed("git_commit", &commit)?;
+        let commit_changed = self.set_repo_meta_if_changed("git_commit", &commit)?;
         let dirty_changed =
-            self.set_meta_if_changed("git_dirty", if dirty { "true" } else { "false" })?;
+            self.set_repo_meta_if_changed("git_dirty", if dirty { "true" } else { "false" })?;
         Ok(commit_changed || dirty_changed)
     }
 

--- a/crates/rag-rat-core/src/index/github/api.rs
+++ b/crates/rag-rat-core/src/index/github/api.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::index::table_row_count;
+use crate::index::{repo_meta, schema, set_repo_meta, table_row_count};
 
 pub(crate) fn sync_from_refs<C: GitHubClient>(
     conn: &Connection,
@@ -25,7 +25,8 @@ pub(crate) fn sync_from_refs_with_progress<C: GitHubClient>(
         let client = client.ok_or_else(|| anyhow::anyhow!("github sync requires a client"))?;
         sync_refs(conn, client, refs.iter(), &mut progress)?
     };
-    set_meta(conn, "github_last_sync_ms", &now_ms().to_string())?;
+    let repo_id = schema::single_repo_id(conn)?;
+    set_repo_meta(conn, &repo_id, "github_last_sync_ms", &now_ms().to_string())?;
     Ok(GitHubSyncReport {
         offline,
         discovered_refs: refs.len(),
@@ -62,7 +63,8 @@ pub(crate) fn sync_issue<C: GitHubClient>(
         let client = client.ok_or_else(|| anyhow::anyhow!("github sync requires a client"))?;
         sync_refs(conn, client, refs.iter().filter(|r| r.number == parsed.number), &mut |_| {})?
     };
-    set_meta(conn, "github_last_sync_ms", &now_ms().to_string())?;
+    let repo_id = schema::single_repo_id(conn)?;
+    set_repo_meta(conn, &repo_id, "github_last_sync_ms", &now_ms().to_string())?;
     Ok(GitHubSyncReport {
         offline,
         discovered_refs: refs.len(),
@@ -81,7 +83,8 @@ pub(crate) fn status(conn: &Connection, ctx: &GitHubContext) -> anyhow::Result<G
         pulls: table_row_count(conn, "github_pull_requests")?,
         reviews: table_row_count(conn, "github_reviews")?,
         review_comments: table_row_count(conn, "github_review_comments")?,
-        last_sync_ms: meta(conn, "github_last_sync_ms")?.and_then(|value| value.parse().ok()),
+        last_sync_ms: repo_meta(conn, &schema::single_repo_id(conn)?, "github_last_sync_ms")?
+            .and_then(|value| value.parse().ok()),
         capability: if ctx.gh_available {
             "gh_cli_available".to_string()
         } else {

--- a/crates/rag-rat-core/src/index/github/parse.rs
+++ b/crates/rag-rat-core/src/index/github/parse.rs
@@ -242,16 +242,3 @@ pub(crate) fn collect_rows<T>(
     }
     Ok(out)
 }
-pub(crate) fn meta(conn: &Connection, key: &str) -> anyhow::Result<Option<String>> {
-    Ok(conn
-        .query_row("SELECT value FROM index_meta WHERE key = ?1", [key], |row| row.get(0))
-        .optional()?)
-}
-pub(crate) fn set_meta(conn: &Connection, key: &str, value: &str) -> anyhow::Result<()> {
-    conn.execute(
-        "INSERT INTO index_meta(key, value) VALUES (?1, ?2)
-         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-        params![key, value],
-    )?;
-    Ok(())
-}

--- a/crates/rag-rat-core/src/index/graph_index.rs
+++ b/crates/rag-rat-core/src/index/graph_index.rs
@@ -247,7 +247,7 @@ impl IndexDatabase {
     }
 
     pub(super) fn ensure_graph_index_current(&self) -> anyhow::Result<()> {
-        if self.meta("graph_index_version")?.as_deref() == Some(GRAPH_INDEX_VERSION) {
+        if self.repo_meta("graph_index_version")?.as_deref() == Some(GRAPH_INDEX_VERSION) {
             return Ok(());
         }
         let Some(root) = self.storage.source_root().map(Path::to_path_buf) else {
@@ -298,7 +298,7 @@ impl IndexDatabase {
     }
 
     pub(super) fn mark_graph_index_current(&self) -> anyhow::Result<()> {
-        self.set_meta("graph_index_version", GRAPH_INDEX_VERSION)
+        self.set_repo_meta("graph_index_version", GRAPH_INDEX_VERSION)
     }
 
     fn graph_reindex_files(&self) -> anyhow::Result<Vec<GraphReindexFile>> {

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -76,7 +76,7 @@ impl IndexDatabase {
             // is also exactly the false signal the watcher-loop diagnostic keys on
             // (indexed_at_ms advancing while content is unchanged).
             let source_root_changed =
-                db.set_meta_if_changed("source_root", &config.root.display().to_string())?;
+                db.set_repo_meta_if_changed("source_root", &config.root.display().to_string())?;
             db.storage.set_source_root(config.root.clone());
             let git_meta_changed = db.write_git_meta(&config.root)?;
             // Heal the active embedding model from config INSIDE the txn: the incremental /
@@ -156,7 +156,7 @@ impl IndexDatabase {
                 db.sync_fts()?;
             }
             if mutated {
-                db.set_meta("indexed_at_ms", &now_ms().to_string())?;
+                db.set_repo_meta("indexed_at_ms", &now_ms().to_string())?;
                 db.storage.execute_batch("COMMIT")?;
             } else {
                 // Nothing changed since the last pass — close the (empty) transaction without

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -45,7 +45,8 @@ impl IndexDatabase {
             schema::ensure_compatible_or_migrate(storage.connection())?;
         }
         ai::ensure_model_manifest(storage.connection())?;
-        if let Some(root) = read_meta(storage.connection(), "source_root")? {
+        let repo_id = schema::single_repo_id(storage.connection())?;
+        if let Some(root) = repo_meta(storage.connection(), &repo_id, "source_root")? {
             storage.set_source_root(PathBuf::from(root));
         }
         let db = Self {
@@ -108,7 +109,8 @@ impl IndexDatabase {
         if schema::status(storage.connection())?.state != schema::SchemaState::Compatible {
             return Ok(None);
         }
-        if read_meta(storage.connection(), "graph_index_version")?.as_deref()
+        let repo_id = schema::single_repo_id(storage.connection())?;
+        if repo_meta(storage.connection(), &repo_id, "graph_index_version")?.as_deref()
             != Some(GRAPH_INDEX_VERSION)
         {
             return Ok(None);
@@ -187,7 +189,8 @@ impl IndexDatabase {
         let mut storage = IndexConnection::open(path)?;
         schema::apply(storage.connection())?;
         ai::ensure_model_manifest(storage.connection())?;
-        if let Some(root) = read_meta(storage.connection(), "source_root")? {
+        let repo_id = schema::single_repo_id(storage.connection())?;
+        if let Some(root) = repo_meta(storage.connection(), &repo_id, "source_root")? {
             storage.set_source_root(PathBuf::from(root));
         }
         Ok(Self {

--- a/crates/rag-rat-core/src/index/meta.rs
+++ b/crates/rag-rat-core/src/index/meta.rs
@@ -5,18 +5,35 @@ use super::*;
 impl IndexDatabase {
     pub(super) fn record_content_revision(&self) -> anyhow::Result<String> {
         let revision = self.content_revision()?;
-        self.set_meta("content_revision", &revision)?;
+        self.set_repo_meta("content_revision", &revision)?;
         Ok(revision)
     }
 
-    /// Write a meta key only if the stored value differs. Returns whether a write happened — so a
-    /// no-change incremental/sweep pass can avoid dirtying a WAL page (see issue #63).
-    pub(super) fn set_meta_if_changed(&self, key: &str, value: &str) -> anyhow::Result<bool> {
-        if self.meta(key)?.as_deref() == Some(value) {
-            return Ok(false);
-        }
-        self.set_meta(key, value)?;
-        Ok(true)
+    /// Read a per-repo meta value (`repo_meta`) for the repo owning this connection — the ergonomic
+    /// per-connection twin of the [`repo_meta`] free primitive, resolving the active repo via
+    /// [`schema::single_repo_id`] (A3 replaces that with a real scope context).
+    pub(super) fn repo_meta(&self, key: &str) -> anyhow::Result<Option<String>> {
+        let conn = self.storage.connection();
+        let repo_id = schema::single_repo_id(conn)?;
+        // Bare call → the free `repo_meta` primitive below, never this method (methods need a
+        // receiver); the two share a name intentionally (primitive + per-connection wrapper).
+        Ok(repo_meta(conn, &repo_id, key)?)
+    }
+
+    /// Upsert a per-repo meta value for the repo owning this connection.
+    pub(super) fn set_repo_meta(&self, key: &str, value: &str) -> anyhow::Result<()> {
+        let conn = self.storage.connection();
+        let repo_id = schema::single_repo_id(conn)?;
+        set_repo_meta(conn, &repo_id, key, value)?;
+        Ok(())
+    }
+
+    /// Upsert a per-repo meta value only when it changes — returns whether a write happened, so a
+    /// no-change incremental/sweep pass avoids dirtying a WAL page (issue #63).
+    pub(super) fn set_repo_meta_if_changed(&self, key: &str, value: &str) -> anyhow::Result<bool> {
+        let conn = self.storage.connection();
+        let repo_id = schema::single_repo_id(conn)?;
+        Ok(set_repo_meta_if_changed(conn, &repo_id, key, value)?)
     }
 
     pub(super) fn set_meta(&self, key: &str, value: &str) -> anyhow::Result<()> {
@@ -57,4 +74,64 @@ impl IndexDatabase {
         )?;
         Ok(hex_sha256(value.as_bytes()))
     }
+}
+
+/// Read a per-repo meta value from the `repo_meta` table — the repo-scoped twin of
+/// [`read_meta`](crate::index::read_meta) (which reads the global `index_meta`). `repo_id` is the
+/// owning repo; until phase A3 threads a real active-repo context, callers pass
+/// [`schema::single_repo_id`]. Returns `None` when the key is unset for that repo.
+pub(crate) fn repo_meta(
+    conn: &rusqlite::Connection,
+    repo_id: &str,
+    key: &str,
+) -> rusqlite::Result<Option<String>> {
+    conn.query_row(
+        "SELECT value FROM repo_meta WHERE repo_id = ?1 AND key = ?2",
+        params![repo_id, key],
+        |row| row.get(0),
+    )
+    .optional()
+}
+
+/// Upsert a per-repo meta value into `repo_meta` (keyed by `(repo_id, key)`). The repo-scoped twin
+/// of [`IndexDatabase::set_meta`].
+pub(crate) fn set_repo_meta(
+    conn: &rusqlite::Connection,
+    repo_id: &str,
+    key: &str,
+    value: &str,
+) -> rusqlite::Result<()> {
+    conn.execute(
+        "INSERT INTO repo_meta(repo_id, key, value) VALUES (?1, ?2, ?3)
+         ON CONFLICT(repo_id, key) DO UPDATE SET value = excluded.value",
+        params![repo_id, key, value],
+    )?;
+    Ok(())
+}
+
+/// Upsert a per-repo meta value only when it differs from the stored value — returns whether a
+/// write happened, so a no-change pass avoids dirtying a WAL page (the #63 property, mirrored from
+/// [`IndexDatabase::set_meta_if_changed`]).
+pub(crate) fn set_repo_meta_if_changed(
+    conn: &rusqlite::Connection,
+    repo_id: &str,
+    key: &str,
+    value: &str,
+) -> rusqlite::Result<bool> {
+    if repo_meta(conn, repo_id, key)?.as_deref() == Some(value) {
+        return Ok(false);
+    }
+    set_repo_meta(conn, repo_id, key, value)?;
+    Ok(true)
+}
+
+/// Delete a per-repo meta key (a no-op when absent) — the `repo_meta` counterpart of `delete_meta`,
+/// needed by the clear paths of the relocated model / reencode-cursor keys.
+pub(crate) fn delete_repo_meta(
+    conn: &rusqlite::Connection,
+    repo_id: &str,
+    key: &str,
+) -> rusqlite::Result<()> {
+    conn.execute("DELETE FROM repo_meta WHERE repo_id = ?1 AND key = ?2", params![repo_id, key])?;
+    Ok(())
 }

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -46,6 +46,7 @@ pub(crate) use git_context::*;
 pub(crate) use lifecycle::install_scope_view;
 pub use lifecycle::install_worktree_scope_view;
 pub(crate) use mem_diag::{maybe_set_sqlite_soft_heap_limit, mem_trace};
+pub(crate) use meta::{delete_repo_meta, repo_meta, set_repo_meta};
 pub use parser_failures::ParserFailure;
 pub(crate) use prep::*;
 pub use query_api::{

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -4017,7 +4017,8 @@ fn memory_attention_count_reads_file_db_and_fails_open() {
 fn set_source_root(h: &Harness) {
     h.conn
         .execute(
-            "INSERT OR REPLACE INTO index_meta(key, value) VALUES ('source_root', ?1)",
+            "INSERT OR REPLACE INTO repo_meta(repo_id, key, value)
+             VALUES ('__unassigned__', 'source_root', ?1)",
             params![h.root().to_string_lossy()],
         )
         .unwrap();
@@ -4210,7 +4211,8 @@ fn validate_prefers_active_root_over_persisted_meta() {
     // h.root(), where the file actually lives.
     h.conn
         .execute(
-            "INSERT OR REPLACE INTO index_meta(key, value) VALUES ('source_root', ?1)",
+            "INSERT OR REPLACE INTO repo_meta(repo_id, key, value)
+             VALUES ('__unassigned__', 'source_root', ?1)",
             params![h.root().join("nonexistent-worktree").to_string_lossy()],
         )
         .unwrap();

--- a/crates/rag-rat-core/src/index/packages.rs
+++ b/crates/rag-rat-core/src/index/packages.rs
@@ -4,9 +4,9 @@ use super::*;
 
 impl IndexDatabase {
     /// Rewrite the `packages` rows for the ACTIVE scope from the corpus's Cargo manifests, then
-    /// persist the GLOBAL local-crate-root union to `index_meta.local_crate_roots` (#61 per-package
-    /// import scope). Returns whether the package map changed (so an incremental pass can trigger a
-    /// re-resolve only when it must).
+    /// persist the per-repo local-crate-root union to `repo_meta.local_crate_roots` (#61
+    /// per-package import scope). Returns whether the package map changed (so an incremental
+    /// pass can trigger a re-resolve only when it must).
     ///
     /// "Changed" is reported when EITHER the global union changed OR any package's per-scope
     /// `(manifest_dir, local_roots_json)` set changed. Reporting only the global union missed a
@@ -75,7 +75,7 @@ impl IndexDatabase {
             sorted.sort_unstable();
             sorted.join("\n")
         };
-        let union_changed = self.set_meta_if_changed("local_crate_roots", &serialized)?;
+        let union_changed = self.set_repo_meta_if_changed("local_crate_roots", &serialized)?;
         Ok(union_changed || package_map_changed)
     }
 }

--- a/crates/rag-rat-core/src/index/query_api/clones/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/mod.rs
@@ -415,7 +415,7 @@ impl IndexDatabase {
             lim > UNLIMITED_REFINE_BUDGET && total_classes_built > UNLIMITED_REFINE_BUDGET
         });
 
-        let freshness = self.meta("git_commit")?.unwrap_or_else(|| "unknown".to_string());
+        let freshness = self.repo_meta("git_commit")?.unwrap_or_else(|| "unknown".to_string());
 
         // Count DISTINCT member file paths whose on-disk content no longer matches the indexed
         // sha256 (read-only signal; Plan 2 does not heal-before-return).
@@ -613,7 +613,7 @@ impl IndexDatabase {
             }
         };
 
-        let freshness = self.meta("git_commit")?.unwrap_or_else(|| "unknown".to_string());
+        let freshness = self.repo_meta("git_commit")?.unwrap_or_else(|| "unknown".to_string());
 
         let resolved_id = resolve_selector_to_symbol_id(conn, &selector)?;
         let Some(symbol_id) = resolved_id else {

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -405,7 +405,7 @@ impl IndexDatabase {
               WHERE generation = ?3",
             params![now_ms(), edges_written as i64, generation],
         )?;
-        self.set_meta("clone_graph_live_generation", &generation.to_string())?;
+        self.set_repo_meta("clone_graph_live_generation", &generation.to_string())?;
         conn.execute("DELETE FROM clone_graph_generations WHERE generation != ?1", params![
             generation
         ])?;
@@ -691,7 +691,8 @@ fn flush_batch(
 
 /// The live (Complete) generation row, if one is published.
 fn live_generation_row(conn: &Connection) -> anyhow::Result<Option<GenerationRow>> {
-    let Some(live) = read_meta(conn, "clone_graph_live_generation")? else {
+    let repo_id = crate::index::schema::single_repo_id(conn)?;
+    let Some(live) = crate::index::repo_meta(conn, &repo_id, "clone_graph_live_generation")? else {
         return Ok(None);
     };
     let Ok(generation) = live.parse::<i64>() else {
@@ -774,14 +775,6 @@ fn map_generation_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<GenerationRow
         edges_written: row.get::<_, i64>(4)? as u64,
         postings_written: row.get::<_, i64>(5)? != 0,
     })
-}
-
-fn read_meta(conn: &Connection, key: &str) -> anyhow::Result<Option<String>> {
-    Ok(conn
-        .query_row("SELECT value FROM index_meta WHERE key = ?1", params![key], |r| {
-            r.get::<_, String>(0)
-        })
-        .ok())
 }
 
 #[cfg(test)]
@@ -874,7 +867,7 @@ mod tests {
         let conn = db.storage.connection();
         let live: i64 = conn
             .query_row(
-                "SELECT CAST(value AS INTEGER) FROM index_meta WHERE key = \
+                "SELECT CAST(value AS INTEGER) FROM repo_meta WHERE key = \
                  'clone_graph_live_generation'",
                 [],
                 |r| r.get(0),

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -50,19 +50,21 @@ impl IndexDatabase {
         }
 
         let content_revision = self.content_revision()?;
-        let fts_source_revision = self.meta("fts_source_revision")?;
+        let fts_source_revision = self.repo_meta("fts_source_revision")?;
         let fts_dirty = self.fts_dirty()?;
 
         Ok(IndexStatus {
             database: database.display().to_string(),
             exists: database.exists(),
             schema: schema::status(self.storage.connection())?,
-            git_commit: self.meta("git_commit")?,
-            git_dirty: self.meta("git_dirty")?.map(|value| value == "true"),
-            indexed_at_ms: self.meta("indexed_at_ms")?.and_then(|value| value.parse::<i64>().ok()),
+            git_commit: self.repo_meta("git_commit")?,
+            git_dirty: self.repo_meta("git_dirty")?.map(|value| value == "true"),
+            indexed_at_ms: self
+                .repo_meta("indexed_at_ms")?
+                .and_then(|value| value.parse::<i64>().ok()),
             content_revision: content_revision.clone(),
             fts_synced_at_ms: self
-                .meta("fts_synced_at_ms")?
+                .repo_meta("fts_synced_at_ms")?
                 .and_then(|value| value.parse::<i64>().ok()),
             fts_dirty,
             fts_fresh: !fts_dirty

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -51,7 +51,7 @@ impl IndexDatabase {
             db.storage.execute_batch("BEGIN IMMEDIATE")?;
             db.clear_full_rebuild_tables()?;
             mem_trace("after clear_full_rebuild_tables (purge)");
-            db.set_meta("source_root", &config.root.display().to_string())?;
+            db.set_repo_meta("source_root", &config.root.display().to_string())?;
             db.storage.set_source_root(config.root.clone());
             // Per-package import scope (#61): the `packages` rows + the global `local_crate_roots`
             // union are written by `refresh_packages`, called inside `index_targets_with_progress`
@@ -95,7 +95,7 @@ impl IndexDatabase {
             // input — but keeping it exact maximizes the rare-first sub-block prune.
             db.refresh_clone_token_df()?;
             mem_trace("after refresh_clone_token_df");
-            db.set_meta("indexed_at_ms", &now_ms().to_string())?;
+            db.set_repo_meta("indexed_at_ms", &now_ms().to_string())?;
             // Adopt the configured embedding model as this index's active model INSIDE the rebuild
             // transaction, so reconcile targets it (and read-only opens serve immediately) rather
             // than the hash fallback (#394) — and a failed rebuild rolls the seed back with the

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1658,10 +1658,12 @@ const V039_RECONCILE_META_KEYS: &[&str] =
     &["embedding_active_model_version", "vector_int8_reencode_cursor"];
 
 /// V039 (memory-sync phase A2): relocate the per-repo singleton meta keys out of the global
-/// `index_meta` / `reconcile_meta` into `repo_meta`, under the `LEGACY_REPO_ID` placeholder (the
-/// only repo a phase-A DB holds). [`super::register_repo`] re-points these rows to the real repo_id
-/// at adoption. The read/write call sites move to the `repo_meta` accessors in the same change, so
-/// a moved key is never read from the table it was deleted from.
+/// `index_meta` / `reconcile_meta` into `repo_meta`, under the SOLE `repos` row that owns this DB
+/// (see [`sole_repo_id`]) — the real repo_id when the DB was already adopted, else the
+/// [`super::LEGACY_REPO_ID`] placeholder V038 seeds. Targeting the sole row (not a hardcoded
+/// placeholder) is what keeps the `repo_meta → repos` FK satisfied on an ADOPTED DB, where the
+/// placeholder row is gone. The read/write call sites move to the `repo_meta` accessors in the same
+/// change, so a moved key is never read from the table it was deleted from.
 ///
 /// Idempotent (`INSERT OR IGNORE` deduped by the `(repo_id, key)` PK + `DELETE` of the source
 /// rows): a fresh DB has empty meta tables → the copy/delete are no-ops, and a forward-migrated
@@ -1675,23 +1677,56 @@ pub(crate) fn apply_move_per_repo_meta(conn: &Connection) -> rusqlite::Result<()
 }
 
 /// Copy the listed keys from `source_table` (a `(key, value)` k/v table) into `repo_meta` under the
-/// placeholder repo_id, then delete them from the source. `source_table` and `keys` are internal
-/// string literals (never user input), so interpolating them into the SQL is safe.
+/// repo that owns this DB ([`sole_repo_id`]), then delete them from the source. Resolving the
+/// target HERE — inside the shared helper — means every future key-move caller inherits the correct
+/// target (real-after-adoption / placeholder-before), instead of each re-deriving a placeholder
+/// that a prior adoption may have deleted. `source_table` and `keys` are internal string literals
+/// (never user input), so interpolating them into the SQL is safe.
 fn relocate_meta_keys(
     conn: &Connection,
     source_table: &str,
     keys: &[&str],
 ) -> rusqlite::Result<()> {
+    let target_repo_id = sole_repo_id(conn)?;
     let in_list = keys.iter().map(|key| format!("'{key}'")).collect::<Vec<_>>().join(", ");
     conn.execute(
         &format!(
             "INSERT OR IGNORE INTO repo_meta(repo_id, key, value)
              SELECT ?1, key, value FROM {source_table} WHERE key IN ({in_list})"
         ),
-        [super::LEGACY_REPO_ID],
+        [target_repo_id.as_str()],
     )?;
     conn.execute(&format!("DELETE FROM {source_table} WHERE key IN ({in_list})"), [])?;
     Ok(())
+}
+
+/// The single `repos` row that owns this DB at migration time — the real repo_id if it was already
+/// adopted via [`super::register_repo`], else the [`super::LEGACY_REPO_ID`] placeholder V038 seeds.
+///
+/// The relocation MUST target this id, not a hardcoded placeholder: on an adopted DB the
+/// placeholder row is deleted, so an `INSERT` into `repo_meta` under it trips the `repo_meta →
+/// repos` FK — with `foreign_keys = ON` (production) that aborts the whole `migrate_forward`; with
+/// it off it orphans rows the per-repo accessors ([`super::single_repo_id`]) can never resolve.
+/// V038 always leaves exactly one `repos` row and `register_repo` keeps it at one, so 0 or >1 is a
+/// broken invariant — surfaced as an attributable migration error rather than a silent FK abort or
+/// a wrong-scope pick. (Distinct from [`super::single_repo_id`], the runtime stand-in: that one
+/// `debug_assert`s the one-row invariant and `LIMIT 1`s in release; a migration needs the hard
+/// error on `!= 1`.)
+fn sole_repo_id(conn: &Connection) -> rusqlite::Result<String> {
+    let mut stmt = conn.prepare("SELECT repo_id FROM repos")?;
+    let mut ids =
+        stmt.query_map([], |row| row.get::<_, String>(0))?.collect::<rusqlite::Result<Vec<_>>>()?;
+    if ids.len() == 1 {
+        return Ok(ids.pop().expect("length checked to be exactly 1"));
+    }
+    Err(rusqlite::Error::SqliteFailure(
+        rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CONSTRAINT),
+        Some(format!(
+            "V039 per-repo meta relocation expects exactly one repos row (the sole repo owning \
+             this DB), found {}",
+            ids.len()
+        )),
+    ))
 }
 
 /// V035: add `symbols.is_test` (cross-language test-code marker computed at parse time; see

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1173,6 +1173,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_036_ID => Some(36),
             MIGRATION_037_ID => Some(37),
             MIGRATION_038_ID => Some(38),
+            MIGRATION_039_ID => Some(39),
             _ => None,
         })
         .max()
@@ -1220,6 +1221,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_036_ID
             | MIGRATION_037_ID
             | MIGRATION_038_ID
+            | MIGRATION_039_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1264,6 +1266,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_036_ID => migration.checksum != MIGRATION_036_CHECKSUM,
         MIGRATION_037_ID => migration.checksum != MIGRATION_037_CHECKSUM,
         MIGRATION_038_ID => migration.checksum != MIGRATION_038_CHECKSUM,
+        MIGRATION_039_ID => migration.checksum != MIGRATION_039_CHECKSUM,
         _ => false,
     }
 }
@@ -1622,6 +1625,74 @@ pub(crate) const REPOS_REGISTRY_DDL: &str = "
         SELECT '__unassigned__', '', 0
         WHERE NOT EXISTS (SELECT 1 FROM repos WHERE repo_id != '__unassigned__');
 ";
+
+/// The `index_meta` keys V039 relocates into `repo_meta` (memory-sync phase A2) — the per-repo
+/// singletons that were global-by-accident under the one-DB-per-repo assumption. Kept as ONE list
+/// so the copy and the matching delete cannot drift. Machine/db-level keys
+/// (`generated_flags_version`, the reencode DONE gate, the active-model provenance flag + remote
+/// config, the throughput-tune cache) deliberately STAY in `index_meta` — they are not per-repo, or
+/// are scoped by a later workstream.
+const V039_INDEX_META_KEYS: &[&str] = &[
+    "source_root",
+    "content_revision",
+    "git_commit",
+    "git_dirty",
+    "graph_index_version",
+    "active_embedding_model",
+    "clone_graph_live_generation",
+    "github_last_sync_ms",
+    "git_history_indexed_head",
+    "git_history_indexed_root",
+    "git_history_indexed_shallow",
+    "local_crate_roots",
+    "indexed_at_ms",
+    "fts_dirty",
+    "fts_source_revision",
+    "fts_synced_at_ms",
+];
+
+/// The `reconcile_meta` keys V039 relocates into `repo_meta`. The `reconcile_meta` TABLE is
+/// intentionally NOT dropped here — a later cleanup migration owns that (the remaining reconcile
+/// timing keys still live in it); only these two per-repo keys move.
+const V039_RECONCILE_META_KEYS: &[&str] =
+    &["embedding_active_model_version", "vector_int8_reencode_cursor"];
+
+/// V039 (memory-sync phase A2): relocate the per-repo singleton meta keys out of the global
+/// `index_meta` / `reconcile_meta` into `repo_meta`, under the `LEGACY_REPO_ID` placeholder (the
+/// only repo a phase-A DB holds). [`super::register_repo`] re-points these rows to the real repo_id
+/// at adoption. The read/write call sites move to the `repo_meta` accessors in the same change, so
+/// a moved key is never read from the table it was deleted from.
+///
+/// Idempotent (`INSERT OR IGNORE` deduped by the `(repo_id, key)` PK + `DELETE` of the source
+/// rows): a fresh DB has empty meta tables → the copy/delete are no-ops, and a forward-migrated
+/// legacy DB converges on the identical shape. Copy-before-delete on each table means even a torn
+/// run (crash between the copy and the delete) re-converges: the re-run's copy is ignored and the
+/// delete finishes, and readers already read `repo_meta` (the authoritative side).
+pub(crate) fn apply_move_per_repo_meta(conn: &Connection) -> rusqlite::Result<()> {
+    relocate_meta_keys(conn, "index_meta", V039_INDEX_META_KEYS)?;
+    relocate_meta_keys(conn, "reconcile_meta", V039_RECONCILE_META_KEYS)?;
+    Ok(())
+}
+
+/// Copy the listed keys from `source_table` (a `(key, value)` k/v table) into `repo_meta` under the
+/// placeholder repo_id, then delete them from the source. `source_table` and `keys` are internal
+/// string literals (never user input), so interpolating them into the SQL is safe.
+fn relocate_meta_keys(
+    conn: &Connection,
+    source_table: &str,
+    keys: &[&str],
+) -> rusqlite::Result<()> {
+    let in_list = keys.iter().map(|key| format!("'{key}'")).collect::<Vec<_>>().join(", ");
+    conn.execute(
+        &format!(
+            "INSERT OR IGNORE INTO repo_meta(repo_id, key, value)
+             SELECT ?1, key, value FROM {source_table} WHERE key IN ({in_list})"
+        ),
+        [super::LEGACY_REPO_ID],
+    )?;
+    conn.execute(&format!("DELETE FROM {source_table} WHERE key IN ({in_list})"), [])?;
+    Ok(())
+}
 
 /// V035: add `symbols.is_test` (cross-language test-code marker computed at parse time; see
 /// `parser::detect_is_test`) so clone detection can keep tests out of the corpus. Idempotent via

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -3,11 +3,12 @@ mod migrations;
 mod registry;
 pub(crate) use baseline::*;
 pub(crate) use migrations::*;
+pub(crate) use registry::single_repo_id;
 pub use registry::{LEGACY_REPO_ID, register_repo};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 38;
+pub const LATEST_SCHEMA_VERSION: u32 = 39;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -245,6 +246,11 @@ const MIGRATION_038_DESCRIPTION: &str =
     "Add repos registry + repo_roots + repo_meta (per-machine repo identity registry and per-repo \
      key/value store) with the __unassigned__ adoption placeholder — the substrate for the global \
      consolidated database and repo_id scoping (memory-sync phase A)";
+const MIGRATION_039_ID: &str = "039_per_repo_meta";
+const MIGRATION_039_CHECKSUM: &str = "sha256:rag-rat-per-repo-meta-v39";
+const MIGRATION_039_DESCRIPTION: &str = "Relocate the per-repo singleton meta keys from the \
+                                         global index_meta / reconcile_meta into repo_meta under \
+                                         the __unassigned__ placeholder (memory-sync phase A2)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -572,6 +578,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_038_CHECKSUM,
         description: MIGRATION_038_DESCRIPTION,
         apply: apply_repos_registry,
+    },
+    Migration {
+        id: MIGRATION_039_ID,
+        checksum: MIGRATION_039_CHECKSUM,
+        description: MIGRATION_039_DESCRIPTION,
+        apply: apply_move_per_repo_meta,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema/registry.rs
+++ b/crates/rag-rat-core/src/index/schema/registry.rs
@@ -65,22 +65,28 @@ pub fn register_repo(
         )));
     }
 
-    // No real repo yet: adopt the placeholder in place, or insert fresh if it is somehow absent.
+    // No real repo yet: adopt the placeholder. Insert the real `repos` row FIRST, then re-point the
+    // placeholder's children, then drop the placeholder. Since V039 (phase A2) `repo_meta` carries
+    // rows under the placeholder, and its FK to `repos` is enforced (`foreign_keys = ON`), the
+    // placeholder PK cannot be rewritten in place while children reference it. Insert-first /
+    // delete-last keeps every FK satisfied at each statement boundary without needing an enclosing
+    // transaction or deferred checks. `repo_roots` never holds placeholder rows (it is only ever
+    // written under a real id, by `record_repo_root` below), so only `repo_meta` needs re-pointing;
+    // A3 extends this to the direct-scoped tables it adds.
     let placeholder_present = conn
         .query_row("SELECT 1 FROM repos WHERE repo_id = ?1", [LEGACY_REPO_ID], |_| Ok(()))
         .optional()?
         .is_some();
+    conn.execute(
+        "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, ?2, ?3)",
+        params![identity.repo_id, identity.display_name, now_ms],
+    )?;
     if placeholder_present {
-        conn.execute(
-            "UPDATE repos SET repo_id = ?1, display_name = ?2, registered_at_ms = ?3
-             WHERE repo_id = ?4",
-            params![identity.repo_id, identity.display_name, now_ms, LEGACY_REPO_ID],
-        )?;
-    } else {
-        conn.execute(
-            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, ?2, ?3)",
-            params![identity.repo_id, identity.display_name, now_ms],
-        )?;
+        conn.execute("UPDATE repo_meta SET repo_id = ?1 WHERE repo_id = ?2", params![
+            identity.repo_id,
+            LEGACY_REPO_ID
+        ])?;
+        conn.execute("DELETE FROM repos WHERE repo_id = ?1", [LEGACY_REPO_ID])?;
     }
     record_repo_root(conn, &identity.repo_id, &root, now_ms)?;
     Ok(identity.repo_id.clone())
@@ -95,6 +101,22 @@ fn registry_refusal(msg: String) -> rusqlite::Error {
         rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CONSTRAINT),
         Some(msg),
     )
+}
+
+/// The single repo owning this database — the connection-level active-repo stand-in the per-repo
+/// [`repo_meta`](crate::index::repo_meta) accessors resolve until phase A3 threads a real
+/// `ScopeContext`. Phase A keeps ONE repo per DB ([`register_repo`] refuses a second), so `repos`
+/// holds exactly one row: the adopted real id after [`register_repo`], or the [`LEGACY_REPO_ID`]
+/// placeholder on a not-yet-adopted DB (a bare `schema::apply` in a test, or any open before A3
+/// wires registration into `open_config`). A3 replaces every caller with the active repo id from
+/// its scope context.
+pub(crate) fn single_repo_id(conn: &Connection) -> rusqlite::Result<String> {
+    debug_assert_eq!(
+        conn.query_row("SELECT COUNT(*) FROM repos", [], |row| row.get::<_, i64>(0))?,
+        1,
+        "phase A holds exactly one repos row per DB until the default-path flip (A3/A7)"
+    );
+    conn.query_row("SELECT repo_id FROM repos LIMIT 1", [], |row| row.get(0))
 }
 
 /// Every registered `repo_id` that is a real (adopted) id — i.e. excluding the [`LEGACY_REPO_ID`]

--- a/crates/rag-rat-core/src/index/schema/registry.rs
+++ b/crates/rag-rat-core/src/index/schema/registry.rs
@@ -65,30 +65,38 @@ pub fn register_repo(
         )));
     }
 
-    // No real repo yet: adopt the placeholder. Insert the real `repos` row FIRST, then re-point the
-    // placeholder's children, then drop the placeholder. Since V039 (phase A2) `repo_meta` carries
-    // rows under the placeholder, and its FK to `repos` is enforced (`foreign_keys = ON`), the
-    // placeholder PK cannot be rewritten in place while children reference it. Insert-first /
-    // delete-last keeps every FK satisfied at each statement boundary without needing an enclosing
-    // transaction or deferred checks. `repo_roots` never holds placeholder rows (it is only ever
-    // written under a real id, by `record_repo_root` below), so only `repo_meta` needs re-pointing;
-    // A3 extends this to the direct-scoped tables it adds.
-    let placeholder_present = conn
+    // No real repo yet: adopt the placeholder in ONE transaction. Insert the real `repos` row
+    // FIRST, re-point the placeholder's children, then drop the placeholder. Since V039 (phase
+    // A2) `repo_meta` carries rows under the placeholder, and its FK to `repos` is enforced
+    // (`foreign_keys = ON`), the placeholder PK cannot be rewritten in place while children
+    // reference it; the insert-first / delete-last order keeps every FK satisfied at each statement
+    // boundary. The enclosing `unchecked_transaction` makes the whole adoption ATOMIC: a crash or
+    // mid-sequence error rolls it ALL back, so the DB never lands in the torn state where BOTH the
+    // real row and the placeholder survive — a state the "already registered" fast path above would
+    // never repair and `single_repo_id`'s one-row expectation would break on.
+    // `unchecked_transaction` is the right tool on a shared `&Connection` (rusqlite): it needs
+    // no `&mut`, commits on `.commit()`, and rolls back on drop. `repo_roots` never holds
+    // placeholder rows (it is only ever written under a real id, by `record_repo_root` below),
+    // so only `repo_meta` needs re-pointing; A3 extends this to the direct-scoped tables it
+    // adds. The fresh path (no placeholder) runs in the same transaction for uniformity.
+    let tx = conn.unchecked_transaction()?;
+    let placeholder_present = tx
         .query_row("SELECT 1 FROM repos WHERE repo_id = ?1", [LEGACY_REPO_ID], |_| Ok(()))
         .optional()?
         .is_some();
-    conn.execute(
+    tx.execute(
         "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, ?2, ?3)",
         params![identity.repo_id, identity.display_name, now_ms],
     )?;
     if placeholder_present {
-        conn.execute("UPDATE repo_meta SET repo_id = ?1 WHERE repo_id = ?2", params![
+        tx.execute("UPDATE repo_meta SET repo_id = ?1 WHERE repo_id = ?2", params![
             identity.repo_id,
             LEGACY_REPO_ID
         ])?;
-        conn.execute("DELETE FROM repos WHERE repo_id = ?1", [LEGACY_REPO_ID])?;
+        tx.execute("DELETE FROM repos WHERE repo_id = ?1", [LEGACY_REPO_ID])?;
     }
-    record_repo_root(conn, &identity.repo_id, &root, now_ms)?;
+    record_repo_root(&tx, &identity.repo_id, &root, now_ms)?;
+    tx.commit()?;
     Ok(identity.repo_id.clone())
 }
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/git_history_reload.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/git_history_reload.rs
@@ -90,8 +90,9 @@ fn idle_discover_sweep_does_not_rewrite_indexed_at_ms() {
     db.storage
         .connection()
         .execute(
-            "INSERT INTO index_meta(key, value) VALUES('indexed_at_ms', 'SENTINEL')
-             ON CONFLICT(key) DO UPDATE SET value = 'SENTINEL'",
+            "INSERT INTO repo_meta(repo_id, key, value) VALUES('__unassigned__', 'indexed_at_ms', \
+             'SENTINEL')
+             ON CONFLICT(repo_id, key) DO UPDATE SET value = 'SENTINEL'",
             [],
         )
         .unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/github_papertrail.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/github_papertrail.rs
@@ -270,7 +270,7 @@ fn heal_index_limit_does_not_warn_when_only_fresh_files_are_skipped() {
 fn search_recovers_when_fts_revision_is_stale() {
     let (root, config) = markdown_config("alpha token");
     let db = IndexDatabase::rebuild(&config).unwrap();
-    db.set_meta("fts_source_revision", "stale").unwrap();
+    db.set_repo_meta("fts_source_revision", "stale").unwrap();
 
     let stale = db.status(&config.database).unwrap();
     assert!(!stale.fts_dirty);

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -99,11 +99,9 @@ fn git_history_test_config(root: &Path) -> Config {
 }
 
 fn read_meta(db: &IndexDatabase, key: &str) -> Option<String> {
-    db.storage
-        .connection()
-        .query_row("SELECT value FROM index_meta WHERE key = ?1", [key], |row| row.get(0))
-        .optional()
-        .unwrap()
+    // Reads the per-repo `repo_meta` (V039 relocated the singleton keys there); the only caller
+    // reads `indexed_at_ms`, which moved.
+    db.repo_meta(key).unwrap()
 }
 
 /// The callee identifier byte range (#67) stored on the single edge matching

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
@@ -482,7 +482,7 @@ fn read_only_open_serves_current_index_and_declines_when_heal_is_owed() {
     // Mark the graph index stale (a heal write is now owed). open() already ran and left it
     // current, so set it afterward; the read-only path does not heal, so it must decline.
     let db = IndexDatabase::open(&config.database).unwrap();
-    db.set_meta("graph_index_version", "0").unwrap();
+    db.set_repo_meta("graph_index_version", "0").unwrap();
     drop(db);
     assert!(
         IndexDatabase::try_open_config_read_only(&config).unwrap().is_none(),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -77,7 +77,7 @@ fn rebuild_populates_revision_metadata_and_fresh_fts_state() {
     assert!(!status.content_revision.is_empty());
     assert_eq!(status.fts_source_revision.as_deref(), Some(status.content_revision.as_str()));
     assert_eq!(
-        db.meta("content_revision").unwrap().as_deref(),
+        db.repo_meta("content_revision").unwrap().as_deref(),
         Some(status.content_revision.as_str())
     );
     assert!(!status.fts_dirty);
@@ -271,7 +271,7 @@ fn an_incremental_pass_heals_a_missing_active_model_atomically() {
     // Simulate a pre-#394 index: drop the seeded active-model meta.
     db.storage
         .connection()
-        .execute("DELETE FROM index_meta WHERE key = 'active_embedding_model'", [])
+        .execute("DELETE FROM repo_meta WHERE key = 'active_embedding_model'", [])
         .unwrap();
     drop(db);
 
@@ -305,8 +305,8 @@ fn cached_fastembed_model_recovers_ready_state() {
     // `model_version`).
     {
         let conn = db.storage.connection();
-        conn.execute("DELETE FROM index_meta WHERE key = 'active_embedding_model'", []).unwrap();
-        ai::set_reconcile_meta(conn, "embedding_active_model_version", "legacy-stale-key").unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'active_embedding_model'", []).unwrap();
+        ai::set_repo_meta(conn, "embedding_active_model_version", "legacy-stale-key").unwrap();
     }
 
     ai::recover_cached_fastembed_model_at(db.storage.connection(), &cache_dir).unwrap();
@@ -685,8 +685,9 @@ fn reconcile_plan_reports_policy_skips_for_fastembed_model() {
     db.storage
         .connection()
         .execute(
-            "INSERT INTO index_meta(key, value) VALUES ('active_embedding_model', ?1)
-                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            "INSERT INTO repo_meta(repo_id, key, value)
+                 VALUES ('__unassigned__', 'active_embedding_model', ?1)
+                 ON CONFLICT(repo_id, key) DO UPDATE SET value = excluded.value",
             [FASTEMBED_MODEL_ID],
         )
         .unwrap();
@@ -708,8 +709,9 @@ fn blocked_fastembed_reconcile_still_reports_policy_skips() {
     db.storage
         .connection()
         .execute(
-            "INSERT INTO index_meta(key, value) VALUES ('active_embedding_model', ?1)
-                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            "INSERT INTO repo_meta(repo_id, key, value)
+                 VALUES ('__unassigned__', 'active_embedding_model', ?1)
+                 ON CONFLICT(repo_id, key) DO UPDATE SET value = excluded.value",
             [FASTEMBED_MODEL_ID],
         )
         .unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -20,15 +20,36 @@ fn root_count(conn: &rusqlite::Connection, repo_id: &str) -> i64 {
         .unwrap()
 }
 
+/// Upsert a key into a `(key, value)` k/v table (`index_meta` / `reconcile_meta`) — seeds the
+/// pre-relocation state a legacy DB carries.
+fn upsert_meta(conn: &rusqlite::Connection, table: &str, key: &str, value: &str) {
+    conn.execute(
+        &format!(
+            "INSERT INTO {table}(key, value) VALUES (?1, ?2)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+        ),
+        [key, value],
+    )
+    .unwrap();
+}
+
+/// Whether `table` still holds `key` (used to assert relocated keys are gone / retained keys stay).
+fn meta_present(conn: &rusqlite::Connection, table: &str, key: &str) -> bool {
+    conn.query_row(&format!("SELECT COUNT(*) FROM {table} WHERE key = ?1"), [key], |r| {
+        r.get::<_, i64>(0)
+    })
+    .unwrap()
+        > 0
+}
+
 /// Fresh `apply` creates the three registry tables with their exact columns, STRICT, and seeds the
-/// single adoption placeholder whose id MUST equal `LEGACY_REPO_ID`. This is also the current
-/// schema-tip test, so it owns the absolute `LATEST_SCHEMA_VERSION` pin (V037's test relinquished
-/// it — see the hardcoded-LATEST footgun).
+/// single adoption placeholder whose id MUST equal `LEGACY_REPO_ID`. The absolute
+/// `LATEST_SCHEMA_VERSION` pin moved to the new tip's test (`migration_039_*`); this one uses only
+/// the symbolic `current_version == LATEST_SCHEMA_VERSION` check (the hardcoded-LATEST footgun).
 #[test]
 fn migration_038_creates_repos_registry_tables() {
     let conn = rusqlite::Connection::open_in_memory().expect("open");
     schema::apply(&conn).expect("apply");
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 38, "V038 is the schema tip");
 
     assert_eq!(conn_table_columns(&conn, "repos"), vec![
         "repo_id",
@@ -170,6 +191,57 @@ fn reapplying_schema_after_adoption_does_not_resurrect_the_placeholder() {
     assert_eq!(repo_row_count(&conn, "repo-abc"), 1, "the adopted repo survives the re-apply");
 }
 
+/// The cross-phase interaction of V038's conditional seed, the one-repos-row invariant, and V039's
+/// per-repo `repo_meta`: an ADOPTED DB carrying relocated meta must survive a full `schema::apply`
+/// re-run (the `create_or_migrate`/`rebuild` path) with its identity and meta intact. If the V038
+/// seed regressed to an unconditional `INSERT OR IGNORE`, the re-apply would re-mint the
+/// placeholder beside the real row — two `repos` rows — which trips `single_repo_id`'s one-row
+/// `debug_assert` AND leaves it resolving an arbitrary repo, so the per-repo `repo_meta` accessors
+/// would read the wrong scope. This pins BOTH sides at once: after re-apply `single_repo_id` still
+/// returns the real id, and the meta rows stay under it (never resurrected under the placeholder).
+#[test]
+fn reapplying_schema_after_adoption_keeps_single_repo_id_and_repo_meta_under_the_real_id() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    // As V039 leaves a not-yet-adopted DB: per-repo meta under the placeholder.
+    crate::index::meta::set_repo_meta(&conn, LEGACY_REPO_ID, "source_root", "/src/repo").unwrap();
+    crate::index::meta::set_repo_meta(&conn, LEGACY_REPO_ID, "indexed_at_ms", "9").unwrap();
+
+    register_repo(&conn, &identity("repo-abc", "myrepo"), Path::new("/src/repo"), 1).unwrap();
+    // Adoption re-pointed the meta to the real id and `single_repo_id` resolves it.
+    assert_eq!(
+        schema::single_repo_id(&conn).unwrap(),
+        "repo-abc",
+        "adopted: real id is the sole repo"
+    );
+
+    // The exact re-run `create_or_migrate` (hence `rebuild`) performs on an existing index.
+    schema::apply(&conn).expect("re-apply is idempotent on an already-migrated DB");
+
+    // `single_repo_id` still resolves the real id — its internal one-row `debug_assert` also fires
+    // if the conditional seed regressed and resurrected the placeholder beside the real row.
+    assert_eq!(
+        schema::single_repo_id(&conn).unwrap(),
+        "repo-abc",
+        "re-apply leaves the real id as the sole repo (no placeholder resurrected)"
+    );
+    // The relocated meta stays scoped to the real id, with its values, across the re-apply.
+    assert_eq!(
+        crate::index::meta::repo_meta(&conn, "repo-abc", "source_root").unwrap().as_deref(),
+        Some("/src/repo"),
+    );
+    assert_eq!(
+        crate::index::meta::repo_meta(&conn, "repo-abc", "indexed_at_ms").unwrap().as_deref(),
+        Some("9"),
+    );
+    let placeholder_meta: i64 = conn
+        .query_row("SELECT COUNT(*) FROM repo_meta WHERE repo_id = ?1", [LEGACY_REPO_ID], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(placeholder_meta, 0, "no repo_meta rows resurrected under the placeholder");
+}
+
 /// Defense in depth (FINDING 3): even though the resolver refuses a pinned placeholder, a
 /// hand-built `RepoIdentity` carrying the reserved marker must be REFUSED by `register_repo` —
 /// otherwise adoption degenerates: `real_repo_ids` filters the marker, the adoption UPDATE rewrites
@@ -263,4 +335,241 @@ fn register_repo_refuses_a_different_real_repo() {
     // The incumbent is untouched; the intruder never landed.
     assert_eq!(repo_row_count(&conn, "repo-abc"), 1);
     assert_eq!(repo_row_count(&conn, "repo-xyz"), 0);
+}
+
+// --- V039: per-repo meta relocation (memory-sync phase A2) ---
+
+/// Fresh `apply` runs V039; it relocates the listed per-repo singleton keys into `repo_meta` under
+/// the placeholder and leaves the machine-level keys in their global tables. This is the schema
+/// tip, so it owns the absolute `LATEST_SCHEMA_VERSION` pin.
+#[test]
+fn migration_039_relocates_per_repo_meta_and_leaves_global_keys() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 39, "V039 is the schema tip");
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema is at LATEST after V039"
+    );
+
+    // Seed the SOURCE tables as a legacy DB carries them: relocated keys plus, to prove
+    // selectivity, one machine-level key in EACH table that MUST stay put.
+    upsert_meta(&conn, "index_meta", "source_root", "/src/repo");
+    upsert_meta(&conn, "index_meta", "git_commit", "abc123");
+    upsert_meta(&conn, "index_meta", "active_embedding_model", "embedding-hash");
+    upsert_meta(&conn, "index_meta", "generated_flags_version", "1"); // machine-level, stays
+    upsert_meta(&conn, "reconcile_meta", "embedding_active_model_version", "hash-v1");
+    upsert_meta(&conn, "reconcile_meta", "vector_int8_reencode_cursor", "42\nmodel-a");
+    upsert_meta(&conn, "reconcile_meta", "last_embedding_reconcile_started_at_ms", "1000"); // stays
+
+    // Re-run the relocation (the tables were empty when apply() first ran it).
+    schema::apply_move_per_repo_meta(&conn).expect("relocate");
+
+    for (key, value) in [
+        ("source_root", "/src/repo"),
+        ("git_commit", "abc123"),
+        ("active_embedding_model", "embedding-hash"),
+        ("embedding_active_model_version", "hash-v1"),
+        ("vector_int8_reencode_cursor", "42\nmodel-a"),
+    ] {
+        assert_eq!(
+            crate::index::meta::repo_meta(&conn, LEGACY_REPO_ID, key).unwrap().as_deref(),
+            Some(value),
+            "{key} relocated to repo_meta under the placeholder"
+        );
+        assert!(!meta_present(&conn, "index_meta", key), "{key} removed from index_meta");
+        assert!(!meta_present(&conn, "reconcile_meta", key), "{key} removed from reconcile_meta");
+    }
+
+    // Machine-level keys are untouched: they stay in their global tables and never enter repo_meta.
+    assert!(meta_present(&conn, "index_meta", "generated_flags_version"), "index_meta key stays");
+    assert!(
+        meta_present(&conn, "reconcile_meta", "last_embedding_reconcile_started_at_ms"),
+        "reconcile timing key stays"
+    );
+    assert!(
+        crate::index::meta::repo_meta(&conn, LEGACY_REPO_ID, "generated_flags_version")
+            .unwrap()
+            .is_none(),
+        "machine-level key did not leak into repo_meta"
+    );
+}
+
+/// A legacy V038 index (per-repo keys still in the global tables, ledger at 38) gains the
+/// relocation on `migrate_forward`.
+#[test]
+fn migration_039_forward_migrates_a_v038_index() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+
+    // Simulate the V038 state: per-repo keys still in the GLOBAL tables, ledger reverted to 38.
+    upsert_meta(&conn, "index_meta", "indexed_at_ms", "5000");
+    upsert_meta(&conn, "reconcile_meta", "embedding_active_model_version", "hash-v1");
+    truncate_schema_to(&conn, 38);
+    assert_eq!(
+        schema::status(&conn).unwrap().state,
+        schema::SchemaState::Older,
+        "schema is Older after removing the V039 ledger row"
+    );
+
+    schema::migrate_forward(&conn).expect("migrate_forward");
+
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema is at LATEST after forward migrate"
+    );
+    assert_eq!(
+        crate::index::meta::repo_meta(&conn, LEGACY_REPO_ID, "indexed_at_ms").unwrap().as_deref(),
+        Some("5000"),
+        "index_meta key relocated on forward migrate"
+    );
+    assert_eq!(
+        crate::index::meta::repo_meta(&conn, LEGACY_REPO_ID, "embedding_active_model_version")
+            .unwrap()
+            .as_deref(),
+        Some("hash-v1"),
+        "reconcile_meta key relocated on forward migrate"
+    );
+    assert!(!meta_present(&conn, "index_meta", "indexed_at_ms"));
+    assert!(!meta_present(&conn, "reconcile_meta", "embedding_active_model_version"));
+}
+
+/// V039 in ISOLATION: on a bare conn carrying only the source meta tables + the V038 registry, the
+/// migration function relocates the keys — anchored to the migration function, not the full ladder
+/// (the directory's "assert behavior in isolation" rule). It also proves the run is idempotent.
+#[test]
+fn v039_relocation_runs_standalone_and_is_idempotent() {
+    let bare = rusqlite::Connection::open_in_memory().expect("open");
+    bare.execute_batch(
+        "CREATE TABLE index_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+         CREATE TABLE reconcile_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);",
+    )
+    .unwrap();
+    schema::apply_repos_registry(&bare).expect("V038 registry");
+    upsert_meta(&bare, "index_meta", "fts_dirty", "true");
+    upsert_meta(&bare, "reconcile_meta", "vector_int8_reencode_cursor", "7\nm");
+
+    schema::apply_move_per_repo_meta(&bare).expect("V039 relocation standalone");
+    schema::apply_move_per_repo_meta(&bare).expect("V039 relocation is idempotent");
+
+    assert_eq!(
+        crate::index::meta::repo_meta(&bare, LEGACY_REPO_ID, "fts_dirty").unwrap().as_deref(),
+        Some("true"),
+    );
+    assert_eq!(
+        crate::index::meta::repo_meta(&bare, LEGACY_REPO_ID, "vector_int8_reencode_cursor")
+            .unwrap()
+            .as_deref(),
+        Some("7\nm"),
+    );
+    assert!(!meta_present(&bare, "index_meta", "fts_dirty"));
+    assert!(!meta_present(&bare, "reconcile_meta", "vector_int8_reencode_cursor"));
+    // Re-run left exactly one relocated row (no duplicate from the second pass).
+    let count: i64 = bare
+        .query_row(
+            "SELECT COUNT(*) FROM repo_meta WHERE repo_id = ?1 AND key = 'fts_dirty'",
+            [LEGACY_REPO_ID],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(count, 1, "re-run does not duplicate the relocated row");
+}
+
+/// V039 leaves the relocated meta under the placeholder repo_id; `register_repo` adoption MUST
+/// carry those rows over to the real repo_id (Step 4), so a post-migration open does not orphan
+/// them.
+#[test]
+fn register_repo_adoption_relocates_repo_meta_rows() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    // As V039 leaves it: per-repo meta under the placeholder.
+    crate::index::meta::set_repo_meta(&conn, LEGACY_REPO_ID, "source_root", "/src/repo").unwrap();
+    crate::index::meta::set_repo_meta(&conn, LEGACY_REPO_ID, "indexed_at_ms", "9").unwrap();
+
+    register_repo(&conn, &identity("repo-abc", "myrepo"), Path::new("/src/repo"), 1).unwrap();
+
+    assert_eq!(
+        crate::index::meta::repo_meta(&conn, "repo-abc", "source_root").unwrap().as_deref(),
+        Some("/src/repo"),
+    );
+    assert_eq!(
+        crate::index::meta::repo_meta(&conn, "repo-abc", "indexed_at_ms").unwrap().as_deref(),
+        Some("9"),
+    );
+    let placeholder_rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM repo_meta WHERE repo_id = ?1", [LEGACY_REPO_ID], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(
+        placeholder_rows, 0,
+        "no repo_meta rows remain under the placeholder after adoption"
+    );
+}
+
+/// `single_repo_id` returns the sole `repos` row — the placeholder before adoption, the real id
+/// after — the connection-level stand-in the per-repo accessors resolve until A3.
+#[test]
+fn single_repo_id_returns_the_sole_repo() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    assert_eq!(
+        schema::single_repo_id(&conn).unwrap(),
+        LEGACY_REPO_ID,
+        "the placeholder is the sole repo before adoption"
+    );
+
+    register_repo(&conn, &identity("repo-abc", "myrepo"), Path::new("/src/repo"), 1).unwrap();
+    assert_eq!(
+        schema::single_repo_id(&conn).unwrap(),
+        "repo-abc",
+        "the adopted real id is the sole repo after registration"
+    );
+}
+
+/// The `repo_meta` accessors: upsert, read, no-op-if-unchanged, and delete — each scoped by
+/// `(repo_id, key)` so the same key under a different repo is independent.
+#[test]
+fn repo_meta_accessors_round_trip_and_scope_by_repo() {
+    use crate::index::meta::{
+        delete_repo_meta, repo_meta, set_repo_meta, set_repo_meta_if_changed,
+    };
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    // A second repos row so the (repo_id, key) scoping is observable (inserted directly — the
+    // phase-A single-repo invariant is about register_repo, not the storage layer).
+    conn.execute(
+        "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('repo-b', 'b', 0)",
+        [],
+    )
+    .unwrap();
+
+    // Upsert + read + overwrite.
+    assert!(repo_meta(&conn, LEGACY_REPO_ID, "k").unwrap().is_none());
+    set_repo_meta(&conn, LEGACY_REPO_ID, "k", "v1").unwrap();
+    assert_eq!(repo_meta(&conn, LEGACY_REPO_ID, "k").unwrap().as_deref(), Some("v1"));
+    set_repo_meta(&conn, LEGACY_REPO_ID, "k", "v2").unwrap();
+    assert_eq!(repo_meta(&conn, LEGACY_REPO_ID, "k").unwrap().as_deref(), Some("v2"));
+
+    // Scoped by repo_id: the same key under a different repo is independent.
+    set_repo_meta(&conn, "repo-b", "k", "other").unwrap();
+    assert_eq!(repo_meta(&conn, LEGACY_REPO_ID, "k").unwrap().as_deref(), Some("v2"));
+    assert_eq!(repo_meta(&conn, "repo-b", "k").unwrap().as_deref(), Some("other"));
+
+    // if_changed: no write when equal, write when different.
+    assert!(!set_repo_meta_if_changed(&conn, LEGACY_REPO_ID, "k", "v2").unwrap());
+    assert!(set_repo_meta_if_changed(&conn, LEGACY_REPO_ID, "k", "v3").unwrap());
+    assert_eq!(repo_meta(&conn, LEGACY_REPO_ID, "k").unwrap().as_deref(), Some("v3"));
+
+    // Delete is scoped and idempotent.
+    delete_repo_meta(&conn, LEGACY_REPO_ID, "k").unwrap();
+    assert!(repo_meta(&conn, LEGACY_REPO_ID, "k").unwrap().is_none());
+    assert_eq!(
+        repo_meta(&conn, "repo-b", "k").unwrap().as_deref(),
+        Some("other"),
+        "delete does not cross repos"
+    );
+    delete_repo_meta(&conn, LEGACY_REPO_ID, "k").unwrap(); // no-op when already absent
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -573,3 +573,130 @@ fn repo_meta_accessors_round_trip_and_scope_by_repo() {
     );
     delete_repo_meta(&conn, LEGACY_REPO_ID, "k").unwrap(); // no-op when already absent
 }
+
+/// FINDING 1 regression: an ALREADY-ADOPTED V038 DB (placeholder deleted, one REAL `repos` row)
+/// must forward-migrate through V039 without tripping the `repo_meta → repos` FK. V039 relocates
+/// the per-repo meta under the SOLE `repos` row — the real id here — not a hardcoded
+/// `__unassigned__` placeholder (gone after adoption). With `foreign_keys = ON` (production, via
+/// `IndexConnection`), the old hardcoded-placeholder insert ABORTS `migrate_forward` (`INSERT OR
+/// IGNORE` does NOT suppress an immediate FK violation); with it off it orphans rows
+/// `single_repo_id` can never resolve. Asserting the keys land under the real id — and the
+/// migration completes — covers both.
+#[test]
+fn migration_039_relocates_under_the_real_id_on_an_adopted_v038_db() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    // Match production: the FK is enforced, so a relocation targeting the vanished placeholder
+    // aborts (rather than silently orphaning the rows under a dangling id).
+    conn.execute_batch("PRAGMA foreign_keys = ON;").expect("enable FK enforcement");
+    schema::apply(&conn).expect("apply");
+
+    // The pre-relocation legacy shape: the per-repo keys still sit in the GLOBAL k/v tables.
+    upsert_meta(&conn, "index_meta", "source_root", "/src/repo");
+    upsert_meta(&conn, "index_meta", "indexed_at_ms", "5000");
+    upsert_meta(&conn, "reconcile_meta", "embedding_active_model_version", "hash-v1");
+
+    // Adopt: the placeholder row is deleted, leaving exactly one REAL repos row.
+    register_repo(&conn, &identity("repo-abc", "myrepo"), Path::new("/src/repo"), 1).unwrap();
+    assert_eq!(repo_row_count(&conn, LEGACY_REPO_ID), 0, "adopted: placeholder gone");
+
+    // Rewind the ledger to V038 and forward-migrate: V039 re-runs against the adopted DB.
+    truncate_schema_to(&conn, 38);
+    assert_eq!(schema::status(&conn).unwrap().state, schema::SchemaState::Older);
+    schema::migrate_forward(&conn)
+        .expect("V039 forward-migrates an adopted DB without an FK abort");
+
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema reaches LATEST after the forward migrate",
+    );
+    // The keys land under the REAL id (never the vanished placeholder); `single_repo_id` resolves
+    // it.
+    assert_eq!(schema::single_repo_id(&conn).unwrap(), "repo-abc");
+    for (key, value) in [
+        ("source_root", "/src/repo"),
+        ("indexed_at_ms", "5000"),
+        ("embedding_active_model_version", "hash-v1"),
+    ] {
+        assert_eq!(
+            crate::index::meta::repo_meta(&conn, "repo-abc", key).unwrap().as_deref(),
+            Some(value),
+            "{key} relocated under the real repo id",
+        );
+    }
+    let placeholder_meta: i64 = conn
+        .query_row("SELECT COUNT(*) FROM repo_meta WHERE repo_id = ?1", [LEGACY_REPO_ID], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(placeholder_meta, 0, "nothing relocated under the vanished placeholder");
+}
+
+/// FINDING 2 (atomicity): `register_repo`'s adoption — insert the real row, re-point `repo_meta`,
+/// drop the placeholder, record the root — runs in ONE transaction, so a failure mid-sequence rolls
+/// the WHOLE thing back. Without it, a crash after the insert but before the delete would leave
+/// BOTH the real row and the placeholder: the "already registered" fast path would then never
+/// repair it, and `single_repo_id`'s one-row expectation would break. Forced here with a temporary
+/// `BEFORE DELETE ON repos` trigger that RAISEs on the placeholder delete — adoption must return
+/// Err with the DB FULLY unchanged (placeholder present, its `repo_meta` rows intact, no real row,
+/// no roots); after dropping the trigger, adoption succeeds cleanly, proving the failed attempt
+/// left nothing behind.
+#[test]
+fn register_repo_adoption_is_atomic_on_a_mid_sequence_failure() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    conn.execute_batch("PRAGMA foreign_keys = ON;").expect("enable FK enforcement");
+    schema::apply(&conn).expect("apply");
+    // As V039 leaves a not-yet-adopted DB: per-repo meta under the placeholder.
+    crate::index::meta::set_repo_meta(&conn, LEGACY_REPO_ID, "source_root", "/src/repo").unwrap();
+    crate::index::meta::set_repo_meta(&conn, LEGACY_REPO_ID, "indexed_at_ms", "9").unwrap();
+
+    // Fail the adoption at its LAST mutation (the placeholder delete), mid-transaction.
+    conn.execute_batch(
+        "CREATE TRIGGER fail_placeholder_delete BEFORE DELETE ON repos
+         WHEN OLD.repo_id = '__unassigned__'
+         BEGIN SELECT RAISE(ABORT, 'injected adoption failure'); END;",
+    )
+    .expect("install failure trigger");
+
+    let err = register_repo(&conn, &identity("repo-abc", "myrepo"), Path::new("/src/repo"), 1)
+        .expect_err("adoption must fail while the trigger blocks the placeholder delete");
+    assert!(
+        err.to_string().contains("injected adoption failure"),
+        "surfaces the trigger RAISE: {err}",
+    );
+
+    // The transaction rolled back: the DB is the exact pre-adoption state.
+    assert_eq!(repo_row_count(&conn, LEGACY_REPO_ID), 1, "placeholder survives the rollback");
+    assert_eq!(repo_row_count(&conn, "repo-abc"), 0, "the half-inserted real row rolled back");
+    let total: i64 = conn.query_row("SELECT COUNT(*) FROM repos", [], |r| r.get(0)).unwrap();
+    assert_eq!(total, 1, "exactly the placeholder row remains");
+    assert_eq!(
+        crate::index::meta::repo_meta(&conn, LEGACY_REPO_ID, "source_root").unwrap().as_deref(),
+        Some("/src/repo"),
+        "repo_meta stays under the placeholder (the re-point rolled back)",
+    );
+    assert_eq!(
+        crate::index::meta::repo_meta(&conn, LEGACY_REPO_ID, "indexed_at_ms").unwrap().as_deref(),
+        Some("9"),
+    );
+    let real_meta: i64 = conn
+        .query_row("SELECT COUNT(*) FROM repo_meta WHERE repo_id = 'repo-abc'", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(real_meta, 0, "no repo_meta rows re-pointed to the real id");
+    let roots: i64 = conn.query_row("SELECT COUNT(*) FROM repo_roots", [], |r| r.get(0)).unwrap();
+    assert_eq!(roots, 0, "no root recorded (record_repo_root never committed)");
+
+    // Remove the fault and adopt again: a clean success, proving nothing was left half-done.
+    conn.execute_batch("DROP TRIGGER fail_placeholder_delete;").expect("drop trigger");
+    register_repo(&conn, &identity("repo-abc", "myrepo"), Path::new("/src/repo"), 2)
+        .expect("adoption succeeds once the fault is removed");
+    assert_eq!(repo_row_count(&conn, LEGACY_REPO_ID), 0, "placeholder adopted away");
+    assert_eq!(repo_row_count(&conn, "repo-abc"), 1, "the real repo owns the DB");
+    assert_eq!(schema::single_repo_id(&conn).unwrap(), "repo-abc");
+    assert_eq!(
+        crate::index::meta::repo_meta(&conn, "repo-abc", "source_root").unwrap().as_deref(),
+        Some("/src/repo"),
+        "meta carried over to the real id on the successful adoption",
+    );
+    assert_eq!(root_count(&conn, "repo-abc"), 1, "its root is recorded");
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
@@ -692,7 +692,7 @@ fn execute_one() {
     let db = IndexDatabase::rebuild(&config).unwrap();
     db.storage
         .connection()
-        .execute("UPDATE index_meta SET value = 'old' WHERE key = 'graph_index_version'", [])
+        .execute("UPDATE repo_meta SET value = 'old' WHERE key = 'graph_index_version'", [])
         .unwrap();
     db.storage
         .connection()

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
@@ -775,7 +775,7 @@ fn worktree_overlay_fts_freshness_revision_is_scope_invariant() {
     // And it matches the stored `fts_source_revision` `sync_fts` wrote during the overlay refresh,
     // so a base read sees FTS as fresh (no rebuild) rather than perpetually stale.
     assert_eq!(
-        db.meta("fts_source_revision").unwrap().as_deref(),
+        db.repo_meta("fts_source_revision").unwrap().as_deref(),
         Some(base_revision.as_str()),
         "fts_source_revision recorded during the overlay pass matches the global digest",
     );

--- a/crates/rag-rat-core/src/index/staleness.rs
+++ b/crates/rag-rat-core/src/index/staleness.rs
@@ -30,7 +30,7 @@ impl IndexDatabase {
         include_tests: bool,
     ) -> anyhow::Result<Vec<crate::query::graph::TextOnlyHit>> {
         let Some(root) = self.storage.source_root() else {
-            anyhow::bail!("cannot compare graph to text: source_root is missing from index_meta");
+            anyhow::bail!("cannot compare graph to text: source_root is missing from repo_meta");
         };
         let mut stmt = self.storage.connection().prepare("SELECT path FROM files ORDER BY path")?;
         let paths =

--- a/crates/rag-rat-core/src/query/memory/validate.rs
+++ b/crates/rag-rat-core/src/query/memory/validate.rs
@@ -408,24 +408,20 @@ pub(crate) fn validate_path_binding(
         _ => Ok("current".to_string()),
     }
 }
-/// The persisted `source_root` (the on-disk repo root recorded in `index_meta` at
+/// The persisted `source_root` (the on-disk repo root recorded in `repo_meta` at
 /// open/rebuild/incremental). `None` on a raw connection that never recorded it (some test
 /// fixtures). This is a SINGLE shared value — under a shared DB across git worktrees it reflects
 /// whichever worktree last indexed, which is why [`validate_memories`] prefers the caller-supplied
 /// active checkout root and only falls back to this (#98 review).
 fn persisted_source_root(conn: &Connection) -> Option<PathBuf> {
-    conn.query_row("SELECT value FROM index_meta WHERE key = 'source_root'", [], |row| {
-        row.get::<_, String>(0)
-    })
-    .optional()
-    .ok()
-    .flatten()
-    .map(PathBuf::from)
+    // `source_root` moved to `repo_meta` (V039); resolve the active repo (the lone one in phase A).
+    let repo_id = crate::index::schema::single_repo_id(conn).ok()?;
+    crate::index::repo_meta(conn, &repo_id, "source_root").ok().flatten().map(PathBuf::from)
 }
 
 /// The filesystem root the off-index existence checks resolve against: the caller-supplied ACTIVE
 /// checkout root (`storage.source_root`, correct under a multi-worktree shared DB) when known, else
-/// the single persisted `index_meta.source_root` (#98 review).
+/// the single persisted `repo_meta.source_root` (#98 review).
 pub(crate) fn effective_fs_root(conn: &Connection, active_root: Option<&Path>) -> Option<PathBuf> {
     active_root.map(Path::to_path_buf).or_else(|| persisted_source_root(conn))
 }


### PR DESCRIPTION
Phase A2 of the global-DB consolidation (#397, milestone "Memory durability & p2p sync"). Builds on the V038 registry (#408).

- **V039**: relocates the 18 per-repo singleton keys out of the global `index_meta`/`reconcile_meta` into `repo_meta(repo_id, key, value)` under the adoption placeholder — `source_root`, `content_revision`, `git_commit`/`git_dirty`, `graph_index_version`, `active_embedding_model`, `clone_graph_live_generation`, `github_last_sync_ms`, the `git_history_indexed_*` trio, `local_crate_roots`, `indexed_at_ms`, the FTS-freshness trio, and the reconcile model-version + reencode cursor. Truly machine/db-level keys stay in `index_meta`.
- **Repo-scoped accessors**: `repo_meta` / `set_repo_meta` / `set_repo_meta_if_changed` / `delete_repo_meta` (upsert semantics matching the existing helpers), with `IndexDatabase` method wrappers; every reader/writer swept (including three single-quoted-SQL readers a double-quoted grep would miss).
- **`single_repo_id(conn)`**: interim scope resolution until the connection carries a full `(repo_id, commit_sha, worktree_id)` context in phase A3 — the method wrappers resolve it internally, so A3 swaps one body.
- **Adoption extended**: `register_repo` re-points placeholder `repo_meta` rows to the real id (insert-first ordering; the `repo_meta`→`repos` FK forbids rewriting the PK in place), with an interaction test proving a post-adoption schema re-apply keeps `single_repo_id` and the relocated rows on the real id.

Tests: relocation completeness per key (moved keys present under the placeholder, gone from both source tables; unmoved keys stay), forward-migration from V038, standalone/idempotent migration form, adoption re-pointing, accessor round-trip + cross-repo scoping isolation. Workspace suite 1423 passed; clippy `-D warnings` clean.

Fixes #397