### PR TITLE
feat(search): V041 — repo-scoped FTS and papertrail queries (#399 phase A4)

### DIFF
--- a/crates/rag-rat-core/src/index/git_history.rs
+++ b/crates/rag-rat-core/src/index/git_history.rs
@@ -149,14 +149,14 @@ pub(crate) fn apply_prepared(
 
     // `git_commits` / `git_file_changes` are direct-scoped since V040, so a history reindex of ONE
     // repo must delete and re-insert only THAT repo's rows — a wholesale wipe would drop a sibling
-    // repo's commits in a consolidated DB. (`git_chunk_blame` is transitive via `chunks`/`files`
-    // and regenerated lazily; its per-repo scoping is deferred to the blame/query workstream — a
-    // marked A4/A5 seam. `commit_fts` is external-content over `git_commits` and is resynced
-    // below.)
+    // repo's commits in a consolidated DB. `git_chunk_blame` is transitive via `chunks`/`files`, so
+    // it is cleared through the active repo's chunks (A4): a history reindex invalidates blame for
+    // this whole repo (new commits change attribution), but must not touch a sibling repo's cache.
+    // `commit_fts` is external-content over `git_commits` and is resynced below.
     let repo_id = schema::active_repo_id(conn)?;
     conn.execute("DELETE FROM git_file_changes WHERE repo_id = ?1", params![repo_id])?;
     conn.execute("DELETE FROM git_commits WHERE repo_id = ?1", params![repo_id])?;
-    conn.execute_batch("DELETE FROM git_chunk_blame;")?;
+    delete_repo_chunk_blame(conn, &repo_id)?;
 
     for commit in &prepared.commits {
         conn.execute(
@@ -607,15 +607,34 @@ pub fn source_text_hash(text: &str) -> String {
     hex_sha256(text.as_bytes())
 }
 
+/// Delete the cached chunk-blame rows belonging to `repo_id`'s chunks. `git_chunk_blame` carries no
+/// `repo_id` (it is transitive via `chunks` → `files`), so scope the delete through the join to
+/// `main.files.repo_id` — NOT the `temp.files` scope view, which would additionally narrow to the
+/// active commit/worktree and leave this repo's other-context blame behind. A git-history reindex
+/// invalidates blame for the whole repo, so every chunk of the active repo is cleared.
+fn delete_repo_chunk_blame(conn: &Connection, repo_id: &str) -> anyhow::Result<()> {
+    conn.execute(
+        "DELETE FROM git_chunk_blame
+         WHERE chunk_id IN (
+             SELECT chunks.id
+             FROM chunks
+             JOIN main.files ON main.files.id = chunks.file_id
+             WHERE main.files.repo_id = ?1
+         )",
+        params![repo_id],
+    )?;
+    Ok(())
+}
+
 fn clear(conn: &Connection) -> anyhow::Result<()> {
     // Clear only the ACTIVE repo's git history (V040 scoping) — a wholesale wipe would drop a
-    // sibling repo's commits in a consolidated DB. `git_chunk_blame` is transitive/regenerated
-    // (A4/A5 seam). `commit_fts` is resynced from the surviving `git_commits` via the #51-safe
-    // `'rebuild'` afterward.
+    // sibling repo's commits in a consolidated DB. `git_chunk_blame` is transitive via
+    // `chunks`/`files`, cleared through the active repo's chunks (A4). `commit_fts` is resynced
+    // from the surviving `git_commits` via the #51-safe `'rebuild'` afterward.
     let repo_id = schema::active_repo_id(conn)?;
     conn.execute("DELETE FROM git_file_changes WHERE repo_id = ?1", params![repo_id])?;
     conn.execute("DELETE FROM git_commits WHERE repo_id = ?1", params![repo_id])?;
-    conn.execute_batch("DELETE FROM git_chunk_blame;")?;
+    delete_repo_chunk_blame(conn, &repo_id)?;
     crate::index::schema::rebuild_commit_fts(conn)?;
     // The reload-gate keys moved to `repo_meta` (V039); clear them for the active repo.
     for key in

--- a/crates/rag-rat-core/src/index/github/api.rs
+++ b/crates/rag-rat-core/src/index/github/api.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::index::{repo_meta, schema, set_repo_meta, table_row_count};
+use crate::index::{repo_meta, schema, scoped_table_row_count, set_repo_meta};
 
 pub(crate) fn sync_from_refs<C: GitHubClient>(
     conn: &Connection,
@@ -76,14 +76,17 @@ pub(crate) fn sync_issue<C: GitHubClient>(
     })
 }
 pub(crate) fn status(conn: &Connection, ctx: &GitHubContext) -> anyhow::Result<GitHubStatus> {
+    // The github_* tables are direct-scoped (V041); report only the ACTIVE repo's counts, not the
+    // union across a consolidated DB.
+    let repo_id = schema::active_repo_id(conn)?;
     Ok(GitHubStatus {
-        refs: table_row_count(conn, "github_refs")?,
-        issues: table_row_count(conn, "github_issues")?,
-        comments: table_row_count(conn, "github_comments")?,
-        pulls: table_row_count(conn, "github_pull_requests")?,
-        reviews: table_row_count(conn, "github_reviews")?,
-        review_comments: table_row_count(conn, "github_review_comments")?,
-        last_sync_ms: repo_meta(conn, &schema::active_repo_id(conn)?, "github_last_sync_ms")?
+        refs: scoped_table_row_count(conn, "github_refs", &repo_id)?,
+        issues: scoped_table_row_count(conn, "github_issues", &repo_id)?,
+        comments: scoped_table_row_count(conn, "github_comments", &repo_id)?,
+        pulls: scoped_table_row_count(conn, "github_pull_requests", &repo_id)?,
+        reviews: scoped_table_row_count(conn, "github_reviews", &repo_id)?,
+        review_comments: scoped_table_row_count(conn, "github_review_comments", &repo_id)?,
+        last_sync_ms: repo_meta(conn, &repo_id, "github_last_sync_ms")?
             .and_then(|value| value.parse().ok()),
         capability: if ctx.gh_available {
             "gh_cli_available".to_string()
@@ -125,16 +128,17 @@ pub(crate) fn refs_for_path(
     path: &str,
     limit: u32,
 ) -> anyhow::Result<Vec<GitHubRef>> {
+    let repo_id = schema::active_repo_id(conn)?;
     let mut stmt = conn.prepare(
         "
         SELECT owner, repo, number, ref_kind, source_kind, source_path, source_commit, source_text
         FROM github_refs
-        WHERE source_path = ?1
+        WHERE source_path = ?1 AND repo_id = ?3
         ORDER BY id DESC
         LIMIT ?2
         ",
     )?;
-    let rows = stmt.query_map(params![path, i64::from(limit)], ref_row)?;
+    let rows = stmt.query_map(params![path, i64::from(limit), repo_id], ref_row)?;
     collect_rows(rows)
 }
 pub(crate) fn papertrail_for_chunk(

--- a/crates/rag-rat-core/src/index/github/evidence.rs
+++ b/crates/rag-rat-core/src/index/github/evidence.rs
@@ -53,15 +53,17 @@ pub(crate) fn evidence_for_issue(
     number: i64,
     limit: u32,
 ) -> anyhow::Result<Vec<GitHubEvidence>> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     let mut stmt = conn.prepare(
         "
         SELECT owner, repo, number, item_kind, item_id, url, title, body, classification, 0.0
         FROM github_fts
-        WHERE owner = ?1 AND repo = ?2 AND number = ?3
+        WHERE owner = ?1 AND repo = ?2 AND number = ?3 AND repo_id = ?5
         LIMIT ?4
         ",
     )?;
-    let rows = stmt.query_map(params![owner, repo, number, i64::from(limit)], evidence_row)?;
+    let rows =
+        stmt.query_map(params![owner, repo, number, i64::from(limit), repo_id], evidence_row)?;
     let mut evidence = collect_rows(rows)?;
     for item in &mut evidence {
         item.evidence_kind = "literal_github_ref";
@@ -74,18 +76,20 @@ pub(crate) fn evidence_for_commit_refs(
     commit_hash: &str,
     limit: u32,
 ) -> anyhow::Result<Vec<GitHubEvidence>> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     let mut stmt = conn.prepare(
         "
         SELECT owner, repo, number
         FROM github_refs
         WHERE source_kind = 'commit'
           AND source_commit LIKE ?1
+          AND repo_id = ?3
         ORDER BY ref_kind = 'closing' DESC, id DESC
         LIMIT ?2
         ",
     )?;
     let commit_like = format!("{commit_hash}%");
-    let refs = stmt.query_map(params![commit_like, i64::from(limit)], |row| {
+    let refs = stmt.query_map(params![commit_like, i64::from(limit), repo_id], |row| {
         Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, i64>(2)?))
     })?;
     let mut evidence = Vec::new();
@@ -104,7 +108,14 @@ pub(crate) fn search_fts(
     limit: u32,
 ) -> anyhow::Result<Vec<GitHubEvidence>> {
     let fts_query = fts_query(query);
-    let kind_clause = kind.map(|_| "AND item_kind = ?3").unwrap_or("");
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    // The `repo_id` filter is MANDATORY (V041): `github_fts` is one index over every repo's
+    // papertrail in a consolidated DB, so a bare MATCH would surface a sibling repo's issues. Its
+    // parameter index trails the optional `item_kind` bind, so it shifts with the kind clause.
+    let (kind_clause, repo_index) = match kind {
+        Some(_) => ("AND item_kind = ?3", 4),
+        None => ("", 3),
+    };
     let sql = format!(
         "
         SELECT owner, repo, number, item_kind, item_id, url, title, body, classification,
@@ -112,15 +123,16 @@ pub(crate) fn search_fts(
         FROM github_fts
         WHERE github_fts MATCH ?1
         {kind_clause}
+          AND repo_id = ?{repo_index}
         ORDER BY score
         LIMIT ?2
         "
     );
     let mut stmt = conn.prepare(&sql)?;
     let rows = if let Some(kind) = kind {
-        stmt.query_map(params![fts_query, i64::from(limit), kind], evidence_row)?
+        stmt.query_map(params![fts_query, i64::from(limit), kind, repo_id], evidence_row)?
     } else {
-        stmt.query_map(params![fts_query, i64::from(limit)], evidence_row)?
+        stmt.query_map(params![fts_query, i64::from(limit), repo_id], evidence_row)?
     };
     let mut hits = collect_rows(rows)?;
     for (rank, hit) in hits.iter_mut().enumerate() {
@@ -173,10 +185,11 @@ pub(crate) fn ref_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<GitHubRef> {
     })
 }
 pub(crate) fn refs(conn: &Connection) -> anyhow::Result<Vec<GitHubRef>> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     let mut stmt = conn.prepare(
         "SELECT owner, repo, number, ref_kind, source_kind, source_path, source_commit, \
-         source_text FROM github_refs",
+         source_text FROM github_refs WHERE repo_id = ?1",
     )?;
-    let rows = stmt.query_map([], ref_row)?;
+    let rows = stmt.query_map([repo_id], ref_row)?;
     collect_rows(rows)
 }

--- a/crates/rag-rat-core/src/index/github/mod.rs
+++ b/crates/rag-rat-core/src/index/github/mod.rs
@@ -312,6 +312,9 @@ pub(crate) struct FtsRow<'a> {
     url: &'a str,
     title: &'a str,
     body: &'a str,
+    /// The active repo that owns this papertrail row (V041). Stamped into `github_fts.repo_id`
+    /// (UNINDEXED) so a MATCH in a consolidated DB filters to one repo.
+    repo_id: &'a str,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rag-rat-core/src/index/github/store.rs
+++ b/crates/rag-rat-core/src/index/github/store.rs
@@ -1,13 +1,35 @@
 use super::*;
 
+// UPSERT-RECLAIM INVARIANT (all seven github writers): the github tables keep their natural keys
+// WITHOUT `repo_id` (the deliberate V041 phase-A deviation — one repo per DB until A7), so on a
+// consolidated DB a row stranded under the `'__unassigned__'` placeholder (the V041 backfill's
+// leave-at-placeholder path) OCCUPIES the key. Every writer must therefore RECLAIM on conflict —
+// re-stamp `repo_id` and refresh the content — never `INSERT OR IGNORE`, which would silently keep
+// the stale placeholder row forever and break the migration's "the next sync reclaims" promise.
+// Last-syncer-owns is the documented phase-A posture for the un-qualified keys; the `github_fts`
+// mirror follows automatically because every sync path ends in the whole-table [`rebuild_fts`],
+// which re-derives each mirror row's `repo_id` from its reclaimed base row. The id-keyed writers
+// (`store_comment` / `store_review` / `store_review_comment`) reclaim via `INSERT OR REPLACE`
+// (REPLACE deletes the conflicting row and re-inserts with the new stamp).
+
 pub(crate) fn store_ref(conn: &Connection, reference: &GitHubRef) -> anyhow::Result<()> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    // The `WHERE repo_id changes` guard keeps the old first-discovery semantics for a repo
+    // re-discovering its OWN ref (no rewrite, `discovered_at_ms` keeps the first sighting) while
+    // reclaiming + refreshing a row another owner (the placeholder, pre-A7) holds on this key.
     conn.execute(
         "
-        INSERT OR IGNORE INTO github_refs(
+        INSERT INTO github_refs(
             owner, repo, number, ref_kind, source_kind, source_path, source_commit, source_text, \
-         discovered_at_ms
+         discovered_at_ms, repo_id
         )
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+        ON CONFLICT(owner, repo, number, source_kind, COALESCE(source_path, ''), \
+         COALESCE(source_commit, ''), source_text) DO UPDATE SET
+            ref_kind = excluded.ref_kind,
+            discovered_at_ms = excluded.discovered_at_ms,
+            repo_id = excluded.repo_id
+        WHERE github_refs.repo_id != excluded.repo_id
         ",
         params![
             reference.owner,
@@ -19,21 +41,23 @@ pub(crate) fn store_ref(conn: &Connection, reference: &GitHubRef) -> anyhow::Res
             reference.source_commit,
             reference.source_text,
             now_ms(),
+            repo_id,
         ],
     )?;
     Ok(())
 }
 pub(crate) fn store_issue(conn: &Connection, issue: &GitHubIssue) -> anyhow::Result<()> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     conn.execute(
         "
         INSERT INTO github_issues(owner, repo, number, html_url, state, title, body, author, \
-         created_at, updated_at, is_pull_request, synced_at_ms)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+         created_at, updated_at, is_pull_request, synced_at_ms, repo_id)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
         ON CONFLICT(owner, repo, number) DO UPDATE SET
             html_url = excluded.html_url, state = excluded.state, title = excluded.title,
             body = excluded.body, author = excluded.author, created_at = excluded.created_at,
             updated_at = excluded.updated_at, is_pull_request = excluded.is_pull_request,
-            synced_at_ms = excluded.synced_at_ms
+            synced_at_ms = excluded.synced_at_ms, repo_id = excluded.repo_id
         ",
         params![
             issue.owner,
@@ -48,16 +72,18 @@ pub(crate) fn store_issue(conn: &Connection, issue: &GitHubIssue) -> anyhow::Res
             issue.updated_at,
             issue.is_pull_request,
             now_ms(),
+            repo_id,
         ],
     )?;
     Ok(())
 }
 pub(crate) fn store_comment(conn: &Connection, comment: &GitHubComment) -> anyhow::Result<()> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     conn.execute(
         "
         INSERT OR REPLACE INTO github_comments(id, owner, repo, number, html_url, body, author, \
-         created_at, updated_at, synced_at_ms)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+         created_at, updated_at, synced_at_ms, repo_id)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
         ",
         params![
             comment.id,
@@ -70,21 +96,23 @@ pub(crate) fn store_comment(conn: &Connection, comment: &GitHubComment) -> anyho
             comment.created_at,
             comment.updated_at,
             now_ms(),
+            repo_id,
         ],
     )?;
     Ok(())
 }
 pub(crate) fn store_pull(conn: &Connection, pull: &GitHubPullRequest) -> anyhow::Result<()> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     conn.execute(
         "
         INSERT INTO github_pull_requests(owner, repo, number, html_url, state, title, body, \
-         author, created_at, updated_at, merged_at, synced_at_ms)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+         author, created_at, updated_at, merged_at, synced_at_ms, repo_id)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
         ON CONFLICT(owner, repo, number) DO UPDATE SET
             html_url = excluded.html_url, state = excluded.state, title = excluded.title,
             body = excluded.body, author = excluded.author, created_at = excluded.created_at,
             updated_at = excluded.updated_at, merged_at = excluded.merged_at,
-            synced_at_ms = excluded.synced_at_ms
+            synced_at_ms = excluded.synced_at_ms, repo_id = excluded.repo_id
         ",
         params![
             pull.owner,
@@ -99,16 +127,18 @@ pub(crate) fn store_pull(conn: &Connection, pull: &GitHubPullRequest) -> anyhow:
             pull.updated_at,
             pull.merged_at,
             now_ms(),
+            repo_id,
         ],
     )?;
     Ok(())
 }
 pub(crate) fn store_review(conn: &Connection, review: &GitHubReview) -> anyhow::Result<()> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     conn.execute(
         "
         INSERT OR REPLACE INTO github_reviews(id, owner, repo, number, html_url, state, body, \
-         author, submitted_at, synced_at_ms)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+         author, submitted_at, synced_at_ms, repo_id)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
         ",
         params![
             review.id,
@@ -121,6 +151,7 @@ pub(crate) fn store_review(conn: &Connection, review: &GitHubReview) -> anyhow::
             review.author,
             review.submitted_at,
             now_ms(),
+            repo_id,
         ],
     )?;
     Ok(())
@@ -129,11 +160,12 @@ pub(crate) fn store_review_comment(
     conn: &Connection,
     comment: &GitHubReviewComment,
 ) -> anyhow::Result<()> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     conn.execute(
         "
         INSERT OR REPLACE INTO github_review_comments(id, owner, repo, number, path, html_url, \
-         body, author, created_at, updated_at, synced_at_ms)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+         body, author, created_at, updated_at, synced_at_ms, repo_id)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
         ",
         params![
             comment.id,
@@ -147,6 +179,7 @@ pub(crate) fn store_review_comment(
             comment.created_at,
             comment.updated_at,
             now_ms(),
+            repo_id,
         ],
     )?;
     Ok(())
@@ -154,42 +187,48 @@ pub(crate) fn store_review_comment(
 pub(crate) fn rebuild_fts(conn: &Connection) -> anyhow::Result<()> {
     // github_fts is a standalone (own-content) FTS5 table, so a DELETE + re-insert is the correct
     // rebuild — unlike the external-content chunk_fts / commit_fts, which must rebuild via
-    // INSERT(t) VALUES('rebuild'). Each query below selects the seven FtsRow columns in order
-    // (id, owner, repo, number, url, title, body); kinds without a title (comment, review) select
-    // an empty string for that slot, and review comments surface the file path as the title.
+    // INSERT(t) VALUES('rebuild'). This is a WHOLE-TABLE rebuild (every repo's rows in a
+    // consolidated DB): the DELETE clears all rows and each per-kind SELECT re-reads the entire
+    // base table, so github_fts is repopulated complete for EVERY repo, each row stamped its
+    // base row's `repo_id` (V041). The papertrail cache is small, so the whole-table cost is
+    // acceptable — a per-repo incremental rebuild is not worth the bookkeeping. Each query
+    // selects the eight `FtsRow` columns in order (id, owner, repo, number, url, title, body,
+    // repo_id); kinds without a title (comment, review) select an empty string for that slot,
+    // and review comments surface the file path as the title.
     conn.execute("DELETE FROM github_fts", [])?;
     insert_fts_rows(
         conn,
         "issue",
-        "SELECT id, owner, repo, number, html_url, title, body FROM github_issues",
+        "SELECT id, owner, repo, number, html_url, title, body, repo_id FROM github_issues",
     )?;
     insert_fts_rows(
         conn,
         "comment",
-        "SELECT id, owner, repo, number, html_url, '', body FROM github_comments",
+        "SELECT id, owner, repo, number, html_url, '', body, repo_id FROM github_comments",
     )?;
     insert_fts_rows(
         conn,
         "pull",
-        "SELECT id, owner, repo, number, html_url, title, body FROM github_pull_requests",
+        "SELECT id, owner, repo, number, html_url, title, body, repo_id FROM github_pull_requests",
     )?;
     insert_fts_rows(
         conn,
         "review",
-        "SELECT id, owner, repo, number, COALESCE(html_url, ''), '', body FROM github_reviews",
+        "SELECT id, owner, repo, number, COALESCE(html_url, ''), '', body, repo_id FROM \
+         github_reviews",
     )?;
     insert_fts_rows(
         conn,
         "review_comment",
-        "SELECT id, owner, repo, number, html_url, COALESCE(path, ''), body FROM \
+        "SELECT id, owner, repo, number, html_url, COALESCE(path, ''), body, repo_id FROM \
          github_review_comments",
     )?;
     Ok(())
 }
-/// Bulk-load one GitHub item kind into `github_fts`. `sql` must select exactly the seven `FtsRow`
-/// columns in order — `id, owner, repo, number, url, title, body` — using an empty-string literal
-/// in the title slot for kinds that carry no title. Adding a new item kind is a one-line call here,
-/// not another copy of the load loop.
+/// Bulk-load one GitHub item kind into `github_fts`. `sql` must select exactly the eight `FtsRow`
+/// columns in order — `id, owner, repo, number, url, title, body, repo_id` — using an empty-string
+/// literal in the title slot for kinds that carry no title. Adding a new item kind is a one-line
+/// call here, not another copy of the load loop.
 fn insert_fts_rows(conn: &Connection, kind: &str, sql: &str) -> anyhow::Result<()> {
     let mut stmt = conn.prepare(sql)?;
     let rows = stmt.query_map([], |row| {
@@ -201,10 +240,11 @@ fn insert_fts_rows(conn: &Connection, kind: &str, sql: &str) -> anyhow::Result<(
             row.get::<_, String>(4)?,
             row.get::<_, String>(5)?,
             row.get::<_, String>(6)?,
+            row.get::<_, String>(7)?,
         ))
     })?;
     for row in rows {
-        let (id, owner, repo, number, url, title, body) = row?;
+        let (id, owner, repo, number, url, title, body, repo_id) = row?;
         insert_fts(conn, FtsRow {
             owner: &owner,
             repo: &repo,
@@ -214,6 +254,7 @@ fn insert_fts_rows(conn: &Connection, kind: &str, sql: &str) -> anyhow::Result<(
             url: &url,
             title: &title,
             body: &body,
+            repo_id: &repo_id,
         })?;
     }
     Ok(())
@@ -221,8 +262,8 @@ fn insert_fts_rows(conn: &Connection, kind: &str, sql: &str) -> anyhow::Result<(
 pub(crate) fn insert_fts(conn: &Connection, row: FtsRow<'_>) -> anyhow::Result<()> {
     conn.execute(
         "INSERT INTO github_fts(owner, repo, number, item_kind, item_id, url, title, body, \
-         classification)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+         classification, repo_id)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
         params![
             row.owner,
             row.repo,
@@ -232,7 +273,8 @@ pub(crate) fn insert_fts(conn: &Connection, row: FtsRow<'_>) -> anyhow::Result<(
             row.url,
             row.title,
             row.body,
-            classify_text(&format!("{}\n{}", row.title, row.body))
+            classify_text(&format!("{}\n{}", row.title, row.body)),
+            row.repo_id,
         ],
     )?;
     Ok(())

--- a/crates/rag-rat-core/src/index/github/sync.rs
+++ b/crates/rag-rat-core/src/index/github/sync.rs
@@ -155,14 +155,15 @@ pub(crate) fn sync_progress(
     }
 }
 pub(crate) fn github_ref_synced(conn: &Connection, reference: &GitHubRef) -> anyhow::Result<bool> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     let status = conn
         .query_row(
             "
             SELECT status
             FROM github_ref_sync
-            WHERE owner = ?1 AND repo = ?2 AND number = ?3
+            WHERE owner = ?1 AND repo = ?2 AND number = ?3 AND repo_id = ?4
             ",
-            params![reference.owner, reference.repo, reference.number],
+            params![reference.owner, reference.repo, reference.number, repo_id],
             |row| row.get::<_, String>(0),
         )
         .optional()?;
@@ -173,10 +174,10 @@ pub(crate) fn github_ref_synced(conn: &Connection, reference: &GitHubRef) -> any
         "
         SELECT EXISTS(
             SELECT 1 FROM github_issues
-            WHERE owner = ?1 AND repo = ?2 AND number = ?3
+            WHERE owner = ?1 AND repo = ?2 AND number = ?3 AND repo_id = ?4
         )
         ",
-        params![reference.owner, reference.repo, reference.number],
+        params![reference.owner, reference.repo, reference.number, repo_id],
         |row| row.get::<_, bool>(0),
     )?;
     Ok(cached_issue)
@@ -187,16 +188,26 @@ pub(crate) fn mark_ref_sync(
     status: &str,
     error: Option<&str>,
 ) -> anyhow::Result<()> {
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     conn.execute(
         "
-        INSERT INTO github_ref_sync(owner, repo, number, status, synced_at_ms, last_error)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+        INSERT INTO github_ref_sync(owner, repo, number, status, synced_at_ms, last_error, repo_id)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
         ON CONFLICT(owner, repo, number) DO UPDATE SET
             status = excluded.status,
             synced_at_ms = excluded.synced_at_ms,
-            last_error = excluded.last_error
+            last_error = excluded.last_error,
+            repo_id = excluded.repo_id
         ",
-        params![reference.owner, reference.repo, reference.number, status, now_ms(), error],
+        params![
+            reference.owner,
+            reference.repo,
+            reference.number,
+            status,
+            now_ms(),
+            error,
+            repo_id
+        ],
     )?;
     Ok(())
 }

--- a/crates/rag-rat-core/src/index/poison_sibling.rs
+++ b/crates/rag-rat-core/src/index/poison_sibling.rs
@@ -11,16 +11,37 @@
 //! assertion trips; a production DELETE that forgets it silently wipes the sibling, which
 //! [`assert_sibling_intact`] catches.
 //!
-//! SCHEMA-VERSION SCOPE (load-bearing): this worktree is **V040** (`LATEST_SCHEMA_VERSION = 40`),
-//! where exactly TEN tables carry a `repo_id` column — `repos`, `repo_roots`, `repo_meta`, `files`,
-//! `packages`, `logical_symbols`, `docs`, `parser_failures`, `git_commits`, `git_file_changes` —
-//! plus tables scoped TRANSITIVELY through them (`chunks`/`symbols`/`edges_data` via `files.id`;
-//! `logical_symbol_members`/`logical_symbol_monikers` via `logical_symbols.id`). The github, repo
-//! memory, oracle (`oracle_runs`/`edge_oracle`), clone, `dream_findings`, and `reconcile_attempts`
-//! tables are GLOBAL at V040 — they gain `repo_id` only in A4 (V041) / A5 (V042), which are NOT in
-//! this worktree — so seeding a `repo_id='poison-sibling'` row into them is impossible and a read
-//! of them is *legitimately* cross-repo here. Seeding them would manufacture FALSE tripwires. When
-//! A4/A5 land, extend [`seed_sibling`] to those tables at the same time their scoping does.
+//! TWO TRIPWIRE CLASSES (load-bearing). (1) DISTINCT-PATH rows seed under `zz_poison_`-prefixed
+//! paths/keys that can never collide with a primary-repo path — they catch an unscoped
+//! read/count/delete that returns the UNION across repos (a missing `repo_id` filter on a
+//! whole-table scan). (2) SAME-PATH rows seed under a REAL primary-repo path (resolved at seed time
+//! by [`primary_collision_path`]) — they catch the class the distinct-path rows CANNOT: an
+//! aggregate that reads a scoped table grouped by a NON-repo key (path / source_path) and then
+//! JOINS the result onto the active repo's rows BY PATH instead of flowing repo attribution through
+//! the join. The canonical example is the V041 `github_ref_counts` CTE in
+//! `query::repo_brief::file_rows` (`SELECT source_path, COUNT(*) FROM github_refs GROUP BY
+//! source_path` then `LEFT JOIN … ON github_ref_counts.path = files.path`): a sibling's
+//! `github_refs` row at `src/lib.rs` inflates the active repo's file `src/lib.rs` unless the CTE
+//! filters `repo_id`. A distinct-path sibling ref at `zz_poison_path.rs` never joins onto a primary
+//! file, so ONLY a same-path ref exposes that leak. Same-path rows go in for `github_refs` (the
+//! join-by-path papertrail), `files`, `git_file_changes`, and `parser_failures`; each is pinned in
+//! [`sibling_tripwires`] by a path-INDEPENDENT sentinel column so the intact check holds regardless
+//! of which fixture path was chosen.
+//!
+//! SCHEMA-VERSION SCOPE (load-bearing): this worktree is **V041** (`LATEST_SCHEMA_VERSION = 41`),
+//! which scopes the V040 core tables — `repos`, `repo_roots`, `repo_meta`, `files`, `packages`,
+//! `logical_symbols`, `docs`, `parser_failures`, `git_commits`, `git_file_changes` (plus tables
+//! scoped TRANSITIVELY through them: `chunks`/`symbols`/`edges_data` via `files.id`;
+//! `logical_symbol_members`/`logical_symbol_monikers` via `logical_symbols.id`) — AND the seven
+//! V041 GitHub papertrail tables (`github_refs`, `github_issues`, `github_comments`,
+//! `github_pull_requests`, `github_reviews`, `github_review_comments`, `github_ref_sync`) plus the
+//! `github_fts` mirror, each of which gained a `repo_id` column in V041. [`seed_sibling`] seeds a
+//! tripwire row into every one of those. The repo-memory, oracle (`oracle_runs`/`edge_oracle`),
+//! clone, `dream_findings`, and `reconcile_attempts` tables are STILL GLOBAL at V041 — they gain
+//! `repo_id` only in A5 (V042), which is NOT in this worktree — so seeding a
+//! `repo_id='poison-sibling'` row into them is impossible and a read of them is *legitimately*
+//! cross-repo here. Seeding them would manufacture FALSE tripwires. When A5 lands, extend
+//! [`seed_sibling`] to those tables at the same time their scoping does.
 //!
 //! WHY THE SIBLING IS NOT REGISTERED IN `repos` (load-bearing at V040): the eight direct-scoped
 //! DATA tables (`files`, `packages`, `logical_symbols`, `docs`, `parser_failures`, `git_commits`,
@@ -60,6 +81,40 @@ const POISON_LOGICAL_ID: i64 = 9_900_000_777;
 
 /// The poison sibling's git commit hash (a distinctive 40-hex-shaped sentinel).
 const POISON_COMMIT: &str = "zzpoison00000000000000000000000000000000";
+
+/// The poison sibling's GitHub issue/PR/ref number — a distinctive sentinel far outside any
+/// fixture's range, so a seeded papertrail row is unmistakable and never collides on the
+/// `UNIQUE(owner, repo, number)` / `PRIMARY KEY(owner, repo, number)` keys.
+const POISON_GH_NUMBER: i64 = 9_900_077;
+
+/// Base for the EXPLICIT GitHub item ids on the five body-bearing poison rows (+1 issue, +2
+/// comment, +3 pull, +4 review, +5 review comment). `github::rebuild_fts` derives
+/// `github_fts.item_id` from each base row's `id`, so the harness pins the ids rather than letting
+/// AUTOINCREMENT choose — the seeded mirror rows and a post-resync re-derived mirror then agree on
+/// every tripwire-pinned column (see `github_fts_tripwires_survive_a_papertrail_resync`).
+const POISON_GH_ITEM_ID: i64 = 9_900_077_000;
+
+/// SAME-PATH tripwire sentinels. The DISTINCT-PATH rows above seed under `zz_poison_`-prefixed
+/// paths that never collide with a primary-repo path, so a leak that JOINS a scoped table onto the
+/// active repo's rows BY PATH (rather than flowing repo attribution through the join) cannot trip —
+/// the sibling's path never matches a primary path. These SAME-PATH rows instead seed under a REAL
+/// primary-repo path (resolved at seed time by [`primary_collision_path`]), so an unscoped
+/// join-by-path aggregate attributes the sibling's rows to the active repo and an existing read
+/// assertion trips. Each carries its own path-INDEPENDENT sentinel column value (distinct from the
+/// distinct-path rows) so the intact check pins it regardless of which primary path was chosen.
+const POISON_SAMEPATH_GH_NUMBER: i64 = 9_900_078;
+/// `github_refs.source_text` sentinel on the same-path ref (so it reads distinctly in a dump).
+const POISON_SAMEPATH_REFTEXT: &str = "zz_poison_samepath_reftext";
+/// `files.sha256` sentinel pinning the same-path `files` row.
+const POISON_SAMEPATH_SHA: &str = "zz_poison_samepath_sha";
+/// `parser_failures.message` sentinel pinning the same-path `parser_failures` row.
+const POISON_SAMEPATH_MSG: &str = "zz_poison_samepath_msg";
+/// `git_file_changes.additions` sentinel pinning the same-path `git_file_changes` row (a value no
+/// real fixture change produces).
+const POISON_SAMEPATH_ADDITIONS: i64 = 7_700_077;
+/// Fallback collision path when the fixture indexed no files — nothing to collide with, but the row
+/// still guards against an unscoped DELETE.
+const POISON_SAMEPATH_FALLBACK: &str = "zz_poison_no_primary_file.rs";
 
 thread_local! {
     /// Whether [`seed_if_enabled`] seeds on this thread. Default ON. Thread-local (not a global
@@ -107,6 +162,10 @@ pub(crate) fn seed_if_enabled(conn: &Connection) -> anyhow::Result<()> {
 /// Deliberately touches NO registry table (`repos`/`repo_roots`/`repo_meta`) — see the module docs.
 pub(crate) fn seed_sibling(conn: &Connection) -> anyhow::Result<()> {
     clear_sibling(conn)?;
+
+    // Resolve the primary-repo path the SAME-PATH tripwires collide onto BEFORE seeding any sibling
+    // rows (so the poison rows never win the `ORDER BY path` pick).
+    let collision_path = primary_collision_path(conn)?;
 
     // --- git history (git_file_changes FKs git_commits(repo_id, hash); git_commits has NO FK to
     // repos, so this needs no registry row) ---
@@ -228,7 +287,218 @@ pub(crate) fn seed_sibling(conn: &Connection) -> anyhow::Result<()> {
         ],
     )?;
 
+    // --- github papertrail (V041): the seven base tables + the standalone `github_fts` mirror each
+    // gained a `repo_id` column, so a sibling row is now valid (these caches carry NO FK to
+    // `repos`) and any unscoped papertrail read/count/delete trips a tripwire. The five
+    // body-bearing rows carry EXPLICIT item ids (`POISON_GH_ITEM_ID` + kind offset) because a
+    // papertrail resync (`github::rebuild_fts`) re-derives the whole mirror from these rows —
+    // pinned ids keep the re-derived mirror identical to the seeded one. ---
+    let gh_owner = format!("{POISON_PREFIX}owner");
+    let gh_repo = format!("{POISON_PREFIX}repo");
+    conn.execute(
+        "INSERT INTO github_refs(owner, repo, number, ref_kind, source_kind, source_path, \
+         source_text, discovered_at_ms, repo_id)
+         VALUES (?1, ?2, ?3, 'closing', 'file', ?4, ?5, 0, ?6)",
+        params![
+            gh_owner,
+            gh_repo,
+            POISON_GH_NUMBER,
+            format!("{POISON_PREFIX}path.rs"),
+            format!("{POISON_PREFIX}reftext"),
+            POISON_REPO_ID
+        ],
+    )?;
+    conn.execute(
+        "INSERT INTO github_issues(id, owner, repo, number, html_url, state, title, body, \
+         synced_at_ms, repo_id)
+         VALUES (?1, ?2, ?3, ?4, 'http://x', 'open', ?5, ?6, 0, ?7)",
+        params![
+            POISON_GH_ITEM_ID + 1,
+            gh_owner,
+            gh_repo,
+            POISON_GH_NUMBER,
+            format!("{POISON_PREFIX}title"),
+            format!("{POISON_PREFIX}body"),
+            POISON_REPO_ID
+        ],
+    )?;
+    conn.execute(
+        "INSERT INTO github_comments(id, owner, repo, number, html_url, body, synced_at_ms, \
+         repo_id)
+         VALUES (?1, ?2, ?3, ?4, 'http://x', ?5, 0, ?6)",
+        params![
+            POISON_GH_ITEM_ID + 2,
+            gh_owner,
+            gh_repo,
+            POISON_GH_NUMBER,
+            format!("{POISON_PREFIX}comment"),
+            POISON_REPO_ID
+        ],
+    )?;
+    conn.execute(
+        "INSERT INTO github_pull_requests(id, owner, repo, number, html_url, state, title, body, \
+         synced_at_ms, repo_id)
+         VALUES (?1, ?2, ?3, ?4, 'http://x', 'open', ?5, ?6, 0, ?7)",
+        params![
+            POISON_GH_ITEM_ID + 3,
+            gh_owner,
+            gh_repo,
+            POISON_GH_NUMBER,
+            format!("{POISON_PREFIX}prtitle"),
+            format!("{POISON_PREFIX}prbody"),
+            POISON_REPO_ID
+        ],
+    )?;
+    conn.execute(
+        "INSERT INTO github_reviews(id, owner, repo, number, state, body, synced_at_ms, repo_id)
+         VALUES (?1, ?2, ?3, ?4, 'commented', ?5, 0, ?6)",
+        params![
+            POISON_GH_ITEM_ID + 4,
+            gh_owner,
+            gh_repo,
+            POISON_GH_NUMBER,
+            format!("{POISON_PREFIX}review"),
+            POISON_REPO_ID
+        ],
+    )?;
+    conn.execute(
+        "INSERT INTO github_review_comments(id, owner, repo, number, html_url, body, \
+         synced_at_ms, repo_id)
+         VALUES (?1, ?2, ?3, ?4, 'http://x', ?5, 0, ?6)",
+        params![
+            POISON_GH_ITEM_ID + 5,
+            gh_owner,
+            gh_repo,
+            POISON_GH_NUMBER,
+            format!("{POISON_PREFIX}revcomment"),
+            POISON_REPO_ID
+        ],
+    )?;
+    conn.execute(
+        "INSERT INTO github_ref_sync(owner, repo, number, status, synced_at_ms, repo_id)
+         VALUES (?1, ?2, ?3, 'ok', 0, ?4)",
+        params![gh_owner, gh_repo, POISON_GH_NUMBER, POISON_REPO_ID],
+    )?;
+    // github_fts mirror rows, seeded EXACTLY as `github::rebuild_fts` derives them from the five
+    // base rows above (one row per item kind; same item_id / url / title / body slot mapping —
+    // reviews derive url = COALESCE(html_url, '') = '' and review comments derive title =
+    // COALESCE(path, '') = '' from the unseeded nullable columns). A resync DELETEs the whole
+    // mirror and re-derives it, so seeding anything else would strand the intact check on a
+    // vanished row set; `github_fts_tripwires_survive_a_papertrail_resync` pins this equivalence.
+    // `classification` is recomputed by `insert_fts` (`classify_text`) at re-derivation and is
+    // deliberately NOT pinned by the tripwires.
+    let insert_poison_fts = |kind: &str, item_id: i64, url: &str, title: &str, body: String| {
+        conn.execute(
+            "INSERT INTO github_fts(owner, repo, number, item_kind, item_id, url, title, body, \
+             classification, repo_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 'other', ?9)",
+            params![
+                gh_owner,
+                gh_repo,
+                POISON_GH_NUMBER,
+                kind,
+                item_id.to_string(),
+                url,
+                title,
+                body,
+                POISON_REPO_ID
+            ],
+        )
+    };
+    insert_poison_fts(
+        "issue",
+        POISON_GH_ITEM_ID + 1,
+        "http://x",
+        &format!("{POISON_PREFIX}title"),
+        format!("{POISON_PREFIX}body"),
+    )?;
+    insert_poison_fts(
+        "comment",
+        POISON_GH_ITEM_ID + 2,
+        "http://x",
+        "",
+        format!("{POISON_PREFIX}comment"),
+    )?;
+    insert_poison_fts(
+        "pull",
+        POISON_GH_ITEM_ID + 3,
+        "http://x",
+        &format!("{POISON_PREFIX}prtitle"),
+        format!("{POISON_PREFIX}prbody"),
+    )?;
+    insert_poison_fts("review", POISON_GH_ITEM_ID + 4, "", "", format!("{POISON_PREFIX}review"))?;
+    insert_poison_fts(
+        "review_comment",
+        POISON_GH_ITEM_ID + 5,
+        "http://x",
+        "",
+        format!("{POISON_PREFIX}revcomment"),
+    )?;
+
+    // --- SAME-PATH tripwires: sibling rows whose PATH deliberately collides with a real primary
+    // path (`collision_path`). A join-by-path aggregate that reads a scoped table without a
+    // `repo_id` predicate attributes these to the active repo. The DISTINCT-PATH rows above cannot
+    // catch that class — their `zz_poison_` paths never match a primary path. Each row is under
+    // `POISON_REPO_ID`, so `clear_sibling`'s existing `WHERE repo_id = POISON_REPO_ID` deletes
+    // them; the intact check pins each by its own sentinel column (not by path). ---
+    // files: caught by any unscoped `main.files` read that groups/joins by path (the scope view
+    // would exclude the sibling, so only a view-bypassing path read leaks). No children hung off
+    // it.
+    conn.execute(
+        "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+         commit_sha, worktree_id, repo_id)
+         VALUES (?1, 'rust', 'source', ?2, 0, 0, ?3, '', ?4)",
+        params![collision_path, POISON_SAMEPATH_SHA, POISON_COMMIT, POISON_REPO_ID],
+    )?;
+    // git_file_changes at the shared path (off the sibling commit): caught by an unscoped churn /
+    // co-change / history aggregate that joins `git_file_changes.path` onto the scoped `files`.
+    conn.execute(
+        "INSERT INTO git_file_changes(commit_hash, path, additions, deletions, change_kind, \
+         repo_id)
+         VALUES (?1, ?2, ?3, 0, 'modified', ?4)",
+        params![POISON_COMMIT, collision_path, POISON_SAMEPATH_ADDITIONS, POISON_REPO_ID],
+    )?;
+    // parser_failures at the shared path (PK is (repo_id, path), so this is distinct from the
+    // distinct-path failure): caught by an unscoped parser-failure read joined/grouped by path.
+    conn.execute(
+        "INSERT INTO parser_failures(repo_id, path, language, message) VALUES (?1, ?2, 'rust', ?3)",
+        params![POISON_REPO_ID, collision_path, POISON_SAMEPATH_MSG],
+    )?;
+    // github_refs at the shared source_path: THE canonical join-by-path leak (the V041
+    // `github_ref_counts` CTE in `repo_brief::file_rows`). Distinct `number` from the distinct-path
+    // ref, so the `UNIQUE(owner, repo, number, source_kind, ...)` index is satisfied.
+    conn.execute(
+        "INSERT INTO github_refs(owner, repo, number, ref_kind, source_kind, source_path, \
+         source_text, discovered_at_ms, repo_id)
+         VALUES (?1, ?2, ?3, 'closing', 'file', ?4, ?5, 0, ?6)",
+        params![
+            gh_owner,
+            gh_repo,
+            POISON_SAMEPATH_GH_NUMBER,
+            collision_path,
+            POISON_SAMEPATH_REFTEXT,
+            POISON_REPO_ID
+        ],
+    )?;
+
     Ok(())
+}
+
+/// The lexicographically-first REAL (non-sibling) indexed path — the primary-repo path the
+/// SAME-PATH tripwires collide onto. Falls back to [`POISON_SAMEPATH_FALLBACK`] when the fixture
+/// indexed no files (an empty repo): there is then nothing to collide with, but the seeded rows
+/// still guard against an unscoped DELETE. Deterministic (`ORDER BY path`), so a meta-test can
+/// re-resolve the same path. Resolve it BEFORE seeding the sibling's own rows (all under
+/// `POISON_REPO_ID`, so `repo_id != POISON_REPO_ID` also excludes them defensively).
+fn primary_collision_path(conn: &Connection) -> anyhow::Result<String> {
+    let path: String = conn.query_row(
+        "SELECT COALESCE(
+             (SELECT path FROM main.files WHERE repo_id != ?1 ORDER BY path LIMIT 1),
+             ?2)",
+        params![POISON_REPO_ID, POISON_SAMEPATH_FALLBACK],
+        |row| row.get(0),
+    )?;
+    Ok(path)
 }
 
 /// Remove every poison-sibling row, child→parent, so [`seed_sibling`] is idempotent across repeated
@@ -249,7 +519,15 @@ fn clear_sibling(conn: &Connection) -> anyhow::Result<()> {
          DELETE FROM packages WHERE repo_id = '{POISON_REPO_ID}';
          DELETE FROM git_file_changes WHERE repo_id = '{POISON_REPO_ID}';
          DELETE FROM git_commits WHERE repo_id = '{POISON_REPO_ID}';
-         DELETE FROM main.files WHERE repo_id = '{POISON_REPO_ID}';"
+         DELETE FROM main.files WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM github_refs WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM github_issues WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM github_comments WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM github_pull_requests WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM github_reviews WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM github_review_comments WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM github_ref_sync WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM github_fts WHERE repo_id = '{POISON_REPO_ID}';"
     ))?;
     Ok(())
 }
@@ -264,10 +542,20 @@ fn sibling_tripwires() -> Vec<(&'static str, String)> {
         format!("file_id IN (SELECT id FROM main.files WHERE repo_id = '{POISON_REPO_ID}')");
     vec![
         ("git_commits", format!("repo_id = '{POISON_REPO_ID}' AND hash = '{POISON_COMMIT}'")),
-        ("git_file_changes", format!("repo_id = '{POISON_REPO_ID}'")),
+        // Pinned to the distinct-path row's path so the same-path `git_file_changes` tripwire
+        // (a second row under `POISON_REPO_ID`) doesn't inflate this count.
+        (
+            "git_file_changes",
+            format!("repo_id = '{POISON_REPO_ID}' AND path = '{POISON_PREFIX}change.rs'"),
+        ),
         ("main.files", format!("repo_id = '{POISON_REPO_ID}' AND path = '{POISON_PREFIX}file.rs'")),
         ("packages", format!("repo_id = '{POISON_REPO_ID}'")),
-        ("parser_failures", format!("repo_id = '{POISON_REPO_ID}'")),
+        // Pinned to the distinct-path row's path so the same-path `parser_failures` tripwire
+        // doesn't inflate this count.
+        (
+            "parser_failures",
+            format!("repo_id = '{POISON_REPO_ID}' AND path = '{POISON_PREFIX}fail.rs'"),
+        ),
         ("docs", format!("repo_id = '{POISON_REPO_ID}'")),
         ("logical_symbols", format!("id = {POISON_LOGICAL_ID} AND repo_id = '{POISON_REPO_ID}'")),
         ("symbols", file_scope.clone()),
@@ -284,6 +572,88 @@ fn sibling_tripwires() -> Vec<(&'static str, String)> {
             format!(
                 "logical_symbol_id = {POISON_LOGICAL_ID} AND moniker = '{POISON_PREFIX}moniker'"
             ),
+        ),
+        // github papertrail (V041): each base table + the fts mirror pinned by the sentinel
+        // number.
+        ("github_refs", format!("repo_id = '{POISON_REPO_ID}' AND number = {POISON_GH_NUMBER}")),
+        ("github_issues", format!("repo_id = '{POISON_REPO_ID}' AND number = {POISON_GH_NUMBER}")),
+        (
+            "github_comments",
+            format!("repo_id = '{POISON_REPO_ID}' AND number = {POISON_GH_NUMBER}"),
+        ),
+        (
+            "github_pull_requests",
+            format!("repo_id = '{POISON_REPO_ID}' AND number = {POISON_GH_NUMBER}"),
+        ),
+        ("github_reviews", format!("repo_id = '{POISON_REPO_ID}' AND number = {POISON_GH_NUMBER}")),
+        (
+            "github_review_comments",
+            format!("repo_id = '{POISON_REPO_ID}' AND number = {POISON_GH_NUMBER}"),
+        ),
+        (
+            "github_ref_sync",
+            format!("repo_id = '{POISON_REPO_ID}' AND number = {POISON_GH_NUMBER}"),
+        ),
+        // github_fts: one derived mirror row per item kind, pinned by item_kind + item_id + body
+        // so a papertrail resync's re-derivation must reconverge onto exactly this set
+        // (`classification` is derivation-owned and deliberately unpinned).
+        (
+            "github_fts",
+            format!(
+                "repo_id = '{POISON_REPO_ID}' AND number = {POISON_GH_NUMBER} AND item_kind = \
+                 'issue' AND item_id = '{}' AND body = '{POISON_PREFIX}body'",
+                POISON_GH_ITEM_ID + 1
+            ),
+        ),
+        (
+            "github_fts",
+            format!(
+                "repo_id = '{POISON_REPO_ID}' AND number = {POISON_GH_NUMBER} AND item_kind = \
+                 'comment' AND item_id = '{}' AND body = '{POISON_PREFIX}comment'",
+                POISON_GH_ITEM_ID + 2
+            ),
+        ),
+        (
+            "github_fts",
+            format!(
+                "repo_id = '{POISON_REPO_ID}' AND number = {POISON_GH_NUMBER} AND item_kind = \
+                 'pull' AND item_id = '{}' AND body = '{POISON_PREFIX}prbody'",
+                POISON_GH_ITEM_ID + 3
+            ),
+        ),
+        (
+            "github_fts",
+            format!(
+                "repo_id = '{POISON_REPO_ID}' AND number = {POISON_GH_NUMBER} AND item_kind = \
+                 'review' AND item_id = '{}' AND body = '{POISON_PREFIX}review'",
+                POISON_GH_ITEM_ID + 4
+            ),
+        ),
+        (
+            "github_fts",
+            format!(
+                "repo_id = '{POISON_REPO_ID}' AND number = {POISON_GH_NUMBER} AND item_kind = \
+                 'review_comment' AND item_id = '{}' AND body = '{POISON_PREFIX}revcomment'",
+                POISON_GH_ITEM_ID + 5
+            ),
+        ),
+        // SAME-PATH tripwires: pinned by a path-INDEPENDENT sentinel column (the collision path is
+        // fixture-dependent), so the intact check holds whichever primary path was chosen.
+        (
+            "main.files",
+            format!("repo_id = '{POISON_REPO_ID}' AND sha256 = '{POISON_SAMEPATH_SHA}'"),
+        ),
+        (
+            "git_file_changes",
+            format!("repo_id = '{POISON_REPO_ID}' AND additions = {POISON_SAMEPATH_ADDITIONS}"),
+        ),
+        (
+            "parser_failures",
+            format!("repo_id = '{POISON_REPO_ID}' AND message = '{POISON_SAMEPATH_MSG}'"),
+        ),
+        (
+            "github_refs",
+            format!("repo_id = '{POISON_REPO_ID}' AND number = {POISON_SAMEPATH_GH_NUMBER}"),
         ),
     ]
 }
@@ -338,6 +708,93 @@ mod tests {
         assert!(sibling_files >= 1, "the poison file must be seeded by the default rebuild");
 
         // And every tripwire is intact right after seeding.
+        assert_sibling_intact(conn);
+    }
+
+    /// SAME-PATH tripwire liveness: the harness must seed a sibling row whose join key COLLIDES
+    /// with a real primary-repo path, and an intentionally path-keyed UNSCOPED aggregate must see
+    /// it — proving the harness can trip a join-by-path leak (the class the distinct-path rows
+    /// cannot). The paired assertion pins the FIX: the SCOPED production `repo_brief` attributes
+    /// ZERO of the sibling's refs to the primary path. If the unscoped side stops seeing the
+    /// sentinel, the same-path harness is asleep and every join-by-path scoping test is toothless.
+    #[test]
+    fn same_path_tripwires_expose_a_join_by_path_leak() {
+        let (_root, config) = poison_test_config("poison_samepath");
+        let db = IndexDatabase::rebuild(&config).unwrap();
+        let conn = db.storage.connection();
+
+        // The real primary path the harness collided onto — re-resolved the same deterministic way
+        // `primary_collision_path` picks it (src/lib.rs for this fixture).
+        let collision_path: String = conn
+            .query_row(
+                "SELECT path FROM main.files WHERE repo_id != ?1 ORDER BY path LIMIT 1",
+                [POISON_REPO_ID],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(
+            !collision_path.starts_with(POISON_PREFIX),
+            "the collision path must be a REAL primary path, got `{collision_path}`"
+        );
+
+        // The UNSCOPED join-by-path shape (the pre-fix `github_ref_counts` CTE) sees the sibling's
+        // colliding ref at the primary path — the tripwire is live.
+        let unscoped_refs: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM github_refs WHERE source_path = ?1",
+                [&collision_path],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(
+            unscoped_refs >= 1,
+            "same-path github_refs tripwire is asleep: an unscoped path aggregate saw no sibling \
+             ref at the primary path `{collision_path}`",
+        );
+
+        // The SCOPED production surface must NOT leak it: the fixture repo has no github_refs of
+        // its own, so its `src/lib.rs` candidate reports zero refs.
+        let brief = db
+            .repo_brief(crate::query::repo_brief::RepoBriefOptions {
+                mode: crate::query::repo_brief::RepoBriefMode::Spine,
+                limit: 50,
+                include_generated: true,
+                include_memories: false,
+            })
+            .unwrap();
+        let primary = brief
+            .candidates
+            .iter()
+            .find(|candidate| candidate.path == collision_path)
+            .expect("the primary path must appear in the brief");
+        assert_eq!(
+            primary.metrics.github_ref_count, 0,
+            "repo_brief leaked a sibling repo's github_refs across the shared path \
+             `{collision_path}` — scope the github_ref_counts CTE by repo_id",
+        );
+
+        // The same-path rows are counted by the intact check too.
+        assert_sibling_intact(conn);
+    }
+
+    /// A papertrail resync (the github sync tail) DELETEs the whole `github_fts` mirror and
+    /// re-derives it from the base tables — every poisoned base row becomes a derived mirror row.
+    /// The harness must reconverge: the seeded mirror rows are derivation-faithful copies (same
+    /// item_id / url / title / body slots per kind), so the rebuilt mirror carries the SAME
+    /// tripwire set and `assert_sibling_intact` stays meaningful after a mid-test resync. This
+    /// pins `seed_sibling`'s fts seeding to `rebuild_fts`'s derivation — if a column mapping in
+    /// either drifts, this fails locally instead of surfacing as a phantom sibling
+    /// leak in whichever github test resyncs first.
+    #[test]
+    fn github_fts_tripwires_survive_a_papertrail_resync() {
+        let (_root, config) = poison_test_config("poison_resync");
+        let db = IndexDatabase::rebuild(&config).unwrap();
+        let conn = db.storage.connection();
+
+        // Intact on the seeded mirror…
+        assert_sibling_intact(conn);
+        // …and byte-equivalently intact on the re-derived mirror.
+        crate::index::github::rebuild_fts(conn).unwrap();
         assert_sibling_intact(conn);
     }
 

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1175,6 +1175,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_038_ID => Some(38),
             MIGRATION_039_ID => Some(39),
             MIGRATION_040_ID => Some(40),
+            MIGRATION_041_ID => Some(41),
             _ => None,
         })
         .max()
@@ -1224,6 +1225,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_038_ID
             | MIGRATION_039_ID
             | MIGRATION_040_ID
+            | MIGRATION_041_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1270,6 +1272,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_038_ID => migration.checksum != MIGRATION_038_CHECKSUM,
         MIGRATION_039_ID => migration.checksum != MIGRATION_039_CHECKSUM,
         MIGRATION_040_ID => migration.checksum != MIGRATION_040_CHECKSUM,
+        MIGRATION_041_ID => migration.checksum != MIGRATION_041_CHECKSUM,
         _ => false,
     }
 }
@@ -2116,6 +2119,153 @@ fn rebuild_git_commits_tables_with_repo_id(conn: &Connection) -> rusqlite::Resul
         INSERT INTO commit_fts(commit_fts) VALUES('rebuild');
         ",
     )
