### PR TITLE
feat(clones): per-generation df snapshot (clone_df_epoch) frees the live df to move

### DIFF
--- a/crates/rag-rat-core/src/index/file_index.rs
+++ b/crates/rag-rat-core/src/index/file_index.rs
@@ -11,6 +11,13 @@ struct ChunkInsertFile<'a> {
     source_revision: &'a str,
 }
 
+/// Whether `write_symbol_fingerprints` should bump the LIVE `clone_token_df` per token (#215,
+/// restored by #479). Named so the call site reads its intent: `BumpDf(false)` on the
+/// full-rebuild path (df is recomputed authoritatively at finalize, so the per-token bump is
+/// wasted work), `BumpDf(true)` on the incremental/heal path (no finalize runs there, so the
+/// bump keeps the live df current).
+struct BumpDf(bool);
+
 impl IndexDatabase {
     pub fn heal_file(&self, path: &Path) -> anyhow::Result<()> {
         // A heal reads bytes from `source_root` (the MAIN checkout). Under a linked-worktree
@@ -230,13 +237,18 @@ impl IndexDatabase {
         )?;
         let symbol_db_ids = self.insert_symbols(file_id, file.language, &prepared.symbols)?;
         // Clone fingerprints were computed in the parallel prepare phase from the same parse used
-        // for symbols/edges (#230) — no second read, no second parse here, just the DB write. No
-        // path bumps `clone_token_df` anymore (#473 df EPOCH FREEZE): the persisted clone-graph
-        // postings order sub-block tokens by df AS OF their build, so moving df on incremental
-        // writes would desync them; df is refreshed authoritatively only at a FULL rebuild's
-        // finalize (refresh_clone_token_df, rebuild.rs). A new token simply rides `DF_FALLBACK`
-        // (selectivity-only) until the next full rebuild.
-        self.write_symbol_fingerprints(&symbol_db_ids, &prepared.symbol_fingerprints)?;
+        // for symbols/edges (#230) — no second read, no second parse here, just the DB write.
+        // bump_df = graph.is_none(): the full-rebuild path (graph: Some) recomputes clone_token_df
+        // authoritatively from the token-bag BLOBs in refresh_clone_token_df at finalize
+        // (rebuild.rs), so per-token upserts here would be recomputed-and-discarded — pure waste
+        // plus hot-row contention on common tokens. The incremental path (graph: None) runs no
+        // such finalize, so the bump is how the LIVE df stays current (#479 — the persisted
+        // postings' order is safe regardless: it is pinned per generation in `clone_df_epoch`).
+        self.write_symbol_fingerprints(
+            &symbol_db_ids,
+            &prepared.symbol_fingerprints,
+            BumpDf(graph.is_none()),
+        )?;
         // Edge candidates were computed in the parallel prepare phase with LOCAL symbol indices;
         // remap them to the real DB ids just assigned.
         match graph {
@@ -291,9 +303,9 @@ impl IndexDatabase {
             return Ok(());
         };
         let fingerprints = clones::fingerprint_symbols(parsed.root(), text, language, symbols);
-        // The heal path does not touch `clone_token_df` either — the #473 df epoch freeze (see
-        // `index_file`'s fingerprint write): df moves only at a full rebuild.
-        self.write_symbol_fingerprints(symbol_ids, &fingerprints)
+        // Heal/inline path runs no full-rebuild finalize, so the LIVE df is kept current here via
+        // the per-token bump (drift-tolerated; see write_symbol_fingerprints).
+        self.write_symbol_fingerprints(symbol_ids, &fingerprints, BumpDf(true))
     }
 
     /// Write precomputed baseline clone fingerprints (#215). `fingerprints` carries
@@ -305,19 +317,41 @@ impl IndexDatabase {
     /// The token bag is serialized into the `symbol_fingerprints.token_bag` BLOB column (#231),
     /// one BLOB per symbol — there is no longer a `symbol_token_postings` row-per-token write.
     ///
-    /// This write never touches `clone_token_df` (#473 df EPOCH FREEZE): df is recomputed
-    /// authoritatively only at a full rebuild's finalize (`refresh_clone_token_df`, rebuild.rs) —
-    /// or seeded once by `refresh_clone_token_df_if_unseeded` on a first standalone index — so the
-    /// persisted clone-graph postings and every later sub-block computation share one total order.
-    /// df is a selectivity hint only (the candidate read COALESCEs a missing row to
-    /// `DF_FALLBACK`), so epoch drift never changes a result — see query_api/clones.
+    /// `bump_df` gates the per-token LIVE `clone_token_df` upsert (#479 restored the #215
+    /// mechanism the #473 freeze removed). On the full-rebuild path it is `BumpDf(false)`:
+    /// `refresh_clone_token_df` (rebuild.rs) recomputes df exactly from the token-bag BLOBs at
+    /// finalize, so bumping per token here is recomputed-and-discarded work plus hot-row B-tree
+    /// contention on common tokens. On the incremental/heal paths it is `BumpDf(true)` — no
+    /// finalize runs there, so the drift-tolerated bump is how the LIVE df stays current for the
+    /// live candidate paths (a new token gets real selectivity instead of riding `DF_FALLBACK`
+    /// until the next full build). The PERSISTED graph is unaffected either way: each
+    /// generation's order is pinned in `clone_df_epoch` at its build.
     fn write_symbol_fingerprints(
         &self,
         symbol_db_ids: &[i64],
         fingerprints: &[(usize, clones::SymbolFingerprint)],
+        bump_df: BumpDf,
     ) -> anyhow::Result<()> {
         let conn = self.storage.connection();
         let normalizer_kind = clones::NormalizerKind::Baseline.as_db_str();
+        // Resolve the periphery scope ONCE (not per token). Post-A5 `clone_token_df`'s PK is
+        // `(repo_id, normalizer_kind, token_hash)`, so the upsert must stamp `repo_id` AND target
+        // it in the ON CONFLICT — the repo id is embedded as a per-call literal so the bound
+        // params (`?1` kind, `?2` token) stay unchanged. Pre-A5 (no `repo_id` column) uses the
+        // original SQL.
+        let clone_df_bump_sql =
+            match crate::index::schema::periphery_repo_scope(conn, "clone_token_df")? {
+                Some(repo_id) => format!(
+                    "INSERT INTO clone_token_df(repo_id, normalizer_kind, token_hash, df)
+                 VALUES ('{}', ?1, ?2, 1)
+                 ON CONFLICT(repo_id, normalizer_kind, token_hash) DO UPDATE SET df = df + 1",
+                    repo_id.replace('\'', "''")
+                ),
+                None => "INSERT INTO clone_token_df(normalizer_kind, token_hash, df)
+                 VALUES (?1, ?2, 1)
+                 ON CONFLICT(normalizer_kind, token_hash) DO UPDATE SET df = df + 1"
+                    .to_string(),
+            };
         for (local_index, fp) in fingerprints {
             let symbol_id = symbol_db_ids[*local_index];
             // The token bag rides the fingerprint row as ONE serialized BLOB (#231), replacing the
@@ -339,6 +373,17 @@ impl IndexDatabase {
                 token_bag_blob,
                 now_ms(),
             ])?;
+            // Bump the LIVE document frequency per distinct token ONLY when `bump_df`
+            // (incremental/heal): df is a selectivity hint for the live candidate paths (the read
+            // COALESCEs a missing row to DF_FALLBACK), so the increment-only drift is tolerated;
+            // full builds recompute exactly. R7: iterate the IN-MEMORY `fp.token_bag` — no decode
+            // round-trip.
+            if bump_df.0 {
+                for &(token_hash, _freq) in &fp.token_bag {
+                    conn.prepare_cached(&clone_df_bump_sql)?
+                        .execute(params![normalizer_kind, token_hash])?;
+                }
+            }
         }
         Ok(())
     }

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -290,11 +290,11 @@ impl IndexDatabase {
         // - apply_staged_parser_failures: THE batch-7 finding — the wave loop stages failures
         //   (`graph.is_some()` routing), so the finalize must publish them; at this connection's
         //   own (live) generation, atomic with its edges (no flip exists to defer to).
-        // - refresh_clone_token_df_if_unseeded: SEED the df epoch on a first standalone index
-        //   (pre-#473 this was an unconditional refresh). The #473 df EPOCH FREEZE keeps df fixed
-        //   between FULL rebuilds so the persisted clone-graph postings and every later sub-block
-        //   computation share one total order — an unconditional refresh here would both desync
-        //   them and re-invalidate the postings every incremental pass.
+        // - refresh_clone_token_df: recompute the LIVE df exactly (the wave ran with
+        //   `BumpDf(false)` — this pass, like the full rebuild, recomputes at finalize instead of
+        //   paying per-token upserts). Restored to the pre-#473 unconditional refresh by #479: the
+        //   persisted clone-graph postings are ordered by their own generation's `clone_df_epoch`,
+        //   so a live refresh no longer desyncs (or invalidates) anything.
         // - sync_fts + the graph/flags marks: chunk_fts was written inline and the edges/flags were
         //   just derived in full, so record freshness like the rebuild does — otherwise the very
         //   next open pays a full (safe but wasted) edge re-derive heal and an FTS rebuild.
@@ -308,7 +308,7 @@ impl IndexDatabase {
             self.finalize_base_edges(config, graph)?;
             self.rebuild_logical_symbols()?;
             self.apply_staged_parser_failures(self.active_generation)?;
-            self.refresh_clone_token_df_if_unseeded()?;
+            self.refresh_clone_token_df()?;
             self.sync_fts()?;
             self.mark_graph_index_current()?;
             self.mark_generated_flags_current()

--- a/crates/rag-rat-core/src/index/query_api/clones/delta.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/delta.rs
@@ -8,9 +8,11 @@
 //! - Edges are VERIFICATION RESULTS: `clone_edges.overlap` depends only on the two endpoint bags,
 //!   so an edit to file X cannot change any edge not touching X — edges between unchanged files
 //!   stay valid verbatim.
-//! - Prefix filtering is recall-lossless under ANY single consistent token order, and the #473 df
-//!   EPOCH FREEZE (see `refresh_clone_token_df_if_unseeded`) pins that order between FULL rebuilds,
-//!   so delta sub-blocks and the persisted postings always agree.
+//! - Prefix filtering is recall-lossless under ANY single consistent token order, and the
+//!   generation's `clone_df_epoch` snapshot (#479, superseding the #473 whole-table freeze) pins
+//!   the order its postings were built under — the delta reads THAT, so its sub-blocks and the
+//!   persisted postings always agree even while the live `clone_token_df` moves on incremental
+//!   passes.
 //!
 //! PARITY DISCIPLINE (pinned by `clone_graph_delta_matches_a_full_rebuild_over_an_edit_sequence`):
 //! the delta-maintained edge set must equal a from-scratch rebuild's at the same content. Two
@@ -113,6 +115,19 @@ impl IndexDatabase {
                 started,
             ));
         }
+        if !super::precompute::clone_df_epoch_exists(conn, live.generation)? {
+            // #479: the delta computes sub-blocks under the generation's pinned epoch; without
+            // the epoch rows the build order is unrecoverable, and patching under a different
+            // order would silently drop edges. One full rebuild re-pins it.
+            return Ok(report(
+                "NotEligible",
+                Some("live generation has no df epoch (pre-epoch build)"),
+                0,
+                0,
+                0,
+                started,
+            ));
+        }
         let revision = self.content_revision()?;
         if live.source_revision == revision {
             return Ok(CloneDeltaReport {
@@ -151,7 +166,12 @@ impl IndexDatabase {
             });
         }
 
-        let delta_bags = load_scoped_baseline_bags_for_paths(conn, &paths)?;
+        // #479: the delta's bags — and therefore every sub-block computed below — are ordered by
+        // the generation's FROZEN epoch, not the live `clone_token_df` (which moves on
+        // incremental passes). This is what keeps delta-emitted postings byte-compatible with the
+        // build's.
+        let epoch_df = super::substrate::load_clone_df_epoch(conn, generation)?;
+        let delta_bags = load_scoped_baseline_bags_for_paths(conn, &paths, &epoch_df)?;
         let anchors = anchors_for_paths(conn, &paths)?;
         let sub_blocks: BTreeMap<i64, Vec<i64>> = delta_bags
             .iter()
@@ -596,6 +616,10 @@ fn hydrate_posting_candidates(
 #[cfg(test)]
 mod tests {
     use super::super::precompute::tests::{clone_fixture_config, edge_keys};
+    use super::{
+        BTreeSet, CLONE_PRECOMPUTE_THETA, load_scoped_baseline_bags_for_paths, params,
+        sub_block_tokens,
+    };
     use crate::index::query_api::clones::precompute::CloneEdgeOptions;
 
     /// One incremental index over the fixture root (the watcher's discover path — works without
@@ -684,6 +708,97 @@ mod tests {
         let delta_edges = edge_keys(&db);
         let rebuilt_edges = force_rebuild_edges(&db);
         assert_eq!(delta_edges, rebuilt_edges, "compound deltas stay parity-equal");
+        drop(db);
+
+        // INTERLEAVED LIVE-INDEX STEP (#479): every reindex above already bumps the LIVE df; here
+        // an adversarial whole-table inversion (the most live drift could ever diverge from the
+        // pinned epoch) precedes one more edit + delta. Parity with a from-scratch rebuild must
+        // still hold — the delta orders by the generation's epoch, not the live table. (The
+        // byte-level discriminator lives in
+        // `delta_postings_are_ordered_by_the_epoch_not_the_live_df`; this step pins the
+        // end-to-end soundness claim on the edge set.)
+        {
+            let db = crate::IndexDatabase::open_config(&config).unwrap();
+            db.storage
+                .connection()
+                .execute("UPDATE clone_token_df SET df = 1000000 - df", [])
+                .unwrap();
+        }
+        std::fs::write(
+            config.root.join("src/e.rs"),
+            "pub fn load_shipment(db: Db) -> i32 { let s = db.get(50); validate(s); s + 1 }\n",
+        )
+        .unwrap();
+        let db = reindex(&config);
+        assert_eq!(db.apply_clone_graph_delta(64).unwrap().status, "Applied");
+        let delta_edges = edge_keys(&db);
+        let rebuilt_edges = force_rebuild_edges(&db);
+        assert_eq!(
+            delta_edges, rebuilt_edges,
+            "parity holds through an adversarial live-table inversion between deltas"
+        );
+    }
+
+    /// The byte-level pin for the #479 df split: the delta's persisted postings are ordered by
+    /// the generation's PINNED epoch, not the live `clone_token_df`. The live table is inverted
+    /// before the delta, so the two orders provably select DIFFERENT sub-block prefixes for the
+    /// touched file — and the postings must match the EPOCH's selection.
+    #[test]
+    fn delta_postings_are_ordered_by_the_epoch_not_the_live_df() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let config = clone_fixture_config("delta-epoch-postings");
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        let built = db.precompute_clone_graph(None).unwrap();
+        assert_eq!(built.status, "Complete");
+        // Adversarial live drift: invert the whole live table.
+        db.storage.connection().execute("UPDATE clone_token_df SET df = 1000000 - df", []).unwrap();
+        drop(db);
+
+        // A near-clone family member: enough shared (mid-df) and unique (df=1) tokens that the
+        // epoch and inverted-live orders pick different prefixes.
+        let touched = "src/shipment.rs".to_string();
+        std::fs::write(
+            config.root.join(&touched),
+            "pub fn load_shipment(db: Db) -> i32 { let s = db.get(50); validate(s); s + 1 }\n",
+        )
+        .unwrap();
+        let db = reindex(&config);
+        assert_eq!(db.apply_clone_graph_delta(64).unwrap().status, "Applied");
+
+        let conn = db.storage.connection();
+        let paths = vec![touched.clone()];
+        let sub_block_union = |df: &std::collections::HashMap<i64, i64>| -> BTreeSet<i64> {
+            load_scoped_baseline_bags_for_paths(conn, &paths, df)
+                .unwrap()
+                .iter()
+                .flat_map(|bag| sub_block_tokens(bag, CLONE_PRECOMPUTE_THETA))
+                .collect()
+        };
+        let epoch_df =
+            super::super::substrate::load_clone_df_epoch(conn, built.generation).unwrap();
+        let live_df = super::super::substrate::load_current_clone_df(conn).unwrap();
+        let under_epoch = sub_block_union(&epoch_df);
+        let under_live = sub_block_union(&live_df);
+        assert_ne!(
+            under_epoch, under_live,
+            "precondition: the inversion must actually change the prefix selection — if this \
+             fails the fixture has degenerated and the test is vacuous"
+        );
+
+        let persisted: BTreeSet<i64> = conn
+            .prepare(
+                "SELECT DISTINCT token_hash FROM clone_subblock_postings
+                 WHERE build_generation = ?1 AND path = ?2",
+            )
+            .unwrap()
+            .query_map(params![built.generation, touched], |r| r.get::<_, i64>(0))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        assert_eq!(
+            persisted, under_epoch,
+            "delta-emitted postings are selected under the generation's pinned epoch"
+        );
     }
 
     /// A current generation is a cheap no-op — and a SECOND delta right after an applied one must
@@ -947,8 +1062,10 @@ mod tests {
         drop(db);
 
         // A content pass inside the quiet window: the delta settles freshness in place; the
-        // drift-owed FULL rebuild stays deferred. The new file's tokens do NOT enter the frozen
-        // df epoch (that is exactly the drift the counter measures).
+        // drift-owed FULL rebuild stays deferred. #479: the new file's tokens DO enter the LIVE
+        // df immediately (the incremental bump), but the generation's PINNED epoch — what its
+        // postings are ordered by — still predates them; that gap is exactly the drift the
+        // counter measures.
         std::fs::write(
             config.root.join("src/i.rs"),
             "pub fn drift_probe(q: i64) -> i64 { q * 11 - 6 }\n",
@@ -956,13 +1073,17 @@ mod tests {
         .unwrap();
         crate::watch::maintenance_pass(&config, false).unwrap();
         let db = crate::IndexDatabase::open_config(&config).unwrap();
-        let df_count = |db: &crate::IndexDatabase| -> i64 {
+        let epoch_count = |db: &crate::IndexDatabase, generation: i64| -> i64 {
             db.storage
                 .connection()
-                .query_row("SELECT COUNT(*) FROM clone_token_df", [], |r| r.get(0))
+                .query_row(
+                    "SELECT COUNT(*) FROM clone_df_epoch WHERE build_generation = ?1",
+                    [generation],
+                    |r| r.get(0),
+                )
                 .unwrap()
         };
-        let frozen_df = df_count(&db);
+        let pinned_epoch = epoch_count(&db, built.generation);
         let live: i64 = db
             .storage
             .connection()
@@ -999,11 +1120,13 @@ mod tests {
             .unwrap();
         assert!(live > built.generation, "the quiet-elapsed pass ran the drift full rebuild");
         assert_eq!(absorbed, 0, "the fresh generation starts with zero absorbed deltas");
-        // The whole POINT of the drift rebuild (PR #477 review): it must refresh the df epoch,
-        // not just reset the counter — the delta-added file's tokens enter df with the rebuild.
+        // The whole POINT of the drift rebuild (PR #477 review): it must move the PINNED epoch,
+        // not just reset the counter — the fresh generation's postings are ordered by a df that
+        // includes the delta-added file's tokens (#479: the live table already had them from the
+        // incremental bump; the rebuild is what folds them into the served order).
         assert!(
-            df_count(&db) > frozen_df,
-            "the drift full rebuild refreshes the df epoch (absorbs the delta-added tokens)"
+            epoch_count(&db, live) > pinned_epoch,
+            "the drift full rebuild re-pins the epoch with the delta-added tokens"
         );
     }
 

--- a/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/of_text.rs
@@ -24,8 +24,8 @@ use rusqlite::{Connection, params, params_from_iter};
 use serde::Serialize;
 
 use super::substrate::{
-    DF_FALLBACK, SymbolBag, TokenPosting, load_scoped_baseline_bags, overlap, sub_block_tokens,
-    verified_clone,
+    DF_FALLBACK, SymbolBag, TokenPosting, load_clone_df_epoch, load_current_clone_df,
+    load_scoped_baseline_bags, overlap, sub_block_tokens, verified_clone,
 };
 use super::{HYDRATION_CHUNK, THETA};
 use crate::index::clones::bag_blob::decode_token_bag;
@@ -217,7 +217,7 @@ impl CheckIndex {
         if indexed.is_empty() {
             return Ok(None);
         }
-        let df_by_token = load_clone_token_df(conn)?;
+        let df_by_token = load_current_clone_df(conn)?;
         let mut id_to_idx = HashMap::with_capacity(indexed.len());
         let mut by_struct: HashMap<(String, String), Vec<i64>> = HashMap::new();
         let mut inverted: HashMap<i64, Vec<i64>> = HashMap::new();
@@ -309,8 +309,9 @@ impl CloneCorpus for CheckIndex {
 /// The BOUNDED postings fast path (#296 phase 3): resolve EXACT + NEAR candidates for each new
 /// function with index-covered SQL against the live clone-graph generation's persisted
 /// `clone_subblock_postings`, instead of preloading every scoped bag into a RAM inverted index.
-/// Held per batch; the only up-front load is `clone_token_df` (a small selectivity table, NOT
-/// O(functions)) for the new bags' token ordering.
+/// Held per batch; the only up-front load is the generation's `clone_df_epoch` (a small
+/// selectivity table, NOT O(functions)) for the new bags' token ordering (#479 — the pinned
+/// order the postings were built under, not the moving live `clone_token_df`).
 struct IndexedCorpus {
     generation: i64,
     df_by_token: HashMap<i64, i64>,
@@ -318,7 +319,10 @@ struct IndexedCorpus {
 
 impl IndexedCorpus {
     fn load(conn: &Connection, generation: i64) -> anyhow::Result<Self> {
-        Ok(Self { generation, df_by_token: load_clone_token_df(conn)? })
+        // #479: a NEW bag checked against this generation's postings must order its sub-block by
+        // the generation's FROZEN epoch — the live `clone_token_df` moves on incremental passes
+        // and would silently pick different prefix tokens than the postings were built under.
+        Ok(Self { generation, df_by_token: load_clone_df_epoch(conn, generation)? })
     }
 }
 
@@ -590,27 +594,6 @@ fn load_test_symbol_ids(conn: &Connection) -> anyhow::Result<HashSet<i64>> {
     let ids =
         stmt.query_map([], |r| r.get::<_, i64>(0))?.collect::<rusqlite::Result<HashSet<i64>>>()?;
     Ok(ids)
-}
-
-/// `token_hash -> df` over the baseline normalizer — the selectivity source for a NEW bag's
-/// sub-block ordering. A token absent from the index is maximally selective (`DF_FALLBACK`),
-/// matching `load_scoped_baseline_bags`.
-fn load_clone_token_df(conn: &Connection) -> anyhow::Result<HashMap<i64, i64>> {
-    // Per-repo df (A5): scope to the active repo; `{df_repo_clause}` is empty pre-A5.
-    let df_scope = crate::index::schema::periphery_repo_scope(conn, "clone_token_df")?;
-    let df_repo_clause =
-        crate::index::schema::periphery_repo_scope_clause(&df_scope, "clone_token_df");
-    let mut stmt = conn.prepare(&format!(
-        "SELECT token_hash, df FROM clone_token_df WHERE normalizer_kind = \
-         'baseline'{df_repo_clause}"
-    ))?;
-    let rows = stmt.query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, i64>(1)?)))?;
-    let mut map = HashMap::new();
-    for row in rows {
-        let (token_hash, df) = row?;
-        map.insert(token_hash, df);
-    }
-    Ok(map)
 }
 
 /// A candidate-gen [`SymbolBag`] for a fresh, not-yet-indexed fingerprint (`symbol_id = -1`).

--- a/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/precompute.rs
@@ -21,8 +21,12 @@ use rusqlite::{Connection, params};
 use serde::Serialize;
 
 use super::THETA;
+// The current-df bag load stays test-only here: production build passes read the pinned epoch.
+#[cfg(test)]
+use super::substrate::load_scoped_baseline_bags;
 use super::substrate::{
-    SymbolBag, load_scoped_baseline_bags, overlap, sub_block_tokens, verified_clone,
+    SymbolBag, load_clone_df_epoch, load_scoped_baseline_bags_with_df, overlap, sub_block_tokens,
+    verified_clone,
 };
 use crate::index::IndexDatabase;
 use crate::index::clones::NORM_VERSION;
@@ -175,7 +179,12 @@ impl IndexDatabase {
             // A live generation built before postings existed (`postings_written = 0`) is pending
             // so one rebuild pass fills `clone_subblock_postings` — else an upgraded DB with an
             // already-Complete clone graph would keep an empty postings table forever (review R2).
-            || !live.postings_written)
+            || !live.postings_written
+            // Same self-heal contract for the df epoch (#479, the R2 shape): a Complete
+            // generation without its `clone_df_epoch` rows (the V051 backfill's empty-df edge, a
+            // torn epoch) is unservable by the fast path and the delta — it must read as pending
+            // so one rebuild re-pins it, not skip as current forever.
+            || !clone_df_epoch_serves(conn, live.generation)?)
     }
 
     /// The background quiet-window gate for the clone-graph tail (#472): true when the graph is
@@ -271,44 +280,18 @@ impl IndexDatabase {
         Ok(())
     }
 
-    /// Invalidate the persisted clone-graph postings — mark EVERY generation postings-stale
-    /// (`postings_written = 0`) so `pending_clone_graph` reports pending and the next maintenance
-    /// pass rebuilds the graph. Called when `clone_token_df` is recomputed (a full rebuild): the
-    /// postings freeze `sub_block_tokens`' ordering by the df table AS OF their build, but a full
-    /// rebuild corrects df drift WITHOUT changing file content, so `content_revision()` (the
-    /// clone-graph freshness key) stays equal and nothing else would catch the drift. Serving those
-    /// postings would rank a new function with the current df while reading postings ordered by the
-    /// old df, silently missing near-clones whose selected sub-block token shifted. Until the
-    /// rebuild, the write-time fast path falls back to the RAM build; `find_clones`' edges are
-    /// df-INDEPENDENT (they store the verified overlap) and are unaffected. Incremental indexing
-    /// bumps df alongside file-content changes, so `content_revision()` already gates that path —
-    /// only this content-invariant refresh needs the explicit nudge.
-    pub(crate) fn invalidate_clone_graph_postings(&self) -> anyhow::Result<()> {
-        let conn = self.storage.connection();
-        // Per-repo (A5): only the active repo's generations are invalidated — a full rebuild of one
-        // repo must not force a sibling repo's postings stale. `{repo_clause}` is empty pre-A5.
-        let repo_clause = clone_generation_scope_clause(conn)?;
-        conn.execute(
-            &format!(
-                "UPDATE clone_graph_generations SET postings_written = 0 WHERE 1=1{repo_clause}"
-            ),
-            [],
-        )?;
-        Ok(())
-    }
-
     /// The live clone-graph generation the write-time postings fast path may read from —
     /// `Some(gen)` ONLY when the persisted postings are safe to serve, `None` otherwise (→ the
     /// caller uses the RAM fallback). Eligibility is EXACT-freshness, deliberately STRICTER
-    /// than the `find_clones` edge fast path's "mildly-stale-OK" (review R1): the persisted
-    /// sub-block token set for a symbol depends on `sub_block_tokens`' ordering by the CURRENT
-    /// `clone_token_df`, so a generation whose `source_revision` has drifted from
+    /// than the `find_clones` edge fast path's "mildly-stale-OK" (review R1): the postings cover
+    /// exactly the file set of `source_revision`, so a generation drifted from
     /// `content_revision()` could disagree with what the live index would compute — a silent
     /// missed near-clone. So require:
     /// - a `Complete` live generation (the meta live-pointer only ever names a Complete one),
     /// - `normalizer_version == NORM_VERSION`,
-    /// - `postings_written` (a postings-complete, postings-aware generation — review R2), AND
-    /// - `source_revision == content_revision()` EXACTLY (not merely present).
+    /// - `postings_written` (a postings-complete, postings-aware generation — review R2),
+    /// - `source_revision == content_revision()` EXACTLY (not merely present), AND
+    /// - the generation's `clone_df_epoch` rows exist (#479 — the order to read the postings by).
     pub fn clone_check_indexed_generation(&self) -> anyhow::Result<Option<i64>> {
         // BASE-SCOPE ONLY. The clone graph (edges + postings) is built in the BASE scope —
         // maintenance restores it before the clone-graph pass, and `content_revision()` is GLOBAL
@@ -326,7 +309,11 @@ impl IndexDatabase {
         };
         let eligible = live.normalizer_version == NORM_VERSION
             && live.postings_written
-            && live.source_revision == self.content_revision()?;
+            && live.source_revision == self.content_revision()?
+            // #479: the postings are ordered by the generation's pinned epoch; without the epoch
+            // rows (a pre-V051 build the backfill could not cover) the reader cannot reproduce
+            // that order — fall back rather than silently miss near-clones.
+            && clone_df_epoch_serves(conn, live.generation)?;
         Ok(eligible.then_some(live.generation))
     }
 
@@ -353,6 +340,10 @@ impl IndexDatabase {
             // skip forever with an empty `clone_subblock_postings` (review R2). A postings-less
             // live generation falls through and rebuilds a postings-full one.
             && live.postings_written
+            // And the pinned df epoch (#479, same R2 shape): an epoch-less Complete generation is
+            // unservable by the fast path and the delta, so skipping-as-current would strand them
+            // on the fallback forever — fall through and rebuild one that pins its epoch.
+            && clone_df_epoch_serves(conn, live.generation)?
             // #473: a generation that has absorbed enough in-place delta files owes a df-epoch
             // refresh — it is FRESH (deltas keep `source_revision` current) but must not
             // skip-as-current, or the drift rebuild the quiet gate scheduled would no-op forever.
@@ -374,26 +365,29 @@ impl IndexDatabase {
         // discarded — its symbol-id cursor is meaningless against the new symbol rows.
         let building = open_building_generation(conn, &source_revision)?;
         // A FRESH build (cursor 0 ⇒ no symbol walked ⇒ zero postings staged for this generation)
-        // moves the df EPOCH to now (#477 review): the #473 drift rebuild exists to restore
-        // sub-block selectivity, so a full build that kept the old frozen df would reset the
-        // drift counter without delivering the refresh it promises — and more generally, every
-        // fresh generation's postings must be ordered by the df of ITS OWN build. The refresh
-        // invalidates every generation's postings flag (df moved), including the row just opened,
-        // whose (empty) postings set trivially matches the new epoch — re-mark it postings-aware.
-        // A RESUMED partial (cursor > 0) must NOT refresh: its persisted postings are ordered by
-        // the epoch its build started under.
+        // moves the df epoch to now (#477 review): the #473 drift rebuild exists to restore
+        // sub-block selectivity, so a full build that kept the old df would reset the drift
+        // counter without delivering the refresh it promises — and more generally, every fresh
+        // generation's postings must be ordered by the df of ITS OWN build. The refreshed df is
+        // then pinned durably in `clone_df_epoch` (#479): that snapshot — not the live
+        // `clone_token_df`, which moves on incremental passes — is what the delta pass and the
+        // write-time fast path read back for this generation. A RESUMED partial (cursor > 0)
+        // must NOT refresh or re-snapshot: its persisted postings are ordered by the epoch its
+        // build opened under.
         if building.cursor_symbol_id == 0 {
             self.refresh_clone_token_df()?;
-            conn.execute(
-                "UPDATE clone_graph_generations SET postings_written = 1 WHERE generation = ?1",
-                params![building.generation],
-            )?;
+            snapshot_clone_df_epoch(conn, building.generation)?;
         }
 
         // Load the scoped baseline bags + the content anchors for every scoped symbol, and build
         // the struct-hash buckets + sub-block inverted index in RAM (rebuilt each pass —
-        // cheap relative to the pair emission this avoids persisting postings for).
-        let bags = load_scoped_baseline_bags(conn)?;
+        // cheap relative to the pair emission this avoids persisting postings for). Bags are
+        // ordered by the generation's PINNED epoch (#479): identical to the just-refreshed live
+        // df on a fresh build, and — the case that matters — the OPEN-time order on a resumed
+        // partial, whose remaining postings must match the ones already staged even if the live
+        // table moved between the paused passes (Codex review of this change).
+        let epoch_df = load_clone_df_epoch(conn, building.generation)?;
+        let bags = load_scoped_baseline_bags_with_df(conn, &epoch_df)?;
         let symbols_total = bags.len() as u64;
         let by_id: BTreeMap<i64, &SymbolBag> = bags.iter().map(|b| (b.symbol_id, b)).collect();
         let anchors = resolve_symbol_anchors(conn)?;
@@ -858,6 +852,58 @@ pub(super) fn insert_posting_groups(
             stmt.execute(params![generation, token_hash, path, start_byte, file_sha])?;
         }
     }
+    Ok(())
+}
+
+/// Whether `generation`'s postings can be ORDERED for serving (#479): its pinned df epoch
+/// exists, or there is nothing to order (a zero-postings generation — a docs-only or
+/// fingerprint-less repo — has no order to lose, and refusing it would make `pending_clone_graph`
+/// rebuild an already-current empty graph forever). Only "postings exist but the epoch is gone"
+/// (a pre-V051 build the backfill's empty-df edge could not cover, a torn epoch) is unservable —
+/// every eligibility gate treats that like `postings_written = 0` (fall back / refuse; one full
+/// rebuild self-heals).
+pub(super) fn clone_df_epoch_serves(conn: &Connection, generation: i64) -> anyhow::Result<bool> {
+    if clone_df_epoch_exists(conn, generation)? {
+        return Ok(true);
+    }
+    let has_postings = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM clone_subblock_postings WHERE build_generation = ?1)",
+        params![generation],
+        |r| r.get::<_, i64>(0),
+    )? != 0;
+    Ok(!has_postings)
+}
+
+/// The STRICT probe: `generation` has pinned epoch rows. The delta pass requires this — not the
+/// [`clone_df_epoch_serves`] sentinel — because it may CREATE the generation's first postings,
+/// and emitting them under an empty epoch map would leave postings no reader can order (Codex
+/// review of this change). An epoch-less generation goes to the full-rebuild path, which pins one.
+pub(super) fn clone_df_epoch_exists(conn: &Connection, generation: i64) -> anyhow::Result<bool> {
+    Ok(conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM clone_df_epoch WHERE build_generation = ?1)",
+        params![generation],
+        |r| r.get::<_, i64>(0),
+    )? != 0)
+}
+
+/// Pin a FRESH generation's df order (#479): copy the active repo's just-refreshed
+/// `clone_token_df` (baseline — the only normalizer kind the graph builds) into `clone_df_epoch`
+/// for `generation`. Runs only when a Building generation opens fresh (cursor 0); a resumed
+/// partial keeps the epoch it opened under, and CASCADE sweeps the rows with the generation.
+/// DELETE-first: a torn pass that snapshotted, died before its first checkpoint, and re-entered
+/// the fresh branch re-pins against the re-refreshed df instead of tripping the PK.
+fn snapshot_clone_df_epoch(conn: &Connection, generation: i64) -> anyhow::Result<()> {
+    conn.execute("DELETE FROM clone_df_epoch WHERE build_generation = ?1", params![generation])?;
+    let df_scope = crate::index::schema::periphery_repo_scope(conn, "clone_token_df")?;
+    let df_clause = crate::index::schema::periphery_repo_scope_clause(&df_scope, "clone_token_df");
+    conn.execute(
+        &format!(
+            "INSERT INTO clone_df_epoch(build_generation, token_hash, df)
+             SELECT ?1, token_hash, df FROM clone_token_df
+             WHERE normalizer_kind = 'baseline'{df_clause}"
+        ),
+        params![generation],
+    )?;
     Ok(())
 }
 
@@ -1408,6 +1454,212 @@ pub(super) mod tests {
         assert_eq!(leftover, 0, "the armed candidate is dropped once the graph is current");
     }
 
+    /// #479: a FRESH Building generation pins its build-time df order durably in
+    /// `clone_df_epoch`, so the persisted postings survive later movement of the live
+    /// `clone_token_df`. A RESUMED partial must not re-snapshot — its postings are ordered by the
+    /// epoch its build opened under, and a mid-build df movement must not leak in.
+    #[test]
+    fn a_fresh_build_snapshots_the_df_epoch_and_a_resume_preserves_it() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let epoch_rows = |db: &crate::IndexDatabase, generation: i64| -> Vec<(i64, i64)> {
+            let conn = db.storage.connection();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT token_hash, df FROM clone_df_epoch WHERE build_generation = ?1
+                     ORDER BY token_hash",
+                )
+                .unwrap();
+            stmt.query_map([generation], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, i64>(1)?)))
+                .unwrap()
+                .map(Result::unwrap)
+                .collect()
+        };
+        let df_rows = |db: &crate::IndexDatabase| -> Vec<(i64, i64)> {
+            let conn = db.storage.connection();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT token_hash, df FROM clone_token_df WHERE normalizer_kind = 'baseline'
+                     ORDER BY token_hash",
+                )
+                .unwrap();
+            stmt.query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, i64>(1)?)))
+                .unwrap()
+                .map(Result::unwrap)
+                .collect()
+        };
+
+        let db = build_clone_fixture("df-epoch-fresh");
+        let report = db.precompute_clone_graph(None).unwrap();
+        assert_eq!(report.status, "Complete");
+        let fresh_epoch = epoch_rows(&db, report.generation);
+        assert!(!fresh_epoch.is_empty(), "a fresh build snapshots its df epoch");
+        assert_eq!(fresh_epoch, df_rows(&db), "the snapshot equals the df the build ran under");
+
+        // Resume: trip the budget so a Building generation persists, move the live df between
+        // passes (what an interleaved incremental bump does), and finish the build.
+        let resumed = build_clone_fixture("df-epoch-resume");
+        let first = resumed
+            .reconcile_clone_edges_pass(&CloneEdgeOptions {
+                max_seconds: Some(0),
+                batch_size: 1,
+                force: false,
+            })
+            .unwrap();
+        assert_eq!(first.status, "Partial", "a zero-second budget trips after one batch");
+        let open_epoch = epoch_rows(&resumed, first.generation);
+        assert!(!open_epoch.is_empty(), "the epoch is pinned when the generation opens");
+        // Adversarial mid-build live-df movement: invert the whole table between the paused
+        // passes (an incremental bump storm's worst case).
+        resumed
+            .storage
+            .connection()
+            .execute("UPDATE clone_token_df SET df = 1000000 - df", [])
+            .unwrap();
+        let mut passes = 0;
+        let completed = loop {
+            let report = resumed
+                .reconcile_clone_edges_pass(&CloneEdgeOptions {
+                    max_seconds: Some(0),
+                    batch_size: 1,
+                    force: false,
+                })
+                .unwrap();
+            passes += 1;
+            assert!(passes < 10_000, "must converge");
+            if report.status != "Partial" {
+                assert_eq!(report.status, "Complete");
+                break report;
+            }
+        };
+        assert_eq!(
+            epoch_rows(&resumed, completed.generation),
+            open_epoch,
+            "a resume preserves the open-time epoch — the mid-build df movement must not leak in"
+        );
+        // And the resumed passes must EMIT under that epoch too (Codex review): every persisted
+        // posting — including the symbols walked after the inversion — matches the sub-block
+        // selection under the pinned epoch, not the moved live table.
+        let conn = resumed.storage.connection();
+        let epoch_df = load_clone_df_epoch(conn, completed.generation).unwrap();
+        let live_df = super::super::substrate::load_current_clone_df(conn).unwrap();
+        let union_under = |df: &std::collections::HashMap<i64, i64>| -> BTreeSet<i64> {
+            load_scoped_baseline_bags_with_df(conn, df)
+                .unwrap()
+                .iter()
+                .flat_map(|bag| sub_block_tokens(bag, CLONE_PRECOMPUTE_THETA))
+                .collect()
+        };
+        let under_epoch = union_under(&epoch_df);
+        assert_ne!(
+            under_epoch,
+            union_under(&live_df),
+            "precondition: the inversion must actually change the prefix selection"
+        );
+        let persisted: BTreeSet<i64> = conn
+            .prepare(
+                "SELECT DISTINCT token_hash FROM clone_subblock_postings
+                 WHERE build_generation = ?1",
+            )
+            .unwrap()
+            .query_map(params![completed.generation], |r| r.get::<_, i64>(0))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        assert_eq!(
+            persisted, under_epoch,
+            "resumed passes emit postings under the pinned epoch, not the moved live df"
+        );
+    }
+
+    /// #479 empty-graph sentinel (Codex review): a repo with no baseline fingerprints (docs-only,
+    /// data-only) builds a Complete generation with ZERO postings and therefore ZERO epoch rows —
+    /// a legitimately empty order, not a lost one. It must read as current, or
+    /// `pending_clone_graph` would schedule a rebuild of the already-current empty graph on every
+    /// maintenance pass, forever.
+    #[test]
+    fn an_empty_generation_without_epoch_rows_stays_current() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let mut config = clone_fixture_config("df-epoch-empty");
+        // Replace the clone fixture's sources with a data-only file: no functions, so nothing is
+        // fingerprinted and the built graph is empty.
+        std::fs::remove_file(config.root.join("src/a.rs")).unwrap();
+        std::fs::remove_file(config.root.join("src/b.rs")).unwrap();
+        std::fs::write(config.root.join("src/data.rs"), "pub struct OnlyData { pub x: i64 }\n")
+            .unwrap();
+        config.allow_empty = true;
+        let db = crate::IndexDatabase::rebuild(&config).unwrap();
+        assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
+        assert!(
+            !db.pending_clone_graph().unwrap(),
+            "an empty generation with no epoch rows is current, not perpetually pending"
+        );
+        assert_eq!(
+            db.precompute_clone_graph(None).unwrap().status,
+            "Current",
+            "and the next pass skips instead of rebuilding the empty graph forever"
+        );
+        drop(db);
+
+        // The FIRST fingerprinted content arrives: the delta must REFUSE (it would otherwise
+        // write the generation's first postings under an empty epoch map — postings no reader
+        // could order; Codex review) and the full path builds a fresh, epoch-pinned generation.
+        std::fs::write(
+            config.root.join("src/first.rs"),
+            "pub fn first_function(q: i64) -> i64 { q * 13 + 1 }\n",
+        )
+        .unwrap();
+        let (db, _changed) = crate::IndexDatabase::index_discover_reporting(&config).unwrap();
+        let report = db.apply_clone_graph_delta(64).unwrap();
+        assert_eq!(
+            report.status, "NotEligible",
+            "the delta must not create first postings on an epoch-less generation: {report:?}"
+        );
+        assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
+        assert!(
+            db.clone_check_indexed_generation().unwrap().is_some(),
+            "the full rebuild pins an epoch and the fast path serves"
+        );
+    }
+
+    /// #479 upgrade defense: postings without their generation's epoch rows cannot be ordered
+    /// correctly (the reader would fall to DF_FALLBACK for every token — a silently different
+    /// order than the postings were built under). A missing epoch must behave like
+    /// `postings_written = 0`: the fast path falls back and the delta refuses, so one full
+    /// rebuild self-heals instead of silently losing recall.
+    #[test]
+    fn a_generation_without_epoch_rows_is_not_servable() {
+        let _poison = crate::index::poison_sibling::disable_poison_sibling();
+        let db = build_clone_fixture("df-epoch-eligibility");
+        assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
+        assert!(
+            db.clone_check_indexed_generation().unwrap().is_some(),
+            "a fresh build with its epoch serves the fast path"
+        );
+        db.storage.connection().execute("DELETE FROM clone_df_epoch", []).unwrap();
+        assert!(
+            db.clone_check_indexed_generation().unwrap().is_none(),
+            "an epoch-less generation must not serve the postings fast path"
+        );
+        let report = db.apply_clone_graph_delta(64).unwrap();
+        assert_eq!(
+            report.status, "NotEligible",
+            "the delta must not patch postings whose build order is unknown: {report:?}"
+        );
+        // The self-heal loop must CLOSE (Codex review of this change): the unservable state has
+        // to read as pending and rebuild on the next pass — not skip as "Current" forever, which
+        // would strand the fast path and the delta on the fallback.
+        assert!(
+            db.pending_clone_graph().unwrap(),
+            "an epoch-less generation reads as pending, scheduling the healing rebuild"
+        );
+        let heal = db.precompute_clone_graph(None).unwrap();
+        assert_eq!(heal.status, "Complete", "the pass rebuilds instead of skipping as current");
+        assert!(
+            db.clone_check_indexed_generation().unwrap().is_some(),
+            "the rebuilt generation pins a fresh epoch and serves again"
+        );
+    }
+
     /// `quiet_ms = 0` disables the gate — a pending graph is immediately due (the pre-#472
     /// immediate-rebuild behavior).
     #[test]
