### PR TITLE
test: give git fixtures deterministic distinct identities

### DIFF
--- a/crates/rag-rat-cli/tests/common/mod.rs
+++ b/crates/rag-rat-cli/tests/common/mod.rs
@@ -1,0 +1,71 @@
+//! Shared fixtures for the `rag-rat` CLI integration tests.
+//!
+//! Every git fixture repo built here gets a DETERMINISTIC, wall-clock-independent commit identity,
+//! so two fixtures built in the same test process can never share a root commit. rag-rat's portable
+//! `repo_id` is the smallest root-commit hash; identical fixture content committed on the system
+//! clock (1-second granularity, no `GIT_*_DATE`) used to produce byte-identical root commits →
+//! the SAME `repo_id`, and two such fixtures landing in one consolidated/global DB collided (#434).
+//!
+//! The commit date is a fixed base epoch plus a per-commit counter — the SAME atomic that keys
+//! temp-dir uniqueness — so fixture identities are both DISTINCT across fixtures and REPRODUCIBLE
+//! across runs (stable hashes, independent of CI load). No sleeps, retries, or `--no-verify`.
+//!
+//! Not every integration binary uses every helper here; `#![allow(dead_code)]` keeps the shared
+//! module warning-clean under `clippy --all-targets -D warnings`.
+#![allow(dead_code)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// 2021-01-01T00:00:00Z — a fixed, wall-clock-independent anchor for fixture commit dates.
+const FIXTURE_EPOCH_BASE: u64 = 1_609_459_200;
+
+/// One process-wide counter drives BOTH temp-dir names and fixture commit dates, so every fixture
+/// gets a unique path AND a unique, reproducible root-commit hash. nextest runs each test in its
+/// own process, so the call order — and thus the assigned counters — is deterministic per test.
+static SEQ: AtomicU64 = AtomicU64::new(0);
+
+fn next_seq() -> u64 {
+    SEQ.fetch_add(1, Ordering::Relaxed)
+}
+
+/// A throwaway temp dir under the system temp root, keyed by `tag`, the process id, and a unique
+/// counter. Any stale dir at the path is removed first.
+pub fn unique_dir(tag: &str) -> PathBuf {
+    let dir =
+        std::env::temp_dir().join(format!("rag-rat-{tag}-{}-{}", std::process::id(), next_seq()));
+    let _ = fs::remove_dir_all(&dir);
+    dir
+}
+
+/// Run `git -C dir args`, asserting success. Use [`git_commit`] for commits so the commit carries a
+/// deterministic, unique date (a plain `git(dir, &["commit", ...])` would commit on the wall clock
+/// and could collide on `repo_id`).
+pub fn git(dir: &Path, args: &[&str]) {
+    let out = Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
+    assert!(out.status.success(), "git {args:?} failed: {}", String::from_utf8_lossy(&out.stderr));
+}
+
+/// `git commit` with `GIT_AUTHOR_DATE`/`GIT_COMMITTER_DATE` pinned to a fixed base epoch plus a
+/// unique counter, so two fixtures with identical content never share a root-commit hash (and thus
+/// never collide on the portable `repo_id`), while the hashes stay reproducible across runs. `args`
+/// are the commit flags/message, e.g. `&["-q", "-m", "seed"]`.
+pub fn git_commit(dir: &Path, args: &[&str]) {
+    let date = format!("@{} +0000", FIXTURE_EPOCH_BASE + next_seq());
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .arg("commit")
+        .args(args)
+        .env("GIT_AUTHOR_DATE", &date)
+        .env("GIT_COMMITTER_DATE", &date)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "git commit {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/crates/rag-rat-cli/tests/consolidate.rs
+++ b/crates/rag-rat-cli/tests/consolidate.rs
@@ -11,24 +11,10 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
-use std::sync::atomic::{AtomicU64, Ordering};
 
-static TEMP: AtomicU64 = AtomicU64::new(0);
+mod common;
 
-fn unique_dir(tag: &str) -> PathBuf {
-    let dir = std::env::temp_dir().join(format!(
-        "rag-rat-consolidate-{tag}-{}-{}",
-        std::process::id(),
-        TEMP.fetch_add(1, Ordering::Relaxed)
-    ));
-    let _ = fs::remove_dir_all(&dir);
-    dir
-}
-
-fn git(dir: &Path, args: &[&str]) {
-    let out = Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
-    assert!(out.status.success(), "git {args:?} failed: {}", String::from_utf8_lossy(&out.stderr));
-}
+use common::{git, git_commit, unique_dir};
 
 /// A git fixture repo with one rust file and an EXPLICIT `database` key — the pre-flip `init`
 /// shape — so the initial index builds the LEGACY per-repo `.rag-rat/index.sqlite`.
@@ -46,7 +32,7 @@ fn fixture_repo() -> PathBuf {
     git(&root, &["config", "user.email", "t@e"]);
     git(&root, &["config", "user.name", "t"]);
     git(&root, &["add", "."]);
-    git(&root, &["commit", "-q", "-m", "seed"]);
+    git_commit(&root, &["-q", "-m", "seed"]);
     root
 }
 
@@ -161,7 +147,7 @@ fn consolidate_custom_pin_remedy_moves_then_imports() {
     git(&root, &["config", "user.email", "t@e"]);
     git(&root, &["config", "user.name", "t"]);
     git(&root, &["add", "."]);
-    git(&root, &["commit", "-q", "-m", "seed"]);
+    git_commit(&root, &["-q", "-m", "seed"]);
 
     let custom = root.join("custom/my-index.sqlite");
     let default_legacy = root.join(".rag-rat/index.sqlite");

--- a/crates/rag-rat-cli/tests/init_yes_writes_valid_config.rs
+++ b/crates/rag-rat-cli/tests/init_yes_writes_valid_config.rs
@@ -11,31 +11,26 @@
 
 use std::path::PathBuf;
 use std::process::Command;
-use std::sync::atomic::{AtomicU32, Ordering};
 
 use rag_rat_core::Config;
 
-static TEMP_COUNTER: AtomicU32 = AtomicU32::new(0);
+mod common;
 
 fn unique_temp_root() -> PathBuf {
-    let id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    std::env::temp_dir().join(format!("rag-rat-init-yes-{}-{id}", std::process::id()))
+    common::unique_dir("init-yes")
 }
 
 /// Initialize a git repo at `dir` WITH a first commit: an identity-bearing root, so the keyless
 /// config init writes resolves to the (sandboxed) GLOBAL store — an unborn HEAD is identity-less
-/// and stays on the per-root legacy path (covered by the config-level tests).
+/// and stays on the per-root legacy path (covered by the config-level tests). The commit goes
+/// through [`common::git_commit`], so its root-commit hash is deterministically unique and two
+/// fixtures never collide on `repo_id`.
 fn git_init(dir: &std::path::Path) {
-    for args in [
-        &["init", "-q"][..],
-        &["config", "user.email", "t@e.com"],
-        &["config", "user.name", "t"],
-        &["add", "-A"],
-        &["commit", "-qm", "seed"],
-    ] {
-        let out = Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
-        assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
-    }
+    common::git(dir, &["init", "-q"]);
+    common::git(dir, &["config", "user.email", "t@e.com"]);
+    common::git(dir, &["config", "user.name", "t"]);
+    common::git(dir, &["add", "-A"]);
+    common::git_commit(dir, &["-qm", "seed"]);
 }
 
 #[test]

--- a/crates/rag-rat-cli/tests/worktree_git_env.rs
+++ b/crates/rag-rat-cli/tests/worktree_git_env.rs
@@ -11,26 +11,17 @@
 use std::fs;
 use std::path::Path;
 use std::process::Command;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use rag_rat_core::language::Language;
 use rag_rat_core::{Config, IndexDatabase};
 
-static TEMP: AtomicU64 = AtomicU64::new(0);
+mod common;
 
-fn git(dir: &Path, args: &[&str]) {
-    let out = Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
-    assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
-}
+use common::{git, git_commit, unique_dir};
 
 #[test]
 fn worktree_overlay_ignores_inherited_git_dir_env() {
-    let base = std::env::temp_dir().join(format!(
-        "rag-rat-wtenv-{}-{}",
-        std::process::id(),
-        TEMP.fetch_add(1, Ordering::Relaxed)
-    ));
-    let _ = fs::remove_dir_all(&base);
+    let base = unique_dir("wtenv");
     let main = base.join("main");
     fs::create_dir_all(main.join("src")).unwrap();
     fs::write(main.join("src/keep.rs"), "pub fn keep_fn() {}\n").unwrap();
@@ -47,7 +38,7 @@ fn worktree_overlay_ignores_inherited_git_dir_env() {
     git(&main, &["config", "user.email", "t@e.com"]);
     git(&main, &["config", "user.name", "t"]);
     git(&main, &["add", "."]);
-    git(&main, &["commit", "-q", "-m", "C1 has reinf"]);
+    git_commit(&main, &["-q", "-m", "C1 has reinf"]);
 
     // Linked worktree forked at C1 (HAS reinf.rs), nested + gitignored.
     let wt = main.join("wt");
@@ -56,7 +47,7 @@ fn worktree_overlay_ignores_inherited_git_dir_env() {
     // Main REMOVES reinf.rs at C2; the branch keeps it — so reinf.rs lives ONLY in the overlay.
     fs::remove_file(main.join("src/reinf.rs")).unwrap();
     git(&main, &["add", "."]);
-    git(&main, &["commit", "-q", "-m", "C2 removed reinf"]);
+    git_commit(&main, &["-q", "-m", "C2 removed reinf"]);
 
     let config_path = main.join("rag-rat.toml");
     let config = Config::load(&config_path).unwrap();
@@ -103,12 +94,7 @@ fn worktree_overlay_ignores_inherited_git_dir_env() {
 /// config BELONGS: main's `rag-rat.toml`, not the linked checkout's.
 #[test]
 fn default_config_discovery_reaches_the_main_worktree_from_a_linked_checkout() {
-    let base = std::env::temp_dir().join(format!(
-        "rag-rat-wtdisc-{}-{}",
-        std::process::id(),
-        TEMP.fetch_add(1, Ordering::Relaxed)
-    ));
-    let _ = fs::remove_dir_all(&base);
+    let base = unique_dir("wtdisc");
     let main = base.join("main");
     fs::create_dir_all(main.join("src")).unwrap();
     fs::write(main.join("src/lib.rs"), "pub fn discovery_anchor() {}\n").unwrap();
@@ -116,7 +102,7 @@ fn default_config_discovery_reaches_the_main_worktree_from_a_linked_checkout() {
     git(&main, &["config", "user.email", "t@e.com"]);
     git(&main, &["config", "user.name", "t"]);
     git(&main, &["add", "."]);
-    git(&main, &["commit", "-q", "-m", "seed"]);
+    git_commit(&main, &["-q", "-m", "seed"]);
     let linked = base.join("wt");
     git(&main, &["worktree", "add", "--detach", "-q", linked.to_str().unwrap()]);
 


### PR DESCRIPTION
## Problem

The CLI integration tests build multiple real git fixture repos with **identical** content, author, and commit message, committing on the **system clock** (1-second granularity, no `GIT_*_DATE`). rag-rat's portable `repo_id` is the **smallest root-commit hash**, so two fixtures committed in the same wall-clock second produce a **byte-identical root commit** and collapse onto the **same `repo_id`**.

When two such fixtures land in one consolidated/global DB, the second repo's `consolidate` re-registers the first repo's id and the model-state mirror clears the first repo's meta. That surfaced as the flaky `consolidating_a_second_repo_leaves_the_first_repos_heal_owed_meta` (reproduced 42/60 in isolation; **20/20** back-to-back fixture pairs collided on the root-commit hash).

This is a test-fixture isolation defect, not a product bug: distinct real repos never share content+history, and two repos that genuinely share a root commit are the same repository (clones) and correctly share identity.

## Fix

Route every fixture commit through a shared `crates/rag-rat-cli/tests/common/mod.rs` helper that pins `GIT_AUTHOR_DATE`/`GIT_COMMITTER_DATE` to a fixed base epoch plus a per-commit counter (the same atomic that keys temp-dir uniqueness). Fixture identities become both **distinct** (no two fixtures share a root commit) and **reproducible** across runs (stable hashes, independent of CI load). No sleeps, retries, or `--no-verify`. The invariant lives in one place (`git_commit`) so it cannot regress as new fixtures are added.

Hardened builders: `consolidate.rs` (`fixture_repo` + the custom-pin inline fixture), `worktree_git_env.rs` (both tests), `init_yes_writes_valid_config.rs` (`git_init`, which also feeds a two-repos-one-DB test). The core `schema_bootstrap_tests/multi_repo_scope.rs` seeds its second repo via explicit-id SQL insert (no git-derived identity) and is left unchanged.

## Verification

- Direct collision check: **20/20** collisions before, **0/20** after; identical counter → identical hash (reproducible).
- `taskset -c 0,1 cargo nextest run --no-default-features`: victim test **120/120**; `consolidate` + `worktree_git_env` + `init_yes_writes_valid_config` binaries **100/100**.
- `cargo nextest run --workspace` (1589) and `--workspace --no-default-features` (1587) green; `cargo clippy --all-targets` clean (both feature sets); nightly fmt clean.

## Follow-up

`multi_repo_e2e.rs::build_repo` (on a separate branch) has the same latent issue and should get the same hardening there.

Fixes #434