### PR TITLE
feat(index): V042 — repo-scoped clones, oracle, reconcile, memories (#400 phase A5)

### DIFF
--- a/crates/rag-rat-core/src/dream.rs
+++ b/crates/rag-rat-core/src/dream.rs
@@ -63,7 +63,30 @@ fn claim_hash(kind: &str, subject: &str, evidence: &str) -> String {
     hex16(&h.finalize())
 }
 
-fn finding_id(kind: &str, subject: &str, ch: &str) -> String {
+/// Derive a finding id with the owning repo FOLDED into the hash (the `logical_symbols.stable_id`
+/// precedent, A3). The id column stays a GLOBAL `TEXT PRIMARY KEY` while the lifecycle lookups are
+/// repo-scoped — without the fold, two repos producing the same `(kind, subject, claim_hash)`
+/// derive the SAME id, and the second repo's scoped lookup (which no longer sees the sibling's row)
+/// takes the INSERT path straight into a PK violation. Folding keeps ids globally unique and
+/// coordination-free with no PK shape change.
+pub(crate) fn repo_folded_finding_id(repo_id: &str, kind: &str, subject: &str, ch: &str) -> String {
+    let mut h = Sha256::new();
+    h.update(repo_id.as_bytes());
+    h.update([0x1f]);
+    h.update(kind.as_bytes());
+    h.update([0x1f]);
+    h.update(subject.as_bytes());
+    h.update([0x1f]);
+    h.update(ch.as_bytes());
+    hex16(&h.finalize())
+}
+
+/// The runtime id derivation: repo-folded on the post-A5 schema (`scope` is `Some`), the original
+/// repo-blind hash pre-A5 (no `repo_id` column — single-repo by construction, ids stay compatible).
+fn finding_id(scope: &Option<String>, kind: &str, subject: &str, ch: &str) -> String {
+    if let Some(repo_id) = scope {
+        return repo_folded_finding_id(repo_id, kind, subject, ch);
+    }
     let mut h = Sha256::new();
     h.update(kind.as_bytes());
     h.update([0x1f]);
@@ -71,6 +94,36 @@ fn finding_id(kind: &str, subject: &str, ch: &str) -> String {
     h.update([0x1f]);
     h.update(ch.as_bytes());
     hex16(&h.finalize())
+}
+
+/// Re-derive every persisted finding id under its row's CURRENT `repo_id` (and remap the in-table
+/// `superseded_by` references — the only place a finding id is persisted outside the `id` column
+/// itself). Called from the V042 migration (after the periphery backfill) and from `register_repo`
+/// adoption (after the periphery re-point), mirroring `realign_logical_symbol_ids`: whenever a
+/// row's `repo_id` changes, the id it SHOULD have changes with it. Idempotent (an already-derived
+/// id re-derives to itself) and cheap (the worklist is small). Callers guard on the `repo_id`
+/// column existing.
+pub(crate) fn rederive_finding_ids(conn: &Connection) -> rusqlite::Result<()> {
+    let rows: Vec<(String, String, String, String, String)> = conn
+        .prepare("SELECT id, kind, subject, claim_hash, repo_id FROM dream_findings")?
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)))?
+        .collect::<rusqlite::Result<_>>()?;
+    let mut remap = Vec::new();
+    for (old_id, kind, subject, ch, repo_id) in rows {
+        let new_id = repo_folded_finding_id(&repo_id, &kind, &subject, &ch);
+        if new_id != old_id {
+            remap.push((old_id, new_id));
+        }
+    }
+    for (old_id, new_id) in &remap {
+        conn.execute("UPDATE dream_findings SET id = ?2 WHERE id = ?1", [old_id, new_id])?;
+    }
+    for (old_id, new_id) in &remap {
+        conn.execute("UPDATE dream_findings SET superseded_by = ?2 WHERE superseded_by = ?1", [
+            old_id, new_id,
+        ])?;
+    }
+    Ok(())
 }
 
 fn hex16(bytes: &[u8]) -> String {
@@ -89,17 +142,26 @@ fn hex16(bytes: &[u8]) -> String {
 /// are checkout-scoped; the caller in-degree is not yet scoped (follow-up: reuse the scoped
 /// `important_symbols` PageRank instead of this raw in-degree proxy).
 fn coverage_gap(conn: &Connection, limit: usize) -> rusqlite::Result<Vec<DreamFinding>> {
-    let mut stmt = conn.prepare(
+    // The COVERAGE exclusion subqueries read `repo_memory_bindings` and must be scoped to the
+    // ACTIVE repo (V042): a SIBLING repo's binding — a colliding `symbol_id` rowid, or a path
+    // binding at a path this repo also has (the same-path case) — would otherwise mark this repo's
+    // load-bearing symbol as covered and SUPPRESS its coverage-gap finding (a false negative).
+    // `{binding_clause}`/`{b_clause}` empty pre-A5.
+    let scope = crate::index::schema::periphery_repo_scope(conn, "repo_memories")?;
+    let binding_clause =
+        crate::index::schema::periphery_repo_scope_clause(&scope, "repo_memory_bindings");
+    let b_clause = crate::index::schema::periphery_repo_scope_clause(&scope, "b");
+    let mut stmt = conn.prepare(&format!(
         "SELECT s.name, f.path, COUNT(DISTINCT e.from_symbol_id) AS d FROM edges_data e JOIN \
          symbols s ON s.id = e.to_symbol_id JOIN files f ON f.id = s.file_id WHERE e.to_symbol_id \
          IS NOT NULL AND e.from_symbol_id IS NOT NULL AND f.has_test_code = 0 AND e.to_symbol_id \
-         NOT IN (SELECT symbol_id FROM repo_memory_bindings WHERE symbol_id IS NOT NULL) AND \
-         e.to_symbol_id NOT IN (SELECT lsm.symbol_id FROM logical_symbol_members lsm JOIN \
-         repo_memory_bindings b ON b.logical_symbol_id = lsm.logical_symbol_id WHERE \
-         b.logical_symbol_id IS NOT NULL) AND f.path NOT IN (SELECT path FROM \
-         repo_memory_bindings WHERE path IS NOT NULL) GROUP BY e.to_symbol_id ORDER BY d DESC \
-         LIMIT ?1",
-    )?;
+         NOT IN (SELECT symbol_id FROM repo_memory_bindings WHERE symbol_id IS NOT \
+         NULL{binding_clause}) AND e.to_symbol_id NOT IN (SELECT lsm.symbol_id FROM \
+         logical_symbol_members lsm JOIN repo_memory_bindings b ON b.logical_symbol_id = \
+         lsm.logical_symbol_id WHERE b.logical_symbol_id IS NOT NULL{b_clause}) AND f.path NOT IN \
+         (SELECT path FROM repo_memory_bindings WHERE path IS NOT NULL{binding_clause}) GROUP BY \
+         e.to_symbol_id ORDER BY d DESC LIMIT ?1"
+    ))?;
     let rows: Vec<(String, String, i64)> = stmt
         .query_map([limit as i64], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))?
         .collect::<rusqlite::Result<_>>()?;
@@ -130,8 +192,13 @@ fn stale_reference(conn: &Connection) -> rusqlite::Result<Vec<DreamFinding>> {
     let mut out = Vec::new();
     // 'stale'-status memories are still LIVE (just flagged) and are the ones most likely to hold a
     // moved/deleted path — scan them too, matching the memory layer's status IN ('active','stale').
-    let mut stmt =
-        conn.prepare("SELECT id, body FROM repo_memories WHERE status IN ('active', 'stale')")?;
+    // Scoped to the ACTIVE repo (V042): a sibling repo's memory referencing a path that does not
+    // resolve in THIS repo's index must not surface as this repo's stale_reference finding.
+    let scope = crate::index::schema::periphery_repo_scope(conn, "repo_memories")?;
+    let repo_clause = crate::index::schema::periphery_repo_scope_clause(&scope, "repo_memories");
+    let mut stmt = conn.prepare(&format!(
+        "SELECT id, body FROM repo_memories WHERE status IN ('active', 'stale'){repo_clause}"
+    ))?;
     let mems: Vec<(String, String)> =
         stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?.collect::<rusqlite::Result<_>>()?;
     for (id, body) in mems {
@@ -160,10 +227,30 @@ fn stale_reference(conn: &Connection) -> rusqlite::Result<Vec<DreamFinding>> {
     Ok(out)
 }
 
+/// The active `repo_id` to scope the `dream_findings` lifecycle by (V042), or `None` on the pre-A5
+/// schema (the column is absent, so the reads/writes run unscoped — the original repo-global SQL).
+/// Probes `dream_findings` — see `schema::periphery_repo_scope`.
+fn dream_repo_scope(conn: &Connection) -> rusqlite::Result<Option<String>> {
+    crate::index::schema::periphery_repo_scope(conn, "dream_findings")
+}
+
+/// The ` AND dream_findings.repo_id = '…'` predicate for a scoped `dream_findings` read/write, or
+/// `""` when unscoped.
+fn dream_repo_scope_clause(scope: &Option<String>) -> String {
+    crate::index::schema::periphery_repo_scope_clause(scope, "dream_findings")
+}
+
 /// Sync findings into `dream_findings` with the identity-keyed lifecycle (refresh / supersede /
 /// resolve), ATOMICALLY: all writes run in one transaction so a mid-run failure can't leave a torn
 /// worklist (the per-finding upserts + the resolve pass commit together or not at all). Returns
 /// (opened, refreshed, superseded, resolved).
+///
+/// SCOPE (A5): every lookup / supersede / resolve / list here filters `dream_findings.repo_id`, and
+/// the INSERT stamps it, so a run in one repo of a consolidated DB never reads, supersedes, or
+/// resolves a sibling repo's worklist rows. The id is derived by [`repo_folded_finding_id`] — the
+/// repo is IN the hash, so two repos minting the same `(kind, subject, claim_hash)` never collide
+/// on the global `id` PK (the scoped lookup cannot see a sibling's row, so a repo-blind id would
+/// turn that case into a PK violation on insert rather than the pre-scoping silent UPDATE).
 fn sync(
     conn: &Connection,
     findings: &[DreamFinding],
@@ -182,26 +269,41 @@ fn sync_in_tx(
 ) -> rusqlite::Result<(usize, usize, usize, usize)> {
     let (mut opened, mut refreshed, mut superseded, mut resolved) = (0, 0, 0, 0);
     let mut seen: HashSet<(String, String)> = HashSet::new();
+    // Resolve the active-repo scope once for the whole sync (all statements below share it): the
+    // read predicate `{repo_clause}` and the INSERT's `{repo_col}`/`{repo_val}` stamp prefix.
+    let scope = dream_repo_scope(conn)?;
+    let repo_clause = dream_repo_scope_clause(&scope);
+    let (repo_col, repo_val) = match &scope {
+        Some(repo_id) => ("repo_id, ".to_string(), format!("'{}', ", repo_id.replace('\'', "''"))),
+        None => (String::new(), String::new()),
+    };
     for f in findings {
         let ch = claim_hash(&f.kind, &f.subject, &f.evidence);
         seen.insert((f.kind.clone(), f.subject.clone()));
         // Look up by the EXACT claim (incl. its current status) — NOT status-blind, or an evidence
         // flip-back (A→B→A) or a resolved-then-reappears would match a terminal row and silently
-        // refresh it, stranding the actually-current finding.
+        // refresh it, stranding the actually-current finding. Scoped to the active repo so a
+        // sibling's identically-keyed row can't hijack this repo's re-resolution.
         let existing: Option<(String, String)> = conn
             .query_row(
-                "SELECT id, status FROM dream_findings WHERE kind = ?1 AND subject = ?2 AND \
-                 claim_hash = ?3",
+                &format!(
+                    "SELECT id, status FROM dream_findings WHERE kind = ?1 AND subject = ?2 AND \
+                     claim_hash = ?3{repo_clause}"
+                ),
                 rusqlite::params![f.kind, f.subject, ch],
                 |r| Ok((r.get(0)?, r.get(1)?)),
             )
             .ok();
         // supersede any OTHER current row for this (kind, subject) — used by both the revive and
-        // the brand-new branches (the world changed, so a prior verdict no longer applies).
+        // the brand-new branches (the world changed, so a prior verdict no longer applies). Scoped
+        // so it never supersedes a sibling repo's current finding sharing this (kind, subject).
         let supersede_others = |id: &str| {
             conn.execute(
-                "UPDATE dream_findings SET status = 'superseded', superseded_by = ?1 WHERE kind = \
-                 ?2 AND subject = ?3 AND id != ?1 AND status IN ('open','accepted','dismissed')",
+                &format!(
+                    "UPDATE dream_findings SET status = 'superseded', superseded_by = ?1 WHERE \
+                     kind = ?2 AND subject = ?3 AND id != ?1 AND status IN \
+                     ('open','accepted','dismissed'){repo_clause}"
+                ),
                 rusqlite::params![id, f.kind, f.subject],
             )
         };
@@ -228,11 +330,13 @@ fn sync_in_tx(
             },
             // brand-new claim for this (kind, subject): open fresh + supersede prior current rows
             None => {
-                let id = finding_id(&f.kind, &f.subject, &ch);
+                let id = finding_id(&scope, &f.kind, &f.subject, &ch);
                 conn.execute(
-                    "INSERT INTO dream_findings(id, kind, subject, claim_hash, evidence, \
-                     base_rank, status, first_seen_at_ms, last_seen_at_ms) \
-                     VALUES(?1,?2,?3,?4,?5,?6,'open',?7,?7)",
+                    &format!(
+                        "INSERT INTO dream_findings({repo_col}id, kind, subject, claim_hash, \
+                         evidence, base_rank, status, first_seen_at_ms, last_seen_at_ms) \
+                         VALUES({repo_val}?1,?2,?3,?4,?5,?6,'open',?7,?7)"
+                    ),
                     rusqlite::params![id, f.kind, f.subject, ch, f.evidence, f.rank, now_ms],
                 )?;
                 opened += 1;
@@ -240,12 +344,14 @@ fn sync_in_tx(
             },
         }
     }
-    // resolve: any current finding whose (kind, subject) was not reported this run -> drift gone
+    // resolve: any current finding whose (kind, subject) was not reported this run -> drift gone.
+    // Scoped so this repo's run only resolves ITS OWN worklist, never a sibling repo's open
+    // findings.
     let current: Vec<(String, String, String)> = conn
-        .prepare(
+        .prepare(&format!(
             "SELECT id, kind, subject FROM dream_findings WHERE status IN \
-             ('open','accepted','dismissed')",
-        )?
+             ('open','accepted','dismissed'){repo_clause}"
+        ))?
         .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))?
         .collect::<rusqlite::Result<_>>()?;
     for (id, kind, subject) in current {
@@ -266,12 +372,14 @@ pub fn dream_run(conn: &Connection, opts: DreamOptions) -> rusqlite::Result<Drea
 
     // emit the OPEN worklist from the store (post-sync); each finding's exposed rank is its
     // base_rank DECAYED by age since first_seen (effective_rank) — a stale unreviewed finding
-    // sinks below fresh ones (the documented anti-rot, now real, not just base_rank DESC).
+    // sinks below fresh ones (the documented anti-rot, now real, not just base_rank DESC). Scoped
+    // to the active repo so the emitted worklist never mixes in a sibling repo's open findings.
+    let repo_clause = dream_repo_scope_clause(&dream_repo_scope(conn)?);
     let mut open: Vec<DreamFinding> = conn
-        .prepare(
+        .prepare(&format!(
             "SELECT kind, subject, evidence, base_rank, first_seen_at_ms FROM dream_findings \
-             WHERE status = 'open'",
-        )?
+             WHERE status = 'open'{repo_clause}"
+        ))?
         .query_map([], |r| {
             let base: f64 = r.get(3)?;
             let first_seen: i64 = r.get(4)?;
@@ -302,6 +410,103 @@ mod tests {
         let c = Connection::open_in_memory().unwrap();
         crate::index::schema::apply(&c).unwrap();
         c
+    }
+
+    /// Point the connection's periphery scope at `repo_id` — mirrors the scope-context write the
+    /// production open installs (and `multi_repo_scope::a5_set_active_repo`).
+    fn set_repo(c: &Connection, repo_id: &str) {
+        c.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS connection_context(key TEXT PRIMARY KEY, value TEXT);",
+        )
+        .unwrap();
+        c.execute(
+            "INSERT OR REPLACE INTO temp.connection_context(key, value) VALUES ('repo_id', ?1)",
+            [repo_id],
+        )
+        .unwrap();
+    }
+
+    /// A5 finding: `finding_id` folds the owning repo. Two repos minting the SAME
+    /// `(kind, subject, claim_hash)` derive DISTINCT ids — a repo-blind id would make the second
+    /// repo's sync explode on the global `id` PK, because its repo-scoped lookup cannot see the
+    /// sibling's row and takes the INSERT path.
+    #[test]
+    fn two_repos_minting_the_same_finding_do_not_collide_on_the_global_id() {
+        let c = mem_db();
+        let finding = || {
+            vec![DreamFinding {
+                kind: "coverage_gap".into(),
+                subject: "x::F".into(),
+                evidence: "7 callers".into(),
+                rank: 0.5,
+            }]
+        };
+        set_repo(&c, "repo-a");
+        sync(&c, &finding(), 1000).unwrap();
+        set_repo(&c, "repo-b");
+        // Pre-fix this is a PK violation, not an UPDATE: the scoped lookup misses repo-a's row and
+        // the insert derives the same repo-blind id.
+        sync(&c, &finding(), 2000).unwrap();
+
+        let rows: Vec<(String, String)> = c
+            .prepare(
+                "SELECT id, repo_id FROM dream_findings WHERE status = 'open' ORDER BY repo_id",
+            )
+            .unwrap()
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(rows.len(), 2, "each repo holds its own open finding: {rows:?}");
+        assert_eq!(rows[0].1, "repo-a");
+        assert_eq!(rows[1].1, "repo-b");
+        assert_ne!(rows[0].0, rows[1].0, "the two findings carry DISTINCT repo-folded ids");
+    }
+
+    /// `rederive_finding_ids` re-points every id (and the in-table `superseded_by` references) to
+    /// the repo-folded derivation, and is idempotent — the V042 migration and adoption both call
+    /// it after re-stamping `repo_id`.
+    #[test]
+    fn rederive_finding_ids_repoints_ids_and_superseded_by() {
+        let c = mem_db();
+        // Two rows under `repo-x` carrying LEGACY (repo-blind) ids, chained by superseded_by.
+        c.execute_batch(
+            "INSERT INTO dream_findings(id, kind, subject, claim_hash, evidence, base_rank, \
+             status, superseded_by, first_seen_at_ms, last_seen_at_ms, repo_id)
+             VALUES ('oldid1', 'coverage_gap', 'x::F', 'c1', 'ev1', 0.5, 'superseded', 'oldid2', \
+             0, 0, 'repo-x'),
+                    ('oldid2', 'coverage_gap', 'x::F', 'c2', 'ev2', 0.6, 'open', NULL, 0, 0, \
+             'repo-x');",
+        )
+        .unwrap();
+        rederive_finding_ids(&c).unwrap();
+
+        let new1 = repo_folded_finding_id("repo-x", "coverage_gap", "x::F", "c1");
+        let new2 = repo_folded_finding_id("repo-x", "coverage_gap", "x::F", "c2");
+        let ids: Vec<(String, Option<String>)> = c
+            .prepare("SELECT id, superseded_by FROM dream_findings ORDER BY claim_hash")
+            .unwrap()
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(ids[0].0, new1, "row 1's id re-derived under its repo");
+        assert_eq!(ids[1].0, new2, "row 2's id re-derived under its repo");
+        assert_eq!(
+            ids[0].1.as_deref(),
+            Some(new2.as_str()),
+            "the superseded_by reference is remapped to the re-derived id"
+        );
+        // Idempotent: a second pass moves nothing.
+        rederive_finding_ids(&c).unwrap();
+        let again: Vec<String> = c
+            .prepare("SELECT id FROM dream_findings ORDER BY claim_hash")
+            .unwrap()
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(again, vec![new1, new2], "re-derivation is idempotent");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
@@ -50,9 +50,22 @@ pub(crate) fn reconcile_with_options_progress(
     let max_embedding_chars = options.max_embedding_chars.max(MIN_EMBEDDING_CHARS);
     let started = now_ms();
     set_reconcile_meta(conn, LAST_EMBEDDING_RECONCILE_STARTED_META, &started.to_string())?;
+    // Stamp the active repo (V042): `reconcile_attempts` carries `repo_id`, so the attempt is
+    // attributed to the repo whose reconcile this is — else the row defaults to the placeholder and
+    // the per-repo status read never sees it. Per-call literal prefix so the bound params are
+    // unchanged; pre-A5 uses the original 4-column shape. The finalize UPDATE keys the row by its
+    // autoincrement `id`, so it needs no repo predicate.
+    let (repo_col, repo_val) =
+        match crate::index::schema::periphery_repo_scope(conn, "reconcile_attempts")? {
+            Some(repo_id) =>
+                ("repo_id, ".to_string(), format!("'{}', ", repo_id.replace('\'', "''"))),
+            None => (String::new(), String::new()),
+        };
     conn.execute(
-        "INSERT INTO reconcile_attempts(started_at_ms, limit_count, status, batch_size) VALUES \
-         (?1, ?2, 'Running', ?3)",
+        &format!(
+            "INSERT INTO reconcile_attempts({repo_col}started_at_ms, limit_count, status, \
+             batch_size) VALUES ({repo_val}?1, ?2, 'Running', ?3)"
+        ),
         params![
             started,
             options.limit.map(i64::from),

--- a/crates/rag-rat-core/src/index/ai/reconcile/status.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/status.rs
@@ -166,8 +166,15 @@ pub(crate) fn embedding_reconcile_plan(
 pub(crate) fn last_reconcile_status(
     conn: &Connection,
 ) -> anyhow::Result<Option<LastReconcileStatus>> {
+    // Scoped to the active repo (V042): `reconcile_attempts` is a global append-only log, so the
+    // "latest attempt" pick must filter `repo_id` — else a sibling repo's newer attempt on a
+    // consolidated DB would be reported as this repo's status. `{repo_clause}` empty pre-A5.
+    let scope = crate::index::schema::periphery_repo_scope(conn, "reconcile_attempts")?;
+    let repo_clause =
+        crate::index::schema::periphery_repo_scope_clause(&scope, "reconcile_attempts");
     conn.query_row(
-        "
+        &format!(
+            "
         SELECT started_at_ms,
                finished_at_ms,
                batch_size,
@@ -179,9 +186,11 @@ pub(crate) fn last_reconcile_status(
                status,
                message
         FROM reconcile_attempts
+        WHERE 1=1{repo_clause}
         ORDER BY started_at_ms DESC, id DESC
         LIMIT 1
-        ",
+        "
+        ),
         [],
         |row| {
             let elapsed_ms = u64::try_from(row.get::<_, i64>(6)?).unwrap_or(0);

--- a/crates/rag-rat-core/src/index/clones/refine/cache.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/cache.rs
@@ -133,13 +133,22 @@ pub(crate) fn refine_lookup(
     // The full content payload (4b): the rendered template + the serialized variation_points /
     // proposed_signature + the REAL anti_unify_coverage round-trip alongside the scoring outputs,
     // so a warm hit returns everything without recomputing the alignment.
+    // Per-repo (A5): `clone_refinements.class_key` is content-derived, so it collides across repos;
+    // scope the read to the active repo. `{repo_clause}` is empty pre-A5. Read-only-safe (both the
+    // column probe and the active-repo resolve are reads), so it stays callable on a read-only
+    // conn.
+    let scope = crate::index::schema::periphery_repo_scope(conn, "clone_refinements")?;
+    let repo_clause =
+        crate::index::schema::periphery_repo_scope_clause(&scope, "clone_refinements");
     #[allow(clippy::type_complexity)]
     let hit: Option<(f64, String, f64, i64, String, String, String, f64)> = conn
         .query_row(
-            "SELECT lcs_ratio, confidence, refactorability, lcs_sampled,
+            &format!(
+                "SELECT lcs_ratio, confidence, refactorability, lcs_sampled,
                     template, variation_points_json, proposed_signature_json, anti_unify_coverage
              FROM clone_refinements
-             WHERE class_key = ?1 AND norm_version = ?2 AND alignment_version = ?3",
+             WHERE class_key = ?1 AND norm_version = ?2 AND alignment_version = ?3{repo_clause}"
+            ),
             rusqlite::params![refinement_key, NORM_VERSION, ALIGNMENT_VERSION],
             |row| {
                 Ok((
@@ -283,15 +292,25 @@ pub(crate) fn refine_compute_and_store_budgeted(
     let variation_points_json = serde_json::to_string(&template.variation_points)?;
     let proposed_signature_json = serde_json::to_string(&signature)?;
 
-    // Persist the full row. INSERT OR REPLACE because `class_key` is the table PRIMARY KEY — a
-    // re-run at a NEW version pin replaces the stale row in place rather than accumulating.
+    // Persist the full row. INSERT OR REPLACE keys on the PRIMARY KEY — pre-A5 that is `class_key`;
+    // post-A5 it is `(repo_id, class_key)`, so stamp the active repo (a content class_key collides
+    // across repos). The repo id is a per-call literal prefix so the bound params (`?1`..`?14`)
+    // stay unchanged.
+    let (repo_col, repo_val) =
+        match crate::index::schema::periphery_repo_scope(conn, "clone_refinements")? {
+            Some(repo_id) =>
+                ("repo_id, ".to_string(), format!("'{}', ", repo_id.replace('\'', "''"))),
+            None => (String::new(), String::new()),
+        };
     conn.execute(
-        "INSERT OR REPLACE INTO clone_refinements(
-             class_key, language, refine_mode, template,
+        &format!(
+            "INSERT OR REPLACE INTO clone_refinements(
+             {repo_col}class_key, language, refine_mode, template,
              variation_points_json, proposed_signature_json, confidence,
              anti_unify_coverage, lcs_ratio, refactorability,
              norm_version, alignment_version, created_at_ms, lcs_sampled
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+         ) VALUES ({repo_val}?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)"
+        ),
         rusqlite::params![
             refinement_key,
             language,

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -293,6 +293,24 @@ impl IndexDatabase {
     ) -> anyhow::Result<()> {
         let conn = self.storage.connection();
         let normalizer_kind = clones::NormalizerKind::Baseline.as_db_str();
+        // Resolve the periphery scope ONCE (not per token). Post-A5 `clone_token_df`'s PK is
+        // `(repo_id, normalizer_kind, token_hash)`, so the upsert must stamp `repo_id` AND target
+        // it in the ON CONFLICT — the repo id is embedded as a per-call literal so the
+        // bound params (`?1` kind, `?2` token) stay unchanged. Pre-A5 (no `repo_id` column)
+        // uses the original SQL.
+        let clone_df_bump_sql =
+            match crate::index::schema::periphery_repo_scope(conn, "clone_token_df")? {
+                Some(repo_id) => format!(
+                    "INSERT INTO clone_token_df(repo_id, normalizer_kind, token_hash, df)
+                 VALUES ('{}', ?1, ?2, 1)
+                 ON CONFLICT(repo_id, normalizer_kind, token_hash) DO UPDATE SET df = df + 1",
+                    repo_id.replace('\'', "''")
+                ),
+                None => "INSERT INTO clone_token_df(normalizer_kind, token_hash, df)
+                 VALUES (?1, ?2, 1)
+                 ON CONFLICT(normalizer_kind, token_hash) DO UPDATE SET df = df + 1"
+                    .to_string(),
+            };
         for (local_index, fp) in fingerprints {
             let symbol_id = symbol_db_ids[*local_index];
             // The token bag rides the fingerprint row as ONE serialized BLOB (#231), replacing the
@@ -321,12 +339,8 @@ impl IndexDatabase {
             // rebuild.rs). R7: iterate the IN-MEMORY `fp.token_bag` here — no decode round-trip.
             if bump_df.0 {
                 for &(token_hash, _freq) in &fp.token_bag {
-                    conn.prepare_cached(
-                        "INSERT INTO clone_token_df(normalizer_kind, token_hash, df)
-                         VALUES (?1, ?2, 1)
-                         ON CONFLICT(normalizer_kind, token_hash) DO UPDATE SET df = df + 1",
-                    )?
-                    .execute(params![normalizer_kind, token_hash])?;
+                    conn.prepare_cached(&clone_df_bump_sql)?
+                        .execute(params![normalizer_kind, token_hash])?;
                 }
             }
         }

--- a/crates/rag-rat-core/src/index/oracle/run.rs
+++ b/crates/rag-rat-core/src/index/oracle/run.rs
@@ -699,7 +699,7 @@ fn count_low_confidence_with_oracle(
     let count: i64 = conn.query_row(
         &format!(
             "SELECT COUNT(*){} AND edges.confidence IN ('NameOnly', 'Ambiguous')",
-            store::edge_oracle_scope_join()
+            store::edge_oracle_scope_join(conn)?
         ),
         rusqlite::params![tool.as_db_str(), tool_version, commit_sha, worktree_id],
         |row| row.get(0),
@@ -724,7 +724,7 @@ fn count_low_confidence_upgrades(
         &format!(
             "SELECT COUNT(*){} AND edge_oracle.kind = 'upgrade' AND edges.confidence IN \
              ('NameOnly', 'Ambiguous')",
-            store::edge_oracle_scope_join()
+            store::edge_oracle_scope_join(conn)?
         ),
         rusqlite::params![tool.as_db_str(), tool_version, commit_sha, worktree_id],
         |row| row.get(0),
@@ -750,7 +750,7 @@ fn count_upgradeable_low_confidence(
         &format!(
             "SELECT COUNT(*){} AND edge_oracle.kind IN ('upgrade', 'resolved-external') AND \
              edges.confidence IN ('NameOnly', 'Ambiguous')",
-            store::edge_oracle_scope_join()
+            store::edge_oracle_scope_join(conn)?
         ),
         rusqlite::params![tool.as_db_str(), tool_version, commit_sha, worktree_id],
         |row| row.get(0),

--- a/crates/rag-rat-core/src/index/oracle/status.rs
+++ b/crates/rag-rat-core/src/index/oracle/status.rs
@@ -53,8 +53,11 @@ pub(crate) fn status(
 /// `(status, commit_sha)` of the most recent run for a tool/version **in the active checkout**, if
 /// any. SCOPE (load-bearing): filtered to `(commit_sha, worktree_id)` so a sibling worktree's run
 /// sharing the same `(tool, tool_version, commit_sha)` can't surface as THIS checkout's last run.
-/// The verdict counts in `status` are already worktree-scoped; this keeps the run meta consistent
-/// with them rather than describing a different checkout's pass.
+/// ALSO filtered to the ACTIVE REPO (V042): the verdict counts beside this in `status` route
+/// through the repo-scoped `edge_oracle_scope_join`, so without the same predicate here a SIBLING
+/// repo's newer run at the same `(tool, tool_version, commit_sha, worktree_id)` — the fork case —
+/// would headline this repo's `oracle status` while the counts describe a different repo's pass.
+/// `{repo_clause}` empty pre-A5.
 fn last_run_meta(
     conn: &Connection,
     tool: OracleTool,
@@ -62,15 +65,18 @@ fn last_run_meta(
     commit_sha: &str,
     worktree_id: &str,
 ) -> anyhow::Result<Option<(String, String)>> {
+    let repo_clause = super::store::oracle_repo_scope_clause(conn, "oracle_runs")?;
     let row = conn
         .query_row(
-            "
+            &format!(
+                "
             SELECT status, commit_sha FROM oracle_runs
             WHERE tool = ?1 AND tool_version = ?2
-              AND commit_sha = ?3 AND worktree_id = ?4
+              AND commit_sha = ?3 AND worktree_id = ?4{repo_clause}
             ORDER BY id DESC
             LIMIT 1
-            ",
+            "
+            ),
             rusqlite::params![tool.as_db_str(), tool_version, commit_sha, worktree_id],
             |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
         )

--- a/crates/rag-rat-core/src/index/oracle/store.rs
+++ b/crates/rag-rat-core/src/index/oracle/store.rs
@@ -76,23 +76,44 @@ pub(crate) fn resolution_before_counts(
 /// "symbols enriched" signal (#70). Scoped to `tool_version` (not just `tool`) so the count
 /// describes the SAME run as the report's `edge_oracle`-derived metrics: a later same-tool run with
 /// a different `tool_version` must not bleed its monikers into this report. Also scoped to the
-/// ACTIVE repo (A3): `logical_symbol_monikers` carries no `repo_id`, so a consolidated DB's count
-/// must join `logical_symbols` and filter `repo_id = active_repo_id` — otherwise a sibling repo's
-/// monikers inflate this report's enriched-symbol count.
+/// ACTIVE repo: `logical_symbol_monikers` gained its own `repo_id` column in V042 (A5), so the
+/// count filters it directly via the periphery scope clause — otherwise a sibling repo's monikers
+/// inflate this report's enriched-symbol count.
 pub(crate) fn count_symbols_with_moniker(
     conn: &Connection,
     tool: OracleTool,
     tool_version: &str,
 ) -> anyhow::Result<u64> {
-    let repo_id = crate::index::schema::active_repo_id(conn)?;
+    let repo_clause = oracle_repo_scope_clause(conn, "logical_symbol_monikers")?;
     let count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM logical_symbol_monikers
-         WHERE tool = ?1 AND tool_version = ?2
-           AND logical_symbol_id IN (SELECT id FROM logical_symbols WHERE repo_id = ?3)",
-        params![tool.as_db_str(), tool_version, repo_id],
+        &format!(
+            "SELECT COUNT(*) FROM logical_symbol_monikers
+             WHERE tool = ?1 AND tool_version = ?2{repo_clause}"
+        ),
+        params![tool.as_db_str(), tool_version],
         |row| row.get(0),
     )?;
     Ok(u64::try_from(count).unwrap_or(0))
+}
+
+/// The ` AND <qualifier>.repo_id = '…'` predicate for the oracle periphery tables (`oracle_runs` /
+/// `edge_oracle` / `logical_symbol_monikers`, all scoped in the A5 migration), or `""` on the
+/// pre-A5 schema. Probing `oracle_runs` is authoritative for the set (all three gain `repo_id` in
+/// the same migration). See `schema::periphery_repo_scope`.
+pub(super) fn oracle_repo_scope_clause(
+    conn: &Connection,
+    qualifier: &str,
+) -> anyhow::Result<String> {
+    let scope = crate::index::schema::periphery_repo_scope(conn, "oracle_runs")?;
+    Ok(crate::index::schema::periphery_repo_scope_clause(&scope, qualifier))
+}
+
+/// The active `repo_id` to STAMP on an oracle-periphery write (`oracle_runs` / `edge_oracle` /
+/// `logical_symbol_monikers`), or `None` on the pre-A5 schema. Embedded as a per-call literal in
+/// the writers so their bound params (and the ON CONFLICT target column list) are the only things
+/// that change with scoping.
+fn oracle_repo_scope(conn: &Connection) -> anyhow::Result<Option<String>> {
+    Ok(crate::index::schema::periphery_repo_scope(conn, "oracle_runs")?)
 }
 
 /// An edge candidate to feed the oracle join: the callee identifier byte range (the SCIP key, #67)
@@ -300,27 +321,21 @@ pub(crate) fn logical_symbol_id_for_member(
 /// inside the run's transaction, so the moniker set is **authoritative** for the latest run: a
 /// symbol the current `.scip` no longer defines must not keep a stale moniker.
 ///
-/// SCOPE (load-bearing, A3): the DELETE is restricted to monikers whose logical symbol belongs to
-/// the ACTIVE repo (`logical_symbols.repo_id = active_repo_id`) — `logical_symbols` ids are now
-/// repo-distinct, so `logical_symbol_monikers` (which has no `repo_id` column of its own) can hold
-/// rows for several repos in a consolidated DB. A global `DELETE ... WHERE tool = ?` would erase a
-/// SIBLING repo's live moniker anchors on every oracle run, making its `scip_moniker` memory
-/// relocation go gone/unverified. Dangling rows (whose content-derived logical id died in a
-/// rebuild, so they join NO repo's `logical_symbols`) are still swept — they belong to no repo and
-/// never resolve through the live-join reads, so sweeping them can never touch a sibling's valid
-/// rows.
+/// SCOPE (load-bearing): the DELETE is restricted to the ACTIVE repo's monikers via
+/// `logical_symbol_monikers.repo_id` — its own column since V042 (A5), stamped on write to the
+/// repo that owns the moniker. A global `DELETE ... WHERE tool = ?` would erase a SIBLING repo's
+/// live moniker anchors on every oracle run, making its `scip_moniker` memory relocation go
+/// gone/unverified. This repo's dangling rows (whose content-derived logical id died in a rebuild
+/// but whose `repo_id` still marks them ours) are swept alongside; a sibling's dangling rows are
+/// left for that repo's own run to clear (they resolve through no live join, so they never leak).
 pub(crate) fn clear_logical_symbol_monikers_for_tool(
     conn: &Connection,
     tool: OracleTool,
 ) -> anyhow::Result<()> {
-    let repo_id = crate::index::schema::active_repo_id(conn)?;
-    conn.execute(
-        "DELETE FROM logical_symbol_monikers
-         WHERE tool = ?1
-           AND (logical_symbol_id IN (SELECT id FROM logical_symbols WHERE repo_id = ?2)
-                OR logical_symbol_id NOT IN (SELECT id FROM logical_symbols))",
-        params![tool.as_db_str(), repo_id],
-    )?;
+    let repo_clause = oracle_repo_scope_clause(conn, "logical_symbol_monikers")?;
+    conn.execute(&format!("DELETE FROM logical_symbol_monikers WHERE tool = ?1{repo_clause}"), [
+        tool.as_db_str(),
+    ])?;
     Ok(())
 }
 
@@ -334,16 +349,29 @@ pub(crate) fn write_logical_symbol_moniker(
     logical_symbol_id: i64,
     moniker: &str,
 ) -> anyhow::Result<()> {
+    // Post-A5 the PK is `(repo_id, logical_symbol_id, tool)`, so stamp `repo_id` AND widen the ON
+    // CONFLICT target. The repo id is a per-call literal prefix so the bound params (`?1`..`?5`)
+    // are unchanged; pre-A5 uses the original 5-column shape.
+    let (repo_col, repo_val, conflict_prefix) = match oracle_repo_scope(conn)? {
+        Some(repo_id) => (
+            "repo_id, ".to_string(),
+            format!("'{}', ", repo_id.replace('\'', "''")),
+            "repo_id, ".to_string(),
+        ),
+        None => (String::new(), String::new(), String::new()),
+    };
     conn.execute(
-        "
-        INSERT INTO logical_symbol_monikers(logical_symbol_id, tool, tool_version, moniker, \
-         computed_at)
-        VALUES (?1, ?2, ?3, ?4, ?5)
-        ON CONFLICT(logical_symbol_id, tool) DO UPDATE SET
+        &format!(
+            "
+        INSERT INTO logical_symbol_monikers({repo_col}logical_symbol_id, tool, tool_version, \
+             moniker, computed_at)
+        VALUES ({repo_val}?1, ?2, ?3, ?4, ?5)
+        ON CONFLICT({conflict_prefix}logical_symbol_id, tool) DO UPDATE SET
             tool_version = excluded.tool_version,
             moniker = excluded.moniker,
             computed_at = excluded.computed_at
-        ",
+        "
+        ),
         params![logical_symbol_id, tool.as_db_str(), tool_version, moniker, now_ms()],
     )?;
     Ok(())
@@ -374,11 +402,18 @@ pub(crate) fn clear_edge_oracle_for_tool(
     // `name_strings` join for the `edge_kind` text match. The callsite-file `files.sha256` is NOT
     // gated here: the authoritative clear must drop the prior verdict for a content-matching edge
     // even when the file drifted (the run rewrites it), exactly as the old rowid clear did.
+    //
+    // SCOPE (load-bearing, A5): the DELETE also filters `edge_oracle.repo_id` (its own column since
+    // V042). Without it, a SIBLING repo's verdict whose `source_path` + content key collide with
+    // one of this repo's live edges (an identical shared file, the same-path poison tripwire)
+    // would be cross-cleared by this repo's run — the same content join
+    // `edge_oracle_scope_join` guards on the read side. `{repo_clause}` empty pre-A5.
+    let repo_clause = oracle_repo_scope_clause(conn, "edge_oracle")?;
     conn.execute(
         &format!(
             "
         DELETE FROM edge_oracle
-        WHERE tool = ?1 AND tool_version = ?2
+        WHERE tool = ?1 AND tool_version = ?2{repo_clause}
           AND EXISTS (
             SELECT 1
             FROM edges_data
@@ -429,17 +464,29 @@ pub(crate) fn write_edge_oracle(
     tool_version: &str,
     row: &EdgeOracleRow<'_>,
 ) -> anyhow::Result<()> {
+    // Post-A5 the content-key PK gains a leading `repo_id`, so stamp it AND widen the ON CONFLICT
+    // target. The repo id is a per-call literal prefix so the bound params (`?1`..`?13`) are
+    // unchanged; pre-A5 uses the original shape.
+    let (repo_col, repo_val, conflict_prefix) = match oracle_repo_scope(conn)? {
+        Some(repo_id) => (
+            "repo_id, ".to_string(),
+            format!("'{}', ", repo_id.replace('\'', "''")),
+            "repo_id, ".to_string(),
+        ),
+        None => (String::new(), String::new(), String::new()),
+    };
     conn.execute(
-        "
+        &format!(
+            "
         INSERT INTO edge_oracle(
-            source_path, source_start_byte, source_end_byte,
+            {repo_col}source_path, source_start_byte, source_end_byte,
             callee_start_byte, callee_end_byte, edge_kind,
             file_sha, tool, tool_version,
             resolved_symbol_id, scip_symbol, kind, computed_at
         )
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+        VALUES ({repo_val}?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
         ON CONFLICT(
-            tool, tool_version, source_path,
+            {conflict_prefix}tool, tool_version, source_path,
             source_start_byte, source_end_byte,
             callee_start_byte, callee_end_byte, edge_kind
         ) DO UPDATE SET
@@ -448,7 +495,8 @@ pub(crate) fn write_edge_oracle(
             scip_symbol = excluded.scip_symbol,
             kind = excluded.kind,
             computed_at = excluded.computed_at
-        ",
+        "
+        ),
         params![
             row.source_path,
             row.source_start_byte,
@@ -512,13 +560,22 @@ pub(crate) fn record_oracle_run_at(
     // against the index's last-change clock; stamping completion time made a run that
     // overlapped a watcher reindex look fresher than the edits it skipped, wedging the gate at
     // NotStale (#145).
+    // Post-A5 `oracle_runs` carries `repo_id` (the read key is (repo_id, tool, tool_version,
+    // commit_sha, worktree_id)); stamp it as a per-call literal prefix so the bound params are
+    // unchanged. Pre-A5 uses the original 7-column shape.
+    let (repo_col, repo_val) = match oracle_repo_scope(conn)? {
+        Some(repo_id) => ("repo_id, ".to_string(), format!("'{}', ", repo_id.replace('\'', "''"))),
+        None => (String::new(), String::new()),
+    };
     conn.execute(
-        "
+        &format!(
+            "
         INSERT INTO oracle_runs(
-            tool, tool_version, commit_sha, worktree_id, started_at, status, stats_json
+            {repo_col}tool, tool_version, commit_sha, worktree_id, started_at, status, stats_json
         )
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
-        ",
+        VALUES ({repo_val}?1, ?2, ?3, ?4, ?5, ?6, ?7)
+        "
+        ),
         params![
             tool.as_db_str(),
             tool_version,
@@ -548,14 +605,17 @@ pub(crate) fn latest_run_tool_version(
     commit_sha: &str,
     worktree_id: &str,
 ) -> anyhow::Result<Option<String>> {
+    let repo_clause = oracle_repo_scope_clause(conn, "oracle_runs")?;
     let version = conn
         .query_row(
-            "
+            &format!(
+                "
             SELECT tool_version FROM oracle_runs
-            WHERE tool = ?1 AND commit_sha = ?2 AND worktree_id = ?3
+            WHERE tool = ?1 AND commit_sha = ?2 AND worktree_id = ?3{repo_clause}
             ORDER BY id DESC
             LIMIT 1
-            ",
+            "
+            ),
             params![tool.as_db_str(), commit_sha, worktree_id],
             |row| row.get::<_, String>(0),
         )
@@ -576,14 +636,17 @@ pub(crate) fn latest_run_started_at(
     commit_sha: &str,
     worktree_id: &str,
 ) -> anyhow::Result<Option<i64>> {
+    let repo_clause = oracle_repo_scope_clause(conn, "oracle_runs")?;
     let started_at = conn
         .query_row(
-            "
+            &format!(
+                "
             SELECT started_at FROM oracle_runs
-            WHERE tool = ?1 AND commit_sha = ?2 AND worktree_id = ?3
+            WHERE tool = ?1 AND commit_sha = ?2 AND worktree_id = ?3{repo_clause}
             ORDER BY id DESC
             LIMIT 1
-            ",
+            "
+            ),
             params![tool.as_db_str(), commit_sha, worktree_id],
             |row| row.get::<_, i64>(0),
         )
@@ -599,9 +662,13 @@ pub(crate) fn any_run_in_scope(
     commit_sha: &str,
     worktree_id: &str,
 ) -> anyhow::Result<bool> {
+    let repo_clause = oracle_repo_scope_clause(conn, "oracle_runs")?;
     let exists = conn
         .query_row(
-            "SELECT 1 FROM oracle_runs WHERE commit_sha = ?1 AND worktree_id = ?2 LIMIT 1",
+            &format!(
+                "SELECT 1 FROM oracle_runs WHERE commit_sha = ?1 AND worktree_id = \
+                 ?2{repo_clause} LIMIT 1"
+            ),
             params![commit_sha, worktree_id],
             |_| Ok(()),
         )
@@ -644,8 +711,18 @@ pub(crate) fn any_run_in_scope(
 /// need its `name_strings`-joined text columns (`edge_kind`, `confidence`, `to_name`); the
 /// surfacing reads are bound by an `edge_id IN (...)` list or the staleness/anchor indexes, so the
 /// view's joins are not on an unbounded hot scan.
-pub(crate) fn edge_oracle_scope_join() -> String {
-    format!(
+///
+/// SCOPE (load-bearing, A5): the join to `files` is by the edge's CONTENT key (`source_path`,
+/// `file_sha`) — so in a consolidated DB a SIBLING repo's `edge_oracle` verdict whose `source_path`
+/// and `file_sha` collide with one of THIS repo's files (an identical vendored/shared file, the
+/// same-path poison tripwire) would join onto the active repo's `files` and surface/count as ours.
+/// The `edge_oracle.repo_id` predicate (its own column since V042) pins the verdict to the active
+/// repo directly, so every read consumer that routes through this helper inherits the isolation.
+/// `{repo_clause}` is empty pre-A5. Appended last so a caller's trailing ` AND <extra>` still
+/// composes.
+pub(crate) fn edge_oracle_scope_join(conn: &Connection) -> anyhow::Result<String> {
+    let repo_clause = oracle_repo_scope_clause(conn, "edge_oracle")?;
+    Ok(format!(
         "
     FROM edge_oracle
     JOIN files ON files.path = edge_oracle.source_path
@@ -657,9 +734,9 @@ pub(crate) fn edge_oracle_scope_join() -> String {
               AND edges.callee_end_byte = edge_oracle.callee_end_byte
               AND edges.edge_kind = edge_oracle.edge_kind
     WHERE edge_oracle.tool = ?1 AND edge_oracle.tool_version = ?2
-      AND {scope}",
+      AND {scope}{repo_clause}",
         scope = active_checkout_file_predicate("?3", "?4"),
-    )
+    ))
 }
 
 /// Count `edge_oracle` rows for `(tool, tool_version)` **within the active checkout**, optionally
@@ -674,7 +751,7 @@ pub(crate) fn count_edge_oracle_scoped(
     worktree_id: &str,
     kind: Option<OracleResolutionKind>,
 ) -> anyhow::Result<u64> {
-    let scope_join = edge_oracle_scope_join();
+    let scope_join = edge_oracle_scope_join(conn)?;
     // COUNT(DISTINCT edge_oracle.rowid), not COUNT(*): the scope join joins each `edge_oracle` row
     // to its LIVE edge by the content key. That key is measured 1:1 with a live edge (0
     // collisions / 1.03M rows — the call-site source span makes it unique), so today this
@@ -807,6 +884,7 @@ pub(crate) fn current_oracle_verdicts_for_edges(
     if edge_ids.is_empty() {
         return Ok(out);
     }
+    let scope_join = edge_oracle_scope_join(conn)?;
     // Bind the variable-length id list after the fixed ?1..?4 scope slots. Chunk to stay under
     // SQLite's bound-variable limit on large traversals.
     for chunk in edge_ids.chunks(900) {
@@ -827,7 +905,6 @@ pub(crate) fn current_oracle_verdicts_for_edges(
              FROM name_strings WHERE name_strings.id = (SELECT qualified_name_id FROM symbols \
              WHERE symbols.id = edge_oracle.resolved_symbol_id)), \
              edge_oracle.scip_symbol{scope_join}{current} AND edges.id IN ({placeholders})",
-            scope_join = edge_oracle_scope_join(),
             current = edge_oracle_current_predicate(),
         );
         let mut params: Vec<Box<dyn rusqlite::ToSql>> = vec![
@@ -886,7 +963,7 @@ pub(crate) fn current_oracle_verdicts_all(
     // resolves to), which is the id the importance ranker's heuristic traversal carries.
     let sql = format!(
         "SELECT edges.id, edge_oracle.kind, edge_oracle.resolved_symbol_id{scope_join}{current}",
-        scope_join = edge_oracle_scope_join(),
+        scope_join = edge_oracle_scope_join(conn)?,
         current = edge_oracle_current_predicate(),
     );
     let mut stmt = conn.prepare(&sql)?;
@@ -957,7 +1034,7 @@ pub(crate) fn current_oracle_comparisons(
          symbols.id = edges.to_symbol_id)), edges.to_name, edge_oracle.resolved_symbol_id, \
          edge_oracle.scip_symbol, files.path, COALESCE(NULLIF(edges.source_start_line, 0), 1) \
          {scope_join}{current} ORDER BY files.path, edges.source_start_line",
-        scope_join = edge_oracle_scope_join(),
+        scope_join = edge_oracle_scope_join(conn)?,
         current = edge_oracle_current_predicate(),
     );
     let mut stmt = conn.prepare(&sql)?;
@@ -1029,11 +1106,16 @@ pub(crate) fn prune_oracle_runs_outside_scope(
     }
     let commit_list = sql_quoted_list(live_commits);
     let worktree_list = sql_quoted_list(live_worktrees);
+    // Per-repo (A5): scope the prune to the ACTIVE repo's runs — `live_commits`/`live_worktrees`
+    // are the active repo's live set, so without this a gc of repo A would delete every sibling
+    // repo's runs (their commits are not in A's live set). `{repo_clause}` empty pre-A5. This
+    // is the "oracle prune parity across repos" contract.
+    let repo_clause = oracle_repo_scope_clause(conn, "oracle_runs")?;
     let deleted = conn.execute(
         &format!(
             "DELETE FROM oracle_runs
              WHERE commit_sha NOT IN ({commit_list})
-               AND worktree_id NOT IN ({worktree_list})"
+               AND worktree_id NOT IN ({worktree_list}){repo_clause}"
         ),
         [],
     )?;
@@ -1059,8 +1141,14 @@ pub(crate) fn prune_oracle_runs_outside_scope(
 /// is deliberately decoupled from sweep timing (the next `oracle run`'s authoritative clear also
 /// removes content-matching stale rows; this catches the rows that have no live edge at all).
 pub(crate) fn prune_edge_oracle_without_live_edge(conn: &Connection) -> anyhow::Result<u64> {
+    // Per-repo (A5): only sweep the ACTIVE repo's dangling verdicts (`{repo_clause}` on
+    // `edge_oracle`, empty pre-A5). The inner live-edge match stays GLOBAL-across-worktrees within
+    // the repo (no `active_checkout_file_predicate`), so a sibling worktree's still-live verdict is
+    // never swept — the #248 R6 posture, now bounded to one repo.
+    let repo_clause = oracle_repo_scope_clause(conn, "edge_oracle")?;
     let deleted = conn.execute(
-        "
+        &format!(
+            "
         DELETE FROM edge_oracle
         WHERE NOT EXISTS (
             SELECT 1
@@ -1073,8 +1161,9 @@ pub(crate) fn prune_edge_oracle_without_live_edge(conn: &Connection) -> anyhow::
               AND edges_data.callee_start_byte = edge_oracle.callee_start_byte
               AND edges_data.callee_end_byte = edge_oracle.callee_end_byte
               AND ek.value = edge_oracle.edge_kind
-        )
-        ",
+        ){repo_clause}
+        "
+        ),
         [],
     )?;
     Ok(u64::try_from(deleted).unwrap_or(0))

--- a/crates/rag-rat-core/src/index/oracle/tests.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests.rs
@@ -1931,6 +1931,111 @@ fn clear_edge_oracle_for_tool_scopes_by_checkout_content() {
     );
 }
 
+/// A5 finding: `edge_oracle` reads (via the shared `edge_oracle_scope_join`) and the authoritative
+/// clear (`clear_edge_oracle_for_tool`) are scoped by `edge_oracle.repo_id`. A SIBLING repo's
+/// verdict whose CONTENT key (path + spans + sha) collides with one of THIS repo's live edges must
+/// neither inflate the scoped count nor be cross-cleared by this repo's run — the content join
+/// alone (files/edges are shared) would otherwise surface and delete it.
+#[test]
+fn edge_oracle_reads_and_clears_are_scoped_to_the_active_repo() {
+    let h = Harness::new();
+    let active_file = h.add_file("a.rs", "fn caller() { target(); }\n");
+    let active_sha = h.file_sha("a.rs");
+    let active_edge = h.add_edge(active_file, "target", 14, 20, "NameOnly", None);
+    h.write_verdict(active_edge, &active_sha, None, "s", OracleResolutionKind::Upgrade);
+    assert_eq!(
+        store::count_edge_oracle_scoped(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, None).unwrap(),
+        1
+    );
+
+    // Copy the active verdict under a SIBLING repo_id: SAME content key, so it joins the SAME live
+    // edge — an UNSCOPED read would double-count it and an unscoped clear would delete it.
+    let copied = h
+        .conn
+        .execute(
+            "INSERT INTO edge_oracle(repo_id, source_path, source_start_byte, source_end_byte, \
+             callee_start_byte, callee_end_byte, edge_kind, file_sha, tool, tool_version, \
+             resolved_symbol_id, scip_symbol, kind, computed_at)
+             SELECT 'oracle-sibling', source_path, source_start_byte, source_end_byte, \
+             callee_start_byte, callee_end_byte, edge_kind, file_sha, tool, tool_version, \
+             resolved_symbol_id, scip_symbol, kind, computed_at
+             FROM edge_oracle WHERE repo_id != 'oracle-sibling'",
+            [],
+        )
+        .unwrap();
+    assert_eq!(copied, 1, "one content-colliding sibling verdict seeded");
+
+    // The scoped count still sees ONLY the active repo's verdict.
+    assert_eq!(
+        store::count_edge_oracle_scoped(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, None).unwrap(),
+        1,
+        "a sibling repo's content-colliding verdict must not inflate the active repo's count",
+    );
+
+    // The scoped clear removes ONLY the active repo's verdict; the sibling survives.
+    store::clear_edge_oracle_for_tool(&h.conn, TOOL, VERSION, COMMIT, WORKTREE).unwrap();
+    let remaining: i64 =
+        h.conn.query_row("SELECT COUNT(*) FROM edge_oracle", [], |r| r.get(0)).unwrap();
+    assert_eq!(remaining, 1, "the sibling repo's verdict survives the active repo's clear");
+    let sibling: i64 = h
+        .conn
+        .query_row("SELECT COUNT(*) FROM edge_oracle WHERE repo_id = 'oracle-sibling'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(sibling, 1, "the surviving row is the sibling's");
+}
+
+/// A5 finding: `oracle status` pairs its run HEADER (`last_run_meta`) and its verdict COUNTS to the
+/// SAME repo. The counts route through the repo-scoped `edge_oracle_scope_join`; without the same
+/// `oracle_runs.repo_id` predicate on the header read, a SIBLING repo's NEWER run at the identical
+/// `(tool, tool_version, commit_sha, worktree_id)` — the fork case — would headline this repo's
+/// status while the counts describe this repo's pass.
+#[test]
+fn oracle_status_header_and_counts_describe_the_active_repo_not_a_sibling() {
+    let h = Harness::new();
+    // One active-repo verdict + its run row (stamped with the active repo by the writer).
+    let f = h.add_file("a.rs", "fn caller() { target(); }\n");
+    let sha = h.file_sha("a.rs");
+    let edge = h.add_edge(f, "target", 14, 20, "NameOnly", None);
+    h.write_verdict(edge, &sha, None, "s", OracleResolutionKind::Upgrade);
+    store::record_oracle_run(&h.conn, TOOL, VERSION, COMMIT, WORKTREE, "complete", "{}").unwrap();
+
+    // A sibling repo's NEWER run (higher id — wins an unscoped ORDER BY id DESC) at the SAME
+    // (tool, version, commit, worktree), plus a content-colliding sibling verdict.
+    h.conn
+        .execute(
+            "INSERT INTO oracle_runs(repo_id, tool, tool_version, commit_sha, worktree_id, \
+             started_at, status, stats_json)
+             VALUES ('oracle-sibling', ?1, ?2, ?3, ?4, 999, 'failed', '{}')",
+            params![TOOL.as_db_str(), VERSION, COMMIT, WORKTREE],
+        )
+        .unwrap();
+    h.conn
+        .execute(
+            "INSERT INTO edge_oracle(repo_id, source_path, source_start_byte, source_end_byte, \
+             callee_start_byte, callee_end_byte, edge_kind, file_sha, tool, tool_version, \
+             resolved_symbol_id, scip_symbol, kind, computed_at)
+             SELECT 'oracle-sibling', source_path, source_start_byte, source_end_byte, \
+             callee_start_byte, callee_end_byte, edge_kind, file_sha, tool, tool_version, \
+             resolved_symbol_id, scip_symbol, kind, computed_at
+             FROM edge_oracle WHERE repo_id != 'oracle-sibling'",
+            [],
+        )
+        .unwrap();
+
+    let status = super::status::status(&h.conn, TOOL, VERSION, COMMIT, WORKTREE).unwrap();
+    assert_eq!(
+        status.last_run_status.as_deref(),
+        Some("complete"),
+        "the status header must be the ACTIVE repo's run, not the sibling's newer 'failed' run",
+    );
+    assert_eq!(
+        status.total_verdicts, 1,
+        "the counts stay scoped to the active repo — header and counts describe the SAME repo",
+    );
+}
+
 /// #248 THE killer test: an `edge_oracle` verdict SURVIVES reindex for an UNCHANGED file. A reindex
 /// rewrites `edges_data` (DELETE + reinsert with NEW rowids); before the content-key fix the
 /// `ON DELETE CASCADE` FK wiped every verdict and the opt-in oracle never repopulated. Now the

--- a/crates/rag-rat-core/src/index/poison_sibling.rs
+++ b/crates/rag-rat-core/src/index/poison_sibling.rs
@@ -16,32 +16,36 @@
 //! read/count/delete that returns the UNION across repos (a missing `repo_id` filter on a
 //! whole-table scan). (2) SAME-PATH rows seed under a REAL primary-repo path (resolved at seed time
 //! by [`primary_collision_path`]) — they catch the class the distinct-path rows CANNOT: an
-//! aggregate that reads a scoped table grouped by a NON-repo key (path / source_path) and then
-//! JOINS the result onto the active repo's rows BY PATH instead of flowing repo attribution through
-//! the join. The canonical example is the V041 `github_ref_counts` CTE in
-//! `query::repo_brief::file_rows` (`SELECT source_path, COUNT(*) FROM github_refs GROUP BY
+//! aggregate that reads a scoped table grouped by a NON-repo key (path / source_path / (path,
+//! start_byte)) and then JOINS the result onto the active repo's rows BY THAT KEY instead of
+//! flowing repo attribution through the join. The canonical example is the V041 `github_ref_counts`
+//! CTE in `query::repo_brief::file_rows` (`SELECT source_path, COUNT(*) FROM github_refs GROUP BY
 //! source_path` then `LEFT JOIN … ON github_ref_counts.path = files.path`): a sibling's
 //! `github_refs` row at `src/lib.rs` inflates the active repo's file `src/lib.rs` unless the CTE
 //! filters `repo_id`. A distinct-path sibling ref at `zz_poison_path.rs` never joins onto a primary
-//! file, so ONLY a same-path ref exposes that leak. Same-path rows go in for `github_refs` (the
-//! join-by-path papertrail), `files`, `git_file_changes`, and `parser_failures`; each is pinned in
+//! file, so ONLY a same-path ref exposes that leak. Same-path rows go in for `github_refs`,
+//! `files`, `git_file_changes`, `parser_failures` (V041), and — for the V042 periphery whose
+//! readers key by path — `repo_memory_bindings` (path-bound memories joined onto files by path) and
+//! `edge_oracle` (source_path + source_start_byte joined onto files); each is pinned in
 //! [`sibling_tripwires`] by a path-INDEPENDENT sentinel column so the intact check holds regardless
 //! of which fixture path was chosen.
 //!
-//! SCHEMA-VERSION SCOPE (load-bearing): this worktree is **V041** (`LATEST_SCHEMA_VERSION = 41`),
+//! SCHEMA-VERSION SCOPE (load-bearing): this worktree is **V042** (`LATEST_SCHEMA_VERSION = 42`),
 //! which scopes the V040 core tables — `repos`, `repo_roots`, `repo_meta`, `files`, `packages`,
-//! `logical_symbols`, `docs`, `parser_failures`, `git_commits`, `git_file_changes` (plus tables
-//! scoped TRANSITIVELY through them: `chunks`/`symbols`/`edges_data` via `files.id`;
-//! `logical_symbol_members`/`logical_symbol_monikers` via `logical_symbols.id`) — AND the seven
-//! V041 GitHub papertrail tables (`github_refs`, `github_issues`, `github_comments`,
-//! `github_pull_requests`, `github_reviews`, `github_review_comments`, `github_ref_sync`) plus the
-//! `github_fts` mirror, each of which gained a `repo_id` column in V041. [`seed_sibling`] seeds a
-//! tripwire row into every one of those. The repo-memory, oracle (`oracle_runs`/`edge_oracle`),
-//! clone, `dream_findings`, and `reconcile_attempts` tables are STILL GLOBAL at V041 — they gain
-//! `repo_id` only in A5 (V042), which is NOT in this worktree — so seeding a
-//! `repo_id='poison-sibling'` row into them is impossible and a read of them is *legitimately*
-//! cross-repo here. Seeding them would manufacture FALSE tripwires. When A5 lands, extend
-//! [`seed_sibling`] to those tables at the same time their scoping does.
+//! `logical_symbols`, `docs`, `parser_failures`, `git_commits`, `git_file_changes` (plus
+//! `chunks`/`symbols`/`edges_data` TRANSITIVELY via `files.id` and `logical_symbol_members` via
+//! `logical_symbols.id`) — the seven V041 GitHub papertrail tables (`github_refs`, `github_issues`,
+//! `github_comments`, `github_pull_requests`, `github_reviews`, `github_review_comments`,
+//! `github_ref_sync`) plus the `github_fts` mirror — AND the V042 periphery tables that each gained
+//! their OWN `repo_id`: `repo_memories`, `repo_memory_bindings`, `repo_memory_fts`,
+//! `logical_symbol_monikers` (now direct, no longer only transitive), `oracle_runs`, `edge_oracle`,
+//! `clone_graph_generations`, `clone_token_df`, `clone_refinements`, `dream_findings`, and
+//! `reconcile_attempts` (with `repo_memory_tags` scoped transitively through `repo_memories`).
+//! [`seed_sibling`] seeds a tripwire row into every one of those. Nothing repo-scoped is left
+//! unseeded at V042; a table without a `repo_id` dimension (content-addressed pools like
+//! `name_strings` / `embedding_cache`, the FTS-derived `chunk_fts`, `clone_edges`/postings scoped
+//! by their globally-unique `build_generation`) is deliberately absent — seeding it would
+//! manufacture a FALSE tripwire against a legitimately cross-repo store.
 //!
 //! WHY THE SIBLING IS NOT REGISTERED IN `repos` (load-bearing at V040): the eight direct-scoped
 //! DATA tables (`files`, `packages`, `logical_symbols`, `docs`, `parser_failures`, `git_commits`,
@@ -112,9 +116,24 @@ const POISON_SAMEPATH_MSG: &str = "zz_poison_samepath_msg";
 /// `git_file_changes.additions` sentinel pinning the same-path `git_file_changes` row (a value no
 /// real fixture change produces).
 const POISON_SAMEPATH_ADDITIONS: i64 = 7_700_077;
+/// `repo_memory_bindings.binding_id` sentinel pinning the same-path memory binding (a SECOND
+/// binding off the poison memory whose `path` column is a REAL primary path — the distinct-path
+/// binding leaves `path` NULL, so it never reaches the `path IS NOT NULL` path-join readers).
+const POISON_SAMEPATH_BIND: &str = "zz_poison_samepath_bind";
+/// `edge_oracle.scip_symbol` sentinel pinning the same-path oracle edge (its `source_path` +
+/// `file_sha` collide with a real primary file so the `edge_oracle`→`files` path+sha join trips).
+const POISON_SAMEPATH_SCIP: &str = "zz_poison_samepath_scip";
 /// Fallback collision path when the fixture indexed no files — nothing to collide with, but the row
 /// still guards against an unscoped DELETE.
 const POISON_SAMEPATH_FALLBACK: &str = "zz_poison_no_primary_file.rs";
+
+/// The poison sibling's repo-memory id — the anchor the memory bindings / tags / FTS mirror hang
+/// off (they scope through `memory_id` → `repo_memories.repo_id`, or carry `repo_id` directly).
+const POISON_MEMORY_ID: &str = "zz_poison_mem";
+
+/// The poison sibling's clone generation / token-hash sentinel — a distinctive integer far outside
+/// any fixture's `MAX(generation)+1` allocation so a seeded clone row never collides.
+const POISON_GENERATION: i64 = 9_900_000_042;
 
 thread_local! {
     /// Whether [`seed_if_enabled`] seeds on this thread. Default ON. Thread-local (not a global
@@ -276,14 +295,17 @@ pub(crate) fn seed_sibling(conn: &Connection) -> anyhow::Result<()> {
     )?;
     // logical_symbol_monikers has NO repo_id and NO FK; it is scoped only by the join to
     // logical_symbols. This row is the tripwire for the oracle moniker clear/count (round-6 P2 #3).
+    // Since V042 `logical_symbol_monikers` carries its OWN `repo_id` (the count/clear/write now
+    // filter it directly rather than joining `logical_symbols`), stamp it the sibling id.
     conn.execute(
         "INSERT INTO logical_symbol_monikers(logical_symbol_id, tool, tool_version, moniker, \
-         computed_at)
-         VALUES (?1, 'scip-rust', ?2, ?3, 0)",
+         computed_at, repo_id)
+         VALUES (?1, 'scip-rust', ?2, ?3, 0, ?4)",
         params![
             POISON_LOGICAL_ID,
             format!("{POISON_PREFIX}ver"),
-            format!("{POISON_PREFIX}moniker")
+            format!("{POISON_PREFIX}moniker"),
+            POISON_REPO_ID
         ],
     )?;
 
@@ -435,12 +457,106 @@ pub(crate) fn seed_sibling(conn: &Connection) -> anyhow::Result<()> {
         format!("{POISON_PREFIX}revcomment"),
     )?;
 
-    // --- SAME-PATH tripwires: sibling rows whose PATH deliberately collides with a real primary
-    // path (`collision_path`). A join-by-path aggregate that reads a scoped table without a
-    // `repo_id` predicate attributes these to the active repo. The DISTINCT-PATH rows above cannot
-    // catch that class — their `zz_poison_` paths never match a primary path. Each row is under
-    // `POISON_REPO_ID`, so `clear_sibling`'s existing `WHERE repo_id = POISON_REPO_ID` deletes
-    // them; the intact check pins each by its own sentinel column (not by path). ---
+    // --- A5 periphery (V042): repo memories (+ bindings / tags / FTS mirror), oracle runs, edge
+    // oracle, clone generations / token-df / refinements, dream findings, and reconcile attempts
+    // each gained a `repo_id` column in V042, so a sibling row is now valid and any unscoped
+    // periphery read/count/delete trips a tripwire. `repo_memory_tags` has NO `repo_id` of its own
+    // (it scopes transitively via `memory_id` → `repo_memories.repo_id`), so it hangs off the
+    // poison memory. ---
+    conn.execute(
+        "INSERT INTO repo_memories(id, kind, title, body, confidence, status, created_at_ms, \
+         updated_at_ms, source, memory_version, repo_id)
+         VALUES (?1, 'Invariant', ?2, ?3, 'high', 'active', 0, 0, 'agent', 'v1', ?4)",
+        params![
+            POISON_MEMORY_ID,
+            format!("{POISON_PREFIX}title"),
+            format!("{POISON_PREFIX}body"),
+            POISON_REPO_ID
+        ],
+    )?;
+    conn.execute(
+        "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id, anchor_status, \
+         created_at_ms, repo_id)
+         VALUES (?1, 'path', ?2, 'current', 0, ?3)",
+        params![POISON_MEMORY_ID, format!("{POISON_PREFIX}bind"), POISON_REPO_ID],
+    )?;
+    conn.execute("INSERT INTO repo_memory_tags(memory_id, tag) VALUES (?1, ?2)", params![
+        POISON_MEMORY_ID,
+        format!("{POISON_PREFIX}tag")
+    ])?;
+    conn.execute(
+        "INSERT INTO repo_memory_fts(repo_id, memory_id, title, body, kind, tags)
+         VALUES (?1, ?2, ?3, ?4, 'Invariant', ?5)",
+        params![
+            POISON_REPO_ID,
+            POISON_MEMORY_ID,
+            format!("{POISON_PREFIX}title"),
+            format!("{POISON_PREFIX}body"),
+            format!("{POISON_PREFIX}tag")
+        ],
+    )?;
+    conn.execute(
+        "INSERT INTO oracle_runs(tool, tool_version, commit_sha, worktree_id, started_at, status, \
+         stats_json, repo_id)
+         VALUES ('scip-rust', ?1, ?2, '', 0, 'complete', '{}', ?3)",
+        params![format!("{POISON_PREFIX}ver"), POISON_COMMIT, POISON_REPO_ID],
+    )?;
+    conn.execute(
+        "INSERT INTO edge_oracle(repo_id, source_path, source_start_byte, source_end_byte, \
+         callee_start_byte, callee_end_byte, edge_kind, file_sha, tool, tool_version, \
+         scip_symbol, kind, computed_at)
+         VALUES (?1, ?2, 0, 0, 0, 0, 'calls_name', ?3, 'scip-rust', ?4, ?5, 'resolved', 0)",
+        params![
+            POISON_REPO_ID,
+            format!("{POISON_PREFIX}edge.rs"),
+            format!("{POISON_PREFIX}sha"),
+            format!("{POISON_PREFIX}ver"),
+            format!("{POISON_PREFIX}scip")
+        ],
+    )?;
+    conn.execute(
+        "INSERT INTO clone_graph_generations(generation, status, theta_floor, normalizer_kind, \
+         normalizer_version, source_revision, started_at_ms, repo_id)
+         VALUES (?1, 'Complete', 0.7, 'baseline', 1, ?2, 0, ?3)",
+        params![POISON_GENERATION, format!("{POISON_PREFIX}rev"), POISON_REPO_ID],
+    )?;
+    conn.execute(
+        "INSERT INTO clone_token_df(repo_id, normalizer_kind, token_hash, df)
+         VALUES (?1, 'baseline', ?2, 1)",
+        params![POISON_REPO_ID, POISON_GENERATION],
+    )?;
+    conn.execute(
+        "INSERT INTO clone_refinements(repo_id, class_key, language, refine_mode, template, \
+         variation_points_json, proposed_signature_json, confidence, anti_unify_coverage, \
+         lcs_ratio, refactorability, norm_version, alignment_version, created_at_ms, lcs_sampled)
+         VALUES (?1, ?2, 'rust', 'exact', ?3, '[]', '{}', 'high', 0.0, 0.0, 0.0, 1, 1, 0, 0)",
+        params![POISON_REPO_ID, format!("{POISON_PREFIX}class"), format!("{POISON_PREFIX}tmpl")],
+    )?;
+    conn.execute(
+        "INSERT INTO dream_findings(id, kind, subject, claim_hash, evidence, base_rank, \
+         first_seen_at_ms, last_seen_at_ms, repo_id)
+         VALUES (?1, ?2, ?3, ?4, ?5, 0.0, 0, 0, ?6)",
+        params![
+            format!("{POISON_PREFIX}dream"),
+            format!("{POISON_PREFIX}kind"),
+            format!("{POISON_PREFIX}subj"),
+            format!("{POISON_PREFIX}claim"),
+            format!("{POISON_PREFIX}ev"),
+            POISON_REPO_ID
+        ],
+    )?;
+    conn.execute(
+        "INSERT INTO reconcile_attempts(started_at_ms, status, repo_id) VALUES (0, ?1, ?2)",
+        params![format!("{POISON_PREFIX}status"), POISON_REPO_ID],
+    )?;
+
+    // --- SAME-PATH tripwires: sibling rows whose PATH (or path+sha / path+byte) deliberately
+    // collides with a real primary row (`collision_path`). A join-by-<key> aggregate that reads a
+    // scoped table without a `repo_id` predicate attributes these to the active repo. The
+    // DISTINCT-PATH rows above cannot catch that class — their `zz_poison_` paths never match a
+    // primary path. Each row is under `POISON_REPO_ID`, so `clear_sibling`'s existing
+    // `WHERE repo_id = POISON_REPO_ID` deletes them; the intact check pins each by its own sentinel
+    // column (not by path). ---
     // files: caught by any unscoped `main.files` read that groups/joins by path (the scope view
     // would exclude the sibling, so only a view-bypassing path read leaks). No children hung off
     // it.
@@ -478,6 +594,44 @@ pub(crate) fn seed_sibling(conn: &Connection) -> anyhow::Result<()> {
             collision_path,
             POISON_SAMEPATH_REFTEXT,
             POISON_REPO_ID
+        ],
+    )?;
+    // repo_memory_bindings at the shared `path` (V042): a SECOND path-binding off the poison memory
+    // whose `path` column is a REAL primary path — caught by the memory path-join readers
+    // (`repo_brief::memory_counts_by_path`, `orientation` memory titles, `memory::memories_for_*`)
+    // if they forget the `repo_id` predicate. The distinct-path binding leaves `path` NULL, so it
+    // never reaches those `path IS NOT NULL` readers. Distinct `binding_id` for the PK.
+    conn.execute(
+        "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id, path, \
+         anchor_status, created_at_ms, repo_id)
+         VALUES (?1, 'path', ?2, ?3, 'current', 0, ?4)",
+        params![POISON_MEMORY_ID, POISON_SAMEPATH_BIND, collision_path, POISON_REPO_ID],
+    )?;
+    // edge_oracle at the shared (source_path, file_sha) (V042): the `edge_oracle`→`files` metric
+    // join keys on `files.path = source_path AND files.sha256 = file_sha`, so it is scoped only
+    // transitively through the `files` view — a sibling row whose path AND sha match a real primary
+    // file (an identical vendored/shared file across repos) leaks unless the read filters
+    // `edge_oracle.repo_id`. `collision_sha` is the primary file's sha at `collision_path` (or the
+    // fallback when no primary file exists — then nothing collides).
+    let collision_sha: String = conn.query_row(
+        "SELECT COALESCE(
+             (SELECT sha256 FROM main.files WHERE path = ?1 AND repo_id != ?2 ORDER BY sha256 \
+         LIMIT 1),
+             ?3)",
+        params![collision_path, POISON_REPO_ID, POISON_SAMEPATH_SHA],
+        |row| row.get(0),
+    )?;
+    conn.execute(
+        "INSERT INTO edge_oracle(repo_id, source_path, source_start_byte, source_end_byte, \
+         callee_start_byte, callee_end_byte, edge_kind, file_sha, tool, tool_version, \
+         scip_symbol, kind, computed_at)
+         VALUES (?1, ?2, 0, 0, 0, 0, 'calls_name', ?3, 'scip-rust', ?4, ?5, 'resolved', 0)",
+        params![
+            POISON_REPO_ID,
+            collision_path,
+            collision_sha,
+            format!("{POISON_PREFIX}ver"),
+            POISON_SAMEPATH_SCIP
         ],
     )?;
 
@@ -527,7 +681,18 @@ fn clear_sibling(conn: &Connection) -> anyhow::Result<()> {
          DELETE FROM github_reviews WHERE repo_id = '{POISON_REPO_ID}';
          DELETE FROM github_review_comments WHERE repo_id = '{POISON_REPO_ID}';
          DELETE FROM github_ref_sync WHERE repo_id = '{POISON_REPO_ID}';
-         DELETE FROM github_fts WHERE repo_id = '{POISON_REPO_ID}';"
+         DELETE FROM github_fts WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM reconcile_attempts WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM dream_findings WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM clone_refinements WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM clone_token_df WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM clone_graph_generations WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM edge_oracle WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM oracle_runs WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM repo_memory_fts WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM repo_memory_tags WHERE memory_id = '{POISON_MEMORY_ID}';
+         DELETE FROM repo_memory_bindings WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM repo_memories WHERE repo_id = '{POISON_REPO_ID}';"
     ))?;
     Ok(())
 }
@@ -570,7 +735,8 @@ fn sibling_tripwires() -> Vec<(&'static str, String)> {
         (
             "logical_symbol_monikers",
             format!(
-                "logical_symbol_id = {POISON_LOGICAL_ID} AND moniker = '{POISON_PREFIX}moniker'"
+                "logical_symbol_id = {POISON_LOGICAL_ID} AND repo_id = '{POISON_REPO_ID}' AND \
+                 moniker = '{POISON_PREFIX}moniker'"
             ),
         ),
         // github papertrail (V041): each base table + the fts mirror pinned by the sentinel
@@ -637,8 +803,8 @@ fn sibling_tripwires() -> Vec<(&'static str, String)> {
                 POISON_GH_ITEM_ID + 5
             ),
         ),
-        // SAME-PATH tripwires: pinned by a path-INDEPENDENT sentinel column (the collision path is
-        // fixture-dependent), so the intact check holds whichever primary path was chosen.
+        // SAME-PATH tripwires (V041): pinned by a path-INDEPENDENT sentinel column (the collision
+        // path is fixture-dependent), so the intact check holds whichever primary path was chosen.
         (
             "main.files",
             format!("repo_id = '{POISON_REPO_ID}' AND sha256 = '{POISON_SAMEPATH_SHA}'"),
@@ -654,6 +820,46 @@ fn sibling_tripwires() -> Vec<(&'static str, String)> {
         (
             "github_refs",
             format!("repo_id = '{POISON_REPO_ID}' AND number = {POISON_SAMEPATH_GH_NUMBER}"),
+        ),
+        // A5 periphery (V042): each directly-scoped table pinned by the sibling repo_id (plus its
+        // sentinel key where a table's row is otherwise ambiguous). `repo_memory_tags` scopes
+        // transitively through the poison memory.
+        ("repo_memories", format!("repo_id = '{POISON_REPO_ID}' AND id = '{POISON_MEMORY_ID}'")),
+        // Pinned to the distinct-path binding's `binding_id` so the same-path binding tripwire
+        // (a SECOND binding under the same memory) doesn't inflate this count.
+        (
+            "repo_memory_bindings",
+            format!("repo_id = '{POISON_REPO_ID}' AND binding_id = '{POISON_PREFIX}bind'"),
+        ),
+        ("repo_memory_tags", format!("memory_id = '{POISON_MEMORY_ID}'")),
+        (
+            "repo_memory_fts",
+            format!("repo_id = '{POISON_REPO_ID}' AND memory_id = '{POISON_MEMORY_ID}'"),
+        ),
+        ("oracle_runs", format!("repo_id = '{POISON_REPO_ID}'")),
+        // Pinned to the distinct-path edge's `scip_symbol` so the same-path edge tripwire doesn't
+        // inflate this count.
+        (
+            "edge_oracle",
+            format!("repo_id = '{POISON_REPO_ID}' AND scip_symbol = '{POISON_PREFIX}scip'"),
+        ),
+        (
+            "clone_graph_generations",
+            format!("repo_id = '{POISON_REPO_ID}' AND generation = {POISON_GENERATION}"),
+        ),
+        ("clone_token_df", format!("repo_id = '{POISON_REPO_ID}'")),
+        ("clone_refinements", format!("repo_id = '{POISON_REPO_ID}'")),
+        ("dream_findings", format!("repo_id = '{POISON_REPO_ID}'")),
+        ("reconcile_attempts", format!("repo_id = '{POISON_REPO_ID}'")),
+        // SAME-PATH tripwires (V042): the memory binding and oracle edge whose path (and, for the
+        // oracle, path+sha) collide with a real primary row, pinned by their own sentinel keys.
+        (
+            "repo_memory_bindings",
+            format!("repo_id = '{POISON_REPO_ID}' AND binding_id = '{POISON_SAMEPATH_BIND}'"),
+        ),
+        (
+            "edge_oracle",
+            format!("repo_id = '{POISON_REPO_ID}' AND scip_symbol = '{POISON_SAMEPATH_SCIP}'"),
         ),
     ]
 }

--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -596,8 +596,14 @@ fn load_test_symbol_ids(conn: &Connection) -> anyhow::Result<HashSet<i64>> {
 /// sub-block ordering. A token absent from the index is maximally selective (`DF_FALLBACK`),
 /// matching `load_scoped_baseline_bags`.
 fn load_clone_token_df(conn: &Connection) -> anyhow::Result<HashMap<i64, i64>> {
-    let mut stmt = conn
-        .prepare("SELECT token_hash, df FROM clone_token_df WHERE normalizer_kind = 'baseline'")?;
+    // Per-repo df (A5): scope to the active repo; `{df_repo_clause}` is empty pre-A5.
+    let df_scope = crate::index::schema::periphery_repo_scope(conn, "clone_token_df")?;
+    let df_repo_clause =
+        crate::index::schema::periphery_repo_scope_clause(&df_scope, "clone_token_df");
+    let mut stmt = conn.prepare(&format!(
+        "SELECT token_hash, df FROM clone_token_df WHERE normalizer_kind = \
+         'baseline'{df_repo_clause}"
+    ))?;
     let rows = stmt.query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, i64>(1)?)))?;
     let mut map = HashMap::new();
     for row in rows {

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -167,9 +167,16 @@ impl IndexDatabase {
     /// bumps df alongside file-content changes, so `content_revision()` already gates that path —
     /// only this content-invariant refresh needs the explicit nudge.
     pub(crate) fn invalidate_clone_graph_postings(&self) -> anyhow::Result<()> {
-        self.storage
-            .connection()
-            .execute("UPDATE clone_graph_generations SET postings_written = 0", [])?;
+        let conn = self.storage.connection();
+        // Per-repo (A5): only the active repo's generations are invalidated — a full rebuild of one
+        // repo must not force a sibling repo's postings stale. `{repo_clause}` is empty pre-A5.
+        let repo_clause = clone_generation_scope_clause(conn)?;
+        conn.execute(
+            &format!(
+                "UPDATE clone_graph_generations SET postings_written = 0 WHERE 1=1{repo_clause}"
+            ),
+            [],
+        )?;
         Ok(())
     }
 
@@ -406,18 +413,17 @@ impl IndexDatabase {
             params![now_ms(), edges_written as i64, generation],
         )?;
         self.set_repo_meta("clone_graph_live_generation", &generation.to_string())?;
-        // V042 SEAM: `clone_graph_generations` has NO `repo_id` yet, so this GC is global — it
-        // would delete a SIBLING repo's Complete/Building generation on a consolidated DB,
-        // even though that repo's `repo_meta` still points its live pointer at it (losing
-        // its persisted clone fast path). The live pointer is already per-repo
-        // (`live_generation_row`); the generation TABLE becomes per-repo in V042. Until
-        // then, skip the destructive cleanup when more than one real repo is registered; a
-        // single-repo DB (every DB pre-A7) prunes as before.
-        if !crate::index::schema::multiple_real_repos(conn)? {
-            conn.execute("DELETE FROM clone_graph_generations WHERE generation != ?1", params![
-                generation
-            ])?;
-        }
+        // GC superseded generations PER REPO (A5): repo-scoped so completing repo A's generation
+        // never deletes (and CASCADE-wipes the edges/postings of) a sibling repo's generations —
+        // the "clone precompute on repo A leaves repo B's generation untouched" contract. This
+        // real `repo_id` predicate (from V042's `clone_graph_generations.repo_id`) SUPERSEDES the
+        // A3 `multiple_real_repos` seam guard. `{repo_clause}` is empty pre-A5, restoring the
+        // original global sweep.
+        let repo_clause = clone_generation_scope_clause(conn)?;
+        conn.execute(
+            &format!("DELETE FROM clone_graph_generations WHERE generation != ?1{repo_clause}"),
+            params![generation],
+        )?;
         Ok(())
     }
 }
@@ -698,6 +704,17 @@ fn flush_batch(
     }
 }
 
+/// The ` AND clone_graph_generations.repo_id = '…'` predicate for the per-repo generation SWEEPS,
+/// or `""` on the pre-A5 schema (the generations table is still repo-global). The generation
+/// INTEGER stays globally unique (allocated `MAX(generation)+1` over ALL repos), so the transitive
+/// `clone_edges` / `clone_subblock_postings` are scoped for free by `build_generation`; only the
+/// generation lifecycle sweeps (allocate/build/complete/invalidate) filter `repo_id` so a repo's
+/// precompute never touches a sibling's generations. See `schema::periphery_repo_scope`.
+fn clone_generation_scope_clause(conn: &Connection) -> anyhow::Result<String> {
+    let scope = crate::index::schema::periphery_repo_scope(conn, "clone_graph_generations")?;
+    Ok(crate::index::schema::periphery_repo_scope_clause(&scope, "clone_graph_generations"))
+}
+
 /// The live (Complete) generation row, if one is published.
 fn live_generation_row(conn: &Connection) -> anyhow::Result<Option<GenerationRow>> {
     let repo_id = crate::index::schema::active_repo_id(conn)?;
@@ -716,45 +733,44 @@ fn open_building_generation(
     conn: &Connection,
     source_revision: &str,
 ) -> anyhow::Result<GenerationRow> {
-    // V042 SEAM: `clone_graph_generations` has no `repo_id` until V042, so the global `Building`
-    // row below can belong to ANY repo. On a consolidated multi-repo DB we must NOT touch it —
-    // neither RESUME nor DISCARD:
-    //  * RESUMING would adopt a SIBLING's in-progress generation. `source_revision` here is
-    //    `content_revision()`, GLOBAL over `main.files` (V040 reclassification), so a sibling's
-    //    Building row at the same DB content matches this repo's revision exactly;
-    //    `complete_generation` would then publish the sibling's generation under THIS repo's
-    //    `clone_graph_live_generation`.
-    //  * DISCARDING would delete the sibling's partial (a global `DELETE`).
-    // So gate the WHOLE resume/discard block on a single-repo DB. On a consolidated DB, fall
-    // straight through to a fresh `MAX(generation)+1` allocation (globally unique), leaving
-    // every sibling row intact. A single-repo DB (every DB pre-A7) keeps the resume/discard
-    // fast path unchanged.
-    if !crate::index::schema::multiple_real_repos(conn)? {
-        let existing: Option<GenerationRow> = conn
-            .query_row(
+    // Per-repo (A5): resume / discard only THIS repo's Building generation, via a real `repo_id`
+    // predicate from V042's `clone_graph_generations.repo_id` — this SUPERSEDES the A3
+    // `multiple_real_repos` seam guard that used to gate the whole resume/discard block.
+    // `{repo_clause}` empty pre-A5. The MAX(generation) allocation below stays GLOBAL so the
+    // generation integer is unique across repos (keeping the transitive edges/postings scoped by
+    // build_generation).
+    let scope = crate::index::schema::periphery_repo_scope(conn, "clone_graph_generations")?;
+    let repo_clause =
+        crate::index::schema::periphery_repo_scope_clause(&scope, "clone_graph_generations");
+    let existing: Option<GenerationRow> = conn
+        .query_row(
+            &format!(
                 "SELECT generation, source_revision, normalizer_version, cursor_symbol_id, \
                  edges_written, postings_written
-                   FROM clone_graph_generations WHERE status = 'Building'
-                  ORDER BY generation DESC LIMIT 1",
-                [],
-                map_generation_row,
-            )
-            .ok();
-        if let Some(row) = existing {
-            if row.source_revision == source_revision
-                && row.normalizer_version == NORM_VERSION
-                // Resume only a POSTINGS-AWARE partial. A pre-feature Building generation
-                // (`postings_written = 0`) has no postings for its already-walked symbols; resuming
-                // it would Complete a generation with a permanent postings gap. Discard it instead
-                // so the fresh generation below writes postings from symbol 0 (review R2).
-                && row.postings_written
-            {
-                return Ok(row);
-            }
-            // Stale partial (a reindex landed) OR a pre-feature postings-less partial: discard it
-            // (CASCADE drops its edges + postings) and start over.
-            conn.execute("DELETE FROM clone_graph_generations WHERE status = 'Building'", [])?;
+                   FROM clone_graph_generations WHERE status = 'Building'{repo_clause}
+                  ORDER BY generation DESC LIMIT 1"
+            ),
+            [],
+            map_generation_row,
+        )
+        .ok();
+    if let Some(row) = existing {
+        if row.source_revision == source_revision
+            && row.normalizer_version == NORM_VERSION
+            // Resume only a POSTINGS-AWARE partial. A pre-feature Building generation
+            // (`postings_written = 0`) has no postings for its already-walked symbols; resuming it
+            // would Complete a generation with a permanent postings gap. Discard it instead so the
+            // fresh generation below writes postings from symbol 0 (review R2).
+            && row.postings_written
+        {
+            return Ok(row);
         }
+        // Stale partial (a reindex landed) OR a pre-feature postings-less partial: discard it
+        // (CASCADE drops its edges + postings) and start over.
+        conn.execute(
+            &format!("DELETE FROM clone_graph_generations WHERE status = 'Building'{repo_clause}"),
+            [],
+        )?;
     }
     let generation: i64 = conn.query_row(
         "SELECT COALESCE(MAX(generation), 0) + 1 FROM clone_graph_generations",
@@ -768,6 +784,14 @@ fn open_building_generation(
          VALUES (?1, 'Building', ?2, 'baseline', ?3, ?4, 0, 0, 1, ?5)",
         params![generation, CLONE_PRECOMPUTE_THETA, NORM_VERSION, source_revision, now_ms()],
     )?;
+    // Stamp the active repo on the just-allocated generation (A5). No-op pre-A5 (no repo_id
+    // column).
+    if let Some(repo_id) = &scope {
+        conn.execute(
+            "UPDATE clone_graph_generations SET repo_id = ?1 WHERE generation = ?2",
+            params![repo_id, generation],
+        )?;
+    }
     Ok(GenerationRow {
         generation,
         source_revision: source_revision.to_string(),
@@ -883,6 +907,9 @@ mod tests {
 
     #[test]
     fn precompute_writes_graph_and_skips_when_current() {
+        // Asserts a whole-DB `clone_graph_generations` count; opt out of the poison harness whose
+        // sibling seeds another repo's generation.
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
         let db = build_clone_fixture("write");
         let report = db.precompute_clone_graph(None).unwrap();
         assert_eq!(report.status, "Complete", "fresh precompute completes");
@@ -1177,13 +1204,24 @@ mod tests {
     }
 
     /// Insert a `clone_graph_generations` row in `status` toward `source_revision`.
-    fn seed_generation(conn: &rusqlite::Connection, generation: i64, status: &str, revision: &str) {
+    fn seed_generation(
+        conn: &rusqlite::Connection,
+        generation: i64,
+        status: &str,
+        revision: &str,
+        repo_id: &str,
+    ) {
+        // Stamp `repo_id` explicitly: since V042 `complete_generation` / `open_building_generation`
+        // scope by `clone_graph_generations.repo_id` (superseding the old `multiple_real_repos`
+        // guard), a "sibling" generation must carry a DIFFERENT id than the active repo for these
+        // tests to exercise the per-repo predicate.
         conn.execute(
             "INSERT INTO clone_graph_generations
                 (generation, status, theta_floor, normalizer_kind, normalizer_version,
-                 source_revision, cursor_symbol_id, edges_written, postings_written, started_at_ms)
-             VALUES (?1, ?2, 0.0, 'baseline', ?3, ?4, 0, 0, 1, 0)",
-            params![generation, status, NORM_VERSION, revision],
+                 source_revision, cursor_symbol_id, edges_written, postings_written, started_at_ms,
+                 repo_id)
+             VALUES (?1, ?2, 0.0, 'baseline', ?3, ?4, 0, 0, 1, 0, ?5)",
+            params![generation, status, NORM_VERSION, revision, repo_id],
         )
         .unwrap();
     }
@@ -1192,21 +1230,31 @@ mod tests {
         conn.query_row("SELECT COUNT(*) FROM clone_graph_generations", [], |r| r.get(0)).unwrap()
     }
 
-    /// `complete_generation` GCs every other generation; on a multi-repo DB that global delete
-    /// would wipe a sibling repo's live generation, so the guard must skip it.
+    /// `complete_generation` GCs every OTHER generation of the ACTIVE repo; the V042 `repo_id`
+    /// predicate scopes that delete, so a sibling repo's live generation is spared (superseding the
+    /// old `multiple_real_repos` guard).
     #[test]
     fn complete_generation_spares_sibling_generations_on_a_multi_repo_db() {
+        // Whole-DB `generation_count` — opt out of the poison harness (whose sibling seeds another
+        // generation) so this test controls the exact generation set it asserts on.
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
         let db = build_clone_fixture("mr-complete");
         {
             let conn = db.storage.connection();
             make_multi_repo(conn);
-            seed_generation(conn, 1, "Building", "rev-a"); // this repo's, to complete
-            seed_generation(conn, 2, "Complete", "rev-sibling"); // a sibling's live generation
+            // this repo's, to complete
+            seed_generation(conn, 1, "Building", "rev-a", &db.active_repo_id);
+            // a sibling repo's live generation
+            seed_generation(conn, 2, "Complete", "rev-sibling", "repo-x");
         }
         db.complete_generation(1, 0).unwrap();
 
         let conn = db.storage.connection();
-        assert_eq!(generation_count(conn), 2, "the multi-repo guard spared the sibling generation");
+        assert_eq!(
+            generation_count(conn),
+            2,
+            "the per-repo predicate spared the sibling repo's generation"
+        );
         let g1_status: String = conn
             .query_row("SELECT status FROM clone_graph_generations WHERE generation = 1", [], |r| {
                 r.get(0)
@@ -1215,20 +1263,23 @@ mod tests {
         assert_eq!(g1_status, "Complete", "this repo's generation still completes + publishes");
     }
 
-    /// The complement: a single-repo DB (no sibling to protect) GCs the other generations as
-    /// before.
+    /// The complement: with only the active repo's own generations present, `complete_generation`
+    /// GCs every OTHER one of them.
     #[test]
     fn complete_generation_prunes_other_generations_on_a_single_repo_db() {
+        // Whole-DB `generation_count` — opt out of the poison harness (its sibling generation is a
+        // different repo's and is correctly spared, but would inflate this whole-DB count).
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
         let db = build_clone_fixture("sr-complete");
         {
             let conn = db.storage.connection();
-            seed_generation(conn, 1, "Building", "rev-a");
-            seed_generation(conn, 2, "Complete", "rev-old");
+            seed_generation(conn, 1, "Building", "rev-a", &db.active_repo_id);
+            seed_generation(conn, 2, "Complete", "rev-old", &db.active_repo_id);
         }
         db.complete_generation(1, 0).unwrap();
 
         let conn = db.storage.connection();
-        assert_eq!(generation_count(conn), 1, "single-repo GC drops every other generation");
+        assert_eq!(generation_count(conn), 1, "GC drops every other generation of the active repo");
     }
 
     /// `open_building_generation` discards a stale (different-revision) Building row before
@@ -1239,7 +1290,8 @@ mod tests {
         let db = build_clone_fixture("mr-open");
         let conn = db.storage.connection();
         make_multi_repo(conn);
-        seed_generation(conn, 7, "Building", "sibling-rev"); // a sibling's in-progress build
+        // a sibling repo's in-progress build
+        seed_generation(conn, 7, "Building", "sibling-rev", "repo-x");
 
         let opened = open_building_generation(conn, "my-new-rev").unwrap();
         assert_ne!(opened.generation, 7, "a fresh generation is allocated, not the sibling's");
@@ -1263,10 +1315,10 @@ mod tests {
         let db = build_clone_fixture("mr-resume");
         let conn = db.storage.connection();
         make_multi_repo(conn);
-        // A sibling's in-progress build at the SAME revision this repo is about to open (a
-        // matching, postings-aware row — `seed_generation` writes `postings_written = 1`).
-        // The pre-fix code would RESUME generation 9 and hand it to this repo.
-        seed_generation(conn, 9, "Building", "shared-rev");
+        // A SIBLING repo's in-progress build at the SAME revision this repo is about to open (a
+        // matching, postings-aware row — `seed_generation` writes `postings_written = 1`). The
+        // pre-predicate code would RESUME generation 9 and hand it to this repo.
+        seed_generation(conn, 9, "Building", "shared-rev", "repo-x");
 
         let opened = open_building_generation(conn, "shared-rev").unwrap();
         assert_ne!(
@@ -1286,7 +1338,7 @@ mod tests {
     fn open_building_generation_discards_the_stale_building_row_on_a_single_repo_db() {
         let db = build_clone_fixture("sr-open");
         let conn = db.storage.connection();
-        seed_generation(conn, 7, "Building", "stale-rev");
+        seed_generation(conn, 7, "Building", "stale-rev", &db.active_repo_id);
 
         open_building_generation(conn, "new-rev").unwrap();
         let stale: i64 = conn

--- a/crates/rag-rat-core/src/index/query_api/clones/substrate.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/substrate.rs
@@ -130,8 +130,16 @@ pub(crate) fn load_scoped_baseline_bags(conn: &Connection) -> anyhow::Result<Vec
     // `token_bag` BLOB, so df can no longer be a per-token SQL JOIN. Each decoded token's df is
     // looked up here in Rust and COALESCEd to the fallback sentinel — a missing-df token must NOT
     // be dropped (design rev-4 §2). Only the baseline normalizer feeds candidate recall.
-    let mut df_stmt = conn
-        .prepare("SELECT token_hash, df FROM clone_token_df WHERE normalizer_kind = 'baseline'")?;
+    // Post-A5 df is per-repo (its PK carries `repo_id`), so scope the read to the active repo —
+    // `{df_repo_clause}` is empty pre-A5. The writer (`refresh_clone_token_df` / the incremental
+    // bump) stamps the same repo, so the two agree.
+    let df_scope = crate::index::schema::periphery_repo_scope(conn, "clone_token_df")?;
+    let df_repo_clause =
+        crate::index::schema::periphery_repo_scope_clause(&df_scope, "clone_token_df");
+    let mut df_stmt = conn.prepare(&format!(
+        "SELECT token_hash, df FROM clone_token_df WHERE normalizer_kind = \
+         'baseline'{df_repo_clause}"
+    ))?;
     let df_by_token: std::collections::HashMap<i64, i64> = df_stmt
         .query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)))?
         .collect::<Result<_, _>>()?;

--- a/crates/rag-rat-core/src/index/query_api/gc.rs
+++ b/crates/rag-rat-core/src/index/query_api/gc.rs
@@ -117,16 +117,13 @@ impl IndexDatabase {
         // prune a dead checkout's run rows with the SAME live sets, so a run and the
         // edges it produced are dropped together.
         oracle::prune_edge_oracle_without_live_edge(conn)?;
-        // V042 SEAM: `oracle_runs` has NO `repo_id` yet, so `prune_oracle_runs_outside_scope`
-        // deletes GLOBALLY against THIS repo's live sets. On a consolidated multi-repo DB that
-        // would wipe a sibling repo's run rows (its commits/worktrees are legitimately
-        // absent from this repo's live sets). Skip the global prune when more than one real
-        // repo is registered; the per-repo prune lands once `oracle_runs` gains `repo_id`
-        // in V042 (successor branch). A single-repo DB (every DB pre-A7) is unaffected —
-        // the guard is dormant.
-        if !schema::multiple_real_repos(conn)? {
-            oracle::prune_oracle_runs_outside_scope(conn, live_commits, live_worktrees)?;
-        }
+        // Per-repo (A5): `prune_oracle_runs_outside_scope` now filters `oracle_runs.repo_id` (its
+        // own column since V042), so it deletes only THIS repo's run rows that fall outside THIS
+        // repo's live sets — a sibling repo's runs are legitimately absent from this repo's live
+        // set but are no longer touched. That real `repo_id` predicate SUPERSEDES the old V042-seam
+        // `multiple_real_repos` guard, so the prune runs unconditionally again (exactly as it did
+        // on a single-repo DB before scoping).
+        oracle::prune_oracle_runs_outside_scope(conn, live_commits, live_worktrees)?;
         // #357: `embedding_cache` is content-keyed too (survives reindex, like the oracle above),
         // so it needs the SAME global sweep — drop vectors no live chunk references in ANY
         // context (a sibling worktree / branch may still use one, so this must not be

--- a/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
@@ -707,6 +707,9 @@ fn compiler_upgrade_survives_heuristic_limit() {
 /// `(commit, worktree)` is dropped by `prune_to_live` when that context is not live.
 #[test]
 fn gc_prunes_oracle_runs_for_dead_contexts() {
+    // Asserts whole-DB `oracle_runs` counts; opt out of the poison harness whose sibling seeds a
+    // run under its own repo_id.
+    let _poison = crate::index::poison_sibling::disable_poison_sibling();
     let root = temp_root();
     fs::write(root.join("src/lib.rs"), "fn caller() { target(); } fn target() {}\n").unwrap();
     let config = rust_config(root.clone());

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -153,18 +153,42 @@ impl IndexDatabase {
     /// for recall either way.) df feeds candidate GENERATION (the `sub_block_tokens` ordering), not
     /// just ranking. Each symbol's decoded bag has no duplicate `token_hash` (the codec invariant),
     /// so counting one increment per (symbol, token) pair equals `COUNT(DISTINCT symbol_id)`.
-    fn refresh_clone_token_df(&self) -> anyhow::Result<()> {
-        // Phase 1 (read): decode every fingerprint's bag and accumulate df in memory, off the
-        // connection borrow. NULL `token_bag` rows (un-reindexed after the V032 migration) and any
-        // stale/corrupt blob (decode → None) contribute nothing, exactly as a missing postings row
-        // would have.
+    pub(crate) fn refresh_clone_token_df(&self) -> anyhow::Result<()> {
+        // Resolve the active-repo scope ONCE: it gates BOTH the fingerprint READ below and the df
+        // wipe/reinsert (Phase 2). `symbol_fingerprints` is deliberately `repo_id`-free (keyed by
+        // `symbol_id`, FK CASCADE — see the CLONE_FINGERPRINT_DDL note), so the read is scoped
+        // TRANSITIVELY by joining `symbols` → `main.files` and filtering `files.repo_id`, exactly
+        // like the clone candidate reads. Without it, a consolidated DB's SIBLING repo's
+        // fingerprints pool their token frequencies into THIS repo's df — inflating
+        // document frequencies and reordering `sub_block_tokens`, which changes SourcererCC
+        // candidate selection (the review finding). `probe = "clone_token_df"` is
+        // authoritative for the periphery set.
+        let df_scope = {
+            let conn = self.storage.connection();
+            crate::index::schema::periphery_repo_scope(conn, "clone_token_df")?
+        };
+
+        // Phase 1 (read): decode every (active-repo) fingerprint's bag and accumulate df in memory,
+        // off the connection borrow. NULL `token_bag` rows (un-reindexed after the V032 migration)
+        // and any stale/corrupt blob (decode → None) contribute nothing, exactly as a missing
+        // postings row would have.
         // Outer key: normalizer_kind (cloned once per kind, not per (symbol, token) pair).
         // Inner key: token_hash → df count.
         let mut df: BTreeMap<String, BTreeMap<i64, i64>> = BTreeMap::new();
         {
             let conn = self.storage.connection();
-            let mut stmt =
-                conn.prepare("SELECT normalizer_kind, token_bag FROM symbol_fingerprints")?;
+            let read_sql = match &df_scope {
+                Some(repo_id) => format!(
+                    "SELECT symbol_fingerprints.normalizer_kind, symbol_fingerprints.token_bag
+                     FROM symbol_fingerprints
+                     JOIN symbols ON symbols.id = symbol_fingerprints.symbol_id
+                     JOIN main.files ON main.files.id = symbols.file_id
+                     WHERE main.files.repo_id = '{}'",
+                    repo_id.replace('\'', "''")
+                ),
+                None => "SELECT normalizer_kind, token_bag FROM symbol_fingerprints".to_string(),
+            };
+            let mut stmt = conn.prepare(&read_sql)?;
             let mut rows = stmt.query([])?;
             while let Some(row) = rows.next()? {
                 let normalizer_kind: String = row.get(0)?;
@@ -181,16 +205,36 @@ impl IndexDatabase {
             }
         }
 
-        // Phase 2 (write): replace the table contents with the recomputed df.
+        // Phase 2 (write): replace the ACTIVE REPO's df with the recomputed df. Post-A5
+        // `clone_token_df` carries `repo_id` in its PK (df must not pool across repos), so both the
+        // wipe and the reinsert scope to the active repo — the repo id is embedded as a per-call
+        // literal so the bound params stay unchanged; pre-A5 uses the original global SQL.
         let conn = self.storage.connection();
-        conn.execute_batch("DELETE FROM clone_token_df;")?;
+        let df_delete_sql = match &df_scope {
+            Some(repo_id) => format!(
+                "DELETE FROM clone_token_df WHERE repo_id = '{}';",
+                repo_id.replace('\'', "''")
+            ),
+            None => "DELETE FROM clone_token_df;".to_string(),
+        };
+        let df_insert_sql = match &df_scope {
+            Some(repo_id) => format!(
+                "INSERT INTO clone_token_df(repo_id, normalizer_kind, token_hash, df)
+                 VALUES ('{}', ?1, ?2, ?3)",
+                repo_id.replace('\'', "''")
+            ),
+            None => "INSERT INTO clone_token_df(normalizer_kind, token_hash, df) VALUES (?1, ?2, \
+                     ?3)"
+            .to_string(),
+        };
+        conn.execute_batch(&df_delete_sql)?;
         for (normalizer_kind, inner) in df {
             for (token_hash, count) in inner {
-                conn.prepare_cached(
-                    "INSERT INTO clone_token_df(normalizer_kind, token_hash, df) VALUES (?1, ?2, \
-                     ?3)",
-                )?
-                .execute(params![normalizer_kind, token_hash, count])?;
+                conn.prepare_cached(&df_insert_sql)?.execute(params![
+                    normalizer_kind,
+                    token_hash,
+                    count
+                ])?;
             }
         }
         // The recomputed df may reorder `sub_block_tokens`, so the persisted clone-graph postings

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1176,6 +1176,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_039_ID => Some(39),
             MIGRATION_040_ID => Some(40),
             MIGRATION_041_ID => Some(41),
+            MIGRATION_042_ID => Some(42),
             _ => None,
         })
         .max()
@@ -1226,6 +1227,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_039_ID
             | MIGRATION_040_ID
             | MIGRATION_041_ID
+            | MIGRATION_042_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1273,6 +1275,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_039_ID => migration.checksum != MIGRATION_039_CHECKSUM,
         MIGRATION_040_ID => migration.checksum != MIGRATION_040_CHECKSUM,
         MIGRATION_041_ID => migration.checksum != MIGRATION_041_CHECKSUM,
+        MIGRATION_042_ID => migration.checksum != MIGRATION_042_CHECKSUM,
         _ => false,
     }
 }
@@ -2266,6 +2269,403 @@ fn backfill_github_repo_id_to_sole_repo(conn: &Connection) -> rusqlite::Result<(
         super::LEGACY_REPO_ID,
     ])?;
     Ok(())
+}
+
+// ============================================================================================
+// Memory-sync phase A5 (periphery scoping) — V042.
+//
+// Registered in `ADDITIVE_MIGRATIONS` as V042 (id `042_repo_id_periphery_scoping`): the whole
+// schema change is `apply_repo_id_periphery_scoping` below, shaped like every other ladder step
+// (idempotent, atomic, torn-state re-convergent, placeholder-backfilled). It stacks on V041 (the
+// GitHub papertrail scoping); the two were authored in parallel workstreams and consolidated here.
+//
+// GATING (why the queries still probe): every periphery query sweep gates its `repo_id` predicate
+// on [`super::periphery_repo_scope`] — column present ⇒ scope by the active repo, column absent ⇒
+// the original unscoped SQL. On a normal open `schema::apply` runs the full ladder including V042,
+// so the column is always present and the scoped path always taken. The absent branch is the
+// defensive path for a raw connection that never ran the ladder (and the pre-migration schema in
+// forward-migration bootstrap tests): it degrades to the pre-A5 repo-global behavior instead of
+// referencing a column that does not exist. Keeping the probe is what lets raw-connection callers
+// and partial-schema fixtures share these code paths without a separate unscoped variant.
+// ============================================================================================
+
+/// The periphery tables A5 scopes DIRECTLY by `repo_id` via an ADDITIVE `repo_id` column (no PK /
+/// UNIQUE change — [`add_column_if_missing`] suffices, idempotent + AUTOCOMMIT-safe). Adoption
+/// re-points their placeholder rows (see `registry::A5_PERIPHERY_DIRECT_SCOPED_TABLES`).
+const A5_ADDITIVE_SCOPED_TABLES: &[&str] = &[
+    // Per-repo generation counter (the generation integer stays globally unique — see the apply
+    // fn — so the transitive `clone_edges`/`clone_subblock_postings` need no `repo_id`).
+    "clone_graph_generations",
+    // Oracle run log; the read "key" (repo_id, tool, tool_version, commit_sha, worktree_id) is a
+    // query predicate, not a UNIQUE, so a plain column is enough.
+    "oracle_runs",
+    // Reconcile run log (no UNIQUE); the "latest attempt" read scopes by repo_id.
+    "reconcile_attempts",
+    // Memories + per-binding repo_id (spec §4.5 cross-repo bindings default to the parent memory's
+    // repo; the PK id TEXT / (memory_id, binding_kind, binding_id) are unchanged).
+    "repo_memories",
+    "repo_memory_bindings",
+];
+
+/// V042 (memory-sync phase A5, see the block comment above): add `repo_id`
+/// scoping to the clone / oracle / reconcile / memory PERIPHERY tables — every direct-scoped table
+/// left after A3's core sweep (per the plan's disposition table). Two shapes:
+///
+///  * ADDITIVE column ([`A5_ADDITIVE_SCOPED_TABLES`]): `clone_graph_generations`, `oracle_runs`,
+///    `reconcile_attempts`, `repo_memories`, `repo_memory_bindings` — no key change, so
+///    `add_column_if_missing` (self-guarding) is all that is needed.
+///  * KEY REBUILD (`repo_id` joins the PK / UNIQUE, so SQLite forces a table rebuild):
+///    `clone_token_df` (PK `(repo_id, normalizer_kind, token_hash)` — df must not pool across
+///    repos), `clone_refinements` (PK `(repo_id, class_key)` — content class-keys collide across
+///    repos), `edge_oracle` (content-key PK gains a leading `repo_id`), `logical_symbol_monikers`
+///    (PK `(repo_id, logical_symbol_id, tool)`), `dream_findings` (UNIQUE `(repo_id, kind, subject,
+///    claim_hash)`).
+///  * STANDALONE FTS rebuild: `repo_memory_fts` gains `repo_id UNINDEXED` and a mandatory filter —
+///    rebuilt from `repo_memories` (the same content `upsert_memory_fts` writes), so `repo_id`
+///    comes from each memory's freshly-added column.
+///
+/// `clone_edges` / `clone_subblock_postings` are NOT scoped directly (disposition: transitive via
+/// the generations FK). The generation integer stays GLOBALLY unique (allocated `MAX(generation) +
+/// 1` over ALL repos), so a `build_generation` value belongs to exactly one repo and those children
+/// are scoped for free; only the generation SWEEPS (`complete_generation`, the Building cleanup,
+/// the postings invalidation) must add a `repo_id` predicate so a repo's precompute never deletes a
+/// sibling's generations. `symbol_fingerprints` / `symbol_token_postings` stay `symbol_id`-keyed
+/// (transitive via `symbols -> files.repo_id`) — the "NEVER add scope columns here" rule in
+/// [`CLONE_FINGERPRINT_DDL`] is about the COMMIT/WORKTREE scope axis; `repo_id` is a different
+/// (cross-repo) axis and only `clone_token_df` / `clone_refinements` there take it.
+///
+/// MECHANICS (identical to V040): the key rebuilds RENAME/DROP tables, which needs FK enforcement
+/// OFF; a PRAGMA toggle is a no-op inside a transaction, so it is set BEFORE `BEGIN IMMEDIATE`. The
+/// whole migration runs under ONE atomic transaction (the ladder runs apply fns in AUTOCOMMIT, so a
+/// multi-statement rebuild must self-wrap), and `repo_memories.repo_id` existing is the
+/// all-or-nothing sentinel: because every statement commits together, that column is present iff
+/// the whole migration committed, so a re-apply (fresh DB already transformed, or an `index --full`
+/// re-run once this is registered) short-circuits before taking the write lock. Each rebuild starts
+/// `DROP TABLE IF EXISTS <scratch>_new` so a prior pass killed mid-rebuild (bypassing a clean
+/// rollback) re-converges from a clean slate rather than failing on `CREATE`.
+pub(crate) fn apply_repo_id_periphery_scoping(conn: &Connection) -> rusqlite::Result<()> {
+    // All-or-nothing sentinel (see the doc comment): everything below commits atomically, so
+    // `repo_memories.repo_id` present means the whole migration already ran.
+    if column_exists(conn, "repo_memories", "repo_id")? {
+        return Ok(());
+    }
+
+    conn.execute_batch("PRAGMA foreign_keys = OFF; BEGIN IMMEDIATE;")?;
+    let result = (|| -> rusqlite::Result<()> {
+        // --- Additive columns (no key change): idempotent, placeholder-backfilled. ---
+        for table in A5_ADDITIVE_SCOPED_TABLES {
+            add_column_if_missing(conn, table, "repo_id", REPO_ID_COLUMN_DEF)?;
+        }
+
+        // --- Key rebuilds (repo_id joins the PK / UNIQUE). ---
+        rebuild_clone_token_df_with_repo_id(conn)?;
+        rebuild_clone_refinements_with_repo_id(conn)?;
+        rebuild_edge_oracle_with_repo_id(conn)?;
+        rebuild_logical_symbol_monikers_with_repo_id(conn)?;
+        rebuild_dream_findings_with_repo_id(conn)?;
+
+        // --- Standalone FTS rebuild (repo_id UNINDEXED), rebuilt from `repo_memories`. ---
+        rebuild_repo_memory_fts_with_repo_id(conn)?;
+        // P1 (the V039/V040 class): the additive columns' static `DEFAULT '__unassigned__'`, the
+        // rebuilds' literal `'__unassigned__'` copy, and the FTS repopulated from those rows all
+        // stamp the placeholder — and on an ALREADY-ADOPTED DB `register_repo`'s fast path never
+        // re-points, so the scoped periphery reads (clones / oracle / memories) would miss this
+        // repo's rows. Resolve the sole `repos` row and re-point them onto it (no-op on an
+        // un-adopted DB, where the rows correctly wait for `register_repo`). Atomic with the
+        // sentinel-setting steps because it runs inside this same txn.
+        backfill_periphery_repo_id_to_sole_repo(conn)?;
+        // Finding ids now FOLD `repo_id` (`dream::repo_folded_finding_id` — the stable_id
+        // precedent), so re-derive every persisted id under its post-backfill `repo_id`. Runs
+        // AFTER the backfill so an adopted DB's ids fold the real repo, not the placeholder.
+        // `superseded_by` (the only persisted reference to a finding id, in-table) is remapped by
+        // the helper. Replay-safe: the sentinel short-circuits a re-apply, and the re-derivation
+        // is idempotent anyway.
+        crate::dream::rederive_finding_ids(conn)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = conn.execute_batch("ROLLBACK; PRAGMA foreign_keys = ON;");
+        return result;
+    }
+    conn.execute_batch("COMMIT; PRAGMA foreign_keys = ON;")?;
+    Ok(())
+}
+
+/// P1 backfill (the V040 [`backfill_repo_id_to_sole_repo`] pattern, periphery edition): re-point
+/// every V042 periphery row — the additive-column tables, the PK-rebuilt tables, AND the
+/// `repo_memory_fts` mirror — from the placeholder onto the sole `repos` id when the DB is ALREADY
+/// ADOPTED, so the scoped clone / oracle / memory reads see this repo's rows immediately after the
+/// upgrade. No-op on an un-adopted DB (`sole_repo_id` == the placeholder — the rows correctly wait
+/// for `register_repo`). Runs inside the V042 txn (FK OFF), so it is atomic with the sentinel. The
+/// sentinel short-circuit keeps a replay off this path entirely; the explicit `repos`-cardinality
+/// gate below additionally makes the FIRST apply safe on a CONSOLIDATED DB (leave-at-placeholder
+/// instead of `sole_repo_id`'s one-row hard error aborting the upgrade). The table set mirrors
+/// `A5_PERIPHERY_DIRECT_SCOPED_TABLES` (registry.rs), the same rows adoption re-points.
+fn backfill_periphery_repo_id_to_sole_repo(conn: &Connection) -> rusqlite::Result<()> {
+    // Cardinality gate (the V041 github-backfill twin): on `!= 1` repos rows there is no single
+    // owner to re-point onto, so the periphery rows stay under the placeholder rather than
+    // aborting the forward-migration. One nuance vs the github edition: placeholder-stranded
+    // `repo_memories` would be USER-AUTHORED data invisible to scoped reads, not a refetchable
+    // cache. That state is only reachable by hand-driving `register_repo` pre-consolidation
+    // (phase A refuses a second real repo; the real multi-repo entry path arrives with the
+    // consolidate importer, which attributes memories at import) — and `memory doctor` surfaces
+    // any placeholder-scoped memories (one `placeholder_repo` entry each, `doctor_report`) so
+    // they are visible, not silently lost. The clone / oracle / reconcile tables are derived
+    // caches the next rebuild / oracle run / reconcile re-populates under the proper stamp.
+    //
+    // No github-style RECLAIM is needed here (audited per table): unlike the V041 github tables,
+    // whose natural keys exclude `repo_id` and whose stranded rows therefore OCCUPY the key the
+    // next sync writes to (see the upsert-reclaim invariant in `github/store.rs`), every V042
+    // periphery key either LEADS with `repo_id` (clone_token_df, clone_refinements, edge_oracle,
+    // logical_symbol_monikers, dream_findings' UNIQUE), is an append-only autoincrement log
+    // (oracle_runs, reconcile_attempts), a fresh generated id (repo_memories + its bindings/fts,
+    // keyed by the repo-unique memory id), or a globally-unique counter (clone_graph_generations,
+    // allocated MAX(generation)+1 across ALL repos). New writes under the real repo can never
+    // conflict with a placeholder row — stranded rows merely LINGER invisibly until a later gc
+    // sweep reclaims the space (acceptable; nothing blocks repopulation).
+    let repos_rows: i64 = conn.query_row("SELECT COUNT(*) FROM repos", [], |row| row.get(0))?;
+    if repos_rows != 1 {
+        return Ok(());
+    }
+    let target = sole_repo_id(conn)?;
+    if target == super::LEGACY_REPO_ID {
+        return Ok(());
+    }
+    for table in [
+        "clone_graph_generations",
+        "clone_token_df",
+        "clone_refinements",
+        "oracle_runs",
+        "edge_oracle",
+        "logical_symbol_monikers",
+        "reconcile_attempts",
+        "dream_findings",
+        "repo_memories",
+        "repo_memory_bindings",
+        "repo_memory_fts",
+    ] {
+        conn.execute(&format!("UPDATE {table} SET repo_id = ?1 WHERE repo_id = ?2"), [
+            target.as_str(),
+            super::LEGACY_REPO_ID,
+        ])?;
+    }
+    Ok(())
+}
+
+/// Rebuild `clone_token_df` with a leading `repo_id` in the PK so document-frequency stats never
+/// pool across repos (a shared df corrupts the SourcererCC selectivity ordering for both repos).
+/// No FK children; STRICT preserved.
+fn rebuild_clone_token_df_with_repo_id(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS clone_token_df_new;
+        CREATE TABLE clone_token_df_new(
+            repo_id         TEXT    NOT NULL DEFAULT '__unassigned__',
+            normalizer_kind TEXT    NOT NULL,
+            token_hash      INTEGER NOT NULL,
+            df              INTEGER NOT NULL,
+            PRIMARY KEY (repo_id, normalizer_kind, token_hash)
+        ) STRICT;
+        INSERT OR IGNORE INTO clone_token_df_new(repo_id, normalizer_kind, token_hash, df)
+        SELECT '__unassigned__', normalizer_kind, token_hash, df FROM clone_token_df;
+        DROP TABLE clone_token_df;
+        ALTER TABLE clone_token_df_new RENAME TO clone_token_df;
+        ",
+    )
+}
+
+/// Rebuild `clone_refinements` with a leading `repo_id` in the PK — `class_key` is content-derived
+/// (normalized code shape), so two repos with the same clone shape would otherwise clobber each
+/// other's cached refinement. STRICT preserved; the full V030 column set (incl. `lcs_sampled`) is
+/// reproduced.
+fn rebuild_clone_refinements_with_repo_id(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS clone_refinements_new;
+        CREATE TABLE clone_refinements_new(
+            repo_id                 TEXT    NOT NULL DEFAULT '__unassigned__',
+            class_key               TEXT    NOT NULL,
+            language                TEXT    NOT NULL,
+            refine_mode             TEXT    NOT NULL,
+            template                TEXT    NOT NULL,
+            variation_points_json   TEXT    NOT NULL CHECK (json_valid(variation_points_json)),
+            proposed_signature_json TEXT    NOT NULL CHECK (json_valid(proposed_signature_json)),
+            confidence              TEXT    NOT NULL,
+            anti_unify_coverage     REAL    NOT NULL,
+            lcs_ratio               REAL    NOT NULL,
+            refactorability         REAL    NOT NULL,
+            norm_version            INTEGER NOT NULL,
+            alignment_version       INTEGER NOT NULL,
+            created_at_ms           INTEGER NOT NULL,
+            lcs_sampled             INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (repo_id, class_key)
+        ) STRICT;
+        INSERT OR IGNORE INTO clone_refinements_new(
+            repo_id, class_key, language, refine_mode, template, variation_points_json,
+            proposed_signature_json, confidence, anti_unify_coverage, lcs_ratio, refactorability,
+            norm_version, alignment_version, created_at_ms, lcs_sampled
+        )
+        SELECT
+            '__unassigned__', class_key, language, refine_mode, template, variation_points_json,
+            proposed_signature_json, confidence, anti_unify_coverage, lcs_ratio, refactorability,
+            norm_version, alignment_version, created_at_ms, lcs_sampled
+        FROM clone_refinements;
+        DROP TABLE clone_refinements;
+        ALTER TABLE clone_refinements_new RENAME TO clone_refinements;
+        ",
+    )
+}
+
+/// Rebuild `edge_oracle` with a leading `repo_id` in the content-key PK. It stays content-anchored
+/// with NO FK to `edges_data` (the #248 rule — the read join to live edges filters dangling rows),
+/// so prepending `repo_id` is a pure PK-widening rebuild; the three indexes are recreated. STRICT
+/// preserved. A cross-repo content-key collision (same source span in two repos) would otherwise
+/// surface one repo's verdict for the other; the scoped reads (store.rs) filter `repo_id`.
+fn rebuild_edge_oracle_with_repo_id(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS edge_oracle_new;
+        CREATE TABLE edge_oracle_new(
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__',
+            source_path TEXT NOT NULL,
+            source_start_byte INTEGER NOT NULL,
+            source_end_byte INTEGER NOT NULL,
+            callee_start_byte INTEGER NOT NULL,
+            callee_end_byte INTEGER NOT NULL,
+            edge_kind TEXT NOT NULL,
+            file_sha TEXT NOT NULL,
+            tool TEXT NOT NULL,
+            tool_version TEXT NOT NULL,
+            resolved_symbol_id INTEGER,
+            scip_symbol TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            computed_at INTEGER NOT NULL,
+            PRIMARY KEY(
+                repo_id, tool, tool_version, source_path,
+                source_start_byte, source_end_byte,
+                callee_start_byte, callee_end_byte, edge_kind
+            )
+        ) STRICT;
+        INSERT OR IGNORE INTO edge_oracle_new(
+            repo_id, source_path, source_start_byte, source_end_byte, callee_start_byte,
+            callee_end_byte, edge_kind, file_sha, tool, tool_version, resolved_symbol_id,
+            scip_symbol, kind, computed_at
+        )
+        SELECT
+            '__unassigned__', source_path, source_start_byte, source_end_byte, callee_start_byte,
+            callee_end_byte, edge_kind, file_sha, tool, tool_version, resolved_symbol_id,
+            scip_symbol, kind, computed_at
+        FROM edge_oracle;
+        DROP TABLE edge_oracle;
+        ALTER TABLE edge_oracle_new RENAME TO edge_oracle;
+        CREATE INDEX IF NOT EXISTS idx_edge_oracle_staleness
+            ON edge_oracle(file_sha, tool, tool_version);
+        CREATE INDEX IF NOT EXISTS idx_edge_oracle_symbol
+            ON edge_oracle(resolved_symbol_id);
+        CREATE INDEX IF NOT EXISTS idx_edge_oracle_anchor
+            ON edge_oracle(source_path, callee_start_byte, callee_end_byte, edge_kind);
+        ",
+    )
+}
+
+/// Rebuild `logical_symbol_monikers` with a leading `repo_id` in the PK. The id is content-derived
+/// (`LogicalSymbolKey::stable_id`) so it collides across repos; NO FK to `logical_symbols` (the #70
+/// rule — reads join live logical symbols). The moniker index is recreated. STRICT preserved.
+fn rebuild_logical_symbol_monikers_with_repo_id(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS logical_symbol_monikers_new;
+        CREATE TABLE logical_symbol_monikers_new(
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__',
+            logical_symbol_id INTEGER NOT NULL,
+            tool TEXT NOT NULL,
+            tool_version TEXT NOT NULL,
+            moniker TEXT NOT NULL,
+            computed_at INTEGER NOT NULL,
+            PRIMARY KEY(repo_id, logical_symbol_id, tool)
+        ) STRICT;
+        INSERT OR IGNORE INTO logical_symbol_monikers_new(
+            repo_id, logical_symbol_id, tool, tool_version, moniker, computed_at
+        )
+        SELECT '__unassigned__', logical_symbol_id, tool, tool_version, moniker, computed_at
+        FROM logical_symbol_monikers;
+        DROP TABLE logical_symbol_monikers;
+        ALTER TABLE logical_symbol_monikers_new RENAME TO logical_symbol_monikers;
+        CREATE INDEX IF NOT EXISTS idx_logical_symbol_monikers_moniker
+            ON logical_symbol_monikers(moniker, tool);
+        ",
+    )
+}
+
+/// Rebuild `dream_findings` with `repo_id` in the UNIQUE `(repo_id, kind, subject, claim_hash)` —
+/// the dream worklist's identity key is content-derived (subject + claim hash of a memory-anchored
+/// finding), so it must not merge two repos' findings. The `id TEXT PRIMARY KEY` is unchanged; both
+/// indexes are recreated. STRICT preserved.
+fn rebuild_dream_findings_with_repo_id(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS dream_findings_new;
+        CREATE TABLE dream_findings_new(
+            id TEXT PRIMARY KEY,
+            kind TEXT NOT NULL,
+            subject TEXT NOT NULL,
+            claim_hash TEXT NOT NULL,
+            evidence TEXT NOT NULL,
+            base_rank REAL NOT NULL,
+            status TEXT NOT NULL DEFAULT 'open',
+            superseded_by TEXT,
+            first_seen_at_ms INTEGER NOT NULL,
+            last_seen_at_ms INTEGER NOT NULL,
+            reviewed_at_ms INTEGER,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__',
+            UNIQUE(repo_id, kind, subject, claim_hash)
+        ) STRICT;
+        INSERT OR IGNORE INTO dream_findings_new(
+            id, kind, subject, claim_hash, evidence, base_rank, status, superseded_by,
+            first_seen_at_ms, last_seen_at_ms, reviewed_at_ms, repo_id
+        )
+        SELECT
+            id, kind, subject, claim_hash, evidence, base_rank, status, superseded_by,
+            first_seen_at_ms, last_seen_at_ms, reviewed_at_ms, '__unassigned__'
+        FROM dream_findings;
+        DROP TABLE dream_findings;
+        ALTER TABLE dream_findings_new RENAME TO dream_findings;
+        CREATE INDEX IF NOT EXISTS idx_dream_findings_status ON dream_findings(status);
+        CREATE INDEX IF NOT EXISTS idx_dream_findings_subject ON dream_findings(kind, subject);
+        ",
+    )
+}
+
+/// Rebuild the standalone `repo_memory_fts` with a leading `repo_id UNINDEXED` column and
+/// repopulate it from `repo_memories` (the same title/body/kind/tags content `upsert_memory_fts`
+/// writes, tags space-joined). Rebuilding from source — rather than copying the old FTS rows — lets
+/// `repo_id` come from each memory's freshly-added column and needs no FTS `RENAME` (which has
+/// historically been fragile on shadow tables); the DROP + CREATE keeps the canonical table name.
+/// `memory_search` then filters `repo_id` after the MATCH.
+fn rebuild_repo_memory_fts_with_repo_id(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS repo_memory_fts;
+        CREATE VIRTUAL TABLE repo_memory_fts USING fts5(
+            repo_id UNINDEXED,
+            memory_id UNINDEXED,
+            title,
+            body,
+            kind,
+            tags,
+            tokenize='porter'
+        );
+        INSERT INTO repo_memory_fts(repo_id, memory_id, title, body, kind, tags)
+        SELECT
+            m.repo_id, m.id, m.title, m.body, m.kind,
+            COALESCE(
+                (SELECT group_concat(t.tag, ' ')
+                 FROM repo_memory_tags t WHERE t.memory_id = m.id),
+                ''
+            )
+        FROM repo_memories m;
+        ",
+    )
 }
 
 /// V035: add `symbols.is_test` (cross-language test-code marker computed at parse time; see

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -3,15 +3,21 @@ mod migrations;
 mod registry;
 pub(crate) use baseline::*;
 pub(crate) use migrations::*;
+// `multiple_real_repos` lost its production callers when V042's real `repo_id` predicates
+// superseded the gc / clone-precompute seam guards (A5); it survives only as a
+// registry-internal check (`resolve_config_repo_id`) and a `multi_repo_scope` test assertion,
+// so the re-export is test-only now.
+#[cfg(test)]
+pub(crate) use registry::multiple_real_repos;
 pub(crate) use registry::{
-    CONNECTION_CONTEXT_REPO_KEY, active_repo_id, multiple_real_repos, resolve_config_repo_id,
-    sole_repo_id,
+    CONNECTION_CONTEXT_REPO_KEY, active_repo_id, periphery_repo_scope, periphery_repo_scope_clause,
+    resolve_config_repo_id, sole_repo_id,
 };
 pub use registry::{LEGACY_REPO_ID, register_repo};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 41;
+pub const LATEST_SCHEMA_VERSION: u32 = 42;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -268,6 +274,16 @@ const MIGRATION_041_DESCRIPTION: &str =
      issues, comments, pull_requests, reviews, review_comments, ref_sync) and rebuild github_fts \
      with a repo_id UNINDEXED column, so lexical and papertrail queries in a consolidated \
      database never surface a sibling repo's refs or issues (memory-sync phase A4)";
+const MIGRATION_042_ID: &str = "042_repo_id_periphery_scoping";
+const MIGRATION_042_CHECKSUM: &str = "sha256:rag-rat-repo-id-periphery-scoping-v42";
+const MIGRATION_042_DESCRIPTION: &str =
+    "Repo-scope the clone / oracle / reconcile / memory periphery: add repo_id to \
+     clone_graph_generations, oracle_runs, reconcile_attempts, repo_memories, \
+     repo_memory_bindings (additive) and rebuild clone_token_df, clone_refinements, edge_oracle, \
+     logical_symbol_monikers, dream_findings with repo_id in their PK / UNIQUE plus \
+     repo_memory_fts with a repo_id UNINDEXED column, so clone stats, oracle runs, and memory \
+     search in a consolidated database never pool or surface a sibling repo's rows (memory-sync \
+     phase A5)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -613,6 +629,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_041_CHECKSUM,
         description: MIGRATION_041_DESCRIPTION,
         apply: apply_github_repo_id_scoping,
+    },
+    Migration {
+        id: MIGRATION_042_ID,
+        checksum: MIGRATION_042_CHECKSUM,
+        description: MIGRATION_042_DESCRIPTION,
+        apply: apply_repo_id_periphery_scoping,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema/registry.rs
+++ b/crates/rag-rat-core/src/index/schema/registry.rs
@@ -38,6 +38,33 @@ const DIRECT_SCOPED_ADOPTION_TABLES: &[&str] = &[
     "github_fts",
 ];
 
+/// The periphery tables that gain a `repo_id` column in the phase-A5 periphery-scoping migration
+/// (V042, `apply_repo_id_periphery_scoping`) and therefore also need their [`LEGACY_REPO_ID`]
+/// placeholder rows re-pointed at the real id when [`register_repo`] adopts a legacy DB — the A5
+/// continuation of the A1/A3 adoption contract. `repo_memory_fts` is the standalone FTS mirror of
+/// `repo_memories` (its `repo_id` snapshots the parent's at rebuild time), re-pointed alongside.
+///
+/// COLUMN GUARD: several of these tables predate V042 — they exist at earlier schema versions
+/// WITHOUT a `repo_id` column, which V042 adds or rebuilds in. `register_repo` runs on every open,
+/// including against partial-schema bootstrap fixtures that stop before V042, so each re-point is
+/// guarded by `column_exists`: a no-op when the column is absent (a table present without its
+/// `repo_id` column), the real backfill once V042 has run (every normal open applies the full
+/// ladder). The `DIRECT_SCOPED_ADOPTION_TABLES` loop above guards on table-presence instead; a
+/// periphery table can exist without the column, so it needs the stronger column-level guard.
+const A5_PERIPHERY_DIRECT_SCOPED_TABLES: &[&str] = &[
+    "clone_graph_generations",
+    "clone_token_df",
+    "clone_refinements",
+    "oracle_runs",
+    "edge_oracle",
+    "logical_symbol_monikers",
+    "reconcile_attempts",
+    "dream_findings",
+    "repo_memories",
+    "repo_memory_bindings",
+    "repo_memory_fts",
+];
+
 /// The placeholder `repo_id` a freshly-migrated single-repo DB carries until it is adopted (see the
 /// V038 DDL) — and the backfill value every direct-scoped table gets when later migrations add
 /// `repo_id` columns (phase A3). A consolidated DB holding more than one repo NEVER carries this id
@@ -213,6 +240,29 @@ pub fn register_repo(
                 source_id
             ])?;
         }
+        // A5 periphery tables (clones/oracle/reconcile/memories). Their `repo_id` column lands in
+        // V042; several of these tables predate it, so a partial-schema bootstrap fixture that
+        // stops before V042 can have the table without the column. Guard each re-point with
+        // `column_exists` (no-op when the column is absent, real backfill once V042 has run — every
+        // normal open applies the full ladder) so this adoption never trips "no such column". Uses
+        // `source_id` (not the placeholder literal) so a shallow-clone upgrade re-points periphery
+        // rows off the `local:` incumbent too, exactly like the core/github loop above.
+        for table in A5_PERIPHERY_DIRECT_SCOPED_TABLES {
+            if super::column_exists(&tx, table, "repo_id")? {
+                tx.execute(
+                    &format!("UPDATE {table} SET repo_id = ?1 WHERE repo_id = ?2"),
+                    params![identity.repo_id, source_id],
+                )?;
+            }
+        }
+        // `dream_findings.id` folds `repo_id` (the `logical_symbols.stable_id` precedent), so the
+        // periphery re-point above changed the id every finding SHOULD have — re-derive them (and
+        // the in-table `superseded_by` references) under the adopted id: the dream twin of the
+        // `realign_logical_symbol_ids` call below. Guarded like the loop above (a partial-schema
+        // bootstrap fixture can lack the table or the V042 column); idempotent.
+        if super::column_exists(&tx, "dream_findings", "repo_id")? {
+            crate::dream::rederive_finding_ids(&tx)?;
+        }
         // Move the source id's recorded roots onto the new id BEFORE the source `repos` row is
         // deleted (its FK is `ON DELETE CASCADE`, so the roots would otherwise be dropped). A
         // shallow-clone upgrade carries the local id's roots; the placeholder never has any.
@@ -345,6 +395,46 @@ pub(crate) fn active_repo_id(conn: &Connection) -> rusqlite::Result<String> {
         return Ok(repo_id);
     }
     sole_repo_id(conn)
+}
+
+/// The active `repo_id` to scope a PERIPHERY table (clones / oracle / reconcile / memories) by, or
+/// `None` when that subsystem is not repo-scoped on this connection.
+///
+/// Those `repo_id` columns are added by the phase-A5 periphery-scoping migration (V042,
+/// `apply_repo_id_periphery_scoping`). A normal open applies the full ladder, so the column is
+/// present and this returns `Some(active_repo_id)` — the scoped path. The `None` branch is the
+/// defensive path for a connection that never ran the ladder (a raw connection, or the
+/// pre-migration schema in a forward-migration bootstrap fixture): a `repo_id` predicate would
+/// reference a column that does not exist, so the caller instead runs its original unscoped SQL —
+/// the pre-A5 repo-global behavior. Gating on the probe lets scoped and raw-connection callers
+/// share one code path without a separate unscoped variant.
+///
+/// `probe_table` is the subsystem's representative table (`repo_memories`,
+/// `clone_graph_generations`, `oracle_runs`, …). V042 adds `repo_id` to every table in a subsystem
+/// in the SAME migration, so one probe per subsystem is authoritative for the set.
+pub(crate) fn periphery_repo_scope(
+    conn: &Connection,
+    probe_table: &str,
+) -> rusqlite::Result<Option<String>> {
+    if super::column_exists(conn, probe_table, "repo_id")? {
+        Ok(Some(active_repo_id(conn)?))
+    } else {
+        Ok(None)
+    }
+}
+
+/// A ` AND <qualifier>.repo_id = '<escaped>'` SQL fragment for a periphery read, or `""` when
+/// `scope` is `None` (the periphery is not yet repo-scoped — see [`periphery_repo_scope`]). The id
+/// is embedded as an escaped string literal, NOT a bind parameter: these reads carry positional
+/// params and dynamic `IN (…)` placeholder lists where re-slotting a bound id is error-prone, and
+/// the id is a registry-validated content-derived value (never user free-text at query time) — the
+/// same posture `oracle::store::sql_quoted_list` takes for the commit/worktree `IN`-lists. Doubling
+/// any single quote keeps it a safe literal regardless.
+pub(crate) fn periphery_repo_scope_clause(scope: &Option<String>, qualifier: &str) -> String {
+    match scope {
+        Some(repo_id) => format!(" AND {qualifier}.repo_id = '{}'", repo_id.replace('\'', "''")),
+        None => String::new(),
+    }
 }
 
 /// Read the active repo id from the per-connection scope context, tolerating the common absence of

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
@@ -685,6 +685,9 @@ fn indexing_writes_baseline_fingerprints_for_functions() {
 /// persisted `clone_token_df` row-for-row.
 #[test]
 fn clone_token_df_recomputed_from_blobs_matches_postings_era() {
+    // Asserts the whole-DB `clone_token_df` contents; opt out of the poison harness whose sibling
+    // seeds a df row under its own repo_id.
+    let _poison = crate::index::poison_sibling::disable_poison_sibling();
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join("src")).unwrap();
@@ -1970,6 +1973,9 @@ fn refinement_key_is_content_addressed_and_distinct_from_read_key() {
 /// NOT grow the row count.
 #[test]
 fn refine_cache_is_read_through() {
+    // Asserts whole-DB `clone_refinements` counts (0 before the run, N after); opt out of the
+    // poison harness whose sibling seeds a refinement under its own repo_id.
+    let _poison = crate::index::poison_sibling::disable_poison_sibling();
     let root = unique_temp_root();
     let db = write_four_renamed_clones(&root);
 
@@ -2086,6 +2092,9 @@ fn find_clones_warm_cache_metrics_sampled_consistent() {
 /// the persisted-row count is the observable proof that only the top-N were refined.)
 #[test]
 fn unrefined_class_outside_top_n_keeps_plan2_shape() {
+    // Asserts a whole-DB `clone_refinements` count; opt out of the poison harness whose sibling
+    // seeds a refinement under its own repo_id.
+    let _poison = crate::index::poison_sibling::disable_poison_sibling();
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(root.join("src")).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
@@ -424,21 +424,24 @@ fn full_ladder_replay_on_a_two_repo_db_is_idempotent() {
     let _ = fs::remove_dir_all(fx.root_a);
 }
 
-/// #413 finding #5: `oracle_runs` has NO `repo_id` yet (V042 seam), so its GLOBAL prune must be
-/// SKIPPED on a consolidated multi-repo DB — else GC for repo A wipes repo B's run rows whenever
-/// B's context is absent from A's live sets.
+/// #413 finding #5 (now V042): `oracle_runs.repo_id` scopes the prune to the ACTIVE repo, so GC for
+/// repo A leaves repo B's run rows intact whenever B's context is absent from A's live sets — the
+/// per-repo predicate that superseded the old `multiple_real_repos` seam guard.
 #[test]
 fn gc_skips_the_global_oracle_prune_on_a_multi_repo_db() {
     let fx = two_repo_fixture();
-    // A dead-context oracle run: its commit/worktree are not in repo A's live sets.
+    // A dead-context oracle run belonging to the SIBLING repo B (its commit/worktree are not in
+    // repo A's live sets, and its `repo_id` is REPO_B). Repo A's gc runs a repo-scoped oracle prune
+    // (V042 `oracle_runs.repo_id` predicate, superseding the old `multiple_real_repos` guard), so
+    // it must spare repo B's run.
     fx.db
         .storage
         .connection()
         .execute(
             "INSERT INTO oracle_runs(tool, tool_version, commit_sha, worktree_id, started_at, \
-             status, stats_json)
-             VALUES ('rust-analyzer', 'v1', 'dead-commit', 'dead-wt', 0, 'Completed', '{}')",
-            [],
+             status, stats_json, repo_id)
+             VALUES ('rust-analyzer', 'v1', 'dead-commit', 'dead-wt', 0, 'Completed', '{}', ?1)",
+            [REPO_B],
         )
         .unwrap();
 
@@ -452,12 +455,13 @@ fn gc_skips_the_global_oracle_prune_on_a_multi_repo_db() {
             r.get(0)
         })
         .unwrap();
-    assert_eq!(surviving, 1, "the multi-repo guard spares sibling oracle runs");
+    assert_eq!(surviving, 1, "repo A's repo-scoped oracle prune spares repo B's run");
     let _ = fs::remove_dir_all(fx.root_a);
 }
 
-/// The complement: a single-repo DB has no sibling to protect, so the global oracle prune runs and
-/// drops the dead-context run — unchanged behavior.
+/// The complement: the ACTIVE repo's OWN dead-context run IS pruned. The dead run is stamped the
+/// active (adopted) repo id — exactly as `record_oracle_run` stamps it in production — so the V042
+/// repo-scoped prune (`oracle_runs.repo_id = active`) reaches it.
 #[test]
 fn gc_prunes_a_dead_oracle_run_on_a_single_repo_db() {
     let root = unique_temp_root();
@@ -471,13 +475,14 @@ fn gc_prunes_a_dead_oracle_run_on_a_single_repo_db() {
     run_git(&root, &["commit", "-q", "-m", "init"]);
     let config = source_config(root.clone(), Language::Rust);
     let db = IndexDatabase::rebuild(&config).unwrap();
+    let active = db.active_repo_id.clone();
     db.storage
         .connection()
         .execute(
             "INSERT INTO oracle_runs(tool, tool_version, commit_sha, worktree_id, started_at, \
-             status, stats_json)
-             VALUES ('rust-analyzer', 'v1', 'dead-commit', 'dead-wt', 0, 'Completed', '{}')",
-            [],
+             status, stats_json, repo_id)
+             VALUES ('rust-analyzer', 'v1', 'dead-commit', 'dead-wt', 0, 'Completed', '{}', ?1)",
+            [&active],
         )
         .unwrap();
 
@@ -848,6 +853,679 @@ fn papertrail_queries_never_surface_the_other_repo() {
     assert!(leaked_refs.is_empty(), "repo B github ref leaked: {leaked_refs:?}");
     let own_refs = crate::index::github::refs_for_path(conn, "src/a_only.rs", 10).unwrap();
     assert!(!own_refs.is_empty(), "repo A must still see its own github ref");
+
+    let _ = fs::remove_dir_all(fx.root_a);
+}
+
+// ================================================================================================
+// Phase A5 periphery scoping (clones / oracle / reconcile / memories).
+//
+// The A5 periphery-scoping migration is V042 (in the ladder), so a plain `schema::apply` scopes the
+// periphery — these tests reach the scoped schema through the ladder, then seed two repos and
+// switch the active repo through the scope-context row (the per-repo drive A7 will own). Every
+// periphery query gates its `repo_id` predicate on `schema::periphery_repo_scope`, so a raw
+// connection with no ladder applied runs unscoped (the pre-A5 behavior). The migration-shape
+// assertions (fresh-tip, deferred-absence / rebuild in isolation, forward path) live in
+// `repo_registry.rs`; these tests pin the cross-repo SCOPING BEHAVIOR of the query sweeps.
+// ================================================================================================
+
+use crate::query::memory::{
+    RepoMemoryBindTarget, RepoMemoryCreate, RepoMemoryCreateResult, create_memory, memory_search,
+};
+
+const A5_REPO_A: &str = "a5-repo-a";
+const A5_REPO_B: &str = "a5-repo-b";
+
+/// A raw connection at the periphery-scoped schema (`schema::apply` runs the ladder through V042),
+/// holding two real repos beside the `__unassigned__` placeholder V038 seeds.
+fn a5_scoped_two_repo_conn() -> rusqlite::Connection {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    schema::apply(&conn).unwrap();
+    for repo in [A5_REPO_A, A5_REPO_B] {
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, ?1, 0)",
+            [repo],
+        )
+        .unwrap();
+    }
+    conn
+}
+
+/// Point the connection's periphery scope at `repo_id` — the value `schema::active_repo_id` reads
+/// (what A7 drives per repo). Mirrors `install_scope_view`'s `temp.connection_context` write.
+fn a5_set_active_repo(conn: &rusqlite::Connection, repo_id: &str) {
+    conn.execute_batch(
+        "CREATE TEMP TABLE IF NOT EXISTS connection_context(key TEXT PRIMARY KEY, value TEXT);",
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT OR REPLACE INTO temp.connection_context(key, value) VALUES ('repo_id', ?1)",
+        [repo_id],
+    )
+    .unwrap();
+}
+
+/// Create a memory under the connection's active repo, bound to a commit (no `files` row needed).
+fn a5_create_memory(
+    conn: &rusqlite::Connection,
+    title: &str,
+    body: &str,
+    commit: &str,
+) -> RepoMemoryCreateResult {
+    create_memory(conn, RepoMemoryCreate {
+        kind: "Invariant".to_string(),
+        title: title.to_string(),
+        body: body.to_string(),
+        confidence: "high".to_string(),
+        created_by: None,
+        source: None,
+        tags: Vec::new(),
+        bind: RepoMemoryBindTarget { commit_hash: Some(commit.to_string()), ..Default::default() },
+    })
+    .unwrap()
+}
+
+fn a5_repo_memory_count(conn: &rusqlite::Connection, repo_id: &str) -> i64 {
+    conn.query_row("SELECT COUNT(*) FROM repo_memories WHERE repo_id = ?1", [repo_id], |r| r.get(0))
+        .unwrap()
+}
+
+/// An identically-titled memory created under each repo is a DISTINCT live memory, and
+/// `memory_search` from one repo's scope never surfaces the other's — the cross-repo memory-search
+/// leak guard (the FTS MATCH spans both repos, so the post-MATCH `repo_id` filter is what
+/// isolates).
+#[test]
+fn identical_titled_memories_live_in_both_repos_and_search_isolates() {
+    let conn = a5_scoped_two_repo_conn();
+
+    a5_set_active_repo(&conn, A5_REPO_A);
+    let a =
+        a5_create_memory(&conn, "shared reentrancy invariant", "repo A body about widgets", "ca");
+    assert!(!a.duplicate);
+
+    a5_set_active_repo(&conn, A5_REPO_B);
+    let b =
+        a5_create_memory(&conn, "shared reentrancy invariant", "repo B body about widgets", "cb");
+    assert!(!b.duplicate, "the same title under a DIFFERENT repo is not a duplicate");
+
+    assert_eq!(a5_repo_memory_count(&conn, A5_REPO_A), 1, "repo A holds exactly its memory");
+    assert_eq!(a5_repo_memory_count(&conn, A5_REPO_B), 1, "repo B holds exactly its memory");
+    assert_ne!(a.memory.memory_id, b.memory.memory_id, "the two are distinct memories");
+
+    a5_set_active_repo(&conn, A5_REPO_A);
+    let hits_a = memory_search(&conn, "reentrancy", 10).unwrap();
+    assert_eq!(hits_a.len(), 1, "repo A search returns exactly its own memory: {hits_a:?}");
+    assert_eq!(hits_a[0].memory_id, a.memory.memory_id);
+
+    a5_set_active_repo(&conn, A5_REPO_B);
+    let hits_b = memory_search(&conn, "reentrancy", 10).unwrap();
+    assert_eq!(hits_b.len(), 1, "repo B search returns exactly its own memory: {hits_b:?}");
+    assert_eq!(hits_b[0].memory_id, b.memory.memory_id);
+}
+
+/// Dedupe NEVER crosses repos: identical title+body+binding is a duplicate WITHIN a repo, but the
+/// same content under a sibling repo is a fresh memory.
+#[test]
+fn memory_dedupe_does_not_cross_repos() {
+    let conn = a5_scoped_two_repo_conn();
+
+    a5_set_active_repo(&conn, A5_REPO_A);
+    let first = a5_create_memory(&conn, "dedupe title", "dedupe body", "sha-shared");
+    assert!(!first.duplicate);
+    let again = a5_create_memory(&conn, "dedupe title", "dedupe body", "sha-shared");
+    assert!(again.duplicate, "same content in the SAME repo dedupes");
+    assert_eq!(again.memory.memory_id, first.memory.memory_id);
+    assert_eq!(a5_repo_memory_count(&conn, A5_REPO_A), 1);
+
+    a5_set_active_repo(&conn, A5_REPO_B);
+    let cross = a5_create_memory(&conn, "dedupe title", "dedupe body", "sha-shared");
+    assert!(!cross.duplicate, "identical content in a DIFFERENT repo is never a duplicate");
+    assert_ne!(cross.memory.memory_id, first.memory.memory_id);
+    assert_eq!(a5_repo_memory_count(&conn, A5_REPO_B), 1);
+}
+
+fn a5_seed_oracle_run(conn: &rusqlite::Connection, repo_id: &str, commit: &str, worktree: &str) {
+    conn.execute(
+        "INSERT INTO oracle_runs(
+             repo_id, tool, tool_version, commit_sha, worktree_id, started_at, status, stats_json)
+         VALUES (?1, 'scip', 'v1', ?2, ?3, 0, 'ok', '{}')",
+        rusqlite::params![repo_id, commit, worktree],
+    )
+    .unwrap();
+}
+
+fn a5_oracle_run_count(conn: &rusqlite::Connection, repo_id: &str) -> i64 {
+    conn.query_row("SELECT COUNT(*) FROM oracle_runs WHERE repo_id = ?1", [repo_id], |r| r.get(0))
+        .unwrap()
+}
+
+/// `prune_oracle_runs_outside_scope` is per-repo: gc of repo A prunes only repo A's dead runs and
+/// leaves every one of repo B's — even though repo B's `(commit, worktree)` is equally "not live"
+/// from repo A's live set (the pre-A5 unscoped sweep would have deleted it too).
+#[test]
+fn oracle_run_prune_is_per_repo() {
+    let conn = a5_scoped_two_repo_conn();
+    a5_seed_oracle_run(&conn, A5_REPO_A, "a-dead", "a-wt");
+    a5_seed_oracle_run(&conn, A5_REPO_B, "b-commit", "b-wt");
+
+    a5_set_active_repo(&conn, A5_REPO_A);
+    // Repo A's live set names neither run's (commit, worktree), so repo A's run is dead. The prune
+    // is scoped to repo A, so repo B's run (equally not-live here) is untouched.
+    let live_commits = vec!["a-live".to_string()];
+    let live_worktrees = vec!["a-live-wt".to_string()];
+    let deleted = crate::index::oracle::prune_oracle_runs_outside_scope(
+        &conn,
+        &live_commits,
+        &live_worktrees,
+    )
+    .unwrap();
+    assert_eq!(deleted, 1, "only repo A's dead run is pruned");
+    assert_eq!(a5_oracle_run_count(&conn, A5_REPO_A), 0, "repo A's dead run is gone");
+    assert_eq!(a5_oracle_run_count(&conn, A5_REPO_B), 1, "repo B's run survives repo A's prune");
+}
+
+/// A clone-graph precompute on repo A completes a fresh generation and GCs its OWN superseded
+/// generations, but leaves a sibling repo's generation row intact — the per-repo generation sweep
+/// (`complete_generation`'s scoped DELETE). The pre-A5 unscoped `DELETE WHERE generation != live`
+/// would have wiped repo B's row.
+#[test]
+fn clone_precompute_leaves_sibling_repo_generation_untouched() {
+    let mut fx = two_repo_fixture();
+    {
+        let conn = fx.db.storage.connection();
+        // V042 already ran at OPEN time (before `install_scope_view`), so the periphery is scoped
+        // here; `two_repo_fixture` left the connection on repo A's scope.
+        // Clean slate: drop whatever generation the rebuild may have left and clear repo A's live
+        // pointer so the precompute below is not skipped as already-current.
+        conn.execute_batch("DELETE FROM clone_graph_generations;").unwrap();
+        conn.execute(
+            "DELETE FROM repo_meta WHERE repo_id = ?1 AND key = 'clone_graph_live_generation'",
+            [fx.repo_a_id.as_str()],
+        )
+        .unwrap();
+        // Seed a COMPLETE generation owned by repo B (a high number, so repo A's MAX+1 is
+        // distinct).
+        conn.execute(
+            "INSERT INTO clone_graph_generations(
+                 generation, status, theta_floor, normalizer_kind, normalizer_version,
+                 source_revision, cursor_symbol_id, edges_written, postings_written, started_at_ms,
+                 finished_at_ms, repo_id)
+             VALUES (5000, 'Complete', 0.7, 'baseline', ?1, 'revB', 0, 0, 1, 0, 0, ?2)",
+            rusqlite::params![crate::index::clones::NORM_VERSION, REPO_B],
+        )
+        .unwrap();
+    }
+
+    // Re-install the scope view (dropped for the migration) so the precompute reads repo A's scoped
+    // symbols, and drive a REAL precompute on repo A (the active scope). It allocates gen 5001
+    // (global MAX+1), completes it, and runs `complete_generation`'s scoped DELETE.
+    fx.db.set_context(&fx.shared_commit, "").unwrap();
+    fx.db.precompute_clone_graph(None).unwrap();
+
+    let conn = fx.db.storage.connection();
+    let repo_b_gen: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM clone_graph_generations WHERE repo_id = ?1 AND generation = 5000",
+            [REPO_B],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(repo_b_gen, 1, "repo A's precompute must NOT delete repo B's generation");
+    let repo_a_complete: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM clone_graph_generations WHERE repo_id = ?1 AND status = \
+             'Complete'",
+            [fx.repo_a_id.as_str()],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(repo_a_complete >= 1, "repo A published its own fresh Complete generation");
+
+    let _ = fs::remove_dir_all(fx.root_a);
+}
+
+/// A5 finding 2: `refresh_clone_token_df` reads `symbol_fingerprints` scoped to the active repo
+/// (joining `symbols` → `files.repo_id`, since the table is content-addressed with no `repo_id`),
+/// so a consolidated DB's SIBLING repo's fingerprints never pool their token frequencies into THIS
+/// repo's df — which would inflate document frequencies and reorder SourcererCC candidate
+/// selection.
+#[test]
+fn clone_token_df_recompute_excludes_a_sibling_repos_fingerprints() {
+    // A sentinel token far outside any real `FNV-1a(token)` the fixture produces.
+    const SENTINEL_TOKEN: i64 = 9_900_000_333;
+    let fx = two_repo_fixture();
+    {
+        let conn = fx.db.storage.connection();
+        // Hang a symbol + a baseline fingerprint (carrying the sentinel token) off repo B's live
+        // file. An UNSCOPED df recompute would pool the sentinel into repo A's df.
+        let file_id: i64 = conn
+            .query_row(
+                "SELECT id FROM main.files WHERE repo_id = ?1 AND path = 'src/b_only.rs'",
+                [REPO_B],
+                |r| r.get(0),
+            )
+            .unwrap();
+        conn.execute(
+            "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, start_byte, \
+             end_byte, start_line, end_line, is_test)
+             VALUES (?1, 'rust', 'b_fn', NULL, 'function', 0, 0, 0, 0, 0)",
+            [file_id],
+        )
+        .unwrap();
+        let symbol_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO symbol_fingerprints(symbol_id, normalizer_kind, normalizer_version, \
+             oracle_run_id, struct_hash, token_len, token_bag, created_at_ms)
+             VALUES (?1, 'baseline', 1, NULL, 'bstruct', 1, ?2, 0)",
+            rusqlite::params![
+                symbol_id,
+                crate::index::clones::bag_blob::encode_token_bag(&[(SENTINEL_TOKEN, 1)])
+            ],
+        )
+        .unwrap();
+    }
+
+    // Recompute df scoped to repo A (as `two_repo_fixture` left the connection). The sibling's
+    // fingerprint must NOT pool in.
+    fx.db.refresh_clone_token_df().unwrap();
+    let conn = fx.db.storage.connection();
+    let leaked: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM clone_token_df WHERE token_hash = ?1 AND repo_id = ?2",
+            rusqlite::params![SENTINEL_TOKEN, fx.repo_a_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        leaked, 0,
+        "a sibling repo's fingerprint token leaked into the active repo's clone_token_df",
+    );
+
+    let _ = fs::remove_dir_all(fx.root_a);
+}
+
+/// A5 finding: `memory_by_id` is the guard for `memory_get` / `update_memory` / `mark_obsolete` /
+/// `rebind_memory`. Scoped to the active repo, so a caller holding a SIBLING repo's memory id can
+/// neither READ nor MUTATE it — the by-id lookup returns `None` (surfaced as "not found") and the
+/// sibling memory is left untouched.
+#[test]
+fn memory_by_id_read_and_mutations_refuse_a_sibling_repos_memory() {
+    use crate::query::memory::{
+        RepoMemoryUpdate, mark_obsolete, memory_by_id, rebind_memory, update_memory,
+    };
+    let conn = a5_scoped_two_repo_conn();
+
+    a5_set_active_repo(&conn, A5_REPO_A);
+    let a = a5_create_memory(&conn, "repo A only", "body a", "ca");
+
+    // Switch to repo B and try to reach repo A's memory by its id.
+    a5_set_active_repo(&conn, A5_REPO_B);
+    assert!(
+        memory_by_id(&conn, &a.memory.memory_id).unwrap().is_none(),
+        "memory_get must not read a sibling repo's memory by id",
+    );
+    assert!(
+        update_memory(&conn, RepoMemoryUpdate {
+            memory_id: a.memory.memory_id.clone(),
+            kind: None,
+            title: Some("hijacked".to_string()),
+            body: None,
+            confidence: None,
+            status: None,
+            tags: None,
+        })
+        .is_err(),
+        "update_memory must refuse a sibling repo's memory id",
+    );
+    assert!(
+        mark_obsolete(&conn, &a.memory.memory_id).is_err(),
+        "mark_obsolete must refuse a sibling repo's memory id",
+    );
+    assert!(
+        rebind_memory(&conn, &a.memory.memory_id, RepoMemoryBindTarget {
+            commit_hash: Some("cx".to_string()),
+            ..Default::default()
+        })
+        .is_err(),
+        "rebind_memory must refuse a sibling repo's memory id",
+    );
+
+    // Repo A's memory is untouched: back under repo A it is still active with its original title.
+    a5_set_active_repo(&conn, A5_REPO_A);
+    let still = memory_by_id(&conn, &a.memory.memory_id).unwrap().expect("repo A still owns it");
+    assert_eq!(still.status, "active");
+    assert_eq!(still.title, "repo A only", "a sibling-scoped update must not have landed");
+}
+
+/// A5 finding: `rebind_memory` deletes + re-inserts bindings; the re-inserted rows must inherit the
+/// PARENT memory's `repo_id` (not strand at the `__unassigned__` placeholder), or they drop out of
+/// the binding-scoped sweeps while the parent memory stays in its repo.
+#[test]
+fn rebind_keeps_bindings_on_the_parent_memorys_repo() {
+    use crate::query::memory::rebind_memory;
+    let conn = a5_scoped_two_repo_conn();
+    a5_set_active_repo(&conn, A5_REPO_A);
+    let a = a5_create_memory(&conn, "rebind me", "body", "c-old");
+
+    rebind_memory(&conn, &a.memory.memory_id, RepoMemoryBindTarget {
+        commit_hash: Some("c-new".to_string()),
+        ..Default::default()
+    })
+    .unwrap();
+
+    let stranded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM repo_memory_bindings WHERE memory_id = ?1 AND repo_id != ?2",
+            rusqlite::params![a.memory.memory_id, A5_REPO_A],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(stranded, 0, "every rebound binding must carry the parent memory's repo_id");
+    let owned: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM repo_memory_bindings WHERE memory_id = ?1 AND repo_id = ?2",
+            rusqlite::params![a.memory.memory_id, A5_REPO_A],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(owned >= 1, "the rebound commit binding is stamped under repo A");
+}
+
+/// A5 finding: `resolve_moniker` scans `logical_symbol_monikers` and joins `logical_symbols`. BOTH
+/// sides are scoped, so a SIBLING repo carrying the SAME SCIP moniker string cannot capture this
+/// repo's re-resolution — turning a unique match ambiguous, or relocating onto the sibling symbol.
+#[test]
+fn resolve_moniker_ignores_a_sibling_repos_moniker_row() {
+    use crate::query::memory::{MonikerResolution, resolve_moniker};
+    let conn = a5_scoped_two_repo_conn();
+
+    // The same moniker string "M" under the same tool in BOTH repos, each with a live logical
+    // symbol (`logical_symbol_id` is content-derived + repo-folded, so the two ids differ).
+    for (lsid, repo) in [(111_i64, A5_REPO_A), (222_i64, A5_REPO_B)] {
+        conn.execute(
+            "INSERT INTO logical_symbols(id, language, path, logical_name, qualified_name_id, \
+             kind, variant_count, group_reason, repo_id)
+             VALUES (?1, 'rust', 'src/x.rs', 'x', NULL, 'function', 1, 'g', ?2)",
+            rusqlite::params![lsid, repo],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO logical_symbol_monikers(logical_symbol_id, tool, tool_version, moniker, \
+             computed_at, repo_id)
+             VALUES (?1, 'scip-rust', 'v1', 'M', 0, ?2)",
+            rusqlite::params![lsid, repo],
+        )
+        .unwrap();
+    }
+
+    a5_set_active_repo(&conn, A5_REPO_A);
+    match resolve_moniker(&conn, "M", "scip-rust").unwrap() {
+        MonikerResolution::Unique { logical_symbol_id, .. } => assert_eq!(
+            logical_symbol_id, 111,
+            "moniker resolution must bind repo A's symbol, not the sibling's",
+        ),
+        other => panic!(
+            "expected a unique repo-A resolution, got {other:?} (a sibling leak reads as \
+             ambiguous)"
+        ),
+    }
+}
+
+/// A5 finding: `dream_run`'s lifecycle (lookup / supersede / resolve / list) is scoped, so a run in
+/// one repo never resolves or emits a SIBLING repo's worklist rows on a consolidated DB.
+#[test]
+fn dream_run_leaves_a_sibling_repos_findings_untouched() {
+    use crate::dream::{DreamOptions, dream_run};
+    let conn = a5_scoped_two_repo_conn();
+
+    // An OPEN finding owned by each repo.
+    for (id, subject, repo) in
+        [("a-open", "a::subject", A5_REPO_A), ("b-open", "b::subject", A5_REPO_B)]
+    {
+        conn.execute(
+            "INSERT INTO dream_findings(id, kind, subject, claim_hash, evidence, base_rank, \
+             status, first_seen_at_ms, last_seen_at_ms, repo_id)
+             VALUES (?1, 'coverage_gap', ?2, 'ch', 'ev', 1.0, 'open', 0, 0, ?3)",
+            rusqlite::params![id, subject, repo],
+        )
+        .unwrap();
+    }
+
+    // Run dream on repo A. Its (empty) index reports nothing this run, so the resolve pass resolves
+    // repo A's own unreported finding — but repo B's finding must be left OPEN and unemitted.
+    a5_set_active_repo(&conn, A5_REPO_A);
+    let report = dream_run(&conn, DreamOptions { limit: 50, now_ms: 1_000 }).unwrap();
+
+    let a_status: String = conn
+        .query_row("SELECT status FROM dream_findings WHERE id = 'a-open'", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(a_status, "resolved", "repo A's own unreported finding is resolved");
+    let b_status: String = conn
+        .query_row("SELECT status FROM dream_findings WHERE id = 'b-open'", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(b_status, "open", "repo A's dream run must NOT resolve repo B's finding");
+    assert!(
+        !report.findings.iter().any(|f| f.subject == "b::subject"),
+        "the emitted worklist must not include a sibling repo's finding",
+    );
+}
+
+/// A5 finding: the dream CANDIDATE BUILDERS are repo-scoped, not just the lifecycle. A sibling
+/// repo's path-bound memory at a path this repo also has must NOT suppress this repo's
+/// coverage-gap finding (a false negative via the unscoped `repo_memory_bindings` exclusion
+/// subquery), and a sibling repo's memory referencing a gone path must NOT surface as this repo's
+/// stale_reference finding.
+#[test]
+fn dream_candidate_builders_ignore_a_sibling_repos_memories() {
+    use crate::dream::{DreamOptions, dream_run};
+    let conn = a5_scoped_two_repo_conn();
+
+    // Repo A: a load-bearing symbol (one caller edge) in `src/shared.rs`, with NO memory of its
+    // own — the coverage-gap candidate.
+    conn.execute(
+        "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+         commit_sha, worktree_id, repo_id)
+         VALUES ('src/shared.rs', 'rust', 'source', 'asha', 0, 0, '', '', ?1)",
+        [A5_REPO_A],
+    )
+    .unwrap();
+    let file_id = conn.last_insert_rowid();
+    let mut symbol_ids = Vec::new();
+    for name in ["shared_fn", "caller_fn"] {
+        conn.execute(
+            "INSERT INTO symbols(file_id, language, name, qualified_name_id, kind, start_byte, \
+             end_byte, start_line, end_line, is_test)
+             VALUES (?1, 'rust', ?2, NULL, 'function', 0, 0, 0, 0, 0)",
+            rusqlite::params![file_id, name],
+        )
+        .unwrap();
+        symbol_ids.push(conn.last_insert_rowid());
+    }
+    conn.execute_batch(
+        "INSERT OR IGNORE INTO name_strings(value)
+             VALUES ('caller_fn'), ('shared_fn'), ('calls_name'), ('Exact');",
+    )
+    .unwrap();
+    let name_id = |value: &str| -> i64 {
+        conn.query_row("SELECT id FROM name_strings WHERE value = ?1", [value], |r| r.get(0))
+            .unwrap()
+    };
+    conn.execute(
+        "INSERT INTO edges_data(source_file_id, from_symbol_id, to_symbol_id, from_name_id, \
+         to_name_id, edge_kind_id, confidence_id, resolution_id)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7)",
+        rusqlite::params![
+            file_id,
+            symbol_ids[1],
+            symbol_ids[0],
+            name_id("caller_fn"),
+            name_id("shared_fn"),
+            name_id("calls_name"),
+            name_id("Exact"),
+        ],
+    )
+    .unwrap();
+
+    // Repo B: a memory whose PATH BINDING collides with repo A's file (the suppression vector) and
+    // whose body references a path that resolves nowhere (the stale_reference vector).
+    conn.execute(
+        "INSERT INTO repo_memories(id, kind, title, body, confidence, status, created_at_ms, \
+         updated_at_ms, source, memory_version, repo_id)
+         VALUES ('bmem', 'Invariant', 'b title', 'refs crates/ghost/src/vanished.rs', 'high', \
+         'active', 0, 0, 'agent', 'v1', ?1)",
+        [A5_REPO_B],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id, path, \
+         anchor_status, created_at_ms, repo_id)
+         VALUES ('bmem', 'path', 'b-bind', 'src/shared.rs', 'current', 0, ?1)",
+        [A5_REPO_B],
+    )
+    .unwrap();
+
+    a5_set_active_repo(&conn, A5_REPO_A);
+    let report = dream_run(&conn, DreamOptions { limit: 10, now_ms: 1_000 }).unwrap();
+
+    assert!(
+        report
+            .findings
+            .iter()
+            .any(|f| f.kind == "coverage_gap" && f.subject == "src/shared.rs::shared_fn"),
+        "a sibling repo's same-path memory binding must NOT suppress the active repo's \
+         coverage-gap finding: {:?}",
+        report.findings,
+    );
+    assert!(
+        !report.findings.iter().any(|f| f.kind == "stale_reference" && f.subject == "bmem"),
+        "a sibling repo's memory must NOT surface as the active repo's stale_reference: {:?}",
+        report.findings,
+    );
+}
+
+/// A5 finding: `memory_id` folds the owning repo into its hash suffix, so two repos creating
+/// IDENTICAL content in the SAME millisecond derive distinct ids (the repo-scoped dedupe correctly
+/// passes both — a repo-blind id would explode on the global PK). Pre-A5 (`None` scope) keeps the
+/// original derivation. Memory ids stay globally unique and coordination-free either way — folding
+/// the repo INTO the hash strengthens that (phase B replication relies on it).
+#[test]
+fn memory_ids_fold_the_repo_so_same_millisecond_identical_content_cannot_collide() {
+    use crate::query::memory::memory_id;
+    let input_hash = "0123456789abcdef0123456789abcdef";
+    let a = memory_id(1_000, input_hash, &Some(A5_REPO_A.to_string()));
+    let b = memory_id(1_000, input_hash, &Some(A5_REPO_B.to_string()));
+    assert_ne!(a, b, "same content + same millisecond under two repos derive DISTINCT ids");
+    assert!(a.starts_with("mem_3e8_") && b.starts_with("mem_3e8_"), "id shape unchanged: {a} {b}");
+    assert_eq!(
+        memory_id(1_000, input_hash, &None),
+        format!("mem_3e8_{}", &input_hash[..12]),
+        "the pre-A5 (unscoped) derivation is byte-identical to the original",
+    );
+}
+
+/// A5 finding: `reconcile_attempts` is a global append-only log; the `last_reconcile` status read
+/// must scope by `repo_id`, or a sibling repo's NEWER attempt is reported as this repo's status.
+#[test]
+fn reconcile_status_ignores_a_sibling_repos_attempt() {
+    let fx = two_repo_fixture();
+    {
+        let conn = fx.db.storage.connection();
+        // Repo A's attempt (older) + repo B's attempt (NEWER — wins an unscoped ORDER BY).
+        conn.execute(
+            "INSERT INTO reconcile_attempts(started_at_ms, status, batch_size, repo_id)
+             VALUES (100, 'Ok', 8, ?1)",
+            [fx.repo_a_id.as_str()],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO reconcile_attempts(started_at_ms, status, batch_size, repo_id)
+             VALUES (999, 'Blocked', 8, ?1)",
+            [REPO_B],
+        )
+        .unwrap();
+    }
+    let status =
+        fx.db.llm_status().unwrap().last_reconcile.expect("repo A has a reconcile attempt");
+    assert_eq!(status.status, "Ok", "the status must be repo A's, not repo B's newer attempt");
+    assert_eq!(status.started_at_ms, 100);
+    let _ = fs::remove_dir_all(fx.root_a);
+}
+
+/// A5 finding: the raw memory-summary readers (`repo_brief::memory_counts` /
+/// `memory_counts_by_path`, `orientation`'s `active_non_dir_memory_*`, `tree::dir_memory_titles`)
+/// bypass the scoped memory API. Scoped now, so a sibling repo's memory — even one whose path or
+/// dir collides with ours — never inflates this repo's brief or shows in its orientation / tree.
+#[test]
+fn memory_summary_readers_exclude_a_sibling_repos_memory() {
+    let fx = two_repo_fixture();
+    {
+        let conn = fx.db.storage.connection();
+        // Repo B's ACTIVE memory: a path binding at repo A's REAL file path (collision), plus a
+        // ROOT `dir` binding (so `tree`'s `root_memory_title` would leak it if unscoped).
+        conn.execute(
+            "INSERT INTO repo_memories(id, kind, title, body, confidence, status, created_at_ms, \
+             updated_at_ms, source, memory_version, repo_id)
+             VALUES ('bmem', 'Invariant', 'REPO B SECRET', 'b body', 'high', 'active', 0, 0, \
+             'agent', 'v1', ?1)",
+            [REPO_B],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id, path, \
+             anchor_status, created_at_ms, repo_id)
+             VALUES ('bmem', 'path', 'b-path', 'src/a_only.rs', 'current', 0, ?1)",
+            [REPO_B],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id, path, \
+             anchor_status, created_at_ms, repo_id)
+             VALUES ('bmem', 'dir', '', NULL, 'current', 0, ?1)",
+            [REPO_B],
+        )
+        .unwrap();
+    }
+    let conn = fx.db.storage.connection();
+
+    // (a) repo_brief: the summary + per-path memory counts exclude the sibling.
+    let brief = fx
+        .db
+        .repo_brief(crate::query::repo_brief::RepoBriefOptions {
+            mode: crate::query::repo_brief::RepoBriefMode::Spine,
+            limit: 50,
+            include_generated: true,
+            include_memories: true,
+        })
+        .unwrap();
+    assert_eq!(
+        brief.summary.repo_memories.active, 0,
+        "repo_brief summary counted a sibling repo's memory",
+    );
+    if let Some(candidate) = brief.candidates.iter().find(|c| c.path == "src/a_only.rs") {
+        assert_eq!(
+            candidate.metrics.memories.active, 0,
+            "per-path memory count leaked the sibling at the shared path src/a_only.rs",
+        );
+    }
+
+    // (b) tree: the root dir-memory title is not the sibling's.
+    let tree =
+        crate::query::tree::dir_tree(conn, &crate::query::tree::TreeOpts::default()).unwrap();
+    assert_ne!(
+        tree.root_memory_title.as_deref(),
+        Some("REPO B SECRET"),
+        "dir_memory_titles leaked a sibling repo's root dir memory",
+    );
+
+    // (c) orientation: the active non-dir memory titles do not include the sibling. (Runs last —
+    // it re-installs the scope view on the connection.)
+    let orient =
+        crate::query::orientation::orientation(conn, &fx.root_a, &fx.root_a, None).unwrap();
+    assert!(
+        !orient.active_memory_titles.iter().any(|t| t == "REPO B SECRET"),
+        "orientation leaked a sibling repo's active memory title",
+    );
 
     let _ = fs::remove_dir_all(fx.root_a);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -1248,11 +1248,14 @@ fn memory_stays_gone_when_two_files_define_the_same_name() {
     let db = IndexDatabase::rebuild(&config).unwrap();
     // Null out the symbol_id so the exact-id check misses, and corrupt binding_id to an
     // impossible qualified_name so the qualified_name lookup also misses — leaving only
-    // the bare-name+hash path, which must return None (>=2 candidates).
+    // the bare-name+hash path, which must return None (>=2 candidates). Scoped to the test's
+    // own SYMBOL binding: the poison sibling seeds two PATH bindings under one memory, and an
+    // unscoped rewrite would collapse their binding_ids into a PK collision.
     db.storage
         .connection()
         .execute(
-            "UPDATE repo_memory_bindings SET symbol_id = NULL, binding_id = 'src/gone.rs::target'",
+            "UPDATE repo_memory_bindings SET symbol_id = NULL, binding_id = 'src/gone.rs::target' \
+             WHERE binding_kind = 'symbol'",
             [],
         )
         .unwrap();
@@ -1849,6 +1852,40 @@ fn memory_doctor_lists_gone_and_suggests_candidates() {
     );
 
     let _ = fs::remove_dir_all(root);
+}
+
+/// A memory stranded under the `'__unassigned__'` placeholder on an ADOPTED DB — the V042
+/// consolidated-DB backfill's leave-at-placeholder path — is user-authored data invisible to
+/// every scoped memory read. The doctor must surface it as a `placeholder_repo` entry instead of
+/// letting it vanish silently. (Needs a REAL git fixture: on a placeholder-active DB the
+/// placeholder scope is the normal state and the doctor deliberately stays quiet about it.)
+#[test]
+fn memory_doctor_surfaces_placeholder_scoped_memories() {
+    let (_root, config) = super::poison_test_config("doctor_placeholder");
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    // Strand a memory under the placeholder, exactly as the V042 backfill leaves one on a
+    // consolidated DB.
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO repo_memories(
+                 id, kind, title, body, confidence, status, created_at_ms, updated_at_ms, source,
+                 memory_version, repo_id)
+             VALUES ('mem_placeholder', 'Invariant', 'stranded memory', 'body', 'high', 'active', \
+             0, 0, 'manual', 'v1', ?1)",
+            [crate::index::schema::LEGACY_REPO_ID],
+        )
+        .unwrap();
+
+    let entries = db.memory_doctor().unwrap();
+    let entry = entries
+        .iter()
+        .find(|e| e.memory_id == "mem_placeholder")
+        .expect("the placeholder-scoped memory must be surfaced by the doctor");
+    assert_eq!(entry.anchor_status, "placeholder_repo");
+    assert_eq!(entry.title, "stranded memory");
+    assert_eq!(entry.binding_kind, "repo");
+    assert!(entry.candidates.is_empty(), "no computable rebind candidates for a repo strand");
 }
 
 #[test]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -1833,14 +1833,18 @@ fn seed_pre_v041_github_schema(conn: &rusqlite::Connection) {
     schema::apply_repos_registry(conn).expect("V038 registry seeds the placeholder");
 }
 
-/// Fresh `apply` runs V041 (the schema tip): the seven GitHub tables and `github_fts` gain a direct
-/// `repo_id`. Owns the absolute `LATEST_SCHEMA_VERSION` pin.
+/// Fresh `apply` runs V041: the seven GitHub tables and `github_fts` gain a direct `repo_id`. (The
+/// absolute `LATEST_SCHEMA_VERSION` pin moved to `migration_042_*`, the new tip; this uses only the
+/// symbolic `current_version == LATEST` check.)
 #[test]
-fn migration_041_is_the_latest_tip_and_scopes_github() {
+fn migration_041_scopes_github() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 41, "V041 is the schema tip");
-    assert_eq!(schema::status(&conn).unwrap().current_version, 41, "schema at LATEST after apply");
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply"
+    );
 
     for table in [
         "github_refs",
@@ -2207,4 +2211,422 @@ fn migration_041_forward_migrates_a_v040_index() {
     assert_eq!(schema::status(&conn).unwrap().state, schema::SchemaState::Older);
     schema::migrate_forward(&conn).unwrap();
     assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
+}
+
+/// The eleven periphery tables A5 scopes — the direct-column set plus the standalone FTS mirror.
+const V042_PERIPHERY_TABLES: &[&str] = &[
+    "clone_graph_generations",
+    "clone_token_df",
+    "clone_refinements",
+    "oracle_runs",
+    "edge_oracle",
+    "logical_symbol_monikers",
+    "reconcile_attempts",
+    "dream_findings",
+    "repo_memories",
+    "repo_memory_bindings",
+    "repo_memory_fts",
+];
+
+/// Whether `table`'s PRIMARY KEY includes a `repo_id` column (the rebuilt-PK set).
+fn pk_includes_repo_id(conn: &rusqlite::Connection, table: &str) -> bool {
+    conn.query_row(
+        &format!(
+            "SELECT COUNT(*) FROM pragma_table_info('{table}') WHERE name = 'repo_id' AND pk > 0"
+        ),
+        [],
+        |r| r.get::<_, i64>(0),
+    )
+    .unwrap()
+        > 0
+}
+
+/// The pre-V042 shape of the clone / oracle / reconcile / memory periphery tables (NO `repo_id`),
+/// built by calling the real table-creating DDL fns in ISOLATION — so
+/// [`schema::apply_repo_id_periphery_scoping`] runs against its own genuine inputs (the directory's
+/// "assert deferred absence / rebuild behavior in isolation, not the full ladder" rule). Calling
+/// the real DDL fns (not hand-copied `CREATE TABLE`s) keeps the fixture drift-free as those tables
+/// evolve. The core / GitHub tables are deliberately NOT scoped here (V040 / V041 are not run):
+/// this fixture drives only V042, so [`register_repo`] adoption is exercised in the full-ladder
+/// test below, where every direct-scoped column exists.
+fn seed_pre_v042_periphery_schema(conn: &rusqlite::Connection) {
+    schema::apply_baseline(conn)
+        .expect("baseline: repo_memories/bindings/tags/fts + reconcile_attempts + core tables");
+    schema::apply_oracle_tables(conn).expect("oracle_runs + edge_oracle");
+    schema::apply_scip_moniker_anchors(conn).expect("logical_symbol_monikers");
+    schema::apply_clone_fingerprint_tables(conn).expect("clone_token_df + clone_refinements");
+    schema::apply_clone_graph_tables(conn).expect("clone_graph_generations");
+    schema::apply_dream_findings(conn).expect("dream_findings");
+    schema::apply_repos_registry(conn).expect("V038 registry seeds the placeholder");
+}
+
+/// Fresh `apply` runs V042 (the schema tip): every periphery table gains a direct `repo_id` and the
+/// content-keyed tables rebuild their PK to lead with it. Owns the absolute `LATEST_SCHEMA_VERSION`
+/// pin.
+#[test]
+fn migration_042_is_the_latest_tip_and_scopes_periphery() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 42, "V042 is the schema tip");
+    assert_eq!(schema::status(&conn).unwrap().current_version, 42, "schema at LATEST after apply");
+
+    for table in V042_PERIPHERY_TABLES {
+        assert!(
+            conn_table_columns(&conn, table).contains(&"repo_id".to_string()),
+            "{table} gains a direct repo_id column"
+        );
+    }
+    // The content-keyed tables lead their PK with repo_id (df must not pool; class-keys, moniker
+    // keys, and the edge-oracle content key collide across repos otherwise).
+    for table in ["clone_token_df", "clone_refinements", "edge_oracle", "logical_symbol_monikers"] {
+        assert!(pk_includes_repo_id(&conn, table), "{table} PK leads with repo_id");
+    }
+}
+
+/// V042's rebuilds are driven against the pre-V042 fixture IN ISOLATION: the periphery tables gain
+/// `repo_id`, a seeded memory's row survives into the rebuilt `repo_memory_fts` (backfilled to the
+/// placeholder and still MATCHing), a seeded `clone_token_df` row survives its PK rebuild, and the
+/// migration RE-CONVERGES from a torn intermediate (a leftover `clone_token_df_new` scratch from a
+/// crashed prior pass). Then a re-run short-circuits on the sentinel. This is the retained
+/// direct-fn isolation test (adoption is covered by the full-ladder test).
+#[test]
+fn migration_042_periphery_rebuild_preserves_rows_and_reconverges_from_torn_state() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    seed_pre_v042_periphery_schema(&conn);
+
+    // Deferred-absence in isolation: repo_id is absent on every periphery table before V042 runs.
+    for table in V042_PERIPHERY_TABLES {
+        assert!(
+            !conn_table_columns(&conn, table).contains(&"repo_id".to_string()),
+            "{table} must NOT carry repo_id before V042"
+        );
+    }
+
+    // A memory (the FTS rebuild's source) + a df row (a rebuilt-PK table) as a pre-V042 index
+    // holds.
+    conn.execute(
+        "INSERT INTO repo_memories(
+             id, kind, title, body, confidence, status, created_at_ms, updated_at_ms, source,
+             memory_version)
+         VALUES ('m1', 'Invariant', 'zebra invariant', 'zebra body', 'high', 'active', 0, 0, \
+         'manual', 'v1')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO clone_token_df(normalizer_kind, token_hash, df) VALUES ('baseline', 42, 7)",
+        [],
+    )
+    .unwrap();
+
+    // TORN STATE: a prior V042 pass crashed after creating a rebuild scratch table.
+    conn.execute_batch("CREATE TABLE clone_token_df_new(bogus INTEGER);").unwrap();
+
+    schema::apply_repo_id_periphery_scoping(&conn).expect("V042 converges from the torn state");
+
+    assert!(!conn_table_exists(&conn, "clone_token_df_new"), "scratch table swept");
+    for table in V042_PERIPHERY_TABLES {
+        assert!(
+            conn_table_columns(&conn, table).contains(&"repo_id".to_string()),
+            "{table} gained repo_id"
+        );
+    }
+    assert!(pk_includes_repo_id(&conn, "clone_token_df"), "clone_token_df PK leads with repo_id");
+
+    // The df row survived its PK rebuild, backfilled to the placeholder.
+    let (df, df_repo): (i64, String) = conn
+        .query_row("SELECT df, repo_id FROM clone_token_df WHERE token_hash = 42", [], |r| {
+            Ok((r.get(0)?, r.get(1)?))
+        })
+        .unwrap();
+    assert_eq!(df, 7, "df value preserved through the PK rebuild");
+    assert_eq!(df_repo, LEGACY_REPO_ID, "existing df rows backfill to the placeholder");
+
+    // The memory survived into the rebuilt FTS, backfilled to the placeholder and still MATCHing.
+    let (fts_repo, matched): (String, i64) = conn
+        .query_row(
+            "SELECT repo_id, (SELECT COUNT(*) FROM repo_memory_fts WHERE repo_memory_fts MATCH \
+             'zebra')
+             FROM repo_memory_fts WHERE repo_memory_fts MATCH 'zebra'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(fts_repo, LEGACY_REPO_ID, "the rebuilt FTS row carries the placeholder repo_id");
+    assert_eq!(matched, 1, "repo_memory_fts still MATCHes the seeded memory after the rebuild");
+
+    // Idempotent re-run (the repo_memories.repo_id sentinel short-circuits).
+    schema::apply_repo_id_periphery_scoping(&conn).expect("re-apply is a clean no-op");
+}
+
+/// P1 backfill (the V040 class): applying V042 on an ALREADY-ADOPTED DB (a real `repos` row, the
+/// placeholder gone) must re-point the existing periphery rows — an additive-column table, a
+/// PK-rebuilt table, AND the `repo_memory_fts` mirror — onto the real id via `sole_repo_id`, NOT
+/// strand them under the static `'__unassigned__'` default where the scoped periphery reads would
+/// never see them.
+#[test]
+fn migration_042_backfills_an_adopted_pre_v042_db_under_the_real_repo_id() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    seed_pre_v042_periphery_schema(&conn);
+    conn.execute(
+        "INSERT INTO repo_memories(
+             id, kind, title, body, confidence, status, created_at_ms, updated_at_ms, source,
+             memory_version)
+         VALUES ('m1', 'Invariant', 'zebra invariant', 'zebra body', 'high', 'active', 0, 0, \
+         'manual', 'v1')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO clone_token_df(normalizer_kind, token_hash, df) VALUES ('baseline', 42, 7)",
+        [],
+    )
+    .unwrap();
+    // Adopt as a pre-V042 binary's `register_repo` left it: a real `repos` row, placeholder gone.
+    conn.execute(
+        "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('repo-adopted', 'r', \
+         1)",
+        [],
+    )
+    .unwrap();
+    conn.execute("DELETE FROM repos WHERE repo_id = ?1", [LEGACY_REPO_ID]).unwrap();
+
+    schema::apply_repo_id_periphery_scoping(&conn).expect("V042 applies on an adopted DB");
+
+    let df_repo: String = conn
+        .query_row("SELECT repo_id FROM clone_token_df WHERE token_hash = 42", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(df_repo, "repo-adopted", "clone_token_df backfilled under the real repo id");
+    let mem_repo: String = conn
+        .query_row("SELECT repo_id FROM repo_memories WHERE id = 'm1'", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(mem_repo, "repo-adopted", "repo_memories backfilled under the real repo id");
+    let fts_repo: String = conn
+        .query_row(
+            "SELECT repo_id FROM repo_memory_fts WHERE repo_memory_fts MATCH 'zebra'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        fts_repo, "repo-adopted",
+        "repo_memory_fts mirror backfilled under the real repo id"
+    );
+    let stranded: i64 = conn
+        .query_row("SELECT COUNT(*) FROM repo_memories WHERE repo_id = ?1", [LEGACY_REPO_ID], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(stranded, 0, "no periphery row remains under the placeholder");
+}
+
+/// V042 on a CONSOLIDATED (multi-repo) V041-level DB — the V041 github-backfill twin: there is no
+/// single owner for the backfill to re-point onto, so the migration must SUCCEED (not abort on
+/// `sole_repo_id`'s one-row hard error) and leave the periphery rows under the placeholder,
+/// invisible to every scoped reader. Unlike the github cache, a placeholder-stranded
+/// `repo_memories` row is user-authored data — `memory doctor` surfaces it as a
+/// `placeholder_repo` entry rather than letting it vanish silently (covered by
+/// `memory_doctor_surfaces_placeholder_scoped_memories` in repo_memory.rs).
+#[test]
+fn migration_042_leaves_periphery_rows_at_the_placeholder_on_a_consolidated_db() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    seed_pre_v042_periphery_schema(&conn);
+    conn.execute(
+        "INSERT INTO repo_memories(
+             id, kind, title, body, confidence, status, created_at_ms, updated_at_ms, source,
+             memory_version)
+         VALUES ('m1', 'Invariant', 'zebra invariant', 'zebra body', 'high', 'active', 0, 0, \
+         'manual', 'v1')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO clone_token_df(normalizer_kind, token_hash, df) VALUES ('baseline', 42, 7)",
+        [],
+    )
+    .unwrap();
+    // The consolidated end-state: TWO real repos, placeholder row gone.
+    conn.execute(
+        "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('repo-a', 'a', 1), \
+         ('repo-b', 'b', 2)",
+        [],
+    )
+    .unwrap();
+    conn.execute("DELETE FROM repos WHERE repo_id = ?1", [LEGACY_REPO_ID]).unwrap();
+
+    schema::apply_repo_id_periphery_scoping(&conn)
+        .expect("V042 must not abort the upgrade on a consolidated DB");
+
+    for table in ["repo_memories", "clone_token_df", "repo_memory_fts"] {
+        let (total, under_placeholder): (i64, i64) = conn
+            .query_row(
+                &format!(
+                    "SELECT COUNT(*), COALESCE(SUM(repo_id = '{LEGACY_REPO_ID}'), 0) FROM {table}"
+                ),
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert!(total > 0, "{table}: the fixture seeded at least one row");
+        assert_eq!(
+            under_placeholder, total,
+            "{table}: every row stays under the placeholder — no arbitrary owner is picked"
+        );
+        // The shape every scoped periphery reader uses: placeholder rows are invisible to BOTH
+        // repos.
+        for repo in ["repo-a", "repo-b"] {
+            let visible: i64 = conn
+                .query_row(
+                    &format!("SELECT COUNT(*) FROM {table} WHERE repo_id = ?1"),
+                    [repo],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(visible, 0, "{table}: placeholder rows must be invisible to {repo}");
+        }
+    }
+}
+
+/// A V041 index forward-migrates to V042 on `migrate_forward` — reaching LATEST.
+#[test]
+fn migration_042_forward_migrates_a_v041_index() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    truncate_schema_to(&conn, 41);
+    assert_eq!(schema::status(&conn).unwrap().state, schema::SchemaState::Older);
+    schema::migrate_forward(&conn).unwrap();
+    assert_eq!(schema::status(&conn).unwrap().current_version, schema::LATEST_SCHEMA_VERSION);
+}
+
+/// Cross-workstream: a legacy single-repo index carrying BOTH A4's GitHub papertrail rows and A5's
+/// clone / oracle / memory rows migrates through the WHOLE A-phase ladder (rolled back to the
+/// pre-A-phase V037 tip, then `migrate_forward` re-runs V038..V042 idempotently) with every row
+/// intact and repo-scoped to the placeholder — then ONE `register_repo` adoption re-points both
+/// workstreams' rows to the real id at once. Pins that the two parallel scoping workstreams
+/// compose: the ledger advances 37 -> 42 (so both the V041 and V042 `known_version` arms are
+/// load-bearing) and adoption spans both tables sets.
+#[test]
+fn full_ladder_v037_to_v042_scopes_both_workstreams_data() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    schema::apply(&conn).unwrap();
+
+    // Seed A4 (GitHub) + A5 (memory / oracle / clone) rows under the LEGACY placeholder — the shape
+    // a legacy single-repo index carries before adoption.
+    conn.execute(
+        "INSERT INTO github_issues(
+             owner, repo, number, html_url, state, title, body, \
+         is_pull_request, synced_at_ms,
+             repo_id)
+         VALUES ('o', 'r', 7, 'http://i', \
+         'open', 'zebra title', 'zebra body', 0, 0, ?1)",
+        [LEGACY_REPO_ID],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO github_fts(
+             owner, repo, number, item_kind, item_id, url, title, body, \
+         classification, repo_id)
+         VALUES ('o', 'r', 7, 'issue', '1', 'http://i', 'zebra title', 'zebra body', 'other', ?1)",
+        [LEGACY_REPO_ID],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO repo_memories(
+             id, kind, title, body, confidence, status, created_at_ms, updated_at_ms, source,
+             memory_version, repo_id)
+         VALUES ('m1', 'Invariant', 'llama invariant', 'body', 'high', 'active', 0, 0, 'manual', \
+         'v1', ?1)",
+        [LEGACY_REPO_ID],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO oracle_runs(
+             repo_id, tool, tool_version, commit_sha, worktree_id, started_at, status, stats_json)
+         VALUES (?1, 'scip', 'v1', 'c', '', 0, 'ok', '{}')",
+        [LEGACY_REPO_ID],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO clone_graph_generations(
+             generation, status, theta_floor, normalizer_kind, normalizer_version, source_revision,
+             cursor_symbol_id, edges_written, postings_written, started_at_ms, finished_at_ms,
+             repo_id)
+         VALUES (1, 'Complete', 0.7, 'baseline', ?1, 'rev', 0, 0, 1, 0, 0, ?2)",
+        rusqlite::params![crate::index::clones::NORM_VERSION, LEGACY_REPO_ID],
+    )
+    .unwrap();
+
+    // Roll the ledger back to the pre-A-phase tip and forward-migrate the WHOLE A-phase ladder.
+    truncate_schema_to(&conn, 37);
+    assert_eq!(schema::status(&conn).unwrap().state, schema::SchemaState::Older);
+    schema::migrate_forward(&conn).unwrap();
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        42,
+        "the A-phase ladder reached V042"
+    );
+
+    // Every seeded row survived the ladder, still under the placeholder (scoped to the legacy id).
+    let placeholder_count = |sql: &str| -> i64 { conn.query_row(sql, [], |r| r.get(0)).unwrap() };
+    assert_eq!(
+        placeholder_count(&format!(
+            "SELECT COUNT(*) FROM github_issues WHERE repo_id = '{LEGACY_REPO_ID}'"
+        )),
+        1,
+        "A4's github issue survived under the placeholder"
+    );
+    assert_eq!(
+        placeholder_count(
+            "SELECT COUNT(*) FROM github_fts WHERE github_fts MATCH 'zebra' AND repo_id = \
+             '__unassigned__'"
+        ),
+        1,
+        "A4's github_fts row still MATCHes under the placeholder"
+    );
+    for (table, id_pred) in [
+        ("repo_memories", "id = 'm1'"),
+        ("oracle_runs", "tool = 'scip'"),
+        ("clone_graph_generations", "generation = 1"),
+    ] {
+        assert_eq!(
+            placeholder_count(&format!(
+                "SELECT COUNT(*) FROM {table} WHERE {id_pred} AND repo_id = '{LEGACY_REPO_ID}'"
+            )),
+            1,
+            "A5's {table} row survived under the placeholder"
+        );
+    }
+
+    // ONE adoption re-points BOTH workstreams' rows onto the real id.
+    register_repo(&conn, &identity("repo-real", "r"), std::path::Path::new("/src/r"), 1).unwrap();
+    let real_repo = |sql: &str| -> String { conn.query_row(sql, [], |r| r.get(0)).unwrap() };
+    assert_eq!(
+        real_repo("SELECT repo_id FROM github_issues WHERE number = 7"),
+        "repo-real",
+        "adoption re-points A4's github_issues"
+    );
+    assert_eq!(
+        real_repo("SELECT repo_id FROM github_fts WHERE github_fts MATCH 'zebra'"),
+        "repo-real",
+        "adoption re-points A4's github_fts mirror"
+    );
+    assert_eq!(
+        real_repo("SELECT repo_id FROM repo_memories WHERE id = 'm1'"),
+        "repo-real",
+        "adoption re-points A5's memory"
+    );
+    assert_eq!(
+        real_repo("SELECT repo_id FROM oracle_runs WHERE tool = 'scip'"),
+        "repo-real",
+        "adoption re-points A5's oracle run"
+    );
+    assert_eq!(
+        real_repo("SELECT repo_id FROM clone_graph_generations WHERE generation = 1"),
+        "repo-real",
+        "adoption re-points A5's clone generation"
+    );
 }

--- a/crates/rag-rat-core/src/query/memory/api.rs
+++ b/crates/rag-rat-core/src/query/memory/api.rs
@@ -26,7 +26,12 @@ pub(crate) fn create_memory(
     }
 
     let now = now_ms();
-    let id = memory_id(now, &input_hash);
+    // The active-repo scope is folded into the id derivation (post-A5): without it, two repos
+    // creating IDENTICAL content in the same millisecond derive the same id — the repo-scoped
+    // dedupe above correctly passes, and the INSERT explodes on the global PK. The same resolved
+    // scope drives the repo stamp below.
+    let scope = memory_repo_scope(conn)?;
+    let id = memory_id(now, &input_hash, &scope);
     conn.execute(
         "
         INSERT INTO repo_memories(
@@ -52,6 +57,16 @@ pub(crate) fn create_memory(
     // A symbol-bound memory whose logical symbol has a known SCIP moniker gets the moniker anchor
     // automatically (#70) — the relocation fallback the hash anchors can't provide.
     insert_auto_moniker_binding(conn, &id, &binding, now)?;
+    // Stamp the active repo on the new memory, then stamp its bindings FROM the (now-stamped)
+    // parent memory (spec §4.5: a binding defaults to its memory's repo). Gated on the
+    // periphery scope — a no-op on the pre-A5 schema (no `repo_id` column). MUST run before
+    // `upsert_memory_fts`, which mirrors `repo_memories.repo_id` into the FTS row.
+    // `repo_memory_tags` / `repo_memory_call_paths` are transitive (scoped via the
+    // `repo_memories` FK), so they are not stamped here.
+    if let Some(repo_id) = &scope {
+        conn.execute("UPDATE repo_memories SET repo_id = ?1 WHERE id = ?2", params![repo_id, id])?;
+    }
+    stamp_bindings_from_parent_repo(conn, &id)?;
     replace_tags(conn, &id, &request.tags)?;
     upsert_memory_fts(conn, &id)?;
     let memory = memory_by_id(conn, &id)?
@@ -124,9 +139,20 @@ pub(crate) fn memory_by_id(
     conn: &Connection,
     memory_id: &str,
 ) -> anyhow::Result<Option<RepoMemory>> {
+    // Scoped to the active repo (V042): this by-id read guards `memory_get` / `update_memory` /
+    // `mark_obsolete` / `rebind_memory`, so an unscoped lookup would let any caller holding a
+    // SIBLING repo's memory id read OR mutate that sibling on a consolidated DB (the mutation
+    // guards all key on the row this returns). A sibling id resolves to `None` here — "not
+    // found" — which the mutation callers surface as a refusal. The upstream list/search
+    // readers already scope, so adding the predicate is a no-op there. Phase E's explicit
+    // cross-repo READ surfaces arrive with their own APIs; mutation stays repo-bound.
+    // `{repo_clause}` empty pre-A5.
+    let scope = memory_repo_scope(conn)?;
+    let repo_clause = memory_repo_scope_clause(&scope);
     let Some(mut memory) = conn
         .query_row(
-            "
+            &format!(
+                "
             SELECT id AS memory_id,
                    kind AS kind,
                    title AS title,
@@ -141,8 +167,9 @@ pub(crate) fn memory_by_id(
                    input_hash AS input_hash,
                    memory_version AS memory_version
             FROM repo_memories
-            WHERE id = ?1
-            ",
+            WHERE id = ?1{repo_clause}
+            "
+            ),
             [memory_id],
             memory_row,
         )
@@ -158,22 +185,24 @@ pub(crate) fn memories_for_chunk(
     chunk_id: i64,
     limit: u32,
 ) -> anyhow::Result<Vec<RepoMemory>> {
-    let mut stmt = conn.prepare(
+    let scope = memory_repo_scope(conn)?;
+    let repo_clause = memory_repo_scope_clause(&scope);
+    let mut stmt = conn.prepare(&format!(
         "
         SELECT DISTINCT repo_memories.id AS memory_id
         FROM repo_memories
         JOIN repo_memory_bindings ON repo_memory_bindings.memory_id = repo_memories.id
         LEFT JOIN chunks ON chunks.id = ?1
         LEFT JOIN files ON files.id = chunks.file_id
-        WHERE repo_memories.status IN ('active', 'stale')
+        WHERE repo_memories.status IN ('active', 'stale'){repo_clause}
           AND (
               repo_memory_bindings.chunk_id = ?1
               OR (files.path IS NOT NULL AND repo_memory_bindings.path = files.path)
           )
         ORDER BY repo_memories.updated_at_ms DESC
         LIMIT ?2
-        ",
-    )?;
+        "
+    ))?;
     ids_to_memories(
         conn,
         stmt.query_map(params![chunk_id, i64::from(limit)], |row| {
@@ -186,17 +215,19 @@ pub(crate) fn memories_for_path(
     path: &str,
     limit: u32,
 ) -> anyhow::Result<Vec<RepoMemory>> {
-    let mut stmt = conn.prepare(
+    let scope = memory_repo_scope(conn)?;
+    let repo_clause = memory_repo_scope_clause(&scope);
+    let mut stmt = conn.prepare(&format!(
         "
         SELECT DISTINCT repo_memories.id AS memory_id
         FROM repo_memories
         JOIN repo_memory_bindings ON repo_memory_bindings.memory_id = repo_memories.id
-        WHERE repo_memories.status IN ('active', 'stale')
+        WHERE repo_memories.status IN ('active', 'stale'){repo_clause}
           AND repo_memory_bindings.path = ?1
         ORDER BY repo_memories.updated_at_ms DESC
         LIMIT ?2
-        ",
-    )?;
+        "
+    ))?;
     ids_to_memories(
         conn,
         stmt.query_map(params![path, i64::from(limit)], |row| row.get("memory_id"))?,
@@ -209,12 +240,14 @@ pub(crate) fn memories_for_symbol(
 ) -> anyhow::Result<Vec<RepoMemory>> {
     let chunk_ids = chunk_ids_for_symbol(conn, symbol)?;
     let mut candidate_ids = BTreeSet::new();
-    let mut stmt = conn.prepare(
+    let scope = memory_repo_scope(conn)?;
+    let repo_clause = memory_repo_scope_clause(&scope);
+    let mut stmt = conn.prepare(&format!(
         "
         SELECT DISTINCT repo_memories.id AS memory_id
         FROM repo_memories
         JOIN repo_memory_bindings ON repo_memory_bindings.memory_id = repo_memories.id
-        WHERE repo_memories.status IN ('active', 'stale')
+        WHERE repo_memories.status IN ('active', 'stale'){repo_clause}
           AND (
               repo_memory_bindings.logical_symbol_id = ?1
               OR repo_memory_bindings.symbol_id = ?2
@@ -226,8 +259,8 @@ pub(crate) fn memories_for_symbol(
           )
         ORDER BY repo_memories.updated_at_ms DESC
         LIMIT ?5
-        ",
-    )?;
+        "
+    ))?;
     let rows = stmt.query_map(
         params![
             symbol.logical_symbol_id,
@@ -248,7 +281,7 @@ pub(crate) fn memories_for_symbol(
             SELECT DISTINCT repo_memories.id AS memory_id
             FROM repo_memories
             JOIN repo_memory_bindings ON repo_memory_bindings.memory_id = repo_memories.id
-            WHERE repo_memories.status IN ('active', 'stale')
+            WHERE repo_memories.status IN ('active', 'stale'){repo_clause}
               AND repo_memory_bindings.chunk_id IN ({placeholders})
             ORDER BY repo_memories.updated_at_ms DESC
             LIMIT ?
@@ -354,12 +387,14 @@ pub(crate) fn call_path_memories_for_crossed(
     }
 
     let placeholders = std::iter::repeat_n("?", hashes.len()).collect::<Vec<_>>().join(",");
+    let scope = memory_repo_scope(conn)?;
+    let repo_clause = memory_repo_scope_clause(&scope);
     let sql = format!(
         "
         SELECT DISTINCT repo_memories.id AS memory_id
         FROM repo_memories
         JOIN repo_memory_call_paths ON repo_memory_call_paths.memory_id = repo_memories.id
-        WHERE repo_memories.status IN ('active', 'stale')
+        WHERE repo_memories.status IN ('active', 'stale'){repo_clause}
           AND repo_memory_call_paths.edge_sequence_hash IN ({placeholders})
         ORDER BY repo_memories.updated_at_ms DESC
         LIMIT ?
@@ -387,12 +422,14 @@ pub(crate) fn memories_for_edges(
     unique_edge_ids.dedup();
     let placeholders =
         std::iter::repeat_n("?", unique_edge_ids.len()).collect::<Vec<_>>().join(",");
+    let scope = memory_repo_scope(conn)?;
+    let repo_clause = memory_repo_scope_clause(&scope);
     let sql = format!(
         "
         SELECT DISTINCT repo_memories.id AS memory_id
         FROM repo_memories
         JOIN repo_memory_bindings ON repo_memory_bindings.memory_id = repo_memories.id
-        WHERE repo_memories.status IN ('active', 'stale')
+        WHERE repo_memories.status IN ('active', 'stale'){repo_clause}
           AND repo_memory_bindings.edge_id IN ({placeholders})
         ORDER BY repo_memories.updated_at_ms DESC
         LIMIT ?
@@ -412,17 +449,19 @@ pub(crate) fn memories_for_call_path_hash(
     edge_sequence_hash: &str,
     limit: u32,
 ) -> anyhow::Result<Vec<RepoMemory>> {
-    let mut stmt = conn.prepare(
+    let scope = memory_repo_scope(conn)?;
+    let repo_clause = memory_repo_scope_clause(&scope);
+    let mut stmt = conn.prepare(&format!(
         "
         SELECT DISTINCT repo_memories.id AS memory_id
         FROM repo_memories
         JOIN repo_memory_call_paths ON repo_memory_call_paths.memory_id = repo_memories.id
-        WHERE repo_memories.status IN ('active', 'stale')
+        WHERE repo_memories.status IN ('active', 'stale'){repo_clause}
           AND repo_memory_call_paths.edge_sequence_hash = ?1
         ORDER BY repo_memories.updated_at_ms DESC
         LIMIT ?2
-        ",
-    )?;
+        "
+    ))?;
     ids_to_memories(
         conn,
         stmt.query_map(params![edge_sequence_hash, i64::from(limit)], |row| row.get("memory_id"))?,
@@ -437,17 +476,23 @@ pub(crate) fn memory_search(
     if query.is_empty() {
         return Ok(Vec::new());
     }
-    let mut stmt = conn.prepare(
+    // Isolation: the FTS MATCH spans every repo, so the join to `repo_memories` filters to the
+    // active repo. `{repo_clause}` is empty pre-A5 (memory still repo-global). This is the
+    // cross-repo memory search leak guard — an identical-titled memory in a sibling repo must
+    // never surface here.
+    let scope = memory_repo_scope(conn)?;
+    let repo_clause = memory_repo_scope_clause(&scope);
+    let mut stmt = conn.prepare(&format!(
         "
         SELECT DISTINCT repo_memory_fts.memory_id
         FROM repo_memory_fts
         JOIN repo_memories ON repo_memories.id = repo_memory_fts.memory_id
         WHERE repo_memory_fts MATCH ?1
-          AND repo_memories.status IN ('active', 'stale')
+          AND repo_memories.status IN ('active', 'stale'){repo_clause}
         ORDER BY bm25(repo_memory_fts)
         LIMIT ?2
-        ",
-    )?;
+        "
+    ))?;
     ids_to_memories(
         conn,
         stmt.query_map(params![query, i64::from(limit)], |row| row.get("memory_id"))?,
@@ -471,6 +516,10 @@ pub(crate) fn rebind_memory(
     let now = now_ms();
     insert_binding(conn, memory_id, &binding, now)?;
     insert_auto_moniker_binding(conn, memory_id, &binding, now)?;
+    // Re-stamp the freshly re-inserted bindings from the parent memory's repo (the create path does
+    // this too). Without it the rebound rows keep the `__unassigned__` default and fall out of the
+    // binding-scoped reads while the parent memory stays in its real repo — the review finding.
+    stamp_bindings_from_parent_repo(conn, memory_id)?;
     conn.execute(
         "UPDATE repo_memories SET source_text_hash = ?2, updated_at_ms = ?3 WHERE id = ?1",
         params![memory_id, binding.source_text_hash, now],
@@ -506,14 +555,16 @@ pub(crate) fn list_memories(
     // Use a subquery to pick the first binding per memory (stable tie-break).
     // The outer WHERE on m.status restricts to non-obsolete memories, matching
     // the memory_search / memories_for_* convention.
+    let scope = memory_repo_scope(conn)?;
+    let repo_clause = crate::index::schema::periphery_repo_scope_clause(&scope, "m");
     let rows: Vec<MemorySummary> = if let Some(binding_kind) = kind {
-        let mut stmt = conn.prepare(
+        let mut stmt = conn.prepare(&format!(
             "
             SELECT m.id AS memory_id, m.kind, m.title, m.status,
                    b.binding_kind, b.binding_id
             FROM repo_memories AS m
             JOIN repo_memory_bindings AS b ON b.memory_id = m.id
-            WHERE m.status IN ('active', 'stale')
+            WHERE m.status IN ('active', 'stale'){repo_clause}
               AND b.binding_kind = ?1
               AND b.rowid = (
                   SELECT b2.rowid FROM repo_memory_bindings AS b2
@@ -522,17 +573,17 @@ pub(crate) fn list_memories(
                   LIMIT 1
               )
             ORDER BY m.updated_at_ms DESC
-            ",
-        )?;
+            "
+        ))?;
         stmt.query_map([binding_kind], memory_summary_row)?.collect::<Result<_, _>>()?
     } else {
-        let mut stmt = conn.prepare(
+        let mut stmt = conn.prepare(&format!(
             "
             SELECT m.id AS memory_id, m.kind, m.title, m.status,
                    b.binding_kind, b.binding_id
             FROM repo_memories AS m
             JOIN repo_memory_bindings AS b ON b.memory_id = m.id
-            WHERE m.status IN ('active', 'stale')
+            WHERE m.status IN ('active', 'stale'){repo_clause}
               AND b.rowid = (
                   SELECT b2.rowid FROM repo_memory_bindings AS b2
                   WHERE b2.memory_id = m.id
@@ -540,8 +591,8 @@ pub(crate) fn list_memories(
                   LIMIT 1
               )
             ORDER BY m.updated_at_ms DESC
-            ",
-        )?;
+            "
+        ))?;
         stmt.query_map([], memory_summary_row)?.collect::<Result<_, _>>()?
     };
     Ok(rows)
@@ -580,15 +631,19 @@ pub struct MemoryDoctorEntry {
 /// `scip_moniker` bindings are excluded (self-heal on the next oracle run, never
 /// rebind-actionable).
 pub(crate) fn doctor_attention_count(conn: &Connection) -> anyhow::Result<u64> {
+    let scope = memory_repo_scope(conn)?;
+    let repo_clause = crate::index::schema::periphery_repo_scope_clause(&scope, "m");
     let count: i64 = conn.query_row(
-        "
+        &format!(
+            "
         SELECT COUNT(*)
         FROM repo_memory_bindings AS b
         JOIN repo_memories AS m ON m.id = b.memory_id
         WHERE m.status = 'active'
           AND b.anchor_status IN ('gone', 'stale')
-          AND b.binding_kind != 'scip_moniker'
-        ",
+          AND b.binding_kind != 'scip_moniker'{repo_clause}
+        "
+        ),
         [],
         |row| row.get(0),
     )?;
@@ -598,7 +653,9 @@ pub(crate) fn doctor_attention_count(conn: &Connection) -> anyhow::Result<u64> {
 pub(crate) fn doctor_report(conn: &Connection) -> anyhow::Result<Vec<MemoryDoctorEntry>> {
     // Query bindings whose anchor_status is non-current, restricted to active memories.
     // Mirrors the column list used by validate_memories / binding_row.
-    let mut stmt = conn.prepare(
+    let scope = memory_repo_scope(conn)?;
+    let repo_clause = crate::index::schema::periphery_repo_scope_clause(&scope, "m");
+    let mut stmt = conn.prepare(&format!(
         "
         SELECT b.memory_id, b.binding_kind, b.binding_id, b.path,
                b.symbol_kind, b.signature_hash, b.anchor_status,
@@ -610,10 +667,10 @@ pub(crate) fn doctor_report(conn: &Connection) -> anyhow::Result<Vec<MemoryDocto
           -- `scip_moniker` bindings are excluded: a lagging moniker self-heals on the next
           -- `oracle run` and is never rebind-actionable; a genuinely dead symbol surfaces via
           -- its symbol/logical_symbol binding anyway (#70).
-          AND b.binding_kind != 'scip_moniker'
+          AND b.binding_kind != 'scip_moniker'{repo_clause}
         ORDER BY b.memory_id, b.binding_kind, b.binding_id
-        ",
-    )?;
+        "
+    ))?;
 
     struct RawRow {
         memory_id: String,
@@ -657,6 +714,39 @@ pub(crate) fn doctor_report(conn: &Connection) -> anyhow::Result<Vec<MemoryDocto
             anchor_status: r.anchor_status,
             candidates,
         });
+    }
+
+    // Placeholder-scoped memories (V042): user-authored memories stranded under the
+    // '__unassigned__' repo on a consolidated DB — the V042 backfill's leave-at-placeholder path,
+    // reachable only by hand-driving `register_repo` before the consolidate importer exists. They
+    // are invisible to every scoped memory read, so the doctor must surface them rather than let
+    // them vanish silently: one entry per memory under the distinct `placeholder_repo` marker
+    // (rebind-by-hand territory — no computable candidates). Skipped when the active repo IS the
+    // placeholder (an un-adopted single-repo DB, where placeholder scope is the normal state).
+    if let Some(active) = &scope
+        && active != crate::index::schema::LEGACY_REPO_ID
+    {
+        let mut stmt = conn.prepare(
+            "
+            SELECT id, title FROM repo_memories
+            WHERE status IN ('active', 'stale') AND repo_id = ?1
+            ORDER BY id
+            ",
+        )?;
+        let rows = stmt.query_map([crate::index::schema::LEGACY_REPO_ID], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
+        for row in rows {
+            let (memory_id, title) = row?;
+            entries.push(MemoryDoctorEntry {
+                memory_id,
+                title,
+                binding_kind: "repo".to_string(),
+                binding_id: crate::index::schema::LEGACY_REPO_ID.to_string(),
+                anchor_status: "placeholder_repo".to_string(),
+                candidates: Vec::new(),
+            });
+        }
     }
     Ok(entries)
 }
@@ -733,7 +823,11 @@ pub(crate) fn anchor_health_counts(
     conn: &Connection,
 ) -> anyhow::Result<crate::index::AnchorHealth> {
     let mut health = crate::index::AnchorHealth::default();
-    let mut stmt = conn.prepare(
+    // Scoped to the active repo (V042): these counts drive per-repo doctor warnings, so a sibling
+    // repo's bindings must not inflate them on a consolidated DB.
+    let scope = memory_repo_scope(conn)?;
+    let repo_clause = crate::index::schema::periphery_repo_scope_clause(&scope, "m");
+    let mut stmt = conn.prepare(&format!(
         "
         SELECT b.anchor_status, COUNT(*) AS cnt
         FROM repo_memory_bindings AS b
@@ -742,10 +836,10 @@ pub(crate) fn anchor_health_counts(
           -- Auxiliary `scip_moniker` anchors are excluded exactly as in `doctor_report`: these
           -- counts drive the 'run memory doctor' warnings, so counting rows doctor then hides
           -- would yield an unresolvable warning (#70 review).
-          AND b.binding_kind != 'scip_moniker'
+          AND b.binding_kind != 'scip_moniker'{repo_clause}
         GROUP BY b.anchor_status
-        ",
-    )?;
+        "
+    ))?;
     let rows = stmt.query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)))?;
     for row in rows {
         let (status, count) = row?;
@@ -769,15 +863,25 @@ pub(crate) fn validate_memories(
     // root when known (correct under a multi-worktree shared DB), else the persisted source_root.
     let fs_root = effective_fs_root(conn, active_root);
     let fs_root = fs_root.as_deref();
-    let mut stmt = conn.prepare(
+    // Validate ONLY the active repo's bindings (V042): this sweep both counts AND rewrites
+    // anchor_status, so an unscoped pass would validate a sibling repo's bindings against THIS
+    // repo's index/filesystem — flipping a sibling's healthy anchors to gone (its paths don't
+    // exist here) or, worse, blessing a sibling's binding as current when its path collides with
+    // one of ours. The downstream UPDATE/DELETE key on rows this SELECT returned, so scoping the
+    // read scopes the mutation.
+    let scope = memory_repo_scope(conn)?;
+    let repo_clause =
+        crate::index::schema::periphery_repo_scope_clause(&scope, "repo_memory_bindings");
+    let mut stmt = conn.prepare(&format!(
         "
         SELECT memory_id, binding_kind, binding_id, path, start_line, end_line,
                logical_symbol_id, symbol_id, chunk_id, edge_id, commit_hash, github_owner,
                github_repo, github_number, symbol_kind, signature_hash, moniker_tool,
                moniker_tool_version, relocation_reason, anchor_status, created_at_ms
         FROM repo_memory_bindings
-        ",
-    )?;
+        WHERE 1=1{repo_clause}
+        "
+    ))?;
     let rows = stmt.query_map([], binding_row)?;
     let tx = conn.unchecked_transaction()?;
     let mut report = RepoMemoryValidationReport {

--- a/crates/rag-rat-core/src/query/memory/hydrate.rs
+++ b/crates/rag-rat-core/src/query/memory/hydrate.rs
@@ -6,8 +6,14 @@ pub(crate) fn duplicate_memory_id(
     body: &str,
     binding: &ResolvedBinding,
 ) -> anyhow::Result<Option<String>> {
+    // Dedupe NEVER crosses repos (spec §4.4): a duplicate is a same-repo title+body+binding match.
+    // The `{repo_clause}` is empty on the pre-A5 schema (memory still repo-global), so this stays
+    // the original global dedupe until the periphery-scoping migration lands.
+    let scope = memory_repo_scope(conn)?;
+    let repo_clause = memory_repo_scope_clause(&scope);
     conn.query_row(
-        "
+        &format!(
+            "
         SELECT repo_memories.id AS memory_id
         FROM repo_memories
         JOIN repo_memory_bindings ON repo_memory_bindings.memory_id = repo_memories.id
@@ -15,9 +21,10 @@ pub(crate) fn duplicate_memory_id(
           AND lower(repo_memories.body) = lower(?2)
           AND repo_memory_bindings.binding_kind = ?3
           AND repo_memory_bindings.binding_id = ?4
-          AND repo_memories.status != 'obsolete'
+          AND repo_memories.status != 'obsolete'{repo_clause}
         LIMIT 1
-        ",
+        "
+        ),
         params![title.trim(), body.trim(), binding.binding_kind, binding.binding_id],
         |row| row.get("memory_id"),
     )
@@ -42,15 +49,31 @@ pub(crate) fn replace_tags(
 pub(crate) fn upsert_memory_fts(conn: &Connection, memory_id: &str) -> anyhow::Result<()> {
     conn.execute("DELETE FROM repo_memory_fts WHERE memory_id = ?1", [memory_id])?;
     let tags = tags_for_memory(conn, memory_id)?.join(" ");
-    conn.execute(
-        "
-        INSERT INTO repo_memory_fts(memory_id, title, body, kind, tags)
-        SELECT id, title, body, kind, ?2
-        FROM repo_memories
-        WHERE id = ?1
-        ",
-        params![memory_id, tags],
-    )?;
+    // Post-A5 the FTS carries a `repo_id UNINDEXED` mirror of the parent memory's, so
+    // `memory_search` can filter it after the MATCH. Stamp it from `repo_memories.repo_id`
+    // (already set by the time this runs). On the pre-A5 schema the column does not exist, so
+    // write the original row shape.
+    if memory_repo_scope(conn)?.is_some() {
+        conn.execute(
+            "
+            INSERT INTO repo_memory_fts(repo_id, memory_id, title, body, kind, tags)
+            SELECT repo_id, id, title, body, kind, ?2
+            FROM repo_memories
+            WHERE id = ?1
+            ",
+            params![memory_id, tags],
+        )?;
+    } else {
+        conn.execute(
+            "
+            INSERT INTO repo_memory_fts(memory_id, title, body, kind, tags)
+            SELECT id, title, body, kind, ?2
+            FROM repo_memories
+            WHERE id = ?1
+            ",
+            params![memory_id, tags],
+        )?;
+    }
     Ok(())
 }
 pub(crate) fn memory_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RepoMemory> {

--- a/crates/rag-rat-core/src/query/memory/mod.rs
+++ b/crates/rag-rat-core/src/query/memory/mod.rs
@@ -15,6 +15,19 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 pub(crate) use validate::*;
 
+/// The active `repo_id` scope for the memory tables, or `None` on the pre-A5 schema (the memory
+/// tables are still repo-global until the periphery-scoping migration lands). Every memory
+/// read/write gates its `repo_id` predicate on this: `Some(repo_id)` scopes to the active repo,
+/// `None` runs the original unscoped SQL. See `schema::periphery_repo_scope` for the deferral.
+pub(crate) fn memory_repo_scope(conn: &Connection) -> anyhow::Result<Option<String>> {
+    Ok(crate::index::schema::periphery_repo_scope(conn, "repo_memories")?)
+}
+
+/// The ` AND repo_memories.repo_id = '…'` predicate for a memory read, or `""` when unscoped.
+pub(crate) fn memory_repo_scope_clause(scope: &Option<String>) -> String {
+    crate::index::schema::periphery_repo_scope_clause(scope, "repo_memories")
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct RepoMemory {
     pub memory_id: String,

--- a/crates/rag-rat-core/src/query/memory/moniker.rs
+++ b/crates/rag-rat-core/src/query/memory/moniker.rs
@@ -46,14 +46,21 @@ pub(crate) fn moniker_for_logical_symbol(
     conn: &Connection,
     logical_symbol_id: i64,
 ) -> anyhow::Result<Option<MonikerRow>> {
+    // Per-repo (A5): `logical_symbol_id` is content-derived and collides across repos, so scope to
+    // the active repo. `{repo_clause}` empty pre-A5.
+    let scope = crate::index::schema::periphery_repo_scope(conn, "logical_symbol_monikers")?;
+    let repo_clause =
+        crate::index::schema::periphery_repo_scope_clause(&scope, "logical_symbol_monikers");
     conn.query_row(
-        "
+        &format!(
+            "
         SELECT moniker, tool, tool_version
         FROM logical_symbol_monikers
-        WHERE logical_symbol_id = ?1
+        WHERE logical_symbol_id = ?1{repo_clause}
         ORDER BY tool
         LIMIT 1
-        ",
+        "
+        ),
         [logical_symbol_id],
         |row| Ok(MonikerRow { moniker: row.get(0)?, tool: row.get(1)?, tool_version: row.get(2)? }),
     )
@@ -69,12 +76,17 @@ pub(crate) fn moniker_for_logical_symbol_tool(
     logical_symbol_id: i64,
     tool: &str,
 ) -> anyhow::Result<Option<MonikerRow>> {
+    let scope = crate::index::schema::periphery_repo_scope(conn, "logical_symbol_monikers")?;
+    let repo_clause =
+        crate::index::schema::periphery_repo_scope_clause(&scope, "logical_symbol_monikers");
     conn.query_row(
-        "
+        &format!(
+            "
         SELECT moniker, tool, tool_version
         FROM logical_symbol_monikers
-        WHERE logical_symbol_id = ?1 AND tool = ?2
-        ",
+        WHERE logical_symbol_id = ?1 AND tool = ?2{repo_clause}
+        "
+        ),
         params![logical_symbol_id, tool],
         |row| Ok(MonikerRow { moniker: row.get(0)?, tool: row.get(1)?, tool_version: row.get(2)? }),
     )
@@ -108,15 +120,31 @@ pub(crate) fn resolve_moniker(
     moniker: &str,
     tool: &str,
 ) -> anyhow::Result<MonikerResolution> {
-    let mut stmt = conn.prepare(
+    // Per-repo (A5): BOTH sides are scoped. `logical_symbol_monikers` carries its own `repo_id`
+    // since V042, so a SIBLING repo carrying the same SCIP moniker string must not capture this
+    // memory's re-resolution during validation (relocate it onto — or mark it ambiguous/gone by —
+    // the sibling's row). The `logical_symbols` liveness join is scoped too (its `repo_id`
+    // predicate rides the LEFT JOIN's `ON` so a dangling row still reads as not-live rather
+    // than being dropped) — belt-and-suspenders since `logical_symbol_id` already folds
+    // `repo_id` into its content hash. The `tool_has_rows` probe (the Gone-vs-NoData
+    // discriminator) is scoped identically so a sibling's rows can't make this repo's tool look
+    // populated. `{repo_clause}` empty pre-A5.
+    let scope = crate::index::schema::periphery_repo_scope(conn, "logical_symbol_monikers")?;
+    let moniker_clause =
+        crate::index::schema::periphery_repo_scope_clause(&scope, "logical_symbol_monikers");
+    let symbol_clause =
+        crate::index::schema::periphery_repo_scope_clause(&scope, "logical_symbols");
+    let mut stmt = conn.prepare(&format!(
         "
         SELECT logical_symbol_monikers.logical_symbol_id, logical_symbol_monikers.tool_version,
                logical_symbols.id IS NOT NULL AS live
         FROM logical_symbol_monikers
-        LEFT JOIN logical_symbols ON logical_symbols.id = logical_symbol_monikers.logical_symbol_id
-        WHERE logical_symbol_monikers.moniker = ?1 AND logical_symbol_monikers.tool = ?2
-        ",
-    )?;
+        LEFT JOIN logical_symbols ON logical_symbols.id = \
+         logical_symbol_monikers.logical_symbol_id{symbol_clause}
+        WHERE logical_symbol_monikers.moniker = ?1 AND logical_symbol_monikers.tool = \
+         ?2{moniker_clause}
+        "
+    ))?;
     let rows = stmt
         .query_map(params![moniker, tool], |row| {
             Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?, row.get::<_, bool>(2)?))
@@ -129,7 +157,10 @@ pub(crate) fn resolve_moniker(
     match (rows.is_empty(), first, second) {
         (true, ..) => {
             let tool_has_rows: bool = conn.query_row(
-                "SELECT EXISTS(SELECT 1 FROM logical_symbol_monikers WHERE tool = ?1)",
+                &format!(
+                    "SELECT EXISTS(SELECT 1 FROM logical_symbol_monikers WHERE tool = \
+                     ?1{moniker_clause})"
+                ),
                 [tool],
                 |row| row.get(0),
             )?;

--- a/crates/rag-rat-core/src/query/memory/resolve.rs
+++ b/crates/rag-rat-core/src/query/memory/resolve.rs
@@ -835,6 +835,30 @@ pub(crate) fn insert_binding(
     }
     Ok(())
 }
+/// Stamp every `repo_memory_bindings` row of `memory_id` with the PARENT memory's `repo_id` (spec
+/// §4.5: a binding inherits its memory's repo). Sourced from `repo_memories.repo_id`, NOT the
+/// active repo — a memory bound under a repo other than the currently-active one (a future
+/// cross-repo shape) keeps its own attribution. Called after every binding (re-)insert
+/// (`create_memory` after its memory is stamped, `rebind_memory` which deletes + re-inserts), so a
+/// re-inserted binding never strands at the `__unassigned__` default — which would drop it out of
+/// the binding-scoped sweeps (`validate_memories`, `doctor_report`, `anchor_health_counts`) while
+/// the parent memory sat in the active repo. No-op pre-A5 (no `repo_id` column).
+/// `repo_memory_call_paths` / `repo_memory_call_path_edges` are transitive (scoped via the
+/// `repo_memories` FK), so they carry no `repo_id` to stamp.
+pub(crate) fn stamp_bindings_from_parent_repo(
+    conn: &Connection,
+    memory_id: &str,
+) -> anyhow::Result<()> {
+    if crate::index::schema::periphery_repo_scope(conn, "repo_memory_bindings")?.is_some() {
+        conn.execute(
+            "UPDATE repo_memory_bindings
+             SET repo_id = (SELECT repo_id FROM repo_memories WHERE id = ?1)
+             WHERE memory_id = ?1",
+            [memory_id],
+        )?;
+    }
+    Ok(())
+}
 pub(crate) struct RelocateMatch {
     pub(crate) binding_id: String,
     pub(crate) symbol_id: i64,

--- a/crates/rag-rat-core/src/query/memory/validate.rs
+++ b/crates/rag-rat-core/src/query/memory/validate.rs
@@ -518,8 +518,21 @@ pub(crate) fn validate_len(field: &str, value: &str, max: usize) -> anyhow::Resu
     }
     Ok(())
 }
-pub(crate) fn memory_id(now: i64, input_hash: &str) -> String {
-    let suffix = input_hash.chars().take(12).collect::<String>();
+/// Derive a memory id. On the post-A5 schema (`scope` is `Some`) the owning repo is FOLDED into the
+/// hash suffix: two repos creating IDENTICAL content in the same millisecond would otherwise derive
+/// the same `mem_<ms>_<hash-prefix>` id — the repo-scoped dedupe (correctly) sees no duplicate, and
+/// the insert explodes on the global PK. Phase B and beyond: memory ids must remain globally unique
+/// and coordination-free (they replicate across devices/DBs with no allocator) — folding the repo
+/// INTO the hash strengthens that property, never weakens it. Pre-A5 (`None`) keeps the original
+/// repo-blind suffix so a single-repo DB's ids are unchanged.
+pub(crate) fn memory_id(now: i64, input_hash: &str, scope: &Option<String>) -> String {
+    let suffix = match scope {
+        Some(repo_id) => hex_sha256(format!("{repo_id}\u{1f}{input_hash}").as_bytes())
+            .chars()
+            .take(12)
+            .collect::<String>(),
+        None => input_hash.chars().take(12).collect::<String>(),
+    };
     format!("mem_{now:x}_{suffix}")
 }
 pub(crate) fn memory_input_hash(kind: &str, title: &str, body: &str, tags: &[String]) -> String {

--- a/crates/rag-rat-core/src/query/orientation.rs
+++ b/crates/rag-rat-core/src/query/orientation.rs
@@ -206,20 +206,26 @@ fn recently_changed_source_files(conn: &Connection, limit: usize) -> anyhow::Res
 /// Dir-bound memories already appear as annotations on the tree nodes (or as
 /// `root_memory_title`), so we exclude them here to avoid duplication.
 fn active_non_dir_memory_titles(conn: &Connection, limit: usize) -> anyhow::Result<Vec<String>> {
-    let mut stmt = conn.prepare(
+    // Scoped to the active repo (V042): a sibling repo's active memory must not appear in this
+    // repo's orientation. Scoping the outer `m` on `repo_memories.repo_id` is sufficient — the
+    // inner `dir`-exclusion subquery only removes ids, and a sibling id can never equal an
+    // active memory's. `{repo_clause}` empty pre-A5.
+    let scope = crate::index::schema::periphery_repo_scope(conn, "repo_memories")?;
+    let repo_clause = crate::index::schema::periphery_repo_scope_clause(&scope, "m");
+    let mut stmt = conn.prepare(&format!(
         "-- Active memories not bound to a directory, newest-updated first.
          -- Invariant: excludes binding_kind='dir' rows so tree-shown titles are not repeated.
          SELECT m.title
          FROM repo_memories AS m
-         WHERE m.status = 'active'
+         WHERE m.status = 'active'{repo_clause}
            AND m.id NOT IN (
                SELECT b.memory_id
                FROM repo_memory_bindings AS b
                WHERE b.binding_kind = 'dir'
            )
          ORDER BY m.updated_at_ms DESC
-         LIMIT ?1",
-    )?;
+         LIMIT ?1"
+    ))?;
     let rows = stmt.query_map([limit as i64], |row| row.get::<_, String>(0))?;
     let mut out = Vec::new();
     for row in rows {
@@ -234,18 +240,24 @@ fn active_non_dir_memory_titles(conn: &Connection, limit: usize) -> anyhow::Resu
 /// [`active_non_dir_memory_titles`] (active + excludes `binding_kind='dir'`) so the
 /// `(+N more)` overflow note reflects the true total, not the truncated title list.
 fn active_non_dir_memory_count(conn: &Connection) -> anyhow::Result<u32> {
+    // Scoped to the active repo (V042), matching `active_non_dir_memory_titles` so the `(+N more)`
+    // total counts only this repo's memories. `{repo_clause}` empty pre-A5.
+    let scope = crate::index::schema::periphery_repo_scope(conn, "repo_memories")?;
+    let repo_clause = crate::index::schema::periphery_repo_scope_clause(&scope, "m");
     let count: i64 = conn.query_row(
-        "-- Total active memories not bound to a directory (mirrors the titles query).
+        &format!(
+            "-- Total active memories not bound to a directory (mirrors the titles query).
          -- Invariant: excludes binding_kind='dir' rows so the count matches what the
          -- titles list draws from; only the LIMIT/ORDER differ.
          SELECT COUNT(*)
          FROM repo_memories AS m
-         WHERE m.status = 'active'
+         WHERE m.status = 'active'{repo_clause}
            AND m.id NOT IN (
                SELECT b.memory_id
                FROM repo_memory_bindings AS b
                WHERE b.binding_kind = 'dir'
-           )",
+           )"
+        ),
         [],
         |row| row.get(0),
     )?;

--- a/crates/rag-rat-core/src/query/repo_brief.rs
+++ b/crates/rag-rat-core/src/query/repo_brief.rs
@@ -693,29 +693,35 @@ fn newest_commit_time(conn: &Connection) -> anyhow::Result<i64> {
 fn memory_counts(conn: &Connection, path: Option<&str>) -> anyhow::Result<RepoBriefMemoryCounts> {
     let mut counts = RepoBriefMemoryCounts::default();
 
+    // Scoped to the active repo (V042): these counts drive the per-repo brief, so a sibling repo's
+    // memories (including a same-path binding that collides with one of ours) must not inflate them
+    // on a consolidated DB. `{repo_clause}` empty pre-A5 — see `schema::periphery_repo_scope`.
+    let scope = crate::index::schema::periphery_repo_scope(conn, "repo_memories")?;
+    let repo_clause = crate::index::schema::periphery_repo_scope_clause(&scope, "repo_memories");
     if let Some(path) = path {
-        let mut stmt = conn.prepare(
+        let mut stmt = conn.prepare(&format!(
             "
             SELECT repo_memories.status, COUNT(DISTINCT repo_memories.id)
             FROM repo_memories
             JOIN repo_memory_bindings ON repo_memory_bindings.memory_id = repo_memories.id
-            WHERE repo_memory_bindings.path = ?1
+            WHERE repo_memory_bindings.path = ?1{repo_clause}
             GROUP BY repo_memories.status
-            ",
-        )?;
+            "
+        ))?;
         let rows =
             stmt.query_map([path], |row| Ok((row.get::<_, String>(0)?, row_u64(row, 1)?)))?;
         for row in rows {
             add_memory_count(&mut counts, row?);
         }
     } else {
-        let mut stmt = conn.prepare(
+        let mut stmt = conn.prepare(&format!(
             "
             SELECT status, COUNT(*)
             FROM repo_memories
+            WHERE 1=1{repo_clause}
             GROUP BY status
-            ",
-        )?;
+            "
+        ))?;
         let rows = stmt.query_map([], |row| Ok((row.get::<_, String>(0)?, row_u64(row, 1)?)))?;
         for row in rows {
             add_memory_count(&mut counts, row?);
@@ -779,17 +785,22 @@ fn memory_counts_by_path(
     conn: &Connection,
     _paths: &[String],
 ) -> anyhow::Result<BTreeMap<String, RepoBriefMemoryCounts>> {
-    let mut stmt = conn.prepare(
+    // Scoped to the active repo (V042): the join is by `repo_memory_bindings.path`, so a sibling
+    // repo's path-bound memory whose path collides with one of ours (the same-path poison tripwire)
+    // would attribute its counts to our file without this predicate. `{repo_clause}` empty pre-A5.
+    let scope = crate::index::schema::periphery_repo_scope(conn, "repo_memories")?;
+    let repo_clause = crate::index::schema::periphery_repo_scope_clause(&scope, "repo_memories");
+    let mut stmt = conn.prepare(&format!(
         "
         SELECT repo_memory_bindings.path,
                repo_memories.status,
                COUNT(DISTINCT repo_memories.id)
         FROM repo_memories
         JOIN repo_memory_bindings ON repo_memory_bindings.memory_id = repo_memories.id
-        WHERE repo_memory_bindings.path IS NOT NULL
+        WHERE repo_memory_bindings.path IS NOT NULL{repo_clause}
         GROUP BY repo_memory_bindings.path, repo_memories.status
-        ",
-    )?;
+        "
+    ))?;
     let rows = stmt.query_map([], |row| {
         Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row_u64(row, 2)?))
     })?;

--- a/crates/rag-rat-core/src/query/tree.rs
+++ b/crates/rag-rat-core/src/query/tree.rs
@@ -229,13 +229,17 @@ fn file_counts_by_dir(conn: &Connection) -> anyhow::Result<HashMap<String, u32>>
 ///
 /// Returns only `status = 'active'` memories with `binding_kind = 'dir'`.
 fn dir_memory_titles(conn: &Connection) -> anyhow::Result<HashMap<String, String>> {
-    let mut stmt = conn.prepare(
+    // Scoped to the active repo (V042): a sibling repo's `dir` memory must not annotate this repo's
+    // tree. `{repo_clause}` empty pre-A5 — see `schema::periphery_repo_scope`.
+    let scope = crate::index::schema::periphery_repo_scope(conn, "repo_memories")?;
+    let repo_clause = crate::index::schema::periphery_repo_scope_clause(&scope, "m");
+    let mut stmt = conn.prepare(&format!(
         // Only active dir memories; binding_id is the normalized dir path (or "" for repo root).
         "SELECT b.binding_id, m.title
          FROM repo_memory_bindings b
          JOIN repo_memories m ON m.id = b.memory_id
-         WHERE b.binding_kind = 'dir' AND m.status = 'active'",
-    )?;
+         WHERE b.binding_kind = 'dir' AND m.status = 'active'{repo_clause}"
+    ))?;
     let rows = stmt.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))?;
     rows.collect::<Result<_, _>>().map_err(Into::into)
 }


### PR DESCRIPTION
Phase A5 of the global-DB consolidation (#400). The periphery tables the core sweeps left global gain the repo dimension.

- **V042**: `repo_id` on `clone_graph_generations` (per-repo generation counter), `clone_token_df` (df stats never pool across repos), `clone_refinements`, `oracle_runs`, `edge_oracle`, `logical_symbol_monikers`, `reconcile_attempts`, `dream_findings`, `repo_memories`, and `repo_memory_bindings` (binding-level scoping — a memory can later bind across repos); `repo_memory_fts` rebuilt with `repo_id UNINDEXED`. Rebuilt keys lead with `repo_id`, so no placeholder row can block writer reclamation (per-table audit in the migration comments). Backfill is cardinality-gated: sole registered repo → backfill to it; multi-repo consolidated DBs keep placeholder rows rather than aborting the ladder, and `memory doctor` surfaces placeholder-scoped memories explicitly (user-authored data must never go silently invisible).
- **The V042 seams close**: the multi-repo guards at the gc oracle prune, clone `complete_generation`, and the building-generation open/resume are replaced with real `repo_id` predicates — one repo's maintenance can no longer delete or resume a sibling's oracle runs and clone generations.
- **Memory subsystem**: create stamps the active repo; search/list/doctor/validate/moniker queries filter it; create-dedupe never crosses repos; `validate_memories` and `anchor_health_counts` scope their sweeps — one repo's validation can no longer rewrite a sibling's anchor statuses.
- **Reconcile**: chunk selection scopes via the repo-filtered view; `embedding_cache` stays global (content-addressed sharing across repos is a feature); the int8-reencode cursor stays global per the meta-ownership classification.
- **Poison-sibling harness extended** to every table above, including same-path tripwire rows — this flushed and fixed the two memory-validation cross-repo leaks during development.
- Cross-workstream ladder test: V037→V042 forward-migrates a seeded index with both search-side and periphery data intact, scoped, and adoption-re-pointed.

Workspace suite: 1490 passed; clippy `-D warnings` clean; nightly fmt clean.

Fixes #400