### PR TITLE
feat(memory): apply [memory] surface="summary" to every drive-by renderer (#426)

### DIFF
--- a/crates/rag-rat-cli/src/claude_hook/mod.rs
+++ b/crates/rag-rat-cli/src/claude_hook/mod.rs
@@ -743,6 +743,7 @@ fn fallback_compose(config: &Config, cwd: &str, search: &Search) -> Option<Strin
         &search.pattern,
         search.search_path.as_deref(),
         &grep_augment::DedupeFilter::default(),
+        config.memory.surface,
     )
     .ok()
     .flatten()

--- a/crates/rag-rat-core/src/index/query_api/memory.rs
+++ b/crates/rag-rat-core/src/index/query_api/memory.rs
@@ -37,16 +37,24 @@ impl IndexDatabase {
         &self,
         symbol: &crate::query::symbol::SymbolHit,
         limit: u32,
+        surface: crate::config::MemorySurface,
     ) -> anyhow::Result<Vec<crate::query::memory::RepoMemory>> {
-        crate::query::memory::memories_for_symbol(self.storage.connection(), symbol, limit)
+        let conn = self.storage.connection();
+        let mut memories = crate::query::memory::memories_for_symbol(conn, symbol, limit)?;
+        crate::query::memory::apply_memory_surface(conn, &mut memories, surface)?;
+        Ok(memories)
     }
 
     pub fn memory_for_path(
         &self,
         path: &str,
         limit: u32,
+        surface: crate::config::MemorySurface,
     ) -> anyhow::Result<Vec<crate::query::memory::RepoMemory>> {
-        crate::query::memory::memories_for_path(self.storage.connection(), path, limit)
+        let conn = self.storage.connection();
+        let mut memories = crate::query::memory::memories_for_path(conn, path, limit)?;
+        crate::query::memory::apply_memory_surface(conn, &mut memories, surface)?;
+        Ok(memories)
     }
 
     pub fn memory_for_edges(
@@ -63,17 +71,23 @@ impl IndexDatabase {
         caller_edge_ids: &[i64],
         callee_edge_ids: &[i64],
         limit: u32,
+        surface: crate::config::MemorySurface,
     ) -> anyhow::Result<crate::query::memory::RepoMemoryEvidence> {
         // This wrapper exposes only the evidence; the impact builder consumes the truncation flag
-        // directly from the core fn.
-        crate::query::memory::memory_evidence_for_symbol_and_edges(
-            self.storage.connection(),
+        // directly from the core fn. `find_callers` / `trace_callees` emit the evidence FULL (not
+        // compact), so honor `[memory] surface` here by deferring each lane's bodies under
+        // `Summary`.
+        let conn = self.storage.connection();
+        let mut evidence = crate::query::memory::memory_evidence_for_symbol_and_edges(
+            conn,
             symbol,
             caller_edge_ids,
             callee_edge_ids,
             limit,
         )
-        .map(|(evidence, _truncated)| evidence)
+        .map(|(evidence, _truncated)| evidence)?;
+        evidence.apply_surface(conn, surface)?;
+        Ok(evidence)
     }
 
     pub fn memory_for_call_path_hash(

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -376,7 +376,16 @@ impl IndexDatabase {
     }
 
     pub fn read_chunk(&self, chunk_id: i64) -> anyhow::Result<Option<crate::query::ReadChunk>> {
-        self.read_chunk_with_graph_and_memories(chunk_id, GraphMetaMode::Full, 20, true)
+        // Internal/CLI/test entry — always the FULL memory bodies; the surface-aware path is the
+        // MCP `read_chunk` tool, which calls `read_chunk_with_graph_and_memories` with the
+        // config surface.
+        self.read_chunk_with_graph_and_memories(
+            chunk_id,
+            GraphMetaMode::Full,
+            20,
+            true,
+            crate::config::MemorySurface::Full,
+        )
     }
 
     pub fn read_chunk_with_graph(
@@ -385,7 +394,14 @@ impl IndexDatabase {
         graph_mode: GraphMetaMode,
         graph_limit: u32,
     ) -> anyhow::Result<Option<crate::query::ReadChunk>> {
-        self.read_chunk_with_graph_and_memories(chunk_id, graph_mode, graph_limit, false)
+        // `include_memories = false`, so the surface never applies — pass `Full`.
+        self.read_chunk_with_graph_and_memories(
+            chunk_id,
+            graph_mode,
+            graph_limit,
+            false,
+            crate::config::MemorySurface::Full,
+        )
     }
 
     pub fn read_chunk_with_graph_and_memories(
@@ -394,6 +410,7 @@ impl IndexDatabase {
         graph_mode: GraphMetaMode,
         graph_limit: u32,
         include_memories: bool,
+        surface: crate::config::MemorySurface,
     ) -> anyhow::Result<Option<crate::query::ReadChunk>> {
         let Some(mut chunk) = self.read_chunk_current(chunk_id)? else {
             return Ok(None);
@@ -405,8 +422,12 @@ impl IndexDatabase {
             graph_limit,
         )?;
         if include_memories {
-            chunk.memories =
-                crate::query::memory::memories_for_chunk(self.storage.connection(), chunk_id, 20)?;
+            let conn = self.storage.connection();
+            chunk.memories = crate::query::memory::memories_for_chunk(conn, chunk_id, 20)?;
+            // Drive-by chunk attachments honor `[memory] surface`: under `Summary` each memory's
+            // body is deferred to `memory show`, leaving the summary + verdict marker
+            // (title-only fallback).
+            crate::query::memory::apply_memory_surface(conn, &mut chunk.memories, surface)?;
         }
         Ok(Some(chunk))
     }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -62,7 +62,7 @@ fn repo_memory_bound_to_logical_symbol_surfaces_in_symbol_chunk_and_impact() {
     assert!(!created.duplicate);
     assert_eq!(created.memory.bindings[0].binding_kind, "logical_symbol");
 
-    let memories = db.memory_for_symbol(&symbol, 10).unwrap();
+    let memories = db.memory_for_symbol(&symbol, 10, crate::config::MemorySurface::Full).unwrap();
     assert_eq!(memories.len(), 1);
     assert_eq!(memories[0].kind, "Invariant");
     let chunk_id = memories[0].bindings[0].chunk_id.expect("bound chunk");
@@ -328,7 +328,7 @@ fn repo_memory_survives_reindex_and_relocates_when_symbol_moves() {
     // Re-validation re-anchors the binding to keystone's new location, not "gone".
     db.memory_validate().unwrap();
     let symbol = db.select_symbol(&selector).unwrap().unwrap().expect("symbol after move");
-    let anchored = db.memory_for_symbol(&symbol, 10).unwrap();
+    let anchored = db.memory_for_symbol(&symbol, 10, crate::config::MemorySurface::Full).unwrap();
     assert_eq!(anchored.len(), 1, "memory did not re-anchor to moved symbol");
     assert_ne!(anchored[0].bindings[0].anchor_status, "gone");
 
@@ -409,14 +409,14 @@ fn repo_memory_validate_marks_changed_or_missing_anchors_non_current() {
         .unwrap();
     let report = db.memory_validate().unwrap();
     assert_eq!(report.stale, 1);
-    let stale = db.memory_for_symbol(&symbol, 10).unwrap();
+    let stale = db.memory_for_symbol(&symbol, 10, crate::config::MemorySurface::Full).unwrap();
     assert_eq!(stale[0].memory_id, created.memory.memory_id);
     assert_eq!(stale[0].bindings[0].anchor_status, "stale");
 
     db.storage.connection().execute("DELETE FROM chunks WHERE id = ?1", [chunk_id]).unwrap();
     let report = db.memory_validate().unwrap();
     assert_eq!(report.gone, 1);
-    let gone = db.memory_for_symbol(&symbol, 10).unwrap();
+    let gone = db.memory_for_symbol(&symbol, 10, crate::config::MemorySurface::Full).unwrap();
     assert_eq!(gone[0].bindings[0].anchor_status, "gone");
 
     let _ = fs::remove_dir_all(root);
@@ -849,6 +849,7 @@ fn memory_relocates_when_symbol_moves_to_another_file() {
             .unwrap()
             .expect("target in b.rs"),
             10,
+            crate::config::MemorySurface::Full,
         )
         .unwrap()[0]
         .bindings[0]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -2279,3 +2279,163 @@ fn worktree_overlay_committed_modification_shadows_base() {
     let _ = fs::remove_dir_all(&main);
     let _ = fs::remove_dir_all(&linked);
 }
+
+#[test]
+fn surface_summary_defers_bodies_across_the_db_memory_renderers() {
+    // #426: memory_for_symbol / memory_for_path / read_chunk / memory_evidence_for_symbol_and_edges
+    // all honor `[memory] surface = "summary"` — the full body is deferred to `memory show`, the
+    // compacted summary + verdict marker take its place, and the binding structure is preserved.
+    use crate::config::MemorySurface;
+    use crate::query::graph_meta::GraphMetaMode;
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn target() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let symbol = db
+        .select_symbol(&crate::query::symbol::SymbolSelector {
+            logical_symbol_id: None,
+            symbol_id: None,
+            symbol_path: None,
+            symbol: Some("target".to_string()),
+            language: Some(Language::Rust),
+            allow_ambiguous: true,
+            limit: 10,
+        })
+        .unwrap()
+        .unwrap()
+        .expect("selected symbol");
+
+    let sym_title = "Target invariant";
+    let sym_body = "The target function must keep its full documented invariant intact.";
+    let sym_mem = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: sym_title.to_string(),
+            body: sym_body.to_string(),
+            confidence: "high".to_string(),
+            created_by: Some("test".to_string()),
+            source: Some("agent".to_string()),
+            tags: vec![],
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                logical_symbol_id: symbol.logical_symbol_id,
+                ..Default::default()
+            },
+        })
+        .unwrap()
+        .memory;
+
+    let path_title = "Path note";
+    let path_body = "A note anchored to the file, not a symbol; its body is long enough to matter.";
+    db.memory_create(crate::query::memory::RepoMemoryCreate {
+        kind: "Decision".to_string(),
+        title: path_title.to_string(),
+        body: path_body.to_string(),
+        confidence: "medium".to_string(),
+        created_by: Some("test".to_string()),
+        source: Some("agent".to_string()),
+        tags: vec![],
+        bind: crate::query::memory::RepoMemoryBindTarget {
+            path: Some("src/lib.rs".to_string()),
+            ..Default::default()
+        },
+    })
+    .unwrap();
+
+    // Seed compacted summaries + one verdict, keyed exactly like the dream passes stamp them.
+    let conn = db.storage.connection();
+    let repo_id: String = conn
+        .query_row("SELECT repo_id FROM repo_memories WHERE id = ?1", [&sym_mem.memory_id], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    let seed_summary = |id: &str, title: &str, body: &str, summary: &str| {
+        conn.execute(
+            "INSERT INTO memory_summaries(memory_id, repo_id, content_hash, summary, \
+             prompt_version, generated_at_ms) VALUES (?1,?2,?3,?4,?5,0)",
+            rusqlite::params![
+                id,
+                repo_id,
+                crate::dream::note_content_hash(title, body),
+                summary,
+                crate::dream::COMPACT_PROMPT_VERSION
+            ],
+        )
+        .unwrap();
+    };
+    seed_summary(&sym_mem.memory_id, sym_title, sym_body, "Keep target's invariant.");
+    let path_id: String = conn
+        .query_row("SELECT id FROM repo_memories WHERE title = ?1", [path_title], |r| r.get(0))
+        .unwrap();
+    seed_summary(&path_id, path_title, path_body, "File-level note gist.");
+    let inputs =
+        crate::dream::checked_inputs_hash(conn, &sym_mem.memory_id, &Some(repo_id.clone()))
+            .unwrap();
+    conn.execute(
+        "INSERT INTO memory_reality(memory_id, repo_id, content_hash, verdict, \
+         checked_against_commit, checked_inputs_hash, prompt_version, checked_at_ms) VALUES \
+         (?1,?2,?3,'diverged',NULL,?4,?5,0)",
+        rusqlite::params![
+            sym_mem.memory_id,
+            repo_id,
+            crate::dream::note_content_hash(sym_title, sym_body),
+            inputs,
+            crate::dream::VERDICT_PROMPT_VERSION
+        ],
+    )
+    .unwrap();
+
+    // memory_for_symbol: body deferred, summary + verdict present, structure kept.
+    let by_symbol = db.memory_for_symbol(&symbol, 10, MemorySurface::Summary).unwrap();
+    let m = by_symbol.iter().find(|m| m.memory_id == sym_mem.memory_id).expect("symbol memory");
+    assert_eq!(m.body, "", "body deferred under summary");
+    assert_eq!(m.summary.as_deref(), Some("Keep target's invariant."));
+    assert!(
+        m.verdict.as_deref().unwrap_or_default().contains("diverged"),
+        "verdict: {:?}",
+        m.verdict
+    );
+    assert!(!m.bindings.is_empty(), "the full binding structure is preserved under summary");
+
+    // Full surface leaves the body intact and hydrates nothing.
+    let full = db.memory_for_symbol(&symbol, 10, MemorySurface::Full).unwrap();
+    let mf = full.iter().find(|m| m.memory_id == sym_mem.memory_id).unwrap();
+    assert_eq!(mf.body, sym_body, "full surface keeps the body");
+    assert_eq!(mf.summary, None);
+    let chunk_id = mf.bindings.iter().find_map(|b| b.chunk_id).expect("bound chunk");
+
+    // memory_for_path: the path-bound note defers its body too.
+    let by_path = db.memory_for_path("src/lib.rs", 10, MemorySurface::Summary).unwrap();
+    let mp = by_path.iter().find(|m| m.memory_id == path_id).expect("path memory");
+    assert_eq!(mp.body, "");
+    assert_eq!(mp.summary.as_deref(), Some("File-level note gist."));
+
+    // read_chunk memory attachments (and the include_memories=false wrapper stays exercised).
+    let chunk = db
+        .read_chunk_with_graph_and_memories(
+            chunk_id,
+            GraphMetaMode::Full,
+            20,
+            true,
+            MemorySurface::Summary,
+        )
+        .unwrap()
+        .expect("chunk");
+    let cm =
+        chunk.memories.iter().find(|m| m.memory_id == sym_mem.memory_id).expect("chunk memory");
+    assert_eq!(cm.body, "");
+    assert_eq!(cm.summary.as_deref(), Some("Keep target's invariant."));
+    assert!(db.read_chunk_with_graph(chunk_id, GraphMetaMode::Full, 20).unwrap().is_some());
+
+    // find_callers / trace_callees evidence.
+    let evidence = db
+        .memory_evidence_for_symbol_and_edges(&symbol, &[], &[], 10, MemorySurface::Summary)
+        .unwrap();
+    let em =
+        evidence.direct.iter().find(|m| m.memory_id == sym_mem.memory_id).expect("evidence memory");
+    assert_eq!(em.body, "");
+    assert_eq!(em.summary.as_deref(), Some("Keep target's invariant."));
+
+    let _ = fs::remove_dir_all(&root);
+}

--- a/crates/rag-rat-core/src/query/grep_augment.rs
+++ b/crates/rag-rat-core/src/query/grep_augment.rs
@@ -205,6 +205,7 @@ pub fn compose(
     raw_pattern: &str,
     search_path: Option<&str>,
     dedupe: &DedupeFilter,
+    surface: crate::config::MemorySurface,
 ) -> anyhow::Result<Option<GrepAugment>> {
     let normalized = normalize_pattern(raw_pattern);
     if normalized.is_empty() {
@@ -276,6 +277,10 @@ pub fn compose(
     }
     // Apply session-level dedupe filter last (after insertion-order dedup above).
     memories.retain(|m| !dedupe.memory_ids.contains(&m.memory_id));
+    // Honor `[memory] surface`: under `Summary` each memory renders its dream summary + verdict
+    // marker (title-only fallback) instead of the clamped body — the hook context stays terse and
+    // the full body is one `memory show` away.
+    memory::apply_memory_surface(conn, &mut memories, surface)?;
 
     // Lexical lane: only when the symbol lane found nothing (never had any raw hits). Relevance
     // gate: keep only hits within LEXICAL_RELATIVE_FLOOR of the best hit's score, so the weak tail
@@ -362,16 +367,25 @@ fn render(
     if !memories.is_empty() {
         let items = memories
             .into_iter()
-            .map(|m| RenderItem {
-                line: format!(
-                    "- [{} | {}] {} — {} (rag-rat: memory_search)",
-                    m.kind,
-                    m.status,
-                    m.title,
-                    clamp_body(&m.body),
-                ),
-                memory_id: Some(m.memory_id),
-                symbol_key: None,
+            .map(|m| {
+                // The gist: the summary under `surface = "summary"`, else the clamped body. Both
+                // empty (a summary-surface memory with no summary) → title-only, no `— …`.
+                let gist = match &m.summary {
+                    Some(summary) => summary.clone(),
+                    None => clamp_body(&m.body),
+                };
+                let gist_part =
+                    if gist.is_empty() { String::new() } else { format!(" — {gist}") };
+                let verdict_part =
+                    m.verdict.as_deref().map(|v| format!(" {v}")).unwrap_or_default();
+                RenderItem {
+                    line: format!(
+                        "- [{} | {}] {}{}{} (rag-rat: memory_search)",
+                        m.kind, m.status, m.title, gist_part, verdict_part,
+                    ),
+                    memory_id: Some(m.memory_id),
+                    symbol_key: None,
+                }
             })
             .collect();
         sections.push(Section {
@@ -566,9 +580,15 @@ mod tests {
             )
             .unwrap();
         }
-        let out = compose(&conn, "foo", None, &DedupeFilter::default())
-            .unwrap()
-            .expect("symbol lane augments");
+        let out = compose(
+            &conn,
+            "foo",
+            None,
+            &DedupeFilter::default(),
+            crate::config::MemorySurface::Full,
+        )
+        .unwrap()
+        .expect("symbol lane augments");
         assert_eq!(
             out.context.matches("`a::foo`").count(),
             1,
@@ -672,9 +692,15 @@ mod tests {
     #[test]
     fn compose_identifier_pattern_yields_symbol_and_memory() {
         let conn = seeded_conn();
-        let out = compose(&conn, r"watcher_main\b", None, &DedupeFilter::default())
-            .unwrap()
-            .expect("payload expected");
+        let out = compose(
+            &conn,
+            r"watcher_main\b",
+            None,
+            &DedupeFilter::default(),
+            crate::config::MemorySurface::Full,
+        )
+        .unwrap()
+        .expect("payload expected");
         assert!(out.context.contains("src/watch.rs"), "symbol location present");
         assert!(out.context.contains("One watcher per worktree"), "memory title present");
         let memory_pos = out.context.find("One watcher per worktree").unwrap();
@@ -686,16 +712,88 @@ mod tests {
     }
 
     #[test]
+    fn compose_summary_surface_renders_the_summary_and_verdict_not_the_full_body() {
+        let conn = seeded_conn();
+        // Seed a dream summary + verdict for the seeded memory, keyed on its id, repo scope, and
+        // current content_hash / prompt versions — exactly what the surfacing hydrator gates on.
+        let (id, repo_id): (String, String) = conn
+            .query_row("SELECT id, repo_id FROM repo_memories LIMIT 1", [], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .unwrap();
+        let title = "One watcher per worktree";
+        let body = "The election lock guarantees a single watcher; never bind without it.";
+        conn.execute(
+            "INSERT INTO memory_summaries(memory_id, repo_id, content_hash, summary, \
+             prompt_version, generated_at_ms) VALUES (?1,?2,?3,?4,?5,0)",
+            rusqlite::params![
+                id,
+                repo_id,
+                crate::dream::note_content_hash(title, body),
+                "Election lock ensures exactly one watcher; bind only under it.",
+                crate::dream::COMPACT_PROMPT_VERSION
+            ],
+        )
+        .unwrap();
+        let inputs = crate::dream::checked_inputs_hash(&conn, &id, &Some(repo_id.clone())).unwrap();
+        conn.execute(
+            "INSERT INTO memory_reality(memory_id, repo_id, content_hash, verdict, \
+             checked_against_commit, checked_inputs_hash, prompt_version, checked_at_ms) VALUES \
+             (?1,?2,?3,'diverged',NULL,?4,?5,0)",
+            rusqlite::params![
+                id,
+                repo_id,
+                crate::dream::note_content_hash(title, body),
+                inputs,
+                crate::dream::VERDICT_PROMPT_VERSION
+            ],
+        )
+        .unwrap();
+
+        let out = compose(
+            &conn,
+            r"watcher_main\b",
+            None,
+            &DedupeFilter::default(),
+            crate::config::MemorySurface::Summary,
+        )
+        .unwrap()
+        .expect("payload expected");
+        assert!(
+            out.context.contains("Election lock ensures exactly one watcher"),
+            "the summary renders in place of the body: {}",
+            out.context
+        );
+        assert!(
+            !out.context.contains("never bind without it"),
+            "the full body is deferred under summary: {}",
+            out.context
+        );
+        assert!(out.context.contains("diverged"), "the verdict marker renders: {}", out.context);
+        assert!(out.context.contains(title), "the title still renders: {}", out.context);
+    }
+
+    #[test]
     fn compose_respects_dedupe_filter_and_returns_none_when_everything_filtered() {
         let conn = seeded_conn();
-        let first = compose(&conn, "watcher_main", None, &DedupeFilter::default())
-            .unwrap()
-            .expect("first payload");
+        let first = compose(
+            &conn,
+            "watcher_main",
+            None,
+            &DedupeFilter::default(),
+            crate::config::MemorySurface::Full,
+        )
+        .unwrap()
+        .expect("first payload");
         let filter = DedupeFilter {
             memory_ids: first.memory_ids.iter().cloned().collect::<HashSet<_>>(),
             symbol_keys: first.symbol_keys.iter().cloned().collect::<HashSet<_>>(),
         };
-        assert!(compose(&conn, "watcher_main", None, &filter).unwrap().is_none());
+        assert!(
+            compose(&conn, "watcher_main", None, &filter, crate::config::MemorySurface::Full)
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]
@@ -718,9 +816,15 @@ mod tests {
     #[test]
     fn compose_definition_pattern_routes_to_symbol_lane_not_lexical() {
         let conn = seeded_conn();
-        let out = compose(&conn, r"fn watcher_main", None, &DedupeFilter::default())
-            .unwrap()
-            .expect("payload expected");
+        let out = compose(
+            &conn,
+            r"fn watcher_main",
+            None,
+            &DedupeFilter::default(),
+            crate::config::MemorySurface::Full,
+        )
+        .unwrap()
+        .expect("payload expected");
         // Resolves to the symbol + its bound memory; the redundant lexical echo is suppressed.
         assert!(out.context.contains("watch::watcher_main"), "symbol lane fired");
         assert!(out.context.contains("One watcher per worktree"), "bound memory surfaced");
@@ -735,9 +839,15 @@ mod tests {
     #[test]
     fn compose_non_identifier_pattern_uses_lexical_lane() {
         let conn = seeded_conn();
-        let out = compose(&conn, "election retry loop", None, &DedupeFilter::default())
-            .unwrap()
-            .expect("lexical payload");
+        let out = compose(
+            &conn,
+            "election retry loop",
+            None,
+            &DedupeFilter::default(),
+            crate::config::MemorySurface::Full,
+        )
+        .unwrap()
+        .expect("lexical payload");
         assert!(out.context.contains("src/watch.rs"));
     }
 
@@ -745,7 +855,15 @@ mod tests {
     fn compose_unknown_pattern_yields_none() {
         let conn = seeded_conn();
         assert!(
-            compose(&conn, "zzqqyyxx_nothing", None, &DedupeFilter::default()).unwrap().is_none()
+            compose(
+                &conn,
+                "zzqqyyxx_nothing",
+                None,
+                &DedupeFilter::default(),
+                crate::config::MemorySurface::Full
+            )
+            .unwrap()
+            .is_none()
         );
     }
 
@@ -887,9 +1005,15 @@ mod tests {
         );
 
         // ── Run compose ────────────────────────────────────────────────────────────────
-        let out = compose(&conn, "watcher_main", None, &DedupeFilter::default())
-            .unwrap()
-            .expect("payload expected");
+        let out = compose(
+            &conn,
+            "watcher_main",
+            None,
+            &DedupeFilter::default(),
+            crate::config::MemorySurface::Full,
+        )
+        .unwrap()
+        .expect("payload expected");
 
         // (a) Context must not exceed the cap.
         assert!(

--- a/crates/rag-rat-core/src/query/memory/hydrate.rs
+++ b/crates/rag-rat-core/src/query/memory/hydrate.rs
@@ -82,6 +82,10 @@ pub(crate) fn memory_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RepoMemory
         kind: row.get("kind")?,
         title: row.get("title")?,
         body: row.get("body")?,
+        // Populated only by the summary-first surface (see `apply_memory_surface`); the mechanical
+        // hydration always yields the full body.
+        summary: None,
+        verdict: None,
         confidence: row.get("confidence")?,
         status: row.get("status")?,
         created_by: row.get("created_by")?,

--- a/crates/rag-rat-core/src/query/memory/mod.rs
+++ b/crates/rag-rat-core/src/query/memory/mod.rs
@@ -33,7 +33,22 @@ pub struct RepoMemory {
     pub memory_id: String,
     pub kind: String,
     pub title: String,
+    // Skipped when EMPTY so the `[memory] surface = "summary"` view can defer the full prose to
+    // `memory show` (the summary-first renderers empty this and populate `summary` instead).
+    // Stored bodies are never empty, so `full` surface and `memory_show` always serialize it.
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub body: String,
+    /// The dream-compacted summary of the CURRENT body, populated ONLY by the summary-first
+    /// renderers under `[memory] surface = "summary"` when a `memory_summaries` row exists for the
+    /// current content_hash. `None` under `full` (and for every non-surfacing tool). Title-only
+    /// fallback when absent — the full body is one `memory show` away.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    /// Plain-text verdict marker from the memory's `memory_reality` row (e.g. `[verdict:
+    /// diverged]`), populated alongside `summary` under `surface = "summary"`. `None`
+    /// otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verdict: Option<String>,
     pub confidence: String,
     pub status: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -272,6 +287,53 @@ impl RepoMemoryEvidence {
             stale: project(&self.stale)?,
         })
     }
+
+    /// Apply `[memory] surface` to every lane's FULL memories IN PLACE (Option A: defer bodies,
+    /// keep structure) — the graph-traversal (`find_callers` / `trace_callees`) counterpart to
+    /// [`Self::compact_summary_first`], used where the evidence is emitted full rather than
+    /// compact. Under `Full` every lane is untouched.
+    pub(crate) fn apply_surface(
+        &mut self,
+        conn: &Connection,
+        surface: crate::config::MemorySurface,
+    ) -> rusqlite::Result<()> {
+        for lane in
+            [&mut self.direct, &mut self.path_crossed, &mut self.call_path_crossed, &mut self.stale]
+        {
+            apply_memory_surface(conn, lane, surface)?;
+        }
+        Ok(())
+    }
+}
+
+/// Apply the `[memory] surface` view to a hydrated FULL memory list IN PLACE (the direct-query
+/// counterpart to [`RepoMemoryEvidence::compact_summary_first`]). Under `Summary` each memory's
+/// full body is DEFERRED to `memory show`: the current-body summary + verdict marker are hydrated
+/// from the derived `memory_summaries` / `memory_reality` siblings (repo-scoped, keyed on the
+/// current content_hash, prompt-version-gated), the body is emptied, and a memory with no summary
+/// falls back to title-only. Unlike the compact projection this KEEPS the full binding/call-path
+/// structure a direct `memory_for_symbol` / `memory_for_path` query relies on — only the prose is
+/// compacted. Under `Full` the list is untouched (byte-identical output).
+pub(crate) fn apply_memory_surface(
+    conn: &Connection,
+    memories: &mut [RepoMemory],
+    surface: crate::config::MemorySurface,
+) -> rusqlite::Result<()> {
+    if !matches!(surface, crate::config::MemorySurface::Summary) {
+        return Ok(());
+    }
+    for memory in memories.iter_mut() {
+        let (summary, verdict) = hydrate::current_summary_and_verdict(
+            conn,
+            &memory.memory_id,
+            &memory.title,
+            &memory.body,
+        )?;
+        memory.summary = summary;
+        memory.verdict = verdict;
+        memory.body = String::new();
+    }
+    Ok(())
 }
 
 /// Compact (default) view of `RepoMemoryEvidence` for `impact_surface` (#37) — same lane layout,
@@ -488,6 +550,8 @@ mod tests {
             kind: "Invariant".to_string(),
             title: "t".to_string(),
             body: "b".to_string(),
+            summary: None,
+            verdict: None,
             confidence: "high".to_string(),
             status: "active".to_string(),
             created_by: None,
@@ -556,6 +620,8 @@ mod tests {
             kind: "Invariant".to_string(),
             title: "t".to_string(),
             body: body.to_string(),
+            summary: None,
+            verdict: None,
             confidence: "high".to_string(),
             status: "active".to_string(),
             created_by: None,
@@ -804,5 +870,53 @@ mod tests {
             fetched.body, body,
             "memory_get returns the full body regardless of the summary"
         );
+    }
+
+    #[test]
+    fn apply_memory_surface_summary_defers_the_body_and_hydrates_summary_and_verdict() {
+        // The direct-query / read_chunk / grep counterpart to `compact_summary_first`: under
+        // `Summary` the full body is emptied (deferred to `memory show`) and the current-body
+        // summary + verdict marker are hydrated in its place.
+        let c = summary_conn();
+        let body = "the full body worth compacting";
+        seed_summary(&c, "m1", body, "A compacted summary in place of the body.");
+        seed_reality(&c, "m1", body, "diverged", None);
+        let mut memories = vec![memory_with_body("m1", body)];
+        apply_memory_surface(&c, &mut memories, crate::config::MemorySurface::Summary).unwrap();
+        assert_eq!(memories[0].body, "", "the full body is deferred under summary");
+        assert_eq!(
+            memories[0].summary.as_deref(),
+            Some("A compacted summary in place of the body.")
+        );
+        assert!(
+            memories[0].verdict.as_deref().unwrap_or_default().contains("diverged"),
+            "the verdict marker is set: {:?}",
+            memories[0].verdict
+        );
+    }
+
+    #[test]
+    fn apply_memory_surface_summary_falls_back_to_title_only_without_a_summary_row() {
+        // No `memory_summaries` / `memory_reality` rows → summary + verdict stay None, but the body
+        // is still deferred: the reader sees the title (+ structure) and expands via `memory show`.
+        let c = summary_conn();
+        let mut memories = vec![memory_with_body("m1", "some body")];
+        apply_memory_surface(&c, &mut memories, crate::config::MemorySurface::Summary).unwrap();
+        assert_eq!(memories[0].body, "", "body deferred even without a summary (title-only)");
+        assert_eq!(memories[0].summary, None);
+        assert_eq!(memories[0].verdict, None);
+    }
+
+    #[test]
+    fn apply_memory_surface_full_is_a_noop() {
+        // `Full` keeps the body byte-identical and never hydrates a summary, even when one exists.
+        let c = summary_conn();
+        let body = "kept verbatim in full mode";
+        seed_summary(&c, "m1", body, "would-be summary");
+        let mut memories = vec![memory_with_body("m1", body)];
+        apply_memory_surface(&c, &mut memories, crate::config::MemorySurface::Full).unwrap();
+        assert_eq!(memories[0].body, body, "full surface keeps the body");
+        assert_eq!(memories[0].summary, None, "full surface never hydrates a summary");
+        assert_eq!(memories[0].verdict, None);
     }
 }

--- a/crates/rag-rat-mcp/src/claude_hook.rs
+++ b/crates/rag-rat-mcp/src/claude_hook.rs
@@ -157,6 +157,7 @@ mod listener {
                 let database = config.database.clone();
                 let config_root = config.root.clone();
                 let repo_id_override = config.repo_id_override.clone();
+                let memory_surface = config.memory.surface;
                 // Scope to the session's worktree overlay (#219). Absent cwd (older client) → the
                 // config root, which resolves to the base scope. This also fixes the listener's
                 // prior lack of ANY scope install: compose queries the `files` view, so without
@@ -188,6 +189,7 @@ mod listener {
                         &pattern,
                         search_path.as_deref(),
                         &filter,
+                        memory_surface,
                     )
                 })
                 .await??;

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -29,17 +29,17 @@ pub(crate) fn call_tool_with_db(
         },
         "symbol_lookup" => {
             let args: SymbolArgs = serde_json::from_value(arguments)?;
-            symbol_lookup_tool(db, args)?
+            symbol_lookup_tool(db, args, memory_surface)?
         },
         "find_callers" => {
             let args: SymbolGraphArgs = serde_json::from_value(arguments)?;
             let resolution_mode = resolution_mode(args.resolution);
-            graph_tool(db, args, resolution_mode, true)?
+            graph_tool(db, args, resolution_mode, true, memory_surface)?
         },
         "trace_callees" => {
             let args: SymbolGraphArgs = serde_json::from_value(arguments)?;
             let resolution_mode = resolution_mode(args.resolution);
-            graph_tool(db, args, resolution_mode, false)?
+            graph_tool(db, args, resolution_mode, false, memory_surface)?
         },
         "compare_graph_to_text" => {
             let args: CompareGraphTextArgs = serde_json::from_value(arguments)?;
@@ -88,7 +88,8 @@ pub(crate) fn call_tool_with_db(
                 args.chunk_id,
                 GraphMetaMode::parse(args.include_graph.as_str())?,
                 args.graph_limit,
-                included(&args.include, MemoriesInclude::Memories, true)
+                included(&args.include, MemoriesInclude::Memories, true),
+                memory_surface,
             )?)
         },
         "commit_search" => {
@@ -183,11 +184,11 @@ pub(crate) fn call_tool_with_db(
         },
         "memory_for_symbol" => {
             let args: MemoryForSymbolArgs = serde_json::from_value(arguments)?;
-            memory_for_symbol_tool(db, args)?
+            memory_for_symbol_tool(db, args, memory_surface)?
         },
         "memory_for_path" => {
             let args: MemoryForPathArgs = serde_json::from_value(arguments)?;
-            json!(db.memory_for_path(&args.path, args.limit)?)
+            json!(db.memory_for_path(&args.path, args.limit, memory_surface)?)
         },
         "memory_for_call_path" => {
             let args: MemoryForCallPathArgs = serde_json::from_value(arguments)?;
@@ -221,7 +222,11 @@ pub(crate) fn call_tool_with_db(
     Ok(result)
 }
 
-pub(crate) fn symbol_lookup_tool(db: &IndexDatabase, args: SymbolArgs) -> anyhow::Result<Value> {
+pub(crate) fn symbol_lookup_tool(
+    db: &IndexDatabase,
+    args: SymbolArgs,
+    memory_surface: MemorySurface,
+) -> anyhow::Result<Value> {
     let include_memories = included(&args.include, SymbolInclude::Memories, true);
     let include_generated = included(&args.include, SymbolInclude::Generated, false);
     let lookup = db.symbol_candidates(&symbol_selector(args)?, include_generated)?;
@@ -236,7 +241,7 @@ pub(crate) fn symbol_lookup_tool(db: &IndexDatabase, args: SymbolArgs) -> anyhow
     // serialized candidates no longer expose it (#149), so the old read of `candidate["symbol_id"]`
     // found nothing and dropped every memory — zip by position against the source hits instead.
     for (candidate, hit) in candidates.iter_mut().zip(&lookup.candidates) {
-        let memories = db.memory_for_symbol(hit, 10)?;
+        let memories = db.memory_for_symbol(hit, 10, memory_surface)?;
         if !memories.is_empty() {
             candidate["memories"] = json!(memories);
         }
@@ -249,6 +254,7 @@ pub(crate) fn graph_tool(
     args: SymbolGraphArgs,
     resolution_mode: GraphResolutionMode,
     reverse: bool,
+    memory_surface: MemorySurface,
 ) -> anyhow::Result<Value> {
     let limit = args.limit;
     let include_references = included(&args.include, GraphInclude::References, false);
@@ -296,7 +302,8 @@ pub(crate) fn graph_tool(
                     &symbol,
                     caller_edge_ids,
                     callee_edge_ids,
-                    10
+                    10,
+                    memory_surface,
                 )?);
             }
             Ok(value)
@@ -526,9 +533,10 @@ pub(crate) fn impact_tool(
         include_text_fallback: included(&args.include, ImpactInclude::TextFallback, true),
         include_memories: included(&args.include, ImpactInclude::Memories, true),
         compact_memories: !args.full_memories,
-        // The primary MCP drive-by attachment renderer: the symbol-selected report path below
-        // honors `[memory] surface`. The query-string / allow-ambiguous fallbacks below still use
-        // the default (full) surface — noted for a follow-up.
+        // The symbol-selected report path below honors `[memory] surface` via this field. The
+        // query-string / allow-ambiguous fallbacks return the flat `Vec<ImpactItem>` shape, which
+        // carries NO repo_memories lane at all (it emits only structural/textual/historical items),
+        // so the surface knob does not apply there — there is nothing to render summary-first.
         surface: memory_surface,
     };
     if args.logical_symbol_id.is_some() || args.symbol_path.is_some() || args.symbol.is_some() {
@@ -564,6 +572,7 @@ pub(crate) fn impact_tool(
 pub(crate) fn memory_for_symbol_tool(
     db: &IndexDatabase,
     args: MemoryForSymbolArgs,
+    memory_surface: MemorySurface,
 ) -> anyhow::Result<Value> {
     let selector = SymbolSelector {
         logical_symbol_id: args.logical_symbol_id,
@@ -575,7 +584,7 @@ pub(crate) fn memory_for_symbol_tool(
         limit: args.limit,
     };
     match db.select_symbol(&selector)? {
-        Ok(Some(symbol)) => Ok(json!(db.memory_for_symbol(&symbol, args.limit)?)),
+        Ok(Some(symbol)) => Ok(json!(db.memory_for_symbol(&symbol, args.limit, memory_surface)?)),
         Ok(None) => Ok(Value::Null),
         Err(disambiguation) => Ok(json!(disambiguation)),
     }

--- a/docs/config.md
+++ b/docs/config.md
@@ -457,15 +457,18 @@ moved on, so there is nothing to act on). Reviewing is repo-scoped and never run
 ## Memory surfacing (`[memory] surface`)
 
 `[memory] surface` controls how drive-by memory attachments render. The default is `full`
-(byte-identical to today's mechanical header). Set it to `summary` to have the primary MCP
-attachment (`impact_surface`'s compact `repo_memories`) show the dream-compacted summary plus a
-plain-text verdict marker (`[verdict: diverged]` / `[verdict: current @<short-commit>]`) for each
-memory that has one:
+(byte-identical to today's mechanical view). Set it to `summary` to have memory attachments show the
+dream-compacted summary plus a plain-text verdict marker (`[verdict: diverged]` /
+`[verdict: current @<short-commit>]`) in place of the full body, for each memory that has one:
 
 ```toml
 [memory]
 surface = "full"   # or "summary" — render title + compacted summary + verdict marker
 ```
 
-A memory with no summary for its current body falls back to title-only. `memory show` /
-`memory_show` **always** return the full body, regardless of this setting — it is the expand path.
+`summary` applies across every drive-by renderer: `impact_surface`'s compact `repo_memories`, the
+`symbol_lookup` / `find_callers` / `trace_callees` attached memories, `read_chunk`'s memories,
+`memory_for_symbol` / `memory_for_path` (which keep the full binding/call-path structure but defer
+the body), and the grep-augmentation hook context. A memory with no summary for its current body
+falls back to title-only. `memory show` / `memory_show` **always** return the full body, regardless
+of this setting — it is the expand path.


### PR DESCRIPTION
#422 wired summary-first surfacing (`title + compacted summary + verdict marker`) into only the primary `impact_surface` compact `repo_memories` attachment. This finishes the job — the remaining memory renderers now honor `[memory] surface` too, so a repo on `surface = "summary"` gets consistent terse memory context everywhere and the full body is one `memory show` away. `full` (the default) output is byte-identical.

## What now honors the surface

| Renderer | Shape under `summary` |
|---|---|
| `memory_for_symbol` / `memory_for_path` | full structure (all bindings/call-paths) kept; body deferred, summary + verdict in its place, title-only fallback |
| `read_chunk` memory attachments | same |
| `symbol_lookup` per-candidate memories | same |
| `find_callers` / `trace_callees` evidence | same, per lane |
| grep-augmentation hook context | summary line in place of the clamped body, verdict appended |
| `impact_surface` symbol-selected report | (already done in #422) |

`memory_show` / `memory_show` stay **full** regardless — the expand path.

## Core seam

One hydrator (`current_summary_and_verdict`, unchanged — same body-hash / prompt-version / repo-scope gates as #422/#428), two projections:

- **Compact (#422):** `RepoMemoryEvidence::compact_summary_first` → `CompactRepoMemory` (primary binding only). Impact's symbol-selected report.
- **Full-structure (new):** `apply_memory_surface(conn, &mut [RepoMemory], surface)` — empties the body, sets `summary`/`verdict`, keeps every binding/call-path (a direct query's relevance signal). `RepoMemory` gains `summary`/`verdict` (skip-if-`None`) and `body` becomes skip-when-empty (stored bodies are never empty, so `full` + `memory_show` still always carry it). `RepoMemoryEvidence::apply_surface` runs it over all four lanes.

The `MemorySurface` config threads through `call_tool_with_db` (and `claude_hook`/`fallback_compose` for the hook), exactly like the existing `graded_history`.

## One finding

The query-string / allow-ambiguous `impact_surface` fallback returns the flat `Vec<ImpactItem>` shape, which carries **no** `repo_memories` lane at all (only structural/textual/historical items) — so there is nothing to render summary-first there. The stale comment that implied otherwise is corrected.

## Scope boundary

The direct-query tools `memory_search` and `memory_for_call_path` still return full bodies (not in the issue's list; a search wants the matched text). Trivial follow-up if wanted — the `apply_memory_surface` helper drops straight in.

## Verification

- `apply_memory_surface` tests (defers body + hydrates summary/verdict; title-only fallback; `full` is a no-op) + a grep-augment summary-render test; existing `full`-path tests unchanged.
- `docs/config.md` `[memory] surface` updated to list full coverage.
- `cargo nextest run --workspace` — 1728 passed. `clippy --all-targets --no-default-features -D warnings` clean. `+nightly fmt` clean.

Fixes #426.