### PR TITLE
feat(schema): actionable version-skew messaging for the newer-schema refusal

### DIFF
--- a/crates/rag-rat-cli/src/claude_hook/mod.rs
+++ b/crates/rag-rat-cli/src/claude_hook/mod.rs
@@ -315,6 +315,15 @@ fn session_start(input: &HookInput) -> anyhow::Result<()> {
     // (`let _ = run_inner()`) — so the hook stays silent and never blocks session start. Do NOT
     // add error prints here: this branch's stdout is injected as model context.
     let conn = IndexConnection::open_read_only(&config.database)?;
+    // Version skew (#484): a schema created by a newer rag-rat means this binary — and the MCP
+    // server this session just started, which is at most as new — will refuse every open. Say so
+    // actionably instead of composing a digest that half-works today and errors tomorrow. The
+    // schema message already carries the remedy (and the non-Linux no-hot-upgrade caveat).
+    let schema = rag_rat_core::index::schema::status(conn.connection())?;
+    if schema.state == rag_rat_core::index::schema::SchemaState::Newer {
+        print!("{}", newer_schema_notice(&schema.message));
+        return Ok(());
+    }
     // Scope orientation to the session's worktree: `config.root` (anchored to the main worktree) is
     // the base index, `input.cwd` is where the session is — a linked worktree gets its branch
     // overlay (#219). find_config already anchored config.root to the main worktree, so the two
@@ -332,6 +341,16 @@ fn session_start(input: &HookInput) -> anyhow::Result<()> {
         print!("{line}");
     }
     Ok(())
+}
+
+/// The session-start notice replacing the digest when the index schema is NEWER than this binary
+/// (#484). Pure so it's testable; `schema_message` is the core refusal text, which carries the
+/// remedy and the platform caveat.
+fn newer_schema_notice(schema_message: &str) -> String {
+    format!(
+        "⚠ rag-rat version skew: {schema_message}. Repo-intelligence MCP tools in this session \
+         will error until then.\n"
+    )
 }
 
 /// One digest line stating the running version vs the latest published on crates.io, with the

--- a/crates/rag-rat-cli/tests/claude_hook_e2e.rs
+++ b/crates/rag-rat-cli/tests/claude_hook_e2e.rs
@@ -299,3 +299,44 @@ fn wait_until_gone(path: &Path, timeout: Duration) {
     }
     panic!("listener at {} still accepting after {timeout:?}", path.display());
 }
