### PR TITLE
feat(index): V040 — repo_id scoping on core tables, scope view, gc (#398 phase A3)

### DIFF
--- a/crates/rag-rat-cli/src/claude_hook/mod.rs
+++ b/crates/rag-rat-cli/src/claude_hook/mod.rs
@@ -324,6 +324,7 @@ fn session_start(input: &HookInput) -> anyhow::Result<()> {
         conn.connection(),
         &config.root,
         Path::new(&input.cwd),
+        config.repo_id_override.as_deref(),
     )?;
     let (live, enabled) = watcher_state(&config);
     print!("{}", format_digest(&o, live, enabled));
@@ -719,9 +720,20 @@ fn fallback_compose(config: &Config, cwd: &str, search: &Search) -> Option<Strin
     let conn = IndexConnection::open_read_only(&config.database).ok()?;
     // Scope to the session's worktree overlay before composing — `compose` queries the `files`
     // view, so without this it would read raw (unscoped) rows. config.root is the anchored main
-    // worktree; cwd is the session dir (a linked worktree → its overlay, else base) (#219).
+    // worktree; cwd is the session dir (a linked worktree → its overlay, else base) (#219). Resolve
+    // the repo dimension from this config (identity + override) so the scope binds the config's
+    // repo, not the config-blind sole repo (a sibling in a consolidated DB); an unprovable repo →
+    // empty scope, never a sibling's rows.
+    let repo_id = rag_rat_core::index::resolve_scope_repo_id(
+        conn.connection(),
+        &config.root,
+        config.repo_id_override.as_deref(),
+    )
+    .ok()?
+    .unwrap_or_default();
     rag_rat_core::index::install_worktree_scope_view(
         conn.connection(),
+        &repo_id,
         &config.root,
         Path::new(cwd),
     )

--- a/crates/rag-rat-core/src/index/ai/helpers.rs
+++ b/crates/rag-rat-core/src/index/ai/helpers.rs
@@ -398,33 +398,34 @@ pub(crate) fn meta(conn: &Connection, key: &str) -> anyhow::Result<Option<String
         .optional()?)
 }
 
-/// Delete an `index_meta` key (a no-op when absent) — the `index_meta` counterpart of
-/// [`delete_repo_meta`].
+/// Delete a GLOBAL meta key from `index_meta` (a no-op when absent) — the `index_meta` counterpart
+/// of [`delete_repo_meta`]. Used by the int8 reencode clear path, whose cursor is global (it walks
+/// the whole `chunk_embeddings` table beside an already-global done-gate).
 pub(crate) fn delete_meta(conn: &Connection, key: &str) -> anyhow::Result<()> {
-    conn.execute("DELETE FROM index_meta WHERE key = ?1", params![key])?;
+    conn.execute("DELETE FROM index_meta WHERE key = ?1", [key])?;
     Ok(())
 }
 
 /// Read a per-repo meta value (`repo_meta`) for the repo owning `conn` — the repo-scoped twin of
-/// [`meta`], resolving the active repo via `single_repo_id` (phase A3 replaces that with a real
-/// scope context). Used for the per-repo keys V039 relocated out of `index_meta` /
-/// `reconcile_meta`: the active embedding model and its freshness version, and the int8 reencode
-/// cursor.
+/// [`meta`], resolving the active repo via `schema::active_repo_id` (the scope-context id, falling
+/// back to the sole repo). Used for the per-repo keys relocated out of `index_meta` /
+/// `reconcile_meta`: the active embedding model, its freshness version, its provisional/remote-
+/// config provenance (V040), and the int8 reencode cursor.
 pub(crate) fn repo_meta(conn: &Connection, key: &str) -> anyhow::Result<Option<String>> {
-    let repo_id = crate::index::schema::single_repo_id(conn)?;
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     Ok(crate::index::repo_meta(conn, &repo_id, key)?)
 }
 
 /// Upsert a per-repo meta value — the repo-scoped twin of [`set_meta`].
 pub(crate) fn set_repo_meta(conn: &Connection, key: &str, value: &str) -> anyhow::Result<()> {
-    let repo_id = crate::index::schema::single_repo_id(conn)?;
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     crate::index::set_repo_meta(conn, &repo_id, key, value)?;
     Ok(())
 }
 
-/// Delete a per-repo meta key (a no-op when absent) — the repo-scoped twin of [`delete_meta`].
+/// Delete a per-repo meta key from `repo_meta` (a no-op when absent).
 pub(crate) fn delete_repo_meta(conn: &Connection, key: &str) -> anyhow::Result<()> {
-    let repo_id = crate::index::schema::single_repo_id(conn)?;
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     crate::index::delete_repo_meta(conn, &repo_id, key)?;
     Ok(())
 }
@@ -442,7 +443,8 @@ pub(crate) fn set_active_remote_config(
 ) -> anyhow::Result<()> {
     let json = serde_json::to_string(remote)
         .map_err(|e| anyhow::anyhow!("failed to serialize remote embedding config: {e}"))?;
-    set_meta(conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META, &json)
+    // Per-repo since V040 (rejoined the active-model provenance family in `repo_meta`).
+    set_repo_meta(conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META, &json)
 }
 
 /// Read the persisted active remote-embedding config (the inverse of [`set_active_remote_config`]).
@@ -453,7 +455,7 @@ pub(crate) fn set_active_remote_config(
 pub(crate) fn active_remote_config(
     conn: &Connection,
 ) -> anyhow::Result<Option<RemoteEmbeddingConfig>> {
-    let Some(json) = meta(conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META)? else {
+    let Some(json) = repo_meta(conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META)? else {
         return Ok(None);
     };
     let remote: RemoteEmbeddingConfig = serde_json::from_str(&json).map_err(|e| {
@@ -469,7 +471,7 @@ pub(crate) fn active_remote_config(
 /// `active_embedder` stops reconstructing an `OpenAiEmbedder` from a stale prior remote install of
 /// the same model (a no-op when the meta is already absent).
 pub(crate) fn clear_active_remote_config(conn: &Connection) -> anyhow::Result<()> {
-    delete_meta(conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META)
+    delete_repo_meta(conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META)
 }
 
 pub(crate) fn set_reconcile_meta(conn: &Connection, key: &str, value: &str) -> anyhow::Result<()> {
@@ -570,7 +572,7 @@ mod tests {
         assert_eq!(active_remote_config(&conn).unwrap(), Some(remote));
 
         // SECRET-FREE: the serialized JSON carries the auth_env NAME but no token value.
-        let json = meta(&conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META).unwrap().unwrap();
+        let json = repo_meta(&conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META).unwrap().unwrap();
         assert!(json.contains("OLLAMA_TOKEN"), "stores the env-var name: {json}");
         // Belt-and-suspenders: no bearer/token-shaped material leaks into the meta.
         assert!(!json.to_lowercase().contains("bearer"), "no bearer token in meta: {json}");
@@ -581,7 +583,7 @@ mod tests {
     fn active_remote_config_errors_on_malformed_meta() {
         // A corrupted meta must surface loudly, not silently degrade to "no remote config".
         let conn = schema_conn();
-        set_meta(&conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META, "{not valid json").unwrap();
+        set_repo_meta(&conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META, "{not valid json").unwrap();
         let err = active_remote_config(&conn).expect_err("malformed meta must error");
         assert!(err.to_string().contains("malformed"), "{err}");
     }

--- a/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
@@ -1501,7 +1501,7 @@ mod freshness_version_tests {
         .unwrap();
         set_repo_meta(&conn, ACTIVE_EMBEDDING_MODEL_META, FASTEMBED_MODEL_ID).unwrap();
         set_repo_meta(&conn, ACTIVE_EMBEDDING_MODEL_VERSION_META, spec.version).unwrap();
-        set_meta(&conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META, "{not valid json").unwrap();
+        set_repo_meta(&conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META, "{not valid json").unwrap();
 
         let report =
             reconcile_with_options_progress(&conn, ReconcileOptions::default(), |_| {}).unwrap();

--- a/crates/rag-rat-core/src/index/ai/reconcile/manifest.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/manifest.rs
@@ -32,7 +32,7 @@ pub(crate) fn ensure_model_manifest(conn: &Connection) -> anyhow::Result<()> {
 /// still owed (falling back to the read-write open, which heals once).
 pub(crate) fn model_manifest_is_current(conn: &Connection) -> anyhow::Result<bool> {
     // The active-model meta moved to `repo_meta` (V039); check the active repo's row there.
-    let repo_id = crate::index::schema::single_repo_id(conn)?;
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     for model_id in LEGACY_MODEL_IDS {
         let lingering: bool = conn.query_row(
             "SELECT EXISTS(SELECT 1 FROM ai_models WHERE model_id = ?1)
@@ -71,7 +71,7 @@ pub(crate) fn model_manifest_is_current(conn: &Connection) -> anyhow::Result<boo
 
 pub(crate) fn remove_legacy_models(conn: &Connection) -> anyhow::Result<()> {
     // The active-model meta moved to `repo_meta` (V039); clear it for the active repo.
-    let repo_id = crate::index::schema::single_repo_id(conn)?;
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     for model_id in LEGACY_MODEL_IDS {
         conn.execute("DELETE FROM chunk_embeddings WHERE model_id = ?1", params![model_id])?;
         conn.execute("DELETE FROM ai_models WHERE model_id = ?1", params![model_id])?;

--- a/crates/rag-rat-core/src/index/ai/reconcile/model_lifecycle.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/model_lifecycle.rs
@@ -107,25 +107,29 @@ pub(crate) fn activate_model_with_version(
     version: &str,
     provisional: bool,
 ) -> anyhow::Result<()> {
-    // Model id + freshness version are per-repo (V039 → repo_meta); the provenance flag is NOT in
-    // the phase-A2 move list, so it stays in the global `index_meta` (A3/A5 scope it later). Split
-    // across tables but still stamped together in this single writer's one call.
+    // The whole active-model provenance family is per-repo now: model id + freshness version moved
+    // to `repo_meta` in V039, and V040 reunited the provisional flag (+ remote config) there — one
+    // writer, one table.
     set_repo_meta(conn, ACTIVE_EMBEDDING_MODEL_META, model_id)?;
     set_repo_meta(conn, ACTIVE_EMBEDDING_MODEL_VERSION_META, version)?;
-    set_meta(conn, ACTIVE_EMBEDDING_MODEL_PROVISIONAL_META, if provisional { "1" } else { "0" })?;
+    set_repo_meta(
+        conn,
+        ACTIVE_EMBEDDING_MODEL_PROVISIONAL_META,
+        if provisional { "1" } else { "0" },
+    )?;
     Ok(())
 }
 
 /// Whether the active embedding model is PROVISIONAL — set automatically (seed / cache recovery)
 /// and not yet confirmed by an explicit install or a committed reconcile. Absent ⇒ non-provisional.
 pub(crate) fn active_embedding_model_is_provisional(conn: &Connection) -> anyhow::Result<bool> {
-    Ok(meta(conn, ACTIVE_EMBEDDING_MODEL_PROVISIONAL_META)?.as_deref() == Some("1"))
+    Ok(repo_meta(conn, ACTIVE_EMBEDDING_MODEL_PROVISIONAL_META)?.as_deref() == Some("1"))
 }
 
 /// Clear the provisional flag — the active model is now the CONFIRMED choice (an explicit install,
 /// or a reconcile that committed embeddings under it). Idempotent.
 pub(crate) fn clear_active_embedding_model_provisional(conn: &Connection) -> anyhow::Result<()> {
-    set_meta(conn, ACTIVE_EMBEDDING_MODEL_PROVISIONAL_META, "0")
+    set_repo_meta(conn, ACTIVE_EMBEDDING_MODEL_PROVISIONAL_META, "0")
 }
 
 /// Clear the active embedding model entirely — the inverse of [`activate_model_with_version`].
@@ -138,7 +142,7 @@ pub(crate) fn clear_active_embedding_model_provisional(conn: &Connection) -> any
 pub(crate) fn clear_active_embedding_model(conn: &Connection) -> anyhow::Result<()> {
     delete_repo_meta(conn, ACTIVE_EMBEDDING_MODEL_META)?;
     delete_repo_meta(conn, ACTIVE_EMBEDDING_MODEL_VERSION_META)?;
-    delete_meta(conn, ACTIVE_EMBEDDING_MODEL_PROVISIONAL_META)?;
+    delete_repo_meta(conn, ACTIVE_EMBEDDING_MODEL_PROVISIONAL_META)?;
     clear_active_remote_config(conn)
 }
 
@@ -450,7 +454,7 @@ mod seed_active_embedding_model_tests {
         // A prior open seeded jina PROVISIONALLY, and a remote-config meta was left behind. The
         // user then edits the config to `model = "none"`.
         seed_active_embedding_model(&conn, Some(JINA)).unwrap();
-        set_meta(&conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META, "{\"stale\":true}").unwrap();
+        set_repo_meta(&conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META, "{\"stale\":true}").unwrap();
         assert!(active_embedding_model_is_provisional(&conn).unwrap());
 
         assert!(

--- a/crates/rag-rat-core/src/index/ai/reencode.rs
+++ b/crates/rag-rat-core/src/index/ai/reencode.rs
@@ -6,10 +6,18 @@ use super::*;
 /// so no fresh f32 rows ever appear after the conversion.
 const VECTOR_INT8_REENCODE_DONE_META: &str = "vector_int8_reencode_done";
 
-/// Reconcile-meta key persisting the keyset cursor (the last converted `(chunk_id, model_id)`)
+/// GLOBAL `index_meta` key persisting the keyset cursor (the last converted `(chunk_id, model_id)`)
 /// across maintenance passes, so a deadline-stopped conversion RESUMES from where it left off
 /// instead of rescanning from the table head. Serialized as `"<chunk_id>\n<model_id>"`. Only
 /// meaningful while the done-gate ([`VECTOR_INT8_REENCODE_DONE_META`]) is unset.
+///
+/// GLOBAL, not per-repo (V040 reclassification): the re-encode walks the WHOLE `chunk_embeddings`
+/// table (the SELECT/UPDATE below carry no `repo_id` filter) — a format-only conversion that is
+/// repo-independent — and its done-gate is already global. V039 relocated the cursor to
+/// `repo_meta`, which split a single global walk into per-repo resume markers: a sibling repo's
+/// open would find no cursor and rescan from the head. Keep it in `index_meta` (`meta` / `set_meta`
+/// / `delete_meta`), alongside the done-gate. (V040's `move_repo_meta_keys_to_global` migrates a
+/// stale per-repo copy.)
 const VECTOR_INT8_REENCODE_CURSOR_META: &str = "vector_int8_reencode_cursor";
 
 /// Rows converted per transaction. Bounded so a huge index (millions of embeddings) never builds
@@ -118,7 +126,7 @@ fn reencode_legacy_f32_blobs_batched(
 /// back to the sentinel — re-walking from the head is correct (already-int8 rows are skipped),
 /// never wrong.
 fn load_cursor(conn: &Connection) -> anyhow::Result<(i64, String)> {
-    let Some(raw) = repo_meta(conn, VECTOR_INT8_REENCODE_CURSOR_META)? else {
+    let Some(raw) = meta(conn, VECTOR_INT8_REENCODE_CURSOR_META)? else {
         return Ok((i64::MIN, String::new()));
     };
     let Some((chunk_id, model_id)) = raw.split_once('\n') else {
@@ -132,7 +140,7 @@ fn load_cursor(conn: &Connection) -> anyhow::Result<(i64, String)> {
 
 /// Persist the keyset cursor as `"<chunk_id>\n<model_id>"` (model ids never contain a newline).
 fn save_cursor(conn: &Connection, cursor: &(i64, String)) -> anyhow::Result<()> {
-    set_repo_meta(conn, VECTOR_INT8_REENCODE_CURSOR_META, &format!("{}\n{}", cursor.0, cursor.1))
+    set_meta(conn, VECTOR_INT8_REENCODE_CURSOR_META, &format!("{}\n{}", cursor.0, cursor.1))
 }
 
 /// Read up to `limit` legacy f32 rows past `cursor`, in `(chunk_id, model_id)` order (the UNIQUE
@@ -266,7 +274,7 @@ fn reencode_and_mark_if_complete(
 
 /// Drop the persisted keyset cursor once the conversion is complete (it is no longer meaningful).
 fn clear_cursor(conn: &Connection) -> anyhow::Result<()> {
-    delete_repo_meta(conn, VECTOR_INT8_REENCODE_CURSOR_META)?;
+    delete_meta(conn, VECTOR_INT8_REENCODE_CURSOR_META)?;
     Ok(())
 }
 
@@ -277,8 +285,10 @@ mod tests {
     /// `chunk_embeddings` with the columns the re-encode touches, matching the PROD shape from
     /// `schema/baseline.rs`: a surrogate `id INTEGER PRIMARY KEY AUTOINCREMENT` plus a
     /// `UNIQUE(chunk_id, model_id)` secondary index — so the keyset `ORDER BY chunk_id, model_id`
-    /// exercises that UNIQUE index (not a clustered PK), as in production. `index_meta` is the
-    /// done-gate store; `reconcile_meta` is the keyset-cursor store.
+    /// exercises that UNIQUE index (not a clustered PK), as in production. `index_meta` stores BOTH
+    /// the done-gate AND the keyset cursor: the cursor is GLOBAL (the re-encode walks the whole
+    /// `chunk_embeddings` table repo-independently), so no `repos`/`repo_meta` scaffolding is
+    /// needed.
     fn setup_conn() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(
@@ -290,17 +300,7 @@ mod tests {
                  vector_blob BLOB NOT NULL,
                  UNIQUE(chunk_id, model_id)
              );
-             CREATE TABLE index_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);
-             CREATE TABLE reconcile_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);
-             -- The reencode cursor moved to `repo_meta` (V039), read/written through
-             -- `single_repo_id` → the `repos` registry; seed the placeholder so the cursor path
-             -- resolves the same lone repo production does.
-             CREATE TABLE repos(repo_id TEXT PRIMARY KEY, display_name TEXT NOT NULL, \
-             registered_at_ms INTEGER NOT NULL);
-             INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('__unassigned__', \
-             '', 0);
-             CREATE TABLE repo_meta(repo_id TEXT NOT NULL, key TEXT NOT NULL, value TEXT, PRIMARY \
-             KEY(repo_id, key));",
+             CREATE TABLE index_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);",
         )
         .unwrap();
         conn
@@ -493,7 +493,7 @@ mod tests {
     }
 
     fn stored_cursor(conn: &Connection) -> Option<String> {
-        repo_meta(conn, VECTOR_INT8_REENCODE_CURSOR_META).unwrap()
+        meta(conn, VECTOR_INT8_REENCODE_CURSOR_META).unwrap()
     }
 
     #[test]
@@ -538,7 +538,7 @@ mod tests {
             )
             .unwrap();
         }
-        set_repo_meta(&conn, VECTOR_INT8_REENCODE_CURSOR_META, "1\nmodel-a").unwrap();
+        set_meta(&conn, VECTOR_INT8_REENCODE_CURSOR_META, "1\nmodel-a").unwrap();
         assert_eq!(count_remaining_f32(&conn), 4, "4 f32 rows remain past the cursor");
 
         // A follow-up call with NO deadline resumes from the persisted cursor and finishes the

--- a/crates/rag-rat-core/src/index/edges/helpers.rs
+++ b/crates/rag-rat-core/src/index/edges/helpers.rs
@@ -263,6 +263,16 @@ pub(crate) fn symbols_for_file(
 /// raw `symbols` duplicated every symbol whenever multiple scopes coexist and collapsed edge
 /// resolution (#89).
 pub(crate) fn all_symbols(conn: &Connection) -> anyhow::Result<Vec<IndexedSymbol>> {
+    // Scope the edge-resolution CANDIDATE POOL to the active repo (A3). This SELECT joins `files` —
+    // the per-connection scope VIEW when one is installed (rebuild / incremental / overlay), which
+    // already filters `repo_id`. But the bare-open graph refresh (`IndexDatabase::open` →
+    // `ensure_graph_index_current`) runs with NO scope view, so `files` resolves to the unscoped
+    // `main.files` and would pull EVERY repo's symbols into the pool in a consolidated DB — letting
+    // repo A's edges resolve onto repo B's symbols. The `main.files` sub-select pins the pool to
+    // the active repo in both cases: redundant under a scope view (view rows ⊆ active repo),
+    // and the sole repo predicate on the view-less path. `active_repo_id` falls back to
+    // `sole_repo_id` when no context is installed, matching the bare-open scope.
+    let active_repo_id = crate::index::schema::active_repo_id(conn)?;
     let mut stmt = conn.prepare(
         "
         SELECT symbols.id, symbols.file_id, symbols.language, symbols.name, qn.value, symbols.kind,
@@ -271,10 +281,11 @@ pub(crate) fn all_symbols(conn: &Connection) -> anyhow::Result<Vec<IndexedSymbol
         FROM symbols
         JOIN files ON files.id = symbols.file_id
         LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
+        WHERE symbols.file_id IN (SELECT id FROM main.files WHERE repo_id = ?1)
         ORDER BY qn.value
         ",
     )?;
-    let rows = stmt.query_map([], symbol_row)?;
+    let rows = stmt.query_map(rusqlite::params![active_repo_id], symbol_row)?;
     collect_rows(rows)
 }
 pub(crate) fn symbol_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<IndexedSymbol> {

--- a/crates/rag-rat-core/src/index/edges/imports.rs
+++ b/crates/rag-rat-core/src/index/edges/imports.rs
@@ -27,7 +27,7 @@ use super::{ImportScopeRange, MOD_FILE_ROOT};
 /// absent (a non-Cargo corpus, a pre-V021 index, or a raw conn without the registry), which makes
 /// [`ImportScope`] suppress nothing.
 pub(crate) fn load_local_roots(conn: &Connection) -> HashSet<String> {
-    crate::index::schema::single_repo_id(conn)
+    crate::index::schema::active_repo_id(conn)
         .and_then(|repo_id| crate::index::repo_meta(conn, &repo_id, "local_crate_roots"))
         .ok()
         .flatten()

--- a/crates/rag-rat-core/src/index/edges/resolve/mod.rs
+++ b/crates/rag-rat-core/src/index/edges/resolve/mod.rs
@@ -129,10 +129,15 @@ fn load_package_roots_into_scope(
     conn: &Connection,
     scope: &mut imports::ImportScope,
 ) -> anyhow::Result<()> {
-    // The active checkout's (commit_sha, worktree_id), so the `packages` read is scoped exactly
-    // like the `files` view (which reads the same context table). A raw test connection without
-    // the context falls back to empty strings — the same scope `add_package`/`refresh_packages`
-    // write under for non-git fixtures, so the test path stays consistent.
+    // The active checkout's (repo_id, commit_sha, worktree_id), so the `packages` read is scoped
+    // exactly like the `files` view (which reads the same context table). The `repo_id` predicate
+    // (A3) is what keeps a sibling repo's package roots out of THIS repo's import scope in a
+    // consolidated DB where two repos share the empty non-git scope. A raw test connection without
+    // the context falls back to the sole repo (placeholder on an un-adopted DB, matching the
+    // placeholder-defaulted `packages` rows) and to empty commit/worktree — the same scope
+    // `add_package`/`refresh_packages` write under for non-git fixtures, so the test path stays
+    // consistent.
+    let active_repo_id = crate::index::schema::active_repo_id(conn)?;
     let active_commit_sha = scope_context_value(conn, "commit_sha");
     let active_worktree_id = scope_context_value(conn, "worktree_id");
 
@@ -142,16 +147,17 @@ fn load_package_roots_into_scope(
     // reinsert and is meaningless across scopes).
     let packages: Vec<(String, HashSet<String>)> = {
         let mut stmt = match conn.prepare(
-            "SELECT manifest_dir, local_roots_json FROM packages WHERE commit_sha = ?1 AND \
-             worktree_id = ?2",
+            "SELECT manifest_dir, local_roots_json FROM packages WHERE repo_id = ?1 AND \
+             commit_sha = ?2 AND worktree_id = ?3",
         ) {
             Ok(stmt) => stmt,
             // No `packages` table (pre-V022 / non-Cargo): nothing to load, fall open.
             Err(_) => return Ok(()),
         };
-        let rows = stmt.query_map(params![active_commit_sha, active_worktree_id], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-        })?;
+        let rows = stmt
+            .query_map(params![active_repo_id, active_commit_sha, active_worktree_id], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?;
         let mut packages: Vec<(String, HashSet<String>)> = rows
             .map(|row| {
                 let (manifest_dir, roots_json) = row?;

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -97,8 +97,8 @@ impl IndexDatabase {
         let has_test_code = chunks.iter().any(|pc| text_has_test_marker(&pc.chunk.text));
         let file_id = self.storage.connection().query_row(
             "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, generated, \
-             indexed_at_ms, indexed_revision, commit_sha, worktree_id, has_test_code)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+             indexed_at_ms, indexed_revision, commit_sha, worktree_id, has_test_code, repo_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
              RETURNING id",
             params![
                 path_string(path),
@@ -112,6 +112,7 @@ impl IndexDatabase {
                 &scope.commit_sha,
                 &scope.worktree_id,
                 has_test_code,
+                self.active_repo_id,
             ],
             |row| row.get::<_, i64>(0),
         )?;
@@ -171,8 +172,8 @@ impl IndexDatabase {
             .connection()
             .prepare_cached(
                 "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, generated, \
-                 indexed_at_ms, indexed_revision, commit_sha, worktree_id, has_test_code)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+                 indexed_at_ms, indexed_revision, commit_sha, worktree_id, has_test_code, repo_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
                  RETURNING id",
             )?
             .query_row(
@@ -188,6 +189,7 @@ impl IndexDatabase {
                     file.commit_sha,
                     file.worktree_id,
                     has_test_code,
+                    self.active_repo_id,
                 ],
                 |row| row.get::<_, i64>(0),
             )?;
@@ -485,19 +487,23 @@ impl IndexDatabase {
     /// call would dominate.
     pub(super) fn insert_logical_group(
         conn: &rusqlite::Connection,
+        repo_id: &str,
         key: &LogicalSymbolKey,
         members: &[LogicalSymbolMemberRow],
     ) -> anyhow::Result<()> {
         let group_reason = if members.len() > 1 { "cfg_variant" } else { "single" };
-        let logical_symbol_id = key.stable_id();
+        // Repo-distinct id (A3): `stable_id` folds `repo_id` into the content hash so two repos
+        // with identical content don't collide on the `logical_symbols.id` PK in a
+        // consolidated DB.
+        let logical_symbol_id = key.stable_id(repo_id);
         // Intern the qualified name into the shared `name_strings` pool (#224) — the
         // qualified_name TEXT column was dropped in V028.
         let qualified_name_id = crate::index::edges::intern_edge_string(conn, &key.qualified_name)?;
         conn.prepare_cached(
             "
             INSERT INTO logical_symbols(id, language, path, logical_name, qualified_name_id, kind, \
-             variant_count, group_reason)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             variant_count, group_reason, repo_id)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
             ",
         )?
         .execute(params![
@@ -509,6 +515,7 @@ impl IndexDatabase {
             key.kind,
             i64::try_from(members.len()).unwrap_or(i64::MAX),
             group_reason,
+            repo_id,
         ])?;
         for member in members {
             let signature_hash =

--- a/crates/rag-rat-core/src/index/file_rows.rs
+++ b/crates/rag-rat-core/src/index/file_rows.rs
@@ -23,14 +23,14 @@ impl IndexDatabase {
         self.remove_file_in_scope(Path::new(&path), "", worktree_id)?;
         self.storage.connection().execute(
             "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, generated, \
-             indexed_at_ms, indexed_revision, commit_sha, worktree_id)
-             VALUES (?1, 'unknown', 'deleted', '', 0, 0, ?2, '', '', ?3)
-             ON CONFLICT(path, commit_sha, worktree_id) DO UPDATE SET
+             indexed_at_ms, indexed_revision, commit_sha, worktree_id, repo_id)
+             VALUES (?1, 'unknown', 'deleted', '', 0, 0, ?2, '', '', ?3, ?4)
+             ON CONFLICT(repo_id, path, commit_sha, worktree_id) DO UPDATE SET
                 kind = 'deleted',
                 sha256 = '',
                 modified_at_ms = 0,
                 indexed_at_ms = excluded.indexed_at_ms",
-            params![path, now_ms(), worktree_id],
+            params![path, now_ms(), worktree_id, self.active_repo_id],
         )?;
         self.mark_fts_dirty()?;
         Ok(())
@@ -47,6 +47,7 @@ impl IndexDatabase {
         // symbols, so they must not pay the view triggers' per-row dictionary probes.
         // 'NameOnly' is the EdgeConfidence demotion the resolver applies to a target-less edge.
         let name_only_id = edges::intern_edge_string(self.storage.connection(), "NameOnly")?;
+        let repo_id = self.active_repo_id.as_str();
         self.storage.connection().execute(
             "UPDATE edges_data
              SET to_symbol_id = NULL,
@@ -57,14 +58,15 @@ impl IndexDatabase {
                  WHERE main.files.path = ?1
                    AND main.files.commit_sha = ?2
                    AND main.files.worktree_id = ?3
+                   AND main.files.repo_id = ?5
              )",
-            params![path, commit_sha, worktree_id, name_only_id],
+            params![path, commit_sha, worktree_id, name_only_id, repo_id],
         )?;
         self.storage.connection().execute(
             "DELETE FROM edges_data
              WHERE source_file_id IN (
                     SELECT id FROM main.files
-                    WHERE path = ?1 AND commit_sha = ?2 AND worktree_id = ?3
+                    WHERE path = ?1 AND commit_sha = ?2 AND worktree_id = ?3 AND repo_id = ?4
                 )
                 OR from_symbol_id IN (
                     SELECT symbols.id FROM symbols
@@ -72,17 +74,21 @@ impl IndexDatabase {
                     WHERE main.files.path = ?1
                       AND main.files.commit_sha = ?2
                       AND main.files.worktree_id = ?3
+                      AND main.files.repo_id = ?4
                 )",
-            params![path, commit_sha, worktree_id],
+            params![path, commit_sha, worktree_id, repo_id],
         )?;
-        // `parser_failures` is keyed by `path` only (no scope). A LINKED-WORKTREE OVERLAY pass must
-        // NOT delete by bare path: that would clear a REAL parse failure recorded for the same path
+        // `parser_failures` is keyed by `(repo_id, path)` (V040). A LINKED-WORKTREE OVERLAY pass
+        // must NOT delete: that would clear a REAL parse failure recorded for the same path
         // by the base (or a sibling) scope. The overlay never WRITES this table either (see
-        // `insert_parser_failure`), so it has nothing of its own to remove (#219 review).
+        // `insert_parser_failure`), so it has nothing of its own to remove (#219 review). Scoped by
+        // `repo_id` (A3) so a sibling REPO's failure at the same path is never clobbered (the
+        // inventory-#12 cross-repo clobber the PK change fixes).
         if !self.active_scope_is_linked_overlay() {
-            self.storage
-                .connection()
-                .execute("DELETE FROM parser_failures WHERE path = ?1", [&path])?;
+            self.storage.connection().execute(
+                "DELETE FROM parser_failures WHERE repo_id = ?1 AND path = ?2",
+                params![repo_id, &path],
+            )?;
         }
         self.storage.connection().execute(
             "DELETE FROM chunk_fts
@@ -92,8 +98,9 @@ impl IndexDatabase {
                  WHERE main.files.path = ?1
                    AND main.files.commit_sha = ?2
                    AND main.files.worktree_id = ?3
+                   AND main.files.repo_id = ?4
              )",
-            params![path, commit_sha, worktree_id],
+            params![path, commit_sha, worktree_id, repo_id],
         )?;
         // Deleting the chunks cascades (ON DELETE CASCADE, foreign_keys=ON) to git_chunk_blame,
         // chunk_embeddings, chunk_summaries, and chunk_text — so the gate skipping the full
@@ -105,21 +112,22 @@ impl IndexDatabase {
             "DELETE FROM chunks
              WHERE file_id IN (
                 SELECT id FROM main.files
-                WHERE path = ?1 AND commit_sha = ?2 AND worktree_id = ?3
+                WHERE path = ?1 AND commit_sha = ?2 AND worktree_id = ?3 AND repo_id = ?4
              )",
-            params![path, commit_sha, worktree_id],
+            params![path, commit_sha, worktree_id, repo_id],
         )?;
         self.storage.connection().execute(
             "DELETE FROM symbols
              WHERE file_id IN (
                 SELECT id FROM main.files
-                WHERE path = ?1 AND commit_sha = ?2 AND worktree_id = ?3
+                WHERE path = ?1 AND commit_sha = ?2 AND worktree_id = ?3 AND repo_id = ?4
              )",
-            params![path, commit_sha, worktree_id],
+            params![path, commit_sha, worktree_id, repo_id],
         )?;
         self.storage.connection().execute(
-            "DELETE FROM main.files WHERE path = ?1 AND commit_sha = ?2 AND worktree_id = ?3",
-            params![path, commit_sha, worktree_id],
+            "DELETE FROM main.files
+             WHERE path = ?1 AND commit_sha = ?2 AND worktree_id = ?3 AND repo_id = ?4",
+            params![path, commit_sha, worktree_id, repo_id],
         )?;
         self.mark_fts_dirty()?;
         Ok(())

--- a/crates/rag-rat-core/src/index/fts.rs
+++ b/crates/rag-rat-core/src/index/fts.rs
@@ -1,4 +1,13 @@
 //! Full-text search (FTS5) index lifecycle: rebuild/sync the FTS mirror and track its freshness.
+//!
+//! FTS FRESHNESS KEYS ARE GLOBAL, NOT PER-REPO (V040 reclassification). `chunk_fts` is ONE FTS5
+//! index over the whole `chunks` table (never repo-scoped), and its freshness digest
+//! (`content_revision()`) is computed over the GLOBAL `main.files`. So `fts_dirty`,
+//! `fts_source_revision`, and `fts_synced_at_ms` track global infrastructure and MUST live in the
+//! global `index_meta` (`self.meta` / `self.set_meta`), not per-repo `repo_meta`. V039 relocated
+//! them to `repo_meta` under the one-DB-per-repo assumption; per-repo copies made a consolidated DB
+//! pay a full FTS rebuild forever after a sibling synced (stale-dirty loop). Do NOT route these
+//! back through `self.repo_meta` / `self.set_repo_meta`.
 
 use super::*;
 
@@ -11,7 +20,7 @@ impl IndexDatabase {
         schema::rebuild_commit_fts(self.storage.connection())?;
         self.record_content_revision()?;
         self.record_fts_current()?;
-        self.set_repo_meta("fts_dirty", "false")?;
+        self.set_meta("fts_dirty", "false")?;
         Ok(())
     }
 
@@ -22,7 +31,7 @@ impl IndexDatabase {
         schema::rebuild_commit_fts(self.storage.connection())?;
         self.record_content_revision()?;
         self.record_fts_current()?;
-        self.set_repo_meta("fts_dirty", "false")?;
+        self.set_meta("fts_dirty", "false")?;
         Ok(())
     }
 
@@ -75,29 +84,29 @@ impl IndexDatabase {
     pub fn sync_fts(&self) -> anyhow::Result<()> {
         self.record_content_revision()?;
         self.record_fts_current()?;
-        self.set_repo_meta("fts_dirty", "false")?;
+        self.set_meta("fts_dirty", "false")?;
         Ok(())
     }
 
     fn record_fts_current(&self) -> anyhow::Result<()> {
-        self.set_repo_meta("fts_synced_at_ms", &now_ms().to_string())?;
+        self.set_meta("fts_synced_at_ms", &now_ms().to_string())?;
         let revision = self.content_revision()?;
-        self.set_repo_meta("fts_source_revision", &revision)?;
+        self.set_meta("fts_source_revision", &revision)?;
         Ok(())
     }
 
     pub(super) fn mark_fts_dirty(&self) -> anyhow::Result<()> {
-        self.set_repo_meta("fts_dirty", "true")
+        self.set_meta("fts_dirty", "true")
     }
 
     pub(super) fn ensure_fts_fresh(&self) -> anyhow::Result<()> {
         let content_revision = self.content_revision()?;
-        let fts_source_revision = self.repo_meta("fts_source_revision")?;
+        let fts_source_revision = self.meta("fts_source_revision")?;
         if !self.fts_dirty()? && fts_source_revision.as_deref() == Some(content_revision.as_str()) {
             return Ok(());
         }
         self.rebuild_fts()?;
-        let refreshed_revision = self.repo_meta("fts_source_revision")?;
+        let refreshed_revision = self.meta("fts_source_revision")?;
         if refreshed_revision.as_deref() != Some(content_revision.as_str()) {
             anyhow::bail!(
                 "FTS freshness invariant failed: content_revision={content_revision}, \
@@ -109,6 +118,6 @@ impl IndexDatabase {
     }
 
     pub(super) fn fts_dirty(&self) -> anyhow::Result<bool> {
-        Ok(self.repo_meta("fts_dirty")?.as_deref() == Some("true"))
+        Ok(self.meta("fts_dirty")?.as_deref() == Some("true"))
     }
 }

--- a/crates/rag-rat-core/src/index/git_history.rs
+++ b/crates/rag-rat-core/src/index/git_history.rs
@@ -7,7 +7,7 @@ use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
-use crate::index::{delete_repo_meta, repo_meta, schema, set_repo_meta, table_row_count};
+use crate::index::{delete_repo_meta, repo_meta, schema, scoped_table_row_count, set_repo_meta};
 use crate::search::lexical::SearchHit;
 
 #[derive(Debug, Clone, Serialize)]
@@ -147,20 +147,22 @@ pub(crate) fn apply_prepared(
         return status(conn, root);
     };
 
-    conn.execute_batch(
-        "
-        DELETE FROM commit_fts;
-        DELETE FROM git_chunk_blame;
-        DELETE FROM git_file_changes;
-        DELETE FROM git_commits;
-        ",
-    )?;
+    // `git_commits` / `git_file_changes` are direct-scoped since V040, so a history reindex of ONE
+    // repo must delete and re-insert only THAT repo's rows — a wholesale wipe would drop a sibling
+    // repo's commits in a consolidated DB. (`git_chunk_blame` is transitive via `chunks`/`files`
+    // and regenerated lazily; its per-repo scoping is deferred to the blame/query workstream — a
+    // marked A4/A5 seam. `commit_fts` is external-content over `git_commits` and is resynced
+    // below.)
+    let repo_id = schema::active_repo_id(conn)?;
+    conn.execute("DELETE FROM git_file_changes WHERE repo_id = ?1", params![repo_id])?;
+    conn.execute("DELETE FROM git_commits WHERE repo_id = ?1", params![repo_id])?;
+    conn.execute_batch("DELETE FROM git_chunk_blame;")?;
 
     for commit in &prepared.commits {
         conn.execute(
             "INSERT INTO git_commits(hash, author_name, author_email, authored_at_s, \
-             committed_at_s, subject, body, changed_file_count)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0)",
+             committed_at_s, subject, body, changed_file_count, repo_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0, ?8)",
             params![
                 commit.hash,
                 commit.author_name,
@@ -169,6 +171,7 @@ pub(crate) fn apply_prepared(
                 commit.committed_at_s,
                 commit.subject,
                 commit.body,
+                repo_id,
             ],
         )?;
     }
@@ -177,32 +180,33 @@ pub(crate) fn apply_prepared(
     for change in prepared.changes {
         *changed_counts.entry(change.commit_hash.clone()).or_default() += 1;
         conn.execute(
-            "INSERT INTO git_file_changes(commit_hash, path, additions, deletions, change_kind)
-             VALUES (?1, ?2, ?3, ?4, ?5)",
+            "INSERT INTO git_file_changes(commit_hash, path, additions, deletions, change_kind, \
+             repo_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             params![
                 change.commit_hash,
                 change.path,
                 change.additions,
                 change.deletions,
                 change.change_kind,
+                repo_id,
             ],
         )?;
     }
     for (hash, count) in changed_counts {
-        conn.execute("UPDATE git_commits SET changed_file_count = ?2 WHERE hash = ?1", params![
-            hash, count
-        ])?;
+        conn.execute(
+            "UPDATE git_commits SET changed_file_count = ?2 WHERE hash = ?1 AND repo_id = ?3",
+            params![hash, count, repo_id],
+        )?;
     }
 
-    conn.execute_batch(
-        "
-        INSERT INTO commit_fts(rowid, subject, body)
-        SELECT rowid, subject, body FROM git_commits;
-        ",
-    )?;
+    // Resync the external-content FTS from `git_commits` with the desync-safe `'rebuild'` (#51),
+    // never a `DELETE FROM commit_fts` + manual repopulate — the reinserted commit rows took new
+    // rowids, so the stored mapping is stale. `'rebuild'` re-indexes all repos' commits, keeping
+    // every repo searchable.
+    crate::index::schema::rebuild_commit_fts(conn)?;
     // Reload-gate key: head + root + shallow flag. `is_history_current` skips the next reload
     // only when all three still match and git_commits is non-empty.
-    let repo_id = schema::single_repo_id(conn)?;
     set_repo_meta(conn, &repo_id, "git_history_indexed_head", &repo.head)?;
     set_repo_meta(conn, &repo_id, "git_history_indexed_root", &root_key(root))?;
     set_repo_meta(
@@ -221,9 +225,12 @@ pub fn index(conn: &Connection, root: &Path) -> anyhow::Result<GitHistoryIndexSt
 
 pub fn status(conn: &Connection, root: &Path) -> anyhow::Result<GitHistoryIndexStatus> {
     let repo = git_repo(root);
-    let commit_count = table_row_count(conn, "git_commits")?;
-    let file_change_count = table_row_count(conn, "git_file_changes")?;
-    let repo_id = schema::single_repo_id(conn)?;
+    // `git_commits` / `git_file_changes` are direct-scoped since V040, so status must count only
+    // THIS repo's rows — a whole-table `table_row_count` would report the union across a
+    // consolidated DB.
+    let repo_id = schema::active_repo_id(conn)?;
+    let commit_count = scoped_table_row_count(conn, "git_commits", &repo_id)?;
+    let file_change_count = scoped_table_row_count(conn, "git_file_changes", &repo_id)?;
     Ok(GitHistoryIndexStatus {
         available: repo.is_some(),
         head: repo.map(|repo| repo.head),
@@ -253,28 +260,32 @@ pub fn replay_commit_cases(
     limit: u32,
     max_files: u32,
 ) -> anyhow::Result<Vec<ReplayCase>> {
+    // Direct-scoped (V040): the eval cases come only from the ACTIVE repo's history.
+    let repo_id = schema::active_repo_id(conn)?;
     let mut stmt = conn.prepare(
         "
         SELECT hash, subject, body
         FROM git_commits
         WHERE changed_file_count BETWEEN 1 AND ?2
           AND subject NOT LIKE 'Merge %'
+          AND repo_id = ?3
         ORDER BY authored_at_s DESC
         LIMIT ?1
         ",
     )?;
     let commits: Vec<(String, String, String)> = stmt
-        .query_map(params![i64::from(limit), i64::from(max_files)], |row| {
+        .query_map(params![i64::from(limit), i64::from(max_files), repo_id], |row| {
             Ok((row.get(0)?, row.get(1)?, row.get(2)?))
         })?
         .collect::<rusqlite::Result<_>>()?;
 
-    let mut paths_stmt =
-        conn.prepare("SELECT path FROM git_file_changes WHERE commit_hash = ?1 ORDER BY path")?;
+    let mut paths_stmt = conn.prepare(
+        "SELECT path FROM git_file_changes WHERE commit_hash = ?1 AND repo_id = ?2 ORDER BY path",
+    )?;
     let mut cases = Vec::with_capacity(commits.len());
     for (hash, subject, body) in commits {
         let changed_paths: Vec<String> = paths_stmt
-            .query_map(params![hash], |row| row.get::<_, String>(0))?
+            .query_map(params![hash, repo_id], |row| row.get::<_, String>(0))?
             .collect::<rusqlite::Result<_>>()?;
         if changed_paths.is_empty() {
             continue;
@@ -336,6 +347,10 @@ pub fn commit_search(
     limit: u32,
 ) -> anyhow::Result<Vec<CommitSearchHit>> {
     let fts_query = fts_query(query);
+    // `commit_fts` is external-content over the direct-scoped `git_commits` (V040); the MATCH runs
+    // over every repo's commits, so the join predicate `git_commits.repo_id = ?` is what keeps a
+    // sibling repo's commits out of THIS repo's results in a consolidated DB.
+    let repo_id = schema::active_repo_id(conn)?;
     let mut stmt = conn.prepare(
         "
         SELECT git_commits.hash, git_commits.author_name, git_commits.author_email,
@@ -344,12 +359,12 @@ pub fn commit_search(
                bm25(commit_fts) AS score
         FROM commit_fts
         JOIN git_commits ON git_commits.rowid = commit_fts.rowid
-        WHERE commit_fts MATCH ?1
+        WHERE commit_fts MATCH ?1 AND git_commits.repo_id = ?3
         ORDER BY score, git_commits.authored_at_s DESC
         LIMIT ?2
         ",
     )?;
-    let rows = stmt.query_map(params![fts_query, i64::from(limit)], |row| {
+    let rows = stmt.query_map(params![fts_query, i64::from(limit), repo_id], |row| {
         Ok(CommitSearchHit {
             hash: row.get(0)?,
             author_name: row.get(1)?,
@@ -379,6 +394,9 @@ pub fn history_for_path(
     path: &str,
     limit: u32,
 ) -> anyhow::Result<Vec<PathHistoryItem>> {
+    // `git_file_changes` / `git_commits` are direct-scoped (V040): join AND filter on `repo_id` so
+    // a fork sharing a commit hash can't surface a sibling repo's change rows for this path.
+    let repo_id = schema::active_repo_id(conn)?;
     let mut stmt = conn.prepare(
         "
         SELECT git_commits.hash, git_file_changes.path, git_file_changes.additions,
@@ -386,12 +404,13 @@ pub fn history_for_path(
                git_commits.author_name, git_commits.authored_at_s, git_commits.subject
         FROM git_file_changes
         JOIN git_commits ON git_commits.hash = git_file_changes.commit_hash
-        WHERE git_file_changes.path = ?1
+                        AND git_commits.repo_id = git_file_changes.repo_id
+        WHERE git_file_changes.path = ?1 AND git_file_changes.repo_id = ?3
         ORDER BY git_commits.authored_at_s DESC, git_commits.hash
         LIMIT ?2
         ",
     )?;
-    let rows = stmt.query_map(params![path, i64::from(limit)], path_history_row)?;
+    let rows = stmt.query_map(params![path, i64::from(limit), repo_id], path_history_row)?;
     collect_rows(rows)
 }
 
@@ -589,16 +608,16 @@ pub fn source_text_hash(text: &str) -> String {
 }
 
 fn clear(conn: &Connection) -> anyhow::Result<()> {
-    conn.execute_batch(
-        "
-        DELETE FROM commit_fts;
-        DELETE FROM git_chunk_blame;
-        DELETE FROM git_file_changes;
-        DELETE FROM git_commits;
-        ",
-    )?;
+    // Clear only the ACTIVE repo's git history (V040 scoping) — a wholesale wipe would drop a
+    // sibling repo's commits in a consolidated DB. `git_chunk_blame` is transitive/regenerated
+    // (A4/A5 seam). `commit_fts` is resynced from the surviving `git_commits` via the #51-safe
+    // `'rebuild'` afterward.
+    let repo_id = schema::active_repo_id(conn)?;
+    conn.execute("DELETE FROM git_file_changes WHERE repo_id = ?1", params![repo_id])?;
+    conn.execute("DELETE FROM git_commits WHERE repo_id = ?1", params![repo_id])?;
+    conn.execute_batch("DELETE FROM git_chunk_blame;")?;
+    crate::index::schema::rebuild_commit_fts(conn)?;
     // The reload-gate keys moved to `repo_meta` (V039); clear them for the active repo.
-    let repo_id = schema::single_repo_id(conn)?;
     for key in
         ["git_history_indexed_head", "git_history_indexed_root", "git_history_indexed_shallow"]
     {
@@ -921,7 +940,7 @@ pub(crate) fn is_history_current(conn: &Connection, root: &Path) -> bool {
         return false;
     }
     let probe = || -> anyhow::Result<bool> {
-        let repo_id = schema::single_repo_id(conn)?;
+        let repo_id = schema::active_repo_id(conn)?;
         let head_matches = repo_meta(conn, &repo_id, "git_history_indexed_head")?.as_deref()
             == Some(repo.head.as_str());
         let root_matches = repo_meta(conn, &repo_id, "git_history_indexed_root")?.as_deref()
@@ -930,8 +949,9 @@ pub(crate) fn is_history_current(conn: &Connection, root: &Path) -> bool {
         // not shallow even if HEAD is unchanged.
         let prior_was_full =
             repo_meta(conn, &repo_id, "git_history_indexed_shallow")?.as_deref() == Some("0");
-        // Guard against a torn/empty prior reload writing the meta without rows.
-        let has_rows = table_row_count(conn, "git_commits")? > 0;
+        // Guard against a torn/empty prior reload writing the meta without rows — counted per-repo
+        // (V040), so a sibling repo's commits can't mask THIS repo's empty history.
+        let has_rows = scoped_table_row_count(conn, "git_commits", &repo_id)? > 0;
         Ok(head_matches && root_matches && prior_was_full && has_rows)
     };
     probe().unwrap_or(false)

--- a/crates/rag-rat-core/src/index/github/api.rs
+++ b/crates/rag-rat-core/src/index/github/api.rs
@@ -25,7 +25,7 @@ pub(crate) fn sync_from_refs_with_progress<C: GitHubClient>(
         let client = client.ok_or_else(|| anyhow::anyhow!("github sync requires a client"))?;
         sync_refs(conn, client, refs.iter(), &mut progress)?
     };
-    let repo_id = schema::single_repo_id(conn)?;
+    let repo_id = schema::active_repo_id(conn)?;
     set_repo_meta(conn, &repo_id, "github_last_sync_ms", &now_ms().to_string())?;
     Ok(GitHubSyncReport {
         offline,
@@ -63,7 +63,7 @@ pub(crate) fn sync_issue<C: GitHubClient>(
         let client = client.ok_or_else(|| anyhow::anyhow!("github sync requires a client"))?;
         sync_refs(conn, client, refs.iter().filter(|r| r.number == parsed.number), &mut |_| {})?
     };
-    let repo_id = schema::single_repo_id(conn)?;
+    let repo_id = schema::active_repo_id(conn)?;
     set_repo_meta(conn, &repo_id, "github_last_sync_ms", &now_ms().to_string())?;
     Ok(GitHubSyncReport {
         offline,
@@ -83,7 +83,7 @@ pub(crate) fn status(conn: &Connection, ctx: &GitHubContext) -> anyhow::Result<G
         pulls: table_row_count(conn, "github_pull_requests")?,
         reviews: table_row_count(conn, "github_reviews")?,
         review_comments: table_row_count(conn, "github_review_comments")?,
-        last_sync_ms: repo_meta(conn, &schema::single_repo_id(conn)?, "github_last_sync_ms")?
+        last_sync_ms: repo_meta(conn, &schema::active_repo_id(conn)?, "github_last_sync_ms")?
             .and_then(|value| value.parse().ok()),
         capability: if ctx.gh_available {
             "gh_cli_available".to_string()
@@ -191,12 +191,17 @@ pub(crate) fn papertrail_for_commit(
     let mut evidence = evidence_for_commit_refs(conn, commit_hash, limit)?;
     let mut fallback_evidence = Vec::new();
     if evidence.is_empty() {
+        // `git_file_changes` is direct-scoped (V040): the prefix probe must not resolve a sibling
+        // repo's commit in a consolidated DB (forks share hashes).
+        let repo_id = schema::active_repo_id(conn)?;
         let mut stmt = conn.prepare(
-            "SELECT path FROM git_file_changes WHERE commit_hash LIKE ?1 ORDER BY path LIMIT ?2",
+            "SELECT path FROM git_file_changes WHERE commit_hash LIKE ?1 AND repo_id = ?3 ORDER \
+             BY path LIMIT ?2",
         )?;
         let commit_like = format!("{commit_hash}%");
-        let rows =
-            stmt.query_map(params![commit_like, i64::from(limit)], |row| row.get::<_, String>(0))?;
+        let rows = stmt.query_map(params![commit_like, i64::from(limit), repo_id], |row| {
+            row.get::<_, String>(0)
+        })?;
         for row in rows {
             fallback_evidence.extend(evidence_for_path(conn, &row?, limit)?);
         }

--- a/crates/rag-rat-core/src/index/github/sync.rs
+++ b/crates/rag-rat-core/src/index/github/sync.rs
@@ -208,8 +208,13 @@ pub(crate) fn discover_commit_refs(
     default_repo: Option<&str>,
     out: &mut Vec<GitHubRef>,
 ) -> anyhow::Result<()> {
-    let mut stmt = conn.prepare("SELECT hash, subject, body FROM git_commits")?;
-    let rows = stmt.query_map([], |row| {
+    // `git_commits` is direct-scoped (V040), so discovery only mines the ACTIVE repo's commit
+    // messages for issue refs — a consolidated DB must not attribute a sibling repo's `#N` refs to
+    // this repo.
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    let mut stmt =
+        conn.prepare("SELECT hash, subject, body FROM git_commits WHERE repo_id = ?1")?;
+    let rows = stmt.query_map([&repo_id], |row| {
         Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))
     })?;
     for row in rows {

--- a/crates/rag-rat-core/src/index/graph_index.rs
+++ b/crates/rag-rat-core/src/index/graph_index.rs
@@ -29,14 +29,23 @@ impl LogicalSymbolKey {
         }
     }
 
-    /// Deterministic logical-symbol id derived from the key, so it is **stable across reindex**
-    /// (the table is fully rebuilt each pass; an autoincrement rowid would churn the id every
-    /// time, breaking any cached id or logical-symbol-bound memory). A 63-bit truncation of the
-    /// key's SHA-256 — collisions are astronomically unlikely across a repo's symbols, and a
-    /// collision would surface as a loud primary-key error on rebuild rather than silent merging.
-    pub(super) fn stable_id(&self) -> i64 {
+    /// Deterministic logical-symbol id derived from the key AND its owning `repo_id`, so it is
+    /// **stable across reindex** (the table is fully rebuilt each pass; an autoincrement rowid
+    /// would churn the id every time, breaking any cached id or logical-symbol-bound memory)
+    /// yet **repo-distinct** (A3). Folding `repo_id` in is what prevents two repos with
+    /// byte-identical file content from deriving the SAME content-only id and colliding on the
+    /// `logical_symbols.id` PK in a consolidated DB. Fold — not a composite `(repo_id, id)` PK
+    /// — because `id` is ALSO the scalar `sym_<hex>` wire handle and the FK/PK target of
+    /// `logical_symbol_members`, `logical_symbol_monikers`, and `repo_memory_bindings`, so it
+    /// MUST stay a single globally- unique scalar; a composite PK would demote `id` to
+    /// non-unique and break every one of those. `repo_id` is invariant across reindex, so the
+    /// id is as stable as before. A 63-bit truncation of the SHA-256 — collisions are
+    /// astronomically unlikely across a repo's symbols, and a collision would surface as a loud
+    /// primary-key error on rebuild rather than silent merging.
+    pub(super) fn stable_id(&self, repo_id: &str) -> i64 {
         let canonical = format!(
-            "{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}",
+            "{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}",
+            repo_id,
             self.language,
             self.path,
             self.name,
@@ -49,6 +58,139 @@ impl LogicalSymbolKey {
         bytes.copy_from_slice(&digest[..8]);
         (u64::from_be_bytes(bytes) >> 1) as i64
     }
+}
+
+/// Recompute every `logical_symbols` row's content-derived id from its OWN `repo_id` and re-point
+/// that id everywhere it is referenced, so ids stay consistent now that
+/// [`LogicalSymbolKey::stable_id`] folds `repo_id` in (A3). Returns the number of rows remapped.
+///
+/// WHY: on an UPGRADED DB (existing pre-fold `logical_symbols`), or when a `repo_id` changes at
+/// adoption (placeholder → real), the next [`IndexDatabase::rebuild_logical_symbols`] would
+/// re-derive every logical symbol under a NEW id, dangling every `repo_memory_bindings`,
+/// `repo_memory_call_paths`, `logical_symbol_monikers`, and `logical_symbol_members` row that still
+/// points at the OLD id (pre-V040 memories + oracle data). This migrates those references IN PLACE
+/// before the first rebuild, so a bound memory resolves to the same symbol under the new id. Called
+/// from the V040 migration (after the `repo_id` backfill) and from [`register_repo`] adoption
+/// (after the placeholder → real re-point), both idempotent: a row already at `hash(repo_id ‖ key)`
+/// is skipped, so the two calls compose without double-remapping.
+///
+/// The hash inputs are row-resident EXCEPT `signature`, which `logical_symbols` does not store —
+/// recover it from any member's `symbols.signature` (every member of a group shares it, since the
+/// signature is part of the key). A logical symbol with no live member is an orphan the next
+/// rebuild would drop anyway (its binding is already effectively dead), so it is left untouched.
+///
+/// FK NOTE: `logical_symbol_members` carries an `ON DELETE CASCADE` FK to `logical_symbols(id)`, so
+/// the caller MUST run with FK enforcement OFF (the V040 migration) or DEFERRED
+/// (`PRAGMA defer_foreign_keys = ON`, the adoption transaction) — else the parent-id UPDATE trips
+/// the child FK. The remap runs inside the caller's transaction (torn-safe) and uses a NEGATIVE
+/// temp-id pass so a new id that equals another remapped row's OLD id can never collide on the PK
+/// mid-migration.
+pub(crate) fn realign_logical_symbol_ids(conn: &rusqlite::Connection) -> rusqlite::Result<usize> {
+    struct Row {
+        old_id: i64,
+        repo_id: String,
+        language: String,
+        path: String,
+        name: String,
+        qualified_name: Option<String>,
+        kind: String,
+        signature: Option<String>,
+    }
+    let mut stmt = conn.prepare(
+        "SELECT ls.id, ls.repo_id, ls.language, ls.path, ls.logical_name,
+                (SELECT value FROM name_strings WHERE id = ls.qualified_name_id),
+                ls.kind,
+                (SELECT s.signature FROM logical_symbol_members m
+                   JOIN symbols s ON s.id = m.symbol_id
+                  WHERE m.logical_symbol_id = ls.id LIMIT 1)
+         FROM logical_symbols ls",
+    )?;
+    let rows = stmt
+        .query_map([], |r| {
+            Ok(Row {
+                old_id: r.get(0)?,
+                repo_id: r.get(1)?,
+                language: r.get(2)?,
+                path: r.get(3)?,
+                name: r.get(4)?,
+                qualified_name: r.get(5)?,
+                kind: r.get(6)?,
+                signature: r.get(7)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    let mut remap: Vec<(i64, i64)> = Vec::new();
+    for row in rows {
+        // A NULL interned `qualified_name` means the row predates the #224 backfill (rebuild would
+        // itself fail on it) or is otherwise unrecoverable — skip rather than hash a wrong key.
+        let Some(qualified_name) = row.qualified_name else {
+            continue;
+        };
+        let key = LogicalSymbolKey {
+            language: row.language,
+            path: row.path,
+            name: row.name,
+            qualified_name,
+            kind: row.kind,
+            signature: row.signature,
+        };
+        let new_id = key.stable_id(&row.repo_id);
+        if new_id != row.old_id {
+            remap.push((row.old_id, new_id));
+        }
+    }
+
+    // Two-phase through negative temp ids: `stable_id` values are all >= 0 (`>> 1`), so a `-(i+1)`
+    // temp can never collide with a real id or with another temp. Phase 1 vacates every OLD id in
+    // the remap set; phase 2 lands the finals — so a new id equal to another remapped row's old
+    // id never trips the PK mid-pass. (A new id equal to an already-aligned row's id is a
+    // 63-bit hash collision — the same astronomically-unlikely case a plain rebuild already
+    // surfaces loudly.)
+    for (i, (old_id, _)) in remap.iter().enumerate() {
+        let temp_id = -(i as i64 + 1);
+        rewrite_logical_symbol_id(conn, *old_id, temp_id)?;
+    }
+    for (i, (_, new_id)) in remap.iter().enumerate() {
+        let temp_id = -(i as i64 + 1);
+        rewrite_logical_symbol_id(conn, temp_id, *new_id)?;
+    }
+    Ok(remap.len())
+}
+
+/// Move a single logical-symbol id from `from` to `to` across the PK row and every column that
+/// references it — the members join table, the per-tool monikers, and the two durable-memory
+/// reference tables (`repo_memory_bindings`, `repo_memory_call_paths`' start/end). See
+/// [`realign_logical_symbol_ids`] for the FK-off/deferred requirement.
+fn rewrite_logical_symbol_id(
+    conn: &rusqlite::Connection,
+    from: i64,
+    to: i64,
+) -> rusqlite::Result<()> {
+    conn.execute("UPDATE logical_symbols SET id = ?1 WHERE id = ?2", params![to, from])?;
+    conn.execute(
+        "UPDATE logical_symbol_members SET logical_symbol_id = ?1 WHERE logical_symbol_id = ?2",
+        params![to, from],
+    )?;
+    conn.execute(
+        "UPDATE logical_symbol_monikers SET logical_symbol_id = ?1 WHERE logical_symbol_id = ?2",
+        params![to, from],
+    )?;
+    conn.execute(
+        "UPDATE repo_memory_bindings SET logical_symbol_id = ?1 WHERE logical_symbol_id = ?2",
+        params![to, from],
+    )?;
+    conn.execute(
+        "UPDATE repo_memory_call_paths SET start_logical_symbol_id = ?1
+          WHERE start_logical_symbol_id = ?2",
+        params![to, from],
+    )?;
+    conn.execute(
+        "UPDATE repo_memory_call_paths SET end_logical_symbol_id = ?1
+          WHERE end_logical_symbol_id = ?2",
+        params![to, from],
+    )?;
+    Ok(())
 }
 
 #[derive(Debug, Clone)]
@@ -79,17 +221,26 @@ impl IndexDatabase {
     }
 
     pub(super) fn rebuild_logical_symbols(&self) -> anyhow::Result<()> {
-        // The insert below re-derives the COMPLETE logical-symbol table from all current symbols,
-        // so clear it entirely first. A member-join "rebuild set" misses logical_symbols whose
-        // members were cascade-deleted with their symbols (clear_full_rebuild_tables deletes
-        // files → symbols → logical_symbol_members via FK, but logical_symbols has no such FK).
-        // Those orphans would then collide with the deterministic stable id on re-insert.
-        self.storage.connection().execute_batch(
-            "
-            DELETE FROM main.logical_symbol_members;
-            DELETE FROM main.logical_symbols;
-            ",
+        // The insert below re-derives the COMPLETE logical-symbol table for the ACTIVE REPO from
+        // its current symbols, so clear that repo's rows entirely first. A member-join
+        // "rebuild set" misses logical_symbols whose members were cascade-deleted with
+        // their symbols (clear_full_rebuild_tables deletes files → symbols →
+        // logical_symbol_members via FK, but logical_symbols has no such FK). Those orphans
+        // would then collide with the deterministic stable id on re-insert. Scoped to
+        // `active_repo_id` (A3): a wholesale clear would wipe a sibling repo's grouping in
+        // a consolidated DB, and the content-derived stable ids can collide across repos —
+        // so the DELETE and the re-derive SELECT both filter this repo. (The
+        // A6 note "constrained to the active repo slice" is folded in here, since the wholesale
+        // cross-repo rebuild became incorrect the moment `logical_symbols` gained `repo_id`.)
+        let conn = self.storage.connection();
+        conn.execute(
+            "DELETE FROM main.logical_symbol_members
+             WHERE logical_symbol_id IN (SELECT id FROM main.logical_symbols WHERE repo_id = ?1)",
+            params![self.active_repo_id],
         )?;
+        conn.execute("DELETE FROM main.logical_symbols WHERE repo_id = ?1", params![
+            self.active_repo_id
+        ])?;
 
         // STREAM the grouping instead of materializing every symbol. The previous version built a
         // `BTreeMap<LogicalSymbolKey, Vec<row>>` over ALL symbols — at kernel scale ~3.5M rows ×
@@ -103,17 +254,18 @@ impl IndexDatabase {
         // current group's members (kilobytes). Byte-identical: same grouping, same
         // `logical_symbols` insert order (ids are content-derived via `stable_id`, not rowids), and
         // the same member order, verified against the golden index.
-        // Read RAW `main.files` (all scopes), NOT the per-connection `files` scope VIEW.
-        // logical_symbols is a GLOBAL table; building it must not depend on whichever scope happens
-        // to be active. When this runs in a worktree-overlay context (a scope view IS installed),
-        // an unqualified `files` resolves to the scoped temp view, so the wholesale DELETE
-        // + repopulate would WIPE every other scope's grouping (base + sibling worktrees)
-        // and restore only the active scope's — persistently breaking `sym_<hex>`-handle
-        // graph nav for base symbols (the #219 review finding). Reading `main.files`
-        // groups every symbol in every live scope; the content-derived `stable_id`
-        // collapses cross-scope duplicates into one logical symbol with per-scope members,
-        // and downstream reads stay scope-filtered via the `files` view.
-        let conn = self.storage.connection();
+        // Read RAW `main.files` (ALL of the active repo's scopes), NOT the per-connection `files`
+        // scope VIEW. logical_symbols is per-repo but scope-INDEPENDENT within a repo; building it
+        // must not depend on whichever commit/worktree scope happens to be active. When this runs
+        // in a worktree-overlay context (a scope view IS installed), an unqualified `files`
+        // resolves to the scoped temp view, so the DELETE + repopulate would WIPE every
+        // other scope's grouping (base + sibling worktrees) and restore only the active
+        // scope's — persistently breaking `sym_<hex>`-handle graph nav for base symbols
+        // (the #219 review finding). Filtering `main.files.repo_id` (A3) keeps every symbol
+        // in every live scope OF THIS REPO while excluding a sibling repo's rows in a
+        // consolidated DB; the content-derived `stable_id` collapses cross-scope duplicates
+        // into one logical symbol with per-scope members, and downstream reads stay
+        // scope-filtered via the `files` view.
         let mut stmt = conn.prepare(
             "
             SELECT symbols.id, main.files.path, symbols.language, symbols.name,
@@ -122,11 +274,12 @@ impl IndexDatabase {
             FROM main.symbols AS symbols
             JOIN main.files ON main.files.id = symbols.file_id
             LEFT JOIN main.name_strings qn ON qn.id = symbols.qualified_name_id
+            WHERE main.files.repo_id = ?1
             ORDER BY symbols.language, main.files.path, symbols.name, qn.value,
                      symbols.kind, symbols.signature, symbols.start_byte, symbols.end_byte
             ",
         )?;
-        let mut rows = stmt.query([])?;
+        let mut rows = stmt.query(params![self.active_repo_id])?;
         let mut current: Option<(LogicalSymbolKey, Vec<LogicalSymbolMemberRow>)> = None;
         while let Some(row) = rows.next()? {
             let member = LogicalSymbolMemberRow {
@@ -154,14 +307,14 @@ impl IndexDatabase {
                 current.as_mut().expect("same_group implies Some").1.push(member);
             } else {
                 if let Some((key, members)) = current.take() {
-                    Self::insert_logical_group(conn, &key, &members)?;
+                    Self::insert_logical_group(conn, &self.active_repo_id, &key, &members)?;
                 }
                 let key = LogicalSymbolKey::from(&member);
                 current = Some((key, vec![member]));
             }
         }
         if let Some((key, members)) = current.take() {
-            Self::insert_logical_group(conn, &key, &members)?;
+            Self::insert_logical_group(conn, &self.active_repo_id, &key, &members)?;
         }
         Ok(())
     }
@@ -255,7 +408,19 @@ impl IndexDatabase {
         };
         self.storage.execute_batch("BEGIN IMMEDIATE TRANSACTION")?;
         let result = (|| -> anyhow::Result<()> {
-            self.storage.connection().execute("DELETE FROM edges_data", [])?;
+            // Scope the wipe to the ACTIVE REPO's edges (A3): `graph_index_version` is per-repo, so
+            // a stale/missing version for repo A must not wipe repo B's edges in a
+            // consolidated DB. An edge belongs to its `source_file_id`'s repo;
+            // `source_file_id` is always set (its FK is `ON DELETE CASCADE`, every edge
+            // is inserted with a file id), so this removes exactly this repo's edges —
+            // the same set the repopulate below (over the repo-scoped `files`
+            // view) re-derives. Within the repo this matches the prior wholesale behavior; only
+            // sibling repos are now spared.
+            self.storage.connection().execute(
+                "DELETE FROM edges_data
+                  WHERE source_file_id IN (SELECT id FROM main.files WHERE repo_id = ?1)",
+                params![self.active_repo_id],
+            )?;
             // Repopulate the per-package import scope BEFORE re-resolving (#61). A bare
             // version-bump re-resolve would re-derive `import_scope_*` on the new edges
             // but read an empty `packages` table (V022 only ADDED the column; it did not

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -47,9 +47,31 @@ impl IndexDatabase {
             return Self::rebuild_with_progress(config, progress).map(|db| (db, true));
         }
 
-        let mut db = Self::open(&config.database)?;
+        // Open with the graph check DEFERRED (`check_graph = false`). `Self::open`'s eager check
+        // runs `ensure_graph_index_current` — a repo-scoped edge DELETE+rebuild keyed on
+        // `active_repo_id` — during the open itself, BEFORE this pass adopts the config's repo. On
+        // a consolidated DB `Self::open` scopes to the config-blind SOLE repo (the
+        // lexicographically-first), so the eager check would refresh/wipe the WRONG repo's graph
+        // (or skip the config repo's own stale graph) before adoption switches scope. Adopt
+        // + install the scope context FIRST, then run the graph/generated-flags heal for
+        // the correct repo — the exact sequence `open_config` uses.
+        let mut db = Self::open_with_graph_check(&config.database, false)?;
+        // Register/adopt the config's repo BEFORE `set_context` stamps `active_repo_id` into the
+        // scope view (A3). `Self::open` scoped to the SOLE repo via the config-blind fallback; on a
+        // consolidated DB that would pick the lexicographically-first repo, so this incremental
+        // pass could delete/stamp rows under the WRONG repo. Adopting here — the same step
+        // `open_config` and `rebuild` run — resolves the config's own identity and points
+        // every repo-scoped write below at it. Idempotent on an already-adopted single-repo
+        // DB (the common case).
+        db.adopt_repo_from_config(config)?;
         let (commit_sha, worktree_id) = resolve_git_context(&config.root);
         db.set_context(&commit_sha, &worktree_id)?;
+        // Now that the config's repo is adopted and its scope is installed, run the deferred graph
+        // + generated-flags heal against the RIGHT repo (the graph check's edge DELETE is
+        // scoped by `active_repo_id`, so it must not run under the pre-adoption sole-repo
+        // fallback).
+        db.ensure_graph_index_current()?;
+        db.ensure_generated_flags_current()?;
         if db.indexed_file_count()? == 0 {
             return Self::rebuild_with_progress(config, progress).map(|db| (db, true));
         }
@@ -338,13 +360,20 @@ impl IndexDatabase {
         }
         let overlays: Vec<(i64, String, String)> = {
             let conn = self.storage.connection();
+            // Direct `main.files` probes bypass the repo-scoped `files` view, so they carry the
+            // `repo_id` predicate explicitly (A3): in a consolidated DB two forks at the same
+            // commit share `commit_sha`/`worktree_id`, and without `repo_id` the
+            // committed-row probe below would see a SIBLING repo's committed row and
+            // delete THIS repo's overlay as if its own base row existed.
             let mut stmt = conn.prepare(
                 "SELECT id, path, sha256 FROM main.files
-                 WHERE worktree_id = ?1 AND worktree_id != '' AND kind != 'deleted'",
+                 WHERE repo_id = ?1 AND worktree_id = ?2 AND worktree_id != '' AND kind != \
+                 'deleted'",
             )?;
-            let rows = stmt.query_map([&self.active_worktree_id], |row| {
-                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
-            })?;
+            let rows = stmt
+                .query_map(params![self.active_repo_id, self.active_worktree_id], |row| {
+                    Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+                })?;
             rows.collect::<Result<Vec<_>, _>>()?
         };
         let mut healed = 0usize;
@@ -354,8 +383,8 @@ impl IndexDatabase {
             }
             let committed_exists: bool = self.storage.connection().query_row(
                 "SELECT EXISTS(SELECT 1 FROM main.files
-                 WHERE path = ?1 AND commit_sha = ?2 AND worktree_id = '')",
-                params![path, self.active_commit_sha],
+                 WHERE repo_id = ?1 AND path = ?2 AND commit_sha = ?3 AND worktree_id = '')",
+                params![self.active_repo_id, path, self.active_commit_sha],
                 |row| row.get(0),
             )?;
             if committed_exists {

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -15,8 +15,12 @@ impl IndexDatabase {
         self.storage.database_path()
     }
 
-    fn open_with_graph_check(path: &Path, check_graph: bool) -> anyhow::Result<Self> {
-        let mut storage = IndexConnection::open(path)?;
+    /// Open the DB at `path` and bring its schema current, migrating FORWARD under the index write
+    /// lock when it lags this binary. Shared by every open path; resolves NO repo scope (the caller
+    /// does — a bare open via [`sole_repo_id`](schema::sole_repo_id), a config-bearing open via
+    /// `register_repo`).
+    fn open_and_migrate(path: &Path) -> anyhow::Result<IndexConnection> {
+        let storage = IndexConnection::open(path)?;
         // Forward schema migrations are automatic on open (the index is our own derived data — a
         // binary upgrade must not require a manual `migrate`). Only Newer/Dirty/Missing refuse.
         //
@@ -44,13 +48,23 @@ impl IndexDatabase {
         } else {
             schema::ensure_compatible_or_migrate(storage.connection())?;
         }
+        Ok(storage)
+    }
+
+    pub(super) fn open_with_graph_check(path: &Path, check_graph: bool) -> anyhow::Result<Self> {
+        let mut storage = Self::open_and_migrate(path)?;
         ai::ensure_model_manifest(storage.connection())?;
-        let repo_id = schema::single_repo_id(storage.connection())?;
+        // A bare `open` has no config identity to register, so it scopes to the SOLE repo of a
+        // single-repo DB (a consolidated multi-repo DB is only reached through `open_config`, which
+        // registers). The model-manifest heal above resolves the same sole repo via the no-context
+        // fallback in `schema::active_repo_id`.
+        let repo_id = schema::sole_repo_id(storage.connection())?;
         if let Some(root) = repo_meta(storage.connection(), &repo_id, "source_root")? {
             storage.set_source_root(PathBuf::from(root));
         }
         let db = Self {
             storage,
+            active_repo_id: repo_id,
             active_commit_sha: String::new(),
             active_worktree_id: String::new(),
             github: github::GitHubContext::default(),
@@ -64,14 +78,26 @@ impl IndexDatabase {
     }
 
     pub fn open_config(config: &Config) -> anyhow::Result<Self> {
-        let mut db = Self::open_with_graph_check(&config.database, false)?;
+        let storage = Self::open_and_migrate(&config.database)?;
+        let mut db = Self {
+            storage,
+            active_repo_id: String::new(),
+            active_commit_sha: String::new(),
+            active_worktree_id: String::new(),
+            // Real usage: resolve the GitHub repo context from the local `gh` CLI here, at the
+            // boundary. rebuild/open (used by tests and the bare index command) leave it offline.
+            github: github::GitHubContext::from_gh(),
+            config: Some(config.clone()),
+        };
         db.storage.set_source_root(config.root.clone());
+        // Register/adopt BEFORE anything repo-scoped runs, then install the scope context so the
+        // model-manifest heal + seed below resolve the correct repo (in a consolidated DB the sole-
+        // repo fallback would be ambiguous — the ordering, not the fallback, is load-bearing
+        // there).
+        db.adopt_repo_from_config(config)?;
         let (commit_sha, worktree_id) = resolve_git_context(&config.root);
         db.set_context(&commit_sha, &worktree_id)?;
-        // Real usage: resolve the GitHub repo context from the local `gh` CLI here, at the
-        // boundary. rebuild/open (used by tests and the bare index command) leave it offline.
-        db.github = github::GitHubContext::from_gh();
-        db.config = Some(config.clone());
+        ai::ensure_model_manifest(db.storage.connection())?;
         db.ensure_graph_index_current()?;
         db.ensure_generated_flags_current()?;
         // Adopt the configured embedding model as the index's active model when it has none yet, so
@@ -82,6 +108,33 @@ impl IndexDatabase {
             config.llm.embedding.backend.model_id(),
         )?;
         Ok(db)
+    }
+
+    /// Resolve this config's repo IDENTITY and register/adopt it, stamping `self.active_repo_id`.
+    /// Identity-resolution failures split by class
+    /// ([`RepoIdentityError`](crate::repo_identity::RepoIdentityError)):
+    /// - `Absent` (not a git repo / unborn HEAD — many tests, and any bare temp-dir index) is NOT
+    ///   an error: fall back to the sole registered repo (the placeholder on a fresh DB), leaving
+    ///   the DB single-repo and un-adopted exactly as before A3.
+    /// - `Rejected` (a pinned reserved `[index] repo_id`, or an unreadable / root-less history)
+    ///   PROPAGATES: falling back would silently scope the DB to the placeholder and bury the
+    ///   configuration problem the error names, leaving rows unadopted under the legacy id. A cut
+    ///   shallow clone is NOT rejected — it resolves to a `LocalOnly` id and registers normally.
+    ///
+    /// A genuine registration refusal (a different repo already owns a consolidated DB) also
+    /// propagates, via `register_repo` itself.
+    pub(super) fn adopt_repo_from_config(&mut self, config: &Config) -> anyhow::Result<()> {
+        let conn = self.storage.connection();
+        let repo_id = match crate::repo_identity::resolve_repo_identity(
+            &config.root,
+            config.repo_id_override.as_deref(),
+        ) {
+            Ok(identity) => schema::register_repo(conn, &identity, &config.root, schema::now_ms())?,
+            Err(err) if err.is_absent() => schema::sole_repo_id(conn)?,
+            Err(err) => return Err(err.into()),
+        };
+        self.active_repo_id = repo_id;
+        Ok(())
     }
 
     /// Open the index **read-only** for a pure-read tool, returning `None` when the index still
@@ -109,40 +162,58 @@ impl IndexDatabase {
         if schema::status(storage.connection())?.state != schema::SchemaState::Compatible {
             return Ok(None);
         }
-        let repo_id = schema::single_repo_id(storage.connection())?;
-        if repo_meta(storage.connection(), &repo_id, "graph_index_version")?.as_deref()
+        // Resolve the repo this CONFIG maps to on the read-only connection, WITHOUT registering (a
+        // write). A consolidated DB (post-A7) can hold several repos; the config-blind sole-repo
+        // pick would bind a SIBLING, so `resolve_config_repo_id` scopes by the config's identity /
+        // recorded root instead. `None` — the repo is not provably registered here (a fresh DB, or
+        // a consolidated one whose config root is not recorded) — means a write is owed to
+        // register it, so fall back to the read-write `open_config` (same posture as the
+        // gates below).
+        let Some(repo_id) = schema::resolve_config_repo_id(
+            storage.connection(),
+            &config.root,
+            config.repo_id_override.as_deref(),
+        )?
+        else {
+            return Ok(None);
+        };
+        storage.set_source_root(config.root.clone());
+        let (commit_sha, worktree_id) = resolve_git_context(&config.root);
+        let mut db = Self {
+            storage,
+            active_repo_id: repo_id,
+            active_commit_sha: String::new(),
+            active_worktree_id: String::new(),
+            github: github::GitHubContext::from_gh(),
+            config: Some(config.clone()),
+        };
+        // Install the scope context BEFORE the heal-owed gates: `set_context` mirrors the resolved
+        // `repo_id` into `temp.connection_context` (writable even on a read-only main DB), so the
+        // gates below that resolve `active_repo_id` from the connection (the model manifest + the
+        // embedding-model seed) see the CONFIG's repo — not the config-blind sole repo, which is a
+        // SIBLING in a consolidated DB and would make them falsely report a heal is owed under an
+        // empty scope. The graph / generated-flags gates read `repo_id` explicitly.
+        db.set_context(&commit_sha, &worktree_id)?;
+        let conn = db.storage.connection();
+        if repo_meta(conn, &db.active_repo_id, "graph_index_version")?.as_deref()
             != Some(GRAPH_INDEX_VERSION)
         {
             return Ok(None);
         }
         // A stale generated-flags version owes a re-derive (a write); fall back to read-write so it
         // heals once, after which reads are lock-free again (#202, same posture as the graph gate).
-        if read_meta(storage.connection(), GENERATED_FLAGS_VERSION_KEY)?.as_deref()
-            != Some(GENERATED_FLAGS_VERSION)
+        if read_meta(conn, GENERATED_FLAGS_VERSION_KEY)?.as_deref() != Some(GENERATED_FLAGS_VERSION)
         {
             return Ok(None);
         }
-        if !ai::model_manifest_is_current(storage.connection())? {
+        if !ai::model_manifest_is_current(conn)? {
             return Ok(None);
         }
         // A fresh index owes an active-embedding-model seed from config (a write); fall back to the
         // read-write open so it heals once (#394, same posture as the manifest / graph gates).
-        if ai::active_embedding_model_seed_owed(
-            storage.connection(),
-            config.llm.embedding.backend.model_id(),
-        )? {
+        if ai::active_embedding_model_seed_owed(conn, config.llm.embedding.backend.model_id())? {
             return Ok(None);
         }
-        storage.set_source_root(config.root.clone());
-        let (commit_sha, worktree_id) = resolve_git_context(&config.root);
-        let mut db = Self {
-            storage,
-            active_commit_sha: String::new(),
-            active_worktree_id: String::new(),
-            github: github::GitHubContext::from_gh(),
-            config: Some(config.clone()),
-        };
-        db.set_context(&commit_sha, &worktree_id)?;
         Ok(Some(db))
     }
 
@@ -185,16 +256,17 @@ impl IndexDatabase {
         schema::status(storage.connection())
     }
 
+    /// Create-or-migrate the schema for a full [`rebuild`](Self::rebuild). Leaves the repo scope
+    /// UNSET (`active_repo_id` empty): `rebuild` registers/adopts the repo and installs the scope
+    /// context itself (so the model-manifest heal and every direct-scoped write see the right repo,
+    /// even on a consolidated DB), then stamps `source_root` from the config. The manifest heal and
+    /// source-root restore therefore move to `rebuild`, out of this low-level helper.
     pub(super) fn create_or_migrate(path: &Path) -> anyhow::Result<Self> {
-        let mut storage = IndexConnection::open(path)?;
+        let storage = IndexConnection::open(path)?;
         schema::apply(storage.connection())?;
-        ai::ensure_model_manifest(storage.connection())?;
-        let repo_id = schema::single_repo_id(storage.connection())?;
-        if let Some(root) = repo_meta(storage.connection(), &repo_id, "source_root")? {
-            storage.set_source_root(PathBuf::from(root));
-        }
         Ok(Self {
             storage,
+            active_repo_id: String::new(),
             active_commit_sha: String::new(),
             active_worktree_id: String::new(),
             github: github::GitHubContext::default(),
@@ -205,7 +277,14 @@ impl IndexDatabase {
     pub fn set_context(&mut self, commit_sha: &str, worktree_id: &str) -> anyhow::Result<()> {
         self.active_commit_sha = commit_sha.to_string();
         self.active_worktree_id = worktree_id.to_string();
-        install_scope_view(self.storage.connection(), commit_sha, worktree_id)?;
+        // The repo dimension comes from `self.active_repo_id` (resolved at open), not re-derived
+        // from the connection — a consolidated DB's sole-repo fallback would be ambiguous. This is
+        // the one caller that scopes to a SPECIFIC repo without reading it back from the context.
+        write_scope_view(self.storage.connection(), &ScopeContext {
+            repo_id: self.active_repo_id.clone(),
+            commit_sha: commit_sha.to_string(),
+            worktree_id: worktree_id.to_string(),
+        })?;
         Ok(())
     }
 
@@ -249,25 +328,82 @@ impl IndexDatabase {
 /// `use_worktree_scope`. Resolves the OVERLAY scope from `config_root` (the main worktree, where
 /// the base index lives) and `cwd` (the session's working dir): when `cwd` is a linked worktree of
 /// `config_root`'s repo, the view serves that branch's overlay on the base; otherwise (main /
-/// foreign / unreadable) it is the base scope. `pub` so the CLI hook + the MCP listener (other
-/// crates) can scope their context to the worktree the session is actually in (#219).
+/// foreign / unreadable) it is the base scope.
+///
+/// The REPO dimension is passed EXPLICITLY (`repo_id`) rather than re-resolved from the raw
+/// connection: a raw conn has no scope context installed, so the free-conn
+/// [`schema::active_repo_id`] fallback would pick the config-blind sole repo — a SIBLING in a
+/// consolidated DB. The caller resolves it from its config (where the identity / override is
+/// reachable) via [`resolve_scope_repo_id`]; an empty string binds a scope that matches nothing —
+/// the safe result when the config's repo can't be proven, never a sibling's rows. `pub` so the CLI
+/// hook + the MCP listener (other crates) can scope their context to the worktree the session is
+/// actually in (#219).
 pub fn install_worktree_scope_view(
     conn: &rusqlite::Connection,
+    repo_id: &str,
     config_root: &Path,
     cwd: &Path,
 ) -> anyhow::Result<()> {
     let (commit_sha, worktree_id) = resolve_worktree_scope(config_root, Some(cwd));
-    install_scope_view(conn, &commit_sha, &worktree_id)?;
+    write_scope_view(conn, &ScopeContext {
+        repo_id: repo_id.to_string(),
+        commit_sha,
+        worktree_id,
+    })?;
     Ok(())
 }
 
-/// Installs the per-connection commit/worktree scoping view; callers query `files` afterward and
-/// see only the active context.
+/// Resolve the `repo_id` a config maps to on a READ-ONLY connection, without registering — the
+/// public entry point for the raw-connection scope-view callers (the Claude Code / MCP hooks) that
+/// live in other crates. Thin wrapper over [`schema::resolve_config_repo_id`]; see it for the
+/// resolution routes and the `None` semantics. Pass the resolved id into
+/// [`install_worktree_scope_view`] (or `unwrap_or_default()` for an empty — sibling-safe — scope
+/// when the repo can't be proven).
+pub fn resolve_scope_repo_id(
+    conn: &rusqlite::Connection,
+    config_root: &Path,
+    repo_id_override: Option<&str>,
+) -> anyhow::Result<Option<String>> {
+    Ok(schema::resolve_config_repo_id(conn, config_root, repo_id_override)?)
+}
+
+/// The active scope a connection's `files` view is filtered to: the repo dimension (A3) plus the
+/// existing commit/worktree dimensions. Threaded into [`write_scope_view`], which mirrors it into
+/// `temp.connection_context` so free-conn helpers (`schema::active_repo_id`, `edges::resolve`)
+/// recover the same values.
+pub(crate) struct ScopeContext {
+    pub repo_id: String,
+    pub commit_sha: String,
+    pub worktree_id: String,
+}
+
+/// Install the scope view on a RAW connection that has no `IndexDatabase` to carry
+/// `active_repo_id`, resolving the repo dimension from the connection via
+/// [`schema::active_repo_id`] (the sole repo of a single-repo DB, or the placeholder on an
+/// un-adopted test DB — matching the placeholder-defaulted `files` rows those tests insert).
+/// TEST-ONLY now: the raw-conn hook listeners resolve the repo id explicitly from their config and
+/// pass it into [`install_worktree_scope_view`], so only the graph tests (which seed rows under the
+/// sole/placeholder repo) reach this config-blind resolver. `IndexDatabase::set_context` likewise
+/// passes an explicit repo id (the multi-repo path).
+#[cfg(test)]
 pub(crate) fn install_scope_view(
     conn: &rusqlite::Connection,
     commit_sha: &str,
     worktree_id: &str,
 ) -> rusqlite::Result<()> {
+    let repo_id = schema::active_repo_id(conn)?;
+    write_scope_view(conn, &ScopeContext {
+        repo_id,
+        commit_sha: commit_sha.to_string(),
+        worktree_id: worktree_id.to_string(),
+    })
+}
+
+/// Installs the per-connection repo/commit/worktree scoping view; callers query `files` afterward
+/// and see only the active context. The `files` view filters on `repo_id` FIRST (A3) so a
+/// consolidated DB never leaks another repo's rows through the view — every read path that goes
+/// through `temp.files` is repo-scoped for free.
+fn write_scope_view(conn: &rusqlite::Connection, ctx: &ScopeContext) -> rusqlite::Result<()> {
     conn.execute_batch(
         "
             CREATE TEMP TABLE IF NOT EXISTS connection_context(key TEXT PRIMARY KEY, value TEXT);
@@ -276,9 +412,13 @@ pub(crate) fn install_scope_view(
 
     let mut stmt =
         conn.prepare("INSERT OR REPLACE INTO temp.connection_context(key, value) VALUES (?1, ?2)")?;
-    stmt.execute(params!["commit_sha", commit_sha])?;
-    stmt.execute(params!["worktree_id", worktree_id])?;
+    stmt.execute(params![schema::CONNECTION_CONTEXT_REPO_KEY, ctx.repo_id])?;
+    stmt.execute(params!["commit_sha", ctx.commit_sha])?;
+    stmt.execute(params!["worktree_id", ctx.worktree_id])?;
 
+    // Every branch (and the shadowing sub-select) is repo-scoped: `worktree_id`/`commit_sha` alone
+    // are not globally unique across repos (forks share a commit; the empty base scope is shared),
+    // so the `repo_id` predicate is what keeps a sibling repo's rows out of the view.
     conn.execute_batch(
         "
             DROP VIEW IF EXISTS temp.files;
@@ -286,17 +426,20 @@ pub(crate) fn install_scope_view(
             SELECT id, path, language, kind, sha256, modified_at_ms, generated, indexed_at_ms, \
          indexed_revision, commit_sha, worktree_id, has_test_code
             FROM main.files
-            WHERE worktree_id = (SELECT value FROM temp.connection_context WHERE key = \
+            WHERE repo_id = (SELECT value FROM temp.connection_context WHERE key = 'repo_id')
+              AND worktree_id = (SELECT value FROM temp.connection_context WHERE key = \
          'worktree_id') AND worktree_id != '' AND kind != 'deleted'
             UNION ALL
             SELECT id, path, language, kind, sha256, modified_at_ms, generated, indexed_at_ms, \
          indexed_revision, commit_sha, worktree_id, has_test_code
             FROM main.files
-            WHERE commit_sha = (SELECT value FROM temp.connection_context WHERE key = 'commit_sha')
+            WHERE repo_id = (SELECT value FROM temp.connection_context WHERE key = 'repo_id')
+              AND commit_sha = (SELECT value FROM temp.connection_context WHERE key = 'commit_sha')
               AND commit_sha != ''
               AND path NOT IN (
                   SELECT path FROM main.files
-                  WHERE worktree_id = (SELECT value FROM temp.connection_context WHERE key = \
+                  WHERE repo_id = (SELECT value FROM temp.connection_context WHERE key = 'repo_id')
+                    AND worktree_id = (SELECT value FROM temp.connection_context WHERE key = \
          'worktree_id')
                     AND worktree_id != ''
               );

--- a/crates/rag-rat-core/src/index/meta.rs
+++ b/crates/rag-rat-core/src/index/meta.rs
@@ -5,35 +5,36 @@ use super::*;
 impl IndexDatabase {
     pub(super) fn record_content_revision(&self) -> anyhow::Result<String> {
         let revision = self.content_revision()?;
-        self.set_repo_meta("content_revision", &revision)?;
+        // GLOBAL, not per-repo (V040 reclassification): `content_revision()` digests the WHOLE
+        // `main.files` (no repo filter — see the method below), so its stored value is scope- and
+        // repo-invariant. V039 relocated it to `repo_meta` under the one-DB-per-repo assumption;
+        // per-repo copies would make a consolidated DB's FTS freshness alternate. `set_meta` writes
+        // the global `index_meta`. (V040's `move_repo_meta_keys_to_global` migrates any stale
+        // per-repo copy back; the shared relocate helper no longer re-relocates it.)
+        self.set_meta("content_revision", &revision)?;
         Ok(revision)
     }
 
     /// Read a per-repo meta value (`repo_meta`) for the repo owning this connection — the ergonomic
-    /// per-connection twin of the [`repo_meta`] free primitive, resolving the active repo via
-    /// [`schema::single_repo_id`] (A3 replaces that with a real scope context).
+    /// per-connection twin of the [`repo_meta`] free primitive, scoped by `self.active_repo_id`
+    /// (resolved at open: `register_repo` on a config open, the sole repo on a bare open).
     pub(super) fn repo_meta(&self, key: &str) -> anyhow::Result<Option<String>> {
         let conn = self.storage.connection();
-        let repo_id = schema::single_repo_id(conn)?;
         // Bare call → the free `repo_meta` primitive below, never this method (methods need a
         // receiver); the two share a name intentionally (primitive + per-connection wrapper).
-        Ok(repo_meta(conn, &repo_id, key)?)
+        Ok(repo_meta(conn, &self.active_repo_id, key)?)
     }
 
     /// Upsert a per-repo meta value for the repo owning this connection.
     pub(super) fn set_repo_meta(&self, key: &str, value: &str) -> anyhow::Result<()> {
-        let conn = self.storage.connection();
-        let repo_id = schema::single_repo_id(conn)?;
-        set_repo_meta(conn, &repo_id, key, value)?;
+        set_repo_meta(self.storage.connection(), &self.active_repo_id, key, value)?;
         Ok(())
     }
 
     /// Upsert a per-repo meta value only when it changes — returns whether a write happened, so a
     /// no-change incremental/sweep pass avoids dirtying a WAL page (issue #63).
     pub(super) fn set_repo_meta_if_changed(&self, key: &str, value: &str) -> anyhow::Result<bool> {
-        let conn = self.storage.connection();
-        let repo_id = schema::single_repo_id(conn)?;
-        Ok(set_repo_meta_if_changed(conn, &repo_id, key, value)?)
+        Ok(set_repo_meta_if_changed(self.storage.connection(), &self.active_repo_id, key, value)?)
     }
 
     pub(super) fn set_meta(&self, key: &str, value: &str) -> anyhow::Result<()> {
@@ -78,8 +79,9 @@ impl IndexDatabase {
 
 /// Read a per-repo meta value from the `repo_meta` table — the repo-scoped twin of
 /// [`read_meta`](crate::index::read_meta) (which reads the global `index_meta`). `repo_id` is the
-/// owning repo; until phase A3 threads a real active-repo context, callers pass
-/// [`schema::single_repo_id`]. Returns `None` when the key is unset for that repo.
+/// owning repo — the caller's active-repo scope (`IndexDatabase::active_repo_id`, or
+/// [`schema::active_repo_id`](crate::index::schema) on a free connection). Returns `None` when the
+/// key is unset for that repo.
 pub(crate) fn repo_meta(
     conn: &rusqlite::Connection,
     repo_id: &str,
@@ -125,8 +127,8 @@ pub(crate) fn set_repo_meta_if_changed(
     Ok(true)
 }
 
-/// Delete a per-repo meta key (a no-op when absent) — the `repo_meta` counterpart of `delete_meta`,
-/// needed by the clear paths of the relocated model / reencode-cursor keys.
+/// Delete a per-repo meta key (a no-op when absent) — needed by the clear paths of the relocated
+/// model / reencode-cursor keys.
 pub(crate) fn delete_repo_meta(
     conn: &rusqlite::Connection,
     repo_id: &str,

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -39,12 +39,13 @@ pub use discovery::DiscoveryStatus;
 pub(crate) use discovery::*;
 pub use git_context::resolve_git_context;
 pub(crate) use git_context::*;
-// Only tests reach `install_scope_view` directly now (non-test code goes through
-// `install_worktree_scope_view`, which calls it within `lifecycle`); gate the re-export so the
-// non-test build doesn't warn it unused.
+// Only tests reach `install_scope_view` directly now: non-test code resolves the repo id
+// explicitly (`resolve_scope_repo_id`) and passes it into `install_worktree_scope_view`, which
+// writes the scope itself rather than routing through the config-blind `active_repo_id`
+// fallback. Gate the re-export so the non-test build doesn't warn it unused.
 #[cfg(test)]
 pub(crate) use lifecycle::install_scope_view;
-pub use lifecycle::install_worktree_scope_view;
+pub use lifecycle::{install_worktree_scope_view, resolve_scope_repo_id};
 pub(crate) use mem_diag::{maybe_set_sqlite_soft_heap_limit, mem_trace};
 pub(crate) use meta::{delete_repo_meta, repo_meta, set_repo_meta};
 pub use parser_failures::ParserFailure;
@@ -99,6 +100,12 @@ use crate::storage::{IndexConnection, StorageStatus};
 #[derive(Debug)]
 pub struct IndexDatabase {
     storage: IndexConnection,
+    /// The repo this connection is scoped to — resolved once at open (`register_repo` on a
+    /// config-bearing open, the sole registered repo on a bare/read-only open) and stamped onto
+    /// every direct-scoped write. Mirrored into `temp.connection_context` by `install_scope_view`
+    /// so free-conn helpers resolve the same id via `schema::active_repo_id`. Empty only between
+    /// construction and the first repo resolution.
+    pub active_repo_id: String,
     pub active_commit_sha: String,
     pub active_worktree_id: String,
     /// Injected GitHub repo context. Resolved from `gh` only in `open_config` (real usage);
@@ -324,6 +331,12 @@ impl FileScope {
 
 #[cfg(test)]
 mod schema_bootstrap_tests;
+
+// The poison-sibling test harness. `pub(crate)` (not private) so the `rebuild` seam and the
+// mutating tests across submodules can reach `seed_if_enabled` / `disable_poison_sibling` /
+// `assert_sibling_intact`. See the module docs for what it enforces and how to opt out.
+#[cfg(test)]
+pub(crate) mod poison_sibling;
 
 #[cfg(test)]
 mod generated_path_tests {

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -75,17 +75,21 @@ pub(crate) fn resolution_before_counts(
 /// The number of logical symbols enriched with a SCIP moniker for `(tool, tool_version)` — the
 /// "symbols enriched" signal (#70). Scoped to `tool_version` (not just `tool`) so the count
 /// describes the SAME run as the report's `edge_oracle`-derived metrics: a later same-tool run with
-/// a different `tool_version` must not bleed its monikers into this report.
-/// `logical_symbol_monikers` is keyed `(logical_symbol_id, tool)` (repo-global, not
-/// checkout-scoped).
+/// a different `tool_version` must not bleed its monikers into this report. Also scoped to the
+/// ACTIVE repo (A3): `logical_symbol_monikers` carries no `repo_id`, so a consolidated DB's count
+/// must join `logical_symbols` and filter `repo_id = active_repo_id` — otherwise a sibling repo's
+/// monikers inflate this report's enriched-symbol count.
 pub(crate) fn count_symbols_with_moniker(
     conn: &Connection,
     tool: OracleTool,
     tool_version: &str,
 ) -> anyhow::Result<u64> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     let count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM logical_symbol_monikers WHERE tool = ?1 AND tool_version = ?2",
-        params![tool.as_db_str(), tool_version],
+        "SELECT COUNT(*) FROM logical_symbol_monikers
+         WHERE tool = ?1 AND tool_version = ?2
+           AND logical_symbol_id IN (SELECT id FROM logical_symbols WHERE repo_id = ?3)",
+        params![tool.as_db_str(), tool_version, repo_id],
         |row| row.get(0),
     )?;
     Ok(u64::try_from(count).unwrap_or(0))
@@ -292,18 +296,31 @@ pub(crate) fn logical_symbol_id_for_member(
     .map_err(Into::into)
 }
 
-/// Delete every `logical_symbol_monikers` row for `tool`. Called at the start of a run, inside the
-/// run's transaction, so the moniker set is **authoritative** for the latest run: a symbol the
-/// current `.scip` no longer defines must not keep a stale moniker, and dangling rows (whose
-/// content-derived logical id died in a rebuild) are swept on every run. The clear is global for
-/// the tool — `logical_symbols` itself is rebuilt unscoped from all symbols, so monikers follow
-/// the same (single-checkout-in-practice) lifecycle rather than inventing a per-checkout scope the
-/// parent table doesn't have.
+/// Delete this repo's `logical_symbol_monikers` rows for `tool`. Called at the start of a run,
+/// inside the run's transaction, so the moniker set is **authoritative** for the latest run: a
+/// symbol the current `.scip` no longer defines must not keep a stale moniker.
+///
+/// SCOPE (load-bearing, A3): the DELETE is restricted to monikers whose logical symbol belongs to
+/// the ACTIVE repo (`logical_symbols.repo_id = active_repo_id`) — `logical_symbols` ids are now
+/// repo-distinct, so `logical_symbol_monikers` (which has no `repo_id` column of its own) can hold
+/// rows for several repos in a consolidated DB. A global `DELETE ... WHERE tool = ?` would erase a
+/// SIBLING repo's live moniker anchors on every oracle run, making its `scip_moniker` memory
+/// relocation go gone/unverified. Dangling rows (whose content-derived logical id died in a
+/// rebuild, so they join NO repo's `logical_symbols`) are still swept — they belong to no repo and
+/// never resolve through the live-join reads, so sweeping them can never touch a sibling's valid
+/// rows.
 pub(crate) fn clear_logical_symbol_monikers_for_tool(
     conn: &Connection,
     tool: OracleTool,
 ) -> anyhow::Result<()> {
-    conn.execute("DELETE FROM logical_symbol_monikers WHERE tool = ?1", [tool.as_db_str()])?;
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    conn.execute(
+        "DELETE FROM logical_symbol_monikers
+         WHERE tool = ?1
+           AND (logical_symbol_id IN (SELECT id FROM logical_symbols WHERE repo_id = ?2)
+                OR logical_symbol_id NOT IN (SELECT id FROM logical_symbols))",
+        params![tool.as_db_str(), repo_id],
+    )?;
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -4883,8 +4883,21 @@ fn resolution_report_assembles_before_after_from_index() {
     write(conf, OracleResolutionKind::Confirm, Some(conf_sym));
     write(contra, OracleResolutionKind::Contradict, Some(contra_sym));
 
-    // Two logical symbols enriched with a moniker for this tool.
+    // Two logical symbols enriched with a moniker for this tool. The `logical_symbols` rows must
+    // exist for the enriched-symbol tally: `count_symbols_with_moniker` joins them and filters by
+    // the active `repo_id` (A3, round-6 P2 #3), so a moniker with no live logical symbol is not an
+    // "enriched symbol" — mirroring production, where oracle only writes a moniker for a resolved
+    // logical symbol. The default `repo_id` (`__unassigned__`) matches this raw-conn harness's
+    // sole/active repo.
     for id in [1_i64, 2] {
+        h.conn
+            .execute(
+                "INSERT INTO logical_symbols(id, language, path, logical_name, kind, \
+                 variant_count, group_reason) VALUES (?1, 'rust', 'a.rs', ?2, 'function', 1, \
+                 'test')",
+                params![id, format!("sym{id}")],
+            )
+            .unwrap();
         h.conn
             .execute(
                 "INSERT INTO logical_symbol_monikers(logical_symbol_id, tool, tool_version, \

--- a/crates/rag-rat-core/src/index/packages.rs
+++ b/crates/rag-rat-core/src/index/packages.rs
@@ -33,22 +33,23 @@ impl IndexDatabase {
         // change (same global union) is still detected as a change → forces a re-resolve.
         let previous_package_map: std::collections::BTreeMap<String, String> = {
             let mut stmt = conn.prepare(
-                "SELECT manifest_dir, local_roots_json FROM packages WHERE commit_sha = ?1 AND \
-                 worktree_id = ?2",
+                "SELECT manifest_dir, local_roots_json FROM packages WHERE repo_id = ?1 AND \
+                 commit_sha = ?2 AND worktree_id = ?3",
             )?;
-            let rows = stmt
-                .query_map(params![self.active_commit_sha, self.active_worktree_id], |row| {
-                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-                })?;
+            let rows = stmt.query_map(
+                params![self.active_repo_id, self.active_commit_sha, self.active_worktree_id],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            )?;
             rows.collect::<Result<_, _>>()?
         };
         // Replace this scope's package rows. The id is reassigned each rebuild, which is fine — the
         // file→package mapping is computed at LOAD time from `manifest_dir`, not from a persisted
-        // id.
-        conn.execute("DELETE FROM packages WHERE commit_sha = ?1 AND worktree_id = ?2", params![
-            self.active_commit_sha,
-            self.active_worktree_id
-        ])?;
+        // id. Scoped by `repo_id` (A3) so a sibling repo's packages in a consolidated DB are
+        // untouched.
+        conn.execute(
+            "DELETE FROM packages WHERE repo_id = ?1 AND commit_sha = ?2 AND worktree_id = ?3",
+            params![self.active_repo_id, self.active_commit_sha, self.active_worktree_id],
+        )?;
         // The freshly-written map, compared against `previous_package_map` below.
         let mut current_package_map: std::collections::BTreeMap<String, String> =
             std::collections::BTreeMap::new();
@@ -58,12 +59,13 @@ impl IndexDatabase {
             )?;
             conn.execute(
                 "INSERT OR REPLACE INTO packages(manifest_dir, commit_sha, worktree_id, \
-                 local_roots_json) VALUES (?1, ?2, ?3, ?4)",
+                 local_roots_json, repo_id) VALUES (?1, ?2, ?3, ?4, ?5)",
                 params![
                     package.manifest_dir,
                     self.active_commit_sha,
                     self.active_worktree_id,
-                    roots_json
+                    roots_json,
+                    self.active_repo_id
                 ],
             )?;
             current_package_map.insert(package.manifest_dir.clone(), roots_json);

--- a/crates/rag-rat-core/src/index/parser_failures.rs
+++ b/crates/rag-rat-core/src/index/parser_failures.rs
@@ -27,27 +27,38 @@ impl IndexDatabase {
         if self.active_scope_is_linked_overlay() {
             return Ok(());
         }
+        // `INSERT OR REPLACE`: the PK is now `(repo_id, path)` (V040), so a re-record of the same
+        // path (e.g. without an intervening `remove_file_in_scope`) upserts rather than tripping
+        // the PK. `repo_id` scopes the row so a sibling repo's failure at the same path is
+        // a distinct row.
         self.storage.connection().execute(
-            "INSERT INTO parser_failures(path, language, message) VALUES (?1, ?2, ?3)",
-            params![path_string(path), language.as_str(), message],
+            "INSERT OR REPLACE INTO parser_failures(repo_id, path, language, message)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![self.active_repo_id, path_string(path), language.as_str(), message],
         )?;
         Ok(())
     }
 
     pub(super) fn parser_failure_count(&self) -> anyhow::Result<u64> {
+        // Scoped to `active_repo_id` (A3): the row is written under a `repo_id`, so an unscoped
+        // count would report a sibling repo's parse failures as this repo's coverage in a
+        // consolidated DB.
         let count = self.storage.connection().query_row(
-            "SELECT COUNT(*) FROM parser_failures",
-            [],
+            "SELECT COUNT(*) FROM parser_failures WHERE repo_id = ?1",
+            [&self.active_repo_id],
             |row| row.get::<_, i64>(0),
         )?;
         Ok(u64::try_from(count).unwrap_or(0))
     }
 
     pub(super) fn parser_failure_paths(&self) -> anyhow::Result<Vec<ParserFailure>> {
+        // Scoped to `active_repo_id` (A3): a same-path healthy file in this repo must not be
+        // reported parser-failed on the strength of a sibling repo's failure at that path.
         let mut stmt = self.storage.connection().prepare(
-            "SELECT path, language, message FROM parser_failures ORDER BY path, language, message",
+            "SELECT path, language, message FROM parser_failures WHERE repo_id = ?1
+             ORDER BY path, language, message",
         )?;
-        let rows = stmt.query_map([], |row| {
+        let rows = stmt.query_map([&self.active_repo_id], |row| {
             Ok(ParserFailure { path: row.get(0)?, language: row.get(1)?, message: row.get(2)? })
         })?;
         let mut failures = Vec::new();

--- a/crates/rag-rat-core/src/index/poison_sibling.rs
+++ b/crates/rag-rat-core/src/index/poison_sibling.rs
@@ -1,0 +1,388 @@
+//! Poison-sibling test harness (`#[cfg(test)]` only).
+//!
+//! GOAL: end the review-driven discovery loop for repo-scoping bugs. Every unscoped read / count /
+//! delete / resume in the engine should fail an EXISTING test **locally** rather than surface in a
+//! reviewer's comment. The mechanism: after a fixture DB reaches its ready state (the tail of
+//! [`IndexDatabase::rebuild_with_progress`]), register a SECOND repo (`poison-sibling`) directly
+//! via SQL — `register_repo` refuses a second real repo before A7, so the harness seeds it the same
+//! way `multi_repo_scope`'s `two_repo_fixture` does — and hang tripwire rows off it in every table
+//! that carries a repo dimension at this schema version. A production read that forgets its
+//! `repo_id` predicate (or bypasses the scope view) then sees the sibling's rows and the test's own
+//! assertion trips; a production DELETE that forgets it silently wipes the sibling, which
+//! [`assert_sibling_intact`] catches.
+//!
+//! SCHEMA-VERSION SCOPE (load-bearing): this worktree is **V040** (`LATEST_SCHEMA_VERSION = 40`),
+//! where exactly TEN tables carry a `repo_id` column — `repos`, `repo_roots`, `repo_meta`, `files`,
+//! `packages`, `logical_symbols`, `docs`, `parser_failures`, `git_commits`, `git_file_changes` —
+//! plus tables scoped TRANSITIVELY through them (`chunks`/`symbols`/`edges_data` via `files.id`;
+//! `logical_symbol_members`/`logical_symbol_monikers` via `logical_symbols.id`). The github, repo
+//! memory, oracle (`oracle_runs`/`edge_oracle`), clone, `dream_findings`, and `reconcile_attempts`
+//! tables are GLOBAL at V040 — they gain `repo_id` only in A4 (V041) / A5 (V042), which are NOT in
+//! this worktree — so seeding a `repo_id='poison-sibling'` row into them is impossible and a read
+//! of them is *legitimately* cross-repo here. Seeding them would manufacture FALSE tripwires. When
+//! A4/A5 land, extend [`seed_sibling`] to those tables at the same time their scoping does.
+//!
+//! WHY THE SIBLING IS NOT REGISTERED IN `repos` (load-bearing at V040): the eight direct-scoped
+//! DATA tables (`files`, `packages`, `logical_symbols`, `docs`, `parser_failures`, `git_commits`,
+//! `git_file_changes`, and the file/symbol children) carry `repo_id` as a plain column with a
+//! `DEFAULT '__unassigned__'` and **no foreign key to `repos`** — so a tripwire row under
+//! `repo_id='poison-sibling'` is valid without a `repos` registry row. The harness deliberately
+//! does NOT insert into `repos`/`repo_roots`/`repo_meta`. If it did, the sibling would become a
+//! second REAL repo, and at phase A that (a) makes `sole_repo_id` (the config-blind fallback for
+//! the many NON-git fixtures, which stay under the `__unassigned__` placeholder) return the sibling
+//! instead of the fixture — hijacking every re-adoption — and (b) flips `multiple_real_repos`,
+//! changing the gc/precompute global-sweep guards. Neither is a production leak; both are phase-A
+//! single-repo assumptions. Seeding only the *scoped data* rows keeps the registry pristine (no
+//! hijack, no `multiple_real_repos` flip) while still tripping any genuinely unscoped
+//! read/count/delete. The cost is no tripwire for an unscoped `repo_meta`/`repos`/`repo_roots` read
+//! — those are covered by the dedicated registry + `multi_repo_scope` tests instead. (When A7 makes
+//! multi-repo the default, the sibling gets a real `repos` row and this note goes away.)
+//!
+//! OPT-OUT: default-ON per test thread (see [`disable_poison_sibling`]). A test that legitimately
+//! asserts a scoped table's UNSCOPED total (a `full_rebuild_preserves_*` cache-total check, a
+//! whole-table row count) disables the harness at its start. Each opt-out is a deliberate statement
+//! that the test's invariant is single-repo by nature, not a workaround for a real leak.
+
+use std::cell::Cell;
+
+use rusqlite::{Connection, params};
+
+/// The reserved id of the tripwire repo. Distinctive so a stray row is unmistakable in a failure.
+pub(crate) const POISON_REPO_ID: &str = "poison-sibling";
+
+/// Sentinel prefix on every text value the harness seeds, so a leaked row is greppable and a
+/// value-mutation is detectable by exact match.
+const POISON_PREFIX: &str = "zz_poison_";
+
+/// The poison sibling's logical-symbol id. Explicit (the real derivation folds `repo_id` into a
+/// content hash) and far outside any real id range so it never collides with a fixture's symbols.
+const POISON_LOGICAL_ID: i64 = 9_900_000_777;
+
+/// The poison sibling's git commit hash (a distinctive 40-hex-shaped sentinel).
+const POISON_COMMIT: &str = "zzpoison00000000000000000000000000000000";
+
+thread_local! {
+    /// Whether [`seed_if_enabled`] seeds on this thread. Default ON. Thread-local (not a global
+    /// static) so a `cargo test` run — which executes tests as parallel THREADS in one process —
+    /// keeps each test's opt-out isolated; under `nextest` (process-per-test) it is trivially
+    /// isolated too.
+    static POISON_ENABLED: Cell<bool> = const { Cell::new(true) };
+}
+
+/// Restores the previous enabled state on drop, so an opt-out is scoped to the test that took it.
+pub(crate) struct PoisonDisabled(bool);
+
+impl Drop for PoisonDisabled {
+    fn drop(&mut self) {
+        POISON_ENABLED.with(|flag| flag.set(self.0));
+    }
+}
+
+/// Disable poison-sibling seeding for the remainder of THIS test (until the returned guard drops).
+/// Bind it: `let _guard = disable_poison_sibling();`. Use it in tests that need a virgin
+/// single-repo DB — registry/adoption/migration-ladder tests, `sole_repo_id` assertions, and any
+/// test asserting a scoped table's UNSCOPED total. Every call is a claim that the test's invariant
+/// is single-repo by nature.
+pub(crate) fn disable_poison_sibling() -> PoisonDisabled {
+    POISON_ENABLED.with(|flag| {
+        let prev = flag.get();
+        flag.set(false);
+        PoisonDisabled(prev)
+    })
+}
+
+/// The rebuild-tail seam: seed the poison sibling on `conn` unless this thread opted out.
+/// Idempotent (clears any prior sibling first), so repeated rebuilds on one DB reconverge to the
+/// same tripwire set. A seeding failure PROPAGATES — a harness that cannot seed is a bug to
+/// surface, never to swallow.
+pub(crate) fn seed_if_enabled(conn: &Connection) -> anyhow::Result<()> {
+    if POISON_ENABLED.with(Cell::get) {
+        seed_sibling(conn)?;
+    }
+    Ok(())
+}
+
+/// Clear then insert the full tripwire row set for the poison sibling. Runs under `foreign_keys =
+/// ON` (the live rebuild connection), so inserts are parent→child and clears child→parent.
+/// Deliberately touches NO registry table (`repos`/`repo_roots`/`repo_meta`) — see the module docs.
+pub(crate) fn seed_sibling(conn: &Connection) -> anyhow::Result<()> {
+    clear_sibling(conn)?;
+
+    // --- git history (git_file_changes FKs git_commits(repo_id, hash); git_commits has NO FK to
+    // repos, so this needs no registry row) ---
+    conn.execute(
+        "INSERT INTO git_commits(hash, author_name, author_email, authored_at_s, committed_at_s, \
+         subject, body, changed_file_count, repo_id)
+         VALUES (?1, ?2, ?2, 0, 0, ?3, '', 1, ?4)",
+        params![
+            POISON_COMMIT,
+            format!("{POISON_PREFIX}author"),
+            format!("{POISON_PREFIX}subject"),
+            POISON_REPO_ID
+        ],
+    )?;
+    conn.execute(
+        "INSERT INTO git_file_changes(commit_hash, path, additions, deletions, change_kind, \
+         repo_id)
+         VALUES (?1, ?2, 0, 0, 'modified', ?3)",
+        params![POISON_COMMIT, format!("{POISON_PREFIX}change.rs"), POISON_REPO_ID],
+    )?;
+
+    // --- direct-scoped core tables ---
+    conn.execute(
+        "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+         commit_sha, worktree_id, repo_id)
+         VALUES (?1, 'rust', 'source', ?2, 0, 0, ?3, '', ?4)",
+        params![
+            format!("{POISON_PREFIX}file.rs"),
+            format!("{POISON_PREFIX}sha"),
+            POISON_COMMIT,
+            POISON_REPO_ID
+        ],
+    )?;
+    let file_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO packages(manifest_dir, commit_sha, worktree_id, local_roots_json, repo_id)
+         VALUES (?1, '', '', '[]', ?2)",
+        params![format!("{POISON_PREFIX}pkg"), POISON_REPO_ID],
+    )?;
+    conn.execute(
+        "INSERT INTO parser_failures(repo_id, path, language, message) VALUES (?1, ?2, 'rust', ?3)",
+        params![POISON_REPO_ID, format!("{POISON_PREFIX}fail.rs"), format!("{POISON_PREFIX}msg")],
+    )?;
+    conn.execute(
+        "INSERT INTO logical_symbols(id, language, path, logical_name, qualified_name_id, kind, \
+         variant_count, group_reason, repo_id)
+         VALUES (?1, 'rust', ?2, ?3, NULL, 'function', 1, ?4, ?5)",
+        params![
+            POISON_LOGICAL_ID,
+            format!("{POISON_PREFIX}file.rs"),
+            format!("{POISON_PREFIX}symbol"),
+            format!("{POISON_PREFIX}group"),
+            POISON_REPO_ID
+        ],
+    )?;
+
+    // --- children hung off the poison file (transitively scoped through files.repo_id) ---
+    conn.execute(
+        "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, start_byte, \
+         end_byte, start_line, end_line, is_test)
+         VALUES (?1, 'rust', ?2, NULL, 'function', 0, 0, 0, 0, 0)",
+        params![file_id, format!("{POISON_PREFIX}symbol")],
+    )?;
+    let symbol_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO chunks(file_id, chunk_kind, start_byte, end_byte, start_line, end_line, \
+         text_hash, source_revision, anchor_version, normalized_hash, start_boundary_hash, \
+         end_boundary_hash, start_context_hash, end_context_hash, context_radius, \
+         embedding_policy, embedding_priority)
+         VALUES (?1, 'symbol', 0, 0, 0, 0, ?2, '', 0, ?2, '', '', '', '', 0, 'none', 0)",
+        params![file_id, format!("{POISON_PREFIX}chunkhash")],
+    )?;
+    let chunk_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT INTO docs(chunk_id, source_kind, heading_path, repo_id) VALUES (?1, 'markdown', \
+         ?2, ?3)",
+        params![chunk_id, format!("{POISON_PREFIX}heading"), POISON_REPO_ID],
+    )?;
+
+    // --- one edge whose source file is the poison file (scoped via source_file_id → files) ---
+    conn.execute_batch(&format!(
+        "INSERT OR IGNORE INTO name_strings(value) VALUES
+            ('{POISON_PREFIX}from'), ('{POISON_PREFIX}to'), ('{POISON_PREFIX}calls'),
+            ('{POISON_PREFIX}conf'), ('{POISON_PREFIX}res');"
+    ))?;
+    let name_id = |value: &str| -> rusqlite::Result<i64> {
+        conn.query_row("SELECT id FROM name_strings WHERE value = ?1", [value], |row| row.get(0))
+    };
+    conn.execute(
+        "INSERT INTO edges_data(source_file_id, from_name_id, to_name_id, edge_kind_id, \
+         confidence_id, resolution_id)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            file_id,
+            name_id(&format!("{POISON_PREFIX}from"))?,
+            name_id(&format!("{POISON_PREFIX}to"))?,
+            name_id(&format!("{POISON_PREFIX}calls"))?,
+            name_id(&format!("{POISON_PREFIX}conf"))?,
+            name_id(&format!("{POISON_PREFIX}res"))?,
+        ],
+    )?;
+
+    // --- children hung off the poison logical symbol (scoped via logical_symbols.repo_id) ---
+    conn.execute(
+        "INSERT INTO logical_symbol_members(logical_symbol_id, symbol_id, start_line, end_line)
+         VALUES (?1, ?2, 0, 0)",
+        params![POISON_LOGICAL_ID, symbol_id],
+    )?;
+    // logical_symbol_monikers has NO repo_id and NO FK; it is scoped only by the join to
+    // logical_symbols. This row is the tripwire for the oracle moniker clear/count (round-6 P2 #3).
+    conn.execute(
+        "INSERT INTO logical_symbol_monikers(logical_symbol_id, tool, tool_version, moniker, \
+         computed_at)
+         VALUES (?1, 'scip-rust', ?2, ?3, 0)",
+        params![
+            POISON_LOGICAL_ID,
+            format!("{POISON_PREFIX}ver"),
+            format!("{POISON_PREFIX}moniker")
+        ],
+    )?;
+
+    Ok(())
+}
+
+/// Remove every poison-sibling row, child→parent, so [`seed_sibling`] is idempotent across repeated
+/// rebuilds on one DB. Explicit child-first order works whether or not the FK cascades fire.
+fn clear_sibling(conn: &Connection) -> anyhow::Result<()> {
+    conn.execute_batch(&format!(
+        "DELETE FROM logical_symbol_monikers WHERE logical_symbol_id = {POISON_LOGICAL_ID};
+         DELETE FROM logical_symbol_members WHERE logical_symbol_id = {POISON_LOGICAL_ID};
+         DELETE FROM logical_symbols WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM docs WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM edges_data WHERE source_file_id IN (SELECT id FROM main.files WHERE repo_id = \
+         '{POISON_REPO_ID}');
+         DELETE FROM chunks WHERE file_id IN (SELECT id FROM main.files WHERE repo_id = \
+         '{POISON_REPO_ID}');
+         DELETE FROM symbols WHERE file_id IN (SELECT id FROM main.files WHERE repo_id = \
+         '{POISON_REPO_ID}');
+         DELETE FROM parser_failures WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM packages WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM git_file_changes WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM git_commits WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM main.files WHERE repo_id = '{POISON_REPO_ID}';"
+    ))?;
+    Ok(())
+}
+
+/// Each seeded tripwire as `(table, full-sentinel WHERE predicate)`. Asserting each still matches
+/// EXACTLY one row is a row-count check (catches an unscoped DELETE) and a value checksum (the
+/// predicate pins every seeded column, so an in-place UPDATE stops matching) in one. The transitive
+/// children are matched through the poison file / logical symbol, exactly how a scoped reader would
+/// have to reach them.
+fn sibling_tripwires() -> Vec<(&'static str, String)> {
+    let file_scope =
+        format!("file_id IN (SELECT id FROM main.files WHERE repo_id = '{POISON_REPO_ID}')");
+    vec![
+        ("git_commits", format!("repo_id = '{POISON_REPO_ID}' AND hash = '{POISON_COMMIT}'")),
+        ("git_file_changes", format!("repo_id = '{POISON_REPO_ID}'")),
+        ("main.files", format!("repo_id = '{POISON_REPO_ID}' AND path = '{POISON_PREFIX}file.rs'")),
+        ("packages", format!("repo_id = '{POISON_REPO_ID}'")),
+        ("parser_failures", format!("repo_id = '{POISON_REPO_ID}'")),
+        ("docs", format!("repo_id = '{POISON_REPO_ID}'")),
+        ("logical_symbols", format!("id = {POISON_LOGICAL_ID} AND repo_id = '{POISON_REPO_ID}'")),
+        ("symbols", file_scope.clone()),
+        ("chunks", file_scope.clone()),
+        (
+            "edges_data",
+            format!(
+                "source_file_id IN (SELECT id FROM main.files WHERE repo_id = '{POISON_REPO_ID}')"
+            ),
+        ),
+        ("logical_symbol_members", format!("logical_symbol_id = {POISON_LOGICAL_ID}")),
+        (
+            "logical_symbol_monikers",
+            format!(
+                "logical_symbol_id = {POISON_LOGICAL_ID} AND moniker = '{POISON_PREFIX}moniker'"
+            ),
+        ),
+    ]
+}
+
+/// Post-condition for a MUTATING test: assert the poison sibling survived intact — every seeded
+/// tripwire still present and unmodified. Any unscoped DELETE / UPDATE in the operation under test
+/// (a GC that wipes a sibling's rows, an oracle clear that drops a sibling's monikers, an
+/// incremental pass that stamps a sibling's file) trips this. Reads `main.*` directly (bypassing
+/// the scope view), because the active connection is scoped to the fixture repo and would never see
+/// the sibling through the view. Call it on the fixture's connection at the end of the mutating
+/// step.
+pub(crate) fn assert_sibling_intact(conn: &Connection) {
+    for (table, predicate) in sibling_tripwires() {
+        let count: i64 = conn
+            .query_row(&format!("SELECT COUNT(*) FROM {table} WHERE {predicate}"), [], |row| {
+                row.get(0)
+            })
+            .unwrap_or_else(|err| panic!("poison-sibling probe failed on {table}: {err}"));
+        assert_eq!(
+            count, 1,
+            "poison sibling leaked/mutated in `{table}` (WHERE {predicate}): expected exactly 1 \
+             row, found {count}. An unscoped read/count/delete in the operation under test \
+             touched a sibling repo's rows — scope it by repo_id.",
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::index::IndexDatabase;
+    use crate::index::schema_bootstrap_tests::poison_test_config;
+
+    /// The harness self-check: after a normal rebuild (poison ON by default), an INTENTIONALLY
+    /// unscoped probe of a scoped table MUST see the sentinel — proving the tripwires are live. If
+    /// this fails, the harness is asleep and every "sibling intact" downstream assertion is
+    /// meaningless.
+    #[test]
+    fn poison_tripwires_are_live_after_a_default_rebuild() {
+        let (_root, config) = poison_test_config("poison_live");
+        let db = IndexDatabase::rebuild(&config).unwrap();
+        let conn = db.storage.connection();
+
+        // Unscoped total over a direct-scoped table sees BOTH the fixture repo and the sibling.
+        let sibling_files: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM main.files WHERE repo_id = ?1",
+                [POISON_REPO_ID],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(sibling_files >= 1, "the poison file must be seeded by the default rebuild");
+
+        // And every tripwire is intact right after seeding.
+        assert_sibling_intact(conn);
+    }
+
+    /// Opt-out honored: with the guard held, a rebuild seeds NO tripwire rows.
+    #[test]
+    fn disabling_the_harness_seeds_no_tripwires() {
+        let _guard = disable_poison_sibling();
+        let (_root, config) = poison_test_config("poison_optout");
+        let db = IndexDatabase::rebuild(&config).unwrap();
+        let sibling_files: i64 = db
+            .storage
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM main.files WHERE repo_id = ?1",
+                [POISON_REPO_ID],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(sibling_files, 0, "opt-out must seed no poison rows");
+    }
+
+    /// The sibling never touches the `repos` registry: even with the harness ON, the DB has exactly
+    /// one real repo (the fixture's), so `sole_repo_id` / `multiple_real_repos` are unperturbed and
+    /// the many non-git placeholder fixtures keep resolving to their own scope.
+    #[test]
+    fn the_sibling_does_not_perturb_the_repos_registry() {
+        let (_root, config) = poison_test_config("poison_registry");
+        let db = IndexDatabase::rebuild(&config).unwrap();
+        let conn = db.storage.connection();
+        let poison_registered: i64 = conn
+            .query_row("SELECT COUNT(*) FROM repos WHERE repo_id = ?1", [POISON_REPO_ID], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(poison_registered, 0, "the sibling must NOT be registered in `repos`");
+        let real_repos: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM repos WHERE repo_id != ?1",
+                [crate::index::schema::LEGACY_REPO_ID],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            real_repos, 1,
+            "only the fixture is a real repo — the sibling is scoped rows only"
+        );
+    }
+}

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -406,9 +406,18 @@ impl IndexDatabase {
             params![now_ms(), edges_written as i64, generation],
         )?;
         self.set_repo_meta("clone_graph_live_generation", &generation.to_string())?;
-        conn.execute("DELETE FROM clone_graph_generations WHERE generation != ?1", params![
-            generation
-        ])?;
+        // V042 SEAM: `clone_graph_generations` has NO `repo_id` yet, so this GC is global — it
+        // would delete a SIBLING repo's Complete/Building generation on a consolidated DB,
+        // even though that repo's `repo_meta` still points its live pointer at it (losing
+        // its persisted clone fast path). The live pointer is already per-repo
+        // (`live_generation_row`); the generation TABLE becomes per-repo in V042. Until
+        // then, skip the destructive cleanup when more than one real repo is registered; a
+        // single-repo DB (every DB pre-A7) prunes as before.
+        if !crate::index::schema::multiple_real_repos(conn)? {
+            conn.execute("DELETE FROM clone_graph_generations WHERE generation != ?1", params![
+                generation
+            ])?;
+        }
         Ok(())
     }
 }
@@ -691,7 +700,7 @@ fn flush_batch(
 
 /// The live (Complete) generation row, if one is published.
 fn live_generation_row(conn: &Connection) -> anyhow::Result<Option<GenerationRow>> {
-    let repo_id = crate::index::schema::single_repo_id(conn)?;
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     let Some(live) = crate::index::repo_meta(conn, &repo_id, "clone_graph_live_generation")? else {
         return Ok(None);
     };
@@ -707,30 +716,45 @@ fn open_building_generation(
     conn: &Connection,
     source_revision: &str,
 ) -> anyhow::Result<GenerationRow> {
-    let existing: Option<GenerationRow> = conn
-        .query_row(
-            "SELECT generation, source_revision, normalizer_version, cursor_symbol_id, \
-             edges_written, postings_written
-               FROM clone_graph_generations WHERE status = 'Building'
-              ORDER BY generation DESC LIMIT 1",
-            [],
-            map_generation_row,
-        )
-        .ok();
-    if let Some(row) = existing {
-        if row.source_revision == source_revision
-            && row.normalizer_version == NORM_VERSION
-            // Resume only a POSTINGS-AWARE partial. A pre-feature Building generation
-            // (`postings_written = 0`) has no postings for its already-walked symbols; resuming it
-            // would Complete a generation with a permanent postings gap. Discard it instead so the
-            // fresh generation below writes postings from symbol 0 (review R2).
-            && row.postings_written
-        {
-            return Ok(row);
+    // V042 SEAM: `clone_graph_generations` has no `repo_id` until V042, so the global `Building`
+    // row below can belong to ANY repo. On a consolidated multi-repo DB we must NOT touch it —
+    // neither RESUME nor DISCARD:
+    //  * RESUMING would adopt a SIBLING's in-progress generation. `source_revision` here is
+    //    `content_revision()`, GLOBAL over `main.files` (V040 reclassification), so a sibling's
+    //    Building row at the same DB content matches this repo's revision exactly;
+    //    `complete_generation` would then publish the sibling's generation under THIS repo's
+    //    `clone_graph_live_generation`.
+    //  * DISCARDING would delete the sibling's partial (a global `DELETE`).
+    // So gate the WHOLE resume/discard block on a single-repo DB. On a consolidated DB, fall
+    // straight through to a fresh `MAX(generation)+1` allocation (globally unique), leaving
+    // every sibling row intact. A single-repo DB (every DB pre-A7) keeps the resume/discard
+    // fast path unchanged.
+    if !crate::index::schema::multiple_real_repos(conn)? {
+        let existing: Option<GenerationRow> = conn
+            .query_row(
+                "SELECT generation, source_revision, normalizer_version, cursor_symbol_id, \
+                 edges_written, postings_written
+                   FROM clone_graph_generations WHERE status = 'Building'
+                  ORDER BY generation DESC LIMIT 1",
+                [],
+                map_generation_row,
+            )
+            .ok();
+        if let Some(row) = existing {
+            if row.source_revision == source_revision
+                && row.normalizer_version == NORM_VERSION
+                // Resume only a POSTINGS-AWARE partial. A pre-feature Building generation
+                // (`postings_written = 0`) has no postings for its already-walked symbols; resuming
+                // it would Complete a generation with a permanent postings gap. Discard it instead
+                // so the fresh generation below writes postings from symbol 0 (review R2).
+                && row.postings_written
+            {
+                return Ok(row);
+            }
+            // Stale partial (a reindex landed) OR a pre-feature postings-less partial: discard it
+            // (CASCADE drops its edges + postings) and start over.
+            conn.execute("DELETE FROM clone_graph_generations WHERE status = 'Building'", [])?;
         }
-        // Stale partial (a reindex landed) OR a pre-feature postings-less partial: discard it
-        // (CASCADE drops its edges + postings) and start over.
-        conn.execute("DELETE FROM clone_graph_generations WHERE status = 'Building'", [])?;
     }
     let generation: i64 = conn.query_row(
         "SELECT COALESCE(MAX(generation), 0) + 1 FROM clone_graph_generations",
@@ -1135,5 +1159,143 @@ mod tests {
         assert_eq!(db2.precompute_clone_graph(None).unwrap().status, "Complete");
         assert!(!db2.pending_clone_graph().unwrap(), "current again after the rebuild");
         assert!(db2.clone_check_indexed_generation().unwrap().is_some(), "eligible again");
+    }
+
+    // --- #413 finding #6: the global clone-generation cleanups are guarded on a multi-repo DB
+    // (`clone_graph_generations` has no `repo_id` until the V042 seam). ---
+
+    /// Register two REAL repos so `schema::multiple_real_repos` reports the consolidated shape. The
+    /// fixture DB is non-git (unadopted), so its registry holds only the placeholder; inserting the
+    /// rows directly is the white-box multi-repo construction (`register_repo` refuses a second
+    /// real repo until A7).
+    fn make_multi_repo(conn: &rusqlite::Connection) {
+        conn.execute_batch(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('repo-x', 'x', 0);
+             INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('repo-y', 'y', 0);",
+        )
+        .unwrap();
+    }
+
+    /// Insert a `clone_graph_generations` row in `status` toward `source_revision`.
+    fn seed_generation(conn: &rusqlite::Connection, generation: i64, status: &str, revision: &str) {
+        conn.execute(
+            "INSERT INTO clone_graph_generations
+                (generation, status, theta_floor, normalizer_kind, normalizer_version,
+                 source_revision, cursor_symbol_id, edges_written, postings_written, started_at_ms)
+             VALUES (?1, ?2, 0.0, 'baseline', ?3, ?4, 0, 0, 1, 0)",
+            params![generation, status, NORM_VERSION, revision],
+        )
+        .unwrap();
+    }
+
+    fn generation_count(conn: &rusqlite::Connection) -> i64 {
+        conn.query_row("SELECT COUNT(*) FROM clone_graph_generations", [], |r| r.get(0)).unwrap()
+    }
+
+    /// `complete_generation` GCs every other generation; on a multi-repo DB that global delete
+    /// would wipe a sibling repo's live generation, so the guard must skip it.
+    #[test]
+    fn complete_generation_spares_sibling_generations_on_a_multi_repo_db() {
+        let db = build_clone_fixture("mr-complete");
+        {
+            let conn = db.storage.connection();
+            make_multi_repo(conn);
+            seed_generation(conn, 1, "Building", "rev-a"); // this repo's, to complete
+            seed_generation(conn, 2, "Complete", "rev-sibling"); // a sibling's live generation
+        }
+        db.complete_generation(1, 0).unwrap();
+
+        let conn = db.storage.connection();
+        assert_eq!(generation_count(conn), 2, "the multi-repo guard spared the sibling generation");
+        let g1_status: String = conn
+            .query_row("SELECT status FROM clone_graph_generations WHERE generation = 1", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(g1_status, "Complete", "this repo's generation still completes + publishes");
+    }
+
+    /// The complement: a single-repo DB (no sibling to protect) GCs the other generations as
+    /// before.
+    #[test]
+    fn complete_generation_prunes_other_generations_on_a_single_repo_db() {
+        let db = build_clone_fixture("sr-complete");
+        {
+            let conn = db.storage.connection();
+            seed_generation(conn, 1, "Building", "rev-a");
+            seed_generation(conn, 2, "Complete", "rev-old");
+        }
+        db.complete_generation(1, 0).unwrap();
+
+        let conn = db.storage.connection();
+        assert_eq!(generation_count(conn), 1, "single-repo GC drops every other generation");
+    }
+
+    /// `open_building_generation` discards a stale (different-revision) Building row before
+    /// starting fresh; on a multi-repo DB that discard is global, so the guard must skip it and
+    /// leave the sibling's in-progress row intact while still allocating a fresh generation.
+    #[test]
+    fn open_building_generation_spares_a_sibling_building_row_on_a_multi_repo_db() {
+        let db = build_clone_fixture("mr-open");
+        let conn = db.storage.connection();
+        make_multi_repo(conn);
+        seed_generation(conn, 7, "Building", "sibling-rev"); // a sibling's in-progress build
+
+        let opened = open_building_generation(conn, "my-new-rev").unwrap();
+        assert_ne!(opened.generation, 7, "a fresh generation is allocated, not the sibling's");
+        let sibling: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM clone_graph_generations WHERE generation = 7",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(sibling, 1, "the sibling repo's Building row is not globally discarded");
+    }
+
+    /// #413 round-5: the multi-repo guard must not just skip the DISCARD — it must also skip the
+    /// RESUME. `source_revision` is `content_revision()`, GLOBAL over `main.files`, so a sibling's
+    /// Building row at the SAME revision (+ postings-aware) would otherwise be RESUMED and then
+    /// published under this repo's live pointer. On a multi-repo DB `open_building_generation` must
+    /// allocate a FRESH generation and leave the sibling's Building row untouched, even on a match.
+    #[test]
+    fn open_building_generation_does_not_resume_a_sibling_building_row_on_a_multi_repo_db() {
+        let db = build_clone_fixture("mr-resume");
+        let conn = db.storage.connection();
+        make_multi_repo(conn);
+        // A sibling's in-progress build at the SAME revision this repo is about to open (a
+        // matching, postings-aware row — `seed_generation` writes `postings_written = 1`).
+        // The pre-fix code would RESUME generation 9 and hand it to this repo.
+        seed_generation(conn, 9, "Building", "shared-rev");
+
+        let opened = open_building_generation(conn, "shared-rev").unwrap();
+        assert_ne!(
+            opened.generation, 9,
+            "a matching sibling Building row is NOT resumed on a multi-repo DB — fresh generation",
+        );
+        let sibling_status: String = conn
+            .query_row("SELECT status FROM clone_graph_generations WHERE generation = 9", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(sibling_status, "Building", "the sibling's Building row is left intact");
+    }
+
+    /// The complement: a single-repo DB discards its own stale Building row as before.
+    #[test]
+    fn open_building_generation_discards_the_stale_building_row_on_a_single_repo_db() {
+        let db = build_clone_fixture("sr-open");
+        let conn = db.storage.connection();
+        seed_generation(conn, 7, "Building", "stale-rev");
+
+        open_building_generation(conn, "new-rev").unwrap();
+        let stale: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM clone_graph_generations WHERE generation = 7",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stale, 0, "single-repo discards the stale Building row as before");
     }
 }

--- a/crates/rag-rat-core/src/index/query_api/gc.rs
+++ b/crates/rag-rat-core/src/index/query_api/gc.rs
@@ -88,15 +88,20 @@ impl IndexDatabase {
             }
         }
         // A file survives if its commit is live OR its worktree overlay is live. Empty-string
-        // keys never appear in the live sets, so unkeyed rows are pruned.
+        // keys never appear in the live sets, so unkeyed rows are pruned. Scoped to the ACTIVE REPO
+        // (A3): the live sets are THIS repo's live contexts, so without the `repo_id` predicate
+        // every OTHER repo's files (whose commits/worktrees are legitimately absent from
+        // this repo's live sets) would be staged and cascade-deleted — gc of one repo would
+        // wipe every sibling. The repo_id filter is what makes `garbage_collect` per-repo.
         conn.execute(
             "
             INSERT OR IGNORE INTO temp.staged_file_ids(id)
             SELECT id FROM main.files
-            WHERE commit_sha NOT IN (SELECT sha FROM temp.gc_live_commits)
+            WHERE repo_id = ?1
+              AND commit_sha NOT IN (SELECT sha FROM temp.gc_live_commits)
               AND worktree_id NOT IN (SELECT id FROM temp.gc_live_worktrees)
             ",
-            [],
+            [self.active_repo_id.as_str()],
         )?;
         self.delete_staged_files_cascade()?;
         conn.execute_batch("DELETE FROM temp.staged_file_ids;")?;
@@ -112,7 +117,16 @@ impl IndexDatabase {
         // prune a dead checkout's run rows with the SAME live sets, so a run and the
         // edges it produced are dropped together.
         oracle::prune_edge_oracle_without_live_edge(conn)?;
-        oracle::prune_oracle_runs_outside_scope(conn, live_commits, live_worktrees)?;
+        // V042 SEAM: `oracle_runs` has NO `repo_id` yet, so `prune_oracle_runs_outside_scope`
+        // deletes GLOBALLY against THIS repo's live sets. On a consolidated multi-repo DB that
+        // would wipe a sibling repo's run rows (its commits/worktrees are legitimately
+        // absent from this repo's live sets). Skip the global prune when more than one real
+        // repo is registered; the per-repo prune lands once `oracle_runs` gains `repo_id`
+        // in V042 (successor branch). A single-repo DB (every DB pre-A7) is unaffected —
+        // the guard is dormant.
+        if !schema::multiple_real_repos(conn)? {
+            oracle::prune_oracle_runs_outside_scope(conn, live_commits, live_worktrees)?;
+        }
         // #357: `embedding_cache` is content-keyed too (survives reindex, like the oracle above),
         // so it needs the SAME global sweep — drop vectors no live chunk references in ANY
         // context (a sibling worktree / branch may still use one, so this must not be
@@ -132,6 +146,18 @@ impl IndexDatabase {
         // pool entry a live symbol points at and null its qname out — the exact footgun
         // this comment warns about (regression test:
         // gc_preserves_a_name_strings_entry_referenced_only_by_a_symbol).
+        //
+        // SHARED-POOL INVARIANT (A3): `name_strings` stays GLOBAL — it is NOT repo-sliced. Liveness
+        // is the UNION over ALL repos: the referencing subqueries below read `edges_data` /
+        // `symbols` / `logical_symbols` across every repo, so a value one repo still
+        // references is kept even while gc runs for a different repo. Scoping this sweep to
+        // the active repo would delete interned strings out from under a sibling repo's
+        // live rows. The same union-liveness rule governs the other content-addressed
+        // shared tables gc touches — `embedding_cache`
+        // (`prune_embedding_cache_unreferenced`, keyed by content hash, swept over live chunks in
+        // ANY scope) — and `chunk_text_dict`, whose immutable decode dictionaries are never swept
+        // at all (a version any repo's blob references must survive), so it needs no
+        // per-repo logic.
         conn.execute(
             "
             DELETE FROM main.name_strings

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -50,7 +50,10 @@ impl IndexDatabase {
         }
 
         let content_revision = self.content_revision()?;
-        let fts_source_revision = self.repo_meta("fts_source_revision")?;
+        // GLOBAL keys (V040 reclassification): `chunk_fts` is one global FTS5 index and
+        // `content_revision()` digests the whole `main.files`, so their freshness lives in
+        // `index_meta` (`self.meta`), never per-repo `repo_meta`.
+        let fts_source_revision = self.meta("fts_source_revision")?;
         let fts_dirty = self.fts_dirty()?;
 
         Ok(IndexStatus {
@@ -64,7 +67,7 @@ impl IndexDatabase {
                 .and_then(|value| value.parse::<i64>().ok()),
             content_revision: content_revision.clone(),
             fts_synced_at_ms: self
-                .repo_meta("fts_synced_at_ms")?
+                .meta("fts_synced_at_ms")?
                 .and_then(|value| value.parse::<i64>().ok()),
             fts_dirty,
             fts_fresh: !fts_dirty

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -14,8 +14,16 @@ impl IndexDatabase {
             mode: IndexMode::Full,
         });
         let mut db = Self::create_or_migrate(&config.database)?;
+        // Register/adopt the repo BEFORE the scope view is installed and BEFORE any repo-scoped
+        // write, so `active_repo_id` is a real (registered) id — every direct-scoped insert stamps
+        // it, and `repo_meta` writes below satisfy the `repo_meta → repos` FK (an
+        // empty/unregistered id would violate it). `create_or_migrate` no longer resolves
+        // the repo or heals the model manifest, so both move here, ordered after
+        // registration.
+        db.adopt_repo_from_config(config)?;
         let (commit_sha, worktree_id) = resolve_git_context(&config.root);
         db.set_context(&commit_sha, &worktree_id)?;
+        ai::ensure_model_manifest(db.storage.connection())?;
         progress(IndexProgress::IndexingGitHistory);
         let mut git_history = Some(spawn_git_history_prepare(&config.root));
         // RAM-first bulk build: a full rebuild is one big atomic write, so skip per-commit fsyncs
@@ -120,6 +128,13 @@ impl IndexDatabase {
         // cache_size is left bumped — harmless for the short remaining lifetime of the connection.
         let _ = db.storage.execute_batch("PRAGMA synchronous = NORMAL;");
         result?;
+        // Poison-sibling test harness (compiled out of production): after the rebuild commits,
+        // register a second `poison-sibling` repo with tripwire rows in every repo-scoped table, so
+        // any unscoped read/count/delete downstream trips an EXISTING test. Default-ON per test
+        // thread; a test needing a virgin single-repo DB opts out via
+        // `poison_sibling::disable_poison_sibling`. See the module docs.
+        #[cfg(test)]
+        crate::index::poison_sibling::seed_if_enabled(db.storage.connection())?;
         Ok(db)
     }
 
@@ -199,6 +214,11 @@ impl IndexDatabase {
         // rebuild with a UNIQUE constraint error. Stage every row of the active commit AND
         // every row of the active worktree, shadowed or not. A sibling worktree at the same
         // commit self-heals on its next discover pass (its missing paths reindex).
+        // Every staged row is constrained to the ACTIVE REPO (A3): the commit/worktree keys are not
+        // globally unique across repos in a consolidated DB (forks share a commit), so without the
+        // `repo_id` predicate a full rebuild of one repo would stage — and cascade-delete — a
+        // sibling repo's rows. The repo id lives in the same `temp.connection_context` the scope
+        // view populates.
         self.storage.execute_batch(
             "
             CREATE TEMP TABLE IF NOT EXISTS staged_file_ids(id INTEGER PRIMARY KEY);
@@ -206,13 +226,15 @@ impl IndexDatabase {
             INSERT OR IGNORE INTO temp.staged_file_ids(id)
             SELECT id
             FROM main.files
-            WHERE worktree_id = (SELECT value FROM temp.connection_context WHERE key = \
+            WHERE repo_id = (SELECT value FROM temp.connection_context WHERE key = 'repo_id')
+              AND worktree_id = (SELECT value FROM temp.connection_context WHERE key = \
              'worktree_id')
               AND worktree_id != '';
             INSERT OR IGNORE INTO temp.staged_file_ids(id)
             SELECT id
             FROM main.files
-            WHERE commit_sha = (SELECT value FROM temp.connection_context WHERE key = 'commit_sha')
+            WHERE repo_id = (SELECT value FROM temp.connection_context WHERE key = 'repo_id')
+              AND commit_sha = (SELECT value FROM temp.connection_context WHERE key = 'commit_sha')
               AND commit_sha != '';
             ",
         )?;
@@ -319,9 +341,12 @@ impl IndexDatabase {
                 FROM main.chunks
                 JOIN temp.staged_file_ids ON staged_file_ids.id = chunks.file_id
             );
+            -- `parser_failures` is keyed by `(repo_id, path)` (V040), so match BOTH — a bare-path
+            -- delete would clobber a sibling repo's failure at the same path. Staged files all
+            -- belong to one repo, but the row-value join is correct regardless of that.
             DELETE FROM main.parser_failures
-            WHERE path IN (
-                SELECT path
+            WHERE (repo_id, path) IN (
+                SELECT files.repo_id, files.path
                 FROM main.files
                 JOIN temp.staged_file_ids ON staged_file_ids.id = files.id
             );

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1174,6 +1174,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_037_ID => Some(37),
             MIGRATION_038_ID => Some(38),
             MIGRATION_039_ID => Some(39),
+            MIGRATION_040_ID => Some(40),
             _ => None,
         })
         .max()
@@ -1222,6 +1223,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_037_ID
             | MIGRATION_038_ID
             | MIGRATION_039_ID
+            | MIGRATION_040_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1267,6 +1269,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_037_ID => migration.checksum != MIGRATION_037_CHECKSUM,
         MIGRATION_038_ID => migration.checksum != MIGRATION_038_CHECKSUM,
         MIGRATION_039_ID => migration.checksum != MIGRATION_039_CHECKSUM,
+        MIGRATION_040_ID => migration.checksum != MIGRATION_040_CHECKSUM,
         _ => false,
     }
 }
@@ -1687,8 +1690,43 @@ fn relocate_meta_keys(
     source_table: &str,
     keys: &[&str],
 ) -> rusqlite::Result<()> {
-    let target_repo_id = sole_repo_id(conn)?;
+    // V040 RECLASSIFICATION: some keys V039 lists here are GLOBAL infrastructure, not per-repo, and
+    // V040 moves them back to `index_meta` (see [`RECLASSIFIED_GLOBAL_INDEX_META_KEYS`] +
+    // [`move_repo_meta_keys_to_global`]). V039 is frozen (merged), so it still names them — filter
+    // them out HERE so this shared helper never re-relocates a now-global key OUT of `index_meta`.
+    // Two failures this prevents on a ladder replay (`schema::apply` / `index --full`, which
+    // re-runs V039): (1) it would undo the reclassification every full rebuild; (2) with the
+    // key present in `index_meta` the movable-keys gate below would fire, resolve
+    // `sole_repo_id`, and HARD-ERROR on a consolidated >1-repo DB — regressing the round-4
+    // replay property. Every genuinely-per-repo key is unaffected, so V039's relocation is
+    // byte-identical for them.
+    let keys: Vec<&str> = keys
+        .iter()
+        .copied()
+        .filter(|key| !RECLASSIFIED_GLOBAL_INDEX_META_KEYS.contains(key))
+        .collect();
+    if keys.is_empty() {
+        return Ok(());
+    }
     let in_list = keys.iter().map(|key| format!("'{key}'")).collect::<Vec<_>>().join(", ");
+    // IDEMPOTENCE GATE, resolved BEFORE `sole_repo_id`: on a re-apply the source keys are already
+    // gone (schema::apply re-runs the WHOLE ladder — a `create_or_migrate` / `rag-rat index --full`
+    // full rebuild), so there is nothing to move. Return without resolving the sole repo. This is
+    // load-bearing on a CONSOLIDATED (>1 real repo) DB, where `sole_repo_id`'s exactly-one-row
+    // expectation would otherwise HARD-ERROR the ladder replay even though the move is a proven
+    // no-op — breaking `index --full` for every repo in the DB. Only a genuinely-unmigrated
+    // (single-repo / legacy) DB, whose source rows still exist, reaches the resolution. A torn run
+    // (crash between the copy and the delete) still re-converges: the source rows survived the
+    // missing delete, so the gate finds them present and finishes the move.
+    let has_movable_keys: bool = conn.query_row(
+        &format!("SELECT EXISTS(SELECT 1 FROM {source_table} WHERE key IN ({in_list}))"),
+        [],
+        |row| row.get(0),
+    )?;
+    if !has_movable_keys {
+        return Ok(());
+    }
+    let target_repo_id = sole_repo_id(conn)?;
     conn.execute(
         &format!(
             "INSERT OR IGNORE INTO repo_meta(repo_id, key, value)
@@ -1706,12 +1744,12 @@ fn relocate_meta_keys(
 /// The relocation MUST target this id, not a hardcoded placeholder: on an adopted DB the
 /// placeholder row is deleted, so an `INSERT` into `repo_meta` under it trips the `repo_meta →
 /// repos` FK — with `foreign_keys = ON` (production) that aborts the whole `migrate_forward`; with
-/// it off it orphans rows the per-repo accessors ([`super::single_repo_id`]) can never resolve.
+/// it off it orphans rows the per-repo accessors ([`super::sole_repo_id`]) can never resolve.
 /// V038 always leaves exactly one `repos` row and `register_repo` keeps it at one, so 0 or >1 is a
 /// broken invariant — surfaced as an attributable migration error rather than a silent FK abort or
-/// a wrong-scope pick. (Distinct from [`super::single_repo_id`], the runtime stand-in: that one
-/// `debug_assert`s the one-row invariant and `LIMIT 1`s in release; a migration needs the hard
-/// error on `!= 1`.)
+/// a wrong-scope pick. (Distinct from the runtime [`super::sole_repo_id`], which `ORDER BY`s the
+/// placeholder last and `LIMIT 1`s without a hard error; a migration wants the hard error on `!= 1`
+/// so a broken invariant is loud.)
 fn sole_repo_id(conn: &Connection) -> rusqlite::Result<String> {
     let mut stmt = conn.prepare("SELECT repo_id FROM repos")?;
     let mut ids =
@@ -1722,11 +1760,362 @@ fn sole_repo_id(conn: &Connection) -> rusqlite::Result<String> {
     Err(rusqlite::Error::SqliteFailure(
         rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CONSTRAINT),
         Some(format!(
-            "V039 per-repo meta relocation expects exactly one repos row (the sole repo owning \
-             this DB), found {}",
+            "per-repo meta relocation expects exactly one repos row (the sole repo owning this \
+             DB), found {}",
             ids.len()
         )),
     ))
+}
+
+/// The `repo_id` column added to every direct-scoped core table in V040. `NOT NULL DEFAULT` the
+/// [`super::LEGACY_REPO_ID`] placeholder: existing rows backfill to the placeholder, which
+/// `register_repo` rewrites to the real id at adoption (the A1/A2 pattern), and any writer that
+/// forgets to stamp still produces a scannable single-repo value rather than NULL.
+const REPO_ID_COLUMN_DEF: &str = "TEXT NOT NULL DEFAULT '__unassigned__'";
+
+/// The `index_meta` keys V040 relocates into `repo_meta` — the active-embedding-model provenance
+/// pair that stayed behind in A2's V039 sweep (they postdated the plan's inventory). Reuniting them
+/// with `active_embedding_model` / `embedding_active_model_version` (already in `repo_meta`) so the
+/// whole model-provenance family is per-repo. Idempotent: on a re-apply the source keys are already
+/// gone, so the copy inserts nothing.
+const V040_INDEX_META_KEYS: &[&str] =
+    &["active_embedding_model_provisional", "active_embedding_remote_config"];
+
+/// The keys V039 relocated to `repo_meta` that V040 RECLASSIFIES as GLOBAL infrastructure and moves
+/// BACK to `index_meta` (see [`move_repo_meta_keys_to_global`]). V039 (frozen) misfiled these under
+/// the one-DB-per-repo assumption, but they are not per-repo state:
+///  * `content_revision` — digest over the WHOLE `main.files` (no `repo_id` filter);
+///  * `fts_dirty` / `fts_source_revision` / `fts_synced_at_ms` — freshness of the ONE global
+///    `chunk_fts` FTS5 index (never repo-scoped);
+///  * `vector_int8_reencode_cursor` — resume marker for a walk over the WHOLE `chunk_embeddings`
+///    table, beside an already-global done-gate.
+///
+/// Per-repo copies caused stale-dirty loops (a consolidated DB paying a full FTS rebuild forever
+/// after a sibling synced) and cross-repo resume confusion. The runtime accessors write these to
+/// the global `index_meta` (`self.meta` / `ai::set_meta`); this migration relocates any
+/// pre-existing per-repo copy.
+const V040_REPO_META_KEYS_TO_GLOBAL: &[&str] = &[
+    "content_revision",
+    "fts_dirty",
+    "fts_source_revision",
+    "fts_synced_at_ms",
+    "vector_int8_reencode_cursor",
+];
+
+/// The subset of [`V040_REPO_META_KEYS_TO_GLOBAL`] that also appears in [`V039_INDEX_META_KEYS`],
+/// so [`relocate_meta_keys`] must EXCLUDE them from V039's `index_meta → repo_meta` sweep (the
+/// runtime now stores them globally in `index_meta`). The reencode cursor is reclassified too but
+/// lives in `V039_RECONCILE_META_KEYS` (a different source table) AND, once global, sits in
+/// `index_meta` where neither V039 sweep names it — so it needs no exclusion here; V040's move-back
+/// handles a stale per-repo copy.
+const RECLASSIFIED_GLOBAL_INDEX_META_KEYS: &[&str] =
+    &["content_revision", "fts_dirty", "fts_source_revision", "fts_synced_at_ms"];
+
+/// Move the listed keys OUT of the per-repo `repo_meta` and back into the GLOBAL `index_meta` — the
+/// inverse of [`relocate_meta_keys`], correcting V039's over-relocation of global-infrastructure
+/// state (see [`V040_REPO_META_KEYS_TO_GLOBAL`]).
+///
+/// IDEMPOTENT + MULTI-REPO-REPLAY-SAFE (the round-4 pattern): resolves NO `sole_repo_id`, so it
+/// never hard-errors on a consolidated DB. `INSERT OR IGNORE` into the `key`-PK'd `index_meta`
+/// keeps ONE global value — every repo computes the same content digest so their copies agree;
+/// where a per-repo copy could differ (`fts_dirty`) the first row wins and the `DELETE` still
+/// clears every copy, and the next FTS freshness check self-corrects the surviving global value.
+/// The `value IS NOT NULL` guard skips a `repo_meta` NULL (its `value` is nullable;
+/// `index_meta.value` is `NOT NULL`). On a re-apply the `repo_meta` rows are already gone, so both
+/// statements are no-ops — the whole helper is safe to run on every `schema::apply`.
+fn move_repo_meta_keys_to_global(conn: &Connection, keys: &[&str]) -> rusqlite::Result<()> {
+    let in_list = keys.iter().map(|key| format!("'{key}'")).collect::<Vec<_>>().join(", ");
+    conn.execute(
+        &format!(
+            "INSERT OR IGNORE INTO index_meta(key, value)
+             SELECT key, value FROM repo_meta WHERE key IN ({in_list}) AND value IS NOT NULL"
+        ),
+        [],
+    )?;
+    conn.execute(&format!("DELETE FROM repo_meta WHERE key IN ({in_list})"), [])?;
+    Ok(())
+}
+
+/// V040 (memory-sync phase A3): add `repo_id` scoping to the core tables that have no FK path to
+/// `files` (they scope DIRECTLY; the `files`-reachable tables scope transitively through the
+/// `files.repo_id` the scope view filters on). Per the disposition table:
+///  * `files` — direct `repo_id`; UNIQUE becomes `(repo_id, path, commit_sha, worktree_id)`.
+///  * `packages` — direct; UNIQUE becomes `(repo_id, manifest_dir, commit_sha, worktree_id)`.
+///  * `logical_symbols`, `docs` — direct `repo_id` (add column; no key change).
+///  * `parser_failures` — direct; PK becomes `(repo_id, path)` (was a bare autoincrement id, so
+///    `remove_file_in_scope`'s path-only delete clobbered a sibling repo — inventory #12).
+///  * `git_commits` — direct; PK becomes `(repo_id, hash)`; `commit_fts` external content follows
+///    and `git_file_changes` gains `repo_id` + a composite `(repo_id, commit_hash)` FK.
+///
+/// Also reunites the two straggler active-model meta keys with their family in `repo_meta`.
+///
+/// The key/PK changes force table REBUILDS (SQLite can't alter a UNIQUE/PK in place). Modeled on
+/// the V031 STRICT-rebuild recipe: `foreign_keys = OFF` OUTSIDE `BEGIN IMMEDIATE`,
+/// RENAME→CREATE→copy→ DROP preserving rowids/ids, ROLLBACK on error, then `COMMIT; foreign_keys =
+/// ON`. Every rebuild is wrapped in ONE transaction so a failure leaves the schema untouched;
+/// `files.repo_id` existing is the all-or-nothing sentinel (atomic ⇒ present iff the whole V040
+/// committed), so a re-apply (fresh DB already transformed, or `create_or_migrate`/`rebuild` on an
+/// applied DB) short-circuits.
+///
+/// #51 GUARD: `commit_fts` is external-content over `git_commits`; after the git_commits rebuild its
+/// stored rowids are stale, so it is resynced with the desync-safe `'rebuild'` command, NEVER a
+/// `DELETE FROM commit_fts` (which corrupts a desynced external-content index).
+pub(crate) fn apply_repo_id_core_scoping(conn: &Connection) -> rusqlite::Result<()> {
+    // Reclassify the global-infrastructure keys V039 over-relocated to `repo_meta` back to the
+    // GLOBAL `index_meta`. Runs BEFORE the `files.repo_id` short-circuit so it also corrects a DB a
+    // PRIOR commit of THIS (unreleased) branch already migrated to V040 with those keys in
+    // `repo_meta` — that DB's `files.repo_id` exists, so the short-circuit would otherwise skip it.
+    // Idempotent + multi-repo-safe (resolves no `sole_repo_id`), so running it on every apply is a
+    // no-op once the keys are global.
+    move_repo_meta_keys_to_global(conn, V040_REPO_META_KEYS_TO_GLOBAL)?;
+
+    // All-or-nothing sentinel: the rebuilds below run under one atomic transaction, so `files`
+    // carrying `repo_id` means the whole migration already committed — a fresh-from-target DB or a
+    // `create_or_migrate`/`rebuild` re-apply. Short-circuit before taking the write lock.
+    if column_exists(conn, "files", "repo_id")? {
+        return Ok(());
+    }
+
+    // The table rebuilds need FK enforcement OFF (they RENAME/DROP FK-referenced parents); a PRAGMA
+    // toggle is a no-op inside a transaction, so set it BEFORE BEGIN (V031 recipe).
+    conn.execute_batch("PRAGMA foreign_keys = OFF; BEGIN IMMEDIATE;")?;
+    let result = (|| -> rusqlite::Result<()> {
+        rebuild_files_table_with_repo_id(conn)?;
+        rebuild_packages_table_with_repo_id(conn)?;
+        // `logical_symbols` / `docs` are FK-less on their scoping key (no UNIQUE/PK change), so a
+        // plain additive column suffices — no rebuild.
+        add_column_if_missing(conn, "logical_symbols", "repo_id", REPO_ID_COLUMN_DEF)?;
+        add_column_if_missing(conn, "docs", "repo_id", REPO_ID_COLUMN_DEF)?;
+        rebuild_parser_failures_table_with_repo_id(conn)?;
+        rebuild_git_commits_tables_with_repo_id(conn)?;
+        // Re-point the placeholder-backfilled rows onto the sole repo that owns this DB. On an
+        // already-adopted DB this is what keeps the rebuilt rows visible; on a not-yet-adopted DB
+        // it is a no-op (see the helper). Runs inside the txn, atomic with the rebuilds.
+        backfill_repo_id_to_sole_repo(conn)?;
+        // Now that every `logical_symbols` row carries its final `repo_id`, migrate its
+        // content-derived id to the new `repo_id`-folded derivation and re-point every reference
+        // (memories, monikers, members), so pre-V040 memory/oracle handles survive the first
+        // `rebuild_logical_symbols` after upgrade instead of dangling. FK enforcement is OFF for
+        // the whole V040 transaction (set before BEGIN), which is exactly what the
+        // parent-id remap needs. On a not-yet-adopted DB the rows carry the placeholder
+        // here; `register_repo` runs the same realign again after adopting the real id
+        // (idempotent — already-aligned rows are skipped).
+        crate::index::graph_index::realign_logical_symbol_ids(conn)?;
+        // Reunite the two active-model provenance stragglers with their family in `repo_meta`
+        // (relocated under the sole repo via `relocate_meta_keys`' own `sole_repo_id` resolution;
+        // `register_repo` keeps them there). Runs inside the txn so it is atomic with the rebuilds.
+        relocate_meta_keys(conn, "index_meta", V040_INDEX_META_KEYS)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = conn.execute_batch("ROLLBACK; PRAGMA foreign_keys = ON;");
+        return result;
+    }
+    conn.execute_batch("COMMIT; PRAGMA foreign_keys = ON;")?;
+    Ok(())
+}
+
+/// Re-point every V040 direct-scoped table's placeholder-backfilled rows onto the sole repo that
+/// owns this DB — the same established resolution [`relocate_meta_keys`] uses for the meta move
+/// (and the V039 fix e2a2bc5 established).
+///
+/// The rebuilds / `add_column`s above stamp every existing row with the STATIC `__unassigned__`
+/// column DEFAULT (a DEFAULT cannot be a runtime-resolved value). That is correct on a NOT-yet-
+/// adopted DB — the sole repo IS the placeholder, so the rows already carry the right id and
+/// [`super::register_repo`] re-points them at adoption. But on an ALREADY-ADOPTED DB (V038/V039 ran
+/// `register_repo`, so `repos` holds the real id and NO placeholder), `register_repo` takes the
+/// "already registered" fast path that never re-points — so the rebuilt rows would orphan under
+/// `__unassigned__` and the active real-repo scope view would see an EMPTY index after upgrade.
+/// Resolve the sole `repos` row (real when adopted, else the placeholder) via [`sole_repo_id`] and
+/// UPDATE the placeholder rows onto it; skip the no-op churn when the DB is not yet adopted.
+///
+/// FK enforcement is OFF for the whole V040 transaction, so `git_commits`' `ON UPDATE CASCADE` does
+/// NOT fire here — `git_file_changes` is re-pointed EXPLICITLY (unlike the runtime `register_repo`
+/// path, which runs with FK ON and relies on that cascade, so it lists only `git_commits`).
+fn backfill_repo_id_to_sole_repo(conn: &Connection) -> rusqlite::Result<()> {
+    let target = sole_repo_id(conn)?;
+    // Not adopted yet: rows already carry the placeholder; `register_repo` re-points at adoption.
+    if target == super::LEGACY_REPO_ID {
+        return Ok(());
+    }
+    for table in [
+        "files",
+        "packages",
+        "logical_symbols",
+        "docs",
+        "parser_failures",
+        "git_commits",
+        "git_file_changes",
+    ] {
+        conn.execute(&format!("UPDATE {table} SET repo_id = ?1 WHERE repo_id = ?2"), [
+            target.as_str(),
+            super::LEGACY_REPO_ID,
+        ])?;
+    }
+    Ok(())
+}
+
+/// Rebuild `files` with a leading `repo_id` column and the widened UNIQUE key. `files` is the
+/// scoping ROOT and is FK-referenced by `chunks` / `symbols` / `edges_data` (all `REFERENCES
+/// files(id)`), so the `id` values MUST be preserved — the rebuild copies them verbatim (the V008
+/// `rebuild_files_table_for_commit_scopes` precedent). The full current column set (through V024's
+/// `has_test_code`) is reproduced; `files` stays non-STRICT to match its baseline shape.
+fn rebuild_files_table_with_repo_id(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        -- Re-convergence: migrations run in AUTOCOMMIT, so a crash that killed a prior V040 pass
+        -- mid-rebuild could leave the scratch table behind (the enclosing BEGIN/ROLLBACK normally
+        -- prevents this, but a hard process kill bypasses a clean rollback). Drop it so the \
+         rebuild
+        -- restarts from a clean slate rather than failing on CREATE.
+        DROP TABLE IF EXISTS files_new;
+        CREATE TABLE files_new(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            path TEXT NOT NULL,
+            language TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            sha256 TEXT NOT NULL,
+            modified_at_ms INTEGER NOT NULL,
+            generated INTEGER NOT NULL DEFAULT 0,
+            indexed_at_ms INTEGER NOT NULL,
+            indexed_revision TEXT NOT NULL DEFAULT '',
+            commit_sha TEXT NOT NULL DEFAULT '',
+            worktree_id TEXT NOT NULL DEFAULT '',
+            has_test_code INTEGER NOT NULL DEFAULT 0,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__',
+            UNIQUE(repo_id, path, commit_sha, worktree_id)
+        );
+        INSERT OR IGNORE INTO files_new(
+            id, path, language, kind, sha256, modified_at_ms, generated, indexed_at_ms,
+            indexed_revision, commit_sha, worktree_id, has_test_code, repo_id
+        )
+        SELECT
+            id, path, language, kind, sha256, modified_at_ms, generated, indexed_at_ms,
+            indexed_revision, commit_sha, worktree_id, has_test_code, '__unassigned__'
+        FROM files;
+        DROP TABLE files;
+        ALTER TABLE files_new RENAME TO files;
+        CREATE INDEX IF NOT EXISTS idx_files_language ON files(language);
+        CREATE INDEX IF NOT EXISTS idx_files_commit_path ON files(commit_sha, path);
+        CREATE INDEX IF NOT EXISTS idx_files_worktree_path ON files(worktree_id, path);
+        ",
+    )
+}
+
+/// Rebuild `packages` (STRICT) with a leading `repo_id` column and the widened UNIQUE key.
+/// `packages` has no FK children (the file→package map is computed at load time, never persisted —
+/// #106), so no id preservation is required, but the rows are copied to keep an already-populated
+/// index intact through the migration.
+fn rebuild_packages_table_with_repo_id(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS packages_new;
+        CREATE TABLE packages_new(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            manifest_dir TEXT NOT NULL,
+            commit_sha TEXT NOT NULL DEFAULT '',
+            worktree_id TEXT NOT NULL DEFAULT '',
+            local_roots_json TEXT NOT NULL DEFAULT '[]',
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__',
+            UNIQUE(repo_id, manifest_dir, commit_sha, worktree_id)
+        ) STRICT;
+        INSERT OR IGNORE INTO packages_new(
+            id, manifest_dir, commit_sha, worktree_id, local_roots_json, repo_id
+        )
+        SELECT id, manifest_dir, commit_sha, worktree_id, local_roots_json, '__unassigned__'
+        FROM packages;
+        DROP TABLE packages;
+        ALTER TABLE packages_new RENAME TO packages;
+        CREATE INDEX IF NOT EXISTS idx_packages_scope ON packages(commit_sha, worktree_id);
+        ",
+    )
+}
+
+/// Rebuild `parser_failures` with PK `(repo_id, path)` (was a bare autoincrement `id`). The old
+/// shape allowed multiple rows per path and `remove_file_in_scope` deleted by bare path —
+/// clobbering a sibling repo's failure once repos share a DB (inventory #12). The new PK collapses
+/// to one row per `(repo_id, path)`; `INSERT OR IGNORE` dedupes any legacy multi-row-per-path data.
+/// Nothing FK-references `parser_failures`, so dropping the `id` column is safe. Rebuilt STRICT.
+fn rebuild_parser_failures_table_with_repo_id(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS parser_failures_new;
+        CREATE TABLE parser_failures_new(
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__',
+            path TEXT NOT NULL,
+            language TEXT NOT NULL,
+            message TEXT NOT NULL,
+            PRIMARY KEY(repo_id, path)
+        ) STRICT;
+        INSERT OR IGNORE INTO parser_failures_new(repo_id, path, language, message)
+        SELECT '__unassigned__', path, language, message FROM parser_failures;
+        DROP TABLE parser_failures;
+        ALTER TABLE parser_failures_new RENAME TO parser_failures;
+        ",
+    )
+}
+
+/// Rebuild `git_commits` with PK `(repo_id, hash)` and `git_file_changes` with `repo_id` + a
+/// composite `(repo_id, commit_hash)` FK to it (`ON DELETE CASCADE ON UPDATE CASCADE` — the UPDATE
+/// cascade is what lets `register_repo` adoption re-point `git_commits.repo_id` and carry the
+/// changes along). `git_commits` rowids are PRESERVED (copied explicitly) so the `commit_fts`
+/// external-content rowid mapping stays valid; it is then resynced with the desync-safe `'rebuild'`
+/// (#51 — never `DELETE FROM commit_fts`). These two tables were repo-GLOBAL before; scoping them
+/// stops a `git history` reindex of one repo from wiping another's commits.
+fn rebuild_git_commits_tables_with_repo_id(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS git_commits_new;
+        DROP TABLE IF EXISTS git_file_changes_new;
+        CREATE TABLE git_commits_new(
+            hash TEXT NOT NULL,
+            author_name TEXT NOT NULL,
+            author_email TEXT NOT NULL,
+            authored_at_s INTEGER NOT NULL,
+            committed_at_s INTEGER NOT NULL,
+            subject TEXT NOT NULL,
+            body TEXT NOT NULL,
+            changed_file_count INTEGER NOT NULL DEFAULT 0,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__',
+            PRIMARY KEY(repo_id, hash)
+        ) STRICT;
+        INSERT OR IGNORE INTO git_commits_new(
+            rowid, hash, author_name, author_email, authored_at_s, committed_at_s,
+            subject, body, changed_file_count, repo_id
+        )
+        SELECT
+            rowid, hash, author_name, author_email, authored_at_s, committed_at_s,
+            subject, body, changed_file_count, '__unassigned__'
+        FROM git_commits;
+        DROP TABLE git_commits;
+        ALTER TABLE git_commits_new RENAME TO git_commits;
+
+        CREATE TABLE git_file_changes_new(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            commit_hash TEXT NOT NULL,
+            path TEXT NOT NULL,
+            additions INTEGER,
+            deletions INTEGER,
+            change_kind TEXT NOT NULL DEFAULT 'modified',
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__',
+            FOREIGN KEY(repo_id, commit_hash)
+                REFERENCES git_commits(repo_id, hash) ON DELETE CASCADE ON UPDATE CASCADE
+        );
+        INSERT OR IGNORE INTO git_file_changes_new(
+            id, commit_hash, path, additions, deletions, change_kind, repo_id
+        )
+        SELECT id, commit_hash, path, additions, deletions, change_kind, '__unassigned__'
+        FROM git_file_changes;
+        DROP TABLE git_file_changes;
+        ALTER TABLE git_file_changes_new RENAME TO git_file_changes;
+        CREATE INDEX IF NOT EXISTS idx_git_file_changes_path ON git_file_changes(path);
+        CREATE INDEX IF NOT EXISTS idx_git_file_changes_commit ON git_file_changes(commit_hash);
+
+        -- Resync the external-content FTS after the content-table rebuild (#51: 'rebuild', never a
+        -- DELETE, on a possibly-desynced external-content index).
+        INSERT INTO commit_fts(commit_fts) VALUES('rebuild');
+        ",
+    )
 }
 
 /// V035: add `symbols.is_test` (cross-language test-code marker computed at parse time; see
@@ -2001,7 +2390,49 @@ pub(crate) fn apply_commit_addressable_worktrees(conn: &Connection) -> rusqlite:
     Ok(())
 }
 
+/// Whether `files` already carries a UNIQUE index whose columns include `commit_sha` — i.e. it is
+/// already commit-addressable (the V008 `UNIQUE(path, commit_sha, worktree_id)` or the V040
+/// `UNIQUE(repo_id, path, commit_sha, worktree_id)` that supersedes it). Used to make the V008
+/// files rebuild idempotent + non-clobbering on `apply`'s full re-run.
+fn files_has_commit_scoped_unique(conn: &Connection) -> rusqlite::Result<bool> {
+    let unique_indexes: Vec<String> = {
+        let mut stmt = conn.prepare("PRAGMA index_list(files)")?;
+        let rows = stmt.query_map([], |row| {
+            // index_list columns: (seq, name, unique, origin, partial).
+            Ok((row.get::<_, String>(1)?, row.get::<_, i64>(2)? != 0))
+        })?;
+        rows.filter_map(|row| match row {
+            Ok((name, true)) => Some(Ok(name)),
+            Ok((_, false)) => None,
+            Err(err) => Some(Err(err)),
+        })
+        .collect::<rusqlite::Result<_>>()?
+    };
+    for index in unique_indexes {
+        let mut stmt = conn.prepare(&format!("PRAGMA index_info({index})"))?;
+        // index_info columns: (seqno, cid, name).
+        let mut cols = stmt.query_map([], |row| row.get::<_, Option<String>>(2))?;
+        if cols.any(|col| matches!(col, Ok(Some(name)) if name == "commit_sha")) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 pub(crate) fn rebuild_files_table_for_commit_scopes(conn: &Connection) -> rusqlite::Result<()> {
+    // IDEMPOTENCE / NON-CLOBBER (load-bearing since V040): this V008 rebuild recreates `files` with
+    // the columns it knew at V008 — it has NO `repo_id` column. `apply` re-runs EVERY migration
+    // (the `create_or_migrate`/`rebuild` path), so on an already-V040 DB an unconditional rebuild
+    // here would DROP the `repo_id` column (and its real values) BEFORE V040 re-adds it as the
+    // placeholder — and a case-1 `register_repo` (already adopted) would not re-backfill it,
+    // leaving every file row stranded under `__unassigned__`. The rebuild's ONLY job beyond the
+    // additive columns (already added by `apply_commit_addressable_worktrees`) is the
+    // commit-scoped UNIQUE; once `files` already carries a UNIQUE that includes `commit_sha`
+    // (this V008 one, or the V040 `(repo_id, path, commit_sha, worktree_id)` that supersedes
+    // it), the rebuild is redundant.
+    if files_has_commit_scoped_unique(conn)? {
+        return Ok(());
+    }
     conn.execute_batch(
         "
         PRAGMA foreign_keys = OFF;

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -3,12 +3,15 @@ mod migrations;
 mod registry;
 pub(crate) use baseline::*;
 pub(crate) use migrations::*;
-pub(crate) use registry::single_repo_id;
+pub(crate) use registry::{
+    CONNECTION_CONTEXT_REPO_KEY, active_repo_id, multiple_real_repos, resolve_config_repo_id,
+    sole_repo_id,
+};
 pub use registry::{LEGACY_REPO_ID, register_repo};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 39;
+pub const LATEST_SCHEMA_VERSION: u32 = 40;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -251,6 +254,13 @@ const MIGRATION_039_CHECKSUM: &str = "sha256:rag-rat-per-repo-meta-v39";
 const MIGRATION_039_DESCRIPTION: &str = "Relocate the per-repo singleton meta keys from the \
                                          global index_meta / reconcile_meta into repo_meta under \
                                          the __unassigned__ placeholder (memory-sync phase A2)";
+const MIGRATION_040_ID: &str = "040_repo_id_core_scoping";
+const MIGRATION_040_CHECKSUM: &str = "sha256:rag-rat-repo-id-core-scoping-v40";
+const MIGRATION_040_DESCRIPTION: &str =
+    "Add repo_id scoping to the core tables (files, packages, logical_symbols, docs, \
+     parser_failures, git_commits + git_file_changes) with rebuilt UNIQUE / PK keys and the \
+     re-pointed commit_fts external content, plus the two active-embedding-model provenance meta \
+     keys moved to repo_meta (memory-sync phase A3)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -584,6 +594,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_039_CHECKSUM,
         description: MIGRATION_039_DESCRIPTION,
         apply: apply_move_per_repo_meta,
+    },
+    Migration {
+        id: MIGRATION_040_ID,
+        checksum: MIGRATION_040_CHECKSUM,
+        description: MIGRATION_040_DESCRIPTION,
+        apply: apply_repo_id_core_scoping,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema/registry.rs
+++ b/crates/rag-rat-core/src/index/schema/registry.rs
@@ -2,13 +2,34 @@ use std::path::Path;
 
 use rusqlite::{Connection, OptionalExtension, params};
 
-use crate::repo_identity::RepoIdentity;
+use crate::repo_identity::{LOCAL_ONLY_ID_PREFIX, RepoIdentity, RepoIdentityClass};
+
+/// The `temp.connection_context` key under which the scope view stashes the active repo id (beside
+/// `commit_sha` / `worktree_id`). [`active_repo_id`] reads it; `install_scope_view` writes it.
+pub(crate) const CONNECTION_CONTEXT_REPO_KEY: &str = "repo_id";
+
+/// The direct-scoped tables that gained a `repo_id TEXT NOT NULL` column in V040 (phase A3) and
+/// therefore need their [`LEGACY_REPO_ID`] placeholder rows re-pointed at the real id when
+/// [`register_repo`] adopts a legacy DB. `git_file_changes` is intentionally ABSENT: its
+/// `(repo_id, commit_hash)` FK to `git_commits(repo_id, hash)` is `ON UPDATE CASCADE`, so rewriting
+/// `git_commits.repo_id` re-points its rows automatically — an explicit UPDATE would instead trip
+/// the FK (the child would reference the real id before the parent moved). `repo_meta` is handled
+/// separately (its FK is to `repos`, and it moved in V039). The A1 adoption contract requires every
+/// direct-scoped table backfill in the same call as the `repos`-row rewrite.
+const V040_DIRECT_SCOPED_TABLES: &[&str] =
+    &["files", "packages", "logical_symbols", "docs", "parser_failures", "git_commits"];
 
 /// The placeholder `repo_id` a freshly-migrated single-repo DB carries until it is adopted (see the
 /// V038 DDL) — and the backfill value every direct-scoped table gets when later migrations add
 /// `repo_id` columns (phase A3). A consolidated DB holding more than one repo NEVER carries this id
 /// (enforced by [`register_repo`]).
 pub const LEGACY_REPO_ID: &str = "__unassigned__";
+
+/// The `repo_meta` key a [`LocalOnly`](crate::repo_identity::RepoIdentityClass::LocalOnly)
+/// registration records its SORTED shallow-boundary commit hashes under (newline-joined), so a
+/// later LocalOnly→Portable upgrade can PROVE the incoming deepened clone is the same repository —
+/// its HEAD must reach these boundary commits. Absent ⇒ no proof recorded ⇒ the upgrade is refused.
+const SHALLOW_BOUNDARY_META_KEY: &str = "shallow_boundary";
 
 /// Register `identity` in this database's `repos`/`repo_roots` registry, returning the stored
 /// `repo_id`.
@@ -20,9 +41,17 @@ pub const LEGACY_REPO_ID: &str = "__unassigned__";
 ///   `root` is recorded in `repo_roots`.
 /// - **Already this repo** → a no-op except that a not-yet-seen `root` is appended to `repo_roots`
 ///   (worktrees of one repo share a `repo_id`, so several roots on one machine are expected).
-/// - **A different real repo_id already owns the DB** → refuses (returns an error) rather than
-///   corrupting a single-repo DB. Multi-repo registration is deliberately out of scope until the
-///   default-path flip (phase A7); until then one DB == one repo.
+/// - **A `local:` incumbent + an incoming `Portable` id** → *upgrade in place*: the DB was first
+///   indexed under a machine-local shallow-clone id, and the caller has since deepened it (`git
+///   fetch --unshallow`, our own remedy) or pinned a stable id, so the incoming identity is now
+///   portable. Every scoped row, `repo_meta`, `repo_roots`, and logical-symbol id is re-pointed
+///   from the local id to the portable one (the same adoption machinery), rather than stranding the
+///   existing index behind a refusal.
+/// - **Any other different real repo_id already owns the DB** → refuses (returns an error) rather
+///   than corrupting a single-repo DB: two genuinely-different portable repos, or a `LocalOnly`
+///   incoming against a real incumbent (a deepened clone must never DOWNGRADE a portable id back to
+///   machine-local). Multi-repo registration is deliberately out of scope until the default-path
+///   flip (phase A7); until then one DB == one repo.
 ///
 /// `now_ms` is the injected clock (see the repo's time-injection convention), stamped as the
 /// registration time on adoption / first insert.
@@ -47,38 +76,73 @@ pub fn register_repo(
         )));
     }
 
-    let root = root.to_string_lossy();
+    let root_str = root.to_string_lossy();
     let real_ids = real_repo_ids(conn)?;
 
-    // Already registered under this id → idempotent; just make sure the root is recorded.
+    // Already registered under this id → idempotent; just make sure the root is recorded (and, for
+    // a LocalOnly re-registration of the same clone, that its shallow boundary is on record so
+    // a later upgrade can prove against it — self-healing for an index first registered before
+    // this gate).
     if real_ids.iter().any(|id| id == &identity.repo_id) {
-        record_repo_root(conn, &identity.repo_id, &root, now_ms)?;
+        record_repo_root(conn, &identity.repo_id, &root_str, now_ms)?;
+        persist_shallow_boundary(conn, identity)?;
         return Ok(identity.repo_id.clone());
     }
 
-    // A different real repo already owns this DB — refuse rather than adopt (single-repo invariant
-    // for phase A; multi-repo registration lands with the default-path flip).
-    if let Some(other) = real_ids.first() {
-        return Err(registry_refusal(format!(
-            "cannot register repo {}: this index is already registered to a different repo {}",
-            identity.repo_id, other
-        )));
-    }
+    // A different real repo already owns this DB. The single-repo invariant refuses a second repo —
+    // with ONE exception: a shallow-clone UPGRADE. The DB was first indexed under a machine-local
+    // `local:` id (a cut shallow clone), and the caller has since deepened it (`git fetch
+    // --unshallow`, our own remedy) or pinned a stable id, so the incoming identity is now
+    // `Portable`. Re-point the DB from the local id onto the portable one in place (below) instead
+    // of stranding the existing index behind a refusal. Every OTHER mismatch still refuses:
+    // Portable↔different-Portable (two genuinely different repos), and a `LocalOnly` incoming
+    // against any existing real repo (a deepened clone must never DOWNGRADE a portable id back to
+    // machine-local). Guarded on exactly one real repo — a consolidated DB (post-A7) is never
+    // upgraded through this path.
+    let upgrade_from = match real_ids.as_slice() {
+        [] => None,
+        [incumbent]
+            if incumbent.starts_with(LOCAL_ONLY_ID_PREFIX)
+                && identity.class == RepoIdentityClass::Portable =>
+        {
+            // The `local:` prefix + Portable incoming is NECESSARY but not SUFFICIENT: a DB first
+            // indexed from a cut shallow clone, later opened from an UNRELATED full repo at the
+            // same database path (or with a mistaken pin), would otherwise silently
+            // re-point every scoped row, repo_meta, root, and logical id onto that
+            // unrelated id — data loss across two repos. Require PROOF the incoming
+            // clone is a DEEPENED version of THIS incumbent: the incumbent's recorded
+            // shallow-boundary commits must be reachable from the incoming clone's HEAD
+            // (a `git fetch --unshallow` keeps those commits in history; a different
+            // repo reaches none of them). No recorded boundary (a pre-gate registration) counts as
+            // NO PROOF. Verified BEFORE the adoption transaction so a refusal touches nothing.
+            let boundary = read_shallow_boundary(conn, incumbent)?;
+            let proven = !boundary.is_empty()
+                && crate::repo_identity::boundary_reachable_from_head(root, &boundary)
+                    .unwrap_or(false);
+            if !proven {
+                return Err(registry_refusal(unproven_upgrade_error(incumbent, &identity.repo_id)));
+            }
+            Some(incumbent.clone())
+        },
+        _ =>
+            return Err(registry_refusal(format!(
+                "cannot register repo {}: this index is already registered to a different repo {}",
+                identity.repo_id, real_ids[0]
+            ))),
+    };
 
-    // No real repo yet: adopt the placeholder in ONE transaction. Insert the real `repos` row
-    // FIRST, re-point the placeholder's children, then drop the placeholder. Since V039 (phase
-    // A2) `repo_meta` carries rows under the placeholder, and its FK to `repos` is enforced
-    // (`foreign_keys = ON`), the placeholder PK cannot be rewritten in place while children
-    // reference it; the insert-first / delete-last order keeps every FK satisfied at each statement
-    // boundary. The enclosing `unchecked_transaction` makes the whole adoption ATOMIC: a crash or
-    // mid-sequence error rolls it ALL back, so the DB never lands in the torn state where BOTH the
-    // real row and the placeholder survive — a state the "already registered" fast path above would
-    // never repair and `single_repo_id`'s one-row expectation would break on.
-    // `unchecked_transaction` is the right tool on a shared `&Connection` (rusqlite): it needs
-    // no `&mut`, commits on `.commit()`, and rolls back on drop. `repo_roots` never holds
-    // placeholder rows (it is only ever written under a real id, by `record_repo_root` below),
-    // so only `repo_meta` needs re-pointing; A3 extends this to the direct-scoped tables it
-    // adds. The fresh path (no placeholder) runs in the same transaction for uniformity.
+    // No real repo yet (or a `local:`-id upgrade): adopt in ONE transaction. Insert the real
+    // `repos` row FIRST, re-point the source id's children, then drop the source row. Since
+    // V039 (phase A2) `repo_meta` carries rows under the placeholder, and its FK to `repos` is
+    // enforced (`foreign_keys = ON`), the source PK cannot be rewritten in place while children
+    // reference it; the insert-first / delete-last order keeps every FK satisfied at each
+    // statement boundary. The enclosing `unchecked_transaction` makes the whole adoption
+    // ATOMIC: a crash or mid-sequence error rolls it ALL back, so the DB never lands in the
+    // torn state where BOTH the real row and the source survive — a state the "already
+    // registered" fast path above would never repair and `single_repo_id`'s one-row expectation
+    // would break on. `unchecked_transaction` is the right tool on a shared `&Connection`
+    // (rusqlite): it needs no `&mut`, commits on `.commit()`, and rolls back on drop. The fresh
+    // path (no placeholder, no upgrade) runs in the same transaction for uniformity.
     let tx = conn.unchecked_transaction()?;
     let placeholder_present = tx
         .query_row("SELECT 1 FROM repos WHERE repo_id = ?1", [LEGACY_REPO_ID], |_| Ok(()))
@@ -88,15 +152,76 @@ pub fn register_repo(
         "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, ?2, ?3)",
         params![identity.repo_id, identity.display_name, now_ms],
     )?;
-    if placeholder_present {
-        tx.execute("UPDATE repo_meta SET repo_id = ?1 WHERE repo_id = ?2", params![
+    // The id whose rows this registration re-points ONTO the new id: the machine-local incumbent on
+    // a shallow-clone upgrade, else the `__unassigned__` placeholder on a fresh adoption. Both
+    // cases re-point the same scoped tables + realign the same logical ids and then drop the
+    // old `repos` row; only the upgrade path actually has `repo_roots` rows to move (the
+    // placeholder never does, so that UPDATE is a harmless no-op there).
+    let repoint_from =
+        upgrade_from.as_deref().or_else(|| placeholder_present.then_some(LEGACY_REPO_ID));
+    if let Some(source_id) = repoint_from {
+        // Move every source-id `repo_meta` row onto the new id EXCEPT the shallow-boundary record:
+        // it describes the OLD `local:` clone's cut history and is meaningless under the portable
+        // id (which has a full history and never upgrades). Leaving it under `source_id`
+        // lets the `DELETE FROM repos WHERE repo_id = source_id` below cascade it away, so
+        // the portable id never inherits a stale boundary. Harmless no-op on the
+        // placeholder path (no such row).
+        tx.execute("UPDATE repo_meta SET repo_id = ?1 WHERE repo_id = ?2 AND key != ?3", params![
             identity.repo_id,
-            LEGACY_REPO_ID
+            source_id,
+            SHALLOW_BOUNDARY_META_KEY,
         ])?;
-        tx.execute("DELETE FROM repos WHERE repo_id = ?1", [LEGACY_REPO_ID])?;
+        // Re-point every direct-scoped table's source rows onto the real id (A3 extends the A1/A2
+        // adoption contract from `repos`/`repo_meta` to the V040 tables). Runs INSIDE the same
+        // transaction, keeping the insert-first ordering: on a fresh open the tables are empty and
+        // these are no-ops; on a forward-migrated DB (or a shallow-clone upgrade) they carry the
+        // rows onto the real id atomically with the `repos` rewrite. `git_commits` is updated here;
+        // `git_file_changes` follows via its `ON UPDATE CASCADE` FK.
+        for table in V040_DIRECT_SCOPED_TABLES {
+            tx.execute(&format!("UPDATE {table} SET repo_id = ?1 WHERE repo_id = ?2"), params![
+                identity.repo_id,
+                source_id
+            ])?;
+        }
+        // Move the source id's recorded roots onto the new id BEFORE the source `repos` row is
+        // deleted (its FK is `ON DELETE CASCADE`, so the roots would otherwise be dropped). A
+        // shallow-clone upgrade carries the local id's roots; the placeholder never has any.
+        tx.execute("UPDATE repo_roots SET repo_id = ?1 WHERE repo_id = ?2", params![
+            identity.repo_id,
+            source_id
+        ])?;
+        // `logical_symbols.id` is content-derived and now folds `repo_id` (A3), so re-pointing its
+        // `repo_id` above changed the id every row SHOULD have — the next `rebuild_logical_symbols`
+        // will re-derive `hash(real_repo_id ‖ key)` and dangle every pre-re-point memory/oracle
+        // handle still pointing at the source-derived id. Realign the ids (and every reference) in
+        // place NOW, before that rebuild. `logical_symbol_members` has an `ON DELETE CASCADE` FK to
+        // `logical_symbols(id)`, and adoption runs with `foreign_keys = ON`, so defer FK checks to
+        // COMMIT for this transaction (auto-resets on commit/rollback) — otherwise the parent-id
+        // UPDATE trips the child FK mid-statement. Idempotent with the V040 migration's own
+        // realign.
+        tx.execute_batch("PRAGMA defer_foreign_keys = ON")?;
+        crate::index::graph_index::realign_logical_symbol_ids(&tx)?;
+        tx.execute("DELETE FROM repos WHERE repo_id = ?1", [source_id])?;
     }
-    record_repo_root(&tx, &identity.repo_id, &root, now_ms)?;
+    record_repo_root(&tx, &identity.repo_id, &root_str, now_ms)?;
+    // Record a fresh LocalOnly adoption's shallow boundary INSIDE the transaction (atomic with the
+    // `repos` row it references), so a future deepened clone can prove the upgrade against it. A
+    // no-op for a Portable identity (empty boundary) and for the upgrade path itself (Portable
+    // incoming).
+    persist_shallow_boundary(&tx, identity)?;
     tx.commit()?;
+    // State what happened on a shallow-clone upgrade (a `local:` id re-pointed to a portable one)
+    // so the transition is legible in the log — it re-writes every scoped row and every logical
+    // id.
+    if let Some(local_id) = upgrade_from {
+        tracing::warn!(
+            old_repo_id = %local_id,
+            new_repo_id = %identity.repo_id,
+            "shallow-clone identity upgraded: the index was registered under a machine-local id \
+             (`local:`) and is now re-pointed to a portable id. All scoped rows, repo_meta, \
+             repo_roots, and logical-symbol ids were migrated in place."
+        );
+    }
     Ok(identity.repo_id.clone())
 }
 
@@ -111,20 +236,199 @@ fn registry_refusal(msg: String) -> rusqlite::Error {
     )
 }
 
-/// The single repo owning this database — the connection-level active-repo stand-in the per-repo
-/// [`repo_meta`](crate::index::repo_meta) accessors resolve until phase A3 threads a real
-/// `ScopeContext`. Phase A keeps ONE repo per DB ([`register_repo`] refuses a second), so `repos`
-/// holds exactly one row: the adopted real id after [`register_repo`], or the [`LEGACY_REPO_ID`]
-/// placeholder on a not-yet-adopted DB (a bare `schema::apply` in a test, or any open before A3
-/// wires registration into `open_config`). A3 replaces every caller with the active repo id from
-/// its scope context.
-pub(crate) fn single_repo_id(conn: &Connection) -> rusqlite::Result<String> {
-    debug_assert_eq!(
-        conn.query_row("SELECT COUNT(*) FROM repos", [], |row| row.get::<_, i64>(0))?,
-        1,
-        "phase A holds exactly one repos row per DB until the default-path flip (A3/A7)"
-    );
-    conn.query_row("SELECT repo_id FROM repos LIMIT 1", [], |row| row.get(0))
+/// Persist a [`LocalOnly`](RepoIdentityClass::LocalOnly) identity's sorted shallow-boundary hashes
+/// under its repo id, so a later LocalOnly→Portable upgrade can verify the incoming clone deepens
+/// THIS clone. Idempotent (upsert). A no-op for a Portable identity (empty boundary — nothing to
+/// prove against). Takes a bare `&Connection` so it composes with both the free connection (the
+/// idempotent re-registration path) and the adoption transaction.
+fn persist_shallow_boundary(conn: &Connection, identity: &RepoIdentity) -> rusqlite::Result<()> {
+    if identity.class != RepoIdentityClass::LocalOnly || identity.shallow_boundary.is_empty() {
+        return Ok(());
+    }
+    crate::index::set_repo_meta(
+        conn,
+        &identity.repo_id,
+        SHALLOW_BOUNDARY_META_KEY,
+        &identity.shallow_boundary.join("\n"),
+    )
+}
+
+/// A LocalOnly incumbent's recorded shallow-boundary commit hashes (newline-joined in `repo_meta`),
+/// as a vec. Empty when none was recorded — a pre-gate registration, which the upgrade path treats
+/// as no proof available.
+fn read_shallow_boundary(conn: &Connection, repo_id: &str) -> rusqlite::Result<Vec<String>> {
+    let raw = crate::index::repo_meta(conn, repo_id, SHALLOW_BOUNDARY_META_KEY)?;
+    Ok(raw
+        .map(|value| value.lines().map(str::to_string).filter(|h| !h.is_empty()).collect())
+        .unwrap_or_default())
+}
+
+/// The refusal message for a LocalOnly→Portable upgrade that could not be PROVEN: the incoming
+/// portable clone does not reach the machine-local incumbent's recorded shallow boundary (or none
+/// was recorded), so re-pointing the index onto it risks migrating one repo's data onto an
+/// unrelated id. Names the pin escape hatch to force it when the two genuinely ARE the same repo.
+fn unproven_upgrade_error(incumbent: &str, incoming: &str) -> String {
+    format!(
+        "cannot upgrade the machine-local repo id {incumbent} to {incoming}: could not prove the \
+         incoming repository is a deepened clone of this index (its history does not reach the \
+         recorded shallow boundary, or no boundary was recorded). Refusing rather than re-point \
+         this index onto a possibly-different repo. If they ARE the same repository, pin `[index] \
+         repo_id = \"{incoming}\"` in rag-rat.toml to force it."
+    )
+}
+
+/// The active repo id for `conn` — the value every repo-scoped read/write scopes against.
+///
+/// Prefers the SCOPE CONTEXT installed by `install_scope_view`
+/// (`temp.connection_context['repo_id']`): a consolidated multi-repo DB is only ever reached
+/// through a config-bearing open that registers the repo and installs the context first, so the
+/// context branch is authoritative there and never resolves the wrong repo. Falls back to
+/// [`sole_repo_id`] when NO context row is installed — the identity-less paths (bare `open`,
+/// `create_or_migrate`, a raw test connection, the model-manifest heal before a context is set): a
+/// phase-A DB opened without a config holds exactly one repo, so the fallback is unambiguous there.
+/// This replaced the old `single_repo_id` stand-in at every free-conn call site (A3).
+///
+/// An INSTALLED-BUT-EMPTY context (`""`) is AUTHORITATIVE and returned as-is — it is NOT a missing
+/// context. The raw read callers (CLI/MCP grep hooks, `query::orientation`) deliberately install
+/// `""` when `resolve_scope_repo_id` cannot prove the config repo, meaning "match nothing" rather
+/// than "pick a repo". The scoped `files` view then matches no rows; a direct-scoped reader
+/// (git history, parser failures, `repo_meta`) scoping on this `""` likewise reads nothing — a repo
+/// with the empty id does not exist. Falling through to `sole_repo_id` on an empty context would
+/// let those readers serve a SIBLING repo while the file view is empty (round-5 finding). So only
+/// the ABSENCE of the context row falls back.
+pub(crate) fn active_repo_id(conn: &Connection) -> rusqlite::Result<String> {
+    if let Some(repo_id) = context_repo_id(conn) {
+        return Ok(repo_id);
+    }
+    sole_repo_id(conn)
+}
+
+/// Read the active repo id from the per-connection scope context, tolerating the common absence of
+/// the `temp.connection_context` table (a raw connection with no view installed) — `.ok()` swallows
+/// the "no such table" error into `None`, exactly like `edges::resolve`'s `scope_context_value`.
+fn context_repo_id(conn: &Connection) -> Option<String> {
+    conn.query_row(
+        "SELECT value FROM temp.connection_context WHERE key = ?1",
+        [CONNECTION_CONTEXT_REPO_KEY],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()
+    .ok()
+    .flatten()
+}
+
+/// The sole repo owning a single-repo database — the identity-less fallback for [`active_repo_id`]
+/// and the config-less open paths (bare `open`, `create_or_migrate`, read-only opens). Prefers an
+/// adopted real repo, falling back to the [`LEGACY_REPO_ID`] placeholder on a not-yet-adopted DB
+/// (`ORDER BY (repo_id = placeholder)` sorts real ids first). Phase A keeps ONE repo per DB on
+/// these paths ([`register_repo`] refuses a second real repo until A7), so the result is
+/// unambiguous; multi-repo access always flows through the scope context, never here. Demoted from
+/// the former universal `single_repo_id` resolver — no hard one-row assertion, so a stray call on a
+/// consolidated DB degrades to a deterministic pick rather than a panic.
+pub(crate) fn sole_repo_id(conn: &Connection) -> rusqlite::Result<String> {
+    conn.query_row(
+        "SELECT repo_id FROM repos ORDER BY (repo_id = ?1), repo_id LIMIT 1",
+        [LEGACY_REPO_ID],
+        |row| row.get(0),
+    )
+}
+
+/// Whether this DB holds MORE THAN ONE real (adopted) repo — the interim guard for global-scope
+/// destructive sweeps over tables that do not yet carry `repo_id` (`oracle_runs`,
+/// `clone_graph_generations`; both gain the column in V042). When true, a per-repo caller must SKIP
+/// the global cleanup rather than wipe a sibling repo's rows. Today `register_repo` keeps this at
+/// one real repo until the A7 default-path flip, so the guard is dormant but present for the V042
+/// seam.
+pub(crate) fn multiple_real_repos(conn: &Connection) -> rusqlite::Result<bool> {
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM repos WHERE repo_id != ?1",
+        [LEGACY_REPO_ID],
+        |row| row.get(0),
+    )?;
+    Ok(count > 1)
+}
+
+/// Resolve the `repo_id` a config maps to on a connection WITHOUT registering anything — the
+/// READ-path counterpart to [`register_repo`]. Used by the read-only open
+/// (`try_open_config_read_only`) and the raw-connection scope-view installers (the Claude Code /
+/// MCP hooks, `query::orientation`), which must scope to the CONFIG's repo, not the config-blind
+/// sole repo: in a consolidated DB (post-A7) the [`sole_repo_id`] pick could bind a SIBLING repo.
+///
+/// Returns `None` when the repo cannot be proven to be registered — a fresh/unregistered DB, a
+/// `Rejected` config, or a consolidated DB whose config root is not recorded. The read-only open
+/// then bails to the read-write open (which registers/heals); a raw scope-view caller binds an
+/// empty scope rather than a sibling's rows.
+///
+/// Resolution routes, in order:
+///  1. by IDENTITY — [`resolve_repo_identity`](crate::repo_identity::resolve_repo_identity) derives
+///     the id (honoring an `[index] repo_id` override); if it is a REGISTERED real repo, use it. A
+///     derivable-but-UNREGISTERED id (a new/changed pin, or a now-portable shallow clone) returns
+///     `None` — a changed identity must adopt/surface on the read-write path, never silently keep
+///     serving the old scope.
+///  2. by ROOT (ABSENT configs only) — when there is NO derivable identity (non-git / unborn HEAD),
+///     the recorded `repo_roots` mapping for this root path (registration always records the root,
+///     so this binds the registered repo for a non-git root, e.g. a directly-seeded test repo).
+///  3. the SOLE repo (ABSENT configs only) — on a single-repo DB the sole repo is unambiguous,
+///     preserving the pre-A3 read-path behavior for un-adopted temp/test DBs; on a consolidated DB
+///     it is not, so `None`.
+///
+/// A `Rejected` identity (a reserved/`local:` pin, a root-less/corrupt history) short-circuits to
+/// `None`: it must NOT silently resolve — the read-write open surfaces the actionable error
+/// instead.
+pub(crate) fn resolve_config_repo_id(
+    conn: &Connection,
+    root: &Path,
+    repo_id_override: Option<&str>,
+) -> rusqlite::Result<Option<String>> {
+    match crate::repo_identity::resolve_repo_identity(root, repo_id_override) {
+        // Route 1: a derivable id that is registered scopes correctly even in a consolidated DB.
+        Ok(identity) if repo_id_is_registered(conn, &identity.repo_id)? =>
+            Ok(Some(identity.repo_id)),
+        // A RESOLVED but UNREGISTERED identity — a new/changed `[index] repo_id` pin, or a shallow
+        // clone that now derives a portable id — must NOT silently bind the OLD scope. Return None
+        // so the read-only open declines to the read-write open, which registers/upgrades
+        // the identity and surfaces any mismatch. The recorded-root / sole fallbacks are
+        // ONLY for an ABSENT config (no derivable id at all), never for a config that
+        // resolved to a different, real id: falling through to route 2 here would keep
+        // serving the previously-registered repo under the new identity (round-5 finding).
+        Ok(_) => Ok(None),
+        Err(err) if err.is_absent() => resolve_by_root_or_sole(conn, root),
+        // A Rejected config must surface through the read-write open, never resolve silently here.
+        Err(_) => Ok(None),
+    }
+}
+
+/// Whether `repo_id` is a REGISTERED real repo (present in `repos`, and not the placeholder
+/// marker).
+fn repo_id_is_registered(conn: &Connection, repo_id: &str) -> rusqlite::Result<bool> {
+    if repo_id == LEGACY_REPO_ID {
+        return Ok(false);
+    }
+    conn.query_row("SELECT EXISTS(SELECT 1 FROM repos WHERE repo_id = ?1)", [repo_id], |row| {
+        row.get(0)
+    })
+}
+
+/// Routes 2 + 3 of [`resolve_config_repo_id`]: the recorded `repo_roots` mapping for `root`, else
+/// the sole repo of a single-repo DB (unambiguous), else `None` on a consolidated DB (cannot prove
+/// which repo this root maps to — bind nothing rather than a sibling).
+fn resolve_by_root_or_sole(conn: &Connection, root: &Path) -> rusqlite::Result<Option<String>> {
+    let root = root.to_string_lossy();
+    // A recorded root maps unambiguously to its repo (a physical path belongs to exactly one repo).
+    if let Some(repo_id) = conn
+        .query_row(
+            "SELECT repo_id FROM repo_roots WHERE root = ?1 LIMIT 1",
+            [root.as_ref()],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+    {
+        return Ok(Some(repo_id));
+    }
+    if multiple_real_repos(conn)? {
+        return Ok(None);
+    }
+    Ok(Some(sole_repo_id(conn)?))
 }
 
 /// Every registered `repo_id` that is a real (adopted) id — i.e. excluding the [`LEGACY_REPO_ID`]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/chunk_store_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/chunk_store_migrations.rs
@@ -117,6 +117,11 @@ fn rebuild_fts_repopulates_contentless_chunk_fts_from_the_store() {
 
 #[test]
 fn full_rebuild_populates_the_chunk_text_store() {
+    // `chunk_text` is a GLOBAL compression store keyed by `chunk_id` (no repo dimension); this test
+    // asserts it mirrors the WHOLE `chunks` table 1:1. The poison-sibling harness seeds a raw
+    // tripwire chunk with no `chunk_text` row, breaking that whole-DB 1:1 by design — a single-repo
+    // invariant, not a leak. Opt out.
+    let _poison = crate::index::poison_sibling::disable_poison_sibling();
     // #77 Phase 2: a full rebuild compresses every chunk into chunk_text against the shared dict,
     // and every stored blob round-trips to its chunks.text.
     let root = unique_temp_root();
@@ -160,6 +165,9 @@ fn full_rebuild_populates_the_chunk_text_store() {
 
 #[test]
 fn incremental_heal_maintains_the_chunk_text_store() {
+    // Whole-DB `chunk_text`↔`chunks` 1:1 invariant (global store) — the poison-sibling tripwire
+    // chunk has no `chunk_text` mirror by design. Single-repo invariant; opt out.
+    let _poison = crate::index::poison_sibling::disable_poison_sibling();
     // #77 Phase 2 (2b-2a): the incremental/heal path writes chunk_text inline with the existing
     // dict, so a healed file's compressed blobs match its NEW text (the old rows cascade out with
     // the chunks). Without this, chunk_text would go stale on every incremental update.
@@ -205,6 +213,10 @@ fn incremental_heal_maintains_the_chunk_text_store() {
 
 #[test]
 fn rebuild_with_files_but_no_chunks_still_trains_a_dict_so_incrementals_dont_orphan() {
+    // Asserts the WHOLE DB has zero chunks (a whitespace-only markdown produces none). The
+    // poison-sibling tripwire seeds one chunk under a sibling repo, so this unscoped whole-DB count
+    // is a single-repo assertion; opt out.
+    let _poison = crate::index::poison_sibling::disable_poison_sibling();
     // #77 Phase 2 regression (adversarial finding). A full rebuild that indexes a file producing
     // ZERO chunks — a whitespace-only markdown file (markdown_chunks has no whole-file fallback) —
     // must still establish dict version 1. Pre-fix, build_store early-returned on an empty corpus,
@@ -878,7 +890,7 @@ fn orientation_composes_read_only() {
 
     // orientation installs its own scope view — pass the raw connection.
     let conn = db.storage.connection();
-    let o1 = crate::query::orientation::orientation(conn, &root, &root).unwrap();
+    let o1 = crate::query::orientation::orientation(conn, &root, &root, None).unwrap();
 
     // tree: root memory must be set; nodes must be non-empty.
     assert_eq!(
@@ -927,7 +939,7 @@ fn orientation_composes_read_only() {
     let _ = o1.parser_failures;
 
     // Idempotency: run orientation a second time — must succeed with same key results.
-    let o2 = crate::query::orientation::orientation(conn, &root, &root).unwrap();
+    let o2 = crate::query::orientation::orientation(conn, &root, &root, None).unwrap();
     assert_eq!(
         o2.tree.root_memory_title.as_deref(),
         Some("root purpose"),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
@@ -1384,6 +1384,8 @@ fn clones_for_symbol_returns_the_class_by_ref_and_by_path_line() {
     assert!(solo_res.symbol_resolved, "the solo symbol still resolves");
     assert!(solo_res.symbol_fingerprinted, "the solo function is eligible (fingerprinted)");
 
+    // Post-condition: the clone rebuild/precompute must not touch a sibling repo (round-6 harness).
+    crate::index::poison_sibling::assert_sibling_intact(db2.storage.connection());
     let _ = fs::remove_dir_all(root);
 }
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/git_history_reload.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/git_history_reload.rs
@@ -65,8 +65,18 @@ fn git_history_reload_is_not_skipped_on_a_shallow_clone() {
         shallow.to_str().unwrap(),
     ]);
     let config = rag_rat_config(&shallow);
+    // A depth-cut shallow clone cannot derive a PORTABLE identity (its root is unreachable), but it
+    // no longer fails: `resolve_repo_identity` derives a deterministic `local:`-prefixed LocalOnly
+    // id from the shallow boundary and proceeds. So rebuild/open/incremental adopt it WITHOUT a
+    // pin — exactly the path CI's shallow fixtures exercise — and this test keeps its subject
+    // (the history reload gate) while also covering LocalOnly adoption end-to-end.
 
     let db = IndexDatabase::rebuild(&config).unwrap();
+    assert!(
+        db.active_repo_id.starts_with("local:"),
+        "a cut shallow clone adopts under a LocalOnly id, got {}",
+        db.active_repo_id
+    );
     insert_sentinel_commit(&db);
     drop(db);
 
@@ -86,14 +96,15 @@ fn idle_discover_sweep_does_not_rewrite_indexed_at_ms() {
     let config = git_history_test_config(&root);
 
     let db = IndexDatabase::rebuild(&config).unwrap();
-    // Stamp a non-numeric sentinel so any spurious timestamp write is unmistakable.
+    // Stamp a non-numeric sentinel so any spurious timestamp write is unmistakable. Under the
+    // ACTIVE repo id (a real git fixture is adopted, so the `__unassigned__` placeholder repos row
+    // is gone and `repo_meta` under it would trip the FK).
     db.storage
         .connection()
         .execute(
-            "INSERT INTO repo_meta(repo_id, key, value) VALUES('__unassigned__', 'indexed_at_ms', \
-             'SENTINEL')
+            "INSERT INTO repo_meta(repo_id, key, value) VALUES(?1, 'indexed_at_ms', 'SENTINEL')
              ON CONFLICT(repo_id, key) DO UPDATE SET value = 'SENTINEL'",
-            [],
+            [&db.active_repo_id],
         )
         .unwrap();
     drop(db);

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/github_papertrail.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/github_papertrail.rs
@@ -270,7 +270,9 @@ fn heal_index_limit_does_not_warn_when_only_fresh_files_are_skipped() {
 fn search_recovers_when_fts_revision_is_stale() {
     let (root, config) = markdown_config("alpha token");
     let db = IndexDatabase::rebuild(&config).unwrap();
-    db.set_repo_meta("fts_source_revision", "stale").unwrap();
+    // `fts_source_revision` is a GLOBAL freshness key (V040 reclassification) — stored in
+    // `index_meta`, so stale it there, not in per-repo `repo_meta`.
+    db.set_meta("fts_source_revision", "stale").unwrap();
 
     let stale = db.status(&config.database).unwrap();
     assert!(!stale.fts_dirty);

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -22,14 +22,19 @@ const SENTINEL_PATH: &str = "__rag_rat_reload_sentinel__";
 
 fn insert_sentinel_commit(db: &IndexDatabase) {
     let conn = db.storage.connection();
-    // git_file_changes.commit_hash has a FK to git_commits.hash, so reuse a real commit hash; the
-    // sentinel marker is the path, which the reload wipes along with every other change row.
-    let hash: String =
-        conn.query_row("SELECT hash FROM git_commits LIMIT 1", [], |row| row.get(0)).unwrap();
+    // git_file_changes has a COMPOSITE FK `(repo_id, commit_hash) → git_commits(repo_id, hash)`
+    // (V040), so reuse a real commit's BOTH keys; the sentinel marker is the path, which the reload
+    // wipes along with every other change row.
+    let (hash, repo_id): (String, String) = conn
+        .query_row("SELECT hash, repo_id FROM git_commits LIMIT 1", [], |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })
+        .unwrap();
     conn.execute(
-        "INSERT INTO git_file_changes(commit_hash, path, additions, deletions, change_kind)
-         VALUES (?1, ?2, 0, 0, 'modified')",
-        rusqlite::params![hash, SENTINEL_PATH],
+        "INSERT INTO git_file_changes(commit_hash, path, additions, deletions, change_kind, \
+         repo_id)
+         VALUES (?1, ?2, 0, 0, 'modified', ?3)",
+        rusqlite::params![hash, SENTINEL_PATH, repo_id],
     )
     .unwrap();
 }
@@ -268,11 +273,17 @@ fn calls_edge_target(db: &IndexDatabase, path: &str) -> Option<i64> {
         .unwrap()
 }
 
-/// Global `parser_failures` row count (the table is unscoped — keyed by `path` only).
+/// The ACTIVE repo's `parser_failures` row count. Scoped by `repo_id` (V040 gave `parser_failures`
+/// a `(repo_id, path)` PK), so a consolidated DB's other repos — including the poison-sibling test
+/// tripwire — never inflate the "this repo's parse failures" count the overlay tests assert on.
 fn parser_failure_total(db: &IndexDatabase) -> i64 {
     db.storage
         .connection()
-        .query_row("SELECT COUNT(*) FROM parser_failures", [], |row| row.get(0))
+        .query_row(
+            "SELECT COUNT(*) FROM parser_failures WHERE repo_id = ?1",
+            [&db.active_repo_id],
+            |row| row.get(0),
+        )
         .unwrap()
 }
 
@@ -296,6 +307,24 @@ fn overlay_row_count(db: &IndexDatabase) -> i64 {
         .connection()
         .query_row("SELECT COUNT(*) FROM main.files WHERE worktree_id != ''", [], |row| row.get(0))
         .unwrap()
+}
+
+/// A real git repo with one committed rust file, plus its source `Config` — the fixture the
+/// poison-sibling harness self-tests against. A REAL git root (not a bare temp dir) so
+/// `adopt_repo_from_config` registers a portable repo id (a non-git root is `Absent` and stays
+/// under the placeholder, which would leave `real_repos == 0` and defeat the opt-out self-check).
+pub(crate) fn poison_test_config(tag: &str) -> (PathBuf, Config) {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), format!("pub fn {tag}_anchor() -> i32 {{ 1 }}\n")).unwrap();
+    run_git(&root, &["init", "-q", "-b", "main"]);
+    run_git(&root, &["config", "user.email", "t@e"]);
+    run_git(&root, &["config", "user.name", "t"]);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "seed"]);
+    let config = source_config(root.clone(), Language::Rust);
+    (root, config)
 }
 
 fn source_config(root: PathBuf, language: Language) -> Config {
@@ -679,12 +708,15 @@ fn insert_stale_overlay_row(db: &IndexDatabase, path: &str, worktree_id: &str) -
             |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         )
         .unwrap();
+    // Stamp the ACTIVE repo id (V040): a stale overlay row is a leftover from a prior index of the
+    // SAME repo, so it must carry that repo's id for the full-rebuild staging + scope view to see
+    // it.
     db.storage
         .connection()
         .execute(
             "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
-             commit_sha, worktree_id) VALUES (?1, ?2, ?3, ?4, 0, 0, '', ?5)",
-            rusqlite::params![path, language, kind, sha, worktree_id],
+             commit_sha, worktree_id, repo_id) VALUES (?1, ?2, ?3, ?4, 0, 0, '', ?5, ?6)",
+            rusqlite::params![path, language, kind, sha, worktree_id, db.active_repo_id],
         )
         .unwrap();
     db.storage.connection().last_insert_rowid()
@@ -799,6 +831,7 @@ mod dispatch;
 mod git_history_reload;
 mod github_papertrail;
 mod graph_edges;
+mod multi_repo_scope;
 mod orientation_healing;
 mod reconcile_embeddings;
 mod repo_memory;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
@@ -1,0 +1,655 @@
+//! Multi-repo scoping (memory-sync phase A3): two registered repos share ONE database, and the
+//! `repo_id` dimension must keep them isolated through the scope view (reads) and `garbage_collect`
+//! (sweeps) — even when they share a commit sha (the fork case) or an identical `(path, commit)`
+//! dead-context row. These pin the A3 disposition's "direct-scoped core tables" contract.
+//!
+//! Building two repos in one DB is deliberately below the phase-A open pipeline (which is single-
+//! repo until A7's multi-repo registration): repo A is indexed for real, then repo B's registry row
+//! and rows are seeded directly, and the connection is re-scoped by setting `active_repo_id` (a
+//! `pub` field) + `set_context` — the exact machinery A7 will drive per-repo.
+
+use super::*;
+
+/// A shared DB holding repo A (really indexed) plus repo B (seeded rows at repo A's SAME commit).
+struct TwoRepoFixture {
+    db: IndexDatabase,
+    root_a: PathBuf,
+    repo_a_id: String,
+    /// The commit both repos' rows sit at — proves the isolation is by `repo_id`, not commit sha.
+    shared_commit: String,
+}
+
+const REPO_B: &str = "test-repo-b";
+const DEAD_COMMIT: &str = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
+fn seed_repo_b_file(conn: &rusqlite::Connection, path: &str, commit: &str) {
+    conn.execute(
+        "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+         commit_sha, worktree_id, repo_id)
+         VALUES (?1, 'rust', 'source', 'bsha', 0, 0, ?2, '', ?3)",
+        rusqlite::params![path, commit, REPO_B],
+    )
+    .unwrap();
+}
+
+/// Index repo A into a shared DB for real (a git checkout, so the scope view has a real commit),
+/// then seed repo B directly: its registry row + a live file at repo A's commit + an identical
+/// `(path, commit)` DEAD-context row in EACH repo (for the gc parity assertion). The connection
+/// stays scoped to repo A (as `rebuild` left it).
+fn two_repo_fixture() -> TwoRepoFixture {
+    let root_a = unique_temp_root();
+    let _ = fs::remove_dir_all(&root_a);
+    fs::create_dir_all(root_a.join("src")).unwrap();
+    fs::write(root_a.join("src/a_only.rs"), "pub fn a_only() {}\n").unwrap();
+    run_git(&root_a, &["init", "-q", "-b", "main"]);
+    run_git(&root_a, &["config", "user.email", "t@e"]);
+    run_git(&root_a, &["config", "user.name", "t"]);
+    run_git(&root_a, &["add", "."]);
+    run_git(&root_a, &["commit", "-q", "-m", "init"]);
+
+    let shared_db = unique_temp_root().join("shared.sqlite");
+    let mut config_a = source_config(root_a.clone(), Language::Rust);
+    config_a.database = shared_db;
+    let db = IndexDatabase::rebuild(&config_a).unwrap();
+    let repo_a_id = db.active_repo_id.clone();
+    let shared_commit = db.active_commit_sha.clone();
+    assert!(!shared_commit.is_empty(), "repo A is a real git checkout");
+    assert_ne!(repo_a_id, REPO_B, "the two repos have distinct ids");
+
+    {
+        let conn = db.storage.connection();
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, 'B', 0)",
+            [REPO_B],
+        )
+        .unwrap();
+        // Repo B's live file at repo A's SAME commit (the fork case).
+        seed_repo_b_file(conn, "src/b_only.rs", &shared_commit);
+        // An identical (path, commit) DEAD-context row in each repo — gc of repo A must prune only
+        // its own.
+        seed_repo_b_file(conn, "src/dead.rs", DEAD_COMMIT);
+        conn.execute(
+            "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+             commit_sha, worktree_id, repo_id)
+             VALUES ('src/dead.rs', 'rust', 'source', 'asha', 0, 0, ?1, '', ?2)",
+            rusqlite::params![DEAD_COMMIT, repo_a_id],
+        )
+        .unwrap();
+    }
+
+    TwoRepoFixture { db, root_a, repo_a_id, shared_commit }
+}
+
+/// Paths visible through the per-connection scope VIEW (`temp.files`) at the active scope.
+fn paths_in_view(db: &IndexDatabase) -> Vec<String> {
+    let mut stmt = db.storage.connection().prepare("SELECT path FROM files ORDER BY path").unwrap();
+    stmt.query_map([], |r| r.get::<_, String>(0)).unwrap().map(Result::unwrap).collect()
+}
+
+fn repo_file_count(db: &IndexDatabase, repo_id: &str) -> i64 {
+    db.storage
+        .connection()
+        .query_row("SELECT COUNT(*) FROM main.files WHERE repo_id = ?1", [repo_id], |r| r.get(0))
+        .unwrap()
+}
+
+/// The scope view filters on `repo_id` FIRST: repo A's connection never sees repo B's file even
+/// though they sit at the SAME commit, and re-scoping the same connection to repo B flips the view.
+#[test]
+fn scope_view_isolates_repos_sharing_a_commit() {
+    let mut fx = two_repo_fixture();
+
+    // Scoped to repo A (as rebuild left it): sees repo A's file, NOT repo B's — despite the shared
+    // commit sha.
+    let view_a = paths_in_view(&fx.db);
+    assert!(view_a.contains(&"src/a_only.rs".to_string()), "repo A sees its own file: {view_a:?}");
+    assert!(
+        !view_a.contains(&"src/b_only.rs".to_string()),
+        "repo A's view must NOT leak repo B's file at the shared commit: {view_a:?}"
+    );
+
+    // Re-scope the SAME connection to repo B (the A7 per-repo drive, done here by hand).
+    fx.db.active_repo_id = REPO_B.to_string();
+    fx.db.set_context(&fx.shared_commit, "").unwrap();
+    let view_b = paths_in_view(&fx.db);
+    assert!(view_b.contains(&"src/b_only.rs".to_string()), "repo B sees its own file: {view_b:?}");
+    assert!(
+        !view_b.contains(&"src/a_only.rs".to_string()),
+        "repo B's view must NOT leak repo A's file: {view_b:?}"
+    );
+
+    let _ = fs::remove_dir_all(fx.root_a);
+}
+
+/// `garbage_collect` is repo-sliced: sweeping repo A prunes ONLY repo A's dead-context rows and
+/// leaves every one of repo B's rows intact — including a row with the IDENTICAL `(path, commit)`
+/// as the repo A row it prunes (row-count parity across the sweep).
+#[test]
+fn gc_of_one_repo_leaves_the_other_intact() {
+    let fx = two_repo_fixture();
+
+    let repo_b_before = repo_file_count(&fx.db, REPO_B);
+    assert_eq!(repo_b_before, 2, "repo B seeded with a live + a dead file");
+    // Repo A carries its indexed files plus the seeded dead-context row.
+    let repo_a_dead_before: i64 = fx
+        .db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM main.files WHERE repo_id = ?1 AND commit_sha = ?2",
+            rusqlite::params![fx.repo_a_id, DEAD_COMMIT],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(repo_a_dead_before, 1, "repo A has its dead-context row before gc");
+
+    let report = fx.db.garbage_collect().unwrap();
+    assert!(!report.skipped, "a live context was determined, so gc ran");
+
+    // Repo A's dead-context row is gone (its commit is not live).
+    let repo_a_dead_after: i64 = fx
+        .db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM main.files WHERE repo_id = ?1 AND commit_sha = ?2",
+            rusqlite::params![fx.repo_a_id, DEAD_COMMIT],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(repo_a_dead_after, 0, "gc pruned repo A's dead-context row");
+
+    // Repo B is untouched — EVERY row survives, including the one at the identical (path, commit)
+    // as the repo A row that was just pruned. This is the per-repo gc slice.
+    let repo_b_after = repo_file_count(&fx.db, REPO_B);
+    assert_eq!(repo_b_after, repo_b_before, "gc of repo A deletes nothing of repo B");
+    let repo_b_dead: i64 = fx
+        .db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM main.files WHERE repo_id = ?1 AND path = 'src/dead.rs'",
+            [REPO_B],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        repo_b_dead, 1,
+        "repo B's identical (path, commit) dead row is NOT pruned by A's gc"
+    );
+
+    let _ = fs::remove_dir_all(fx.root_a);
+}
+
+/// The all-zeros id: the lexicographically SMALLEST 40-hex string, so a real commit-hash repo id
+/// always sorts after it — used to expose a `sole_repo_id` fallback picking the wrong repo.
+const SMALLER_SIBLING: &str = "0000000000000000000000000000000000000000";
+
+/// Count `edges_data` rows whose source file belongs to `repo_id` (edges are attributed to a repo
+/// through `source_file_id → files.repo_id`).
+fn repo_edge_count(db: &IndexDatabase, repo_id: &str) -> i64 {
+    db.storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM edges_data
+              WHERE source_file_id IN (SELECT id FROM main.files WHERE repo_id = ?1)",
+            [repo_id],
+            |r| r.get(0),
+        )
+        .unwrap()
+}
+
+/// Seed ONE `edges_data` row whose source file is repo B's live file, so a repo-scoped graph wipe
+/// can be shown to spare it.
+fn seed_repo_b_edge(conn: &rusqlite::Connection) {
+    let file_id: i64 = conn
+        .query_row(
+            "SELECT id FROM main.files WHERE repo_id = ?1 AND path = 'src/b_only.rs'",
+            [REPO_B],
+            |r| r.get(0),
+        )
+        .unwrap();
+    conn.execute_batch(
+        "INSERT OR IGNORE INTO name_strings(value)
+             VALUES ('b_fn'), ('b_callee'), ('calls'), ('Exact');",
+    )
+    .unwrap();
+    let id_of = |v: &str| -> i64 {
+        conn.query_row("SELECT id FROM name_strings WHERE value = ?1", [v], |r| r.get(0)).unwrap()
+    };
+    conn.execute(
+        "INSERT INTO edges_data(source_file_id, from_name_id, to_name_id, edge_kind_id, \
+         confidence_id, resolution_id)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        rusqlite::params![
+            file_id,
+            id_of("b_fn"),
+            id_of("b_callee"),
+            id_of("calls"),
+            id_of("Exact"),
+            id_of("Exact"),
+        ],
+    )
+    .unwrap();
+}
+
+/// #413 finding #3: `ensure_graph_index_current` wipes then repopulates edges. `graph_index_version`
+/// is per-repo, so a stale version for repo A must wipe ONLY repo A's edges — a global
+/// `DELETE FROM edges_data` would leave repo B's graph empty until its own forced rebuild.
+#[test]
+fn graph_refresh_of_one_repo_leaves_the_other_repos_edges() {
+    let fx = two_repo_fixture();
+    seed_repo_b_edge(fx.db.storage.connection());
+    let repo_b_before = repo_edge_count(&fx.db, REPO_B);
+    assert_eq!(repo_b_before, 1, "repo B has its seeded edge before the refresh");
+
+    // Mark repo A's graph index stale, then refresh it (the connection is scoped to repo A).
+    fx.db.set_repo_meta("graph_index_version", "0").unwrap();
+    fx.db.ensure_graph_index_current().unwrap();
+
+    assert_eq!(
+        repo_edge_count(&fx.db, REPO_B),
+        repo_b_before,
+        "repo A's graph refresh must not wipe repo B's edges"
+    );
+    let _ = fs::remove_dir_all(fx.root_a);
+}
+
+/// #413 finding #4: the config-bearing incremental path (`index --changed`/`--discover`) must
+/// register/adopt the config's repo BEFORE stamping rows, exactly like `open_config`/`rebuild` —
+/// not ride the config-blind sole-repo fallback. With a lexicographically-SMALLER sibling repo
+/// present, `sole_repo_id` would pick the sibling; adoption must correct the active scope to the
+/// config's repo so the pass stamps rows under it, not the sibling.
+#[test]
+fn incremental_adopts_the_config_repo_over_a_smaller_sibling() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+    run_git(&root, &["init", "-q", "-b", "main"]);
+    run_git(&root, &["config", "user.email", "t@e"]);
+    run_git(&root, &["config", "user.name", "t"]);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "init"]);
+
+    let config = source_config(root.clone(), Language::Rust);
+    let repo_id = IndexDatabase::rebuild(&config).unwrap().active_repo_id;
+    assert!(SMALLER_SIBLING < repo_id.as_str(), "the sibling id sorts before the real repo id");
+
+    // A sibling repo whose id sorts BEFORE repo A's, so the sole-repo fallback would pick it.
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, 'decoy', 0)",
+            [SMALLER_SIBLING],
+        )
+        .unwrap();
+    }
+
+    // Edit a file so the incremental pass actually re-stamps a row, then run the config discover.
+    fs::write(root.join("src/lib.rs"), "pub fn f() { let _ = 1; }\n").unwrap();
+    let db = IndexDatabase::index_discover(&config).unwrap();
+    assert_eq!(db.active_repo_id, repo_id, "incremental adopts the config's repo, not the sibling");
+    let under_sibling: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT COUNT(*) FROM main.files WHERE repo_id = ?1", [SMALLER_SIBLING], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(under_sibling, 0, "no rows stamped under the sibling repo");
+    let under_config: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT COUNT(*) FROM main.files WHERE repo_id = ?1", [&repo_id], |r| r.get(0))
+        .unwrap();
+    assert!(under_config > 0, "rows are stamped under the config's repo");
+    let _ = fs::remove_dir_all(root);
+}
+
+/// #413 round-4 finding #1: the read-only MCP open (`try_open_config_read_only`) must scope to the
+/// CONFIG's repo, not the config-blind sole repo. With a lexicographically-SMALLER sibling repo
+/// present, `sole_repo_id` would pick the sibling and serve ITS (empty) scope; the read path now
+/// resolves the config's identity instead, so it serves the config repo's rows.
+#[test]
+fn read_only_open_binds_the_config_repo_over_a_smaller_sibling() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn ro_sibling_anchor() {}\n").unwrap();
+    run_git(&root, &["init", "-q", "-b", "main"]);
+    run_git(&root, &["config", "user.email", "t@e"]);
+    run_git(&root, &["config", "user.name", "t"]);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "init"]);
+
+    let config = source_config(root.clone(), Language::Rust);
+    let repo_id = IndexDatabase::rebuild(&config).unwrap().active_repo_id;
+    assert!(SMALLER_SIBLING < repo_id.as_str(), "the sibling id sorts before the real repo id");
+
+    // A sibling repos row whose id sorts BEFORE the config repo's, so the config-blind sole-repo
+    // fallback would pick it.
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, 'decoy', 0)",
+            [SMALLER_SIBLING],
+        )
+        .unwrap();
+        assert_eq!(
+            schema::sole_repo_id(&conn).unwrap(),
+            SMALLER_SIBLING,
+            "the config-blind sole pick is the WRONG (sibling) repo — the bug this fix closes",
+        );
+    }
+
+    let ro = IndexDatabase::try_open_config_read_only(&config)
+        .unwrap()
+        .expect("a current index is served read-only");
+    assert_eq!(
+        ro.active_repo_id, repo_id,
+        "the read-only open binds the CONFIG's repo (by identity), not the smaller sibling",
+    );
+    // And it actually serves the config repo's rows (not the sibling's empty scope).
+    assert!(
+        !ro.symbols("ro_sibling_anchor", Some(Language::Rust), 10).unwrap().is_empty(),
+        "the read-only connection answers queries scoped to the config repo",
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+/// All `repo_meta` rows as a sorted `(repo_id, key, value)` list — the snapshot the full-ladder
+/// replay must leave byte-identical (V039/V040 relocate meta, so a no-op replay must move nothing).
+fn dump_repo_meta(conn: &rusqlite::Connection) -> Vec<(String, String, Option<String>)> {
+    let mut stmt =
+        conn.prepare("SELECT repo_id, key, value FROM repo_meta ORDER BY repo_id, key").unwrap();
+    let mut rows: Vec<(String, String, Option<String>)> = stmt
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+        .unwrap()
+        .map(Result::unwrap)
+        .collect();
+    rows.sort();
+    rows
+}
+
+/// #413 round-4 finding #3: a full rebuild replays the WHOLE migration ladder (`create_or_migrate` →
+/// `schema::apply`). V039's per-repo-meta relocation resolves a migration-local `sole_repo_id` that
+/// HARD-ERRORS on a >1-repo registry — so `rag-rat index --full` for any repo in a CONSOLIDATED DB
+/// would fail before adoption. The idempotence gate makes the already-migrated relocation a true
+/// no-op (it never resolves the sole repo), so the replay succeeds and moves nothing. This also
+/// proves V038 (NOT-EXISTS seed guard) and V040 (files.repo_id sentinel) are replay-safe on the
+/// same two-repo DB — the whole ladder runs without error.
+#[test]
+fn full_ladder_replay_on_a_two_repo_db_is_idempotent() {
+    let fx = two_repo_fixture();
+    let db_path = fx.db.database_path().to_path_buf();
+    // Replay on a FRESH connection — exactly like `create_or_migrate` (which opens its own
+    // `IndexConnection` before `schema::apply`). The fixture's own connection carries the
+    // `temp.files` scope VIEW, which would shadow `main.files` for a migration's `CREATE INDEX ...
+    // ON files`; production never applies the ladder through a scoped connection.
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+
+    // Two real repos own the DB — the consolidated shape that trips the migration-local
+    // sole_repo_id.
+    assert!(schema::multiple_real_repos(&conn).unwrap(), "the fixture DB holds >1 real repo");
+    let repo_meta_before = dump_repo_meta(&conn);
+    let index_meta_before: i64 =
+        conn.query_row("SELECT COUNT(*) FROM index_meta", [], |r| r.get(0)).unwrap();
+    let files_before: i64 =
+        conn.query_row("SELECT COUNT(*) FROM main.files", [], |r| r.get(0)).unwrap();
+
+    // Replay the FULL ladder, exactly what `create_or_migrate` / `index --full` does. Before the
+    // gate this HARD-ERRORS at V039 on the 2-repo registry.
+    schema::apply(&conn).expect("full-ladder replay on a consolidated 2-repo DB must not error");
+
+    // A no-op: no meta relocated, no rows resurrected in the source tables, no files moved.
+    assert_eq!(dump_repo_meta(&conn), repo_meta_before, "the replay moved no repo_meta rows");
+    assert_eq!(
+        conn.query_row("SELECT COUNT(*) FROM index_meta", [], |r| r.get::<_, i64>(0)).unwrap(),
+        index_meta_before,
+        "the replay resurrected no keys in index_meta",
+    );
+    assert_eq!(
+        conn.query_row("SELECT COUNT(*) FROM main.files", [], |r| r.get::<_, i64>(0)).unwrap(),
+        files_before,
+        "the replay moved/duplicated no files rows",
+    );
+    // Both repos still registered.
+    assert!(schema::multiple_real_repos(&conn).unwrap(), "both repos still registered post-replay");
+    let repo_b_files: i64 = conn
+        .query_row("SELECT COUNT(*) FROM main.files WHERE repo_id = ?1", [REPO_B], |r| r.get(0))
+        .unwrap();
+    assert_eq!(repo_b_files, 2, "repo B's rows are intact after the replay");
+    let _ = fs::remove_dir_all(fx.root_a);
+}
+
+/// #413 finding #5: `oracle_runs` has NO `repo_id` yet (V042 seam), so its GLOBAL prune must be
+/// SKIPPED on a consolidated multi-repo DB — else GC for repo A wipes repo B's run rows whenever
+/// B's context is absent from A's live sets.
+#[test]
+fn gc_skips_the_global_oracle_prune_on_a_multi_repo_db() {
+    let fx = two_repo_fixture();
+    // A dead-context oracle run: its commit/worktree are not in repo A's live sets.
+    fx.db
+        .storage
+        .connection()
+        .execute(
+            "INSERT INTO oracle_runs(tool, tool_version, commit_sha, worktree_id, started_at, \
+             status, stats_json)
+             VALUES ('rust-analyzer', 'v1', 'dead-commit', 'dead-wt', 0, 'Completed', '{}')",
+            [],
+        )
+        .unwrap();
+
+    let report = fx.db.garbage_collect().unwrap();
+    assert!(!report.skipped, "a live context was determined, so gc ran");
+    let surviving: i64 = fx
+        .db
+        .storage
+        .connection()
+        .query_row("SELECT COUNT(*) FROM oracle_runs WHERE commit_sha = 'dead-commit'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(surviving, 1, "the multi-repo guard spares sibling oracle runs");
+    let _ = fs::remove_dir_all(fx.root_a);
+}
+
+/// The complement: a single-repo DB has no sibling to protect, so the global oracle prune runs and
+/// drops the dead-context run — unchanged behavior.
+#[test]
+fn gc_prunes_a_dead_oracle_run_on_a_single_repo_db() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+    run_git(&root, &["init", "-q", "-b", "main"]);
+    run_git(&root, &["config", "user.email", "t@e"]);
+    run_git(&root, &["config", "user.name", "t"]);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "init"]);
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO oracle_runs(tool, tool_version, commit_sha, worktree_id, started_at, \
+             status, stats_json)
+             VALUES ('rust-analyzer', 'v1', 'dead-commit', 'dead-wt', 0, 'Completed', '{}')",
+            [],
+        )
+        .unwrap();
+
+    db.garbage_collect().unwrap();
+    let surviving: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT COUNT(*) FROM oracle_runs WHERE commit_sha = 'dead-commit'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(surviving, 0, "single-repo gc prunes the dead-context oracle run as before");
+    let _ = fs::remove_dir_all(root);
+}
+
+/// `LogicalSymbolKey::stable_id` folds the OWNING repo into the content hash: two repos with
+/// byte-identical content (the same language/path/name/qualified-name/kind/signature key) derive
+/// DISTINCT logical-symbol ids, so `insert_logical_group` for the second repo inserts a second row
+/// instead of colliding on the `logical_symbols.id` PK (the pre-fix failure: `id` is the scalar
+/// `sym_<hex>` wire handle and the FK/PK target of members/monikers/memory bindings, so it must
+/// stay globally unique — the repo dimension lives INSIDE the derivation, not in a composite PK).
+#[test]
+fn identical_content_in_two_repos_yields_distinct_logical_symbols() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    crate::index::schema::apply(&conn).unwrap();
+
+    let key = crate::index::graph_index::LogicalSymbolKey {
+        language: "rust".to_string(),
+        path: "src/lib.rs".to_string(),
+        name: "parse".to_string(),
+        qualified_name: "lib::parse".to_string(),
+        kind: "function".to_string(),
+        signature: Some("fn parse()".to_string()),
+    };
+
+    IndexDatabase::insert_logical_group(&conn, "repo-a", &key, &[])
+        .expect("repo A inserts its group");
+    IndexDatabase::insert_logical_group(&conn, "repo-b", &key, &[])
+        .expect("the IDENTICAL key under repo B must not collide on the id PK");
+
+    let rows: Vec<(i64, String)> = {
+        let mut stmt =
+            conn.prepare("SELECT id, repo_id FROM logical_symbols ORDER BY repo_id").unwrap();
+        stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?))).unwrap().map(Result::unwrap).collect()
+    };
+    assert_eq!(rows.len(), 2, "one logical-symbol row per repo");
+    assert_eq!(rows[0].1, "repo-a");
+    assert_eq!(rows[1].1, "repo-b");
+    assert_ne!(rows[0].0, rows[1].0, "identical content derives repo-distinct ids");
+    // Per-repo resolution: each id is the deterministic repo-folded derivation, so a cached
+    // `sym_<hex>` handle keeps resolving to ITS repo's row across reindexes.
+    assert_eq!(rows[0].0, key.stable_id("repo-a"));
+    assert_eq!(rows[1].0, key.stable_id("repo-b"));
+}
+
+/// #413 round-5: `repo_brief`'s `graph_edges` total is scoped to the ACTIVE repo. `edges` has no
+/// `repo_id`, so a global `COUNT(*)` over the `edges` view would report the union across a
+/// consolidated DB while every other brief count is repo-scoped. It must count via
+/// `source_file_id → main.files.repo_id` instead.
+#[test]
+fn repo_brief_edges_are_scoped_to_the_active_repo() {
+    let fx = two_repo_fixture();
+    seed_repo_b_edge(fx.db.storage.connection());
+    let conn = fx.db.storage.connection();
+
+    let repo_a_edges = repo_edge_count(&fx.db, &fx.repo_a_id);
+    let global_edges: i64 =
+        conn.query_row("SELECT COUNT(*) FROM edges_data", [], |r| r.get(0)).unwrap();
+    assert!(
+        global_edges > repo_a_edges,
+        "the seeded repo B edge makes the global total exceed repo A's ({global_edges} > \
+         {repo_a_edges})",
+    );
+
+    // The connection is scoped to repo A (as rebuild left it), so the brief counts repo A's edges.
+    let summary = crate::query::repo_brief::summary_counts(conn).unwrap();
+    assert_eq!(
+        summary.graph_edges,
+        u64::try_from(repo_a_edges).unwrap(),
+        "repo_brief graph_edges counts only the active repo's edges, not repo B's",
+    );
+    assert!(
+        summary.graph_edges < u64::try_from(global_edges).unwrap(),
+        "and is strictly below the global union (repo B's edge is excluded)",
+    );
+    let _ = fs::remove_dir_all(fx.root_a);
+}
+
+/// #413 round-5: an INSTALLED-but-EMPTY scope context (`""`, the sibling-safe "match nothing" scope
+/// raw read callers install when the config repo can't be proven) is AUTHORITATIVE for
+/// `active_repo_id` — it must NOT fall through to `sole_repo_id`, which would let a direct-scoped
+/// reader (git history, parser failures, `repo_meta`) serve a sibling repo while the file view is
+/// empty.
+#[test]
+fn active_repo_id_honors_an_installed_empty_scope() {
+    let fx = two_repo_fixture();
+    let conn = fx.db.storage.connection();
+    // A repo_meta row under repo A that a config-blind sole/active pick WOULD surface.
+    crate::index::meta::set_repo_meta(conn, &fx.repo_a_id, "git_commit", "a-head").unwrap();
+
+    // Install an EMPTY scope: overwrite the connection's repo_id context with "" (what
+    // `install_worktree_scope_view(conn, "", ..)` writes when the repo is unprovable).
+    conn.execute(
+        "INSERT OR REPLACE INTO temp.connection_context(key, value) VALUES ('repo_id', '')",
+        [],
+    )
+    .unwrap();
+
+    assert_eq!(
+        schema::active_repo_id(conn).unwrap(),
+        "",
+        "an installed empty context is authoritative — never the sole/first repo",
+    );
+    // Therefore a direct-scoped reader reads NOTHING, not repo A's (or a sibling's) row.
+    let scoped = schema::active_repo_id(conn).unwrap();
+    assert_eq!(
+        crate::index::meta::repo_meta(conn, &scoped, "git_commit").unwrap(),
+        None,
+        "installed-empty scope yields empty direct-scoped reads, never a sibling's rows",
+    );
+    let _ = fs::remove_dir_all(fx.root_a);
+}
+
+/// #413 round-5: `query::orientation` threads the config's `[index] repo_id` override into its
+/// raw-connection scope resolution. A fork that PINS an id while sharing a root commit with its
+/// upstream would otherwise mis-scope: with `override = None` the identity route derives the shared
+/// root-commit id and binds the (registered) UPSTREAM sibling. With the override, the pinned fork
+/// id resolves first, so orientation installs the fork's own scope.
+#[test]
+fn orientation_pins_the_fork_repo_over_a_shared_root_sibling() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn fork_anchor() {}\n").unwrap();
+    run_git(&root, &["init", "-q", "-b", "main"]);
+    run_git(&root, &["config", "user.email", "t@e"]);
+    run_git(&root, &["config", "user.name", "t"]);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "init"]);
+
+    // Index the fork under a PINNED id (records root → fork-pin).
+    let mut config = source_config(root.clone(), Language::Rust);
+    config.repo_id_override = Some("fork-pin".to_string());
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    assert_eq!(db.active_repo_id, "fork-pin", "the fork indexes under its pinned id");
+
+    // The portable id the shared root commit derives — the UPSTREAM sibling's id. Seed it directly
+    // (register_repo refuses a second real repo before A7).
+    let upstream_id = crate::repo_identity::resolve_repo_identity(&root, None).unwrap().repo_id;
+    assert_ne!(upstream_id, "fork-pin", "the shared-root id differs from the fork's pin");
+    let conn = db.storage.connection();
+    conn.execute(
+        "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, 'upstream', 0)",
+        [&upstream_id],
+    )
+    .unwrap();
+
+    // WITH the override: orientation installs the fork's own scope.
+    crate::query::orientation::orientation(conn, &root, &root, Some("fork-pin")).unwrap();
+    assert_eq!(
+        schema::active_repo_id(conn).unwrap(),
+        "fork-pin",
+        "orientation threads the pin and installs the fork's scope",
+    );
+
+    // WITHOUT the override: the identity route resolves the shared-root sibling (the mis-scope the
+    // pin fixes).
+    crate::query::orientation::orientation(conn, &root, &root, None).unwrap();
+    assert_eq!(
+        schema::active_repo_id(conn).unwrap(),
+        upstream_id,
+        "no pin → orientation binds the shared-root upstream sibling",
+    );
+    let _ = fs::remove_dir_all(root);
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
@@ -24,7 +24,7 @@ fn orientation_composes_through_read_only_connection() {
 
     // Open the SAME on-disk DB read-only, exactly as session_start does.
     let conn = IndexConnection::open_read_only(&db_path).unwrap();
-    let o = crate::query::orientation::orientation(conn.connection(), &root, &root)
+    let o = crate::query::orientation::orientation(conn.connection(), &root, &root, None)
         .expect("orientation must compose through a read-only main-DB connection");
 
     // The scope view (TEMP table/view) was created and queried — non-empty tree + 6 files.
@@ -87,9 +87,9 @@ fn full_rebuild_clears_foreign_leaked_rows_at_the_active_scope() {
         .connection()
         .execute(
             "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
-             commit_sha, worktree_id) VALUES ('src/foreign_leak.rs', 'rust', 'source', 'leak', 0, \
-             0, ?1, '')",
-            rusqlite::params![commit],
+             commit_sha, worktree_id, repo_id) VALUES ('src/foreign_leak.rs', 'rust', 'source', \
+             'leak', 0, 0, ?1, '', ?2)",
+            rusqlite::params![commit, db.active_repo_id],
         )
         .unwrap();
     drop(db);

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -70,6 +70,12 @@ fn dirty_git_files_are_indexed_as_worktree_overlay() {
 
 #[test]
 fn rebuild_populates_revision_metadata_and_fresh_fts_state() {
+    // `content_revision` is a deliberately-GLOBAL digest over the whole `files` table (round-5 kept
+    // it in `index_meta`, not per-repo), and `fts_source_revision` tracks it. This test asserts the
+    // FRESH digest equals the value stored at rebuild time — but the poison-sibling harness seeds a
+    // file AFTER the rebuild commits, so the fresh digest legitimately includes it while the stored
+    // value does not. A whole-DB-digest assertion; opt out.
+    let _poison = crate::index::poison_sibling::disable_poison_sibling();
     let (root, config) = markdown_config("alpha token");
     let db = IndexDatabase::rebuild(&config).unwrap();
     let status = db.status(&config.database).unwrap();
@@ -77,7 +83,7 @@ fn rebuild_populates_revision_metadata_and_fresh_fts_state() {
     assert!(!status.content_revision.is_empty());
     assert_eq!(status.fts_source_revision.as_deref(), Some(status.content_revision.as_str()));
     assert_eq!(
-        db.repo_meta("content_revision").unwrap().as_deref(),
+        db.meta("content_revision").unwrap().as_deref(),
         Some(status.content_revision.as_str())
     );
     assert!(!status.fts_dirty);
@@ -547,6 +553,9 @@ fn discover_deletion_is_worktree_scoped() {
     assert_eq!(active("src/a.rs"), 0, "deleted file still active in own worktree");
     assert_eq!(active("src/b.rs"), 1, "live file dropped from own worktree");
 
+    // Post-condition: a worktree-scoped discover-deletion must not delete a sibling repo's rows
+    // (round-6 harness) — the same "delete only my scope" invariant, widened to the repo axis.
+    crate::index::poison_sibling::assert_sibling_intact(conn);
     let _ = fs::remove_dir_all(root);
 }
 
@@ -611,6 +620,8 @@ fn gc_refuses_to_prune_with_no_live_context() {
     assert_eq!(report.files_pruned, 0);
     assert_eq!(table_row_count(db.storage.connection(), "files").unwrap(), before);
 
+    // Post-condition: the refused prune must leave the poison sibling untouched (round-6 harness).
+    crate::index::poison_sibling::assert_sibling_intact(db.storage.connection());
     let _ = fs::remove_dir_all(root);
 }
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -851,6 +851,9 @@ fn memory_relocates_when_symbol_moves_to_another_file() {
     assert!(path.contains("b.rs"), "binding path should be b.rs after relocation: {path}");
     assert_ne!(binding.anchor_status, "gone");
 
+    // Post-condition: memory validation/relocation (which rewrites bindings) must not rebind onto,
+    // or delete, a SIBLING repo's rows (round-6 harness; guards the P2 #2 relocation scoping).
+    crate::index::poison_sibling::assert_sibling_intact(db.storage.connection());
     let _ = fs::remove_dir_all(root);
 }
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -4,10 +4,35 @@
 
 use super::*;
 use crate::index::schema::{self, LEGACY_REPO_ID, register_repo};
-use crate::repo_identity::RepoIdentity;
+use crate::repo_identity::{RepoIdentity, RepoIdentityClass};
 
 fn identity(repo_id: &str, display_name: &str) -> RepoIdentity {
-    RepoIdentity { repo_id: repo_id.to_string(), display_name: display_name.to_string() }
+    RepoIdentity {
+        repo_id: repo_id.to_string(),
+        display_name: display_name.to_string(),
+        // The class is a scoping-neutral tag; ADOPTION of a placeholder / refusal of a second repo
+        // ignore it — only the LocalOnly→Portable upgrade branch reads it (see `identity_local`).
+        class: RepoIdentityClass::Portable,
+        shallow_boundary: Vec::new(),
+    }
+}
+
+/// A machine-local (`LocalOnly`) identity — a `local:`-prefixed id, as a cut shallow clone derives.
+/// `register_repo` refuses one against an existing real repo (a deepened clone must not DOWNGRADE a
+/// portable id), and only UPGRADES *away* from one when an incoming `Portable` id arrives — after
+/// PROVING the deepened clone reaches the recorded `shallow_boundary` (pass the boundary commits a
+/// later portable clone must reach; empty ⇒ no proof recorded ⇒ the upgrade is refused).
+fn identity_local(
+    repo_id: &str,
+    display_name: &str,
+    shallow_boundary: Vec<String>,
+) -> RepoIdentity {
+    RepoIdentity {
+        repo_id: repo_id.to_string(),
+        display_name: display_name.to_string(),
+        class: RepoIdentityClass::LocalOnly,
+        shallow_boundary,
+    }
 }
 
 fn repo_row_count(conn: &rusqlite::Connection, repo_id: &str) -> i64 {
@@ -195,10 +220,10 @@ fn reapplying_schema_after_adoption_does_not_resurrect_the_placeholder() {
 /// per-repo `repo_meta`: an ADOPTED DB carrying relocated meta must survive a full `schema::apply`
 /// re-run (the `create_or_migrate`/`rebuild` path) with its identity and meta intact. If the V038
 /// seed regressed to an unconditional `INSERT OR IGNORE`, the re-apply would re-mint the
-/// placeholder beside the real row — two `repos` rows — which trips `single_repo_id`'s one-row
-/// `debug_assert` AND leaves it resolving an arbitrary repo, so the per-repo `repo_meta` accessors
-/// would read the wrong scope. This pins BOTH sides at once: after re-apply `single_repo_id` still
-/// returns the real id, and the meta rows stay under it (never resurrected under the placeholder).
+/// placeholder beside the real row — two `repos` rows — leaving `sole_repo_id` to resolve an
+/// arbitrary repo, so the per-repo `repo_meta` accessors would read the wrong scope. This pins BOTH
+/// sides at once: after re-apply the real id is still the SOLE repos row, and the meta rows stay
+/// under it (never resurrected under the placeholder).
 #[test]
 fn reapplying_schema_after_adoption_keeps_single_repo_id_and_repo_meta_under_the_real_id() {
     let conn = rusqlite::Connection::open_in_memory().expect("open");
@@ -208,9 +233,9 @@ fn reapplying_schema_after_adoption_keeps_single_repo_id_and_repo_meta_under_the
     crate::index::meta::set_repo_meta(&conn, LEGACY_REPO_ID, "indexed_at_ms", "9").unwrap();
 
     register_repo(&conn, &identity("repo-abc", "myrepo"), Path::new("/src/repo"), 1).unwrap();
-    // Adoption re-pointed the meta to the real id and `single_repo_id` resolves it.
+    // Adoption re-pointed the meta to the real id and `sole_repo_id` resolves it.
     assert_eq!(
-        schema::single_repo_id(&conn).unwrap(),
+        schema::sole_repo_id(&conn).unwrap(),
         "repo-abc",
         "adopted: real id is the sole repo"
     );
@@ -218,10 +243,13 @@ fn reapplying_schema_after_adoption_keeps_single_repo_id_and_repo_meta_under_the
     // The exact re-run `create_or_migrate` (hence `rebuild`) performs on an existing index.
     schema::apply(&conn).expect("re-apply is idempotent on an already-migrated DB");
 
-    // `single_repo_id` still resolves the real id — its internal one-row `debug_assert` also fires
-    // if the conditional seed regressed and resurrected the placeholder beside the real row.
+    // Exactly one repos row (the real id) survives the re-apply — the conditional seed did NOT
+    // resurrect the placeholder beside it (the resolver no longer carries a one-row `debug_assert`,
+    // so this asserts the invariant explicitly).
+    let repos_total: i64 = conn.query_row("SELECT COUNT(*) FROM repos", [], |r| r.get(0)).unwrap();
+    assert_eq!(repos_total, 1, "exactly one repos row after re-apply");
     assert_eq!(
-        schema::single_repo_id(&conn).unwrap(),
+        schema::sole_repo_id(&conn).unwrap(),
         "repo-abc",
         "re-apply leaves the real id as the sole repo (no placeholder resurrected)"
     );
@@ -340,17 +368,17 @@ fn register_repo_refuses_a_different_real_repo() {
 // --- V039: per-repo meta relocation (memory-sync phase A2) ---
 
 /// Fresh `apply` runs V039; it relocates the listed per-repo singleton keys into `repo_meta` under
-/// the placeholder and leaves the machine-level keys in their global tables. This is the schema
-/// tip, so it owns the absolute `LATEST_SCHEMA_VERSION` pin.
+/// the placeholder and leaves the machine-level keys in their global tables. (The absolute
+/// `LATEST_SCHEMA_VERSION` pin moved to `migration_040_*`, the new tip; this uses only the symbolic
+/// `current_version == LATEST` check.)
 #[test]
 fn migration_039_relocates_per_repo_meta_and_leaves_global_keys() {
     let conn = rusqlite::Connection::open_in_memory().expect("open");
     schema::apply(&conn).expect("apply");
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 39, "V039 is the schema tip");
     assert_eq!(
         schema::status(&conn).unwrap().current_version,
         schema::LATEST_SCHEMA_VERSION,
-        "schema is at LATEST after V039"
+        "schema is at LATEST after apply"
     );
 
     // Seed the SOURCE tables as a legacy DB carries them: relocated keys plus, to prove
@@ -448,15 +476,18 @@ fn v039_relocation_runs_standalone_and_is_idempotent() {
     )
     .unwrap();
     schema::apply_repos_registry(&bare).expect("V038 registry");
-    upsert_meta(&bare, "index_meta", "fts_dirty", "true");
+    // `git_commit` is a genuinely per-repo key V039 relocates; the reencode cursor moves too. (The
+    // `fts_*` trio + `content_revision` are RECLASSIFIED GLOBAL by V040, so V039 no longer
+    // relocates them — covered by `v039_leaves_reclassified_global_keys_in_index_meta`.)
+    upsert_meta(&bare, "index_meta", "git_commit", "abc123");
     upsert_meta(&bare, "reconcile_meta", "vector_int8_reencode_cursor", "7\nm");
 
     schema::apply_move_per_repo_meta(&bare).expect("V039 relocation standalone");
     schema::apply_move_per_repo_meta(&bare).expect("V039 relocation is idempotent");
 
     assert_eq!(
-        crate::index::meta::repo_meta(&bare, LEGACY_REPO_ID, "fts_dirty").unwrap().as_deref(),
-        Some("true"),
+        crate::index::meta::repo_meta(&bare, LEGACY_REPO_ID, "git_commit").unwrap().as_deref(),
+        Some("abc123"),
     );
     assert_eq!(
         crate::index::meta::repo_meta(&bare, LEGACY_REPO_ID, "vector_int8_reencode_cursor")
@@ -464,17 +495,57 @@ fn v039_relocation_runs_standalone_and_is_idempotent() {
             .as_deref(),
         Some("7\nm"),
     );
-    assert!(!meta_present(&bare, "index_meta", "fts_dirty"));
+    assert!(!meta_present(&bare, "index_meta", "git_commit"));
     assert!(!meta_present(&bare, "reconcile_meta", "vector_int8_reencode_cursor"));
     // Re-run left exactly one relocated row (no duplicate from the second pass).
     let count: i64 = bare
         .query_row(
-            "SELECT COUNT(*) FROM repo_meta WHERE repo_id = ?1 AND key = 'fts_dirty'",
+            "SELECT COUNT(*) FROM repo_meta WHERE repo_id = ?1 AND key = 'git_commit'",
             [LEGACY_REPO_ID],
             |r| r.get(0),
         )
         .unwrap();
     assert_eq!(count, 1, "re-run does not duplicate the relocated row");
+}
+
+/// V040 RECLASSIFICATION: `content_revision` + the `fts_*` freshness trio are GLOBAL infrastructure
+/// (one `chunk_fts` index, a digest over the whole `main.files`), NOT per-repo. V039 (frozen) still
+/// lists them, so the shared `relocate_meta_keys` filters them out — V039's sweep must LEAVE them
+/// in `index_meta` while still relocating the genuinely-per-repo keys beside them. This is the
+/// property that keeps `index --full` from hard-erroring at V039 on a consolidated DB after the
+/// reclassification.
+#[test]
+fn v039_leaves_reclassified_global_keys_in_index_meta() {
+    let bare = rusqlite::Connection::open_in_memory().expect("open");
+    bare.execute_batch(
+        "CREATE TABLE index_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+         CREATE TABLE reconcile_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);",
+    )
+    .unwrap();
+    schema::apply_repos_registry(&bare).expect("V038 registry");
+    // The 4 reclassified-global index_meta keys, plus one genuinely-per-repo key as a positive
+    // control that DOES relocate.
+    for key in ["content_revision", "fts_dirty", "fts_source_revision", "fts_synced_at_ms"] {
+        upsert_meta(&bare, "index_meta", key, "global-val");
+    }
+    upsert_meta(&bare, "index_meta", "source_root", "/src/repo");
+
+    schema::apply_move_per_repo_meta(&bare).expect("V039 relocation standalone");
+
+    // The 4 global keys STAY in index_meta and never enter repo_meta.
+    for key in ["content_revision", "fts_dirty", "fts_source_revision", "fts_synced_at_ms"] {
+        assert!(meta_present(&bare, "index_meta", key), "{key} stays GLOBAL in index_meta");
+        assert!(
+            crate::index::meta::repo_meta(&bare, LEGACY_REPO_ID, key).unwrap().is_none(),
+            "{key} did NOT relocate to repo_meta",
+        );
+    }
+    // The per-repo control still relocated — V039's behavior for non-reclassified keys is intact.
+    assert!(!meta_present(&bare, "index_meta", "source_root"), "per-repo key still relocates");
+    assert_eq!(
+        crate::index::meta::repo_meta(&bare, LEGACY_REPO_ID, "source_root").unwrap().as_deref(),
+        Some("/src/repo"),
+    );
 }
 
 /// V039 leaves the relocated meta under the placeholder repo_id; `register_repo` adoption MUST
@@ -516,14 +587,14 @@ fn single_repo_id_returns_the_sole_repo() {
     let conn = rusqlite::Connection::open_in_memory().expect("open");
     schema::apply(&conn).expect("apply");
     assert_eq!(
-        schema::single_repo_id(&conn).unwrap(),
+        schema::sole_repo_id(&conn).unwrap(),
         LEGACY_REPO_ID,
         "the placeholder is the sole repo before adoption"
     );
 
     register_repo(&conn, &identity("repo-abc", "myrepo"), Path::new("/src/repo"), 1).unwrap();
     assert_eq!(
-        schema::single_repo_id(&conn).unwrap(),
+        schema::sole_repo_id(&conn).unwrap(),
         "repo-abc",
         "the adopted real id is the sole repo after registration"
     );
@@ -612,7 +683,7 @@ fn migration_039_relocates_under_the_real_id_on_an_adopted_v038_db() {
     );
     // The keys land under the REAL id (never the vanished placeholder); `single_repo_id` resolves
     // it.
-    assert_eq!(schema::single_repo_id(&conn).unwrap(), "repo-abc");
+    assert_eq!(schema::sole_repo_id(&conn).unwrap(), "repo-abc");
     for (key, value) in [
         ("source_root", "/src/repo"),
         ("indexed_at_ms", "5000"),
@@ -692,11 +763,1014 @@ fn register_repo_adoption_is_atomic_on_a_mid_sequence_failure() {
         .expect("adoption succeeds once the fault is removed");
     assert_eq!(repo_row_count(&conn, LEGACY_REPO_ID), 0, "placeholder adopted away");
     assert_eq!(repo_row_count(&conn, "repo-abc"), 1, "the real repo owns the DB");
-    assert_eq!(schema::single_repo_id(&conn).unwrap(), "repo-abc");
+    assert_eq!(schema::sole_repo_id(&conn).unwrap(), "repo-abc");
     assert_eq!(
         crate::index::meta::repo_meta(&conn, "repo-abc", "source_root").unwrap().as_deref(),
         Some("/src/repo"),
         "meta carried over to the real id on the successful adoption",
     );
     assert_eq!(root_count(&conn, "repo-abc"), 1, "its root is recorded");
+}
+
+// --- V040: repo_id scoping on the core tables (memory-sync phase A3) ---
+
+/// The pre-V040 (post-V039) shape of every core table [`schema::apply_repo_id_core_scoping`]
+/// transforms, plus the V038 registry it relocates meta under — built in ISOLATION so the migration
+/// is exercised against its own inputs, not the full ladder (the directory's "assert deferred
+/// absence / rebuild behavior in isolation" rule). `files`/`packages`/… carry NO `repo_id`;
+/// `parser_failures` is id-keyed; `git_commits` is `hash`-PK with `commit_fts` external content and
+/// a `git_file_changes(commit_hash)` FK — exactly what V040 rebuilds.
+fn seed_pre_v040_core_schema(conn: &rusqlite::Connection) {
+    conn.execute_batch(
+        "
+        CREATE TABLE index_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        CREATE TABLE files(
+            id INTEGER PRIMARY KEY AUTOINCREMENT, path TEXT NOT NULL, language TEXT NOT NULL,
+            kind TEXT NOT NULL, sha256 TEXT NOT NULL, modified_at_ms INTEGER NOT NULL,
+            generated INTEGER NOT NULL DEFAULT 0, indexed_at_ms INTEGER NOT NULL,
+            indexed_revision TEXT NOT NULL DEFAULT '', commit_sha TEXT NOT NULL DEFAULT '',
+            worktree_id TEXT NOT NULL DEFAULT '', has_test_code INTEGER NOT NULL DEFAULT 0,
+            UNIQUE(path, commit_sha, worktree_id));
+        CREATE TABLE packages(
+            id INTEGER PRIMARY KEY AUTOINCREMENT, manifest_dir TEXT NOT NULL,
+            commit_sha TEXT NOT NULL DEFAULT '', worktree_id TEXT NOT NULL DEFAULT '',
+            local_roots_json TEXT NOT NULL DEFAULT '[]',
+            UNIQUE(manifest_dir, commit_sha, worktree_id)) STRICT;
+        CREATE TABLE logical_symbols(
+            id INTEGER PRIMARY KEY AUTOINCREMENT, language TEXT NOT NULL, path TEXT NOT NULL,
+            logical_name TEXT NOT NULL, qualified_name_id INTEGER, kind TEXT NOT NULL,
+            variant_count INTEGER NOT NULL, group_reason TEXT NOT NULL);
+        CREATE TABLE docs(
+            id INTEGER PRIMARY KEY AUTOINCREMENT, chunk_id INTEGER NOT NULL,
+            source_kind TEXT NOT NULL, heading_path TEXT);
+        CREATE TABLE parser_failures(
+            id INTEGER PRIMARY KEY AUTOINCREMENT, path TEXT NOT NULL, language TEXT NOT NULL,
+            message TEXT NOT NULL);
+        CREATE TABLE git_commits(
+            hash TEXT PRIMARY KEY, author_name TEXT NOT NULL, author_email TEXT NOT NULL,
+            authored_at_s INTEGER NOT NULL, committed_at_s INTEGER NOT NULL, subject TEXT NOT NULL,
+            body TEXT NOT NULL, changed_file_count INTEGER NOT NULL DEFAULT 0);
+        CREATE TABLE git_file_changes(
+            id INTEGER PRIMARY KEY AUTOINCREMENT, commit_hash TEXT NOT NULL, path TEXT NOT NULL,
+            additions INTEGER, deletions INTEGER, change_kind TEXT NOT NULL DEFAULT 'modified',
+            FOREIGN KEY(commit_hash) REFERENCES git_commits(hash) ON DELETE CASCADE);
+        CREATE VIRTUAL TABLE commit_fts USING fts5(
+            subject, body, content='git_commits', content_rowid='rowid', tokenize='porter');
+        -- The logical-symbol companion tables a real pre-V040 DB carries (all baseline). V040's
+        -- logical-symbol id realign (repo_id fold) reads name_strings / symbols /
+        -- logical_symbol_members for the hash inputs and re-points logical_symbol_monikers +
+        -- repo_memory_bindings / repo_memory_call_paths; the tables must exist for that pass to
+        -- PREPARE even when (as here) logical_symbols is empty, so it is a no-op.
+        CREATE TABLE name_strings(id INTEGER PRIMARY KEY, value TEXT NOT NULL UNIQUE) STRICT;
+        CREATE TABLE symbols(id INTEGER PRIMARY KEY AUTOINCREMENT, signature TEXT);
+        CREATE TABLE logical_symbol_members(
+            logical_symbol_id INTEGER NOT NULL, symbol_id INTEGER NOT NULL, cfg_expr TEXT,
+            signature_hash TEXT, start_line INTEGER NOT NULL DEFAULT 0,
+            end_line INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(logical_symbol_id, symbol_id),
+            -- The real ON DELETE CASCADE FK: it is exactly what forces the id realign to run with \
+         FK
+            -- OFF (V040) or DEFERRED (adoption), so the fixture carries it to exercise those \
+         paths.
+            FOREIGN KEY(logical_symbol_id) REFERENCES logical_symbols(id) ON DELETE CASCADE);
+        CREATE TABLE logical_symbol_monikers(
+            logical_symbol_id INTEGER NOT NULL, tool TEXT NOT NULL, tool_version TEXT NOT NULL,
+            moniker TEXT NOT NULL, computed_at INTEGER NOT NULL,
+            PRIMARY KEY(logical_symbol_id, tool)) STRICT;
+        CREATE TABLE repo_memory_bindings(
+            memory_id TEXT NOT NULL, binding_kind TEXT NOT NULL, binding_id TEXT NOT NULL,
+            logical_symbol_id INTEGER, PRIMARY KEY(memory_id, binding_kind, binding_id));
+        CREATE TABLE repo_memory_call_paths(
+            memory_id TEXT NOT NULL, start_logical_symbol_id INTEGER, end_logical_symbol_id \
+         INTEGER,
+            edge_sequence_hash TEXT NOT NULL, PRIMARY KEY(memory_id, edge_sequence_hash));
+        ",
+    )
+    .unwrap();
+    schema::apply_repos_registry(conn).expect("V038 registry seeds the placeholder");
+}
+
+/// Seed one git commit + its file change + its FTS entry into a pre-V040 fixture, returning the
+/// hash.
+fn seed_pre_v040_commit(conn: &rusqlite::Connection, hash: &str, subject: &str) {
+    conn.execute(
+        "INSERT INTO git_commits(hash, author_name, author_email, authored_at_s, committed_at_s, \
+         subject, body, changed_file_count) VALUES (?1, 'a', 'a@b', 1, 1, ?2, 'body', 1)",
+        rusqlite::params![hash, subject],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO git_file_changes(commit_hash, path, additions, deletions, change_kind) \
+         VALUES (?1, 'src/lib.rs', 1, 0, 'modified')",
+        [hash],
+    )
+    .unwrap();
+    // Populate the external-content FTS from the seeded commit rows so it starts in sync (as a real
+    // pre-V040 index would be) — V040's rebuild then has a consistent index to re-point.
+    conn.execute_batch("INSERT INTO commit_fts(commit_fts) VALUES('rebuild');").unwrap();
+}
+
+/// Fresh `apply` runs V040 (the schema tip): every direct-scoped core table gains `repo_id`, and
+/// the widened UNIQUE/PK keys make same-path/same-hash rows distinct across repos. Owns the
+/// absolute `LATEST_SCHEMA_VERSION` pin.
+#[test]
+fn migration_040_is_the_latest_tip_and_scopes_core_tables() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 40, "V040 is the schema tip");
+    assert_eq!(schema::status(&conn).unwrap().current_version, 40, "schema at LATEST after apply");
+
+    for table in [
+        "files",
+        "packages",
+        "logical_symbols",
+        "docs",
+        "parser_failures",
+        "git_commits",
+        "git_file_changes",
+    ] {
+        assert!(
+            conn_table_columns(&conn, table).contains(&"repo_id".to_string()),
+            "{table} gains a direct repo_id column"
+        );
+    }
+    // `parser_failures` dropped its bare autoincrement id for the `(repo_id, path)` PK.
+    assert!(
+        !conn_table_columns(&conn, "parser_failures").contains(&"id".to_string()),
+        "parser_failures PK is (repo_id, path), no id column"
+    );
+
+    // files UNIQUE is now repo-scoped: the SAME (path, commit_sha, worktree_id) in two repos is
+    // fine.
+    conn.execute(
+        "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, repo_id) \
+         VALUES ('src/lib.rs', 'rust', 'source', 'a', 0, 0, 'repo-a')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, repo_id) \
+         VALUES ('src/lib.rs', 'rust', 'source', 'a', 0, 0, 'repo-b')",
+        [],
+    )
+    .expect("same path/commit/worktree in a DIFFERENT repo does not collide");
+    let dup = conn.execute(
+        "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, repo_id) \
+         VALUES ('src/lib.rs', 'rust', 'source', 'a', 0, 0, 'repo-a')",
+        [],
+    );
+    assert!(dup.is_err(), "the SAME repo/path/commit/worktree still conflicts");
+}
+
+/// V040's `git_commits` PK rebuild + `git_file_changes` composite FK + `commit_fts` re-point,
+/// driven against the pre-V040 fixture IN ISOLATION: rows survive the rebuild, `commit_fts` still
+/// MATCHes after the desync-safe `'rebuild'` (#51), and the migration RE-CONVERGES from a torn
+/// intermediate state (a leftover scratch table from a crashed prior pass). Then `register_repo`
+/// adoption re-points the placeholder rows — carrying `git_file_changes` along via the FK's ON
+/// UPDATE CASCADE.
+#[test]
+fn migration_040_git_rebuild_preserves_rows_commit_fts_and_reconverges_from_torn_state() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    seed_pre_v040_core_schema(&conn);
+    seed_pre_v040_commit(&conn, "cafef00d", "alpha subject token");
+    conn.execute(
+        "INSERT INTO parser_failures(path, language, message) VALUES ('x.rs','rust','boom')",
+        [],
+    )
+    .unwrap();
+
+    // TORN STATE: a prior V040 pass crashed after creating a scratch table. The rebuild must drop
+    // it and re-converge rather than fail on CREATE.
+    conn.execute_batch(
+        "CREATE TABLE files_new(bogus INTEGER); CREATE TABLE git_commits_new(bogus INTEGER);",
+    )
+    .unwrap();
+
+    schema::apply_repo_id_core_scoping(&conn).expect("V040 converges from the torn state");
+
+    // The scratch tables are gone; the transform completed.
+    assert!(!conn_table_exists(&conn, "files_new"));
+    assert!(!conn_table_exists(&conn, "git_commits_new"));
+    assert!(conn_table_columns(&conn, "git_commits").contains(&"repo_id".to_string()));
+
+    // The commit row survived, backfilled to the placeholder, and commit_fts still MATCHes it.
+    let (hash, repo_id): (String, String) = conn
+        .query_row("SELECT hash, repo_id FROM git_commits", [], |r| Ok((r.get(0)?, r.get(1)?)))
+        .unwrap();
+    assert_eq!(hash, "cafef00d");
+    assert_eq!(repo_id, LEGACY_REPO_ID, "existing rows backfill to the placeholder");
+    let matched: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM commit_fts JOIN git_commits ON git_commits.rowid = \
+             commit_fts.rowid WHERE commit_fts MATCH 'alpha'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(matched, 1, "commit_fts still MATCHes after the git_commits rebuild + 'rebuild'");
+    // The composite FK holds: the file change carries the same placeholder repo_id.
+    let fc_repo: String =
+        conn.query_row("SELECT repo_id FROM git_file_changes", [], |r| r.get(0)).unwrap();
+    assert_eq!(fc_repo, LEGACY_REPO_ID);
+
+    // Idempotent re-run (the all-or-nothing sentinel short-circuits once files carries repo_id).
+    schema::apply_repo_id_core_scoping(&conn).expect("re-apply is a clean no-op");
+
+    // Adoption re-points git_commits.repo_id → real, and the ON UPDATE CASCADE carries the change
+    // row.
+    register_repo(&conn, &identity("repo-real", "r"), Path::new("/src/r"), 1).unwrap();
+    let (gc_repo, fc_repo2): (String, String) = conn
+        .query_row(
+            "SELECT (SELECT repo_id FROM git_commits), (SELECT repo_id FROM git_file_changes)",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(gc_repo, "repo-real", "adoption re-points git_commits");
+    assert_eq!(fc_repo2, "repo-real", "ON UPDATE CASCADE carries git_file_changes along");
+    // parser_failures was re-pointed too.
+    let pf_repo: String =
+        conn.query_row("SELECT repo_id FROM parser_failures", [], |r| r.get(0)).unwrap();
+    assert_eq!(pf_repo, "repo-real", "adoption re-points parser_failures");
+}
+
+/// V040 in ISOLATION reunites the two active-model provenance stragglers (`active_embedding_model_
+/// provisional`, `active_embedding_remote_config`) with their family in `repo_meta` — the keys A2's
+/// V039 sweep left behind in `index_meta`.
+#[test]
+fn migration_040_reunites_active_model_provenance_meta_into_repo_meta() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    seed_pre_v040_core_schema(&conn);
+    upsert_meta(&conn, "index_meta", "active_embedding_model_provisional", "1");
+    upsert_meta(&conn, "index_meta", "active_embedding_remote_config", "{\"endpoint\":\"x\"}");
+    upsert_meta(&conn, "index_meta", "generated_flags_version", "1"); // machine-level, stays
+
+    schema::apply_repo_id_core_scoping(&conn).unwrap();
+
+    for key in ["active_embedding_model_provisional", "active_embedding_remote_config"] {
+        assert!(
+            crate::index::meta::repo_meta(&conn, LEGACY_REPO_ID, key).unwrap().is_some(),
+            "{key} relocated to repo_meta"
+        );
+        assert!(!meta_present(&conn, "index_meta", key), "{key} removed from index_meta");
+    }
+    assert!(
+        meta_present(&conn, "index_meta", "generated_flags_version"),
+        "machine key stays global"
+    );
+}
+
+/// A V039 index forward-migrates to V040 on `migrate_forward` — reaching LATEST.
+#[test]
+fn migration_040_forward_migrates_a_v039_index() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    truncate_schema_to(&conn, 39);
+    assert_eq!(schema::status(&conn).unwrap().state, schema::SchemaState::Older);
+    schema::migrate_forward(&conn).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
+}
+
+/// P1 regression (the V039/e2a2bc5 class): on an ALREADY-ADOPTED pre-V040 DB (`repos` holds only
+/// the REAL id; the placeholder row is gone), V040's rebuilds stamp existing rows with the STATIC
+/// `__unassigned__` column DEFAULT — and the next `register_repo` takes the already-registered
+/// fast path that never re-points, so without the in-migration backfill every row would orphan
+/// under the placeholder and the real repo's scope view would see an EMPTY index after the
+/// upgrade. `apply_repo_id_core_scoping` therefore resolves the SOLE `repos` row (the established
+/// [`sole_repo_id`] pattern) and backfills every direct-scoped table to it — `git_file_changes`
+/// explicitly, because FK enforcement is OFF inside the migration transaction so the `ON UPDATE
+/// CASCADE` does not fire there.
+#[test]
+fn migration_040_backfills_an_adopted_pre_v040_db_under_the_real_repo_id() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    seed_pre_v040_core_schema(&conn);
+    seed_pre_v040_commit(&conn, "cafef00d", "alpha subject token");
+    conn.execute(
+        "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms)
+         VALUES ('src/lib.rs', 'rust', 'source', 'sha', 0, 0)",
+        [],
+    )
+    .unwrap();
+    conn.execute("INSERT INTO packages(manifest_dir) VALUES ('.')", []).unwrap();
+    conn.execute(
+        "INSERT INTO logical_symbols(id, language, path, logical_name, kind, variant_count, \
+         group_reason)
+         VALUES (7, 'rust', 'src/lib.rs', 'f', 'function', 1, 'single')",
+        [],
+    )
+    .unwrap();
+    conn.execute("INSERT INTO docs(chunk_id, source_kind) VALUES (1, 'doc_comment')", []).unwrap();
+    conn.execute(
+        "INSERT INTO parser_failures(path, language, message) VALUES ('x.rs', 'rust', 'boom')",
+        [],
+    )
+    .unwrap();
+    // A straggler meta key: the V040 relocation must land it under the real id too.
+    upsert_meta(&conn, "index_meta", "active_embedding_model_provisional", "1");
+
+    // Adopt as the PRE-V040 binary's `register_repo` left it (there were no direct-scoped tables
+    // to re-point yet): real `repos` row in, `repo_meta` re-pointed, placeholder deleted.
+    conn.execute(
+        "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('repo-adopted', 'r', \
+         1)",
+        [],
+    )
+    .unwrap();
+    conn.execute("UPDATE repo_meta SET repo_id = 'repo-adopted' WHERE repo_id = ?1", [
+        LEGACY_REPO_ID,
+    ])
+    .unwrap();
+    conn.execute("DELETE FROM repos WHERE repo_id = ?1", [LEGACY_REPO_ID]).unwrap();
+
+    schema::apply_repo_id_core_scoping(&conn).expect("V040 applies on an adopted DB");
+
+    for table in [
+        "files",
+        "packages",
+        "logical_symbols",
+        "docs",
+        "parser_failures",
+        "git_commits",
+        "git_file_changes",
+    ] {
+        let (total, under_real): (i64, i64) = conn
+            .query_row(
+                &format!(
+                    "SELECT COUNT(*), COALESCE(SUM(repo_id = 'repo-adopted'), 0) FROM {table}"
+                ),
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert!(total > 0, "{table}: the fixture seeded at least one row");
+        assert_eq!(under_real, total, "{table}: every row backfilled under the REAL repo id");
+    }
+    // The straggler relocation targeted the sole (real) repos row, never the vanished placeholder.
+    assert_eq!(
+        crate::index::meta::repo_meta(&conn, "repo-adopted", "active_embedding_model_provisional")
+            .unwrap()
+            .as_deref(),
+        Some("1"),
+        "V040 meta relocation lands under the real id on an adopted DB"
+    );
+
+    // The runtime fast path (next open re-registers the same repo) stays a no-op and leaves the
+    // backfill intact.
+    register_repo(&conn, &identity("repo-adopted", "r"), Path::new("/src/r"), 2).unwrap();
+    let stranded: i64 = conn
+        .query_row("SELECT COUNT(*) FROM files WHERE repo_id = ?1", [LEGACY_REPO_ID], |r| r.get(0))
+        .unwrap();
+    assert_eq!(stranded, 0, "nothing remains stranded under the placeholder");
+}
+
+// --- Logical-symbol id realign across the repo_id fold (A3, #413 finding #1) ---
+
+/// Seed ONE logical symbol (`logical_id`) with a fully-recoverable key — a member symbol carrying
+/// the signature, an interned qualified name — plus every kind of reference that must follow it: a
+/// per-tool moniker, a memory binding, and a memory call-path (start + end). The next realign (V040
+/// or adoption) re-derives the id under the folded hash and must carry ALL of them along.
+fn seed_pre_v040_logical_symbol_with_a_bound_memory(conn: &rusqlite::Connection, logical_id: i64) {
+    conn.execute("INSERT INTO name_strings(id, value) VALUES (1, 'mymod::my_fn')", []).unwrap();
+    conn.execute("INSERT INTO symbols(id, signature) VALUES (100, 'fn my_fn()')", []).unwrap();
+    conn.execute(
+        "INSERT INTO logical_symbols(id, language, path, logical_name, qualified_name_id, kind, \
+         variant_count, group_reason)
+         VALUES (?1, 'rust', 'src/lib.rs', 'my_fn', 1, 'function', 1, 'single')",
+        [logical_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO logical_symbol_members(logical_symbol_id, symbol_id, start_line, end_line) \
+         VALUES (?1, 100, 1, 3)",
+        [logical_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO logical_symbol_monikers(logical_symbol_id, tool, tool_version, moniker, \
+         computed_at) VALUES (?1, 'scip-rust', 'v1', 'moniker', 0)",
+        [logical_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id, logical_symbol_id) \
+         VALUES ('mem-1', 'logical_symbol', 'b1', ?1)",
+        [logical_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO repo_memory_call_paths(memory_id, start_logical_symbol_id, \
+         end_logical_symbol_id, edge_sequence_hash) VALUES ('mem-1', ?1, ?1, 'h1')",
+        [logical_id],
+    )
+    .unwrap();
+}
+
+/// The `logical_symbol_id` every reference table now points at (binding / call-path start+end /
+/// moniker / member), asserted equal so a single value proves they all followed the realign.
+fn bound_logical_symbol_id(conn: &rusqlite::Connection) -> i64 {
+    let binding: i64 = conn
+        .query_row(
+            "SELECT logical_symbol_id FROM repo_memory_bindings WHERE memory_id = 'mem-1'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    for (sql, label) in [
+        ("SELECT logical_symbol_id FROM logical_symbol_members", "member"),
+        ("SELECT logical_symbol_id FROM logical_symbol_monikers", "moniker"),
+        ("SELECT start_logical_symbol_id FROM repo_memory_call_paths", "call-path start"),
+        ("SELECT end_logical_symbol_id FROM repo_memory_call_paths", "call-path end"),
+    ] {
+        let other: i64 = conn.query_row(sql, [], |r| r.get(0)).unwrap();
+        assert_eq!(other, binding, "the {label} reference must match the binding after realign");
+    }
+    // "Resolves to the SAME symbol": the id joins to a live logical symbol with the seeded content.
+    let name: String = conn
+        .query_row(
+            "SELECT ls.logical_name FROM repo_memory_bindings b
+               JOIN logical_symbols ls ON ls.id = b.logical_symbol_id
+              WHERE b.memory_id = 'mem-1'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(name, "my_fn", "the bound memory resolves to the same logical symbol");
+    binding
+}
+
+/// #413 finding #1, migration half: folding `repo_id` into the logical-symbol id derivation (A3)
+/// changes every id the next `rebuild_logical_symbols` produces, so a pre-V040 memory/oracle handle
+/// would dangle. V040 must migrate the ids IN PLACE and carry every reference along, so a bound
+/// memory still resolves to the same symbol under the new id.
+#[test]
+fn migration_040_realigns_logical_symbol_ids_and_carries_bound_memories() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    seed_pre_v040_core_schema(&conn);
+    let old_id = 424_242_i64; // an arbitrary pre-fold id
+    seed_pre_v040_logical_symbol_with_a_bound_memory(&conn, old_id);
+
+    schema::apply_repo_id_core_scoping(&conn).expect("V040 applies");
+
+    // The symbol's id was re-derived (repo_id folded in), so it CHANGED from the pre-fold value.
+    let new_id: i64 = conn.query_row("SELECT id FROM logical_symbols", [], |r| r.get(0)).unwrap();
+    assert_ne!(new_id, old_id, "the id was re-derived under the repo_id-folded hash");
+    // Every reference followed the symbol to its new id, and no orphan is left at the old id.
+    assert_eq!(bound_logical_symbol_id(&conn), new_id, "all references follow the symbol");
+    let stale: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM repo_memory_bindings WHERE logical_symbol_id = ?1",
+            [old_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(stale, 0, "no reference dangles at the pre-fold id");
+}
+
+/// #413 finding #1, adoption half: on a NOT-yet-adopted DB the V040 realign lands the id under the
+/// PLACEHOLDER repo_id; adoption re-points `logical_symbols.repo_id` to the real id, which changes
+/// the derived id AGAIN — so `register_repo` must realign a SECOND time (with FK checks deferred).
+/// A bound memory must survive BOTH transitions — the common real-world upgrade path (a pre-V038 DB
+/// with memories, adopted on first config-bearing open).
+#[test]
+fn adoption_realigns_logical_symbol_ids_so_pre_v040_memories_survive() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    seed_pre_v040_core_schema(&conn);
+    let old_id = 999_001_i64;
+    seed_pre_v040_logical_symbol_with_a_bound_memory(&conn, old_id);
+
+    schema::apply_repo_id_core_scoping(&conn).expect("V040 applies (unadopted → placeholder id)");
+    let placeholder_id = bound_logical_symbol_id(&conn);
+    assert_ne!(placeholder_id, old_id, "V040 already realigned under the placeholder repo_id");
+
+    // Adopt the placeholder as a real repo — the id derivation changes with the real repo_id.
+    register_repo(&conn, &identity("real-repo", "r"), Path::new("/src/r"), 1).unwrap();
+
+    let real_id: i64 = conn
+        .query_row("SELECT id FROM logical_symbols WHERE repo_id = 'real-repo'", [], |r| r.get(0))
+        .unwrap();
+    assert_ne!(real_id, placeholder_id, "adoption re-derived the id under the real repo_id");
+    assert_eq!(
+        bound_logical_symbol_id(&conn),
+        real_id,
+        "the pre-V040 memory survives adoption, still bound to the symbol under its real-repo id"
+    );
+}
+
+// --- LocalOnly → Portable id upgrade (deepened shallow clone; #413 round-4 finding #4) ---
+
+/// A DB first indexed under a machine-local `local:` id (a cut shallow clone) must UPGRADE in place
+/// when the caller deepens it (`git fetch --unshallow` — our own remedy) and re-opens under a
+/// portable id: every scoped row, `repo_meta`, `repo_roots`, and logical-symbol id re-points from
+/// the local id to the portable one, and a bound memory survives (its `logical_symbol_id` follows
+/// the realign). Without this the deepened clone would hit the "different real repo" refusal and
+/// the existing index could never open again without deletion — a dead end.
+#[test]
+fn register_repo_upgrades_a_local_only_id_to_a_portable_id_in_place() {
+    // A REAL git repo supplies the upgrade PROOF (round-6 P2 #4): the incoming deepened clone's
+    // HEAD must reach the incumbent's recorded shallow boundary. The DB (in-memory) and the
+    // repo are decoupled — register_repo re-points rows in `conn` while verifying ancestry
+    // against `repo`.
+    let repo = real_git_repo("upgrade-in-place");
+    let boundary = head_commit_hash(&repo);
+
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    seed_pre_v040_core_schema(&conn);
+    // A file + a logical symbol with a bound memory — the rows the upgrade must re-point + realign.
+    conn.execute(
+        "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms) VALUES \
+         ('src/lib.rs', 'rust', 'source', 'a', 0, 0)",
+        [],
+    )
+    .unwrap();
+    seed_pre_v040_logical_symbol_with_a_bound_memory(&conn, 777_001);
+
+    schema::apply_repo_id_core_scoping(&conn).expect("V040 applies (unadopted → placeholder id)");
+
+    // First registration: a cut shallow clone adopts under a machine-local id AND records its
+    // shallow boundary (the proof material a later upgrade verifies against).
+    let local_id = "local:deadbeefcafef00d";
+    register_repo(&conn, &identity_local(local_id, "shallow", vec![boundary]), repo.as_path(), 1)
+        .unwrap();
+    assert_eq!(schema::sole_repo_id(&conn).unwrap(), local_id, "adopted under the LocalOnly id");
+    let local_symbol_id = bound_logical_symbol_id(&conn);
+
+    // Deepen + re-open: the incoming identity is now Portable and its HEAD reaches the recorded
+    // boundary → PROVEN → UPGRADE, not a refusal.
+    let portable_id = "0abc123root";
+    register_repo(&conn, &identity(portable_id, "deepened"), repo.as_path(), 2)
+        .expect("a PROVEN Portable id against a local: incumbent UPGRADES in place, not refused");
+
+    // The portable id now solely owns the DB; the local id is gone.
+    assert_eq!(schema::sole_repo_id(&conn).unwrap(), portable_id, "portable id owns the DB");
+    assert_eq!(repo_row_count(&conn, local_id), 0, "the machine-local repos row is gone");
+    assert_eq!(repo_row_count(&conn, portable_id), 1, "exactly the portable repos row remains");
+    // Scoped rows + the recorded root re-pointed off the local id.
+    assert_eq!(
+        conn.query_row("SELECT repo_id FROM files", [], |r| r.get::<_, String>(0)).unwrap(),
+        portable_id,
+        "the file row re-pointed to the portable id",
+    );
+    assert_eq!(root_count(&conn, local_id), 0, "no root left under the local id");
+    assert_eq!(root_count(&conn, portable_id), 1, "the root moved to the portable id");
+    // The logical id re-derived under the portable fold, and the bound memory followed it.
+    let portable_symbol_id: i64 =
+        conn.query_row("SELECT id FROM logical_symbols", [], |r| r.get(0)).unwrap();
+    assert_ne!(portable_symbol_id, local_symbol_id, "the id re-derived under the portable repo_id");
+    assert_eq!(
+        bound_logical_symbol_id(&conn),
+        portable_symbol_id,
+        "the bound memory survives the upgrade, still resolving to the same symbol",
+    );
+    let _ = fs::remove_dir_all(&repo);
+}
+
+/// A real git repo (two empty commits) for the upgrade-proof tests — its HEAD is a commit a genuine
+/// deepened clone would reach.
+fn real_git_repo(tag: &str) -> PathBuf {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+    run_git(&root, &["init", "-q", "-b", "main"]);
+    run_git(&root, &["config", "user.email", "t@e"]);
+    run_git(&root, &["config", "user.name", "t"]);
+    run_git(&root, &["commit", "-q", "--allow-empty", "-m", &format!("{tag}-one")]);
+    run_git(&root, &["commit", "-q", "--allow-empty", "-m", &format!("{tag}-two")]);
+    root
+}
+
+/// The full HEAD commit hash — a commit reachable from HEAD, used as a recorded shallow boundary.
+fn head_commit_hash(root: &Path) -> String {
+    let out = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "git rev-parse HEAD failed");
+    String::from_utf8(out.stdout).unwrap().trim().to_string()
+}
+
+/// PROOF is REQUIRED, not just a `local:` prefix (round-6 P2 #4): a DB first indexed from a cut
+/// shallow clone of repo X, later opened from an UNRELATED full repo Y at the same DB path, must be
+/// REFUSED — Y's HEAD reaches NONE of X's boundary commits, so re-pointing the index onto Y's id
+/// would migrate one repo's data onto another. The refusal names the pin escape hatch.
+#[test]
+fn register_repo_refuses_a_portable_upgrade_from_an_unrelated_repo() {
+    let repo_x = real_git_repo("origin-x");
+    let x_boundary = head_commit_hash(&repo_x);
+    let repo_y = real_git_repo("unrelated-y"); // an independent root — no shared history with X.
+
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    let local_id = "local:beefbeefcafe";
+    register_repo(
+        &conn,
+        &identity_local(local_id, "shallow", vec![x_boundary]),
+        repo_x.as_path(),
+        1,
+    )
+    .expect("the shallow clone of X adopts under its local id, recording X's boundary");
+
+    let err = register_repo(&conn, &identity("y-portable-root", "y"), repo_y.as_path(), 2)
+        .expect_err(
+            "an unrelated repo's HEAD does not reach X's boundary → the upgrade is refused",
+        );
+    let msg = err.to_string();
+    assert!(msg.contains("could not prove"), "refusal explains the missing proof: {msg}");
+    assert!(msg.contains("repo_id"), "refusal names the pin escape hatch: {msg}");
+    assert_eq!(schema::sole_repo_id(&conn).unwrap(), local_id, "the incumbent is untouched");
+    assert_eq!(repo_row_count(&conn, "y-portable-root"), 0, "the unrelated id never landed");
+    let _ = fs::remove_dir_all(&repo_x);
+    let _ = fs::remove_dir_all(&repo_y);
+}
+
+/// No recorded shallow boundary ⇒ no proof available ⇒ refuse. A `local:` incumbent registered
+/// before the proof gate (or with an unknown boundary) cannot be upgraded on faith, even by a
+/// genuine deepened clone; the actionable error points at the `[index] repo_id` pin to force it.
+#[test]
+fn register_repo_refuses_a_local_upgrade_without_a_recorded_boundary() {
+    let repo = real_git_repo("no-boundary");
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    // Register the local incumbent with an EMPTY boundary — nothing to prove against.
+    let local_id = "local:nobound00";
+    register_repo(&conn, &identity_local(local_id, "shallow", vec![]), repo.as_path(), 1).expect(
+        "a LocalOnly registration succeeds even without a boundary — the gate is at UPGRADE",
+    );
+
+    let err = register_repo(&conn, &identity("would-be-portable", "p"), repo.as_path(), 2)
+        .expect_err("no recorded boundary ⇒ no proof ⇒ the upgrade is refused");
+    assert!(err.to_string().contains("repo_id"), "refusal names the pin remedy: {err}");
+    assert_eq!(schema::sole_repo_id(&conn).unwrap(), local_id, "the incumbent is untouched");
+    let _ = fs::remove_dir_all(&repo);
+}
+
+/// The upgrade is NARROW: only a `local:` incumbent upgrades. Two genuinely-different PORTABLE
+/// repos still trip the single-repo refusal — a Portable incoming must never silently re-point a
+/// Portable incumbent (that would be data loss across two real repos).
+#[test]
+fn register_repo_refuses_a_portable_incoming_against_a_portable_incumbent() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    register_repo(&conn, &identity("portable-a", "a"), Path::new("/src/a"), 1).unwrap();
+
+    let err = register_repo(&conn, &identity("portable-b", "b"), Path::new("/src/b"), 2)
+        .expect_err("a second portable repo is refused — only a local: incumbent upgrades");
+    assert!(err.to_string().contains("portable-a"), "refusal names the incumbent: {err}");
+    assert_eq!(schema::sole_repo_id(&conn).unwrap(), "portable-a", "incumbent untouched");
+    assert_eq!(repo_row_count(&conn, "portable-b"), 0, "the intruder never landed");
+}
+
+/// A `LocalOnly` incoming against an existing REAL repo is refused — a deepened clone (or a second
+/// shallow clone) must never DOWNGRADE a portable id back to machine-local. The upgrade only runs
+/// in the Portable direction.
+#[test]
+fn register_repo_refuses_a_local_only_incoming_against_a_real_incumbent() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    register_repo(&conn, &identity("portable-a", "a"), Path::new("/src/a"), 1).unwrap();
+
+    let err = register_repo(
+        &conn,
+        &identity_local("local:beef", "shallow", vec![]),
+        Path::new("/src/s"),
+        2,
+    )
+    .expect_err("a LocalOnly incoming must not downgrade a portable incumbent");
+    assert!(err.to_string().contains("portable-a"), "refusal names the incumbent: {err}");
+    assert_eq!(schema::sole_repo_id(&conn).unwrap(), "portable-a", "portable id stays");
+    assert_eq!(repo_row_count(&conn, "local:beef"), 0, "the local id never landed");
+}
+
+/// End-to-end: a real cut shallow clone is indexed under a `local:` id, then `git fetch
+/// --unshallow` makes the portable root reachable, and re-opening UPGRADES the existing index in
+/// place — the registered id flips to the portable root hash, the `local:` id is gone, and a memory
+/// bound to an indexed symbol still resolves. This is the exact path the LocalOnly warning tells
+/// the user to take; it must not strand their index.
+#[test]
+fn unshallow_upgrades_a_shallow_clone_index_from_local_to_portable_in_place() {
+    let base = unique_temp_root();
+    let _ = fs::remove_dir_all(&base);
+    let origin = base.join("origin");
+    fs::create_dir_all(origin.join("src")).unwrap();
+    fs::write(origin.join("src/lib.rs"), "pub fn shallow_anchor() {}\n").unwrap();
+    run_git(&origin, &["init", "-q", "-b", "main"]);
+    run_git(&origin, &["config", "user.email", "t@e"]);
+    run_git(&origin, &["config", "user.name", "t"]);
+    run_git(&origin, &["add", "."]);
+    run_git(&origin, &["commit", "-q", "-m", "one"]);
+    run_git(&origin, &["commit", "-q", "--allow-empty", "-m", "two"]);
+    // The portable id the deepened clone must resolve to: origin has full history, so its identity
+    // is the (Portable) root-commit hash — the exact id `git fetch --unshallow` makes reachable
+    // again.
+    let origin_root = crate::repo_identity::resolve_repo_identity(&origin, None).unwrap().repo_id;
+
+    // --depth 1 < history: a genuinely CUT shallow clone (root unreachable → LocalOnly id).
+    let url = format!("file://{}", origin.display());
+    run_git(&base, &["clone", "-q", "--depth", "1", &url, "clone"]);
+    let clone_root = base.join("clone");
+
+    let config = source_config(clone_root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).expect("index the shallow clone under a LocalOnly id");
+    let local_id = db.active_repo_id.clone();
+    assert!(
+        local_id.starts_with("local:"),
+        "shallow clone indexes under a local: id, got {local_id}"
+    );
+
+    // Bind a memory to an indexed logical symbol so we can prove it survives the id realign.
+    let symbol_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT id FROM logical_symbols LIMIT 1", [], |r| r.get(0))
+        .expect("the shallow clone indexed at least one logical symbol");
+    let symbol_name: String = db
+        .storage
+        .connection()
+        .query_row("SELECT logical_name FROM logical_symbols WHERE id = ?1", [symbol_id], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    // A real memory row + a binding to the indexed symbol (the FK + NOT NULL columns the actual
+    // schema carries). The upgrade's realign must re-point this binding as `logical_symbols.id`
+    // changes under the portable fold.
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO repo_memories(id, kind, title, body, confidence, status, created_at_ms, \
+             updated_at_ms, source, memory_version) VALUES ('mem-upgrade', 'Invariant', 't', 'b', \
+             'high', 'active', 0, 0, 'agent', 'v1')",
+            [],
+        )
+        .unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id, \
+             logical_symbol_id, anchor_status, created_at_ms) VALUES ('mem-upgrade', \
+             'logical_symbol', 'b1', ?1, 'current', 0)",
+            [symbol_id],
+        )
+        .unwrap();
+    drop(db);
+
+    // Deepen the clone: the real root becomes reachable, so identity is now Portable (the root
+    // hash).
+    run_git(&clone_root, &["fetch", "-q", "--unshallow"]);
+
+    // Re-open the EXISTING index (not a rebuild): register_repo detects local: incumbent + Portable
+    // incoming → upgrade in place.
+    let reopened = IndexDatabase::open_config(&config)
+        .expect("re-opening a deepened clone upgrades the index, it does not refuse");
+    assert_eq!(reopened.active_repo_id, origin_root, "upgraded to the portable root-commit id");
+    assert!(!reopened.active_repo_id.starts_with("local:"), "no longer a machine-local id");
+    assert_eq!(
+        repo_row_count(reopened.storage.connection(), &local_id),
+        0,
+        "the machine-local repos row is gone after the upgrade",
+    );
+    // The bound memory survived: its (realigned) logical_symbol_id still resolves to the same
+    // symbol.
+    let resolved_name: String = reopened
+        .storage
+        .connection()
+        .query_row(
+            "SELECT ls.logical_name FROM repo_memory_bindings b
+               JOIN logical_symbols ls ON ls.id = b.logical_symbol_id
+              WHERE b.memory_id = 'mem-upgrade'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("the memory binding still resolves after the in-place upgrade");
+    assert_eq!(resolved_name, symbol_name, "the memory resolves to the same symbol post-upgrade");
+    let _ = fs::remove_dir_all(base);
+}
+
+// --- Read-path repo resolution without registering (#413 round-4 findings #1 + #2) ---
+
+/// `resolve_config_repo_id` (the read-path resolver behind the read-only open + the raw scope-view
+/// hooks) binds the repo a config's ROOT is recorded under, NOT the config-blind sole repo. In a
+/// consolidated DB the sole pick could be a sibling; the recorded-root route keeps a read scoped to
+/// the config's own repo even for a non-git root that has no derivable identity.
+#[test]
+fn resolve_config_repo_id_binds_a_recorded_root_over_the_sole_pick() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    // Repo A adopted (sorts first). A sibling repo B seeded directly with its recorded root — the
+    // A7 consolidated shape (register_repo forbids a second real repo before A7).
+    register_repo(&conn, &identity("repo-a", "a"), Path::new("/src/a"), 1).unwrap();
+    conn.execute(
+        "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('sibling-b', 'b', 0)",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO repo_roots(repo_id, root, registered_at_ms) VALUES ('sibling-b', ?1, 0)",
+        [Path::new("/src/b").to_string_lossy().as_ref()],
+    )
+    .unwrap();
+
+    // The config-blind sole pick is repo-a (lexicographically smallest) — the WRONG repo for
+    // /src/b.
+    assert_eq!(schema::sole_repo_id(&conn).unwrap(), "repo-a");
+    // The resolver binds the repo the ROOT is recorded under (a non-git root → the by-root route).
+    assert_eq!(
+        schema::resolve_config_repo_id(&conn, Path::new("/src/b"), None).unwrap().as_deref(),
+        Some("sibling-b"),
+        "a recorded root binds its own repo, not the smaller sole pick",
+    );
+    // A single-repo DB with an unrecorded, non-git root still falls back to the sole repo
+    // (preserves the pre-A3 read fast path) — asserted here by an unknown root resolving to
+    // None on this CONSOLIDATED DB (>1 real repo → cannot prove, bind nothing rather than a
+    // sibling).
+    assert_eq!(
+        schema::resolve_config_repo_id(&conn, Path::new("/src/unknown"), None).unwrap(),
+        None,
+        "an unprovable root on a consolidated DB resolves to None (never a sibling)",
+    );
+}
+
+/// A `Rejected` config (a reserved `[index] repo_id` pin) resolves to `None` on the read path — it
+/// must NOT silently bind a repo; the read-write open surfaces the actionable error instead.
+#[test]
+fn resolve_config_repo_id_returns_none_for_a_rejected_pin() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+    run_git(&root, &["init", "-q", "-b", "main"]);
+    run_git(&root, &["config", "user.email", "t@e"]);
+    run_git(&root, &["config", "user.name", "t"]);
+    run_git(&root, &["commit", "-q", "--allow-empty", "-m", "genesis"]);
+
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    register_repo(&conn, &identity("repo-a", "a"), root.as_path(), 1).unwrap();
+
+    // A reserved pin is the Rejected class → None, even though the root is a real registered repo.
+    assert_eq!(
+        schema::resolve_config_repo_id(&conn, &root, Some(LEGACY_REPO_ID)).unwrap(),
+        None,
+        "a reserved-id pin does not resolve on the read path — it surfaces via the read-write open",
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+/// #413 round-5: a NEW, unregistered `[index] repo_id` pin resolves to `None` on the read path —
+/// NOT to the repo the root was previously registered under. A changed identity must adopt/surface
+/// on the read-write open; the read-only path declining is what forces that, instead of silently
+/// serving the old scope under the new pin.
+#[test]
+fn resolve_config_repo_id_returns_none_for_a_new_unregistered_pin() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+    run_git(&root, &["init", "-q", "-b", "main"]);
+    run_git(&root, &["config", "user.email", "t@e"]);
+    run_git(&root, &["config", "user.name", "t"]);
+    run_git(&root, &["commit", "-q", "--allow-empty", "-m", "genesis"]);
+
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    // The root is registered (and recorded) under repo-a — so the pre-fix by-root fallback would
+    // resolve the new pin to repo-a.
+    register_repo(&conn, &identity("repo-a", "a"), root.as_path(), 1).unwrap();
+
+    assert_eq!(
+        schema::resolve_config_repo_id(&conn, &root, Some("brand-new-pin")).unwrap(),
+        None,
+        "a new unregistered pin declines on the read path — it does not bind the old (repo-a) \
+         scope",
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+/// #413 round-5, the shallow-upgrade sibling case: a repo registered under a `local:` id whose
+/// full-history root now derives a DIFFERENT (portable) id. `resolve_config_repo_id` with no pin
+/// derives the unregistered portable id and must return `None` — the LocalOnly→Portable upgrade
+/// belongs on the read-write path (`register_repo`), not a silent read-path rebind to the old
+/// `local:` scope.
+#[test]
+fn resolve_config_repo_id_returns_none_for_a_newly_portable_local_incumbent() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+    run_git(&root, &["init", "-q", "-b", "main"]);
+    run_git(&root, &["config", "user.email", "t@e"]);
+    run_git(&root, &["config", "user.name", "t"]);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "one"]);
+
+    // The portable id the full-history root derives (what a deepened clone would resolve to).
+    let portable_id = crate::repo_identity::resolve_repo_identity(&root, None).unwrap().repo_id;
+    assert!(!portable_id.starts_with("local:"), "full history → a portable root id");
+
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    // Incumbent: registered (and root recorded) under a machine-local id, as a prior shallow index.
+    register_repo(&conn, &identity_local("local:beef", "shallow", vec![]), root.as_path(), 1)
+        .unwrap();
+    assert!(!repo_id_is_registered_probe(&conn, &portable_id), "portable id is not yet registered");
+
+    // No pin: the identity route derives the portable id (unregistered) → None. The pre-fix by-root
+    // fallback would rebind to the incumbent `local:beef`.
+    assert_eq!(
+        schema::resolve_config_repo_id(&conn, &root, None).unwrap(),
+        None,
+        "a newly-portable identity declines on the read path — upgrade happens on the write path",
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+/// Test-local probe: is `repo_id` a registered real repo? (mirrors the private
+/// `repo_id_is_registered`, kept here so the test above needn't expose it.)
+fn repo_id_is_registered_probe(conn: &rusqlite::Connection, repo_id: &str) -> bool {
+    conn.query_row("SELECT EXISTS(SELECT 1 FROM repos WHERE repo_id = ?1)", [repo_id], |r| r.get(0))
+        .unwrap()
+}
+
+// --- Identity-resolution error classes at the open_config boundary (A3) ---
+
+/// A pinned RESERVED `[index] repo_id` must SURFACE from `open_config` — the `Rejected` class of
+/// `RepoIdentityError`. The old blanket fallback silently scoped the DB to the placeholder, hiding
+/// the configuration problem and leaving every row unadopted under the legacy id.
+#[test]
+fn open_config_surfaces_a_reserved_repo_id_pin() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    let mut config = source_config(root.clone(), Language::Rust);
+    config.repo_id_override = Some(LEGACY_REPO_ID.to_string());
+    // `open_config` opens an EXISTING index (a Missing schema refuses); create it first, exactly
+    // like the `rag-rat index` → later plain opens sequence.
+    IndexDatabase::migrate(&config.database).unwrap();
+
+    let err = IndexDatabase::open_config(&config)
+        .expect_err("a reserved-id pin is a rejection, never a silent placeholder fallback");
+    assert!(err.to_string().contains("reserved"), "error names the rejection: {err}");
+    let _ = fs::remove_dir_all(root);
+}
+
+/// A cut shallow clone (its root commit unreachable, so a derived id would be depth-dependent) does
+/// NOT fail through `open_config`: it adopts under a deterministic `local:`-prefixed LocalOnly id
+/// and proceeds. Blocking a `--depth 1` checkout would break CI fixtures for no benefit — the id is
+/// stable on this machine, only not portable across machines (the sync layer enforces that later).
+#[test]
+fn open_config_adopts_a_shallow_clone_under_a_local_only_id() {
+    let base = unique_temp_root();
+    let _ = fs::remove_dir_all(&base);
+    let origin = base.join("origin");
+    fs::create_dir_all(origin.join("src")).unwrap();
+    fs::write(origin.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
+    run_git(&origin, &["init", "-q", "-b", "main"]);
+    run_git(&origin, &["config", "user.email", "t@e"]);
+    run_git(&origin, &["config", "user.name", "t"]);
+    run_git(&origin, &["add", "."]);
+    run_git(&origin, &["commit", "-q", "-m", "one"]);
+    run_git(&origin, &["commit", "-q", "--allow-empty", "-m", "two"]);
+    // --depth 1 < history: the clone's root commit is unreachable (a genuinely CUT shallow clone).
+    let url = format!("file://{}", origin.display());
+    run_git(&base, &["clone", "-q", "--depth", "1", &url, "clone"]);
+    let clone_root = base.join("clone");
+
+    let config = source_config(clone_root, Language::Rust);
+    IndexDatabase::migrate(&config.database).unwrap();
+    let db = IndexDatabase::open_config(&config)
+        .expect("a cut shallow clone adopts under a LocalOnly id, it does not fail");
+    assert!(
+        db.active_repo_id.starts_with("local:"),
+        "a cut shallow clone adopts under a LocalOnly id, got {}",
+        db.active_repo_id
+    );
+    // Adopted as a real repo: the placeholder is gone and the LocalOnly id owns the registry.
+    assert_eq!(repo_row_count(db.storage.connection(), LEGACY_REPO_ID), 0, "placeholder adopted");
+    assert_eq!(
+        repo_row_count(db.storage.connection(), &db.active_repo_id),
+        1,
+        "LocalOnly repo row"
+    );
+    let _ = fs::remove_dir_all(base);
+}
+
+/// A NON-git root (no identity to derive at all) is the EXPECTED-absence class: `open_config`
+/// still opens, scoped to the sole repo of the single-repo DB (the placeholder on a fresh one) —
+/// the pre-A3 behavior every bare temp-dir index relies on.
+#[test]
+fn open_config_falls_back_to_the_sole_repo_on_a_non_git_root() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    IndexDatabase::migrate(&config.database).unwrap();
+
+    let db = IndexDatabase::open_config(&config)
+        .expect("expected absence (not a git repo) falls back, it does not error");
+    assert_eq!(
+        db.active_repo_id, LEGACY_REPO_ID,
+        "the un-adopted single-repo DB scopes to the placeholder"
+    );
+    let _ = fs::remove_dir_all(root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
@@ -522,6 +522,8 @@ fn worktree_overlay_gc_prunes_a_removed_worktrees_overlay() {
     db.garbage_collect().unwrap();
     assert_eq!(overlay_row_count(&db), 0, "GC prunes a removed worktree's overlay");
 
+    // Post-condition: a repo-scoped GC must not touch a SIBLING repo's rows (round-6 harness).
+    crate::index::poison_sibling::assert_sibling_intact(db.storage.connection());
     let _ = fs::remove_dir_all(&main);
     let _ = fs::remove_dir_all(&linked);
 }
@@ -775,9 +777,10 @@ fn worktree_overlay_fts_freshness_revision_is_scope_invariant() {
     // And it matches the stored `fts_source_revision` `sync_fts` wrote during the overlay refresh,
     // so a base read sees FTS as fresh (no rebuild) rather than perpetually stale.
     assert_eq!(
-        db.repo_meta("fts_source_revision").unwrap().as_deref(),
+        db.meta("fts_source_revision").unwrap().as_deref(),
         Some(base_revision.as_str()),
-        "fts_source_revision recorded during the overlay pass matches the global digest",
+        "fts_source_revision (GLOBAL, in index_meta) recorded during the overlay pass matches the \
+         global digest",
     );
     assert!(!db.fts_dirty().unwrap(), "the overlay refresh left FTS clean, not dirty");
 
@@ -1157,14 +1160,16 @@ fn orientation_in_a_linked_worktree_reflects_the_overlay_on_base() {
 
     let conn = IndexConnection::open_read_only(&db_path).unwrap();
     // Worktree cwd: overlay ON base = base.rs + keep.rs + the overlay's added.rs = 3.
-    let o_wt = crate::query::orientation::orientation(conn.connection(), &main, &linked).unwrap();
+    let o_wt =
+        crate::query::orientation::orientation(conn.connection(), &main, &linked, None).unwrap();
     assert_eq!(
         o_wt.total_files, 3,
         "worktree orientation must show base files + the overlay's added file"
     );
 
     // Main cwd: base scope only = 2.
-    let o_main = crate::query::orientation::orientation(conn.connection(), &main, &main).unwrap();
+    let o_main =
+        crate::query::orientation::orientation(conn.connection(), &main, &main, None).unwrap();
     assert_eq!(o_main.total_files, 2, "main orientation shows the base scope");
 
     let _ = fs::remove_dir_all(&main);

--- a/crates/rag-rat-core/src/index/util.rs
+++ b/crates/rag-rat-core/src/index/util.rs
@@ -15,6 +15,24 @@ pub(crate) fn table_row_count(conn: &rusqlite::Connection, table: &str) -> anyho
     Ok(u64::try_from(count).unwrap_or(0))
 }
 
+/// `table_row_count` for a directly-`repo_id`-scoped table: counts only the rows owned by `repo_id`
+/// (the active repo), so a status/freshness read reports THIS repo's totals rather than the union
+/// across every repo in a consolidated DB. `table` is always an internal string literal, never user
+/// input, and MUST carry a `repo_id` column (the V040 direct-scoped tables — git_commits,
+/// git_file_changes, and their siblings).
+pub(crate) fn scoped_table_row_count(
+    conn: &rusqlite::Connection,
+    table: &str,
+    repo_id: &str,
+) -> anyhow::Result<u64> {
+    let count = conn.query_row(
+        &format!("SELECT COUNT(*) FROM main.{table} WHERE repo_id = ?1"),
+        [repo_id],
+        |row| row.get::<_, i64>(0),
+    )?;
+    Ok(u64::try_from(count).unwrap_or(0))
+}
+
 /// Whether `text` contains a test marker — the file-level `files.has_test_code` signal that lets
 /// `impact_surface`'s "tests touching this symbol" query filter on an indexed flag instead of a
 /// `chunks.text LIKE` scan (#77). INVARIANT: this marker set MUST match the V024 backfill SQL in

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -373,9 +373,10 @@ impl IndexDatabase {
             let mut tombstoned = 0;
             for path in &delta.tombstones {
                 let exists: bool = self.storage.connection().query_row(
-                    "SELECT EXISTS(SELECT 1 FROM main.files WHERE path = ?1 AND commit_sha = '' \
-                     AND worktree_id = ?2 AND kind = 'deleted')",
-                    params![path_string(path), worktree_id],
+                    // Direct `main.files` probe → explicit `repo_id` predicate (A3).
+                    "SELECT EXISTS(SELECT 1 FROM main.files WHERE repo_id = ?1 AND path = ?2 AND \
+                     commit_sha = '' AND worktree_id = ?3 AND kind = 'deleted')",
+                    params![self.active_repo_id, path_string(path), worktree_id],
                     |row| row.get(0),
                 )?;
                 if !exists {
@@ -496,7 +497,11 @@ impl IndexDatabase {
         self.apply_incremental_file_plan(files, BTreeSet::new(), progress)
     }
 
-    /// Existing file rows in a scope as `path → sha256` — for the idle-safe skip above.
+    /// Existing file rows in a scope as `path → sha256` — for the idle-safe skip above. A direct
+    /// `main.files` probe (bypasses the repo-scoped view), so it carries the `repo_id` predicate
+    /// explicitly (A3): today's sole caller passes a non-empty (path-derived, globally unique)
+    /// `worktree_id`, but this is the documented reusable primitive — a base-scope caller
+    /// (`commit_sha`, `''`) would otherwise skip files on the strength of a fork sibling's sha.
     fn scope_file_shas(
         &self,
         commit_sha: &str,
@@ -504,11 +509,13 @@ impl IndexDatabase {
     ) -> anyhow::Result<HashMap<String, String>> {
         let conn = self.storage.connection();
         let mut stmt = conn.prepare(
-            "SELECT path, sha256 FROM main.files WHERE commit_sha = ?1 AND worktree_id = ?2",
+            "SELECT path, sha256 FROM main.files
+             WHERE repo_id = ?1 AND commit_sha = ?2 AND worktree_id = ?3",
         )?;
-        let rows = stmt.query_map(params![commit_sha, worktree_id], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-        })?;
+        let rows = stmt
+            .query_map(params![self.active_repo_id, commit_sha, worktree_id], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?;
         rows.collect::<Result<HashMap<_, _>, _>>().map_err(Into::into)
     }
 
@@ -521,10 +528,15 @@ impl IndexDatabase {
     ) -> anyhow::Result<usize> {
         let existing: Vec<String> = {
             let conn = self.storage.connection();
+            // Direct `main.files` probe → explicit `repo_id` predicate (A3), same class as the
+            // heal probes in `incremental.rs`.
             let mut stmt = conn.prepare(
-                "SELECT path FROM main.files WHERE worktree_id = ?1 AND worktree_id != ''",
+                "SELECT path FROM main.files
+                 WHERE repo_id = ?1 AND worktree_id = ?2 AND worktree_id != ''",
             )?;
-            let rows = stmt.query_map([worktree_id], |row| row.get::<_, String>(0))?;
+            let rows = stmt.query_map(params![self.active_repo_id, worktree_id], |row| {
+                row.get::<_, String>(0)
+            })?;
             rows.collect::<Result<Vec<_>, _>>()?
         };
         let mut pruned = 0usize;

--- a/crates/rag-rat-core/src/query/clusters.rs
+++ b/crates/rag-rat-core/src/query/clusters.rs
@@ -281,16 +281,20 @@ fn co_touch_pairs(
     rows: &[FileBriefRow],
 ) -> anyhow::Result<BTreeMap<PathPair, u64>> {
     let path_index = path_index(rows);
+    // `git_file_changes` is direct-scoped (V040); the `files` view join is by PATH, so the
+    // explicit `repo_id` predicate is what keeps a sibling repo's co-touch history for a shared
+    // path out of this repo's clusters in a consolidated DB.
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     let mut stmt = conn.prepare(
         "
         SELECT git_file_changes.commit_hash, git_file_changes.path
         FROM git_file_changes
         JOIN files ON files.path = git_file_changes.path
-        WHERE (?1 OR files.generated = 0)
+        WHERE (?1 OR files.generated = 0) AND git_file_changes.repo_id = ?2
         ORDER BY git_file_changes.commit_hash, git_file_changes.path
         ",
     )?;
-    let mut query_rows = stmt.query([include_generated])?;
+    let mut query_rows = stmt.query((include_generated, &repo_id))?;
     let mut pairs = BTreeMap::<PathPair, u64>::new();
     let mut current_commit = String::new();
     let mut paths = Vec::new();

--- a/crates/rag-rat-core/src/query/impact/historical.rs
+++ b/crates/rag-rat-core/src/query/impact/historical.rs
@@ -1,9 +1,11 @@
 use super::*;
 
 pub(crate) fn parser_failure_count(conn: &Connection) -> anyhow::Result<u64> {
-    let count: i64 =
-        conn.query_row("SELECT COUNT(*) FROM parser_failures", [], |row| row.get(0))?;
-    Ok(u64::try_from(count).unwrap_or(0))
+    // `parser_failures` is direct-scoped (V040): count only the ACTIVE repo's failures, matching
+    // the scoped `IndexDatabase::parser_failure_count` twin — a sibling repo's parse failures must
+    // not depress this repo's graph-coverage confidence in a consolidated DB.
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    crate::index::scoped_table_row_count(conn, "parser_failures", &repo_id)
 }
 
 pub(crate) fn historical_evidence(
@@ -43,6 +45,10 @@ pub(crate) fn git_commits_for_paths(
     if budget == 0 {
         return Ok(());
     }
+    // `git_commits` / `git_file_changes` are direct-scoped (V040); join AND filter on `repo_id` so
+    // a consolidated DB never attributes a sibling repo's history to this path (a fork shares
+    // hashes).
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     let mut added = 0usize;
     let mut stmt = conn.prepare(
         "
@@ -50,8 +56,9 @@ pub(crate) fn git_commits_for_paths(
                git_commits.hash, git_commits.subject, git_commits.authored_at_s
         FROM git_file_changes
         JOIN git_commits ON git_commits.hash = git_file_changes.commit_hash
+                        AND git_commits.repo_id = git_file_changes.repo_id
         LEFT JOIN files ON files.path = git_file_changes.path
-        WHERE git_file_changes.path = ?1
+        WHERE git_file_changes.path = ?1 AND git_file_changes.repo_id = ?3
         ORDER BY git_commits.authored_at_s DESC, git_commits.hash
         LIMIT ?2
         ",
@@ -62,8 +69,9 @@ pub(crate) fn git_commits_for_paths(
         }
         let before = surface.len();
         let file = file_for_path(conn, path)?;
-        let rows =
-            stmt.query_map(params![path, i64::try_from(budget).unwrap_or(i64::MAX)], |row| {
+        let rows = stmt.query_map(
+            params![path, i64::try_from(budget).unwrap_or(i64::MAX), repo_id],
+            |row| {
                 Ok((
                     row.get::<_, Option<String>>(0)?,
                     row.get::<_, Option<String>>(1)?,
@@ -72,7 +80,8 @@ pub(crate) fn git_commits_for_paths(
                     row.get::<_, String>(4)?,
                     row.get::<_, i64>(5)?,
                 ))
-            })?;
+            },
+        )?;
         for row in rows {
             let (row_path, language, kind, hash, subject, authored_at_s) = row?;
             let file_symbol = FileSymbol {

--- a/crates/rag-rat-core/src/query/memory/validate.rs
+++ b/crates/rag-rat-core/src/query/memory/validate.rs
@@ -69,15 +69,24 @@ pub(crate) fn validate_logical_symbol_binding(
         }
         return validate_bound_chunk(conn, binding);
     }
+    // Scope the qualified-name relocation to the ACTIVE repo. `logical_symbols` is direct-scoped by
+    // `repo_id` (V040) and its ids are repo-distinct, so a consolidated DB can hold the SAME
+    // qualified name under a sibling repo. Without the predicate, validating repo A's memory (whose
+    // remembered symbol was deleted/renamed) could rebind it to repo B's logical id/path and report
+    // `relocated` instead of `gone`/`stale`. The `files`-view queries elsewhere in this module are
+    // repo-scoped for free through the scope view; `logical_symbols` is a direct table, so it needs
+    // the explicit filter.
+    let active_repo_id = crate::index::schema::active_repo_id(conn)?;
     let relocated = conn
         .query_row(
             "
             SELECT id, path
             FROM logical_symbols
             WHERE qualified_name_id = (SELECT id FROM name_strings WHERE value = ?1)
+              AND repo_id = ?2
             LIMIT 1
             ",
-            [&binding.binding_id],
+            params![&binding.binding_id, active_repo_id],
             |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
         )
         .optional()?;
@@ -415,7 +424,7 @@ pub(crate) fn validate_path_binding(
 /// active checkout root and only falls back to this (#98 review).
 fn persisted_source_root(conn: &Connection) -> Option<PathBuf> {
     // `source_root` moved to `repo_meta` (V039); resolve the active repo (the lone one in phase A).
-    let repo_id = crate::index::schema::single_repo_id(conn).ok()?;
+    let repo_id = crate::index::schema::active_repo_id(conn).ok()?;
     crate::index::repo_meta(conn, &repo_id, "source_root").ok().flatten().map(PathBuf::from)
 }
 

--- a/crates/rag-rat-core/src/query/orientation.rs
+++ b/crates/rag-rat-core/src/query/orientation.rs
@@ -1,4 +1,4 @@
-use rusqlite::Connection;
+use rusqlite::{Connection, params};
 
 use crate::index::AnchorHealth;
 use crate::query::tree::DirTree;
@@ -52,6 +52,7 @@ pub fn orientation(
     conn: &Connection,
     config_root: &std::path::Path,
     cwd: &std::path::Path,
+    repo_id_override: Option<&str>,
 ) -> anyhow::Result<Orientation> {
     // Step 1: install the WORKTREE-AWARE scoping view. `config_root` (the main worktree, where the
     // shared base index lives) anchors the base commit; `cwd` is the session's working dir — when
@@ -59,7 +60,18 @@ pub fn orientation(
     // otherwise the base scope (#219). Using the worktree's own HEAD as the base (the old
     // `resolve_git_context(cwd)`) was wrong: the index has no committed scope at a linked
     // worktree's HEAD, so orientation saw only the bare overlay delta.
-    crate::index::install_worktree_scope_view(conn, config_root, cwd)?;
+    //
+    // Resolve the REPO dimension explicitly from `config_root` (the raw conn has no scope context
+    // to fall back on, and the config-blind sole repo would be a sibling in a consolidated DB).
+    // Thread the config's `[index] repo_id` override: a fork that PINS an id while sharing a root
+    // commit with its upstream would otherwise mis-resolve — `resolve_config_repo_id`'s identity
+    // route derives the shared root-commit id from `None`, and if the upstream is also registered
+    // it binds the SIBLING's scope, ignoring the pin (round-5 finding). With the override, the
+    // pinned id resolves first. An unprovable repo → empty scope (matches nothing), never a
+    // sibling.
+    let repo_id = crate::index::resolve_scope_repo_id(conn, config_root, repo_id_override)?
+        .unwrap_or_default();
+    crate::index::install_worktree_scope_view(conn, &repo_id, config_root, cwd)?;
 
     // Step 2: directory tree (reads scoped `files` view).
     let tree = crate::query::tree::dir_tree(conn, &Default::default())?;
@@ -136,17 +148,21 @@ fn spine_load_bearing(conn: &Connection, limit: usize) -> anyhow::Result<Vec<(St
 /// READ: subjects of the most recent indexed commits, newest first.
 ///
 /// Invariant: reads `git_commits` — no writes.  Returns an empty Vec when no commits are
-/// indexed (git_commits is empty).
+/// indexed (git_commits is empty for the active repo).
 fn recent_commit_subjects(conn: &Connection, limit: usize) -> anyhow::Result<Vec<String>> {
+    // `git_commits` is direct-scoped (V040): orientation describes the ACTIVE repo, so a sibling
+    // repo's commit subjects must not surface in a consolidated DB.
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     let mut stmt = conn.prepare(
-        "-- Most recent indexed commit subjects, newest first.
-         -- Invariant: git_commits rows are global (not scoped); subjects only.
+        "-- Most recent indexed commit subjects for the active repo, newest first.
+         -- Invariant: git_commits is direct-scoped by repo_id (V040); subjects only.
          SELECT subject
          FROM git_commits
+         WHERE repo_id = ?2
          ORDER BY authored_at_s DESC, committed_at_s DESC
          LIMIT ?1",
     )?;
-    let rows = stmt.query_map([limit as i64], |row| row.get::<_, String>(0))?;
+    let rows = stmt.query_map(params![limit as i64, repo_id], |row| row.get::<_, String>(0))?;
     let mut out = Vec::new();
     for row in rows {
         out.push(row?);
@@ -160,18 +176,22 @@ fn recent_commit_subjects(conn: &Connection, limit: usize) -> anyhow::Result<Vec
 /// Returns an empty Vec when git history is not indexed.
 /// Only returns paths of files that are currently indexed (inner join to scoped `files`).
 fn recently_changed_source_files(conn: &Connection, limit: usize) -> anyhow::Result<Vec<String>> {
+    // The `files` view join bounds output to this repo's indexed paths, but the join key is the
+    // PATH — a sibling repo's git rows for a shared path (`src/lib.rs` in two repos) would still
+    // match, so the direct-scoped tables (V040) carry the explicit `repo_id` predicate too.
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     let mut stmt = conn.prepare(
         "-- Most recently changed source paths that are currently indexed in the active scope.
-         -- Invariant: files resolves to the scoped TEMP VIEW; git_file_changes is global.
+         -- Invariant: files resolves to the scoped TEMP VIEW; git rows filter repo_id (V040).
          SELECT DISTINCT gfc.path
          FROM git_file_changes AS gfc
-         JOIN git_commits AS gc ON gc.hash = gfc.commit_hash
+         JOIN git_commits AS gc ON gc.hash = gfc.commit_hash AND gc.repo_id = gfc.repo_id
          JOIN files ON files.path = gfc.path
-         WHERE files.generated = 0
+         WHERE files.generated = 0 AND gfc.repo_id = ?2
          ORDER BY gc.authored_at_s DESC, gfc.path ASC
          LIMIT ?1",
     )?;
-    let rows = stmt.query_map([limit as i64], |row| row.get::<_, String>(0))?;
+    let rows = stmt.query_map(params![limit as i64, repo_id], |row| row.get::<_, String>(0))?;
     let mut out = Vec::new();
     for row in rows {
         out.push(row?);

--- a/crates/rag-rat-core/src/query/repo_brief.rs
+++ b/crates/rag-rat-core/src/query/repo_brief.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use rusqlite::{Connection, OptionalExtension, Row};
 use serde::Serialize;
 
-use crate::index::table_row_count;
+use crate::index::scoped_table_row_count;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RepoBriefMode {
@@ -504,9 +504,23 @@ pub(crate) fn summary_counts(conn: &Connection) -> anyhow::Result<SummaryCounts>
         conn.query_row("SELECT COUNT(*), COALESCE(SUM(generated), 0) FROM files", [], |row| {
             Ok((row_u64(row, 0)?, row_u64(row, 1)?))
         })?;
-    let graph_edges = table_row_count(conn, "edges")?;
-    let git_commits = table_row_count(conn, "git_commits")?;
-    let git_file_changes = table_row_count(conn, "git_file_changes")?;
+    // `graph_edges` / `git_commits` / `git_file_changes` are all scoped to the ACTIVE repo: the
+    // brief describes ONE repo, so its counts must not report the union across a consolidated
+    // DB. `files` above flows through the repo-scoped view; `git_commits` / `git_file_changes`
+    // are direct-scoped (V040). `edges` has no `repo_id` of its own — it is attributed
+    // transitively through `source_file_id → main.files.repo_id` (the same join
+    // `lexical::graph_boost` and `ensure_graph_index_current`'s scoped delete use), so count it
+    // that way rather than via the global `edges` compatibility view (round-5 finding).
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    let graph_edges: u64 = conn.query_row(
+        "SELECT COUNT(*) FROM edges_data e
+           JOIN main.files f ON f.id = e.source_file_id
+          WHERE f.repo_id = ?1",
+        [&repo_id],
+        |row| row_u64(row, 0),
+    )?;
+    let git_commits = scoped_table_row_count(conn, "git_commits", &repo_id)?;
+    let git_file_changes = scoped_table_row_count(conn, "git_file_changes", &repo_id)?;
     let memories = memory_counts(conn, None)?;
     Ok(SummaryCounts {
         total_files,
@@ -524,6 +538,11 @@ pub(crate) fn file_rows(
 ) -> anyhow::Result<Vec<FileBriefRow>> {
     let newest_commit = newest_commit_time(conn)?;
     let recent_floor = newest_commit.saturating_sub(90 * 24 * 60 * 60);
+    // The churn CTE reads the direct-scoped `git_file_changes` / `git_commits` (V040); the
+    // `repo_id` predicate keeps a sibling repo's churn for a SHARED path (two repos both having
+    // `src/lib.rs`) out of this repo's brief — the outer LEFT JOIN is by path, so the scoped
+    // `files` view alone cannot exclude it.
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     let mut stmt = conn.prepare(
         "
         WITH file_size AS (
@@ -560,6 +579,8 @@ pub(crate) fn file_rows(
                  COALESCE(SUM(git_file_changes.deletions), 0) AS deletions
           FROM git_file_changes
           JOIN git_commits ON git_commits.hash = git_file_changes.commit_hash
+                          AND git_commits.repo_id = git_file_changes.repo_id
+          WHERE git_file_changes.repo_id = ?3
           GROUP BY git_file_changes.path
         ),
         github_ref_counts AS (
@@ -590,7 +611,7 @@ pub(crate) fn file_rows(
         ",
     )?;
 
-    let rows = stmt.query_map((recent_floor, include_generated), |row| {
+    let rows = stmt.query_map((recent_floor, include_generated, repo_id), |row| {
         Ok(FileBriefRow {
             path: row.get(0)?,
             language: row.get(1)?,
@@ -653,8 +674,15 @@ fn enrich_rows<T: Clone + Default>(
 }
 
 fn newest_commit_time(conn: &Connection) -> anyhow::Result<i64> {
+    // Direct-scoped (V040): the recency floor tracks the ACTIVE repo's newest commit, not a more
+    // recently indexed sibling's.
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     Ok(conn
-        .query_row("SELECT MAX(authored_at_s) FROM git_commits", [], |row| row.get(0))
+        .query_row(
+            "SELECT MAX(authored_at_s) FROM git_commits WHERE repo_id = ?1",
+            [&repo_id],
+            |row| row.get(0),
+        )
         .optional()?
         .flatten()
         .unwrap_or(0))

--- a/crates/rag-rat-core/src/repo_identity.rs
+++ b/crates/rag-rat-core/src/repo_identity.rs
@@ -1,41 +1,127 @@
 //! Machine-stable repo identity: a content-derived `repo_id` (the repo's root-commit hash) plus a
-//! cosmetic display name. This id is what the consolidated global database scopes every repo's
-//! rows and memories by (memory-sync phase A). It is deliberately derived from the commit graph,
-//! not the on-disk path, so worktrees, clones, and re-clones of the same repo share one identity.
+//! cosmetic display name and a [`RepoIdentityClass`] portability tag. This id is what the
+//! consolidated global database scopes every repo's rows and memories by (memory-sync phase A). It
+//! is deliberately derived from the commit graph, not the on-disk path, so worktrees, clones, and
+//! re-clones of the same repo share one identity.
+//!
+//! A repo whose full history is present derives a `Portable` id (the same on every machine — the
+//! identity family sync can trust). A shallow clone whose history was CUT cannot reach its root, so
+//! it derives a deterministic-but-depth-dependent `LocalOnly` id from the shallow boundary instead
+//! of failing: indexing must not be blocked by a shallow checkout (CI fixtures, `--depth 1`
+//! clones). The portability class travels with the identity so the future sync layer can refuse to
+//! replicate a `LocalOnly` id; open-time never hard-rejects a shallow clone.
 
 use std::path::Path;
 
 use crate::index::schema::LEGACY_REPO_ID;
 
-/// A repo's identity for the registry: the scoping key + a human label.
+/// The prefix every machine-local [`LocalOnly`](RepoIdentityClass::LocalOnly) id carries (a cut
+/// shallow clone's boundary hash). RESERVED: the resolver only ever mints it for a shallow clone,
+/// and `register_repo` keys the LocalOnly→Portable upgrade off it (an incumbent id starting with
+/// this prefix, being re-pointed to an incoming `Portable` id, is a deepened clone). Pinning a
+/// `local:`-prefixed `[index] repo_id` is therefore refused — it would collide with that detection.
+pub const LOCAL_ONLY_ID_PREFIX: &str = "local:";
+
+/// Whether a repo's identity is portable across machines (safe for family sync) or only stable on
+/// THIS machine's clone. Open-time resolution NEVER hard-rejects a shallow clone — it downgrades
+/// the class instead — so the hard "portable required" gate lives in the sync layer, not here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepoIdentityClass {
+    /// Machine-stable: derived from the repo's root commit, or an explicit `[index] repo_id` pin.
+    /// The same repo resolves to the same id on every machine, so family sync can replicate it.
+    Portable,
+    /// Deterministic on THIS clone but depth-dependent: a shallow clone whose history was cut, so
+    /// the root commit is unreachable and the id is derived from the shallow BOUNDARY commits
+    /// instead. Two clones of one repo at different depths derive DIFFERENT ids, so this id must
+    /// never cross machines. The remedy is `git fetch --unshallow` (recovers the real root) or a
+    /// pinned `repo_id`; until then indexing proceeds locally under the `local:` id.
+    LocalOnly,
+}
+
+/// A repo's identity for the registry: the scoping key + a human label + its portability class.
 #[derive(Debug, Clone)]
 pub struct RepoIdentity {
-    /// Machine-stable, content-derived (root-commit hash) unless pinned via `rag-rat.toml`. Never
-    /// derived from the on-disk path.
+    /// Machine-stable, content-derived (root-commit hash) unless pinned via `rag-rat.toml`, or a
+    /// `local:`-prefixed boundary hash for a cut shallow clone. Never derived from the on-disk
+    /// path.
     pub repo_id: String,
     /// The working-tree directory name — cosmetic only, never an identity input.
     pub display_name: String,
+    /// Whether [`repo_id`](Self::repo_id) is portable across machines (family sync eligible) or
+    /// only stable on this clone (a cut shallow clone). Never an identity input; a
+    /// scoping-neutral tag.
+    pub class: RepoIdentityClass,
+    /// For a [`LocalOnly`](RepoIdentityClass::LocalOnly) id, the SORTED shallow-boundary commit
+    /// hashes the id was derived from; EMPTY for a `Portable` id (a full history or a pin has no
+    /// boundary). `register_repo` persists these at LocalOnly registration so a later
+    /// LocalOnly→Portable upgrade can PROVE the incoming deepened clone is the same repository —
+    /// its HEAD must reach these boundary commits ([`boundary_reachable_from_head`]). Never an
+    /// identity input; the id is already a hash OF this boundary.
+    pub shallow_boundary: Vec<String>,
+}
+
+/// Why [`resolve_repo_identity`] could not derive a `repo_id`, split into the two classes its one
+/// production caller (`IndexDatabase::adopt_repo_from_config`) MUST treat differently. Stringly
+/// matching the message to tell them apart is not acceptable — the variant is the contract.
+///
+/// A cut shallow clone is DELIBERATELY not in here: since it derives a [`LocalOnly`] id rather than
+/// failing, it is an `Ok` outcome, not an error. `Rejected` therefore covers only genuinely-invalid
+/// inputs (a pinned reserved id, an unreadable / structurally-rootless history).
+///
+/// [`LocalOnly`]: RepoIdentityClass::LocalOnly
+#[derive(Debug, thiserror::Error)]
+pub enum RepoIdentityError {
+    /// EXPECTED absence: the directory simply has no identity to derive yet — it is not a git
+    /// repository, or it has an unborn HEAD (zero commits). This is the ordinary shape of a
+    /// config-less / temp-dir / test index, so the caller falls back to the sole registered repo
+    /// and leaves the DB single-repo and un-adopted (the pre-A3 behavior).
+    #[error("{0}")]
+    Absent(String),
+    /// A user-actionable REJECTION that MUST surface, never silently fall back: a pinned reserved
+    /// id, or an unreadable / root-less history (a walk failure, or a non-shallow graph with no
+    /// reachable parentless commit). Falling back here would scope the DB to the placeholder and
+    /// hide the real configuration problem, leaving every row unadopted under the legacy id.
+    #[error("{0}")]
+    Rejected(String),
+}
+
+impl RepoIdentityError {
+    /// Whether this is the EXPECTED-absence class a config-less single-repo open may fall back on
+    /// (not a git repo / unborn HEAD), as opposed to a [`Rejected`](Self::Rejected) config that
+    /// must surface. The one predicate the registry adoption path branches on.
+    pub fn is_absent(&self) -> bool {
+        matches!(self, Self::Absent(_))
+    }
 }
 
 /// Resolve a repo's identity from its working tree at `root`.
 ///
 /// The default `repo_id` is the **lexicographically smallest root-commit hash** reachable from
-/// HEAD. A linear history has exactly one root (parentless) commit; a history stitched from
-/// several orphan branches has several, and choosing the smallest by byte order makes the id
-/// deterministic across machines regardless of which root the walk reaches first.
+/// HEAD (a [`Portable`](RepoIdentityClass::Portable) id). A linear history has exactly one root
+/// (parentless) commit; a history stitched from several orphan branches has several, and choosing
+/// the smallest by byte order makes the id deterministic across machines regardless of which root
+/// the walk reaches first.
 ///
-/// `override_id` (from `rag-rat.toml`'s `[index] repo_id`) wins outright when set and non-empty —
-/// the escape hatch for forks that must NOT share identity with their upstream, and for pinning an
-/// id on a repo whose root is unreachable (an empty repo, or a shallow clone that cut history).
+/// `override_id` (from `rag-rat.toml`'s `[index] repo_id`) wins outright when set and non-empty — a
+/// `Portable` id by construction (the user chose a stable string). It is the escape hatch for forks
+/// that must NOT share identity with their upstream, and for pinning an id on a repo whose root is
+/// unreachable (an empty repo, or a shallow clone that cut history).
+///
+/// A shallow clone whose history was CUT (its root is unreachable) does NOT error: it derives a
+/// deterministic [`LocalOnly`](RepoIdentityClass::LocalOnly) id from the sorted shallow-boundary
+/// commits, logs one warning naming the future sync constraint, and proceeds. Blocking indexing on
+/// a shallow checkout would break CI fixtures and `--depth 1` clones for no benefit — the id is
+/// stable on this machine, only not across machines.
 ///
 /// Errors — each with an actionable remedy — when no override was supplied and the id cannot be
-/// derived: the directory is not a git repository, the repo has no commits (unborn HEAD), or its
-/// history is a cut shallow clone (the root is unreachable, so any derived id would depend on clone
-/// depth and split identity across machines).
+/// derived, split by [`RepoIdentityError`] class: [`Absent`](RepoIdentityError::Absent) for the
+/// directory not being a git repository or having no commits (unborn HEAD);
+/// [`Rejected`](RepoIdentityError::Rejected) for a pinned reserved id or an unreadable / root-less
+/// history.
 pub fn resolve_repo_identity(
     root: &Path,
     override_id: Option<&str>,
-) -> anyhow::Result<RepoIdentity> {
+) -> Result<RepoIdentity, RepoIdentityError> {
     let display_name =
         root.file_name().map(|name| name.to_string_lossy().into_owned()).unwrap_or_default();
 
@@ -44,13 +130,39 @@ pub fn resolve_repo_identity(
         // degenerate registry adoption (see `register_repo`). Refuse with a remedy-naming error
         // rather than mint an identity that can never be adopted.
         if id == LEGACY_REPO_ID {
-            anyhow::bail!(reserved_repo_id_error());
+            return Err(RepoIdentityError::Rejected(reserved_repo_id_error()));
         }
-        return Ok(RepoIdentity { repo_id: id.to_string(), display_name });
+        // The `local:` prefix is reserved for machine-derived shallow-clone ids: `register_repo`
+        // keys its LocalOnly→Portable upgrade off an incumbent id carrying it, so a pinned
+        // `local:`-prefixed id would be ambiguously treated as upgradeable. Refuse it with a
+        // remedy.
+        if id.starts_with(LOCAL_ONLY_ID_PREFIX) {
+            return Err(RepoIdentityError::Rejected(reserved_local_prefix_error()));
+        }
+        // A pinned id is portable by construction — the user chose a stable string.
+        return Ok(RepoIdentity {
+            repo_id: id.to_string(),
+            display_name,
+            class: RepoIdentityClass::Portable,
+            shallow_boundary: Vec::new(),
+        });
     }
 
-    let repo_id = smallest_root_commit(root)?;
-    Ok(RepoIdentity { repo_id, display_name })
+    let (repo_id, class, shallow_boundary) = derive_repo_id(root)?;
+    if class == RepoIdentityClass::LocalOnly {
+        // ONE warning per resolution, naming the future constraint and both remedies. The id is
+        // usable NOW (single-repo indexing on this machine); the warning is about family sync,
+        // which will refuse a non-portable id.
+        tracing::warn!(
+            repo_id = %repo_id,
+            root = %root.display(),
+            "shallow clone: derived a machine-local repo identity because the root commit is \
+             unreachable (history is cut). Indexing proceeds, but family sync requires a portable \
+             identity — run `git fetch --unshallow` to derive the stable root-commit id, or pin \
+             `[index] repo_id` in rag-rat.toml."
+        );
+    }
+    Ok(RepoIdentity { repo_id, display_name, class, shallow_boundary })
 }
 
 /// The remedy-naming error for pinning the reserved placeholder id: it marks a pre-adoption
@@ -66,30 +178,64 @@ fn reserved_repo_id_error() -> String {
     )
 }
 
-/// The lexicographically smallest hash among the parentless commits reachable from HEAD. Mirrors
-/// the git-history walk (`index::git_history`): discover the repo, resolve HEAD, `rev_walk`, and
-/// keep the commits whose first parent is absent.
+/// The remedy-naming error for pinning a `local:`-prefixed id: the prefix is reserved for
+/// machine-derived shallow-clone ids, and `register_repo` treats an incumbent id carrying it as
+/// upgradeable to a portable id — pinning one would be ambiguous.
+fn reserved_local_prefix_error() -> String {
+    format!(
+        "the `{LOCAL_ONLY_ID_PREFIX}` prefix is reserved for machine-derived shallow-clone repo \
+         ids and cannot be pinned via `[index] repo_id` in rag-rat.toml. Choose a different \
+         stable string, or omit the override to derive the id from the root commit."
+    )
+}
+
+/// Derive the `repo_id` and its portability class from the commit graph at `root`.
 ///
-/// Refuses (with an actionable error) when no parentless root is reachable — the exact signature of
-/// a shallow clone that CUT history: gix reads parents from the commit object and does not apply
-/// shallow grafts, so the boundary commit reports parents whose objects are absent (never a root),
-/// while the walk itself honors the boundary and yields no true root. Deriving an id from that
-/// boundary would make identity depend on clone depth, so we reject rather than mint a
-/// depth-varying id. A shallow clone whose depth COVERS the whole history keeps its true root
-/// reachable and resolves normally — hence the "no reachable root" signal rather than
+/// The default id is the lexicographically smallest hash among the parentless commits reachable
+/// from HEAD (a [`Portable`](RepoIdentityClass::Portable) id) — mirrors the git-history walk
+/// (`index::git_history`): discover the repo, resolve HEAD, `rev_walk`, keep the commits whose
+/// first parent is absent.
+///
+/// When NO parentless root is reachable — the exact signature of a shallow clone that CUT history
+/// (gix reads parents from the commit object and does not apply shallow grafts, so the boundary
+/// commit reports parents whose objects are absent, never a root, while the walk itself honors the
+/// boundary and yields no true root) — it derives a [`LocalOnly`](RepoIdentityClass::LocalOnly) id
+/// from the sorted shallow-boundary commits instead of failing. That id is stable across opens of
+/// THIS clone but varies with clone depth, hence the non-portable class. A non-shallow graph with
+/// no reachable root is genuinely corrupt and is [`Rejected`](RepoIdentityError::Rejected). A
+/// shallow clone whose depth COVERS the whole history keeps its true root reachable and resolves
+/// normally to a `Portable` id — hence the "no reachable root" signal rather than
 /// `repo.is_shallow()` alone, which is also set for those fully-present clones.
-fn smallest_root_commit(root: &Path) -> anyhow::Result<String> {
-    let repo = crate::index::discover_repo(root)?;
-    // Unborn HEAD (`git init` with no commits) has no history to derive an id from.
+fn derive_repo_id(
+    root: &Path,
+) -> Result<(String, RepoIdentityClass, Vec<String>), RepoIdentityError> {
+    // Not a git repository at all → the EXPECTED-absence class (config-less temp dirs, tests).
+    let repo = crate::index::discover_repo(root).map_err(|err| {
+        RepoIdentityError::Absent(format!(
+            "cannot derive a repo_id: {} is not a git repository ({err}). Run `git init`, or pin \
+             `[index] repo_id = \"…\"` in rag-rat.toml.",
+            root.display()
+        ))
+    })?;
+    // Unborn HEAD (`git init` with no commits) has no history to derive an id from — also the
+    // expected-absence class.
     let Ok(head) = repo.head_id() else {
-        anyhow::bail!(empty_repo_error(root));
+        return Err(RepoIdentityError::Absent(empty_repo_error(root)));
     };
     let head_id = head.detach();
 
+    // A history that EXISTS but cannot be read is not "no identity yet" — it must surface, so the
+    // walk failures below are the Rejected class, never a silent fallback.
+    let walk_failed = |err: &dyn std::fmt::Display| {
+        RepoIdentityError::Rejected(format!(
+            "cannot derive a repo_id: failed to walk the history at {}: {err}",
+            root.display()
+        ))
+    };
     let mut roots: Vec<String> = Vec::new();
-    for info in repo.rev_walk([head_id]).all()? {
-        let info = info?;
-        let commit = repo.find_commit(info.id)?;
+    for info in repo.rev_walk([head_id]).all().map_err(|err| walk_failed(&err))? {
+        let info = info.map_err(|err| walk_failed(&err))?;
+        let commit = repo.find_commit(info.id).map_err(|err| walk_failed(&err))?;
         // A root commit has no parents; `parent_ids().next().is_none()` is the same predicate the
         // history walk uses to detect roots. A cut shallow boundary reports (absent) parents, so it
         // is deliberately NOT counted here.
@@ -99,27 +245,86 @@ fn smallest_root_commit(root: &Path) -> anyhow::Result<String> {
     }
     roots.sort();
     if let Some(smallest) = roots.into_iter().next() {
-        return Ok(smallest);
+        return Ok((smallest, RepoIdentityClass::Portable, Vec::new()));
     }
 
-    // No reachable parentless root: a cut shallow clone (the common case) or a corrupt object
-    // graph.
-    if repo.is_shallow() {
-        anyhow::bail!(shallow_clone_error(root));
+    // No reachable parentless root. A cut shallow clone records its boundary in `.git/shallow`
+    // (gix exposes it, already SORTED for bisecting); derive a deterministic LocalOnly id from it
+    // rather than failing. A graph with neither a root NOR a shallow boundary is genuinely corrupt.
+    match repo.shallow_commits() {
+        Ok(Some(boundary)) => {
+            // Carry the sorted boundary hashes alongside the id so `register_repo` can persist them
+            // for the later upgrade-proof check; the id is a hash OF exactly these bytes.
+            let hashes = boundary_hashes(&boundary);
+            Ok((local_only_id_from_hashes(&hashes), RepoIdentityClass::LocalOnly, hashes))
+        },
+        Ok(None) => Err(RepoIdentityError::Rejected(format!(
+            "repository at {} has no reachable root commit and is not a shallow clone (corrupt or \
+             root-less history). Pin `[index] repo_id = \"…\"` in rag-rat.toml to index it anyway.",
+            root.display()
+        ))),
+        Err(err) => Err(RepoIdentityError::Rejected(format!(
+            "cannot derive a repo_id: failed to read the shallow boundary at {}: {err}",
+            root.display()
+        ))),
     }
-    anyhow::bail!("repository at {} has no reachable root commit", root.display());
 }
 
-/// The remedy-naming error for a shallow clone that cut history: identity would depend on clone
-/// depth, so refuse and point at the two fixes (unshallow, or pin the id).
-fn shallow_clone_error(root: &Path) -> String {
-    format!(
-        "cannot derive a stable repo_id from the shallow clone at {}: its history is cut, so the \
-         root commit is unreachable and any derived id would depend on clone depth (splitting \
-         this repo's identity across machines). Run `git fetch --unshallow`, or pin `[index] \
-         repo_id = \"…\"` in rag-rat.toml.",
-        root.display()
-    )
+/// The shallow-boundary commit hashes as sorted hex strings. gix keeps `.git/shallow` sorted (for
+/// bisecting), so the order is deterministic across opens of the SAME clone.
+fn boundary_hashes(boundary: &gix::shallow::Commits) -> Vec<String> {
+    boundary.iter().map(|id| id.to_hex().to_string()).collect()
+}
+
+/// A deterministic `local:`-prefixed id hashed from the SORTED shallow-boundary commit hashes. Two
+/// opens of the SAME clone hash the identical byte sequence and derive the same id — the
+/// determinism the `LocalOnly` class promises. A DEEPER clone of the same repo has a different
+/// boundary and thus a different id, which is exactly why the id is not portable across machines.
+/// Kept byte-for-byte compatible with the pre-refactor derivation (sorted hashes joined by `\n`,
+/// then sha256).
+fn local_only_id_from_hashes(hashes: &[String]) -> String {
+    let mut material = String::new();
+    for hash in hashes {
+        material.push_str(hash);
+        material.push('\n');
+    }
+    format!("{LOCAL_ONLY_ID_PREFIX}{}", crate::index::hex_sha256(material.as_bytes()))
+}
+
+/// Whether EVERY commit in `boundary` is reachable from the repository's HEAD at `root` — the PROOF
+/// that a deepened clone is the same repository as a `LocalOnly` incumbent whose recorded shallow
+/// boundary these hashes are. A `git fetch --unshallow` (or deeper fetch) keeps the old boundary
+/// commits in history (they are real commits, now with their parents present), so they stay
+/// ancestors of HEAD; an UNRELATED repo's HEAD reaches none of them. `register_repo` gates the
+/// LocalOnly→Portable upgrade on this so it never re-points a local index onto a genuinely
+/// different repo's id.
+///
+/// An empty `boundary` is never provable (returns `false`): the caller treats "no recorded
+/// boundary" as no proof. Errors surface (the caller refuses on them) rather than silently
+/// upgrading. Walks HEAD's ancestry once, short-circuiting as soon as every boundary commit is
+/// found — mirrors [`derive_repo_id`]'s `rev_walk`.
+pub(crate) fn boundary_reachable_from_head(
+    root: &Path,
+    boundary: &[String],
+) -> anyhow::Result<bool> {
+    if boundary.is_empty() {
+        return Ok(false);
+    }
+    let repo = crate::index::discover_repo(root).map_err(|err| {
+        anyhow::anyhow!("cannot open the repository at {}: {err}", root.display())
+    })?;
+    let head = repo
+        .head_id()
+        .map_err(|err| anyhow::anyhow!("cannot resolve HEAD at {}: {err}", root.display()))?;
+    let mut needed: std::collections::HashSet<&str> = boundary.iter().map(String::as_str).collect();
+    for info in repo.rev_walk([head.detach()]).all()? {
+        let info = info?;
+        needed.remove(info.id.to_hex().to_string().as_str());
+        if needed.is_empty() {
+            return Ok(true);
+        }
+    }
+    Ok(needed.is_empty())
 }
 
 /// The remedy-naming error for an empty repo (unborn HEAD): there is no commit graph to derive
@@ -189,6 +394,7 @@ mod tests {
 
         let identity = resolve_repo_identity(&root, None).unwrap();
         assert_eq!(identity.repo_id, expected[0]);
+        assert_eq!(identity.class, RepoIdentityClass::Portable, "a full history is portable");
         assert_eq!(identity.display_name, root.file_name().unwrap().to_string_lossy());
         std::fs::remove_dir_all(&root).ok();
     }
@@ -209,6 +415,7 @@ mod tests {
 
         let identity = resolve_repo_identity(&root, None).unwrap();
         assert_eq!(identity.repo_id, roots[0], "smallest root hash by byte order wins");
+        assert_eq!(identity.class, RepoIdentityClass::Portable);
         std::fs::remove_dir_all(&root).ok();
     }
 
@@ -221,11 +428,17 @@ mod tests {
 
         let identity = resolve_repo_identity(&root, Some("  pinned-id  ")).unwrap();
         assert_eq!(identity.repo_id, "pinned-id", "override is trimmed and wins");
+        assert_eq!(
+            identity.class,
+            RepoIdentityClass::Portable,
+            "a pin is portable by construction"
+        );
         assert_ne!(identity.repo_id, derived);
 
         // An empty/whitespace override falls through to the derived id.
         let blank = resolve_repo_identity(&root, Some("   ")).unwrap();
         assert_eq!(blank.repo_id, derived);
+        assert_eq!(blank.class, RepoIdentityClass::Portable);
         std::fs::remove_dir_all(&root).ok();
     }
 
@@ -241,6 +454,7 @@ mod tests {
 
         let err = resolve_repo_identity(&root, Some(LEGACY_REPO_ID))
             .expect_err("the reserved placeholder id must not be pinnable");
+        assert!(!err.is_absent(), "a reserved pin is the Rejected class — it must propagate");
         let msg = err.to_string();
         assert!(msg.contains(LEGACY_REPO_ID), "error names the reserved value: {msg}");
         assert!(msg.contains("reserved"), "error explains it is reserved: {msg}");
@@ -250,6 +464,28 @@ mod tests {
         let err_padded = resolve_repo_identity(&root, Some(&padded))
             .expect_err("the trimmed reserved id is still refused");
         assert!(err_padded.to_string().contains("reserved"), "{err_padded}");
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// The `local:` prefix is reserved for machine-derived shallow-clone ids: `register_repo` keys
+    /// its LocalOnly→Portable upgrade off an incumbent id carrying it, so a pinned
+    /// `local:`-prefixed id would be ambiguous. The resolver refuses it (the `Rejected` class),
+    /// like the placeholder.
+    #[test]
+    fn override_with_the_reserved_local_prefix_is_refused() {
+        let root = temp_root();
+        init_repo(&root);
+        git(&root, &["commit", "--allow-empty", "-q", "-m", "genesis"]);
+
+        let err = resolve_repo_identity(&root, Some("local:deadbeef"))
+            .expect_err("a `local:`-prefixed pin must be refused");
+        assert!(
+            !err.is_absent(),
+            "a reserved-prefix pin is the Rejected class — it must propagate"
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("local:"), "error names the reserved prefix: {msg}");
+        assert!(msg.contains("reserved"), "error explains it is reserved: {msg}");
         std::fs::remove_dir_all(&root).ok();
     }
 
@@ -269,33 +505,48 @@ mod tests {
     }
 
     /// A genuinely-cut shallow clone (`--depth` < history) has no reachable parentless root: the
-    /// boundary commit records parents whose objects are absent. Deriving an id from the boundary
-    /// would make identity depend on clone depth and split it across machines — so it is REFUSED,
-    /// with an error naming both remedies (`git fetch --unshallow` or a pinned `repo_id`).
+    /// boundary commit records parents whose objects are absent. Rather than fail (which would
+    /// block indexing a `--depth 1` checkout — CI fixtures, quick clones), it derives a
+    /// DETERMINISTIC `local:`-prefixed [`LocalOnly`] id from the sorted shallow boundary and
+    /// proceeds. The id is stable across opens of the SAME clone; the pin escape hatch still
+    /// overrides it to `Portable`.
     #[test]
-    fn shallow_clone_that_cuts_history_is_refused_with_an_actionable_error() {
+    fn shallow_clone_that_cuts_history_gets_a_deterministic_local_only_id() {
         let base = temp_root();
-        let (shallow, _origin_root) = shallow_clone(&base, 5, 1, "shallow");
+        let (shallow, origin_root) = shallow_clone(&base, 5, 1, "shallow");
         // Sanity: the fixture is really a shallow clone that cut history.
         assert!(crate::index::discover_repo(&shallow).unwrap().is_shallow());
 
-        let err = resolve_repo_identity(&shallow, None)
-            .expect_err("a depth-cut shallow clone must not derive a depth-dependent id");
-        let msg = err.to_string();
-        assert!(msg.contains("shallow"), "error names the cause: {msg}");
-        assert!(msg.contains("git fetch --unshallow"), "error names the unshallow remedy: {msg}");
-        assert!(msg.contains("repo_id"), "error names the pin remedy: {msg}");
+        let identity = resolve_repo_identity(&shallow, None)
+            .expect("a cut shallow clone must NOT fail — it derives a LocalOnly id");
+        assert_eq!(
+            identity.class,
+            RepoIdentityClass::LocalOnly,
+            "a cut shallow clone is LocalOnly"
+        );
+        assert!(
+            identity.repo_id.starts_with("local:"),
+            "a LocalOnly id is `local:`-prefixed, got {}",
+            identity.repo_id
+        );
+        assert_ne!(identity.repo_id, origin_root, "the id is the boundary hash, not the real root");
 
-        // The override escape hatch still lets a shallow clone be pinned deterministically.
+        // DETERMINISTIC across two opens of the same clone (the `.git/shallow` boundary is stable).
+        let again = resolve_repo_identity(&shallow, None).unwrap();
+        assert_eq!(identity.repo_id, again.repo_id, "same clone → same LocalOnly id");
+
+        // The pin escape hatch still overrides a shallow clone to a Portable id.
         let pinned = resolve_repo_identity(&shallow, Some("pinned-shallow")).unwrap();
         assert_eq!(pinned.repo_id, "pinned-shallow");
+        assert_eq!(pinned.class, RepoIdentityClass::Portable, "a pin overrides to Portable");
         std::fs::remove_dir_all(&base).ok();
     }
 
     /// A clone flagged shallow whose `--depth` COVERS the whole history is NOT depth-dependent: the
     /// boundary commit IS the true root (all its ancestors are present), so identity resolves to
-    /// the real root hash and matches the origin. `is_shallow()` alone would wrongly reject
-    /// this; the "no reachable parentless root" signal correctly accepts it.
+    /// the real root hash (a `Portable` id) and matches the origin. `is_shallow()` alone would
+    /// wrongly treat this as LocalOnly; the "no reachable parentless root" signal correctly accepts
+    /// it as portable.
     #[test]
     fn shallow_clone_covering_full_history_resolves_the_real_root() {
         let base = temp_root();
@@ -309,6 +560,7 @@ mod tests {
         let identity = resolve_repo_identity(&shallow, None)
             .expect("full history present → the real root is reachable");
         assert_eq!(identity.repo_id, origin_root, "id is the real root, depth-independent");
+        assert_eq!(identity.class, RepoIdentityClass::Portable, "a covered clone is portable");
         std::fs::remove_dir_all(&base).ok();
     }
 
@@ -321,24 +573,29 @@ mod tests {
 
         let err = resolve_repo_identity(&root, None)
             .expect_err("an empty repo has no commit graph to derive an id from");
+        assert!(err.is_absent(), "an unborn HEAD is the expected-absence class (fallback-safe)");
         let msg = err.to_string();
         assert!(msg.contains("no commits"), "error names the cause: {msg}");
         assert!(msg.contains("repo_id"), "error names the pin remedy: {msg}");
 
-        // A pin still lets an empty repo be registered.
+        // A pin still lets an empty repo be registered (a Portable id).
         let pinned = resolve_repo_identity(&root, Some("pinned-empty")).unwrap();
         assert_eq!(pinned.repo_id, "pinned-empty");
+        assert_eq!(pinned.class, RepoIdentityClass::Portable);
         std::fs::remove_dir_all(&root).ok();
     }
 
     #[test]
     fn non_git_dir_without_override_is_an_error() {
         let root = temp_root(); // created, but never `git init`ed
-        assert!(resolve_repo_identity(&root, None).is_err());
+        let err = resolve_repo_identity(&root, None)
+            .expect_err("a non-git directory has no identity to derive");
+        assert!(err.is_absent(), "not-a-git-repo is the expected-absence class (fallback-safe)");
         // ...but an override lets a non-git dir resolve (a repo with no commits can still be
         // pinned).
         let identity = resolve_repo_identity(&root, Some("pinned")).unwrap();
         assert_eq!(identity.repo_id, "pinned");
+        assert_eq!(identity.class, RepoIdentityClass::Portable);
         std::fs::remove_dir_all(&root).ok();
     }
 }

--- a/crates/rag-rat-core/src/search/lexical.rs
+++ b/crates/rag-rat-core/src/search/lexical.rs
@@ -206,6 +206,12 @@ fn search_with_query_embedding(
     options: SearchOptions,
 ) -> anyhow::Result<Vec<SearchHit>> {
     let terms = query_terms(query);
+    // REPO SCOPING (A3): every candidate row flows through the `files` scope VIEW (both the bm25
+    // and the vector pass JOIN `files`), which filters `repo_id` FIRST — so in a consolidated
+    // DB a sibling repo's chunks are dropped by the INNER JOIN before ranking. `active_repo_id`
+    // is resolved ONCE here and threaded into the git boost queries (which read the
+    // direct-scoped `git_file_changes` by path, bypassing the view).
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     let candidate_limit = i64::from(limit.max(10)).saturating_mul(8);
     let vector_available = query_embedding.is_some();
     let mut ranked = BTreeMap::<i64, RankedHit>::new();
@@ -243,7 +249,7 @@ fn search_with_query_embedding(
     let (graded_git, demotions) = if options.graded_history {
         let paths = ranked.values().map(|hit| hit.hit.path.clone()).collect::<Vec<_>>();
         let chunk_ids = ranked.keys().copied().collect::<Vec<_>>();
-        (graded_git_scores(conn, &paths)?, demotion_flags(conn, &chunk_ids)?)
+        (graded_git_scores(conn, &paths, &repo_id)?, demotion_flags(conn, &chunk_ids)?)
     } else {
         (std::collections::HashMap::new(), std::collections::HashMap::new())
     };
@@ -251,7 +257,7 @@ fn search_with_query_embedding(
     let mut hits = ranked
         .into_values()
         .map(|mut hit| {
-            let boosts = boosts(conn, &hit.hit, &terms, options)?;
+            let boosts = boosts(conn, &hit.hit, &terms, options, &repo_id)?;
             hit.components.symbol = SYMBOL_WEIGHT * boosts.symbol;
             hit.components.graph = GRAPH_WEIGHT * boosts.graph;
             // The git component is the one real lever: under the flag, replace the binary
@@ -510,11 +516,12 @@ fn boosts(
     hit: &SearchHit,
     terms: &[String],
     options: SearchOptions,
+    repo_id: &str,
 ) -> anyhow::Result<BoostComponents> {
-    let historical = historical_boost(conn, &hit.path, options)?;
+    let historical = historical_boost(conn, &hit.path, options, repo_id)?;
     Ok(BoostComponents {
         symbol: symbol_path_boost(hit, terms),
-        graph: graph_boost(conn, hit, terms)?,
+        graph: graph_boost(conn, hit, terms, repo_id)?,
         git: historical.git,
         github: historical.github,
     })
@@ -535,7 +542,12 @@ fn symbol_path_boost(hit: &SearchHit, terms: &[String]) -> f64 {
     boost.min(1.0)
 }
 
-fn graph_boost(conn: &Connection, hit: &SearchHit, terms: &[String]) -> anyhow::Result<f64> {
+fn graph_boost(
+    conn: &Connection,
+    hit: &SearchHit,
+    terms: &[String],
+    repo_id: &str,
+) -> anyhow::Result<f64> {
     let Some(symbol) = hit.symbol_path.as_deref() else {
         return Ok(0.0);
     };
@@ -551,6 +563,14 @@ fn graph_boost(conn: &Connection, hit: &SearchHit, terms: &[String]) -> anyhow::
     // prepare_cached: this runs once per search CANDIDATE (~limit*8); caching collapses ~80
     // cold statement compilations of this multi-join query to one per connection (#79 cold-query
     // prepare cost).
+    // REPO SCOPING (A3): the name-id predicate matches by symbol NAME, which is not repo-unique — a
+    // sibling repo's identically-named symbol would otherwise inject its edges into this hit's
+    // graph score. Constrain each edge to the active repo through its `source_file_id →
+    // files.repo_id` (the same repo predicate the candidate/git reads carry). `source_file_id`
+    // is always set (its FK is `ON DELETE CASCADE`, and every edge is inserted with its file
+    // id), so the `EXISTS` drops no live edge in a single-repo DB. It applies AFTER the
+    // `from_name_id`/`to_name_id` index seek narrows to ≤64 candidate edges, so the hot-path
+    // integer indexes still drive the scan.
     let mut stmt = conn.prepare_cached(
         "
         SELECT ek.value, conf.value, fn.value, tn.value
@@ -559,8 +579,10 @@ fn graph_boost(conn: &Connection, hit: &SearchHit, terms: &[String]) -> anyhow::
         JOIN name_strings conf ON conf.id = d.confidence_id
         LEFT JOIN name_strings fn ON fn.id = d.from_name_id
         JOIN name_strings tn ON tn.id = d.to_name_id
-        WHERE d.from_name_id IN (SELECT id FROM name_strings WHERE value IN (?1, ?2))
-           OR d.to_name_id IN (SELECT id FROM name_strings WHERE value IN (?1, ?2))
+        WHERE (d.from_name_id IN (SELECT id FROM name_strings WHERE value IN (?1, ?2))
+            OR d.to_name_id IN (SELECT id FROM name_strings WHERE value IN (?1, ?2)))
+          AND EXISTS (SELECT 1 FROM main.files f
+                       WHERE f.id = d.source_file_id AND f.repo_id = ?3)
         ORDER BY
             CASE conf.value
                 WHEN 'Exact' THEN 0
@@ -572,7 +594,7 @@ fn graph_boost(conn: &Connection, hit: &SearchHit, terms: &[String]) -> anyhow::
         LIMIT 64
         ",
     )?;
-    let rows = stmt.query_map(params![symbol, qualified], |row| {
+    let rows = stmt.query_map(params![symbol, qualified, repo_id], |row| {
         Ok(GraphEdgeEvidence {
             edge_kind: row.get(0)?,
             confidence: row.get(1)?,
@@ -664,11 +686,16 @@ fn historical_boost(
     conn: &Connection,
     path: &str,
     options: SearchOptions,
+    repo_id: &str,
 ) -> anyhow::Result<HistoricalBoost> {
+    // `git_file_changes` is direct-scoped (V040) and queried by PATH here (bypassing the scope
+    // view), so the `repo_id` predicate keeps a sibling repo's history from boosting a same-named
+    // path in a consolidated DB. (`github_refs` stays global until the papertrail tables gain
+    // `repo_id` in the A4 scoping phase.)
     let git = if options.include_git {
         conn.query_row(
-            "SELECT COUNT(*) FROM git_file_changes WHERE path = ?1 LIMIT 1",
-            [path],
+            "SELECT COUNT(*) FROM git_file_changes WHERE path = ?1 AND repo_id = ?2 LIMIT 1",
+            params![path, repo_id],
             |row| row.get::<_, i64>(0),
         )?
     } else {
@@ -707,18 +734,25 @@ fn git_score(recent_touch_count: i64, commit_touch_count: i64) -> f64 {
 fn graded_git_scores(
     conn: &Connection,
     paths: &[String],
+    repo_id: &str,
 ) -> anyhow::Result<std::collections::HashMap<String, f64>> {
     let mut scores = std::collections::HashMap::new();
     if paths.is_empty() {
         return Ok(scores);
     }
-    let newest_commit: i64 =
-        conn.query_row("SELECT COALESCE(MAX(authored_at_s), 0) FROM git_commits", [], |row| {
-            row.get(0)
-        })?;
+    // `git_commits` / `git_file_changes` are direct-scoped (V040); the newest-commit floor and the
+    // churn aggregate both filter `repo_id` so a consolidated DB grades against THIS repo's history
+    // only (a fork shares hashes and paths).
+    let newest_commit: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(authored_at_s), 0) FROM git_commits WHERE repo_id = ?1",
+        params![repo_id],
+        |row| row.get(0),
+    )?;
     // Resolve the 90-day recency floor ONCE per query (not per path).
     let recent_floor = newest_commit.saturating_sub(RECENT_WINDOW_SECS);
     let placeholders = std::iter::repeat_n("?", paths.len()).collect::<Vec<_>>().join(", ");
+    // ?1 = recent_floor, ?2..?(paths.len()+1) = paths, ?(paths.len()+2) = repo_id.
+    let repo_index = paths.len() + 2;
     let sql = format!(
         "
         SELECT git_file_changes.path,
@@ -727,16 +761,19 @@ fn graded_git_scores(
          recent_touch_count
         FROM git_file_changes
         JOIN git_commits ON git_commits.hash = git_file_changes.commit_hash
+                        AND git_commits.repo_id = git_file_changes.repo_id
         WHERE git_file_changes.path IN ({placeholders})
+          AND git_file_changes.repo_id = ?{repo_index}
         GROUP BY git_file_changes.path
         "
     );
     let mut stmt = conn.prepare(&sql)?;
-    let mut params = Vec::<&dyn rusqlite::ToSql>::with_capacity(paths.len() + 1);
+    let mut params = Vec::<&dyn rusqlite::ToSql>::with_capacity(paths.len() + 2);
     params.push(&recent_floor);
     for path in paths {
         params.push(path);
     }
+    params.push(&repo_id);
     let rows = stmt.query_map(params.as_slice(), |row| {
         let path: String = row.get(0)?;
         let commit_touch_count: i64 = row.get(1)?;
@@ -897,8 +934,10 @@ mod tests {
                 "EXPLAIN QUERY PLAN
                  SELECT ek.value FROM edges_data d
                  JOIN name_strings ek ON ek.id = d.edge_kind_id
-                 WHERE d.from_name_id IN (SELECT id FROM name_strings WHERE value IN ('a', 'b'))
-                    OR d.to_name_id IN (SELECT id FROM name_strings WHERE value IN ('a', 'b'))",
+                 WHERE (d.from_name_id IN (SELECT id FROM name_strings WHERE value IN ('a', 'b'))
+                     OR d.to_name_id IN (SELECT id FROM name_strings WHERE value IN ('a', 'b')))
+                   AND EXISTS (SELECT 1 FROM main.files f
+                                WHERE f.id = d.source_file_id AND f.repo_id = 'r')",
             )
             .unwrap()
             .query_map([], |row| row.get::<_, String>(3))
@@ -913,6 +952,11 @@ mod tests {
         assert!(
             !plan.contains("SCAN d "),
             "graph_boost must not full-scan edges_data, got plan:\n{plan}"
+        );
+        // The repo predicate must be a PK lookup on files (per candidate edge), never a files scan.
+        assert!(
+            !plan.contains("SCAN f"),
+            "graph_boost repo scope must PK-search files, not scan it, got plan:\n{plan}"
         );
     }
 

--- a/crates/rag-rat-mcp/src/claude_hook.rs
+++ b/crates/rag-rat-mcp/src/claude_hook.rs
@@ -156,6 +156,7 @@ mod listener {
                 };
                 let database = config.database.clone();
                 let config_root = config.root.clone();
+                let repo_id_override = config.repo_id_override.clone();
                 // Scope to the session's worktree overlay (#219). Absent cwd (older client) → the
                 // config root, which resolves to the base scope. This also fixes the listener's
                 // prior lack of ANY scope install: compose queries the `files` view, so without
@@ -166,8 +167,19 @@ mod listener {
                 // rusqlite is sync; one short read off the runtime threads.
                 let composed = tokio::task::spawn_blocking(move || {
                     let conn = IndexConnection::open_read_only(&database)?;
+                    // Resolve the repo dimension from this config (identity + override) so the
+                    // scope binds the config's repo, not the config-blind sole
+                    // repo (a sibling in a consolidated DB); an unprovable repo
+                    // → empty scope, never a sibling's rows.
+                    let repo_id = rag_rat_core::index::resolve_scope_repo_id(
+                        conn.connection(),
+                        &config_root,
+                        repo_id_override.as_deref(),
+                    )?
+                    .unwrap_or_default();
                     rag_rat_core::index::install_worktree_scope_view(
                         conn.connection(),
+                        &repo_id,
                         &config_root,
                         &cwd,
                     )?;


### PR DESCRIPTION
Phase A3 of the global-DB consolidation (#398, milestone "Memory durability & p2p sync"). The core scoping step: the repo dimension threads through the tables, the connection context, the scope view, gc, and the open/adoption flow.

## Schema (V040)
- Direct `repo_id` on `files` (UNIQUE → `(repo_id, path, commit_sha, worktree_id)`), `packages`, `logical_symbols`, `docs`, `parser_failures` (PK → `(repo_id, path)`), `git_commits` (PK → `(repo_id, hash)`, STRICT rebuild) with `git_file_changes` on a composite FK (`ON UPDATE CASCADE` so adoption re-points children); `commit_fts` re-pointed via `'rebuild'`.
- The multi-statement rebuild is torn-state re-convergent (the migration ladder runs apply fns in autocommit), and the full ladder is replay-idempotent on consolidated DBs in **both** adoption states — proven by a two-repo full-ladder replay test.
- Logical-symbol identity folds the owning repo into the content hash, so id-equality implies same-repo for every id-keyed reader. V040 and adoption realign existing ids across members, monikers, memory bindings, and call paths (two-phase, collision-free), so pre-V040 memories survive the upgrade.
- Meta-key ownership audited key-by-key: the FTS freshness trio, `content_revision`, and the int8-reencode cursor are **global infrastructure** and live in `index_meta` (invariant comments at each accessor); the shared relocate helper filters them so the frozen V039 replay cannot re-relocate them.

## Scope resolution
- `ScopeContext { repo_id, commit_sha, worktree_id }`: `open_config` resolves repo identity, registers/adopts atomically, installs a repo-filtered scope view.
- Read-only opens and raw-connection hook/orientation paths resolve the **config repo** explicitly (identity → registry → recorded root), never the sole-registry-row fallback; a resolved-but-unregistered identity declines the read-only path so the writable path can register or upgrade. An installed empty scope means match-nothing, never a sibling.
- Repo identity carries a portability class: **Portable** (root-commit hash or pinned id) vs **LocalOnly** (deterministic id from a shallow clone's boundary, warned once). Shallow checkouts index normally; a LocalOnly id upgrades in place to Portable once ancestry proof (recorded boundary reachable from the deepened history) is presented; reserved ids (`__unassigned__`, the `local:` prefix) are rejected at every entry point.

## Repo-sliced behavior
- gc per-repo with union-liveness for shared pools (`name_strings`, `embedding_cache`, `chunk_text_dict`); graph refresh deletes, search/graph boosts, brief counts, moniker sweeps, and the incremental-open ordering (adopt before graph checks) are all active-repo scoped; edge resolution's candidate pool is pinned to the active repo even on view-less bare opens.
- Destructive cleanups whose tables gain `repo_id` in a later migration (oracle prune, clone-generation sweeps/resume) are guarded on multi-repo DBs at marked seams.
- Latent bug fixed en route: the V008 files rebuild dropped `repo_id` on every `apply()` re-run, orphaning all files under the adoption placeholder — now guarded with a regression test.

## Enforcement
- **Poison-sibling test harness**: standard test fixtures seed tripwire rows for a sibling repo into every scoped table, with a sibling-intact post-condition on mutating paths — the suite itself now enforces "every access is repo-attributed or explicitly global" (this flushed and fixed an unscoped edge-resolution candidate pool that could crash on cross-repo NULL-qname symbols).
- Multi-repo isolation tests: scope-view isolation at a shared commit, gc row-count parity, read-only opens binding the config repo over a lexicographically-smaller sibling, pinned forks over shared-root siblings.

Workspace suite: 1467 passed; clippy `-D warnings` clean; nightly fmt clean.

Fixes #398