### PR TITLE
fix(index): carry retained committed rows across a HEAD move instead of re-deriving the repo

### DIFF
--- a/crates/rag-rat-core/src/index/discovery.rs
+++ b/crates/rag-rat-core/src/index/discovery.rs
@@ -9,6 +9,10 @@ pub struct DiscoveryStatus {
     pub indexed_files: usize,
     pub unindexed_files: usize,
     pub unindexed_source_files: usize,
+    /// Files a discover pass would CARRY onto the current HEAD instead of re-deriving (#502):
+    /// their retained rows are not in the active scope yet, so until that pass runs, queries at
+    /// the new HEAD miss them — pending work (with a cheap remedy), not an indexed state.
+    pub carryable_files: usize,
     pub changed_indexed_files: usize,
     pub removed_indexed_files: usize,
     pub unindexed_sample: Vec<String>,
@@ -21,20 +25,38 @@ pub(crate) struct DiscoveryPlan {
     pub(crate) deleted: BTreeSet<PathBuf>,
     pub(crate) unindexed: Vec<IndexFile>,
     pub(crate) changed: Vec<PathBuf>,
+    /// `files.id` of retained committed rows to ADOPT into the active commit scope instead of
+    /// re-deriving (#502): rows of a previous HEAD's scope (same repo + generation,
+    /// `worktree_id = ''`, a different `commit_sha`) whose (sha256, language, kind) match the
+    /// discovered file exactly. Re-stamping a row's `commit_sha` in place preserves its id and
+    /// every chunk/symbol/edge/embedding/memory-binding hanging off it, so a `git pull` or
+    /// branch checkout costs roughly its diff instead of a full re-derive. Discovery is a pure
+    /// read (the status command shares it), so the plan carries the ids and the indexing pass
+    /// applies the re-stamps inside its own transaction.
+    pub(crate) carried: Vec<i64>,
     pub(crate) discovered_files: usize,
     pub(crate) indexed_files: usize,
 }
 
+/// `changes` is the working tree's git status (dirty + untracked paths) — the caller computes it
+/// once and shares it with the scope assignment that follows the plan. The carry (#502) consults
+/// it because retained-row adoption writes the COMMITTED scope: a dirty or untracked path whose
+/// disk bytes happen to match an older commit must fall through to normal indexing (which stamps
+/// it into the worktree OVERLAY scope) — a carry would record uncommitted content as committed,
+/// and committed rows are shared with every linked worktree's base view.
 pub(crate) fn discovery_plan(
     conn: &rusqlite::Connection,
     config: &Config,
+    changes: &GitChangedPaths,
 ) -> anyhow::Result<DiscoveryPlan> {
     let discovered = collect_index_files(config)?;
     let mut indexed = indexed_file_map(conn)?;
+    let retained = retained_committed_file_map(conn)?;
     let mut current_paths = BTreeSet::new();
     let mut files = Vec::new();
     let mut unindexed = Vec::new();
     let mut changed = Vec::new();
+    let mut carried = Vec::new();
     let discovered_files = discovered.len();
     let hashed = discovered
         .par_iter()
@@ -49,6 +71,26 @@ pub(crate) fn discovery_plan(
         let relative = path_string(&file.relative_path);
         current_paths.insert(file.relative_path.clone());
         let Some(indexed) = indexed.remove(&relative) else {
+            // Absent from the ACTIVE scope, but a retained committed row (a previous HEAD's
+            // scope) holds this exact content under the same target: adopt it instead of
+            // re-deriving (#502). The match mirrors the drift checks below — sha for content,
+            // (language, kind) for target drift — so a carry can never smuggle a stale parse
+            // into the new scope; among several matching retained rows the most recently
+            // derived (highest id) wins. A DIRTY or UNTRACKED path is never carried even on a
+            // sha match: its disk bytes are working-tree content, not the new HEAD's committed
+            // content (a deleted-then-recreated file, or a revert to an old commit's bytes),
+            // so it falls through to normal indexing and lands in the overlay scope.
+            if !changes.changed.contains(&file.relative_path)
+                && let Some(rows) = retained.get(&relative)
+                && let Some(matching) = rows.iter().rev().find(|row| {
+                    row.sha256 == current_hash
+                        && row.language == file.language.as_str()
+                        && row.kind == file.kind.as_str()
+                })
+            {
+                carried.push(matching.file_id);
+                continue;
+            }
             unindexed.push(file.clone());
             files.push(file);
             continue;
@@ -73,6 +115,8 @@ pub(crate) fn discovery_plan(
 
     Ok(DiscoveryPlan {
         discovered_files,
+        // Carried paths count as indexed: no re-derive is owed for them, only the scope
+        // re-stamp the indexing pass applies.
         indexed_files: current_paths
             .len()
             .saturating_add(deleted.len())
@@ -81,6 +125,7 @@ pub(crate) fn discovery_plan(
         deleted,
         unindexed,
         changed,
+        carried,
     })
 }
 
@@ -108,6 +153,59 @@ pub(crate) fn indexed_file_map(
     for row in rows {
         let (path, indexed) = row?;
         files.insert(path, indexed);
+    }
+    Ok(files)
+}
+
+/// A retained committed row's carry identity: the row to re-stamp plus the (sha256, language,
+/// kind) triple a discovered file must match for the adoption to be sound (#502).
+struct RetainedFileRow {
+    file_id: i64,
+    sha256: String,
+    language: String,
+    kind: String,
+}
+
+/// Retained committed rows — this repo + live generation, `worktree_id = ''`, any commit OTHER
+/// than the active one — keyed by path: the carry source when a HEAD move re-keys the base scope
+/// (#502). Reads the scope dimensions from `temp.connection_context` like the `files` view does.
+/// ALL rows per path are kept (in id order): a path can retain rows for several old commits with
+/// DIFFERENT content — e.g. a branch round-trip leaves a stale feature row with a HIGHER id
+/// beside the old-main row a later pull actually matches — so the triple match must see every
+/// candidate, not a pre-collapsed "latest" one. Empty outside a git context (no committed scope
+/// exists, and no active commit to carry into).
+fn retained_committed_file_map(
+    conn: &rusqlite::Connection,
+) -> anyhow::Result<BTreeMap<String, Vec<RetainedFileRow>>> {
+    let active_commit: String = conn.query_row(
+        "SELECT value FROM temp.connection_context WHERE key = 'commit_sha'",
+        [],
+        |row| row.get(0),
+    )?;
+    let mut files: BTreeMap<String, Vec<RetainedFileRow>> = BTreeMap::new();
+    if active_commit.is_empty() {
+        return Ok(files);
+    }
+    let mut stmt = conn.prepare(
+        "SELECT path, id, sha256, language, kind FROM main.files
+         WHERE repo_id = (SELECT value FROM temp.connection_context WHERE key = 'repo_id')
+           AND generation = (SELECT value FROM temp.connection_context WHERE key = \
+         'files_generation')
+           AND worktree_id = '' AND kind != 'deleted'
+           AND commit_sha != '' AND commit_sha != ?1
+         ORDER BY id",
+    )?;
+    let rows = stmt.query_map([&active_commit], |row| {
+        Ok((row.get::<_, String>(0)?, RetainedFileRow {
+            file_id: row.get(1)?,
+            sha256: row.get(2)?,
+            language: row.get(3)?,
+            kind: row.get(4)?,
+        }))
+    })?;
+    for row in rows {
+        let (path, retained) = row?;
+        files.entry(path).or_default().push(retained);
     }
     Ok(files)
 }

--- a/crates/rag-rat-core/src/index/file_rows.rs
+++ b/crates/rag-rat-core/src/index/file_rows.rs
@@ -152,6 +152,51 @@ impl IndexDatabase {
         Ok(())
     }
 
+    /// Adopt retained committed rows into the ACTIVE commit scope by re-stamping
+    /// `files.commit_sha` in place (#502): the row id — and every chunk, symbol, edge,
+    /// embedding, fingerprint, FTS entry, and memory binding hanging off it — survives, so a
+    /// HEAD move (pull, branch checkout) costs roughly its diff instead of a full re-derive.
+    /// The overlay→commit re-stamp in [`Self::heal_stale_overlay_rows`] is the precedent.
+    ///
+    /// The candidates come from [`discovery_plan`](super::discovery::discovery_plan), which
+    /// selects only paths ABSENT from the active scope, and the caller's pass transaction
+    /// isolates selection from application — so the V043 UNIQUE
+    /// `(repo_id, path, commit_sha, worktree_id, generation)` cannot collide. The WHERE still
+    /// pins the row to this writer's repo + generation + base scope (belt to the plan's
+    /// selection), so a stale candidate updates nothing rather than the wrong row.
+    pub(super) fn carry_retained_files_into_active_scope(
+        &self,
+        carried: &[i64],
+    ) -> anyhow::Result<usize> {
+        if carried.is_empty() || self.active_commit_sha.is_empty() {
+            return Ok(0);
+        }
+        let conn = self.storage.connection();
+        let mut stmt = conn.prepare(
+            "UPDATE main.files SET commit_sha = ?2
+             WHERE id = ?1 AND repo_id = ?3 AND generation = ?4 AND worktree_id = ''
+               AND commit_sha != ?2",
+        )?;
+        let mut restamped = 0usize;
+        for file_id in carried {
+            restamped += stmt.execute(params![
+                file_id,
+                self.active_commit_sha,
+                self.active_repo_id,
+                self.active_generation,
+            ])?;
+        }
+        if restamped > 0 {
+            tracing::info!(
+                target: "rag_rat_core::maintenance",
+                carried = restamped,
+                commit = %self.active_commit_sha,
+                "carried retained committed rows into the active scope (HEAD move)"
+            );
+        }
+        Ok(restamped)
+    }
+
     pub(super) fn file_row(&self, path: &Path) -> anyhow::Result<FileRow> {
         self.storage
             .connection()

--- a/crates/rag-rat-core/src/index/incremental.rs
+++ b/crates/rag-rat-core/src/index/incremental.rs
@@ -1,5 +1,16 @@
 use super::*;
 
+/// What an incremental file pass did, split by what each count gates downstream: `indexed`
+/// (derived or deleted rows — real content change), `manifest_in_change_set` (a `Cargo.toml`
+/// moved — refresh the package map), and `carried` (#502 — retained rows re-stamped into the
+/// active scope; mutates the DB and re-keys the package scope, but is NOT a content change:
+/// chunks, embeddings, and FTS entries all survive the re-stamp untouched).
+struct IncrementalFilesOutcome {
+    indexed: usize,
+    manifest_in_change_set: bool,
+    carried: usize,
+}
+
 impl IndexDatabase {
     pub fn index_changed(config: &Config) -> anyhow::Result<Self> {
         Self::index_changed_with_progress(config, |_| {})
@@ -179,11 +190,12 @@ impl IndexDatabase {
                     config.llm.embedding.backend.model_id(),
                 )?;
             }
-            let (indexed, manifest_in_change_set) = match effective_mode {
+            let outcome = match effective_mode {
                 IndexMode::Changed => db.index_changed_files_with_progress(config, progress)?,
                 IndexMode::Discover => db.index_discovered_files_with_progress(config, progress)?,
                 IndexMode::Full => unreachable!("full mode is handled by rebuild_with_progress"),
             };
+            let IncrementalFilesOutcome { indexed, manifest_in_change_set, carried } = outcome;
             let base_scope_discovery_marked = if effective_mode == IndexMode::Discover {
                 db.mark_active_base_scope_discovered(&config.targets)?
             } else {
@@ -201,6 +213,7 @@ impl IndexDatabase {
             };
             let mut mutated = indexed > 0
                 || healed > 0
+                || carried > 0
                 || source_root_changed
                 || git_meta_changed
                 || embedding_model_seeded
@@ -221,19 +234,28 @@ impl IndexDatabase {
             // inside that gate and was skipped, leaving the crate set stale until the
             // next full rebuild). `refresh_packages` returns whether the package map
             // changed, which forces a re-resolve even when no file was indexed.
-            let roots_changed = if indexed > 0 || healed > 0 || manifest_in_change_set {
-                db.refresh_packages(&config.root)?
-            } else {
-                false
-            };
+            // `carried > 0` also refreshes (#502): the package map is keyed by
+            // `(commit_sha, worktree_id)`, so a carried scope needs its rows re-derived at the
+            // new commit even when nothing was (re)indexed — otherwise import resolution falls
+            // open until the next real edit (the incremental twin of the rebuild's
+            // `carry_forward_overlay_packages`).
+            let roots_changed =
+                if indexed > 0 || healed > 0 || carried > 0 || manifest_in_change_set {
+                    db.refresh_packages(&config.root)?
+                } else {
+                    false
+                };
             if roots_changed {
                 mutated = true;
             }
             // Healing can delete overlay symbols (NULLing their in-edges via
             // `remove_file_in_scope`), so it needs the same re-derive tail as real file changes.
             // Also re-resolve when the crate set changed but no file was indexed (a manifest-only
-            // change) so `use new_crate::X` resolves correctly (#95).
-            if indexed > 0 || healed > 0 || roots_changed {
+            // change) so `use new_crate::X` resolves correctly (#95). A carried scope (#502)
+            // re-resolves too: a carried caller's edge may point at a symbol of a file that
+            // changed (or vanished) across the HEAD move and was re-derived with fresh rowids —
+            // the full-scope resolve every ordinary edit pass runs is what re-points it.
+            if indexed > 0 || healed > 0 || carried > 0 || roots_changed {
                 progress(IndexProgress::RebuildingLogicalSymbols);
                 db.rebuild_logical_symbols()?;
                 progress(IndexProgress::ResolvingGraph);
@@ -470,14 +492,16 @@ impl IndexDatabase {
         Ok((total, graph))
     }
 
-    /// Returns `(file_count, manifest_in_change_set)`. The manifest flag is true when any changed
-    /// or deleted path is a `Cargo.toml`, signalling the workspace crate set may have changed
-    /// and the `packages` map should be refreshed before the resolve pass (#61, salvaging #95).
+    /// The manifest flag is true when any changed or deleted path is a `Cargo.toml`, signalling
+    /// the workspace crate set may have changed and the `packages` map should be refreshed
+    /// before the resolve pass (#61, salvaging #95). Changed mode never carries: it only sees
+    /// working-tree dirt, and the stale base-scope marker promotes a HEAD move to Discover
+    /// (#459), where the carry lives.
     fn index_changed_files_with_progress<F>(
         &self,
         config: &Config,
         progress: &mut F,
-    ) -> anyhow::Result<(usize, bool)>
+    ) -> anyhow::Result<IncrementalFilesOutcome>
     where
         F: FnMut(IndexProgress),
     {
@@ -488,24 +512,29 @@ impl IndexDatabase {
                 || paths_include_cargo_toml(changes.deleted.iter().map(PathBuf::as_path));
         let files = collect_changed_index_files(config, &changes)?;
         let files = self.assign_file_scopes(files, &changes);
-        let count = self.apply_incremental_file_plan(files, changes.deleted, progress)?;
-        Ok((count, manifest_in_change_set))
+        let indexed = self.apply_incremental_file_plan(files, changes.deleted, progress)?;
+        Ok(IncrementalFilesOutcome { indexed, manifest_in_change_set, carried: 0 })
     }
 
-    /// Returns `(file_count, manifest_in_change_set)`. The manifest flag also consults the
-    /// discovery plan's file list, so a NEW (untracked, not-yet-committed) `Cargo.toml` is
-    /// caught even though git status would not list it as changed (#61, salvaging #95).
+    /// The manifest flag also consults the discovery plan's file list, so a NEW (untracked,
+    /// not-yet-committed) `Cargo.toml` is caught even though git status would not list it as
+    /// changed (#61, salvaging #95). Applies the plan's carry candidates (#502) — retained
+    /// committed rows re-stamped into the active commit scope — before deriving the (diff-sized)
+    /// remainder, all inside the caller's pass transaction.
     fn index_discovered_files_with_progress<F>(
         &self,
         config: &Config,
         progress: &mut F,
-    ) -> anyhow::Result<(usize, bool)>
+    ) -> anyhow::Result<IncrementalFilesOutcome>
     where
         F: FnMut(IndexProgress),
     {
         progress(IndexProgress::Discovering);
-        let plan = discovery_plan(self.storage.connection(), config)?;
+        // The status walk feeds BOTH the plan's carry filter (a dirty/untracked path must never
+        // be carried into the committed scope) and the scope assignment below — one walk, shared.
         let changes = git_changed_paths(&config.root).unwrap_or_default();
+        let plan = discovery_plan(self.storage.connection(), config, &changes)?;
+        let carried = self.carry_retained_files_into_active_scope(&plan.carried)?;
         let manifest_in_change_set =
             paths_include_cargo_toml(changes.changed.iter().map(PathBuf::as_path))
                 || paths_include_cargo_toml(changes.deleted.iter().map(PathBuf::as_path))
@@ -513,8 +542,8 @@ impl IndexDatabase {
                     plan.files.iter().map(|file| file.relative_path.as_path()),
                 );
         let files = self.assign_file_scopes(plan.files, &changes);
-        let count = self.apply_incremental_file_plan(files, plan.deleted, progress)?;
-        Ok((count, manifest_in_change_set))
+        let indexed = self.apply_incremental_file_plan(files, plan.deleted, progress)?;
+        Ok(IncrementalFilesOutcome { indexed, manifest_in_change_set, carried })
     }
 
     pub(super) fn assign_file_scopes(

--- a/crates/rag-rat-core/src/index/query_api/mod.rs
+++ b/crates/rag-rat-core/src/index/query_api/mod.rs
@@ -98,22 +98,40 @@ impl IndexDatabase {
     }
 
     pub fn discovery_status(&self, config: &Config) -> anyhow::Result<DiscoveryStatus> {
-        let plan = discovery_plan(self.storage.connection(), config)?;
+        // The plan's carry filter needs the working tree's status (dirty/untracked paths are
+        // never carried), so status computes it exactly like the discover pass does — keeping
+        // the reported counts identical to what that pass would do.
+        let changes = git_changed_paths(&config.root).unwrap_or_default();
+        let plan = discovery_plan(self.storage.connection(), config, &changes)?;
         let unindexed_source_files =
             plan.unindexed.iter().filter(|file| file.kind == TargetKind::Source).count();
         let unindexed_sample =
             plan.unindexed.iter().take(10).map(|file| path_string(&file.relative_path)).collect();
-        let warning = (unindexed_source_files > 0).then(|| {
-            format!(
+        // A pending carry (#502) is pending work too: the retained rows are not in the active
+        // scope until a discover pass re-stamps them, so a carry-only HEAD move must not read as
+        // a clean index (a watcher-less install would otherwise report clean while queries at
+        // the new HEAD miss those files). The unindexed warning wins when both apply — its
+        // remedy covers the carry as well.
+        let warning = if unindexed_source_files > 0 {
+            Some(format!(
                 "{unindexed_source_files} unindexed source files detected. Run `rag-rat index \
                  --full` or `rag-rat index --discover`."
-            )
-        });
+            ))
+        } else if !plan.carried.is_empty() {
+            Some(format!(
+                "{} indexed files await adoption onto the current HEAD (it moved since the last \
+                 pass). Run `rag-rat index --discover`.",
+                plan.carried.len()
+            ))
+        } else {
+            None
+        };
         Ok(DiscoveryStatus {
             discovered_files: plan.discovered_files,
             indexed_files: plan.indexed_files,
             unindexed_files: plan.unindexed.len(),
             unindexed_source_files,
+            carryable_files: plan.carried.len(),
             changed_indexed_files: plan.changed.len(),
             removed_indexed_files: plan.deleted.len(),
             unindexed_sample,

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/head_move_carry.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/head_move_carry.rs
@@ -1,0 +1,517 @@
+//! HEAD-move carry (#502): a `git pull` / branch checkout re-keys the base commit scope, but the
+//! content of nearly every file is byte-identical with the previous scope. Discovery adopts the
+//! retained committed rows by re-stamping `files.commit_sha` in place — the row id, and every
+//! chunk/symbol/edge/embedding/memory-binding hanging off it, survives — so a HEAD move costs
+//! roughly its diff, not a full reindex.
+
+use super::*;
+
+/// A repo with two committed rust files, returning `(root, config)`. `keep.rs` stays unchanged
+/// across every HEAD move in these tests; `edit.rs` is the file the moves modify.
+fn head_move_repo(tag: &str) -> (PathBuf, Config) {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/keep.rs"), format!("pub fn {tag}_kept_anchor() -> i32 {{ 1 }}\n"))
+        .unwrap();
+    fs::write(root.join("src/edit.rs"), "pub fn edit_v1() -> i32 { 1 }\n").unwrap();
+    // Keep the test index out of the tree: a later `git add .` would otherwise commit the
+    // database file and block branch switches over it.
+    fs::write(root.join(".gitignore"), ".rag-rat/\n").unwrap();
+    init_git_repo(&root);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "seed"]);
+    let config = source_config(root.clone(), Language::Rust);
+    (root, config)
+}
+
+/// The raw `main.files` rows `(id, commit_sha, sha256)` for `path` in the ACTIVE repo's base
+/// scope — bypassing the commit dimension of the scope view so retained (out-of-scope) rows are
+/// observable, while staying repo-scoped so the poison sibling's same-path row is not counted.
+fn committed_rows(db: &IndexDatabase, path: &str) -> Vec<(i64, String, String)> {
+    let conn = db.storage.connection();
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, commit_sha, sha256 FROM main.files
+             WHERE path = ?1 AND worktree_id = '' AND kind != 'deleted'
+               AND repo_id = (SELECT value FROM temp.connection_context WHERE key = 'repo_id')
+             ORDER BY id",
+        )
+        .unwrap();
+    stmt.query_map([path], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+}
+
+/// The active-scope (view) row id for `path`, or None when the path is out of scope.
+fn active_row_id(db: &IndexDatabase, path: &str) -> Option<i64> {
+    db.storage
+        .connection()
+        .query_row("SELECT id FROM files WHERE path = ?1", [path], |row| row.get(0))
+        .ok()
+}
+
+fn chunk_ids_of_file(db: &IndexDatabase, file_id: i64) -> Vec<i64> {
+    let conn = db.storage.connection();
+    let mut stmt = conn.prepare("SELECT id FROM chunks WHERE file_id = ?1 ORDER BY id").unwrap();
+    stmt.query_map([file_id], |row| row.get(0)).unwrap().collect::<Result<_, _>>().unwrap()
+}
+
+#[test]
+fn a_head_move_carries_unchanged_rows_and_rederives_only_the_diff() {
+    let (root, config) = head_move_repo("carry");
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let old_head = head_sha(&root);
+    let keep_id = active_row_id(&db, "src/keep.rs").expect("keep.rs indexed");
+    let keep_chunks = chunk_ids_of_file(&db, keep_id);
+    let edit_id = active_row_id(&db, "src/edit.rs").expect("edit.rs indexed");
+    drop(db);
+
+    // A commit editing ONE file moves HEAD; keep.rs is byte-identical across the move.
+    fs::write(root.join("src/edit.rs"), "pub fn edit_v2() -> i32 { 2 }\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "edit"]);
+    let new_head = head_sha(&root);
+    assert_ne!(old_head, new_head);
+
+    let (db, content_changed) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    assert!(content_changed, "the edited file is a real content change");
+
+    // keep.rs: the SAME row (and its chunks) re-stamped to the new commit — no re-derive.
+    let keep_rows = committed_rows(&db, "src/keep.rs");
+    assert_eq!(
+        keep_rows.len(),
+        1,
+        "an unchanged file must be carried, not duplicated across scopes: {keep_rows:?}"
+    );
+    assert_eq!(keep_rows[0].0, keep_id, "carry must re-stamp the row in place (same id)");
+    assert_eq!(keep_rows[0].1, new_head, "the carried row lives at the new HEAD");
+    assert_eq!(
+        chunk_ids_of_file(&db, keep_id),
+        keep_chunks,
+        "carried chunks (and everything keyed by them) survive"
+    );
+
+    // edit.rs: re-derived at the new HEAD; the old row stays behind at the old sha (out of
+    // scope, gc's business), so the active view serves exactly one fresh row.
+    let edit_rows = committed_rows(&db, "src/edit.rs");
+    assert_eq!(
+        edit_rows.len(),
+        2,
+        "changed path: old row retained + new row derived; old={old_head} new={new_head} \
+         rows={edit_rows:?}"
+    );
+    assert!(edit_rows.iter().any(|(id, sha, _)| *id == edit_id && sha == &old_head));
+    let active_edit = active_row_id(&db, "src/edit.rs").expect("edit.rs active");
+    assert_ne!(active_edit, edit_id, "the changed file is a fresh derive");
+    let symbols: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM symbols s JOIN files f ON f.id = s.file_id
+             WHERE s.name = 'edit_v2'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(symbols, 1, "the re-derived file's new symbol is in scope");
+
+    // A carried pass must never touch a sibling repo's rows (round-6 harness).
+    crate::index::poison_sibling::assert_sibling_intact(db.storage.connection());
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn a_branch_switch_back_carries_everything_with_no_rederive() {
+    let (root, config) = head_move_repo("swback");
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let main_head = head_sha(&root);
+    let keep_id = active_row_id(&db, "src/keep.rs").unwrap();
+    let edit_id = active_row_id(&db, "src/edit.rs").unwrap();
+    drop(db);
+
+    // A feature branch edits one file; index it there.
+    run_git(&root, &["checkout", "-q", "-b", "feat"]);
+    fs::write(root.join("src/edit.rs"), "pub fn edit_branch() -> i32 { 2 }\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "branch edit"]);
+    let (db, _) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    assert_eq!(
+        active_row_id(&db, "src/keep.rs"),
+        Some(keep_id),
+        "the unchanged file is carried onto the branch head"
+    );
+    drop(db);
+
+    // Switching back re-adopts BOTH rows: the carried one comes back, and the changed path's
+    // old row — left behind at the main head with main's content — matches disk again. Nothing
+    // re-derives, so the pass reports no content change.
+    run_git(&root, &["checkout", "-q", "main"]);
+    let (db, content_changed) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    assert!(!content_changed, "a switch back to already-derived content re-derives nothing");
+    assert_eq!(active_row_id(&db, "src/keep.rs"), Some(keep_id));
+    assert_eq!(
+        active_row_id(&db, "src/edit.rs"),
+        Some(edit_id),
+        "the old-branch row still holding this content is re-adopted, not re-derived"
+    );
+    let keep_rows = committed_rows(&db, "src/keep.rs");
+    assert_eq!(keep_rows.len(), 1);
+    assert_eq!(keep_rows[0].1, main_head);
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn carry_requires_matching_language_and_kind() {
+    let (root, config) = head_move_repo("drift");
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    // A forged retained row at a stale commit whose sha256 matches the file about to appear,
+    // but under a different language — the target-drift twin of discovery's sha check. Carry
+    // must refuse it and derive the path properly.
+    let new_bytes = "pub fn freshly_added() -> i32 { 3 }\n";
+    let (repo_id, generation): (String, i64) = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT repo_id, generation FROM main.files WHERE path = 'src/keep.rs' AND \
+             worktree_id = ''",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    db.storage
+        .connection()
+        .execute(
+            "INSERT INTO main.files(path, language, kind, sha256, modified_at_ms, generated,
+                     indexed_at_ms, indexed_revision, commit_sha, worktree_id, repo_id, generation)
+             VALUES ('src/new.rs', 'markdown', 'docs', ?1, 0, 0, 0, '', 'stalecommit', '', ?2, ?3)",
+            params![hex_sha256(new_bytes.as_bytes()), repo_id, generation],
+        )
+        .unwrap();
+    let forged_id: i64 = db
+        .storage
+        .connection()
+        .query_row("SELECT MAX(id) FROM main.files WHERE path = 'src/new.rs'", [], |row| row.get(0))
+        .unwrap();
+    drop(db);
+
+    fs::write(root.join("src/new.rs"), new_bytes).unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "add new.rs"]);
+
+    let (db, _) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    let active = active_row_id(&db, "src/new.rs").expect("new.rs indexed");
+    assert_ne!(active, forged_id, "a language/kind mismatch must not be carried");
+    let language: String = db
+        .storage
+        .connection()
+        .query_row("SELECT language FROM files WHERE path = 'src/new.rs'", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(language, "rust");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn dirty_paths_keep_their_overlay_and_are_not_carried() {
+    let (root, config) = head_move_repo("dirty");
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let old_head = head_sha(&root);
+    drop(db);
+
+    // keep.rs goes dirty (overlay row); a commit to edit.rs then moves HEAD.
+    fs::write(root.join("src/keep.rs"), "pub fn dirty_kept_anchor() -> i32 { 9 }\n").unwrap();
+    let db = IndexDatabase::index_discover(&config).unwrap();
+    let overlay: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM main.files WHERE path = 'src/keep.rs' AND worktree_id != ''",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(overlay, 1, "dirty edit creates the overlay row");
+    drop(db);
+
+    fs::write(root.join("src/edit.rs"), "pub fn edit_v2() -> i32 { 2 }\n").unwrap();
+    run_git(&root, &["add", "src/edit.rs"]);
+    run_git(&root, &["commit", "-q", "-m", "edit only edit.rs"]);
+
+    let (db, _) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    // The dirty path is served by its overlay (which shadows any committed row), so it is not a
+    // carry candidate: its committed row may stay at the old sha without harming the view.
+    let sha: String = db
+        .storage
+        .connection()
+        .query_row("SELECT sha256 FROM files WHERE path = 'src/keep.rs'", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(
+        sha,
+        hex_sha256(b"pub fn dirty_kept_anchor() -> i32 { 9 }\n"),
+        "the overlay row keeps serving the dirty content"
+    );
+    let committed = committed_rows(&db, "src/keep.rs");
+    assert_eq!(committed.len(), 1, "no duplicate committed row is derived for a dirty path");
+    assert_eq!(committed[0].1, old_head, "the shadowed committed row is left in place");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn a_pull_after_a_branch_round_trip_still_carries_despite_stale_higher_id_rows() {
+    // main → feat (edit.rs re-derived there, HIGHER row id) → main → commit on main. The pull's
+    // carry must adopt the OLD-main row that matches disk, not give up because the stale feat
+    // row (higher id, different sha) shadows it for the same path.
+    let (root, config) = head_move_repo("multiret");
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let keep_id = active_row_id(&db, "src/keep.rs").unwrap();
+    let edit_id = active_row_id(&db, "src/edit.rs").unwrap();
+    drop(db);
+
+    run_git(&root, &["checkout", "-q", "-b", "feat"]);
+    fs::write(root.join("src/edit.rs"), "pub fn edit_branch() -> i32 { 2 }\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "branch edit"]);
+    let (db, _) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    drop(db);
+    run_git(&root, &["checkout", "-q", "main"]);
+    let (db, _) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    drop(db);
+
+    // The "pull": a commit on main that does not touch edit.rs. edit.rs now has retained rows
+    // at BOTH the feat head (higher id, branch content) and the old main head (its own row,
+    // matching disk) — the matching row must win.
+    fs::write(root.join("src/keep.rs"), "pub fn multiret_kept_anchor() -> i32 { 7 }\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "pull"]);
+    let new_head = head_sha(&root);
+
+    let (db, _) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    assert_eq!(
+        active_row_id(&db, "src/edit.rs"),
+        Some(edit_id),
+        "the sha-matching retained row is carried even when a stale row has a higher id"
+    );
+    let edit_active = committed_rows(&db, "src/edit.rs")
+        .into_iter()
+        .filter(|(_, sha, _)| sha == &new_head)
+        .collect::<Vec<_>>();
+    assert_eq!(edit_active.len(), 1, "exactly the carried row serves the new HEAD");
+    assert_ne!(
+        active_row_id(&db, "src/keep.rs"),
+        Some(keep_id),
+        "the genuinely changed file is re-derived"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn discovery_status_surfaces_a_pending_carry_instead_of_reporting_clean() {
+    // With no watcher running, `doctor`/`status` is the only signal after a HEAD move. A
+    // carry-only scope must not read as "everything indexed": the scope view misses the rows
+    // until a discover pass applies the re-stamps, so status reports the pending carry and
+    // names the remedy.
+    let (root, config) = head_move_repo("status");
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    drop(db);
+
+    fs::write(root.join("src/edit.rs"), "pub fn edit_v2() -> i32 { 2 }\n").unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "edit"]);
+
+    let db = IndexDatabase::open_config(&config).unwrap();
+    let status = db.discovery_status(&config).unwrap();
+    assert_eq!(status.carryable_files, 1, "the unchanged file awaits its carry");
+    let warning = status.warning.expect("a pending carry is pending work, not a clean index");
+    assert!(warning.contains("index --discover"), "the warning names the remedy: {warning}");
+    drop(db);
+
+    let (db, _) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    let status = db.discovery_status(&config).unwrap();
+    assert_eq!(status.carryable_files, 0, "the applied carry clears the pending count");
+    assert_eq!(status.warning, None, "a carried-and-derived scope is clean");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn an_untracked_recreation_of_old_content_is_not_carried_into_the_committed_scope() {
+    // A file deleted at the new HEAD but re-created UNTRACKED with its old bytes matches a
+    // retained row on sha — but the committed tree at the new HEAD does not contain it, and
+    // committed rows are shared with every linked worktree's base view. It must be indexed as
+    // this worktree's OVERLAY row, never re-stamped into the committed scope.
+    let (root, config) = head_move_repo("untracked");
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let old_head = head_sha(&root);
+    drop(db);
+
+    let old_bytes = fs::read(root.join("src/edit.rs")).unwrap();
+    run_git(&root, &["rm", "-q", "src/edit.rs"]);
+    run_git(&root, &["commit", "-q", "-m", "delete edit.rs"]);
+    let new_head = head_sha(&root);
+    fs::write(root.join("src/edit.rs"), &old_bytes).unwrap();
+
+    let (db, _) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    let committed = committed_rows(&db, "src/edit.rs");
+    assert!(
+        committed.iter().all(|(_, sha, _)| sha == &old_head),
+        "untracked working-tree content must not become a committed row at the new HEAD: \
+         {committed:?}"
+    );
+    let overlay: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM files WHERE path = 'src/edit.rs' AND worktree_id != ''",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(overlay, 1, "the re-created file is served as this worktree's overlay");
+    assert_eq!(
+        committed_rows(&db, "src/keep.rs")[0].1,
+        new_head,
+        "the genuinely committed unchanged file is still carried"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn a_dirty_revert_to_old_content_is_not_carried_into_the_committed_scope() {
+    // The tracked twin: the file changes at the new HEAD, and the working tree then reverts it
+    // to the OLD commit's bytes without committing. The path is dirty, so its true committed
+    // content at the new HEAD is the edited version — the old-content retained row must not be
+    // re-stamped as committed; the dirty bytes belong to the overlay scope.
+    let (root, config) = head_move_repo("dirtyrevert");
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    drop(db);
+
+    let old_bytes = fs::read(root.join("src/edit.rs")).unwrap();
+    fs::write(root.join("src/edit.rs"), "pub fn edit_v2() -> i32 { 2 }\n").unwrap();
+    run_git(&root, &["add", "src/edit.rs"]);
+    run_git(&root, &["commit", "-q", "-m", "edit"]);
+    let new_head = head_sha(&root);
+    fs::write(root.join("src/edit.rs"), &old_bytes).unwrap();
+
+    let (db, _) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    let committed = committed_rows(&db, "src/edit.rs");
+    assert!(
+        !committed
+            .iter()
+            .any(|(_, sha, bytes_sha)| sha == &new_head && bytes_sha == &hex_sha256(&old_bytes)),
+        "dirty working-tree bytes must not be recorded as committed at the new HEAD: {committed:?}"
+    );
+    let overlay_sha: String = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT sha256 FROM files WHERE path = 'src/edit.rs' AND worktree_id != ''",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        overlay_sha,
+        hex_sha256(&old_bytes),
+        "the reverted bytes are served from this worktree's overlay"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn a_carried_callers_edge_reresolves_to_the_rederived_callee() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/callee.rs"), "pub fn target_fn() -> i32 { 1 }\n").unwrap();
+    fs::write(root.join("src/caller.rs"), "pub fn caller_fn() -> i32 { target_fn() }\n").unwrap();
+    fs::write(root.join(".gitignore"), ".rag-rat/\n").unwrap();
+    init_git_repo(&root);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "seed"]);
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    let caller_id = active_row_id(&db, "src/caller.rs").unwrap();
+    drop(db);
+
+    // The callee is re-derived across the HEAD move (its symbols get fresh rowids); the carried
+    // caller's edge must re-point at the fresh symbol, not the retired one.
+    fs::write(
+        root.join("src/callee.rs"),
+        "pub fn target_fn() -> i32 { 2 }\npub fn second_fn() -> i32 { 3 }\n",
+    )
+    .unwrap();
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "edit callee"]);
+    let (db, _) = IndexDatabase::index_discover_reporting(&config).unwrap();
+
+    assert_eq!(active_row_id(&db, "src/caller.rs"), Some(caller_id), "caller is carried");
+    let fresh_target: i64 = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT s.id FROM symbols s JOIN files f ON f.id = s.file_id
+             WHERE s.name = 'target_fn'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let resolved_to: Option<i64> = db
+        .storage
+        .connection()
+        .query_row(
+            "SELECT to_symbol_id FROM edges
+             WHERE source_file_id = ?1 AND to_name = 'target_fn'",
+            [caller_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        resolved_to,
+        Some(fresh_target),
+        "the carried caller's edge re-resolves to the re-derived callee symbol"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn a_carry_only_pass_still_refreshes_package_roots() {
+    let root = unique_temp_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("Cargo.toml"), "[package]\nname = \"carrypkg\"\nversion = \"0.1.0\"\n")
+        .unwrap();
+    fs::write(root.join("src/lib.rs"), "pub fn pkg_anchor() -> i32 { 1 }\n").unwrap();
+    fs::write(root.join("README.md"), "seed\n").unwrap();
+    fs::write(root.join(".gitignore"), ".rag-rat/\n").unwrap();
+    init_git_repo(&root);
+    run_git(&root, &["add", "."]);
+    run_git(&root, &["commit", "-q", "-m", "seed"]);
+    let config = source_config(root.clone(), Language::Rust);
+    let db = IndexDatabase::rebuild(&config).unwrap();
+    drop(db);
+
+    // The commit touches only a non-target file: the pass indexes nothing, carries everything —
+    // and must still re-key the package map to the new scope, or import resolution falls open
+    // until the next real edit.
+    fs::write(root.join("README.md"), "moved\n").unwrap();
+    run_git(&root, &["add", "README.md"]);
+    run_git(&root, &["commit", "-q", "-m", "docs only"]);
+    let new_head = head_sha(&root);
+
+    let (db, content_changed) = IndexDatabase::index_discover_reporting(&config).unwrap();
+    assert!(!content_changed, "no indexed content changed across the move");
+    let package_rows: Vec<(String, String)> = {
+        let conn = db.storage.connection();
+        let mut stmt =
+            conn.prepare("SELECT manifest_dir, commit_sha FROM packages ORDER BY id").unwrap();
+        stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap()
+    };
+    assert!(
+        package_rows.iter().any(|(_, sha)| sha == &new_head),
+        "package roots follow the carried scope to the new HEAD {new_head}: {package_rows:?}"
+    );
+    let _ = fs::remove_dir_all(root);
+}

--- a/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
+++ b/crates/rag-rat-core/src/index/schema_bootstrap_tests/mod.rs
@@ -884,6 +884,7 @@ mod generation_rebuild;
 mod git_history_reload;
 mod github_papertrail;
 mod graph_edges;
+mod head_move_carry;
 mod multi_repo_scope;
 mod orientation_healing;
 mod reconcile_embeddings;

--- a/crates/rag-rat-core/src/watch.rs
+++ b/crates/rag-rat-core/src/watch.rs
@@ -129,12 +129,14 @@ fn run_pass(
     retry_base_embedding_backlog: bool,
 ) -> anyhow::Result<()> {
     let started = Instant::now();
+    let mut timings = PassTimings::new(started);
     // #427: the core refuses a first-time-empty registration (`rag-rat mcp` / a hook on a config
     // with no `[target_bindings]` or no matching files). A maintenance/watch pass treats that as
     // "nothing to index yet" and DEFERS silently — a later pass registers once real content
     // appears. A recorded root going empty still prunes (not first-time → not refused). The
     // one-shot `index` command instead surfaces the same error to the operator.
-    let (mut db, content_changed) = match IndexDatabase::index_discover_reporting(config) {
+    let discover = timings.stage("discover", || IndexDatabase::index_discover_reporting(config));
+    let (mut db, content_changed) = match discover {
         Ok(result) => result,
         Err(err) if err.downcast_ref::<crate::index::EmptyIndexRefused>().is_some() => {
             return Ok(());
@@ -161,7 +163,8 @@ fn run_pass(
     // worktree change counts toward running the tail below even when config.root itself didn't
     // change. Reconcile a CHANGED overlay's embeddings INLINE (while scoped to it) so a worktree
     // query isn't BM25-only for branch content — the base reconcile below can't see overlay chunks.
-    let overlays_changed = refresh_worktree_overlays(&mut db, config, Some(&budget));
+    let overlays_changed =
+        timings.stage("overlays", || refresh_worktree_overlays(&mut db, config, Some(&budget)));
     let tail_already_forced = pass_tail_forced_by_state(
         content_changed,
         overlays_changed,
@@ -212,14 +215,18 @@ fn run_pass(
         base_embedding_backlog,
         clone_graph_due,
     ) {
-        maybe_checkpoint_wal(&db, quiet_pass, crate::index::WAL_CHECKPOINT_MIN_BYTES);
+        timings.stage("wal", || {
+            maybe_checkpoint_wal(&db, quiet_pass, crate::index::WAL_CHECKPOINT_MIN_BYTES)
+        });
+        timings.emit(false, content_changed, overlays_changed);
         return Ok(());
     }
     // The base reconcile gets only the budget the overlays left behind; `None` → already exhausted,
     // so skip it (the embedding backlog rides the next pass) rather than spend a fresh full budget.
     let mut base_reconcile_status = None;
     if let Some(options) = budget.next_options() {
-        let report = db.reconcile_with_options_progress(options, |_| {})?;
+        let report =
+            timings.stage("reconcile", || db.reconcile_with_options_progress(options, |_| {}))?;
         base_reconcile_status = Some(report.status);
     }
     // Clone-edge graph (#286/#473): try the cheap IN-PLACE delta first — it settles an ordinary
@@ -230,8 +237,8 @@ fn run_pass(
     // (`clone_graph_due`) so sustained editing defers it instead of treadmilling. Best-effort +
     // resumable, with whatever budget the embedding reconcile left (shared
     // PASS_RECONCILE_MAX_SECONDS so a pass can't overrun); `None` budget → rides the next pass.
-    let clone_full_rebuild_owed = match db
-        .apply_clone_graph_delta(crate::index::CLONE_DELTA_MAX_FILES)
+    let clone_full_rebuild_owed = match timings
+        .stage("clone_delta", || db.apply_clone_graph_delta(crate::index::CLONE_DELTA_MAX_FILES))
     {
         Ok(delta) if delta.status == "Applied" || delta.status == "Noop" => delta.full_rebuild_owed,
         _ => true,
@@ -240,17 +247,73 @@ fn run_pass(
         && clone_graph_due
         && let Some(options) = budget.next_options()
     {
-        let _ = db.reconcile_clone_edges_with_budget(options.max_seconds);
+        let _ = timings
+            .stage("clone_rebuild", || db.reconcile_clone_edges_with_budget(options.max_seconds));
     }
     if run_gc {
-        let _ = db.garbage_collect();
+        let _ = timings.stage("gc", || db.garbage_collect());
     }
-    let _ = db.memory_validate();
+    let _ = timings.stage("memory_validate", || db.memory_validate());
     if shutdown_reconcile_pending && base_reconcile_status.as_deref() == Some("Current") {
         db.clear_watch_shutdown_reconcile_pending()?;
     }
-    maybe_checkpoint_wal(&db, quiet_pass, crate::index::WAL_CHECKPOINT_MIN_BYTES);
+    timings.stage("wal", || {
+        maybe_checkpoint_wal(&db, quiet_pass, crate::index::WAL_CHECKPOINT_MIN_BYTES)
+    });
+    timings.emit(true, content_changed, overlays_changed);
     Ok(())
+}
+
+/// Per-stage wall-clock for one maintenance pass, emitted as a single summary event (#502): the
+/// dogfood investigation had to reconstruct where a long pass went from `reconcile_attempts`
+/// timestamps because the pass logged no stage timings. One greppable line per pass fixes that.
+/// Tail passes log at `info`; an idle discover-only sweep logs at `debug` so a quiet server does
+/// not fill the log.
+struct PassTimings {
+    started: Instant,
+    stages: Vec<(&'static str, Duration)>,
+}
+
+impl PassTimings {
+    fn new(started: Instant) -> Self {
+        Self { started, stages: Vec::new() }
+    }
+
+    fn stage<T>(&mut self, name: &'static str, work: impl FnOnce() -> T) -> T {
+        let stage_started = Instant::now();
+        let result = work();
+        self.stages.push((name, stage_started.elapsed()));
+        result
+    }
+
+    fn emit(&self, tail_ran: bool, content_changed: bool, overlays_changed: bool) {
+        let stages = self
+            .stages
+            .iter()
+            .map(|(name, elapsed)| format!("{name}={}ms", elapsed.as_millis()))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let total_ms = self.started.elapsed().as_millis() as u64;
+        if tail_ran {
+            tracing::info!(
+                target: "rag_rat_core::maintenance",
+                total_ms,
+                content_changed,
+                overlays_changed,
+                %stages,
+                "maintenance pass"
+            );
+        } else {
+            tracing::debug!(
+                target: "rag_rat_core::maintenance",
+                total_ms,
+                content_changed,
+                overlays_changed,
+                %stages,
+                "maintenance pass (tail skipped)"
+            );
+        }
+    }
 }
 
 /// Opportunistic WAL hygiene (#482), on QUIET passes only: nothing else truncates the shared


### PR DESCRIPTION
## Problem

A `git pull --ff-only` or branch checkout re-keys the base commit scope: `files` rows are keyed by `(repo_id, path, commit_sha, worktree_id, generation)`, so after a HEAD move every committed row falls out of the scope view. The next discover pass saw every file as unindexed and re-derived the whole repo — tree-sitter parse, chunking, edge extraction, `resolve_all_edges`, blame — ~6.8–7.5k chunks per pass, tens of minutes at 100% of one core, twice per evening of ordinary git activity (#502). The per-file sha check existed; the scope re-key defeated it.

## Fix: carry retained rows across the scope re-key

`discovery_plan` now loads the retained committed rows of previous HEADs (same repo + live generation, `worktree_id = ''`, other `commit_sha`s) and, for a path absent from the active scope, matches on the full **(sha256, language, kind)** triple — the same content + target-drift checks the existing per-file comparison uses. Matches become carry candidates; the discover pass re-stamps those rows' `commit_sha` to the active HEAD in place, inside the pass transaction (`carry_retained_files_into_active_scope`). The row id — and every chunk, symbol, edge, embedding, fingerprint, FTS entry, and memory binding hanging off it — survives. A HEAD move now costs roughly its diff; a branch switch-back costs zero re-derives (the rows left behind at the old sha still hold that branch's content and are re-adopted).

Guard rails:

- **Dirty/untracked paths are never carried**, even on a sha match: their bytes are working-tree content, not the new HEAD's committed content (a deleted-then-recreated file, or a revert to an old commit's bytes), and committed rows are shared with every linked worktree's base view. The status walk is computed once and shared between the carry filter and scope assignment; excluded paths fall through to normal indexing and land in the overlay scope.
- `carried > 0` re-keys the package map (`packages` is keyed by `(commit_sha, worktree_id)` — the incremental twin of the rebuild's `carry_forward_overlay_packages`) and re-runs the resolve tail, so a carried caller's edge re-points at a re-derived callee's fresh symbol rowids.
- Carry counts as a mutation (the pass commits) but not as a content change: nothing needs re-embedding, and `content_revision` stays stable across the move, so FTS and the clone graph stay fresh instead of invalidating on every pull.
- The retained map and the re-stamp are repo + generation scoped (the poison-sibling harness rides the tests).
- All retained rows per path stay matchable: after a branch round-trip a stale feature row (higher id, different content) sits beside the old-main row a later pull actually matches, so the triple match scans every candidate and the most recently derived match wins.
- Discovery stays a pure read (the status command shares it); only the indexing pass applies the re-stamps. `discovery_status` reports a pending carry as its own `carryable_files` count with a warning naming the remedy — a watcher-less install after a HEAD move must not read as clean while the scope view still misses the rows — instead of the pre-change wall of "unindexed" files.

## Observability (secondary ask in #502)

The watcher pass now emits one greppable summary line per pass with per-stage wall-clock (discover / overlays / reconcile / clone delta / clone rebuild / gc / memory validate / WAL) at `info` for tail passes and `debug` for idle sweeps, plus an `info` line whenever a carry happens (`carried=N commit=…`). The next slow-pass investigation is one grep instead of a `reconcile_attempts` reconstruction.

Not addressed here (still open in #502's liveness note): the pass runs synchronously on the watcher thread.

## Tests

Ten new tests in `schema_bootstrap_tests/head_move_carry.rs`: in-place carry with only the diff re-derived (row/chunk ids asserted stable), free branch switch-back, carry-through-stale-higher-id-rows after a branch round-trip, language/kind drift refusal, dirty-overlay shadowing, untracked-recreation and dirty-revert exclusion (the committed-scope purity guards), carried-edge re-resolution, package-root re-keying on a carry-only pass, and the pending-carry status warning. Verified end-to-end with the CLI on a scratch repo: a one-file commit re-derives 1 file and carries the other 39 in place.

Fixes #502
