### PR TITLE
feat(skills): @rag-rat/skills installer + using-rag-rat skill

### DIFF
--- a/.agents/skills/using-rag-rat/SKILL.md
+++ b/.agents/skills/using-rag-rat/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: using-rag-rat
+description: >
+  Use when working in a repository indexed by rag-rat (a `rag-rat.toml` at the root and a rag-rat MCP
+  server available). Establishes the working rule: reach for the rag-rat MCP tools
+  (semantic_search, symbol_lookup, impact_surface, find_callers/trace_callees, repo_brief,
+  important_symbols) to FIND and UNDERSTAND code before falling back to grep/cat, and record durable,
+  non-obvious learnings as rag-rat memories before finishing. Triggers: "use rag-rat", "how do I
+  navigate this repo", any code-understanding task in a rag-rat repo.
+---
+
+# using-rag-rat — navigate with the MCP, remember what you learn
+
+This repo is indexed by **rag-rat**, a local repo-intelligence index + MCP server. One MCP call
+returns graph (callers/callees), git, GitHub papertrail, and **drive-by repo memories**
+(source-anchored invariants, decisions, risks) — all validated against current source. A `grep`
+can't surface any of that. Two rules follow.
+
+## Rule 1 — Find and understand through the MCP, not a shell sweep
+
+Prefer these over `grep`/`cat`/file sweeps when browsing or understanding code:
+
+- **`semantic_search`** — "where is this concept implemented?" Current source chunks with inline
+  graph, git, and papertrail.
+- **`symbol_lookup`** — exact/fuzzy symbol resolution (Rust/TS/Kotlin/C/C++/Python), with any bound
+  memories attached.
+- **`impact_surface`** — the **coding preflight before editing any non-trivial symbol**: callers,
+  callees, tests, git history, papertrail, and the repo memories crossing that call path. Run it
+  before you change something load-bearing — it's how you avoid missing an invariant.
+- **`find_callers` / `trace_callees`** — reverse/forward graph traversal instead of grepping for
+  call sites.
+- **`read_chunk`** — current text for a chunk with anchor validation + graph + memories.
+- **`repo_brief` / `repo_clusters`** — orientation (spine, churn, god-modules, ownership clusters).
+- **`important_symbols`** — load-bearing symbols by (SCIP-aware) PageRank; pass `personalize` to bias
+  toward what you're editing.
+
+**Symbol handle:** symbol-returning tools emit `id`, an opaque `sym_<hex>` token — the stable handle
+to cache and pass back into graph/impact/memory tools as `id` (copy verbatim; never parse it as a
+number). Use `ref` (the `path::name` qualified name) for human-readable identity.
+
+Why this beats grep: results carry **provenance** (confidence, coverage warnings, raw evidence) so
+you can judge them; a function may carry an `Invariant`/`Decision`/`Risk` **memory** that explains a
+non-obvious constraint grep can't show; and the index is **kept fresh by git hooks**, so what the
+MCP returns matches HEAD.
+
+Use the MCP to **find and understand**; use your file tools to **change** (and to confirm exact text
+before an edit). The MCP is read-only on source — it never edits files.
+
+If the MCP returns empty/thin results, the index is stale or mis-rooted: `rag-rat index --discover`
+then `rag-rat reconcile`. (Optional but recommended: `rag-rat hooks install --claude` adds a
+PreToolUse hook that auto-augments your `grep`/`rg` calls with symbol + memory context.)
+
+## Rule 2 — Record durable learnings as rag-rat memories before you finish
+
+When you discover something **durable and non-obvious** — a load-bearing invariant, a decision + its
+rationale, a risk/footgun that cost you time, a perf or platform quirk — record it with
+`memory_create` **before finishing the task**. If you had to read several files and reason to learn
+it, the next agent should get it in one MCP call.
+
+**Why rag-rat and not your harness's own notes:** rag-rat memories live in the repo's shared index,
+so they surface for **every** agent that queries it — Claude Code, Codex, any future tool — not just
+the one that wrote them. Your harness's private memory is invisible to the others. rag-rat is the
+**cross-agent memory layer**.
+
+Do it well:
+- **`memory_search` first** to avoid duplicates.
+- **Anchor to the tightest stable target:** prefer an `id` binding (the `sym_<hex>` handle —
+  self-heals across cross-file moves); fall back to a `path` binding for file/area notes, or a
+  commit/GitHub ref for historical rationale.
+- **Pick the right `kind`:** `Invariant` (must stay true), `Decision`/`RejectedAlternative` (why
+  this / why not that), `Risk`/`BugPattern` (footguns), `PerformanceNote`, `PlatformQuirk`,
+  `FFIBoundary`. Write a concrete title and a body with the **why** + **how to apply** — not just the
+  what.
+- **`memory_update` / `memory_mark_obsolete`** when a memory is wrong or superseded — don't leave
+  stale guidance. After a large refactor, `rag-rat memory doctor` flags `gone` anchors to re-bind.
+
+The equivalents exist on the CLI too (`rag-rat memory …`) — use whichever your harness exposes.

