### PR TITLE
Derive enum strings with strum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3366,6 +3366,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "strum",
  "tempfile",
  "thiserror 2.0.18",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ schemars = { version = "1.2.1", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.11"
+strum = { version = "0.28.0", features = ["derive"] }
 thiserror = "2.0"
 tokio = { version = "1.52", features = ["rt-multi-thread", "macros", "io-std"] }
 # Minimal blocking HTTP for the crates.io version check (and future GitHub/GitLab/Bitbucket REST).

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -30,6 +30,7 @@ scip = "0.8.1"
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+strum.workspace = true
 thiserror.workspace = true
 toml.workspace = true
 toon-format.workspace = true

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -385,8 +385,20 @@ impl Default for EmbeddingRuntimeConfig {
 /// the selector only routes ephemeral provisioning (which cookbook container), the freshness /
 /// vector- identity marker (different backends can produce slightly different vectors), the tune
 /// cache key, and the `ai_models.runtime` install marker.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Default,
+    Serialize,
+    Deserialize,
+    strum::EnumString,
+    strum::IntoStaticStr,
+)]
 #[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase", ascii_case_insensitive)]
 pub enum RemoteBackend {
     /// ollama, via its `/v1/embeddings` OpenAI-compatibility route (the default; back-compat).
     #[default]
@@ -401,22 +413,13 @@ impl RemoteBackend {
     /// The stable wire/DB string (matches the serde repr): the `ai_models.runtime` marker, and the
     /// backend discriminator folded into the freshness key + the tune cache key.
     pub fn as_db_str(self) -> &'static str {
-        match self {
-            RemoteBackend::Ollama => "ollama",
-            RemoteBackend::Infinity => "infinity",
-            RemoteBackend::Vllm => "vllm",
-        }
+        self.into()
     }
 
     /// Parse a config `backend = "..."` value (case-insensitive). `None` for an unknown value — the
     /// config layer turns that into `ConfigError::RemoteBackendUnknown`.
     pub fn from_db_str(s: &str) -> Option<Self> {
-        match s.trim().to_ascii_lowercase().as_str() {
-            "ollama" => Some(RemoteBackend::Ollama),
-            "infinity" => Some(RemoteBackend::Infinity),
-            "vllm" => Some(RemoteBackend::Vllm),
-            _ => None,
-        }
+        s.trim().parse().ok()
     }
 
     /// The HTTP path (appended to the endpoint) of this backend's embeddings route. The

--- a/crates/rag-rat-core/src/dream/failure.rs
+++ b/crates/rag-rat-core/src/dream/failure.rs
@@ -8,7 +8,8 @@
 use rusqlite::{Connection, OptionalExtension};
 
 /// Which model pass attempted a memory. Persisted in `memory_model_failures.pass`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumString, strum::IntoStaticStr)]
+#[strum(serialize_all = "lowercase")]
 pub(crate) enum DreamModelPass {
     Verify,
     Compact,
@@ -19,24 +20,18 @@ impl DreamModelPass {
     pub(crate) const ALL: [Self; 2] = [Self::Verify, Self::Compact];
 
     pub(crate) fn as_db_str(self) -> &'static str {
-        match self {
-            Self::Verify => "verify",
-            Self::Compact => "compact",
-        }
+        self.into()
     }
 
     #[cfg(test)]
     pub(crate) fn from_db_str(value: &str) -> Option<Self> {
-        match value {
-            "verify" => Some(Self::Verify),
-            "compact" => Some(Self::Compact),
-            _ => None,
-        }
+        value.parse().ok()
     }
 }
 
 /// Why a model attempt failed. Persisted in `memory_model_failures.reason`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumString, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
 pub(crate) enum DreamFailureReason {
     /// Transport/server failure. Audited, but not used to suppress future model calls because it is
     /// often transient.
@@ -59,22 +54,11 @@ impl DreamFailureReason {
     ];
 
     pub(crate) fn as_db_str(self) -> &'static str {
-        match self {
-            Self::ModelCallFailed => "model_call_failed",
-            Self::MalformedVerdict => "malformed_verdict",
-            Self::FabricatedEvidence => "fabricated_evidence",
-            Self::SummaryGuardRejected => "summary_guard_rejected",
-        }
+        self.into()
     }
 
     pub(crate) fn from_db_str(value: &str) -> Option<Self> {
-        match value {
-            "model_call_failed" => Some(Self::ModelCallFailed),
-            "malformed_verdict" => Some(Self::MalformedVerdict),
-            "fabricated_evidence" => Some(Self::FabricatedEvidence),
-            "summary_guard_rejected" => Some(Self::SummaryGuardRejected),
-            _ => None,
-        }
+        value.parse().ok()
     }
 
     /// Whether an unchanged input should be considered already annotated for this model.
@@ -209,12 +193,19 @@ mod tests {
 
     #[test]
     fn persisted_enums_round_trip() {
-        for pass in DreamModelPass::ALL {
+        for (pass, token) in DreamModelPass::ALL.into_iter().zip(["verify", "compact"]) {
+            assert_eq!(pass.as_db_str(), token);
             assert_eq!(DreamModelPass::from_db_str(pass.as_db_str()), Some(pass));
         }
         assert_eq!(DreamModelPass::from_db_str("nope"), None);
 
-        for reason in DreamFailureReason::ALL {
+        for (reason, token) in DreamFailureReason::ALL.into_iter().zip([
+            "model_call_failed",
+            "malformed_verdict",
+            "fabricated_evidence",
+            "summary_guard_rejected",
+        ]) {
+            assert_eq!(reason.as_db_str(), token);
             assert_eq!(DreamFailureReason::from_db_str(reason.as_db_str()), Some(reason));
         }
         assert_eq!(DreamFailureReason::from_db_str("nope"), None);

--- a/crates/rag-rat-core/src/index/clones/mod.rs
+++ b/crates/rag-rat-core/src/index/clones/mod.rs
@@ -57,7 +57,8 @@ pub(crate) const MIN_TOKENS: usize = 20;
 
 /// Which token space a fingerprint was computed in. Baseline is always present and is the only
 /// input to candidate recall; Scip is an optional precision signal (Plan 3).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumString, strum::IntoStaticStr)]
+#[strum(serialize_all = "lowercase")]
 pub(crate) enum NormalizerKind {
     Baseline,
     Scip,
@@ -65,18 +66,11 @@ pub(crate) enum NormalizerKind {
 
 impl NormalizerKind {
     pub(crate) fn as_db_str(self) -> &'static str {
-        match self {
-            NormalizerKind::Baseline => "baseline",
-            NormalizerKind::Scip => "scip",
-        }
+        self.into()
     }
 
     pub(crate) fn from_db_str(value: &str) -> Option<Self> {
-        match value {
-            "baseline" => Some(NormalizerKind::Baseline),
-            "scip" => Some(NormalizerKind::Scip),
-            _ => None,
-        }
+        value.parse().ok()
     }
 }
 
@@ -164,6 +158,17 @@ mod tests {
     use super::*;
     use crate::index::{parser, symbols};
     use crate::language::Language;
+
+    #[test]
+    fn normalizer_kind_db_str_round_trips() {
+        for (kind, token) in
+            [(NormalizerKind::Baseline, "baseline"), (NormalizerKind::Scip, "scip")]
+        {
+            assert_eq!(kind.as_db_str(), token);
+            assert_eq!(NormalizerKind::from_db_str(kind.as_db_str()), Some(kind));
+        }
+        assert_eq!(NormalizerKind::from_db_str("bogus"), None);
+    }
 
     /// Generalized fingerprint harness (#232): parse `src` with `language` (under `path`), select
     /// the target symbol — the one whose subtree normalizes to the MOST tokens, language-agnostic

--- a/crates/rag-rat-core/src/index/clones/refine/antiunify/types.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/antiunify/types.rs
@@ -9,8 +9,9 @@ use super::super::score::Confidence;
 /// `serde` serializes each variant to its `as_db_str` machine string (`value_param`,
 /// `closure_param`, `type_param`, `gapped`) so the persisted `variation_points_json` is legible
 /// without consulting the Rust enum (matches the `_json` column convention).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, strum::IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub(crate) enum MetavarKind {
     /// A single compatible leaf (local identifier or literal) — a plain by-value parameter.
     ValueParam,
@@ -27,12 +28,7 @@ pub(crate) enum MetavarKind {
 impl MetavarKind {
     /// Stable lower-case machine string. Used both as the persisted role and as `extraction_role`.
     pub(crate) fn as_db_str(&self) -> &'static str {
-        match self {
-            MetavarKind::ValueParam => "value_param",
-            MetavarKind::ClosureParam => "closure_param",
-            MetavarKind::TypeParam => "type_param",
-            MetavarKind::Gapped => "gapped",
-        }
+        (*self).into()
     }
 }
 
@@ -235,6 +231,27 @@ impl EmittedSpan {
             EmittedSpan::Raw(_, hi)
             | EmittedSpan::Statement { hi, .. }
             | EmittedSpan::Classified { hi, .. } => hi,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metavar_kind_db_str_matches_serde_for_all_variants() {
+        for (kind, token) in [
+            (MetavarKind::ValueParam, "value_param"),
+            (MetavarKind::ClosureParam, "closure_param"),
+            (MetavarKind::TypeParam, "type_param"),
+            (MetavarKind::Gapped, "gapped"),
+        ] {
+            assert_eq!(kind.as_db_str(), token);
+            assert_eq!(
+                serde_json::to_value(kind).unwrap(),
+                serde_json::Value::String(token.into())
+            );
         }
     }
 }

--- a/crates/rag-rat-core/src/index/clones/refine/score.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/score.rs
@@ -10,8 +10,11 @@
 /// `serde` serializes to the same lower-case band (`high`/`medium`/`low`) as
 /// [`Confidence::as_db_str`] so the band reads identically whether it comes from the dedicated
 /// column or the embedded `variation_points_json` / `proposed_signature_json` payloads.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, strum::EnumString, strum::IntoStaticStr,
+)]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub(crate) enum Confidence {
     High,
     Medium,
@@ -20,21 +23,13 @@ pub(crate) enum Confidence {
 
 impl Confidence {
     pub(crate) fn as_db_str(&self) -> &'static str {
-        match self {
-            Confidence::High => "high",
-            Confidence::Medium => "medium",
-            Confidence::Low => "low",
-        }
+        (*self).into()
     }
 
     /// Parse the persisted lower-case band back (cache read-through). An unknown value degrades to
     /// `Low` rather than erroring — a stale/foreign band should never crash a read.
     pub(crate) fn from_db_str(value: &str) -> Self {
-        match value {
-            "high" => Confidence::High,
-            "medium" => Confidence::Medium,
-            _ => Confidence::Low,
-        }
+        value.parse().unwrap_or(Confidence::Low)
     }
 }
 
@@ -233,7 +228,10 @@ mod tests {
 
     #[test]
     fn confidence_db_str_round_trips() {
-        for c in [Confidence::High, Confidence::Medium, Confidence::Low] {
+        for (c, token) in
+            [(Confidence::High, "high"), (Confidence::Medium, "medium"), (Confidence::Low, "low")]
+        {
+            assert_eq!(c.as_db_str(), token);
             assert_eq!(Confidence::from_db_str(c.as_db_str()), c);
         }
         // unknown → Low (never panics).

--- a/crates/rag-rat-core/src/index/clones/refine/signature.rs
+++ b/crates/rag-rat-core/src/index/clones/refine/signature.rs
@@ -22,8 +22,9 @@ use crate::language::Language;
 /// into this enum), so a new variant is additive: no migration, no reader change. A stale cached
 /// row written before this variant existed surfaces the OLD label until the class is recomputed,
 /// which is a less-honest label, never an over-claim.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, strum::IntoStaticStr)]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub(crate) enum Typedness {
     /// Every promoted param was assigned a CONCRETE type (from an AST annotation or a
     /// literal-bucket coarse mapping) AND there are no `unresolved_type_slots`. The signature
@@ -56,12 +57,7 @@ pub(crate) enum Typedness {
 
 impl Typedness {
     pub(crate) fn as_db_str(&self) -> &'static str {
-        match self {
-            Typedness::Syntactic => "syntactic",
-            Typedness::Structural => "structural",
-            Typedness::Partial => "partial",
-            Typedness::Unknown => "unknown",
-        }
+        (*self).into()
     }
 }
 
@@ -708,6 +704,22 @@ mod tests {
         (members, template, sig)
     }
 
+    #[test]
+    fn typedness_db_str_matches_serde_for_all_variants() {
+        for (typedness, token) in [
+            (Typedness::Syntactic, "syntactic"),
+            (Typedness::Structural, "structural"),
+            (Typedness::Partial, "partial"),
+            (Typedness::Unknown, "unknown"),
+        ] {
+            assert_eq!(typedness.as_db_str(), token);
+            assert_eq!(
+                serde_json::to_value(typedness).unwrap(),
+                serde_json::Value::String(token.into())
+            );
+        }
+    }
+
     // ── Test 1: a STABLE type position → Syntactic ───────────────────────────────────────────────
 
     #[test]
@@ -1092,7 +1104,7 @@ mod tests {
         // The serialized/DB string is the new `structural` token (additive — opaque to readers).
         assert_eq!(sig.typedness.as_db_str(), "structural");
         assert_eq!(
-            serde_json::to_value(&sig.typedness).unwrap(),
+            serde_json::to_value(sig.typedness).unwrap(),
             serde_json::Value::String("structural".to_string()),
             "serde must serialize Structural to the same `structural` token as as_db_str"
         );

--- a/crates/rag-rat-core/src/index/oracle/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/mod.rs
@@ -637,7 +637,8 @@ pub(crate) fn current_oracle_comparisons(
 /// The oracle tool that produced a SCIP index. Phase 1 ships only the Rust backend (consumed from a
 /// pre-built `.scip`); the enum is the registry seam phase 2 (#69) extends. Persisted enum →
 /// `as_db_str` / `from_db_str` per `rust-modern-style`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, strum::EnumString, strum::IntoStaticStr)]
+#[strum(serialize_all = "kebab-case")]
 pub enum OracleTool {
     /// `rust-analyzer scip` — Rust (phase 2, #69).
     RustAnalyzer,
@@ -673,24 +674,11 @@ impl OracleTool {
     ];
 
     pub fn as_db_str(self) -> &'static str {
-        match self {
-            Self::RustAnalyzer => "rust-analyzer",
-            Self::ScipClang => "scip-clang",
-            Self::ScipPython => "scip-python",
-            Self::ScipTypescript => "scip-typescript",
-            Self::ScipJava => "scip-java",
-        }
+        self.into()
     }
 
     pub fn from_db_str(value: &str) -> Option<Self> {
-        match value {
-            "rust-analyzer" => Some(Self::RustAnalyzer),
-            "scip-clang" => Some(Self::ScipClang),
-            "scip-python" => Some(Self::ScipPython),
-            "scip-typescript" => Some(Self::ScipTypescript),
-            "scip-java" => Some(Self::ScipJava),
-            _ => None,
-        }
+        value.parse().ok()
     }
 
     /// Whether this backend's non-zero EXIT CODE reflects source DIAGNOSTICS rather than indexing
@@ -729,7 +717,8 @@ impl OracleTool {
 
 /// What the oracle concluded about one edge candidate. The names mirror the #61 design taxonomy.
 /// Persisted on `edge_oracle.kind`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, strum::EnumString, strum::IntoStaticStr)]
+#[strum(serialize_all = "kebab-case")]
 pub enum OracleResolutionKind {
     /// An unresolved / `NameOnly` / `Ambiguous` edge whose callee the oracle resolved to a symbol
     /// inside the corpus — a recovery the heuristic missed or under-resolved.
@@ -747,22 +736,11 @@ pub enum OracleResolutionKind {
 
 impl OracleResolutionKind {
     pub fn as_db_str(self) -> &'static str {
-        match self {
-            Self::Upgrade => "upgrade",
-            Self::ResolvedExternal => "resolved-external",
-            Self::Confirm => "confirm",
-            Self::Contradict => "contradict",
-        }
+        self.into()
     }
 
     pub fn from_db_str(value: &str) -> Option<Self> {
-        match value {
-            "upgrade" => Some(Self::Upgrade),
-            "resolved-external" => Some(Self::ResolvedExternal),
-            "confirm" => Some(Self::Confirm),
-            "contradict" => Some(Self::Contradict),
-            _ => None,
-        }
+        value.parse().ok()
     }
 }
 

--- a/crates/rag-rat-core/src/index/oracle/tests/persisted_enums.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests/persisted_enums.rs
@@ -8,17 +8,25 @@ use super::*;
 /// reject an unknown string — the `rust-modern-style` closed-enum contract.
 #[test]
 fn persisted_enums_round_trip_through_db_strings() {
-    for &tool in OracleTool::ALL {
+    for (tool, token) in [
+        (OracleTool::RustAnalyzer, "rust-analyzer"),
+        (OracleTool::ScipClang, "scip-clang"),
+        (OracleTool::ScipPython, "scip-python"),
+        (OracleTool::ScipTypescript, "scip-typescript"),
+        (OracleTool::ScipJava, "scip-java"),
+    ] {
+        assert_eq!(tool.as_db_str(), token);
         assert_eq!(OracleTool::from_db_str(tool.as_db_str()), Some(tool));
     }
     assert_eq!(OracleTool::from_db_str("no-such-tool"), None);
 
-    for kind in [
-        OracleResolutionKind::Upgrade,
-        OracleResolutionKind::ResolvedExternal,
-        OracleResolutionKind::Confirm,
-        OracleResolutionKind::Contradict,
+    for (kind, token) in [
+        (OracleResolutionKind::Upgrade, "upgrade"),
+        (OracleResolutionKind::ResolvedExternal, "resolved-external"),
+        (OracleResolutionKind::Confirm, "confirm"),
+        (OracleResolutionKind::Contradict, "contradict"),
     ] {
+        assert_eq!(kind.as_db_str(), token);
         assert_eq!(OracleResolutionKind::from_db_str(kind.as_db_str()), Some(kind));
     }
     assert_eq!(OracleResolutionKind::from_db_str("nonsense"), None);

--- a/crates/rag-rat-core/src/index/query_api/clones/types.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/types.rs
@@ -171,8 +171,11 @@ pub struct CloneCompleteness {
 /// `Generated` ⊃ `StaleNormalizerVersion` ⊃ `NonFunctionKind` ⊃ `BelowMinTokens`.
 ///
 /// [`classify_ineligibility_reason`]: super::resolve::classify_ineligibility_reason
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, strum::EnumString, strum::IntoStaticStr,
+)]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum CloneIneligibilityReason {
     /// The symbol's file is generated (`files.generated = 1` — a `kind = generated` target or a
     /// path-heuristic codegen file like `src/generated/…`/`.d.ts`). Generated code is excluded from
@@ -201,23 +204,12 @@ pub enum CloneIneligibilityReason {
 impl CloneIneligibilityReason {
     /// The stable wire/DB token for this reason (matches the `serde` snake_case rename).
     pub fn as_db_str(self) -> &'static str {
-        match self {
-            CloneIneligibilityReason::Generated => "generated",
-            CloneIneligibilityReason::NonFunctionKind => "non_function_kind",
-            CloneIneligibilityReason::StaleNormalizerVersion => "stale_normalizer_version",
-            CloneIneligibilityReason::BelowMinTokens => "below_min_tokens",
-        }
+        self.into()
     }
 
     /// Parse a wire/DB token back into a reason (inverse of [`as_db_str`](Self::as_db_str)).
     pub fn from_db_str(value: &str) -> Option<Self> {
-        match value {
-            "generated" => Some(CloneIneligibilityReason::Generated),
-            "non_function_kind" => Some(CloneIneligibilityReason::NonFunctionKind),
-            "stale_normalizer_version" => Some(CloneIneligibilityReason::StaleNormalizerVersion),
-            "below_min_tokens" => Some(CloneIneligibilityReason::BelowMinTokens),
-            _ => None,
-        }
+        value.parse().ok()
     }
 }
 
@@ -302,4 +294,27 @@ pub enum CloneSymbolSelector {
     Ref(String),
     /// The tightest-spanning in-scope symbol whose line range contains `line` in `path`.
     PathLine { path: String, line: i64 },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clone_ineligibility_reason_db_str_matches_serde_for_all_variants() {
+        for (reason, token) in [
+            (CloneIneligibilityReason::Generated, "generated"),
+            (CloneIneligibilityReason::NonFunctionKind, "non_function_kind"),
+            (CloneIneligibilityReason::StaleNormalizerVersion, "stale_normalizer_version"),
+            (CloneIneligibilityReason::BelowMinTokens, "below_min_tokens"),
+        ] {
+            assert_eq!(reason.as_db_str(), token);
+            assert_eq!(CloneIneligibilityReason::from_db_str(reason.as_db_str()), Some(reason));
+            assert_eq!(
+                serde_json::to_value(reason).unwrap(),
+                serde_json::Value::String(token.into())
+            );
+        }
+        assert_eq!(CloneIneligibilityReason::from_db_str("bogus"), None);
+    }
 }


### PR DESCRIPTION
## Summary
- add `strum` 0.28.0 with derive support to the workspace
- replace manual persisted enum string match arms in `rag-rat-core` with `strum` derives while preserving existing `as_db_str` / `from_db_str` wrapper APIs
- add exact-token tests so serde/DB string contracts cannot drift behind symmetric round trips

## Validation
- `cargo test -p rag-rat-core --no-default-features db_str`
- `cargo test -p rag-rat-core --no-default-features persisted_enums_round_trip`
- `cargo test -p rag-rat-core --no-default-features pure_closure_param_typedness_is_structural_not_unknown`
- `cargo +nightly fmt --check`
- `cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings`
- `git diff --check`
