### PR TITLE
feat(memory): canonical content_hash primitive (phase B §5.5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2794,6 +2794,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicbor"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b7a5041e12946f8b7d3f5a9d96383a19d694b9335457c522be7815b9abafb02"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3355,6 +3361,7 @@ dependencies = [
  "iai-callgrind",
  "ignore",
  "libc",
+ "minicbor",
  "model2vec-rs",
  "notify",
  "path-slash",
@@ -3381,6 +3388,7 @@ dependencies = [
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
+ "unicode-normalization",
  "ureq 3.3.0",
  "zstd",
 ]

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -48,6 +48,8 @@ tree-sitter-kotlin.workspace = true
 tree-sitter-python.workspace = true
 tree-sitter-rust.workspace = true
 tree-sitter-typescript.workspace = true
+minicbor = { version = "2.2.2", features = ["alloc"] }
+unicode-normalization = "0.1.25"
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true

--- a/crates/rag-rat-core/src/canonical.rs
+++ b/crates/rag-rat-core/src/canonical.rs
@@ -1,0 +1,275 @@
+//! Canonical, deterministic encoding for signed / content-addressed objects (phase B, §5.5).
+//!
+//! Every hashed or signed object is encoded as a **canonical CBOR** value (RFC 8949 §4.2
+//! core-deterministic): definite lengths, minimal integer encoding, map keys sorted by their
+//! CBOR-encoded bytes, and UTF-8 text **NFC**-normalized. Hashes are always over a canonical CBOR
+//! tuple/struct — NEVER raw string concatenation, which is delimiter-malleable. Each object is
+//! DOMAIN-TAGGED and versioned (`"rag-rat/content-hash/1"`, …) as its first tuple element, so two
+//! object kinds can never collide and the canonical rule can be versioned independently of the
+//! data.
+//!
+//! This module is the shared substrate: `content_hash` (query/memory) and, later, the edge_key /
+//! op-log entry hashes build their tuples on top of `encode_canonical_json` + `nfc`.
+
+use std::fmt;
+
+use minicbor::Encoder;
+use minicbor::encode::Write;
+use serde::de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
+use serde_json::Value;
+
+/// NFC-normalize a string (RFC 8949 identity requirement — canonically-equivalent Unicode must hash
+/// identically).
+pub(crate) fn nfc(s: &str) -> String {
+    use unicode_normalization::UnicodeNormalization;
+    s.nfc().collect()
+}
+
+/// Parse a payload JSON, ERRORING on a duplicate object key at ANY depth. `serde_json`'s default
+/// `Value` silently keeps the LAST of a repeated key — but JSON parsers disagree on which wins, so
+/// a dup-key payload would hash differently across devices and diverge sync. Rejecting it on write
+/// keeps the cross-device content hash well-defined. (NFC-normalized duplicates are caught
+/// separately by [`payload_encoding_error`].)
+pub(crate) fn parse_rejecting_duplicate_keys(raw: &str) -> Result<Value, String> {
+    struct Strict(Value);
+
+    impl<'de> Deserialize<'de> for Strict {
+        fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+            struct V;
+            impl<'de> Visitor<'de> for V {
+                type Value = Value;
+
+                fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    f.write_str("a JSON value")
+                }
+
+                fn visit_unit<E>(self) -> Result<Value, E> {
+                    Ok(Value::Null)
+                }
+
+                fn visit_bool<E>(self, b: bool) -> Result<Value, E> {
+                    Ok(Value::Bool(b))
+                }
+
+                fn visit_i64<E>(self, n: i64) -> Result<Value, E> {
+                    Ok(n.into())
+                }
+
+                fn visit_u64<E>(self, n: u64) -> Result<Value, E> {
+                    Ok(n.into())
+                }
+
+                fn visit_f64<E>(self, n: f64) -> Result<Value, E> {
+                    Ok(serde_json::Number::from_f64(n).map_or(Value::Null, Value::Number))
+                }
+
+                fn visit_str<E>(self, s: &str) -> Result<Value, E> {
+                    Ok(Value::String(s.to_owned()))
+                }
+
+                fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Value, A::Error> {
+                    let mut arr = Vec::new();
+                    while let Some(Strict(v)) = seq.next_element()? {
+                        arr.push(v);
+                    }
+                    Ok(Value::Array(arr))
+                }
+
+                fn visit_map<A: MapAccess<'de>>(self, mut m: A) -> Result<Value, A::Error> {
+                    let mut map = serde_json::Map::new();
+                    while let Some((k, Strict(v))) = m.next_entry::<String, Strict>()? {
+                        if map.insert(k.clone(), v).is_some() {
+                            return Err(de::Error::custom(format!("duplicate object key `{k}`")));
+                        }
+                    }
+                    Ok(Value::Object(map))
+                }
+            }
+            d.deserialize_any(V).map(Strict)
+        }
+    }
+
+    serde_json::from_str::<Strict>(raw).map(|s| s.0).map_err(|e| e.to_string())
+}
+
+/// Encode a JSON value as CANONICAL CBOR into `enc`:
+/// - integers via minimal unsigned/negative encoding;
+/// - text strings NFC-normalized;
+/// - arrays in order; objects as maps whose keys are sorted by their CBOR-ENCODED bytes (§4.2.1),
+///   not merely by code point — the length prefix participates in the ordering.
+///
+/// ERRORS on a NON-INTEGER number (JSON floats collapse to binary64 → an unreliable content-hash
+/// input) or on two object keys that NFC-normalize to the same key (a dup-key map is
+/// non-canonical). These are the only error paths when writing to a `Vec<u8>` (whose own writes are
+/// infallible), and [`payload_encoding_error`] surfaces both at write time so a stored payload
+/// never trips them later.
+pub(crate) fn encode_canonical_json<W: Write>(
+    value: &Value,
+    enc: &mut Encoder<W>,
+) -> Result<(), minicbor::encode::Error<W::Error>> {
+    match value {
+        Value::Null => {
+            enc.null()?;
+        },
+        Value::Bool(b) => {
+            enc.bool(*b)?;
+        },
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                enc.i64(i)?;
+            } else if let Some(u) = n.as_u64() {
+                enc.u64(u)?;
+            } else {
+                // REJECT a non-integer number. JSON floats collapse to binary64 at parse time, so
+                // `1.0` and `1.0000000000000001` would hash identically — a payload edit the
+                // freshness key must NOT miss. A fractional value must be a STRING or a scaled
+                // integer. (`validate_payload` surfaces this on write; `content_hash` raw-hashes a
+                // legacy/out-of-band float payload.)
+                return Err(minicbor::encode::Error::message(
+                    "canonical encoding rejects non-integer numbers (use a string or a scaled \
+                     integer for fractional values)",
+                ));
+            }
+        },
+        Value::String(s) => {
+            enc.str(&nfc(s))?;
+        },
+        Value::Array(items) => {
+            enc.array(items.len() as u64)?;
+            for item in items {
+                encode_canonical_json(item, enc)?;
+            }
+        },
+        Value::Object(map) => {
+            // Sort by the CBOR-encoded key bytes (§4.2.1) — a text string's length prefix sorts
+            // before its content, so this is NOT the same as sorting the NFC strings directly.
+            let mut entries: Vec<(Vec<u8>, String, &Value)> = map
+                .iter()
+                .map(|(k, v)| {
+                    let key = nfc(k);
+                    (encoded_str(&key), key, v)
+                })
+                .collect();
+            entries.sort_by(|a, b| a.0.cmp(&b.0));
+            // A canonical map forbids duplicate keys (§4.2.1). NFC-normalizing keys can collapse
+            // two DISTINCT source keys (e.g. a precomposed vs a decomposed "café") to
+            // the SAME key — reject rather than emit an ambiguous dup-key map.
+            // (`validate_payload` runs this on write, so a stored payload never reaches
+            // `content_hash` with such keys.)
+            if entries.windows(2).any(|w| w[0].0 == w[1].0) {
+                return Err(minicbor::encode::Error::message(
+                    "canonical CBOR forbids duplicate map keys (two keys normalized to the same \
+                     value)",
+                ));
+            }
+            enc.map(entries.len() as u64)?;
+            for (_, key, v) in &entries {
+                enc.str(key)?;
+                encode_canonical_json(v, enc)?;
+            }
+        },
+    }
+    Ok(())
+}
+
+/// The canonical-encoding error for a payload `value`, or `None` if it encodes cleanly. Currently
+/// the sole failure is a pair of object keys that NFC-normalize to the same key. Called by
+/// `validate_payload` on WRITE so a stored payload always hashes cleanly (`content_hash` can then
+/// treat the encoding as infallible).
+pub(crate) fn payload_encoding_error(value: &Value) -> Option<String> {
+    let mut buf = Vec::new();
+    encode_canonical_json(value, &mut Encoder::new(&mut buf)).err().map(|e| e.to_string())
+}
+
+/// The canonical CBOR encoding of a single text string — used only to derive a map key's sort
+/// order.
+fn encoded_str(s: &str) -> Vec<u8> {
+    let mut buf = Vec::new();
+    Encoder::new(&mut buf).str(s).expect("encoding a str to a Vec is infallible");
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn cbor(value: &Value) -> Vec<u8> {
+        let mut buf = Vec::new();
+        encode_canonical_json(value, &mut Encoder::new(&mut buf)).unwrap();
+        buf
+    }
+
+    #[test]
+    fn object_key_order_is_normalized() {
+        // The same entries in a different insertion order encode byte-identically.
+        assert_eq!(cbor(&json!({"b": 1, "a": 2, "c": 3})), cbor(&json!({"c": 3, "a": 2, "b": 1})));
+    }
+
+    #[test]
+    fn keys_sort_by_encoded_bytes_not_code_points() {
+        // "z" (encoded 0x61 0x7a) precedes "aa" (0x62 0x61 0x61): the CBOR length prefix sorts
+        // first, so this is NOT plain lexicographic order (where "aa" < "z").
+        let bytes = cbor(&json!({"aa": 1, "z": 2}));
+        let z = bytes.windows(2).position(|w| w == [0x61, 0x7a]).unwrap();
+        let aa = bytes.windows(3).position(|w| w == [0x62, 0x61, 0x61]).unwrap();
+        assert!(z < aa, "the shorter key sorts first by encoded bytes: {bytes:02x?}");
+    }
+
+    #[test]
+    fn nfc_equivalent_strings_encode_identically() {
+        // é precomposed (U+00E9) vs e + combining acute (U+0065 U+0301) are NFC-equivalent.
+        assert_eq!(cbor(&json!("caf\u{00e9}")), cbor(&json!("cafe\u{0301}")));
+    }
+
+    #[test]
+    fn integers_are_minimal_and_distinct_from_floats() {
+        assert_eq!(cbor(&json!(5)), vec![0x05], "unsigned 5 is a single minimal byte");
+    }
+
+    #[test]
+    fn non_integer_numbers_are_rejected() {
+        // A float can't be a reliable content-hash input (it collapses to binary64), so the
+        // canonical encoder rejects it at the top level AND nested in a payload object.
+        let mut buf = Vec::new();
+        assert!(encode_canonical_json(&json!(1.5), &mut Encoder::new(&mut buf)).is_err());
+        assert!(payload_encoding_error(&json!({"x": 0.1})).is_some());
+        // Integers are still fine.
+        assert!(payload_encoding_error(&json!({"x": 42, "y": -3})).is_none());
+    }
+
+    #[test]
+    fn strict_parse_accepts_every_json_value_kind() {
+        // Exercise every Visitor arm: null, bool, signed/unsigned int, float, string, array,
+        // object.
+        let v = parse_rejecting_duplicate_keys(
+            r#"{"n":null,"b":true,"i":-5,"u":9,"f":1.5,"s":"x","arr":[1,"y",false,null]}"#,
+        )
+        .unwrap();
+        assert!(v.is_object());
+        assert_eq!(v["arr"].as_array().unwrap().len(), 4);
+        assert_eq!(v["i"], json!(-5));
+        assert_eq!(v["b"], json!(true));
+        // Top-level non-object values parse too (visit_seq / scalar arms at the root).
+        assert_eq!(parse_rejecting_duplicate_keys("42").unwrap(), json!(42));
+        assert_eq!(parse_rejecting_duplicate_keys("[1,2]").unwrap(), json!([1, 2]));
+        // A genuine syntax error is surfaced (not a dup message).
+        assert!(parse_rejecting_duplicate_keys("{bad").is_err());
+    }
+
+    #[test]
+    fn rejects_keys_that_normalize_to_a_duplicate() {
+        // Two DISTINCT source keys — "café" precomposed (U+00E9) and decomposed (e + U+0301) —
+        // collapse to one NFC key, which would make an ambiguous dup-key map.
+        let dup = json!({"caf\u{00e9}": 1, "cafe\u{0301}": 2});
+        let mut buf = Vec::new();
+        assert!(
+            encode_canonical_json(&dup, &mut Encoder::new(&mut buf)).is_err(),
+            "NFC-duplicate keys must be rejected"
+        );
+        // A normal object still encodes fine.
+        assert!(payload_encoding_error(&json!({"a": 1, "b": 2})).is_none());
+        assert!(payload_encoding_error(&dup).is_some());
+    }
+}

