### PR TITLE
chore: release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.13.0...rag-rat-core-v0.14.0) - 2026-07-07
+
+### Added
+
+- *(index)* make explicit-config adoption loud and refuse empty indexes ([#458](https://github.com/cq27-dev/rag-rat/pull/458))
+- *(memory)* apply [memory] surface="summary" to every drive-by renderer ([#426](https://github.com/cq27-dev/rag-rat/pull/426)) ([#453](https://github.com/cq27-dev/rag-rat/pull/453))
+
+### Fixed
+
+- reduce incremental index churn ([#460](https://github.com/cq27-dev/rag-rat/pull/460))
+- *(watch)* prune linked worktree watches ([#454](https://github.com/cq27-dev/rag-rat/pull/454))
+- *(cross-platform)* full request drain in the ollama-probe and embed stubs ([#446](https://github.com/cq27-dev/rag-rat/pull/446)) ([#452](https://github.com/cq27-dev/rag-rat/pull/452))
+- *(cross-platform)* TOML path escaping, cookbook slash, clone teardown, Windows clippy ([#446](https://github.com/cq27-dev/rag-rat/pull/446)) ([#449](https://github.com/cq27-dev/rag-rat/pull/449))
+- *(dream)* persist failed model attempts ([#450](https://github.com/cq27-dev/rag-rat/pull/450))
+
+### Other
+
+- derive enum strings with strum ([#457](https://github.com/cq27-dev/rag-rat/pull/457))
+- Split oracle tests and antiunify module ([#456](https://github.com/cq27-dev/rag-rat/pull/456))
+- *(watch)* cover watcher state helpers ([#455](https://github.com/cq27-dev/rag-rat/pull/455))
+
 ## [0.13.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.12.0...rag-rat-core-v0.13.0) - 2026-07-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3320,7 +3320,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rag-rat"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3346,7 +3346,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3387,7 +3387,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-mcp"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "3"
 # and the internal path deps below pin the same literal, so the three crates always publish in
 # lockstep. Bump this one line (and the two internal-dep `version`s under workspace.dependencies)
 # to release.
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Kristaps Karlsons"]
 edition = "2024"
 # Bundled SQLite (rusqlite `bundled` -> libsqlite3-sys 0.38.1) compiles a build script that uses the
@@ -28,8 +28,8 @@ categories = ["command-line-utilities", "development-tools"]
 # Internal crates — declared once here so the version requirement is set in lockstep with
 # [workspace.package].version above. Members reference these via `{ workspace = true }` and add
 # their own feature toggles at the use site.
-rag-rat-core = { version = "0.13.0", path = "crates/rag-rat-core", default-features = false }
-rag-rat-mcp = { version = "0.13.0", path = "crates/rag-rat-mcp", default-features = false }
+rag-rat-core = { version = "0.14.0", path = "crates/rag-rat-core", default-features = false }
+rag-rat-mcp = { version = "0.14.0", path = "crates/rag-rat-mcp", default-features = false }
 anyhow = "1.0"
 fastembed = { version = "5.17.2", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
 gix = { version = "0.85.0", default-features = false, features = ["status", "parallel", "sha1", "sha256", "revision", "blob-diff", "blame"] }


### PR DESCRIPTION



## 🤖 New release

* `rag-rat-core`: 0.13.0 -> 0.14.0 (⚠ API breaking changes)
* `rag-rat-mcp`: 0.13.0 -> 0.14.0 (✓ API compatible changes)
* `rag-rat`: 0.13.0 -> 0.14.0

### ⚠ `rag-rat-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Config.source_root_reanchored_from in /tmp/.tmp93IX2e/rag-rat/crates/rag-rat-core/src/config.rs:44
  field Config.allow_empty in /tmp/.tmp93IX2e/rag-rat/crates/rag-rat-core/src/config.rs:50
  field Config.source_root_reanchored_from in /tmp/.tmp93IX2e/rag-rat/crates/rag-rat-core/src/config.rs:44
  field Config.allow_empty in /tmp/.tmp93IX2e/rag-rat/crates/rag-rat-core/src/config.rs:50
  field RepoMemory.summary in /tmp/.tmp93IX2e/rag-rat/crates/rag-rat-core/src/query/memory/mod.rs:46
  field RepoMemory.verdict in /tmp/.tmp93IX2e/rag-rat/crates/rag-rat-core/src/query/memory/mod.rs:51

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_parameter_count_changed.ron

Failed in:
  rag_rat_core::dream::model_work_pending now takes 6 parameters instead of 5, in /tmp/.tmp93IX2e/rag-rat/crates/rag-rat-core/src/dream/mod.rs:243
  rag_rat_core::query::grep_augment::compose now takes 5 parameters instead of 4, in /tmp/.tmp93IX2e/rag-rat/crates/rag-rat-core/src/query/grep_augment.rs:203

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  rag_rat_core::index::IndexDatabase::dream_model_work_pending takes 4 parameters in /tmp/.tmpWUNjVs/rag-rat-core/src/index/query_api/dream.rs:36, but now takes 5 parameters in /tmp/.tmp93IX2e/rag-rat/crates/rag-rat-core/src/index/query_api/dream.rs:36
  rag_rat_core::index::IndexDatabase::memory_for_symbol takes 2 parameters in /tmp/.tmpWUNjVs/rag-rat-core/src/index/query_api/memory.rs:36, but now takes 3 parameters in /tmp/.tmp93IX2e/rag-rat/crates/rag-rat-core/src/index/query_api/memory.rs:36
  rag_rat_core::index::IndexDatabase::memory_for_path takes 2 parameters in /tmp/.tmpWUNjVs/rag-rat-core/src/index/query_api/memory.rs:44, but now takes 3 parameters in /tmp/.tmp93IX2e/rag-rat/crates/rag-rat-core/src/index/query_api/memory.rs:48
  rag_rat_core::index::IndexDatabase::memory_evidence_for_symbol_and_edges takes 4 parameters in /tmp/.tmpWUNjVs/rag-rat-core/src/index/query_api/memory.rs:60, but now takes 5 parameters in /tmp/.tmp93IX2e/rag-rat/crates/rag-rat-core/src/index/query_api/memory.rs:68
  rag_rat_core::index::IndexDatabase::read_chunk_with_graph_and_memories takes 4 parameters in /tmp/.tmpWUNjVs/rag-rat-core/src/index/query_api/mod.rs:391, but now takes 5 parameters in /tmp/.tmp93IX2e/rag-rat/crates/rag-rat-core/src/index/query_api/mod.rs:407
  rag_rat_core::IndexDatabase::dream_model_work_pending takes 4 parameters in /tmp/.tmpWUNjVs/rag-rat-core/src/index/query_api/dream.rs:36, but now takes 5 parameters in /tmp/.tmp93IX2e/rag-rat/crates/rag-rat-core/src/index/query_api/dream.rs:36
  rag_rat_core::IndexDatabase::memory_for_symbol takes 2 parameters in /tmp/.tmpWUNjVs/rag-rat-core/src/index/query_api/memory.rs:36, but now takes 3 parameters in /tmp/.tmp93IX2e/rag-rat/crates/rag-rat-core/src/index/query_api/memory.rs:36
  rag_rat_core::IndexDatabase::memory_for_path takes 2 parameters in /tmp/.tmpWUNjVs/rag-rat-core/src/index/query_api/memory.rs:44, but now takes 3 parameters in /tmp/.tmp93IX2e/rag-rat/crates/rag-rat-core/src/index/query_api/memory.rs:48
  rag_rat_core::IndexDatabase::memory_evidence_for_symbol_and_edges takes 4 parameters in /tmp/.tmpWUNjVs/rag-rat-core/src/index/query_api/memory.rs:60, but now takes 5 parameters in /tmp/.tmp93IX2e/rag-rat/crates/rag-rat-core/src/index/query_api/memory.rs:68
  rag_rat_core::IndexDatabase::read_chunk_with_graph_and_memories takes 4 parameters in /tmp/.tmpWUNjVs/rag-rat-core/src/index/query_api/mod.rs:391, but now takes 5 parameters in /tmp/.tmp93IX2e/rag-rat/crates/rag-rat-core/src/index/query_api/mod.rs:407
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rag-rat-core`

<blockquote>

## [0.14.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.13.0...rag-rat-core-v0.14.0) - 2026-07-07

### Added

- *(index)* make explicit-config adoption loud and refuse empty indexes ([#458](https://github.com/cq27-dev/rag-rat/pull/458))
- *(memory)* apply [memory] surface="summary" to every drive-by renderer ([#426](https://github.com/cq27-dev/rag-rat/pull/426)) ([#453](https://github.com/cq27-dev/rag-rat/pull/453))

### Fixed

- reduce incremental index churn ([#460](https://github.com/cq27-dev/rag-rat/pull/460))
- *(watch)* prune linked worktree watches ([#454](https://github.com/cq27-dev/rag-rat/pull/454))
- *(cross-platform)* full request drain in the ollama-probe and embed stubs ([#446](https://github.com/cq27-dev/rag-rat/pull/446)) ([#452](https://github.com/cq27-dev/rag-rat/pull/452))
- *(cross-platform)* TOML path escaping, cookbook slash, clone teardown, Windows clippy ([#446](https://github.com/cq27-dev/rag-rat/pull/446)) ([#449](https://github.com/cq27-dev/rag-rat/pull/449))
- *(dream)* persist failed model attempts ([#450](https://github.com/cq27-dev/rag-rat/pull/450))

### Other

- derive enum strings with strum ([#457](https://github.com/cq27-dev/rag-rat/pull/457))
- Split oracle tests and antiunify module ([#456](https://github.com/cq27-dev/rag-rat/pull/456))
- *(watch)* cover watcher state helpers ([#455](https://github.com/cq27-dev/rag-rat/pull/455))
</blockquote>

## `rag-rat-mcp`

<blockquote>

## [0.14.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.13.0...rag-rat-core-v0.14.0) - 2026-07-07

### Added

- *(index)* make explicit-config adoption loud and refuse empty indexes ([#458](https://github.com/cq27-dev/rag-rat/pull/458))
- *(memory)* apply [memory] surface="summary" to every drive-by renderer ([#426](https://github.com/cq27-dev/rag-rat/pull/426)) ([#453](https://github.com/cq27-dev/rag-rat/pull/453))

### Fixed

- reduce incremental index churn ([#460](https://github.com/cq27-dev/rag-rat/pull/460))
- *(watch)* prune linked worktree watches ([#454](https://github.com/cq27-dev/rag-rat/pull/454))
- *(cross-platform)* full request drain in the ollama-probe and embed stubs ([#446](https://github.com/cq27-dev/rag-rat/pull/446)) ([#452](https://github.com/cq27-dev/rag-rat/pull/452))
- *(cross-platform)* TOML path escaping, cookbook slash, clone teardown, Windows clippy ([#446](https://github.com/cq27-dev/rag-rat/pull/446)) ([#449](https://github.com/cq27-dev/rag-rat/pull/449))
- *(dream)* persist failed model attempts ([#450](https://github.com/cq27-dev/rag-rat/pull/450))

### Other

- derive enum strings with strum ([#457](https://github.com/cq27-dev/rag-rat/pull/457))
- Split oracle tests and antiunify module ([#456](https://github.com/cq27-dev/rag-rat/pull/456))
- *(watch)* cover watcher state helpers ([#455](https://github.com/cq27-dev/rag-rat/pull/455))
</blockquote>

## `rag-rat`

<blockquote>

## [0.14.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.13.0...rag-rat-core-v0.14.0) - 2026-07-07

### Added

- *(index)* make explicit-config adoption loud and refuse empty indexes ([#458](https://github.com/cq27-dev/rag-rat/pull/458))
- *(memory)* apply [memory] surface="summary" to every drive-by renderer ([#426](https://github.com/cq27-dev/rag-rat/pull/426)) ([#453](https://github.com/cq27-dev/rag-rat/pull/453))

### Fixed

- reduce incremental index churn ([#460](https://github.com/cq27-dev/rag-rat/pull/460))
- *(watch)* prune linked worktree watches ([#454](https://github.com/cq27-dev/rag-rat/pull/454))
- *(cross-platform)* full request drain in the ollama-probe and embed stubs ([#446](https://github.com/cq27-dev/rag-rat/pull/446)) ([#452](https://github.com/cq27-dev/rag-rat/pull/452))
- *(cross-platform)* TOML path escaping, cookbook slash, clone teardown, Windows clippy ([#446](https://github.com/cq27-dev/rag-rat/pull/446)) ([#449](https://github.com/cq27-dev/rag-rat/pull/449))
- *(dream)* persist failed model attempts ([#450](https://github.com/cq27-dev/rag-rat/pull/450))

### Other

- derive enum strings with strum ([#457](https://github.com/cq27-dev/rag-rat/pull/457))
- Split oracle tests and antiunify module ([#456](https://github.com/cq27-dev/rag-rat/pull/456))
- *(watch)* cover watcher state helpers ([#455](https://github.com/cq27-dev/rag-rat/pull/455))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).