### PR TITLE
feat(index): quiet-pass WAL checkpointing + doctor file-health warnings

### DIFF
--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -206,7 +206,7 @@ pub(crate) fn run_watch(config: Config) -> anyhow::Result<()> {
 
 pub(crate) fn doctor(config: &Config) -> anyhow::Result<()> {
     let schema = IndexDatabase::migration_check(&config.database)?;
-    let (index, discovery, storage, clone_fingerprints) =
+    let (index, discovery, storage, clone_fingerprints, file_health) =
         if schema.state == rag_rat_core::index::schema::SchemaState::Compatible {
             let db = IndexDatabase::open_config(config)?;
             let mut index_status = serde_json::to_value(db.status(&config.database)?)?;
@@ -221,15 +221,17 @@ pub(crate) fn doctor(config: &Config) -> anyhow::Result<()> {
                 Some(serde_json::to_value(db.discovery_status(config)?)?),
                 Some(serde_json::to_value(db.storage_status()?)?),
                 Some(serde_json::to_value(db.clone_fingerprint_health()?)?),
+                Some(serde_json::to_value(db.database_file_health()?)?),
             )
         } else {
-            (None, None, None, None)
+            (None, None, None, None, None)
         };
     print_output(&serde_json::json!({
         "config_root": config.root,
         "database": config.database,
         "schema": schema,
         "storage": storage,
+        "file_health": file_health,
         "discovery": discovery,
         "clone_fingerprints": clone_fingerprints,
         "targets": config.targets.iter().map(|target| serde_json::json!({

--- a/crates/rag-rat-cli/tests/doctor_file_health.rs
+++ b/crates/rag-rat-cli/tests/doctor_file_health.rs
@@ -1,0 +1,61 @@
+//! `doctor` must surface the database file-health block (#482): WAL sidecar size and freelist
+//! dead space were previously invisible, so an oversized `-wal` or a mostly-free file could only
+//! be found by inspecting the data dir by hand.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use rag_rat_core::Config;
+
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Build a throwaway index over one Rust file and return (root, config path).
+fn build_index() -> (PathBuf, PathBuf) {
+    let root = std::env::temp_dir().join(format!(
+        "rag-rat-cli-doctor-health-{}-{}",
+        std::process::id(),
+        TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn doctor_probe() {}\n").unwrap();
+    fs::write(
+        root.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\ndatabase = \".rag-rat/index.sqlite\"\n\n[target_bindings]\nrust = \
+         [\"src\"]\n",
+    )
+    .unwrap();
+    let config_path = root.join("rag-rat.toml");
+    let config = Config::load(&config_path).unwrap();
+    rag_rat_core::IndexDatabase::rebuild(&config).unwrap();
+    (root, config_path)
+}
+
+#[test]
+fn doctor_reports_database_file_health() {
+    let (root, config_path) = build_index();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_rag-rat"))
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--json")
+        .arg("doctor")
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "doctor failed: {}", String::from_utf8_lossy(&out.stderr));
+    let report: serde_json::Value =
+        serde_json::from_str(&String::from_utf8(out.stdout).unwrap()).unwrap();
+
+    let health = &report["file_health"];
+    assert!(health.is_object(), "doctor must report a file_health block, got: {report}");
+    assert!(health["main_bytes"].as_u64().unwrap() > 0);
+    assert!(health["page_count"].as_i64().unwrap() > 0);
+    // A one-file fixture is nowhere near either warn threshold — flags present and quiet.
+    assert_eq!(health["wal_oversized"], serde_json::Value::Bool(false));
+    assert_eq!(health["freelist_excessive"], serde_json::Value::Bool(false));
+    assert!(health["note"].is_null(), "no advisory on a healthy file: {health}");
+
+    let _ = fs::remove_dir_all(&root);
+}

--- a/crates/rag-rat-core/src/index/mod.rs
+++ b/crates/rag-rat-core/src/index/mod.rs
@@ -62,8 +62,9 @@ pub use query_api::{
     CLONE_DELTA_MAX_FILES, CandidateCloneClass, CloneCheckInput, CloneCompleteness,
     CloneDeltaReport, CloneEdgeReport, CloneEligibility, CloneFingerprintHealth,
     CloneIneligibilityReason, CloneMember, CloneSymbolSelector, ClonesForSymbolResult,
-    FindClonesOptions, FindClonesResult, GcReport, ImportantSymbolsRequest, OracleShaSnapshots,
-    RoiFactors, SearchRequest, TextCloneMatch,
+    DatabaseFileHealth, FindClonesOptions, FindClonesResult, GcReport, ImportantSymbolsRequest,
+    OracleShaSnapshots, RoiFactors, SearchRequest, TextCloneMatch, WAL_CHECKPOINT_MIN_BYTES,
+    WalCheckpointReport,
 };
 pub(crate) use util::*;
 

--- a/crates/rag-rat-core/src/index/query_api/db_file_health.rs
+++ b/crates/rag-rat-core/src/index/query_api/db_file_health.rs
@@ -1,0 +1,288 @@
+//! Physical health of the shared database file (#482): WAL checkpointing and size/freelist
+//! reporting on `IndexDatabase`. The global store is written by every repo's watcher, hooks, and
+//! MCP servers, but nothing owned its file hygiene: passive autocheckpoint never truncates the
+//! `-wal` (it keeps its high-water mark forever) and freed pages stay in the freelist. The
+//! checkpoint here is threshold-gated (a bare `stat` of the sidecar) so quiet watcher passes can
+//! attempt it for free; `database_file_health` feeds the `doctor` report.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use super::*;
+
+/// The pass-tail checkpoint trigger: attempt `wal_checkpoint(TRUNCATE)` only once the sidecar
+/// exceeds this. A healthy autocheckpointing WAL stays around 4 MiB (1000 default-size pages), so
+/// anything past this is accumulated high-water from a heavy write phase. Below it, the probe is a
+/// single `stat` — cheap enough for every quiet watcher pass.
+pub const WAL_CHECKPOINT_MIN_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Doctor warning threshold for the `-wal` sidecar: past this, checkpoints are being starved
+/// (long-lived readers) or no quiet pass ever runs — worth surfacing rather than silently holding
+/// disk.
+const WAL_WARN_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Doctor warning threshold for dead space: freelist pages as a fraction of the whole file.
+const FREELIST_WARN_FRACTION: f64 = 0.25;
+
+/// Freelist floor below which the fraction never warns — a small database reusing a few dozen
+/// pages is healthy churn, not reclaimable waste. 2560 default-size (4 KiB) pages ≈ 10 MiB.
+const FREELIST_WARN_MIN_PAGES: i64 = 2_560;
+
+/// What [`IndexDatabase::checkpoint_wal_if_oversized`] did, for the caller's debug logging.
+#[derive(Debug, Clone, Serialize)]
+pub struct WalCheckpointReport {
+    /// Sidecar size at the probe (0 when the file is absent).
+    pub wal_bytes_before: u64,
+    /// False when the sidecar was under the threshold and nothing ran.
+    pub attempted: bool,
+    /// True when the checkpoint fully completed and truncated the sidecar (`busy = 0`). False
+    /// under concurrent readers/writers that kept frames pinned — the next quiet pass retries.
+    pub truncated: bool,
+}
+
+/// Physical health of the database file for the `doctor` report: sizes, freelist share, and the
+/// two warning flags with an actionable note. Facts a reader acts on, not internal counters.
+#[derive(Debug, Clone, Serialize)]
+pub struct DatabaseFileHealth {
+    pub main_bytes: u64,
+    pub wal_bytes: u64,
+    pub page_count: i64,
+    pub freelist_pages: i64,
+    /// `freelist_pages / page_count` (0 for an empty file).
+    pub freelist_fraction: f64,
+    /// The `-wal` sidecar exceeds the warn threshold: checkpoints are starved or never attempted.
+    pub wal_oversized: bool,
+    /// Dead space exceeds the warn fraction (with a floor): a one-off `VACUUM` would reclaim it.
+    pub freelist_excessive: bool,
+    /// Actionable remedy when either flag is set; `None` otherwise.
+    pub note: Option<String>,
+}
+
+impl IndexDatabase {
+    /// Truncate the WAL sidecar when it has outgrown `min_bytes`; below that, a bare `stat` and
+    /// return. Best-effort: `wal_checkpoint(TRUNCATE)` waits for concurrent readers only within
+    /// `busy_timeout`, then reports `truncated: false` rather than erroring, and the next quiet
+    /// pass retries. Callers must NOT compensate for a busy report by weakening durability —
+    /// `synchronous` stays NORMAL on the shared database (the A6 global constraint, #401).
+    pub fn checkpoint_wal_if_oversized(
+        &self,
+        min_bytes: u64,
+    ) -> anyhow::Result<WalCheckpointReport> {
+        let wal_bytes_before = wal_bytes(self.storage.database_path());
+        if wal_bytes_before < min_bytes {
+            return Ok(WalCheckpointReport {
+                wal_bytes_before,
+                attempted: false,
+                truncated: false,
+            });
+        }
+        // Row shape: (busy, log, checkpointed). busy = 1 means readers/writers kept the truncate
+        // from completing after the busy handler gave up — not an error.
+        let busy =
+            self.storage
+                .connection()
+                .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| row.get::<_, i64>(0))?;
+        Ok(WalCheckpointReport { wal_bytes_before, attempted: true, truncated: busy == 0 })
+    }
+
+    /// Size and dead-space facts about the database file, with warning flags at the default
+    /// thresholds. Read-only; feeds the `doctor` report.
+    pub fn database_file_health(&self) -> anyhow::Result<DatabaseFileHealth> {
+        self.database_file_health_at(
+            WAL_WARN_BYTES,
+            FREELIST_WARN_FRACTION,
+            FREELIST_WARN_MIN_PAGES,
+        )
+    }
+
+    /// [`Self::database_file_health`] with the thresholds injected (tests).
+    pub(crate) fn database_file_health_at(
+        &self,
+        wal_warn_bytes: u64,
+        freelist_warn_fraction: f64,
+        freelist_warn_min_pages: i64,
+    ) -> anyhow::Result<DatabaseFileHealth> {
+        let conn = self.storage.connection();
+        let page_count: i64 = conn.query_row("PRAGMA page_count", [], |row| row.get(0))?;
+        let freelist_pages: i64 = conn.query_row("PRAGMA freelist_count", [], |row| row.get(0))?;
+        let main_bytes =
+            std::fs::metadata(self.storage.database_path()).map(|meta| meta.len()).unwrap_or(0);
+        let wal_bytes = wal_bytes(self.storage.database_path());
+        let freelist_fraction =
+            if page_count > 0 { freelist_pages as f64 / page_count as f64 } else { 0.0 };
+        let wal_oversized = wal_bytes > wal_warn_bytes;
+        let freelist_excessive =
+            freelist_pages >= freelist_warn_min_pages && freelist_fraction > freelist_warn_fraction;
+        let note = match (wal_oversized, freelist_excessive) {
+            (false, false) => None,
+            (wal, freelist) => {
+                let mut parts = Vec::new();
+                if wal {
+                    parts.push(
+                        "the -wal sidecar is oversized — a quiet watcher pass truncates it, or \
+                         long-lived readers are starving checkpoints",
+                    );
+                }
+                if freelist {
+                    parts.push(
+                        "dead space is excessive — reclaim with a one-off `VACUUM` on the \
+                         database while no rag-rat writers are running (stop agents/watchers \
+                         first)",
+                    );
+                }
+                Some(parts.join("; "))
+            },
+        };
+        Ok(DatabaseFileHealth {
+            main_bytes,
+            wal_bytes,
+            page_count,
+            freelist_pages,
+            freelist_fraction,
+            wal_oversized,
+            freelist_excessive,
+            note,
+        })
+    }
+}
+
+/// Size of the `-wal` sidecar, 0 when absent. SQLite derives the sidecar name by appending
+/// `-wal` to the database path byte-for-byte, so build it the same way (no extension juggling).
+fn wal_bytes(database: &Path) -> u64 {
+    let mut sidecar = database.as_os_str().to_os_string();
+    sidecar.push("-wal");
+    std::fs::metadata(PathBuf::from(sidecar)).map(|meta| meta.len()).unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+
+    static FIXTURE_SEQ: AtomicU64 = AtomicU64::new(0);
+
+    /// Minimal single-file fixture: file-health tests need a real WAL-mode database with a
+    /// registered repo, not any particular indexed content.
+    fn fixture_config(tag: &str) -> crate::Config {
+        let seq = FIXTURE_SEQ.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir()
+            .join(format!("rag-rat-file-health-{tag}-{}-{seq}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/a.rs"), "pub fn health_probe() -> i32 { 1 }\n").unwrap();
+        crate::Config {
+            repo_id_override: None,
+            database_key_pinned: true,
+            root: root.clone(),
+            database: root.join(".rag-rat/index.sqlite"),
+            targets: vec![crate::config::ResolvedTarget {
+                name: "rust".to_string(),
+                language: crate::language::Language::Rust,
+                directories: vec![std::path::PathBuf::from("src")],
+                include: vec!["src/".to_string()],
+                exclude: Vec::new(),
+                kind: crate::config::TargetKind::Source,
+            }],
+            llm: Default::default(),
+            watch: Default::default(),
+            version_check: Default::default(),
+            oracle: Default::default(),
+            search: Default::default(),
+            memory: Default::default(),
+            log: Default::default(),
+            source_root_reanchored_from: None,
+            allow_empty: false,
+        }
+    }
+
+    fn build_fixture(tag: &str) -> crate::IndexDatabase {
+        crate::IndexDatabase::rebuild(&fixture_config(tag)).unwrap()
+    }
+
+    /// Guarantee at least one un-checkpointed WAL frame (the rebuild may have autocheckpointed).
+    fn write_a_wal_frame(db: &crate::IndexDatabase) {
+        db.storage
+            .execute_batch(
+                "INSERT INTO index_meta(key, value) VALUES('file_health_probe', '1')
+                 ON CONFLICT(key) DO UPDATE SET value = value || '1'",
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn checkpoint_skips_when_wal_is_under_the_threshold() {
+        let db = build_fixture("skip");
+        write_a_wal_frame(&db);
+        let before = wal_bytes(db.storage.database_path());
+        assert!(before > 0, "fixture must have WAL content for the skip to be meaningful");
+
+        let report = db.checkpoint_wal_if_oversized(u64::MAX).unwrap();
+        assert!(!report.attempted, "under the threshold the checkpoint must not run");
+        assert!(!report.truncated);
+        assert_eq!(report.wal_bytes_before, before);
+        assert_eq!(
+            wal_bytes(db.storage.database_path()),
+            before,
+            "a skipped checkpoint must leave the WAL untouched"
+        );
+    }
+
+    #[test]
+    fn checkpoint_truncates_an_oversized_wal_to_zero() {
+        let db = build_fixture("truncate");
+        write_a_wal_frame(&db);
+        assert!(wal_bytes(db.storage.database_path()) > 0);
+
+        let report = db.checkpoint_wal_if_oversized(1).unwrap();
+        assert!(report.attempted);
+        assert!(report.truncated, "no concurrent readers → TRUNCATE must complete");
+        assert!(report.wal_bytes_before > 0);
+        assert_eq!(
+            wal_bytes(db.storage.database_path()),
+            0,
+            "TRUNCATE resets the WAL high-water mark to an empty sidecar"
+        );
+    }
+
+    #[test]
+    fn file_health_stays_quiet_on_a_healthy_database() {
+        let db = build_fixture("healthy");
+        let health = db.database_file_health().unwrap();
+        assert!(health.main_bytes > 0);
+        assert!(health.page_count > 0);
+        assert!(
+            (0.0..=1.0).contains(&health.freelist_fraction),
+            "fraction is a ratio, got {}",
+            health.freelist_fraction
+        );
+        assert!(!health.wal_oversized, "a fresh fixture is nowhere near the WAL warn threshold");
+        assert!(!health.freelist_excessive);
+        assert!(health.note.is_none(), "no advisory when nothing is wrong");
+    }
+
+    #[test]
+    fn file_health_flags_fire_with_injected_thresholds() {
+        let db = build_fixture("flags");
+        write_a_wal_frame(&db);
+        // Free a deterministic batch of pages: stage a scratch table (in `main` — a temp table
+        // lives in a separate temp database and frees nothing here), then drop it.
+        db.storage
+            .execute_batch(
+                "CREATE TABLE file_health_scratch(x BLOB);
+                 WITH RECURSIVE cnt(i) AS (SELECT 1 UNION ALL SELECT i + 1 FROM cnt WHERE i < 200)
+                 INSERT INTO file_health_scratch SELECT randomblob(4096) FROM cnt;
+                 DROP TABLE file_health_scratch;",
+            )
+            .unwrap();
+
+        let health = db.database_file_health_at(1, 0.0, 1).unwrap();
+        assert!(health.wal_bytes > 1, "the meta write and drop must have landed in the WAL");
+        assert!(health.wal_oversized, "wal_warn_bytes=1 must flag any non-empty WAL");
+        assert!(health.freelist_pages > 0, "dropping the scratch table must free pages");
+        assert!(health.freelist_excessive, "zero thresholds must flag any freelist");
+        let note = health.note.expect("an advisory accompanies raised flags");
+        assert!(note.contains("VACUUM"), "the freelist remedy names VACUUM: {note}");
+    }
+}

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -8,6 +8,7 @@ use crate::search::lexical::SearchOptions;
 
 mod ai_lifecycle;
 mod clones;
+mod db_file_health;
 mod dream;
 mod gc;
 mod graph;
@@ -31,6 +32,7 @@ pub use clones::{
 };
 #[cfg(test)]
 pub(crate) use clones::{MAX_MEMBERS, MEMBER_VALUE_CAP};
+pub use db_file_health::{DatabaseFileHealth, WAL_CHECKPOINT_MIN_BYTES, WalCheckpointReport};
 pub use gc::GcReport;
 pub use importance::ImportantSymbolsRequest;
 pub use oracle_runs::OracleShaSnapshots;

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -201,6 +201,9 @@ fn run_pass(
     // content change runs the full tail immediately. Startup has two discover-only exceptions:
     // a prior bounded shutdown discover that marked base reconcile owed, and an already-indexed
     // base embedding backlog left by a time-capped or blocked prior pass.
+    // A pass with no content/overlay change is the quiet moment WAL hygiene waits for (#482) —
+    // whether or not something else (gc, a backlog, the clone gate) still forces the tail below.
+    let quiet_pass = !content_changed && !overlays_changed;
     if !should_run_pass_tail(
         content_changed,
         overlays_changed,
@@ -209,6 +212,7 @@ fn run_pass(
         base_embedding_backlog,
         clone_graph_due,
     ) {
+        maybe_checkpoint_wal(&db, quiet_pass, crate::index::WAL_CHECKPOINT_MIN_BYTES);
         return Ok(());
     }
     // The base reconcile gets only the budget the overlays left behind; `None` → already exhausted,
@@ -245,7 +249,34 @@ fn run_pass(
     if shutdown_reconcile_pending && base_reconcile_status.as_deref() == Some("Current") {
         db.clear_watch_shutdown_reconcile_pending()?;
     }
+    maybe_checkpoint_wal(&db, quiet_pass, crate::index::WAL_CHECKPOINT_MIN_BYTES);
     Ok(())
+}
+
+/// Opportunistic WAL hygiene (#482), on QUIET passes only: nothing else truncates the shared
+/// database's `-wal`, so it keeps its high-water mark forever without this. During sustained
+/// editing every pass has content changes, so the truncate — which waits on concurrent readers up
+/// to the busy timeout — defers exactly like the clone-graph rebuild and lands once churn pauses.
+/// Under `min_bytes` the probe is a bare stat of the sidecar, free on idle passes. Best-effort: a
+/// busy or failed checkpoint just rides the next quiet pass, and never fails the pass itself.
+fn maybe_checkpoint_wal(db: &IndexDatabase, quiet_pass: bool, min_bytes: u64) {
+    if !quiet_pass {
+        return;
+    }
+    match db.checkpoint_wal_if_oversized(min_bytes) {
+        Ok(report) if report.attempted => {
+            tracing::debug!(
+                target: "rag_rat_core::watch",
+                wal_bytes_before = report.wal_bytes_before,
+                truncated = report.truncated,
+                "wal checkpoint attempted"
+            );
+        },
+        Ok(_) => {},
+        Err(err) => {
+            tracing::debug!(target: "rag_rat_core::watch", error = %err, "wal checkpoint failed");
+        },
+    }
 }
 
 fn should_run_pass_tail(
@@ -1705,6 +1736,43 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn wal_checkpoint_runs_on_quiet_passes_only() {
+        // #482: the TRUNCATE checkpoint waits on concurrent readers up to the busy timeout, so a
+        // churn pass (content changed) must never attempt it; it lands on the first quiet pass
+        // after editing pauses — the same deferral posture as the clone-graph rebuild.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let id = N.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir()
+            .join(format!("ragrat-watch-wal-checkpoint-{}-{id}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/a.rs"), "pub fn wal_probe() -> i32 { 1 }\n").unwrap();
+        let config = whole_root_config(&root, &[PathBuf::from("src")]);
+        let db = IndexDatabase::rebuild(&config).unwrap();
+
+        // Put frames in the WAL so there is something to truncate (any meta write serves).
+        db.mark_watch_shutdown_reconcile_pending().unwrap();
+        db.clear_watch_shutdown_reconcile_pending().unwrap();
+        assert!(db.database_file_health().unwrap().wal_bytes > 0);
+
+        maybe_checkpoint_wal(&db, false, 1);
+        assert!(
+            db.database_file_health().unwrap().wal_bytes > 0,
+            "a churn pass must leave the WAL alone"
+        );
+
+        maybe_checkpoint_wal(&db, true, 1);
+        assert_eq!(
+            db.database_file_health().unwrap().wal_bytes,
+            0,
+            "a quiet pass truncates the oversized WAL"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #482.

Nothing owned the shared database's file hygiene: the only `wal_checkpoint(TRUNCATE)` in the tree runs during `consolidate` against the legacy per-repo file, so the global store's `-wal` kept its high-water mark forever (passive autocheckpoint never truncates, and is deferred by long-lived readers), and pages freed by generation churn accumulated invisibly in the freelist — measured at 29% of a 530 MB dogfood database.

**Core** (`index/query_api/db_file_health.rs`, new sibling module):
- `IndexDatabase::checkpoint_wal_if_oversized(min_bytes)` — `PRAGMA wal_checkpoint(TRUNCATE)` behind a bare `stat` of the sidecar (free under the 16 MiB threshold). Best-effort: busy under concurrent readers reports `truncated: false` rather than erroring, and the next attempt retries.
- `IndexDatabase::database_file_health()` — main/WAL bytes, page and freelist counts, freelist fraction, and two warning flags (`wal_oversized` > 64 MiB, `freelist_excessive` > 25% with a ~10 MiB floor) with an actionable note.

**Watcher** (`watch.rs`): the pass tail attempts the checkpoint on **quiet passes only** (no content/overlay change) — during sustained editing it defers exactly like the #472 clone-graph quiet gate and lands once churn pauses. Never fails the pass.

**Doctor**: gains a `file_health` block so an oversized `-wal` or excessive dead space surfaces with a remedy (one-off `VACUUM` while no writers run) instead of silent disk growth.

Durability is untouched — `synchronous` stays NORMAL per the A6 global constraint (#401). `auto_vacuum=INCREMENTAL` was evaluated and deliberately not adopted: enabling it on an existing file requires a full `VACUUM` under total write lockout, so the doctor-suggested one-off remains the better shape.

Tests: threshold-skip and truncate-to-zero behavior, health flags via injected thresholds (scratch-table drop to populate the freelist), quiet-vs-churn gating in the watcher, and a CLI integration test pinning the `file_health` block in `doctor --json`.