### PR TITLE
feat(oplog): signed hash-chained entry envelope + ed25519 device keys (phase B C4 layer-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +440,12 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -629,6 +641,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +792,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,7 +889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
 ]
 
@@ -896,6 +945,30 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "either"
@@ -1003,6 +1076,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -1530,7 +1609,7 @@ dependencies = [
  "faster-hex",
  "gix-features",
  "sha1-checked",
- "sha2",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
 ]
 
@@ -3144,6 +3223,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3356,6 +3445,7 @@ version = "0.14.0"
 dependencies = [
  "anyhow",
  "criterion",
+ "ed25519-dalek",
  "fastembed",
  "gix",
  "iai-callgrind",
@@ -3372,7 +3462,7 @@ dependencies = [
  "scip",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "strum",
  "tempfile",
  "thiserror 2.0.18",
@@ -3390,6 +3480,7 @@ dependencies = [
  "tree-sitter-typescript",
  "unicode-normalization",
  "ureq 3.3.0",
+ "zeroize",
  "zstd",
 ]
 
@@ -3416,7 +3507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3426,7 +3517,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -3979,6 +4079,17 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
@@ -4041,6 +4152,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4077,6 +4197,16 @@ dependencies = [
  "byteorder",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,11 @@ categories = ["command-line-utilities", "development-tools"]
 rag-rat-core = { version = "0.14.0", path = "crates/rag-rat-core", default-features = false }
 rag-rat-mcp = { version = "0.14.0", path = "crates/rag-rat-mcp", default-features = false }
 anyhow = "1.0"
+# ed25519 device-identity signing for the op-log's signed entry envelope (§C4 layer-1). Default
+# features (incl. `zeroize`, which zeroizes a `SigningKey`'s seed on drop) are kept; the `rand_core`
+# CSPRNG-keygen feature stays OFF — device keys derive deterministically from a seed via
+# `SigningKey::from_bytes`. Verification uses `verify_strict` (rejects malleable / small-order sigs).
+ed25519-dalek = "2"
 fastembed = { version = "5.17.2", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
 gix = { version = "0.85.0", default-features = false, features = ["status", "parallel", "sha1", "sha256", "revision", "blob-diff", "blame"] }
 libc = "0.2"
@@ -72,6 +77,9 @@ tree-sitter-kotlin = { package = "tree-sitter-kotlin-ng", version = "1.1.0" }
 tree-sitter-python = "=0.25.0"
 tree-sitter-rust = "=0.24.2"
 tree-sitter-typescript = "=0.23.2"
+# Secret-material hygiene for the op-log device seed — `Zeroizing<[u8; 32]>` scrubs the seed copy on
+# drop (already in the tree transitively via ed25519-dalek; pinned here as a direct dep).
+zeroize = "1"
 
 # `cc` compiles the bundled SQLite amalgamation at the profile's opt-level, which is 0 for
 # `cargo build`/`cargo test` — an unoptimized SQLite is dramatically slower at the heavy INSERT

--- a/crates/rag-rat-core/Cargo.toml
+++ b/crates/rag-rat-core/Cargo.toml
@@ -13,6 +13,7 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+ed25519-dalek.workspace = true
 fastembed = { workspace = true, optional = true }
 gix.workspace = true
 ignore = "0.4.26"
@@ -50,6 +51,7 @@ tree-sitter-rust.workspace = true
 tree-sitter-typescript.workspace = true
 minicbor = { version = "2.2.2", features = ["alloc"] }
 unicode-normalization = "0.1.25"
+zeroize.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true

--- a/crates/rag-rat-core/src/oplog/cbor.rs
+++ b/crates/rag-rat-core/src/oplog/cbor.rs
@@ -1,0 +1,177 @@
+//! Shared canonical-CBOR discipline for the op-log wire (phase B, §5.4/§5.6).
+//!
+//! Every op-log object — the op envelope ([`super::op`]) and the signed, hash-chained entry
+//! ([`super::entry`]) — serializes to CANONICAL, deterministic CBOR (RFC 8949 §4.2
+//! core-deterministic): DEFINITE lengths only, MINIMAL-length argument headers, sorted + unique map
+//! keys, no floats (this wire is integer-only). Canonicity is the security boundary: a signature or
+//! `entry_hash` over these bytes is only unambiguous if the SAME logical value has exactly ONE
+//! accepted encoding.
+//!
+//! Two complementary gates live here, both used by op + entry:
+//! - [`require_canonical_cbor`] walks RAW bytes and rejects every non-canonical encoding — the
+//!   check a retained-opaque value (an unknown op, an opaque `op_bytes` inside an entry body)
+//!   needs, since it can't be re-encoded from a decoded form.
+//! - [`expect_array`] / [`expect_definite_len`] are the `minicbor::Decoder` structural helpers that
+//!   read a definite-length array header (canonical CBOR is definite-length only; an indefinite or
+//!   wrong-arity header is a hard error).
+//!
+//! A KNOWN object gets an even stronger, value-level guarantee from its module by re-encoding and
+//! demanding `encode(decode(bytes)) == bytes` (e.g. sorted+deduped tags in `op`); this module is
+//! the encoding-level floor beneath that.
+
+use minicbor::decode::{Decoder, Error as CborError};
+
+/// Validate that `bytes` is EXACTLY one canonical CBOR item (RFC 8949 §4.2 core-deterministic) with
+/// no trailing bytes: MINIMAL-length argument headers, DEFINITE lengths only, sorted + unique map
+/// keys, and no floats (this wire format is integer-only). This is the encoding-level canonicity a
+/// retained-opaque value needs; a known object gets the same guarantee (plus value-level rules)
+/// from `encode(decode) == bytes`.
+pub(super) fn require_canonical_cbor(bytes: &[u8]) -> Result<(), CborError> {
+    let mut pos = 0;
+    check_canonical_item(bytes, &mut pos, 0)?;
+    if pos != bytes.len() {
+        return Err(CborError::message("trailing bytes after canonical CBOR item"));
+    }
+    Ok(())
+}
+
+/// Max CBOR nesting depth. Real objects nest shallowly (envelope → payload array → content array →
+/// tags array ≈ depth 4); a deeper structure is malformed/hostile, and unbounded recursion in the
+/// validator would overflow the stack — so cap it well above any real object and reject beyond.
+pub(super) const MAX_CBOR_DEPTH: usize = 32;
+
+/// Validate one canonical CBOR item at `*pos`, advancing past it; recurses into arrays/maps/tags
+/// with a bounded `depth` (a pathologically nested input errors instead of overflowing the stack).
+fn check_canonical_item(bytes: &[u8], pos: &mut usize, depth: usize) -> Result<(), CborError> {
+    if depth > MAX_CBOR_DEPTH {
+        return Err(CborError::message("CBOR nesting too deep"));
+    }
+    let (major, arg) = read_canonical_header(bytes, pos)?;
+    match major {
+        0 | 1 => Ok(()), // uint / negative int — the header IS the value
+        2 => {
+            // byte string: `arg` opaque content bytes (no UTF-8 requirement).
+            advance_string(bytes, pos, arg)
+        },
+        3 => {
+            // text string: `arg` bytes that MUST be valid UTF-8. A future decoder reads this field
+            // with `d.str()`, which rejects invalid UTF-8 — so a non-UTF-8 text string is not a
+            // re-foldable canonical object even though its length header is well-formed.
+            let start = *pos;
+            advance_string(bytes, pos, arg)?;
+            str::from_utf8(&bytes[start..*pos])
+                .map_err(|_| CborError::message("invalid UTF-8 in CBOR text string"))?;
+            Ok(())
+        },
+        4 => {
+            for _ in 0..arg {
+                check_canonical_item(bytes, pos, depth + 1)?;
+            }
+            Ok(())
+        },
+        5 => {
+            // Map: keys must be strictly ascending by their encoded bytes (sorted + no duplicates).
+            let mut prev_key: Option<&[u8]> = None;
+            for _ in 0..arg {
+                let key_start = *pos;
+                check_canonical_item(bytes, pos, depth + 1)?;
+                let key = &bytes[key_start..*pos];
+                if prev_key.is_some_and(|prev| key <= prev) {
+                    return Err(CborError::message("map keys not sorted or duplicated"));
+                }
+                prev_key = Some(key);
+                check_canonical_item(bytes, pos, depth + 1)?;
+            }
+            Ok(())
+        },
+        6 => check_canonical_item(bytes, pos, depth + 1), // tag: one following item
+        7 => Ok(()),                                      /* simple value (null/bool/…); floats */
+        // already rejected by the header
+        // reader
+        _ => Err(CborError::message("invalid CBOR major type")),
+    }
+}
+
+/// Read one CBOR item header at `*pos`, returning `(major, argument)` and advancing past it.
+/// Rejects non-minimal argument encodings, indefinite/reserved lengths, and floats.
+fn read_canonical_header(bytes: &[u8], pos: &mut usize) -> Result<(u8, u64), CborError> {
+    let first = read_u8(bytes, pos)?;
+    let major = first >> 5;
+    let arg = match first & 0x1f {
+        info @ 0..=23 => u64::from(info),
+        24 => {
+            let v = u64::from(read_u8(bytes, pos)?);
+            require(v >= 24, "non-minimal 1-byte CBOR argument")?;
+            v
+        },
+        25 => {
+            require(major != 7, "float is non-canonical (integer-only wire format)")?;
+            let v = read_be(bytes, pos, 2)?;
+            require(v > u64::from(u8::MAX), "non-minimal 2-byte CBOR argument")?;
+            v
+        },
+        26 => {
+            require(major != 7, "float is non-canonical (integer-only wire format)")?;
+            let v = read_be(bytes, pos, 4)?;
+            require(v > u64::from(u16::MAX), "non-minimal 4-byte CBOR argument")?;
+            v
+        },
+        27 => {
+            require(major != 7, "float is non-canonical (integer-only wire format)")?;
+            let v = read_be(bytes, pos, 8)?;
+            require(v > u64::from(u32::MAX), "non-minimal 8-byte CBOR argument")?;
+            v
+        },
+        _ => return Err(CborError::message("reserved or indefinite CBOR length")), // 28..=31
+    };
+    Ok((major, arg))
+}
+
+/// Advance `*pos` past `arg` string content bytes, bounds-checking against `bytes`.
+fn advance_string(bytes: &[u8], pos: &mut usize, arg: u64) -> Result<(), CborError> {
+    let len = usize::try_from(arg).map_err(|_| CborError::message("CBOR length overflow"))?;
+    let end = pos
+        .checked_add(len)
+        .filter(|end| *end <= bytes.len())
+        .ok_or_else(|| CborError::message("CBOR string runs past end"))?;
+    *pos = end;
+    Ok(())
+}
+
+fn read_u8(bytes: &[u8], pos: &mut usize) -> Result<u8, CborError> {
+    let byte = *bytes.get(*pos).ok_or_else(|| CborError::message("unexpected end of CBOR"))?;
+    *pos += 1;
+    Ok(byte)
+}
+
+/// Read `n` (≤ 8) big-endian bytes into a `u64`.
+fn read_be(bytes: &[u8], pos: &mut usize, n: usize) -> Result<u64, CborError> {
+    let end = pos
+        .checked_add(n)
+        .filter(|end| *end <= bytes.len())
+        .ok_or_else(|| CborError::message("unexpected end of CBOR"))?;
+    let value = bytes[*pos..end].iter().fold(0u64, |acc, &byte| (acc << 8) | u64::from(byte));
+    *pos = end;
+    Ok(value)
+}
+
+fn require(condition: bool, message: &'static str) -> Result<(), CborError> {
+    if condition { Ok(()) } else { Err(CborError::message(message)) }
+}
+
+/// Read a definite-length array header and assert its element count — canonical CBOR is
+/// definite-length only, and a wrong count is a structural (hard) error.
+pub(super) fn expect_array(d: &mut Decoder<'_>, want: u64) -> Result<(), CborError> {
+    let got = expect_definite_len(d)?;
+    if got == want {
+        Ok(())
+    } else {
+        Err(CborError::message(format!("expected a {want}-element array, got {got}")))
+    }
+}
+
+/// Read a definite-length array header, returning its element count. Rejects an indefinite-length
+/// array (canonical CBOR is definite-length only).
+pub(super) fn expect_definite_len(d: &mut Decoder<'_>) -> Result<u64, CborError> {
+    d.array()?.ok_or_else(|| CborError::message("expected a definite-length array"))
+}

--- a/crates/rag-rat-core/src/oplog/device.rs
+++ b/crates/rag-rat-core/src/oplog/device.rs
@@ -1,0 +1,166 @@
+//! The op-log's ed25519 device identity (phase B op-log, §C4 layer-1).
+//!
+//! A device is an ed25519 keypair. [`DeviceSecret`] signs entry bodies; [`DevicePublic`] verifies
+//! them and derives the op model's opaque [`DeviceFingerprint`] = `sha256(pubkey_bytes)` — the
+//! bytes that bind a signed entry to a key without embedding the full 32-byte pubkey in every
+//! entry.
+//!
+//! Keys are SEED-DETERMINISTIC on purpose: [`DeviceSecret::from_seed`] derives the key from a
+//! caller-supplied 32-byte seed via `SigningKey::from_bytes` (no CSPRNG), so golden vectors and
+//! chain tests are byte-reproducible. Production CSPRNG keygen is a later concern. The seed is
+//! secret material: the local copy is scrubbed via `Zeroizing`, and `SigningKey` zeroizes its own
+//! seed on drop (ed25519-dalek's `zeroize` feature).
+//!
+//! Verification is [`ed25519_dalek::VerifyingKey::verify_strict`], which REJECTS malleable and
+//! small-order signatures — the strict ed25519 check the protocol requires (a plain `verify` would
+//! accept signatures a peer could re-encode).
+
+use anyhow::Context;
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
+use sha2::{Digest, Sha256};
+use zeroize::Zeroizing;
+
+use super::op::DeviceFingerprint;
+
+/// A device's ed25519 secret key — the signing capability, built deterministically from a 32-byte
+/// seed. Holds a `SigningKey`, which zeroizes its seed on drop. Intentionally not `Debug` /
+/// `Clone`: secret material should not be trivially printed or duplicated.
+pub(super) struct DeviceSecret(SigningKey);
+
+impl DeviceSecret {
+    /// Derive the device key from a 32-byte seed (the ed25519 secret-scalar seed). Deterministic:
+    /// the same seed always yields the same key, so signatures and fingerprints are reproducible.
+    pub(super) fn from_seed(seed: &[u8; 32]) -> Self {
+        // Copy the seed into a scrubbing buffer so this stack copy can't linger after use;
+        // `SigningKey` keeps (and later zeroizes on drop) its own internal copy.
+        let seed = Zeroizing::new(*seed);
+        Self(SigningKey::from_bytes(&seed))
+    }
+
+    /// The matching public identity (for verification + fingerprint derivation).
+    pub(super) fn public(&self) -> DevicePublic {
+        DevicePublic(self.0.verifying_key())
+    }
+
+    /// Sign `msg` (the canonical entry body bytes), returning the raw 64-byte ed25519 signature.
+    pub(super) fn sign(&self, msg: &[u8]) -> [u8; 64] {
+        self.0.sign(msg).to_bytes()
+    }
+}
+
+/// A device's ed25519 public key — the verification capability and the source of the opaque
+/// [`DeviceFingerprint`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct DevicePublic(VerifyingKey);
+
+impl DevicePublic {
+    /// Parse a compressed 32-byte ed25519 public key, REJECTING an invalid curve point. Validation
+    /// happens here at construction so a [`DevicePublic`] is always a well-formed verifying key.
+    pub(super) fn from_bytes(bytes: &[u8; 32]) -> anyhow::Result<Self> {
+        VerifyingKey::from_bytes(bytes).map(Self).context("invalid ed25519 public key point")
+    }
+
+    /// The 32-byte compressed public key.
+    pub(super) fn to_bytes(self) -> [u8; 32] {
+        self.0.to_bytes()
+    }
+
+    /// The opaque device fingerprint the op model carries: `sha256(pubkey_bytes)`. A 32-byte hash
+    /// of the key, so a signed entry binds to a key without embedding the whole pubkey.
+    pub(super) fn fingerprint(&self) -> DeviceFingerprint {
+        let mut fp = [0u8; 32];
+        fp.copy_from_slice(&Sha256::digest(self.to_bytes()));
+        DeviceFingerprint::from_bytes(fp)
+    }
+
+    /// Verify `sig` over `msg` under this key with `verify_strict` (rejects malleable / small-order
+    /// signatures). A `Signature` from 64 raw bytes is always constructible — validity is decided
+    /// here, at verification.
+    pub(super) fn verify(&self, msg: &[u8], sig: &[u8; 64]) -> anyhow::Result<()> {
+        let signature = Signature::from_bytes(sig);
+        self.0.verify_strict(msg, &signature).context("ed25519 signature verification failed")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two distinct fixed seeds → two distinct devices; deterministic across calls.
+    fn seed_a() -> [u8; 32] {
+        [7u8; 32]
+    }
+
+    fn seed_b() -> [u8; 32] {
+        [9u8; 32]
+    }
+
+    #[test]
+    fn from_seed_is_deterministic() {
+        // The same seed must always yield the same key material (pubkey + signature) — the property
+        // the golden vectors and chain reproducibility rely on.
+        let a1 = DeviceSecret::from_seed(&seed_a());
+        let a2 = DeviceSecret::from_seed(&seed_a());
+        assert_eq!(a1.public().to_bytes(), a2.public().to_bytes());
+        let msg = b"the same message";
+        assert_eq!(a1.sign(msg), a2.sign(msg), "ed25519 signing is deterministic per seed");
+        // A different seed is a different device.
+        let b = DeviceSecret::from_seed(&seed_b());
+        assert_ne!(a1.public().to_bytes(), b.public().to_bytes());
+    }
+
+    #[test]
+    fn fingerprint_is_sha256_of_the_pubkey() {
+        let secret = DeviceSecret::from_seed(&seed_a());
+        let public = secret.public();
+        let mut expected = [0u8; 32];
+        expected.copy_from_slice(&Sha256::digest(public.to_bytes()));
+        assert_eq!(public.fingerprint().to_bytes(), expected);
+    }
+
+    #[test]
+    fn public_bytes_round_trip() {
+        let public = DeviceSecret::from_seed(&seed_a()).public();
+        let parsed = DevicePublic::from_bytes(&public.to_bytes()).expect("valid pubkey re-parses");
+        assert_eq!(parsed, public);
+    }
+
+    #[test]
+    fn sign_then_verify_round_trips() {
+        let secret = DeviceSecret::from_seed(&seed_a());
+        let public = secret.public();
+        let msg = b"canonical entry body bytes";
+        let sig = secret.sign(msg);
+        assert!(public.verify(msg, &sig).is_ok());
+        // A different message under the same signature must fail.
+        assert!(public.verify(b"tampered body bytes", &sig).is_err());
+    }
+
+    #[test]
+    fn verify_rejects_the_wrong_key() {
+        let secret = DeviceSecret::from_seed(&seed_a());
+        let wrong = DeviceSecret::from_seed(&seed_b()).public();
+        let msg = b"body";
+        let sig = secret.sign(msg);
+        assert!(wrong.verify(msg, &sig).is_err(), "the wrong key must not verify a signature");
+    }
+
+    #[test]
+    fn from_bytes_rejects_encodings_that_are_not_curve_points() {
+        // ~half of all 32-byte strings do not decompress to a valid Edwards point; `from_bytes`
+        // must reject those so a `DevicePublic` is always a well-formed verifying key. (An all-zero
+        // encoding is NOT a good negative case — it's a valid small-order point `from_bytes`
+        // accepts; only `verify_strict` refuses small-order.) Scan deterministic encodings and
+        // assert at least one is refused, and that a genuine pubkey is accepted.
+        let refused = (2u8..32)
+            .filter(|&lsb| {
+                let mut candidate = [0u8; 32];
+                candidate[0] = lsb;
+                DevicePublic::from_bytes(&candidate).is_err()
+            })
+            .count();
+        assert!(refused > 0, "from_bytes must reject non-curve encodings");
+        let real = DeviceSecret::from_seed(&seed_a()).public().to_bytes();
+        assert!(DevicePublic::from_bytes(&real).is_ok(), "a genuine pubkey must parse");
+    }
+}

--- a/crates/rag-rat-core/src/oplog/entry.rs
+++ b/crates/rag-rat-core/src/oplog/entry.rs
@@ -1,0 +1,594 @@
+//! The signed, hash-chained op-log entry envelope (phase B op-log, §C4 layer-1).
+//!
+//! Wraps an opaque op ([`super::op`]) in a per-device, append-only signed log. Two domain-tagged
+//! canonical CBOR objects, both DEFINITE-length + minimal-header (the same discipline `super::op`
+//! and `super::cbor` enforce):
+//!
+//! ```text
+//! body_bytes   = cbor([ "rag-rat/entry/1", prev_hash, lamport, device_fingerprint, op_bytes ])
+//! signed_bytes = cbor([ "rag-rat/signed-entry/1", body_bytes (bstr), signature (64-byte bstr) ])
+//! ```
+//!
+//! - `prev_hash` is the previous entry's `entry_hash` (32-byte bstr), or CBOR `null` for the
+//!   genesis (first) entry — the hash-chain link.
+//! - `op_bytes` = `op::encode(op)`, carried as an opaque bstr. Layer-1 forwards op bytes verbatim:
+//!   an UNKNOWN op still signs, verifies, and chains (§5.4) — verification NEVER requires
+//!   `op::decode` to succeed.
+//! - `entry_hash = sha256(body_bytes)` — the chain link + content address (§5.6 watermark `(seq,
+//!   entry_hash)`).
+//!
+//! **The signature covers exactly `body_bytes`** — the canonical CBOR of
+//! `[domain, prev_hash, lamport, device_fingerprint, op_bytes]`, and nothing else. `signed_bytes`
+//! (the outer envelope) is NOT signed; it is the transport form bundling the signed body with its
+//! signature. This is the security boundary: a byte that is not inside `body_bytes` is not
+//! protected by the signature, and the canonical rule guarantees the SAME logical body has exactly
+//! one signed encoding.
+
+use anyhow::Context;
+use minicbor::Encoder;
+use minicbor::data::Type;
+use minicbor::decode::{Decoder, Error as CborError};
+use sha2::{Digest, Sha256};
+
+use super::cbor;
+use super::device::{DevicePublic, DeviceSecret};
+use super::op::{self, DeviceFingerprint, MemoryOp};
+
+/// Domain tag + version for the signed BODY (the bytes the signature covers). Bump the version to
+/// evolve the entry wire deliberately — an old binary then rejects the new domain rather than
+/// misreading it.
+const ENTRY_DOMAIN: &str = "rag-rat/entry/1";
+
+/// Domain tag + version for the outer transport envelope (body + signature).
+const SIGNED_DOMAIN: &str = "rag-rat/signed-entry/1";
+
+/// Writing CBOR into a `Vec` cannot fail (its `Write` impl is infallible), so every encode step
+/// `.expect`s this — mirrors `super::op`.
+const INFALLIBLE: &str = "encoding CBOR to a Vec is infallible";
+
+/// The decoded, structurally-validated contents of an entry BODY. The op is carried as opaque
+/// `op_bytes`, so an UNKNOWN op still verifies + chains; decode it with `op::decode` only when the
+/// projection actually needs it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct VerifiedEntry {
+    /// The previous entry's `entry_hash`, or `None` for the genesis entry.
+    pub(super) prev_hash: Option<[u8; 32]>,
+    pub(super) lamport: u64,
+    pub(super) device_fingerprint: DeviceFingerprint,
+    /// `op::encode(op)` — the frozen op wire, opaque at this layer.
+    pub(super) op_bytes: Vec<u8>,
+    /// `sha256(body_bytes)` — the chain link + content address.
+    pub(super) entry_hash: [u8; 32],
+}
+
+/// A signed op-log entry: its structured body, the signature over `body_bytes`, and both wire
+/// encodings. `signed_bytes` is the transport/storage form; `body_bytes` is exactly what the
+/// signature and `entry_hash` cover.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SignedEntry {
+    pub(super) entry: VerifiedEntry,
+    pub(super) signature: [u8; 64],
+    pub(super) body_bytes: Vec<u8>,
+    pub(super) signed_bytes: Vec<u8>,
+}
+
+/// The pieces of one entry body, grouped so the encoder takes a single named argument rather than a
+/// four-primitive train (two of which are 32-byte arrays that are easy to transpose).
+struct BodyParts<'a> {
+    prev_hash: Option<[u8; 32]>,
+    lamport: u64,
+    device_fingerprint: DeviceFingerprint,
+    op_bytes: &'a [u8],
+}
+
+/// Author a signed entry: encode + sign the body (`device_fingerprint = secret.public()`), and
+/// build the transport envelope. Pure and deterministic given `secret` (ed25519 signing is
+/// deterministic).
+pub(super) fn sign_entry(
+    secret: &DeviceSecret,
+    prev_hash: Option<[u8; 32]>,
+    lamport: u64,
+    op: &MemoryOp,
+) -> SignedEntry {
+    let device_fingerprint = secret.public().fingerprint();
+    let op_bytes = op::encode(op);
+    let body_bytes =
+        encode_body(&BodyParts { prev_hash, lamport, device_fingerprint, op_bytes: &op_bytes });
+    let entry_hash = sha256(&body_bytes);
+    let signature = secret.sign(&body_bytes);
+    let signed_bytes = encode_signed(&body_bytes, &signature);
+    SignedEntry {
+        entry: VerifiedEntry { prev_hash, lamport, device_fingerprint, op_bytes, entry_hash },
+        signature,
+        body_bytes,
+        signed_bytes,
+    }
+}
+
+/// Decode a signed entry envelope, STRUCTURE only — canonical (no trailing) outer + body, extract
+/// the fields. Does NOT verify the signature (that is [`verify_signed`]).
+pub(super) fn decode_signed(bytes: &[u8]) -> anyhow::Result<SignedEntry> {
+    decode_signed_cbor(bytes).map_err(|err| anyhow::anyhow!("signed entry decode failed: {err}"))
+}
+
+/// Decode + cryptographically verify a signed entry under `pubkey`: `verify_strict` over
+/// `body_bytes`, then assert `pubkey.fingerprint() == body.device_fingerprint` so the key is bound
+/// to the device the body names. Returns the [`VerifiedEntry`] (op left opaque). A tampered body /
+/// header / signature, a wrong key, or a fingerprint mismatch each → `Err`.
+pub(super) fn verify_signed(bytes: &[u8], pubkey: &DevicePublic) -> anyhow::Result<VerifiedEntry> {
+    let signed = decode_signed(bytes)?;
+    pubkey.verify(&signed.body_bytes, &signed.signature)?;
+    // Bind key ↔ device: the signature proves SOME holder of `pubkey` signed the body; this proves
+    // `pubkey` IS the device the body claims. Without it, a valid signature under an unrelated key
+    // could be paired with any device_fingerprint.
+    if pubkey.fingerprint() != signed.entry.device_fingerprint {
+        anyhow::bail!("device fingerprint does not match the verifying key");
+    }
+    Ok(signed.entry)
+}
+
+/// Verify a SINGLE device's append-only chain under `pubkey`: genesis `prev_hash == None`, each
+/// subsequent `prev_hash == previous.entry_hash`, STRICTLY increasing `lamport`, and every
+/// signature valid (re-checked from `signed_bytes`, not trusted from the struct's cached fields).
+/// Cross-device merge is the fold (`super::project`), never here.
+pub(super) fn verify_chain(entries: &[SignedEntry], pubkey: &DevicePublic) -> anyhow::Result<()> {
+    let mut prev: Option<VerifiedEntry> = None;
+    for (idx, signed) in entries.iter().enumerate() {
+        // Trust only the signed bytes: re-verify the signature + fingerprint from the wire, so a
+        // hand-forged `SignedEntry` whose cached `entry` disagrees with `signed_bytes` can't pass.
+        let verified = verify_signed(&signed.signed_bytes, pubkey)
+            .with_context(|| format!("entry {idx} failed signature verification"))?;
+        match &prev {
+            None =>
+                if verified.prev_hash.is_some() {
+                    anyhow::bail!("genesis entry {idx} must have prev_hash == None");
+                },
+            Some(previous) => {
+                if verified.prev_hash != Some(previous.entry_hash) {
+                    anyhow::bail!("entry {idx} prev_hash does not link to the previous entry_hash");
+                }
+                if verified.lamport <= previous.lamport {
+                    anyhow::bail!(
+                        "entry {idx} lamport {} is not strictly greater than {}",
+                        verified.lamport,
+                        previous.lamport
+                    );
+                }
+            },
+        }
+        prev = Some(verified);
+    }
+    Ok(())
+}
+
+/// Encode the signed body: `[domain, prev_hash | null, lamport, device_fingerprint, op_bytes]`,
+/// definite lengths + minimal headers. THESE are the bytes the signature and `entry_hash` cover.
+fn encode_body(parts: &BodyParts<'_>) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(96);
+    {
+        let mut enc = Encoder::new(&mut buf);
+        enc.array(5).expect(INFALLIBLE);
+        enc.str(ENTRY_DOMAIN).expect(INFALLIBLE);
+        match parts.prev_hash {
+            // A 32-byte bstr for a linked entry, CBOR null for the genesis — an unambiguous,
+            // distinct "no predecessor" marker (not an all-zero hash).
+            Some(hash) => enc.bytes(&hash).expect(INFALLIBLE),
+            None => enc.null().expect(INFALLIBLE),
+        };
+        enc.u64(parts.lamport).expect(INFALLIBLE);
+        enc.bytes(&parts.device_fingerprint.to_bytes()).expect(INFALLIBLE);
+        enc.bytes(parts.op_bytes).expect(INFALLIBLE);
+    }
+    buf
+}
+
+/// Encode the outer transport envelope: `[domain, body_bytes (bstr), signature (bstr)]`. NOT signed
+/// — it bundles the already-signed body with its signature.
+fn encode_signed(body_bytes: &[u8], signature: &[u8; 64]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(body_bytes.len() + 96);
+    {
+        let mut enc = Encoder::new(&mut buf);
+        enc.array(3).expect(INFALLIBLE);
+        enc.str(SIGNED_DOMAIN).expect(INFALLIBLE);
+        enc.bytes(body_bytes).expect(INFALLIBLE);
+        enc.bytes(signature).expect(INFALLIBLE);
+    }
+    buf
+}
+
+fn decode_signed_cbor(bytes: &[u8]) -> Result<SignedEntry, CborError> {
+    // The whole wire must be exactly one canonical CBOR item, no trailing bytes (body_bytes and the
+    // signature are validated as opaque bstrs here; the body's own canonicity is checked below).
+    cbor::require_canonical_cbor(bytes)?;
+    let mut d = Decoder::new(bytes);
+    cbor::expect_array(&mut d, 3)?;
+    expect_domain(&mut d, SIGNED_DOMAIN)?;
+    let body_bytes = d.bytes()?.to_vec();
+    let signature = fixed_bytes::<64>(d.bytes()?, "signature")?;
+    let entry = decode_body(&body_bytes)?;
+    Ok(SignedEntry { entry, signature, body_bytes, signed_bytes: bytes.to_vec() })
+}
+
+fn decode_body(body_bytes: &[u8]) -> Result<VerifiedEntry, CborError> {
+    // The body must independently be exactly one canonical CBOR item (op_bytes stays an opaque bstr
+    // — layer-1 does NOT require the op to be a recognizable / canonical op here).
+    cbor::require_canonical_cbor(body_bytes)?;
+    let mut d = Decoder::new(body_bytes);
+    cbor::expect_array(&mut d, 5)?;
+    expect_domain(&mut d, ENTRY_DOMAIN)?;
+    let prev_hash = decode_prev_hash(&mut d)?;
+    let lamport = d.u64()?;
+    let device_fingerprint =
+        DeviceFingerprint::from_bytes(fixed_bytes::<32>(d.bytes()?, "device fingerprint")?);
+    let op_bytes = d.bytes()?.to_vec();
+    let entry_hash = sha256(body_bytes);
+    Ok(VerifiedEntry { prev_hash, lamport, device_fingerprint, op_bytes, entry_hash })
+}
+
+/// Read the leading domain string and assert it matches `want` — a wrong/absent tag is a foreign or
+/// version-bumped object an old binary must reject, never misread.
+fn expect_domain(d: &mut Decoder<'_>, want: &str) -> Result<(), CborError> {
+    let got = d.str()?;
+    if got == want {
+        Ok(())
+    } else {
+        Err(CborError::message(format!("unknown domain tag `{got}` (expected `{want}`)")))
+    }
+}
+
+/// Decode the `prev_hash` slot: CBOR null → genesis (`None`), else a 32-byte bstr link.
+fn decode_prev_hash(d: &mut Decoder<'_>) -> Result<Option<[u8; 32]>, CborError> {
+    if d.datatype()? == Type::Null {
+        d.null()?;
+        Ok(None)
+    } else {
+        Ok(Some(fixed_bytes::<32>(d.bytes()?, "prev_hash")?))
+    }
+}
+
+/// Convert an opaque byte slice to a fixed `[u8; N]`, erroring with the field name on a length
+/// mismatch (a wrong-length hash / fingerprint / signature is a structural error).
+fn fixed_bytes<const N: usize>(bytes: &[u8], field: &str) -> Result<[u8; N], CborError> {
+    <[u8; N]>::try_from(bytes)
+        .map_err(|_| CborError::message(format!("{field} must be {N} bytes, got {}", bytes.len())))
+}
+
+/// `sha256` into a fixed 32-byte array — the entry-hash / content-address primitive.
+fn sha256(bytes: &[u8]) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&Sha256::digest(bytes));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::oplog::op::{NodeContent, NodeId};
+
+    fn hex(bytes: &[u8]) -> String {
+        bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+    }
+
+    fn secret() -> DeviceSecret {
+        DeviceSecret::from_seed(&[7u8; 32])
+    }
+
+    /// A representative content op for round-trip / tamper tests.
+    fn node_create() -> MemoryOp {
+        MemoryOp::NodeCreate {
+            node_id: NodeId::from("mem_1"),
+            content: NodeContent {
+                kind: "Invariant".to_string(),
+                title: "title".to_string(),
+                body: "body".to_string(),
+                confidence: "high".to_string(),
+                source: "agent".to_string(),
+                tags: vec!["a".to_string(), "b".to_string()],
+                payload: None,
+            },
+        }
+    }
+
+    #[test]
+    fn golden_vectors_pin_the_entry_wire_format() {
+        // The entry wire is a frozen primitive: the signature, `entry_hash`, and the chain all
+        // build on these exact bytes. A canonical-rule change must break this test and
+        // force a deliberate `rag-rat/entry/1` / `rag-rat/signed-entry/1` domain bump.
+        // Fixture: genesis Snapshot, lamport 1, seed [7; 32] — fully deterministic (ed25519
+        // signing is deterministic).
+        let signed = sign_entry(&secret(), None, 1, &MemoryOp::Snapshot);
+        assert_eq!(
+            hex(&signed.body_bytes),
+            "856f7261672d7261742f656e7472792f31f6015820fe812c12f3ab4ce6ac5db69ac352f906cb1b11ef43fb33e252ef7ff5522638895818836c7261672d7261742f6f702f3168736e617073686f74f6",
+            "body_bytes golden",
+        );
+        assert_eq!(
+            hex(&signed.signed_bytes),
+            "83767261672d7261742f7369676e65642d656e7472792f31584f856f7261672d7261742f656e7472792f31f6015820fe812c12f3ab4ce6ac5db69ac352f906cb1b11ef43fb33e252ef7ff5522638895818836c7261672d7261742f6f702f3168736e617073686f74f658402d6c805bb70968fdfb32ecf19fdbbbccdc2130dad9b067b25c9782824c1dceb0ec5c03c7090bc786bad56ad3e05f8b0ad0129ffb699cf2bcc4d56b63c5b24800",
+            "signed_bytes golden",
+        );
+    }
+
+    #[test]
+    fn body_bytes_has_the_expected_canonical_structure() {
+        // Structure-level proof (independent of the opaque fingerprint / signature bytes) that the
+        // encoder emits the frozen shape the golden vector pins.
+        let signed = sign_entry(&secret(), None, 1, &MemoryOp::Snapshot);
+        let body = &signed.body_bytes;
+        assert_eq!(body[0], 0x85, "5-element array header");
+        assert_eq!(body[1], 0x6f, "text header, len 15");
+        assert_eq!(&body[2..17], b"rag-rat/entry/1");
+        assert_eq!(body[17], 0xf6, "genesis prev_hash is CBOR null");
+        assert_eq!(body[18], 0x01, "lamport 1, minimal uint");
+        assert_eq!(&body[19..21], &[0x58, 0x20], "device_fp bstr header, len 32");
+        assert_eq!(
+            &body[21..53],
+            &secret().public().fingerprint().to_bytes(),
+            "device_fp bytes == sha256(pubkey)",
+        );
+        assert_eq!(&body[53..55], &[0x58, 0x18], "op_bytes bstr header, len 24");
+        assert_eq!(&body[55..], &op::encode(&MemoryOp::Snapshot), "op_bytes == op::encode");
+        assert_eq!(body.len(), 79);
+    }
+
+    #[test]
+    fn signed_bytes_has_the_expected_canonical_structure() {
+        let signed = sign_entry(&secret(), None, 1, &MemoryOp::Snapshot);
+        let wire = &signed.signed_bytes;
+        assert_eq!(wire[0], 0x83, "3-element array header");
+        assert_eq!(wire[1], 0x76, "text header, len 22");
+        assert_eq!(&wire[2..24], b"rag-rat/signed-entry/1");
+        assert_eq!(&wire[24..26], &[0x58, 0x4f], "body bstr header, len 79");
+        assert_eq!(&wire[26..105], signed.body_bytes.as_slice());
+        assert_eq!(&wire[105..107], &[0x58, 0x40], "signature bstr header, len 64");
+        assert_eq!(&wire[107..171], &signed.signature);
+        assert_eq!(wire.len(), 171);
+    }
+
+    #[test]
+    fn entry_hash_is_sha256_of_the_body() {
+        let signed = sign_entry(&secret(), None, 1, &MemoryOp::Snapshot);
+        assert_eq!(signed.entry.entry_hash, sha256(&signed.body_bytes));
+    }
+
+    #[test]
+    fn genesis_round_trips_through_verify() {
+        let secret = secret();
+        let signed = sign_entry(&secret, None, 1, &node_create());
+        let verified = verify_signed(&signed.signed_bytes, &secret.public()).expect("verifies");
+        assert_eq!(verified, signed.entry);
+        assert_eq!(verified.prev_hash, None);
+        // decode_signed alone (no signature check) yields the same structure.
+        assert_eq!(decode_signed(&signed.signed_bytes).unwrap().entry, signed.entry);
+    }
+
+    #[test]
+    fn non_genesis_round_trips_through_verify() {
+        let secret = secret();
+        let genesis = sign_entry(&secret, None, 1, &MemoryOp::Snapshot);
+        let second = sign_entry(&secret, Some(genesis.entry.entry_hash), 2, &node_create());
+        let verified = verify_signed(&second.signed_bytes, &secret.public()).expect("verifies");
+        assert_eq!(verified.prev_hash, Some(genesis.entry.entry_hash));
+        assert_eq!(verified.lamport, 2);
+    }
+
+    #[test]
+    fn verify_rejects_the_wrong_key() {
+        let signed = sign_entry(&secret(), None, 1, &MemoryOp::Snapshot);
+        let wrong = DeviceSecret::from_seed(&[9u8; 32]).public();
+        assert!(
+            verify_signed(&signed.signed_bytes, &wrong).is_err(),
+            "a signature must not verify under an unrelated key",
+        );
+    }
+
+    #[test]
+    fn verify_rejects_a_fingerprint_mismatch() {
+        // Sign under key A but re-wrap the body with key B's fingerprint: the signature is over the
+        // ORIGINAL body (fingerprint A), so decoding + re-signing under B is needed to forge — but
+        // the honest check is: a body claiming a fingerprint that isn't the verifying key's is
+        // rejected. Build a body whose device_fingerprint is B's while signing with A.
+        let secret_a = secret();
+        let public_b = DeviceSecret::from_seed(&[9u8; 32]).public();
+        let op_bytes = op::encode(&MemoryOp::Snapshot);
+        let forged_body = encode_body(&BodyParts {
+            prev_hash: None,
+            lamport: 1,
+            device_fingerprint: public_b.fingerprint(),
+            op_bytes: &op_bytes,
+        });
+        let signature = secret_a.sign(&forged_body);
+        let forged = encode_signed(&forged_body, &signature);
+        // Verifying under A fails the SIGNATURE-fingerprint bind (A's fingerprint != claimed B).
+        assert!(verify_signed(&forged, &secret_a.public()).is_err());
+        // Verifying under B fails the SIGNATURE (A signed it, not B).
+        assert!(verify_signed(&forged, &public_b).is_err());
+    }
+
+    /// Flip one byte at `index` of an otherwise-valid signed entry and assert verification fails.
+    fn assert_tamper_rejected(index: usize, label: &str) {
+        let secret = secret();
+        let signed = sign_entry(&secret, Some([0x11; 32]), 5, &node_create());
+        let mut wire = signed.signed_bytes.clone();
+        wire[index] ^= 0x01;
+        assert!(
+            verify_signed(&wire, &secret.public()).is_err(),
+            "tampering {label} (byte {index}) must be rejected",
+        );
+    }
+
+    #[test]
+    fn tampering_any_signed_field_is_rejected() {
+        // Locate each field inside the fixture's wire and flip a byte within it. Layout (a
+        // non-genesis node_create entry): outer [0x83, 0x76, 22-byte domain, 0x58 0x4f, body(79+),
+        // 0x58 0x40, sig(64)]; body [0x85, 0x6f, 15-byte domain, 0x58 0x20 prev_hash(32), lamport,
+        // 0x58 0x20 device_fp(32), 0x58 .. op_bytes(..)].
+        let secret = secret();
+        let signed = sign_entry(&secret, Some([0x11; 32]), 5, &node_create());
+        let wire = &signed.signed_bytes;
+        // Body starts after outer header [0x83, 0x76, 22 domain bytes, 0x58, len] = 2 + 22 + 2 =
+        // 26.
+        let body_start = 26;
+        // Within the body: [0]=array, [1..17)=domain(0x6f+15), [17]=0x58,[18]=0x20 prev_hash
+        // header, prev_hash = [19..51), lamport at 51 (5 → 0x05), device_fp header [52,53],
+        // fp [54..86), op header at 86, op_bytes after.
+        let prev_hash_byte = body_start + 19; // inside the 32-byte prev_hash
+        let lamport_byte = body_start + 51; // the lamport uint
+        let device_fp_byte = body_start + 54; // inside the 32-byte device_fp
+        let op_byte = body_start + 88; // inside op_bytes
+        let signature_byte = wire.len() - 1; // last signature byte
+        for (index, label) in [
+            (prev_hash_byte, "prev_hash"),
+            (lamport_byte, "lamport"),
+            (device_fp_byte, "device_fingerprint"),
+            (op_byte, "op_bytes"),
+            (signature_byte, "signature"),
+        ] {
+            assert_tamper_rejected(index, label);
+        }
+    }
+
+    #[test]
+    fn trailing_bytes_are_rejected() {
+        let signed = sign_entry(&secret(), None, 1, &MemoryOp::Snapshot);
+        let mut wire = signed.signed_bytes.clone();
+        wire.push(0x00);
+        assert!(decode_signed(&wire).is_err(), "trailing bytes after the wire are rejected");
+    }
+
+    #[test]
+    fn non_canonical_lamport_header_is_rejected() {
+        // A lamport encoded with a non-minimal 8-byte header is non-canonical: the body must have
+        // exactly one accepted encoding, so `decode_body` rejects it.
+        let secret = secret();
+        let op_bytes = op::encode(&MemoryOp::Snapshot);
+        let good = encode_body(&BodyParts {
+            prev_hash: None,
+            lamport: 1,
+            device_fingerprint: secret.public().fingerprint(),
+            op_bytes: &op_bytes,
+        });
+        // good[18] is the minimal lamport uint (0x01). Splice a non-minimal 8-byte header for 1.
+        assert_eq!(good[18], 0x01);
+        let mut overlong = good[..18].to_vec();
+        overlong.extend_from_slice(&[0x1b, 0, 0, 0, 0, 0, 0, 0, 1]); // uint 1, non-minimal 8-byte
+        overlong.extend_from_slice(&good[19..]);
+        let signature = secret.sign(&overlong);
+        let wire = encode_signed(&overlong, &signature);
+        assert!(verify_signed(&wire, &secret.public()).is_err(), "non-canonical lamport rejected");
+    }
+
+    #[test]
+    fn malformed_and_wrong_domain_bytes_are_rejected() {
+        assert!(decode_signed(&[0x00]).is_err(), "not even a CBOR array");
+        assert!(decode_signed(&[]).is_err(), "empty input");
+        // A wrong outer domain tag.
+        let mut buf = Vec::new();
+        {
+            let mut enc = Encoder::new(&mut buf);
+            enc.array(3).unwrap();
+            enc.str("rag-rat/signed-entry/2").unwrap();
+            enc.bytes(&[0x80]).unwrap();
+            enc.bytes(&[0u8; 64]).unwrap();
+        }
+        assert!(decode_signed(&buf).is_err(), "a bumped outer domain must not decode");
+    }
+
+    #[test]
+    fn an_unknown_op_still_signs_verifies_and_chains() {
+        // Layer-1 forwards op bytes opaque: a future op KIND this binary can't decode must still
+        // sign, verify, and chain. Craft an unknown-but-canonical op envelope directly as op_bytes.
+        let secret = secret();
+        let mut unknown_op = Vec::new();
+        {
+            let mut enc = Encoder::new(&mut unknown_op);
+            enc.array(3).unwrap();
+            enc.str("rag-rat/op/1").unwrap();
+            enc.str("future_op").unwrap();
+            enc.u64(42).unwrap();
+        }
+        // Sanity: op::decode keeps it opaque (Unknown), never errors.
+        assert!(op::decode(&unknown_op).is_ok());
+        let body = encode_body(&BodyParts {
+            prev_hash: None,
+            lamport: 1,
+            device_fingerprint: secret.public().fingerprint(),
+            op_bytes: &unknown_op,
+        });
+        let signature = secret.sign(&body);
+        let wire = encode_signed(&body, &signature);
+        let verified = verify_signed(&wire, &secret.public()).expect("unknown op still verifies");
+        assert_eq!(verified.op_bytes, unknown_op, "op_bytes forwarded verbatim");
+        // And it chains as a single-entry genesis.
+        let genesis =
+            SignedEntry { entry: verified, signature, body_bytes: body, signed_bytes: wire };
+        verify_chain(&[genesis], &secret.public()).expect("unknown op chains");
+    }
+
+    /// A good three-entry chain from one device: genesis + two links, strictly increasing lamport.
+    fn good_chain(secret: &DeviceSecret) -> Vec<SignedEntry> {
+        let e0 = sign_entry(secret, None, 1, &MemoryOp::Snapshot);
+        let e1 = sign_entry(secret, Some(e0.entry.entry_hash), 2, &node_create());
+        let e2 = sign_entry(secret, Some(e1.entry.entry_hash), 5, &MemoryOp::Snapshot);
+        vec![e0, e1, e2]
+    }
+
+    #[test]
+    fn a_good_three_entry_chain_verifies() {
+        let secret = secret();
+        verify_chain(&good_chain(&secret), &secret.public()).expect("a well-formed chain verifies");
+    }
+
+    #[test]
+    fn a_chain_under_the_wrong_key_fails() {
+        let secret = secret();
+        let chain = good_chain(&secret);
+        let wrong = DeviceSecret::from_seed(&[9u8; 32]).public();
+        assert!(verify_chain(&chain, &wrong).is_err());
+    }
+
+    #[test]
+    fn a_broken_prev_hash_link_fails() {
+        let secret = secret();
+        let mut chain = good_chain(&secret);
+        // Re-author entry 2 pointing at the WRONG predecessor hash (still a valid signature).
+        chain[2] = sign_entry(&secret, Some([0xaa; 32]), 5, &MemoryOp::Snapshot);
+        assert!(verify_chain(&chain, &secret.public()).is_err(), "a broken link must fail");
+    }
+
+    #[test]
+    fn a_non_monotonic_lamport_fails() {
+        let secret = secret();
+        let e0 = sign_entry(&secret, None, 5, &MemoryOp::Snapshot);
+        // entry 1 links correctly but does NOT advance the lamport (5 is not > 5).
+        let e1 = sign_entry(&secret, Some(e0.entry.entry_hash), 5, &node_create());
+        assert!(
+            verify_chain(&[e0, e1], &secret.public()).is_err(),
+            "lamport must strictly increase",
+        );
+    }
+
+    #[test]
+    fn a_non_none_genesis_prev_hash_fails() {
+        let secret = secret();
+        // A genesis entry that claims a predecessor is not a valid chain head.
+        let genesis = sign_entry(&secret, Some([0x22; 32]), 1, &MemoryOp::Snapshot);
+        assert!(
+            verify_chain(&[genesis], &secret.public()).is_err(),
+            "genesis prev_hash must be None",
+        );
+    }
+
+    #[test]
+    fn a_single_bad_signature_fails_the_chain() {
+        let secret = secret();
+        let mut chain = good_chain(&secret);
+        // Corrupt one byte of the middle entry's wire signature.
+        let last = chain[1].signed_bytes.len() - 1;
+        chain[1].signed_bytes[last] ^= 0x01;
+        assert!(
+            verify_chain(&chain, &secret.public()).is_err(),
+            "a single bad signature fails the whole chain",
+        );
+    }
+}

