### PR TITLE
feat(memory): allow unanchored nodes (Concept / standalone Task)

### DIFF
--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -2443,3 +2443,136 @@ fn surface_summary_defers_bodies_across_the_db_memory_renderers() {
 
     let _ = fs::remove_dir_all(&root);
 }
+
+/// #463: a node created with NO binding target is UNANCHORED — a graph node (a `Concept` /
+/// standalone `Task`) with no code anchor. It surfaces in the general `memory list` with blank
+/// binding columns, dedupes against another unanchored node of the same text, is excluded by a
+/// binding-kind filter, and is never flagged by `memory_validate` (no anchor to go stale/gone).
+#[test]
+fn unanchored_node_is_created_listed_and_deduped() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn anchor() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let make = || crate::query::memory::RepoMemoryCreate {
+        kind: "Decision".to_string(), /* Task/Concept kinds land in #465; any kind may be
+                                       * unanchored. */
+        title: "Prefer the event log over polling".to_string(),
+        body: "A cross-cutting decision not anchored to any one symbol.".to_string(),
+        confidence: "high".to_string(),
+        created_by: Some("test-agent".to_string()),
+        source: Some("agent".to_string()),
+        tags: vec![],
+        bind: crate::query::memory::RepoMemoryBindTarget::default(), // empty → unanchored
+    };
+
+    let created = db.memory_create(make()).unwrap();
+    assert!(!created.duplicate);
+    assert!(created.memory.bindings.is_empty(), "an unanchored node has zero bindings");
+
+    let conn = db.storage.connection();
+
+    // Surfaces in the general list with blank binding columns (LEFT JOIN).
+    let all = crate::query::memory::list_memories(conn, None).unwrap();
+    let summary = all
+        .iter()
+        .find(|s| s.memory_id == created.memory.memory_id)
+        .expect("unanchored node must appear in `memory list`");
+    assert_eq!(summary.kind, "Decision");
+    assert_eq!(summary.binding_kind, "");
+    assert_eq!(summary.binding_id, "");
+
+    // A binding-kind filter excludes it (it has no binding kind).
+    assert!(
+        crate::query::memory::list_memories(conn, Some("path")).unwrap().is_empty(),
+        "an unanchored node must not surface under a binding-kind filter"
+    );
+
+    // A second unanchored node with identical text dedupes to the same id.
+    let again = db.memory_create(make()).unwrap();
+    assert!(again.duplicate, "a second unanchored node with the same text dedupes");
+    assert_eq!(again.memory.memory_id, created.memory.memory_id);
+
+    // Validation never flags an unanchored node (no anchor to go stale/gone).
+    assert_eq!(db.memory_validate().unwrap().stale, 0);
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #463: `memory_rebind` still REQUIRES an anchor — moving a memory to "no binding" is meaningless.
+/// Only `memory_create` accepts the unanchored case.
+#[test]
+fn rebind_still_requires_a_binding_target() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn anchor() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Decision".to_string(),
+            title: "an unanchored node".to_string(),
+            body: "created without a binding".to_string(),
+            confidence: "medium".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: vec![],
+            bind: crate::query::memory::RepoMemoryBindTarget::default(),
+        })
+        .unwrap();
+
+    let err = db
+        .memory_rebind(
+            &created.memory.memory_id,
+            crate::query::memory::RepoMemoryBindTarget::default(),
+        )
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("requires a binding target"),
+        "rebind must reject an empty bind target: {err}"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #463 guard: a PARTIALLY populated bind (an intended anchor missing a field) must ERROR, not
+/// silently become an unanchored node — otherwise a typo'd anchor yields an invisible memory that
+/// no `memory_for_*` lookup surfaces and validation never checks.
+#[test]
+fn a_partial_binding_is_rejected_not_silently_unanchored() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn anchor() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    // github owner+repo but NO number — an incomplete anchor, not an unanchored node.
+    let err = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Decision".to_string(),
+            title: "partial github anchor".to_string(),
+            body: "owner+repo without a number".to_string(),
+            confidence: "low".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: vec![],
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                github_owner: Some("o".to_string()),
+                github_repo: Some("r".to_string()),
+                ..Default::default()
+            },
+        })
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("binding is incomplete"),
+        "a partial binding must be rejected, got: {err}"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}

