### PR TITLE
feat(dream): run the verdict/compaction model on an ephemeral remote GPU (`[llm.dream.remote]`)

### DIFF
--- a/cookbook/package.json
+++ b/cookbook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rag-rat/cookbook",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Ephemeral remote-runtime provisioning recipes for rag-rat. rag-rat (Rust) spawns a recipe as a subprocess, reads a typed JSONL event stream from its stdout (status/log/ready/error), embeds against the endpoint, then signals teardown.",
   "license": "MIT",
   "repository": {

--- a/cookbook/recipes/backends.mts
+++ b/cookbook/recipes/backends.mts
@@ -6,7 +6,12 @@
  * the embeddings route, and how the model gets loaded — so one provider recipe serves all backends.
  *
  * All three speak the OpenAI-compatible embeddings API, so the embed CALL and {@link verifyEmbed}
- * are backend-independent; only the ROUTE differs (`embedPath`) — see the per-backend note on it.
+ * are backend-independent; only the ROUTE differs (`servePath("embed")`) — see the per-backend note.
+ *
+ * A spec is also CAPABILITY-aware (`embed` vs `chat`): ollama and vLLM serve both — vLLM drops its
+ * `--runner pooling` flag and answers `/v1/chat/completions` for chat — while infinity is embed-only
+ * ({@link assertCapabilitySupported} rejects infinity + chat before a box is created). Chat is the
+ * dream verdict/compaction model; the chat CALL and {@link verifyChat} are likewise backend-independent.
  *
  * Launch facts (verified against upstream docs/live probes, 2026-07):
  *   - ollama    `ollama/ollama:latest`         entrypoint `/bin/ollama`  → `serve` (empty server;
@@ -20,7 +25,7 @@
  *               `/v1/embeddings`; port 8000; GPU-REQUIRED (no official CPU image).
  */
 
-import type { Backend, CookbookInput } from "../src/contract.js";
+import type { Backend, Capability, CookbookInput } from "../src/contract.js";
 
 /** The declarative, provider-independent description of one embedding backend. */
 export interface BackendServerSpec {
@@ -32,11 +37,11 @@ export interface BackendServerSpec {
    */
   readonly port: number;
   /**
-   * The OpenAI embeddings route this server answers on. MUST mirror `RemoteBackend::embed_path` on
-   * the Rust side (ollama/vLLM → `/v1/embeddings`; infinity → `/embeddings`) — the recipe's
-   * verification probe and rag-rat's real embed call have to hit the same URL.
+   * The capabilities this backend can serve — `embed`, `chat`, or both. ollama and vLLM serve both;
+   * infinity is embed-only. {@link assertCapabilitySupported} gates a request against this before a
+   * box is created, so an unsupported (backend, capability) pair fails loudly at provision time.
    */
-  readonly embedPath: string;
+  readonly capabilities: readonly Capability[];
   /**
    * Whether this backend needs a GPU. vLLM's published image is CUDA-only, so a provider MUST attach
    * a GPU for it (the recipe defaults one in when the caller didn't). ollama/infinity are
@@ -58,11 +63,20 @@ export interface BackendServerSpec {
   /**
    * The args to pass AFTER the image's baked entrypoint. A provider hands these to the box verbatim
    * (Modal as a `command` array, RunPod joined into `dockerArgs`). Never include the entrypoint
-   * itself — that's baked into the image.
+   * itself — that's baked into the image. Capability-aware via `input.capability` (default `embed`):
+   * vLLM includes `--runner pooling` (embedding mode) for `embed` and OMITS it for `chat` (the
+   * default generation runner). Absent/null capability → `embed`, so existing callers are unaffected.
    */
   entrypointArgs(input: CookbookInput): readonly string[];
   /** Container env as a plain record; a provider maps it to its own shape. */
   env(input: CookbookInput): Record<string, string>;
+  /**
+   * The OpenAI-compatible route this server answers on for `capability`. MUST mirror the Rust side:
+   * embed → `RemoteBackend::embed_path` (ollama/vLLM `/v1/embeddings`; infinity `/embeddings`); chat
+   * → `/v1/chat/completions` (ollama/vLLM). Throws for a capability the backend cannot serve
+   * (infinity + chat) — the readiness probe and rag-rat's real call have to hit the same URL.
+   */
+  servePath(capability: Capability): string;
 }
 
 /** ollama serves on 11434 and binds loopback by default (OLLAMA_HOST opens it to the tunnel). */
@@ -75,11 +89,14 @@ const VLLM_PORT = 8000;
 const OLLAMA_SPEC: BackendServerSpec = {
   backend: "ollama",
   port: OLLAMA_PORT,
-  embedPath: "/v1/embeddings",
+  // ollama serves both embeddings and chat from the same `serve` process; only the model differs.
+  capabilities: ["embed", "chat"],
   requiresGpu: false,
   modelLoad: "ollama-pull",
   image: () => "ollama/ollama:latest",
+  // `serve` boots an empty server regardless of capability; the model (embed or chat) is pulled after.
   entrypointArgs: () => ["serve"],
+  servePath: (capability) => (capability === "chat" ? "/v1/chat/completions" : "/v1/embeddings"),
   env: (input) => ({
     // ollama binds 127.0.0.1 by default, unreachable through a tunnel/proxy — open all interfaces.
     OLLAMA_HOST: `0.0.0.0:${OLLAMA_PORT}`,
@@ -95,9 +112,10 @@ const OLLAMA_SPEC: BackendServerSpec = {
 const INFINITY_SPEC: BackendServerSpec = {
   backend: "infinity",
   port: INFINITY_PORT,
-  // infinity's OpenAI shape lives at `/embeddings` (it also mounts `/v1/embeddings`, but `/embeddings`
-  // is canonical and is what `RemoteBackend::embed_path` uses).
-  embedPath: "/embeddings",
+  // Embed-only: infinity's `v2` server does embeddings/rerank/classify, NOT chat generation. A chat
+  // request for this backend is rejected (Rust config rejects it too, but the recipe must fail loudly
+  // rather than serve the wrong thing) — see `servePath`.
+  capabilities: ["embed"],
   requiresGpu: false,
   modelLoad: "in-launch",
   // CPU image unless a GPU was explicitly requested (infinity is CPU-capable; the CPU tag is slimmer).
@@ -108,21 +126,41 @@ const INFINITY_SPEC: BackendServerSpec = {
   // rag-rat's client-side fan-out tune still applies.
   entrypointArgs: (input) => ["v2", "--model-id", input.model, "--port", String(INFINITY_PORT)],
   env: () => ({}),
+  // infinity's OpenAI shape lives at `/embeddings` (it also mounts `/v1/embeddings`, but `/embeddings`
+  // is canonical and is what `RemoteBackend::embed_path` uses). Chat is unsupported → throw.
+  servePath: (capability) => {
+    if (capability !== "embed") {
+      throw new Error(
+        `backend "infinity" cannot serve capability "${capability}" — it is embeddings-only ` +
+          `(embeddings/rerank/classify, no chat generation).`,
+      );
+    }
+    return "/embeddings";
+  },
 };
 
 const VLLM_SPEC: BackendServerSpec = {
   backend: "vllm",
   port: VLLM_PORT,
-  embedPath: "/v1/embeddings",
+  // vLLM serves both: `--runner pooling` → embeddings; the default (generation) runner → chat.
+  capabilities: ["embed", "chat"],
   // vLLM's published image (`vllm/vllm-openai`) is CUDA-only — a provider must attach a GPU.
   requiresGpu: true,
   modelLoad: "in-launch",
   image: () => "vllm/vllm-openai:latest",
-  // Entrypoint is `vllm serve`, so the model id is the first positional. `--runner pooling` puts
-  // vLLM in embedding mode (current flag; the old `--task embed` is deprecated as of v0.11). vLLM
-  // binds loopback unless `--host 0.0.0.0` is passed — the classic "up but unreachable" trap.
+  // Entrypoint is `vllm serve`, so the model id is the first positional. vLLM binds loopback unless
+  // `--host 0.0.0.0` is passed — the classic "up but unreachable" trap. The RUNNER is capability-
+  // dependent: `--runner pooling` puts vLLM in embedding mode (current flag; the old `--task embed`
+  // is deprecated as of v0.11); for `chat` we OMIT it so vLLM uses its default GENERATION runner and
+  // serves `/v1/chat/completions`. Passing `--runner pooling` for chat would force embedding mode and
+  // 404 the chat route — the whole reason chat drops the flag.
   entrypointArgs: (input) => {
-    const args = [input.model, "--runner", "pooling", "--host", "0.0.0.0", "--port", String(VLLM_PORT)];
+    const capability = input.capability ?? "embed";
+    const args = [input.model];
+    if (capability === "embed") {
+      args.push("--runner", "pooling");
+    }
+    args.push("--host", "0.0.0.0", "--port", String(VLLM_PORT));
     // Map the concurrency cap to vLLM's max concurrent sequences when set.
     if (input.server_concurrency != null) {
       args.push("--max-num-seqs", String(input.server_concurrency));
@@ -130,6 +168,7 @@ const VLLM_SPEC: BackendServerSpec = {
     return args;
   },
   env: () => ({}),
+  servePath: (capability) => (capability === "chat" ? "/v1/chat/completions" : "/v1/embeddings"),
 };
 
 /** All backend specs, keyed by backend. The one lookup table {@link selectBackendSpec} resolves. */
@@ -142,4 +181,20 @@ const SPECS: Readonly<Record<Backend, BackendServerSpec>> = {
 /** Resolve the {@link BackendServerSpec} for `backend`. Total over the {@link Backend} union. */
 export function selectBackendSpec(backend: Backend): BackendServerSpec {
   return SPECS[backend];
+}
+
+/**
+ * Fail loudly if `spec.backend` cannot serve `capability` (today: infinity + chat). A provider
+ * recipe calls this at the TOP of `provision` — BEFORE it creates any box — so an unsupported pair
+ * aborts into `runRecipe`'s error path with a clear message instead of provisioning a box that would
+ * serve the wrong API (or 404 the probe). rag-rat's Rust config already rejects infinity-for-chat,
+ * but the recipe is the last line of defense and must not silently serve the wrong thing.
+ */
+export function assertCapabilitySupported(spec: BackendServerSpec, capability: Capability): void {
+  if (!spec.capabilities.includes(capability)) {
+    throw new Error(
+      `backend "${spec.backend}" cannot serve capability "${capability}" ` +
+        `(supported: ${spec.capabilities.join(", ")}).`,
+    );
+  }
 }

--- a/cookbook/recipes/modal.mts
+++ b/cookbook/recipes/modal.mts
@@ -44,10 +44,11 @@ import {
   log,
   raceWithTimeout,
   runRecipe,
+  verifyChat,
   verifyEmbed,
   withBudget,
 } from "../src/contract.js";
-import { selectBackendSpec } from "./backends.mjs";
+import { assertCapabilitySupported, selectBackendSpec } from "./backends.mjs";
 
 /** Provider-side max-lifetime backstop in ms — a leaked box self-destructs after this. */
 const BOX_MAX_LIFETIME_MS = 1_800_000; // 30 minutes
@@ -68,6 +69,10 @@ const TEARDOWN_TIMEOUT_MS = 8_000;
 async function provision(ctx: ProvisionContext<Sandbox>): Promise<Provisioned<Sandbox>> {
   const { input, provisionTimeoutMs } = ctx;
   const spec = selectBackendSpec(input.backend ?? "ollama");
+  // What the box should SERVE (embeddings vs chat). Absent → embed (back-compat). Fail loudly NOW,
+  // before any box is created, if this backend can't serve it (infinity + chat).
+  const capability = input.capability ?? "embed";
+  assertCapabilitySupported(spec, capability);
   const port = spec.port;
   // ONE deadline for the WHOLE sequence (create + pull + verify). EVERY SDK await below — none of
   // which has a native timeout — is raced against the time REMAINING until this deadline via
@@ -161,16 +166,19 @@ async function provision(ctx: ProvisionContext<Sandbox>): Promise<Provisioned<Sa
   const endpoint = tunnel.url;
   log("info", `tunnel up: ${endpoint}`);
 
-  // Verify the server actually embeds before we emit `ready`. This catches a box that booted but
+  // Verify the server actually serves before we emit `ready`. This catches a box that booted but
   // isn't serving (the whole point of waiting before the ready event). Budget = the time REMAINING
-  // until the shared deadline (create + pull already consumed some); throws if it's spent.
-  ctx.status("verifying", `probing ${spec.embedPath} for a real vector`);
-  await verifyEmbed(endpoint, {
-    model: input.model,
-    embedPath: spec.embedPath,
-    budgetMs: assertBudgetRemaining(deadline, "embed verification"),
-  });
-  log("info", "embed verification passed; box is serving");
+  // until the shared deadline (create + pull already consumed some); throws if it's spent. The probe
+  // matches the capability: a chat box gets a chat-completions ping, an embed box an embeddings one.
+  const servePath = spec.servePath(capability);
+  ctx.status("verifying", `probing ${servePath} for a real ${capability === "chat" ? "completion" : "vector"}`);
+  const verifyBudgetMs = assertBudgetRemaining(deadline, `${capability} verification`);
+  if (capability === "chat") {
+    await verifyChat(endpoint, { model: input.model, chatPath: servePath, budgetMs: verifyBudgetMs });
+  } else {
+    await verifyEmbed(endpoint, { model: input.model, embedPath: servePath, budgetMs: verifyBudgetMs });
+  }
+  log("info", `${capability} verification passed; box is serving`);
 
   // Open tunnel via encryptedPorts → no per-request token needed. auth_token stays null.
   return { handle: sb, endpoint, auth_token: null };

--- a/cookbook/recipes/runpod.mts
+++ b/cookbook/recipes/runpod.mts
@@ -53,9 +53,10 @@ import {
   log,
   pollUntil,
   runRecipe,
+  verifyChat,
   verifyEmbed,
 } from "../src/contract.js";
-import { selectBackendSpec } from "./backends.mjs";
+import { assertCapabilitySupported, selectBackendSpec } from "./backends.mjs";
 
 /**
  * Default provisioning budget (boot + pull + first serving response) when input omits it. A GPU
@@ -102,6 +103,10 @@ interface DeployedPod {
 async function provision(ctx: ProvisionContext<PodHandle>): Promise<Provisioned<PodHandle>> {
   const { input, provisionTimeoutMs } = ctx;
   const spec = selectBackendSpec(input.backend ?? "ollama");
+  // What the box should SERVE (embeddings vs chat). Absent → embed (back-compat). Fail loudly NOW,
+  // before any pod is deployed, if this backend can't serve it (infinity + chat).
+  const capability = input.capability ?? "embed";
+  assertCapabilitySupported(spec, capability);
   const port = spec.port;
   // ONE deadline for the WHOLE sequence (deploy + pull + verify). Each step below uses the budget
   // REMAINING until this deadline — never a fresh full budget — so the total stays inside the
@@ -180,15 +185,18 @@ async function provision(ctx: ProvisionContext<PodHandle>): Promise<Provisioned<
     log("info", `model "${input.model}" pulled`);
   }
 
-  // Confirm the server actually embeds before we emit `ready`. Budget = the REMAINING time after the
-  // pull, so deploy+pull+verify together stay inside the single provisioning budget.
-  ctx.status("verifying", `probing ${spec.embedPath} for a real vector`);
-  await verifyEmbed(endpoint, {
-    model: input.model,
-    embedPath: spec.embedPath,
-    budgetMs: assertBudgetRemaining(deadline, "embed verification"),
-  });
-  log("info", "embed verification passed; pod is serving");
+  // Confirm the server actually serves before we emit `ready`. Budget = the REMAINING time after the
+  // pull, so deploy+pull+verify together stay inside the single provisioning budget. The probe matches
+  // the capability: a chat box gets a chat-completions ping, an embed box an embeddings one.
+  const servePath = spec.servePath(capability);
+  ctx.status("verifying", `probing ${servePath} for a real ${capability === "chat" ? "completion" : "vector"}`);
+  const verifyBudgetMs = assertBudgetRemaining(deadline, `${capability} verification`);
+  if (capability === "chat") {
+    await verifyChat(endpoint, { model: input.model, chatPath: servePath, budgetMs: verifyBudgetMs });
+  } else {
+    await verifyEmbed(endpoint, { model: input.model, embedPath: servePath, budgetMs: verifyBudgetMs });
+  }
+  log("info", `${capability} verification passed; pod is serving`);
 
   // RunPod's HTTP proxy is open (no per-request token for proxied ports) → auth_token null.
   return { handle, endpoint, auth_token: null };

--- a/cookbook/src/contract.ts
+++ b/cookbook/src/contract.ts
@@ -48,6 +48,24 @@ export function asBackend(value: string): Backend | undefined {
   return (BACKENDS as readonly string[]).includes(value) ? (value as Backend) : undefined;
 }
 
+/**
+ * What a provisioned box SERVES. Orthogonal to {@link Backend}: a backend may serve one or both.
+ *   - `embed` → the OpenAI embeddings API (`/v1/embeddings` or `/embeddings`); {@link verifyEmbed}
+ *     is the readiness probe. This is the historical, default capability.
+ *   - `chat` → the OpenAI chat-completions API (`/v1/chat/completions`); {@link verifyChat} is the
+ *     readiness probe. Used for the dream verdict/compaction model (see the remote-GPU plan).
+ * ollama and vLLM serve both; infinity is embed-only.
+ */
+export type Capability = "embed" | "chat";
+
+/** The capabilities a recipe understands, for input validation. Keep in sync with {@link Capability}. */
+export const CAPABILITIES: readonly Capability[] = ["embed", "chat"] as const;
+
+/** Narrows an arbitrary string to a known {@link Capability}, or `undefined` if unrecognized. */
+export function asCapability(value: string): Capability | undefined {
+  return (CAPABILITIES as readonly string[]).includes(value) ? (value as Capability) : undefined;
+}
+
 /** Provisioning lifecycle phases reported by a `status` event. */
 export type Phase = "provisioning" | "pulling" | "verifying" | "tearing_down";
 
@@ -97,6 +115,15 @@ export interface CookbookInput {
    * hand-run dev invocation). {@link readInput} validates it against {@link BACKENDS}.
    */
   readonly backend?: Backend | null;
+  /**
+   * What the box should SERVE: `"embed"` (OpenAI embeddings) or `"chat"` (OpenAI chat completions —
+   * the dream verdict/compaction model). Omitted/null → `"embed"` (back-compat: existing embedding
+   * callers predate this field and never send it). {@link readInput} validates it against
+   * {@link CAPABILITIES}. The backend spec branches on it — vLLM drops `--runner pooling` for chat,
+   * the route switches to `/v1/chat/completions`, and the readiness probe switches from
+   * {@link verifyEmbed} to {@link verifyChat}. `infinity` cannot serve `"chat"` (embed-only).
+   */
+  readonly capability?: Capability | null;
   /**
    * Ollama context window (`OLLAMA_CONTEXT_LENGTH`) to bake into the ephemeral box for the OLLAMA
    * backend, so chunk vectors match the freshness key that folds `num_ctx` in. Ignored by
@@ -257,6 +284,12 @@ export function readInput(): CookbookInput {
   // config beats a silent wrong-backend provision).
   const backend = optionalBackend(obj["backend"]);
 
+  // capability: optional; absent/null → "embed" (back-compat — existing embedding callers never send
+  // it). A present-but-unknown value is a hard error, mirroring `backend`: silently serving the wrong
+  // capability (embeddings when chat was intended, or vice versa) is exactly the wrong-provision
+  // footgun the strict validation exists to prevent.
+  const capability = optionalCapability(obj["capability"]);
+
   // gpu: optional; if present must be a string (provider spec) or null.
   const gpu = obj["gpu"];
   if (gpu !== undefined && gpu !== null && typeof gpu !== "string") {
@@ -266,6 +299,7 @@ export function readInput(): CookbookInput {
   const result: CookbookInput = {
     model: obj["model"],
     backend,
+    capability,
     ...(provisionTimeout !== undefined ? { provision_timeout_s: provisionTimeout } : {}),
     ...(requestTimeout !== undefined ? { request_timeout_s: requestTimeout } : {}),
     ...(typeof gpu === "string" ? { gpu } : gpu === null ? { gpu: null } : {}),
@@ -291,6 +325,27 @@ function optionalBackend(value: unknown): Backend {
     );
   }
   return backend;
+}
+
+/**
+ * Validate the optional `capability` field: absent/null → `"embed"` (the default — existing
+ * embedding callers predate the field); a known {@link Capability} string passes through; anything
+ * else is a hard error naming the accepted values (a typo beats a silent wrong-capability provision).
+ */
+function optionalCapability(value: unknown): Capability {
+  if (value === undefined || value === null) return "embed";
+  if (typeof value !== "string") {
+    throw new Error(
+      `${COOKBOOK_INPUT_ENV}.capability must be a string or null (got ${describe(value)}).`,
+    );
+  }
+  const capability = asCapability(value);
+  if (capability === undefined) {
+    throw new Error(
+      `${COOKBOOK_INPUT_ENV}.capability "${value}" is not a known capability (one of: ${CAPABILITIES.join(", ")}).`,
+    );
+  }
+  return capability;
 }
 
 /** Validates an optional positive-number field; returns the number, or undefined if absent/null. */
@@ -578,6 +633,90 @@ export function verifyEmbed(endpoint: string, options: VerifyEmbedOptions): Prom
       return {
         ready: false,
         reason: `200 OK but no embedding vector: ${JSON.stringify(body).slice(0, 200)}`,
+      };
+    },
+  });
+}
+
+/** Default delay between chat-readiness probes (ms). */
+const VERIFY_CHAT_POLL_INTERVAL_MS = 3_000;
+/**
+ * Default per-attempt timeout for a chat probe (ms). The first completion on a freshly-booted box
+ * can be slow (weights load into VRAM + first-token latency), so this is generous — but still well
+ * under any sane provisioning budget, so a genuinely stalled attempt aborts and retries.
+ */
+const VERIFY_CHAT_ATTEMPT_TIMEOUT_MS = 30_000;
+
+/** Options for {@link verifyChat}. */
+export interface VerifyChatOptions {
+  /** Chat model name to probe with (the value the server keys on). */
+  readonly model: string;
+  /**
+   * Backend-specific chat-completions route to probe, e.g. `/v1/chat/completions` (ollama/vLLM).
+   * MUST match the route the Rust chat client posts to — the probe and the real chat call have to
+   * hit the same URL, or a box that passes verification still 404s under load.
+   */
+  readonly chatPath: string;
+  /** Wall-clock budget in ms to keep retrying before giving up. Use the provisioning budget. */
+  readonly budgetMs: number;
+  /** Extra headers (e.g. an auth bearer) to send with each probe. Defaults to none. */
+  readonly headers?: Record<string, string>;
+  /** Delay between retries in ms. Defaults to {@link VERIFY_CHAT_POLL_INTERVAL_MS}. */
+  readonly pollIntervalMs?: number;
+  /** Per-attempt fetch timeout in ms. Defaults to {@link VERIFY_CHAT_ATTEMPT_TIMEOUT_MS}. */
+  readonly perAttemptTimeoutMs?: number;
+}
+
+/**
+ * Polls `<endpoint><options.chatPath>` with a tiny OpenAI-compatible chat-completions request until
+ * the server returns a well-formed completion, or the budget runs out — the chat parallel of
+ * {@link verifyEmbed}.
+ *
+ * Every chat recipe must call this BEFORE handing rag-rat the endpoint: a box can be reachable
+ * (tunnel up) while the model is still loading, so "box created" is not "box serving". The probe
+ * posts the SAME shape a chat client uses — a one-turn `messages` array with `max_tokens:1`,
+ * `temperature:0`, `stream:false` — so a server that can't actually generate fails HERE, at
+ * provision time, not later on the hot path. A well-formed `choices[0].message.content` (a string —
+ * a single token under `max_tokens:1`, possibly empty when truncated) is the readiness signal.
+ * Throws if the budget elapses with no completion.
+ */
+export function verifyChat(endpoint: string, options: VerifyChatOptions): Promise<void> {
+  const url = endpointPath(endpoint, options.chatPath);
+  return pollUntil<{ choices?: unknown }>(url, {
+    label: "chat probe",
+    budgetMs: options.budgetMs,
+    // The smallest possible generation: one user turn, a single deterministic token. Enough to prove
+    // the generation pipeline is live without paying for real output.
+    body: {
+      model: options.model,
+      messages: [{ role: "user", content: "ping" }],
+      max_tokens: 1,
+      temperature: 0,
+      stream: false,
+    },
+    pollIntervalMs: options.pollIntervalMs ?? VERIFY_CHAT_POLL_INTERVAL_MS,
+    perAttemptTimeoutMs: options.perAttemptTimeoutMs ?? VERIFY_CHAT_ATTEMPT_TIMEOUT_MS,
+    ...(options.headers !== undefined ? { headers: options.headers } : {}),
+    isReady: (body) => {
+      // OpenAI shape: {choices:[{message:{role,content}, finish_reason}, …]}. A well-formed first
+      // choice whose `message.content` is a STRING = the model generated (the content may be a single
+      // token, or an empty string when truncated at max_tokens:1 — either way the pipeline served).
+      const choices = body.choices;
+      const first = Array.isArray(choices) && choices.length > 0 ? choices[0] : undefined;
+      const message =
+        typeof first === "object" && first !== null
+          ? (first as { message?: unknown }).message
+          : undefined;
+      const content =
+        typeof message === "object" && message !== null
+          ? (message as { content?: unknown }).content
+          : undefined;
+      if (typeof content === "string") {
+        return { ready: true };
+      }
+      return {
+        ready: false,
+        reason: `200 OK but no chat completion: ${JSON.stringify(body).slice(0, 200)}`,
       };
     },
   });

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -200,12 +200,12 @@ pub(crate) struct DreamArgs {
     #[arg(long)]
     pub limit: Option<u32>,
     /// Run the memory verification pass (dream v2). Emits `memory_unverifiable` findings
-    /// deterministically; with `[dream.model] enabled = true` it also runs the out-of-process
+    /// deterministically; with `[llm.dream] enabled = true` it also runs the out-of-process
     /// model verdict pass, writing `memory_reality` verdicts and `memory_divergence` findings.
     /// Off by default, so plain `rag-rat dream` stays byte-identical.
     #[arg(long)]
     pub verify: bool,
-    /// Run the memory compaction pass (dream v2 pass 2). With `[dream.model] enabled = true` it
+    /// Run the memory compaction pass (dream v2 pass 2). With `[llm.dream] enabled = true` it
     /// runs the out-of-process model compaction pass, rewriting un-summarized memories into 3–4
     /// sentence summaries in `memory_summaries`. Off by default; independent of `--verify`, so
     /// plain `rag-rat dream` stays byte-identical.

--- a/crates/rag-rat-cli/src/commands/clones.rs
+++ b/crates/rag-rat-cli/src/commands/clones.rs
@@ -294,7 +294,6 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
-            dream: Default::default(),
             memory: Default::default(),
             log: Default::default(),
         };

--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -487,7 +487,6 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
-            dream: Default::default(),
             memory: Default::default(),
             log: Default::default(),
         };
@@ -567,7 +566,6 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
-            dream: Default::default(),
             memory: Default::default(),
             log: Default::default(),
         };
@@ -645,7 +643,6 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
-            dream: Default::default(),
             memory: Default::default(),
             log: Default::default(),
         };
@@ -718,7 +715,6 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
-            dream: Default::default(),
             memory: Default::default(),
             log: Default::default(),
         };

--- a/crates/rag-rat-cli/src/commands/memory.rs
+++ b/crates/rag-rat-cli/src/commands/memory.rs
@@ -14,7 +14,7 @@ use crate::render::print_output;
 /// `repo_memories` row.
 ///
 /// `--verify` turns on the dream v2 verification pass: the deterministic `memory_unverifiable`
-/// findings always, and — when `[dream.model] enabled = true` — the out-of-process model verdict
+/// findings always, and — when `[llm.dream] enabled = true` — the out-of-process model verdict
 /// pass (writing `memory_reality` verdicts + `memory_divergence` findings). `--compact`
 /// (independent of `--verify`) turns on the compaction pass: when the model is enabled it rewrites
 /// un-summarized memories into `memory_summaries`. With neither flag the run is byte-identical to
@@ -44,20 +44,20 @@ pub(crate) fn dream(config: &Config, args: &DreamArgs) -> anyhow::Result<()> {
     // in config — the generative-model dependency stays strictly opt-in (#122). One client is built
     // (out-of-process) and borrowed by whichever passes are active; with the model disabled, both
     // are `None` and the run stays 100% deterministic.
-    let model_enabled = config.dream.model.enabled;
+    let model_enabled = config.llm.dream.enabled;
     // A model-pass flag with the model disabled would otherwise run silently as a
     // deterministic-only pass; name the config key so the operator knows why no
     // verdicts/summaries were written.
     if (args.verify || args.compact) && !model_enabled {
         eprintln!(
-            "note: --verify/--compact was requested but [dream.model] enabled = false — running \
-             the deterministic passes only; set [dream.model] enabled = true to run the model \
+            "note: --verify/--compact was requested but [llm.dream] enabled = false — running the \
+             deterministic passes only; set [llm.dream] enabled = true to run the model \
              verdict/compaction pass."
         );
     }
     let budget = args.max_memories.unwrap_or(20) as usize;
     let model = (model_enabled && (args.verify || args.compact))
-        .then(|| rag_rat_core::dream::HttpVerdictModel::from_config(&config.dream.model));
+        .then(|| rag_rat_core::dream::HttpVerdictModel::from_config(&config.llm.dream.remote));
     let verdict_pass = (args.verify && model_enabled)
         .then(|| rag_rat_core::dream::VerdictPass { model: model.as_ref().unwrap(), budget });
     let compact_pass = (args.compact && model_enabled)

--- a/crates/rag-rat-cli/src/commands/memory.rs
+++ b/crates/rag-rat-cli/src/commands/memory.rs
@@ -56,11 +56,36 @@ pub(crate) fn dream(config: &Config, args: &DreamArgs) -> anyhow::Result<()> {
         );
     }
     let budget = args.max_memories.unwrap_or(20) as usize;
-    let model = (model_enabled && (args.verify || args.compact))
-        .then(|| rag_rat_core::dream::HttpVerdictModel::from_config(&config.llm.dream.remote));
-    let verdict_pass = (args.verify && model_enabled)
+    let remote = &config.llm.dream.remote;
+    // Build the model client when a model pass is asked-for AND enabled. For an EPHEMERAL
+    // `[llm.dream.remote]` (cookbook set), provision a GPU box first — but a ZERO-WORK GUARD skips
+    // that entirely when the churn-skip queues are already drained, so an idle `dream --verify`
+    // never cold-starts a paid box. `_provisioned` holds the box for the whole run; its `Drop`
+    // tears it down after the passes finish. Connect mode (or the local-Ollama default) builds
+    // directly.
+    let mut _provisioned = None;
+    let model = if model_enabled && (args.verify || args.compact) {
+        if remote.is_ephemeral() {
+            if db.dream_model_work_pending(opts, budget, args.verify, args.compact)? {
+                let (m, provisioned) = rag_rat_core::dream::provision_verdict_model(remote)?;
+                _provisioned = Some(provisioned);
+                Some(m)
+            } else {
+                eprintln!(
+                    "note: no memories pending verification/compaction — skipping the ephemeral \
+                     `[llm.dream.remote]` GPU box for this run."
+                );
+                None
+            }
+        } else {
+            Some(rag_rat_core::dream::HttpVerdictModel::from_config(remote))
+        }
+    } else {
+        None
+    };
+    let verdict_pass = (args.verify && model.is_some())
         .then(|| rag_rat_core::dream::VerdictPass { model: model.as_ref().unwrap(), budget });
-    let compact_pass = (args.compact && model_enabled)
+    let compact_pass = (args.compact && model.is_some())
         .then(|| rag_rat_core::dream::CompactPass { model: model.as_ref().unwrap(), budget });
     let report = db.dream_run_with_passes(opts, verdict_pass, compact_pass)?;
     print_output(&report)

--- a/crates/rag-rat-cli/src/commands/memory.rs
+++ b/crates/rag-rat-cli/src/commands/memory.rs
@@ -78,7 +78,7 @@ pub(crate) fn dream(config: &Config, args: &DreamArgs) -> anyhow::Result<()> {
                 None
             }
         } else {
-            Some(rag_rat_core::dream::HttpVerdictModel::from_config(remote))
+            Some(rag_rat_core::dream::HttpVerdictModel::from_config(remote)?)
         }
     } else {
         None

--- a/crates/rag-rat-cli/src/commands/oracle.rs
+++ b/crates/rag-rat-cli/src/commands/oracle.rs
@@ -482,7 +482,6 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
-            dream: Default::default(),
             memory: Default::default(),
             log: Default::default(),
         };
@@ -532,7 +531,6 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
-            dream: Default::default(),
             memory: Default::default(),
             log: Default::default(),
         };

--- a/crates/rag-rat-cli/tests/multi_repo_e2e.rs
+++ b/crates/rag-rat-cli/tests/multi_repo_e2e.rs
@@ -997,6 +997,17 @@ fn dream_worklist_is_repo_scoped_end_to_end() {
         .memory
         .memory_id;
 
+    // Cover the IndexDatabase `dream_model_work_pending` wrapper — the ephemeral zero-work-guard
+    // seam the `dream` command consults before cold-starting a paid GPU box. A has an active,
+    // never-verified memory, so the model pass has pending work (repo-scoped to A).
+    let work_opts = rag_rat_core::dream::DreamOptions { now_ms: 0, limit: 20, verify: true };
+    assert!(
+        open_scoped(&repo_a, &data_dir)
+            .dream_model_work_pending(work_opts, 20, true, true)
+            .unwrap(),
+        "A's model pass has pending work (an un-verified memory) — the guard would provision"
+    );
+
     // dream from A: FLAGS only_in_b.rs (absent from A's files) as stale, and never surfaces B's
     // memory or B's own-resolving path.
     let a_dream = run_ok(&repo_a, &data_dir, &cache, &["--json", "dream"]);

--- a/crates/rag-rat-core/benches/shared/mod.rs
+++ b/crates/rag-rat-core/benches/shared/mod.rs
@@ -70,7 +70,6 @@ pub fn bench_config(subdir: &str) -> Config {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     }

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -23,7 +23,6 @@ pub struct Config {
     pub version_check: VersionCheckConfig,
     pub oracle: OracleConfig,
     pub search: SearchConfig,
-    pub dream: DreamConfig,
     pub memory: MemoryConfig,
     /// Optional `[index] repo_id` override for the consolidated global store — pins the repo's
     /// identity instead of deriving it from the root-commit hash. `None` = derive. Consumed by
@@ -48,15 +47,6 @@ pub struct SearchConfig {
     /// A/B-swept on the commit-replay eval (`rag-rat eval --replay --rerank`); see
     /// [`crate::search::lexical::SearchOptions::graded_history`].
     pub graded_git_rerank: bool,
-}
-
-/// Dream-mode model verdict pass (`[dream]`). rag-rat's first generative-model dependency (#122),
-/// shaped by its constraints: out-of-process only, an explicit batch command, and a deterministic
-/// layer that gates the model. Default OFF, so `rag-rat dream` stays 100% deterministic unless the
-/// operator opts in.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct DreamConfig {
-    pub model: DreamModelConfig,
 }
 
 /// Repo-memory surfacing (`[memory]`) — how drive-by memory attachments render. Default is `full`
@@ -98,37 +88,6 @@ impl MemorySurface {
             "full" => Some(Self::Full),
             "summary" => Some(Self::Summary),
             _ => None,
-        }
-    }
-}
-
-/// `[dream.model]` — the OpenAI-compatible chat endpoint the verdict pass calls (a local Ollama by
-/// default). The client speaks the standard `/v1/chat/completions` route, so any compatible server
-/// works. `enabled = false` by default: turning it on (together with `--verify`) is what enables
-/// the model verdict pass; the deterministic pass-0 findings never depend on it.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DreamModelConfig {
-    /// Run the model verdict pass at all (default false — opt in explicitly). When false, `rag-rat
-    /// dream --verify` still runs the deterministic pass-0 findings; only the model turn is
-    /// skipped.
-    pub enabled: bool,
-    /// Base URL of the OpenAI-compatible chat server (default a local Ollama). The verdict client
-    /// appends `/v1/chat/completions`.
-    pub endpoint: String,
-    /// The server-side model name sent in the chat request body.
-    pub model: String,
-    /// Per-request HTTP timeout, in seconds. A 4B verdict on CPU can take a while, so the default
-    /// is generous.
-    pub request_timeout_s: u64,
-}
-
-impl Default for DreamModelConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            endpoint: "http://localhost:11434".to_string(),
-            model: "qwen3:4b-instruct".to_string(),
-            request_timeout_s: 300,
         }
     }
 }