@@ -1416,42 +1668,19 @@ pub(super) mod tests {
         assert!(db.clone_graph_rebuild_due_at(1_000, 0, true).unwrap());
     }
 
-    /// The freeze's bootstrap exception (`refresh_clone_token_df_if_unseeded`): an UNSEEDED repo
-    /// (no df rows) seeds the epoch; a seeded repo is left untouched — the frozen epoch must not
-    /// move on the incremental finalize that calls this.
+    /// #479: incremental passes bump the LIVE `clone_token_df` (a new file's tokens get real df
+    /// instead of riding `DF_FALLBACK` until the next full build — the live-fallback recall fix),
+    /// while the published generation's PINNED epoch stays byte-identical and its postings stay
+    /// servable. This inverts the #473 whole-table freeze: the freeze now lives per generation in
+    /// `clone_df_epoch`, not on the live table.
     #[test]
-    fn refresh_if_unseeded_seeds_once_then_preserves_the_epoch() {
+    fn incremental_index_bumps_live_df_and_keeps_the_generation_epoch_frozen() {
         let _poison = crate::index::poison_sibling::disable_poison_sibling();
-        let db = build_clone_fixture("df-freeze-bootstrap");
-        let df_count = |db: &crate::IndexDatabase| -> i64 {
-            db.storage
-                .connection()
-                .query_row("SELECT COUNT(*) FROM clone_token_df", [], |r| r.get(0))
-                .unwrap()
-        };
-        // Simulate the pre-epoch state (a DB whose df was never seeded for this repo).
-        db.storage.connection().execute("DELETE FROM clone_token_df", []).unwrap();
-        db.refresh_clone_token_df_if_unseeded().unwrap();
-        let seeded = df_count(&db);
-        assert!(seeded > 0, "an unseeded repo gets its epoch seeded");
-
-        // Seeded → the guard is a strict no-op (the frozen epoch must not move).
-        db.refresh_clone_token_df_if_unseeded().unwrap();
-        assert_eq!(df_count(&db), seeded, "a seeded repo's epoch is preserved");
-    }
-
-    /// The df EPOCH FREEZE (#473): incremental passes must not move `clone_token_df` — the
-    /// persisted postings order sub-block tokens by df AS OF their build, so a moving df would
-    /// desync them from every later sub-block computation (which is why the old per-pass refresh
-    /// had to invalidate the postings each time). After the freeze, a content change through a
-    /// maintenance pass leaves the df table byte-identical AND the live generation's
-    /// `postings_written` intact; df moves only at a FULL rebuild.
-    #[test]
-    fn incremental_index_keeps_the_df_epoch_frozen() {
-        let _poison = crate::index::poison_sibling::disable_poison_sibling();
-        let config = clone_fixture_config("df-freeze-epoch");
+        let config = clone_fixture_config("df-live-bump");
         let db = crate::IndexDatabase::rebuild(&config).unwrap();
-        assert_eq!(db.precompute_clone_graph(None).unwrap().status, "Complete");
+        let report = db.precompute_clone_graph(None).unwrap();
+        assert_eq!(report.status, "Complete");
+        let generation = report.generation;
         let df_rows = |db: &crate::IndexDatabase| -> Vec<(i64, i64)> {
             let conn = db.storage.connection();
             let mut stmt = conn
@@ -1462,41 +1691,47 @@ pub(super) mod tests {
                 .map(Result::unwrap)
                 .collect()
         };
-        let postings_written = |db: &crate::IndexDatabase| -> i64 {
-            db.storage
-                .connection()
-                .query_row(
-                    "SELECT postings_written FROM clone_graph_generations WHERE status = \
-                     'Complete'",
-                    [],
-                    |r| r.get(0),
+        let epoch_rows = |db: &crate::IndexDatabase| -> Vec<(i64, i64)> {
+            let conn = db.storage.connection();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT token_hash, df FROM clone_df_epoch WHERE build_generation = ?1
+                     ORDER BY token_hash",
                 )
+                .unwrap();
+            stmt.query_map([generation], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, i64>(1)?)))
                 .unwrap()
+                .map(Result::unwrap)
+                .collect()
         };
-        let epoch = df_rows(&db);
-        assert!(!epoch.is_empty(), "the full rebuild seeded the df epoch");
-        assert_eq!(postings_written(&db), 1, "the precompute published postings");
+        let live_df = df_rows(&db);
+        let pinned_epoch = epoch_rows(&db);
+        assert!(!live_df.is_empty(), "the full rebuild computed the df");
+        assert_eq!(live_df, pinned_epoch, "at build time the live df IS the epoch");
         drop(db);
 
         // A new file with brand-new tokens through the watcher/maintenance incremental path.
         std::fs::write(
-            config.root.join("src/frozen_probe.rs"),
-            "pub fn frozen_epoch_probe(zx: u64) -> u64 { zx.rotate_left(9) ^ 0xfeed_beef }\n",
+            config.root.join("src/live_probe.rs"),
+            "pub fn live_bump_probe(zx: u64) -> u64 { zx.rotate_left(9) ^ 0xfeed_beef }\n",
         )
         .unwrap();
         crate::watch::maintenance_pass(&config, false).unwrap();
 
         let db = crate::IndexDatabase::open_config(&config).unwrap();
-        assert_eq!(
-            df_rows(&db),
-            epoch,
-            "an incremental pass must not move the df epoch (new tokens ride DF_FALLBACK until \
-             the next full rebuild)"
+        assert!(
+            df_rows(&db).len() > live_df.len(),
+            "the incremental pass bumps the live df with the new file's tokens"
         );
         assert_eq!(
-            postings_written(&db),
-            1,
-            "and must not invalidate the live generation's postings"
+            epoch_rows(&db),
+            pinned_epoch,
+            "the generation's pinned epoch never moves after its build"
+        );
+        assert!(
+            db.clone_check_indexed_generation().unwrap().is_some(),
+            "the live df movement must not invalidate the generation's postings (they are \
+             epoch-pinned; the maintenance pass's delta keeps them fresh)"
         );
     }
 
@@ -1555,14 +1790,14 @@ pub(super) mod tests {
         assert!(!edge_keys(&db).is_empty(), "and the fixture's clone edges are persisted");
     }
 
-    /// A full rebuild recomputes `clone_token_df` authoritatively (correcting incremental drift)
-    /// WITHOUT changing file content, so `content_revision()` — the clone-graph freshness key —
-    /// stays equal. The persisted postings freeze the OLD df ordering, so serving them under
-    /// the fresh df could silently miss near-clones; the rebuild must therefore INVALIDATE the
-    /// postings (mark the generation stale) so they rebuild against the fresh df. The
-    /// write-time fast path falls back to RAM until then. Self-heals on the next precompute.
+    /// A second FULL index rebuild over identical content leaves the clone graph transiently
+    /// pending — `content_revision()` digests raw `main.files`, and the freshly staged file
+    /// generation coexists with the superseded one until gc, so the digest moves — and one
+    /// precompute settles it. #479 note: the df refresh the rebuild runs no longer invalidates
+    /// anything (`invalidate_clone_graph_postings` is gone — postings are pinned to their own
+    /// `clone_df_epoch`); the pending window here is purely the revision-key movement.
     #[test]
-    fn full_rebuild_invalidates_postings_for_df_freshness() {
+    fn a_second_full_rebuild_leaves_the_graph_pending_until_one_precompute() {
         let config = clone_fixture_config("df-refresh");
         let db1 = crate::IndexDatabase::rebuild(&config).unwrap();
         db1.precompute_clone_graph(None).unwrap();
@@ -1574,18 +1809,18 @@ pub(super) mod tests {
         drop(db1); // release the DB file before the second rebuild takes the write lock
 
         // Second FULL rebuild over IDENTICAL content: the clone graph survives (it is content-
-        // anchored), but `refresh_clone_token_df` runs, so the postings must be invalidated.
+        // anchored), but the staged file generation moves the revision key until gc.
         let db2 = crate::IndexDatabase::rebuild(&config).unwrap();
         assert!(
             db2.pending_clone_graph().unwrap(),
-            "the full-rebuild df refresh invalidates the postings, so the graph is pending"
+            "the staged-generation revision drift leaves the graph pending"
         );
         assert!(
             db2.clone_check_indexed_generation().unwrap().is_none(),
-            "and the write-time fast path falls back to RAM until the postings are rebuilt"
+            "and the write-time fast path falls back to RAM until the graph settles"
         );
 
-        // Self-heals: re-precompute rebuilds the postings against the fresh df.
+        // Settles on the next precompute (a maintenance pass's delta would re-pin it likewise).
         assert_eq!(db2.precompute_clone_graph(None).unwrap().status, "Complete");
         assert!(!db2.pending_clone_graph().unwrap(), "current again after the rebuild");
         assert!(db2.clone_check_indexed_generation().unwrap().is_some(), "eligible again");

--- a/crates/rag-rat-core/src/index/query_api/clones/substrate.rs
+++ b/crates/rag-rat-core/src/index/query_api/clones/substrate.rs
@@ -126,44 +126,83 @@ pub(crate) fn candidate_pairs(conn: &Connection) -> anyhow::Result<Vec<(i64, i64
 /// so only the ACTIVE version of each file participates (SCOPED-VIEW REQUIREMENT #89). df is read
 /// via LEFT JOIN + COALESCE so a missing-df token is never dropped (design rev-4 §2).
 pub(crate) fn load_scoped_baseline_bags(conn: &Connection) -> anyhow::Result<Vec<SymbolBag>> {
-    load_scoped_baseline_bags_filtered(conn, None)
+    // Live callers (the RAM fallback, `find_clones`) order by the CURRENT df.
+    let df_by_token = load_current_clone_df(conn)?;
+    load_scoped_baseline_bags_filtered(conn, None, &df_by_token)
+}
+
+/// [`load_scoped_baseline_bags`] with the df source injected (#479) — the persisted-graph BUILD's
+/// bag load: a fresh build passes its just-snapshotted epoch (identical to current df at that
+/// moment), and a RESUMED partial passes the epoch it opened under, so postings emitted across
+/// paused passes stay ordered consistently even when the live table moved in between.
+pub(crate) fn load_scoped_baseline_bags_with_df(
+    conn: &Connection,
+    df_by_token: &std::collections::HashMap<i64, i64>,
+) -> anyhow::Result<Vec<SymbolBag>> {
+    load_scoped_baseline_bags_filtered(conn, None, df_by_token)
 }
 
 /// [`load_scoped_baseline_bags`] restricted to symbols whose file `path` is in `paths` — the #473
 /// delta pass's bag load. IDENTICAL corpus filters (this is the parity contract: the delta's bags
 /// must be exactly the subset of the full build's bags for those files), just with a chunked
-/// `files.path IN (…)` narrowing so a small delta never decodes the whole corpus.
+/// `files.path IN (…)` narrowing so a small delta never decodes the whole corpus. `df_by_token`
+/// is injected (#479): the delta orders by its generation's FROZEN epoch
+/// ([`load_clone_df_epoch`]), never the moving live table.
 pub(crate) fn load_scoped_baseline_bags_for_paths(
     conn: &Connection,
     paths: &[String],
+    df_by_token: &std::collections::HashMap<i64, i64>,
 ) -> anyhow::Result<Vec<SymbolBag>> {
     if paths.is_empty() {
         return Ok(Vec::new());
     }
-    load_scoped_baseline_bags_filtered(conn, Some(paths))
+    load_scoped_baseline_bags_filtered(conn, Some(paths), df_by_token)
+}
+
+/// `token_hash -> df` from the LIVE `clone_token_df` (baseline normalizer — the only kind that
+/// feeds candidate recall), scoped to the active repo (A5). The CURRENT-order source for the live
+/// candidate paths; the persisted graph's consumers read [`load_clone_df_epoch`] instead (#479).
+/// A token absent from the map is maximally selective (`DF_FALLBACK`) — never dropped
+/// (design rev-4 §2).
+pub(crate) fn load_current_clone_df(
+    conn: &Connection,
+) -> anyhow::Result<std::collections::HashMap<i64, i64>> {
+    let df_scope = crate::index::schema::periphery_repo_scope(conn, "clone_token_df")?;
+    let df_repo_clause =
+        crate::index::schema::periphery_repo_scope_clause(&df_scope, "clone_token_df");
+    let mut stmt = conn.prepare(&format!(
+        "SELECT token_hash, df FROM clone_token_df WHERE normalizer_kind = \
+         'baseline'{df_repo_clause}"
+    ))?;
+    let df_by_token = stmt
+        .query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)))?
+        .collect::<Result<_, _>>()?;
+    Ok(df_by_token)
+}
+
+/// `token_hash -> df` as pinned at `generation`'s build (#479) — the order every persisted
+/// posting of that generation was emitted under. Generation-keyed, so no repo scoping is needed
+/// (the generation integer is globally unique and CASCADEs with its repo's rows).
+pub(crate) fn load_clone_df_epoch(
+    conn: &Connection,
+    generation: i64,
+) -> anyhow::Result<std::collections::HashMap<i64, i64>> {
+    let mut stmt =
+        conn.prepare("SELECT token_hash, df FROM clone_df_epoch WHERE build_generation = ?1")?;
+    let df_by_token = stmt
+        .query_map([generation], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)))?
+        .collect::<Result<_, _>>()?;
+    Ok(df_by_token)
 }
 
 fn load_scoped_baseline_bags_filtered(
     conn: &Connection,
     paths: Option<&[String]>,
+    df_by_token: &std::collections::HashMap<i64, i64>,
 ) -> anyhow::Result<Vec<SymbolBag>> {
-    // Load `clone_token_df` ONCE into a map (#231 R3): the token bag now lives in an opaque
-    // `token_bag` BLOB, so df can no longer be a per-token SQL JOIN. Each decoded token's df is
-    // looked up here in Rust and COALESCEd to the fallback sentinel — a missing-df token must NOT
-    // be dropped (design rev-4 §2). Only the baseline normalizer feeds candidate recall.
-    // Post-A5 df is per-repo (its PK carries `repo_id`), so scope the read to the active repo —
-    // `{df_repo_clause}` is empty pre-A5. The writer (`refresh_clone_token_df`, full-rebuild /
-    // first-index only under the #473 df epoch freeze) stamps the same repo, so the two agree.
-    let df_scope = crate::index::schema::periphery_repo_scope(conn, "clone_token_df")?;
-    let df_repo_clause =
-        crate::index::schema::periphery_repo_scope_clause(&df_scope, "clone_token_df");
-    let mut df_stmt = conn.prepare(&format!(
-        "SELECT token_hash, df FROM clone_token_df WHERE normalizer_kind = \
-         'baseline'{df_repo_clause}"
-    ))?;
-    let df_by_token: std::collections::HashMap<i64, i64> = df_stmt
-        .query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)))?
-        .collect::<Result<_, _>>()?;
+    // Each decoded token's df is looked up in the injected map (#231 R3: the token bag lives in
+    // an opaque `token_bag` BLOB, so df cannot be a per-token SQL JOIN) and COALESCEd to the
+    // fallback sentinel — a missing-df token must NOT be dropped (design rev-4 §2).
 
     // Scoped baseline fingerprints + their token-bag BLOB, in one read (no per-token join).
     // `files.generated = 0` excludes generated files (e.g. `src/generated/…`, `.d.ts`) from the