+}
+
+/// The seven GitHub papertrail tables V041 (phase A4) gives a direct `repo_id` column. Order is
+/// stable so the adoption re-point loop and this migration agree; `github_fts` is NOT here — it is
+/// the standalone FTS mirror, rebuilt separately by [`rebuild_github_fts_with_repo_id`].
+const V041_GITHUB_SCOPED_TABLES: &[&str] = &[
+    "github_refs",
+    "github_issues",
+    "github_comments",
+    "github_pull_requests",
+    "github_reviews",
+    "github_review_comments",
+    "github_ref_sync",
+];
+
+/// V041 (memory-sync phase A4): repo-scope the GitHub papertrail cache so a lexical/papertrail
+/// query in a consolidated DB never surfaces a sibling repo's refs or issues. The seven
+/// [`V041_GITHUB_SCOPED_TABLES`] were repo-GLOBAL before; each gains a `repo_id` column
+/// ([`REPO_ID_COLUMN_DEF`] — existing rows backfill to the placeholder that `register_repo`
+/// re-points at adoption, the A1/A2/A3 pattern), and the standalone `github_fts` gains a `repo_id
+/// UNINDEXED` column via a REBUILD (its FTS5 columns can't be ALTERed).
+///
+/// SCOPE (deliberate): the base tables gain the column but keep their existing keys
+/// (`github_issues`/`github_pull_requests` `UNIQUE(owner, repo, number)`; `github_ref_sync`'s PK;
+/// the id-keyed caches). Phase A keeps ONE repo per DB (`register_repo` refuses a second real repo
+/// until A7), so those keys stay correct; widening them to include `repo_id` for the eventual
+/// multi-repo DB is an A7 concern. Reads scope by the connection's active `repo_id`; writes stamp
+/// it.
+///
+/// TORN-STATE / RE-APPLY: the whole migration self-wraps in ONE `BEGIN IMMEDIATE ... COMMIT` (the
+/// ladder runs apply fns in AUTOCOMMIT), so the base-table columns, the `github_fts` rebuild, AND
+/// the already-adopted-DB backfill commit together — the `github_fts.repo_id` sentinel flips only
+/// once every step (backfill included) has landed. `add_column_if_missing` and the rebuild's
+/// leading `DROP ... IF EXISTS` keep a re-run after a torn intermediate idempotent. All-or-nothing
+/// sentinel: `github_fts` carrying `repo_id` means the whole migration already committed, so a
+/// fresh-from-target DB or a `create_or_migrate` / `rebuild` re-apply short-circuits before
+/// touching anything (and never resolves `sole_repo_id`, keeping the ladder replay-safe on a
+/// consolidated DB).
+pub(crate) fn apply_github_repo_id_scoping(conn: &Connection) -> rusqlite::Result<()> {
+    if column_exists(conn, "github_fts", "repo_id")? {
+        return Ok(());
+    }
+    conn.execute_batch("BEGIN IMMEDIATE;")?;
+    let result = (|| -> rusqlite::Result<()> {
+        // Each base-table column is independent additive DDL (one atomic ALTER).
+        for table in V041_GITHUB_SCOPED_TABLES {
+            add_column_if_missing(conn, table, "repo_id", REPO_ID_COLUMN_DEF)?;
+        }
+        rebuild_github_fts_with_repo_id(conn)?;
+        // P1 (the V039/V040 class): the static `DEFAULT '__unassigned__'` stamps existing rows the
+        // placeholder, and on an ALREADY-ADOPTED DB `register_repo`'s fast path never re-points —
+        // so scoped papertrail reads would return NOTHING for the real repo until the next github
+        // sync. Resolve the sole `repos` row and re-point the placeholder rows onto it (no-op on an
+        // un-adopted DB, where the rows correctly wait for `register_repo` to adopt them).
+        backfill_github_repo_id_to_sole_repo(conn)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = conn.execute_batch("ROLLBACK;");
+        return result;
+    }
+    conn.execute_batch("COMMIT;")
+}
+
+/// Rebuild the standalone (own-content) `github_fts` with an added `repo_id UNINDEXED` column via
+/// the create-new / copy / drop / rename recipe. Its rows are copied stamped the placeholder; the
+/// caller's [`backfill_github_repo_id_to_sole_repo`] then re-points them onto the real id on an
+/// adopted DB.
+///
+/// Runs INSIDE the caller's transaction ([`apply_github_repo_id_scoping`] wraps the whole V041
+/// migration in one `BEGIN IMMEDIATE`), so it opens no txn of its own. The leading `DROP TABLE IF
+/// EXISTS github_fts_new` drops a hard-kill scratch artifact (which bypasses rollback) so the
+/// rebuild re-converges rather than failing on CREATE — the V040 recipe. `github_fts` has no FK, so
+/// no `foreign_keys` toggle is needed.
+fn rebuild_github_fts_with_repo_id(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS github_fts_new;
+        CREATE VIRTUAL TABLE github_fts_new USING fts5(
+            owner,
+            repo,
+            number UNINDEXED,
+            item_kind UNINDEXED,
+            item_id UNINDEXED,
+            url UNINDEXED,
+            title,
+            body,
+            classification,
+            repo_id UNINDEXED,
+            tokenize='porter'
+        );
+        INSERT INTO github_fts_new(
+            owner, repo, number, item_kind, item_id, url, title, body, classification, repo_id
+        )
+        SELECT owner, repo, number, item_kind, item_id, url, title, body, classification,
+               '__unassigned__'
+        FROM github_fts;
+        DROP TABLE github_fts;
+        ALTER TABLE github_fts_new RENAME TO github_fts;
+        ",
+    )
+}
+
+/// P1 backfill (the V040 [`backfill_repo_id_to_sole_repo`] pattern, github edition): re-point every
+/// V041 github row from the placeholder onto the sole `repos` id when the DB is ALREADY ADOPTED, so
+/// a scoped papertrail read sees this repo's cached refs/issues immediately after the upgrade
+/// rather than only after the next sync. No-op on an un-adopted DB (`sole_repo_id` == the
+/// placeholder — the rows correctly wait for `register_repo` to adopt them). Runs inside the
+/// caller's V041 txn, so it is atomic with the sentinel-setting FTS rebuild. The sentinel
+/// short-circuit keeps a replay off this path entirely; the explicit `repos`-cardinality gate
+/// below additionally makes the FIRST apply safe on a CONSOLIDATED DB (leave-at-placeholder
+/// instead of `sole_repo_id`'s one-row hard error aborting the upgrade).
+fn backfill_github_repo_id_to_sole_repo(conn: &Connection) -> rusqlite::Result<()> {
+    // Cardinality gate: the backfill re-points onto THE sole owner of a single-repo DB, and only
+    // that shape has one. A CONSOLIDATED DB (multiple `repos` rows) that reaches V041 without the
+    // sentinel must not abort the forward-migration on `sole_repo_id`'s one-row hard error — there
+    // is no single correct owner to pick. Invariant: on `!= 1` repos rows the github rows stay
+    // under the placeholder, which is safe because (a) the papertrail is a refetchable CACHE, not
+    // authored data; (b) every scoped reader filters `repo_id = <active>`, so placeholder rows are
+    // simply invisible — never misattributed; and (c) the github writers RECLAIM stranded rows by
+    // UPSERT: the tables keep natural keys WITHOUT `repo_id` (the phase-A deviation), so a
+    // placeholder row OCCUPIES its key and a bare `INSERT OR IGNORE` could never repopulate it —
+    // instead each writer's `ON CONFLICT ... DO UPDATE` (or `OR REPLACE` on the id-keyed caches)
+    // re-stamps `repo_id` and refreshes the content on the next sync touching the key, and the
+    // sync-tail `rebuild_fts` re-derives the mirror accordingly (the upsert-reclaim invariant in
+    // `github/store.rs`).
+    let repos_rows: i64 = conn.query_row("SELECT COUNT(*) FROM repos", [], |row| row.get(0))?;
+    if repos_rows != 1 {
+        return Ok(());
+    }
+    let target = sole_repo_id(conn)?;
+    if target == super::LEGACY_REPO_ID {
+        return Ok(());
+    }
+    for table in V041_GITHUB_SCOPED_TABLES {
+        conn.execute(&format!("UPDATE {table} SET repo_id = ?1 WHERE repo_id = ?2"), [
+            target.as_str(),
+            super::LEGACY_REPO_ID,
+        ])?;
+    }
+    // The own-content FTS mirror carries its own `repo_id UNINDEXED` value; re-point it in place
+    // too.
+    conn.execute("UPDATE github_fts SET repo_id = ?1 WHERE repo_id = ?2", [
+        target.as_str(),
+        super::LEGACY_REPO_ID,
+    ])?;
+    Ok(())
 }
 
 /// V035: add `symbols.is_test` (cross-language test-code marker computed at parse time; see

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -11,7 +11,7 @@ pub use registry::{LEGACY_REPO_ID, register_repo};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 40;
+pub const LATEST_SCHEMA_VERSION: u32 = 41;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -261,6 +261,13 @@ const MIGRATION_040_DESCRIPTION: &str =
      parser_failures, git_commits + git_file_changes) with rebuilt UNIQUE / PK keys and the \
      re-pointed commit_fts external content, plus the two active-embedding-model provenance meta \
      keys moved to repo_meta (memory-sync phase A3)";