@@ -283,6 +242,26 @@ impl Default for LogConfig {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct LlmConfig {
     pub embedding: EmbeddingConfig,
+    pub dream: DreamLlmConfig,
+}
+
+/// Dream-mode model pass (`[llm.dream]`) — rag-rat's first generative-model dependency (#122),
+/// serving its verdict/compaction turns over an OpenAI-compatible chat endpoint. Mirrors
+/// [`EmbeddingConfig`]: an `enabled` gate plus a [`RemoteDreamConfig`] serving block (connect XOR
+/// ephemeral). Default OFF, so `rag-rat dream` stays 100% deterministic unless the operator opts
+/// in.
+///
+/// Unlike embeddings, `remote` is NOT optional: dream has no in-process backend, so an absent
+/// `[llm.dream.remote]` block still resolves to a serving config — [`RemoteDreamConfig::default`],
+/// a connect to a local Ollama (today's `[dream.model]` default).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DreamLlmConfig {
+    /// Run the model pass at all (default false — opt in explicitly). When false, `rag-rat dream
+    /// --verify` still runs the deterministic pass-0 findings; only the model turn is skipped.
+    pub enabled: bool,
+    /// Which chat server serves the dream turns (connect XOR ephemeral). Absent
+    /// `[llm.dream.remote]` → [`RemoteDreamConfig::default`] (a local-Ollama connect).
+    pub remote: RemoteDreamConfig,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -450,6 +429,25 @@ impl RemoteBackend {
             RemoteBackend::Ollama | RemoteBackend::Vllm => "/v1/embeddings",
             RemoteBackend::Infinity => "/embeddings",
         }
+    }
+
+    /// Whether this backend can serve CHAT completions (the dream verdict/compaction turn). Ollama
+    /// (same image, pull a chat model) and vLLM (a generation runner, no `--runner pooling`) both
+    /// can; michaelfeil/infinity is embeddings/rerank/classify only, so a `[llm.dream.remote]`
+    /// block on `infinity` is a config error (`DreamBackendCannotServeChat`). Embeddings request
+    /// the `embed` capability; dream requests `chat`.
+    pub fn supports_chat(self) -> bool {
+        match self {
+            RemoteBackend::Ollama | RemoteBackend::Vllm => true,
+            RemoteBackend::Infinity => false,
+        }
+    }
+
+    /// The HTTP path (appended to the endpoint) of this backend's chat-completions route. Uniform
+    /// across chat-capable backends — ollama and vLLM both expose the OpenAI-standard
+    /// `/v1/chat/completions`; only the SERVING differs (see `supports_chat`), not the route.
+    pub fn chat_path(self) -> &'static str {
+        "/v1/chat/completions"
     }
 
     /// How long the ephemeral cookbook may take to provision + serve a box for this backend before
