### PR TITLE
chore(cookbook): sync package-lock.json to 0.6.0

### DIFF
--- a/cookbook/package-lock.json
+++ b/cookbook/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rag-rat/cookbook",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rag-rat/cookbook",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "modal": "^0.8.1"


### PR DESCRIPTION
Follow-up to #438: the 0.6.0 version bump committed `cookbook/package.json` but not `cookbook/package-lock.json`, so main has the lockfile at 0.5.0 while package.json is 0.6.0 — `npm ci` in `cookbook/` would error on the mismatch. This syncs the lockfile's version fields (root + self-entry) to 0.6.0. No dependency changes.