--- a/crates/rag-rat-core/src/index/rebuild.rs
+++ b/crates/rag-rat-core/src/index/rebuild.rs
@@ -457,31 +457,11 @@ impl IndexDatabase {
     /// for recall either way.) df feeds candidate GENERATION (the `sub_block_tokens` ordering), not
     /// just ranking. Each symbol's decoded bag has no duplicate `token_hash` (the codec invariant),
     /// so counting one increment per (symbol, token) pair equals `COUNT(DISTINCT symbol_id)`.
-    /// Seed the df epoch ONLY when this repo has no `clone_token_df` rows yet — the #473 df EPOCH
-    /// FREEZE's one exception. Incremental finalizes call this instead of the unconditional
-    /// refresh: the persisted clone-graph postings order sub-block tokens by df AS OF their build,
-    /// so a per-pass refresh would desync them (which is why `refresh_clone_token_df` must
-    /// invalidate the postings every time it runs). A FIRST standalone index has no epoch to
-    /// preserve — and no postings to invalidate — so seeding here is safe and keeps the
-    /// selectivity ordering useful from the start; afterwards df moves only at a full rebuild.
-    pub(crate) fn refresh_clone_token_df_if_unseeded(&self) -> anyhow::Result<()> {
-        let seeded = {
-            let conn = self.storage.connection();
-            let df_scope = crate::index::schema::periphery_repo_scope(conn, "clone_token_df")?;
-            let df_clause =
-                crate::index::schema::periphery_repo_scope_clause(&df_scope, "clone_token_df");
-            conn.query_row(
-                &format!("SELECT EXISTS(SELECT 1 FROM clone_token_df WHERE 1=1{df_clause})"),
-                [],
-                |r| r.get::<_, i64>(0),
-            )? != 0
-        };
-        if seeded {
-            return Ok(());
-        }
-        self.refresh_clone_token_df()
-    }
-
+    /// Recompute the LIVE `clone_token_df` exactly from the active repo's token-bag BLOBs — the
+    /// authoritative refresh the full-rebuild / standalone-index finalizes run (the waves skip
+    /// per-token bumps via `BumpDf(false)` and settle here instead). #479: this refreshes the
+    /// LIVE selectivity table only; the persisted clone-graph postings are ordered by their own
+    /// generation's `clone_df_epoch` snapshot, so a refresh no longer invalidates them.
     pub(crate) fn refresh_clone_token_df(&self) -> anyhow::Result<()> {
         // Resolve the active-repo scope ONCE: it gates BOTH the fingerprint READ below and the df
         // wipe/reinsert (Phase 2). `symbol_fingerprints` is deliberately `repo_id`-free (keyed by
@@ -575,12 +555,6 @@ impl IndexDatabase {
                 ])?;
             }
         }