--- a/.claude/skills/using-rag-rat
+++ b/.claude/skills/using-rag-rat
@@ -1,0 +1,1 @@
+../../.agents/skills/using-rag-rat

--- a/.codex/skills/using-rag-rat
+++ b/.codex/skills/using-rag-rat
@@ -1,0 +1,1 @@
+../../.agents/skills/using-rag-rat

--- a/skills/.gitignore
+++ b/skills/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/skills/README.md
+++ b/skills/README.md
@@ -26,8 +26,10 @@ npx @rag-rat/skills list            # list installed skills
 npx @rag-rat/skills remove          # remove rag-rat's skills
 ```
 
-`update` and `remove` are scoped to rag-rat's own skills (`using-rag-rat`, `dream-review`) — they
-never touch unrelated skills you've installed. Pass `-s <name>` to target one explicitly.
+`update` and `remove` (plain, or with only `-g`/`-y`) default to rag-rat's own skills
+(`using-rag-rat`, `dream-review`) — they won't touch unrelated skills you've installed. Pass your
+own targets — a skill name, `--agent`, or `--all` — to drive the underlying `skills` CLI directly
+instead.
 
 Flags are forwarded to the underlying installer:
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,54 @@
+# @rag-rat/skills
+
+One-command installer for **rag-rat's agent skills** — reusable instruction sets that teach your
+coding agent to get the most out of a [rag-rat](https://github.com/cq27-dev/rag-rat)-indexed repo.
+
+```bash
+npx @rag-rat/skills
+```
+
+That installs the skills into whichever agents it detects (Claude Code → `.claude/skills/`, Codex →
+`.codex/skills/`, Cursor, opencode, and 70+ others).
+
+## What you get
+
+| Skill | What it does |
+|---|---|
+| **`using-rag-rat`** | The working rule for any rag-rat repo: reach for the MCP tools (`semantic_search`, `symbol_lookup`, `impact_surface`, the call graph, `important_symbols`) to find and understand code before grep, and record durable, non-obvious learnings as cross-agent rag-rat memories before finishing. |
+| **`dream-review`** | Triage and resolve the `rag-rat dream` memory-maintenance worklist: per finding kind, fix the underlying memory / coverage gap (resolving the finding at the root) or record an accept / dismiss verdict. |
+
+## Commands
+
+```bash
+npx @rag-rat/skills                 # install (default)
+npx @rag-rat/skills update          # refresh installed skills to the latest
+npx @rag-rat/skills list            # list installed skills
+npx @rag-rat/skills remove          # remove them
+```
+
+Flags are forwarded to the underlying installer:
+
+```bash
+npx @rag-rat/skills -a claude-code       # only Claude Code
+npx @rag-rat/skills -s using-rag-rat     # only one skill
+npx @rag-rat/skills -g                   # install to your home dir (global), not the project
+npx @rag-rat/skills --copy               # copy files instead of symlinking
+npx @rag-rat/skills -y                   # non-interactive
+```
+
+## How it works
+
+This package is a **thin wrapper** over the [`skills`](https://github.com/vercel-labs/skills) CLI,
+pinned to rag-rat's canonical skill directory (`.agents/skills` in the rag-rat repo). It doesn't
+reinvent the multi-agent installer — `skills` already knows how to place a `SKILL.md` into every
+supported agent, symlink-or-copy, project-or-global. `npx @rag-rat/skills` is just the branded,
+single-command entry point; it forwards your flags verbatim.
+
+Equivalent to running:
+
+```bash
+npx skills add https://github.com/cq27-dev/rag-rat/tree/main/.agents/skills
+```
+
+The skills themselves live in [`.agents/skills/`](https://github.com/cq27-dev/rag-rat/tree/main/.agents/skills)
+in the rag-rat repo — that's the single source of truth; this package installs from it.

--- a/skills/README.md
+++ b/skills/README.md
@@ -21,10 +21,13 @@ That installs the skills into whichever agents it detects (Claude Code → `.cla
 
 ```bash
 npx @rag-rat/skills                 # install (default)
-npx @rag-rat/skills update          # refresh installed skills to the latest
+npx @rag-rat/skills update          # refresh rag-rat's skills to the latest
 npx @rag-rat/skills list            # list installed skills
-npx @rag-rat/skills remove          # remove them
+npx @rag-rat/skills remove          # remove rag-rat's skills
 ```