--- a/crates/rag-rat-core/src/oplog/mod.rs
+++ b/crates/rag-rat-core/src/oplog/mod.rs
@@ -1,16 +1,30 @@
-//! Memory op-log: the op model + a deterministic projection fold (phase B, §5.4).
+//! Memory op-log: the op model, a deterministic projection fold, and the signed hash-chained entry
+//! envelope (phase B, §5.4 / §C4 layer-1).
 //!
-//! A pure, in-memory, crypto/network-free primitive frozen in isolation — the op-log's ordering
-//! semantics without any of its transport. It has two parts:
+//! A pure, in-memory primitive frozen in isolation — the op-log's ordering + integrity semantics
+//! without any transport or storage. Parts:
 //! - [`op`]: the frozen [`op::MemoryOp`] set, its canonical CBOR wire form
 //!   ([`op::encode`]/[`op::decode`]), and the known/unknown split ([`op::DecodedOp`]) that keeps a
 //!   forward-version op opaque-but-retained.
-//! - [`project`]: the LWW [`project::project`] fold from a Lamport/device-ordered `[Entry]` to a
-//!   converged [`project::ProjectedState`].
+//! - [`project`]: the LWW [`project::project`] fold from a Lamport/device-ordered `[op::Entry]` to
+//!   a converged [`project::ProjectedState`].
+//! - [`device`]: the ed25519 device identity — [`device::DeviceSecret`] signs,
+//!   [`device::DevicePublic`] verifies (`verify_strict`) and derives the op model's opaque
+//!   `DeviceFingerprint` = `sha256(pubkey)`.
+//! - [`entry`]: the signed, hash-chained entry envelope over an OPAQUE op — sign / verify /
+//!   per-device chain-verify. The signature covers the canonical body `[domain, prev_hash, lamport,
+//!   device_fingerprint, op_bytes]`; `entry_hash = sha256(body)` links the chain, so an UNKNOWN op
+//!   still verifies + chains.
+//! - [`cbor`]: the shared canonical-CBOR discipline (definite lengths, minimal headers, sorted map
+//!   keys, no trailing) both wire layers enforce.
 //!