-        // The recomputed df may reorder `sub_block_tokens`, so the persisted clone-graph postings
-        // (frozen at their build-time df) can no longer be served against the current df without
-        // silently missing near-clones. Invalidate them so the next maintenance pass rebuilds the
-        // graph; this refresh keeps file content (and `content_revision()`) unchanged, so nothing
-        // else would catch it. See `invalidate_clone_graph_postings`.
-        self.invalidate_clone_graph_postings()?;
         Ok(())
     }
 

--- a/crates/rag-rat-core/src/index/schema/migrations.rs
+++ b/crates/rag-rat-core/src/index/schema/migrations.rs
@@ -1185,6 +1185,7 @@ pub(crate) fn known_version(migrations: &[AppliedMigration]) -> u32 {
             MIGRATION_048_ID => Some(48),
             MIGRATION_049_ID => Some(49),
             MIGRATION_050_ID => Some(50),
+            MIGRATION_051_ID => Some(51),
             _ => None,
         })
         .max()
@@ -1244,6 +1245,7 @@ pub(crate) fn known_migration(id: &str) -> bool {
             | MIGRATION_048_ID
             | MIGRATION_049_ID
             | MIGRATION_050_ID
+            | MIGRATION_051_ID
             | DIRTY_MIGRATION_ID
     )
 }