@@ -636,6 +634,82 @@ impl RemoteEmbeddingConfig {
     }
 
     /// EPHEMERAL mode: provision an on-demand box via `cookbook` for the bulk reconcile.
+    pub fn is_ephemeral(&self) -> bool {
+        self.cookbook.is_some()
+    }
+}
+
+/// Remote-serving config for the dream model pass (`[llm.dream.remote]`). The CHAT-flavored mirror
+/// of [`RemoteEmbeddingConfig`]: it hands the verdict/compaction turn to an OpenAI-compatible chat
+/// server (`POST /v1/chat/completions` on ollama/vLLM) instead of running a model in-process.
+///
+/// Chat is one-turn and budget-capped, so this carries NONE of the embedding block's batching knobs
+/// (`query_endpoint`, `num_ctx`, `batch_size`, `concurrency`, `max_batch_chars`) — only the serving
+/// selector plus a request timeout.
+///
+/// Like embeddings, the mode is INFERRED, not configured — EXACTLY ONE of `endpoint` / `cookbook`
+/// is set:
+/// - `endpoint` present → CONNECT: talk to an already-running chat server at that URL.
+/// - `cookbook` present → EPHEMERAL: the dream command provisions an on-demand box via the cookbook
+///   subprocess, runs the pass against it, then tears it down.
+///
+/// NOT `Serialize`/`Deserialize`: dream config does not round-trip through the index meta (unlike
+/// the embedder, which reconstructs itself from persisted config), matching the old
+/// `DreamModelConfig`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteDreamConfig {
+    /// Which OpenAI-compatible server serves this block (`ollama` | `vllm`). `infinity` is
+    /// embed-only and rejected at parse time (`DreamBackendCannotServeChat`). Omitted → `Ollama`.
+    pub backend: RemoteBackend,
+    /// CONNECT: base URL of an already-running chat server (e.g. `"http://localhost:11434"`);
+    /// `/v1/chat/completions` is appended by the verdict client. Mutually exclusive with
+    /// `cookbook`.
+    pub endpoint: Option<String>,
+    /// EPHEMERAL: the cookbook recipe rag-rat spawns to provision an on-demand box — an npm
+    /// package spec (`"@rag-rat/cookbook modal"`, run via `npx -y`) or a recipe file path.
+    /// Mutually exclusive with `endpoint`.
+    pub cookbook: Option<String>,
+    /// The SERVER-side chat model sent in the request body — the server's own identifier, NOT a
+    /// rag-rat registry alias. For `backend = "ollama"` the ollama model name (e.g. `"qwen3:8b"`);
+    /// for vLLM the HuggingFace id the server was launched with (e.g. `"Qwen/Qwen3-4B-Instruct"`).
+    pub model: String,
+    /// EPHEMERAL-only: the GPU the cookbook recipe should provision. PROVIDER-specific and
+    /// validated by the provider at provision time, not here. Set together with a connect
+    /// `endpoint` it is a config error (`DreamRemoteGpuRequiresCookbook`).
+    pub gpu: Option<String>,
+    /// Name of the environment variable holding the bearer token, if the server needs auth. Local
+    /// Ollama needs none, so this is optional; the verdict client reads the var once at
+    /// construction.
+    pub auth_env: Option<String>,
+    /// Per-request HTTP timeout, in seconds. A dense evidence pack against a remote model can take
+    /// a while, so the default is generous.
+    pub request_timeout_s: u64,
+}
+
+impl Default for RemoteDreamConfig {
+    /// A local-Ollama CONNECT — byte-for-byte the pre-migration `[dream.model]` default, so an
+    /// absent `[llm.dream.remote]` block preserves today's behavior.
+    fn default() -> Self {
+        Self {
+            backend: RemoteBackend::Ollama,
+            endpoint: Some("http://localhost:11434".to_string()),
+            cookbook: None,
+            model: "qwen3:4b-instruct".to_string(),
+            gpu: None,
+            auth_env: None,
+            request_timeout_s: 300,
+        }
+    }
+}
+
+impl RemoteDreamConfig {
+    /// CONNECT mode: an already-running server at `endpoint`. Exactly one of connect/ephemeral
+    /// holds (config validation guarantees it), so `is_connect() == !is_ephemeral()`.
+    pub fn is_connect(&self) -> bool {
+        self.endpoint.is_some()
+    }
+
+    /// EPHEMERAL mode: provision an on-demand box via `cookbook` for the dream pass.
     pub fn is_ephemeral(&self) -> bool {
         self.cookbook.is_some()
     }
@@ -926,11 +1000,19 @@ impl Config {
         {
             remote.cookbook = Some(resolved);
         }
+        // Same relative-cookbook resolution for the dream remote — its recipe is handed to
+        // `node`/`npx` too, so a relative path must resolve against the config dir, not the process
+        // CWD. `remote` is not optional for dream (a local-Ollama connect default), so only the
+        // ephemeral case has a cookbook to rewrite.
+        if let Some(cookbook) = llm.dream.remote.cookbook.as_ref()
+            && let Some(resolved) = resolve_relative_cookbook_path(cookbook, &config_dir)
+        {
+            llm.dream.remote.cookbook = Some(resolved);
+        }
         let watch = raw.watch.into();
         let version_check = raw.version_check.into();
         let oracle = raw.oracle.into();
         let search = raw.search.into();
-        let dream = raw.dream.into();
         let memory = MemoryConfig::try_from(raw.memory)?;
         let mut log = LogConfig::try_from(raw.log)?;
         // Finalize `dir`: empty (unset) → sibling of the db (`<db_parent>/logs`); a set value is
@@ -952,7 +1034,6 @@ impl Config {
             version_check,
             oracle,
             search,
-            dream,
             memory,
             log,
             repo_id_override,
@@ -1283,8 +1364,6 @@ struct RawConfig {
     #[serde(default)]
     search: RawSearch,
     #[serde(default)]
-    dream: RawDream,
-    #[serde(default)]
     memory: RawMemory,
     #[serde(default)]
     target_bindings: BTreeMap<String, Vec<String>>,
@@ -1400,26 +1479,6 @@ impl From<RawSearch> for SearchConfig {
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq)]
-struct RawDream {
-    #[serde(default)]
-    model: RawDreamModel,
-}
-
-#[derive(Debug, Default, Deserialize, PartialEq)]
-struct RawDreamModel {
-    enabled: Option<bool>,
-    endpoint: Option<String>,
-    model: Option<String>,
-    request_timeout_s: Option<u64>,
-}
-
-impl From<RawDream> for DreamConfig {
-    fn from(raw: RawDream) -> Self {
-        Self { model: raw.model.into() }
-    }
-}
-
-#[derive(Debug, Default, Deserialize, PartialEq)]
 struct RawMemory {
     surface: Option<String>,
 }
@@ -1433,28 +1492,6 @@ impl TryFrom<RawMemory> for MemoryConfig {
             None => MemorySurface::default(),
         };
         Ok(Self { surface })
-    }
-}
-
-impl From<RawDreamModel> for DreamModelConfig {
-    fn from(raw: RawDreamModel) -> Self {
-        let d = DreamModelConfig::default();
-        // Trim + drop empty so a blank `endpoint = ""` / `model = ""` falls back to the default
-        // instead of producing an unusable URL/model name.
-        Self {
-            enabled: raw.enabled.unwrap_or(d.enabled),
-            endpoint: raw
-                .endpoint
-                .map(|e| e.trim().to_string())
-                .filter(|e| !e.is_empty())
-                .unwrap_or(d.endpoint),
-            model: raw
-                .model
-                .map(|m| m.trim().to_string())
-                .filter(|m| !m.is_empty())
-                .unwrap_or(d.model),
-            request_timeout_s: raw.request_timeout_s.unwrap_or(d.request_timeout_s),
-        }
     }
 }
 
@@ -1473,13 +1510,123 @@ struct RawIndex {
 struct RawLlm {
     #[serde(default)]
     embedding: RawEmbedding,
+    #[serde(default)]
+    dream: RawDreamLlm,
 }
 
 impl TryFrom<RawLlm> for LlmConfig {
     type Error = ConfigError;
 
     fn try_from(raw: RawLlm) -> Result<Self, Self::Error> {
-        Ok(Self { embedding: EmbeddingConfig::try_from(raw.embedding)? })
+        Ok(Self {
+            embedding: EmbeddingConfig::try_from(raw.embedding)?,
+            dream: DreamLlmConfig::try_from(raw.dream)?,
+        })
+    }
+}
+
+#[derive(Debug, Default, Deserialize, PartialEq)]
+struct RawDreamLlm {
+    enabled: Option<bool>,
+    /// `[llm.dream.remote]` — absent → [`RemoteDreamConfig::default`] (a local-Ollama connect).
+    /// Unlike embeddings there is no in-process fallback, so a missing block still yields a
+    /// serving config rather than `None`.
+    remote: Option<RawRemoteDream>,
+}
+
+impl TryFrom<RawDreamLlm> for DreamLlmConfig {
+    type Error = ConfigError;
+
+    fn try_from(raw: RawDreamLlm) -> Result<Self, Self::Error> {
+        let remote = match raw.remote {
+            Some(remote) => RemoteDreamConfig::try_from(remote)?,
+            None => RemoteDreamConfig::default(),
+        };
+        Ok(Self { enabled: raw.enabled.unwrap_or_default(), remote })
+    }
+}
+
+#[derive(Debug, Default, Deserialize, PartialEq)]
+struct RawRemoteDream {
+    backend: Option<String>,
+    endpoint: Option<String>,
+    cookbook: Option<String>,
+    model: Option<String>,
+    gpu: Option<String>,
+    auth_env: Option<String>,
+    request_timeout_s: Option<u64>,
+}
+
+impl TryFrom<RawRemoteDream> for RemoteDreamConfig {
+    type Error = ConfigError;
+
+    fn try_from(raw: RawRemoteDream) -> Result<Self, Self::Error> {
+        let default = RemoteDreamConfig::default();
+        let trimmed = |s: Option<String>| s.map(|v| v.trim().to_string()).filter(|v| !v.is_empty());
+        // The SERVER-side chat model name — required, non-empty. For ollama the ollama model name;
+        // for vLLM the HF id the server was launched with.
+        let model = raw.model.unwrap_or_default();
+        let model = model.trim();
+        if model.is_empty() {
+            return Err(ConfigError::DreamRemoteMissingModel);
+        }
+        // Which OpenAI-compatible server serves this block. Omitted → `ollama`.
+        let backend = match trimmed(raw.backend) {
+            None => RemoteBackend::default(),
+            Some(raw_backend) => RemoteBackend::from_db_str(&raw_backend)
+                .ok_or(ConfigError::RemoteBackendUnknown(raw_backend))?,
+        };
+        // Dream requests the CHAT capability; `infinity` is embed-only. Reject it at parse time so
+        // a misrouted backend never reaches the verdict client.
+        if !backend.supports_chat() {
+            return Err(ConfigError::DreamBackendCannotServeChat(backend.as_db_str().to_string()));
+        }
+        // The MODE is INFERRED from which URL field is set (mirrors embeddings): EXACTLY ONE of
+        // `endpoint` (connect) / `cookbook` (ephemeral). Both → ambiguous; neither → no server.
+        let endpoint = trimmed(raw.endpoint);
+        let cookbook = trimmed(raw.cookbook);
+        match (endpoint.is_some(), cookbook.is_some()) {
+            (true, true) | (false, false) => {
+                return Err(ConfigError::DreamRemoteModeAmbiguous);
+            },
+            _ => {},
+        }
+        // SECRET HYGIENE: reject a `user:pass@host` endpoint and direct the user to `auth_env`
+        // instead. Checked against the URL authority only, so an `@` in a path/query is fine.
+        // `cookbook` is a recipe spec, not a URL, so it is not checked.
+        if let Some(url) = endpoint.as_deref()
+            && endpoint_authority_has_userinfo(url)
+        {
+            return Err(ConfigError::DreamRemoteEndpointHasCredentials);
+        }
+        // EPHEMERAL-only: the GPU to provision. A PRESENT-but-empty value is a config error
+        // (clearer than silently dropping a meant-to-be-set key). Set with a connect
+        // `endpoint` it is meaningless → rejected. The VALUE is provider-specific and
+        // validated at provision time.
+        let gpu = match raw.gpu {
+            Some(g) => {
+                let g = g.trim();
+                if g.is_empty() {
+                    return Err(ConfigError::RemoteGpuEmpty);
+                }
+                if endpoint.is_some() {
+                    return Err(ConfigError::DreamRemoteGpuRequiresCookbook);
+                }
+                Some(g.to_string())
+            },
+            None => None,
+        };
+        // Optional — local Ollama needs no auth; trim if present.
+        let auth_env = trimmed(raw.auth_env);
+        Ok(Self {
+            backend,
+            endpoint,
+            cookbook,
+            model: model.to_string(),
+            gpu,
+            auth_env,
+            request_timeout_s: raw.request_timeout_s.unwrap_or(default.request_timeout_s),
+        })
     }
 }
 
@@ -1802,6 +1949,33 @@ pub enum ConfigError {
          `jinaai/jina-embeddings-v2-base-code`)"
     )]
     RemoteEmbeddingNonTransformerModel(String),
