### PR TITLE
feat(memory): polymorphic node payload + Task/Concept kinds

### DIFF
--- a/crates/rag-rat-cli/tests/multi_repo_e2e.rs
+++ b/crates/rag-rat-cli/tests/multi_repo_e2e.rs
@@ -278,6 +278,7 @@ fn ref_memory(title: &str, gone_path: &str, bind_path: &str) -> RepoMemoryCreate
         created_by: Some("a8-matrix".into()),
         source: Some("agent".into()),
         tags: vec![],
+        payload_json: None,
         bind: RepoMemoryBindTarget { path: Some(bind_path.into()), ..Default::default() },
     }
 }
@@ -446,6 +447,7 @@ fn memories_are_isolated_across_repos() {
         created_by: Some("a8".into()),
         source: Some("agent".into()),
         tags: vec![],
+        payload_json: None,
         bind: RepoMemoryBindTarget { path: Some("src/common.rs".into()), ..Default::default() },
     };
     let a_mem = open_scoped(&repo_a, &data_dir)
@@ -510,6 +512,7 @@ fn memories_are_isolated_across_repos() {
             created_by: Some("a8".into()),
             source: Some("agent".into()),
             tags: vec![],
+            payload_json: None,
             bind: RepoMemoryBindTarget {
                 path: Some("src/vanished_a.rs".into()),
                 ..Default::default()
@@ -635,6 +638,7 @@ fn gc_of_one_repo_leaves_the_other_intact_and_reports_per_repo() {
             created_by: Some("a8".into()),
             source: Some("agent".into()),
             tags: vec![],
+            payload_json: None,
             bind: RepoMemoryBindTarget { path: Some("src/b1.rs".into()), ..Default::default() },
         })
         .unwrap();
@@ -711,6 +715,7 @@ fn consolidate_lands_a_third_legacy_repos_memories_fts_searchable() {
             created_by: Some("a8".into()),
             source: Some("agent".into()),
             tags: vec![],
+            payload_json: None,
             bind: RepoMemoryBindTarget { path: Some("src/common.rs".into()), ..Default::default() },
         })
         .unwrap()
@@ -804,6 +809,7 @@ fn concurrent_index_of_a_and_write_on_b_are_lock_disjoint() {
             created_by: Some("a8".into()),
             source: Some("agent".into()),
             tags: vec![],
+            payload_json: None,
             bind: RepoMemoryBindTarget { path: Some("src/common.rs".into()), ..Default::default() },
         })
         .expect("B's memory write completes while its own flock is held and A is reindexing");
@@ -900,6 +906,7 @@ fn linked_worktree_resolves_through_main_config() {
             created_by: Some("a8".into()),
             source: Some("agent".into()),
             tags: vec![],
+            payload_json: None,
             bind: RepoMemoryBindTarget { path: Some("src/common.rs".into()), ..Default::default() },
         })
         .unwrap()

--- a/crates/rag-rat-core/src/dream/verify.rs
+++ b/crates/rag-rat-core/src/dream/verify.rs
@@ -412,7 +412,7 @@ pub(super) fn unverifiable_findings(conn: &Connection) -> rusqlite::Result<Vec<D
         // anchor, so a zero-binding one is NOT "unverifiable". A zero-binding memory of any OTHER
         // kind is an orphan (all should-be-anchored) and is still flagged below, as is any memory
         // whose bindings all went `gone` (≥1 row, none live).
-        if matches!(kind.as_str(), "Task" | "Concept")
+        if crate::query::memory::is_polymorphic_node_kind(&kind)
             && !memory_has_any_binding(conn, &memory_id, &scope)?
         {
             continue;

--- a/crates/rag-rat-core/src/dream/verify.rs
+++ b/crates/rag-rat-core/src/dream/verify.rs
@@ -268,6 +268,11 @@ fn queue_reason(
 ///
 /// `pub(crate)` so the surfacing hydrator recomputes it identically to the queue / verdict-pass
 /// stamp.
+/// The dream content-identity key over a memory's CURRENT note (title + body). NOTE (#465): the
+/// polymorphic `payload_json` is NOT folded here yet — the canonical payload fold is deferred to
+/// phase B (#404) with the rest of the §5.5 canonicalization. This is not a live staleness bug: the
+/// derived summary/verdict rows are over title+body, which a payload-only edit does not change, so
+/// they stay correct. (Create-time dedup DOES fold the payload — see `memory_input_hash`.)
 pub(crate) fn note_content_hash(title: &str, body: &str) -> String {
     crate::index::hex_sha256(format!("{}\n{}", title.trim(), body.trim()).as_bytes())
 }
@@ -380,9 +385,12 @@ pub fn evidence_pack(conn: &Connection, memory_id: &str) -> anyhow::Result<Evide
     Ok(EvidencePack { memory_id: memory_id.to_string(), identifiers: resolutions, excerpts })
 }
 
-/// The deterministic `memory_unverifiable` findings: active memories whose bindings are all
-/// gone/absent (no live non-`scip_moniker` binding) AND none of whose identifiers resolve anywhere
-/// in the whole-tree index. Repo-scoped; the evidence names exactly what was checked. Folded into
+/// The deterministic `memory_unverifiable` findings: active memories that WERE anchored but whose
+/// bindings are now all gone (no live non-`scip_moniker` binding, yet ≥1 binding row) — OR a
+/// zero-binding ORPHAN of a should-be-anchored kind — AND none of whose identifiers resolve
+/// anywhere in the whole-tree index. An intentional UNANCHORED node (a `Task`/`Concept` with zero
+/// binding rows — #463/#465) is EXCLUDED: it is anchorless BY DESIGN, not broken, so flagging it
+/// would be spurious noise. Repo-scoped; the evidence names exactly what was checked. Folded into
 /// the identity-keyed `dream_findings` lifecycle by `dream_run` (so a memory that becomes
 /// verifiable again is resolved), which is why this runs over the full active population, not the
 /// budget.
@@ -391,14 +399,24 @@ pub(super) fn unverifiable_findings(conn: &Connection) -> rusqlite::Result<Vec<D
     let mem_clause = schema::periphery_repo_scope_clause(&scope, "repo_memories");
     let file_paths = indexed_file_paths(conn)?;
     let mut stmt = conn.prepare(&format!(
-        "SELECT id, title, body FROM repo_memories WHERE status = 'active'{mem_clause} ORDER BY id"
+        "SELECT id, kind, title, body FROM repo_memories WHERE status = 'active'{mem_clause} \
+         ORDER BY id"
     ))?;
-    let mems: Vec<(String, String, String)> = stmt
-        .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))?
+    let mems: Vec<(String, String, String, String)> = stmt
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)))?
         .collect::<rusqlite::Result<_>>()?;
 
     let mut out = Vec::new();
