### PR TITLE
Append fast-forward git history reloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,9 +1198,9 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.84.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae54ae0ebd1a5a3c3f8d95dd3b5ca6e63f4fed9bfd585e13801a97d7bde8f9ce"
+checksum = "fa8b2e38ebfc4484dfef8580ddcaf8abb7285e6f3eb6413ff6775d104ae96ca6"
 dependencies = [
  "gix-actor",
  "gix-attributes",
@@ -1262,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.33.1"
+version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d43f12e246d3bf7ec624c8fc15ac4a4b62b7c4c6f586cb82be6c90bf84c9d02"
+checksum = "39b40888d0ed415c0744a6cdc61eebf0304c9d26ab726725b718443c322e5ba4"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -1288,9 +1288,9 @@ dependencies = [
 
 [[package]]
 name = "gix-blame"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d39a0c14af94c2edaa5eefe06d5ef2cdea55316ae9a9321314288e3f55fa4c0"
+checksum = "cf49c828ad8a8a674d52caaf0b61fdee1f20cc46c15439ca3d875ef3b6f64bdc"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -1344,9 +1344,9 @@ dependencies = [
 
 [[package]]
 name = "gix-config"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2372d4b49ca28431e7d150cab9d25edc1890f0184bd57eb0e917c7799e63de"
+checksum = "a29bf266c4cdaf759e535c24ad4ce655b987aeb6911075643403cc7cc5ade583"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -1375,9 +1375,9 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ecab64a98bbac9f8e02990a9ea5e3c974a7d49b95f2bd70ad94ad22fa6b48c"
+checksum = "3d63f9e28b59ddeb1a1eb9e5cf986a9222b5d484947445edbc20473939cc7fd0"
 dependencies = [
  "bstr",
  "gix-error",
@@ -1387,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.64.0"
+version = "0.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b6d9528f32d94cef2edf39a1ac01fe5a0fc44ddbb18d9e44099936047c3302b"
+checksum = "92c6d56c94edf92d78203a1cd416f770e35e10b6955ede6b9d7d0c22ff88a5f3"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -1411,9 +1411,9 @@ dependencies = [
 
 [[package]]
 name = "gix-dir"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bb2a53a6fd917ec499ed0bfb5b6887de7a15bd79197dcea7c987938749a9f1"
+checksum = "20098fba2b9c6e29361ccb4c0379d42dfb81fc7f86f7ab11f2dff4528c0bf01f"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -1431,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "gix-discover"
-version = "0.52.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77bacdd12b7879d2178a80c58c2f319995e4654e1a7a23e3181e5c8a12b824f7"
+checksum = "d624d5b23b10c1d85337645227abe353ac95ab8ff66a7bdd5ce689b2db33a722"
 dependencies = [
  "bstr",
  "dunce",
@@ -1476,9 +1476,9 @@ dependencies = [
 
 [[package]]
 name = "gix-filter"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecf74b7d16f6694ce4a3049074c41be0c7987105743674f1671807bd6dce09fa"
+checksum = "6644fb2ef97928c278675b239f366b457103d7e436f811d27331a8daf212759c"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -1536,9 +1536,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hashtable"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0e30b93eea8718baf7d8153fcb938e2926175bbf18097c09f1c01b6f0be0563"
+checksum = "7e261d54091f0d1c729bc83f54548c071bdec60a697de1e58e88bdfd7a99d24e"
 dependencies = [
  "gix-hash",
  "hashbrown 0.17.1",
@@ -1560,9 +1560,9 @@ dependencies = [
 
 [[package]]
 name = "gix-imara-diff"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
+checksum = "b305d85504de270ad3525d726a6b69cc59ee7b2269b014387651107ab9f0755b"
 dependencies = [
  "bstr",
  "hashbrown 0.17.1",
@@ -1570,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "gix-index"
-version = "0.52.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6b28cc592dc753adb58302bb14a64e412ee591a3bec77aa4df87bff74fa80d"
+checksum = "36d45f82ec5a4d7542ea595e9ad16e03e26c8cb4f221e5bc9fcdcf469f63a681"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
@@ -1609,9 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.61.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5cd857e29429c7213bdef3f5aef83f8cc124774fe8ae0d27b1607d218d6d525"
+checksum = "019b38afc3eac1e41f9fe09a327664b313ba4a120fa5f40e3678795d0e42783e"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -1628,9 +1628,9 @@ dependencies = [
 
 [[package]]
 name = "gix-odb"
-version = "0.81.0"
+version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d004c32858b1556f2d7874405edb3c97dc78fc09beaa87d57bb077ee2858a7d"
+checksum = "7fadc59f6fa0f9dd445eceee61060a2b59ca557f48da9fc677f567db535b782a"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -1649,9 +1649,9 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.71.0"
+version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e43626f2a27d1033674ec1a196b845614231e6bbd949d5e21c133045ff56b174"
+checksum = "ca3e7f1726cd2c0cd1cf1fc20be8a8e623f0b163f1f8d6fc836cfb9bc8cd758b"
 dependencies = [
  "clru",
  "gix-chunk",
@@ -1707,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.62.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51dea3acb390707ab868f1f9584f18449eb95d869deffae96768e47d303595ee"
+checksum = "978468bae4ea2df20c72db3b20d0bdb548a0c1090b85a83643b553e6e0e041f2"
 dependencies = [
  "bstr",
  "gix-date",
@@ -1737,9 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.64.0"
+version = "0.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c04f64c37eb7e6feb73c7060f8dc6f381cc5de5d53249bfd450bc48a86b2e8b"
+checksum = "9bbfbce1dfd7d7f8469ddef6d3518376aff664348f153cbe0fc3e58ef993d24e"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -1757,9 +1757,9 @@ dependencies = [
 
 [[package]]
 name = "gix-refspec"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b216ae06ec74b5f24ad0142026a997fb0a935b7410eaf9c1616fc3f0e6c5a6d3"
+checksum = "7bc36a4fb1a1540b59cf2da498783080743fa274b02a3f19ca444fc4015a9d4f"
 dependencies = [
  "bstr",
  "gix-error",
@@ -1773,9 +1773,9 @@ dependencies = [
 
 [[package]]
 name = "gix-revision"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b47c88884dd3c1a19a39da19d10211fcdea2809aadc86869b6e824a1774340f"
+checksum = "885075c3c21eb9c06e0be3b3728ba5932c04e1c1011dcee7c81801980e3e986f"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
@@ -1792,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "gix-revwalk"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f5756abffe0917827aac683b13684ed99875bc398fa1f9b8f479b0681ef9e6"
+checksum = "8f11fe7ca2585193d3d70bbe0be175a2008d883a704cc7a55e454e113e689455"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -1833,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "gix-status"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22042e385d28a34275e029d98f4970285045be14b9073658ca897923f2ed8700"
+checksum = "aec3293f75db1212f99217832cbc70c30faeb95cefc97c7f1a17fd3bcf13a72e"
 dependencies = [
  "bstr",
  "filetime",
@@ -1856,9 +1856,9 @@ dependencies = [
 
 [[package]]
 name = "gix-submodule"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3059890ef054066c22a94bfc6a3eaba0d806aedcd630a0bc9e5783fd88884781"
+checksum = "a7f9f594f7cbda0b38ba6b633b3e9a7b7901acdc5d27bc186a16633800cd1ac8"
 dependencies = [
  "bstr",
  "gix-config",
@@ -1890,9 +1890,9 @@ checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
 
 [[package]]
 name = "gix-transport"
-version = "0.57.1"
+version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd0e34995b1aab0fa8dff2af8db726a0bfad3e119c89302604463264046e7ff"
+checksum = "186874f7ad1fb2f9a2f2aa9c2dabc7f9dd087bef74c1a0eee2b4a9cf0248fcb3"
 dependencies = [
  "bstr",
  "gix-command",
@@ -1906,9 +1906,9 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de590ecc86a3b2870665f2288324fa9f7f8672c7fc2d4e020fdd81cd1f7aed"
+checksum = "5062cca8f2977565bbaf666ec31dbdb9bc9d9293beb65f9bec52e6c1121b62a1"
 dependencies = [
  "bitflags 2.13.0",
  "gix-commitgraph",
@@ -1955,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree"
-version = "0.53.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef414ed275e8407cd5d53d301e83be19700b0dd3f859d2434417b58f454a2d1"
+checksum = "92399ed66f259592050c6ed9dc80105e095a2f8e87e6b83d98aa2e21d8e27036"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -1973,9 +1973,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-stream"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25e9ed30100c63f7590bc581c225e53f731a53e06aa79a245739c07f7dcc557"
+checksum = "55f3a878c89a05470ad98c644b0015777c530da24854dd29e41fe4f41176840f"
 dependencies = [
  "gix-attributes",
  "gix-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rag-rat-core = { version = "0.13.0", path = "crates/rag-rat-core", default-featu
 rag-rat-mcp = { version = "0.13.0", path = "crates/rag-rat-mcp", default-features = false }
 anyhow = "1.0"
 fastembed = { version = "5.17.2", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
-gix = { version = "0.84.0", default-features = false, features = ["status", "parallel", "sha1", "sha256", "revision", "blob-diff", "blame"] }
+gix = { version = "0.85.0", default-features = false, features = ["status", "parallel", "sha1", "sha256", "revision", "blob-diff", "blame"] }
 libc = "0.2"
 # Separator-aware path→forward-slash conversion. Unlike a raw `\`→`/` replace, it only rewrites the
 # actual path SEPARATOR — so a literal backslash in a Unix filename is preserved. Used where a path

--- a/crates/rag-rat-core/src/index/ai/providers/mod.rs
+++ b/crates/rag-rat-core/src/index/ai/providers/mod.rs
@@ -168,11 +168,13 @@ fn light_embedder(
 pub(crate) enum ChunkEmbedder {
     /// An embedder is ready. `provisioned` is `Some` only for an ephemeral box; `None` for
     /// connect/local. `remote` is the already-read active remote config, if any, so reconcile does
-    /// not need to re-read potentially malformed meta outside the NotReady path.
+    /// not need to re-read potentially malformed meta outside the NotReady path. `estimated_jobs`
+    /// carries a paid candidate scan from a preflight path so reconcile can reuse it.
     Ready {
         embedder: Box<dyn Embedder>,
         provisioned: Option<ProvisionedBox>,
         remote: Option<Box<RemoteEmbeddingConfig>>,
+        estimated_jobs: Option<u64>,
     },
     /// Ephemeral active model on a non-provisioning pass whose local `query_endpoint` is absent or
     /// fails a probe embed (down, a wrong service on the port, the model not pulled, a dim
@@ -274,6 +276,7 @@ pub(crate) fn acquire_chunk_embedder(
                 embedder,
                 provisioned: None,
                 remote: Some(Box::new(transport)),
+                estimated_jobs: None,
             };
         }
         // BEFORE provisioning a paid box, confirm there's actually work to do. An explicit
@@ -338,6 +341,7 @@ pub(crate) fn acquire_chunk_embedder(
                     embedder: Box::new(embedder),
                     provisioned: Some(provisioned),
                     remote: Some(Box::new(window_remote)),
+                    estimated_jobs,
                 }
             },
             Err(err) => ChunkEmbedder::NotReady(err),
@@ -345,8 +349,12 @@ pub(crate) fn acquire_chunk_embedder(
     }
     // Connect / local: the usual single construction site.
     match active_embedder(conn, intra_threads) {
-        Ok(embedder) =>
-            ChunkEmbedder::Ready { embedder, provisioned: None, remote: remote.map(Box::new) },
+        Ok(embedder) => ChunkEmbedder::Ready {
+            embedder,
+            provisioned: None,
+            remote: remote.map(Box::new),
+            estimated_jobs: None,
+        },
         Err(err) => ChunkEmbedder::NotReady(err),
     }
 }

--- a/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/embed_loop.rs
@@ -48,6 +48,32 @@ pub(crate) fn reconcile_with_options_progress(
         .filter(|value| *value > 0)
         .unwrap_or(DEFAULT_BATCH_SIZE);
     let max_embedding_chars = options.max_embedding_chars.max(MIN_EMBEDDING_CHARS);
+    // The reconcile scan identity (model id/version/dim + char cap), built ONCE up front so the
+    // ephemeral pending-work check inside `acquire_chunk_embedder` sizes candidates exactly like
+    // the embed loop below (which reuses this same `scan`).
+    let scan = EmbeddingScan {
+        model_id: &active_model_id,
+        model_version: &model_version,
+        dim: embedding_dim,
+        max_embedding_chars,
+    };
+    let preflight_estimated_jobs = if automatic_reconcile_can_skip_noop(conn, &options) {
+        match estimated_reconcile_jobs(conn, &scan, &options) {
+            Ok(0) =>
+                return Ok(empty_current_reconcile_report(
+                    active_model_id,
+                    model_version,
+                    embedding_dim,
+                    batch_size,
+                    max_embedding_chars,
+                    &options,
+                )),
+            Ok(jobs) => Some(jobs),
+            Err(_) => None,
+        }
+    } else {
+        None
+    };
     let started = now_ms();
     set_reconcile_meta(conn, LAST_EMBEDDING_RECONCILE_STARTED_META, &started.to_string())?;
     // Stamp the active repo (V042): `reconcile_attempts` carries `repo_id`, so the attempt is
@@ -74,16 +100,6 @@ pub(crate) fn reconcile_with_options_progress(
     )?;
     let attempt_id = conn.last_insert_rowid();
     let timer = Instant::now();
-
-    // The reconcile scan identity (model id/version/dim + char cap), built ONCE up front so the
-    // ephemeral pending-work check inside `acquire_chunk_embedder` sizes candidates exactly like
-    // the embed loop below (which reuses this same `scan`).
-    let scan = EmbeddingScan {
-        model_id: &active_model_id,
-        model_version: &model_version,
-        dim: embedding_dim,
-        max_embedding_chars,
-    };
     // The chunk-embed embedder. For an EPHEMERAL active model on a provisioning reconcile, this
     // PROVISIONS a cookbook box (held by `_provisioned` for the whole loop — its `Drop` tears the
     // box down on success/error/panic) — but only AFTER confirming there's pending work, so a no-op
@@ -203,8 +219,9 @@ pub(crate) fn reconcile_with_options_progress(
 
     // `_provisioned` MUST outlive the embed loop: its `Drop` is the box teardown. Bound at function
     // scope here (not inside the match) so it lives until the function returns.
-    let (embedder, _provisioned, remote_config) = match acquired {
-        ChunkEmbedder::Ready { embedder, provisioned, remote } => (embedder, provisioned, remote),
+    let (embedder, _provisioned, remote_config, acquired_estimated_jobs) = match acquired {
+        ChunkEmbedder::Ready { embedder, provisioned, remote, estimated_jobs } =>
+            (embedder, provisioned, remote, estimated_jobs),
         ChunkEmbedder::NotReady(err) => {
             // Surface the cause (e.g. a cookbook provisioning failure with its captured stderr) so
             // a remote outage isn't swallowed; the report keeps the actionable "install" hint AND
@@ -238,7 +255,10 @@ pub(crate) fn reconcile_with_options_progress(
         .as_deref()
         .map(|remote| remote_reconcile_batch_size(remote, batch_size, options.max_seconds))
         .unwrap_or(batch_size);
-    let mut progress_total_chunks = estimated_reconcile_jobs(conn, &scan, &options)?;
+    let mut progress_total_chunks = match preflight_estimated_jobs.or(acquired_estimated_jobs) {
+        Some(jobs) => jobs,
+        None => estimated_reconcile_jobs(conn, &scan, &options)?,
+    };
     progress(ReconcileProgress::Started {
         model_id: active_model_id.clone(),
         total_chunks: progress_total_chunks,
@@ -411,6 +431,53 @@ pub(crate) fn reconcile_with_options_progress(
         "reconcile complete"
     );
     Ok(report)
+}
+
+fn automatic_reconcile_can_skip_noop(conn: &Connection, options: &ReconcileOptions) -> bool {
+    if options.provision_remote || options.force || options.max_seconds.is_none() {
+        return false;
+    }
+    match active_remote_config(conn) {
+        Ok(Some(remote)) if remote.is_ephemeral() => false,
+        Ok(_) => true,
+        Err(_) => false,
+    }
+}
+
+fn empty_current_reconcile_report(
+    active_model_id: String,
+    model_version: String,
+    embedding_dim: usize,
+    batch_size: usize,
+    max_embedding_chars: usize,
+    options: &ReconcileOptions,
+) -> ReconcileReport {
+    ReconcileReport {
+        processed_chunks: 0,
+        embeddings_written: 0,
+        skipped_chunks: 0,
+        failed_chunks: 0,
+        blocked_chunks: 0,
+        model_id: active_model_id,
+        model_version,
+        embedding_dim,
+        batch_size,
+        max_embedding_chars,
+        forced: options.force,
+        changed_first: options.changed_first,
+        until_clean: options.until_clean,
+        max_seconds: options.max_seconds,
+        work_reasons: BTreeMap::new(),
+        skipped_by_policy: BTreeMap::new(),
+        input_chars: 0,
+        truncated_inputs: 0,
+        elapsed_ms: 0,
+        chunks_per_sec: 0.0,
+        chars_per_sec: 0.0,
+        avg_chars_per_chunk: 0.0,
+        status: "Current".to_string(),
+        message: None,
+    }
 }
 
 fn remote_reconcile_batch_size(
@@ -821,6 +888,14 @@ mod freshness_version_tests {
         conn
     }
 
+    fn reset_estimated_reconcile_job_calls() {
+        crate::index::ai::store::ESTIMATED_RECONCILE_JOBS_CALLS.with(|calls| calls.set(0));
+    }
+
+    fn estimated_reconcile_job_calls() -> usize {
+        crate::index::ai::store::ESTIMATED_RECONCILE_JOBS_CALLS.with(std::cell::Cell::get)
+    }
+
     fn remote_at(endpoint: &str) -> RemoteEmbeddingConfig {
         RemoteEmbeddingConfig {
             model: "all-minilm".to_string(),
@@ -836,6 +911,36 @@ mod freshness_version_tests {
             max_batch_chars: 384_000,
             request_timeout_s: 5,
         }
+    }
+
+    fn activate_remote_fastembed(conn: &Connection, remote: &RemoteEmbeddingConfig) {
+        let spec = spec(FASTEMBED_MODEL_ID).unwrap();
+        set_active_remote_config(conn, remote).unwrap();
+        conn.execute(
+            "UPDATE ai_models
+             SET installed = 1, disabled = 0, status = 'Ready', embedding_dim = ?2, runtime = \
+             'ollama'
+             WHERE model_id = ?1",
+            params![FASTEMBED_MODEL_ID, i64::try_from(spec.dim).unwrap()],
+        )
+        .unwrap();
+        set_repo_meta(conn, ACTIVE_EMBEDDING_MODEL_META, FASTEMBED_MODEL_ID).unwrap();
+        set_repo_meta(
+            conn,
+            ACTIVE_EMBEDDING_MODEL_VERSION_META,
+            &remote_freshness_version(spec, remote),
+        )
+        .unwrap();
+    }
+
+    fn reconcile_attempt_count(conn: &Connection) -> i64 {
+        conn.query_row("SELECT COUNT(*) FROM reconcile_attempts", [], |row| row.get(0)).unwrap()
+    }
+
+    fn reconcile_meta_value(conn: &Connection, key: &str) -> Option<String> {
+        conn.query_row("SELECT value FROM reconcile_meta WHERE key = ?1", [key], |row| row.get(0))
+            .optional()
+            .unwrap()
     }
 
     struct TimeoutsThenOkEmbedder {
@@ -1219,6 +1324,70 @@ mod freshness_version_tests {
     }
 
     #[test]
+    fn automatic_noop_reconcile_does_not_write_attempt() {
+        let conn = schema_conn();
+        let spec = spec(FASTEMBED_MODEL_ID).unwrap();
+        seed_embedding_chunk(&conn, 1);
+        let (url, handle, _) = spawn_reconcile_embed_stub(spec.dim, 1, Duration::ZERO);
+        let remote = remote_at(&url);
+        activate_remote_fastembed(&conn, &remote);
+
+        reset_estimated_reconcile_job_calls();
+        let report = reconcile_with_options_progress(
+            &conn,
+            ReconcileOptions {
+                max_seconds: Some(30),
+                provision_remote: false,
+                ..ReconcileOptions::default()
+            },
+            std::mem::drop,
+        )
+        .unwrap();
+        handle.join().unwrap();
+        assert_eq!(report.embeddings_written, 1);
+        assert_eq!(
+            estimated_reconcile_job_calls(),
+            1,
+            "non-empty automatic reconcile must reuse the no-op preflight estimate"
+        );
+        let attempts_after_work = reconcile_attempt_count(&conn);
+        let started_meta_after_work =
+            reconcile_meta_value(&conn, LAST_EMBEDDING_RECONCILE_STARTED_META)
+                .expect("working reconcile writes started meta");
+
+        reset_estimated_reconcile_job_calls();
+        let report = reconcile_with_options_progress(
+            &conn,
+            ReconcileOptions {
+                max_seconds: Some(30),
+                provision_remote: false,
+                ..ReconcileOptions::default()
+            },
+            std::mem::drop,
+        )
+        .unwrap();
+
+        assert_eq!(report.status, "Current");
+        assert_eq!(report.processed_chunks, 0);
+        assert_eq!(report.embeddings_written, 0);
+        assert_eq!(
+            estimated_reconcile_job_calls(),
+            1,
+            "automatic no-op reconcile needs only the preflight estimate"
+        );
+        assert_eq!(
+            reconcile_attempt_count(&conn),
+            attempts_after_work,
+            "automatic no-op reconcile must not append write-heavy attempt rows"
+        );
+        assert_eq!(
+            reconcile_meta_value(&conn, LAST_EMBEDDING_RECONCILE_STARTED_META),
+            Some(started_meta_after_work),
+            "automatic no-op reconcile must not dirty reconcile meta"
+        );
+    }
+
+    #[test]
     fn remote_reconcile_scopes_request_failure_to_remote_request_batch() {
         let conn = schema_conn();
         let spec = spec(FASTEMBED_MODEL_ID).unwrap();
@@ -1526,6 +1695,13 @@ mod freshness_version_tests {
         set_repo_meta(&conn, ACTIVE_EMBEDDING_MODEL_META, FASTEMBED_MODEL_ID).unwrap();
         set_repo_meta(&conn, ACTIVE_EMBEDDING_MODEL_VERSION_META, spec.version).unwrap();
         set_repo_meta(&conn, ACTIVE_EMBEDDING_REMOTE_CONFIG_META, "{not valid json").unwrap();
+        assert!(
+            !automatic_reconcile_can_skip_noop(&conn, &ReconcileOptions {
+                max_seconds: Some(1),
+                ..ReconcileOptions::default()
+            },),
+            "malformed remote meta fails the automatic no-op preflight closed"
+        );
 
         let report =
             reconcile_with_options_progress(&conn, ReconcileOptions::default(), |_| {}).unwrap();
@@ -1539,6 +1715,21 @@ mod freshness_version_tests {
             )
             .unwrap();
         assert_eq!(attempt_status, "Blocked");
+    }
+
+    #[test]
+    fn automatic_reconcile_continues_when_preflight_estimate_errors() {
+        let conn = schema_conn();
+        install_model(&conn, HASH_MODEL_ID, None).expect("hash installs");
+        conn.execute("DROP TABLE chunks", []).unwrap();
+
+        let err = reconcile_with_options_progress(
+            &conn,
+            ReconcileOptions { max_seconds: Some(1), ..ReconcileOptions::default() },
+            std::mem::drop,
+        )
+        .expect_err("the later reconcile estimate should report the broken schema");
+        assert!(err.to_string().contains("chunks"));
     }
 
     #[test]
@@ -1885,6 +2076,21 @@ mod freshness_version_tests {
         activate_ephemeral_with_query_endpoint(&conn, Some(&closed));
         seed_embedding_chunk(&conn, 1);
         assert!(matches!(ephemeral_light_acquire(&conn), ChunkEmbedder::SkipEphemeral));
+    }
+
+    #[test]
+    fn automatic_noop_scan_is_not_used_for_ephemeral_query_endpoint() {
+        let conn = schema_conn();
+        activate_ephemeral_with_query_endpoint(&conn, Some("http://127.0.0.1:9"));
+
+        assert!(
+            !automatic_reconcile_can_skip_noop(&conn, &ReconcileOptions {
+                max_seconds: Some(1),
+                provision_remote: false,
+                ..ReconcileOptions::default()
+            }),
+            "ephemeral light passes must probe query_endpoint before any O(repo) no-op scan"
+        );
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/ai/reconcile/status.rs
+++ b/crates/rag-rat-core/src/index/ai/reconcile/status.rs
@@ -40,21 +40,75 @@ pub(crate) fn status(conn: &Connection) -> anyhow::Result<LlmStatus> {
 /// is ready (nothing to retry) rather than erroring — the watcher must not abort a pass over a
 /// missing embedder.
 pub(crate) fn pending_embedding_jobs(conn: &Connection) -> anyhow::Result<u64> {
-    ensure_model_manifest(conn)?;
-    let model_id = active_embedding_model_id(conn)?;
-    let model = model(conn, &model_id)?;
-    if validate_ready_model(&model).is_err() {
+    pending_embedding_jobs_with_options(conn, &ReconcileOptions::default())
+}
+
+pub(crate) fn pending_embedding_jobs_with_options(
+    conn: &Connection,
+    options: &ReconcileOptions,
+) -> anyhow::Result<u64> {
+    let Some((model_id, model_version, dim, max_embedding_chars)) =
+        ready_embedding_scan_parts(conn, options)?
+    else {
         return Ok(0);
-    }
-    let model_version = active_embedding_model_version(conn, &model_id)?;
-    let dim = usize::try_from(model.embedding_dim.unwrap_or_default()).unwrap_or(0);
+    };
     let scan = EmbeddingScan {
         model_id: &model_id,
         model_version: &model_version,
         dim,
-        max_embedding_chars: DEFAULT_MAX_EMBEDDING_CHARS,
+        max_embedding_chars,
     };
-    estimated_reconcile_jobs(conn, &scan, &ReconcileOptions::default())
+    estimated_reconcile_jobs(conn, &scan, options)
+}
+
+/// Count pending work for watcher backlog retries, but first prove an ephemeral incremental pass
+/// can actually embed. Without this guard, an absent/down local `query_endpoint` pays the O(repo)
+/// candidate scan on every startup only to have reconcile immediately return `SkipEphemeral`.
+pub(crate) fn pending_embedding_jobs_with_available_incremental_embedder(
+    conn: &Connection,
+    options: &ReconcileOptions,
+) -> anyhow::Result<u64> {
+    let Some(remote) = active_remote_config(conn)? else {
+        return pending_embedding_jobs_with_options(conn, options);
+    };
+    if !remote.is_ephemeral() {
+        return pending_embedding_jobs_with_options(conn, options);
+    }
+    let Some((model_id, model_version, dim, max_embedding_chars)) =
+        ready_embedding_scan_parts(conn, options)?
+    else {
+        return Ok(0);
+    };
+    let scan = EmbeddingScan {
+        model_id: &model_id,
+        model_version: &model_version,
+        dim,
+        max_embedding_chars,
+    };
+    let mut light_options = options.clone();
+    light_options.provision_remote = false;
+    match acquire_chunk_embedder(conn, light_options.intra_threads, &scan, &light_options) {
+        ChunkEmbedder::Ready { .. } => estimated_reconcile_jobs(conn, &scan, &light_options),
+        ChunkEmbedder::SkipEphemeral
+        | ChunkEmbedder::NoEphemeralWork
+        | ChunkEmbedder::NotReady(_) => Ok(0),
+    }
+}
+
+fn ready_embedding_scan_parts(
+    conn: &Connection,
+    options: &ReconcileOptions,
+) -> anyhow::Result<Option<(String, String, usize, usize)>> {
+    ensure_model_manifest(conn)?;
+    let model_id = active_embedding_model_id(conn)?;
+    let model = model(conn, &model_id)?;
+    if validate_ready_model(&model).is_err() {
+        return Ok(None);
+    }
+    let model_version = active_embedding_model_version(conn, &model_id)?;
+    let dim = usize::try_from(model.embedding_dim.unwrap_or_default()).unwrap_or(0);
+    let max_embedding_chars = options.max_embedding_chars.max(MIN_EMBEDDING_CHARS);
+    Ok(Some((model_id, model_version, dim, max_embedding_chars)))
 }
 
 pub(crate) fn reconcile_plan(conn: &Connection) -> anyhow::Result<ReconcilePlan> {

--- a/crates/rag-rat-core/src/index/ai/store.rs
+++ b/crates/rag-rat-core/src/index/ai/store.rs
@@ -1,6 +1,22 @@
 use super::*;
 use crate::index::text_compression::{ChunkTextDecoder, ChunkTextRow};
 
+#[cfg(test)]
+thread_local! {
+    pub(crate) static ESTIMATED_RECONCILE_JOBS_CALLS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_estimated_reconcile_job_calls() {
+    ESTIMATED_RECONCILE_JOBS_CALLS.with(|calls| calls.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn estimated_reconcile_job_calls() -> usize {
+    ESTIMATED_RECONCILE_JOBS_CALLS.with(std::cell::Cell::get)
+}
+
 /// Map one candidate row to its `CurrentChunk` (with a placeholder `text`) plus the
 /// [`ChunkTextRow`] carrying the chunk's stored text (the compressed `chunk_text` blob + `raw_len`;
 /// the `chunks.text` column is gone, so the SELECT INNER JOINs `chunk_text`). The real `text` is
@@ -222,6 +238,9 @@ pub(crate) fn estimated_reconcile_jobs(
     scan: &EmbeddingScan<'_>,
     options: &ReconcileOptions,
 ) -> anyhow::Result<u64> {
+    #[cfg(test)]
+    ESTIMATED_RECONCILE_JOBS_CALLS.with(|calls| calls.set(calls.get().saturating_add(1)));
+
     // STREAM the candidates and count — never materialize EVERY candidate's decompressed text into
     // a `Vec` just to size the backlog (#64 audit; mirrors the streamed
     // `embedding_reconcile_plan`, #379). This runs on the watcher/maintenance gate

--- a/crates/rag-rat-core/src/index/consolidate.rs
+++ b/crates/rag-rat-core/src/index/consolidate.rs
@@ -80,9 +80,9 @@ use crate::{data_dir, locks};
 ///  (b) DB-LOCAL STATE — never copied; each entry states why:
 ///      * freshness/progress cursors that would make a fresh 0-row index falsely report itself
 ///        current: `content_revision`, `git_commit`, `git_dirty`, `git_history_indexed_head` /
-///        `_root` / `_shallow`, `github_last_sync_ms`, `graph_index_version`, `indexed_at_ms`,
-///        `vector_int8_reencode_done` / `_cursor`, `last_embedding_reconcile_started_at_ms` /
-///        `_finished_at_ms`;
+///        `_root` / `_shallow` / `_complete`, `github_last_sync_ms`, `graph_index_version`,
+///        `indexed_at_ms`, `vector_int8_reencode_done` / `_cursor`,
+///        `last_embedding_reconcile_started_at_ms` / `_finished_at_ms`;
 ///      * pointers/state owned by THIS database file's lifecycle: `live_files_generation` (absent ⇒
 ///        0 is load-bearing — A6), `clone_graph_live_generation`, `shallow_boundary` (adoption
 ///        proof for the legacy file's own registry), `source_root` (re-recorded by registration);

--- a/crates/rag-rat-core/src/index/file_rows.rs
+++ b/crates/rag-rat-core/src/index/file_rows.rs
@@ -242,4 +242,45 @@ impl IndexDatabase {
                 .query_row("SELECT COUNT(*) FROM files", [], |row| row.get::<_, i64>(0))?;
         Ok(usize::try_from(count).unwrap_or(usize::MAX))
     }
+
+    pub(super) fn repo_generation_file_count(
+        &self,
+        include_retained_commit_fallback: bool,
+    ) -> anyhow::Result<usize> {
+        let count = self.storage.connection().query_row(
+            "SELECT COUNT(*) FROM (
+                 SELECT path FROM main.files
+                 WHERE repo_id = ?1 AND generation = ?2
+                   AND worktree_id = ?3 AND worktree_id != '' AND kind != 'deleted'
+                 UNION
+                 SELECT path FROM main.files
+                 WHERE repo_id = ?1 AND generation = ?2
+                   AND worktree_id = '' AND kind != 'deleted'
+                   AND (
+                       commit_sha = ?4
+                       OR (
+                           ?5 AND ?4 != '' AND commit_sha != '' AND NOT EXISTS (
+                               SELECT 1 FROM main.files
+                               WHERE repo_id = ?1 AND generation = ?2
+                                 AND worktree_id = '' AND commit_sha = ?4 AND kind != 'deleted'
+                           )
+                       )
+                   )
+                   AND path NOT IN (
+                       SELECT path FROM main.files
+                       WHERE repo_id = ?1 AND generation = ?2
+                         AND worktree_id = ?3 AND worktree_id != ''
+                   )
+             )",
+            params![
+                self.active_repo_id,
+                self.active_generation,
+                self.active_worktree_id,
+                self.active_commit_sha,
+                include_retained_commit_fallback,
+            ],
+            |row| row.get::<_, i64>(0),
+        )?;
+        Ok(usize::try_from(count).unwrap_or(usize::MAX))
+    }
 }

--- a/crates/rag-rat-core/src/index/git_history.rs
+++ b/crates/rag-rat-core/src/index/git_history.rs
@@ -10,6 +10,11 @@ use sha2::{Digest, Sha256};
 use crate::index::{delete_repo_meta, repo_meta, schema, scoped_table_row_count, set_repo_meta};
 use crate::search::lexical::SearchHit;
 
+const GIT_HISTORY_INDEXED_HEAD_META: &str = "git_history_indexed_head";
+const GIT_HISTORY_INDEXED_ROOT_META: &str = "git_history_indexed_root";
+const GIT_HISTORY_INDEXED_SHALLOW_META: &str = "git_history_indexed_shallow";
+const GIT_HISTORY_INDEXED_COMPLETE_META: &str = "git_history_indexed_complete";
+
 #[derive(Debug, Clone, Serialize)]
 pub struct GitHistoryIndexStatus {
     pub available: bool,
@@ -118,36 +123,136 @@ struct FileChange {
 }
 
 #[derive(Debug)]
+struct ReadGitHistory {
+    commits: Vec<CommitRecord>,
+    changes: Vec<FileChange>,
+    complete: bool,
+}
+
+#[derive(Debug)]
 pub(crate) struct PreparedGitHistory {
     repo: Option<GitRepo>,
     commits: Vec<CommitRecord>,
     changes: Vec<FileChange>,
+    complete: bool,
+    mode: PreparedGitHistoryMode,
+}
+
+#[derive(Debug)]
+enum PreparedGitHistoryMode {
+    Full,
+    Append { expected: HistoryCursors },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum GitHistoryPreparePlan {
+    Full,
+    Append { expected: HistoryCursors },
 }
 
 pub(crate) fn prepare(root: &Path) -> anyhow::Result<PreparedGitHistory> {
     let Some(repo) = git_repo(root) else {
-        return Ok(PreparedGitHistory { repo: None, commits: Vec::new(), changes: Vec::new() });
+        return Ok(PreparedGitHistory {
+            repo: None,
+            commits: Vec::new(),
+            changes: Vec::new(),
+            complete: true,
+            mode: PreparedGitHistoryMode::Full,
+        });
     };
     // One streaming gix revwalk pinned to the captured HEAD produces both the commit records and
     // their file changes — no `git log` subprocess and no full-history stdout buffer, so memory
     // stays bounded on deep-history repos (#212). Pinning to the captured sha (not implicit HEAD)
     // keeps `prepare` atomic w.r.t. a concurrent commit, so the stored `git_history_indexed_head`
     // stays honest for the reload gate.
-    let (commits, changes) = read_history(root, &repo.worktree_root, &repo.head);
-    Ok(PreparedGitHistory { repo: Some(repo), commits, changes })
+    let history = read_history(root, &repo.worktree_root, &repo.head);
+    Ok(PreparedGitHistory {
+        repo: Some(repo),
+        commits: history.commits,
+        changes: history.changes,
+        complete: history.complete,
+        mode: PreparedGitHistoryMode::Full,
+    })
 }
 
-/// The history reload-gate CURSOR values (`git_history_indexed_head`/`_root`/`_shallow`) a row
-/// apply produces, held back for a deferred write (A6, batch-4 P2). The git rows themselves are
-/// keyed, INERT data — `is_history_current` and `status` treat the CURSORS as the authority, never
-/// bare row presence — so a generation-staged rebuild lands the bulky rows early (Phase 2) and
-/// writes these cursors inside the terminal flip transaction, keeping "what commit is this index
-/// at" consistent with the file generation the pointer publishes. `None` cursors = a non-git root
-/// (the apply cleared the tables; nothing to record).
+pub(crate) fn prepare_with_plan(
+    root: &Path,
+    plan: GitHistoryPreparePlan,
+) -> anyhow::Result<PreparedGitHistory> {
+    match plan {
+        GitHistoryPreparePlan::Full => prepare(root),
+        GitHistoryPreparePlan::Append { expected } => prepare_append(root, expected),
+    }
+}
+
+fn prepare_append(root: &Path, expected: HistoryCursors) -> anyhow::Result<PreparedGitHistory> {
+    let Some(repo) = git_repo(root) else {
+        return Ok(PreparedGitHistory {
+            repo: None,
+            commits: Vec::new(),
+            changes: Vec::new(),
+            complete: true,
+            mode: PreparedGitHistoryMode::Full,
+        });
+    };
+    if expected.complete
+        && !repo.shallow
+        && root_key(root) == expected.root_key
+        && is_fast_forward(root, &expected.head, &repo.head)
+        && let Ok(history) =
+            read_history_excluding(root, &repo.worktree_root, &repo.head, &expected.head)
+        && history.complete
+    {
+        return Ok(PreparedGitHistory {
+            repo: Some(repo),
+            commits: history.commits,
+            changes: history.changes,
+            complete: true,
+            mode: PreparedGitHistoryMode::Append { expected },
+        });
+    }
+    prepare(root)
+}
+
+pub(crate) fn prepare_plan(conn: &Connection, root: &Path) -> GitHistoryPreparePlan {
+    let Some(repo) = git_repo(root) else {
+        return GitHistoryPreparePlan::Full;
+    };
+    if repo.shallow {
+        return GitHistoryPreparePlan::Full;
+    }
+    let probe = || -> anyhow::Result<GitHistoryPreparePlan> {
+        let repo_id = schema::active_repo_id(conn)?;
+        let expected = history_cursors(conn, &repo_id)?
+            .ok_or_else(|| anyhow::anyhow!("missing git history cursor"))?;
+        let has_rows = scoped_table_row_count(conn, "git_commits", &repo_id)? > 0;
+        if !has_rows
+            || expected.head == repo.head
+            || expected.root_key != root_key(root)
+            || expected.shallow
+            || !is_fast_forward(root, &expected.head, &repo.head)
+        {
+            return Ok(GitHistoryPreparePlan::Full);
+        }
+        Ok(GitHistoryPreparePlan::Append { expected })
+    };
+    probe().unwrap_or(GitHistoryPreparePlan::Full)
+}
+
+/// The history reload-gate CURSOR values (`git_history_indexed_head`/`_root`/`_shallow` plus
+/// `_complete`) a row apply produces, held back for a deferred write (A6, batch-4 P2). The git rows
+/// themselves are keyed, INERT data — `is_history_current` and `status` treat the CURSORS as the
+/// authority, never bare row presence — so a generation-staged rebuild lands the bulky rows early
+/// (Phase 2) and writes these cursors inside the terminal flip transaction, keeping "what commit is
+/// this index at" consistent with the file generation the pointer publishes. `complete=false`
+/// records a best-effort partial read that may be useful to inspect but must not be used as an
+/// append base. `None` cursors = a non-git root (the apply cleared the tables; nothing to record).
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct HistoryCursors {
     head: String,
     root_key: String,
     shallow: bool,
+    complete: bool,
 }
 
 /// Write the reload-gate cursors — the LAST step of a history apply, split out so the full
@@ -158,14 +263,16 @@ pub(crate) fn record_history_cursors(
     cursors: &HistoryCursors,
 ) -> anyhow::Result<()> {
     let repo_id = schema::active_repo_id(conn)?;
-    set_repo_meta(conn, &repo_id, "git_history_indexed_head", &cursors.head)?;
-    set_repo_meta(conn, &repo_id, "git_history_indexed_root", &cursors.root_key)?;
+    set_repo_meta(conn, &repo_id, GIT_HISTORY_INDEXED_HEAD_META, &cursors.head)?;
+    set_repo_meta(conn, &repo_id, GIT_HISTORY_INDEXED_ROOT_META, &cursors.root_key)?;
     set_repo_meta(
         conn,
         &repo_id,
-        "git_history_indexed_shallow",
+        GIT_HISTORY_INDEXED_SHALLOW_META,
         if cursors.shallow { "1" } else { "0" },
     )?;
+    let complete = if cursors.complete { "1" } else { "0" };
+    set_repo_meta(conn, &repo_id, GIT_HISTORY_INDEXED_COMPLETE_META, complete)?;
     Ok(())
 }
 
@@ -194,18 +301,128 @@ pub(crate) fn apply_prepared_deferring_cursors(
         return Ok((status(conn, root)?, None));
     };
 
+    let repo_id = schema::active_repo_id(conn)?;
+    let mut applied_cursors = HistoryCursors {
+        head: repo.head.clone(),
+        root_key: root_key(root),
+        shallow: repo.shallow,
+        complete: prepared.complete,
+    };
+
+    match prepared.mode {
+        PreparedGitHistoryMode::Append { ref expected }
+            if prepared.complete
+                && expected_history_cursors_match(conn, &repo_id, expected)?
+                && append_commit_hashes_absent(conn, &repo_id, &prepared.commits)? =>
+        {
+            append_history_rows(conn, &repo_id, &prepared.commits, prepared.changes)?;
+        },
+        PreparedGitHistoryMode::Append { .. } => {
+            if let Some(cursors) =
+                current_history_cursors_at_or_after_prepared(conn, &repo_id, root, &repo)?
+            {
+                return Ok((status(conn, root)?, Some(cursors)));
+            }
+            let Some(current_repo) = git_repo(root) else {
+                clear(conn)?;
+                return Ok((status(conn, root)?, None));
+            };
+            applied_cursors = HistoryCursors {
+                head: current_repo.head.clone(),
+                root_key: root_key(root),
+                shallow: current_repo.shallow,
+                complete: true,
+            };
+            let history = read_history(root, &current_repo.worktree_root, &current_repo.head);
+            applied_cursors.complete = history.complete;
+            replace_history_rows(conn, &repo_id, &history.commits, history.changes)?;
+        },
+        PreparedGitHistoryMode::Full => {
+            replace_history_rows(conn, &repo_id, &prepared.commits, prepared.changes)?;
+        },
+    }
+
+    // Reload-gate key: head + root + shallow flag + completeness. `is_history_current` skips the
+    // next reload only when the complete cursor matches and git_commits is non-empty. Returned for
+    // the caller to record — immediately (`apply_prepared`) or deferred into the rebuild's terminal
+    // txn.
+    Ok((status(conn, root)?, Some(applied_cursors)))
+}
+
+fn replace_history_rows(
+    conn: &Connection,
+    repo_id: &str,
+    commits: &[CommitRecord],
+    changes: Vec<FileChange>,
+) -> anyhow::Result<()> {
     // `git_commits` / `git_file_changes` are direct-scoped since V040, so a history reindex of ONE
     // repo must delete and re-insert only THAT repo's rows — a wholesale wipe would drop a sibling
     // repo's commits in a consolidated DB. `git_chunk_blame` is transitive via `chunks`/`files`, so
     // it is cleared through the active repo's chunks (A4): a history reindex invalidates blame for
     // this whole repo (new commits change attribution), but must not touch a sibling repo's cache.
     // `commit_fts` is external-content over `git_commits` and is resynced below.
-    let repo_id = schema::active_repo_id(conn)?;
     conn.execute("DELETE FROM git_file_changes WHERE repo_id = ?1", params![repo_id])?;
     conn.execute("DELETE FROM git_commits WHERE repo_id = ?1", params![repo_id])?;
-    delete_repo_chunk_blame(conn, &repo_id)?;
+    delete_repo_chunk_blame(conn, repo_id)?;
+    insert_history_rows(conn, repo_id, commits, changes)?;
 
-    for commit in &prepared.commits {
+    // Resync the external-content FTS from `git_commits` with the desync-safe `'rebuild'` (#51),
+    // never a `DELETE FROM commit_fts` + manual repopulate — the reinserted commit rows took new
+    // rowids, so the stored mapping is stale. `'rebuild'` re-indexes all repos' commits, keeping
+    // every repo searchable.
+    crate::index::schema::rebuild_commit_fts(conn)?;
+    Ok(())
+}
+
+fn append_history_rows(
+    conn: &Connection,
+    repo_id: &str,
+    commits: &[CommitRecord],
+    changes: Vec<FileChange>,
+) -> anyhow::Result<()> {
+    if commits.is_empty() {
+        debug_assert!(changes.is_empty(), "append changes must belong to appended commits");
+        // The history cursor may still advance for an out-of-scope fast-forward. Since existing
+        // `git_commits` rows are preserved, rebuild the external-content FTS so any prior desync
+        // is not carried past the new cursor.
+        crate::index::schema::rebuild_commit_fts(conn)?;
+        return Ok(());
+    }
+    // V1 keeps blame invalidation whole-repo even on append. Scoping by touched paths is a
+    // follow-up because merge commits' first-parent diff paths are used for scope but are not
+    // stored as `git_file_changes` rows.
+    delete_repo_chunk_blame(conn, repo_id)?;
+    insert_history_rows(conn, repo_id, commits, changes)?;
+    // External-content FTS can be missing or stale independently of `git_commits`. A fast-forward
+    // append preserves existing rows, but still has to run the desync-safe rebuild so older
+    // commits do not stay unsearchable until a later full history reload.
+    crate::index::schema::rebuild_commit_fts(conn)?;
+    Ok(())
+}
+
+fn append_commit_hashes_absent(
+    conn: &Connection,
+    repo_id: &str,
+    commits: &[CommitRecord],
+) -> anyhow::Result<bool> {
+    let mut stmt =
+        conn.prepare("SELECT EXISTS(SELECT 1 FROM git_commits WHERE repo_id = ?1 AND hash = ?2)")?;
+    for commit in commits {
+        let exists: bool = stmt.query_row(params![repo_id, commit.hash], |row| row.get(0))?;
+        if exists {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn insert_history_rows(
+    conn: &Connection,
+    repo_id: &str,
+    commits: &[CommitRecord],
+    changes: Vec<FileChange>,
+) -> anyhow::Result<()> {
+    for commit in commits {
         conn.execute(
             "INSERT INTO git_commits(hash, author_name, author_email, authored_at_s, \
              committed_at_s, subject, body, changed_file_count, repo_id)
@@ -224,7 +441,7 @@ pub(crate) fn apply_prepared_deferring_cursors(
     }
 
     let mut changed_counts = BTreeMap::<String, i64>::new();
-    for change in prepared.changes {
+    for change in changes {
         *changed_counts.entry(change.commit_hash.clone()).or_default() += 1;
         conn.execute(
             "INSERT INTO git_file_changes(commit_hash, path, additions, deletions, change_kind, \
@@ -246,18 +463,67 @@ pub(crate) fn apply_prepared_deferring_cursors(
             params![hash, count, repo_id],
         )?;
     }
+    Ok(())
+}
 
-    // Resync the external-content FTS from `git_commits` with the desync-safe `'rebuild'` (#51),
-    // never a `DELETE FROM commit_fts` + manual repopulate — the reinserted commit rows took new
-    // rowids, so the stored mapping is stale. `'rebuild'` re-indexes all repos' commits, keeping
-    // every repo searchable.
-    crate::index::schema::rebuild_commit_fts(conn)?;
-    // Reload-gate key: head + root + shallow flag. `is_history_current` skips the next reload
-    // only when all three still match and git_commits is non-empty. Returned for the caller to
-    // record — immediately (`apply_prepared`) or deferred into the rebuild's terminal txn.
-    let cursors =
-        HistoryCursors { head: repo.head.clone(), root_key: root_key(root), shallow: repo.shallow };
-    Ok((status(conn, root)?, Some(cursors)))
+fn raw_history_cursors(conn: &Connection, repo_id: &str) -> anyhow::Result<Option<HistoryCursors>> {
+    let Some(head) = repo_meta(conn, repo_id, GIT_HISTORY_INDEXED_HEAD_META)? else {
+        return Ok(None);
+    };
+    let Some(root_key) = repo_meta(conn, repo_id, GIT_HISTORY_INDEXED_ROOT_META)? else {
+        return Ok(None);
+    };
+    let Some(shallow) = repo_meta(conn, repo_id, GIT_HISTORY_INDEXED_SHALLOW_META)? else {
+        return Ok(None);
+    };
+    let shallow = match shallow.as_str() {
+        "0" => false,
+        "1" => true,
+        _ => return Ok(None),
+    };
+    let Some(complete) = repo_meta(conn, repo_id, GIT_HISTORY_INDEXED_COMPLETE_META)? else {
+        return Ok(None);
+    };
+    let complete = match complete.as_str() {
+        "0" => false,
+        "1" => true,
+        _ => return Ok(None),
+    };
+    Ok(Some(HistoryCursors { head, root_key, shallow, complete }))
+}
+
+fn history_cursors(conn: &Connection, repo_id: &str) -> anyhow::Result<Option<HistoryCursors>> {
+    Ok(raw_history_cursors(conn, repo_id)?.filter(|cursor| cursor.complete))
+}
+
+fn expected_history_cursors_match(
+    conn: &Connection,
+    repo_id: &str,
+    expected: &HistoryCursors,
+) -> anyhow::Result<bool> {
+    let has_rows = scoped_table_row_count(conn, "git_commits", repo_id)? > 0;
+    Ok(has_rows && history_cursors(conn, repo_id)?.as_ref() == Some(expected))
+}
+
+fn current_history_cursors_at_or_after_prepared(
+    conn: &Connection,
+    repo_id: &str,
+    root: &Path,
+    repo: &GitRepo,
+) -> anyhow::Result<Option<HistoryCursors>> {
+    if scoped_table_row_count(conn, "git_commits", repo_id)? == 0 {
+        return Ok(None);
+    }
+    let Some(current) = history_cursors(conn, repo_id)? else {
+        return Ok(None);
+    };
+    if current.root_key != root_key(root) || current.shallow != repo.shallow {
+        return Ok(None);
+    }
+    if current.head == repo.head || is_fast_forward(root, &repo.head, &current.head) {
+        return Ok(Some(current));
+    }
+    Ok(None)
 }
 
 pub fn index(conn: &Connection, root: &Path) -> anyhow::Result<GitHistoryIndexStatus> {
@@ -276,7 +542,7 @@ pub fn status(conn: &Connection, root: &Path) -> anyhow::Result<GitHistoryIndexS
     Ok(GitHistoryIndexStatus {
         available: repo.is_some(),
         head: repo.map(|repo| repo.head),
-        indexed_head: repo_meta(conn, &repo_id, "git_history_indexed_head")?,
+        indexed_head: repo_meta(conn, &repo_id, GIT_HISTORY_INDEXED_HEAD_META)?,
         commit_count,
         file_change_count,
     })
@@ -679,9 +945,12 @@ fn clear(conn: &Connection) -> anyhow::Result<()> {
     delete_repo_chunk_blame(conn, &repo_id)?;
     crate::index::schema::rebuild_commit_fts(conn)?;
     // The reload-gate keys moved to `repo_meta` (V039); clear them for the active repo.
-    for key in
-        ["git_history_indexed_head", "git_history_indexed_root", "git_history_indexed_shallow"]
-    {
+    for key in [
+        GIT_HISTORY_INDEXED_HEAD_META,
+        GIT_HISTORY_INDEXED_ROOT_META,
+        GIT_HISTORY_INDEXED_SHALLOW_META,
+        GIT_HISTORY_INDEXED_COMPLETE_META,
+    ] {
         delete_repo_meta(conn, &repo_id, key)?;
     }
     Ok(())
@@ -691,25 +960,42 @@ fn clear(conn: &Connection) -> anyhow::Result<()> {
 /// and their per-file changes in a SINGLE streaming pass — no `git log` subprocess and no
 /// full-history stdout buffer, so memory stays bounded on deep-history repos (#212). Best-effort: a
 /// repo gix can't open, or a commit it can't read, yields fewer rows rather than failing the whole
-/// index (matching the previous subprocess path's graceful degradation).
-fn read_history(
+/// index, but marks the result incomplete so it cannot become an append base.
+fn read_history(root: &Path, worktree_root: &Path, head: &str) -> ReadGitHistory {
+    let mut commits = Vec::new();
+    let mut changes = Vec::new();
+    let complete = read_history_inner(root, worktree_root, head, None, &mut commits, &mut changes)
+        .unwrap_or(false);
+    ReadGitHistory { commits, changes, complete }
+}
+
+fn read_history_excluding(
     root: &Path,
     worktree_root: &Path,
     head: &str,
-) -> (Vec<CommitRecord>, Vec<FileChange>) {
+    hidden_head: &str,
+) -> anyhow::Result<ReadGitHistory> {
     let mut commits = Vec::new();
     let mut changes = Vec::new();
-    let _ = read_history_inner(root, worktree_root, head, &mut commits, &mut changes);
-    (commits, changes)
+    let complete = read_history_inner(
+        root,
+        worktree_root,
+        head,
+        Some(hidden_head),
+        &mut commits,
+        &mut changes,
+    )?;
+    Ok(ReadGitHistory { commits, changes, complete })
 }
 
 fn read_history_inner(
     root: &Path,
     worktree_root: &Path,
     head: &str,
+    hidden_head: Option<&str>,
     commits: &mut Vec<CommitRecord>,
     changes: &mut Vec<FileChange>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<bool> {
     let mut repo = crate::index::git_context::discover_repo(root)?;
     // The by-commit-time walk + per-commit tree diffs look up each commit/tree more than once; an
     // object cache avoids repeated zlib inflation (gitoxide's own recommendation for these passes).
@@ -725,13 +1011,20 @@ fn read_history_inner(
     let walk = repo
         .rev_walk([head_id])
         // Newest-first, matching `git log`'s default reverse-chronological order.
-        .sorting(Sorting::ByCommitTime(gix::traverse::commit::simple::CommitTimeOrder::NewestFirst))
-        .all()?;
+        .sorting(Sorting::ByCommitTime(gix::traverse::commit::simple::CommitTimeOrder::NewestFirst));
+    let walk = match hidden_head {
+        Some(hidden_head) => {
+            let hidden_id = gix::ObjectId::from_hex(hidden_head.as_bytes())?;
+            walk.with_hidden([hidden_id])
+        },
+        None => walk,
+    }
+    .all()?;
     for info in walk {
         // A walk error (e.g. traversing past a shallow clone's boundary into absent objects) ends
         // the walk with what we have, rather than discarding the whole history (#213 review).
-        let Ok(info) = info else { break };
-        let Ok(commit) = repo.find_commit(info.id) else { break };
+        let Ok(info) = info else { return Ok(false) };
+        let Ok(commit) = repo.find_commit(info.id) else { return Ok(false) };
         let author = commit.author()?;
         let committer = commit.committer()?;
         let body = commit.message_raw_sloppy().to_string();
@@ -796,7 +1089,7 @@ fn read_history_inner(
             changes.append(&mut commit_changes);
         }
     }
-    Ok(())
+    Ok(true)
 }
 
 /// Record one tree-diff change as a `FileChange` — any leaf path change (regular blob, symlink,
@@ -976,6 +1269,18 @@ fn git_repo(root: &Path) -> Option<GitRepo> {
     Some(GitRepo { worktree_root, head, shallow })
 }
 
+fn is_fast_forward(root: &Path, old_head: &str, new_head: &str) -> bool {
+    let probe = || -> anyhow::Result<bool> {
+        let mut repo = crate::index::git_context::discover_repo(root)?;
+        repo.object_cache_size_if_unset(16 * 1024 * 1024);
+        let old_id = gix::ObjectId::from_hex(old_head.as_bytes())?;
+        let new_id = gix::ObjectId::from_hex(new_head.as_bytes())?;
+        let merge_base = repo.merge_base(old_id, new_id)?;
+        Ok(merge_base.detach() == old_id)
+    };
+    probe().unwrap_or(false)
+}
+
 /// Canonical serialization of the indexed root for the reload gate. The git-history row set is
 /// a function of (HEAD, root) because the `-- .` pathspec runs in `current_dir(root)`, so the
 /// gate stores and compares the root alongside the head sha.
@@ -1002,18 +1307,16 @@ pub(crate) fn is_history_current(conn: &Connection, root: &Path) -> bool {
     }
     let probe = || -> anyhow::Result<bool> {
         let repo_id = schema::active_repo_id(conn)?;
-        let head_matches = repo_meta(conn, &repo_id, "git_history_indexed_head")?.as_deref()
-            == Some(repo.head.as_str());
-        let root_matches = repo_meta(conn, &repo_id, "git_history_indexed_root")?.as_deref()
-            == Some(root_key(root).as_str());
-        // A prior reload done while shallow only saw truncated history; redo it now that we are
-        // not shallow even if HEAD is unchanged.
-        let prior_was_full =
-            repo_meta(conn, &repo_id, "git_history_indexed_shallow")?.as_deref() == Some("0");
+        let Some(cursors) = history_cursors(conn, &repo_id)? else {
+            return Ok(false);
+        };
         // Guard against a torn/empty prior reload writing the meta without rows — counted per-repo
         // (V040), so a sibling repo's commits can't mask THIS repo's empty history.
         let has_rows = scoped_table_row_count(conn, "git_commits", &repo_id)? > 0;
-        Ok(head_matches && root_matches && prior_was_full && has_rows)
+        Ok(cursors.head == repo.head
+            && cursors.root_key == root_key(root)
+            && !cursors.shallow
+            && has_rows)
     };
     probe().unwrap_or(false)
 }
@@ -1039,4 +1342,109 @@ fn hex_sha256(bytes: &[u8]) -> String {
 
 fn path_string(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::process::Command;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+
+    static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_root(label: &str) -> PathBuf {
+        let id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("ragrat-git-history-{label}-{}-{id}", std::process::id()))
+    }
+
+    fn run_git(root: &Path, args: &[&str]) {
+        let status = Command::new("git").current_dir(root).args(args).status().unwrap();
+        assert!(status.success(), "git {args:?} failed");
+    }
+
+    fn git_output(root: &Path, args: &[&str]) -> String {
+        let output = Command::new("git").current_dir(root).args(args).output().unwrap();
+        assert!(output.status.success(), "git {args:?} failed");
+        String::from_utf8(output.stdout).unwrap().trim().to_string()
+    }
+
+    fn insert_commit_row(conn: &Connection, repo_id: &str, hash: &str) {
+        conn.execute(
+            "INSERT INTO git_commits(hash, author_name, author_email, authored_at_s,
+             committed_at_s, subject, body, changed_file_count, repo_id)
+             VALUES (?1, 'Test', 'test@example.com', 0, 0, 'subject', '', 0, ?2)",
+            params![hash, repo_id],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn current_history_cursor_guard_rejects_empty_incomplete_or_wrong_scope() {
+        let root = temp_root("cursor-guard");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let conn = Connection::open_in_memory().unwrap();
+        schema::apply(&conn).unwrap();
+        let repo_id = "repo";
+        conn.execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES (?1, 'repo', 0)",
+            params![repo_id],
+        )
+        .unwrap();
+        let repo = GitRepo {
+            worktree_root: root.clone(),
+            head: "prepared-head".to_string(),
+            shallow: false,
+        };
+
+        assert!(
+            current_history_cursors_at_or_after_prepared(&conn, repo_id, &root, &repo)
+                .unwrap()
+                .is_none(),
+            "empty history rows are never current"
+        );
+
+        insert_commit_row(&conn, repo_id, "existing-head");
+        assert!(
+            current_history_cursors_at_or_after_prepared(&conn, repo_id, &root, &repo)
+                .unwrap()
+                .is_none(),
+            "rows without a complete cursor are never current"
+        );
+
+        set_repo_meta(&conn, repo_id, GIT_HISTORY_INDEXED_HEAD_META, "existing-head").unwrap();
+        set_repo_meta(&conn, repo_id, GIT_HISTORY_INDEXED_ROOT_META, "other-root").unwrap();
+        set_repo_meta(&conn, repo_id, GIT_HISTORY_INDEXED_SHALLOW_META, "0").unwrap();
+        set_repo_meta(&conn, repo_id, GIT_HISTORY_INDEXED_COMPLETE_META, "1").unwrap();
+        assert!(
+            current_history_cursors_at_or_after_prepared(&conn, repo_id, &root, &repo)
+                .unwrap()
+                .is_none(),
+            "a cursor from another root cannot satisfy a stale prepared append"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn read_history_excluding_reports_invalid_hidden_head() {
+        let root = temp_root("invalid-hidden-head");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        run_git(&root, &["init"]);
+        run_git(&root, &["config", "user.name", "Rag Rat"]);
+        run_git(&root, &["config", "user.email", "rag@example.com"]);
+        fs::write(root.join("README.md"), "tracked\n").unwrap();
+        run_git(&root, &["add", "."]);
+        run_git(&root, &["commit", "-m", "Initial"]);
+        let head = git_output(&root, &["rev-parse", "HEAD"]);
+
+        let err = read_history_excluding(&root, &root, &head, "not-a-git-object")
+            .expect_err("invalid hidden head must be reported");
+        assert!(!err.to_string().is_empty());
+
+        let _ = fs::remove_dir_all(root);
+    }
 }

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -92,21 +92,39 @@ impl IndexDatabase {
         // fallback).
         db.ensure_graph_index_current()?;
         db.ensure_generated_flags_current()?;
-        if db.indexed_file_count()? == 0 {
+        let scoped_file_count = db.indexed_file_count()?;
+        let active_base_scope_discovered = db.active_base_scope_discovered(&config.targets)?;
+        let repo_generation_file_count =
+            db.repo_generation_file_count(!active_base_scope_discovered)?;
+        if repo_generation_file_count == 0 && !active_base_scope_discovered {
             return Self::rebuild_with_progress(config, progress).map(|db| (db, true));
         }
-        progress(IndexProgress::Started { database: config.database.clone(), mode });
-        // Gate the git-history reload: `apply_prepared` is a full `git log` re-read (O(total
-        // history) — the `--numstat` pass diffs every commit) + 4-table wipe, and it runs on EVERY
-        // incremental/watcher pass. Skip it when HEAD/root/shallow are unchanged (the common case:
-        // a file edit or idle sweep leaves history untouched). Reloading only on a real change
-        // still catches every rewrite, since HEAD's sha is content-addressed. Decide BEFORE
-        // spawning `prepare` so an unchanged HEAD never pays the `git log` cost at all.
+        // A commit advances HEAD before committed-scope rows have been stamped for it. Likewise, a
+        // target-set change can make the active scope marker stale even when the old rows still
+        // make the counts match. Neither is a complete changed-file pass: discover the tree
+        // and restamp the generation for the active HEAD/target fingerprint (#459 review).
+        let active_scope_incomplete =
+            !active_base_scope_discovered || scoped_file_count < repo_generation_file_count;
+        let effective_mode = if active_scope_incomplete && mode == IndexMode::Changed {
+            IndexMode::Discover
+        } else {
+            mode
+        };
+        progress(IndexProgress::Started {
+            database: config.database.clone(),
+            mode: effective_mode,
+        });
+        // Gate the git-history reload. Unchanged HEAD/root/shallow skips it entirely; a
+        // fast-forward HEAD prepares only the new range (`old..new`) and appends rows; uncertainty,
+        // shallow history, root drift, and non-fast-forward rewrites prepare the full history. The
+        // append plan is revalidated after BEGIN IMMEDIATE because preparation happens before this
+        // writer owns the lock.
         let mut git_history = if db.git_history_is_current(&config.root) {
             None
         } else {
             progress(IndexProgress::IndexingGitHistory);
-            Some(spawn_git_history_prepare(&config.root))
+            let plan = git_history::prepare_plan(db.storage.connection(), &config.root);
+            Some(spawn_git_history_prepare_with_plan(&config.root, plan))
         };
         let result = (|| -> anyhow::Result<bool> {
             // BEGIN IMMEDIATE: acquire the write lock up front so a racing writer waits out
@@ -140,10 +158,15 @@ impl IndexDatabase {
                     config.llm.embedding.backend.model_id(),
                 )?;
             }
-            let (indexed, manifest_in_change_set) = match mode {
+            let (indexed, manifest_in_change_set) = match effective_mode {
                 IndexMode::Changed => db.index_changed_files_with_progress(config, progress)?,
                 IndexMode::Discover => db.index_discovered_files_with_progress(config, progress)?,
                 IndexMode::Full => unreachable!("full mode is handled by rebuild_with_progress"),
+            };
+            let base_scope_discovery_marked = if effective_mode == IndexMode::Discover {
+                db.mark_active_base_scope_discovered(&config.targets)?
+            } else {
+                false
             };
             // Self-heal stale worktree-overlay rows (#87): a dirty-then-committed file's overlay
             // row otherwise lingers forever, shadowing its (correct) committed row in every
@@ -159,7 +182,8 @@ impl IndexDatabase {
                 || healed > 0
                 || source_root_changed
                 || git_meta_changed
-                || embedding_model_seeded;
+                || embedding_model_seeded
+                || base_scope_discovery_marked;
             // None when the gate above found git history already current — skip the reload.
             if let Some(handle) = git_history.take() {
                 db.apply_prepared_git_history(&config.root, handle)?;
@@ -622,5 +646,9 @@ impl IndexDatabase {
 /// incremental pass (#61, salvaging #95). Checked against both changed and deleted paths so a crate
 /// removal also triggers the refresh.
 fn paths_include_cargo_toml<'a>(mut paths: impl Iterator<Item = &'a Path>) -> bool {
-    paths.any(|path| path.file_name().and_then(|name| name.to_str()) == Some("Cargo.toml"))
+    paths.any(is_cargo_toml)
+}
+
+fn is_cargo_toml(path: &Path) -> bool {
+    path.file_name().and_then(|name| name.to_str()) == Some("Cargo.toml")
 }

--- a/crates/rag-rat-core/src/index/meta.rs
+++ b/crates/rag-rat-core/src/index/meta.rs
@@ -1,6 +1,10 @@
 //! Index key-value meta (the `index_meta` table) and the content-revision digest.
 
 use super::*;
+use crate::config::ResolvedTarget;
+
+const WATCH_SHUTDOWN_RECONCILE_PENDING_META: &str = "watch_shutdown_reconcile_pending";
+const BASE_SCOPE_DISCOVERED_META: &str = "files_base_scope_discovered";
 
 impl IndexDatabase {
     pub(super) fn record_content_revision(&self) -> anyhow::Result<String> {
@@ -35,6 +39,60 @@ impl IndexDatabase {
     /// no-change incremental/sweep pass avoids dirtying a WAL page (issue #63).
     pub(super) fn set_repo_meta_if_changed(&self, key: &str, value: &str) -> anyhow::Result<bool> {
         Ok(set_repo_meta_if_changed(self.storage.connection(), &self.active_repo_id, key, value)?)
+    }
+
+    pub(crate) fn mark_watch_shutdown_reconcile_pending(&self) -> anyhow::Result<bool> {
+        self.set_repo_meta_if_changed(WATCH_SHUTDOWN_RECONCILE_PENDING_META, "1")
+    }
+
+    pub(crate) fn watch_shutdown_reconcile_pending(&self) -> anyhow::Result<bool> {
+        Ok(self.repo_meta(WATCH_SHUTDOWN_RECONCILE_PENDING_META)?.as_deref() == Some("1"))
+    }
+
+    pub(crate) fn clear_watch_shutdown_reconcile_pending(&self) -> anyhow::Result<bool> {
+        if !self.watch_shutdown_reconcile_pending()? {
+            return Ok(false);
+        }
+        let conn = self.storage.connection();
+        delete_repo_meta(conn, &self.active_repo_id, WATCH_SHUTDOWN_RECONCILE_PENDING_META)?;
+        Ok(true)
+    }
+
+    pub(super) fn active_base_scope_discovered(
+        &self,
+        targets: &[ResolvedTarget],
+    ) -> anyhow::Result<bool> {
+        let Some(marker) = self.base_scope_discovery_marker(targets) else {
+            return Ok(false);
+        };
+        Ok(self.repo_meta(BASE_SCOPE_DISCOVERED_META)?.as_deref() == Some(marker.as_str()))
+    }
+
+    pub(super) fn mark_active_base_scope_discovered(
+        &self,
+        targets: &[ResolvedTarget],
+    ) -> anyhow::Result<bool> {
+        let Some(marker) = self.base_scope_discovery_marker(targets) else {
+            return Ok(false);
+        };
+        self.set_repo_meta_if_changed(BASE_SCOPE_DISCOVERED_META, &marker)
+    }
+
+    fn base_scope_discovery_marker(&self, targets: &[ResolvedTarget]) -> Option<String> {
+        let scope = if self.active_commit_sha.is_empty() {
+            if self.active_worktree_id.is_empty() {
+                return None;
+            }
+            format!("worktree={}", hex_sha256(self.active_worktree_id.as_bytes()))
+        } else {
+            format!("commit={}", self.active_commit_sha)
+        };
+        Some(format!(
+            "generation={};{};targets={}",
+            self.active_generation,
+            scope,
+            target_scope_fingerprint(targets)
+        ))
     }
 
     pub(super) fn set_meta(&self, key: &str, value: &str) -> anyhow::Result<()> {
@@ -75,6 +133,35 @@ impl IndexDatabase {
         )?;
         Ok(hex_sha256(value.as_bytes()))
     }
+}
+
+fn target_scope_fingerprint(targets: &[ResolvedTarget]) -> String {
+    let mut input = String::new();
+    for target in targets {
+        input.push_str("target\0");
+        input.push_str(&target.name);
+        input.push('\0');
+        input.push_str(target.language.as_str());
+        input.push('\0');
+        input.push_str(target.kind.as_str());
+        input.push('\0');
+        for dir in &target.directories {
+            input.push_str("dir\0");
+            input.push_str(&path_string(dir));
+            input.push('\0');
+        }
+        for include in &target.include {
+            input.push_str("include\0");
+            input.push_str(include);
+            input.push('\0');
+        }
+        for exclude in &target.exclude {
+            input.push_str("exclude\0");
+            input.push_str(exclude);
+            input.push('\0');
+        }
+    }
+    hex_sha256(input.as_bytes())
 }
 
 /// Read a per-repo meta value from the `repo_meta` table — the repo-scoped twin of

--- a/crates/rag-rat-core/src/index/prep.rs
+++ b/crates/rag-rat-core/src/index/prep.rs
@@ -137,6 +137,14 @@ pub(crate) fn spawn_git_history_prepare(
     thread::spawn(move || git_history::prepare(&root))
 }
 
+pub(crate) fn spawn_git_history_prepare_with_plan(
+    root: &Path,
+    plan: git_history::GitHistoryPreparePlan,
+) -> JoinHandle<anyhow::Result<git_history::PreparedGitHistory>> {
+    let root = root.to_path_buf();
+    thread::spawn(move || git_history::prepare_with_plan(&root, plan))
+}
+
 pub(crate) fn join_git_history_prepare(
     handle: JoinHandle<anyhow::Result<git_history::PreparedGitHistory>>,
 ) -> anyhow::Result<git_history::PreparedGitHistory> {

--- a/crates/rag-rat-core/src/index/query_api/ai_lifecycle.rs
+++ b/crates/rag-rat-core/src/index/query_api/ai_lifecycle.rs
@@ -66,6 +66,16 @@ impl IndexDatabase {
         ai::pending_embedding_jobs(self.storage.connection())
     }
 
+    pub(crate) fn pending_embedding_jobs_with_available_incremental_embedder(
+        &self,
+        options: &ai::ReconcileOptions,
+    ) -> anyhow::Result<u64> {
+        ai::pending_embedding_jobs_with_available_incremental_embedder(
+            self.storage.connection(),
+            options,
+        )
+    }
+
     /// One-time upgrade: re-encode any `chunk_embeddings` row still stored in the legacy f32 format
     /// to the compact int8 format (#312), gated by a meta key so later maintenance passes skip the
     /// table scan. A format-only conversion (decode f32 → encode int8), no model inference. Returns

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -233,6 +233,7 @@ impl IndexDatabase {
             // reload stays owed), and the retry publishes files + git authority together.
             db.set_repo_meta("source_root", &config.root.display().to_string())?;
             db.write_git_meta(&config.root)?;
+            db.mark_active_base_scope_discovered(&config.targets)?;
             if let Some(cursors) = &history_cursors {
                 db.record_git_history_cursors(cursors)?;
             }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/git_history_reload.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/git_history_reload.rs
@@ -1,23 +1,803 @@
 use super::*;
 
 #[test]
-fn git_history_reloads_after_a_new_commit() {
+fn git_history_appends_after_a_new_commit() {
     let root = unique_temp_root();
     let _ = fs::remove_dir_all(&root);
     let config = git_history_test_config(&root);
 
     let db = IndexDatabase::rebuild(&config).unwrap();
+    let before = db.status(&config.database).unwrap().git_history.commit_count;
     insert_sentinel_commit(&db);
     drop(db);
 
-    // A real new commit moves HEAD → the gate must reload, wiping the sentinel.
+    // Simulate the watcher path: first index the dirty file as this worktree's overlay, then
+    // commit it. The follow-up pass has visible rows to heal and should append git history instead
+    // of doing a full file rebuild. Give the new commit an older timestamp than the indexed tip: a
+    // naive newest-first walk that stops when it sees the old head would miss this commit, while
+    // `rev_walk(new).with_hidden(old)` still finds it.
+    fs::write(root.join("docs/search.md"), "# Title\ngamma token\n").unwrap();
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    assert_eq!(sentinel_commit_count(&db), 1, "dirty-file indexing must not reload history");
+    drop(db);
+    run_git(&root, &["add", "."]);
+    run_git_with_env(&root, &["commit", "-m", "Add gamma docs"], &[
+        ("GIT_AUTHOR_DATE", "2001-01-01T00:00:00Z"),
+        ("GIT_COMMITTER_DATE", "2001-01-01T00:00:00Z"),
+    ]);
+
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    let status = db.status(&config.database).unwrap();
+    assert_eq!(status.git_history.commit_count, before + 1, "one new commit was appended");
+    assert_eq!(sentinel_commit_count(&db), 1, "a fast-forward append must not wipe old rows");
+    assert_eq!(db.commit_search("gamma", 10).unwrap().len(), 1, "new commit is indexed");
+    assert_eq!(db.commit_search("beta", 10).unwrap().len(), 1, "old commit FTS rows remain live");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn git_history_append_rebuilds_desynced_commit_fts() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let repo_id = db.active_repo_id.clone();
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO git_commits(hash, author_name, author_email, authored_at_s, \
+             committed_at_s, subject, body, changed_file_count, repo_id)
+             VALUES ('__desynced_commit__', 'Desync', 'desync@example.com', 0, 0,
+                     'desyncunique subject', '', 0, ?1)",
+            rusqlite::params![repo_id],
+        )
+        .unwrap();
+    assert_eq!(
+        db.commit_search("desyncunique", 10).unwrap().len(),
+        0,
+        "the synthetic existing commit starts absent from commit_fts"
+    );
+    drop(db);
+
     fs::write(root.join("docs/search.md"), "# Title\ngamma token\n").unwrap();
     run_git(&root, &["add", "."]);
     run_git(&root, &["commit", "-m", "Add gamma docs"]);
 
     let db = IndexDatabase::index_changed(&config).unwrap();
-    assert_eq!(sentinel_commit_count(&db), 0, "a new commit must force a reload");
     assert_eq!(db.commit_search("gamma", 10).unwrap().len(), 1, "new commit is indexed");
+    assert_eq!(
+        db.commit_search("desyncunique", 10).unwrap().len(),
+        1,
+        "fast-forward append rebuilds commit_fts and repairs pre-existing desync"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn git_history_falls_back_when_append_rows_are_already_present() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let before = db.status(&config.database).unwrap().git_history.commit_count;
+    insert_sentinel_commit(&db);
+    drop(db);
+
+    fs::write(root.join("docs/search.md"), "# Title\ntorn token\n").unwrap();
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    assert_eq!(sentinel_commit_count(&db), 1, "dirty-file indexing must not reload history");
+    drop(db);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "Add torn docs"]);
+    let new_head = git_output(&root, &["rev-parse", "HEAD"]);
+
+    let db = IndexDatabase::open_config(&config).unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO git_commits(hash, author_name, author_email, authored_at_s, \
+             committed_at_s, subject, body, changed_file_count, repo_id)
+             VALUES (?1, 'Torn', 'torn@example.com', 0, 0, 'torn partial row', '', 0, ?2)",
+            rusqlite::params![new_head, db.active_repo_id],
+        )
+        .unwrap();
+    drop(db);
+
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    let status = db.status(&config.database).unwrap();
+    assert_eq!(status.git_history.commit_count, before + 1, "full replacement reconverges rows");
+    assert_eq!(sentinel_commit_count(&db), 0, "a torn append state must force full replacement");
+    assert_eq!(db.commit_search("torn", 10).unwrap().len(), 1, "commit FTS is rebuilt");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn git_history_append_plan_falls_back_for_non_git_or_other_root() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    drop(db);
+    fs::write(root.join("docs/search.md"), "# Title\nforeign plan token\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "Add foreign plan docs"]);
+
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let append_plan = crate::index::git_history::prepare_plan(db.storage.connection(), &root);
+    assert!(matches!(append_plan, crate::index::git_history::GitHistoryPreparePlan::Append { .. }));
+    drop(db);
+
+    let non_git = unique_temp_root();
+    let _ = fs::remove_dir_all(&non_git);
+    fs::create_dir_all(&non_git).unwrap();
+    let _prepared =
+        crate::index::git_history::prepare_with_plan(&non_git, append_plan.clone()).unwrap();
+
+    let other = unique_temp_root();
+    let _ = fs::remove_dir_all(&other);
+    let other_config = git_history_test_config(&other);
+    let other_db = IndexDatabase::rebuild(&other_config).unwrap();
+    let prepared = crate::index::git_history::prepare_with_plan(&other, append_plan).unwrap();
+    let status =
+        crate::index::git_history::apply_prepared(other_db.storage.connection(), &other, prepared)
+            .unwrap();
+    let other_head = git_output(&other, &["rev-parse", "HEAD"]);
+    assert_eq!(status.indexed_head.as_deref(), Some(other_head.as_str()));
+
+    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(non_git);
+    let _ = fs::remove_dir_all(other);
+}
+
+#[test]
+fn git_history_prepare_plan_fails_closed_on_incomplete_or_shallow_cursors() {
+    enum CursorCase {
+        MissingHead,
+        MissingRoot,
+        MissingShallow,
+        MissingComplete,
+        ShallowTrue,
+        ShallowBad,
+        CompleteFalse,
+        CompleteBad,
+    }
+    for case in [
+        CursorCase::MissingHead,
+        CursorCase::MissingRoot,
+        CursorCase::MissingShallow,
+        CursorCase::MissingComplete,
+        CursorCase::ShallowTrue,
+        CursorCase::ShallowBad,
+        CursorCase::CompleteFalse,
+        CursorCase::CompleteBad,
+    ] {
+        let root = unique_temp_root();
+        let _ = fs::remove_dir_all(&root);
+        let config = git_history_test_config(&root);
+        let db = IndexDatabase::rebuild(&config).unwrap();
+        match case {
+            CursorCase::MissingHead => {
+                db.storage
+                    .connection()
+                    .execute(
+                        "DELETE FROM repo_meta WHERE repo_id = ?1 AND key = \
+                         'git_history_indexed_head'",
+                        [&db.active_repo_id],
+                    )
+                    .unwrap();
+            },
+            CursorCase::MissingRoot => {
+                db.storage
+                    .connection()
+                    .execute(
+                        "DELETE FROM repo_meta WHERE repo_id = ?1 AND key = \
+                         'git_history_indexed_root'",
+                        [&db.active_repo_id],
+                    )
+                    .unwrap();
+            },
+            CursorCase::MissingShallow => {
+                db.storage
+                    .connection()
+                    .execute(
+                        "DELETE FROM repo_meta WHERE repo_id = ?1 AND key = \
+                         'git_history_indexed_shallow'",
+                        [&db.active_repo_id],
+                    )
+                    .unwrap();
+            },
+            CursorCase::MissingComplete => {
+                db.storage
+                    .connection()
+                    .execute(
+                        "DELETE FROM repo_meta WHERE repo_id = ?1 AND key = \
+                         'git_history_indexed_complete'",
+                        [&db.active_repo_id],
+                    )
+                    .unwrap();
+            },
+            CursorCase::ShallowTrue => {
+                db.storage
+                    .connection()
+                    .execute(
+                        "UPDATE repo_meta SET value = '1'
+                         WHERE repo_id = ?1 AND key = 'git_history_indexed_shallow'",
+                        [&db.active_repo_id],
+                    )
+                    .unwrap();
+            },
+            CursorCase::ShallowBad => {
+                db.storage
+                    .connection()
+                    .execute(
+                        "UPDATE repo_meta SET value = 'not-a-flag'
+                         WHERE repo_id = ?1 AND key = 'git_history_indexed_shallow'",
+                        [&db.active_repo_id],
+                    )
+                    .unwrap();
+            },
+            CursorCase::CompleteFalse => {
+                db.storage
+                    .connection()
+                    .execute(
+                        "UPDATE repo_meta SET value = '0'
+                         WHERE repo_id = ?1 AND key = 'git_history_indexed_complete'",
+                        [&db.active_repo_id],
+                    )
+                    .unwrap();
+            },
+            CursorCase::CompleteBad => {
+                db.storage
+                    .connection()
+                    .execute(
+                        "UPDATE repo_meta SET value = 'not-a-flag'
+                         WHERE repo_id = ?1 AND key = 'git_history_indexed_complete'",
+                        [&db.active_repo_id],
+                    )
+                    .unwrap();
+            },
+        }
+
+        let plan = crate::index::git_history::prepare_plan(db.storage.connection(), &root);
+        assert!(
+            matches!(plan, crate::index::git_history::GitHistoryPreparePlan::Full),
+            "corrupt cursor metadata must fail closed to a full reload plan"
+        );
+        drop(db);
+        let _ = fs::remove_dir_all(root);
+    }
+}
+
+#[test]
+fn incomplete_git_history_cursor_forces_full_reload_before_fast_forward_append() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let before = db.status(&config.database).unwrap().git_history.commit_count;
+    insert_sentinel_commit(&db);
+    db.storage
+        .connection()
+        .execute(
+            "UPDATE repo_meta SET value = '0'
+             WHERE repo_id = ?1 AND key = 'git_history_indexed_complete'",
+            [&db.active_repo_id],
+        )
+        .unwrap();
+    drop(db);
+
+    fs::write(root.join("docs/search.md"), "# Title\ncomplete marker token\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "Add complete marker docs"]);
+
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    let status = db.status(&config.database).unwrap();
+    assert_eq!(status.git_history.commit_count, before + 1, "full reload indexes the new commit");
+    assert_eq!(
+        sentinel_commit_count(&db),
+        0,
+        "an incomplete cursor must force full replacement, not append"
+    );
+    assert_eq!(db.commit_search("complete marker", 10).unwrap().len(), 1);
+    assert_eq!(
+        db.repo_meta("git_history_indexed_complete").unwrap().as_deref(),
+        Some("1"),
+        "a complete full reload restores the append-safe cursor marker"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn stale_prepared_append_is_noop_after_another_pass_catches_up() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    drop(db);
+    fs::write(root.join("docs/search.md"), "# Title\nalready current token\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "Add already current docs"]);
+    let new_head = git_output(&root, &["rev-parse", "HEAD"]);
+
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let plan = crate::index::git_history::prepare_plan(db.storage.connection(), &root);
+    let prepared = crate::index::git_history::prepare_with_plan(&root, plan).unwrap();
+    drop(db);
+
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    insert_sentinel_commit(&db);
+    let (status, cursors) = crate::index::git_history::apply_prepared_deferring_cursors(
+        db.storage.connection(),
+        &root,
+        prepared,
+    )
+    .unwrap();
+    assert!(cursors.is_some(), "the no-op path still returns the current cursor");
+    assert_eq!(status.indexed_head.as_deref(), Some(new_head.as_str()));
+    assert_eq!(sentinel_commit_count(&db), 1, "stale prepared append must not rewrite rows");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn stale_prepared_append_clears_when_root_loses_git_dir() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    drop(db);
+    fs::write(root.join("docs/search.md"), "# Title\ndetached root token\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "Add detached root docs"]);
+
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let plan = crate::index::git_history::prepare_plan(db.storage.connection(), &root);
+    let prepared = crate::index::git_history::prepare_with_plan(&root, plan).unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "UPDATE repo_meta SET value = '0'
+             WHERE repo_id = ?1 AND key = 'git_history_indexed_complete'",
+            [&db.active_repo_id],
+        )
+        .unwrap();
+    fs::rename(root.join(".git"), root.join(".git.gone")).unwrap();
+
+    let (status, cursors) = crate::index::git_history::apply_prepared_deferring_cursors(
+        db.storage.connection(),
+        &root,
+        prepared,
+    )
+    .unwrap();
+    assert!(cursors.is_none(), "a vanished repository cannot keep append cursors");
+    assert!(!status.available, "status reports the lost git repository");
+    assert_eq!(status.commit_count, 0, "the stale git-history rows were cleared");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn stale_prepared_append_is_noop_when_db_cursor_is_ahead() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    drop(db);
+
+    fs::write(root.join("docs/search.md"), "# Title\nmiddle race token\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "Add middle race docs"]);
+    let middle_head = git_output(&root, &["rev-parse", "HEAD"]);
+
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let plan = crate::index::git_history::prepare_plan(db.storage.connection(), &root);
+    let prepared = crate::index::git_history::prepare_with_plan(&root, plan).unwrap();
+    drop(db);
+
+    fs::write(root.join("docs/search.md"), "# Title\nnewer race token\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "Add newer race docs"]);
+    let newer_head = git_output(&root, &["rev-parse", "HEAD"]);
+    assert_ne!(middle_head, newer_head);
+
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    let status = db.status(&config.database).unwrap();
+    assert_eq!(status.git_history.indexed_head.as_deref(), Some(newer_head.as_str()));
+    assert_eq!(db.commit_search("middle", 10).unwrap().len(), 1, "middle commit is indexed");
+    assert_eq!(db.commit_search("newer", 10).unwrap().len(), 1, "newer commit is indexed");
+    insert_sentinel_commit(&db);
+    let before = db.status(&config.database).unwrap().git_history.commit_count;
+
+    let status =
+        crate::index::git_history::apply_prepared(db.storage.connection(), &root, prepared)
+            .unwrap();
+
+    assert_eq!(status.indexed_head.as_deref(), Some(newer_head.as_str()));
+    assert_eq!(status.commit_count, before);
+    assert_eq!(sentinel_commit_count(&db), 1, "stale prepared append must not rewrite newer rows");
+    assert_eq!(db.commit_search("middle", 10).unwrap().len(), 1);
+    assert_eq!(db.commit_search("newer", 10).unwrap().len(), 1);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn git_history_append_records_new_head_for_out_of_scope_fast_forward_commit() {
+    let worktree = unique_temp_root();
+    let _ = fs::remove_dir_all(&worktree);
+    fs::create_dir_all(worktree.join("pkg/docs")).unwrap();
+    fs::create_dir_all(worktree.join("pkg/src")).unwrap();
+    run_git(&worktree, &["init"]);
+    run_git(&worktree, &["config", "user.name", "Rag Rat"]);
+    run_git(&worktree, &["config", "user.email", "rag@example.com"]);
+    fs::write(worktree.join(".gitignore"), ".rag-rat/\n").unwrap();
+    fs::write(worktree.join("pkg/docs/search.md"), "# Title\nscoped token\n").unwrap();
+    fs::write(worktree.join("pkg/src/lib.rs"), "pub fn tracked_symbol() {}\n").unwrap();
+    run_git(&worktree, &["add", "."]);
+    run_git(&worktree, &["commit", "-m", "Initial scoped content"]);
+    let config = rag_rat_config(&worktree.join("pkg"));
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let repo_id = db.active_repo_id.clone();
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO git_commits(hash, author_name, author_email, authored_at_s, \
+             committed_at_s, subject, body, changed_file_count, repo_id)
+             VALUES ('__empty_append_desynced_commit__', 'Desync', 'desync@example.com', 0, 0,
+                     'emptyappendunique subject', '', 0, ?1)",
+            rusqlite::params![repo_id],
+        )
+        .unwrap();
+    assert_eq!(
+        db.commit_search("emptyappendunique", 10).unwrap().len(),
+        0,
+        "the synthetic existing commit starts absent from commit_fts"
+    );
+    let before = db.status(&config.database).unwrap().git_history.commit_count;
+    insert_sentinel_commit(&db);
+    drop(db);
+
+    fs::write(worktree.join("README.md"), "outside the configured root\n").unwrap();
+    run_git(&worktree, &["add", "."]);
+    run_git(&worktree, &["commit", "-m", "Change outside indexed subtree"]);
+    let new_head = git_output(&worktree, &["rev-parse", "HEAD"]);
+
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    let status = db.status(&config.database).unwrap();
+    assert_eq!(status.git_history.commit_count, before, "out-of-scope commit adds no row");
+    assert_eq!(status.git_history.indexed_head.as_deref(), Some(new_head.as_str()));
+    assert_eq!(sentinel_commit_count(&db), 1, "empty append must not full-replace history rows");
+    assert_eq!(
+        db.commit_search("emptyappendunique", 10).unwrap().len(),
+        1,
+        "empty append still rebuilds commit_fts and repairs pre-existing desync"
+    );
+
+    let _ = fs::remove_dir_all(worktree);
+}
+
+#[test]
+fn git_history_append_reports_commit_fts_prepare_errors() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    drop(db);
+    fs::write(root.join("docs/search.md"), "# Title\nfts prepare token\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "Add fts prepare docs"]);
+
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let plan = crate::index::git_history::prepare_plan(db.storage.connection(), &root);
+    let prepared = crate::index::git_history::prepare_with_plan(&root, plan).unwrap();
+    db.storage.connection().execute("DROP TABLE commit_fts", []).unwrap();
+    let err = crate::index::git_history::apply_prepared_deferring_cursors(
+        db.storage.connection(),
+        &root,
+        prepared,
+    )
+    .expect_err("missing commit_fts must surface an append failure");
+    assert!(err.to_string().contains("commit_fts"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn repo_generation_file_count_reports_sql_errors() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    db.storage.connection().execute("DROP TABLE main.files", []).unwrap();
+    let err = db.repo_generation_file_count(true).expect_err("missing files table must error");
+    assert!(err.to_string().contains("files"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn repo_generation_file_count_ignores_foreign_worktree_overlays() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let scoped = db.indexed_file_count().unwrap();
+    assert_eq!(db.repo_generation_file_count(true).unwrap(), scoped);
+
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, generated,
+             indexed_at_ms, indexed_revision, commit_sha, worktree_id, has_test_code, repo_id,
+             generation)
+             SELECT 'src/linked_overlay.rs', language, kind, sha256, modified_at_ms, generated,
+                    indexed_at_ms, indexed_revision, '', '__linked_worktree__', has_test_code,
+                    repo_id, generation
+             FROM main.files WHERE repo_id = ?1 LIMIT 1",
+            rusqlite::params![db.active_repo_id],
+        )
+        .unwrap();
+    assert_eq!(
+        db.indexed_file_count().unwrap(),
+        scoped,
+        "foreign linked-worktree overlay rows are outside the active temp scope"
+    );
+    assert_eq!(
+        db.repo_generation_file_count(true).unwrap(),
+        scoped,
+        "foreign linked-worktree overlay rows must not make changed-mode look incomplete"
+    );
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, generated,
+             indexed_at_ms, indexed_revision, commit_sha, worktree_id, has_test_code, repo_id,
+             generation)
+             SELECT 'src/future_commit.rs', language, kind, sha256, modified_at_ms, generated,
+                    indexed_at_ms, indexed_revision, '__other_commit__', '', has_test_code,
+                    repo_id, generation
+             FROM main.files WHERE repo_id = ?1 LIMIT 1",
+            rusqlite::params![db.active_repo_id],
+        )
+        .unwrap();
+    assert_eq!(
+        db.repo_generation_file_count(true).unwrap(),
+        scoped,
+        "committed rows from another checkout commit must not make changed-mode look incomplete"
+    );
+
+    db.write_tombstone_in_scope(Path::new("docs/search.md"), &db.active_worktree_id).unwrap();
+    assert_eq!(
+        db.repo_generation_file_count(true).unwrap(),
+        db.indexed_file_count().unwrap(),
+        "active tombstones shadow committed rows and should not inflate the expected scope count"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn discovered_empty_active_commit_does_not_promote_changed_mode() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    assert!(db.indexed_file_count().unwrap() > 0);
+
+    fs::remove_file(root.join("docs/search.md")).unwrap();
+    fs::remove_file(root.join("src/lib.rs")).unwrap();
+    run_git(&root, &["add", "-A"]);
+    run_git(&root, &["commit", "-m", "Remove target files"]);
+
+    let db = IndexDatabase::index_discover(&config).unwrap();
+    assert_eq!(db.indexed_file_count().unwrap(), 0);
+    assert!(
+        db.active_base_scope_discovered(&config.targets).unwrap(),
+        "a successful discover pass marks even an empty active base scope complete"
+    );
+    assert!(
+        db.repo_generation_file_count(true).unwrap() > 0,
+        "retained rows from older commits still exist in the live generation"
+    );
+    assert_eq!(
+        db.repo_generation_file_count(false).unwrap(),
+        0,
+        "a marked-complete active empty scope must not count retained older commit rows"
+    );
+
+    let mut started_mode = None;
+    let _db = IndexDatabase::index_changed_with_progress(&config, |progress| {
+        if let IndexProgress::Started { mode, .. } = progress {
+            started_mode = Some(mode);
+        }
+    })
+    .unwrap();
+    assert_eq!(
+        started_mode,
+        Some(IndexMode::Changed),
+        "after an empty active scope is discover-checked, changed-mode must not promote forever"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn changed_mode_discovers_when_target_fingerprint_is_stale() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+    fs::create_dir_all(root.join("examples")).unwrap();
+    fs::write(root.join("examples/guide.md"), "# Guide\nnew target token\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "Add example docs"]);
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    assert!(!path_in_scope(&db, "examples/guide.md"), "old targets do not index examples/");
+    assert!(db.active_base_scope_discovered(&config.targets).unwrap());
+
+    let mut expanded_config = config.clone();
+    expanded_config.targets.push(ResolvedTarget {
+        name: "examples".to_string(),
+        language: Language::Markdown,
+        directories: vec![PathBuf::from("examples")],
+        include: vec!["**/*.md".to_string()],
+        exclude: vec!["drafts/**".to_string()],
+        kind: TargetKind::Docs,
+    });
+    assert!(
+        !db.active_base_scope_discovered(&expanded_config.targets).unwrap(),
+        "adding a configured target invalidates the base-scope marker"
+    );
+    assert_eq!(
+        db.indexed_file_count().unwrap(),
+        db.repo_generation_file_count(true).unwrap(),
+        "the old target rows can still make the count-only fallback look complete"
+    );
+    drop(db);
+
+    let mut started_mode = None;
+    let db = IndexDatabase::index_changed_with_progress(&expanded_config, |progress| {
+        if let IndexProgress::Started { mode, .. } = progress {
+            started_mode = Some(mode);
+        }
+    })
+    .unwrap();
+    assert_eq!(
+        started_mode,
+        Some(IndexMode::Discover),
+        "a stale target fingerprint must force discovery even when row counts match"
+    );
+    assert!(
+        path_in_scope(&db, "examples/guide.md"),
+        "changed-mode discovery indexes the new target"
+    );
+    assert!(db.active_base_scope_discovered(&expanded_config.targets).unwrap());
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn base_scope_marker_is_absent_without_commit_or_worktree_scope() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+    let mut db = IndexDatabase::rebuild(&config).unwrap();
+    db.active_commit_sha.clear();
+    db.active_worktree_id.clear();
+
+    assert!(
+        !db.active_base_scope_discovered(&config.targets).unwrap(),
+        "an unscoped connection cannot satisfy the base-scope discovery marker"
+    );
+    assert!(
+        !db.mark_active_base_scope_discovered(&config.targets).unwrap(),
+        "an unscoped connection has no stable marker to write"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn watch_shutdown_marker_clear_is_idempotent() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    assert!(
+        !db.clear_watch_shutdown_reconcile_pending().unwrap(),
+        "clearing an absent shutdown marker is a no-op"
+    );
+    assert!(db.mark_watch_shutdown_reconcile_pending().unwrap());
+    assert!(db.watch_shutdown_reconcile_pending().unwrap());
+    assert!(db.clear_watch_shutdown_reconcile_pending().unwrap());
+    assert!(!db.watch_shutdown_reconcile_pending().unwrap());
+    assert!(
+        !db.clear_watch_shutdown_reconcile_pending().unwrap(),
+        "a second clear remains write-free"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn git_history_appends_after_a_merge_commit() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let before = db.status(&config.database).unwrap().git_history.commit_count;
+    insert_sentinel_commit(&db);
+    drop(db);
+
+    let indexed_head = git_output(&root, &["rev-parse", "HEAD"]);
+    run_git(&root, &["checkout", "-b", "topic"]);
+    fs::write(root.join("docs/search.md"), "# Title\nomega token\n").unwrap();
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    assert_eq!(sentinel_commit_count(&db), 1, "dirty-file indexing must not reload history");
+    drop(db);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "Add omega docs"]);
+    run_git(&root, &["checkout", "-B", "merge-target", &indexed_head]);
+    run_git(&root, &["merge", "--no-ff", "topic", "-m", "Merge topic branch"]);
+
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    let status = db.status(&config.database).unwrap();
+    assert_eq!(status.git_history.commit_count, before + 2, "topic and merge commits append");
+    assert_eq!(sentinel_commit_count(&db), 1, "a merge append must not wipe old rows");
+    assert!(
+        db.commit_search("omega", 10).unwrap().iter().any(|hit| hit.subject == "Add omega docs"),
+        "topic commit must be searchable after merge append"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn git_history_appends_after_a_squash_commit() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let before = db.status(&config.database).unwrap().git_history.commit_count;
+    insert_sentinel_commit(&db);
+    drop(db);
+
+    let indexed_head = git_output(&root, &["rev-parse", "HEAD"]);
+    run_git(&root, &["checkout", "-b", "topic"]);
+    fs::write(root.join("docs/search.md"), "# Title\ntheta token\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "Draft theta docs"]);
+    fs::write(root.join("docs/search.md"), "# Title\ntheta token\nlambda token\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "Refine theta docs"]);
+    run_git(&root, &["checkout", "-B", "squash-target", &indexed_head]);
+    run_git(&root, &["merge", "--squash", "topic"]);
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    assert_eq!(sentinel_commit_count(&db), 1, "dirty-file indexing must not reload history");
+    drop(db);
+    run_git(&root, &["commit", "-m", "Squash theta docs"]);
+
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    let status = db.status(&config.database).unwrap();
+    assert_eq!(status.git_history.commit_count, before + 1, "squash adds one new commit");
+    assert_eq!(sentinel_commit_count(&db), 1, "a squash append must not wipe old rows");
+    assert_eq!(db.commit_search("theta", 10).unwrap().len(), 1, "squash commit is indexed");
 
     let _ = fs::remove_dir_all(root);
 }
@@ -43,6 +823,77 @@ fn git_history_reloads_after_a_history_rewrite() {
     assert_eq!(status.git_history.commit_count, before, "amend does not change the commit count");
     assert_eq!(db.commit_search("delta", 10).unwrap().len(), 1, "rewritten subject is indexed");
     assert_eq!(db.commit_search("beta", 10).unwrap().len(), 0, "old subject is gone after rewrite");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn git_history_reloads_after_a_non_fast_forward_branch_switch() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    insert_sentinel_commit(&db);
+    drop(db);
+
+    run_git(&root, &["checkout", "-b", "side", "HEAD~1"]);
+    fs::write(root.join("docs/search.md"), "# Title\nbranch token\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "Switch to branch docs"]);
+
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    assert_eq!(sentinel_commit_count(&db), 0, "a non-FF branch switch must force a reload");
+    assert_eq!(db.commit_search("branch", 10).unwrap().len(), 1, "new branch history is indexed");
+    assert_eq!(db.commit_search("beta", 10).unwrap().len(), 0, "old branch history is gone");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn git_history_reloads_after_squashing_indexed_commits() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    let config = git_history_test_config(&root);
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let before = db.status(&config.database).unwrap().git_history.commit_count;
+    insert_sentinel_commit(&db);
+    drop(db);
+
+    let base = git_output(&root, &["rev-parse", "HEAD"]);
+    fs::write(root.join("docs/search.md"), "# Title\nrho token\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "Add rho docs"]);
+    fs::write(root.join("docs/search.md"), "# Title\nrho token\nsigma token\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "obsoleteunique sigma docs"]);
+
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    assert_eq!(sentinel_commit_count(&db), 1, "FF commits append before the squash");
+    assert_eq!(
+        db.status(&config.database).unwrap().git_history.commit_count,
+        before + 2,
+        "both temporary commits were appended"
+    );
+    drop(db);
+
+    run_git(&root, &["reset", "--soft", &base]);
+    run_git(&root, &["commit", "-m", "Squash rho sigma docs"]);
+
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    assert_eq!(sentinel_commit_count(&db), 0, "squashing indexed commits must force a reload");
+    assert_eq!(
+        db.status(&config.database).unwrap().git_history.commit_count,
+        before + 1,
+        "two indexed commits were replaced by one squashed commit"
+    );
+    assert_eq!(db.commit_search("sigma", 10).unwrap().len(), 1, "squashed commit is indexed");
+    assert_eq!(
+        db.commit_search("obsoleteunique", 10).unwrap().len(),
+        0,
+        "old commit FTS row is gone"
+    );
 
     let _ = fs::remove_dir_all(root);
 }
@@ -182,6 +1033,54 @@ fn discover_relanguages_h_when_binding_changes_c_to_cpp() {
         .query_row("SELECT language FROM files WHERE path = 'src/lib.h'", [], |r| r.get(0))
         .unwrap();
     assert_eq!(lang, "cpp", "the .h must be reindexed as C++ after the binding change");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn changed_mode_ignores_gitignored_target_files_under_root_target() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::create_dir_all(root.join("target/debug")).unwrap();
+    run_git(&root, &["init"]);
+    run_git(&root, &["config", "user.name", "Rag Rat"]);
+    run_git(&root, &["config", "user.email", "rag@example.com"]);
+    fs::write(root.join(".gitignore"), "target/\n").unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn tracked_symbol() {}\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "Initial source"]);
+
+    let mut config = source_config(root.clone(), Language::Rust);
+    config.targets[0].directories = vec![PathBuf::from(".")];
+    config.targets[0].include = vec!["**/*.rs".to_string()];
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let before: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT COUNT(*) FROM files", [], |row| row.get(0))
+        .unwrap();
+    drop(db);
+
+    fs::write(root.join("target/debug/generated.rs"), "pub fn ignored_build_artifact() {}\n")
+        .unwrap();
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    let after: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT COUNT(*) FROM files", [], |row| row.get(0))
+        .unwrap();
+    let target_rows: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT COUNT(*) FROM main.files WHERE path LIKE 'target/%'", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+
+    assert_eq!(before, after, "ignored target/ writes must not index new files");
+    assert_eq!(target_rows, 0, "target/ artifacts must not enter the index");
 
     let _ = fs::remove_dir_all(root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -13,11 +13,12 @@ use crate::embedding_models::{
 
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-/// A recognizable bogus row that only a git-history *reload* (full table wipe) would remove.
-/// Surviving the next incremental pass ⇒ the reload was skipped; gone ⇒ it ran. It lives in
-/// `git_file_changes` (a plain table the reload also wipes) rather than `git_commits`, because a
-/// stray `git_commits` row with no matching `commit_fts` entry desyncs the external-content FTS5
-/// and the reload's `DELETE FROM commit_fts` then corrupts it — a test artifact, not a real state.
+/// A recognizable bogus row that only a git-history full replacement would remove. Surviving the
+/// next incremental pass means the reload was skipped or appended; gone means the full path ran. It
+/// lives in `git_file_changes` (a plain table the full path wipes) rather than `git_commits`,
+/// because a stray `git_commits` row with no matching `commit_fts` entry desyncs the
+/// external-content FTS5 and the reload's `commit_fts` rebuild then has to repair it — a test
+/// artifact, not a real state.
 const SENTINEL_PATH: &str = "__rag_rat_reload_sentinel__";
 
 fn insert_sentinel_commit(db: &IndexDatabase) {
@@ -520,6 +521,22 @@ fn run_git(root: &Path, args: &[&str]) {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+fn run_git_with_env(root: &Path, args: &[&str], env: &[(&str, &str)]) {
+    let output = Command::new("git")
+        .args(args)
+        .envs(env.iter().copied())
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "git {:?} failed", args);
+}
+
+fn git_output(root: &Path, args: &[&str]) -> String {
+    let output = Command::new("git").args(args).current_dir(root).output().unwrap();
+    assert!(output.status.success(), "git {:?} failed", args);
+    String::from_utf8(output.stdout).unwrap().trim().to_string()
 }
 
 struct MockGitHubClient;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
@@ -291,6 +291,135 @@ fn incremental_pass_heals_stale_overlay_rows() {
     let _ = fs::remove_dir_all(root);
 }
 
+/// #459 review: if the watcher indexes a dirty file and that file is then committed, a changed-mode
+/// follow-up at the new HEAD sees the lingering overlay row but not the unchanged committed files.
+/// It must promote to discover mode and restamp the whole clean tree, not preserve a partial scope.
+#[test]
+fn changed_pass_after_dirty_commit_restamps_unchanged_files() {
+    let (root, config) = git_fixture_for_overlay_tests();
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    assert_eq!(
+        db.storage
+            .connection()
+            .query_row("SELECT COUNT(*) FROM files", [], |row| row.get::<_, i64>(0))
+            .unwrap(),
+        2,
+        "fixture starts with both files visible"
+    );
+    drop(db);
+
+    fs::write(root.join("src/lib.rs"), "pub fn stable() -> i32 { 3 }\n").unwrap();
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    let dirty_scope_count: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT COUNT(*) FROM files", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(dirty_scope_count, 2, "the dirty overlay still shadows a complete active view");
+    drop(db);
+
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "commit dirty overlay"]);
+    let new_head = git_output(&root, &["rev-parse", "HEAD"]);
+
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    let rows: Vec<(String, String, String)> = {
+        let mut stmt = db
+            .storage
+            .connection()
+            .prepare("SELECT path, commit_sha, worktree_id FROM files ORDER BY path")
+            .unwrap();
+        stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    };
+    assert_eq!(
+        rows,
+        vec![
+            ("src/extra.rs".to_string(), new_head.clone(), String::new()),
+            ("src/lib.rs".to_string(), new_head, String::new()),
+        ],
+        "the clean post-commit scope must contain every file at the new HEAD"
+    );
+    let overlays: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM main.files WHERE worktree_id != '' AND kind != 'deleted'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(overlays, 0, "the stale dirty overlay row is healed after the commit");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+/// The dirty-commit fallback must still discover/restamp the clean tree when another target file
+/// remains dirty; the dirty overlay should coexist with committed rows for unchanged files at the
+/// new HEAD.
+#[test]
+fn changed_pass_after_dirty_commit_restamps_with_another_dirty_target() {
+    let (root, config) = git_fixture_for_overlay_tests();
+    fs::write(root.join("src/kept.rs"), "pub fn kept() -> i32 { 4 }\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-m", "add kept file"]);
+
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    assert_eq!(
+        db.storage
+            .connection()
+            .query_row("SELECT COUNT(*) FROM files", [], |row| row.get::<_, i64>(0))
+            .unwrap(),
+        3,
+        "fixture starts with three files visible"
+    );
+    drop(db);
+
+    fs::write(root.join("src/lib.rs"), "pub fn stable() -> i32 { 3 }\n").unwrap();
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    assert_eq!(
+        db.storage
+            .connection()
+            .query_row("SELECT COUNT(*) FROM files", [], |row| row.get::<_, i64>(0))
+            .unwrap(),
+        3,
+        "dirty overlay still shadows a complete active view"
+    );
+    drop(db);
+
+    run_git(&root, &["add", "src/lib.rs"]);
+    run_git(&root, &["commit", "-m", "commit dirty overlay"]);
+    let new_head = git_output(&root, &["rev-parse", "HEAD"]);
+    fs::write(root.join("src/extra.rs"), "pub fn extra() -> i32 { 5 }\n").unwrap();
+
+    let db = IndexDatabase::index_changed(&config).unwrap();
+    let rows: Vec<(String, String, bool)> = {
+        let mut stmt = db
+            .storage
+            .connection()
+            .prepare("SELECT path, commit_sha, worktree_id != '' FROM files ORDER BY path")
+            .unwrap();
+        stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    };
+    assert_eq!(
+        rows,
+        vec![
+            ("src/extra.rs".to_string(), String::new(), true),
+            ("src/kept.rs".to_string(), new_head.clone(), false),
+            ("src/lib.rs".to_string(), new_head, false),
+        ],
+        "discover fallback must restamp committed files while preserving the remaining dirty \
+         overlay"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
 /// Phase 3: the LOCAL structural-load enrichment (`scoped weighted fan-in`) rides along on BOTH the
 /// `impact_surface` neighbors AND `symbol_lookup` / `search` hits — labeled, never as PageRank. A
 /// hub called by several functions outranks a leaf nothing depends on.

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -34,6 +34,7 @@ use crate::locks::{self, FileLock};
 const GC_EVERY_PASSES: u64 = 20;
 /// Bound a single reconcile so a pass never holds the write lock indefinitely.
 const PASS_RECONCILE_MAX_SECONDS: u64 = 60;
+const STARTUP_CATCHUP_RUN_GC: bool = false;
 /// Shutdown / interactive lock acquisition: skip rather than block forever.
 const SKIP_TIMEOUT: Duration = Duration::from_secs(3);
 /// Quiet window after a change to the installed binary before signaling the fleet to hot-upgrade.
@@ -87,7 +88,7 @@ impl Debounce {
 pub fn maintenance_pass(config: &Config, run_gc: bool) -> anyhow::Result<()> {
     let lock_repo = locks::write_lock_repo_id(config);
     let _lock = locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
-    run_pass(config, run_gc)
+    run_pass(config, run_gc, false)
 }
 
 /// Run one maintenance pass only if the write lock is free within `SKIP_TIMEOUT`; returns whether
@@ -96,16 +97,27 @@ pub fn maintenance_pass_or_skip(config: &Config, run_gc: bool) -> anyhow::Result
     let lock_repo = locks::write_lock_repo_id(config);
     match locks::WriteLock::acquire_timeout(&config.database, &lock_repo, SKIP_TIMEOUT)? {
         Some(_lock) => {
-            run_pass(config, run_gc)?;
+            run_pass(config, run_gc, false)?;
             Ok(true)
         },
         None => Ok(false),
     }
 }
 
-fn run_pass(config: &Config, run_gc: bool) -> anyhow::Result<()> {
+fn startup_catchup_pass(config: &Config) -> anyhow::Result<()> {
+    let lock_repo = locks::write_lock_repo_id(config);
+    let _lock = locks::WriteLock::acquire_blocking(&config.database, &lock_repo)?;
+    run_pass(config, STARTUP_CATCHUP_RUN_GC, true)
+}
+
+fn run_pass(
+    config: &Config,
+    run_gc: bool,
+    retry_base_embedding_backlog: bool,
+) -> anyhow::Result<()> {
     let started = Instant::now();
     let (mut db, content_changed) = IndexDatabase::index_discover_reporting(config)?;
+    let shutdown_reconcile_pending = db.watch_shutdown_reconcile_pending()?;
     let runtime = &config.llm.embedding.runtime;
     let options = ReconcileOptions {
         batch_size: Some(runtime.batch_size),
@@ -126,19 +138,44 @@ fn run_pass(config: &Config, run_gc: bool) -> anyhow::Result<()> {
     // change. Reconcile a CHANGED overlay's embeddings INLINE (while scoped to it) so a worktree
     // query isn't BM25-only for branch content — the base reconcile below can't see overlay chunks.
     let overlays_changed = refresh_worktree_overlays(&mut db, config, Some(&budget));
+    let tail_already_forced = pass_tail_forced_by_state(
+        content_changed,
+        overlays_changed,
+        run_gc,
+        shutdown_reconcile_pending,
+    );
+    let base_embedding_backlog = base_embedding_backlog_needs_tail(
+        tail_already_forced,
+        retry_base_embedding_backlog,
+        &budget,
+        |options| {
+            db.pending_embedding_jobs_with_available_incremental_embedder(options)
+                .is_ok_and(|pending| pending > 0)
+        },
+    );
     // Idle backstop (issue #63, facet 2): when the sweep changed no content, skip the reconcile /
     // gc / memory-validate tail — an idle server should do no work past discovery. `run_gc` (every
     // GC_EVERY_PASSES) still forces a full tail, so the cases that DON'T flip content_changed are
     // still caught within that bound: a freshly-installed embedder, an embedding backlog left by a
     // time-capped reconcile (PASS_RECONCILE_MAX_SECONDS), and drifted memory anchors. Any real
-    // content change runs the full tail immediately.
-    if !content_changed && !overlays_changed && !run_gc {
+    // content change runs the full tail immediately. Startup has two discover-only exceptions:
+    // a prior bounded shutdown discover that marked base reconcile owed, and an already-indexed
+    // base embedding backlog left by a time-capped or blocked prior pass.
+    if !should_run_pass_tail(
+        content_changed,
+        overlays_changed,
+        run_gc,
+        shutdown_reconcile_pending,
+        base_embedding_backlog,
+    ) {
         return Ok(());
     }
     // The base reconcile gets only the budget the overlays left behind; `None` → already exhausted,
     // so skip it (the embedding backlog rides the next pass) rather than spend a fresh full budget.
+    let mut base_reconcile_status = None;
     if let Some(options) = budget.next_options() {
-        db.reconcile_with_options_progress(options, |_| {})?;
+        let report = db.reconcile_with_options_progress(options, |_| {})?;
+        base_reconcile_status = Some(report.status);
     }
     // Clone-edge graph (#286): refresh the persisted graph when it's ABSENT or STALE, with whatever
     // budget the embedding reconcile left — sharing the same PASS_RECONCILE_MAX_SECONDS so a pass
@@ -155,7 +192,45 @@ fn run_pass(config: &Config, run_gc: bool) -> anyhow::Result<()> {
         let _ = db.garbage_collect();
     }
     let _ = db.memory_validate();
+    if shutdown_reconcile_pending && base_reconcile_status.as_deref() == Some("Current") {
+        db.clear_watch_shutdown_reconcile_pending()?;
+    }
     Ok(())
+}
+
+fn should_run_pass_tail(
+    content_changed: bool,
+    overlays_changed: bool,
+    run_gc: bool,
+    shutdown_reconcile_pending: bool,
+    base_embedding_backlog: bool,
+) -> bool {
+    content_changed
+        || overlays_changed
+        || run_gc
+        || shutdown_reconcile_pending
+        || base_embedding_backlog
+}
+
+fn pass_tail_forced_by_state(
+    content_changed: bool,
+    overlays_changed: bool,
+    run_gc: bool,
+    shutdown_reconcile_pending: bool,
+) -> bool {
+    content_changed || overlays_changed || run_gc || shutdown_reconcile_pending
+}
+
+fn base_embedding_backlog_needs_tail(
+    tail_already_forced: bool,
+    retry_base_embedding_backlog: bool,
+    budget: &ReconcileBudget,
+    pending_embedding_jobs: impl FnOnce(&ReconcileOptions) -> bool,
+) -> bool {
+    if tail_already_forced || !retry_base_embedding_backlog {
+        return false;
+    }
+    budget.next_options().is_some_and(|options| pending_embedding_jobs(&options))
 }
 
 /// Refresh the branch overlay of every live LINKED worktree of `config.root`'s repo (#219), so a
@@ -218,9 +293,10 @@ pub fn refresh_worktree_overlays(
                 // from the time left in the SHARED budget so overlays + base can't each spend the
                 // full `--max-seconds`; `None` → budget exhausted, skip and let the NEXT pass
                 // retry.
-                let needs_embed = this_changed
-                    || reconcile.is_some()
-                        && db.pending_embedding_jobs().is_ok_and(|pending| pending > 0);
+                let needs_embed = overlay_needs_embed(this_changed, reconcile, |options| {
+                    db.pending_embedding_jobs_with_available_incremental_embedder(options)
+                        .is_ok_and(|pending| pending > 0)
+                });
                 if needs_embed
                     && let Some(budget) = reconcile
                     && let Some(options) = budget.next_options()
@@ -236,6 +312,19 @@ pub fn refresh_worktree_overlays(
     // scoped to the last worktree it touched).
     let _ = db.use_worktree_scope(&config.root, None);
     changed
+}
+
+fn overlay_needs_embed(
+    this_changed: bool,
+    reconcile: Option<&ReconcileBudget>,
+    pending_embedding_jobs: impl FnOnce(&ReconcileOptions) -> bool,
+) -> bool {
+    if this_changed {
+        return true;
+    }
+    reconcile
+        .and_then(ReconcileBudget::next_options)
+        .is_some_and(|options| pending_embedding_jobs(&options))
 }
 
 /// A time budget shared across the per-overlay embedding reconciles AND the trailing base reconcile
@@ -912,7 +1001,9 @@ fn watcher_main(config: Config, fleet_bin: Option<PathBuf>, stop: &AtomicBool) {
     };
 
     // Catch-up pass: covers edits made while no watcher was running (startup / election gap).
-    let _ = maintenance_pass(&config, true);
+    // Do not force the reconcile/gc/memory tail on every process start; on an unchanged checkout,
+    // startup must stay discover-only and write nothing past any cheap freshness repairs.
+    let _ = startup_catchup_pass(&config);
 
     let (tx, rx) = std::sync::mpsc::channel();
     let Ok(mut notify_watcher) = recommended_watcher(move |res| {
@@ -1066,7 +1157,8 @@ fn watcher_main(config: Config, fleet_bin: Option<PathBuf>, stop: &AtomicBool) {
 
     // Final pass for edits in the last debounce window — discover only (no embedding), timeout-and-
     // skip. The host may SIGKILL shortly after stdin EOF, so shutdown must be bounded; discover is
-    // fast and keeps structure fresh, and the next session's startup catch-up does the embedding.
+    // fast and keeps structure fresh, and the next content-changing or periodic pass does the
+    // embedding.
     if debounce.fire_at().is_some() {
         let _ = shutdown_discover(&config);
     }
@@ -1077,8 +1169,12 @@ fn shutdown_discover(config: &Config) -> anyhow::Result<bool> {
     let lock_repo = locks::write_lock_repo_id(config);
     match locks::WriteLock::acquire_timeout(&config.database, &lock_repo, SKIP_TIMEOUT)? {
         Some(_lock) => {
-            IndexDatabase::index_discover(config)?;
-            Ok(true)
+            let (db, content_changed) = IndexDatabase::index_discover_reporting(config)?;
+            if content_changed {
+                db.mark_watch_shutdown_reconcile_pending()?;
+                return Ok(true);
+            }
+            Ok(false)
         },
         None => Ok(false),
     }
@@ -1090,7 +1186,11 @@ mod tests {
     use notify::event::{CreateKind, Flag, ModifyKind};
 
     use super::*;
-    use crate::config::{Config, LlmConfig, ResolvedTarget, TargetKind, WatchConfig};
+    use crate::config::{
+        Config, LlmConfig, RemoteBackend, RemoteEmbeddingConfig, ResolvedTarget, TargetKind,
+        WatchConfig,
+    };
+    use crate::embedding_models::{FASTEMBED_MODEL_ID, HASH_MODEL_ID, spec};
     use crate::language::Language;
 
     fn mutation_event(path: PathBuf) -> Event {
@@ -1122,6 +1222,53 @@ mod tests {
             memory: Default::default(),
             log: Default::default(),
         }
+    }
+
+    fn ephemeral_remote(query_endpoint: Option<&str>) -> RemoteEmbeddingConfig {
+        RemoteEmbeddingConfig {
+            model: "all-minilm".to_string(),
+            backend: RemoteBackend::Ollama,
+            endpoint: None,
+            cookbook: Some("@rag-rat/cookbook/modal".to_string()),
+            query_endpoint: query_endpoint.map(str::to_string),
+            auth_env: None,
+            gpu: None,
+            num_ctx: None,
+            batch_size: 256,
+            concurrency: 32,
+            max_batch_chars: 384_000,
+            request_timeout_s: 5,
+        }
+    }
+
+    fn activate_ephemeral_model(config: &Config, repo_id: &str, query_endpoint: Option<&str>) {
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        let remote = ephemeral_remote(query_endpoint);
+        let model_spec = spec(FASTEMBED_MODEL_ID).unwrap();
+        conn.execute(
+            "UPDATE ai_models
+             SET installed = 1, disabled = 0, status = 'Ready', embedding_dim = ?2, runtime = \
+             'ollama', last_error = NULL
+             WHERE model_id = ?1",
+            rusqlite::params![FASTEMBED_MODEL_ID, i64::try_from(model_spec.dim).unwrap()],
+        )
+        .unwrap();
+        crate::index::set_repo_meta(&conn, repo_id, "active_embedding_model", FASTEMBED_MODEL_ID)
+            .unwrap();
+        crate::index::set_repo_meta(
+            &conn,
+            repo_id,
+            "active_embedding_remote_config",
+            &serde_json::to_string(&remote).unwrap(),
+        )
+        .unwrap();
+        crate::index::set_repo_meta(
+            &conn,
+            repo_id,
+            "embedding_active_model_version",
+            &crate::index::ai::remote_freshness_version(model_spec, &remote),
+        )
+        .unwrap();
     }
 
     #[derive(Debug, Default)]
@@ -1189,6 +1336,292 @@ mod tests {
         watcher.unwatch(Path::new("repo/src")).unwrap();
         assert_eq!(<RecordingWatcher as notify::Watcher>::kind(), notify::WatcherKind::NullWatcher,);
         assert_eq!(watcher.watched.len(), 1);
+    }
+
+    #[test]
+    fn startup_catchup_does_not_force_the_expensive_tail() {
+        assert!(
+            !should_run_pass_tail(false, false, STARTUP_CATCHUP_RUN_GC, false, false),
+            "an unchanged startup catch-up must not run reconcile/gc/memory validation",
+        );
+        assert!(
+            should_run_pass_tail(true, false, STARTUP_CATCHUP_RUN_GC, false, false),
+            "real base content changes still run the maintenance tail",
+        );
+        assert!(
+            should_run_pass_tail(false, true, STARTUP_CATCHUP_RUN_GC, false, false),
+            "linked-worktree overlay changes still run the maintenance tail",
+        );
+        assert!(
+            should_run_pass_tail(false, false, true, false, false),
+            "scheduled GC passes still force the maintenance tail",
+        );
+        assert!(
+            should_run_pass_tail(false, false, STARTUP_CATCHUP_RUN_GC, true, false),
+            "a bounded shutdown discover marks base reconcile owed for the next startup pass",
+        );
+        assert!(
+            should_run_pass_tail(false, false, STARTUP_CATCHUP_RUN_GC, false, true),
+            "startup catch-up retries an already-indexed base embedding backlog",
+        );
+    }
+
+    #[test]
+    fn changed_overlay_skips_backlog_probe() {
+        let budget = ReconcileBudget::new(
+            ReconcileOptions::default(),
+            Instant::now() - Duration::from_secs(1),
+        );
+        let needs_embed = overlay_needs_embed(true, Some(&budget), |_| false);
+
+        assert!(needs_embed, "a changed overlay still embeds inline");
+    }
+
+    #[test]
+    fn forced_tail_skips_base_backlog_probe() {
+        let budget = ReconcileBudget::new(
+            ReconcileOptions::default(),
+            Instant::now() - Duration::from_secs(1),
+        );
+        let needs_tail = base_embedding_backlog_needs_tail(true, true, &budget, |_| true);
+
+        assert!(!needs_tail, "another tail trigger already guarantees reconcile");
+    }
+
+    #[test]
+    fn maintenance_pass_or_skip_runs_when_lock_is_available() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let id = N.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir()
+            .join(format!("ragrat-watch-maintenance-skip-{}-{id}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/lib.rs"), "pub fn maintenance_target() {}\n").unwrap();
+        let root = root.canonicalize().unwrap();
+        let config = whole_root_config(&root, &[PathBuf::from("src")]);
+
+        assert!(
+            maintenance_pass_or_skip(&config, false).unwrap(),
+            "an available writer lock should run the maintenance pass"
+        );
+        let db = IndexDatabase::open_config(&config).unwrap();
+        assert!(
+            db.status(&config.database).unwrap().file_count_by_language.values().sum::<u64>() > 0
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn startup_catchup_retries_existing_base_embedding_backlog() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let id = N.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir()
+            .join(format!("ragrat-watch-startup-backlog-{}-{id}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(
+            root.join("src/lib.rs"),
+            "pub fn pending_startup_embedding(input: i32) -> i32 {
+    let doubled = input * 2;
+    let shifted = doubled + 13;
+    shifted + 7
+}
+",
+        )
+        .unwrap();
+        let root = root.canonicalize().unwrap();
+
+        let mut config = whole_root_config(&root, &[PathBuf::from("src")]);
+        config.llm.embedding.backend = HASH_MODEL_ID.parse().unwrap();
+
+        let db = IndexDatabase::rebuild(&config).unwrap();
+        db.install_model(HASH_MODEL_ID, None).unwrap();
+        assert!(
+            db.pending_embedding_jobs().unwrap() > 0,
+            "fixture starts with indexed chunks but no embeddings"
+        );
+        drop(db);
+
+        startup_catchup_pass(&config).unwrap();
+        let db = IndexDatabase::open_config(&config).unwrap();
+        assert_eq!(
+            db.pending_embedding_jobs().unwrap(),
+            0,
+            "unchanged startup catch-up retried and embedded the existing base backlog"
+        );
+        assert!(
+            db.current_embedding_count(HASH_MODEL_ID).unwrap() > 0,
+            "startup retry wrote hash embeddings"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn startup_catchup_skips_ephemeral_backlog_scan_without_query_endpoint() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let id = N.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir()
+            .join(format!("ragrat-watch-ephemeral-backlog-{}-{id}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(
+            root.join("src/lib.rs"),
+            "pub fn pending_ephemeral_startup(input: i32) -> i32 {
+    let doubled = input * 2;
+    let shifted = doubled + 13;
+    shifted + 7
+}
+",
+        )
+        .unwrap();
+        let root = root.canonicalize().unwrap();
+
+        let mut config = whole_root_config(&root, &[PathBuf::from("src")]);
+        config.llm.embedding.backend = FASTEMBED_MODEL_ID.parse().unwrap();
+
+        let db = IndexDatabase::rebuild(&config).unwrap();
+        let repo_id = db.active_repo_id.clone();
+        drop(db);
+        activate_ephemeral_model(&config, &repo_id, None);
+
+        let db = IndexDatabase::open_config(&config).unwrap();
+        assert!(
+            db.pending_embedding_jobs().unwrap() > 0,
+            "fixture has indexed chunks missing embeddings for the active ephemeral model"
+        );
+        drop(db);
+
+        crate::index::ai::reset_estimated_reconcile_job_calls();
+        startup_catchup_pass(&config).unwrap();
+        assert_eq!(
+            crate::index::ai::estimated_reconcile_job_calls(),
+            0,
+            "startup must not scan chunks before the ephemeral light endpoint is known usable"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn startup_catchup_reconciles_shutdown_discovered_content() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let id = N.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir()
+            .join(format!("ragrat-watch-shutdown-reconcile-{}-{id}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(
+            root.join("src/lib.rs"),
+            "pub fn initial_value(input: i32) -> i32 {
+    let doubled = input * 2;
+    let shifted = doubled + 13;
+    shifted + 7
+}
+",
+        )
+        .unwrap();
+        let root = root.canonicalize().unwrap();
+
+        let mut config = whole_root_config(&root, &[PathBuf::from("src")]);
+        config.llm.embedding.backend = HASH_MODEL_ID.parse().unwrap();
+
+        let db = IndexDatabase::rebuild(&config).unwrap();
+        db.install_model(HASH_MODEL_ID, None).unwrap();
+        db.reconcile_with_options_progress(ReconcileOptions::default(), |_| {}).unwrap();
+        assert!(
+            db.current_embedding_count(HASH_MODEL_ID).unwrap() > 0,
+            "fixture must produce at least one embeddable chunk"
+        );
+        assert_eq!(db.pending_embedding_jobs().unwrap(), 0, "fixture starts fully reconciled");
+        assert!(
+            !shutdown_discover(&config).unwrap(),
+            "shutdown discover without source edits has no reconcile marker to set"
+        );
+        drop(db);
+
+        std::fs::write(
+            root.join("src/lib.rs"),
+            "pub fn changed_value(input: i32) -> i32 {
+    let tripled = input * 3;
+    let shifted = tripled + 21;
+    shifted - 4
+}
+",
+        )
+        .unwrap();
+        assert!(shutdown_discover(&config).unwrap(), "shutdown discover indexed the edit");
+
+        let db = IndexDatabase::open_config(&config).unwrap();
+        assert!(
+            db.watch_shutdown_reconcile_pending().unwrap(),
+            "shutdown-discovered content leaves a startup reconcile marker"
+        );
+        assert!(
+            db.pending_embedding_jobs().unwrap() > 0,
+            "the discover-only shutdown pass leaves changed chunks without embeddings"
+        );
+        drop(db);
+
+        maintenance_pass(&config, STARTUP_CATCHUP_RUN_GC).unwrap();
+        let db = IndexDatabase::open_config(&config).unwrap();
+        assert!(
+            !db.watch_shutdown_reconcile_pending().unwrap(),
+            "successful startup reconcile clears the shutdown marker"
+        );
+        assert_eq!(
+            db.pending_embedding_jobs().unwrap(),
+            0,
+            "startup catch-up embedded the backlog"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn startup_catchup_keeps_shutdown_marker_when_reconcile_is_blocked() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let id = N.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir()
+            .join(format!("ragrat-watch-shutdown-blocked-{}-{id}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(
+            root.join("src/lib.rs"),
+            "pub fn pending_embedding(input: i32) -> i32 {
+    let doubled = input * 2;
+    let shifted = doubled + 13;
+    shifted + 7
+}
+",
+        )
+        .unwrap();
+        let root = root.canonicalize().unwrap();
+
+        let config = whole_root_config(&root, &[PathBuf::from("src")]);
+        let db = IndexDatabase::rebuild(&config).unwrap();
+        db.mark_watch_shutdown_reconcile_pending().unwrap();
+        drop(db);
+
+        maintenance_pass(&config, STARTUP_CATCHUP_RUN_GC).unwrap();
+        let db = IndexDatabase::open_config(&config).unwrap();
+        assert!(
+            db.watch_shutdown_reconcile_pending().unwrap(),
+            "a blocked startup reconcile must keep the shutdown marker for a later retry"
+        );
+        assert_eq!(
+            db.pending_embedding_jobs().unwrap(),
+            0,
+            "not-ready models report no pending jobs, so marker clearing must key off status"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]
@@ -2694,6 +3127,24 @@ mod tests {
         false
     }
 
+    /// Drain real-watcher setup noise until the channel stays quiet for `quiet_ms`, capped by
+    /// `max_ms`, so negative placement probes only observe events from the mutation under test.
+    fn drain_until_quiet(
+        rx: &std::sync::mpsc::Receiver<notify::Result<Event>>,
+        quiet_ms: u64,
+        max_ms: u64,
+    ) {
+        let quiet = Duration::from_millis(quiet_ms);
+        let deadline = Instant::now() + Duration::from_millis(max_ms);
+        while Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            match rx.recv_timeout(quiet.min(remaining)) {
+                Ok(_) => {},
+                Err(RecvTimeoutError::Timeout | RecvTimeoutError::Disconnected) => break,
+            }
+        }
+    }
+
     // Linux/inotify only: this asserts the watch-PLACEMENT optimization (an ignored subtree gets no
     // watch, so its edits are never delivered) — the mitigation for inotify `max_user_watches`
     // exhaustion that motivated #331/#332. inotify places one NON-recursive watch per directory, so
@@ -2715,13 +3166,13 @@ mod tests {
         static N: AtomicU64 = AtomicU64::new(0);
         let id = N.fetch_add(1, Ordering::Relaxed);
         let root = std::env::temp_dir().join(format!("ragrat-331ign-{}-{id}", std::process::id()));
-        std::fs::create_dir_all(root.join("ignored_dir")).unwrap();
-        std::fs::create_dir_all(root.join("kept_dir")).unwrap();
+        std::fs::create_dir_all(root.join("ignored_dir/nested")).unwrap();
+        std::fs::create_dir_all(root.join("kept_dir/nested")).unwrap();
         let root = root.canonicalize().unwrap();
         std::fs::write(root.join(".gitignore"), "ignored_dir/\n").unwrap();
         // Seed a file in each so the dirs exist before the watch is placed.
-        std::fs::write(root.join("ignored_dir/a.rs"), "// a\n").unwrap();
-        std::fs::write(root.join("kept_dir/b.rs"), "// b\n").unwrap();
+        std::fs::write(root.join("ignored_dir/nested/a.rs"), "// a\n").unwrap();
+        std::fs::write(root.join("kept_dir/nested/b.rs"), "// b\n").unwrap();
 
         let (tx, rx) = std::sync::mpsc::channel();
         let Ok(mut w) = recommended_watcher(move |res| {
@@ -2733,14 +3184,17 @@ mod tests {
         // Place watches exactly as watcher_main does: the gitignore-pruned target subtree.
         let ignore = IgnoreMatcher::compile(&root, &[PathBuf::from(".")]);
         watch_tree_pruned(&mut w, &root, &ignore);
+        drain_until_quiet(&rx, 100, 1000);
 
         // A write inside the gitignored subtree must NOT be delivered (the dir was never watched).
-        std::fs::write(root.join("ignored_dir/a.rs"), "// a edited\n").unwrap();
-        let ignored_seen = drain_until_path_under(&rx, &root.join("ignored_dir"), 2);
+        let ignored_probe = root.join("ignored_dir/nested");
+        std::fs::write(ignored_probe.join("a.rs"), "// a edited\n").unwrap();
+        let ignored_seen = drain_until_path_under(&rx, &ignored_probe, 2);
 
         // A write to a non-ignored sibling under the same target MUST be delivered.
-        std::fs::write(root.join("kept_dir/b.rs"), "// b edited\n").unwrap();
-        let kept_seen = drain_until_path_under(&rx, &root.join("kept_dir"), 3);
+        let kept_probe = root.join("kept_dir/nested");
+        std::fs::write(kept_probe.join("b.rs"), "// b edited\n").unwrap();
+        let kept_seen = drain_until_path_under(&rx, &kept_probe, 3);
 
         drop(w);
         std::fs::remove_dir_all(&root).ok();
@@ -3065,24 +3519,28 @@ mod tests {
         let config = whole_root_config(&root, &target_dirs);
         let mut ignore = IgnoreMatcher::compile(&root, &target_dirs);
         watch_tree_pruned(&mut w, &root, &ignore);
+        drain_until_quiet(&rx, 100, 1000);
 
         // Build the moved-in dir with a NESTED `.gitignore` ignoring `ignored_sub/`, plus a kept
         // sibling — all created BEFORE feeding the rename event (so the matcher was stale to them).
         let pkg = root.join("pkg");
-        std::fs::create_dir_all(pkg.join("ignored_sub")).unwrap();
-        std::fs::create_dir_all(pkg.join("kept_sub")).unwrap();
+        std::fs::create_dir_all(pkg.join("ignored_sub/deep")).unwrap();
+        std::fs::create_dir_all(pkg.join("kept_sub/deep")).unwrap();
         std::fs::write(pkg.join(".gitignore"), "ignored_sub/\n").unwrap();
-        std::fs::write(pkg.join("ignored_sub/x.rs"), "// x\n").unwrap();
-        std::fs::write(pkg.join("kept_sub/y.rs"), "// y\n").unwrap();
+        std::fs::write(pkg.join("ignored_sub/deep/x.rs"), "// x\n").unwrap();
+        std::fs::write(pkg.join("kept_sub/deep/y.rs"), "// y\n").unwrap();
         let rename =
             Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::To))).add_path(pkg.clone());
         watch_created_dirs(&mut w, &rename, &config, &target_dirs, &mut ignore, None);
+        drain_until_quiet(&rx, 100, 1000);
 
         // The nested-ignored subdir must NOT be watched; the kept sibling MUST be.
-        std::fs::write(pkg.join("ignored_sub/x.rs"), "// x edited\n").unwrap();
-        let ignored_seen = drain_until_path_under(&rx, &pkg.join("ignored_sub"), 2);
-        std::fs::write(pkg.join("kept_sub/y.rs"), "// y edited\n").unwrap();
-        let kept_seen = drain_until_path_under(&rx, &pkg.join("kept_sub"), 3);
+        let ignored_probe = pkg.join("ignored_sub/deep");
+        std::fs::write(ignored_probe.join("x.rs"), "// x edited\n").unwrap();
+        let ignored_seen = drain_until_path_under(&rx, &ignored_probe, 2);
+        let kept_probe = pkg.join("kept_sub/deep");
+        std::fs::write(kept_probe.join("y.rs"), "// y edited\n").unwrap();
+        let kept_seen = drain_until_path_under(&rx, &kept_probe, 3);
 
         drop(w);
         std::fs::remove_dir_all(&root).ok();

--- a/rag-rat.toml
+++ b/rag-rat.toml
@@ -1,6 +1,5 @@
 [index]
 root = "."
-database = ".rag-rat/index.sqlite"
 
 [llm.embedding]
 # DOGFOOD: jina-embeddings-v2-base-code (768-dim, 8192-token ALiBi context) — a CODE-specialized


### PR DESCRIPTION
## Summary
- Add append-vs-full git-history prepare plans so fast-forward HEAD moves insert only new commits, file changes, and matching commit FTS rows.
- Revalidate the expected git-history cursor under the write lock, skip already-applied appends, and fall back to full replacement for torn state, shallow repos, root/config changes, and non-fast-forward rewrites including rebases, amends, squashes, force-pushes, and branch switches.
- Keep clean HEAD advances from forcing a full file rebuild by restamping existing repo-generation rows, bump gix to 0.85.0, and stop watcher startup catch-up from forcing reconcile/GC on unchanged checkouts.
- Remove the checked-in repo-local `database` pin from `rag-rat.toml` so the repo uses the keyless global database path.
- De-flake the Linux ignored-subtree watcher probes by draining setup events and probing nested paths, while preserving the placement assertion.

## Root Cause
Every HEAD change previously invalidated the stored git-history cursor and ran the full replacement path: delete repo git history rows, invalidate chunk blame, reinsert all commits/file changes, and rebuild commit FTS. That made ordinary commit-driven maintenance O(total history) per pass and amplified startup/watch writes.

The CI failure in `watch::tests::gitignored_subdir_under_a_target_is_not_watched` was a stale-event test hazard: the negative probe could consume watcher setup or parent-directory noise instead of only observing the mutation under test.

## Validation
- cargo +nightly fmt --check
- cargo test -p rag-rat-core git_history_ --locked
- cargo test -p rag-rat-core startup_catchup_does_not_force_the_expensive_tail --locked
- cargo test -p rag-rat-core linked_worktree_events_honor_its_ignore_rules --locked
- cargo test -p rag-rat-core --lib --locked
- cargo clippy -p rag-rat-core --all-targets --locked
- cargo test -p rag-rat --test init_yes_writes_valid_config --locked
- cargo test -p rag-rat-core watch::tests::gitignored_subdir_under_a_target_is_not_watched --locked -- --nocapture
- cargo test -p rag-rat-core watch::tests::a_moved_in_dir_with_a_nested_gitignore_prunes_against_it --locked -- --nocapture
- cargo nextest run -p rag-rat-core 'watch::tests::' --no-default-features --locked --profile ci --failure-output immediate-final
- cargo clippy -p rag-rat-core --all-targets --no-default-features --locked -- -D warnings
- git diff --check

Closes #459