+
+`update` and `remove` are scoped to rag-rat's own skills (`using-rag-rat`, `dream-review`) — they
+never touch unrelated skills you've installed. Pass `-s <name>` to target one explicitly.
 
 Flags are forwarded to the underlying installer:
 

--- a/skills/cli.mjs
+++ b/skills/cli.mjs
@@ -54,14 +54,19 @@ function main() {
     return 0;
   }
 
-  // No subcommand, or an install alias → `skills add <SOURCE> [flags]`.
-  // Any other subcommand (update/list/ls/remove/rm/find/use) → forwarded verbatim to `skills`,
-  // which operates on the already-installed set (source not needed).
+  // Dispatch. The INSTALL path is `skills add <SOURCE> [flags]`; it fires for:
+  //   - no subcommand           (`npx @rag-rat/skills`)
+  //   - an install alias        (`add` / `install` / `i`) — its own token is dropped
+  //   - a LEADING FLAG          (`-a`, `-s`, `-g`, `--copy`, `-y`, …) — these are `skills add`
+  //     options, so the documented `npx @rag-rat/skills -a claude-code` forms must install, not
+  //     forward a bare `skills -a …` (which the upstream CLI rejects).
+  // Only a real subcommand word (update / list / ls / remove / rm / find / use / init) is forwarded
+  // verbatim — those operate on the already-installed set, so no source is needed.
+  const isInstall = sub === undefined || INSTALL.has(sub) || sub.startsWith("-");
   let skillsArgs;