+
+/// #484: when the index schema was created by a newer rag-rat (one upgraded agent migrated the
+/// shared DB; this hook binary — and therefore this session's MCP server — is older), the
+/// session-start digest must become an actionable version-skew notice instead of going silent.
+#[test]
+fn session_start_warns_when_the_index_schema_is_newer() {
+    let dir = std::env::temp_dir().join(format!("ragrat-hook-newer-schema-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(dir.join("src/lib.rs"), "pub fn skew_probe() {}\n").unwrap();
+    std::fs::write(
+        dir.join("rag-rat.toml"),
+        "[index]\nroot = \".\"\ndatabase = \".rag-rat/index.sqlite\"\n\n[target_bindings]\nrust = \
+         [\"src\"]\n",
+    )
+    .unwrap();
+    let config = rag_rat_core::Config::load(dir.join("rag-rat.toml")).unwrap();
+    rag_rat_core::IndexDatabase::rebuild(&config).unwrap();
+
+    // Make the schema read as created-by-a-future-rag-rat: an unrecognized migration id.
+    let conn = rusqlite::Connection::open(&config.database).unwrap();
+    conn.execute_batch(
+        "INSERT INTO schema_version(id, applied_at_ms, checksum, description)
+         VALUES ('999_future_schema', 1, 'sha256:future', 'future schema');",
+    )
+    .unwrap();
+    drop(conn);
+
+    let input = serde_json::json!({
+        "session_id": "s-skew", "cwd": dir, "hook_event_name": "SessionStart",
+        "source": "startup"
+    });
+    let (stdout, status) = run_hook(&input.to_string(), &dir);
+    assert!(status.success(), "the hook must never block session start");
+    assert!(
+        stdout.contains("newer rag-rat") && stdout.contains("upgrade rag-rat"),
+        "expected an actionable version-skew notice, got: {stdout:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -764,6 +764,19 @@ pub fn migrate_forward(conn: &Connection) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Appended to the `Newer` refusal: on Linux the fleet hot-upgrade re-execs armed MCP servers
+/// when a new binary lands, so a stale server heals itself once rag-rat is reinstalled; on every
+/// other platform running servers keep the old binary until their sessions restart, and the
+/// message must say so (#484).
+fn hot_upgrade_caveat() -> &'static str {
+    if cfg!(target_os = "linux") {
+        ""
+    } else {
+        "; running MCP servers do not hot-upgrade on this platform — restart their sessions after \
+         upgrading"
+    }
+}
+
 pub fn status(conn: &Connection) -> anyhow::Result<SchemaStatus> {
     if !table_exists(conn, "schema_version")? {
         let has_legacy_tables = table_exists(conn, "files")? || table_exists(conn, "chunks")?;
@@ -819,7 +832,14 @@ pub fn status(conn: &Connection) -> anyhow::Result<SchemaStatus> {
             current_version: known_version(&migrations),
             latest_version: LATEST_SCHEMA_VERSION,
             migrations,
-            message: "index schema was created by a newer rag-rat; refusing to open".to_string(),
+            // #484: on a shared global DB one upgraded agent migrates the schema and every
+            // process still on an older binary lands here — the refusal must carry the remedy,
+            // because it surfaces as the error text of every CLI/MCP open.
+            message: format!(
+                "index schema was created by a newer rag-rat; refusing to open — upgrade rag-rat \
+                 or restart sessions/servers still running an older binary{}",
+                hot_upgrade_caveat()
+            ),
         });
     }
     let current_version = known_version(&migrations);

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -661,6 +661,17 @@ fn compatible_open_refuses_dirty_and_newer_schema() {
     assert_eq!(newer.state, schema::SchemaState::Newer);
     let err = IndexDatabase::open(&database).unwrap_err().to_string();
     assert!(err.contains("newer rag-rat"), "{err}");
+    // #484: the refusal must carry the remedy — on a shared global DB one upgraded agent migrates
+    // the schema and every older-binary process hits this, so a bare refusal reads as breakage.
+    assert!(err.contains("upgrade rag-rat"), "{err}");
+    assert!(err.contains("restart"), "{err}");
+    // The fleet hot-upgrade re-execs armed MCP servers only on Linux; elsewhere the message must
+    // say running servers stay stale until their sessions restart.
+    if cfg!(target_os = "linux") {
+        assert!(!err.contains("hot-upgrade"), "{err}");
+    } else {
+        assert!(err.contains("do not hot-upgrade"), "{err}");
+    }
 
     let _ = fs::remove_dir_all(root);
 }


### PR DESCRIPTION
Fixes #484.

With the shared global database, one upgraded agent migrates the schema (under the global schema lock) and every process still running an older binary refuses to open with a bare "index schema was created by a newer rag-rat; refusing to open". That reads as breakage rather than skew, surfaces as an opaque per-tool error in whichever session is stale, and on macOS/Windows nothing self-heals — the fleet hot-upgrade walks `/proc` and signals `SIGUSR1`, so it is Linux-only by construction.

Two changes, one message as the root fix:

- **Core** (`schema::status`): the `Newer` refusal now carries the remedy — upgrade rag-rat, or restart sessions/servers still running an older binary — and, on non-Linux platforms, states that running MCP servers do not hot-upgrade and need their sessions restarted after upgrading. Every surface that renders `status().message` inherits this for free: the CLI/MCP open errors (`open`, `migrate_schema_only`, `open_config`) and the `doctor` schema block, which already reports `state` / `current_version` / `latest_version` in both skew directions.
- **Session-start hook**: after its read-only open, the hook checks the schema state; on `Newer` it prints a one-line version-skew notice (reusing the core message) instead of composing an orientation digest that half-works today and errors tomorrow. Previously this path went silent, so the agent lost repo intelligence with no explanation.

The `Older` direction already self-describes ("migrates forward automatically on open") and needs no nudge — it heals on the next write pass.

Deliberately out of scope, per the issue: porting the `/proc`-walk fleet mechanism to other platforms, and the optional `version-check.json` request-boundary probe.

Tests: the existing dirty/newer refusal test now pins the remediation text (with per-platform hot-upgrade caveat assertions), and a new hook e2e builds a real index, stamps a future migration id, and asserts the session-start notice replaces the digest without blocking session start.