### PR TITLE
feat(memory): typed cross-repo node edges (repo_node_edges)

### DIFF
--- a/crates/rag-rat-cli/src/commands/consolidate.rs
+++ b/crates/rag-rat-cli/src/commands/consolidate.rs
@@ -36,6 +36,7 @@ pub(crate) fn consolidate(config: &Config) -> anyhow::Result<()> {
             "tags": summary.tags,
             "call_paths": summary.call_paths,
             "call_path_edges": summary.call_path_edges,
+            "edges": summary.edges,
             "embedding_cache_rows": summary.embedding_cache_rows,
             "meta_keys": summary.meta_keys,
             "next": "run `rag-rat index --full` to rebuild the derived index — the carried \

--- a/crates/rag-rat-core/src/index/consolidate.rs
+++ b/crates/rag-rat-core/src/index/consolidate.rs
@@ -130,6 +130,7 @@ pub struct ImportSummary {
     pub tags: u64,
     pub call_paths: u64,
     pub call_path_edges: u64,
+    pub edges: u64,
     pub embedding_cache_rows: u64,
     pub meta_keys: u64,
 }
@@ -295,6 +296,7 @@ pub fn run(config: &Config) -> anyhow::Result<ConsolidateOutcome> {
         tags: counts.tags,
         call_paths: counts.call_paths,
         call_path_edges: counts.call_path_edges,
+        edges: counts.edges,
         embedding_cache_rows: counts.embedding_cache_rows,
         meta_keys: counts.meta_keys,
     }))
@@ -456,6 +458,7 @@ struct ImportCounts {
     tags: u64,
     call_paths: u64,
     call_path_edges: u64,
+    edges: u64,
     embedding_cache_rows: u64,
     meta_keys: u64,
 }
@@ -525,6 +528,7 @@ fn import_from_source(
         tags: copy_tags(source, &tx, &id_map)?,
         call_paths: copy_call_paths(source, &tx, &id_map)?,
         call_path_edges: copy_call_path_edges(source, &tx, &id_map)?,
+        edges: copy_node_edges(source, &tx, repo_id, &id_map)?,
         embedding_cache_rows: copy_embedding_cache(source, &tx)?,
         meta_keys: copy_model_state(source, &tx, repo_id)?,
     };
@@ -538,6 +542,7 @@ fn import_from_source(
         } else {
             raw.call_path_edges
         },
+        edges: if pre.edges == post.edges { 0 } else { raw.edges },
         ..raw
     };
     rebuild_memory_fts_for_repo(&tx, repo_id)?;
@@ -554,6 +559,7 @@ struct ChildSliceDigests {
     bindings: [u8; 32],
     call_paths: [u8; 32],
     call_path_edges: [u8; 32],
+    edges: [u8; 32],
 }
 
 fn child_slice_digests(
@@ -561,21 +567,29 @@ fn child_slice_digests(
     id_map: &BTreeMap<String, String>,
 ) -> anyhow::Result<ChildSliceDigests> {
     Ok(ChildSliceDigests {
-        tags: child_slice_digest(tx, "repo_memory_tags", id_map)?,
-        bindings: child_slice_digest(tx, "repo_memory_bindings", id_map)?,
-        call_paths: child_slice_digest(tx, "repo_memory_call_paths", id_map)?,
-        call_path_edges: child_slice_digest(tx, "repo_memory_call_path_edges", id_map)?,
+        tags: child_slice_digest(tx, "repo_memory_tags", "memory_id", id_map)?,
+        bindings: child_slice_digest(tx, "repo_memory_bindings", "memory_id", id_map)?,
+        call_paths: child_slice_digest(tx, "repo_memory_call_paths", "memory_id", id_map)?,
+        call_path_edges: child_slice_digest(
+            tx,
+            "repo_memory_call_path_edges",
+            "memory_id",
+            id_map,
+        )?,
+        // Node edges key on `source_node_id` (the owning node), not `memory_id`.
+        edges: child_slice_digest(tx, "repo_node_edges", "source_node_id", id_map)?,
     })
 }
 
 fn child_slice_digest(
     tx: &Connection,
     table: &str,
+    id_column: &str,
     id_map: &BTreeMap<String, String>,
 ) -> anyhow::Result<[u8; 32]> {
     use sha2::{Digest, Sha256};
-    // `table` is a compile-time constant at every call site, never user input.
-    let mut stmt = tx.prepare(&format!("SELECT * FROM {table} WHERE memory_id = ?1"))?;
+    // `table` / `id_column` are compile-time constants at every call site, never user input.
+    let mut stmt = tx.prepare(&format!("SELECT * FROM {table} WHERE {id_column} = ?1"))?;
     let mut lines: Vec<String> = Vec::new();
     for target_id in id_map.values() {
         let mut rows = stmt.query([target_id])?;
@@ -740,6 +754,9 @@ fn refresh_children(tx: &Connection, id_map: &BTreeMap<String, String>) -> anyho
         ] {
             tx.execute(&format!("DELETE FROM {table} WHERE memory_id = ?1"), [id])?;
         }
+        // Node edges (#464) key on `source_node_id`, not `memory_id` — delete them here too so the
+        // subsequent `copy_node_edges` REPLACES the source's edge set (the mirror invariant).
+        tx.execute("DELETE FROM repo_node_edges WHERE source_node_id = ?1", [id])?;
     }
     Ok(())
 }
@@ -852,6 +869,74 @@ fn source_column_or_null(source: &Connection, column: &str) -> anyhow::Result<St
 
 /// Copy `repo_memory_tags` (scoped transitively via `memory_id` — no `repo_id` column; both
 /// columns copied, the full table shape).
