### PR TITLE
chore(cookbook): mark the scoped package public via publishConfig

### DIFF
--- a/cookbook/package.json
+++ b/cookbook/package.json
@@ -14,6 +14,9 @@
   "engines": {
     "node": ">=18"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "dist/src/contract.js",
   "types": "dist/src/contract.d.ts",
   "bin": {


### PR DESCRIPTION
`@rag-rat/cookbook` is scoped, so npm publishes it restricted unless `--access public` is passed; 0.6.0 was published with the manual flag. Adds `publishConfig.access: "public"` so future `npm publish` runs are public without it — matching `@rag-rat/skills`. Metadata-only, no code change.