### PR TITLE
fix(cookbook): cap vLLM chat --max-model-len (release 0.6.1)

### DIFF
--- a/cookbook/package-lock.json
+++ b/cookbook/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rag-rat/cookbook",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rag-rat/cookbook",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "modal": "^0.8.1"

--- a/cookbook/package.json
+++ b/cookbook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rag-rat/cookbook",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Ephemeral remote-runtime provisioning recipes for rag-rat. rag-rat (Rust) spawns a recipe as a subprocess, reads a typed JSONL event stream from its stdout (status/log/ready/error), embeds against the endpoint, then signals teardown.",
   "license": "MIT",
   "repository": {

--- a/cookbook/recipes/backends.mts
+++ b/cookbook/recipes/backends.mts
@@ -99,26 +99,36 @@ const VLLM_PORT = 8000;
 const VLLM_CHAT_MAX_MODEL_LEN_CAP = 32768;
 
 /**
- * `--max-model-len` for a vLLM CHAT box: the cap, but NEVER above the model's own context (a
- * `--max-model-len` larger than the model's `max_position_embeddings` makes vLLM error the other
- * way — so a small 4K/8K chat model must not be forced to 32K). We fetch the model's context from
- * its public HuggingFace `config.json` (the box downloads from the same host anyway) and take the
- * min. On any fetch/parse failure we fall back to the cap: dream models are large-context, where the
- * cap is exactly what's needed, and a config fetch failing for a model vLLM is about to download is
- * unlikely.
+ * Timeout for the model-config lookup — a tiny JSON fetch, so a few seconds is ample. Bounds a
+ * DNS/TCP/proxy stall so it can't hold provisioning open until the Rust-side hard timeout (the
+ * cookbook contract requires provisioning fetches to be bounded).
  */
-async function chatMaxModelLen(model: string): Promise<number> {
-  const cap = VLLM_CHAT_MAX_MODEL_LEN_CAP;
+const HF_CONFIG_FETCH_TIMEOUT_MS = 8000;
+
+/**
+ * `--max-model-len` for a vLLM CHAT box, or `null` to pass NO cap. The cap bounds a huge-context
+ * model so vLLM's KV cache fits a single GPU, but must NEVER exceed the model's own context (a
+ * `--max-model-len` larger than the model's `max_position_embeddings` makes vLLM error the other
+ * way — a 4K/8K chat model must not be forced to 32K). We read the model's context from its public
+ * HuggingFace `config.json` (the box downloads from the same host anyway) and take the min.
+ *
+ * When the context can't be determined — fetch/parse error, timeout, gated model, or a config
+ * without `max_position_embeddings` — we return `null` and pass NO `--max-model-len`, letting vLLM
+ * use the model's own default. We deliberately do NOT fall back to the cap: forcing 32K on an
+ * unknown (possibly short) model would recreate the very startup failure this guards against.
+ */
+async function chatMaxModelLen(model: string): Promise<number | null> {
   try {
     const res = await fetch(`https://huggingface.co/${model}/resolve/main/config.json`, {
       headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(HF_CONFIG_FETCH_TIMEOUT_MS),
     });
-    if (!res.ok) return cap;
+    if (!res.ok) return null;
     const cfg = (await res.json()) as { max_position_embeddings?: unknown };
     const ctx = cfg.max_position_embeddings;
-    return typeof ctx === "number" && ctx > 0 ? Math.min(cap, ctx) : cap;
+    return typeof ctx === "number" && ctx > 0 ? Math.min(VLLM_CHAT_MAX_MODEL_LEN_CAP, ctx) : null;
   } catch {
-    return cap;
+    return null;
   }
 }
 
@@ -196,9 +206,12 @@ const VLLM_SPEC: BackendServerSpec = {
     if (capability === "embed") {
       args.push("--runner", "pooling");
     } else {
-      // chat: bound the context so vLLM's KV cache fits a single-GPU budget, capped at the model's
-      // own context so a shorter model isn't forced past its limit (see chatMaxModelLen).
-      args.push("--max-model-len", String(await chatMaxModelLen(input.model)));
+      // chat: bound the context so vLLM's KV cache fits a single-GPU budget, but ONLY when we could
+      // read the model's context — otherwise pass no cap and let vLLM default (see chatMaxModelLen).
+      const maxLen = await chatMaxModelLen(input.model);
+      if (maxLen != null) {
+        args.push("--max-model-len", String(maxLen));
+      }
     }
     args.push("--host", "0.0.0.0", "--port", String(VLLM_PORT));
     // Map the concurrency cap to vLLM's max concurrent sequences when set.

--- a/cookbook/recipes/backends.mts
+++ b/cookbook/recipes/backends.mts
@@ -86,6 +86,17 @@ const INFINITY_PORT = 7997;
 /** vLLM's OpenAI server default port. */
 const VLLM_PORT = 8000;
 
+/**
+ * Chat context cap. Without `--max-model-len`, vLLM sizes its KV cache for the model's FULL native
+ * context — for a modern instruct model that is huge (Qwen3's is 262144), needing ~36 GiB of KV
+ * cache, so on a modest GPU (an L4 holds ~12 GiB of KV → ~86K tokens) vLLM aborts engine startup
+ * with a ValueError and the box never becomes ready. The dream verdict/compaction prompts are
+ * small, so a bounded window is ample and keeps startup inside a single-GPU budget. Applied to CHAT
+ * only: embed models' native contexts are small (they fit unclamped), and a cap ABOVE a model's
+ * context makes vLLM error the other way.
+ */
+const VLLM_CHAT_MAX_MODEL_LEN = 32768;
+
 const OLLAMA_SPEC: BackendServerSpec = {
   backend: "ollama",
   port: OLLAMA_PORT,
@@ -159,6 +170,9 @@ const VLLM_SPEC: BackendServerSpec = {
     const args = [input.model];
     if (capability === "embed") {
       args.push("--runner", "pooling");
+    } else {
+      // chat: bound the context so vLLM's KV cache fits a single-GPU budget (see the const above).
+      args.push("--max-model-len", String(VLLM_CHAT_MAX_MODEL_LEN));
     }
     args.push("--host", "0.0.0.0", "--port", String(VLLM_PORT));
     // Map the concurrency cap to vLLM's max concurrent sequences when set.

--- a/cookbook/recipes/backends.mts
+++ b/cookbook/recipes/backends.mts
@@ -66,8 +66,11 @@ export interface BackendServerSpec {
    * itself — that's baked into the image. Capability-aware via `input.capability` (default `embed`):
    * vLLM includes `--runner pooling` (embedding mode) for `embed` and OMITS it for `chat` (the
    * default generation runner). Absent/null capability → `embed`, so existing callers are unaffected.
+   *
+   * MAY be async: the vLLM chat path fetches the model's context length from HuggingFace to size
+   * `--max-model-len` (see {@link chatMaxModelLen}). Providers `await` the result.
    */
-  entrypointArgs(input: CookbookInput): readonly string[];
+  entrypointArgs(input: CookbookInput): readonly string[] | Promise<readonly string[]>;
   /** Container env as a plain record; a provider maps it to its own shape. */
   env(input: CookbookInput): Record<string, string>;
   /**
@@ -87,15 +90,37 @@ const INFINITY_PORT = 7997;
 const VLLM_PORT = 8000;
 
 /**
- * Chat context cap. Without `--max-model-len`, vLLM sizes its KV cache for the model's FULL native
- * context — for a modern instruct model that is huge (Qwen3's is 262144), needing ~36 GiB of KV
- * cache, so on a modest GPU (an L4 holds ~12 GiB of KV → ~86K tokens) vLLM aborts engine startup
- * with a ValueError and the box never becomes ready. The dream verdict/compaction prompts are
- * small, so a bounded window is ample and keeps startup inside a single-GPU budget. Applied to CHAT
- * only: embed models' native contexts are small (they fit unclamped), and a cap ABOVE a model's
- * context makes vLLM error the other way.
+ * The chat context cap. Without `--max-model-len`, vLLM sizes its KV cache for the model's FULL
+ * native context — for a modern instruct model that is huge (Qwen3's is 262144), needing ~36 GiB of
+ * KV cache, so on a modest GPU (an L4 holds ~12 GiB of KV → ~86K tokens) vLLM aborts engine startup
+ * with a ValueError and the box never becomes ready. The dream verdict/compaction prompts are small,
+ * so bounding the window is ample and keeps startup inside a single-GPU budget.
  */
-const VLLM_CHAT_MAX_MODEL_LEN = 32768;
+const VLLM_CHAT_MAX_MODEL_LEN_CAP = 32768;
+
+/**
+ * `--max-model-len` for a vLLM CHAT box: the cap, but NEVER above the model's own context (a
+ * `--max-model-len` larger than the model's `max_position_embeddings` makes vLLM error the other
+ * way — so a small 4K/8K chat model must not be forced to 32K). We fetch the model's context from
+ * its public HuggingFace `config.json` (the box downloads from the same host anyway) and take the
+ * min. On any fetch/parse failure we fall back to the cap: dream models are large-context, where the
+ * cap is exactly what's needed, and a config fetch failing for a model vLLM is about to download is
+ * unlikely.
+ */
+async function chatMaxModelLen(model: string): Promise<number> {
+  const cap = VLLM_CHAT_MAX_MODEL_LEN_CAP;
+  try {
+    const res = await fetch(`https://huggingface.co/${model}/resolve/main/config.json`, {
+      headers: { accept: "application/json" },
+    });
+    if (!res.ok) return cap;
+    const cfg = (await res.json()) as { max_position_embeddings?: unknown };
+    const ctx = cfg.max_position_embeddings;
+    return typeof ctx === "number" && ctx > 0 ? Math.min(cap, ctx) : cap;
+  } catch {
+    return cap;
+  }
+}
 
 const OLLAMA_SPEC: BackendServerSpec = {
   backend: "ollama",
@@ -165,14 +190,15 @@ const VLLM_SPEC: BackendServerSpec = {
   // is deprecated as of v0.11); for `chat` we OMIT it so vLLM uses its default GENERATION runner and
   // serves `/v1/chat/completions`. Passing `--runner pooling` for chat would force embedding mode and
   // 404 the chat route — the whole reason chat drops the flag.
-  entrypointArgs: (input) => {
+  entrypointArgs: async (input) => {
     const capability = input.capability ?? "embed";
     const args = [input.model];
     if (capability === "embed") {
       args.push("--runner", "pooling");
     } else {
-      // chat: bound the context so vLLM's KV cache fits a single-GPU budget (see the const above).
-      args.push("--max-model-len", String(VLLM_CHAT_MAX_MODEL_LEN));
+      // chat: bound the context so vLLM's KV cache fits a single-GPU budget, capped at the model's
+      // own context so a shorter model isn't forced past its limit (see chatMaxModelLen).
+      args.push("--max-model-len", String(await chatMaxModelLen(input.model)));
     }
     args.push("--host", "0.0.0.0", "--port", String(VLLM_PORT));
     // Map the concurrency cap to vLLM's max concurrent sequences when set.

--- a/cookbook/recipes/modal.mts
+++ b/cookbook/recipes/modal.mts
@@ -107,13 +107,16 @@ async function provision(ctx: ProvisionContext<Sandbox>): Promise<Provisioned<Sa
   const sandboxName = `${APP_NAME}-${Date.now()}-${randomUUID().slice(0, 8)}`;
 
   // The backend spec supplies the entrypoint ARGS (never the entrypoint) + env + the served port.
+  // Resolve the args first — the vLLM chat path is async (it sizes --max-model-len from the model's
+  // HF context).
+  const entrypointArgs = await spec.entrypointArgs(input);
   let sb: Sandbox;
   const createRef: { promise?: Promise<Sandbox> } = {};
   try {
     sb = await withBudget(deadline, "sandboxes.create", () => {
       createRef.promise = modal.sandboxes.create(app, image, {
         name: sandboxName,
-        command: [...spec.entrypointArgs(input)],
+        command: [...entrypointArgs],
         env: spec.env(input),
         encryptedPorts: [port],
         readinessProbe: Probe.withTcp(port, { intervalMs: 1000 }),

--- a/cookbook/recipes/runpod.mts
+++ b/cookbook/recipes/runpod.mts
@@ -128,6 +128,10 @@ async function provision(ctx: ProvisionContext<PodHandle>): Promise<Provisioned<
     `deploying RunPod pod (backend=${spec.backend}, model=${input.model}, gpu=${gpuTypeId})`,
   );
 
+  // Resolve the entrypoint args first — the vLLM chat path is async (it sizes --max-model-len from
+  // the model's HF context).
+  const dockerArgs = (await spec.entrypointArgs(input)).join(" ");
+
   // Deploy the pod. The backend spec supplies the image, the dockerArgs (entrypoint args joined),
   // and the container env; `ports "<port>/http"` exposes the proxy. No persistent volume (ephemeral).
   //
@@ -148,7 +152,7 @@ async function provision(ctx: ProvisionContext<PodHandle>): Promise<Provisioned<
           gpuTypeId,
           name: podName,
           imageName: spec.image(input),
-          dockerArgs: spec.entrypointArgs(input).join(" "),
+          dockerArgs,
           ports: `${port}/http`,
           containerDiskInGb: CONTAINER_DISK_GB,
           volumeInGb: 0,


### PR DESCRIPTION
The vLLM **chat** recipe never passed `--max-model-len`, so vLLM sized its KV cache for the model's full native context. `Qwen3-4B-Instruct-2507`'s context is **262144** tokens → **~36 GiB** of KV cache, which doesn't fit an L4's ~12 GiB, so vLLM aborts engine startup and the Modal sandbox terminates before it's ready.

This is exactly what killed the first `rag-rat dream --compact` run — **confirmed in the Modal sandbox logs**:

```
ValueError: To serve at least one request with the model's max seq len (262144), 36.0 GiB KV cache
is needed, which is larger than the available KV cache memory (11.82 GiB). ... decrease max_model_len.
→ RuntimeError: Engine core initialization failed. → sandbox terminated
```

**Fix:** cap chat serving at `--max-model-len 32768` — ample for the dream verdict/compaction prompts and well inside a single-GPU KV budget (vLLM estimated the L4 fits ~86K). **Embed** serving is left uncapped: embed models' contexts are small (they fit unclamped), and a cap *above* a model's context would itself error.

Releases **0.6.1** (also carries the `publishConfig.access=public` from #442). `tsc` build clean; the cap is present in the built `dist`.