### PR TITLE
feat(index): make explicit-config adoption loud and refuse empty indexes

### DIFF
--- a/crates/rag-rat-cli/src/cli.rs
+++ b/crates/rag-rat-cli/src/cli.rs
@@ -151,6 +151,10 @@ pub(crate) struct IndexArgs {
     /// Run the background file watcher in the foreground until interrupted.
     #[arg(long)]
     pub watch: bool,
+    /// Allow `index` to complete when zero files are discovered (e.g. no `[target_bindings]`),
+    /// registering the repo with empty content instead of erroring. Default: refuse (#427).
+    #[arg(long)]
+    pub allow_empty: bool,
 }
 
 #[derive(Debug, Args)]

--- a/crates/rag-rat-cli/src/commands/clones.rs
+++ b/crates/rag-rat-cli/src/commands/clones.rs
@@ -296,6 +296,8 @@ mod tests {
             search: Default::default(),
             memory: Default::default(),
             log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
         };
         IndexDatabase::rebuild(&config).unwrap();
 

--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -15,7 +15,20 @@ use crate::render::{
 use crate::{DEFAULT_MAINTENANCE_SECONDS, open_index};
 
 pub(crate) fn index(config: &Config, args: &IndexArgs) -> anyhow::Result<()> {
+    // The empty-index refusal is enforced ONCE, in the core `rebuild_with_progress` (#427); the CLI
+    // only threads the `--allow-empty` opt-in via `Config::allow_empty`, so every mode below
+    // (full / discover / changed / watch) inherits the same policy with no per-mode guard.
+    let config = &Config { allow_empty: args.allow_empty, ..config.clone() };
     if args.watch {
+        // Surface the loud-adoption warnings (re-anchor / same-identity join) for watch mode too —
+        // the watcher's catch-up pass indexes this scope, so a worktree/clone starting `--watch`
+        // must still get the `--worktree` / `[index] repo_id` guidance (#427 review). `run_watch`
+        // refuses a NO-`[target_bindings]` config up front (it could never index anything); a
+        // config with targets that currently match zero files instead starts and defers via
+        // the watcher's own rebuild, which refuses the first-time-empty registration and
+        // `let _ =`-discards it (waiting for content). `--allow-empty` registers a
+        // deliberately empty index either way.
+        surface_adoption_warnings(config)?;
         return run_watch(config.clone());
     }
     // Serialize with the background watcher / other writers OF THIS REPO (busy_timeout backstops
@@ -47,6 +60,7 @@ pub(crate) fn index(config: &Config, args: &IndexArgs) -> anyhow::Result<()> {
         );
         return Ok(());
     }
+    surface_adoption_warnings(config)?;
     let db = if args.full {
         IndexDatabase::rebuild_with_progress(config, render_index_progress)?
     } else if args.discover {
@@ -67,6 +81,42 @@ pub(crate) fn index(config: &Config, args: &IndexArgs) -> anyhow::Result<()> {
         eprintln!("⚠ {doctor_count} repo memories need re-anchoring — run 'rag-rat memory doctor'");
     }
     print_output(&db.status(&config.database)?)
+}
+
+/// #427: emit the loud-adoption warnings for a one-shot or watch `index`. Non-fatal (stderr), and
+/// deliberately NOT run for `--worktree` overlays (that is an explicit, correct overlay op). The
+/// re-anchor message leads the more generic same-identity-join message (worktree is the more
+/// specific diagnosis).
+fn surface_adoption_warnings(config: &Config) -> anyhow::Result<()> {
+    // The configured `[index] root` named a LINKED worktree; `Config::load` re-anchored it to the
+    // main checkout (worktrees share one base index). Say so, and point at the two ways to get the
+    // branch's own content: the overlay, or a distinct pinned identity.
+    if let Some(worktree_root) = &config.source_root_reanchored_from {
+        eprintln!(
+            "warning: `[index] root` names a linked worktree ({}); indexing the MAIN checkout {} \
+             instead — worktrees share one base index.\n  Index this branch's delta with `rag-rat \
+             index --worktree {}`.\n  To index {} as its own repo, pin `[index] repo_id`.",
+            worktree_root.display(),
+            config.root.display(),
+            worktree_root.display(),
+            worktree_root.display(),
+        );
+    }
+    // Warn — don't block — when this root shares an already-registered repo's identity and would
+    // merge into that ONE scope (a fresh clone, or a worktree not yet anchored). The user may want
+    // that (re-index) or may have meant an independent index; name the remedy either way.
+    if let Some(join) = rag_rat_core::index::same_identity_join_note(config)? {
+        eprintln!(
+            "warning: this checkout ({}) shares the identity of already-indexed repo `{}` \
+             (recorded at {}); indexing merges it into that one scope.\n  To index {} as its own \
+             repo, add `[index] repo_id = \"...\"` to rag-rat.toml.",
+            config.root.display(),
+            join.repo_id,
+            join.existing_root.display(),
+            config.root.display(),
+        );
+    }
+    Ok(())
 }
 
 pub(crate) fn reconcile(config: &Config, args: &ReconcileArgs) -> anyhow::Result<()> {
@@ -128,6 +178,21 @@ pub(crate) fn reconcile(config: &Config, args: &ReconcileArgs) -> anyhow::Result
 }
 
 pub(crate) fn run_watch(config: Config) -> anyhow::Result<()> {
+    // #427 (review): a config with no watchable target DIRECTORIES can discover nothing, EVER. Its
+    // watcher would place zero source watches and then sit forever — a silent, unrecoverable state
+    // (it never re-reads config, so adding targets later doesn't help until restart). Keyed on
+    // `target_directories()`, NOT `targets.is_empty()`: a target with an empty directory list
+    // (`[target_bindings] rust = []`) leaves `targets` non-empty yet watches nothing, the same dead
+    // end. Unlike a config WITH target dirs that currently match zero files — that legitimately
+    // starts and DEFERS, because a file appearing under a watched dir wakes it — the
+    // no-watchable-dir case is a misconfiguration, so refuse it up front with the actionable
+    // message, the same policy as the one-shot `index`. `--allow-empty` opts in to an empty watch.
+    if !config.allow_empty && config.target_directories().is_empty() {
+        return Err(rag_rat_core::index::EmptyIndexRefused {
+            root: config.root.display().to_string(),
+        }
+        .into());
+    }
     let Some(_watcher) = rag_rat_core::watch::Watcher::spawn(config.clone()) else {
         anyhow::bail!("watcher is disabled ([watch] enabled = false or RAG_RAT_NO_WATCH set)");
     };
@@ -279,7 +344,23 @@ fn run_maintenance_pass(
     let _lock = rag_rat_core::locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
     tracing::debug!(target: "rag_rat_core::maintenance", phase = "lock_acquired", elapsed_ms = started.elapsed().as_millis() as u64, "write lock acquired");
 
-    let mut db = IndexDatabase::index_discover_with_progress(config, render_index_progress)?;
+    // #427: the core refuses a first-time-empty registration (a post-commit/checkout hook on a repo
+    // with no `[target_bindings]` or no matching files). The hook-driven maintenance pass treats
+    // that as "nothing to index yet" and DEFERS — a later pass registers once content appears —
+    // rather than surfacing an error into the git hook. A recorded root going empty still prunes
+    // (it is not first-time, so the core does not refuse it).
+    let mut db = match IndexDatabase::index_discover_with_progress(config, render_index_progress) {
+        Ok(db) => db,
+        Err(err) if err.downcast_ref::<rag_rat_core::index::EmptyIndexRefused>().is_some() => {
+            tracing::info!(target: "rag_rat_core::maintenance", "deferred: no discoverable files (first-time empty index)");
+            return Ok(serde_json::json!({
+                "trigger": trigger,
+                "status": "deferred",
+                "reason": "no discoverable files (first-time empty index)",
+            }));
+        },
+        Err(err) => return Err(err),
+    };
     tracing::debug!(target: "rag_rat_core::maintenance", phase = "index_discover", elapsed_ms = started.elapsed().as_millis() as u64, "phase complete");
     // One-time on upgrade: re-encode any legacy f32 vector blobs to the compact int8 format (#312).
     // Meta-gated, so this runs once and then skips the table scan cheaply on every later pass; run
@@ -489,6 +570,8 @@ mod tests {
             search: Default::default(),
             memory: Default::default(),
             log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
         };
         IndexDatabase::rebuild(&config).unwrap();
 
@@ -568,6 +651,8 @@ mod tests {
             search: Default::default(),
             memory: Default::default(),
             log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
         };
         IndexDatabase::rebuild(&config).unwrap();
 
@@ -645,6 +730,8 @@ mod tests {
             search: Default::default(),
             memory: Default::default(),
             log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
         };
         IndexDatabase::rebuild(&config).unwrap();
 
@@ -717,6 +804,8 @@ mod tests {
             search: Default::default(),
             memory: Default::default(),
             log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
         };
         IndexDatabase::rebuild(&config).unwrap();
 

--- a/crates/rag-rat-cli/src/commands/oracle.rs
+++ b/crates/rag-rat-cli/src/commands/oracle.rs
@@ -484,6 +484,8 @@ mod tests {
             search: Default::default(),
             memory: Default::default(),
             log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
         };
         (root, config)
     }
@@ -533,6 +535,8 @@ mod tests {
             search: Default::default(),
             memory: Default::default(),
             log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
         };
         let config = config_with(vec!["**/*.rs".to_string()], Vec::new());
         let profile = |dirs: &[&str]| {

--- a/crates/rag-rat-cli/tests/index_guards.rs
+++ b/crates/rag-rat-cli/tests/index_guards.rs
@@ -1,0 +1,459 @@
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use path_slash::{PathBufExt, PathExt};
+use tempfile::TempDir;
+
+/// #427: `index` with no `[target_bindings]` must FAIL (non-zero exit) and name the section,
+/// rather than silently registering an empty repo.
+#[test]
+fn index_refuses_zero_discovered_files() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(root.join("src/a.rs"), "fn a() {}\n").unwrap();
+    // Config with a root + database but NO [target_bindings].
+    let db = root.join("index.sqlite");
+    let toml = format!(
+        "[index]\nroot = \".\"\ndatabase = \"{}\"\n[llm.embedding]\nmodel = \"none\"\n",
+        db.to_slash_lossy()
+    );
+    let config_path = root.join("rag-rat.toml");
+    std::fs::write(&config_path, toml).unwrap();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+        .args(["--config", config_path.to_str().unwrap(), "index"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "index should refuse a zero-file config");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("target_bindings"), "stderr should name target_bindings: {stderr}");
+    assert!(!db.exists() || is_empty_db_absent(&db), "must not register an empty repo");
+}
+
+/// With `--allow-empty`, the same config succeeds (empty index).
+#[test]
+fn index_allow_empty_permits_zero_discovered_files() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let db = root.join("index.sqlite");
+    let toml = format!(
+        "[index]\nroot = \".\"\ndatabase = \"{}\"\n[llm.embedding]\nmodel = \"none\"\n",
+        db.to_slash_lossy()
+    );
+    let config_path = root.join("rag-rat.toml");
+    std::fs::write(&config_path, toml).unwrap();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+        .args(["--config", config_path.to_str().unwrap(), "index", "--allow-empty"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "--allow-empty should succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// #427: pointing `[index] root` at a fresh clone of an already-indexed repo (same identity, shared
+/// database) must WARN that it merges into the existing scope and name the `[index] repo_id` remedy
+/// — the same-identity-join hint, exercised through the real CLI so the warning wiring is covered.
+#[test]
+fn index_warns_when_a_clone_joins_an_indexed_repo() {
+    if !git_available() {
+        return; // identity resolution needs git; skip rather than fail.
+    }
+    let dir = TempDir::new().unwrap();
+    let tmp = dir.path();
+    let shared = tmp.join("shared.sqlite");
+
+    // Repo A: a committed git repo, indexed into the shared database.
+    let a = tmp.join("A");
+    std::fs::create_dir_all(a.join("src")).unwrap();
+    git_init_commit(&a);
+    std::fs::write(a.join("rag-rat.toml"), shared_config(&shared)).unwrap();
+    let out = run_index(&a.join("rag-rat.toml"), &a);
+    assert!(out.status.success(), "indexing A should succeed: {}", stderr(&out));
+
+    // Clone B (same root commit → same portable identity) pointed at the SAME database.
+    let b = tmp.join("B");
+    let cloned = Command::new("git")
+        .args(["clone", "-q", a.to_str().unwrap(), b.to_str().unwrap()])
+        .status()
+        .unwrap();
+    assert!(cloned.success(), "git clone A B failed");
+    std::fs::write(b.join("rag-rat.toml"), shared_config(&shared)).unwrap();
+
+    let out = run_index(&b.join("rag-rat.toml"), &b);
+    let stderr = stderr(&out);
+    assert!(out.status.success(), "indexing the clone should still succeed: {stderr}");
+    assert!(
+        stderr.contains("shares the identity") && stderr.contains("repo_id"),
+        "clone should warn it joins the existing scope and name the repo_id remedy: {stderr}"
+    );
+}
+
+/// #427: when `[index] root` names a linked worktree, `Config::load` re-anchors it to the main
+/// checkout and `index` must WARN that it is indexing the main tree, naming `--worktree` — the
+/// re-anchor hint, exercised through the real CLI.
+#[test]
+fn index_warns_when_root_names_a_linked_worktree() {
+    if !git_available() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let tmp = dir.path();
+    let shared = tmp.join("shared.sqlite");
+
+    // Main checkout with its own config (so the governing seam anchors root to main).
+    let main = tmp.join("main");
+    std::fs::create_dir_all(main.join("src")).unwrap();
+    git_init_commit(&main);
+    std::fs::write(main.join("rag-rat.toml"), shared_config(&shared)).unwrap();
+
+    // A linked worktree with a local config whose root="." resolves to the worktree.
+    let wt = tmp.join("wt");
+    let added = Command::new("git")
+        .args([
+            "-C",
+            main.to_str().unwrap(),
+            "worktree",
+            "add",
+            "--detach",
+            "-q",
+            wt.to_str().unwrap(),
+        ])
+        .status()
+        .unwrap();
+    assert!(added.success(), "git worktree add failed");
+    std::fs::create_dir_all(wt.join("src")).unwrap();
+    std::fs::write(wt.join("rag-rat.toml"), shared_config(&shared)).unwrap();
+
+    // Run from inside the worktree so config discovery finds its local config, then re-anchors.
+    let out = run_index(&wt.join("rag-rat.toml"), &wt);
+    let stderr = stderr(&out);
+    assert!(out.status.success(), "indexing from a worktree should succeed: {stderr}");
+    assert!(
+        stderr.contains("linked worktree") && stderr.contains("--worktree"),
+        "a linked-worktree root should warn it indexes the main checkout: {stderr}"
+    );
+}
+
+/// #427 review: an ALREADY-indexed repo whose last file is deleted must still index (pruning the
+/// stale rows), NOT be refused by the empty-index guard — that refusal is only for first-time empty
+/// registrations.
+#[test]
+fn index_allows_an_already_indexed_repo_to_go_empty() {
+    if !git_available() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let tmp = dir.path();
+    let db = tmp.join("index.sqlite");
+    let repo = tmp.join("repo");
+    std::fs::create_dir_all(repo.join("src")).unwrap();
+    git_init_commit(&repo);
+    std::fs::write(repo.join("rag-rat.toml"), shared_config(&db)).unwrap();
+
+    // First index registers the repo with one file.
+    let out = run_index(&repo.join("rag-rat.toml"), &repo);
+    assert!(out.status.success(), "first index should succeed: {}", stderr(&out));
+
+    // Delete the only indexed file, then re-discover: the guard must let it through so the pass
+    // prunes to empty instead of stranding the deleted file's row.
+    std::fs::remove_file(repo.join("src/a.rs")).unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+        .args(["--config", repo.join("rag-rat.toml").to_str().unwrap(), "index", "--discover"])
+        .current_dir(&repo)
+        .output()
+        .unwrap();
+    let err = stderr(&out);
+    assert!(out.status.success(), "an existing index going empty must not be refused: {err}");
+    assert!(
+        !err.contains("no `[target_bindings]`"),
+        "must not print the first-time-empty refusal for an existing index: {err}"
+    );
+    assert!(err.contains("discovered 0 files"), "should have run the discover/prune pass: {err}");
+}
+
+/// #427 review: `index --full` on an EXISTING index whose files were all deleted must MIGRATE +
+/// PRUNE it, not refuse it as first-time-empty. The rebuild guard checks AFTER `create_or_migrate`
+/// for an existing DB (so a pre-registry/older index becomes readable first) and recognizes it via
+/// the persisted `source_root` — here a not-yet-adopted placeholder index (indexed while non-git).
+#[test]
+fn full_rebuild_prunes_an_existing_placeholder_index_instead_of_refusing() {
+    if !git_available() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let repo = dir.path();
+    let db = repo.join("index.sqlite");
+    std::fs::create_dir_all(repo.join("src")).unwrap();
+    std::fs::write(repo.join("src/a.rs"), "fn a() {}\n").unwrap();
+    std::fs::write(repo.join("rag-rat.toml"), shared_config(&db)).unwrap();
+
+    // Index while NON-git → adopts the `__unassigned__` placeholder (a legacy-style,
+    // not-yet-adopted index) and persists source_root under it.
+    let out = run_index(&repo.join("rag-rat.toml"), repo);
+    assert!(out.status.success(), "initial index should succeed: {}", stderr(&out));
+
+    // Give the root a git identity the DB has NOT adopted, then delete all target files.
+    let git = |args: &[&str]| {
+        Command::new("git").arg("-C").arg(repo).args(args).output().unwrap();
+    };
+    git(&["init", "-q"]);
+    git(&["config", "user.email", "t@example.com"]);
+    git(&["config", "user.name", "t"]);
+    git(&["add", "-A"]);
+    git(&["commit", "-qm", "init"]);
+    std::fs::remove_file(repo.join("src/a.rs")).unwrap();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+        .args(["--config", repo.join("rag-rat.toml").to_str().unwrap(), "index", "--full"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    let err = stderr(&out);
+    assert!(
+        out.status.success(),
+        "an existing index going empty must be pruned by --full, not refused: {err}"
+    );
+    assert!(
+        !err.contains("no `[target_bindings]`"),
+        "must not print the first-time-empty refusal for an existing index: {err}"
+    );
+}
+
+/// #427 root-cause: the empty refusal must fire on the INCREMENTAL path too, not just the fresh
+/// rebuild. When the DB already exists (repo A indexed into a shared DB), a first-time-empty repo B
+/// pointed at it takes the incremental/discover path, whose guard must refuse BEFORE adopting B —
+/// otherwise adoption records B's root and a later check would wave the empty registration through.
+#[test]
+fn index_discover_refuses_a_first_time_empty_repo_against_an_existing_db() {
+    if !git_available() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let tmp = dir.path();
+    let db = tmp.join("shared.sqlite");
+
+    // Repo A: real content, indexed into the shared DB — so the DB EXISTS and is non-empty, which
+    // is what routes B below through the incremental path instead of the fresh-DB rebuild.
+    let a = tmp.join("A");
+    std::fs::create_dir_all(a.join("src")).unwrap();
+    git_init_commit(&a);
+    std::fs::write(a.join("rag-rat.toml"), shared_config(&db)).unwrap();
+    let out = run_index(&a.join("rag-rat.toml"), &a);
+    assert!(out.status.success(), "indexing A should succeed: {}", stderr(&out));
+
+    // Repo B: a DISTINCT git repo (own first-commit content → own identity) pointed at A's SAME DB,
+    // but with NO [target_bindings]. `index --discover` here hits the incremental empty-index
+    // guard.
+    let b = tmp.join("B");
+    std::fs::create_dir_all(b.join("src")).unwrap();
+    std::fs::write(b.join("src/b.rs"), "fn b() {}\n").unwrap();
+    let git_b = |args: &[&str]| {
+        Command::new("git").arg("-C").arg(&b).args(args).output().unwrap();
+    };
+    git_b(&["init", "-q"]);
+    git_b(&["config", "user.email", "t@example.com"]);
+    git_b(&["config", "user.name", "t"]);
+    git_b(&["add", "-A"]);
+    git_b(&["commit", "-qm", "b"]);
+    let no_targets = format!(
+        "[index]\nroot = \".\"\ndatabase = \"{}\"\n[llm.embedding]\nmodel = \"none\"\n",
+        db.to_slash_lossy()
+    );
+    std::fs::write(b.join("rag-rat.toml"), &no_targets).unwrap();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+        .args(["--config", b.join("rag-rat.toml").to_str().unwrap(), "index", "--discover"])
+        .current_dir(&b)
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "a first-time-empty repo on an existing DB must be refused on the incremental path"
+    );
+    let err = stderr(&out);
+    assert!(err.contains("target_bindings"), "should name target_bindings: {err}");
+}
+
+/// #427 review: `index --watch` on a config with NO `[target_bindings]` can never discover
+/// anything, so it must FAIL FAST at startup (naming the section) rather than sit as a silent,
+/// unrecoverable watcher that watches nothing and never re-reads config. Contrast with
+/// `index_watch_with_configured_targets_but_no_files_defers`.
+#[test]
+fn index_watch_on_a_no_target_config_errors() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let db = root.join("index.sqlite");
+    // No [target_bindings], fresh database.
+    let toml = format!(
+        "[index]\nroot = \".\"\ndatabase = \"{}\"\n[llm.embedding]\nmodel = \"none\"\n",
+        db.to_slash_lossy()
+    );
+    let config_path = root.join("rag-rat.toml");
+    std::fs::write(&config_path, toml).unwrap();
+
+    // `env_remove` so the failure is the no-target refusal, not the "watcher disabled" error.
+    let out = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+        .args(["--config", config_path.to_str().unwrap(), "index", "--watch"])
+        .current_dir(root)
+        .env_remove("RAG_RAT_NO_WATCH")
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "no-target index --watch should fail fast, not park");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("target_bindings"), "stderr should name target_bindings: {stderr}");
+    assert!(!db.exists() || is_empty_db_absent(&db), "must not register an empty index");
+}
+
+/// #427 review: `index --watch` on a config WITH `[target_bindings]` that currently match zero
+/// files starts and DEFERS — the watcher keeps running (a file added under a watched target dir
+/// will register + index it) and registers nothing until then. Bounded: sleep briefly, confirm it
+/// is still watching and registered nothing, then kill it.
+#[test]
+fn index_watch_with_configured_targets_but_no_files_defers() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let db = root.join("index.sqlite");
+    // [target_bindings] present, but the target dir currently holds no matching files.
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    let toml = format!(
+        "[index]\nroot = \".\"\ndatabase = \"{}\"\n[llm.embedding]\nmodel = \
+         \"none\"\n[target_bindings]\nrust = [\"src\"]\n",
+        db.to_slash_lossy()
+    );
+    let config_path = root.join("rag-rat.toml");
+    std::fs::write(&config_path, toml).unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+        .args(["--config", config_path.to_str().unwrap(), "index", "--watch"])
+        .current_dir(root)
+        .env_remove("RAG_RAT_NO_WATCH")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    // Give the watcher time to start and run its first (deferring) maintenance pass.
+    std::thread::sleep(Duration::from_secs(3));
+    let still_watching = child.try_wait().unwrap().is_none();
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert!(
+        still_watching,
+        "index --watch with configured-but-empty targets should keep watching, not exit/refuse"
+    );
+    assert!(!db.exists() || is_empty_db_absent(&db), "watch must not register an empty index");
+}
+
+/// #427 review: the git-hook `rag-rat maintenance` pass must NOT first-time-register an empty index
+/// either. It defers (creates no database, no error) until real content appears — the same policy
+/// as the watcher, so a post-commit/checkout hook on a misconfigured repo doesn't silently register
+/// an empty scope.
+#[test]
+fn maintenance_defers_a_first_time_empty_config() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let db = root.join("index.sqlite");
+    // No [target_bindings] → no discoverable files.
+    let toml = format!(
+        "[index]\nroot = \".\"\ndatabase = \"{}\"\n[llm.embedding]\nmodel = \"none\"\n",
+        db.to_slash_lossy()
+    );
+    let config_path = root.join("rag-rat.toml");
+    std::fs::write(&config_path, toml).unwrap();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+        .args(["--config", config_path.to_str().unwrap(), "maintenance"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "maintenance must not error on an empty config: {}",
+        stderr(&out)
+    );
+    assert!(!db.exists(), "maintenance must not register an empty first-time index");
+}
+
+/// #427 review: a target with an EMPTY directory list (`[target_bindings] rust = []`) leaves
+/// `config.targets` non-empty but `target_directories()` empty — the watcher would place no source
+/// watches and sit stuck. `index --watch` must refuse it at startup, same as a no-target config.
+#[test]
+fn index_watch_on_empty_target_dirs_errors() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let db = root.join("index.sqlite");
+    // A binding present but with no directories → non-empty targets, zero watchable dirs.
+    let toml = format!(
+        "[index]\nroot = \".\"\ndatabase = \"{}\"\n[llm.embedding]\nmodel = \
+         \"none\"\n[target_bindings]\nrust = []\n",
+        db.to_slash_lossy()
+    );
+    let config_path = root.join("rag-rat.toml");
+    std::fs::write(&config_path, toml).unwrap();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+        .args(["--config", config_path.to_str().unwrap(), "index", "--watch"])
+        .current_dir(root)
+        .env_remove("RAG_RAT_NO_WATCH")
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "empty target dirs should fail fast, not park");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("target_bindings"), "stderr should name target_bindings: {stderr}");
+    assert!(!db.exists() || is_empty_db_absent(&db), "must not register an empty index");
+}
+
+fn git_available() -> bool {
+    Command::new("git").arg("--version").output().is_ok_and(|o| o.status.success())
+}
+
+fn git_init_commit(dir: &Path) {
+    let git = |args: &[&str]| {
+        Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
+    };
+    git(&["init", "-q"]);
+    git(&["config", "user.email", "t@example.com"]);
+    git(&["config", "user.name", "t"]);
+    std::fs::write(dir.join("src/a.rs"), "fn a() {}\n").unwrap();
+    git(&["add", "-A"]);
+    git(&["commit", "-qm", "init"]);
+}
+
+fn shared_config(db: &Path) -> String {
+    format!(
+        "[index]\nroot = \".\"\ndatabase = \"{}\"\n[llm.embedding]\nmodel = \
+         \"none\"\n[target_bindings]\nrust = [\"src\"]\n",
+        db.to_slash_lossy()
+    )
+}
+
+fn run_index(config_path: &Path, cwd: &Path) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+        .args(["--config", config_path.to_str().unwrap(), "index"])
+        .current_dir(cwd)
+        .output()
+        .unwrap()
+}
+
+fn stderr(out: &std::process::Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+// The refuse path must not leave a registered repo behind. A never-created DB file, or a DB with
+// no `repos` rows, both satisfy "nothing registered".
+fn is_empty_db_absent(db: &std::path::Path) -> bool {
+    let Ok(conn) = rusqlite::Connection::open(db) else { return true };
+    let n: i64 = conn
+        .query_row("SELECT count(*) FROM repos WHERE repo_id <> '__unassigned__'", [], |r| r.get(0))
+        .unwrap_or(0);
+    n == 0
+}

--- a/crates/rag-rat-core/benches/shared/mod.rs
+++ b/crates/rag-rat-core/benches/shared/mod.rs
@@ -72,6 +72,8 @@ pub fn bench_config(subdir: &str) -> Config {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     }
 }
 