+/// Copy `repo_node_edges` (#464), stamping the OWNER `repo_id` and REMAPPING both endpoints through
+/// the id map. An edge's SOURCE must map — an edge of an unmapped memory is a dangling orphan in
+/// the source, dropped, never attached to a stranger (the child-ownership invariant). A NODE target
+/// that ALSO maps is remapped (id + repo) and `current`; a node target that does NOT map is kept
+/// verbatim as an `unresolved` cross-repo reference; a github target re-homes to the import repo
+/// and stays `current`. The `edge_key` is RECOMPUTED from the remapped coordinates — it
+/// content-addresses owner+source+target, all of which change on import. Local rowid columns are
+/// NOT copied (re-resolved on read); `INSERT OR IGNORE` because `refresh_children` cleared the
+/// source's edge set this run.
+fn copy_node_edges(
+    source: &Connection,
+    tx: &Connection,
+    repo_id: &str,
+    id_map: &BTreeMap<String, String>,
+) -> anyhow::Result<u64> {
+    if !schema::table_exists(source, "repo_node_edges")? {
+        return Ok(0);
+    }
+    let mut stmt = source.prepare(
+        "SELECT source_node_id, relation, target_repo_id, target_kind, target_anchor, \
+         created_at_ms FROM repo_node_edges",
+    )?;
+    let mut rows = stmt.query([])?;
+    let mut count = 0u64;
+    while let Some(row) = rows.next()? {
+        // Child-ownership: only edges whose SOURCE this import owns; an unmapped source is dropped.
+        let Some(source_node_id) = id_map.get(&row.get::<_, String>(0)?) else {
+            continue;
+        };
+        let relation = row.get::<_, String>(1)?;
+        let src_target_repo = row.get::<_, String>(2)?;
+        let target_kind = row.get::<_, String>(3)?;
+        let src_target_anchor = row.get::<_, String>(4)?;
+        let created_at_ms = row.get::<_, i64>(5)?;
+        let (target_repo_id, target_anchor, target_node_id, anchor_status) =
+            match target_kind.as_str() {
+                "node" => match id_map.get(&src_target_anchor) {
+                    Some(mapped) =>
+                        (repo_id.to_string(), mapped.clone(), Some(mapped.clone()), "current"),
+                    None => (src_target_repo, src_target_anchor.clone(), None, "unresolved"),
+                },
+                _ => (repo_id.to_string(), src_target_anchor.clone(), None, "current"),
+            };
+        let key =
+            crate::query::memory::edge_key(source_node_id, &relation, &target_kind, &target_anchor);
+        let changed = tx.execute(
+            "INSERT OR IGNORE INTO repo_node_edges(edge_key, repo_id, source_node_id, relation, \
+             target_repo_id, target_kind, target_anchor, target_node_id, \
+             target_logical_symbol_id, symbol_kind, signature_hash, anchor_status, created_at_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, NULL, NULL, ?9, ?10)",
+            params![
+                key,
+                repo_id,
+                source_node_id,
+                relation,
+                target_repo_id,
+                target_kind,
+                target_anchor,
+                target_node_id,
+                anchor_status,
+                created_at_ms
+            ],
+        )?;
+        count += changed as u64;
+    }
+    Ok(count)
+}
+
 fn copy_tags(
     source: &Connection,
     tx: &Connection,
@@ -1173,6 +1258,27 @@ mod tests {
             [],
         )
         .unwrap();
+        // #464: a node edge m1 --depends_on--> m2. Its `edge_key` is RECOMPUTED on import from the
+        // (possibly remapped) endpoints, so the seed's placeholder key here is intentionally not
+        // the real one.
+        // Three edge shapes exercise every `copy_node_edges` branch on import: a node target that
+        // IS carried (remapped, current), a github target (re-homed to the import repo, current),
+        // and a node target that is NOT carried (kept as an `unresolved` cross-repo
+        // reference).
+        for (key, relation, target_repo, kind, anchor, node, status) in [
+            ("seed-node", "depends_on", "legacy-repo", "node", "m2", "m2", "current"),
+            ("seed-gh", "tracks", "legacy-repo", "github", "o/r#7", "", "current"),
+            ("seed-ext", "relates_to", "other-repo", "node", "external-node", "", "unresolved"),
+        ] {
+            let node_id: Option<&str> = (!node.is_empty()).then_some(node);
+            conn.execute(
+                "INSERT INTO repo_node_edges(edge_key, repo_id, source_node_id, relation, \
+                 target_repo_id, target_kind, target_anchor, target_node_id, anchor_status, \
+                 created_at_ms) VALUES (?1, 'legacy-repo', 'm1', ?2, ?3, ?4, ?5, ?6, ?7, 0)",
+                rusqlite::params![key, relation, target_repo, kind, anchor, node_id, status],
+            )
+            .unwrap();
+        }
         for (hash, dim) in [("ih1", 384), ("ih2", 768)] {
             conn.execute(
                 "INSERT INTO embedding_cache(input_hash, model_id, embedding_dim, vector_blob, \
@@ -1366,6 +1472,7 @@ mod tests {
         let target = fresh_target();
         let first = import_from_source(&source, &target, "global-repo").unwrap();
         assert_eq!(first.memories, 3);
+        assert_eq!(first.edges, 3, "all three edges (node, github, cross-repo) were carried");
         // A second import (a retry after a rename that never happened) inserts no duplicates AND
         // reports ZERO copies — the summary must not claim work the `INSERT OR IGNORE`s skipped.
         let second = import_from_source(&source, &target, "global-repo").unwrap();
@@ -1374,6 +1481,7 @@ mod tests {
         assert_eq!(second.tags, 0);
         assert_eq!(second.call_paths, 0);
         assert_eq!(second.call_path_edges, 0);
+        assert_eq!(second.edges, 0, "a no-edit re-import reports zero edges (honest count)");
         assert_eq!(second.embedding_cache_rows, 0);
         assert_eq!(second.meta_keys, 0);
         assert_eq!(count(&target, "SELECT COUNT(*) FROM repo_memories"), 3);
@@ -1396,6 +1504,26 @@ mod tests {
         assert_eq!((title.as_str(), body.as_str()), ("one", "body"));
         // #465: the payload was carried through the consolidation upsert (not turned into NULL).
         assert_eq!(payload.as_deref(), Some(r#"{"priority":1}"#), "m1 payload survives import");
+        // #464: all three edges carried under the global repo — a node edge to a carried target
+        // (current), a github `tracks` edge re-homed to the import repo (current), and a node edge
+        // whose target was NOT carried (kept `unresolved`).
+        let edge = |kind: &str, anchor: &str| -> (String, String) {
+            target
+                .query_row(
+                    "SELECT anchor_status, target_repo_id FROM repo_node_edges WHERE repo_id = \
+                     'global-repo' AND target_kind = ?1 AND target_anchor = ?2",
+                    [kind, anchor],
+                    |r| Ok((r.get(0)?, r.get(1)?)),
+                )
+                .unwrap()
+        };
+        assert_eq!(edge("node", "m2").0, "current", "node edge to a carried target");
+        assert_eq!(edge("github", "o/r#7"), ("current".to_string(), "global-repo".to_string()));
+        assert_eq!(
+            edge("node", "external-node").0,
+            "unresolved",
+            "target not carried stays unresolved"
+        );
     }
 
     /// The CRASH-CREATED divergence window (Codex batch 8, finding 4): the import txn commits,

--- a/crates/rag-rat-core/src/index/poison_sibling.rs
+++ b/crates/rag-rat-core/src/index/poison_sibling.rs
@@ -42,7 +42,8 @@
 //! `clone_graph_generations`, `clone_token_df`, `clone_refinements`, `dream_findings`, and
 //! `reconcile_attempts` (with `repo_memory_tags` scoped transitively through `repo_memories`) — AND
 //! the dream-verification siblings `memory_reality` / `memory_summaries` /
-//! `memory_model_failures`, each of which carries its own `repo_id`.
+//! `memory_model_failures`, each of which carries its own `repo_id` — AND the typed-edge set
+//! `repo_node_edges` (V049), owner-scoped by `repo_id`.
 //! [`seed_sibling`] seeds a tripwire row into every one of those. Nothing repo-scoped is left
 //! unseeded; a table without a `repo_id` dimension (content-addressed pools like
 //! `name_strings` / `embedding_cache`, the FTS-derived `chunk_fts`, `clone_edges`/postings scoped
@@ -524,6 +525,19 @@ pub(crate) fn seed_sibling(conn: &Connection) -> anyhow::Result<()> {
             format!("{POISON_PREFIX}tag")
         ],
     )?;
+    // A sibling typed edge (#464, V049): owned by the poison repo, authored on the poison memory.
+    // Any UNSCOPED `edges_from` / `edges_into` / count would surface it and trip a tripwire.
+    conn.execute(
+        "INSERT INTO repo_node_edges(edge_key, repo_id, source_node_id, relation, target_repo_id, \
+         target_kind, target_anchor, target_node_id, anchor_status, created_at_ms)
+         VALUES (?1, ?2, ?3, 'depends_on', ?2, 'node', ?4, NULL, 'unresolved', 0)",
+        params![
+            format!("{POISON_PREFIX}edge_key"),
+            POISON_REPO_ID,
+            POISON_MEMORY_ID,
+            format!("{POISON_PREFIX}target"),
+        ],
+    )?;
     conn.execute(
         "INSERT INTO oracle_runs(tool, tool_version, commit_sha, worktree_id, started_at, status, \
          stats_json, repo_id)
@@ -794,6 +808,10 @@ fn clear_sibling(conn: &Connection) -> anyhow::Result<()> {
          DELETE FROM repo_memory_fts WHERE repo_id = '{POISON_REPO_ID}';
          DELETE FROM repo_memory_tags WHERE memory_id = '{POISON_MEMORY_ID}';
          DELETE FROM repo_memory_bindings WHERE repo_id = '{POISON_REPO_ID}';
+         -- #464: cleared EXPLICITLY (not just via the source FK cascade) so a reseed is idempotent
+         -- even with `foreign_keys` off or an orphaned row — else the next INSERT trips the \
+         edge_key PK.
+         DELETE FROM repo_node_edges WHERE repo_id = '{POISON_REPO_ID}';
          DELETE FROM repo_memories WHERE repo_id = '{POISON_REPO_ID}';
          -- Registry rows (A7): child-first (repo_meta/repo_roots FK repos ON DELETE CASCADE), so a
          -- re-seed on a git fixture starts from a clean slate. No-op when the sibling was never
@@ -943,6 +961,10 @@ fn sibling_tripwires(conn: &Connection) -> anyhow::Result<Vec<(&'static str, Str
         (
             "repo_memory_fts",
             format!("repo_id = '{POISON_REPO_ID}' AND memory_id = '{POISON_MEMORY_ID}'"),
+        ),
+        (
+            "repo_node_edges",
+            format!("repo_id = '{POISON_REPO_ID}' AND edge_key = '{POISON_PREFIX}edge_key'"),
         ),
         ("oracle_runs", format!("repo_id = '{POISON_REPO_ID}'")),
         // Pinned to the distinct-path edge's `scip_symbol` so the same-path edge tripwire doesn't

--- a/crates/rag-rat-core/src/index/query_api/memory.rs
+++ b/crates/rag-rat-core/src/index/query_api/memory.rs
@@ -25,6 +25,39 @@ impl IndexDatabase {
         crate::query::memory::mark_obsolete(self.storage.connection(), memory_id)
     }
 
+    /// Add a typed graph edge from a source node to another node or a GitHub issue (#464).
+    pub fn memory_edge_add(
+        &self,
+        source_node_id: &str,
+        relation: &str,
+        target: crate::query::memory::EdgeTarget,
+    ) -> anyhow::Result<crate::query::memory::NodeEdge> {
+        let relation = crate::query::memory::EdgeRelation::from_db_str(relation)?;
+        crate::query::memory::add_edge(self.storage.connection(), source_node_id, relation, &target)
+    }
+
+    /// Remove a graph edge by its stable `edge_key` (#464). `false` when the key is unknown.
+    pub fn memory_edge_remove(&self, edge_key: &str) -> anyhow::Result<bool> {
+        crate::query::memory::remove_edge(self.storage.connection(), edge_key)
+    }
+
+    /// Every edge OUT of a node — its outgoing graph (deps / mind-map links / tracks) (#464).
+    pub fn memory_edges_from(
+        &self,
+        source_node_id: &str,
+    ) -> anyhow::Result<Vec<crate::query::memory::NodeEdge>> {
+        crate::query::memory::edges_from(self.storage.connection(), source_node_id)
+    }
+
+    /// Every edge INTO a target — the reverse traversal (e.g. tasks tracking a github issue)
+    /// (#464).
+    pub fn memory_edges_into(
+        &self,
+        target: crate::query::memory::EdgeTarget,
+    ) -> anyhow::Result<Vec<crate::query::memory::NodeEdge>> {
+        crate::query::memory::edges_into(self.storage.connection(), &target)
+    }
+
     pub fn memory_search(
         &self,
         query: &str,

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1183,6 +1183,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_046_ID => Some(46),
             MIGRATION_047_ID => Some(47),
             MIGRATION_048_ID => Some(48),
+            MIGRATION_049_ID => Some(49),
             _ => None,
         })
         .max()
@@ -1240,6 +1241,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_046_ID
             | MIGRATION_047_ID
             | MIGRATION_048_ID
+            | MIGRATION_049_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1294,6 +1296,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_046_ID => migration.checksum != MIGRATION_046_CHECKSUM,
         MIGRATION_047_ID => migration.checksum != MIGRATION_047_CHECKSUM,
         MIGRATION_048_ID => migration.checksum != MIGRATION_048_CHECKSUM,
+        MIGRATION_049_ID => migration.checksum != MIGRATION_049_CHECKSUM,
         _ => false,
     }
 }
@@ -3383,6 +3386,51 @@ fn rebuild_repo_memory_fts_with_repo_id(conn: &Connection) -> rusqlite::Result<(
 pub(crate) fn apply_memory_payload_json(conn: &Connection) -> rusqlite::Result<()> {
     add_column_if_missing(conn, "repo_memories", "payload_json", "TEXT")?;
     Ok(())
+}
+
+/// V049 (#464): `repo_node_edges` — the typed, content-addressed, cross-repo edge set. One row per
+/// edge from a source memory NODE to a target that is either another node or a code/github anchor.
+///
+/// Design invariants baked into the shape:
+///   - `edge_key` (PK) is the stable content-addressed identity: a `rebind` re-resolves the local
+///     rowids WITHOUT changing the key, so a sync fold keeps presence/tombstones keyed by it.
+///   - `repo_id` is the OWNER repo (the source node's repo — the periphery scope + adoption key);
+///     `target_repo_id` is the target's repo, which MAY differ (a cross-repo edge into a sibling).
+///   - Portable `target_kind` + `target_anchor` carry the durable target identity; the resolved
+///     local rowids (`target_node_id` / `target_logical_symbol_id`) are re-derivable and carry NO
+///     FK to volatile graph rows (the #248 rule — a reindex must never cascade-delete a durable
+///     edge). The ONLY FK is `source_node_id` -> `repo_memories(id)` (a durable node), cascading so
+///     an edge dies with its source.
+///   - `anchor_status` is `current` | `gone` | `unresolved` (the last for a cross-repo target whose
+///     repo is not present locally yet — re-resolved when it is indexed, never a hard failure).
+pub(crate) fn apply_repo_node_edges(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS repo_node_edges(
+            edge_key TEXT PRIMARY KEY,
+            repo_id TEXT NOT NULL DEFAULT '__unassigned__',
+            source_node_id TEXT NOT NULL,
+            relation TEXT NOT NULL,
+            target_repo_id TEXT NOT NULL,
+            target_kind TEXT NOT NULL,
+            target_anchor TEXT NOT NULL,
+            target_node_id TEXT,
+            target_logical_symbol_id INTEGER,
+            symbol_kind TEXT,
+            signature_hash TEXT,
+            anchor_status TEXT NOT NULL,
+            created_at_ms INTEGER NOT NULL,
+            FOREIGN KEY(source_node_id) REFERENCES repo_memories(id) ON DELETE CASCADE
+        ) STRICT;
+        CREATE INDEX IF NOT EXISTS idx_repo_node_edges_source
+            ON repo_node_edges(source_node_id, relation);
+        -- Reverse traversal (edges_into) matches on the globally-unique
+        -- (target_kind, target_anchor) only, not target_repo_id (the anchor
+        -- determines its repo), so the index leads with exactly those two columns.
+        CREATE INDEX IF NOT EXISTS idx_repo_node_edges_target
+            ON repo_node_edges(target_kind, target_anchor);
+        ",
+    )
 }
 
 pub(crate) fn apply_symbols_is_test(conn: &Connection) -> rusqlite::Result<()> {

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -18,7 +18,7 @@ pub use registry::{LEGACY_REPO_ID, register_repo, register_repo_read_only};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 48;
+pub const LATEST_SCHEMA_VERSION: u32 = 49;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -328,6 +328,13 @@ const MIGRATION_048_DESCRIPTION: &str =
     "Add repo_memories.payload_json, a nullable opaque canonical-JSON payload for polymorphic \
      memory nodes (the Task / Concept kinds), folded into the content_hash so a payload edit \
      self-invalidates the derived dream summary/verdict rows exactly as a title/body edit does";
+const MIGRATION_049_ID: &str = "049_repo_node_edges";
+const MIGRATION_049_CHECKSUM: &str = "sha256:rag-rat-repo-node-edges-v49";
+const MIGRATION_049_DESCRIPTION: &str =
+    "Add repo_node_edges, the typed content-addressed cross-repo edge set (#464): relation-typed \
+     edges from a memory node to another node or a code/github target, with explicit owner + \
+     target repo ids and a stable edge_key, no FK to volatile graph rows (only the durable source \
+     memory)";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -715,6 +722,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_048_CHECKSUM,
         description: MIGRATION_048_DESCRIPTION,
         apply: apply_memory_payload_json,
+    },
+    Migration {
+        id: MIGRATION_049_ID,
+        checksum: MIGRATION_049_CHECKSUM,
+        description: MIGRATION_049_DESCRIPTION,
+        apply: apply_repo_node_edges,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema/registry.rs
+++ b/crates/rag-rat-core/src/index/schema/registry.rs
@@ -82,6 +82,11 @@ const A5_PERIPHERY_DIRECT_SCOPED_TABLES: &[&str] = &[
     "memory_reality",
     "memory_summaries",
     "memory_model_failures",
+    // The typed node-edge set (#464, V049): `repo_id` is the OWNER repo (the source node's), so a
+    // LocalOnly→Portable adoption re-points it exactly like the other periphery tables. Its
+    // `target_repo_id` is a REFERENCE and is deliberately NOT re-pointed here (it may name a
+    // sibling).
+    "repo_node_edges",
 ];
 
 /// The placeholder `repo_id` a freshly-migrated single-repo DB carries until it is adopted (see the
@@ -435,6 +440,17 @@ fn register_repo_inner(
                 )?;
             }
         }
+        // repo_node_edges (#464): the loop above re-pointed the OWNER `repo_id`; a SAME-repo
+        // `target_repo_id` must move with it (a cross-repo target names a sibling and is left
+        // alone). Edge reads self-heal `target_repo_id` from the live node, but keep the
+        // stored column honest here too. Guarded like the loop (a partial-schema fixture
+        // can lack the V049 column).
+        if super::column_exists(&tx, "repo_node_edges", "repo_id")? {
+            tx.execute(
+                "UPDATE main.repo_node_edges SET target_repo_id = ?1 WHERE target_repo_id = ?2",
+                params![identity.repo_id, source_id],
+            )?;
+        }
         // `dream_findings.id` folds `repo_id` (the `logical_symbols.stable_id` precedent), so the
         // periphery re-point above changed the id every finding SHOULD have — re-derive them (and
         // the in-table `superseded_by` references) under the adopted id: the dream twin of the
@@ -638,6 +654,21 @@ fn merge_local_incumbent_into_registered(
     ])?;
     if adoption_table_present(&tx, "repo_memory_fts")? {
         tx.execute("UPDATE main.repo_memory_fts SET repo_id = ?1 WHERE repo_id = ?2", params![
+            identity.repo_id,
+            owner
+        ])?;
+    }
+    // Node edges (#464) are AUTHORED — move the owner's edges onto the target id, else they orphan
+    // under a `repo_id` whose `repos` row is about to be deleted (no FK cascades them). Re-point
+    // the OWNER `repo_id` and any SAME-repo `target_repo_id` (a cross-repo target names a
+    // sibling, left alone). The `edge_key` folds node ids (stable across a repo-id move), not
+    // repo ids, so no recompute is needed. Guarded for a partial-schema fixture.
+    if super::column_exists(&tx, "repo_node_edges", "repo_id")? {
+        tx.execute(
+            "UPDATE main.repo_node_edges SET target_repo_id = ?1 WHERE target_repo_id = ?2",
+            params![identity.repo_id, owner],
+        )?;
+        tx.execute("UPDATE main.repo_node_edges SET repo_id = ?1 WHERE repo_id = ?2", params![
             identity.repo_id,
             owner
         ])?;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -2872,3 +2872,166 @@ fn dedup_and_unanchored_create_are_kind_aware() {
 
     let _ = fs::remove_dir_all(&root);
 }
+
+/// #464: typed edges — a task `depends_on` another (forward `edges_from` + reverse `edges_into`), a
+/// task `tracks` a github issue, `edge_key` is stable/idempotent, `remove` works, self-loops are
+/// rejected, and an edge into an ABSENT repo is stored `unresolved` (not an error).
+#[test]
+fn typed_edges_add_traverse_and_resolve() {
+    use crate::query::memory::EdgeTarget;
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn anchor() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let task = |title: &str| crate::query::memory::RepoMemoryCreate {
+        kind: "Task".to_string(),
+        title: title.to_string(),
+        body: "b".to_string(),
+        confidence: "medium".to_string(),
+        created_by: Some("t".to_string()),
+        source: Some("agent".to_string()),
+        tags: vec![],
+        payload_json: None,
+        bind: crate::query::memory::RepoMemoryBindTarget::default(),
+    };
+    let a = db.memory_create(task("task A")).unwrap().memory.memory_id;
+    let b = db.memory_create(task("task B")).unwrap().memory.memory_id;
+    let node = |id: &str| EdgeTarget::Node { repo_id: None, node_id: id.to_string() };
+
+    // A depends_on B (same repo).
+    let edge = db.memory_edge_add(&a, "depends_on", node(&b)).unwrap();
+    assert_eq!(edge.relation, "depends_on");
+    assert_eq!(edge.target_node_id.as_deref(), Some(b.as_str()));
+    assert_eq!(edge.anchor_status, "current");
+
+    // Forward: edges_from(A) sees it. Reverse: edges_into(B) is the reverse traversal.
+    let from = db.memory_edges_from(&a).unwrap();
+    assert_eq!(from.len(), 1);
+    assert_eq!(from[0].target_node_id.as_deref(), Some(b.as_str()));
+    let into = db.memory_edges_into(node(&b)).unwrap();
+    assert_eq!(into.len(), 1);
+    assert_eq!(into[0].source_node_id, a);
+
+    // Idempotent: re-adding the same logical edge keeps the SAME edge_key (no duplicate row).
+    let again = db.memory_edge_add(&a, "depends_on", node(&b)).unwrap();
+    assert_eq!(again.edge_key, edge.edge_key);
+    assert_eq!(db.memory_edges_from(&a).unwrap().len(), 1);
+
+    // A tracks a github issue — reverse-bindable "issue <- task".
+    let gh = || EdgeTarget::Github { owner: "o".to_string(), repo: "r".to_string(), number: 42 };
+    db.memory_edge_add(&a, "tracks", gh()).unwrap();
+    let tracking = db.memory_edges_into(gh()).unwrap();
+    assert_eq!(tracking.len(), 1);
+    assert_eq!(tracking[0].source_node_id, a);
+    assert_eq!(tracking[0].relation, "tracks");
+
+    // A cross-repo edge into an ABSENT repo is stored `unresolved`, never a hard failure.
+    let cross = db
+        .memory_edge_add(&a, "relates_to", EdgeTarget::Node {
+            repo_id: Some("some-other-repo".to_string()),
+            node_id: "mem_absent".to_string(),
+        })
+        .unwrap();
+    assert_eq!(cross.anchor_status, "unresolved");
+    assert!(cross.target_node_id.is_none());
+
+    // Re-resolution on READ: once the previously-absent target is indexed, a later read shows the
+    // edge `current` with its target self-healed (the stored `unresolved` was only an add-time
+    // snapshot). Seed the target node directly under its sibling repo (id copied from `a`, repo
+    // overridden) so the id lookup finds it.
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO repo_memories(id, kind, title, body, confidence, status, created_by, \
+             created_at_ms, updated_at_ms, source, input_hash, memory_version, repo_id) SELECT \
+             'mem_absent', kind, title, body, confidence, status, created_by, created_at_ms, \
+             updated_at_ms, source, 'reresolve-hash', memory_version, 'some-other-repo' FROM \
+             repo_memories WHERE id = ?1",
+            [&a],
+        )
+        .unwrap();
+    let healed = db.memory_edges_from(&a).unwrap();
+    let cross_now = healed.iter().find(|e| e.edge_key == cross.edge_key).unwrap();
+    assert_eq!(
+        cross_now.anchor_status, "current",
+        "an unresolved edge re-resolves once its target is indexed"
+    );
+    assert_eq!(cross_now.target_node_id.as_deref(), Some("mem_absent"));
+    assert_eq!(
+        cross_now.target_repo_id, "some-other-repo",
+        "target_repo_id self-heals from the node"
+    );
+
+    // An IMPLICIT cross-repo target (no explicit repo_id) that resolves to a SIBLING repo is
+    // rejected — `mem_absent` now lives in `some-other-repo`, so a bare `node()` edge to it must be
+    // made explicit. (The `relates_to` edge above was allowed only because it named the repo.)
+    let implicit = db.memory_edge_add(&a, "depends_on", node("mem_absent")).unwrap_err();
+    assert!(implicit.to_string().contains("is not a node in this repo"), "{implicit}");
+
+    // EXPLICIT cross-repo whose id resolves to a DIFFERENT repo than named → rejected (`mem_absent`
+    // lives in `some-other-repo`, not the named `wrong-repo`).
+    let mismatch = db
+        .memory_edge_add(&a, "depends_on", crate::query::memory::EdgeTarget::Node {
+            repo_id: Some("wrong-repo".to_string()),
+            node_id: "mem_absent".to_string(),
+        })
+        .unwrap_err();
+    assert!(mismatch.to_string().contains("not the named `wrong-repo`"), "{mismatch}");
+
+    // EXPLICIT cross-repo into a REGISTERED repo but the node is absent → a typo, rejected. (An
+    // UNREGISTERED repo is instead a legitimate deferred `unresolved` reference — the `relates_to`
+    // edge above.)
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO repos(repo_id, display_name, registered_at_ms) VALUES \
+             ('some-other-repo', 'other', 0)",
+            [],
+        )
+        .unwrap();
+    let typo = db
+        .memory_edge_add(&a, "depends_on", crate::query::memory::EdgeTarget::Node {
+            repo_id: Some("some-other-repo".to_string()),
+            node_id: "mem_ghost".to_string(),
+        })
+        .unwrap_err();
+    assert!(typo.to_string().contains("is not a node in repo `some-other-repo`"), "{typo}");
+
+    // A self-loop is rejected.
+    let err = db.memory_edge_add(&a, "relates_to", node(&a)).unwrap_err();
+    assert!(err.to_string().contains("cannot point a node at itself"), "{err}");
+
+    // A SAME-repo target that doesn't exist is a typo → rejected (a cross-repo absent target is
+    // fine, as the `relates_to` edge above stored `unresolved`).
+    let missing = db.memory_edge_add(&a, "depends_on", node("mem_nonexistent")).unwrap_err();
+    assert!(missing.to_string().contains("is not a node in this repo"), "{missing}");
+
+    // Remove by edge_key.
+    assert!(db.memory_edge_remove(&edge.edge_key).unwrap());
+    assert!(db.memory_edges_from(&a).unwrap().iter().all(|e| e.edge_key != edge.edge_key));
+
+    // An obsoleted SOURCE node's edges drop out of both traversals — a hidden node's relationships
+    // are dead. `a` still owns the `tracks` and (now-resolved) `relates_to` edges here.
+    assert!(
+        !db.memory_edges_from(&a).unwrap().is_empty(),
+        "sanity: a has live edges before obsolete"
+    );
+    db.memory_mark_obsolete(&a).unwrap();
+    assert!(
+        db.memory_edges_from(&a).unwrap().is_empty(),
+        "obsolete source has no live outgoing edges"
+    );
+    assert!(
+        db.memory_edges_into(gh()).unwrap().is_empty(),
+        "reverse traversal drops an obsolete source's edges"
+    );
+    // ...and you cannot author a NEW edge FROM an obsolete source (the add-time twin of the
+    // filter).
+    let from_dead = db.memory_edge_add(&a, "depends_on", node(&b)).unwrap_err();
+    assert!(from_dead.to_string().contains("not found or is obsolete"), "{from_dead}");
+
+    let _ = fs::remove_dir_all(&root);
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -820,10 +820,13 @@ fn migration_047_creates_the_model_failure_table_on_fresh_apply() {
 fn migration_048_adds_the_memory_payload_json_column() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
-    // V048 is the schema tip — the absolute pin (the previous tip test, migration_047_*, dropped to
-    // the symbolic `current_version == LATEST` check when this landed).
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 48, "V048 is the schema tip");
-    assert_eq!(schema::status(&conn).unwrap().current_version, 48, "schema at LATEST after apply");
+    // The absolute-tip pin moved to `migration_049_*` (V049 is the tip now); this keeps the
+    // symbolic "schema at LATEST after apply" check and its V048 column coverage.
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply"
+    );
     assert!(
         conn_table_columns(&conn, "repo_memories").contains(&"payload_json".to_string()),
         "repo_memories carries the payload_json column (#465)"
@@ -834,6 +837,53 @@ fn migration_048_adds_the_memory_payload_json_column() {
         conn_table_columns(&conn, "repo_memories").contains(&"payload_json".to_string()),
         "payload_json survives a re-apply"
     );
+}
+
+#[test]
+fn migration_049_adds_the_repo_node_edges_table() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    // V049 is the schema tip — the absolute pin (migration_048_* dropped to symbolic when this
+    // landed).
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 49, "V049 is the schema tip");
+    assert_eq!(schema::status(&conn).unwrap().current_version, 49, "schema at LATEST after apply");
+
+    let table_sql = conn
+        .query_row("SELECT sql FROM sqlite_master WHERE name = 'repo_node_edges'", [], |r| {
+            r.get::<_, String>(0)
+        })
+        .unwrap();
+    assert!(table_sql.contains("STRICT"), "repo_node_edges is STRICT");
+    for column in [
+        "edge_key",
+        "repo_id",
+        "source_node_id",
+        "relation",
+        "target_repo_id",
+        "target_kind",
+        "target_anchor",
+        "target_node_id",
+        "target_logical_symbol_id",
+        "anchor_status",
+        "created_at_ms",
+    ] {
+        assert!(
+            conn_table_columns(&conn, "repo_node_edges").contains(&column.to_string()),
+            "repo_node_edges carries {column}"
+        );
+    }
+    let pk_cols: Vec<String> = conn
+        .prepare("SELECT name FROM pragma_table_info('repo_node_edges') WHERE pk > 0 ORDER BY pk")
+        .unwrap()
+        .query_map([], |r| r.get::<_, String>(0))
+        .unwrap()
+        .map(Result::unwrap)
+        .collect();
+    assert_eq!(pk_cols, vec!["edge_key".to_string()], "edge_key is the stable PK");
+
+    // Idempotent re-apply.
+    schema::apply(&conn).unwrap();
+    assert!(conn_table_exists(&conn, "repo_node_edges"), "edge table survives a re-apply");
 }
 
 #[test]

