### PR TITLE
feat(mcp): memory_show — expand a memory to its full body by id

### DIFF
--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -368,4 +368,47 @@ mod tests {
         assert!(svc.call("definitely_not_a_tool", json!({})).is_err(), "unknown tool must error");
         let _ = std::fs::remove_dir_all(&root);
     }
+
+    #[test]
+    fn memory_show_expands_a_memory_to_its_full_body_by_id() {
+        // The expand path: given the `memory_id` from a compact summary (surface="summary"),
+        // `memory_show` returns the COMPLETE original body — no shelling out to the CLI.
+        let (root, config) = config_over_temp_repo();
+        let db_path = &config.database;
+        let created = crate::tools::call_tool(
+            db_path,
+            "memory_create",
+            json!({
+                "kind": "Invariant",
+                "title": "t",
+                "body": "FULL-BODY-MARKER expand text",
+                "confidence": "high",
+                "bind": { "path": "src/lib.rs" }
+            }),
+        )
+        .unwrap();
+        // memory_create returns RepoMemoryCreateResult { memory, duplicate } — the id is nested.
+        let id = created["memory"]["memory_id"]
+            .as_str()
+            .expect("created memory carries a memory_id")
+            .to_string();
+
+        let shown =
+            crate::tools::call_tool(db_path, "memory_show", json!({ "memory_id": id })).unwrap();
+        assert_eq!(
+            shown["body"].as_str(),
+            Some("FULL-BODY-MARKER expand text"),
+            "returns the full body"
+        );
+        assert_eq!(shown["title"].as_str(), Some("t"));
+
+        // An unknown id errors, not a silent null.
+        assert!(
+            crate::tools::call_tool(db_path, "memory_show", json!({ "memory_id": "mem_nope" }))
+                .is_err(),
+            "unknown memory id must error",
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
 }

--- a/crates/rag-rat-mcp/src/tools/catalog.rs
+++ b/crates/rag-rat-mcp/src/tools/catalog.rs
@@ -38,6 +38,7 @@ pub const TOOL_NAMES: &[&str] = &[
     "memory_for_symbol",
     "memory_for_path",
     "memory_for_call_path",
+    "memory_show",
     "memory_validate",
     "memory_doctor",
     "memory_mark_obsolete",
@@ -191,6 +192,11 @@ pub fn description(name: &str) -> &'static str {
         "memory_for_path" => "Return repo memories bound to a path.",
         "memory_for_call_path" =>
             "Return repo memories bound to a specific call-path edge sequence.",
+        "memory_show" =>
+            "Expand ONE repo memory to its FULL body by `memory_id` — the expand path for a \
+             compact summary. When `[memory] surface = \"summary\"` renders drive-by attachments \
+             (e.g. impact_surface) as the dream-compacted summary, call this with the attachment's \
+             `memory_id` to get the complete original. Surface-independent: always the full body.",
         "memory_validate" =>
             "Re-anchor every repo memory against current source and mark each current / relocated \
              / stale / gone. Runs automatically after indexing.",
@@ -239,7 +245,7 @@ pub fn schema(name: &str) -> Value {
         "memory_for_symbol" => schema_for::<MemoryForSymbolArgs>(),
         "memory_for_path" => schema_for::<MemoryForPathArgs>(),
         "memory_for_call_path" => schema_for::<MemoryForCallPathArgs>(),
-        "memory_mark_obsolete" => schema_for::<MemoryIdArgs>(),
+        "memory_mark_obsolete" | "memory_show" => schema_for::<MemoryIdArgs>(),
         "llm_status" | "github_sync_status" | "index_status" | "memory_validate"
         | "memory_doctor" => schema_for::<EmptyArgs>(),
         _ => json!({"type": "object"}),

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -193,6 +193,15 @@ pub(crate) fn call_tool_with_db(
             let args: MemoryForCallPathArgs = serde_json::from_value(arguments)?;
             json!(db.memory_for_call_path_hash(&args.edge_sequence_hash, args.limit)?)
         },
+        "memory_show" => {
+            let args: MemoryIdArgs = serde_json::from_value(arguments)?;
+            // The EXPAND path: full body by id, surface-independent (mirrors the CLI `memory
+            // show`).
+            let Some(memory) = db.memory_get(&args.memory_id)? else {
+                anyhow::bail!("memory `{}` not found", args.memory_id);
+            };
+            json!(memory)
+        },
         "memory_validate" => json!(db.memory_validate()?),
         "memory_doctor" => json!(db.memory_doctor()?),
         "memory_mark_obsolete" => {

--- a/crates/rag-rat-mcp/src/tools/requests.rs
+++ b/crates/rag-rat-mcp/src/tools/requests.rs
@@ -450,8 +450,8 @@ pub struct ImpactArgs {
     pub include: Option<Vec<ImpactInclude>>,
     /// Return full memory bodies + every binding + call paths instead of the default compact,
     /// scannable per-memory headers (#37). To expand ONE memory by id (e.g. the `memory_id` from a
-    /// `surface="summary"` compact attachment), call `memory_show`; full detail for a symbol/path is
-    /// also reachable via `memory_for_symbol` / `memory_for_path` / `memory_for_call_path`.
+    /// `surface="summary"` compact attachment), call `memory_show`; full detail for a symbol/path
+    /// is also reachable via `memory_for_symbol` / `memory_for_path` / `memory_for_call_path`.
     #[serde(default)]
     pub full_memories: bool,
     /// Absolute path to a linked git worktree you're working in; serves that worktree's branch

--- a/crates/rag-rat-mcp/src/tools/requests.rs
+++ b/crates/rag-rat-mcp/src/tools/requests.rs
@@ -449,8 +449,9 @@ pub struct ImpactArgs {
     #[serde(default, deserialize_with = "de_seq_or_json_string")]
     pub include: Option<Vec<ImpactInclude>>,
     /// Return full memory bodies + every binding + call paths instead of the default compact,
-    /// scannable per-memory headers (#37). Full detail is also reachable via `memory_for_symbol` /
-    /// `memory_for_path` / `memory_for_call_path`.
+    /// scannable per-memory headers (#37). To expand ONE memory by id (e.g. the `memory_id` from a
+    /// `surface="summary"` compact attachment), call `memory_show`; full detail for a symbol/path is
+    /// also reachable via `memory_for_symbol` / `memory_for_path` / `memory_for_call_path`.
     #[serde(default)]
     pub full_memories: bool,
     /// Absolute path to a linked git worktree you're working in; serves that worktree's branch


### PR DESCRIPTION
`surface="summary"` (landed in #444) renders drive-by memory attachments as the dream-compacted summary + a `memory_id`. But the **only** way to expand one to its full body was the CLI `memory show` — so an agent working through the MCP had to shell out to the binary, which it shouldn't.

Adds the **`memory_show`** MCP tool:
- Takes a `memory_id` (schema reuses `MemoryIdArgs`), returns the complete `RepoMemory` via `db.memory_get` — the same method the CLI `memory show` uses.
- **Surface-independent**: always the full body, regardless of `[memory] surface` (mirrors the documented expand semantics).
- Read-only (not in the writer deny-list); an unknown id errors rather than returning a silent null.
- The `impact_surface` `full_memories` docstring now points agents at it as the by-id expand path.

This closes the compact↔expand round-trip entirely within the MCP: **compact summary (impact_surface) → `memory_show(memory_id)` → full body** — no CLI shelling.

Tests: create → `memory_show` returns the full body; unknown id errors. Full MCP suite (38) green, clippy clean (`--no-default-features -D warnings`).