@@ -1300,6 +1302,7 @@ pub(crate) fn migration_checksum_mismatch(migration: &AppliedMigration) -> bool 
         MIGRATION_048_ID => migration.checksum != MIGRATION_048_CHECKSUM,
         MIGRATION_049_ID => migration.checksum != MIGRATION_049_CHECKSUM,
         MIGRATION_050_ID => migration.checksum != MIGRATION_050_CHECKSUM,
+        MIGRATION_051_ID => migration.checksum != MIGRATION_051_CHECKSUM,
         _ => false,
     }
 }
@@ -3469,6 +3472,60 @@ pub(crate) fn apply_clone_delta_maintenance(conn: &Connection) -> rusqlite::Resu
         "delta_files_applied",
         "INTEGER NOT NULL DEFAULT 0",
     )?;
+    Ok(())
+}
+
+/// V051 (#479): per-generation df snapshot. The #473 freeze made `clone_token_df` itself the
+/// postings' frozen order, which left the LIVE candidate paths reading stale df — a newly indexed
+/// token rides `DF_FALLBACK` (sorted last) until the next full build, so a new clone family's
+/// sub-block prefixes prefer old tokens, and at the hot-token-cap margin its candidates drop
+/// entirely. `clone_df_epoch` pins each generation's build-time df durably (CASCADE-swept with the
+/// generation row, like edges/postings), so the persisted-graph consumers read their own build's
+/// order while `clone_token_df` is free to move again on incremental passes.
+///
+/// BACKFILL (the V050→V051 bridge): a pre-epoch DB's servable generations were built under the
+/// CURRENT `clone_token_df` — under the #473 freeze df cannot have moved since (any refresh
+/// invalidated `postings_written`, and a postings-invalid Building generation is discarded, never
+/// resumed) — so snapshotting current df per generation is exact and no forced rebuild is needed.
+/// Backfill targets only generations with ZERO epoch rows (each per-generation INSERT is one
+/// atomic statement, so a torn retry resumes cleanly), which also keeps a re-apply from folding
+/// post-V051 (moving) df rows into an already-pinned epoch. Known degenerate edge: a generation
+/// built while its repo's df table was empty backfills nothing; the runtime treats a missing
+/// epoch like `postings_written = 0` (one self-healing rebuild).
+pub(crate) fn apply_clone_df_epoch(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS clone_df_epoch(
+             build_generation INTEGER NOT NULL REFERENCES clone_graph_generations(generation)
+                                               ON DELETE CASCADE,
+             token_hash       INTEGER NOT NULL,
+             df               INTEGER NOT NULL,
+             PRIMARY KEY (build_generation, token_hash)
+         ) STRICT;",
+    )?;
+    // Enumerate the epoch-less generations FIRST, then snapshot each with its own atomic INSERT.
+    // A single self-referencing `INSERT … WHERE NOT EXISTS(SELECT … FROM clone_df_epoch)` is not
+    // used deliberately: SQLite may interleave the SELECT with the insertion, so rows landed for a
+    // generation earlier in the same statement could suppress its remaining rows.
+    let epoch_less: Vec<i64> = {
+        let mut stmt = conn.prepare(
+            "SELECT g.generation FROM clone_graph_generations g
+             LEFT JOIN clone_df_epoch e ON e.build_generation = g.generation
+             WHERE e.build_generation IS NULL
+             GROUP BY g.generation",
+        )?;
+        stmt.query_map([], |row| row.get::<_, i64>(0))?.collect::<Result<Vec<_>, _>>()?
+    };
+    for generation in epoch_less {
+        conn.execute(
+            "INSERT INTO clone_df_epoch(build_generation, token_hash, df)
+             SELECT g.generation, d.token_hash, d.df
+             FROM clone_graph_generations g
+             JOIN clone_token_df d
+               ON d.repo_id = g.repo_id AND d.normalizer_kind = g.normalizer_kind
+             WHERE g.generation = ?1",
+            params![generation],
+        )?;
+    }
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -18,7 +18,7 @@ pub use registry::{LEGACY_REPO_ID, register_repo, register_repo_read_only};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
-pub const LATEST_SCHEMA_VERSION: u32 = 50;
+pub const LATEST_SCHEMA_VERSION: u32 = 51;
 
 /// Every oracle-DERIVED persisted table — the outputs an `oracle run` writes that must OUTLIVE a
 /// reindex.