--- a/crates/rag-rat-core/src/query/memory/edges.rs
+++ b/crates/rag-rat-core/src/query/memory/edges.rs
@@ -1,0 +1,406 @@
+//! The typed, content-addressed, cross-repo edge set (#464) — `repo_node_edges`. Generalizes the
+//! memory→code binding into relation-typed edges from a source memory NODE to another node or an
+//! external target (a GitHub issue today). The `anchors` relation is NOT here — memory→code stays
+//! `repo_memory_bindings`, its deeply-wired projection; this module is everything else.
+//!
+//! Invariants (mirrored from the schema): `edge_key` is the stable content-addressed identity (a
+//! `rebind` re-resolves the local rowid WITHOUT changing it); `repo_id` is the OWNER repo (the
+//! source node's — the scope + adoption key) while `target_repo_id` may differ (cross-repo); the
+//! resolved local rowids carry NO FK to volatile graph rows; a cross-repo target whose repo is not
+//! present locally is stored `unresolved`, never a hard failure — and node targets are RE-RESOLVED
+//! on every read (`reresolve_on_read`) by their globally-unique id, so an edge becomes `current`
+//! once its target repo is indexed and its `target_repo_id` self-heals across a repo-id re-point.
+
+use super::*;
+
+/// The relation an edge expresses, from a source memory node to its target. Persisted in
+/// `repo_node_edges.relation`; the db tokens are the snake_case variant names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumString, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum EdgeRelation {
+    /// A task depends on another task (the task DAG).
+    DependsOn,
+    /// A mind-map link between two nodes (undirected in spirit; stored source→target).
+    RelatesTo,
+    /// This node replaces another (e.g. a revised decision).
+    Supersedes,
+    /// This node was derived from another.
+    DerivedFrom,
+    /// A task tracks a GitHub issue (the reverse-bindable "issue ← task").
+    Tracks,
+}
+
+impl EdgeRelation {
+    pub(crate) fn as_db_str(self) -> &'static str {
+        self.into()
+    }
+
+    pub(crate) fn from_db_str(value: &str) -> anyhow::Result<Self> {
+        value.parse().map_err(|_| anyhow::anyhow!("invalid edge relation `{value}`"))
+    }
+}
+
+/// Where an edge points. MVP: another NODE (memory / task / concept) or a GitHub issue. More target
+/// kinds (symbol / path / chunk / commit / call-path edge) are additive — the same
+/// `(kind, repo, anchor)` shape, resolved against the index like a binding.
+#[derive(Debug, Clone)]
+pub enum EdgeTarget {
+    /// Another node. `repo_id: None` means the SAME repo as the source (the common case);
+    /// `Some(id)` is a cross-repo edge into a sibling on the shared global DB.
+    Node { repo_id: Option<String>, node_id: String },
+    /// A GitHub issue (the `tracks` relation): `owner/repo#number`.
+    Github { owner: String, repo: String, number: i64 },
+}
+
+impl EdgeTarget {
+    pub(crate) fn kind(&self) -> &'static str {
+        match self {
+            Self::Node { .. } => "node",
+            Self::Github { .. } => "github",
+        }
+    }
+
+    /// The portable, canonical anchor string that (with `kind`) content-addresses the target — the
+    /// last component of `edge_key`. Globally unique on its own (a node id, or
+    /// `owner/repo#number`).
+    pub(crate) fn anchor(&self) -> String {
+        match self {
+            Self::Node { node_id, .. } => node_id.clone(),
+            Self::Github { owner, repo, number } => format!("{owner}/{repo}#{number}"),
+        }
+    }
+
+    /// The target's repo. A node carries its own; a GitHub ref belongs to the OWNER's repo, so the
+    /// caller threads that in.
+    pub(crate) fn target_repo_id(&self, owner_repo_id: &str) -> String {
+        match self {
+            Self::Node { repo_id, .. } =>
+                repo_id.clone().unwrap_or_else(|| owner_repo_id.to_string()),
+            Self::Github { .. } => owner_repo_id.to_string(),
+        }
+    }
+}
+
+/// One resolved edge row — the boundary shape returned by the edge APIs.
+#[derive(Debug, Clone, Serialize)]
+pub struct NodeEdge {
+    pub edge_key: String,
+    pub source_node_id: String,
+    pub relation: String,
+    pub target_repo_id: String,
+    pub target_kind: String,
+    pub target_anchor: String,
+    /// The resolved local id when the target is a node present in this DB; `None` when unresolved.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_node_id: Option<String>,
+    /// `current` | `gone` | `unresolved`.
+    pub anchor_status: String,
+}
+
+/// The stable content-addressed edge identity. A `rebind` re-resolves the local rowid WITHOUT
+/// changing this key, so a sync fold keeps presence/tombstones keyed by it.
+///
+/// It folds `(source_node_id, relation, target_kind, target_anchor)` — NOT the owner/target repo
+/// ids. Those are redundant: a node id is globally unique and repo-folded (its derivation includes
+/// the repo scope), so `source_node_id` and a node `target_anchor` already carry repo identity, and
+/// a github `target_anchor` is repo-independent by construction. Dropping the repo ids makes the
+/// key STABLE across a repo-id re-point (adoption / late-merge move the `repo_id` column but never
+/// the node ids), so those paths need NO key recompute — only consolidation, which REMAPS node ids,
+/// recomputes it. (A `\u{1e}` record-separator delimiter that cannot appear in any component; the
+/// canonical deterministic-CBOR form is deferred to phase B (#404) with the rest of §5.5.)
+pub(crate) fn edge_key(
+    source_node_id: &str,
+    relation: &str,
+    target_kind: &str,
+    target_anchor: &str,
+) -> String {
+    hex_sha256(
+        format!("{source_node_id}\u{1e}{relation}\u{1e}{target_kind}\u{1e}{target_anchor}")
+            .as_bytes(),
+    )
+}
+
+/// Add a typed edge from `source_node_id` to `target`. Idempotent on `edge_key` — re-adding the
+/// same logical edge refreshes its resolution (the `rebind` semantics) without minting a new row.
+/// The source must be a node in the ACTIVE repo (its repo is the edge OWNER).
+pub(crate) fn add_edge(
+    conn: &Connection,
+    source_node_id: &str,
+    relation: EdgeRelation,
+    target: &EdgeTarget,
+) -> anyhow::Result<NodeEdge> {
+    let owner_repo_id = source_node_owner_repo(conn, source_node_id)?.ok_or_else(|| {
+        anyhow::anyhow!("source node `{source_node_id}` not found or is obsolete")
+    })?;
+    // A node must never edge to ITSELF (a self-loop is meaningless for a DAG / mind-map).
+    if let EdgeTarget::Node { node_id, .. } = target
+        && node_id == source_node_id
+    {
+        anyhow::bail!("an edge cannot point a node at itself");
+    }
+    let hint_repo_id = target.target_repo_id(&owner_repo_id);
+    let target_kind = target.kind();
+    let target_anchor = target.anchor();
+    let key = edge_key(source_node_id, relation.as_db_str(), target_kind, &target_anchor);
+    // Resolve the target against the CURRENT db. A node's ACTUAL owning repo is authoritative when
+    // it is present (self-healing across a repo-id re-point); an absent cross-repo target keeps
+    // the caller's hint and stays `unresolved` until that repo is indexed. A github ref is
+    // always current.
+    let (target_repo_id, target_node_id, anchor_status) = match target {
+        EdgeTarget::Node { repo_id, node_id } => {
+            let (repo, node, status) =
+                resolve_node_target(conn, node_id, &hint_repo_id, "unresolved")?;
+            match repo_id.as_deref() {
+                // EXPLICIT cross-repo (`repo_id` names a DIFFERENT repo): a resolved target must
+                // actually live in the NAMED repo (else the id points somewhere the caller didn't
+                // name); an unresolved one is a legitimate deferred reference ONLY when that repo
+                // is not indexed here — if the named repo IS registered, the
+                // missing node is a typo.
+                Some(named) if named != owner_repo_id => {
+                    if status == "current" && repo != named {
+                        anyhow::bail!(
+                            "edge target node `{node_id}` resolves to repo `{repo}`, not the \
+                             named `{named}`"
+                        );
+                    }
+                    if status != "current" && repo_is_registered(conn, named)? {
+                        anyhow::bail!(
+                            "edge target node `{node_id}` is not a node in repo `{named}`"
+                        );
+                    }
+                },
+                // SAME-repo intent (`repo_id` omitted, or equal to the owner): the target must be a
+                // PRESENT node in the owner repo — an absent one is a typo, one that resolves to a
+                // SIBLING repo is an IMPLICIT cross-repo edge the caller must make explicit.
+                _ =>
+                    if status != "current" || repo != owner_repo_id {
+                        anyhow::bail!(
+                            "edge target node `{node_id}` is not a node in this repo (pass an \
+                             explicit target_repo_id for a cross-repo edge)"
+                        );
+                    },
+            }
+            (repo, node, status)
+        },
+        EdgeTarget::Github { .. } => (hint_repo_id.clone(), None, "current".to_string()),
+    };
+    let now = now_ms();
+    conn.execute(
+        "
+        INSERT INTO repo_node_edges(
+            edge_key, repo_id, source_node_id, relation, target_repo_id, target_kind,
+            target_anchor, target_node_id, anchor_status, created_at_ms
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+        ON CONFLICT(edge_key) DO UPDATE SET
+            target_repo_id = excluded.target_repo_id,
+            target_node_id = excluded.target_node_id,
+            anchor_status = excluded.anchor_status
+        ",
+        params![
+            key,
+            owner_repo_id,
+            source_node_id,
+            relation.as_db_str(),
+            target_repo_id,
+            target_kind,
+            target_anchor,
+            target_node_id,
+            anchor_status,
+            now
+        ],
+    )?;
+    edge_by_key(conn, &key)?.ok_or_else(|| anyhow::anyhow!("edge `{key}` disappeared after insert"))
+}
+
+/// Remove an edge by its stable `edge_key`. A no-op (returns `false`) when the key is unknown.
+pub(crate) fn remove_edge(conn: &Connection, edge_key: &str) -> anyhow::Result<bool> {
+    let scope = memory_repo_scope(conn)?;
+    let repo_clause = periphery_edge_scope_clause(&scope);
+    let n = conn
+        .execute(&format!("DELETE FROM repo_node_edges WHERE edge_key = ?1{repo_clause}"), [
+            edge_key,
+        ])?;
+    Ok(n > 0)
+}
+
+/// Every edge OUT of `source_node_id` (its outgoing graph — deps, mind-map links, tracks).
+pub(crate) fn edges_from(conn: &Connection, source_node_id: &str) -> anyhow::Result<Vec<NodeEdge>> {
+    let scope = memory_repo_scope(conn)?;
+    let repo_clause = periphery_edge_scope_clause(&scope);
+    let mut stmt = conn.prepare(&format!(
+        "{EDGE_SELECT} WHERE source_node_id = ?1{repo_clause}{LIVE_SOURCE_PREDICATE} ORDER BY \
+         relation, target_anchor"
+    ))?;
+    let rows = stmt.query_map([source_node_id], edge_row)?.collect::<rusqlite::Result<_>>()?;
+    reresolve_on_read(conn, rows)
+}
+
+/// Every edge INTO a target — the reverse traversal (e.g. "tasks that `track` issue N", "notes that
+/// `depend_on` task X"). Cross-repo aware: matches on the portable `(target_repo_id, kind,
+/// anchor)`.
+pub(crate) fn edges_into(conn: &Connection, target: &EdgeTarget) -> anyhow::Result<Vec<NodeEdge>> {
+    // A node/github target's anchor is globally unique, so match on `(target_kind, target_anchor)`
+    // alone — no `target_repo_id` needed (which also means a repo-id re-point never breaks reverse
+    // traversal). Owner-scoped like the other memory reads; cross-repo reverse traversal (a sibling
+    // repo's inbound edge) is a follow-up.
+    let scope = memory_repo_scope(conn)?;
+    let repo_clause = periphery_edge_scope_clause(&scope);
+    let mut stmt = conn.prepare(&format!(
+        "{EDGE_SELECT} WHERE target_kind = ?1 AND target_anchor = \
+         ?2{repo_clause}{LIVE_SOURCE_PREDICATE} ORDER BY source_node_id, relation"
+    ))?;
+    let rows = stmt
+        .query_map(params![target.kind(), target.anchor()], edge_row)?
+        .collect::<rusqlite::Result<_>>()?;
+    reresolve_on_read(conn, rows)
+}
+
+/// Read one edge by its `edge_key` (active-repo scoped).
+pub(crate) fn edge_by_key(conn: &Connection, edge_key: &str) -> anyhow::Result<Option<NodeEdge>> {
+    let scope = memory_repo_scope(conn)?;
+    let repo_clause = periphery_edge_scope_clause(&scope);
+    conn.query_row(&format!("{EDGE_SELECT} WHERE edge_key = ?1{repo_clause}"), [edge_key], edge_row)
+        .optional()
+        .map_err(Into::into)
+}
+
+const UNASSIGNED_REPO: &str = "__unassigned__";
+
+const EDGE_SELECT: &str = "
+    SELECT edge_key, source_node_id, relation, target_repo_id, target_kind, target_anchor,
+           target_node_id, anchor_status
+    FROM repo_node_edges";
+
+/// Edges are surfaced only for a LIVE source node — one whose memory is still surfaceable by
+/// recall. That is `status IN ('active', 'stale')`, exactly as the binding reads
+/// (`memories_for_symbol` etc.) filter: a `stale` node is live (its anchor drifted, not its
+/// memory), only `obsolete`/`rejected` are dead. A subquery, not a join, so the `EDGE_SELECT`
+/// column list / `edge_row` mapper are unchanged.
+const LIVE_SOURCE_PREDICATE: &str =
+    " AND source_node_id IN (SELECT id FROM repo_memories WHERE status IN ('active', 'stale'))";
+
+fn edge_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<NodeEdge> {
+    Ok(NodeEdge {
+        edge_key: row.get("edge_key")?,
+        source_node_id: row.get("source_node_id")?,
+        relation: row.get("relation")?,
+        target_repo_id: row.get("target_repo_id")?,
+        target_kind: row.get("target_kind")?,
+        target_anchor: row.get("target_anchor")?,
+        target_node_id: row.get("target_node_id")?,
+        anchor_status: row.get("anchor_status")?,
+    })
+}
+
+/// The ` AND repo_node_edges.repo_id = '…'` OWNER-scope predicate, or `""` when unscoped (pre-A5).
+/// The edge is owned by / authored on its source node's repo, so reads/deletes scope by `repo_id`
+/// exactly like the other periphery tables.
+fn periphery_edge_scope_clause(scope: &Option<String>) -> String {
+    crate::index::schema::periphery_repo_scope_clause(scope, "repo_node_edges")
+}
+
+/// Whether `repo_id` is a repo REGISTERED (indexed) in this DB — a row in `repos`. An explicit
+/// cross-repo edge target in a REGISTERED repo must resolve (else it's a typo); one in an unknown
+/// repo is a legitimate deferred `unresolved` reference until that repo is indexed.
+fn repo_is_registered(conn: &Connection, repo_id: &str) -> anyhow::Result<bool> {
+    conn.query_row("SELECT EXISTS(SELECT 1 FROM repos WHERE repo_id = ?1)", [repo_id], |r| r.get(0))
+        .map_err(Into::into)
+}
+
+/// The active-repo owner of `source_node_id` (its `repo_id`), or `None` when the node is not a LIVE
+/// memory in the active repo. New edges are authored on — and owned by — this repo; a dead
+/// (`obsolete`/`rejected`) node is treated as absent so you cannot author a relationship FROM it
+/// (the add-time twin of the `LIVE_SOURCE_PREDICATE` read filter — a `stale` node is still live).
+fn source_node_owner_repo(conn: &Connection, node_id: &str) -> anyhow::Result<Option<String>> {
+    let scope = memory_repo_scope(conn)?;
+    let repo_clause = memory_repo_scope_clause(&scope);
+    let owner = scope.clone().unwrap_or_else(|| UNASSIGNED_REPO.to_string());
+    let exists: bool = conn.query_row(
+        &format!(
+            "SELECT EXISTS(SELECT 1 FROM repo_memories WHERE id = ?1 AND status IN ('active', \
+             'stale'){repo_clause})"
+        ),
+        [node_id],
+        |r| r.get(0),
+    )?;
+    Ok(exists.then_some(owner))
+}
+
+/// Resolve a NODE target by its GLOBALLY-UNIQUE id → `(target_repo_id, resolved local node id,
+/// anchor_status)`. When the node is present its ACTUAL owning `repo_id` is authoritative (so the
+/// result self-heals across a repo-id re-point / adoption — the id never changes, only the column);
+/// when absent, keep `hint_repo_id` (an unresolved cross-repo edge remembers which repo it names).
+/// `prior_status` distinguishes a target that was NEVER present (`unresolved`) from one that was
+/// and is now deleted (`gone`) — a fresh add passes `"unresolved"`.
+fn resolve_node_target(
+    conn: &Connection,
+    node_id: &str,
+    hint_repo_id: &str,
+    prior_status: &str,
+) -> anyhow::Result<(String, Option<String>, String)> {
+    let actual_repo: Option<String> = conn
+        .query_row(
+            "SELECT COALESCE(repo_id, '__unassigned__') FROM repo_memories WHERE id = ?1",
+            [node_id],
+            |r| r.get(0),
+        )
+        .optional()?;
+    Ok(match actual_repo {
+        Some(repo_id) => (repo_id, Some(node_id.to_string()), "current".to_string()),
+        None => {
+            let status = if prior_status == "current" || prior_status == "gone" {
+                "gone" // was resolved before, target since deleted
+            } else {
+                "unresolved" // never resolved — the target repo is not indexed here (yet)
+            };
+            (hint_repo_id.to_string(), None, status.to_string())
+        },
+    })
+}
+
+/// Re-resolve every NODE edge's target against the CURRENT db (the stored resolution is only an
+/// add-time snapshot). This is what makes an `unresolved` cross-repo edge become `current` once its
+/// target repo is indexed, and refreshes `target_repo_id` from the live node — so a read always
+/// reflects the live graph regardless of any repo-id re-point since the edge was authored. A github
+/// (external) target is not db-backed and is left as stored (`current`).
+fn reresolve_on_read(conn: &Connection, mut edges: Vec<NodeEdge>) -> anyhow::Result<Vec<NodeEdge>> {
+    for edge in &mut edges {
+        if edge.target_kind != "node" {
+            continue;
+        }
+        let (repo_id, node_id, status) = resolve_node_target(
+            conn,
+            &edge.target_anchor,
+            &edge.target_repo_id,
+            &edge.anchor_status,
+        )?;
+        edge.target_repo_id = repo_id;
+        edge.target_node_id = node_id;
+        edge.anchor_status = status;
+    }
+    Ok(edges)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The strum-derived tokens are PERSISTED in `repo_node_edges.relation` — pin them exactly so a
+    /// rename or reorder can't silently repoint stored rows (the `as_db_str`/`from_db_str`
+    /// contract).
+    #[test]
+    fn edge_relation_db_tokens_are_stable_and_round_trip() {
+        for (relation, token) in [
+            (EdgeRelation::DependsOn, "depends_on"),
+            (EdgeRelation::RelatesTo, "relates_to"),
+            (EdgeRelation::Supersedes, "supersedes"),
+            (EdgeRelation::DerivedFrom, "derived_from"),
+            (EdgeRelation::Tracks, "tracks"),
+        ] {
+            assert_eq!(relation.as_db_str(), token);
+            assert_eq!(EdgeRelation::from_db_str(token).unwrap(), relation);
+        }
+        assert!(EdgeRelation::from_db_str("bogus").is_err(), "an unknown token must not resolve");
+    }
+}

--- a/crates/rag-rat-core/src/query/memory/mod.rs
+++ b/crates/rag-rat-core/src/query/memory/mod.rs
@@ -1,4 +1,5 @@
 mod api;
+mod edges;
 mod hydrate;
 mod moniker;
 mod resolve;
@@ -7,6 +8,10 @@ use std::collections::BTreeSet;
 
 pub use api::memory_evidence_for_symbol;
 pub(crate) use api::*;
+// The typed-edge public surface (#464): the boundary types cross the FFI/MCP/CLI edge, so they
+// are `pub`; the query fns stay crate-internal.
+pub use edges::{EdgeRelation, EdgeTarget, NodeEdge};
+pub(crate) use edges::{add_edge, edge_key, edges_from, edges_into, remove_edge};
 pub(crate) use hydrate::*;
 pub(crate) use moniker::*;
 pub(crate) use resolve::*;

--- a/crates/rag-rat-core/src/query/memory/validate.rs
+++ b/crates/rag-rat-core/src/query/memory/validate.rs
@@ -514,9 +514,14 @@ pub(crate) fn is_polymorphic_node_kind(kind: &str) -> bool {
 /// Validate a memory's `payload_json` for its `kind`. Only the polymorphic graph-node kinds
 /// (`is_polymorphic_node_kind`) may carry a payload, and it must be a JSON OBJECT (so it
 /// round-trips and can be folded into the identity hash). A payload on a plain-note kind, or a
-/// non-object payload, is rejected; `None` (no payload) is always fine. Payload-closure (a payload
-/// carries no node/edge references) is enforced once the edge model (#464) defines what a reference
-/// IS.
+/// non-object payload, is rejected; `None` (no payload) is always fine.
+///
+/// Payload-closure — that a relationship between nodes lives in a typed EDGE (#464
+/// `repo_node_edges`) rather than embedded in an opaque payload — is a documented CONVENTION,
+/// deliberately NOT a hard validator: reliably detecting a "node reference" inside arbitrary JSON
+/// isn't feasible without false positives (a reserved-word scan would reject a legitimate
+/// `{"tracks": [...]}` domain field, since `tracks` is also an edge relation). It is steered by the
+/// edge API + tool docs, not rejected here.
 pub(crate) fn validate_payload(kind: &str, payload_json: Option<&str>) -> anyhow::Result<()> {
     let Some(payload) = payload_json else {
         return Ok(());

--- a/crates/rag-rat-mcp/src/tools/catalog.rs
+++ b/crates/rag-rat-mcp/src/tools/catalog.rs
@@ -42,6 +42,9 @@ pub const TOOL_NAMES: &[&str] = &[
     "memory_validate",
     "memory_doctor",
     "memory_mark_obsolete",
+    "memory_edge_add",
+    "memory_edge_remove",
+    "memory_edges",
 ];
 
 pub fn list_tools() -> Value {
@@ -207,6 +210,17 @@ pub fn description(name: &str) -> &'static str {
              Rebind the listed memories with memory_rebind.",
         "memory_mark_obsolete" =>
             "Mark a repo memory obsolete — kept for audit, hidden from active recall.",
+        "memory_edge_add" =>
+            "Add a typed graph edge from a source node to another node or a GitHub issue. \
+             Relations: depends_on (task DAG), relates_to (mind-map link), supersedes, \
+             derived_from, tracks (issue <- task). Give exactly ONE target: a target_node_id (with \
+             an optional target_repo_id for a cross-repo edge) or a full github ref (owner + repo \
+             + number).",
+        "memory_edge_remove" => "Remove a graph edge by its stable edge_key.",
+        "memory_edges" =>
+            "List a node's typed edges: direction=from returns its outgoing edges (deps / links / \
+             tracks); direction=into is the reverse traversal (e.g. tasks that track an issue, or \
+             nodes that depend on this one).",
         _ => "Unknown tool.",
     }
 }
@@ -248,6 +262,9 @@ pub fn schema(name: &str) -> Value {
         "memory_mark_obsolete" | "memory_show" => schema_for::<MemoryIdArgs>(),
         "llm_status" | "github_sync_status" | "index_status" | "memory_validate"
         | "memory_doctor" => schema_for::<EmptyArgs>(),
+        "memory_edge_add" => schema_for::<MemoryEdgeAddArgs>(),
+        "memory_edge_remove" => schema_for::<MemoryEdgeRemoveArgs>(),
+        "memory_edges" => schema_for::<MemoryEdgesArgs>(),
         _ => json!({"type": "object"}),
     }
 }

--- a/crates/rag-rat-mcp/src/tools/handlers.rs
+++ b/crates/rag-rat-mcp/src/tools/handlers.rs
@@ -178,6 +178,30 @@ pub(crate) fn call_tool_with_db(
             let args: MemoryUpdateArgs = serde_json::from_value(arguments)?;
             json!(db.memory_update(args.core())?)
         },
+        "memory_edge_add" => {
+            let args: MemoryEdgeAddArgs = serde_json::from_value(arguments)?;
+            json!(db.memory_edge_add(&args.source_node_id, args.relation_str(), args.target()?)?)
+        },
+        "memory_edge_remove" => {
+            let args: MemoryEdgeRemoveArgs = serde_json::from_value(arguments)?;
+            json!(db.memory_edge_remove(&args.edge_key)?)
+        },
+        "memory_edges" => {
+            let args: MemoryEdgesArgs = serde_json::from_value(arguments)?;
+            let edges = match args.direction {
+                // A source node's OUTGOING edges — a github issue has none, so `node_id` is
+                // required.
+                McpEdgeDirection::From => {
+                    let source = args.node_id.as_deref().ok_or_else(|| {
+                        anyhow::anyhow!("memory_edges direction=from needs a source node_id")
+                    })?;
+                    db.memory_edges_from(source)?
+                },
+                // Reverse traversal INTO a node OR a github issue (e.g. tasks that track it).
+                McpEdgeDirection::Into => db.memory_edges_into(args.reverse_target()?)?,
+            };
+            json!(edges)
+        },
         "memory_search" => {
             let args: MemorySearchArgs = serde_json::from_value(arguments)?;
             json!(db.memory_search(&args.query, args.limit)?)

--- a/crates/rag-rat-mcp/src/tools/mod.rs
+++ b/crates/rag-rat-mcp/src/tools/mod.rs
@@ -55,6 +55,8 @@ pub(crate) fn is_write_tool(name: &str) -> bool {
             | "memory_create"
             | "memory_rebind"
             | "memory_update"
+            | "memory_edge_add"
+            | "memory_edge_remove"
             | "memory_mark_obsolete"
             | "memory_validate"
     )

--- a/crates/rag-rat-mcp/src/tools/requests.rs
+++ b/crates/rag-rat-mcp/src/tools/requests.rs
@@ -788,6 +788,120 @@ impl MemoryUpdateArgs {
     }
 }
 
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum McpEdgeRelation {
+    DependsOn,
+    RelatesTo,
+    Supersedes,
+    DerivedFrom,
+    Tracks,
+}
+
+impl McpEdgeRelation {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::DependsOn => "depends_on",
+            Self::RelatesTo => "relates_to",
+            Self::Supersedes => "supersedes",
+            Self::DerivedFrom => "derived_from",
+            Self::Tracks => "tracks",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum McpEdgeDirection {
+    /// Edges OUT of the node (its dependencies / mind-map links / tracks).
+    From,
+    /// Edges INTO the node — the reverse traversal (e.g. tasks that track an issue).
+    Into,
+}
+
+/// Add a typed graph edge (#464). Give EXACTLY ONE target: another node (`target_node_id`, with an
+/// optional `target_repo_id` for a cross-repo edge) OR a GitHub issue (all three `github_*`).
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
+pub struct MemoryEdgeAddArgs {
+    pub source_node_id: String,
+    pub relation: McpEdgeRelation,
+    pub target_node_id: Option<String>,
+    pub target_repo_id: Option<String>,
+    pub github_owner: Option<String>,
+    pub github_repo: Option<String>,
+    pub github_number: Option<i64>,
+}
+
+/// Build an `EdgeTarget` from the flat wire fields shared by the edge tools: EXACTLY ONE of a node
+/// (`node_id`, with optional `node_repo_id`) or a full github ref. `node_field` names the node arg
+/// in the error so each tool reports its own field name.
+fn edge_target_from_parts(
+    node_id: Option<&str>,
+    node_repo_id: Option<&str>,
+    github: (Option<&str>, Option<&str>, Option<i64>),
+    node_field: &str,
+) -> anyhow::Result<rag_rat_core::query::memory::EdgeTarget> {
+    use rag_rat_core::query::memory::EdgeTarget;
+    match (node_id, github) {
+        (Some(node_id), (None, None, None)) => Ok(EdgeTarget::Node {
+            repo_id: node_repo_id.map(str::to_string),
+            node_id: node_id.to_string(),
+        }),
+        (None, (Some(owner), Some(repo), Some(number))) =>
+            Ok(EdgeTarget::Github { owner: owner.to_string(), repo: repo.to_string(), number }),
+        _ => anyhow::bail!(
+            "needs exactly one target: a {node_field}, OR a full github ref (github_owner + \
+             github_repo + github_number)"
+        ),
+    }
+}
+
+impl MemoryEdgeAddArgs {
+    pub(super) fn relation_str(&self) -> &'static str {
+        self.relation.as_str()
+    }
+
+    pub(super) fn target(&self) -> anyhow::Result<rag_rat_core::query::memory::EdgeTarget> {
+        edge_target_from_parts(
+            self.target_node_id.as_deref(),
+            self.target_repo_id.as_deref(),
+            (self.github_owner.as_deref(), self.github_repo.as_deref(), self.github_number),
+            "target_node_id",
+        )
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
+pub struct MemoryEdgeRemoveArgs {
+    pub edge_key: String,
+}
+
+/// List a node's typed edges. `direction=from` lists a SOURCE node's outgoing edges (`node_id`
+/// required — a github issue has no outgoing edges). `direction=into` is the reverse traversal INTO
+/// a target: give EITHER `node_id` (nodes that edge into it) OR a full github ref (e.g. the tasks
+/// that `tracks` an issue).
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
+pub struct MemoryEdgesArgs {
+    pub direction: McpEdgeDirection,
+    pub node_id: Option<String>,
+    pub github_owner: Option<String>,
+    pub github_repo: Option<String>,
+    pub github_number: Option<i64>,
+}
+
+impl MemoryEdgesArgs {
+    /// The reverse-traversal target for `direction=into` — a node id ignores its repo (the match is
+    /// on the globally-unique anchor), or a full github ref.
+    pub(super) fn reverse_target(&self) -> anyhow::Result<rag_rat_core::query::memory::EdgeTarget> {
+        edge_target_from_parts(
+            self.node_id.as_deref(),
+            None,
+            (self.github_owner.as_deref(), self.github_repo.as_deref(), self.github_number),
+            "node_id",
+        )
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
 pub struct FindClonesArgs {
     /// Minimum pairwise overlap/max_len similarity. Must be in the range [0.5, 1.0]; defaults to
@@ -885,6 +999,69 @@ mod tests {
     use rag_rat_core::index::CloneSymbolSelector;
 
     use super::ClonesForSymbolArgs;
+
+    #[test]
+    fn memory_edges_into_target_routes_node_and_github() {
+        use rag_rat_core::query::memory::EdgeTarget;
+
+        use super::{McpEdgeDirection, MemoryEdgesArgs};
+        let into = |node_id, gh: Option<(&str, &str, i64)>| MemoryEdgesArgs {
+            direction: McpEdgeDirection::Into,
+            node_id,
+            github_owner: gh.map(|g| g.0.to_string()),
+            github_repo: gh.map(|g| g.1.to_string()),
+            github_number: gh.map(|g| g.2),
+        };
+        // #464 review fix: `direction=into` must reach a GITHUB target, not always build a node.
+        assert!(matches!(
+            into(None, Some(("o", "r", 7))).reverse_target().unwrap(),
+            EdgeTarget::Github { number: 7, .. }
+        ));
+        assert!(matches!(
+            into(Some("mem_x".to_string()), None).reverse_target().unwrap(),
+            EdgeTarget::Node { .. }
+        ));
+        // Exactly one target: neither (or both) is an error.
+        assert!(into(None, None).reverse_target().is_err());
+        assert!(into(Some("mem_x".to_string()), Some(("o", "r", 7))).reverse_target().is_err());
+    }
+
+    #[test]
+    fn memory_edge_add_relation_and_target_mappings() {
+        use rag_rat_core::query::memory::EdgeTarget;
+
+        use super::{McpEdgeRelation, MemoryEdgeAddArgs};
+        let add = |relation, node: Option<&str>, gh: Option<(&str, &str, i64)>| MemoryEdgeAddArgs {
+            source_node_id: "s".to_string(),
+            relation,
+            target_node_id: node.map(str::to_string),
+            target_repo_id: None,
+            github_owner: gh.map(|g| g.0.to_string()),
+            github_repo: gh.map(|g| g.1.to_string()),
+            github_number: gh.map(|g| g.2),
+        };
+        // Every relation maps to its db token.
+        for (relation, token) in [
+            (McpEdgeRelation::DependsOn, "depends_on"),
+            (McpEdgeRelation::RelatesTo, "relates_to"),
+            (McpEdgeRelation::Supersedes, "supersedes"),
+            (McpEdgeRelation::DerivedFrom, "derived_from"),
+            (McpEdgeRelation::Tracks, "tracks"),
+        ] {
+            assert_eq!(add(relation, Some("t"), None).relation_str(), token);
+        }
+        // Target: exactly one of a node or a github ref.
+        assert!(matches!(
+            add(McpEdgeRelation::RelatesTo, Some("t"), None).target().unwrap(),
+            EdgeTarget::Node { .. }
+        ));
+        assert!(matches!(
+            add(McpEdgeRelation::Tracks, None, Some(("o", "r", 1))).target().unwrap(),
+            EdgeTarget::Github { .. }
+        ));
+        assert!(add(McpEdgeRelation::Tracks, None, None).target().is_err());
+        assert!(add(McpEdgeRelation::Tracks, Some("t"), Some(("o", "r", 1))).target().is_err());
+    }
 
     fn args(
         id: Option<i64>,

--- a/crates/rag-rat-mcp/src/tools/tests.rs
+++ b/crates/rag-rat-mcp/src/tools/tests.rs
@@ -396,6 +396,67 @@ fn mcp_tool_calls_preserve_compatibility_shapes() {
 }
 
 #[test]
+fn mcp_edge_tools_add_traverse_and_remove() {
+    let (root, config) = mixed_config();
+    IndexDatabase::rebuild(&config).unwrap();
+
+    let create = |title: &str| -> String {
+        let v = call_tool_for_config(
+            &config,
+            "memory_create",
+            json!({"kind": "Task", "title": title, "body": "b", "confidence": "low", "bind": {}}),
+        )
+        .unwrap();
+        v["memory"]["memory_id"].as_str().unwrap().to_string()
+    };
+    let a = create("task a");
+    let b = create("task b");
+
+    // add a --depends_on--> b via the MCP surface; forward + reverse traversal see it.
+    let edge = call_tool_for_config(
+        &config,
+        "memory_edge_add",
+        json!({"source_node_id": a, "relation": "depends_on", "target_node_id": b}),
+    )
+    .unwrap();
+    assert_eq!(edge["relation"], "depends_on");
+    let key = edge["edge_key"].as_str().unwrap().to_string();
+    let from =
+        call_tool_for_config(&config, "memory_edges", json!({"direction": "from", "node_id": a}))
+            .unwrap();
+    assert_eq!(from.as_array().unwrap().len(), 1);
+    let into =
+        call_tool_for_config(&config, "memory_edges", json!({"direction": "into", "node_id": b}))
+            .unwrap();
+    assert_eq!(into.as_array().unwrap().len(), 1);
+
+    // a `tracks` github edge, reachable by the REVERSE traversal on the github ref.
+    call_tool_for_config(
+        &config,
+        "memory_edge_add",
+        json!({"source_node_id": a, "relation": "tracks",
+               "github_owner": "o", "github_repo": "r", "github_number": 5}),
+    )
+    .unwrap();
+    let tracking = call_tool_for_config(
+        &config,
+        "memory_edges",
+        json!({"direction": "into", "github_owner": "o", "github_repo": "r", "github_number": 5}),
+    )
+    .unwrap();
+    assert_eq!(tracking.as_array().unwrap().len(), 1);
+    assert_eq!(tracking[0]["source_node_id"], a);
+
+    // remove by edge_key.
+    assert_eq!(
+        call_tool_for_config(&config, "memory_edge_remove", json!({"edge_key": key})).unwrap(),
+        json!(true)
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn mcp_memory_tools_create_surface_validate_and_obsolete_symbol_memory() {
     let root = unique_temp_root();
     fs::create_dir_all(root.join("src")).unwrap();
@@ -1215,6 +1276,8 @@ fn read_only_classification_covers_every_tool_and_denies_writers() {
         "memory_create",
         "memory_rebind",
         "memory_update",
+        "memory_edge_add",
+        "memory_edge_remove",
         "memory_mark_obsolete",
         "memory_validate",
     ];


### PR DESCRIPTION
Generalizes the memory→code binding into a relation-typed edge set: a source memory node → another node or an external target (a GitHub issue today). The `anchors` relation stays in `repo_memory_bindings`; this is everything else. Prereq for the knowledge-graph model.

## Model
- **V049 `repo_node_edges`** — STRICT, periphery `repo_id`-scoped (owner = source node's repo), `source_node_id` FK → `repo_memories` `ON DELETE CASCADE`.
- **`edge_key`** content-addresses each edge by its node ids `(source_node_id, relation, target_kind, target_anchor)` — *not* the repo ids. A node id is globally unique and repo-folded, so the key stays **stable across a repo-id re-point** (adoption / late-merge); only consolidation (which remaps node ids) recomputes it.
- **Relations**: `depends_on` (task DAG), `relates_to` (mind-map), `supersedes`, `derived_from`, `tracks` (issue ← task). `EdgeRelation` is a strum persisted enum with an exact-token test.
- **Targets**: another node (same- or cross-repo) or a GitHub issue. A cross-repo target whose repo isn't indexed locally is stored `unresolved` — never a hard failure.

## Resolution lifecycle
- **Add**: source must be a live node (`status IN ('active','stale')`) in the active repo; a same-repo target must be *present in the owner repo* (an absent one, or one that resolves to a sibling repo, is rejected — a cross-repo edge must name its repo explicitly); self-loops rejected.
- **Read**: `edges_from` / `edges_into` filter to live sources and **re-resolve node targets on read** by global id, so an `unresolved` edge becomes `current` once its target repo is indexed and `target_repo_id` self-heals. `edges_into` matches on the globally-unique `(target_kind, target_anchor)`, immune to a repo-id re-point.

## Multi-repo integrity
- Consolidation carries edges (`copy_node_edges`: source/target remap + `edge_key` recompute + child-ownership + honest counts, surfaced in `ImportSummary`); adoption + late-merge re-point the owner `repo_id` (and same-repo `target_repo_id`) without a key recompute.
- Poison-sibling harness seeds a `repo_node_edges` row and lists it in `sibling_tripwires` — any unscoped edge read/count/delete trips.

## Surface
- Core: `memory_edge_add` / `memory_edge_remove` / `memory_edges_from` / `memory_edges_into`.
- MCP: `memory_edge_add` / `memory_edge_remove` / `memory_edges` (direction `from`/`into`, node or github target).

Refs #464.
