### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.14.0...rag-rat-core-v0.15.0) - 2026-07-09
+
+### Added
+
+- *(oplog)* wire authoring into the live memory write path (phase B) ([#538](https://github.com/cq27-dev/rag-rat/pull/538))
+- *(oplog)* op-authoring helper + full backfill of existing memories (phase B, unwired) ([#526](https://github.com/cq27-dev/rag-rat/pull/526))
+- *(oracle)* live LSP client substrate for the incremental resolution path ([#531](https://github.com/cq27-dev/rag-rat/pull/531))
+- *(index)* realign logical-symbol references on key-derivation drift ([#493](https://github.com/cq27-dev/rag-rat/pull/493)) ([#525](https://github.com/cq27-dev/rag-rat/pull/525))
+- *(memory)* two-observation downgrade hysteresis for anchor status ([#492](https://github.com/cq27-dev/rag-rat/pull/492)) ([#528](https://github.com/cq27-dev/rag-rat/pull/528))
+- *(clones)* scip refine mode — moniker-collapse same-symbol callees to Type-2 ([#512](https://github.com/cq27-dev/rag-rat/pull/512))
+- *(dream)* expose dream + dream_review MCP tools ([#263](https://github.com/cq27-dev/rag-rat/pull/263)) ([#514](https://github.com/cq27-dev/rag-rat/pull/514))
+- *(oplog)* persisted local device identity — CSPRNG keygen + single-row store (phase B) ([#523](https://github.com/cq27-dev/rag-rat/pull/523))
+- *(oplog)* immutable stream identity — signed stream binding, stream-scoped store, fork quarantine (phase B S2) ([#511](https://github.com/cq27-dev/rag-rat/pull/511))
+- *(memory)* default the memory surface to summary; extend it to the memory-query tools ([#508](https://github.com/cq27-dev/rag-rat/pull/508))
+- *(oplog)* durable storage — layer-1 signed log + full-replay shadow projection (phase B C4) ([#504](https://github.com/cq27-dev/rag-rat/pull/504))
+- *(oplog)* signed hash-chained entry envelope + ed25519 device keys (phase B C4 layer-1) ([#500](https://github.com/cq27-dev/rag-rat/pull/500))
+- *(memory)* pending anchor status for in-flight worktree branches ([#496](https://github.com/cq27-dev/rag-rat/pull/496))
+- *(oplog)* memory op model + deterministic projection fold (phase B §5.4) ([#495](https://github.com/cq27-dev/rag-rat/pull/495))
+- *(clones)* per-generation df snapshot (clone_df_epoch) frees the live df to move ([#490](https://github.com/cq27-dev/rag-rat/pull/490))
+- *(memory)* canonical content_hash primitive (phase B §5.5) ([#480](https://github.com/cq27-dev/rag-rat/pull/480))
+- *(schema)* actionable version-skew messaging for the newer-schema refusal ([#487](https://github.com/cq27-dev/rag-rat/pull/487))
+- *(index)* quiet-pass WAL checkpointing + doctor file-health warnings ([#486](https://github.com/cq27-dev/rag-rat/pull/486))
+- *(locks)* per-database sync-session lock for the device-wide iroh endpoint ([#485](https://github.com/cq27-dev/rag-rat/pull/485))
+- *(clones)* incremental delta maintenance of the persisted clone graph ([#477](https://github.com/cq27-dev/rag-rat/pull/477))
+- *(memory)* typed cross-repo node edges (repo_node_edges) ([#476](https://github.com/cq27-dev/rag-rat/pull/476))
+- *(memory)* polymorphic node payload + Task/Concept kinds ([#471](https://github.com/cq27-dev/rag-rat/pull/471))
+- *(memory)* allow unanchored nodes (Concept / standalone Task) ([#466](https://github.com/cq27-dev/rag-rat/pull/466))
+
+### Fixed
+
+- *(oracle)* surface real I/O errors from the tool-output read ([#556](https://github.com/cq27-dev/rag-rat/pull/556))
+- *(parser)* grow the stack for recursive tree-descent helpers + tripwire enforcing it ([#551](https://github.com/cq27-dev/rag-rat/pull/551))
+- *(dream)* rank coverage_gap by scoped PageRank, not unscoped caller in-degree ([#261](https://github.com/cq27-dev/rag-rat/pull/261)) ([#515](https://github.com/cq27-dev/rag-rat/pull/515))
+- *(watch)* run maintenance passes on a worker thread so events and the fleet trigger stay live ([#510](https://github.com/cq27-dev/rag-rat/pull/510))
+- *(index)* carry retained committed rows across a HEAD move instead of re-deriving the repo ([#505](https://github.com/cq27-dev/rag-rat/pull/505))
+- *(schema)* forward-migrate replay no longer stamps the dirty marker ([#501](https://github.com/cq27-dev/rag-rat/pull/501))
+- *(memory)* relocation prefers the discriminator-matching twin, not plan order ([#494](https://github.com/cq27-dev/rag-rat/pull/494))
+- *(index)* stop the gix status walk from descending into gitignored directories ([#481](https://github.com/cq27-dev/rag-rat/pull/481))
+- *(watch)* gate the background clone-graph rebuild on a content quiet window ([#475](https://github.com/cq27-dev/rag-rat/pull/475))
+- *(watch)* gate the linux-only drain_until_quiet test helper behind cfg ([#468](https://github.com/cq27-dev/rag-rat/pull/468))
+
+### Other
+
+- *(index)* route the heal path through the shared single-parse core ([#552](https://github.com/cq27-dev/rag-rat/pull/552))
+- *(parser)* iterative depth-safe tree walks for symbol and edge extraction ([#540](https://github.com/cq27-dev/rag-rat/pull/540))
+- *(init)* print the MCP connect command instead of auto-registering ([#542](https://github.com/cq27-dev/rag-rat/pull/542))
+- complete the MCP tool catalog, trim the README, make the skills MCP-native ([#539](https://github.com/cq27-dev/rag-rat/pull/539))
+- *(edges)* linearize contains_edges and containing_symbol; dedup the grammar match ([#533](https://github.com/cq27-dev/rag-rat/pull/533))
+- *(reconcile)* skip the policy re-parse for current chunks on the backlog gate ([#529](https://github.com/cq27-dev/rag-rat/pull/529))
+- *(index)* shared-parse low-signal classification + O(1) chunker line spans ([#527](https://github.com/cq27-dev/rag-rat/pull/527))
+
 ## [0.14.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.13.0...rag-rat-core-v0.14.0) - 2026-07-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3443,7 +3443,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rag-rat"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3469,7 +3469,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "rag-rat-mcp"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "3"
 # and the internal path deps below pin the same literal, so the three crates always publish in
 # lockstep. Bump this one line (and the two internal-dep `version`s under workspace.dependencies)
 # to release.
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Kristaps Karlsons"]
 edition = "2024"
 # Bundled SQLite (rusqlite `bundled` -> libsqlite3-sys 0.38.1) compiles a build script that uses the
@@ -28,8 +28,8 @@ categories = ["command-line-utilities", "development-tools"]
 # Internal crates — declared once here so the version requirement is set in lockstep with
 # [workspace.package].version above. Members reference these via `{ workspace = true }` and add
 # their own feature toggles at the use site.
-rag-rat-core = { version = "0.14.0", path = "crates/rag-rat-core", default-features = false }
-rag-rat-mcp = { version = "0.14.0", path = "crates/rag-rat-mcp", default-features = false }
+rag-rat-core = { version = "0.15.0", path = "crates/rag-rat-core", default-features = false }
+rag-rat-mcp = { version = "0.15.0", path = "crates/rag-rat-mcp", default-features = false }
 anyhow = "1.0"
 # ed25519 device-identity signing for the op-log's signed entry envelope (§C4 layer-1). Default
 # features (incl. `zeroize`, which zeroizes a `SigningKey`'s seed on drop) are kept; the `rand_core`


### PR DESCRIPTION



## 🤖 New release

* `rag-rat-core`: 0.14.0 -> 0.15.0 (⚠ API breaking changes)
* `rag-rat-mcp`: 0.14.0 -> 0.15.0 (⚠ API breaking changes)
* `rag-rat`: 0.14.0 -> 0.15.0

### ⚠ `rag-rat-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field RepoMemory.payload_json in /tmp/.tmpdRHTNh/rag-rat/crates/rag-rat-core/src/query/memory/mod.rs:72
  field RepoMemoryValidationReport.pending in /tmp/.tmpdRHTNh/rag-rat/crates/rag-rat-core/src/query/memory/mod.rs:263
  field RepoMemoryUpdate.payload_json in /tmp/.tmpdRHTNh/rag-rat/crates/rag-rat-core/src/query/memory/mod.rs:250
  field ImportSummary.edges in /tmp/.tmpdRHTNh/rag-rat/crates/rag-rat-core/src/index/consolidate.rs:133
  field DiscoveryStatus.carryable_files in /tmp/.tmpdRHTNh/rag-rat/crates/rag-rat-core/src/index/discovery.rs:15
  field RepoMemoryCreate.payload_json in /tmp/.tmpdRHTNh/rag-rat/crates/rag-rat-core/src/query/memory/mod.rs:176

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant MemorySurface::Full 0 -> 1 in /tmp/.tmpdRHTNh/rag-rat/crates/rag-rat-core/src/config.rs:87
  variant MemorySurface::Summary 1 -> 0 in /tmp/.tmpdRHTNh/rag-rat/crates/rag-rat-core/src/config.rs:84

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function rag_rat_core::index::parser::parse_error, previously in file /tmp/.tmpw0Tukr/rag-rat-core/src/index/parser.rs:298

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  rag_rat_core::index::IndexDatabase::memory_search takes 2 parameters in /tmp/.tmpw0Tukr/rag-rat-core/src/index/query_api/memory.rs:28, but now takes 3 parameters in /tmp/.tmpdRHTNh/rag-rat/crates/rag-rat-core/src/index/query_api/memory.rs:61
  rag_rat_core::index::IndexDatabase::memory_for_edges takes 2 parameters in /tmp/.tmpw0Tukr/rag-rat-core/src/index/query_api/memory.rs:60, but now takes 3 parameters in /tmp/.tmpdRHTNh/rag-rat/crates/rag-rat-core/src/index/query_api/memory.rs:97
  rag_rat_core::index::IndexDatabase::memory_for_call_path_hash takes 2 parameters in /tmp/.tmpw0Tukr/rag-rat-core/src/index/query_api/memory.rs:93, but now takes 3 parameters in /tmp/.tmpdRHTNh/rag-rat/crates/rag-rat-core/src/index/query_api/memory.rs:134
  rag_rat_core::IndexDatabase::memory_search takes 2 parameters in /tmp/.tmpw0Tukr/rag-rat-core/src/index/query_api/memory.rs:28, but now takes 3 parameters in /tmp/.tmpdRHTNh/rag-rat/crates/rag-rat-core/src/index/query_api/memory.rs:61
  rag_rat_core::IndexDatabase::memory_for_edges takes 2 parameters in /tmp/.tmpw0Tukr/rag-rat-core/src/index/query_api/memory.rs:60, but now takes 3 parameters in /tmp/.tmpdRHTNh/rag-rat/crates/rag-rat-core/src/index/query_api/memory.rs:97
  rag_rat_core::IndexDatabase::memory_for_call_path_hash takes 2 parameters in /tmp/.tmpw0Tukr/rag-rat-core/src/index/query_api/memory.rs:93, but now takes 3 parameters in /tmp/.tmpdRHTNh/rag-rat/crates/rag-rat-core/src/index/query_api/memory.rs:134
```

### ⚠ `rag-rat-mcp` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field MemoryUpdateArgs.payload in /tmp/.tmpdRHTNh/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:674
  field MemoryCreateArgs.payload in /tmp/.tmpdRHTNh/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:648

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant McpMemoryKind:Task in /tmp/.tmpdRHTNh/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:502
  variant McpMemoryKind:Concept in /tmp/.tmpdRHTNh/rag-rat/crates/rag-rat-mcp/src/tools/requests.rs:503
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rag-rat-core`

<blockquote>

## [0.15.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.14.0...rag-rat-core-v0.15.0) - 2026-07-09

### Added

- *(oplog)* wire authoring into the live memory write path (phase B) ([#538](https://github.com/cq27-dev/rag-rat/pull/538))
- *(oplog)* op-authoring helper + full backfill of existing memories (phase B, unwired) ([#526](https://github.com/cq27-dev/rag-rat/pull/526))
- *(oracle)* live LSP client substrate for the incremental resolution path ([#531](https://github.com/cq27-dev/rag-rat/pull/531))
- *(index)* realign logical-symbol references on key-derivation drift ([#493](https://github.com/cq27-dev/rag-rat/pull/493)) ([#525](https://github.com/cq27-dev/rag-rat/pull/525))
- *(memory)* two-observation downgrade hysteresis for anchor status ([#492](https://github.com/cq27-dev/rag-rat/pull/492)) ([#528](https://github.com/cq27-dev/rag-rat/pull/528))
- *(clones)* scip refine mode — moniker-collapse same-symbol callees to Type-2 ([#512](https://github.com/cq27-dev/rag-rat/pull/512))
- *(dream)* expose dream + dream_review MCP tools ([#263](https://github.com/cq27-dev/rag-rat/pull/263)) ([#514](https://github.com/cq27-dev/rag-rat/pull/514))
- *(oplog)* persisted local device identity — CSPRNG keygen + single-row store (phase B) ([#523](https://github.com/cq27-dev/rag-rat/pull/523))
- *(oplog)* immutable stream identity — signed stream binding, stream-scoped store, fork quarantine (phase B S2) ([#511](https://github.com/cq27-dev/rag-rat/pull/511))
- *(memory)* default the memory surface to summary; extend it to the memory-query tools ([#508](https://github.com/cq27-dev/rag-rat/pull/508))
- *(oplog)* durable storage — layer-1 signed log + full-replay shadow projection (phase B C4) ([#504](https://github.com/cq27-dev/rag-rat/pull/504))
- *(oplog)* signed hash-chained entry envelope + ed25519 device keys (phase B C4 layer-1) ([#500](https://github.com/cq27-dev/rag-rat/pull/500))
- *(memory)* pending anchor status for in-flight worktree branches ([#496](https://github.com/cq27-dev/rag-rat/pull/496))
- *(oplog)* memory op model + deterministic projection fold (phase B §5.4) ([#495](https://github.com/cq27-dev/rag-rat/pull/495))
- *(clones)* per-generation df snapshot (clone_df_epoch) frees the live df to move ([#490](https://github.com/cq27-dev/rag-rat/pull/490))
- *(memory)* canonical content_hash primitive (phase B §5.5) ([#480](https://github.com/cq27-dev/rag-rat/pull/480))
- *(schema)* actionable version-skew messaging for the newer-schema refusal ([#487](https://github.com/cq27-dev/rag-rat/pull/487))
- *(index)* quiet-pass WAL checkpointing + doctor file-health warnings ([#486](https://github.com/cq27-dev/rag-rat/pull/486))
- *(locks)* per-database sync-session lock for the device-wide iroh endpoint ([#485](https://github.com/cq27-dev/rag-rat/pull/485))
- *(clones)* incremental delta maintenance of the persisted clone graph ([#477](https://github.com/cq27-dev/rag-rat/pull/477))
- *(memory)* typed cross-repo node edges (repo_node_edges) ([#476](https://github.com/cq27-dev/rag-rat/pull/476))
- *(memory)* polymorphic node payload + Task/Concept kinds ([#471](https://github.com/cq27-dev/rag-rat/pull/471))
- *(memory)* allow unanchored nodes (Concept / standalone Task) ([#466](https://github.com/cq27-dev/rag-rat/pull/466))

### Fixed

- *(oracle)* surface real I/O errors from the tool-output read ([#556](https://github.com/cq27-dev/rag-rat/pull/556))
- *(parser)* grow the stack for recursive tree-descent helpers + tripwire enforcing it ([#551](https://github.com/cq27-dev/rag-rat/pull/551))
- *(dream)* rank coverage_gap by scoped PageRank, not unscoped caller in-degree ([#261](https://github.com/cq27-dev/rag-rat/pull/261)) ([#515](https://github.com/cq27-dev/rag-rat/pull/515))
- *(watch)* run maintenance passes on a worker thread so events and the fleet trigger stay live ([#510](https://github.com/cq27-dev/rag-rat/pull/510))
- *(index)* carry retained committed rows across a HEAD move instead of re-deriving the repo ([#505](https://github.com/cq27-dev/rag-rat/pull/505))
- *(schema)* forward-migrate replay no longer stamps the dirty marker ([#501](https://github.com/cq27-dev/rag-rat/pull/501))
- *(memory)* relocation prefers the discriminator-matching twin, not plan order ([#494](https://github.com/cq27-dev/rag-rat/pull/494))
- *(index)* stop the gix status walk from descending into gitignored directories ([#481](https://github.com/cq27-dev/rag-rat/pull/481))
- *(watch)* gate the background clone-graph rebuild on a content quiet window ([#475](https://github.com/cq27-dev/rag-rat/pull/475))
- *(watch)* gate the linux-only drain_until_quiet test helper behind cfg ([#468](https://github.com/cq27-dev/rag-rat/pull/468))

### Other

- *(index)* route the heal path through the shared single-parse core ([#552](https://github.com/cq27-dev/rag-rat/pull/552))
- *(parser)* iterative depth-safe tree walks for symbol and edge extraction ([#540](https://github.com/cq27-dev/rag-rat/pull/540))
- *(init)* print the MCP connect command instead of auto-registering ([#542](https://github.com/cq27-dev/rag-rat/pull/542))
- complete the MCP tool catalog, trim the README, make the skills MCP-native ([#539](https://github.com/cq27-dev/rag-rat/pull/539))
- *(edges)* linearize contains_edges and containing_symbol; dedup the grammar match ([#533](https://github.com/cq27-dev/rag-rat/pull/533))
- *(reconcile)* skip the policy re-parse for current chunks on the backlog gate ([#529](https://github.com/cq27-dev/rag-rat/pull/529))
- *(index)* shared-parse low-signal classification + O(1) chunker line spans ([#527](https://github.com/cq27-dev/rag-rat/pull/527))
</blockquote>

## `rag-rat-mcp`

<blockquote>

## [0.15.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.14.0...rag-rat-core-v0.15.0) - 2026-07-09

### Added

- *(oplog)* wire authoring into the live memory write path (phase B) ([#538](https://github.com/cq27-dev/rag-rat/pull/538))
- *(oplog)* op-authoring helper + full backfill of existing memories (phase B, unwired) ([#526](https://github.com/cq27-dev/rag-rat/pull/526))
- *(oracle)* live LSP client substrate for the incremental resolution path ([#531](https://github.com/cq27-dev/rag-rat/pull/531))
- *(index)* realign logical-symbol references on key-derivation drift ([#493](https://github.com/cq27-dev/rag-rat/pull/493)) ([#525](https://github.com/cq27-dev/rag-rat/pull/525))
- *(memory)* two-observation downgrade hysteresis for anchor status ([#492](https://github.com/cq27-dev/rag-rat/pull/492)) ([#528](https://github.com/cq27-dev/rag-rat/pull/528))
- *(clones)* scip refine mode — moniker-collapse same-symbol callees to Type-2 ([#512](https://github.com/cq27-dev/rag-rat/pull/512))
- *(dream)* expose dream + dream_review MCP tools ([#263](https://github.com/cq27-dev/rag-rat/pull/263)) ([#514](https://github.com/cq27-dev/rag-rat/pull/514))
- *(oplog)* persisted local device identity — CSPRNG keygen + single-row store (phase B) ([#523](https://github.com/cq27-dev/rag-rat/pull/523))
- *(oplog)* immutable stream identity — signed stream binding, stream-scoped store, fork quarantine (phase B S2) ([#511](https://github.com/cq27-dev/rag-rat/pull/511))
- *(memory)* default the memory surface to summary; extend it to the memory-query tools ([#508](https://github.com/cq27-dev/rag-rat/pull/508))
- *(oplog)* durable storage — layer-1 signed log + full-replay shadow projection (phase B C4) ([#504](https://github.com/cq27-dev/rag-rat/pull/504))
- *(oplog)* signed hash-chained entry envelope + ed25519 device keys (phase B C4 layer-1) ([#500](https://github.com/cq27-dev/rag-rat/pull/500))
- *(memory)* pending anchor status for in-flight worktree branches ([#496](https://github.com/cq27-dev/rag-rat/pull/496))
- *(oplog)* memory op model + deterministic projection fold (phase B §5.4) ([#495](https://github.com/cq27-dev/rag-rat/pull/495))
- *(clones)* per-generation df snapshot (clone_df_epoch) frees the live df to move ([#490](https://github.com/cq27-dev/rag-rat/pull/490))
- *(memory)* canonical content_hash primitive (phase B §5.5) ([#480](https://github.com/cq27-dev/rag-rat/pull/480))
- *(schema)* actionable version-skew messaging for the newer-schema refusal ([#487](https://github.com/cq27-dev/rag-rat/pull/487))
- *(index)* quiet-pass WAL checkpointing + doctor file-health warnings ([#486](https://github.com/cq27-dev/rag-rat/pull/486))
- *(locks)* per-database sync-session lock for the device-wide iroh endpoint ([#485](https://github.com/cq27-dev/rag-rat/pull/485))
- *(clones)* incremental delta maintenance of the persisted clone graph ([#477](https://github.com/cq27-dev/rag-rat/pull/477))
- *(memory)* typed cross-repo node edges (repo_node_edges) ([#476](https://github.com/cq27-dev/rag-rat/pull/476))
- *(memory)* polymorphic node payload + Task/Concept kinds ([#471](https://github.com/cq27-dev/rag-rat/pull/471))
- *(memory)* allow unanchored nodes (Concept / standalone Task) ([#466](https://github.com/cq27-dev/rag-rat/pull/466))

### Fixed

- *(oracle)* surface real I/O errors from the tool-output read ([#556](https://github.com/cq27-dev/rag-rat/pull/556))
- *(parser)* grow the stack for recursive tree-descent helpers + tripwire enforcing it ([#551](https://github.com/cq27-dev/rag-rat/pull/551))
- *(dream)* rank coverage_gap by scoped PageRank, not unscoped caller in-degree ([#261](https://github.com/cq27-dev/rag-rat/pull/261)) ([#515](https://github.com/cq27-dev/rag-rat/pull/515))
- *(watch)* run maintenance passes on a worker thread so events and the fleet trigger stay live ([#510](https://github.com/cq27-dev/rag-rat/pull/510))
- *(index)* carry retained committed rows across a HEAD move instead of re-deriving the repo ([#505](https://github.com/cq27-dev/rag-rat/pull/505))
- *(schema)* forward-migrate replay no longer stamps the dirty marker ([#501](https://github.com/cq27-dev/rag-rat/pull/501))
- *(memory)* relocation prefers the discriminator-matching twin, not plan order ([#494](https://github.com/cq27-dev/rag-rat/pull/494))
- *(index)* stop the gix status walk from descending into gitignored directories ([#481](https://github.com/cq27-dev/rag-rat/pull/481))
- *(watch)* gate the background clone-graph rebuild on a content quiet window ([#475](https://github.com/cq27-dev/rag-rat/pull/475))
- *(watch)* gate the linux-only drain_until_quiet test helper behind cfg ([#468](https://github.com/cq27-dev/rag-rat/pull/468))

### Other

- *(index)* route the heal path through the shared single-parse core ([#552](https://github.com/cq27-dev/rag-rat/pull/552))
- *(parser)* iterative depth-safe tree walks for symbol and edge extraction ([#540](https://github.com/cq27-dev/rag-rat/pull/540))
- *(init)* print the MCP connect command instead of auto-registering ([#542](https://github.com/cq27-dev/rag-rat/pull/542))
- complete the MCP tool catalog, trim the README, make the skills MCP-native ([#539](https://github.com/cq27-dev/rag-rat/pull/539))
- *(edges)* linearize contains_edges and containing_symbol; dedup the grammar match ([#533](https://github.com/cq27-dev/rag-rat/pull/533))
- *(reconcile)* skip the policy re-parse for current chunks on the backlog gate ([#529](https://github.com/cq27-dev/rag-rat/pull/529))
- *(index)* shared-parse low-signal classification + O(1) chunker line spans ([#527](https://github.com/cq27-dev/rag-rat/pull/527))
</blockquote>

## `rag-rat`

<blockquote>

## [0.15.0](https://github.com/cq27-dev/rag-rat/compare/rag-rat-core-v0.14.0...rag-rat-core-v0.15.0) - 2026-07-09

### Added

- *(oplog)* wire authoring into the live memory write path (phase B) ([#538](https://github.com/cq27-dev/rag-rat/pull/538))
- *(oplog)* op-authoring helper + full backfill of existing memories (phase B, unwired) ([#526](https://github.com/cq27-dev/rag-rat/pull/526))
- *(oracle)* live LSP client substrate for the incremental resolution path ([#531](https://github.com/cq27-dev/rag-rat/pull/531))
- *(index)* realign logical-symbol references on key-derivation drift ([#493](https://github.com/cq27-dev/rag-rat/pull/493)) ([#525](https://github.com/cq27-dev/rag-rat/pull/525))
- *(memory)* two-observation downgrade hysteresis for anchor status ([#492](https://github.com/cq27-dev/rag-rat/pull/492)) ([#528](https://github.com/cq27-dev/rag-rat/pull/528))
- *(clones)* scip refine mode — moniker-collapse same-symbol callees to Type-2 ([#512](https://github.com/cq27-dev/rag-rat/pull/512))
- *(dream)* expose dream + dream_review MCP tools ([#263](https://github.com/cq27-dev/rag-rat/pull/263)) ([#514](https://github.com/cq27-dev/rag-rat/pull/514))
- *(oplog)* persisted local device identity — CSPRNG keygen + single-row store (phase B) ([#523](https://github.com/cq27-dev/rag-rat/pull/523))
- *(oplog)* immutable stream identity — signed stream binding, stream-scoped store, fork quarantine (phase B S2) ([#511](https://github.com/cq27-dev/rag-rat/pull/511))
- *(memory)* default the memory surface to summary; extend it to the memory-query tools ([#508](https://github.com/cq27-dev/rag-rat/pull/508))
- *(oplog)* durable storage — layer-1 signed log + full-replay shadow projection (phase B C4) ([#504](https://github.com/cq27-dev/rag-rat/pull/504))
- *(oplog)* signed hash-chained entry envelope + ed25519 device keys (phase B C4 layer-1) ([#500](https://github.com/cq27-dev/rag-rat/pull/500))
- *(memory)* pending anchor status for in-flight worktree branches ([#496](https://github.com/cq27-dev/rag-rat/pull/496))
- *(oplog)* memory op model + deterministic projection fold (phase B §5.4) ([#495](https://github.com/cq27-dev/rag-rat/pull/495))
- *(clones)* per-generation df snapshot (clone_df_epoch) frees the live df to move ([#490](https://github.com/cq27-dev/rag-rat/pull/490))
- *(memory)* canonical content_hash primitive (phase B §5.5) ([#480](https://github.com/cq27-dev/rag-rat/pull/480))
- *(schema)* actionable version-skew messaging for the newer-schema refusal ([#487](https://github.com/cq27-dev/rag-rat/pull/487))
- *(index)* quiet-pass WAL checkpointing + doctor file-health warnings ([#486](https://github.com/cq27-dev/rag-rat/pull/486))
- *(locks)* per-database sync-session lock for the device-wide iroh endpoint ([#485](https://github.com/cq27-dev/rag-rat/pull/485))
- *(clones)* incremental delta maintenance of the persisted clone graph ([#477](https://github.com/cq27-dev/rag-rat/pull/477))
- *(memory)* typed cross-repo node edges (repo_node_edges) ([#476](https://github.com/cq27-dev/rag-rat/pull/476))
- *(memory)* polymorphic node payload + Task/Concept kinds ([#471](https://github.com/cq27-dev/rag-rat/pull/471))
- *(memory)* allow unanchored nodes (Concept / standalone Task) ([#466](https://github.com/cq27-dev/rag-rat/pull/466))

### Fixed

- *(oracle)* surface real I/O errors from the tool-output read ([#556](https://github.com/cq27-dev/rag-rat/pull/556))
- *(parser)* grow the stack for recursive tree-descent helpers + tripwire enforcing it ([#551](https://github.com/cq27-dev/rag-rat/pull/551))
- *(dream)* rank coverage_gap by scoped PageRank, not unscoped caller in-degree ([#261](https://github.com/cq27-dev/rag-rat/pull/261)) ([#515](https://github.com/cq27-dev/rag-rat/pull/515))
- *(watch)* run maintenance passes on a worker thread so events and the fleet trigger stay live ([#510](https://github.com/cq27-dev/rag-rat/pull/510))
- *(index)* carry retained committed rows across a HEAD move instead of re-deriving the repo ([#505](https://github.com/cq27-dev/rag-rat/pull/505))
- *(schema)* forward-migrate replay no longer stamps the dirty marker ([#501](https://github.com/cq27-dev/rag-rat/pull/501))
- *(memory)* relocation prefers the discriminator-matching twin, not plan order ([#494](https://github.com/cq27-dev/rag-rat/pull/494))
- *(index)* stop the gix status walk from descending into gitignored directories ([#481](https://github.com/cq27-dev/rag-rat/pull/481))
- *(watch)* gate the background clone-graph rebuild on a content quiet window ([#475](https://github.com/cq27-dev/rag-rat/pull/475))
- *(watch)* gate the linux-only drain_until_quiet test helper behind cfg ([#468](https://github.com/cq27-dev/rag-rat/pull/468))

### Other

- *(index)* route the heal path through the shared single-parse core ([#552](https://github.com/cq27-dev/rag-rat/pull/552))
- *(parser)* iterative depth-safe tree walks for symbol and edge extraction ([#540](https://github.com/cq27-dev/rag-rat/pull/540))
- *(init)* print the MCP connect command instead of auto-registering ([#542](https://github.com/cq27-dev/rag-rat/pull/542))
- complete the MCP tool catalog, trim the README, make the skills MCP-native ([#539](https://github.com/cq27-dev/rag-rat/pull/539))
- *(edges)* linearize contains_edges and containing_symbol; dedup the grammar match ([#533](https://github.com/cq27-dev/rag-rat/pull/533))
- *(reconcile)* skip the policy re-parse for current chunks on the backlog gate ([#529](https://github.com/cq27-dev/rag-rat/pull/529))
- *(index)* shared-parse low-signal classification + O(1) chunker line spans ([#527](https://github.com/cq27-dev/rag-rat/pull/527))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).