### PR TITLE
feat(index): V043 — generation-staged full rebuild, per-repo write locks (#401 phase A6)

### DIFF
--- a/crates/rag-rat-cli/src/commands/clones.rs
+++ b/crates/rag-rat-cli/src/commands/clones.rs
@@ -11,7 +11,8 @@ pub(crate) fn clones(config: &Config, args: &ClonesArgs) -> anyhow::Result<()> {
     // `--precompute`: the WRITER path — build/refresh the persisted clone-edge graph (#286) under a
     // write lock (mirroring `maintenance`), then print the build report instead of a clone listing.
     if args.precompute {
-        let _lock = rag_rat_core::locks::WriteLock::acquire_blocking(&config.database)?;
+        let lock_repo = rag_rat_core::locks::write_lock_repo_id(config);
+        let _lock = rag_rat_core::locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
         let db = open_index(config)?;
         let report: rag_rat_core::index::CloneEdgeReport =
             db.precompute_clone_graph(args.max_seconds)?;

--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -18,9 +18,11 @@ pub(crate) fn index(config: &Config, args: &IndexArgs) -> anyhow::Result<()> {
     if args.watch {
         return run_watch(config.clone());
     }
-    // Serialize with the background watcher / other writers (busy_timeout backstops any heal on
-    // the query path).
-    let _lock = rag_rat_core::locks::WriteLock::acquire_blocking(&config.database)?;
+    // Serialize with the background watcher / other writers OF THIS REPO (busy_timeout backstops
+    // any heal on the query path). The write lock is per-repo (A6), so a rebuild here never
+    // blocks an unrelated repo's writer in a shared global DB.
+    let lock_repo = rag_rat_core::locks::write_lock_repo_id(config);
+    let _lock = rag_rat_core::locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
     // `--worktree`: index a linked worktree's branch overlay on top of the existing base index
     // (#219). A distinct mode — the delta vs the base, not a base (re)build — so handle it before
     // the full/discover/changed branches.
@@ -226,8 +228,9 @@ pub(crate) fn maintenance(config: &Config, args: &MaintenanceArgs) -> anyhow::Re
     // "rerun pending" marker and exit immediately; the runner re-checks the marker after its pass
     // and runs once more to cover a change that arrived mid-pass. The pass still takes the write
     // lock internally, so serialization with the watcher is unchanged.
-    let pending = rag_rat_core::locks::maintenance_pending_path(&config.database);
-    let lock_path = rag_rat_core::locks::maintenance_lock_path(&config.database);
+    let lock_repo = rag_rat_core::locks::write_lock_repo_id(config);
+    let pending = rag_rat_core::locks::maintenance_pending_path(&config.database, &lock_repo);
+    let lock_path = rag_rat_core::locks::maintenance_lock_path(&config.database, &lock_repo);
     let Some(_maint) = rag_rat_core::locks::FileLock::try_acquire(&lock_path)? else {
         let _ = fs::File::create(&pending);
         return print_output(&serde_json::json!({
@@ -269,10 +272,11 @@ fn run_maintenance_pass(
     let _span = tracing::info_span!("maintenance_pass", %trigger, max_seconds).entered();
     tracing::info!(target: "rag_rat_core::maintenance", "maintenance pass started");
 
-    // Serialize with the background watcher (and other writers). The hook backgrounds this command,
-    // so blocking here never holds up the git operation; busy_timeout backstops the query-path
-    // heal.
-    let _lock = rag_rat_core::locks::WriteLock::acquire_blocking(&config.database)?;
+    // Serialize with the background watcher (and other writers) OF THIS REPO. The hook backgrounds
+    // this command, so blocking here never holds up the git operation; busy_timeout backstops the
+    // query-path heal. Per-repo write lock (A6).
+    let lock_repo = rag_rat_core::locks::write_lock_repo_id(config);
+    let _lock = rag_rat_core::locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
     tracing::debug!(target: "rag_rat_core::maintenance", phase = "lock_acquired", elapsed_ms = started.elapsed().as_millis() as u64, "write lock acquired");
 
     let mut db = IndexDatabase::index_discover_with_progress(config, render_index_progress)?;
@@ -672,7 +676,9 @@ mod tests {
 
     #[test]
     fn maintenance_coalesces_a_concurrent_trigger() {
-        use rag_rat_core::locks::{FileLock, maintenance_lock_path, maintenance_pending_path};
+        use rag_rat_core::locks::{
+            FileLock, maintenance_lock_path, maintenance_pending_path, write_lock_repo_id,
+        };
 
         // #267: a single amend/merge/rebase fires several git hooks, each backgrounding
         // `rag-rat maintenance`. A concurrent trigger must coalesce — skip its pass and set the
@@ -706,7 +712,8 @@ mod tests {
         };
         IndexDatabase::rebuild(&config).unwrap();
 
-        let pending = maintenance_pending_path(&config.database);
+        let lock_repo = write_lock_repo_id(&config);
+        let pending = maintenance_pending_path(&config.database, &lock_repo);
         let args = super::MaintenanceArgs {
             trigger: Some("post-rewrite".to_string()),
             max_seconds: Some(0), // skip the embedding reconcile; we only assert coalescing
@@ -716,8 +723,9 @@ mod tests {
         };
 
         // Hold the coordination lock to simulate an in-flight maintenance pass.
-        let held =
-            FileLock::try_acquire(&maintenance_lock_path(&config.database)).unwrap().unwrap();
+        let held = FileLock::try_acquire(&maintenance_lock_path(&config.database, &lock_repo))
+            .unwrap()
+            .unwrap();
         assert!(!pending.exists());
         // A concurrent trigger coalesces: it does NOT run a pass; it sets the rerun marker.
         super::maintenance(&config, &args).unwrap();

--- a/crates/rag-rat-cli/src/commands/memory.rs
+++ b/crates/rag-rat-cli/src/commands/memory.rs
@@ -14,7 +14,8 @@ use crate::render::print_output;
 pub(crate) fn dream(config: &Config, args: &DreamArgs) -> anyhow::Result<()> {
     // `dream` WRITES dream_findings — serialize with the watcher/index like every other write
     // command (index/maintenance/oracle); WriteLock is reentrant so the open-time migrate is safe.
-    let _lock = rag_rat_core::locks::WriteLock::acquire_blocking(&config.database)?;
+    let lock_repo = rag_rat_core::locks::write_lock_repo_id(config);
+    let _lock = rag_rat_core::locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
     let db = open_index(config)?;
     let now_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/crates/rag-rat-cli/src/commands/oracle.rs
+++ b/crates/rag-rat-cli/src/commands/oracle.rs
@@ -40,7 +40,8 @@ pub(crate) fn with_oracle_write_lock<T>(
     config: &Config,
     body: impl FnOnce(&IndexDatabase) -> anyhow::Result<T>,
 ) -> anyhow::Result<T> {
-    let _lock = rag_rat_core::locks::WriteLock::acquire_blocking(&config.database)?;
+    let lock_repo = rag_rat_core::locks::write_lock_repo_id(config);
+    let _lock = rag_rat_core::locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
     let db = open_index(config)?;
     body(&db)
 }
@@ -446,7 +447,7 @@ mod tests {
 
     use rag_rat_core::config::{ResolvedTarget, TargetKind};
     use rag_rat_core::language::Language;
-    use rag_rat_core::locks::{FileLock, write_lock_path};
+    use rag_rat_core::locks::{FileLock, write_lock_path, write_lock_repo_id};
     use rag_rat_core::{Config, IndexDatabase};
 
     use crate::cli::{OracleArgs, OracleCommand, OracleRunArgs, OracleToolArg};
@@ -596,8 +597,12 @@ mod tests {
             run.scip = Some(scip_path);
         }
 
-        // Hold the write lock the run must contend for.
-        let lock = FileLock::acquire_blocking(&write_lock_path(&config.database)).unwrap();
+        // Hold the write lock the run must contend for (per-repo, A6).
+        let lock = FileLock::acquire_blocking(&write_lock_path(
+            &config.database,
+            &write_lock_repo_id(&config),
+        ))
+        .unwrap();
 
         let (tx, rx) = mpsc::channel();
         let handle = std::thread::spawn(move || {
@@ -637,7 +642,9 @@ mod tests {
         super::oracle(&config, &args).unwrap();
 
         // The lock is free now — a non-blocking acquire must succeed.
-        let lock = FileLock::try_acquire(&write_lock_path(&config.database)).unwrap();
+        let lock =
+            FileLock::try_acquire(&write_lock_path(&config.database, &write_lock_repo_id(&config)))
+                .unwrap();
         assert!(lock.is_some(), "oracle run must release the write lock when it returns");
 
         let _ = std::fs::remove_dir_all(&root);

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -132,6 +132,16 @@ fn main() -> anyhow::Result<()> {
         Cmd::Models(args) => models(&config, &args)?,
         Cmd::Reconcile(args) => reconcile(&config, &args)?,
         Cmd::Gc => {
+            // gc is a WRITER (it cascade-deletes dead generations and dead contexts), so it takes
+            // the per-repo write flock like every other CLI writer. That flock is exactly what
+            // makes gc's `generation != live` deadness predicate safe (batch 5):
+            // holding it proves no rebuild is mid-flight, so an ABOVE-live staging is
+            // abandoned, not in-progress — and every rebuild entry now takes the flock
+            // too (batch 6), so a gc racing a mid-flight rebuild serializes with it
+            // instead of sweeping the staged generation out from under it.
+            let lock_repo = rag_rat_core::locks::write_lock_repo_id(&config);
+            let _lock =
+                rag_rat_core::locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
             let db = open_index(&config)?;
             print_output(&db.garbage_collect()?)?;
         },

--- a/crates/rag-rat-core/src/index/edges/helpers.rs
+++ b/crates/rag-rat-core/src/index/edges/helpers.rs
@@ -273,6 +273,13 @@ pub(crate) fn all_symbols(conn: &Connection) -> anyhow::Result<Vec<IndexedSymbol
     // and the sole repo predicate on the view-less path. `active_repo_id` falls back to
     // `sole_repo_id` when no context is installed, matching the bare-open scope.
     let active_repo_id = crate::index::schema::active_repo_id(conn)?;
+    // Also pin the pool to the active GENERATION (A6): a full rebuild leaves the superseded
+    // generation's rows in place until gc, so a bare `repo_id` pin would pull a dead generation's
+    // symbols into the pool. `active_generation` reads the connection's scope context (the WRITE
+    // generation on the rebuild connection, so edge resolution during a rebuild resolves onto the
+    // symbols it is building) and falls back to the repo's LIVE generation from `repo_meta` on the
+    // view-less bare-open heal path — matching the `active_repo_id` fallback exactly.
+    let active_generation = crate::index::schema::active_generation(conn)?;
     let mut stmt = conn.prepare(
         "
         SELECT symbols.id, symbols.file_id, symbols.language, symbols.name, qn.value, symbols.kind,
@@ -281,11 +288,13 @@ pub(crate) fn all_symbols(conn: &Connection) -> anyhow::Result<Vec<IndexedSymbol
         FROM symbols
         JOIN files ON files.id = symbols.file_id
         LEFT JOIN name_strings qn ON qn.id = symbols.qualified_name_id
-        WHERE symbols.file_id IN (SELECT id FROM main.files WHERE repo_id = ?1)
+        WHERE symbols.file_id IN (
+                  SELECT id FROM main.files WHERE repo_id = ?1 AND generation = ?2
+              )
         ORDER BY qn.value
         ",
     )?;
-    let rows = stmt.query_map(rusqlite::params![active_repo_id], symbol_row)?;
+    let rows = stmt.query_map(rusqlite::params![active_repo_id, active_generation], symbol_row)?;
     collect_rows(rows)
 }
 pub(crate) fn symbol_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<IndexedSymbol> {

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -97,8 +97,9 @@ impl IndexDatabase {
         let has_test_code = chunks.iter().any(|pc| text_has_test_marker(&pc.chunk.text));
         let file_id = self.storage.connection().query_row(
             "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, generated, \
-             indexed_at_ms, indexed_revision, commit_sha, worktree_id, has_test_code, repo_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+             indexed_at_ms, indexed_revision, commit_sha, worktree_id, has_test_code, repo_id, \
+             generation)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
              RETURNING id",
             params![
                 path_string(path),
@@ -113,6 +114,8 @@ impl IndexDatabase {
                 &scope.worktree_id,
                 has_test_code,
                 self.active_repo_id,
+                // A6: heal writes land on the connection's live generation.
+                self.active_generation,
             ],
             |row| row.get::<_, i64>(0),
         )?;
@@ -150,15 +153,44 @@ impl IndexDatabase {
         graph: Option<&mut edges::FullRebuildGraph>,
     ) -> anyhow::Result<()> {
         let file = &prepared_file.file;
+        // Parser-failure routing (A6, P2 review): the FULL REBUILD (`graph.is_some()` — the same
+        // mode split the edge accumulator uses) STAGES its upserts/clears into the connection's
+        // temp table, published atomically with the flip by `apply_staged_parser_failures`. The
+        // per-wave commits land BEFORE the flip, so a direct write here would expose (and, on a
+        // tail failure, strand) an UNPUBLISHED generation's failure state to readers still scoped
+        // to the old generation. Incremental passes (`None`) write the LIVE generation in place,
+        // so they keep the direct upsert/clear (their `remove_file_in_scope` already cleared; the
+        // clear branch is the full-rebuild's clean-reparse path, a no-op for them).
+        let staged_rebuild = graph.is_some();
         let prepared = match &prepared_file.prepared {
             Ok(prepared) => prepared,
             Err(err) => {
-                self.insert_parser_failure(&file.relative_path, file.language, &err.to_string())?;
+                if staged_rebuild {
+                    self.stage_parser_failure(
+                        &file.relative_path,
+                        file.language,
+                        Some(&err.to_string()),
+                    )?;
+                } else {
+                    self.insert_parser_failure(
+                        &file.relative_path,
+                        file.language,
+                        &err.to_string(),
+                    )?;
+                }
                 return Ok(());
             },
         };
         if let Some(message) = &prepared.parser_failure {
-            self.insert_parser_failure(&file.relative_path, file.language, message)?;
+            if staged_rebuild {
+                self.stage_parser_failure(&file.relative_path, file.language, Some(message))?;
+            } else {
+                self.insert_parser_failure(&file.relative_path, file.language, message)?;
+            }
+        } else if staged_rebuild {
+            self.stage_parser_failure(&file.relative_path, file.language, None)?;
+        } else {
+            self.clear_parser_failure(&file.relative_path)?;
         }
         let path = path_string(&file.relative_path);
         // Precompute the file-level test-code flag (#77): impact_surface's "tests touching this
@@ -172,8 +204,9 @@ impl IndexDatabase {
             .connection()
             .prepare_cached(
                 "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, generated, \
-                 indexed_at_ms, indexed_revision, commit_sha, worktree_id, has_test_code, repo_id)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+                 indexed_at_ms, indexed_revision, commit_sha, worktree_id, has_test_code, \
+                 repo_id, generation)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
                  RETURNING id",
             )?
             .query_row(
@@ -190,6 +223,10 @@ impl IndexDatabase {
                     file.worktree_id,
                     has_test_code,
                     self.active_repo_id,
+                    // A6: the WRITE generation of this pass — N+1 for a full rebuild (staged
+                    // alongside the live generation, made live by the flip), the live generation
+                    // for incremental (written in place).
+                    self.active_generation,
                 ],
                 |row| row.get::<_, i64>(0),
             )?;

--- a/crates/rag-rat-core/src/index/file_rows.rs
+++ b/crates/rag-rat-core/src/index/file_rows.rs
@@ -23,14 +23,17 @@ impl IndexDatabase {
         self.remove_file_in_scope(Path::new(&path), "", worktree_id)?;
         self.storage.connection().execute(
             "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, generated, \
-             indexed_at_ms, indexed_revision, commit_sha, worktree_id, repo_id)
-             VALUES (?1, 'unknown', 'deleted', '', 0, 0, ?2, '', '', ?3, ?4)
-             ON CONFLICT(repo_id, path, commit_sha, worktree_id) DO UPDATE SET
+             indexed_at_ms, indexed_revision, commit_sha, worktree_id, repo_id, generation)
+             VALUES (?1, 'unknown', 'deleted', '', 0, 0, ?2, '', '', ?3, ?4, ?5)
+             ON CONFLICT(repo_id, path, commit_sha, worktree_id, generation) DO UPDATE SET
                 kind = 'deleted',
                 sha256 = '',
                 modified_at_ms = 0,
                 indexed_at_ms = excluded.indexed_at_ms",
-            params![path, now_ms(), worktree_id, self.active_repo_id],
+            // A6: the tombstone lands on the connection's live generation, and the ON CONFLICT
+            // target matches the V043 UNIQUE (repo_id, path, commit_sha, worktree_id,
+            // generation).
+            params![path, now_ms(), worktree_id, self.active_repo_id, self.active_generation],
         )?;
         self.mark_fts_dirty()?;
         Ok(())
@@ -48,6 +51,15 @@ impl IndexDatabase {
         // 'NameOnly' is the EdgeConfidence demotion the resolver applies to a target-less edge.
         let name_only_id = edges::intern_edge_string(self.storage.connection(), "NameOnly")?;
         let repo_id = self.active_repo_id.as_str();
+        // Every delete below carries the WRITER'S generation (A6, P2 review): the V043 UNIQUE
+        // admits one row per (repo, path, commit, worktree) PER GENERATION, so a scope key alone
+        // over-matches — a lockless heal or incremental replacement running mid-rebuild (its
+        // connection at the LIVE generation) would otherwise also delete the STAGED generation's
+        // freshly committed row for the same scope key, punching a hole in the generation about
+        // to be published. The writer's `active_generation` is live for heals/incremental and
+        // the staging target on the rebuild connection, so each writer removes only its own
+        // generation's rows.
+        let generation = self.active_generation;
         self.storage.connection().execute(
             "UPDATE edges_data
              SET to_symbol_id = NULL,
@@ -59,14 +71,16 @@ impl IndexDatabase {
                    AND main.files.commit_sha = ?2
                    AND main.files.worktree_id = ?3
                    AND main.files.repo_id = ?5
+                   AND main.files.generation = ?6
              )",
-            params![path, commit_sha, worktree_id, name_only_id, repo_id],
+            params![path, commit_sha, worktree_id, name_only_id, repo_id, generation],
         )?;
         self.storage.connection().execute(
             "DELETE FROM edges_data
              WHERE source_file_id IN (
                     SELECT id FROM main.files
                     WHERE path = ?1 AND commit_sha = ?2 AND worktree_id = ?3 AND repo_id = ?4
+                      AND generation = ?5
                 )
                 OR from_symbol_id IN (
                     SELECT symbols.id FROM symbols
@@ -75,8 +89,9 @@ impl IndexDatabase {
                       AND main.files.commit_sha = ?2
                       AND main.files.worktree_id = ?3
                       AND main.files.repo_id = ?4
+                      AND main.files.generation = ?5
                 )",
-            params![path, commit_sha, worktree_id, repo_id],
+            params![path, commit_sha, worktree_id, repo_id, generation],
         )?;
         // `parser_failures` is keyed by `(repo_id, path)` (V040). A LINKED-WORKTREE OVERLAY pass
         // must NOT delete: that would clear a REAL parse failure recorded for the same path
@@ -99,8 +114,9 @@ impl IndexDatabase {
                    AND main.files.commit_sha = ?2
                    AND main.files.worktree_id = ?3
                    AND main.files.repo_id = ?4
+                   AND main.files.generation = ?5
              )",
-            params![path, commit_sha, worktree_id, repo_id],
+            params![path, commit_sha, worktree_id, repo_id, generation],
         )?;
         // Deleting the chunks cascades (ON DELETE CASCADE, foreign_keys=ON) to git_chunk_blame,
         // chunk_embeddings, chunk_summaries, and chunk_text — so the gate skipping the full
@@ -113,21 +129,24 @@ impl IndexDatabase {
              WHERE file_id IN (
                 SELECT id FROM main.files
                 WHERE path = ?1 AND commit_sha = ?2 AND worktree_id = ?3 AND repo_id = ?4
+                  AND generation = ?5
              )",
-            params![path, commit_sha, worktree_id, repo_id],
+            params![path, commit_sha, worktree_id, repo_id, generation],
         )?;
         self.storage.connection().execute(
             "DELETE FROM symbols
              WHERE file_id IN (
                 SELECT id FROM main.files
                 WHERE path = ?1 AND commit_sha = ?2 AND worktree_id = ?3 AND repo_id = ?4
+                  AND generation = ?5
              )",
-            params![path, commit_sha, worktree_id, repo_id],
+            params![path, commit_sha, worktree_id, repo_id, generation],
         )?;
         self.storage.connection().execute(
             "DELETE FROM main.files
-             WHERE path = ?1 AND commit_sha = ?2 AND worktree_id = ?3 AND repo_id = ?4",
-            params![path, commit_sha, worktree_id, repo_id],
+             WHERE path = ?1 AND commit_sha = ?2 AND worktree_id = ?3 AND repo_id = ?4
+               AND generation = ?5",
+            params![path, commit_sha, worktree_id, repo_id, generation],
         )?;
         self.mark_fts_dirty()?;
         Ok(())

--- a/crates/rag-rat-core/src/index/fts.rs
+++ b/crates/rag-rat-core/src/index/fts.rs
@@ -105,6 +105,31 @@ impl IndexDatabase {
         if !self.fts_dirty()? && fts_source_revision.as_deref() == Some(content_revision.as_str()) {
             return Ok(());
         }
+        // NEVER rebuild while any SEARCHABLE chunk lacks its durable text row (A6, P2 review): a
+        // generation-staged full rebuild commits its waves BEFORE `build_chunk_text_store` runs,
+        // so on a FIRST index (no `chunk_text_dict` yet) the staged chunks carry inline
+        // `chunk_fts` rows whose text exists only in the REBUILDING connection's temp table.
+        // `rebuild_chunk_fts`'s 'delete-all' + re-derive from `chunk_text` would silently drop
+        // those rows from BM25 and the freshness stamp below would mark the loss clean —
+        // permanent missing rows in the published generation. Degrade instead: serve the current
+        // (possibly stale) FTS and leave the dirty/stale state in place, so the refresh re-fires
+        // once the text store is complete (the rebuild's own finalize records freshness for the
+        // fast path). The probe is deliberately "HAS an fts row we cannot re-derive" — not a bare
+        // "lacks text" — so a chunk with NEITHER row (never searchable; the re-derive would
+        // exclude it regardless) can never wedge freshness healing permanently. Runs only on the
+        // dirty/stale path, never steady-state.
+        let irreplaceable_fts_rows: bool = self.storage.connection().query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM main.chunks
+                 WHERE id IN (SELECT rowid FROM chunk_fts)
+                   AND id NOT IN (SELECT chunk_id FROM main.chunk_text)
+             )",
+            [],
+            |row| row.get(0),
+        )?;
+        if irreplaceable_fts_rows {
+            return Ok(());
+        }
         self.rebuild_fts()?;
         let refreshed_revision = self.meta("fts_source_revision")?;
         if refreshed_revision.as_deref() != Some(content_revision.as_str()) {

--- a/crates/rag-rat-core/src/index/git_history.rs
+++ b/crates/rag-rat-core/src/index/git_history.rs
@@ -137,14 +137,61 @@ pub(crate) fn prepare(root: &Path) -> anyhow::Result<PreparedGitHistory> {
     Ok(PreparedGitHistory { repo: Some(repo), commits, changes })
 }
 
+/// The history reload-gate CURSOR values (`git_history_indexed_head`/`_root`/`_shallow`) a row
+/// apply produces, held back for a deferred write (A6, batch-4 P2). The git rows themselves are
+/// keyed, INERT data — `is_history_current` and `status` treat the CURSORS as the authority, never
+/// bare row presence — so a generation-staged rebuild lands the bulky rows early (Phase 2) and
+/// writes these cursors inside the terminal flip transaction, keeping "what commit is this index
+/// at" consistent with the file generation the pointer publishes. `None` cursors = a non-git root
+/// (the apply cleared the tables; nothing to record).
+pub(crate) struct HistoryCursors {
+    head: String,
+    root_key: String,
+    shallow: bool,
+}
+
+/// Write the reload-gate cursors — the LAST step of a history apply, split out so the full
+/// rebuild can defer it into the terminal flip transaction while incremental/recovery paths write
+/// it immediately after their rows (live-in-place semantics).
+pub(crate) fn record_history_cursors(
+    conn: &Connection,
+    cursors: &HistoryCursors,
+) -> anyhow::Result<()> {
+    let repo_id = schema::active_repo_id(conn)?;
+    set_repo_meta(conn, &repo_id, "git_history_indexed_head", &cursors.head)?;
+    set_repo_meta(conn, &repo_id, "git_history_indexed_root", &cursors.root_key)?;
+    set_repo_meta(
+        conn,
+        &repo_id,
+        "git_history_indexed_shallow",
+        if cursors.shallow { "1" } else { "0" },
+    )?;
+    Ok(())
+}
+
 pub(crate) fn apply_prepared(
     conn: &Connection,
     root: &Path,
     prepared: PreparedGitHistory,
 ) -> anyhow::Result<GitHistoryIndexStatus> {
+    let (status, cursors) = apply_prepared_deferring_cursors(conn, root, prepared)?;
+    if let Some(cursors) = cursors {
+        record_history_cursors(conn, &cursors)?;
+    }
+    Ok(status)
+}
+
+/// [`apply_prepared`] minus the cursor write: lands the `git_commits`/`git_file_changes` rows +
+/// the `commit_fts` resync and RETURNS the cursors for the caller to record later — the
+/// generation-staged rebuild's rows-inert/cursors-last seam (A6, batch-4 P2).
+pub(crate) fn apply_prepared_deferring_cursors(
+    conn: &Connection,
+    root: &Path,
+    prepared: PreparedGitHistory,
+) -> anyhow::Result<(GitHistoryIndexStatus, Option<HistoryCursors>)> {
     let Some(repo) = prepared.repo else {
         clear(conn)?;
-        return status(conn, root);
+        return Ok((status(conn, root)?, None));
     };
 
     // `git_commits` / `git_file_changes` are direct-scoped since V040, so a history reindex of ONE
@@ -206,16 +253,11 @@ pub(crate) fn apply_prepared(
     // every repo searchable.
     crate::index::schema::rebuild_commit_fts(conn)?;
     // Reload-gate key: head + root + shallow flag. `is_history_current` skips the next reload
-    // only when all three still match and git_commits is non-empty.
-    set_repo_meta(conn, &repo_id, "git_history_indexed_head", &repo.head)?;
-    set_repo_meta(conn, &repo_id, "git_history_indexed_root", &root_key(root))?;
-    set_repo_meta(
-        conn,
-        &repo_id,
-        "git_history_indexed_shallow",
-        if repo.shallow { "1" } else { "0" },
-    )?;
-    status(conn, root)
+    // only when all three still match and git_commits is non-empty. Returned for the caller to
+    // record — immediately (`apply_prepared`) or deferred into the rebuild's terminal txn.
+    let cursors =
+        HistoryCursors { head: repo.head.clone(), root_key: root_key(root), shallow: repo.shallow };
+    Ok((status(conn, root)?, Some(cursors)))
 }
 
 pub fn index(conn: &Connection, root: &Path) -> anyhow::Result<GitHistoryIndexStatus> {

--- a/crates/rag-rat-core/src/index/git_meta.rs
+++ b/crates/rag-rat-core/src/index/git_meta.rs
@@ -30,6 +30,35 @@ impl IndexDatabase {
         git_history::apply_prepared(self.storage.connection(), root, prepared)
     }
 
+    /// [`Self::apply_prepared_git_history`] minus the reload-gate cursor write — the
+    /// generation-staged rebuild's rows-inert/cursors-last seam (A6, batch-4 P2): the bulky
+    /// `git_commits`/`git_file_changes` rows land in Phase 2 (keyed, inert data — no reader
+    /// treats row presence alone as authority), while the returned cursors are recorded inside
+    /// the terminal flip transaction via [`Self::record_git_history_cursors`], so "what commit
+    /// is this index at" flips atomically with the file generation.
+    pub(super) fn apply_prepared_git_history_deferring_cursors(
+        &self,
+        root: &Path,
+        handle: JoinHandle<anyhow::Result<git_history::PreparedGitHistory>>,
+    ) -> anyhow::Result<Option<git_history::HistoryCursors>> {
+        let prepared = join_git_history_prepare(handle)?;
+        let (_status, cursors) = git_history::apply_prepared_deferring_cursors(
+            self.storage.connection(),
+            root,
+            prepared,
+        )?;
+        Ok(cursors)
+    }
+
+    /// Record deferred history reload-gate cursors (see
+    /// [`Self::apply_prepared_git_history_deferring_cursors`]).
+    pub(super) fn record_git_history_cursors(
+        &self,
+        cursors: &git_history::HistoryCursors,
+    ) -> anyhow::Result<()> {
+        git_history::record_history_cursors(self.storage.connection(), cursors)
+    }
+
     pub(super) fn git_history_status(&self) -> anyhow::Result<GitHistoryIndexStatus> {
         let Some(root) = self.storage.source_root() else {
             return git_history::status(self.storage.connection(), Path::new("."));

--- a/crates/rag-rat-core/src/index/graph_index.rs
+++ b/crates/rag-rat-core/src/index/graph_index.rs
@@ -266,6 +266,13 @@ impl IndexDatabase {
         // consolidated DB; the content-derived `stable_id` collapses cross-scope duplicates
         // into one logical symbol with per-scope members, and downstream reads stay
         // scope-filtered via the `files` view.
+        // Filter `main.files.generation` to the ACTIVE generation (A6): a full rebuild leaves the
+        // superseded generation's file rows in place (swept lazily by gc), so a bare `repo_id`
+        // predicate would fold BOTH the dead and the live generation's symbols into one grouping.
+        // `self.active_generation` is the WRITE generation on the rebuild connection — which the
+        // rebuild flips to LIVE and carries forward every live overlay onto BEFORE this runs, so
+        // filtering it folds the base scope + every carried-forward overlay of the live generation
+        // and nothing dead. On an incremental pass it is the live generation, unchanged behavior.
         let mut stmt = conn.prepare(
             "
             SELECT symbols.id, main.files.path, symbols.language, symbols.name,
@@ -274,12 +281,12 @@ impl IndexDatabase {
             FROM main.symbols AS symbols
             JOIN main.files ON main.files.id = symbols.file_id
             LEFT JOIN main.name_strings qn ON qn.id = symbols.qualified_name_id
-            WHERE main.files.repo_id = ?1
+            WHERE main.files.repo_id = ?1 AND main.files.generation = ?2
             ORDER BY symbols.language, main.files.path, symbols.name, qn.value,
                      symbols.kind, symbols.signature, symbols.start_byte, symbols.end_byte
             ",
         )?;
-        let mut rows = stmt.query(params![self.active_repo_id])?;
+        let mut rows = stmt.query(params![self.active_repo_id, self.active_generation])?;
         let mut current: Option<(LogicalSymbolKey, Vec<LogicalSymbolMemberRow>)> = None;
         while let Some(row) = rows.next()? {
             let member = LogicalSymbolMemberRow {
@@ -416,10 +423,18 @@ impl IndexDatabase {
             // the same set the repopulate below (over the repo-scoped `files`
             // view) re-derives. Within the repo this matches the prior wholesale behavior; only
             // sibling repos are now spared.
+            // The `generation` predicate (A6) makes the sentence above literally true: the wipe
+            // removes exactly the set the repopulate re-derives (the ACTIVE generation's edges).
+            // Without it, a heal would also wipe a superseded generation's edges (merely early gc)
+            // — and, in the rare concurrent case of a version-bump heal racing another
+            // connection's staged rebuild, the STAGED generation's edges, which nothing would
+            // re-resolve.
             self.storage.connection().execute(
                 "DELETE FROM edges_data
-                  WHERE source_file_id IN (SELECT id FROM main.files WHERE repo_id = ?1)",
-                params![self.active_repo_id],
+                  WHERE source_file_id IN (
+                      SELECT id FROM main.files WHERE repo_id = ?1 AND generation = ?2
+                  )",
+                params![self.active_repo_id, self.active_generation],
             )?;
             // Repopulate the per-package import scope BEFORE re-resolving (#61). A bare
             // version-bump re-resolve would re-derive `import_scope_*` on the new edges

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -201,16 +201,81 @@ impl IndexDatabase {
         Ok((db, content_changed))
     }
 
+    /// Standalone full-corpus indexing into the CURRENT context — no generation staging, no
+    /// pointer flip: the connection's `active_generation` is written directly, so this is only
+    /// correct on a scope+generation with no pre-existing file rows (a fresh index). The wave
+    /// loop shares the full rebuild's temp-table staging (`graph.is_some()` routing), so this
+    /// finalize must publish everything the rebuild's terminal transaction would (batch 7 P2:
+    /// staged parser failures were silently dropped here — a standalone pass's newly failing
+    /// files vanished from `parser_failures`, and coverage/repo-brief underreported, until some
+    /// later full rebuild happened to publish the staging). Unlike the rebuild there is no flip
+    /// to defer to: this path operates on the LIVE generation, so its failure state is not
+    /// staged-generation authority — it publishes atomically with this pass's own edges.
     pub fn index_targets(&self, config: &Config) -> anyhow::Result<()> {
-        self.index_targets_with_progress(config, &mut |_| {})?;
+        let (_, graph) = self.index_targets_with_progress(config, &mut |_| {})?;
+        // The standalone twin of the rebuild's Phase-2 + terminal tail, in ONE short transaction
+        // (batch 6 moved base edges + package roots out of the wave loop; batch 7 completed the
+        // twin), mirroring the rebuild's order. Step by step against `rebuild_with_progress`:
+        // - build_chunk_text_store: first-index dict training — `insert_chunks` staged the text
+        //   into `temp.rebuild_chunk_text` when no dict existed; a no-op once a dict exists.
+        // - finalize_base_edges: base package roots + accumulated-edge resolution (batch 6).
+        // - rebuild_logical_symbols: the open-time graph heal re-derives EDGES only, so without
+        //   this fold the standalone pass's symbols stay invisible to symbol_lookup/graph nav (the
+        //   `finalize_overlay_refresh` precedent — every finalize that writes symbols folds).
+        // - apply_staged_parser_failures: THE batch-7 finding — the wave loop stages failures
+        //   (`graph.is_some()` routing), so the finalize must publish them; at this connection's
+        //   own (live) generation, atomic with its edges (no flip exists to defer to).
+        // - refresh_clone_token_df: the waves wrote fingerprints under `BumpDf(false)`, whose
+        //   contract is "df is recomputed authoritatively at finalize" — without this the
+        //   standalone path left df stale/empty.
+        // - sync_fts + the graph/flags marks: chunk_fts was written inline and the edges/flags were
+        //   just derived in full, so record freshness like the rebuild does — otherwise the very
+        //   next open pays a full (safe but wasted) edge re-derive heal and an FTS rebuild.
+        // NOT here, deliberately: the generation carry-forwards, overlay re-resolution, git
+        // history/meta/cursors, source_root, the live-generation pointer, and the model seed are
+        // PUBLISH authority — a standalone pass writes the live generation in place and owns no
+        // flip, no git authority, and no checkout move.
+        self.storage.execute_batch("BEGIN IMMEDIATE")?;
+        let result = (|| -> anyhow::Result<()> {
+            self.build_chunk_text_store()?;
+            self.finalize_base_edges(config, graph)?;
+            self.rebuild_logical_symbols()?;
+            self.apply_staged_parser_failures(self.active_generation)?;
+            self.refresh_clone_token_df()?;
+            self.sync_fts()?;
+            self.mark_graph_index_current()?;
+            self.mark_generated_flags_current()
+        })();
+        if result.is_err() {
+            let _ = self.storage.execute_batch("ROLLBACK");
+            return result;
+        }
+        self.storage.execute_batch("COMMIT")?;
         Ok(())
+    }
+
+    /// Write the ACTIVE (base) scope's `packages` rows + the global `local_crate_roots` union, then
+    /// resolve and insert every accumulated base edge against those roots (the full-rebuild fast
+    /// path — [`edges::resolve_and_insert_edges`] computes each file's package from the
+    /// just-written rows at load time, so the rows MUST land first). NO transaction of its own
+    /// — the caller wraps it. `rebuild` runs this INSIDE its terminal publish transaction so
+    /// the generation-less `packages`/`local_crate_roots` writes are invisible to a concurrent
+    /// reader/heal until the pointer flips and roll back with a failed tail (batch 6 P2, #4);
+    /// the standalone `index_targets` runs it in a short transaction of its own.
+    pub(super) fn finalize_base_edges(
+        &self,
+        config: &Config,
+        graph: edges::FullRebuildGraph,
+    ) -> anyhow::Result<()> {
+        self.refresh_packages(&config.root)?;
+        edges::resolve_and_insert_edges(self.storage.connection(), graph)
     }
 
     pub(super) fn index_targets_with_progress<F>(
         &self,
         config: &Config,
         progress: &mut F,
-    ) -> anyhow::Result<usize>
+    ) -> anyhow::Result<(usize, edges::FullRebuildGraph)>
     where
         F: FnMut(IndexProgress),
     {
@@ -232,36 +297,110 @@ impl IndexDatabase {
         let wave_size = index_wave_size();
         let mut graph = edges::FullRebuildGraph::default();
         let mut done = 0usize;
+        // Per-connection staging for the generation-less `parser_failures` mutations this pass
+        // produces (A6, P2 review): the waves below commit BEFORE the flip, so upserting/clearing
+        // the real table here would expose an unpublished generation's failure state. Insert
+        // routes stage into this table; `apply_staged_parser_failures` publishes it — inside the
+        // rebuild's terminal flip transaction, or the standalone `index_targets`' own finalize
+        // transaction (batch 7). `message` NULL = clean parse (clear at publish).
+        self.storage.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS rebuild_parser_failures(
+                 path TEXT PRIMARY KEY,
+                 language TEXT NOT NULL,
+                 message TEXT
+             );
+             DELETE FROM temp.rebuild_parser_failures;",
+        )?;
+        // The first-index chunk-text staging table lives with the wave loop that writes it
+        // (batch 7): BOTH entries — the full rebuild and the standalone `index_targets` — run
+        // waves whose `insert_chunks` stages text here when no dict exists yet, so the creation
+        // belongs to the shared loop, not the rebuild alone (the standalone path used to error
+        // "no such table" on a fresh, dict-less index).
+        self.prepare_rebuild_scratch_tables()?;
         for wave in files.chunks(wave_size) {
             let prepared = prepare_files_with_progress(wave, progress, done, total)?;
-            for prepared_file in &prepared {
-                done += 1;
-                if should_report_file_progress(done, total) {
-                    progress(IndexProgress::IndexingFile {
-                        current: done,
-                        total,
-                        path: prepared_file.file.relative_path.clone(),
-                        language: prepared_file.file.language,
-                        kind: prepared_file.file.kind,
-                    });
+            // A6: commit each wave in its OWN short transaction. A full rebuild stages a fresh file
+            // GENERATION (`self.active_generation`, set to N+1 by the rebuild's `set_context`)
+            // ALONGSIDE the still-live one, so it must NOT hold the shared DB's write lock across
+            // the whole file set — a sibling repo's short write (a memory create) has
+            // to be able to slip in between waves within the busy-timeout slice (spec
+            // §3.3). Readers stay on the live generation until the flip; a wave that
+            // fails rolls back just its own batch, and a torn
+            // rebuild's committed-but-never-flipped generation is swept lazily by gc.
+            //
+            // INTERLEAVED SAME-REPO WRITERS ARE SAFE HERE (A6, P2 review — the proof, not a
+            // hand-wave). The per-repo advisory flock covers the CLI/watcher writers, but NOT
+            // every write path (MCP `memory_create`/`memory_update` and the read-path heals go
+            // through `open_config` locklessly), so a same-repo write CAN land between wave
+            // commits. The proof splits by what the writer touches:
+            // - DISJOINT-TABLE writers — this proof's own scope (regression test
+            //   `a_memory_written_mid_rebuild_survives_the_flip_intact`): MEMORY writes touch only
+            //   `repo_memories`/bindings/tags/fts, none of the rebuild's tables. A binding captured
+            //   against the LIVE generation's symbol/chunk ROWIDS goes stale when the flip + gc
+            //   retire those rows — the ORDINARY reindex lifecycle those bindings already live with
+            //   (rowids re-mint on every incremental pass too): `memory_validate` re-anchors by
+            //   content hash / the generation-stable `logical_symbol_id`. (The pre-A6
+            //   mega-transaction did not make such a write safe — it made it FAIL with SQLITE_BUSY
+            //   after the busy_timeout; landing it and re-anchoring is the designed behavior, not a
+            //   regression.)
+            // - FILES-ADJACENT writers (heals, incremental replacement, gc) are NOT covered by
+            //   disjointness; they get the same GENERATION DISCIPLINE the rebuild uses. Their
+            //   deletes carry the writer's own generation (`remove_file_in_scope` — a
+            //   live-generation heal can never remove a staged row for the same scope key); gc's
+            //   deadness predicate is `generation != live` UNDER THE PER-REPO WRITE FLOCK (batch 5:
+            //   a collector holding the flock knows no rebuild is mid-flight, so an above-live
+            //   staging is abandoned, not in-progress — the flockless-safe `< live` form is the
+            //   fallback; see `gc.rs`, plus the CLI `gc` flock belt). Every rebuild ENTRY acquires
+            //   that flock (`rebuild_with_progress`, batch 6), so the precondition holds by
+            //   construction. And every reader resolves `files` through a repo+generation view
+            //   (`set_context` on config opens, `write_repo_generation_view` on bare opens), so the
+            //   staged generation is invisible until the flip. Writes they DO make land at the live
+            //   generation and die with it at gc after the flip (wasted work, not corruption);
+            //   `target` is allocated strictly above both the row-MAX and the live pointer, so
+            //   staged keys never collide.
+            self.storage.execute_batch("BEGIN IMMEDIATE")?;
+            let wave_result: anyhow::Result<()> = (|| {
+                for prepared_file in &prepared {
+                    done += 1;
+                    if should_report_file_progress(done, total) {
+                        progress(IndexProgress::IndexingFile {
+                            current: done,
+                            total,
+                            path: prepared_file.file.relative_path.clone(),
+                            language: prepared_file.file.language,
+                            kind: prepared_file.file.kind,
+                        });
+                    }
+                    // chunk_fts is written inline from the in-memory chunk text (#77 Phase 2): it's
+                    // contentless now, so there is no content table for a closing 'rebuild' to
+                    // re-read, and the in-memory text is available regardless of whether the
+                    // chunks.text column still exists. `finalize_full_rebuild_fts` then only
+                    // rebuilds commit_fts.
+                    self.insert_prepared_file(prepared_file, Some(&mut graph))?;
                 }
-                // chunk_fts is written inline from the in-memory chunk text (#77 Phase 2): it's
-                // contentless now, so there is no content table for a closing 'rebuild' to re-read,
-                // and the in-memory text is available regardless of whether the chunks.text column
-                // still exists. `finalize_full_rebuild_fts` then only rebuilds commit_fts.
-                self.insert_prepared_file(prepared_file, Some(&mut graph))?;
+                Ok(())
+            })();
+            if let Err(err) = wave_result {
+                let _ = self.storage.execute_batch("ROLLBACK");
+                return Err(err);
             }
+            self.storage.execute_batch("COMMIT")?;
+            // Test seam: a barrier between committed waves lets a concurrent reader observe the
+            // staged (but not-yet-live) generation. Keyed by THIS connection's database path so
+            // parallel same-process tests (libtest / coverage) never trip each other's barrier.
+            // No-op in production.
+            #[cfg(test)]
+            crate::index::rebuild::run_after_wave_commit(self.database_path());
             // `prepared` (this wave's chunk texts / symbols / edge candidates) drops here.
         }
-        // Per-package import scope (#61): write the active scope's `packages` rows + the global
-        // `local_crate_roots` union now — files are inserted, but the resolve below has not run, so
-        // it computes each file's package from these fresh rows at load time. (`set_context`
-        // installs the `files` scope view at open, so the scoped reads in the resolve see
-        // these rows.)
-        self.refresh_packages(&config.root)?;
-        edges::resolve_and_insert_edges(self.storage.connection(), graph)?;
-
-        Ok(total)
+        // Base-edge resolution + package roots NO LONGER run here (batch 6 P2, #4). The full
+        // rebuild carries the accumulated `graph` out to its TERMINAL publish transaction
+        // (`finalize_base_edges`), where `refresh_packages` writes the generation-less
+        // `packages`/`local_crate_roots` and the resolve inserts the base edges — all atomic with
+        // the pointer flip, so a concurrent reader/heal on the old generation never sees the new
+        // package map, and a failed tail rolls the whole lot back. The waves above committed only
+        // the staged-generation file/chunk/symbol rows (inert until the flip).
+        Ok((total, graph))
     }
 
     /// Returns `(file_count, manifest_in_change_set)`. The manifest flag is true when any changed
@@ -365,15 +504,18 @@ impl IndexDatabase {
             // commit share `commit_sha`/`worktree_id`, and without `repo_id` the
             // committed-row probe below would see a SIBLING repo's committed row and
             // delete THIS repo's overlay as if its own base row existed.
+            // Also generation-qualified (A6): the heal operates on THIS connection's live
+            // generation only — a staged or superseded generation's overlay rows are the
+            // rebuild's / gc's business.
             let mut stmt = conn.prepare(
                 "SELECT id, path, sha256 FROM main.files
                  WHERE repo_id = ?1 AND worktree_id = ?2 AND worktree_id != '' AND kind != \
-                 'deleted'",
+                 'deleted' AND generation = ?3",
             )?;
-            let rows = stmt
-                .query_map(params![self.active_repo_id, self.active_worktree_id], |row| {
-                    Ok((row.get(0)?, row.get(1)?, row.get(2)?))
-                })?;
+            let rows = stmt.query_map(
+                params![self.active_repo_id, self.active_worktree_id, self.active_generation],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )?;
             rows.collect::<Result<Vec<_>, _>>()?
         };
         let mut healed = 0usize;
@@ -382,9 +524,13 @@ impl IndexDatabase {
                 continue; // genuinely dirty — the overlay is the canonical row
             }
             let committed_exists: bool = self.storage.connection().query_row(
+                // Generation-qualified (A6): only a committed row at THIS connection's live
+                // generation can take over from the overlay — a staged or superseded generation's
+                // committed row must not trigger deleting a live overlay.
                 "SELECT EXISTS(SELECT 1 FROM main.files
-                 WHERE repo_id = ?1 AND path = ?2 AND commit_sha = ?3 AND worktree_id = '')",
-                params![self.active_repo_id, path, self.active_commit_sha],
+                 WHERE repo_id = ?1 AND path = ?2 AND commit_sha = ?3 AND worktree_id = ''
+                   AND generation = ?4)",
+                params![self.active_repo_id, path, self.active_commit_sha, self.active_generation],
                 |row| row.get(0),
             )?;
             if committed_exists {

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -37,11 +37,17 @@ impl IndexDatabase {
         // (read/MCP/init open) still takes the real lock. Compatible/Newer/Dirty/Missing
         // need no lock — `ensure_compatible_or_migrate` returns or refuses without writing.
         if schema::status(storage.connection())?.state == schema::SchemaState::Older {
+            // A6: the GLOBAL schema lock, not a per-repo write lock — a migration rewrites the
+            // shared ladder (every repo's tables), so it serializes across all repos.
+            // Reentrant on the holding thread, so a CLI write command that opens under
+            // its per-repo write lock and migrates here takes a DIFFERENT (schema) lock
+            // without self-deadlocking.
             let _lock =
-                crate::locks::WriteLock::acquire_timeout(path, SCHEMA_MIGRATE_LOCK_TIMEOUT)?
+                crate::locks::WriteLock::acquire_schema_timeout(path, SCHEMA_MIGRATE_LOCK_TIMEOUT)?
                     .ok_or_else(|| {
                         anyhow::anyhow!(
-                            "timed out waiting for the index write lock to auto-migrate the schema"
+                            "timed out waiting for the schema-migration lock to auto-migrate the \
+                             schema"
                         )
                     })?;
             schema::ensure_compatible_or_migrate(storage.connection())?;
@@ -62,13 +68,26 @@ impl IndexDatabase {
         if let Some(root) = repo_meta(storage.connection(), &repo_id, "source_root")? {
             storage.set_source_root(PathBuf::from(root));
         }
+        // Stamp the sole repo's LIVE generation (a heal write on this connection lands on the
+        // live generation, not 0) AND install the repo+generation `files` view (A6, P2 review):
+        // `set_context` is never called on a bare open, so without a view every unqualified
+        // `files` join (lexical search, status counts, the graph heal) resolved to raw
+        // `main.files` — which post-A6 also holds STAGED (pre-flip) and SUPERSEDED (pre-gc)
+        // generations. This is the round-6 bare-open class on the generation axis; the view
+        // closes it for every reader on this connection at once, while deliberately keeping the
+        // bare open's CROSS-SCOPE semantics (all commits/worktrees of the sole repo — #360
+        // pins that `open` counts more than the base-scoped `open_config`).
+        let active_generation = schema::live_files_generation(storage.connection(), &repo_id)?;
+        write_repo_generation_view(storage.connection(), &repo_id, active_generation)?;
         let db = Self {
             storage,
             active_repo_id: repo_id,
             active_commit_sha: String::new(),
             active_worktree_id: String::new(),
+            active_generation,
             github: github::GitHubContext::default(),
             config: None,
+            _identity_lock: None,
         };
         if check_graph {
             db.ensure_graph_index_current()?;
@@ -84,10 +103,12 @@ impl IndexDatabase {
             active_repo_id: String::new(),
             active_commit_sha: String::new(),
             active_worktree_id: String::new(),
+            active_generation: 0,
             // Real usage: resolve the GitHub repo context from the local `gh` CLI here, at the
             // boundary. rebuild/open (used by tests and the bare index command) leave it offline.
             github: github::GitHubContext::from_gh(),
             config: Some(config.clone()),
+            _identity_lock: None,
         };
         db.storage.set_source_root(config.root.clone());
         // Register/adopt BEFORE anything repo-scoped runs, then install the scope context so the
@@ -133,6 +154,35 @@ impl IndexDatabase {
             Err(err) if err.is_absent() => schema::sole_repo_id(conn)?,
             Err(err) => return Err(err.into()),
         };
+        // FENCE-GAP CLOSE (A6, batch-5 P2): a LOCK-DISCIPLINED writer's held lock must match the
+        // repo id it writes under. The entry lock was keyed by the id DERIVED before open; if the
+        // clone was unshallowed in between, the id just resolved (and upgraded to) is a DIFFERENT
+        // discriminator — the rest of this command would write the portable repo's rows under
+        // only the stale `local:` lock, concurrent with any fresh portable-lock writer. Detect
+        // "I hold SOME per-repo lock for this DB, but not the resolved id's" and acquire the
+        // resolved id's lock for this connection's lifetime. Lockless openers (MCP reads/heals)
+        // hold nothing and stay lockless. This is the out-of-order edge of the canonical lock
+        // order (the resolved portable id sorts before the held `local:` one), so it is BOUNDED —
+        // a timeout is a retryable error, never a hang (see the locks module doc).
+        let db_path = self.storage.database_path().to_path_buf();
+        if crate::locks::thread_holds_any_repo_write_lock(&db_path)
+            && !crate::locks::thread_holds_write_lock(&db_path, &repo_id)
+        {
+            self._identity_lock = Some(
+                crate::locks::WriteLock::acquire_timeout(
+                    &db_path,
+                    &repo_id,
+                    SCHEMA_MIGRATE_LOCK_TIMEOUT,
+                )?
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "the repo identity changed to {repo_id} underneath this command (its \
+                         write lock is keyed by the old identity) and the new identity's lock is \
+                         still held elsewhere; re-run the command"
+                    )
+                })?,
+            );
+        }
         self.active_repo_id = repo_id;
         Ok(())
     }
@@ -184,8 +234,10 @@ impl IndexDatabase {
             active_repo_id: repo_id,
             active_commit_sha: String::new(),
             active_worktree_id: String::new(),
+            active_generation: 0,
             github: github::GitHubContext::from_gh(),
             config: Some(config.clone()),
+            _identity_lock: None,
         };
         // Install the scope context BEFORE the heal-owed gates: `set_context` mirrors the resolved
         // `repo_id` into `temp.connection_context` (writable even on a read-only main DB), so the
@@ -239,7 +291,9 @@ impl IndexDatabase {
             },
             schema::SchemaState::Compatible => {},
             schema::SchemaState::Missing | schema::SchemaState::Older => {
-                schema::apply(storage.connection())?;
+                // Every schema-APPLY path serializes on the GLOBAL schema lock and RE-CHECKS
+                // under it (the racer may have finished) — see `apply_schema_under_lock`.
+                Self::apply_schema_under_lock(path, storage.connection())?;
             },
         }
         ai::ensure_model_manifest(storage.connection())?;
@@ -263,20 +317,92 @@ impl IndexDatabase {
     /// source-root restore therefore move to `rebuild`, out of this low-level helper.
     pub(super) fn create_or_migrate(path: &Path) -> anyhow::Result<Self> {
         let storage = IndexConnection::open(path)?;
-        schema::apply(storage.connection())?;
+        // Double-checked schema apply (batch-4 P2): two repos' concurrent `index --full` against
+        // one shared Missing/Older DB reach this constructor simultaneously, and an un-serialized
+        // `schema::apply` races itself (`add_column_if_missing`'s check-then-ALTER trips duplicate
+        // -column errors; the dirty-marker dance churns). Skip when already Compatible — `apply`
+        // on a Compatible DB is a proven data no-op (the full-ladder replay tests), so skipping is
+        // both safe and cheaper — else serialize on the GLOBAL schema lock and re-check under it.
+        if schema::status(storage.connection())?.state != schema::SchemaState::Compatible {
+            Self::apply_schema_under_lock(path, storage.connection())?;
+        }
         Ok(Self {
             storage,
             active_repo_id: String::new(),
             active_commit_sha: String::new(),
             active_worktree_id: String::new(),
+            active_generation: 0,
             github: github::GitHubContext::default(),
             config: None,
+            _identity_lock: None,
         })
     }
 
+    /// Run `schema::apply` under the GLOBAL schema-migration lock, RE-CHECKING the state once the
+    /// lock is held (double-checked: the concurrent applier we serialized behind may have finished
+    /// the work, in which case this is a no-op). EVERY path that can APPLY schema goes through
+    /// here or `open_and_migrate`'s equivalent (batch-4 P2 rule) — the schema ladder is shared by
+    /// all repos in the DB file, so appliers must serialize across repos, which the per-repo write
+    /// flock deliberately does not do.
+    fn apply_schema_under_lock(path: &Path, conn: &rusqlite::Connection) -> anyhow::Result<()> {
+        let _lock =
+            crate::locks::WriteLock::acquire_schema_timeout(path, SCHEMA_MIGRATE_LOCK_TIMEOUT)?
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "timed out waiting for the schema-migration lock to apply the schema"
+                    )
+                })?;
+        if schema::status(conn)?.state != schema::SchemaState::Compatible {
+            schema::apply(conn)?;
+        }
+        Ok(())
+    }
+
     pub fn set_context(&mut self, commit_sha: &str, worktree_id: &str) -> anyhow::Result<()> {
+        // A reader / incremental open scopes to the repo's LIVE generation (A6) — the pointer a
+        // full rebuild flips once its staged generation is complete. The rebuild connection
+        // overrides this with its WRITE generation via `set_context_at_generation`.
+        let generation =
+            schema::live_files_generation(self.storage.connection(), &self.active_repo_id)?;
+        self.set_context_at_generation(commit_sha, worktree_id, generation)
+    }
+
+    /// Install the scope VIEW for an arbitrary `(commit, worktree)` at an explicit generation
+    /// WITHOUT touching this connection's `active_*` fields — the rebuild tail's overlay
+    /// re-resolution seam (A6). The terminal flip transaction swaps the view to each carried
+    /// overlay scope (so `resolve_overlay_edges` resolves that overlay's edges against its view
+    /// over the freshly staged base), then back to the base scope; the connection's own identity
+    /// (`active_commit_sha` / `active_worktree_id` / `active_generation`) must stay the base
+    /// rebuild's throughout, so the writer-side stamps and `active_scope_is_linked_overlay`
+    /// gates are unaffected by the temporary view swaps.
+    pub(super) fn install_view_for_scope(
+        &self,
+        commit_sha: &str,
+        worktree_id: &str,
+        generation: i64,
+    ) -> rusqlite::Result<()> {
+        write_scope_view(self.storage.connection(), &ScopeContext {
+            repo_id: self.active_repo_id.clone(),
+            commit_sha: commit_sha.to_string(),
+            worktree_id: worktree_id.to_string(),
+            generation,
+        })
+    }
+
+    /// [`set_context`] pinned to an EXPLICIT `files.generation` — the full rebuild's seam (A6). The
+    /// rebuild installs the scope view (and stamps every direct-scoped write, via
+    /// `self.active_generation`) at the WRITE generation N+1 it is building, so its own
+    /// edge-resolution / logical-symbol reads see only the generation being built; concurrent
+    /// readers stay on the live generation N until the flip.
+    pub(crate) fn set_context_at_generation(
+        &mut self,
+        commit_sha: &str,
+        worktree_id: &str,
+        generation: i64,
+    ) -> anyhow::Result<()> {
         self.active_commit_sha = commit_sha.to_string();
         self.active_worktree_id = worktree_id.to_string();
+        self.active_generation = generation;
         // The repo dimension comes from `self.active_repo_id` (resolved at open), not re-derived
         // from the connection — a consolidated DB's sole-repo fallback would be ambiguous. This is
         // the one caller that scopes to a SPECIFIC repo without reading it back from the context.
@@ -284,6 +410,7 @@ impl IndexDatabase {
             repo_id: self.active_repo_id.clone(),
             commit_sha: commit_sha.to_string(),
             worktree_id: worktree_id.to_string(),
+            generation,
         })?;
         Ok(())
     }
@@ -345,10 +472,15 @@ pub fn install_worktree_scope_view(
     cwd: &Path,
 ) -> anyhow::Result<()> {
     let (commit_sha, worktree_id) = resolve_worktree_scope(config_root, Some(cwd));
+    // A6: this raw-conn READ installer scopes to the repo's LIVE generation from `repo_meta` (an
+    // empty `repo_id` — the sibling-safe "match nothing" case — reads generation 0, still matching
+    // nothing, since no row carries the empty repo).
+    let generation = schema::live_files_generation(conn, repo_id)?;
     write_scope_view(conn, &ScopeContext {
         repo_id: repo_id.to_string(),
         commit_sha,
         worktree_id,
+        generation,
     })?;
     Ok(())
 }
@@ -375,6 +507,10 @@ pub(crate) struct ScopeContext {
     pub repo_id: String,
     pub commit_sha: String,
     pub worktree_id: String,
+    /// The `files.generation` the view filters on (A6): the repo's LIVE generation for a
+    /// reader/incremental open, the WRITE generation N+1 for the connection driving a full
+    /// rebuild.
+    pub generation: i64,
 }
 
 /// Install the scope view on a RAW connection that has no `IndexDatabase` to carry
@@ -392,10 +528,12 @@ pub(crate) fn install_scope_view(
     worktree_id: &str,
 ) -> rusqlite::Result<()> {
     let repo_id = schema::active_repo_id(conn)?;
+    let generation = schema::active_generation(conn)?;
     write_scope_view(conn, &ScopeContext {
         repo_id,
         commit_sha: commit_sha.to_string(),
         worktree_id: worktree_id.to_string(),
+        generation,
     })
 }
 
@@ -415,10 +553,18 @@ fn write_scope_view(conn: &rusqlite::Connection, ctx: &ScopeContext) -> rusqlite
     stmt.execute(params![schema::CONNECTION_CONTEXT_REPO_KEY, ctx.repo_id])?;
     stmt.execute(params!["commit_sha", ctx.commit_sha])?;
     stmt.execute(params!["worktree_id", ctx.worktree_id])?;
+    // A6: the file generation the view filters on. Stored as TEXT beside the other context keys;
+    // the INTEGER `generation` column's numeric affinity coerces it back in the comparisons
+    // below.
+    stmt.execute(params![schema::CONNECTION_CONTEXT_GENERATION_KEY, ctx.generation.to_string()])?;
+    drop(stmt);
 
-    // Every branch (and the shadowing sub-select) is repo-scoped: `worktree_id`/`commit_sha` alone
-    // are not globally unique across repos (forks share a commit; the empty base scope is shared),
-    // so the `repo_id` predicate is what keeps a sibling repo's rows out of the view.
+    // Every branch (and the shadowing sub-select) is repo- AND generation-scoped (A3 + A6):
+    // `worktree_id`/`commit_sha` alone are not globally unique across repos (forks share a commit;
+    // the empty base scope is shared), so the `repo_id` predicate keeps a sibling repo's rows out;
+    // the `generation` predicate keeps a superseded full-rebuild generation (dead until gc sweeps
+    // it) out, so a reader sees the COMPLETE old generation until the rebuild flips
+    // `live_files_generation`, then the complete new one — never a half-built mix.
     conn.execute_batch(
         "
             DROP VIEW IF EXISTS temp.files;
@@ -427,6 +573,8 @@ fn write_scope_view(conn: &rusqlite::Connection, ctx: &ScopeContext) -> rusqlite
          indexed_revision, commit_sha, worktree_id, has_test_code
             FROM main.files
             WHERE repo_id = (SELECT value FROM temp.connection_context WHERE key = 'repo_id')
+              AND generation = (SELECT value FROM temp.connection_context WHERE key = \
+         'files_generation')
               AND worktree_id = (SELECT value FROM temp.connection_context WHERE key = \
          'worktree_id') AND worktree_id != '' AND kind != 'deleted'
             UNION ALL
@@ -434,11 +582,15 @@ fn write_scope_view(conn: &rusqlite::Connection, ctx: &ScopeContext) -> rusqlite
          indexed_revision, commit_sha, worktree_id, has_test_code
             FROM main.files
             WHERE repo_id = (SELECT value FROM temp.connection_context WHERE key = 'repo_id')
+              AND generation = (SELECT value FROM temp.connection_context WHERE key = \
+         'files_generation')
               AND commit_sha = (SELECT value FROM temp.connection_context WHERE key = 'commit_sha')
               AND commit_sha != ''
               AND path NOT IN (
                   SELECT path FROM main.files
                   WHERE repo_id = (SELECT value FROM temp.connection_context WHERE key = 'repo_id')
+                    AND generation = (SELECT value FROM temp.connection_context WHERE key = \
+         'files_generation')
                     AND worktree_id = (SELECT value FROM temp.connection_context WHERE key = \
          'worktree_id')
                     AND worktree_id != ''
@@ -446,5 +598,45 @@ fn write_scope_view(conn: &rusqlite::Connection, ctx: &ScopeContext) -> rusqlite
         ",
     )?;
 
+    Ok(())
+}
+
+/// Repo + generation-only `files` view for the BARE open (A6, P2 review). A bare
+/// `IndexDatabase::open` (the MCP `call_tool(database, …)` read path, tests, `doctor`)
+/// deliberately serves ALL commits/worktrees of the sole repo — #360 pins that its counts exceed
+/// the base-scoped `open_config` — so it cannot install the commit/worktree-scoped view above.
+/// But leaving `files` unqualified resolved it to raw `main.files`, which post-A6 also holds
+/// STAGED (pre-flip) and SUPERSEDED (pre-gc) generations: the round-6 bare-open class on the
+/// generation axis. This view keeps the cross-scope semantics while pinning `repo_id` and the
+/// LIVE generation. The context rows are written too, so free-conn helpers
+/// (`schema::active_repo_id` / `schema::active_generation`) resolve the same values;
+/// `commit_sha`/`worktree_id` stay empty (no checkout scope).
+fn write_repo_generation_view(
+    conn: &rusqlite::Connection,
+    repo_id: &str,
+    generation: i64,
+) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TEMP TABLE IF NOT EXISTS connection_context(key TEXT PRIMARY KEY, value TEXT);",
+    )?;
+    let mut stmt =
+        conn.prepare("INSERT OR REPLACE INTO temp.connection_context(key, value) VALUES (?1, ?2)")?;
+    stmt.execute(params![schema::CONNECTION_CONTEXT_REPO_KEY, repo_id])?;
+    stmt.execute(params!["commit_sha", ""])?;
+    stmt.execute(params!["worktree_id", ""])?;
+    stmt.execute(params![schema::CONNECTION_CONTEXT_GENERATION_KEY, generation.to_string()])?;
+    drop(stmt);
+    conn.execute_batch(
+        "
+            DROP VIEW IF EXISTS temp.files;
+            CREATE TEMP VIEW temp.files AS
+            SELECT id, path, language, kind, sha256, modified_at_ms, generated, indexed_at_ms, \
+         indexed_revision, commit_sha, worktree_id, has_test_code
+            FROM main.files
+            WHERE repo_id = (SELECT value FROM temp.connection_context WHERE key = 'repo_id')
+              AND generation = (SELECT value FROM temp.connection_context WHERE key = \
+         'files_generation');
+        ",
+    )?;
     Ok(())
 }

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -108,6 +108,12 @@ pub struct IndexDatabase {
     pub active_repo_id: String,
     pub active_commit_sha: String,
     pub active_worktree_id: String,
+    /// The `files.generation` this connection writes at and scopes to (A6): the repo's LIVE
+    /// generation on a reader / incremental open, the WRITE generation N+1 while a full rebuild
+    /// stages a fresh generation before flipping the live pointer. Resolved by `set_context` /
+    /// `set_context_at_generation`; every direct-scoped file INSERT stamps it. `0` until the first
+    /// context is installed — the generation a fresh index and every pre-V043 row carries.
+    pub active_generation: i64,
     /// Injected GitHub repo context. Resolved from `gh` only in `open_config` (real usage);
     /// `rebuild`/`open` leave it offline, and tests set it explicitly — so the library never
     /// shells out to `gh` during tests (#60).
@@ -118,6 +124,15 @@ pub struct IndexDatabase {
     /// zero-hit heal (`symbol_candidates`, #152) needs it to index a just-added file the watcher
     /// hasn't caught yet. Without it that heal is a graceful no-op.
     config: Option<Config>,
+    /// The RESOLVED repo's per-repo write lock, held for this connection's lifetime when identity
+    /// resolution lands on a repo whose lock differs from the one the surrounding command took at
+    /// entry (A6, batch-5 P2 — the fence gap). Entry locks are keyed by the id DERIVED before
+    /// open; an unshallow between derivation and adoption re-points the repo to a portable id, so
+    /// without this the writer would keep writing the portable repo's rows under only the stale
+    /// `local:` lock while a fresh portable-lock writer runs concurrently. RULE: a writer's held
+    /// lock must match the repo id it writes under. `None` on the lockless open paths (they stay
+    /// lockless by design) and whenever the entry lock already covers the resolved id.
+    _identity_lock: Option<crate::locks::WriteLock>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rag-rat-core/src/index/parser_failures.rs
+++ b/crates/rag-rat-core/src/index/parser_failures.rs
@@ -39,6 +39,101 @@ impl IndexDatabase {
         Ok(())
     }
 
+    /// Clear a path's failure record on a CLEAN (re)parse — the write-time half of the table's
+    /// maintenance contract (A6): `parser_failures` is path-keyed, generation-less indexer state
+    /// OWNED at (re)parse time, never by the generation-dead gc sweep (which would delete a LIVE
+    /// path's record while sweeping a superseded generation's row at the same path). The full
+    /// rebuild reaches this per visited file; incremental passes additionally clear via
+    /// `remove_file_in_scope`. Overlay-gated like [`Self::insert_parser_failure`] — an overlay pass
+    /// must not clear the base scope's real failure.
+    pub(super) fn clear_parser_failure(&self, path: &Path) -> anyhow::Result<()> {
+        if self.active_scope_is_linked_overlay() {
+            return Ok(());
+        }
+        self.storage.connection().execute(
+            "DELETE FROM parser_failures WHERE repo_id = ?1 AND path = ?2",
+            params![self.active_repo_id, path_string(path)],
+        )?;
+        Ok(())
+    }
+
+    /// STAGE a full-rebuild pass's parser-failure mutation for `path` instead of writing the
+    /// generation-less table mid-wave (A6, P2 review): the waves commit BEFORE the flip, so a
+    /// direct upsert/clear would expose the UNPUBLISHED generation's failure state to readers
+    /// still scoped to the old generation — and a tail failure would leave it torn off from the
+    /// never-flipped pointer. `message = None` records a CLEAN parse (clear at publish); `Some`
+    /// records the failure text. Staged rows live in the rebuild connection's
+    /// `temp.rebuild_parser_failures` (created by `index_targets_with_progress`) and are applied
+    /// atomically with the pointer by [`Self::apply_staged_parser_failures`]. Last write per path
+    /// wins (path-PK upsert), matching the direct path's INSERT OR REPLACE.
+    pub(super) fn stage_parser_failure(
+        &self,
+        path: &Path,
+        language: Language,
+        message: Option<&str>,
+    ) -> anyhow::Result<()> {
+        self.storage.connection().execute(
+            "INSERT OR REPLACE INTO temp.rebuild_parser_failures(path, language, message)
+             VALUES (?1, ?2, ?3)",
+            params![path_string(path), language.as_str(), message],
+        )?;
+        Ok(())
+    }
+
+    /// Publish the staged parser-failure state for `target` — the finalize half of the table's
+    /// maintenance contract (A6). TWO callers (batch 7): the full rebuild runs it inside the
+    /// terminal flip transaction (after the carry-forward), atomic with the pointer, so readers
+    /// see the OLD failure state until the flip, then exactly the published generation's; the
+    /// standalone `index_targets` runs it in its own finalize transaction at the connection's
+    /// LIVE generation (no flip exists there — its failure state publishes atomically with its
+    /// own edges instead). Three steps:
+    ///
+    /// 1. Apply staged UPSERTS — paths that failed this pass: parse errors (which also have a file
+    ///    row) and PREPARE failures (unreadable / invalid UTF-8 — which never earn one).
+    /// 2. Apply staged CLEARS — paths that parsed cleanly this pass.
+    /// 3. Orphan sweep — drop records for paths the rebuilt BASE scope no longer contains: a path
+    ///    REMOVED from the tree is never visited, so no staged row covers it and its stale record
+    ///    would otherwise linger forever (the generation-dead gc sweep deliberately never touches
+    ///    this table). Presence is judged against the BASE scope at `target` (`commit_sha` = the
+    ///    rebuilt HEAD or `worktree_id` = the base checkout) — NOT any row at `target`: the
+    ///    carry-forward drags other-commit leftovers and overlays onto `target`, and this table is
+    ///    base-owned (`insert_parser_failure` never writes under an overlay). Staged-UPSERTED paths
+    ///    are EXCLUDED (P2 review): a PREPARE-failed file has no file row in ANY generation, so a
+    ///    file-row presence test alone would sweep the failure recorded moments earlier — the
+    ///    staged set is the authoritative "visited and failed" list and shields exactly those.
+    pub(super) fn apply_staged_parser_failures(&self, target: i64) -> anyhow::Result<()> {
+        let conn = self.storage.connection();
+        conn.execute(
+            "INSERT OR REPLACE INTO parser_failures(repo_id, path, language, message)
+             SELECT ?1, path, language, message
+             FROM temp.rebuild_parser_failures WHERE message IS NOT NULL",
+            params![self.active_repo_id],
+        )?;
+        conn.execute(
+            "DELETE FROM parser_failures
+             WHERE repo_id = ?1
+               AND path IN (
+                   SELECT path FROM temp.rebuild_parser_failures WHERE message IS NULL
+               )",
+            params![self.active_repo_id],
+        )?;
+        conn.execute(
+            "DELETE FROM parser_failures
+             WHERE repo_id = ?1
+               AND path NOT IN (
+                   SELECT path FROM temp.rebuild_parser_failures WHERE message IS NOT NULL
+               )
+               AND path NOT IN (
+                   SELECT path FROM main.files
+                   WHERE repo_id = ?1 AND generation = ?2
+                     AND (commit_sha = ?3 OR worktree_id = ?4)
+               )",
+            params![self.active_repo_id, target, self.active_commit_sha, self.active_worktree_id],
+        )?;
+        conn.execute_batch("DELETE FROM temp.rebuild_parser_failures;")?;
+        Ok(())
+    }
+
     pub(super) fn parser_failure_count(&self) -> anyhow::Result<u64> {
         // Scoped to `active_repo_id` (A3): the row is written under a `repo_id`, so an unscoped
         // count would report a sibling repo's parse failures as this repo's coverage in a

--- a/crates/rag-rat-core/src/index/poison_sibling.rs
+++ b/crates/rag-rat-core/src/index/poison_sibling.rs
@@ -207,10 +207,17 @@ pub(crate) fn seed_sibling(conn: &Connection) -> anyhow::Result<()> {
     )?;
 
     // --- direct-scoped core tables ---
+    // A6: seed the sibling's files at generation 0 — the sibling's OWN live generation (it has no
+    // `repo_meta[live_files_generation]`, so its live generation reads 0). This is DISTINCT from
+    // the primary repo's post-rebuild live generation (>= 1, since the seed runs at the rebuild
+    // tail after the flip), so a repo-UNSCOPED dead-generation sweep — `WHERE generation !=
+    // <primary live>` missing the `repo_id` predicate — would delete these rows and trip
+    // `assert_sibling_intact`. That is the exact class the generation gc sweep must never regress
+    // (and the reason the sibling carries no `repo_meta` live-generation pointer of its own).
     conn.execute(
         "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
-         commit_sha, worktree_id, repo_id)
-         VALUES (?1, 'rust', 'source', ?2, 0, 0, ?3, '', ?4)",
+         commit_sha, worktree_id, repo_id, generation)
+         VALUES (?1, 'rust', 'source', ?2, 0, 0, ?3, '', ?4, 0)",
         params![
             format!("{POISON_PREFIX}file.rs"),
             format!("{POISON_PREFIX}sha"),
@@ -560,10 +567,11 @@ pub(crate) fn seed_sibling(conn: &Connection) -> anyhow::Result<()> {
     // files: caught by any unscoped `main.files` read that groups/joins by path (the scope view
     // would exclude the sibling, so only a view-bypassing path read leaks). No children hung off
     // it.
+    // Generation 0 (the sibling's live generation), as for the distinct-path file above.
     conn.execute(
         "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
-         commit_sha, worktree_id, repo_id)
-         VALUES (?1, 'rust', 'source', ?2, 0, 0, ?3, '', ?4)",
+         commit_sha, worktree_id, repo_id, generation)
+         VALUES (?1, 'rust', 'source', ?2, 0, 0, ?3, '', ?4, 0)",
         params![collision_path, POISON_SAMEPATH_SHA, POISON_COMMIT, POISON_REPO_ID],
     )?;
     // git_file_changes at the shared path (off the sibling commit): caught by an unscoped churn /

--- a/crates/rag-rat-core/src/index/query_api/gc.rs
+++ b/crates/rag-rat-core/src/index/query_api/gc.rs
@@ -4,6 +4,7 @@
 use serde::Serialize;
 
 use super::*;
+use crate::index::rebuild::StagedSweep;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct GcReport {
@@ -43,9 +44,11 @@ impl IndexDatabase {
     }
 
     /// Prune file rows (and their derived rows) whose `commit_sha` and `worktree_id` are both
-    /// outside the live sets. Refuses to prune when both live sets are empty, so a missing
-    /// live set never wipes the index. `parser_failures` are keyed by path (shared across
-    /// commits) and are regenerated on the next index, so they are not preserved per-commit.
+    /// outside the live sets, after unconditionally sweeping the repo's DEAD file generations
+    /// (which need no git context — see the sweep comment below). Refuses CONTEXT pruning when
+    /// both live sets are empty, so a missing live set never wipes the index. `parser_failures`
+    /// (path-keyed, generation-less) fall only with a dead CONTEXT — never with a dead
+    /// generation, whose paths live on ([`StagedSweep`]).
     pub fn prune_to_live(
         &self,
         live_commits: &[String],
@@ -54,12 +57,58 @@ impl IndexDatabase {
         let conn = self.storage.connection();
         let files_before = table_row_count(conn, "files")?;
         let chunks_before = table_row_count(conn, "chunks")?;
+        // A6 (P2 review): sweep this repo's DEAD file GENERATIONS FIRST, and UNCONDITIONALLY —
+        // BEFORE the empty-live-sets early return below. Generation liveness needs only
+        // `repo_id` + the repo's live-generation pointer, never a git context, so the "no live
+        // context ⇒ refuse to prune" guard (which protects CONTEXT pruning from a missing live
+        // set) must not gate it: behind the guard, a non-git / plain-directory index would leak a
+        // full generation of files/chunks/symbols/FTS rows on EVERY rebuild, unbounded.
+        //
+        // DEADNESS IS `generation != live` UNDER A LOCK PRECONDITION (batch-5 P2, superseding the
+        // batch-3 `< live` form): non-live generations split into SUPERSEDED (`< live`) and
+        // ABANDONED staging (`> live` — a failed rebuild's committed-but-never-flipped waves; a
+        // persistently failing tail would otherwise leak a full staged copy PER RETRY,
+        // unreclaimable by a below-live sweep). Sweeping ABOVE live is safe exactly when no
+        // rebuild is mid-flight — and the PER-REPO WRITE FLOCK is that proof: every production
+        // rebuild entry runs under it (CLI `index`, the watcher/maintenance passes; verified —
+        // the only flock-less rebuild callers are tests), so a collector HOLDING the flock knows
+        // any above-live rows are abandoned, not in-progress.
+        //
+        // INVARIANT (documented precondition, not asserted): callers of `garbage_collect` /
+        // `prune_to_live` hold this repo's write flock. All production callers do — `Cmd::Gc`
+        // (batch-4 belt), `run_maintenance_pass`, and the watcher's pass all acquire it before
+        // opening. A hypothetical flock-less embedded collector must fall back to the
+        // lockless-safe `< live` form — do NOT weaken this predicate's precondition silently.
+        // (The allocator still guarantees staging sits strictly above live:
+        // `next_files_generation` = max(row-MAX, live) + 1.) `StagedSweep::DeadGeneration` keeps
+        // the cascade off the generation-less `parser_failures` (the same paths live on in the
+        // current generation). Scoped to the active repo, so a sibling's generations are
+        // untouched.
+        conn.execute_batch(
+            "
+            CREATE TEMP TABLE IF NOT EXISTS staged_file_ids(id INTEGER PRIMARY KEY);
+            DELETE FROM temp.staged_file_ids;
+            ",
+        )?;
+        let live_generation =
+            crate::index::schema::live_files_generation(conn, &self.active_repo_id)?;
+        conn.execute(
+            "INSERT OR IGNORE INTO temp.staged_file_ids(id)
+             SELECT id FROM main.files WHERE repo_id = ?1 AND generation != ?2",
+            params![self.active_repo_id, live_generation],
+        )?;
+        self.delete_staged_files_cascade(StagedSweep::DeadGeneration)?;
+        conn.execute_batch("DELETE FROM temp.staged_file_ids;")?;
         if live_commits.is_empty() && live_worktrees.is_empty() {
+            let files_remaining = table_row_count(conn, "files")?;
+            let chunks_remaining = table_row_count(conn, "chunks")?;
             return Ok(GcReport {
-                files_pruned: 0,
-                chunks_pruned: 0,
-                files_remaining: files_before,
-                chunks_remaining: chunks_before,
+                files_pruned: files_before.saturating_sub(files_remaining),
+                chunks_pruned: chunks_before.saturating_sub(chunks_remaining),
+                files_remaining,
+                chunks_remaining,
+                // Context pruning was skipped (no live context could be determined); the
+                // generation sweep above needs no context and ran regardless.
                 skipped: true,
             });
         }
@@ -69,7 +118,6 @@ impl IndexDatabase {
             DELETE FROM temp.gc_live_commits;
             CREATE TEMP TABLE IF NOT EXISTS gc_live_worktrees(id TEXT PRIMARY KEY);
             DELETE FROM temp.gc_live_worktrees;
-            CREATE TEMP TABLE IF NOT EXISTS staged_file_ids(id INTEGER PRIMARY KEY);
             DELETE FROM temp.staged_file_ids;
             ",
         )?;
@@ -103,7 +151,10 @@ impl IndexDatabase {
             ",
             [self.active_repo_id.as_str()],
         )?;
-        self.delete_staged_files_cascade()?;
+        // Context-death cascade: this staging holds only rows whose (commit, worktree) fell out of
+        // every live set, so path-keyed satellite state (`parser_failures`) goes with them. The
+        // dead-GENERATION sweep already ran above, unconditionally.
+        self.delete_staged_files_cascade(StagedSweep::DeadContext)?;
         conn.execute_batch("DELETE FROM temp.staged_file_ids;")?;
         // Since #248 `edge_oracle` is content-keyed with NO `edges_data` FK (it survives reindex,
         // the moniker model), so the file/edge prune above no longer cascades verdicts

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -1,4 +1,26 @@
+// Re-export the test-only wave barrier (defined at the end of the file so the `#[cfg(test)]`
+// module stays last — clippy::items_after_test_module). `incremental.rs`'s wave loop calls
+// `run_after_wave_commit`; the reader-consistency tests register a database-keyed hook via
+// `set_after_wave_commit` and hold the returned guard.
+#[cfg(test)]
+pub(crate) use wave_barrier::{WaveBarrierGuard, run_after_wave_commit, set_after_wave_commit};
+
 use super::*;
+
+/// Which liveness AXIS staged the rows a [`IndexDatabase::delete_staged_files_cascade`] call is
+/// sweeping (A6). The cascade's id-keyed children behave identically under both, but the
+/// GENERATION-LESS, path-keyed tables must be classified per axis — see the `parser_failures`
+/// block inside the cascade.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum StagedSweep {
+    /// The staged rows' `(commit_sha, worktree_id)` context is dead (outside every live set): the
+    /// path's last owner in this repo is going away, so path-keyed satellite state goes with it.
+    DeadContext,
+    /// The staged rows belong to a superseded `files.generation` (a completed rebuild's old
+    /// generation, or a torn rebuild's never-flipped staging). The SAME paths live on in the
+    /// current generation, so path-keyed satellite state must survive untouched.
+    DeadGeneration,
+}
 
 impl IndexDatabase {
     pub fn rebuild(config: &Config) -> anyhow::Result<Self> {
@@ -13,6 +35,22 @@ impl IndexDatabase {
             database: config.database.clone(),
             mode: IndexMode::Full,
         });
+        // Every rebuild ENTRY holds the per-repo write flock (batch 6, concurrency HIGH). The
+        // library `rebuild` was a FLOCK-LESS production writer reachable from `rag-rat init`'s
+        // `setup_index` (through `index_discover`'s missing-DB / empty-index fallback to
+        // `rebuild_with_progress`) — which FALSIFIED the precondition gc's `generation != live`
+        // deadness predicate documents ("every production rebuild entry runs under the flock"): a
+        // flock-holding collector (watcher/git-hook maintenance, `rag-rat gc`) racing this staging
+        // would read live=N, classify the mid-flight staged N+1 as dead, and cascade it — the
+        // rebuild's flip then publishes an EMPTY generation and returns Ok. Acquiring here makes
+        // the precondition hold by CONSTRUCTION, not convention. `WriteLock` is reentrant
+        // within a thread, so the CLI/watcher wrappers that already hold it just bump the
+        // depth; a flock-less caller (init) acquires it fresh. `write_lock_repo_id`
+        // resolves from git WITHOUT opening the DB, so it precedes `create_or_migrate`
+        // (which opens it). Blocking (non-interactive writer); a racing collector holds the
+        // flock only for its brief sweep.
+        let lock_repo = crate::locks::write_lock_repo_id(config);
+        let _write_lock = crate::locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
         let mut db = Self::create_or_migrate(&config.database)?;
         // Register/adopt the repo BEFORE the scope view is installed and BEFORE any repo-scoped
         // write, so `active_repo_id` is a real (registered) id — every direct-scoped insert stamps
@@ -21,121 +59,349 @@ impl IndexDatabase {
         // the repo or heals the model manifest, so both move here, ordered after
         // registration.
         db.adopt_repo_from_config(config)?;
+        // A6: stage a FRESH file generation instead of clearing-then-reinserting in one long
+        // write-locked transaction. `old_live` is the generation readers currently see; `target` is
+        // higher than any the repo holds, so it never collides with a torn prior rebuild's
+        // committed-but-never-flipped generation (which `old_live + 1` could). The rebuild writes
+        // `target`; the flip publishes it.
+        let old_live = schema::live_files_generation(db.storage.connection(), &db.active_repo_id)?;
+        let target = db.next_files_generation(old_live)?;
         let (commit_sha, worktree_id) = resolve_git_context(&config.root);
-        db.set_context(&commit_sha, &worktree_id)?;
+        // Install the scope view + writer stamp at the WRITE generation, so every insert lands on
+        // `target` and the rebuild's own edge-resolution / logical-symbol reads see only it.
+        db.set_context_at_generation(&commit_sha, &worktree_id, target)?;
         ai::ensure_model_manifest(db.storage.connection())?;
         progress(IndexProgress::IndexingGitHistory);
         let mut git_history = Some(spawn_git_history_prepare(&config.root));
-        // RAM-first bulk build: a full rebuild is one big atomic write, so skip per-commit fsyncs
-        // (synchronous=OFF) and give SQLite a large page cache. Restored to NORMAL after the
-        // rebuild. Only `rebuild` uses this; incremental indexing and the watcher stay durable.
-        //
-        // NB: stay in WAL — switching journal_mode needs an EXCLUSIVE database lock, which fails
-        // ("database is locked") whenever another connection is open (e.g. the watcher, or a
-        // concurrent reader). `synchronous` and `cache_size` are per-connection and safe under
-        // concurrency. Also do NOT touch `temp_store` — changing it drops the connection_context
-        // overlay temp table created by `set_context` above.
-        db.storage.execute_batch(
-            "PRAGMA synchronous = OFF;
-             PRAGMA cache_size = -262144;",
-        )?;
+        // RAM-first bulk build: give SQLite a large per-connection page cache. `synchronous` stays
+        // NORMAL — the shared global DB must NEVER run `synchronous = OFF` (spec §3.3, Global
+        // Constraint). A full rebuild is no longer one mega-transaction, so a crash mid-rebuild
+        // leaves a STAGED (never-flipped) generation gc reclaims, not a corrupt file — durability
+        // no longer trades against a giant write. `cache_size`/`soft_heap_limit` are per-connection
+        // and safe under concurrency; do NOT touch `temp_store` (it would drop the
+        // connection_context overlay temp table `set_context_at_generation` created above).
+        db.storage.execute_batch("PRAGMA cache_size = -262144;")?;
         maybe_set_sqlite_soft_heap_limit();
-        // Diagnostic: override wal_autocheckpoint for this rebuild. Setting it to 0 disables the
-        // auto-checkpoint that fires at COMMIT — used to test whether the trailing peak spike is
-        // the final checkpoint of the multi-GB WAL (mega-transaction) vs something else. No-op
-        // unless RAG_RAT_WAL_AUTOCHECKPOINT is set.
+        // Diagnostic: override wal_autocheckpoint for this rebuild. No-op unless
+        // RAG_RAT_WAL_AUTOCHECKPOINT is set.
         if let Ok(raw) = std::env::var("RAG_RAT_WAL_AUTOCHECKPOINT")
             && let Ok(pages) = raw.trim().parse::<i64>()
         {
             db.storage.execute_batch(&format!("PRAGMA wal_autocheckpoint = {pages};"))?;
         }
-        let result = (|| -> anyhow::Result<()> {
-            mem_trace("before clear (start of rebuild txn)");
-            // BEGIN IMMEDIATE acquires the write lock up front. A plain BEGIN starts as a reader
-            // and upgrades on the first mutation; if another writer raced in between, the upgrade
-            // fails with SQLITE_BUSY *immediately* (busy_timeout doesn't apply to the upgrade,
-            // since retrying would break snapshot isolation). IMMEDIATE makes the wait honor
-            // busy_timeout instead — the fix for the intermittent multi-writer "deadlock".
-            db.storage.execute_batch("BEGIN IMMEDIATE")?;
-            db.clear_full_rebuild_tables()?;
-            mem_trace("after clear_full_rebuild_tables (purge)");
-            db.set_repo_meta("source_root", &config.root.display().to_string())?;
+        let result = (|| -> anyhow::Result<usize> {
+            mem_trace("before rebuild (staging a fresh generation)");
+            // NO clear of the live rows anywhere below: the old generation stays intact and
+            // complete for concurrent readers until the flip; the fresh generation lands alongside
+            // it and gc sweeps the dead one afterward (A6). The wave-staging scratch temp tables
+            // are created by `index_targets_with_progress` itself (batch 7 — the standalone
+            // `index_targets` entry shares the same wave loop and needs them too).
+            // Only the IN-MEMORY source root is set here (this connection reads file bytes from
+            // the new checkout for the whole staging run); the PERSISTED
+            // `repo_meta[source_root]` is an AUTHORITY key other readers resolve fs-fallback
+            // paths against (memory validation, heals), so it joins the cursors-last set and is
+            // written inside the terminal flip transaction (batch-5 P2): a rebuild from a NEW
+            // checkout root that fails pre-publish must leave old-generation readers resolving
+            // against the OLD root. Audit of the other early meta writes found no further
+            // authority keys: the FTS freshness trio is global infrastructure over main.* (not
+            // generation authority), and everything else already rides the flip.
             db.storage.set_source_root(config.root.clone());
-            // Per-package import scope (#61): the `packages` rows + the global `local_crate_roots`
-            // union are written by `refresh_packages`, called inside `index_targets_with_progress`
-            // AFTER files are inserted but BEFORE the in-memory resolve pass (which computes each
-            // file's package from those rows at load time) — the files do not exist yet here.
-            db.write_git_meta(&config.root)?;
-            let indexed = db.index_targets_with_progress(config, &mut progress)?;
-            mem_trace("after index_targets (edges resolved+inserted)");
-            db.apply_prepared_git_history(
+
+            // Phase 1: the file/chunk/symbol bulk, written at the WRITE generation in CHUNKED
+            // transactions (one per wave) so the rebuild never holds the shared DB's write lock
+            // across the whole file set. Base EDGES accumulate in the returned `graph` and are
+            // resolved LATER, inside the terminal transaction (batch 6 #4) — NOT here — so the
+            // generation-less `packages`/`local_crate_roots` they resolve against never precede the
+            // flip. `refresh_packages` moved out with them.
+            let (indexed, graph) = db.index_targets_with_progress(config, &mut progress)?;
+            mem_trace("after index_targets (staged generation written; base edges pending)");
+
+            // Phase 2: the ONLY pre-flip derived write left is the compressed chunk_text store. It
+            // is keyed by STAGED chunk ids (a live-generation reader never joins them — inert) and
+            // gc sweeps it with the dead generation, so committing it before the flip misleads no
+            // reader. Everything a reader treats as AUTHORITY moved into the terminal flip
+            // transaction below (batch 6): base edges + package roots (#4), the git-history ROWS +
+            // `commit_fts` (#1), and the clone-token df (#2). The pre-A6 mega-transaction's
+            // atomicity for those domains is restored WITHOUT re-inflating Phase 1's chunked waves.
+            db.storage.execute_batch("BEGIN IMMEDIATE")?;
+            // Derive the compressed chunk_text store (#77 Phase 2) from the staged chunk text.
+            db.build_chunk_text_store()?;
+            db.storage.execute_batch("COMMIT")?;
+            mem_trace("after phase 2 (chunk_text store)");
+
+            // Phase 3: the TERMINAL transaction. The pointer flip is the LAST fallible step of a
+            // rebuild — everything a reader treats as AUTHORITY or that must be CONSISTENT with the
+            // published generation completes INSIDE this one transaction, with
+            // `live_files_generation` written last. A failure anywhere here rolls the WHOLE tail
+            // back — the pointer never moves, readers stay on the complete old generation, and a
+            // retry stages a fresh target. Its writes are uncommitted until the flip, so a
+            // concurrent reader/heal never observes any of the GENERATION-LESS ones (base package
+            // roots, re-keyed overlay packages, git-history rows, clone df) in front of the
+            // still-live OLD generation. TXN-SIZE TRADEOFF (batch 6): the terminal txn now also
+            // carries base-edge resolution (O(edges), formerly its own Phase-1 tail txn) and the
+            // git-history rows + external-content `commit_fts` rebuild (O(commits) on a
+            // deep-history repo). Both are the price of atomicity and stay proportional
+            // to symbol/edge/history counts, NOT the file bytes — the whole-file
+            // indexing bulk stays in Phase 1's waves.
+            db.storage.execute_batch("BEGIN IMMEDIATE")?;
+            // Carry every live row OUTSIDE the base scope (linked-worktree overlays, other-commit
+            // leftovers) forward onto `target` — the rebuild only re-emits the base scope, so
+            // they must ride along to stay visible after the flip.
+            db.carry_forward_live_overlays(target, old_live)?;
+            let carried_overlays = db.carried_overlay_worktrees(target)?;
+            // Carry each carried overlay's PACKAGE ROOTS onto the new base scope (batch 6 #3): the
+            // overlay FILE rows carried above are matched into the scope view by `worktree_id`
+            // alone, but `load_package_roots_into_scope` reads `packages` by `(commit_sha,
+            // worktree_id)`, so an overlay keyed to the OLD base HEAD finds NO package map under
+            // the re-resolution view (installed at the NEW base commit) and resolves
+            // its imports fall-open. Re-key their `commit_sha` to the rebuilt HEAD
+            // BEFORE the re-resolution.
+            db.carry_forward_overlay_packages(&carried_overlays)?;
+            // Base package roots + base-edge resolution, folded into the flip (batch 6 #4):
+            // `finalize_base_edges` writes the generation-less `packages`/`local_crate_roots` and
+            // resolves every accumulated base edge against them. Runs INSIDE the terminal txn so
+            // those authority writes are invisible to a concurrent reader/heal until the pointer
+            // moves and roll back with a failed tail; the resolve reads the package rows back from
+            // this same uncommitted transaction.
+            db.finalize_base_edges(config, graph)?;
+            // Re-resolve each carried overlay's OWN edges against the freshly staged base (P2
+            // review): the base re-emit re-minted every base `symbols.id`, so a carried overlay
+            // edge's `to_symbol_id` still points at the OLD generation's symbol row — dead the
+            // moment gc sweeps it. `resolve_overlay_edges` writes only the overlay's own rows
+            // (targets span the overlay view), exactly as `finalize_overlay_refresh` uses it; the
+            // view is swapped per overlay and restored to the base scope after.
+            for worktree_id in &carried_overlays {
+                db.install_view_for_scope(&db.active_commit_sha, worktree_id, target)?;
+                db.resolve_overlay_edges(worktree_id)?;
+            }
+            if !carried_overlays.is_empty() {
+                db.install_view_for_scope(&db.active_commit_sha, &db.active_worktree_id, target)?;
+            }
+            // Logical symbols fold the generation being published (base scope + carried
+            // overlays), scoped to `self.active_generation == target` — the carried overlays are
+            // already at `target` within this transaction, so the fold sees them (the A6 handoff
+            // note, now satisfied PRE-flip inside the same atomic write).
+            progress(IndexProgress::RebuildingLogicalSymbols);
+            db.rebuild_logical_symbols()?;
+            // Publish the STAGED `parser_failures` state (upserts for paths that failed this
+            // pass, clears for clean re-parses, an orphan sweep for paths removed from the tree)
+            // atomically with the flip: the waves staged these mutations in a temp table instead
+            // of writing the generation-less table mid-pass, so readers see the OLD failure state
+            // until the pointer moves and a tail failure rolls the whole reconciliation back with
+            // it. Generation-dead gc deliberately never touches this table.
+            db.apply_staged_parser_failures(target)?;
+            // Recompute clone-token df over the FINAL published set (batch 6 #2): it reads
+            // `symbol_fingerprints` at `active_generation == target`, which AFTER the overlay
+            // carry-forward above is exactly the generation about to go live (base + carried
+            // overlays). Recomputing in Phase 2 (before carry-forward) either omitted carried
+            // overlay fingerprints from the df on success, or on a tail failure left the OLD
+            // generation's clone queries reading a df computed from the never-published target —
+            // and the df drives sub-block-postings selection + persisted-postings
+            // invalidation, so it is consumed as authority w.r.t. the published set,
+            // not merely a drift-tolerated hint.
+            db.refresh_clone_token_df()?;
+            // Git-history ROWS + external-content `commit_fts` fold into the flip too (batch 6 #1):
+            // `git_commits`/`git_file_changes` are read DIRECTLY by
+            // `query::orientation::recent_commit_subjects`, lexical churn, and commit search — not
+            // only through the deferred `git_history_indexed_*` cursors — so landing them in Phase
+            // 2 let a rebuild that observed changed/cleared history then failed
+            // pre-flip strand the NEW history rows in front of the still-live OLD file
+            // generation. The reload-gate CURSORS still write cursors-last below; the
+            // ROWS + `commit_fts` now ride the same atomic transaction as the file
+            // generation, so orientation/search can never mix new history with the old
+            // files.
+            let history_cursors = db.apply_prepared_git_history_deferring_cursors(
                 &config.root,
                 git_history
                     .take()
                     .ok_or_else(|| anyhow::anyhow!("git history preparation was already used"))?,
             )?;
-            mem_trace("after git_history");
-            progress(IndexProgress::RebuildingLogicalSymbols);
-            db.rebuild_logical_symbols()?;
-            mem_trace("after rebuild_logical_symbols");
-            // Edges were resolved and inserted in one in-memory pass inside
-            // index_targets_with_progress (full rebuild), so there is no separate resolve_edges
-            // phase.
+            progress(IndexProgress::RebuildingFts);
+            // chunk_fts was written inline during chunk insert; only the external-content
+            // commit_fts needs the bulk 'rebuild' here (#77 Phase 2), now atomic with
+            // the git rows it indexes.
+            db.finalize_full_rebuild_fts()?;
             progress(IndexProgress::ResolvingGraph);
             db.mark_graph_index_current()?;
-            // Full rebuild writes correct `files.generated` via `file_is_generated`, so stamp the
-            // flags version current and skip a redundant re-derive on next open (#202).
+            // Full rebuild writes correct `files.generated`, so stamp the flags version current and
+            // skip a redundant re-derive on next open (#202).
             db.mark_generated_flags_current()?;
-            mem_trace("after mark_graph_index_current");
-            // Derive the compressed chunk_text store (#77 Phase 2) from chunks.text inside the same
-            // transaction, so the dict row + the blobs that use it are committed atomically.
-            db.build_chunk_text_store()?;
-            mem_trace("after build_chunk_text_store");
-            progress(IndexProgress::RebuildingFts);
-            // chunk_fts was written inline during chunk insert; only commit_fts
-            // needs the bulk 'rebuild' here (#77 Phase 2).
-            db.finalize_full_rebuild_fts()?;
-            mem_trace("after finalize_full_rebuild_fts");
-            // Recompute clone token document-frequency authoritatively from the token-bag BLOBs
-            // just written (#231). The per-symbol incremental bump in store_symbol_fingerprints
-            // drifts over edits; a full rebuild owns the whole checkout, so derive df exactly here.
-            // df is a selectivity hint only (candidate read COALESCEs it), never a correctness
-            // input — but keeping it exact maximizes the rare-first sub-block prune.
-            db.refresh_clone_token_df()?;
-            mem_trace("after refresh_clone_token_df");
+            // The git AUTHORITY writes ride the flip (batch-4 P2): `git_commit`/`git_dirty` meta
+            // and the history reload-gate cursors say "this index reflects commit H" — true only
+            // once the generation built at H is published. Deferring them here means a tail
+            // failure leaves status()/`is_history_current` honestly reporting the OLD state (a
+            // reload stays owed), and the retry publishes files + git authority together.
+            db.set_repo_meta("source_root", &config.root.display().to_string())?;
+            db.write_git_meta(&config.root)?;
+            if let Some(cursors) = &history_cursors {
+                db.record_git_history_cursors(cursors)?;
+            }
+            // Publish: `live_files_generation` LAST, so a concurrent reader sees either the whole
+            // old generation or the whole new one, never a mix. The active-model seed rides the
+            // flip (#394): it is advanced only when the fresh generation actually goes live.
+            db.set_repo_meta(schema::LIVE_FILES_GENERATION_META_KEY, &target.to_string())?;
             db.set_repo_meta("indexed_at_ms", &now_ms().to_string())?;
-            // Adopt the configured embedding model as this index's active model INSIDE the rebuild
-            // transaction, so reconcile targets it (and read-only opens serve immediately) rather
-            // than the hash fallback (#394) — and a failed rebuild rolls the seed back with the
-            // rest, leaving the pre-rebuild active model intact rather than pointing at
-            // a missing model (#394 review).
             ai::seed_active_embedding_model(
                 db.storage.connection(),
                 config.llm.embedding.backend.model_id(),
             )?;
             db.storage.execute_batch("COMMIT")?;
-            mem_trace("after COMMIT");
+            mem_trace("after terminal flip (overlay edges + logical symbols + pointer)");
             progress(IndexProgress::Finished { files: indexed });
-            Ok(())
+            Ok(indexed)
         })();
         if result.is_err() {
             if let Some(handle) = git_history.take() {
                 let _ = join_git_history_prepare(handle);
             }
+            // Roll back whichever phase transaction was left open by the failing `?` (Phase 1's
+            // per-wave commits already landed a staged generation that never flips — dead,
+            // gc-swept).
             let _ = db.storage.execute_batch("ROLLBACK");
         }
-        // Restore durable fsync behavior for any later writes on this connection (reconcile, etc.).
         // cache_size is left bumped — harmless for the short remaining lifetime of the connection.
-        let _ = db.storage.execute_batch("PRAGMA synchronous = NORMAL;");
         result?;
-        // Poison-sibling test harness (compiled out of production): after the rebuild commits,
-        // register a second `poison-sibling` repo with tripwire rows in every repo-scoped table, so
-        // any unscoped read/count/delete downstream trips an EXISTING test. Default-ON per test
-        // thread; a test needing a virgin single-repo DB opts out via
-        // `poison_sibling::disable_poison_sibling`. See the module docs.
+        // Poison-sibling test harness (compiled out of production): after the rebuild flips,
+        // register a second `poison-sibling` repo with tripwire rows in every repo-scoped
+        // table, so any unscoped read/count/delete downstream trips an EXISTING test.
+        // Default-ON per test thread; a test needing a virgin single-repo DB opts out via
+        // `poison_sibling::disable_poison_sibling`.
         #[cfg(test)]
         crate::index::poison_sibling::seed_if_enabled(db.storage.connection())?;
         Ok(db)
+    }
+
+    /// The generation a full rebuild stages into (A6): STRICTLY ABOVE both every generation the
+    /// ACTIVE repo's rows currently carry AND the live pointer itself. The row-MAX keeps it above
+    /// a torn prior rebuild's committed-but-never-flipped staging (which `live + 1` could collide
+    /// with); folding `old_live` in keeps it above the pointer even when the live generation has
+    /// ZERO rows left (every file incrementally removed) — without that, `MAX(rows) + 1` could
+    /// allocate BELOW live, and gc's LOCKLESS-SAFE `generation < live` fallback predicate would
+    /// classify the fresh staging as superseded and cascade it mid-rebuild. (Under gc's primary
+    /// `generation != live` form the per-repo write flock is the protection — every rebuild entry
+    /// holds it, batch 6 — but the allocator stays above live so the lockless fallback is safe too,
+    /// and so the `< live`/`!= live` forms agree on an in-flight staging.) Per-repo — the `files`
+    /// view scopes `(repo_id, generation)`, so generations need only be unique WITHIN a repo.
+    fn next_files_generation(&self, old_live: i64) -> anyhow::Result<i64> {
+        let max_row_generation = self.storage.connection().query_row(
+            "SELECT COALESCE(MAX(generation), 0) FROM main.files WHERE repo_id = ?1",
+            params![self.active_repo_id],
+            |row| row.get::<_, i64>(0),
+        )?;
+        Ok(max_row_generation.max(old_live) + 1)
+    }
+
+    /// The DISTINCT linked-worktree ids among the rows just carried forward onto `target` — the
+    /// overlay scopes whose edges the terminal transaction must re-resolve against the freshly
+    /// staged base (their old `to_symbol_id` targets die with the superseded generation). Excludes
+    /// the empty (committed) scope and the base checkout's own worktree id; other-commit leftovers
+    /// carry no worktree id, so they never appear here (their edges are self-contained per scope
+    /// and die with their context at gc).
+    fn carried_overlay_worktrees(&self, target: i64) -> anyhow::Result<Vec<String>> {
+        let conn = self.storage.connection();
+        let mut stmt = conn.prepare(
+            "SELECT DISTINCT worktree_id FROM main.files
+             WHERE repo_id = ?1 AND generation = ?2
+               AND worktree_id != '' AND worktree_id != ?3
+             ORDER BY worktree_id",
+        )?;
+        let rows = stmt
+            .query_map(params![self.active_repo_id, target, self.active_worktree_id], |row| {
+                row.get::<_, String>(0)
+            })?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    /// Carry every LIVE row OUTSIDE the base rebuild scope — linked-worktree overlays and
+    /// other-commit leftovers — forward from the previous live generation `old_live` onto the
+    /// freshly-staged `target`, so they stay visible after the flip. A full rebuild only re-emits
+    /// the BASE scope (`commit_sha` = the rebuilt HEAD, or `worktree_id` = the base checkout),
+    /// so those non-base rows would otherwise vanish under the new live generation; the base
+    /// scope it DID re-emit stays at `old_live` → dead → swept by gc. A no-op on a non-git repo
+    /// (base commit + base worktree both empty ⇒ every row IS in the base scope) and when there
+    /// are no overlays. Runs INSIDE the terminal flip transaction so a reader sees overlays at
+    /// exactly one generation.
+    fn carry_forward_live_overlays(&self, target: i64, old_live: i64) -> anyhow::Result<()> {
+        self.storage.connection().execute(
+            "UPDATE main.files SET generation = ?1
+             WHERE repo_id = ?2 AND generation = ?3
+               AND commit_sha != ?4 AND worktree_id != ?5",
+            params![
+                target,
+                self.active_repo_id,
+                old_live,
+                self.active_commit_sha,
+                self.active_worktree_id
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Re-key each carried linked-worktree overlay's generation-less `packages` rows onto the
+    /// rebuilt base commit so its terminal-txn edge re-resolution finds them (batch 6 #3). An
+    /// overlay's FILE rows are matched into the scope view by `worktree_id` ALONE
+    /// (commit-agnostic), but `load_package_roots_into_scope` (resolve.rs) reads `packages` by
+    /// BOTH `(commit_sha, worktree_id)`, and the re-resolution installs the view at
+    /// `active_commit_sha` (the NEW base HEAD). An overlay indexed at the OLD base HEAD keyed
+    /// its package rows to that old commit, so without this the read finds no overlay package
+    /// map and resolves the branch's imports against the wrong / fall-open roots — until a
+    /// separate overlay refresh runs. Re-keying `commit_sha` to the rebuilt HEAD aligns them
+    /// with BOTH the re-resolution context AND a post-flip overlay query's `(base_sha,
+    /// worktree_id)` scope.
+    ///
+    /// SUPERSEDED OLD ROWS ARE DELETED, NOT RE-KEYED (batch 7 P2): an overlay that already
+    /// REFRESHED after the base HEAD moved wrote fresh rows at the NEW `(commit_sha,
+    /// worktree_id)` while its old-commit rows lingered (`refresh_packages` deletes only its own
+    /// scope). A blind re-key of those old rows collides with the fresh ones under
+    /// `UNIQUE(repo_id, manifest_dir, commit_sha, worktree_id)` and ABORTS the whole rebuild —
+    /// and the fresh refresh is also more current than any re-key could make the stale row. So:
+    /// (1) DELETE old-commit rows whose `manifest_dir` already has a row at the new key (the
+    /// fresh refresh wins); (2) DELETE all-but-the-newest duplicates among the REMAINING
+    /// old-commit rows — rows at TWO different stale commits (two refreshes, two HEAD moves ago)
+    /// would otherwise both re-key to the same new key and collide with each other; highest
+    /// `id` wins (`refresh_packages` reinserts per pass, so rowid order is recency); (3) re-key
+    /// the survivors. `commit_sha != ?1` throughout keeps a same-HEAD rebuild (the overlay
+    /// already at this commit) a pure no-op — no self-UPDATE, no collision, nothing deleted.
+    /// Scoped to exactly the `worktree_ids` `carried_overlay_worktrees` re-resolves (non-empty,
+    /// != the base checkout), so other-commit leftovers (`worktree_id = ''`) are untouched. Runs
+    /// INSIDE the terminal flip transaction, so the re-key is invisible until the pointer moves.
+    fn carry_forward_overlay_packages(&self, worktree_ids: &[String]) -> anyhow::Result<()> {
+        let conn = self.storage.connection();
+        let mut delete_shadowed = conn.prepare(
+            "DELETE FROM packages
+             WHERE repo_id = ?2 AND worktree_id = ?3 AND commit_sha != ?1
+               AND manifest_dir IN (
+                   SELECT manifest_dir FROM packages
+                   WHERE repo_id = ?2 AND worktree_id = ?3 AND commit_sha = ?1
+               )",
+        )?;
+        let mut delete_stale_duplicates = conn.prepare(
+            "DELETE FROM packages
+             WHERE repo_id = ?2 AND worktree_id = ?3 AND commit_sha != ?1
+               AND id NOT IN (
+                   SELECT MAX(id) FROM packages
+                   WHERE repo_id = ?2 AND worktree_id = ?3 AND commit_sha != ?1
+                   GROUP BY manifest_dir
+               )",
+        )?;
+        let mut rekey = conn.prepare(
+            "UPDATE packages SET commit_sha = ?1
+             WHERE repo_id = ?2 AND worktree_id = ?3 AND commit_sha != ?1",
+        )?;
+        for worktree_id in worktree_ids {
+            delete_shadowed.execute(params![
+                self.active_commit_sha,
+                self.active_repo_id,
+                worktree_id
+            ])?;
+            delete_stale_duplicates.execute(params![
+                self.active_commit_sha,
+                self.active_repo_id,
+                worktree_id
+            ])?;
+            rekey.execute(params![self.active_commit_sha, self.active_repo_id, worktree_id])?;
+        }
+        Ok(())
     }
 
     /// Recompute `clone_token_df` exactly from the `symbol_fingerprints.token_bag` BLOBs (#231).
@@ -177,14 +443,23 @@ impl IndexDatabase {
         let mut df: BTreeMap<String, BTreeMap<i64, i64>> = BTreeMap::new();
         {
             let conn = self.storage.connection();
+            // A6: the join also filters the ACTIVE generation. During a full rebuild this runs
+            // AFTER the fresh generation's fingerprints are staged but BEFORE gc sweeps the
+            // superseded one, so a repo-only join would fold BOTH generations' bags and
+            // systematically double every df — not drift, a 2x skew of the "exact" recompute this
+            // function exists to produce. `active_generation` is the WRITE generation on the
+            // rebuild connection (exactly the fingerprints just written) and the live generation
+            // elsewhere. The pre-V042 `None` branch has no files join to filter (that schema also
+            // predates V043).
             let read_sql = match &df_scope {
                 Some(repo_id) => format!(
                     "SELECT symbol_fingerprints.normalizer_kind, symbol_fingerprints.token_bag
                      FROM symbol_fingerprints
                      JOIN symbols ON symbols.id = symbol_fingerprints.symbol_id
                      JOIN main.files ON main.files.id = symbols.file_id
-                     WHERE main.files.repo_id = '{}'",
-                    repo_id.replace('\'', "''")
+                     WHERE main.files.repo_id = '{}' AND main.files.generation = {}",
+                    repo_id.replace('\'', "''"),
+                    self.active_generation
                 ),
                 None => "SELECT normalizer_kind, token_bag FROM symbol_fingerprints".to_string(),
             };
@@ -246,51 +521,21 @@ impl IndexDatabase {
         Ok(())
     }
 
-    fn clear_full_rebuild_tables(&self) -> anyhow::Result<()> {
-        // Stage the active context's file ids, then cascade-delete them and their derived rows.
-        //
-        // AUTHORITATIVE (load-bearing, #87): a full rebuild owns the WHOLE checkout, so the
-        // commit-scope staging deliberately does NOT mirror the scope VIEW's shadowing rule.
-        // The view excludes a committed row whose path has a worktree-overlay row (overlay
-        // wins for reads) — but exempting it from the CLEAR left it behind to collide with the
-        // rebuild's fresh insert at the same `(path, commit_sha, '')` whenever a stale overlay
-        // lingered (a dirty-then-committed file whose cleanup never ran), failing the whole
-        // rebuild with a UNIQUE constraint error. Stage every row of the active commit AND
-        // every row of the active worktree, shadowed or not. A sibling worktree at the same
-        // commit self-heals on its next discover pass (its missing paths reindex).
-        // Every staged row is constrained to the ACTIVE REPO (A3): the commit/worktree keys are not
-        // globally unique across repos in a consolidated DB (forks share a commit), so without the
-        // `repo_id` predicate a full rebuild of one repo would stage — and cascade-delete — a
-        // sibling repo's rows. The repo id lives in the same `temp.connection_context` the scope
-        // view populates.
-        self.storage.execute_batch(
-            "
-            CREATE TEMP TABLE IF NOT EXISTS staged_file_ids(id INTEGER PRIMARY KEY);
-            DELETE FROM temp.staged_file_ids;
-            INSERT OR IGNORE INTO temp.staged_file_ids(id)
-            SELECT id
-            FROM main.files
-            WHERE repo_id = (SELECT value FROM temp.connection_context WHERE key = 'repo_id')
-              AND worktree_id = (SELECT value FROM temp.connection_context WHERE key = \
-             'worktree_id')
-              AND worktree_id != '';
-            INSERT OR IGNORE INTO temp.staged_file_ids(id)
-            SELECT id
-            FROM main.files
-            WHERE repo_id = (SELECT value FROM temp.connection_context WHERE key = 'repo_id')
-              AND commit_sha = (SELECT value FROM temp.connection_context WHERE key = 'commit_sha')
-              AND commit_sha != '';
-            ",
-        )?;
-        self.delete_staged_files_cascade()?;
-        // Do NOT clear chunk_text_dict: dicts are IMMUTABLE decode keys (#77 Phase 2). Other
-        // worktree contexts' blobs reference existing versions, and deleting a version would orphan
-        // them. The staged cascade above already removed THIS context's chunk_text rows;
-        // insert_chunks recompresses them against the latest existing dict version (or, on
-        // the very first index when no dict exists yet, stages the text so
-        // build_chunk_text_store trains version 1). Per-connection staging table for that
-        // first-index path: insert_chunks writes the in-memory text here (there is no
-        // chunks.text column) and build_chunk_text_store reads + clears it.
+    /// Set up the per-connection scratch temp tables the wave loop needs, WITHOUT clearing any
+    /// live rows (A6). The rebuild stages a FRESH generation alongside the live one — the old
+    /// generation must stay intact for concurrent readers until the flip, and gc sweeps it
+    /// afterward — so the former staged-cascade DELETE of the active scope is GONE (its
+    /// collision-avoidance job is obsolete: the widened `UNIQUE(repo_id, path, commit_sha,
+    /// worktree_id, generation)` lets a stale lingering overlay coexist with the fresh insert
+    /// at a different generation).
+    ///
+    /// Only the first-index chunk-text staging table is (re)created here: `insert_chunks` writes
+    /// the in-memory text into it and `build_chunk_text_store` reads + clears it (there is no
+    /// chunks.text column). `chunk_text_dict` is never cleared — dicts are IMMUTABLE decode
+    /// keys (#77 Phase 2), and other generations'/scopes' blobs reference existing versions.
+    /// Called by `index_targets_with_progress` (batch 7): BOTH entries — the full rebuild and the
+    /// standalone `index_targets` — run the wave loop whose inserts stage into this table.
+    pub(super) fn prepare_rebuild_scratch_tables(&self) -> anyhow::Result<()> {
         self.storage.execute_batch(
             "CREATE TEMP TABLE IF NOT EXISTS rebuild_chunk_text(
                  chunk_id INTEGER PRIMARY KEY,
@@ -298,15 +543,36 @@ impl IndexDatabase {
              );
              DELETE FROM temp.rebuild_chunk_text;",
         )?;
-        self.storage.execute_batch("DELETE FROM temp.staged_file_ids;")?;
         Ok(())
     }
 
-    /// Cascade-delete every derived row (edges, symbols, chunks, embeddings, FTS, blame, docs,
-    /// parser failures) for the file ids staged in `temp.staged_file_ids`, then the files
-    /// themselves. The caller is responsible for populating and clearing the temp table.
-    /// Shared by full rebuild (active context) and GC (dead, non-live contexts).
-    pub(super) fn delete_staged_files_cascade(&self) -> anyhow::Result<()> {
+    /// Cascade-delete every derived row (edges, symbols, chunks, embeddings, FTS, blame, docs —
+    /// and, for a context-death sweep only, parser failures) for the file ids staged in
+    /// `temp.staged_file_ids`, then the files themselves. The caller is responsible for populating
+    /// and clearing the temp table. GC's two sweeps share it, distinguished by [`StagedSweep`].
+    pub(super) fn delete_staged_files_cascade(&self, sweep: StagedSweep) -> anyhow::Result<()> {
+        // GENERATION-LESS TABLE CLASSIFICATION (A6, P2 review): `parser_failures` is keyed by
+        // `(repo_id, path)` with NO generation — path-keyed indexer state OWNED at (re)parse time
+        // (upsert on failure, clear on clean parse, orphan-path sweep in the rebuild tail). A
+        // DEAD-GENERATION sweep must NOT delete it: the staged dead rows share their paths with the
+        // LIVE generation, so the path-keyed delete would drop a still-failing live path's only
+        // record. Only true CONTEXT death (a dead commit/worktree — the path's last owner in this
+        // repo going away) may clear it. The row-value join matches BOTH key columns so a sibling
+        // repo's failure at the same path is never clobbered. Runs BEFORE the batch below (it joins
+        // the staged `main.files` rows the batch deletes). Everything else in the cascade is keyed
+        // by staged file/symbol/chunk ids (per-generation rows) or, for the `logical_symbols`
+        // orphan cleanup, by membership — correct under both sweep axes.
+        if sweep == StagedSweep::DeadContext {
+            self.storage.connection().execute(
+                "DELETE FROM main.parser_failures
+                 WHERE (repo_id, path) IN (
+                     SELECT files.repo_id, files.path
+                     FROM main.files
+                     JOIN temp.staged_file_ids ON staged_file_ids.id = files.id
+                 )",
+                [],
+            )?;
+        }
         self.storage.execute_batch(
             "
             INSERT OR IGNORE INTO main.name_strings(value) VALUES ('unresolved');
@@ -385,15 +651,6 @@ impl IndexDatabase {
                 FROM main.chunks
                 JOIN temp.staged_file_ids ON staged_file_ids.id = chunks.file_id
             );
-            -- `parser_failures` is keyed by `(repo_id, path)` (V040), so match BOTH — a bare-path
-            -- delete would clobber a sibling repo's failure at the same path. Staged files all
-            -- belong to one repo, but the row-value join is correct regardless of that.
-            DELETE FROM main.parser_failures
-            WHERE (repo_id, path) IN (
-                SELECT files.repo_id, files.path
-                FROM main.files
-                JOIN temp.staged_file_ids ON staged_file_ids.id = files.id
-            );
             DELETE FROM main.symbol_fingerprints
             WHERE symbol_id IN (
                 SELECT symbols.id
@@ -413,5 +670,73 @@ impl IndexDatabase {
             ",
         )?;
         Ok(())
+    }
+}
+
+/// Test seam for the generation-staged rebuild: a barrier the full rebuild runs after each
+/// committed file wave, so a concurrent reader can observe the STAGED (committed but not-yet-live)
+/// generation mid-rebuild. Compiled out of production entirely; kept at the end of the file so it
+/// does not read as a `#[cfg(test)]` module with production items after it
+/// (clippy::items_after_test_module).
+///
+/// KEYED BY DATABASE PATH, never a single process-global slot: the coverage job runs plain
+/// `cargo test` under llvm-cov — every test shares ONE process with parallel libtest threads
+/// (unlike nextest's process-per-test), so two barrier tests racing a global slot drop each
+/// other's hook (and its channel sender → `RecvError`), and a leaked hook could fire inside an
+/// UNRELATED test's rebuild. The same class as the #409 flock/fork coverage incident: same-process
+/// global state that is safe under nextest breaks under libtest. Keying by the rebuild's database
+/// path makes concurrent tests inherently isolated (each uses its own temp DB), and registration
+/// returns an RAII [`WaveBarrierGuard`] so the entry is removed even when the test panics.
+#[cfg(test)]
+mod wave_barrier {
+    use std::collections::BTreeMap;
+    use std::path::{Path, PathBuf};
+    use std::sync::{Arc, Mutex};
+
+    /// `Arc`, not `Box`: [`run_after_wave_commit`] clones the hook out of the registry and RELEASES
+    /// the map lock before calling it — the hook blocks on its test barrier, and holding the map
+    /// lock across that block would serialize (or deadlock) every other test's registration.
+    /// `Sync` is required by the shared `Arc`; hook captures that are `!Sync` (channel endpoints)
+    /// ride in `Mutex`es.
+    pub(crate) type WaveHook = Arc<dyn Fn() + Send + Sync + 'static>;
+
+    static AFTER_WAVE_COMMIT: Mutex<BTreeMap<PathBuf, WaveHook>> = Mutex::new(BTreeMap::new());
+
+    /// Unregisters its database's hook on drop — panic-safe cleanup, so a failing barrier test
+    /// can never leak a hook into a stranger's rebuild.
+    pub(crate) struct WaveBarrierGuard {
+        database: PathBuf,
+    }
+
+    impl Drop for WaveBarrierGuard {
+        fn drop(&mut self) {
+            if let Ok(mut hooks) = AFTER_WAVE_COMMIT.lock() {
+                hooks.remove(&self.database);
+            }
+        }
+    }
+
+    /// Register the after-wave-commit hook for the rebuild whose `config.database` is `database`.
+    /// Hold the returned guard for the duration of the observed rebuild.
+    #[must_use = "dropping the guard unregisters the hook"]
+    pub(crate) fn set_after_wave_commit(database: &Path, hook: WaveHook) -> WaveBarrierGuard {
+        AFTER_WAVE_COMMIT
+            .lock()
+            .expect("wave barrier registry poisoned")
+            .insert(database.to_path_buf(), hook);
+        WaveBarrierGuard { database: database.to_path_buf() }
+    }
+
+    /// Invoked by the full-rebuild wave loop after each wave commits, with the rebuilding
+    /// connection's database path; fires only a hook registered for THAT database.
+    pub(crate) fn run_after_wave_commit(database: &Path) {
+        let hook = AFTER_WAVE_COMMIT
+            .lock()
+            .expect("wave barrier registry poisoned")
+            .get(database)
+            .cloned();
+        if let Some(hook) = hook {
+            hook();
+        }
     }
 }

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1177,6 +1177,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_040_ID => Some(40),
             MIGRATION_041_ID => Some(41),
             MIGRATION_042_ID => Some(42),
+            MIGRATION_043_ID => Some(43),
             _ => None,
         })
         .max()
@@ -1228,6 +1229,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_040_ID
             | MIGRATION_041_ID
             | MIGRATION_042_ID
+            | MIGRATION_043_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1276,6 +1278,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_040_ID => migration.checksum != MIGRATION_040_CHECKSUM,
         MIGRATION_041_ID => migration.checksum != MIGRATION_041_CHECKSUM,
         MIGRATION_042_ID => migration.checksum != MIGRATION_042_CHECKSUM,
+        MIGRATION_043_ID => migration.checksum != MIGRATION_043_CHECKSUM,
         _ => false,
     }
 }
@@ -1998,6 +2001,85 @@ fn rebuild_files_table_with_repo_id(conn: &Connection) -> rusqlite::Result<()> {
         SELECT
             id, path, language, kind, sha256, modified_at_ms, generated, indexed_at_ms,
             indexed_revision, commit_sha, worktree_id, has_test_code, '__unassigned__'
+        FROM files;
+        DROP TABLE files;
+        ALTER TABLE files_new RENAME TO files;
+        CREATE INDEX IF NOT EXISTS idx_files_language ON files(language);
+        CREATE INDEX IF NOT EXISTS idx_files_commit_path ON files(commit_sha, path);
+        CREATE INDEX IF NOT EXISTS idx_files_worktree_path ON files(worktree_id, path);
+        ",
+    )
+}
+
+/// V043 (phase A6): add `files.generation` and widen the UNIQUE to `(repo_id, path, commit_sha,
+/// worktree_id, generation)`, so a full rebuild can STAGE a fresh generation of every file row
+/// ALONGSIDE the live one (same `(repo_id, path, commit_sha, worktree_id)`, different `generation`)
+/// and flip readers over atomically, instead of clearing-then-reinserting inside one long
+/// write-locked transaction (spec §3.3 — bounded writer holds + reader consistency).
+///
+/// SENTINEL: `files.generation` present ⇒ the whole migration already committed (the rebuild below
+/// is atomic), so a `create_or_migrate`/`rebuild`/`index --full` re-apply short-circuits before the
+/// write lock — the V040/V042 recipe.
+///
+/// NO placeholder→sole-repo backfill (unlike V040–V042): `generation` is REPO-NEUTRAL. Every
+/// pre-V043 row is the current live generation of its repo, and `DEFAULT 0` stamps them all 0 —
+/// which is exactly the live generation a fresh index carries (`repo_meta[live_files_generation]`
+/// absent ⇒ 0). So existing rows stay visible under the live-generation scope view with no per-repo
+/// resolution, on an adopted or an un-adopted DB alike.
+pub(crate) fn apply_files_generation(conn: &Connection) -> rusqlite::Result<()> {
+    // All-or-nothing sentinel: the rebuild commits atomically, so `files.generation` present means
+    // the whole migration already ran. Short-circuit before taking the write lock.
+    if column_exists(conn, "files", "generation")? {
+        return Ok(());
+    }
+    // The rebuild RENAMEs an FK-referenced parent (`chunks`/`symbols`/`edges_data` REFERENCE
+    // files(id)); FK enforcement must be OFF, and a PRAGMA toggle is a no-op inside a transaction,
+    // so set it BEFORE BEGIN (the V040 recipe).
+    conn.execute_batch("PRAGMA foreign_keys = OFF; BEGIN IMMEDIATE;")?;
+    let result = rebuild_files_table_with_generation(conn);
+    if result.is_err() {
+        let _ = conn.execute_batch("ROLLBACK; PRAGMA foreign_keys = ON;");
+        return result;
+    }
+    conn.execute_batch("COMMIT; PRAGMA foreign_keys = ON;")?;
+    Ok(())
+}
+
+/// Rebuild `files` adding a trailing `generation INTEGER NOT NULL DEFAULT 0` column and the widened
+/// `UNIQUE(repo_id, path, commit_sha, worktree_id, generation)`. Copies `id` verbatim (FK target of
+/// `chunks`/`symbols`/`edges_data` — the V040 `rebuild_files_table_with_repo_id` precedent) and
+/// stamps every existing row `generation = 0` (the live generation of a not-yet-restaged index).
+/// `files` stays non-STRICT to match its baseline shape. Leading `DROP TABLE IF EXISTS files_new` =
+/// torn-state re-convergence (a hard kill of a prior V043 pass could leave the scratch table
+/// behind).
+fn rebuild_files_table_with_generation(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS files_new;
+        CREATE TABLE files_new(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            path TEXT NOT NULL,
+            language TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            sha256 TEXT NOT NULL,
+            modified_at_ms INTEGER NOT NULL,
+            generated INTEGER NOT NULL DEFAULT 0,
+            indexed_at_ms INTEGER NOT NULL,
+            indexed_revision TEXT NOT NULL DEFAULT '',
+            commit_sha TEXT NOT NULL DEFAULT '',
+            worktree_id TEXT NOT NULL DEFAULT '',
+            has_test_code INTEGER NOT NULL DEFAULT 0,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__',
+            generation INTEGER NOT NULL DEFAULT 0,
+            UNIQUE(repo_id, path, commit_sha, worktree_id, generation)
+        );
+        INSERT OR IGNORE INTO files_new(
+            id, path, language, kind, sha256, modified_at_ms, generated, indexed_at_ms,
+            indexed_revision, commit_sha, worktree_id, has_test_code, repo_id, generation
+        )
+        SELECT
+            id, path, language, kind, sha256, modified_at_ms, generated, indexed_at_ms,
+            indexed_revision, commit_sha, worktree_id, has_test_code, repo_id, 0
         FROM files;
         DROP TABLE files;
         ALTER TABLE files_new RENAME TO files;

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -10,14 +10,15 @@ pub(crate) use migrations::*;
 #[cfg(test)]
 pub(crate) use registry::multiple_real_repos;
 pub(crate) use registry::{
-    CONNECTION_CONTEXT_REPO_KEY, active_repo_id, periphery_repo_scope, periphery_repo_scope_clause,
-    resolve_config_repo_id, sole_repo_id,
+    CONNECTION_CONTEXT_GENERATION_KEY, CONNECTION_CONTEXT_REPO_KEY, LIVE_FILES_GENERATION_META_KEY,
+    active_generation, active_repo_id, live_files_generation, periphery_repo_scope,
+    periphery_repo_scope_clause, resolve_config_repo_id, sole_repo_id,
 };
 pub use registry::{LEGACY_REPO_ID, register_repo};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 42;
+pub const LATEST_SCHEMA_VERSION: u32 = 43;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -284,6 +285,13 @@ const MIGRATION_042_DESCRIPTION: &str =
      repo_memory_fts with a repo_id UNINDEXED column, so clone stats, oracle runs, and memory \
      search in a consolidated database never pool or surface a sibling repo's rows (memory-sync \
      phase A5)";
+const MIGRATION_043_ID: &str = "043_files_generation";
+const MIGRATION_043_CHECKSUM: &str = "sha256:rag-rat-files-generation-v43";
+const MIGRATION_043_DESCRIPTION: &str =
+    "Add files.generation and widen the UNIQUE key to (repo_id, path, commit_sha, worktree_id, \
+     generation), so a full rebuild can stage a fresh generation of every file row alongside the \
+     live one and flip readers over atomically instead of clearing-then-reinserting inside one \
+     long write-locked transaction (memory-sync phase A6)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -635,6 +643,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_042_CHECKSUM,
         description: MIGRATION_042_DESCRIPTION,
         apply: apply_repo_id_periphery_scoping,
+    },
+    Migration {
+        id: MIGRATION_043_ID,
+        checksum: MIGRATION_043_CHECKSUM,
+        description: MIGRATION_043_DESCRIPTION,
+        apply: apply_files_generation,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema/registry.rs
+++ b/crates/rag-rat-core/src/index/schema/registry.rs
@@ -8,6 +8,17 @@ use crate::repo_identity::{LOCAL_ONLY_ID_PREFIX, RepoIdentity, RepoIdentityClass
 /// `commit_sha` / `worktree_id`). [`active_repo_id`] reads it; `install_scope_view` writes it.
 pub(crate) const CONNECTION_CONTEXT_REPO_KEY: &str = "repo_id";
 
+/// The `temp.connection_context` key under which the scope view stashes the active file GENERATION
+/// (A6) — the value the `files` view filters on. `write_scope_view` writes it (the LIVE generation
+/// for a reader/incremental open, the WRITE generation for the connection driving a full rebuild);
+/// [`active_generation`] reads it back for the view-less heal paths.
+pub(crate) const CONNECTION_CONTEXT_GENERATION_KEY: &str = "files_generation";
+
+/// The `repo_meta` key holding a repo's LIVE `files.generation` — the pointer a full rebuild flips
+/// once its freshly-staged generation is complete (A6). Absent ⇒ 0 (a fresh index, and every row a
+/// pre-V043 upgrade carries), so an un-restaged index needs no `repo_meta` write to be visible.
+pub(crate) const LIVE_FILES_GENERATION_META_KEY: &str = "live_files_generation";
+
 /// The direct-scoped tables whose [`LEGACY_REPO_ID`] placeholder rows [`register_repo`] re-points
 /// at the real id when it adopts a legacy DB. V040 (phase A3) added the core tables; V041 (phase
 /// A4) added the seven GitHub papertrail tables plus the derived `github_fts` mirror (own-content
@@ -76,6 +87,12 @@ pub const LEGACY_REPO_ID: &str = "__unassigned__";
 /// later LocalOnly→Portable upgrade can PROVE the incoming deepened clone is the same repository —
 /// its HEAD must reach these boundary commits. Absent ⇒ no proof recorded ⇒ the upgrade is refused.
 const SHALLOW_BOUNDARY_META_KEY: &str = "shallow_boundary";
+
+/// How long a LocalOnly→Portable upgrade waits for a writer still holding the OUTGOING `local:`
+/// discriminator's write lock (A6, batch-4 P2) before refusing. Generous — an in-flight
+/// index/maintenance pass finishes its lock holds well within it; a timeout surfaces an explicit
+/// refusal, never a silent re-point under a live writer.
+const UPGRADE_OUTGOING_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Register `identity` in this database's `repos`/`repo_roots` registry, returning the stored
 /// `repo_id`.
@@ -175,6 +192,54 @@ pub fn register_repo(
                 "cannot register repo {}: this index is already registered to a different repo {}",
                 identity.repo_id, real_ids[0]
             ))),
+    };
+
+    // UPGRADE HOLDS BOTH REPO LOCKS (A6, batch-4/5 P2). Writers key their per-repo advisory flock
+    // by the DERIVED repo id, and the derivation flips `local:` → portable the moment the clone
+    // is deepened — so around an upgrade the lock IDENTITY is unstable: a writer that started
+    // PRE-unshallow holds the OUTGOING `local:` lock, a post-unshallow writer holds the INCOMING
+    // portable one, and the re-point below must serialize with BOTH. Acquire the two ids' locks
+    // in the CANONICAL LEXICOGRAPHIC ORDER (`locks::canonical_lock_order`; the locks module doc
+    // owns the ordering rule, which SUPERSEDES the old role-based "incoming-then-outgoing"
+    // argument — that argument broke as soon as a second multi-lock path appeared with the roles
+    // reversed, the batch-5 fence-gap writer). Each acquisition is reentrant-instant when this
+    // thread already holds it (a CLI entry lock for either id) and BOUNDED otherwise — bounded
+    // because entry locks are taken identity-blind, so a pre-held later-sorting lock can force an
+    // out-of-order edge, and bounded out-of-order edges are what keep that topology deadlock-free
+    // (a timeout surfaces a retryable refusal instead of a hang; see the locks module doc).
+    // ROOT-PATH-KEYED LOCKS REJECTED as the alternative: two clones of the SAME repo on one
+    // machine must still serialize on repo_id, which path-keying would break. A pathless
+    // (in-memory) connection skips the locks — no cross-process writer can exist for it.
+    let _upgrade_locks = match (&upgrade_from, conn.path().filter(|p| !p.is_empty())) {
+        (Some(local_id), Some(db_path)) => {
+            let db_path = Path::new(db_path);
+            let (first, second) =
+                crate::locks::canonical_lock_order(local_id.as_str(), &identity.repo_id);
+            let mut guards = Vec::with_capacity(2);
+            for repo in [first, second] {
+                guards.push(
+                    crate::locks::WriteLock::acquire_timeout(
+                        db_path,
+                        repo,
+                        UPGRADE_OUTGOING_LOCK_TIMEOUT,
+                    )
+                    .map_err(|err| {
+                        registry_refusal(format!(
+                            "cannot upgrade {local_id}: failed acquiring the write lock for \
+                             {repo}: {err}"
+                        ))
+                    })?
+                    .ok_or_else(|| {
+                        registry_refusal(format!(
+                            "cannot upgrade {local_id}: timed out waiting for an in-flight writer \
+                             holding the write lock for {repo}"
+                        ))
+                    })?,
+                );
+            }
+            Some(guards)
+        },
+        _ => None,
     };
 
     // No real repo yet (or a `local:`-id upgrade): adopt in ONE transaction. Insert the real
@@ -449,6 +514,48 @@ fn context_repo_id(conn: &Connection) -> Option<String> {
     .optional()
     .ok()
     .flatten()
+}
+
+/// The LIVE `files.generation` for `repo_id` (A6), read from `repo_meta`. Absent or unparseable ⇒
+/// `0`, which is the generation `DEFAULT 0` stamps every pre-V043 row and every never-restaged
+/// index carries — so a fresh / upgraded index is visible under generation 0 with no `repo_meta`
+/// write. The full rebuild advances this pointer atomically once its staged generation is complete.
+pub(crate) fn live_files_generation(conn: &Connection, repo_id: &str) -> rusqlite::Result<i64> {
+    let raw = crate::index::repo_meta(conn, repo_id, LIVE_FILES_GENERATION_META_KEY)?;
+    Ok(raw.and_then(|value| value.trim().parse::<i64>().ok()).unwrap_or(0))
+}
+
+/// The `files.generation` a connection operates on (A6) — the value every generation-scoped read
+/// filters against and every view-less heal path pins its `main.files` candidate pool to.
+///
+/// Prefers the SCOPE CONTEXT (`temp.connection_context['files_generation']`) installed by
+/// `write_scope_view`: a reader/incremental open carries the LIVE generation there, and the
+/// connection driving a full rebuild carries its WRITE generation (N+1) so its own edge-resolution
+/// / logical-symbol reads see the generation it is building, not the one still live. Falls back to
+/// the active repo's LIVE generation from `repo_meta` when NO context row is installed — the bare
+/// `open` heal paths (`ensure_graph_index_current` → `resolve_edges` → `all_symbols`) run without a
+/// scope view, exactly as [`active_repo_id`] falls back to [`sole_repo_id`] there.
+pub(crate) fn active_generation(conn: &Connection) -> rusqlite::Result<i64> {
+    if let Some(generation) = context_generation(conn) {
+        return Ok(generation);
+    }
+    let repo_id = active_repo_id(conn)?;
+    live_files_generation(conn, &repo_id)
+}
+
+/// Read the active generation from the per-connection scope context, tolerating the absence of the
+/// `temp.connection_context` table (a raw connection with no view installed) — the
+/// [`context_repo_id`] pattern, parsing the stored TEXT value to an integer.
+fn context_generation(conn: &Connection) -> Option<i64> {
+    conn.query_row(
+        "SELECT value FROM temp.connection_context WHERE key = ?1",
+        [CONNECTION_CONTEXT_GENERATION_KEY],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()
+    .ok()
+    .flatten()
+    .and_then(|value| value.trim().parse::<i64>().ok())
 }
 
 /// The sole repo owning a single-repo database — the identity-less fallback for [`active_repo_id`]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/chunk_store_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/chunk_store_migrations.rs
@@ -298,9 +298,11 @@ fn open_under_a_held_write_lock_migrates_older_schema_without_deadlock() {
         );
     }
 
-    // Hold the write lock exactly as the CLI `index` command does, then open under it. Pre-#226
-    // this blocked 30s on the migrate lock and errored; now it migrates immediately.
-    let _lock = crate::locks::WriteLock::acquire_blocking(&db_path).unwrap();
+    // Hold the PER-REPO write lock exactly as the CLI `index` command does, then open under it.
+    // Pre-#226 the open-time migrate took the SAME lock and self-deadlocked; A6 moved the migrate
+    // onto the GLOBAL schema lock, so it is now an INDEPENDENT lock — the held per-repo write lock
+    // never blocks it, and the open migrates immediately.
+    let _lock = crate::locks::WriteLock::acquire_blocking(&db_path, "testrepo0000").unwrap();
     let db =
         IndexDatabase::open(&db_path).expect("open migrates the Older schema under the held lock");
     assert_eq!(
@@ -595,11 +597,14 @@ fn gc_preserves_a_name_strings_entry_referenced_only_by_a_symbol() {
     let conn = db.storage.connection();
     // `files`/`symbols` are per-connection scoped TEMP VIEWS after open/rebuild; write the base
     // tables in `main`. Scope the file to the live commit so gc keeps it.
+    // Insert at the ACTIVE generation (A6) so gc's dead-generation sweep keeps this row (it is the
+    // live generation), the same way a real indexed file lands — the default 0 would be a dead
+    // generation after the rebuild advanced the live pointer, and gc would sweep it.
     conn.execute(
         "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms,
-                                commit_sha, worktree_id)
-         VALUES ('only.rs', 'rust', 'source', 'h', 0, 0, ?1, ?2)",
-        params![db.active_commit_sha, db.active_worktree_id],
+                                commit_sha, worktree_id, generation)
+         VALUES ('only.rs', 'rust', 'source', 'h', 0, 0, ?1, ?2, ?3)",
+        params![db.active_commit_sha, db.active_worktree_id, db.active_generation],
     )
     .unwrap();
     let file_id = conn.last_insert_rowid();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/generation_rebuild.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/generation_rebuild.rs
@@ -1,0 +1,1768 @@
+//! A6 generation-staged full rebuild: the V043 `files.generation` shape, reader consistency across
+//! the generation flip, that a paused (staged, chunked) rebuild does not hold the write lock, and
+//! that the poison sibling survives a full rebuild of the primary repo.
+//!
+//! The reader-consistency tests drive `rebuild_with_progress` on a background thread and pause it
+//! at the after-wave-commit barrier ([`crate::index::rebuild::set_after_wave_commit`]). The
+//! barrier registry is KEYED BY DATABASE PATH with an RAII unregister guard, so the tests are
+//! safe under plain `cargo test` (one process, parallel libtest threads — the coverage job's
+//! model) as well as nextest's process-per-test: concurrent tests use distinct temp databases and
+//! therefore distinct keys.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, mpsc};
+
+use rusqlite::OptionalExtension;
+
+use super::*;
+
+/// A git fixture repo with the named source files under `src/`, plus its source `Config` (absolute
+/// DB path, like production). A REAL git checkout so `adopt_repo_from_config` registers a portable
+/// repo id.
+fn generation_fixture(files: &[(&str, &str)]) -> (PathBuf, Config) {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    for (name, body) in files {
+        fs::write(root.join("src").join(name), body).unwrap();
+    }
+    run_git(&root, &["init", "-q", "-b", "main"]);
+    run_git(&root, &["config", "user.email", "t@e"]);
+    run_git(&root, &["config", "user.name", "t"]);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "seed"]);
+    let config = source_config(root.clone(), Language::Rust);
+    (root, config)
+}
+
+/// The repo id `root` maps to, resolved on a fresh read connection (registration already happened).
+fn resolve_repo_id(db_path: &Path, root: &Path) -> String {
+    let conn = rusqlite::Connection::open(db_path).unwrap();
+    crate::index::resolve_scope_repo_id(&conn, root, None).unwrap().unwrap_or_default()
+}
+
+/// The live `files.generation` pointer for `repo_id`, read from a fresh connection.
+fn live_generation(db_path: &Path, repo_id: &str) -> i64 {
+    let conn = rusqlite::Connection::open(db_path).unwrap();
+    conn.query_row(
+        "SELECT value FROM repo_meta WHERE repo_id = ?1 AND key = 'live_files_generation'",
+        [repo_id],
+        |r| r.get::<_, String>(0),
+    )
+    .optional()
+    .unwrap()
+    .and_then(|v| v.parse().ok())
+    .unwrap_or(0)
+}
+
+/// Non-deleted file rows of `repo_id` at a specific generation, read directly from `main.files`.
+fn files_at_generation(db_path: &Path, repo_id: &str, generation: i64) -> i64 {
+    let conn = rusqlite::Connection::open(db_path).unwrap();
+    conn.query_row(
+        "SELECT COUNT(*) FROM main.files WHERE repo_id = ?1 AND generation = ?2 AND kind != \
+         'deleted'",
+        rusqlite::params![repo_id, generation],
+        |r| r.get(0),
+    )
+    .unwrap()
+}
+
+/// The file count a READER sees through the production scope view — installs `temp.files` on a
+/// fresh connection exactly as the raw-conn hook path does (resolving the live generation from
+/// repo_meta), then counts through it. This is what a concurrent reader of the repo actually
+/// observes.
+fn reader_scoped_file_count(db_path: &Path, root: &Path) -> i64 {
+    let conn = rusqlite::Connection::open(db_path).unwrap();
+    let repo_id =
+        crate::index::resolve_scope_repo_id(&conn, root, None).unwrap().unwrap_or_default();
+    crate::index::install_worktree_scope_view(&conn, &repo_id, root, root).unwrap();
+    conn.query_row("SELECT COUNT(*) FROM temp.files", [], |r| r.get(0)).unwrap()
+}
+
+/// Whether a path is visible to a READER through the scope view (live generation).
+fn reader_sees_path(db_path: &Path, root: &Path, path: &str) -> bool {
+    let conn = rusqlite::Connection::open(db_path).unwrap();
+    let repo_id =
+        crate::index::resolve_scope_repo_id(&conn, root, None).unwrap().unwrap_or_default();
+    crate::index::install_worktree_scope_view(&conn, &repo_id, root, root).unwrap();
+    conn.query_row("SELECT EXISTS(SELECT 1 FROM temp.files WHERE path = ?1)", [path], |r| r.get(0))
+        .unwrap()
+}
+
+/// V043 is the schema tip: `files` gains `generation` and the UNIQUE widens to include it, so two
+/// rows identical except in generation coexist while a true duplicate still violates the key.
+#[test]
+fn schema_at_latest_after_apply_is_v043() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 43, "V043 is the schema tip");
+    assert_eq!(schema::status(&conn).unwrap().current_version, 43, "schema at LATEST after apply");
+    assert!(
+        conn_table_columns(&conn, "files").contains(&"generation".to_string()),
+        "files gains a generation column"
+    );
+
+    // generation is part of the UNIQUE: two rows differing ONLY in generation coexist.
+    let insert = |generation: i64| {
+        conn.execute(
+            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+             repo_id, generation) VALUES ('a.rs', 'rust', 'source', 'h', 0, 0, 'r', ?1)",
+            [generation],
+        )
+    };
+    insert(0).unwrap();
+    insert(1).expect("a second generation of the same (repo_id, path, scope) coexists");
+    assert!(
+        insert(0).is_err(),
+        "a true duplicate (same repo_id, path, commit_sha, worktree_id, generation) violates \
+         UNIQUE"
+    );
+}
+
+/// V043's `files` rebuild in ISOLATION against a post-V040 shape: it adds `generation` (absent
+/// before — the deferred-absence assertion anchored to the migration DDL, not the full ladder),
+/// preserves `id` + `repo_id` verbatim, backfills generation 0 (repo-neutral — no sole-repo
+/// resolution), re-converges from a torn `files_new` scratch table, and is a no-op on replay.
+#[test]
+fn migration_043_adds_generation_and_reconverges_from_torn_state() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    // A post-V040 `files` shape (repo_id, NO generation) with one adopted row, plus a leftover
+    // scratch table from a crashed prior V043 pass.
+    conn.execute_batch(
+        "CREATE TABLE files(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            path TEXT NOT NULL, language TEXT NOT NULL, kind TEXT NOT NULL, sha256 TEXT NOT NULL,
+            modified_at_ms INTEGER NOT NULL, generated INTEGER NOT NULL DEFAULT 0,
+            indexed_at_ms INTEGER NOT NULL, indexed_revision TEXT NOT NULL DEFAULT '',
+            commit_sha TEXT NOT NULL DEFAULT '', worktree_id TEXT NOT NULL DEFAULT '',
+            has_test_code INTEGER NOT NULL DEFAULT 0, repo_id TEXT NOT NULL DEFAULT \
+         '__unassigned__',
+            UNIQUE(repo_id, path, commit_sha, worktree_id)
+        );
+        INSERT INTO files(id, path, language, kind, sha256, modified_at_ms, indexed_at_ms, repo_id)
+            VALUES (42, 'keep.rs', 'rust', 'source', 'h', 0, 0, 'realrepo');
+        CREATE TABLE files_new(leftover INTEGER);",
+    )
+    .unwrap();
+    // Deferred-absence, anchored to the migration DDL in isolation (the Risk-memory pattern).
+    assert!(
+        !conn_table_columns(&conn, "files").contains(&"generation".to_string()),
+        "generation is absent before V043 runs"
+    );
+
+    schema::apply_files_generation(&conn).unwrap();
+
+    assert!(
+        conn_table_columns(&conn, "files").contains(&"generation".to_string()),
+        "V043 adds the generation column"
+    );
+    let (id, repo, generation): (i64, String, i64) = conn
+        .query_row("SELECT id, repo_id, generation FROM files WHERE path = 'keep.rs'", [], |r| {
+            Ok((r.get(0)?, r.get(1)?, r.get(2)?))
+        })
+        .unwrap();
+    assert_eq!(id, 42, "id preserved verbatim (FK target of chunks/symbols/edges_data)");
+    assert_eq!(
+        repo, "realrepo",
+        "repo_id preserved verbatim (generation backfill is repo-neutral)"
+    );
+    assert_eq!(generation, 0, "existing rows carry generation 0");
+    // Torn scratch re-converged (dropped + rebuilt), and a replay short-circuits on the sentinel.
+    schema::apply_files_generation(&conn).expect("replay is a no-op");
+    // The widened UNIQUE now admits a second generation of the same scope.
+    conn.execute(
+        "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, repo_id, \
+         generation) VALUES ('keep.rs', 'rust', 'source', 'h', 0, 0, 'realrepo', 1)",
+        [],
+    )
+    .expect("generation joined the UNIQUE key");
+}
+
+/// STEP 1 (reader consistency): a reader opened while a full rebuild is mid-flight sees the
+/// COMPLETE old generation until the flip, then the complete new one; the dead generation is swept
+/// by gc.
+#[test]
+fn a_reader_sees_the_complete_old_generation_until_the_rebuild_flips() {
+    let (root, config) = generation_fixture(&[
+        ("a.rs", "pub fn a() -> u32 { 1 }\n"),
+        ("b.rs", "pub fn b() -> u32 { 2 }\n"),
+        ("c.rs", "pub fn c() -> u32 { 3 }\n"),
+    ]);
+    // First rebuild establishes the live generation with three files.
+    IndexDatabase::rebuild(&config).unwrap();
+    let db_path = config.database.clone();
+    let repo_id = resolve_repo_id(&db_path, &root);
+    let old_live = live_generation(&db_path, &repo_id);
+    assert_eq!(reader_scoped_file_count(&db_path, &root), 3, "three files live before the rebuild");
+
+    // Add a FOURTH file as an UNCOMMITTED (dirty) working-tree file, so the next generation differs
+    // in count from the live one WITHOUT moving HEAD — the reader-consistency invariant is about
+    // the GENERATION axis with commit/worktree held fixed (a HEAD move would put the old
+    // generation's committed rows at a different commit scope than the reader resolves to,
+    // conflating the axes).
+    fs::write(root.join("src/d.rs"), "pub fn d() -> u32 { 4 }\n").unwrap();
+
+    // Pause the rebuild at the after-wave-commit barrier: the fresh generation is staged
+    // (committed) but the live pointer has NOT flipped yet. The barrier is KEYED by this test's
+    // own database path (parallel same-process tests never collide) and the guard unregisters it
+    // on drop, panic included (see `spawn_paused_rebuild`).
+    let (_barrier, reached_rx, resume_tx, handle) = spawn_paused_rebuild(&config);
+
+    // The rebuild is now paused with the staged generation committed but not live.
+    reached_rx.recv().unwrap();
+    assert_eq!(
+        live_generation(&db_path, &repo_id),
+        old_live,
+        "the live generation has NOT advanced while the rebuild is mid-flight"
+    );
+    assert_eq!(
+        reader_scoped_file_count(&db_path, &root),
+        3,
+        "a reader mid-rebuild sees the COMPLETE old generation (three files), not the staged one"
+    );
+    assert!(
+        !reader_sees_path(&db_path, &root, "src/d.rs"),
+        "the staged new file is invisible to readers until the flip"
+    );
+
+    // Let the rebuild finish (flip). The barrier guard unregisters on scope exit.
+    resume_tx.send(()).unwrap();
+    handle.join().unwrap();
+
+    // After the flip a reader sees the NEW generation (four files, including d.rs).
+    let new_live = live_generation(&db_path, &repo_id);
+    assert!(new_live > old_live, "the flip advanced the live generation: {old_live} -> {new_live}");
+    assert_eq!(reader_scoped_file_count(&db_path, &root), 4, "the reader now sees four files");
+    assert!(
+        reader_sees_path(&db_path, &root, "src/d.rs"),
+        "the new file is visible after the flip"
+    );
+
+    // The dead old generation lingers until gc, then is swept.
+    assert!(
+        files_at_generation(&db_path, &repo_id, old_live) > 0,
+        "the dead old generation lingers in storage before gc"
+    );
+    let db = IndexDatabase::open_config(&config).unwrap();
+    db.garbage_collect().unwrap();
+    assert_eq!(
+        files_at_generation(&db_path, &repo_id, old_live),
+        0,
+        "gc sweeps the dead old generation"
+    );
+
+    drop(db);
+    let _ = fs::remove_dir_all(root);
+}
+
+/// STEP 2 (bounded writer holds): while a full rebuild is PAUSED between committed waves — holding
+/// no transaction, because the rebuild is chunked, not one mega-transaction — a write to ANOTHER
+/// repo in the same shared DB completes well within the busy-timeout slice. A whole-rebuild
+/// `BEGIN IMMEDIATE` would pin the WAL write lock and this would block past the 2 s bar.
+#[test]
+fn a_paused_rebuild_does_not_block_a_write_to_another_repo() {
+    let (root, config) = generation_fixture(&[
+        ("a.rs", "pub fn a() -> u32 { 1 }\n"),
+        ("b.rs", "pub fn b() -> u32 { 2 }\n"),
+    ]);
+    // Register repo A by indexing it once, THEN seed a second repo B directly (phase-A
+    // `register_repo` refuses a second real repo through the normal open path, exactly as the
+    // multi_repo_scope fixtures seed a sibling).
+    IndexDatabase::rebuild(&config).unwrap();
+    let db_path = config.database.clone();
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('repo-b-gen', \
+             'B', 0)",
+            [],
+        )
+        .unwrap();
+    }
+
+    // Pause repo A's SECOND rebuild between committed waves. Database-keyed barrier + RAII guard
+    // (see the step-1 test) — parallel same-process tests never collide on it.
+    let (_barrier, reached_rx, resume_tx, handle) = spawn_paused_rebuild(&config);
+
+    reached_rx.recv().unwrap();
+    // The rebuild is paused with no open transaction. A write to repo B must land immediately.
+    let write_conn = rusqlite::Connection::open(&db_path).unwrap();
+    write_conn.busy_timeout(std::time::Duration::from_secs(2)).unwrap();
+    let started = std::time::Instant::now();
+    write_conn
+        .execute(
+            "INSERT INTO repo_memories(id, kind, title, body, confidence, status, created_at_ms, \
+             updated_at_ms, source, memory_version, repo_id)
+             VALUES ('gen-b-mem', 'Invariant', 't', 'b', 'high', 'active', 0, 0, 'manual', 'v1', \
+             'repo-b-gen')",
+            [],
+        )
+        .expect("the write to repo B must not be blocked by repo A's paused rebuild");
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < std::time::Duration::from_secs(2),
+        "a write to another repo completed in {elapsed:?} while repo A's rebuild was mid-flight — \
+         the staged rebuild must not hold the write lock across the whole file set"
+    );
+
+    resume_tx.send(()).unwrap();
+    handle.join().unwrap();
+
+    let _ = fs::remove_dir_all(root);
+}
+
+/// The poison-sibling harness survives a full rebuild of the PRIMARY repo: the generation-staged
+/// rebuild + flip + carry-forward operate only on the primary repo's generations, so the sibling's
+/// generation-0 rows (its own live generation) are never swept — and a repo-unscoped generation
+/// sweep would have deleted them and tripped this assertion.
+#[test]
+fn the_poison_sibling_survives_a_full_rebuild_of_the_primary_repo() {
+    let (root, config) = poison_test_config("gen_sibling");
+    // The first rebuild seeds the poison sibling at its tail (default-on). A SECOND full rebuild of
+    // the primary repo advances the primary's generation, carries its overlays forward, and leaves
+    // its prior generation dead — none of which may disturb the sibling.
+    let _first = IndexDatabase::rebuild(&config).unwrap();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    crate::index::poison_sibling::assert_sibling_intact(db.storage.connection());
+    drop(db);
+    let _ = fs::remove_dir_all(root);
+}
+
+/// This repo's `parser_failures` count for a path, from a fresh connection.
+fn failure_count_for_path(db_path: &Path, repo_id: &str, path: &str) -> i64 {
+    let conn = rusqlite::Connection::open(db_path).unwrap();
+    conn.query_row(
+        "SELECT COUNT(*) FROM parser_failures WHERE repo_id = ?1 AND path = ?2",
+        rusqlite::params![repo_id, path],
+        |r| r.get(0),
+    )
+    .unwrap()
+}
+
+/// P2 #1: `parser_failures` is path-keyed, generation-less indexer state — the dead-GENERATION
+/// sweep must NOT clear it (a path still failing in the LIVE generation shares its path with the
+/// dead generation's row), while the (re)parse itself upserts on failure and clears on a clean
+/// parse, and the rebuild tail drops records for paths removed from the tree.
+#[test]
+fn dead_generation_sweep_keeps_a_live_paths_parser_failure() {
+    let (root, config) = generation_fixture(&[
+        ("good.rs", "pub fn good() -> i32 { 1 }\n"),
+        ("bad.rs", "pub fn broken( {\n"),
+    ]);
+    IndexDatabase::rebuild(&config).unwrap();
+    let db_path = config.database.clone();
+    let repo_id = resolve_repo_id(&db_path, &root);
+    assert_eq!(
+        failure_count_for_path(&db_path, &repo_id, "src/bad.rs"),
+        1,
+        "the failing file's record is written by the first rebuild"
+    );
+
+    // Second rebuild: bad.rs still fails in the NEW generation; the old generation is left dead.
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    // Sweep the dead generation. The path exists (and still fails) in the LIVE generation, so the
+    // path-keyed record must SURVIVE the generation-dead cascade.
+    db.garbage_collect().unwrap();
+    assert_eq!(
+        failure_count_for_path(&db_path, &repo_id, "src/bad.rs"),
+        1,
+        "sweeping the dead generation must not clear a LIVE path's parser failure (P2 #1)"
+    );
+    drop(db);
+
+    // Fix the file: the next rebuild's clean (re)parse clears the record — the REBUILD owns the
+    // table, not the sweep (no gc needed).
+    fs::write(root.join("src/bad.rs"), "pub fn repaired() -> i32 { 2 }\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "fix"]);
+    IndexDatabase::rebuild(&config).unwrap();
+    assert_eq!(
+        failure_count_for_path(&db_path, &repo_id, "src/bad.rs"),
+        0,
+        "a clean re-parse clears the path's failure record at rebuild time"
+    );
+
+    // Break it again, then DELETE the file: the rebuild-tail orphan sweep drops the record for a
+    // path with a dead-generation row but none in the published generation.
+    fs::write(root.join("src/bad.rs"), "pub fn broken_again( {\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "break"]);
+    IndexDatabase::rebuild(&config).unwrap();
+    assert_eq!(failure_count_for_path(&db_path, &repo_id, "src/bad.rs"), 1);
+    fs::remove_file(root.join("src/bad.rs")).unwrap();
+    run_git(&root, &["add", "-A"]);
+    run_git(&root, &["commit", "-q", "-m", "remove"]);
+    IndexDatabase::rebuild(&config).unwrap();
+    assert_eq!(
+        failure_count_for_path(&db_path, &repo_id, "src/bad.rs"),
+        0,
+        "a path removed from the tree loses its stale record in the rebuild tail"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+/// P2 #2: the pointer flip is the TERMINAL write of a rebuild. A failure anywhere in the tail
+/// (here: injected into the logical-symbol rebuild via a trigger) must roll the WHOLE terminal
+/// transaction back — `live_files_generation` stays on the old generation and readers are
+/// unaffected; a retry stages a fresh generation and flips. Also pins the STAGED-until-publish
+/// parser-failure contract: the fixture's failing file is FIXED before the failing rebuild, and
+/// its failure record survives the failed rebuild (the staged clear rolled back with the terminal
+/// transaction) then clears on the successful retry.
+#[test]
+fn a_tail_failure_leaves_the_old_generation_live_and_a_retry_flips() {
+    let (root, config) = generation_fixture(&[
+        ("a.rs", "pub fn a() -> u32 { 1 }\n"),
+        ("b.rs", "pub fn b() -> u32 { 2 }\n"),
+        ("bad.rs", "pub fn broken( {\n"),
+    ]);
+    IndexDatabase::rebuild(&config).unwrap();
+    let db_path = config.database.clone();
+    let repo_id = resolve_repo_id(&db_path, &root);
+    let old_live = live_generation(&db_path, &repo_id);
+    assert_eq!(reader_scoped_file_count(&db_path, &root), 3);
+    assert_eq!(failure_count_for_path(&db_path, &repo_id, "src/bad.rs"), 1);
+
+    // Fix the failing file (dirty working-tree edit — the rebuild reads disk): the NEXT successful
+    // rebuild will clear the record, but the FAILED one below must not (the clear is staged and
+    // rolls back with the terminal transaction — parser-failure state flips WITH the pointer).
+    fs::write(root.join("src/bad.rs"), "pub fn repaired() -> u32 { 3 }\n").unwrap();
+
+    // Inject a failure into the terminal transaction: every logical-symbol INSERT aborts. The
+    // trigger lives in the MAIN schema, so the rebuild's own fresh connection hits it.
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TRIGGER fail_logical_symbols BEFORE INSERT ON logical_symbols
+             BEGIN SELECT RAISE(ABORT, 'injected logical-symbol failure'); END;",
+        )
+        .unwrap();
+    }
+
+    let err = IndexDatabase::rebuild(&config);
+    assert!(err.is_err(), "the injected logical-symbol failure must fail the rebuild");
+    assert_eq!(
+        live_generation(&db_path, &repo_id),
+        old_live,
+        "a tail failure must NOT publish the staged generation (P2 #2): the flip is terminal"
+    );
+    assert_eq!(
+        reader_scoped_file_count(&db_path, &root),
+        3,
+        "readers stay on the complete old generation after the failed rebuild"
+    );
+    assert_eq!(
+        failure_count_for_path(&db_path, &repo_id, "src/bad.rs"),
+        1,
+        "the fixed file's staged CLEAR rolled back with the terminal txn — parser-failure state \
+         is published atomically with the pointer, never mid-pass"
+    );
+
+    // Retry after removing the fault: the rebuild stages a FRESH generation (above the failed
+    // attempt's committed-but-never-flipped waves) and flips.
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch("DROP TRIGGER fail_logical_symbols;").unwrap();
+    }
+    IndexDatabase::rebuild(&config).unwrap();
+    assert!(
+        live_generation(&db_path, &repo_id) > old_live,
+        "the retry flips to a fresh generation"
+    );
+    assert_eq!(reader_scoped_file_count(&db_path, &root), 3);
+    assert_eq!(
+        failure_count_for_path(&db_path, &repo_id, "src/bad.rs"),
+        0,
+        "the successful retry publishes the staged clear"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+/// P2 #3: dead-generation reclamation needs NO git context, so it runs even on the "no live
+/// context" path that refuses CONTEXT pruning — a non-git / plain-directory index must not leak a
+/// full generation per rebuild.
+#[test]
+fn non_git_indexes_sweep_dead_generations_despite_the_context_prune_refusal() {
+    // A PLAIN DIRECTORY (no git init): the repo registers under the placeholder (identity Absent),
+    // and `prune_to_live(&[], &[])` is exactly the refused-context path.
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/a.rs"), "pub fn a() -> u32 { 1 }\n").unwrap();
+    fs::write(root.join("src/b.rs"), "pub fn b() -> u32 { 2 }\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let repo_id = db.active_repo_id.clone();
+    let fts_count = |db: &IndexDatabase| -> i64 {
+        db.storage
+            .connection()
+            .query_row("SELECT COUNT(*) FROM chunk_fts", [], |r| r.get(0))
+            .unwrap()
+    };
+    let report = db.prune_to_live(&[], &[]).unwrap();
+    assert!(report.skipped, "context pruning is still refused with no live sets");
+    let baseline_fts = fts_count(&db);
+    drop(db);
+
+    // A second full rebuild leaves the first generation dead; the context-refused prune must
+    // still reclaim it (files, chunks, symbols, FTS), keeping growth flat.
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let live =
+        crate::index::schema::live_files_generation(db.storage.connection(), &repo_id).unwrap();
+    let dead_count = |db: &IndexDatabase| -> i64 {
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM main.files WHERE repo_id = ?1 AND generation != ?2",
+                rusqlite::params![repo_id, live],
+                |r| r.get(0),
+            )
+            .unwrap()
+    };
+    assert!(dead_count(&db) > 0, "the second rebuild leaves the first generation dead");
+
+    let report = db.prune_to_live(&[], &[]).unwrap();
+    assert!(report.skipped, "context pruning is refused — but the generation sweep ran");
+    assert!(report.files_pruned > 0, "the dead generation was reclaimed");
+    assert_eq!(dead_count(&db), 0, "no dead-generation rows remain for this repo (P2 #3)");
+    assert_eq!(
+        fts_count(&db),
+        baseline_fts,
+        "chunk_fts stays flat across rebuild + sweep — no unbounded growth"
+    );
+    crate::index::poison_sibling::assert_sibling_intact(db.storage.connection());
+    drop(db);
+    let _ = fs::remove_dir_all(root);
+}
+
+/// P2 #4: a carried-forward overlay's edges are re-resolved against the freshly staged base inside
+/// the terminal transaction — a base symbol referenced by an overlay edge gets the NEW
+/// generation's re-minted `symbols.id`, and after gc no edge endpoint dangles.
+#[test]
+fn carried_overlay_edges_re_resolve_onto_the_new_base_generation() {
+    let (root, config) = generation_fixture(&[("lib.rs", "pub fn base_fn() -> i32 { 1 }\n")]);
+    IndexDatabase::rebuild(&config).unwrap();
+    let db_path = config.database.clone();
+    let repo_id = resolve_repo_id(&db_path, &root);
+
+    // A linked worktree whose overlay ADDS a caller of the base symbol.
+    let linked =
+        root.parent().unwrap().join(format!("{}-wt", root.file_name().unwrap().to_string_lossy()));
+    run_git(&root, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/caller.rs"), "pub fn overlay_caller() -> i32 { base_fn() }\n")
+        .unwrap();
+    let mut db = IndexDatabase::open_config(&config).unwrap();
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    drop(db);
+
+    // The overlay edge resolved onto the CURRENT base generation's symbol id.
+    let overlay_edge_target = |db_path: &Path| -> Option<i64> {
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        conn.query_row(
+            "SELECT d.to_symbol_id FROM edges_data d
+             JOIN main.files f ON f.id = d.source_file_id
+             JOIN name_strings ek ON ek.id = d.edge_kind_id
+             WHERE f.path = 'src/caller.rs' AND f.worktree_id != '' AND ek.value = 'calls_name'",
+            [],
+            |r| r.get::<_, Option<i64>>(0),
+        )
+        .unwrap()
+    };
+    let before = overlay_edge_target(&db_path).expect("overlay edge resolves onto the base symbol");
+
+    // Full rebuild: the base re-emits with re-minted symbol ids; the overlay rows are carried
+    // forward and their edges re-resolved in the terminal transaction.
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let live = live_generation(&db_path, &repo_id);
+    let new_base_symbol: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT s.id FROM main.symbols s JOIN main.files f ON f.id = s.file_id
+             WHERE s.name = 'base_fn' AND f.repo_id = ?1 AND f.generation = ?2",
+            rusqlite::params![repo_id, live],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let after = overlay_edge_target(&db_path)
+        .expect("the carried overlay edge must stay resolved after the rebuild");
+    assert_eq!(
+        after, new_base_symbol,
+        "the carried overlay edge re-resolves onto the NEW base generation's symbol id (P2 #4)"
+    );
+    assert_ne!(after, before, "the base symbol id was re-minted by the rebuild");
+
+    // After the dead generation is swept, no non-NULL edge endpoint dangles.
+    db.garbage_collect().unwrap();
+    let dangling: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM edges_data
+             WHERE to_symbol_id IS NOT NULL
+               AND to_symbol_id NOT IN (SELECT id FROM main.symbols)",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(dangling, 0, "no dangling edge endpoints after the sweep");
+
+    drop(db);
+    let _ = fs::remove_dir_all(&linked);
+    let _ = fs::remove_dir_all(root);
+}
+
+/// P2 (parser_failures.rs): a previously-indexed path that freshly fails PREPARATION (invalid
+/// UTF-8 — a failure recorded with NO new file row) must survive the rebuild-tail orphan sweep:
+/// the staged-upsert set shields exactly the paths visited-and-failed this pass.
+#[test]
+fn a_fresh_prepare_failure_for_a_previously_indexed_path_survives_the_tail_sweep() {
+    let (root, config) = generation_fixture(&[
+        ("good.rs", "pub fn good() -> i32 { 1 }\n"),
+        ("vic.rs", "pub fn victim() -> i32 { 2 }\n"),
+    ]);
+    IndexDatabase::rebuild(&config).unwrap();
+    let db_path = config.database.clone();
+    let repo_id = resolve_repo_id(&db_path, &root);
+    assert_eq!(failure_count_for_path(&db_path, &repo_id, "src/vic.rs"), 0);
+
+    // Turn the previously-indexed file UNREADABLE-as-text (invalid UTF-8): preparation fails, a
+    // failure is recorded, and NO new file row is written — while the OLD generation still holds
+    // vic.rs rows. A file-row-presence sweep alone would treat the path as removed and delete the
+    // record recorded moments earlier.
+    fs::write(root.join("src/vic.rs"), [0xFF, 0xFE, 0x00, 0x9F, 0x92]).unwrap();
+    IndexDatabase::rebuild(&config).unwrap();
+    assert_eq!(
+        failure_count_for_path(&db_path, &repo_id, "src/vic.rs"),
+        1,
+        "a fresh PREPARE failure for a previously-indexed path survives the tail orphan sweep"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+/// P2 (rebuild.rs FTS race): during a FIRST index (no `chunk_text_dict` yet — chunk text only
+/// temp-staged until `build_chunk_text_store`), a concurrent connection's FTS freshness heal must
+/// NOT destroy the staged generation's inline `chunk_fts` rows: `ensure_fts_fresh` defers while
+/// any chunk lacks its durable text row, and the published generation ends BM25-complete.
+#[test]
+fn a_concurrent_fts_refresh_during_first_index_does_not_lose_staged_rows() {
+    let (root, config) = generation_fixture(&[
+        ("a.rs", "pub fn first_index_alpha() -> u32 { 1 }\n"),
+        ("b.rs", "pub fn first_index_beta() -> u32 { 2 }\n"),
+    ]);
+    let db_path = config.database.clone();
+
+    // Pause the FIRST index between committed waves: chunk_fts rows exist for the staged chunks,
+    // chunk_text does not (the text store is built in Phase 2).
+    let (_barrier, reached_rx, resume_tx, handle) = spawn_paused_rebuild(&config);
+    reached_rx.recv().unwrap();
+
+    // A concurrent open sees a content revision the FTS has never synced (first index) — exactly
+    // the state that used to trigger the destructive 'delete-all' + rebuild-from-chunk_text.
+    let db2 = IndexDatabase::open(&db_path).unwrap();
+    let fts_rows = |db: &IndexDatabase| -> i64 {
+        db.storage
+            .connection()
+            .query_row("SELECT COUNT(*) FROM chunk_fts", [], |r| r.get(0))
+            .unwrap()
+    };
+    let staged_fts_before = fts_rows(&db2);
+    assert!(staged_fts_before > 0, "the committed waves wrote inline chunk_fts rows");
+    db2.ensure_fts_fresh().expect("the freshness heal must degrade gracefully, not error");
+    assert_eq!(
+        fts_rows(&db2),
+        staged_fts_before,
+        "the freshness heal must NOT destroy staged chunk_fts rows while chunk text is only \
+         temp-staged (it defers until the text store is complete)"
+    );
+    drop(db2);
+
+    resume_tx.send(()).unwrap();
+    handle.join().unwrap();
+
+    // The published generation is BM25-complete: every chunk of THIS repo has its FTS row (the
+    // poison sibling's chunk deliberately has neither an fts nor a text row and is excluded).
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let repo_id = resolve_repo_id(&db_path, &root);
+    let missing_fts: bool = conn
+        .query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM main.chunks
+                 JOIN main.files ON main.files.id = main.chunks.file_id
+                 WHERE main.files.repo_id = ?1
+                   AND main.chunks.id NOT IN (SELECT rowid FROM chunk_fts)
+             )",
+            [&repo_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(!missing_fts, "every published chunk has a BM25 row after the first index");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+/// P2 (incremental.rs interleaved writers) — the PROOF's regression test: a memory written
+/// mid-rebuild through the LOCKLESS path (`open_config`, the MCP route — no advisory flock),
+/// bound to a LIVE-generation chunk rowid that the flip + gc then retire, survives with full
+/// integrity: the memory is intact, `memory_validate` re-anchors its binding by content hash, no
+/// FK violation exists, and the poison sibling is untouched.
+#[test]
+fn a_memory_written_mid_rebuild_survives_the_flip_intact() {
+    let (root, config) = generation_fixture(&[
+        ("anchor.rs", "pub fn interleave_anchor() -> u32 {\n    777\n}\n"),
+        ("other.rs", "pub fn other() -> u32 { 1 }\n"),
+    ]);
+    IndexDatabase::rebuild(&config).unwrap();
+
+    // Pause the SECOND rebuild between committed waves, then write a memory through the lockless
+    // open_config path exactly as the MCP tools do — mid-rebuild, against the LIVE generation.
+    let (_barrier, reached_rx, resume_tx, handle) = spawn_paused_rebuild(&config);
+    reached_rx.recv().unwrap();
+
+    // The interleaved writer: no WriteLock taken anywhere on this path.
+    let writer = IndexDatabase::open_config(&config).unwrap();
+    let live_chunk_id: i64 = writer
+        .storage
+        .connection()
+        .query_row(
+            "SELECT chunks.id FROM chunks JOIN files ON files.id = chunks.file_id
+             WHERE files.path = 'src/anchor.rs' ORDER BY chunks.id LIMIT 1",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let created = writer
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "interleave_anchor returns 777".to_string(),
+            body: "Written mid-rebuild through the lockless path; must survive the flip."
+                .to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                chunk_id: Some(live_chunk_id),
+                ..Default::default()
+            },
+        })
+        .expect("a mid-rebuild memory write on the lockless path must succeed");
+    drop(writer);
+
+    resume_tx.send(()).unwrap();
+    handle.join().unwrap();
+
+    // Post-flip + gc: the chunk rowid the binding captured is retired with the dead generation.
+    let db = IndexDatabase::open_config(&config).unwrap();
+    db.garbage_collect().unwrap();
+    let old_chunk_live: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT COUNT(*) FROM main.chunks WHERE id = ?1", [live_chunk_id], |r| r.get(0))
+        .unwrap();
+    assert_eq!(old_chunk_live, 0, "the bound chunk rowid was retired by the flip + gc");
+
+    // Full integrity: the memory is intact and re-anchors by content hash onto the published
+    // generation's chunk (the ordinary reindex lifecycle — rowids re-mint, content anchors hold).
+    let report = db.memory_validate().unwrap();
+    assert_eq!(
+        report.relocated, 1,
+        "the mid-rebuild binding relocates onto the published generation: {report:?}"
+    );
+    let (status, rebound_chunk): (String, Option<i64>) = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT anchor_status, chunk_id FROM repo_memory_bindings WHERE memory_id = ?1",
+            [&created.memory.memory_id],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(status, "relocated", "the binding re-anchored (the healthy relocated state)");
+    assert_ne!(rebound_chunk, Some(live_chunk_id), "the binding points at the NEW chunk row");
+    let fk_violations: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT COUNT(*) FROM pragma_foreign_key_check", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(fk_violations, 0, "no FK violation from the interleaved write");
+    crate::index::poison_sibling::assert_sibling_intact(db.storage.connection());
+
+    drop(db);
+    let _ = fs::remove_dir_all(root);
+}
+
+/// P2 (incremental.rs / repo_brief): `summary_counts.graph_edges` is an EXACTNESS counter — it
+/// must count only the ACTIVE generation's edges, not the superseded generation's (visible until
+/// gc) or a staged one's.
+#[test]
+fn repo_brief_edge_count_is_generation_scoped() {
+    let (root, config) = generation_fixture(&[(
+        "lib.rs",
+        "pub fn callee() -> u32 { 1 }\npub fn caller() -> u32 { callee() }\n",
+    )]);
+    IndexDatabase::rebuild(&config).unwrap();
+    // Second rebuild: the first generation's edges linger until gc.
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+
+    let live_edges: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM edges_data e
+             JOIN main.files f ON f.id = e.source_file_id
+             WHERE f.repo_id = ?1 AND f.generation = ?2",
+            rusqlite::params![db.active_repo_id, db.active_generation],
+            |r| r.get(0),
+        )
+        .unwrap();
+    let all_repo_edges: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM edges_data e
+             JOIN main.files f ON f.id = e.source_file_id
+             WHERE f.repo_id = ?1",
+            [&db.active_repo_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(live_edges > 0, "the fixture produces at least one live edge");
+    assert!(
+        all_repo_edges > live_edges,
+        "pre-gc the repo carries the dead generation's edges too ({all_repo_edges} vs \
+         {live_edges}) — the very over-count the predicate exists to exclude"
+    );
+
+    let counts = crate::query::repo_brief::summary_counts(conn).unwrap();
+    assert_eq!(
+        counts.graph_edges, live_edges as u64,
+        "summary_counts.graph_edges counts exactly the live generation's edges"
+    );
+
+    drop(db);
+    let _ = fs::remove_dir_all(root);
+}
+
+/// Install the keyed pause barrier for `config`'s database and spawn a full rebuild on a thread,
+/// returning `(barrier_guard, reached_rx, resume_tx, join_handle)`. The rebuild pauses after its
+/// FIRST committed wave until `resume_tx` fires. Shared by the interleaving tests.
+#[allow(clippy::type_complexity)]
+fn spawn_paused_rebuild(
+    config: &Config,
+) -> (
+    crate::index::rebuild::WaveBarrierGuard,
+    mpsc::Receiver<()>,
+    mpsc::Sender<()>,
+    std::thread::JoinHandle<()>,
+) {
+    let (reached_tx, reached_rx) = mpsc::channel();
+    let (resume_tx, resume_rx) = mpsc::channel::<()>();
+    let guard = {
+        let paused = AtomicBool::new(false);
+        let reached_tx = Mutex::new(reached_tx);
+        let resume_rx = Mutex::new(resume_rx);
+        crate::index::rebuild::set_after_wave_commit(
+            &config.database,
+            Arc::new(move || {
+                if !paused.swap(true, Ordering::SeqCst) {
+                    reached_tx.lock().unwrap().send(()).unwrap();
+                    resume_rx.lock().unwrap().recv().unwrap();
+                }
+            }),
+        )
+    };
+    let rebuild_config = config.clone();
+    let handle = std::thread::spawn(move || {
+        // `rebuild_with_progress` acquires the per-repo write flock ITSELF (batch 6) — every
+        // rebuild entry holds it by construction, which is what gc's `!= live` deadness predicate
+        // relies on (holding the flock proves no rebuild is mid-flight, so above-live rows are
+        // abandoned staging, not in-progress). The barrier fires AFTER the first wave commit, well
+        // past that acquisition, so the flock is held for the whole pause — a main-thread collector
+        // that takes it then genuinely contends.
+        IndexDatabase::rebuild(&rebuild_config).unwrap();
+    });
+    (guard, reached_rx, resume_tx, handle)
+}
+
+/// P2 batch 5 (gc.rs, lock-as-discriminator): with deadness `generation != live` under the
+/// flock precondition, a collector racing a mid-flight rebuild SERIALIZES on the per-repo write
+/// flock (which every production rebuild entry holds) instead of sweeping around it — and once
+/// the rebuild completes, gc reclaims the superseded generation.
+#[test]
+fn gc_serializes_on_the_flock_while_a_rebuild_is_mid_flight() {
+    let (root, config) = generation_fixture(&[
+        ("a.rs", "pub fn a() -> u32 { 1 }\n"),
+        ("b.rs", "pub fn b() -> u32 { 2 }\n"),
+    ]);
+    IndexDatabase::rebuild(&config).unwrap();
+    let db_path = config.database.clone();
+    let repo_id = resolve_repo_id(&db_path, &root);
+    let old_live = live_generation(&db_path, &repo_id);
+
+    let (_barrier, reached_rx, resume_tx, handle) = spawn_paused_rebuild(&config);
+    reached_rx.recv().unwrap();
+
+    // Mid-pause the staged (above-live) generation is committed. A production collector takes
+    // the per-repo flock first — held by the paused rebuild — so it SERIALIZES rather than
+    // sweeping the in-progress staging (the `!= live` predicate is only safe under that lock).
+    let lock_repo = crate::locks::write_lock_repo_id(&config);
+    let contended = crate::locks::WriteLock::acquire_timeout(
+        &config.database,
+        &lock_repo,
+        std::time::Duration::from_millis(150),
+    )
+    .unwrap();
+    assert!(
+        contended.is_none(),
+        "a flock-taking collector must block while the rebuild is mid-flight"
+    );
+
+    // Resume; the rebuild flips; the flock frees; the collector proceeds and reclaims the now-
+    // superseded generation.
+    resume_tx.send(()).unwrap();
+    handle.join().unwrap();
+    assert!(live_generation(&db_path, &repo_id) > old_live, "the rebuild flipped");
+    let _flock = crate::locks::WriteLock::acquire_blocking(&config.database, &lock_repo).unwrap();
+    let db = IndexDatabase::open_config(&config).unwrap();
+    db.garbage_collect().unwrap();
+    assert_eq!(
+        files_at_generation(&db_path, &repo_id, old_live),
+        0,
+        "the superseded generation is reclaimed once the rebuild completed"
+    );
+    assert_eq!(reader_scoped_file_count(&db_path, &root), 2);
+    drop(db);
+    let _ = fs::remove_dir_all(root);
+}
+
+/// P2 (file_rows.rs, generation-bounded deletes): a LOCKLESS heal replacing a path mid-rebuild
+/// operates at the LIVE generation — it must not remove the STAGED generation's committed row for
+/// the same scope key (the V043 UNIQUE admits one row per scope key PER generation, so a
+/// generation-less delete over-matched both).
+#[test]
+fn a_lockless_heal_mid_rebuild_does_not_remove_the_staged_row() {
+    let (root, config) = generation_fixture(&[
+        ("a.rs", "pub fn heal_target() -> u32 { 1 }\n"),
+        ("b.rs", "pub fn bystander() -> u32 { 2 }\n"),
+    ]);
+    IndexDatabase::rebuild(&config).unwrap();
+    let db_path = config.database.clone();
+    let repo_id = resolve_repo_id(&db_path, &root);
+    let old_live = live_generation(&db_path, &repo_id);
+
+    let (_barrier, reached_rx, resume_tx, handle) = spawn_paused_rebuild(&config);
+    reached_rx.recv().unwrap();
+
+    let staged_rows_for_path = |db_path: &Path, path: &str| -> i64 {
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        conn.query_row(
+            "SELECT COUNT(*) FROM main.files
+             WHERE repo_id = ?1 AND generation > ?2 AND path = ?3",
+            rusqlite::params![repo_id, old_live, path],
+            |r| r.get(0),
+        )
+        .unwrap()
+    };
+    assert_eq!(
+        staged_rows_for_path(&db_path, "src/a.rs"),
+        1,
+        "the paused rebuild staged the path's fresh row"
+    );
+
+    // The lockless heal (open_config — no flock anywhere on this path) replaces the path at the
+    // LIVE generation: remove_file_in_scope + re-index. Its generation-bounded delete must leave
+    // the staged row alone.
+    let writer = IndexDatabase::open_config(&config).unwrap();
+    writer.heal_file(Path::new("src/a.rs")).unwrap();
+    drop(writer);
+    assert_eq!(
+        staged_rows_for_path(&db_path, "src/a.rs"),
+        1,
+        "a live-generation heal must not remove the staged generation's row for the same scope \
+         key (P2: deletes carry the writer's generation)"
+    );
+
+    // The rebuild resumes, flips, and the published generation serves the path.
+    resume_tx.send(()).unwrap();
+    handle.join().unwrap();
+    assert!(
+        live_generation(&db_path, &repo_id) > old_live,
+        "the rebuild flipped despite the interleaved heal"
+    );
+    assert!(
+        reader_sees_path(&db_path, &root, "src/a.rs"),
+        "the published generation serves the healed path's content"
+    );
+    assert_eq!(reader_scoped_file_count(&db_path, &root), 2);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+/// P2 (lifecycle.rs, bare-open scope view): the bare `IndexDatabase::open` (the MCP
+/// `call_tool(database, …)` read path) resolves `files` through a repo+generation view — a reader
+/// on that path sees only the LIVE generation during a mid-flight rebuild, and only the NEW
+/// generation after the flip while the superseded one lingers pre-gc.
+#[test]
+fn a_bare_open_reader_is_generation_scoped() {
+    let (root, config) = generation_fixture(&[
+        ("a.rs", "pub fn a() -> u32 { 1 }\n"),
+        ("b.rs", "pub fn b() -> u32 { 2 }\n"),
+    ]);
+    IndexDatabase::rebuild(&config).unwrap();
+    let db_path = config.database.clone();
+
+    let (_barrier, reached_rx, resume_tx, handle) = spawn_paused_rebuild(&config);
+    reached_rx.recv().unwrap();
+
+    // Mid-rebuild: the bare open's `files` view serves only the live generation — the committed
+    // staged waves are invisible (pre-fix, unqualified `files` = main.files showed both).
+    let bare = IndexDatabase::open(&db_path).unwrap();
+    let view_count: i64 = bare
+        .storage
+        .connection()
+        .query_row("SELECT COUNT(*) FROM files", [], |r| r.get(0))
+        .unwrap();
+    let raw_count: i64 = bare
+        .storage
+        .connection()
+        .query_row("SELECT COUNT(*) FROM main.files", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(view_count, 2, "the bare open serves exactly the live generation mid-rebuild");
+    assert!(
+        raw_count > view_count,
+        "main.files holds the staged rows too ({raw_count} vs {view_count}) — the view is what \
+         hides them"
+    );
+    drop(bare);
+
+    resume_tx.send(()).unwrap();
+    handle.join().unwrap();
+
+    // Post-flip, pre-gc: the superseded generation lingers in main.files, but a fresh bare open
+    // serves only the NEW generation.
+    let bare = IndexDatabase::open(&db_path).unwrap();
+    let view_count: i64 = bare
+        .storage
+        .connection()
+        .query_row("SELECT COUNT(*) FROM files", [], |r| r.get(0))
+        .unwrap();
+    let raw_count: i64 = bare
+        .storage
+        .connection()
+        .query_row("SELECT COUNT(*) FROM main.files", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(view_count, 2, "the bare open serves exactly the new live generation post-flip");
+    assert!(
+        raw_count > view_count,
+        "the superseded generation (and the sibling repo's rows) linger in main.files pre-gc; the \
+         repo+generation view keeps them out of every unqualified `files` read"
+    );
+    drop(bare);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+/// P2 batch 4 (schema-apply race): every path that can APPLY schema serializes on the GLOBAL
+/// schema lock with a double-checked state probe — two repos' concurrent `index --full` against
+/// one shared Missing-schema DB reach `create_or_migrate` simultaneously, and un-serialized
+/// `schema::apply` races itself (check-then-ALTER duplicate columns, dirty-marker churn).
+#[test]
+fn concurrent_create_or_migrate_applies_the_schema_exactly_once() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+    let db_path = root.join("index.sqlite");
+
+    let a = db_path.clone();
+    let b = db_path.clone();
+    let t1 = std::thread::spawn(move || IndexDatabase::create_or_migrate(&a).map(|_| ()));
+    let t2 = std::thread::spawn(move || IndexDatabase::create_or_migrate(&b).map(|_| ()));
+    t1.join().unwrap().expect("one concurrent applier applies");
+    t2.join().unwrap().expect("the other no-ops under the schema lock");
+
+    // The ladder is intact: Compatible at LATEST, one ledger row per migration, no dirty marker
+    // (a lingering dirty marker or duplicate-column failure would surface as Dirty / an error
+    // above).
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let status = crate::index::schema::status(&conn).unwrap();
+    assert_eq!(status.state, crate::index::schema::SchemaState::Compatible);
+    assert_eq!(status.current_version, crate::index::schema::LATEST_SCHEMA_VERSION);
+    assert_eq!(
+        status.migrations.len(),
+        crate::index::schema::LATEST_SCHEMA_VERSION as usize,
+        "exactly one schema_version row per migration"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+/// P2 batch 6 #1 (git history rides the flip): a tail failure must leave the WHOLE git-history
+/// domain reporting the OLD state — `git_commit` meta, the `git_history_indexed_*` reload-gate
+/// cursors, AND the `git_commits`/`git_file_changes` ROWS themselves. Batch 4 landed the rows early
+/// as "keyed, inert facts," but they are read DIRECTLY by orientation / churn / commit search
+/// (`recent_commit_subjects` et al.), so a rebuild that observed the new history then failed
+/// pre-flip would let those surfaces show H2's commit while readers stay on the old file
+/// generation. Now the rows fold into the terminal transaction, so a tail failure rolls them back
+/// with the pointer, and the retry publishes files + history together.
+#[test]
+fn a_tail_failure_leaves_git_meta_and_history_cursors_on_the_old_state() {
+    let (root, config) = generation_fixture(&[("a.rs", "pub fn a() -> u32 { 1 }\n")]);
+    IndexDatabase::rebuild(&config).unwrap();
+    let db_path = config.database.clone();
+    let repo_id = resolve_repo_id(&db_path, &root);
+    let (h1, _) = crate::index::resolve_git_context(&root);
+
+    let git_commit_meta = |db_path: &Path, repo_id: &str| -> Option<String> {
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        crate::index::repo_meta(&conn, repo_id, "git_commit").unwrap()
+    };
+    let history_current = |db_path: &Path, root: &Path| -> bool {
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        crate::index::git_history::is_history_current(&conn, root)
+    };
+    assert_eq!(git_commit_meta(&db_path, &repo_id).as_deref(), Some(h1.as_str()));
+    assert!(history_current(&db_path, &root), "history is current at H1 after the first rebuild");
+
+    // Move HEAD to H2, then fail the next rebuild in its terminal transaction.
+    fs::write(root.join("src/b.rs"), "pub fn b() -> u32 { 2 }\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "h2"]);
+    let (h2, _) = crate::index::resolve_git_context(&root);
+    assert_ne!(h1, h2);
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TRIGGER fail_logical_symbols BEFORE INSERT ON logical_symbols
+             BEGIN SELECT RAISE(ABORT, 'injected logical-symbol failure'); END;",
+        )
+        .unwrap();
+    }
+    assert!(IndexDatabase::rebuild(&config).is_err(), "the injected failure fails the rebuild");
+
+    // The WHOLE history domain still reports the OLD state: status() would show H1, a history
+    // reload stays owed (the cursors did not advance), AND the H2 commit ROW never landed — it was
+    // written inside the terminal transaction and rolled back with the failed tail (batch 6 #1), so
+    // orientation / churn / commit search (which read `git_commits` directly) never see H2 while
+    // the old file generation is live.
+    assert_eq!(
+        git_commit_meta(&db_path, &repo_id).as_deref(),
+        Some(h1.as_str()),
+        "git_commit meta must not report H2 while the old generation is live"
+    );
+    assert!(
+        !history_current(&db_path, &root),
+        "the history cursors must not claim H2 — a reload is still owed after the tail failure"
+    );
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let h2_row: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM git_commits WHERE repo_id = ?1 AND hash = ?2",
+                rusqlite::params![repo_id, h2],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            h2_row, 0,
+            "the H2 commit ROW must roll back with the failed terminal txn (batch 6 #1) — the git \
+             rows are read directly by orientation/search, so they cannot precede the flip"
+        );
+        // Orientation reads the newest indexed subjects straight from `git_commits`; the H2
+        // subject must be absent after the tail failure (the exact surface batch 6 #1 protects).
+        let h2_subject_visible: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM git_commits WHERE repo_id = ?1 AND subject = 'h2')",
+                rusqlite::params![repo_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            !h2_subject_visible,
+            "orientation/commit-search must not surface H2's subject while readers are on the old \
+             generation"
+        );
+    }
+
+    // The retry publishes files + git authority together.
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch("DROP TRIGGER fail_logical_symbols;").unwrap();
+    }
+    IndexDatabase::rebuild(&config).unwrap();
+    assert_eq!(git_commit_meta(&db_path, &repo_id).as_deref(), Some(h2.as_str()));
+    assert!(history_current(&db_path, &root), "cursors advanced with the successful flip");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+/// P2 batch 5 (abandoned staging): failed rebuilds leave committed-but-never-flipped generations
+/// ABOVE live — with `!= live` deadness under the flock precondition, gc reclaims them (a
+/// persistently failing tail must not leak a full staged copy per retry).
+#[test]
+fn gc_reclaims_abandoned_staged_generations_from_failed_rebuilds() {
+    let (root, config) = generation_fixture(&[
+        ("a.rs", "pub fn a() -> u32 { 1 }\n"),
+        ("b.rs", "pub fn b() -> u32 { 2 }\n"),
+    ]);
+    IndexDatabase::rebuild(&config).unwrap();
+    let db_path = config.database.clone();
+    let repo_id = resolve_repo_id(&db_path, &root);
+    let live = live_generation(&db_path, &repo_id);
+
+    // Two consecutive tail failures abandon two staged generations above live.
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TRIGGER fail_logical_symbols BEFORE INSERT ON logical_symbols
+             BEGIN SELECT RAISE(ABORT, 'injected logical-symbol failure'); END;",
+        )
+        .unwrap();
+    }
+    assert!(IndexDatabase::rebuild(&config).is_err());
+    assert!(IndexDatabase::rebuild(&config).is_err());
+    let above_live = |db_path: &Path| -> i64 {
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        conn.query_row(
+            "SELECT COUNT(DISTINCT generation) FROM main.files
+             WHERE repo_id = ?1 AND generation > ?2",
+            rusqlite::params![repo_id, live],
+            |r| r.get(0),
+        )
+        .unwrap()
+    };
+    assert_eq!(above_live(&db_path), 2, "each failed rebuild abandoned one staged generation");
+
+    // A production collector (flock held — no rebuild can be mid-flight) reclaims BOTH.
+    let lock_repo = crate::locks::write_lock_repo_id(&config);
+    let _flock = crate::locks::WriteLock::acquire_blocking(&config.database, &lock_repo).unwrap();
+    let db = IndexDatabase::open_config(&config).unwrap();
+    db.garbage_collect().unwrap();
+    drop(db);
+    assert_eq!(above_live(&db_path), 0, "both abandoned staged generations reclaimed (P2)");
+    assert_eq!(live_generation(&db_path, &repo_id), live, "the live pointer never moved");
+    assert_eq!(reader_scoped_file_count(&db_path, &root), 2, "the live generation is untouched");
+
+    // The fault removed, the retry stages and flips normally.
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch("DROP TRIGGER fail_logical_symbols;").unwrap();
+    }
+    IndexDatabase::rebuild(&config).unwrap();
+    assert!(live_generation(&db_path, &repo_id) > live);
+    assert_eq!(reader_scoped_file_count(&db_path, &root), 2);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+/// P2 batch 5 (source_root joins cursors-last): a rebuild from a NEW checkout root that fails
+/// pre-publish must leave the persisted `repo_meta[source_root]` on the OLD root — old-generation
+/// readers resolve fs-fallback paths (memory validation, heals) against it; the retry publishes
+/// the new root together with the flip.
+#[test]
+fn a_tail_failure_leaves_source_root_on_the_old_checkout() {
+    let (root, config) = generation_fixture(&[("a.rs", "pub fn a() -> u32 { 1 }\n")]);
+    IndexDatabase::rebuild(&config).unwrap();
+    let db_path = config.database.clone();
+    let repo_id = resolve_repo_id(&db_path, &root);
+    let persisted_root = |db_path: &Path| -> Option<String> {
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        crate::index::repo_meta(&conn, &repo_id, "source_root").unwrap()
+    };
+    assert_eq!(persisted_root(&db_path).as_deref(), Some(root.display().to_string().as_str()));
+
+    // A SECOND checkout of the same repo (same root commit → same repo id), rebuilt against the
+    // SAME database.
+    let root2 = unique_temp_root();
+    let _ = fs::remove_dir_all(&root2);
+    run_git(&root, &["clone", "-q", ".", root2.to_str().unwrap()]);
+    let mut config2 = config.clone();
+    config2.root = root2.clone();
+
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TRIGGER fail_logical_symbols BEFORE INSERT ON logical_symbols
+             BEGIN SELECT RAISE(ABORT, 'injected logical-symbol failure'); END;",
+        )
+        .unwrap();
+    }
+    assert!(IndexDatabase::rebuild(&config2).is_err(), "the tail failure aborts the rebuild");
+    assert_eq!(
+        persisted_root(&db_path).as_deref(),
+        Some(root.display().to_string().as_str()),
+        "source_root must stay on the OLD checkout after a failed rebuild from a new one (P2)"
+    );
+
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch("DROP TRIGGER fail_logical_symbols;").unwrap();
+    }
+    IndexDatabase::rebuild(&config2).unwrap();
+    assert_eq!(
+        persisted_root(&db_path).as_deref(),
+        Some(root2.display().to_string().as_str()),
+        "the retry publishes the new root together with the flip"
+    );
+
+    let _ = fs::remove_dir_all(&root2);
+    let _ = fs::remove_dir_all(root);
+}
+
+/// A git fixture that is also a Cargo crate (`[package] name = crate_name` + `src/lib.rs`), so
+/// `refresh_packages` records a real `packages` row + `repo_meta.local_crate_roots`.
+fn cargo_generation_fixture(crate_name: &str) -> (PathBuf, Config) {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("Cargo.toml"), format!("[package]\nname=\"{crate_name}\"\n")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn lib_fn() -> u32 { 1 }\n").unwrap();
+    run_git(&root, &["init", "-q", "-b", "main"]);
+    run_git(&root, &["config", "user.email", "t@e"]);
+    run_git(&root, &["config", "user.name", "t"]);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "seed"]);
+    let config = source_config(root.clone(), Language::Rust);
+    (root, config)
+}
+
+/// Batch 6 #4 (package roots ride the flip): `refresh_packages` writes the generation-less
+/// `packages` rows + `repo_meta.local_crate_roots` INSIDE the terminal publish transaction now
+/// (folded into `finalize_base_edges`), so a rebuild that observes CHANGED Cargo roots then fails
+/// pre-flip leaves both on the OLD state — a concurrent reader/heal never resolves old-generation
+/// files against the new package map, and a failed tail strands nothing.
+#[test]
+fn a_tail_failure_leaves_package_roots_on_the_old_state() {
+    let (root, config) = cargo_generation_fixture("alpha");
+    IndexDatabase::rebuild(&config).unwrap();
+    let db_path = config.database.clone();
+    let repo_id = resolve_repo_id(&db_path, &root);
+    let local_roots = |db_path: &Path| -> Option<String> {
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        crate::index::repo_meta(&conn, &repo_id, "local_crate_roots").unwrap()
+    };
+    assert_eq!(
+        local_roots(&db_path).as_deref(),
+        Some("alpha"),
+        "the first rebuild recorded the alpha crate root"
+    );
+
+    // Change the crate root (dirty Cargo.toml edit — the rebuild reads disk), then fail the next
+    // rebuild in its terminal transaction.
+    fs::write(root.join("Cargo.toml"), "[package]\nname=\"beta\"\n").unwrap();
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TRIGGER fail_logical_symbols BEFORE INSERT ON logical_symbols
+             BEGIN SELECT RAISE(ABORT, 'injected logical-symbol failure'); END;",
+        )
+        .unwrap();
+    }
+    assert!(IndexDatabase::rebuild(&config).is_err(), "the tail failure aborts the rebuild");
+    assert_eq!(
+        local_roots(&db_path).as_deref(),
+        Some("alpha"),
+        "local_crate_roots must stay on the OLD roots after a failed rebuild (batch 6 #4) — the \
+         package-root write rides the flip, so it rolled back with the terminal transaction"
+    );
+
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch("DROP TRIGGER fail_logical_symbols;").unwrap();
+    }
+    IndexDatabase::rebuild(&config).unwrap();
+    assert_eq!(
+        local_roots(&db_path).as_deref(),
+        Some("beta"),
+        "the retry publishes the new crate root together with the flip"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+/// Batch 6 #3 (overlay package roots carried across a base HEAD advance): a full rebuild that
+/// advances the base HEAD while a linked-worktree overlay is carried forward moves the overlay's
+/// FILE rows by `worktree_id` (commit-agnostic) but leaves its `packages` rows keyed to the OLD
+/// base commit — so the terminal-txn edge re-resolution (view installed at the NEW HEAD) would read
+/// the overlay's imports against NO package map and resolve them fall-open.
+/// `carry_forward_overlay_packages` re-keys them to the rebuilt HEAD first.
+#[test]
+fn a_head_advancing_rebuild_carries_overlay_package_roots_onto_the_new_base_commit() {
+    let (root, config) = cargo_generation_fixture("alpha");
+    IndexDatabase::rebuild(&config).unwrap();
+    let db_path = config.database.clone();
+    let repo_id = resolve_repo_id(&db_path, &root);
+    let (old_head, _) = crate::index::resolve_git_context(&root);
+
+    // A linked worktree that CHANGES a file (so the overlay refresh runs and writes its own
+    // `packages` rows from the linked checkout's manifest).
+    let linked =
+        root.parent().unwrap().join(format!("{}-wt", root.file_name().unwrap().to_string_lossy()));
+    run_git(&root, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/caller.rs"), "pub fn overlay_caller() -> u32 { 7 }\n").unwrap();
+    let mut db = IndexDatabase::open_config(&config).unwrap();
+    let overlay_wt = db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap().worktree_id;
+    drop(db);
+    assert!(!overlay_wt.is_empty(), "the linked worktree produced an overlay scope");
+
+    let overlay_pkg_commit = |db_path: &Path| -> Option<String> {
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        conn.query_row(
+            "SELECT DISTINCT commit_sha FROM packages WHERE repo_id = ?1 AND worktree_id = ?2",
+            rusqlite::params![repo_id, overlay_wt],
+            |r| r.get::<_, String>(0),
+        )
+        .optional()
+        .unwrap()
+    };
+    assert_eq!(
+        overlay_pkg_commit(&db_path).as_deref(),
+        Some(old_head.as_str()),
+        "the overlay indexed its packages at the old base HEAD"
+    );
+
+    // Advance the base HEAD, then full-rebuild: the overlay is carried forward and its packages
+    // re-keyed to the new HEAD (batch 6 #3).
+    fs::write(root.join("src/added.rs"), "pub fn added() -> u32 { 9 }\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "advance"]);
+    let (new_head, _) = crate::index::resolve_git_context(&root);
+    assert_ne!(old_head, new_head, "HEAD advanced");
+    IndexDatabase::rebuild(&config).unwrap();
+
+    assert_eq!(
+        overlay_pkg_commit(&db_path).as_deref(),
+        Some(new_head.as_str()),
+        "the carried overlay's packages must be re-keyed to the rebuilt HEAD (batch 6 #3), so \
+         load_package_roots_into_scope finds the overlay package map under the new base commit"
+    );
+
+    let _ = fs::remove_dir_all(&linked);
+    let _ = fs::remove_dir_all(root);
+}
+
+/// Batch 6 (count-scoping class, the adversary's repro): during a DEAD-GENERATION window (two
+/// rebuilds, no gc) the graph-traversal SUMMARY counts must equal the view-joined ROWS — an
+/// unscoped `COUNT(*) FROM edges` would double `total_matching_edges` over the superseded
+/// generation and mis-flip `truncated`, and an unscoped `unique_symbol_name` would see the live
+/// name twice and suppress a live hop. The row query was always view-joined; the counts now are
+/// too.
+#[test]
+fn graph_traversal_summary_counts_match_the_live_rows_during_a_dead_generation_window() {
+    let (root, config) = generation_fixture(&[(
+        "lib.rs",
+        "pub fn callee() -> u32 { 1 }\npub fn caller() -> u32 { callee() }\n",
+    )]);
+    IndexDatabase::rebuild(&config).unwrap();
+    // Second rebuild WITHOUT gc: the first generation's edges/symbols linger (the dead-generation
+    // window the adversary's repro exploits).
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let conn = db.storage.connection();
+
+    // Confirm we ARE in a dead-generation window: the repo carries a `callee` symbol at a dead
+    // generation too, so an unscoped COUNT would double.
+    let dead_callee: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM main.symbols s JOIN main.files f ON f.id = s.file_id
+             WHERE f.repo_id = ?1 AND s.name = 'callee' AND f.generation != ?2",
+            rusqlite::params![db.active_repo_id, db.active_generation],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(dead_callee > 0, "the second rebuild leaves a dead generation's `callee` behind");
+
+    let options = crate::query::graph::GraphTraversalOptions::default();
+    let rows = db.find_callers("callee", 50).unwrap();
+    let summary =
+        crate::query::graph::traversal_summary(conn, "callee", true, 50, &options, rows.len())
+            .unwrap();
+    assert_eq!(rows.len(), 1, "exactly one LIVE caller of callee");
+    assert_eq!(
+        summary.total_matching_edges,
+        rows.len() as u64,
+        "the traversal summary must count only the live generation's edges (batch 6 \
+         count-scoping): during a dead-generation window an unscoped COUNT doubles \
+         total_matching_edges over the view-joined rows"
+    );
+    assert!(!summary.truncated, "a live result that fits the limit must not be marked truncated");
+    assert!(
+        crate::query::graph::unique_symbol_name(conn, "callee").unwrap(),
+        "unique_symbol_name must count only the live generation (batch 6): a dead-generation \
+         duplicate would read count == 2, disable the short-name fallback, and suppress a live hop"
+    );
+
+    drop(db);
+    let _ = fs::remove_dir_all(root);
+}
+
+/// Batch 7 P2 (incremental.rs, standalone finalize): the public `index_targets()` entry shares
+/// the full rebuild's wave loop (`graph.is_some()`), so its parse/read failures STAGE into
+/// `temp.rebuild_parser_failures` — and the standalone finalize must PUBLISH them (it has no
+/// terminal flip to defer to; failures publish atomically with its own edges). Before the fix a
+/// standalone pass's failing files silently vanished from `parser_failures`. Also pins the
+/// standalone twin's self-sufficiency: it creates its own chunk-text scratch table and trains the
+/// first-index dict (the pre-fix path errored "no such table: temp.rebuild_chunk_text" on any
+/// fresh, dict-less index).
+#[test]
+fn standalone_index_targets_publishes_staged_parser_failures_immediately() {
+    let (root, config) = generation_fixture(&[
+        ("good.rs", "pub fn fine() -> u32 { 1 }\n"),
+        ("parsefail.rs", "pub fn broken( {\n"),
+    ]);
+    // A PREPARE failure too (invalid UTF-8 — records a failure with NO file row), so both staging
+    // arms are exercised.
+    fs::write(root.join("src/binfail.rs"), [0xFF, 0xFE, 0x00, 0x9F, 0x92]).unwrap();
+
+    // The standalone driver: create/adopt/scope, then index_targets — NO rebuild anywhere.
+    let mut db = IndexDatabase::create_or_migrate(&config.database).unwrap();
+    db.adopt_repo_from_config(&config).unwrap();
+    let (sha, wt) = crate::index::resolve_git_context(&root);
+    db.set_context(&sha, &wt).unwrap();
+    db.index_targets(&config).unwrap();
+
+    let db_path = config.database.clone();
+    let repo_id = db.active_repo_id.clone();
+    assert_eq!(
+        failure_count_for_path(&db_path, &repo_id, "src/parsefail.rs"),
+        1,
+        "a standalone index_targets pass must publish its staged PARSE failure immediately (batch \
+         7) — not leave it in the temp table for some later rebuild"
+    );
+    assert_eq!(
+        failure_count_for_path(&db_path, &repo_id, "src/binfail.rs"),
+        1,
+        "the staged PREPARE failure (no file row) publishes too"
+    );
+    assert_eq!(failure_count_for_path(&db_path, &repo_id, "src/good.rs"), 0);
+    // Self-sufficiency: the standalone finalize built the durable chunk-text store (first-index
+    // dict training) — every indexed chunk has its compressed text row.
+    let missing_text: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM main.chunks
+             WHERE id NOT IN (SELECT chunk_id FROM main.chunk_text)",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(missing_text, 0, "the standalone finalize trains the dict and stores chunk text");
+    // The logical-symbol fold ran (the open-time heal re-derives edges only, so the finalize must
+    // fold or the fresh symbols stay invisible to symbol_lookup/graph nav).
+    let logical_fine: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM main.logical_symbols WHERE repo_id = ?1 AND logical_name = \
+             'fine'",
+            [&repo_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(logical_fine, 1, "the standalone finalize folds logical symbols (batch 7 twin)");
+
+    drop(db);
+    let _ = fs::remove_dir_all(root);
+}
+
+/// Batch 7 P2 (rebuild.rs, overlay package carry vs a fresh refresh): an overlay that ALREADY
+/// refreshed after the base HEAD moved holds `packages` rows at the NEW `(commit_sha,
+/// worktree_id)` while the old commit's rows linger. The carry's blind re-key then collided with
+/// the fresh rows under `UNIQUE(repo_id, manifest_dir, commit_sha, worktree_id)` and ABORTED the
+/// whole rebuild. Superseded old rows are deleted instead; the rebuild completes and the overlay
+/// package map ends deduplicated at the rebuilt HEAD.
+#[test]
+fn a_rebuild_after_an_overlay_already_refreshed_at_the_new_head_does_not_collide() {
+    let (root, config) = cargo_generation_fixture("alpha");
+    IndexDatabase::rebuild(&config).unwrap();
+    let db_path = config.database.clone();
+    let repo_id = resolve_repo_id(&db_path, &root);
+
+    // Overlay refresh #1 at H1.
+    let linked =
+        root.parent().unwrap().join(format!("{}-wt", root.file_name().unwrap().to_string_lossy()));
+    run_git(&root, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/caller.rs"), "pub fn overlay_caller() -> u32 { 7 }\n").unwrap();
+    let mut db = IndexDatabase::open_config(&config).unwrap();
+    let overlay_wt = db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap().worktree_id;
+    drop(db);
+    assert!(!overlay_wt.is_empty());
+
+    // Base HEAD advances to H2, then the overlay refreshes AGAIN — its packages land at (H2, wt)
+    // while the (H1, wt) rows linger (refresh_packages deletes only its own scope).
+    fs::write(root.join("src/added.rs"), "pub fn added() -> u32 { 9 }\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "advance"]);
+    let (new_head, _) = crate::index::resolve_git_context(&root);
+    fs::write(linked.join("src/caller.rs"), "pub fn overlay_caller() -> u32 { 8 }\n").unwrap();
+    let mut db = IndexDatabase::open_config(&config).unwrap();
+    db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap();
+    drop(db);
+    let overlay_pkg_commits = |db_path: &Path| -> i64 {
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        conn.query_row(
+            "SELECT COUNT(DISTINCT commit_sha) FROM packages WHERE repo_id = ?1 AND worktree_id = \
+             ?2",
+            rusqlite::params![repo_id, overlay_wt],
+            |r| r.get(0),
+        )
+        .unwrap()
+    };
+    assert_eq!(
+        overlay_pkg_commits(&db_path),
+        2,
+        "precondition: fresh rows at the new HEAD coexist with the old commit's lingering rows"
+    );
+
+    // The full rebuild must COMPLETE (the pre-fix blind re-key aborted on the UNIQUE here) and
+    // leave exactly one overlay package row per manifest_dir, at the rebuilt HEAD.
+    IndexDatabase::rebuild(&config).unwrap();
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let (rows, distinct_dirs, at_new_head): (i64, i64, i64) = conn
+        .query_row(
+            "SELECT COUNT(*), COUNT(DISTINCT manifest_dir),
+                    SUM(CASE WHEN commit_sha = ?3 THEN 1 ELSE 0 END)
+             FROM packages WHERE repo_id = ?1 AND worktree_id = ?2",
+            rusqlite::params![repo_id, overlay_wt, new_head],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(rows, distinct_dirs, "exactly one overlay package row per manifest_dir (batch 7)");
+    assert_eq!(rows, at_new_head, "every surviving overlay package row is at the rebuilt HEAD");
+    assert!(rows > 0, "the overlay package map survived the carry");
+
+    let _ = fs::remove_dir_all(&linked);
+    let _ = fs::remove_dir_all(root);
+}
+
+/// Batch 7 (the re-key's second collision shape): overlay rows at TWO different STALE commits
+/// (no fresh row at the new HEAD) would BOTH re-key to the same new key and collide with each
+/// other. The carry keeps only the most recent stale row per manifest_dir (highest rowid) and
+/// re-keys it.
+#[test]
+fn a_rebuild_dedupes_multi_stale_overlay_package_rows_before_the_re_key() {
+    let (root, config) = cargo_generation_fixture("alpha");
+    IndexDatabase::rebuild(&config).unwrap();
+    let db_path = config.database.clone();
+    let repo_id = resolve_repo_id(&db_path, &root);
+
+    let linked =
+        root.parent().unwrap().join(format!("{}-wt", root.file_name().unwrap().to_string_lossy()));
+    run_git(&root, &["worktree", "add", "-q", "-b", "feat", linked.to_str().unwrap()]);
+    fs::write(linked.join("src/caller.rs"), "pub fn overlay_caller() -> u32 { 7 }\n").unwrap();
+    let mut db = IndexDatabase::open_config(&config).unwrap();
+    let overlay_wt = db.index_worktree_overlay(&config, &linked, &mut |_| {}).unwrap().worktree_id;
+    drop(db);
+
+    // A second, MORE RECENT stale row for the same manifest_dir at another dead commit (the
+    // two-stale-refreshes-two-HEAD-moves-ago shape), marked so the survivor is identifiable.
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO packages(manifest_dir, commit_sha, worktree_id, local_roots_json, \
+             repo_id)
+             SELECT manifest_dir, 'stalecafe', worktree_id, '[\"survivor_marker\"]', repo_id
+             FROM packages WHERE repo_id = ?1 AND worktree_id = ?2",
+            rusqlite::params![repo_id, overlay_wt],
+        )
+        .unwrap();
+    }
+
+    // Advance the base HEAD WITHOUT another overlay refresh, then rebuild: both stale commits'
+    // rows meet the re-key; the pre-fix UPDATE collided them into one UNIQUE key and aborted.
+    fs::write(root.join("src/added.rs"), "pub fn added() -> u32 { 9 }\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "advance"]);
+    let (new_head, _) = crate::index::resolve_git_context(&root);
+    IndexDatabase::rebuild(&config).unwrap();
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let survivors: Vec<(String, String)> = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT commit_sha, local_roots_json FROM packages
+                 WHERE repo_id = ?1 AND worktree_id = ?2",
+            )
+            .unwrap();
+        let rows = stmt
+            .query_map(rusqlite::params![repo_id, overlay_wt], |r| {
+                Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+            })
+            .unwrap();
+        rows.collect::<Result<_, _>>().unwrap()
+    };
+    assert_eq!(survivors.len(), 1, "one overlay package row survives the multi-stale dedup");
+    assert_eq!(survivors[0].0, new_head, "the survivor is re-keyed to the rebuilt HEAD");
+    assert_eq!(
+        survivors[0].1, "[\"survivor_marker\"]",
+        "the MOST RECENT stale row (highest rowid) wins the dedup"
+    );
+
+    let _ = fs::remove_dir_all(&linked);
+    let _ = fs::remove_dir_all(root);
+}
+
+/// Batch 6 (concurrency HIGH): `rag-rat init`'s `setup_index` reaches the rebuild through
+/// `index_discover`'s missing-DB fallback — a FLOCK-LESS production writer before batch 6.
+/// `rebuild_with_progress` now takes the per-repo write flock ITSELF, so even that entry holds it:
+/// a flock-holding collector racing the staging SERIALIZES instead of cascading the mid-flight
+/// generation, and the published generation is never empty (the adversary's repro shape, promoted).
+#[test]
+fn a_lockless_init_rebuild_serializes_a_concurrent_flock_gc() {
+    let (root, config) = generation_fixture(&[
+        ("a.rs", "pub fn a() -> u32 { 1 }\n"),
+        ("b.rs", "pub fn b() -> u32 { 2 }\n"),
+    ]);
+    let db_path = config.database.clone();
+
+    // Pause the FIRST index between waves — driven through `index_discover` (the init path), NOT
+    // the library `rebuild`: a fresh DB → `index_incremental`'s missing-DB fallback → the SAME
+    // `rebuild_with_progress`, which acquires the flock at its top (before the barrier fires).
+    let (reached_tx, reached_rx) = mpsc::channel();
+    let (resume_tx, resume_rx) = mpsc::channel::<()>();
+    let _guard = {
+        let paused = AtomicBool::new(false);
+        let reached_tx = Mutex::new(reached_tx);
+        let resume_rx = Mutex::new(resume_rx);
+        crate::index::rebuild::set_after_wave_commit(
+            &config.database,
+            Arc::new(move || {
+                if !paused.swap(true, Ordering::SeqCst) {
+                    reached_tx.lock().unwrap().send(()).unwrap();
+                    resume_rx.lock().unwrap().recv().unwrap();
+                }
+            }),
+        )
+    };
+    let discover_config = config.clone();
+    let handle = std::thread::spawn(move || {
+        IndexDatabase::index_discover(&discover_config).unwrap();
+    });
+    reached_rx.recv().unwrap();
+
+    // A production collector takes the per-repo flock first — held by the paused init rebuild — so
+    // it SERIALIZES rather than cascading the in-progress staging (the exact race that
+    // published empty).
+    let lock_repo = crate::locks::write_lock_repo_id(&config);
+    let contended = crate::locks::WriteLock::acquire_timeout(
+        &config.database,
+        &lock_repo,
+        std::time::Duration::from_millis(150),
+    )
+    .unwrap();
+    assert!(
+        contended.is_none(),
+        "a flock-taking collector must block while the lockless init rebuild is mid-flight"
+    );
+
+    resume_tx.send(()).unwrap();
+    handle.join().unwrap();
+
+    // The published generation is NON-EMPTY: the collector could not cascade the staging.
+    assert_eq!(
+        reader_scoped_file_count(&db_path, &root),
+        2,
+        "the init-path rebuild published a non-empty generation despite the racing collector"
+    );
+    let _ = fs::remove_dir_all(root);
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -711,12 +711,26 @@ fn insert_stale_overlay_row(db: &IndexDatabase, path: &str, worktree_id: &str) -
     // Stamp the ACTIVE repo id (V040): a stale overlay row is a leftover from a prior index of the
     // SAME repo, so it must carry that repo's id for the full-rebuild staging + scope view to see
     // it.
+    // Stamp the ACTIVE generation (A6): a real stale overlay is a leftover from a PRIOR index of
+    // the LIVE generation, so it lives at that generation and is visible through the scope view
+    // exactly like a genuine leftover — inserting it at the default 0 while the index is on a
+    // later generation would make it invisible to discovery and defeat the heal path the tests
+    // exercise.
     db.storage
         .connection()
         .execute(
             "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
-             commit_sha, worktree_id, repo_id) VALUES (?1, ?2, ?3, ?4, 0, 0, '', ?5, ?6)",
-            rusqlite::params![path, language, kind, sha, worktree_id, db.active_repo_id],
+             commit_sha, worktree_id, repo_id, generation) VALUES (?1, ?2, ?3, ?4, 0, 0, '', ?5, \
+             ?6, ?7)",
+            rusqlite::params![
+                path,
+                language,
+                kind,
+                sha,
+                worktree_id,
+                db.active_repo_id,
+                db.active_generation
+            ],
         )
         .unwrap();
     db.storage.connection().last_insert_rowid()
@@ -828,6 +842,7 @@ mod chunk_store_migrations;
 mod clones;
 mod dir_memory_tree;
 mod dispatch;
+mod generation_rebuild;
 mod git_history_reload;
 mod github_papertrail;
 mod graph_edges;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
@@ -49,6 +49,11 @@ fn full_rebuild_survives_stale_overlay_rows() {
     drop(db);
 
     let db = IndexDatabase::rebuild(&config).expect("rebuild must survive stale overlay rows");
+    // A6: the rebuild stages a fresh generation and leaves the prior one (the stale overlay
+    // included) DEAD for lazy reclamation rather than clearing it in-transaction. gc sweeps
+    // that dead generation, after which raw `main.files` holds exactly the new generation's one
+    // row per path.
+    db.garbage_collect().unwrap();
 
     let rows: Vec<(String, String)> = {
         let conn = db.storage.connection();
@@ -96,6 +101,11 @@ fn full_rebuild_clears_foreign_leaked_rows_at_the_active_scope() {
 
     let db = IndexDatabase::rebuild(&config)
         .expect("rebuild must survive and clear foreign leaked rows");
+    // A6: the rebuild no longer clears the foreign row in-transaction — it stages a fresh
+    // generation and the foreign row (an old, now-superseded generation) is DEAD and invisible
+    // to readers (the scope view filters the live generation). gc reclaims that dead generation
+    // from `main.files`.
+    db.garbage_collect().unwrap();
     let leaked: i64 = db
         .storage
         .connection()

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -561,11 +561,17 @@ fn server_derived_call_path_hash_is_stable_and_validates_through_edge_churn() {
     let config = source_config(root.clone(), Language::Rust);
     let db = IndexDatabase::rebuild(&config).unwrap();
 
+    // A6: scope the edge lookup through the live-generation `files` view (`JOIN files` on
+    // `source_file_id`). The rebuild stages a fresh generation and leaves the prior generation's
+    // `edges_data` rows in place (dead until gc), so a raw `edges` read with `ORDER BY id LIMIT 1`
+    // would keep returning the dead gen's edge — this pins the LIVE edge id, which the rebuild does
+    // reassign.
     let edge_id = |db: &IndexDatabase| -> i64 {
         db.storage
             .connection()
             .query_row(
-                "SELECT id FROM edges WHERE to_name LIKE '%callee%' ORDER BY id LIMIT 1",
+                "SELECT edges.id FROM edges JOIN files ON files.id = edges.source_file_id
+                 WHERE edges.to_name LIKE '%callee%' ORDER BY edges.id LIMIT 1",
                 [],
                 |row| row.get(0),
             )
@@ -1068,10 +1074,21 @@ fn full_rebuild_leaves_no_orphan_symbol_rows_for_a_path() {
     fs::write(root.join("src/a.rs"), "pub fn target() -> u32 {\n    42\n}\n").unwrap();
     let config = source_config(root.clone(), Language::Rust);
 
+    // A6: count through the scope VIEW (`files` = the live-generation `temp.files`). A full rebuild
+    // stages a fresh generation and leaves the prior one's symbol rows in RAW `main.symbols` (dead,
+    // reclaimed lazily by gc — which is a no-op on this non-git fixture, so they persist here). But
+    // a reader and a symbol-id-keyed binding only ever see the LIVE generation, which is
+    // exactly one `target` — the #50 invariant restated for generation staging (a stranded
+    // binding relocates against the live generation, never onto a dead orphan).
     let count_targets = |db: &IndexDatabase| -> i64 {
         db.storage
             .connection()
-            .query_row("SELECT COUNT(*) FROM symbols WHERE name = 'target'", [], |row| row.get(0))
+            .query_row(
+                "SELECT COUNT(*) FROM symbols JOIN files ON files.id = symbols.file_id
+                 WHERE symbols.name = 'target'",
+                [],
+                |row| row.get(0),
+            )
             .unwrap()
     };
 
@@ -1481,13 +1498,21 @@ fn memory_chunk_binding_relocates_by_hash() {
     // different text_hash, so the content-exact match remains unique.
     let db = IndexDatabase::rebuild(&config).unwrap();
 
-    // The old chunk_id must no longer exist.
+    // The old chunk_id must no longer refer to a LIVE chunk. A6: the rebuild stages a fresh
+    // generation and leaves the old chunk row in `main.chunks` (dead until gc), so scope through
+    // the live-generation `files` view — the dead chunk's file row is absent from it, so the
+    // join drops the stale rowid exactly as a reader (and `relocate_chunk_by_hash`) sees it.
     let old_exists: i64 = db
         .storage
         .connection()
-        .query_row("SELECT COUNT(*) FROM chunks WHERE id = ?1", [chunk_id], |row| row.get(0))
+        .query_row(
+            "SELECT COUNT(*) FROM chunks JOIN files ON files.id = chunks.file_id
+             WHERE chunks.id = ?1",
+            [chunk_id],
+            |row| row.get(0),
+        )
         .unwrap();
-    assert_eq!(old_exists, 0, "old chunk_id should be gone after rebuild");
+    assert_eq!(old_exists, 0, "old chunk_id should no longer refer to a live chunk after rebuild");
 
     let report = db.memory_validate().unwrap();
     assert_eq!(

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -1332,6 +1332,158 @@ fn register_repo_upgrades_a_local_only_id_to_a_portable_id_in_place() {
     let _ = fs::remove_dir_all(&repo);
 }
 
+/// A6 batch-4 P2: the LocalOnly→Portable upgrade must SERIALIZE with a writer still holding the
+/// OUTGOING `local:` discriminator's write lock — the lock identity flips with the derived id at
+/// unshallow time, so without this the upgrade re-points every scoped row out from under an
+/// in-flight pre-unshallow writer. (Deadlock order: the upgrade is the only multi-lock holder and
+/// always acquires incoming-then-outgoing; see the comment in `register_repo`.)
+#[test]
+fn upgrade_blocks_until_the_outgoing_local_lock_holder_finishes() {
+    let repo = real_git_repo("upgrade-lock");
+    let boundary = head_commit_hash(&repo);
+
+    // FILE-backed DB: the outgoing-lock acquisition keys off `conn.path()` (a pathless in-memory
+    // DB skips it — no cross-process writer can exist there).
+    let db_root = unique_temp_root();
+    let _ = fs::remove_dir_all(&db_root);
+    fs::create_dir_all(&db_root).unwrap();
+    let db_path = db_root.join("index.sqlite");
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    seed_pre_v040_core_schema(&conn);
+    conn.execute(
+        "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms) VALUES \
+         ('src/lib.rs', 'rust', 'source', 'a', 0, 0)",
+        [],
+    )
+    .unwrap();
+    schema::apply_repo_id_core_scoping(&conn).expect("V040 applies");
+    let local_id = "local:aaaa1111bbbb";
+    register_repo(&conn, &identity_local(local_id, "shallow", vec![boundary]), repo.as_path(), 1)
+        .unwrap();
+
+    // Writer 1: an in-flight pre-unshallow writer — holds the OUTGOING local-id lock while
+    // writing two rows with a deliberate pause between them.
+    let writer_db = db_path.clone();
+    let (held_tx, held_rx) = std::sync::mpsc::channel();
+    let writer = std::thread::spawn(move || {
+        let _lock =
+            crate::locks::WriteLock::acquire_blocking(&writer_db, "local:aaaa1111bbbb").unwrap();
+        let conn = rusqlite::Connection::open(&writer_db).unwrap();
+        conn.execute(
+            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+             repo_id) VALUES ('src/w1.rs', 'rust', 'source', 'w1', 0, 0, 'local:aaaa1111bbbb')",
+            [],
+        )
+        .unwrap();
+        held_tx.send(()).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(400));
+        conn.execute(
+            "INSERT INTO files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+             repo_id) VALUES ('src/w2.rs', 'rust', 'source', 'w2', 0, 0, 'local:aaaa1111bbbb')",
+            [],
+        )
+        .unwrap();
+        // The lock releases on drop, AFTER both writes — the upgrade must not run before this.
+    });
+    held_rx.recv().unwrap();
+
+    // Writer 2 triggers the upgrade (the post-unshallow open). It must BLOCK on the outgoing
+    // lock until writer 1 finishes, then re-point EVERYTHING — including writer 1's second row.
+    let started = std::time::Instant::now();
+    register_repo(&conn, &identity("0abc123root", "deepened"), repo.as_path(), 2)
+        .expect("the upgrade proceeds once the outgoing-lock holder finishes");
+    let elapsed = started.elapsed();
+    writer.join().unwrap();
+    assert!(
+        elapsed >= std::time::Duration::from_millis(300),
+        "the upgrade must block until the outgoing local-lock holder completes, got {elapsed:?}"
+    );
+    // No interleaved re-point: row attribution is consistent — every row (the seed + BOTH of the
+    // in-flight writer's rows) ended under the portable id, none stranded under the local id.
+    let under_local: i64 = conn
+        .query_row("SELECT COUNT(*) FROM files WHERE repo_id = ?1", [local_id], |r| r.get(0))
+        .unwrap();
+    let under_portable: i64 = conn
+        .query_row("SELECT COUNT(*) FROM files WHERE repo_id = '0abc123root'", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(under_local, 0, "no row left under the outgoing local id");
+    assert_eq!(under_portable, 3, "seed + both in-flight writer rows re-pointed together");
+
+    let _ = fs::remove_dir_all(&db_root);
+    let _ = fs::remove_dir_all(&repo);
+}
+
+/// A6 batch-5 P2 (the fence gap): a writer whose entry lock was keyed by the STALE `local:` id
+/// (derived pre-unshallow) and whose open then resolves + upgrades to the portable id must extend
+/// its lock coverage to the RESOLVED id for the rest of its run — a fresh portable-lock writer
+/// blocks until it completes, instead of running concurrently with a writer holding only the
+/// retired local lock. RULE: a writer's held lock must match the repo id it writes under.
+#[test]
+fn a_writer_whose_identity_upgrades_mid_run_extends_its_lock_to_the_resolved_id() {
+    let repo = real_git_repo("fence-gap");
+    let boundary = head_commit_hash(&repo);
+    let config = source_config(repo.clone(), Language::Rust);
+    let local_id = "local:feedfacecafe";
+    {
+        let db = IndexDatabase::create_or_migrate(&config.database).unwrap();
+        register_repo(
+            db.storage.connection(),
+            &identity_local(local_id, "shallow", vec![boundary]),
+            repo.as_path(),
+            1,
+        )
+        .unwrap();
+    }
+
+    // The gap writer: entry lock keyed by the stale local id (what a pre-unshallow derivation
+    // gave), then the open resolves the portable id, upgrades, and — the fix — stashes the
+    // resolved id's lock on the connection for its lifetime.
+    let _entry_lock =
+        crate::locks::WriteLock::acquire_blocking(&config.database, local_id).unwrap();
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let resolved = db.active_repo_id.clone();
+    assert!(
+        !resolved.starts_with("local:"),
+        "the open resolved + upgraded to the portable id, got {resolved}"
+    );
+
+    // A concurrent portable-lock writer (another thread — same-thread probes would re-enter)
+    // must BLOCK while the gap writer's connection lives...
+    let probe_db = config.database.clone();
+    let probe_id = resolved.clone();
+    let blocked = std::thread::spawn(move || {
+        crate::locks::WriteLock::acquire_timeout(
+            &probe_db,
+            &probe_id,
+            std::time::Duration::from_millis(150),
+        )
+        .unwrap()
+        .is_some()
+    })
+    .join()
+    .unwrap();
+    assert!(!blocked, "a portable-lock writer must block while the gap writer runs");
+
+    // ...and proceed once it completes (dropping the connection releases the stashed lock).
+    drop(db);
+    let probe_db = config.database.clone();
+    let free = std::thread::spawn(move || {
+        crate::locks::WriteLock::acquire_timeout(
+            &probe_db,
+            &resolved,
+            std::time::Duration::from_millis(500),
+        )
+        .unwrap()
+        .is_some()
+    })
+    .join()
+    .unwrap();
+    assert!(free, "the resolved id's lock frees when the gap writer's connection drops");
+
+    let _ = fs::remove_dir_all(&repo);
+}
+
 /// A real git repo (two empty commits) for the upgrade-proof tests — its HEAD is a commit a genuine
 /// deepened clone would reach.
 fn real_git_repo(tag: &str) -> PathBuf {
@@ -2267,8 +2419,14 @@ fn seed_pre_v042_periphery_schema(conn: &rusqlite::Connection) {
 fn migration_042_is_the_latest_tip_and_scopes_periphery() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 42, "V042 is the schema tip");
-    assert_eq!(schema::status(&conn).unwrap().current_version, 42, "schema at LATEST after apply");
+    // V042 is no longer the ABSOLUTE tip (V043 adds files.generation on top); the tip pin moves to
+    // the newest migration's test (`schema_at_latest_after_apply_is_v043` in generation_rebuild).
+    // Here just assert `apply` reaches LATEST — V042's periphery scoping is on the way to the tip.
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply"
+    );
 
     for table in V042_PERIPHERY_TABLES {
         assert!(
@@ -2566,8 +2724,8 @@ fn full_ladder_v037_to_v042_scopes_both_workstreams_data() {
     schema::migrate_forward(&conn).unwrap();
     assert_eq!(
         schema::status(&conn).unwrap().current_version,
-        42,
-        "the A-phase ladder reached V042"
+        schema::LATEST_SCHEMA_VERSION,
+        "the A-phase ladder reached LATEST (V042's periphery scoping is on the way to the tip)"
     );
 
     // Every seeded row survived the ladder, still under the placeholder (scoped to the legacy id).

--- a/crates/rag-rat-core/src/index/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/worktree_overlay.rs
@@ -373,10 +373,18 @@ impl IndexDatabase {
             let mut tombstoned = 0;
             for path in &delta.tombstones {
                 let exists: bool = self.storage.connection().query_row(
-                    // Direct `main.files` probe → explicit `repo_id` predicate (A3).
+                    // Direct `main.files` probe → explicit `repo_id` (A3) + `generation` (A6)
+                    // predicates: only a tombstone at THIS connection's live generation suppresses
+                    // the write — a superseded generation's copy does not hide the path.
                     "SELECT EXISTS(SELECT 1 FROM main.files WHERE repo_id = ?1 AND path = ?2 AND \
-                     commit_sha = '' AND worktree_id = ?3 AND kind = 'deleted')",
-                    params![self.active_repo_id, path_string(path), worktree_id],
+                     commit_sha = '' AND worktree_id = ?3 AND kind = 'deleted' AND generation = \
+                     ?4)",
+                    params![
+                        self.active_repo_id,
+                        path_string(path),
+                        worktree_id,
+                        self.active_generation
+                    ],
                     |row| row.get(0),
                 )?;
                 if !exists {

--- a/crates/rag-rat-core/src/locks.rs
+++ b/crates/rag-rat-core/src/locks.rs
@@ -4,11 +4,27 @@
 //!
 //! - the **per-worktree election lock** (one watcher per worktree), keyed by the canonicalized
 //!   worktree root and living under the git common dir;
-//! - the **per-DB write-serialization lock** (held by the watcher, the git hooks, and manual
-//!   `index`), so exactly one writer touches the shared index at a time.
+//! - the **per-DB, per-repo write-serialization lock** (held by the watcher, the git hooks, and
+//!   manual `index`), so exactly one writer touches a repo's slice of the shared index at a time.
 //!
 //! Locks release when the file handle drops (the OS also releases on process death), so there is no
 //! stale-pidfile cleanup. Caveat: file locks are unreliable on NFS and WSL2 `drvfs`/`9p` mounts.
+//!
+//! # Canonical lock order (A6, batch-5 P2)
+//!
+//! When a flow must hold MORE THAN ONE per-repo write lock (today: the LocalOnly→Portable identity
+//! upgrade, and a writer whose resolved repo id turns out to differ from the one it locked at
+//! entry), the CANONICAL TOTAL ORDER is LEXICOGRAPHIC on the sanitized discriminator
+//! ([`canonical_lock_order`]) — supersedes the earlier role-based
+//! "incoming-then-outgoing" argument, which broke the moment a second multi-lock path appeared
+//! with the opposite roles. Multi-lock acquirers sort the ids they need and acquire in that order
+//! wherever they start from a clean slate; an acquisition that would VIOLATE the order (the
+//! earlier-sorting lock requested while a later-sorting one is already held — unavoidable when
+//! the entry lock was taken identity-blind before the second id was knowable) MUST be BOUNDED
+//! (`acquire_timeout`, never `acquire_blocking`): the bounded out-of-order edge is what keeps the
+//! pre-held-entry-lock topology deadlock-free — a wait cycle needs two hold-and-wait edges, purely
+//! in-order unbounded edges cannot form a cycle under a total order, and any cycle containing a
+//! bounded edge self-breaks within its timeout (one side surfaces a retryable error).
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;
@@ -89,25 +105,109 @@ impl Drop for FileLock {
     }
 }
 
-/// Per-DB write-serialization lock path: next to the index database (under the git common dir for a
-/// shared DB, or `<root>/.rag-rat/` for a single worktree — both excluded from the watch tree).
-pub fn write_lock_path(database: &Path) -> PathBuf {
-    database.parent().unwrap_or_else(|| Path::new(".")).join("rag-rat-write.lock")
+/// A short, filesystem-safe discriminator for a repo's per-DB lock files (A6): the first 12 ASCII
+/// alphanumerics of `repo_id`. Stable per repo (a portable id is a hex root-commit hash; a `local:`
+/// id and the root-hash fallback are hex too) and distinct enough that different repos in one
+/// shared global DB never share a lock file — 12 chars ≈ 48 bits, collision-negligible for the
+/// handful of repos on a machine. Empty / all-punctuation ids degrade to a fixed stem rather than a
+/// bare `rag-rat-write-.lock`.
+fn lock_discriminator(repo_id: &str) -> String {
+    let disc: String = repo_id.chars().filter(char::is_ascii_alphanumeric).take(12).collect();
+    if disc.is_empty() { "repo".to_string() } else { disc }
 }
 
-/// Per-DB maintenance coordination lock, held by the running `rag-rat maintenance` command for its
-/// whole pass so the multiple git hooks a single amend/merge/rebase fires coalesce into one pass
-/// instead of each running a full discover (#267). Separate from [`write_lock_path`] so it only
-/// coordinates CLI maintenance invocations — the pass itself still takes the write lock internally,
-/// serializing with the watcher as before.
-pub fn maintenance_lock_path(database: &Path) -> PathBuf {
-    database.parent().unwrap_or_else(|| Path::new(".")).join("rag-rat-maintenance.lock")
+/// Per-DB, PER-REPO write-serialization lock path: next to the index database, keyed by `repo_id`
+/// (A6). On a shared global DB this keeps two writers to DIFFERENT repos from serializing on one
+/// flock — a full rebuild of repo A must not block a memory write to repo B beyond the busy-timeout
+/// slice (spec §3.3) — while writers to the SAME repo (across its worktrees, which share a repo_id)
+/// still contend. The concurrent access to the SQLite file itself is serialized by WAL, not this
+/// lock. Resolve `repo_id` before opening via [`write_lock_repo_id`].
+pub fn write_lock_path(database: &Path, repo_id: &str) -> PathBuf {
+    database
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(format!("rag-rat-write-{}.lock", lock_discriminator(repo_id)))
+}
+
+/// The GLOBAL schema-migration lock path, beside the DB (A6): ONE per database file, taken only by
+/// the open-time auto-migrate ([`crate::index`] lifecycle). A schema migration rewrites the SHARED
+/// migration ladder — every repo's tables — so it must serialize across ALL repos, unlike the
+/// per-repo [`write_lock_path`]. Keeping it separate means a repo's ordinary write is neither
+/// blocked by nor blocks an unrelated repo except during the brief migration itself.
+pub fn schema_lock_path(database: &Path) -> PathBuf {
+    database.parent().unwrap_or_else(|| Path::new(".")).join("rag-rat-schema.lock")
+}
+
+/// Per-DB, PER-REPO maintenance coordination lock, held by the running `rag-rat maintenance`
+/// command for its whole pass so the multiple git hooks a single amend/merge/rebase fires coalesce
+/// into one pass instead of each running a full discover (#267). Keyed by `repo_id` (A6) like
+/// [`write_lock_path`], so a maintenance pass on one repo never coalesces (or blocks) an unrelated
+/// repo's. Separate from the write lock so it only coordinates CLI maintenance invocations — the
+/// pass itself still takes the write lock internally.
+pub fn maintenance_lock_path(database: &Path, repo_id: &str) -> PathBuf {
+    database
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(format!("rag-rat-maintenance-{}.lock", lock_discriminator(repo_id)))
 }
 
 /// Marker a coalesced `maintenance` trigger sets to ask the in-flight runner to run one more pass
-/// after the current one, so a change that arrived mid-pass is still covered (#267).
-pub fn maintenance_pending_path(database: &Path) -> PathBuf {
-    database.parent().unwrap_or_else(|| Path::new(".")).join("rag-rat-maintenance.pending")
+/// after the current one, so a change that arrived mid-pass is still covered (#267). Per-repo (A6),
+/// pairing with the per-repo [`maintenance_lock_path`].
+pub fn maintenance_pending_path(database: &Path, repo_id: &str) -> PathBuf {
+    database
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(format!("rag-rat-maintenance-{}.pending", lock_discriminator(repo_id)))
+}
+
+/// Order two repo ids by the CANONICAL LOCK ORDER (see the module doc): lexicographic on the
+/// sanitized discriminator, i.e. the order of the lock FILE NAMES themselves. Multi-lock
+/// acquirers sort with this before acquiring. Ties (same discriminator — same repo) are the
+/// reentrant case, not an ordering question.
+pub fn canonical_lock_order<'a>(a: &'a str, b: &'a str) -> (&'a str, &'a str) {
+    if lock_discriminator(a) <= lock_discriminator(b) { (a, b) } else { (b, a) }
+}
+
+/// Whether THIS THREAD currently holds the per-repo write lock for `(database, repo_id)` — the
+/// reentrancy registry probe, exposed so identity-resolution code can tell "my held entry lock
+/// already covers the resolved repo" from the batch-5 fence gap (entry lock keyed by a stale
+/// derived id).
+pub fn thread_holds_write_lock(database: &Path, repo_id: &str) -> bool {
+    write_lock_held_on_this_thread(&write_lock_path(database, repo_id))
+}
+
+/// Whether THIS THREAD holds ANY per-repo write lock for `database` (any `rag-rat-write-*.lock`
+/// sibling of the DB file; the global schema lock and maintenance locks do not count). `true` for
+/// a LOCKED writer (CLI/watcher entry), `false` for the deliberately lockless openers (MCP reads,
+/// heals) — the discriminating probe for the batch-5 rule "a writer's held lock must match the
+/// repo id it writes under": only a flow that IS lock-disciplined must extend its coverage when
+/// the resolved id differs; a lockless flow stays lockless.
+pub fn thread_holds_any_repo_write_lock(database: &Path) -> bool {
+    let dir = database.parent().unwrap_or_else(|| Path::new(".")).to_path_buf();
+    HELD_WRITE_LOCKS.with_borrow(|held| {
+        held.iter().any(|(path, &depth)| {
+            depth > 0
+                && path.parent() == Some(dir.as_path())
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with("rag-rat-write-"))
+        })
+    })
+}
+
+/// The repo discriminator for a config's per-DB write / maintenance locks (A6). Resolution CANNOT
+/// open the DB (this lock guards the open itself), so it derives the identity straight from git via
+/// [`resolve_repo_identity`](crate::repo_identity::resolve_repo_identity), honoring an `[index]
+/// repo_id` override — worktrees of one repo resolve to the same id and therefore share a lock. A
+/// non-git / unresolvable root (a bare temp dir, a rejected pin) falls back to a stable hash of the
+/// canonicalized root; a per-repo DB there holds exactly one repo, so any stable value serializes
+/// its writers correctly.
+pub fn write_lock_repo_id(config: &Config) -> String {
+    crate::repo_identity::resolve_repo_identity(&config.root, config.repo_id_override.as_deref())
+        .map(|identity| identity.repo_id)
+        .unwrap_or_else(|_| format!("root{}", worktree_hash(&config.root)))
 }
 
 thread_local! {
@@ -159,10 +259,37 @@ pub struct WriteLock {
 }
 
 impl WriteLock {
-    /// Blocks until acquired (returns immediately if this thread already holds it). Use only for
-    /// non-interactive writers; interactive / hook callers use [`WriteLock::acquire_timeout`].
-    pub fn acquire_blocking(database: &Path) -> anyhow::Result<WriteLock> {
-        let lock_path = write_lock_path(database);
+    /// Blocks until the PER-REPO write lock is acquired (returns immediately if this thread already
+    /// holds it). Use only for non-interactive writers; interactive / hook callers use
+    /// [`WriteLock::acquire_timeout`]. `repo_id` keys the lock file (A6) — resolve it via
+    /// [`write_lock_repo_id`].
+    pub fn acquire_blocking(database: &Path, repo_id: &str) -> anyhow::Result<WriteLock> {
+        Self::acquire_path_blocking(write_lock_path(database, repo_id))
+    }
+
+    /// Polls until the PER-REPO write lock is acquired or `timeout` elapses (returns immediately if
+    /// this thread already holds it); `Ok(None)` on timeout. `repo_id` keys the lock file (A6).
+    pub fn acquire_timeout(
+        database: &Path,
+        repo_id: &str,
+        timeout: Duration,
+    ) -> anyhow::Result<Option<WriteLock>> {
+        Self::acquire_path_timeout(write_lock_path(database, repo_id), timeout)
+    }
+
+    /// Polls until the GLOBAL schema-migration lock ([`schema_lock_path`]) is acquired or `timeout`
+    /// elapses; `Ok(None)` on timeout. Taken ONLY by the open-time auto-migrate (A6): a schema
+    /// migration rewrites the shared ladder, so it serializes across ALL repos, unlike the per-repo
+    /// write lock. Reentrant on the holding thread like the per-repo lock (a command already
+    /// holding it that re-opens under it does not self-deadlock).
+    pub fn acquire_schema_timeout(
+        database: &Path,
+        timeout: Duration,
+    ) -> anyhow::Result<Option<WriteLock>> {
+        Self::acquire_path_timeout(schema_lock_path(database), timeout)
+    }
+
+    fn acquire_path_blocking(lock_path: PathBuf) -> anyhow::Result<WriteLock> {
         if write_lock_held_on_this_thread(&lock_path) {
             register_write_lock(&lock_path);
             return Ok(WriteLock { _inner: None, lock_path });
@@ -172,13 +299,10 @@ impl WriteLock {
         Ok(WriteLock { _inner: Some(inner), lock_path })
     }
 
-    /// Polls until acquired or `timeout` elapses (returns immediately if this thread already holds
-    /// it); `Ok(None)` on timeout.
-    pub fn acquire_timeout(
-        database: &Path,
+    fn acquire_path_timeout(
+        lock_path: PathBuf,
         timeout: Duration,
     ) -> anyhow::Result<Option<WriteLock>> {
-        let lock_path = write_lock_path(database);
         if write_lock_held_on_this_thread(&lock_path) {
             register_write_lock(&lock_path);
             return Ok(Some(WriteLock { _inner: None, lock_path }));
@@ -384,33 +508,87 @@ mod tests {
         // thread is a genuine second writer → must still contend on the real OS lock.
         let dir = temp_dir();
         let db = dir.join("index.sqlite");
+        let repo = "repoaaaa0000";
 
-        let outer = WriteLock::acquire_blocking(&db).unwrap();
+        let outer = WriteLock::acquire_blocking(&db, repo).unwrap();
         // Nested acquire on the same thread re-enters immediately (a raw lock would self-deadlock).
-        let inner = WriteLock::acquire_timeout(&db, Duration::from_millis(50)).unwrap();
+        let inner = WriteLock::acquire_timeout(&db, repo, Duration::from_millis(50)).unwrap();
         assert!(inner.is_some(), "nested same-thread acquire must re-enter, not block");
         drop(inner);
 
         // While `outer` is still held, a DIFFERENT thread must not be able to acquire it.
         let db_other = db.clone();
         let got = std::thread::spawn(move || {
-            WriteLock::acquire_timeout(&db_other, Duration::from_millis(100)).unwrap().is_some()
+            WriteLock::acquire_timeout(&db_other, repo, Duration::from_millis(100))
+                .unwrap()
+                .is_some()
         })
         .join()
         .unwrap();
         assert!(!got, "a second thread must contend on the real OS lock while the first holds it");
 
+        // A6: a DIFFERENT repo's write lock is an INDEPENDENT file, so it acquires even while this
+        // repo's lock is held — the whole point of per-repo locks (a rebuild of one repo must not
+        // block a write to another in a shared DB).
+        let db_sibling = db.clone();
+        let sibling_got = std::thread::spawn(move || {
+            WriteLock::acquire_timeout(&db_sibling, "repobbbb1111", Duration::from_millis(100))
+                .unwrap()
+                .is_some()
+        })
+        .join()
+        .unwrap();
+        assert!(sibling_got, "a different repo's write lock must not be blocked by this repo's");
+
         drop(outer);
         // Fully released once the outermost guard drops: a fresh (cross-thread) acquire succeeds.
         let db_after = db.clone();
         let reacquired = std::thread::spawn(move || {
-            WriteLock::acquire_timeout(&db_after, Duration::from_millis(100)).unwrap().is_some()
+            WriteLock::acquire_timeout(&db_after, repo, Duration::from_millis(100))
+                .unwrap()
+                .is_some()
         })
         .join()
         .unwrap();
         assert!(reacquired, "the lock is free after the outermost guard drops");
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn canonical_lock_order_is_total_and_lexicographic_on_the_discriminator() {
+        // A portable (hex-leading) id sorts before a `local:`-derived one (hex digits < 'l' after
+        // sanitization), whichever way the pair is passed — the total order every multi-lock
+        // acquirer sorts by (see the module doc).
+        assert_eq!(
+            canonical_lock_order("0abc123root", "local:deadbeef"),
+            ("0abc123root", "local:deadbeef")
+        );
+        assert_eq!(
+            canonical_lock_order("local:deadbeef", "0abc123root"),
+            ("0abc123root", "local:deadbeef")
+        );
+        // Equal discriminators (the same repo) are the reentrant case, not an ordering question;
+        // the order is merely stable.
+        assert_eq!(canonical_lock_order("aaaa", "aaaa"), ("aaaa", "aaaa"));
+    }
+
+    #[test]
+    fn lock_paths_are_per_repo_but_the_schema_lock_is_global() {
+        // A6: the write / maintenance locks are keyed by repo_id (different repos → different
+        // files), while the schema-migration lock is one file per DB regardless of repo.
+        let db = Path::new("/repo/.rag-rat/index.sqlite");
+        assert_ne!(write_lock_path(db, "aaaa11112222"), write_lock_path(db, "bbbb33334444"));
+        assert_eq!(write_lock_path(db, "aaaa11112222"), write_lock_path(db, "aaaa11112222"));
+        assert_ne!(
+            maintenance_lock_path(db, "aaaa11112222"),
+            maintenance_lock_path(db, "bbbb33334444")
+        );
+        // The schema lock ignores the repo entirely (one migration serializer per DB file).
+        assert_eq!(schema_lock_path(db), schema_lock_path(db));
+        assert!(schema_lock_path(db).to_string_lossy().ends_with("rag-rat-schema.lock"));
+        // A `local:`-prefixed id sanitizes to alphanumerics (the `:` is dropped), still per-repo.
+        assert_eq!(write_lock_path(db, "local:abcdef01"), write_lock_path(db, "local:abcdef01"));
     }
 
     #[test]

--- a/crates/rag-rat-core/src/query/graph/predicates.rs
+++ b/crates/rag-rat-core/src/query/graph/predicates.rs
@@ -305,8 +305,17 @@ pub(crate) fn forward_visibility_filter(options: &GraphTraversalOptions) -> &'st
     }
 }
 pub(crate) fn unique_symbol_name(conn: &Connection, name: &str) -> anyhow::Result<bool> {
+    // GENERATION-SCOPED via the `files` view (batch 6, count-scoping class): an unscoped
+    // `COUNT(*) FROM symbols` counts the SAME live name once per generation during a
+    // dead-generation window (post-flip pre-gc, or crashed pre-flip staging) → count == 2 →
+    // "not unique" → the caller's `unique_short_name` gate DISABLES the short-name fallback
+    // branch and suppresses a genuine LIVE hop from the returned rows. Joining the scoped view
+    // counts only the live generation's symbols, matching the row queries in `traverse` /
+    // `traversal_summary`.
     let count: i64 = conn.query_row(
-        "SELECT COUNT(*) AS symbol_count FROM symbols WHERE name = ?1",
+        "SELECT COUNT(*) AS symbol_count FROM symbols
+         JOIN files ON files.id = symbols.file_id
+         WHERE symbols.name = ?1",
         [name],
         |row| row.get("symbol_count"),
     )?;

--- a/crates/rag-rat-core/src/query/graph/traverse.rs
+++ b/crates/rag-rat-core/src/query/graph/traverse.rs
@@ -207,6 +207,7 @@ pub(crate) fn traversal_summary(
                 SUM(CASE WHEN edges.confidence = 'Ambiguous' THEN 1 ELSE 0 END),
                 SUM(CASE WHEN edges.to_symbol_id IS NULL THEN 1 ELSE 0 END)
             FROM edges
+            JOIN files source_files ON source_files.id = edges.source_file_id
             LEFT JOIN symbols to_symbols ON to_symbols.id = edges.to_symbol_id
             LEFT JOIN name_strings to_qn ON to_qn.id = to_symbols.qualified_name_id
             WHERE edges.edge_kind IN ({quoted})
@@ -227,6 +228,7 @@ pub(crate) fn traversal_summary(
                 SUM(CASE WHEN edges.confidence = 'Ambiguous' THEN 1 ELSE 0 END),
                 SUM(CASE WHEN edges.to_symbol_id IS NULL THEN 1 ELSE 0 END)
             FROM edges
+            JOIN files source_files ON source_files.id = edges.source_file_id
             LEFT JOIN symbols from_symbols ON from_symbols.id = edges.from_symbol_id
             LEFT JOIN name_strings from_qn ON from_qn.id = from_symbols.qualified_name_id
             WHERE edges.edge_kind IN ({quoted})
@@ -383,6 +385,7 @@ pub(crate) fn hidden_unresolved_candidate_count(
             "
             SELECT COUNT(*)
             FROM edges
+            JOIN files source_files ON source_files.id = edges.source_file_id
             LEFT JOIN symbols to_symbols ON to_symbols.id = edges.to_symbol_id
             LEFT JOIN name_strings to_qn ON to_qn.id = to_symbols.qualified_name_id
             WHERE edges.edge_kind IN ({quoted})
@@ -403,6 +406,7 @@ pub(crate) fn hidden_unresolved_candidate_count(
             "
             SELECT COUNT(*)
             FROM edges
+            JOIN files source_files ON source_files.id = edges.source_file_id
             LEFT JOIN symbols from_symbols ON from_symbols.id = edges.from_symbol_id
             LEFT JOIN name_strings from_qn ON from_qn.id = from_symbols.qualified_name_id
             WHERE edges.edge_kind IN ({quoted})

--- a/crates/rag-rat-core/src/query/graph_meta.rs
+++ b/crates/rag-rat-core/src/query/graph_meta.rs
@@ -247,14 +247,23 @@ fn primary_symbol(conn: &Connection, chunk_id: i64) -> anyhow::Result<Option<Pri
 }
 
 fn count_callers(conn: &Connection, symbol: &PrimarySymbol) -> anyhow::Result<u64> {
+    // GENERATION-SCOPED via the `files` view (batch 6, count-scoping class): the `to_symbol_id =
+    // ?1` arm keys on a LIVE rowid (dead-generation edges carry re-minted ids, so they never
+    // match — as the clean `count_callees`/`count_edges_for_symbol` siblings rely on), but the
+    // unresolved `(to_symbol_id IS NULL AND to_name_id = …)` arm matches callsites purely by
+    // NAME and so counts dead-generation edges during a dead-generation window, inflating
+    // `caller_count`/`truncated` on GraphEvidence. Joining the scoped view bounds the count to
+    // the live generation's callsites (columns qualified because `files.id` would otherwise
+    // collide with the `-id` edge term).
     let count = conn
         .prepare_cached(
             "
-        SELECT COUNT(DISTINCT COALESCE(from_symbol_id, -id))
+        SELECT COUNT(DISTINCT COALESCE(edges.from_symbol_id, -edges.id))
         FROM edges
-        WHERE edge_kind IN ('calls_name', 'constructs', 'uses_macro')
-          AND (to_symbol_id = ?1 OR (to_symbol_id IS NULL AND to_name_id = (SELECT id FROM \
-             name_strings WHERE value = ?2)))
+        JOIN files source_files ON source_files.id = edges.source_file_id
+        WHERE edges.edge_kind IN ('calls_name', 'constructs', 'uses_macro')
+          AND (edges.to_symbol_id = ?1 OR (edges.to_symbol_id IS NULL AND edges.to_name_id = \
+             (SELECT id FROM name_strings WHERE value = ?2)))
         ",
         )?
         .query_row(params![symbol.id, symbol.name], |row| row.get::<_, i64>(0))?;

--- a/crates/rag-rat-core/src/query/grep_augment.rs
+++ b/crates/rag-rat-core/src/query/grep_augment.rs
@@ -461,8 +461,14 @@ fn render(
 /// Caller/callee edge counts. Callers resolve by `to_symbol_id` or qualified-name match;
 /// callees are edges leaving any of the symbol's concrete rows.
 fn edge_counts(conn: &Connection, hit: &symbol::SymbolHit) -> anyhow::Result<(i64, i64)> {
+    // GENERATION-SCOPED via the `files` view (batch 6, count-scoping class; `compose` installs the
+    // worktree scope view before calling in). The `to_symbol_id = ?1` arm keys on a LIVE rowid, but
+    // the `OR target_qualified_name = ?2` arm matches callers purely by NAME and so double-counts
+    // dead-generation edges during a dead-generation window, inflating the "{N} callers" line.
     let callers: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM edges WHERE to_symbol_id = ?1 OR target_qualified_name = ?2",
+        "SELECT COUNT(*) FROM edges
+         JOIN files source_files ON source_files.id = edges.source_file_id
+         WHERE edges.to_symbol_id = ?1 OR edges.target_qualified_name = ?2",
         rusqlite::params![hit.symbol_id, hit.qualified_name],
         |row| row.get(0),
     )?;

--- a/crates/rag-rat-core/src/query/memory/validate.rs
+++ b/crates/rag-rat-core/src/query/memory/validate.rs
@@ -320,7 +320,13 @@ pub(crate) fn validate_call_path_binding(
 }
 
 /// Is there still an edge matching this one's loose identity (names/kind/target), ignoring line
-/// numbers? Used to call a call-path edge `relocated` (moved) rather than `gone` (#38).
+/// numbers? Used to call a call-path edge `relocated` (moved) rather than `gone` (#38). The
+/// `JOIN files` is load-bearing (A6): `edges`/`edges_data` are NOT generation-scoped, so without it
+/// a superseded generation's edge rows (dead until gc) would keep matching — a genuinely-deleted
+/// call site would be reported `relocated` forever instead of `gone`. The join drops
+/// dead-generation edges (their `source_file_id` file row is absent from the live scope view) and
+/// scopes to the active repo for free, matching the sibling helpers `edge_by_fingerprint` /
+/// `call_path_edge_by_id`.
 fn call_path_edge_relocatable(
     conn: &Connection,
     from_name: Option<&str>,
@@ -332,6 +338,7 @@ fn call_path_edge_relocatable(
         "
         SELECT COUNT(*)
         FROM edges
+        JOIN files ON files.id = edges.source_file_id
         WHERE edge_kind = ?3
           AND COALESCE(from_name, '') = COALESCE(?1, '')
           AND COALESCE(to_name, '') = COALESCE(?2, '')

--- a/crates/rag-rat-core/src/query/repo_brief.rs
+++ b/crates/rag-rat-core/src/query/repo_brief.rs
@@ -511,12 +511,18 @@ pub(crate) fn summary_counts(conn: &Connection) -> anyhow::Result<SummaryCounts>
     // transitively through `source_file_id → main.files.repo_id` (the same join
     // `lexical::graph_boost` and `ensure_graph_index_current`'s scoped delete use), so count it
     // that way rather than via the global `edges` compatibility view (round-5 finding).
+    // The `generation` predicate is EXACTNESS-load-bearing (A6, P2 review): a generation-staged
+    // rebuild's committed waves make the staged generation's edges visible in `edges_data`
+    // pre-flip, and the superseded generation's linger until gc — a repo-only join would report
+    // old+new (roughly double) edges. `active_generation` matches the `files` count above (the
+    // view filters the same value), keeping the two counts one consistent snapshot.
     let repo_id = crate::index::schema::active_repo_id(conn)?;
+    let generation = crate::index::schema::active_generation(conn)?;
     let graph_edges: u64 = conn.query_row(
         "SELECT COUNT(*) FROM edges_data e
            JOIN main.files f ON f.id = e.source_file_id
-          WHERE f.repo_id = ?1",
-        [&repo_id],
+          WHERE f.repo_id = ?1 AND f.generation = ?2",
+        rusqlite::params![repo_id, generation],
         |row| row_u64(row, 0),
     )?;
     let git_commits = scoped_table_row_count(conn, "git_commits", &repo_id)?;

--- a/crates/rag-rat-core/src/search/lexical.rs
+++ b/crates/rag-rat-core/src/search/lexical.rs
@@ -578,6 +578,12 @@ fn graph_boost(
     // id), so the `EXISTS` drops no live edge in a single-repo DB. It applies AFTER the
     // `from_name_id`/`to_name_id` index seek narrows to ≤64 candidate edges, so the hot-path
     // integer indexes still drive the scan.
+    //
+    // A6 SURVIVOR (deliberately NOT generation-scoped, re-justified in the P2 sweep): this is a
+    // RANKING boost, not an exactness counter — a superseded generation's edges can inflate a
+    // confidence pick until gc, shifting ordering marginally before self-correcting, while the
+    // candidate set itself flows through the generation-scoped view. Re-evaluate only if this
+    // ever feeds a count a caller treats as exact.
     let mut stmt = conn.prepare_cached(
         "
         SELECT ek.value, conf.value, fn.value, tn.value

--- a/crates/rag-rat-core/src/storage.rs
+++ b/crates/rag-rat-core/src/storage.rs
@@ -134,11 +134,36 @@ impl IndexConnection {
             "
             PRAGMA busy_timeout = 5000;
             PRAGMA foreign_keys = ON;
-            PRAGMA journal_mode = WAL;
-            PRAGMA synchronous = NORMAL;
             ",
         )?;
-        Ok(())
+        // The delete→WAL transition needs an EXCLUSIVE lock, and SQLite deliberately does NOT run
+        // the busy handler on parts of that upgrade path (it returns SQLITE_BUSY immediately to
+        // break potential deadlocks among racing upgraders) — so busy_timeout alone does NOT save
+        // two truly concurrent FIRST opens of a fresh DB: one fails instantly with "database is
+        // locked" (the `concurrent_create_or_migrate_applies_the_schema_exactly_once` race, and a
+        // real production shape once a shared multi-repo DB gets its first two writers at once).
+        // Bounded manual retry instead: the loser converges as soon as the winner completes,
+        // because an ALREADY-WAL database answers `journal_mode = WAL` as a no-op without the
+        // exclusive lock. Not a flock: this must cover EVERY open path uniformly (config opens,
+        // bare opens, heals), not just the schema-apply bootstrap.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            match self.conn.execute_batch(
+                "
+                PRAGMA journal_mode = WAL;
+                PRAGMA synchronous = NORMAL;
+                ",
+            ) {
+                Ok(()) => return Ok(()),
+                Err(err) => {
+                    let err = anyhow::Error::from(err);
+                    if !is_busy(&err) || std::time::Instant::now() >= deadline {
+                        return Err(err);
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(20));
+                },
+            }
+        }
     }
 
     fn fts5_available(&self) -> bool {

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -84,14 +84,16 @@ impl Debounce {
 
 /// Run one maintenance pass, blocking on the per-DB write lock (watcher-to-watcher serializes).
 pub fn maintenance_pass(config: &Config, run_gc: bool) -> anyhow::Result<()> {
-    let _lock = locks::WriteLock::acquire_blocking(&config.database)?;
+    let lock_repo = locks::write_lock_repo_id(config);
+    let _lock = locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
     run_pass(config, run_gc)
 }
 
 /// Run one maintenance pass only if the write lock is free within `SKIP_TIMEOUT`; returns whether
 /// it ran. Used by interactive / hook / shutdown callers so a held lock can't hang them.
 pub fn maintenance_pass_or_skip(config: &Config, run_gc: bool) -> anyhow::Result<bool> {
-    match locks::WriteLock::acquire_timeout(&config.database, SKIP_TIMEOUT)? {
+    let lock_repo = locks::write_lock_repo_id(config);
+    match locks::WriteLock::acquire_timeout(&config.database, &lock_repo, SKIP_TIMEOUT)? {
         Some(_lock) => {
             run_pass(config, run_gc)?;
             Ok(true)
@@ -810,7 +812,8 @@ fn watcher_main(config: Config, fleet_bin: Option<PathBuf>, stop: &AtomicBool) {
 
 /// A bounded shutdown refresh: take the write lock only if free, run discover (no reconcile/embed).
 fn shutdown_discover(config: &Config) -> anyhow::Result<bool> {
-    match locks::WriteLock::acquire_timeout(&config.database, SKIP_TIMEOUT)? {
+    let lock_repo = locks::write_lock_repo_id(config);
+    match locks::WriteLock::acquire_timeout(&config.database, &lock_repo, SKIP_TIMEOUT)? {
         Some(_lock) => {
             IndexDatabase::index_discover(config)?;
             Ok(true)


### PR DESCRIPTION
Phase A6 of the global-DB consolidation (#401). Full rebuilds stop monopolizing the shared database's writer, and reader consistency survives mid-rebuild.

- **V043**: `files` gains `generation INTEGER NOT NULL DEFAULT 0`; UNIQUE → `(repo_id, path, commit_sha, worktree_id, generation)`; `id` preserved verbatim (FK target). Torn-state re-convergent, replay-idempotent, and deliberately free of cardinality-sensitive backfill — `DEFAULT 0` with an absent `live_files_generation` pointer meaning 0 makes existing rows correct on every adoption state.
- **Staged rebuild**: a full rebuild writes generation N+1 in chunked per-wave transactions, then flips `repo_meta[live_files_generation]` in a millisecond transaction; dead generations sweep lazily in gc (children follow via the FK cascade). The whole-run `BEGIN IMMEDIATE` is gone; `synchronous` stays NORMAL. Incremental indexing keeps writing the live generation in short transactions, unchanged.
- **Reader consistency, proven**: a reader opened mid-rebuild sees the *complete old generation* until the flip (barrier-paused rebuild, scoped counts + path probes on both sides of the flip); a paused rebuild of repo A does not block a write to repo B beyond the busy-timeout slice (< 2 s asserted).
- **Per-repo write locks**: `rag-rat-write-<repo>.lock` / per-repo maintenance lock+marker; a new global `rag-rat-schema.lock` guards only the open-time auto-migrate. Worktrees of one repo share the lock; the explicit unlock-on-drop flock invariant is preserved.
- **Generation-aware scope**: the connection context carries the generation; the scope view and the bare-open explicit-predicate paths (`all_symbols`, `rebuild_logical_symbols`) filter it; repo-scoped exact-count joins through `files` (clone df recompute) carry the generation predicate so a mid-rebuild recompute cannot double-count coexisting generations.
- **Found en route**: `call_path_edge_relocatable` read the raw edges view and reported deleted call sites as "relocated" — now joins through the scoped files.
- **Harness**: the poison sibling seeds its file rows at its own generation, so an unscoped dead-generation sweep trips the sibling-intact assertion; a dedicated test rebuilds the primary twice and asserts the sibling survives.

Workspace suite: 1509 passed; clippy `-D warnings` clean; nightly fmt clean.

Fixes #401

Also fixes a latent first-open race exposed by the new multi-writer tests: the delete→WAL `journal_mode` upgrade bypasses the SQLite busy handler, so two truly concurrent first opens of a fresh DB could fail instantly with SQLITE_BUSY despite `busy_timeout`; `IndexConnection::setup` now retries that pragma on a bounded deadline. Fixes #418
