### PR TITLE
fix(dream): persist failed model attempts

### DIFF
--- a/crates/rag-rat-cli/src/commands/memory.rs
+++ b/crates/rag-rat-cli/src/commands/memory.rs
@@ -97,7 +97,13 @@ pub(crate) fn dream(config: &Config, args: &DreamArgs) -> anyhow::Result<()> {
     let mut _provisioned = None;
     let model = if model_enabled && (args.verify || args.compact) {
         if remote.is_ephemeral() {
-            if db.dream_model_work_pending(opts, budget, args.verify, args.compact)? {
+            if db.dream_model_work_pending(
+                opts,
+                budget,
+                args.verify,
+                args.compact,
+                remote.model.trim(),
+            )? {
                 let (m, provisioned) = rag_rat_core::dream::provision_verdict_model(remote)?;
                 _provisioned = Some(provisioned);
                 Some(m)

--- a/crates/rag-rat-cli/tests/multi_repo_e2e.rs
+++ b/crates/rag-rat-cli/tests/multi_repo_e2e.rs
@@ -1008,7 +1008,7 @@ fn dream_worklist_is_repo_scoped_end_to_end() {
     };
     assert!(
         open_scoped(&repo_a, &data_dir)
-            .dream_model_work_pending(work_opts, 20, true, true)
+            .dream_model_work_pending(work_opts, 20, true, true, "mock-verdict-model")
             .unwrap(),
         "A's model pass has pending work (an un-verified memory) — the guard would provision"
     );

--- a/crates/rag-rat-cli/tests/multi_repo_e2e.rs
+++ b/crates/rag-rat-cli/tests/multi_repo_e2e.rs
@@ -1069,3 +1069,42 @@ fn dream_worklist_is_repo_scoped_end_to_end() {
 
     cleanup(&[&repo_a, &repo_b, &data_dir, &cache]);
 }
+
+#[test]
+fn dream_ephemeral_zero_work_guard_skips_cli_provisioning() {
+    let data_dir = unique_dir("dream-zero-data");
+    let cache = unique_dir("dream-zero-cache");
+    let repo = build_repo(
+        "dream-zero",
+        &[("lib.rs", chunky_fn("dream_zero_anchor"))],
+        concat!(
+            "[index]\n",
+            "root = \".\"\n\n",
+            "[target_bindings]\n",
+            "rust = [\"src\"]\n\n",
+            "[llm.dream]\n",
+            "enabled = true\n\n",
+            "[llm.dream.remote]\n",
+            "backend = \"vllm\"\n",
+            "cookbook = \"./missing-dream-cookbook.mjs\"\n",
+            "model = \"Qwen/Qwen3-4B-Instruct\"\n",
+        ),
+    );
+
+    run_ok(&repo, &data_dir, &cache, &["index", "--full"]);
+    let out =
+        run(&repo, &data_dir, &cache, &["dream", "--verify", "--compact", "--max-memories", "500"]);
+
+    assert!(
+        out.status.success(),
+        "zero-work dream run should not try to spawn the missing cookbook: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("skipping the ephemeral `[llm.dream.remote]` GPU box"),
+        "expected the CLI zero-work guard note, got stderr:\n{stderr}"
+    );
+
+    cleanup(&[&repo, &data_dir, &cache]);
+}

--- a/crates/rag-rat-core/src/dream/compact.rs
+++ b/crates/rag-rat-core/src/dream/compact.rs
@@ -5,8 +5,8 @@
 //! deliberately spartan: one model turn per memory, NO tools, NO code context, NO evidence pack —
 //! the note body is the whole input (the offline eval measured that code context DEGRADES
 //! compaction fidelity). Accepted summaries land in `memory_summaries` (PK `(repo_id, memory_id,
-//! content_hash)`, so a title/body edit self-invalidates and re-queues); a rejected one stores
-//! NOTHING, and the absence of a summary row IS the title-only fallback at surfacing.
+//! content_hash)`, so a title/body edit self-invalidates and re-queues); a rejected one records a
+//! failure row while the absence of a summary row remains the title-only fallback at surfacing.
 //!
 //! Two surfaces the rest of dream consumes:
 //!   - [`run_compact_pass`] — the budgeted runner: queue (active memories with no summary for their
@@ -21,6 +21,9 @@
 
 use rusqlite::{Connection, OptionalExtension};
 
+use super::failure::{
+    self, DreamFailureReason, DreamModelFailure, DreamModelPass, FailureStamp, RecordFailure,
+};
 use super::model::VerdictModel;
 use crate::index::schema;
 
@@ -51,25 +54,51 @@ struct CompactionEntry {
 /// Run the compaction pass over the churn-skip queue (budget-capped). For each queued memory:
 /// render the prompt (note body only), ask the model, run the deterministic acceptance guards
 /// (retry once), and on accept UPSERT `memory_summaries` (pruning superseded rows). A
-/// rejected-twice or errored completion writes nothing — the absence of a row is the title-only
-/// fallback at surfacing, and the next run re-queues the memory. Repo-scoped; never writes a
-/// `repo_memories` column.
+/// rejected-twice completion records `memory_model_failures`; a transient model-call error is
+/// recorded for audit but remains retryable. The absence of a summary row is still the title-only
+/// fallback at surfacing. Repo-scoped; never writes a `repo_memories` column.
 pub(super) fn run_compact_pass(
     conn: &Connection,
     pass: CompactPass<'_>,
     now_ms: i64,
 ) -> anyhow::Result<()> {
-    let queue = compaction_queue(conn, pass.budget)?;
+    let queue = compaction_queue(conn, usize::MAX)?;
     if queue.is_empty() {
         return Ok(());
     }
     let scope = schema::periphery_repo_scope(conn, "repo_memories")?;
     let repo_id = scope.as_deref().unwrap_or("__unassigned__");
 
+    let mut processed = 0usize;
     for entry in queue {
-        let prompt = render_compact_prompt(&entry.title, &entry.body);
-        let Some(summary) = obtain_summary(conn, pass.model, &prompt)? else {
+        if processed >= pass.budget {
+            break;
+        }
+        let content_hash = super::verify::note_content_hash(&entry.title, &entry.body);
+        let failure_stamp = FailureStamp {
+            memory_id: &entry.memory_id,
+            repo_id,
+            pass: DreamModelPass::Compact,
+            content_hash: &content_hash,
+            checked_inputs_hash: None,
+            prompt_version: COMPACT_PROMPT_VERSION,
+            model_id: pass.model.model_id(),
+        };
+        if failure::blocking_failure_is_current(conn, &failure_stamp)? {
             continue;
+        }
+        processed += 1;
+        let prompt = render_compact_prompt(&entry.title, &entry.body);
+        let summary = match obtain_summary(conn, pass.model, &prompt)? {
+            Ok(summary) => summary,
+            Err(failure) => {
+                failure::record_failure(conn, RecordFailure {
+                    stamp: failure_stamp,
+                    failure: &failure,
+                    now_ms,
+                })?;
+                continue;
+            },
         };
         record_summary(conn, RecordSummary {
             memory_id: &entry.memory_id,
@@ -80,6 +109,16 @@ pub(super) fn run_compact_pass(
             model_id: pass.model.model_id(),
             now_ms,
         })?;
+        let failure_stamp = FailureStamp {
+            memory_id: &entry.memory_id,
+            repo_id,
+            pass: DreamModelPass::Compact,
+            content_hash: &content_hash,
+            checked_inputs_hash: None,
+            prompt_version: COMPACT_PROMPT_VERSION,
+            model_id: pass.model.model_id(),
+        };
+        failure::clear_failure(conn, &failure_stamp)?;
     }
     Ok(())
 }
@@ -131,35 +170,63 @@ fn compaction_queue(conn: &Connection, budget: usize) -> rusqlite::Result<Vec<Co
 /// Whether the compaction queue has ANY pending memory (budget-capped) — the compaction half of the
 /// ephemeral zero-work guard ([`super::model_work_pending`]). Cheap: the same churn-skip query the
 /// pass runs, short-circuited to emptiness so a fully-summarized repo never cold-starts a paid box.
-pub(super) fn compaction_pending(conn: &Connection, budget: usize) -> rusqlite::Result<bool> {
-    Ok(!compaction_queue(conn, budget)?.is_empty())
+pub(super) fn compaction_pending(
+    conn: &Connection,
+    budget: usize,
+    model_id: &str,
+) -> rusqlite::Result<bool> {
+    if budget == 0 {
+        return Ok(false);
+    }
+    let scope = schema::periphery_repo_scope(conn, "repo_memories")?;
+    let repo_id = scope.as_deref().unwrap_or("__unassigned__");
+    for entry in compaction_queue(conn, usize::MAX)? {
+        let content_hash = super::verify::note_content_hash(&entry.title, &entry.body);
+        let failure_stamp = FailureStamp {
+            memory_id: &entry.memory_id,
+            repo_id,
+            pass: DreamModelPass::Compact,
+            content_hash: &content_hash,
+            checked_inputs_hash: None,
+            prompt_version: COMPACT_PROMPT_VERSION,
+            model_id,
+        };
+        if failure::blocking_failure_is_current(conn, &failure_stamp)? {
+            continue;
+        }
+        return Ok(true);
+    }
+    Ok(false)
 }
 
 /// Ask the model once, strip any think block, and run the deterministic acceptance guards. On a
-/// guard failure RETRY ONCE (same prompt); a second failure returns `Ok(None)` — store nothing (the
-/// title-only fallback). A model call error also yields `None` (this memory is skipped, re-queued
-/// next run); a DB error in the guards propagates. Small models drift, so the guards are
-/// load-bearing — an unchecked summary would surface a wrong 3-line claim as if authoritative.
+/// guard failure RETRY ONCE (same prompt); a second failure returns a typed deterministic failure.
+/// A model call error also returns a typed failure, but that reason does not suppress future work;
+/// a DB error in the guards propagates. Small models drift, so the guards are load-bearing — an
+/// unchecked summary would surface a wrong 3-line claim as if authoritative.
 fn obtain_summary(
     conn: &Connection,
     model: &dyn VerdictModel,
     prompt: &str,
-) -> rusqlite::Result<Option<String>> {
+) -> rusqlite::Result<Result<String, DreamModelFailure>> {
     for attempt in 1..=2 {
         let raw = match model.complete(prompt) {
             Ok(raw) => raw,
             Err(err) => {
                 tracing::warn!(target: "rag_rat_core::dream::compact", attempt, %err, "compaction model call failed; skipping this memory");
-                return Ok(None);
+                return Ok(Err(DreamModelFailure::with_detail(
+                    DreamFailureReason::ModelCallFailed,
+                    err.to_string(),
+                )));
             },
         };
         let summary = strip_think(&raw);
         if guards::accepts(conn, summary)? {
-            return Ok(Some(summary.to_string()));
+            return Ok(Ok(summary.to_string()));
         }
         tracing::warn!(target: "rag_rat_core::dream::compact", attempt, "compaction summary failed the acceptance guards");
     }
-    Ok(None)
+    Ok(Err(DreamModelFailure::new(DreamFailureReason::SummaryGuardRejected)))
 }
 
 /// Drop a leading `<think>…</think>` reasoning block a thinking model may prepend (the default
@@ -598,6 +665,32 @@ mod tests {
             summary_rows(&c, "m1").is_empty(),
             "two guard failures store nothing (title-only fallback)"
         );
+        let reason: String = c
+            .query_row(
+                "SELECT reason FROM memory_model_failures WHERE repo_id='r' AND memory_id='m1' \
+                 AND pass='compact'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(reason, DreamFailureReason::SummaryGuardRejected.as_db_str());
+
+        run_compact_pass(&c, CompactPass { model: &model, budget: 10 }, 6000).unwrap();
+        assert_eq!(model.calls(), 2, "the current deterministic failure suppresses another retry");
+
+        c.execute("UPDATE repo_memories SET body='edited body' WHERE id='m1'", []).unwrap();
+        let good = MockVerdictModel::new([GOOD_SUMMARY]);
+        run_compact_pass(&c, CompactPass { model: &good, budget: 10 }, 7000).unwrap();
+        assert_eq!(good.calls(), 1, "a content change invalidates the failure row");
+        assert_eq!(summary_rows(&c, "m1").len(), 1, "the changed memory can be summarized");
+        let failures: i64 = c
+            .query_row(
+                "SELECT COUNT(*) FROM memory_model_failures WHERE repo_id='r' AND memory_id='m1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(failures, 0, "a successful summary clears the stale failure row");
     }
 
     // ── write-path stamps + churn / invalidation ─────────────────────────────────

--- a/crates/rag-rat-core/src/dream/compact.rs
+++ b/crates/rag-rat-core/src/dream/compact.rs
@@ -693,6 +693,72 @@ mod tests {
         assert_eq!(failures, 0, "a successful summary clears the stale failure row");
     }
 
+    #[test]
+    fn zero_budget_does_not_call_model_or_report_pending_compaction() {
+        let c = mem_db();
+        set_repo(&c, "r");
+        seed_memory(&c, "m1", "note", "a body worth compacting", "r");
+        let model = MockVerdictModel::new([GOOD_SUMMARY]);
+
+        run_compact_pass(&c, CompactPass { model: &model, budget: 0 }, 1000).unwrap();
+
+        assert_eq!(model.calls(), 0, "budget zero stops before the first model turn");
+        assert!(
+            !compaction_pending(&c, 0, "mock-verdict-model").unwrap(),
+            "budget zero is no pending model work"
+        );
+        assert!(summary_rows(&c, "m1").is_empty(), "no summary is written at budget zero");
+    }
+
+    #[test]
+    fn current_compact_failure_suppresses_pending_compaction() {
+        let c = mem_db();
+        set_repo(&c, "r");
+        seed_memory(&c, "m1", "note", "a body worth compacting", "r");
+        let content_hash = crate::dream::note_content_hash("note", "a body worth compacting");
+        let stamp = FailureStamp {
+            memory_id: "m1",
+            repo_id: "r",
+            pass: DreamModelPass::Compact,
+            content_hash: &content_hash,
+            checked_inputs_hash: None,
+            prompt_version: COMPACT_PROMPT_VERSION,
+            model_id: "mock-verdict-model",
+        };
+        let failure = DreamModelFailure::new(DreamFailureReason::SummaryGuardRejected);
+        failure::record_failure(&c, RecordFailure { stamp, failure: &failure, now_ms: 1 }).unwrap();
+
+        assert!(
+            !compaction_pending(&c, 10, "mock-verdict-model").unwrap(),
+            "a current deterministic compact failure means the memory is already annotated"
+        );
+    }
+
+    #[test]
+    fn model_error_records_retryable_compact_failure() {
+        let c = mem_db();
+        set_repo(&c, "r");
+        seed_memory(&c, "m1", "note", "a body worth compacting", "r");
+        let model = MockVerdictModel::new(Vec::<String>::new());
+
+        run_compact_pass(&c, CompactPass { model: &model, budget: 10 }, 1000).unwrap();
+
+        let (reason, detail): (String, String) = c
+            .query_row(
+                "SELECT reason, detail FROM memory_model_failures WHERE repo_id='r' AND \
+                 memory_id='m1' AND pass='compact'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(reason, DreamFailureReason::ModelCallFailed.as_db_str());
+        assert!(detail.contains("no responses"), "the transient model error is stored for audit");
+        assert!(
+            compaction_pending(&c, 10, "mock-verdict-model").unwrap(),
+            "model-call failures remain retryable work"
+        );
+    }
+
     // ── write-path stamps + churn / invalidation ─────────────────────────────────
 
     #[test]

--- a/crates/rag-rat-core/src/dream/failure.rs
+++ b/crates/rag-rat-core/src/dream/failure.rs
@@ -195,6 +195,18 @@ mod tests {
     use super::*;
     use crate::dream::tests::mem_db;
 
+    fn stamp() -> FailureStamp<'static> {
+        FailureStamp {
+            memory_id: "m1",
+            repo_id: "r",
+            pass: DreamModelPass::Verify,
+            content_hash: "content",
+            checked_inputs_hash: Some("inputs"),
+            prompt_version: "prompt",
+            model_id: "model",
+        }
+    }
+
     #[test]
     fn persisted_enums_round_trip() {
         for pass in DreamModelPass::ALL {
@@ -276,5 +288,50 @@ mod tests {
             !blocking_failure_is_current(&c, &active_stamp).unwrap(),
             "a sibling repo's failure row must not suppress active-repo work"
         );
+    }
+
+    #[test]
+    fn failure_detail_is_trimmed_bounded_and_attempts_are_counted() {
+        let c = mem_db();
+        let long_detail = format!("  {}  ", "x".repeat(501));
+        let failure =
+            DreamModelFailure::with_detail(DreamFailureReason::MalformedVerdict, long_detail);
+
+        record_failure(&c, RecordFailure { stamp: stamp(), failure: &failure, now_ms: 1 }).unwrap();
+        record_failure(&c, RecordFailure { stamp: stamp(), failure: &failure, now_ms: 2 }).unwrap();
+
+        let (detail, attempts): (String, i64) = c
+            .query_row(
+                "SELECT detail, attempts FROM memory_model_failures WHERE repo_id='r' AND \
+                 memory_id='m1' AND pass='verify'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(detail.chars().count(), 503, "500 chars plus an ellipsis marker are stored");
+        assert!(detail.ends_with("..."), "oversized detail is explicitly marked as truncated");
+        assert!(!detail.starts_with(' '), "detail is trimmed before storage");
+        assert_eq!(attempts, 2, "same failure/input increments the audit attempt count");
+    }
+
+    #[test]
+    fn unknown_reason_does_not_block_and_clear_removes_the_row() {
+        let c = mem_db();
+        c.execute(
+            "INSERT INTO memory_model_failures(memory_id, repo_id, pass, content_hash, \
+             checked_inputs_hash, model_id, prompt_version, reason, failed_at_ms) VALUES \
+             ('m1','r','verify','content','inputs','model','prompt','legacy_reason',1)",
+            [],
+        )
+        .unwrap();
+        assert!(
+            !blocking_failure_is_current(&c, &stamp()).unwrap(),
+            "unknown persisted reasons are audit-only and must not suppress work"
+        );
+
+        clear_failure(&c, &stamp()).unwrap();
+        let remaining: i64 =
+            c.query_row("SELECT COUNT(*) FROM memory_model_failures", [], |r| r.get(0)).unwrap();
+        assert_eq!(remaining, 0, "clear_failure deletes the current row");
     }
 }

--- a/crates/rag-rat-core/src/dream/failure.rs
+++ b/crates/rag-rat-core/src/dream/failure.rs
@@ -1,0 +1,280 @@
+//! Persisted model-pass failures for dream verification / compaction.
+//!
+//! A missing `memory_reality` / `memory_summaries` row used to mean both "never tried" and "the
+//! model result was rejected", so deterministic guard failures were retried every run. This table
+//! records the latter explicitly, with stable enum tokens and the same freshness stamps the
+//! producer queues already use.
+
+use rusqlite::{Connection, OptionalExtension};
+
+/// Which model pass attempted a memory. Persisted in `memory_model_failures.pass`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DreamModelPass {
+    Verify,
+    Compact,
+}
+
+impl DreamModelPass {
+    #[cfg(test)]
+    pub(crate) const ALL: [Self; 2] = [Self::Verify, Self::Compact];
+
+    pub(crate) fn as_db_str(self) -> &'static str {
+        match self {
+            Self::Verify => "verify",
+            Self::Compact => "compact",
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_db_str(value: &str) -> Option<Self> {
+        match value {
+            "verify" => Some(Self::Verify),
+            "compact" => Some(Self::Compact),
+            _ => None,
+        }
+    }
+}
+
+/// Why a model attempt failed. Persisted in `memory_model_failures.reason`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DreamFailureReason {
+    /// Transport/server failure. Audited, but not used to suppress future model calls because it is
+    /// often transient.
+    ModelCallFailed,
+    /// The verdict completion did not contain a supported `current` / `diverged` answer.
+    MalformedVerdict,
+    /// The verdict cited evidence absent from the deterministic pack, twice.
+    FabricatedEvidence,
+    /// The compaction completion failed the deterministic shape/reference guards, twice.
+    SummaryGuardRejected,
+}
+
+impl DreamFailureReason {
+    #[cfg(test)]
+    pub(crate) const ALL: [Self; 4] = [
+        Self::ModelCallFailed,
+        Self::MalformedVerdict,
+        Self::FabricatedEvidence,
+        Self::SummaryGuardRejected,
+    ];
+
+    pub(crate) fn as_db_str(self) -> &'static str {
+        match self {
+            Self::ModelCallFailed => "model_call_failed",
+            Self::MalformedVerdict => "malformed_verdict",
+            Self::FabricatedEvidence => "fabricated_evidence",
+            Self::SummaryGuardRejected => "summary_guard_rejected",
+        }
+    }
+
+    pub(crate) fn from_db_str(value: &str) -> Option<Self> {
+        match value {
+            "model_call_failed" => Some(Self::ModelCallFailed),
+            "malformed_verdict" => Some(Self::MalformedVerdict),
+            "fabricated_evidence" => Some(Self::FabricatedEvidence),
+            "summary_guard_rejected" => Some(Self::SummaryGuardRejected),
+            _ => None,
+        }
+    }
+
+    /// Whether an unchanged input should be considered already annotated for this model.
+    pub(crate) fn blocks_model_work(self) -> bool {
+        !matches!(self, Self::ModelCallFailed)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DreamModelFailure {
+    pub(crate) reason: DreamFailureReason,
+    pub(crate) detail: Option<String>,
+}
+
+impl DreamModelFailure {
+    pub(crate) fn new(reason: DreamFailureReason) -> Self {
+        Self { reason, detail: None }
+    }
+
+    pub(crate) fn with_detail(reason: DreamFailureReason, detail: impl Into<String>) -> Self {
+        Self { reason, detail: Some(detail.into()) }
+    }
+}
+
+pub(crate) struct FailureStamp<'a> {
+    pub(crate) memory_id: &'a str,
+    pub(crate) repo_id: &'a str,
+    pub(crate) pass: DreamModelPass,
+    pub(crate) content_hash: &'a str,
+    pub(crate) checked_inputs_hash: Option<&'a str>,
+    pub(crate) prompt_version: &'a str,
+    pub(crate) model_id: &'a str,
+}
+
+pub(crate) struct RecordFailure<'a> {
+    pub(crate) stamp: FailureStamp<'a>,
+    pub(crate) failure: &'a DreamModelFailure,
+    pub(crate) now_ms: i64,
+}
+
+/// True when a current failure row exists and its reason is deterministic enough to suppress
+/// another model call for the same memory/pass/input/model.
+pub(crate) fn blocking_failure_is_current(
+    conn: &Connection,
+    stamp: &FailureStamp<'_>,
+) -> rusqlite::Result<bool> {
+    let row: Option<(String, Option<String>, String, String, String)> = conn
+        .query_row(
+            "SELECT content_hash, checked_inputs_hash, prompt_version, model_id, reason FROM \
+             memory_model_failures WHERE repo_id = ?1 AND memory_id = ?2 AND pass = ?3",
+            rusqlite::params![stamp.repo_id, stamp.memory_id, stamp.pass.as_db_str()],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+        )
+        .optional()?;
+    let Some((content_hash, inputs_hash, prompt_version, model_id, reason)) = row else {
+        return Ok(false);
+    };
+    let Some(reason) = DreamFailureReason::from_db_str(&reason) else {
+        return Ok(false);
+    };
+    Ok(reason.blocks_model_work()
+        && content_hash == stamp.content_hash
+        && inputs_hash.as_deref() == stamp.checked_inputs_hash
+        && prompt_version == stamp.prompt_version
+        && model_id == stamp.model_id)
+}
+
+pub(crate) fn record_failure(conn: &Connection, r: RecordFailure<'_>) -> rusqlite::Result<()> {
+    let detail = r.failure.detail.as_deref().map(bounded_detail);
+    conn.execute(
+        "INSERT INTO memory_model_failures(memory_id, repo_id, pass, content_hash, \
+         checked_inputs_hash, model_id, prompt_version, reason, detail, failed_at_ms, attempts) \
+         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,1) ON CONFLICT(repo_id, memory_id, pass) DO \
+         UPDATE SET attempts = CASE WHEN memory_model_failures.content_hash = \
+         excluded.content_hash AND memory_model_failures.checked_inputs_hash IS \
+         excluded.checked_inputs_hash AND memory_model_failures.model_id = excluded.model_id AND \
+         memory_model_failures.prompt_version = excluded.prompt_version AND \
+         memory_model_failures.reason = excluded.reason THEN memory_model_failures.attempts + 1 \
+         ELSE 1 END, content_hash = excluded.content_hash, checked_inputs_hash = \
+         excluded.checked_inputs_hash, model_id = excluded.model_id, prompt_version = \
+         excluded.prompt_version, reason = excluded.reason, detail = excluded.detail, \
+         failed_at_ms = excluded.failed_at_ms",
+        rusqlite::params![
+            r.stamp.memory_id,
+            r.stamp.repo_id,
+            r.stamp.pass.as_db_str(),
+            r.stamp.content_hash,
+            r.stamp.checked_inputs_hash,
+            r.stamp.model_id,
+            r.stamp.prompt_version,
+            r.failure.reason.as_db_str(),
+            detail.as_deref(),
+            r.now_ms,
+        ],
+    )?;
+    Ok(())
+}
+
+pub(crate) fn clear_failure(conn: &Connection, stamp: &FailureStamp<'_>) -> rusqlite::Result<()> {
+    conn.execute(
+        "DELETE FROM memory_model_failures WHERE repo_id = ?1 AND memory_id = ?2 AND pass = ?3",
+        rusqlite::params![stamp.repo_id, stamp.memory_id, stamp.pass.as_db_str()],
+    )?;
+    Ok(())
+}
+
+fn bounded_detail(detail: &str) -> String {
+    let trimmed = detail.trim();
+    let mut out = trimmed.chars().take(500).collect::<String>();
+    if trimmed.chars().count() > 500 {
+        out.push_str("...");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dream::tests::mem_db;
+
+    #[test]
+    fn persisted_enums_round_trip() {
+        for pass in DreamModelPass::ALL {
+            assert_eq!(DreamModelPass::from_db_str(pass.as_db_str()), Some(pass));
+        }
+        assert_eq!(DreamModelPass::from_db_str("nope"), None);
+
+        for reason in DreamFailureReason::ALL {
+            assert_eq!(DreamFailureReason::from_db_str(reason.as_db_str()), Some(reason));
+        }
+        assert_eq!(DreamFailureReason::from_db_str("nope"), None);
+    }
+
+    #[test]
+    fn current_deterministic_failures_block_but_model_call_failures_do_not() {
+        let c = mem_db();
+        let stamp = FailureStamp {
+            memory_id: "m1",
+            repo_id: "r",
+            pass: DreamModelPass::Verify,
+            content_hash: "content",
+            checked_inputs_hash: Some("inputs"),
+            prompt_version: "prompt",
+            model_id: "model",
+        };
+        let deterministic = DreamModelFailure::new(DreamFailureReason::FabricatedEvidence);
+        record_failure(&c, RecordFailure { stamp, failure: &deterministic, now_ms: 1 }).unwrap();
+        let stamp = FailureStamp {
+            memory_id: "m1",
+            repo_id: "r",
+            pass: DreamModelPass::Verify,
+            content_hash: "content",
+            checked_inputs_hash: Some("inputs"),
+            prompt_version: "prompt",
+            model_id: "model",
+        };
+        assert!(blocking_failure_is_current(&c, &stamp).unwrap());
+
+        let transient = DreamModelFailure::new(DreamFailureReason::ModelCallFailed);
+        record_failure(&c, RecordFailure { stamp, failure: &transient, now_ms: 2 }).unwrap();
+        let stamp = FailureStamp {
+            memory_id: "m1",
+            repo_id: "r",
+            pass: DreamModelPass::Verify,
+            content_hash: "content",
+            checked_inputs_hash: Some("inputs"),
+            prompt_version: "prompt",
+            model_id: "model",
+        };
+        assert!(!blocking_failure_is_current(&c, &stamp).unwrap());
+    }
+
+    #[test]
+    fn failure_rows_are_repo_scoped() {
+        let c = mem_db();
+        let sibling_stamp = FailureStamp {
+            memory_id: "m1",
+            repo_id: "sibling",
+            pass: DreamModelPass::Compact,
+            content_hash: "content",
+            checked_inputs_hash: None,
+            prompt_version: "prompt",
+            model_id: "model",
+        };
+        let failure = DreamModelFailure::new(DreamFailureReason::SummaryGuardRejected);
+        record_failure(&c, RecordFailure { stamp: sibling_stamp, failure: &failure, now_ms: 1 })
+            .unwrap();
+
+        let active_stamp = FailureStamp {
+            memory_id: "m1",
+            repo_id: "active",
+            pass: DreamModelPass::Compact,
+            content_hash: "content",
+            checked_inputs_hash: None,
+            prompt_version: "prompt",
+            model_id: "model",
+        };
+        assert!(
+            !blocking_failure_is_current(&c, &active_stamp).unwrap(),
+            "a sibling repo's failure row must not suppress active-repo work"
+        );
+    }
+}

--- a/crates/rag-rat-core/src/dream/mod.rs
+++ b/crates/rag-rat-core/src/dream/mod.rs
@@ -19,10 +19,11 @@
 //! The v2 verification pass (`verify`) also exposes [`verification_queue`] and [`evidence_pack`] —
 //! the deterministic substrate the phase-B model verdict pass consumes (churn-skip queue + a
 //! citation-checkable evidence pack), reading the `memory_reality` / `memory_summaries` sibling
-//! tables (V045). Those sibling tables hold DERIVED, regenerable data, which is what preserves
+//! tables (V046+). Those sibling tables hold DERIVED, regenerable data, which is what preserves
 //! dream's "never mutates a `repo_memories` row" invariant even as verification lands.
 
 mod compact;
+mod failure;
 mod findings;
 mod model;
 mod verdict;
@@ -245,15 +246,37 @@ pub fn model_work_pending(
     budget: usize,
     verify: bool,
     compact: bool,
+    model_id: &str,
 ) -> anyhow::Result<bool> {
     if verify {
-        for entry in verify::verification_queue(conn, opts.now_ms, budget)? {
+        let scope = crate::index::schema::periphery_repo_scope(conn, "repo_memories")?;
+        let repo_id = scope.as_deref().unwrap_or("__unassigned__");
+        let mut considered = 0usize;
+        for entry in verify::verification_queue(conn, opts.now_ms, usize::MAX)? {
+            if considered >= budget {
+                break;
+            }
+            let inputs_hash = verify::checked_inputs_hash(conn, &entry.memory_id, &scope)?;
+            let content_hash = verify::note_content_hash(&entry.title, &entry.body);
+            let failure_stamp = failure::FailureStamp {
+                memory_id: &entry.memory_id,
+                repo_id,
+                pass: failure::DreamModelPass::Verify,
+                content_hash: &content_hash,
+                checked_inputs_hash: Some(&inputs_hash),
+                prompt_version: verdict::PROMPT_VERSION,
+                model_id,
+            };
+            if failure::blocking_failure_is_current(conn, &failure_stamp)? {
+                continue;
+            }
+            considered += 1;
             if verify::evidence_pack(conn, &entry.memory_id)?.is_citable() {
                 return Ok(true);
             }
         }
     }
-    if compact && compact::compaction_pending(conn, budget)? {
+    if compact && compact::compaction_pending(conn, budget, model_id)? {
         return Ok(true);
     }
     Ok(false)

--- a/crates/rag-rat-core/src/dream/verdict.rs
+++ b/crates/rag-rat-core/src/dream/verdict.rs
@@ -893,6 +893,33 @@ mod tests {
         assert_eq!(model.calls(), 2, "retried exactly once");
     }
 
+    #[test]
+    fn obtain_verdict_records_model_call_failure() {
+        let pack = "IDENTIFIERS:\n- `real_symbol` -> symbol src/lib.rs::real_symbol\n";
+        let model = MockVerdictModel::new(Vec::<String>::new());
+
+        let err = obtain_verdict(&model, "prompt", pack).expect_err("model error fails");
+
+        assert_eq!(err.reason, DreamFailureReason::ModelCallFailed);
+        assert!(
+            err.detail.as_deref().is_some_and(|detail| detail.contains("no responses")),
+            "the model-call error detail is preserved"
+        );
+        assert_eq!(model.calls(), 1, "transport/model errors are not retried");
+    }
+
+    #[test]
+    fn obtain_verdict_discards_malformed_without_retry() {
+        let pack = "IDENTIFIERS:\n- `real_symbol` -> symbol src/lib.rs::real_symbol\n";
+        let model =
+            MockVerdictModel::new(["not a verdict".to_string(), current_citing("real_symbol")]);
+
+        let err = obtain_verdict(&model, "prompt", pack).expect_err("malformed verdict fails");
+
+        assert_eq!(err.reason, DreamFailureReason::MalformedVerdict);
+        assert_eq!(model.calls(), 1, "malformed completions are discarded without retry");
+    }
+
     // ── prompt + pack rendering ──────────────────────────────────────────────────
 
     #[test]
@@ -970,6 +997,44 @@ mod tests {
         assert_eq!(row.3, PROMPT_VERSION);
         assert_eq!(row.4, verify::note_content_hash("note", "describes `resolvable_thing`"));
         assert_eq!(row.5, 5000);
+    }
+
+    #[test]
+    fn verdict_pass_budget_stops_before_second_memory() {
+        let c = seeded_verifiable_repo();
+        seed_symbol_file(&c, "src/other.rs", "second_thing", "r");
+        seed_memory(&c, "m2", "note", "describes `second_thing`", "r");
+        let model = MockVerdictModel::new([
+            current_citing("resolvable_thing"),
+            current_citing("second_thing"),
+        ]);
+
+        run_verdict_pass(&c, VerdictPass { model: &model, budget: 1 }, 5000).unwrap();
+
+        assert_eq!(model.calls(), 1, "budget one verifies only the first queued memory");
+        let rows: i64 =
+            c.query_row("SELECT COUNT(*) FROM memory_reality", [], |r| r.get(0)).unwrap();
+        assert_eq!(rows, 1, "the second queued memory is left for a later run");
+    }
+
+    #[test]
+    fn failed_verdict_completion_records_failure_row() {
+        let c = seeded_verifiable_repo();
+        let model = MockVerdictModel::new(["not a verdict"]);
+
+        run_verdict_pass(&c, VerdictPass { model: &model, budget: 10 }, 5000).unwrap();
+
+        let (reason, attempts): (String, i64) = c
+            .query_row(
+                "SELECT reason, attempts FROM memory_model_failures WHERE repo_id='r' AND \
+                 memory_id='m1' AND pass='verify'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(reason, DreamFailureReason::MalformedVerdict.as_db_str());
+        assert_eq!(attempts, 1);
+        assert_eq!(model.calls(), 1);
     }
 
     #[test]

--- a/crates/rag-rat-core/src/dream/verdict.rs
+++ b/crates/rag-rat-core/src/dream/verdict.rs
@@ -23,6 +23,9 @@
 use rusqlite::Connection;
 
 use super::DreamFinding;
+use super::failure::{
+    self, DreamFailureReason, DreamModelFailure, DreamModelPass, FailureStamp, RecordFailure,
+};
 use super::model::VerdictModel;
 use super::verify::{
     self, EvidencePack, VerificationQueueEntry, evidence_pack, verification_queue,
@@ -124,14 +127,15 @@ struct AcceptedVerdict {
 /// Run the model verdict pass over the churn-skip queue (budget-capped). For each queued memory:
 /// build the deterministic evidence pack, render the prompt, ask the model, guard citations, and on
 /// accept UPSERT `memory_reality`. A discarded verdict (unverifiable/malformed/fabricated-twice) or
-/// a memory not visible in scope simply writes nothing — the next run re-queues it. Repo-scoped;
+/// a memory not visible in scope writes no verdict; deterministic model rejections are recorded in
+/// `memory_model_failures` so unchanged inputs do not re-call the model every run. Repo-scoped;
 /// never writes a `repo_memories` column.
 pub(super) fn run_verdict_pass(
     conn: &Connection,
     pass: VerdictPass<'_>,
     now_ms: i64,
 ) -> anyhow::Result<()> {
-    let queue = verification_queue(conn, now_ms, pass.budget)?;
+    let queue = verification_queue(conn, now_ms, usize::MAX)?;
     if queue.is_empty() {
         return Ok(());
     }
@@ -141,9 +145,27 @@ pub(super) fn run_verdict_pass(
     // unmerged in-flight work is reviewable rather than looking arbitrarily stale.
     let checked_against_commit = indexed_commit(conn, &scope)?;
 
+    let mut processed = 0usize;
     for entry in queue {
+        if processed >= pass.budget {
+            break;
+        }
         let pack = evidence_pack(conn, &entry.memory_id)?;
         let inputs_hash = verify::checked_inputs_hash(conn, &entry.memory_id, &scope)?;
+        let content_hash = verify::note_content_hash(&entry.title, &entry.body);
+        let failure_stamp = FailureStamp {
+            memory_id: &entry.memory_id,
+            repo_id,
+            pass: DreamModelPass::Verify,
+            content_hash: &content_hash,
+            checked_inputs_hash: Some(&inputs_hash),
+            prompt_version: PROMPT_VERSION,
+            model_id: pass.model.model_id(),
+        };
+        if failure::blocking_failure_is_current(conn, &failure_stamp)? {
+            continue;
+        }
+        processed += 1;
         // An uncitable pack (no identifiers, no excerpts) can only produce a discarded verdict, so
         // skip the model and record a TERMINAL verdict-less row: it stamps the churn-skip
         // comparators so the memory does not re-queue every run (starving later memories), while a
@@ -159,13 +181,22 @@ pub(super) fn run_verdict_pass(
                 checked_against_commit: checked_against_commit.as_deref(),
                 now_ms,
             })?;
+            failure::clear_failure(conn, &failure_stamp)?;
             continue;
         }
         let pack_text = render_pack(&pack);
         let binding = binding_label(conn, &entry.memory_id, &scope)?;
         let prompt = render_verdict_prompt(&entry, &binding, &pack_text);
-        let Some(accepted) = obtain_verdict(pass.model, &prompt, &pack_text) else {
-            continue;
+        let accepted = match obtain_verdict(pass.model, &prompt, &pack_text) {
+            Ok(accepted) => accepted,
+            Err(failure) => {
+                failure::record_failure(conn, RecordFailure {
+                    stamp: failure_stamp,
+                    failure: &failure,
+                    now_ms,
+                })?;
+                continue;
+            },
         };
         record_verdict(conn, RecordVerdict {
             memory_id: &entry.memory_id,
@@ -178,6 +209,16 @@ pub(super) fn run_verdict_pass(
             model_id: pass.model.model_id(),
             now_ms,
         })?;
+        let failure_stamp = FailureStamp {
+            memory_id: &entry.memory_id,
+            repo_id,
+            pass: DreamModelPass::Verify,
+            content_hash: &content_hash,
+            checked_inputs_hash: Some(&inputs_hash),
+            prompt_version: PROMPT_VERSION,
+            model_id: pass.model.model_id(),
+        };
+        failure::clear_failure(conn, &failure_stamp)?;
     }
     Ok(())
 }
@@ -191,22 +232,25 @@ fn obtain_verdict(
     model: &dyn VerdictModel,
     prompt: &str,
     pack_text: &str,
-) -> Option<AcceptedVerdict> {
+) -> Result<AcceptedVerdict, DreamModelFailure> {
     for attempt in 1..=2 {
         let raw = match model.complete(prompt) {
             Ok(raw) => raw,
             Err(err) => {
                 tracing::warn!(target: "rag_rat_core::dream::verdict", attempt, %err, "verdict model call failed; discarding this memory's verdict");
-                return None;
+                return Err(DreamModelFailure::with_detail(
+                    DreamFailureReason::ModelCallFailed,
+                    err.to_string(),
+                ));
             },
         };
         let Some(parsed) = parse_verdict(&raw) else {
             // Malformed or a stray `unverifiable` — discard, no retry (not a citation fault).
             tracing::debug!(target: "rag_rat_core::dream::verdict", "discarding unparseable/unverifiable verdict completion");
-            return None;
+            return Err(DreamModelFailure::new(DreamFailureReason::MalformedVerdict));
         };
         if verdict_is_cited(pack_text, &parsed) {
-            return Some(AcceptedVerdict {
+            return Ok(AcceptedVerdict {
                 verdict: parsed.verdict,
                 direction: parsed.direction,
                 evidence: parsed.evidence,
@@ -215,7 +259,7 @@ fn obtain_verdict(
         // Fabricated citation. Retry once, then discard.
         tracing::warn!(target: "rag_rat_core::dream::verdict", attempt, "verdict cited a line absent from the evidence pack (possible fabrication)");
     }
-    None
+    Err(DreamModelFailure::new(DreamFailureReason::FabricatedEvidence))
 }
 
 // ── Prompt + pack rendering ──────────────────────────────────────────────────────────────────
@@ -844,10 +888,8 @@ mod tests {
     fn obtain_verdict_discards_after_two_fabrications() {
         let pack = "IDENTIFIERS:\n- `real_symbol` -> symbol src/lib.rs::real_symbol\n";
         let model = MockVerdictModel::new([current_citing("ghost_a"), current_citing("ghost_b")]);
-        assert!(
-            obtain_verdict(&model, "prompt", pack).is_none(),
-            "two fabrications discard the verdict"
-        );
+        let err = obtain_verdict(&model, "prompt", pack).expect_err("two fabrications fail");
+        assert_eq!(err.reason, DreamFailureReason::FabricatedEvidence);
         assert_eq!(model.calls(), 2, "retried exactly once");
     }
 
@@ -957,6 +999,46 @@ mod tests {
         .unwrap();
         run_verdict_pass(&c, VerdictPass { model: &model, budget: 10 }, 3000).unwrap();
         assert_eq!(model.calls(), 2, "a body edit re-invokes the model");
+    }
+
+    #[test]
+    fn current_failed_verdict_attempt_skips_model_until_input_changes() {
+        let c = seeded_verifiable_repo();
+        let scope = Some("r".to_string());
+        let inputs = verify::checked_inputs_hash(&c, "m1", &scope).unwrap();
+        let content_hash = verify::note_content_hash("note", "describes `resolvable_thing`");
+        let stamp = FailureStamp {
+            memory_id: "m1",
+            repo_id: "r",
+            pass: DreamModelPass::Verify,
+            content_hash: &content_hash,
+            checked_inputs_hash: Some(&inputs),
+            prompt_version: PROMPT_VERSION,
+            model_id: "mock-verdict-model",
+        };
+        let failed = DreamModelFailure::new(DreamFailureReason::FabricatedEvidence);
+        failure::record_failure(&c, RecordFailure { stamp, failure: &failed, now_ms: 1000 })
+            .unwrap();
+
+        let model = MockVerdictModel::new([current_citing("resolvable_thing")]);
+        run_verdict_pass(&c, VerdictPass { model: &model, budget: 10 }, 2000).unwrap();
+        assert_eq!(model.calls(), 0, "a current deterministic failure row suppresses the retry");
+
+        c.execute(
+            "UPDATE repo_memories SET body='describes `resolvable_thing` v2' WHERE id='m1'",
+            [],
+        )
+        .unwrap();
+        run_verdict_pass(&c, VerdictPass { model: &model, budget: 10 }, 3000).unwrap();
+        assert_eq!(model.calls(), 1, "a content change invalidates the failure row");
+        let failures: i64 = c
+            .query_row(
+                "SELECT COUNT(*) FROM memory_model_failures WHERE repo_id='r' AND memory_id='m1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(failures, 0, "a successful verdict clears the stale failure row");
     }
 
     // ── divergence-finding lifecycle (the resolve trap) ──────────────────────────

--- a/crates/rag-rat-core/src/dream/verify.rs
+++ b/crates/rag-rat-core/src/dream/verify.rs
@@ -829,6 +829,11 @@ mod tests {
                 .unwrap(),
             "a citable never-checked memory is verify-pending"
         );
+        assert!(
+            !crate::dream::model_work_pending(&c, opts, 0, true, false, "mock-verdict-model")
+                .unwrap(),
+            "budget zero stops before considering the citable verify entry"
+        );
         let inputs = checked_inputs_hash(&c, "m2", &Some("r".to_string())).unwrap();
         let content_hash = content_hash("t", "a note about `resolve_marker_token`");
         let stamp = crate::dream::failure::FailureStamp {

--- a/crates/rag-rat-core/src/dream/verify.rs
+++ b/crates/rag-rat-core/src/dream/verify.rs
@@ -796,7 +796,8 @@ mod tests {
             include_reviewed: false,
         };
         assert!(
-            !crate::dream::model_work_pending(&c, opts, 10, true, true).unwrap(),
+            !crate::dream::model_work_pending(&c, opts, 10, true, true, "mock-verdict-model")
+                .unwrap(),
             "empty repo → no work"
         );
 
@@ -804,11 +805,13 @@ mod tests {
         // but compaction WILL summarize it.
         seed_memory(&c, "m1", "t", "a prose note with no identifiers", "r");
         assert!(
-            !crate::dream::model_work_pending(&c, opts, 10, true, false).unwrap(),
+            !crate::dream::model_work_pending(&c, opts, 10, true, false, "mock-verdict-model")
+                .unwrap(),
             "an all-uncitable verify queue is NOT model work — never cold-start a box for it"
         );
         assert!(
-            crate::dream::model_work_pending(&c, opts, 10, false, true).unwrap(),
+            crate::dream::model_work_pending(&c, opts, 10, false, true, "mock-verdict-model")
+                .unwrap(),
             "the same memory IS compact-pending (compaction has no uncitable short-circuit)"
         );
 
@@ -822,12 +825,39 @@ mod tests {
         .unwrap();
         seed_memory(&c, "m2", "t", "a note about `resolve_marker_token`", "r");
         assert!(
-            crate::dream::model_work_pending(&c, opts, 10, true, false).unwrap(),
+            crate::dream::model_work_pending(&c, opts, 10, true, false, "mock-verdict-model")
+                .unwrap(),
             "a citable never-checked memory is verify-pending"
+        );
+        let inputs = checked_inputs_hash(&c, "m2", &Some("r".to_string())).unwrap();
+        let content_hash = content_hash("t", "a note about `resolve_marker_token`");
+        let stamp = crate::dream::failure::FailureStamp {
+            memory_id: "m2",
+            repo_id: "r",
+            pass: crate::dream::failure::DreamModelPass::Verify,
+            content_hash: &content_hash,
+            checked_inputs_hash: Some(&inputs),
+            prompt_version: crate::dream::verdict::PROMPT_VERSION,
+            model_id: "mock-verdict-model",
+        };
+        let failed = crate::dream::failure::DreamModelFailure::new(
+            crate::dream::failure::DreamFailureReason::FabricatedEvidence,
+        );
+        crate::dream::failure::record_failure(&c, crate::dream::failure::RecordFailure {
+            stamp,
+            failure: &failed,
+            now_ms: 2,
+        })
+        .unwrap();
+        assert!(
+            !crate::dream::model_work_pending(&c, opts, 10, true, false, "mock-verdict-model")
+                .unwrap(),
+            "a current deterministic failure is annotated work, not pending model work"
         );
 
         assert!(
-            !crate::dream::model_work_pending(&c, opts, 10, false, false).unwrap(),
+            !crate::dream::model_work_pending(&c, opts, 10, false, false, "mock-verdict-model")
+                .unwrap(),
             "neither flag → never pending"
         );
     }

--- a/crates/rag-rat-core/src/index/poison_sibling.rs
+++ b/crates/rag-rat-core/src/index/poison_sibling.rs
@@ -41,8 +41,8 @@
 //! `logical_symbol_monikers` (now direct, no longer only transitive), `oracle_runs`, `edge_oracle`,
 //! `clone_graph_generations`, `clone_token_df`, `clone_refinements`, `dream_findings`, and
 //! `reconcile_attempts` (with `repo_memory_tags` scoped transitively through `repo_memories`) — AND
-//! the V046 dream-verification siblings `memory_reality` / `memory_summaries`, each of which
-//! carries its own `repo_id`.
+//! the dream-verification siblings `memory_reality` / `memory_summaries` /
+//! `memory_model_failures`, each of which carries its own `repo_id`.
 //! [`seed_sibling`] seeds a tripwire row into every one of those. Nothing repo-scoped is left
 //! unseeded; a table without a `repo_id` dimension (content-addressed pools like
 //! `name_strings` / `embedding_cache`, the FTS-derived `chunk_fts`, `clone_edges`/postings scoped
@@ -579,9 +579,9 @@ pub(crate) fn seed_sibling(conn: &Connection) -> anyhow::Result<()> {
         params![format!("{POISON_PREFIX}status"), POISON_REPO_ID],
     )?;
 
-    // --- Dream v2 verification siblings (V046): memory_reality + memory_summaries each carry their
-    // own `repo_id`, so a sibling row is now valid and any unscoped verification-queue / evidence /
-    // summary read/count/delete trips a tripwire. Both hang off the poison memory id. ---
+    // --- Dream v2 verification siblings: each carries its own `repo_id`, so a sibling row is now
+    // valid and any unscoped verification-queue / evidence / summary / failure read/count/delete
+    // trips a tripwire. They all hang off the poison memory id. ---
     conn.execute(
         "INSERT INTO memory_reality(memory_id, repo_id, content_hash, checked_at_ms)
          VALUES (?1, ?2, ?3, 0)",
@@ -595,6 +595,18 @@ pub(crate) fn seed_sibling(conn: &Connection) -> anyhow::Result<()> {
             POISON_REPO_ID,
             format!("{POISON_PREFIX}bodyhash"),
             format!("{POISON_PREFIX}summary")
+        ],
+    )?;
+    conn.execute(
+        "INSERT INTO memory_model_failures(memory_id, repo_id, pass, content_hash, model_id, \
+         prompt_version, reason, failed_at_ms)
+         VALUES (?1, ?2, 'compact', ?3, ?4, ?5, 'summary_guard_rejected', 0)",
+        params![
+            POISON_MEMORY_ID,
+            POISON_REPO_ID,
+            format!("{POISON_PREFIX}bodyhash"),
+            format!("{POISON_PREFIX}model"),
+            format!("{POISON_PREFIX}prompt")
         ],
     )?;
 
@@ -772,6 +784,7 @@ fn clear_sibling(conn: &Connection) -> anyhow::Result<()> {
          DELETE FROM reconcile_attempts WHERE repo_id = '{POISON_REPO_ID}';
          DELETE FROM memory_reality WHERE repo_id = '{POISON_REPO_ID}';
          DELETE FROM memory_summaries WHERE repo_id = '{POISON_REPO_ID}';
+         DELETE FROM memory_model_failures WHERE repo_id = '{POISON_REPO_ID}';
          DELETE FROM dream_findings WHERE repo_id = '{POISON_REPO_ID}';
          DELETE FROM clone_refinements WHERE repo_id = '{POISON_REPO_ID}';
          DELETE FROM clone_token_df WHERE repo_id = '{POISON_REPO_ID}';
@@ -946,14 +959,17 @@ fn sibling_tripwires(conn: &Connection) -> anyhow::Result<Vec<(&'static str, Str
         ("clone_refinements", format!("repo_id = '{POISON_REPO_ID}'")),
         ("dream_findings", format!("repo_id = '{POISON_REPO_ID}'")),
         ("reconcile_attempts", format!("repo_id = '{POISON_REPO_ID}'")),
-        // Dream v2 verification siblings (V046): each pinned by the sibling repo_id + poison
-        // memory.
+        // Dream v2 verification siblings: each pinned by the sibling repo_id + poison memory.
         (
             "memory_reality",
             format!("repo_id = '{POISON_REPO_ID}' AND memory_id = '{POISON_MEMORY_ID}'"),
         ),
         (
             "memory_summaries",
+            format!("repo_id = '{POISON_REPO_ID}' AND memory_id = '{POISON_MEMORY_ID}'"),
+        ),
+        (
+            "memory_model_failures",
             format!("repo_id = '{POISON_REPO_ID}' AND memory_id = '{POISON_MEMORY_ID}'"),
         ),
         // SAME-PATH tripwires (V042): the memory binding and oracle edge whose path (and, for the

--- a/crates/rag-rat-core/src/index/poison_sibling.rs
+++ b/crates/rag-rat-core/src/index/poison_sibling.rs
@@ -1053,6 +1053,24 @@ mod tests {
         assert_sibling_intact(conn);
     }
 
+    #[test]
+    fn poison_sibling_seeds_memory_model_failure_tripwire() {
+        let (_root, config) = poison_test_config("poison_failure");
+        let db = IndexDatabase::rebuild(&config).unwrap();
+        let conn = db.storage.connection();
+
+        let (pass, reason): (String, String) = conn
+            .query_row(
+                "SELECT pass, reason FROM memory_model_failures WHERE repo_id = ?1 AND memory_id \
+                 = ?2",
+                [POISON_REPO_ID, POISON_MEMORY_ID],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(pass, "compact");
+        assert_eq!(reason, "summary_guard_rejected");
+    }
+
     /// SAME-PATH tripwire liveness: the harness must seed a sibling row whose join key COLLIDES
     /// with a real primary-repo path, and an intentionally path-keyed UNSCOPED aggregate must see
     /// it — proving the harness can trip a join-by-path leak (the class the distinct-path rows

--- a/crates/rag-rat-core/src/index/query_api/dream.rs
+++ b/crates/rag-rat-core/src/index/query_api/dream.rs
@@ -31,16 +31,24 @@ impl IndexDatabase {
 
     /// Whether the model passes have pending work (the zero-work guard for ephemeral
     /// `[llm.dream.remote]`): peek the verify/compact churn-skip queues without touching the model,
-    /// so the CLI skips cold-starting a paid GPU box when the queues are already drained. See
-    /// [`crate::dream::model_work_pending`].
+    /// considering current model-specific failure annotations, so the CLI skips cold-starting a
+    /// paid GPU box when the queues are already drained. See [`crate::dream::model_work_pending`].
     pub fn dream_model_work_pending(
         &self,
         opts: DreamOptions,
         budget: usize,
         verify: bool,
         compact: bool,
+        model_id: &str,
     ) -> anyhow::Result<bool> {
-        crate::dream::model_work_pending(self.storage.connection(), opts, budget, verify, compact)
+        crate::dream::model_work_pending(
+            self.storage.connection(),
+            opts,
+            budget,
+            verify,
+            compact,
+            model_id,
+        )
     }
 
     /// Apply a human review verdict (accept / dismiss / reset) to a dream finding by id or prefix —

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -2764,6 +2764,38 @@ pub(crate) fn apply_memory_model_failures_table(conn: &Connection) -> rusqlite::
     conn.execute_batch("COMMIT;")
 }
 
+#[cfg(test)]
+mod memory_model_failure_migration_tests {
+    use super::*;
+
+    #[test]
+    fn rolls_back_when_reason_index_is_blocked() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "
+            CREATE TABLE blocker(x TEXT);
+            CREATE INDEX idx_memory_model_failures_reason ON blocker(x);
+            ",
+        )
+        .unwrap();
+
+        let err = apply_memory_model_failures_table(&conn)
+            .expect_err("conflicting index name must make the migration fail");
+
+        assert!(
+            err.to_string().contains("idx_memory_model_failures_reason"),
+            "the failure should come from the blocked index name, got {err}"
+        );
+        assert!(
+            !table_exists(&conn, "memory_model_failures").unwrap(),
+            "CREATE TABLE is inside the transaction and rolls back with the failed index"
+        );
+        let blocker_rows: i64 =
+            conn.query_row("SELECT COUNT(*) FROM blocker", [], |r| r.get(0)).unwrap();
+        assert_eq!(blocker_rows, 0, "the preexisting blocker table/index is left intact");
+    }
+}
+
 /// Re-derive the standalone `github_fts` mirror from the freshly-widened base tables, INSIDE the
 /// V045 transaction — the V042 memory-FTS posture. Without this, the repos that just gained
 /// duplicated child rows still cannot FIND them through the scoped FTS readers

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1181,6 +1181,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_044_ID => Some(44),
             MIGRATION_045_ID => Some(45),
             MIGRATION_046_ID => Some(46),
+            MIGRATION_047_ID => Some(47),
             _ => None,
         })
         .max()
@@ -1236,6 +1237,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_044_ID
             | MIGRATION_045_ID
             | MIGRATION_046_ID
+            | MIGRATION_047_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1288,6 +1290,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_044_ID => migration.checksum != MIGRATION_044_CHECKSUM,
         MIGRATION_045_ID => migration.checksum != MIGRATION_045_CHECKSUM,
         MIGRATION_046_ID => migration.checksum != MIGRATION_046_CHECKSUM,
+        MIGRATION_047_ID => migration.checksum != MIGRATION_047_CHECKSUM,
         _ => false,
     }
 }
@@ -2713,6 +2716,45 @@ pub(crate) fn apply_memory_verification_tables(conn: &Connection) -> rusqlite::R
             generated_at_ms INTEGER NOT NULL,
             PRIMARY KEY (repo_id, memory_id, content_hash)
         ) STRICT;
+        ",
+    );
+    if result.is_err() {
+        let _ = conn.execute_batch("ROLLBACK;");
+        return result;
+    }
+    conn.execute_batch("COMMIT;")
+}
+
+/// V047: record deterministic dream model failures in a derived sibling table.
+///
+/// The table is keyed one current row per `(repo_id, memory_id, pass)`, with the same freshness
+/// stamps the queues already consult (`content_hash`, optional `checked_inputs_hash`,
+/// `prompt_version`, `model_id`). A current row whose persisted enum reason is deterministic
+/// suppresses another model call; content/evidence/prompt/model churn invalidates it.
+pub(crate) fn apply_memory_model_failures_table(conn: &Connection) -> rusqlite::Result<()> {
+    if column_exists(conn, "memory_model_failures", "reason")? {
+        return Ok(());
+    }
+    conn.execute_batch("BEGIN IMMEDIATE;")?;
+    let result = conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS memory_model_failures;
+        CREATE TABLE memory_model_failures(
+            memory_id           TEXT    NOT NULL,
+            repo_id             TEXT    NOT NULL DEFAULT '__unassigned__',
+            pass                TEXT    NOT NULL,
+            content_hash        TEXT    NOT NULL,
+            checked_inputs_hash TEXT,
+            model_id            TEXT    NOT NULL,
+            prompt_version      TEXT    NOT NULL,
+            reason              TEXT    NOT NULL,
+            detail              TEXT,
+            failed_at_ms        INTEGER NOT NULL,
+            attempts            INTEGER NOT NULL DEFAULT 1,
+            PRIMARY KEY (repo_id, memory_id, pass)
+        ) STRICT;
+        CREATE INDEX idx_memory_model_failures_reason
+            ON memory_model_failures(repo_id, pass, reason);
         ",
     );
     if result.is_err() {

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -2764,38 +2764,6 @@ pub(crate) fn apply_memory_model_failures_table(conn: &Connection) -> rusqlite::
     conn.execute_batch("COMMIT;")
 }
 
-#[cfg(test)]
-mod memory_model_failure_migration_tests {
-    use super::*;
-
-    #[test]
-    fn rolls_back_when_reason_index_is_blocked() {
-        let conn = Connection::open_in_memory().unwrap();
-        conn.execute_batch(
-            "
-            CREATE TABLE blocker(x TEXT);
-            CREATE INDEX idx_memory_model_failures_reason ON blocker(x);
-            ",
-        )
-        .unwrap();
-
-        let err = apply_memory_model_failures_table(&conn)
-            .expect_err("conflicting index name must make the migration fail");
-
-        assert!(
-            err.to_string().contains("idx_memory_model_failures_reason"),
-            "the failure should come from the blocked index name, got {err}"
-        );
-        assert!(
-            !table_exists(&conn, "memory_model_failures").unwrap(),
-            "CREATE TABLE is inside the transaction and rolls back with the failed index"
-        );
-        let blocker_rows: i64 =
-            conn.query_row("SELECT COUNT(*) FROM blocker", [], |r| r.get(0)).unwrap();
-        assert_eq!(blocker_rows, 0, "the preexisting blocker table/index is left intact");
-    }
-}
-
 /// Re-derive the standalone `github_fts` mirror from the freshly-widened base tables, INSIDE the
 /// V045 transaction — the V042 memory-FTS posture. Without this, the repos that just gained
 /// duplicated child rows still cannot FIND them through the scoped FTS readers
@@ -3748,4 +3716,36 @@ pub(crate) fn rebuild_files_table_for_commit_scopes(conn: &Connection) -> rusqli
         PRAGMA foreign_keys = ON;
         ",
     )
+}
+
+#[cfg(test)]
+mod memory_model_failure_migration_tests {
+    use super::*;
+
+    #[test]
+    fn rolls_back_when_reason_index_is_blocked() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "
+            CREATE TABLE blocker(x TEXT);
+            CREATE INDEX idx_memory_model_failures_reason ON blocker(x);
+            ",
+        )
+        .unwrap();
+
+        let err = apply_memory_model_failures_table(&conn)
+            .expect_err("conflicting index name must make the migration fail");
+
+        assert!(
+            err.to_string().contains("idx_memory_model_failures_reason"),
+            "the failure should come from the blocked index name, got {err}"
+        );
+        assert!(
+            !table_exists(&conn, "memory_model_failures").unwrap(),
+            "CREATE TABLE is inside the transaction and rolls back with the failed index"
+        );
+        let blocker_rows: i64 =
+            conn.query_row("SELECT COUNT(*) FROM blocker", [], |r| r.get(0)).unwrap();
+        assert_eq!(blocker_rows, 0, "the preexisting blocker table/index is left intact");
+    }
 }

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -17,7 +17,7 @@ pub use registry::{LEGACY_REPO_ID, register_repo};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 46;
+pub const LATEST_SCHEMA_VERSION: u32 = 47;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -315,6 +315,12 @@ const MIGRATION_046_DESCRIPTION: &str =
      content_hash) so a body edit self-invalidates), both STRICT and repo_id-scoped. They hold \
      derived, regenerable data so dream verifies memories without ever mutating a repo_memories \
      row (dream v2 pass 0)";
+const MIGRATION_047_ID: &str = "047_memory_model_failures";
+const MIGRATION_047_CHECKSUM: &str = "sha256:rag-rat-memory-model-failures-v47";
+const MIGRATION_047_DESCRIPTION: &str =
+    "Add memory_model_failures, a repo_id-scoped dream sibling table that records deterministic \
+     verdict/compaction model failures with stable enum tokens and input/model freshness stamps, \
+     so rejected current attempts do not rerun every dream pass";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -690,6 +696,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_046_CHECKSUM,
         description: MIGRATION_046_DESCRIPTION,
         apply: apply_memory_verification_tables,
+    },
+    Migration {
+        id: MIGRATION_047_ID,
+        checksum: MIGRATION_047_CHECKSUM,
+        description: MIGRATION_047_DESCRIPTION,
+        apply: apply_memory_model_failures_table,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema/registry.rs
+++ b/crates/rag-rat-core/src/index/schema/registry.rs
@@ -51,11 +51,11 @@ const DIRECT_SCOPED_ADOPTION_TABLES: &[&str] = &[
 
 /// The periphery tables that gain a `repo_id` column in the phase-A5 periphery-scoping migration
 /// (V042, `apply_repo_id_periphery_scoping`) — plus the V045 dream-v2 verification siblings
-/// (`memory_reality` / `memory_summaries`), repo_id-scoped from birth — and therefore also need
-/// their [`LEGACY_REPO_ID`] placeholder rows re-pointed at the real id when [`register_repo`]
-/// adopts a legacy DB — the A5 continuation of the A1/A3 adoption contract. `repo_memory_fts` is
-/// the standalone FTS mirror of `repo_memories` (its `repo_id` snapshots the parent's at rebuild
-/// time), re-pointed alongside.
+/// (`memory_reality` / `memory_summaries` / `memory_model_failures`), repo_id-scoped from birth —
+/// and therefore also need their [`LEGACY_REPO_ID`] placeholder rows re-pointed at the real id when
+/// [`register_repo`] adopts a legacy DB — the A5 continuation of the A1/A3 adoption contract.
+/// `repo_memory_fts` is the standalone FTS mirror of `repo_memories` (its `repo_id` snapshots the
+/// parent's at rebuild time), re-pointed alongside.
 ///
 /// COLUMN GUARD: several of these tables predate V042 — they exist at earlier schema versions
 /// WITHOUT a `repo_id` column, which V042 adds or rebuilds in. `register_repo` runs on every open,
@@ -76,11 +76,12 @@ const A5_PERIPHERY_DIRECT_SCOPED_TABLES: &[&str] = &[
     "repo_memories",
     "repo_memory_bindings",
     "repo_memory_fts",
-    // V045 dream-v2 verification siblings — repo_id-scoped like `dream_findings`; a LocalOnly→
-    // Portable adoption must re-point their rows too. Guarded by `column_exists` in the re-point
-    // loop, so a pre-V045 partial-schema fixture (table/column absent) is a no-op.
+    // Dream-v2 siblings — repo_id-scoped like `dream_findings`; a LocalOnly→Portable adoption
+    // must re-point their rows too. Guarded by `column_exists` in the re-point loop, so an older
+    // partial-schema fixture (table/column absent) is a no-op.
     "memory_reality",
     "memory_summaries",
+    "memory_model_failures",
 ];
 
 /// The placeholder `repo_id` a freshly-migrated single-repo DB carries until it is adopted (see the

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -3126,11 +3126,18 @@ fn full_ladder_v037_to_v042_scopes_both_workstreams_data() {
         rusqlite::params![crate::index::clones::NORM_VERSION, LEGACY_REPO_ID],
     )
     .unwrap();
-    // A V045 dream-v2 verification sibling — repo_id-scoped from birth. Adoption must re-point it
+    // A V046 dream-v2 verification sibling — repo_id-scoped from birth. Adoption must re-point it
     // like the rest of the A5 periphery set (it is NOT part of V042; the sibling landed later).
     conn.execute(
         "INSERT INTO memory_reality(memory_id, repo_id, content_hash, verdict, checked_at_ms)
          VALUES ('m1', ?1, 'bh', 'current', 0)",
+        [LEGACY_REPO_ID],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO memory_model_failures(memory_id, repo_id, pass, content_hash, model_id, \
+         prompt_version, reason, failed_at_ms)
+         VALUES ('m1', ?1, 'compact', 'bh', 'model', 'prompt', 'summary_guard_rejected', 0)",
         [LEGACY_REPO_ID],
     )
     .unwrap();
@@ -3167,6 +3174,7 @@ fn full_ladder_v037_to_v042_scopes_both_workstreams_data() {
         ("oracle_runs", "tool = 'scip'"),
         ("clone_graph_generations", "generation = 1"),
         ("memory_reality", "memory_id = 'm1'"),
+        ("memory_model_failures", "memory_id = 'm1'"),
     ] {
         assert_eq!(
             placeholder_count(&format!(
@@ -3208,6 +3216,11 @@ fn full_ladder_v037_to_v042_scopes_both_workstreams_data() {
     assert_eq!(
         real_repo("SELECT repo_id FROM memory_reality WHERE memory_id = 'm1'"),
         "repo-real",
-        "adoption re-points the V045 memory_reality verification sibling"
+        "adoption re-points the V046 memory_reality verification sibling"
+    );
+    assert_eq!(
+        real_repo("SELECT repo_id FROM memory_model_failures WHERE memory_id = 'm1'"),
+        "repo-real",
+        "adoption re-points the V047 memory_model_failures sibling"
     );
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -704,15 +704,17 @@ fn discover_mode_indexes_new_files_and_removes_deleted_files() {
 }
 
 /// V046 (dream v2 pass 0): fresh `schema::apply` creates the `memory_reality` / `memory_summaries`
-/// sibling tables, both STRICT + repo_id-scoped with the documented PKs. Carries the ABSOLUTE
-/// schema-tip pin now that V046 is the newest migration; re-applying is idempotent (the
-/// `memory_reality` existence sentinel short-circuits).
+/// sibling tables, both STRICT + repo_id-scoped with the documented PKs. The absolute schema-tip
+/// pin lives on the newest migration's test; this one uses only symbolic latest checks.
 #[test]
 fn migration_046_creates_the_verification_tables_on_fresh_apply() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 46, "V046 is the schema tip");
-    assert_eq!(schema::status(&conn).unwrap().current_version, 46, "schema at LATEST after apply");
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply"
+    );
 
     let table_sql = |table: &str| -> String {
         conn.query_row("SELECT sql FROM sqlite_master WHERE name = ?1", [table], |r| r.get(0))
@@ -751,6 +753,99 @@ fn migration_046_creates_the_verification_tables_on_fresh_apply() {
     // Re-apply is a no-op (the memory_reality existence sentinel short-circuits).
     schema::apply(&conn).unwrap();
     assert!(conn_table_exists(&conn, "memory_reality"), "tables survive a re-apply");
+}
+
+/// V047: fresh `schema::apply` creates `memory_model_failures`, the dream model-failure sibling
+/// table. Carries the absolute schema-tip pin now that V047 is newest.
+#[test]
+fn migration_047_creates_the_model_failure_table_on_fresh_apply() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 47, "V047 is the schema tip");
+    assert_eq!(schema::status(&conn).unwrap().current_version, 47, "schema at LATEST after apply");
+
+    let table_sql = conn
+        .query_row("SELECT sql FROM sqlite_master WHERE name = 'memory_model_failures'", [], |r| {
+            r.get::<_, String>(0)
+        })
+        .unwrap();
+    assert!(table_sql.contains("STRICT"), "memory_model_failures is STRICT");
+    for column in [
+        "memory_id",
+        "repo_id",
+        "pass",
+        "content_hash",
+        "checked_inputs_hash",
+        "model_id",
+        "prompt_version",
+        "reason",
+        "failed_at_ms",
+        "attempts",
+    ] {
+        assert!(
+            conn_table_columns(&conn, "memory_model_failures").contains(&column.to_string()),
+            "memory_model_failures carries {column}"
+        );
+    }
+    let pk_cols: Vec<String> = conn
+        .prepare(
+            "SELECT name FROM pragma_table_info('memory_model_failures') WHERE pk > 0 ORDER BY pk",
+        )
+        .unwrap()
+        .query_map([], |r| r.get::<_, String>(0))
+        .unwrap()
+        .map(Result::unwrap)
+        .collect();
+    assert_eq!(
+        pk_cols,
+        vec!["repo_id".to_string(), "memory_id".to_string(), "pass".to_string()],
+        "one current failure row per repo/memory/pass"
+    );
+
+    schema::apply(&conn).unwrap();
+    assert!(conn_table_exists(&conn, "memory_model_failures"), "failure table survives a re-apply");
+}
+
+#[test]
+fn migration_047_deferred_absence_and_reconverges_from_torn_state() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch("CREATE TABLE memory_model_failures(leftover INTEGER);").unwrap();
+    assert!(
+        !conn_table_columns(&conn, "memory_model_failures").contains(&"reason".to_string()),
+        "torn table lacks the sentinel column"
+    );
+
+    schema::apply_memory_model_failures_table(&conn).unwrap();
+
+    assert!(
+        conn_table_columns(&conn, "memory_model_failures").contains(&"reason".to_string()),
+        "V047 drops the torn scratch table and creates the real shape"
+    );
+    schema::apply_memory_model_failures_table(&conn).expect("replay is a no-op");
+    conn.execute(
+        "INSERT INTO memory_model_failures(memory_id, repo_id, pass, content_hash, model_id, \
+         prompt_version, reason, failed_at_ms) VALUES \
+         ('m','r','verify','h','model','prompt','fabricated_evidence',0)",
+        [],
+    )
+    .unwrap();
+    assert!(
+        conn.execute(
+            "INSERT INTO memory_model_failures(memory_id, repo_id, pass, content_hash, model_id, \
+             prompt_version, reason, failed_at_ms) VALUES \
+             ('m','r','verify','h2','model','prompt','malformed_verdict',1)",
+            [],
+        )
+        .is_err(),
+        "PK(repo_id, memory_id, pass) rejects a second current failure for the same pass"
+    );
+    conn.execute(
+        "INSERT INTO memory_model_failures(memory_id, repo_id, pass, content_hash, model_id, \
+         prompt_version, reason, failed_at_ms) VALUES \
+         ('m','r','compact','h','model','prompt','summary_guard_rejected',0)",
+        [],
+    )
+    .expect("verify and compact failures are distinct pass rows");
 }
 
 /// V046 in ISOLATION against a bare connection: the sibling tables are ABSENT before the migration


### PR DESCRIPTION
`rag-rat dream --compact --verify` treated missing `memory_reality` / `memory_summaries` rows as both "never tried" and "tried, but the model output was rejected." That meant deterministic failures like malformed verdicts, fabricated citations, or compaction guard rejects stayed indistinguishable from fresh work, so the same memory could fire the LLM again on every run.

**Fix:** add V047 `memory_model_failures`, a repo-scoped sibling table keyed by `(repo_id, memory_id, pass)`, with persisted enum tokens for the dream pass and failure reason. Current deterministic reasons suppress another model call until the memory content, checked inputs, prompt version, or model id changes; transient `model_call_failed` rows are kept audit-only and remain retryable.

The verify and compact runners now skip current blocking failures without consuming the `--max-memories` budget, so a failed memory does not keep burning calls or starve later memories. The ephemeral zero-work guard now receives the model id and uses the same failure annotations before deciding whether to provision a remote GPU.

**Tests:** `cargo +nightly fmt --check`; `cargo test -p rag-rat-core dream:: --lib`; `cargo test -p rag-rat-core migration_047 --lib`; `cargo test -p rag-rat-core full_ladder_v037_to_v042_scopes_both_workstreams_data --lib`; `cargo check -p rag-rat`; `cargo test -p rag-rat --test multi_repo_e2e dream_worklist_is_repo_scoped_end_to_end`.