### PR TITLE
fix(watch): gate the background clone-graph rebuild on a content quiet window

### DIFF
--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -444,9 +444,14 @@ fn run_maintenance_pass(
     let gc_report = db.garbage_collect().ok();
     // Clone-edge graph (#286): refresh the persisted graph when absent/stale with whatever budget
     // the embedding reconcile left (shared so the pass can't overrun), so the git-hook
-    // maintenance keeps the graph warm too — not just the foreground watcher. Best-effort +
-    // resumable across passes.
-    let clone_graph_report = if db.pending_clone_graph().unwrap_or(false) {
+    // maintenance keeps the graph warm too — not just the foreground watcher. Gated on the #472
+    // quiet window (shared with the watcher via per-repo meta): a pass observing a fresh content
+    // revision arms/defers instead of discarding and rebuilding the whole generation, so a stream
+    // of commits can't treadmill full rebuilds. Best-effort + resumable across passes.
+    let clone_graph_report = if db
+        .clone_graph_rebuild_due(rag_rat_core::watch::CLONE_GRAPH_QUIET_MS, true)
+        .unwrap_or(false)
+    {
         match budget.as_ref().and_then(rag_rat_core::watch::ReconcileBudget::next_options) {
             Some(options) => db.reconcile_clone_edges_with_budget(options.max_seconds).ok(),
             None => None,
@@ -833,6 +838,95 @@ mod tests {
         // change the coalesced trigger requested).
         super::maintenance(&config, &args).unwrap();
         assert!(!pending.exists(), "the runner clears the rerun marker after its pass");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The hook-driven maintenance tail shares the #472 quiet-window gate with the watcher: a
+    /// pass observing a fresh content revision ARMS the window and DEFERS the clone-graph
+    /// rebuild; once the armed candidate has sat past the window, the next pass completes it.
+    #[test]
+    fn maintenance_defers_the_clone_graph_rebuild_inside_the_quiet_window() {
+        let root = std::env::temp_dir().join(format!(
+            "rag-rat-cli-clone-quiet-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(
+            root.join("src/a.rs"),
+            "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("src/b.rs"),
+            "pub fn load_order(store: Db) -> i32 { let o = store.get(20); validate(o); o + 1 }\n",
+        )
+        .unwrap();
+        let config = Config {
+            repo_id_override: None,
+            database_key_pinned: true,
+            root: root.clone(),
+            database: root.join(".rag-rat/index.sqlite"),
+            targets: vec![ResolvedTarget {
+                name: "rust".to_string(),
+                language: Language::Rust,
+                directories: vec![PathBuf::from("src")],
+                include: vec!["src/".to_string()],
+                exclude: Vec::new(),
+                kind: TargetKind::Source,
+            }],
+            llm: Default::default(),
+            watch: Default::default(),
+            version_check: Default::default(),
+            oracle: Default::default(),
+            search: Default::default(),
+            memory: Default::default(),
+            log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
+        };
+        IndexDatabase::rebuild(&config).unwrap();
+
+        // A content change lands, then the hook pass runs inside the window: it must arm the
+        // gate and defer the rebuild, not discard-and-rebuild the generation.
+        std::fs::write(root.join("src/c.rs"), "pub fn freshly_edited(x: i32) -> i32 { x * 3 }\n")
+            .unwrap();
+        let args = super::MaintenanceArgs {
+            trigger: Some("post-commit".to_string()),
+            max_seconds: None,
+            branch_checkout: None,
+            old_head: None,
+            new_head: None,
+        };
+        super::maintenance(&config, &args).unwrap();
+
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        let generations: i64 = conn
+            .query_row("SELECT COUNT(*) FROM clone_graph_generations", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(generations, 0, "a hook pass inside the quiet window defers the clone rebuild");
+
+        // Backdate the armed candidate past the window; the next hook pass completes the owed
+        // rebuild.
+        conn.execute(
+            "UPDATE repo_meta SET value = '1' WHERE key = 'clone_graph_quiet_candidate_since_ms'",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+        super::maintenance(&config, &args).unwrap();
+
+        let conn = rusqlite::Connection::open(&config.database).unwrap();
+        let complete: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM clone_graph_generations WHERE status = 'Complete'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(complete, 1, "the quiet-elapsed hook pass builds the graph to completion");
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -34,6 +34,11 @@ pub(crate) const CLONE_PRECOMPUTE_THETA: f64 = THETA;
 
 const DEFAULT_BATCH_SIZE: usize = 512;
 
+/// Per-repo meta keys for the #472 quiet-window gate: the stale content revision under
+/// observation and when it was first observed (epoch ms).
+const CLONE_GRAPH_QUIET_REVISION_META: &str = "clone_graph_quiet_candidate_revision";
+const CLONE_GRAPH_QUIET_SINCE_META: &str = "clone_graph_quiet_candidate_since_ms";
+
 /// Soft per-pass budget + checkpoint granularity for one
 /// [`IndexDatabase::reconcile_clone_edges_pass`].
 #[derive(Debug, Clone)]
@@ -139,19 +144,109 @@ impl IndexDatabase {
         })
     }
 
-    /// True when the precomputed graph is ABSENT or STALE vs the current content — the gate the
-    /// watcher / maintenance pass uses to decide whether to spend budget on a recompute.
+    /// True when the precomputed graph is ABSENT or STALE vs the current content. The background
+    /// watcher / maintenance tails wrap this in [`Self::clone_graph_rebuild_due`] (the #472
+    /// quiet-window gate); explicit callers (`clones --precompute`) read the staleness directly.
     pub fn pending_clone_graph(&self) -> anyhow::Result<bool> {
+        let revision = self.content_revision()?;
+        self.clone_graph_stale_against(&revision)
+    }
+
+    /// The staleness core of [`Self::pending_clone_graph`], against an already-computed
+    /// `content_revision()` so the quiet gate pays the digest once per probe.
+    fn clone_graph_stale_against(&self, content_revision: &str) -> anyhow::Result<bool> {
         let conn = self.storage.connection();
         let Some(live) = live_generation_row(conn)? else {
             return Ok(true); // no completed generation yet
         };
-        Ok(live.source_revision != self.content_revision()?
+        Ok(live.source_revision != content_revision
             || live.normalizer_version != NORM_VERSION
             // A live generation built before postings existed (`postings_written = 0`) is pending
             // so one rebuild pass fills `clone_subblock_postings` — else an upgraded DB with an
             // already-Complete clone graph would keep an empty postings table forever (review R2).
             || !live.postings_written)
+    }
+
+    /// The background quiet-window gate for the clone-graph tail (#472): true when the graph is
+    /// pending AND the content revision has been stable for `quiet_ms`. Under sustained editing
+    /// `content_revision()` moves every pass, so an ungated tail discards the in-flight Building
+    /// generation and rebuilds the whole graph from symbol 0 each time (measured ~1 GB of DB
+    /// writes per pass); the gate defers the rebuild until the churn pauses. Bookkeeping lives in
+    /// per-repo meta (`clone_graph_quiet_*`), so the watcher and the hook-driven CLI `maintenance`
+    /// share one window across processes:
+    /// - graph current → drop any armed candidate, not due;
+    /// - stale revision != armed candidate (or nothing armed) → (re-)arm the window, not due;
+    /// - stale revision == armed candidate for ≥ `quiet_ms` → due.
+    ///
+    /// `probe_without_candidate = false` lets an idle pass skip the probe — and its
+    /// content-revision digest — entirely when no deferred rebuild is owed (nothing armed).
+    /// `quiet_ms = 0` disables the gate (a pending graph is immediately due). Explicit rebuild
+    /// paths (`clones --precompute`, full `index`) bypass the gate entirely.
+    pub fn clone_graph_rebuild_due(
+        &self,
+        quiet_ms: i64,
+        probe_without_candidate: bool,
+    ) -> anyhow::Result<bool> {
+        self.clone_graph_rebuild_due_at(now_ms(), quiet_ms, probe_without_candidate)
+    }
+
+    /// [`Self::clone_graph_rebuild_due`] with the clock injected (tests).
+    pub(crate) fn clone_graph_rebuild_due_at(
+        &self,
+        now_ms: i64,
+        quiet_ms: i64,
+        probe_without_candidate: bool,
+    ) -> anyhow::Result<bool> {
+        let candidate = self.clone_graph_quiet_candidate()?;
+        if candidate.is_none() && !probe_without_candidate {
+            return Ok(false);
+        }
+        let revision = self.content_revision()?;
+        if !self.clone_graph_stale_against(&revision)? {
+            if candidate.is_some() {
+                self.clear_clone_graph_quiet_candidate()?;
+            }
+            return Ok(false);
+        }
+        if quiet_ms == 0 {
+            return Ok(true);
+        }
+        match candidate {
+            Some((armed_revision, since_ms)) if armed_revision == revision =>
+                Ok(now_ms.saturating_sub(since_ms) >= quiet_ms),
+            _ => {
+                self.set_repo_meta(CLONE_GRAPH_QUIET_REVISION_META, &revision)?;
+                self.set_repo_meta(CLONE_GRAPH_QUIET_SINCE_META, &now_ms.to_string())?;
+                Ok(false)
+            },
+        }
+    }
+
+    /// The armed quiet-window candidate, if any: the stale revision under observation and when it
+    /// was first seen. A torn/corrupt pair reads as absent (the next probe re-arms it).
+    fn clone_graph_quiet_candidate(&self) -> anyhow::Result<Option<(String, i64)>> {
+        let Some(revision) = self.repo_meta(CLONE_GRAPH_QUIET_REVISION_META)? else {
+            return Ok(None);
+        };
+        let since_ms = self
+            .repo_meta(CLONE_GRAPH_QUIET_SINCE_META)?
+            .and_then(|since| since.parse::<i64>().ok());
+        Ok(since_ms.map(|since_ms| (revision, since_ms)))
+    }
+
+    fn clear_clone_graph_quiet_candidate(&self) -> anyhow::Result<()> {
+        let conn = self.storage.connection();
+        crate::index::meta::delete_repo_meta(
+            conn,
+            &self.active_repo_id,
+            CLONE_GRAPH_QUIET_REVISION_META,
+        )?;
+        crate::index::meta::delete_repo_meta(
+            conn,
+            &self.active_repo_id,
+            CLONE_GRAPH_QUIET_SINCE_META,
+        )?;
+        Ok(())
     }
 
     /// Invalidate the persisted clone-graph postings — mark EVERY generation postings-stale
@@ -1154,6 +1249,160 @@ mod tests {
             .unwrap();
         assert!(postings > 0, "the upgrade rebuild fills clone_subblock_postings");
         assert!(!db.pending_clone_graph().unwrap(), "no longer pending after the rebuild");
+    }
+
+    /// The background quiet-window gate (#472): a pending clone graph does NOT fire a rebuild on
+    /// first observation — the probe ARMS the window by recording the stale revision — and fires
+    /// only once that revision has stayed stable past the window. This is what stops sustained
+    /// editing from treadmilling full-generation rebuilds on every watcher/maintenance pass.
+    #[test]
+    fn clone_graph_quiet_gate_arms_then_fires_after_the_window() {
+        let db = build_clone_fixture("quiet-gate-arms");
+        assert!(db.pending_clone_graph().unwrap(), "fresh fixture has no generation yet");
+        assert!(
+            !db.clone_graph_rebuild_due_at(1_000, 300_000, true).unwrap(),
+            "first observation arms the window instead of firing"
+        );
+        assert!(
+            !db.clone_graph_rebuild_due_at(1_000 + 299_999, 300_000, true).unwrap(),
+            "still inside the window"
+        );
+        assert!(
+            db.clone_graph_rebuild_due_at(1_000 + 300_000, 300_000, true).unwrap(),
+            "a stable revision past the window fires"
+        );
+    }
+
+    /// Content moving while armed re-arms the window for the NEW revision: sustained editing keeps
+    /// deferring (the treadmill fix), and only a revision that stays put for the full window fires.
+    #[test]
+    fn clone_graph_quiet_gate_rearms_when_the_revision_moves() {
+        let config = clone_fixture_config("quiet-gate-rearm");
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        assert!(!db.clone_graph_rebuild_due_at(1_000, 300_000, true).unwrap(), "arm");
+        drop(db);
+
+        // Edit a fixture file and re-index so `content_revision()` moves past the armed candidate
+        // (the armed `clone_graph_quiet_*` repo_meta survives the rebuild, like the live-generation
+        // pointer does).
+        let a = config.root.join("src/a.rs");
+        let mut text = std::fs::read_to_string(&a).unwrap();
+        text.push_str("pub fn freshly_added(x: i32) -> i32 { x + 41 }\n");
+        std::fs::write(&a, text).unwrap();
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+
+        assert!(
+            !db.clone_graph_rebuild_due_at(10_000_000, 300_000, true).unwrap(),
+            "a moved revision re-arms instead of firing, however long the old candidate sat"
+        );
+        assert!(
+            db.clone_graph_rebuild_due_at(10_000_000 + 300_000, 300_000, true).unwrap(),
+            "the new revision fires once it has been stable for the window"
+        );
+    }
+
+    /// `probe_without_candidate = false` (an idle watcher pass with no deferred rebuild owed)
+    /// skips the probe entirely — nothing is armed, so an idle server never pays the
+    /// content-revision digest for the gate.
+    #[test]
+    fn clone_graph_quiet_gate_skips_the_probe_without_a_candidate() {
+        let db = build_clone_fixture("quiet-gate-cold");
+        assert!(
+            !db.clone_graph_rebuild_due_at(1_000, 300_000, false).unwrap(),
+            "no candidate + no probe permission means not due"
+        );
+        // The cold call did no bookkeeping: a later probing call still only ARMS.
+        assert!(
+            !db.clone_graph_rebuild_due_at(50_000_000, 300_000, true).unwrap(),
+            "the probing call after a cold one arms fresh"
+        );
+        assert!(db.clone_graph_rebuild_due_at(50_000_000 + 300_000, 300_000, true).unwrap());
+    }
+
+    /// Once the graph is current the gate reports not-due and drops the armed candidate, so idle
+    /// passes go back to the cheap no-candidate path.
+    #[test]
+    fn clone_graph_quiet_gate_clears_once_current() {
+        let db = build_clone_fixture("quiet-gate-clear");
+        assert!(!db.clone_graph_rebuild_due_at(1_000, 300_000, true).unwrap(), "arm");
+        assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
+        assert!(
+            !db.clone_graph_rebuild_due_at(90_000_000, 300_000, true).unwrap(),
+            "a current graph is never due, regardless of the armed candidate's age"
+        );
+        let leftover: i64 = db
+            .storage
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM repo_meta WHERE key LIKE 'clone_graph_quiet_%'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(leftover, 0, "the armed candidate is dropped once the graph is current");
+    }
+
+    /// `quiet_ms = 0` disables the gate — a pending graph is immediately due (the pre-#472
+    /// immediate-rebuild behavior).
+    #[test]
+    fn clone_graph_quiet_gate_zero_window_fires_immediately() {
+        let db = build_clone_fixture("quiet-gate-zero");
+        assert!(db.clone_graph_rebuild_due_at(1_000, 0, true).unwrap());
+    }
+
+    /// End-to-end through the watcher pass (#472): a content-changing maintenance pass ARMS the
+    /// gate and DEFERS the clone rebuild; once the armed candidate has sat past the quiet window,
+    /// an otherwise-idle pass picks the owed rebuild up (the gate is also a tail trigger) and
+    /// completes it.
+    #[test]
+    fn maintenance_pass_defers_the_clone_rebuild_until_the_quiet_window() {
+        // Asserts whole-DB `clone_graph_generations` counts; opt out of the poison harness whose
+        // sibling seeds another repo's generation.
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let config = clone_fixture_config("quiet-gate-pass");
+        drop(crate::IndexDatabase::rebuild(&config).unwrap());
+
+        // A content change lands, then a maintenance pass runs while the window is still open: it
+        // must arm and defer (no generation built), not discard-and-rebuild.
+        let a = config.root.join("src/a.rs");
+        let mut text = std::fs::read_to_string(&a).unwrap();
+        text.push_str("pub fn freshly_edited(x: i32) -> i32 { x * 3 }\n");
+        std::fs::write(&a, text).unwrap();
+        crate::watch::maintenance_pass(&config, false).unwrap();
+
+        let db = crate::IndexDatabase::open_config(&config).unwrap();
+        let generations: i64 = db
+            .storage
+            .connection()
+            .query_row("SELECT COUNT(*) FROM clone_graph_generations", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(generations, 0, "a pass inside the quiet window defers the clone rebuild");
+
+        // Backdate the armed candidate past the window, then run an IDLE pass: the owed rebuild
+        // is now due, forces the otherwise-skipped tail, and completes.
+        db.storage
+            .connection()
+            .execute(
+                "UPDATE repo_meta SET value = '1' WHERE key = \
+                 'clone_graph_quiet_candidate_since_ms'",
+                [],
+            )
+            .unwrap();
+        drop(db);
+        crate::watch::maintenance_pass(&config, false).unwrap();
+
+        let db = crate::IndexDatabase::open_config(&config).unwrap();
+        let complete: i64 = db
+            .storage
+            .connection()
+            .query_row(
+                "SELECT COUNT(*) FROM clone_graph_generations WHERE status = 'Complete'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(complete, 1, "the quiet-elapsed pass builds the graph to completion");
+        assert!(!edge_keys(&db).is_empty(), "and the fixture's clone edges are persisted");
     }
 
     /// A full rebuild recomputes `clone_token_df` authoritatively (correcting incremental drift)

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -34,6 +34,19 @@ use crate::locks::{self, FileLock};
 const GC_EVERY_PASSES: u64 = 20;
 /// Bound a single reconcile so a pass never holds the write lock indefinitely.
 const PASS_RECONCILE_MAX_SECONDS: u64 = 60;
+/// Quiet window before the background clone-graph rebuild fires (#472): the pass tail only spends
+/// budget on the clone graph once `content_revision()` has been STABLE this long. Every content
+/// change invalidates the whole precomputed graph (its freshness key is the global revision), so
+/// an ungated tail under sustained editing discards the in-flight generation and rebuilds from
+/// symbol 0 every pass — measured at ~1 GB of DB writes per pass. Shared by the watcher and the
+/// hook-driven CLI `maintenance`; explicit `clones --precompute` / full `index` stay immediate.
+///
+/// Convergence: the watcher's periodic sweeps pick a deferred rebuild up within one sweep of the
+/// window elapsing. On a HOOK-ONLY install (no watcher) a deferral waits for the next git action —
+/// the same cadence as an embedding backlog left by a time-capped hook pass, and bounded in
+/// impact: reads keep serving the last Complete generation, and the write-time clone check falls
+/// back to the RAM path until the rebuild lands.
+pub const CLONE_GRAPH_QUIET_MS: i64 = 5 * 60 * 1000;
 const STARTUP_CATCHUP_RUN_GC: bool = false;
 /// Shutdown / interactive lock acquisition: skip rather than block forever.
 const SKIP_TIMEOUT: Duration = Duration::from_secs(3);
@@ -164,6 +177,22 @@ fn run_pass(
                 .is_ok_and(|pending| pending > 0)
         },
     );
+    // Clone-graph quiet gate (#472): one probe serves two roles. Inside the tail it REPLACES the
+    // bare `pending_clone_graph` check — a pass during active editing arms/re-arms the quiet
+    // window instead of discarding the in-flight generation and rebuilding the whole graph — and
+    // on an otherwise-idle pass a quiet-elapsed backlog FORCES the tail (like the embedding
+    // backlog above) so the owed rebuild lands right after the churn pauses rather than waiting
+    // for a gc pass. Unlike the embedding probe it must also run whenever the tail will run —
+    // including a startup embedding-backlog tail, which doesn't flip `tail_already_forced` — so
+    // every tail pass can at least ARM an unarmed pending graph (else it rides until a content
+    // change or gc pass). When nothing runs the tail the probe stays cheap: without an armed
+    // candidate it skips the content-revision digest entirely.
+    let clone_graph_due = db
+        .clone_graph_rebuild_due(
+            CLONE_GRAPH_QUIET_MS,
+            tail_already_forced || base_embedding_backlog,
+        )
+        .unwrap_or(false);
     // Idle backstop (issue #63, facet 2): when the sweep changed no content, skip the reconcile /
     // gc / memory-validate tail — an idle server should do no work past discovery. `run_gc` (every
     // GC_EVERY_PASSES) still forces a full tail, so the cases that DON'T flip content_changed are
@@ -178,6 +207,7 @@ fn run_pass(
         run_gc,
         shutdown_reconcile_pending,
         base_embedding_backlog,
+        clone_graph_due,
     ) {
         return Ok(());
     }
@@ -188,15 +218,14 @@ fn run_pass(
         let report = db.reconcile_with_options_progress(options, |_| {})?;
         base_reconcile_status = Some(report.status);
     }
-    // Clone-edge graph (#286): refresh the persisted graph when it's ABSENT or STALE, with whatever
-    // budget the embedding reconcile left — sharing the same PASS_RECONCILE_MAX_SECONDS so a pass
-    // can't overrun. Best-effort + resumable: a bounded pass makes partial progress and the next
-    // pass continues, so a large/dense repo's graph converges over several passes, entirely off
-    // the query path. `None` budget → skip (rides the next pass), exactly like the base
-    // reconcile.
-    if db.pending_clone_graph().unwrap_or(false)
-        && let Some(options) = budget.next_options()
-    {
+    // Clone-edge graph (#286): refresh the persisted graph when it's ABSENT or STALE — gated on
+    // the #472 quiet window (`clone_graph_due` above) so sustained editing defers the rebuild
+    // instead of treadmilling it — with whatever budget the embedding reconcile left, sharing the
+    // same PASS_RECONCILE_MAX_SECONDS so a pass can't overrun. Best-effort + resumable: a bounded
+    // pass makes partial progress and the next pass continues (the revision is quiet-stable, so
+    // the Building generation resumes), entirely off the query path. `None` budget → skip (rides
+    // the next pass), exactly like the base reconcile.
+    if clone_graph_due && let Some(options) = budget.next_options() {
         let _ = db.reconcile_clone_edges_with_budget(options.max_seconds);
     }
     if run_gc {
@@ -215,12 +244,14 @@ fn should_run_pass_tail(
     run_gc: bool,
     shutdown_reconcile_pending: bool,
     base_embedding_backlog: bool,
+    clone_graph_due: bool,
 ) -> bool {
     content_changed
         || overlays_changed
         || run_gc
         || shutdown_reconcile_pending
         || base_embedding_backlog
+        || clone_graph_due
 }
 
 fn pass_tail_forced_by_state(
@@ -1379,28 +1410,32 @@ mod tests {
     #[test]
     fn startup_catchup_does_not_force_the_expensive_tail() {
         assert!(
-            !should_run_pass_tail(false, false, STARTUP_CATCHUP_RUN_GC, false, false),
+            !should_run_pass_tail(false, false, STARTUP_CATCHUP_RUN_GC, false, false, false),
             "an unchanged startup catch-up must not run reconcile/gc/memory validation",
         );
         assert!(
-            should_run_pass_tail(true, false, STARTUP_CATCHUP_RUN_GC, false, false),
+            should_run_pass_tail(true, false, STARTUP_CATCHUP_RUN_GC, false, false, false),
             "real base content changes still run the maintenance tail",
         );
         assert!(
-            should_run_pass_tail(false, true, STARTUP_CATCHUP_RUN_GC, false, false),
+            should_run_pass_tail(false, true, STARTUP_CATCHUP_RUN_GC, false, false, false),
             "linked-worktree overlay changes still run the maintenance tail",
         );
         assert!(
-            should_run_pass_tail(false, false, true, false, false),
+            should_run_pass_tail(false, false, true, false, false, false),
             "scheduled GC passes still force the maintenance tail",
         );
         assert!(
-            should_run_pass_tail(false, false, STARTUP_CATCHUP_RUN_GC, true, false),
+            should_run_pass_tail(false, false, STARTUP_CATCHUP_RUN_GC, true, false, false),
             "a bounded shutdown discover marks base reconcile owed for the next startup pass",
         );
         assert!(
-            should_run_pass_tail(false, false, STARTUP_CATCHUP_RUN_GC, false, true),
+            should_run_pass_tail(false, false, STARTUP_CATCHUP_RUN_GC, false, true, false),
             "startup catch-up retries an already-indexed base embedding backlog",
+        );
+        assert!(
+            should_run_pass_tail(false, false, STARTUP_CATCHUP_RUN_GC, false, false, true),
+            "a quiet-elapsed clone-graph backlog forces the otherwise-idle tail (#472)",
         );
     }
 


### PR DESCRIPTION
Fixes #472.

## Problem

Every content change invalidates the whole precomputed clone graph (its freshness key is the global `content_revision()`), and both background tails — the watcher pass and the hook-driven CLI `maintenance` — rebuilt it immediately on every pass, discarding any in-flight Building generation and restarting from symbol 0. Under sustained editing this treadmills: measured ~1 GB of DB writes per pass, roughly one full generation per minute, 242 GB of process writes in ~6 h, with the graph never converging and the write-time postings fast path permanently ineligible (`source_revision` never matches).

## Change

A quiet-window gate, shared across processes via per-repo meta (`clone_graph_quiet_candidate_revision` / `clone_graph_quiet_candidate_since_ms`):

- `IndexDatabase::clone_graph_rebuild_due(quiet_ms, probe_without_candidate)` — the single seam both tails call. Graph current → drops any armed candidate, not due. Stale revision ≠ armed candidate → (re-)arms the window, not due. Stale revision stable for ≥ `quiet_ms` → due.
- Watcher tail (`run_pass`): the probe replaces the bare `pending_clone_graph()` check, and a quiet-elapsed backlog also **forces** the otherwise-idle tail (mirroring the embedding-backlog trigger) so the owed rebuild lands within one periodic sweep of the window elapsing instead of waiting for a gc pass. The probe runs whenever the tail will run — including a startup embedding-backlog tail — so every tail pass can at least arm an unarmed pending graph; on passes where nothing runs the tail, an unarmed gate skips the content-revision digest entirely (idle passes stay cheap).
- CLI `maintenance` tail: same gate through the same meta, so a stream of commits through git hooks can't treadmill either. On a hook-only install (no watcher) a deferral waits for the next git action — the same cadence as an embedding backlog left by a time-capped hook pass, and bounded in impact: reads keep serving the last Complete generation and the write-time clone check falls back to the RAM path until the rebuild lands (documented at `CLONE_GRAPH_QUIET_MS`).
- Explicit paths (`clones --precompute`, full `index`) bypass the gate and stay immediate. Resume semantics for a budget-tripped Building generation are unchanged — the revision is quiet-stable when a build starts, so the cursor resumes.

`pending_clone_graph()` is refactored to delegate to `clone_graph_stale_against(&revision)` so the gate pays the content-revision digest once per probe.

## Tests

- Gate unit tests: arms-then-fires, re-arms on revision movement, cold-probe skip does no bookkeeping, candidate cleared once current, `quiet_ms = 0` bypass.
- Watcher end-to-end: a content-changing `maintenance_pass` arms and defers (no generation built); after backdating the armed candidate past the window, an idle pass force-runs the tail and completes the build.
- CLI end-to-end: same defer/complete sequence through `rag-rat maintenance`.
- `should_run_pass_tail` matrix extended for the new trigger.

Workspace suite: 1841 passed. Follow-up (root fix): #473 — incremental delta maintenance so small edits never trigger full rebuilds; this gate stays as the guard on the full-rebuild path.