-//! Nothing here is wired into the live write path yet (a later increment materializes the fold into
-//! the SQL tables) — this mirrors the `content_hash` freeze: pin the semantic primitive first, in
-//! isolation-testable form. See `issue-489-plan.md`.
+//! Nothing here is wired into the live write path yet (later increments add SQLite storage, the
+//! append-on-mutation seam, roster/epochs, and transport) — this mirrors the `content_hash` freeze:
+//! pin the semantic primitive first, in isolation-testable form. See `issue-489-plan.md` /
+//! `issue-497-plan.md`.
 
+mod cbor;
+mod device;
+mod entry;
 mod op;
 mod project;

--- a/crates/rag-rat-core/src/oplog/op.rs
+++ b/crates/rag-rat-core/src/oplog/op.rs
@@ -31,6 +31,7 @@ use minicbor::Encoder;
 use minicbor::data::Type;
 use minicbor::decode::{Decoder, Error as CborError};
 
+use super::cbor;
 use crate::query::memory::{self, EdgeRelation};
 
 /// Domain tag + version, the envelope's first element. Bump the version to evolve the wire format
@@ -91,6 +92,11 @@ pub(crate) struct DeviceFingerprint([u8; 32]);
 impl DeviceFingerprint {
     pub(crate) fn from_bytes(bytes: [u8; 32]) -> Self {
         Self(bytes)
+    }
+
+    /// The raw 32 bytes — the signed entry body encodes the fingerprint verbatim (`super::entry`).
+    pub(crate) fn to_bytes(self) -> [u8; 32] {
+        self.0
     }
 }
 
