### PR TITLE
feat(memory): pending anchor status for in-flight worktree branches

### DIFF
--- a/crates/rag-rat-cli/src/commands/index_ops.rs
+++ b/crates/rag-rat-cli/src/commands/index_ops.rs
@@ -75,8 +75,14 @@ pub(crate) fn index(config: &Config, args: &IndexArgs) -> anyhow::Result<()> {
         eprintln!("warning: repo-memory re-validation failed: {err}");
     }
     // After validate has refreshed anchor_status values, count non-current anchors with a
-    // read-only query (doctor reads persisted values; no re-validation).
-    let doctor_count = db.memory_doctor().map(|entries| entries.len()).unwrap_or(0);
+    // read-only query (doctor reads persisted values; no re-validation). `pending` entries are
+    // excluded — alive on an in-flight worktree branch (#492), they need no re-anchoring — but
+    // everything else doctor lists (gone/stale bindings AND placeholder-scoped memories) stays
+    // actionable and must keep tripping this warning.
+    let doctor_count = db
+        .memory_doctor()
+        .map(|entries| entries.iter().filter(|e| e.anchor_status != "pending").count())
+        .unwrap_or(0);
     if doctor_count > 0 {
         eprintln!("⚠ {doctor_count} repo memories need re-anchoring — run 'rag-rat memory doctor'");
     }