+    #[error(
+        "[llm.dream.remote] requires a non-empty `model` (the server-side chat model name — an \
+         ollama model like `qwen3:8b`, or the HuggingFace id vLLM was launched with, e.g. \
+         `Qwen/Qwen3-4B-Instruct-2507`)"
+    )]
+    DreamRemoteMissingModel,
+    #[error(
+        "[llm.dream.remote] `backend = \"{0}\"` cannot serve chat completions — dream needs a \
+         chat-capable backend (`ollama` or `vllm`); `infinity` is embed-only. Switch the backend, \
+         or point the dream model at an ollama/vLLM server"
+    )]
+    DreamBackendCannotServeChat(String),
+    #[error(
+        "[llm.dream.remote] requires EXACTLY ONE of `endpoint` (connect to a running chat server) \
+         or `cookbook` (provision an ephemeral box) — set neither both nor zero"
+    )]
+    DreamRemoteModeAmbiguous,
+    #[error(
+        "[llm.dream.remote] `endpoint` must not embed credentials in the URL (no \
+         `user:pass@host`) — put any token in an env var and name it via `auth_env` instead"
+    )]
+    DreamRemoteEndpointHasCredentials,
+    #[error(
+        "[llm.dream.remote] `gpu` applies only to ephemeral `cookbook` provisioning, not a \
+         connect `endpoint` — remove `gpu`, or switch the remote block to a `cookbook` recipe"
+    )]
+    DreamRemoteGpuRequiresCookbook,
     #[error(
         "the `[local_ai]` table was renamed to `[llm]` (#317). Update your rag-rat.toml: rename \
          `[local_ai.embedding]` → `[llm.embedding]` (and any `[local_ai.embedding.remote]` / \
@@ -3605,40 +3779,282 @@ mod tests {
     }
 
     #[test]