-    for (memory_id, title, body) in mems {
+    for (memory_id, kind, title, body) in mems {
+        // Intentional UNANCHORED node (#463/#465): a `Task`/`Concept` legitimately has no code
+        // anchor, so a zero-binding one is NOT "unverifiable". A zero-binding memory of any OTHER
+        // kind is an orphan (all should-be-anchored) and is still flagged below, as is any memory
+        // whose bindings all went `gone` (≥1 row, none live).
+        if matches!(kind.as_str(), "Task" | "Concept")
+            && !memory_has_any_binding(conn, &memory_id, &scope)?
+        {
+            continue;
+        }
         if memory_has_live_binding(conn, &memory_id, &scope)? {
             continue;
         }
@@ -438,6 +456,24 @@ fn memory_has_live_binding(
             "SELECT COUNT(*) FROM repo_memory_bindings WHERE memory_id = ?1 AND binding_kind != \
              'scip_moniker' AND anchor_status != 'gone'{bind_clause}"
         ),
+        [memory_id],
+        |r| r.get(0),
+    )?;
+    Ok(count > 0)
+}
+
+/// Whether `memory_id` has ANY binding row at all (any kind, any `anchor_status`). Distinguishes an
+/// intentional UNANCHORED node (#463/#465 — zero rows, anchorless by design) from a broken memory
+/// whose anchors all went `gone` (≥1 row): only the intentional case is excused from
+/// `memory_unverifiable`, and only for the `Task`/`Concept` kinds.
+fn memory_has_any_binding(
+    conn: &Connection,
+    memory_id: &str,
+    scope: &Option<String>,
+) -> rusqlite::Result<bool> {
+    let bind_clause = schema::periphery_repo_scope_clause(scope, "repo_memory_bindings");
+    let count: i64 = conn.query_row(
+        &format!("SELECT COUNT(*) FROM repo_memory_bindings WHERE memory_id = ?1{bind_clause}"),
         [memory_id],
         |r| r.get(0),
     )?;
@@ -754,6 +790,17 @@ mod tests {
         .unwrap();
     }
 
+    /// Seed an active memory of an explicit `kind` (for the #465 Task/Concept cases).
+    fn seed_memory_kind(c: &Connection, id: &str, kind: &str, title: &str, body: &str, repo: &str) {
+        c.execute(
+            "INSERT INTO repo_memories(id, kind, title, body, confidence, status, created_by, \
+             created_at_ms, updated_at_ms, source, memory_version, repo_id) VALUES \
+             (?1,?2,?3,?4,'high','active','agent',1,1,'agent','v1',?5)",
+            rusqlite::params![id, kind, title, body, repo],
+        )
+        .unwrap();
+    }
+
     /// Seed a file + one chunk carrying `text`, under `repo_id`. Returns the file id.
     fn seed_file(c: &Connection, path: &str, text: &str, repo_id: &str) -> i64 {
         c.execute(
@@ -778,6 +825,45 @@ mod tests {
 
     fn content_hash(title: &str, body: &str) -> String {
         note_content_hash(title, body)
+    }
+
+    /// #465: dream-verify excuses an intentional unanchored node (a zero-binding `Task`/`Concept`)
+    /// from `memory_unverifiable`, but still flags a zero-binding ORPHAN of a should-be-anchored
+    /// kind and a memory whose bindings all went `gone`.
+    #[test]
+    fn unverifiable_excuses_unanchored_task_concept_but_flags_orphans() {
+        let c = mem_db();
+        set_repo(&c, "r");
+        // Zero-binding Concept + Task — intentional unanchored nodes; must NOT be flagged.
+        seed_memory_kind(
+            &c,
+            "concept",
+            "Concept",
+            "event log over polling",
+            "prose, no anchor",
+            "r",
+        );
+        seed_memory_kind(&c, "task", "Task", "do the thing", "prose, no anchor", "r");
+        // Zero-binding Invariant — an orphan of a should-be-anchored kind; MUST be flagged.
+        seed_memory(&c, "orphan", "gone note", "refs `no_such_symbol_xyz`", "r");
+        // A gone-binding memory — broken; MUST be flagged.
+        seed_memory(&c, "broken", "another", "refs `also_missing_xyz`", "r");
+        c.execute(
+            "INSERT INTO repo_memory_bindings(memory_id, binding_kind, binding_id, anchor_status, \
+             created_at_ms, repo_id) VALUES ('broken','symbol','old','gone',0,'r')",
+            [],
+        )
+        .unwrap();
+
+        let subjects: Vec<String> =
+            unverifiable_findings(&c).unwrap().into_iter().map(|f| f.subject).collect();
+        assert!(!subjects.iter().any(|s| s == "concept"), "unanchored Concept excused");
+        assert!(!subjects.iter().any(|s| s == "task"), "unanchored Task excused");
+        assert!(
+            subjects.iter().any(|s| s == "orphan"),
+            "a zero-binding orphan of a normal kind is still flagged"
+        );
+        assert!(subjects.iter().any(|s| s == "broken"), "an all-gone memory is still flagged");
     }
 
     #[test]

--- a/crates/rag-rat-core/src/index/consolidate.rs
+++ b/crates/rag-rat-core/src/index/consolidate.rs
@@ -648,7 +648,8 @@ fn copy_memories(
     }
     let mut stmt = source.prepare(
         "SELECT id, kind, title, body, confidence, status, created_by, created_at_ms, \
-         updated_at_ms, source, source_text_hash, input_hash, memory_version FROM repo_memories",
+         updated_at_ms, source, source_text_hash, input_hash, memory_version, payload_json FROM \
+         repo_memories",
     )?;
     let mut rows = stmt.query([])?;
     let mut count = 0u64;
@@ -662,25 +663,25 @@ fn copy_memories(
         let changed = tx.execute(
             "INSERT INTO repo_memories(id, kind, title, body, confidence, status, created_by, \
              created_at_ms, updated_at_ms, source, source_text_hash, input_hash, memory_version, \
-             repo_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+             payload_json, repo_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
              ON CONFLICT(id) DO UPDATE SET
                kind = excluded.kind, title = excluded.title, body = excluded.body,
                confidence = excluded.confidence, status = excluded.status,
                created_by = excluded.created_by, created_at_ms = excluded.created_at_ms,
                updated_at_ms = excluded.updated_at_ms, source = excluded.source,
                source_text_hash = excluded.source_text_hash, input_hash = excluded.input_hash,
-               memory_version = excluded.memory_version
+               memory_version = excluded.memory_version, payload_json = excluded.payload_json
              WHERE repo_memories.repo_id = excluded.repo_id
                AND (repo_memories.kind, repo_memories.title, repo_memories.body, \
              repo_memories.confidence, repo_memories.status, repo_memories.created_by, \
              repo_memories.created_at_ms, repo_memories.updated_at_ms, repo_memories.source, \
              repo_memories.source_text_hash, repo_memories.input_hash, \
-             repo_memories.memory_version)
+             repo_memories.memory_version, repo_memories.payload_json)
                IS NOT (excluded.kind, excluded.title, excluded.body, excluded.confidence, \
              excluded.status, excluded.created_by, excluded.created_at_ms, \
              excluded.updated_at_ms, excluded.source, excluded.source_text_hash, \
-             excluded.input_hash, excluded.memory_version)",
+             excluded.input_hash, excluded.memory_version, excluded.payload_json)",
             params![
                 target_id,
                 row.get::<_, String>(1)?,
@@ -695,6 +696,7 @@ fn copy_memories(
                 row.get::<_, Option<String>>(10)?,
                 row.get::<_, Option<String>>(11)?,
                 row.get::<_, String>(12)?,
+                row.get::<_, Option<String>>(13)?,
                 repo_id,
             ],
         )?;
@@ -1137,6 +1139,12 @@ mod tests {
             )
             .unwrap();
         }
+        // #465: m1 carries a polymorphic payload — it must survive import verbatim, not be NULLed.
+        conn.execute(
+            r#"UPDATE repo_memories SET payload_json = '{"priority":1}' WHERE id = 'm1'"#,
+            [],
+        )
+        .unwrap();
         // A binding on m1 with the LOCAL rowid columns populated (must be NULLed on import) and
         // EVERY portable field set (must survive verbatim), including the moniker relocation
         // provenance.
@@ -1378,12 +1386,16 @@ mod tests {
         );
         // Zero-diff content: the no-edit retry converged — the target rows still carry the
         // source content verbatim (the gated upsert wrote NOTHING, it didn't rewrite in place).
-        let (title, body): (String, String) = target
-            .query_row("SELECT title, body FROM repo_memories WHERE id='m1'", [], |r| {
-                Ok((r.get(0)?, r.get(1)?))
-            })
+        let (title, body, payload): (String, String, Option<String>) = target
+            .query_row(
+                "SELECT title, body, payload_json FROM repo_memories WHERE id='m1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
             .unwrap();
         assert_eq!((title.as_str(), body.as_str()), ("one", "body"));
+        // #465: the payload was carried through the consolidation upsert (not turned into NULL).
+        assert_eq!(payload.as_deref(), Some(r#"{"priority":1}"#), "m1 payload survives import");
     }
 
     /// The CRASH-CREATED divergence window (Codex batch 8, finding 4): the import txn commits,

--- a/crates/rag-rat-core/src/index/oracle/tests/memory_bindings.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests/memory_bindings.rs
@@ -27,6 +27,7 @@ fn path_binding_status_after_validate(h: &Harness, path: &str) -> String {
         created_by: None,
         source: None,
         tags: Vec::new(),
+        payload_json: None,
         bind: RepoMemoryBindTarget { path: Some(path.to_string()), ..Default::default() },
     })
     .unwrap();
@@ -88,6 +89,7 @@ fn spanned_path_binding_to_unindexed_file_is_unverified() {
         created_by: None,
         source: None,
         tags: Vec::new(),
+        payload_json: None,
         bind: RepoMemoryBindTarget {
             path: Some("tools/build.sh".to_string()),
             start_line: Some(1),
@@ -121,6 +123,7 @@ fn dir_binding_to_unindexed_dir_present_on_disk_is_current() {
         created_by: None,
         source: None,
         tags: Vec::new(),
+        payload_json: None,
         bind: RepoMemoryBindTarget { dir: Some("scripts".to_string()), ..Default::default() },
     })
     .unwrap();
@@ -146,6 +149,7 @@ fn dir_binding_to_missing_dir_is_gone() {
         created_by: None,
         source: None,
         tags: Vec::new(),
+        payload_json: None,
         bind: RepoMemoryBindTarget {
             dir: Some("does/not/exist".to_string()),
             ..Default::default()
@@ -218,6 +222,7 @@ fn validate_prefers_active_root_over_persisted_meta() {
         created_by: None,
         source: None,
         tags: Vec::new(),
+        payload_json: None,
         bind: RepoMemoryBindTarget {
             path: Some("tools/notes.Containerfile".to_string()),
             ..Default::default()
@@ -483,6 +488,7 @@ fn bare_path_binding_survives_file_edit_spanned_goes_stale() {
             created_by: None,
             source: None,
             tags: Vec::new(),
+            payload_json: None,
             bind: RepoMemoryBindTarget {
                 path: Some("notes.rs".to_string()),
                 start_line: start,

--- a/crates/rag-rat-core/src/index/oracle/tests/mod.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests/mod.rs
@@ -483,6 +483,7 @@ fn create_target_memory(h: &Harness, symbol_id: i64) -> String {
         created_by: None,
         source: None,
         tags: Vec::new(),
+        payload_json: None,
         bind: RepoMemoryBindTarget { symbol_id: Some(symbol_id), ..Default::default() },
     })
     .unwrap();

--- a/crates/rag-rat-core/src/index/oracle/tests/monikers.rs
+++ b/crates/rag-rat-core/src/index/oracle/tests/monikers.rs
@@ -300,6 +300,7 @@ fn logical_symbol_binding_survives_chunk_id_churn_on_reindex() {
         created_by: None,
         source: None,
         tags: Vec::new(),
+        payload_json: None,
         bind: RepoMemoryBindTarget { logical_symbol_id: Some(1001), ..Default::default() },
     })
     .unwrap();
@@ -361,6 +362,7 @@ fn memory_body_cap_is_8000_chars() {
         created_by: None,
         source: None,
         tags: Vec::new(),
+        payload_json: None,
         bind: RepoMemoryBindTarget { path: Some("a.rs".to_string()), ..Default::default() },
     };
     assert!(create_memory(&h.conn, make("x".repeat(8000))).is_ok(), "8000 chars is accepted");
@@ -381,6 +383,7 @@ fn doctor_attention_count_counts_active_gone_and_stale_bindings() {
         created_by: None,
         source: None,
         tags: Vec::new(),
+        payload_json: None,
         bind: RepoMemoryBindTarget { path: Some("a.rs".to_string()), ..Default::default() },
     })
     .unwrap();
@@ -429,6 +432,7 @@ fn memory_attention_count_reads_file_db_and_fails_open() {
             created_by: None,
             source: None,
             tags: Vec::new(),
+            payload_json: None,
             bind: RepoMemoryBindTarget { path: Some("a.rs".to_string()), ..Default::default() },
         })
         .unwrap();

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1182,6 +1182,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_045_ID => Some(45),
             MIGRATION_046_ID => Some(46),
             MIGRATION_047_ID => Some(47),
+            MIGRATION_048_ID => Some(48),
             _ => None,
         })
         .max()
@@ -1238,6 +1239,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_045_ID
             | MIGRATION_046_ID
             | MIGRATION_047_ID
+            | MIGRATION_048_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1291,6 +1293,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_045_ID => migration.checksum != MIGRATION_045_CHECKSUM,
         MIGRATION_046_ID => migration.checksum != MIGRATION_046_CHECKSUM,
         MIGRATION_047_ID => migration.checksum != MIGRATION_047_CHECKSUM,
+        MIGRATION_048_ID => migration.checksum != MIGRATION_048_CHECKSUM,
         _ => false,
     }
 }
@@ -3371,6 +3374,17 @@ fn rebuild_repo_memory_fts_with_repo_id(conn: &Connection) -> rusqlite::Result<(
 /// `parser::detect_is_test`) so clone detection can keep tests out of the corpus. Idempotent via
 /// `add_column_if_missing`. Existing rows default to 0 (non-test) until the next reindex
 /// repopulates them — accurate `is_test` needs a reindex with this binary.
+/// V048 (#465): `repo_memories.payload_json` — a nullable opaque canonical-JSON payload for
+/// polymorphic memory nodes. The `Task` / `Concept` kinds carry a kind-specific,
+/// `schema_version`-tagged payload here; the core stores it verbatim and folds its canonical form
+/// into `content_hash` (`dream::note_content_hash`), so a payload edit self-invalidates the derived
+/// dream summary/verdict rows exactly as a title/body edit does. Additive + nullable: existing rows
+/// read back `NULL` (no payload).
+pub(crate) fn apply_memory_payload_json(conn: &Connection) -> rusqlite::Result<()> {
+    add_column_if_missing(conn, "repo_memories", "payload_json", "TEXT")?;
+    Ok(())
+}
+
 pub(crate) fn apply_symbols_is_test(conn: &Connection) -> rusqlite::Result<()> {
     add_column_if_missing(conn, "symbols", "is_test", "INTEGER NOT NULL DEFAULT 0")?;
     Ok(())

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -18,7 +18,7 @@ pub use registry::{LEGACY_REPO_ID, register_repo, register_repo_read_only};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 47;
+pub const LATEST_SCHEMA_VERSION: u32 = 48;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -322,6 +322,12 @@ const MIGRATION_047_DESCRIPTION: &str =
     "Add memory_model_failures, a repo_id-scoped dream sibling table that records deterministic \
      verdict/compaction model failures with stable enum tokens and input/model freshness stamps, \
      so rejected current attempts do not rerun every dream pass";
+const MIGRATION_048_ID: &str = "048_memory_payload_json";
+const MIGRATION_048_CHECKSUM: &str = "sha256:rag-rat-memory-payload-json-v48";
+const MIGRATION_048_DESCRIPTION: &str =
+    "Add repo_memories.payload_json, a nullable opaque canonical-JSON payload for polymorphic \
+     memory nodes (the Task / Concept kinds), folded into the content_hash so a payload edit \
+     self-invalidates the derived dream summary/verdict rows exactly as a title/body edit does";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -703,6 +709,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_047_CHECKSUM,
         description: MIGRATION_047_DESCRIPTION,
         apply: apply_memory_model_failures_table,
+    },
+    Migration {
+        id: MIGRATION_048_ID,
+        checksum: MIGRATION_048_CHECKSUM,
+        description: MIGRATION_048_DESCRIPTION,
+        apply: apply_memory_payload_json,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/chunk_store_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/chunk_store_migrations.rs
@@ -878,6 +878,7 @@ fn orientation_composes_read_only() {
         created_by: Some("test".to_string()),
         source: Some("agent".to_string()),
         tags: vec![],
+        payload_json: None,
         bind: crate::query::memory::RepoMemoryBindTarget {
             path: Some("src/a/x.rs".to_string()),
             logical_symbol_id: None,

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/dir_memory_tree.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/dir_memory_tree.rs
@@ -18,6 +18,7 @@ fn dir_memory_binds_to_a_directory() {
             created_by: Some("test-agent".to_string()),
             source: Some("agent".to_string()),
             tags: vec![],
+            payload_json: None,
             bind: crate::query::memory::RepoMemoryBindTarget {
                 logical_symbol_id: None,
                 symbol_id: None,
@@ -89,6 +90,7 @@ fn dir_memory_validation_current_and_gone() {
         created_by: Some("test".to_string()),
         source: Some("agent".to_string()),
         tags: vec![],
+        payload_json: None,
         bind: dir_bind(Some("src".to_string())),
     })
     .unwrap();
@@ -103,6 +105,7 @@ fn dir_memory_validation_current_and_gone() {
         created_by: Some("test".to_string()),
         source: Some("agent".to_string()),
         tags: vec![],
+        payload_json: None,
         bind: dir_bind(Some("does/not/exist".to_string())),
     })
     .unwrap();
@@ -116,6 +119,7 @@ fn dir_memory_validation_current_and_gone() {
         created_by: Some("test".to_string()),
         source: Some("agent".to_string()),
         tags: vec![],
+        payload_json: None,
         bind: dir_bind(Some("".to_string())),
     })
     .unwrap();
@@ -186,6 +190,7 @@ fn list_memories_returns_summaries_and_filters_by_binding_kind() {
             created_by: Some("test".to_string()),
             source: Some("agent".to_string()),
             tags: vec![],
+            payload_json: None,
             bind: dir_bind(Some("src".to_string())),
         })
         .unwrap();
@@ -200,6 +205,7 @@ fn list_memories_returns_summaries_and_filters_by_binding_kind() {
             created_by: Some("test".to_string()),
             source: Some("agent".to_string()),
             tags: vec![],
+            payload_json: None,
             bind: path_bind("src/lib.rs".to_string()),
         })
         .unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/generation_rebuild.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/generation_rebuild.rs
@@ -749,6 +749,7 @@ fn a_memory_written_mid_rebuild_survives_the_flip_intact() {
             created_by: Some("test".to_string()),
             source: Some("agent".to_string()),
             tags: Vec::new(),
+            payload_json: None,
             bind: crate::query::memory::RepoMemoryBindTarget {
                 chunk_id: Some(live_chunk_id),
                 ..Default::default()

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -417,6 +417,7 @@ fn create_dir_memory(db: &IndexDatabase, title: &str, dir: Option<String>) {
         created_by: Some("test".to_string()),
         source: Some("agent".to_string()),
         tags: vec![],
+        payload_json: None,
         bind: dir_bind_target(dir),
     })
     .unwrap();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/multi_repo_scope.rs
@@ -960,6 +960,7 @@ fn a5_create_memory(
         created_by: None,
         source: None,
         tags: Vec::new(),
+        payload_json: None,
         bind: RepoMemoryBindTarget { commit_hash: Some(commit.to_string()), ..Default::default() },
     })
     .unwrap()
@@ -1213,6 +1214,7 @@ fn memory_by_id_read_and_mutations_refuse_a_sibling_repos_memory() {
             confidence: None,
             status: None,
             tags: None,
+            payload_json: None,
         })
         .is_err(),
         "update_memory must refuse a sibling repo's memory id",

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/orientation_healing.rs
@@ -663,6 +663,7 @@ fn impact_report_flags_a_section_truncated_at_limit() {
             created_by: Some("test".to_string()),
             source: Some("agent".to_string()),
             tags: vec![],
+            payload_json: None,
             bind: crate::query::memory::RepoMemoryBindTarget {
                 symbol_id: Some(hub.symbol_id),
                 ..Default::default()

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -38,6 +38,7 @@ fn repo_memory_bound_to_logical_symbol_surfaces_in_symbol_chunk_and_impact() {
             created_by: Some("test-agent".to_string()),
             source: Some("agent".to_string()),
             tags: vec!["cfg".to_string(), "graph".to_string()],
+            payload_json: None,
             bind: crate::query::memory::RepoMemoryBindTarget {
                 logical_symbol_id: Some(logical_symbol_id),
                 symbol_id: None,
@@ -118,6 +119,7 @@ fn compact_repo_memory_view_projects_primary_binding_then_full_mode_round_trips(
             created_by: Some("test-agent".to_string()),
             source: Some("agent".to_string()),
             tags: vec!["runtime".to_string()],
+            payload_json: None,
             bind: crate::query::memory::RepoMemoryBindTarget {
                 logical_symbol_id: Some(logical_symbol_id),
                 ..Default::default()
@@ -216,6 +218,7 @@ fn compact_repo_memory_view_separates_the_stale_lane() {
             created_by: Some("test-agent".to_string()),
             source: Some("agent".to_string()),
             tags: Vec::new(),
+            payload_json: None,
             bind: crate::query::memory::RepoMemoryBindTarget {
                 chunk_id: Some(chunk_id),
                 ..Default::default()
@@ -290,6 +293,7 @@ fn repo_memory_survives_reindex_and_relocates_when_symbol_moves() {
             created_by: Some("test".to_string()),
             source: Some("agent".to_string()),
             tags: Vec::new(),
+            payload_json: None,
             bind: crate::query::memory::RepoMemoryBindTarget {
                 symbol_id: Some(symbol.symbol_id),
                 logical_symbol_id: None,
@@ -381,6 +385,7 @@ fn repo_memory_validate_marks_changed_or_missing_anchors_non_current() {
             created_by: Some("test-agent".to_string()),
             source: Some("agent".to_string()),
             tags: Vec::new(),
+            payload_json: None,
             bind: crate::query::memory::RepoMemoryBindTarget {
                 logical_symbol_id: None,
                 symbol_id: None,
@@ -468,6 +473,7 @@ fn repo_memory_bound_to_edge_surfaces_when_impact_crosses_call_path() {
             created_by: Some("test-agent".to_string()),
             source: Some("agent".to_string()),
             tags: vec!["edge".to_string()],
+            payload_json: None,
             bind: crate::query::memory::RepoMemoryBindTarget {
                 logical_symbol_id: None,
                 symbol_id: None,
@@ -518,6 +524,7 @@ fn repo_memory_bound_to_edge_surfaces_when_impact_crosses_call_path() {
             created_by: Some("test-agent".to_string()),
             source: Some("agent".to_string()),
             tags: vec!["call-path".to_string()],
+            payload_json: None,
             bind: crate::query::memory::RepoMemoryBindTarget {
                 logical_symbol_id: None,
                 symbol_id: None,
@@ -598,6 +605,7 @@ fn server_derived_call_path_hash_is_stable_and_validates_through_edge_churn() {
             created_by: Some("test".to_string()),
             source: Some("agent".to_string()),
             tags: Vec::new(),
+            payload_json: None,
             bind: crate::query::memory::RepoMemoryBindTarget {
                 logical_symbol_id: None,
                 symbol_id: None,
@@ -705,6 +713,7 @@ fn impact_surface_surfaces_call_path_memory_when_path_crossed() {
         created_by: Some("test".to_string()),
         source: Some("agent".to_string()),
         tags: Vec::new(),
+        payload_json: None,
         bind: crate::query::memory::RepoMemoryBindTarget {
             logical_symbol_id: None,
             symbol_id: None,
@@ -801,6 +810,7 @@ fn memory_relocates_when_symbol_moves_to_another_file() {
             created_by: Some("test".to_string()),
             source: Some("agent".to_string()),
             tags: Vec::new(),
+            payload_json: None,
             bind: crate::query::memory::RepoMemoryBindTarget {
                 symbol_id: Some(symbol.symbol_id),
                 logical_symbol_id: None,
@@ -899,6 +909,7 @@ fn memory_relocation_is_durable_across_a_second_reindex() {
         created_by: Some("test".to_string()),
         source: Some("agent".to_string()),
         tags: Vec::new(),
+        payload_json: None,
         bind: crate::query::memory::RepoMemoryBindTarget {
             symbol_id: Some(symbol.symbol_id),
             logical_symbol_id: None,
@@ -997,6 +1008,7 @@ fn relocation_persists_refreshed_symbol_and_logical_ids() {
         created_by: Some("test".to_string()),
         source: Some("agent".to_string()),
         tags: Vec::new(),
+        payload_json: None,
         bind: crate::query::memory::RepoMemoryBindTarget {
             symbol_id: Some(original.symbol_id),
             logical_symbol_id: None,
@@ -1143,6 +1155,7 @@ fn memory_stays_gone_when_moved_symbol_body_changed() {
         created_by: Some("test".to_string()),
         source: Some("agent".to_string()),
         tags: Vec::new(),
+        payload_json: None,
         bind: crate::query::memory::RepoMemoryBindTarget {
             symbol_id: Some(symbol.symbol_id),
             logical_symbol_id: None,
@@ -1222,6 +1235,7 @@ fn memory_stays_gone_when_two_files_define_the_same_name() {
         created_by: Some("test".to_string()),
         source: Some("agent".to_string()),
         tags: Vec::new(),
+        payload_json: None,
         bind: crate::query::memory::RepoMemoryBindTarget {
             symbol_id: Some(symbol_id),
             logical_symbol_id: None,
@@ -1332,6 +1346,7 @@ fn memory_logical_binding_relocates_across_files() {
             created_by: Some("test".to_string()),
             source: Some("agent".to_string()),
             tags: Vec::new(),
+            payload_json: None,
             bind: crate::query::memory::RepoMemoryBindTarget {
                 logical_symbol_id: Some(logical_symbol_id),
                 symbol_id: None,
@@ -1458,6 +1473,7 @@ fn memory_chunk_binding_relocates_by_hash() {
             created_by: Some("test".to_string()),
             source: Some("agent".to_string()),
             tags: Vec::new(),
+            payload_json: None,
             bind: crate::query::memory::RepoMemoryBindTarget {
                 logical_symbol_id: None,
                 symbol_id: None,
@@ -1586,6 +1602,7 @@ fn memory_rebind_reanchors_and_refreshes_hash() {
             created_by: Some("test".to_string()),
             source: Some("agent".to_string()),
             tags: Vec::new(),
+            payload_json: None,
             bind: crate::query::memory::RepoMemoryBindTarget {
                 symbol_id: Some(src_symbol.symbol_id),
                 logical_symbol_id: None,
@@ -1761,6 +1778,7 @@ fn anchor_health_counts_tallies_persisted_statuses() {
         created_by: Some("test".to_string()),
         source: Some("agent".to_string()),
         tags: Vec::new(),
+        payload_json: None,
         bind: bind_target(alpha.symbol_id),
     })
     .unwrap();
@@ -1773,6 +1791,7 @@ fn anchor_health_counts_tallies_persisted_statuses() {
         created_by: Some("test".to_string()),
         source: Some("agent".to_string()),
         tags: Vec::new(),
+        payload_json: None,
         bind: bind_target(beta.symbol_id),
     })
     .unwrap();
@@ -1823,6 +1842,7 @@ fn memory_doctor_lists_gone_and_suggests_candidates() {
         created_by: Some("test".to_string()),
         source: Some("agent".to_string()),
         tags: Vec::new(),
+        payload_json: None,
         bind: crate::query::memory::RepoMemoryBindTarget {
             symbol_id: Some(src_symbol.symbol_id),
             logical_symbol_id: None,
@@ -1951,6 +1971,7 @@ fn memory_doctor_dedupes_cfg_split_candidates() {
         created_by: Some("test".to_string()),
         source: Some("agent".to_string()),
         tags: Vec::new(),
+        payload_json: None,
         bind: crate::query::memory::RepoMemoryBindTarget {
             symbol_id: Some(original),
             ..Default::default()
@@ -2322,6 +2343,7 @@ fn surface_summary_defers_bodies_across_the_db_memory_renderers() {
             created_by: Some("test".to_string()),
             source: Some("agent".to_string()),
             tags: vec![],
+            payload_json: None,
             bind: crate::query::memory::RepoMemoryBindTarget {
                 logical_symbol_id: symbol.logical_symbol_id,
                 ..Default::default()
@@ -2340,6 +2362,7 @@ fn surface_summary_defers_bodies_across_the_db_memory_renderers() {
         created_by: Some("test".to_string()),
         source: Some("agent".to_string()),
         tags: vec![],
+        payload_json: None,
         bind: crate::query::memory::RepoMemoryBindTarget {
             path: Some("src/lib.rs".to_string()),
             ..Default::default()
@@ -2466,6 +2489,7 @@ fn unanchored_node_is_created_listed_and_deduped() {
         created_by: Some("test-agent".to_string()),
         source: Some("agent".to_string()),
         tags: vec![],
+        payload_json: None,
         bind: crate::query::memory::RepoMemoryBindTarget::default(), // empty → unanchored
     };
 
@@ -2522,6 +2546,7 @@ fn rebind_still_requires_a_binding_target() {
             created_by: Some("test-agent".to_string()),
             source: Some("agent".to_string()),
             tags: vec![],
+            payload_json: None,
             bind: crate::query::memory::RepoMemoryBindTarget::default(),
         })
         .unwrap();
@@ -2562,6 +2587,7 @@ fn a_partial_binding_is_rejected_not_silently_unanchored() {
             created_by: Some("test-agent".to_string()),
             source: Some("agent".to_string()),
             tags: vec![],
+            payload_json: None,
             bind: crate::query::memory::RepoMemoryBindTarget {
                 github_owner: Some("o".to_string()),
                 github_repo: Some("r".to_string()),
@@ -2573,6 +2599,120 @@ fn a_partial_binding_is_rejected_not_silently_unanchored() {
         err.to_string().contains("binding is incomplete"),
         "a partial binding must be rejected, got: {err}"
     );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #465: a polymorphic node (a `Task`/`Concept` kind) stores and round-trips an opaque JSON payload
+/// through create → read → update. A non-object payload is rejected.
+#[test]
+fn a_polymorphic_node_stores_and_round_trips_its_payload() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn anchor() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    // A `Task` node (a new #465 kind), unanchored, carrying a structured payload.
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Task".to_string(),
+            title: "Wire the payload column".to_string(),
+            body: "Track the polymorphic payload work.".to_string(),
+            confidence: "medium".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: vec![],
+            payload_json: Some(r#"{"estimate":"1d","priority":2}"#.to_string()),
+            bind: crate::query::memory::RepoMemoryBindTarget::default(),
+        })
+        .unwrap();
+    assert!(!created.duplicate);
+    assert_eq!(created.memory.kind, "Task");
+    assert!(created.memory.bindings.is_empty(), "a Task node is unanchored");
+    assert_eq!(
+        created.memory.payload_json.as_deref(),
+        Some(r#"{"estimate":"1d","priority":2}"#),
+        "the payload round-trips verbatim on create"
+    );
+
+    // Read back independently.
+    let fetched = db.memory_get(&created.memory.memory_id).unwrap().expect("memory");
+    assert_eq!(fetched.payload_json.as_deref(), Some(r#"{"estimate":"1d","priority":2}"#));
+
+    // Update just the payload; `None` on the other fields leaves them unchanged.
+    let updated = db
+        .memory_update(crate::query::memory::RepoMemoryUpdate {
+            memory_id: created.memory.memory_id.clone(),
+            kind: None,
+            title: None,
+            body: None,
+            confidence: None,
+            status: None,
+            tags: None,
+            payload_json: Some(r#"{"priority":1}"#.to_string()),
+        })
+        .unwrap();
+    assert_eq!(updated.payload_json.as_deref(), Some(r#"{"priority":1}"#));
+    assert_eq!(updated.title, "Wire the payload column", "other fields unchanged");
+
+    // A non-object payload (an array) is rejected.
+    let err = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Concept".to_string(),
+            title: "bad payload".to_string(),
+            body: "an array is not a valid payload".to_string(),
+            confidence: "low".to_string(),
+            created_by: None,
+            source: Some("agent".to_string()),
+            tags: vec![],
+            payload_json: Some("[1,2,3]".to_string()),
+            bind: crate::query::memory::RepoMemoryBindTarget::default(),
+        })
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("must be a JSON object"),
+        "a non-object payload must be rejected, got: {err}"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #465: dedup folds the payload — two polymorphic nodes with identical text but DIFFERENT payloads
+/// are distinct (neither silently collapses onto the other, dropping its payload); identical text
+/// AND payload dedups.
+#[test]
+fn payload_bearing_nodes_dedupe_on_payload_not_just_text() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn anchor() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let make = |payload: &str| crate::query::memory::RepoMemoryCreate {
+        kind: "Task".to_string(),
+        title: "same title".to_string(),
+        body: "same body".to_string(),
+        confidence: "medium".to_string(),
+        created_by: Some("test-agent".to_string()),
+        source: Some("agent".to_string()),
+        tags: vec![],
+        payload_json: Some(payload.to_string()),
+        bind: crate::query::memory::RepoMemoryBindTarget::default(),
+    };
+
+    let a = db.memory_create(make(r#"{"priority":1}"#)).unwrap();
+    assert!(!a.duplicate);
+    // Same text, DIFFERENT payload → a distinct node, not a duplicate.
+    let b = db.memory_create(make(r#"{"priority":2}"#)).unwrap();
+    assert!(!b.duplicate, "a different payload must not dedup onto the first node");
+    assert_ne!(a.memory.memory_id, b.memory.memory_id);
+    // Same text AND payload → a duplicate.
+    let c = db.memory_create(make(r#"{"priority":1}"#)).unwrap();
+    assert!(c.duplicate, "identical text and payload dedups");
+    assert_eq!(c.memory.memory_id, a.memory.memory_id);
 
     let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -2481,10 +2481,10 @@ fn unanchored_node_is_created_listed_and_deduped() {
     let db = IndexDatabase::rebuild(&config).unwrap();
 
     let make = || crate::query::memory::RepoMemoryCreate {
-        kind: "Decision".to_string(), /* Task/Concept kinds land in #465; any kind may be
-                                       * unanchored. */
+        // Only Task/Concept may be created UNANCHORED (#465); other kinds must anchor to code.
+        kind: "Concept".to_string(),
         title: "Prefer the event log over polling".to_string(),
-        body: "A cross-cutting decision not anchored to any one symbol.".to_string(),
+        body: "A cross-cutting concept not anchored to any one symbol.".to_string(),
         confidence: "high".to_string(),
         created_by: Some("test-agent".to_string()),
         source: Some("agent".to_string()),
@@ -2505,7 +2505,7 @@ fn unanchored_node_is_created_listed_and_deduped() {
         .iter()
         .find(|s| s.memory_id == created.memory.memory_id)
         .expect("unanchored node must appear in `memory list`");
-    assert_eq!(summary.kind, "Decision");
+    assert_eq!(summary.kind, "Concept");
     assert_eq!(summary.binding_kind, "");
     assert_eq!(summary.binding_id, "");
 
@@ -2539,7 +2539,7 @@ fn rebind_still_requires_a_binding_target() {
 
     let created = db
         .memory_create(crate::query::memory::RepoMemoryCreate {
-            kind: "Decision".to_string(),
+            kind: "Concept".to_string(),
             title: "an unanchored node".to_string(),
             body: "created without a binding".to_string(),
             confidence: "medium".to_string(),
@@ -2713,6 +2713,162 @@ fn payload_bearing_nodes_dedupe_on_payload_not_just_text() {
     let c = db.memory_create(make(r#"{"priority":1}"#)).unwrap();
     assert!(c.duplicate, "identical text and payload dedups");
     assert_eq!(c.memory.memory_id, a.memory.memory_id);
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// #465 (PR #471 review): dedup folds KIND, and the unanchored-create gate is kind-aware. Two
+/// distinct graph-node kinds sharing text+payload are NOT duplicates; and only Task/Concept may be
+/// created unanchored — an unanchored Decision is rejected (which keeps `create` in lock-step with
+/// the dream verifier's kind exemption).
+#[test]
+fn dedup_and_unanchored_create_are_kind_aware() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn anchor() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let unanchored = |kind: &str| crate::query::memory::RepoMemoryCreate {
+        kind: kind.to_string(),
+        title: "same text".to_string(),
+        body: "same body".to_string(),
+        confidence: "medium".to_string(),
+        created_by: Some("test-agent".to_string()),
+        source: Some("agent".to_string()),
+        tags: vec![],
+        payload_json: Some(r#"{"p":1}"#.to_string()),
+        bind: crate::query::memory::RepoMemoryBindTarget::default(),
+    };
+
+    // A Concept and a Task with identical text+payload are DISTINCT (dedup folds kind).
+    let concept = db.memory_create(unanchored("Concept")).unwrap();
+    assert!(!concept.duplicate);
+    let task = db.memory_create(unanchored("Task")).unwrap();
+    assert!(!task.duplicate, "a different kind is not a duplicate");
+    assert_ne!(concept.memory.memory_id, task.memory.memory_id);
+    // Re-creating the same kind+text+payload dedups.
+    let again = db.memory_create(unanchored("Concept")).unwrap();
+    assert!(again.duplicate, "identical kind+text+payload dedups");
+    assert_eq!(again.memory.memory_id, concept.memory.memory_id);
+
+    // A non-Task/Concept kind cannot be created UNANCHORED (no payload here, so the anchor gate is
+    // what fires).
+    let err = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Decision".to_string(),
+            title: "unanchored decision".to_string(),
+            body: "b".to_string(),
+            confidence: "low".to_string(),
+            created_by: None,
+            source: Some("agent".to_string()),
+            tags: vec![],
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget::default(),
+        })
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("must anchor to code"),
+        "an unanchored Decision must be rejected, got: {err}"
+    );
+    // A payload is rejected on a non-polymorphic kind, even when ANCHORED to code.
+    let perr = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "invariant with payload".to_string(),
+            body: "b".to_string(),
+            confidence: "low".to_string(),
+            created_by: None,
+            source: Some("agent".to_string()),
+            tags: vec![],
+            payload_json: Some(r#"{"p":1}"#.to_string()),
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                path: Some("src/lib.rs".to_string()),
+                ..Default::default()
+            },
+        })
+        .unwrap_err();
+    assert!(
+        perr.to_string().contains("only Task/Concept may have a payload"),
+        "a payload on a non-polymorphic kind must be rejected, got: {perr}"
+    );
+
+    // The invariant holds on UPDATE too: a zero-binding node cannot be retyped to a non-graph kind,
+    // but retyping between graph-node kinds (Task -> Concept) is fine.
+    let retype = |kind: &str| crate::query::memory::RepoMemoryUpdate {
+        memory_id: task.memory.memory_id.clone(),
+        kind: Some(kind.to_string()),
+        title: None,
+        body: None,
+        confidence: None,
+        status: None,
+        tags: None,
+        payload_json: None,
+    };
+    let bad = db.memory_update(retype("Decision")).unwrap_err();
+    assert!(
+        bad.to_string().contains("only Task/Concept may be unanchored"),
+        "retyping an unanchored node to Decision must be rejected, got: {bad}"
+    );
+    assert_eq!(
+        db.memory_update(retype("Concept")).unwrap().kind,
+        "Concept",
+        "retyping between graph-node kinds is allowed"
+    );
+
+    // Retyping an ANCHORED Task (carrying a payload) to a non-polymorphic kind is allowed (it has a
+    // binding) and CLEARS the stranded payload rather than preserving it.
+    let anchored = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Task".to_string(),
+            title: "anchored task".to_string(),
+            body: "b".to_string(),
+            confidence: "medium".to_string(),
+            created_by: None,
+            source: Some("agent".to_string()),
+            tags: vec![],
+            payload_json: Some(r#"{"p":9}"#.to_string()),
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                path: Some("src/lib.rs".to_string()),
+                ..Default::default()
+            },
+        })
+        .unwrap();
+    assert_eq!(anchored.memory.payload_json.as_deref(), Some(r#"{"p":9}"#));
+    let retyped = db
+        .memory_update(crate::query::memory::RepoMemoryUpdate {
+            memory_id: anchored.memory.memory_id.clone(),
+            kind: Some("Decision".to_string()),
+            title: None,
+            body: None,
+            confidence: None,
+            status: None,
+            tags: None,
+            payload_json: None,
+        })
+        .unwrap();
+    assert_eq!(retyped.kind, "Decision");
+    assert!(retyped.payload_json.is_none(), "retyping away from Task/Concept clears the payload");
+
+    // A LEGACY zero-binding non-graph memory (a pre-gate Decision, seeded directly under the active
+    // repo) stays CLEANABLE: a status-only update (mark_obsolete) does not change the kind, so the
+    // gate does not trap it.
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO repo_memories(id, kind, title, body, confidence, status, created_by, \
+             created_at_ms, updated_at_ms, source, memory_version, repo_id)
+             SELECT 'mem_legacy', 'Decision', 'legacy orphan', 'b', 'low', 'active', 'agent', 0, \
+             0, 'agent', 'v1', repo_id FROM repo_memories WHERE id = ?1",
+            [&concept.memory.memory_id],
+        )
+        .unwrap();
+    assert_eq!(
+        db.memory_mark_obsolete("mem_legacy").unwrap().status,
+        "obsolete",
+        "a legacy unanchored non-graph memory can still be cleaned up"
+    );
 
     let _ = fs::remove_dir_all(&root);
 }

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -766,8 +766,13 @@ fn migration_046_creates_the_verification_tables_on_fresh_apply() {
 fn migration_047_creates_the_model_failure_table_on_fresh_apply() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 47, "V047 is the schema tip");
-    assert_eq!(schema::status(&conn).unwrap().current_version, 47, "schema at LATEST after apply");
+    // The absolute-tip pin moved to `migration_048_*` (V048 is the tip now); this test keeps the
+    // symbolic "schema at LATEST after apply" check and its V047 table coverage.
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply"
+    );
 
     let table_sql = conn
         .query_row("SELECT sql FROM sqlite_master WHERE name = 'memory_model_failures'", [], |r| {
@@ -809,6 +814,26 @@ fn migration_047_creates_the_model_failure_table_on_fresh_apply() {
 
     schema::apply(&conn).unwrap();
     assert!(conn_table_exists(&conn, "memory_model_failures"), "failure table survives a re-apply");
+}
+
+#[test]
+fn migration_048_adds_the_memory_payload_json_column() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    // V048 is the schema tip — the absolute pin (the previous tip test, migration_047_*, dropped to
+    // the symbolic `current_version == LATEST` check when this landed).
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 48, "V048 is the schema tip");
+    assert_eq!(schema::status(&conn).unwrap().current_version, 48, "schema at LATEST after apply");
+    assert!(
+        conn_table_columns(&conn, "repo_memories").contains(&"payload_json".to_string()),
+        "repo_memories carries the payload_json column (#465)"
+    );
+    // Additive + nullable: a re-apply is idempotent and the column survives.
+    schema::apply(&conn).unwrap();
+    assert!(
+        conn_table_columns(&conn, "repo_memories").contains(&"payload_json".to_string()),
+        "payload_json survives a re-apply"
+    );
 }
 
 #[test]

--- a/crates/rag-rat-core/src/query/grep_augment.rs
+++ b/crates/rag-rat-core/src/query/grep_augment.rs
@@ -658,6 +658,7 @@ mod tests {
             created_by: Some("test".to_string()),
             source: None,
             tags: vec![],
+            payload_json: None,
             bind: RepoMemoryBindTarget {
                 symbol_id: Some(1),
                 logical_symbol_id: None,
@@ -960,6 +961,7 @@ mod tests {
                 created_by: Some("test".to_string()),
                 source: None,
                 tags: vec![],
+                payload_json: None,
                 bind: RepoMemoryBindTarget {
                     symbol_id: Some(1),
                     logical_symbol_id: None,

--- a/crates/rag-rat-core/src/query/memory/api.rs
+++ b/crates/rag-rat-core/src/query/memory/api.rs
@@ -17,12 +17,23 @@ pub(crate) fn create_memory(
     validate_len("body", &request.body, MAX_MEMORY_BODY_LEN)?;
     let source = request.source.clone().unwrap_or_else(|| "agent".to_string());
     validate_source(&source)?;
+    validate_payload(request.payload_json.as_deref())?;
     // `None` = an UNANCHORED node (#463): a `Concept` / standalone `Task` with no code anchor.
     let binding = resolve_binding(conn, &request.bind)?;
-    let input_hash = memory_input_hash(&request.kind, &request.title, &request.body, &request.tags);
-    if let Some(existing_id) =
-        duplicate_memory_id(conn, &request.title, &request.body, binding.as_ref())?
-    {
+    let input_hash = memory_input_hash(
+        &request.kind,
+        &request.title,
+        &request.body,
+        &request.tags,
+        request.payload_json.as_deref(),
+    );
+    if let Some(existing_id) = duplicate_memory_id(
+        conn,
+        &request.title,
+        &request.body,
+        request.payload_json.as_deref(),
+        binding.as_ref(),
+    )? {
         let memory = memory_by_id(conn, &existing_id)?
             .ok_or_else(|| anyhow::anyhow!("duplicate memory `{existing_id}` disappeared"))?;
         return Ok(RepoMemoryCreateResult { memory, duplicate: true });
@@ -39,9 +50,9 @@ pub(crate) fn create_memory(
         "
         INSERT INTO repo_memories(
             id, kind, title, body, confidence, status, created_by, created_at_ms, updated_at_ms,
-            source, source_text_hash, input_hash, memory_version
+            source, payload_json, source_text_hash, input_hash, memory_version
         )
-        VALUES (?1, ?2, ?3, ?4, ?5, 'active', ?6, ?7, ?7, ?8, ?9, ?10, 'v1')
+        VALUES (?1, ?2, ?3, ?4, ?5, 'active', ?6, ?7, ?7, ?8, ?9, ?10, ?11, 'v1')
         ",
         params![
             id,
@@ -52,6 +63,7 @@ pub(crate) fn create_memory(
             request.created_by,
             now,
             source,
+            request.payload_json,
             binding.as_ref().and_then(|b| b.source_text_hash.clone()),
             input_hash
         ],
@@ -100,6 +112,7 @@ pub(crate) fn update_memory(
     if let Some(body) = update.body.as_deref() {
         validate_len("body", body, MAX_MEMORY_BODY_LEN)?;
     }
+    validate_payload(update.payload_json.as_deref())?;
     let now = now_ms();
     conn.execute(
         "
@@ -109,6 +122,7 @@ pub(crate) fn update_memory(
             body = ?4,
             confidence = ?5,
             status = ?6,
+            payload_json = ?8,
             updated_at_ms = ?7
         WHERE id = ?1
         ",
@@ -119,7 +133,9 @@ pub(crate) fn update_memory(
             update.body.unwrap_or(current.body),
             update.confidence.unwrap_or(current.confidence),
             update.status.unwrap_or(current.status),
-            now
+            now,
+            // `None` leaves the stored payload unchanged (like the other fields above).
+            update.payload_json.or(current.payload_json)
         ],
     )?;
     if let Some(tags) = update.tags {
@@ -139,6 +155,7 @@ pub(crate) fn mark_obsolete(conn: &Connection, memory_id: &str) -> anyhow::Resul
         confidence: None,
         status: Some("obsolete".to_string()),
         tags: None,
+        payload_json: None,
     })
 }
 pub(crate) fn memory_by_id(
@@ -169,6 +186,7 @@ pub(crate) fn memory_by_id(
                    created_at_ms AS created_at_ms,
                    updated_at_ms AS updated_at_ms,
                    source AS source,
+                   payload_json AS payload_json,
                    source_text_hash AS source_text_hash,
                    input_hash AS input_hash,
                    memory_version AS memory_version

--- a/crates/rag-rat-core/src/query/memory/api.rs
+++ b/crates/rag-rat-core/src/query/memory/api.rs
@@ -17,9 +17,19 @@ pub(crate) fn create_memory(
     validate_len("body", &request.body, MAX_MEMORY_BODY_LEN)?;
     let source = request.source.clone().unwrap_or_else(|| "agent".to_string());
     validate_source(&source)?;
-    validate_payload(request.payload_json.as_deref())?;
-    // `None` = an UNANCHORED node (#463): a `Concept` / standalone `Task` with no code anchor.
+    validate_payload(&request.kind, request.payload_json.as_deref())?;
+    // `None` = an UNANCHORED node: only the polymorphic graph-node kinds (`Task` / `Concept`) may
+    // be anchorless (#463/#465). Every OTHER kind must anchor to code — a zero-binding one is
+    // an orphan the dream verifier flags, so allowing its create would generate self-inflicted
+    // `memory_unverifiable` noise. This gate stays in lock-step with `dream::unverifiable_findings`
+    // via the shared `is_polymorphic_node_kind`.
     let binding = resolve_binding(conn, &request.bind)?;
+    if binding.is_none() && !is_polymorphic_node_kind(&request.kind) {
+        anyhow::bail!(
+            "a `{}` memory must anchor to code (only Task/Concept may be unanchored)",
+            request.kind
+        );
+    }
     let input_hash = memory_input_hash(
         &request.kind,
         &request.title,
@@ -29,6 +39,7 @@ pub(crate) fn create_memory(
     );
     if let Some(existing_id) = duplicate_memory_id(
         conn,
+        &request.kind,
         &request.title,
         &request.body,
         request.payload_json.as_deref(),
@@ -112,7 +123,27 @@ pub(crate) fn update_memory(
     if let Some(body) = update.body.as_deref() {
         validate_len("body", body, MAX_MEMORY_BODY_LEN)?;
     }
-    validate_payload(update.payload_json.as_deref())?;
+    // The resulting kind drives payload validation, the unanchored gate, and payload-clearing.
+    let new_kind = update.kind.clone().unwrap_or_else(|| current.kind.clone());
+    validate_payload(&new_kind, update.payload_json.as_deref())?;
+    // The unanchored-kind invariant holds on UPDATE too — but only to PREVENT INTRODUCING it, not
+    // to trap rows already in that state (a legacy pre-#465 unanchored `Decision`, or the
+    // same-kind no-op of a status-only update / `mark_obsolete`, stays editable so it can be
+    // CLEANED UP). Fire ONLY on a kind CHANGE to a non-polymorphic kind on a zero-binding node.
+    let changing_kind = update.kind.as_deref().is_some_and(|kind| kind != current.kind);
+    if changing_kind && !is_polymorphic_node_kind(&new_kind) && current.bindings.is_empty() {
+        anyhow::bail!(
+            "cannot retype an unanchored memory to `{new_kind}` (only Task/Concept may be \
+             unanchored); bind it to code first"
+        );
+    }
+    // A non-polymorphic kind carries NO payload — retyping AWAY from Task/Concept CLEARS a stranded
+    // payload rather than preserving it. Otherwise keep the update's payload, else the current one.
+    let stored_payload = if is_polymorphic_node_kind(&new_kind) {
+        update.payload_json.clone().or_else(|| current.payload_json.clone())
+    } else {
+        None
+    };
     let now = now_ms();
     conn.execute(
         "
@@ -128,14 +159,13 @@ pub(crate) fn update_memory(
         ",
         params![
             update.memory_id,
-            update.kind.unwrap_or(current.kind),
+            new_kind,
             update.title.unwrap_or(current.title),
             update.body.unwrap_or(current.body),
             update.confidence.unwrap_or(current.confidence),
             update.status.unwrap_or(current.status),
             now,
-            // `None` leaves the stored payload unchanged (like the other fields above).
-            update.payload_json.or(current.payload_json)
+            stored_payload
         ],
     )?;
     if let Some(tags) = update.tags {

--- a/crates/rag-rat-core/src/query/memory/hydrate.rs
+++ b/crates/rag-rat-core/src/query/memory/hydrate.rs
@@ -2,13 +2,16 @@ use super::*;
 
 pub(crate) fn duplicate_memory_id(
     conn: &Connection,
+    kind: &str,
     title: &str,
     body: &str,
     payload_json: Option<&str>,
     binding: Option<&ResolvedBinding>,
 ) -> anyhow::Result<Option<String>> {
-    // Dedupe NEVER crosses repos (spec §4.4): a duplicate is a same-repo title+body+PAYLOAD+binding
-    // match. The `{repo_clause}` is empty on the pre-A5 schema (memory still repo-global), so this
+    // Dedupe NEVER crosses repos (spec §4.4): a duplicate is a same-repo KIND+title+body+PAYLOAD+
+    // binding match — every dimension `memory_input_hash` folds, so two DISTINCT graph-node kinds
+    // (a `Concept` and a `Task`) sharing text+payload are NOT duplicates (the second must not be
+    // lost). The `{repo_clause}` is empty on the pre-A5 schema (memory still repo-global), so this
     // stays the original global dedupe until the periphery-scoping migration lands. An UNANCHORED
     // node (#463) has no binding, so its dupe is a same-repo title+body+payload match with NO
     // bindings — never a false collision with an anchored memory that happens to share text. The
@@ -24,7 +27,8 @@ pub(crate) fn duplicate_memory_id(
         SELECT repo_memories.id AS memory_id
         FROM repo_memories
         JOIN repo_memory_bindings ON repo_memory_bindings.memory_id = repo_memories.id
-        WHERE lower(repo_memories.title) = lower(?1)
+        WHERE repo_memories.kind = ?6
+          AND lower(repo_memories.title) = lower(?1)
           AND lower(repo_memories.body) = lower(?2)
           AND repo_memory_bindings.binding_kind = ?3
           AND repo_memory_bindings.binding_id = ?4
@@ -38,7 +42,8 @@ pub(crate) fn duplicate_memory_id(
                 body.trim(),
                 binding.binding_kind,
                 binding.binding_id,
-                payload_json
+                payload_json,
+                kind
             ],
             |row| row.get("memory_id"),
         ),
@@ -47,7 +52,8 @@ pub(crate) fn duplicate_memory_id(
                 "
         SELECT repo_memories.id AS memory_id
         FROM repo_memories
-        WHERE lower(repo_memories.title) = lower(?1)
+        WHERE repo_memories.kind = ?4
+          AND lower(repo_memories.title) = lower(?1)
           AND lower(repo_memories.body) = lower(?2)
           AND repo_memories.payload_json IS ?3
           AND repo_memories.status != 'obsolete'{repo_clause}
@@ -58,7 +64,7 @@ pub(crate) fn duplicate_memory_id(
         LIMIT 1
         "
             ),
-            params![title.trim(), body.trim(), payload_json],
+            params![title.trim(), body.trim(), payload_json, kind],
             |row| row.get("memory_id"),
         ),
     }

--- a/crates/rag-rat-core/src/query/memory/hydrate.rs
+++ b/crates/rag-rat-core/src/query/memory/hydrate.rs
@@ -4,13 +4,17 @@ pub(crate) fn duplicate_memory_id(
     conn: &Connection,
     title: &str,
     body: &str,
+    payload_json: Option<&str>,
     binding: Option<&ResolvedBinding>,
 ) -> anyhow::Result<Option<String>> {
-    // Dedupe NEVER crosses repos (spec §4.4): a duplicate is a same-repo title+body+binding match.
-    // The `{repo_clause}` is empty on the pre-A5 schema (memory still repo-global), so this stays
-    // the original global dedupe until the periphery-scoping migration lands. An UNANCHORED node
-    // (#463) has no binding, so its dupe is a same-repo title+body match with NO bindings — never a
-    // false collision with an anchored memory that happens to share text.
+    // Dedupe NEVER crosses repos (spec §4.4): a duplicate is a same-repo title+body+PAYLOAD+binding
+    // match. The `{repo_clause}` is empty on the pre-A5 schema (memory still repo-global), so this
+    // stays the original global dedupe until the periphery-scoping migration lands. An UNANCHORED
+    // node (#463) has no binding, so its dupe is a same-repo title+body+payload match with NO
+    // bindings — never a false collision with an anchored memory that happens to share text. The
+    // `payload_json IS ?` compare is NULL-safe (both-null OR equal), so two polymorphic nodes
+    // (#465) with identical text but DIFFERENT payloads are NOT duplicates — neither collapses
+    // onto the other (which would silently drop the second's payload).
     let scope = memory_repo_scope(conn)?;
     let repo_clause = memory_repo_scope_clause(&scope);
     match binding {
@@ -24,11 +28,18 @@ pub(crate) fn duplicate_memory_id(
           AND lower(repo_memories.body) = lower(?2)
           AND repo_memory_bindings.binding_kind = ?3
           AND repo_memory_bindings.binding_id = ?4
+          AND repo_memories.payload_json IS ?5
           AND repo_memories.status != 'obsolete'{repo_clause}
         LIMIT 1
         "
             ),
-            params![title.trim(), body.trim(), binding.binding_kind, binding.binding_id],
+            params![
+                title.trim(),
+                body.trim(),
+                binding.binding_kind,
+                binding.binding_id,
+                payload_json
+            ],
             |row| row.get("memory_id"),
         ),
         None => conn.query_row(
@@ -38,6 +49,7 @@ pub(crate) fn duplicate_memory_id(
         FROM repo_memories
         WHERE lower(repo_memories.title) = lower(?1)
           AND lower(repo_memories.body) = lower(?2)
+          AND repo_memories.payload_json IS ?3
           AND repo_memories.status != 'obsolete'{repo_clause}
           AND NOT EXISTS (
               SELECT 1 FROM repo_memory_bindings WHERE repo_memory_bindings.memory_id = \
@@ -46,7 +58,7 @@ pub(crate) fn duplicate_memory_id(
         LIMIT 1
         "
             ),
-            params![title.trim(), body.trim()],
+            params![title.trim(), body.trim(), payload_json],
             |row| row.get("memory_id"),
         ),
     }
@@ -114,6 +126,7 @@ pub(crate) fn memory_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RepoMemory
         created_at_ms: row.get("created_at_ms")?,
         updated_at_ms: row.get("updated_at_ms")?,
         source: row.get("source")?,
+        payload_json: row.get("payload_json")?,
         source_text_hash: row.get("source_text_hash")?,
         input_hash: row.get("input_hash")?,
         memory_version: row.get("memory_version")?,

--- a/crates/rag-rat-core/src/query/memory/mod.rs
+++ b/crates/rag-rat-core/src/query/memory/mod.rs
@@ -56,6 +56,12 @@ pub struct RepoMemory {
     pub created_at_ms: i64,
     pub updated_at_ms: i64,
     pub source: String,
+    /// Opaque, `schema_version`-tagged JSON payload for polymorphic nodes (#465) — the
+    /// kind-specific structured data a `Task` / `Concept` carries (e.g. a task's
+    /// priority/estimate). `None` for a plain note. Stored verbatim; the core does not type
+    /// it. (content_hash folds it in phase B.)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload_json: Option<String>,
     // Internal anchoring/dedup mechanics — never actionable for a reader, so kept off the wire.
     #[serde(skip_serializing)]
     pub source_text_hash: Option<String>,
@@ -155,6 +161,11 @@ pub struct RepoMemoryCreate {
     pub confidence: String,
     pub created_by: Option<String>,
     pub source: Option<String>,
+    /// Opaque JSON payload for a polymorphic node (#465) — a `Task`/`Concept`'s kind-specific
+    /// data. Validated as a JSON object with no node/edge references (payload-closure); stored
+    /// verbatim.
+    #[serde(default)]
+    pub payload_json: Option<String>,
     #[serde(default)]
     pub tags: Vec<String>,
     pub bind: RepoMemoryBindTarget,
@@ -226,6 +237,9 @@ pub struct RepoMemoryUpdate {
     pub confidence: Option<String>,
     pub status: Option<String>,
     pub tags: Option<Vec<String>>,
+    /// Set the node's payload (#465). `None` leaves the stored payload unchanged (like the other
+    /// fields); a `Some` value replaces it. Clearing a payload to null is not supported yet.
+    pub payload_json: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -569,6 +583,7 @@ mod tests {
             created_at_ms: 0,
             updated_at_ms: 0,
             source: "agent".to_string(),
+            payload_json: None,
             source_text_hash: None,
             input_hash: None,
             memory_version: String::new(),
@@ -639,6 +654,7 @@ mod tests {
             created_at_ms: 0,
             updated_at_ms: 0,
             source: "agent".to_string(),
+            payload_json: None,
             source_text_hash: None,
             input_hash: None,
             memory_version: String::new(),

--- a/crates/rag-rat-core/src/query/memory/validate.rs
+++ b/crates/rag-rat-core/src/query/memory/validate.rs
@@ -493,10 +493,31 @@ pub(crate) fn validate_kind(kind: &str) -> anyhow::Result<()> {
         | "PlatformQuirk"
         | "FollowUp"
         | "OpenQuestion"
-        | "Obsolete" => Ok(()),
+        | "Obsolete"
+        // Polymorphic graph-node kinds (#465): legitimately unanchored (a Concept / standalone
+        // Task lives as a graph node with no code binding — see resolve_binding / #463).
+        | "Task"
+        | "Concept" => Ok(()),
         _ => anyhow::bail!("invalid memory kind `{kind}`"),
     }
 }
+/// A polymorphic node's payload (#465) must be a JSON OBJECT — so it round-trips, and so it can be
+/// folded into `content_hash` in phase B. An array/scalar/malformed value is rejected; `None` (no
+/// payload) is fine. Payload-closure (a payload carries no node/edge references) is enforced once
+/// the edge model (#464) defines what a reference IS — a payload cannot "reference a node" before
+/// nodes are referenceable, so there is nothing to reject here yet.
+pub(crate) fn validate_payload(payload_json: Option<&str>) -> anyhow::Result<()> {
+    let Some(payload) = payload_json else {
+        return Ok(());
+    };
+    let value: serde_json::Value = serde_json::from_str(payload)
+        .map_err(|e| anyhow::anyhow!("payload_json is not valid JSON: {e}"))?;
+    if !value.is_object() {
+        anyhow::bail!("payload_json must be a JSON object");
+    }
+    Ok(())
+}
+
 pub(crate) fn validate_confidence(confidence: &str) -> anyhow::Result<()> {
     match confidence {
         "high" | "medium" | "low" => Ok(()),
@@ -542,12 +563,29 @@ pub(crate) fn memory_id(now: i64, input_hash: &str, scope: &Option<String>) -> S
     };
     format!("mem_{now:x}_{suffix}")
 }
-pub(crate) fn memory_input_hash(kind: &str, title: &str, body: &str, tags: &[String]) -> String {
+pub(crate) fn memory_input_hash(
+    kind: &str,
+    title: &str,
+    body: &str,
+    tags: &[String],
+    payload_json: Option<&str>,
+) -> String {
     let mut normalized_tags = tags.iter().map(|tag| tag.trim()).collect::<Vec<_>>();
     normalized_tags.sort_unstable();
+    // The payload is folded RAW (not canonicalized): this is the create-time dedup / id seed, which
+    // wants EXACT-input identity so two nodes with identical text but different payloads get
+    // different ids and neither collapses onto the other (#465). This is NOT the dream content
+    // identity — `dream::note_content_hash` is separate, and its CANONICAL payload fold is deferred
+    // to phase B (#404).
     hex_sha256(
-        format!("{kind}\n{}\n{}\n{}", title.trim(), body.trim(), normalized_tags.join(","))
-            .as_bytes(),
+        format!(
+            "{kind}\n{}\n{}\n{}\n{}",
+            title.trim(),
+            body.trim(),
+            normalized_tags.join(","),
+            payload_json.unwrap_or("")
+        )
+        .as_bytes(),
     )
 }
 pub(crate) fn hex_sha256(bytes: &[u8]) -> String {

--- a/crates/rag-rat-core/src/query/memory/validate.rs
+++ b/crates/rag-rat-core/src/query/memory/validate.rs
@@ -501,15 +501,31 @@ pub(crate) fn validate_kind(kind: &str) -> anyhow::Result<()> {
         _ => anyhow::bail!("invalid memory kind `{kind}`"),
     }
 }
-/// A polymorphic node's payload (#465) must be a JSON OBJECT — so it round-trips, and so it can be
-/// folded into `content_hash` in phase B. An array/scalar/malformed value is rejected; `None` (no
-/// payload) is fine. Payload-closure (a payload carries no node/edge references) is enforced once
-/// the edge model (#464) defines what a reference IS — a payload cannot "reference a node" before
-/// nodes are referenceable, so there is nothing to reject here yet.
-pub(crate) fn validate_payload(payload_json: Option<&str>) -> anyhow::Result<()> {
+/// The polymorphic graph-node kinds — `Task` and `Concept` (#463/#465). They ALONE may be created
+/// UNANCHORED (no code binding) AND may carry a structured `payload_json`; every other kind is a
+/// plain note (anchors to code, no payload). The SINGLE source of truth for the unanchored-create
+/// gate (`create`/`update_memory`), the payload-kind gate (`validate_payload`), and the dream
+/// verifier's `memory_unverifiable` exemption — they must never drift, or a create the gate allows
+/// becomes self-inflicted dream noise, or an off-contract payload/anchor slips through.
+pub(crate) fn is_polymorphic_node_kind(kind: &str) -> bool {
+    matches!(kind, "Task" | "Concept")
+}
+
+/// Validate a memory's `payload_json` for its `kind`. Only the polymorphic graph-node kinds
+/// (`is_polymorphic_node_kind`) may carry a payload, and it must be a JSON OBJECT (so it
+/// round-trips and can be folded into the identity hash). A payload on a plain-note kind, or a
+/// non-object payload, is rejected; `None` (no payload) is always fine. Payload-closure (a payload
+/// carries no node/edge references) is enforced once the edge model (#464) defines what a reference
+/// IS.
+pub(crate) fn validate_payload(kind: &str, payload_json: Option<&str>) -> anyhow::Result<()> {
     let Some(payload) = payload_json else {
         return Ok(());
     };
+    if !is_polymorphic_node_kind(kind) {
+        anyhow::bail!(
+            "a `{kind}` memory carries no payload (only Task/Concept may have a payload_json)"
+        );
+    }
     let value: serde_json::Value = serde_json::from_str(payload)
         .map_err(|e| anyhow::anyhow!("payload_json is not valid JSON: {e}"))?;
     if !value.is_object() {

--- a/crates/rag-rat-mcp/src/tools/requests.rs
+++ b/crates/rag-rat-mcp/src/tools/requests.rs
@@ -499,6 +499,8 @@ pub enum McpMemoryKind {
     FollowUp,
     OpenQuestion,
     Obsolete,
+    Task,
+    Concept,
 }
 
 impl McpMemoryKind {
@@ -517,6 +519,8 @@ impl McpMemoryKind {
             Self::FollowUp => "FollowUp",
             Self::OpenQuestion => "OpenQuestion",
             Self::Obsolete => "Obsolete",
+            Self::Task => "Task",
+            Self::Concept => "Concept",
         }
     }
 }
@@ -638,6 +642,10 @@ pub struct MemoryCreateArgs {
     pub source: Option<McpMemorySource>,
     #[serde(default)]
     pub tags: Vec<String>,
+    /// Optional structured payload (#465) for a polymorphic node — a `Task`/`Concept`'s
+    /// kind-specific JSON object (e.g. a task's priority/estimate). Must be a JSON object.
+    #[serde(default)]
+    pub payload: Option<serde_json::Value>,
     /// Optional (#463): omit to create an UNANCHORED node (a `Concept` or standalone `Task` that
     /// lives only as a graph node). When present, names exactly one code/anchor binding.
     #[serde(default)]
@@ -661,6 +669,9 @@ pub struct MemoryUpdateArgs {
     pub confidence: Option<McpMemoryConfidence>,
     pub status: Option<McpMemoryStatus>,
     pub tags: Option<Vec<String>>,
+    /// Set the node's structured payload (#465). Omit to leave the stored payload unchanged; a
+    /// JSON object replaces it.
+    pub payload: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
@@ -756,6 +767,7 @@ impl MemoryCreateArgs {
             created_by: self.created_by,
             source: self.source.map(|source| source.as_str().to_string()),
             tags: self.tags,
+            payload_json: self.payload.map(|payload| payload.to_string()),
             bind: self.bind.into(),
         }
     }
@@ -771,6 +783,7 @@ impl MemoryUpdateArgs {
             confidence: self.confidence.map(|confidence| confidence.as_str().to_string()),
             status: self.status.map(|status| status.as_str().to_string()),
             tags: self.tags,
+            payload_json: self.payload.map(|payload| payload.to_string()),
         }
     }
 }


### PR DESCRIPTION
The second prerequisite for the knowledge-graph data model (#462): give memory nodes an opaque **polymorphic payload** and add the two graph-node **kinds** (`Task`, `Concept`).

## What changed

- **V048 migration** — `repo_memories.payload_json` (nullable, additive, idempotent re-apply). The absolute schema-tip pin moved from `migration_047` (now symbolic) to `migration_048`.
- **Kinds** — `Task` and `Concept` are valid in `validate_kind` + the MCP kind enum. They are legitimately unanchored (a graph node with no code binding, per #463).
- **Round-trip** — `RepoMemoryCreate`/`RepoMemoryUpdate` carry `payload_json`; create/update store it; `RepoMemory` / `memory_row` / `memory_by_id` read it back. `validate_payload` rejects a non-object payload. The MCP `memory_create`/`memory_update` gain a `payload` (JSON object).
- **Dedup folds the payload** — `memory_input_hash` + `duplicate_memory_id` (NULL-safe `IS`): two nodes with identical text but **different** payloads are distinct, so neither silently collapses onto the other (dropping its payload).
- **Consolidation carries the payload** — the import upsert + change-detection tuple include `payload_json`, so importing a source DB no longer NULLs every `Task`/`Concept` payload.
- **Dream-verify kind-gated skip** — `dream --verify` excuses an intentional unanchored node (a zero-binding `Task`/`Concept`) from `memory_unverifiable`, while still flagging a zero-binding **orphan** of a should-be-anchored kind and a memory whose bindings all went `gone`.

## Deferred to phase B (#404)

The canonical `content_hash`-over-payload (the §5.5 fold used by the phase-B sync log) is deferred to #404, where the full canonicalization (domain tag, NFC, deterministic CBOR, kind/tags excluded) lands together — so the hash is designed once. `dream::note_content_hash` stays title+body here; that is **not** a live staleness bug (summaries/verdicts are over title+body, which a payload-only edit does not change).

## Tests

- `migration_048` (tip pin + `payload_json` column + idempotent re-apply).
- payload round-trip (create → read → update) + non-object rejection.
- payload-aware dedup (same text / different payload → distinct; same payload → duplicate).
- consolidation carries the payload through import.
- dream-verify excuses unanchored `Task`/`Concept` but flags orphans + all-gone.

Full workspace: 1833 tests pass; clippy `--all-targets` clean; nightly fmt clean.

Closes #465