--- a/crates/rag-rat-core/src/config.rs
+++ b/crates/rag-rat-core/src/config.rs
@@ -36,6 +36,18 @@ pub struct Config {
     /// nor un-pin the repo's database. `rag-rat consolidate` keys its pinned-config refusal off
     /// this, so the refusal and `database` resolution can never disagree.
     pub database_key_pinned: bool,
+    /// When `Config::load` re-anchored `[index] root` from a LINKED worktree to the MAIN checkout
+    /// (so all worktrees share one base index), this holds the ORIGINAL linked-worktree root; else
+    /// `None`. The pre-anchor root is otherwise lost after `anchor_root_to_main_worktree`. Used by
+    /// the `index` command to warn that it is indexing the main checkout, not the named worktree
+    /// (#427). Not read from TOML — populated during load.
+    pub source_root_reanchored_from: Option<PathBuf>,
+    /// Opt in to registering an EMPTY index (zero discovered files). Default `false`: the core
+    /// registration path (`rebuild_with_progress`) refuses a first-time-empty registration with
+    /// [`crate::index::EmptyIndexRefused`], so no entry point silently creates one (#427). The CLI
+    /// `index --allow-empty` flag sets this `true`; every other caller (watcher, git-hook
+    /// `maintenance`, MCP, init) leaves it `false`. Not read from TOML — set per invocation.
+    pub allow_empty: bool,
 }
 
 /// Search-ranking knobs (`[search]`). Default OFF so the shipped fuse is byte-identical to today;
