### PR TITLE
feat(index): global database by default, rag-rat consolidate importer (#402)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3324,6 +3324,7 @@ dependencies = [
  "rag-rat-core",
  "rag-rat-mcp",
  "ratatui",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",

--- a/README.md
+++ b/README.md
@@ -265,6 +265,12 @@ Optional git hooks (`rag-rat hooks install`) keep the index current on checkout/
 One watcher per worktree and one writer at a time are enforced with file locks (unreliable on
 NFS / WSL2 `/mnt` mounts).
 
+By default every repo's index and memories live in **one consolidated database per machine**
+(`$XDG_DATA_HOME/rag-rat/rag-rat.sqlite`; override with `RAG_RAT_DATA_DIR`), so a deleted checkout or
+`git clean -fdx` no longer loses your authored memories. Set an explicit `[index] database` to keep a
+repo on its own file (deprecated), and run `rag-rat consolidate` to import a pre-existing
+`.rag-rat/index.sqlite` into the global store — see [docs/config.md](docs/config.md#database-location-index-database).
+
 ## <a id="output"></a>Output format
 
 The CLI and MCP results default to **TOON** (Token-Oriented Object Notation) — a token-efficient

--- a/crates/rag-rat-cli/Cargo.toml
+++ b/crates/rag-rat-cli/Cargo.toml
@@ -47,6 +47,8 @@ tikv-jemalloc-ctl = "0.6"
 # MCP tool results render as TOON; integration tests decode them back to JSON Values to assert.
 toon-format.workspace = true
 tempfile.workspace = true
+# The consolidate integration tests assert sibling-repo repo_meta state directly in the global DB.
+rusqlite.workspace = true
 
 [features]
 default = ["fastembed", "model2vec"]

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -1,7 +1,7 @@
 //! Declarative command-line surface (clap derive). The parser owns `--help`/`-h`,
 //! `--version`/`-V`, per-subcommand help, and flag validation — `main.rs` only dispatches on
-//! the typed result. The global `--config` defaults to `rag-rat.toml` and may appear before or
-//! after the subcommand.
+//! the typed result. The global `--config` defaults to governing-path discovery and may appear
+//! before or after the subcommand.
 
 use std::path::PathBuf;
 
@@ -15,9 +15,12 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
     propagate_version = true
 )]
 pub(crate) struct Cli {
-    /// Path to the rag-rat.toml config (relative to the current directory).
-    #[arg(long, global = true, default_value = "rag-rat.toml")]
-    pub config: String,
+    /// Path to the rag-rat.toml config (relative to the current directory). When omitted, the
+    /// config is DISCOVERED through the checkout's governing path: `rag-rat.toml` here, or — in a
+    /// linked git worktree with no local file — the main worktree's `rag-rat.toml`. An explicit
+    /// path is taken literally (no redirect).
+    #[arg(long, global = true)]
+    pub config: Option<String>,
 
     /// Emit JSON instead of the default TOON (Token-Oriented Object Notation). TOON is denser for
     /// LLM consumers; pass --json when a JSON parser must read the output. For commands that print
@@ -103,6 +106,10 @@ pub(crate) enum Command {
 
     /// SCIP-oracle pass: compiler-grade edge resolution from a language indexer.
     Oracle(OracleArgs),
+
+    /// Import this repo's legacy per-repo index into the consolidated global database, then rename
+    /// the legacy `.rag-rat/index.sqlite` so the repo uses the global store from then on.
+    Consolidate,
 
     /// Print the resolved configuration as JSON.
     DumpConfig,
@@ -617,7 +624,7 @@ mod tests {
     fn parses_global_config_after_subcommand() {
         let cli = Cli::try_parse_from(["rag-rat", "query", "--config", "x.toml", "foo", "bar"])
             .expect("parse");
-        assert_eq!(cli.config, "x.toml");
+        assert_eq!(cli.config.as_deref(), Some("x.toml"));
         match cli.command {
             Command::Query(args) => {
                 assert_eq!(args.query, vec!["foo", "bar"]);
@@ -628,9 +635,9 @@ mod tests {
     }
 
     #[test]
-    fn config_defaults_to_rag_rat_toml() {
+    fn config_defaults_to_discovery() {
         let cli = Cli::try_parse_from(["rag-rat", "gc"]).expect("parse");
-        assert_eq!(cli.config, "rag-rat.toml");
+        assert_eq!(cli.config, None, "no explicit --config ⇒ governing-path discovery");
     }
 
     #[test]

--- a/crates/rag-rat-cli/src/commands/clones.rs
+++ b/crates/rag-rat-cli/src/commands/clones.rs
@@ -278,6 +278,7 @@ mod tests {
 
         let config = Config {
             repo_id_override: None,
+            database_key_pinned: true,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {

--- a/crates/rag-rat-cli/src/commands/consolidate.rs
+++ b/crates/rag-rat-cli/src/commands/consolidate.rs
@@ -1,0 +1,45 @@
+//! `consolidate`: import this repo's legacy per-repo index into the consolidated global database
+//! (memory-sync phase A7). The logic lives in `rag_rat_core::index::consolidate`; this is the thin
+//! CLI shim that renders the outcome (a pinned `database` key is refused inside `run` with the
+//! remove-the-key remedy, so every rendered import is a completed import + rename).
+use rag_rat_core::Config;
+use rag_rat_core::index::consolidate::{self, ConsolidateOutcome};
+
+use crate::render::print_output;
+
+pub(crate) fn consolidate(config: &Config) -> anyhow::Result<()> {
+    let outcome = consolidate::run(config)?;
+    match &outcome {
+        ConsolidateOutcome::AlreadyGlobal { database } => print_output(&serde_json::json!({
+            "status": "already_global",
+            "database": database,
+            "note": "this repo already uses the consolidated global database",
+        })),
+        ConsolidateOutcome::AlreadyImported { imported } => print_output(&serde_json::json!({
+            "status": "already_consolidated",
+            "imported": imported,
+            "note": "already imported (an `.imported` marker is present); nothing to do",
+        })),
+        ConsolidateOutcome::NoLegacyIndex { source } => print_output(&serde_json::json!({
+            "status": "no_legacy_index",
+            "source": source,
+            "note": "no legacy per-repo index found to import",
+        })),
+        ConsolidateOutcome::Imported(summary) => print_output(&serde_json::json!({
+            "status": "imported",
+            "repo_id": summary.repo_id,
+            "target": summary.target,
+            "imported_from": summary.source,
+            "renamed_to": summary.renamed_to,
+            "memories": summary.memories,
+            "bindings": summary.bindings,
+            "tags": summary.tags,
+            "call_paths": summary.call_paths,
+            "call_path_edges": summary.call_path_edges,
+            "embedding_cache_rows": summary.embedding_cache_rows,
+            "meta_keys": summary.meta_keys,
+            "next": "run `rag-rat index --full` to rebuild the derived index — the carried \
+                     embedding cache makes re-embedding a no-op",
+        })),
+    }
+}

--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -471,6 +471,7 @@ mod tests {
         git(&main, &["commit", "-qm", "base"]);
         let config = Config {
             repo_id_override: None,
+            database_key_pinned: true,
             root: main.clone(),
             database: main.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
@@ -548,6 +549,7 @@ mod tests {
         git(&main, &["commit", "-qm", "base"]);
         let config = Config {
             repo_id_override: None,
+            database_key_pinned: true,
             root: main.clone(),
             database: main.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
@@ -623,6 +625,7 @@ mod tests {
         git(&root, &["commit", "-qm", "base"]);
         let config = Config {
             repo_id_override: None,
+            database_key_pinned: true,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
@@ -693,6 +696,7 @@ mod tests {
         std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
         let config = Config {
             repo_id_override: None,
+            database_key_pinned: true,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {

--- a/crates/rag-rat-cli/src/commands/mod.rs
+++ b/crates/rag-rat-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@
 
 mod clones;
 mod config_info;
+mod consolidate;
 mod format;
 mod hooks;
 mod index_ops;
@@ -17,6 +18,7 @@ mod search;
 
 pub(crate) use clones::{clones, clones_for};
 pub(crate) use config_info::{dump_config, version_check};
+pub(crate) use consolidate::consolidate;
 pub(crate) use format::{output_format, set_output_format};
 pub(crate) use hooks::{claude_hooks, github, hooks};
 pub(crate) use index_ops::{doctor, index, maintenance, reconcile};

--- a/crates/rag-rat-cli/src/commands/oracle.rs
+++ b/crates/rag-rat-cli/src/commands/oracle.rs
@@ -466,6 +466,7 @@ mod tests {
             .unwrap();
         let config = Config {
             repo_id_override: None,
+            database_key_pinned: true,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
@@ -513,6 +514,7 @@ mod tests {
         // (`include = ["**/*.rs"]`, no exclude), so the bindings-match check accepts it.
         let config_with = |include: Vec<String>, exclude: Vec<String>| Config {
             repo_id_override: None,
+            database_key_pinned: true,
             root: PathBuf::from("/x"),
             database: PathBuf::from("/x/db"),
             targets: vec![ResolvedTarget {

--- a/crates/rag-rat-cli/src/init/mod.rs
+++ b/crates/rag-rat-cli/src/init/mod.rs
@@ -22,7 +22,6 @@ use crate::{
     apply_embedding_runtime_env, git_paths, render_index_progress, render_reconcile_progress,
 };
 
-pub(crate) const DEFAULT_DATABASE: &str = ".rag-rat/index.sqlite";
 const SKIPPED_DIRS: &[&str] = &[
     ".git",
     ".rag-rat",
@@ -285,7 +284,17 @@ mod tests {
         let text = render_config(&plan);
 
         assert!(text.contains("[index]"));
-        assert!(text.contains("database = \".rag-rat/index.sqlite\""));
+        // A7: NO active `database` key — the keyless config resolves to the machine-global store.
+        // The deprecated per-repo opt-out is documented as a COMMENT only, so check for an active
+        // (uncommented) key, not the substring.
+        assert!(
+            !text.lines().any(|line| line.trim_start().starts_with("database")),
+            "a fresh config must not activate the deprecated per-repo `database` key:\n{text}"
+        );
+        assert!(
+            text.contains("# database = \".rag-rat/index.sqlite\""),
+            "the per-repo opt-out stays discoverable as a comment"
+        );
         assert!(text.contains("rust = [\"crates/app/src\"]"));
         assert!(text.contains("typescript = [\"web/src\", \"app/src\"]"));
         assert!(text.contains("[llm.embedding]"));
@@ -346,6 +355,48 @@ mod tests {
         assert!(config.watch.enabled);
         // Commented [log] falls back to its default (disabled).
         assert!(!config.log.enabled);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A7: the freshly rendered config has NO `database` key, so `Config::load` resolves it to the
+    /// consolidated GLOBAL store — the flip covers the primary onboarding path, not just
+    /// hand-written configs. Path resolution only; nothing is created at the global path.
+    #[test]
+    fn rendered_config_is_keyless_and_resolves_to_the_global_database() {
+        let root =
+            std::env::temp_dir().join(format!("ragrat-render-globaldb-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        // Identity-bearing root: the global default requires a derivable repo identity (a
+        // committed git repo); an identity-less root stays per-root.
+        for args in [
+            &["init", "-q"][..],
+            &["config", "user.email", "t@e"],
+            &["config", "user.name", "t"],
+            &["add", "-A"],
+            &["commit", "-qm", "seed"],
+        ] {
+            let out =
+                std::process::Command::new("git").arg("-C").arg(&root).args(args).output().unwrap();
+            assert!(out.status.success());
+        }
+        let plan = InitPlan {
+            root_value: ".".to_string(),
+            languages: vec![Language::Rust],
+            bindings: BTreeMap::from([(Language::Rust, vec![PathBuf::from("src")])]),
+            backend: EmbeddingBackend::fast_embed(),
+            oracle_auto_run: false,
+        };
+        std::fs::write(root.join("rag-rat.toml"), render_config(&plan)).unwrap();
+
+        let config = Config::load(root.join("rag-rat.toml")).unwrap();
+        assert_eq!(
+            config.database,
+            rag_rat_core::data_dir::global_database_path()
+                .expect("a data dir resolves in the test environment"),
+            "a fresh init's keyless config lands on the machine-global store",
+        );
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/crates/rag-rat-cli/src/init/render.rs
+++ b/crates/rag-rat-cli/src/init/render.rs
@@ -1,10 +1,11 @@
 use super::*;
 
 /// Render a complete, commented `rag-rat.toml`. The lines that reflect *this* repo's choices —
-/// root/database, the language bindings, the chosen embedding model, the oracle opt-in — are
-/// active; every other table is emitted as commented defaults so the full config surface is
-/// discoverable without leaving the file (the bare-bindings stub used to hide it). See
-/// `docs/config.md`.
+/// root, the language bindings, the chosen embedding model, the oracle opt-in — are active; every
+/// other table is emitted as commented defaults so the full config surface is discoverable without
+/// leaving the file (the bare-bindings stub used to hide it). No `database` key is emitted: the
+/// keyless config resolves to the machine-global store (the A7 default), with the deprecated
+/// per-repo opt-out documented as a comment. See `docs/config.md`.
 pub(crate) fn render_config(plan: &InitPlan) -> String {
     let mut text = String::new();
     text.push_str(
@@ -15,7 +16,15 @@ pub(crate) fn render_config(plan: &InitPlan) -> String {
 
     text.push_str("[index]\n");
     text.push_str(&format!("root = {}\n", toml_string(&plan.root_value)));
-    text.push_str(&format!("database = {}\n\n", toml_string(DEFAULT_DATABASE)));
+    // No `database` key: the index + memories live in the machine-global store by default (A7),
+    // which is what makes them survive `git clean -fdx` / a deleted checkout. The commented line
+    // documents the deprecated per-repo opt-out without activating it.
+    text.push_str(
+        "# The index and repo memories live in the machine-global database by default\n# \
+         ($XDG_DATA_HOME/rag-rat/rag-rat.sqlite; override the location with RAG_RAT_DATA_DIR).\n# \
+         Uncomment to keep this repo on its own per-repo file instead (deprecated):\n# database = \
+         \".rag-rat/index.sqlite\"\n\n",
+    );
 
     text.push_str(
         "# Language → directories to index. Each language indexes its default file extensions in \

--- a/crates/rag-rat-cli/src/init/run.rs
+++ b/crates/rag-rat-cli/src/init/run.rs
@@ -7,6 +7,18 @@ pub(crate) fn run(args: &crate::cli::InitArgs, config_path: &str) -> anyhow::Res
     let _terminal_reset = TerminalResetGuard::install_if_interactive(!options.yes)?;
     let root = env::current_dir()?.canonicalize()?;
 
+    // A config authored in a LINKED worktree is a trap: `Config::load`'s governing seam resolves
+    // every worktree of a repo through the MAIN worktree's `rag-rat.toml`, so a branch-local file
+    // would be ignored the moment main gains one (and governs only by fallback until then).
+    // Refuse with the pointer instead of writing a file that doesn't do what it says.
+    if let Some(main_root) = rag_rat_core::config::linked_worktree_main_root(&root) {
+        anyhow::bail!(
+            "this is a linked git worktree; the repo's rag-rat.toml lives in the main worktree — \
+             run `rag-rat init` there instead: {}",
+            main_root.display()
+        );
+    }
+
     // The interactive path runs the full-screen ratatui wizard. `--yes` keeps the legacy
     // `default_plan` + `render_config` flow; `--dry-run` remains interactive unless paired with
     // `--yes`, so the preview reflects the wizard choices.
@@ -302,7 +314,12 @@ pub(crate) fn default_plan(root_value: String, scan: &RepoScan) -> InitPlan {
 }
 pub(crate) fn setup_index(config: &Config) -> anyhow::Result<IndexDatabase> {
     eprintln!("init: migrating SQLite schema");
-    let migration = IndexDatabase::migrate(&config.database)?;
+    // SCHEMA-ONLY: init's subject repo is NOT registered yet (this is its very first index), so on
+    // a global DB that already holds another repo the healing `migrate`'s open-time healers would
+    // attribute an owed heal to that SIBLING via the witness's sole-repo arm — the same
+    // unregistered-subject rule consolidate follows (see `scoped_repo_witness`'s limit). The
+    // config-bearing index open below registers the new repo and runs the heals correctly scoped.
+    let migration = IndexDatabase::migrate_schema_only(&config.database)?;
     if migration.state != rag_rat_core::index::schema::SchemaState::Compatible {
         anyhow::bail!("{}", migration.message);
     }

--- a/crates/rag-rat-cli/src/init/wizard/draft.rs
+++ b/crates/rag-rat-cli/src/init/wizard/draft.rs
@@ -16,7 +16,7 @@ use toml_edit::{Array, DocumentMut, Item, Table};
 
 use crate::init::render::{config_root_value, display_rel, render_config};
 use crate::init::scan::{candidate_dirs, estimated_chunks, recommend_backend};
-use crate::init::{DEFAULT_DATABASE, InitPlan, RepoScan};
+use crate::init::{InitPlan, RepoScan};
 
 /// The embedding remote connection mode, derived from `RemoteEmbeddingConfig`.
 ///
@@ -214,12 +214,14 @@ pub(crate) struct WizardDraft {
     /// Resolved absolute repo root, for dir-existence validation; NOT serialized — only
     /// `root_value` renders to TOML.
     pub root_abs: PathBuf,
-    /// The `[index] database` value.
+    /// The RESOLVED database path — where this repo's index actually lands, for display.
     ///
-    /// Captured from the existing config (reconfigure) so a future Database step can surface/edit
-    /// it, but NOT yet emitted: `write_fresh` uses `DEFAULT_DATABASE` and `patch_existing` only
-    /// touches `[index] root` (toml_edit preserves any existing `database` key untouched).
-    /// Reserved seam — keep the narrow allow until a step writes it back.
+    /// For a fresh draft this is the keyless default (`config::default_database_path`: the
+    /// machine-global store, or a pre-existing legacy `.rag-rat/index.sqlite`); for a reconfigure
+    /// it is `Config::load`'s resolved `database` (an explicit key, or the same keyless default).
+    /// NOT emitted: `write_fresh` renders a keyless config (the A7 global default) and
+    /// `patch_existing` never touches `database` (toml_edit preserves an existing explicit key
+    /// untouched). Reserved seam — keep the narrow allow until a step surfaces/edits it.
     #[allow(dead_code)]
     pub db_path: String,
     /// Per-language directory bindings (`[target_bindings]`).
@@ -292,10 +294,16 @@ impl WizardDraft {
         let backend = recommend_backend(estimated_chunks(scan.total_source_bytes()));
         let oracle = OracleConfig::default();
 
+        // The RESOLVED landing spot for the keyless config this draft renders (display only):
+        // the machine-global store, or a pre-existing legacy `.rag-rat/index.sqlite`.
+        let db_path = rag_rat_core::config::default_database_path(&root_abs, &root_abs, None)
+            .display()
+            .to_string();
+
         Self {
             root_value,
             root_abs,
-            db_path: DEFAULT_DATABASE.to_string(),
+            db_path,
             bindings,
             has_rich_targets: false,
             rich_target_names: BTreeSet::new(),
@@ -733,6 +741,41 @@ mod tests {
         assert!(!RUNPOD_GPUS.contains(&"NVIDIA A100"));
         assert!(!RUNPOD_GPUS.contains(&"NVIDIA H100"));
         assert!(!RUNPOD_GPUS.contains(&"NVIDIA RTX 4090"));
+    }
+
+    /// A7 reconfigure invariant: an EXPLICIT `[index] database` key in the original TOML survives
+    /// `patch_existing` byte-for-byte — the wizard never un-migrates a deliberately per-repo config
+    /// (and never adds a key to a keyless one; `write_fresh` renders keyless).
+    #[test]
+    fn patch_existing_preserves_an_explicit_database_key() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        let config_path = dir.path().join("rag-rat.toml");
+        let raw = "[index]\nroot = \".\"\ndatabase = \
+                   \"custom/index.sqlite\"\n\n[llm.embedding]\nmodel = \
+                   \"none\"\n\n[target_bindings]\nrust = [\"src\"]\n";
+        std::fs::write(&config_path, raw).unwrap();
+        let cfg = rag_rat_core::config::Config::load(&config_path).unwrap();
+
+        let d = WizardDraft::from_existing(raw, &cfg, &config_path);
+        // The display seam shows the RESOLVED path (the explicit key, made absolute by load).
+        assert!(
+            d.db_path.ends_with("custom/index.sqlite"),
+            "reconfigure displays the explicit database path, got {}",
+            d.db_path
+        );
+        let patched = d.patch_existing(raw).unwrap();
+        assert!(
+            patched.contains("database = \"custom/index.sqlite\""),
+            "the explicit key must survive a reconfigure untouched:\n{patched}"
+        );
+
+        // The fresh-write path is the keyless counterpart: no active `database` key rendered.
+        let fresh = d.write_fresh();
+        assert!(
+            !fresh.lines().any(|line| line.trim_start().starts_with("database")),
+            "write_fresh must render a keyless config:\n{fresh}"
+        );
     }
 
     #[test]

--- a/crates/rag-rat-cli/src/main.rs
+++ b/crates/rag-rat-cli/src/main.rs
@@ -70,12 +70,12 @@ fn main() -> anyhow::Result<()> {
     // These commands must work without a config file present — `init` creates one, and the
     // Claude Code hook entrypoint reads its event from stdin. Everything else needs a config.
     match &cli.command {
-        Cmd::Init(args) => return init::run(args, &cli.config),
+        Cmd::Init(args) => return init::run(args, cli.config.as_deref().unwrap_or("rag-rat.toml")),
         Cmd::ClaudeHook => return claude_hook::run(),
         _ => {},
     }
 
-    let config = load_config_or_hint(&cli.config)?;
+    let config = load_config_or_hint(cli.config.as_deref())?;
     apply_embedding_runtime_env(&config.llm.embedding.runtime);
 
     // Debug logging (off unless `[log] enabled` or `RAG_RAT_LOG`). Writes are blocking (synchronous
@@ -150,6 +150,7 @@ fn main() -> anyhow::Result<()> {
         #[cfg(feature = "eval")]
         Cmd::BenchmarkEmbedding(args) => benchmark_embedding(&config, &args)?,
         Cmd::Oracle(args) => oracle(&config, &args)?,
+        Cmd::Consolidate => consolidate(&config)?,
         Cmd::DumpConfig => dump_config(&config)?,
         Cmd::VersionCheck => version_check(&config)?,
     }
@@ -347,11 +348,22 @@ fn now_epoch_ms() -> i64 {
 /// Load the config, mapping a missing file to a friendly hint instead of a raw IO error.
 /// `init`/`--help`/`--version` never reach here, so this only guards commands that genuinely
 /// need a configured repo.
-pub(crate) fn load_config_or_hint(path: &str) -> anyhow::Result<Config> {
-    if !Path::new(path).exists() {
+///
+/// `explicit` is the user's `--config` value, taken literally; `None` resolves through
+/// [`rag_rat_core::config::discover_config_path`] — the discovery side of the governing seam, so
+/// a linked worktree with no branch-local `rag-rat.toml` (the state `init`'s refusal leaves)
+/// finds the MAIN worktree's config instead of dying at the existence check, and the hint in a
+/// truly config-less repo names the path where the config BELONGS (main's, in a linked checkout).
+pub(crate) fn load_config_or_hint(explicit: Option<&str>) -> anyhow::Result<Config> {
+    let path = match explicit {
+        Some(path) => std::path::PathBuf::from(path),
+        None => rag_rat_core::config::discover_config_path(Path::new(".")),
+    };
+    if !path.exists() {
         anyhow::bail!(
-            "No rag-rat config found at `{path}`.\nRun `rag-rat init` to create one, or pass \
-             --config <path>."
+            "No rag-rat config found at `{}`.\nRun `rag-rat init` to create one, or pass --config \
+             <path>.",
+            path.display()
         );
     }
     Ok(Config::load(path)?)
@@ -428,7 +440,7 @@ mod tests {
         let missing =
             std::env::temp_dir().join(format!("rag-rat-no-config-{}-{n}.toml", std::process::id()));
         let _ = std::fs::remove_file(&missing);
-        let err = load_config_or_hint(missing.to_str().unwrap()).unwrap_err();
+        let err = load_config_or_hint(Some(missing.to_str().unwrap())).unwrap_err();
         let message = err.to_string();
         assert!(message.contains("rag-rat init"), "expected init hint, got: {message}");
     }

--- a/crates/rag-rat-cli/tests/consolidate.rs
+++ b/crates/rag-rat-cli/tests/consolidate.rs
@@ -1,0 +1,571 @@
+//! Integration: `rag-rat consolidate` imports a repo's legacy per-repo index into the consolidated
+//! global database (phase A7). A pinned `database` key (the exact shape pre-flip `init` rendered)
+//! is REFUSED with the remove-the-key remedy — no import, no side effects — so there is never a
+//! divergence window between an early import and a later rename; the single post-removal run
+//! imports and renames atomically. Idempotent afterwards.
+//!
+//! Runs the built binary in a subprocess with `RAG_RAT_DATA_DIR` set (per-process env — never races
+//! the thread-based `cargo test` runner), so the global store lands in a throwaway temp dir and
+//! never touches a developer's real `~/.local/share/rag-rat`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static TEMP: AtomicU64 = AtomicU64::new(0);
+
+fn unique_dir(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "rag-rat-consolidate-{tag}-{}-{}",
+        std::process::id(),
+        TEMP.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = fs::remove_dir_all(&dir);
+    dir
+}
+
+fn git(dir: &Path, args: &[&str]) {
+    let out = Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
+    assert!(out.status.success(), "git {args:?} failed: {}", String::from_utf8_lossy(&out.stderr));
+}
+
+/// A git fixture repo with one rust file and an EXPLICIT `database` key — the pre-flip `init`
+/// shape — so the initial index builds the LEGACY per-repo `.rag-rat/index.sqlite`.
+fn fixture_repo() -> PathBuf {
+    let root = unique_dir("repo");
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn consolidate_anchor() {}\n").unwrap();
+    fs::write(
+        root.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\ndatabase = \".rag-rat/index.sqlite\"\n\n[target_bindings]\nrust = \
+         [\"src\"]\n",
+    )
+    .unwrap();
+    git(&root, &["init", "-q", "-b", "main"]);
+    git(&root, &["config", "user.email", "t@e"]);
+    git(&root, &["config", "user.name", "t"]);
+    git(&root, &["add", "."]);
+    git(&root, &["commit", "-q", "-m", "seed"]);
+    root
+}
+
+fn run(root: &Path, data_dir: &Path, model_cache: &Path, args: &[&str]) -> Output {
+    let binary = env!("CARGO_BIN_EXE_rag-rat");
+    Command::new(binary)
+        .current_dir(root)
+        .env("RAG_RAT_DATA_DIR", data_dir)
+        .env("RAG_RAT_MODEL_CACHE", model_cache)
+        .env("RAG_RAT_NO_WATCH", "1")
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn consolidate_refuses_a_pinned_config_then_completes_after_key_removal() {
+    let root = fixture_repo();
+    let data_dir = unique_dir("data");
+    let model_cache = unique_dir("cache");
+    let legacy = root.join(".rag-rat/index.sqlite");
+    let imported = root.join(".rag-rat/index.sqlite.imported");
+    let global = data_dir.join("rag-rat.sqlite");
+
+    // Build the LEGACY per-repo index (the explicit `database` key targets
+    // `.rag-rat/index.sqlite`).
+    let out = run(&root, &data_dir, &model_cache, &["index", "--full"]);
+    assert!(out.status.success(), "index --full failed: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(legacy.exists(), "the legacy per-repo index was built");
+    assert!(!global.exists(), "the global store does not exist before consolidate");
+
+    // A pinned `database` key is REFUSED outright: no import, no global store, no rename — an
+    // early import would open a divergence window in which legacy-side memory edits are silently
+    // dropped by the idempotent finishing run.
+    let out = run(&root, &data_dir, &model_cache, &["consolidate"]);
+    assert!(!out.status.success(), "a pinned config must be refused, not imported");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("Remove the `database` key"), "the refusal names the remedy: {stderr}");
+    assert!(!global.exists(), "REFUSED: no global store was created");
+    assert!(legacy.exists(), "REFUSED: the legacy file is untouched");
+    assert!(!imported.exists(), "REFUSED: no .imported marker");
+
+    // The refused repo is untouched: its next index run still uses the legacy DB.
+    let out = run(&root, &data_dir, &model_cache, &["index"]);
+    assert!(
+        out.status.success(),
+        "a refused repo keeps indexing its legacy DB: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(legacy.exists(), "the legacy DB is still the pinned repo's live index");
+
+    // Remove the `database` key (the config goes keyless) and re-run: the SINGLE completing run
+    // imports and renames atomically — no window in which legacy-side edits can be lost.
+    fs::write(
+        root.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\n\n[target_bindings]\nrust = [\"src\"]\n",
+    )
+    .unwrap();
+    let out = run(&root, &data_dir, &model_cache, &["consolidate"]);
+    assert!(
+        out.status.success(),
+        "the post-removal run failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("imported"), "the completing run reports the import: {stdout}");
+    assert!(global.exists(), "the global store now exists");
+    assert!(!legacy.exists(), "the completing run renamed the legacy file away");
+    assert!(imported.exists(), "the .imported marker is in place");
+    // No WAL-sidecar litter remains at the legacy path (they travel with the archive or were
+    // folded by the checkpoint — either way the directory is clean).
+    for suffix in ["-wal", "-shm"] {
+        let mut sidecar = legacy.as_os_str().to_os_string();
+        sidecar.push(suffix);
+        assert!(
+            !std::path::Path::new(&sidecar).exists(),
+            "no bare {suffix} sidecar remains beside the renamed legacy file"
+        );
+    }
+
+    // A further re-run is a no-op: the `.imported` marker LATCHES the keyless config onto the
+    // global store, so resolution now lands there directly (`already_global`).
+    let out = run(&root, &data_dir, &model_cache, &["consolidate"]);
+    assert!(out.status.success(), "re-run failed: {}", String::from_utf8_lossy(&out.stderr));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("already_global"), "re-run is a no-op via the latch: {stdout}");
+
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_dir_all(&data_dir);
+    let _ = fs::remove_dir_all(&model_cache);
+}
+
+/// A CUSTOM pinned `database` path gets the path-aware remedy: the refusal prints the literal move
+/// to the default legacy location (keyless resolution never consults a custom path, so removing
+/// the key alone would strand the index as `no_legacy_index` and its memories would never be
+/// imported). Following the printed remedy — move, remove the key, re-run — imports the custom
+/// index end-to-end.
+#[test]
+fn consolidate_custom_pin_remedy_moves_then_imports() {
+    let root = unique_dir("custom");
+    let data_dir = unique_dir("customdata");
+    let model_cache = unique_dir("customcache");
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn custom_pin_anchor() {}\n").unwrap();
+    fs::write(
+        root.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\ndatabase = \"custom/my-index.sqlite\"\n\n[target_bindings]\nrust \
+         = [\"src\"]\n",
+    )
+    .unwrap();
+    git(&root, &["init", "-q", "-b", "main"]);
+    git(&root, &["config", "user.email", "t@e"]);
+    git(&root, &["config", "user.name", "t"]);
+    git(&root, &["add", "."]);
+    git(&root, &["commit", "-q", "-m", "seed"]);
+
+    let custom = root.join("custom/my-index.sqlite");
+    let default_legacy = root.join(".rag-rat/index.sqlite");
+    let global = data_dir.join("rag-rat.sqlite");
+
+    let out = run(&root, &data_dir, &model_cache, &["index", "--full"]);
+    assert!(out.status.success(), "index --full failed: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(custom.exists(), "the custom-pinned index was built");
+
+    // Refused with the CUSTOM remedy: the literal move to the default location.
+    let out = run(&root, &data_dir, &model_cache, &["consolidate"]);
+    assert!(!out.status.success(), "a custom pin must be refused");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("mv "), "the custom remedy prints the literal move: {stderr}");
+    assert!(
+        stderr.contains("my-index.sqlite") && stderr.contains(".rag-rat/index.sqlite"),
+        "the move names the user's actual paths: {stderr}"
+    );
+    assert!(custom.exists(), "REFUSED: the custom index is untouched");
+    assert!(!global.exists(), "REFUSED: no global store was created");
+
+    // Follow the remedy: move the file to the default location, drop the key, re-run.
+    fs::create_dir_all(default_legacy.parent().unwrap()).unwrap();
+    fs::rename(&custom, &default_legacy).unwrap();
+    fs::write(
+        root.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\n\n[target_bindings]\nrust = [\"src\"]\n",
+    )
+    .unwrap();
+    let out = run(&root, &data_dir, &model_cache, &["consolidate"]);
+    assert!(
+        out.status.success(),
+        "the post-move run must import: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("imported"), "the moved index imported: {stdout}");
+    assert!(global.exists(), "the global store now exists");
+    assert!(!default_legacy.exists(), "the moved file was renamed to the marker");
+    assert!(root.join(".rag-rat/index.sqlite.imported").exists(), "marker in place");
+
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_dir_all(&data_dir);
+    let _ = fs::remove_dir_all(&model_cache);
+}
+
+/// Consolidating a SECOND repo into a one-repo global DB must not heal/mutate the FIRST repo's
+/// meta: consolidate's pre-registration migration is schema-only, because on that config-less
+/// connection the open-time healers' witness would resolve the sole registered repo — the SIBLING
+/// of the incoming one — and a heal-owed pass would clear its model meta under only the incoming
+/// repo's locks.
+#[test]
+fn consolidating_a_second_repo_leaves_the_first_repos_heal_owed_meta() {
+    let data_dir = unique_dir("seconddata");
+    let model_cache = unique_dir("secondcache");
+    let global = data_dir.join("rag-rat.sqlite");
+
+    // Repo 1: index under a pin, then complete the keyless consolidate.
+    let repo1 = fixture_repo();
+    let out = run(&repo1, &data_dir, &model_cache, &["index", "--full"]);
+    assert!(out.status.success(), "repo1 index: {}", String::from_utf8_lossy(&out.stderr));
+    fs::write(
+        repo1.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\n\n[target_bindings]\nrust = [\"src\"]\n",
+    )
+    .unwrap();
+    let out = run(&repo1, &data_dir, &model_cache, &["consolidate"]);
+    assert!(out.status.success(), "repo1 consolidate: {}", String::from_utf8_lossy(&out.stderr));
+
+    // Give repo 1 a HEAL-OWED model meta (a legacy model id) directly in the global DB.
+    let repo1_id: String = {
+        let conn = rusqlite::Connection::open(&global).unwrap();
+        let id: String = conn
+            .query_row(
+                "SELECT repo_id FROM repos WHERE repo_id != '__unassigned__' LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO repo_meta(repo_id, key, value) VALUES (?1, \
+             'active_embedding_model', 'fastembed-all-minilm-l6-v2')",
+            [&id],
+        )
+        .unwrap();
+        id
+    };
+
+    // Repo 2: index under a pin, then consolidate INTO the one-repo global DB.
+    let repo2 = fixture_repo();
+    let out = run(&repo2, &data_dir, &model_cache, &["index", "--full"]);
+    assert!(out.status.success(), "repo2 index: {}", String::from_utf8_lossy(&out.stderr));
+    fs::write(
+        repo2.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\n\n[target_bindings]\nrust = [\"src\"]\n",
+    )
+    .unwrap();
+    let out = run(&repo2, &data_dir, &model_cache, &["consolidate"]);
+    assert!(out.status.success(), "repo2 consolidate: {}", String::from_utf8_lossy(&out.stderr));
+
+    // Repo 1's heal-owed meta is UNTOUCHED — consolidate never healed the sibling.
+    let conn = rusqlite::Connection::open(&global).unwrap();
+    let survived: Option<String> = conn
+        .query_row(
+            "SELECT value FROM repo_meta WHERE repo_id = ?1 AND key = 'active_embedding_model'",
+            [&repo1_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        survived.as_deref(),
+        Some("fastembed-all-minilm-l6-v2"),
+        "consolidating repo 2 healed (cleared) repo 1's model meta through the sibling witness",
+    );
+
+    let _ = fs::remove_dir_all(&repo1);
+    let _ = fs::remove_dir_all(&repo2);
+    let _ = fs::remove_dir_all(&data_dir);
+    let _ = fs::remove_dir_all(&model_cache);
+}
+
+/// Guard ordering: a config still PINNED at a missing/renamed path must be REFUSED with the
+/// remedy — not exit happily as `no_legacy_index` while the repo stays stranded on the pin (the
+/// next `rag-rat index` would recreate an empty per-repo DB there). A pin at the global target
+/// itself is genuinely `already_global`.
+#[test]
+fn consolidate_refuses_a_pin_at_a_missing_path_and_accepts_a_pin_at_global() {
+    let root = fixture_repo(); // pinned at .rag-rat/index.sqlite, never indexed → path missing
+    let data_dir = unique_dir("pinorderdata");
+    let model_cache = unique_dir("pinordercache");
+
+    let out = run(&root, &data_dir, &model_cache, &["consolidate"]);
+    assert!(!out.status.success(), "a pin at a MISSING path must still be refused");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Remove the `database` key"),
+        "the refusal (not no_legacy_index) surfaces with the remedy: {stderr}"
+    );
+
+    // A pin at the global target itself is the one genuinely-fine pin: already_global.
+    let global = data_dir.join("rag-rat.sqlite");
+    fs::write(
+        root.join("rag-rat.toml"),
+        format!(
+            "[index]\nroot = \".\"\ndatabase = \"{}\"\n\n[target_bindings]\nrust = [\"src\"]\n",
+            global.display()
+        ),
+    )
+    .unwrap();
+    let out = run(&root, &data_dir, &model_cache, &["consolidate"]);
+    assert!(out.status.success(), "a pin at the global target is already_global");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("already_global"), "pin-at-global reports already_global: {stdout}");
+
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_dir_all(&data_dir);
+    let _ = fs::remove_dir_all(&model_cache);
+}
+
+/// The legacy-side lock drain covers the source DB's OWN registered ids, not just the current
+/// identity (Codex batch 5): a legacy index created under a `local:` shallow id and deepened
+/// before consolidating derives a PORTABLE identity — a current-identity lock alone would not
+/// conflict with a pre-deepen watcher still holding the `local:` lock, letting the snapshot +
+/// rename race its writes into the renamed artifact. Consolidate peeks the source's `repos`
+/// registry and drains EVERY recorded id's legacy-side lock (canonical order, bounded), so it
+/// BLOCKS while the pre-deepen writer runs and completes once the lock is released.
+#[test]
+fn consolidate_drains_a_pre_deepen_writers_legacy_lock() {
+    let root = fixture_repo();
+    let data_dir = unique_dir("draindata");
+    let model_cache = unique_dir("draincache");
+    let legacy = root.join(".rag-rat/index.sqlite");
+
+    let out = run(&root, &data_dir, &model_cache, &["index", "--full"]);
+    assert!(out.status.success(), "index --full failed: {}", String::from_utf8_lossy(&out.stderr));
+    fs::write(
+        root.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\n\n[target_bindings]\nrust = [\"src\"]\n",
+    )
+    .unwrap();
+
+    // The legacy DB's registry records the OLD `local:` id it was created under (the pre-deepen
+    // identity); the checkout now derives portable.
+    {
+        let conn = rusqlite::Connection::open(&legacy).unwrap();
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES \
+             ('local:predeepen00', 's', 0)",
+            [],
+        )
+        .unwrap();
+    }
+
+    // A simulated PRE-DEEPEN writer: holds the `local:` id's legacy-side flock (the exact lock a
+    // watcher/memory command started before the unshallow would hold).
+    let lock_path = rag_rat_core::locks::write_lock_path(&legacy, "local:predeepen00");
+    let lock_file =
+        fs::OpenOptions::new().create(true).truncate(false).write(true).open(&lock_path).unwrap();
+    lock_file.lock().unwrap();
+
+    // Consolidate must BLOCK on the outgoing lock (bounded, 30s) — not race the writer.
+    let binary = env!("CARGO_BIN_EXE_rag-rat");
+    let mut child = Command::new(binary)
+        .current_dir(&root)
+        .env("RAG_RAT_DATA_DIR", &data_dir)
+        .env("RAG_RAT_MODEL_CACHE", &model_cache)
+        .env("RAG_RAT_NO_WATCH", "1")
+        .arg("consolidate")
+        .spawn()
+        .unwrap();
+    std::thread::sleep(std::time::Duration::from_secs(2));
+    assert!(
+        child.try_wait().unwrap().is_none(),
+        "consolidate must block on the pre-deepen writer's local: lock, not race it"
+    );
+
+    // Writer finishes → consolidate acquires the drained lock set and completes the import.
+    lock_file.unlock().unwrap();
+    let status = child.wait().unwrap();
+    assert!(status.success(), "consolidate completes once the pre-deepen writer releases");
+    assert!(
+        root.join(".rag-rat/index.sqlite.imported").exists(),
+        "the import + rename completed after the drain"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_dir_all(&data_dir);
+    let _ = fs::remove_dir_all(&model_cache);
+}
+
+/// OLD-VINTAGE sources (Codex batch 6): a legacy DB this binary never opened keeps its model meta
+/// in the pre-V039 `index_meta`/`reconcile_meta` tables, while the import reads `repo_meta` only —
+/// consolidate therefore runs the migration LADDER on the source first (under the source-side
+/// locks, before the snapshot; the file is about to be renamed `.imported` anyway), letting
+/// V039/V040's own migrations relocate the meta instead of the importer re-implementing dual-path
+/// reads. The model-state unit must arrive complete on the global side.
+#[test]
+fn consolidate_migrates_an_old_vintage_source_so_model_meta_arrives() {
+    let root = fixture_repo();
+    let data_dir = unique_dir("vintagedata");
+    let model_cache = unique_dir("vintagecache");
+    let legacy = root.join(".rag-rat/index.sqlite");
+    let global = data_dir.join("rag-rat.sqlite");
+
+    let out = run(&root, &data_dir, &model_cache, &["index", "--full"]);
+    assert!(out.status.success(), "index --full failed: {}", String::from_utf8_lossy(&out.stderr));
+
+    // Doctor the legacy file into the pre-V039 vintage: model meta lives in the OLD global
+    // `index_meta` table, and the schema ledger stops at V038 so the ladder re-runs the
+    // relocation migrations on the next apply.
+    {
+        let conn = rusqlite::Connection::open(&legacy).unwrap();
+        conn.execute("DELETE FROM repo_meta WHERE key = 'active_embedding_model'", []).unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO index_meta(key, value) VALUES ('active_embedding_model', \
+             'vintage-model')",
+            [],
+        )
+        .unwrap();
+        conn.execute("DELETE FROM schema_version WHERE CAST(substr(id, 1, 3) AS INTEGER) > 38", [])
+            .unwrap();
+    }
+
+    fs::write(
+        root.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\n\n[target_bindings]\nrust = [\"src\"]\n",
+    )
+    .unwrap();
+    let out = run(&root, &data_dir, &model_cache, &["consolidate"]);
+    assert!(out.status.success(), "consolidate failed: {}", String::from_utf8_lossy(&out.stderr));
+
+    // The model identity crossed: the source's ladder run relocated it into repo_meta, and the
+    // import carried it into the global store under the repo's id.
+    let conn = rusqlite::Connection::open(&global).unwrap();
+    let carried: Option<String> = conn
+        .query_row(
+            "SELECT value FROM repo_meta WHERE key = 'active_embedding_model' AND repo_id != \
+             '__unassigned__'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        carried.as_deref(),
+        Some("vintage-model"),
+        "an old-vintage source's model meta must arrive with the import (ladder-relocated)",
+    );
+
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_dir_all(&data_dir);
+    let _ = fs::remove_dir_all(&model_cache);
+}
+
+/// Batch-7 finding 3: a config explicitly PINNED AT the global path can coexist with a lingering,
+/// never-imported legacy `.rag-rat/index.sqlite` (the pin was added by hand — no consolidate run
+/// ever renamed the old per-repo DB). `already_global` there would strand the legacy file's
+/// authored memories while claiming success, so the arm probes the default legacy path and
+/// IMPORTS it — the one pinned shape where proceeding is strictly correct, because the pin
+/// already names the target and the rename cannot strand the config. The marker then latches the
+/// re-run back to `already_global`.
+#[test]
+fn consolidate_imports_a_lingering_legacy_under_a_pin_at_global() {
+    let root = fixture_repo();
+    let data_dir = unique_dir("pinlegacydata");
+    let model_cache = unique_dir("pinlegacycache");
+    let legacy = root.join(".rag-rat/index.sqlite");
+    let imported = root.join(".rag-rat/index.sqlite.imported");
+    let global = data_dir.join("rag-rat.sqlite");
+
+    // Build the legacy per-repo index under the default pin, then hand-edit the pin to the
+    // GLOBAL path — the "I consolidated by editing the config" mistake.
+    let out = run(&root, &data_dir, &model_cache, &["index", "--full"]);
+    assert!(out.status.success(), "index --full failed: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(legacy.exists());
+    fs::write(
+        root.join("rag-rat.toml"),
+        format!(
+            "[index]\nroot = \".\"\ndatabase = \"{}\"\n\n[target_bindings]\nrust = [\"src\"]\n",
+            global.display()
+        ),
+    )
+    .unwrap();
+
+    let out = run(&root, &data_dir, &model_cache, &["consolidate"]);
+    assert!(
+        out.status.success(),
+        "pin-at-global with a lingering legacy imports: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("imported"), "the run reports an import, not already_global: {stdout}");
+    assert!(global.exists(), "the global store exists");
+    assert!(!legacy.exists(), "the lingering legacy file was renamed away");
+    assert!(imported.exists(), "the .imported marker is in place");
+
+    // With the marker present, the arm returns to `already_global` — idempotent.
+    let out = run(&root, &data_dir, &model_cache, &["consolidate"]);
+    assert!(out.status.success(), "re-run failed: {}", String::from_utf8_lossy(&out.stderr));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("already_global"), "the marker latches the re-run: {stdout}");
+
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_dir_all(&data_dir);
+    let _ = fs::remove_dir_all(&model_cache);
+}
+
+/// The worktree dimension of consolidate (batch-7 directive): run FROM a LINKED worktree whose
+/// checked-out `rag-rat.toml` still carries the old pinned key while MAIN's config went keyless.
+/// The governing seam resolves the WHOLE config from main — so consolidate finds MAIN's legacy
+/// file, imports it, and renames it beside MAIN's checkout; the divergent branch-local file is
+/// ignored with a warning naming it. No paths ever resolve against the linked checkout.
+#[test]
+fn consolidate_from_a_linked_worktree_uses_the_main_config_and_legacy() {
+    let root = fixture_repo(); // committed toml pins .rag-rat/index.sqlite
+    let data_dir = unique_dir("wtdata");
+    let model_cache = unique_dir("wtcache");
+    let legacy = root.join(".rag-rat/index.sqlite");
+    let imported = root.join(".rag-rat/index.sqlite.imported");
+    let global = data_dir.join("rag-rat.sqlite");
+
+    let out = run(&root, &data_dir, &model_cache, &["index", "--full"]);
+    assert!(out.status.success(), "index --full failed: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(legacy.exists());
+
+    // The linked worktree checks out the COMMITTED (pinned) config; main goes keyless.
+    let linked = unique_dir("wtlinked");
+    git(&root, &["worktree", "add", "--detach", "-q", linked.to_str().unwrap()]);
+    fs::write(
+        root.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\n\n[target_bindings]\nrust = [\"src\"]\n",
+    )
+    .unwrap();
+
+    let out = run(&linked, &data_dir, &model_cache, &["consolidate"]);
+    assert!(
+        out.status.success(),
+        "consolidate from the linked worktree completes via main's config: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stdout.contains("imported"), "main's legacy index was imported: {stdout}");
+    assert!(!legacy.exists(), "MAIN's legacy file was renamed away");
+    assert!(imported.exists(), "the marker lands beside MAIN's legacy path");
+    assert!(global.exists(), "the global store exists");
+    assert!(
+        !linked.join(".rag-rat").exists(),
+        "nothing resolved against the linked checkout's own .rag-rat"
+    );
+    assert!(
+        stderr.contains("ignoring") && stderr.contains("main worktree"),
+        "the divergent branch-local config is ignored LOUDLY: {stderr}"
+    );
+
+    // Idempotent from either checkout.
+    let out = run(&linked, &data_dir, &model_cache, &["consolidate"]);
+    assert!(out.status.success());
+    assert!(String::from_utf8_lossy(&out.stdout).contains("already_global"));
+    let out = run(&root, &data_dir, &model_cache, &["consolidate"]);
+    assert!(out.status.success());
+    assert!(String::from_utf8_lossy(&out.stdout).contains("already_global"));
+
+    let _ = fs::remove_dir_all(&root);
+    let _ = fs::remove_dir_all(&linked);
+    let _ = fs::remove_dir_all(&data_dir);
+    let _ = fs::remove_dir_all(&model_cache);
+}

--- a/crates/rag-rat-cli/tests/init_yes_writes_valid_config.rs
+++ b/crates/rag-rat-cli/tests/init_yes_writes_valid_config.rs
@@ -22,11 +22,17 @@ fn unique_temp_root() -> PathBuf {
     std::env::temp_dir().join(format!("rag-rat-init-yes-{}-{id}", std::process::id()))
 }
 
-/// Initialize a quiet git repo at `dir` (identity configured so any commit would succeed).
+/// Initialize a git repo at `dir` WITH a first commit: an identity-bearing root, so the keyless
+/// config init writes resolves to the (sandboxed) GLOBAL store — an unborn HEAD is identity-less
+/// and stays on the per-root legacy path (covered by the config-level tests).
 fn git_init(dir: &std::path::Path) {
-    for args in
-        [&["init", "-q"][..], &["config", "user.email", "t@e.com"], &["config", "user.name", "t"]]
-    {
+    for args in [
+        &["init", "-q"][..],
+        &["config", "user.email", "t@e.com"],
+        &["config", "user.name", "t"],
+        &["add", "-A"],
+        &["commit", "-qm", "seed"],
+    ] {
         let out = Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
         assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
     }
@@ -36,6 +42,9 @@ fn git_init(dir: &std::path::Path) {
 fn init_yes_writes_a_config_that_config_load_accepts() {
     let root = unique_temp_root();
     let cache = root.join("model-cache");
+    // The keyless config (A7) resolves the database through RAG_RAT_DATA_DIR — sandbox it to this
+    // test's temp dir so init's index build can never touch the developer's real global store.
+    let data_dir = root.join("data");
     std::fs::create_dir_all(root.join("src")).unwrap();
     std::fs::create_dir_all(&cache).unwrap();
     // A trivial Rust source tree so the scan binds `rust = ["src"]` (a non-empty plan; an empty
@@ -50,11 +59,13 @@ fn init_yes_writes_a_config_that_config_load_accepts() {
         .args(["init", "--yes"])
         .current_dir(&root)
         // Keep the run hermetic: no git hooks firing, no background watcher, and the model
-        // cache/HOME sandboxed to this test's temp dir so a model install can't touch the real
-        // cache (offline → hash fallback; online → downloads into `cache`).
+        // cache/HOME/data dir sandboxed to this test's temp dir so a model install or the index
+        // build can't touch the real cache or the real global database (offline → hash fallback;
+        // online → downloads into `cache`).
         .env("RAG_RAT_HOOK_DISABLE", "1")
         .env("RAG_RAT_NO_WATCH", "1")
         .env("RAG_RAT_MODEL_CACHE", &cache)
+        .env("RAG_RAT_DATA_DIR", &data_dir)
         .env("HOME", &root)
         .env("XDG_CACHE_HOME", &cache)
         .output()
@@ -70,6 +81,23 @@ fn init_yes_writes_a_config_that_config_load_accepts() {
     let config_path = root.join("rag-rat.toml");
     assert!(config_path.exists(), "init --yes must write rag-rat.toml");
 
+    // A7: the written config is KEYLESS — no active `database` key — and init's own index build
+    // (`setup_index` → migrate → discover) resolved through it to the sandboxed GLOBAL store, not
+    // to a per-repo `.rag-rat/index.sqlite`.
+    let written = std::fs::read_to_string(&config_path).unwrap();
+    assert!(
+        !written.lines().any(|line| line.trim_start().starts_with("database")),
+        "init must write a keyless config (global database by default):\n{written}"
+    );
+    assert!(
+        data_dir.join("rag-rat.sqlite").exists(),
+        "init's index build must land in the RAG_RAT_DATA_DIR global store"
+    );
+    assert!(
+        !root.join(".rag-rat/index.sqlite").exists(),
+        "no legacy per-repo index may be created by a fresh init"
+    );
+
     // The written config round-trips through the real loader, and reflects the `default_plan`
     // rendering the `--yes` path has always used (active `rust = ["src"]` binding + the documented
     // oracle/version surface).
@@ -81,4 +109,165 @@ fn init_yes_writes_a_config_that_config_load_accepts() {
     );
 
     std::fs::remove_dir_all(&root).ok();
+}
+
+/// `init` in a NEW repo must not heal/mutate an EXISTING repo's meta in the shared global DB
+/// (Codex batch 6 — the second unregistered-subject migrate caller, after consolidate):
+/// `setup_index` runs its migration config-less BEFORE the new repo is registered, so a healing
+/// migrate's witness would resolve the sole registered repo — the SIBLING — and a heal-owed pass
+/// would clear its model meta. `setup_index` is schema-only; the config-bearing index open right
+/// after registers the new repo and heals correctly scoped.
+#[test]
+fn init_in_a_new_repo_leaves_an_existing_repos_heal_owed_meta() {
+    let base = unique_temp_root();
+    let cache = base.join("model-cache");
+    let data_dir = base.join("data");
+    std::fs::create_dir_all(&cache).unwrap();
+    let global = data_dir.join("rag-rat.sqlite");
+
+    let make_repo = |name: &str, file: &str| {
+        let dir = base.join(name);
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+        std::fs::write(dir.join("src/lib.rs"), format!("pub fn {file}() {{}}\n")).unwrap();
+        git_init(&dir);
+        dir
+    };
+    let run = |dir: &std::path::Path, args: &[&str]| {
+        Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+            .args(args)
+            .current_dir(dir)
+            .env("RAG_RAT_HOOK_DISABLE", "1")
+            .env("RAG_RAT_NO_WATCH", "1")
+            .env("RAG_RAT_MODEL_CACHE", &cache)
+            .env("RAG_RAT_DATA_DIR", &data_dir)
+            .env("HOME", &base)
+            .env("XDG_CACHE_HOME", &cache)
+            .output()
+            .unwrap()
+    };
+
+    // Repo 1 populates the global DB (keyless config → global store).
+    let repo1 = make_repo("first", "first_anchor");
+    std::fs::write(
+        repo1.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n",
+    )
+    .unwrap();
+    let out = run(&repo1, &["index", "--full"]);
+    assert!(out.status.success(), "repo1 index: {}", String::from_utf8_lossy(&out.stderr));
+
+    // Repo 1 now OWES a heal: its active-model meta names a legacy id.
+    let repo1_id: String = {
+        let conn = rusqlite::Connection::open(&global).unwrap();
+        let id: String = conn
+            .query_row(
+                "SELECT repo_id FROM repos WHERE repo_id != '__unassigned__' LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO repo_meta(repo_id, key, value) VALUES (?1, \
+             'active_embedding_model', 'fastembed-all-minilm-l6-v2')",
+            [&id],
+        )
+        .unwrap();
+        id
+    };
+
+    // A brand-new repo runs `init -y` against the SAME global store.
+    let repo2 = make_repo("second", "second_anchor");
+    let out = run(&repo2, &["init", "--yes"]);
+    assert!(out.status.success(), "init -y: {}", String::from_utf8_lossy(&out.stderr));
+
+    // Repo 1's heal-owed meta is untouched — init's pre-registration migration never healed it.
+    let conn = rusqlite::Connection::open(&global).unwrap();
+    let survived: Option<String> = conn
+        .query_row(
+            "SELECT value FROM repo_meta WHERE repo_id = ?1 AND key = 'active_embedding_model'",
+            [&repo1_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        survived.as_deref(),
+        Some("fastembed-all-minilm-l6-v2"),
+        "init of a new repo healed (cleared) the existing repo's model meta",
+    );
+
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// Init from a SUBDIRECTORY of the normal MAIN worktree proceeds (Codex batch 8, finding 1): the
+/// linked-ness predicate is topology-derived (this checkout's workdir vs the designated main), so
+/// a main-worktree subdir is main — the old path-equality check falsely refused here. Uses
+/// `--dry-run` so nothing is written; the point is that the refusal does NOT fire.
+#[test]
+fn init_proceeds_from_a_subdirectory_of_the_main_worktree() {
+    let root = unique_temp_root();
+    std::fs::create_dir_all(root.join("tools/sub/src")).unwrap();
+    std::fs::write(root.join("tools/sub/src/lib.rs"), "pub fn alpha() {}\n").unwrap();
+    git_init(&root);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+        .args(["init", "--yes", "--dry-run"])
+        .current_dir(root.join("tools/sub"))
+        .env("RAG_RAT_HOOK_DISABLE", "1")
+        .env("RAG_RAT_NO_WATCH", "1")
+        .env("RAG_RAT_DATA_DIR", root.join("data"))
+        .env("HOME", &root)
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "init from a main-worktree SUBDIR is not a linked worktree — it must proceed: {stderr}"
+    );
+    assert!(
+        !stderr.contains("linked git worktree"),
+        "no linked-worktree refusal from a main subdir: {stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Init REFUSES to run in a LINKED git worktree (batch-7 worktree audit): the governing seam in
+/// `Config::load` resolves every worktree through the MAIN worktree's `rag-rat.toml`, so a config
+/// authored in a linked checkout would be ignored the moment main gains one. The refusal points
+/// at the main worktree instead of writing a file that doesn't do what it says.
+#[test]
+fn init_refuses_to_run_in_a_linked_worktree() {
+    let root = unique_temp_root();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(root.join("src/lib.rs"), "pub fn alpha() {}\n").unwrap();
+    git_init(&root);
+
+    let linked =
+        root.parent().unwrap().join(format!("{}-wt", root.file_name().unwrap().to_string_lossy()));
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&root)
+        .args(["worktree", "add", "--detach", "-q"])
+        .arg(&linked)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "worktree add: {}", String::from_utf8_lossy(&out.stderr));
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+        .args(["init", "-y"])
+        .current_dir(&linked)
+        .output()
+        .unwrap();
+    assert!(!output.status.success(), "init in a linked worktree is refused");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("main worktree"), "the refusal points at the main worktree: {stderr}");
+    let root_canonical = root.canonicalize().unwrap();
+    assert!(
+        stderr.contains(&root_canonical.display().to_string()),
+        "the refusal names the main worktree path: {stderr}"
+    );
+    assert!(!linked.join("rag-rat.toml").exists(), "no branch-local config was written");
+
+    let _ = std::fs::remove_dir_all(&linked);
+    let _ = std::fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-cli/tests/worktree_git_env.rs
+++ b/crates/rag-rat-cli/tests/worktree_git_env.rs
@@ -95,3 +95,78 @@ fn worktree_overlay_ignores_inherited_git_dir_env() {
 
     let _ = fs::remove_dir_all(&base);
 }
+
+/// The DISCOVERY side of the governing seam (Codex batch 9): a linked worktree with no
+/// branch-local `rag-rat.toml` — exactly the state `init`'s linked-worktree refusal leaves — must
+/// find the MAIN worktree's config through default discovery instead of dying at the existence
+/// check. And in a truly config-less repo, the missing-config hint names the path where the
+/// config BELONGS: main's `rag-rat.toml`, not the linked checkout's.
+#[test]
+fn default_config_discovery_reaches_the_main_worktree_from_a_linked_checkout() {
+    let base = std::env::temp_dir().join(format!(
+        "rag-rat-wtdisc-{}-{}",
+        std::process::id(),
+        TEMP.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = fs::remove_dir_all(&base);
+    let main = base.join("main");
+    fs::create_dir_all(main.join("src")).unwrap();
+    fs::write(main.join("src/lib.rs"), "pub fn discovery_anchor() {}\n").unwrap();
+    git(&main, &["init", "-q"]);
+    git(&main, &["config", "user.email", "t@e.com"]);
+    git(&main, &["config", "user.name", "t"]);
+    git(&main, &["add", "."]);
+    git(&main, &["commit", "-q", "-m", "seed"]);
+    let linked = base.join("wt");
+    git(&main, &["worktree", "add", "--detach", "-q", linked.to_str().unwrap()]);
+
+    // Truly config-less: the hint from the LINKED checkout names MAIN's path (where init runs).
+    let run = |dir: &Path, args: &[&str]| {
+        Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+            .current_dir(dir)
+            .args(args)
+            .env("RAG_RAT_HOOK_DISABLE", "1")
+            .env("RAG_RAT_NO_WATCH", "1")
+            .env("RAG_RAT_DATA_DIR", base.join("data"))
+            .env("RAG_RAT_MODEL_CACHE", base.join("cache"))
+            .output()
+            .unwrap()
+    };
+    let out = run(&linked, &["gc"]);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let main_toml = main.canonicalize().unwrap().join("rag-rat.toml");
+    assert!(
+        stderr.contains(&main_toml.display().to_string()),
+        "the config-less hint names MAIN's config path from a linked checkout: {stderr}"
+    );
+
+    // The config exists in MAIN only (uncommitted — the linked checkout has NO rag-rat.toml,
+    // the post-refusal state). Every default-config command from the linked checkout works.
+    fs::write(
+        main.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\ndatabase = \".rag-rat/index.sqlite\"\n\n[target_bindings]\nrust = \
+         [\"src\"]\n",
+    )
+    .unwrap();
+    assert!(!linked.join("rag-rat.toml").exists(), "the linked checkout has no branch config");
+    let out = run(&linked, &["index", "--full"]);
+    assert!(
+        out.status.success(),
+        "index from the linked checkout resolves main's config: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        main.join(".rag-rat/index.sqlite").exists(),
+        "the index landed at MAIN's configured database"
+    );
+    assert!(!linked.join(".rag-rat").exists(), "nothing resolved against the linked checkout");
+    let out = run(&linked, &["memory", "list"]);
+    assert!(
+        out.status.success(),
+        "a read command from the linked checkout works too: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let _ = fs::remove_dir_all(&base);
+}

--- a/crates/rag-rat-core/benches/shared/mod.rs
+++ b/crates/rag-rat-core/benches/shared/mod.rs
@@ -54,6 +54,7 @@ pub fn temp_db_path() -> PathBuf {
 pub fn bench_config(subdir: &str) -> Config {
     Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: corpus_dir(),
         database: temp_db_path(),
         targets: vec![ResolvedTarget {

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -25,8 +25,16 @@ pub struct Config {
     pub search: SearchConfig,
     /// Optional `[index] repo_id` override for the consolidated global store — pins the repo's
     /// identity instead of deriving it from the root-commit hash. `None` = derive. Consumed by
-    /// `crate::repo_identity::resolve_repo_identity`; it does NOT influence the database path.
+    /// `crate::repo_identity::resolve_repo_identity`. An EXPLICIT `database` path never depends on
+    /// it; a KEYLESS config's default does only through the identity-existence gate (a pin makes a
+    /// non-git root identity-bearing, so it resolves to the global store instead of per-root).
     pub repo_id_override: Option<String>,
+    /// Whether the GOVERNING config sets an explicit `[index] database` key. "Governing" is
+    /// main-worktree-anchored (see `main_database_key`): in a linked worktree the MAIN checkout's
+    /// config decides, exactly as it does for `repo_id` — a branch-local config can neither pin
+    /// nor un-pin the repo's database. `rag-rat consolidate` keys its pinned-config refusal off
+    /// this, so the refusal and `database` resolution can never disagree.
+    pub database_key_pinned: bool,
 }
 
 /// Search-ranking knobs (`[search]`). Default OFF so the shipped fuse is byte-identical to today;
@@ -666,68 +674,170 @@ impl Config {
         }
     }
 
+    /// Load a config, resolving WHICH `rag-rat.toml` GOVERNS at one seam: in a linked git
+    /// worktree, the MAIN worktree's config file is authoritative for the WHOLE config — identity,
+    /// database location, targets, models, everything. A branch-local `rag-rat.toml` (an older
+    /// branch, a divergent checkout) cannot fork any of it; when its content differs from main's
+    /// it is ignored with a one-line warning naming the ignored file. This subsumes the historical
+    /// per-key anchoring (root #218/#219, targets #219, `repo_id` #413, `database` A7) — the
+    /// question "which config governs this repo" is answered once, so new keys are main-anchored
+    /// by default and cannot re-open the split-brain class.
+    ///
+    /// DECLARED WORKTREE-LOCAL ALLOW-LIST (the only keys that legitimately vary per worktree):
+    ///  * `target_bindings` / `[[target]]` — FOR THE OVERLAY INDEX ONLY, read by
+    ///    [`Config::for_linked_worktree_overlay`] from the linked checkout's own file, because a
+    ///    branch may add/remove source dirs and its overlay must index its own file set (#219). The
+    ///    BASE config's targets remain main-anchored here.
+    ///
+    /// Everything else, present and future, resolves from the governing (main) config.
+    ///
+    /// EDGE POSTURES:
+    ///  * Main worktree resolvable but CONFIG-LESS → the local config governs, with a warning (the
+    ///    repo's config belongs in main; until it exists there, the branch copy is all we have —
+    ///    best-effort, mirroring the old per-key fallbacks).
+    ///  * Main config exists but FAILS to parse/read → the error PROPAGATES: loading from any
+    ///    worktree must behave like loading from main, errors included (silently falling back to
+    ///    the branch config would fork the repo exactly when main is briefly broken).
+    ///  * No resolvable main (bare-repo hubs, pruned main, custom GIT_DIR, non-git roots) →
+    ///    `main_worktree_root` is `None`, the local config governs unchanged — there is no
+    ///    designated main to defer to.
     pub fn load(path: impl AsRef<Path>) -> Result<Self, ConfigError> {
         let path = path.as_ref();
         let text = fs::read_to_string(path)?;
-        let raw: RawConfig = toml::from_str(&text)?;
-        // Reject the renamed `[local_ai]` table loudly (#317) — a silently-ignored old table would
-        // drop the user's embedding settings on upgrade. See `RawConfig::local_ai`.
-        if raw.local_ai.is_some() {
-            return Err(ConfigError::LocalAiTableRenamed);
-        }
-        let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
-        let root = config_dir.join(raw.index.root.unwrap_or_else(|| ".".to_string()));
-        // The root of the checkout the config was actually READ from (a linked worktree has its own
-        // checked-out `rag-rat.toml`). Targets are validated against THIS, not the anchored main
-        // root below: a linked branch can add a target dir that exists only in that branch, and the
-        // launch must not fail with `MissingDirectory` against the main checkout (#219 review).
-        let local_root = normalize_existing_dir(&root)?;
-        // Anchor `root` to the MAIN worktree root, so EVERY invocation resolves to the same root
-        // and thus the same base commit for the one shared index — whether launched from
-        // the main checkout, a linked worktree, or any cwd (`root="."` resolves against the
-        // launch dir, and a linked worktree has its OWN checked-out config). Per-worktree
-        // results come from the `worktree` QUERY scope, never a per-worktree config root:
-        // otherwise two processes rooted at different worktrees (different base commits)
-        // write CONFLICTING overlay rows to the shared DB — a file present on one branch
-        // races between readable and tombstone (#218/#219). The main worktree (and non-git
-        // dirs) resolve to themselves, so single-worktree users see no change.
-        let root = anchor_root_to_main_worktree(&local_root);
-        // One database per repo, shared across worktrees: a relative path resolves against the MAIN
-        // worktree TOP — NOT `root`, which may be a subdirectory — so every worktree of a repo AND
-        // any `root="<subdir>"` config land on the SAME index. An absolute path is honored as-is.
-        let database = match raw.index.database {
+        // Parse the LOCAL file but DO NOT fail yet: when a main config governs, the branch-local
+        // file's contents are irrelevant by design — a parse/validation failure there must fold
+        // into the divergence warning, never block every command from the linked checkout (Codex
+        // batch 8, finding 2). Wherever the local config GOVERNS, the error is fatal as always.
+        // The `[local_ai]` rejection (#317) is part of local validity — see `RawConfig::local_ai`.
+        let local_parse: Result<RawConfig, ConfigError> =
+            toml::from_str::<RawConfig>(&text).map_err(ConfigError::from).and_then(|raw| {
+                if raw.local_ai.is_some() { Err(ConfigError::LocalAiTableRenamed) } else { Ok(raw) }
+            });
+        let local_config_dir = path.parent().unwrap_or_else(|| Path::new("."));
+        // The topology subject must be a discoverable directory: a RELATIVE config path like
+        // `rag-rat.toml` has the EMPTY path as its parent (`Path::parent` yields `Some("")`, not
+        // `None`), which git discovery cannot open — it means the process cwd.
+        let local_checkout =
+            if local_config_dir.as_os_str().is_empty() { Path::new(".") } else { local_config_dir };
+
+        // THE GOVERNING SEAM (see the doc comment). Linked-ness comes from git TOPOLOGY — the
+        // checkout holding the config file vs the repo's designated main worktree
+        // ([`linked_worktree_main_root`]) — and governance is UNCONDITIONAL on that predicate.
+        // It must never hang off a root-anchoring proxy: a branch-only `[index] root` makes
+        // `anchor_root_to_main_worktree` return the local root unchanged, and an equality trigger
+        // would then let the branch config govern database/identity/models — the exact
+        // split-brain the seam exists to prevent (Codex batch 8, finding 3). Anchoring outcomes
+        // affect ROOT resolution only, never who governs.
+        let (mut raw, config_dir, root, target_validation_root) =
+            match linked_worktree_main_root(local_checkout) {
+                Some(main_top) => match governing_main_config(&main_top)? {
+                    Some((main_raw, main_config_dir)) => {
+                        let divergent = match &local_parse {
+                            Ok(local_raw) => *local_raw != main_raw,
+                            Err(_) => true,
+                        };
+                        if divergent {
+                            let ignored =
+                                path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+                            let invalid_note =
+                                if local_parse.is_err() { " (also invalid)" } else { "" };
+                            eprintln!(
+                                "rag-rat: ignoring branch config{invalid_note} {} — in a linked \
+                                 worktree the main worktree's config governs ({}); edit that file \
+                                 instead",
+                                ignored.display(),
+                                main_config_dir.join("rag-rat.toml").display(),
+                            );
+                        }
+                        // Re-derive root from MAIN's own config, exactly as loading it directly
+                        // would (its root is already the main worktree — anchoring is identity).
+                        let main_root =
+                            normalize_existing_dir(&main_config_dir.join(
+                                main_raw.index.root.clone().unwrap_or_else(|| ".".to_string()),
+                            ))?;
+                        (main_raw, main_config_dir, main_root.clone(), main_root)
+                    },
+                    None => {
+                        // Config-less main: the LOCAL config governs (best-effort, loudly), so
+                        // its validity is fatal exactly as in a non-linked checkout.
+                        let local_raw = local_parse?;
+                        eprintln!(
+                            "rag-rat: the main worktree has no rag-rat.toml; using {} until one \
+                             exists there (the repo's config belongs in the main worktree)",
+                            path.display(),
+                        );
+                        // Root stays anchored so the shared index still keys off the main
+                        // checkout; targets validate against the local checkout where they
+                        // exist (#219).
+                        let local_root = normalize_existing_dir(&local_config_dir.join(
+                            local_raw.index.root.clone().unwrap_or_else(|| ".".to_string()),
+                        ))?;
+                        let anchored_root = anchor_root_to_main_worktree(&local_root);
+                        (local_raw, local_config_dir.to_path_buf(), anchored_root, local_root)
+                    },
+                },
+                None => {
+                    // The config's own checkout is the main worktree (or there is no designated
+                    // main): the local config governs and its validity is fatal. Root anchoring
+                    // still applies for the exotic `[index] root` pointing into a linked
+                    // checkout (#218/#219) — an anchoring concern, not a governance one.
+                    let local_raw = local_parse?;
+                    let local_root = normalize_existing_dir(
+                        &local_config_dir
+                            .join(local_raw.index.root.clone().unwrap_or_else(|| ".".to_string())),
+                    )?;
+                    let anchored_root = anchor_root_to_main_worktree(&local_root);
+                    (local_raw, local_config_dir.to_path_buf(), anchored_root, local_root)
+                },
+            };
+
+        // The database path (A7 default flip): an explicit `database` key is honored as-is — the
+        // deprecated per-repo deployment, that repo stays un-consolidated and never syncs. ABSENT,
+        // the default is the CONSOLIDATED GLOBAL store, EXCEPT a pre-existing legacy
+        // `.rag-rat/index.sqlite` is kept (with a deprecation nudge toward `rag-rat consolidate`).
+        // Relative explicit paths (and the legacy path) resolve against the MAIN worktree TOP —
+        // NOT `root`, which may be a subdirectory — so every worktree of a repo AND any
+        // `root="<subdir>"` config land on the SAME index.
+        let db_base = main_worktree_root(&root).unwrap_or_else(|| root.clone());
+        let repo_id_override =
+            raw.index.repo_id.take().map(|id| id.trim().to_string()).filter(|id| !id.is_empty());
+        let governing_database_key = raw.index.database.take();
+        let database_key_pinned = governing_database_key.is_some();
+        let database = match governing_database_key {
             Some(db) if Path::new(&db).is_absolute() => PathBuf::from(db),
-            other => {
-                let relative = other.unwrap_or_else(|| ".rag-rat/index.sqlite".to_string());
-                main_worktree_root(&root).unwrap_or_else(|| root.clone()).join(relative)
-            },
+            Some(db) => db_base.join(db),
+            // The keyless default probes the repo IDENTITY (root + the governing `[index]
+            // repo_id` pin): only an identity-BEARING root may land in the shared global store —
+            // see `default_database_with_disposition`.
+            None => resolve_default_database(&db_base, &root, repo_id_override.as_deref()),
         };
-        // Validate directories against the local checkout (`local_root`), where the config — and
-        // any branch-only target dir — actually lives; the stored `Config.root` stays
-        // anchored to main so every worktree shares one base index.
-        // `ResolvedTarget.directories` are root-relative, so the stored targets are
-        // identical either way (#219 review).
-        let local_targets = resolve_targets(&local_root, raw.target_bindings, raw.target)?;
-        // The stored `Config.targets` are the BASE targets — they drive discovery over the anchored
-        // `root` (= main). When this config was read from a LINKED worktree, its branch
-        // `rag-rat.toml` may NARROW or DROP a target that still exists on main; using the
-        // branch targets for base discovery would classify the now-undiscovered main files
-        // as deleted and tombstone them in the BASE scope, hiding committed files from main
-        // queries. So when anchoring to a different (main) root, re-resolve the base
-        // targets from MAIN's own `rag-rat.toml`. The branch's targets are NOT lost: the
-        // overlay refresh reloads each linked worktree's own config
-        // (`refresh_worktree_overlays`) and indexes the branch with its own target set (#219
-        // review).
-        let targets = main_base_targets(&root, &local_root).unwrap_or(local_targets);
+        // The identity gate's SECOND entrance (Codex batch 8, finding 5): an explicit pin AT the
+        // consolidated global store bypasses the keyless identity gate above, and an
+        // identity-less root (non-git, unborn HEAD) opening the shared store would fall through
+        // to adoption's sole-repo fallback — scoping this project onto whichever SIBLING repo
+        // sorts first. Refuse at resolution with the remedy. (The structural backstop for every
+        // other shared-path pin shape lives in `adopt_repo_from_config`: an identity-less open
+        // never sole-picks on a multi-repo database.)
+        if database_key_pinned
+            && Some(database.as_path()) == crate::data_dir::global_database_path().as_deref()
+            && !crate::repo_identity::identity_is_resolvable(&root, repo_id_override.as_deref())
+        {
+            return Err(ConfigError::GlobalPinWithoutIdentity);
+        }
+        // Targets resolve from the GOVERNING config; validation runs against the checkout that
+        // config describes (main when main governs; the local checkout on the config-less-main
+        // fallback, tolerating branch-only dirs — #219). `ResolvedTarget.directories` are
+        // root-relative, so the stored targets are checkout-independent either way. A linked
+        // branch's own target set is NOT lost: the overlay refresh reads the branch config via
+        // `for_linked_worktree_overlay` and indexes the branch with it (#219).
+        let targets = resolve_targets(&target_validation_root, raw.target_bindings, raw.target)?;
         let mut llm = LlmConfig::try_from(raw.llm)?;
-        // Resolve a RELATIVE cookbook recipe PATH against the config dir, not the process CWD (R6):
-        // the recipe is handed to `node`/`npx`, which resolve it against wherever reconcile/the
-        // watcher runs — ENOENT from a subdir or a daemon. npm-package specs (`@scope/pkg`) are
-        // left untouched. Done here (not in the config TryFrom) because only `load` knows
-        // the config dir.
+        // Resolve a RELATIVE cookbook recipe PATH against the GOVERNING config dir, not the
+        // process CWD (R6): the recipe is handed to `node`/`npx`, which resolve it against
+        // wherever reconcile/the watcher runs — ENOENT from a subdir or a daemon.
         if let Some(remote) = llm.embedding.remote.as_mut()
             && let Some(cookbook) = remote.cookbook.as_ref()
-            && let Some(resolved) = resolve_relative_cookbook_path(cookbook, config_dir)
+            && let Some(resolved) = resolve_relative_cookbook_path(cookbook, &config_dir)
         {
             remote.cookbook = Some(resolved);
         }
@@ -737,7 +847,7 @@ impl Config {
         let search = raw.search.into();
         let mut log = LogConfig::try_from(raw.log)?;
         // Finalize `dir`: empty (unset) → sibling of the db (`<db_parent>/logs`); a set value is
-        // resolved relative to the config dir (absolute honored). Mirrors the cookbook-path rule.
+        // resolved relative to the GOVERNING config dir (absolute honored).
         log.dir = if log.dir.as_os_str().is_empty() {
             database.parent().map(|p| p.join("logs")).unwrap_or_else(|| PathBuf::from("logs"))
         } else if log.dir.is_absolute() {
@@ -746,15 +856,6 @@ impl Config {
             config_dir.join(&log.dir)
         };
 
-        // The branch-local override (trim + drop empty), then ANCHORED to the MAIN worktree's
-        // config. Repo IDENTITY is per-repo, not per-branch: every worktree of a repo must resolve
-        // the SAME override regardless of which checkout launched — consistent with the
-        // root/database/targets anchoring above. A linked branch whose `rag-rat.toml` omits or pins
-        // a DIFFERENT `[index] repo_id` would otherwise split identity by launch point. Parse-only:
-        // the override never affects the database path resolved above.
-        let local_repo_id_override =
-            raw.index.repo_id.map(|id| id.trim().to_string()).filter(|id| !id.is_empty());
-        let repo_id_override = main_repo_id_override(&root, &local_root, local_repo_id_override);
         Ok(Self {
             root,
             database,
@@ -766,8 +867,30 @@ impl Config {
             search,
             log,
             repo_id_override,
+            database_key_pinned,
         })
     }
+}
+
+/// The MAIN worktree's parsed config, when one exists — the governing side of `Config::load`'s
+/// seam. `main_top` is the already-derived main worktree top ([`linked_worktree_main_root`]).
+/// `Ok(None)` = main has NO `rag-rat.toml` (the local-governs fallback); a main config that
+/// exists but cannot be read or parsed PROPAGATES its error (loading from a linked worktree must
+/// behave like loading from main, errors included). Returns the main worktree TOP as the
+/// governing config dir.
+fn governing_main_config(main_top: &Path) -> Result<Option<(RawConfig, PathBuf)>, ConfigError> {
+    let main_top = main_top.to_path_buf();
+    let main_config_path = main_top.join("rag-rat.toml");
+    let text = match fs::read_to_string(&main_config_path) {
+        Ok(text) => text,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err.into()),
+    };
+    let raw: RawConfig = toml::from_str(&text)?;
+    if raw.local_ai.is_some() {
+        return Err(ConfigError::LocalAiTableRenamed);
+    }
+    Ok(Some((raw, main_top)))
 }
 
 fn resolve_targets(
@@ -866,83 +989,50 @@ fn anchor_root_to_main_worktree(root: &Path) -> PathBuf {
     if anchored.is_dir() { anchored } else { root.to_path_buf() }
 }
 
-/// The BASE targets for a config that was read from a LINKED worktree: the MAIN checkout's
-/// `rag-rat.toml` targets, resolved against the anchored (main) `root`. `None` — so the caller
-/// keeps the local (branch) targets — when this config is NOT anchored away from its own checkout
-/// (`root == local_root`: the main checkout or a non-git dir), when main has no readable
-/// `rag-rat.toml`, or when main's targets don't validate against `root` (e.g. a main target dir
-/// that only the subdir layout reaches). Reading main's config keeps base DISCOVERY faithful to
-/// main, so a branch that narrows/drops a target can't tombstone main's committed files in the base
-/// scope (#219 review). The branch's own targets still drive its overlay via
-/// `refresh_worktree_overlays`.
-fn main_base_targets(root: &Path, local_root: &Path) -> Option<Vec<ResolvedTarget>> {
-    if root == local_root {
-        return None; // not anchored away — the local config IS the base config
-    }
-    let main_config_path = main_worktree_root(root)?.join("rag-rat.toml");
-    let text = fs::read_to_string(&main_config_path).ok()?;
-    let raw: RawConfig = toml::from_str(&text).ok()?;
-    // Main's targets are root-relative; validate (and store) them against the anchored `root`,
-    // which is the equivalent path under the main worktree the base index is discovered from.
-    resolve_targets(root, raw.target_bindings, raw.target).ok()
-}
-
-/// The `[index] repo_id` override anchored to the MAIN worktree's `rag-rat.toml`, mirroring
-/// [`main_base_targets`]: repo identity is per-repo, so every worktree must resolve the same override
-/// no matter which checkout launched. `local_override` (already trimmed + non-empty-or-`None`) is
-/// returned unchanged when this config is NOT anchored away from its own checkout (`root ==
-/// local_root`: the main checkout or a non-git dir), or when main's `rag-rat.toml` is unreadable /
-/// unparsable (best-effort fallback, exactly as `main_base_targets` does for targets).
-///
-/// When anchored to main, MAIN's value is authoritative — INCLUDING when main OMITS the override
-/// (→ `None`, derive from the root commit): honoring the branch's pin there would make identity
-/// launch-point-dependent, the exact split this guards. A branch that pins a DIFFERENT non-empty id
-/// than main is warned (identity is per-repo; main wins), matching how the base-target anchoring
-/// silently prefers main. This re-reads main's config rather than sharing `main_base_targets`'
-/// read, because the two have different fallback semantics (targets fall back on VALIDATION
-/// failure; the override has nothing to validate) — a second read of one small TOML at load time.
-fn main_repo_id_override(
-    root: &Path,
-    local_root: &Path,
-    local_override: Option<String>,
-) -> Option<String> {
-    if root == local_root {
-        return local_override; // not anchored away — the local config IS the base config
-    }
-    // Anchored to a different (main) root. Read MAIN's config; its `[index] repo_id` is the
-    // per-repo identity. If main's config can't be located/read/parsed, fall back to the local
-    // override (best effort, as `main_base_targets` does).
-    let Some(main_config_path) = main_worktree_root(root).map(|main| main.join("rag-rat.toml"))
-    else {
-        return local_override;
-    };
-    let Ok(text) = fs::read_to_string(&main_config_path) else {
-        return local_override;
-    };
-    let Ok(raw) = toml::from_str::<RawConfig>(&text) else {
-        return local_override;
-    };
-    let main_override =
-        raw.index.repo_id.map(|id| id.trim().to_string()).filter(|id| !id.is_empty());
-    // A linked branch pinning a different non-empty id than main is a divergence: identity is
-    // per-repo, so main's value wins. Warn (eprintln, this file's only user-facing channel) so the
-    // mismatch is visible rather than silently dropped.
-    if let Some(local) = local_override.as_deref()
-        && local != main_override.as_deref().unwrap_or_default()
-    {
-        eprintln!(
-            "rag-rat: [index] repo_id in the linked worktree config ({local}) differs from the \
-             main worktree config ({}); using the main worktree's value so every worktree of this \
-             repo shares one identity",
-            main_override.as_deref().unwrap_or("<derived from root commit>")
-        );
-    }
-    main_override
-}
-
 /// The main worktree root, derived from the git common dir (`<main>/.git`). Returns `None` outside
 /// a standard git repo (bare repo, custom `GIT_DIR`, git unavailable) so resolution falls back to
 /// `root` — never guess.
+/// The DEFAULT config path for the checkout containing `dir` — the DISCOVERY side of the
+/// governing seam. [`Config::load`]'s seam decides which config WINS once a file is loaded; this
+/// decides where the CLI LOOKS when no explicit `--config` was given. Without it, a linked
+/// worktree with no branch-local `rag-rat.toml` (the state `init`'s refusal deliberately leaves)
+/// dies at the existence check before the seam ever runs (Codex batch 9). Resolution:
+///  * a local `rag-rat.toml` exists → use it. In a linked worktree the seam then governs from main
+///    AND emits the divergence warning — routing discovery straight to main when a branch file
+///    exists would silently skip that warning, so the file's presence keeps the load going through
+///    the seam (governance is identical either way).
+///  * no local file, linked worktree → the MAIN worktree's `rag-rat.toml` (whether or not it exists
+///    yet — a missing-config hint should name the path where the config BELONGS).
+///  * no local file, main/non-git → the local path (the hint names it).
+///
+/// An EXPLICIT `--config` path never routes through this — a user override is taken literally.
+pub fn discover_config_path(dir: &Path) -> PathBuf {
+    let local = dir.join("rag-rat.toml");
+    if local.exists() {
+        return local;
+    }
+    match linked_worktree_main_root(dir) {
+        Some(main_top) => main_top.join("rag-rat.toml"),
+        None => local,
+    }
+}
+
+/// The MAIN worktree top for `root` when `root` sits in a LINKED git worktree — `None` when the
+/// checkout containing `root` IS the main worktree (or the layout has no designated main:
+/// bare-repo hubs, custom `GIT_DIR`, non-git dirs). This is THE linked-ness predicate — derived
+/// from git topology (the discovered checkout's WORKDIR vs the common dir's main), never from a
+/// path-equality proxy: comparing `root` itself to main falsely classifies a SUBDIRECTORY of the
+/// main worktree as linked, and root-anchoring success is defeated by a branch-only `[index]
+/// root` (Codex batch 8, findings 1+3). Both `Config::load`'s governing seam and the CLI's
+/// `init` refusal resolve linked-ness through this one helper.
+pub fn linked_worktree_main_root(root: &Path) -> Option<PathBuf> {
+    let repo = crate::index::discover_repo(root).ok()?;
+    let main = main_worktree_root(root)?;
+    let workdir = repo.workdir()?;
+    let workdir = workdir.canonicalize().unwrap_or_else(|_| workdir.to_path_buf());
+    (main != workdir).then_some(main)
+}
+
 fn main_worktree_root(root: &Path) -> Option<PathBuf> {
     let repo = crate::index::discover_repo(root).ok()?;
     let common_dir = repo.common_dir().canonicalize().ok()?;
@@ -952,6 +1042,122 @@ fn main_worktree_root(root: &Path) -> Option<PathBuf> {
     }
     let main_root = common_dir.parent()?.to_path_buf();
     main_root.is_dir().then_some(main_root)
+}
+
+/// The database path a `rag-rat.toml` WITHOUT a `database` key resolves to (A7), pure — no logging,
+/// no filesystem writes. The default is the CONSOLIDATED GLOBAL store (`data_dir()/rag-rat.sqlite`)
+/// — one database per machine — with two exceptions that keep an upgrade safe:
+///  1. A pre-existing legacy `<main_worktree>/.rag-rat/index.sqlite` is honored, so a repo indexed
+///     before the flip never silently abandons its authored memories; once `rag-rat consolidate`
+///     imports and renames the file away, resolution falls through to the global path.
+///  2. When no data dir resolves at all (no `HOME`/XDG on this platform), fall back to the legacy
+///     per-repo path rather than failing — the pre-A7 behavior.
+///
+/// `db_base` is the directory a relative/legacy path anchors to (the main worktree top — see
+/// `Config::load`). Public so the init wizard can display where a keyless config will land without
+/// loading one.
+pub fn default_database_path(
+    db_base: &Path,
+    identity_root: &Path,
+    repo_id_override: Option<&str>,
+) -> PathBuf {
+    let (path, _) = default_database_with_disposition(db_base, identity_root, repo_id_override);
+    path
+}
+
+/// How a keyless config's default database resolved — the load path warns per variant.
+enum DefaultDatabaseDisposition {
+    /// The root has NO derivable repo identity (non-git dir, unborn `git init`, no pin): the
+    /// per-root legacy path, exactly the pre-flip posture.
+    IdentityLess,
+    /// The legacy per-repo file is in use (awaiting `rag-rat consolidate`).
+    Legacy,
+    /// The global store (or the no-data-dir legacy fallback path, which does not exist on disk).
+    Global,
+    /// The global store, with a STRAY legacy file present DESPITE the `.imported` marker — an old
+    /// binary, a backup restore, or a stray process re-created it after consolidation.
+    GlobalWithStrayLegacy,
+}
+
+/// [`default_database_path`] plus the [`DefaultDatabaseDisposition`] the resolution took.
+///
+/// IDENTITY GATE (first, before everything): the global default REQUIRES a resolvable repo
+/// identity (`repo_identity::identity_is_resolvable` — a pin, or a git repo with a born HEAD).
+/// An identity-less root stays on its per-root `.rag-rat/index.sqlite` exactly as pre-flip:
+/// in the shared global store every such root would pool under the ONE `__unassigned__`
+/// placeholder scope — two fresh non-git projects would see and overwrite each other — and an
+/// unborn repo would strand its placeholder rows the moment its first commit mints a real id.
+/// Per-root, the placeholder stays a single-repo-DB concept with its existing adoption flow
+/// (first commit → the placeholder adopts in the per-root DB → consolidate when ready).
+///
+/// The `.imported` marker is a STAY-GLOBAL LATCH: once `rag-rat consolidate` has renamed the legacy
+/// file away, a keyless repo resolves to the global store even if a legacy `index.sqlite`
+/// REAPPEARS beside the marker (an old binary, a restored backup, a stray process) — otherwise the
+/// stray would silently divert the repo off the store its memories were imported into.
+fn default_database_with_disposition(
+    db_base: &Path,
+    identity_root: &Path,
+    repo_id_override: Option<&str>,
+) -> (PathBuf, DefaultDatabaseDisposition) {
+    let legacy = db_base.join(".rag-rat/index.sqlite");
+    if !crate::repo_identity::identity_is_resolvable(identity_root, repo_id_override) {
+        return (legacy, DefaultDatabaseDisposition::IdentityLess);
+    }
+    let marker = db_base.join(".rag-rat/index.sqlite.imported");
+    let global = crate::data_dir::global_database_path();
+    if marker.exists()
+        && let Some(global) = global
+    {
+        let disposition = if legacy.exists() {
+            DefaultDatabaseDisposition::GlobalWithStrayLegacy
+        } else {
+            DefaultDatabaseDisposition::Global
+        };
+        return (global, disposition);
+    }
+    if legacy.exists() {
+        return (legacy, DefaultDatabaseDisposition::Legacy);
+    }
+    (global.unwrap_or(legacy), DefaultDatabaseDisposition::Global)
+}
+
+/// The load-time wrapper around [`default_database_path`]: same resolution, plus a one-line notice
+/// per disposition — the deprecation nudge toward `rag-rat consolidate` while the legacy file is
+/// what keeps the repo off the global store, and a stray-file warning when a legacy file reappears
+/// after consolidation (it is ignored, never silently adopted). An identity-less root is SILENT:
+/// it is the pre-flip posture, and `rag-rat consolidate` refuses identity-less repos, so a nudge
+/// would dead-end.
+fn resolve_default_database(
+    db_base: &Path,
+    identity_root: &Path,
+    repo_id_override: Option<&str>,
+) -> PathBuf {
+    let (path, disposition) =
+        default_database_with_disposition(db_base, identity_root, repo_id_override);
+    match disposition {
+        DefaultDatabaseDisposition::Legacy => tracing::warn!(
+            path = %path.display(),
+            "using the legacy per-repo index at `.rag-rat/index.sqlite`; the default database is now \
+             the consolidated global store. Run `rag-rat consolidate` to import this repo's memories \
+             and switch to it."
+        ),
+        DefaultDatabaseDisposition::GlobalWithStrayLegacy => tracing::warn!(
+            "a stray `.rag-rat/index.sqlite` exists beside the `.imported` consolidation marker; \
+             ignoring it and staying on the consolidated global store. Delete the stray file (its \
+             contents were NOT imported)."
+        ),
+        DefaultDatabaseDisposition::Global | DefaultDatabaseDisposition::IdentityLess => {},
+    }
+    path
+}
+
+/// The DEFAULT legacy per-repo path a KEYLESS config at `root` would consult
+/// (`<main_worktree_top>/.rag-rat/index.sqlite`) — what `rag-rat consolidate` compares a pinned
+/// `database` path against to pick the right remedy: a pin AT this path just needs the key
+/// removed, while a CUSTOM pin must also move its file here first (keyless resolution never looks
+/// anywhere else, so removing the key alone would strand the custom file unimported).
+pub fn default_legacy_database_path(root: &Path) -> PathBuf {
+    main_worktree_root(root).unwrap_or_else(|| root.to_path_buf()).join(".rag-rat/index.sqlite")
 }
 
 fn normalize_existing_dir(path: &Path) -> Result<PathBuf, ConfigError> {
@@ -964,7 +1170,7 @@ fn normalize_existing_dir(path: &Path) -> Result<PathBuf, ConfigError> {
     Ok(canonical)
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq)]
 struct RawConfig {
     #[serde(default)]
     index: RawIndex,
@@ -993,7 +1199,7 @@ struct RawConfig {
     target: Vec<RawTarget>,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, PartialEq)]
 struct RawWatch {
     enabled: Option<bool>,
     debounce_ms: Option<u64>,
@@ -1013,7 +1219,7 @@ impl From<RawWatch> for WatchConfig {
     }
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, PartialEq)]
 struct RawLog {
     enabled: Option<bool>,
     level: Option<String>,
@@ -1052,7 +1258,7 @@ impl TryFrom<RawLog> for LogConfig {
     }
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, PartialEq)]
 struct RawVersionCheck {
     enabled: Option<bool>,
 }
@@ -1063,7 +1269,7 @@ impl From<RawVersionCheck> for VersionCheckConfig {
     }
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, PartialEq)]
 struct RawOracle {
     auto_run: Option<bool>,
     auto_run_quiet_period_secs: Option<u64>,
@@ -1085,7 +1291,7 @@ impl From<RawOracle> for OracleConfig {
     }
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, PartialEq)]
 struct RawSearch {
     graded_git_rerank: Option<bool>,
 }
@@ -1100,7 +1306,7 @@ impl From<RawSearch> for SearchConfig {
     }
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, PartialEq)]
 struct RawIndex {
     root: Option<String>,
     database: Option<String>,
@@ -1111,7 +1317,7 @@ struct RawIndex {
     repo_id: Option<String>,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, PartialEq)]
 struct RawLlm {
     #[serde(default)]
     embedding: RawEmbedding,
@@ -1125,7 +1331,7 @@ impl TryFrom<RawLlm> for LlmConfig {
     }
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, PartialEq)]
 struct RawEmbedding {
     /// `model = "<model_id>" | "none"` — the embedding model selector, the registry model_id (the
     /// HF path, e.g. `sentence-transformers/all-MiniLM-L6-v2`; no aliases, #317).
@@ -1166,7 +1372,7 @@ impl TryFrom<RawEmbedding> for EmbeddingConfig {
     }
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, PartialEq)]
 struct RawRemoteEmbedding {
     model: Option<String>,
     backend: Option<String>,
@@ -1336,7 +1542,7 @@ impl TryFrom<RawRemoteEmbedding> for RemoteEmbeddingConfig {
     }
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, PartialEq)]
 struct RawEmbeddingRuntime {
     batch_size: Option<u32>,
     ort_threads: Option<u32>,
@@ -1356,7 +1562,7 @@ impl From<RawEmbeddingRuntime> for EmbeddingRuntimeConfig {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq)]
 struct RawTarget {
     name: String,
     language: String,
@@ -1376,6 +1582,12 @@ pub enum ConfigError {
     Language(#[from] LanguageError),
     #[error("unknown target kind `{0}`")]
     UnknownTargetKind(String),
+    #[error(
+        "`database` points at the consolidated global store, but this root has no resolvable repo \
+         identity (not a committed git repo). Add `[index] repo_id = \"...\"` to pin an identity, \
+         or point `database` at a per-repo file (e.g. `.rag-rat/index.sqlite`)"
+    )]
+    GlobalPinWithoutIdentity,
     #[error(
         "unknown embedding model `{0}` (expected a registered model id — the HF path, e.g. \
          `sentence-transformers/all-MiniLM-L6-v2`, `BAAI/bge-small-en-v1.5`, \
@@ -1476,7 +1688,8 @@ mod tests {
         std::fs::write(main.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
         std::fs::write(
             main.join("rag-rat.toml"),
-            "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n",
+            "[index]\nroot = \".\"\ndatabase = \".rag-rat/index.sqlite\"\n[target_bindings]\nrust \
+             = [\"src\"]\n",
         )
         .unwrap();
         git(&main, &["init", "-q"]);
@@ -1516,8 +1729,8 @@ mod tests {
         std::fs::write(tmp.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
         std::fs::write(
             tmp.join("rag-rat.toml"),
-            "[index]\nroot = \".\"\nrepo_id = \"  pinned-id  \"\n[target_bindings]\nrust = \
-             [\"src\"]\n",
+            "[index]\nroot = \".\"\ndatabase = \".rag-rat/index.sqlite\"\nrepo_id = \"  pinned-id  \
+             \"\n[target_bindings]\nrust = [\"src\"]\n",
         )
         .unwrap();
 
@@ -1527,11 +1740,601 @@ mod tests {
             Some("pinned-id"),
             "the [index] repo_id override is parsed and trimmed",
         );
-        // Parse-only: the override must NOT influence path resolution — the database stays at the
-        // per-repo default beside `root`.
+        // Parse-only: the override must NOT influence path resolution — the explicit database stays
+        // at the per-repo path beside `root`.
         assert_eq!(config.database, config.root.join(".rag-rat/index.sqlite"));
 
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Seed a minimal COMMITTED git repo at `dir` — the identity-bearing fixture the global
+    /// default requires (a keyless config resolves globally only for a root with a derivable repo
+    /// identity).
+    fn git_commit_all(dir: &Path) {
+        let git = |args: &[&str]| {
+            let out =
+                std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
+            assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.email", "t@e"]);
+        git(&["config", "user.name", "t"]);
+        git(&["add", "-A"]);
+        git(&["commit", "-qm", "seed"]);
+    }
+
+    /// A7 default flip: a keyless config in an IDENTITY-BEARING repo (a committed git root) with
+    /// no legacy `.rag-rat/index.sqlite` resolves to the consolidated GLOBAL store. Compared
+    /// against `global_database_path()` in the CURRENT environment (no env mutation ⇒ no
+    /// cross-test race); `Config::load` only RESOLVES the path, it never opens or creates the DB,
+    /// so this never touches a developer's real global store.
+    #[test]
+    fn config_load_without_a_database_key_resolves_to_the_global_database() {
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let tmp = std::env::temp_dir().join(format!("ragrat-globaldb-{}-{id}", std::process::id()));
+        std::fs::create_dir_all(tmp.join("src")).unwrap();
+        std::fs::write(tmp.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        std::fs::write(
+            tmp.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n",
+        )
+        .unwrap();
+        git_commit_all(&tmp);
+
+        let config = Config::load(tmp.join("rag-rat.toml")).unwrap();
+        let expected = crate::data_dir::global_database_path()
+            .expect("a data dir resolves in the test environment (HOME is set)");
+        assert_eq!(
+            config.database, expected,
+            "a keyless config defaults to the consolidated global database",
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// The GOVERNING SEAM: in a linked worktree the MAIN config governs the WHOLE config, not a
+    /// per-key subset — a divergent branch-local file cannot fork the embedding model (or any
+    /// other key) even though no per-key anchoring was ever written for `[llm]`. The two loads
+    /// must produce the SAME resolved `Config`.
+    #[test]
+    fn config_load_in_a_linked_worktree_is_governed_wholesale_by_the_main_config() {
+        let git = |dir: &Path, args: &[&str]| {
+            let out =
+                std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
+            assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        };
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let tmp = std::env::temp_dir().join(format!("ragrat-wholecfg-{}-{id}", std::process::id()));
+        let main = tmp.join("main");
+        std::fs::create_dir_all(main.join("src")).unwrap();
+        std::fs::write(main.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        std::fs::write(
+            main.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\ndatabase = \"main.sqlite\"\n[watch]\ndebounce_ms = \
+             1111\n[target_bindings]\nrust = [\"src\"]\n",
+        )
+        .unwrap();
+        git(&main, &["init", "-q"]);
+        git(&main, &["config", "user.email", "t@e"]);
+        git(&main, &["config", "user.name", "t"]);
+        git(&main, &["add", "-A"]);
+        git(&main, &["commit", "-qm", "seed"]);
+        let linked = tmp.join("wt");
+        git(&main, &["worktree", "add", "--detach", "-q", linked.to_str().unwrap()]);
+
+        // The branch config diverges on a key with NO historical per-key anchoring: `[watch]`.
+        std::fs::write(
+            linked.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\ndatabase = \"branch.sqlite\"\n[watch]\ndebounce_ms = \
+             9999\n[target_bindings]\nrust = [\"src\"]\n",
+        )
+        .unwrap();
+        let from_main = Config::load(main.join("rag-rat.toml")).unwrap();
+        let from_linked = Config::load(linked.join("rag-rat.toml")).unwrap();
+        assert_eq!(
+            from_linked.watch.debounce_ms, from_main.watch.debounce_ms,
+            "the divergent branch config is IGNORED wholesale — keys with no per-key anchoring \
+             history included",
+        );
+        assert_eq!(from_linked.watch.debounce_ms, 1111, "main's value, not the branch's 9999");
+        assert_eq!(from_linked.database, from_main.database);
+        assert_eq!(from_linked.root, from_main.root);
+        assert_eq!(from_linked.targets, from_main.targets);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Config-less-main fallback posture: main is resolvable but has NO `rag-rat.toml`, so the
+    /// linked worktree's local config governs best-effort (with a warning) — root still anchors
+    /// to main so the shared index keys off one base checkout.
+    #[test]
+    fn config_load_falls_back_to_the_local_config_when_main_has_none() {
+        let git = |dir: &Path, args: &[&str]| {
+            let out =
+                std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
+            assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        };
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let tmp =
+            std::env::temp_dir().join(format!("ragrat-nomaincfg-{}-{id}", std::process::id()));
+        let main = tmp.join("main");
+        std::fs::create_dir_all(main.join("src")).unwrap();
+        std::fs::write(main.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        git(&main, &["init", "-q"]);
+        git(&main, &["config", "user.email", "t@e"]);
+        git(&main, &["config", "user.name", "t"]);
+        git(&main, &["add", "-A"]);
+        git(&main, &["commit", "-qm", "seed"]);
+        let linked = tmp.join("wt");
+        git(&main, &["worktree", "add", "--detach", "-q", linked.to_str().unwrap()]);
+
+        // Only the LINKED checkout has a config (e.g. authored on a branch, not yet merged).
+        std::fs::write(
+            linked.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\ndatabase = \"branch.sqlite\"\n[target_bindings]\nrust = \
+             [\"src\"]\n",
+        )
+        .unwrap();
+        let cfg = Config::load(linked.join("rag-rat.toml")).unwrap();
+        let canonical_main = main.canonicalize().unwrap();
+        assert_eq!(cfg.root, canonical_main, "root anchors to main even on the fallback");
+        assert_eq!(
+            cfg.database,
+            canonical_main.join("branch.sqlite"),
+            "the local key governs (resolved against the main top) until main gains a config",
+        );
+        assert!(cfg.database_key_pinned);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// The DISCOVERY resolver matrix (Codex batch 9): local file wins wherever it exists (the
+    /// seam then governs + warns), a linked checkout without one resolves to MAIN's path (even
+    /// when that file doesn't exist yet — hints must name where the config belongs), and
+    /// main/non-git checkouts stay local.
+    #[test]
+    fn discover_config_path_resolves_the_governing_checkout() {
+        let git = |dir: &Path, args: &[&str]| {
+            let out =
+                std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
+            assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        };
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let tmp = std::env::temp_dir().join(format!("ragrat-discover-{}-{id}", std::process::id()));
+        let main = tmp.join("main");
+        std::fs::create_dir_all(main.join("src")).unwrap();
+        std::fs::write(main.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        git(&main, &["init", "-q"]);
+        git(&main, &["config", "user.email", "t@e"]);
+        git(&main, &["config", "user.name", "t"]);
+        git(&main, &["add", "-A"]);
+        git(&main, &["commit", "-qm", "seed"]);
+        let linked = tmp.join("wt");
+        git(&main, &["worktree", "add", "--detach", "-q", linked.to_str().unwrap()]);
+        let main_c = main.canonicalize().unwrap();
+
+        // Linked, no local file, main config not yet written: MAIN's path (where it belongs).
+        assert_eq!(discover_config_path(&linked), main_c.join("rag-rat.toml"));
+        // Main checkout: always local, present or not.
+        assert_eq!(discover_config_path(&main), main.join("rag-rat.toml"));
+        // Linked WITH a local (divergent) file: the local path — the load then routes through
+        // the governing seam, which warns; discovery must not silently skip that.
+        std::fs::write(linked.join("rag-rat.toml"), "[index]\nroot = \".\"\n").unwrap();
+        assert_eq!(discover_config_path(&linked), linked.join("rag-rat.toml"));
+        // Non-git: local.
+        let plain = tmp.join("plain");
+        std::fs::create_dir_all(&plain).unwrap();
+        assert_eq!(discover_config_path(&plain), plain.join("rag-rat.toml"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// The linked-ness PRIMITIVE (Codex batch 8, findings 1+3): topology-derived — the discovered
+    /// checkout's workdir vs the designated main — so a SUBDIRECTORY of the main worktree is NOT
+    /// linked (pre-fix, `init` from `main/src` falsely refused), while any path inside a linked
+    /// checkout (its top OR a subdir) is.
+    #[test]
+    fn linked_worktree_main_root_derives_linkedness_from_topology() {
+        let git = |dir: &Path, args: &[&str]| {
+            let out =
+                std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
+            assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        };
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let tmp = std::env::temp_dir().join(format!("ragrat-linkpred-{}-{id}", std::process::id()));
+        let main = tmp.join("main");
+        std::fs::create_dir_all(main.join("src")).unwrap();
+        std::fs::write(main.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        git(&main, &["init", "-q"]);
+        git(&main, &["config", "user.email", "t@e"]);
+        git(&main, &["config", "user.name", "t"]);
+        git(&main, &["add", "-A"]);
+        git(&main, &["commit", "-qm", "seed"]);
+        let linked = tmp.join("wt");
+        git(&main, &["worktree", "add", "--detach", "-q", linked.to_str().unwrap()]);
+        let main_c = main.canonicalize().unwrap();
+
+        assert_eq!(linked_worktree_main_root(&main), None, "the main worktree is not linked");
+        assert_eq!(
+            linked_worktree_main_root(&main.join("src")),
+            None,
+            "a SUBDIRECTORY of main is main — not linked (the false-refusal bug)",
+        );
+        assert_eq!(linked_worktree_main_root(&linked), Some(main_c.clone()));
+        assert_eq!(
+            linked_worktree_main_root(&linked.join("src")),
+            Some(main_c),
+            "a subdir of a linked checkout is still linked",
+        );
+        let plain = tmp.join("plain");
+        std::fs::create_dir_all(&plain).unwrap();
+        assert_eq!(linked_worktree_main_root(&plain), None, "non-git has no designated main");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Validation ORDERING (Codex batch 8, finding 2): the governing config is chosen FIRST; hard
+    /// validation applies only to the config actually used. A branch-local file that fails to
+    /// parse (or trips the `[local_ai]` rejection) in a linked worktree folds into the divergence
+    /// warning — it must never make every command from the linked checkout fatal, because its
+    /// contents are irrelevant by design when main governs.
+    #[test]
+    fn config_load_ignores_an_invalid_branch_config_when_main_governs() {
+        let git = |dir: &Path, args: &[&str]| {
+            let out =
+                std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
+            assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        };
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let tmp = std::env::temp_dir().join(format!("ragrat-brokecfg-{}-{id}", std::process::id()));
+        let main = tmp.join("main");
+        std::fs::create_dir_all(main.join("src")).unwrap();
+        std::fs::write(main.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        std::fs::write(
+            main.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\ndatabase = \"main.sqlite\"\n[target_bindings]\nrust = \
+             [\"src\"]\n",
+        )
+        .unwrap();
+        git(&main, &["init", "-q"]);
+        git(&main, &["config", "user.email", "t@e"]);
+        git(&main, &["config", "user.name", "t"]);
+        git(&main, &["add", "-A"]);
+        git(&main, &["commit", "-qm", "seed"]);
+        let linked = tmp.join("wt");
+        git(&main, &["worktree", "add", "--detach", "-q", linked.to_str().unwrap()]);
+
+        // Unparseable garbage on the branch: main still governs.
+        std::fs::write(linked.join("rag-rat.toml"), "this is [not toml").unwrap();
+        let cfg = Config::load(linked.join("rag-rat.toml"))
+            .expect("a broken branch config is ignored when main governs");
+        let main_c = main.canonicalize().unwrap();
+        assert_eq!(cfg.database, main_c.join("main.sqlite"));
+
+        // The deprecated `[local_ai]` table on the branch: same posture (it is a VALIDATION
+        // failure, not a parse failure — both fold into the warning).
+        std::fs::write(
+            linked.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\n[local_ai]\nmodel = \"x\"\n[target_bindings]\nrust = \
+             [\"src\"]\n",
+        )
+        .unwrap();
+        let cfg = Config::load(linked.join("rag-rat.toml")).unwrap();
+        assert_eq!(cfg.database, main_c.join("main.sqlite"));
+
+        // In the checkout that GOVERNS (main), the same brokenness stays fatal.
+        std::fs::write(main.join("rag-rat.toml"), "this is [not toml").unwrap();
+        assert!(
+            Config::load(main.join("rag-rat.toml")).is_err(),
+            "the governing config's validation is fatal as always",
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// The seam's trigger is TOPOLOGY, not the root-anchoring proxy (Codex batch 8, finding 3): a
+    /// branch-only `[index] root` makes `anchor_root_to_main_worktree` keep the local root (the
+    /// dir doesn't exist in main), which under the old `anchored != local` trigger concluded
+    /// "not linked" and let the branch config govern database/watch/models — the exact
+    /// split-brain the seam prevents. Governance must be unconditional on linked-ness.
+    #[test]
+    fn config_load_governs_from_main_even_when_a_branch_only_root_defeats_anchoring() {
+        let git = |dir: &Path, args: &[&str]| {
+            let out =
+                std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
+            assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        };
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let tmp =
+            std::env::temp_dir().join(format!("ragrat-branchroot-{}-{id}", std::process::id()));
+        let main = tmp.join("main");
+        std::fs::create_dir_all(main.join("src")).unwrap();
+        std::fs::write(main.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        std::fs::write(
+            main.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\ndatabase = \"main.sqlite\"\n[watch]\ndebounce_ms = \
+             1111\n[target_bindings]\nrust = [\"src\"]\n",
+        )
+        .unwrap();
+        git(&main, &["init", "-q"]);
+        git(&main, &["config", "user.email", "t@e"]);
+        git(&main, &["config", "user.name", "t"]);
+        git(&main, &["add", "-A"]);
+        git(&main, &["commit", "-qm", "seed"]);
+        let linked = tmp.join("wt");
+        git(&main, &["worktree", "add", "--detach", "-q", linked.to_str().unwrap()]);
+
+        // The branch config points `[index] root` at a dir that exists ONLY on the branch —
+        // anchoring keeps the local root (missing in main), defeating the old equality proxy.
+        std::fs::create_dir_all(linked.join("branch_only/src")).unwrap();
+        std::fs::write(linked.join("branch_only/src/lib.rs"), "pub fn b() {}\n").unwrap();
+        assert!(!main.join("branch_only").exists(), "main never had this dir");
+        std::fs::write(
+            linked.join("rag-rat.toml"),
+            "[index]\nroot = \"branch_only\"\ndatabase = \"branch.sqlite\"\n[watch]\ndebounce_ms \
+             = 9999\n[target_bindings]\nrust = [\"src\"]\n",
+        )
+        .unwrap();
+        let cfg = Config::load(linked.join("rag-rat.toml")).unwrap();
+        let main_c = main.canonicalize().unwrap();
+        assert_eq!(
+            cfg.database,
+            main_c.join("main.sqlite"),
+            "main's database governs — the branch-only root cannot defeat the seam",
+        );
+        assert_eq!(cfg.watch.debounce_ms, 1111, "main's watch config governs too");
+        assert_eq!(cfg.root, main_c, "root comes from MAIN's config when main governs");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// The identity gate's SECOND entrance (Codex batch 8, finding 5a): an EXPLICIT pin at the
+    /// consolidated global store from an identity-less root is refused at resolution — the
+    /// keyless gate never sees a pinned config, and letting it open the shared store would land
+    /// this project on adoption's sole-repo pick (a SIBLING repo). A `repo_id` pin restores the
+    /// identity and lifts the refusal. Compares against `global_database_path()` in the CURRENT
+    /// environment (no env mutation ⇒ parallel-safe); `load` only resolves, never writes there.
+    #[test]
+    fn config_load_refuses_an_identity_less_pin_at_the_global_store() {
+        let Some(global) = crate::data_dir::global_database_path() else {
+            return; // no resolvable data dir on this platform — the gate cannot trigger
+        };
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let tmp = std::env::temp_dir().join(format!("ragrat-globpin-{}-{id}", std::process::id()));
+        std::fs::create_dir_all(tmp.join("src")).unwrap();
+        std::fs::write(tmp.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        let config_path = tmp.join("rag-rat.toml");
+        std::fs::write(
+            &config_path,
+            format!(
+                "[index]\nroot = \".\"\ndatabase = \"{}\"\n[target_bindings]\nrust = [\"src\"]\n",
+                global.display()
+            ),
+        )
+        .unwrap();
+        let err = Config::load(&config_path).expect_err("identity-less global pin is refused");
+        assert!(
+            matches!(err, ConfigError::GlobalPinWithoutIdentity),
+            "the refusal names the remedy: {err}",
+        );
+
+        // A `repo_id` pin IS a resolvable identity — the same config with one loads fine.
+        std::fs::write(
+            &config_path,
+            format!(
+                "[index]\nroot = \".\"\nrepo_id = \"pinned-project\"\ndatabase = \
+                 \"{}\"\n[target_bindings]\nrust = [\"src\"]\n",
+                global.display()
+            ),
+        )
+        .unwrap();
+        let cfg = Config::load(&config_path).expect("a repo_id pin lifts the refusal");
+        assert_eq!(cfg.database, global);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// The `database` decision is MAIN-WORKTREE-ANCHORED (Codex batch 7): a linked worktree's
+    /// branch-local config can neither UN-PIN (a branch toml omitting the key while main pins —
+    /// pre-fix that split the repo across the global store and main's per-repo file) nor RE-PIN
+    /// (a branch adding its own key) the repo's database. Main's config is authoritative, exactly
+    /// as it is for `repo_id`.
+    #[test]
+    fn config_load_anchors_the_database_key_to_the_main_worktree() {
+        let git = |dir: &Path, args: &[&str]| {
+            let out =
+                std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
+            assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        };
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let tmp = std::env::temp_dir().join(format!("ragrat-dbanchor-{}-{id}", std::process::id()));
+        let main = tmp.join("main");
+        std::fs::create_dir_all(main.join("src")).unwrap();
+        std::fs::write(main.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        // MAIN pins an explicit per-repo database.
+        std::fs::write(
+            main.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\ndatabase = \"custom/pinned.sqlite\"\n[target_bindings]\nrust \
+             = [\"src\"]\n",
+        )
+        .unwrap();
+        git(&main, &["init", "-q"]);
+        git(&main, &["config", "user.email", "t@e"]);
+        git(&main, &["config", "user.name", "t"]);
+        git(&main, &["add", "-A"]);
+        git(&main, &["commit", "-qm", "seed"]);
+        let linked = tmp.join("wt");
+        git(&main, &["worktree", "add", "--detach", "-q", linked.to_str().unwrap()]);
+
+        // The BRANCH config omits the key (a branch predating the pin): pre-fix the keyless
+        // default resolved the linked checkout to the GLOBAL store — a different DB than main's.
+        std::fs::write(
+            linked.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n",
+        )
+        .unwrap();
+        let from_main = Config::load(main.join("rag-rat.toml")).unwrap();
+        let from_linked = Config::load(linked.join("rag-rat.toml")).unwrap();
+        assert_eq!(
+            from_linked.database, from_main.database,
+            "a branch omitting the key must not divert the linked worktree off main's pin",
+        );
+        assert!(from_linked.database_key_pinned, "the GOVERNING (main) key decision travels too");
+
+        // The BRANCH config pinning its OWN key: main (keyless here) stays authoritative — a
+        // branch cannot fork the repo onto a private database.
+        std::fs::write(
+            main.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n",
+        )
+        .unwrap();
+        std::fs::write(
+            linked.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\ndatabase = \"branch/fork.sqlite\"\n[target_bindings]\nrust = \
+             [\"src\"]\n",
+        )
+        .unwrap();
+        let from_main = Config::load(main.join("rag-rat.toml")).unwrap();
+        let from_linked = Config::load(linked.join("rag-rat.toml")).unwrap();
+        assert_eq!(
+            from_linked.database, from_main.database,
+            "a branch-local pin must not fork the repo onto its own database",
+        );
+        assert!(!from_linked.database_key_pinned, "main keyless ⇒ governing decision is keyless");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// A7 legacy interplay: a keyless config in a repo that ALREADY has a `.rag-rat/index.sqlite`
+    /// (indexed before the flip, or a fresh `rag-rat init` over an old checkout) keeps resolving to
+    /// that legacy file — never silently abandoning its memories — until `rag-rat consolidate`
+    /// imports and renames it, after which resolution falls through to the global store.
+    #[test]
+    fn config_load_without_a_database_key_prefers_an_existing_legacy_index() {
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let tmp = std::env::temp_dir().join(format!("ragrat-legacydb-{}-{id}", std::process::id()));
+        std::fs::create_dir_all(tmp.join("src")).unwrap();
+        std::fs::create_dir_all(tmp.join(".rag-rat")).unwrap();
+        std::fs::write(tmp.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        std::fs::write(tmp.join(".rag-rat/index.sqlite"), b"legacy").unwrap();
+        std::fs::write(
+            tmp.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n",
+        )
+        .unwrap();
+        git_commit_all(&tmp);
+
+        let config = Config::load(tmp.join("rag-rat.toml")).unwrap();
+        assert_eq!(
+            config.database,
+            tmp.canonicalize().unwrap().join(".rag-rat/index.sqlite"),
+            "a pre-existing legacy index wins over the global default until consolidated",
+        );
+
+        // Once consolidated (the legacy file renamed away), the same config resolves globally.
+        std::fs::rename(
+            tmp.join(".rag-rat/index.sqlite"),
+            tmp.join(".rag-rat/index.sqlite.imported"),
+        )
+        .unwrap();
+        let config = Config::load(tmp.join("rag-rat.toml")).unwrap();
+        assert_eq!(
+            config.database,
+            crate::data_dir::global_database_path().expect("data dir resolves"),
+            "after consolidation the keyless config falls through to the global store",
+        );
+
+        // The `.imported` marker is a STAY-GLOBAL LATCH: a stray legacy file REAPPEARING beside it
+        // (an old binary, a restored backup) must not silently divert the repo off the global
+        // store its memories were imported into.
+        std::fs::write(tmp.join(".rag-rat/index.sqlite"), b"stray").unwrap();
+        let config = Config::load(tmp.join("rag-rat.toml")).unwrap();
+        assert_eq!(
+            config.database,
+            crate::data_dir::global_database_path().expect("data dir resolves"),
+            "a stray legacy file beside the .imported marker is ignored, not adopted",
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// The IDENTITY GATE on the global default: a keyless config at a root with NO derivable repo
+    /// identity (non-git, or a `git init` with an unborn HEAD) stays on its PER-ROOT legacy path —
+    /// in the shared global store every identity-less root would pool under the one
+    /// `__unassigned__` placeholder scope, so two fresh non-git projects would see and overwrite
+    /// each other's rows, and an unborn repo would strand its placeholder rows once its first
+    /// commit mints a real id. Two identity-less roots therefore NEVER share a database.
+    #[test]
+    fn config_load_without_a_database_key_stays_per_root_for_identity_less_roots() {
+        let keyless_config = |tag: &str| {
+            let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+            let tmp = std::env::temp_dir()
+                .join(format!("ragrat-noident-{tag}-{}-{id}", std::process::id()));
+            std::fs::create_dir_all(tmp.join("src")).unwrap();
+            std::fs::write(tmp.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+            std::fs::write(
+                tmp.join("rag-rat.toml"),
+                "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n",
+            )
+            .unwrap();
+            tmp
+        };
+
+        // Two NON-GIT roots: each resolves to its OWN per-root legacy path — never the shared
+        // global store, and never each other's.
+        let a = keyless_config("a");
+        let b = keyless_config("b");
+        let config_a = Config::load(a.join("rag-rat.toml")).unwrap();
+        let config_b = Config::load(b.join("rag-rat.toml")).unwrap();
+        assert_eq!(
+            config_a.database,
+            a.canonicalize().unwrap().join(".rag-rat/index.sqlite"),
+            "an identity-less root stays on its per-root legacy path",
+        );
+        assert_eq!(
+            config_b.database,
+            b.canonicalize().unwrap().join(".rag-rat/index.sqlite"),
+            "each identity-less root gets its own database",
+        );
+        assert_ne!(config_a.database, config_b.database, "identity-less roots never share scope");
+
+        // An UNBORN repo (`git init`, no commit yet) is identity-less too: it lands per-root, so
+        // its placeholder rows adopt IN THAT DB when the first commit mints a real id (the
+        // existing single-repo adoption flow), instead of stranding in the global store.
+        let unborn = keyless_config("unborn");
+        let git = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .arg("-C")
+                .arg(&unborn)
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(out.status.success());
+        };
+        git(&["init", "-q"]);
+        let config = Config::load(unborn.join("rag-rat.toml")).unwrap();
+        assert_eq!(
+            config.database,
+            unborn.canonicalize().unwrap().join(".rag-rat/index.sqlite"),
+            "an unborn repo stays per-root until its first commit mints an identity",
+        );
+        // A `[index] repo_id` pin IS an identity: the same root then resolves globally.
+        std::fs::write(
+            unborn.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\nrepo_id = \"pinned-project\"\n[target_bindings]\nrust = \
+             [\"src\"]\n",
+        )
+        .unwrap();
+        let config = Config::load(unborn.join("rag-rat.toml")).unwrap();
+        assert_eq!(
+            config.database,
+            crate::data_dir::global_database_path().expect("data dir resolves"),
+            "a pinned repo_id makes the root identity-bearing, so the global default applies",
+        );
+
+        let _ = std::fs::remove_dir_all(&a);
+        let _ = std::fs::remove_dir_all(&b);
+        let _ = std::fs::remove_dir_all(&unborn);
     }
 
     #[test]
@@ -1575,7 +2378,8 @@ mod tests {
         // Main's config indexes only `src`.
         std::fs::write(
             main.join("rag-rat.toml"),
-            "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n",
+            "[index]\nroot = \".\"\ndatabase = \".rag-rat/index.sqlite\"\n[target_bindings]\nrust \
+             = [\"src\"]\n",
         )
         .unwrap();
         git(&main, &["init", "-q"]);
@@ -1753,7 +2557,8 @@ mod tests {
         // Main OMITS repo_id.
         std::fs::write(
             main.join("rag-rat.toml"),
-            "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n",
+            "[index]\nroot = \".\"\ndatabase = \".rag-rat/index.sqlite\"\n[target_bindings]\nrust \
+             = [\"src\"]\n",
         )
         .unwrap();
         git(&main, &["init", "-q"]);

--- a/crates/rag-rat-core/src/index/ai/helpers.rs
+++ b/crates/rag-rat-core/src/index/ai/helpers.rs
@@ -91,6 +91,13 @@ pub(crate) fn current_embedding_count(conn: &Connection, model_id: &str) -> anyh
         SELECT COUNT(*)
         FROM chunk_embeddings
         JOIN chunks ON chunks.id = chunk_embeddings.chunk_id
+        -- Scope through the active `files` view (temp.files: repo_id + live generation), exactly \
+         as
+        -- the `current_artifact_count` sibling does — otherwise this counts every repo's and every
+        -- staged generation's embeddings on a consolidated DB. Without a connection context, \
+         `files`
+        -- falls back to the base table (all commits), preserving the single-repo behavior.
+        JOIN files ON files.id = chunks.file_id
         JOIN ai_models ON ai_models.model_id = chunk_embeddings.model_id
         WHERE chunk_embeddings.model_id = ?1
           AND ai_models.installed = 1

--- a/crates/rag-rat-core/src/index/ai/reconcile/manifest.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/manifest.rs
@@ -2,6 +2,19 @@ use super::super::*;
 use crate::embedding_models::{EMBEDDING_MODELS, HASH_MODEL_ID};
 
 pub(crate) fn ensure_model_manifest(conn: &Connection) -> anyhow::Result<()> {
+    // SCOPED-REPO WITNESS (A7): the heal's repo-scoped mutations (`remove_legacy_models` clears
+    // the ACTIVE repo's `repo_meta` active-model keys) must only ever land on a repo this
+    // connection can honestly attribute them to. On a CONFIG-LESS connection to a MULTI-REPO DB
+    // there is none — `active_repo_id` would resolve the arbitrary first-sorting repo, and a
+    // heal-owed pass would delete THAT sibling's model meta under whatever lock (if any) the
+    // caller holds. This is a CALLEE-level invariant precisely because the caller set kept
+    // growing: the incremental pre-adoption open (batch 2) and consolidate's pre-registration
+    // `migrate` (batch 3) both reached here config-less. SKIP + DEFER: every production query
+    // path opens through a config-bearing open that re-runs this heal after adopt + set_context,
+    // so a skipped heal is only ever postponed, never lost.
+    if scoped_repo_witness(conn)?.is_none() {
+        return Ok(());
+    }
     // Read-first: skip the (write-locking) DML entirely when the manifest already matches what we
     // would write. `ensure_model_manifest` runs on EVERY `IndexDatabase::open*`, so issuing
     // unconditional INSERT/UPDATE/DELETE here made every open — including read-only MCP tools —
@@ -21,6 +34,30 @@ pub(crate) fn ensure_model_manifest(conn: &Connection) -> anyhow::Result<()> {
     }
     normalize_embedding_model_versions(conn)?;
     Ok(())
+}
+
+/// The repo an open-time heal may attribute its repo-scoped `repo_meta` mutations to: the
+/// INSTALLED scope context when present (authoritative — even the deliberate empty "match
+/// nothing" scope, whose repo_meta reads/deletes then match no rows), else the sole repo of a
+/// single-repo DB (unambiguous), else `None` on a config-less connection to a multi-repo DB — the
+/// caller-independent skip condition. Shared by [`ensure_model_manifest`] and the fastembed cache
+/// recovery (`recover_cached_fastembed_model_at`), the two open-time healers that read/write the
+/// active-model `repo_meta` keys.
+///
+/// LIMIT: the sole-repo arm is only valid when the operation's SUBJECT is a registered repo (a
+/// normal open of an existing index). A caller whose subject may be UNREGISTERED — consolidate
+/// importing a repo into a one-repo global DB, or any future importer — must not reach the
+/// healers through a config-less connection at all: the sole registered repo is then a SIBLING of
+/// the subject, and "single repo ⇒ unambiguous" silently attributes the heal to it. Those callers
+/// use the schema-only migration path (`IndexDatabase::migrate_schema_only`) instead.
+pub(super) fn scoped_repo_witness(conn: &Connection) -> anyhow::Result<Option<String>> {
+    if let Some(repo_id) = crate::index::schema::scope_context_repo_id(conn) {
+        return Ok(Some(repo_id));
+    }
+    if crate::index::schema::multiple_real_repos(conn)? {
+        return Ok(None);
+    }
+    Ok(Some(crate::index::schema::sole_repo_id(conn)?))
 }
 
 /// Read-only test of whether `ensure_model_manifest` would be a no-op — i.e. the manifest is

--- a/crates/rag-rat-core/src/index/ai/reconcile/model_lifecycle.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/model_lifecycle.rs
@@ -35,6 +35,15 @@ pub(crate) fn recover_cached_fastembed_model_at(
     if !fastembed_cache_ready(cache_dir) {
         return Ok(());
     }
+    // SCOPED-REPO WITNESS (A7): recovery both REQUIRES the manifest rows (which the witness gate
+    // skips seeding on this connection shape) and — worse — ACTIVATES the recovered model by
+    // writing the active-model `repo_meta` keys via the context-less `active_repo_id` fallback,
+    // i.e. onto the arbitrary first-sorting repo of a multi-repo DB. Same skip + defer posture as
+    // `ensure_model_manifest` (the other open-time healer): a scoped open recovers/activates for
+    // its own repo.
+    if super::manifest::scoped_repo_witness(conn)?.is_none() {
+        return Ok(());
+    }
     let fastembed = model(conn, FASTEMBED_MODEL_ID)?;
     if !fastembed.installed || fastembed.status != "Ready" {
         conn.execute(

--- a/crates/rag-rat-core/src/index/consolidate.rs
+++ b/crates/rag-rat-core/src/index/consolidate.rs
@@ -1,0 +1,1929 @@
+//! `rag-rat consolidate` (memory-sync phase A7): import a repo's legacy per-repo index into the
+//! consolidated GLOBAL database, then rename the legacy file out of the way so the config default
+//! resolves to the global store from then on.
+//!
+//! What is imported is exactly the AUTHORED and EXPENSIVE data — `repo_memories` (with their
+//! bindings / tags / call-paths / call-path edges), the content-addressed `embedding_cache`, and
+//! the durable model-identity `repo_meta` keys. Everything else is DERIVED (chunks, symbols, edges,
+//! FTS, …) and is cheaper and safer to rebuild than to translate across rowid spaces — so a fresh
+//! index of the consolidated repo regenerates it, and the carried `embedding_cache` makes the
+//! re-embedding a no-op (its `input_hash` folds model + version + input text).
+//!
+//! POSTURE (spec §3.4):
+//! - Portable bindings only: the memory bindings' LOCAL rowid columns (`logical_symbol_id` /
+//!   `symbol_id` / `chunk_id` / `edge_id`) are NULLed on import — those rowids mean nothing in a
+//!   fresh index — and the normal validate loop re-resolves them from the portable anchor (path /
+//!   commit / github / moniker fields, which ARE copied verbatim) after the next index pass.
+//! - `live_files_generation` is NOT carried (absent ⇒ 0 is load-bearing: a fresh index of the
+//!   consolidated repo stages above 0 and flips normally — A6 handoff rule #1).
+//! - Idempotent AND crash-honest: a no-edit retry writes nothing (content-gated upserts / `INSERT
+//!   OR IGNORE`), and a retry after a crashed RENAME carries legacy-side edits made in the window
+//!   forward — the legacy file is the live store until the rename lands, so its content REPLACES
+//!   stale same-repo global copies (children included). Once the legacy file is renamed to
+//!   `index.sqlite.imported` a re-run is a no-op with a notice.
+//! - LOCKED: the whole registration → import → rename sequence runs under the repo's per-repo write
+//!   locks — on the TARGET side (a writer's held lock must match the repo id it writes under, the
+//!   A6 structural rule) AND on the SOURCE side (a watcher / MCP server still pointed at the legacy
+//!   file keys its lock beside THAT path; holding it means no lock-disciplined writer can append to
+//!   the legacy DB between the snapshot read and the rename — writes there would otherwise silently
+//!   vanish into the renamed artifact).
+//! - An explicit `[index] database` key is REFUSED outright (no import, no side effects): renaming
+//!   the file out from under the still-pinned config would strand it on a fresh empty DB, and an
+//!   early import WITHOUT the rename would open a DELIBERATE divergence window with the global
+//!   store reachable, which the refusal exists to prevent (the crash-retry upsert covers the
+//!   accidental window a failed rename creates). A pinned config never reads the global store, so
+//!   an early import has no value; the refusal names the remedy (remove the key, re-run) and the
+//!   single completing run imports and renames atomically with no window.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use rusqlite::{Connection, OptionalExtension, params};
+
+use crate::config::{self, Config};
+use crate::index::{IndexDatabase, schema};
+use crate::repo_identity::{self, RepoIdentity};
+use crate::storage::IndexConnection;
+use crate::{data_dir, locks};
+
+/// The `repo_meta` keys consolidate carries from the legacy DB into the global DB. Carried as a
+/// per-key MIRROR of the source (the import's mirror invariant): a key present in the legacy DB
+/// upserts (value-gated, so an unchanged retry writes nothing), a carried key ABSENT there
+/// deletes any stale target row — the legacy DB is the live store until the rename lands, so a
+/// model switch made in the crash-retry window (including one that removes a key, e.g. dropping
+/// the remote config when moving to a local model) must win over the previous run's copy.
+/// Nothing else writes these keys for a mid-consolidate repo (the import holds the repo's write
+/// locks and the target migrate is schema-only), so there is no competing "config-seeded" value
+/// to preserve.
+///
+/// CLASSIFICATION RULE (every `repo_meta` key must land in exactly one class — classify a NEW key
+/// here at birth):
+///
+///  (a) REPO-PORTABLE CONFIGURATION — durable "how this repo embeds" identity/state that must
+///      survive the move or the carried `embedding_cache` / remote transport is stranded → COPIED
+///      (as ONE model-state unit — see [`copy_model_state`], which also carries the active
+///      model's `ai_models` readiness row):
+///      * `active_embedding_model` — which embedder the cache rows belong to;
+///      * `embedding_active_model_version` — the active model's freshness key;
+///      * `active_embedding_remote_config` — the persisted remote-endpoint config
+///        `active_embedder()` reconstructs its query/connect-mode transport from; dropping it would
+///        silently reroute post-consolidation searches to the local backend (or lexical) until the
+///        model is reinstalled;
+///      * `active_embedding_model_provisional` — SEMANTIC state, not transient: absent reads as
+///        NON-provisional (an explicit, config-immune choice), so dropping a set `"1"` would
+///        CONVERT an auto-selected model into a confirmed one and `seed_active_embedding_model`
+///        could no longer override/clear it from config. ABSENCE-HAS-MEANING keys like this need
+///        the absent state classified too, not just the value.
+///
+///  (b) DB-LOCAL STATE — never copied; each entry states why:
+///      * freshness/progress cursors that would make a fresh 0-row index falsely report itself
+///        current: `content_revision`, `git_commit`, `git_dirty`, `git_history_indexed_head` /
+///        `_root` / `_shallow`, `github_last_sync_ms`, `graph_index_version`, `indexed_at_ms`,
+///        `vector_int8_reencode_done` / `_cursor`, `last_embedding_reconcile_started_at_ms` /
+///        `_finished_at_ms`;
+///      * pointers/state owned by THIS database file's lifecycle: `live_files_generation` (absent ⇒
+///        0 is load-bearing — A6), `clone_graph_live_generation`, `shallow_boundary` (adoption
+///        proof for the legacy file's own registry), `source_root` (re-recorded by registration);
+///      * derived/re-derivable caches: `local_crate_roots` (re-read from manifests),
+///        `embedding_throughput_tune_v1` (a tuning cache, re-derived).
+const CARRIED_META_KEYS: &[&str] = &[
+    "active_embedding_model",
+    "embedding_active_model_version",
+    "active_embedding_remote_config",
+    "active_embedding_model_provisional",
+];
+
+/// How long consolidate waits for the repo's per-repo write locks (global-side and legacy-side)
+/// before refusing — an in-flight index/maintenance pass finishes well within it, and an explicit
+/// retryable refusal beats importing under a live writer.
+const CONSOLIDATE_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// The result of a `rag-rat consolidate` run — the CLI renders it; the core owns the logic.
+#[derive(Debug)]
+pub enum ConsolidateOutcome {
+    /// The repo already resolves to the global database (no `database` key, no legacy file, or an
+    /// explicit `database` already pointing at the global store) — nothing to do.
+    AlreadyGlobal { database: PathBuf },
+    /// A previous run already imported this repo (the `.imported` marker is present) — a no-op.
+    AlreadyImported { imported: PathBuf },
+    /// No legacy per-repo index exists to import (a fresh repo already on the global default).
+    NoLegacyIndex { source: PathBuf },
+    /// The legacy index was imported (and, unless the config pins an explicit `database` key,
+    /// renamed away).
+    Imported(ImportSummary),
+}
+
+/// Per-run import counts + the paths involved, for the CLI summary. Counts reflect rows actually
+/// WRITTEN — an idempotent re-run over already-imported rows reports zeros, not phantom copies.
+#[derive(Debug)]
+pub struct ImportSummary {
+    pub repo_id: String,
+    pub source: PathBuf,
+    /// The `index.sqlite.imported` marker the legacy file was renamed to (always — a pinned config
+    /// is refused before any import, so a summary only exists for a completed import + rename).
+    pub renamed_to: PathBuf,
+    pub target: PathBuf,
+    pub memories: u64,
+    pub bindings: u64,
+    pub tags: u64,
+    pub call_paths: u64,
+    pub call_path_edges: u64,
+    pub embedding_cache_rows: u64,
+    pub meta_keys: u64,
+}
+
+/// Consolidate the repo of `config` into the global database. The pinned-key refusal keys off
+/// `config.database_key_pinned` — the GOVERNING (main-worktree-anchored) key decision
+/// `Config::load` already made — so the refusal and the `database` resolution can never disagree (a
+/// linked worktree's branch-local toml is not authoritative for either).
+pub fn run(config: &Config) -> anyhow::Result<ConsolidateOutcome> {
+    let target = data_dir::global_database_path().context(
+        "cannot resolve the global database path: no data directory is available (set \
+         RAG_RAT_DATA_DIR, XDG_DATA_HOME, or HOME)",
+    )?;
+    let mut source = config.database.clone();
+
+    // Already on the global store (an explicit `database = <global>` or a keyless config whose
+    // legacy file was already imported) — usually nothing to import, with ONE refinement: a
+    // config explicitly PINNED AT the global path can coexist with a lingering, never-imported
+    // legacy file (the pin was added by hand, so no consolidate run ever renamed the old
+    // per-repo DB) — reporting `already_global` there strands the authored memories in the old
+    // file while claiming success. Probe the default legacy path: present without its
+    // `.imported` marker ⇒ import FROM it. This is the one pinned shape where proceeding is
+    // strictly correct — the pin already names the target, so the rename cannot strand the
+    // config (post-import it still resolves global), which is why the pinned refusal below is
+    // skipped for it.
+    let mut pinned_at_target = false;
+    if source == target {
+        let legacy = config::default_legacy_database_path(&config.root);
+        if legacy != target && legacy.exists() && !imported_marker(&legacy).exists() {
+            source = legacy;
+            pinned_at_target = true;
+        } else {
+            return Ok(ConsolidateOutcome::AlreadyGlobal { database: target });
+        }
+    }
+
+    // A pinned `[index] database` key is REFUSED before ANY side effect — and BEFORE the
+    // missing-source exits below: a pin at a missing/renamed path would otherwise report a happy
+    // `no_legacy_index` / `already_consolidated` while the repo stays stranded on the pin (the
+    // next `rag-rat index` recreates an empty per-repo DB there). Only a pin at the global target
+    // itself is genuinely fine — that returned `AlreadyGlobal` above. Rationale for refusing at
+    // all: renaming the legacy file would strand the still-pinned config on a fresh empty DB, and
+    // importing WITHOUT renaming would open a divergence window (memories edited in the
+    // still-live legacy DB before a later finishing run are silently dropped by the idempotent
+    // `INSERT OR IGNORE`s); a pinned config never reads the global store, so an early import buys
+    // nothing.
+    if config.database_key_pinned && !pinned_at_target {
+        let default_legacy = config::default_legacy_database_path(&config.root);
+        anyhow::bail!("{}", pinned_refusal_message(&source, &default_legacy));
+    }
+
+    let imported = imported_marker(&source);
+    if !source.exists() {
+        return Ok(if imported.exists() {
+            ConsolidateOutcome::AlreadyImported { imported }
+        } else {
+            ConsolidateOutcome::NoLegacyIndex { source }
+        });
+    }
+
+    // Resolve the repo identity FIRST: the per-repo write locks are keyed by the id this run
+    // registers and writes under (the A6 lock-matches-written-id rule).
+    let identity = resolve_identity_for_config(config)?;
+
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("creating the global data directory {}", parent.display()))?;
+    }
+
+    // Hold the repo's per-repo write locks for the WHOLE registration → import → rename sequence:
+    // the GLOBAL-side lock covers every row written under `identity.repo_id` in the global DB, and
+    // the LEGACY-side locks exclude a watcher / MCP writer still keyed beside the legacy file, so
+    // nothing can append to it between the snapshot read and the rename. Both bounded; the global
+    // locks taken inside (schema in the migration, registry in `register_repo`) follow the
+    // per-repo → global ordering rule (see `locks::registry_lock_path`).
+    //
+    // The LEGACY side drains EVERY id the source DB itself records, not just the CURRENT identity:
+    // the legacy file predates the identity transition, so a writer started PRE-deepen still keys
+    // its flock by the OLD `local:` id — a current-identity lock alone would not conflict with it,
+    // and the snapshot + rename could race its writes into the renamed artifact (the same loss the
+    // same-id lock exists to prevent; the outgoing-drain rule the upgrade path follows). The ids
+    // come from a read-only PRE-lock peek at the source's own `repos` registry; canonical order,
+    // bounded. A source so old it predates the registry tables peeks empty — only pre-A6 binaries
+    // (whose lock files predate per-repo keying entirely) ever wrote such a file, so no
+    // current-scheme lock could coordinate with them regardless.
+    let _target_lock = acquire_consolidate_lock(&target, &identity.repo_id, "global")?;
+    let mut source_side_ids = source_registered_repo_ids(&source);
+    if !source_side_ids.iter().any(|id| id == &identity.repo_id) {
+        source_side_ids.push(identity.repo_id.clone());
+    }
+    source_side_ids.sort_by(|a, b| {
+        if crate::locks::canonical_lock_order(a, b).0 == a.as_str() {
+            std::cmp::Ordering::Less
+        } else {
+            std::cmp::Ordering::Greater
+        }
+    });
+    let mut _source_locks = Vec::with_capacity(source_side_ids.len());
+    for id in &source_side_ids {
+        _source_locks.push(acquire_consolidate_lock(&source, id, "legacy")?);
+    }
+
+    // Bring the global DB to current schema (creating it under the shared schema lock), then open
+    // a fresh connection to register this repo and copy rows into it. SCHEMA-ONLY, never the
+    // healing `migrate`: this connection is config-less and the SUBJECT repo is not registered
+    // yet, so the open-time healers' scoped-repo witness would resolve the sole REGISTERED repo —
+    // a SIBLING when consolidating a second repo into a one-repo global DB — and heal ITS
+    // `repo_meta` under only the incoming repo's locks (see the witness-limit note on
+    // `scoped_repo_witness`). Any owed sibling heal belongs to that sibling's next scoped open.
+    IndexDatabase::migrate_schema_only(&target)
+        .with_context(|| format!("migrating the global database {}", target.display()))?;
+    let target_storage = IndexConnection::open(&target)?;
+    let target_conn = target_storage.connection();
+
+    // Register (or adopt/extend) this repo in the global DB. The returned id is what every imported
+    // row is stamped with — the legacy DB's own `repo_id` (placeholder or otherwise) is discarded.
+    let repo_id = schema::register_repo(target_conn, &identity, &config.root, schema::now_ms())?;
+
+    // Bring the SOURCE to current schema too (read-write, under the source-side locks held above,
+    // and about to be renamed `.imported` anyway): an old-vintage legacy DB this binary never
+    // opened keeps its model meta in the pre-V039 `index_meta`/`reconcile_meta` tables, and the
+    // import below reads `repo_meta` ONLY — without this the embedding cache would carry while
+    // the model identity/remote config/provisional flag silently dropped (the model-state unit
+    // broken on the vintage axis). Running the ladder lets V039/V040's own migrations do the meta
+    // relocation instead of the importer re-implementing dual-path key reads. Schema-only (no
+    // heals — single-repo or not, there is nothing an open-time heal should touch on a file being
+    // retired). An unmigratable source propagates: it cannot be trusted for import.
+    IndexDatabase::migrate_schema_only(&source).with_context(|| {
+        format!("migrating the legacy index {} before import", source.display())
+    })?;
+
+    // Fold any WAL content into the legacy main file before the snapshot read, so the file the
+    // rename moves is self-contained (a bare rename leaves `-wal`/`-shm` sidecars behind). The
+    // import itself reads THROUGH the WAL either way; this keeps the `.imported` artifact whole.
+    checkpoint_source_wal(&source);
+
+    // Open the legacy DB READ-ONLY and copy the authored + expensive rows across in one
+    // transaction.
+    let source_storage = IndexConnection::open_read_only_blocking(&source)
+        .with_context(|| format!("opening the legacy index {} read-only", source.display()))?;
+    let counts = import_from_source(source_storage.connection(), target_conn, &repo_id)?;
+    drop(source_storage);
+
+    // Rename the legacy file so a keyless config now resolves to the global store (via the
+    // `.imported` latch), and a re-run is a no-op. AFTER the import commits, so a failure leaves
+    // the legacy file in place to retry. The WAL sidecars travel WITH the archive: a bare
+    // main-file rename would orphan `-wal`/`-shm` as permanent litter, and any un-checkpointed
+    // frames in the WAL belong to the archive (SQLite opens the renamed pair as a unit) — the
+    // same discipline the custom-pin remedy tells users to follow.
+    fs::rename(&source, &imported)
+        .with_context(|| format!("renaming {} to {}", source.display(), imported.display()))?;
+    rename_wal_sidecars(&source, &imported);
+
+    Ok(ConsolidateOutcome::Imported(ImportSummary {
+        repo_id,
+        source,
+        renamed_to: imported,
+        target,
+        memories: counts.memories,
+        bindings: counts.bindings,
+        tags: counts.tags,
+        call_paths: counts.call_paths,
+        call_path_edges: counts.call_path_edges,
+        embedding_cache_rows: counts.embedding_cache_rows,
+        meta_keys: counts.meta_keys,
+    }))
+}
+
+/// The real (non-placeholder) repo ids the SOURCE legacy DB's own `repos` registry records — the
+/// ids pre-transition writers key their legacy-side flocks by (a pre-deepen watcher holds the old
+/// `local:` id's lock). Read-only, pre-lock, and TOLERANT: any failure (a source predating the
+/// V038 registry, an unreadable file) peeks empty — such vintages were only ever written by
+/// pre-per-repo-lock binaries, which no current lock scheme can coordinate with anyway.
+fn source_registered_repo_ids(source: &Path) -> Vec<String> {
+    let Ok(storage) = IndexConnection::open_read_only_blocking(source) else {
+        return Vec::new();
+    };
+    let conn = storage.connection();
+    let Ok(mut stmt) = conn.prepare("SELECT repo_id FROM repos WHERE repo_id != '__unassigned__'")
+    else {
+        return Vec::new();
+    };
+    stmt.query_map([], |row| row.get::<_, String>(0))
+        .map(|rows| rows.flatten().collect())
+        .unwrap_or_default()
+}
+
+/// `<source>.imported` — the marker the legacy file is renamed to after a successful import.
+fn imported_marker(source: &Path) -> PathBuf {
+    let mut name = source.as_os_str().to_os_string();
+    name.push(".imported");
+    PathBuf::from(name)
+}
+
+/// Resolve the identity consolidate registers and locks under. A non-git root with no pinned
+/// `[index] repo_id` has no derivable identity to scope the import under, so consolidation refuses
+/// it with an actionable message rather than guess.
+fn resolve_identity_for_config(config: &Config) -> anyhow::Result<RepoIdentity> {
+    match repo_identity::resolve_repo_identity(&config.root, config.repo_id_override.as_deref()) {
+        Ok(identity) => Ok(identity),
+        Err(err) if err.is_absent() => anyhow::bail!(
+            "cannot determine a repo identity to consolidate {}: it is not a git repository and \
+             rag-rat.toml pins no `[index] repo_id`. Pin `[index] repo_id = \"…\"` to consolidate \
+             a non-git root.",
+            config.root.display(),
+        ),
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// The pinned-`database` refusal, shaped by WHERE the pin points. A pin at the DEFAULT legacy path
+/// needs only the key removed — the keyless re-run resolves straight to the file. A CUSTOM pin
+/// additionally needs its file MOVED to the default location first: keyless resolution never looks
+/// at a custom path, so removing the key alone would leave the custom index invisible (a follow-up
+/// run reports `no_legacy_index` / `already_global`) and its memories never imported. The custom
+/// remedy prints the literal commands for the user's paths.
+fn pinned_refusal_message(source: &Path, default_legacy: &Path) -> String {
+    let base = format!(
+        "refusing to consolidate: rag-rat.toml pins `[index] database`, so this repo would keep \
+         using {} and any memories written there after an import would be silently lost when the \
+         file is later renamed.",
+        source.display(),
+    );
+    if source == default_legacy {
+        format!(
+            "{base} Remove the `database` key from rag-rat.toml, then re-run `rag-rat \
+             consolidate` — the single completing run imports and renames with no divergence \
+             window."
+        )
+    } else {
+        format!(
+            "{base} The pin points at a CUSTOM path, which a keyless config never consults — \
+             removing the key alone would leave this index invisible and its memories unimported. \
+             Move it to the default location, remove the `database` key from rag-rat.toml, then \
+             re-run `rag-rat consolidate`:\n    mkdir -p {default_dir} && mv {src} \
+             {default}\n(move {src}-wal / {src}-shm alongside if present — they can hold recent \
+             writes)",
+            default_dir = default_legacy.parent().unwrap_or(Path::new(".")).display(),
+            src = source.display(),
+            default = default_legacy.display(),
+        )
+    }
+}
+
+/// Acquire the per-repo write lock beside `database` for `repo_id`, bounded — `side` names which
+/// file ("global" / "legacy") in the refusal so a timeout is actionable.
+fn acquire_consolidate_lock(
+    database: &Path,
+    repo_id: &str,
+    side: &str,
+) -> anyhow::Result<locks::WriteLock> {
+    locks::WriteLock::acquire_timeout(database, repo_id, CONSOLIDATE_LOCK_TIMEOUT)?.ok_or_else(
+        || {
+            anyhow::anyhow!(
+                "timed out waiting for an in-flight writer holding this repo's {side}-side write \
+                 lock (an index or maintenance pass); re-run `rag-rat consolidate` once it \
+                 finishes"
+            )
+        },
+    )
+}
+
+/// Move the legacy DB's `-wal` / `-shm` sidecars beside the renamed `.imported` archive, so no
+/// litter remains at the legacy path and any un-checkpointed WAL frames TRAVEL with the archive
+/// (SQLite opens the main+wal pair as a unit — the archive stays whole even when the best-effort
+/// checkpoint was refused by a concurrent reader). Best-effort per file: the main rename already
+/// committed the consolidation, so a sidecar rename failure is a warn — the LIVE import read
+/// through the WAL and lost nothing; only the archive may lag its sidecar.
+fn rename_wal_sidecars(source: &Path, imported: &Path) {
+    for suffix in ["-wal", "-shm"] {
+        let sidecar = path_with_suffix(source, suffix);
+        if !sidecar.exists() {
+            continue;
+        }
+        let dest = path_with_suffix(imported, suffix);
+        if let Err(err) = fs::rename(&sidecar, &dest) {
+            tracing::warn!(
+                sidecar = %sidecar.display(),
+                "failed to move a legacy WAL sidecar beside the .imported archive: {err}"
+            );
+        }
+    }
+}
+
+/// `path` with `suffix` appended to its final component (`index.sqlite` + `-wal` →
+/// `index.sqlite-wal`) — how SQLite names its WAL sidecars.
+fn path_with_suffix(path: &Path, suffix: &str) -> PathBuf {
+    let mut name = path.as_os_str().to_os_string();
+    name.push(suffix);
+    PathBuf::from(name)
+}
+
+/// Best-effort `PRAGMA wal_checkpoint(TRUNCATE)` on the legacy file, folding its WAL into the
+/// main file before the snapshot read / rename when nothing contends. DELIBERATELY not fatal on a
+/// busy checkpoint: the lockless read-only MCP openers are a SANCTIONED reader class (they take no
+/// per-repo flock by design), so a reader holding the WAL open here is a legitimate state, not a
+/// lock-discipline violation — and correctness does not depend on the checkpoint succeeding: the
+/// import reads through the WAL on its own connection, and [`rename_wal_sidecars`] moves any
+/// un-checkpointed frames WITH the archive.
+fn checkpoint_source_wal(source: &Path) {
+    let checkpoint = Connection::open(source).and_then(|conn| {
+        conn.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| row.get::<_, i64>(0))
+    });
+    match checkpoint {
+        Ok(0) => {},
+        Ok(_busy) => tracing::warn!(
+            path = %source.display(),
+            "could not fully checkpoint the legacy index's WAL (a reader is holding it open); the \
+             import is unaffected, but the renamed .imported file may lag its -wal sidecar"
+        ),
+        Err(err) => tracing::warn!(
+            path = %source.display(),
+            "failed to checkpoint the legacy index's WAL before import: {err}"
+        ),
+    }
+}
+
+/// Import counts, threaded back to the [`ImportSummary`].
+struct ImportCounts {
+    memories: u64,
+    bindings: u64,
+    tags: u64,
+    call_paths: u64,
+    call_path_edges: u64,
+    embedding_cache_rows: u64,
+    meta_keys: u64,
+}
+
+/// Copy every authored + expensive row from `source` into `target` under `repo_id`, in ONE
+/// IMMEDIATE transaction (all-or-nothing; the SQLite write lock is taken up front instead of on a
+/// mid-transaction upgrade). Every SOURCE table is guarded by presence so a legacy DB predating a
+/// feature (e.g. `embedding_cache`, added later than the memory tables) is imported for what it
+/// does have rather than erroring.
+///
+/// THE MIRROR INVARIANT (Codex batch 9, closes the retry-window class): until the archive rename
+/// lands, the legacy DB is AUTHORITATIVE for this repo's imported slice — keyless resolution
+/// keeps serving the legacy file, so any edit in the window between a committed import and a
+/// failed rename happens THERE. Every artifact the import copies is therefore REFRESHED to match
+/// the source on every run; after the rename, the `.imported` latch makes re-runs unreachable.
+/// Per-artifact disposition (every copied artifact MUST appear here and obey the invariant —
+/// a new artifact gets classified at birth):
+///  * `repo_memories` (parents)          — content-gated UPSERT ([`copy_memories`]); a no-edit
+///    retry writes nothing, foreign rows are never updated (ownership rides the gate).
+///  * children of ALL mapped ids         — REPLACED unconditionally ([`refresh_children`]): the
+///    (tags/bindings/call-paths/edges)     children of every mapped target id — same-repo AND
+///    remapped — are deleted, then reinserted from the source. Unconditional because a parent-edit
+///    gate needs a "children changed ⇒ parent row changed" signal (updated_at_ms chaining) that is
+///    true today but brittle — the batch-8 gate already missed remapped parents. Replace-in-txn is
+///    convergent and signal-free. Counts stay honest via a before/after slice DIGEST per table:
+///    identical slice ⇒ 0, else the reinserted rows.
+///  * `repo_memory_fts`                  — re-derived for the WHOLE repo at the end
+///    ([`rebuild_memory_fts_for_repo`]); covers refreshed same-repo AND remapped rows alike (both
+///    are stamped `repo_id` = ours by the copy).
+///  * `repo_meta` model-state unit       — per-key MIRROR ([`copy_model_state`]): value-gated
+///    upsert for keys present in the source, DELETE for carried keys absent there (a model switch
+///    in the window may legitimately remove a key, e.g. the remote config when moving to a local
+///    model — keeping it would tear the unit).
+///  * `ai_models` readiness              — restore-style carry ([`carry_active_model_readiness`]),
+///    re-derived from the SOURCE's active model each run, so a window model change restores the NEW
+///    model's readiness on retry; an explicit machine-level `disabled` is never overridden.
+///  * `embedding_cache`                  — `INSERT OR IGNORE`, the ONE legitimate IGNORE: rows are
+///    CONTENT-ADDRESSED (`(input_hash, model_id)` determines the vector bytes), so an existing row
+///    is by definition identical and a "stale" extra row is harmless cache that re-embedding never
+///    consults incorrectly.
+///
+/// Ends by re-deriving the `repo_memory_fts` mirror for the repo: the copies write the base
+/// tables directly, and `memory_search` retrieves EXCLUSIVELY through the FTS mirror — without
+/// this, imported memories would be permanently invisible to keyword search (no reconcile/index
+/// path repairs the mirror).
+fn import_from_source(
+    source: &Connection,
+    target: &Connection,
+    repo_id: &str,
+) -> anyhow::Result<ImportCounts> {
+    let tx =
+        rusqlite::Transaction::new_unchecked(target, rusqlite::TransactionBehavior::Immediate)?;
+    // CHILD-OWNERSHIP INVARIANT: `copy_memories` returns the source→target MEMORY-ID MAP, and every
+    // child copy inserts ONLY under a mapped target id — an id this import verified it owns under
+    // `repo_id` this run. A child row must never attach to a parent the import does not own: a
+    // legacy memory id colliding with ANOTHER repo's memory in the global store would otherwise
+    // have its memory dropped while its tags/bindings/call-paths silently contaminate the other
+    // repo's memory.
+    let CopiedMemories { rows_written: memories, id_map } = copy_memories(source, &tx, repo_id)?;
+    // Mirror invariant: children of EVERY mapped id are replaced, not unioned. Digest the target's
+    // child slices before and after — identical slice ⇒ that table reports 0 (an honest no-op).
+    let pre = child_slice_digests(&tx, &id_map)?;
+    refresh_children(&tx, &id_map)?;
+    let raw = ImportCounts {
+        memories,
+        bindings: copy_bindings(source, &tx, repo_id, &id_map)?,
+        tags: copy_tags(source, &tx, &id_map)?,
+        call_paths: copy_call_paths(source, &tx, &id_map)?,
+        call_path_edges: copy_call_path_edges(source, &tx, &id_map)?,
+        embedding_cache_rows: copy_embedding_cache(source, &tx)?,
+        meta_keys: copy_model_state(source, &tx, repo_id)?,
+    };
+    let post = child_slice_digests(&tx, &id_map)?;
+    let counts = ImportCounts {
+        bindings: if pre.bindings == post.bindings { 0 } else { raw.bindings },
+        tags: if pre.tags == post.tags { 0 } else { raw.tags },
+        call_paths: if pre.call_paths == post.call_paths { 0 } else { raw.call_paths },
+        call_path_edges: if pre.call_path_edges == post.call_path_edges {
+            0
+        } else {
+            raw.call_path_edges
+        },
+        ..raw
+    };
+    rebuild_memory_fts_for_repo(&tx, repo_id)?;
+    tx.commit()?;
+    Ok(counts)
+}
+
+/// One SHA-256 digest per child table over the TARGET rows of the mapped ids (order-insensitive:
+/// rows are serialized with type tags and sorted before hashing). Drives the honest-count gate in
+/// [`import_from_source`]: replace-then-reinsert genuinely rewrites rows on every run, but a run
+/// that leaves a slice byte-identical did no work worth reporting.
+struct ChildSliceDigests {
+    tags: [u8; 32],
+    bindings: [u8; 32],
+    call_paths: [u8; 32],
+    call_path_edges: [u8; 32],
+}
+
+fn child_slice_digests(
+    tx: &Connection,
+    id_map: &BTreeMap<String, String>,
+) -> anyhow::Result<ChildSliceDigests> {
+    Ok(ChildSliceDigests {
+        tags: child_slice_digest(tx, "repo_memory_tags", id_map)?,
+        bindings: child_slice_digest(tx, "repo_memory_bindings", id_map)?,
+        call_paths: child_slice_digest(tx, "repo_memory_call_paths", id_map)?,
+        call_path_edges: child_slice_digest(tx, "repo_memory_call_path_edges", id_map)?,
+    })
+}
+
+fn child_slice_digest(
+    tx: &Connection,
+    table: &str,
+    id_map: &BTreeMap<String, String>,
+) -> anyhow::Result<[u8; 32]> {
+    use sha2::{Digest, Sha256};
+    // `table` is a compile-time constant at every call site, never user input.
+    let mut stmt = tx.prepare(&format!("SELECT * FROM {table} WHERE memory_id = ?1"))?;
+    let mut lines: Vec<String> = Vec::new();
+    for target_id in id_map.values() {
+        let mut rows = stmt.query([target_id])?;
+        while let Some(row) = rows.next()? {
+            let mut line = String::new();
+            for i in 0..row.as_ref().column_count() {
+                match row.get_ref(i)? {
+                    rusqlite::types::ValueRef::Null => line.push_str("|n"),
+                    rusqlite::types::ValueRef::Integer(v) => {
+                        line.push_str(&format!("|i{v}"));
+                    },
+                    rusqlite::types::ValueRef::Real(v) => line.push_str(&format!("|r{v}")),
+                    rusqlite::types::ValueRef::Text(v) => {
+                        line.push_str(&format!("|t{}", String::from_utf8_lossy(v)));
+                    },
+                    rusqlite::types::ValueRef::Blob(v) => {
+                        line.push_str(&format!("|b{}", v.len()));
+                        line.push_str(
+                            &v.iter().map(|byte| format!("{byte:02x}")).collect::<String>(),
+                        );
+                    },
+                }
+            }
+            lines.push(line);
+        }
+    }
+    lines.sort_unstable();
+    let mut hasher = Sha256::new();
+    for line in &lines {
+        hasher.update(line.as_bytes());
+        hasher.update([0u8]);
+    }
+    Ok(hasher.finalize().into())
+}
+
+/// Copy `repo_memories`, stamping the target `repo_id`, and return `(rows written, source→target
+/// id map)`. Selects only the STABLE portable columns (never the source `repo_id`), so it reads
+/// faithfully even from a legacy DB predating `repo_memories.repo_id` (V042). COLUMN
+/// CLASSIFICATION (the audit rule for every copy below): every column is either PORTABLE (copied
+/// verbatim) or a LOCAL ROWID (NULLed for re-resolution) — a new column added to one of these
+/// tables must be consciously classified into one of the two, never silently dropped by a partial
+/// SELECT.
+///
+/// ID COLLISIONS: memory ids are TEXT and only unique per DB, so a second legacy import can carry
+/// an id the global store already holds. Three cases:
+///  * unclaimed → insert under the ORIGINAL id (ids are referenced in prose; keep them when free);
+///  * owned by THIS repo → the CRASH-RETRY case (Codex batch 8): the import txn committed but the
+///    rename failed, the legacy file stayed the LIVE store (keyless resolution keeps serving it
+///    until the rename lands), and the user may have edited the memory there. The write is an
+///    honest UPSERT — the legacy content REPLACES the stale global copy, gated on an actual content
+///    difference (row-value `IS NOT`) so a no-edit retry writes nothing and the counts stay honest.
+///    The gate also requires `repo_id` ownership, so a foreign row is never updated.
+///  * owned by a DIFFERENT repo → REMAP to [`remapped_memory_id`] (deterministic, so a retry
+///    converges on the same id) and import under the new id — never drop the memory, never let its
+///    children attach to the other repo's row.
+///
+/// Children are NOT gated here: [`import_from_source`] replaces the children of EVERY mapped id
+/// unconditionally (see the mirror invariant there) — a parent-edit gate would need the
+/// "children changed ⇒ parent bumped" signal, which the remap path already broke once.
+///
+/// After every insert the target row's ownership is VERIFIED (`repo_id` must be ours) — the
+/// structural backstop for the child-ownership invariant in [`import_from_source`].
+fn copy_memories(
+    source: &Connection,
+    tx: &Connection,
+    repo_id: &str,
+) -> anyhow::Result<CopiedMemories> {
+    if !schema::table_exists(source, "repo_memories")? {
+        return Ok(CopiedMemories::default());
+    }
+    let mut stmt = source.prepare(
+        "SELECT id, kind, title, body, confidence, status, created_by, created_at_ms, \
+         updated_at_ms, source, source_text_hash, input_hash, memory_version FROM repo_memories",
+    )?;
+    let mut rows = stmt.query([])?;
+    let mut count = 0u64;
+    let mut id_map: BTreeMap<String, String> = BTreeMap::new();
+    while let Some(row) = rows.next()? {
+        let source_id = row.get::<_, String>(0)?;
+        let target_id = match memory_owner(tx, &source_id)? {
+            Some(owner) if owner != repo_id => remapped_memory_id(repo_id, &source_id),
+            _ => source_id.clone(),
+        };
+        let changed = tx.execute(
+            "INSERT INTO repo_memories(id, kind, title, body, confidence, status, created_by, \
+             created_at_ms, updated_at_ms, source, source_text_hash, input_hash, memory_version, \
+             repo_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+             ON CONFLICT(id) DO UPDATE SET
+               kind = excluded.kind, title = excluded.title, body = excluded.body,
+               confidence = excluded.confidence, status = excluded.status,
+               created_by = excluded.created_by, created_at_ms = excluded.created_at_ms,
+               updated_at_ms = excluded.updated_at_ms, source = excluded.source,
+               source_text_hash = excluded.source_text_hash, input_hash = excluded.input_hash,
+               memory_version = excluded.memory_version
+             WHERE repo_memories.repo_id = excluded.repo_id
+               AND (repo_memories.kind, repo_memories.title, repo_memories.body, \
+             repo_memories.confidence, repo_memories.status, repo_memories.created_by, \
+             repo_memories.created_at_ms, repo_memories.updated_at_ms, repo_memories.source, \
+             repo_memories.source_text_hash, repo_memories.input_hash, \
+             repo_memories.memory_version)
+               IS NOT (excluded.kind, excluded.title, excluded.body, excluded.confidence, \
+             excluded.status, excluded.created_by, excluded.created_at_ms, \
+             excluded.updated_at_ms, excluded.source, excluded.source_text_hash, \
+             excluded.input_hash, excluded.memory_version)",
+            params![
+                target_id,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, String>(5)?,
+                row.get::<_, Option<String>>(6)?,
+                row.get::<_, i64>(7)?,
+                row.get::<_, i64>(8)?,
+                row.get::<_, String>(9)?,
+                row.get::<_, Option<String>>(10)?,
+                row.get::<_, Option<String>>(11)?,
+                row.get::<_, String>(12)?,
+                repo_id,
+            ],
+        )?;
+        // The structural invariant: whatever happened above, the mapped target id must now be OURS
+        // — else children keyed to it would attach to another repo's memory. Unreachable in
+        // practice (the remap made the id collision-free), but a violated invariant here must be a
+        // hard error, never silent contamination.
+        if memory_owner(tx, &target_id)?.as_deref() != Some(repo_id) {
+            anyhow::bail!(
+                "memory id {target_id} is not owned by {repo_id} after import — refusing to \
+                 attach its children across repos"
+            );
+        }
+        count += changed as u64;
+        id_map.insert(source_id, target_id);
+    }
+    Ok(CopiedMemories { rows_written: count, id_map })
+}
+
+/// [`copy_memories`]' result: rows actually written, and the source→target id map every child
+/// copy keys off.
+#[derive(Default)]
+struct CopiedMemories {
+    rows_written: u64,
+    id_map: BTreeMap<String, String>,
+}
+
+/// Delete the CHILD rows (tags, bindings, call-paths, call-path edges) of EVERY mapped target id
+/// — same-repo and remapped alike — inside the import transaction, so the subsequent child copies
+/// reinsert the legacy state wholesale (the mirror invariant in [`import_from_source`]): the
+/// legacy is the live store until the rename lands, so its child sets REPLACE the stale global
+/// ones (a tag removed legacy-side must not survive by union). Table presence is not probed:
+/// these are TARGET tables, always at current schema.
+fn refresh_children(tx: &Connection, id_map: &BTreeMap<String, String>) -> anyhow::Result<()> {
+    for id in id_map.values() {
+        for table in [
+            "repo_memory_tags",
+            "repo_memory_bindings",
+            "repo_memory_call_paths",
+            "repo_memory_call_path_edges",
+        ] {
+            tx.execute(&format!("DELETE FROM {table} WHERE memory_id = ?1"), [id])?;
+        }
+    }
+    Ok(())
+}
+
+/// The `repo_id` owning memory `id` in the target DB, or `None` when the id is unclaimed.
+fn memory_owner(conn: &Connection, id: &str) -> anyhow::Result<Option<String>> {
+    Ok(conn
+        .query_row("SELECT repo_id FROM repo_memories WHERE id = ?1", [id], |row| {
+            row.get::<_, Option<String>>(0)
+        })
+        .optional()?
+        .flatten())
+}
+
+/// The DETERMINISTIC replacement id for a legacy memory whose original id is owned by a DIFFERENT
+/// repo in the global store: `sha256(repo_id ‖ 0x00 ‖ original_id)`, rendered in the native
+/// `mem_<hex>_<hex>` shape. Deterministic so an import retry (a rename that failed mid-run)
+/// converges on the SAME remapped id instead of minting duplicates.
+fn remapped_memory_id(repo_id: &str, original_id: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(repo_id.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(original_id.as_bytes());
+    let hex: String = hasher.finalize().iter().map(|byte| format!("{byte:02x}")).collect();
+    format!("mem_{}_{}", &hex[..13], &hex[13..25])
+}
+
+/// Copy `repo_memory_bindings`, stamping `repo_id` and NULLing ONLY the LOCAL rowid columns
+/// (`logical_symbol_id` / `symbol_id` / `chunk_id` / `edge_id`) so the validate loop re-resolves
+/// them from the portable anchor after the next index pass (spec §4.5). EVERY portable column is
+/// copied verbatim — including the relocation-provenance set (`symbol_kind`, `signature_hash`,
+/// `moniker_tool`, `moniker_tool_version`, `relocation_reason`): moniker validation reports
+/// `unverified` without `moniker_tool`, and moniker relocation requires both tool fields, so
+/// dropping them would permanently strip imported `scip_moniker` bindings of their oracle-backed
+/// relocation path. The column probes tolerate a legacy DB predating the signals /
+/// moniker-provenance migrations (absent columns import as NULL).
+fn copy_bindings(
+    source: &Connection,
+    tx: &Connection,
+    repo_id: &str,
+    id_map: &BTreeMap<String, String>,
+) -> anyhow::Result<u64> {
+    if !schema::table_exists(source, "repo_memory_bindings")? {
+        return Ok(0);
+    }
+    let symbol_kind = source_column_or_null(source, "symbol_kind")?;
+    let signature_hash = source_column_or_null(source, "signature_hash")?;
+    let moniker_tool = source_column_or_null(source, "moniker_tool")?;
+    let moniker_tool_version = source_column_or_null(source, "moniker_tool_version")?;
+    let relocation_reason = source_column_or_null(source, "relocation_reason")?;
+    let mut stmt = source.prepare(&format!(
+        "SELECT memory_id, binding_kind, binding_id, path, start_line, end_line, commit_hash, \
+         github_owner, github_repo, github_number, anchor_status, created_at_ms, {symbol_kind}, \
+         {signature_hash}, {moniker_tool}, {moniker_tool_version}, {relocation_reason}
+         FROM repo_memory_bindings",
+    ))?;
+    let mut rows = stmt.query([])?;
+    let mut count = 0u64;
+    while let Some(row) = rows.next()? {
+        // Only rows whose parent memory this import OWNS (the id map); an unmapped memory_id is a
+        // dangling orphan in the source — dropped, never attached to a stranger's memory.
+        let Some(memory_id) = id_map.get(&row.get::<_, String>(0)?) else {
+            continue;
+        };
+        let changed = tx.execute(
+            "INSERT OR IGNORE INTO repo_memory_bindings(memory_id, binding_kind, binding_id, \
+             path, start_line, end_line, logical_symbol_id, symbol_id, chunk_id, edge_id, \
+             commit_hash, github_owner, github_repo, github_number, anchor_status, created_at_ms, \
+             symbol_kind, signature_hash, moniker_tool, moniker_tool_version, relocation_reason, \
+             repo_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, NULL, NULL, NULL, ?7, ?8, ?9, ?10, ?11, ?12, \
+             ?13, ?14, ?15, ?16, ?17, ?18)",
+            params![
+                memory_id,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, Option<i64>>(4)?,
+                row.get::<_, Option<i64>>(5)?,
+                row.get::<_, Option<String>>(6)?,
+                row.get::<_, Option<String>>(7)?,
+                row.get::<_, Option<String>>(8)?,
+                row.get::<_, Option<i64>>(9)?,
+                row.get::<_, String>(10)?,
+                row.get::<_, i64>(11)?,
+                row.get::<_, Option<String>>(12)?,
+                row.get::<_, Option<String>>(13)?,
+                row.get::<_, Option<String>>(14)?,
+                row.get::<_, Option<String>>(15)?,
+                row.get::<_, Option<String>>(16)?,
+                repo_id,
+            ],
+        )?;
+        count += changed as u64;
+    }
+    Ok(count)
+}
+
+/// `column` when the SOURCE `repo_memory_bindings` carries it, else a `NULL AS column` literal —
+/// the probe that lets [`copy_bindings`] read one SELECT shape from any legacy vintage. `column`
+/// is a compile-time constant at every call site, never user input.
+fn source_column_or_null(source: &Connection, column: &str) -> anyhow::Result<String> {
+    Ok(if schema::column_exists(source, "repo_memory_bindings", column)? {
+        column.to_string()
+    } else {
+        format!("NULL AS {column}")
+    })
+}
+
+/// Copy `repo_memory_tags` (scoped transitively via `memory_id` — no `repo_id` column; both
+/// columns copied, the full table shape).
+fn copy_tags(
+    source: &Connection,
+    tx: &Connection,
+    id_map: &BTreeMap<String, String>,
+) -> anyhow::Result<u64> {
+    if !schema::table_exists(source, "repo_memory_tags")? {
+        return Ok(0);
+    }
+    let mut stmt = source.prepare("SELECT memory_id, tag FROM repo_memory_tags")?;
+    let mut rows = stmt.query([])?;
+    let mut count = 0u64;
+    while let Some(row) = rows.next()? {
+        let Some(memory_id) = id_map.get(&row.get::<_, String>(0)?) else {
+            continue;
+        };
+        let changed = tx.execute(
+            "INSERT OR IGNORE INTO repo_memory_tags(memory_id, tag) VALUES (?1, ?2)",
+            params![memory_id, row.get::<_, String>(1)?],
+        )?;
+        count += changed as u64;
+    }
+    Ok(count)
+}
+
+/// Copy `repo_memory_call_paths`, NULLing the local `start`/`end_logical_symbol_id` (re-resolved
+/// by the validate loop, like the bindings' rowid columns); the portable identity
+/// (`edge_sequence_hash`, `path_summary`, `created_at_ms`) is copied verbatim.
+fn copy_call_paths(
+    source: &Connection,
+    tx: &Connection,
+    id_map: &BTreeMap<String, String>,
+) -> anyhow::Result<u64> {
+    if !schema::table_exists(source, "repo_memory_call_paths")? {
+        return Ok(0);
+    }
+    let mut stmt = source.prepare(
+        "SELECT memory_id, edge_sequence_hash, path_summary, created_at_ms
+         FROM repo_memory_call_paths",
+    )?;
+    let mut rows = stmt.query([])?;
+    let mut count = 0u64;
+    while let Some(row) = rows.next()? {
+        let Some(memory_id) = id_map.get(&row.get::<_, String>(0)?) else {
+            continue;
+        };
+        let changed = tx.execute(
+            "INSERT OR IGNORE INTO repo_memory_call_paths(memory_id, start_logical_symbol_id, \
+             end_logical_symbol_id, edge_sequence_hash, path_summary, created_at_ms)
+             VALUES (?1, NULL, NULL, ?2, ?3, ?4)",
+            params![
+                memory_id,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(3)?,
+            ],
+        )?;
+        count += changed as u64;
+    }
+    Ok(count)
+}
+
+/// Copy `repo_memory_call_path_edges` verbatim — every column is a row-id-independent portable
+/// identity used to re-find the edge (the full 9-column table shape), so nothing is nulled.
+fn copy_call_path_edges(
+    source: &Connection,
+    tx: &Connection,
+    id_map: &BTreeMap<String, String>,
+) -> anyhow::Result<u64> {
+    if !schema::table_exists(source, "repo_memory_call_path_edges")? {
+        return Ok(0);
+    }
+    let mut stmt = source.prepare(
+        "SELECT memory_id, edge_sequence_hash, ordinal, edge_fingerprint, from_name, to_name, \
+         edge_kind, target_qualified_name, receiver_hint FROM repo_memory_call_path_edges",
+    )?;
+    let mut rows = stmt.query([])?;
+    let mut count = 0u64;
+    while let Some(row) = rows.next()? {
+        let Some(memory_id) = id_map.get(&row.get::<_, String>(0)?) else {
+            continue;
+        };
+        let changed = tx.execute(
+            "INSERT OR IGNORE INTO repo_memory_call_path_edges(memory_id, edge_sequence_hash, \
+             ordinal, edge_fingerprint, from_name, to_name, edge_kind, target_qualified_name, \
+             receiver_hint)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                memory_id,
+                row.get::<_, String>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, String>(5)?,
+                row.get::<_, String>(6)?,
+                row.get::<_, Option<String>>(7)?,
+                row.get::<_, Option<String>>(8)?,
+            ],
+        )?;
+        count += changed as u64;
+    }
+    Ok(count)
+}
+
+/// Copy `embedding_cache` — content-addressed by `input_hash` (which folds model + version + input
+/// text), so `INSERT OR IGNORE` is a conflict-free union — the ONE copy the mirror invariant
+/// exempts, because rows are CONTENT-ADDRESSED: `(input_hash, model_id)` determines the vector
+/// bytes, an existing row is by definition identical (same content) and an extra unreferenced row
+/// is harmless cache. A vector already present (same content)
+/// is kept, a new one is added (the full 6-column table shape). This is the durable unit that
+/// makes re-embedding the consolidated repo a no-op. It is a GLOBAL/shared table (no `repo_id`).
+fn copy_embedding_cache(source: &Connection, tx: &Connection) -> anyhow::Result<u64> {
+    if !schema::table_exists(source, "embedding_cache")? {
+        return Ok(0);
+    }
+    let mut stmt = source.prepare(
+        "SELECT input_hash, model_id, embedding_dim, vector_blob, computed_at_ms, last_used_at_ms
+         FROM embedding_cache",
+    )?;
+    let mut rows = stmt.query([])?;
+    let mut count = 0u64;
+    while let Some(row) = rows.next()? {
+        let changed = tx.execute(
+            "INSERT OR IGNORE INTO embedding_cache(input_hash, model_id, embedding_dim, \
+             vector_blob, computed_at_ms, last_used_at_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, Vec<u8>>(3)?,
+                row.get::<_, i64>(4)?,
+                row.get::<_, i64>(5)?,
+            ],
+        )?;
+        count += changed as u64;
+    }
+    Ok(count)
+}
+
+/// Carry the repo's MODEL STATE as one coherent unit: the portable `repo_meta` keys
+/// ([`CARRIED_META_KEYS`] — identity, freshness version, remote-endpoint config, and the
+/// provisional-provenance flag) plus the active model's `ai_models` READINESS row. Splitting this
+/// across the move breaks it as a set: the cache rows are useless without the model identity, the
+/// identity routes nowhere without the remote config, an absent provisional flag hardens an
+/// auto-pick into a config-immune choice, and an identity pointing at a `MissingModel` row makes
+/// `active_embedder` refuse — semantic search/reconcile "not ready" despite the carried cache
+/// making re-embedding a no-op. Each `repo_meta` carry MIRRORS the source per key (see
+/// [`CARRIED_META_KEYS`]): value-gated upsert when present, delete when absent — counts reflect
+/// rows actually changed, so a no-edit retry reports zero. The legacy DB is single-repo, so
+/// values are read by KEY regardless of the source's own `repo_id`.
+fn copy_model_state(source: &Connection, tx: &Connection, repo_id: &str) -> anyhow::Result<u64> {
+    if !schema::table_exists(source, "repo_meta")? {
+        return Ok(0);
+    }
+    let mut count = 0u64;
+    let mut active_model: Option<String> = None;
+    for key in CARRIED_META_KEYS {
+        let value: Option<String> = source
+            .query_row("SELECT value FROM repo_meta WHERE key = ?1 LIMIT 1", [key], |row| {
+                row.get(0)
+            })
+            .optional()?
+            .flatten();
+        let changed = match value {
+            Some(value) => {
+                if *key == "active_embedding_model" {
+                    active_model = Some(value.clone());
+                }
+                tx.execute(
+                    "INSERT INTO repo_meta(repo_id, key, value) VALUES (?1, ?2, ?3)
+                     ON CONFLICT(repo_id, key) DO UPDATE SET value = excluded.value
+                     WHERE repo_meta.value IS NOT excluded.value",
+                    params![repo_id, key, value],
+                )?
+            },
+            // Absent in the authoritative source: a window model switch may have REMOVED the key
+            // (absence has meaning — batch 6); a surviving stale copy would tear the unit.
+            None => tx
+                .execute("DELETE FROM repo_meta WHERE repo_id = ?1 AND key = ?2", params![
+                    repo_id, key
+                ])?,
+        };
+        count += changed as u64;
+    }
+    if let Some(model_id) = active_model {
+        carry_active_model_readiness(source, tx, &model_id)?;
+    }
+    Ok(count)
+}
+
+/// Carry the active model's `ai_models` READINESS onto the target when the legacy DB holds it
+/// Ready and the target does not. WHY carrying `Ready` is sound here: consolidation is
+/// SAME-MACHINE by construction, and `Ready` asserts machine-level availability — fastembed
+/// artifacts live in the machine-global HF cache (which `recover_cached_fastembed_model` re-probes
+/// on scoped opens, so a stale carry self-corrects), remote runtimes reconstruct their transport
+/// from the carried `active_embedding_remote_config` at use time, and the hash model needs no
+/// artifacts at all. A misjudged carry surfaces as a use-time embed error and is repaired by
+/// install/recovery — never data corruption. GUARD: a target row with `disabled = 1` is an
+/// explicit machine-level opt-out shared by every repo in the global DB — never overridden.
+fn carry_active_model_readiness(
+    source: &Connection,
+    tx: &Connection,
+    model_id: &str,
+) -> anyhow::Result<()> {
+    if !schema::table_exists(source, "ai_models")? {
+        return Ok(());
+    }
+    // Only a legacy row that is genuinely Ready (installed, not disabled) is worth carrying.
+    let legacy: Option<(Option<i64>, String, Option<i64>)> = source
+        .query_row(
+            "SELECT embedding_dim, runtime, installed_at_ms FROM ai_models
+             WHERE model_id = ?1 AND installed = 1 AND disabled = 0 AND status = 'Ready'",
+            [model_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .optional()?;
+    let Some((embedding_dim, runtime, installed_at_ms)) = legacy else {
+        return Ok(());
+    };
+    // Absent on the target → seed the full row Ready.
+    let changed = tx.execute(
+        "INSERT OR IGNORE INTO ai_models(model_id, capability, embedding_dim, runtime, installed, \
+         disabled, status, installed_at_ms, last_error)
+         VALUES (?1, 'embedding', ?2, ?3, 1, 0, 'Ready', ?4, NULL)",
+        params![model_id, embedding_dim, runtime, installed_at_ms],
+    )?;
+    if changed > 0 {
+        return Ok(());
+    }
+    // Present but not usable (e.g. the manifest seeded it `MissingModel`) → restore the legacy
+    // readiness, UNLESS explicitly disabled on the target (machine-level opt-out wins).
+    tx.execute(
+        "UPDATE ai_models
+         SET installed = 1, status = 'Ready', embedding_dim = ?2, runtime = ?3,
+             installed_at_ms = ?4, last_error = NULL
+         WHERE model_id = ?1 AND disabled = 0 AND NOT (installed = 1 AND status = 'Ready')",
+        params![model_id, embedding_dim, runtime, installed_at_ms],
+    )?;
+    Ok(())
+}
+
+/// Re-derive the `repo_memory_fts` mirror for `repo_id` from the freshly-imported base tables —
+/// the V042-rebuild shape (same space-joined tag derivation as `upsert_memory_fts`). Runs inside
+/// the import transaction. Delete-then-insert scoped to the repo keeps a retry convergent (the
+/// mirror has no PK, so re-inserting would otherwise accumulate duplicate rows) and re-derives any
+/// pre-existing global-side memories of this repo to identical content.
+fn rebuild_memory_fts_for_repo(tx: &Connection, repo_id: &str) -> anyhow::Result<()> {
+    tx.execute("DELETE FROM repo_memory_fts WHERE repo_id = ?1", [repo_id])?;
+    tx.execute(
+        "INSERT INTO repo_memory_fts(repo_id, memory_id, title, body, kind, tags)
+         SELECT
+             m.repo_id, m.id, m.title, m.body, m.kind,
+             COALESCE(
+                 (SELECT group_concat(t.tag, ' ')
+                  FROM repo_memory_tags t WHERE t.memory_id = m.id),
+                 ''
+             )
+         FROM repo_memories m
+         WHERE m.repo_id = ?1",
+        [repo_id],
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    use super::*;
+
+    /// A source legacy DB (current schema) seeded with 3 memories — one carrying a binding whose
+    /// LOCAL rowid columns are set alongside FULL relocation provenance (symbol_kind /
+    /// signature_hash / moniker trio), a tag, a call-path + edge — plus 2 embedding-cache rows and
+    /// the model-identity meta keys.
+    fn seeded_source() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        for (id, title) in [("m1", "one"), ("m2", "two"), ("m3", "three")] {
+            conn.execute(
+                "INSERT INTO repo_memories(id, kind, title, body, confidence, status, \
+                 created_at_ms, updated_at_ms, source, memory_version, repo_id)
+                 VALUES (?1, 'Invariant', ?2, 'body', 'high', 'active', 0, 0, 'agent', 'v1', \
+                 'legacy-repo')",
+                params![id, title],
+            )
+            .unwrap();
+        }
+        // A binding on m1 with the LOCAL rowid columns populated (must be NULLed on import) and
+        // EVERY portable field set (must survive verbatim), including the moniker relocation
+        // provenance.
+        conn.execute(
+            "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id, path, \
+             start_line, end_line, logical_symbol_id, symbol_id, chunk_id, edge_id, commit_hash, \
+             github_owner, github_repo, github_number, anchor_status, created_at_ms, symbol_kind, \
+             signature_hash, moniker_tool, moniker_tool_version, relocation_reason, repo_id)
+             VALUES ('m1', 'path', 'b1', 'src/x.rs', 10, 20, 111, 222, 333, 444, 'abc', 'o', 'r', \
+             7, 'current', 0, 'function', 'sighash', 'scip-rust', '0.4', 'moved', 'legacy-repo')",
+            [],
+        )
+        .unwrap();
+        conn.execute("INSERT INTO repo_memory_tags(memory_id, tag) VALUES ('m1', 'tagalpha')", [])
+            .unwrap();
+        conn.execute(
+            "INSERT INTO repo_memory_call_paths(memory_id, start_logical_symbol_id, \
+             end_logical_symbol_id, edge_sequence_hash, path_summary, created_at_ms)
+             VALUES ('m1', 555, 666, 'h1', 'a -> b', 0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO repo_memory_call_path_edges(memory_id, edge_sequence_hash, ordinal, \
+             edge_fingerprint, to_name, edge_kind) VALUES ('m1', 'h1', 0, 'fp', 'b', 'calls')",
+            [],
+        )
+        .unwrap();
+        for (hash, dim) in [("ih1", 384), ("ih2", 768)] {
+            conn.execute(
+                "INSERT INTO embedding_cache(input_hash, model_id, embedding_dim, vector_blob, \
+                 computed_at_ms, last_used_at_ms) VALUES (?1, 'model-a', ?2, X'00', 0, 0)",
+                params![hash, dim],
+            )
+            .unwrap();
+        }
+        // Seed the meta under the placeholder (which always exists in `repos`, so the FK holds);
+        // `copy_model_state` reads it by KEY regardless of the source's repo_id. Keys from both
+        // classification classes: three PORTABLE keys (identity, remote config, and the
+        // provisional flag — an auto-picked model, "1") and one DB-LOCAL freshness cursor (must
+        // NOT copy).
+        for (key, value) in [
+            ("active_embedding_model", "model-a"),
+            ("active_embedding_remote_config", "{\"endpoint\":\"http://ollama:11434\"}"),
+            ("active_embedding_model_provisional", "1"),
+            ("git_commit", "cursor-sha"),
+        ] {
+            conn.execute(
+                "INSERT INTO repo_meta(repo_id, key, value) VALUES ('__unassigned__', ?1, ?2)",
+                params![key, value],
+            )
+            .unwrap();
+        }
+        // The active model's READINESS row — part of the model-state unit `copy_model_state`
+        // carries (an identity pointing at a MissingModel/absent row leaves active_embedder
+        // refusing despite the carried cache).
+        conn.execute(
+            "INSERT INTO ai_models(model_id, capability, embedding_dim, runtime, installed, \
+             disabled, status, installed_at_ms) VALUES ('model-a', 'embedding', 384, 'local', 1, \
+             0, 'Ready', 7)",
+            [],
+        )
+        .unwrap();
+        conn
+    }
+
+    fn fresh_target() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        // The target must hold the repo `import_from_source` stamps: `repo_meta.repo_id` has a FK
+        // to `repos` (in production `register_repo` creates this row before the import runs).
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('global-repo', \
+             'g', 0)",
+            [],
+        )
+        .unwrap();
+        conn
+    }
+
+    fn count(conn: &Connection, sql: &str) -> i64 {
+        conn.query_row(sql, [], |row| row.get(0)).unwrap()
+    }
+
+    #[test]
+    fn import_stamps_the_new_repo_id_and_nulls_local_rowids() {
+        let source = seeded_source();
+        let target = fresh_target();
+        let counts = import_from_source(&source, &target, "global-repo").unwrap();
+
+        assert_eq!(counts.memories, 3);
+        assert_eq!(counts.bindings, 1);
+        assert_eq!(counts.tags, 1);
+        assert_eq!(counts.call_paths, 1);
+        assert_eq!(counts.call_path_edges, 1);
+        assert_eq!(counts.embedding_cache_rows, 2);
+        assert_eq!(
+            counts.meta_keys, 3,
+            "the portable model-state keys carried (identity + remote config + provisional)",
+        );
+
+        // Every memory + binding is stamped the NEW repo id, never the legacy one.
+        assert_eq!(
+            count(&target, "SELECT COUNT(*) FROM repo_memories WHERE repo_id='global-repo'"),
+            3
+        );
+        assert_eq!(
+            count(&target, "SELECT COUNT(*) FROM repo_memories WHERE repo_id='legacy-repo'"),
+            0
+        );
+        assert_eq!(
+            count(&target, "SELECT COUNT(*) FROM repo_memory_bindings WHERE repo_id='global-repo'"),
+            1,
+        );
+
+        // The binding's LOCAL rowid columns are all NULLed (re-resolved by the validate loop).
+        let nulled = count(
+            &target,
+            "SELECT COUNT(*) FROM repo_memory_bindings WHERE memory_id='m1' AND logical_symbol_id \
+             IS NULL AND symbol_id IS NULL AND chunk_id IS NULL AND edge_id IS NULL",
+        );
+        assert_eq!(nulled, 1, "local rowids nulled for re-resolution");
+        // Its portable fields survive.
+        let (path, commit, num): (Option<String>, Option<String>, Option<i64>) = target
+            .query_row(
+                "SELECT path, commit_hash, github_number FROM repo_memory_bindings WHERE \
+                 memory_id='m1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(path.as_deref(), Some("src/x.rs"), "portable path survives");
+        assert_eq!(commit.as_deref(), Some("abc"));
+        assert_eq!(num, Some(7));
+
+        // Call-path logical ids are NULLed too; the edge is copied verbatim.
+        let (start, end): (Option<i64>, Option<i64>) = target
+            .query_row(
+                "SELECT start_logical_symbol_id, end_logical_symbol_id FROM \
+                 repo_memory_call_paths WHERE memory_id='m1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!((start, end), (None, None));
+
+        // Both content-addressed cache rows landed, and the model meta key was carried.
+        assert_eq!(count(&target, "SELECT COUNT(*) FROM embedding_cache"), 2);
+        assert_eq!(
+            count(
+                &target,
+                "SELECT COUNT(*) FROM repo_meta WHERE repo_id='global-repo' AND \
+                 key='active_embedding_model'"
+            ),
+            1,
+        );
+    }
+
+    /// The relocation-provenance columns (`symbol_kind`, `signature_hash`, `moniker_tool`,
+    /// `moniker_tool_version`, `relocation_reason`) survive the import verbatim — dropping them
+    /// would strip imported `scip_moniker` bindings of validation (`unverified` without
+    /// `moniker_tool`) and of the oracle-backed relocation path (which requires both tool fields).
+    #[test]
+    fn import_preserves_moniker_binding_provenance() {
+        let source = seeded_source();
+        let target = fresh_target();
+        import_from_source(&source, &target, "global-repo").unwrap();
+
+        let provenance = |column: &str| -> Option<String> {
+            target
+                .query_row(
+                    &format!("SELECT {column} FROM repo_memory_bindings WHERE memory_id='m1'"),
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap()
+        };
+        assert_eq!(provenance("symbol_kind").as_deref(), Some("function"));
+        assert_eq!(provenance("signature_hash").as_deref(), Some("sighash"));
+        assert_eq!(provenance("moniker_tool").as_deref(), Some("scip-rust"));
+        assert_eq!(provenance("moniker_tool_version").as_deref(), Some("0.4"));
+        assert_eq!(provenance("relocation_reason").as_deref(), Some("moved"));
+    }
+
+    /// Imported memories are reachable through KEYWORD search: `memory_search` retrieves
+    /// exclusively through the `repo_memory_fts` mirror, whose only other writers are
+    /// `upsert_memory_fts` (create/update) and the one-time V042 rebuild — so the import must
+    /// re-derive it, or the whole imported corpus stays invisible to search forever.
+    #[test]
+    fn imported_memories_are_findable_via_memory_fts() {
+        let source = seeded_source();
+        let target = fresh_target();
+        import_from_source(&source, &target, "global-repo").unwrap();
+
+        let hits: i64 = target
+            .query_row(
+                "SELECT COUNT(*) FROM repo_memory_fts WHERE repo_memory_fts MATCH 'three' AND \
+                 repo_id = 'global-repo'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(hits, 1, "an imported memory matches by its title words");
+        // The tag derivation matches upsert_memory_fts (space-joined), so tag words match too.
+        let tag_hits: i64 = target
+            .query_row(
+                "SELECT COUNT(*) FROM repo_memory_fts WHERE repo_memory_fts MATCH 'tagalpha' AND \
+                 repo_id = 'global-repo'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(tag_hits, 1, "an imported memory matches by its tag");
+    }
+
+    #[test]
+    fn import_is_idempotent_and_reports_honest_counts() {
+        let source = seeded_source();
+        let target = fresh_target();
+        let first = import_from_source(&source, &target, "global-repo").unwrap();
+        assert_eq!(first.memories, 3);
+        // A second import (a retry after a rename that never happened) inserts no duplicates AND
+        // reports ZERO copies — the summary must not claim work the `INSERT OR IGNORE`s skipped.
+        let second = import_from_source(&source, &target, "global-repo").unwrap();
+        assert_eq!(second.memories, 0, "re-run reports zero memories copied");
+        assert_eq!(second.bindings, 0);
+        assert_eq!(second.tags, 0);
+        assert_eq!(second.call_paths, 0);
+        assert_eq!(second.call_path_edges, 0);
+        assert_eq!(second.embedding_cache_rows, 0);
+        assert_eq!(second.meta_keys, 0);
+        assert_eq!(count(&target, "SELECT COUNT(*) FROM repo_memories"), 3);
+        assert_eq!(count(&target, "SELECT COUNT(*) FROM repo_memory_bindings"), 1);
+        assert_eq!(count(&target, "SELECT COUNT(*) FROM embedding_cache"), 2);
+        // The FTS mirror re-derivation is convergent too — one row per memory, not accumulated.
+        assert_eq!(
+            count(&target, "SELECT COUNT(*) FROM repo_memory_fts WHERE repo_id='global-repo'"),
+            3
+        );
+        // Zero-diff content: the no-edit retry converged — the target rows still carry the
+        // source content verbatim (the gated upsert wrote NOTHING, it didn't rewrite in place).
+        let (title, body): (String, String) = target
+            .query_row("SELECT title, body FROM repo_memories WHERE id='m1'", [], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .unwrap();
+        assert_eq!((title.as_str(), body.as_str()), ("one", "body"));
+    }
+
+    /// The CRASH-CREATED divergence window (Codex batch 8, finding 4): the import txn commits,
+    /// the RENAME fails, the legacy file stays the LIVE store (keyless resolution keeps serving
+    /// it), and the user edits a memory there. The retry must carry those edits into the global
+    /// store — content upserted, children REPLACED (a tag removed legacy-side must not survive by
+    /// union) — because the legacy always wins until the rename lands. Counts stay honest (only
+    /// the actually-refreshed memory reports), and a further no-edit retry is a true no-op.
+    #[test]
+    fn a_retry_after_a_failed_rename_carries_legacy_edits_made_in_the_window() {
+        let source = seeded_source();
+        let target = fresh_target();
+        import_from_source(&source, &target, "global-repo").unwrap();
+        // ... the rename fails here; the legacy DB stays live and the user edits m1: new body,
+        // tag set REPLACED (alpha removed, window added), binding re-anchored. Every authored
+        // mutation path bumps `updated_at_ms` (update_memory / rebind_memory), mirrored here.
+        source
+            .execute(
+                "UPDATE repo_memories SET body='edited in the window', updated_at_ms=99 WHERE \
+                 id='m1'",
+                [],
+            )
+            .unwrap();
+        source.execute("DELETE FROM repo_memory_tags WHERE memory_id='m1'", []).unwrap();
+        source
+            .execute("INSERT INTO repo_memory_tags(memory_id, tag) VALUES ('m1','window-tag')", [])
+            .unwrap();
+        source
+            .execute("UPDATE repo_memory_bindings SET path='src/y.rs' WHERE memory_id='m1'", [])
+            .unwrap();
+
+        let counts = import_from_source(&source, &target, "global-repo").unwrap();
+        assert_eq!(counts.memories, 1, "only the edited memory reports as written");
+        assert_eq!(counts.tags, 1, "the replaced tag set reports its reinserted row");
+        assert_eq!(counts.bindings, 1);
+
+        let body: String = target
+            .query_row("SELECT body FROM repo_memories WHERE id='m1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(body, "edited in the window", "the legacy edit wins in the global store");
+        let tags: Vec<String> = target
+            .prepare("SELECT tag FROM repo_memory_tags WHERE memory_id='m1' ORDER BY tag")
+            .unwrap()
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(tags, ["window-tag"], "children are REPLACED — the removed tag is gone");
+        let path: String = target
+            .query_row("SELECT path FROM repo_memory_bindings WHERE memory_id='m1'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(path, "src/y.rs");
+        // The FTS mirror carries the refreshed body — the edit is immediately searchable.
+        assert_eq!(
+            count(
+                &target,
+                "SELECT COUNT(*) FROM repo_memory_fts WHERE repo_id='global-repo' AND \
+                 repo_memory_fts MATCH 'window'"
+            ),
+            1
+        );
+        // Untouched memories reported nothing and kept their rows: convergence.
+        let third = import_from_source(&source, &target, "global-repo").unwrap();
+        assert_eq!(third.memories, 0, "a further no-edit retry is a true no-op");
+        assert_eq!(third.tags, 0);
+        assert_eq!(third.bindings, 0);
+        assert_eq!(count(&target, "SELECT COUNT(*) FROM repo_memories"), 3);
+        assert_eq!(count(&target, "SELECT COUNT(*) FROM repo_memory_tags"), 1);
+    }
+
+    /// The mirror invariant covers REMAPPED parents too (Codex batch 9): a memory whose id
+    /// collided with another repo's row imports under the remapped id — a window edit to it
+    /// legacy-side must still refresh the remapped row AND replace its children on retry. The
+    /// batch-8 parent-edit gate missed exactly this (it tested the SOURCE id's owner, which stays
+    /// foreign); the unconditional child replace closes the shape. The foreign row stays
+    /// untouched throughout.
+    #[test]
+    fn a_retry_carries_window_edits_to_a_remapped_memory() {
+        let source = seeded_source();
+        let target = fresh_target();
+        // The global store already owns "m1" under a different repo — the import remaps.
+        target
+            .execute(
+                "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('other-repo', \
+                 'o', 0)",
+                [],
+            )
+            .unwrap();
+        target
+            .execute(
+                "INSERT INTO repo_memories(id, kind, title, body, confidence, status, \
+                 created_at_ms, updated_at_ms, source, memory_version, repo_id)
+                 VALUES ('m1', 'Risk', 'other title', 'other body', 'low', 'active', 0, 0, \
+                 'agent', 'v1', 'other-repo')",
+                [],
+            )
+            .unwrap();
+        import_from_source(&source, &target, "global-repo").unwrap();
+        let remapped = remapped_memory_id("global-repo", "m1");
+
+        // ... rename fails; the user edits m1 in the still-live legacy DB: body + tag replaced.
+        source
+            .execute(
+                "UPDATE repo_memories SET body='remapped window edit', updated_at_ms=99 WHERE \
+                 id='m1'",
+                [],
+            )
+            .unwrap();
+        source.execute("DELETE FROM repo_memory_tags WHERE memory_id='m1'", []).unwrap();
+        source
+            .execute("INSERT INTO repo_memory_tags(memory_id, tag) VALUES ('m1','remap-tag')", [])
+            .unwrap();
+
+        let counts = import_from_source(&source, &target, "global-repo").unwrap();
+        assert_eq!(counts.memories, 1, "the remapped parent's refresh reports honestly");
+
+        let body: String = target
+            .query_row("SELECT body FROM repo_memories WHERE id=?1", [&remapped], |r| r.get(0))
+            .unwrap();
+        assert_eq!(body, "remapped window edit", "the window edit reaches the REMAPPED row");
+        let tags: Vec<String> = target
+            .prepare("SELECT tag FROM repo_memory_tags WHERE memory_id=?1 ORDER BY tag")
+            .unwrap()
+            .query_map([&remapped], |r| r.get(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(tags, ["remap-tag"], "the remapped parent's children are replaced, not unioned");
+        // The FTS mirror covers the remapped refresh (whole-repo re-derive).
+        assert_eq!(
+            count(
+                &target,
+                "SELECT COUNT(*) FROM repo_memory_fts WHERE repo_id='global-repo' AND \
+                 repo_memory_fts MATCH 'remapped'"
+            ),
+            1
+        );
+        // The foreign owner of the ORIGINAL id is untouched — content and children.
+        let (other_title, other_repo): (String, String) = target
+            .query_row("SELECT title, repo_id FROM repo_memories WHERE id='m1'", [], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .unwrap();
+        assert_eq!((other_title.as_str(), other_repo.as_str()), ("other title", "other-repo"));
+
+        // Convergence: a no-edit retry reports zeros.
+        let third = import_from_source(&source, &target, "global-repo").unwrap();
+        assert_eq!(third.memories, 0);
+        assert_eq!(third.tags, 0);
+    }
+
+    /// The mirror invariant on the MODEL-STATE unit (Codex batch 9): a model switch made in the
+    /// crash-retry window — new active model, bumped freshness version, the remote config KEY
+    /// REMOVED (moving remote → local) — is carried whole by the retry: values upserted, the
+    /// absent key deleted, the NEW model's readiness restored. A no-edit retry reports zero meta
+    /// keys.
+    #[test]
+    fn a_retry_carries_a_window_model_switch() {
+        let source = seeded_source();
+        let target = fresh_target();
+        import_from_source(&source, &target, "global-repo").unwrap();
+
+        // ... rename fails; the user switches models in the still-live legacy DB.
+        source
+            .execute("UPDATE repo_meta SET value='model-b' WHERE key='active_embedding_model'", [])
+            .unwrap();
+        source
+            .execute("DELETE FROM repo_meta WHERE key='active_embedding_remote_config'", [])
+            .unwrap();
+        source
+            .execute(
+                "INSERT INTO ai_models(model_id, capability, embedding_dim, runtime, installed, \
+                 disabled, status, installed_at_ms, last_error)
+                 VALUES ('model-b', 'embedding', 512, 'fastembed', 1, 0, 'Ready', 7, NULL)",
+                [],
+            )
+            .unwrap();
+
+        let counts = import_from_source(&source, &target, "global-repo").unwrap();
+        assert!(counts.meta_keys >= 2, "the upserted model + deleted remote config both report");
+
+        let meta = |key: &str| -> Option<String> {
+            target
+                .query_row(
+                    "SELECT value FROM repo_meta WHERE repo_id='global-repo' AND key=?1",
+                    [key],
+                    |r| r.get(0),
+                )
+                .optional()
+                .unwrap()
+        };
+        assert_eq!(meta("active_embedding_model").as_deref(), Some("model-b"));
+        assert_eq!(
+            meta("active_embedding_remote_config"),
+            None,
+            "the key removed legacy-side is removed here too — absence has meaning"
+        );
+        // The NEW model's readiness restored on the retry (re-derived from the source each run).
+        let status: String = target
+            .query_row("SELECT status FROM ai_models WHERE model_id='model-b'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(status, "Ready");
+
+        let third = import_from_source(&source, &target, "global-repo").unwrap();
+        assert_eq!(third.meta_keys, 0, "a no-edit retry writes no meta");
+    }
+
+    /// A memory id already owned by a DIFFERENT repo in the global store (a pre-repo-vintage id,
+    /// or a copied index) is REMAPPED — never dropped, and its children never attach to the other
+    /// repo's memory. The remap is deterministic, so a retry converges instead of duplicating.
+    #[test]
+    fn import_remaps_a_memory_id_owned_by_another_repo() {
+        let source = seeded_source();
+        let target = fresh_target();
+        // The global store already holds a DIFFERENT repo's memory under the id "m1" (m1 is the
+        // source memory that carries the binding/tag/call-path children), with its own tag.
+        target
+            .execute(
+                "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('other-repo', \
+                 'o', 0)",
+                [],
+            )
+            .unwrap();
+        target
+            .execute(
+                "INSERT INTO repo_memories(id, kind, title, body, confidence, status, \
+                 created_at_ms, updated_at_ms, source, memory_version, repo_id)
+                 VALUES ('m1', 'Risk', 'other title', 'other body', 'low', 'active', 0, 0, \
+                 'agent', 'v1', 'other-repo')",
+                [],
+            )
+            .unwrap();
+        target
+            .execute("INSERT INTO repo_memory_tags(memory_id, tag) VALUES ('m1', 'other-tag')", [])
+            .unwrap();
+
+        let counts = import_from_source(&source, &target, "global-repo").unwrap();
+        assert_eq!(counts.memories, 3, "the colliding memory is remapped, not dropped");
+
+        // The other repo's memory is untouched — content, ownership, and its own children.
+        let (other_title, other_repo): (String, String) = target
+            .query_row("SELECT title, repo_id FROM repo_memories WHERE id='m1'", [], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .unwrap();
+        assert_eq!(other_title, "other title", "the other repo's memory content is untouched");
+        assert_eq!(other_repo, "other-repo");
+        let other_tags: i64 = target
+            .query_row("SELECT COUNT(*) FROM repo_memory_tags WHERE memory_id='m1'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(other_tags, 1, "no imported child attached to the other repo's memory id");
+
+        // The imported memory landed under the DETERMINISTIC remapped id, with its children.
+        let new_id = remapped_memory_id("global-repo", "m1");
+        let (title, repo): (String, String) = target
+            .query_row("SELECT title, repo_id FROM repo_memories WHERE id = ?1", [&new_id], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .unwrap();
+        assert_eq!(title, "one", "the source memory's content imported under the remapped id");
+        assert_eq!(repo, "global-repo");
+        for (table, expected) in [
+            ("repo_memory_bindings", 1i64),
+            ("repo_memory_tags", 1),
+            ("repo_memory_call_paths", 1),
+            ("repo_memory_call_path_edges", 1),
+        ] {
+            let rows: i64 = target
+                .query_row(
+                    &format!("SELECT COUNT(*) FROM {table} WHERE memory_id = ?1"),
+                    [&new_id],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(rows, expected, "{table}: children follow the remapped id");
+        }
+
+        // RETRY: the deterministic remap converges — zero new rows, no duplicate remapped copies.
+        let retry = import_from_source(&source, &target, "global-repo").unwrap();
+        assert_eq!(retry.memories, 0, "the retry re-derives the SAME remapped id and no-ops");
+        let remapped_copies: i64 = target
+            .query_row(
+                "SELECT COUNT(*) FROM repo_memories WHERE repo_id='global-repo' AND title='one'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(remapped_copies, 1, "exactly one remapped copy across retries");
+    }
+
+    /// A dangling child row in the SOURCE (its memory_id absent from the source's repo_memories,
+    /// while a memory with that id exists in the target under ANOTHER repo) is skipped — the
+    /// child-ownership invariant: children only ever insert under a parent id this import owns.
+    #[test]
+    fn import_skips_orphan_children_instead_of_attaching_them_across_repos() {
+        let source = seeded_source();
+        // A dangling tag in the source referencing a memory the source does NOT hold. The child
+        // tables carry no FK in some legacy vintages; simulate by deleting the parent after
+        // inserting the tag under FK-off.
+        source.execute_batch("PRAGMA foreign_keys = OFF").unwrap();
+        source
+            .execute(
+                "INSERT INTO repo_memory_tags(memory_id, tag) VALUES ('foreign-mem', 'stray')",
+                [],
+            )
+            .unwrap();
+
+        let target = fresh_target();
+        // The target holds 'foreign-mem' under ANOTHER repo — the row the orphan child would have
+        // contaminated.
+        target
+            .execute(
+                "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('other-repo', \
+                 'o', 0)",
+                [],
+            )
+            .unwrap();
+        target
+            .execute(
+                "INSERT INTO repo_memories(id, kind, title, body, confidence, status, \
+                 created_at_ms, updated_at_ms, source, memory_version, repo_id)
+                 VALUES ('foreign-mem', 'Risk', 't', 'b', 'low', 'active', 0, 0, 'agent', 'v1', \
+                 'other-repo')",
+                [],
+            )
+            .unwrap();
+
+        import_from_source(&source, &target, "global-repo").unwrap();
+        let stray: i64 = target
+            .query_row(
+                "SELECT COUNT(*) FROM repo_memory_tags WHERE memory_id='foreign-mem'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stray, 0, "an orphan source child never attaches to another repo's memory");
+    }
+
+    /// The mirror invariant on the model-state unit (Codex batch 9, SUPERSEDES the batch-4
+    /// "config-seeded value wins" posture): the legacy DB is the LIVE store for this repo until
+    /// the rename lands — nothing else can legitimately write this repo's meta mid-consolidate
+    /// (the import holds the repo's write locks; the target migrate is schema-only), so a target
+    /// value that differs is a STALE copy from a previous crashed run and the source must win.
+    #[test]
+    fn carried_meta_mirrors_the_source_over_a_stale_target_value() {
+        let source = seeded_source();
+        let target = fresh_target();
+        // A previous crashed run copied an older model choice; the window changed it legacy-side.
+        target
+            .execute(
+                "INSERT INTO repo_meta(repo_id, key, value) VALUES ('global-repo', \
+                 'active_embedding_model', 'stale-model')",
+                [],
+            )
+            .unwrap();
+        import_from_source(&source, &target, "global-repo").unwrap();
+        let value: String = target
+            .query_row(
+                "SELECT value FROM repo_meta WHERE repo_id='global-repo' AND \
+                 key='active_embedding_model'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(value, "model-a", "the authoritative legacy value replaces the stale copy");
+    }
+
+    /// The `repo_meta` classification (see [`CARRIED_META_KEYS`]): repo-PORTABLE configuration is
+    /// carried verbatim — including `active_embedding_remote_config`, which `active_embedder()`
+    /// reconstructs the remote transport from (dropping it silently rerouted post-consolidation
+    /// searches to the local backend until reinstall) — while DB-LOCAL state (freshness cursors,
+    /// transient install markers) never crosses.
+    #[test]
+    fn import_carries_portable_meta_and_leaves_db_local_state() {
+        let source = seeded_source();
+        let target = fresh_target();
+        import_from_source(&source, &target, "global-repo").unwrap();
+
+        let meta = |key: &str| -> Option<String> {
+            target
+                .query_row(
+                    "SELECT value FROM repo_meta WHERE repo_id='global-repo' AND key=?1",
+                    [key],
+                    |r| r.get(0),
+                )
+                .optional()
+                .unwrap()
+        };
+        assert_eq!(meta("active_embedding_model").as_deref(), Some("model-a"));
+        assert_eq!(
+            meta("active_embedding_remote_config").as_deref(),
+            Some("{\"endpoint\":\"http://ollama:11434\"}"),
+            "the remote-endpoint config survives verbatim — active_embedder routes remote",
+        );
+        assert_eq!(meta("git_commit"), None, "freshness cursors never cross (DB-local)");
+        // The provisional flag is SEMANTIC state: absent ⇒ non-provisional (config-immune explicit
+        // choice), so an auto-picked "1" must cross or `seed_active_embedding_model` could no
+        // longer override the model from config post-consolidation.
+        assert_eq!(
+            meta("active_embedding_model_provisional").as_deref(),
+            Some("1"),
+            "the provisional auto-pick provenance survives — config can still override",
+        );
+        // And the model-state unit includes the ai_models READINESS row: identity without it
+        // points at MissingModel and active_embedder refuses despite the carried cache.
+        let (installed, status): (i64, String) = target
+            .query_row(
+                "SELECT installed, status FROM ai_models WHERE model_id='model-a'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!((installed, status.as_str()), (1, "Ready"), "readiness row carried");
+    }
+
+    /// The readiness carry's two guarded shapes: a target row stuck at `MissingModel` (the
+    /// manifest's fresh-DB seed) is RESTORED to the legacy Ready state; a target row the machine
+    /// explicitly DISABLED is never overridden (the opt-out is shared by every repo in the global
+    /// DB).
+    #[test]
+    fn readiness_carry_restores_missing_model_but_respects_disabled() {
+        let source = seeded_source();
+
+        // Target seeded MissingModel (what ensure_model_manifest writes on a fresh DB) → restored.
+        let target = fresh_target();
+        target
+            .execute(
+                "INSERT INTO ai_models(model_id, capability, embedding_dim, runtime, installed, \
+                 disabled, status) VALUES ('model-a', 'embedding', 384, 'local', 0, 0, \
+                 'MissingModel')",
+                [],
+            )
+            .unwrap();
+        import_from_source(&source, &target, "global-repo").unwrap();
+        let (installed, status): (i64, String) = target
+            .query_row(
+                "SELECT installed, status FROM ai_models WHERE model_id='model-a'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            (installed, status.as_str()),
+            (1, "Ready"),
+            "a MissingModel manifest seed is restored from the legacy Ready row",
+        );
+
+        // Target explicitly disabled → untouched.
+        let target = fresh_target();
+        target
+            .execute(
+                "INSERT INTO ai_models(model_id, capability, embedding_dim, runtime, installed, \
+                 disabled, status) VALUES ('model-a', 'embedding', 384, 'local', 0, 1, \
+                 'MissingModel')",
+                [],
+            )
+            .unwrap();
+        import_from_source(&source, &target, "global-repo").unwrap();
+        let (installed, disabled, status): (i64, i64, String) = target
+            .query_row(
+                "SELECT installed, disabled, status FROM ai_models WHERE model_id='model-a'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            (installed, disabled, status.as_str()),
+            (0, 1, "MissingModel"),
+            "an explicit machine-level disable is never overridden by a carry",
+        );
+    }
+
+    #[test]
+    fn imported_marker_appends_the_suffix() {
+        assert_eq!(
+            imported_marker(Path::new("/repo/.rag-rat/index.sqlite")),
+            PathBuf::from("/repo/.rag-rat/index.sqlite.imported"),
+        );
+    }
+
+    /// The WAL sidecars travel with the `.imported` archive: a bare main-file rename would orphan
+    /// `-wal`/`-shm` as permanent litter, and an un-checkpointed `-wal` (a busy checkpoint under a
+    /// concurrent lockless reader — a sanctioned state) holds frames that BELONG to the archive.
+    /// Renaming them alongside is what keeps the archive whole regardless of checkpoint outcome —
+    /// the pinned BUSY posture.
+    #[test]
+    fn wal_sidecars_travel_with_the_imported_archive() {
+        let dir =
+            std::env::temp_dir().join(format!("ragrat-sidecars-{}-{:p}", std::process::id(), &()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let source = dir.join("index.sqlite");
+        let imported = imported_marker(&source);
+        // Simulate the post-rename state with LEFTOVER sidecars (incl. an un-checkpointed wal).
+        fs::write(&source, b"db").unwrap();
+        fs::write(path_with_suffix(&source, "-wal"), b"frames").unwrap();
+        fs::write(path_with_suffix(&source, "-shm"), b"shm").unwrap();
+        fs::rename(&source, &imported).unwrap();
+
+        rename_wal_sidecars(&source, &imported);
+
+        for suffix in ["-wal", "-shm"] {
+            assert!(
+                !path_with_suffix(&source, suffix).exists(),
+                "no {suffix} litter remains at the legacy path"
+            );
+            assert!(
+                path_with_suffix(&imported, suffix).exists(),
+                "the {suffix} sidecar travelled with the archive"
+            );
+        }
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// The pinned-`database` refusal is PATH-AWARE: a pin at the default legacy path needs only
+    /// the key removed, while a CUSTOM pin must move its file first — keyless resolution never
+    /// consults a custom path, so "remove the key" alone would strand the index unimported. The
+    /// custom shape prints the literal commands for the user's paths.
+    #[test]
+    fn pinned_refusal_message_states_the_move_for_custom_paths() {
+        let default_legacy = Path::new("/repo/.rag-rat/index.sqlite");
+
+        let at_default = pinned_refusal_message(default_legacy, default_legacy);
+        assert!(at_default.contains("Remove the `database` key"), "default shape: {at_default}");
+        assert!(!at_default.contains("mv "), "default shape needs no move: {at_default}");
+
+        let custom = pinned_refusal_message(Path::new("/repo/custom/my.db"), default_legacy);
+        assert!(
+            custom.contains("mv /repo/custom/my.db /repo/.rag-rat/index.sqlite"),
+            "custom shape prints the literal move: {custom}"
+        );
+        assert!(
+            custom.contains("mkdir -p /repo/.rag-rat"),
+            "custom shape creates the default dir: {custom}"
+        );
+        assert!(
+            custom.contains("-wal"),
+            "custom shape warns about WAL sidecars holding recent writes: {custom}"
+        );
+    }
+}

--- a/crates/rag-rat-core/src/index/github/store.rs
+++ b/crates/rag-rat-core/src/index/github/store.rs
@@ -1,22 +1,28 @@
 use super::*;
 
-// UPSERT-RECLAIM INVARIANT (all seven github writers): the github tables keep their natural keys
-// WITHOUT `repo_id` (the deliberate V041 phase-A deviation — one repo per DB until A7), so on a
-// consolidated DB a row stranded under the `'__unassigned__'` placeholder (the V041 backfill's
-// leave-at-placeholder path) OCCUPIES the key. Every writer must therefore RECLAIM on conflict —
-// re-stamp `repo_id` and refresh the content — never `INSERT OR IGNORE`, which would silently keep
-// the stale placeholder row forever and break the migration's "the next sync reclaims" promise.
-// Last-syncer-owns is the documented phase-A posture for the un-qualified keys; the `github_fts`
-// mirror follows automatically because every sync path ends in the whole-table [`rebuild_fts`],
-// which re-derives each mirror row's `repo_id` from its reclaimed base row. The id-keyed writers
-// (`store_comment` / `store_review` / `store_review_comment`) reclaim via `INSERT OR REPLACE`
-// (REPLACE deletes the conflicting row and re-inserts with the new stamp).
+// KEY SCOPING (V044 + V045, phase A7): every github cache key folds `repo_id`. The `(owner,
+// repo, number)`-style natural keys are `(repo_id, owner, repo, number)` (V044:
+// `github_issues` / `github_pull_requests` UNIQUE, `github_ref_sync` PK, `idx_github_refs_unique`
+// leading column), and the id-keyed CHILD caches (`github_comments` / `github_reviews` /
+// `github_review_comments`) are `(repo_id, id)` unique (V045). So on a consolidated DB two repos
+// referencing the SAME external item each own a full copy — parent AND children — and a conflict
+// only ever fires WITHIN one repo (this repo re-syncing its own item). The natural-key writers'
+// `ON CONFLICT` targets name the widened keys and refresh content in place; the id-keyed writers
+// keep `INSERT OR REPLACE`, which resolves through the widened unique index — a same-repo re-sync
+// replaces in place, a sibling repo's sync inserts its own row, and neither can restamp the
+// other's copy (the pre-V045 last-syncer-owns oscillation: repo A's scoped papertrail lost a
+// shared PR's comments the moment repo B synced). The `github_fts` mirror follows automatically
+// because every sync path ends in the whole-table [`rebuild_fts`], which re-derives each mirror
+// row's `repo_id` from its base row.
 
 pub(crate) fn store_ref(conn: &Connection, reference: &GitHubRef) -> anyhow::Result<()> {
     let repo_id = crate::index::schema::active_repo_id(conn)?;
-    // The `WHERE repo_id changes` guard keeps the old first-discovery semantics for a repo
-    // re-discovering its OWN ref (no rewrite, `discovered_at_ms` keeps the first sighting) while
-    // reclaiming + refreshing a row another owner (the placeholder, pre-A7) holds on this key.
+    // The widened `idx_github_refs_unique` (V044) leads with `repo_id`, so a conflict is always
+    // THIS repo re-discovering its OWN ref — keep the first-sighting row untouched (`DO
+    // NOTHING` preserves the original `discovered_at_ms`/`ref_kind`, the pre-V044 same-repo
+    // semantics). A sibling repo referencing the same `(owner, repo, number)` gets its own
+    // distinct row rather than conflicting, so the old cross-owner reclaim guard is no longer
+    // reachable.
     conn.execute(
         "
         INSERT INTO github_refs(
@@ -24,12 +30,8 @@ pub(crate) fn store_ref(conn: &Connection, reference: &GitHubRef) -> anyhow::Res
          discovered_at_ms, repo_id
         )
         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
-        ON CONFLICT(owner, repo, number, source_kind, COALESCE(source_path, ''), \
-         COALESCE(source_commit, ''), source_text) DO UPDATE SET
-            ref_kind = excluded.ref_kind,
-            discovered_at_ms = excluded.discovered_at_ms,
-            repo_id = excluded.repo_id
-        WHERE github_refs.repo_id != excluded.repo_id
+        ON CONFLICT(repo_id, owner, repo, number, source_kind, COALESCE(source_path, ''), \
+         COALESCE(source_commit, ''), source_text) DO NOTHING
         ",
         params![
             reference.owner,
@@ -53,11 +55,11 @@ pub(crate) fn store_issue(conn: &Connection, issue: &GitHubIssue) -> anyhow::Res
         INSERT INTO github_issues(owner, repo, number, html_url, state, title, body, author, \
          created_at, updated_at, is_pull_request, synced_at_ms, repo_id)
         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
-        ON CONFLICT(owner, repo, number) DO UPDATE SET
+        ON CONFLICT(repo_id, owner, repo, number) DO UPDATE SET
             html_url = excluded.html_url, state = excluded.state, title = excluded.title,
             body = excluded.body, author = excluded.author, created_at = excluded.created_at,
             updated_at = excluded.updated_at, is_pull_request = excluded.is_pull_request,
-            synced_at_ms = excluded.synced_at_ms, repo_id = excluded.repo_id
+            synced_at_ms = excluded.synced_at_ms
         ",
         params![
             issue.owner,
@@ -108,11 +110,11 @@ pub(crate) fn store_pull(conn: &Connection, pull: &GitHubPullRequest) -> anyhow:
         INSERT INTO github_pull_requests(owner, repo, number, html_url, state, title, body, \
          author, created_at, updated_at, merged_at, synced_at_ms, repo_id)
         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
-        ON CONFLICT(owner, repo, number) DO UPDATE SET
+        ON CONFLICT(repo_id, owner, repo, number) DO UPDATE SET
             html_url = excluded.html_url, state = excluded.state, title = excluded.title,
             body = excluded.body, author = excluded.author, created_at = excluded.created_at,
             updated_at = excluded.updated_at, merged_at = excluded.merged_at,
-            synced_at_ms = excluded.synced_at_ms, repo_id = excluded.repo_id
+            synced_at_ms = excluded.synced_at_ms
         ",
         params![
             pull.owner,

--- a/crates/rag-rat-core/src/index/github/sync.rs
+++ b/crates/rag-rat-core/src/index/github/sync.rs
@@ -193,11 +193,10 @@ pub(crate) fn mark_ref_sync(
         "
         INSERT INTO github_ref_sync(owner, repo, number, status, synced_at_ms, last_error, repo_id)
         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
-        ON CONFLICT(owner, repo, number) DO UPDATE SET
+        ON CONFLICT(repo_id, owner, repo, number) DO UPDATE SET
             status = excluded.status,
             synced_at_ms = excluded.synced_at_ms,
-            last_error = excluded.last_error,
-            repo_id = excluded.repo_id
+            last_error = excluded.last_error
         ",
         params![
             reference.owner,

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -47,15 +47,15 @@ impl IndexDatabase {
             return Self::rebuild_with_progress(config, progress).map(|db| (db, true));
         }
 
-        // Open with the graph check DEFERRED (`check_graph = false`). `Self::open`'s eager check
-        // runs `ensure_graph_index_current` — a repo-scoped edge DELETE+rebuild keyed on
-        // `active_repo_id` — during the open itself, BEFORE this pass adopts the config's repo. On
-        // a consolidated DB `Self::open` scopes to the config-blind SOLE repo (the
-        // lexicographically-first), so the eager check would refresh/wipe the WRONG repo's graph
-        // (or skip the config repo's own stale graph) before adoption switches scope. Adopt
-        // + install the scope context FIRST, then run the graph/generated-flags heal for
-        // the correct repo — the exact sequence `open_config` uses.
-        let mut db = Self::open_with_graph_check(&config.database, false)?;
+        // Open in ADOPTION-PENDING mode: the multi-repo fail-fast must not fire (the config below
+        // supplies the scope, unlike a genuinely config-less `Self::open`), and the graph check is
+        // DEFERRED — its `ensure_graph_index_current` is a repo-scoped edge DELETE+rebuild keyed
+        // on `active_repo_id`, which pre-adoption would resolve the config-blind SOLE-repo pick
+        // and refresh/wipe the WRONG repo's graph (or skip the config repo's own stale graph).
+        // Adopt + install the scope context FIRST, then run the graph/generated-flags heal for the
+        // correct repo — the exact sequence `open_config` uses.
+        let mut db =
+            Self::open_bare(&config.database, super::lifecycle::BareOpenMode::AdoptionPending)?;
         // Register/adopt the config's repo BEFORE `set_context` stamps `active_repo_id` into the
         // scope view (A3). `Self::open` scoped to the SOLE repo via the config-blind fallback; on a
         // consolidated DB that would pick the lexicographically-first repo, so this incremental
@@ -66,6 +66,26 @@ impl IndexDatabase {
         db.adopt_repo_from_config(config)?;
         let (commit_sha, worktree_id) = resolve_git_context(&config.root);
         db.set_context(&commit_sha, &worktree_id)?;
+        // ADOPTION RESETS ALL CONNECTION-CARRIED REPO-DERIVED STATE BEFORE ANY DEFERRED HEAL (the
+        // rule that closes the pre-adoption-pick family). `open_bare` derived per-repo state from
+        // the config-less SOLE pick — on a consolidated DB, a first-sorting SIBLING — and each
+        // piece must be re-derived for the adopted repo before a heal consumes it:
+        //  * `active_repo_id` / scope view / `active_generation` — re-derived by
+        //    `adopt_repo_from_config` + `set_context` above;
+        //  * `source_root` — reset HERE from the config: `ensure_graph_index_current` re-reads
+        //    changed files from `source_root.join(path)` while stamping the ADOPTED repo, so a
+        //    stale sibling root would refresh the target's graph from the WRONG CHECKOUT;
+        //  * the model-manifest heal — deferred below, so its `repo_meta` reads/writes resolve the
+        //    adopted repo, not the pick.
+        // (`active_commit_sha` / `active_worktree_id` were set by `set_context`; the GitHub
+        // context and `_identity_lock` are not repo-pick-derived.)
+        db.storage.set_source_root(config.root.clone());
+        // The DEFERRED model-manifest heal (open_bare skips it in AdoptionPending mode): now that
+        // the scope context names the CONFIG's repo, a heal-owed pass reads/clears the RIGHT
+        // repo's `repo_meta` active-model keys under the lock this command actually holds —
+        // pre-adoption it resolved the sole-repo pick, mutating a first-sorting SIBLING's meta on
+        // a consolidated DB. The `open_config` ordering, mirrored.
+        ai::ensure_model_manifest(db.storage.connection())?;
         // Now that the config's repo is adopted and its scope is installed, run the deferred graph
         // + generated-flags heal against the RIGHT repo (the graph check's edge DELETE is
         // scoped by `active_repo_id`, so it must not run under the pre-adoption sole-repo

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -6,9 +6,23 @@ use super::*;
 /// half-open.
 const SCHEMA_MIGRATE_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
+/// How a config-less open resolves its repo scope — the two callers of
+/// [`IndexDatabase::open_bare`] want opposite postures on a multi-repo DB.
+pub(super) enum BareOpenMode {
+    /// A genuinely CONFIG-LESS open (`IndexDatabase::open`: the MCP `call_tool(database, …)` path,
+    /// tests, tooling): scope stays the sole repo for the connection's lifetime, so a multi-repo
+    /// DB is REFUSED up front (A7) and the graph/generated-flags heal runs for the sole repo.
+    ConfigLess,
+    /// The incremental pass's low-level first step: `adopt_repo_from_config` + `set_context`
+    /// follow immediately, so the multi-repo refusal must NOT fire (the config supplies the scope)
+    /// and the graph heal is DEFERRED until after adoption (it is `active_repo_id`-scoped and
+    /// would otherwise heal the pre-adoption sole-repo pick).
+    AdoptionPending,
+}
+
 impl IndexDatabase {
     pub fn open(path: &Path) -> anyhow::Result<Self> {
-        Self::open_with_graph_check(path, true)
+        Self::open_bare(path, BareOpenMode::ConfigLess)
     }
 
     pub fn database_path(&self) -> &Path {
@@ -57,13 +71,37 @@ impl IndexDatabase {
         Ok(storage)
     }
 
-    pub(super) fn open_with_graph_check(path: &Path, check_graph: bool) -> anyhow::Result<Self> {
+    pub(super) fn open_bare(path: &Path, mode: BareOpenMode) -> anyhow::Result<Self> {
         let mut storage = Self::open_and_migrate(path)?;
-        ai::ensure_model_manifest(storage.connection())?;
         // A bare `open` has no config identity to register, so it scopes to the SOLE repo of a
-        // single-repo DB (a consolidated multi-repo DB is only reached through `open_config`, which
-        // registers). The model-manifest heal above resolves the same sole repo via the no-context
-        // fallback in `schema::active_repo_id`.
+        // single-repo DB. On a CONSOLIDATED multi-repo DB (A7) there is no sole repo to pick —
+        // `sole_repo_id`'s deterministic lexicographic tiebreak would silently serve whichever repo
+        // sorts first, the exact ambient-scope assumption phase A exists to kill — so a
+        // [`ConfigLess`](BareOpenMode::ConfigLess) open FAILS FAST with the config-bearing remedy
+        // instead of degrading. Gated BEFORE the model-manifest heal, which itself resolves
+        // `active_repo_id` (⇒ the same first-sorting pick) and could otherwise seed per-repo meta
+        // under the wrong repo. An [`AdoptionPending`](BareOpenMode::AdoptionPending) open is
+        // exempt: the caller adopts the config's repo immediately after, which re-scopes the
+        // connection before any repo-scoped heal runs.
+        if matches!(mode, BareOpenMode::ConfigLess)
+            && schema::multiple_real_repos(storage.connection())?
+        {
+            anyhow::bail!(
+                "this database holds multiple repos; a bare open cannot choose one. Open through \
+                 a rag-rat.toml config (run from the repo's checkout, or pass --config) so the \
+                 repo scope is explicit."
+            );
+        }
+        // The model-manifest heal resolves `active_repo_id` — context-less, the sole-repo pick —
+        // and on a heal-owed pass its `remove_legacy_models` DELETES that repo's `repo_meta`
+        // active-model keys. Safe here only for ConfigLess (the fail-fast above guarantees a
+        // single repo, so the pick IS the repo); an AdoptionPending open on a multi-repo DB would
+        // mutate the FIRST-SORTING repo's meta while the caller holds only its own repo's lock —
+        // so the heal is DEFERRED to the caller, after adopt + set_context scope the connection
+        // (the exact ordering `open_config` uses).
+        if matches!(mode, BareOpenMode::ConfigLess) {
+            ai::ensure_model_manifest(storage.connection())?;
+        }
         let repo_id = schema::sole_repo_id(storage.connection())?;
         if let Some(root) = repo_meta(storage.connection(), &repo_id, "source_root")? {
             storage.set_source_root(PathBuf::from(root));
@@ -89,7 +127,7 @@ impl IndexDatabase {
             config: None,
             _identity_lock: None,
         };
-        if check_graph {
+        if matches!(mode, BareOpenMode::ConfigLess) {
             db.ensure_graph_index_current()?;
             db.ensure_generated_flags_current()?;
         }
@@ -151,7 +189,25 @@ impl IndexDatabase {
             config.repo_id_override.as_deref(),
         ) {
             Ok(identity) => schema::register_repo(conn, &identity, &config.root, schema::now_ms())?,
-            Err(err) if err.is_absent() => schema::sole_repo_id(conn)?,
+            Err(err) if err.is_absent() => {
+                // STRUCTURAL BACKSTOP (Codex batch 8, finding 5): an identity-less root may
+                // sole-pick only on a SINGLE-repo database. On a multi-repo store (an explicit
+                // `database` pin at the global file or any shared path), `sole_repo_id`'s
+                // lexicographic tiebreak would silently adopt a SIBLING repo's scope and write
+                // this project's rows under it. Refuse with the remedy instead — the same
+                // doctrine as the config-less bare-open fail-fast and the healers' witness: no
+                // entrance may guess a repo on a multi-repo database. (`Config::load` already
+                // refuses the global-pin shape at resolution; this closes every other entrance.)
+                if schema::multiple_real_repos(conn)? {
+                    anyhow::bail!(
+                        "this root has no resolvable repo identity (not a committed git repo), \
+                         and the configured database holds multiple repos — refusing to guess \
+                         which one this project is. Add `[index] repo_id = \"...\"` to pin an \
+                         identity, or point `database` at a per-repo file"
+                    );
+                }
+                schema::sole_repo_id(conn)?
+            },
             Err(err) => return Err(err.into()),
         };
         // FENCE-GAP CLOSE (A6, batch-5 P2): a LOCK-DISCIPLINED writer's held lock must match the
@@ -277,6 +333,30 @@ impl IndexDatabase {
 
     pub fn migrate(path: &Path) -> anyhow::Result<schema::SchemaStatus> {
         Self::migrate_with_fastembed_cache(path, None)
+    }
+
+    /// Bring the schema at `path` current and NOTHING ELSE — no model-manifest heal, no fastembed
+    /// cache recovery. For callers whose operation's SUBJECT REPO IS NOT REGISTERED YET
+    /// (`rag-rat consolidate`, future importers): the open-time healers attribute their per-repo
+    /// `repo_meta` reads/writes via the scoped-repo witness, and the witness's single-repo arm
+    /// picks the sole REGISTERED repo — which for an unregistered subject is a SIBLING, healed
+    /// under the wrong repo's locks. Such callers must use this schema-only path; any owed sibling
+    /// heal belongs to that sibling's own next scoped open.
+    pub fn migrate_schema_only(path: &Path) -> anyhow::Result<schema::SchemaStatus> {
+        let storage = IndexConnection::open(path)?;
+        let status = schema::status(storage.connection())?;
+        match status.state {
+            schema::SchemaState::Newer | schema::SchemaState::Dirty => {
+                anyhow::bail!("{}", status.message);
+            },
+            schema::SchemaState::Compatible => {},
+            schema::SchemaState::Missing | schema::SchemaState::Older => {
+                // Serializes on the GLOBAL schema lock and re-checks under it, like every
+                // schema-apply path (see `apply_schema_under_lock`).
+                Self::apply_schema_under_lock(path, storage.connection())?;
+            },
+        }
+        schema::status(storage.connection())
     }
 
     pub(super) fn migrate_with_fastembed_cache(

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -11,6 +11,8 @@ pub mod schema;
 pub mod symbols;
 pub mod walker;
 
+pub mod consolidate;
+
 pub(crate) mod chunk_text_store;
 pub(crate) mod clones;
 mod discovery;

--- a/crates/rag-rat-core/src/index/poison_sibling.rs
+++ b/crates/rag-rat-core/src/index/poison_sibling.rs
@@ -47,21 +47,24 @@
 //! by their globally-unique `build_generation`) is deliberately absent — seeding it would
 //! manufacture a FALSE tripwire against a legitimately cross-repo store.
 //!
-//! WHY THE SIBLING IS NOT REGISTERED IN `repos` (load-bearing at V040): the eight direct-scoped
-//! DATA tables (`files`, `packages`, `logical_symbols`, `docs`, `parser_failures`, `git_commits`,
-//! `git_file_changes`, and the file/symbol children) carry `repo_id` as a plain column with a
-//! `DEFAULT '__unassigned__'` and **no foreign key to `repos`** — so a tripwire row under
-//! `repo_id='poison-sibling'` is valid without a `repos` registry row. The harness deliberately
-//! does NOT insert into `repos`/`repo_roots`/`repo_meta`. If it did, the sibling would become a
-//! second REAL repo, and at phase A that (a) makes `sole_repo_id` (the config-blind fallback for
-//! the many NON-git fixtures, which stay under the `__unassigned__` placeholder) return the sibling
-//! instead of the fixture — hijacking every re-adoption — and (b) flips `multiple_real_repos`,
-//! changing the gc/precompute global-sweep guards. Neither is a production leak; both are phase-A
-//! single-repo assumptions. Seeding only the *scoped data* rows keeps the registry pristine (no
-//! hijack, no `multiple_real_repos` flip) while still tripping any genuinely unscoped
-//! read/count/delete. The cost is no tripwire for an unscoped `repo_meta`/`repos`/`repo_roots` read
-//! — those are covered by the dedicated registry + `multi_repo_scope` tests instead. (When A7 makes
-//! multi-repo the default, the sibling gets a real `repos` row and this note goes away.)
+//! REGISTRY REGISTRATION IS CONDITIONAL (A7): the sibling gets a REAL `repos` + `repo_roots` +
+//! `repo_meta` registry row **only when the fixture repo is itself a real (adopted) repo** — i.e.
+//! when the DB already holds a non-placeholder, non-sibling repo (see [`primary_is_real`]). That is
+//! the genuinely multi-repo shape A7 makes the default, and registering the sibling there closes
+//! the last tripwire gap: an unscoped `repos`/`repo_roots`/`repo_meta` read/count/delete now trips.
+//! The eight direct-scoped DATA tables carry `repo_id` as a plain column with **no foreign key to
+//! `repos`**, so the scoped-row tripwires are valid with or without the registry row.
+//!
+//! For a NON-git fixture (the many bare temp-dir fixtures that stay under the `__unassigned__`
+//! placeholder because `adopt_repo_from_config` reads them as `Absent`), the sibling stays
+//! registry-LESS: registering it as a second real repo would (a) make `sole_repo_id` — the
+//! config-blind fallback those fixtures rely on — return the sibling instead of the placeholder,
+//! hijacking their scope, and (b) flip `multiple_real_repos`. So the harness registers the sibling
+//! ONLY where a real repo already anchors the DB (a git fixture, resolved by
+//! identity/recorded-root, never by `sole_repo_id`), and leaves the registry pristine on
+//! placeholder DBs. The registry tripwires are correspondingly conditional — [`sibling_tripwires`]
+//! appends them only when `primary_is_real`, keyed on the fixture's own (never mutated) real repo
+//! row so a leak that deletes the sibling's registry rows is still caught.
 //!
 //! OPT-OUT: default-ON per test thread (see [`disable_poison_sibling`]). A test that legitimately
 //! asserts a scoped table's UNSCOPED total (a `full_rebuild_preserves_*` cache-total check, a
@@ -135,6 +138,16 @@ const POISON_MEMORY_ID: &str = "zz_poison_mem";
 /// any fixture's `MAX(generation)+1` allocation so a seeded clone row never collides.
 const POISON_GENERATION: i64 = 9_900_000_042;
 
+/// The poison sibling's recorded working-tree root (A7). A distinctive path that can never collide
+/// with a real fixture root, so registering the sibling in `repo_roots` never claims a fixture's
+/// root nor lets `real_root_owner` mis-resolve a fixture path to the sibling.
+const POISON_REPO_ROOT: &str = "/zz_poison_root";
+
+/// The poison sibling's `repo_meta` sentinel key/value (A7) — the tripwire for an unscoped
+/// `repo_meta` read/count/delete once the sibling is a REAL registered repo.
+const POISON_META_KEY: &str = "zz_poison_meta_key";
+const POISON_META_VALUE: &str = "zz_poison_meta_val";
+
 thread_local! {
     /// Whether [`seed_if_enabled`] seeds on this thread. Default ON. Thread-local (not a global
     /// static) so a `cargo test` run — which executes tests as parallel THREADS in one process —
@@ -150,6 +163,13 @@ impl Drop for PoisonDisabled {
     fn drop(&mut self) {
         POISON_ENABLED.with(|flag| flag.set(self.0));
     }
+}
+
+/// Whether seeding is currently disabled on THIS thread — for test helpers that spawn a WORKER
+/// thread (e.g. a paused rebuild) and must propagate the calling test's opt-out onto it (the
+/// thread-local default is ON, so a spawned rebuild would otherwise re-seed behind the opt-out).
+pub(crate) fn poison_disabled_on_this_thread() -> bool {
+    !POISON_ENABLED.with(Cell::get)
 }
 
 /// Disable poison-sibling seeding for the remainder of THIS test (until the returned guard drops).
@@ -643,7 +663,45 @@ pub(crate) fn seed_sibling(conn: &Connection) -> anyhow::Result<()> {
         ],
     )?;
 
+    // --- registry rows (A7): register the sibling as a REAL repo ONLY on a DB that already holds a
+    // real fixture repo (a git fixture). This is the genuinely multi-repo shape A7 makes the
+    // default, and it makes an unscoped `repos`/`repo_roots`/`repo_meta` read/count/delete trip a
+    // tripwire. On a placeholder-only (non-git) fixture the sibling stays registry-less — a second
+    // real repo would hijack `sole_repo_id` for the many fixtures that rely on it (see the module
+    // docs). `repo_roots` / `repo_meta` FK `repos(repo_id)` ON DELETE CASCADE, so insert the parent
+    // `repos` row FIRST (the connection runs `foreign_keys = ON`). ---
+    if primary_is_real(conn)? {
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, ?2, 0)",
+            params![POISON_REPO_ID, format!("{POISON_PREFIX}name")],
+        )?;
+        conn.execute(
+            "INSERT INTO repo_roots(repo_id, root, registered_at_ms) VALUES (?1, ?2, 0)",
+            params![POISON_REPO_ID, POISON_REPO_ROOT],
+        )?;
+        conn.execute("INSERT INTO repo_meta(repo_id, key, value) VALUES (?1, ?2, ?3)", params![
+            POISON_REPO_ID,
+            POISON_META_KEY,
+            POISON_META_VALUE
+        ])?;
+    }
+
     Ok(())
+}
+
+/// Whether the DB already holds a REAL fixture repo — a `repos` row that is neither the
+/// `__unassigned__` placeholder nor the poison sibling itself. Gates whether [`seed_sibling`]
+/// registers the sibling as a real repo and whether [`sibling_tripwires`] appends the registry
+/// tripwires (see the module docs). Stable across the mutation under test: the fixture's own real
+/// repo row is never the target of the unscoped-read leaks the harness hunts, so a seed-time and an
+/// assert-time evaluation agree — a leak that deletes the SIBLING's registry rows is still caught.
+fn primary_is_real(conn: &Connection) -> anyhow::Result<bool> {
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM repos WHERE repo_id != ?1 AND repo_id != ?2",
+        params![crate::index::schema::LEGACY_REPO_ID, POISON_REPO_ID],
+        |row| row.get(0),
+    )?;
+    Ok(count > 0)
 }
 
 /// The lexicographically-first REAL (non-sibling) indexed path — the primary-repo path the
@@ -700,7 +758,13 @@ fn clear_sibling(conn: &Connection) -> anyhow::Result<()> {
          DELETE FROM repo_memory_fts WHERE repo_id = '{POISON_REPO_ID}';
          DELETE FROM repo_memory_tags WHERE memory_id = '{POISON_MEMORY_ID}';
          DELETE FROM repo_memory_bindings WHERE repo_id = '{POISON_REPO_ID}';
-         DELETE FROM repo_memories WHERE repo_id = '{POISON_REPO_ID}';"
+         DELETE FROM repo_memories WHERE repo_id = '{POISON_REPO_ID}';
+         -- Registry rows (A7): child-first (repo_meta/repo_roots FK repos ON DELETE CASCADE), so a
+         -- re-seed on a git fixture starts from a clean slate. No-op when the sibling was never
+         -- registered (a placeholder-only fixture).
+         DELETE FROM repo_meta WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM repo_roots WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM repos WHERE repo_id = '{POISON_REPO_ID}';"
     ))?;
     Ok(())
 }
@@ -710,10 +774,10 @@ fn clear_sibling(conn: &Connection) -> anyhow::Result<()> {
 /// predicate pins every seeded column, so an in-place UPDATE stops matching) in one. The transitive
 /// children are matched through the poison file / logical symbol, exactly how a scoped reader would
 /// have to reach them.
-fn sibling_tripwires() -> Vec<(&'static str, String)> {
+fn sibling_tripwires(conn: &Connection) -> anyhow::Result<Vec<(&'static str, String)>> {
     let file_scope =
         format!("file_id IN (SELECT id FROM main.files WHERE repo_id = '{POISON_REPO_ID}')");
-    vec![
+    let mut tripwires = vec![
         ("git_commits", format!("repo_id = '{POISON_REPO_ID}' AND hash = '{POISON_COMMIT}'")),
         // Pinned to the distinct-path row's path so the same-path `git_file_changes` tripwire
         // (a second row under `POISON_REPO_ID`) doesn't inflate this count.
@@ -869,7 +933,22 @@ fn sibling_tripwires() -> Vec<(&'static str, String)> {
             "edge_oracle",
             format!("repo_id = '{POISON_REPO_ID}' AND scip_symbol = '{POISON_SAMEPATH_SCIP}'"),
         ),
-    ]
+    ];
+    // Registry tripwires (A7): present ONLY when the sibling is a REAL registered repo (a git
+    // fixture — see `primary_is_real`, which gates the matching seed). Each pins the sibling's own
+    // registry row, so an unscoped `repos` / `repo_roots` / `repo_meta` read/count/delete trips.
+    if primary_is_real(conn)? {
+        tripwires.push(("repos", format!("repo_id = '{POISON_REPO_ID}'")));
+        tripwires.push((
+            "repo_roots",
+            format!("repo_id = '{POISON_REPO_ID}' AND root = '{POISON_REPO_ROOT}'"),
+        ));
+        tripwires.push((
+            "repo_meta",
+            format!("repo_id = '{POISON_REPO_ID}' AND key = '{POISON_META_KEY}'"),
+        ));
+    }
+    Ok(tripwires)
 }
 
 /// Post-condition for a MUTATING test: assert the poison sibling survived intact — every seeded
@@ -880,7 +959,7 @@ fn sibling_tripwires() -> Vec<(&'static str, String)> {
 /// the sibling through the view. Call it on the fixture's connection at the end of the mutating
 /// step.
 pub(crate) fn assert_sibling_intact(conn: &Connection) {
-    for (table, predicate) in sibling_tripwires() {
+    for (table, predicate) in sibling_tripwires(conn).expect("read the sibling tripwire set") {
         let count: i64 = conn
             .query_row(&format!("SELECT COUNT(*) FROM {table} WHERE {predicate}"), [], |row| {
                 row.get(0)
@@ -1030,11 +1109,12 @@ mod tests {
         assert_eq!(sibling_files, 0, "opt-out must seed no poison rows");
     }
 
-    /// The sibling never touches the `repos` registry: even with the harness ON, the DB has exactly
-    /// one real repo (the fixture's), so `sole_repo_id` / `multiple_real_repos` are unperturbed and
-    /// the many non-git placeholder fixtures keep resolving to their own scope.
+    /// A7: on a git fixture (a REAL registered repo), the sibling now becomes a SECOND real repo —
+    /// `repos` + `repo_roots` + `repo_meta` rows — so the DB is a genuine multi-repo shape and an
+    /// unscoped registry read/count/delete trips a tripwire. The fixture resolves by identity /
+    /// recorded root (never `sole_repo_id`), so the second real repo does not hijack it.
     #[test]
-    fn the_sibling_does_not_perturb_the_repos_registry() {
+    fn the_sibling_is_a_real_repo_on_a_git_fixture() {
         let (_root, config) = poison_test_config("poison_registry");
         let db = IndexDatabase::rebuild(&config).unwrap();
         let conn = db.storage.connection();
@@ -1043,17 +1123,16 @@ mod tests {
                 row.get(0)
             })
             .unwrap();
-        assert_eq!(poison_registered, 0, "the sibling must NOT be registered in `repos`");
-        let real_repos: i64 = conn
-            .query_row(
-                "SELECT COUNT(*) FROM repos WHERE repo_id != ?1",
-                [crate::index::schema::LEGACY_REPO_ID],
-                |row| row.get(0),
-            )
-            .unwrap();
         assert_eq!(
-            real_repos, 1,
-            "only the fixture is a real repo — the sibling is scoped rows only"
+            poison_registered, 1,
+            "the sibling is registered as a real repo on a git fixture"
         );
+        assert!(
+            crate::index::schema::multiple_real_repos(conn).unwrap(),
+            "the fixture + the sibling make the DB genuinely multi-repo",
+        );
+        // The sibling's registry rows are counted by the intact check (the registry tripwires are
+        // appended because `primary_is_real`).
+        assert_sibling_intact(conn);
     }
 }

--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -683,6 +683,7 @@ mod tests {
         .unwrap();
         let config = crate::Config {
             repo_id_override: None,
+            database_key_pinned: true,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![crate::config::ResolvedTarget {
@@ -794,6 +795,7 @@ mod tests {
         let db_path = root.join(".rag-rat/index.sqlite");
         let config = crate::Config {
             repo_id_override: None,
+            database_key_pinned: true,
             root: root.clone(),
             database: db_path.clone(),
             targets: vec![crate::config::ResolvedTarget {
@@ -859,6 +861,7 @@ mod tests {
         .unwrap();
         let config = crate::Config {
             repo_id_override: None,
+            database_key_pinned: true,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![crate::config::ResolvedTarget {
@@ -955,6 +958,7 @@ mod tests {
         };
         let config = crate::Config {
             repo_id_override: None,
+            database_key_pinned: true,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -858,6 +858,7 @@ mod tests {
         .unwrap();
         crate::Config {
             repo_id_override: None,
+            database_key_pinned: true,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![crate::config::ResolvedTarget {

--- a/crates/rag-rat-core/src/index/query_api/clones/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/tests.rs
@@ -194,6 +194,7 @@ fn find_clones_rejects_nan_and_non_finite_min_similarity() {
     std::fs::write(root.join("src/lib.rs"), "pub fn f() {}\n").unwrap();
     let config = crate::Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![crate::config::ResolvedTarget {
@@ -776,6 +777,7 @@ fn recall_candidates_identical_blob_vs_postings_grouping() {
     .unwrap();
     let config = crate::Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![crate::config::ResolvedTarget {

--- a/crates/rag-rat-core/src/index/query_api/gc.rs
+++ b/crates/rag-rat-core/src/index/query_api/gc.rs
@@ -55,8 +55,12 @@ impl IndexDatabase {
         live_worktrees: &[String],
     ) -> anyhow::Result<GcReport> {
         let conn = self.storage.connection();
-        let files_before = table_row_count(conn, "files")?;
-        let chunks_before = table_row_count(conn, "chunks")?;
+        // Counts are SCOPED to the active repo (the DELETEs below always were): on a consolidated
+        // DB a whole-table count would report the union across every repo — `files_remaining: 2`
+        // from a repo owning one file — and a sibling's index pass committing between the
+        // before/after reads would skew the derived pruned counts (saturating_sub can zero them).
+        let files_before = scoped_table_row_count(conn, "files", &self.active_repo_id)?;
+        let chunks_before = scoped_chunk_row_count(conn, &self.active_repo_id)?;
         // A6 (P2 review): sweep this repo's DEAD file GENERATIONS FIRST, and UNCONDITIONALLY —
         // BEFORE the empty-live-sets early return below. Generation liveness needs only
         // `repo_id` + the repo's live-generation pointer, never a git context, so the "no live
@@ -100,8 +104,8 @@ impl IndexDatabase {
         self.delete_staged_files_cascade(StagedSweep::DeadGeneration)?;
         conn.execute_batch("DELETE FROM temp.staged_file_ids;")?;
         if live_commits.is_empty() && live_worktrees.is_empty() {
-            let files_remaining = table_row_count(conn, "files")?;
-            let chunks_remaining = table_row_count(conn, "chunks")?;
+            let files_remaining = scoped_table_row_count(conn, "files", &self.active_repo_id)?;
+            let chunks_remaining = scoped_chunk_row_count(conn, &self.active_repo_id)?;
             return Ok(GcReport {
                 files_pruned: files_before.saturating_sub(files_remaining),
                 chunks_pruned: chunks_before.saturating_sub(chunks_remaining),
@@ -227,8 +231,8 @@ impl IndexDatabase {
             ",
             [],
         )?;
-        let files_remaining = table_row_count(conn, "files")?;
-        let chunks_remaining = table_row_count(conn, "chunks")?;
+        let files_remaining = scoped_table_row_count(conn, "files", &self.active_repo_id)?;
+        let chunks_remaining = scoped_chunk_row_count(conn, &self.active_repo_id)?;
         Ok(GcReport {
             files_pruned: files_before.saturating_sub(files_remaining),
             chunks_pruned: chunks_before.saturating_sub(chunks_remaining),

--- a/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
@@ -30,6 +30,7 @@ fn temp_root() -> PathBuf {
 fn rust_config(root: PathBuf) -> Config {
     Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
@@ -1144,6 +1145,7 @@ fn deleted_and_generated_paths_counted_in_skipped() {
     // A config with a Generated target for `gen/` so `out.rs` indexes generated.
     let config = Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1178,6 +1178,8 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_041_ID => Some(41),
             MIGRATION_042_ID => Some(42),
             MIGRATION_043_ID => Some(43),
+            MIGRATION_044_ID => Some(44),
+            MIGRATION_045_ID => Some(45),
             _ => None,
         })
         .max()
@@ -1230,6 +1232,8 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_041_ID
             | MIGRATION_042_ID
             | MIGRATION_043_ID
+            | MIGRATION_044_ID
+            | MIGRATION_045_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1279,6 +1283,8 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_041_ID => migration.checksum != MIGRATION_041_CHECKSUM,
         MIGRATION_042_ID => migration.checksum != MIGRATION_042_CHECKSUM,
         MIGRATION_043_ID => migration.checksum != MIGRATION_043_CHECKSUM,
+        MIGRATION_044_ID => migration.checksum != MIGRATION_044_CHECKSUM,
+        MIGRATION_045_ID => migration.checksum != MIGRATION_045_CHECKSUM,
         _ => false,
     }
 }
@@ -2351,6 +2357,470 @@ fn backfill_github_repo_id_to_sole_repo(conn: &Connection) -> rusqlite::Result<(
         super::LEGACY_REPO_ID,
     ])?;
     Ok(())
+}
+
+// ============================================================================================
+// Memory-sync phase A7 (GitHub natural-key widening) — V044.
+//
+// V041 gave the GitHub papertrail tables a `repo_id` column but DELIBERATELY left their
+// `(owner, repo, number)`-style natural keys un-widened (one repo per DB until A7, so those keys
+// stayed correct). A7 makes multi-repo the default: two distinct repos in one consolidated DB can
+// each reference the SAME external `(owner, repo, number)` — a shared upstream issue, a fork — and
+// the un-widened key would make the second repo's sync UPSERT OVER the first's row (stamping the
+// wrong `repo_id`, so a scoped read then loses it). V044 folds `repo_id` into every such key.
+// ============================================================================================
+
+/// The unique index V044 creates on `github_issues` — also the migration's all-or-nothing SENTINEL
+/// (it exists iff the whole atomic migration committed). Distinct from `idx_github_refs_unique`,
+/// which predates V044 (baseline) and so cannot mark this migration's completion.
+const GITHUB_ISSUES_REPO_UNIQUE_INDEX: &str = "idx_github_issues_repo_unique";
+
+/// V044 (memory-sync phase A7): widen the `(owner, repo, number)`-style GitHub natural keys to fold
+/// `repo_id`, so a consolidated multi-repo DB can cache the same external issue/PR/ref for two
+/// repos without one repo's sync UPSERTing over the other's row. Three shapes:
+///
+///  * INLINE-UNIQUE REBUILD: `github_issues` / `github_pull_requests` carried an inline
+///    `UNIQUE(owner, repo, number)` table constraint (droppable only by rebuild). Each is rebuilt
+///    WITHOUT the inline constraint plus a NAMED unique index `(repo_id, owner, repo, number)` —
+///    the named index doubles as the migration sentinel and as the writers' `ON CONFLICT` target.
+///  * INLINE-PK REBUILD: `github_ref_sync` carried an inline `PRIMARY KEY(owner, repo, number)`;
+///    rebuilt with `PRIMARY KEY(repo_id, owner, repo, number)`.
+///  * INDEX SWAP: `github_refs` scopes uniqueness through the SEPARATE `idx_github_refs_unique`
+///    index (its own PK is `id AUTOINCREMENT`), so it needs only a DROP + CREATE of that index with
+///    a leading `repo_id` — no table rebuild.
+///
+/// The id-keyed caches (`github_comments` / `github_reviews` / `github_review_comments`) are NOT
+/// touched here — V044 originally left them last-syncer-owns, which V045
+/// ([`apply_github_child_key_widening`]) superseded with `(repo_id, id)` uniqueness after the
+/// restamping proved to evict a sibling repo's scoped papertrail (see the V045 block comment).
+///
+/// SAFE ON EXISTING DATA: this migration only ever runs on a SINGLE-repo DB (multi-repo does not
+/// exist until A7 registration, which post-dates the migration ladder), so every existing github
+/// row shares one `repo_id` and the old `(owner, repo, number)` uniqueness already guarantees the
+/// widened key is unique — a plain `INSERT ... SELECT` copies faithfully with no dup risk.
+///
+/// MECHANICS: the github base tables carry NO incoming FK (nothing REFERENCES them), so unlike V040
+/// no `foreign_keys` toggle is needed — the DROP/RENAME rebuilds touch no FK parent. The whole
+/// migration self-wraps in ONE `BEGIN IMMEDIATE` (the ladder runs apply fns in AUTOCOMMIT), so the
+/// rebuilds and index swaps commit together; the named `github_issues` unique index present is the
+/// all-or-nothing sentinel, so a `create_or_migrate` / `rebuild` / `index --full` re-apply
+/// short-circuits before the write lock. Each rebuild's leading `DROP TABLE IF EXISTS
+/// <scratch>_new` re-converges after a hard-kill that bypassed a clean rollback (the V040 recipe).
+pub(crate) fn apply_github_natural_key_widening(conn: &Connection) -> rusqlite::Result<()> {
+    // All-or-nothing sentinel (see the doc comment): the whole migration commits atomically, so the
+    // named github_issues unique index existing means every rebuild + index swap already landed.
+    if github_object_exists(conn, "index", GITHUB_ISSUES_REPO_UNIQUE_INDEX)? {
+        return Ok(());
+    }
+    conn.execute_batch("BEGIN IMMEDIATE;")?;
+    let result = (|| -> rusqlite::Result<()> {
+        rebuild_github_issues_with_repo_scoped_key(conn)?;
+        rebuild_github_pull_requests_with_repo_scoped_key(conn)?;
+        rebuild_github_ref_sync_with_repo_scoped_key(conn)?;
+        widen_github_refs_unique_index(conn)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = conn.execute_batch("ROLLBACK;");
+        return result;
+    }
+    conn.execute_batch("COMMIT;")
+}
+
+/// Whether a `type`-kind object named `name` exists in `sqlite_master` — the V044 sentinel probe
+/// (an index, but generic so the same helper reads for a table if a later widening needs it).
+fn github_object_exists(conn: &Connection, kind: &str, name: &str) -> rusqlite::Result<bool> {
+    Ok(conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type = ?1 AND name = ?2",
+            [kind, name],
+            |_| Ok(()),
+        )
+        .optional()?
+        .is_some())
+}
+
+/// Rebuild `github_issues` dropping the inline `UNIQUE(owner, repo, number)` and adding a NAMED
+/// unique index `(repo_id, owner, repo, number)` (the V044 sentinel + the `store_issue` `ON
+/// CONFLICT` target). The full V041 column set (through `repo_id`) is reproduced verbatim; `id`
+/// values are copied so a mid-flight papertrail resync's `github_fts.item_id` stays stable. Runs
+/// inside the caller's transaction (opens none of its own).
+fn rebuild_github_issues_with_repo_scoped_key(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS github_issues_new;
+        CREATE TABLE github_issues_new(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            owner TEXT NOT NULL,
+            repo TEXT NOT NULL,
+            number INTEGER NOT NULL,
+            html_url TEXT NOT NULL,
+            state TEXT NOT NULL,
+            title TEXT NOT NULL,
+            body TEXT NOT NULL,
+            author TEXT,
+            created_at TEXT,
+            updated_at TEXT,
+            is_pull_request INTEGER NOT NULL DEFAULT 0,
+            synced_at_ms INTEGER NOT NULL,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__'
+        );
+        INSERT INTO github_issues_new(
+            id, owner, repo, number, html_url, state, title, body, author, created_at, updated_at,
+            is_pull_request, synced_at_ms, repo_id
+        )
+        SELECT id, owner, repo, number, html_url, state, title, body, author, created_at,
+               updated_at, is_pull_request, synced_at_ms, repo_id
+        FROM github_issues;
+        DROP TABLE github_issues;
+        ALTER TABLE github_issues_new RENAME TO github_issues;
+        CREATE UNIQUE INDEX idx_github_issues_repo_unique
+            ON github_issues(repo_id, owner, repo, number);
+        ",
+    )
+}
+
+/// Rebuild `github_pull_requests` dropping the inline `UNIQUE(owner, repo, number)` and adding a
+/// NAMED unique index `(repo_id, owner, repo, number)` (the `store_pull` `ON CONFLICT` target). See
+/// [`rebuild_github_issues_with_repo_scoped_key`] for the shared rationale.
+fn rebuild_github_pull_requests_with_repo_scoped_key(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS github_pull_requests_new;
+        CREATE TABLE github_pull_requests_new(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            owner TEXT NOT NULL,
+            repo TEXT NOT NULL,
+            number INTEGER NOT NULL,
+            html_url TEXT NOT NULL,
+            state TEXT NOT NULL,
+            title TEXT NOT NULL,
+            body TEXT NOT NULL,
+            author TEXT,
+            created_at TEXT,
+            updated_at TEXT,
+            merged_at TEXT,
+            synced_at_ms INTEGER NOT NULL,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__'
+        );
+        INSERT INTO github_pull_requests_new(
+            id, owner, repo, number, html_url, state, title, body, author, created_at, updated_at,
+            merged_at, synced_at_ms, repo_id
+        )
+        SELECT id, owner, repo, number, html_url, state, title, body, author, created_at,
+               updated_at, merged_at, synced_at_ms, repo_id
+        FROM github_pull_requests;
+        DROP TABLE github_pull_requests;
+        ALTER TABLE github_pull_requests_new RENAME TO github_pull_requests;
+        CREATE UNIQUE INDEX idx_github_pull_requests_repo_unique
+            ON github_pull_requests(repo_id, owner, repo, number);
+        ",
+    )
+}
+
+/// Rebuild `github_ref_sync` widening its inline `PRIMARY KEY(owner, repo, number)` to
+/// `PRIMARY KEY(repo_id, owner, repo, number)` (the `github/sync.rs` `ON CONFLICT` target). Copies
+/// the full V041 column set verbatim.
+fn rebuild_github_ref_sync_with_repo_scoped_key(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS github_ref_sync_new;
+        CREATE TABLE github_ref_sync_new(
+            owner TEXT NOT NULL,
+            repo TEXT NOT NULL,
+            number INTEGER NOT NULL,
+            status TEXT NOT NULL,
+            synced_at_ms INTEGER NOT NULL,
+            last_error TEXT,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__',
+            PRIMARY KEY(repo_id, owner, repo, number)
+        );
+        INSERT INTO github_ref_sync_new(owner, repo, number, status, synced_at_ms, last_error, \
+         repo_id)
+        SELECT owner, repo, number, status, synced_at_ms, last_error, repo_id FROM github_ref_sync;
+        DROP TABLE github_ref_sync;
+        ALTER TABLE github_ref_sync_new RENAME TO github_ref_sync;
+        ",
+    )
+}
+
+/// Widen `github_refs`' uniqueness index to lead with `repo_id`. `github_refs`' own PK is `id
+/// AUTOINCREMENT`, so its `(owner, repo, number, source_kind, …)` uniqueness lives in the SEPARATE
+/// `idx_github_refs_unique` index — a DROP + CREATE swap suffices, no table rebuild. The trailing
+/// columns match `store_ref`'s widened `ON CONFLICT` target exactly.
+fn widen_github_refs_unique_index(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        DROP INDEX IF EXISTS idx_github_refs_unique;
+        CREATE UNIQUE INDEX idx_github_refs_unique
+            ON github_refs(repo_id, owner, repo, number, source_kind, COALESCE(source_path, ''),
+                           COALESCE(source_commit, ''), source_text);
+        ",
+    )
+}
+
+// ============================================================================================
+// Memory-sync phase A7 (GitHub id-keyed child widening) — V045.
+//
+// V044 widened the `(owner, repo, number)` natural keys but left the id-keyed CHILD caches
+// (`github_comments` / `github_reviews` / `github_review_comments`) keyed by GitHub's own item id
+// alone, documented as "last-syncer-owns". The consequence on a shared external issue/PR: each
+// repo's sync RESTAMPS the child rows to itself, the sync-tail FTS rebuild copies that repo_id
+// into the mirror, and every scoped reader filters `repo_id = active` — so repo A's papertrail
+// LOSES the PR's comments/reviews the moment repo B syncs, oscillating on every re-sync. V045
+// folds `repo_id` into the child keys so each repo owns its own copy.
+// ============================================================================================
+
+/// The V045 sentinel: the named unique index on `github_comments` (created inside the atomic
+/// migration, so its existence ⇒ the whole migration committed).
+const GITHUB_COMMENTS_REPO_UNIQUE_INDEX: &str = "idx_github_comments_repo_unique";
+
+/// V045 (memory-sync phase A7): widen the id-keyed GitHub child caches to `(repo_id, id)`
+/// uniqueness, so two repos sharing an external issue/PR each keep their own copy of its
+/// comments/reviews instead of last-syncer-owns oscillation (see the block comment above). Each
+/// table is rebuilt WITHOUT the inline `id INTEGER PRIMARY KEY` (the implicit rowid remains) plus
+/// a NAMED unique index `(repo_id, id)` — the V044 recipe; the `github_comments` index doubles as
+/// the all-or-nothing sentinel.
+///
+/// BACKFILL RULE (per row, lossless): a child row is copied once PER OWNING-PARENT repo — the
+/// DISTINCT `repo_id`s of the parent rows matching its `(owner, repo, number)` (comments parent =
+/// issues ∪ pull requests, both stored via the issues API; reviews / review comments parent =
+/// pull requests) — because post-V044 a shared parent exists under MULTIPLE repos and each owner's
+/// scoped papertrail must see the children. Additionally every row survives under its OWN stamped
+/// `repo_id` when not already covered (`NOT EXISTS` second pass): orphans with no cached parent,
+/// and the defensive case of a stamped repo whose parent row is missing. No row is ever dropped.
+///
+/// MECHANICS: no incoming FKs (no `foreign_keys` toggle needed); ONE self-wrapped
+/// `BEGIN IMMEDIATE`; leading `DROP TABLE IF EXISTS <scratch>_new` re-converges a hard-killed
+/// prior pass; the unique indexes are created AFTER the copies (the copy dedupes via UNION /
+/// NOT EXISTS, never via constraint suppression). The writers keep `INSERT OR REPLACE`, which now
+/// resolves through the widened unique index — a same-repo re-sync replaces in place, a sibling
+/// repo's sync inserts its own row. The `github_fts` mirror is re-derived INSIDE the migration
+/// ([`rebuild_github_fts_from_widened_bases`]) so the duplicated rows are scoped-searchable
+/// immediately, not only after the next sync.
+pub(crate) fn apply_github_child_key_widening(conn: &Connection) -> rusqlite::Result<()> {
+    if github_object_exists(conn, "index", GITHUB_COMMENTS_REPO_UNIQUE_INDEX)? {
+        return Ok(());
+    }
+    conn.execute_batch("BEGIN IMMEDIATE;")?;
+    let result = (|| -> rusqlite::Result<()> {
+        rebuild_github_comments_with_repo_scoped_key(conn)?;
+        rebuild_github_reviews_with_repo_scoped_key(conn)?;
+        rebuild_github_review_comments_with_repo_scoped_key(conn)?;
+        rebuild_github_fts_from_widened_bases(conn)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = conn.execute_batch("ROLLBACK;");
+        return result;
+    }
+    conn.execute_batch("COMMIT;")
+}
+
+/// Re-derive the standalone `github_fts` mirror from the freshly-widened base tables, INSIDE the
+/// V045 transaction — the V042 memory-FTS posture. Without this, the repos that just gained
+/// duplicated child rows still cannot FIND them through the scoped FTS readers
+/// (`rationale_search` / papertrail filter `repo_id = active`) until some later github sync
+/// happens to run the sync-tail rebuild — the migration would fix the base tables while the
+/// mirror kept serving the last-syncer state. The derivation mirrors `github::rebuild_fts`'s
+/// column mapping exactly (per-kind title slots; reviews' `COALESCE(html_url,'')`); the
+/// `classification` column is a Rust-derived label (`classify_text`), so it is CARRIED from the
+/// old mirror by `(item_kind, item_id)` — identical per item across per-repo duplicates — with
+/// `'other'` for never-mirrored rows (refreshed to the real label at the next sync's rebuild).
+/// GUARDED on `github_fts` presence: the schema-bootstrap isolation fixtures seed only the base
+/// tables. Torn-state safe: runs inside the caller's single transaction; the temp scratch is
+/// per-connection and re-created per run.
+fn rebuild_github_fts_from_widened_bases(conn: &Connection) -> rusqlite::Result<()> {
+    if !github_object_exists(conn, "table", "github_fts")? {
+        return Ok(());
+    }
+    conn.execute_batch(
+        "
+        CREATE TEMP TABLE IF NOT EXISTS v045_fts_class(
+            item_kind TEXT NOT NULL,
+            item_id TEXT NOT NULL,
+            classification TEXT NOT NULL,
+            PRIMARY KEY(item_kind, item_id)
+        );
+        DELETE FROM temp.v045_fts_class;
+        INSERT OR IGNORE INTO temp.v045_fts_class(item_kind, item_id, classification)
+            SELECT item_kind, item_id, classification FROM github_fts;
+        DELETE FROM github_fts;
+        INSERT INTO github_fts(owner, repo, number, item_kind, item_id, url, title, body, \
+         classification, repo_id)
+        SELECT i.owner, i.repo, i.number, 'issue', CAST(i.id AS TEXT), i.html_url, i.title, \
+         i.body, COALESCE(c.classification, 'other'), i.repo_id
+        FROM github_issues i
+        LEFT JOIN temp.v045_fts_class c
+          ON c.item_kind = 'issue' AND c.item_id = CAST(i.id AS TEXT);
+        INSERT INTO github_fts(owner, repo, number, item_kind, item_id, url, title, body, \
+         classification, repo_id)
+        SELECT m.owner, m.repo, m.number, 'comment', CAST(m.id AS TEXT), m.html_url, '', m.body,
+               COALESCE(c.classification, 'other'), m.repo_id
+        FROM github_comments m
+        LEFT JOIN temp.v045_fts_class c
+          ON c.item_kind = 'comment' AND c.item_id = CAST(m.id AS TEXT);
+        INSERT INTO github_fts(owner, repo, number, item_kind, item_id, url, title, body, \
+         classification, repo_id)
+        SELECT p.owner, p.repo, p.number, 'pull', CAST(p.id AS TEXT), p.html_url, p.title, p.body, \
+         COALESCE(c.classification, 'other'), p.repo_id
+        FROM github_pull_requests p
+        LEFT JOIN temp.v045_fts_class c
+          ON c.item_kind = 'pull' AND c.item_id = CAST(p.id AS TEXT);
+        INSERT INTO github_fts(owner, repo, number, item_kind, item_id, url, title, body, \
+         classification, repo_id)
+        SELECT r.owner, r.repo, r.number, 'review', CAST(r.id AS TEXT), COALESCE(r.html_url, ''), \
+         '', r.body, COALESCE(c.classification, 'other'), r.repo_id
+        FROM github_reviews r
+        LEFT JOIN temp.v045_fts_class c
+          ON c.item_kind = 'review' AND c.item_id = CAST(r.id AS TEXT);
+        INSERT INTO github_fts(owner, repo, number, item_kind, item_id, url, title, body, \
+         classification, repo_id)
+        SELECT rc.owner, rc.repo, rc.number, 'review_comment', CAST(rc.id AS TEXT), rc.html_url, \
+         COALESCE(rc.path, ''), rc.body, COALESCE(c.classification, 'other'), rc.repo_id
+        FROM github_review_comments rc
+        LEFT JOIN temp.v045_fts_class c
+          ON c.item_kind = 'review_comment' AND c.item_id = CAST(rc.id AS TEXT);
+        DROP TABLE temp.v045_fts_class;
+        ",
+    )
+}
+
+/// Rebuild `github_comments` with `(repo_id, id)` uniqueness, backfilled once per owning parent
+/// (issues ∪ pull requests — issue comments cover both) plus the own-repo_id lossless pass. Runs
+/// inside the caller's transaction.
+fn rebuild_github_comments_with_repo_scoped_key(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS github_comments_new;
+        CREATE TABLE github_comments_new(
+            id INTEGER NOT NULL,
+            owner TEXT NOT NULL,
+            repo TEXT NOT NULL,
+            number INTEGER NOT NULL,
+            html_url TEXT NOT NULL,
+            body TEXT NOT NULL,
+            author TEXT,
+            created_at TEXT,
+            updated_at TEXT,
+            synced_at_ms INTEGER NOT NULL,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__'
+        );
+        INSERT INTO github_comments_new(
+            id, owner, repo, number, html_url, body, author, created_at, updated_at, synced_at_ms,
+            repo_id
+        )
+        SELECT c.id, c.owner, c.repo, c.number, c.html_url, c.body, c.author, c.created_at,
+               c.updated_at, c.synced_at_ms, p.repo_id
+        FROM github_comments c
+        JOIN (SELECT owner, repo, number, repo_id FROM github_issues
+              UNION
+              SELECT owner, repo, number, repo_id FROM github_pull_requests) p
+          ON p.owner = c.owner AND p.repo = c.repo AND p.number = c.number;
+        INSERT INTO github_comments_new(
+            id, owner, repo, number, html_url, body, author, created_at, updated_at, synced_at_ms,
+            repo_id
+        )
+        SELECT c.id, c.owner, c.repo, c.number, c.html_url, c.body, c.author, c.created_at,
+               c.updated_at, c.synced_at_ms, c.repo_id
+        FROM github_comments c
+        WHERE NOT EXISTS (SELECT 1 FROM github_comments_new n
+                          WHERE n.repo_id = c.repo_id AND n.id = c.id);
+        DROP TABLE github_comments;
+        ALTER TABLE github_comments_new RENAME TO github_comments;
+        CREATE UNIQUE INDEX idx_github_comments_repo_unique ON github_comments(repo_id, id);
+        ",
+    )
+}
+
+/// Rebuild `github_reviews` with `(repo_id, id)` uniqueness, backfilled once per owning
+/// pull-request repo plus the own-repo_id lossless pass.
+fn rebuild_github_reviews_with_repo_scoped_key(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS github_reviews_new;
+        CREATE TABLE github_reviews_new(
+            id INTEGER NOT NULL,
+            owner TEXT NOT NULL,
+            repo TEXT NOT NULL,
+            number INTEGER NOT NULL,
+            html_url TEXT,
+            state TEXT NOT NULL,
+            body TEXT NOT NULL,
+            author TEXT,
+            submitted_at TEXT,
+            synced_at_ms INTEGER NOT NULL,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__'
+        );
+        INSERT INTO github_reviews_new(
+            id, owner, repo, number, html_url, state, body, author, submitted_at, synced_at_ms,
+            repo_id
+        )
+        SELECT r.id, r.owner, r.repo, r.number, r.html_url, r.state, r.body, r.author,
+               r.submitted_at, r.synced_at_ms, p.repo_id
+        FROM github_reviews r
+        JOIN (SELECT DISTINCT owner, repo, number, repo_id FROM github_pull_requests) p
+          ON p.owner = r.owner AND p.repo = r.repo AND p.number = r.number;
+        INSERT INTO github_reviews_new(
+            id, owner, repo, number, html_url, state, body, author, submitted_at, synced_at_ms,
+            repo_id
+        )
+        SELECT r.id, r.owner, r.repo, r.number, r.html_url, r.state, r.body, r.author,
+               r.submitted_at, r.synced_at_ms, r.repo_id
+        FROM github_reviews r
+        WHERE NOT EXISTS (SELECT 1 FROM github_reviews_new n
+                          WHERE n.repo_id = r.repo_id AND n.id = r.id);
+        DROP TABLE github_reviews;
+        ALTER TABLE github_reviews_new RENAME TO github_reviews;
+        CREATE UNIQUE INDEX idx_github_reviews_repo_unique ON github_reviews(repo_id, id);
+        ",
+    )
+}
+
+/// Rebuild `github_review_comments` with `(repo_id, id)` uniqueness, backfilled once per owning
+/// pull-request repo plus the own-repo_id lossless pass.
+fn rebuild_github_review_comments_with_repo_scoped_key(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS github_review_comments_new;
+        CREATE TABLE github_review_comments_new(
+            id INTEGER NOT NULL,
+            owner TEXT NOT NULL,
+            repo TEXT NOT NULL,
+            number INTEGER NOT NULL,
+            path TEXT,
+            html_url TEXT NOT NULL,
+            body TEXT NOT NULL,
+            author TEXT,
+            created_at TEXT,
+            updated_at TEXT,
+            synced_at_ms INTEGER NOT NULL,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__'
+        );
+        INSERT INTO github_review_comments_new(
+            id, owner, repo, number, path, html_url, body, author, created_at, updated_at,
+            synced_at_ms, repo_id
+        )
+        SELECT c.id, c.owner, c.repo, c.number, c.path, c.html_url, c.body, c.author,
+               c.created_at, c.updated_at, c.synced_at_ms, p.repo_id
+        FROM github_review_comments c
+        JOIN (SELECT DISTINCT owner, repo, number, repo_id FROM github_pull_requests) p
+          ON p.owner = c.owner AND p.repo = c.repo AND p.number = c.number;
+        INSERT INTO github_review_comments_new(
+            id, owner, repo, number, path, html_url, body, author, created_at, updated_at,
+            synced_at_ms, repo_id
+        )
+        SELECT c.id, c.owner, c.repo, c.number, c.path, c.html_url, c.body, c.author,
+               c.created_at, c.updated_at, c.synced_at_ms, c.repo_id
+        FROM github_review_comments c
+        WHERE NOT EXISTS (SELECT 1 FROM github_review_comments_new n
+                          WHERE n.repo_id = c.repo_id AND n.id = c.id);
+        DROP TABLE github_review_comments;
+        ALTER TABLE github_review_comments_new RENAME TO github_review_comments;
+        CREATE UNIQUE INDEX idx_github_review_comments_repo_unique
+            ON github_review_comments(repo_id, id);
+        ",
+    )
 }
 
 // ============================================================================================

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -3,22 +3,21 @@ mod migrations;
 mod registry;
 pub(crate) use baseline::*;
 pub(crate) use migrations::*;
-// `multiple_real_repos` lost its production callers when V042's real `repo_id` predicates
-// superseded the gc / clone-precompute seam guards (A5); it survives only as a
-// registry-internal check (`resolve_config_repo_id`) and a `multi_repo_scope` test assertion,
-// so the re-export is test-only now.
-#[cfg(test)]
+// `multiple_real_repos` lost its V042-era seam-guard callers (real `repo_id` predicates
+// superseded them, A5), but A7's bare-open fail-fast made it production again: a config-less
+// `IndexDatabase::open` refuses a multi-repo DB rather than silently scoping to the
+// lexicographically-first repo.
 pub(crate) use registry::multiple_real_repos;
 pub(crate) use registry::{
     CONNECTION_CONTEXT_GENERATION_KEY, CONNECTION_CONTEXT_REPO_KEY, LIVE_FILES_GENERATION_META_KEY,
     active_generation, active_repo_id, live_files_generation, periphery_repo_scope,
-    periphery_repo_scope_clause, resolve_config_repo_id, sole_repo_id,
+    periphery_repo_scope_clause, resolve_config_repo_id, scope_context_repo_id, sole_repo_id,
 };
 pub use registry::{LEGACY_REPO_ID, register_repo};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 43;
+pub const LATEST_SCHEMA_VERSION: u32 = 45;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -292,6 +291,22 @@ const MIGRATION_043_DESCRIPTION: &str =
      generation), so a full rebuild can stage a fresh generation of every file row alongside the \
      live one and flip readers over atomically instead of clearing-then-reinserting inside one \
      long write-locked transaction (memory-sync phase A6)";
+const MIGRATION_044_ID: &str = "044_github_natural_key_widening";
+const MIGRATION_044_CHECKSUM: &str = "sha256:rag-rat-github-natural-key-widening-v44";
+const MIGRATION_044_DESCRIPTION: &str =
+    "Fold repo_id into the (owner, repo, number)-style GitHub natural keys — widen github_issues \
+     / github_pull_requests UNIQUE and github_ref_sync PRIMARY KEY to (repo_id, owner, repo, \
+     number) and re-create idx_github_refs_unique with a leading repo_id — so two repos in a \
+     consolidated database can each cache the same external issue/PR/ref without one repo's sync \
+     overwriting the other's row (memory-sync phase A7)";
+const MIGRATION_045_ID: &str = "045_github_child_key_widening";
+const MIGRATION_045_CHECKSUM: &str = "sha256:rag-rat-github-child-key-widening-v45";
+const MIGRATION_045_DESCRIPTION: &str =
+    "Fold repo_id into the id-keyed GitHub child caches — rebuild github_comments / \
+     github_reviews / github_review_comments with (repo_id, id) uniqueness, backfilling one copy \
+     per owning-parent repo — so two repos sharing an external issue/PR each keep that item's \
+     comments and reviews in their scoped papertrail instead of last-syncer-owns restamping \
+     (memory-sync phase A7)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -649,6 +664,18 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_043_CHECKSUM,
         description: MIGRATION_043_DESCRIPTION,
         apply: apply_files_generation,
+    },
+    Migration {
+        id: MIGRATION_044_ID,
+        checksum: MIGRATION_044_CHECKSUM,
+        description: MIGRATION_044_DESCRIPTION,
+        apply: apply_github_natural_key_widening,
+    },
+    Migration {
+        id: MIGRATION_045_ID,
+        checksum: MIGRATION_045_CHECKSUM,
+        description: MIGRATION_045_DESCRIPTION,
+        apply: apply_github_child_key_widening,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema/registry.rs
+++ b/crates/rag-rat-core/src/index/schema/registry.rs
@@ -94,6 +94,11 @@ const SHALLOW_BOUNDARY_META_KEY: &str = "shallow_boundary";
 /// refusal, never a silent re-point under a live writer.
 const UPGRADE_OUTGOING_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
+/// How long [`register_repo`] waits for the DB-global registry lock (A7) before refusing — a
+/// registration is a millisecond-scale write, so a timeout means a wedged sibling process, and an
+/// explicit retryable refusal beats queueing forever.
+const REGISTRY_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Register `identity` in this database's `repos`/`repo_roots` registry, returning the stored
 /// `repo_id`.
 ///
@@ -104,17 +109,23 @@ const UPGRADE_OUTGOING_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::
 ///   `root` is recorded in `repo_roots`.
 /// - **Already this repo** → a no-op except that a not-yet-seen `root` is appended to `repo_roots`
 ///   (worktrees of one repo share a `repo_id`, so several roots on one machine are expected).
-/// - **A `local:` incumbent + an incoming `Portable` id** → *upgrade in place*: the DB was first
-///   indexed under a machine-local shallow-clone id, and the caller has since deepened it (`git
-///   fetch --unshallow`, our own remedy) or pinned a stable id, so the incoming identity is now
-///   portable. Every scoped row, `repo_meta`, `repo_roots`, and logical-symbol id is re-pointed
-///   from the local id to the portable one (the same adoption machinery), rather than stranding the
-///   existing index behind a refusal.
-/// - **Any other different real repo_id already owns the DB** → refuses (returns an error) rather
-///   than corrupting a single-repo DB: two genuinely-different portable repos, or a `LocalOnly`
-///   incoming against a real incumbent (a deepened clone must never DOWNGRADE a portable id back to
-///   machine-local). Multi-repo registration is deliberately out of scope until the default-path
-///   flip (phase A7); until then one DB == one repo.
+/// - **A `local:` incumbent + an incoming `Portable` id that proves the upgrade** → *upgrade in
+///   place*: the DB was first indexed under a machine-local shallow-clone id, and the caller has
+///   since deepened it (`git fetch --unshallow`, our own remedy) or pinned a stable id, so the
+///   incoming identity is now portable. Every scoped row, `repo_meta`, `repo_roots`, and
+///   logical-symbol id is re-pointed from the local id to the portable one (the same adoption
+///   machinery), rather than stranding the existing index behind a refusal. On a consolidated DB
+///   the incumbent is found by boundary reachability among ALL registered repos, so only the
+///   matching repo moves.
+/// - **A genuinely new repo joining the DB** → *fresh registration*: a new `repos` row and a
+///   `repo_roots` entry, nothing re-pointed. A7 makes several repos sharing one global database the
+///   default (replacing phase A's single-repo "refuse a second real repo" invariant).
+/// - **A new id whose working-tree `root` is already recorded under a DIFFERENT real repo** →
+///   refuses: a physical path belongs to exactly one repo, so an unregistered id at an
+///   already-owned root is a checkout whose identity changed without proving an upgrade (a
+///   re-shallowed clone downgrading a portable id, a deepened clone with no recorded boundary, or a
+///   rewritten root commit). Refusing avoids forking the repo across two ids; the remedy is to
+///   unshallow or pin `[index] repo_id`.
 ///
 /// `now_ms` is the injected clock (see the repo's time-injection convention), stamped as the
 /// registration time on adoption / first insert.
@@ -140,6 +151,43 @@ pub fn register_repo(
     }
 
     let root_str = root.to_string_lossy();
+
+    // REGISTRY LOCK (A7): serialize the WHOLE read-decide-write sequence across processes.
+    // Registration reads the registered-repo set, decides (idempotent / upgrade / refuse / fresh),
+    // then writes — two repos' concurrent FIRST registrations on the shared global DB would
+    // otherwise interleave between the read and the write (`SQLITE_BUSY_SNAPSHOT` on the deferred
+    // write upgrade, or a `repos`-PK constraint on the same-id race), and neither failure is
+    // retried on the CLI paths. Per-repo write locks cannot serialize this — the racing writers
+    // hold DIFFERENT repo ids by construction — so this is a DB-global lock like the schema lock,
+    // following the same ordering rule (per-repo entry locks → global lock; the per-repo locks the
+    // UPGRADE path takes while holding this are BOUNDED, so no cross-type cycle can hang — see
+    // `locks::registry_lock_path`). Bounded and reentrant; a timeout is a retryable refusal. A
+    // pathless (in-memory) connection skips it — no cross-process writer can exist for it.
+    let _registry_lock = match conn.path().filter(|p| !p.is_empty()) {
+        Some(db_path) => Some(
+            crate::locks::WriteLock::acquire_registry_timeout(
+                Path::new(db_path),
+                REGISTRY_LOCK_TIMEOUT,
+            )
+            .map_err(|err| {
+                registry_refusal(format!(
+                    "cannot register repo {}: failed acquiring the repo-registry lock: {err}",
+                    identity.repo_id
+                ))
+            })?
+            .ok_or_else(|| {
+                registry_refusal(format!(
+                    "cannot register repo {}: timed out waiting for a concurrent registration to \
+                     finish; re-run the command",
+                    identity.repo_id
+                ))
+            })?,
+        ),
+        None => None,
+    };
+    // Read the registered set INSIDE the registry lock, so the decision below cannot race a
+    // concurrent registration's write (a same-id racer that lost the lock re-reads a set already
+    // containing the id and collapses into the idempotent path).
     let real_ids = real_repo_ids(conn)?;
 
     // Already registered under this id → idempotent; just make sure the root is recorded (and, for
@@ -147,52 +195,69 @@ pub fn register_repo(
     // a later upgrade can prove against it — self-healing for an index first registered before
     // this gate).
     if real_ids.iter().any(|id| id == &identity.repo_id) {
+        // Even the idempotent path must not silently map one physical root onto TWO repos: a
+        // checkout whose identity changed to an ALREADY-REGISTERED id (an `[index] repo_id` pin
+        // switched to an existing repo, an in-place re-clone) would otherwise record its root
+        // under the second id and make `resolve_config_repo_id`'s recorded-root route
+        // non-deterministic (`LIMIT 1` over two owners). ONE exception before refusing: the
+        // LATE-upgrade merge — the owner is a `local:` incumbent whose (root ∧ boundary) proof
+        // holds for the incoming portable id, i.e. this is the SECOND shallow clone of an
+        // upstream deepening after a sibling clone already claimed the portable id. Refusing that
+        // shape would strand it permanently (the pin remedy re-enters this same guard); merging
+        // retires the local id into the registered one.
+        if let Some(owner) = real_root_owner(conn, &root_str, &identity.repo_id)? {
+            if late_upgrade_is_proven(conn, &owner, identity, root)? {
+                merge_local_incumbent_into_registered(conn, identity, &owner, &root_str, now_ms)?;
+                persist_shallow_boundary(conn, identity)?;
+                return Ok(identity.repo_id.clone());
+            }
+            return Err(registry_refusal(mismatched_root_owner_error(
+                &owner,
+                &identity.repo_id,
+                &root_str,
+            )));
+        }
         record_repo_root(conn, &identity.repo_id, &root_str, now_ms)?;
         persist_shallow_boundary(conn, identity)?;
         return Ok(identity.repo_id.clone());
     }
 
-    // A different real repo already owns this DB. The single-repo invariant refuses a second repo —
-    // with ONE exception: a shallow-clone UPGRADE. The DB was first indexed under a machine-local
-    // `local:` id (a cut shallow clone), and the caller has since deepened it (`git fetch
-    // --unshallow`, our own remedy) or pinned a stable id, so the incoming identity is now
-    // `Portable`. Re-point the DB from the local id onto the portable one in place (below) instead
-    // of stranding the existing index behind a refusal. Every OTHER mismatch still refuses:
-    // Portable↔different-Portable (two genuinely different repos), and a `LocalOnly` incoming
-    // against any existing real repo (a deepened clone must never DOWNGRADE a portable id back to
-    // machine-local). Guarded on exactly one real repo — a consolidated DB (post-A7) is never
-    // upgraded through this path.
-    let upgrade_from = match real_ids.as_slice() {
-        [] => None,
-        [incumbent]
-            if incumbent.starts_with(LOCAL_ONLY_ID_PREFIX)
-                && identity.class == RepoIdentityClass::Portable =>
-        {
-            // The `local:` prefix + Portable incoming is NECESSARY but not SUFFICIENT: a DB first
-            // indexed from a cut shallow clone, later opened from an UNRELATED full repo at the
-            // same database path (or with a mistaken pin), would otherwise silently
-            // re-point every scoped row, repo_meta, root, and logical id onto that
-            // unrelated id — data loss across two repos. Require PROOF the incoming
-            // clone is a DEEPENED version of THIS incumbent: the incumbent's recorded
-            // shallow-boundary commits must be reachable from the incoming clone's HEAD
-            // (a `git fetch --unshallow` keeps those commits in history; a different
-            // repo reaches none of them). No recorded boundary (a pre-gate registration) counts as
-            // NO PROOF. Verified BEFORE the adoption transaction so a refusal touches nothing.
-            let boundary = read_shallow_boundary(conn, incumbent)?;
-            let proven = !boundary.is_empty()
-                && crate::repo_identity::boundary_reachable_from_head(root, &boundary)
-                    .unwrap_or(false);
-            if !proven {
-                return Err(registry_refusal(unproven_upgrade_error(incumbent, &identity.repo_id)));
-            }
-            Some(incumbent.clone())
-        },
-        _ =>
-            return Err(registry_refusal(format!(
-                "cannot register repo {}: this index is already registered to a different repo {}",
-                identity.repo_id, real_ids[0]
-            ))),
-    };
+    // The incoming id is NOT yet registered. Three outcomes, decided BEFORE any lock or transaction
+    // so a refusal touches nothing:
+    //
+    //  (1) UPGRADE — the incoming id is Portable and some already-registered `local:` incumbent's
+    //      recorded shallow boundary is reachable from the incoming clone's HEAD: the caller
+    // deepened      that machine-local shallow clone (`git fetch --unshallow`, our own remedy)
+    // or opened a      full clone of the same repo, so re-point the incumbent onto the portable
+    // id IN PLACE      (below). Searching ALL registered ids — not a lone incumbent — is what
+    // makes this correct      on a CONSOLIDATED multi-repo DB (A7): only the matching repo's
+    // boundary is reachable, and      the re-point touches only that repo's rows, so every
+    // other registered repo is left alone.
+    //
+    //  (2) FRESH REGISTRATION — a genuinely NEW repo joining the DB. A7 makes several repos sharing
+    //      one global database the default, so a new id at an unclaimed working tree simply gets
+    // its      own `repos` row (no re-point). This is the behavior that replaces phase A's
+    // single-repo      "refuse a second real repo" invariant.
+    //
+    //  (3) REFUSAL — the incoming id is new AND its working-tree `root` is already recorded under a
+    //      DIFFERENT real repo (see [`real_root_owner`]). A physical path belongs to exactly one
+    //      repo, so this is a checkout whose identity changed WITHOUT proving an upgrade: a
+    //      re-shallowed clone (a `LocalOnly` incoming must never DOWNGRADE the portable id its root
+    //      already owns), a deepened clone whose shallow boundary was never recorded (unprovable
+    //      upgrade), or a rewritten root commit. Refuse rather than fork the repo across two ids;
+    //      the remedy is to unshallow or pin `[index] repo_id`. This generalizes the phase-A
+    //      single-repo "different real repo" / "unproven upgrade" / "no downgrade" refusals to the
+    //      multi-repo DB, keyed on the ROOT rather than a lone incumbent.
+    let upgrade_from = find_upgradeable_local_incumbent(conn, &real_ids, identity, root)?;
+    if upgrade_from.is_none()
+        && let Some(owner) = real_root_owner(conn, &root_str, &identity.repo_id)?
+    {
+        return Err(registry_refusal(mismatched_root_owner_error(
+            &owner,
+            &identity.repo_id,
+            &root_str,
+        )));
+    }
 
     // UPGRADE HOLDS BOTH REPO LOCKS (A6, batch-4/5 P2). Writers key their per-repo advisory flock
     // by the DERIVED repo id, and the derivation flips `local:` → portable the moment the clone
@@ -211,34 +276,8 @@ pub fn register_repo(
     // machine must still serialize on repo_id, which path-keying would break. A pathless
     // (in-memory) connection skips the locks — no cross-process writer can exist for it.
     let _upgrade_locks = match (&upgrade_from, conn.path().filter(|p| !p.is_empty())) {
-        (Some(local_id), Some(db_path)) => {
-            let db_path = Path::new(db_path);
-            let (first, second) =
-                crate::locks::canonical_lock_order(local_id.as_str(), &identity.repo_id);
-            let mut guards = Vec::with_capacity(2);
-            for repo in [first, second] {
-                guards.push(
-                    crate::locks::WriteLock::acquire_timeout(
-                        db_path,
-                        repo,
-                        UPGRADE_OUTGOING_LOCK_TIMEOUT,
-                    )
-                    .map_err(|err| {
-                        registry_refusal(format!(
-                            "cannot upgrade {local_id}: failed acquiring the write lock for \
-                             {repo}: {err}"
-                        ))
-                    })?
-                    .ok_or_else(|| {
-                        registry_refusal(format!(
-                            "cannot upgrade {local_id}: timed out waiting for an in-flight writer \
-                             holding the write lock for {repo}"
-                        ))
-                    })?,
-                );
-            }
-            Some(guards)
-        },
+        (Some(local_id), Some(db_path)) =>
+            Some(acquire_dual_repo_locks(Path::new(db_path), local_id, &identity.repo_id)?),
         _ => None,
     };
 
@@ -254,22 +293,40 @@ pub fn register_repo(
     // would break on. `unchecked_transaction` is the right tool on a shared `&Connection`
     // (rusqlite): it needs no `&mut`, commits on `.commit()`, and rolls back on drop. The fresh
     // path (no placeholder, no upgrade) runs in the same transaction for uniformity.
-    let tx = conn.unchecked_transaction()?;
+    // IMMEDIATE, not deferred (A7): the transaction is decided-then-written, and a deferred BEGIN
+    // that upgrades to a write mid-transaction can fail `SQLITE_BUSY_SNAPSHOT` (not retried by
+    // `busy_timeout`) if any other writer committed since the first read. `BEGIN IMMEDIATE` takes
+    // the write lock up front under the normal busy-timeout wait. The registry flock above already
+    // serializes registrations against each other; IMMEDIATE covers contention with NON-registry
+    // writers (an index pass on a sibling repo).
+    let tx = rusqlite::Transaction::new_unchecked(conn, rusqlite::TransactionBehavior::Immediate)?;
     let placeholder_present = tx
         .query_row("SELECT 1 FROM repos WHERE repo_id = ?1", [LEGACY_REPO_ID], |_| Ok(()))
         .optional()?
         .is_some();
+    // `ON CONFLICT DO NOTHING` is defense in depth for the lockless (pathless/in-memory)
+    // connections the registry flock cannot serialize: a same-id racer that somehow landed first
+    // collapses this into a no-op instead of a PK constraint failure, and the row content it wrote
+    // is what an idempotent re-registration would have kept anyway.
     tx.execute(
-        "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, ?2, ?3)",
+        "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, ?2, ?3)
+         ON CONFLICT(repo_id) DO NOTHING",
         params![identity.repo_id, identity.display_name, now_ms],
     )?;
     // The id whose rows this registration re-points ONTO the new id: the machine-local incumbent on
     // a shallow-clone upgrade, else the `__unassigned__` placeholder on a fresh adoption. Both
     // cases re-point the same scoped tables + realign the same logical ids and then drop the
     // old `repos` row; only the upgrade path actually has `repo_roots` rows to move (the
-    // placeholder never does, so that UPDATE is a harmless no-op there).
-    let repoint_from =
-        upgrade_from.as_deref().or_else(|| placeholder_present.then_some(LEGACY_REPO_ID));
+    // placeholder never does, so that UPDATE is a harmless no-op there). The placeholder is adopted
+    // ONLY on a genuinely fresh legacy DB (no real repo yet): on a CONSOLIDATED DB that already
+    // holds real repos (A7), a new repo registers FRESH and must NOT claim any vestigial
+    // placeholder rows as its own — so `repoint_from` is `None` there and the block below is
+    // skipped entirely.
+    let repoint_from = match upgrade_from.as_deref() {
+        Some(local_id) => Some(local_id),
+        None if real_ids.is_empty() && placeholder_present => Some(LEGACY_REPO_ID),
+        None => None,
+    };
     if let Some(source_id) = repoint_from {
         // Move every source-id `repo_meta` row onto the new id EXCEPT the shallow-boundary record:
         // it describes the OLD `local:` clone's cut history and is meaningless under the portable
@@ -300,10 +357,15 @@ pub fn register_repo(
             if !adoption_table_present(&tx, table)? {
                 continue;
             }
-            tx.execute(&format!("UPDATE {table} SET repo_id = ?1 WHERE repo_id = ?2"), params![
-                identity.repo_id,
-                source_id
-            ])?;
+            // `main.`-qualified: adoption can run on a connection that already carries the
+            // temp `files` scope view (the incremental pass's bare open installs it BEFORE
+            // adopting), and an unqualified `UPDATE files` would hit that view — "cannot
+            // modify files because it is a view". The qualifier pins every re-point to the
+            // real table regardless of what temp views the connection carries.
+            tx.execute(
+                &format!("UPDATE main.{table} SET repo_id = ?1 WHERE repo_id = ?2"),
+                params![identity.repo_id, source_id],
+            )?;
         }
         // A5 periphery tables (clones/oracle/reconcile/memories). Their `repo_id` column lands in
         // V042; several of these tables predate it, so a partial-schema bootstrap fixture that
@@ -314,8 +376,9 @@ pub fn register_repo(
         // rows off the `local:` incumbent too, exactly like the core/github loop above.
         for table in A5_PERIPHERY_DIRECT_SCOPED_TABLES {
             if super::column_exists(&tx, table, "repo_id")? {
+                // `main.`-qualified for the same view-shadowing reason as the core loop above.
                 tx.execute(
-                    &format!("UPDATE {table} SET repo_id = ?1 WHERE repo_id = ?2"),
+                    &format!("UPDATE main.{table} SET repo_id = ?1 WHERE repo_id = ?2"),
                     params![identity.repo_id, source_id],
                 )?;
             }
@@ -370,6 +433,190 @@ pub fn register_repo(
     Ok(identity.repo_id.clone())
 }
 
+/// Acquire BOTH repo ids' per-repo write locks in the CANONICAL LEXICOGRAPHIC ORDER
+/// (`locks::canonical_lock_order`), each reentrant-instant when this thread already holds it and
+/// BOUNDED otherwise — the A6 rule that keeps identity-transition flows deadlock-free (in-order
+/// unbounded edges cannot cycle under a total order; bounded out-of-order edges self-break).
+/// Shared by the in-place LocalOnly→Portable upgrade and the LATE-upgrade merge, both of which
+/// re-point/move rows across an OUTGOING `local:` id and an incoming/target id and must serialize
+/// with writers holding EITHER lock (a pre-unshallow writer holds the `local:` one, a
+/// post-unshallow writer the portable one).
+fn acquire_dual_repo_locks(
+    db_path: &Path,
+    outgoing_id: &str,
+    target_id: &str,
+) -> rusqlite::Result<Vec<crate::locks::WriteLock>> {
+    let (first, second) = crate::locks::canonical_lock_order(outgoing_id, target_id);
+    let mut guards = Vec::with_capacity(2);
+    for repo in [first, second] {
+        guards.push(
+            crate::locks::WriteLock::acquire_timeout(db_path, repo, UPGRADE_OUTGOING_LOCK_TIMEOUT)
+                .map_err(|err| {
+                    registry_refusal(format!(
+                        "cannot upgrade {outgoing_id}: failed acquiring the write lock for \
+                         {repo}: {err}"
+                    ))
+                })?
+                .ok_or_else(|| {
+                    registry_refusal(format!(
+                        "cannot upgrade {outgoing_id}: timed out waiting for an in-flight writer \
+                         holding the write lock for {repo}"
+                    ))
+                })?,
+        );
+    }
+    Ok(guards)
+}
+
+/// The direct-scoped tables whose rows the LATE-upgrade merge DELETES under the retiring `local:`
+/// id (its DERIVED data): the A5 periphery list MINUS the three memory tables, which are AUTHORED
+/// and are MOVED onto the target id instead. Children fall via `ON DELETE CASCADE`
+/// (`clone_edges`/`clone_subblock_postings` off `clone_graph_generations`,
+/// `logical_symbol_members` off `logical_symbols` — deleted via [`DIRECT_SCOPED_ADOPTION_TABLES`]).
+const LATE_MERGE_DERIVED_PERIPHERY_TABLES: &[&str] = &[
+    "clone_graph_generations",
+    "clone_token_df",
+    "clone_refinements",
+    "oracle_runs",
+    "edge_oracle",
+    "logical_symbol_monikers",
+    "reconcile_attempts",
+    "dream_findings",
+];
+
+/// Whether the conflicting `owner` of the incoming root is a `local:` incumbent that PROVES a
+/// LATE upgrade onto the already-registered `identity`: the incoming id is Portable, the owner is
+/// machine-local, and the owner's recorded shallow boundary is reachable from the incoming root's
+/// HEAD — i.e. this checkout IS that shallow clone, deepened AFTER a sibling clone already
+/// upgraded their shared upstream id. Without this, the second clone is PERMANENTLY stranded: the
+/// idempotent branch's root-owner guard refuses, and pinning the portable id re-enters the same
+/// refusal.
+fn late_upgrade_is_proven(
+    conn: &Connection,
+    owner: &str,
+    identity: &RepoIdentity,
+    root: &Path,
+) -> rusqlite::Result<bool> {
+    if !owner.starts_with(LOCAL_ONLY_ID_PREFIX) || identity.class != RepoIdentityClass::Portable {
+        return Ok(false);
+    }
+    let boundary = read_shallow_boundary(conn, owner)?;
+    Ok(!boundary.is_empty()
+        && crate::repo_identity::boundary_reachable_from_head(root, &boundary).unwrap_or(false))
+}
+
+/// LATE-upgrade merge: retire the `local:` incumbent `owner` INTO the already-registered
+/// `target_id` (the second shallow clone of an upstream whose portable id a sibling clone already
+/// claimed). Unlike the in-place upgrade, the target has LIVE data — same upstream, so the same
+/// paths/commits — and a wholesale re-point would collide on the widened UNIQUE keys and the
+/// generation axis. So the merge takes the consolidate-shaped split:
+///
+///  * AUTHORED data MOVES: `repo_memories` (+ bindings / FTS mirror) re-point to `target_id` — the
+///    memory `id` is the bare PK, so a re-point can never collide. The bindings' LOCAL rowid
+///    columns and the call-paths' logical-symbol endpoints are NULLed (they reference the retiring
+///    id's derived rows, deleted below); the validate loop re-resolves them from the portable
+///    anchor after the next index pass — exactly the consolidate posture. Tags/call-paths follow
+///    via `memory_id`.
+///  * DERIVED data is DROPPED, not migrated: files (cascading chunks/symbols/edges), git history,
+///    github papertrail, clones, oracle, reconcile, dream rows under `owner` are deleted — a fresh
+///    index of this root re-derives them under `target_id`, and the carried `embedding_cache`
+///    (content-addressed, global) makes re-embedding a no-op. Leaving them "for gc" was rejected:
+///    gc sweeps are per-ACTIVE-repo, so rows under a retired id would be permanent invisible
+///    garbage.
+///  * The root and registration retire atomically: `repo_roots` moves to `target_id`, the `owner`
+///    repos row is deleted (cascading its `repo_meta`, including the now-meaningless shallow
+///    boundary). The target's own model-state meta is left as-is — same machine, same upstream.
+///
+/// Crash-convergent: everything runs in ONE IMMEDIATE transaction under the registry lock and BOTH
+/// ids' per-repo locks (canonical order, bounded — the caller-held entry lock for either id is
+/// reentrant-instant). A crash rolls the whole merge back to the pre-merge state, which re-proves
+/// and re-runs on the next open.
+///
+/// REGISTRY-STALL TRADEOFF (deliberate — do not split this transaction in an optimization pass
+/// without re-weighing it): the cascade-DELETE of the retiring repo's ENTIRE derived dataset runs
+/// inside the registry lock, so a very large late-merging repo stalls every OTHER repo's
+/// registering open for the DELETE's duration — worst case a bounded, RETRYABLE refusal after
+/// `REGISTRY_LOCK_TIMEOUT` (30s), never a hang, and read paths never take the registry lock.
+/// Accepted because a late merge happens at most once per shallow clone's lifetime and the
+/// alternative forfeits more: draining the derived rows in a PRIOR committed transaction (under
+/// the two per-repo locks only) would keep the registry lock hold at milliseconds, but gives up
+/// the single-transaction atomicity claim — a crash between the drain and the merge leaves
+/// derived-row-less-but-still-registered `local:` state that the next open's re-prove must
+/// tolerate (it does converge: the proof re-holds and the merge re-runs over the already-drained
+/// rows). That is the sketched escape hatch if the stall ever bites in practice.
+///
+/// TABLE COVERAGE: [`DIRECT_SCOPED_ADOPTION_TABLES`] + [`LATE_MERGE_DERIVED_PERIPHERY_TABLES`]
+/// were audited complete against every `repo_id`-carrying table at V044; V045 widened the github
+/// CHILD tables' keys but introduced no new `repo_id` table (they were already in the direct
+/// list via V041), so the disposition is unchanged. A future migration adding a NEW
+/// `repo_id`-scoped table must add it to one of these lists (or the authored-move set above).
+fn merge_local_incumbent_into_registered(
+    conn: &Connection,
+    identity: &RepoIdentity,
+    owner: &str,
+    root_str: &str,
+    now_ms: i64,
+) -> rusqlite::Result<()> {
+    let _merge_locks = match conn.path().filter(|p| !p.is_empty()) {
+        Some(db_path) =>
+            Some(acquire_dual_repo_locks(Path::new(db_path), owner, &identity.repo_id)?),
+        None => None,
+    };
+    let tx = rusqlite::Transaction::new_unchecked(conn, rusqlite::TransactionBehavior::Immediate)?;
+    // AUTHORED data moves. Call-path logical endpoints first (they key off the memories that are
+    // about to change repo_id), then bindings (repo_id + rowid NULLing in one pass), then the
+    // memories and the FTS mirror.
+    tx.execute(
+        "UPDATE repo_memory_call_paths SET start_logical_symbol_id = NULL, end_logical_symbol_id \
+         = NULL
+         WHERE memory_id IN (SELECT id FROM repo_memories WHERE repo_id = ?1)",
+        [owner],
+    )?;
+    tx.execute(
+        "UPDATE main.repo_memory_bindings SET repo_id = ?1, logical_symbol_id = NULL, symbol_id = \
+         NULL, chunk_id = NULL, edge_id = NULL WHERE repo_id = ?2",
+        params![identity.repo_id, owner],
+    )?;
+    tx.execute("UPDATE main.repo_memories SET repo_id = ?1 WHERE repo_id = ?2", params![
+        identity.repo_id,
+        owner
+    ])?;
+    if adoption_table_present(&tx, "repo_memory_fts")? {
+        tx.execute("UPDATE main.repo_memory_fts SET repo_id = ?1 WHERE repo_id = ?2", params![
+            identity.repo_id,
+            owner
+        ])?;
+    }
+    // DERIVED data drops (cascades take the transitive children).
+    for table in DIRECT_SCOPED_ADOPTION_TABLES {
+        if adoption_table_present(&tx, table)? {
+            tx.execute(&format!("DELETE FROM main.{table} WHERE repo_id = ?1"), [owner])?;
+        }
+    }
+    for table in LATE_MERGE_DERIVED_PERIPHERY_TABLES {
+        if super::column_exists(&tx, table, "repo_id")? {
+            tx.execute(&format!("DELETE FROM main.{table} WHERE repo_id = ?1"), [owner])?;
+        }
+    }
+    // Registration retires: roots move BEFORE the repos delete (its FK cascades), then the owner
+    // row falls, taking its repo_meta (shallow boundary included) with it.
+    tx.execute("UPDATE repo_roots SET repo_id = ?1 WHERE repo_id = ?2", params![
+        identity.repo_id,
+        owner
+    ])?;
+    tx.execute("DELETE FROM repos WHERE repo_id = ?1", [owner])?;
+    record_repo_root(&tx, &identity.repo_id, root_str, now_ms)?;
+    tx.commit()?;
+    tracing::warn!(
+        old_repo_id = %owner,
+        new_repo_id = %identity.repo_id,
+        "late shallow-clone upgrade: this checkout's machine-local id was retired into the \
+         already-registered portable id (a sibling clone upgraded it first). Its memories moved \
+         over; its derived index rows were dropped and will re-derive on the next index pass."
+    );
+    Ok(())
+}
+
 /// Whether `table` exists in the schema (a plain or FTS5-virtual table both register in
 /// `sqlite_master` as `type = 'table'`) — the adoption loop's guard so a partial isolation
 /// fixture's absent direct-scoped table is skipped rather than tripping a `no such table` failure.
@@ -422,17 +669,100 @@ fn read_shallow_boundary(conn: &Connection, repo_id: &str) -> rusqlite::Result<V
         .unwrap_or_default())
 }
 
-/// The refusal message for a LocalOnly→Portable upgrade that could not be PROVEN: the incoming
-/// portable clone does not reach the machine-local incumbent's recorded shallow boundary (or none
-/// was recorded), so re-pointing the index onto it risks migrating one repo's data onto an
-/// unrelated id. Names the pin escape hatch to force it when the two genuinely ARE the same repo.
-fn unproven_upgrade_error(incumbent: &str, incoming: &str) -> String {
+/// The already-registered `local:` incumbent, if any, that the INCOMING identity upgrades in place:
+/// a Portable incoming from the SAME recorded working tree whose HEAD reaches that incumbent's
+/// recorded shallow boundary — proof the incoming clone is a DEEPENED version of the machine-local
+/// one (`git fetch --unshallow` keeps the boundary commits in history; an unrelated repo reaches
+/// none of them).
+///
+/// BOTH conditions are load-bearing (root ∧ boundary): with two shallow clones of the SAME upstream
+/// registered under distinct `local:` ids — an ordinary shape on the shared global DB — a deepened
+/// checkout's HEAD reaches BOTH boundaries, so a boundary-only scan would re-point whichever
+/// incumbent SORTS first, hijacking the sibling clone's index and stranding the actually-deepened
+/// one behind the root-owner refusal. Deepening happens in place (`git fetch --unshallow` mutates
+/// the working tree that registered shallow), so the deepened clone's root IS the incumbent's
+/// recorded root — require that match first, then the boundary proof on top (a root match alone
+/// could be a re-cloned unrelated repo at a reused path).
+///
+/// `None` for a LocalOnly incoming (an upgrade only runs Portable-ward — a deepened clone must
+/// never downgrade), for a root-matching incumbent with no recorded boundary (a pre-gate
+/// registration ⇒ no proof — falls through to the root-owner refusal, which names the pin remedy),
+/// or when no root-matching `local:` incumbent exists (a genuinely new clone registers fresh).
+/// Runs inside the registry lock, before any transaction, so a non-match touches nothing.
+fn find_upgradeable_local_incumbent(
+    conn: &Connection,
+    real_ids: &[String],
+    identity: &RepoIdentity,
+    root: &Path,
+) -> rusqlite::Result<Option<String>> {
+    if identity.class != RepoIdentityClass::Portable {
+        return Ok(None);
+    }
+    let root_str = root.to_string_lossy();
+    for id in real_ids {
+        if !id.starts_with(LOCAL_ONLY_ID_PREFIX) {
+            continue;
+        }
+        if !repo_has_recorded_root(conn, id, &root_str)? {
+            continue;
+        }
+        let boundary = read_shallow_boundary(conn, id)?;
+        if !boundary.is_empty()
+            && crate::repo_identity::boundary_reachable_from_head(root, &boundary).unwrap_or(false)
+        {
+            return Ok(Some(id.clone()));
+        }
+    }
+    Ok(None)
+}
+
+/// Whether `repo_id` has `root` recorded in `repo_roots` — the upgrade scan's working-tree match
+/// (both sides store the identical `to_string_lossy` rendering of a `Config::load`-canonicalized
+/// root, so equality is exact).
+fn repo_has_recorded_root(conn: &Connection, repo_id: &str, root: &str) -> rusqlite::Result<bool> {
+    conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM repo_roots WHERE repo_id = ?1 AND root = ?2)",
+        params![repo_id, root],
+        |row| row.get(0),
+    )
+}
+
+/// The real repo id — other than `exclude_id` and the placeholder — that already records `root` in
+/// `repo_roots`, or `None` when no OTHER real repo claims this working-tree path. A physical path
+/// belongs to exactly one repo, so a recorded owner that differs from the incoming id signals an
+/// identity change that must not silently fork the repo — [`register_repo`] refuses it on BOTH the
+/// fresh path (unless the incoming proved an upgrade) and the idempotent path (an identity change
+/// ONTO an already-registered id). `exclude_id` is the incoming id itself, so the idempotent
+/// re-registration of a root under its own repo never self-trips (on the fresh path the incoming id
+/// is unregistered and cannot own roots, so the exclusion is a no-op there).
+fn real_root_owner(
+    conn: &Connection,
+    root: &str,
+    exclude_id: &str,
+) -> rusqlite::Result<Option<String>> {
+    conn.query_row(
+        "SELECT repo_id FROM repo_roots WHERE root = ?1 AND repo_id != ?2 AND repo_id != ?3 LIMIT \
+         1",
+        params![root, LEGACY_REPO_ID, exclude_id],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()
+}
+
+/// The refusal message for an unregistered incoming id whose working-tree `root` is already
+/// recorded under a DIFFERENT real repo, without proving a shallow-clone upgrade. Covers all three
+/// phase-A refusals now keyed on the root: a re-shallowed clone downgrading a portable id, a
+/// deepened clone whose shallow boundary was never recorded (unprovable upgrade), and a rewritten
+/// root commit. Names both remedies (unshallow / pin) to force it when the two genuinely ARE the
+/// same repo.
+fn mismatched_root_owner_error(owner: &str, incoming: &str, root: &str) -> String {
     format!(
-        "cannot upgrade the machine-local repo id {incumbent} to {incoming}: could not prove the \
-         incoming repository is a deepened clone of this index (its history does not reach the \
-         recorded shallow boundary, or no boundary was recorded). Refusing rather than re-point \
-         this index onto a possibly-different repo. If they ARE the same repository, pin `[index] \
-         repo_id = \"{incoming}\"` in rag-rat.toml to force it."
+        "cannot register repo {incoming} for {root}: that working tree is already registered to a \
+         different repo {owner}, and the incoming identity did not prove a shallow-clone upgrade \
+         (its history does not reach the recorded shallow boundary, or a machine-local id would \
+         downgrade a portable one). Refusing rather than fork the repo across two ids. If they \
+         ARE the same repository, unshallow the clone (`git fetch --unshallow`) or pin `[index] \
+         repo_id = \"{incoming}\"` in rag-rat.toml."
     )
 }
 
@@ -500,6 +830,15 @@ pub(crate) fn periphery_repo_scope_clause(scope: &Option<String>, qualifier: &st
         Some(repo_id) => format!(" AND {qualifier}.repo_id = '{}'", repo_id.replace('\'', "''")),
         None => String::new(),
     }
+}
+
+/// The repo id INSTALLED in the per-connection scope context, or `None` when no context row exists
+/// — the public probe for "is this connection scoped?". Unlike [`active_repo_id`] it NEVER falls
+/// back to [`sole_repo_id`], so a caller can distinguish a genuinely scoped connection from the
+/// config-less sole-repo pick (the manifest heal's witness needs exactly that distinction: on a
+/// multi-repo DB the sole pick is an arbitrary first-sorting repo, not an honest attribution).
+pub(crate) fn scope_context_repo_id(conn: &Connection) -> Option<String> {
+    context_repo_id(conn)
 }
 
 /// Read the active repo id from the per-connection scope context, tolerating the common absence of
@@ -575,11 +914,10 @@ pub(crate) fn sole_repo_id(conn: &Connection) -> rusqlite::Result<String> {
 }
 
 /// Whether this DB holds MORE THAN ONE real (adopted) repo — the interim guard for global-scope
-/// destructive sweeps over tables that do not yet carry `repo_id` (`oracle_runs`,
-/// `clone_graph_generations`; both gain the column in V042). When true, a per-repo caller must SKIP
-/// the global cleanup rather than wipe a sibling repo's rows. Today `register_repo` keeps this at
-/// one real repo until the A7 default-path flip, so the guard is dormant but present for the V042
-/// seam.
+/// destructive sweeps over tables that did not yet carry `repo_id` (superseded by V042's real
+/// predicates) — and, since A7 made multi-repo the default, the bare-open fail-fast: a config-less
+/// `IndexDatabase::open` refuses a DB where this is true rather than silently scoping to the
+/// lexicographically-first repo, and `resolve_config_repo_id` declines its sole-repo fallback.
 pub(crate) fn multiple_real_repos(conn: &Connection) -> rusqlite::Result<bool> {
     let count: i64 = conn.query_row(
         "SELECT COUNT(*) FROM repos WHERE repo_id != ?1",
@@ -622,9 +960,20 @@ pub(crate) fn resolve_config_repo_id(
     repo_id_override: Option<&str>,
 ) -> rusqlite::Result<Option<String>> {
     match crate::repo_identity::resolve_repo_identity(root, repo_id_override) {
-        // Route 1: a derivable id that is registered scopes correctly even in a consolidated DB.
-        Ok(identity) if repo_id_is_registered(conn, &identity.repo_id)? =>
-            Ok(Some(identity.repo_id)),
+        // Route 1: a derivable id that is registered scopes correctly even in a consolidated DB —
+        // UNLESS this root is recorded under a DIFFERENT real repo. That is the read-only MIRROR
+        // of `register_repo`'s root-owner refusal: after an `[index] repo_id` pin is switched to a
+        // SIBLING's id, the write path refuses, but without this check the read-only fast path
+        // (MCP reads, hooks) would silently serve the sibling's scope. Returning `None` declines
+        // the fast path, so the caller falls back to the read-write open where the refusal
+        // surfaces with its remedy.
+        Ok(identity) if repo_id_is_registered(conn, &identity.repo_id)? => {
+            let root_str = root.to_string_lossy();
+            if real_root_owner(conn, &root_str, &identity.repo_id)?.is_some() {
+                return Ok(None);
+            }
+            Ok(Some(identity.repo_id))
+        },
         // A RESOLVED but UNREGISTERED identity — a new/changed `[index] repo_id` pin, or a shallow
         // clone that now derives a portable id — must NOT silently bind the OLD scope. Return None
         // so the read-only open declines to the read-write open, which registers/upgrades

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
@@ -1069,6 +1069,7 @@ fn multi_language_clone_integration_finds_within_language_no_cross() {
 
     let config = Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![
@@ -1280,6 +1281,7 @@ fn find_clones_ranks_a_clean_clone_class_with_metrics() {
 
     let config = Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dir_memory_tree.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dir_memory_tree.rs
@@ -302,6 +302,7 @@ fn dir_tree_label_depth_collapse_single_child_chain() {
     }
     let config = Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
@@ -530,6 +531,7 @@ fn dir_tree_truncates_at_max_nodes() {
     }
     let config = Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
@@ -675,6 +677,7 @@ fn dir_tree_children_of_collapsed_node_use_leaf_labels() {
     }
     let config = Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/generation_rebuild.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/generation_rebuild.rs
@@ -89,14 +89,19 @@ fn reader_sees_path(db_path: &Path, root: &Path, path: &str) -> bool {
         .unwrap()
 }
 
-/// V043 is the schema tip: `files` gains `generation` and the UNIQUE widens to include it, so two
-/// rows identical except in generation coexist while a true duplicate still violates the key.
+/// V043 adds `files.generation` and widens the UNIQUE to include it, so two rows identical except
+/// in generation coexist while a true duplicate still violates the key. (The ABSOLUTE schema-tip
+/// pin lives in the NEWEST migration's test — see `v044_widens_the_github_natural_keys_...` — so
+/// this checks the tip SYMBOLICALLY and never needs a bump when a later migration lands.)
 #[test]
-fn schema_at_latest_after_apply_is_v043() {
+fn migration_043_adds_generation_to_the_files_unique_key() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 43, "V043 is the schema tip");
-    assert_eq!(schema::status(&conn).unwrap().current_version, 43, "schema at LATEST after apply");
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply",
+    );
     assert!(
         conn_table_columns(&conn, "files").contains(&"generation".to_string()),
         "files gains a generation column"
@@ -873,7 +878,13 @@ fn spawn_paused_rebuild(
         )
     };
     let rebuild_config = config.clone();
+    // Propagate the calling test's poison opt-out onto the worker thread: the harness flag is
+    // THREAD-local (deliberately — parallel `cargo test` isolation), so a spawned rebuild would
+    // otherwise re-seed the sibling behind a test that disabled it.
+    let poison_disabled = crate::index::poison_sibling::poison_disabled_on_this_thread();
     let handle = std::thread::spawn(move || {
+        let _poison_off =
+            poison_disabled.then(crate::index::poison_sibling::disable_poison_sibling);
         // `rebuild_with_progress` acquires the per-repo write flock ITSELF (batch 6) — every
         // rebuild entry holds it by construction, which is what gc's `!= live` deadness predicate
         // relies on (holding the flock proves no rebuild is mid-flight, so above-live rows are
@@ -1005,6 +1016,10 @@ fn a_lockless_heal_mid_rebuild_does_not_remove_the_staged_row() {
 /// generation after the flip while the superseded one lingers pre-gc.
 #[test]
 fn a_bare_open_reader_is_generation_scoped() {
+    // Single-repo by nature: post-A7 the bare open is DEFINED only for a single-repo DB (it
+    // refuses the multi-repo shape the registered poison sibling would make real on this git
+    // fixture), and this test's subject is exactly that bare-open path.
+    let _poison_off = crate::index::poison_sibling::disable_poison_sibling();
     let (root, config) = generation_fixture(&[
         ("a.rs", "pub fn a() -> u32 { 1 }\n"),
         ("b.rs", "pub fn b() -> u32 { 2 }\n"),

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/github_papertrail.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/github_papertrail.rs
@@ -296,6 +296,7 @@ fn parser_failures_report_paths() {
     fs::write(src.join("broken.rs"), "pub fn broken(").unwrap();
     let config = Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
@@ -320,4 +321,315 @@ fn parser_failures_report_paths() {
     assert_eq!(status.parser_failure_paths[0].path, "src/broken.rs");
 
     let _ = fs::remove_dir_all(root);
+}
+
+// --- V044 (phase A7): GitHub natural-key widening ---
+
+/// Fresh `schema::apply` (baseline's old `(owner, repo, number)` keys → V041 repo_id column → V044
+/// widening) leaves the `(owner, repo, number)`-style keys folding `repo_id`: the named unique
+/// indexes exist and `github_ref_sync`'s PK leads with `repo_id`. Re-applying is idempotent (the
+/// sentinel short-circuits).
+#[test]
+fn v044_widens_the_github_natural_keys_to_include_repo_id() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    // The ABSOLUTE schema-tip pin moved to the newest migration's test (V045); here just assert
+    // `apply` reaches LATEST symbolically.
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply"
+    );
+    assert!(conn_index_exists(&conn, "idx_github_issues_repo_unique"), "issues unique index");
+    assert!(conn_index_exists(&conn, "idx_github_pull_requests_repo_unique"), "pulls unique index");
+    let ref_sync_pk_has_repo_id: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('github_ref_sync') WHERE name='repo_id' AND \
+             pk > 0",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(ref_sync_pk_has_repo_id > 0, "github_ref_sync PK now includes repo_id");
+    // Re-apply is a no-op (the named issues index is the all-or-nothing sentinel).
+    schema::apply(&conn).unwrap();
+    assert!(conn_index_exists(&conn, "idx_github_issues_repo_unique"), "index survives re-apply");
+}
+
+/// The load-bearing multi-repo invariant: two repos can each cache the SAME external `(owner, repo,
+/// number)` after V044 — the widened keys are per-repo. A same-repo duplicate of that natural key
+/// is still rejected, so the uniqueness the writers' `ON CONFLICT` relies on is preserved.
+#[test]
+fn v044_lets_two_repos_cache_the_same_github_item() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    for repo in ["repo-a", "repo-b"] {
+        conn.execute(
+            "INSERT INTO github_issues(owner, repo, number, html_url, state, title, body, \
+             synced_at_ms, repo_id) VALUES ('o','r',7,'u','open','t','b',0,?1)",
+            [repo],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO github_pull_requests(owner, repo, number, html_url, state, title, body, \
+             synced_at_ms, repo_id) VALUES ('o','r',7,'u','open','t','b',0,?1)",
+            [repo],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO github_ref_sync(owner, repo, number, status, synced_at_ms, repo_id) \
+             VALUES ('o','r',7,'ok',0,?1)",
+            [repo],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO github_refs(owner, repo, number, ref_kind, source_kind, source_text, \
+             discovered_at_ms, repo_id) VALUES ('o','r',7,'closing','file','txt',0,?1)",
+            [repo],
+        )
+        .unwrap();
+    }
+    for table in ["github_issues", "github_pull_requests", "github_ref_sync", "github_refs"] {
+        let rows: i64 = conn
+            .query_row(
+                &format!("SELECT COUNT(*) FROM {table} WHERE owner='o' AND repo='r' AND number=7"),
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(rows, 2, "both repos coexist in {table} for the same (owner, repo, number)");
+    }
+    // Within one repo the widened key still rejects a duplicate (what the writers' ON CONFLICT
+    // needs).
+    let dup = conn.execute(
+        "INSERT INTO github_issues(owner, repo, number, html_url, state, title, body, \
+         synced_at_ms, repo_id) VALUES ('o','r',7,'u','open','t','b',0,'repo-a')",
+        [],
+    );
+    assert!(dup.is_err(), "a same-repo duplicate of (owner, repo, number) is still rejected");
+}
+
+// --- V045 (phase A7): GitHub id-keyed child widening ---
+
+/// V045 is the schema tip: the id-keyed child caches gain `(repo_id, id)` uniqueness, so two repos
+/// sharing an external issue/PR each keep their own copy of its comments/reviews (the pre-V045
+/// `INSERT OR REPLACE` restamped the single row to the last syncer, evicting the sibling's scoped
+/// papertrail). Re-apply is idempotent (the named `github_comments` index is the sentinel).
+#[test]
+fn v045_widens_the_github_child_keys_to_include_repo_id() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    // The ABSOLUTE schema-tip pin lives with the newest migration (V045): a later migration moves
+    // it to its own test and this becomes a symbolic check.
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 45, "V045 is the schema tip");
+    assert_eq!(schema::status(&conn).unwrap().current_version, 45, "schema at LATEST after apply");
+    for index in [
+        "idx_github_comments_repo_unique",
+        "idx_github_reviews_repo_unique",
+        "idx_github_review_comments_repo_unique",
+    ] {
+        assert!(conn_index_exists(&conn, index), "{index} exists");
+    }
+
+    // Two repos hold the SAME external comment id; a same-repo duplicate is still rejected.
+    for repo in ["repo-a", "repo-b"] {
+        conn.execute(
+            "INSERT INTO github_comments(id, owner, repo, number, html_url, body, synced_at_ms, \
+             repo_id) VALUES (7, 'o', 'r', 1, 'u', 'b', 0, ?1)",
+            [repo],
+        )
+        .unwrap();
+    }
+    let rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM github_comments WHERE id = 7", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(rows, 2, "both repos keep their own copy of the shared comment");
+    let dup = conn.execute(
+        "INSERT INTO github_comments(id, owner, repo, number, html_url, body, synced_at_ms, \
+         repo_id) VALUES (7, 'o', 'r', 1, 'u', 'b', 0, 'repo-a')",
+        [],
+    );
+    assert!(dup.is_err(), "a same-repo duplicate id is still rejected");
+
+    schema::apply(&conn).unwrap();
+    assert!(conn_index_exists(&conn, "idx_github_comments_repo_unique"), "survives re-apply");
+}
+
+/// V045's BACKFILL rule in isolation, against the exact V044-state shape (`id INTEGER PRIMARY
+/// KEY` + the V041 `repo_id` column — reproduced here because a fresh `apply` is already
+/// post-V045): a child row is duplicated once PER OWNING-PARENT repo (comments parent = issues ∪
+/// pulls; reviews/review comments parent = pulls), and an orphan with no cached parent survives
+/// under its own stamped repo_id. No row is lost.
+#[test]
+fn migration_045_duplicates_children_per_owning_repo_and_keeps_orphans() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "
+        CREATE TABLE github_issues(
+            id INTEGER PRIMARY KEY AUTOINCREMENT, owner TEXT NOT NULL, repo TEXT NOT NULL,
+            number INTEGER NOT NULL, html_url TEXT NOT NULL, state TEXT NOT NULL,
+            title TEXT NOT NULL, body TEXT NOT NULL, author TEXT, created_at TEXT,
+            updated_at TEXT, is_pull_request INTEGER NOT NULL DEFAULT 0,
+            synced_at_ms INTEGER NOT NULL, repo_id TEXT NOT NULL DEFAULT '__unassigned__'
+        );
+        CREATE TABLE github_pull_requests(
+            id INTEGER PRIMARY KEY AUTOINCREMENT, owner TEXT NOT NULL, repo TEXT NOT NULL,
+            number INTEGER NOT NULL, html_url TEXT NOT NULL, state TEXT NOT NULL,
+            title TEXT NOT NULL, body TEXT NOT NULL, author TEXT, created_at TEXT,
+            updated_at TEXT, merged_at TEXT, synced_at_ms INTEGER NOT NULL,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__'
+        );
+        CREATE TABLE github_comments(
+            id INTEGER PRIMARY KEY, owner TEXT NOT NULL, repo TEXT NOT NULL,
+            number INTEGER NOT NULL, html_url TEXT NOT NULL, body TEXT NOT NULL, author TEXT,
+            created_at TEXT, updated_at TEXT, synced_at_ms INTEGER NOT NULL,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__'
+        );
+        CREATE TABLE github_reviews(
+            id INTEGER PRIMARY KEY, owner TEXT NOT NULL, repo TEXT NOT NULL,
+            number INTEGER NOT NULL, html_url TEXT, state TEXT NOT NULL, body TEXT NOT NULL,
+            author TEXT, submitted_at TEXT, synced_at_ms INTEGER NOT NULL,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__'
+        );
+        CREATE TABLE github_review_comments(
+            id INTEGER PRIMARY KEY, owner TEXT NOT NULL, repo TEXT NOT NULL,
+            number INTEGER NOT NULL, path TEXT, html_url TEXT NOT NULL, body TEXT NOT NULL,
+            author TEXT, created_at TEXT, updated_at TEXT, synced_at_ms INTEGER NOT NULL,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__'
+        );
+
+        -- The shared PR exists under BOTH repos (the post-V044 state); its issue mirror too.
+        INSERT INTO github_pull_requests(owner, repo, number, html_url, state, title, body, \
+         synced_at_ms, repo_id)
+        VALUES ('o','r',1,'u','open','t','b',0,'repo-a'), \
+         ('o','r',1,'u','open','t','b',0,'repo-b');
+        INSERT INTO github_issues(owner, repo, number, html_url, state, title, body, synced_at_ms, \
+         repo_id)
+        VALUES ('o','r',1,'u','open','t','b',0,'repo-a');
+
+        -- One comment / review / review-comment, all stamped by the LAST syncer (repo-b).
+        INSERT INTO github_comments(id, owner, repo, number, html_url, body, synced_at_ms, repo_id)
+        VALUES (10, 'o', 'r', 1, 'u', 'cbody', 0, 'repo-b');
+        INSERT INTO github_reviews(id, owner, repo, number, state, body, synced_at_ms, repo_id)
+        VALUES (20, 'o', 'r', 1, 'ok', 'rbody', 0, 'repo-b');
+        INSERT INTO github_review_comments(id, owner, repo, number, html_url, body, synced_at_ms, \
+         repo_id)
+        VALUES (30, 'o', 'r', 1, 'u', 'rcbody', 0, 'repo-b');
+
+        -- An ORPHAN comment: no cached parent anywhere — must survive under its own repo_id.
+        INSERT INTO github_comments(id, owner, repo, number, html_url, body, synced_at_ms, repo_id)
+        VALUES (99, 'o', 'r', 42, 'u', 'orphan', 0, 'repo-x');
+
+        -- The standalone FTS mirror in its LAST-SYNCER state: the comment is findable only from
+        -- repo-b. V045 must re-derive it in-migration, or repo-a's scoped rationale/papertrail
+        -- search still cannot see the duplicated row until some later sync rebuilds the mirror.
+        CREATE VIRTUAL TABLE github_fts USING fts5(
+            owner, repo, number UNINDEXED, item_kind UNINDEXED, item_id UNINDEXED,
+            url UNINDEXED, title, body, classification, repo_id UNINDEXED, tokenize='porter'
+        );
+        INSERT INTO github_fts(owner, repo, number, item_kind, item_id, url, title, body, \
+         classification, repo_id)
+        VALUES ('o', 'r', 1, 'comment', '10', 'u', '', 'cbody', 'decision', 'repo-b');
+        ",
+    )
+    .unwrap();
+
+    schema::apply_github_child_key_widening(&conn).unwrap();
+
+    // The shared children now exist once per OWNING repo.
+    for (table, id) in
+        [("github_comments", 10i64), ("github_reviews", 20), ("github_review_comments", 30)]
+    {
+        let owners: Vec<String> = {
+            let mut stmt = conn
+                .prepare(&format!("SELECT repo_id FROM {table} WHERE id = {id} ORDER BY repo_id"))
+                .unwrap();
+            let rows = stmt.query_map([], |r| r.get::<_, String>(0)).unwrap();
+            rows.map(Result::unwrap).collect()
+        };
+        assert_eq!(
+            owners,
+            vec!["repo-a".to_string(), "repo-b".to_string()],
+            "{table} row {id} duplicated per owning-parent repo",
+        );
+    }
+    // The orphan survives exactly once, under its own stamped repo.
+    let (orphan_rows, orphan_repo): (i64, String) = conn
+        .query_row("SELECT COUNT(*), MAX(repo_id) FROM github_comments WHERE id = 99", [], |r| {
+            Ok((r.get(0)?, r.get(1)?))
+        })
+        .unwrap();
+    assert_eq!((orphan_rows, orphan_repo.as_str()), (1, "repo-x"), "orphan kept, not dropped");
+
+    // The FTS mirror was re-derived IN-MIGRATION: the widened comment is scoped-searchable from
+    // BOTH owning repos immediately (no sync required), and the Rust-derived `classification`
+    // label was carried from the old mirror by (item_kind, item_id).
+    for repo in ["repo-a", "repo-b"] {
+        let hits: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM github_fts WHERE github_fts MATCH 'cbody' AND repo_id = ?1",
+                [repo],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(hits, 1, "{repo}: the duplicated comment is FTS-findable without a sync");
+    }
+    let carried_class: String = conn
+        .query_row(
+            "SELECT classification FROM github_fts WHERE item_kind = 'comment' AND item_id = '10' \
+             AND repo_id = 'repo-a'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(carried_class, "decision", "the classification label carried across the rebuild");
+}
+
+/// The end-to-end oscillation regression (Codex batch 6): two repos sync the SAME external PR's
+/// comment — both scoped papertrails keep it, and a re-sync by either repo replaces ITS OWN copy
+/// in place without evicting the sibling's (pre-V045, `INSERT OR REPLACE` on the bare id
+/// restamped the single row to the last syncer).
+#[test]
+fn both_repos_keep_a_shared_prs_comments_across_syncs() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    conn.execute_batch(
+        "CREATE TEMP TABLE IF NOT EXISTS connection_context(key TEXT PRIMARY KEY, value TEXT);",
+    )
+    .unwrap();
+    let sync_as = |repo_id: &str, body: &str| {
+        conn.execute(
+            "INSERT OR REPLACE INTO temp.connection_context(key, value) VALUES ('repo_id', ?1)",
+            [repo_id],
+        )
+        .unwrap();
+        crate::index::github::store_comment(&conn, &crate::index::github::GitHubComment {
+            id: 7,
+            owner: "o".into(),
+            repo: "r".into(),
+            number: 1,
+            html_url: "http://c".into(),
+            body: body.into(),
+            author: None,
+            created_at: None,
+            updated_at: None,
+        })
+        .unwrap();
+    };
+
+    sync_as("repo-a", "from-a");
+    sync_as("repo-b", "from-b");
+    // Repo A re-syncs with fresh content: replaces ITS copy, never B's.
+    sync_as("repo-a", "from-a-v2");
+
+    let body_for = |repo: &str| -> String {
+        conn.query_row(
+            "SELECT body FROM github_comments WHERE id = 7 AND repo_id = ?1",
+            [repo],
+            |r| r.get(0),
+        )
+        .unwrap()
+    };
+    assert_eq!(body_for("repo-a"), "from-a-v2", "A's re-sync refreshed A's own copy");
+    assert_eq!(body_for("repo-b"), "from-b", "B's copy survived A's re-sync — no oscillation");
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -74,6 +74,7 @@ fn git_history_targets() -> Vec<ResolvedTarget> {
 fn rag_rat_config(root: &Path) -> Config {
     Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.to_path_buf(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: git_history_targets(),
@@ -195,6 +196,7 @@ fn markdown_config(text: &str) -> (PathBuf, Config) {
 fn markdown_config_for_root(root: PathBuf) -> Config {
     Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
@@ -330,6 +332,7 @@ pub(crate) fn poison_test_config(tag: &str) -> (PathBuf, Config) {
 fn source_config(root: PathBuf, language: Language) -> Config {
     Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
@@ -676,6 +679,7 @@ fn git_fixture_for_overlay_tests() -> (PathBuf, Config) {
     run_git(&root, &["commit", "-m", "init"]);
     let config = Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
@@ -796,6 +800,7 @@ fn write_four_renamed_clones(root: &PathBuf) -> IndexDatabase {
     }
     let config = Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
@@ -178,6 +178,40 @@ fn gc_of_one_repo_leaves_the_other_intact() {
         "repo B's identical (path, commit) dead row is NOT pruned by A's gc"
     );
 
+    // The REPORT is repo-scoped too (2nd adversary wave): `files_remaining`/`chunks_remaining`
+    // count the ACTIVE repo's slice, never the whole consolidated store — a whole-table count
+    // would include repo B's 2 files (and the poison sibling's), and a sibling's index pass
+    // committing between the before/after reads would skew the derived pruned counts.
+    let repo_a_files: i64 = fx
+        .db
+        .storage
+        .connection()
+        .query_row("SELECT COUNT(*) FROM main.files WHERE repo_id = ?1", [&fx.repo_a_id], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(
+        report.files_remaining,
+        u64::try_from(repo_a_files).unwrap(),
+        "gc reports repo A's file slice, not the whole-store union",
+    );
+    let repo_a_chunks: i64 = fx
+        .db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM main.chunks c JOIN main.files f ON f.id = c.file_id WHERE \
+             f.repo_id = ?1",
+            [&fx.repo_a_id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        report.chunks_remaining,
+        u64::try_from(repo_a_chunks).unwrap(),
+        "gc reports repo A's chunk slice, not the whole-store union",
+    );
+
     let _ = fs::remove_dir_all(fx.root_a);
 }
 
@@ -648,13 +682,18 @@ fn orientation_pins_the_fork_repo_over_a_shared_root_sibling() {
         "orientation threads the pin and installs the fork's scope",
     );
 
-    // WITHOUT the override: the identity route resolves the shared-root sibling (the mis-scope the
-    // pin fixes).
+    // WITHOUT the override: the identity route derives the shared-root UPSTREAM id, but this root
+    // is RECORDED under the fork's pin — the read-only owner mirror (Codex batch 4) now DECLINES
+    // instead of serving the sibling's scope, installing the deliberate empty "match nothing"
+    // scope. That matches the write path, which refuses this exact shape with the
+    // mismatched-root-owner remedy. (Pre-mirror, this phase pinned the sibling BIND as the
+    // documented mis-scope the pin fixes; the mirror upgrades it from "wrong scope" to "no
+    // scope + surfaced refusal on the write path".)
     crate::query::orientation::orientation(conn, &root, &root, None).unwrap();
     assert_eq!(
         schema::active_repo_id(conn).unwrap(),
-        upstream_id,
-        "no pin → orientation binds the shared-root upstream sibling",
+        "",
+        "no pin at a fork-owned root → the owner mirror declines rather than bind the sibling",
     );
     let _ = fs::remove_dir_all(root);
 }
@@ -1525,6 +1564,146 @@ fn memory_summary_readers_exclude_a_sibling_repos_memory() {
     assert!(
         !orient.active_memory_titles.iter().any(|t| t == "REPO B SECRET"),
         "orientation leaked a sibling repo's active memory title",
+    );
+
+    let _ = fs::remove_dir_all(fx.root_a);
+}
+
+/// A7 (Codex batch 2 P2): the open-time model-manifest heal must never mutate a SIBLING repo's
+/// `repo_meta`. Pre-fix, the incremental pass's low-level open ran `ensure_model_manifest` BEFORE
+/// adoption, so its `active_repo_id` resolved the config-less sole pick — the lexicographically
+/// FIRST repo — and a heal-owed pass (`remove_legacy_models`) DELETED that repo's active-model
+/// meta while the command held only its own repo's lock. Post-fix the heal is deferred until after
+/// adopt + set_context, so it reads/clears only the config's own repo.
+#[test]
+fn incremental_open_heal_leaves_a_sibling_repos_model_meta_alone() {
+    let fx = two_repo_fixture();
+    let conn = fx.db.storage.connection();
+
+    // A sibling registered under an id that sorts FIRST (before any hex-derived id), carrying a
+    // LEGACY active-model value — exactly the row the pre-adoption sole-pick heal would delete.
+    conn.execute(
+        "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('0-first-sibling', \
+         's', 0)",
+        [],
+    )
+    .unwrap();
+    crate::index::meta::set_repo_meta(
+        conn,
+        "0-first-sibling",
+        "active_embedding_model",
+        "fastembed-all-minilm-l6-v2",
+    )
+    .unwrap();
+    // The fixture's DB is a shared temp file, not root_a/.rag-rat — reuse its path for the config.
+    let db_path = fx.db.database_path().to_path_buf();
+    drop(fx.db);
+
+    // A production incremental pass on repo A (the config's repo).
+    let mut config = source_config(fx.root_a.clone(), Language::Rust);
+    config.database = db_path;
+    let db = IndexDatabase::index_changed(&config).unwrap();
+
+    // The sibling's legacy meta row SURVIVES: the heal ran scoped to repo A, never the sole pick.
+    let sibling_meta = crate::index::meta::repo_meta(
+        db.storage.connection(),
+        "0-first-sibling",
+        "active_embedding_model",
+    )
+    .unwrap();
+    assert_eq!(
+        sibling_meta.as_deref(),
+        Some("fastembed-all-minilm-l6-v2"),
+        "the open-time manifest heal mutated a sibling repo's repo_meta (pre-adoption sole pick)",
+    );
+
+    let _ = fs::remove_dir_all(fx.root_a);
+}
+
+/// A7 (Codex batch 3, same class as the incremental finding — the CALLEE now enforces it): a
+/// config-less `IndexDatabase::migrate` on a MULTI-REPO DB must not run the model-manifest heal —
+/// its connection has no scope context, so `active_repo_id` would resolve the first-sorting repo
+/// and a heal-owed pass would delete THAT sibling's `repo_meta` model keys. This is exactly the
+/// connection `rag-rat consolidate` reaches migrate through BEFORE registering its repo. The
+/// witness gate in `ensure_model_manifest` skips + defers (the next config-bearing open heals
+/// scoped), regardless of which caller reaches it next.
+#[test]
+fn config_less_migrate_on_a_multi_repo_db_leaves_sibling_model_meta_alone() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+    let db_path = root.join("global.sqlite");
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.pragma_update(None, "foreign_keys", "ON").unwrap();
+        schema::apply(&conn).unwrap();
+        // Two real repos make the DB consolidated; the first-sorting one carries a LEGACY
+        // active-model value — the row a config-less heal would delete.
+        conn.execute_batch(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES
+                 ('0-first-sibling', 's', 0), ('zz-other', 'z', 0);
+             DELETE FROM repos WHERE repo_id = '__unassigned__';",
+        )
+        .unwrap();
+        crate::index::meta::set_repo_meta(
+            &conn,
+            "0-first-sibling",
+            "active_embedding_model",
+            "fastembed-all-minilm-l6-v2",
+        )
+        .unwrap();
+    }
+
+    IndexDatabase::migrate(&db_path).unwrap();
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let sibling_meta =
+        crate::index::meta::repo_meta(&conn, "0-first-sibling", "active_embedding_model").unwrap();
+    assert_eq!(
+        sibling_meta.as_deref(),
+        Some("fastembed-all-minilm-l6-v2"),
+        "a config-less migrate healed (deleted) a sibling repo's model meta",
+    );
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// A7 (Codex batch 4 — the source_root variant of the pre-adoption-pick family): an
+/// AdoptionPending open derives `source_root` from the config-less SOLE pick (a first-sorting
+/// SIBLING on a consolidated DB); adoption must RESET it from the config before any deferred heal,
+/// or `ensure_graph_index_current` re-reads changed files from the sibling's checkout while
+/// stamping the target's rows. The rule: adoption resets ALL connection-carried repo-derived state
+/// before any deferred heal.
+#[test]
+fn incremental_open_resets_source_root_from_the_config_before_heals() {
+    let fx = two_repo_fixture();
+    let conn = fx.db.storage.connection();
+    // A first-sorting sibling whose recorded source_root points at a NONEXISTENT checkout — the
+    // root the pre-adoption pick would carry into the deferred graph heal.
+    conn.execute(
+        "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES ('0-first-sibling', \
+         's', 0)",
+        [],
+    )
+    .unwrap();
+    crate::index::meta::set_repo_meta(
+        conn,
+        "0-first-sibling",
+        "source_root",
+        "/nonexistent-sibling-checkout",
+    )
+    .unwrap();
+    let db_path = fx.db.database_path().to_path_buf();
+    drop(fx.db);
+
+    let mut config = source_config(fx.root_a.clone(), Language::Rust);
+    config.database = db_path;
+    let db = IndexDatabase::index_changed(&config).unwrap();
+
+    assert_eq!(
+        db.storage.source_root(),
+        Some(config.root.as_path()),
+        "adoption must reset source_root from the config before the deferred heals — a stale \
+         sibling root would refresh the target's graph from the wrong checkout",
     );
 
     let _ = fs::remove_dir_all(fx.root_a);

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
@@ -165,6 +165,7 @@ fn clean_checkout_file_resolves_against_its_own_package_roots() {
 
     let config = Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -818,6 +818,7 @@ fn git_history_indexes_commits_paths_queries_and_blame() {
 
     let config = Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -2114,6 +2114,7 @@ fn repo_brief_ranks_churn_and_god_module_candidates() {
 
     let config = Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
@@ -2197,6 +2198,7 @@ fn repo_clusters_groups_cotouched_files() {
 
     let config = Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -349,20 +349,25 @@ fn register_repo_appends_a_second_root() {
     assert_eq!(root_count(&conn, "repo-abc"), 2, "both roots recorded");
 }
 
-/// Once a real repo owns the DB, registering a DIFFERENT real repo is REFUSED (the single-repo
-/// invariant for phase A — multi-repo registration lands with the default-path flip).
+/// A7: once a real repo owns the DB, registering a DIFFERENT real repo at an unclaimed root
+/// REGISTERS IT — several repos sharing one global database is the multi-repo default (replacing
+/// phase A's single-repo "refuse a second real repo" invariant). Both repos coexist; neither is
+/// re-pointed.
 #[test]
-fn register_repo_refuses_a_different_real_repo() {
+fn register_repo_registers_a_second_repo_in_a_consolidated_db() {
     let conn = rusqlite::Connection::open_in_memory().expect("open");
     schema::apply(&conn).expect("apply");
     register_repo(&conn, &identity("repo-abc", "a"), Path::new("/src/a"), 1).unwrap();
 
-    let err = register_repo(&conn, &identity("repo-xyz", "b"), Path::new("/src/b"), 2)
-        .expect_err("a different real repo must be refused");
-    assert!(err.to_string().contains("repo-abc"), "refusal names the incumbent repo: {err}");
-    // The incumbent is untouched; the intruder never landed.
+    let registered = register_repo(&conn, &identity("repo-xyz", "b"), Path::new("/src/b"), 2)
+        .expect("a different real repo at an unclaimed root registers as a second repo");
+    assert_eq!(registered, "repo-xyz");
+    // Both repos are real, each with its own recorded root; neither was re-pointed.
     assert_eq!(repo_row_count(&conn, "repo-abc"), 1);
-    assert_eq!(repo_row_count(&conn, "repo-xyz"), 0);
+    assert_eq!(repo_row_count(&conn, "repo-xyz"), 1);
+    assert_eq!(root_count(&conn, "repo-abc"), 1);
+    assert_eq!(root_count(&conn, "repo-xyz"), 1);
+    assert!(schema::multiple_real_repos(&conn).unwrap(), "the DB now holds two real repos");
 }
 
 // --- V039: per-repo meta relocation (memory-sync phase A2) ---
@@ -1509,12 +1514,14 @@ fn head_commit_hash(root: &Path) -> String {
     String::from_utf8(out.stdout).unwrap().trim().to_string()
 }
 
-/// PROOF is REQUIRED, not just a `local:` prefix (round-6 P2 #4): a DB first indexed from a cut
-/// shallow clone of repo X, later opened from an UNRELATED full repo Y at the same DB path, must be
-/// REFUSED — Y's HEAD reaches NONE of X's boundary commits, so re-pointing the index onto Y's id
-/// would migrate one repo's data onto another. The refusal names the pin escape hatch.
+/// PROOF gates the RE-POINT, not the registration (A7): a DB first indexed from a cut shallow clone
+/// of repo X, later opened from an UNRELATED full repo Y at a NEW root, must NOT upgrade X's local
+/// id onto Y — Y's HEAD reaches NONE of X's boundary commits, so re-pointing would migrate one
+/// repo's data onto another. Instead Y registers as its OWN repo (the multi-repo default) and X's
+/// `local:` index is left exactly as it was. The critical safety — no cross-repo data migration —
+/// holds because the upgrade did not fire.
 #[test]
-fn register_repo_refuses_a_portable_upgrade_from_an_unrelated_repo() {
+fn register_repo_adds_an_unrelated_repo_without_upgrading_the_local_incumbent() {
     let repo_x = real_git_repo("origin-x");
     let x_boundary = head_commit_hash(&repo_x);
     let repo_y = real_git_repo("unrelated-y"); // an independent root — no shared history with X.
@@ -1530,15 +1537,13 @@ fn register_repo_refuses_a_portable_upgrade_from_an_unrelated_repo() {
     )
     .expect("the shallow clone of X adopts under its local id, recording X's boundary");
 
-    let err = register_repo(&conn, &identity("y-portable-root", "y"), repo_y.as_path(), 2)
-        .expect_err(
-            "an unrelated repo's HEAD does not reach X's boundary → the upgrade is refused",
-        );
-    let msg = err.to_string();
-    assert!(msg.contains("could not prove"), "refusal explains the missing proof: {msg}");
-    assert!(msg.contains("repo_id"), "refusal names the pin escape hatch: {msg}");
-    assert_eq!(schema::sole_repo_id(&conn).unwrap(), local_id, "the incumbent is untouched");
-    assert_eq!(repo_row_count(&conn, "y-portable-root"), 0, "the unrelated id never landed");
+    let registered = register_repo(&conn, &identity("y-portable-root", "y"), repo_y.as_path(), 2)
+        .expect("an unrelated repo at a new root registers as its own repo — no upgrade attempted");
+    assert_eq!(registered, "y-portable-root");
+    // X's local incumbent is untouched (NOT re-pointed onto Y); both repos now coexist.
+    assert_eq!(repo_row_count(&conn, local_id), 1, "X's local id is left as-is, never upgraded");
+    assert_eq!(repo_row_count(&conn, "y-portable-root"), 1, "Y registered as a separate repo");
+    assert!(schema::multiple_real_repos(&conn).unwrap(), "the DB now holds two real repos");
     let _ = fs::remove_dir_all(&repo_x);
     let _ = fs::remove_dir_all(&repo_y);
 }
@@ -1564,39 +1569,390 @@ fn register_repo_refuses_a_local_upgrade_without_a_recorded_boundary() {
     let _ = fs::remove_dir_all(&repo);
 }
 
-/// The upgrade is NARROW: only a `local:` incumbent upgrades. Two genuinely-different PORTABLE
-/// repos still trip the single-repo refusal — a Portable incoming must never silently re-point a
-/// Portable incumbent (that would be data loss across two real repos).
+/// A7: a second PORTABLE repo at a DIFFERENT root registers fresh (like any new repo) and NEVER
+/// re-points the incumbent — the upgrade machinery is reserved for a `local:` incumbent, so a
+/// Portable incoming can only ever add a new repo, never silently migrate one portable repo's rows
+/// onto another (which would be data loss). The incumbent is left exactly as it was.
 #[test]
-fn register_repo_refuses_a_portable_incoming_against_a_portable_incumbent() {
+fn register_repo_adds_a_second_portable_repo_without_repointing_the_incumbent() {
     let conn = rusqlite::Connection::open_in_memory().expect("open");
     schema::apply(&conn).expect("apply");
     register_repo(&conn, &identity("portable-a", "a"), Path::new("/src/a"), 1).unwrap();
 
-    let err = register_repo(&conn, &identity("portable-b", "b"), Path::new("/src/b"), 2)
-        .expect_err("a second portable repo is refused — only a local: incumbent upgrades");
-    assert!(err.to_string().contains("portable-a"), "refusal names the incumbent: {err}");
-    assert_eq!(schema::sole_repo_id(&conn).unwrap(), "portable-a", "incumbent untouched");
-    assert_eq!(repo_row_count(&conn, "portable-b"), 0, "the intruder never landed");
+    register_repo(&conn, &identity("portable-b", "b"), Path::new("/src/b"), 2)
+        .expect("a second portable repo at an unclaimed root registers as its own repo");
+    // The incumbent is untouched (still one row, its own root); portable-b is a distinct repo.
+    assert_eq!(repo_row_count(&conn, "portable-a"), 1, "incumbent untouched — not re-pointed");
+    assert_eq!(root_count(&conn, "portable-a"), 1);
+    assert_eq!(repo_row_count(&conn, "portable-b"), 1, "the second portable repo landed");
 }
 
-/// A `LocalOnly` incoming against an existing REAL repo is refused — a deepened clone (or a second
-/// shallow clone) must never DOWNGRADE a portable id back to machine-local. The upgrade only runs
-/// in the Portable direction.
+/// The SECOND shallow clone of one upstream must not be stranded once the portable id exists
+/// (Codex batch 5): clones A and B register under distinct `local:` ids; A deepens and claims the
+/// portable id P; B deepens LATER — register_repo(P at B's root) hits the idempotent branch, whose
+/// root-owner guard would refuse (and pinning P re-enters the same refusal). The LATE-upgrade
+/// merge instead retires B's local id INTO P: B's AUTHORED memories move (rowid anchors nulled for
+/// re-resolution), B's DERIVED rows drop (a fresh index re-derives them under P), both roots land
+/// under P, and P's existing data — A's — is untouched.
 #[test]
-fn register_repo_refuses_a_local_only_incoming_against_a_real_incumbent() {
+fn second_shallow_clone_late_upgrades_into_the_existing_portable_repo() {
+    let root_b = real_git_repo("late-b");
+    let boundary_b = head_commit_hash(&root_b);
+
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+
+    // A's story already completed: the portable id P is registered at A's root (the in-place
+    // upgrade path, covered by its own tests) and carries A's authored + derived data.
+    register_repo(&conn, &identity("P-portable", "up"), Path::new("/src/clone-a"), 1).unwrap();
+    conn.execute(
+        "INSERT INTO repo_memories(id, kind, title, body, confidence, status, created_at_ms,          updated_at_ms, source, memory_version, repo_id)
+         VALUES ('mem-a', 'Invariant', 'a title', 'a body', 'high', 'active', 0, 0, 'agent',          'v1', 'P-portable')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms,          commit_sha, worktree_id, repo_id, generation)
+         VALUES ('src/shared.rs', 'rust', 'source', 'a-sha', 0, 0, 'c1', '', 'P-portable', 0)",
+        [],
+    )
+    .unwrap();
+
+    // B registers as a shallow clone at its own (real) root, with its boundary recorded, and
+    // authors a memory (full anchor set) plus a derived file row.
+    register_repo(
+        &conn,
+        &identity_local("local:bbbb", "clone-b", vec![boundary_b]),
+        root_b.as_path(),
+        2,
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO repo_memories(id, kind, title, body, confidence, status, created_at_ms,          updated_at_ms, source, memory_version, repo_id)
+         VALUES ('mem-b', 'Decision', 'b title', 'b body', 'high', 'active', 0, 0, 'agent',          'v1', 'local:bbbb')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id, path,          \
+         logical_symbol_id, symbol_id, chunk_id, edge_id, anchor_status, created_at_ms, repo_id)
+         VALUES ('mem-b', 'path', 'bind-b', 'src/b.rs', 11, 22, 33, 44, 'current', 0,          \
+         'local:bbbb')",
+        [],
+    )
+    .unwrap();
+    conn.execute("INSERT INTO repo_memory_tags(memory_id, tag) VALUES ('mem-b', 'tag-b')", [])
+        .unwrap();
+    conn.execute(
+        "INSERT INTO repo_memory_call_paths(memory_id, start_logical_symbol_id,          \
+         end_logical_symbol_id, edge_sequence_hash, path_summary, created_at_ms)
+         VALUES ('mem-b', 55, 66, 'hash-b', 'x -> y', 0)",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO repo_memory_fts(repo_id, memory_id, title, body, kind, tags)
+         VALUES ('local:bbbb', 'mem-b', 'b title', 'b body', 'Decision', 'tag-b')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms,          commit_sha, worktree_id, repo_id, generation)
+         VALUES ('src/shared.rs', 'rust', 'source', 'b-sha', 0, 0, 'c1', '', 'local:bbbb', 0)",
+        [],
+    )
+    .unwrap();
+
+    // B deepens: the incoming portable identity is the ALREADY-REGISTERED P at B's root — the
+    // late-upgrade merge, not a refusal.
+    let registered = register_repo(&conn, &identity("P-portable", "up"), root_b.as_path(), 3)
+        .expect("the second clone's late upgrade must complete, never strand");
+    assert_eq!(registered, "P-portable");
+
+    // The local id is retired; BOTH roots live under P.
+    assert_eq!(repo_row_count(&conn, "local:bbbb"), 0, "B's local id retired");
+    for root in ["/src/clone-a", &root_b.to_string_lossy()] {
+        let owned: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM repo_roots WHERE repo_id = 'P-portable' AND root = ?1",
+                [root],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(owned, 1, "root {root} recorded under P");
+    }
+
+    // B's memory MOVED with correct attribution: repo_id = P, rowid anchors nulled, portable
+    // anchor + tag + call-path + FTS row intact.
+    let (repo, ls, sy, path_col): (String, Option<i64>, Option<i64>, Option<String>) = conn
+        .query_row(
+            "SELECT m.repo_id, b.logical_symbol_id, b.symbol_id, b.path
+             FROM repo_memories m JOIN repo_memory_bindings b ON b.memory_id = m.id
+             WHERE m.id = 'mem-b'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+        )
+        .unwrap();
+    assert_eq!(repo, "P-portable", "B's memory re-attributed to P");
+    assert_eq!((ls, sy), (None, None), "rowid anchors nulled for re-resolution");
+    assert_eq!(path_col.as_deref(), Some("src/b.rs"), "portable anchor survives");
+    let (cp_start, fts_repo): (Option<i64>, String) = conn
+        .query_row(
+            "SELECT cp.start_logical_symbol_id, f.repo_id
+             FROM repo_memory_call_paths cp, repo_memory_fts f
+             WHERE cp.memory_id = 'mem-b' AND f.memory_id = 'mem-b'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(cp_start, None, "call-path endpoints nulled");
+    assert_eq!(fts_repo, "P-portable", "FTS mirror row follows the memory");
+
+    // B's DERIVED row dropped (re-derived by the next index); A's data untouched.
+    let b_files: i64 = conn
+        .query_row("SELECT COUNT(*) FROM main.files WHERE sha256 = 'b-sha'", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(b_files, 0, "B's derived rows dropped, not migrated");
+    let (a_mem, a_files): (i64, i64) = conn
+        .query_row(
+            "SELECT (SELECT COUNT(*) FROM repo_memories WHERE id='mem-a' AND              \
+             repo_id='P-portable' AND title='a title'),
+                    (SELECT COUNT(*) FROM main.files WHERE sha256='a-sha' AND              \
+             repo_id='P-portable')",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!((a_mem, a_files), (1, 1), "P's existing (A's) data untouched by the merge");
+
+    // The flow is now plainly idempotent: P at B's root re-registers without drama.
+    register_repo(&conn, &identity("P-portable", "up"), root_b.as_path(), 4)
+        .expect("post-merge re-registration is the plain idempotent path");
+    let _ = fs::remove_dir_all(&root_b);
+}
+
+/// The read-only resolver MIRRORS `register_repo`'s root-owner refusal: an `[index] repo_id` pin
+/// switched to a SIBLING's id at a root recorded under another repo must NOT resolve on the
+/// read-only fast path (MCP reads / hooks would silently serve the sibling's scope while the
+/// write path refuses). `None` declines the fast path so the read-write open surfaces the refusal.
+#[test]
+fn read_only_resolver_declines_a_pin_onto_a_root_owned_by_another_repo() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    register_repo(&conn, &identity("repo-a", "a"), Path::new("/src/a"), 1).unwrap();
+    register_repo(&conn, &identity("repo-b", "b"), Path::new("/src/b"), 2).unwrap();
+
+    // The pin names repo-b, but /src/a is recorded under repo-a → decline (mirror of the write
+    // path's mismatched-root refusal).
+    let resolved =
+        schema::resolve_config_repo_id(&conn, Path::new("/src/a"), Some("repo-b")).unwrap();
+    assert_eq!(resolved, None, "a sibling-id pin at an owned root must not fast-path resolve");
+
+    // Control: the OWNING repo's own pin at its root still resolves.
+    let resolved =
+        schema::resolve_config_repo_id(&conn, Path::new("/src/a"), Some("repo-a")).unwrap();
+    assert_eq!(resolved.as_deref(), Some("repo-a"), "self-ownership resolves normally");
+}
+
+/// Adoption re-points write the REAL tables even when the connection carries a temp `files` scope
+/// view — the incremental pass's bare open installs one BEFORE `adopt_repo_from_config` runs, and
+/// an unqualified `UPDATE files` resolves to the view ("cannot modify files because it is a
+/// view"), aborting the first index of a fresh keyless DB in an identity-bearing repo.
+#[test]
+fn adoption_repoints_files_through_a_connection_carrying_the_scope_view() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    // A placeholder-scoped file row awaiting adoption.
+    conn.execute(
+        "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, indexed_at_ms, \
+         commit_sha, worktree_id, repo_id, generation)
+         VALUES ('src/a.rs', 'rust', 'source', 'h', 0, 0, '', '', '__unassigned__', 0)",
+        [],
+    )
+    .unwrap();
+    // The temp `files` view a bare open installs (shape irrelevant — its EXISTENCE is what
+    // shadows the table name for unqualified writes).
+    conn.execute_batch(
+        "CREATE TEMP VIEW files AS SELECT * FROM main.files WHERE repo_id = '__unassigned__'",
+    )
+    .unwrap();
+
+    register_repo(&conn, &identity("repo-viewed", "v"), Path::new("/src/v"), 1)
+        .expect("adoption must write main.files through the shadowing temp view");
+    let adopted: i64 = conn
+        .query_row("SELECT COUNT(*) FROM main.files WHERE repo_id = 'repo-viewed'", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(adopted, 1, "the placeholder file row re-pointed to the adopted id");
+}
+
+/// The upgrade scan matches on (root AND boundary), never boundary alone: with TWO shallow clones
+/// of the same upstream registered under distinct `local:` ids — an ordinary shape on the shared
+/// global DB — a deepened checkout's HEAD reaches BOTH boundaries, and a boundary-only pick would
+/// re-point whichever incumbent SORTS first, hijacking the sibling clone's index and stranding the
+/// actually-deepened one. The root match pins the upgrade to the working tree that was deepened.
+#[test]
+fn upgrade_picks_the_root_matching_incumbent_among_two_shallow_clones() {
+    let repo = real_git_repo("two-shallow"); // clone B's working tree — the one that deepens.
+    let boundary = head_commit_hash(&repo);
+
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    // Clone A: a SIBLING shallow clone of the same upstream at a DIFFERENT root, whose id sorts
+    // FIRST — the incumbent a boundary-only scan would wrongly pick (its boundary is equally
+    // reachable from the deepened HEAD).
+    register_repo(
+        &conn,
+        &identity_local("local:aaa", "clone-a", vec![boundary.clone()]),
+        Path::new("/src/clone-a"),
+        1,
+    )
+    .expect("sibling shallow clone registers fresh at its own root");
+    // Clone B: the clone that will be deepened, registered at the REAL working tree.
+    register_repo(
+        &conn,
+        &identity_local("local:bbb", "clone-b", vec![boundary]),
+        repo.as_path(),
+        2,
+    )
+    .expect("second shallow clone registers fresh at its own root");
+
+    // B deepens (its HEAD reaches both recorded boundaries) and re-registers portable from B's
+    // root: ONLY B's incumbent upgrades.
+    register_repo(&conn, &identity("portable-root", "b"), repo.as_path(), 3)
+        .expect("the deepened clone upgrades its own incumbent");
+    assert_eq!(repo_row_count(&conn, "local:bbb"), 0, "B's local id upgraded in place");
+    assert_eq!(repo_row_count(&conn, "portable-root"), 1);
+    assert_eq!(
+        repo_row_count(&conn, "local:aaa"),
+        1,
+        "the first-sorting SIBLING incumbent is untouched — never hijacked by boundary alone",
+    );
+    // And the untouched sibling is not bricked: its own re-registration stays idempotent.
+    register_repo(
+        &conn,
+        &identity_local("local:aaa", "clone-a", vec![]),
+        Path::new("/src/clone-a"),
+        4,
+    )
+    .expect("the sibling clone keeps re-registering under its own id");
+    let _ = fs::remove_dir_all(&repo);
+}
+
+/// The IDEMPOTENT path carries the root-owner guard too: a checkout whose identity changes to an
+/// ALREADY-REGISTERED id (a pin switched to an existing repo, an in-place re-clone) must not
+/// silently record one physical root under TWO repos — that would make `resolve_config_repo_id`'s
+/// recorded-root route (`LIMIT 1` over two owners) non-deterministic.
+#[test]
+fn idempotent_reregistration_refuses_a_root_owned_by_another_repo() {
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    register_repo(&conn, &identity("repo-abc", "a"), Path::new("/src/a"), 1).unwrap();
+    register_repo(&conn, &identity("repo-xyz", "b"), Path::new("/src/b"), 2).unwrap();
+
+    // repo-xyz (already registered) shows up at repo-abc's root — an identity change, not a new
+    // worktree of xyz. Refused; the root stays mapped to exactly one repo.
+    let err = register_repo(&conn, &identity("repo-xyz", "b"), Path::new("/src/a"), 3)
+        .expect_err("an owned root must not be recorded under a second repo");
+    assert!(err.to_string().contains("repo-abc"), "refusal names the owning repo: {err}");
+    let owners: i64 = conn
+        .query_row(
+            "SELECT COUNT(DISTINCT repo_id) FROM repo_roots WHERE root = '/src/a'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(owners, 1, "one physical root maps to exactly one repo");
+    // The same repo's own root re-registration stays idempotent (self-ownership never trips).
+    register_repo(&conn, &identity("repo-xyz", "b"), Path::new("/src/b"), 4)
+        .expect("re-registering an owned root under its OWN repo is idempotent");
+}
+
+/// Two repos' concurrent FIRST registrations on one shared file DB both succeed (A7): the
+/// DB-global registry lock serializes the read-decide-write sequence, so neither writer sees the
+/// torn middle (`SQLITE_BUSY_SNAPSHOT` on a deferred upgrade, or a `repos`-PK constraint on the
+/// same-id race). The same-id pair collapses the loser into the idempotent path.
+#[test]
+fn concurrent_registrations_on_a_shared_db_both_succeed() {
+    use std::sync::{Arc, Barrier};
+
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+    let db_path = root.join("global.sqlite");
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        schema::apply(&conn).unwrap();
+    }
+
+    // Round 1: two DIFFERENT repos race their first registration.
+    let barrier = Arc::new(Barrier::new(2));
+    let handles: Vec<_> = ["repo-one", "repo-two"]
+        .into_iter()
+        .map(|id| {
+            let barrier = Arc::clone(&barrier);
+            let db_path = db_path.clone();
+            std::thread::spawn(move || {
+                let conn = rusqlite::Connection::open(&db_path).unwrap();
+                conn.busy_timeout(std::time::Duration::from_secs(5)).unwrap();
+                conn.pragma_update(None, "foreign_keys", "ON").unwrap();
+                barrier.wait();
+                register_repo(&conn, &identity(id, id), Path::new(&format!("/src/{id}")), 1)
+            })
+        })
+        .collect();
+    for handle in handles {
+        handle.join().unwrap().expect("a concurrent first registration must succeed");
+    }
+
+    // Round 2: the SAME repo races itself (two worktrees' first open) — winner registers, loser
+    // collapses into the idempotent path; never a PK constraint.
+    let barrier = Arc::new(Barrier::new(2));
+    let handles: Vec<_> = (0..2)
+        .map(|_| {
+            let barrier = Arc::clone(&barrier);
+            let db_path = db_path.clone();
+            std::thread::spawn(move || {
+                let conn = rusqlite::Connection::open(&db_path).unwrap();
+                conn.busy_timeout(std::time::Duration::from_secs(5)).unwrap();
+                conn.pragma_update(None, "foreign_keys", "ON").unwrap();
+                barrier.wait();
+                register_repo(&conn, &identity("repo-same", "s"), Path::new("/src/same"), 2)
+            })
+        })
+        .collect();
+    for handle in handles {
+        handle.join().unwrap().expect("a same-id registration race must collapse idempotently");
+    }
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    for id in ["repo-one", "repo-two", "repo-same"] {
+        assert_eq!(repo_row_count(&conn, id), 1, "{id} registered exactly once");
+    }
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// A `LocalOnly` incoming for a working tree ALREADY registered under a real repo is refused — a
+/// re-shallowed clone must never DOWNGRADE the portable id its root already owns. Keyed on the ROOT
+/// (`real_root_owner`): the same physical path resolving to a machine-local id while it is recorded
+/// under a portable one is exactly the downgrade the refusal guards. (A LocalOnly incoming at a
+/// NEW, unclaimed root is instead a genuinely new shallow repo and registers fresh.)
+#[test]
+fn register_repo_refuses_a_local_only_downgrade_of_an_owned_root() {
     let conn = rusqlite::Connection::open_in_memory().expect("open");
     schema::apply(&conn).expect("apply");
     register_repo(&conn, &identity("portable-a", "a"), Path::new("/src/a"), 1).unwrap();
 
+    // Same root as portable-a: a re-shallowed clone of A resolving to a machine-local id.
     let err = register_repo(
         &conn,
         &identity_local("local:beef", "shallow", vec![]),
-        Path::new("/src/s"),
+        Path::new("/src/a"),
         2,
     )
-    .expect_err("a LocalOnly incoming must not downgrade a portable incumbent");
-    assert!(err.to_string().contains("portable-a"), "refusal names the incumbent: {err}");
+    .expect_err("a LocalOnly incoming must not downgrade the portable id its root already owns");
+    assert!(err.to_string().contains("portable-a"), "refusal names the owning repo: {err}");
     assert_eq!(schema::sole_repo_id(&conn).unwrap(), "portable-a", "portable id stays");
     assert_eq!(repo_row_count(&conn, "local:beef"), 0, "the local id never landed");
 }
@@ -1931,6 +2287,51 @@ fn open_config_falls_back_to_the_sole_repo_on_a_non_git_root() {
     let _ = fs::remove_dir_all(root);
 }
 
+/// The STRUCTURAL BACKSTOP for the identity gate's second entrance (Codex batch 8, finding 5): an
+/// identity-less root (non-git) whose explicit `database` pin lands on a MULTI-repo store must
+/// never sole-pick — `sole_repo_id`'s lexicographic tiebreak would silently adopt the first
+/// SIBLING repo and write this project's rows under it. The open REFUSES with the remedy, and the
+/// siblings' registry state is untouched. (The global-path pin shape is already refused at
+/// `Config::load`; this closes every other shared-path entrance — the same doctrine as the
+/// config-less bare-open fail-fast and the healers' witness.)
+#[test]
+fn an_identity_less_open_refuses_to_sole_pick_on_a_multi_repo_db() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    let mut config = source_config(root.clone(), Language::Rust);
+    // The pin points at a SHARED store that already holds two sibling repos.
+    config.database = root.join("shared.sqlite");
+    IndexDatabase::migrate(&config.database).unwrap();
+    {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        for repo in ["repo-alpha", "repo-beta"] {
+            conn.execute(
+                "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, ?1, 0)",
+                [repo],
+            )
+            .unwrap();
+        }
+    }
+
+    let err = IndexDatabase::open_config(&config)
+        .expect_err("an identity-less root must not guess a repo on a multi-repo store");
+    assert!(
+        err.to_string().contains("no resolvable repo identity")
+            && err.to_string().contains("repo_id"),
+        "the refusal names the problem and the remedy: {err}"
+    );
+    // The siblings are untouched — no adoption, no placeholder re-point, no root recorded.
+    let conn = rusqlite::Connection::open(&config.database).unwrap();
+    let repos: i64 = conn
+        .query_row("SELECT COUNT(*) FROM repos WHERE repo_id != ?1", [LEGACY_REPO_ID], |r| r.get(0))
+        .unwrap();
+    assert_eq!(repos, 2, "both siblings still registered, nothing adopted");
+    let roots: i64 = conn.query_row("SELECT COUNT(*) FROM repo_roots", [], |r| r.get(0)).unwrap();
+    assert_eq!(roots, 0, "no root was recorded for the refused open");
+    let _ = fs::remove_dir_all(root);
+}
+
 // --- V041: repo_id scoping on the GitHub papertrail tables (memory-sync phase A4) ---
 
 /// The pre-V041 shape of the seven GitHub tables + `github_fts` (no `repo_id`) plus the V038
@@ -2246,14 +2647,14 @@ fn migration_041_leaves_github_rows_at_the_placeholder_on_a_consolidated_db() {
     }
 }
 
-/// The reclamation half of the consolidated-DB gate: the github tables keep natural keys WITHOUT
-/// `repo_id`, so a placeholder-stranded row OCCUPIES its key — a conflict-ignoring writer could
-/// never repopulate it and the cache would be stranded forever. The writers upsert-reclaim
-/// instead: the next sync that touches a stranded key re-stamps `repo_id`, refreshes the content,
-/// and the sync-tail `rebuild_fts` re-derives the mirror. Rows the sync does NOT touch stay under
-/// the placeholder (they wait for their own repo's sync).
+/// V044 widens the github natural keys to fold `repo_id`, so a placeholder-stranded row no longer
+/// OCCUPIES a real repo's key: a syncing repo writes its OWN row (fresh content, its `repo_id`)
+/// ALONGSIDE the stranded placeholder row rather than clobbering it or reclaiming it. Cross-repo
+/// isolation is the win — the placeholder rows are re-pointed separately at ADOPTION (see
+/// `register_repo_repoints_github_papertrail_rows_to_the_real_id`). This supersedes the V041
+/// upsert-reclaim workaround (which existed only because the keys were un-widened before A7).
 #[test]
-fn v041_placeholder_github_rows_are_reclaimed_by_the_next_sync() {
+fn v044_a_syncing_repo_is_isolated_from_stranded_placeholder_github_rows() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
     // The state the consolidated-DB gate leaves: github rows stranded under the placeholder on a
@@ -2317,26 +2718,35 @@ fn v041_placeholder_github_rows_are_reclaimed_by_the_next_sync() {
     // The sync tail: the whole-table mirror rebuild follows the reclaimed base rows.
     crate::index::github::rebuild_fts(&conn).unwrap();
 
-    // The touched rows are re-stamped to repo-a with refreshed content…
-    let (issue_repo, issue_title): (String, String) = conn
-        .query_row("SELECT repo_id, title FROM github_issues WHERE number = 7", [], |r| {
-            Ok((r.get(0)?, r.get(1)?))
-        })
+    // repo-a's sync wrote its OWN issue row with fresh content, under its own repo_id…
+    let a_title: String = conn
+        .query_row(
+            "SELECT title FROM github_issues WHERE number = 7 AND repo_id = 'repo-a'",
+            [],
+            |r| r.get(0),
+        )
         .unwrap();
-    assert_eq!(issue_repo, "repo-a", "the stranded issue row is reclaimed by the syncing repo");
-    assert_eq!(issue_title, "fresh title", "reclaim refreshes the content, not just the stamp");
-    for table in ["github_refs", "github_ref_sync"] {
-        let repo: String = conn
-            .query_row(&format!("SELECT repo_id FROM {table} WHERE number = 7"), [], |r| r.get(0))
+    assert_eq!(a_title, "fresh title", "repo-a's sync wrote its own fresh row");
+    // …and the stranded placeholder row for the SAME (owner, repo, number) is UNTOUCHED — the
+    // widened key keeps them distinct instead of one clobbering the other.
+    let placeholder_title: String = conn
+        .query_row(
+            &format!(
+                "SELECT title FROM github_issues WHERE number = 7 AND repo_id = '{LEGACY_REPO_ID}'"
+            ),
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(placeholder_title, "stale title", "the stranded placeholder row is not reclaimed");
+    // Each base table now holds TWO rows for o/r#7 — repo-a's and the placeholder's — coexisting.
+    for table in ["github_issues", "github_refs", "github_ref_sync"] {
+        let rows: i64 = conn
+            .query_row(&format!("SELECT COUNT(*) FROM {table} WHERE number = 7"), [], |r| r.get(0))
             .unwrap();
-        assert_eq!(repo, "repo-a", "{table}: stranded row reclaimed");
+        assert_eq!(rows, 2, "{table}: repo-a's row coexists with the stranded placeholder row");
     }
-    // …the FTS mirror is consistent with the reclaimed base rows…
-    let fts_repo: String = conn
-        .query_row("SELECT repo_id FROM github_fts WHERE number = 7", [], |r| r.get(0))
-        .unwrap();
-    assert_eq!(fts_repo, "repo-a", "the mirror row follows the reclaimed base row");
-    // …a scoped read now sees the papertrail…
+    // A scoped read for repo-a sees exactly its own fresh row, never the placeholder's.
     let visible: i64 = conn
         .query_row(
             "SELECT COUNT(*) FROM github_issues WHERE repo_id = 'repo-a' AND number = 7",
@@ -2344,14 +2754,12 @@ fn v041_placeholder_github_rows_are_reclaimed_by_the_next_sync() {
             |r| r.get(0),
         )
         .unwrap();
-    assert_eq!(visible, 1, "the reclaimed row is visible to repo-a's scoped reads");
-    // …and the row the sync did NOT touch stays under the placeholder for its own repo's sync.
-    for table in ["github_issues", "github_fts"] {
-        let repo: String = conn
-            .query_row(&format!("SELECT repo_id FROM {table} WHERE number = 8"), [], |r| r.get(0))
-            .unwrap();
-        assert_eq!(repo, LEGACY_REPO_ID, "{table}: untouched stranded row stays placeholder");
-    }
+    assert_eq!(visible, 1, "repo-a's scoped read sees exactly its own row");
+    // The row the sync did NOT touch (o/r#8) stays under the placeholder for its own repo's sync.
+    let untouched: String = conn
+        .query_row("SELECT repo_id FROM github_issues WHERE number = 8", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(untouched, LEGACY_REPO_ID, "the untouched stranded row stays placeholder");
 }
 
 /// A V040 index forward-migrates to V041 on `migrate_forward` — reaching LATEST.
@@ -2419,9 +2827,10 @@ fn seed_pre_v042_periphery_schema(conn: &rusqlite::Connection) {
 fn migration_042_is_the_latest_tip_and_scopes_periphery() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
-    // V042 is no longer the ABSOLUTE tip (V043 adds files.generation on top); the tip pin moves to
-    // the newest migration's test (`schema_at_latest_after_apply_is_v043` in generation_rebuild).
-    // Here just assert `apply` reaches LATEST — V042's periphery scoping is on the way to the tip.
+    // V042 is no longer the ABSOLUTE tip (V043 adds files.generation, V044 widens the github keys);
+    // the tip pin lives with the newest migration's test (`v044_widens_the_github_natural_keys_...`
+    // in github_papertrail). Here just assert `apply` reaches LATEST — V042 is on the way to the
+    // tip.
     assert_eq!(
         schema::status(&conn).unwrap().current_version,
         schema::LATEST_SCHEMA_VERSION,

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -9,6 +9,7 @@ fn rebuild_bootstraps_sqlite_schema_for_empty_target_root() {
 
     let config = Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
@@ -522,6 +522,7 @@ DEVICE_DT_INST_DEFINE(0, entropy_init, NULL, NULL, NULL,
     .unwrap();
     let config = Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
@@ -1295,6 +1296,7 @@ where
     .unwrap();
     let config = Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/worktree_overlay.rs
@@ -583,7 +583,9 @@ fn maintenance_pass_refreshes_a_linked_worktree_overlay() {
     // A watcher maintenance pass auto-refreshes the overlay — no manual `index --worktree`.
     crate::watch::maintenance_pass(&config, false).unwrap();
 
-    let mut db = IndexDatabase::open(&config.database).unwrap();
+    // A fresh reader on the shared DB: config-bearing (post-A7 a bare open refuses the
+    // multi-repo shape the poison sibling makes real on this git fixture).
+    let mut db = IndexDatabase::open_config(&config).unwrap();
     db.use_worktree_scope(&main, Some(&linked)).unwrap();
     assert_eq!(
         names_in_scope(&db, "src/a.rs"),
@@ -928,8 +930,9 @@ fn worktree_overlay_committed_added_file_symbol_resolves_cross_connection() {
         assert!(report.indexed >= 1, "the added file is indexed into the overlay");
     }
 
-    // A FRESH connection (the MCP server querying after the CLI wrote the overlay).
-    let mut db = IndexDatabase::open(&config.database).unwrap();
+    // A FRESH connection (the MCP server querying after the CLI wrote the overlay) —
+    // config-bearing, the post-A7 MCP posture (a bare open refuses the poisoned multi-repo DB).
+    let mut db = IndexDatabase::open_config(&config).unwrap();
     db.use_worktree_scope(&main, Some(&linked)).unwrap();
     assert!(
         !db.symbols("added_fn", Some(Language::Rust), 10).unwrap().is_empty(),
@@ -1029,7 +1032,7 @@ fn worktree_overlay_stable_when_main_removed_a_file_a_nested_branch_keeps() {
 
     for pass in 0..3 {
         crate::watch::maintenance_pass(&config, pass == 2).unwrap(); // gc on the last pass
-        let mut db = IndexDatabase::open(&config.database).unwrap();
+        let mut db = IndexDatabase::open_config(&config).unwrap();
         db.use_worktree_scope(&main, Some(&linked)).unwrap();
         assert_eq!(
             names_in_scope(&db, "src/reinf.rs"),

--- a/crates/rag-rat-core/src/index/util.rs
+++ b/crates/rag-rat-core/src/index/util.rs
@@ -8,10 +8,34 @@ pub(crate) fn read_meta(conn: &rusqlite::Connection, key: &str) -> anyhow::Resul
         .optional()?)
 }
 
+/// Whole-table row count — DELIBERATELY UNSCOPED, so on a consolidated multi-repo DB it reports
+/// the union across every repo. TEST-ONLY, structurally: the A7 sweep converted every production
+/// reporting caller to [`scoped_table_row_count`] (direct `repo_id` tables) or
+/// [`scoped_chunk_row_count`] (the files-transitive `chunks`), and the `#[cfg(test)]` gate keeps
+/// a future reporting path from reaching for the lying union count — single-repo test fixtures
+/// asserting whole-fixture totals are the only legitimate use.
+#[cfg(test)]
 pub(crate) fn table_row_count(conn: &rusqlite::Connection, table: &str) -> anyhow::Result<u64> {
     // `table` is always an internal string literal, never user input.
     let count = conn
         .query_row(&format!("SELECT COUNT(*) FROM main.{table}"), [], |row| row.get::<_, i64>(0))?;
+    Ok(u64::try_from(count).unwrap_or(0))
+}
+
+/// The repo's TOTAL chunk count across ALL its contexts and generations. `chunks` carries no
+/// `repo_id` of its own (it scopes transitively through `files`), so this joins `main.files`
+/// directly — NOT the scoped temp view, which filters to the active commit/worktree/generation
+/// and is narrower than a whole-repo report (gc prunes across all of a repo's contexts).
+pub(crate) fn scoped_chunk_row_count(
+    conn: &rusqlite::Connection,
+    repo_id: &str,
+) -> anyhow::Result<u64> {
+    let count = conn.query_row(
+        "SELECT COUNT(*) FROM main.chunks c JOIN main.files f ON f.id = c.file_id
+         WHERE f.repo_id = ?1",
+        [repo_id],
+        |row| row.get::<_, i64>(0),
+    )?;
     Ok(u64::try_from(count).unwrap_or(0))
 }
 

--- a/crates/rag-rat-core/src/locks.rs
+++ b/crates/rag-rat-core/src/locks.rs
@@ -138,6 +138,21 @@ pub fn schema_lock_path(database: &Path) -> PathBuf {
     database.parent().unwrap_or_else(|| Path::new(".")).join("rag-rat-schema.lock")
 }
 
+/// The GLOBAL repo-registry lock path, beside the DB (A7): ONE per database file, taken by
+/// `register_repo` for its whole read-decide-write sequence. Registration reads the registered-repo
+/// set, DECIDES (idempotent / upgrade / refuse / fresh), then writes `repos`/`repo_roots` — two
+/// concurrent first-registrations on the shared global DB would otherwise interleave between the
+/// read and the write (a `SQLITE_BUSY_SNAPSHOT` on the deferred upgrade, or a `repos`-PK constraint
+/// on the same-id race). Per-repo write locks cannot serialize this: the writers hold DIFFERENT
+/// repo ids by construction. GLOBAL-LOCK ORDERING RULE (shared with [`schema_lock_path`]): a global
+/// lock is acquired while per-repo entry locks may already be held (per-repo → global), and any
+/// per-repo lock taken while a global lock is held (the upgrade path) must be BOUNDED — bounded
+/// edges self-break any cross-type cycle within their timeout, exactly like the canonical-order
+/// rule's out-of-order edges.
+pub fn registry_lock_path(database: &Path) -> PathBuf {
+    database.parent().unwrap_or_else(|| Path::new(".")).join("rag-rat-registry.lock")
+}
+
 /// Per-DB, PER-REPO maintenance coordination lock, held by the running `rag-rat maintenance`
 /// command for its whole pass so the multiple git hooks a single amend/merge/rebase fires coalesce
 /// into one pass instead of each running a full discover (#267). Keyed by `repo_id` (A6) like
@@ -287,6 +302,18 @@ impl WriteLock {
         timeout: Duration,
     ) -> anyhow::Result<Option<WriteLock>> {
         Self::acquire_path_timeout(schema_lock_path(database), timeout)
+    }
+
+    /// Polls until the GLOBAL repo-registry lock ([`registry_lock_path`]) is acquired or `timeout`
+    /// elapses; `Ok(None)` on timeout. Taken by `register_repo` for its whole read-decide-write
+    /// sequence (A7) — registration decisions span all repos, so per-repo locks cannot serialize
+    /// them. Reentrant on the holding thread like the other write locks (a `consolidate` that
+    /// pre-registers, then imports, may re-enter registration idempotently).
+    pub fn acquire_registry_timeout(
+        database: &Path,
+        timeout: Duration,
+    ) -> anyhow::Result<Option<WriteLock>> {
+        Self::acquire_path_timeout(registry_lock_path(database), timeout)
     }
 
     fn acquire_path_blocking(lock_path: PathBuf) -> anyhow::Result<WriteLock> {

--- a/crates/rag-rat-core/src/logging/mod.rs
+++ b/crates/rag-rat-core/src/logging/mod.rs
@@ -130,6 +130,7 @@ mod tests {
     fn test_config(dir: &std::path::Path, enabled: bool) -> Config {
         Config {
             repo_id_override: None,
+            database_key_pinned: true,
             root: dir.to_path_buf(),
             database: dir.join(".rag-rat/index.sqlite"),
             targets: Vec::new(),

--- a/crates/rag-rat-core/src/repo_identity.rs
+++ b/crates/rag-rat-core/src/repo_identity.rs
@@ -165,6 +165,28 @@ pub fn resolve_repo_identity(
     Ok(RepoIdentity { repo_id, display_name, class, shallow_boundary })
 }
 
+/// Whether `root` has a DERIVABLE repo identity at all — a non-empty `[index] repo_id` pin, or a
+/// git repository with a born HEAD. The cheap existence probe behind the A7 default-database
+/// resolution: an identity-LESS root (non-git dir, unborn `git init`) must stay on its per-root
+/// legacy database rather than resolve to the machine-global store, where every such root would
+/// pool under the shared `__unassigned__` placeholder scope (mutual visibility/overwrite) and an
+/// unborn repo would strand its placeholder rows the moment its first commit mints a real id.
+///
+/// Deliberately NEVER walks history (`Config::load` runs on every command): it answers only
+/// "would [`resolve_repo_identity`] return [`Absent`](RepoIdentityError::Absent)?" — the
+/// Portable/LocalOnly split and Rejected-pin surfacing still happen at open time. A non-empty pin
+/// counts as resolvable even when reserved (a Rejected pin must surface through the open's
+/// actionable error, not silently divert the database path).
+pub fn identity_is_resolvable(root: &Path, override_id: Option<&str>) -> bool {
+    if override_id.map(str::trim).is_some_and(|id| !id.is_empty()) {
+        return true;
+    }
+    let Ok(repo) = crate::index::discover_repo(root) else {
+        return false;
+    };
+    repo.head_id().is_ok()
+}
+
 /// The remedy-naming error for pinning the reserved placeholder id: it marks a pre-adoption
 /// single-repo DB, so adopting under it would rewrite the placeholder PK to itself and leave the DB
 /// unadopted while reporting success (see [`register_repo`]).

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -842,6 +842,7 @@ mod tests {
     fn whole_root_config(root: &Path, target_dirs: &[PathBuf]) -> Config {
         Config {
             repo_id_override: None,
+            database_key_pinned: true,
             root: root.to_path_buf(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
@@ -865,6 +866,7 @@ mod tests {
     fn event_touches_worktree_matches_checkout_targets_and_registry() {
         let config = Config {
             repo_id_override: None,
+            database_key_pinned: true,
             root: PathBuf::from("/main"),
             database: PathBuf::from("/main/.rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
@@ -963,6 +965,7 @@ mod tests {
         let config_root = repo.join("crate").canonicalize().unwrap();
         let config = Config {
             repo_id_override: None,
+            database_key_pinned: true,
             root: config_root,
             database: repo.join("crate/.rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
@@ -1008,6 +1011,7 @@ mod tests {
 
         let config = Config {
             repo_id_override: None,
+            database_key_pinned: true,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
@@ -1071,6 +1075,7 @@ mod tests {
 
         let config = Config {
             repo_id_override: None,
+            database_key_pinned: true,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
@@ -1145,6 +1150,7 @@ mod tests {
         let target_dirs = vec![PathBuf::from(".")];
         let config = Config {
             repo_id_override: None,
+            database_key_pinned: true,
             root: sub.clone(),
             database: sub.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
@@ -1291,6 +1297,7 @@ mod tests {
         let sub = main.join("crate").canonicalize().unwrap(); // config.root is the subdir.
         let config = Config {
             repo_id_override: None,
+            database_key_pinned: true,
             root: sub.clone(),
             database: sub.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {
@@ -1554,6 +1561,7 @@ mod tests {
         let root = root.canonicalize().unwrap();
         let config = Config {
             repo_id_override: None,
+            database_key_pinned: true,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -268,6 +268,7 @@ mod tests {
         std::fs::write(root.join("src/lib.rs"), "pub fn open_database() {}\n").unwrap();
         let config = Config {
             repo_id_override: None,
+            database_key_pinned: true,
             root: root.clone(),
             database: root.join(".rag-rat/index.sqlite"),
             targets: vec![ResolvedTarget {

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -864,6 +864,7 @@ fn mixed_config() -> (PathBuf, Config) {
     fs::write(root.join("src/lib.rs"), "pub fn alpha_symbol() {}\n").unwrap();
     (root.clone(), Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![
@@ -899,6 +900,7 @@ fn markdown_config(text: &str) -> (PathBuf, Config) {
     fs::write(root.join("docs/search.md"), text).unwrap();
     (root.clone(), Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {
@@ -921,6 +923,7 @@ fn markdown_config(text: &str) -> (PathBuf, Config) {
 fn rust_config(root: PathBuf) -> Config {
     Config {
         repo_id_override: None,
+        database_key_pinned: true,
         root: root.clone(),
         database: root.join(".rag-rat/index.sqlite"),
         targets: vec![ResolvedTarget {

--- a/docs/config.md
+++ b/docs/config.md
@@ -7,7 +7,9 @@
 ```toml
 [index]
 root = "."
-database = ".rag-rat/index.sqlite"
+# database is unset by default: the index + memories live in the machine-global store
+# (see "Database location" below). Set it to keep this repo on its own file (deprecated):
+# database = ".rag-rat/index.sqlite"
 
 [llm.embedding]
 # the MODEL by its full id (the HF path) — no aliases. "none" disables embeddings.
@@ -19,6 +21,58 @@ ort_threads = 4
 omp_threads = 1
 max_embedding_chars = 4000
 ```
+
+## Database location (`[index] database`)
+
+By default rag-rat keeps **one consolidated database per machine** — `$XDG_DATA_HOME/rag-rat/rag-rat.sqlite`
+(falling back to `~/.local/share/rag-rat/rag-rat.sqlite`, or `%APPDATA%\rag-rat\rag-rat.sqlite` on
+Windows) — holding every registered repo's index and, most importantly, its **repo memories**. This
+means an accidental `git clean -fdx` or a deleted checkout no longer takes your authored memories
+with it. The location is resolved by cascade:
+
+1. `RAG_RAT_DATA_DIR` — an explicit override, honored verbatim.
+2. `$XDG_DATA_HOME/rag-rat`.
+3. `$HOME/.local/share/rag-rat` (the XDG default).
+4. (Windows) `%APPDATA%\rag-rat`.
+
+Set an explicit `database` key to opt a repo **out** of the consolidated store and keep it on its own
+per-repo file:
+
+```toml
+[index]
+database = ".rag-rat/index.sqlite"   # deprecated: this repo stays un-consolidated
+```
+
+An explicit key is honored for backward compatibility but is **deprecated** — an un-consolidated repo
+does not share the machine's global store (and, later, cannot participate in memory sync). A relative
+path resolves against the **main worktree top**, so every worktree of a repo shares one index; an
+absolute path is used as-is.
+
+**Upgrading an existing repo.** A repo indexed before this default flip has a legacy
+`.rag-rat/index.sqlite`. rag-rat keeps using it (with a one-line deprecation notice) until you run:
+
+```
+rag-rat consolidate
+```
+
+which imports the legacy index's memories and content-addressed embedding cache into the global store,
+renames the old file to `index.sqlite.imported` (delete it at your leisure), and prints a summary.
+Consolidation is idempotent, and everything else in the legacy file is rebuilt on the next
+`rag-rat index --full` (the carried embedding cache makes re-embedding a no-op).
+
+If `rag-rat.toml` pins an explicit `database` key, consolidation refuses outright (nothing is
+imported): remove the key first, then run `rag-rat consolidate` — the single run imports and renames
+atomically, so there is never a window in which memories written to the still-live legacy file could
+be lost. A pin at a **custom** path additionally needs its file moved to `.rag-rat/index.sqlite`
+first (a keyless config never consults a custom path); the refusal prints the exact commands for
+your paths. Once the `.imported` marker exists it acts as a stay-global latch — a stray legacy file that
+later reappears beside it is ignored (with a warning), never silently adopted.
+
+The global default also requires a **resolvable repo identity** — a git repository with at least one
+commit, or an `[index] repo_id` pin. A root without one (a non-git directory, a fresh `git init`
+with no commits yet) keeps its per-root `.rag-rat/index.sqlite` exactly as before the flip, so
+unrelated identity-less projects never share scope in the global store; once the repo gains a first
+commit (or a pin), the default resolves globally and `rag-rat consolidate` migrates it.
 
 ## Embedding model (`[llm.embedding] model`)
 


### PR DESCRIPTION
Phase A7 of the global-database consolidation: flip the default database to the consolidated global store, add the `rag-rat consolidate` importer, and make the registry and GitHub papertrail keys multi-repo-correct.

## The default flip

When `rag-rat.toml` has no `database` key, the index and its repo memories now live in **one consolidated database per machine** — `$XDG_DATA_HOME/rag-rat/rag-rat.sqlite` (resolved by the `RAG_RAT_DATA_DIR` → XDG cascade). This means an accidental `git clean -fdx` or a deleted checkout no longer loses authored memories.

The global default requires a **resolvable repo identity** (a committed git repo, or an `[index] repo_id` pin). An identity-less root — a non-git directory, or a fresh `git init` with an unborn HEAD — stays on its per-root `.rag-rat/index.sqlite` exactly as pre-flip, so unrelated identity-less projects never pool under the shared `__unassigned__` placeholder scope in the global store, and an unborn repo's placeholder rows adopt in its own per-root DB once the first commit mints a real id.

The identity requirement guards **both entrances** to the shared store: the keyless default (above), and an explicit `database` pin *at* the global path — an identity-less root pinning the global store is refused at config resolution with the remedy (add `[index] repo_id`, or use a per-repo file), because it would otherwise fall through to adoption's sole-repo fallback and scope onto whichever sibling repo sorts first. The structural backstop closes every other shared-path shape: an identity-less open **never sole-picks on a multi-repo database** — it refuses with the same remedy instead of guessing, the same doctrine as the config-less bare-open fail-fast and the healers' witness.

An explicit `database` key keeps a repo on its own per-repo file (deprecated but honored); a pre-existing legacy `.rag-rat/index.sqlite` keeps being used, with a deprecation notice, until it is imported. Once the `.imported` marker exists it acts as a **stay-global latch**: a stray legacy file that later reappears is ignored with a warning, never silently adopted.

`rag-rat init` now renders a **keyless** config, so the primary onboarding path lands on the global store by default; the deprecated per-repo opt-out is documented as a comment in the rendered TOML. Reconfiguring an existing config preserves an explicit `database` key untouched, and the wizard draft carries the resolved path so the user sees where the index actually lands.

**Linked git worktrees resolve through one governing config.** `Config::load` now answers "which `rag-rat.toml` governs this repo" once, at a single seam: in a linked worktree the **main** worktree's config is authoritative for the *whole* config — database location, identity, targets, models, everything — replacing the historical per-key anchoring (root, targets, `repo_id`) that this flip would otherwise have needed a fourth per-key patch for. A branch checkout carrying an older config can neither un-pin nor re-pin the database (pre-fix, a keyless branch toml sent that worktree to the global store while main used its pinned file — a split-brain within one repo); a divergent branch-local file is ignored with a one-line warning naming it and the governing file. Linked-ness is derived from **git topology** (the checkout containing the config file vs the repo's designated main worktree), never from a root-anchoring proxy — a branch-only `[index] root` that defeats anchoring cannot defeat governance, and a subdirectory of the main worktree is main. Validation ordering follows governance: hard validation applies only to the config actually used, so a branch-local file that fails to parse (or trips the `[local_ai]` rejection) folds into the divergence warning instead of making every command from the linked checkout fatal; wherever the local config governs, its validation stays fatal as always. Remaining edge postures are explicit: a config-less main falls back to the local config (loudly, root still anchored), a main config that fails to parse propagates its error (loading from any worktree behaves like loading from main, errors included), and layouts with no designated main (bare-repo hubs, non-git roots) are unchanged. The only declared worktree-local key is the overlay index's target set, which deliberately reads the branch's own file. `rag-rat init` now **refuses to run in a linked worktree**, pointing at the main checkout, instead of authoring a file the seam would ignore — and proceeds normally from a main-worktree subdirectory.

**Config discovery goes through the same primitive.** The seam decides which config wins once a file is loaded; a companion resolver decides where the CLI *looks* when no `--config` is given: a local `rag-rat.toml` when present (the seam then governs and warns), otherwise — in a linked worktree — the main worktree's `rag-rat.toml`. Without it, a linked checkout with no branch-local config (exactly the state init's refusal leaves) died at the existence check before the seam ever ran; now every default-config command works from a linked checkout end-to-end, and the missing-config hint in a truly config-less repo names the path where the config belongs (main's, from a linked checkout). An explicit `--config` path is taken literally — a user override never redirects.

## `rag-rat consolidate`

Imports a legacy per-repo index into the global store: registers the repo, copies its memories — bindings/tags/call-paths with local rowid columns nulled for re-resolution and **every portable column copied verbatim**, including the moniker relocation provenance — plus the content-addressed embedding cache and the repo's **model state as one coherent unit**: active model, freshness version, the remote-endpoint config `active_embedder()` routes through, the provisional-provenance flag (absence means "explicit choice" — dropping a set flag would make the model config-immune), and the active model's `ai_models` readiness row (sound same-machine: fastembed artifacts live in the machine-global cache and re-verify on scoped opens; an explicit machine-level `disabled` is never overridden). Every `repo_meta` key is classified portable-vs-DB-local in a stated table at the allow-list — including the absent-state semantics of absence-has-meaning keys — so new keys get classified at birth. **Re-derives the `repo_memory_fts` mirror** so imported memories are immediately findable by keyword search, and renames the legacy file to `index.sqlite.imported`.

The whole registration → import → rename sequence runs under the repo's per-repo write locks on **both** the global and legacy sides, with the legacy WAL checkpointed first. The legacy side drains **every id the source database itself records** (a read-only pre-lock peek at its `repos` registry, canonical bounded order): the legacy file predates identity transitions, so a writer started before `git fetch --unshallow` still keys its lock by the old `local:` id, and a current-identity lock alone would not conflict with it. A source predating the registry tables peeks empty — only pre-per-repo-lock binaries ever wrote such files, so no current lock scheme could coordinate with them regardless. Consolidate's own migration is **schema-only**: its connection is config-less and its subject repo is not registered yet, so the open-time healers' witness would resolve the sole *registered* repo — a sibling when consolidating a second repo into a one-repo global DB — and heal it under the wrong locks (the witness's documented limit). A memory id already owned by a **different repo** in the global store is deterministically remapped — never dropped — and child rows (tags/bindings/call-paths) only ever attach to parents the import owns this run, so a colliding legacy id can never contaminate another repo's memory.

**Pinned configs are refused outright** — no import, no side effects — and the refusal is evaluated **before** the missing-source exits, so a pin at a missing/renamed path surfaces the remedy instead of a happy `no_legacy_index` while the repo stays stranded (only a pin at the global target itself reports `already_global` — and even that arm first probes the default legacy path: a hand-edited pin at the global store can coexist with a never-imported legacy file, and reporting `already_global` there would strand its authored memories while claiming success, so a marker-less legacy file under a global pin is imported and renamed; this is the one pinned shape where proceeding is strictly correct, because the pin already names the target and the rename cannot strand the config). An early import without the rename would open a divergence window in which memories edited in the still-live legacy DB are silently dropped by the idempotent finishing run; refusing eliminates the window, and the single post-removal run imports and renames atomically. The **accidental** window — the import transaction commits but the rename itself fails — is covered from the other side by a declared invariant at the import: *until the archive rename lands, the legacy DB is authoritative for this repo's imported slice, and every artifact the import copies is refreshed to match the source on every run*. Each copied artifact carries an explicit disposition: parent memories are content-gated upserts (foreign rows never touched); the children of **every** mapped id — same-repo and remapped alike — are replaced wholesale inside the transaction (a tag removed legacy-side does not survive by union, and a parent-edit gate is deliberately not used: it would depend on a "children changed ⇒ parent bumped" signal that the remap path already defeated once); the FTS mirror is re-derived per repo; the `repo_meta` model-state unit mirrors per key — value-gated upsert when present, delete when a carried key was removed legacy-side (a window model switch that drops the remote config must not leave a torn unit); the active model's readiness restore re-derives from the source each run, so a window model change restores the new model on retry; and the embedding cache stays `INSERT OR IGNORE` as the one documented exemption (content-addressed rows — an existing row is by definition identical). Summary counts stay honest: a before/after digest per child slice reports zero when a run leaves it byte-identical, so a no-edit retry still reports zeros. The remedy is **path-aware**: a pin at the default legacy path just removes the key, while a custom pin gets the literal `mkdir`/`mv` commands for the user's paths — a keyless config never consults a custom path, so removing the key alone would strand that index unimported. Summary counts reflect rows actually written (a retry reports zeros).

## Multi-repo registry

`register_repo` now supports multiple repos in one database, with the whole read-decide-write sequence serialized on a **database-global registry lock** (plus an immediate transaction and a convergent insert), so two repos' concurrent first registrations both succeed. A genuinely new repo at an unclaimed working tree registers alongside the others. The shallow-clone upgrade matches its incumbent by **recorded root AND boundary proof** — two shallow clones of the same upstream can no longer hijack each other. One physical root can never be recorded under two repos: the identity-split refusal guards the idempotent re-registration path as well — with one **proven exception**: the second shallow clone of an upstream whose portable id a sibling clone already claimed **late-upgrades by merging** instead of being permanently stranded (the pin remedy would re-enter the same refusal). Its authored memories move onto the registered id (memory ids are bare PKs, so the move cannot collide; rowid anchors are nulled for re-resolution — the consolidate posture), its derived rows are dropped for re-derivation by the next index (re-pointing would collide with the sibling's live rows on the widened UNIQUE keys), both roots land under the portable id, and the sibling's existing data is untouched. Crash-convergent (one immediate transaction) under the registry lock plus both ids' per-repo locks in canonical bounded order. Adoption re-points write `main.`-qualified tables, so registering through a connection that already carries the temp `files` scope view (the incremental pass's open) works.

A config-less `IndexDatabase::open` **fails fast** on a multi-repo database instead of silently scoping to the lexicographically-first repo (the incremental pass's internal pre-adoption open is exempt — it re-scopes via the config immediately). The open-time healers — the model-manifest heal and the fastembed cache recovery — now enforce a **scoped-repo witness in the callee**: on a config-less connection to a multi-repo database they skip and defer to the next config-bearing open, so no caller (the incremental pre-adoption open, a bare `migrate`, consolidate's pre-registration migrate) can read or mutate a sibling repo's `repo_meta` model keys under the wrong lock. Adoption also **resets every connection-carried repo-derived value** — including `source_root` — before the deferred heals run, so a heal never reads the pre-adoption sole pick's checkout while stamping the adopted repo. And the **read-only resolver mirrors the root-owner refusal**: an `[index] repo_id` pin switched to a sibling's id no longer serves the sibling's scope through read-only MCP/hook opens — it declines to the read-write open, where the refusal surfaces.

## V044 + V045 — GitHub key widening

The `(owner, repo, number)`-style keys on `github_issues`, `github_pull_requests`, `github_ref_sync`, and the `github_refs` unique index now fold `repo_id` (V044), and the id-keyed child caches — `github_comments`, `github_reviews`, `github_review_comments` — gain `(repo_id, id)` uniqueness (V045), so two repos sharing an external issue/PR each keep a full copy, parent **and** children. Pre-V045, the child writers' `INSERT OR REPLACE` restamped the single row to the last syncer, so repo A's scoped papertrail *lost* a shared PR's comments the moment repo B synced, oscillating on every re-sync. The V045 backfill duplicates each existing child row once per **owning-parent** repo (comments' parent = issues ∪ pull requests; reviews'/review comments' = pull requests) and keeps orphans under their own stamped repo — lossless. The upsert writers resolve through the widened keys. The standalone `github_fts` mirror is **re-derived inside the V045 transaction**: the backfill's duplicated child rows must be scoped-searchable from both owning repos immediately, not only after some later sync happens to run the sync-tail rebuild — the Rust-derived classification labels are carried across the rebuild by `(item_kind, item_id)` (identical per item across per-repo duplicates), with never-mirrored rows labeled provisionally until the next sync refreshes them.

Consolidate and `init` both use **schema-only** migrations (their subject repo is unregistered — the healing migration's witness would attribute an owed heal to the sole registered sibling), and consolidate now **migrates the legacy source itself** (under the already-held source locks, before the snapshot) so old-vintage files whose model meta still lives in the pre-V039 `index_meta`/`reconcile_meta` tables deliver the complete model-state unit — the ladder's own V039/V040 migrations relocate the keys instead of the importer growing dual-path reads.

## Also

- Scope a repo/generation-unscoped embedding count through the active `files` view.
- Scope `rag-rat gc`'s reported before/after counts to the active repo (the deletes always were repo-sliced; the reports counted the whole store, so a two-repo DB printed union totals and a sibling's concurrent index skewed the derived pruned counts). The unscoped whole-table counter is now `#[cfg(test)]`, so no future reporting path can reach it.
- Move the legacy `-wal`/`-shm` sidecars alongside the `.imported` archive: no litter remains at the legacy path, and un-checkpointed WAL frames travel with the archive — the source checkpoint stays best-effort (a busy checkpoint under a lockless read-only MCP reader is a sanctioned state, and archive wholeness no longer depends on it).
- Extend the scoping test harness to seed real multi-repo registry state on git fixtures, and propagate a test's harness opt-out onto spawned rebuild threads.

## Verification

- `cargo nextest run --workspace` — 1589 passed
- `cargo clippy --all-targets` — no warnings
- concurrency-adjacent tests under `taskset -c 0,1` (registry/locks/rebuild/consolidate, incl. the concurrent-registration barrier test and the worktree matrix) — clean across repeated rounds
- `cargo +nightly fmt`

Docs: config.md gains a "Database location" section (identity requirement, pinned-config refusal, stay-global latch); README gains a short paragraph.

Fixes #402