+const MIGRATION_041_ID: &str = "041_github_repo_id_scoping";
+const MIGRATION_041_CHECKSUM: &str = "sha256:rag-rat-github-repo-id-scoping-v41";
+const MIGRATION_041_DESCRIPTION: &str =
+    "Repo-scope the GitHub papertrail cache: add repo_id to the seven github_* tables (refs, \
+     issues, comments, pull_requests, reviews, review_comments, ref_sync) and rebuild github_fts \
+     with a repo_id UNINDEXED column, so lexical and papertrail queries in a consolidated \
+     database never surface a sibling repo's refs or issues (memory-sync phase A4)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -600,6 +607,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_040_CHECKSUM,
         description: MIGRATION_040_DESCRIPTION,
         apply: apply_repo_id_core_scoping,
+    },
+    Migration {
+        id: MIGRATION_041_ID,
+        checksum: MIGRATION_041_CHECKSUM,
+        description: MIGRATION_041_DESCRIPTION,
+        apply: apply_github_repo_id_scoping,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema/registry.rs
+++ b/crates/rag-rat-core/src/index/schema/registry.rs
@@ -8,16 +8,35 @@ use crate::repo_identity::{LOCAL_ONLY_ID_PREFIX, RepoIdentity, RepoIdentityClass
 /// `commit_sha` / `worktree_id`). [`active_repo_id`] reads it; `install_scope_view` writes it.
 pub(crate) const CONNECTION_CONTEXT_REPO_KEY: &str = "repo_id";
 
-/// The direct-scoped tables that gained a `repo_id TEXT NOT NULL` column in V040 (phase A3) and
-/// therefore need their [`LEGACY_REPO_ID`] placeholder rows re-pointed at the real id when
-/// [`register_repo`] adopts a legacy DB. `git_file_changes` is intentionally ABSENT: its
-/// `(repo_id, commit_hash)` FK to `git_commits(repo_id, hash)` is `ON UPDATE CASCADE`, so rewriting
-/// `git_commits.repo_id` re-points its rows automatically — an explicit UPDATE would instead trip
-/// the FK (the child would reference the real id before the parent moved). `repo_meta` is handled
-/// separately (its FK is to `repos`, and it moved in V039). The A1 adoption contract requires every
-/// direct-scoped table backfill in the same call as the `repos`-row rewrite.
-const V040_DIRECT_SCOPED_TABLES: &[&str] =
-    &["files", "packages", "logical_symbols", "docs", "parser_failures", "git_commits"];
+/// The direct-scoped tables whose [`LEGACY_REPO_ID`] placeholder rows [`register_repo`] re-points
+/// at the real id when it adopts a legacy DB. V040 (phase A3) added the core tables; V041 (phase
+/// A4) added the seven GitHub papertrail tables plus the derived `github_fts` mirror (own-content
+/// FTS5, so its `repo_id UNINDEXED` value updates in place — re-pointing here keeps papertrail
+/// scoped to the real id without waiting for the next sync's `rebuild_fts`). `git_file_changes` is
+/// intentionally ABSENT: its `(repo_id, commit_hash)` FK to `git_commits(repo_id, hash)` is `ON
+/// UPDATE CASCADE`, so rewriting `git_commits.repo_id` re-points its rows automatically — an
+/// explicit UPDATE would instead trip the FK (the child would reference the real id before the
+/// parent moved). `repo_meta` is handled separately (its FK is to `repos`, and it moved in V039).
+/// The A1 adoption contract requires every direct-scoped table backfill in the same call as the
+/// `repos`-row rewrite.
+const DIRECT_SCOPED_ADOPTION_TABLES: &[&str] = &[
+    // V040 (phase A3) core tables.
+    "files",
+    "packages",
+    "logical_symbols",
+    "docs",
+    "parser_failures",
+    "git_commits",
+    // V041 (phase A4) GitHub papertrail tables + the derived FTS mirror.
+    "github_refs",
+    "github_issues",
+    "github_comments",
+    "github_pull_requests",
+    "github_reviews",
+    "github_review_comments",
+    "github_ref_sync",
+    "github_fts",
+];
 
 /// The placeholder `repo_id` a freshly-migrated single-repo DB carries until it is adopted (see the
 /// V038 DDL) — and the backfill value every direct-scoped table gets when later migrations add
@@ -171,13 +190,24 @@ pub fn register_repo(
             source_id,
             SHALLOW_BOUNDARY_META_KEY,
         ])?;
-        // Re-point every direct-scoped table's source rows onto the real id (A3 extends the A1/A2
-        // adoption contract from `repos`/`repo_meta` to the V040 tables). Runs INSIDE the same
-        // transaction, keeping the insert-first ordering: on a fresh open the tables are empty and
-        // these are no-ops; on a forward-migrated DB (or a shallow-clone upgrade) they carry the
-        // rows onto the real id atomically with the `repos` rewrite. `git_commits` is updated here;
-        // `git_file_changes` follows via its `ON UPDATE CASCADE` FK.
-        for table in V040_DIRECT_SCOPED_TABLES {
+        // Re-point every direct-scoped table's source rows onto the real id (A3/A4 extend the
+        // A1/A2 adoption contract from `repos`/`repo_meta` to the V040 core tables and the V041
+        // GitHub papertrail tables). Runs INSIDE the same adoption transaction, keeping the
+        // insert-first ordering: on a fresh open the tables are empty and these are no-ops; on a
+        // forward-migrated DB that indexed under the placeholder (or a shallow-clone upgrade) they
+        // carry the rows onto the real id atomically with the `repos` rewrite. `git_commits` is
+        // updated here; `git_file_changes` follows via its `ON UPDATE CASCADE` FK.
+        for table in DIRECT_SCOPED_ADOPTION_TABLES {
+            // Guard on table presence: a real consolidated DB is fully migrated (every
+            // direct-scoped table exists), but the schema-bootstrap tests exercise
+            // adoption against ISOLATION fixtures that seed only the subset a given
+            // migration touches (V040 core tables OR V041 github tables). Skipping an
+            // absent table keeps adoption correct on the full schema while staying
+            // robust to those partial fixtures — a table that does not exist has no
+            // source rows to re-point.
+            if !adoption_table_present(&tx, table)? {
+                continue;
+            }
             tx.execute(&format!("UPDATE {table} SET repo_id = ?1 WHERE repo_id = ?2"), params![
                 identity.repo_id,
                 source_id
@@ -223,6 +253,20 @@ pub fn register_repo(
         );
     }
     Ok(identity.repo_id.clone())
+}
+
+/// Whether `table` exists in the schema (a plain or FTS5-virtual table both register in
+/// `sqlite_master` as `type = 'table'`) — the adoption loop's guard so a partial isolation
+/// fixture's absent direct-scoped table is skipped rather than tripping a `no such table` failure.
+fn adoption_table_present(conn: &Connection, table: &str) -> rusqlite::Result<bool> {
+    Ok(conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1",
+            [table],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some())
 }
 
 /// A `SQLITE_CONSTRAINT` failure carrying `msg` — the registry's refusal shape. These are

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/chunk_store_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/chunk_store_migrations.rs
@@ -724,12 +724,19 @@ fn files_has_test_code_flag_survives_the_heal_path() {
     let config = source_config(root.clone(), Language::Rust);
     let db = IndexDatabase::rebuild(&config).unwrap();
 
+    // Scope the assertion read to the ACTIVE repo: the poison-sibling harness seeds a same-path
+    // `main.files` row at this fixture's path, so an unscoped `WHERE path = ...` `query_row` is
+    // ambiguous (and after heal re-inserts the primary row at a higher rowid, would return the
+    // sibling's flag). This is a single-repo test, but the fix is to scope the query, not disable
+    // the harness.
+    let repo_id = crate::index::schema::active_repo_id(db.storage.connection()).unwrap();
     let flag = || -> i64 {
         db.storage
             .connection()
             .query_row(
-                "SELECT has_test_code FROM main.files WHERE path = 'src/markers.rs'",
-                [],
+                "SELECT has_test_code FROM main.files WHERE path = 'src/markers.rs' AND repo_id = \
+                 ?1",
+                [&repo_id],
                 |row| row.get(0),
             )
             .unwrap()

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
@@ -653,3 +653,201 @@ fn orientation_pins_the_fork_repo_over_a_shared_root_sibling() {
     );
     let _ = fs::remove_dir_all(root);
 }
+
+// --- Cross-repo FTS / papertrail leak matrix (spec §9, memory-sync phase A4) ---
+//
+// Repo A is really indexed (its chunk_fts / commit_fts / git_file_changes are populated by the
+// rebuild); repo B's search rows are SEEDED directly under REPO_B with UNIQUELY-named content. The
+// contract: every search / git-history / papertrail query run on repo A's scoped connection returns
+// ONLY repo A's rows and NEVER surfaces repo B's — even though both live in the one database.
+
+/// Repo B's unique tokens (seeded under REPO_B); a query for any of these from repo A's connection
+/// must come back empty.
+const B_LEXICAL_TOKEN: &str = "zebrafishunique";
+const B_COMMIT_TOKEN: &str = "narwhalcommitunique";
+const B_ISSUE_TOKEN: &str = "unicornissueunique";
+/// Repo A's unique GitHub token (seeded under the real repo id) — the positive control on the same
+/// papertrail surface.
+const A_ISSUE_TOKEN: &str = "phoenixissueunique";
+
+/// Seed a GitHub ref + issue + FTS row for `repo_id`, all carrying `token`.
+fn seed_github_issue(
+    conn: &rusqlite::Connection,
+    repo_id: &str,
+    owner: &str,
+    repo: &str,
+    number: i64,
+    token: &str,
+    source_path: &str,
+) {
+    conn.execute(
+        "INSERT INTO github_refs(owner, repo, number, ref_kind, source_kind, source_path, \
+         source_commit, source_text, discovered_at_ms, repo_id)
+         VALUES (?1, ?2, ?3, 'closing', 'file', ?4, NULL, ?5, 0, ?6)",
+        rusqlite::params![owner, repo, number, source_path, format!("{token} ref"), repo_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO github_issues(owner, repo, number, html_url, state, title, body, \
+         is_pull_request, synced_at_ms, repo_id)
+         VALUES (?1, ?2, ?3, 'http://x', 'open', ?4, ?5, 0, 0, ?6)",
+        rusqlite::params![
+            owner,
+            repo,
+            number,
+            format!("{token} title"),
+            format!("{token} body"),
+            repo_id
+        ],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO github_fts(owner, repo, number, item_kind, item_id, url, title, body, \
+         classification, repo_id)
+         VALUES (?1, ?2, ?3, 'issue', ?4, 'http://x', ?5, ?6, 'other', ?7)",
+        rusqlite::params![
+            owner,
+            repo,
+            number,
+            number.to_string(),
+            format!("{token} title"),
+            format!("{token} body"),
+            repo_id
+        ],
+    )
+    .unwrap();
+}
+
+/// Seed repo B's search-surface rows (a chunk in chunk_fts, a commit in commit_fts, a
+/// git_file_changes row, a github ref/issue/fts) under REPO_B, plus repo A's own github issue under
+/// the real id (the positive control). Requires a `two_repo_fixture` (repo A indexed, repo B's file
+/// rows already seeded).
+fn seed_search_leak_data(fx: &TwoRepoFixture) {
+    let conn = fx.db.storage.connection();
+
+    // Repo B: a chunk whose text carries a unique token, wired into chunk_text + the contentless
+    // chunk_fts, hung off repo B's live b_only.rs file row.
+    let file_id: i64 = conn
+        .query_row(
+            "SELECT id FROM main.files WHERE repo_id = ?1 AND path = 'src/b_only.rs'",
+            [REPO_B],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let text = format!("fn b_fn() {{ /* {B_LEXICAL_TOKEN} */ }}");
+    let chunk_id: i64 = conn
+        .query_row(
+            "INSERT INTO chunks(file_id, chunk_kind, symbol_path, start_byte, end_byte, \
+             start_line, end_line, text_hash)
+             VALUES (?1, 'symbol', 'b_fn', 0, 10, 1, 5, 'bhash') RETURNING id",
+            [file_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    crate::index::chunk_text_store::seed_chunk_text(conn, chunk_id, &text).unwrap();
+    conn.execute("INSERT INTO chunk_fts(rowid, text) VALUES (?1, ?2)", rusqlite::params![
+        chunk_id, text
+    ])
+    .unwrap();
+
+    // Repo B: a commit + file change under REPO_B, then re-point the external-content commit_fts
+    // over EVERY repo's commits so repo B's commit IS in the FTS (the leak surface the join
+    // must filter).
+    conn.execute(
+        "INSERT INTO git_commits(hash, author_name, author_email, authored_at_s, committed_at_s, \
+         subject, body, changed_file_count, repo_id)
+         VALUES ('bbbbb1111', 'b', 'b@e', 10, 10, ?1, '', 1, ?2)",
+        rusqlite::params![format!("{B_COMMIT_TOKEN} subject"), REPO_B],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO git_file_changes(commit_hash, path, additions, deletions, change_kind, \
+         repo_id)
+         VALUES ('bbbbb1111', 'src/b_only.rs', 1, 0, 'modified', ?1)",
+        [REPO_B],
+    )
+    .unwrap();
+    crate::index::schema::rebuild_commit_fts(conn).unwrap();
+
+    // Repo B's papertrail (must never leak) + repo A's own papertrail (the positive control).
+    seed_github_issue(conn, REPO_B, "octob", "rb", 77, B_ISSUE_TOKEN, "src/b_only.rs");
+    seed_github_issue(conn, &fx.repo_a_id, "octoa", "ra", 11, A_ISSUE_TOKEN, "src/a_only.rs");
+}
+
+/// Lexical + hybrid candidate selection is repo-scoped: repo B's uniquely-tokened chunk is
+/// unreachable from repo A's connection (both the bm25 and the vector candidate pass JOIN the
+/// repo-scoped `files` view, so a sibling repo's chunk is dropped before ranking), while repo A's
+/// own chunk is still found.
+#[test]
+fn lexical_and_hybrid_search_never_surface_the_other_repo() {
+    let fx = two_repo_fixture();
+    seed_search_leak_data(&fx);
+    let conn = fx.db.storage.connection();
+
+    // Raw lexical (bm25 candidates through the scope view): repo B's token does not leak.
+    let leaked =
+        crate::search::lexical::search_lexical_only(conn, B_LEXICAL_TOKEN, 10, false).unwrap();
+    assert!(leaked.is_empty(), "repo B chunk leaked into repo A lexical search: {leaked:?}");
+    // Full hybrid entry (bm25 + vector fuse; no model ⇒ lexical-only, still through the view).
+    let leaked_hybrid = fx.db.search(B_LEXICAL_TOKEN, 10, false).unwrap();
+    assert!(leaked_hybrid.is_empty(), "repo B chunk leaked into repo A hybrid search");
+    // Positive control: repo A's own indexed symbol IS reachable.
+    let own = crate::search::lexical::search_lexical_only(conn, "a_only", 10, false).unwrap();
+    assert!(
+        own.iter().any(|hit| hit.path == "src/a_only.rs"),
+        "repo A must still see its own chunk: {own:?}"
+    );
+
+    let _ = fs::remove_dir_all(fx.root_a);
+}
+
+/// Git-history queries are repo-scoped: repo B's commit (commit_fts MATCH) and its path history are
+/// unreachable from repo A, and `status` counts only repo A's commits — repo A still sees its own.
+#[test]
+fn git_history_queries_never_surface_the_other_repo() {
+    let fx = two_repo_fixture();
+    seed_search_leak_data(&fx);
+    let conn = fx.db.storage.connection();
+
+    // commit_search joins commit_fts → git_commits and filters git_commits.repo_id.
+    let leaked = crate::index::git_history::commit_search(conn, B_COMMIT_TOKEN, 10).unwrap();
+    assert!(leaked.is_empty(), "repo B commit leaked into repo A commit_search: {leaked:?}");
+    let own = crate::index::git_history::commit_search(conn, "init", 10).unwrap();
+    assert!(!own.is_empty(), "repo A must still see its own commit");
+
+    // history_for_path filters git_file_changes.repo_id.
+    let leaked_hist =
+        crate::index::git_history::history_for_path(conn, "src/b_only.rs", 10).unwrap();
+    assert!(leaked_hist.is_empty(), "repo B path history leaked: {leaked_hist:?}");
+    let own_hist = crate::index::git_history::history_for_path(conn, "src/a_only.rs", 10).unwrap();
+    assert!(!own_hist.is_empty(), "repo A must still see its own path history");
+
+    // status counts are per-repo: repo A has exactly its one indexed commit, not repo B's.
+    let status = crate::index::git_history::status(conn, &fx.root_a).unwrap();
+    assert_eq!(status.commit_count, 1, "status counts only repo A's git_commits, not repo B's");
+
+    let _ = fs::remove_dir_all(fx.root_a);
+}
+
+/// Papertrail queries are repo-scoped: repo B's issue (github_fts MATCH) and its path-anchored ref
+/// are unreachable from repo A, while repo A's own issue on the SAME surface is found.
+#[test]
+fn papertrail_queries_never_surface_the_other_repo() {
+    let fx = two_repo_fixture();
+    seed_search_leak_data(&fx);
+    let conn = fx.db.storage.connection();
+
+    // github_issue_search → search_fts, which filters github_fts.repo_id.
+    let leaked = fx.db.github_issue_search(B_ISSUE_TOKEN, 10).unwrap();
+    assert!(leaked.is_empty(), "repo B issue leaked into repo A github search: {leaked:?}");
+    let own = fx.db.github_issue_search(A_ISSUE_TOKEN, 10).unwrap();
+    assert!(!own.is_empty(), "repo A must still see its own issue");
+
+    // refs_for_path filters github_refs.repo_id.
+    let leaked_refs = crate::index::github::refs_for_path(conn, "src/b_only.rs", 10).unwrap();
+    assert!(leaked_refs.is_empty(), "repo B github ref leaked: {leaked_refs:?}");
+    let own_refs = crate::index::github::refs_for_path(conn, "src/a_only.rs", 10).unwrap();
+    assert!(!own_refs.is_empty(), "repo A must still see its own github ref");
+
+    let _ = fs::remove_dir_all(fx.root_a);
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -42,19 +42,23 @@ fn dirty_git_files_are_indexed_as_worktree_overlay() {
 
     fs::write(docs.join("search.md"), "# Title\noverlay token\n").unwrap();
     let db = IndexDatabase::index_changed(&config).unwrap();
-    let scopes = db
-        .storage
-        .connection()
+    // Scope the raw file-scope enumeration to the ACTIVE repo: the poison-sibling harness seeds a
+    // same-path (committed-shaped) `main.files` row at this fixture's path, which would otherwise
+    // appear as an extra `(true, false)`. Reading through the scope view is wrong here (the test
+    // needs both the raw committed row AND the overlay row), so scope by `repo_id` instead.
+    let conn = db.storage.connection();
+    let repo_id = crate::index::schema::active_repo_id(conn).unwrap();
+    let scopes = conn
         .prepare(
             "
                 SELECT commit_sha != '', worktree_id != ''
                 FROM main.files
-                WHERE path = 'docs/search.md'
+                WHERE path = 'docs/search.md' AND repo_id = ?1
                 ORDER BY commit_sha != '' DESC, worktree_id != '' DESC
                 ",
         )
         .unwrap()
-        .query_map([], |row| Ok((row.get::<_, bool>(0)?, row.get::<_, bool>(1)?)))
+        .query_map([&repo_id], |row| Ok((row.get::<_, bool>(0)?, row.get::<_, bool>(1)?)))
         .unwrap()
         .collect::<Result<Vec<_>, _>>()
         .unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -869,15 +869,19 @@ fn seed_pre_v040_commit(conn: &rusqlite::Connection, hash: &str, subject: &str) 
     conn.execute_batch("INSERT INTO commit_fts(commit_fts) VALUES('rebuild');").unwrap();
 }
 
-/// Fresh `apply` runs V040 (the schema tip): every direct-scoped core table gains `repo_id`, and
-/// the widened UNIQUE/PK keys make same-path/same-hash rows distinct across repos. Owns the
-/// absolute `LATEST_SCHEMA_VERSION` pin.
+/// Fresh `apply` runs V040: every direct-scoped core table gains `repo_id`, and the widened
+/// UNIQUE/PK keys make same-path/same-hash rows distinct across repos. (The absolute
+/// `LATEST_SCHEMA_VERSION` pin moved to `migration_041_*`, the new tip; this uses only the symbolic
+/// `current_version == LATEST` check.)
 #[test]
-fn migration_040_is_the_latest_tip_and_scopes_core_tables() {
+fn migration_040_scopes_core_tables() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 40, "V040 is the schema tip");
-    assert_eq!(schema::status(&conn).unwrap().current_version, 40, "schema at LATEST after apply");
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply"
+    );
 
     for table in [
         "files",
@@ -1773,4 +1777,434 @@ fn open_config_falls_back_to_the_sole_repo_on_a_non_git_root() {
         "the un-adopted single-repo DB scopes to the placeholder"
     );
     let _ = fs::remove_dir_all(root);
+}
+
+// --- V041: repo_id scoping on the GitHub papertrail tables (memory-sync phase A4) ---
+
+/// The pre-V041 shape of the seven GitHub tables + `github_fts` (no `repo_id`) plus the V038
+/// registry, built in ISOLATION so [`schema::apply_github_repo_id_scoping`] is exercised against
+/// its own inputs (the directory's "assert deferred absence / rebuild behavior in isolation" rule).
+fn seed_pre_v041_github_schema(conn: &rusqlite::Connection) {
+    conn.execute_batch(
+        "
+        CREATE TABLE github_refs(
+            id INTEGER PRIMARY KEY AUTOINCREMENT, owner TEXT NOT NULL, repo TEXT NOT NULL,
+            number INTEGER NOT NULL, ref_kind TEXT NOT NULL DEFAULT 'unknown',
+            source_kind TEXT NOT NULL, source_path TEXT, source_commit TEXT,
+            source_text TEXT NOT NULL, discovered_at_ms INTEGER NOT NULL);
+        CREATE TABLE github_issues(
+            id INTEGER PRIMARY KEY AUTOINCREMENT, owner TEXT NOT NULL, repo TEXT NOT NULL,
+            number INTEGER NOT NULL, html_url TEXT NOT NULL, state TEXT NOT NULL, title TEXT NOT \
+         NULL,
+            body TEXT NOT NULL, author TEXT, created_at TEXT, updated_at TEXT,
+            is_pull_request INTEGER NOT NULL DEFAULT 0, synced_at_ms INTEGER NOT NULL,
+            UNIQUE(owner, repo, number));
+        CREATE TABLE github_comments(
+            id INTEGER PRIMARY KEY, owner TEXT NOT NULL, repo TEXT NOT NULL, number INTEGER NOT \
+         NULL,
+            html_url TEXT NOT NULL, body TEXT NOT NULL, author TEXT, created_at TEXT, updated_at \
+         TEXT,
+            synced_at_ms INTEGER NOT NULL);
+        CREATE TABLE github_pull_requests(
+            id INTEGER PRIMARY KEY AUTOINCREMENT, owner TEXT NOT NULL, repo TEXT NOT NULL,
+            number INTEGER NOT NULL, html_url TEXT NOT NULL, state TEXT NOT NULL, title TEXT NOT \
+         NULL,
+            body TEXT NOT NULL, author TEXT, created_at TEXT, updated_at TEXT, merged_at TEXT,
+            synced_at_ms INTEGER NOT NULL, UNIQUE(owner, repo, number));
+        CREATE TABLE github_reviews(
+            id INTEGER PRIMARY KEY, owner TEXT NOT NULL, repo TEXT NOT NULL, number INTEGER NOT \
+         NULL,
+            html_url TEXT, state TEXT NOT NULL, body TEXT NOT NULL, author TEXT, submitted_at TEXT,
+            synced_at_ms INTEGER NOT NULL);
+        CREATE TABLE github_review_comments(
+            id INTEGER PRIMARY KEY, owner TEXT NOT NULL, repo TEXT NOT NULL, number INTEGER NOT \
+         NULL,
+            path TEXT, html_url TEXT NOT NULL, body TEXT NOT NULL, author TEXT, created_at TEXT,
+            updated_at TEXT, synced_at_ms INTEGER NOT NULL);
+        CREATE TABLE github_ref_sync(
+            owner TEXT NOT NULL, repo TEXT NOT NULL, number INTEGER NOT NULL, status TEXT NOT NULL,
+            synced_at_ms INTEGER NOT NULL, last_error TEXT, PRIMARY KEY(owner, repo, number));
+        CREATE VIRTUAL TABLE github_fts USING fts5(
+            owner, repo, number UNINDEXED, item_kind UNINDEXED, item_id UNINDEXED, url UNINDEXED,
+            title, body, classification, tokenize='porter');
+        ",
+    )
+    .unwrap();
+    schema::apply_repos_registry(conn).expect("V038 registry seeds the placeholder");
+}
+
+/// Fresh `apply` runs V041 (the schema tip): the seven GitHub tables and `github_fts` gain a direct
+/// `repo_id`. Owns the absolute `LATEST_SCHEMA_VERSION` pin.
+#[test]
+fn migration_041_is_the_latest_tip_and_scopes_github() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 41, "V041 is the schema tip");
+    assert_eq!(schema::status(&conn).unwrap().current_version, 41, "schema at LATEST after apply");
+
+    for table in [
+        "github_refs",
+        "github_issues",
+        "github_comments",
+        "github_pull_requests",
+        "github_reviews",
+        "github_review_comments",
+        "github_ref_sync",
+        "github_fts",
+    ] {
+        assert!(
+            conn_table_columns(&conn, table).contains(&"repo_id".to_string()),
+            "{table} gains a direct repo_id column"
+        );
+    }
+}
+
+/// V041's `github_fts` REBUILD is driven against the pre-V041 fixture IN ISOLATION: the base tables
+/// gain `repo_id`, the FTS row survives the rebuild (backfilled to the placeholder) and still
+/// MATCHes, and the migration RE-CONVERGES from a torn intermediate (a leftover `github_fts_new`
+/// scratch table from a crashed prior pass). Then `register_repo` adoption re-points every
+/// placeholder row — the base tables AND the derived FTS mirror.
+#[test]
+fn migration_041_github_rebuild_preserves_rows_and_reconverges_from_torn_state() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    seed_pre_v041_github_schema(&conn);
+    // A synced issue + its FTS row, as a pre-V041 index carries them.
+    conn.execute(
+        "INSERT INTO github_issues(owner, repo, number, html_url, state, title, body, synced_at_ms)
+         VALUES ('o', 'r', 7, 'http://i', 'open', 'zebra title', 'zebra body', 0)",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO github_fts(owner, repo, number, item_kind, item_id, url, title, body, \
+         classification)
+         VALUES ('o', 'r', 7, 'issue', '1', 'http://i', 'zebra title', 'zebra body', 'other')",
+        [],
+    )
+    .unwrap();
+
+    // TORN STATE: a prior V041 pass crashed after creating the scratch FTS table. The rebuild must
+    // drop it and re-converge rather than fail on CREATE.
+    conn.execute_batch("CREATE TABLE github_fts_new(bogus INTEGER);").unwrap();
+
+    schema::apply_github_repo_id_scoping(&conn).expect("V041 converges from the torn state");
+
+    assert!(!conn_table_exists(&conn, "github_fts_new"), "scratch table gone");
+    assert!(
+        conn_table_columns(&conn, "github_fts").contains(&"repo_id".to_string()),
+        "github_fts rebuilt with repo_id"
+    );
+    assert!(
+        conn_table_columns(&conn, "github_issues").contains(&"repo_id".to_string()),
+        "github_issues gained repo_id"
+    );
+
+    // The FTS row survived, backfilled to the placeholder, and still MATCHes.
+    let (repo_id, matched): (String, i64) = conn
+        .query_row(
+            "SELECT repo_id, (SELECT COUNT(*) FROM github_fts WHERE github_fts MATCH 'zebra')
+             FROM github_fts WHERE github_fts MATCH 'zebra'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(repo_id, LEGACY_REPO_ID, "existing FTS rows backfill to the placeholder");
+    assert_eq!(matched, 1, "github_fts still MATCHes after the rebuild");
+
+    // Idempotent re-run (the sentinel short-circuits once github_fts carries repo_id).
+    schema::apply_github_repo_id_scoping(&conn).expect("re-apply is a clean no-op");
+}
+
+/// Full-schema adoption of the V041 GitHub papertrail: `register_repo` re-points the placeholder
+/// github rows (a base table AND the `github_fts` mirror) onto the real id. Kept SEPARATE from the
+/// `migration_041_github_rebuild_*` isolation test above because adoption now runs
+/// `realign_logical_symbol_ids`, which needs the full core schema the github-only isolation fixture
+/// omits (it would trip `no such table: logical_symbols`). The full ladder gives adoption every
+/// table it touches.
+#[test]
+fn register_repo_repoints_github_papertrail_rows_to_the_real_id() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    schema::apply(&conn).unwrap();
+    // A synced issue + its FTS mirror seeded under the placeholder, as a pre-adoption index carries
+    // them (both explicitly stamped LEGACY_REPO_ID so adoption's placeholder re-point matches).
+    conn.execute(
+        "INSERT INTO github_issues(owner, repo, number, html_url, state, title, body, \
+         synced_at_ms, repo_id)
+         VALUES ('o', 'r', 7, 'http://i', 'open', 'zebra title', 'zebra body', 0, ?1)",
+        [LEGACY_REPO_ID],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO github_fts(owner, repo, number, item_kind, item_id, url, title, body, \
+         classification, repo_id)
+         VALUES ('o', 'r', 7, 'issue', '1', 'http://i', 'zebra title', 'zebra body', 'other', ?1)",
+        [LEGACY_REPO_ID],
+    )
+    .unwrap();
+
+    register_repo(&conn, &identity("repo-real", "r"), Path::new("/src/r"), 1).unwrap();
+
+    let issue_repo: String =
+        conn.query_row("SELECT repo_id FROM github_issues", [], |r| r.get(0)).unwrap();
+    assert_eq!(issue_repo, "repo-real", "adoption re-points github_issues");
+    let fts_repo: String = conn
+        .query_row("SELECT repo_id FROM github_fts WHERE github_fts MATCH 'zebra'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(fts_repo, "repo-real", "adoption re-points the github_fts mirror in place");
+}
+
+/// P1 backfill (the V040 class): applying V041 on an ALREADY-ADOPTED DB (a real `repos` row, the
+/// placeholder gone) must re-point the existing github rows — base tables AND the `github_fts`
+/// mirror — onto the real id via `sole_repo_id`, NOT strand them under the static
+/// `'__unassigned__'` column default where a scoped papertrail read would never see them until the
+/// next sync.
+#[test]
+fn migration_041_backfills_an_adopted_pre_v041_db_under_the_real_repo_id() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    seed_pre_v041_github_schema(&conn);
+    conn.execute(
+        "INSERT INTO github_issues(owner, repo, number, html_url, state, title, body, synced_at_ms)
+         VALUES ('o', 'r', 7, 'http://i', 'open', 't', 'b', 0)",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO github_refs(owner, repo, number, source_kind, source_text, discovered_at_ms)
+         VALUES ('o', 'r', 7, 'file', 'reftext', 0)",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO github_fts(owner, repo, number, item_kind, item_id, url, title, body, \
+         classification)
+         VALUES ('o', 'r', 7, 'issue', '1', 'http://i', 't', 'b', 'other')",
+        [],
+    )
+    .unwrap();
+    // Adopt as a pre-V041 binary's `register_repo` left it: a real `repos` row, placeholder gone.
+    conn.execute(
+        "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('repo-adopted', 'r', \
+         1)",
+        [],
+    )
+    .unwrap();
+    conn.execute("DELETE FROM repos WHERE repo_id = ?1", [LEGACY_REPO_ID]).unwrap();
+
+    schema::apply_github_repo_id_scoping(&conn).expect("V041 applies on an adopted DB");
+
+    for table in ["github_refs", "github_issues", "github_fts"] {
+        let (total, under_real): (i64, i64) = conn
+            .query_row(
+                &format!(
+                    "SELECT COUNT(*), COALESCE(SUM(repo_id = 'repo-adopted'), 0) FROM {table}"
+                ),
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert!(total > 0, "{table}: the fixture seeded at least one row");
+        assert_eq!(under_real, total, "{table}: every row backfilled under the REAL repo id");
+    }
+    let stranded: i64 = conn
+        .query_row("SELECT COUNT(*) FROM github_issues WHERE repo_id = ?1", [LEGACY_REPO_ID], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(stranded, 0, "nothing remains stranded under the placeholder");
+}
+
+/// V041 on a CONSOLIDATED (multi-repo) V040-level DB: there is no single owner for the backfill to
+/// re-point onto, so the migration must SUCCEED — not abort on `sole_repo_id`'s one-row hard error
+/// — and leave the github rows under the placeholder. That is safe: the papertrail is a
+/// refetchable cache, every scoped reader filters `repo_id = <active>` (placeholder rows are
+/// invisible, never misattributed), and each repo's next github sync re-populates its slice under
+/// the proper stamp.
+#[test]
+fn migration_041_leaves_github_rows_at_the_placeholder_on_a_consolidated_db() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    seed_pre_v041_github_schema(&conn);
+    conn.execute(
+        "INSERT INTO github_issues(owner, repo, number, html_url, state, title, body, synced_at_ms)
+         VALUES ('o', 'r', 7, 'http://i', 'open', 't', 'b', 0)",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO github_refs(owner, repo, number, source_kind, source_text, discovered_at_ms)
+         VALUES ('o', 'r', 7, 'file', 'reftext', 0)",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO github_fts(owner, repo, number, item_kind, item_id, url, title, body, \
+         classification)
+         VALUES ('o', 'r', 7, 'issue', '1', 'http://i', 't', 'b', 'other')",
+        [],
+    )
+    .unwrap();
+    // The consolidated end-state: TWO real repos, placeholder row gone.
+    conn.execute(
+        "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('repo-a', 'a', 1), \
+         ('repo-b', 'b', 2)",
+        [],
+    )
+    .unwrap();
+    conn.execute("DELETE FROM repos WHERE repo_id = ?1", [LEGACY_REPO_ID]).unwrap();
+
+    schema::apply_github_repo_id_scoping(&conn)
+        .expect("V041 must not abort the upgrade on a consolidated DB");
+
+    for table in ["github_refs", "github_issues", "github_fts"] {
+        let (total, under_placeholder): (i64, i64) = conn
+            .query_row(
+                &format!(
+                    "SELECT COUNT(*), COALESCE(SUM(repo_id = '{LEGACY_REPO_ID}'), 0) FROM {table}"
+                ),
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert!(total > 0, "{table}: the fixture seeded at least one row");
+        assert_eq!(
+            under_placeholder, total,
+            "{table}: every row stays under the placeholder — no arbitrary owner is picked"
+        );
+        // The shape every V041 reader uses: a scoped read filters `repo_id = <active>`, so the
+        // placeholder rows are invisible to BOTH repos.
+        for repo in ["repo-a", "repo-b"] {
+            let visible: i64 = conn
+                .query_row(
+                    &format!("SELECT COUNT(*) FROM {table} WHERE repo_id = ?1"),
+                    [repo],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(visible, 0, "{table}: placeholder rows must be invisible to {repo}");
+        }
+    }
+}
+
+/// The reclamation half of the consolidated-DB gate: the github tables keep natural keys WITHOUT
+/// `repo_id`, so a placeholder-stranded row OCCUPIES its key — a conflict-ignoring writer could
+/// never repopulate it and the cache would be stranded forever. The writers upsert-reclaim
+/// instead: the next sync that touches a stranded key re-stamps `repo_id`, refreshes the content,
+/// and the sync-tail `rebuild_fts` re-derives the mirror. Rows the sync does NOT touch stay under
+/// the placeholder (they wait for their own repo's sync).
+#[test]
+fn v041_placeholder_github_rows_are_reclaimed_by_the_next_sync() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    // The state the consolidated-DB gate leaves: github rows stranded under the placeholder on a
+    // two-real-repo DB.
+    conn.execute_batch(&format!(
+        "INSERT INTO github_refs(owner, repo, number, ref_kind, source_kind, source_path, \
+         source_commit, source_text, discovered_at_ms, repo_id)
+         VALUES ('o', 'r', 7, 'unknown', 'manual', NULL, NULL, 'o/r#7', 1, '{p}');
+         INSERT INTO github_issues(owner, repo, number, html_url, state, title, body, \
+         synced_at_ms, repo_id)
+         VALUES ('o', 'r', 7, 'http://stale', 'open', 'stale title', 'stale body', 1, '{p}');
+         INSERT INTO github_issues(owner, repo, number, html_url, state, title, body, \
+         synced_at_ms, repo_id)
+         VALUES ('o', 'r', 8, 'http://other', 'open', 'other stale', 'other body', 1, '{p}');
+         INSERT INTO github_ref_sync(owner, repo, number, status, synced_at_ms, repo_id)
+         VALUES ('o', 'r', 7, 'synced', 1, '{p}');
+         INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('repo-a', 'a', 1), \
+         ('repo-b', 'b', 2);
+         DELETE FROM repos WHERE repo_id = '{p}';",
+        p = LEGACY_REPO_ID
+    ))
+    .unwrap();
+    // Mirror state before any reclaim: derived from the stranded base rows.
+    crate::index::github::rebuild_fts(&conn).unwrap();
+
+    // Pin the connection's active repo to repo-a (what `set_context` installs on a real open).
+    conn.execute_batch(
+        "CREATE TEMP TABLE IF NOT EXISTS connection_context(key TEXT PRIMARY KEY, value TEXT);
+         INSERT OR REPLACE INTO temp.connection_context(key, value) VALUES ('repo_id', 'repo-a');",
+    )
+    .unwrap();
+
+    // repo-a's sync touches o/r#7: re-discovers the ref (same natural key as the stranded row),
+    // refetches the issue with fresh content, and marks the sync cursor.
+    let reference = crate::index::github::GitHubRef {
+        owner: "o".to_string(),
+        repo: "r".to_string(),
+        number: 7,
+        ref_kind: "unknown".to_string(),
+        source_kind: "manual".to_string(),
+        source_path: None,
+        source_commit: None,
+        source_text: "o/r#7".to_string(),
+    };
+    crate::index::github::store_ref(&conn, &reference).unwrap();
+    crate::index::github::store_issue(&conn, &crate::index::github::GitHubIssue {
+        owner: "o".to_string(),
+        repo: "r".to_string(),
+        number: 7,
+        html_url: "http://fresh".to_string(),
+        state: "closed".to_string(),
+        title: "fresh title".to_string(),
+        body: "fresh body".to_string(),
+        author: None,
+        created_at: None,
+        updated_at: None,
+        is_pull_request: false,
+    })
+    .unwrap();
+    crate::index::github::mark_ref_sync(&conn, &reference, "synced", None).unwrap();
+    // The sync tail: the whole-table mirror rebuild follows the reclaimed base rows.
+    crate::index::github::rebuild_fts(&conn).unwrap();
+
+    // The touched rows are re-stamped to repo-a with refreshed content…
+    let (issue_repo, issue_title): (String, String) = conn
+        .query_row("SELECT repo_id, title FROM github_issues WHERE number = 7", [], |r| {
+            Ok((r.get(0)?, r.get(1)?))
+        })
+        .unwrap();
+    assert_eq!(issue_repo, "repo-a", "the stranded issue row is reclaimed by the syncing repo");
+    assert_eq!(issue_title, "fresh title", "reclaim refreshes the content, not just the stamp");
+    for table in ["github_refs", "github_ref_sync"] {
+        let repo: String = conn
+            .query_row(&format!("SELECT repo_id FROM {table} WHERE number = 7"), [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(repo, "repo-a", "{table}: stranded row reclaimed");
+    }
+    // …the FTS mirror is consistent with the reclaimed base rows…
+    let fts_repo: String = conn
+        .query_row("SELECT repo_id FROM github_fts WHERE number = 7", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(fts_repo, "repo-a", "the mirror row follows the reclaimed base row");
+    // …a scoped read now sees the papertrail…
+    let visible: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM github_issues WHERE repo_id = 'repo-a' AND number = 7",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(visible, 1, "the reclaimed row is visible to repo-a's scoped reads");
+    // …and the row the sync did NOT touch stays under the placeholder for its own repo's sync.
+    for table in ["github_issues", "github_fts"] {
+        let repo: String = conn
+            .query_row(&format!("SELECT repo_id FROM {table} WHERE number = 8"), [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(repo, LEGACY_REPO_ID, "{table}: untouched stranded row stays placeholder");
+    }
+}
+
+/// A V040 index forward-migrates to V041 on `migrate_forward` — reaching LATEST.
+#[test]
+fn migration_041_forward_migrates_a_v040_index() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    truncate_schema_to(&conn, 40);
+    assert_eq!(schema::status(&conn).unwrap().state, schema::SchemaState::Older);
+    schema::migrate_forward(&conn).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -376,6 +376,11 @@ fn migrate_adds_edge_name_columns_before_indexing_them() {
 
 #[test]
 fn migrate_preserves_github_papertrail_cache() {
+    // Whole-table `row_count` cache-total checks are single-repo by nature: they assert the
+    // papertrail cache survived a schema migration. The poison sibling's V041-scoped github rows
+    // would inflate the unscoped totals (production github reads ARE scoped — the multi_repo_scope
+    // leak matrix proves it), so opt this cache-total test out of the harness.
+    let _poison = crate::index::poison_sibling::disable_poison_sibling();
     let (root, config) =
         markdown_config("# Decision\nRefs cq27-dev/rag-rat#42\nwe will keep sqlite\n");
     let db = IndexDatabase::rebuild(&config).unwrap();
@@ -419,6 +424,11 @@ fn migrate_preserves_github_papertrail_cache() {
 
 #[test]
 fn full_rebuild_preserves_github_papertrail_cache() {
+    // Whole-table `row_count` cache-total checks are single-repo by nature: they assert the
+    // papertrail cache survived a full rebuild. The poison sibling's V041-scoped github rows would
+    // inflate the unscoped totals (production github reads ARE scoped — the multi_repo_scope leak
+    // matrix proves it), so opt this cache-total test out of the harness.
+    let _poison = crate::index::poison_sibling::disable_poison_sibling();
     let (root, config) =
         markdown_config("# Decision\nRefs cq27-dev/rag-rat#42\nwe will keep sqlite\n");
     let db = IndexDatabase::rebuild(&config).unwrap();

--- a/crates/rag-rat-core/src/index/util.rs
+++ b/crates/rag-rat-core/src/index/util.rs
@@ -18,8 +18,8 @@ pub(crate) fn table_row_count(conn: &rusqlite::Connection, table: &str) -> anyho
 /// `table_row_count` for a directly-`repo_id`-scoped table: counts only the rows owned by `repo_id`
 /// (the active repo), so a status/freshness read reports THIS repo's totals rather than the union
 /// across every repo in a consolidated DB. `table` is always an internal string literal, never user
-/// input, and MUST carry a `repo_id` column (the V040 direct-scoped tables — git_commits,
-/// git_file_changes, and their siblings).
+/// input, and MUST carry a `repo_id` column (the V040/V041 direct-scoped tables — git_commits,
+/// git_file_changes, the github_* papertrail tables).
 pub(crate) fn scoped_table_row_count(
     conn: &rusqlite::Connection,
     table: &str,

--- a/crates/rag-rat-core/src/query/impact/historical.rs
+++ b/crates/rag-rat-core/src/query/impact/historical.rs
@@ -115,12 +115,14 @@ pub(crate) fn github_refs_for_paths(
     if budget == 0 {
         return Ok(());
     }
+    // `github_refs` is direct-scoped (V041): only surface the ACTIVE repo's refs for this path.
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     let mut added = 0usize;
     let mut stmt = conn.prepare(
         "
         SELECT owner, repo, number, ref_kind, source_kind, source_text
         FROM github_refs
-        WHERE source_path = ?1
+        WHERE source_path = ?1 AND repo_id = ?3
         ORDER BY id DESC
         LIMIT ?2
         ",
@@ -131,8 +133,9 @@ pub(crate) fn github_refs_for_paths(
         }
         let before = surface.len();
         let file = file_for_path(conn, path)?;
-        let rows =
-            stmt.query_map(params![path, i64::try_from(budget).unwrap_or(i64::MAX)], |row| {
+        let rows = stmt.query_map(
+            params![path, i64::try_from(budget).unwrap_or(i64::MAX), repo_id],
+            |row| {
                 Ok((
                     row.get::<_, String>(0)?,
                     row.get::<_, String>(1)?,
@@ -141,7 +144,8 @@ pub(crate) fn github_refs_for_paths(
                     row.get::<_, String>(4)?,
                     row.get::<_, String>(5)?,
                 ))
-            })?;
+            },
+        )?;
         for row in rows {
             let (owner, repo, number, ref_kind, source_kind, source_text) = row?;
             surface.push(
@@ -168,19 +172,22 @@ pub(crate) fn github_rationale_for_query(
     if fts_query.is_empty() {
         return Ok(());
     }
+    // `github_fts` is one index over every repo's papertrail; the `repo_id` filter is MANDATORY
+    // (V041) so a MATCH here never surfaces a sibling repo's issue in a consolidated DB.
+    let repo_id = crate::index::schema::active_repo_id(conn)?;
     let mut stmt = conn.prepare(
         "
         SELECT url, title, classification
         FROM github_fts
-        WHERE github_fts MATCH ?1
+        WHERE github_fts MATCH ?1 AND repo_id = ?3
         ORDER BY rank
         LIMIT ?2
         ",
     )?;
-    let rows = stmt
-        .query_map(params![fts_query, i64::try_from(limit).unwrap_or(i64::MAX)], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))
-        })?;
+    let rows = stmt.query_map(
+        params![fts_query, i64::try_from(limit).unwrap_or(i64::MAX), repo_id],
+        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?)),
+    )?;
     for row in rows {
         let (url, title, classification) = row?;
         surface.push(

--- a/crates/rag-rat-core/src/query/repo_brief.rs
+++ b/crates/rag-rat-core/src/query/repo_brief.rs
@@ -538,10 +538,11 @@ pub(crate) fn file_rows(
 ) -> anyhow::Result<Vec<FileBriefRow>> {
     let newest_commit = newest_commit_time(conn)?;
     let recent_floor = newest_commit.saturating_sub(90 * 24 * 60 * 60);
-    // The churn CTE reads the direct-scoped `git_file_changes` / `git_commits` (V040); the
-    // `repo_id` predicate keeps a sibling repo's churn for a SHARED path (two repos both having
-    // `src/lib.rs`) out of this repo's brief — the outer LEFT JOIN is by path, so the scoped
-    // `files` view alone cannot exclude it.
+    // The `churn` (V040 `git_file_changes` / `git_commits`) and `github_ref_counts` (V041
+    // `github_refs`) CTEs both aggregate a direct-scoped table by PATH and LEFT JOIN the result
+    // onto `files` by path. Their `repo_id = ?3` predicate keeps a sibling repo's rows for a
+    // SHARED path (two repos both having `src/lib.rs`) out of this repo's brief — the outer join is
+    // by path, so the scoped `files` view alone cannot exclude a sibling's colliding-path row.
     let repo_id = crate::index::schema::active_repo_id(conn)?;
     let mut stmt = conn.prepare(
         "
@@ -587,6 +588,7 @@ pub(crate) fn file_rows(
           SELECT source_path AS path, COUNT(*) AS ref_count
           FROM github_refs
           WHERE source_path IS NOT NULL
+            AND github_refs.repo_id = ?3
           GROUP BY source_path
         )
         SELECT files.path, files.language, files.kind, files.generated,

--- a/crates/rag-rat-core/src/search/lexical.rs
+++ b/crates/rag-rat-core/src/search/lexical.rs
@@ -206,12 +206,19 @@ fn search_with_query_embedding(
     options: SearchOptions,
 ) -> anyhow::Result<Vec<SearchHit>> {
     let terms = query_terms(query);
-    // REPO SCOPING (A3): every candidate row flows through the `files` scope VIEW (both the bm25
+    // REPO SCOPING (A4): every candidate row flows through the `files` scope VIEW (both the bm25
     // and the vector pass JOIN `files`), which filters `repo_id` FIRST — so in a consolidated
     // DB a sibling repo's chunks are dropped by the INNER JOIN before ranking. `active_repo_id`
-    // is resolved ONCE here and threaded into the git boost queries (which read the
-    // direct-scoped `git_file_changes` by path, bypassing the view).
+    // is resolved ONCE here and threaded into the git/github boost queries (which read the
+    // direct-scoped `git_file_changes` / `github_refs` by path, bypassing the view).
     let repo_id = crate::index::schema::active_repo_id(conn)?;
+    // RECALL BOUND: `chunk_fts` / `chunk_embeddings` MATCH globally, then the repo (+ commit +
+    // worktree) filter is applied by the scope-view JOIN. Because SQLite applies `LIMIT` AFTER the
+    // join filter, the candidate window is a PER-REPO window — the active repo is never starved by
+    // a sibling repo's matches. `candidate_limit` (8× the caller's limit, well past the plan's
+    // 4× floor) caps how many post-filter candidates enter ranking; a query whose active-repo
+    // matches exceed 8×limit keeps only the BM25/vector-top `candidate_limit` of them, the same
+    // bound as a single-repo DB.
     let candidate_limit = i64::from(limit.max(10)).saturating_mul(8);
     let vector_available = query_embedding.is_some();
     let mut ranked = BTreeMap::<i64, RankedHit>::new();
@@ -688,10 +695,9 @@ fn historical_boost(
     options: SearchOptions,
     repo_id: &str,
 ) -> anyhow::Result<HistoricalBoost> {
-    // `git_file_changes` is direct-scoped (V040) and queried by PATH here (bypassing the scope
-    // view), so the `repo_id` predicate keeps a sibling repo's history from boosting a same-named
-    // path in a consolidated DB. (`github_refs` stays global until the papertrail tables gain
-    // `repo_id` in the A4 scoping phase.)
+    // `git_file_changes` / `github_refs` are direct-scoped (V040/V041) and queried by PATH here
+    // (bypassing the scope view), so the `repo_id` predicate keeps a sibling repo's history from
+    // boosting a same-named path in a consolidated DB.
     let git = if options.include_git {
         conn.query_row(
             "SELECT COUNT(*) FROM git_file_changes WHERE path = ?1 AND repo_id = ?2 LIMIT 1",
@@ -703,8 +709,8 @@ fn historical_boost(
     };
     let github = if options.include_papertrail {
         conn.query_row(
-            "SELECT COUNT(*) FROM github_refs WHERE source_path = ?1 LIMIT 1",
-            [path],
+            "SELECT COUNT(*) FROM github_refs WHERE source_path = ?1 AND repo_id = ?2 LIMIT 1",
+            params![path, repo_id],
             |row| row.get::<_, i64>(0),
         )?
     } else {


### PR DESCRIPTION
Phase A4 of the global-DB consolidation (#399). FTS and papertrail surfaces gain the repo dimension — each FTS table scoped per its own rowid contract rather than by blanket rule.

- **V041**: the 7 github tables gain `repo_id` (`(owner,repo)` is not identity — forks/renames); `github_fts` standalone rebuild adds `repo_id UNINDEXED` with mandatory query filters (torn-state re-convergent; the apply fn self-wraps one transaction). Backfill resolves the sole registered repo — correct on both fresh and already-adopted databases, with a regression test for the adopted path. Full-ladder replay on a two-repo DB stays idempotent.
- **`chunk_fts`** (contentless, rowid == `chunks.id`): candidates scope through the repo-filtered `files` view in SQL — complete and per-repo with no cross-repo starvation; the candidate window and its recall bound are documented at the site. Same filter on the vector/hybrid candidate path.
- **`commit_fts`** (external-content over `(repo_id, hash)` `git_commits`): MATCH results scope through `git_commits.repo_id`; maintenance stays whole-table `'rebuild'` with the cost documented.
- **git history**: `status`/`is_history_current` count per-repo; `commit_search`, `history_for_path`, replay, and the blame wipe (`delete_repo_chunk_blame`) scope through the repo's rows; search boosts (`graded_git_scores`, `historical_boost`) carry the repo predicate.
- **github writers** stamp the active repo; reads (`search_fts`, evidence, refs, sync status) filter it; adoption extends to the github tables inside the existing atomic transaction.
- **Poison-sibling harness extended** to the github tables + `github_fts` mirror, so the suite enforces the new scoping the same way it enforces V040's.
- Leak-matrix tests: lexical/hybrid search, git history, and papertrail queries from one repo's connection never surface a sibling's uniquely-named rows.

Workspace suite: 1475 passed; clippy `-D warnings` clean; nightly fmt clean.

Fixes #399