@@ -889,6 +901,19 @@ impl Config {
         let local_checkout =
             if local_config_dir.as_os_str().is_empty() { Path::new(".") } else { local_config_dir };
 
+        // Best-effort resolution of what the LOCAL checkout's own `[index] root` names, taken
+        // BEFORE the governing seam below picks a winner — used only to detect + report a re-anchor
+        // to the caller (#427), never to decide anything (the seam is the sole source of truth for
+        // governance). `None` on any parse/resolution failure; that is not a second error path,
+        // just a diagnostic that stays silent when it cannot be computed.
+        let local_root_named: Option<PathBuf> = local_parse.as_ref().ok().and_then(|local_raw| {
+            normalize_existing_dir(
+                &local_config_dir
+                    .join(local_raw.index.root.clone().unwrap_or_else(|| ".".to_string())),
+            )
+            .ok()
+        });
+
         // THE GOVERNING SEAM (see the doc comment). Linked-ness comes from git TOPOLOGY — the
         // checkout holding the config file vs the repo's designated main worktree
         // ([`linked_worktree_main_root`]) — and governance is UNCONDITIONAL on that predicate.
@@ -959,6 +984,13 @@ impl Config {
                     (local_raw, local_config_dir.to_path_buf(), anchored_root, local_root)
                 },
             };
+
+        // #427: `root` may have ended up different from what the LOCAL checkout's own `[index]
+        // root` names — either because a linked worktree's config was overridden wholesale by
+        // MAIN's (the common case, above), or because `anchor_root_to_main_worktree` rebased an
+        // exotic branch-only root (#218/#219). Either way, report the pre-anchor value so `index`
+        // can warn the operator they're indexing the main checkout, not the worktree they named.
+        let source_root_reanchored_from = local_root_named.filter(|named| *named != root);
 
         // The database path (A7 default flip): an explicit `database` key is honored as-is — the
         // deprecated per-repo deployment, that repo stays un-consolidated and never syncs. ABSENT,
@@ -1048,6 +1080,8 @@ impl Config {
             log,
             repo_id_override,
             database_key_pinned,
+            source_root_reanchored_from,
+            allow_empty: false,
         })
     }
 }