--- a/crates/rag-rat-core/src/dream/verify.rs
+++ b/crates/rag-rat-core/src/dream/verify.rs
@@ -258,21 +258,20 @@ fn queue_reason(
 }
 
 /// The dream freshness key for a memory's NOTE content — the single `content_hash` stamped into
-/// `memory_reality` / `memory_summaries`. Hashes the TRIMMED title AND body, newline-delimited (the
-/// house `memory_input_hash` style — deliberately NOT a bare `title ‖ body` concat, which would let
-/// `"ab"+"c"` and `"a"+"bc"` collide), because BOTH the verdict prompt and the compaction prompt
-/// audit the whole note (TITLE + body). So a title-only edit re-verifies / re-summarizes and drops
-/// the stale verdict / summary / marker exactly as a body edit does. (Kept dream-local rather than
-/// reusing `memory_input_hash`, which also folds kind + tags — dimensions the prompts don't audit —
-/// and reads the frozen-at-creation stored `input_hash`.)
+/// `memory_reality` / `memory_summaries`. It is `sha256(trim(title) + "\n" + trim(body))`, covering
+/// EXACTLY what the verdict and compaction prompts render: the title and body, and nothing else. So
+/// a title / body edit re-verifies / re-summarizes and drops the stale verdict / summary / marker,
+/// while a change to a dimension the prompts don't render (kind, tags, payload) does NOT churn the
+/// derived overlays. It becomes the §5.5 canonical [`content_hash`] (which folds the payload) only
+/// when the prompts start rendering the payload — bundled with a [`PROMPT_VERSION`] bump so that
+/// rollout is backfill-free (a bump re-queues every memory anyway). Distinct from the raw
+/// create-time `memory_input_hash`, which also folds kind + tags (dimensions the prompts don't
+/// audit) and reads the frozen-at-creation stored `input_hash`.
 ///
