### PR TITLE
fix(schema): forward-migrate replay no longer stamps the dirty marker

### DIFF
--- a/crates/rag-rat-core/src/index/schema/baseline.rs
+++ b/crates/rag-rat-core/src/index/schema/baseline.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
+    drop_legacy_ai_prototype_tables(conn)?;
     conn.execute_batch(
         "
         CREATE TABLE IF NOT EXISTS index_meta(
@@ -229,9 +230,6 @@ pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
             language TEXT NOT NULL,
             message TEXT NOT NULL
         );
-
-        DROP TABLE IF EXISTS embeddings;
-        DROP TABLE IF EXISTS chunk_summaries;
 
         CREATE TABLE IF NOT EXISTS ai_models(
             model_id TEXT PRIMARY KEY,
@@ -608,6 +606,22 @@ pub(crate) fn apply_baseline(conn: &Connection) -> rusqlite::Result<()> {
     // baseline) cannot leave the postings table behind it. R5: V029's DDL is not edited; the
     // convergence lives here, not in the checksummed migration body.
     apply_token_bag_blob(conn)?;
+    Ok(())
+}
+
+/// Drop the pre-ladder AI prototype tables, CONDITIONALLY: `embeddings` (superseded by
+/// `chunk_embeddings`; nothing modern recreates it, so `IF EXISTS` alone makes it a no-op on a
+/// current DB) and the ORIGINAL single-summary `chunk_summaries` shape (chunk_id PK, no
+/// `prompt_version` — superseded by the (chunk_id, model_id, prompt_version)-keyed table the
+/// baseline batch creates). The `prompt_version` probe is load-bearing (#501 review): these DROPs
+/// used to run unconditionally inside the batch, so every baseline REPLAY (every forward migrate)
+/// wiped the current summaries on its way to recreating the table empty. A replay must be
+/// data-preserving — destructive conversions fire only when the legacy shape is actually present.
+fn drop_legacy_ai_prototype_tables(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch("DROP TABLE IF EXISTS embeddings;")?;
+    if !column_exists(conn, "chunk_summaries", "prompt_version")? {
+        conn.execute_batch("DROP TABLE IF EXISTS chunk_summaries;")?;
+    }
     Ok(())
 }
 

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -394,10 +394,13 @@ pub struct SchemaStatus {
 /// stamp is durable and globally visible the moment it lands, and the GLOBAL schema lock
 /// deliberately does not serialize against ordinary per-repo writers — a `SQLITE_BUSY` between
 /// the stamp and the clear stranded a marker on a healthy DB and every subsequent open refused
-/// until a manual `index --full` (observed live on V050→V051). The replay needs no marker: with
-/// 001 recorded the baseline ran to completion once, and every replayed statement is an
-/// individually atomic, idempotent no-op (`IF NOT EXISTS` DDL; the legacy conversions self-wrap
-/// in their own transaction), so a torn replay just resumes as `Older` on the next open.
+/// until a manual `index --full` (observed live on V050→V051). The replay needs no marker
+/// because it is CONVERGENT and DATA-PRESERVING, not because every statement is a no-op: creates
+/// are `IF NOT EXISTS`, the destructive legacy conversions are CONDITIONAL — they fire only when
+/// the legacy shape is present (`drop_legacy_ai_prototype_tables`, the `edge_strings` rename
+/// below, `ensure_edges_data`'s self-wrapped copy) — and a torn replay leaves the owed step rows
+/// unrecorded, so the DB still reads `Older` and the next open re-runs the baseline to
+/// completion before anything serves.
 fn provision_baseline(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(
         "

--- a/crates/rag-rat-core/src/index/schema/mod.rs
+++ b/crates/rag-rat-core/src/index/schema/mod.rs
@@ -380,11 +380,24 @@ pub struct SchemaStatus {
 }
 
 /// Provision the baseline (001) idempotently: the schema_version ledger, then `apply_baseline`
-/// (all `CREATE … IF NOT EXISTS`) wrapped in the dirty marker so a crash mid-baseline is
-/// detectable, then record 001. Shared by [`apply`] (fresh DB) and [`migrate_forward`] (existing DB
-/// behind by N). LOAD-BEARING for forward-only: a pre-interning (≤v19) DB lacks shared tables like
-/// `name_strings`/`edges_data` that later migrations INSERT into, so the baseline must run BEFORE
-/// any forward step replays — exactly what the old full `apply` did before the ladder.
+/// (all `CREATE … IF NOT EXISTS`), then record 001. Shared by [`apply`] (fresh DB) and
+/// [`migrate_forward`] (existing DB behind by N). LOAD-BEARING for forward-only: a pre-interning
+/// (≤v19) DB lacks shared tables like `name_strings`/`edges_data` that later migrations INSERT
+/// into, so the baseline must run BEFORE any forward step replays — exactly what the old full
+/// `apply` did before the ladder.
+///
+/// The `__dirty__` marker wraps ONLY a provision that OWES the baseline record — 001 not yet
+/// recorded (first-ever provision), or recorded with a stale checksum (a mismatch reads as Dirty,
+/// and `index --full` recovery must refresh the row like it refreshes every step's) — where it
+/// makes a crash mid-baseline detectable. A REPLAY over a current 001 (every open-time forward
+/// migrate) must not touch the marker (#498): the marker choreography runs in autocommit, so the
+/// stamp is durable and globally visible the moment it lands, and the GLOBAL schema lock
+/// deliberately does not serialize against ordinary per-repo writers — a `SQLITE_BUSY` between
+/// the stamp and the clear stranded a marker on a healthy DB and every subsequent open refused
+/// until a manual `index --full` (observed live on V050→V051). The replay needs no marker: with
+/// 001 recorded the baseline ran to completion once, and every replayed statement is an
+/// individually atomic, idempotent no-op (`IF NOT EXISTS` DDL; the legacy conversions self-wrap
+/// in their own transaction), so a torn replay just resumes as `Older` on the next open.
 fn provision_baseline(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(
         "
@@ -396,11 +409,20 @@ fn provision_baseline(conn: &Connection) -> rusqlite::Result<()> {
         );
         ",
     )?;
-    conn.execute(
-        "INSERT OR REPLACE INTO schema_version(id, applied_at_ms, checksum, description)
-         VALUES (?1, ?2, ?3, ?4)",
-        params![DIRTY_MIGRATION_ID, now_ms(), "", "partial migration in progress"],
-    )?;
+    let baseline_owed = conn
+        .query_row("SELECT checksum FROM schema_version WHERE id = ?1", [MIGRATION_001_ID], |row| {
+            row.get::<_, String>(0)
+        })
+        .optional()?
+        .as_deref()
+        != Some(MIGRATION_001_CHECKSUM);
+    if baseline_owed {
+        conn.execute(
+            "INSERT OR REPLACE INTO schema_version(id, applied_at_ms, checksum, description)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![DIRTY_MIGRATION_ID, now_ms(), "", "partial migration in progress"],
+        )?;
+    }
     // The string pool was `edge_strings` before the name-pool merge (#224, the V028 bump); it now
     // also holds symbol qualified-names, so the current schema names it `name_strings`. On a
     // pre-merge DB the POPULATED table is still `edge_strings` — rename it into place HERE, before
@@ -425,14 +447,25 @@ fn provision_baseline(conn: &Connection) -> rusqlite::Result<()> {
     }
     let result = apply_baseline(conn);
     if let Err(err) = result {
-        let _ = conn.execute("UPDATE schema_version SET description = ?2 WHERE id = ?1", params![
-            DIRTY_MIGRATION_ID,
-            format!("partial migration failed: {err}")
-        ]);
+        if baseline_owed {
+            let _ =
+                conn.execute("UPDATE schema_version SET description = ?2 WHERE id = ?1", params![
+                    DIRTY_MIGRATION_ID,
+                    format!("partial migration failed: {err}")
+                ]);
+        }
         return Err(err);
     }
-    conn.execute("DELETE FROM schema_version WHERE id = ?1", [DIRTY_MIGRATION_ID])?;
-    record_migration(conn, MIGRATION_001_ID, MIGRATION_001_CHECKSUM, MIGRATION_001_DESCRIPTION)
+    if baseline_owed {
+        conn.execute("DELETE FROM schema_version WHERE id = ?1", [DIRTY_MIGRATION_ID])?;
+        record_migration(
+            conn,
+            MIGRATION_001_ID,
+            MIGRATION_001_CHECKSUM,
+            MIGRATION_001_DESCRIPTION,
+        )?;
+    }
+    Ok(())
 }
 
 pub fn apply(conn: &Connection) -> rusqlite::Result<()> {
@@ -443,6 +476,12 @@ pub fn apply(conn: &Connection) -> rusqlite::Result<()> {
         (step.apply)(conn)?;
         record_migration(conn, step.id, step.checksum, step.description)?;
     }
+    // `index --full` is the sanctioned recovery the Dirty refusal names, and apply is its schema
+    // step: every migration just re-ran to completion, so a `__dirty__` marker that still
+    // survives (stranded by an older binary's failed mid-replay migrate) is provably stale —
+    // clear it, or the remedy would leave the DB refusing every open forever (#498). A crash
+    // before this point keeps the marker, so a genuinely torn apply still reads as Dirty.
+    conn.execute("DELETE FROM schema_version WHERE id = ?1", [DIRTY_MIGRATION_ID])?;
     Ok(())
 }
 
@@ -766,10 +805,22 @@ const ADDITIVE_MIGRATIONS: &[Migration] = &[
 /// re-runs an already-applied migration, so a data backfill like 005's resolution rewrite (an
 /// unconditional UPDATE) cannot clobber current values on a routine open. The caller guarantees a
 /// versioned ledger exists; a ledger-less legacy DB is refused upstream, not force-migrated.
+///
+/// LOSER DISCIPLINE (#498): the ledger is read FIRST, and a migrate that finds nothing owed
+/// returns without writing anything at all — no dirty stamp, no 001 re-record, no baseline
+/// replay. The loser of a migration race normally never reaches here (the callers re-check state
+/// under the GLOBAL schema lock), but a direct call must be equally write-free: every avoided
+/// autocommit write is one fewer `SQLITE_BUSY` hazard against ordinary per-repo writers, which
+/// the schema lock deliberately does not serialize against.
 pub fn migrate_forward(conn: &Connection) -> anyhow::Result<()> {
-    provision_baseline(conn)?;
     let applied: std::collections::HashSet<String> =
         applied_migrations(conn)?.into_iter().map(|migration| migration.id).collect();
+    if applied.contains(MIGRATION_001_ID)
+        && ADDITIVE_MIGRATIONS.iter().all(|step| applied.contains(step.id))
+    {
+        return Ok(());
+    }
+    provision_baseline(conn)?;
     for step in ADDITIVE_MIGRATIONS {
         if !applied.contains(step.id) {
             (step.apply)(conn)?;

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -676,6 +676,226 @@ fn compatible_open_refuses_dirty_and_newer_schema() {
     let _ = fs::remove_dir_all(root);
 }
 
+/// #498: the forward-migrate REPLAY path (an existing versioned ledger — every open-time
+/// auto-migrate) must never touch the `__dirty__` marker. The marker choreography ran in
+/// autocommit around a baseline replay that is a pure idempotent no-op on a versioned DB, so any
+/// failure between the stamp and the clear — the live incident was a `SQLITE_BUSY` from an
+/// ordinary writer, which the GLOBAL schema lock deliberately does not serialize against —
+/// stranded a durable marker on a healthy DB, and every subsequent open refused with "dirty or
+/// partial schema migration detected" until a manual `index --full`.
+#[test]
+fn forward_migrate_replay_never_touches_the_dirty_marker() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    truncate_schema_to(&conn, 50);
+
+    // Audit every write that targets the marker: the stamp (the INSERT half of `INSERT OR
+    // REPLACE` fires the insert trigger) and the clear (DELETE).
+    conn.execute_batch(
+        "
+        CREATE TABLE dirty_marker_audit(op TEXT NOT NULL);
+        CREATE TRIGGER audit_dirty_stamp AFTER INSERT ON schema_version
+        WHEN NEW.id = '__dirty__'
+        BEGIN INSERT INTO dirty_marker_audit(op) VALUES ('stamp'); END;
+        CREATE TRIGGER audit_dirty_clear BEFORE DELETE ON schema_version
+        WHEN OLD.id = '__dirty__'
+        BEGIN INSERT INTO dirty_marker_audit(op) VALUES ('clear'); END;
+        ",
+    )
+    .unwrap();
+
+    schema::migrate_forward(&conn).unwrap();
+
+    let marker_writes: i64 =
+        conn.query_row("SELECT COUNT(*) FROM dirty_marker_audit", [], |row| row.get(0)).unwrap();
+    assert_eq!(
+        marker_writes, 0,
+        "a forward migrate over an existing ledger must not stamp or clear the dirty marker — the \
+         stamp..clear window is what a concurrent writer's SQLITE_BUSY strands (#498)"
+    );
+    let status = schema::status(&conn).unwrap();
+    assert_eq!(status.state, schema::SchemaState::Compatible);
+    assert_eq!(status.current_version, schema::LATEST_SCHEMA_VERSION);
+}
+
+/// #498: a failure while REPLAYING a pending step must leave the schema `Older` — retryable on
+/// the next open — never `Dirty` (which refuses every open until a manual rebuild). The injected
+/// abort at the step's ledger record stands in for any mid-replay failure; the live one was a
+/// `SQLITE_BUSY` during the V050→V051 step.
+#[test]
+fn forward_migrate_step_failure_leaves_a_retryable_older_schema_not_dirty() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    truncate_schema_to(&conn, 50);
+
+    conn.execute_batch(
+        "
+        CREATE TRIGGER fail_051_record BEFORE INSERT ON schema_version
+        WHEN NEW.id = '051_clone_df_epoch'
+        BEGIN SELECT RAISE(ABORT, 'injected mid-replay failure'); END;
+        ",
+    )
+    .unwrap();
+    assert!(schema::migrate_forward(&conn).is_err(), "the injected failure fails the migrate");
+
+    let status = schema::status(&conn).unwrap();
+    assert_eq!(
+        status.state,
+        schema::SchemaState::Older,
+        "a mid-replay failure must leave the schema Older (retryable), not Dirty: {}",
+        status.message
+    );
+
+    // With the failure gone, the next migrate completes the pending step exactly once.
+    conn.execute_batch("DROP TRIGGER fail_051_record;").unwrap();
+    schema::migrate_forward(&conn).unwrap();
+    let status = schema::status(&conn).unwrap();
+    assert_eq!(status.state, schema::SchemaState::Compatible);
+    assert_eq!(status.current_version, schema::LATEST_SCHEMA_VERSION);
+    let recorded: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_version WHERE id = '051_clone_df_epoch'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(recorded, 1, "the retried step is recorded exactly once");
+}
+
+/// #498 loser discipline: a forward migrate that finds NOTHING owed (001 and every additive step
+/// already recorded — the loser of a migration race re-entering after the winner finished) must
+/// leave the ledger completely untouched: no dirty stamp, no 001 re-record, no writes at all.
+/// Every avoided write is one fewer `SQLITE_BUSY` hazard against concurrent ordinary writers.
+#[test]
+fn forward_migrate_when_nothing_is_owed_leaves_the_ledger_untouched() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+
+    conn.execute_batch(
+        "
+        CREATE TABLE ledger_write_audit(op TEXT NOT NULL, id TEXT NOT NULL);
+        CREATE TRIGGER audit_ledger_insert AFTER INSERT ON schema_version
+        BEGIN INSERT INTO ledger_write_audit(op, id) VALUES ('insert', NEW.id); END;
+        CREATE TRIGGER audit_ledger_update AFTER UPDATE ON schema_version
+        BEGIN INSERT INTO ledger_write_audit(op, id) VALUES ('update', NEW.id); END;
+        CREATE TRIGGER audit_ledger_delete AFTER DELETE ON schema_version
+        BEGIN INSERT INTO ledger_write_audit(op, id) VALUES ('delete', OLD.id); END;
+        ",
+    )
+    .unwrap();
+
+    schema::migrate_forward(&conn).unwrap();
+
+    let mut stmt = conn.prepare("SELECT op, id FROM ledger_write_audit").unwrap();
+    let writes: Vec<(String, String)> = stmt
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .unwrap()
+        .map(Result::unwrap)
+        .collect();
+    assert!(
+        writes.is_empty(),
+        "a forward migrate with nothing owed must not write the ledger, got: {writes:?}"
+    );
+    assert_eq!(schema::status(&conn).unwrap().state, schema::SchemaState::Compatible);
+}
+
+/// #498: `rag-rat index --full` ([`schema::apply`]) is the sanctioned recovery the Dirty refusal
+/// names, so a successful apply must CLEAR a stranded `__dirty__` marker: apply re-runs every
+/// idempotent step, so a marker that survives it is provably stale. Without the clear, the
+/// remedy would leave the DB refusing every open forever. (The marker can be stranded by an
+/// older binary's failed mid-replay migrate; new binaries no longer stamp it on replay.)
+#[test]
+fn apply_clears_a_stranded_dirty_marker() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    conn.execute(
+        "INSERT OR REPLACE INTO schema_version(id, applied_at_ms, checksum, description)
+         VALUES ('__dirty__', 1, '', 'partial migration in progress')",
+        [],
+    )
+    .unwrap();
+    assert_eq!(schema::status(&conn).unwrap().state, schema::SchemaState::Dirty);
+
+    schema::apply(&conn).unwrap();
+
+    let status = schema::status(&conn).unwrap();
+    assert_eq!(
+        status.state,
+        schema::SchemaState::Compatible,
+        "a full apply must clear a stranded dirty marker: {}",
+        status.message
+    );
+}
+
+/// #498 review: a Dirty state can also come from a CHECKSUM-MISMATCHED baseline row (not just a
+/// stranded marker), and `index --full` must recover that too — apply re-records every additive
+/// step's checksum unconditionally, and the baseline provision must treat a stale 001 checksum
+/// as "provision owed" so the 001 row is refreshed as well.
+#[test]
+fn apply_recovers_a_baseline_checksum_mismatch() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    conn.execute(
+        "UPDATE schema_version SET checksum = 'sha256:corrupted'
+         WHERE id = '001_sqlite_storage_baseline'",
+        [],
+    )
+    .unwrap();
+    assert_eq!(schema::status(&conn).unwrap().state, schema::SchemaState::Dirty);
+
+    schema::apply(&conn).unwrap();
+
+    let status = schema::status(&conn).unwrap();
+    assert_eq!(
+        status.state,
+        schema::SchemaState::Compatible,
+        "a full apply must refresh a checksum-mismatched baseline row: {}",
+        status.message
+    );
+}
+
+/// #498: the forward-migrate variant of the double-checked schema race
+/// ([`concurrent_create_or_migrate_applies_the_schema_exactly_once`] covers the fresh-CREATE
+/// side): two upgraded processes racing one pending step over a shared V(N-1) DB. Both opens must
+/// succeed — the winner migrates under the GLOBAL schema lock, the loser re-checks under it and
+/// no-ops — and the ledger must hold exactly one row per migration with no stranded dirty marker.
+/// Before #498 the loser's UNLOCKED status probe could catch the winner's transient `__dirty__`
+/// stamp and refuse the open outright instead of waiting on the lock.
+#[test]
+fn concurrent_forward_migrate_applies_the_pending_step_exactly_once() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+    let db_path = root.join("index.sqlite");
+
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        schema::apply(&conn).unwrap();
+        truncate_schema_to(&conn, 50);
+        // Make the pending step real work again, as on a live V050 DB.
+        conn.execute_batch("DROP TABLE IF EXISTS clone_df_epoch;").unwrap();
+    }
+
+    let a = db_path.clone();
+    let b = db_path.clone();
+    let t1 = std::thread::spawn(move || IndexDatabase::open(&a).map(|_| ()));
+    let t2 = std::thread::spawn(move || IndexDatabase::open(&b).map(|_| ()));
+    t1.join().unwrap().expect("one concurrent opener migrates forward");
+    t2.join().unwrap().expect("the other re-checks under the schema lock and no-ops");
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let status = schema::status(&conn).unwrap();
+    assert_eq!(status.state, schema::SchemaState::Compatible);
+    assert_eq!(status.current_version, schema::LATEST_SCHEMA_VERSION);
+    assert_eq!(
+        status.migrations.len(),
+        schema::LATEST_SCHEMA_VERSION as usize,
+        "exactly one schema_version row per migration and no stranded dirty marker"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
 #[test]
 fn discover_mode_indexes_new_files_and_removes_deleted_files() {
     let root = unique_temp_root();

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/schema_migrations.rs
@@ -827,6 +827,90 @@ fn apply_clears_a_stranded_dirty_marker() {
     );
 }
 
+/// #501 review: the baseline replay must be DATA-PRESERVING, not just convergent — the pre-ladder
+/// prototype conversion ran `DROP TABLE IF EXISTS chunk_summaries` unconditionally, so every
+/// forward migrate wiped the current summaries (re-derivable only at model cost) on its way to
+/// recreating the table empty. Destructive legacy conversions may fire only when the LEGACY shape
+/// is actually present.
+#[test]
+fn forward_migrate_replay_preserves_chunk_summaries() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    schema::apply(&conn).unwrap();
+    // Seed a bare summary row (FK off — the parent chunk chain is irrelevant to what this test
+    // pins: the replay must not touch the rows).
+    conn.execute_batch(
+        "PRAGMA foreign_keys = OFF;
+         INSERT INTO chunk_summaries(chunk_id, model_id, prompt_version, input_hash, text_hash,
+                                     summary, status)
+         VALUES (1, 'model', 'v1', 'ih', 'th', 'a summary worth keeping', 'Current');",
+    )
+    .unwrap();
+    truncate_schema_to(&conn, 50);
+
+    schema::migrate_forward(&conn).unwrap();
+
+    let kept: i64 =
+        conn.query_row("SELECT COUNT(*) FROM chunk_summaries", [], |row| row.get(0)).unwrap();
+    assert_eq!(kept, 1, "a baseline replay must not wipe current-shape chunk summaries");
+}
+
+/// #501 review companion: the legacy-prototype conversion still fires where it should — a
+/// pre-ladder DB whose `chunk_summaries` is the ORIGINAL single-summary shape (chunk_id PK, no
+/// `prompt_version`) gets it replaced with the current shape, and the prototype `embeddings`
+/// table is removed.
+#[test]
+fn baseline_replay_still_converts_the_legacy_prototype_ai_tables() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "
+        CREATE TABLE embeddings(chunk_id INTEGER PRIMARY KEY, vector BLOB);
+        CREATE TABLE chunk_summaries(
+            chunk_id INTEGER PRIMARY KEY,
+            model_id TEXT NOT NULL,
+            source_text_hash TEXT NOT NULL,
+            summary TEXT NOT NULL,
+            status TEXT NOT NULL,
+            created_at_ms INTEGER NOT NULL,
+            last_error TEXT
+        );
+        ",
+    )
+    .unwrap();
+
+    schema::apply(&conn).unwrap();
+
+    assert!(!conn_table_exists(&conn, "embeddings"), "the prototype embeddings table is dropped");
+    assert!(
+        conn_table_columns(&conn, "chunk_summaries").contains(&"prompt_version".to_string()),
+        "the legacy chunk_summaries shape is replaced with the current one"
+    );
+}
+
+/// #498: a failed FIRST-EVER provision (001 never recorded) keeps the crash-detectability
+/// contract — the DB reads Dirty and the marker row records the failure, so a torn fresh
+/// bootstrap refuses to serve until `index --full` re-runs it.
+#[test]
+fn a_failed_first_provision_reads_dirty_with_the_failure_recorded() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    // Poison the bootstrap: a pre-existing wrong-shape `files` table no-ops the baseline's
+    // `CREATE TABLE IF NOT EXISTS files` and then fails its index build (`no such column`).
+    conn.execute_batch("CREATE TABLE files(id INTEGER PRIMARY KEY);").unwrap();
+
+    assert!(schema::apply(&conn).is_err(), "the poisoned baseline fails the first provision");
+
+    let status = schema::status(&conn).unwrap();
+    assert_eq!(status.state, schema::SchemaState::Dirty);
+    let description: String = conn
+        .query_row("SELECT description FROM schema_version WHERE id = '__dirty__'", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert!(
+        description.contains("partial migration failed"),
+        "the marker records the failure: {description}"
+    );
+}
+
 /// #498 review: a Dirty state can also come from a CHECKSUM-MISMATCHED baseline row (not just a
 /// stranded marker), and `index --full` must recover that too — apply re-records every additive
 /// step's checksum unconditionally, and the baseline provision must treat a stale 001 checksum


### PR DESCRIPTION
Fixes #498.

## Problem

A forward migrate over an existing versioned ledger ran the `__dirty__` stamp → baseline replay → clear choreography in autocommit on every open-time auto-migrate. The stamp is durable and globally visible the moment it lands, and the global schema lock deliberately does not serialize against ordinary per-repo writers — so a `SQLITE_BUSY` (or any failure) between the stamp and the clear stranded the marker on a healthy DB, and every subsequent open refused with "dirty or partial schema migration detected" until a manual `index --full`. Observed live on a V050→V051 upgrade with two hot-upgraded MCP servers racing the open-time migrate.

Two adjacent defects in the same seam:
- while a winner was mid-provision, a concurrent opener's **unlocked** status probe could catch the transient stamp and refuse the open outright instead of waiting on the schema lock;
- `migrate_forward` with nothing owed still churned stamp + clear + a 001 re-record — three pointless autocommit writes, each a `SQLITE_BUSY` hazard.

## Fix

- `provision_baseline` stamps/clears the marker only when the baseline **record is owed**: 001 missing (first-ever provision), or recorded with a stale checksum (the `index --full` recovery for a checksum mismatch must refresh the 001 row like it refreshes every step's). The routine replay path is idempotent `IF NOT EXISTS` DDL that safely resumes as `Older` after any torn failure, so it needs no marker.
- `migrate_forward` reads the ledger first and returns write-free when nothing is owed (loser discipline).
- `schema::apply` clears a stale stranded marker after a successful full replay, so `index --full` remains the working recovery for DBs stranded by older binaries.

An enclosing transaction was deliberately **not** used: the ladder's contract is that appliers run in autocommit and the heavyweight ones (V031/V040/V041 table rebuilds, the legacy edges conversion reachable from `apply_baseline`) self-wrap in `BEGIN IMMEDIATE` with `PRAGMA foreign_keys` toggled outside — an outer transaction would nest-fail and silently no-op the FK toggles.

## Tests

- `forward_migrate_replay_never_touches_the_dirty_marker` — trigger-audited; red before the fix (`stamp`, `clear` captured).
- `forward_migrate_when_nothing_is_owed_leaves_the_ledger_untouched` — red before the fix (`insert __dirty__`, `delete __dirty__`, `insert 001…` captured).
- `forward_migrate_step_failure_leaves_a_retryable_older_schema_not_dirty` — injected mid-replay abort leaves `Older`, retry applies the step exactly once.
- `apply_clears_a_stranded_dirty_marker` / `apply_recovers_a_baseline_checksum_mismatch` — the `index --full` recovery contract for both Dirty causes.
- `concurrent_forward_migrate_applies_the_pending_step_exactly_once` — the forward-migrate variant of the existing fresh-CREATE race test: two threads through `IndexDatabase::open` on a V(N−1) ledger.