### PR TITLE
fix(watch): gate the linux-only drain_until_quiet test helper behind cfg

### DIFF
--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -3179,6 +3179,7 @@ mod tests {
 
     /// Drain real-watcher setup noise until the channel stays quiet for `quiet_ms`, capped by
     /// `max_ms`, so negative placement probes only observe events from the mutation under test.
+    #[cfg(target_os = "linux")]
     fn drain_until_quiet(
         rx: &std::sync::mpsc::Receiver<notify::Result<Event>>,
         quiet_ms: u64,


### PR DESCRIPTION
## Root cause

The cross-platform CI (windows-latest / macos-latest) clippy job was red on `main`:

```
error: function `drain_until_quiet` is never used
  --> crates/rag-rat-core/src/watch.rs:3182:8
  = note: `-D dead-code` implied by `-D warnings`
```

`drain_until_quiet` is a `#[cfg(test)]` helper in `crates/rag-rat-core/src/watch.rs`. Its only callers live in watch-**placement** tests that are gated `#[cfg(target_os = "linux")]` (inotify-specific). On windows/macos those tests compile out, so the helper has no callers → dead code → the `--no-default-features --all-targets -- -D warnings` clippy leg fails. Linux CI stayed green because there the callers compile and the helper is live. The sibling `drain_until_path_under` was unaffected — it also has callers in non-Linux-gated tests.

## Fix

Gate the helper with `#[cfg(target_os = "linux")]` so it is present on exactly the platforms that use it, matching its exclusively-Linux callers. A targeted cfg rather than a blanket `#[allow(dead_code)]` keeps genuinely dead code detectable in the future. One-line change.

## Verification

- `cargo +nightly fmt` — clean.
- `cargo clippy --workspace --all-targets --no-default-features --locked -- -D warnings` on Linux — passes (unchanged; Linux was already green).
- The cross-platform CI (`CI (cross-platform)`) — `clippy (windows-latest)` and `clippy (macos-latest)` green on this branch.

Closes #467