### PR TITLE
fix(memory): relocation prefers the discriminator-matching twin, not plan order

### DIFF
--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -427,6 +427,105 @@ fn repo_memory_validate_marks_changed_or_missing_anchors_non_current() {
     let _ = fs::remove_dir_all(root);
 }
 
+/// #491: one qualified name, two logical twins (a `struct` and its `impl` block). The impl's
+/// logical key sorts first ("impl" < "struct"), so it gets the lower rowid and an unordered
+/// `LIMIT 1` relocation deterministically lands a struct-bound memory on the impl row. The
+/// binding stores the V014 discriminators (`symbol_kind`, `signature_hash`) for exactly this —
+/// relocation must prefer the twin that agrees with them.
+#[test]
+fn relocation_lands_on_the_kind_matching_twin_not_plan_order() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/twin.rs"),
+        "pub struct TwinAnchor {\n    pub x: i64,\n}\n\nimpl TwinAnchor {\n    pub fn \
+         probe(&self) -> i64 {\n        self.x\n    }\n}\n",
+    )
+    .unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let twin_id = |kind: &str| -> i64 {
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT ls.id FROM logical_symbols ls
+                 JOIN name_strings qn ON qn.id = ls.qualified_name_id
+                 WHERE qn.value LIKE '%::TwinAnchor' AND ls.kind = ?1",
+                [kind],
+                |r| r.get(0),
+            )
+            .unwrap()
+    };
+    let struct_id = twin_id("struct");
+    let impl_id = twin_id("impl");
+    assert_ne!(struct_id, impl_id, "the fixture must produce both twins");
+
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Invariant".to_string(),
+            title: "Bound to the struct twin".to_string(),
+            body: "Relocation must land back on the struct, not the impl block.".to_string(),
+            confidence: "medium".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                logical_symbol_id: Some(struct_id),
+                symbol_id: None,
+                chunk_id: None,
+                edge_id: None,
+                path: None,
+                start_line: None,
+                end_line: None,
+                commit_hash: None,
+                github_owner: None,
+                github_repo: None,
+                github_number: None,
+                start_logical_symbol_id: None,
+                end_logical_symbol_id: None,
+                edge_sequence_hash: None,
+                path_summary: None,
+                edge_path: None,
+                dir: None,
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+
+    // Simulate key-derivation drift: the stored id no longer resolves, while the qualified name
+    // and the stored discriminators (symbol_kind = struct + the struct's signature hash) survive.
+    db.storage
+        .connection()
+        .execute(
+            "UPDATE repo_memory_bindings SET logical_symbol_id = 424242 WHERE memory_id = ?1",
+            params![memory_id],
+        )
+        .unwrap();
+
+    db.memory_validate().unwrap();
+    let (relocated_id, status): (i64, String) = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT logical_symbol_id, anchor_status FROM repo_memory_bindings
+             WHERE memory_id = ?1",
+            params![memory_id],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(status, "relocated", "the dead id must relocate by qualified name");
+    assert_eq!(
+        relocated_id, struct_id,
+        "relocation must prefer the kind-matching twin (struct), not the impl row plan order \
+         happens to return first"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
 #[test]
 fn repo_memory_bound_to_edge_surfaces_when_impact_crosses_call_path() {
     let root = unique_temp_root();

--- a/crates/rag-rat-core/src/query/memory/validate.rs
+++ b/crates/rag-rat-core/src/query/memory/validate.rs
@@ -77,19 +77,40 @@ pub(crate) fn validate_logical_symbol_binding(
     // repo-scoped for free through the scope view; `logical_symbols` is a direct table, so it needs
     // the explicit filter.
     let active_repo_id = crate::index::schema::active_repo_id(conn)?;
-    let relocated = conn
-        .query_row(
+    // #491: one qualified name can hold several live twins (a struct and its impl block;
+    // overloads with distinct signatures), so a bare `LIMIT 1` is a plan-order coin flip that
+    // can land a struct-bound memory on the impl row. The binding stores the V014 relocation
+    // discriminators (`symbol_kind`, `signature_hash`) — fetch every twin (with a member
+    // signature: all members of a group share it, since the signature is part of the logical
+    // key) and prefer the one that agrees, tiebreaking deterministically by id.
+    let candidates: Vec<RelocationTwin> = {
+        let mut stmt = conn.prepare(
             "
-            SELECT id, path
-            FROM logical_symbols
-            WHERE qualified_name_id = (SELECT id FROM name_strings WHERE value = ?1)
-              AND repo_id = ?2
-            LIMIT 1
+            SELECT ls.id, ls.path, ls.kind,
+                   (SELECT s.signature FROM logical_symbol_members m
+                      JOIN symbols s ON s.id = m.symbol_id
+                     WHERE m.logical_symbol_id = ls.id LIMIT 1)
+            FROM logical_symbols ls
+            WHERE ls.qualified_name_id = (SELECT id FROM name_strings WHERE value = ?1)
+              AND ls.repo_id = ?2
+            ORDER BY ls.id
             ",
-            params![&binding.binding_id, active_repo_id],
-            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
-        )
-        .optional()?;
+        )?;
+        let rows = stmt.query_map(params![&binding.binding_id, active_repo_id], |row| {
+            Ok(RelocationTwin {
+                id: row.get(0)?,
+                path: row.get(1)?,
+                kind: row.get(2)?,
+                signature: row.get(3)?,
+            })
+        })?;
+        rows.collect::<rusqlite::Result<_>>()?
+    };
+    let relocated = pick_relocation_twin(
+        candidates,
+        binding.symbol_kind.as_deref(),
+        binding.signature_hash.as_deref(),
+    );
     if let Some((id, path)) = relocated {
         binding.logical_symbol_id = Some(id);
         binding.path = Some(path);
@@ -123,6 +144,42 @@ pub(crate) fn validate_logical_symbol_binding(
     }
     relocate_via_moniker_or_gone(conn, binding)
 }
+/// A live logical-symbol row sharing the dead binding's qualified name — a relocation candidate.
+struct RelocationTwin {
+    id: i64,
+    path: String,
+    kind: String,
+    signature: Option<String>,
+}
+
+/// Choose which same-qualified-name twin a gone binding relocates onto (#491): the stored
+/// discriminators win — kind agreement outranks signature-hash agreement (a rename usually keeps
+/// the kind but changes the signature text) — and equal evidence falls back to the lowest id, so
+/// the pick is deterministic instead of plan-order. `None` evidence on the binding degrades
+/// gracefully: every candidate scores equally and the id tiebreak decides, matching the old
+/// behavior for bindings that predate the V014 discriminators.
+fn pick_relocation_twin(
+    candidates: Vec<RelocationTwin>,
+    bound_kind: Option<&str>,
+    bound_signature_hash: Option<&str>,
+) -> Option<(i64, String)> {
+    candidates
+        .into_iter()
+        .map(|twin| {
+            let kind_agrees = bound_kind == Some(twin.kind.as_str());
+            let signature_agrees = match (bound_signature_hash, &twin.signature) {
+                (Some(bound), Some(sig)) => bound == hex_sha256(sig.trim().as_bytes()),
+                _ => false,
+            };
+            // Candidates arrive id-ascending; max_by_key keeps the LAST maximum, so compare on
+            // (score, negated id) to keep the lowest-id winner among evidence ties.
+            let score = (u8::from(kind_agrees) << 1) | u8::from(signature_agrees);
+            (score, -twin.id, twin)
+        })
+        .max_by_key(|(score, neg_id, _)| (*score, *neg_id))
+        .map(|(_, _, twin)| (twin.id, twin.path))
+}
+
 pub(crate) fn validate_symbol_binding(
     conn: &Connection,
     binding: &mut RepoMemoryBinding,


### PR DESCRIPTION
Fixes #491.

The gone-binding relocation arm in `validate_logical_symbol_binding` resolved by qualified name with a bare `LIMIT 1` — no kind/signature discrimination, no ORDER BY. One qualified name can hold several live twins (a `struct` and its `impl` block; overloads with distinct signatures), and the impl's logical key sorts first in the rebuild's insertion order, so the unordered pick deterministically landed a struct-bound memory on the impl row. Observed on the dogfood index: a `FileLock`-bound memory whose stored `symbol_kind = struct` ended up on the impl logical id.

Bindings have carried `symbol_kind` + `signature_hash` since V014 for durable relocation — this makes the arm use them: fetch every same-name twin (with a member signature — all members of a logical group share it, since the signature is part of the key), prefer kind agreement, then signature-hash agreement, then lowest id. Deterministic in every case; bindings predating the discriminators degrade to the id tiebreak, which is the old behavior made stable.

Test: struct+impl twins at one qualified name where the impl deterministically wins the buggy pick; a struct-bound binding pointed at a dead id must relocate onto the struct row (fails against the old query, verified).

First of the three anchor-automation issues from the dogfood incident (#491 → #492 auto-rebind → #493 realign-on-drift).