### PR TITLE
feat(dream): human review surface — dream <id> --accept|--dismiss|--reset (#262)

### DIFF
--- a/.agents/skills/dream-review/SKILL.md
+++ b/.agents/skills/dream-review/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: dream-review
+description: >
+  Use when asked to review, triage, or resolve rag-rat "dream" findings — the memory-maintenance
+  worklist `rag-rat dream` produces. Walks the pending (open) findings and, per kind, either fixes
+  the underlying memory / coverage gap (which resolves the finding at the root) or records an
+  accept / dismiss verdict. Triggers: "dream review", "resolve dream findings", "triage the dream
+  worklist", "go through pending dream findings".
+---
+
+# dream-review — triage and resolve the rag-rat dream worklist
+
+`rag-rat dream` surfaces findings **about** the repo's memories and load-bearing code. It never
+mutates a memory — the deterministic passes and the optional model **propose**; a reviewer
+**decides**. This skill is that reviewer loop: for each open finding, investigate with the rag-rat
+tools, then resolve it — preferring a **root fix** (repair the memory / close the coverage gap, so
+the finding resolves on its own next run) over a bare verdict.
+
+Run this from inside the rag-rat-indexed repo. Use the **rag-rat MCP tools** to investigate
+(`semantic_search`, `symbol_lookup`, `impact_surface`, `find_callers`, `git_history_for_symbol`,
+`memory_search`) — not `grep`. It is a batch chore meant to run a few times a day, not continuously.
+
+## 1. Preflight
+
+- Confirm the index is fresh: `rag-rat index_status` (MCP) or `rag-rat doctor`. If findings look
+  stale/empty, `rag-rat index --discover` then `rag-rat reconcile`.
+- (Re)generate findings. Deterministic only:
+
+  ```bash
+  rag-rat dream
+  ```
+
+  With the model configured (`[llm.dream] enabled = true`) also run the verdict + compaction passes,
+  which add `memory_divergence` findings and summaries:
+
+  ```bash
+  rag-rat dream --verify --compact --max-memories 20
+  ```
+
+## 2. Pull the open worklist
+
+```bash
+rag-rat dream --json
+```
+
+`findings[]` carries `{ id, kind, subject, evidence, rank, status }`. Work **highest `rank`
+first** (rank decays with age). The `id` (a short hex; a unique prefix also works) is what you pass
+to the verdict commands. `rag-rat dream --all --json` additionally lists already-`accepted` /
+`dismissed` findings (use it to find one to `--reset`).
+
+## 3. Resolve each finding, by kind
+
+For every finding: **investigate first, then act.** Prefer the root fix; fall back to a verdict.
+
+### `coverage_gap` — `subject = "path::symbol"`
+A load-bearing symbol (many callers) with no memory binding.
+- Investigate: `impact_surface` / `important_symbols` (personalize on the symbol) /
+  `git_history_for_symbol` — is there a durable, non-obvious invariant, decision, or footgun here?
+- **Root fix:** if yes, `memory_create` (MCP) an `Invariant`/`Decision`/`Risk` **bound to that
+  symbol** (`bind.id` = its `sym_…` handle, or `bind.path`). The gap closes automatically on the
+  next `rag-rat dream` (the binding now exists) — no verdict needed.
+- **Dismiss** if the symbol is self-explanatory / not memory-worthy: `rag-rat dream <id> --dismiss`.
+- Use **accept** only to mean "real gap, but I'm not writing the memory in this pass" (keeps it out
+  of the open list without claiming it's a non-issue).
+
+### `stale_reference` — `subject = <memory id>`, `evidence` lists the unresolved path(s)
+A memory body references a `.rs` path that no longer resolves against the index.
+- Read the memory: `rag-rat memory show <id>`. Locate where the path went: `semantic_search` /
+  `symbol_lookup` on the moved code.
+- **Root fix:** if the code moved, `memory_update` (MCP) the body to the new path, and/or
+  `memory_rebind` (MCP or `rag-rat memory rebind`) to re-anchor. The finding resolves once the
+  reference is valid again. If the memory is genuinely stale, `memory_mark_obsolete` (MCP).
+- **Dismiss** only for a true false positive (e.g. a deliberate historical reference the regex
+  can't tell apart): `rag-rat dream <id> --dismiss`.
+
+### `memory_unverifiable` — `subject = <memory id>`
+Decided deterministically: the memory's bindings are all gone/absent **and** none of its
+identifiers resolve anywhere in the whole-tree index.
+- Read it (`rag-rat memory show <id>`). Does the code it describes still exist under a new name?
+- **Root fix:** re-anchor with `memory_rebind`; or if it's obsolete, `memory_mark_obsolete` (MCP).
+- **Dismiss** if it's still-true prose that simply isn't code-anchorable (accept it as-is):
+  `rag-rat dream <id> --dismiss`.
+
+### `memory_divergence` — `subject = <memory id>`, `evidence` = the model's cited pack lines
+The model judged the memory to have drifted from current code. **The model is ~71–76% accurate —
+verify before acting.**
+- Read the memory and the cited lines yourself (`impact_surface`, `read_chunk`). Is the note
+  actually wrong about current code?
+- **Root fix:** if genuinely stale, `memory_update` to correct it (or `memory_mark_obsolete`). The
+  divergence finding drops once the stored verdict flips `current` on a re-check, or the body edit
+  self-invalidates the old verdict.
+- **Accept** if the divergence is real but intentional — the note is deliberately *ahead* of
+  unmerged code (a "note-ahead" case): `rag-rat dream <id> --accept`.
+- **Dismiss** if the model is wrong (false positive): `rag-rat dream <id> --dismiss`.
+
+## 4. Verdict semantics (quick reference)
+
+```bash
+rag-rat dream <id> --accept    # real, acknowledged (action pending) — leaves the open worklist
+rag-rat dream <id> --dismiss   # false positive / won't-fix — hidden from the worklist
+rag-rat dream <id> --reset     # undo a verdict, back to open
+```
+
+- A verdict **survives future runs**: a re-run that still reports the finding keeps your
+  accept/dismiss; a finding the code makes obsolete resolves on its own.
+- Fixing the root (memory / coverage) is **better than a verdict** whenever a real fix exists — the
+  finding resolves cleanly and the next agent benefits from the repaired memory.
+- Only `open`/`accepted`/`dismissed` findings are reviewable; a `resolved`/`superseded` one is not.
+
+## 5. Loop until clear
+
+Re-run `rag-rat dream --json` and repeat until `findings[]` is empty (or only accepted/dismissed
+remain under `--all`). If your fixes created new memories, a fresh run may open follow-on findings —
+one more pass usually converges.
+
+## Guardrails
+
+- **Never edit, demote, or mark-obsolete a memory without verifying the claim yourself.** The passes
+  propose; you decide. This is the invariant that keeps dream from silently corrupting the memory
+  layer.
+- **Prefer the root fix over a bare `--dismiss`.** Dismissing a real issue just hides it.
+- **Capture what you learn.** If investigating a finding taught you a durable, non-obvious fact,
+  `memory_create` it (that also closes `coverage_gap` findings).
+- Respect the voice/scope rules of whatever repo you're in when writing memory bodies.

--- a/.claude/skills/dream-review
+++ b/.claude/skills/dream-review
@@ -1,0 +1,1 @@
+../../.agents/skills/dream-review

--- a/.codex/skills/dream-review
+++ b/.codex/skills/dream-review
@@ -1,0 +1,1 @@
+../../.agents/skills/dream-review

--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -216,6 +216,27 @@ pub(crate) struct DreamArgs {
     /// model.
     #[arg(long)]
     pub max_memories: Option<u32>,
+    /// A dream finding id (or unambiguous prefix, git-style) to REVIEW instead of running the
+    /// worklist. Pair with exactly one of `--accept` / `--dismiss` / `--reset`; the verdict is
+    /// preserved across future runs.
+    #[arg(value_name = "FINDING_ID")]
+    pub finding: Option<String>,
+    /// Review verdict: mark the finding ACCEPTED (acknowledged, action pending). Requires
+    /// `<FINDING_ID>`.
+    #[arg(long, conflicts_with_all = ["dismiss", "reset"])]
+    pub accept: bool,
+    /// Review verdict: DISMISS the finding (false positive / won't-fix) — hidden from the default
+    /// worklist. Requires `<FINDING_ID>`.
+    #[arg(long, conflicts_with_all = ["accept", "reset"])]
+    pub dismiss: bool,
+    /// Review verdict: RESET a previously accepted/dismissed finding back to open. Requires
+    /// `<FINDING_ID>`.
+    #[arg(long, conflicts_with_all = ["accept", "dismiss"])]
+    pub reset: bool,
+    /// In the worklist listing, ALSO show human-reviewed findings (accepted / dismissed), not just
+    /// open — so you can see (and `--reset`) what you previously reviewed.
+    #[arg(long)]
+    pub all: bool,
 }
 
 #[derive(Debug, Args)]

--- a/crates/rag-rat-cli/src/commands/memory.rs
+++ b/crates/rag-rat-cli/src/commands/memory.rs
@@ -35,10 +35,41 @@ pub(crate) fn dream(config: &Config, args: &DreamArgs) -> anyhow::Result<()> {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as i64)
         .unwrap_or(0);
+
+    // REVIEW mode: `rag-rat dream <FINDING_ID> --accept|--dismiss|--reset` applies a human verdict
+    // to ONE finding and prints it — it does NOT run the worklist/model passes. The verdict is
+    // preserved across future runs (the sync refresh keeps accepted/dismissed).
+    if let Some(finding) = &args.finding {
+        let verdict = match (args.accept, args.dismiss, args.reset) {
+            (true, false, false) => rag_rat_core::dream::ReviewVerdict::Accept,
+            (false, true, false) => rag_rat_core::dream::ReviewVerdict::Dismiss,
+            (false, false, true) => rag_rat_core::dream::ReviewVerdict::Reset,
+            _ => anyhow::bail!(
+                "reviewing `{finding}` needs exactly one of --accept / --dismiss / --reset"
+            ),
+        };
+        if args.verify || args.compact {
+            anyhow::bail!(
+                "--verify / --compact run the worklist; they can't combine with reviewing a \
+                 finding"
+            );
+        }
+        let reviewed = db.review_dream_finding(finding, verdict, now_ms)?;
+        return print_output(&reviewed);
+    }
+    // A verdict flag with no finding id is a mistake (clap keeps the three verdicts mutually
+    // exclusive; this catches "flag but no id").
+    if args.accept || args.dismiss || args.reset {
+        anyhow::bail!("--accept / --dismiss / --reset need a <FINDING_ID> to review");
+    }
+
     let opts = rag_rat_core::dream::DreamOptions {
         now_ms,
         limit: args.limit.unwrap_or(20) as usize,
         verify: args.verify,
+        // `--all` also lists the human-reviewed (accepted/dismissed) findings, so you can see and
+        // `--reset` them; the default worklist is the open (needs-attention) set.
+        include_reviewed: args.all,
     };
     // The model passes run only when the operator asked for the matching flag AND enabled the model
     // in config — the generative-model dependency stays strictly opt-in (#122). One client is built

--- a/crates/rag-rat-cli/tests/multi_repo_e2e.rs
+++ b/crates/rag-rat-cli/tests/multi_repo_e2e.rs
@@ -1000,7 +1000,12 @@ fn dream_worklist_is_repo_scoped_end_to_end() {
     // Cover the IndexDatabase `dream_model_work_pending` wrapper — the ephemeral zero-work-guard
     // seam the `dream` command consults before cold-starting a paid GPU box. A has an active,
     // never-verified memory, so the model pass has pending work (repo-scoped to A).
-    let work_opts = rag_rat_core::dream::DreamOptions { now_ms: 0, limit: 20, verify: true };
+    let work_opts = rag_rat_core::dream::DreamOptions {
+        now_ms: 0,
+        limit: 20,
+        verify: true,
+        include_reviewed: false,
+    };
     assert!(
         open_scoped(&repo_a, &data_dir)
             .dream_model_work_pending(work_opts, 20, true, true)

--- a/crates/rag-rat-core/src/dream/findings.rs
+++ b/crates/rag-rat-core/src/dream/findings.rs
@@ -365,8 +365,9 @@ pub struct ReviewedFinding {
 /// `reviewed_at_ms`; `Reset` clears the human verdict (back to `open`, `reviewed_at_ms` NULL). The
 /// verdict SURVIVES churn re-runs — [`sync`]'s refresh branch preserves `accepted`/`dismissed`.
 ///
-/// Prefix resolution scans the active repo's reviewable findings (a small set) and matches in Rust,
-/// so a `_`/`%` in the input can't act as a SQL `LIKE` wildcard.
+/// Prefix resolution scans ALL of the active repo's findings (a small set) and matches in Rust — so
+/// a `_`/`%` in the input can't act as a SQL `LIKE` wildcard, AND a prefix that also hits a
+/// terminal row is rejected as ambiguous rather than silently acting on the one reviewable match.
 pub(crate) fn review_dream_finding(
     conn: &Connection,
     id_or_prefix: &str,
@@ -379,36 +380,30 @@ pub(crate) fn review_dream_finding(
     }
     let scope = dream_repo_scope(conn)?;
     let repo_clause = dream_repo_scope_clause(&scope);
-    let reviewable: Vec<(String, String, String)> = conn
+    // Match the prefix against ALL of this repo's findings — reviewable AND terminal
+    // (resolved/superseded/archived). A prefix that also hits a terminal row is NOT unambiguous
+    // even if only one match is reviewable, so a stale short prefix can never silently act on a
+    // *different* open finding than the one the user remembers. `WHERE 1` + `{repo_clause}` (which
+    // starts with ` AND`) keeps every status in scope.
+    let all: Vec<(String, String, String, String)> = conn
         .prepare(&format!(
-            "SELECT id, kind, subject FROM dream_findings WHERE status IN \
-             ('open','accepted','dismissed'){repo_clause} ORDER BY id"
+            "SELECT id, kind, subject, status FROM dream_findings WHERE 1{repo_clause} ORDER BY id"
         ))?
-        .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))?
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)))?
         .collect::<rusqlite::Result<_>>()?;
-    let matches: Vec<&(String, String, String)> =
-        reviewable.iter().filter(|(id, ..)| id.starts_with(prefix)).collect();
+    let matches: Vec<&(String, String, String, String)> =
+        all.iter().filter(|(id, ..)| id.starts_with(prefix)).collect();
     let (id, kind, subject) = match matches.as_slice() {
-        [one] => (*one).clone(),
-        [] => {
-            // Distinguish "no such id" from "matched a TERMINAL (non-reviewable) finding".
-            let terminal: bool = conn
-                .prepare(&format!(
-                    "SELECT id FROM dream_findings WHERE status IN \
-                     ('resolved','superseded','archived'){repo_clause}"
-                ))?
-                .query_map([], |r| r.get::<_, String>(0))?
-                .collect::<rusqlite::Result<Vec<_>>>()?
-                .iter()
-                .any(|id| id.starts_with(prefix));
-            if terminal {
+        [(id, kind, subject, status)] => {
+            if !matches!(status.as_str(), "open" | "accepted" | "dismissed") {
                 anyhow::bail!(
-                    "finding `{prefix}` is resolved/superseded/archived — not reviewable (the \
-                     code moved on; there's nothing to act on)"
+                    "finding `{prefix}` is {status} — not reviewable (the code moved on; there's \
+                     nothing to act on)"
                 );
             }
-            anyhow::bail!("no open/accepted/dismissed finding matches id `{prefix}`");
+            (id.clone(), kind.clone(), subject.clone())
         },
+        [] => anyhow::bail!("no finding matches id `{prefix}`"),
         many => {
             let ids = many.iter().map(|(id, ..)| id.as_str()).collect::<Vec<_>>().join(", ");
             anyhow::bail!("id `{prefix}` is ambiguous — matches {} findings: {ids}", many.len());
@@ -531,9 +526,32 @@ mod tests {
             "zzz999"
         );
         let none = review_dream_finding(&c, "qqq", ReviewVerdict::Accept, 10).unwrap_err();
-        assert!(none.to_string().contains("no open"), "got: {none}");
+        assert!(none.to_string().contains("no finding matches"), "got: {none}");
         let amb = review_dream_finding(&c, "abc", ReviewVerdict::Accept, 10).unwrap_err();
         assert!(amb.to_string().contains("ambiguous"), "got: {amb}");
+    }
+
+    #[test]
+    fn review_prefix_that_also_hits_a_terminal_finding_is_ambiguous() {
+        // A stale short prefix that matches BOTH an open and a resolved finding must be rejected as
+        // ambiguous — never silently act on the open one (PR #440 review). The match considers ALL
+        // findings, not just the reviewable set.
+        let c = mem_db();
+        set_repo(&c, "r");
+        for (id, subj, status) in [("abcd11", "s1", "open"), ("abcd22", "s2", "resolved")] {
+            c.execute(
+                "INSERT INTO dream_findings(repo_id, id, kind, subject, claim_hash, evidence, \
+                 base_rank, status, first_seen_at_ms, last_seen_at_ms) \
+                 VALUES('r',?1,'coverage_gap',?2,'ch',?2,0.5,?3,1,1)",
+                rusqlite::params![id, subj, status],
+            )
+            .unwrap();
+        }
+        let err = review_dream_finding(&c, "abcd", ReviewVerdict::Dismiss, 10).unwrap_err();
+        assert!(err.to_string().contains("ambiguous"), "got: {err}");
+        // the open finding must be untouched
+        let (status, _) = status_and_reviewed(&c, "abcd11");
+        assert_eq!(status, "open", "the open finding was not silently dismissed");
     }
 
     #[test]
@@ -544,7 +562,7 @@ mod tests {
         let id = seed_one_finding(&c, "x::F", 1000);
         set_repo(&c, "repo-b");
         let err = review_dream_finding(&c, &id, ReviewVerdict::Dismiss, 2000).unwrap_err();
-        assert!(err.to_string().contains("no open"), "got: {err}");
+        assert!(err.to_string().contains("no finding matches"), "got: {err}");
         set_repo(&c, "repo-a");
         assert_eq!(status_and_reviewed(&c, &id).0, "open", "repo-a's finding is untouched");
     }

--- a/crates/rag-rat-core/src/dream/findings.rs
+++ b/crates/rag-rat-core/src/dream/findings.rs
@@ -7,6 +7,7 @@ use std::collections::HashSet;
 
 use regex::Regex;
 use rusqlite::Connection;
+use serde::Serialize;
 use sha2::{Digest, Sha256};
 
 use super::DreamFinding;
@@ -339,10 +340,214 @@ fn sync_in_tx(
     Ok((opened, refreshed, superseded, resolved))
 }
 
+/// The human verdict a reviewer applies to a dream finding via
+/// `rag-rat dream <id> --accept|--dismiss|--reset`.
+#[derive(Debug, Clone, Copy)]
+pub enum ReviewVerdict {
+    Accept,
+    Dismiss,
+    Reset,
+}
+
+/// The outcome of a review transition, echoed back to the operator.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReviewedFinding {
+    pub id: String,
+    pub kind: String,
+    pub subject: String,
+    pub status: String,
+}
+
+/// Apply a human review verdict to a dream finding by id — a full id or an unambiguous PREFIX
+/// (git-style). Repo-scoped: only the active repo's findings resolve. Only a NON-terminal finding
+/// (status `open`/`accepted`/`dismissed`) is reviewable — a `resolved`/`superseded`/`archived` row
+/// is rejected (the world moved on; nothing to act on). `Accept`/`Dismiss` set the status +
+/// `reviewed_at_ms`; `Reset` clears the human verdict (back to `open`, `reviewed_at_ms` NULL). The
+/// verdict SURVIVES churn re-runs — [`sync`]'s refresh branch preserves `accepted`/`dismissed`.
+///
+/// Prefix resolution scans the active repo's reviewable findings (a small set) and matches in Rust,
+/// so a `_`/`%` in the input can't act as a SQL `LIKE` wildcard.
+pub(crate) fn review_dream_finding(
+    conn: &Connection,
+    id_or_prefix: &str,
+    verdict: ReviewVerdict,
+    now_ms: i64,
+) -> anyhow::Result<ReviewedFinding> {
+    let prefix = id_or_prefix.trim();
+    if prefix.is_empty() {
+        anyhow::bail!("a finding id is required");
+    }
+    let scope = dream_repo_scope(conn)?;
+    let repo_clause = dream_repo_scope_clause(&scope);
+    let reviewable: Vec<(String, String, String)> = conn
+        .prepare(&format!(
+            "SELECT id, kind, subject FROM dream_findings WHERE status IN \
+             ('open','accepted','dismissed'){repo_clause} ORDER BY id"
+        ))?
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))?
+        .collect::<rusqlite::Result<_>>()?;
+    let matches: Vec<&(String, String, String)> =
+        reviewable.iter().filter(|(id, ..)| id.starts_with(prefix)).collect();
+    let (id, kind, subject) = match matches.as_slice() {
+        [one] => (*one).clone(),
+        [] => {
+            // Distinguish "no such id" from "matched a TERMINAL (non-reviewable) finding".
+            let terminal: bool = conn
+                .prepare(&format!(
+                    "SELECT id FROM dream_findings WHERE status IN \
+                     ('resolved','superseded','archived'){repo_clause}"
+                ))?
+                .query_map([], |r| r.get::<_, String>(0))?
+                .collect::<rusqlite::Result<Vec<_>>>()?
+                .iter()
+                .any(|id| id.starts_with(prefix));
+            if terminal {
+                anyhow::bail!(
+                    "finding `{prefix}` is resolved/superseded/archived — not reviewable (the \
+                     code moved on; there's nothing to act on)"
+                );
+            }
+            anyhow::bail!("no open/accepted/dismissed finding matches id `{prefix}`");
+        },
+        many => {
+            let ids = many.iter().map(|(id, ..)| id.as_str()).collect::<Vec<_>>().join(", ");
+            anyhow::bail!("id `{prefix}` is ambiguous — matches {} findings: {ids}", many.len());
+        },
+    };
+    let new_status = match verdict {
+        ReviewVerdict::Accept => "accepted",
+        ReviewVerdict::Dismiss => "dismissed",
+        ReviewVerdict::Reset => "open",
+    };
+    // Reset clears the human verdict; accept/dismiss stamp when it was reviewed.
+    let reviewed_at = match verdict {
+        ReviewVerdict::Reset => None,
+        _ => Some(now_ms),
+    };
+    conn.execute(
+        &format!(
+            "UPDATE dream_findings SET status = ?2, reviewed_at_ms = ?3 WHERE id = ?1{repo_clause}"
+        ),
+        rusqlite::params![id, new_status, reviewed_at],
+    )?;
+    Ok(ReviewedFinding { id, kind, subject, status: new_status.to_string() })
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::tests::{mem_db, set_repo};
     use super::*;
+
+    // A single coverage_gap finding, synced into the active repo; returns its id.
+    fn seed_one_finding(c: &Connection, subject: &str, now_ms: i64) -> String {
+        let f = vec![DreamFinding {
+            kind: "coverage_gap".into(),
+            subject: subject.into(),
+            evidence: "7 callers".into(),
+            rank: 0.5,
+        }];
+        sync(c, &f, now_ms, BASE_FINDING_KINDS).unwrap();
+        // By subject alone (not status): a re-sync after a review leaves the row non-'open', and
+        // the caller still needs its id.
+        c.query_row("SELECT id FROM dream_findings WHERE subject = ?1", [subject], |r| r.get(0))
+            .unwrap()
+    }
+
+    fn status_and_reviewed(c: &Connection, id: &str) -> (String, Option<i64>) {
+        c.query_row("SELECT status, reviewed_at_ms FROM dream_findings WHERE id = ?1", [id], |r| {
+            Ok((r.get(0)?, r.get(1)?))
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn review_accept_dismiss_reset_toggle_status_and_reviewed_at() {
+        // The human-review transitions (#262): the write-dead accepted/dismissed/reviewed_at_ms
+        // fields are now set. Reset clears the human verdict entirely (back to open, timestamp
+        // NULL).
+        let c = mem_db();
+        set_repo(&c, "r");
+        let id = seed_one_finding(&c, "x::F", 1000);
+        assert_eq!(status_and_reviewed(&c, &id), ("open".into(), None));
+
+        let r = review_dream_finding(&c, &id, ReviewVerdict::Accept, 2000).unwrap();
+        assert_eq!(r.status, "accepted");
+        assert_eq!(status_and_reviewed(&c, &id), ("accepted".into(), Some(2000)));
+
+        review_dream_finding(&c, &id, ReviewVerdict::Dismiss, 3000).unwrap();
+        assert_eq!(status_and_reviewed(&c, &id), ("dismissed".into(), Some(3000)));
+
+        review_dream_finding(&c, &id, ReviewVerdict::Reset, 4000).unwrap();
+        assert_eq!(status_and_reviewed(&c, &id), ("open".into(), None), "reset clears the verdict");
+    }
+
+    #[test]
+    fn review_verdict_survives_a_refresh() {
+        // #262 depends on this: a re-run that STILL reports the finding must not revert the human
+        // verdict — sync's refresh branch keeps accepted/dismissed.
+        let c = mem_db();
+        set_repo(&c, "r");
+        let id = seed_one_finding(&c, "x::F", 1000);
+        review_dream_finding(&c, &id, ReviewVerdict::Accept, 2000).unwrap();
+        // re-sync the same finding (a refresh)
+        seed_one_finding(&c, "x::F", 3000);
+        assert_eq!(
+            status_and_reviewed(&c, &id).0,
+            "accepted",
+            "refresh preserves the human verdict"
+        );
+    }
+
+    #[test]
+    fn review_rejects_a_terminal_finding() {
+        // A resolved/superseded/archived finding is not reviewable — the code moved on.
+        let c = mem_db();
+        set_repo(&c, "r");
+        let id = seed_one_finding(&c, "x::F", 1000);
+        // A run that reports nothing resolves the open finding.
+        sync(&c, &[], 2000, BASE_FINDING_KINDS).unwrap();
+        assert_eq!(status_and_reviewed(&c, &id).0, "resolved");
+        let err = review_dream_finding(&c, &id, ReviewVerdict::Accept, 3000).unwrap_err();
+        assert!(err.to_string().contains("not reviewable"), "got: {err}");
+    }
+
+    #[test]
+    fn review_prefix_matches_uniquely_and_errors_on_none_or_ambiguous() {
+        // Real ids are sha256 hex (no forceable shared prefix), so insert controlled ids to
+        // exercise the git-style prefix resolution.
+        let c = mem_db();
+        set_repo(&c, "r");
+        for (id, subj) in [("abc111", "s1"), ("abc222", "s2"), ("zzz999", "s3")] {
+            c.execute(
+                "INSERT INTO dream_findings(repo_id, id, kind, subject, claim_hash, evidence, \
+                 base_rank, status, first_seen_at_ms, last_seen_at_ms) \
+                 VALUES('r',?1,'coverage_gap',?2,'ch','e',0.5,'open',1,1)",
+                rusqlite::params![id, subj],
+            )
+            .unwrap();
+        }
+        assert_eq!(
+            review_dream_finding(&c, "zzz", ReviewVerdict::Accept, 10).unwrap().id,
+            "zzz999"
+        );
+        let none = review_dream_finding(&c, "qqq", ReviewVerdict::Accept, 10).unwrap_err();
+        assert!(none.to_string().contains("no open"), "got: {none}");
+        let amb = review_dream_finding(&c, "abc", ReviewVerdict::Accept, 10).unwrap_err();
+        assert!(amb.to_string().contains("ambiguous"), "got: {amb}");
+    }
+
+    #[test]
+    fn review_is_repo_scoped() {
+        // A finding in repo-a is invisible to (and untouched by) a review run in repo-b.
+        let c = mem_db();
+        set_repo(&c, "repo-a");
+        let id = seed_one_finding(&c, "x::F", 1000);
+        set_repo(&c, "repo-b");
+        let err = review_dream_finding(&c, &id, ReviewVerdict::Dismiss, 2000).unwrap_err();
+        assert!(err.to_string().contains("no open"), "got: {err}");
+        set_repo(&c, "repo-a");
+        assert_eq!(status_and_reviewed(&c, &id).0, "open", "repo-a's finding is untouched");
+    }
 
     /// A5 finding: `finding_id` folds the owning repo. Two repos minting the SAME
     /// `(kind, subject, claim_hash)` derive DISTINCT ids — a repo-blind id would make the second

--- a/crates/rag-rat-core/src/dream/mod.rs
+++ b/crates/rag-rat-core/src/dream/mod.rs
@@ -39,7 +39,8 @@ pub use compact::CompactPass;
 // Curated crate-facing surface (mod.rs is the index, not the junk drawer): the migration
 // ladder and `register_repo` adoption re-derive persisted finding ids after re-stamping
 // `repo_id`.
-pub(crate) use findings::rederive_finding_ids;
+pub use findings::{ReviewVerdict, ReviewedFinding};
+pub(crate) use findings::{rederive_finding_ids, review_dream_finding};
 // The phase-B model verdict pass: the out-of-process verdict-model trait + its HTTP client
 // (the CLI builds one from `[llm.dream.remote]`) and the `VerdictPass` handle
 // `dream_run_with_passes` consumes.
@@ -58,6 +59,9 @@ pub use verify::{
 };
 pub(crate) use verify::{checked_inputs_hash, note_content_hash};
 
+/// A finding as PRODUCED by a finding kind (`coverage_gap` / `stale_reference` /
+/// `memory_unverifiable` / `memory_divergence`) — the INPUT to [`findings::sync`], which derives
+/// the stable id. It carries no id/status because neither exists until the sync writes the row.
 #[derive(Debug, Clone, Serialize)]
 pub struct DreamFinding {
     pub kind: String,
@@ -66,9 +70,23 @@ pub struct DreamFinding {
     pub rank: f64,
 }
 
+/// A finding as EMITTED in the worklist (post-sync), carrying the stable `dream_findings.id` a
+/// reviewer passes to `rag-rat dream <id> --accept|--dismiss|--reset`, plus its `status` (`open` in
+/// the default worklist; `accepted`/`dismissed` also shown under `--all`).
+#[derive(Debug, Clone, Serialize)]
+pub struct WorklistFinding {
+    pub id: String,
+    pub kind: String,
+    pub subject: String,
+    pub evidence: String,
+    pub rank: f64,
+    pub status: String,
+}
+
 #[derive(Debug, Default, Serialize)]
 pub struct DreamReport {
-    pub findings: Vec<DreamFinding>, // the open worklist, ranked
+    pub findings: Vec<WorklistFinding>, /* the worklist (open, ranked; + accepted/dismissed
+                                         * under --all) */
     pub opened: usize,
     pub refreshed: usize,
     pub superseded: usize,
@@ -84,6 +102,10 @@ pub struct DreamOptions {
     /// OFF by default so plain `rag-rat dream` stays byte-identical to the v1 run; the model
     /// verdict / compaction passes (phases B/C) layer on top of the same `verify` substrate.
     pub verify: bool,
+    /// Also emit the human-reviewed findings (`accepted` / `dismissed`) in the worklist, not just
+    /// `open` — the `--all` listing, so a reviewer can see (and `--reset`) a finding they
+    /// previously dismissed. Off by default: the worklist is the "needs attention" (open) set.
+    pub include_reviewed: bool,
 }
 
 /// Half-life for worklist rank decay: an unreviewed finding loses half its rank every 2 weeks, so a
@@ -135,19 +157,28 @@ pub fn dream_run(conn: &Connection, opts: DreamOptions) -> rusqlite::Result<Drea
     // sinks below fresh ones (the documented anti-rot, now real, not just base_rank DESC). Scoped
     // to the active repo so the emitted worklist never mixes in a sibling repo's open findings.
     let repo_clause = findings::dream_repo_scope_clause(&findings::dream_repo_scope(conn)?);
-    let mut open: Vec<DreamFinding> = conn
+    // Default worklist = the 'open' (needs-attention) set. `--all` (include_reviewed) also surfaces
+    // the human-reviewed 'accepted'/'dismissed' rows so a reviewer can see + `--reset` them.
+    let status_filter = if opts.include_reviewed {
+        "status IN ('open','accepted','dismissed')"
+    } else {
+        "status = 'open'"
+    };
+    let mut open: Vec<WorklistFinding> = conn
         .prepare(&format!(
-            "SELECT kind, subject, evidence, base_rank, first_seen_at_ms FROM dream_findings \
-             WHERE status = 'open'{repo_clause}"
+            "SELECT id, kind, subject, evidence, base_rank, first_seen_at_ms, status FROM \
+             dream_findings WHERE {status_filter}{repo_clause}"
         ))?
         .query_map([], |r| {
-            let base: f64 = r.get(3)?;
-            let first_seen: i64 = r.get(4)?;
-            Ok(DreamFinding {
-                kind: r.get(0)?,
-                subject: r.get(1)?,
-                evidence: r.get(2)?,
+            let base: f64 = r.get(4)?;
+            let first_seen: i64 = r.get(5)?;
+            Ok(WorklistFinding {
+                id: r.get(0)?,
+                kind: r.get(1)?,
+                subject: r.get(2)?,
+                evidence: r.get(3)?,
                 rank: effective_rank(base, first_seen, opts.now_ms),
+                status: r.get(6)?,
             })
         })?
         .collect::<rusqlite::Result<_>>()?;
@@ -257,6 +288,55 @@ pub(super) mod tests {
     }
 
     #[test]
+    fn worklist_surfaces_ids_and_hides_dismissed_unless_include_reviewed() {
+        // memory_divergence is a VERIFY finding kind: a plain dream_run(verify=false) neither
+        // recomputes nor resolves it (resolve is kind-scoped to the kinds the run computed), so
+        // these synthetic rows survive the run — isolating the emit's id surfacing + status
+        // filter.
+        let c = mem_db();
+        set_repo(&c, "r");
+        for (id, subj, status) in [("d0001", "mA", "open"), ("d0002", "mB", "dismissed")] {
+            c.execute(
+                "INSERT INTO dream_findings(repo_id, id, kind, subject, claim_hash, evidence, \
+                 base_rank, status, first_seen_at_ms, last_seen_at_ms) \
+                 VALUES('r',?1,'memory_divergence',?2,'ch',?2,0.6,?3,1,1)",
+                rusqlite::params![id, subj, status],
+            )
+            .unwrap();
+        }
+        let default = dream_run(&c, DreamOptions {
+            now_ms: 10,
+            limit: 10,
+            verify: false,
+            include_reviewed: false,
+        })
+        .unwrap();
+        assert_eq!(
+            default.findings.iter().map(|f| f.subject.as_str()).collect::<Vec<_>>(),
+            vec!["mA"],
+            "the default worklist shows only open findings",
+        );
+        assert_eq!(default.findings[0].id, "d0001", "the stable finding id is surfaced");
+        assert_eq!(default.findings[0].status, "open");
+
+        let all = dream_run(&c, DreamOptions {
+            now_ms: 10,
+            limit: 10,
+            verify: false,
+            include_reviewed: true,
+        })
+        .unwrap();
+        let mut pairs: Vec<(&str, &str)> =
+            all.findings.iter().map(|f| (f.subject.as_str(), f.status.as_str())).collect();
+        pairs.sort();
+        assert_eq!(
+            pairs,
+            vec![("mA", "open"), ("mB", "dismissed")],
+            "--all also surfaces the human-reviewed (dismissed) finding, with its status",
+        );
+    }
+
+    #[test]
     fn dream_run_never_mutates_any_memory_column() {
         let c = mem_db();
         // seed a memory whose body references a gone path so stale_reference is forced to READ it
@@ -299,7 +379,13 @@ pub(super) mod tests {
         // Run with the verification pass ON so the new pass-0 reads/writes are covered by the
         // invariant (memory_reality / memory_summaries writes are ALLOWED; repo_memories must stay
         // byte-identical).
-        let report = dream_run(&c, DreamOptions { now_ms: 1000, limit: 10, verify: true }).unwrap();
+        let report = dream_run(&c, DreamOptions {
+            now_ms: 1000,
+            limit: 10,
+            verify: true,
+            include_reviewed: false,
+        })
+        .unwrap();
         assert_eq!(before, snap(&c), "dream_run must leave EVERY repo_memories column unchanged");
         assert!(
             report.findings.iter().any(|f| f.kind == "stale_reference" && f.subject == "m1"),
@@ -323,8 +409,13 @@ pub(super) mod tests {
         )
         .unwrap();
         // verify OFF: no memory_unverifiable finding is emitted (v1-identical worklist).
-        let report =
-            dream_run(&c, DreamOptions { now_ms: 1000, limit: 10, verify: false }).unwrap();
+        let report = dream_run(&c, DreamOptions {
+            now_ms: 1000,
+            limit: 10,
+            verify: false,
+            include_reviewed: false,
+        })
+        .unwrap();
         assert!(
             !report.findings.iter().any(|f| f.kind == "memory_unverifiable"),
             "the verify pass must be dormant when DreamOptions::verify is false"

--- a/crates/rag-rat-core/src/dream/verdict.rs
+++ b/crates/rag-rat-core/src/dream/verdict.rs
@@ -961,7 +961,7 @@ mod tests {
 
     // ── divergence-finding lifecycle (the resolve trap) ──────────────────────────
 
-    fn divergence_subjects(findings: &[DreamFinding]) -> Vec<String> {
+    fn divergence_subjects(findings: &[crate::dream::WorklistFinding]) -> Vec<String> {
         findings
             .iter()
             .filter(|f| f.kind == "memory_divergence")
@@ -978,7 +978,7 @@ mod tests {
             diverged_citing("resolvable_thing"), // run 1: opens the divergence finding
             current_citing("resolvable_thing"),  // run 3 (after body edit): flips to current
         ]);
-        let opts = DreamOptions { now_ms: 1000, limit: 10, verify: true };
+        let opts = DreamOptions { now_ms: 1000, limit: 10, verify: true, include_reviewed: false };
 
         // Run 1: diverged verdict → memory_divergence finding opens.
         let r1 =
@@ -1037,7 +1037,8 @@ mod tests {
 
         let c = seeded_verifiable_repo();
         let model = MockVerdictModel::new([diverged_citing("resolvable_thing")]);
-        let verify_opts = DreamOptions { now_ms: 1000, limit: 10, verify: true };
+        let verify_opts =
+            DreamOptions { now_ms: 1000, limit: 10, verify: true, include_reviewed: false };
         let r1 = dream_run_with_passes(
             &c,
             verify_opts,
@@ -1050,7 +1051,8 @@ mod tests {
         // A plain deterministic run (verify OFF): the divergence kind is not computed, so its open
         // finding is left untouched — not resolved as "no longer seen". The emitted worklist reads
         // ALL open findings from the store, so the still-open divergence finding is still listed.
-        let plain_opts = DreamOptions { now_ms: 2000, limit: 10, verify: false };
+        let plain_opts =
+            DreamOptions { now_ms: 2000, limit: 10, verify: false, include_reviewed: false };
         let r2 = dream_run(&c, plain_opts).unwrap();
         assert_eq!(
             divergence_subjects(&r2.findings),
@@ -1077,7 +1079,8 @@ mod tests {
 
         let c = seeded_verifiable_repo();
         let model = MockVerdictModel::new([diverged_citing("resolvable_thing")]);
-        let verify_opts = DreamOptions { now_ms: 1000, limit: 10, verify: true };
+        let verify_opts =
+            DreamOptions { now_ms: 1000, limit: 10, verify: true, include_reviewed: false };
         dream_run_with_passes(
             &c,
             verify_opts,
@@ -1095,7 +1098,13 @@ mod tests {
             [],
         )
         .unwrap();
-        let r = dream_run(&c, DreamOptions { now_ms: 2000, limit: 10, verify: true }).unwrap();
+        let r = dream_run(&c, DreamOptions {
+            now_ms: 2000,
+            limit: 10,
+            verify: true,
+            include_reviewed: false,
+        })
+        .unwrap();
         assert!(
             divergence_subjects(&r.findings).is_empty(),
             "a diverged verdict against the pre-edit body is not surfaced against the new note"
@@ -1123,7 +1132,7 @@ mod tests {
         let model = MockVerdictModel::new([diverged_citing("resolvable_thing")]);
         dream_run_with_passes(
             &c,
-            DreamOptions { now_ms: 1000, limit: 10, verify: true },
+            DreamOptions { now_ms: 1000, limit: 10, verify: true, include_reviewed: false },
             Some(VerdictPass { model: &model, budget: 10 }),
             None,
         )
@@ -1137,7 +1146,13 @@ mod tests {
             [],
         )
         .unwrap();
-        let r = dream_run(&c, DreamOptions { now_ms: 2000, limit: 10, verify: true }).unwrap();
+        let r = dream_run(&c, DreamOptions {
+            now_ms: 2000,
+            limit: 10,
+            verify: true,
+            include_reviewed: false,
+        })
+        .unwrap();
         assert!(
             divergence_subjects(&r.findings).is_empty(),
             "a diverged verdict from an obsolete prompt is not surfaced"
@@ -1168,7 +1183,7 @@ mod tests {
         };
         let before = snap(&c);
         let model = MockVerdictModel::new([diverged_citing("resolvable_thing")]);
-        let opts = DreamOptions { now_ms: 1000, limit: 10, verify: true };
+        let opts = DreamOptions { now_ms: 1000, limit: 10, verify: true, include_reviewed: false };
         dream_run_with_passes(&c, opts, Some(VerdictPass { model: &model, budget: 10 }), None)
             .unwrap();
         assert_eq!(before, snap(&c), "the model verdict pass leaves repo_memories byte-identical");
@@ -1207,7 +1222,7 @@ mod tests {
         seed_symbol_file(&c, "src/b.rs", "thing_two", "r2");
         seed_memory(&c, "m2", "note", "describes `thing_two`", "r2");
         let model_r2 = MockVerdictModel::new([current_citing("thing_two")]);
-        let opts = DreamOptions { now_ms: 2000, limit: 10, verify: true };
+        let opts = DreamOptions { now_ms: 2000, limit: 10, verify: true, include_reviewed: false };
         let r2 = dream_run_with_passes(
             &c,
             opts,
@@ -1243,6 +1258,11 @@ mod tests {
         // And back in r1, its divergence finding is intact.
         set_repo(&c, "r1");
         let r1_divergence = divergence_findings(&c).unwrap();
-        assert_eq!(divergence_subjects(&r1_divergence), vec!["m1".to_string()]);
+        // `divergence_findings` already returns only `memory_divergence` rows, so map subjects
+        // directly (the `divergence_subjects` helper is for the WorklistFinding-typed dream_run
+        // output).
+        assert_eq!(r1_divergence.iter().map(|f| f.subject.clone()).collect::<Vec<_>>(), vec![
+            "m1".to_string()
+        ]);
     }
 }

--- a/crates/rag-rat-core/src/dream/verify.rs
+++ b/crates/rag-rat-core/src/dream/verify.rs
@@ -789,7 +789,12 @@ mod tests {
         // pending.
         let c = mem_db();
         set_repo(&c, "r");
-        let opts = crate::dream::DreamOptions { now_ms: 1, limit: 10, verify: true };
+        let opts = crate::dream::DreamOptions {
+            now_ms: 1,
+            limit: 10,
+            verify: true,
+            include_reviewed: false,
+        };
         assert!(
             !crate::dream::model_work_pending(&c, opts, 10, true, true).unwrap(),
             "empty repo → no work"

--- a/crates/rag-rat-core/src/index/query_api/dream.rs
+++ b/crates/rag-rat-core/src/index/query_api/dream.rs
@@ -42,4 +42,16 @@ impl IndexDatabase {
     ) -> anyhow::Result<bool> {
         crate::dream::model_work_pending(self.storage.connection(), opts, budget, verify, compact)
     }
+
+    /// Apply a human review verdict (accept / dismiss / reset) to a dream finding by id or prefix —
+    /// the `rag-rat dream <id> --accept|--dismiss|--reset` surface. Repo-scoped; only a
+    /// non-terminal finding is reviewable. See [`crate::dream::review_dream_finding`].
+    pub fn review_dream_finding(
+        &self,
+        id_or_prefix: &str,
+        verdict: crate::dream::ReviewVerdict,
+        now_ms: i64,
+    ) -> anyhow::Result<crate::dream::ReviewedFinding> {
+        crate::dream::review_dream_finding(self.storage.connection(), id_or_prefix, verdict, now_ms)
+    }
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
@@ -1334,8 +1334,13 @@ fn dream_run_leaves_a_sibling_repos_findings_untouched() {
     // Run dream on repo A. Its (empty) index reports nothing this run, so the resolve pass resolves
     // repo A's own unreported finding — but repo B's finding must be left OPEN and unemitted.
     a5_set_active_repo(&conn, A5_REPO_A);
-    let report =
-        dream_run(&conn, DreamOptions { limit: 50, now_ms: 1_000, verify: false }).unwrap();
+    let report = dream_run(&conn, DreamOptions {
+        limit: 50,
+        now_ms: 1_000,
+        verify: false,
+        include_reviewed: false,
+    })
+    .unwrap();
 
     let a_status: String = conn
         .query_row("SELECT status FROM dream_findings WHERE id = 'a-open'", [], |r| r.get(0))
@@ -1426,8 +1431,13 @@ fn dream_candidate_builders_ignore_a_sibling_repos_memories() {
     .unwrap();
 
     a5_set_active_repo(&conn, A5_REPO_A);
-    let report =
-        dream_run(&conn, DreamOptions { limit: 10, now_ms: 1_000, verify: false }).unwrap();
+    let report = dream_run(&conn, DreamOptions {
+        limit: 10,
+        now_ms: 1_000,
+        verify: false,
+        include_reviewed: false,
+    })
+    .unwrap();
 
     assert!(
         report

--- a/docs/config.md
+++ b/docs/config.md
@@ -435,6 +435,25 @@ reference it cites must resolve in the indexed papertrail); a failing summary is
 dropped (no row is stored, so the surface falls back to the title). The pass **never** writes a
 `repo_memories` column.
 
+### Reviewing findings (`rag-rat dream <id> --accept|--dismiss|--reset`)
+
+The worklist `rag-rat dream` prints carries a stable `id` per finding. Dream only *proposes*; a
+human (or strong agent) resolves a finding by that id — a full id or an unambiguous prefix
+(git-style):
+
+```bash
+rag-rat dream                     # print the open worklist (each row has an id + status)
+rag-rat dream 3f9a1c22 --accept   # acknowledge it (real, action pending)
+rag-rat dream 3f9a1c22 --dismiss  # a false positive / won't-fix — hidden from the worklist
+rag-rat dream 3f9a1c22 --reset    # undo a verdict, back to open
+rag-rat dream --all               # also list the accepted/dismissed findings (to find one to --reset)
+```
+
+A verdict is **preserved across future runs**: a re-run that still reports the finding keeps your
+`accepted`/`dismissed` decision, while a finding the code makes obsolete resolves on its own. Only an
+`open`/`accepted`/`dismissed` finding is reviewable — a `resolved`/`superseded` one is not (the code
+moved on, so there is nothing to act on). Reviewing is repo-scoped and never runs the model.
+
 ## Memory surfacing (`[memory] surface`)
 
 `[memory] surface` controls how drive-by memory attachments render. The default is `full`


### PR DESCRIPTION
The dream finding lifecycle already stored `accepted`/`dismissed`/`reviewed_at_ms`, but only the *machine* transitions (open/refresh/supersede/resolve) were wired — the human-verdict fields were write-dead. This builds the human-in-the-loop review surface the design depends on: dream **proposes**, a human **decides**.

## What's new

- **The worklist surfaces a stable `id` + `status` per finding** (new `WorklistFinding` emit type; `DreamFinding` stays the pre-id sync input). Without the id there was nothing to reference for a review.
- **`review_dream_finding`** — repo-scoped id-or-prefix (git-style) resolution, a reviewable-state gate (only `open`/`accepted`/`dismissed`; a `resolved`/`superseded` finding is rejected — the code moved on), sets `status` + `reviewed_at_ms`. `--reset` clears the verdict (back to `open`, timestamp NULL). The verdict **survives churn re-runs** — sync's refresh branch already preserves `accepted`/`dismissed`.
- **CLI**: `rag-rat dream <FINDING_ID> --accept|--dismiss|--reset` (mutually exclusive), plus `--all` to also list the reviewed findings so a dismissal can be `--reset`. Review mode prints the one finding and never runs the worklist/model passes.

```bash
rag-rat dream                     # open worklist — each row has an id + status
rag-rat dream 3f9a1c22 --accept   # acknowledge (real, action pending)
rag-rat dream 3f9a1c22 --dismiss  # false positive / won't-fix — hidden from the worklist
rag-rat dream 3f9a1c22 --reset    # undo, back to open
rag-rat dream --all               # also list accepted/dismissed
```

## Tests

accept/dismiss/reset + `reviewed_at_ms`; verdict survives a refresh; terminal-finding rejection; prefix none/ambiguous/unique; repo scoping; worklist surfaces ids + hides dismissed unless `--all`. `docs/config.md` documents the review flow. Full workspace green, clippy clean (`--no-default-features -D warnings`).

Fixes #262

## Companion skill

Adds `dream-review` (`.agents/skills/dream-review`, symlinked into `.claude/`/`.codex/`) — a repo skill that drives this review loop: pull `rag-rat dream --json`, and per finding kind either fix the root (create/repair the memory, close the coverage gap → resolves the finding on the next run) or record an accept/dismiss verdict. Encodes the per-kind playbook and the "model proposes, human decides / prefer the root fix" guardrails. First skill in the repo (establishes the `.agents/skills` convention).