@@ -342,6 +342,14 @@ const MIGRATION_050_DESCRIPTION: &str =
      clone_graph_generations.delta_files_applied counter, so the incremental clone-graph delta \
      pass can delete a changed file's postings without a table scan and track df drift toward the \
      next full rebuild";
+const MIGRATION_051_ID: &str = "051_clone_df_epoch";
+const MIGRATION_051_CHECKSUM: &str = "sha256:rag-rat-clone-df-epoch-v51";
+const MIGRATION_051_DESCRIPTION: &str =
+    "Add clone_df_epoch, the per-generation snapshot of clone_token_df taken at each fresh \
+     clone-graph build (#479), so the persisted postings and the delta pass read their own \
+     build's frozen token order while the live candidate paths read a clone_token_df that moves \
+     again on incremental passes; backfilled from the current (freeze-pinned) df for existing \
+     generations";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -741,6 +749,12 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
         checksum: MIGRATION_050_CHECKSUM,
         description: MIGRATION_050_DESCRIPTION,
         apply: apply_clone_delta_maintenance,
+    },
+    Migration {
+        id: MIGRATION_051_ID,
+        checksum: MIGRATION_051_CHECKSUM,
+        description: MIGRATION_051_DESCRIPTION,
+        apply: apply_clone_df_epoch,
     },
 ];
 

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -914,10 +914,13 @@ fn migration_050_adds_the_postings_path_index_and_delta_counter() {
     };
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     schema::apply(&conn).unwrap();
-    // V050 is the schema tip — the absolute pin (migration_049_* dropped to the symbolic
-    // `current_version == LATEST` check when this landed).
-    assert_eq!(schema::LATEST_SCHEMA_VERSION, 50, "V050 is the schema tip");
-    assert_eq!(schema::status(&conn).unwrap().current_version, 50, "schema at LATEST after apply");
+    // Symbolic freshness check (the absolute tip pin lives on the NEWEST migration's test —
+    // migration_051 — per the ladder convention).
+    assert_eq!(
+        schema::status(&conn).unwrap().current_version,
+        schema::LATEST_SCHEMA_VERSION,
+        "schema at LATEST after apply"
+    );
     assert!(
         index_exists(&conn),
         "the delta pass deletes a changed file's postings by (build_generation, path); the PK \
@@ -971,6 +974,89 @@ fn migration_050_adds_the_postings_path_index_and_delta_counter() {
         )
         .unwrap();
     assert_eq!(postings_written, 0, "a pre-freeze generation is forced through a full rebuild");