-    fn dream_model_defaults_off_and_parses_overrides() {
-        let default: DreamModelConfig = RawDreamModel::default().into();
-        assert!(!default.enabled, "the model verdict pass is OFF by default");
-        assert_eq!(default.endpoint, "http://localhost:11434");
-        assert_eq!(default.model, "qwen3:4b-instruct");
-        assert_eq!(default.request_timeout_s, 300);
-
+    fn dream_absent_defaults_to_off_and_local_ollama_connect() {
+        // No `[llm.dream]` at all → disabled, with a local-Ollama CONNECT serving default
+        // (byte-for-byte the pre-migration `[dream.model]` default).
         let raw: RawConfig = toml::from_str(
             r#"
             [index]
             root = "."
 
-            [dream.model]
+            [llm.embedding]
+            model = "sentence-transformers/all-MiniLM-L6-v2"
+            "#,
+        )
+        .unwrap();
+        let dream = LlmConfig::try_from(raw.llm).unwrap().dream;
+        assert!(!dream.enabled, "the model pass is OFF by default");
+        assert_eq!(dream.remote, RemoteDreamConfig::default());
+        assert_eq!(dream.remote.backend, RemoteBackend::Ollama);
+        assert_eq!(dream.remote.endpoint.as_deref(), Some("http://localhost:11434"));
+        assert_eq!(dream.remote.model, "qwen3:4b-instruct");
+        assert_eq!(dream.remote.request_timeout_s, 300);
+        assert!(dream.remote.is_connect() && !dream.remote.is_ephemeral());
+    }
+
+    #[test]
+    fn dream_enabled_flag_without_remote_block_keeps_default_serving() {
+        // `[llm.dream] enabled = true` with no `[llm.dream.remote]` still resolves to the default
+        // (a local-Ollama connect) — dream has no in-process backend, so `remote` is never `None`.
+        let raw: RawConfig = toml::from_str(
+            r#"
+            [index]
+            root = "."
+
+            [llm.dream]
             enabled = true
+            "#,
+        )
+        .unwrap();
+        let dream = LlmConfig::try_from(raw.llm).unwrap().dream;
+        assert!(dream.enabled, "[llm.dream] enabled = true opts in");
+        assert_eq!(dream.remote, RemoteDreamConfig::default());
+    }
+
+    #[test]
+    fn dream_remote_connect_happy_path_applies_defaults() {
+        // CONNECT is inferred from `endpoint` being set.
+        let raw: RawConfig = toml::from_str(
+            r#"
+            [index]
+            root = "."
+
+            [llm.dream]
+            enabled = true
+
+            [llm.dream.remote]
+            backend = "ollama"
             endpoint = "http://ollama.local:11434"
-            model = "qwen3-8b-instruct"
+            model = "qwen3:8b"
+            auth_env = "OLLAMA_TOKEN"
             request_timeout_s = 60
             "#,
         )
         .unwrap();
-        let dream: DreamConfig = raw.dream.into();
-        assert!(dream.model.enabled, "[dream.model] enabled = true opts in");
-        assert_eq!(dream.model.endpoint, "http://ollama.local:11434");
-        assert_eq!(dream.model.model, "qwen3-8b-instruct");
-        assert_eq!(dream.model.request_timeout_s, 60);
+        let dream = LlmConfig::try_from(raw.llm).unwrap().dream;
+        assert!(dream.enabled);
+        assert_eq!(dream.remote, RemoteDreamConfig {
+            backend: RemoteBackend::Ollama,
+            endpoint: Some("http://ollama.local:11434".to_string()),
+            cookbook: None,
+            model: "qwen3:8b".to_string(),
+            gpu: None,
+            auth_env: Some("OLLAMA_TOKEN".to_string()),
+            request_timeout_s: 60,
+        });
+        assert!(dream.remote.is_connect() && !dream.remote.is_ephemeral());
+    }
 
-        // A blank endpoint/model falls back to the default rather than producing an unusable value.
-        let blank: RawConfig = toml::from_str(
-            "[index]\nroot = \".\"\n\n[dream.model]\nendpoint = \"\"\nmodel = \"  \"\n",
+    #[test]
+    fn dream_remote_ephemeral_infers_mode_and_parses_gpu() {
+        // EPHEMERAL is inferred from `cookbook` being set; a vLLM backend serves chat, and `gpu` is
+        // trimmed (not validated here). No `query_endpoint`/batching knobs exist for dream.
+        let raw: RawConfig = toml::from_str(
+            r#"
+            [index]
+            root = "."
+
+            [llm.dream]
+            enabled = true
+
+            [llm.dream.remote]
+            backend = "vllm"
+            cookbook = "@rag-rat/cookbook modal"
+            gpu = "  A10G  "
+            model = "Qwen/Qwen3-4B-Instruct-2507"
+            request_timeout_s = 900
+            "#,
         )
         .unwrap();
-        let blank: DreamConfig = blank.dream.into();
-        assert_eq!(blank.model.endpoint, "http://localhost:11434", "blank endpoint → default");
-        assert_eq!(blank.model.model, "qwen3:4b-instruct", "blank model → default");
+        let remote = LlmConfig::try_from(raw.llm).unwrap().dream.remote;
+        assert!(remote.is_ephemeral() && !remote.is_connect());
+        assert_eq!(remote.backend, RemoteBackend::Vllm);
+        assert_eq!(remote.cookbook.as_deref(), Some("@rag-rat/cookbook modal"));
+        assert_eq!(remote.gpu.as_deref(), Some("A10G"), "gpu is trimmed");
+        assert_eq!(remote.model, "Qwen/Qwen3-4B-Instruct-2507");
+        assert_eq!(remote.request_timeout_s, 900);
+    }
+
+    #[test]
+    fn dream_remote_requires_a_non_empty_model() {
+        for model_line in ["", "model = \"  \""] {
+            let raw: RawConfig = toml::from_str(&format!(
+                r#"
+                [index]
+                root = "."
+
+                [llm.dream.remote]
+                endpoint = "http://localhost:11434"
+                {model_line}
+                "#,
+            ))
+            .unwrap();
+            let err = LlmConfig::try_from(raw.llm).unwrap_err();
+            assert!(
+                matches!(err, ConfigError::DreamRemoteMissingModel),
+                "model={model_line:?} → DreamRemoteMissingModel, got {err:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn dream_remote_infinity_backend_cannot_serve_chat() {
+        // `infinity` is embed-only; a dream remote on it is rejected at parse time.
+        let raw: RawConfig = toml::from_str(
+            r#"
+            [index]
+            root = "."
+
+            [llm.dream.remote]
+            backend = "infinity"
+            endpoint = "http://localhost:7997"
+            model = "some-model"
+            "#,
+        )
+        .unwrap();
+        let err = LlmConfig::try_from(raw.llm).unwrap_err();
+        assert!(
+            matches!(&err, ConfigError::DreamBackendCannotServeChat(b) if b.as_str() == "infinity"),
+            "infinity → DreamBackendCannotServeChat, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn dream_remote_requires_exactly_one_of_endpoint_or_cookbook() {
+        // Neither → no server to reach; both → ambiguous mode. Both reject with the exactly-one
+        // rule.
+        let neither = r#"
+            [index]
+            root = "."
+
+            [llm.dream.remote]
+            model = "qwen3:8b"
+            "#;
+        let both = r#"
+            [index]
+            root = "."
+
+            [llm.dream.remote]
+            model = "qwen3:8b"
+            endpoint = "http://localhost:11434"
+            cookbook = "@rag-rat/cookbook modal"
+            "#;
+        for (label, toml_str) in [("neither", neither), ("both", both)] {
+            let raw: RawConfig = toml::from_str(toml_str).unwrap();
+            let err = LlmConfig::try_from(raw.llm).unwrap_err();
+            assert!(
+                matches!(err, ConfigError::DreamRemoteModeAmbiguous),
+                "{label} endpoint/cookbook → DreamRemoteModeAmbiguous, got {err:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn dream_remote_gpu_with_connect_endpoint_is_rejected() {
+        // `gpu` only applies to ephemeral `cookbook` provisioning. Set alongside a connect
+        // `endpoint` it is meaningless → rejected.
+        let raw: RawConfig = toml::from_str(
+            r#"
+            [index]
+            root = "."
+
+            [llm.dream.remote]
+            endpoint = "http://localhost:11434"
+            model = "qwen3:8b"
+            gpu = "A10G"
+            "#,
+        )
+        .unwrap();
+        let err = LlmConfig::try_from(raw.llm).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::DreamRemoteGpuRequiresCookbook),
+            "gpu + endpoint → DreamRemoteGpuRequiresCookbook, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn dream_remote_empty_gpu_is_rejected() {
+        for value in ["\"\"", "\"   \""] {
+            let raw: RawConfig = toml::from_str(&format!(
+                r#"
+                [index]
+                root = "."
+
+                [llm.dream.remote]
+                backend = "vllm"
+                cookbook = "@rag-rat/cookbook modal"
+                model = "Qwen/Qwen3-4B-Instruct-2507"
+                gpu = {value}
+                "#,
+            ))
+            .unwrap();
+            let err = LlmConfig::try_from(raw.llm).unwrap_err();
+            assert!(
+                matches!(err, ConfigError::RemoteGpuEmpty),
+                "gpu={value} → RemoteGpuEmpty, got {err:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn dream_remote_endpoint_with_credentials_is_rejected() {
+        let raw: RawConfig = toml::from_str(
+            r#"
+            [index]
+            root = "."
+
+            [llm.dream.remote]
+            endpoint = "https://user:token@host:11434"
+            model = "qwen3:8b"
+            "#,
+        )
+        .unwrap();
+        let err = LlmConfig::try_from(raw.llm).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::DreamRemoteEndpointHasCredentials),
+            "endpoint with userinfo → DreamRemoteEndpointHasCredentials, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn dream_remote_unknown_backend_is_rejected() {
+        let raw: RawConfig = toml::from_str(
+            r#"
+            [index]
+            root = "."
+
+            [llm.dream.remote]
+            backend = "tgi"
+            endpoint = "http://localhost:11434"
+            model = "qwen3:8b"
+            "#,
+        )
+        .unwrap();
+        let err = LlmConfig::try_from(raw.llm).unwrap_err();
+        assert!(
+            matches!(&err, ConfigError::RemoteBackendUnknown(b) if b.as_str() == "tgi"),
+            "unknown backend → RemoteBackendUnknown, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn remote_backend_chat_capability_and_path() {
+        assert!(RemoteBackend::Ollama.supports_chat());
+        assert!(RemoteBackend::Vllm.supports_chat());
+        assert!(!RemoteBackend::Infinity.supports_chat(), "infinity is embed-only");
+        // The chat route is uniform across chat-capable backends; only serving differs.
+        assert_eq!(RemoteBackend::Ollama.chat_path(), "/v1/chat/completions");
+        assert_eq!(RemoteBackend::Vllm.chat_path(), "/v1/chat/completions");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -867,10 +867,17 @@ impl Config {
         // file's contents are irrelevant by design — a parse/validation failure there must fold
         // into the divergence warning, never block every command from the linked checkout (Codex
         // batch 8, finding 2). Wherever the local config GOVERNS, the error is fatal as always.
-        // The `[local_ai]` rejection (#317) is part of local validity — see `RawConfig::local_ai`.
+        // The `[local_ai]` / `[dream]` rejections are part of local validity — see the
+        // `RawConfig` presence-capture fields.
         let local_parse: Result<RawConfig, ConfigError> =
             toml::from_str::<RawConfig>(&text).map_err(ConfigError::from).and_then(|raw| {
-                if raw.local_ai.is_some() { Err(ConfigError::LocalAiTableRenamed) } else { Ok(raw) }
+                if raw.local_ai.is_some() {
+                    Err(ConfigError::LocalAiTableRenamed)
+                } else if raw.dream.is_some() {
+                    Err(ConfigError::DreamTableMoved)
+                } else {
+                    Ok(raw)
+                }
             });
         let local_config_dir = path.parent().unwrap_or_else(|| Path::new("."));
         // The topology subject must be a discoverable directory: a RELATIVE config path like
@@ -1059,6 +1066,9 @@ fn governing_main_config(main_top: &Path) -> Result<Option<(RawConfig, PathBuf)>
     let raw: RawConfig = toml::from_str(&text)?;
     if raw.local_ai.is_some() {
         return Err(ConfigError::LocalAiTableRenamed);
+    }
+    if raw.dream.is_some() {
+        return Err(ConfigError::DreamTableMoved);
     }
     Ok(Some((raw, main_top)))
 }
@@ -1353,6 +1363,13 @@ struct RawConfig {
     /// misconfiguring silently.
     #[serde(default)]
     local_ai: Option<toml::Value>,
+    /// Presence-capture for the OLD top-level `[dream]` table (the dream model config moved to
+    /// `[llm.dream]` / `[llm.dream.remote]`). Serde would otherwise SILENTLY DROP it, so an
+    /// upgrade from `[dream.model] enabled = true` would load `[llm.dream] enabled = false`
+    /// and run the deterministic passes only, never the model. Captured so `load` rejects it
+    /// loudly with a migration instruction instead of silently downgrading.
+    #[serde(default)]
+    dream: Option<toml::Value>,
     #[serde(default)]
     watch: RawWatch,
     #[serde(default)]
@@ -1982,6 +1999,13 @@ pub enum ConfigError {
          `[local_ai.embedding.runtime]` → `[llm.embedding.remote]` / `[llm.embedding.runtime]`)"
     )]
     LocalAiTableRenamed,
+    #[error(
+        "the dream model config moved from `[dream.model]` to `[llm.dream]` / \
+         `[llm.dream.remote]`. Update your rag-rat.toml: rename `[dream.model] enabled = true` → \
+         `[llm.dream] enabled = true`, and put the server config (endpoint/model, or a \
+         cookbook/backend/gpu for a remote GPU) under `[llm.dream.remote]`"
+    )]
+    DreamTableMoved,
     #[error("duplicate target name `{0}`")]
     DuplicateTarget(String),
     #[error("configured directory does not exist: {0}")]
@@ -3700,6 +3724,27 @@ mod tests {
         assert!(
             matches!(err, ConfigError::LocalAiTableRenamed),
             "[local_ai] table → LocalAiTableRenamed, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn the_legacy_dream_table_is_rejected_with_a_migration_message() {
+        // The dream model config moved from [dream.model] → [llm.dream]. An old config's top-level
+        // [dream] table must error LOUDLY: serde would otherwise silently DROP it, so an upgrade
+        // from `[dream.model] enabled = true` would run the deterministic passes only (never the
+        // model). Fires in Config::load before any directory resolution.
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let tmp = std::env::temp_dir().join(format!("ragrat-dream-{}-{id}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::fs::write(
+            tmp.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\n[dream.model]\nenabled = true\n",
+        )
+        .unwrap();
+        let err = Config::load(tmp.join("rag-rat.toml")).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::DreamTableMoved),
+            "[dream] table → DreamTableMoved, got {err:?}",
         );
     }
 

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -253,7 +253,7 @@ pub struct LlmConfig {
 ///
 /// Unlike embeddings, `remote` is NOT optional: dream has no in-process backend, so an absent
 /// `[llm.dream.remote]` block still resolves to a serving config — [`RemoteDreamConfig::default`],
-/// a connect to a local Ollama (today's `[dream.model]` default).
+/// a connect to a local Ollama (today's `[llm.dream.remote]` default).
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct DreamLlmConfig {
     /// Run the model pass at all (default false — opt in explicitly). When false, `rag-rat dream

--- a/crates/rag-rat-core/src/dream/compact.rs
+++ b/crates/rag-rat-core/src/dream/compact.rs
@@ -128,6 +128,13 @@ fn compaction_queue(conn: &Connection, budget: usize) -> rusqlite::Result<Vec<Co
     Ok(queue)
 }
 
+/// Whether the compaction queue has ANY pending memory (budget-capped) — the compaction half of the
+/// ephemeral zero-work guard ([`super::model_work_pending`]). Cheap: the same churn-skip query the
+/// pass runs, short-circuited to emptiness so a fully-summarized repo never cold-starts a paid box.
+pub(super) fn compaction_pending(conn: &Connection, budget: usize) -> rusqlite::Result<bool> {
+    Ok(!compaction_queue(conn, budget)?.is_empty())
+}
+
 /// Ask the model once, strip any think block, and run the deterministic acceptance guards. On a
 /// guard failure RETRY ONCE (same prompt); a second failure returns `Ok(None)` — store nothing (the
 /// title-only fallback). A model call error also yields `None` (this memory is skipped, re-queued
@@ -156,7 +163,7 @@ fn obtain_summary(
 }
 
 /// Drop a leading `<think>…</think>` reasoning block a thinking model may prepend (the default
-/// `qwen3:4b-instruct` does not think, but an operator may point `[dream.model]` at one that
+/// `qwen3:4b-instruct` does not think, but an operator may point `[llm.dream.remote]` at one that
 /// does), then trim — mirrors the eval harness's `strip_think`. Everything after the LAST
 /// `</think>` is the summary.
 fn strip_think(raw: &str) -> &str {

--- a/crates/rag-rat-core/src/dream/mod.rs
+++ b/crates/rag-rat-core/src/dream/mod.rs
@@ -196,21 +196,31 @@ pub fn dream_run_with_passes(
     Ok(dream_run(conn, opts)?)
 }
 
-/// Whether the model passes would have ANY work this run — the zero-work guard for EPHEMERAL
-/// `[llm.dream.remote]`. `verify` peeks the verification queue, `compact` the compaction queue
-/// (both budget-capped exactly as the passes consume them); either non-empty → `true`. A fully
-/// churn-skipped repo returns `false`, so `rag-rat dream --verify/--compact` never cold-starts a
-/// paid GPU box with nothing to check — mirroring the embedding path's "never provision for zero
-/// work" rule. Reads only the churn-skip queues; never touches the model.
+/// Whether the model passes would call the model AT ALL this run — the zero-work guard for
+/// EPHEMERAL `[llm.dream.remote]`. A fully churn-skipped (or all-uncitable) repo returns `false`,
+/// so `rag-rat dream --verify/--compact` never cold-starts a paid GPU box that would then do zero
+/// inference — mirroring the embedding path's "never provision for zero work" rule.
+///
+/// `verify` is CITABILITY-aware, not just queue-emptiness: `run_verdict_pass` records an UNCITABLE
+/// entry (prose-only / all-`NOT FOUND`, no excerpts) as a terminal row WITHOUT calling the model,
+/// so a queue whose every entry is uncitable is zero model work. The guard therefore builds each
+/// queued entry's evidence pack and returns `true` on the FIRST citable one — matching exactly what
+/// reaches the model. `compact` has no uncitable short-circuit (every queued memory is summarized),
+/// so a non-empty compaction queue IS model work. Runs once before provisioning, budget-capped, and
+/// short-circuits — the paid box it gates makes the extra pack builds worth it.
 pub fn model_work_pending(
     conn: &Connection,
     opts: DreamOptions,
     budget: usize,
     verify: bool,
     compact: bool,
-) -> rusqlite::Result<bool> {
-    if verify && !verify::verification_queue(conn, opts.now_ms, budget)?.is_empty() {
-        return Ok(true);
+) -> anyhow::Result<bool> {
+    if verify {
+        for entry in verify::verification_queue(conn, opts.now_ms, budget)? {
+            if verify::evidence_pack(conn, &entry.memory_id)?.is_citable() {
+                return Ok(true);
+            }
+        }
     }
     if compact && compact::compaction_pending(conn, budget)? {
         return Ok(true);

--- a/crates/rag-rat-core/src/dream/mod.rs
+++ b/crates/rag-rat-core/src/dream/mod.rs
@@ -41,9 +41,9 @@ pub use compact::CompactPass;
 // `repo_id`.
 pub(crate) use findings::rederive_finding_ids;
 // The phase-B model verdict pass: the out-of-process verdict-model trait + its HTTP client
-// (the CLI builds one from `[dream.model]`) and the `VerdictPass` handle
+// (the CLI builds one from `[llm.dream.remote]`) and the `VerdictPass` handle
 // `dream_run_with_passes` consumes.
-pub use model::{HttpVerdictModel, VerdictModel};
+pub use model::{HttpVerdictModel, VerdictModel, provision_verdict_model};
 use rusqlite::Connection;
 use serde::Serialize;
 pub(crate) use verdict::PROMPT_VERSION as VERDICT_PROMPT_VERSION;
@@ -164,7 +164,7 @@ pub fn dream_run(conn: &Connection, opts: DreamOptions) -> rusqlite::Result<Drea
 
 /// [`dream_run`] plus the phase-B model verdict pass and the phase-C model compaction pass. Both
 /// model passes run BEFORE the deterministic finding computation (the CLI builds each only when
-/// `[dream.model] enabled = true`):
+/// `[llm.dream] enabled = true`):
 ///   - the VERDICT pass (gated on `verify` + a supplied [`VerdictPass`]) checks the budget-capped
 ///     churn-skip queue and writes accepted verdicts into `memory_reality`, which [`dream_run`]
 ///     then reads to derive `memory_divergence` findings (so a fresh `diverged` verdict opens a
@@ -194,6 +194,28 @@ pub fn dream_run_with_passes(
         compact::run_compact_pass(conn, pass, opts.now_ms)?;
     }
     Ok(dream_run(conn, opts)?)
+}
+
+/// Whether the model passes would have ANY work this run — the zero-work guard for EPHEMERAL
+/// `[llm.dream.remote]`. `verify` peeks the verification queue, `compact` the compaction queue
+/// (both budget-capped exactly as the passes consume them); either non-empty → `true`. A fully
+/// churn-skipped repo returns `false`, so `rag-rat dream --verify/--compact` never cold-starts a
+/// paid GPU box with nothing to check — mirroring the embedding path's "never provision for zero
+/// work" rule. Reads only the churn-skip queues; never touches the model.
+pub fn model_work_pending(
+    conn: &Connection,
+    opts: DreamOptions,
+    budget: usize,
+    verify: bool,
+    compact: bool,
+) -> rusqlite::Result<bool> {
+    if verify && !verify::verification_queue(conn, opts.now_ms, budget)?.is_empty() {
+        return Ok(true);
+    }
+    if compact && compact::compaction_pending(conn, budget)? {
+        return Ok(true);
+    }
+    Ok(false)
 }
 
 #[cfg(test)]

--- a/crates/rag-rat-core/src/dream/model.rs
+++ b/crates/rag-rat-core/src/dream/model.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
-use crate::config::DreamModelConfig;
+use crate::config::RemoteDreamConfig;
 
 /// A single-turn verdict model: given a fully-rendered prompt, return the model's raw completion
 /// text. Object-safe so the verdict pass takes a `&dyn VerdictModel` and a test can swap in a mock.
@@ -74,16 +74,24 @@ pub struct HttpVerdictModel {
     agent: ureq::Agent,
     /// `<endpoint>/v1/chat/completions`, precomputed once at construction.
     chat_url: String,
-    /// The server-side model name sent in the request body (`[dream.model] model`).
+    /// The server-side model name sent in the request body (`[llm.dream.remote] model`).
     model: String,
 }
 
 impl HttpVerdictModel {
-    /// Build the verdict client from `[dream.model]`. The endpoint is trimmed and the chat route is
-    /// appended; loopback endpoints bypass the ambient HTTP proxy (a local Ollama routed through a
-    /// corporate proxy 403s), matching the embedder client.
-    pub fn from_config(cfg: &DreamModelConfig) -> Self {
-        let endpoint = cfg.endpoint.trim().trim_end_matches('/');
+    /// Build the verdict client from a CONNECT-mode `[llm.dream.remote]`. The endpoint is trimmed
+    /// and the chat route is appended; loopback endpoints bypass the ambient HTTP proxy (a local
+    /// Ollama routed through a corporate proxy 403s), matching the embedder client. `endpoint` is
+    /// optional on the config, so an absent value falls back to the local-Ollama default (the same
+    /// default `RemoteDreamConfig::default` carries). The ephemeral `from_provisioned` constructor
+    /// that points at a tunnel endpoint lands in a later task.
+    pub fn from_config(cfg: &RemoteDreamConfig) -> Self {
+        let endpoint = cfg
+            .endpoint
+            .as_deref()
+            .unwrap_or("http://localhost:11434")
+            .trim()
+            .trim_end_matches('/');
         let chat_url = format!("{endpoint}/v1/chat/completions");
         let mut builder = ureq::Agent::config_builder()
             .timeout_global(Some(Duration::from_secs(cfg.request_timeout_s)))

--- a/crates/rag-rat-core/src/dream/model.rs
+++ b/crates/rag-rat-core/src/dream/model.rs
@@ -209,28 +209,12 @@ impl VerdictModel for HttpVerdictModel {
 pub fn provision_verdict_model(
     remote: &RemoteDreamConfig,
 ) -> anyhow::Result<(HttpVerdictModel, crate::index::ai::ProvisionedBox)> {
-    use crate::index::ai::{CookbookInput, CookbookProvisioner};
+    use crate::index::ai::CookbookProvisioner;
 
     let cookbook = remote.cookbook.as_deref().ok_or_else(|| {
         anyhow::anyhow!("provision_verdict_model called on a non-ephemeral `[llm.dream.remote]`")
     })?;
-    let input = CookbookInput {
-        model: remote.model.trim().to_string(),
-        backend: remote.backend.as_db_str(),
-        capability: "chat",
-        request_timeout_s: remote.request_timeout_s,
-        // Give the recipe a provisioning budget just under the Rust hard ceiling (backend-aware —
-        // vLLM's large image needs longer), so ITS budget expires first (clean provider teardown)
-        // before the Rust SIGKILL backstop fires. Mirrors the embedding `cookbook_input_for`.
-        provision_timeout_s: remote.backend.provision_timeout().as_secs().saturating_sub(20),
-        gpu: remote.gpu.clone(),
-        // Chat serving ignores these — num_ctx is an ollama-embedding knob, and the
-        // verdict/compaction passes call the model sequentially (one turn per memory), so a
-        // single server slot suffices.
-        num_ctx: None,
-        server_concurrency: 1,
-    };
-    let provisioned = CookbookProvisioner::provision(cookbook, &input)?;
+    let provisioned = CookbookProvisioner::provision(cookbook, &chat_cookbook_input(remote))?;
     let model = HttpVerdictModel::from_provisioned(
         &provisioned.endpoint,
         provisioned.auth_token.as_deref(),
@@ -238,6 +222,26 @@ pub fn provision_verdict_model(
         remote.request_timeout_s,
     );
     Ok((model, provisioned))
+}
+
+/// The `[llm.dream.remote]` → chat [`CookbookInput`] mapping — the pure, unit-testable half of
+/// [`provision_verdict_model`], mirroring the embedding `cookbook_input_for`. `capability` is
+/// pinned `"chat"`; the provisioning budget sits just under the Rust hard ceiling (backend-aware —
+/// vLLM's large image needs longer) so the recipe's own budget expires first (clean provider
+/// teardown) before the Rust SIGKILL backstop fires. Chat serving ignores `num_ctx` (an
+/// ollama-embedding knob) and needs only ONE server slot — the verdict/compaction passes call the
+/// model sequentially.
+fn chat_cookbook_input(remote: &RemoteDreamConfig) -> crate::index::ai::CookbookInput {
+    crate::index::ai::CookbookInput {
+        model: remote.model.trim().to_string(),
+        backend: remote.backend.as_db_str(),
+        capability: "chat",
+        request_timeout_s: remote.request_timeout_s,
+        provision_timeout_s: remote.backend.provision_timeout().as_secs().saturating_sub(20),
+        gpu: remote.gpu.clone(),
+        num_ctx: None,
+        server_concurrency: 1,
+    }
 }
 
 fn response_excerpt(body: &str) -> String {
@@ -333,5 +337,151 @@ pub(super) mod mock {
     fn mock_without_responses_errors() {
         let m = MockVerdictModel::new(Vec::<String>::new());
         assert!(m.complete("p").is_err(), "a mock given no responses errors rather than panicking");
+    }
+}
+
+#[cfg(test)]
+mod http_tests {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    use super::{HttpVerdictModel, VerdictModel, provision_verdict_model};
+    use crate::config::RemoteDreamConfig;
+
+    /// A one-shot HTTP/1.1 server on `127.0.0.1:0`: accepts one connection, reads the full request
+    /// (headers + Content-Length body), replies `status`/`response_body`, and returns the RAW
+    /// captured request so a test can assert the sent body + headers. Base URL + join handle.
+    fn one_shot(
+        status: &'static str,
+        response_body: String,
+    ) -> (String, thread::JoinHandle<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let port = listener.local_addr().unwrap().port();
+        let handle = thread::spawn(move || {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return String::new();
+            };
+            let mut data = Vec::new();
+            let mut buf = [0u8; 2048];
+            loop {
+                let Ok(n) = stream.read(&mut buf) else { break };
+                if n == 0 {
+                    break;
+                }
+                data.extend_from_slice(&buf[..n]);
+                let text = String::from_utf8_lossy(&data);
+                if let Some(hdr_end) = text.find("\r\n\r\n") {
+                    let content_len = text[..hdr_end]
+                        .lines()
+                        .find_map(|l| {
+                            l.to_ascii_lowercase()
+                                .strip_prefix("content-length:")
+                                .and_then(|v| v.trim().parse::<usize>().ok())
+                        })
+                        .unwrap_or(0);
+                    if data.len() >= hdr_end + 4 + content_len {
+                        break;
+                    }
+                }
+            }
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: \
+                 {}\r\nConnection: close\r\n\r\n{response_body}",
+                response_body.len()
+            );
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.flush();
+            String::from_utf8_lossy(&data).into_owned()
+        });
+        (format!("http://127.0.0.1:{port}"), handle)
+    }
+
+    #[test]
+    fn complete_sends_the_chat_body_and_bearer_and_parses_the_content() {
+        let (url, handle) = one_shot(
+            "200 OK",
+            r#"{"choices":[{"message":{"content":"VERDICT: current\nREASON: ok"}}]}"#.to_string(),
+        );
+        let model = HttpVerdictModel::from_provisioned(&url, Some("TOK123"), "Qwen/Qwen3-8B", 10);
+        let out = model.complete("audit this note").unwrap();
+        assert_eq!(out, "VERDICT: current\nREASON: ok");
+
+        let req = handle.join().unwrap();
+        assert!(
+            req.to_ascii_lowercase().contains("authorization: bearer tok123"),
+            "the bearer token is sent: {req}"
+        );
+        assert!(req.contains("/v1/chat/completions"), "chat route: {req}");
+        assert!(req.contains("\"model\":\"Qwen/Qwen3-8B\""), "model in body: {req}");
+        assert!(req.contains("audit this note"), "prompt in body: {req}");
+        assert!(req.contains("\"temperature\":0"), "temperature 0: {req}");
+    }
+
+    #[test]
+    fn complete_surfaces_the_server_error_message_on_non_2xx() {
+        let (url, handle) = one_shot(
+            "500 Internal Server Error",
+            r#"{"error":{"message":"maximum context length exceeded"}}"#.to_string(),
+        );
+        let model = HttpVerdictModel::from_provisioned(&url, None, "m", 10);
+        let err = model.complete("x").unwrap_err().to_string();
+        assert!(err.contains("maximum context length exceeded"), "surfaces server error: {err}");
+        let _ = handle.join();
+    }
+
+    #[test]
+    fn constructors_set_the_model_id() {
+        let cfg = RemoteDreamConfig {
+            model: "qwen3:4b-instruct".to_string(),
+            ..RemoteDreamConfig::default()
+        };
+        assert_eq!(HttpVerdictModel::from_config(&cfg).model_id(), "qwen3:4b-instruct");
+        assert_eq!(
+            HttpVerdictModel::from_provisioned(
+                "https://box.modal.run",
+                Some("t"),
+                "Qwen/Qwen3-8B",
+                900
+            )
+            .model_id(),
+            "Qwen/Qwen3-8B"
+        );
+    }
+
+    #[test]
+    fn provision_verdict_model_rejects_a_non_ephemeral_config() {
+        // The default is a local-Ollama CONNECT (no cookbook) — provisioning must refuse it rather
+        // than attempt to spawn a recipe.
+        let err = provision_verdict_model(&RemoteDreamConfig::default()).unwrap_err().to_string();
+        assert!(err.contains("non-ephemeral"), "{err}");
+    }
+
+    #[test]
+    fn chat_cookbook_input_pins_chat_and_maps_backend_gpu_and_budget() {
+        use crate::config::RemoteBackend;
+        let remote = RemoteDreamConfig {
+            backend: RemoteBackend::Vllm,
+            endpoint: None,
+            cookbook: Some("@rag-rat/cookbook modal".to_string()),
+            model: "Qwen/Qwen3-8B".to_string(),
+            gpu: Some("A10G".to_string()),
+            request_timeout_s: 900,
+            ..RemoteDreamConfig::default()
+        };
+        let input = super::chat_cookbook_input(&remote);
+        assert_eq!(input.capability, "chat", "dream provisions a CHAT box");
+        assert_eq!(input.backend, "vllm");
+        assert_eq!(input.model, "Qwen/Qwen3-8B");
+        assert_eq!(input.gpu.as_deref(), Some("A10G"));
+        assert_eq!(input.num_ctx, None);
+        assert_eq!(input.server_concurrency, 1, "one turn per memory → one server slot");
+        assert_eq!(input.request_timeout_s, 900);
+        // The provisioning budget sits just under the backend's hard ceiling (clean provider
+        // teardown before the Rust SIGKILL backstop).
+        assert_eq!(
+            input.provision_timeout_s,
+            RemoteBackend::Vllm.provision_timeout().as_secs() - 20
+        );
     }
 }

--- a/crates/rag-rat-core/src/dream/model.rs
+++ b/crates/rag-rat-core/src/dream/model.rs
@@ -76,6 +76,10 @@ pub struct HttpVerdictModel {
     chat_url: String,
     /// The server-side model name sent in the request body (`[llm.dream.remote] model`).
     model: String,
+    /// Bearer token sent as `Authorization: Bearer <token>` when present — the value of the
+    /// `[llm.dream.remote] auth_env` variable (connect mode) or the ephemeral box's tunnel token
+    /// (`from_provisioned`). `None` for a local server that needs no auth.
+    auth_token: Option<String>,
 }
 
 impl HttpVerdictModel {
@@ -83,8 +87,8 @@ impl HttpVerdictModel {
     /// and the chat route is appended; loopback endpoints bypass the ambient HTTP proxy (a local
     /// Ollama routed through a corporate proxy 403s), matching the embedder client. `endpoint` is
     /// optional on the config, so an absent value falls back to the local-Ollama default (the same
-    /// default `RemoteDreamConfig::default` carries). The ephemeral `from_provisioned` constructor
-    /// that points at a tunnel endpoint lands in a later task.
+    /// default `RemoteDreamConfig::default` carries). A configured `auth_env` names the environment
+    /// variable holding the bearer token, read once here.
     pub fn from_config(cfg: &RemoteDreamConfig) -> Self {
         let endpoint = cfg
             .endpoint
@@ -92,16 +96,53 @@ impl HttpVerdictModel {
             .unwrap_or("http://localhost:11434")
             .trim()
             .trim_end_matches('/');
+        let auth_token = cfg
+            .auth_env
+            .as_deref()
+            .and_then(|var| std::env::var(var).ok())
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty());
+        Self::build(endpoint, cfg.model.trim(), auth_token, cfg.request_timeout_s)
+    }
+
+    /// Build the verdict client against an EPHEMERAL box just provisioned by the cookbook: the
+    /// tunnel `endpoint` + `auth_token` come from the `ready` handshake (NOT config), the model +
+    /// per-request timeout from `[llm.dream.remote]`. The box's tunnel is a public HTTPS URL (not
+    /// loopback), so the proxy bypass does not apply. Pair with [`provision_verdict_model`], which
+    /// keeps the `ProvisionedBox` alive for the model's lifetime.
+    pub fn from_provisioned(
+        endpoint: &str,
+        auth_token: Option<&str>,
+        model: &str,
+        request_timeout_s: u64,
+    ) -> Self {
+        let auth_token = auth_token.map(str::to_string).filter(|t| !t.is_empty());
+        Self::build(
+            endpoint.trim().trim_end_matches('/'),
+            model.trim(),
+            auth_token,
+            request_timeout_s,
+        )
+    }
+
+    /// Shared constructor for both modes: precompute the chat URL, build the `ureq` agent (loopback
+    /// proxy bypass), and store the bearer token.
+    fn build(
+        endpoint: &str,
+        model: &str,
+        auth_token: Option<String>,
+        request_timeout_s: u64,
+    ) -> Self {
         let chat_url = format!("{endpoint}/v1/chat/completions");
         let mut builder = ureq::Agent::config_builder()
-            .timeout_global(Some(Duration::from_secs(cfg.request_timeout_s)))
+            .timeout_global(Some(Duration::from_secs(request_timeout_s)))
             .http_status_as_error(false)
             .user_agent(concat!("rag-rat/", env!("CARGO_PKG_VERSION"), " (dream-verdict)"));
         if endpoint_is_loopback(endpoint) {
             builder = builder.proxy(None);
         }
         let agent: ureq::Agent = builder.build().into();
-        Self { agent, chat_url, model: cfg.model.trim().to_string() }
+        Self { agent, chat_url, model: model.to_string(), auth_token }
     }
 }
 
@@ -123,10 +164,13 @@ impl VerdictModel for HttpVerdictModel {
         let body = serde_json::to_vec(&payload)
             .map_err(|e| anyhow::anyhow!("failed to serialize verdict request: {e}"))?;
 
-        let mut response =
-            self.agent.post(&self.chat_url).content_type("application/json").send(body).map_err(
-                |e| anyhow::anyhow!("verdict request to `{}` failed: {e}", self.chat_url),
-            )?;
+        let mut request = self.agent.post(&self.chat_url).content_type("application/json");
+        if let Some(token) = &self.auth_token {
+            request = request.header("authorization", format!("Bearer {token}"));
+        }
+        let mut response = request
+            .send(body)
+            .map_err(|e| anyhow::anyhow!("verdict request to `{}` failed: {e}", self.chat_url))?;
         let status = response.status();
         let raw = response
             .body_mut()
@@ -154,6 +198,46 @@ impl VerdictModel for HttpVerdictModel {
             .map(|c| c.message.content)
             .ok_or_else(|| anyhow::anyhow!("chat completion response carried no choices"))
     }
+}
+
+/// Provision an ephemeral cookbook box serving the dream CHAT model and build a verdict client
+/// against it, reusing the embedding path's provisioning driver + leak-safety wholesale (only the
+/// `capability` + backend differ). The returned [`ProvisionedBox`] MUST be kept alive for as long
+/// as the model is used — its `Drop` tears the box down. Ephemeral-only: the caller checks
+/// `remote.is_ephemeral()` (and the zero-work guard) BEFORE calling, so we never cold-start a paid
+/// box for nothing.
+pub fn provision_verdict_model(
+    remote: &RemoteDreamConfig,
+) -> anyhow::Result<(HttpVerdictModel, crate::index::ai::ProvisionedBox)> {
+    use crate::index::ai::{CookbookInput, CookbookProvisioner};
+
+    let cookbook = remote.cookbook.as_deref().ok_or_else(|| {
+        anyhow::anyhow!("provision_verdict_model called on a non-ephemeral `[llm.dream.remote]`")
+    })?;
+    let input = CookbookInput {
+        model: remote.model.trim().to_string(),
+        backend: remote.backend.as_db_str(),
+        capability: "chat",
+        request_timeout_s: remote.request_timeout_s,
+        // Give the recipe a provisioning budget just under the Rust hard ceiling (backend-aware —
+        // vLLM's large image needs longer), so ITS budget expires first (clean provider teardown)
+        // before the Rust SIGKILL backstop fires. Mirrors the embedding `cookbook_input_for`.
+        provision_timeout_s: remote.backend.provision_timeout().as_secs().saturating_sub(20),
+        gpu: remote.gpu.clone(),
+        // Chat serving ignores these — num_ctx is an ollama-embedding knob, and the
+        // verdict/compaction passes call the model sequentially (one turn per memory), so a
+        // single server slot suffices.
+        num_ctx: None,
+        server_concurrency: 1,
+    };
+    let provisioned = CookbookProvisioner::provision(cookbook, &input)?;
+    let model = HttpVerdictModel::from_provisioned(
+        &provisioned.endpoint,
+        provisioned.auth_token.as_deref(),
+        remote.model.trim(),
+        remote.request_timeout_s,
+    );
+    Ok((model, provisioned))
 }
 
 fn response_excerpt(body: &str) -> String {

--- a/crates/rag-rat-core/src/dream/model.rs
+++ b/crates/rag-rat-core/src/dream/model.rs
@@ -366,8 +366,7 @@ mod http_tests {
             };
             let mut data = Vec::new();
             let mut buf = [0u8; 2048];
-            loop {
-                let Ok(n) = stream.read(&mut buf) else { break };
+            while let Ok(n) = stream.read(&mut buf) {
                 if n == 0 {
                     break;
                 }

--- a/crates/rag-rat-core/src/dream/model.rs
+++ b/crates/rag-rat-core/src/dream/model.rs
@@ -76,10 +76,10 @@ pub struct HttpVerdictModel {
     chat_url: String,
     /// The server-side model name sent in the request body (`[llm.dream.remote] model`).
     model: String,
-    /// Bearer token sent as `Authorization: Bearer <token>` when present — the value of the
-    /// `[llm.dream.remote] auth_env` variable (connect mode) or the ephemeral box's tunnel token
-    /// (`from_provisioned`). `None` for a local server that needs no auth.
-    auth_token: Option<String>,
+    /// The full `Authorization` header value (`"Bearer <token>"`) sent when the server needs auth
+    /// — from the `[llm.dream.remote] auth_env` variable (connect) or the ephemeral box's
+    /// tunnel token (`from_provisioned`). `None` for a local server that needs no auth.
+    auth_header: Option<String>,
 }
 
 impl HttpVerdictModel {
@@ -88,49 +88,51 @@ impl HttpVerdictModel {
     /// Ollama routed through a corporate proxy 403s), matching the embedder client. `endpoint` is
     /// optional on the config, so an absent value falls back to the local-Ollama default (the same
     /// default `RemoteDreamConfig::default` carries). A configured `auth_env` names the environment
-    /// variable holding the bearer token, read once here.
-    pub fn from_config(cfg: &RemoteDreamConfig) -> Self {
+    /// variable holding the bearer token; a NAMED-but-unset/empty var is a CONFIG ERROR (the same
+    /// `resolve_auth_header` the embedder uses), so this is fallible — an authenticated endpoint
+    /// must fail fast at startup, not send unauthenticated requests that 401 later.
+    pub fn from_config(cfg: &RemoteDreamConfig) -> anyhow::Result<Self> {
         let endpoint = cfg
             .endpoint
             .as_deref()
             .unwrap_or("http://localhost:11434")
             .trim()
             .trim_end_matches('/');
-        let auth_token = cfg
-            .auth_env
-            .as_deref()
-            .and_then(|var| std::env::var(var).ok())
-            .map(|t| t.trim().to_string())
-            .filter(|t| !t.is_empty());
-        Self::build(endpoint, cfg.model.trim(), auth_token, cfg.request_timeout_s)
+        let auth_header = crate::index::ai::resolve_auth_header(cfg.auth_env.as_deref(), |var| {
+            std::env::var(var).ok()
+        })?;
+        Ok(Self::build(endpoint, cfg.model.trim(), auth_header, cfg.request_timeout_s))
     }
 
     /// Build the verdict client against an EPHEMERAL box just provisioned by the cookbook: the
     /// tunnel `endpoint` + `auth_token` come from the `ready` handshake (NOT config), the model +
     /// per-request timeout from `[llm.dream.remote]`. The box's tunnel is a public HTTPS URL (not
-    /// loopback), so the proxy bypass does not apply. Pair with [`provision_verdict_model`], which
-    /// keeps the `ProvisionedBox` alive for the model's lifetime.
+    /// loopback), so the proxy bypass does not apply. The `auth_token` here is a DIRECT credential
+    /// (not an env-var name), so it is wrapped into the header as-is. Pair with
+    /// [`provision_verdict_model`], which keeps the `ProvisionedBox` alive for the model's
+    /// lifetime.
     pub fn from_provisioned(
         endpoint: &str,
         auth_token: Option<&str>,
         model: &str,
         request_timeout_s: u64,
     ) -> Self {
-        let auth_token = auth_token.map(str::to_string).filter(|t| !t.is_empty());
+        let auth_header =
+            auth_token.map(str::trim).filter(|t| !t.is_empty()).map(|t| format!("Bearer {t}"));
         Self::build(
             endpoint.trim().trim_end_matches('/'),
             model.trim(),
-            auth_token,
+            auth_header,
             request_timeout_s,
         )
     }
 
     /// Shared constructor for both modes: precompute the chat URL, build the `ureq` agent (loopback
-    /// proxy bypass), and store the bearer token.
+    /// proxy bypass), and store the resolved `Authorization` header.
     fn build(
         endpoint: &str,
         model: &str,
-        auth_token: Option<String>,
+        auth_header: Option<String>,
         request_timeout_s: u64,
     ) -> Self {
         let chat_url = format!("{endpoint}/v1/chat/completions");
@@ -142,7 +144,7 @@ impl HttpVerdictModel {
             builder = builder.proxy(None);
         }
         let agent: ureq::Agent = builder.build().into();
-        Self { agent, chat_url, model: model.to_string(), auth_token }
+        Self { agent, chat_url, model: model.to_string(), auth_header }
     }
 }
 
@@ -165,8 +167,8 @@ impl VerdictModel for HttpVerdictModel {
             .map_err(|e| anyhow::anyhow!("failed to serialize verdict request: {e}"))?;
 
         let mut request = self.agent.post(&self.chat_url).content_type("application/json");
-        if let Some(token) = &self.auth_token {
-            request = request.header("authorization", format!("Bearer {token}"));
+        if let Some(header) = &self.auth_header {
+            request = request.header("authorization", header.as_str());
         }
         let mut response = request
             .send(body)
@@ -431,12 +433,24 @@ mod http_tests {
     }
 
     #[test]
+    fn from_config_errors_when_auth_env_var_is_unset() {
+        // Connect mode naming an env var that does not resolve is a CONFIG error — fail fast rather
+        // than send unauthenticated requests. Uses a var name that is not set in the environment.
+        let cfg = RemoteDreamConfig {
+            auth_env: Some("RAG_RAT_DEFINITELY_UNSET_DREAM_AUTH_VAR".to_string()),
+            ..RemoteDreamConfig::default()
+        };
+        let err = HttpVerdictModel::from_config(&cfg).unwrap_err().to_string();
+        assert!(err.contains("auth env"), "surfaces the unresolved auth var: {err}");
+    }
+
+    #[test]
     fn constructors_set_the_model_id() {
         let cfg = RemoteDreamConfig {
             model: "qwen3:4b-instruct".to_string(),
             ..RemoteDreamConfig::default()
         };
-        assert_eq!(HttpVerdictModel::from_config(&cfg).model_id(), "qwen3:4b-instruct");
+        assert_eq!(HttpVerdictModel::from_config(&cfg).unwrap().model_id(), "qwen3:4b-instruct");
         assert_eq!(
             HttpVerdictModel::from_provisioned(
                 "https://box.modal.run",

--- a/crates/rag-rat-core/src/dream/verify.rs
+++ b/crates/rag-rat-core/src/dream/verify.rs
@@ -781,10 +781,12 @@ mod tests {
     }
 
     #[test]
-    fn model_work_pending_reflects_the_queues_and_flags() {
-        // The ephemeral zero-work guard: `verify` peeks the verification queue, `compact` the
-        // compaction queue; neither flag → never pending, so a paid GPU box is never cold-started
-        // for nothing.
+    fn model_work_pending_is_citability_aware_for_verify() {
+        // The ephemeral zero-work guard. VERIFY counts only CITABLE entries — an uncitable
+        // prose-only / all-NOT_FOUND memory records a terminal row WITHOUT a model call, so
+        // it is zero model work and must NOT cold-start a paid box (PR #438 review).
+        // COMPACT counts the whole queue (every memory is summarized). Neither flag → never
+        // pending.
         let c = mem_db();
         set_repo(&c, "r");
         let opts = crate::dream::DreamOptions { now_ms: 1, limit: 10, verify: true };
@@ -792,15 +794,33 @@ mod tests {
             !crate::dream::model_work_pending(&c, opts, 10, true, true).unwrap(),
             "empty repo → no work"
         );
-        seed_memory(&c, "m1", "t", "a note", "r");
+
+        // An UNCITABLE prose-only memory (no identifiers, no bindings): verify is NOT model work,
+        // but compaction WILL summarize it.
+        seed_memory(&c, "m1", "t", "a prose note with no identifiers", "r");
         assert!(
-            crate::dream::model_work_pending(&c, opts, 10, true, false).unwrap(),
-            "a never-checked memory is verify-pending"
+            !crate::dream::model_work_pending(&c, opts, 10, true, false).unwrap(),
+            "an all-uncitable verify queue is NOT model work — never cold-start a box for it"
         );
         assert!(
             crate::dream::model_work_pending(&c, opts, 10, false, true).unwrap(),
-            "an un-summarized memory is compact-pending"
+            "the same memory IS compact-pending (compaction has no uncitable short-circuit)"
         );
+
+        // A CITABLE memory whose identifier resolves to a real symbol → verify IS model work.
+        let fid = seed_file(&c, "src/x.rs", "fn f() {}\n", "r");
+        c.execute(
+            "INSERT INTO symbols(file_id, language, name, kind, start_byte, end_byte) VALUES \
+             (?1,'rust','resolve_marker_token','function',0,0)",
+            rusqlite::params![fid],
+        )
+        .unwrap();
+        seed_memory(&c, "m2", "t", "a note about `resolve_marker_token`", "r");
+        assert!(
+            crate::dream::model_work_pending(&c, opts, 10, true, false).unwrap(),
+            "a citable never-checked memory is verify-pending"
+        );
+
         assert!(
             !crate::dream::model_work_pending(&c, opts, 10, false, false).unwrap(),
             "neither flag → never pending"

--- a/crates/rag-rat-core/src/dream/verify.rs
+++ b/crates/rag-rat-core/src/dream/verify.rs
@@ -781,6 +781,33 @@ mod tests {
     }
 
     #[test]
+    fn model_work_pending_reflects_the_queues_and_flags() {
+        // The ephemeral zero-work guard: `verify` peeks the verification queue, `compact` the
+        // compaction queue; neither flag → never pending, so a paid GPU box is never cold-started
+        // for nothing.
+        let c = mem_db();
+        set_repo(&c, "r");
+        let opts = crate::dream::DreamOptions { now_ms: 1, limit: 10, verify: true };
+        assert!(
+            !crate::dream::model_work_pending(&c, opts, 10, true, true).unwrap(),
+            "empty repo → no work"
+        );
+        seed_memory(&c, "m1", "t", "a note", "r");
+        assert!(
+            crate::dream::model_work_pending(&c, opts, 10, true, false).unwrap(),
+            "a never-checked memory is verify-pending"
+        );
+        assert!(
+            crate::dream::model_work_pending(&c, opts, 10, false, true).unwrap(),
+            "an un-summarized memory is compact-pending"
+        );
+        assert!(
+            !crate::dream::model_work_pending(&c, opts, 10, false, false).unwrap(),
+            "neither flag → never pending"
+        );
+    }
+
+    #[test]
     fn queue_enqueues_anchor_gone_and_skips_a_verified_unchanged_memory() {
         let c = mem_db();
         set_repo(&c, "r");

--- a/crates/rag-rat-core/src/index/ai/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/mod.rs
@@ -27,6 +27,7 @@ pub use providers::Model2VecEmbedder;
 pub use providers::provision_box_for_benchmark;
 pub(crate) use providers::{
     ChunkEmbedder, acquire_chunk_embedder, active_embedder, provision_and_build,
+    resolve_auth_header,
 };
 // Curate the provider surface onto the `index::ai` path so existing `super::*` callers
 // (`reconcile`, `status`, `helpers`) and the external `ai::Embedder` /

--- a/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/cookbook.rs
@@ -134,11 +134,17 @@ pub struct CookbookInput {
     /// The server-side model name the box should serve (the `[remote] model`): an ollama model
     /// name for the ollama backend, or a HuggingFace model id for infinity/vLLM.
     pub model: String,
-    /// Which embedding backend the recipe should provision — the `RemoteBackend::as_db_str` of the
+    /// Which backend the recipe should provision — the `RemoteBackend::as_db_str` of the
     /// configured backend (`ollama`/`infinity`/`vllm`). Selects the recipe's image, launch
-    /// command, port, embeddings route, and model-load strategy; the embed WIRE CALL is
-    /// identical across all three (OpenAI `/v1/embeddings` shape).
+    /// command, port, serving route, and model-load strategy.
     pub backend: &'static str,
+    /// What the box should SERVE: `"embed"` (`/v1/embeddings`, the readiness probe posts an
+    /// embeddings request) or `"chat"` (`/v1/chat/completions`, generation — the dream verdict /
+    /// compaction model). The backend's launch args + readiness probe branch on this: `vllm` drops
+    /// its `--runner pooling` (embedding) flag for chat, and only chat-capable backends
+    /// (`ollama`/`vllm`) accept `"chat"` — config rejects `infinity` for chat before it reaches
+    /// here.
+    pub capability: &'static str,
     /// Per-REQUEST HTTP timeout the cookbook may forward to its box config — the
     /// `OpenAiEmbedder`'s per-request budget. UNRELATED to provisioning; do NOT use it as the
     /// boot budget.
@@ -518,6 +524,9 @@ fn cookbook_input_for(remote: &RemoteEmbeddingConfig) -> CookbookInput {
         // The selected backend routes the recipe's image/launch/port/route; the embed wire call is
         // identical across all three.
         backend: remote.backend.as_db_str(),
+        // Embedding path: serve the `/v1/embeddings` API (readiness probe posts an embeddings
+        // request). The dream path passes `"chat"`.
+        capability: "embed",
         request_timeout_s: remote.request_timeout_s,
         // Give the recipe a provisioning budget just under the Rust hard ceiling (backend-aware:
         // vLLM's large image needs longer), so ITS budget runs out first (clean provider-side
@@ -1213,12 +1222,32 @@ mod tests {
         CookbookInput {
             model: "all-minilm".to_string(),
             backend: "ollama",
+            capability: "embed",
             request_timeout_s: 30,
             provision_timeout_s: 280,
             gpu: None,
             num_ctx: None,
             server_concurrency: 32,
         }
+    }
+
+    #[test]
+    fn embedding_input_is_embed_capability_and_field_serializes() {
+        // The embedding config→input mapping pins `capability = "embed"`; the field must serialize
+        // into the recipe's JSON so a chat box (dream) is distinguishable from an embed box.
+        let remote = RemoteEmbeddingConfig {
+            model: "all-minilm".to_string(),
+            cookbook: Some("@rag-rat/cookbook modal".to_string()),
+            query_endpoint: Some(crate::config::DEFAULT_QUERY_ENDPOINT.to_string()),
+            ..RemoteEmbeddingConfig::default()
+        };
+        assert_eq!(cookbook_input_for(&remote).capability, "embed");
+        let mut chat = input();
+        chat.capability = "chat";
+        assert!(
+            serde_json::to_string(&chat).unwrap().contains("\"capability\":\"chat\""),
+            "capability serializes for the recipe"
+        );
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -43,6 +43,10 @@ pub use self::model2vec::Model2VecEmbedder;
 pub use self::openai::OpenAiEmbedder;
 // The tuning sweep (index::ai::throughput_tune) builds embedders at varied concurrencies.
 pub(crate) use self::openai::ProvisionedEmbedderParams;
+// The shared connect-mode auth resolver — reused by the dream verdict client
+// (`dream/model.rs`) so a configured-but-unresolved `auth_env` errors identically for
+// embeddings and the dream model.
+pub(crate) use self::openai::resolve_auth_header;
 use crate::config::RemoteEmbeddingConfig;
 use crate::embedding_models::{Backend, EmbeddingModelSpec, spec};
 use crate::index::ai::{

--- a/crates/rag-rat-core/src/index/ai/providers/openai.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/openai.rs
@@ -452,7 +452,7 @@ fn response_excerpt(body: &str) -> String {
 /// auth (`Ok(None)`); a named-but-missing/empty value → `Err` (the operator asked for auth but the
 /// token isn't there). Closure-injected so the env-mutation footgun (unsafe + flaky under nextest's
 /// parallel runner in Rust 2024) never enters the test path.
-fn resolve_auth_header(
+pub(crate) fn resolve_auth_header(
     auth_env: Option<&str>,
     lookup: impl Fn(&str) -> Option<String>,
 ) -> anyhow::Result<Option<String>> {
@@ -462,8 +462,7 @@ fn resolve_auth_header(
     let token =
         lookup(var).map(|t| t.trim().to_string()).filter(|t| !t.is_empty()).ok_or_else(|| {
             anyhow::anyhow!(
-                "remote embedding auth env var `{var}` is set in config but missing or empty in \
-                 the environment"
+                "auth env var `{var}` is set in config but missing or empty in the environment"
             )
         })?;
     Ok(Some(format!("Bearer {token}")))

--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -699,7 +699,6 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
-            dream: Default::default(),
             memory: Default::default(),
             log: Default::default(),
         };
@@ -813,7 +812,6 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
-            dream: Default::default(),
             memory: Default::default(),
             log: Default::default(),
         };
@@ -881,7 +879,6 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
-            dream: Default::default(),
             memory: Default::default(),
             log: Default::default(),
         };
@@ -976,7 +973,6 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
-            dream: Default::default(),
             memory: Default::default(),
             log: Default::default(),
         };

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -874,7 +874,6 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
-            dream: Default::default(),
             memory: Default::default(),
             log: Default::default(),
         }

--- a/crates/rag-rat-core/src/index/query_api/clones/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/tests.rs
@@ -210,7 +210,6 @@ fn find_clones_rejects_nan_and_non_finite_min_similarity() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     };
@@ -795,7 +794,6 @@ fn recall_candidates_identical_blob_vs_postings_grouping() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     };

--- a/crates/rag-rat-core/src/index/query_api/dream.rs
+++ b/crates/rag-rat-core/src/index/query_api/dream.rs
@@ -40,12 +40,6 @@ impl IndexDatabase {
         verify: bool,
         compact: bool,
     ) -> anyhow::Result<bool> {
-        Ok(crate::dream::model_work_pending(
-            self.storage.connection(),
-            opts,
-            budget,
-            verify,
-            compact,
-        )?)
+        crate::dream::model_work_pending(self.storage.connection(), opts, budget, verify, compact)
     }
 }

--- a/crates/rag-rat-core/src/index/query_api/dream.rs
+++ b/crates/rag-rat-core/src/index/query_api/dream.rs
@@ -12,7 +12,7 @@ impl IndexDatabase {
     }
 
     /// [`Self::dream_run`] plus the phase-B model verdict pass and the phase-C model compaction
-    /// pass — the CLI supplies each `Some(pass)` only when `[dream.model] enabled = true` and the
+    /// pass — the CLI supplies each `Some(pass)` only when `[llm.dream] enabled = true` and the
     /// matching flag (`--verify` / `--compact`) is set; `None`/`None` is byte-identical to
     /// [`Self::dream_run`].
     pub fn dream_run_with_passes(
@@ -27,5 +27,25 @@ impl IndexDatabase {
             verdict_pass,
             compact_pass,
         )
+    }
+
+    /// Whether the model passes have pending work (the zero-work guard for ephemeral
+    /// `[llm.dream.remote]`): peek the verify/compact churn-skip queues without touching the model,
+    /// so the CLI skips cold-starting a paid GPU box when the queues are already drained. See
+    /// [`crate::dream::model_work_pending`].
+    pub fn dream_model_work_pending(
+        &self,
+        opts: DreamOptions,
+        budget: usize,
+        verify: bool,
+        compact: bool,
+    ) -> anyhow::Result<bool> {
+        Ok(crate::dream::model_work_pending(
+            self.storage.connection(),
+            opts,
+            budget,
+            verify,
+            compact,
+        )?)
     }
 }

--- a/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
@@ -46,7 +46,6 @@ fn rust_config(root: PathBuf) -> Config {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     }
@@ -1173,7 +1172,6 @@ fn deleted_and_generated_paths_counted_in_skipped() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     };

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
@@ -1103,7 +1103,6 @@ fn multi_language_clone_integration_finds_within_language_no_cross() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     };
@@ -1299,7 +1298,6 @@ fn find_clones_ranks_a_clean_clone_class_with_metrics() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     };

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dir_memory_tree.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dir_memory_tree.rs
@@ -318,7 +318,6 @@ fn dir_tree_label_depth_collapse_single_child_chain() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     };
@@ -549,7 +548,6 @@ fn dir_tree_truncates_at_max_nodes() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     };
@@ -697,7 +695,6 @@ fn dir_tree_children_of_collapsed_node_use_leaf_labels() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     };

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/github_papertrail.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/github_papertrail.rs
@@ -312,7 +312,6 @@ fn parser_failures_report_paths() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     };

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -83,7 +83,6 @@ fn rag_rat_config(root: &Path) -> Config {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     }
@@ -214,7 +213,6 @@ fn markdown_config_for_root(root: PathBuf) -> Config {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     }
@@ -352,7 +350,6 @@ fn source_config(root: PathBuf, language: Language) -> Config {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     }
@@ -701,7 +698,6 @@ fn git_fixture_for_overlay_tests() -> (PathBuf, Config) {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     };
@@ -824,7 +820,6 @@ fn write_four_renamed_clones(root: &PathBuf) -> IndexDatabase {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     };

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
@@ -181,7 +181,6 @@ fn clean_checkout_file_resolves_against_its_own_package_roots() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     };

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -844,7 +844,6 @@ fn git_history_indexes_commits_paths_queries_and_blame() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     };

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -2130,7 +2130,6 @@ fn repo_brief_ranks_churn_and_god_module_candidates() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     };
@@ -2216,7 +2215,6 @@ fn repo_clusters_groups_cotouched_files() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     };

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -25,7 +25,6 @@ fn rebuild_bootstraps_sqlite_schema_for_empty_target_root() {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     };

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
@@ -538,7 +538,6 @@ DEVICE_DT_INST_DEFINE(0, entropy_init, NULL, NULL, NULL,
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     };
@@ -1324,7 +1323,6 @@ where
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     };

--- a/crates/rag-rat-core/src/logging/mod.rs
+++ b/crates/rag-rat-core/src/logging/mod.rs
@@ -139,7 +139,6 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
-            dream: Default::default(),
             memory: Default::default(),
             log: LogConfig { enabled, dir: dir.join("logs"), ..LogConfig::default() },
         }

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -827,9 +827,7 @@ mod tests {
     use notify::event::{CreateKind, ModifyKind};
 
     use super::*;
-    use crate::config::{
-        Config, EmbeddingConfig, LlmConfig, ResolvedTarget, TargetKind, WatchConfig,
-    };
+    use crate::config::{Config, LlmConfig, ResolvedTarget, TargetKind, WatchConfig};
     use crate::language::Language;
 
     fn mutation_event(path: PathBuf) -> Event {
@@ -853,12 +851,11 @@ mod tests {
                 exclude: Vec::new(),
                 kind: TargetKind::Source,
             }],
-            llm: LlmConfig { embedding: EmbeddingConfig::default() },
+            llm: LlmConfig::default(),
             watch: WatchConfig::default(),
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
-            dream: Default::default(),
             memory: Default::default(),
             log: Default::default(),
         }
@@ -879,12 +876,11 @@ mod tests {
                 exclude: Vec::new(),
                 kind: TargetKind::Source,
             }],
-            llm: LlmConfig { embedding: EmbeddingConfig::default() },
+            llm: LlmConfig::default(),
             watch: WatchConfig::default(),
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
-            dream: Default::default(),
             memory: Default::default(),
             log: Default::default(),
         };
@@ -980,12 +976,11 @@ mod tests {
                 exclude: Vec::new(),
                 kind: TargetKind::Source,
             }],
-            llm: LlmConfig { embedding: EmbeddingConfig::default() },
+            llm: LlmConfig::default(),
             watch: WatchConfig::default(),
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
-            dream: Default::default(),
             memory: Default::default(),
             log: Default::default(),
         };
@@ -1028,12 +1023,11 @@ mod tests {
                 exclude: Vec::new(),
                 kind: TargetKind::Source,
             }],
-            llm: LlmConfig { embedding: EmbeddingConfig::default() },
+            llm: LlmConfig::default(),
             watch: WatchConfig::default(),
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
-            dream: Default::default(),
             memory: Default::default(),
             log: Default::default(),
         };
@@ -1094,12 +1088,11 @@ mod tests {
                 exclude: Vec::new(),
                 kind: TargetKind::Source,
             }],
-            llm: LlmConfig { embedding: EmbeddingConfig::default() },
+            llm: LlmConfig::default(),
             watch: WatchConfig::default(),
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
-            dream: Default::default(),
             memory: Default::default(),
             log: Default::default(),
         };
@@ -1171,12 +1164,11 @@ mod tests {
                 exclude: Vec::new(),
                 kind: TargetKind::Source,
             }],
-            llm: LlmConfig { embedding: EmbeddingConfig::default() },
+            llm: LlmConfig::default(),
             watch: WatchConfig::default(),
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
-            dream: Default::default(),
             memory: Default::default(),
             log: Default::default(),
         };
@@ -1320,12 +1312,11 @@ mod tests {
                 exclude: Vec::new(),
                 kind: TargetKind::Source,
             }],
-            llm: LlmConfig { embedding: EmbeddingConfig::default() },
+            llm: LlmConfig::default(),
             watch: WatchConfig::default(),
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
-            dream: Default::default(),
             memory: Default::default(),
             log: Default::default(),
         };
@@ -1586,12 +1577,11 @@ mod tests {
                 exclude: Vec::new(),
                 kind: TargetKind::Source,
             }],
-            llm: LlmConfig { embedding: EmbeddingConfig::default() },
+            llm: LlmConfig::default(),
             watch: WatchConfig::default(),
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
-            dream: Default::default(),
             memory: Default::default(),
             log: Default::default(),
         };

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -284,7 +284,6 @@ mod tests {
             version_check: Default::default(),
             oracle: Default::default(),
             search: Default::default(),
-            dream: Default::default(),
             memory: Default::default(),
             log: Default::default(),
         };

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -890,7 +890,6 @@ fn mixed_config() -> (PathBuf, Config) {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     })
@@ -918,7 +917,6 @@ fn markdown_config(text: &str) -> (PathBuf, Config) {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     })
@@ -943,7 +941,6 @@ fn rust_config(root: PathBuf) -> Config {
         version_check: Default::default(),
         oracle: Default::default(),
         search: Default::default(),
-        dream: Default::default(),
         memory: Default::default(),
         log: Default::default(),
     }