-  if (sub === undefined) {
-    skillsArgs = ["add", SOURCE];
-  } else if (INSTALL.has(sub)) {
-    skillsArgs = ["add", SOURCE, ...argv.slice(1)];
+  if (isInstall) {
+    const rest = sub !== undefined && INSTALL.has(sub) ? argv.slice(1) : argv;
+    skillsArgs = ["add", SOURCE, ...rest];
   } else {
     skillsArgs = argv;
   }

--- a/skills/cli.mjs
+++ b/skills/cli.mjs
@@ -27,13 +27,40 @@ const SOURCE = "https://github.com/cq27-dev/rag-rat/tree/main/.agents/skills";
 /** rag-rat's own skills — used to scope destructive/refresh subcommands to ONLY these. */
 const RAG_RAT_SKILLS = ["using-rag-rat", "dream-review"];
 
-/** Subcommands that mean "install" — mapped to `skills add <SOURCE>`. */
-const INSTALL = new Set(["add", "install", "i"]);
+/** "install" verbs — mapped to `skills add <SOURCE>`. Includes every upstream `add` alias. */
+const INSTALL = new Set(["add", "install", "i", "a"]);
 
-/** Subcommands scoped to rag-rat's own skills when the user didn't name a skill themselves — a bare
- * `skills remove`/`update` would otherwise act over EVERY installed skill (a selector / update-all),
- * and a branded "remove them" must never touch unrelated skills. */
-const SCOPED = new Set(["remove", "rm", "update"]);
+/** Maintenance verbs scoped to rag-rat's own skills when the user didn't name a skill themselves — a
+ * bare `skills remove`/`update` acts over EVERY installed skill (a selector / update-all), so a
+ * branded "remove them"/"update them" must never touch unrelated skills. Includes ALL upstream
+ * aliases (verified against the `skills` CLI source: remove = rm|r, update = check|upgrade) — an
+ * un-listed alias would slip through unscoped. */
+const SCOPED = new Set(["remove", "rm", "r", "update", "check", "upgrade"]);
+
+/** Flags that consume the NEXT token as their value (so that value is not mistaken for a positional
+ * skill name). */
+const VALUE_FLAGS = new Set(["-a", "--agent", "-s", "--skill"]);
+
+/** Did the user already name a skill to act on — via `-s`/`--skill` OR a bare positional token? If
+ * so, the scoped verbs must NOT append the default rag-rat skill set (that would widen the action to
+ * skills the user didn't ask for). Walks args, skipping the value of value-taking flags so `-a
+ * claude-code` is not read as the positional skill `claude-code`. */
+function namesASkill(rest) {
+  for (let i = 0; i < rest.length; i++) {
+    const t = rest[i];
+    if (t === "-s" || t === "--skill" || t.startsWith("-s=") || t.startsWith("--skill=")) {
+      return true;
+    }
+    if (VALUE_FLAGS.has(t)) {
+      i++; // consume this flag's value
+      continue;
+    }
+    if (!t.startsWith("-")) {
+      return true; // a bare positional = a skill name
+    }
+  }
+  return false;
+}
 
 function usage() {
   process.stdout.write(
@@ -76,11 +103,11 @@ function main() {
     const rest = sub !== undefined && INSTALL.has(sub) ? argv.slice(1) : argv;
     skillsArgs = ["add", SOURCE, ...rest];
   } else if (SCOPED.has(sub)) {
-    // `remove`/`update` with no explicit skill → scope to OUR skills, so the branded command never
-    // removes/refreshes unrelated skills. If the user named a skill (`-s`/`--skill`), respect it.
+    // `remove`/`update` (+ aliases) with no explicit skill → scope to OUR skills, so the branded
+    // command never removes/refreshes unrelated skills. If the user named a skill (via `-s`/`--skill`
+    // OR a positional), respect their selection and add nothing.
     const rest = argv.slice(1);
-    const userNamed = rest.some((a) => a === "-s" || a === "--skill");
-    const scope = userNamed ? [] : RAG_RAT_SKILLS.flatMap((n) => ["-s", n]);
+    const scope = namesASkill(rest) ? [] : RAG_RAT_SKILLS.flatMap((n) => ["-s", n]);
     skillsArgs = [sub, ...rest, ...scope];
   } else {
     skillsArgs = argv;

--- a/skills/cli.mjs
+++ b/skills/cli.mjs
@@ -30,37 +30,21 @@ const RAG_RAT_SKILLS = ["using-rag-rat", "dream-review"];
 /** "install" verbs — mapped to `skills add <SOURCE>`. Includes every upstream `add` alias. */
 const INSTALL = new Set(["add", "install", "i", "a"]);
 
-/** Maintenance verbs scoped to rag-rat's own skills when the user didn't name a skill themselves — a
- * bare `skills remove`/`update` acts over EVERY installed skill (a selector / update-all), so a
- * branded "remove them"/"update them" must never touch unrelated skills. Includes ALL upstream
- * aliases (verified against the `skills` CLI source: remove = rm|r, update = check|upgrade) — an
- * un-listed alias would slip through unscoped. */
+/** Maintenance verbs (remove/update) whose DEFAULT is scoped to rag-rat's own skills — a bare
+ * `skills remove`/`update` acts over EVERY installed skill (a selector / update-all), so a branded
+ * "remove them"/"update them" must not. Includes ALL upstream aliases (verified against the `skills`
+ * CLI source: remove = rm|r, update = check|upgrade) — an un-listed alias would slip through
+ * unscoped. */
 const SCOPED = new Set(["remove", "rm", "r", "update", "check", "upgrade"]);
 
-/** Flags that consume the NEXT token as their value (so that value is not mistaken for a positional
- * skill name). */
-const VALUE_FLAGS = new Set(["-a", "--agent", "-s", "--skill"]);
-
-/** Did the user already name a skill to act on — via `-s`/`--skill` OR a bare positional token? If
- * so, the scoped verbs must NOT append the default rag-rat skill set (that would widen the action to
- * skills the user didn't ask for). Walks args, skipping the value of value-taking flags so `-a
- * claude-code` is not read as the positional skill `claude-code`. */
-function namesASkill(rest) {
-  for (let i = 0; i < rest.length; i++) {
-    const t = rest[i];
-    if (t === "-s" || t === "--skill" || t.startsWith("-s=") || t.startsWith("--skill=")) {
-      return true;
-    }
-    if (VALUE_FLAGS.has(t)) {
-      i++; // consume this flag's value
-      continue;
-    }
-    if (!t.startsWith("-")) {
-      return true; // a bare positional = a skill name
-    }
-  }
-  return false;
-}
+/** The ONLY args we combine with an injected default rag-rat skill list: pure scope/confirm toggles
+ * that carry no skill/agent SELECTION and take no value. We deliberately do NOT reimplement
+ * upstream's arg grammar (variadic `--agent`, `--all` precedence, `--skill=` forms). Instead, we
+ * inject our skills as explicit positional targets only when EVERY arg is one of these known-safe
+ * flags (or there are none). Anything else — an agent filter, `--all`, `--skill`, a positional name,
+ * or any unknown flag — means the user is driving `skills` directly, so we forward verbatim and never
+ * risk injecting a wrong scope. */
+const SAFE_MAINT_FLAGS = new Set(["-g", "--global", "-y", "--yes"]);
 
 function usage() {
   process.stdout.write(
@@ -103,12 +87,13 @@ function main() {
     const rest = sub !== undefined && INSTALL.has(sub) ? argv.slice(1) : argv;
     skillsArgs = ["add", SOURCE, ...rest];
   } else if (SCOPED.has(sub)) {
-    // `remove`/`update` (+ aliases) with no explicit skill → scope to OUR skills, so the branded
-    // command never removes/refreshes unrelated skills. If the user named a skill (via `-s`/`--skill`
-    // OR a positional), respect their selection and add nothing.
+    // Inject rag-rat's skills as explicit POSITIONAL targets (upstream's `remove|update [skills…]`
+    // form) ONLY when every arg is a known-safe scope/confirm flag — then the action is provably
+    // limited to our skills. Otherwise the user passed a selection/widening arg we won't second-guess
+    // (agent filter, --all, a skill name, …), so forward verbatim.
     const rest = argv.slice(1);
-    const scope = namesASkill(rest) ? [] : RAG_RAT_SKILLS.flatMap((n) => ["-s", n]);
-    skillsArgs = [sub, ...rest, ...scope];
+    const scopable = rest.every((t) => SAFE_MAINT_FLAGS.has(t));
+    skillsArgs = scopable ? [sub, ...rest, ...RAG_RAT_SKILLS] : [sub, ...rest];
   } else {
     skillsArgs = argv;
   }

--- a/skills/cli.mjs
+++ b/skills/cli.mjs
@@ -24,17 +24,25 @@ import { spawnSync } from "node:child_process";
 /** rag-rat's canonical skill directory on GitHub (walked one level deep: <name>/SKILL.md). */
 const SOURCE = "https://github.com/cq27-dev/rag-rat/tree/main/.agents/skills";
 
+/** rag-rat's own skills — used to scope destructive/refresh subcommands to ONLY these. */
+const RAG_RAT_SKILLS = ["using-rag-rat", "dream-review"];
+
 /** Subcommands that mean "install" — mapped to `skills add <SOURCE>`. */
 const INSTALL = new Set(["add", "install", "i"]);
+
+/** Subcommands scoped to rag-rat's own skills when the user didn't name a skill themselves — a bare
+ * `skills remove`/`update` would otherwise act over EVERY installed skill (a selector / update-all),
+ * and a branded "remove them" must never touch unrelated skills. */
+const SCOPED = new Set(["remove", "rm", "update"]);
 
 function usage() {
   process.stdout.write(
     `@rag-rat/skills — install rag-rat's agent skills (using-rag-rat, dream-review)\n\n` +
       `Usage:\n` +
       `  npx @rag-rat/skills [add|install]   install into your agent(s) (default)\n` +
-      `  npx @rag-rat/skills update          refresh installed skills\n` +
+      `  npx @rag-rat/skills update          refresh rag-rat's installed skills\n` +
       `  npx @rag-rat/skills list            list installed skills\n` +
-      `  npx @rag-rat/skills remove          remove installed skills\n\n` +
+      `  npx @rag-rat/skills remove          remove rag-rat's skills\n\n` +
       `Flags are forwarded to the underlying \`skills\` CLI, e.g.:\n` +
       `  -a, --agent <name>   target a specific agent (claude-code, codex, cursor, …)\n` +
       `  -s, --skill <name>   install one skill by name\n` +
@@ -67,11 +75,24 @@ function main() {
   if (isInstall) {
     const rest = sub !== undefined && INSTALL.has(sub) ? argv.slice(1) : argv;
     skillsArgs = ["add", SOURCE, ...rest];
+  } else if (SCOPED.has(sub)) {
+    // `remove`/`update` with no explicit skill → scope to OUR skills, so the branded command never
+    // removes/refreshes unrelated skills. If the user named a skill (`-s`/`--skill`), respect it.
+    const rest = argv.slice(1);
+    const userNamed = rest.some((a) => a === "-s" || a === "--skill");
+    const scope = userNamed ? [] : RAG_RAT_SKILLS.flatMap((n) => ["-s", n]);
+    skillsArgs = [sub, ...rest, ...scope];
   } else {
     skillsArgs = argv;
   }
 
-  const res = spawnSync("npx", ["-y", "skills", ...skillsArgs], { stdio: "inherit" });
+  const res = spawnSync("npx", ["-y", "skills", ...skillsArgs], {
+    stdio: "inherit",
+    // On Windows `npx` is a `.cmd` shim that spawn can't execute directly (ENOENT); run it through
+    // the shell so cmd.exe resolves it. Our args carry no spaces, so no shell-quoting hazard. POSIX
+    // needs no shell (and keeping it off there preserves exact arg passing).
+    shell: process.platform === "win32",
+  });
   if (res.error) {
     process.stderr.write(
       `failed to run the \`skills\` CLI via npx: ${res.error.message}\n` +

--- a/skills/cli.mjs
+++ b/skills/cli.mjs
@@ -19,7 +19,11 @@
  * skill exactly once.
  */
 
-import { spawnSync } from "node:child_process";
+// cross-spawn, not node:child_process — on Windows `npx` is a `.cmd` shim that Node can only run
+// through a shell, and forwarding user tokens (`find` queries, `--skill` values) through cmd.exe
+// would let shell metacharacters like `&`/`|` execute. cross-spawn resolves the shim and escapes
+// args itself, so we never enable `shell` and untrusted args pass through verbatim.
+import spawn from "cross-spawn";
 
 /** rag-rat's canonical skill directory on GitHub (walked one level deep: <name>/SKILL.md). */
 const SOURCE = "https://github.com/cq27-dev/rag-rat/tree/main/.agents/skills";
@@ -38,13 +42,14 @@ const INSTALL = new Set(["add", "install", "i", "a"]);
 const SCOPED = new Set(["remove", "rm", "r", "update", "check", "upgrade"]);
 
 /** The ONLY args we combine with an injected default rag-rat skill list: pure scope/confirm toggles
- * that carry no skill/agent SELECTION and take no value. We deliberately do NOT reimplement
- * upstream's arg grammar (variadic `--agent`, `--all` precedence, `--skill=` forms). Instead, we
- * inject our skills as explicit positional targets only when EVERY arg is one of these known-safe
- * flags (or there are none). Anything else — an agent filter, `--all`, `--skill`, a positional name,
- * or any unknown flag — means the user is driving `skills` directly, so we forward verbatim and never
- * risk injecting a wrong scope. */
-const SAFE_MAINT_FLAGS = new Set(["-g", "--global", "-y", "--yes"]);
+ * that carry no skill/agent SELECTION and take no value. Enumerated from upstream's option parsers
+ * (`parseRemoveOptions` / `parseUpdateOptions`): scope = -g/--global, -p/--project; confirm =
+ * -y/--yes. We deliberately do NOT reimplement upstream's arg grammar (variadic `--agent`, `--all`
+ * precedence, `--skill=` forms). We inject our skills as explicit positional targets only when EVERY
+ * arg is one of these known-safe flags (or there are none). Anything else — an agent filter, `--all`,
+ * `--skill`, a positional name, or any unknown flag — means the user is driving `skills` directly, so
+ * we forward verbatim and never risk injecting a wrong scope. */
+const SAFE_MAINT_FLAGS = new Set(["-g", "--global", "-p", "--project", "-y", "--yes"]);
 
 function usage() {
   process.stdout.write(
@@ -98,13 +103,7 @@ function main() {
     skillsArgs = argv;
   }
 
-  const res = spawnSync("npx", ["-y", "skills", ...skillsArgs], {
-    stdio: "inherit",
-    // On Windows `npx` is a `.cmd` shim that spawn can't execute directly (ENOENT); run it through
-    // the shell so cmd.exe resolves it. Our args carry no spaces, so no shell-quoting hazard. POSIX
-    // needs no shell (and keeping it off there preserves exact arg passing).
-    shell: process.platform === "win32",
-  });
+  const res = spawn.sync("npx", ["-y", "skills", ...skillsArgs], { stdio: "inherit" });
   if (res.error) {
     process.stderr.write(
       `failed to run the \`skills\` CLI via npx: ${res.error.message}\n` +

--- a/skills/cli.mjs
+++ b/skills/cli.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * @rag-rat/skills — one-command installer for rag-rat's agent skills.
+ *
+ *   npx @rag-rat/skills                 # install rag-rat's skills into your agent(s)
+ *   npx @rag-rat/skills update          # refresh installed skills to the latest
+ *   npx @rag-rat/skills list            # show installed skills
+ *   npx @rag-rat/skills remove          # remove them
+ *
+ * It is a THIN wrapper over the vercel-labs `skills` CLI (https://github.com/vercel-labs/skills),
+ * pinned to rag-rat's canonical skills directory. Rather than reinvent a multi-agent installer, the
+ * default command delegates to `skills add <rag-rat's .agents/skills>`, which knows how to place a
+ * SKILL.md into 70+ agents (Claude Code → .claude/skills, Codex → .codex/skills, Cursor, opencode,
+ * …), symlink or copy, project or --global. Every flag you pass is forwarded verbatim.
+ *
+ * SOURCE is pinned to the `.agents/skills` PATH (not the bare repo) on purpose: rag-rat mirrors its
+ * skills into .claude/ and .codex/ via symlinks for its own agents, and pointing `skills` at the
+ * whole repo would rediscover those mirror copies. Pinning the one canonical directory installs each
+ * skill exactly once.
+ */
+
+import { spawnSync } from "node:child_process";
+
+/** rag-rat's canonical skill directory on GitHub (walked one level deep: <name>/SKILL.md). */
+const SOURCE = "https://github.com/cq27-dev/rag-rat/tree/main/.agents/skills";
+
+/** Subcommands that mean "install" — mapped to `skills add <SOURCE>`. */
+const INSTALL = new Set(["add", "install", "i"]);
+
+function usage() {
+  process.stdout.write(
+    `@rag-rat/skills — install rag-rat's agent skills (using-rag-rat, dream-review)\n\n` +
+      `Usage:\n` +
+      `  npx @rag-rat/skills [add|install]   install into your agent(s) (default)\n` +
+      `  npx @rag-rat/skills update          refresh installed skills\n` +
+      `  npx @rag-rat/skills list            list installed skills\n` +
+      `  npx @rag-rat/skills remove          remove installed skills\n\n` +
+      `Flags are forwarded to the underlying \`skills\` CLI, e.g.:\n` +
+      `  -a, --agent <name>   target a specific agent (claude-code, codex, cursor, …)\n` +
+      `  -s, --skill <name>   install one skill by name\n` +
+      `  -g, --global         install to your home dir instead of the project\n` +
+      `  --copy               copy files instead of symlinking\n` +
+      `  -y, --yes            skip confirmation prompts\n\n` +
+      `Source: ${SOURCE}\n`,
+  );
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const sub = argv[0];
+
+  if (sub === "--help" || sub === "-h" || sub === "help") {
+    usage();
+    return 0;
+  }
+
+  // No subcommand, or an install alias → `skills add <SOURCE> [flags]`.
+  // Any other subcommand (update/list/ls/remove/rm/find/use) → forwarded verbatim to `skills`,
+  // which operates on the already-installed set (source not needed).
+  let skillsArgs;
+  if (sub === undefined) {
+    skillsArgs = ["add", SOURCE];
+  } else if (INSTALL.has(sub)) {
+    skillsArgs = ["add", SOURCE, ...argv.slice(1)];
+  } else {
+    skillsArgs = argv;
+  }
+
+  const res = spawnSync("npx", ["-y", "skills", ...skillsArgs], { stdio: "inherit" });
+  if (res.error) {
+    process.stderr.write(
+      `failed to run the \`skills\` CLI via npx: ${res.error.message}\n` +
+        `install it directly if needed: npm i -g skills\n`,
+    );
+    return 1;
+  }
+  return res.status ?? 1;
+}
+
+process.exit(main());

--- a/skills/package-lock.json
+++ b/skills/package-lock.json
@@ -1,0 +1,87 @@
+{
+  "name": "@rag-rat/skills",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@rag-rat/skills",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "rag-rat-skills": "cli.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    }
+  }
+}

--- a/skills/package.json
+++ b/skills/package.json
@@ -24,6 +24,9 @@
     "cli.mjs",
     "README.md"
   ],
+  "dependencies": {
+    "cross-spawn": "^7.0.6"
+  },
   "keywords": [
     "rag-rat",
     "agent-skills",

--- a/skills/package.json
+++ b/skills/package.json
@@ -14,6 +14,9 @@
   "engines": {
     "node": ">=18"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": {
     "rag-rat-skills": "cli.mjs"
   },

--- a/skills/package.json
+++ b/skills/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@rag-rat/skills",
+  "version": "0.1.0",
+  "description": "One-command installer for rag-rat's agent skills (using-rag-rat, dream-review). A thin wrapper over the vercel-labs `skills` CLI, pinned to rag-rat's canonical skills directory, so `npx @rag-rat/skills` places them into Claude Code, Codex, Cursor, and 70+ other agents.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cq27-dev/rag-rat.git",
+    "directory": "skills"
+  },
+  "homepage": "https://github.com/cq27-dev/rag-rat/tree/main/skills#readme",
+  "bugs": "https://github.com/cq27-dev/rag-rat/issues",
+  "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
+  "bin": {
+    "rag-rat-skills": "cli.mjs"
+  },
+  "files": [
+    "cli.mjs",
+    "README.md"
+  ],
+  "keywords": [
+    "rag-rat",
+    "agent-skills",
+    "skills",
+    "claude-code",
+    "codex",
+    "cursor",
+    "mcp",
+    "ai-agents"
+  ]
+}


### PR DESCRIPTION
Creates **`@rag-rat/skills`** — a branded, one-command installer for rag-rat's agent skills — plus the general skill that is the package's main payload. Stacked on #440 (which adds the `dream-review` skill it also installs).

## `npx @rag-rat/skills`

Installs rag-rat's skills into whatever agents it detects (Claude Code → `.claude/skills`, Codex → `.codex/skills`, Cursor, opencode, 70+ others).

It's a **thin wrapper** over the [`skills`](https://github.com/vercel-labs/skills) CLI — we reuse the proven multi-agent installer instead of reinventing one. `npx @rag-rat/skills` ≡ `skills add <rag-rat's .agents/skills>`; `update`/`list`/`remove` and all flags (`-a`, `-s`, `-g`, `--copy`, `-y`) forward verbatim.

The source is pinned to the **`.agents/skills` path** (not the bare repo) on purpose: rag-rat mirrors its skills into `.claude/`/`.codex/` via symlinks for its own agents, and pointing `skills` at the whole repo would rediscover those mirrors as duplicates. Pinning the one canonical directory installs each skill exactly once.

## Skills shipped

| Skill | What it does |
|---|---|
| **`using-rag-rat`** (new here) | The working rule for any rag-rat-indexed repo: reach for the MCP tools (`semantic_search`, `impact_surface`, symbol graph, `important_symbols`) before grep, and record durable, non-obvious learnings as cross-agent rag-rat memories before finishing. Distilled from AGENTS.md so it applies in any consumer repo. |
| **`dream-review`** (from #440) | Triage + resolve the `rag-rat dream` worklist. |

## Notes

- `skills/` is the npm package (`cli.mjs` + `package.json` + `README.md`); no build step, no runtime deps. The skill content stays in `.agents/skills/` (single source of truth), mirrored into `.claude/`/`.codex/`.
- Publish is a follow-up (`npm publish`, like `@rag-rat/cookbook`); the wrapper's GitHub-pinned source resolves once the skills are on `main`.
- CLI verified locally (syntax, arg mapping, `--help`); end-to-end delegation resolves post-merge.