--- a/crates/rag-rat-core/src/query/memory/api.rs
+++ b/crates/rag-rat-core/src/query/memory/api.rs
@@ -17,9 +17,12 @@ pub(crate) fn create_memory(
     validate_len("body", &request.body, MAX_MEMORY_BODY_LEN)?;
     let source = request.source.clone().unwrap_or_else(|| "agent".to_string());
     validate_source(&source)?;
+    // `None` = an UNANCHORED node (#463): a `Concept` / standalone `Task` with no code anchor.
     let binding = resolve_binding(conn, &request.bind)?;
     let input_hash = memory_input_hash(&request.kind, &request.title, &request.body, &request.tags);
-    if let Some(existing_id) = duplicate_memory_id(conn, &request.title, &request.body, &binding)? {
+    if let Some(existing_id) =
+        duplicate_memory_id(conn, &request.title, &request.body, binding.as_ref())?
+    {
         let memory = memory_by_id(conn, &existing_id)?
             .ok_or_else(|| anyhow::anyhow!("duplicate memory `{existing_id}` disappeared"))?;
         return Ok(RepoMemoryCreateResult { memory, duplicate: true });
@@ -49,14 +52,17 @@ pub(crate) fn create_memory(
             request.created_by,
             now,
             source,
-            binding.source_text_hash,
+            binding.as_ref().and_then(|b| b.source_text_hash.clone()),
             input_hash
         ],
     )?;
-    insert_binding(conn, &id, &binding, now)?;
-    // A symbol-bound memory whose logical symbol has a known SCIP moniker gets the moniker anchor
-    // automatically (#70) — the relocation fallback the hash anchors can't provide.
-    insert_auto_moniker_binding(conn, &id, &binding, now)?;
+    // Unanchored nodes (#463) skip binding writes entirely — nothing to insert or auto-moniker.
+    if let Some(binding) = &binding {
+        insert_binding(conn, &id, binding, now)?;
+        // A symbol-bound memory whose logical symbol has a known SCIP moniker gets the moniker
+        // anchor automatically (#70) — the relocation fallback the hash anchors can't provide.
+        insert_auto_moniker_binding(conn, &id, binding, now)?;
+    }
     // Stamp the active repo on the new memory, then stamp its bindings FROM the (now-stamped)
     // parent memory (spec §4.5: a binding defaults to its memory's repo). Gated on the
     // periphery scope — a no-op on the pre-A5 schema (no `repo_id` column). MUST run before
@@ -510,7 +516,14 @@ pub(crate) fn rebind_memory(
     // Resolve inside the transaction so the stamped source_text_hash is consistent with the
     // bindings written in the same atomic unit.
     let tx = conn.unchecked_transaction()?;
-    let binding = resolve_binding(conn, &bind)?;
+    // Rebind MUST name an anchor — moving a memory to "no binding" is meaningless (delete/recreate
+    // it unanchored instead). Only `create_memory` accepts the unanchored (`None`) case (#463).
+    let binding = resolve_binding(conn, &bind)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "memory_rebind requires a binding target: logical_symbol_id, symbol_id, chunk_id, \
+             edge_id, call path, path/span, commit_hash, or github ref"
+        )
+    })?;
     conn.execute("DELETE FROM repo_memory_bindings WHERE memory_id = ?1", [memory_id])?;
     conn.execute("DELETE FROM repo_memory_call_paths WHERE memory_id = ?1", [memory_id])?;
     let now = now_ms();
@@ -577,19 +590,25 @@ pub(crate) fn list_memories(
         ))?;
         stmt.query_map([binding_kind], memory_summary_row)?.collect::<Result<_, _>>()?
     } else {
+        // LEFT JOIN (not INNER): an UNANCHORED node (#463) has no bindings and must still list —
+        // its binding columns come back NULL (rendered blank). The "first binding"
+        // correlation moves into the ON clause so a zero-binding memory keeps its row. (The
+        // kind-filtered branch above stays an inner join — filtering BY a binding kind
+        // correctly excludes bindingless nodes.)
         let mut stmt = conn.prepare(&format!(
             "
             SELECT m.id AS memory_id, m.kind, m.title, m.status,
                    b.binding_kind, b.binding_id
             FROM repo_memories AS m
-            JOIN repo_memory_bindings AS b ON b.memory_id = m.id
-            WHERE m.status IN ('active', 'stale'){repo_clause}
+            LEFT JOIN repo_memory_bindings AS b
+              ON b.memory_id = m.id
               AND b.rowid = (
                   SELECT b2.rowid FROM repo_memory_bindings AS b2
                   WHERE b2.memory_id = m.id
                   ORDER BY b2.binding_kind, b2.binding_id
                   LIMIT 1
               )
+            WHERE m.status IN ('active', 'stale'){repo_clause}
             ORDER BY m.updated_at_ms DESC
             "
         ))?;
@@ -604,8 +623,9 @@ fn memory_summary_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<MemorySummary
         kind: row.get(1)?,
         title: row.get(2)?,
         status: row.get(3)?,
-        binding_kind: row.get(4)?,
-        binding_id: row.get(5)?,
+        // NULL for an unanchored node (#463, LEFT JOIN) → blank.
+        binding_kind: row.get::<_, Option<String>>(4)?.unwrap_or_default(),
+        binding_id: row.get::<_, Option<String>>(5)?.unwrap_or_default(),
     })
 }
 