+}
+
+#[test]
+fn migration_051_adds_clone_df_epoch_and_backfills_existing_generations() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    // V051 is the schema tip — the absolute pin (migration_050's drops to the symbolic
+    // `current_version == LATEST` check when this lands).
+    assert_eq!(schema::LATEST_SCHEMA_VERSION, 51, "V051 is the schema tip");
+    assert_eq!(schema::status(&conn).unwrap().current_version, 51, "schema at LATEST after apply");
+    assert!(
+        conn_table_exists(&conn, "clone_df_epoch"),
+        "the per-generation df snapshot table exists (#479)"
+    );
+
+    // BACKFILL (the V050→V051 upgrade bridge): a pre-epoch-table DB holds generations whose
+    // postings are ordered by the CURRENT clone_token_df (the #473 freeze guarantees df has not
+    // moved since any servable generation's build), so snapshotting current df per generation is
+    // exact. Seed a V050-shaped state, re-run the applier in isolation (deferred-absence
+    // pattern), and assert the snapshot: matching (repo_id, normalizer_kind) rows only.
+    conn.execute(
+        "INSERT INTO clone_graph_generations
+            (generation, status, theta_floor, normalizer_kind, normalizer_version,
+             source_revision, started_at_ms, postings_written, repo_id)
+         VALUES (7, 'Complete', 0.7, 'baseline', 3, 'rev', 0, 1, 'r1')",
+        [],
+    )
+    .unwrap();
+    conn.execute_batch(
+        "INSERT INTO clone_token_df(repo_id, normalizer_kind, token_hash, df)
+         VALUES ('r1', 'baseline', 101, 3), ('r1', 'baseline', 102, 9);
+         -- Different repo / different normalizer kind: must NOT enter generation 7's epoch.
+         INSERT INTO clone_token_df(repo_id, normalizer_kind, token_hash, df)
+         VALUES ('r2', 'baseline', 103, 5), ('r1', 'other', 104, 2);",
+    )
+    .unwrap();
+    conn.execute_batch("DROP TABLE clone_df_epoch;").unwrap();
+    schema::apply_clone_df_epoch(&conn).unwrap();
+    let epoch_rows = |conn: &rusqlite::Connection| -> Vec<(i64, i64, i64)> {
+        conn.prepare(
+            "SELECT build_generation, token_hash, df FROM clone_df_epoch
+             ORDER BY build_generation, token_hash",
+        )
+        .unwrap()
+        .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+        .unwrap()
+        .map(Result::unwrap)
+        .collect()
+    };
+    assert_eq!(
+        epoch_rows(&conn),
+        vec![(7, 101, 3), (7, 102, 9)],
+        "backfill snapshots exactly the generation's own (repo_id, normalizer_kind) df rows"
+    );
+
+    // Idempotence: a re-apply must not re-snapshot a generation that already has epoch rows —
+    // post-V051, current df moves on incremental passes, so a re-run folding NEW df rows into an
+    // existing epoch would corrupt the frozen order.
+    conn.execute(
+        "INSERT INTO clone_token_df(repo_id, normalizer_kind, token_hash, df)
+         VALUES ('r1', 'baseline', 105, 1)",
+        [],
+    )
+    .unwrap();
+    schema::apply_clone_df_epoch(&conn).unwrap();
+    assert_eq!(
+        epoch_rows(&conn),
+        vec![(7, 101, 3), (7, 102, 9)],
+        "a generation with epoch rows is never re-backfilled"
+    );
+
+    // FK CASCADE: the epoch rows die with their generation row (same lifecycle as
+    // clone_edges / clone_subblock_postings).
+    conn.execute_batch(
+        "PRAGMA foreign_keys = ON;
+         DELETE FROM clone_graph_generations WHERE generation = 7;",
+    )
+    .unwrap();
+    assert_eq!(
+        epoch_rows(&conn),
+        Vec::<(i64, i64, i64)>::new(),
+        "epoch rows CASCADE with the generation"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #479.

The #473 df epoch freeze made `clone_token_df` itself the postings' frozen order, which left the LIVE candidate paths reading stale df: a newly indexed token rode `DF_FALLBACK` (sorted last) until the next full build, so a new clone family's sub-block prefixes preferred old tokens — and at the `HOT_TOKEN_POSTINGS_CAP` margin its candidates dropped entirely. The regression was recall in the live path's windows (pre-first-precompute, invalidated postings, linked-worktree overlays, θ < 0.7 queries).

This splits the two consumers' df sources, per the issue design:

- **V051** adds `clone_df_epoch(build_generation, token_hash, df)` — STRICT, FK CASCADE with the generation row — snapshotted when a fresh Building generation opens (right after the build's `refresh_clone_token_df`). **Backfilled** from the current (freeze-pinned) df for existing generations, so upgrading costs no forced rebuild.
- **Persisted-graph consumers read their generation's epoch**: the build's own bag walk (so a *resumed* partial emits under its open-time order even if the live table moved between passes), the delta's bag loads, and the write-time fast path (`IndexedCorpus`).
- **The live paths return to current df, which moves again**: the #477-removed `BumpDf` per-token upsert is restored on the incremental/heal paths, and the standalone-index finalize returns to the unconditional refresh. `invalidate_clone_graph_postings` is deleted — epoch-pinned postings cannot be desynced by live-df movement, so the fresh-build `postings_written` re-mark hack goes with it.
- **Self-heal contract**: `pending_clone_graph`, the reconcile pass's skip-when-current, and `clone_check_indexed_generation` treat "postings exist but the epoch is gone" like `postings_written = 0` (one rebuild re-pins; review R2 shape), while a zero-postings generation with no epoch rows is legitimately current (no empty-graph rebuild loop). The delta requires strict epoch existence, since it may create a generation's first postings.

Tests: the differential parity test gains an adversarial interleaved live-index step (whole-table df inversion between deltas); byte-level pins verify both the delta's and a resumed build's persisted postings are selected under the pinned epoch, not the live table — each verified to fail when the df source is mutated to current; the empty-graph sentinel, the first-content transition, epoch-less fallback/self-heal, snapshot-at-fresh/preserve-on-resume, and the V051 backfill (matching (repo_id, normalizer_kind) only, idempotent, CASCADE) are all pinned. The stale `full_rebuild_invalidates_postings_for_df_freshness` test is renamed and re-documented to the mechanism that actually keeps it green (staged-generation revision drift).

Note: a zip attachment claiming to implement this issue was posted in a comment (since deleted) — this implementation derives solely from the issue's own design text.