--- a/crates/rag-rat-cli/src/commands/memory.rs
+++ b/crates/rag-rat-cli/src/commands/memory.rs
@@ -178,6 +178,17 @@ pub(crate) fn memory(config: &Config, args: &MemoryArgs) -> anyhow::Result<()> {
             for entry in &entries {
                 eprintln!("[{}] {} ({})", entry.anchor_status, entry.title, entry.memory_id);
                 eprintln!("  binding: {} {}", entry.binding_kind, entry.binding_id);
+                // `pending` (#492): the target is alive in another indexed scope (an in-flight
+                // worktree branch) — informational only. Never suggest rebind/mark-obsolete
+                // (that advice clobbered a valid forward anchor on the dogfood repo), and never
+                // fail the command over it.
+                if entry.anchor_status == "pending" {
+                    eprintln!(
+                        "  -> in flight on another checkout (worktree overlay); no action needed \
+                         — it re-anchors when that branch lands"
+                    );
+                    continue;
+                }
                 if entry.candidates.is_empty() {
                     if entry.anchor_status == "gone" {
                         eprintln!(

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -10,9 +10,10 @@ pub(crate) use migrations::*;
 pub(crate) use registry::multiple_real_repos;
 pub(crate) use registry::{
     CONNECTION_CONTEXT_GENERATION_KEY, CONNECTION_CONTEXT_REPO_KEY, LIVE_FILES_GENERATION_META_KEY,
-    active_generation, active_repo_id, earliest_recorded_root, live_files_generation,
-    periphery_repo_scope, periphery_repo_scope_clause, repo_has_recorded_root,
-    repo_id_is_registered, resolve_config_repo_id, scope_context_repo_id, sole_repo_id,
+    active_generation, active_repo_id, connection_context_value, earliest_recorded_root,
+    live_files_generation, periphery_repo_scope, periphery_repo_scope_clause,
+    repo_has_recorded_root, repo_id_is_registered, resolve_config_repo_id, scope_context_repo_id,
+    sole_repo_id,
 };
 pub use registry::{LEGACY_REPO_ID, register_repo, register_repo_read_only};
 use rusqlite::{Connection, OptionalExtension, params};

--- a/crates/rag-rat-core/src/index/schema/registry.rs
+++ b/crates/rag-rat-core/src/index/schema/registry.rs
@@ -938,11 +938,16 @@ pub(crate) fn scope_context_repo_id(conn: &Connection) -> Option<String> {
 /// the `temp.connection_context` table (a raw connection with no view installed) — `.ok()` swallows
 /// the "no such table" error into `None`, exactly like `edges::resolve`'s `scope_context_value`.
 fn context_repo_id(conn: &Connection) -> Option<String> {
-    conn.query_row(
-        "SELECT value FROM temp.connection_context WHERE key = ?1",
-        [CONNECTION_CONTEXT_REPO_KEY],
-        |row| row.get::<_, String>(0),
-    )
+    connection_context_value(conn, CONNECTION_CONTEXT_REPO_KEY)
+}
+
+/// Read one key from the per-connection scope context (`temp.connection_context`), tolerating the
+/// table's common absence (a raw connection with no scope view installed) as `None` — the shared
+/// tolerant-read for every context key (`repo_id`, `worktree_id`, `commit_sha`, …).
+pub(crate) fn connection_context_value(conn: &Connection, key: &str) -> Option<String> {
+    conn.query_row("SELECT value FROM temp.connection_context WHERE key = ?1", [key], |row| {
+        row.get::<_, String>(0)
+    })
     .optional()
     .ok()
     .flatten()

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/repo_memory.rs
@@ -526,6 +526,180 @@ fn relocation_lands_on_the_kind_matching_twin_not_plan_order() {
     let _ = fs::remove_dir_all(root);
 }
 
+/// #492: the path probe took the newest `files` row with no `kind != 'deleted'` filter, and a
+/// deleted-at-HEAD file's marker row (kind='deleted', sha256='') shadowed the absence — a bare
+/// path binding to a deleted file stayed `current` forever.
+#[test]
+fn a_deleted_at_head_file_makes_a_bare_path_binding_gone() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn keeper() {}\n").unwrap();
+    fs::write(root.join("src/doomed.rs"), "pub fn doomed() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Risk".to_string(),
+            title: "Area note on a file that will be deleted".to_string(),
+            body: "Must go gone with its file, not stay current behind the deleted marker."
+                .to_string(),
+            confidence: "medium".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                path: Some("src/doomed.rs".to_string()),
+                ..Default::default()
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+    let status = |db: &IndexDatabase| -> String {
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT anchor_status FROM repo_memory_bindings WHERE memory_id = ?1",
+                params![memory_id],
+                |r| r.get(0),
+            )
+            .unwrap()
+    };
+    db.memory_validate().unwrap();
+    assert_eq!(status(&db), "current", "alive file → current");
+
+    // The file is deleted at HEAD: the index keeps a deleted-marker row (kind='deleted',
+    // sha256=''), exactly the shape the incremental delete path leaves behind.
+    fs::remove_file(root.join("src/doomed.rs")).unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "UPDATE main.files SET kind = 'deleted', sha256 = '' WHERE path = 'src/doomed.rs'",
+            [],
+        )
+        .unwrap();
+    let report = db.memory_validate().unwrap();
+    assert_eq!(status(&db), "gone", "the deleted marker must not shadow the file's absence");
+    assert_eq!(report.gone, 1);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+/// #492: a path that is absent at THIS context's HEAD but alive in another indexed scope (a
+/// linked-worktree overlay — an in-flight branch) is `pending`, not `gone`. Verified live on the
+/// dogfood DB: a forward anchor to a branch-only file ping-ponged current/gone between contexts,
+/// and doctor advised mark-obsolete for valid in-flight work.
+#[test]
+fn a_path_alive_only_in_another_scope_validates_pending_not_gone() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn base() {}\n").unwrap();
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+
+    let live_generation =
+        crate::index::schema::live_files_generation(db.storage.connection(), &db.active_repo_id)
+            .unwrap();
+    let insert_row = |generation: i64, sha: &str| {
+        db.storage
+            .connection()
+            .execute(
+                "INSERT INTO main.files (path, language, kind, sha256, modified_at_ms,
+                                    generated, indexed_at_ms, indexed_revision, commit_sha,
+                                    worktree_id, has_test_code, repo_id, generation)
+                 VALUES ('src/inflight.rs', 'rust', 'source', ?2, 0, 0, 0, '', '',
+                         'wt-elsewhere', 0, ?1, ?3)",
+                params![db.active_repo_id, sha, generation],
+            )
+            .unwrap();
+    };
+
+    let created = db
+        .memory_create(crate::query::memory::RepoMemoryCreate {
+            kind: "Decision".to_string(),
+            title: "Forward anchor to in-flight work".to_string(),
+            body: "Absent here, alive on a branch — pending, never mark-obsolete bait.".to_string(),
+            confidence: "medium".to_string(),
+            created_by: Some("test-agent".to_string()),
+            source: Some("agent".to_string()),
+            tags: Vec::new(),
+            payload_json: None,
+            bind: crate::query::memory::RepoMemoryBindTarget {
+                path: Some("src/inflight.rs".to_string()),
+                ..Default::default()
+            },
+        })
+        .unwrap();
+    let memory_id = created.memory.memory_id;
+    let status = |db: &IndexDatabase| -> String {
+        db.storage
+            .connection()
+            .query_row(
+                "SELECT anchor_status FROM repo_memory_bindings WHERE memory_id = ?1",
+                params![memory_id],
+                |r| r.get(0),
+            )
+            .unwrap()
+    };
+
+    // A SUPERSEDED generation's not-yet-GC'd row is NOT alive-elsewhere evidence (the review
+    // case: a full rebuild deleted the file; pre-sweep the dead generation still holds a source
+    // row) — only live-generation rows (worktree overlays ride the live generation) count.
+    insert_row(live_generation + 7, "dead-gen-sha");
+    let report = db.memory_validate().unwrap();
+    assert_eq!(
+        status(&db),
+        "gone",
+        "a superseded generation's leftover row must not report pending"
+    );
+    assert_eq!(report.pending, 0);
+
+    // A retained old-commit BASE row (worktree_id = '') at the live generation is THIS context's
+    // history, not another checkout — a path deleted at HEAD must stay gone through the pre-gc
+    // window (review case 2).
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO main.files (path, language, kind, sha256, modified_at_ms, generated,
+                                indexed_at_ms, indexed_revision, commit_sha, worktree_id,
+                                has_test_code, repo_id, generation)
+             VALUES ('src/inflight.rs', 'rust', 'source', 'old-commit-sha', 0, 0, 0, '',
+                     'oldcommit', '', 0, ?1, ?2)",
+            params![db.active_repo_id, live_generation],
+        )
+        .unwrap();
+    let report = db.memory_validate().unwrap();
+    assert_eq!(status(&db), "gone", "a retained old-commit base row must not report pending");
+    assert_eq!(report.pending, 0);
+
+    // The in-flight branch's checkout indexed the file at the LIVE generation (the
+    // worktree-overlay shape) — now it is genuinely pending.
+    insert_row(live_generation, "wt-sha");
+    let report = db.memory_validate().unwrap();
+    assert_eq!(status(&db), "pending", "alive in another scope → pending, not gone");
+    assert_eq!(report.pending, 1);
+    assert_eq!(report.gone, 0);
+
+    // Doctor surfaces it (as pending — informational), never as gone.
+    let doctor = db.memory_doctor().unwrap();
+    let entry = doctor.iter().find(|e| e.memory_id == memory_id).expect("doctor lists pending");
+    assert_eq!(entry.anchor_status, "pending");
+
+    // Once no scope holds the path (the branch was abandoned), it is genuinely gone.
+    db.storage
+        .connection()
+        .execute("DELETE FROM main.files WHERE path = 'src/inflight.rs'", [])
+        .unwrap();
+    let report = db.memory_validate().unwrap();
+    assert_eq!(report.pending, 0);
+    assert_eq!(report.gone, 1);
+
+    let _ = fs::remove_dir_all(root);
+}
+
 #[test]
 fn repo_memory_bound_to_edge_surfaces_when_impact_crosses_call_path() {
     let root = unique_temp_root();

--- a/crates/rag-rat-core/src/query/memory/api.rs
+++ b/crates/rag-rat-core/src/query/memory/api.rs
@@ -695,9 +695,9 @@ pub struct MemoryDoctorEntry {
 ///
 /// Invariant: this function is purely READ — it never writes to the database.
 /// Count of active memories whose anchor is `gone`/`stale` — the EXACT population `doctor_report`
-/// lists (same WHERE), so a "N need re-anchoring" nudge matches what `memory_doctor` then shows.
-/// `scip_moniker` bindings are excluded (self-heal on the next oracle run, never
-/// rebind-actionable).
+/// lists as ACTIONABLE (`pending` entries are listed there informationally but need no
+/// re-anchoring, so they are deliberately not counted here — #492). `scip_moniker` bindings are
+/// excluded (self-heal on the next oracle run, never rebind-actionable).
 pub(crate) fn doctor_attention_count(conn: &Connection) -> anyhow::Result<u64> {
     let scope = memory_repo_scope(conn)?;
     let repo_clause = crate::index::schema::periphery_repo_scope_clause(&scope, "m");
@@ -752,7 +752,10 @@ pub(crate) fn doctor_report(conn: &Connection) -> anyhow::Result<Vec<MemoryDocto
         FROM repo_memory_bindings AS b
         JOIN repo_memories AS m ON m.id = b.memory_id
         WHERE m.status = 'active'
-          AND b.anchor_status IN ('gone', 'stale')
+          -- `pending` is LISTED (informational: alive on an in-flight branch, #492) but is
+          -- deliberately absent from `doctor_attention_count` and the dream queue — it is not
+          -- rebind-actionable and must never draw gone-style remediation.
+          AND b.anchor_status IN ('gone', 'stale', 'pending')
           -- `scip_moniker` bindings are excluded: a lagging moniker self-heals on the next
           -- `oracle run` and is never rebind-actionable; a genuinely dead symbol surfaces via
           -- its symbol/logical_symbol binding anyway (#70).
@@ -979,6 +982,7 @@ pub(crate) fn validate_memories(
         relocated: 0,
         stale: 0,
         gone: 0,
+        pending: 0,
         unverified: 0,
     };
     for row in rows {
@@ -1029,6 +1033,7 @@ pub(crate) fn validate_memories(
             "relocated" => report.relocated += 1,
             "stale" => report.stale += 1,
             "gone" => report.gone += 1,
+            "pending" => report.pending += 1,
             _ => report.unverified += 1,
         }
     }

--- a/crates/rag-rat-core/src/query/memory/hydrate.rs
+++ b/crates/rag-rat-core/src/query/memory/hydrate.rs
@@ -334,7 +334,13 @@ pub(crate) fn split_active_stale(memories: Vec<RepoMemory>) -> (Vec<RepoMemory>,
         if memory.status == "stale"
             || memory.bindings.iter().any(|binding| {
                 binding.binding_kind != SCIP_MONIKER_BINDING_KIND
-                    && matches!(binding.anchor_status.as_str(), "stale" | "gone" | "unverified")
+                    && matches!(
+                        binding.anchor_status.as_str(),
+                        // `pending` (#492) joins the demoted bucket: the anchored code is not in
+                        // THIS context, so drive-by evidence must not present as confidently
+                        // current — but unlike `gone` it draws no remediation.
+                        "stale" | "gone" | "unverified" | "pending"
+                    )
             })
         {
             stale.push(memory);

--- a/crates/rag-rat-core/src/query/memory/mod.rs
+++ b/crates/rag-rat-core/src/query/memory/mod.rs
@@ -254,6 +254,10 @@ pub struct RepoMemoryValidationReport {
     pub relocated: u64,
     pub stale: u64,
     pub gone: u64,
+    /// Absent at THIS context's HEAD but alive in another indexed scope (a linked-worktree
+    /// overlay — in-flight branch work, #492). Not broken: it re-anchors when the branch lands,
+    /// and it must never draw `gone`-style remediation (rebind / mark-obsolete).
+    pub pending: u64,
     pub unverified: u64,
 }
 

--- a/crates/rag-rat-core/src/query/memory/validate.rs
+++ b/crates/rag-rat-core/src/query/memory/validate.rs
@@ -442,9 +442,13 @@ pub(crate) fn validate_path_binding(
     let Some(path) = binding.path.as_deref() else {
         return Ok("unverified".to_string());
     };
+    // `kind != 'deleted'` (#492): a deleted-at-HEAD file leaves a marker row (kind='deleted',
+    // sha256='') that would otherwise be the newest row for the path and shadow the absence —
+    // the binding stayed `current` forever behind it.
     let current_hash = conn
         .query_row(
-            "SELECT sha256 FROM files WHERE path = ?1 ORDER BY id DESC LIMIT 1",
+            "SELECT sha256 FROM files WHERE path = ?1 AND kind != 'deleted'
+             ORDER BY id DESC LIMIT 1",
             [path],
             |row| row.get::<_, String>(0),
         )
@@ -460,10 +464,21 @@ pub(crate) fn validate_path_binding(
         // (alive but un-content-verifiable), never `gone`. The target must be a FILE: a
         // path binding names a file, so a directory now occupying that name leaves the file
         // genuinely `gone`.
-        let status = match path_is_file_on_disk(fs_root, path) {
-            true if binding.start_line.is_none() && binding.end_line.is_none() => "current",
-            true => "unverified",
-            false => "gone",
+        let status = if path_is_file_on_disk(fs_root, path) {
+            if binding.start_line.is_none() && binding.end_line.is_none() {
+                "current"
+            } else {
+                "unverified"
+            }
+        } else if path_is_live_in_another_scope(conn, path)? {
+            // Neither indexed here nor on disk — but ALIVE in another indexed scope (a
+            // linked-worktree overlay: an in-flight branch, #492): the anchor is `pending`,
+            // not gone. Verified live: forward anchors to branch-only files ping-ponged
+            // current/gone between checkout contexts, and doctor advised mark-obsolete for
+            // valid in-flight work. Only when NO scope holds the path is it genuinely gone.
+            "pending"
+        } else {
+            "gone"
         };
         return Ok(status.to_string());
     };
@@ -517,6 +532,36 @@ fn is_repo_relative(path: &str) -> bool {
 /// repo-relative.
 fn path_is_file_on_disk(root: Option<&Path>, path: &str) -> bool {
     root.is_some_and(|root| is_repo_relative(path) && root.join(path).is_file())
+}
+
+/// Whether ANOTHER CHECKOUT's overlay holds a live row for `path` — the `pending` probe (#492).
+/// The scoped `files` view already answered "not in THIS context"; a linked-worktree overlay row
+/// (an in-flight branch's checkout) means the anchor's target exists and will re-anchor when the
+/// branch lands, so it must not be treated (or remediated) as dead. Three predicates keep the
+/// probe honest (each closes a false-pending source found in review):
+/// - repo-scoped: a sibling repo's identical path cannot bless a dead anchor on a consolidated DB;
+/// - LIVE-generation only: a superseded full-rebuild generation's not-yet-GC'd rows are not
+///   alive-elsewhere evidence;
+/// - OTHER-worktree only (`worktree_id != ''` and != the active context's): retained old-commit
+///   base rows (worktree_id = '') and the active checkout's own dirty-scope rows are THIS context,
+///   not another one — a path deleted at HEAD must stay `gone` through the pre-gc window.
+fn path_is_live_in_another_scope(conn: &Connection, path: &str) -> anyhow::Result<bool> {
+    let active_repo_id = crate::index::schema::active_repo_id(conn)?;
+    let live_generation = crate::index::schema::live_files_generation(conn, &active_repo_id)?;
+    let active_worktree = context_worktree_id(conn);
+    Ok(conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM main.files
+                       WHERE path = ?1 AND kind != 'deleted' AND repo_id = ?2
+                         AND generation = ?3
+                         AND worktree_id != '' AND worktree_id != ?4)",
+        params![path, active_repo_id, live_generation, active_worktree],
+        |r| r.get::<_, i64>(0),
+    )? != 0)
+}
+
+/// The active context's worktree id, `''` when no scope view is installed on this connection.
+fn context_worktree_id(conn: &Connection) -> String {
+    crate::index::schema::connection_context_value(conn, "worktree_id").unwrap_or_default()
 }
 
 /// Whether `dir` (repo-root-relative, `""` = repo root) resolves to an existing directory under

--- a/crates/rag-rat-mcp/src/tools/catalog.rs
+++ b/crates/rag-rat-mcp/src/tools/catalog.rs
@@ -202,12 +202,14 @@ pub fn description(name: &str) -> &'static str {
              `memory_id` to get the complete original. Surface-independent: always the full body.",
         "memory_validate" =>
             "Re-anchor every repo memory against current source and mark each current / relocated \
-             / stale / gone. Runs automatically after indexing.",
+             / stale / gone / pending. Runs automatically after indexing.",
         "memory_doctor" =>
-            "List repo memories whose anchor is stale or gone, each with suggested re-anchor \
-             targets (qualified names) — the actionable companion to memory_validate. Read-only; \
+            "List repo memories whose anchor is stale, gone, or pending, each with suggested \
+             re-anchor targets (qualified names) — the actionable companion to memory_validate. A \
+             `pending` anchor is alive on an in-flight worktree branch: informational only — do \
+             NOT rebind or mark it obsolete; it re-anchors when that branch lands. Read-only; \
              reports the last-validated status, so run memory_validate first for a fresh check. \
-             Rebind the listed memories with memory_rebind.",
+             Rebind stale/gone entries with memory_rebind.",
         "memory_mark_obsolete" =>
             "Mark a repo memory obsolete — kept for audit, hidden from active recall.",
         "memory_edge_add" =>


### PR DESCRIPTION
Part of #492 (the verified core; downgrade hysteresis remains open there).

`anchor_status` is one global value, but validate sweeps run from every live checkout context — and they legitimately disagree. Verified on the dogfood DB: a memory path-bound to a file that exists only on an in-flight worktree branch validated `current` from that worktree and `gone` from main; the two contexts ping-ponged the status, and doctor's `mark-obsolete` advice for the main-context view nearly destroyed (and its rebind advice did clobber, once) the owning session's deliberate forward anchor.

- **`pending` status**: a path binding absent at this context's HEAD and from disk, but alive in **another checkout's overlay** — repo-scoped, live-generation-only, other-worktree-only rows (each predicate closes a false-pending source found in review: sibling repos, superseded pre-gc generations, retained old-commit base rows) — now validates `pending`. Doctor lists it informationally ("in flight on another checkout; no action needed"), it never trips the "need re-anchoring" warning or the CLI failure exit, it's excluded from the dream verification queue, and drive-by evidence demotes it like unverified. Only when no scope holds the path is a binding genuinely `gone`.
- **Deleted-marker probe fix**: the path probe took the newest `files` row with no `kind != 'deleted'` filter, so a deleted-at-HEAD file's marker row (sha256 = '') shadowed the absence — a bare path binding to a deleted file stayed `current` forever.
- The post-index warning counts doctor entries excluding `pending` (placeholder-scoped memories keep tripping it), `RepoMemoryValidationReport` gains a `pending` count, and the shared `connection_context_value` reader replaces a would-be duplicate of `context_repo_id`.

Tests: deleted-marker shadow (current-forever regression), and the pending lifecycle — superseded-generation row → gone, retained old-commit base row → gone, other-worktree overlay row → pending (doctor listing included), overlay removed → gone.