-/// `pub(crate)` so the surfacing hydrator recomputes it identically to the queue / verdict-pass
+/// [`PROMPT_VERSION`]: super::verdict::PROMPT_VERSION
+///
+/// `pub(crate)` so the surfacing hydrator recomputes it IDENTICALLY to the queue / verdict-pass
 /// stamp.
-/// The dream content-identity key over a memory's CURRENT note (title + body). NOTE (#465): the
-/// polymorphic `payload_json` is NOT folded here yet — the canonical payload fold is deferred to
-/// phase B (#404) with the rest of the §5.5 canonicalization. This is not a live staleness bug: the
-/// derived summary/verdict rows are over title+body, which a payload-only edit does not change, so
-/// they stay correct. (Create-time dedup DOES fold the payload — see `memory_input_hash`.)
 pub(crate) fn note_content_hash(title: &str, body: &str) -> String {
     crate::index::hex_sha256(format!("{}\n{}", title.trim(), body.trim()).as_bytes())
 }

--- a/crates/rag-rat-core/src/lib.rs
+++ b/crates/rag-rat-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub(crate) mod canonical;
 pub mod config;
 pub mod data_dir;
 pub mod dream;

--- a/crates/rag-rat-core/src/query/memory/validate.rs
+++ b/crates/rag-rat-core/src/query/memory/validate.rs
@@ -531,10 +531,21 @@ pub(crate) fn validate_payload(kind: &str, payload_json: Option<&str>) -> anyhow
             "a `{kind}` memory carries no payload (only Task/Concept may have a payload_json)"
         );
     }
