### PR TITLE
feat(clones): incremental delta maintenance of the persisted clone graph

### DIFF
--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -442,15 +442,22 @@ fn run_maintenance_pass(
     // Prune index rows for git contexts that are no longer live (worktree-safe; keeps every
     // live worktree's HEAD). Cheap and bounded, so it runs every maintenance pass.
     let gc_report = db.garbage_collect().ok();
-    // Clone-edge graph (#286): refresh the persisted graph when absent/stale with whatever budget
-    // the embedding reconcile left (shared so the pass can't overrun), so the git-hook
-    // maintenance keeps the graph warm too — not just the foreground watcher. Gated on the #472
-    // quiet window (shared with the watcher via per-repo meta): a pass observing a fresh content
-    // revision arms/defers instead of discarding and rebuilding the whole generation, so a stream
-    // of commits can't treadmill full rebuilds. Best-effort + resumable across passes.
-    let clone_graph_report = if db
-        .clone_graph_rebuild_due(rag_rat_core::watch::CLONE_GRAPH_QUIET_MS, true)
-        .unwrap_or(false)
+    // Clone-edge graph (#286/#473): try the cheap IN-PLACE delta first — it settles an ordinary
+    // commit's changes on this very hook pass. The FULL rebuild runs only when the delta could
+    // not settle freshness (absent generation, normalizer bump, cap crossing, huge delta, error)
+    // or the generation's accumulated df drift owes a refresh — and it stays behind the #472
+    // quiet window (shared with the watcher via per-repo meta), so a stream of commits can't
+    // treadmill full rebuilds. Best-effort + resumable across passes.
+    let clone_delta = db.apply_clone_graph_delta(rag_rat_core::index::CLONE_DELTA_MAX_FILES).ok();
+    let clone_full_rebuild_owed = match &clone_delta {
+        Some(delta) if delta.status == "Applied" || delta.status == "Noop" =>
+            delta.full_rebuild_owed,
+        _ => true,
+    };
+    let clone_graph_report = if clone_full_rebuild_owed
+        && db
+            .clone_graph_rebuild_due(rag_rat_core::watch::CLONE_GRAPH_QUIET_MS, true)
+            .unwrap_or(false)
     {
         match budget.as_ref().and_then(rag_rat_core::watch::ReconcileBudget::next_options) {
             Some(options) => db.reconcile_clone_edges_with_budget(options.max_seconds).ok(),
@@ -463,7 +470,7 @@ fn run_maintenance_pass(
     // rename, or change, so relocate symbol/chunk bindings (or flag them) here rather than
     // leaving stale anchors until a manual memory_validate.
     let memory_validation = db.memory_validate().ok();
-    tracing::debug!(target: "rag_rat_core::maintenance", phase = "gc_clone_memory", gc = gc_report.is_some(), clone_graph = clone_graph_report.is_some(), memory_validated = memory_validation.is_some(), "post-reconcile phases complete");
+    tracing::debug!(target: "rag_rat_core::maintenance", phase = "gc_clone_memory", gc = gc_report.is_some(), clone_delta = clone_delta.as_ref().map_or("error", |d| d.status.as_str()), clone_graph = clone_graph_report.is_some(), memory_validated = memory_validation.is_some(), "post-reconcile phases complete");
     // Remaining backlog for the ACTIVE embedding model from the CHEAP persisted counts
     // (`status.embedding` / `status.artifacts`, #285), NOT `reconcile_plan` — which rebuilds +
     // re-hashes EVERY chunk's embedding input (O(repo)) on every hook pass. #378 measured that plan

--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -11,12 +11,6 @@ struct ChunkInsertFile<'a> {
     source_revision: &'a str,
 }
 
-/// Whether `write_symbol_fingerprints` should bump `clone_token_df` per token (#215). Named so the
-/// call site reads its intent: `BumpDf(false)` on the full-rebuild path (df is recomputed
-/// authoritatively at finalize, so the per-token bump is wasted work), `BumpDf(true)` on the
-/// incremental/heal path (no finalize runs there, so the bump keeps df current).
-struct BumpDf(bool);
-
 impl IndexDatabase {
     pub fn heal_file(&self, path: &Path) -> anyhow::Result<()> {
         // A heal reads bytes from `source_root` (the MAIN checkout). Under a linked-worktree
@@ -236,17 +230,13 @@ impl IndexDatabase {
         )?;
         let symbol_db_ids = self.insert_symbols(file_id, file.language, &prepared.symbols)?;
         // Clone fingerprints were computed in the parallel prepare phase from the same parse used
-        // for symbols/edges (#230) — no second read, no second parse here, just the DB write.
-        // bump_df = graph.is_none(): the full-rebuild path (graph: Some) recomputes clone_token_df
-        // authoritatively from the postings via one GROUP BY in refresh_clone_token_df at finalize
-        // (rebuild.rs), so the per-token df upserts here would be recomputed-and-discarded — pure
-        // waste + hot-row contention on common tokens. The incremental path (graph: None) runs no
-        // such finalize, so it must keep the df current with the drift-tolerated per-token bump.
-        self.write_symbol_fingerprints(
-            &symbol_db_ids,
-            &prepared.symbol_fingerprints,
-            BumpDf(graph.is_none()),
-        )?;
+        // for symbols/edges (#230) — no second read, no second parse here, just the DB write. No
+        // path bumps `clone_token_df` anymore (#473 df EPOCH FREEZE): the persisted clone-graph
+        // postings order sub-block tokens by df AS OF their build, so moving df on incremental
+        // writes would desync them; df is refreshed authoritatively only at a FULL rebuild's
+        // finalize (refresh_clone_token_df, rebuild.rs). A new token simply rides `DF_FALLBACK`
+        // (selectivity-only) until the next full rebuild.
+        self.write_symbol_fingerprints(&symbol_db_ids, &prepared.symbol_fingerprints)?;
         // Edge candidates were computed in the parallel prepare phase with LOCAL symbol indices;
         // remap them to the real DB ids just assigned.
         match graph {
@@ -301,9 +291,9 @@ impl IndexDatabase {
             return Ok(());
         };
         let fingerprints = clones::fingerprint_symbols(parsed.root(), text, language, symbols);
-        // Heal/inline path runs no full-rebuild finalize, so the df must be kept current here via
-        // the per-token bump (drift-tolerated; see write_symbol_fingerprints).
-        self.write_symbol_fingerprints(symbol_ids, &fingerprints, BumpDf(true))
+        // The heal path does not touch `clone_token_df` either — the #473 df epoch freeze (see
+        // `index_file`'s fingerprint write): df moves only at a full rebuild.
+        self.write_symbol_fingerprints(symbol_ids, &fingerprints)
     }
 
     /// Write precomputed baseline clone fingerprints (#215). `fingerprints` carries
@@ -315,39 +305,19 @@ impl IndexDatabase {
     /// The token bag is serialized into the `symbol_fingerprints.token_bag` BLOB column (#231),
     /// one BLOB per symbol — there is no longer a `symbol_token_postings` row-per-token write.
     ///
-    /// `bump_df` gates the per-token `clone_token_df` upsert. On the full-rebuild path it is
-    /// `BumpDf(false)`: `refresh_clone_token_df` (rebuild.rs) recomputes df exactly from the
-    /// token-bag BLOBs at finalize, so bumping it per token here is recomputed-and-discarded work
-    /// plus hot-row B-tree contention on common tokens. On the incremental/heal paths it is
-    /// `BumpDf(true)` — no finalize runs there, so the drift-tolerated bump is how df stays current
-    /// (df is a selectivity hint only; the candidate read COALESCEs it, so drift never changes a
-    /// result — see query_api/clones.rs).
+    /// This write never touches `clone_token_df` (#473 df EPOCH FREEZE): df is recomputed
+    /// authoritatively only at a full rebuild's finalize (`refresh_clone_token_df`, rebuild.rs) —
+    /// or seeded once by `refresh_clone_token_df_if_unseeded` on a first standalone index — so the
+    /// persisted clone-graph postings and every later sub-block computation share one total order.
+    /// df is a selectivity hint only (the candidate read COALESCEs a missing row to
+    /// `DF_FALLBACK`), so epoch drift never changes a result — see query_api/clones.
     fn write_symbol_fingerprints(
         &self,
         symbol_db_ids: &[i64],
         fingerprints: &[(usize, clones::SymbolFingerprint)],
-        bump_df: BumpDf,
     ) -> anyhow::Result<()> {
         let conn = self.storage.connection();
         let normalizer_kind = clones::NormalizerKind::Baseline.as_db_str();
-        // Resolve the periphery scope ONCE (not per token). Post-A5 `clone_token_df`'s PK is
-        // `(repo_id, normalizer_kind, token_hash)`, so the upsert must stamp `repo_id` AND target
-        // it in the ON CONFLICT — the repo id is embedded as a per-call literal so the
-        // bound params (`?1` kind, `?2` token) stay unchanged. Pre-A5 (no `repo_id` column)
-        // uses the original SQL.
-        let clone_df_bump_sql =
-            match crate::index::schema::periphery_repo_scope(conn, "clone_token_df")? {
-                Some(repo_id) => format!(
-                    "INSERT INTO clone_token_df(repo_id, normalizer_kind, token_hash, df)
-                 VALUES ('{}', ?1, ?2, 1)
-                 ON CONFLICT(repo_id, normalizer_kind, token_hash) DO UPDATE SET df = df + 1",
-                    repo_id.replace('\'', "''")
-                ),
-                None => "INSERT INTO clone_token_df(normalizer_kind, token_hash, df)
-                 VALUES (?1, ?2, 1)
-                 ON CONFLICT(normalizer_kind, token_hash) DO UPDATE SET df = df + 1"
-                    .to_string(),
-            };
         for (local_index, fp) in fingerprints {
             let symbol_id = symbol_db_ids[*local_index];
             // The token bag rides the fingerprint row as ONE serialized BLOB (#231), replacing the
@@ -369,17 +339,6 @@ impl IndexDatabase {
                 token_bag_blob,
                 now_ms(),
             ])?;
-            // Bump the global document frequency per distinct token ONLY when `bump_df`
-            // (incremental/heal): df is a selectivity hint only (the candidate read COALESCEs it),
-            // so the bump is drift-tolerated. A full rebuild skips the bump and instead recomputes
-            // df authoritatively from the token-bag BLOBs at finalize (refresh_clone_token_df,
-            // rebuild.rs). R7: iterate the IN-MEMORY `fp.token_bag` here — no decode round-trip.
-            if bump_df.0 {
-                for &(token_hash, _freq) in &fp.token_bag {
-                    conn.prepare_cached(&clone_df_bump_sql)?
-                        .execute(params![normalizer_kind, token_hash])?;
-                }
-            }
         }
         Ok(())
     }

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -290,9 +290,11 @@ impl IndexDatabase {
         // - apply_staged_parser_failures: THE batch-7 finding — the wave loop stages failures
         //   (`graph.is_some()` routing), so the finalize must publish them; at this connection's
         //   own (live) generation, atomic with its edges (no flip exists to defer to).
-        // - refresh_clone_token_df: the waves wrote fingerprints under `BumpDf(false)`, whose
-        //   contract is "df is recomputed authoritatively at finalize" — without this the
-        //   standalone path left df stale/empty.
+        // - refresh_clone_token_df_if_unseeded: SEED the df epoch on a first standalone index
+        //   (pre-#473 this was an unconditional refresh). The #473 df EPOCH FREEZE keeps df fixed
+        //   between FULL rebuilds so the persisted clone-graph postings and every later sub-block
+        //   computation share one total order — an unconditional refresh here would both desync
+        //   them and re-invalidate the postings every incremental pass.
         // - sync_fts + the graph/flags marks: chunk_fts was written inline and the edges/flags were
         //   just derived in full, so record freshness like the rebuild does — otherwise the very
         //   next open pays a full (safe but wasted) edge re-derive heal and an FTS rebuild.
@@ -306,7 +308,7 @@ impl IndexDatabase {
             self.finalize_base_edges(config, graph)?;
             self.rebuild_logical_symbols()?;
             self.apply_staged_parser_failures(self.active_generation)?;
-            self.refresh_clone_token_df()?;
+            self.refresh_clone_token_df_if_unseeded()?;
             self.sync_fts()?;
             self.mark_graph_index_current()?;
             self.mark_generated_flags_current()

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -59,10 +59,11 @@ pub(crate) use meta::{delete_repo_meta, repo_meta, set_repo_meta};
 pub use parser_failures::ParserFailure;
 pub(crate) use prep::*;
 pub use query_api::{
-    CandidateCloneClass, CloneCheckInput, CloneCompleteness, CloneEdgeReport, CloneEligibility,
-    CloneFingerprintHealth, CloneIneligibilityReason, CloneMember, CloneSymbolSelector,
-    ClonesForSymbolResult, FindClonesOptions, FindClonesResult, GcReport, ImportantSymbolsRequest,
-    OracleShaSnapshots, RoiFactors, SearchRequest, TextCloneMatch,
+    CLONE_DELTA_MAX_FILES, CandidateCloneClass, CloneCheckInput, CloneCompleteness,
+    CloneDeltaReport, CloneEdgeReport, CloneEligibility, CloneFingerprintHealth,
+    CloneIneligibilityReason, CloneMember, CloneSymbolSelector, ClonesForSymbolResult,
+    FindClonesOptions, FindClonesResult, GcReport, ImportantSymbolsRequest, OracleShaSnapshots,
+    RoiFactors, SearchRequest, TextCloneMatch,
 };
 pub(crate) use util::*;
 

--- a/crates/rag-rat-core/src/index/query_api/clones/delta.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/delta.rs
@@ -721,6 +721,59 @@ mod tests {
         assert_eq!(report.status, "NotEligible", "{report:?}");
     }
 
+    /// The remaining eligibility gates: a postings-stale live generation (pre-upgrade or
+    /// df-refresh-invalidated) and an in-flight Building generation both refuse the in-place
+    /// patch — the full-rebuild path owns those states.
+    #[test]
+    fn clone_graph_delta_is_not_eligible_for_stale_postings_or_inflight_builds() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let config = clone_fixture_config("delta-ineligible");
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
+        let conn = db.storage.connection();
+
+        conn.execute("UPDATE clone_graph_generations SET postings_written = 0", []).unwrap();
+        let report = db.apply_clone_graph_delta(64).unwrap();
+        assert_eq!(report.status, "NotEligible", "postings-stale generation: {report:?}");
+        conn.execute("UPDATE clone_graph_generations SET postings_written = 1", []).unwrap();
+
+        // An in-flight (Building) generation means a full rebuild is owed — patching the live
+        // generation now would race its eventual publish.
+        conn.execute(
+            "INSERT INTO clone_graph_generations
+                (generation, status, theta_floor, normalizer_kind, normalizer_version,
+                 source_revision, started_at_ms, postings_written, repo_id)
+             VALUES (9999, 'Building', 0.7, 'baseline', ?1, 'inflight-rev', 0, 1, ?2)",
+            rusqlite::params![crate::index::clones::NORM_VERSION, db.active_repo_id],
+        )
+        .unwrap();
+        let report = db.apply_clone_graph_delta(64).unwrap();
+        assert_eq!(report.status, "NotEligible", "in-flight full rebuild: {report:?}");
+    }
+
+    /// A content-revision move with NO clone-relevant file change (a new file with no
+    /// fingerprintable functions) re-pins `source_revision` without touching the graph —
+    /// `Applied` with zero files, zero edge churn.
+    #[test]
+    fn clone_graph_delta_repins_freshness_for_clone_irrelevant_changes() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let config = clone_fixture_config("delta-irrelevant");
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
+        let edges_before = edge_keys(&db);
+        drop(db);
+
+        // A type-only file: indexed (revision moves) but no function fingerprints.
+        std::fs::write(config.root.join("src/j.rs"), "pub struct MarkerOnly;\n").unwrap();
+        let db = reindex(&config);
+        let report = db.apply_clone_graph_delta(64).unwrap();
+        assert_eq!(report.status, "Applied", "{report:?}");
+        assert_eq!(report.files_changed, 0, "no clone-relevant file changed");
+        assert_eq!(report.edges_added + report.edges_removed, 0);
+        assert_eq!(edge_keys(&db), edges_before, "the graph itself is untouched");
+        assert!(!db.pending_clone_graph().unwrap(), "but the freshness key is re-pinned");
+    }
+
     /// A delta larger than `max_files` escalates without writing anything — a huge delta (branch
     /// switch) is cheaper to rebuild than to patch file-by-file.
     #[test]
@@ -894,7 +947,8 @@ mod tests {
         drop(db);
 
         // A content pass inside the quiet window: the delta settles freshness in place; the
-        // drift-owed FULL rebuild stays deferred.
+        // drift-owed FULL rebuild stays deferred. The new file's tokens do NOT enter the frozen
+        // df epoch (that is exactly the drift the counter measures).
         std::fs::write(
             config.root.join("src/i.rs"),
             "pub fn drift_probe(q: i64) -> i64 { q * 11 - 6 }\n",
@@ -902,6 +956,13 @@ mod tests {
         .unwrap();
         crate::watch::maintenance_pass(&config, false).unwrap();
         let db = crate::IndexDatabase::open_config(&config).unwrap();
+        let df_count = |db: &crate::IndexDatabase| -> i64 {
+            db.storage
+                .connection()
+                .query_row("SELECT COUNT(*) FROM clone_token_df", [], |r| r.get(0))
+                .unwrap()
+        };
+        let frozen_df = df_count(&db);
         let live: i64 = db
             .storage
             .connection()
@@ -938,6 +999,12 @@ mod tests {
             .unwrap();
         assert!(live > built.generation, "the quiet-elapsed pass ran the drift full rebuild");
         assert_eq!(absorbed, 0, "the fresh generation starts with zero absorbed deltas");
+        // The whole POINT of the drift rebuild (PR #477 review): it must refresh the df epoch,
+        // not just reset the counter — the delta-added file's tokens enter df with the rebuild.
+        assert!(
+            df_count(&db) > frozen_df,
+            "the drift full rebuild refreshes the df epoch (absorbs the delta-added tokens)"
+        );
     }
 
     /// The generation bookkeeping: an applied delta bumps `source_revision` to current (making

--- a/crates/rag-rat-core/src/index/query_api/clones/delta.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/delta.rs
@@ -1,0 +1,981 @@
+//! Incremental delta maintenance of the persisted clone-edge graph (#473): when a small set of
+//! files changes, update the LIVE Complete generation in place — delete the changed files' edges +
+//! postings, recompute only their symbols against the persisted postings, and bump the
+//! generation's `source_revision` — instead of discarding and rebuilding the whole generation
+//! (`reconcile_clone_edges_pass`), which costs ~1 GB of DB writes per cycle on this repo.
+//!
+//! WHY THIS IS SOUND (the two load-bearing facts):
+//! - Edges are VERIFICATION RESULTS: `clone_edges.overlap` depends only on the two endpoint bags,
+//!   so an edit to file X cannot change any edge not touching X — edges between unchanged files
+//!   stay valid verbatim.
+//! - Prefix filtering is recall-lossless under ANY single consistent token order, and the #473 df
+//!   EPOCH FREEZE (see `refresh_clone_token_df_if_unseeded`) pins that order between FULL rebuilds,
+//!   so delta sub-blocks and the persisted postings always agree.
+//!
+//! PARITY DISCIPLINE (pinned by `clone_graph_delta_matches_a_full_rebuild_over_an_edit_sequence`):
+//! the delta-maintained edge set must equal a from-scratch rebuild's at the same content. Two
+//! rules keep it exact:
+//! - Corpus filters match the BUILD's (`load_scoped_baseline_bags`): scoped `files` view,
+//!   `generated = 0`, baseline + `NORM_VERSION`, non-NULL bag — and deliberately NO
+//!   `symbols.is_test` filter (that narrower filter belongs to the `of_text` write-time corpus, not
+//!   the persisted graph).
+//! - NO `HOT_TOKEN_POSTINGS_CAP` filtering: the #271 cap belongs to the LIVE candidate paths
+//!   (`sub_block_candidate_pairs` / `subject_component_bfs`) — the persisted-graph build walks
+//!   every sub-block token uncapped, so the delta does too, or a stable-hot shared token would
+//!   silently drop edges a full rebuild keeps (pinned by
+//!   `delta_keeps_hot_token_edges_the_build_would_emit`).
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::Instant;
+
+use rusqlite::types::Value;
+use rusqlite::{Connection, params, params_from_iter};
+use serde::Serialize;
+
+use super::precompute::{
+    Anchor, CLONE_GRAPH_DRIFT_REBUILD_FILES, CLONE_PRECOMPUTE_THETA, EdgeRow, PostingGroup,
+    clone_generation_scope_clause, insert_edge_rows, insert_posting_groups, live_generation_row,
+    make_edge,
+};
+use super::substrate::{
+    SymbolBag, add_struct_hash_pairs, load_scoped_baseline_bags_for_paths, overlap,
+    sub_block_tokens, verified_clone,
+};
+use crate::index::IndexDatabase;
+use crate::index::clones::NORM_VERSION;
+
+/// SQLite bind-variable safety chunk for `IN (…)` lists (mirrors `of_text::HYDRATION_CHUNK`).
+const DELTA_SQL_CHUNK: usize = 400;
+
+/// The background tails' delta size cap: a change touching more files than this escalates to a
+/// full rebuild (a branch switch re-anchors most of the corpus — patching it file-by-file costs
+/// more than one clean generation build).
+pub const CLONE_DELTA_MAX_FILES: usize = 64;
+
+/// Outcome of one [`IndexDatabase::apply_clone_graph_delta`] attempt. `status`:
+/// - `Applied` — the live generation now matches `content_revision()`; counts say what changed.
+/// - `Noop` — already current, nothing to do.
+/// - `NotEligible` — no live Complete postings-aware generation to patch (or a full rebuild is in
+///   flight, or an overlay scope is active); the caller falls back to the full-rebuild path.
+/// - `Escalate` — the delta is too large to patch in place (more changed files than the caller's
+///   cap); the caller schedules a full rebuild instead. Nothing was written.
+#[derive(Debug, Clone, Serialize)]
+pub struct CloneDeltaReport {
+    pub status: String,
+    pub reason: Option<String>,
+    pub files_changed: u64,
+    pub edges_added: u64,
+    pub edges_removed: u64,
+    /// Set on `Applied`/`Noop` when the live generation's accumulated `delta_files_applied` has
+    /// reached [`CLONE_GRAPH_DRIFT_REBUILD_FILES`]: the graph is FRESH (keep serving it) but its
+    /// frozen df epoch owes a full rebuild — the caller lets the quiet-gated full path take it.
+    pub full_rebuild_owed: bool,
+    pub elapsed_ms: u64,
+}
+
+impl IndexDatabase {
+    /// Apply one clone-graph delta toward the current `content_revision()`, bounded to
+    /// `max_files` changed files (larger deltas escalate — a branch switch is cheaper to rebuild).
+    /// MUST run under the caller's write lock (like `reconcile_clone_edges_pass`); the read phase
+    /// runs lock-stable outside a transaction, and all writes commit in ONE transaction, so a
+    /// reader sees either the old graph or the fully-applied delta.
+    pub fn apply_clone_graph_delta(&self, max_files: usize) -> anyhow::Result<CloneDeltaReport> {
+        let started = Instant::now();
+        let conn = self.storage.connection();
+
+        // Eligibility — anything here sends the caller to the full-rebuild path instead.
+        if self.active_scope_is_linked_overlay() {
+            // The graph is built in the BASE scope only (see `clone_check_indexed_generation`).
+            return Ok(report("NotEligible", Some("linked-overlay scope"), 0, 0, 0, started));
+        }
+        let Some(live) = live_generation_row(conn)? else {
+            return Ok(report("NotEligible", Some("no live generation"), 0, 0, 0, started));
+        };
+        if live.normalizer_version != NORM_VERSION || !live.postings_written {
+            return Ok(report(
+                "NotEligible",
+                Some("live generation predates the current normalizer or postings"),
+                0,
+                0,
+                0,
+                started,
+            ));
+        }
+        if building_generation_exists(conn)? {
+            // A partial full build is owed; patching the live generation now would race its
+            // eventual publish. Let the full-rebuild path finish (or discard) it.
+            return Ok(report(
+                "NotEligible",
+                Some("a full rebuild is in flight"),
+                0,
+                0,
+                0,
+                started,
+            ));
+        }
+        let revision = self.content_revision()?;
+        if live.source_revision == revision {
+            return Ok(CloneDeltaReport {
+                full_rebuild_owed: live.delta_files_applied >= CLONE_GRAPH_DRIFT_REBUILD_FILES,
+                ..report("Noop", None, 0, 0, 0, started)
+            });
+        }
+        let generation = live.generation;
+        let drift_after = |absorbed: i64| -> bool {
+            live.delta_files_applied + absorbed >= CLONE_GRAPH_DRIFT_REBUILD_FILES
+        };
+
+        // ---- Read phase (write lock held; no transaction needed for consistency) ----
+
+        let paths = delta_paths(conn, generation)?;
+        if paths.len() > max_files {
+            return Ok(report(
+                "Escalate",
+                Some("more changed files than the delta cap — a full rebuild is cheaper"),
+                paths.len() as u64,
+                0,
+                0,
+                started,
+            ));
+        }
+        if paths.is_empty() {
+            // The revision moved but no clone-relevant file changed (e.g. a docs-target edit):
+            // the graph is semantically current — just re-pin the freshness key.
+            conn.execute(
+                "UPDATE clone_graph_generations SET source_revision = ?1 WHERE generation = ?2",
+                params![revision, generation],
+            )?;
+            return Ok(CloneDeltaReport {
+                full_rebuild_owed: drift_after(0),
+                ..report("Applied", None, 0, 0, 0, started)
+            });
+        }
+
+        let delta_bags = load_scoped_baseline_bags_for_paths(conn, &paths)?;
+        let anchors = anchors_for_paths(conn, &paths)?;
+        let sub_blocks: BTreeMap<i64, Vec<i64>> = delta_bags
+            .iter()
+            .map(|bag| (bag.symbol_id, sub_block_tokens(bag, CLONE_PRECOMPUTE_THETA)))
+            .collect();
+
+        // ---- Emission (RAM; reads only) ----
+        //
+        // Deliberately NO #271 hot-token filtering anywhere below: the persisted-graph build
+        // walks every sub-block token uncapped (the cap belongs to the live candidate paths), so
+        // the delta must too — see the module doc's parity discipline.
+
+        let delta_path_set: BTreeSet<&str> = paths.iter().map(String::as_str).collect();
+        let by_id: BTreeMap<i64, &SymbolBag> =
+            delta_bags.iter().map(|b| (b.symbol_id, b)).collect();
+        let mut edge_batch: Vec<EdgeRow> = Vec::new();
+        let mut posting_groups: Vec<PostingGroup> = Vec::new();
+
+        // (a) delta symbol vs the UNCHANGED corpus.
+        for bag in &delta_bags {
+            let Some(s_anchor) = anchors.get(&bag.symbol_id) else { continue };
+            let sub = &sub_blocks[&bag.symbol_id];
+
+            // Struct-hash exact partners (sim 1.0, no verify), mirroring the build's rule.
+            let mut struct_partner_keys: BTreeSet<(String, i64)> = BTreeSet::new();
+            for (p_anchor, p_len) in old_struct_partners(conn, bag, &delta_path_set, s_anchor)? {
+                struct_partner_keys.insert((p_anchor.0.clone(), p_anchor.1));
+                edge_batch.push(make_edge(
+                    s_anchor,
+                    bag.token_len,
+                    &p_anchor,
+                    p_len,
+                    bag.token_len,
+                    1.0,
+                    "struct_hash",
+                ));
+            }
+
+            // Near candidates via the persisted postings (every sub-block token, uncapped —
+            // build parity).
+            let candidates =
+                hydrate_posting_candidates(conn, generation, sub, &bag.language, &delta_path_set)?;
+            for (t_bag, t_anchor) in candidates {
+                if t_anchor.0 == s_anchor.0 && t_anchor.1 == s_anchor.1 {
+                    continue; // self
+                }
+                if struct_partner_keys.contains(&(t_anchor.0.clone(), t_anchor.1)) {
+                    continue; // already emitted as a struct-hash exact pair
+                }
+                if verified_clone(bag, &t_bag, CLONE_PRECOMPUTE_THETA) {
+                    let ov = overlap(bag, &t_bag);
+                    let max_len = bag.token_len.max(t_bag.token_len);
+                    edge_batch.push(make_edge(
+                        s_anchor,
+                        bag.token_len,
+                        &t_anchor,
+                        t_bag.token_len,
+                        ov,
+                        ov as f64 / max_len as f64,
+                        "sub_block",
+                    ));
+                }
+            }
+
+            // Postings for every walked delta symbol — unconditionally, like the build (the cap
+            // gates pair EMISSION only, never the persisted postings).
+            if !sub.is_empty() {
+                posting_groups.push(PostingGroup { anchor: s_anchor.clone(), tokens: sub.clone() });
+            }
+        }
+
+        // (b) delta vs delta — the build's two rules over just the delta bags.
+        let mut struct_pairs: BTreeSet<(i64, i64)> = BTreeSet::new();
+        add_struct_hash_pairs(&delta_bags, &mut struct_pairs);
+        for &(a, b) in &struct_pairs {
+            let (Some(a_anchor), Some(b_anchor)) = (anchors.get(&a), anchors.get(&b)) else {
+                continue;
+            };
+            edge_batch.push(make_edge(
+                a_anchor,
+                by_id[&a].token_len,
+                b_anchor,
+                by_id[&b].token_len,
+                by_id[&a].token_len,
+                1.0,
+                "struct_hash",
+            ));
+        }
+        let mut local_inverted: BTreeMap<i64, Vec<i64>> = BTreeMap::new();
+        for bag in &delta_bags {
+            for &t in &sub_blocks[&bag.symbol_id] {
+                local_inverted.entry(t).or_default().push(bag.symbol_id);
+            }
+        }
+        let mut local_pairs: BTreeSet<(i64, i64)> = BTreeSet::new();
+        for ids in local_inverted.values() {
+            for (i, &a) in ids.iter().enumerate() {
+                for &b in &ids[i + 1..] {
+                    if by_id[&a].language == by_id[&b].language {
+                        local_pairs.insert((a.min(b), a.max(b)));
+                    }
+                }
+            }
+        }
+        for &(a, b) in &local_pairs {
+            if struct_pairs.contains(&(a, b)) {
+                continue;
+            }
+            let (Some(a_anchor), Some(b_anchor)) = (anchors.get(&a), anchors.get(&b)) else {
+                continue;
+            };
+            let (ba, bb) = (by_id[&a], by_id[&b]);
+            if verified_clone(ba, bb, CLONE_PRECOMPUTE_THETA) {
+                let ov = overlap(ba, bb);
+                let max_len = ba.token_len.max(bb.token_len);
+                edge_batch.push(make_edge(
+                    a_anchor,
+                    ba.token_len,
+                    b_anchor,
+                    bb.token_len,
+                    ov,
+                    ov as f64 / max_len as f64,
+                    "sub_block",
+                ));
+            }
+        }
+
+        // ---- Write phase: one transaction ----
+
+        conn.execute_batch("BEGIN IMMEDIATE")?;
+        let result = (|| -> anyhow::Result<(u64, u64)> {
+            let mut edges_removed = 0u64;
+            for chunk in paths.chunks(DELTA_SQL_CHUNK) {
+                let placeholders: Vec<String> =
+                    (0..chunk.len()).map(|i| format!("?{}", i + 2)).collect();
+                let in_list = placeholders.join(", ");
+                let mut values: Vec<Value> = Vec::with_capacity(1 + chunk.len());
+                values.push(Value::Integer(generation));
+                values.extend(chunk.iter().map(|p| Value::Text(p.clone())));
+                edges_removed += conn.execute(
+                    &format!(
+                        "DELETE FROM clone_edges WHERE build_generation = ?1 AND a_path IN \
+                         ({in_list})"
+                    ),
+                    params_from_iter(values.clone()),
+                )? as u64;
+                edges_removed += conn.execute(
+                    &format!(
+                        "DELETE FROM clone_edges WHERE build_generation = ?1 AND b_path IN \
+                         ({in_list})"
+                    ),
+                    params_from_iter(values.clone()),
+                )? as u64;
+                // Indexed by V049's idx_clone_subblock_postings_path.
+                conn.execute(
+                    &format!(
+                        "DELETE FROM clone_subblock_postings WHERE build_generation = ?1 AND path \
+                         IN ({in_list})"
+                    ),
+                    params_from_iter(values),
+                )?;
+            }
+            let edges_added = insert_edge_rows(conn, generation, &edge_batch)?;
+            insert_posting_groups(conn, generation, &posting_groups)?;
+            conn.execute(
+                "UPDATE clone_graph_generations
+                    SET source_revision = ?1,
+                        delta_files_applied = delta_files_applied + ?2,
+                        edges_written = MAX(edges_written + ?3, 0)
+                  WHERE generation = ?4",
+                params![
+                    revision,
+                    paths.len() as i64,
+                    edges_added as i64 - edges_removed as i64,
+                    generation
+                ],
+            )?;
+            Ok((edges_added, edges_removed))
+        })();
+        match result {
+            Ok((edges_added, edges_removed)) => {
+                conn.execute_batch("COMMIT")?;
+                Ok(CloneDeltaReport {
+                    full_rebuild_owed: drift_after(paths.len() as i64),
+                    ..report(
+                        "Applied",
+                        None,
+                        paths.len() as u64,
+                        edges_added,
+                        edges_removed,
+                        started,
+                    )
+                })
+            },
+            Err(err) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                Err(err)
+            },
+        }
+    }
+}
+
+fn report(
+    status: &str,
+    reason: Option<&str>,
+    files_changed: u64,
+    edges_added: u64,
+    edges_removed: u64,
+    started: Instant,
+) -> CloneDeltaReport {
+    CloneDeltaReport {
+        status: status.to_string(),
+        reason: reason.map(str::to_string),
+        files_changed,
+        edges_added,
+        edges_removed,
+        full_rebuild_owed: false,
+        elapsed_ms: started.elapsed().as_millis() as u64,
+    }
+}
+
+fn building_generation_exists(conn: &Connection) -> anyhow::Result<bool> {
+    let repo_clause = clone_generation_scope_clause(conn)?;
+    let exists: i64 = conn.query_row(
+        &format!(
+            "SELECT EXISTS(SELECT 1 FROM clone_graph_generations WHERE status = \
+             'Building'{repo_clause})"
+        ),
+        [],
+        |r| r.get(0),
+    )?;
+    Ok(exists != 0)
+}
+
+/// The delta's file set, derived from the DB alone (idempotent, self-healing — no plumbing from
+/// discover): postings anchors whose `(path, file_sha)` no longer matches an eligible current
+/// file (edited, deleted, or generated-flipped files), plus eligible fingerprinted files with no
+/// postings at all (new files; every non-empty bag emits ≥1 posting, so only bagless files can
+/// linger here, and they recompute to nothing).
+fn delta_paths(conn: &Connection, generation: i64) -> anyhow::Result<Vec<String>> {
+    let mut set: BTreeSet<String> = BTreeSet::new();
+    let mut stale = conn.prepare(
+        "SELECT DISTINCT p.path FROM clone_subblock_postings p
+          WHERE p.build_generation = ?1
+            AND NOT EXISTS (SELECT 1 FROM files f
+                             WHERE f.path = p.path AND f.sha256 = p.file_sha
+                               AND f.generated = 0)",
+    )?;
+    for row in stale.query_map(params![generation], |r| r.get::<_, String>(0))? {
+        set.insert(row?);
+    }
+    let mut fresh = conn.prepare(
+        "SELECT DISTINCT f.path FROM files f
+           JOIN symbols s ON s.file_id = f.id
+           JOIN symbol_fingerprints sf ON sf.symbol_id = s.id
+          WHERE f.generated = 0
+            AND sf.normalizer_kind = 'baseline' AND sf.normalizer_version = ?1
+            AND sf.token_bag IS NOT NULL
+            AND NOT EXISTS (SELECT 1 FROM clone_subblock_postings p
+                             WHERE p.build_generation = ?2 AND p.path = f.path)",
+    )?;
+    for row in fresh.query_map(params![NORM_VERSION, generation], |r| r.get::<_, String>(0))? {
+        set.insert(row?);
+    }
+    Ok(set.into_iter().collect())
+}
+
+/// `(path, start_byte, file_sha)` anchors for every scoped, non-generated symbol in `paths` —
+/// `resolve_symbol_anchors` narrowed to the delta files.
+fn anchors_for_paths(conn: &Connection, paths: &[String]) -> anyhow::Result<BTreeMap<i64, Anchor>> {
+    let mut map = BTreeMap::new();
+    for chunk in paths.chunks(DELTA_SQL_CHUNK) {
+        let placeholders: Vec<String> = (0..chunk.len()).map(|i| format!("?{}", i + 1)).collect();
+        let mut stmt = conn.prepare(&format!(
+            "SELECT s.id, f.path, s.start_byte, f.sha256
+               FROM symbols s JOIN files f ON f.id = s.file_id
+              WHERE f.generated = 0 AND f.path IN ({})",
+            placeholders.join(", ")
+        ))?;
+        let values: Vec<Value> = chunk.iter().map(|p| Value::Text(p.clone())).collect();
+        let rows = stmt.query_map(params_from_iter(values), |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                (row.get::<_, String>(1)?, row.get::<_, i64>(2)?, row.get::<_, String>(3)?),
+            ))
+        })?;
+        for row in rows {
+            let (id, anchor) = row?;
+            map.insert(id, anchor);
+        }
+    }
+    Ok(map)
+}
+
+/// The UNCHANGED corpus's struct-hash exact partners of one delta bag: same `(struct_hash,
+/// language)`, BUILD-corpus filters (scoped `files` view, `generated = 0`, baseline +
+/// `NORM_VERSION`, non-NULL bag — deliberately NO `is_test` filter, unlike the `of_text` corpus),
+/// excluding the delta files themselves (their pairs are emitted by the delta-vs-delta stage) and
+/// the subject's own anchor.
+fn old_struct_partners(
+    conn: &Connection,
+    bag: &SymbolBag,
+    delta_path_set: &BTreeSet<&str>,
+    s_anchor: &Anchor,
+) -> anyhow::Result<Vec<(Anchor, i64)>> {
+    let mut stmt = conn.prepare_cached(
+        "SELECT f.path, s.start_byte, f.sha256, sf.token_len
+           FROM symbol_fingerprints sf
+           JOIN symbols s ON s.id = sf.symbol_id
+           JOIN files f ON f.id = s.file_id
+          WHERE sf.normalizer_kind = 'baseline' AND sf.normalizer_version = ?1
+            AND f.generated = 0 AND s.language = ?2 AND sf.struct_hash = ?3
+            AND sf.token_bag IS NOT NULL",
+    )?;
+    let rows = stmt.query_map(params![NORM_VERSION, bag.language, bag.struct_hash], |r| {
+        Ok((
+            (r.get::<_, String>(0)?, r.get::<_, i64>(1)?, r.get::<_, String>(2)?),
+            r.get::<_, i64>(3)?,
+        ))
+    })?;
+    let mut partners = Vec::new();
+    for row in rows {
+        let (anchor, token_len) = row?;
+        if delta_path_set.contains(anchor.0.as_str()) {
+            continue;
+        }
+        if anchor.0 == s_anchor.0 && anchor.1 == s_anchor.1 {
+            continue;
+        }
+        partners.push((anchor, token_len));
+    }
+    Ok(partners)
+}
+
+/// Resolve + hydrate the persisted-postings candidates for one delta bag's non-hot sub-block
+/// tokens: postings rows → distinct anchors → scoped bags with the BUILD-corpus filters and the
+/// `file_sha` read-staleness discipline (a posting whose anchor sha no longer matches the current
+/// `files.sha256` is dead weight from a torn state — never a live candidate). Anchors under the
+/// delta files are excluded (their postings were just accounted for deletion; their pairs belong
+/// to the delta-vs-delta stage).
+fn hydrate_posting_candidates(
+    conn: &Connection,
+    generation: i64,
+    tokens: &[i64],
+    language: &str,
+    delta_path_set: &BTreeSet<&str>,
+) -> anyhow::Result<Vec<(SymbolBag, Anchor)>> {
+    if tokens.is_empty() {
+        return Ok(Vec::new());
+    }
+    // 1. Candidate anchors from the postings.
+    let mut anchor_sha: BTreeMap<(String, i64), String> = BTreeMap::new();
+    for chunk in tokens.chunks(DELTA_SQL_CHUNK) {
+        let placeholders: Vec<String> = (0..chunk.len()).map(|i| format!("?{}", i + 2)).collect();
+        let mut stmt = conn.prepare(&format!(
+            "SELECT path, start_byte, file_sha FROM clone_subblock_postings
+              WHERE build_generation = ?1 AND token_hash IN ({})",
+            placeholders.join(", ")
+        ))?;
+        let mut values: Vec<Value> = Vec::with_capacity(1 + chunk.len());
+        values.push(Value::Integer(generation));
+        values.extend(chunk.iter().map(|&t| Value::Integer(t)));
+        let rows = stmt.query_map(params_from_iter(values), |r| {
+            Ok(((r.get::<_, String>(0)?, r.get::<_, i64>(1)?), r.get::<_, String>(2)?))
+        })?;
+        for row in rows {
+            let (key, sha) = row?;
+            if delta_path_set.contains(key.0.as_str()) {
+                continue;
+            }
+            anchor_sha.entry(key).or_insert(sha);
+        }
+    }
+    if anchor_sha.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // 2. Hydrate only those anchors, with staleness + corpus filters.
+    let keys: Vec<(String, i64)> = anchor_sha.keys().cloned().collect();
+    let mut out: Vec<(SymbolBag, Anchor)> = Vec::new();
+    for chunk in keys.chunks(DELTA_SQL_CHUNK / 2) {
+        let tuples: Vec<String> =
+            (0..chunk.len()).map(|i| format!("(?{}, ?{})", 2 * i + 3, 2 * i + 4)).collect();
+        let mut stmt = conn.prepare(&format!(
+            "SELECT f.path, s.start_byte, f.sha256, s.language, sf.struct_hash, sf.token_len,
+                    sf.token_bag, s.id
+               FROM symbol_fingerprints sf
+               JOIN symbols s ON s.id = sf.symbol_id
+               JOIN files f ON f.id = s.file_id
+              WHERE sf.normalizer_kind = 'baseline' AND sf.normalizer_version = ?1
+                AND f.generated = 0 AND s.language = ?2
+                AND (f.path, s.start_byte) IN (VALUES {})",
+            tuples.join(", ")
+        ))?;
+        let mut values: Vec<Value> = Vec::with_capacity(2 + 2 * chunk.len());
+        values.push(Value::Integer(NORM_VERSION));
+        values.push(Value::Text(language.to_string()));
+        for (path, start_byte) in chunk {
+            values.push(Value::Text(path.clone()));
+            values.push(Value::Integer(*start_byte));
+        }
+        let rows = stmt.query_map(params_from_iter(values), |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, i64>(1)?,
+                r.get::<_, String>(2)?,
+                r.get::<_, String>(3)?,
+                r.get::<_, String>(4)?,
+                r.get::<_, i64>(5)?,
+                r.get::<_, Option<Vec<u8>>>(6)?,
+                r.get::<_, i64>(7)?,
+            ))
+        })?;
+        for row in rows {
+            let (path, start_byte, live_sha, lang, struct_hash, token_len, blob, symbol_id) = row?;
+            if anchor_sha.get(&(path.clone(), start_byte)).is_none_or(|s| *s != live_sha) {
+                continue; // the anchor's build-time sha must still be the current sha
+            }
+            let Some(blob) = blob else { continue };
+            let Some(bag_pairs) = crate::index::clones::bag_blob::decode_token_bag(&blob) else {
+                continue;
+            };
+            let tokens = bag_pairs
+                .into_iter()
+                .map(|(token_hash, freq)| super::substrate::TokenPosting {
+                    token_hash,
+                    freq,
+                    // df is irrelevant for the VERIFY side (overlap ignores it); DF_FALLBACK
+                    // keeps the struct well-formed without loading the df map per candidate.
+                    coalesced_df: super::substrate::DF_FALLBACK,
+                })
+                .collect();
+            out.push((
+                SymbolBag { symbol_id, language: lang, struct_hash, token_len, tokens },
+                (path, start_byte, live_sha),
+            ));
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::precompute::tests::{clone_fixture_config, edge_keys};
+    use crate::index::query_api::clones::precompute::CloneEdgeOptions;
+
+    /// One incremental index over the fixture root (the watcher's discover path — works without
+    /// git), returning a fresh handle.
+    fn reindex(config: &crate::Config) -> crate::IndexDatabase {
+        let (db, _changed) = crate::IndexDatabase::index_discover_reporting(config).unwrap();
+        db
+    }
+
+    fn force_rebuild_edges(db: &crate::IndexDatabase) -> Vec<(String, i64, String, i64)> {
+        let report = db
+            .reconcile_clone_edges_pass(&CloneEdgeOptions { force: true, ..Default::default() })
+            .unwrap();
+        assert_eq!(report.status, "Complete", "forced rebuild runs to completion");
+        edge_keys(db)
+    }
+
+    /// THE differential pin: after every delta, the maintained edge set equals what a from-scratch
+    /// generation build produces at the same content (same frozen df epoch). Exercises add, edit,
+    /// delete, and COMPOUND deltas (two deltas with no intermediate rebuild).
+    #[test]
+    fn clone_graph_delta_matches_a_full_rebuild_over_an_edit_sequence() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let config = clone_fixture_config("delta-differential");
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
+        drop(db);
+
+        let steps: &[(&str, Option<&str>)] = &[
+            // Add a near-clone pair member + a unique function.
+            (
+                "src/c.rs",
+                Some(
+                    "pub fn load_invoice(db: Db) -> i32 { let v = db.get(30); validate(v); v + 1 \
+                     }\npub fn distinct_worker(n: u64) -> u64 { n.rotate_left(3) ^ 0x0defaced }\n",
+                ),
+            ),
+            // Edit an existing file: append another member of the tally family.
+            (
+                "src/a.rs",
+                Some(
+                    "pub fn load_user(db: Db) -> i32 { let u = db.get(10); validate(u); u + 1 \
+                     }\npub fn compute_totals(items: Vec<i64>) -> i64 { let mut s = 0; for it in \
+                     items { s += it * 2; } s + 1 }\npub fn sum_figures(rows: Vec<i64>) -> i64 { \
+                     let mut f = 0; for r in rows { f += r * 2; } f + 1 }\n",
+                ),
+            ),
+            // Delete a file that carries clone-family members.
+            ("src/b.rs", None),
+        ];
+        for (path, content) in steps {
+            let target = config.root.join(path);
+            match content {
+                Some(text) => std::fs::write(&target, text).unwrap(),
+                None => std::fs::remove_file(&target).unwrap(),
+            }
+            let db = reindex(&config);
+            let report = db.apply_clone_graph_delta(64).unwrap();
+            assert_eq!(report.status, "Applied", "delta applies for {path}: {report:?}");
+            let delta_edges = edge_keys(&db);
+            let rebuilt_edges = force_rebuild_edges(&db);
+            assert_eq!(
+                delta_edges, rebuilt_edges,
+                "delta-maintained edges equal a from-scratch rebuild after touching {path}"
+            );
+        }
+
+        // COMPOUND: two deltas back-to-back with no intermediate rebuild, compared once at the
+        // end — pins that parity is maintained inductively, not just from a fresh baseline.
+        std::fs::write(
+            config.root.join("src/d.rs"),
+            "pub fn load_invoice(db: Db) -> i32 { let v = db.get(30); validate(v); v + 1 }\n",
+        )
+        .unwrap();
+        let db = reindex(&config);
+        assert_eq!(db.apply_clone_graph_delta(64).unwrap().status, "Applied");
+        drop(db);
+        std::fs::write(
+            config.root.join("src/c.rs"),
+            "pub fn load_invoice(db: Db) -> i32 { let v = db.get(30); validate(v); v + 1 }\npub \
+             fn distinct_worker(n: u64) -> u64 { n.rotate_left(4) ^ 0x0badf00d }\n",
+        )
+        .unwrap();
+        let db = reindex(&config);
+        assert_eq!(db.apply_clone_graph_delta(64).unwrap().status, "Applied");
+        let delta_edges = edge_keys(&db);
+        let rebuilt_edges = force_rebuild_edges(&db);
+        assert_eq!(delta_edges, rebuilt_edges, "compound deltas stay parity-equal");
+    }
+
+    /// A current generation is a cheap no-op — and a SECOND delta right after an applied one must
+    /// also be a no-op (idempotence at the write level).
+    #[test]
+    fn clone_graph_delta_is_noop_when_current() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let config = clone_fixture_config("delta-noop");
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
+        assert_eq!(db.apply_clone_graph_delta(64).unwrap().status, "Noop");
+        drop(db);
+
+        std::fs::write(
+            config.root.join("src/e.rs"),
+            "pub fn delta_probe(q: i64) -> i64 { q * 7 + 5 }\n",
+        )
+        .unwrap();
+        let db = reindex(&config);
+        let applied = db.apply_clone_graph_delta(64).unwrap();
+        assert_eq!(applied.status, "Applied");
+        assert_eq!(applied.files_changed, 1, "exactly the touched file: {applied:?}");
+        let again = db.apply_clone_graph_delta(64).unwrap();
+        assert_eq!(again.status, "Noop", "an applied delta leaves nothing owed");
+        assert_eq!(again.edges_added + again.edges_removed, 0);
+    }
+
+    /// Without a live Complete generation there is nothing to patch — the caller must use the
+    /// full-rebuild path.
+    #[test]
+    fn clone_graph_delta_is_not_eligible_without_a_live_generation() {
+        let config = clone_fixture_config("delta-no-gen");
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        let report = db.apply_clone_graph_delta(64).unwrap();
+        assert_eq!(report.status, "NotEligible", "{report:?}");
+    }
+
+    /// A delta larger than `max_files` escalates without writing anything — a huge delta (branch
+    /// switch) is cheaper to rebuild than to patch file-by-file.
+    #[test]
+    fn clone_graph_delta_escalates_when_too_many_files_changed() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let config = clone_fixture_config("delta-escalate");
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
+        let edges_before = edge_keys(&db);
+        drop(db);
+
+        std::fs::write(
+            config.root.join("src/f.rs"),
+            "pub fn escalate_probe(q: i64) -> i64 { q * 9 + 2 }\n",
+        )
+        .unwrap();
+        let db = reindex(&config);
+        let report = db.apply_clone_graph_delta(0).unwrap();
+        assert_eq!(report.status, "Escalate", "{report:?}");
+        assert_eq!(edge_keys(&db), edges_before, "an escalated delta writes nothing");
+    }
+
+    /// The PERSISTED graph does not apply the live path's #271 hot-token cap (the build walks
+    /// every sub-block token; the cap belongs to `sub_block_candidate_pairs` / the RAM fallback
+    /// only) — so neither may the delta. A stable-hot shared token (postings above the cap before
+    /// AND after the delta) must still re-emit the changed file's verified edges, or the delta
+    /// silently under-populates the graph a full rebuild would keep.
+    #[test]
+    fn delta_keeps_hot_token_edges_the_build_would_emit() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let config = clone_fixture_config("delta-hot-token");
+        // A sub-block-only near-clone pair: same token bag family, DIFFERENT structure (the extra
+        // trailing statement), so no struct-hash edge can mask a dropped sub-block edge.
+        std::fs::write(
+            config.root.join("src/a.rs"),
+            "pub fn alpha_total(vals: Vec<i64>) -> i64 { let mut s = 0; for v in vals { s += v * \
+             3; } s - 2 }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            config.root.join("src/b.rs"),
+            "pub fn omega_total(vals: Vec<i64>) -> i64 { let mut s = 0; for v in vals { s += v * \
+             3; } let z = s; z - 2 }\n",
+        )
+        .unwrap();
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
+        let conn = db.storage.connection();
+        let sub_block_edges: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM clone_edges WHERE edge_source = 'sub_block'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(sub_block_edges > 0, "the pair must be sub-block-discovered, not struct-exact");
+
+        // Make EVERY shared discovery token stable-hot: inflate its postings past the cap with
+        // rows anchored at the UNTOUCHED file's current sha (so they are neither stale nor part
+        // of the delta set) at start_bytes that resolve to no symbol (hydration drops them).
+        let b_sha: String = conn
+            .query_row("SELECT sha256 FROM files WHERE path = 'src/b.rs'", [], |r| r.get(0))
+            .unwrap();
+        let generation: i64 = conn
+            .query_row(
+                "SELECT MAX(generation) FROM clone_graph_generations WHERE status = 'Complete'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let shared_tokens: Vec<i64> = {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT DISTINCT p1.token_hash FROM clone_subblock_postings p1
+                      WHERE p1.path = 'src/a.rs'
+                        AND EXISTS (SELECT 1 FROM clone_subblock_postings p2
+                                     WHERE p2.token_hash = p1.token_hash AND p2.path = 'src/b.rs')",
+                )
+                .unwrap();
+            stmt.query_map([], |r| r.get(0)).unwrap().map(Result::unwrap).collect()
+        };
+        assert!(!shared_tokens.is_empty(), "the near-clone pair shares discovery tokens");
+        for token in &shared_tokens {
+            for i in 0..(super::super::substrate::HOT_TOKEN_POSTINGS_CAP as i64 + 8) {
+                conn.execute(
+                    "INSERT OR IGNORE INTO clone_subblock_postings
+                        (build_generation, token_hash, path, start_byte, file_sha)
+                     VALUES (?1, ?2, 'src/b.rs', ?3, ?4)",
+                    rusqlite::params![generation, token, 1_000_000 + i, b_sha],
+                )
+                .unwrap();
+            }
+        }
+        drop(db);
+
+        // Edit the OTHER file trivially (append an unrelated fn): its symbols recompute through
+        // the delta, and their edges to b.rs must survive despite every shared token being hot.
+        let mut text = std::fs::read_to_string(config.root.join("src/a.rs")).unwrap();
+        text.push_str("pub fn unrelated_probe(q: i64) -> i64 { q ^ 3 }\n");
+        std::fs::write(config.root.join("src/a.rs"), text).unwrap();
+        let db = reindex(&config);
+        let report = db.apply_clone_graph_delta(64).unwrap();
+        assert_eq!(report.status, "Applied", "{report:?}");
+        let delta_edges = edge_keys(&db);
+        let rebuilt_edges = force_rebuild_edges(&db);
+        assert_eq!(
+            delta_edges, rebuilt_edges,
+            "stable-hot shared tokens must not drop edges the build would emit"
+        );
+    }
+
+    /// The watcher tail applies the delta IN PLACE on the same pass that indexed the edit — no
+    /// quiet window, no generation churn. The #472 gate now guards only the full-rebuild path.
+    #[test]
+    fn maintenance_pass_applies_the_delta_in_place() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let config = clone_fixture_config("delta-tail-inplace");
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        let built = db.precompute_clone_graph(None).unwrap();
+        assert_eq!(built.status, "Complete");
+        drop(db);
+
+        std::fs::write(
+            config.root.join("src/h.rs"),
+            "pub fn load_receipt(db: Db) -> i32 { let r = db.get(40); validate(r); r + 1 }\n",
+        )
+        .unwrap();
+        crate::watch::maintenance_pass(&config, false).unwrap();
+
+        let db = crate::IndexDatabase::open_config(&config).unwrap();
+        assert!(
+            !db.pending_clone_graph().unwrap(),
+            "the SAME pass that indexed the edit settled the graph via the in-place delta"
+        );
+        let (generations, live_generation, absorbed): (i64, i64, i64) = db
+            .storage
+            .connection()
+            .query_row(
+                "SELECT COUNT(*), MAX(generation), MAX(delta_files_applied)
+                   FROM clone_graph_generations WHERE status = 'Complete'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(generations, 1);
+        assert_eq!(
+            live_generation, built.generation,
+            "patched in place — no generation was discarded or rebuilt"
+        );
+        assert_eq!(absorbed, 1, "the drift counter absorbed the edited file");
+    }
+
+    /// Accumulated delta drift past [`CLONE_GRAPH_DRIFT_REBUILD_FILES`] owes a df-epoch refresh:
+    /// the graph keeps serving (fresh via deltas), and the full rebuild rides the #472 quiet
+    /// window — deferred while edits land, executed on the first quiet-elapsed pass (the
+    /// reconcile pass must NOT skip-as-current a drifted generation).
+    #[test]
+    fn drift_past_the_limit_schedules_a_quiet_gated_full_rebuild() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let config = clone_fixture_config("delta-drift-rebuild");
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        let built = db.precompute_clone_graph(None).unwrap();
+        assert_eq!(built.status, "Complete");
+        db.storage
+            .connection()
+            .execute(
+                "UPDATE clone_graph_generations SET delta_files_applied = ?1",
+                rusqlite::params![super::CLONE_GRAPH_DRIFT_REBUILD_FILES],
+            )
+            .unwrap();
+        drop(db);
+
+        // A content pass inside the quiet window: the delta settles freshness in place; the
+        // drift-owed FULL rebuild stays deferred.
+        std::fs::write(
+            config.root.join("src/i.rs"),
+            "pub fn drift_probe(q: i64) -> i64 { q * 11 - 6 }\n",
+        )
+        .unwrap();
+        crate::watch::maintenance_pass(&config, false).unwrap();
+        let db = crate::IndexDatabase::open_config(&config).unwrap();
+        let live: i64 = db
+            .storage
+            .connection()
+            .query_row(
+                "SELECT MAX(generation) FROM clone_graph_generations WHERE status = 'Complete'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(live, built.generation, "drift rebuild deferred inside the quiet window");
+
+        // Quiet elapses (backdate the armed candidate): the next idle pass runs the full rebuild
+        // — a NEW generation with the drift counter reset.
+        db.storage
+            .connection()
+            .execute(
+                "UPDATE repo_meta SET value = '1' WHERE key = \
+                 'clone_graph_quiet_candidate_since_ms'",
+                [],
+            )
+            .unwrap();
+        drop(db);
+        crate::watch::maintenance_pass(&config, false).unwrap();
+        let db = crate::IndexDatabase::open_config(&config).unwrap();
+        let (live, absorbed): (i64, i64) = db
+            .storage
+            .connection()
+            .query_row(
+                "SELECT MAX(generation), MAX(delta_files_applied)
+                   FROM clone_graph_generations WHERE status = 'Complete'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert!(live > built.generation, "the quiet-elapsed pass ran the drift full rebuild");
+        assert_eq!(absorbed, 0, "the fresh generation starts with zero absorbed deltas");
+    }
+
+    /// The generation bookkeeping: an applied delta bumps `source_revision` to current (making
+    /// the write-time postings fast path eligible again) and counts the absorbed files in
+    /// `delta_files_applied` (the df-drift signal for scheduling the next full rebuild).
+    #[test]
+    fn clone_graph_delta_updates_generation_bookkeeping() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let config = clone_fixture_config("delta-bookkeeping");
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
+        drop(db);
+
+        std::fs::write(
+            config.root.join("src/g.rs"),
+            "pub fn bookkeeping_probe(q: i64) -> i64 { q * 3 - 4 }\n",
+        )
+        .unwrap();
+        let db = reindex(&config);
+        assert!(
+            db.clone_check_indexed_generation().unwrap().is_none(),
+            "stale revision → write-time fast path ineligible before the delta"
+        );
+        assert_eq!(db.apply_clone_graph_delta(64).unwrap().status, "Applied");
+        assert!(
+            db.clone_check_indexed_generation().unwrap().is_some(),
+            "the applied delta restores exact freshness (source_revision == content_revision)"
+        );
+        let applied: i64 = db
+            .storage
+            .connection()
+            .query_row(
+                "SELECT delta_files_applied FROM clone_graph_generations WHERE status = 'Complete'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(applied, 1, "the drift counter absorbed one file");
+        assert!(!db.pending_clone_graph().unwrap(), "the graph reads as current after the delta");
+    }
+}