--- a/crates/rag-rat-core/src/query/memory/hydrate.rs
+++ b/crates/rag-rat-core/src/query/memory/hydrate.rs
@@ -4,16 +4,19 @@ pub(crate) fn duplicate_memory_id(
     conn: &Connection,
     title: &str,
     body: &str,
-    binding: &ResolvedBinding,
+    binding: Option<&ResolvedBinding>,
 ) -> anyhow::Result<Option<String>> {
     // Dedupe NEVER crosses repos (spec §4.4): a duplicate is a same-repo title+body+binding match.
     // The `{repo_clause}` is empty on the pre-A5 schema (memory still repo-global), so this stays
-    // the original global dedupe until the periphery-scoping migration lands.
+    // the original global dedupe until the periphery-scoping migration lands. An UNANCHORED node
+    // (#463) has no binding, so its dupe is a same-repo title+body match with NO bindings — never a
+    // false collision with an anchored memory that happens to share text.
     let scope = memory_repo_scope(conn)?;
     let repo_clause = memory_repo_scope_clause(&scope);
-    conn.query_row(
-        &format!(
-            "
+    match binding {
+        Some(binding) => conn.query_row(
+            &format!(
+                "
         SELECT repo_memories.id AS memory_id
         FROM repo_memories
         JOIN repo_memory_bindings ON repo_memory_bindings.memory_id = repo_memories.id
@@ -24,10 +27,29 @@ pub(crate) fn duplicate_memory_id(
           AND repo_memories.status != 'obsolete'{repo_clause}
         LIMIT 1
         "
+            ),
+            params![title.trim(), body.trim(), binding.binding_kind, binding.binding_id],
+            |row| row.get("memory_id"),
         ),
-        params![title.trim(), body.trim(), binding.binding_kind, binding.binding_id],
-        |row| row.get("memory_id"),
-    )
+        None => conn.query_row(
+            &format!(
+                "
+        SELECT repo_memories.id AS memory_id
+        FROM repo_memories
+        WHERE lower(repo_memories.title) = lower(?1)
+          AND lower(repo_memories.body) = lower(?2)
+          AND repo_memories.status != 'obsolete'{repo_clause}
+          AND NOT EXISTS (
+              SELECT 1 FROM repo_memory_bindings WHERE repo_memory_bindings.memory_id = \
+                 repo_memories.id
+          )
+        LIMIT 1
+        "
+            ),
+            params![title.trim(), body.trim()],
+            |row| row.get("memory_id"),
+        ),
+    }
     .optional()
     .map_err(Into::into)
 }

--- a/crates/rag-rat-core/src/query/memory/mod.rs
+++ b/crates/rag-rat-core/src/query/memory/mod.rs
@@ -160,7 +160,7 @@ pub struct RepoMemoryCreate {
     pub bind: RepoMemoryBindTarget,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 pub struct RepoMemoryBindTarget {
     // Accept the opaque `sym_<hex>` handle (#149); `default` keeps it optional under the custom
     // deserializer.
@@ -204,6 +204,17 @@ pub struct RepoMemoryBindTarget {
     /// Directory anchor: a repo-root-relative directory path, or `""` for the repo root.
     /// Normalized on resolve (trim, drop leading `./`, strip trailing `/`).
     pub dir: Option<String>,
+}
+
+impl RepoMemoryBindTarget {
+    /// True iff NO field is set — a truly empty target, i.e. an UNANCHORED node (#463). Derived
+    /// structurally (`== default`) so it is drift-proof: any field added to this struct is covered
+    /// automatically. A PARTIALLY populated target (some field set, but not a complete binding —
+    /// e.g. github owner+repo without a number, or a span without a path) is NOT empty; it is a
+    /// malformed anchor that `resolve_binding` rejects rather than silently treating as unanchored.
+    pub(crate) fn is_empty(&self) -> bool {
+        self == &Self::default()
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/rag-rat-core/src/query/memory/resolve.rs
+++ b/crates/rag-rat-core/src/query/memory/resolve.rs
@@ -1,36 +1,41 @@
 use super::*;
 
+/// Resolve the ONE binding target a bind request names, or `Ok(None)` when the request names none
+/// — an UNANCHORED node (#463): a `Concept` or standalone `Task` lives only as a graph node, with
+/// no code anchor. This is the single source of truth for "is a binding present"; each caller
+/// decides what to do with `None` (`create_memory` allows it; `rebind_memory` rejects it — a rebind
+/// with nothing to bind to is meaningless). `Err` is reserved for a NAMED-but-unresolvable target.
 pub(crate) fn resolve_binding(
     conn: &Connection,
     bind: &RepoMemoryBindTarget,
-) -> anyhow::Result<ResolvedBinding> {
+) -> anyhow::Result<Option<ResolvedBinding>> {
     if let Some(logical_symbol_id) = bind.logical_symbol_id {
-        return resolve_logical_symbol_binding(conn, logical_symbol_id);
+        return resolve_logical_symbol_binding(conn, logical_symbol_id).map(Some);
     }
     if let Some(symbol_id) = bind.symbol_id {
-        return resolve_symbol_binding(conn, symbol_id);
+        return resolve_symbol_binding(conn, symbol_id).map(Some);
     }
     if let Some(chunk_id) = bind.chunk_id {
-        return resolve_chunk_binding(conn, chunk_id);
+        return resolve_chunk_binding(conn, chunk_id).map(Some);
     }
     if let Some(edge_id) = bind.edge_id {
-        return resolve_edge_binding(conn, edge_id);
+        return resolve_edge_binding(conn, edge_id).map(Some);
     }
     // Server-derived call path (preferred): compute the authoritative hash from the edges.
     if let Some(edge_path) = bind.edge_path.as_deref() {
-        return resolve_call_path_from_edges(conn, bind, edge_path);
+        return resolve_call_path_from_edges(conn, bind, edge_path).map(Some);
     }
     if let Some(edge_sequence_hash) = bind.edge_sequence_hash.as_deref() {
-        return resolve_call_path_binding(conn, bind, edge_sequence_hash);
+        return resolve_call_path_binding(conn, bind, edge_sequence_hash).map(Some);
     }
     if let Some(dir) = bind.dir.as_deref() {
-        return resolve_dir_binding(conn, dir);
+        return resolve_dir_binding(conn, dir).map(Some);
     }
     if let Some(path) = bind.path.as_deref() {
-        return resolve_path_binding(conn, path, bind.start_line, bind.end_line);
+        return resolve_path_binding(conn, path, bind.start_line, bind.end_line).map(Some);
     }
     if let Some(commit_hash) = bind.commit_hash.as_deref() {
-        return Ok(ResolvedBinding {
+        return Ok(Some(ResolvedBinding {
             binding_kind: "commit".to_string(),
             binding_id: commit_hash.to_string(),
             path: None,
@@ -49,12 +54,12 @@ pub(crate) fn resolve_binding(
             call_path: None,
             source_text_hash: None,
             anchor_status: "unverified".to_string(),
-        });
+        }));
     }
     if let (Some(owner), Some(repo), Some(number)) =
         (bind.github_owner.as_deref(), bind.github_repo.as_deref(), bind.github_number)
     {
-        return Ok(ResolvedBinding {
+        return Ok(Some(ResolvedBinding {
             binding_kind: "github".to_string(),
             binding_id: format!("{owner}/{repo}#{number}"),
             path: None,
@@ -73,11 +78,20 @@ pub(crate) fn resolve_binding(
             call_path: None,
             source_text_hash: None,
             anchor_status: "unverified".to_string(),
-        });
+        }));
+    }
+    // Fell through every binding branch. A TRULY EMPTY target is an unanchored node (#463); a
+    // PARTIALLY populated one (e.g. github owner+repo without a number, a span without a path, or
+    // call-path metadata without an `edge_sequence_hash`/`edge_path`) is a malformed anchor —
+    // reject it rather than silently dropping the intended binding into an invisible unanchored
+    // memory.
+    if bind.is_empty() {
+        return Ok(None);
     }
     anyhow::bail!(
-        "memory_create requires logical_symbol_id, symbol_id, chunk_id, edge_id, call path, \
-         path/span, commit_hash, or github ref binding"
+        "memory_create binding is incomplete: give a full logical_symbol_id, symbol_id, chunk_id, \
+         edge_id, call path, path/span, commit_hash, or github (owner+repo+number) ref — or omit \
+         `bind` entirely to create an unanchored node"
     )
 }
 

--- a/crates/rag-rat-mcp/src/tools/requests.rs
+++ b/crates/rag-rat-mcp/src/tools/requests.rs
@@ -579,7 +579,7 @@ impl McpMemorySource {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
+#[derive(Debug, Default, Deserialize, Serialize, schemars::JsonSchema)]
 pub struct MemoryBindArgs {
     // 64-bit content hash > 2^53: take it as a string so a JSON client doesn't round it (#130).
     #[serde(
@@ -638,6 +638,9 @@ pub struct MemoryCreateArgs {
     pub source: Option<McpMemorySource>,
     #[serde(default)]
     pub tags: Vec<String>,
+    /// Optional (#463): omit to create an UNANCHORED node (a `Concept` or standalone `Task` that
+    /// lives only as a graph node). When present, names exactly one code/anchor binding.
+    #[serde(default)]
     pub bind: MemoryBindArgs,
 }
 

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -278,7 +278,8 @@ fn list_tools_exposes_complete_typed_schemas() {
     ]);
     assert_schema_has_property(tools, "heal_index", "limit");
     assert_schema_requires(tools, "memory_create", "kind");
-    assert_schema_requires(tools, "memory_create", "bind");
+    // `bind` is OPTIONAL (#463): omitting it creates an unanchored Concept/Task node.
+    assert_schema_has_property(tools, "memory_create", "bind");
     assert_schema_has_property(tools, "memory_create", "confidence");
     assert_schema_nested_property(tools, "memory_create", "bind", "edge_id");
     assert_schema_nested_property(tools, "memory_create", "bind", "edge_sequence_hash");


### PR DESCRIPTION
Allow a memory to be created with **no code anchor** — an unanchored node — the first prerequisite for the knowledge-graph data model (#462). `Concept` and standalone `Task` kinds will live only as graph nodes joined by memory→memory edges, with no symbol/path/commit binding.

## What changed

- **`resolve_binding` → `Option<ResolvedBinding>`** — the single source of truth for "is a binding present." `None` = a truly empty bind target (unanchored); a complete target resolves to `Some`; a **partially populated** target (e.g. github owner+repo without a number, or a span without a path) still **errors** rather than silently dropping the intended anchor into an invisible memory. Emptiness is derived structurally (`== default`), so it's drift-proof as bind fields are added.
- **`create_memory`** takes the unanchored path: skips binding + auto-moniker writes, nulls `source_text_hash`, and dedupes by title+body among bindingless nodes (never a false collision with an anchored memory that shares text).
- **`list_memories`** unfiltered variant `LEFT JOIN`s bindings so an unanchored node still surfaces in `memory list` (blank binding columns). The binding-kind-filtered variant still excludes them (a bindingless node has no binding kind).
- **`rebind_memory`** continues to require an anchor — rebinding to "nothing" is meaningless.
- **MCP `memory_create.bind`** is now optional (`#[serde(default)]`); omit it to create an unanchored node.

## Tests

- create → zero bindings, lists with blank binding columns, dedupes a second identical unanchored node, excluded by a binding-kind filter, never flagged by `memory_validate`.
- `rebind_memory` rejects an empty bind target.
- a partial binding (github owner+repo, no number) is rejected, not silently unanchored.

Closes #463

## Scope: dream-verify handling is deferred to #465

This PR is the create-side prerequisite only. `dream --verify` flags a memory with no live binding and no resolving identifier as `memory_unverifiable`; that stays unchanged here on purpose. Skipping intentional unanchored nodes there requires distinguishing them from zero-binding **orphans** (partial-write / imported rows), and the only clean distinguisher is **kind** (`Concept`/`Task`) — which is introduced in #465. Until then, every zero-binding memory is a should-be-anchored kind without an anchor, so flagging it is correct. The kind-gated skip is tracked on #465.