-    let value: serde_json::Value = serde_json::from_str(payload)
-        .map_err(|e| anyhow::anyhow!("payload_json is not valid JSON: {e}"))?;
+    // Strict parse: reject a LITERAL duplicate object key (serde_json's default silently keeps the
+    // last, but parsers disagree on which wins → a cross-device hash divergence). Complete for a
+    // caller that passes the RAW payload string (CLI, direct core); the MCP JSON-RPC transport
+    // parses tool args into a `Value` upstream, collapsing dups deterministically before this runs
+    // (harmless among serde_json writers today) — hardening that boundary is #488.
+    let value = crate::canonical::parse_rejecting_duplicate_keys(payload)
+        .map_err(|e| anyhow::anyhow!("payload_json invalid: {e}"))?;
     if !value.is_object() {
         anyhow::bail!("payload_json must be a JSON object");
+    }
+    // Reject on WRITE anything the canonical encoder can't hash (two keys that NFC-normalize to the
+    // same key → an ambiguous dup-key map), so a STORED payload always encodes cleanly and
+    // `content_hash` can treat the canonical encoding as effectively infallible.
+    if let Some(err) = crate::canonical::payload_encoding_error(&value) {
+        anyhow::bail!("payload_json is not canonically encodable: {err}");
     }
     Ok(())
 }