--- a/crates/rag-rat-core/src/index/query_api/clones/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/mod.rs
@@ -52,6 +52,11 @@ pub(crate) mod precompute;
 /// module so it can reuse this module's private candidate-gen primitives.
 pub(crate) mod of_text;
 
+/// Incremental delta maintenance of the persisted clone graph (#473): patch the live generation
+/// in place for a small set of changed files instead of a full `precompute` rebuild — a child
+/// module so it shares the exact candidate-gen primitives and `precompute`'s write discipline.
+pub(crate) mod delta;
+
 #[cfg(test)]
 mod tests;
 

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -373,6 +373,22 @@ impl IndexDatabase {
         // generation toward a different revision (a reindex landed since it started) is
         // discarded — its symbol-id cursor is meaningless against the new symbol rows.
         let building = open_building_generation(conn, &source_revision)?;
+        // A FRESH build (cursor 0 ⇒ no symbol walked ⇒ zero postings staged for this generation)
+        // moves the df EPOCH to now (#477 review): the #473 drift rebuild exists to restore
+        // sub-block selectivity, so a full build that kept the old frozen df would reset the
+        // drift counter without delivering the refresh it promises — and more generally, every
+        // fresh generation's postings must be ordered by the df of ITS OWN build. The refresh
+        // invalidates every generation's postings flag (df moved), including the row just opened,
+        // whose (empty) postings set trivially matches the new epoch — re-mark it postings-aware.
+        // A RESUMED partial (cursor > 0) must NOT refresh: its persisted postings are ordered by
+        // the epoch its build started under.
+        if building.cursor_symbol_id == 0 {
+            self.refresh_clone_token_df()?;
+            conn.execute(
+                "UPDATE clone_graph_generations SET postings_written = 1 WHERE generation = ?1",
+                params![building.generation],
+            )?;
+        }
 
         // Load the scoped baseline bags + the content anchors for every scoped symbol, and build
         // the struct-hash buckets + sub-block inverted index in RAM (rebuilt each pass —
@@ -1398,6 +1414,30 @@ pub(super) mod tests {
     fn clone_graph_quiet_gate_zero_window_fires_immediately() {
         let db = build_clone_fixture("quiet-gate-zero");
         assert!(db.clone_graph_rebuild_due_at(1_000, 0, true).unwrap());
+    }
+
+    /// The freeze's bootstrap exception (`refresh_clone_token_df_if_unseeded`): an UNSEEDED repo
+    /// (no df rows) seeds the epoch; a seeded repo is left untouched — the frozen epoch must not
+    /// move on the incremental finalize that calls this.
+    #[test]
+    fn refresh_if_unseeded_seeds_once_then_preserves_the_epoch() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let db = build_clone_fixture("df-freeze-bootstrap");
+        let df_count = |db: &crate::IndexDatabase| -> i64 {
+            db.storage
+                .connection()
+                .query_row("SELECT COUNT(*) FROM clone_token_df", [], |r| r.get(0))
+                .unwrap()
+        };
+        // Simulate the pre-epoch state (a DB whose df was never seeded for this repo).
+        db.storage.connection().execute("DELETE FROM clone_token_df", []).unwrap();
+        db.refresh_clone_token_df_if_unseeded().unwrap();
+        let seeded = df_count(&db);
+        assert!(seeded > 0, "an unseeded repo gets its epoch seeded");
+
+        // Seeded → the guard is a strict no-op (the frozen epoch must not move).
+        db.refresh_clone_token_df_if_unseeded().unwrap();
+        assert_eq!(df_count(&db), seeded, "a seeded repo's epoch is preserved");
     }
 
     /// The df EPOCH FREEZE (#473): incremental passes must not move `clone_token_df` — the

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -71,9 +71,9 @@ pub struct CloneEdgeReport {
 }
 
 /// Reindex-stable identity of a symbol endpoint: `(path, start_byte, file_sha)`.
-type Anchor = (String, i64, String);
+pub(super) type Anchor = (String, i64, String);
 
-struct EdgeRow {
+pub(super) struct EdgeRow {
     a_path: String,
     a_start_byte: i64,
     a_file_sha: String,
@@ -91,15 +91,15 @@ struct EdgeRow {
 /// `sub_block_tokens` set. Each `PostingGroup` expands to one `clone_subblock_postings` row per
 /// token at flush time. Grouping is deliberate — it clones the `(path, file_sha)` strings ONCE per
 /// symbol instead of once per token (a large function has hundreds of sub-block tokens).
-struct PostingGroup {
-    anchor: Anchor,
-    tokens: Vec<i64>,
+pub(super) struct PostingGroup {
+    pub(super) anchor: Anchor,
+    pub(super) tokens: Vec<i64>,
 }
 
-struct GenerationRow {
-    generation: i64,
-    source_revision: String,
-    normalizer_version: i64,
+pub(super) struct GenerationRow {
+    pub(super) generation: i64,
+    pub(super) source_revision: String,
+    pub(super) normalizer_version: i64,
     cursor_symbol_id: i64,
     edges_written: u64,
     /// Whether this generation is POSTINGS-AWARE (#296 phase 2): its `clone_subblock_postings` are
@@ -109,8 +109,19 @@ struct GenerationRow {
     /// cursor, a *Complete* postings-aware generation is fully populated — so the live-generation
     /// completeness gate (`pending_clone_graph` / the Phase-0 skip) reads this as "postings
     /// complete", and a `Building` one reads it as "resumable without a postings gap" (review R2).
-    postings_written: bool,
+    pub(super) postings_written: bool,
+    /// Files absorbed by in-place deltas since this generation's full build (#473) — the df-drift
+    /// signal: past [`CLONE_GRAPH_DRIFT_REBUILD_FILES`] the quiet gate schedules a full rebuild to
+    /// restore sub-block selectivity (df is frozen at the build's epoch, so long-lived generations
+    /// slowly lose candidate-pruning efficiency — never correctness).
+    pub(super) delta_files_applied: i64,
 }
+
+/// How many delta-absorbed files a live generation tolerates before the background tail owes a
+/// FULL rebuild (df epoch refresh + fresh postings). Drift degrades candidate-generation
+/// efficiency only — edges stay exact — so this is a performance valve, sized generously: a
+/// typical editing session touches far fewer files between natural quiet windows.
+pub(super) const CLONE_GRAPH_DRIFT_REBUILD_FILES: i64 = 256;
 
 impl IndexDatabase {
     /// Precompute the clone-edge graph to completion under the caller's write lock (loops resumable
@@ -191,6 +202,12 @@ impl IndexDatabase {
     }
 
     /// [`Self::clone_graph_rebuild_due`] with the clock injected (tests).
+    ///
+    /// "Owed" here means a FULL rebuild: the graph is stale in a way the #473 delta can't settle
+    /// (absent / normalizer bump / postings gap), OR the live generation has absorbed enough
+    /// delta files ([`CLONE_GRAPH_DRIFT_REBUILD_FILES`]) that its frozen df epoch owes a refresh.
+    /// A merely revision-stale-but-delta-eligible graph also arms here — if the delta settles it
+    /// first, the next probe sees it current and disarms.
     pub(crate) fn clone_graph_rebuild_due_at(
         &self,
         now_ms: i64,
@@ -202,7 +219,12 @@ impl IndexDatabase {
             return Ok(false);
         }
         let revision = self.content_revision()?;
-        if !self.clone_graph_stale_against(&revision)? {
+        let drifted = {
+            let conn = self.storage.connection();
+            live_generation_row(conn)?
+                .is_some_and(|live| live.delta_files_applied >= CLONE_GRAPH_DRIFT_REBUILD_FILES)
+        };
+        if !self.clone_graph_stale_against(&revision)? && !drifted {
             if candidate.is_some() {
                 self.clear_clone_graph_quiet_candidate()?;
             }
@@ -331,6 +353,10 @@ impl IndexDatabase {
             // skip forever with an empty `clone_subblock_postings` (review R2). A postings-less
             // live generation falls through and rebuilds a postings-full one.
             && live.postings_written
+            // #473: a generation that has absorbed enough in-place delta files owes a df-epoch
+            // refresh — it is FRESH (deltas keep `source_revision` current) but must not
+            // skip-as-current, or the drift rebuild the quiet gate scheduled would no-op forever.
+            && live.delta_files_applied < CLONE_GRAPH_DRIFT_REBUILD_FILES
         {
             return Ok(CloneEdgeReport {
                 status: "Current".to_string(),
@@ -694,7 +720,7 @@ fn resolve_symbol_anchors(conn: &Connection) -> anyhow::Result<BTreeMap<i64, Anc
 /// Build a content-anchored edge with endpoints in canonical `(path, start_byte)` order (the PK
 /// order). `overlap`/`similarity` are symmetric; the per-endpoint `token_len`s follow the chosen
 /// orientation.
-fn make_edge(
+pub(super) fn make_edge(
     s_anchor: &Anchor,
     s_token_len: i64,
     t_anchor: &Anchor,
@@ -740,44 +766,8 @@ fn flush_batch(
 ) -> anyhow::Result<u64> {
     conn.execute_batch("BEGIN IMMEDIATE")?;
     let result = (|| -> anyhow::Result<u64> {
-        let mut inserted = 0u64;
-        {
-            let mut stmt = conn.prepare_cached(
-                "INSERT OR IGNORE INTO clone_edges
-                    (build_generation, a_path, a_start_byte, a_file_sha, b_path, b_start_byte,
-                     b_file_sha, overlap, a_token_len, b_token_len, similarity, edge_source)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
-            )?;
-            for e in batch.iter() {
-                inserted += stmt.execute(params![
-                    generation,
-                    e.a_path,
-                    e.a_start_byte,
-                    e.a_file_sha,
-                    e.b_path,
-                    e.b_start_byte,
-                    e.b_file_sha,
-                    e.overlap,
-                    e.a_token_len,
-                    e.b_token_len,
-                    e.similarity,
-                    e.edge_source,
-                ])? as u64;
-            }
-        }
-        {
-            let mut stmt = conn.prepare_cached(
-                "INSERT OR IGNORE INTO clone_subblock_postings
-                    (build_generation, token_hash, path, start_byte, file_sha)
-                 VALUES (?1, ?2, ?3, ?4, ?5)",
-            )?;
-            for g in postings.iter() {
-                let (path, start_byte, file_sha) = &g.anchor;
-                for &token_hash in &g.tokens {
-                    stmt.execute(params![generation, token_hash, path, start_byte, file_sha])?;
-                }
-            }
-        }
+        let inserted = insert_edge_rows(conn, generation, batch)?;
+        insert_posting_groups(conn, generation, postings)?;
         conn.execute(
             "UPDATE clone_graph_generations SET cursor_symbol_id = ?1, edges_written = ?2
               WHERE generation = ?3",
@@ -799,19 +789,75 @@ fn flush_batch(
     }
 }
 
+/// Insert edge rows for `generation` with the shared idempotent write discipline (`INSERT OR
+/// IGNORE` on the content-key PK). Returns the rows actually inserted. Shared by `flush_batch`
+/// (the full build) and the delta pass so the write shape lives in exactly one place. Runs inside
+/// the CALLER's transaction.
+pub(super) fn insert_edge_rows(
+    conn: &Connection,
+    generation: i64,
+    batch: &[EdgeRow],
+) -> anyhow::Result<u64> {
+    let mut inserted = 0u64;
+    let mut stmt = conn.prepare_cached(
+        "INSERT OR IGNORE INTO clone_edges
+            (build_generation, a_path, a_start_byte, a_file_sha, b_path, b_start_byte,
+             b_file_sha, overlap, a_token_len, b_token_len, similarity, edge_source)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+    )?;
+    for e in batch {
+        inserted += stmt.execute(params![
+            generation,
+            e.a_path,
+            e.a_start_byte,
+            e.a_file_sha,
+            e.b_path,
+            e.b_start_byte,
+            e.b_file_sha,
+            e.overlap,
+            e.a_token_len,
+            e.b_token_len,
+            e.similarity,
+            e.edge_source,
+        ])? as u64;
+    }
+    Ok(inserted)
+}
+
+/// Insert every posting group's per-token rows for `generation` (idempotent, content-key PK).
+/// Shared by `flush_batch` and the delta pass; runs inside the CALLER's transaction.
+pub(super) fn insert_posting_groups(
+    conn: &Connection,
+    generation: i64,
+    postings: &[PostingGroup],
+) -> anyhow::Result<()> {
+    let mut stmt = conn.prepare_cached(
+        "INSERT OR IGNORE INTO clone_subblock_postings
+            (build_generation, token_hash, path, start_byte, file_sha)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+    )?;
+    for g in postings {
+        let (path, start_byte, file_sha) = &g.anchor;
+        for &token_hash in &g.tokens {
+            stmt.execute(params![generation, token_hash, path, start_byte, file_sha])?;
+        }
+    }
+    Ok(())
+}
+
 /// The ` AND clone_graph_generations.repo_id = '…'` predicate for the per-repo generation SWEEPS,
 /// or `""` on the pre-A5 schema (the generations table is still repo-global). The generation
 /// INTEGER stays globally unique (allocated `MAX(generation)+1` over ALL repos), so the transitive
 /// `clone_edges` / `clone_subblock_postings` are scoped for free by `build_generation`; only the
 /// generation lifecycle sweeps (allocate/build/complete/invalidate) filter `repo_id` so a repo's
 /// precompute never touches a sibling's generations. See `schema::periphery_repo_scope`.
-fn clone_generation_scope_clause(conn: &Connection) -> anyhow::Result<String> {
+pub(super) fn clone_generation_scope_clause(conn: &Connection) -> anyhow::Result<String> {
     let scope = crate::index::schema::periphery_repo_scope(conn, "clone_graph_generations")?;
     Ok(crate::index::schema::periphery_repo_scope_clause(&scope, "clone_graph_generations"))
 }
 
 /// The live (Complete) generation row, if one is published.
-fn live_generation_row(conn: &Connection) -> anyhow::Result<Option<GenerationRow>> {
+pub(super) fn live_generation_row(conn: &Connection) -> anyhow::Result<Option<GenerationRow>> {
     let repo_id = crate::index::schema::active_repo_id(conn)?;
     let Some(live) = crate::index::repo_meta(conn, &repo_id, "clone_graph_live_generation")? else {
         return Ok(None);
@@ -841,7 +887,7 @@ fn open_building_generation(
         .query_row(
             &format!(
                 "SELECT generation, source_revision, normalizer_version, cursor_symbol_id, \
-                 edges_written, postings_written
+                 edges_written, postings_written, delta_files_applied
                    FROM clone_graph_generations WHERE status = 'Building'{repo_clause}
                   ORDER BY generation DESC LIMIT 1"
             ),
@@ -894,6 +940,7 @@ fn open_building_generation(
         cursor_symbol_id: 0,
         edges_written: 0,
         postings_written: true,
+        delta_files_applied: 0,
     })
 }
 
@@ -901,7 +948,7 @@ fn read_generation(conn: &Connection, generation: i64) -> anyhow::Result<Option<
     Ok(conn
         .query_row(
             "SELECT generation, source_revision, normalizer_version, cursor_symbol_id, \
-             edges_written, postings_written
+             edges_written, postings_written, delta_files_applied
                FROM clone_graph_generations WHERE generation = ?1",
             params![generation],
             map_generation_row,
@@ -917,11 +964,12 @@ fn map_generation_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<GenerationRow
         cursor_symbol_id: row.get(3)?,
         edges_written: row.get::<_, i64>(4)? as u64,
         postings_written: row.get::<_, i64>(5)? != 0,
+        delta_files_applied: row.get(6)?,
     })
 }
 
 #[cfg(test)]
-mod tests {
+pub(super) mod tests {
     use super::*;
 
     /// The config for a fixed two-file fixture with two renamed-clone groups
@@ -929,7 +977,7 @@ mod tests {
     /// → identical content-key edges, so two builds are directly comparable. Split out so a
     /// test can `rebuild` the SAME config twice (identical content) to exercise the
     /// full-rebuild df refresh.
-    fn clone_fixture_config(tag: &str) -> crate::Config {
+    pub(in super::super) fn clone_fixture_config(tag: &str) -> crate::Config {
         let root = std::env::temp_dir().join(format!(
             "rag-rat-precompute-{tag}-{}-{}",
             std::process::id(),
@@ -983,7 +1031,9 @@ mod tests {
 
     /// The content-key set of the live-or-only generation's edges, sorted — the build-stable
     /// identity of the persisted graph (symbol_id-independent).
-    fn edge_keys(db: &crate::IndexDatabase) -> Vec<(String, i64, String, i64)> {
+    pub(in super::super) fn edge_keys(
+        db: &crate::IndexDatabase,
+    ) -> Vec<(String, i64, String, i64)> {
         let conn = db.storage.connection();
         let mut stmt = conn
             .prepare(
@@ -1348,6 +1398,66 @@ mod tests {
     fn clone_graph_quiet_gate_zero_window_fires_immediately() {
         let db = build_clone_fixture("quiet-gate-zero");
         assert!(db.clone_graph_rebuild_due_at(1_000, 0, true).unwrap());
+    }
+
+    /// The df EPOCH FREEZE (#473): incremental passes must not move `clone_token_df` — the
+    /// persisted postings order sub-block tokens by df AS OF their build, so a moving df would
+    /// desync them from every later sub-block computation (which is why the old per-pass refresh
+    /// had to invalidate the postings each time). After the freeze, a content change through a
+    /// maintenance pass leaves the df table byte-identical AND the live generation's
+    /// `postings_written` intact; df moves only at a FULL rebuild.
+    #[test]
+    fn incremental_index_keeps_the_df_epoch_frozen() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let config = clone_fixture_config("df-freeze-epoch");
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
+        let df_rows = |db: &crate::IndexDatabase| -> Vec<(i64, i64)> {
+            let conn = db.storage.connection();
+            let mut stmt = conn
+                .prepare("SELECT token_hash, df FROM clone_token_df ORDER BY token_hash")
+                .unwrap();
+            stmt.query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, i64>(1)?)))
+                .unwrap()
+                .map(Result::unwrap)
+                .collect()
+        };
+        let postings_written = |db: &crate::IndexDatabase| -> i64 {
+            db.storage
+                .connection()
+                .query_row(
+                    "SELECT postings_written FROM clone_graph_generations WHERE status = \
+                     'Complete'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap()
+        };
+        let epoch = df_rows(&db);
+        assert!(!epoch.is_empty(), "the full rebuild seeded the df epoch");
+        assert_eq!(postings_written(&db), 1, "the precompute published postings");
+        drop(db);
+
+        // A new file with brand-new tokens through the watcher/maintenance incremental path.
+        std::fs::write(
+            config.root.join("src/frozen_probe.rs"),
+            "pub fn frozen_epoch_probe(zx: u64) -> u64 { zx.rotate_left(9) ^ 0xfeed_beef }\n",
+        )
+        .unwrap();
+        crate::watch::maintenance_pass(&config, false).unwrap();
+
+        let db = crate::IndexDatabase::open_config(&config).unwrap();
+        assert_eq!(
+            df_rows(&db),
+            epoch,
+            "an incremental pass must not move the df epoch (new tokens ride DF_FALLBACK until \
+             the next full rebuild)"
+        );
+        assert_eq!(
+            postings_written(&db),
+            1,
+            "and must not invalidate the live generation's postings"
+        );
     }
 
     /// End-to-end through the watcher pass (#472): a content-changing maintenance pass ARMS the

--- a/crates/rag-rat-core/src/index/query_api/clones/substrate.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/substrate.rs
@@ -126,13 +126,34 @@ pub(crate) fn candidate_pairs(conn: &Connection) -> anyhow::Result<Vec<(i64, i64
 /// so only the ACTIVE version of each file participates (SCOPED-VIEW REQUIREMENT #89). df is read
 /// via LEFT JOIN + COALESCE so a missing-df token is never dropped (design rev-4 §2).
 pub(crate) fn load_scoped_baseline_bags(conn: &Connection) -> anyhow::Result<Vec<SymbolBag>> {
+    load_scoped_baseline_bags_filtered(conn, None)
+}
+
+/// [`load_scoped_baseline_bags`] restricted to symbols whose file `path` is in `paths` — the #473
+/// delta pass's bag load. IDENTICAL corpus filters (this is the parity contract: the delta's bags
+/// must be exactly the subset of the full build's bags for those files), just with a chunked
+/// `files.path IN (…)` narrowing so a small delta never decodes the whole corpus.
+pub(crate) fn load_scoped_baseline_bags_for_paths(
+    conn: &Connection,
+    paths: &[String],
+) -> anyhow::Result<Vec<SymbolBag>> {
+    if paths.is_empty() {
+        return Ok(Vec::new());
+    }
+    load_scoped_baseline_bags_filtered(conn, Some(paths))
+}
+
+fn load_scoped_baseline_bags_filtered(
+    conn: &Connection,
+    paths: Option<&[String]>,
+) -> anyhow::Result<Vec<SymbolBag>> {
     // Load `clone_token_df` ONCE into a map (#231 R3): the token bag now lives in an opaque
     // `token_bag` BLOB, so df can no longer be a per-token SQL JOIN. Each decoded token's df is
     // looked up here in Rust and COALESCEd to the fallback sentinel — a missing-df token must NOT
     // be dropped (design rev-4 §2). Only the baseline normalizer feeds candidate recall.
     // Post-A5 df is per-repo (its PK carries `repo_id`), so scope the read to the active repo —
-    // `{df_repo_clause}` is empty pre-A5. The writer (`refresh_clone_token_df` / the incremental
-    // bump) stamps the same repo, so the two agree.
+    // `{df_repo_clause}` is empty pre-A5. The writer (`refresh_clone_token_df`, full-rebuild /
+    // first-index only under the #473 df epoch freeze) stamps the same repo, so the two agree.
     let df_scope = crate::index::schema::periphery_repo_scope(conn, "clone_token_df")?;
     let df_repo_clause =
         crate::index::schema::periphery_repo_scope_clause(&df_scope, "clone_token_df");
@@ -150,53 +171,75 @@ pub(crate) fn load_scoped_baseline_bags(conn: &Connection) -> anyhow::Result<Vec
     // (`prep.rs` / `file_index.rs` gate the compute on `!file_is_generated`), so this filter is now
     // defense-in-depth: it still guards a file that flipped to `generated = 1` AFTER its
     // fingerprints were written (a target reclassification without a reindex of that file).
-    // `token_len` comes from the COLUMN (R3); the bag itself is decoded from the BLOB.
-    let mut fp_stmt = conn.prepare(
-        "SELECT sf.symbol_id, symbols.language, sf.struct_hash, sf.token_len, sf.token_bag
-         FROM symbol_fingerprints sf
-         JOIN symbols ON symbols.id = sf.symbol_id
-         JOIN files ON files.id = symbols.file_id
-         WHERE sf.normalizer_kind = 'baseline'
-           AND sf.normalizer_version = ?1
-           AND files.generated = 0",
-    )?;
+    // `token_len` comes from the COLUMN (R3); the bag itself is decoded from the BLOB. The
+    // optional `paths` narrowing is chunked under the bind-variable cap; `None` runs the single
+    // unfiltered pass.
+    const PATH_CHUNK: usize = 400;
+    let path_chunks: Vec<Option<&[String]>> = match paths {
+        None => vec![None],
+        Some(paths) => paths.chunks(PATH_CHUNK).map(Some).collect(),
+    };
     let mut bags: Vec<SymbolBag> = Vec::new();
-    let mut rows = fp_stmt.query([NORM_VERSION])?;
-    while let Some(row) = rows.next()? {
-        // R4: a NULL `token_bag` (un-reindexed after the V032 migration) is a NO-BAG row — SKIP it
-        // (not an empty bag, no panic). Byte-identical recall holds only for a FULLY (re)indexed
-        // DB; clone recall is undefined for NULL-bag symbols until the post-migration
-        // reindex.
-        let Some(blob) = row.get::<_, Option<Vec<u8>>>(4)? else {
-            continue;
+    for chunk in path_chunks {
+        let (filter_clause, chunk_paths) = match chunk {
+            None => (String::new(), &[][..]),
+            Some(chunk) => {
+                let placeholders: Vec<String> =
+                    (0..chunk.len()).map(|i| format!("?{}", i + 2)).collect();
+                (format!(" AND files.path IN ({})", placeholders.join(", ")), chunk)
+            },
         };
-        let Some(bag_pairs) = crate::index::clones::bag_blob::decode_token_bag(&blob) else {
-            // A stale/corrupt blob (version mismatch / truncation) decodes to None — treat as
-            // no-bag, same as NULL. It is repopulated on the next reindex.
-            continue;
-        };
-        let tokens: Vec<TokenPosting> = bag_pairs
-            .into_iter()
-            .map(|(token_hash, freq)| TokenPosting {
-                token_hash,
-                freq,
-                coalesced_df: df_by_token.get(&token_hash).copied().unwrap_or(DF_FALLBACK),
-            })
-            .collect();
-        // The BLOB is stored token_hash-sorted (the producer's invariant), which is exactly the
-        // order `overlap`'s two-pointer merge and `sub_block_tokens` expect — so no re-sort is
-        // needed on read. Assert it in debug to catch a producer regression.
-        debug_assert!(
-            tokens.windows(2).all(|w| w[0].token_hash <= w[1].token_hash),
-            "decoded token_bag must be token_hash-sorted"
-        );
-        bags.push(SymbolBag {
-            symbol_id: row.get(0)?,
-            language: row.get(1)?,
-            struct_hash: row.get(2)?,
-            token_len: row.get(3)?,
-            tokens,
-        });
+        let mut fp_stmt = conn.prepare(&format!(
+            "SELECT sf.symbol_id, symbols.language, sf.struct_hash, sf.token_len, sf.token_bag
+             FROM symbol_fingerprints sf
+             JOIN symbols ON symbols.id = sf.symbol_id
+             JOIN files ON files.id = symbols.file_id
+             WHERE sf.normalizer_kind = 'baseline'
+               AND sf.normalizer_version = ?1
+               AND files.generated = 0{filter_clause}"
+        ))?;
+        let mut values: Vec<rusqlite::types::Value> = Vec::with_capacity(1 + chunk_paths.len());
+        values.push(rusqlite::types::Value::Integer(NORM_VERSION));
+        for path in chunk_paths {
+            values.push(rusqlite::types::Value::Text(path.clone()));
+        }
+        let mut rows = fp_stmt.query(rusqlite::params_from_iter(values))?;
+        while let Some(row) = rows.next()? {
+            // R4: a NULL `token_bag` (un-reindexed after the V032 migration) is a NO-BAG row —
+            // SKIP it (not an empty bag, no panic). Byte-identical recall holds only for a FULLY
+            // (re)indexed DB; clone recall is undefined for NULL-bag symbols until the
+            // post-migration reindex.
+            let Some(blob) = row.get::<_, Option<Vec<u8>>>(4)? else {
+                continue;
+            };
+            let Some(bag_pairs) = crate::index::clones::bag_blob::decode_token_bag(&blob) else {
+                // A stale/corrupt blob (version mismatch / truncation) decodes to None — treat as
+                // no-bag, same as NULL. It is repopulated on the next reindex.
+                continue;
+            };
+            let tokens: Vec<TokenPosting> = bag_pairs
+                .into_iter()
+                .map(|(token_hash, freq)| TokenPosting {
+                    token_hash,
+                    freq,
+                    coalesced_df: df_by_token.get(&token_hash).copied().unwrap_or(DF_FALLBACK),
+                })
+                .collect();
+            // The BLOB is stored token_hash-sorted (the producer's invariant), which is exactly
+            // the order `overlap`'s two-pointer merge and `sub_block_tokens` expect — so no
+            // re-sort is needed on read. Assert it in debug to catch a producer regression.
+            debug_assert!(
+                tokens.windows(2).all(|w| w[0].token_hash <= w[1].token_hash),
+                "decoded token_bag must be token_hash-sorted"
+            );
+            bags.push(SymbolBag {
+                symbol_id: row.get(0)?,
+                language: row.get(1)?,
+                struct_hash: row.get(2)?,
+                token_len: row.get(3)?,
+                tokens,
+            });
+        }
     }
 
     // Return bags in `symbol_id` order, matching the prior `BTreeMap<symbol_id, _>` keyset (the SQL

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -21,6 +21,7 @@ mod search;
 // the capped-class semantics by name (instead of hardcoding 50). Keeps the `clones` module
 // private so `build_class`'s reachability stays narrow (no `private_interfaces` widening of
 // `SymbolBag`).
+pub use clones::delta::{CLONE_DELTA_MAX_FILES, CloneDeltaReport};
 pub use clones::of_text::{CloneCheckInput, CloneFingerprintHealth, TextCloneMatch};
 pub use clones::precompute::CloneEdgeReport;
 pub use clones::{

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -457,6 +457,31 @@ impl IndexDatabase {
     /// for recall either way.) df feeds candidate GENERATION (the `sub_block_tokens` ordering), not
     /// just ranking. Each symbol's decoded bag has no duplicate `token_hash` (the codec invariant),
     /// so counting one increment per (symbol, token) pair equals `COUNT(DISTINCT symbol_id)`.
+    /// Seed the df epoch ONLY when this repo has no `clone_token_df` rows yet — the #473 df EPOCH
+    /// FREEZE's one exception. Incremental finalizes call this instead of the unconditional
+    /// refresh: the persisted clone-graph postings order sub-block tokens by df AS OF their build,
+    /// so a per-pass refresh would desync them (which is why `refresh_clone_token_df` must
+    /// invalidate the postings every time it runs). A FIRST standalone index has no epoch to
+    /// preserve — and no postings to invalidate — so seeding here is safe and keeps the
+    /// selectivity ordering useful from the start; afterwards df moves only at a full rebuild.
+    pub(crate) fn refresh_clone_token_df_if_unseeded(&self) -> anyhow::Result<()> {
+        let seeded = {
+            let conn = self.storage.connection();
+            let df_scope = crate::index::schema::periphery_repo_scope(conn, "clone_token_df")?;
+            let df_clause =
+                crate::index::schema::periphery_repo_scope_clause(&df_scope, "clone_token_df");
+            conn.query_row(
+                &format!("SELECT EXISTS(SELECT 1 FROM clone_token_df WHERE 1=1{df_clause})"),
+                [],
+                |r| r.get::<_, i64>(0),
+            )? != 0
+        };
+        if seeded {
+            return Ok(());
+        }
+        self.refresh_clone_token_df()
+    }
+
     pub(crate) fn refresh_clone_token_df(&self) -> anyhow::Result<()> {
         // Resolve the active-repo scope ONCE: it gates BOTH the fingerprint READ below and the df
         // wipe/reinsert (Phase 2). `symbol_fingerprints` is deliberately `repo_id`-free (keyed by

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -3442,11 +3442,27 @@ pub(crate) fn apply_repo_node_edges(conn: &Connection) -> rusqlite::Result<()> {
 /// (`delta_files_applied`, the df-drift signal that schedules the next full rebuild). Both
 /// additive + idempotent; the column type is STRICT-valid and defaulted so existing generation
 /// rows read back 0 (no deltas absorbed).
+///
+/// Pre-freeze postings are NOT delta-ready (#477 review): binaries before the df epoch freeze
+/// bumped `clone_token_df` on incremental passes WITHOUT invalidating the postings, so an
+/// upgraded index can hold a live generation whose postings are ordered by an older df than the
+/// current table — a delta patching it would compute sub-blocks under the moved df and silently
+/// miss edges. Clear `postings_written` so those generations take one full rebuild (which re-pins
+/// the epoch at its own build). Gated on the delta column being freshly ADDED, so only the first
+/// run (a genuinely pre-freeze index) invalidates — a re-apply on an already-frozen index must
+/// not throw away a valid graph.
 pub(crate) fn apply_clone_delta_maintenance(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(
         "CREATE INDEX IF NOT EXISTS idx_clone_subblock_postings_path
              ON clone_subblock_postings(build_generation, path);",
     )?;
+    // ORDER IS LOAD-BEARING (torn-retry safety): the invalidation runs BEFORE the gate column is
+    // added. A kill between the two leaves the column absent, so the retry re-runs the
+    // (idempotent) invalidation and then adds the column — the gate can never read "already
+    // frozen" while the clear is still owed.
+    if !column_exists(conn, "clone_graph_generations", "delta_files_applied")? {
+        conn.execute_batch("UPDATE clone_graph_generations SET postings_written = 0;")?;
+    }
     add_column_if_missing(
         conn,
         "clone_graph_generations",

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1184,6 +1184,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_047_ID => Some(47),
             MIGRATION_048_ID => Some(48),
             MIGRATION_049_ID => Some(49),
+            MIGRATION_050_ID => Some(50),
             _ => None,
         })
         .max()
@@ -1242,6 +1243,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_047_ID
             | MIGRATION_048_ID
             | MIGRATION_049_ID
+            | MIGRATION_050_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1297,6 +1299,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_047_ID => migration.checksum != MIGRATION_047_CHECKSUM,
         MIGRATION_048_ID => migration.checksum != MIGRATION_048_CHECKSUM,
         MIGRATION_049_ID => migration.checksum != MIGRATION_049_CHECKSUM,
+        MIGRATION_050_ID => migration.checksum != MIGRATION_050_CHECKSUM,
         _ => false,
     }
 }
@@ -3431,6 +3434,26 @@ pub(crate) fn apply_repo_node_edges(conn: &Connection) -> rusqlite::Result<()> {
             ON repo_node_edges(target_kind, target_anchor);
         ",
     )
+}
+
+/// V050 (#473): incremental clone-graph delta maintenance. The delta pass deletes a changed file's
+/// postings by `(build_generation, path)` — unindexed until now (the PK leads with `token_hash`) —
+/// and tracks how many files the live generation has absorbed since its full build
+/// (`delta_files_applied`, the df-drift signal that schedules the next full rebuild). Both
+/// additive + idempotent; the column type is STRICT-valid and defaulted so existing generation
+/// rows read back 0 (no deltas absorbed).
+pub(crate) fn apply_clone_delta_maintenance(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_clone_subblock_postings_path
+             ON clone_subblock_postings(build_generation, path);",
+    )?;
+    add_column_if_missing(
+        conn,
+        "clone_graph_generations",
+        "delta_files_applied",
+        "INTEGER NOT NULL DEFAULT 0",
+    )?;
+    Ok(())
 }
 
 pub(crate) fn apply_symbols_is_test(conn: &Connection) -> rusqlite::Result<()> {

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -18,7 +18,7 @@ pub use registry::{LEGACY_REPO_ID, register_repo, register_repo_read_only};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 49;
+pub const LATEST_SCHEMA_VERSION: u32 = 50;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -335,6 +335,13 @@ const MIGRATION_049_DESCRIPTION: &str =
      edges from a memory node to another node or a code/github target, with explicit owner + \
      target repo ids and a stable edge_key, no FK to volatile graph rows (only the durable source \
      memory)";
+const MIGRATION_050_ID: &str = "050_clone_delta_maintenance";
+const MIGRATION_050_CHECKSUM: &str = "sha256:rag-rat-clone-delta-maintenance-v50";
+const MIGRATION_050_DESCRIPTION: &str =
+    "Add the clone_subblock_postings (build_generation, path) index and the \
+     clone_graph_generations.delta_files_applied counter, so the incremental clone-graph delta \
+     pass can delete a changed file's postings without a table scan and track df drift toward the \
+     next full rebuild";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -728,6 +735,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_049_CHECKSUM,
         description: MIGRATION_049_DESCRIPTION,
         apply: apply_repo_node_edges,
+    },
+    Migration {
+        id: MIGRATION_050_ID,
+        checksum: MIGRATION_050_CHECKSUM,
+        description: MIGRATION_050_DESCRIPTION,
+        apply: apply_clone_delta_maintenance,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -820,8 +820,8 @@ fn migration_047_creates_the_model_failure_table_on_fresh_apply() {
 fn migration_048_adds_the_memory_payload_json_column() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
-    // The absolute-tip pin moved to `migration_049_*` (V049 is the tip now); this keeps the
-    // symbolic "schema at LATEST after apply" check and its V048 column coverage.
+    // Symbolic freshness check — the absolute tip pin lives on the NEWEST migration's test
+    // (migration_050_*), per the ladder convention.
     assert_eq!(
         schema::status(&conn).unwrap().current_version,
         schema::LATEST_SCHEMA_VERSION,
@@ -843,10 +843,13 @@ fn migration_048_adds_the_memory_payload_json_column() {
 fn migration_049_adds_the_repo_node_edges_table() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
-    // V049 is the schema tip — the absolute pin (migration_048_* dropped to symbolic when this
-    // landed).
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 49, "V049 is the schema tip");
-    assert_eq!(schema::status(&conn).unwrap().current_version, 49, "schema at LATEST after apply");
+    // Symbolic freshness check — the absolute tip pin lives on the NEWEST migration's test
+    // (migration_050_*), per the ladder convention.
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply"
+    );
 
     let table_sql = conn
         .query_row("SELECT sql FROM sqlite_master WHERE name = 'repo_node_edges'", [], |r| {
@@ -884,6 +887,44 @@ fn migration_049_adds_the_repo_node_edges_table() {
     // Idempotent re-apply.
     schema::apply(&conn).unwrap();
     assert!(conn_table_exists(&conn, "repo_node_edges"), "edge table survives a re-apply");
+}
+
+#[test]
+fn migration_050_adds_the_postings_path_index_and_delta_counter() {
+    let index_exists = |conn: &rusqlite::Connection| -> bool {
+        conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = \
+             'idx_clone_subblock_postings_path'",
+            [],
+            |r| r.get::<_, i64>(0),
+        )
+        .unwrap()
+            > 0
+    };
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    // V050 is the schema tip — the absolute pin (migration_049_* dropped to the symbolic
+    // `current_version == LATEST` check when this landed).
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 50, "V050 is the schema tip");
+    assert_eq!(schema::status(&conn).unwrap().current_version, 50, "schema at LATEST after apply");
+    assert!(
+        index_exists(&conn),
+        "the delta pass deletes a changed file's postings by (build_generation, path); the PK \
+         leads with token_hash, so that delete needs this index (#473)"
+    );
+    assert!(
+        conn_table_columns(&conn, "clone_graph_generations")
+            .contains(&"delta_files_applied".to_string()),
+        "generations carry the delta-drift counter that schedules the next full rebuild (#473)"
+    );
+    // Additive + defaulted: a re-apply is idempotent and both survive.
+    schema::apply(&conn).unwrap();
+    assert!(index_exists(&conn), "the postings path index survives a re-apply");
+    assert!(
+        conn_table_columns(&conn, "clone_graph_generations")
+            .contains(&"delta_files_applied".to_string()),
+        "delta_files_applied survives a re-apply"
+    );
 }
 
 #[test]

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -917,7 +917,17 @@ fn migration_050_adds_the_postings_path_index_and_delta_counter() {
             .contains(&"delta_files_applied".to_string()),
         "generations carry the delta-drift counter that schedules the next full rebuild (#473)"
     );
-    // Additive + defaulted: a re-apply is idempotent and both survive.
+    // Additive + defaulted: a re-apply is idempotent and both survive — and a POST-freeze
+    // generation's postings are NOT invalidated by a re-apply (the pre-freeze invalidation below
+    // is gated on the delta column being freshly added).
+    conn.execute(
+        "INSERT INTO clone_graph_generations
+            (generation, status, theta_floor, normalizer_kind, normalizer_version,
+             source_revision, started_at_ms, postings_written)
+         VALUES (1, 'Complete', 0.7, 'baseline', 3, 'rev', 0, 1)",
+        [],
+    )
+    .unwrap();
     schema::apply(&conn).unwrap();
     assert!(index_exists(&conn), "the postings path index survives a re-apply");
     assert!(
@@ -925,6 +935,31 @@ fn migration_050_adds_the_postings_path_index_and_delta_counter() {
             .contains(&"delta_files_applied".to_string()),
         "delta_files_applied survives a re-apply"
     );
+    let postings_written: i64 = conn
+        .query_row(
+            "SELECT postings_written FROM clone_graph_generations WHERE generation = 1",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(postings_written, 1, "a re-apply must not invalidate an already-frozen graph");
+
+    // PRE-freeze upgrade (#477 review): a generation from before the df epoch freeze may carry
+    // postings ordered by an older df than the current table (incremental bumps moved df without
+    // invalidating). The first V050 run — recognized by the delta column being absent — must
+    // clear `postings_written` so those generations take one full rebuild instead of being
+    // treated as delta-ready.
+    conn.execute_batch("ALTER TABLE clone_graph_generations DROP COLUMN delta_files_applied;")
+        .unwrap();
+    schema::apply_clone_delta_maintenance(&conn).unwrap();
+    let postings_written: i64 = conn
+        .query_row(
+            "SELECT postings_written FROM clone_graph_generations WHERE generation = 1",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(postings_written, 0, "a pre-freeze generation is forced through a full rebuild");
 }
 
 #[test]

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -218,14 +218,24 @@ fn run_pass(
         let report = db.reconcile_with_options_progress(options, |_| {})?;
         base_reconcile_status = Some(report.status);
     }
-    // Clone-edge graph (#286): refresh the persisted graph when it's ABSENT or STALE — gated on
-    // the #472 quiet window (`clone_graph_due` above) so sustained editing defers the rebuild
-    // instead of treadmilling it — with whatever budget the embedding reconcile left, sharing the
-    // same PASS_RECONCILE_MAX_SECONDS so a pass can't overrun. Best-effort + resumable: a bounded
-    // pass makes partial progress and the next pass continues (the revision is quiet-stable, so
-    // the Building generation resumes), entirely off the query path. `None` budget → skip (rides
-    // the next pass), exactly like the base reconcile.
-    if clone_graph_due && let Some(options) = budget.next_options() {
+    // Clone-edge graph (#286/#473): try the cheap IN-PLACE delta first — it settles an ordinary
+    // edit on this very pass (freshness is the point; no quiet window) and reports whether a FULL
+    // rebuild is still owed (accumulated df drift). The full rebuild runs only when the delta
+    // could not settle freshness (absent generation, normalizer bump, cap crossing, huge delta,
+    // error) or a drift refresh is owed — and it stays behind the #472 quiet window
+    // (`clone_graph_due`) so sustained editing defers it instead of treadmilling. Best-effort +
+    // resumable, with whatever budget the embedding reconcile left (shared
+    // PASS_RECONCILE_MAX_SECONDS so a pass can't overrun); `None` budget → rides the next pass.
+    let clone_full_rebuild_owed = match db
+        .apply_clone_graph_delta(crate::index::CLONE_DELTA_MAX_FILES)
+    {
+        Ok(delta) if delta.status == "Applied" || delta.status == "Noop" => delta.full_rebuild_owed,
+        _ => true,
+    };
+    if clone_full_rebuild_owed
+        && clone_graph_due
+        && let Some(options) = budget.next_options()
+    {
         let _ = db.reconcile_clone_edges_with_budget(options.max_seconds);
     }
     if run_gc {


### PR DESCRIPTION
Fixes #473. Builds on the #472 quiet-window gate (#475).

## What

Small file changes now patch the **live** clone-graph generation in place — delete the changed files' edges + postings, recompute only their symbols against the persisted postings, bump `source_revision` — instead of discarding and rebuilding the whole generation. A typical edit costs a few hundred rows and milliseconds where a full rebuild cost ~100 MB of rows (~1 GB of disk writes with WAL doubling). Because `source_revision` now tracks content under sustained editing, `clone_check_indexed_generation()` stays eligible and the write-time postings fast path stays hot instead of permanently falling back to the RAM build.

## Why it's sound

- **Edges are verification results**: `clone_edges.overlap` depends only on the two endpoint bags, so an edit to file X cannot change any edge not touching X — edges between unchanged files stay valid verbatim.
- **Prefix filtering is recall-lossless under any single consistent token order.** The new **df epoch freeze** provides that order: `clone_token_df` no longer moves on incremental passes (the per-token bumps are removed; the incremental finalize's refresh is now bootstrap-only, `refresh_clone_token_df_if_unseeded`), so the persisted postings and every later sub-block computation agree between full rebuilds. df is a selectivity hint only (`DF_FALLBACK`), so epoch drift costs candidate-pruning efficiency, never edges. This also stops the per-incremental-pass postings invalidation that `refresh_clone_token_df` had to do.

## Parity discipline (pinned by tests)

`clone_graph_delta_matches_a_full_rebuild_over_an_edit_sequence` pins that the delta-maintained edge set equals a from-scratch rebuild at the same content, across add/edit/delete steps and compound (back-to-back, no intermediate rebuild) deltas. Two rules keep it exact:

- The delta uses the **build's** corpus filters (`load_scoped_baseline_bags`): scoped `files` view, `generated = 0`, baseline + `NORM_VERSION`, non-NULL bag — and deliberately no `is_test` narrowing (that belongs to the `of_text` write-time corpus).
- **No hot-token cap**: the #271 `HOT_TOKEN_POSTINGS_CAP` belongs to the live candidate paths only — the persisted-graph build walks every sub-block token uncapped, so the delta does too. A seeded-hot regression test (`delta_keeps_hot_token_edges_the_build_would_emit`) pins that a stable-hot shared token cannot silently drop edges a rebuild keeps.

Escalation to the full-rebuild path: oversized deltas (`CLONE_DELTA_MAX_FILES = 64` — a branch switch is cheaper to rebuild), absent/normalizer-stale/postings-less generations, an in-flight Building generation, and linked-overlay scopes.

## Wiring

Both background tails (watcher `run_pass` and hook-driven CLI `maintenance`) try the delta **first**, applying it on the same pass that indexed the edit — no quiet window; freshness is the point. The #472 quiet gate now guards only the full-rebuild path: it fires when the delta can't settle freshness, or when accumulated drift owes a df-epoch refresh — generations count absorbed files in the new `delta_files_applied` column, past `CLONE_GRAPH_DRIFT_REBUILD_FILES` (256) the gate schedules a full rebuild, and the reconcile pass no longer skips-as-current a drifted generation (its Phase-0 gained the drift condition). The graph keeps serving throughout.

## Schema

V049 (additive): `idx_clone_subblock_postings_path` on `(build_generation, path)` — the per-file postings delete was unindexed (PK leads with `token_hash`) — and `clone_graph_generations.delta_files_applied INTEGER NOT NULL DEFAULT 0`.

## Tests

12 new: the differential + compound parity pin, seeded-hot-token regression, delta unit tests (noop/idempotence, not-eligible, escalate-writes-nothing, bookkeeping + fast-path re-eligibility), df-freeze pins (incremental pass leaves `clone_token_df` byte-identical and postings valid), tail integration (in-place apply on the indexing pass; drift-owed rebuild deferred inside the window, executed after it with the counter reset), V049 migration bootstrap/idempotence, and the tail-trigger matrix extension. Workspace suite: 1851 passed.