--- a/docs/config.md
+++ b/docs/config.md
@@ -367,22 +367,44 @@ refresh the current worktree index and advance changed-first embedding reconcili
 blocking normal Git operations. Each maintenance pass also runs a worktree-safe `gc` that prunes
 index rows for commits no longer held by any live worktree (run `rag-rat gc` to prune on demand).
 
-## Dream verdict model (`[dream.model]`)
+## Dream verdict model (`[llm.dream]` / `[llm.dream.remote]`)
 
-`[dream.model]` configures the dream verify pass's **model verdict** — rag-rat's only
+`[llm.dream]` configures the dream verify/compaction passes' **model** — rag-rat's only
 generative-model dependency. It is **out-of-process, opt-in, and gated by a deterministic layer**:
-`rag-rat dream` stays 100% deterministic unless you pass `--verify` *and* enable the model here.
+`rag-rat dream` stays 100% deterministic unless you pass `--verify`/`--compact` *and* set
+`enabled = true`. The serving config lives under `[llm.dream.remote]`, mirroring
+`[llm.embedding.remote]` — a **connect** endpoint (an already-running chat server) or an
+**ephemeral** cookbook-provisioned GPU box.
 
 ```toml
-[dream.model]
-enabled = false                     # off by default — the model turn is skipped
-endpoint = "http://localhost:11434" # OpenAI-compatible chat server (a local Ollama by default)
-model = "qwen3:4b-instruct"    # server-side model name sent in the request body
-request_timeout_s = 300             # per-request HTTP timeout (CPU inference over a large evidence pack is slow)
+[llm.dream]
+enabled = false             # off by default — the model turn is skipped
+
+# CONNECT mode (default when [llm.dream.remote] is omitted): a local Ollama.
+[llm.dream.remote]
+backend  = "ollama"
+endpoint = "http://localhost:11434"     # OpenAI-compatible chat server
+model    = "qwen3:4b-instruct"          # server-side model name
+request_timeout_s = 300
 ```
 