@@ -609,6 +620,73 @@ pub(crate) fn memory_input_hash(
         .as_bytes(),
     )
 }
+/// The canonical, content-addressed identity of a memory's CONTENT (phase B §5.5) — hex SHA-256
+/// over a canonical CBOR array `[domain, payload_schema_version, nfc(trim title), nfc(trim body),
+/// payload]`. `kind` and `tags` are EXCLUDED (a pure reclassification / re-tag must not churn the
+/// content-addressed derived overlays); the payload IS folded, and its self-described
+/// `schema_version` is folded separately, so a payload-schema migration is a deliberate identity
+/// change. Distinct from `memory_input_hash` (the raw create-time dedup/id seed) and NEVER raw
+/// concatenation. A `None` payload folds as CBOR null with `schema_version = 0`.
+// Frozen §5.5 primitive, golden-vector-pinned; first production consumer is the op-log increment
+// (#404).
+#[allow(dead_code)]
+pub(crate) fn content_hash(title: &str, body: &str, payload_json: Option<&str>) -> String {
+    use crate::canonical::nfc;
+    let (schema_version, payload_element) = payload_cbor_element(payload_json);
+    let mut buf = Vec::new();
+    {
+        let mut enc = minicbor::Encoder::new(&mut buf);
+        // §5.5: array([domain, schema_version, trimmed_title_nfc, trimmed_body_nfc, payload]).
+        // These fixed ops write to a `Vec`, so they are infallible.
+        enc.array(5).expect("cbor to a Vec is infallible");
+        enc.str("rag-rat/content-hash/1").expect("cbor to a Vec is infallible");
+        enc.u64(schema_version).expect("cbor to a Vec is infallible");
+        enc.str(&nfc(title.trim())).expect("cbor to a Vec is infallible");
+        enc.str(&nfc(body.trim())).expect("cbor to a Vec is infallible");
+    }
+    // Append the pre-encoded payload as the 5th array element (one CBOR item either way).
+    buf.extend_from_slice(&payload_element);
+    hex_sha256(&buf)
+}
+
+/// The `(schema_version, pre-encoded payload CBOR)` for `content_hash`. A payload folds as
+/// CANONICAL CBOR only when it parses with NO duplicate key (`serde_json` silently keeps the last
+/// of a LITERAL dup — parser-dependent — so we parse strictly) AND encodes with no NFC-duplicate
+/// key; otherwise — invalid JSON, a literal-dup, or an NFC-dup, all of which `validate_payload`
+/// rejects on write, so only a legacy / out-of-band payload reaches here — its RAW bytes fold as a
+/// CBOR byte string (a distinct major type, so it can't collide with a structured payload). This
+/// keeps `content_hash` TOTAL, DETERMINISTIC, and PARSER-INDEPENDENT: it runs on every memory in
+/// the dream pass and must never panic, and both duplicate-key kinds must hash identically across
+/// devices.
+fn payload_cbor_element(payload_json: Option<&str>) -> (u64, Vec<u8>) {
+    use crate::canonical::{encode_canonical_json, parse_rejecting_duplicate_keys};
+    let Some(raw) = payload_json else {
+        let mut buf = Vec::new();
+        minicbor::Encoder::new(&mut buf).null().expect("cbor to a Vec is infallible");
+        return (0, buf);
+    };
+    // A payload folds structurally ONLY when it is a JSON OBJECT (what `validate_payload` accepts)
+    // AND encodes canonically. A non-object (`null`, a scalar, an array) is rejected on write just
+    // like a dup-key / invalid one, so — crucially — it must NOT fold as structured CBOR: a text
+    // payload of `"null"` would encode to the SAME CBOR-null element as `None`, colliding a
+    // no-payload memory with a `null`-payload one and never invalidating overlays.
+    if let Ok(value) = parse_rejecting_duplicate_keys(raw)
+        && value.is_object()
+    {
+        let mut buf = Vec::new();
+        if encode_canonical_json(&value, &mut minicbor::Encoder::new(&mut buf)).is_ok() {
+            let version =
+                value.get("schema_version").and_then(serde_json::Value::as_u64).unwrap_or(0);
+            return (version, buf);
+        }
+    }
+    // Legacy / out-of-band non-canonical payload (non-object, literal-dup, NFC-dup, or invalid
+    // JSON).
+    let mut buf = Vec::new();
+    minicbor::Encoder::new(&mut buf).bytes(raw.as_bytes()).expect("cbor to a Vec is infallible");
+    (0, buf)
+}
+
 pub(crate) fn hex_sha256(bytes: &[u8]) -> String {
     let hash = Sha256::digest(bytes);
     hash.iter().map(|byte| format!("{byte:02x}")).collect()
@@ -626,4 +704,111 @@ pub(crate) fn fts_query(query: &str) -> String {
         .map(|term| format!("\"{}\"", term.replace('"', "\"\"")))
         .collect::<Vec<_>>();
     terms.join(" OR ")
+}
+
+#[cfg(test)]
+mod content_hash_tests {
+    use super::content_hash;
+
+    #[test]
+    fn folds_payload_and_schema_version() {
+        let base = content_hash("t", "b", None);
+        assert_ne!(base, content_hash("t", "b", Some(r#"{"schema_version":1,"x":1}"#)));
+        // A payload VALUE change changes the hash.
+        assert_ne!(
+            content_hash("t", "b", Some(r#"{"schema_version":1,"x":1}"#)),
+            content_hash("t", "b", Some(r#"{"schema_version":1,"x":2}"#)),
+        );
+        // A schema_version bump is a DELIBERATE identity change (§5.5), even with identical fields.
+        assert_ne!(
+            content_hash("t", "b", Some(r#"{"schema_version":1,"x":1}"#)),
+            content_hash("t", "b", Some(r#"{"schema_version":2,"x":1}"#)),
+        );
+    }
+
+    #[test]
+    fn payload_is_canonicalized_key_order_and_whitespace_dont_matter() {
+        assert_eq!(
+            content_hash("t", "b", Some(r#"{"a":1,"b":2}"#)),
+            content_hash("t", "b", Some(r#"{ "b": 2, "a": 1 }"#)),
+        );
+    }
+
+    #[test]
+    fn title_body_are_trimmed_and_nfc_normalized() {
+        assert_eq!(content_hash("t", "b", None), content_hash("  t  ", "\nb\t", None));
+        // é precomposed (U+00E9) vs e + combining acute (U+0065 U+0301).
+        assert_eq!(content_hash("caf\u{00e9}", "b", None), content_hash("cafe\u{0301}", "b", None),);
+    }
+
+    #[test]
+    fn no_payload_differs_from_empty_object() {
+        // `None` (CBOR null) is a distinct identity from an empty-object payload `{}`.
+        assert_ne!(content_hash("t", "b", None), content_hash("t", "b", Some("{}")));
+    }
+
+    #[test]
+    fn non_object_legacy_payload_does_not_collide_with_none() {
+        // A non-object text payload (`"null"`, a scalar) folds as raw BYTES, not structured CBOR —
+        // else `"null"` would encode to the same CBOR-null element as `None` and collide.
+        assert_ne!(content_hash("t", "b", Some("null")), content_hash("t", "b", None));
+        assert_ne!(content_hash("t", "b", Some("42")), content_hash("t", "b", None));
+    }
+
+    #[test]
+    fn validate_rejects_non_integer_number_payloads() {
+        // A float can't be a reliable content-hash input (binary64 collapse) — rejected on write.
+        let err = super::validate_payload("Task", Some(r#"{"score":0.85}"#)).unwrap_err();
+        assert!(err.to_string().contains("canonically encodable"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_nfc_duplicate_payload_keys() {
+        // A payload with "café" precomposed AND decomposed collapses to one NFC key on write —
+        // rejected so `content_hash` never sees an ambiguous dup-key map.
+        let dup = "{\"caf\u{00e9}\":1,\"cafe\u{0301}\":2}";
+        let err = super::validate_payload("Task", Some(dup)).unwrap_err();
+        assert!(err.to_string().contains("canonically encodable"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_literal_duplicate_payload_keys() {
+        // serde_json would silently keep the last; reject so the cross-device hash is well-defined.
+        let err = super::validate_payload("Task", Some(r#"{"a":1,"a":2}"#)).unwrap_err();
+        assert!(err.to_string().contains("duplicate object key"), "{err}");
+        // Nested duplicates are caught at any depth.
+        let nested = super::validate_payload("Task", Some(r#"{"x":{"a":1,"a":2}}"#)).unwrap_err();
+        assert!(nested.to_string().contains("duplicate object key"), "{nested}");
+    }
+
+    #[test]
+    fn legacy_dup_key_payloads_hash_as_raw_bytes() {
+        // A dup-key payload can't be created (validate rejects it), but a legacy / out-of-band one
+        // must NOT crash the dream pass. BOTH dup kinds — NFC-normalized and LITERAL — fold the raw
+        // bytes: total, deterministic, and PARSER-INDEPENDENT.
+        let nfc_dup = "{\"caf\u{00e9}\":1,\"cafe\u{0301}\":2}";
+        let literal_dup = r#"{"a":1,"a":2}"#;
+        for dup in [nfc_dup, literal_dup] {
+            let h = content_hash("t", "b", Some(dup));
+            assert_eq!(h, content_hash("t", "b", Some(dup)), "deterministic fallback");
+            assert_eq!(h.len(), 64, "still a sha-256 hex digest");
+        }
+        // A literal-dup must NOT collapse to serde's silent last-wins interpretation.
+        assert_ne!(
+            content_hash("t", "b", Some(literal_dup)),
+            content_hash("t", "b", Some(r#"{"a":2}"#)),
+            "raw-bytes fold is distinct from serde last-wins",
+        );
+    }
+
+    #[test]
+    fn golden_vector_pins_the_canonical_rule() {
+        // A stored dream freshness hash is content-addressed on this exact encoding — pin it so any
+        // change to the §5.5 canonical rule (which would silently re-derive every dream overlay) is
+        // caught and the domain tag `rag-rat/content-hash/1` bumped deliberately.
+        assert_eq!(
+            content_hash("title", "body", Some(r#"{"schema_version":1,"status":"todo"}"#)),
+            "5a07a01d8bc81c1dc9a80a2ea8707fc9d3f3bcfac5a6c31761deb3d2be2107b2"
+        );
+    }
 }


### PR DESCRIPTION
First increment of phase B (#404): the frozen §5.5 canonical `content_hash` — the content-addressed identity of a memory's note. This lands the **primitive**; adopting it as a live freshness/replication key is deferred to the increment that needs it (see *Why no consumer yet*).

## The hash
`content_hash = sha256(canonical_cbor(["rag-rat/content-hash/1", payload_schema_version, nfc(trim title), nfc(trim body), payload]))`
- `kind` and `tags` **excluded** (a reclassification / re-tag must not churn a content-addressed overlay); the payload **included**, with its self-described `schema_version` folded separately (a payload-schema bump is a deliberate identity change). Distinct from the raw create-time `memory_input_hash`.

## New `canonical` module — deterministic CBOR (RFC 8949 §4.2)
Definite lengths, minimal ints, **integer-only**, map keys sorted by their **CBOR-encoded** bytes, NFC strings; domain-tagged + versioned so the rule can evolve deliberately. A golden-vector test pins the exact encoding.

- **Integer-only:** a non-integer number is rejected. JSON floats collapse to binary64 at parse, so `1.0` and `1.0000000000000001` would hash identically — a content change the identity must not miss. Fractional values use a string or a scaled integer.
- **Two duplicate-key kinds** are rejected on write so the cross-device hash never diverges: **literal** (`{"a":1,"a":2}` — serde_json silently keeps last) via a strict recursive parse, and **NFC-normalized** (`café` precomposed vs decomposed) in the encoder.

`validate_payload` enforces both (plus is-object) on create/update — it is the **live consumer** that keeps the `canonical` module exercised. `content_hash` itself is **total** (it must never panic wherever it runs): any non-object / non-canonical payload — only a legacy or out-of-band one, since writes are validated — folds its **raw bytes** deterministically (a distinct CBOR major type, so no collision with a structured payload, and `"null"` does not collide with no-payload).

## Why no consumer yet (the decoupling)
An earlier revision made the **dream** freshness key (`note_content_hash`) fold the payload. Review surfaced that this is the wrong key for that job: the dream verdict/compaction **prompts audit title + body + code evidence, not the payload** (a Task's status/priority is not a code-divergence claim). A churn-skip freshness key must equal *exactly the derivation inputs of the artifact it guards* — folding the payload made the key finer than the inputs, which drops still-valid open divergences on a payload-only edit and needs an intrinsically-ambiguous rollout backfill (the legacy hash never captured the payload; `updated_at_ms` bumps on any edit).

So the dream freshness key **stays title+body** (unchanged from before this PR), consistent with what its prompts render. `content_hash` ships as the frozen, golden-tested identity the phase-B op log / D′ replication will content-address on; it carries `#[allow(dead_code)]` until that consumer lands. When dream prompts eventually render payloads, the key switches to `content_hash` in the same change as the required `PROMPT_VERSION` bump — which re-queues every memory anyway, so that rollout is **backfill-free**.

No schema migration.

## Deferred (#488)
The duplicate-key rejection is complete for callers that pass the **raw** payload string (CLI, direct core). The MCP JSON-RPC transport parses tool args into a `serde_json::Value` upstream, which collapses literal dups *deterministically* (serde_json last-wins) before any rag-rat code runs — so there is no divergence among today's serde_json writers. Hardening that wire boundary (preserve raw payload bytes → strict-parse before collapse) is tracked in #488; it becomes load-bearing only when the op log makes payloads cross-tool content-addressed.

Refs #478, #404.