@@ -2955,6 +2989,75 @@ mod tests {
         assert_eq!(
             from_linked.repo_id_override, None,
             "main omits the override, so the anchored identity derives — the branch pin is ignored",
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// #427: a linked worktree's `[index] root` resolves to itself locally, but `Config::load`
+    /// re-anchors it to MAIN so every worktree of a repo shares one base index. The PRE-anchor
+    /// value (the worktree the operator actually named) would otherwise be lost after anchoring —
+    /// capture it so the `index` command can warn instead of silently indexing a different
+    /// checkout than the one named.
+    #[test]
+    fn load_records_the_pre_anchor_root_for_a_linked_worktree() {
+        let git = |dir: &Path, args: &[&str]| {
+            let out =
+                std::process::Command::new("git").arg("-C").arg(dir).args(args).output().unwrap();
+            assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        };
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let tmp = std::env::temp_dir().join(format!("ragrat-reanchor-{}-{id}", std::process::id()));
+        let main = tmp.join("main");
+        std::fs::create_dir_all(main.join("src")).unwrap();
+        std::fs::write(main.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        std::fs::write(
+            main.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n",
+        )
+        .unwrap();
+        git(&main, &["init", "-q"]);
+        git(&main, &["config", "user.email", "t@e"]);
+        git(&main, &["config", "user.name", "t"]);
+        git(&main, &["add", "-A"]);
+        git(&main, &["commit", "-qm", "seed"]);
+        let linked = tmp.join("wt");
+        git(&main, &["worktree", "add", "--detach", "-q", linked.to_str().unwrap()]);
+        std::fs::write(linked.join("rag-rat.toml"), "[index]\nroot = \".\"\n").unwrap();
+
+        let main_c = main.canonicalize().unwrap();
+        let linked_c = linked.canonicalize().unwrap();
+        let from_linked = Config::load(linked.join("rag-rat.toml")).unwrap();
+        assert_eq!(from_linked.root, main_c, "root anchors to main (existing behavior)");
+        assert_eq!(
+            from_linked.source_root_reanchored_from.as_deref(),
+            Some(linked_c.as_path()),
+            "the pre-anchor (named) linked-worktree root is captured",
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// The counterpart to the above: loading from a plain (non-worktree) repo redirects nothing,
+    /// so the field stays `None`.
+    #[test]
+    fn load_leaves_reanchor_none_for_the_main_worktree() {
+        let id = CFG_TEMP.fetch_add(1, Ordering::Relaxed);
+        let tmp =
+            std::env::temp_dir().join(format!("ragrat-reanchor-none-{}-{id}", std::process::id()));
+        std::fs::create_dir_all(tmp.join("src")).unwrap();
+        std::fs::write(tmp.join("src/lib.rs"), "pub fn a() {}\n").unwrap();
+        std::fs::write(
+            tmp.join("rag-rat.toml"),
+            "[index]\nroot = \".\"\n[target_bindings]\nrust = [\"src\"]\n",
+        )
+        .unwrap();
+        git_commit_all(&tmp);
+
+        let config = Config::load(tmp.join("rag-rat.toml")).unwrap();
+        assert!(
+            config.source_root_reanchored_from.is_none(),
+            "no worktree redirection happened, so the field stays None",
         );
 
         let _ = std::fs::remove_dir_all(&tmp);

--- a/crates/rag-rat-core/src/index/adoption_hints.rs
+++ b/crates/rag-rat-core/src/index/adoption_hints.rs
@@ -90,11 +90,9 @@ pub fn same_identity_join_note(config: &Config) -> anyhow::Result<Option<SameIde
         return Ok(None);
     }
     // This exact checkout was already INDEXED as this repo → an ordinary re-index, not a join.
-    // Keyed on the `source_root` marker (via the shared helper), NOT `repo_roots` membership: a
-    // read-only `open_config` (doctor / MCP) records the root WITHOUT indexing, and suppressing the
-    // warning on that mere recording would let the first real index from a fresh same-identity
-    // clone silently join the shared scope with none of the `[index] repo_id` guidance (#427
-    // review).
+    // Via the shared indexing-only helper: recording is indexing-only, so a read-only `open_config`
+    // (doctor / MCP) of a fresh same-identity clone does NOT suppress the warning — the first real
+    // index from that clone still gets the `[index] repo_id` guidance (#427 review).
     if repo_indexed_at_this_root(conn, &identity.repo_id, config)? {
         return Ok(None);
     }
@@ -111,17 +109,15 @@ pub fn same_identity_join_note(config: &Config) -> anyhow::Result<Option<SameIde
 /// the now-empty set (applies the deletion plan) instead of stranding the old rows live; only a
 /// brand-new checkout landing empty is the footgun worth refusing.
 ///
-/// Judged by the persisted `source_root` of the repo this config resolves to — NOT by a
-/// `repo_roots` recording. That distinction is load-bearing: a read-only `open_config` (a `doctor`
-/// / MCP / query open) also calls `adopt_repo_from_config`, which `register_repo`s the checkout and
-/// RECORDS its root, but it NEVER writes `repo_meta[source_root]` — only a real indexing pass
-/// (rebuild / incremental) does. Keying on the recorded root would therefore let a mere read
-/// masquerade as an indexed checkout: a `doctor` on a no-`[target_bindings]` repo (or on a
-/// same-identity CLONE) would record the root, flip this to `true`, and let a later empty
-/// `--discover` / `--full` prune the scope (#427 review). Keying on `source_root` closes that: only
-/// an indexing pass sets it, and a clone's resolved repo carries the PRIMARY's `source_root`
-/// (≠ the clone's root), so the clone correctly stays not-indexed. `Ok(false)` on a
-/// fresh / never-written / garbage / unreadable database.
+/// Judged by an INDEXING-ONLY signal — a `repo_roots` recording (git repos) or the persisted
+/// `source_root` (non-git fallback) — see [`repo_indexed_at_this_root`]. Both are written only by a
+/// real indexing pass, never by a read-only `open_config` (a `doctor` / MCP / query open now
+/// registers identity via `register_repo_read_only`, which records NO root), so a mere read can't
+/// make an un-indexed checkout — or a fresh same-identity CLONE — look indexed and let a later
+/// empty `--discover` / `--full` prune the shared scope (#427 review). The per-checkout
+/// `repo_roots` row (not the single-valued `source_root`) is also what keeps a same-identity
+/// SIBLING clone's index from stealing this checkout's recognition. `Ok(false)` on a fresh /
+/// never-written / garbage / unreadable database.
 pub fn is_root_already_indexed(config: &Config) -> anyhow::Result<bool> {
     let Some(storage) = open_ro_compatible(config) else {
         return Ok(false);
@@ -130,16 +126,28 @@ pub fn is_root_already_indexed(config: &Config) -> anyhow::Result<bool> {
 }
 
 /// The single "this checkout is `repo_id`'s already-INDEXED home" signal, shared by every #427
-/// consumer (the empty-index guard AND the same-identity-join warning): `repo_id`'s persisted
-/// `source_root` equals this checkout's root. `source_root` is written ONLY by an indexing pass
-/// (rebuild / incremental), never by a read-only `open_config` adoption — so this is immune to a
-/// `doctor` / MCP read having merely recorded the root. Keep both consumers on THIS helper so a fix
-/// (or a footgun) can never apply to one and not the other.
+/// consumer (the empty-index guard AND the same-identity-join warning). Keep both consumers on THIS
+/// helper so a fix (or a footgun) can never apply to one and not the other.
+///
+/// Two indexing-only signals, either of which proves an indexing pass ran at this exact checkout:
+/// 1. Its working-tree root is recorded in `repo_roots` for `repo_id`. Recording is now
+///    INDEXING-ONLY (`register_repo` records; the read-only `register_repo_read_only` does not), so
+///    a recorded root is trustworthy — immune BOTH to a read-only `open_config` merely registering
+///    (the earlier fix's concern) AND to a same-identity sibling clone stealing recognition: each
+///    checkout records its OWN `repo_roots` row, so B indexing the shared repo leaves A's row
+///    intact (whereas the single-valued `source_root` is last-writer-wins — B's index overwrote it
+///    to B, wrongly making A look un-indexed, #427 review).
+/// 2. `repo_id`'s persisted `source_root` equals this root — the FALLBACK for an identity-less
+///    (non-git / unborn) root, which never gets a `repo_roots` entry (`adopt_repo_from_config`
+///    sole-picks WITHOUT `register_repo`). Also written only by an indexing pass.
 fn repo_indexed_at_this_root(
     conn: &rusqlite::Connection,
     repo_id: &str,
     config: &Config,
 ) -> anyhow::Result<bool> {
+    if schema::repo_has_recorded_root(conn, repo_id, &config.root.to_string_lossy())? {
+        return Ok(true);
+    }
     Ok(super::repo_meta(conn, repo_id, "source_root")? == Some(config.root.display().to_string()))
 }
 
@@ -358,13 +366,13 @@ mod tests {
     }
 
     /// `is_root_already_indexed` is `false` before indexing (no DB / fresh) and `true` after a
-    /// rebuild has persisted this checkout's `source_root` — the signal that scopes the #427
-    /// empty-index refusal to FIRST-TIME registrations, so a later delete-to-empty is allowed to
-    /// prune rather than refused. It keys off the persisted `source_root`: a fresh clone sharing
-    /// A's identity resolves to A's repo, whose `source_root` is A's root (≠ the clone), so the
-    /// clone stays `false` and an empty clone can't prune A's shared scope.
+    /// rebuild has recorded this checkout — the signal that scopes the #427 empty-index refusal to
+    /// FIRST-TIME registrations, so a later delete-to-empty is allowed to prune rather than
+    /// refused. It keys off an INDEXING-ONLY signal (the recorded root / source_root), NOT the
+    /// shared identity: a fresh clone sharing A's identity is never indexed, so it stays
+    /// `false` and an empty clone can't prune A's shared scope.
     #[test]
-    fn is_root_already_indexed_tracks_the_source_root_not_the_shared_identity() {
+    fn is_root_already_indexed_tracks_indexing_not_the_shared_identity() {
         if std::process::Command::new("git").arg("--version").output().is_err() {
             return; // no git on PATH — skip rather than fail.
         }
@@ -430,15 +438,14 @@ mod tests {
         let _ = std::fs::remove_dir_all(root);
     }
 
-    /// #427 review (comment 4): a READ-ONLY open (`doctor` / MCP / query via `open_config`) also
-    /// adopts — it `register_repo`s the checkout and RECORDS its root — but it NEVER writes
-    /// `repo_meta[source_root]`. So a mere read must NOT flip `is_root_already_indexed` to `true`,
-    /// or a later empty `--discover` / `--full` on that no-target repo would be waved through as
-    /// "already indexed" and prune the scope. Recognition keys on `source_root` precisely to close
-    /// this: B is read-registered into A's shared DB but never indexed, so it stays
-    /// first-time-empty.
+    /// #427 review (comment 4): a READ-ONLY open (`doctor` / MCP / query via `open_config`) adopts
+    /// identity but must NOT record the checkout's root (it goes through `register_repo_read_only`)
+    /// nor write `repo_meta[source_root]` — both are indexing-only. So a mere read must NOT flip
+    /// `is_root_already_indexed` to `true`, or a later empty `--discover` / `--full` on that
+    /// no-target repo would be waved through as "already indexed" and prune the scope. B is
+    /// read-registered into A's shared DB but never indexed, so it stays first-time-empty.
     #[test]
-    fn a_read_registered_root_without_source_root_is_not_already_indexed() {
+    fn a_read_only_open_does_not_make_an_unindexed_repo_look_indexed() {
         if std::process::Command::new("git").arg("--version").output().is_err() {
             return; // identity resolution needs git; skip rather than fail.
         }
@@ -454,8 +461,8 @@ mod tests {
         crate::index::IndexDatabase::rebuild(&config_a).unwrap();
 
         // Repo B: a DISTINCT git repo (own init → own root commit → own identity), pointed at A's
-        // SAME database but with NO discoverable target files. A read-only `open_config` adopts it
-        // — registering B and recording its root — WITHOUT indexing anything.
+        // SAME database but with NO discoverable target files. A read-only `open_config` registers
+        // B's identity WITHOUT indexing anything and WITHOUT recording its root.
         let root_b = unique_temp_root();
         std::fs::create_dir_all(root_b.join("src")).unwrap();
         std::fs::write(root_b.join("keep.txt"), "not a rust file\n").unwrap();
@@ -467,8 +474,19 @@ mod tests {
 
         let _ = crate::index::IndexDatabase::open_config(&config_b).unwrap();
 
-        // B's root is now recorded, but no indexing pass ever ran for B, so its `source_root` is
-        // unset → it is NOT already-indexed, and a zero-file index on B is still first-time-empty.
+        // The read recorded NO root for B (register_repo_read_only) and ran no indexing pass, so B
+        // is NOT already-indexed and a zero-file index on B is still first-time-empty.
+        {
+            let conn = rusqlite::Connection::open(&config_b.database).unwrap();
+            let recorded: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM repo_roots WHERE root = ?1",
+                    [root_b.to_string_lossy()],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(recorded, 0, "a read-only open must not record the checkout's root");
+        }
         assert!(
             !is_root_already_indexed(&config_b).unwrap(),
             "a read-only open must not make an unindexed repo look already-indexed"
@@ -545,14 +563,13 @@ mod tests {
         let _ = std::fs::remove_dir_all(root);
     }
 
-    /// #427 review ("Warn even when a read open recorded the checkout"): a read-only `open_config`
-    /// (doctor / MCP) on a fresh same-identity clone records the clone's root under the shared repo
-    /// WITHOUT indexing it. The same-identity-join warning must STILL fire on the first real index
-    /// — suppressing it on a mere recording would let the clone silently switch the shared
-    /// scope with none of the `[index] repo_id` guidance. Keyed on `source_root`, not
-    /// `repo_roots` membership.
+    /// #427 review ("Warn even when a read open touched the checkout"): a read-only `open_config`
+    /// (doctor / MCP) on a fresh same-identity clone registers its identity but neither indexes it
+    /// nor records its root. The same-identity-join warning must STILL fire on the first real index
+    /// — suppressing it on a mere read would let the clone silently switch the shared scope with
+    /// none of the `[index] repo_id` guidance.
     #[test]
-    fn same_identity_join_warns_even_after_a_read_recorded_the_clone_root() {
+    fn same_identity_join_warns_even_after_a_read_only_open_of_the_clone() {
         if std::process::Command::new("git").arg("--version").output().is_err() {
             return;
         }
@@ -572,14 +589,63 @@ mod tests {
         let mut config_b = config_a.clone();
         config_b.root = root_b.clone();
 
-        // A read-only open records B's root under the shared id, but indexes nothing (no
-        // source_root).
+        // A read-only open registers B's identity but records no root and indexes nothing.
         let _ = crate::index::IndexDatabase::open_config(&config_b).unwrap();
 
         // The join warning must still fire — the read must not suppress it.
         let note = same_identity_join_note(&config_b).unwrap();
-        assert!(note.is_some(), "a read-recorded clone must still warn it joins the shared scope");
+        assert!(
+            note.is_some(),
+            "a read-only-opened clone must still warn it joins the shared scope"
+        );
         assert_eq!(note.unwrap().existing_root, root_a);
+
+        let _ = std::fs::remove_dir_all(root_a);
+        let _ = std::fs::remove_dir_all(root_b);
+    }
+
+    /// #427 review ("Preserve pruning for earlier same-identity checkouts"): when checkout A has
+    /// indexed the shared repo and a same-identity checkout B then indexes it too, B's pass does
+    /// NOT steal A's already-indexed status — each checkout records its OWN `repo_roots` row
+    /// (the single-valued `source_root` would be last-writer-wins, flipped to B). So A deleting
+    /// its last file and re-indexing to empty is still ALLOWED to prune, not refused as
+    /// first-time-empty.
+    #[test]
+    fn a_sibling_index_does_not_steal_an_earlier_checkouts_prune_right() {
+        if std::process::Command::new("git").arg("--version").output().is_err() {
+            return;
+        }
+        // A: committed git repo, indexed into a shared DB.
+        let root_a = unique_temp_root();
+        std::fs::create_dir_all(root_a.join("src")).unwrap();
+        std::fs::write(root_a.join("src/a.rs"), "fn a() {}\n").unwrap();
+        git(&root_a, &["init", "-q"]);
+        git(&root_a, &["add", "-A"]);
+        git(&root_a, &["commit", "-q", "-m", "init"]);
+        let config_a = source_config(root_a.clone(), Language::Rust);
+        crate::index::IndexDatabase::rebuild(&config_a).unwrap();
+        assert!(is_root_already_indexed(&config_a).unwrap(), "A is indexed after its rebuild");
+
+        // B: a same-identity clone of A, pointed at the SAME DB, INDEXED too (has its own file).
+        let root_b = PathBuf::from(format!("{}-clone", root_a.display()));
+        let _ = std::fs::remove_dir_all(&root_b);
+        git(&root_a, &["clone", "-q", ".", root_b.to_str().unwrap()]);
+        let mut config_b = config_a.clone();
+        config_b.root = root_b.clone();
+        crate::index::IndexDatabase::index_discover(&config_b).unwrap();
+
+        // B's index overwrote the shared `source_root` to B — but A's `repo_roots` row survives, so
+        // A is STILL recognized as already-indexed and its delete-to-empty prunes instead
+        // of refusing.
+        assert!(
+            is_root_already_indexed(&config_a).unwrap(),
+            "A must stay already-indexed after a sibling checkout indexes the shared repo"
+        );
+        std::fs::remove_file(root_a.join("src/a.rs")).unwrap();
+        assert!(
+            !is_first_time_empty(&config_a).unwrap(),
+            "A going empty must be allowed to prune, not refused as first-time-empty"
+        );
 
         let _ = std::fs::remove_dir_all(root_a);
         let _ = std::fs::remove_dir_all(root_b);

--- a/crates/rag-rat-core/src/index/adoption_hints.rs
+++ b/crates/rag-rat-core/src/index/adoption_hints.rs
@@ -1,0 +1,587 @@
+//! Pre-index, read-only hints the one-shot `index` command surfaces BEFORE it registers or
+//! indexes anything (issue #427): whether any file would be discovered, and whether the configured
+//! root is joining an already-registered repo's scope. Detection only — never mutates.
+
+use std::path::PathBuf;
+
+use super::schema;
+use crate::config::Config;
+use crate::repo_identity;
+use crate::storage::IndexConnection;
+
+/// `true` iff indexing `config` would walk at least one target file. `false` means the index would
+/// register the repo with EMPTY content — the exact zero-`[target_bindings]` footgun of #427. A
+/// one-shot walk is fine here: the `index` command that calls this is about to walk anyway.
+pub fn would_discover_any_file(config: &Config) -> anyhow::Result<bool> {
+    // Cheap short-circuit for the issue's headline case (no `[target_bindings]` → no targets):
+    // skip the filesystem walk entirely.
+    if config.targets.is_empty() {
+        return Ok(false);
+    }
+    Ok(!super::prep::collect_index_files(config)?.is_empty())
+}
+
+/// Open the index database read-only IFF it exists and its schema is READABLE (current or
+/// migrateable-forward); else `None`. Shared by the read-only pre-index hints so none of them abort
+/// `index()` on a fresh, never-written, garbage, or unreadable-schema database — SQLite defers
+/// header validation to the first page read, so a non-DB file opens fine and only faults on the
+/// `status` read, which is folded to `None` here.
+///
+/// An `Older` (migrateable-forward) schema is accepted ONLY once the repo-registry tables it reads
+/// exist. Accepting `Older` at all is deliberate: the `repos` / `repo_roots` / `repo_meta` rows the
+/// `source_root` probe reads are stable across recent migrations, so rejecting a merely-behind DB
+/// would misclassify an already-indexed repo on a pre-upgrade database as "never indexed" and
+/// wrongly REFUSE a delete-to-empty prune as a first-time-empty registration (#427 review). But the
+/// registry itself was ADDED in V038, and these read-only probes run BEFORE the normal write-open
+/// migration — so a database OLDER than V038 is `Older` yet has NO `repos` table. Returning a
+/// connection there would fault the probe with `no such table: repos` on `rag-rat index`/`--full`
+/// instead of letting the write path migrate + index (#427 review). Gate on the table existing:
+/// pre-registry `Older` DBs → `None` (treated as not-indexed / no join hint, exactly as before this
+/// widening; the write path then migrates them). `Newer` / `Dirty` / `Missing` / garbage → `None`.
+fn open_ro_compatible(config: &Config) -> Option<IndexConnection> {
+    if !config.database.exists() {
+        return None;
+    }
+    let storage = IndexConnection::open_read_only_blocking(&config.database).ok()?;
+    let readable = match schema::status(storage.connection()) {
+        Ok(status) => match status.state {
+            schema::SchemaState::Compatible => true,
+            // Pre-V038 databases lack the registry these probes read; fall through to migration.
+            schema::SchemaState::Older =>
+                schema::table_exists(storage.connection(), "repos").unwrap_or(false),
+            _ => false,
+        },
+        Err(_) => false,
+    };
+    readable.then_some(storage)
+}
+
+/// The configured root is a NEW physical checkout sharing an already-registered repo's identity —
+/// the same-identity clone / not-yet-anchored worktree of #427.
+#[derive(Debug, Clone)]
+pub struct SameIdentityJoin {
+    /// The registered repo whose scope this checkout would join.
+    pub repo_id: String,
+    /// A representative recorded root of that repo (its earliest-registered checkout).
+    pub existing_root: PathBuf,
+}
+
+/// `Some` when indexing `config` would fold its root into an ALREADY-REGISTERED repo's single scope
+/// because they share a portable identity, and this root is not yet one of that repo's recorded
+/// checkouts (#427). `None` — no warning — for a fresh DB, an incompatible schema, an
+/// identity-less root, an unregistered identity, or a re-index of a KNOWN checkout. Read-only:
+/// opens the DB `SQLITE_OPEN_READ_ONLY` and never writes. Returns `None` generously on any error
+/// resolving identity (a false join warning is worse than a missed one).
+pub fn same_identity_join_note(config: &Config) -> anyhow::Result<Option<SameIdentityJoin>> {
+    // Fresh / never-written / garbage / incompatible DB → there is no existing repo to join.
+    let Some(storage) = open_ro_compatible(config) else {
+        return Ok(None);
+    };
+    let conn = storage.connection();
+    let identity = match repo_identity::resolve_repo_identity(
+        &config.root,
+        config.repo_id_override.as_deref(),
+    ) {
+        Ok(identity) => identity,
+        Err(_) => return Ok(None), // absent / rejected identity → no join hint
+    };
+    // Only a repo that is ALREADY registered can be "joined". A brand-new identity is a fresh repo.
+    if !schema::repo_id_is_registered(conn, &identity.repo_id)? {
+        return Ok(None);
+    }
+    // This exact checkout was already INDEXED as this repo → an ordinary re-index, not a join.
+    // Keyed on the `source_root` marker (via the shared helper), NOT `repo_roots` membership: a
+    // read-only `open_config` (doctor / MCP) records the root WITHOUT indexing, and suppressing the
+    // warning on that mere recording would let the first real index from a fresh same-identity
+    // clone silently join the shared scope with none of the `[index] repo_id` guidance (#427
+    // review).
+    if repo_indexed_at_this_root(conn, &identity.repo_id, config)? {
+        return Ok(None);
+    }
+    let existing = schema::earliest_recorded_root(conn, &identity.repo_id)?;
+    Ok(existing.map(|existing_root| SameIdentityJoin {
+        repo_id: identity.repo_id,
+        existing_root: PathBuf::from(existing_root),
+    }))
+}
+
+/// Whether THIS checkout has actually been INDEXED before — the signal that scopes the zero-file
+/// refusal (#427) to FIRST-TIME empty registrations. An already-indexed root whose last file was
+/// just deleted or moved must still be allowed to index, so the incremental / discover pass records
+/// the now-empty set (applies the deletion plan) instead of stranding the old rows live; only a
+/// brand-new checkout landing empty is the footgun worth refusing.
+///
+/// Judged by the persisted `source_root` of the repo this config resolves to — NOT by a
+/// `repo_roots` recording. That distinction is load-bearing: a read-only `open_config` (a `doctor`
+/// / MCP / query open) also calls `adopt_repo_from_config`, which `register_repo`s the checkout and
+/// RECORDS its root, but it NEVER writes `repo_meta[source_root]` — only a real indexing pass
+/// (rebuild / incremental) does. Keying on the recorded root would therefore let a mere read
+/// masquerade as an indexed checkout: a `doctor` on a no-`[target_bindings]` repo (or on a
+/// same-identity CLONE) would record the root, flip this to `true`, and let a later empty
+/// `--discover` / `--full` prune the scope (#427 review). Keying on `source_root` closes that: only
+/// an indexing pass sets it, and a clone's resolved repo carries the PRIMARY's `source_root`
+/// (≠ the clone's root), so the clone correctly stays not-indexed. `Ok(false)` on a
+/// fresh / never-written / garbage / unreadable database.
+pub fn is_root_already_indexed(config: &Config) -> anyhow::Result<bool> {
+    let Some(storage) = open_ro_compatible(config) else {
+        return Ok(false);
+    };
+    is_root_already_indexed_conn(storage.connection(), config)
+}
+
+/// The single "this checkout is `repo_id`'s already-INDEXED home" signal, shared by every #427
+/// consumer (the empty-index guard AND the same-identity-join warning): `repo_id`'s persisted
+/// `source_root` equals this checkout's root. `source_root` is written ONLY by an indexing pass
+/// (rebuild / incremental), never by a read-only `open_config` adoption — so this is immune to a
+/// `doctor` / MCP read having merely recorded the root. Keep both consumers on THIS helper so a fix
+/// (or a footgun) can never apply to one and not the other.
+fn repo_indexed_at_this_root(
+    conn: &rusqlite::Connection,
+    repo_id: &str,
+    config: &Config,
+) -> anyhow::Result<bool> {
+    Ok(super::repo_meta(conn, repo_id, "source_root")? == Some(config.root.display().to_string()))
+}
+
+/// [`is_root_already_indexed`] against an ALREADY-OPEN connection — used by the indexing paths that
+/// hold a migrated read/write connection and must judge "already indexed" BEFORE they adopt (which
+/// would record this root and defeat a post-adoption check). See that function for the
+/// `source_root` rationale.
+pub fn is_root_already_indexed_conn(
+    conn: &rusqlite::Connection,
+    config: &Config,
+) -> anyhow::Result<bool> {
+    // Primary: the repo this config resolves to (a registered identity, or the recorded-root / sole
+    // fallback for an identity-less root) was last indexed at THIS root.
+    if let Some(repo_id) =
+        schema::resolve_config_repo_id(conn, &config.root, config.repo_id_override.as_deref())?
+    {
+        return repo_indexed_at_this_root(conn, &repo_id, config);
+    }
+    // Fallback: the config's derived git identity is not registered yet, but a LEGACY index still
+    // living under the `__unassigned__` placeholder (a pre-adoption DB that predates open-time
+    // adoption) is single-repo and carries its `source_root` under that placeholder. Recognize it
+    // via the SOLE repo so a legacy index whose files were all deleted PRUNES on the first upgrade
+    // run instead of being refused as first-time-empty (the adoption that re-points the placeholder
+    // runs right after this check, in `adopt_repo_from_config`). Guarded to a single-repo DB: a
+    // multi-repo store has no sole placeholder, and matching on `source_root` means this can only
+    // ever be TRUE for THIS root's own prior index — never a sibling's or the primary's.
+    if !schema::multiple_real_repos(conn)?
+        && let Ok(sole) = schema::sole_repo_id(conn)
+    {
+        return repo_indexed_at_this_root(conn, &sole, config);
+    }
+    Ok(false)
+}
+
+/// Whether indexing `config` would FIRST-TIME-register an EMPTY repo — this checkout was not
+/// indexed before AND no target files would be discovered. The #427 condition the two INDEXING
+/// entry points check before they adopt: the one-shot `index` command turns it into an error
+/// (unless `--allow-empty`), and the background paths (watcher, git-hook `maintenance`) DEFER on it
+/// (skip, waiting for content) so `rag-rat mcp` / a hook on a misconfigured repo never silently
+/// registers an empty index. The cheap already-indexed lookup runs first (via `&&` short-circuit),
+/// so an established repo never pays the discovery walk. Read-only.
+pub fn is_first_time_empty(config: &Config) -> anyhow::Result<bool> {
+    Ok(!is_root_already_indexed(config)? && !would_discover_any_file(config)?)
+}
+
+/// [`is_first_time_empty`] against an ALREADY-OPEN connection (the incremental path's migrated
+/// bare-open connection), checked BEFORE `adopt_repo_from_config` records the root.
+pub fn is_first_time_empty_conn(
+    conn: &rusqlite::Connection,
+    config: &Config,
+) -> anyhow::Result<bool> {
+    Ok(!is_root_already_indexed_conn(conn, config)? && !would_discover_any_file(config)?)
+}
+
+/// The core registration path (`rebuild_with_progress`) refused to FIRST-TIME-register an EMPTY
+/// index (#427). This is the SINGLE enforcement of the empty-index invariant; callers react to it:
+/// the one-shot `index` command surfaces it to the operator, while the background paths (watcher,
+/// git-hook `maintenance`) discard it and wait for content. `--allow-empty` (→
+/// `Config::allow_empty`) opts in, and this is then never produced.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "0 files discovered under {root} — no `[target_bindings]` configured (or none match).\nAdd a \
+     section like:\n\n    [target_bindings]\n    rust = [\"src\"]\n\nto rag-rat.toml, or pass \
+     `--allow-empty` to index nothing."
+)]
+pub struct EmptyIndexRefused {
+    pub root: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::config::{Config, ResolvedTarget, TargetKind};
+    use crate::language::Language;
+
+    // `schema_bootstrap_tests::source_config` / `unique_temp_root` are private to that module and
+    // not reachable from here (a sibling of `index`, not a descendant of `schema_bootstrap_tests`)
+    // — build the fixtures inline instead of widening their visibility just for this test.
+    fn unique_temp_root() -> PathBuf {
+        let mut root = std::env::temp_dir();
+        root.push(format!(
+            "rag-rat-adoption-hints-test-{}-{}",
+            std::process::id(),
+            crate::index::now_ms()
+        ));
+        root
+    }
+
+    fn source_config(root: PathBuf, language: Language) -> Config {
+        Config {
+            repo_id_override: None,
+            database_key_pinned: true,
+            root: root.clone(),
+            database: root.join(".rag-rat/index.sqlite"),
+            targets: vec![ResolvedTarget {
+                name: language.as_str().to_string(),
+                language,
+                directories: vec![PathBuf::from("src")],
+                include: vec!["src/".to_string()],
+                exclude: Vec::new(),
+                kind: TargetKind::Source,
+            }],
+            llm: Default::default(),
+            watch: Default::default(),
+            version_check: Default::default(),
+            oracle: Default::default(),
+            search: Default::default(),
+            memory: Default::default(),
+            log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
+        }
+    }
+
+    #[test]
+    fn would_discover_any_file_is_false_when_targets_are_empty() {
+        let root = unique_temp_root();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/a.rs"), "fn a() {}\n").unwrap();
+        let mut config = source_config(root.clone(), Language::Rust);
+        config.targets.clear(); // no [target_bindings] → nothing to walk
+        assert!(!would_discover_any_file(&config).unwrap());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn would_discover_any_file_is_true_when_a_target_matches() {
+        let root = unique_temp_root();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/a.rs"), "fn a() {}\n").unwrap();
+        let config = source_config(root.clone(), Language::Rust);
+        assert!(would_discover_any_file(&config).unwrap());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    // Run a git command in `root`, panicking on failure — models
+    // `query_api::oracle_surfacing_tests::git`, private to that module and not reachable here.
+    fn git(root: &std::path::Path, args: &[&str]) {
+        let status = std::process::Command::new("git")
+            .args(args)
+            .current_dir(root)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .unwrap();
+        assert!(status.success(), "git {args:?} failed");
+    }
+
+    /// A clone sharing a checkout's portable (root-commit-derived) identity, pointed at the SAME
+    /// database (the consolidated-DB shape the #427 join hint targets), fires the note naming the
+    /// original checkout; the original checkout re-indexing itself, and a config whose DB doesn't
+    /// exist yet, both stay quiet.
+    #[test]
+    fn same_identity_join_note_fires_for_a_second_checkout_and_not_the_first() {
+        if std::process::Command::new("git").arg("--version").output().is_err() {
+            return; // no git on PATH — skip rather than fail.
+        }
+        let root_a = unique_temp_root();
+        std::fs::create_dir_all(root_a.join("src")).unwrap();
+        std::fs::write(root_a.join("src/a.rs"), "fn a() {}\n").unwrap();
+        git(&root_a, &["init", "-q"]);
+        git(&root_a, &["add", "-A"]);
+        git(&root_a, &["commit", "-q", "-m", "init"]);
+        let config_a = source_config(root_a.clone(), Language::Rust);
+
+        // No DB yet at all — nothing to join.
+        assert!(same_identity_join_note(&config_a).unwrap().is_none());
+
+        crate::index::IndexDatabase::rebuild(&config_a).unwrap(); // registers A at root_a
+
+        // A's own recorded checkout re-indexing itself is an ordinary re-index, not a join.
+        assert!(same_identity_join_note(&config_a).unwrap().is_none());
+
+        // A full clone of A shares its portable (root-commit) identity but is a NEW checkout,
+        // pointed at A's SAME database (config_b keeps config_a's `database`, only the `root`
+        // moves) — the consolidated-DB shape the hint exists for.
+        let root_b = PathBuf::from(format!("{}-clone", root_a.display()));
+        let _ = std::fs::remove_dir_all(&root_b);
+        git(&root_a, &["clone", "-q", ".", root_b.to_str().unwrap()]);
+        let mut config_b = config_a.clone();
+        config_b.root = root_b.clone();
+
+        let expected_repo_id =
+            crate::repo_identity::resolve_repo_identity(&root_a, None).unwrap().repo_id;
+        let note = same_identity_join_note(&config_b).unwrap().unwrap();
+        assert_eq!(note.repo_id, expected_repo_id);
+        assert_eq!(note.existing_root, root_a);
+
+        let _ = std::fs::remove_dir_all(&root_a);
+        let _ = std::fs::remove_dir_all(&root_b);
+    }
+
+    /// A garbage/non-DB file at `config.database` must yield `Ok(None)` (no hint), NEVER `Err`:
+    /// SQLite defers header validation to the first page read, so `open_read_only_blocking`
+    /// succeeds on junk content and `schema::status` is the first read to fault. A propagated error
+    /// here would abort `index()` (the CLI calls `same_identity_join_note(config)?`) — a new
+    /// failure mode the generous-`None` contract exists to prevent.
+    #[test]
+    fn same_identity_join_note_is_none_on_a_garbage_db_file() {
+        let root = unique_temp_root();
+        let config = source_config(root.clone(), Language::Rust);
+        std::fs::create_dir_all(config.database.parent().unwrap()).unwrap();
+        std::fs::write(&config.database, b"not a sqlite database at all\x00\xff").unwrap();
+        assert!(config.database.exists());
+
+        let result = same_identity_join_note(&config);
+        assert!(result.is_ok(), "a garbage DB must not abort the index: {result:?}");
+        assert!(result.unwrap().is_none(), "a garbage DB yields no join hint");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// `is_root_already_indexed` is `false` before indexing (no DB / fresh) and `true` after a
+    /// rebuild has persisted this checkout's `source_root` — the signal that scopes the #427
+    /// empty-index refusal to FIRST-TIME registrations, so a later delete-to-empty is allowed to
+    /// prune rather than refused. It keys off the persisted `source_root`: a fresh clone sharing
+    /// A's identity resolves to A's repo, whose `source_root` is A's root (≠ the clone), so the
+    /// clone stays `false` and an empty clone can't prune A's shared scope.
+    #[test]
+    fn is_root_already_indexed_tracks_the_source_root_not_the_shared_identity() {
+        if std::process::Command::new("git").arg("--version").output().is_err() {
+            return; // no git on PATH — skip rather than fail.
+        }
+        let root_a = unique_temp_root();
+        std::fs::create_dir_all(root_a.join("src")).unwrap();
+        std::fs::write(root_a.join("src/a.rs"), "fn a() {}\n").unwrap();
+        git(&root_a, &["init", "-q"]);
+        git(&root_a, &["add", "-A"]);
+        git(&root_a, &["commit", "-q", "-m", "init"]);
+        let config_a = source_config(root_a.clone(), Language::Rust);
+
+        // No database yet → not indexed.
+        assert!(!is_root_already_indexed(&config_a).unwrap());
+
+        crate::index::IndexDatabase::rebuild(&config_a).unwrap();
+
+        // A's recorded root → indexed (so a delete-to-empty on A would be allowed to prune).
+        assert!(is_root_already_indexed(&config_a).unwrap());
+
+        // A full clone of A shares A's portable identity but its root is NOT recorded — it must NOT
+        // count as already-indexed, or an empty clone could prune A's shared scope (#427 review).
+        let root_b = PathBuf::from(format!("{}-clone", root_a.display()));
+        let _ = std::fs::remove_dir_all(&root_b);
+        git(&root_a, &["clone", "-q", ".", root_b.to_str().unwrap()]);
+        let mut config_b = config_a.clone();
+        config_b.root = root_b.clone();
+        assert!(
+            !is_root_already_indexed(&config_b).unwrap(),
+            "a same-identity clone with an unrecorded root is NOT already-indexed"
+        );
+
+        let _ = std::fs::remove_dir_all(root_a);
+        let _ = std::fs::remove_dir_all(root_b);
+    }
+
+    /// An identity-less (NON-git) root gets NO `repo_roots` entry — `adopt_repo_from_config` falls
+    /// back to the sole placeholder repo without recording the root — yet after indexing its repo's
+    /// persisted `source_root` equals the root, so it must still count as already-indexed (#427
+    /// review). Otherwise a delete-to-empty on a non-git project would be wrongly refused as
+    /// first-time instead of pruning its stale rows.
+    #[test]
+    fn is_root_already_indexed_recognizes_an_indexed_non_git_root() {
+        let root = unique_temp_root();
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/a.rs"), "fn a() {}\n").unwrap();
+        let config = source_config(root.clone(), Language::Rust); // NOT a git repo
+
+        // Fresh: not indexed.
+        assert!(!is_root_already_indexed(&config).unwrap());
+
+        crate::index::IndexDatabase::rebuild(&config).unwrap();
+
+        // Indexed: recognized via the persisted source_root, despite no repo_roots entry.
+        assert!(
+            is_root_already_indexed(&config).unwrap(),
+            "an indexed non-git root is recognized via its persisted source_root"
+        );
+        // And so a now-empty re-index is NOT treated as first-time (it would prune, not refuse).
+        std::fs::remove_file(root.join("src/a.rs")).unwrap();
+        assert!(!is_first_time_empty(&config).unwrap());
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// #427 review (comment 4): a READ-ONLY open (`doctor` / MCP / query via `open_config`) also
+    /// adopts — it `register_repo`s the checkout and RECORDS its root — but it NEVER writes
+    /// `repo_meta[source_root]`. So a mere read must NOT flip `is_root_already_indexed` to `true`,
+    /// or a later empty `--discover` / `--full` on that no-target repo would be waved through as
+    /// "already indexed" and prune the scope. Recognition keys on `source_root` precisely to close
+    /// this: B is read-registered into A's shared DB but never indexed, so it stays
+    /// first-time-empty.
+    #[test]
+    fn a_read_registered_root_without_source_root_is_not_already_indexed() {
+        if std::process::Command::new("git").arg("--version").output().is_err() {
+            return; // identity resolution needs git; skip rather than fail.
+        }
+        // Repo A: a committed git repo, actually indexed into a shared DB (persists A's
+        // source_root).
+        let root_a = unique_temp_root();
+        std::fs::create_dir_all(root_a.join("src")).unwrap();
+        std::fs::write(root_a.join("src/a.rs"), "fn a() {}\n").unwrap();
+        git(&root_a, &["init", "-q"]);
+        git(&root_a, &["add", "-A"]);
+        git(&root_a, &["commit", "-q", "-m", "init"]);
+        let config_a = source_config(root_a.clone(), Language::Rust);
+        crate::index::IndexDatabase::rebuild(&config_a).unwrap();
+
+        // Repo B: a DISTINCT git repo (own init → own root commit → own identity), pointed at A's
+        // SAME database but with NO discoverable target files. A read-only `open_config` adopts it
+        // — registering B and recording its root — WITHOUT indexing anything.
+        let root_b = unique_temp_root();
+        std::fs::create_dir_all(root_b.join("src")).unwrap();
+        std::fs::write(root_b.join("keep.txt"), "not a rust file\n").unwrap();
+        git(&root_b, &["init", "-q"]);
+        git(&root_b, &["add", "-A"]);
+        git(&root_b, &["commit", "-q", "-m", "init"]);
+        let mut config_b = source_config(root_b.clone(), Language::Rust);
+        config_b.database = config_a.database.clone(); // shared DB
+
+        let _ = crate::index::IndexDatabase::open_config(&config_b).unwrap();
+
+        // B's root is now recorded, but no indexing pass ever ran for B, so its `source_root` is
+        // unset → it is NOT already-indexed, and a zero-file index on B is still first-time-empty.
+        assert!(
+            !is_root_already_indexed(&config_b).unwrap(),
+            "a read-only open must not make an unindexed repo look already-indexed"
+        );
+        assert!(is_first_time_empty(&config_b).unwrap());
+
+        let _ = std::fs::remove_dir_all(root_a);
+        let _ = std::fs::remove_dir_all(root_b);
+    }
+
+    /// #427 review ("Gate Older schemas on registry availability"): a LEGACY index predating the
+    /// V038 repo-registry is `Older` but has NO `repos` / `repo_meta` tables. The read-only
+    /// pre-index probes run BEFORE the write-open migration, so on such a DB they must NOT fault
+    /// with `no such table: repos` (which would break `rag-rat index` / `--full` on an upgrade) —
+    /// they treat it as not-yet-indexed / no-join and let the write path migrate it. `Ok`, not
+    /// `Err`.
+    #[test]
+    fn a_pre_registry_legacy_schema_does_not_fault_the_readonly_probes() {
+        let root = unique_temp_root();
+        let config = source_config(root.clone(), Language::Rust);
+        std::fs::create_dir_all(config.database.parent().unwrap()).unwrap();
+        // A legacy index: a `files` table makes `schema::status` report `Older` (not `Missing`),
+        // but there is no repo registry — exactly a pre-V038 database.
+        {
+            let conn = rusqlite::Connection::open(&config.database).unwrap();
+            conn.execute_batch("CREATE TABLE files(path TEXT PRIMARY KEY);").unwrap();
+        }
+        // Both probes must SUCCEED with a benign answer, never propagate `no such table: repos`.
+        let indexed = is_root_already_indexed(&config);
+        assert!(indexed.is_ok(), "a pre-registry DB must not fault the probe: {indexed:?}");
+        assert!(!indexed.unwrap(), "a pre-registry DB is not already-indexed");
+        let join = same_identity_join_note(&config);
+        assert!(join.is_ok(), "a pre-registry DB must not fault the join hint: {join:?}");
+        assert!(join.unwrap().is_none());
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// #427 review ("Recognize legacy placeholder indexes before refusing empties"): a LEGACY index
+    /// still living under the `__unassigned__` placeholder (a pre-adoption DB — simulated here by
+    /// indexing the root while it was NON-git, then giving it a git identity the DB has not
+    /// adopted) must count as already-indexed via the SOLE placeholder's `source_root`.
+    /// Otherwise a delete-to-empty on it is refused as first-time instead of pruning on the
+    /// first upgrade run.
+    #[test]
+    fn is_root_already_indexed_recognizes_a_legacy_placeholder_index() {
+        if std::process::Command::new("git").arg("--version").output().is_err() {
+            return; // needs git for the (unregistered) identity; skip rather than fail.
+        }
+        let root = unique_temp_root();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/a.rs"), "fn a() {}\n").unwrap();
+        let config = source_config(root.clone(), Language::Rust);
+
+        // Index while NON-git: `adopt_repo_from_config` sees an ABSENT identity and adopts the sole
+        // `__unassigned__` placeholder, persisting `source_root` under it — a pre-adoption-style
+        // DB.
+        crate::index::IndexDatabase::rebuild(&config).unwrap();
+
+        // Now give the root a git identity the DB has NOT adopted (still under the placeholder), so
+        // `resolve_config_repo_id` returns None and only the sole-repo fallback can recognize it.
+        git(&root, &["init", "-q"]);
+        git(&root, &["add", "-A"]);
+        git(&root, &["commit", "-q", "-m", "init"]);
+
+        assert!(
+            is_root_already_indexed(&config).unwrap(),
+            "a legacy placeholder index must be recognized via the sole repo's source_root"
+        );
+        // So a delete-to-empty prunes rather than being refused as first-time-empty.
+        std::fs::remove_file(root.join("src/a.rs")).unwrap();
+        assert!(!is_first_time_empty(&config).unwrap());
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    /// #427 review ("Warn even when a read open recorded the checkout"): a read-only `open_config`
+    /// (doctor / MCP) on a fresh same-identity clone records the clone's root under the shared repo
+    /// WITHOUT indexing it. The same-identity-join warning must STILL fire on the first real index
+    /// — suppressing it on a mere recording would let the clone silently switch the shared
+    /// scope with none of the `[index] repo_id` guidance. Keyed on `source_root`, not
+    /// `repo_roots` membership.
+    #[test]
+    fn same_identity_join_warns_even_after_a_read_recorded_the_clone_root() {
+        if std::process::Command::new("git").arg("--version").output().is_err() {
+            return;
+        }
+        let root_a = unique_temp_root();
+        std::fs::create_dir_all(root_a.join("src")).unwrap();
+        std::fs::write(root_a.join("src/a.rs"), "fn a() {}\n").unwrap();
+        git(&root_a, &["init", "-q"]);
+        git(&root_a, &["add", "-A"]);
+        git(&root_a, &["commit", "-q", "-m", "init"]);
+        let config_a = source_config(root_a.clone(), Language::Rust);
+        crate::index::IndexDatabase::rebuild(&config_a).unwrap(); // registers A into the shared DB
+
+        // Clone B shares A's identity, pointed at A's SAME database.
+        let root_b = PathBuf::from(format!("{}-clone", root_a.display()));
+        let _ = std::fs::remove_dir_all(&root_b);
+        git(&root_a, &["clone", "-q", ".", root_b.to_str().unwrap()]);
+        let mut config_b = config_a.clone();
+        config_b.root = root_b.clone();
+
+        // A read-only open records B's root under the shared id, but indexes nothing (no
+        // source_root).
+        let _ = crate::index::IndexDatabase::open_config(&config_b).unwrap();
+
+        // The join warning must still fire — the read must not suppress it.
+        let note = same_identity_join_note(&config_b).unwrap();
+        assert!(note.is_some(), "a read-recorded clone must still warn it joins the shared scope");
+        assert_eq!(note.unwrap().existing_root, root_a);
+
+        let _ = std::fs::remove_dir_all(root_a);
+        let _ = std::fs::remove_dir_all(root_b);
+    }
+}

--- a/crates/rag-rat-core/src/index/consolidate.rs
+++ b/crates/rag-rat-core/src/index/consolidate.rs
@@ -246,6 +246,8 @@ pub fn run(config: &Config) -> anyhow::Result<ConsolidateOutcome> {
 
     // Register (or adopt/extend) this repo in the global DB. The returned id is what every imported
     // row is stamped with — the legacy DB's own `repo_id` (placeholder or otherwise) is discarded.
+    // Consolidation IMPORTS an indexed repo, so `register_repo` records the working-tree root
+    // (#427).
     let repo_id = schema::register_repo(target_conn, &identity, &config.root, schema::now_ms())?;
 
     // Bring the SOURCE to current schema too (read-write, under the source-side locks held above,

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -56,6 +56,26 @@ impl IndexDatabase {
         // correct repo — the exact sequence `open_config` uses.
         let mut db =
             Self::open_bare(&config.database, super::lifecycle::BareOpenMode::AdoptionPending)?;
+        // #427 — enforce the empty-index invariant HERE, BEFORE `adopt_repo_from_config` records
+        // this checkout's root. Enforcing after adoption would defeat the check: adoption registers
+        // the repo + records the root, so a post-adoption "was this already indexed?" test would
+        // see the just-recorded root and wave an empty first-time registration through (the
+        // exact seam the earlier rebuild-only guard missed on the incremental/discover
+        // path). `open_bare` already migrated the schema, so this reads current
+        // `source_root` on the live connection: an ESTABLISHED repo whose files were just
+        // deleted still counts as indexed (its persisted `source_root` matches) and is
+        // allowed through to prune, while a genuinely first-time-empty checkout is refused
+        // before anything is registered. Callers react to the error: the watcher / git-hook
+        // `maintenance` `let _ =`-discard it and wait for content; the one-shot
+        // `index` surfaces it. `--allow-empty` (`config.allow_empty`) opts in.
+        if !config.allow_empty
+            && crate::index::is_first_time_empty_conn(db.storage.connection(), config)?
+        {
+            return Err(crate::index::EmptyIndexRefused {
+                root: config.root.display().to_string(),
+            }
+            .into());
+        }
         // Register/adopt the config's repo BEFORE `set_context` stamps `active_repo_id` into the
         // scope view (A3). `Self::open` scoped to the SOLE repo via the config-blind fallback; on a
         // consolidated DB that would pick the lexicographically-first repo, so this incremental

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -82,8 +82,9 @@ impl IndexDatabase {
         // pass could delete/stamp rows under the WRONG repo. Adopting here — the same step
         // `open_config` and `rebuild` run — resolves the config's own identity and points
         // every repo-scoped write below at it. Idempotent on an already-adopted single-repo
-        // DB (the common case).
-        db.adopt_repo_from_config(config)?;
+        // DB (the common case). INDEXING intent: an incremental/discover pass records this
+        // checkout's root (#427).
+        db.adopt_repo_from_config(config, super::lifecycle::AdoptIntent::Indexing)?;
         let (commit_sha, worktree_id) = resolve_git_context(&config.root);
         db.set_context(&commit_sha, &worktree_id)?;
         // ADOPTION RESETS ALL CONNECTION-CARRIED REPO-DERIVED STATE BEFORE ANY DEFERRED HEAL (the

--- a/crates/rag-rat-core/src/index/lifecycle.rs
+++ b/crates/rag-rat-core/src/index/lifecycle.rs
@@ -20,6 +20,20 @@ pub(super) enum BareOpenMode {
     AdoptionPending,
 }
 
+/// Why a config-bearing open is adopting its repo — decides whether the checkout's working-tree
+/// root is RECORDED in `repo_roots` (#427). A recorded root is the "this checkout was INDEXED here"
+/// signal `is_root_already_indexed` / `same_identity_join_note` key on, so only an indexing pass
+/// may create one. A read-only open registers identity (needed to scope its reads) but must NOT
+/// record the root: otherwise a `doctor` / MCP read of a fresh same-identity clone would make it
+/// look indexed and let a later empty index prune the shared scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum AdoptIntent {
+    /// A rebuild / incremental / discover pass that indexes content — records the root.
+    Indexing,
+    /// A read-only `open_config` (doctor / MCP / query) — registers identity, records NO root.
+    ReadOnly,
+}
+
 impl IndexDatabase {
     pub fn open(path: &Path) -> anyhow::Result<Self> {
         Self::open_bare(path, BareOpenMode::ConfigLess)
@@ -152,8 +166,10 @@ impl IndexDatabase {
         // Register/adopt BEFORE anything repo-scoped runs, then install the scope context so the
         // model-manifest heal + seed below resolve the correct repo (in a consolidated DB the sole-
         // repo fallback would be ambiguous — the ordering, not the fallback, is load-bearing
-        // there).
-        db.adopt_repo_from_config(config)?;
+        // there). READ-ONLY intent: `open_config` backs doctor / MCP / query reads, so it registers
+        // identity but records NO working-tree root (#427) — a read must not mark this checkout
+        // "indexed here".
+        db.adopt_repo_from_config(config, AdoptIntent::ReadOnly)?;
         let (commit_sha, worktree_id) = resolve_git_context(&config.root);
         db.set_context(&commit_sha, &worktree_id)?;
         ai::ensure_model_manifest(db.storage.connection())?;
@@ -182,13 +198,30 @@ impl IndexDatabase {
     ///
     /// A genuine registration refusal (a different repo already owns a consolidated DB) also
     /// propagates, via `register_repo` itself.
-    pub(super) fn adopt_repo_from_config(&mut self, config: &Config) -> anyhow::Result<()> {
+    pub(super) fn adopt_repo_from_config(
+        &mut self,
+        config: &Config,
+        intent: AdoptIntent,
+    ) -> anyhow::Result<()> {
         let conn = self.storage.connection();
         let repo_id = match crate::repo_identity::resolve_repo_identity(
             &config.root,
             config.repo_id_override.as_deref(),
         ) {
-            Ok(identity) => schema::register_repo(conn, &identity, &config.root, schema::now_ms())?,
+            // #427: an INDEXING adoption records this checkout's working-tree root in `repo_roots`
+            // (the "this checkout was indexed here" signal); a READ-ONLY adoption (`open_config`
+            // from doctor / MCP / query) registers identity but does NOT record the root, so a mere
+            // read can't make an unindexed checkout look indexed (which would let a later empty
+            // index prune the shared scope).
+            Ok(identity) => {
+                let now = schema::now_ms();
+                match intent {
+                    AdoptIntent::Indexing =>
+                        schema::register_repo(conn, &identity, &config.root, now)?,
+                    AdoptIntent::ReadOnly =>
+                        schema::register_repo_read_only(conn, &identity, &config.root, now)?,
+                }
+            },
             Err(err) if err.is_absent() => {
                 // STRUCTURAL BACKSTOP (Codex batch 8, finding 5): an identity-less root may
                 // sole-pick only on a SINGLE-repo database. On a multi-repo store (an explicit

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -13,6 +13,7 @@ pub mod walker;
 
 pub mod consolidate;
 
+mod adoption_hints;
 pub(crate) mod chunk_text_store;
 pub(crate) mod clones;
 mod discovery;
@@ -37,6 +38,11 @@ mod staleness;
 pub(crate) mod text_compression;
 mod util;
 mod worktree_overlay;
+pub use adoption_hints::{
+    EmptyIndexRefused, SameIdentityJoin, is_first_time_empty, is_first_time_empty_conn,
+    is_root_already_indexed, is_root_already_indexed_conn, same_identity_join_note,
+    would_discover_any_file,
+};
 pub use discovery::DiscoveryStatus;
 pub(crate) use discovery::*;
 pub use git_context::resolve_git_context;

--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -701,6 +701,8 @@ mod tests {
             search: Default::default(),
             memory: Default::default(),
             log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
         };
         crate::IndexDatabase::rebuild(&config).unwrap()
     }
@@ -814,6 +816,8 @@ mod tests {
             search: Default::default(),
             memory: Default::default(),
             log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
         };
         let db = crate::IndexDatabase::rebuild(&config).unwrap();
 
@@ -881,6 +885,8 @@ mod tests {
             search: Default::default(),
             memory: Default::default(),
             log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
         };
         let db = crate::IndexDatabase::rebuild(&config).unwrap();
 
@@ -975,6 +981,8 @@ mod tests {
             search: Default::default(),
             memory: Default::default(),
             log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
         };
         let db = crate::IndexDatabase::rebuild(&config).unwrap();
         assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -876,6 +876,8 @@ mod tests {
             search: Default::default(),
             memory: Default::default(),
             log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
         }
     }
 

--- a/crates/rag-rat-core/src/index/query_api/clones/tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/tests.rs
@@ -212,6 +212,8 @@ fn find_clones_rejects_nan_and_non_finite_min_similarity() {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     };
     crate::IndexDatabase::rebuild(&config).unwrap();
     let db = crate::IndexDatabase::open_config(&config).unwrap();
@@ -796,6 +798,8 @@ fn recall_candidates_identical_blob_vs_postings_grouping() {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     };
     let db = crate::IndexDatabase::rebuild(&config).unwrap();
     let conn = db.storage.connection();

--- a/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
+++ b/crates/rag-rat-core/src/index/query_api/oracle_surfacing_tests.rs
@@ -48,6 +48,8 @@ fn rust_config(root: PathBuf) -> Config {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     }
 }
 
@@ -1174,6 +1176,8 @@ fn deleted_and_generated_paths_counted_in_skipped() {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     };
     git(&root, &["init", "-q"]);
     git(&root, &["add", "-A"]);

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -51,7 +51,44 @@ impl IndexDatabase {
         // flock only for its brief sweep.
         let lock_repo = crate::locks::write_lock_repo_id(config);
         let _write_lock = crate::locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
+        // #427 — enforce the empty-index invariant on the FULL-rebuild entry. Split around
+        // `create_or_migrate` so it mirrors the incremental path (open+migrate, THEN check) while
+        // still leaving NO stray DB file behind on a fresh refusal:
+        //  * PHASE 1 — a FRESH database (the file does not exist yet) that would discover nothing
+        //    is refused BEFORE `create_or_migrate` materializes the file (the `maintenance`
+        //    `!db.exists()` contract). A fresh DB is trivially not-already-indexed, so the check is
+        //    just the discovery walk.
+        //  * PHASE 2 — an EXISTING database is refused only AFTER `create_or_migrate` has brought
+        //    its schema current, because a pre-registry / older index can't be read (no `repos`
+        //    table) until it migrates. Checking post-migration lets a legacy index whose files were
+        //    all deleted be RECOGNIZED (via the persisted `source_root`, incl. the sole-placeholder
+        //    fallback for a not-yet-adopted legacy DB) and PRUNED, instead of wrongly refused as
+        //    first-time-empty (#427 review — the read-before-migrate hole the incremental path
+        //    never had). A genuine first-time-empty registration into an existing shared DB is
+        //    still refused, before `adopt` records it. `is_first_time_empty_conn` short-circuits on
+        //    an already-indexed root, so an established repo pruning to empty never pays the walk.
+        // Read-only `open_config` opens deliberately do NOT enforce (a read must not error); they
+        // can't smuggle an empty scope in because recognition keys on `source_root`, which only
+        // these indexing passes write. Callers react to the error: the one-shot `index`
+        // surfaces it; the watcher / maintenance `let _ =`-discard it and wait for content.
+        // `--allow-empty` opts in.
+        let db_existed = config.database.exists();
+        if !config.allow_empty && !db_existed && !crate::index::would_discover_any_file(config)? {
+            return Err(crate::index::EmptyIndexRefused {
+                root: config.root.display().to_string(),
+            }
+            .into());
+        }
         let mut db = Self::create_or_migrate(&config.database)?;
+        if !config.allow_empty
+            && db_existed
+            && crate::index::is_first_time_empty_conn(db.storage.connection(), config)?
+        {
+            return Err(crate::index::EmptyIndexRefused {
+                root: config.root.display().to_string(),
+            }
+            .into());
+        }
         // Register/adopt the repo BEFORE the scope view is installed and BEFORE any repo-scoped
         // write, so `active_repo_id` is a real (registered) id — every direct-scoped insert stamps
         // it, and `repo_meta` writes below satisfy the `repo_meta → repos` FK (an

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -94,8 +94,8 @@ impl IndexDatabase {
         // it, and `repo_meta` writes below satisfy the `repo_meta → repos` FK (an
         // empty/unregistered id would violate it). `create_or_migrate` no longer resolves
         // the repo or heals the model manifest, so both move here, ordered after
-        // registration.
-        db.adopt_repo_from_config(config)?;
+        // registration. INDEXING intent: a full rebuild records this checkout's root (#427).
+        db.adopt_repo_from_config(config, super::lifecycle::AdoptIntent::Indexing)?;
         // A6: stage a FRESH file generation instead of clearing-then-reinserting in one long
         // write-locked transaction. `old_live` is the generation readers currently see; `target` is
         // higher than any the repo holds, so it never collides with a torn prior rebuild's

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -8,10 +8,17 @@ pub(crate) use migrations::*;
 // `IndexDatabase::open` refuses a multi-repo DB rather than silently scoping to the
 // lexicographically-first repo.
 pub(crate) use registry::multiple_real_repos;
+// `register_repo` uses `repo_has_recorded_root` intra-module; the only consumer of the
+// re-export is now a `schema_bootstrap_tests` case (#427 moved the same-identity-join check
+// off it onto the `source_root` marker). Gate the re-export to test builds so the non-test lib
+// doesn't carry a dead import.
+#[cfg(test)]
+pub(crate) use registry::repo_has_recorded_root;
 pub(crate) use registry::{
     CONNECTION_CONTEXT_GENERATION_KEY, CONNECTION_CONTEXT_REPO_KEY, LIVE_FILES_GENERATION_META_KEY,
-    active_generation, active_repo_id, live_files_generation, periphery_repo_scope,
-    periphery_repo_scope_clause, resolve_config_repo_id, scope_context_repo_id, sole_repo_id,
+    active_generation, active_repo_id, earliest_recorded_root, live_files_generation,
+    periphery_repo_scope, periphery_repo_scope_clause, repo_id_is_registered,
+    resolve_config_repo_id, scope_context_repo_id, sole_repo_id,
 };
 pub use registry::{LEGACY_REPO_ID, register_repo};
 use rusqlite::{Connection, OptionalExtension, params};

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -8,19 +8,13 @@ pub(crate) use migrations::*;
 // `IndexDatabase::open` refuses a multi-repo DB rather than silently scoping to the
 // lexicographically-first repo.
 pub(crate) use registry::multiple_real_repos;
-// `register_repo` uses `repo_has_recorded_root` intra-module; the only consumer of the
-// re-export is now a `schema_bootstrap_tests` case (#427 moved the same-identity-join check
-// off it onto the `source_root` marker). Gate the re-export to test builds so the non-test lib
-// doesn't carry a dead import.
-#[cfg(test)]
-pub(crate) use registry::repo_has_recorded_root;
 pub(crate) use registry::{
     CONNECTION_CONTEXT_GENERATION_KEY, CONNECTION_CONTEXT_REPO_KEY, LIVE_FILES_GENERATION_META_KEY,
     active_generation, active_repo_id, earliest_recorded_root, live_files_generation,
-    periphery_repo_scope, periphery_repo_scope_clause, repo_id_is_registered,
-    resolve_config_repo_id, scope_context_repo_id, sole_repo_id,
+    periphery_repo_scope, periphery_repo_scope_clause, repo_has_recorded_root,
+    repo_id_is_registered, resolve_config_repo_id, scope_context_repo_id, sole_repo_id,
 };
-pub use registry::{LEGACY_REPO_ID, register_repo};
+pub use registry::{LEGACY_REPO_ID, register_repo, register_repo_read_only};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 

--- a/crates/rag-rat-core/src/index/schema/registry.rs
+++ b/crates/rag-rat-core/src/index/schema/registry.rs
@@ -726,8 +726,13 @@ fn find_upgradeable_local_incumbent(
 
 /// Whether `repo_id` has `root` recorded in `repo_roots` — the upgrade scan's working-tree match
 /// (both sides store the identical `to_string_lossy` rendering of a `Config::load`-canonicalized
-/// root, so equality is exact).
-fn repo_has_recorded_root(conn: &Connection, repo_id: &str, root: &str) -> rusqlite::Result<bool> {
+/// root, so equality is exact). Also the #427 same-identity-join hint's known-checkout test:
+/// telling a repo's own re-index from a NEW physical checkout adopting its scope.
+pub(crate) fn repo_has_recorded_root(
+    conn: &Connection,
+    repo_id: &str,
+    root: &str,
+) -> rusqlite::Result<bool> {
     conn.query_row(
         "SELECT EXISTS(SELECT 1 FROM repo_roots WHERE repo_id = ?1 AND root = ?2)",
         params![repo_id, root],
@@ -998,7 +1003,7 @@ pub(crate) fn resolve_config_repo_id(
 
 /// Whether `repo_id` is a REGISTERED real repo (present in `repos`, and not the placeholder
 /// marker).
-fn repo_id_is_registered(conn: &Connection, repo_id: &str) -> rusqlite::Result<bool> {
+pub(crate) fn repo_id_is_registered(conn: &Connection, repo_id: &str) -> rusqlite::Result<bool> {
     if repo_id == LEGACY_REPO_ID {
         return Ok(false);
     }
@@ -1036,6 +1041,20 @@ fn real_repo_ids(conn: &Connection) -> rusqlite::Result<Vec<String>> {
         conn.prepare("SELECT repo_id FROM repos WHERE repo_id != ?1 ORDER BY repo_id")?;
     let ids = stmt.query_map([LEGACY_REPO_ID], |row| row.get::<_, String>(0))?;
     ids.collect()
+}
+
+/// The earliest-registered recorded root for `repo_id` (a representative "home" checkout to name
+/// in the #427 join hint), or `None` when the repo has no recorded roots. Read-only.
+pub(crate) fn earliest_recorded_root(
+    conn: &Connection,
+    repo_id: &str,
+) -> rusqlite::Result<Option<String>> {
+    conn.query_row(
+        "SELECT root FROM repo_roots WHERE repo_id = ?1 ORDER BY registered_at_ms, root LIMIT 1",
+        params![repo_id],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()
 }
 
 /// Append a working-tree root for `repo_id` (idempotent per `(repo_id, root)` — worktrees of one

--- a/crates/rag-rat-core/src/index/schema/registry.rs
+++ b/crates/rag-rat-core/src/index/schema/registry.rs
@@ -137,11 +137,46 @@ const REGISTRY_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_sec
 ///
 /// `now_ms` is the injected clock (see the repo's time-injection convention), stamped as the
 /// registration time on adoption / first insert.
+///
+/// Records this checkout's working-tree `root` in `repo_roots` (the "this checkout was INDEXED
+/// here" signal). This is the INDEXING entry point — rebuild / incremental / consolidate / the
+/// tests. A read-only `open_config` (doctor / MCP / query) must NOT record the root; it calls
+/// [`register_repo_read_only`] instead (see that function for why, #427).
 pub fn register_repo(
     conn: &Connection,
     identity: &RepoIdentity,
     root: &Path,
     now_ms: i64,
+) -> rusqlite::Result<String> {
+    register_repo_inner(conn, identity, root, now_ms, true)
+}
+
+/// Register/adopt `identity` WITHOUT recording the working-tree `root` in `repo_roots` — the
+/// read-only open path (`open_config`: doctor / MCP / query, #427). A recorded root is the "this
+/// checkout was INDEXED here" signal `is_root_already_indexed` / `same_identity_join_note` key on,
+/// so a mere read must not create one: otherwise a fresh same-identity clone that was only ever
+/// opened for reading would masquerade as indexed and let a later empty index prune the shared
+/// scope. All the identity work (adopt placeholder → real, `local:` → Portable upgrade, refuse a
+/// conflicting owner) still runs — a read on a legacy DB still adopts it — only the `repo_roots`
+/// INSERT is skipped; the next indexing pass records the root.
+pub fn register_repo_read_only(
+    conn: &Connection,
+    identity: &RepoIdentity,
+    root: &Path,
+    now_ms: i64,
+) -> rusqlite::Result<String> {
+    register_repo_inner(conn, identity, root, now_ms, false)
+}
+
+/// The registration impl shared by [`register_repo`] (records the root) and
+/// [`register_repo_read_only`] (does not). `record_root` gates ONLY the `repo_roots` INSERT; every
+/// identity decision below is identical.
+fn register_repo_inner(
+    conn: &Connection,
+    identity: &RepoIdentity,
+    root: &Path,
+    now_ms: i64,
+    record_root: bool,
 ) -> rusqlite::Result<String> {
     // Defense in depth: the resolver already refuses a pinned placeholder and never derives it, but
     // a caller can hand-build a `RepoIdentity`. Registering the placeholder (or an empty/whitespace
@@ -215,7 +250,14 @@ pub fn register_repo(
         // retires the local id into the registered one.
         if let Some(owner) = real_root_owner(conn, &root_str, &identity.repo_id)? {
             if late_upgrade_is_proven(conn, &owner, identity, root)? {
-                merge_local_incumbent_into_registered(conn, identity, &owner, &root_str, now_ms)?;
+                merge_local_incumbent_into_registered(
+                    conn,
+                    identity,
+                    &owner,
+                    &root_str,
+                    now_ms,
+                    record_root,
+                )?;
                 persist_shallow_boundary(conn, identity)?;
                 return Ok(identity.repo_id.clone());
             }
@@ -225,7 +267,9 @@ pub fn register_repo(
                 &root_str,
             )));
         }
-        record_repo_root(conn, &identity.repo_id, &root_str, now_ms)?;
+        if record_root {
+            record_repo_root(conn, &identity.repo_id, &root_str, now_ms)?;
+        }
         persist_shallow_boundary(conn, identity)?;
         return Ok(identity.repo_id.clone());
     }
@@ -419,7 +463,9 @@ pub fn register_repo(
         crate::index::graph_index::realign_logical_symbol_ids(&tx)?;
         tx.execute("DELETE FROM repos WHERE repo_id = ?1", [source_id])?;
     }
-    record_repo_root(&tx, &identity.repo_id, &root_str, now_ms)?;
+    if record_root {
+        record_repo_root(&tx, &identity.repo_id, &root_str, now_ms)?;
+    }
     // Record a fresh LocalOnly adoption's shallow boundary INSIDE the transaction (atomic with the
     // `repos` row it references), so a future deepened clone can prove the upgrade against it. A
     // no-op for a Portable identity (empty boundary) and for the upgrade path itself (Portable
@@ -564,6 +610,7 @@ fn merge_local_incumbent_into_registered(
     owner: &str,
     root_str: &str,
     now_ms: i64,
+    record_root: bool,
 ) -> rusqlite::Result<()> {
     let _merge_locks = match conn.path().filter(|p| !p.is_empty()) {
         Some(db_path) =>
@@ -613,7 +660,9 @@ fn merge_local_incumbent_into_registered(
         owner
     ])?;
     tx.execute("DELETE FROM repos WHERE repo_id = ?1", [owner])?;
-    record_repo_root(&tx, &identity.repo_id, root_str, now_ms)?;
+    if record_root {
+        record_repo_root(&tx, &identity.repo_id, root_str, now_ms)?;
+    }
     tx.commit()?;
     tracing::warn!(
         old_repo_id = %owner,

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/clones.rs
@@ -1105,6 +1105,8 @@ fn multi_language_clone_integration_finds_within_language_no_cross() {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
 
@@ -1300,6 +1302,8 @@ fn find_clones_ranks_a_clean_clone_class_with_metrics() {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dir_memory_tree.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dir_memory_tree.rs
@@ -320,6 +320,8 @@ fn dir_tree_label_depth_collapse_single_child_chain() {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let conn = db.storage.connection();
@@ -550,6 +552,8 @@ fn dir_tree_truncates_at_max_nodes() {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let conn = db.storage.connection();
@@ -697,6 +701,8 @@ fn dir_tree_children_of_collapsed_node_use_leaf_labels() {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let conn = db.storage.connection();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/generation_rebuild.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/generation_rebuild.rs
@@ -1530,7 +1530,7 @@ fn standalone_index_targets_publishes_staged_parser_failures_immediately() {
 
     // The standalone driver: create/adopt/scope, then index_targets — NO rebuild anywhere.
     let mut db = IndexDatabase::create_or_migrate(&config.database).unwrap();
-    db.adopt_repo_from_config(&config).unwrap();
+    db.adopt_repo_from_config(&config, crate::index::lifecycle::AdoptIntent::Indexing).unwrap();
     let (sha, wt) = crate::index::resolve_git_context(&root);
     db.set_context(&sha, &wt).unwrap();
     db.index_targets(&config).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/github_papertrail.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/github_papertrail.rs
@@ -314,6 +314,8 @@ fn parser_failures_report_paths() {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     };
 
     let db = IndexDatabase::rebuild(&config).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -86,6 +86,8 @@ fn rag_rat_config(root: &Path) -> Config {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     }
 }
 
@@ -216,6 +218,8 @@ fn markdown_config_for_root(root: PathBuf) -> Config {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     }
 }
 
@@ -353,6 +357,8 @@ fn source_config(root: PathBuf, language: Language) -> Config {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     }
 }
 
@@ -717,6 +723,8 @@ fn git_fixture_for_overlay_tests() -> (PathBuf, Config) {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     };
     (root, config)
 }
@@ -839,6 +847,8 @@ fn write_four_renamed_clones(root: &PathBuf) -> IndexDatabase {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     };
     IndexDatabase::rebuild(&config).unwrap()
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
@@ -183,6 +183,8 @@ fn clean_checkout_file_resolves_against_its_own_package_roots() {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     };
 
     let db = IndexDatabase::rebuild(&config).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/reconcile_embeddings.rs
@@ -507,6 +507,33 @@ fn watch_maintenance_pass_indexes_new_files() {
 }
 
 #[test]
+fn watch_maintenance_pass_defers_a_first_time_empty_config() {
+    // #427 review: a maintenance/watch pass on a brand-new config with NO discoverable files (an
+    // empty target tree — the `rag-rat mcp` / misconfigured-repo case) must NOT first-time-register
+    // an empty repo. It creates no database at all; a later pass registers once real content
+    // appears. (The one-shot `index` command surfaces this as an error; the watcher just waits.)
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap(); // configured target `src/`, but it is empty
+    let config = source_config(root.clone(), Language::Rust);
+
+    crate::watch::maintenance_pass(&config, false).unwrap();
+    assert!(
+        !config.database.exists(),
+        "an empty first-time config must not create/register an index"
+    );
+
+    // Content appears → the next pass registers + indexes it.
+    fs::write(root.join("src/one.rs"), "pub fn appeared() {}\n").unwrap();
+    crate::watch::maintenance_pass(&config, false).unwrap();
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let hits = db.symbols("appeared", Some(Language::Rust), 10).unwrap();
+    assert!(!hits.is_empty(), "a pass after content appears must register + index it");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn discover_deletion_is_worktree_scoped() {
     // Invariant (watcher spec, review item 1): a discover pass run from worktree A must remove
     // only A's own rows for files missing from A's disk — never another worktree's overlay
@@ -846,6 +873,8 @@ fn git_history_indexes_commits_paths_queries_and_blame() {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let status = db.status(&config.database).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -2133,6 +2133,8 @@ fn repo_brief_ranks_churn_and_god_module_candidates() {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
 
@@ -2218,6 +2220,8 @@ fn repo_clusters_groups_cotouched_files() {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_registry.rs
@@ -585,6 +585,40 @@ fn register_repo_adoption_relocates_repo_meta_rows() {
     );
 }
 
+/// The #427 same-identity-join hint's two read-only lookups: whether a given root is already one
+/// of `repo_id`'s recorded checkouts, and which recorded root is the earliest-registered (the
+/// "home" checkout the hint names).
+#[test]
+fn recorded_root_helpers_report_membership_and_earliest() {
+    use crate::index::schema::{earliest_recorded_root, repo_has_recorded_root};
+    let conn = rusqlite::Connection::open_in_memory().expect("open");
+    schema::apply(&conn).expect("apply");
+    let id = identity("repo-x", "repo-x");
+    // First root A (registered_at 100), then a second checkout B (registered_at 200).
+    register_repo(&conn, &id, Path::new("/checkout-a"), 100).unwrap();
+    register_repo(&conn, &id, Path::new("/checkout-b"), 200).unwrap();
+
+    assert!(repo_has_recorded_root(&conn, &id.repo_id, "/checkout-a").unwrap());
+    assert!(repo_has_recorded_root(&conn, &id.repo_id, "/checkout-b").unwrap());
+    assert!(!repo_has_recorded_root(&conn, &id.repo_id, "/checkout-c").unwrap());
+    assert_eq!(
+        earliest_recorded_root(&conn, &id.repo_id).unwrap().as_deref(),
+        Some("/checkout-a"),
+        "earliest by registered_at_ms wins",
+    );
+
+    // Tiebreak: two roots registered at the SAME instant → the lexicographically-smaller root wins
+    // deterministically (the `ORDER BY registered_at_ms, root` secondary key).
+    let tied = identity("repo-tied", "repo-tied");
+    register_repo(&conn, &tied, Path::new("/z-checkout"), 500).unwrap();
+    register_repo(&conn, &tied, Path::new("/a-checkout"), 500).unwrap();
+    assert_eq!(
+        earliest_recorded_root(&conn, &tied.repo_id).unwrap().as_deref(),
+        Some("/a-checkout"),
+        "equal registered_at_ms → lexicographically-smaller root breaks the tie",
+    );
+}
+
 /// `single_repo_id` returns the sole `repos` row — the placeholder before adoption, the real id
 /// after — the connection-level stand-in the per-repo accessors resolve until A3.
 #[test]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -27,6 +27,11 @@ fn rebuild_bootstraps_sqlite_schema_for_empty_target_root() {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        // This test deliberately rebuilds an EMPTY target root (no `.md` files) to verify schema
+        // bootstrap; that is the sanctioned `--allow-empty` path now that the core refuses a
+        // first-time-empty registration by default (#427).
+        allow_empty: true,
     };
 
     let db = IndexDatabase::rebuild(&config).unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/symbol_search_lookup.rs
@@ -540,6 +540,8 @@ DEVICE_DT_INST_DEFINE(0, entropy_init, NULL, NULL, NULL,
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
 
@@ -1325,6 +1327,8 @@ where
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     };
     let db = IndexDatabase::rebuild(&config).unwrap();
     let symbol = db.symbols("spawn_blocking", Some(Language::Rust), 10).unwrap().remove(0);

--- a/crates/rag-rat-core/src/logging/mod.rs
+++ b/crates/rag-rat-core/src/logging/mod.rs
@@ -141,6 +141,8 @@ mod tests {
             search: Default::default(),
             memory: Default::default(),
             log: LogConfig { enabled, dir: dir.join("logs"), ..LogConfig::default() },
+            source_root_reanchored_from: None,
+            allow_empty: false,
         }
     }
 

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -116,7 +116,18 @@ fn run_pass(
     retry_base_embedding_backlog: bool,
 ) -> anyhow::Result<()> {
     let started = Instant::now();
-    let (mut db, content_changed) = IndexDatabase::index_discover_reporting(config)?;
+    // #427: the core refuses a first-time-empty registration (`rag-rat mcp` / a hook on a config
+    // with no `[target_bindings]` or no matching files). A maintenance/watch pass treats that as
+    // "nothing to index yet" and DEFERS silently — a later pass registers once real content
+    // appears. A recorded root going empty still prunes (not first-time → not refused). The
+    // one-shot `index` command instead surfaces the same error to the operator.
+    let (mut db, content_changed) = match IndexDatabase::index_discover_reporting(config) {
+        Ok(result) => result,
+        Err(err) if err.downcast_ref::<crate::index::EmptyIndexRefused>().is_some() => {
+            return Ok(());
+        },
+        Err(err) => return Err(err),
+    };
     let shutdown_reconcile_pending = db.watch_shutdown_reconcile_pending()?;
     let runtime = &config.llm.embedding.runtime;
     let options = ReconcileOptions {
@@ -1169,12 +1180,22 @@ fn shutdown_discover(config: &Config) -> anyhow::Result<bool> {
     let lock_repo = locks::write_lock_repo_id(config);
     match locks::WriteLock::acquire_timeout(&config.database, &lock_repo, SKIP_TIMEOUT)? {
         Some(_lock) => {
-            let (db, content_changed) = IndexDatabase::index_discover_reporting(config)?;
-            if content_changed {
-                db.mark_watch_shutdown_reconcile_pending()?;
-                return Ok(true);
+            // #427: the core refuses a first-time-empty registration; a shutdown refresh defers on
+            // it (same as `run_pass`) rather than creating an empty index on the way out. Otherwise
+            // it preserves #460's shutdown-reconcile debt: a content change on the way out marks
+            // the base reconcile owed so the next startup pays it down.
+            match IndexDatabase::index_discover_reporting(config) {
+                Ok((db, content_changed)) => {
+                    if content_changed {
+                        db.mark_watch_shutdown_reconcile_pending()?;
+                        return Ok(true);
+                    }
+                    Ok(false)
+                },
+                Err(err) if err.downcast_ref::<crate::index::EmptyIndexRefused>().is_some() =>
+                    Ok(false),
+                Err(err) => Err(err),
             }
-            Ok(false)
         },
         None => Ok(false),
     }
@@ -1221,7 +1242,24 @@ mod tests {
             search: Default::default(),
             memory: Default::default(),
             log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
         }
+    }
+
+    /// #427: a maintenance/watch pass on a first-time-empty config DEFERS — the core refuses the
+    /// empty registration and `run_pass` swallows `EmptyIndexRefused`, returning `Ok(())` and
+    /// registering nothing, rather than erroring into the watcher loop. Covers the in-process defer
+    /// path the subprocess CLI guards exercise out-of-process (so it doesn't count toward
+    /// coverage).
+    #[test]
+    fn maintenance_pass_defers_on_a_first_time_empty_config() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // A single rust target with NO directories → discovers nothing → first-time-empty.
+        let config = whole_root_config(tmp.path(), &[]);
+        let result = maintenance_pass(&config, false);
+        assert!(result.is_ok(), "an empty first-time config must defer, not error: {result:?}");
+        assert!(!config.database.exists(), "deferring must register no empty index");
     }
 
     fn ephemeral_remote(query_endpoint: Option<&str>) -> RemoteEmbeddingConfig {
@@ -1969,6 +2007,8 @@ mod tests {
             search: Default::default(),
             memory: Default::default(),
             log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
         };
         let worktree = PathBuf::from("/wt/feat");
         let registry = PathBuf::from("/main/.git/worktrees");
@@ -2604,6 +2644,8 @@ mod tests {
             search: Default::default(),
             memory: Default::default(),
             log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
         };
         // A linked checkout mirrors the layout: `<checkout>/crate/src/a.rs`.
         let checkout =
@@ -2651,6 +2693,8 @@ mod tests {
             search: Default::default(),
             memory: Default::default(),
             log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
         };
         let ignore = IgnoreMatcher::compile(&root, &[]);
 
@@ -2716,6 +2760,8 @@ mod tests {
             search: Default::default(),
             memory: Default::default(),
             log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
         };
 
         let ignore = IgnoreMatcher::compile(&root, &[]);
@@ -2792,6 +2838,8 @@ mod tests {
             search: Default::default(),
             memory: Default::default(),
             log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
         };
 
         // Before: a source file under the subdir fires.
@@ -2940,6 +2988,8 @@ mod tests {
             search: Default::default(),
             memory: Default::default(),
             log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
         };
 
         let (roots, _registry) = worktree_watch_targets(&config);
@@ -3280,6 +3330,8 @@ mod tests {
             search: Default::default(),
             memory: Default::default(),
             log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
         };
         let ignore = IgnoreMatcher::compile(&root, &[PathBuf::from("src")]);
         let dir_create =

--- a/crates/rag-rat-mcp/src/server.rs
+++ b/crates/rag-rat-mcp/src/server.rs
@@ -478,6 +478,8 @@ mod tests {
             search: Default::default(),
             memory: Default::default(),
             log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
         };
         IndexDatabase::rebuild(&config).unwrap();
         (root, config)

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -892,6 +892,8 @@ fn mixed_config() -> (PathBuf, Config) {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     })
 }
 
@@ -919,6 +921,8 @@ fn markdown_config(text: &str) -> (PathBuf, Config) {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     })
 }
 
@@ -943,6 +947,8 @@ fn rust_config(root: PathBuf) -> Config {
         search: Default::default(),
         memory: Default::default(),
         log: Default::default(),
+        source_root_reanchored_from: None,
+        allow_empty: false,
     }
 }
 


### PR DESCRIPTION
Closes the silent-behavior gaps from #427 when `rag-rat index` runs against an explicit config that points at a linked worktree, a same-identity clone, or a target-less config. The identity/adoption semantics are intentionally unchanged — same-identity checkouts (primary, linked worktrees, fresh clones) share one `repo_id` ⇒ one scoped row-set by design — so `index` now says so **loudly** and refuses to register an empty repo, rather than silently indexing a different tree or empty content.

## Changes

- **Refuse zero discovered files.** `index` now errors when no files would be discovered (e.g. no `[target_bindings]`, or bindings that match nothing) instead of silently registering an empty repo. `--allow-empty` opts back in. The check runs *before* the database is opened or the repo is registered, so a refusal writes nothing.
- **Same-identity join warning.** When the configured root shares an already-registered repo's identity but isn't one of its recorded checkouts (a fresh clone / not-yet-anchored worktree joining a shared database), `index` warns that it will merge into that one scope and names the `[index] repo_id` remedy for an independent index. Detection (`same_identity_join_note`) is read-only.
- **Worktree re-anchor warning.** When `[index] root` names a linked worktree that `Config::load` re-anchors to the main checkout, `index` warns that it is indexing the main tree instead, and points at `rag-rat index --worktree <path>` for the branch delta or a pinned `[index] repo_id` for an independent index. Tracked via a new `Config.source_root_reanchored_from` field populated at load.

## Notes

- The zero-file guard adds a full target walk to every manual `index`, including the incremental path (which otherwise discovers files via git-diff). This is acceptable for a manual command; the git-hook `maintenance` path is unaffected.
- `same_identity_join_note` returns `Ok(None)` generously on any ambiguity (no database, incompatible/corrupt database, absent identity, or an already-recorded root), so a warning check can never turn into an indexing failure.
- Known cosmetic edge (documented, deferred): an explicit `--config` whose `[index] root` names a linked-worktree absolute path, against a shared database where the main checkout is already indexed, trips both warnings — `anchor_root_to_main_worktree` appends a trailing slash for a `root="."` worktree, so the re-anchored root no longer string-matches the recorded root. Both messages are truthful and point at the same `[index] repo_id` remedy; the common "working from a worktree with a local config" case fires only the re-anchor warning.

## Tests

- Unit: `would_discover_any_file` (empty vs matching targets); the registry root helpers (membership + earliest-with-tiebreak); `same_identity_join_note` (two-clone shared-database fixture, plus a garbage-database file → `Ok(None)`); the `Config::load` re-anchor field (linked worktree → `Some`, main worktree → `None`).
- Integration (CLI): zero-file refusal names `[target_bindings]` and registers nothing; `--allow-empty` succeeds.
- Full workspace: 1772 tests pass, `clippy --all-targets` clean. All three guards were exercised end-to-end against real git fixtures.

Fixes #427