-The client speaks the standard `/v1/chat/completions` route (temperature 0, no streaming), so any
-compatible server works (Ollama, vLLM, …). Run it with:
+For a dense evidence pack, CPU inference is pathologically slow (a large bound file can blow past the
+timeout and never verify). Run the model on an **ephemeral remote GPU** instead — the same cookbook
+mechanism embeddings use — by setting `cookbook` + `gpu` instead of `endpoint`:
+
+```toml
+[llm.dream.remote]
+backend  = "vllm"                       # ollama | vllm  (infinity is embed-only — rejected here)
+cookbook = "@rag-rat/cookbook modal"    # provision an ephemeral box (mutually exclusive with endpoint)
+gpu      = "A10G"                        # provider-specific GPU class (validated at provision time)
+model    = "Qwen/Qwen3-8B"              # HF id for vllm (an ollama name for the ollama backend)
+auth_env = "MODAL_TOKEN"                # optional: env var holding the box's bearer token
+request_timeout_s = 900
+```
+
+The box is provisioned only when there is pending work (a zero-work guard never cold-starts a paid
+GPU for a fully churn-skipped repo) and is torn down when the run ends. The client speaks the
+standard `/v1/chat/completions` route (temperature 0, no streaming). Run it with:
 
 ```bash
 rag-rat dream --verify --max-memories 20
@@ -397,7 +419,7 @@ the derived `memory_reality` table. A `diverged` verdict opens a `memory_diverge
 review flow. The model **proposes**; it never changes a memory's status. Leaving `enabled = false`
 skips the model turn entirely — no network calls, deterministic findings only.
 