@@ -363,7 +369,7 @@ pub(crate) fn decode(bytes: &[u8]) -> anyhow::Result<DecodedOp> {
 
 fn decode_envelope(bytes: &[u8]) -> Result<DecodedOp, CborError> {
     let mut d = Decoder::new(bytes);
-    expect_array(&mut d, 3)?;
+    cbor::expect_array(&mut d, 3)?;
     let domain = d.str()?;
     if domain != DOMAIN {
         // A wrong/absent domain tag is a foreign or corrupt object, NOT a forward-compat op — a
@@ -418,159 +424,21 @@ fn decode_envelope(bytes: &[u8]) -> Result<DecodedOp, CborError> {
             // future binary that learns the kind could see two wire forms of one
             // logical op (and its `encode == bytes` check would then reject an entry an
             // older peer accepted + forwarded). Validate the raw bytes.
-            require_canonical_cbor(bytes)?;
+            cbor::require_canonical_cbor(bytes)?;
             Ok(DecodedOp::Unknown { tag: kind, raw: bytes.to_vec() })
         },
     }
 }
 
-/// Validate that `bytes` is EXACTLY one canonical CBOR item (RFC 8949 §4.2 core-deterministic) with
-/// no trailing bytes: MINIMAL-length argument headers, DEFINITE lengths only, sorted + unique map
-/// keys, and no floats (this wire format is integer-only, §5.5). This is the encoding-level
-/// canonicity a retained [`DecodedOp::Unknown`] needs; a known op gets the same guarantee (plus
-/// value-level rules like sorted tags) from `encode(decode) == bytes`.
-fn require_canonical_cbor(bytes: &[u8]) -> Result<(), CborError> {
-    let mut pos = 0;
-    check_canonical_item(bytes, &mut pos, 0)?;
-    if pos != bytes.len() {
-        return Err(CborError::message("trailing bytes after canonical CBOR item"));
-    }
-    Ok(())
-}
-
-/// Max CBOR nesting depth. Real ops nest shallowly (envelope → payload array → content array → tags
-/// array ≈ depth 4); a deeper structure is malformed/hostile, and unbounded recursion in the
-/// validator would overflow the stack — so cap it well above any real op and reject beyond.
-const MAX_CBOR_DEPTH: usize = 32;
-
-/// Validate one canonical CBOR item at `*pos`, advancing past it; recurses into arrays/maps/tags
-/// with a bounded `depth` (a pathologically nested input errors instead of overflowing the stack).
-fn check_canonical_item(bytes: &[u8], pos: &mut usize, depth: usize) -> Result<(), CborError> {
-    if depth > MAX_CBOR_DEPTH {
-        return Err(CborError::message("CBOR nesting too deep"));
-    }
-    let (major, arg) = read_canonical_header(bytes, pos)?;
-    match major {
-        0 | 1 => Ok(()), // uint / negative int — the header IS the value
-        2 => {
-            // byte string: `arg` opaque content bytes (no UTF-8 requirement).
-            advance_string(bytes, pos, arg)
-        },
-        3 => {
-            // text string: `arg` bytes that MUST be valid UTF-8. A future decoder reads this field
-            // with `d.str()`, which rejects invalid UTF-8 — so a non-UTF-8 text string is not a
-            // re-foldable canonical op even though its length header is well-formed.
-            let start = *pos;
-            advance_string(bytes, pos, arg)?;
-            str::from_utf8(&bytes[start..*pos])
-                .map_err(|_| CborError::message("invalid UTF-8 in CBOR text string"))?;
-            Ok(())
-        },
-        4 => {
-            for _ in 0..arg {
-                check_canonical_item(bytes, pos, depth + 1)?;
-            }
-            Ok(())
-        },
-        5 => {
-            // Map: keys must be strictly ascending by their encoded bytes (sorted + no duplicates).
-            let mut prev_key: Option<&[u8]> = None;
-            for _ in 0..arg {
-                let key_start = *pos;
-                check_canonical_item(bytes, pos, depth + 1)?;
-                let key = &bytes[key_start..*pos];
-                if prev_key.is_some_and(|prev| key <= prev) {
-                    return Err(CborError::message("map keys not sorted or duplicated"));
-                }
-                prev_key = Some(key);
-                check_canonical_item(bytes, pos, depth + 1)?;
-            }
-            Ok(())
-        },
-        6 => check_canonical_item(bytes, pos, depth + 1), // tag: one following item
-        7 => Ok(()),                                      /* simple value (null/bool/…); floats */
-        // already rejected by the header
-        // reader
-        _ => Err(CborError::message("invalid CBOR major type")),
-    }
-}
-
-/// Read one CBOR item header at `*pos`, returning `(major, argument)` and advancing past it.
-/// Rejects non-minimal argument encodings, indefinite/reserved lengths, and floats.
-fn read_canonical_header(bytes: &[u8], pos: &mut usize) -> Result<(u8, u64), CborError> {
-    let first = read_u8(bytes, pos)?;
-    let major = first >> 5;
-    let arg = match first & 0x1f {
-        info @ 0..=23 => u64::from(info),
-        24 => {
-            let v = u64::from(read_u8(bytes, pos)?);
-            require(v >= 24, "non-minimal 1-byte CBOR argument")?;
-            v
-        },
-        25 => {
-            require(major != 7, "float is non-canonical (integer-only wire format)")?;
-            let v = read_be(bytes, pos, 2)?;
-            require(v > u64::from(u8::MAX), "non-minimal 2-byte CBOR argument")?;
-            v
-        },
-        26 => {
-            require(major != 7, "float is non-canonical (integer-only wire format)")?;
-            let v = read_be(bytes, pos, 4)?;
-            require(v > u64::from(u16::MAX), "non-minimal 4-byte CBOR argument")?;
-            v
-        },
-        27 => {
-            require(major != 7, "float is non-canonical (integer-only wire format)")?;
-            let v = read_be(bytes, pos, 8)?;
-            require(v > u64::from(u32::MAX), "non-minimal 8-byte CBOR argument")?;
-            v
-        },
-        _ => return Err(CborError::message("reserved or indefinite CBOR length")), // 28..=31
-    };
-    Ok((major, arg))
-}
-
-/// Advance `*pos` past `arg` string content bytes, bounds-checking against `bytes`.
-fn advance_string(bytes: &[u8], pos: &mut usize, arg: u64) -> Result<(), CborError> {
-    let len = usize::try_from(arg).map_err(|_| CborError::message("CBOR length overflow"))?;
-    let end = pos
-        .checked_add(len)
-        .filter(|end| *end <= bytes.len())
-        .ok_or_else(|| CborError::message("CBOR string runs past end"))?;
-    *pos = end;
-    Ok(())
-}
-
-fn read_u8(bytes: &[u8], pos: &mut usize) -> Result<u8, CborError> {
-    let byte = *bytes.get(*pos).ok_or_else(|| CborError::message("unexpected end of CBOR"))?;
-    *pos += 1;
-    Ok(byte)
-}
-
-/// Read `n` (≤ 8) big-endian bytes into a `u64`.
-fn read_be(bytes: &[u8], pos: &mut usize, n: usize) -> Result<u64, CborError> {
-    let end = pos
-        .checked_add(n)
-        .filter(|end| *end <= bytes.len())
-        .ok_or_else(|| CborError::message("unexpected end of CBOR"))?;
-    let value = bytes[*pos..end].iter().fold(0u64, |acc, &byte| (acc << 8) | u64::from(byte));
-    *pos = end;
-    Ok(value)
-}
-
-fn require(condition: bool, message: &'static str) -> Result<(), CborError> {
-    if condition { Ok(()) } else { Err(CborError::message(message)) }
-}
-
 fn decode_node_content(d: &mut Decoder<'_>) -> Result<(NodeId, NodeContent), CborError> {
-    expect_array(d, 2)?;
+    cbor::expect_array(d, 2)?;
     let node_id = NodeId::from(d.str()?);
     let content = decode_content(d)?;
     Ok((node_id, content))
 }
 
 fn decode_content(d: &mut Decoder<'_>) -> Result<NodeContent, CborError> {
-    expect_array(d, 7)?;
+    cbor::expect_array(d, 7)?;
     let kind = d.str()?.to_string();
     let title = d.str()?.to_string();
     let body = d.str()?.to_string();
@@ -583,7 +451,7 @@ fn decode_content(d: &mut Decoder<'_>) -> Result<NodeContent, CborError> {
 
 /// Decode a node-status op, or `None` for a forward-compat status token this binary can't project.
 fn decode_node_status(d: &mut Decoder<'_>) -> Result<Option<MemoryOp>, CborError> {
-    expect_array(d, 2)?;
+    cbor::expect_array(d, 2)?;
     let node_id = NodeId::from(d.str()?);
     let token = d.str()?;
     Ok(NodeStatus::from_db_str(token).map(|status| MemoryOp::NodeStatus { node_id, status }))
@@ -591,7 +459,7 @@ fn decode_node_status(d: &mut Decoder<'_>) -> Result<Option<MemoryOp>, CborError
 
 /// Decode an edge spec, or `None` for a forward-compat relation token this binary can't project.
 fn decode_edge_spec(d: &mut Decoder<'_>) -> Result<Option<EdgeSpec>, CborError> {
-    expect_array(d, 6)?;
+    cbor::expect_array(d, 6)?;
     let source_node_id = NodeId::from(d.str()?);
     let token = d.str()?.to_string();
     // Read the WHOLE payload before judging the relation token, so a TRUNCATED `edge_add` is a hard
@@ -616,14 +484,14 @@ fn decode_edge_spec(d: &mut Decoder<'_>) -> Result<Option<EdgeSpec>, CborError> 
 }
 
 fn decode_rebind(d: &mut Decoder<'_>) -> Result<(EdgeKey, ResolvedAnchor), CborError> {
-    expect_array(d, 2)?;
+    cbor::expect_array(d, 2)?;
     let edge_key = EdgeKey::from(d.str()?);
     let resolved = decode_resolved(d)?;
     Ok((edge_key, resolved))
 }
 
 fn decode_resolved(d: &mut Decoder<'_>) -> Result<ResolvedAnchor, CborError> {
-    expect_array(d, 3)?;
+    cbor::expect_array(d, 3)?;
     let target_repo_id = d.str()?.to_string();
     let target_node_id = decode_opt_str(d)?;
     let anchor_status = d.str()?.to_string();
@@ -631,7 +499,7 @@ fn decode_resolved(d: &mut Decoder<'_>) -> Result<ResolvedAnchor, CborError> {
 }
 
 fn decode_str_array(d: &mut Decoder<'_>) -> Result<Vec<String>, CborError> {
-    let len = expect_definite_len(d)?;
+    let len = cbor::expect_definite_len(d)?;
     // Do NOT preallocate `len`: it is an attacker-controllable CBOR array header, so a bogus huge
     // count would OOM before the (short) body is even read. Grow as elements are actually decoded —
     // a truncated array errors at the first missing element, bounding work by real input size.
@@ -649,21 +517,6 @@ fn decode_opt_str(d: &mut Decoder<'_>) -> Result<Option<String>, CborError> {
     } else {
         Ok(Some(d.str()?.to_string()))
     }
-}
-
-/// Read a definite-length array header and assert its element count — canonical CBOR is
-/// definite-length only, and a wrong count is a structural (hard) error.
-fn expect_array(d: &mut Decoder<'_>, want: u64) -> Result<(), CborError> {
-    let got = expect_definite_len(d)?;
-    if got == want {
-        Ok(())
-    } else {
-        Err(CborError::message(format!("expected a {want}-element array, got {got}")))
-    }
-}
-
-fn expect_definite_len(d: &mut Decoder<'_>) -> Result<u64, CborError> {
-    d.array()?.ok_or_else(|| CborError::message("expected a definite-length array"))
 }
 
 #[cfg(test)]
@@ -1041,7 +894,7 @@ mod tests {
             enc.str("future_op").unwrap();
         });
         // Payload = MAX_CBOR_DEPTH+2 nested single-element arrays (0x81) around a uint-0 leaf.
-        buf.extend(std::iter::repeat_n(0x81u8, MAX_CBOR_DEPTH + 2));
+        buf.extend(std::iter::repeat_n(0x81u8, cbor::MAX_CBOR_DEPTH + 2));
         buf.push(0x00);
         assert!(decode(&buf).is_err(), "excessive CBOR nesting is rejected, not overflowed");
     }


### PR DESCRIPTION
Third phase-B op-log increment (#497), after the op model + fold (#489) and the frozen `content_hash`/`edge_key` primitives (#478/#464). Lands the **layer-1 opaque signed log**: a per-device, append-only, hash-chained signed entry + the ed25519 device identity that authors and verifies it — a pure, in-memory primitive. No SQLite storage / append seam, no roster/epochs yet.

## `oplog::device` — ed25519 identity
A device is an ed25519 keypair, **seed-deterministic** (`from_seed(&[u8;32])`) so golden vectors + chain tests are byte-reproducible. `DeviceFingerprint = sha256(pubkey)` wires the op model's opaque 32-byte fingerprint to a real key. Verification is **`verify_strict`** (rejects malleable / small-order signatures). The seed is `Zeroizing`d; `DeviceSecret` is not `Debug`/`Clone`.

## `oplog::entry` — the signed entry
Two domain-tagged canonical CBOR objects (definite lengths, minimal headers — the #489 discipline):
```
body_bytes   = cbor([ "rag-rat/entry/1", prev_hash, lamport, device_fingerprint, op_bytes ])
signed_bytes = cbor([ "rag-rat/signed-entry/1", body_bytes (bstr), signature (64-byte bstr) ])
```
- **The ed25519 signature covers EXACTLY `body_bytes`** — the canonical body, nothing else; `signed_bytes` is the unsigned transport wrapper. `entry_hash = sha256(body_bytes)` is the chain link + content address (§5.6 watermark `(seq, entry_hash)`).
- `prev_hash` is the previous `entry_hash` (32-byte bstr) or CBOR `null` for genesis (a distinct marker, not an all-zero hash).
- `op_bytes = op::encode(op)`, carried **opaque** — an unknown op still signs, verifies, and chains (§5.4); verification never requires `op::decode`.

**API:** `sign_entry`, `decode_signed` (structure-only, canonical + no-trailing), `verify_signed` (`verify_strict` over the body **and** assert `pubkey.fingerprint() == body.device_fingerprint` — a valid signature under an unrelated key can't be paired with any device), and `verify_chain` (a single device's chain: genesis `prev_hash == None`, prev-hash continuity, **strictly-increasing** Lamport, and every signature **re-verified from the wire bytes** — a hand-forged `SignedEntry` whose cached fields disagree with `signed_bytes` cannot pass). Cross-device merge is the fold (`project`), never here.

## `oplog::cbor`
The canonical-CBOR validator (`require_canonical_cbor` + walker) lifted from `op` into a shared module — behavior identical, op golden vectors unchanged. A non-canonical body is rejected even if validly signed, so one logical entry has exactly one signed encoding.

## Out of scope (later)
Roster / epochs / revocation (role-at-epoch); SQLite op-log storage + append-in-one-transaction; `stream_id` / watermarks / tombstone-horizon (S2); transport (D); `edge_key`→canonical-CBOR (S1 gap).

Golden vectors pin both wire objects. 25 new module tests (device 6, entry 19): golden + structure, sign→verify round-trip, tamper detection on every field, wrong-key + fingerprint-mismatch, non-canonical/trailing/malformed rejection, the full chain-integrity matrix, and an unknown-op sign/verify/chain. Adds `ed25519-dalek`, `zeroize`. `#[allow(dead_code)]` until the storage/append consumer lands.

Refs #497, #404.