-`--compact` (independent of `--verify`, and gated the same way on `[dream.model] enabled = true`)
+`--compact` (independent of `--verify`, and gated the same way on `[llm.dream] enabled = true`)
 runs the **compaction pass**, which rewrites each un-summarized memory into a 3–4 sentence,
 self-contained summary and stores it in the derived `memory_summaries` table:
 

--- a/rag-rat.toml
+++ b/rag-rat.toml
@@ -32,6 +32,24 @@ ort_threads = 4
 omp_threads = 1
 max_embedding_chars = 2000    # conservative retry: ~500 tokens/chunk (well within jina's 8192 window)
 
+# Dream v2 MODEL passes (verdict + compaction). OFF until enabled — `rag-rat dream` stays 100%
+# deterministic otherwise. The serving config lives under `[llm.dream.remote]`, mirroring
+# `[llm.embedding.remote]`.
+[llm.dream]
+enabled = true
+
+# EPHEMERAL mode (`cookbook`, not `endpoint`): `rag-rat dream --verify/--compact` provisions a fresh
+# Modal GPU box running vLLM (generation), runs the budget-capped verdict/compaction passes against
+# its OpenAI-compatible `/v1/chat/completions`, then tears the box down. A zero-work guard skips
+# provisioning entirely when the churn-skip queues are already drained, so an idle run never
+# cold-starts a paid box. (infinity is embed-only and rejected here — chat needs ollama or vllm.)
+[llm.dream.remote]
+cookbook = "@rag-rat/cookbook modal"    # same ephemeral Modal recipe as embeddings (published npm)
+backend  = "vllm"                       # generation runner; serves /v1/chat/completions
+model    = "Qwen/Qwen3-8B"              # server-side HF id vLLM launches (Qwen3-4B-Instruct-2507 = lighter, eval-validated)
+gpu      = "L4"                         # 24GB fits Qwen3-8B in fp16 (matches the embedding box class)
+request_timeout_s = 900                 # generous per-request budget (a dense evidence pack is slow on first token)
+
 [target_bindings]
 rust = ["crates"]
 markdown = ["docs"]


### PR DESCRIPTION
Run the dream verdict/compaction model on an ephemeral cookbook-provisioned GPU box, mirroring `[llm.embedding.remote]`. Fixes the CPU-pathological verdict from #425 (a dense evidence pack blew past the timeout and never verified) by moving inference off local CPU.

## What lands

**Config — `[llm.dream]` / `[llm.dream.remote]`** (mirrors `[llm.embedding.remote]`)
- `RemoteDreamConfig`: connect `endpoint` XOR ephemeral `cookbook`, plus `backend`, `model`, `gpu`, `auth_env`, `request_timeout_s`. Default is a local-Ollama connect (prior behavior preserved).
- Retires `[dream.model]` / `DreamModelConfig` / `Config.dream` — full migration, no shim.
- Validation mirrors the embedding remote: mode-ambiguous, gpu-requires-cookbook, endpoint-has-credentials, missing-model.

**Capability model** — one shared `RemoteBackend` (`ollama | infinity | vllm`) gains `embed` vs `chat`. ollama and vllm serve chat; **infinity is embed-only and rejected at parse time** (`DreamBackendCannotServeChat`). `CookbookInput` carries the capability through to the recipe.

**Provisioning** — `HttpVerdictModel::from_provisioned` points the chat client at the provisioned tunnel endpoint with bearer auth; `provision_verdict_model` builds a chat `CookbookInput` and provisions via the existing `CookbookProvisioner` (reusing all of its leak-safety). The `dream()` command holds the `ProvisionedBox` for the run (drop = teardown), gated by a **zero-work guard** (`model_work_pending` peeks the verify/compact churn-skip queues) so an idle run never cold-starts a paid GPU box.

**Cookbook (`@rag-rat/cookbook`, TypeScript)** — a `chat` capability: `verifyChat` readiness probe, capability-aware serving (vLLM drops `--runner pooling` for generation; ollama serves both; infinity fails loudly), route selection per capability. Backwards-compatible — an input without `capability` behaves exactly as before.

## Notes
- `npm publish` of the cookbook is a follow-up (owner credentials) so `cookbook = "@rag-rat/cookbook modal"` works out of the box; until then point `cookbook` at a local recipe path.
- The pack token-budget mitigation in #425 is complementary and stays open.

fmt + clippy clean; full workspace tests green (config parse/validation, the zero-work guard, capability serialization; cookbook typecheck + runtime harnesses).

Fixes #437. Related: #425, #122.